### PR TITLE
feat(sandbox-controller): dispatch on Sandbox.spec.agent for per-agent runtime (Refs #1986)

### DIFF
--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -68,6 +68,18 @@ spec:
   chart:
     spec:
       chart: sandbox
+      # 0.3.5 (TBD-P4 A4 #1986, 2026-05-20): controller now dispatches
+      # per Sandbox.spec.agentCatalogue[0]. The pty-server StatefulSet
+      # renders SANDBOX_DEFAULT_AGENT into container env so the
+      # lazy-spawn-on-attach branch (pty-server routes.go: lazySpawn)
+      # execs the right agent binary on first WS attach. Before this
+      # bump only the claude-code BYOS branch had any controller-side
+      # effect — the 6-row FE agent dropdown was cosmetic for every
+      # other slug (qwen-code/aider/cursor-agent/little-coder/opencode/
+      # sovereign-shell) because the env was unrendered and lazySpawn
+      # returned 404 on every fresh attach. The canonical-journey
+      # `agent: qwen-code` path is now wired end-to-end.
+      #
       # 0.3.4 (TBD-P4 B2 #1986, 2026-05-20): close the EOF-crash hole
       # left by 0.3.3 (B3 mcp.json injection). The
       # `command: /usr/local/bin/openova-sandbox-mcp` referenced by
@@ -106,7 +118,7 @@ spec:
       # helper), not bare `newapi`. Pre-fix every Sovereign's
       # sandbox-controller TokenMint POST returned `no such host`,
       # blocking the canonical Pillar-4 qwen-code customer journey.
-      version: 0.3.4
+      version: 0.3.5
       sourceRef:
         kind: HelmRepository
         name: bp-sandbox

--- a/core/controllers/sandbox/internal/controller/sandbox_controller.go
+++ b/core/controllers/sandbox/internal/controller/sandbox_controller.go
@@ -265,6 +265,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
+	// TBD-P4 A4 (#1986) — canonical projection of the agent picker.
+	// The FE picks exactly one agent at Sandbox create time and the
+	// catalyst-api handler writes it as a single-element catalogue
+	// (sandbox_sessions.go:863 `"agentCatalogue": []any{agent}`). The
+	// pty-server's lazy-spawn-on-attach branch reads this slug from
+	// SANDBOX_DEFAULT_AGENT to dispatch the right agent binary. An
+	// empty catalogue leaves DefaultAgent empty and the StatefulSet
+	// omits the env var entirely (no regression for legacy CRs).
+	var defaultAgent string
+	if len(sb.Spec.AgentCatalogue) > 0 {
+		defaultAgent = sb.Spec.AgentCatalogue[0]
+	}
 	in := gitops.Inputs{
 		Name:                  sb.Name,
 		OwnerUID:              ownerUID,
@@ -275,6 +287,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		Repos:                 sb.Spec.Repos,
 		PreviewDomain:         sb.Spec.PreviewDomain,
 		AgentCatalogue:        sb.Spec.AgentCatalogue,
+		DefaultAgent:          defaultAgent,
 		PtyServerImage:        r.PtyServerImage,
 		MCPImage:              r.MCPImage,
 		NewapiURL:             r.NewapiURL,

--- a/core/controllers/sandbox/internal/controller/sandbox_controller_test.go
+++ b/core/controllers/sandbox/internal/controller/sandbox_controller_test.go
@@ -640,6 +640,71 @@ func TestReconcile_Wave8RuntimeShape(t *testing.T) {
 	}
 }
 
+// TestReconcile_DefaultAgentFromCatalogue asserts the TBD-P4 A4 wire:
+// the controller projects sb.Spec.AgentCatalogue[0] into the pty-server
+// StatefulSet's SANDBOX_DEFAULT_AGENT env var so lazy-spawn-on-attach
+// (products/sandbox/pty-server/internal/server/routes.go: lazySpawn)
+// dispatches the correct agent binary on the first WS attach.
+//
+// We pin qwen-code here because the CLAUDE.md §0 canonical journey
+// requires qwen-code (zero Anthropic cost-leak path); a regression
+// that drops the env var would silently take the canonical journey
+// back to "blank xterm + 404".
+func TestReconcile_DefaultAgentFromCatalogue(t *testing.T) {
+	t.Parallel()
+	sb := sampleSandbox()
+	sb.Spec.AgentCatalogue = []string{"qwen-code"}
+	r, gs := makeReconciler(t, sb)
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sb.Name, Namespace: sb.Namespace},
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	gs.mu.Lock()
+	entry, ok := gs.files["acme/catalyst-tenant/sandbox/ceo-at-acme-com/statefulset-pty-server.yaml"]
+	gs.mu.Unlock()
+	if !ok {
+		t.Fatalf("expected statefulset-pty-server.yaml")
+	}
+	body := string(entry.content)
+	if !strings.Contains(body, "name: SANDBOX_DEFAULT_AGENT") {
+		t.Errorf("statefulset missing SANDBOX_DEFAULT_AGENT env var\n--- rendered ---\n%s", body)
+	}
+	if !strings.Contains(body, `value: "qwen-code"`) {
+		t.Errorf("statefulset SANDBOX_DEFAULT_AGENT value is not %q\n--- rendered ---\n%s", "qwen-code", body)
+	}
+}
+
+// TestReconcile_DefaultAgentEmptyWhenCatalogueEmpty guards the no-regression
+// path: a Sandbox CR with an empty agentCatalogue must NOT emit the env
+// var (preserves the historic 404-on-attach behaviour for hand-rolled
+// CRs without a chosen agent).
+func TestReconcile_DefaultAgentEmptyWhenCatalogueEmpty(t *testing.T) {
+	t.Parallel()
+	sb := sampleSandbox()
+	sb.Spec.AgentCatalogue = nil
+	r, gs := makeReconciler(t, sb)
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sb.Name, Namespace: sb.Namespace},
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	gs.mu.Lock()
+	entry, ok := gs.files["acme/catalyst-tenant/sandbox/ceo-at-acme-com/statefulset-pty-server.yaml"]
+	gs.mu.Unlock()
+	if !ok {
+		t.Fatalf("expected statefulset-pty-server.yaml")
+	}
+	body := string(entry.content)
+	if strings.Contains(body, "SANDBOX_DEFAULT_AGENT") {
+		t.Errorf("statefulset must NOT emit SANDBOX_DEFAULT_AGENT when catalogue is empty\n--- rendered ---\n%s", body)
+	}
+}
+
 // TestReconcile_Wave8NoBYOSWhenAgentMissing asserts that a Sandbox
 // without claude-code in spec.agentCatalogue does NOT wire the
 // ANTHROPIC_API_KEY env into the rendered StatefulSet.

