### PR TITLE
fix(self-sovereign-cutover): correct totalSteps from "8" to "9" in cutover status ConfigMap (Refs #2035)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -341,7 +341,15 @@ spec:
       # admin-secret). Smoke render unaffected (CronJob lacks the
       # cutover-step labels so the contract test's exactly-9-steps
       # assertion still passes).
-      version: 0.1.33
+      #
+      # 0.1.34 (TBD-V25, issue #2035, 2026-05-20): fix stale
+      # `totalSteps: "8"` literal in 09-cutover-status-configmap.yaml
+      # — chart shipped 9 steps since 0.1.30 but the initial-state
+      # status CM still claimed 8. Cosmetic post-trigger (catalyst-api
+      # overwrites with live count on /start) but UIs reading
+      # `<currentIndex>/<totalSteps>` in the pre-trigger window
+      # showed the wrong denominator. Single-literal swap.
+      version: 0.1.34
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 0.1.33
+  version: 0.1.34
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -103,7 +103,21 @@ name: bp-self-sovereign-cutover
 # from the same reflector-mirrored gitea-admin-secret Step-01 mounts.
 # Smoke render unaffected (CronJob lacks the cutover-step labels so
 # the contract test's exactly-9-steps assertion still passes).
-version: 0.1.33
+#
+# 0.1.34 (TBD-V25, issue #2035, 2026-05-20): fix the stale
+# `totalSteps: "8"` literal in 09-cutover-status-configmap.yaml — the
+# chart shipped 9 step ConfigMaps since 0.1.30 (TBD-C18 added step 09
+# gitea-token-mint) but the initial-state status ConfigMap still
+# claimed 8. Post-trigger this is overwritten by catalyst-api on
+# /start (cutover.go:763 patches with `strconv.Itoa(len(steps))`), so
+# the bug only surfaces in the pre-trigger window between chart
+# install and the auto-trigger Job firing — typically seconds, but up
+# to ~25 min on a slow cold-start cluster. UIs rendering progress as
+# `<currentIndex>/<totalSteps>` during that window showed the wrong
+# denominator. Single-literal swap; contract test (asserts step_count
+# -eq 9) already gates against future drift. No code change required
+# in cutover.go — its post-start patch path was always correct.
+version: 0.1.34
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/09-cutover-status-configmap.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/09-cutover-status-configmap.yaml
@@ -43,7 +43,7 @@ data:
   cutoverFinishedAt: ""
   currentStep: ""
   currentStepIndex: "0"
-  totalSteps: "8"
+  totalSteps: "9"
   progressPercent: "0"
   failedStep: ""
   lastError: ""


### PR DESCRIPTION
## Summary

- `platform/self-sovereign-cutover/chart/templates/09-cutover-status-configmap.yaml:46` hardcoded `totalSteps: "8"`, but the chart has shipped **9** step ConfigMaps since 0.1.30 (TBD-C18 added step 09 `gitea-token-mint`).
- Bump literal `"8"` → `"9"`. Chart 0.1.33 → 0.1.34. Blueprint manifest + bootstrap-kit pin bumped in lockstep (Principle #14).

## Why this is a bug (audit-grade detail)

`products/catalyst/bootstrap/api/internal/handler/cutover.go:763` overwrites `totalSteps` with the live discovered count on every `/start`, so **post-trigger** the value is correct. **Pre-trigger** — between chart install and the auto-trigger Job firing the `/start` POST (typically seconds, but on a slow cold-start cluster up to ~25 min) — any `GET /api/v1/sovereign/cutover/status` returns `totalSteps: 8`. Any UI rendering progress as `<currentIndex>/<totalSteps>` shows the wrong denominator in that window.

Audit ref: `/tmp/audit-pillar5-cutover-2026-05-20.md` §6.1.

## Cross-impact: TBD-V13 (#2016) state-resume — NONE

The resume engine in `ResumeInterruptedCutover` derives `totalSteps` from live `listCutoverSteps` discovery (`cutover.go:1087`, `1190`, `1221`), NOT from the literal in the status ConfigMap. The literal is only read for the `/status` response shape (`cutover.go:1371`). Resume was never affected by the off-by-one — confirmed by reading the resume logic end-to-end.

## Why Option B (literal swap) over Option A (drop the literal)

Audit recommended Option A (drop the literal + default from live discovery in `HandleCutoverStatus`). I chose Option B because:

1. Option B is a 1-line YAML swap; Option A needs a parallel patch in `cutover.go:HandleCutoverStatus` + new tests.
2. The contract test (`tests/cutover-contract.sh:64`) already asserts `step_count -eq 9` — the literal cannot drift from 9 without breaking CI on the next bump.
3. Option A is still on the table for a later quality bump if/when another step gets added; this PR fixes the immediate user-visible cosmetic.

## Validation

- [x] `helm template platform/self-sovereign-cutover/chart` renders `totalSteps: "9"` (verified locally)
- [x] `helm lint platform/self-sovereign-cutover/chart` → 0 chart(s) failed
- [x] `bash platform/self-sovereign-cutover/chart/tests/cutover-contract.sh` → all 20 cases green (Case 2 step_count=9 already passed)
- [x] `go test ./products/catalyst/bootstrap/api/internal/handler/... -count=1 -run "Cutover|cutover"` → PASS
- [x] Did NOT use `kubectl --dry-run=server` (per Principle #15, anti-theater rule §4.2)

## DoD

**This PR does NOT close #2035.** Per anti-theater discipline (§4), operator walk on a fresh prov with screenshot is required before flip to VERIFIED-PASS. PR body uses `Refs #2035` (§4 hard rule #1).

## Test plan

- [ ] Wait for CI green
- [ ] Merge (non-admin)
- [ ] Confirm `oci://ghcr.io/openova-io/bp-self-sovereign-cutover:0.1.34` publishes
- [ ] Operator-walk on next fresh prov: at chart-install but pre-auto-trigger, `kubectl get cm -n openova-system cutover-status -o jsonpath='{.data.totalSteps}'` returns `9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)