### PR TITLE
fix(blueprint-controller): add missing COPY pkg/ so image actually builds (Refs #2047)

### DIFF
--- a/core/controllers/blueprint/Containerfile
+++ b/core/controllers/blueprint/Containerfile
@@ -23,6 +23,18 @@ RUN go mod download
 # Copy the controller package tree + shared internal/ helpers.
 WORKDIR /src
 COPY core/controllers/internal/ core/controllers/internal/
+# core/controllers/pkg/ holds the shared HTTP-client tree (gitea,
+# keycloak, kc-mappers, …) used by every Group C controller.
+# blueprint-controller imports core/controllers/pkg/gitea from
+# cmd/main.go + internal/controller/blueprint_controller.go.
+# Without this COPY the `go build` step fails with `no required module
+# provides package github.com/openova-io/openova/core/controllers/pkg/gitea`
+# — the build for every push-to-main has failed silently since slice
+# CC1 (#1095) promoted pkg/ to the shared tree, so the
+# blueprint-controller image has NEVER been published to GHCR
+# (Refs TBD-V28 #2047). Mirrors the COPY layout used by application,
+# environment, and organization Containerfiles.
+COPY core/controllers/pkg/ core/controllers/pkg/
 COPY core/controllers/blueprint/ core/controllers/blueprint/
 
 WORKDIR /src/core/controllers/blueprint


### PR DESCRIPTION
## What

The blueprint-controller `Containerfile` was missing `COPY core/controllers/pkg/`, even though both `cmd/main.go` and `internal/controller/blueprint_controller.go` import `github.com/openova-io/openova/core/controllers/pkg/gitea`. The Containerfile only copied `internal/` and `blueprint/`, leaving `pkg/` outside the build context.

## Why this matters — the real shape of TBD-V28

[TBD-V28 #2047](https://github.com/openova-io/openova/issues/2047) was filed on the assumption that PR #2013's fix was already in GHCR at SHA `5b44a66`, and the only gap was a missing values.yaml auto-bump. Investigation showed the gap is wider:

- `https://ghcr.io/v2/openova-io/openova/blueprint-controller` returns `NAME_UNKNOWN` — **the image has never been published**.
- The build for `5b44a66` (run [26132094637](https://github.com/openova-io/openova/actions/runs/26132094637)) **failed** with:
  ```
  no required module provides package
  github.com/openova-io/openova/core/controllers/pkg/gitea
  ```
- Same failure repeats for `e72efb8` (run [26133103598](https://github.com/openova-io/openova/actions/runs/26133103598)) — the most recent push-to-main that touched the controllers tree.
- Every "success" in the workflow's run history is a PR/branch run that does **not** push (image push is gated on `github.event_name != 'pull_request'`).

The build has been broken silently since slice CC1 (#1095) promoted the shared HTTP-client helpers from per-controller `internal/` packages up to `core/controllers/pkg/`. The build-blueprint-controller workflow was authored before that promotion, when the tree was self-contained, and was never updated.

## The fix

One added COPY line mirroring the pattern used by `application`, `environment`, and `organization` Containerfiles, plus an inline comment explaining why pkg/ is required and citing TBD-V28.

## Why this is not "scope creep" beyond TBD-V28

TBD-V28's stated goal is "blueprint-controller's #2013 fix lands on a fresh prov." Backfilling the values.yaml pin manually (as the issue body originally proposed) would have pinned an image tag that **does not exist in GHCR** — the chart would render, but Pods would `ImagePullBackOff`. The Containerfile fix is the strict prerequisite: once it merges, the next push-to-main triggers the build, which pushes the image, which triggers the auto-bump (already wired in by [#2012](https://github.com/openova-io/openova/pull/2012) / TBD-A69), which commits the `deploy: bump blueprint-controller image to <sha>` that TBD-V28 was originally chasing.

This PR is the minimum delta that gets TBD-V28 unstuck — no Chart.yaml bump or bootstrap-kit pin needed here because the auto-bump path handles the chart-side change downstream.

## Validation

- `core/controllers/pkg/gitea/` exists in the tree and is referenced by `module github.com/openova-io/openova/core/controllers`.
- COPY layout matches `application`, `environment`, and `organization` Containerfiles.
- Not validated against `--dry-run=server` against any running cluster — the real validation is the CI build going green on this PR + on push-to-main after merge.

## Followups (NOT in this PR — explicitly out of scope)

- After this PR merges, watch `build-blueprint-controller` on push-to-main go green.
- Watch the auto-bump bot commit `deploy: bump blueprint-controller image to <sha>` land.
- TBD-V28 stays open until an operator walks a fresh prov and confirms the blueprint-controller Pod runs the new image.

Refs #2047
Refs #2013 (the orphan validator fix that this unblocks)
Refs #2006 / PR #2012 (TBD-A69 — the auto-bump scaffolding this relies on)
Refs #1095 (slice CC1 — promoted the shared pkg/ tree)