### PR TITLE
fix(sme-notification): align JWT signing secret with catalyst-api bridge (Closes #1999)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -746,6 +746,16 @@ spec:
       # PR; the code fix is upstream in #1910. The CI auto-bump-
       # images job skipped controller images (TBD-A69 follow-up
       # tracks closing that gap).
+      # 1.4.215 — TBD-V8 / #1999 (2026-05-20): fix sme/notification 401
+      # on the billing→notification voucher-email dispatch. billing's
+      # outbound POST /notification/send carried no Authorization
+      # header so notification's HS256 JWTAuth middleware 401'd every
+      # voucher-email dispatch — voucher row persisted, HTTP 200 to
+      # operator, no email landed. Fix mints a short-lived HS256
+      # service token signed with the SAME sme-secrets/JWT_SECRET
+      # bytes notification already verifies against. See Chart.yaml
+      # changelog for full trace. Bumped on rebase 1.4.214 → 1.4.215
+      # to claim next slot above TBD-V11/#2002 (also 1.4.214 on main).
       # 1.4.214 (TBD-V11 / #2002): add init container
       # `wait-for-cutover-token` to the SME provisioning Deployment.
       # The Pod now blocks on Secret sme/provisioning-github-token
@@ -763,7 +773,7 @@ spec:
       # via .Values.smeServices.provisioning.waitForCutoverToken.*
       # (default enabled on Sovereigns; contabo overlay flips
       # enabled=false because Step 09 never runs on Catalyst-Zero).
-      version: 1.4.214
+      version: 1.4.215
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/services/billing/handlers/handlers.go
+++ b/core/services/billing/handlers/handlers.go
@@ -64,6 +64,25 @@ type Handler struct {
 	// substitute a fake; production leaves it nil so RecordMetering
 	// falls back to DefaultCustomerResolver wired against h.Store.
 	MeteringCustomerResolver CustomerResolver
+
+	// JWTSecret is the raw bytes of `sme-secrets/JWT_SECRET` — the SAME
+	// Secret value the notification service reads via secretKeyRef on
+	// `sme-secrets/JWT_SECRET` (see chart templates/sme-services/{billing,
+	// notification}.yaml). Used to mint a short-lived HS256 service token
+	// on the billing→notification hop so notification's JWTAuth middleware
+	// (core/services/shared/middleware/jwt.go) accepts the request.
+	//
+	// Pre-#1999 the billing→notification POST carried only Content-Type
+	// and the JSON body, so notification's HS256 gate 401'd every voucher
+	// email dispatch. Symptom on t38 (TBD-V8): voucher row persisted,
+	// HTTP 200 to operator, no email delivery.
+	//
+	// Optional — empty bytes mean billing falls back to the legacy
+	// no-Authorization-header dispatch. Production wires the real bytes
+	// in main.go via the same JWT_SECRET env the inbound JWTAuth
+	// middleware already consumes; tests may leave it nil to assert the
+	// fallback path or supply test bytes to exercise the mint path.
+	JWTSecret []byte
 }
 
 // ---------------------------------------------------------------------------

--- a/core/services/billing/handlers/vouchers.go
+++ b/core/services/billing/handlers/vouchers.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/openova-io/openova/core/services/billing/store"
+	sharedauth "github.com/openova-io/openova/core/services/shared/auth"
 	"github.com/openova-io/openova/core/services/shared/respond"
 )
 
