### PR TITLE
fix(bp-valkey): allow empty password — unblocks bp-newapi (Closes #2003)

### DIFF
--- a/clusters/_template/bootstrap-kit/17-valkey.yaml
+++ b/clusters/_template/bootstrap-kit/17-valkey.yaml
@@ -48,7 +48,15 @@ spec:
   chart:
     spec:
       chart: bp-valkey
-      version: 1.0.1
+      # 1.0.2 (TBD-V12 #2003, 2026-05-20): default
+      # `valkey.auth.enabled` flips to `false` so bp-newapi's
+      # passwordless REDIS_CONN_STRING default stops triggering
+      # `NOAUTH Authentication required` on every freshly
+      # franchised Sovereign (45× CrashLoopBackOff on t38 sandbox
+      # newapi, blocking Pillar 4 / qwen-code / MCP). See
+      # platform/valkey/chart/values.yaml `auth` block for the
+      # consumer-tolerance + follow-up plan.
+      version: 1.0.2
       sourceRef:
         kind: HelmRepository
         name: bp-valkey

--- a/platform/valkey/blueprint.yaml
+++ b/platform/valkey/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-4-1-data-services
 spec:
-  version: 1.0.1
+  version: 1.0.2
   card:
     title: Valkey
     summary: |
@@ -35,8 +35,14 @@ spec:
         properties:
           enabled:
             type: boolean
-            default: true
-            description: Enforce password auth on the Valkey wire protocol.
+            default: false
+            description: |
+              Enforce password auth on the Valkey wire protocol.
+              Default false (TBD-V12 #2003) — matches bp-newapi's
+              passwordless REDIS_CONN_STRING contract; flipping true
+              requires every consumer chart (bp-newapi, catalyst
+              sme-services, projector) to wire the bp-valkey-
+              generated password into their connection strings.
       metrics:
         type: object
         properties:

--- a/platform/valkey/chart/Chart.yaml
+++ b/platform/valkey/chart/Chart.yaml
@@ -1,6 +1,19 @@
 apiVersion: v2
 name: bp-valkey
-version: 1.0.1
+# 1.0.2 (TBD-V12 #2003, 2026-05-20): default valkey.auth.enabled flips
+# from true → false to match bp-newapi's passwordless
+# REDIS_CONN_STRING default. Pre-1.0.2 every freshly-franchised
+# Sovereign hit `NOAUTH Authentication required` on the newapi
+# Redis ping probe — 45× CrashLoopBackOff on t38 — blocking every
+# Sandbox session (Pillar 4 qwen-code + MCP) and acting as the
+# verifier-killing bug for the end-user DoD (#1986). Consumers that
+# DO supply a password (catalyst sme-services, projector) tolerate
+# the change via `secretKeyRef optional: true` and `{{- with }}`
+# gates that fall back to the no-auth connect path. See
+# values.yaml under `valkey.auth` for the full rationale +
+# follow-up to re-enable auth once bp-newapi mirrors the
+# bp-valkey-generated password.
+version: 1.0.2
 description: |
   Catalyst-curated Blueprint umbrella chart for Valkey (Redis-compatible
   cache, BSD-3). Depends on the upstream `valkey` chart (Bitnami) as a

--- a/platform/valkey/chart/values.yaml
+++ b/platform/valkey/chart/values.yaml
@@ -62,12 +62,43 @@ valkey:
       enabled: true
       size: 1Gi
 
-  # Password auth ON by default — Catalyst convention. The bitnami chart
-  # auto-generates a random password and exposes it via the
-  # `<release-name>-valkey` Secret. Cluster overlays MAY override the
-  # password via `auth.existingSecret` to hand-roll secret rotation.
+  # Password auth OFF by default (TBD-V12 #2003, 2026-05-20).
+  #
+  # ROOT CAUSE (caught on t38 walk 2026-05-20):
+  #   The bp-newapi chart's REDIS_CONN_STRING default is the
+  #   passwordless URL `redis://valkey-primary.valkey.svc.cluster.local:
+  #   6379` (platform/newapi/chart/values.yaml `valkey.url`). On every
+  #   freshly franchised Sovereign the newapi Pod CrashLoopBackOff'd 45×
+  #   on the Redis ping probe with `NOAUTH Authentication required`,
+  #   blocking every Sandbox session (qwen-code + MCP) — the
+  #   Pillar-4 verifier-killing bug.
+  #
+  # CONTRACT MATCH:
+  #   The auth contract is set by the CONSUMER (bp-newapi). bp-newapi
+  #   ships a passwordless connection string by default; the only way
+  #   to make that work without churning every consumer chart is to
+  #   flip bp-valkey's default to allow empty password. Other consumers
+  #   that DO supply a password tolerate the change:
+  #     - products/catalyst sme-services (auth.yaml + gateway.yaml)
+  #       read VALKEY_PASSWORD via secretKeyRef `optional: true` and
+  #       fall back to the no-auth connect path in
+  #       core/services/shared/db/valkey.go when the value is empty.
+  #     - products/catalyst projector wraps the password Secret mount
+  #       in `{{- with .Values.services.projector.valkey.passwordSecret
+  #       }}` so an absent Secret just disables the password env var.
+  #
+  # FOLLOW-UP (deferred, scope of #1986 Pillar 4):
+  #   Make bp-newapi read the bp-valkey-generated password via Secret
+  #   reflection (mirror of the bp-valkey password Secret into the
+  #   newapi namespace, env-var REDIS_PASSWORD wired into the
+  #   conn-string template). At that point flip this back to
+  #   `auth.enabled: true`. Tracked under issue #2003.
+  #
+  # Cluster overlays MAY still re-enable auth by setting
+  # `valkey.auth.enabled: true` (and supplying matching consumer
+  # password wiring) on per-Sovereign installs.
   auth:
-    enabled: true
+    enabled: false
 
   # NetworkPolicy from upstream chart — already enabled by default;
   # restate to make the Catalyst posture explicit. (Default-deny is


### PR DESCRIPTION
## Summary
- **Bug (TBD-V12 #2003 P0)**: bp-newapi crashloops 45x on every freshly-franchised Sovereign with `NOAUTH Authentication required` — its REDIS_CONN_STRING default is the passwordless URL `redis://valkey-primary.valkey.svc.cluster.local:6379` but bp-valkey ships `auth.enabled: true` (bitnami default).
- **Fix (Option A)**: flip `valkey.auth.enabled: true → false` in the bp-valkey chart. Upstream bitnami valkey 5.5.1 then exports `ALLOW_EMPTY_PASSWORD=yes` to the Valkey container — verified via `helm template`.
- **Why this unblocks DoD**: this is the Pillar-4 verifier-killing bug for Sandbox + qwen-code + MCP (#1986) — every Sandbox session fails because the upstream newapi container ping-probes Redis on first boot.

## Change footprint
| File | Change |
|------|--------|
| `platform/valkey/chart/values.yaml` | `valkey.auth.enabled: true → false` (with rationale comment) |
| `platform/valkey/chart/Chart.yaml`  | `version: 1.0.1 → 1.0.2` |
| `platform/valkey/blueprint.yaml`    | `spec.version: 1.0.1 → 1.0.2` + configSchema default |
| `clusters/_template/bootstrap-kit/17-valkey.yaml` | chart pin `1.0.1 → 1.0.2` |

Per-Sovereign overlays (`omantel.omani.works`, `otech.omani.works`) intentionally pinned older (`1.0.0`) — left untouched.

## Consumer tolerance
- `products/catalyst` sme-services (`auth.yaml`, `gateway.yaml`) — read VALKEY_PASSWORD via `secretKeyRef ... optional: true` → fall back to no-auth connect path in `core/services/shared/db/valkey.go` when value empty.
- `products/catalyst` projector — mounts password Secret inside `{{- with .Values.services.projector.valkey.passwordSecret }}` → silently disables password env when absent.

## Follow-up (Option B, deferred, scope of #1986 Pillar-4 hardening)
Make bp-newapi mirror the bp-valkey auto-generated password Secret into the `newapi` namespace and template it into REDIS_CONN_STRING; then re-flip `auth.enabled: true`. Tracked under #2003 follow-up.

## Test plan
- [x] `helm dependency build` succeeds (bitnami/valkey 5.5.1 vendored)
- [x] `helm template smoke-vk .` renders `ALLOW_EMPTY_PASSWORD: "yes"` on the Pod env
- [x] `tests/observability-toggle.sh` — all 4 cases PASS
- [ ] CI green on this PR
- [ ] Post-merge: fresh Sovereign prov → newapi Pod reaches `1/1 Ready` without restarts, Sandbox session succeeds

Closes #2003
Refs #1986

🤖 Generated with [Claude Code](https://claude.com/claude-code)