--- a/core/controllers/sandbox/internal/gitops/manifests.go
+++ b/core/controllers/sandbox/internal/gitops/manifests.go
@@ -156,6 +156,24 @@ type Inputs struct {
 	// repo filter"). Populated by Render() from in.Repos so callers do
 	// not need to compute this themselves.
 	SandboxRepos string
+
+	// TBD-P4 A4 (#1986) — SANDBOX_DEFAULT_AGENT is the agent slug the
+	// pty-server's lazy-spawn-on-attach branch (products/sandbox/pty-server/
+	// internal/server/routes.go: lazySpawn) reads when a WS attach lands
+	// on a session id that has not yet been POSTed. Without this env var
+	// pty-server returns 404 on every fresh attach and the xterm panel
+	// stays blank — the FE's agent dropdown becomes cosmetic (only the
+	// claude-code BYOS branch had any controller-side effect before this
+	// PR).
+	//
+	// Populated by the controller from sb.Spec.AgentCatalogue[0] — the
+	// canonical projection per products/catalyst/bootstrap/api/internal/
+	// handler/sandbox_sessions.go:940 (the FE picks exactly one agent at
+	// create time; the CR's catalogue is a single-element list). Empty
+	// leaves the env var unrendered (no `value: ""` stanza), preserving
+	// the historic 404 behaviour for any caller that hand-rolls a CR
+	// with an empty catalogue.
+	DefaultAgent string
 }
 
 const namespaceTemplate = `apiVersion: v1
@@ -446,6 +464,17 @@ spec:
               value: {{ .NewapiURL | quote }}
             - name: LLM_GATEWAY_URL
               value: {{ .NewapiURL | quote }}
+{{- if .DefaultAgent }}
+            # TBD-P4 A4 (#1986) — pty-server lazy-spawn-on-attach
+            # (routes.go: lazySpawn) reads SANDBOX_DEFAULT_AGENT to know
+            # which catalogue slug to execve on the first WS attach. The
+            # value mirrors spec.agentCatalogue[0] which the FE picker
+            # writes when the customer selects an agent from the 6-row
+            # dropdown. Absent stanza preserves the historic 404 behaviour
+            # for hand-rolled CRs with an empty catalogue.
+            - name: SANDBOX_DEFAULT_AGENT
+              value: {{ .DefaultAgent | quote }}
+{{- end }}
             # TBD-V21 — key case alignment with newapiTokenSecretTemplate
             # (line 270 stringData: LLM_GATEWAY_TOKEN). Pre-fix the key
             # ref was lowercase 'llm-gateway-token' while the Secret writes

--- a/core/controllers/sandbox/internal/gitops/manifests_test.go
+++ b/core/controllers/sandbox/internal/gitops/manifests_test.go
@@ -1,0 +1,139 @@
+// Tests for the gitops Render() function — specifically the TBD-P4 A4
+// per-agent dispatch wiring. The controller reads sb.Spec.AgentCatalogue[0]
+// and writes it into Inputs.DefaultAgent; the StatefulSet template MUST
+// then emit a `SANDBOX_DEFAULT_AGENT` env var so the pty-server's
+// lazy-spawn-on-attach branch (products/sandbox/pty-server/internal/
+// server/routes.go: lazySpawn) can execve the right agent binary.
+//
+// Why this matters: without this wire the FE's 6-option agent dropdown
+// is cosmetic — every fresh WS attach returns 404 and the xterm panel
+// stays blank. See TBD-P4 #1986 A4 sub-break.
+package gitops
+
+import (
+	"strings"
+	"testing"
+
+	sandboxapi "github.com/openova-io/openova/core/controllers/sandbox/internal/sandboxapi"
+)
+
+// baseInputs returns a minimally-valid Inputs for Render(). Tests
+// override DefaultAgent + AgentCatalogue to exercise the dispatch path.
+func baseInputs() Inputs {
+	return Inputs{
+		Name:           "demo",
+		OwnerUID:       "ceo-at-acme-com",
+		OwnerEmail:     "ceo@acme.com",
+		OrgSlug:        "acme",
+		SovereignFQDN:  "t99.omani.works",
+		Quota:          sandboxapi.SandboxQuota{CPU: "4", Memory: "8Gi", Storage: "50Gi", ConcurrentSessions: 3},
+		PtyServerImage: "ghcr.io/example/pty-server:test",
+		MCPImage:       "ghcr.io/example/mcp:test",
+		NewapiURL:      "https://newapi.t99.omani.works",
+	}
+}
+
+// TestRender_DefaultAgent_PerSlug walks every FE-visible agent slug and
+// asserts the StatefulSet renders the SANDBOX_DEFAULT_AGENT env var with
+// the expected value. This is the explicit table-driven proof that the
+// 6-row dropdown is no longer cosmetic for non-claude-code agents.
+//
+// The slugs MUST stay in lock-step with:
+//   - products/sandbox/pty-server/internal/agentcatalog/agentcatalog.go (Builtin)
+//   - products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go (sandboxAllowedAgents)
+//   - products/catalyst/bootstrap/ui/src/lib/sandbox.api.ts (SANDBOX_AGENTS)
+//   - products/catalyst/chart/crds/sandbox.yaml (spec.agentCatalogue.items.enum)
+func TestRender_DefaultAgent_PerSlug(t *testing.T) {
+	t.Parallel()
+	agents := []string{
+		"aider",
+		"claude-code",
+		"cursor-agent",
+		"little-coder",
+		"opencode",
+		"qwen-code",
+		"sovereign-shell",
+	}
+	for _, slug := range agents {
+		slug := slug
+		t.Run(slug, func(t *testing.T) {
+			t.Parallel()
+			in := baseInputs()
+			in.AgentCatalogue = []string{slug}
+			in.DefaultAgent = slug
+
+			manifests, err := Render(in)
+			if err != nil {
+				t.Fatalf("Render(%q): %v", slug, err)
+			}
+			body, ok := manifests["statefulset-pty-server.yaml"]
+			if !ok {
+				t.Fatalf("expected statefulset-pty-server.yaml in render output")
+			}
+			s := string(body)
+			// The env entry MUST be present.
+			if !strings.Contains(s, "name: SANDBOX_DEFAULT_AGENT") {
+				t.Errorf("statefulset missing SANDBOX_DEFAULT_AGENT env var for slug %q\n--- rendered ---\n%s", slug, s)
+			}
+			// And it must carry the expected value (quoted by template).
+			wantVal := "value: \"" + slug + "\""
+			if !strings.Contains(s, wantVal) {
+				t.Errorf("statefulset SANDBOX_DEFAULT_AGENT value missing for slug %q (expected %q)\n--- rendered ---\n%s",
+					slug, wantVal, s)
+			}
+		})
+	}
+}
+
+// TestRender_DefaultAgent_OmittedWhenEmpty asserts that an empty
+// DefaultAgent leaves the env var UNRENDERED — preserving the historic
+// 404-on-attach behaviour for hand-rolled CRs without a populated
+// catalogue. This guards against accidentally emitting `value: ""` which
+// would have lazy-spawn enter the dispatch branch with an empty slug
+// and return invalid-agent instead of 404 (semantic regression).
+func TestRender_DefaultAgent_OmittedWhenEmpty(t *testing.T) {
+	t.Parallel()
+	in := baseInputs()
+	// no AgentCatalogue, no DefaultAgent
+
+	manifests, err := Render(in)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	body, ok := manifests["statefulset-pty-server.yaml"]
+	if !ok {
+		t.Fatalf("expected statefulset-pty-server.yaml in render output")
+	}
+	s := string(body)
+	if strings.Contains(s, "SANDBOX_DEFAULT_AGENT") {
+		t.Errorf("statefulset must NOT emit SANDBOX_DEFAULT_AGENT when DefaultAgent is empty\n--- rendered ---\n%s", s)
+	}
+}
+
+// TestRender_DefaultAgent_QwenCodeIsCanonical pins the canonical-journey
+// agent (CLAUDE.md §0 Phase 2: agent = qwen-code) to a dedicated assert
+// so the next reader can grep for the exact wire-level evidence that
+// the canonical journey is no longer cosmetic.
+func TestRender_DefaultAgent_QwenCodeIsCanonical(t *testing.T) {
+	t.Parallel()
+	in := baseInputs()
+	in.AgentCatalogue = []string{"qwen-code"}
+	in.DefaultAgent = "qwen-code"
+
+	manifests, err := Render(in)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	body, ok := manifests["statefulset-pty-server.yaml"]
+	if !ok {
+		t.Fatalf("expected statefulset-pty-server.yaml in render output")
+	}
+	s := string(body)
+	if !strings.Contains(s, "name: SANDBOX_DEFAULT_AGENT") || !strings.Contains(s, "value: \"qwen-code\"") {
+		t.Errorf("canonical journey agent qwen-code not wired into pty-server env\n--- rendered ---\n%s", s)
+	}
+	// Sanity: no BYOS ANTHROPIC_API_KEY for non-claude-code agent.
+	if strings.Contains(s, "ANTHROPIC_API_KEY") {
+		t.Errorf("qwen-code must NOT emit ANTHROPIC_API_KEY env (BYOS branch must be claude-code-only)\n--- rendered ---\n%s", s)
+	}
+}

--- a/platform/sandbox/chart/Chart.yaml
+++ b/platform/sandbox/chart/Chart.yaml
@@ -24,6 +24,19 @@ annotations:
   # (see issue #181 + docs/BLUEPRINT-AUTHORING.md §11.1).
   catalyst.openova.io/no-upstream: "true"
   catalyst.openova.io/smoke-render-mode: "default-off"
+# 0.3.5 (TBD-P4 A4 #1986, 2026-05-20): controller now dispatches per
+# Sandbox.spec.agentCatalogue[0]. The pty-server StatefulSet renders
+# SANDBOX_DEFAULT_AGENT into the container env so pty-server's
+# lazy-spawn-on-attach branch (products/sandbox/pty-server/internal/
+# server/routes.go: lazySpawn) execs the right agent binary on the first
+# WS attach. Before this bump only the claude-code BYOS branch had any
+# controller-side effect — the 6-row FE agent dropdown was cosmetic
+# for every other slug (aider/cursor-agent/little-coder/opencode/
+# qwen-code/sovereign-shell) because the env was unrendered and
+# lazySpawn returned 404 on every fresh attach (blank xterm panel).
+# An empty catalogue keeps the env unrendered to preserve the 404
+# behaviour for hand-rolled CRs without a chosen agent.
+#
 # 0.3.4 (TBD-P4 B2 #1986, 2026-05-20): close the EOF-crash hole left
 # by 0.3.3 (B3 mcp.json injection). The `command: /usr/local/bin/
 # openova-sandbox-mcp` referenced by 0.3.3's mcp.json was ENOENT
