### PR TITLE
fix(sandbox-controller): correct NEWAPI_BASE_URL to actual bp-newapi service name

### DIFF
--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -68,7 +68,15 @@ spec:
   chart:
     spec:
       chart: sandbox
-      version: 0.3.0
+      # 0.3.1 (TBD-V14, issue #2015, 2026-05-20): chart default for
+      # `env.newapiBaseURL` corrected from
+      # `http://newapi.newapi.svc.cluster.local:3000` to
+      # `http://newapi-bp-newapi.newapi.svc.cluster.local:3000`. The
+      # bp-newapi Service is `newapi-bp-newapi` (per `bp-newapi.fullname`
+      # helper), not bare `newapi`. Pre-fix every Sovereign's
+      # sandbox-controller TokenMint POST returned `no such host`,
+      # blocking the canonical Pillar-4 qwen-code customer journey.
+      version: 0.3.1
       sourceRef:
         kind: HelmRepository
         name: bp-sandbox

--- a/platform/sandbox/chart/Chart.yaml
+++ b/platform/sandbox/chart/Chart.yaml
@@ -24,8 +24,21 @@ annotations:
   # (see issue #181 + docs/BLUEPRINT-AUTHORING.md §11.1).
   catalyst.openova.io/no-upstream: "true"
   catalyst.openova.io/smoke-render-mode: "default-off"
-version: 0.3.0
-appVersion: "0.3.0"
+# 0.3.1 (TBD-V14, issue #2015, 2026-05-20): default
+# `env.newapiBaseURL` was `http://newapi.newapi.svc.cluster.local:3000`,
+# but the canonical bp-newapi ClusterIP Service is named via
+# `bp-newapi.fullname` (release `newapi` + chart `bp-newapi`
+# => `newapi-bp-newapi`) per platform/newapi/chart/templates/_helpers.tpl.
+# The bootstrap-kit overlay does NOT override `env.newapiBaseURL`, so
+# every Sovereign sandbox-controller resolved a DNS name no Service
+# publishes — `POST /admin/tokens/sandbox` returned `no such host`
+# and the canonical Pillar-4 customer journey (qwen-code Sandbox
+# session → TokenMint) stalled. Verified via
+# `helm template newapi platform/newapi/chart/ -s templates/service.yaml`
+# → metadata.name: newapi-bp-newapi. Walker on t38 (chart 1.4.216,
+# substrate be4f78bc872e2c56) caught the live regression.
+version: 0.3.1
+appVersion: "0.3.1"
 keywords:
   - catalyst
   - sandbox

--- a/platform/sandbox/chart/templates/deployment.yaml
+++ b/platform/sandbox/chart/templates/deployment.yaml
@@ -86,7 +86,11 @@ spec:
             # land so a fresh-prov Sovereign with bridge-handler
             # rollout pending stays usable for the gitops scaffolding.
             - name: NEWAPI_BASE_URL
-              value: {{ .Values.env.newapiBaseURL | default "http://newapi.newapi.svc.cluster.local:3000" | quote }}
+              # TBD-V14 (issue #2015): canonical bp-newapi Service is named
+              # via `bp-newapi.fullname` => `newapi-bp-newapi` (NOT bare
+              # `newapi`). The pre-fix default resolved to a DNS name no
+              # Service publishes, breaking every Sandbox TokenMint.
+              value: {{ .Values.env.newapiBaseURL | default "http://newapi-bp-newapi.newapi.svc.cluster.local:3000" | quote }}
             - name: NEWAPI_ADMIN_SECRET
               valueFrom:
                 secretKeyRef:

--- a/platform/sandbox/chart/values.yaml
+++ b/platform/sandbox/chart/values.yaml
@@ -40,7 +40,20 @@ env:
   # alongside the rest of its REST surface, so this defaults to the
   # in-cluster NewAPI service. Per Inviolable Principle #4 every
   # operator may override via per-Sovereign overlay.
-  newapiBaseURL: "http://newapi.newapi.svc.cluster.local:3000"
+  #
+  # TBD-V14 (issue #2015, t38 walker 2026-05-19): the canonical bp-newapi
+  # ClusterIP Service is named via `bp-newapi.fullname` (release name
+  # `newapi` + chart name `bp-newapi` → `newapi-bp-newapi`) per
+  # platform/newapi/chart/templates/_helpers.tpl. The pre-fix default
+  # (`http://newapi.newapi.svc.cluster.local:3000`) resolves to a DNS
+  # name that no Service ever publishes, so every TokenMint POST from
+  # sandbox-controller returned `lookup newapi.newapi.svc.cluster.local
+  # ... no such host` and the canonical Pillar-4 customer journey
+  # (console.<orgslug>.omani.homes → Sandbox → qwen-code) stalled at
+  # Wave-9 token mint. Verified with `helm template newapi
+  # platform/newapi/chart/ -s templates/service.yaml` → renders
+  # `metadata.name: newapi-bp-newapi`.
+  newapiBaseURL: "http://newapi-bp-newapi.newapi.svc.cluster.local:3000"
   # Comma-separated list of NewAPI channel names every freshly-minted
   # Sandbox token is allowed to target. The controller refuses to mint
   # tokens with an empty channel set (NoAllowedChannels condition on


