### PR TITLE
fix(self-sovereign-cutover): strip mothership-side auths from ghcr-pull Secret on cutover (Refs #2034)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -349,7 +349,16 @@ spec:
       # overwrites with live count on /start) but UIs reading
       # `<currentIndex>/<totalSteps>` in the pre-trigger window
       # showed the wrong denominator. Single-literal swap.
-      version: 0.1.34
+      #
+      # 0.1.35 (TBD-V24 MISS-2, issue #2034, 2026-05-20): step-06
+      # Phase-0 now STRIPS mothership-side auth entries (ghcr.io,
+      # harbor.openova.io) from the `ghcr-pull` Secret AFTER merging
+      # the local Harbor entry — credential-hygiene close on the
+      # Pillar-5 Sovereign-independence claim per CLAUDE.md §3 #11.
+      # Strip list lives in .Values.harbor.mothershipAuthsToStrip;
+      # operates in the same jq pipeline as the add (single Secret
+      # resourceVersion bump per Phase-0 invocation). Idempotent.
+      version: 0.1.35
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 0.1.34
+  version: 0.1.35
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -117,7 +117,32 @@ name: bp-self-sovereign-cutover
 # denominator. Single-literal swap; contract test (asserts step_count
 # -eq 9) already gates against future drift. No code change required
 # in cutover.go — its post-start patch path was always correct.
-version: 0.1.34
+#
+# 0.1.35 (TBD-V24 MISS-2, issue #2034, 2026-05-20): step-06 Phase-0
+# now STRIPS mothership-side auth entries from the `ghcr-pull` Secret
+# AFTER merging the local Harbor entry — closing the credential-
+# hygiene gap flagged by TBD-V24 (Pillar-5 Sovereign-independence
+# claim). The strip list is driven by
+# `.Values.harbor.mothershipAuthsToStrip` (defaults: ghcr.io,
+# harbor.openova.io) and runs in the SAME jq pipeline as the add so
+# the Secret takes a single resourceVersion bump per Phase-0
+# invocation. Idempotency check extended: re-runs skip when BOTH the
+# local Harbor entry is in place AND every strip target is already
+# absent. The strip pipeline never touches the local harbor host
+# (defence-in-depth guard) even if an operator overlay erroneously
+# lists it. ORDERING: this fix lives in Phase-0 which executes
+# BEFORE Phase-1 URL rewrites, but AFTER step-04 (registries.yaml
+# v2) and AFTER any future TBD-V24 MISS-1 step that may pivot
+# vCluster image refs — there is no dependency on MISS-1 because
+# the strip operates on the Secret data plane, not on chart values.
+# Per CLAUDE.md §3 Principle #11 the post-cutover cluster MUST NOT
+# carry standing auth for any openova-io-rooted registry. Operator
+# walk on a fresh prov verifies `kubectl get secret ghcr-pull -n
+# flux-system -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d
+# | jq '.auths | keys'` returns ONLY `[harbor.<sov-fqdn>]`. Refs
+# #2034 (closes after operator-walk-with-screenshot per anti-theater
+# discipline).
+version: 0.1.35
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -99,6 +99,13 @@ data:
             value: {{ .Values.harbor.ghcrSecretRef.namespace | quote }}
           - name: GHCR_PULL_SECRET_KEY
             value: {{ .Values.harbor.ghcrSecretRef.dockerConfigKey | quote }}
+          # Phase-0 strip targets (TBD-V24 MISS-2, chart 0.1.35). Comma-
+          # separated list of mothership-side auth keys to REMOVE from
+          # `.dockerconfigjson` once the local Harbor entry is in place.
+          # See .Values.harbor.mothershipAuthsToStrip for the canonical
+          # source and rationale.
+          - name: MOTHERSHIP_AUTHS_TO_STRIP
+            value: {{ join "," .Values.harbor.mothershipAuthsToStrip | quote }}
           # Phase -1 gateway-wait inputs (issue #1871, chart 0.1.32).
           # The cutover URL rewrite (Phase 1 below) MUST NOT fire until
           # the Cilium Gateway in kube-system is Programmed=True; that
@@ -276,19 +283,113 @@ data:
 
             existing_json=$(printf '%s' "${existing_b64}" | base64 -d)
 
-            # Idempotency guard: if harbor.<sov-fqdn> already maps to an
-            # auth entry, no-op. Re-runs of step-06 (catalyst-api may
-            # retry) MUST NOT churn the Secret resourceVersion every
-            # time — that triggers a noisy reflector cascade.
+            # Idempotency guard: a re-run is a no-op when BOTH conditions
+            # hold simultaneously —
+            #   (a) harbor.<sov-fqdn> already maps to the expected auth
+            #   (b) every entry listed in MOTHERSHIP_AUTHS_TO_STRIP is
+            #       already absent from .auths
+            # Re-runs of step-06 (catalyst-api may retry) MUST NOT churn
+            # the Secret resourceVersion when there's nothing to do —
+            # that triggers a noisy reflector cascade.
             already=$(printf '%s' "${existing_json}" | jq -r --arg h "${harbor_host}" \
               '.auths[$h].auth // empty')
             harbor_auth=$(printf '%s:%s' "${HARBOR_USERNAME}" "${HARBOR_PASSWORD}" | base64 -w0)
-            if [ -n "${already}" ] && [ "${already}" = "${harbor_auth}" ]; then
-              echo "[helmrepository-patches] Phase-0 skip: ghcr-pull already carries auth for ${harbor_host}"
+
+            # Check whether any of the strip targets is still present.
+            # `MOTHERSHIP_AUTHS_TO_STRIP` is a comma-separated list rendered
+            # from .Values.harbor.mothershipAuthsToStrip — see the chart's
+            # values.yaml for the canonical hosts and rationale (TBD-V24
+            # MISS-2). Empty list → strip_remaining is empty → behaviour is
+            # identical to chart < 0.1.35.
+            strip_remaining=""
+            if [ -n "${MOTHERSHIP_AUTHS_TO_STRIP:-}" ]; then
+              # IFS-split on comma; iterate; collect hosts that still
+              # have an auth entry in existing_json.
+              old_ifs="$IFS"
+              IFS=','
+              for strip_host in ${MOTHERSHIP_AUTHS_TO_STRIP}; do
+                # Strip whitespace defensively (operator-edited overlays
+                # sometimes carry trailing spaces around commas).
+                strip_host=$(printf '%s' "${strip_host}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                [ -z "${strip_host}" ] && continue
+                # Skip the local harbor host even if an operator
+                # accidentally listed it — stripping the entry we just
+                # merged in would deadlock Phase 1.
+                if [ "${strip_host}" = "${harbor_host}" ]; then
+                  echo "[helmrepository-patches] Phase-0 WARN: refusing to strip ${strip_host} (matches local harbor host); check .Values.harbor.mothershipAuthsToStrip overlay"
+                  continue
+                fi
+                present=$(printf '%s' "${existing_json}" | jq -r --arg h "${strip_host}" \
+                  '.auths | has($h)')
+                if [ "${present}" = "true" ]; then
+                  strip_remaining="${strip_remaining}${strip_host} "
+                fi
+              done
+              IFS="$old_ifs"
+            fi
+
+            if [ -n "${already}" ] && [ "${already}" = "${harbor_auth}" ] && [ -z "${strip_remaining}" ]; then
+              echo "[helmrepository-patches] Phase-0 skip: ghcr-pull already carries auth for ${harbor_host} and mothership entries already stripped"
             else
-              new_json=$(printf '%s' "${existing_json}" | jq --arg h "${harbor_host}" \
-                --arg user "${HARBOR_USERNAME}" --arg auth "${harbor_auth}" \
-                '.auths[$h] = {"username":$user,"auth":$auth}')
+              # Single jq pipeline: ADD harbor.<sov-fqdn> auth AND
+              # DELETE every host in MOTHERSHIP_AUTHS_TO_STRIP. Both
+              # mutations happen in one pass so the Secret takes a
+              # single resourceVersion bump regardless of which side
+              # was stale. Per CLAUDE.md §3 Principle #11 the post-
+              # cutover cluster MUST NOT carry standing auth for any
+              # `openova-io`-rooted registry — leaving the ghcr.io or
+              # harbor.openova.io entries in place would let a
+              # regression silently re-authenticate against upstream
+              # (the credential-hygiene gap flagged by TBD-V24 MISS-2).
+              #
+              # `del(.auths[$h])` is idempotent — deleting a missing
+              # key is a no-op in jq, so re-runs after the initial
+              # strip just no-op the strip arms.
+              # Build the jq invocation as a single argv-shell-quoted
+              # string so we can use POSIX-sh `set --` semantics without
+              # bash-only arrays. Each entry in MOTHERSHIP_AUTHS_TO_STRIP
+              # contributes one `--arg s<N> <host>` pair + one
+              # ` | del(.auths[$s<N>])` filter stage.
+              #
+              # `--arg` ALWAYS treats its value as a string (no shell
+              # interpolation), so even a maliciously crafted host like
+              # `"; rm -rf /` would land verbatim as a JSON-string
+              # operand to `del()` — never executed.
+              jq_filter='.auths[$h] = {"username":$user,"auth":$auth}'
+              strip_idx=0
+              # Reset positional params so `set --` below builds a clean
+              # `--arg s<N> <host>` list. The Job's args[] passes only the
+              # script body to `sh -c`, so $@ is normally empty — this is
+              # belt-and-braces against future operator overlays adding
+              # extra args.
+              set --
+              if [ -n "${MOTHERSHIP_AUTHS_TO_STRIP:-}" ]; then
+                # POSIX-safe comma-iteration via parameter expansion.
+                rem="${MOTHERSHIP_AUTHS_TO_STRIP},"
+                while [ -n "${rem}" ] && [ "${rem}" != "," ]; do
+                  strip_host="${rem%%,*}"
+                  rem="${rem#*,}"
+                  strip_host=$(printf '%s' "${strip_host}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                  [ -z "${strip_host}" ] && continue
+                  # Defence-in-depth: never delete the local harbor
+                  # entry even if listed (matches the earlier idempotency
+                  # check that also skips it).
+                  if [ "${strip_host}" = "${harbor_host}" ]; then
+                    continue
+                  fi
+                  jq_filter="${jq_filter} | del(.auths[\$s${strip_idx}])"
+                  # Append `--arg s<N> <host>` to the positional params
+                  # so we can invoke jq with "$@" below.
+                  set -- "$@" --arg "s${strip_idx}" "${strip_host}"
+                  strip_idx=$((strip_idx+1))
+                done
+              fi
+              new_json=$(printf '%s' "${existing_json}" | jq \
+                --arg h "${harbor_host}" \
+                --arg user "${HARBOR_USERNAME}" \
+                --arg auth "${harbor_auth}" \
+                "$@" \
+                "${jq_filter}")
               new_b64=$(printf '%s' "${new_json}" | base64 -w0)
               # Merge-patch the data field. Quoting note: ${GHCR_PULL_SECRET_KEY}
               # is `.dockerconfigjson` which is a literal key (the leading

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -116,6 +116,23 @@ harbor:
     # Secrets of dockerconfigjson type carry their value under
     # `.dockerconfigjson`; step 02 parses it for username/password.
     dockerConfigKey: ".dockerconfigjson"
+  # Mothership-side auth entries to STRIP from `ghcr-pull` Secret's
+  # `.dockerconfigjson` during step-06 Phase-0 (TBD-V24 MISS-2, chart
+  # 0.1.35). Once cutover lands and harbor.<sov-fqdn> auth is merged
+  # in, the original ghcr.io + harbor.openova.io auth entries are no
+  # longer needed — Catalyst-authored images pull through the local
+  # Harbor proxy-cache via containerd registries.yaml v2 (step 04),
+  # not through Flux source-controller against upstream GHCR.
+  # Stripping enforces credential hygiene: post-cutover the cluster
+  # CANNOT silently fall back to mothership-side registries even
+  # under a regression. CLAUDE.md §3 Principle #11 ("Sovereigns must
+  # be independent of openova-io after handover") is the canonical
+  # source for the list — keep this list in lockstep with the 4
+  # tether URL families enumerated there. Idempotent: re-runs with
+  # entries already gone are no-ops. (Refs #2034)
+  mothershipAuthsToStrip:
+    - "ghcr.io"
+    - "harbor.openova.io"
   # Seven proxy-cache projects + their upstream registry endpoints.
   # Names are stable because step 06 (helmrepository-patches) +
   # registries.yaml v2 (registry-pivot) rewrite paths against these


### PR DESCRIPTION
## Summary

TBD-V24 MISS-2 — closes the credential-hygiene gap flagged by the Pillar-5 Sovereign-independence audit. Step-06 Phase-0 currently MERGES the local Harbor entry into `flux-system/ghcr-pull` but never STRIPS the original `ghcr.io` + `harbor.openova.io` entries seeded by cloud-init. This PR adds the strip side so the post-cutover cluster carries auth for ONLY the local Sovereign Harbor — per CLAUDE.md §3 Principle #11.

- **Strip list:** `.Values.harbor.mothershipAuthsToStrip` (defaults: `ghcr.io`, `harbor.openova.io`). Never-hardcoded per INVIOLABLE-PRINCIPLES #4.
- **Same-pipeline mutation:** add + del() in one jq invocation → single Secret resourceVersion bump per Phase-0 run.
- **Idempotency:** Phase-0 skips entirely when BOTH the local Harbor entry is in place AND every strip target is already absent.
- **Defence-in-depth:** strip loop refuses to delete the local harbor host even if listed.
- **POSIX-sh portable:** `set --` argv-array, no bash arrays.

## Test plan

- [x] `bash tests/cutover-contract.sh` — 20/20 gates green
- [x] Fixture script: 3-auth → 1-auth (only local harbor); idempotent re-run; del() of absent key no-op
- [x] `go test ./internal/handler/... -run Cutover` — pass
- [x] Overlay override via `--set harbor.mothershipAuthsToStrip={...}` picked up by env var
- [ ] **Operator walk on fresh prov (REQUIRED for TBD-V24 close):** `.auths | keys` returns ONLY `[harbor.<sov-fqdn>]`

## Chart version

- `Chart.yaml`: `0.1.34` → `0.1.35`
- `06a-bp-self-sovereign-cutover.yaml` pin bumped in lockstep

## Ordering note

No dependency on TBD-V24 MISS-1. The strip operates on the Secret data plane, not on per-chart values.

`Refs #2034`, NOT `Closes` — operator-walk-with-screenshot per CLAUDE.md §0 anti-theater discipline.

Refs #2034