### PR TITLE
fix(sandbox-controller): add 4 missing SANDBOX_* env vars + LLM_GATEWAY_TOKEN case fix (Refs #2032)

### DIFF
--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -68,6 +68,15 @@ spec:
   chart:
     spec:
       chart: sandbox
+      # 0.3.2 (TBD-V21 #2032, 2026-05-20): ship 4 residual MCP env vars
+      # not covered by PR #1987 — SANDBOX_TOKEN (P1; unblocks marketplace.*
+      # tools), SANDBOX_JWT_SECRET (P1; auth gate exits test-mode),
+      # SANDBOX_REPOS (P3; gitea.repos.list filter). Also fixes
+      # case-mismatch bug on LLM_GATEWAY_TOKEN / OPENAI_API_KEY
+      # secretKeyRef (key was lowercase `llm-gateway-token`; Secret
+      # writes uppercase `LLM_GATEWAY_TOKEN`). Paired with bp-newapi
+      # 1.4.31 extending reflectorNamespaces to include `sandbox-.*`.
+      #
       # 0.3.1 (TBD-V14, issue #2015, 2026-05-20): chart default for
       # `env.newapiBaseURL` corrected from
       # `http://newapi.newapi.svc.cluster.local:3000` to
@@ -76,7 +85,7 @@ spec:
       # helper), not bare `newapi`. Pre-fix every Sovereign's
       # sandbox-controller TokenMint POST returned `no such host`,
       # blocking the canonical Pillar-4 qwen-code customer journey.
-      version: 0.3.1
+      version: 0.3.2
       sourceRef:
         kind: HelmRepository
         name: bp-sandbox

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -160,7 +160,14 @@ spec:
       # plain `valkey` Service. Caused 31× CrashLoopBackOff on t34.
       # bp-newapi 1.4.29 ships the corrected
       # `valkey-primary.valkey.svc.cluster.local` default.
-      version: 1.4.30
+      # 1.4.31 (TBD-V21 #2032, 2026-05-20): extend default
+      # `sandboxTokenSigningKey.reflectorNamespaces` to include the
+      # `sandbox-.*` regex pattern so emberstack/reflector mirrors the
+      # SIGNING_KEY Secret into every per-Sandbox namespace. Paired with
+      # bp-sandbox 0.3.2 which mounts SIGNING_KEY as the MCP's
+      # `SANDBOX_JWT_SECRET` env (closes auth-gate-stays-in-test-mode
+      # silent-breakage).
+      version: 1.4.31
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/core/controllers/sandbox/internal/controller/sandbox_controller_test.go
+++ b/core/controllers/sandbox/internal/controller/sandbox_controller_test.go
@@ -506,6 +506,36 @@ func TestReconcile_Wave8RuntimeShape(t *testing.T) {
 		"name: KEYCLOAK_ADMIN_URL",
 		"name: KEYCLOAK_PARENT_REALM",
 		"name: KEYCLOAK_ADMIN_TOKEN",
+		// TBD-V21 #2032 regression — the 4 residual env vars PR #1987
+		// did not ship. SANDBOX_TOKEN unblocks the MCP's marketplace.*
+		// tool family (bearer for every proxy call). SANDBOX_JWT_SECRET
+		// exits the MCP's auth gate test-mode so bearer claims are
+		// actually validated. SANDBOX_REPOS scopes gitea.repos.list to
+		// the per-Sandbox subset instead of the un-filtered org repo
+		// list. (SANDBOX_KUBECONFIG stays unemitted — empty is the
+		// canonical in-cluster value, per MCP env.go:78.)
+		"name: SANDBOX_TOKEN",
+		"name: SANDBOX_JWT_SECRET",
+		"name: SANDBOX_REPOS",
+		// SANDBOX_TOKEN MUST source from the per-Sandbox Secret's
+		// LLM_GATEWAY_TOKEN key — same source as the existing
+		// LLM_GATEWAY_TOKEN env mount (single source of truth, zero
+		// Secret-write changes per Principle #4). Note: the renderer
+		// emits the key as a bare YAML scalar (no quotes); the same
+		// shape as the pre-existing LLM_GATEWAY_TOKEN mount.
+		"key: LLM_GATEWAY_TOKEN",
+		// SANDBOX_JWT_SECRET MUST source from
+		// `newapi-bp-newapi-token-signing-key` Secret's SIGNING_KEY key
+		// (chart default; reflected into per-Sandbox namespaces via
+		// bp-newapi 1.4.31 reflectorNamespaces extension to include
+		// `sandbox-.*`).
+		`name: "newapi-bp-newapi-token-signing-key"`,
+		`key: "SIGNING_KEY"`,
+		// SANDBOX_REPOS MUST be the comma-joined sb.Spec.Repos[].
+		// giteaRepo list (sampleSandbox has acme/eventforge +
+		// acme/internal-tools; renderer sorts stable, so the CSV is
+		// the sorted concatenation).
+		`value: "acme/eventforge,acme/internal-tools"`,
 		// Values plumbed from the controller's chart-level env.
 		"http://gitea-http.gitea.svc.cluster.local:3000",
 		"http://domain.sme.svc.cluster.local:8086",

--- a/core/controllers/sandbox/internal/gitops/manifests.go
+++ b/core/controllers/sandbox/internal/gitops/manifests.go
@@ -123,6 +123,24 @@ type Inputs struct {
 	KeycloakParentRealm       string
 	KeycloakAdminTokenSecret  string
 	KeycloakAdminTokenSecretKey string
+
+	// TBD-V21 — SANDBOX_JWT_SECRET wiring. Defaults below pick the
+	// canonical bp-newapi-emitted Secret + key (Render fills the defaults
+	// when caller passes empty). Mounted with `optional: true` on the MCP
+	// Pod so a Sovereign mid-reflector-rollout doesn't crash-loop the
+	// MCP. SIGNING_KEY material is reflected into every per-Sandbox
+	// namespace via the bp-newapi chart's
+	// `sandboxTokenSigningKey.reflectorNamespaces` default
+	// (`catalyst-system,sandbox,sandbox-.*` regex).
+	JWTSigningKeySecretName string
+	JWTSigningKeySecretKey  string
+
+	// TBD-V21 — SANDBOX_REPOS rendered into the MCP env as a comma-joined
+	// list of `<org>/<repo>` slugs from sb.Spec.Repos. Empty list emits
+	// an empty value (the MCP's CSV-parse contract treats empty as "no
+	// repo filter"). Populated by Render() from in.Repos so callers do
+	// not need to compute this themselves.
+	SandboxRepos string
 }
 
 const namespaceTemplate = `apiVersion: v1
@@ -335,17 +353,25 @@ spec:
               value: {{ .NewapiURL | quote }}
             - name: LLM_GATEWAY_URL
               value: {{ .NewapiURL | quote }}
+            # TBD-V21 — key case alignment with newapiTokenSecretTemplate
+            # (line 270 stringData: LLM_GATEWAY_TOKEN). Pre-fix the key
+            # ref was lowercase 'llm-gateway-token' while the Secret writes
+            # uppercase 'LLM_GATEWAY_TOKEN'. With 'optional: true' the
+            # mismatch silently no-opped to an empty value -- every agent
+            # CLI spawned in the pty-server shell ran without an LLM
+            # bearer (LLM_GATEWAY_TOKEN inherited via os.Environ lands
+            # empty), defeating the newapi-proxy gating contract.
             - name: LLM_GATEWAY_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .LLMGatewayTokenSecret | quote }}
-                  key: llm-gateway-token
+                  key: LLM_GATEWAY_TOKEN
                   optional: true
             - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ .LLMGatewayTokenSecret | quote }}
-                  key: llm-gateway-token
+                  key: LLM_GATEWAY_TOKEN
                   optional: true
 {{- if .ClaudeCodeBYOSActive }}
             - name: ANTHROPIC_API_KEY
@@ -523,8 +549,55 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .LLMGatewayTokenSecret | quote }}
-                  key: llm-gateway-token
+                  key: LLM_GATEWAY_TOKEN
                   optional: true
+            # TBD-V21 P1 — SANDBOX_TOKEN is the bearer the MCP plugin's
+            # marketplace.* tool family expects (products/sandbox/mcp-
+            # server/internal/tools/marketplace.go:95 requireMarketplaceProxy).
+            # The same per-Sandbox JWT lives in the per-Sandbox Secret under
+            # key LLM_GATEWAY_TOKEN (newapiTokenSecretTemplate, line 270).
+            # Mounting it under a SECOND env name is the cheapest single-
+            # source-of-truth wiring (Principle #4 — no Secret writes from
+            # the controller). optional: true so the per-Sandbox Secret can
+            # be absent on a Sovereign mid-bridge-rollout without crash-
+            # looping the MCP Pod (the MCP surfaces a clean "not configured"
+            # error from the affected tool family).
+            - name: SANDBOX_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .LLMGatewayTokenSecret | quote }}
+                  key: LLM_GATEWAY_TOKEN
+                  optional: true
+            # TBD-V21 P1 — SANDBOX_JWT_SECRET is the HS256 signing key the
+            # MCP plugin's registry uses to validate every bearer claim
+            # (registry.go:71 -- empty AND SANDBOX_ORG_ID also empty triggers
+            # test-dev mode, but since #1987 SANDBOX_ORG_ID is now always
+            # set; without SANDBOX_JWT_SECRET the auth gate degrades to
+            # silently passing every call through unvalidated). Key material
+            # lives in 'newapi-bp-newapi-token-signing-key' Secret (auto-
+            # provisioned by platform/newapi/chart/templates/sandbox-token-
+            # signing-key-secret.yaml) and is mirrored into per-Sandbox
+            # namespaces via emberstack/reflector -- the chart's
+            # 'sandboxTokenSigningKey.reflectorNamespaces' default was
+            # extended to 'catalyst-system,sandbox,sandbox-.*' so every
+            # per-Sandbox namespace receives a reflected copy. optional:
+            # true preserves the MCP's behaviour on Sovereigns mid-reflector-
+            # rollout (the MCP detects empty + nonempty SANDBOX_ORG_ID and
+            # surfaces a clear "not configured" error rather than test-
+            # mode).
+            - name: SANDBOX_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .JWTSigningKeySecretName | quote }}
+                  key: {{ .JWTSigningKeySecretKey | quote }}
+                  optional: true
+            # TBD-V21 P3 — SANDBOX_REPOS scopes the MCP plugin's gitea.repos.
+            # list handler (env.go:98-106). Without it the handler returns
+            # the un-filtered org repo list -- functional but over-discloses.
+            # Comma-joined sb.Spec.Repos[].giteaRepo matches the env.go
+            # CSV-parse contract.
+            - name: SANDBOX_REPOS
+              value: {{ .SandboxRepos | quote }}
             # ── D31 active-hot-standby — Sovereign-level toggle + region
             # pair. When SOVEREIGN_ENABLE_HOT_STANDBY parses truthy AND
             # both region values are non-empty AND distinct, sandbox.db.
@@ -647,6 +720,15 @@ const (
 	defaultBYOSSecretPrefix      = "sandbox-byos-claude-code"
 	defaultIdleTimeoutMinutes    = 30
 	defaultConcurrentSessions    = 1
+
+	// TBD-V21 — defaults for SANDBOX_JWT_SECRET wiring. The bp-newapi
+	// chart auto-provisions the `newapi-bp-newapi-token-signing-key`
+	// Secret carrying SIGNING_KEY and reflects it into every per-Sandbox
+	// namespace (sandbox-.* regex pattern in reflectorNamespaces, default
+	// since this PR). Operator override flows through chart values to the
+	// controller env then into Inputs.
+	defaultJWTSigningKeySecretName = "newapi-bp-newapi-token-signing-key"
+	defaultJWTSigningKeySecretKey  = "SIGNING_KEY"
 )
 
 // Render returns (path, bytes) tuples the reconciler writes into the
@@ -683,6 +765,16 @@ func Render(in Inputs) (map[string][]byte, error) {
 	if in.IdleTimeoutMinutes <= 0 {
 		in.IdleTimeoutMinutes = defaultIdleTimeoutMinutes
 	}
+	// TBD-V21 — JWTSigningKey defaults pick the canonical bp-newapi
+	// Secret + key when caller passes empty. The chart-level override
+	// flows through the controller env into Inputs; explicit empty falls
+	// back here.
+	if strings.TrimSpace(in.JWTSigningKeySecretName) == "" {
+		in.JWTSigningKeySecretName = defaultJWTSigningKeySecretName
+	}
+	if strings.TrimSpace(in.JWTSigningKeySecretKey) == "" {
+		in.JWTSigningKeySecretKey = defaultJWTSigningKeySecretKey
+	}
 
 	ns := fmt.Sprintf("sandbox-%s", in.OwnerUID)
 
@@ -691,6 +783,18 @@ func Render(in Inputs) (map[string][]byte, error) {
 	sort.SliceStable(repos, func(i, j int) bool {
 		return repos[i].GiteaRepo < repos[j].GiteaRepo
 	})
+
+	// TBD-V21 — SANDBOX_REPOS env value: comma-joined list of giteaRepo
+	// slugs from sb.Spec.Repos (stable sort order via `repos`). MCP's
+	// env.go:98-106 splits on comma + trims whitespace, so we emit a
+	// canonical CSV that round-trips through the consumer parse.
+	repoSlugs := make([]string, 0, len(repos))
+	for _, r := range repos {
+		if s := strings.TrimSpace(r.GiteaRepo); s != "" {
+			repoSlugs = append(repoSlugs, s)
+		}
+	}
+	in.SandboxRepos = strings.Join(repoSlugs, ",")
 
 	type baseCtx struct {
 		Inputs

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-6-llm-serving
 spec:
-  version: 1.4.30
+  version: 1.4.31
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -310,6 +310,20 @@ name: bp-newapi
 # blueprint's NS); the prior rule could never reach them and the
 # newapi container looped 1/2 Ready with DB-connect timeouts on
 # fresh prov.
+# 1.4.31 (TBD-V21 #2032, 2026-05-20): extend
+# `sandboxTokenSigningKey.reflectorNamespaces` default from
+# `catalyst-system,sandbox` to
+# `catalyst-system,sandbox,sandbox-.*` so emberstack/reflector mirrors
+# the `newapi-bp-newapi-token-signing-key` Secret into every per-Sandbox
+# namespace (`sandbox-<owner-uid>`). The per-Sandbox MCP Deployment
+# template (core/controllers/sandbox/internal/gitops/manifests.go) mounts
+# `SIGNING_KEY` as env `SANDBOX_JWT_SECRET` with `optional: true`;
+# without the regex pattern the mount silently no-ops and the MCP
+# plugin's auth gate degrades to test-mode (registry.go:71) — every
+# bearer claim passes unvalidated. Empberstack's
+# `reflection-{allowed,auto}-namespaces` annotation supports regex
+# entries per comma-separated value (kubernetes-reflector#162).
+#
 # 1.4.29 (TBD-A52 #1944, 2026-05-19): point the default Valkey URL at
 # `valkey-primary.valkey.svc.cluster.local` instead of the non-existent
 # `valkey.valkey.svc.cluster.local`. The bp-valkey blueprint installs
@@ -321,7 +335,7 @@ name: bp-newapi
 # `lookup valkey.valkey.svc.cluster.local: no such host`). Same hostname
 # already documented as canonical in products/catalyst/chart/values.yaml
 # bp-cnpg-pair comments.
-version: 1.4.30
+version: 1.4.31
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/sandbox-token-signing-key-secret.yaml
+++ b/platform/newapi/chart/templates/sandbox-token-signing-key-secret.yaml
@@ -75,9 +75,9 @@ metadata:
     # additional sister controllers need the same admin bearer) by
     # appending to .Values.sandboxTokenSigningKey.reflectorNamespaces.
     reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: {{ .Values.sandboxTokenSigningKey.reflectorNamespaces | default "catalyst-system,sandbox" | quote }}
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: {{ .Values.sandboxTokenSigningKey.reflectorNamespaces | default "catalyst-system,sandbox,sandbox-.*" | quote }}
     reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: {{ .Values.sandboxTokenSigningKey.reflectorNamespaces | default "catalyst-system,sandbox" | quote }}
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: {{ .Values.sandboxTokenSigningKey.reflectorNamespaces | default "catalyst-system,sandbox,sandbox-.*" | quote }}
 type: Opaque
 data:
   SIGNING_KEY: {{ $signingKey | b64enc | quote }}

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -301,17 +301,28 @@ sandboxTokenSigningKey:
   # from release name (`<release>-token-signing-key`).
   autoSecretName: ""
   # Comma-separated list of namespaces emberstack/reflector should
-  # mirror this Secret into. Defaults to "catalyst-system,sandbox" —
+  # mirror this Secret into. Defaults to
+  # `catalyst-system,sandbox,sandbox-.*` —
   # `catalyst-system` is the canonical install namespace of the bp-
   # sandbox HelmRelease (clusters/_template/bootstrap-kit/19a-bp-
   # sandbox.yaml `targetNamespace: catalyst-system`). `sandbox` is
   # included for legacy overlays that still install into a dedicated
   # `sandbox` namespace + for any sister tooling (catalyst-api PATs
   # routed through the bridge) that wants the admin bearer locally.
+  # `sandbox-.*` is an emberstack/reflector regex pattern (issue
+  # emberstack/kubernetes-reflector#162 — comma-separated values are
+  # interpreted as regexes) so the SIGNING_KEY is mirrored into every
+  # per-Sandbox namespace `sandbox-<owner-uid>`. The per-Sandbox MCP
+  # Deployment template (core/controllers/sandbox/internal/gitops/
+  # manifests.go) mounts `SIGNING_KEY` as env `SANDBOX_JWT_SECRET` with
+  # `optional: true`; without the regex pattern that mount silently
+  # no-ops to empty and the MCP plugin's auth gate degrades to test-
+  # mode (registry.go:71) — every bearer claim passes unvalidated.
+  # TBD-V21 issue #2032.
   #
   # Per-Sovereign overlays may extend with additional commas (e.g.
-  # `catalyst-system,sandbox,catalyst-controlplane`) when other
-  # controllers need ADMIN_SECRET for their own bridge calls.
+  # `catalyst-system,sandbox,sandbox-.*,catalyst-controlplane`) when
+  # other controllers need ADMIN_SECRET / SIGNING_KEY locally.
   #
   # IMPORTANT — this MUST contain the namespace the sandbox-controller
   # Deployment runs in. The chart in platform/sandbox/chart/templates/
@@ -321,7 +332,7 @@ sandboxTokenSigningKey:
   # controller starts in gitops-only mode and never mints tokens
   # (silently degraded — operator-visible only via the controller's
   # startup log line).
-  reflectorNamespaces: "catalyst-system,sandbox"
+  reflectorNamespaces: "catalyst-system,sandbox,sandbox-.*"
 # ─── Auth: ops-staff admin UI ────────────────────────────────────────────
 # The admin UI at admin.<host> is gated by the operator's IdP. Default
 # mode is `keycloak` (OIDC against bp-keycloak). `masterKey` is allowed

--- a/platform/sandbox/chart/Chart.yaml
+++ b/platform/sandbox/chart/Chart.yaml
@@ -24,6 +24,27 @@ annotations:
   # (see issue #181 + docs/BLUEPRINT-AUTHORING.md §11.1).
   catalyst.openova.io/no-upstream: "true"
   catalyst.openova.io/smoke-render-mode: "default-off"
+# 0.3.2 (TBD-V21 #2032, 2026-05-20): ship the 4 remaining MCP env-var
+# residuals not covered by PR #1987 — manifests.go now emits
+# `SANDBOX_TOKEN` (mounted from the per-Sandbox Secret's
+# `LLM_GATEWAY_TOKEN` key; same source as the existing `LLM_GATEWAY_TOKEN`
+# mount), `SANDBOX_JWT_SECRET` (mounted from the reflected
+# `newapi-bp-newapi-token-signing-key` Secret's `SIGNING_KEY` key; paired
+# with bp-newapi 1.4.31 extending `reflectorNamespaces` to include the
+# `sandbox-.*` regex pattern), and `SANDBOX_REPOS` (CSV of
+# `sb.Spec.Repos[].giteaRepo` slugs). Also fixes a pre-existing
+# case-mismatch bug at the MCP + pty-server `LLM_GATEWAY_TOKEN`/
+# `OPENAI_API_KEY` secretKeyRef — the key ref was lowercase
+# `llm-gateway-token` while the Secret writes uppercase
+# `LLM_GATEWAY_TOKEN`. `optional: true` on the mount silently no-opped
+# the mismatch to an empty value → every agent CLI spawned in the pty-
+# server shell ran without an LLM bearer, and every `marketplace.*`
+# tool call on the MCP returned "SANDBOX_TOKEN not set". `Inputs`
+# struct gains `JWTSigningKeySecretName` / `JWTSigningKeySecretKey` /
+# `SandboxRepos` fields; `Render()` populates `SandboxRepos` from
+# `in.Repos` and defaults the JWT Secret coordinates to
+# `newapi-bp-newapi-token-signing-key` + `SIGNING_KEY`.
+#
 # 0.3.1 (TBD-V14, issue #2015, 2026-05-20): default
 # `env.newapiBaseURL` was `http://newapi.newapi.svc.cluster.local:3000`,
 # but the canonical bp-newapi ClusterIP Service is named via
@@ -37,8 +58,8 @@ annotations:
 # `helm template newapi platform/newapi/chart/ -s templates/service.yaml`
 # → metadata.name: newapi-bp-newapi. Walker on t38 (chart 1.4.216,
 # substrate be4f78bc872e2c56) caught the live regression.
-version: 0.3.1
-appVersion: "0.3.1"
+version: 0.3.2
+appVersion: "0.3.2"
 keywords:
   - catalyst
   - sandbox


### PR DESCRIPTION
## Summary

Ships the 4 residual MCP env-var residuals PR #1987 did not cover (per the Pillar-4 audit `/tmp/audit-pillar4-deep-wiring-2026-05-20.md` finding D1, tracked in TBD-V21 #2032), plus a pre-existing case-mismatch bug at the LLM_GATEWAY_TOKEN secretKeyRef.

### Env vars added (consumer side — `products/sandbox/mcp-server/internal/tools/env.go`)

| Env var | Source | Severity unblocked |
|---|---|---|
| `SANDBOX_TOKEN` | per-Sandbox Secret `sandbox-tokens`, key `LLM_GATEWAY_TOKEN` (same source as the pre-existing `LLM_GATEWAY_TOKEN` env mount) | **P1** — `marketplace.*` MCP tools were returning "SANDBOX_TOKEN not set"; this unblocks Pillar-4 Phase-2 step 2d |
| `SANDBOX_JWT_SECRET` | `newapi-bp-newapi-token-signing-key` Secret, key `SIGNING_KEY` (chart-mirrored into per-Sandbox namespaces via bp-newapi 1.4.31 `reflectorNamespaces` extension to `sandbox-.*`) | **P1** — MCP auth gate was silently in test-dev mode; bearer claims unvalidated |
| `SANDBOX_REPOS` | comma-joined `sb.Spec.Repos[].giteaRepo` | **P3** — `gitea.repos.list` was returning un-filtered org repo list |
| `SANDBOX_KUBECONFIG` | **NOT emitted** (empty = canonical in-cluster value) | **P4** — no-op |

### Pre-existing bug also fixed

`secretKeyRef.key` was lowercase `llm-gateway-token` while per-Sandbox Secret writes uppercase `LLM_GATEWAY_TOKEN`. With `optional: true` mismatch silently no-opped. Three refs fixed: MCP line 526; pty-server lines 342, 348.

### Chart bumps (Principle #14 lockstep)

- `bp-newapi` 1.4.30 → **1.4.31** (extend `reflectorNamespaces` to include `sandbox-.*`)
- `bp-sandbox` 0.3.1 → **0.3.2** (manifests.go emits 3 new env vars + LLM_GATEWAY_TOKEN key case fix)
- Bootstrap-kit pins updated lockstep

## Test plan

- [x] `go test ./sandbox/... -count=1` — ALL PASS (extended regression test asserts new env vars + LLM_GATEWAY_TOKEN key case + canonical JWT secret ref)
- [x] `helm dependency update && helm template platform/newapi/chart` — rendered Secret carries `reflection-{allowed,auto}-namespaces: "catalyst-system,sandbox,sandbox-.*"`
- [x] `helm template platform/sandbox/chart` renders cleanly
- [x] Did NOT use `--dry-run=server` (Principle #15)
- [ ] **Pending fresh-prov walk** (DoD per CLAUDE.md anti-theater discipline; issue stays OPEN with Refs, not Closes):
  - `kubectl exec -n sandbox-<owner-uid> deploy/openova-sandbox-mcp env | grep -E '^SANDBOX_(TOKEN|REPOS|JWT_SECRET)='` returns 3 non-empty values
  - A `marketplace.*` MCP tool/call no longer returns "SANDBOX_TOKEN not set"
  - MCP auth gate fires (no-bearer call returns 401)
  - `kubectl get secret -n sandbox-<owner-uid> newapi-bp-newapi-token-signing-key` shows reflected copy

## What is NOT in scope

- pty-server bare `ORG_ID`/`SOVEREIGN_FQDN` names retained per audit critical-context (user-shell-inherited agent contract)
- No Secret writes from controller (Principle #4); all new env vars are `secretKeyRef` with `optional: true`

Refs #2032
Refs #1986