### PR TITLE
fix(catalyst-ui): wizard StepSuccess CTA → BSS menu in operator console (kills admin.<fqdn> anti-canon ref)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -785,7 +785,16 @@ spec:
       # service image pins are unchanged from 1.4.216 (TBD-A6 deploy-
       # bot bump in commit d4b995c carrying TBD-V8 #1999 sme image
       # SHA b190566).
-      version: 1.4.220
+      # 1.4.221 — TBD-V20 / #2028 (2026-05-20): wizard StepSuccess
+      # "Issue first voucher" CTA URL fix — replaced the anti-canon
+      # `admin.<fqdn>/billing/vouchers/new` link with the BSS canonical
+      # `console.<fqdn>/bss/vouchers`. Per CLAUDE.md §0 there is no
+      # `admin.*` subdomain; voucher operations live under the BSS
+      # menu inside the operator console. Surfaces-only fix
+      # (StepSuccess.tsx + StepSuccess.test.tsx 3 assertions); no
+      # API / wire / chart-template changes; image SHAs unchanged
+      # from 1.4.220.
+      version: 1.4.221
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/e2e/sme-demo.spec.ts
+++ b/products/catalyst/bootstrap/ui/e2e/sme-demo.spec.ts
@@ -239,7 +239,9 @@ test.describe('@sme-demo SME end-to-end happy path (issue #805)', () => {
       // Pending the SME-billing/credits surface (#802 follow-up).
       // The unified-rbac SME-tier console covers /console/sme/users
       // + /console/sme/roles today; StepSuccess.tsx links at
-      // admin.<fqdn>/billing/vouchers/new for the cross-domain flow.
+      // console.<fqdn>/bss/vouchers (the BSS menu inside the operator
+      // console — voucher operations live there per CLAUDE.md §0;
+      // see TBD-V20).
       // The fixme step activates once an in-SPA /console/sme/billing
       // route lands and asserts the ledger entry for alice.
       await page.goto('/sme/billing' as never)

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepSuccess.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepSuccess.test.tsx
@@ -148,11 +148,14 @@ describe('StepSuccess CTAs render with correct hrefs', () => {
     )
   })
 
-  it('renders voucher CTA pointing at admin.<fqdn>/billing/vouchers/new', () => {
+  it('renders voucher CTA pointing at console.<fqdn>/bss/vouchers (BSS menu)', () => {
+    // Per CLAUDE.md §0 canon + TBD-V20: voucher operations live under the
+    // BSS menu inside the operator console (console.<fqdn>/bss/vouchers),
+    // NOT the legacy anti-canon `admin.<fqdn>/billing/vouchers/new` URL.
     render(<StepSuccess />)
     const voucher = screen.getByTestId('voucher-cta') as HTMLAnchorElement
     expect(voucher.href).toBe(
-      `https://admin.${FIXTURE_FQDN}/billing/vouchers/new`,
+      `https://console.${FIXTURE_FQDN}/bss/vouchers`,
     )
   })
 
@@ -175,7 +178,7 @@ describe('StepSuccess CTAs render with correct hrefs', () => {
     expect(consoleLink.href).toBe(`https://console.${FIXTURE_FQDN}/`)
     const voucher = screen.getByTestId('voucher-cta') as HTMLAnchorElement
     expect(voucher.href).toBe(
-      `https://admin.${FIXTURE_FQDN}/billing/vouchers/new`,
+      `https://console.${FIXTURE_FQDN}/bss/vouchers`,
     )
   })
 })
@@ -309,7 +312,7 @@ describe('No hardcoded sovereign URL', () => {
       `https://console.${newFQDN}/`,
     )
     expect((screen.getByTestId('voucher-cta') as HTMLAnchorElement).href).toBe(
-      `https://admin.${newFQDN}/billing/vouchers/new`,
+      `https://console.${newFQDN}/bss/vouchers`,
     )
     expect((screen.getByTestId('docs-cta') as HTMLAnchorElement).href).toBe(
       `https://docs.${newFQDN}/`,

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepSuccess.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepSuccess.tsx
@@ -25,7 +25,10 @@
  *      "Coming soon — fetch via SSH" copy with a runbook link.
  *
  *   4. Voucher-issuance shortcut — secondary CTA pointing at
- *        https://admin.<sovereign-fqdn>/billing/vouchers/new
+ *        https://console.<sovereign-fqdn>/bss/vouchers
+ *      (BSS menu inside the operator console — voucher operations
+ *      live under the BSS sidebar, NOT under any `admin.*`
+ *      subdomain; see CLAUDE.md §0 canon + TBD-V20).
  *
  *   5. SSE final-state log tail (last 20 lines) collapsed/expandable.
  *
@@ -297,9 +300,13 @@ export function StepSuccess({
 
   // Computed URLs — every one of them goes through sovereignSubURL().
   const consoleURL = result?.consoleURL || sovereignSubURL(fqdn, 'console')
-  const adminURL   = sovereignSubURL(fqdn, 'admin')
   const docsURL    = sovereignSubURL(fqdn, 'docs')
-  const voucherURL = adminURL ? `${adminURL}/billing/vouchers/new` : ''
+  // Voucher CTA points at the BSS menu inside the operator console.
+  // Per CLAUDE.md §0 canon: voucher + billing operations live at
+  // `console.<fqdn>/bss/vouchers` — NOT under any `admin.*` subdomain
+  // (the legacy `admin.<sov>/billing/vouchers/new` URL is anti-canon).
+  // See TBD-V20.
+  const voucherURL = consoleURL ? `${consoleURL.replace(/\/$/, '')}/bss/vouchers` : ''
 
   const adminUsername = fqdn ? `admin@${fqdn}` : ''
 

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,17 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.221 — TBD-V20 / #2028 (2026-05-20): wizard StepSuccess "Issue
+# first voucher" CTA was pointing at the anti-canon
+# `https://admin.<fqdn>/billing/vouchers/new` URL. Per CLAUDE.md §0
+# canon there is no `admin.*` subdomain — voucher + billing
+# operations live under the BSS menu inside the operator console at
+# `https://console.<fqdn>/bss/vouchers`. The fix replaces the
+# computed `voucherURL` in StepSuccess.tsx (uses the existing
+# `consoleURL` + `/bss/vouchers` route, which is already correctly
+# mounted at router.tsx:1576). Test fixtures in StepSuccess.test.tsx
+# (3 assertions) bumped to the new BSS canonical URL. Surfaces
+# only — no API / wire / chart-template changes; image SHAs
+# unchanged from 1.4.220.
 # 1.4.220 — TBD-V13 / #2016 (2026-05-20): bp-self-sovereign-cutover
 # orchestrator state-resume now idempotent across catalyst-api restart.
 # Pre-fix t38 walk: catalyst-api restarted mid-cutover (between
@@ -2022,7 +2034,7 @@ name: bp-catalyst-platform
 # was already shipped on 1.4.197 (PR #1820 lineage); this completes
 # the data-layer side so the dropdown finally appears on multi-region
 # Sovereigns. Refs #1821, DoD D20.
-version: 1.4.220
+version: 1.4.221
 appVersion: 1.4.219
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,


### PR DESCRIPTION
## Summary

Wizard's terminal "Issue first voucher" CTA in StepSuccess.tsx linked at the **anti-canon** URL `https://admin.<sovereign-fqdn>/billing/vouchers/new`. Per CLAUDE.md §0 canon there is no `admin.*` subdomain — voucher + billing operations live under the **BSS menu inside the operator console**:

```
https://console.<sovereign-fqdn>/bss/vouchers
```

The BSS routes are already correctly mounted at `products/catalyst/bootstrap/ui/src/app/router.tsx:1576` (`/bss/vouchers` → `VouchersPage` with `consoleLayoutRoute` parent). This PR points the wizard CTA at them.

## Audit context

Pillar-1 BSS audit dated 2026-05-20 (`/tmp/audit-pillar1-bss-2026-05-20.md`) found 8 surfaces audited → 5 WIRED-CORRECT, 3 WIRED-INCORRECT. This PR closes the 1 small, safe-to-ship anti-canon URL gap. The other 2 (TBD-V18 marketplace configSchema, TBD-V19 phone-OTP vs email-magic-link) are filed for separate scoping/founder decision and are NOT addressed here.

## Changes

| File | Change |
|---|---|
| `products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepSuccess.tsx` | `voucherURL` now derives from `consoleURL` + `/bss/vouchers`; drops the unused `adminURL` computation; updates doc-comment header at line 28. |
| `products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepSuccess.test.tsx` | 3 fixture assertions bumped to the BSS canonical URL `https://console.<FQDN>/bss/vouchers`. |
| `products/catalyst/bootstrap/ui/e2e/sme-demo.spec.ts` | Stale doc-comment in a skipped `test.fixme` updated for consistency. |
| `products/catalyst/chart/Chart.yaml` | `bp-catalyst-platform` 1.4.220 → 1.4.221 + header entry. |
| `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` | Pin bumped 1.4.220 → 1.4.221 (lockstep — Principle #14). |

Surfaces-only — no API / wire / chart-template changes; image SHAs unchanged from 1.4.220.

## Validation

- `helm template products/catalyst/chart/` from a fresh clone of `origin/main` (Principle #15 — NOT `--dry-run=server`). Templates clean.
- All 3 `voucher-cta` assertions in `StepSuccess.test.tsx` now expect the BSS canonical URL and match the new `voucherURL` derivation logic.

## Hard rules respected

- Refs (not Closes) — the V20 issue stays open until a fresh-prov walk + screenshot lands.
- No `openova.io` introduced in any test fixture.
- BSS route `/bss/vouchers` verified to exist at `router.tsx:1576` per audit.

## Test plan

- [ ] CI green (lint + unit tests for StepSuccess pass)
- [ ] After merge: confirm `bp-catalyst-platform:1.4.221` publishes to GHCR
- [ ] After merge: on a fresh prov, complete wizard → click "Issue first voucher" → land on `https://console.<fqdn>/bss/vouchers` (VouchersPage rendered) → screenshot attached to #2028

Refs #2028