@@ -85,8 +98,8 @@ annotations:
 # `helm template newapi platform/newapi/chart/ -s templates/service.yaml`
 # → metadata.name: newapi-bp-newapi. Walker on t38 (chart 1.4.216,
 # substrate be4f78bc872e2c56) caught the live regression.
-version: 0.3.4
-appVersion: "0.3.4"
+version: 0.3.5
+appVersion: "0.3.5"
 keywords:
   - catalyst
   - sandbox


### PR DESCRIPTION
## Summary

Closes the TBD-P4 A4 audit finding: the FE's 6-option agent dropdown is cosmetic for every slug except `claude-code`. PR #1992 shipped the pty-server's `agentcatalog` package + lazy-spawn-on-attach branch that reads `SANDBOX_DEFAULT_AGENT`, but the **controller never rendered that env var** onto the StatefulSet — so the lazy-spawn returned `ErrNotFound` and every fresh WS attach 404'd with a blank xterm panel.

Only the `claude-code` BYOS branch had any controller-side effect (`ANTHROPIC_API_KEY` env from the `sandbox-byos-claude-code-<uid>` Secret). Customer picks `qwen-code` -> Sandbox CR's `spec.agentCatalogue=["qwen-code"]` -> controller renders pty-server StatefulSet with **no** `SANDBOX_DEFAULT_AGENT` env -> pty-server lazy-spawn returns `ErrNotFound` -> blank xterm. The canonical CLAUDE.md §0 Phase 2 journey (`agent: qwen-code`) was wired end-to-end on paper but silently broken at runtime.