@@ -127,6 +128,33 @@ type notificationSendRequest struct {
 //
 // Uses h.NotificationClient if set so tests can inject a round-tripper;
 // production wires a 5s-timeout default in main.go.
+//
+// Auth (#1999 / TBD-V8 fix): notification's HTTP surface
+// (`/notification/`) is gated by the same shared HS256 JWTAuth
+// middleware that every other SME microservice uses
+// (core/services/shared/middleware/jwt.go). Pre-#1999 this dispatch
+// carried no Authorization header → notification 401'd silently →
+// voucher row persisted, HTTP 200 to operator, no email ever sent.
+//
+// Fix: when h.JWTSecret is populated, mint a fresh short-lived HS256
+// service-to-service token signed with the SAME `sme-secrets/JWT_SECRET`
+// bytes notification verifies against, and forward it as
+// `Authorization: Bearer …`. The mint helper is the same one
+// catalyst-api's RS256→HS256 bridge uses (sharedauth.MintSMEAccessToken),
+// so the wire contract on the receive side is symmetric — claims carry
+// sub="sme-billing", role="superadmin" so any future per-role gating in
+// notification recognises this as a privileged service caller (today
+// notification's middleware only checks signature validity; the role is
+// future-proofing, not gating).
+//
+// Empty h.JWTSecret falls back to the legacy no-header path so a stale
+// chart that doesn't wire JWT_SECRET into the billing Pod keeps the
+// best-effort fire-and-forget semantics rather than crashing the upsert
+// (mirrors the optional:true contract on catalyst-api's
+// CATALYST_SME_JWT_SECRET secretKeyRef — see chart api-deployment.yaml).
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #10 the minted token is NEVER
+// logged — only the recipient email + template name are.
 func (h *Handler) sendVoucherIssuedEmail(ctx context.Context, recipient string, p store.PromoCode) error {
 	if h.NotificationURL == "" {
 		// Notification not configured — log via caller, exit clean.
@@ -156,6 +184,24 @@ func (h *Handler) sendVoucherIssuedEmail(ctx context.Context, recipient string, 
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	// Service-to-service auth (#1999 / TBD-V8). Mint a fresh HS256
+	// token with the SAME sme-secrets/JWT_SECRET bytes notification
+	// verifies against. Empty h.JWTSecret → legacy unauth path; the
+	// dispatch will 401 but the voucher row already persisted so the
+	// failure is logged-not-fatal (matches existing best-effort
+	// semantics documented on IssueVoucher).
+	if len(h.JWTSecret) > 0 {
+		tok, mintErr := sharedauth.MintSMEAccessToken(
+			h.JWTSecret,
+			"sme-billing",
+			"sme-billing@openova.internal",
+			"superadmin",
+		)
+		if mintErr != nil {
+			return mintErr
+		}
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
 	client := h.NotificationClient
 	if client == nil {
 		client = &http.Client{Timeout: 5 * time.Second}

--- a/core/services/billing/handlers/vouchers_test.go
+++ b/core/services/billing/handlers/vouchers_test.go
@@ -19,11 +19,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/openova-io/openova/core/services/billing/store"
 )
@@ -195,6 +197,7 @@ type capturedRequest struct {
 	Method string
 	URL    string
 	Body   []byte
+	Header http.Header
 }
 
 func (c *captureRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -206,7 +209,7 @@ func (c *captureRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	}
 	c.mu.Lock()
 	c.requests = append(c.requests, capturedRequest{
-		Method: req.Method, URL: req.URL.String(), Body: body,
+		Method: req.Method, URL: req.URL.String(), Body: body, Header: req.Header.Clone(),
 	})
 	c.mu.Unlock()
 	if c.respondErr != nil {
@@ -438,5 +441,191 @@ func TestIssueVoucher_403WithoutVoucherIssuerRole(t *testing.T) {
 	h.IssueVoucher(w, r)
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}
+
+// TestIssueVoucher_SendsAuthorizationHeader — #1999 / TBD-V8 regression
+// guard. When h.JWTSecret is populated (production wiring), the
+// notification dispatch MUST carry an `Authorization: Bearer …` header
+// signed HS256 with the SAME secret bytes. Pre-#1999 this hop was
+// header-less, notification's matching JWTAuth middleware
+// (core/services/shared/middleware/jwt.go) 401'd, and the voucher email
+// silently never landed. Test asserts:
+//
+//  1. The outbound request includes an Authorization header with the
+//     "Bearer " prefix and a non-empty token.
+//  2. The token verifies against the SAME secret bytes the test placed
+//     on h.JWTSecret — i.e. the wire contract is symmetric. If the
+//     billing-side ever drifts to a different secret source the
+//     notification side cannot accept the token and this test fails.
+//  3. The minted claims carry sub/role/typ/exp shape the notification
+//     middleware (and any future role-gating it grows) can read via the
+//     same jwt.MapClaims path catalyst-api's RS256→HS256 bridge uses.
+func TestIssueVoucher_SendsAuthorizationHeader(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec(regexp.QuoteMeta(
+		`INSERT INTO promo_codes (code, credit_omr, description, active, max_redemptions)
+			 VALUES ($1, $2, $3, $4, $5)
+			 ON CONFLICT (code) DO UPDATE
+			 SET credit_omr = EXCLUDED.credit_omr,
+			     description = EXCLUDED.description,
+			     active = EXCLUDED.active,
+			     max_redemptions = EXCLUDED.max_redemptions,
+			     deleted_at = NULL`,
+	)).WithArgs("AUTH-1", 10, "auth header guard", true, 0).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// Choose explicit test bytes — production reads
+	// sme-secrets/JWT_SECRET in BOTH billing.yaml and notification.yaml
+	// (see chart templates) so the values are guaranteed identical at
+	// runtime. The test exercises the symmetric-bytes property: same
+	// bytes on the mint side as the verify side.
+	secret := []byte("test-sme-jwt-secret-aligned-bytes-32x")
+
+	rt := &captureRoundTripper{}
+	h := &Handler{
+		Store:              store.New(db),
+		NotificationURL:    "http://notification.sme.svc.cluster.local:8087/notification/send",
+		SovereignFQDN:      "omani.works",
+		NotificationClient: &http.Client{Transport: rt},
+		JWTSecret:          secret,
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"code":            "AUTH-1",
+		"credit_omr":      10,
+		"description":     "auth header guard",
+		"active":          true,
+		"recipient_email": "bob@example.test",
+	})
+	r := httptest.NewRequest("POST", "/billing/vouchers/issue", bytes.NewReader(body))
+	r = withSuperadmin(r)
+	w := httptest.NewRecorder()
+	h.IssueVoucher(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("issue voucher: expected 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sqlmock unmet: %v", err)
+	}
+	if len(rt.requests) != 1 {
+		t.Fatalf("expected 1 notification POST, got %d", len(rt.requests))
+	}
+	got := rt.requests[0]
+
+	// (1) Authorization header present + Bearer prefix.
+	authz := got.Header.Get("Authorization")
+	if authz == "" {
+		t.Fatal("notification dispatch missing Authorization header (regresses #1999 / TBD-V8)")
+	}
+	if !strings.HasPrefix(authz, "Bearer ") {
+		t.Fatalf("Authorization header not Bearer-prefixed: %q", authz)
+	}
+	tokenStr := strings.TrimPrefix(authz, "Bearer ")
+	if tokenStr == "" {
+		t.Fatal("Bearer token is empty string")
+	}
+
+	// (2) Token verifies against the SAME secret bytes. This is the
+	// load-bearing assertion — it's what notification's JWTAuth
+	// middleware does on every inbound /notification/send call. If the
+	// billing-side ever drifts to a different secret source the
+	// notification side cannot accept the token and this fails.
+	parsed, err := jwt.Parse(tokenStr, func(t *jwt.Token) (any, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, jwt.ErrSignatureInvalid
+		}
+		return secret, nil
+	})
+	if err != nil {
+		t.Fatalf("notification side cannot verify token with the SAME secret bytes: %v", err)
+	}
+	if !parsed.Valid {
+		t.Fatal("parsed token reports !Valid")
+	}
+
+	// (3) Claim shape — sub / role / typ / exp.
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	if !ok {
+		t.Fatalf("claims not jwt.MapClaims: %T", parsed.Claims)
+	}
+	if sub, _ := claims["sub"].(string); sub != "sme-billing" {
+		t.Errorf("sub claim: got %q, want sme-billing", sub)
+	}
+	if role, _ := claims["role"].(string); role != "superadmin" {
+		t.Errorf("role claim: got %q, want superadmin", role)
+	}
+	if typ, _ := claims["typ"].(string); typ != "session" {
+		t.Errorf("typ claim: got %q, want session", typ)
+	}
+	// Token must expire — defends against an accidental no-exp mint
+	// (which would let a stolen token live forever).
+	exp, _ := claims["exp"].(float64)
+	if exp == 0 {
+		t.Error("token missing exp claim — service token must be short-lived")
+	}
+	if int64(exp) <= time.Now().Unix() {
+		t.Errorf("token already expired: exp=%v, now=%v", int64(exp), time.Now().Unix())
+	}
+}
+
+// TestIssueVoucher_NoAuthHeader_WhenJWTSecretUnset — back-compat guard.
+// Empty h.JWTSecret (legacy chart that doesn't wire JWT_SECRET into
+// billing) MUST fall back to the no-header path rather than crash the
+// voucher upsert. The dispatch will still 401 on a JWT-gated
+// notification, but the voucher row already persisted so the failure
+// remains best-effort.
+func TestIssueVoucher_NoAuthHeader_WhenJWTSecretUnset(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec(regexp.QuoteMeta(
+		`INSERT INTO promo_codes (code, credit_omr, description, active, max_redemptions)
+			 VALUES ($1, $2, $3, $4, $5)
+			 ON CONFLICT (code) DO UPDATE
+			 SET credit_omr = EXCLUDED.credit_omr,
+			     description = EXCLUDED.description,
+			     active = EXCLUDED.active,
+			     max_redemptions = EXCLUDED.max_redemptions,
+			     deleted_at = NULL`,
+	)).WithArgs("BACKCOMPAT", 5, "", true, 0).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	rt := &captureRoundTripper{}
+	h := &Handler{
+		Store:              store.New(db),
+		NotificationURL:    "http://notification.sme.svc.cluster.local:8087/notification/send",
+		NotificationClient: &http.Client{Transport: rt},
+		// JWTSecret: nil — legacy chart path.
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"code":            "BACKCOMPAT",
+		"credit_omr":      5,
+		"active":          true,
+		"recipient_email": "legacy@example.test",
+	})
+	r := httptest.NewRequest("POST", "/billing/vouchers/issue", bytes.NewReader(body))
+	r = withSuperadmin(r)
+	w := httptest.NewRecorder()
+	h.IssueVoucher(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("issue voucher: expected 200 even on legacy unauth path, got %d", w.Code)
+	}
+	if len(rt.requests) != 1 {
+		t.Fatalf("expected 1 notification POST, got %d", len(rt.requests))
+	}
+	if authz := rt.requests[0].Header.Get("Authorization"); authz != "" {
+		t.Errorf("expected no Authorization header on legacy path, got %q", authz)
 	}
 }

--- a/core/services/billing/main.go
+++ b/core/services/billing/main.go
@@ -134,6 +134,14 @@ func main() {
 		NotificationClient: &http.Client{
 			Timeout: 5 * time.Second,
 		},
+		// JWTSecret — same bytes the inbound JWTAuth middleware below
+		// validates against (sme-secrets/JWT_SECRET). Used by
+		// sendVoucherIssuedEmail to mint a short-lived service token for
+		// the billing→notification hop so notification's matching
+		// JWTAuth middleware accepts the dispatch. Pre-#1999 this hop
+		// carried no Authorization header → silent 401 → voucher email
+		// never delivered despite voucher row persisting.
+		JWTSecret: jwtSecret,
 	}
 
 	// Tenant-events consumer drives the billing-side cascade on

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,45 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.215 — TBD-V8 / #1999 (2026-05-20): fix sme/notification 401 on
+# billing→notification voucher-email dispatch. The notification service's
+# HTTP surface is gated by the shared HS256 JWTAuth middleware
+# (core/services/shared/middleware/jwt.go), but billing's
+# sendVoucherIssuedEmail (core/services/billing/handlers/vouchers.go)
+# carried only Content-Type — no Authorization header. notification
+# 401'd silently; the voucher row persisted and the operator saw HTTP
+# 200, but no email ever landed. Symptom on t38 canonical walk
+# (agent a550281a, 2026-05-19 21:37:33Z): voucher issued OK, recipient
+# IMAP empty, catalyst-api logs showed sme/notification 401 on the
+# downstream dispatch.
+#
+# Investigation showed both Pods already read the SAME sme-secrets/
+# JWT_SECRET (see chart templates/sme-services/billing.yaml line 67-71
+# and notification.yaml line 47-51) — the TBD's hypothesis of a
+# secret-name mismatch was incorrect. The real gap was that
+# billing never used those bytes to mint an outbound service token.
+#
+# Fix: thread the JWT_SECRET bytes through the billing Handler struct
+# (already in scope on main.go for the inbound JWTAuth middleware) and
+# use sharedauth.MintSMEAccessToken — the SAME mint helper catalyst-api
+# uses for its RS256→HS256 bridge — to sign a short-lived service token
+# on the billing→notification hop. sub="sme-billing",
+# role="superadmin", 5-minute TTL. Empty JWTSecret falls back to the
+# legacy no-header path so a stale chart that doesn't wire JWT_SECRET
+# into billing doesn't crash the voucher upsert (mirrors the optional:
+# true contract on catalyst-api's CATALYST_SME_JWT_SECRET secretKeyRef).
+#
+# Validation: TestIssueVoucher_SendsAuthorizationHeader exercises the
+# round-trip — billing mints with the test bytes, then we re-parse the
+# captured token with the SAME bytes (the exact path notification's
+# JWTAuth middleware takes) and assert claim shape. Pre-#1999 the
+# captured request had no Authorization header so the assertion would
+# have failed the moment notification's middleware ran. Companion test
+# TestIssueVoucher_NoAuthHeader_WhenJWTSecretUnset guards the back-
+# compat fallback path. No chart-template change — the symmetric
+# JWT_SECRET wiring was already in place; this PR is a Go-side fix.
+# Bumped on rebase 1.4.214 → 1.4.215 to claim the next version slot
+# above TBD-V11/#2002 (also 1.4.214 on main). Refs #1999, #1842 D28,
+# #1829 D29.
 # 1.4.214 — TBD-V11 / #2002 (2026-05-20): add init container
 # `wait-for-cutover-token` to the SME provisioning Deployment so the
 # Pod does NOT accept tenant requests until bp-self-sovereign-cutover
@@ -1897,8 +1937,8 @@ name: bp-catalyst-platform
 # was already shipped on 1.4.197 (PR #1820 lineage); this completes
 # the data-layer side so the dropdown finally appears on multi-region
 # Sovereigns. Refs #1821, DoD D20.
-version: 1.4.214
-appVersion: 1.4.214
+version: 1.4.215
+appVersion: 1.4.215
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned


### PR DESCRIPTION
## Summary

TBD-V8 / #1999: voucher email never delivered. On t38 canonical walk (agent a550281a, 2026-05-19 21:37:33Z) operator issued voucher via API — row persisted, HTTP 200 returned, but recipient IMAP stayed empty.

**Root cause is NOT a JWT signing-secret mismatch** as the TBD hypothesised — both sme/billing and sme/notification Pods already read from the SAME `sme-secrets/JWT_SECRET` (chart `templates/sme-services/billing.yaml` line 67-71 and `notification.yaml` line 47-51, both pointing at the same `secretKeyRef`).

The real gap: billing's `sendVoucherIssuedEmail` (core/services/billing/handlers/vouchers.go) POSTed to notification with only `Content-Type` — **NO Authorization header**. notification's HTTP surface is gated by the shared HS256 JWTAuth middleware (core/services/shared/middleware/jwt.go); a missing header returns 401 silently. The voucher row already persisted so the operator saw 200, but no email ever landed.

Per Founder principle **TRACE REQUIREMENTS END-TO-END BEFORE FIXING SYMPTOMS**, I walked FE → catalyst-api → SME gateway → billing → notification end-to-end and verified that the catalyst-api → gateway → billing legs are all correct (catalyst-api mints HS256 via `sharedauth.MintSMEAccessToken`, gateway+billing both verify with the same bytes). Only the billing → notification hop was unsigned.

## Fix (Go-side only, no chart-template change)

1. Add `JWTSecret []byte` to billing's `Handler` struct.
2. Wire it in `main.go` from the same `JWT_SECRET` env the inbound JWTAuth middleware already consumes.
3. In `sendVoucherIssuedEmail`, mint a 5-minute HS256 service token via `sharedauth.MintSMEAccessToken` (the SAME helper catalyst-api's RS256-HS256 bridge uses, so the wire contract is symmetric) and forward it as `Authorization: Bearer <token>`. Claims: `sub="sme-billing"`, `role="superadmin"`, `typ="session"`.
4. Empty `JWTSecret` falls back to the legacy no-header path so a stale chart that doesn't wire `JWT_SECRET` into billing doesn't crash the voucher upsert (mirrors `optional: true` on catalyst-api's `CATALYST_SME_JWT_SECRET` secretKeyRef).

Chart bumped `1.4.213 -> 1.4.214` and bootstrap-kit pin in `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` updated to match (per docs/INVIOLABLE-PRINCIPLES.md #15: Chart.yaml bump and pin bump must ship together).

## Tests

- **`TestIssueVoucher_SendsAuthorizationHeader`** — load-bearing assertion. Billing mints with the test bytes; we re-parse the captured token with the SAME bytes (the exact path notification's JWTAuth middleware takes on receive) and assert claim shape. Pre-fix the captured request had no Authorization header so this would have failed.
- **`TestIssueVoucher_NoAuthHeader_WhenJWTSecretUnset`** — back-compat guard for the legacy no-secret path.
- All pre-existing `TestIssueVoucher_*` tests still pass.

## Test plan

- [x] `go test ./core/services/billing/... -count=1` → PASS (3 packages)
- [x] `helm template products/catalyst/chart --set ingress.marketplace.enabled=true` → both billing AND notification Deployments read `JWT_SECRET` from `secretKeyRef.name=sme-secrets, key=JWT_SECRET`
- [ ] Post-deploy on t38: issue voucher → notification Pod logs no 401, recipient IMAP receives the `voucher-issued` email

## Refs

- Closes #1999 (TBD-V8)
- Refs #1842 (D28 voucher email arrival)
- Refs #1829 (D29 customer journey)

🤖 Generated with [Claude Code](https://claude.com/claude-code)