### PR DESCRIPTION
## Summary

The bp-sandbox chart defaulted `env.newapiBaseURL` to `http://newapi.newapi.svc.cluster.local:3000`. That assumes the bp-newapi ClusterIP Service is named bare `newapi`. In practice the canonical Service name is **`newapi-bp-newapi`**, because `bp-newapi.fullname` (`platform/newapi/chart/templates/_helpers.tpl`) renders `{Release.Name}-{Chart.Name}` and the bootstrap-kit slot 80 sets `releaseName: newapi` against chart `bp-newapi`.

The bootstrap-kit overlay at `clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml` does NOT override `env.newapiBaseURL`, so every Sovereign's sandbox-controller resolved a DNS name no Service ever publishes:

```
POST /admin/tokens/sandbox -> lookup newapi.newapi.svc.cluster.local
  on 10.43.0.10:53: no such host
```

Walker on **t38** (chart 1.4.216, substrate `be4f78bc872e2c56`, 2026-05-19) caught the live regression. Every qwen-code Sandbox session failed at TokenMint, blocking the canonical **Pillar-4** customer journey (`console.<orgslug>.omani.homes` -> Sandbox -> qwen-code provisions additional app).

## Root cause (file:line)

- `platform/sandbox/chart/values.yaml:43` — wrong default string.
- `platform/sandbox/chart/templates/deployment.yaml:88-89` — inline `default "http://newapi.newapi.svc.cluster.local:3000"` mirrors the wrong string.
- `clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml:117-120` — bootstrap-kit overlay defines `env.hostCluster` / `env.sovereignFQDN` / `env.newapiDefaultChannels`, but NOT `env.newapiBaseURL`, so the chart default reaches every install.

The "real" Service name is verified by:

```
$ helm template newapi platform/newapi/chart/ --namespace newapi \
    -s templates/service.yaml
metadata:
  name: newapi-bp-newapi
```

(See `platform/newapi/chart/Chart.yaml:16` header comment which independently names the Postgres host `newapi-bp-newapi-newapi-pg-rw.newapi.svc.cluster.local`, plus `platform/sandbox/chart/values.yaml:113` which already uses `newapi-bp-newapi-token-signing-key` for the admin-secret name — same naming pattern, consistent inside this PR.)

## Fix

| File | Change |
|---|---|
| `platform/sandbox/chart/values.yaml` | Default `env.newapiBaseURL` -> `http://newapi-bp-newapi.newapi.svc.cluster.local:3000`. |
| `platform/sandbox/chart/templates/deployment.yaml` | Match inline `default` in the env block. |
| `platform/sandbox/chart/Chart.yaml` | bp-sandbox `0.3.0` -> `0.3.1` (+ AppVersion). |
| `clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml` | Pin `0.3.0` -> `0.3.1` in lockstep (Inviolable Principle #14). |

Surgical: 4 files, 43 insertions, 5 deletions. No Go code touched. No retry-alternate-name defensive dial logic — the fix lives at the source of truth (env var default).

## Validation

- `helm template bp-sandbox platform/sandbox/chart/ --set enabled=true --set env.hostCluster=hz-fsn-rtz-prod --set env.sovereignFQDN=t38.omani.works --set runtime.newapiURL=https://newapi.t38.omani.works/v1 -s templates/deployment.yaml` renders the env literal:
  ```
  - name: NEWAPI_BASE_URL
    value: "http://newapi-bp-newapi.newapi.svc.cluster.local:3000"
  ```
- `helm template newapi platform/newapi/chart/ -s templates/service.yaml` renders `metadata.name: newapi-bp-newapi`.
- Per Inviolable Principle #15 the strongest in-cluster validation is `helm install` from-scratch on Kind — Kind is not available on this bastion (no docker daemon), so I lean on the helm-template render here; t38/t39 fresh-prov walk after the GHCR tag publishes is the operator DoD.

Note (anti-theater): I deliberately do NOT use `--dry-run=server` against the running t38 cluster — per PR #1933 that path lies whenever the CRD/Service already exists.

## DoD / closure

Per CLAUDE.md §0 + anti-theater discipline this PR uses `Refs #2015`, NOT `Closes`. Issue closes only after a fresh-prov Sandbox session successfully mints a NewAPI token and reaches `qwen-code` (operator walk + screenshot attached to #2015).

## Test plan

- [x] `helm template` of bp-sandbox renders `NEWAPI_BASE_URL=http://newapi-bp-newapi.newapi.svc.cluster.local:3000`.
- [x] `helm template` of bp-newapi confirms Service name `newapi-bp-newapi`.
- [ ] CI green (chart-publish + smoke render).
- [ ] GHCR tag `oci://ghcr.io/openova-io/bp-sandbox:0.3.1` exists (Inviolable Principle #13).
- [ ] Fresh-prov walk on next Sovereign — Sandbox TokenMint POST succeeds, operator screenshot attached to #2015.

Refs #2015

🤖 Generated with [Claude Code](https://claude.com/claude-code)