## The fix (minimal wire — 1 new field, 1 new env stanza)

- `core/controllers/sandbox/internal/gitops/manifests.go`
  - `Inputs` gains `DefaultAgent string`
  - `ptyServerStatefulSetTemplate` emits `SANDBOX_DEFAULT_AGENT` env when `DefaultAgent` is non-empty; absent stanza preserves the historic 404 behaviour for hand-rolled CRs (no semantic regression).

- `core/controllers/sandbox/internal/controller/sandbox_controller.go`
  - Projects `sb.Spec.AgentCatalogue[0]` into `Inputs.DefaultAgent` — the canonical projection per `products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go:940` (FE picks exactly one agent at create time; the catalogue is a single-element list).

## Per-agent dispatch table

| Slug | Binary | RequiredEnv |
|---|---|---|
| `aider` | `/usr/local/bin/aider` | `OPENAI_BASE_URL`, `OPENAI_API_KEY` |
| `claude-code` | `/usr/local/bin/claude` | `LLM_GATEWAY_URL` |
| `cursor-agent` | `/usr/local/bin/cursor-agent` | `LLM_GATEWAY_URL` |
| `little-coder` | `/usr/local/bin/little-coder` | `OPENAI_BASE_URL`, `OPENAI_API_KEY` |
| `opencode` | `/usr/local/bin/opencode` | `OPENAI_BASE_URL`, `OPENAI_API_KEY` |
| `qwen-code` | `/usr/local/bin/qwen-code` | `OPENAI_BASE_URL`, `OPENAI_API_KEY` |
| `sovereign-shell` | `/bin/sh` | (rescue, no env) |

