### PR TITLE
fix(security/kyverno-policies): annotate chart catalyst.openova.io/no-upstream=true (Refs #2019)

### DIFF
--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -25,3 +25,11 @@ keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:
   - name: OpenOva Catalyst
     email: catalyst@openova.io
+
+# Opt out of the hollow-chart guard (Blueprint-Release workflow / issue #181):
+# this chart legitimately ships only Catalyst-authored CRs (ClusterPolicy
+# CRs that target the kyverno.io CRDs installed by bp-kyverno at slot 27).
+# It has NO upstream Helm subchart to bundle. Same shape as
+# bp-crossplane-claims (XRDs + Compositions, no upstream Crossplane subchart).
+annotations:
+  catalyst.openova.io/no-upstream: "true"


### PR DESCRIPTION
## Summary

Adds the `catalyst.openova.io/no-upstream: "true"` annotation to `platform/kyverno-policies/chart/Chart.yaml` so the Blueprint-Release CI hollow-chart guard (issue #181) allows the chart to publish.

## Why

PR #2022 (merged 2026-05-20T00:42:30Z) split Kyverno policies into a new bp-kyverno-policies@1.0.0 Blueprint. The post-merge Blueprint Release workflow run [#26134163473](https://github.com/openova-io/openova/actions/runs/26134163473) failed at the **hollow-chart guard** step:

```
ERROR: Chart platform/kyverno-policies/chart/Chart.yaml declares NO
dependencies. Every Blueprint umbrella chart at platform/<name>/chart/
MUST declare its upstream chart under `dependencies:` per
docs/BLUEPRINT-AUTHORING.md §11.1 Umbrella shape. See issue #181.
(To opt out for charts that legitimately ship only Catalyst-authored
CRs, set annotations.catalyst.openova.io/no-upstream: "true".)
```

This chart is a pure-overlay Blueprint — it ships 20 ClusterPolicy templates targeting the `kyverno.io/v1` CRDs that bp-kyverno installs (via its upstream Kyverno subchart at slot 27). There is no upstream Helm subchart to bundle.

Same shape as `bp-crossplane-claims/chart/` which already carries the same annotation (XRDs + Compositions, no upstream Crossplane subchart).

## Change

```diff
 type: application
 version: 1.0.0
 appVersion: "1.0.0"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:
   - name: OpenOva Catalyst
     email: catalyst@openova.io
+
+# Opt out of the hollow-chart guard (Blueprint-Release workflow / issue #181):
+# this chart legitimately ships only Catalyst-authored CRs (ClusterPolicy
+# CRs that target the kyverno.io CRDs installed by bp-kyverno at slot 27).
+# It has NO upstream Helm subchart to bundle. Same shape as
+# bp-crossplane-claims (XRDs + Compositions, no upstream Crossplane subchart).
+annotations:
+  catalyst.openova.io/no-upstream: "true"
```

## Version

Chart version stays at `1.0.0` — no artifact was published yet (the failed run aborted before `helm push`). The slot pin in `clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml` already points at 1.0.0, so this single Chart.yaml edit retriggers the workflow on the same version tag.

## Validation

```
$ helm template bp-kyverno-policies platform/kyverno-policies/chart \
    | grep -c '^kind: ClusterPolicy'
18

$ helm lint platform/kyverno-policies/chart
==> 1 chart(s) linted, 0 chart(s) failed

$ cd tests/e2e/bootstrap-kit && go test . -count=1
ok  github.com/openova-io/openova/tests/e2e/bootstrap-kit  1.722s
```

## Test plan

- [x] `helm template` renders 18 ClusterPolicy CRs
- [x] `helm lint` clean
- [x] Bootstrap-kit Go test suite passes (`tests/e2e/bootstrap-kit`)
- [ ] Blueprint-Release CI publishes `oci://ghcr.io/openova-io/bp-kyverno-policies:1.0.0` on merge

Refs #2019, Refs #1096