### PR TITLE
fix(blueprint-controller): align mode enum with bp-*-vcluster blueprint files (unblocks pre-existing CI red)

### DIFF
--- a/core/controllers/blueprint/internal/validate/validate.go
+++ b/core/controllers/blueprint/internal/validate/validate.go
@@ -53,10 +53,41 @@ import (
 
 // canonicalPlacementModes — must mirror the enum in
 // products/catalyst/chart/crds/blueprint.yaml `placementSchema.modes`.
+//
+// Two tiers of placement modes coexist:
+//
+//  1. Application-tier modes — operator/tenant-facing modes for normal
+//     application Blueprints (the marketplace 99%):
+//     - single-region     (one region, no replication)
+//     - active-active     (multi-region, all primary)
+//     - active-hotstandby (multi-region, primary + warm standby)
+//
+//  2. Bootstrap-topology modes — used by `bp-*-vcluster` and other
+//     bootstrap-kit Blueprints whose placement is dictated by the
+//     Sovereign multi-region topology (docs/SOVEREIGN-MULTI-REGION-
+//     DOD.md A4). These are NOT user-selectable; they document which
+//     regions the bootstrap layer auto-installs the chart into:
+//     - primary-only      (installed only in the primary region; e.g.
+//                          bp-mgmt-vcluster, bp-vcluster-helmrepo)
+//     - secondary-only    (installed only in secondary regions; e.g.
+//                          bp-rtz-vcluster)
+//     - every-region      (installed in every region — primary +
+//                          all secondaries; e.g. bp-dmz-vcluster)
+//
+// Both tiers are validated here so the controller accepts the full
+// 71-blueprint corpus. The CRD's openAPIV3Schema enum
+// (products/catalyst/chart/crds/blueprint.yaml) is the structural mirror
+// and must be kept in sync — see that file's `placementSchema.modes`
+// items.enum.
 var canonicalPlacementModes = map[string]struct{}{
-	"single-region":      {},
-	"active-active":      {},
-	"active-hotstandby":  {},
+	// Application-tier
+	"single-region":     {},
+	"active-active":     {},
+	"active-hotstandby": {},
+	// Bootstrap-topology tier (docs/SOVEREIGN-MULTI-REGION-DOD.md A4)
+	"primary-only":   {},
+	"secondary-only": {},
+	"every-region":   {},
 }
 
 // canonicalManifestKinds — must mirror the enum in
@@ -207,7 +238,7 @@ func Validate(bp *unstructured.Unstructured, catalog map[string]struct{}) Result
 			for _, m := range modes {
 				if _, ok := canonicalPlacementModes[m]; !ok {
 					res.Errors = append(res.Errors, fmt.Sprintf(
-						"spec.placementSchema.modes contains %q; legal values: single-region, active-active, active-hotstandby",
+						"spec.placementSchema.modes contains %q; legal values: single-region, active-active, active-hotstandby, primary-only, secondary-only, every-region",
 						m,
 					))
 				}
@@ -217,7 +248,7 @@ func Validate(bp *unstructured.Unstructured, catalog map[string]struct{}) Result
 		if defaultMode, _, _ := unstructured.NestedString(pSchema, "default"); defaultMode != "" {
 			if _, ok := canonicalPlacementModes[defaultMode]; !ok {
 				res.Errors = append(res.Errors, fmt.Sprintf(
-					"spec.placementSchema.default = %q; legal values: single-region, active-active, active-hotstandby",
+					"spec.placementSchema.default = %q; legal values: single-region, active-active, active-hotstandby, primary-only, secondary-only, every-region",
 					defaultMode,
 				))
 			}

--- a/core/controllers/blueprint/internal/validate/validate_test.go
+++ b/core/controllers/blueprint/internal/validate/validate_test.go
@@ -70,6 +70,15 @@ func TestValidate_PlacementModes(t *testing.T) {
 	}{
 		{"valid single", []interface{}{"single-region"}, "", false},
 		{"valid multiple", []interface{}{"single-region", "active-active"}, "", false},
+		// Bootstrap-topology tier (docs/SOVEREIGN-MULTI-REGION-DOD.md A4)
+		// — used by bp-*-vcluster + bp-vcluster-helmrepo. NOT user-
+		// selectable; documents which regions the bootstrap layer
+		// auto-installs the chart into. See canonicalPlacementModes in
+		// validate.go for the full mode taxonomy.
+		{"valid primary-only", []interface{}{"primary-only"}, "", false},
+		{"valid secondary-only", []interface{}{"secondary-only"}, "", false},
+		{"valid every-region", []interface{}{"every-region"}, "", false},
+		{"valid default primary-only", []interface{}{"primary-only"}, "primary-only", false},
 		{"invalid mode", []interface{}{"round-robin"}, "", true},
 		{"empty array", []interface{}{}, "", true},
 		{"null array", nil, "", true},

--- a/products/catalyst/chart/crds/blueprint.yaml
+++ b/products/catalyst/chart/crds/blueprint.yaml
@@ -132,10 +132,31 @@ spec:
                       minItems: 1
                       items:
                         type: string
-                        enum: [single-region, active-active, active-hotstandby]
+                        # Two tiers of placement modes coexist (see
+                        # core/controllers/blueprint/internal/validate/validate.go
+                        # canonicalPlacementModes):
+                        #   - Application-tier (marketplace 99%):
+                        #     single-region / active-active / active-hotstandby
+                        #   - Bootstrap-topology tier (bp-*-vcluster +
+                        #     bp-vcluster-helmrepo, per
+                        #     docs/SOVEREIGN-MULTI-REGION-DOD.md A4):
+                        #     primary-only / secondary-only / every-region
+                        enum:
+                          - single-region
+                          - active-active
+                          - active-hotstandby
+                          - primary-only
+                          - secondary-only
+                          - every-region
                     default:
                       type: string
-                      enum: [single-region, active-active, active-hotstandby]
+                      enum:
+                        - single-region
+                        - active-active
+                        - active-hotstandby
+                        - primary-only
+                        - secondary-only
+                        - every-region
                     minRegions:
                       type: integer
                       minimum: 1


### PR DESCRIPTION
## Summary
- Two tiers of placement modes coexist in the Blueprint corpus, but the validator + CRD enum only registered the application-tier modes, causing `TestValidate_ExistingBlueprintCorpus` to fail on 4 `bp-*-vcluster` blueprints since 2026-05-09.
- Extends `canonicalPlacementModes` and the CRD `placementSchema.modes`/`default` enums with the bootstrap-topology tier (`primary-only` / `secondary-only` / `every-region`) per `docs/SOVEREIGN-MULTI-REGION-DOD.md` A4.
- Unblocks #2012 and every other PR touching `blueprint-controller`.

## Mode taxonomy

| Tier | Modes | Used by |
|------|-------|---------|
| Application-tier (operator-selectable) | `single-region`, `active-active`, `active-hotstandby` | Marketplace blueprints (99%) |
| Bootstrap-topology (auto-installed) | `primary-only`, `secondary-only`, `every-region` | `bp-mgmt-vcluster`, `bp-dmz-vcluster`, `bp-rtz-vcluster`, `bp-vcluster-helmrepo` |

The 4 affected `bp-*-vcluster` blueprints correctly use the bootstrap-topology tier — these are NOT operator-selectable; they document which regions the bootstrap layer auto-installs the chart into.

## Files
- `core/controllers/blueprint/internal/validate/validate.go` — extend enum + inline two-tier doc
- `core/controllers/blueprint/internal/validate/validate_test.go` — 4 new unit cases
- `products/catalyst/chart/crds/blueprint.yaml` — CRD `placementSchema.modes` + `.default` enums kept in sync per validator's "must mirror" comment

## Test plan
- [x] `go test ./core/controllers/blueprint/internal/validate/... -count=1` GREEN locally (go1.23.4)
- [x] `TestValidate_ExistingBlueprintCorpus` 71/71 GREEN (previously 67/71, 4 FAIL)
- [x] `TestValidate_PlacementModes/invalid_mode` still rejects `round-robin`
- [ ] CI `Build blueprint-controller` workflow GREEN
- [ ] CI `Validate Blueprint CRs` workflow (if any) GREEN