### PR TITLE
fix(catalyst-api/kubeconfig): GET fallback to bare path when region == primary (Refs #1882)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -809,7 +809,7 @@ spec:
       # SHA changes (bp-catalyst-platform embeds the built marketplace
       # assets via that image). Threading customer-chosen values into
       # the install POST is a follow-up (TBD-V18-D).
-      version: 1.4.223
+      version: 1.4.224
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/handler/kubeconfig.go
+++ b/products/catalyst/bootstrap/api/internal/handler/kubeconfig.go
@@ -189,6 +189,27 @@ func (h *Handler) GetKubeconfig(w http.ResponseWriter, r *http.Request) {
 				h.log.Info("kubeconfig per-region resolved via slot-suffix glob",
 					"id", id, "region", region, "matchedPath", path, "candidates", len(matches),
 				)
+			} else if region == dep.Request.Region {
+				// Issue #1882: PutKubeconfig stores the primary at
+				// bare `<id>.yaml` (no region suffix) while secondaries
+				// land at `<id>-<region>.yaml` (or the slot-suffixed
+				// `<id>-<region>-<i>.yaml` from cloud-init/handover).
+				// When the operator queries `?region=<X>` where X is
+				// the primary's cloudRegion (mirrored from
+				// Regions[0].CloudRegion into Request.Region by
+				// Validate() at provisioner.go:511), neither the exact
+				// match nor the glob hits — but the primary kubeconfig
+				// DOES exist at bare `<id>.yaml`. Resolve to the
+				// primary path stamped on Result.KubeconfigPath rather
+				// than 409'ing on what is structurally a valid query.
+				dep.mu.Lock()
+				if dep.Result != nil && dep.Result.KubeconfigPath != "" {
+					path = dep.Result.KubeconfigPath
+				}
+				dep.mu.Unlock()
+				h.log.Info("kubeconfig per-region resolved via primary-region fallback to bare path",
+					"id", id, "region", region, "matchedPath", path,
+				)
 			}
 		}
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/kubeconfig_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/kubeconfig_test.go
@@ -1186,3 +1186,94 @@ func TestGetKubeconfig_PerRegion_SlotSuffixGlobFallback(t *testing.T) {
 		}
 	})
 }
+
+// Issue #1882 — GET /kubeconfig?region=<primary-cloudRegion> must
+// resolve to the primary kubeconfig stored at bare `<id>.yaml`.
+//
+// Before the fix the resolver only looked at:
+//
+//	1. <id>-<region>.yaml exact match
+//	2. <id>-<region>-*.yaml glob (cloud-init slot-suffix shape)
+//
+// Both miss the primary file, which PutKubeconfig writes at the bare
+// `<id>.yaml` path (kubeconfig.go:583-587). When the operator queried
+// the primary's cloudRegion (e.g. `?region=hel1` where the primary's
+// Regions[0].CloudRegion is "hel1") the handler 409'd even though the
+// primary kubeconfig DID exist on disk. The fix adds a third
+// resolution step: when `region == dep.Request.Region` AND neither
+// exact nor glob matched, fall through to the bare `<id>.yaml` path
+// stamped on Result.KubeconfigPath.
+//
+// This test asserts the new fallback resolves a primary-region query
+// to 200 with the bare-path file's body, exercising the exact
+// scenario the issue reported.
+func TestGetKubeconfig_PerRegion_PrimaryRegionResolvesViaBarePath(t *testing.T) {
+	kubeconfigsDir := t.TempDir()
+	deploymentsDir := t.TempDir()
+	st, _ := store.New(deploymentsDir)
+	h := NewWithStoreAndKubeconfigsDir(silentLogger(), &fakePDM{}, st, kubeconfigsDir)
+
+	id := "i1882-primary-region-fallback"
+	primaryRegion := "hel1"
+
+	// PutKubeconfig writes the primary at bare `<id>.yaml`. Replicate
+	// that here so the test exercises the exact on-disk shape the PUT
+	// path produces (kubeconfig.go:583 → filename = id + ".yaml").
+	primaryPath := filepath.Join(kubeconfigsDir, id+".yaml")
+	if err := os.WriteFile(primaryPath, []byte(validKubeconfigYAML), 0o600); err != nil {
+		t.Fatalf("write primary file: %v", err)
+	}
+
+	dep := &Deployment{
+		ID:        id,
+		Status:    "ready",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event, 256),
+		done:      make(chan struct{}),
+		Request: provisioner.Request{
+			SovereignFQDN: "test." + id + ".example",
+			// Request.Region mirrors Regions[0].CloudRegion per
+			// provisioner.Validate() (provisioner.go:511). The fix
+			// keys the bare-path fallback on this field.
+			Region: primaryRegion,
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN:  "test." + id + ".example",
+			KubeconfigPath: primaryPath,
+		},
+	}
+	h.deployments.Store(id, dep)
+
+	// GET with `?region=<primary-region>` must succeed via the bare-
+	// path fallback. Pre-fix this returned 409 kubeconfig-file-missing.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet,
+		"/api/v1/deployments/"+id+"/kubeconfig?region="+primaryRegion, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", id)
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+	h.GetKubeconfig(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "TEST-CA-MARKER") {
+		t.Errorf("served body missing TEST-CA-MARKER:\n%s", w.Body.String())
+	}
+
+	// Regression guard: a region that does NOT match the primary AND
+	// has no exact/glob match still 409s. The new fallback only fires
+	// when `region == dep.Request.Region`; an unknown region must NOT
+	// silently resolve to the primary's bare path (that would be a
+	// classic "wrong region returns primary by accident" bug).
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequest(http.MethodGet,
+		"/api/v1/deployments/"+id+"/kubeconfig?region=does-not-exist", nil)
+	rctx2 := chi.NewRouteContext()
+	rctx2.URLParams.Add("id", id)
+	r2 = r2.WithContext(context.WithValue(r2.Context(), chi.RouteCtxKey, rctx2))
+	h.GetKubeconfig(w2, r2)
+	if w2.Code != http.StatusConflict {
+		t.Fatalf("unknown-region status = %d, want 409; body=%s", w2.Code, w2.Body.String())
+	}
+}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2070,8 +2070,8 @@ name: bp-catalyst-platform
 # was already shipped on 1.4.197 (PR #1820 lineage); this completes
 # the data-layer side so the dropdown finally appears on multi-region
 # Sovereigns. Refs #1821, DoD D20.
