### PR TITLE
chore(canon): purge openova.io test-data string leaks (Refs #2025)

### DIFF
--- a/core/marketplace-api/handlers/handlers.go
+++ b/core/marketplace-api/handlers/handlers.go
@@ -459,7 +459,7 @@ func (h *Handler) AddDomain(w http.ResponseWriter, r *http.Request, tenantID str
 	h.writeJSON(w, http.StatusAccepted, map[string]string{
 		"status": "configuring",
 		"domain": req.Domain,
-		"cname":  tenant.Subdomain + ".openova.cloud",
+		"cname":  tenant.Subdomain + ".omani.homes",
 	})
 }
 

--- a/core/marketplace-api/handlers/provisioner.go
+++ b/core/marketplace-api/handlers/provisioner.go
@@ -53,7 +53,7 @@ func (h *Handler) runProvisioning(p *store.Provision) {
 		Apps:           make([]store.App, 0, len(p.Apps)),
 		Domains: []store.Domain{
 			{
-				Domain:    p.Subdomain + ".openova.cloud",
+				Domain:    p.Subdomain + ".omani.homes",
 				Type:      "subdomain",
 				TLSReady:  true,
 				CreatedAt: time.Now().Format(time.RFC3339),
@@ -67,7 +67,7 @@ func (h *Handler) runProvisioning(p *store.Provision) {
 			Slug:       appSlug,
 			Name:       appSlug, // In production, resolve from catalog
 			Status:     "running",
-			URL:        "https://" + appSlug + "." + p.Subdomain + ".openova.cloud",
+			URL:        "https://" + appSlug + "." + p.Subdomain + ".omani.homes",
 			Version:    "latest",
 			DeployedAt: time.Now().Format(time.RFC3339),
 			Healthy:    true,

--- a/products/catalyst/chart/crds/sandbox.yaml
+++ b/products/catalyst/chart/crds/sandbox.yaml
@@ -168,7 +168,7 @@ spec:
                   type: string
                   description: |
                     Apex domain under which preview deploys land (e.g.
-                    `sb-emrah.rzk7.openova.io`). PR previews live at
+                    `sb-emrah.t39.omani.works`). PR previews live at
                     `<pr>.<app>.<previewDomain>`. Wired in Wave 3 (HTTPRoute
                     + Gateway). Wave 1 only records it on status.
                   pattern: '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$'

--- a/products/sandbox/docs/user-journey.md
+++ b/products/sandbox/docs/user-journey.md
@@ -18,12 +18,12 @@ The same applies to Cursor, Qwen Code, Aider, Opencode — their native UX rende
 
 ## Developer journey — building EventForge in a Sandbox
 
-The developer is an experienced Claude Code user. They are signed into their Org inside Sovereign `rzk7` and have just been invited to a Sandbox.
+The developer is an experienced Claude Code user. They are signed into their Org inside Sovereign `t39` and have just been invited to a Sandbox.
 
 ### Scene 1 — Enter the Sandbox
 
 ```
-┌─ Sovereign Console — console.rzk7.openova.io ─────────────┐
+┌─ Sovereign Console — console.t39.omani.works ─────────────┐
 │  Overview   Canvas   Sandbox   Workloads   Settings        │
 └────────────────────────────────────────────────────────────┘
 ```
@@ -98,7 +98,7 @@ ExitPlanMode returns the familiar plan card:
 │  6. Public pages:         /e/[slug]                          │
 │  7. Stripe Connect onboarding (sandbox.stripe.bindAccount)  │
 │  8. Email: Resend (sandbox.secrets.resend)                   │
-│  9. PR -> preview at eventforge.sb-rzk7.openova.io           │
+│  9. PR -> preview at eventforge.sb-t39.omani.homes           │
 │                                                              │
 │  [ Approve & build ]   [ Edit plan ]   [ Cancel ]            │
 └──────────────────────────────────────────────────────────────┘
@@ -117,8 +117,8 @@ ExitPlanMode returns the familiar plan card:
 > v sandbox.auth.provisionRealm   { app: eventforge }
       realm     eventforge-orgs
       client    eventforge-web   (confidential, PKCE)
-      issuer    https://auth.rzk7.openova.io/realms/...
-      redirect  https://eventforge.sb-rzk7.openova.io/...
+      issuer    https://auth.t39.omani.works/realms/...
+      redirect  https://eventforge.sb-t39.omani.homes/...
                 http://localhost:3000/...
       secret    bound to  eventforge-auth                      OK
 
@@ -136,7 +136,7 @@ After the first push, JetStream pushes a `sandbox.preview.ready` event into the 
 
 ```
   v sandbox.preview.ready
-      eventforge.sb-rzk7.openova.io        open ->
+      eventforge.sb-t39.omani.homes        open ->
       build sha     a8f3c12
       cold start    1.4 s
       health        /api/health  200
@@ -174,7 +174,7 @@ The agent calls `marketplace.domain.byod` (which is `POST /domain/byod` — `cor
   v Live
       eventforge.io                served by  sha a8f3c12
       staging.eventforge.io        served by  sha a8f3c12
-      sandbox preview              eventforge.sb-rzk7.openova.io
+      sandbox preview              eventforge.sb-t39.omani.homes
 ```
 
 The user closes the laptop. The agent stays alive in the Sandbox.
@@ -186,7 +186,7 @@ The user closes the laptop. The agent stays alive in the Sandbox.
 The admin sees an extra tab in the Sandbox surface — the **Admin** view — gated by their `org` and `role` claims in the token. Their own personal Sandbox sessions live in the **Sessions** tab exactly the same as a developer.
 
 ```
-┌─ Sandbox · Admin · console.rzk7.openova.io ─────────────────┐
+┌─ Sandbox · Admin · console.t39.omani.works ─────────────────┐
 │                                                              │
 │  [ Sandboxes ]  [ Quotas ]  [ Agents ]  [ Skills ]           │
 │  [ Secrets ]    [ Domains ] [ Audit ]   [ Costs ]            │
@@ -226,4 +226,4 @@ The pty-server (described in [`architecture.md`](architecture.md)) is the only p
 
 ## Conversational provisioning (pre-Sandbox)
 
-A prospective customer who does not have a Sovereign yet lands on `console.openova.io/start` and meets the same Sandbox-style shell — text-only or text+voice — scoped to a much smaller MCP toolbox (catalyst-api provisioning surface). See [`provisioning-chat.md`](provisioning-chat.md) for the full journey.
+A prospective customer who does not have a Sovereign yet lands on `console.t39.omani.works/start` and meets the same Sandbox-style shell — text-only or text+voice — scoped to a much smaller MCP toolbox (catalyst-api provisioning surface). See [`provisioning-chat.md`](provisioning-chat.md) for the full journey.

--- a/products/sandbox/mcp-server/internal/tools/env.go
+++ b/products/sandbox/mcp-server/internal/tools/env.go
@@ -11,7 +11,7 @@
 //	SANDBOX_ORG_ID              = "acme"
 //	SANDBOX_ID                  = "emrah"
 //	SANDBOX_NAMESPACE           = "sandbox-<owner-uid>"
-//	SANDBOX_SOVEREIGN_FQDN      = "acme.openova.io"
+//	SANDBOX_SOVEREIGN_FQDN      = "t39.omani.works"
 //	SANDBOX_REPOS               = "acme/eventforge,acme/internal-tools"
 //	SANDBOX_TOKEN               = "<long-lived PAT>"   (fallback bearer)
 //	SANDBOX_JWT_SECRET          = "<HS256 secret>"     (validates bearers)

--- a/products/sandbox/mcp-server/internal/tools/marketplace.go
+++ b/products/sandbox/mcp-server/internal/tools/marketplace.go
@@ -5,7 +5,7 @@
 // inside a Sandbox routinely needs to bind a public hostname to the
 // per-Org workload — either a custom domain the operator already owns
 // (BYOD) or a free subdomain under one of the Sovereign-managed pools
-// (sme.openova.io / openova.cloud / etc.). The canonical implementation
+// (omani.homes / omani.rest / omani.trade / omani.works). The canonical implementation
 // lives in `core/services/domain/handlers/handlers.go`:
 //
 //   - POST /domain/byod        registerBYODRequest{tenant_id, domain}
@@ -32,7 +32,7 @@
 //     POST <DomainAPIURL>/domain/subdomains with body
 //     {tenant_id: env.TenantID, subdomain, tld: parent_zone}. The
 //     parent_zone defaults to the Sovereign's primary pool (typically
-//     `openova.cloud` or `sme.openova.io`); the canonical allow-list
+//     `omani.homes` / `omani.rest` / `omani.trade` / `omani.works`); the canonical allow-list
 //     lives in core/services/domain/store.AllowedTLDs).
 //
 // Auth: same shape as sandbox.db.* — claims.OrgID must match env.OrgID,
@@ -73,7 +73,7 @@ var mpFQDNRE = regexp.MustCompile(`^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]
 var mpSubdomainRE = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,30}[a-z0-9]$`)
 
 // mpParentZoneRE constrains the `parent_zone` arg — must look like a
-// public DNS suffix (`openova.cloud`, `sme.openova.io`). Same shape as
+// public DNS suffix (`omani.homes`, `omani.rest`, `omani.trade`, `omani.works`). Same shape as
 // mpFQDNRE.
 var mpParentZoneRE = mpFQDNRE
 
@@ -240,7 +240,7 @@ type marketplaceDomainSubdomainArgs struct {
 	Subdomain string `json:"subdomain"`
 
 	// ParentZone — optional override for the parent pool zone
-	// (`openova.cloud`, `sme.openova.io`). When empty we leave the
+	// (`omani.homes`, `omani.rest`, `omani.trade`, `omani.works`). When empty we leave the
 	// `tld` field off the proxied request and let the domain service
 	// apply its own AllowedTLDs default.
 	ParentZone string `json:"parent_zone,omitempty"`
@@ -350,7 +350,7 @@ func schemaMarketplaceDomainSubdomain() map[string]any {
 			},
 			"parent_zone": map[string]any{
 				"type":        "string",
-				"description": "Optional parent pool zone (`openova.cloud`, `sme.openova.io`). When omitted the domain service uses its configured AllowedTLDs default.",
+				"description": "Optional parent pool zone (`omani.homes`, `omani.rest`, `omani.trade`, `omani.works`). When omitted the domain service uses its configured AllowedTLDs default.",
 				"pattern":     mpParentZoneRE.String(),
 			},
 		},

--- a/products/sandbox/mcp-server/internal/tools/marketplace_test.go
+++ b/products/sandbox/mcp-server/internal/tools/marketplace_test.go
@@ -128,7 +128,7 @@ func TestMarketplaceDomainBYOD_Proxy(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 		_, _ = w.Write([]byte(`{
 			"domain": {"id": 42, "domain": "acme.com", "type": "byod"},
-			"cname_target": "sme.openova.io",
+			"cname_target": "cname.t39.omani.works",
 			"registrar": "godaddy",
 			"instructions": "Set CNAME at GoDaddy..."
 		}`))
@@ -157,7 +157,7 @@ func TestMarketplaceDomainBYOD_Proxy(t *testing.T) {
 	if !ok {
 		t.Fatalf("out type=%T want marketplaceDomainBYODResponse", out)
 	}
-	if resp.Status != "Registered" || resp.CNAMETarget != "sme.openova.io" || resp.Registrar != "godaddy" {
+	if resp.Status != "Registered" || resp.CNAMETarget != "cname.t39.omani.works" || resp.Registrar != "godaddy" {
 		t.Errorf("resp=%+v", resp)
 	}
 }
@@ -195,9 +195,9 @@ func TestMarketplaceDomainSubdomain_Proxy(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 		_, _ = w.Write([]byte(`{
 			"id": 7,
-			"domain": "dashboard.openova.cloud",
+			"domain": "dashboard.omani.homes",
 			"type": "subdomain",
-			"tld": "openova.cloud",
+			"tld": "omani.homes",
 			"subdomain": "dashboard"
 		}`))
 	}))
@@ -207,18 +207,18 @@ func TestMarketplaceDomainSubdomain_Proxy(t *testing.T) {
 		TenantID:     "tenant-1",
 		SandboxToken: "tok-abc",
 	})
-	out, err := marketplaceDomainSubdomain(ctx, json.RawMessage(`{"subdomain":"dashboard","parent_zone":"openova.cloud"}`))
+	out, err := marketplaceDomainSubdomain(ctx, json.RawMessage(`{"subdomain":"dashboard","parent_zone":"omani.homes"}`))
 	if err != nil {
 		t.Fatalf("err=%v", err)
 	}
-	if gotBody["tenant_id"] != "tenant-1" || gotBody["subdomain"] != "dashboard" || gotBody["tld"] != "openova.cloud" {
+	if gotBody["tenant_id"] != "tenant-1" || gotBody["subdomain"] != "dashboard" || gotBody["tld"] != "omani.homes" {
 		t.Errorf("body=%v", gotBody)
 	}
 	resp, ok := out.(marketplaceDomainSubdomainResponse)
 	if !ok {
 		t.Fatalf("type=%T", out)
 	}
-	if resp.Status != "Registered" || resp.FQDN != "dashboard.openova.cloud" || resp.ParentZone != "openova.cloud" {
+	if resp.Status != "Registered" || resp.FQDN != "dashboard.omani.homes" || resp.ParentZone != "omani.homes" {
 		t.Errorf("resp=%+v", resp)
 	}
 }

--- a/products/sandbox/mcp-server/internal/tools/registry.go
+++ b/products/sandbox/mcp-server/internal/tools/registry.go
@@ -120,7 +120,7 @@ type Env struct {
 	// + its resources inside the Org vcluster (sandbox-<owner-uid>).
 	SandboxNamespace string
 
-	// SovereignFQDN — the Sovereign's primary FQDN (`acme.openova.io`).
+	// SovereignFQDN — the Sovereign's primary FQDN (`t39.omani.works`).
 	SovereignFQDN string
 
 	// SandboxRepos — comma-separated list of `<org>/<repo>` entries

--- a/products/sandbox/mcp-server/internal/tools/sandbox_preview.go
+++ b/products/sandbox/mcp-server/internal/tools/sandbox_preview.go
@@ -3,7 +3,7 @@
 //
 // Scope (architecture.md §3 + §7): when an agent opens a PR from inside
 // a Sandbox, the operator usually wants a live URL pointing at the PR's
-// build of the app — `pr-1483.eventforge.sb-emrah.acme.openova.io` —
+// build of the app — `pr-1483.eventforge.sb-emrah.acme.omani.homes` —
 // without provoking the marketplace BYOD pipeline or pushing through
 // the production Helm chart. The Sandbox provides ON-DEMAND
 // Deployment + Service + HTTPRoute triples in the Sandbox's OWN


### PR DESCRIPTION
## Summary

- Pillar-4 audit (`/tmp/audit-pillar4-deep-wiring-2026-05-20.md` finding TBD-V25 + audit row "anti-canon checks", item 1) flagged `openova.io` / `openova.cloud` / `sme.openova.io` test-data strings across 5 surfaces. This sweep replaces EXAMPLE-STRING + TEST-FIXTURE-placeholder + DEFAULT-VALUE leaks with the canonical Sovereign + tenant pool (`t39.omani.works` / `omani.homes`+`.rest`+`.trade`+`.works` per `core/services/domain/store/store.go AllowedTLDs`).
- DOES NOT touch real product identifiers: K8s API groups (`sandbox.openova.io`, `apps.openova.io`, `orgs.openova.io`), label keys (`openova.io/region`, `openova.io/managed-by`, `openova.io/preview-pr`, etc.), maintainer emails, marketing-site CORS / from-email defaults.
- Zero chart bumps, zero bootstrap-kit lockstep, zero template touched.

## Files (9)

| File | Type | Replacement |
|---|---|---|
| `products/sandbox/docs/user-journey.md` | EXAMPLE-STRING (8 scene URLs) | `console.rzk7.openova.io` → `console.t39.omani.works`; `eventforge.sb-rzk7.openova.io` → `eventforge.sb-t39.omani.homes`; `auth.rzk7.openova.io` → `auth.t39.omani.works`; `console.openova.io/start` → `console.t39.omani.works/start` |
| `products/sandbox/mcp-server/internal/tools/env.go` | EXAMPLE-STRING (1 docstring) | `SANDBOX_SOVEREIGN_FQDN = "acme.openova.io"` → `"t39.omani.works"`. Label-key parenthetical comments at L42/L43 (`openova.io/region`) preserved — they are real product label keys. |
| `products/sandbox/mcp-server/internal/tools/sandbox_preview.go` | EXAMPLE-STRING (1 docstring) | `pr-1483.eventforge.sb-emrah.acme.openova.io` → `pr-1483.eventforge.sb-emrah.acme.omani.homes`. All `openova.io/preview-*` label-key constants preserved. |
| `products/catalyst/chart/crds/sandbox.yaml` | EXAMPLE-STRING (1 CRD field example) | `sb-emrah.rzk7.openova.io` → `sb-emrah.t39.omani.works`. CRD API group identifiers (`sandboxes.sandbox.openova.io`, `group: sandbox.openova.io`, `orgs.openova.io/v1`) preserved. |
| `products/sandbox/mcp-server/internal/tools/marketplace.go` | EXAMPLE-STRING (5 docstrings) | `sme.openova.io / openova.cloud` → `omani.homes / omani.rest / omani.trade / omani.works` (matches `AllowedTLDs`). |
| `products/sandbox/mcp-server/internal/tools/marketplace_test.go` | TEST-FIXTURE-placeholder (7 hits) | `openova.cloud` → `omani.homes`; `sme.openova.io` → `cname.t39.omani.works`. Test verifies forwarding behavior; the domain value is an arbitrary placeholder. |
| `products/sandbox/mcp-server/internal/tools/registry.go` | EXAMPLE-STRING (1 SovereignFQDN field comment) | `acme.openova.io` → `t39.omani.works`. Label-key Description strings (L558/L724/L725/L740/L799) preserved — they describe real product labels. |
| `core/marketplace-api/handlers/provisioner.go` | DEFAULT-VALUE (2 hardcoded `.openova.cloud` suffixes) | `p.Subdomain + ".openova.cloud"` → `p.Subdomain + ".omani.homes"` |
| `core/marketplace-api/handlers/handlers.go` | DEFAULT-VALUE (1 hardcoded `.openova.cloud` suffix) | `tenant.Subdomain + ".openova.cloud"` → `tenant.Subdomain + ".omani.homes"` |

## Skipped (PRODUCTION-CONFIG / per task do-not-touch list)

- `core/marketplace-api/main.go:21,25` — `https://openova.io` CORS origin + `marketplace@openova.io` from-email: real production marketing-site config.
- All `*.openova.io` K8s API group identifiers — real product API group namespace.
- All `openova.io/*` label keys + annotations — real product label namespace.
- `catalyst@openova.io` / `hati.yildiz@openova.io` Chart maintainer emails.
- All `Co-Authored-By` git trailers, `github.com/openova-io/...` Go import paths, `ghcr.io/openova-io/...` GHCR refs.

## Validation

- `go build ./...` + `go test ./internal/tools/...` from `products/sandbox/mcp-server`: PASS.
- `go build ./...` + `go test ./...` from `core/marketplace-api`: PASS (simulator has no test files).
- `python3 -c "yaml.safe_load(...)"` on `products/catalyst/chart/crds/sandbox.yaml`: PASS.
- Did NOT use `--dry-run=server`. Did NOT touch any chart `values.yaml` default.

## Test plan

- [ ] CI green on the new branch.
- [ ] Post-merge: confirm `grep -rn "openova\.cloud\|sme\.openova\.io" products/sandbox products/catalyst/chart/crds/sandbox.yaml core/marketplace-api` returns 0.
- [ ] Spot-check: re-read `products/sandbox/docs/user-journey.md` for narrative consistency after FQDN swap.

## Refs

- `Refs #2025` (audit doc tracking). Pillar-4 audit findings TBD-V25 (`openova.io` example fixtures) + TBD-V21 (`marketplace.domain.subdomain` defaults docstring).
- Audit doc: `/tmp/audit-pillar4-deep-wiring-2026-05-20.md`.

Note: this is intentionally `Refs` not `Closes` — TBD-V17 / #2025 has additional dormant findings (TBD-V19 env-var drift, TBD-V20 SPIFFE/SVID, TBD-V22 RingBuffer, TBD-V23 card-protocol, TBD-V24 agent-dispatch) that this PR does not address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)