`RequiredEnv` lives in `products/sandbox/pty-server/internal/agentcatalog/agentcatalog.go` (`Builtin`). The controller already plumbs `OPENAI_BASE_URL` / `LLM_GATEWAY_URL` / `OPENAI_API_KEY` onto the StatefulSet env so every slug has its `RequiredEnv` satisfied. The canonical `qwen-code` journey routes through `bp-newapi` (OpenAI-compatible gateway -> Sovereign-hosted Qwen) with zero Anthropic cost-leak.

## Test coverage (5 new tests)

- `gitops.TestRender_DefaultAgent_PerSlug` — 7-row table-driven proof every agent slug renders the env var.
- `gitops.TestRender_DefaultAgent_OmittedWhenEmpty` — no env var when catalogue empty.
- `gitops.TestRender_DefaultAgent_QwenCodeIsCanonical` — explicit pin on the canonical-journey slug + BYOS-isolation guard.
- `controller.TestReconcile_DefaultAgentFromCatalogue` — controller -> renderer end-to-end assertion.
- `controller.TestReconcile_DefaultAgentEmptyWhenCatalogueEmpty` — no-regression guard.

## No new API keys

Every agent's bearer comes from existing wires (BYOS for claude-code; `LLM_GATEWAY_TOKEN` for the rest, sourced from the per-Sandbox NewAPI Secret).

## Validation

- `go build ./core/controllers/sandbox/...` PASS
- `go test ./core/controllers/sandbox/... -count=1 -race` PASS
- `go vet ./core/controllers/...` PASS
- `helm template platform/sandbox/chart ...` PASS (5 resources rendered)
- Did NOT use `kubectl --dry-run=server` (per principle #15).

## Chart / pin lockstep

(After rebase past PR #2051's 0.3.4 B2 MCP-subprocess change.)

- `platform/sandbox/chart/Chart.yaml` 0.3.4 -> 0.3.5
- `clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml` version: 0.3.4 -> 0.3.5

## Test plan

- [ ] (post-merge, after image bump) operator walks the canonical journey on a fresh prov: customer picks `agent: qwen-code` -> WS attach lands on a fresh xterm with the qwen-code prompt.
- [ ] (post-merge) `kubectl -n sandbox-<uid> get sts pty-server -o yaml | grep SANDBOX_DEFAULT_AGENT` returns the slug.

Refs #1986