### PR TITLE
fix(continuum-witness/cfkv): stabilise RenewExtendsTTLAndBumpsGeneration (unblocks pre-existing CI red)

### DIFF
--- a/core/controllers/continuum/internal/witness/cloudflarekv/client.go
+++ b/core/controllers/continuum/internal/witness/cloudflarekv/client.go
@@ -216,14 +216,25 @@ func (c *CFKVClient) Renew(ctx context.Context, holder string, ttl time.Duration
 	if err != nil {
 		return witness.State{}, err
 	}
-	// If we don't currently hold the lease (or it's expired), Renew
-	// MUST surface ErrLeaseLost regardless of what the Worker says.
-	// This matches the K-Cont-2 contract: Renew is for the holder
-	// only.
+	// If we don't currently hold the lease, Renew MUST surface
+	// ErrLeaseLost regardless of what the Worker says. This matches
+	// the K-Cont-2 contract: Renew is for the holder only. A
+	// non-holder client should not even attempt the PUT.
+	//
+	// NOTE: we deliberately do NOT compare cur.ExpiresAt against
+	// time.Now() here. The Worker is the timestamping authority:
+	// ExpiresAt is stamped in the Worker's clock frame and may
+	// legitimately differ from the client's wall-clock (NTP skew,
+	// fake-clock tests). Expiry is enforced server-side — an expired
+	// renew returns 412, which write() maps to
+	// ErrLeaseHeldByAnother, which we then re-map to ErrLeaseLost
+	// below. This keeps a single source of truth for "is the lease
+	// alive" (the Worker), avoiding the client-side wall-clock-vs-
+	// server-clock disagreement that previously failed
+	// TestCFKV_ContractSuite/RenewExtendsTTLAndBumpsGeneration
+	// whenever the fake worker's clock and the test's real clock
+	// diverged.
 	if cur.Holder != holder {
-		return cur, witness.ErrLeaseLost
-	}
-	if !time.Now().Before(cur.ExpiresAt) {
 		return cur, witness.ErrLeaseLost
 	}
 	st, err := c.write(ctx, holder, ttl, "renew", cur.Generation)


### PR DESCRIPTION
## Summary

- **Root cause**: `CFKVClient.Renew` compared the server-stamped `ExpiresAt` against the client's wall-clock (`time.Now()`). The Cloudflare Worker is the timestamping authority — `ExpiresAt` lives in the Worker's clock frame. Whenever the two clocks diverged (NTP skew, fake-clock tests, or the test fixture's pinned date drifting past CI's current date), the client declared the lease expired and returned `ErrLeaseLost` even though the Worker still considered the lease healthy.
- **Symptom**: `Build continuum-controller` red on every push since 2026-05-09 with `Renew: witness: lease lost` failing both `TestCFKV_ContractSuite/RenewExtendsTTLAndBumpsGeneration` and `TestCFKV_ContractSuite/GenerationMonotonicityAcrossOps`. Blocks #2012 and every subsequent continuum-controller PR.
- **Fix**: Remove the client-side wall-clock expiry check in `Renew`. Server-side expiry is already enforced — an expired renew returns 412 → `ErrLeaseHeldByAnother` → re-mapped to `ErrLeaseLost` by the existing wrapper. Single source of truth = the Worker. The non-holder early return (`cur.Holder != holder`) is preserved because it never depended on time.

## Test plan

- [x] `go test ./continuum/internal/witness/cloudflarekv/... -count=10` — passes 10/10 runs (regression for flake)
- [x] `TestCFKV_ContractSuite/RenewExtendsTTLAndBumpsGeneration` GREEN
- [x] `TestCFKV_ContractSuite/GenerationMonotonicityAcrossOps` GREEN
- [x] All 14 contract sub-tests GREEN (no behavioral regression)
- [x] `go test ./continuum/...` all packages GREEN
- [ ] CI: `Build continuum-controller` workflow green

## Why this is correct (not just papering over the test)

The contract suite docstring already states the design: "server-authoritative for CF (the server stamps timestamps + bumps Generation)" and "the in-memory + CFKV impls stamp ExpiresAt with the witness's clock, not the test's wall-clock." The in-memory reference impl uses `c.store.now()` (server-side clock) for its expiry check, never the client's wall-clock. The cloudflarekv client was the outlier — its wall-clock check broke the server-authoritative contract and produced false-positive `ErrLeaseLost`. In production this would also cause spurious lease-lost events whenever a controller's clock drifted ahead of the Worker's by more than a renew interval.

Refs #2012

🤖 Generated with [Claude Code](https://claude.com/claude-code)