-version: 1.4.223
-appVersion: 1.4.223
+version: 1.4.224
+appVersion: 1.4.224
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned


### PR DESCRIPTION
## Summary

Fixes #1882 — `GET /api/v1/deployments/{id}/kubeconfig?region=<primary-cloudRegion>` returned 409 even though the primary kubeconfig existed on disk.

## Root cause

`PutKubeconfig` writes the primary to bare `<id>.yaml` (no region suffix) at [`kubeconfig.go:583-587`](https://github.com/openova-io/openova/blob/main/products/catalyst/bootstrap/api/internal/handler/kubeconfig.go#L583-L587). Secondaries land at `<id>-<region>.yaml` (or the slot-suffix `<id>-<region>-<i>.yaml` from cloud-init / handover fan-out).

`GetKubeconfig`'s region resolver at `kubeconfig.go:170-194` only checked:

1. `<id>-<region>.yaml` exact match
2. `<id>-<region>-*.yaml` glob

Both miss the bare-path primary file. So a GET with `?region=hel1` (where `hel1` is the primary's cloudRegion mirrored from `Regions[0].CloudRegion`) returned 409 `kubeconfig-file-missing` despite the file being on disk.

## Fix

Add a third resolution step in `GetKubeconfig`: when exact + glob both miss AND `region == dep.Request.Region`, fall through to the bare-`<id>.yaml` path stamped on `Result.KubeconfigPath`.

Key correctness property: the fallback ONLY fires when the query region matches the primary's cloudRegion (`dep.Request.Region`). An unknown region still 409s — verified by a regression-guard sub-test.

## Code change

~12 LOC in `products/catalyst/bootstrap/api/internal/handler/kubeconfig.go` (new `else if region == dep.Request.Region` branch inside the existing `if region != ""` resolver block).

## Test plan

- [x] New test `TestGetKubeconfig_PerRegion_PrimaryRegionResolvesViaBarePath` — replicates the PUT path's bare-`<id>.yaml` shape, asserts `GET ?region=<primary>` returns 200 via the new fallback, asserts `?region=does-not-exist` still 409s.
- [x] Existing test `TestGetKubeconfig_PerRegion_SlotSuffixGlobFallback` still PASSES — secondary resolution unchanged (new branch only fires AFTER glob misses).
- [x] Full handler test suite GREEN — `go test ./internal/handler/... -count=1` → ok 67.379s
- [x] `helm template products/catalyst/chart` still renders (4148 lines) with chart 1.4.224.
- [ ] **Operator-walk verification on fresh prov** — primary-region GET must return the rewritten kubeconfig YAML. Awaiting TBD-V15 (#2020) substrate restore. Issue stays OPEN until the walk lands.

## Chart bump

- `products/catalyst/chart/Chart.yaml`: 1.4.223 → 1.4.224
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`: pin lockstep 1.4.223 → 1.4.224 (Principle #14)

## Notes

- Did NOT use `kubectl --dry-run=server` — chart change validated via fresh `helm template` (Principle #15).
- Scope strictly bounded to the GET resolver — PUT, DELETE, and LIST handlers untouched.
- `Refs #1882` (not `Closes`) — issue closes only after fresh-prov walk per anti-theater discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)