### PR TITLE
feat(marketplace-ui): render configSchema fields on AppDetail (Pillar 1 step 2 unblock) (Refs #2026)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -794,7 +794,22 @@ spec:
       # (StepSuccess.tsx + StepSuccess.test.tsx 3 assertions); no
       # API / wire / chart-template changes; image SHAs unchanged
       # from 1.4.220.
-      version: 1.4.221
+      # 1.4.222 — TBD-V18 / #2026 (2026-05-20): marketplace AppDetail
+      # now renders the per-instance configSchema (replicas / disk /
+      # backup for Postgres-backed bundles, replicas / persistence for
+      # Redis, etc.). Pre-fix Pillar 1 step 2 of the CLAUDE.md §0
+      # deterministic walk failed: the catalog Go store carries
+      # `ConfigSchema []ConfigField` and serialises it as
+      # `config_schema` over the wire, but the marketplace TS App
+      # interface in `core/marketplace/src/lib/api.ts` dropped the
+      # field, so AppDetail.svelte had no tunables section. Fix adds
+      # the `configSchema` interface field + the rendering section
+      # (one widget per ConfigField.type) + a new playwright `03b`
+      # regression. Surfaces-only fix — only the catalyst-ui image
+      # SHA changes (bp-catalyst-platform embeds the built marketplace
+      # assets via that image). Threading customer-chosen values into
+      # the install POST is a follow-up (TBD-V18-D).
+      version: 1.4.222
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/marketplace/playwright/customer-journey.spec.ts
+++ b/core/marketplace/playwright/customer-journey.spec.ts
@@ -84,7 +84,18 @@ async function installMocks(page: Page): Promise<MockState> {
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify([
-        { id: '1', name: 'WordPress', slug: 'wordpress', tagline: 'Website & blog platform', description: 'Create blogs, websites, and online stores.', category: 'cms', icon: 'W', color: '#21759b', free: true, popular: true, features: [], website: 'https://wordpress.org', license: 'GPL-2.0', system: false, kind: 'business', deployable: true, dependencies: [] },
+        { id: '1', name: 'WordPress', slug: 'wordpress', tagline: 'Website & blog platform', description: 'Create blogs, websites, and online stores.', category: 'cms', icon: 'W', color: '#21759b', free: true, popular: true, features: [], website: 'https://wordpress.org', license: 'GPL-2.0', system: false, kind: 'business', deployable: true, dependencies: [],
+          // TBD-V18 (#2026) — mirror the catalog's wire-shape so the
+          // marketplace can render per-instance tunables on the
+          // canonical Postgres-backed bundle. Field set matches the
+          // `replicasField` / `diskField` / `backupField` ConfigField
+          // triplet from core/services/catalog/handlers/seed.go.
+          config_schema: [
+            { key: 'replicas', label: 'Replicas', type: 'int', default: 1, min: 1, max: 5, description: 'Number of database instances in the cluster.', advanced: false },
+            { key: 'disk_gb', label: 'Storage (GB)', type: 'int', default: 5, min: 1, max: 500, description: 'Persistent volume size per replica.', advanced: false },
+            { key: 'backups_enabled', label: 'Daily backups', type: 'bool', default: false, description: 'Enable daily backups to object storage.', advanced: true },
+          ],
+        },
         { id: '2', name: 'Ghost', slug: 'ghost', tagline: 'Professional publishing', description: 'Modern publishing platform for blogs and newsletters.', category: 'cms', icon: 'G', color: '#15171A', free: true, features: [], website: 'https://ghost.org', license: 'MIT', system: false, kind: 'business', deployable: true, dependencies: [] },
         { id: '3', name: 'Nextcloud', slug: 'nextcloud', tagline: 'File sync & share', description: 'Store, share, and collaborate on files.', category: 'productivity', icon: 'N', color: '#0082c9', free: true, popular: true, features: [], website: 'https://nextcloud.com', license: 'AGPL-3.0', system: false, kind: 'business', deployable: true, dependencies: [] },
         { id: '4', name: 'Twenty CRM', slug: 'twenty', tagline: 'Open-source CRM', description: 'Customer relationship management.', category: 'crm', icon: 'T', color: '#000000', free: true, features: [], website: 'https://twenty.com', license: 'AGPL-3.0', system: false, kind: 'business', deployable: true, dependencies: [] },
@@ -314,6 +325,25 @@ test.describe('marketplace customer-journey (17-step regression gate)', () => {
     await page.goto('/app?slug=wordpress')
     // AppDetail hero renders the app name as <h1>.
     await expect(page.getByRole('heading', { name: /WordPress/i })).toBeVisible({ timeout: 10_000 })
+  })
+
+  // TBD-V18 (#2026) — Pillar 1 step 2 of the CLAUDE.md §0 deterministic
+  // walk: clicking the canonical Postgres-backed bundle must render
+  // its configSchema (replicas / disk / backup). Surface regressions
+  // here before they reach a fresh prov.
+  test('03b product detail renders configSchema (replicas/disk/backup)', async ({ page }) => {
+    await page.goto('/app?slug=wordpress')
+    const section = page.locator('[data-testid="config-schema-section"]')
+    await expect(section).toBeVisible({ timeout: 10_000 })
+    // Each of the 3 catalog-declared fields must render one input.
+    await expect(section.locator('[data-config-key="replicas"]')).toBeVisible()
+    await expect(section.locator('[data-config-key="disk_gb"]')).toBeVisible()
+    await expect(section.locator('[data-config-key="backups_enabled"]')).toBeVisible()
+    // Defaults arrive seeded from the catalog wire shape.
+    await expect(section.locator('#cfg-replicas')).toHaveValue('1')
+    await expect(section.locator('#cfg-disk_gb')).toHaveValue('5')
+    // 'advanced' field carries the badge.
+    await expect(section.locator('[data-config-key="backups_enabled"] .config-badge')).toHaveText(/advanced/i)
   })
 
   test('04 voucher input visible', async ({ page }) => {

--- a/core/marketplace/src/components/AppDetail.svelte
+++ b/core/marketplace/src/components/AppDetail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getApps, type App } from '../lib/api';
+  import { getApps, type App, type ConfigField } from '../lib/api';
   import { readCart, toggleApp, toggleAgent, SANDBOX_AGENTS } from '../lib/cart';
 
   interface Props {
@@ -12,10 +12,24 @@
   let dependencyApps = $state<App[]>([]);
   let loading = $state(true);
   let cart = $state(readCart());
+  // TBD-V18 (#2026) — local form state for the per-instance tunables
+  // declared on app.configSchema. Initialised from each field's
+  // `default` so the rendered form is always populated for the
+  // canonical Postgres-backed bundle (replicas=1, disk_gb=5,
+  // backups_enabled=false). Threading these into the install POST is
+  // a follow-up — for now this proves the schema renders end-to-end.
+  let configValues = $state<Record<string, number | string | boolean>>({});
 
   const inCart = $derived(app ? cart.apps.includes(app.id) : false);
   const isService = $derived(app ? (app.system === true || app.kind === 'service') : false);
   const comingSoon = $derived(app ? (app.deployable === false && !isService) : false);
+  // Schema fields render below the Description / Features sections so
+  // operators get the configuration surface immediately after the
+  // marketing context. Empty/missing schema = section is skipped (Postgres
+  // is a System app that ships ConfigSchema; per-Pillar-1-step-2 the
+  // bundle UI surfaces these tunables to the customer).
+  const configSchemaFields = $derived<ConfigField[]>(app?.configSchema ?? []);
+  const hasConfigSchema = $derived(configSchemaFields.length > 0);
   // Sandbox product — render the 6-agent pre-select grid below the
   // features section. Cards reuse the .related-card chrome verbatim
   // (design-system inheritance rule from Wave 4 brief: no bespoke
@@ -36,9 +50,40 @@
       dependencyApps = depSlugs
         .map(slug => apps.find(a => a.slug === slug))
         .filter((a): a is App => !!a);
+      // Seed configValues from per-field defaults. Falls back to a
+      // type-appropriate zero when `default` is missing so the form
+      // always has a coherent initial state.
+      const fields = app?.configSchema ?? [];
+      const seeded: Record<string, number | string | boolean> = {};
+      for (const f of fields) {
+        if (f.default !== undefined && f.default !== null) {
+          seeded[f.key] = f.default;
+        } else {
+          seeded[f.key] = f.type === 'int' ? 0 : f.type === 'bool' ? false : '';
+        }
+      }
+      configValues = seeded;
       loading = false;
     }).catch(() => { loading = false; });
   });
+
+  // Cast helpers — Svelte 5 + TS doesn't narrow $state<Record<string,...>>
+  // values to a single primitive when bound to <input>, so these helpers
+  // keep the binding strictly typed.
+  function numValue(key: string): number {
+    const v = configValues[key];
+    return typeof v === 'number' ? v : Number(v) || 0;
+  }
+  function strValue(key: string): string {
+    const v = configValues[key];
+    return typeof v === 'string' ? v : v == null ? '' : String(v);
+  }
+  function boolValue(key: string): boolean {
+    return configValues[key] === true;
+  }
+  function setValue(key: string, v: number | string | boolean): void {
+    configValues = { ...configValues, [key]: v };
+  }
 
   function toggle() {
     if (!app) return;
@@ -112,6 +157,77 @@
             <li>{feat}</li>
           {/each}
         </ul>
+      </section>
+    {/if}
+
+    <!-- Configuration schema — TBD-V18 (#2026). Renders per-instance
+         tunables declared by the catalog (replicas/disk/backup for a
+         Postgres-backed bundle, replicas/persistence for Redis, etc.).
+         Unblocks Pillar 1 step 2 of the deterministic CLAUDE.md §0
+         walk ("Click the canonical Postgres-backed bundle → app card
+         opens; configSchema renders"). One input widget per
+         ConfigField.type — matches the Go store.ConfigField contract
+         exactly. Threading these into the install POST is a follow-up
+         (TBD-V18-D). -->
+    {#if hasConfigSchema}
+      <section class="detail-section" data-testid="config-schema-section">
+        <h2>Configuration</h2>
+        <p class="detail-dependencies-hint">Tune the per-instance defaults. You can change these any time from the app's admin tab after install.</p>
+        <div class="config-grid" role="group" aria-label="App configuration">
+          {#each configSchemaFields as field}
+            <div class="config-field" data-config-key={field.key} data-config-type={field.type}>
+              <label for={`cfg-${field.key}`}>
+                <span class="config-label">{field.label}</span>
+                {#if field.advanced}
+                  <span class="config-badge">advanced</span>
+                {/if}
+              </label>
+              {#if field.type === 'int'}
+                <input
+                  id={`cfg-${field.key}`}
+                  class="config-input"
+                  type="number"
+                  min={field.min ?? undefined}
+                  max={field.max ?? undefined}
+                  value={numValue(field.key)}
+                  oninput={(e) => setValue(field.key, Number((e.currentTarget as HTMLInputElement).value))}
+                />
+              {:else if field.type === 'bool'}
+                <label class="config-toggle">
+                  <input
+                    id={`cfg-${field.key}`}
+                    type="checkbox"
+                    checked={boolValue(field.key)}
+                    oninput={(e) => setValue(field.key, (e.currentTarget as HTMLInputElement).checked)}
+                  />
+                  <span class="config-toggle-text">{boolValue(field.key) ? 'Enabled' : 'Disabled'}</span>
+                </label>
+              {:else if field.type === 'enum' && field.options}
+                <select
+                  id={`cfg-${field.key}`}
+                  class="config-input"
+                  value={strValue(field.key)}
+                  onchange={(e) => setValue(field.key, (e.currentTarget as HTMLSelectElement).value)}
+                >
+                  {#each field.options as opt}
+                    <option value={opt}>{opt}</option>
+                  {/each}
+                </select>
+              {:else}
+                <input
+                  id={`cfg-${field.key}`}
+                  class="config-input"
+                  type="text"
+                  value={strValue(field.key)}
+                  oninput={(e) => setValue(field.key, (e.currentTarget as HTMLInputElement).value)}
+                />
+              {/if}
+              {#if field.description}
+                <p class="config-desc">{field.description}</p>
+              {/if}
+            </div>
+          {/each}
+        </div>
       </section>
     {/if}
 
@@ -354,6 +470,74 @@
     border-radius: 50%;
     background: var(--color-success);
     flex-shrink: 0;
+  }
+
+  /* Configuration schema — TBD-V18 (#2026). Reuses existing tokens
+     (--color-surface, --color-border, --color-accent, --color-text*).
+     Two-column responsive grid mirrors .detail-features so this
+     surface inherits the marketplace's existing card aesthetic. */
+  .config-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 0.85rem;
+  }
+  .config-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .config-field label {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    color: var(--color-text-strong);
+    font-size: 0.82rem;
+    font-weight: 600;
+  }
+  .config-label { color: var(--color-text-strong); }
+  .config-badge {
+    background: color-mix(in srgb, var(--color-text-dim) 12%, transparent);
+    color: var(--color-text-dim);
+    border-radius: 4px;
+    padding: 0.1rem 0.4rem;
+    font-size: 0.66rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .config-input {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    color: var(--color-text);
+    font-size: 0.85rem;
+    font-family: inherit;
+    padding: 0.4rem 0.55rem;
+    width: 100%;
+  }
+  .config-input:focus {
+    outline: none;
+    border-color: var(--color-accent);
+  }
+  .config-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+    color: var(--color-text);
+    font-size: 0.85rem;
+  }
+  .config-toggle input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    accent-color: var(--color-accent);
+  }
+  .config-toggle-text { color: var(--color-text); }
+  .config-desc {
+    margin: 0;
+    color: var(--color-text-dim);
+    font-size: 0.74rem;
+    line-height: 1.45;
   }
 
   /* Related */

--- a/core/marketplace/src/lib/api.ts
+++ b/core/marketplace/src/lib/api.ts
@@ -137,6 +137,15 @@ export const getApps = async (): Promise<App[]> => {
     kind: (a.kind as 'business' | 'service') || (a.system ? 'service' : 'business'),
     shareable: a.shareable ?? false,
     deployable: a.deployable ?? false, // #102 — must carry through to template
+    // TBD-V18 (#2026) — surface ConfigSchema so AppDetail renders
+    // per-instance tunables (replicas/disk/backup for Postgres-backed
+    // bundles, etc.). Go store carries this as `config_schema` (per
+    // store.App.ConfigSchema bson tag); wire shape matches
+    // store.ConfigField exactly. Empty list when the catalog has no
+    // tunables for the app (omitempty on the Go side).
+    configSchema: Array.isArray(a.config_schema)
+      ? (a.config_schema as ConfigField[])
+      : [],
   }));
 };
 export const getIndustries = async (): Promise<Industry[]> => {
@@ -289,6 +298,32 @@ export interface Plan {
   popular?: boolean;
 }
 
+// ConfigField mirrors the Go `core/services/catalog/store/store.go`
+// `ConfigField` struct (line 91) one-for-one. The wire JSON tag for
+// each Go field is the lowercase form used here, e.g. Go's
+// `Default any` ⇄ TS `default?: number | string | boolean`. The
+// console renders one input widget per `type` —
+//   - "int"    → <input type="number">  (min/max bound)
+//   - "string" → <input type="text">
+//   - "bool"   → <input type="checkbox">
+//   - "enum"   → <select> populated from `options`
+//   - "size"   → <input type="text">    (e.g. "10Gi", parsed downstream)
+//
+// `advanced` fields collapse behind an "Advanced" toggle (UI iteration
+// follow-up; for now they render inline with an `advanced` badge so
+// nothing is hidden from the operator). See TBD-V18 (#2026).
+export interface ConfigField {
+  key: string;
+  label: string;
+  type: 'int' | 'string' | 'bool' | 'enum' | 'size';
+  default?: number | string | boolean;
+  min?: number;
+  max?: number;
+  options?: string[];
+  description?: string;
+  advanced?: boolean;
+}
+
 export interface App {
   id: string;
   name: string;
@@ -313,6 +348,12 @@ export interface App {
   // wired yet. Cards show a 'Coming soon' overlay, toggle is disabled.
   // See issue #102.
   deployable?: boolean;
+  // TBD-V18 (#2026) — per-instance tunables (replicas / disk / backup
+  // for Postgres-backed bundles, replicas / persistence for Redis,
+  // etc.). Empty array when the catalog has no tunables for this app.
+  // Threading the customer's chosen values into the install payload is
+  // a follow-up — see CartState extension TODO in cart.ts.
+  configSchema?: ConfigField[];
 }
 
 // GitHub org/user avatar URLs — reliable, CDN-backed, consistent sizing

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,41 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.222 — TBD-V18 / #2026 (2026-05-20): marketplace AppDetail now
+# renders the per-instance configSchema (replicas / disk / backup
+# for Postgres-backed bundles, replicas / persistence for Redis, etc.)
+# directly under Description / Features. Pre-fix Pillar 1 step 2 of
+# the CLAUDE.md §0 deterministic walk ("Click the canonical
+# Postgres-backed bundle → app card opens; configSchema renders")
+# failed: catalog Go store carries `ConfigSchema []ConfigField`
+# (store.go:55) and serialises it as `config_schema` over the wire,
+# but core/marketplace/src/lib/api.ts::getApps's mapper dropped the
+# field entirely → AppDetail.svelte had no per-instance tunables
+# section.
+#
+# Fix:
+#   - Add `configSchema` to the marketplace `App` interface +
+#     `ConfigField` shape mirroring `core/services/catalog/store/
+#     store.go::ConfigField` one-for-one (key/label/type/default/
+#     min/max/options/description/advanced).
+#   - getApps mapper reads `a.config_schema` (Go bson/json tag).
+#   - AppDetail.svelte renders one widget per ConfigField.type
+#     (int → numeric input with min/max bounds, bool → checkbox,
+#     enum → select, string/size → text input). 'advanced' fields
+#     carry a muted badge. Local form state is seeded from
+#     per-field defaults so the rendered surface is always
+#     populated for the canonical Postgres-backed bundle
+#     (replicas=1, disk_gb=5, backups_enabled=false).
+#   - Playwright customer-journey gets a new `03b` test asserting
+#     replicas/disk/backup render with seeded defaults so the
+#     regression surfaces locally before reaching a fresh prov.
+#
+# Threading customer-chosen values into the install POST is a
+# follow-up (TBD-V18-D) — this PR's scope is "configSchema
+# renders" only, per the issue body.
+#
+# Surfaces only — no API / wire / chart-template changes; only the
+# catalyst-ui image SHA carries the change (bp-catalyst-platform
+# embeds the built marketplace assets via the catalyst-ui image).
 # 1.4.221 — TBD-V20 / #2028 (2026-05-20): wizard StepSuccess "Issue
 # first voucher" CTA was pointing at the anti-canon
 # `https://admin.<fqdn>/billing/vouchers/new` URL. Per CLAUDE.md §0
@@ -2034,7 +2070,7 @@ name: bp-catalyst-platform
 # was already shipped on 1.4.197 (PR #1820 lineage); this completes
 # the data-layer side so the dropdown finally appears on multi-region
 # Sovereigns. Refs #1821, DoD D20.
-version: 1.4.221
+version: 1.4.222
 appVersion: 1.4.219
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,


### PR DESCRIPTION
## Summary

Marketplace AppDetail now renders the per-instance configSchema declared by the catalog (replicas / disk / backup for Postgres-backed bundles, replicas / persistence for Redis, etc.) directly under Description / Features. Unblocks **Pillar 1 step 2** of the CLAUDE.md §0 deterministic walk ("Click the canonical Postgres-backed bundle → app card opens; configSchema renders").

## Why this matters

Per the Pillar-1 BSS audit (`/tmp/audit-pillar1-bss-2026-05-20.md`) and TBD-V18 (#2026), the catalog Go store carries `ConfigSchema []ConfigField` (`core/services/catalog/store/store.go:55`) and serialises it as `config_schema` over the wire via the embedded `appResponse` (JSON omitempty tag). But `core/marketplace/src/lib/api.ts::getApps` mapper dropped the field entirely on the client side → AppDetail.svelte had no per-instance tunables section.

**Root cause: TS interface drift from the Go contract.** No backend change required — the wire already carries the field.

## What changed

- **`core/marketplace/src/lib/api.ts`** — add a `ConfigField` interface mirroring `store.ConfigField` one-for-one (`key`/`label`/`type`/`default`/`min`/`max`/`options`/`description`/`advanced`) + `configSchema?: ConfigField[]` on the `App` interface. `getApps` mapper now reads `a.config_schema` from the wire.
- **`core/marketplace/src/components/AppDetail.svelte`** — render one widget per `ConfigField.type`:
  - `int` → `<input type="number">` (bound by min/max)
  - `bool` → checkbox toggle
  - `enum` → `<select>` populated from `options`
  - `string` / `size` → `<input type="text">`
  - `advanced` fields carry a muted badge.
  Local form state seeded from per-field defaults so the rendered surface is always populated.
- **`core/marketplace/playwright/customer-journey.spec.ts`** — new `03b` regression test asserting `/app?slug=wordpress` renders the 3 declared fields (`replicas`/`disk_gb`/`backups_enabled`) with seeded defaults + 'advanced' badge.
- **`products/catalyst/chart/Chart.yaml`** + **`clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`** — chart version bumped 1.4.221 → 1.4.222 in lockstep (Inviolable Principle #14).

Threading customer-chosen values into the install POST is **out of scope** here — that's a follow-up (TBD-V18-D). Per the issue body, this PR's scope is "configSchema renders" only.

## Validation

- `npm run build` in `core/marketplace` — succeeds. AppDetail bundle grows 7.43 → 10.31 kB (configSchema + widgets).
- `helm template products/catalyst/chart` — renders clean.
- Did NOT use `kubectl --dry-run=server` (Inviolable Principle #15).

## Anti-theater reminder

PR body uses `Refs #2026`, **NOT** `Closes #2026`. Per CLAUDE.md §4: an operator must walk the surface on a fresh multi-region prov + attach a screenshot of the rendered configSchema form as a comment on #2026 itself before the issue can close. PR-merged + tests-green is insufficient.

## Test plan

- [x] `npm run build` green in `core/marketplace`
- [x] `helm template products/catalyst/chart` renders
- [ ] On fresh prov: navigate `marketplace.t<NN>.omani.works` → click the canonical Postgres-backed bundle → confirm Configuration section renders with 3 fields populated from defaults
- [ ] Screenshot attached to #2026 comment thread

Generated with Claude Code