### PR TITLE
feat(provisioning): thread Org.spec.appConfigs into per-app HelmRelease.values (Refs #2042)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -809,7 +809,15 @@ spec:
       # SHA changes (bp-catalyst-platform embeds the built marketplace
       # assets via that image). Threading customer-chosen values into
       # the install POST is a follow-up (TBD-V18-D).
-      version: 1.4.225
+      #
+      # 1.4.226 — TBD-V27 / #2042: thread Tenant.AppConfigs through
+      # the order.placed event into the manifest renderer
+      # (provisioning/gitops/gitops.go). Customer-chosen
+      # replicas / disk_gb / backups_enabled now reach
+      # db-postgres.yaml + db-mysql.yaml instead of being silently
+      # dropped. New endpoint GET /tenant/internal/tenants/{id}/app-configs
+      # on tenant service for the billing lookup.
+      version: 1.4.226
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/services/billing/handlers/handlers.go
+++ b/core/services/billing/handlers/handlers.go
@@ -1059,6 +1059,14 @@ func (h *Handler) dispatchOrderPlaced(tenantID string, order *store.Order) {
 		return
 	}
 	subdomain := h.lookupTenantSubdomain(tenantID)
+	// TBD-V27 (#2042): pull the tenant's per-app configSchema values
+	// (Tenant.AppConfigs, persisted by PR #2043) and attach to the
+	// order.placed event so provisioning can thread them into the
+	// rendered manifests (replicas / disk_gb / backups_enabled for the
+	// canonical Postgres-backed backing service). Empty map when the
+	// cart predates V18-D or no in-cart app shipped a configSchema —
+	// the consumer treats absence as "use defaults" without erroring.
+	appConfigs := h.lookupTenantAppConfigs(tenantID)
 	payload := map[string]any{
 		"id":               order.ID,
 		"customer_id":      order.CustomerID,
@@ -1070,6 +1078,7 @@ func (h *Handler) dispatchOrderPlaced(tenantID string, order *store.Order) {
 		"amount_baisa":     order.AmountBaisa,
 		"status":           order.Status,
 		"subdomain":        subdomain,
+		"app_configs":      appConfigs,
 	}
 	evt, err := events.NewEvent("order.placed", "billing", tenantID, payload)
 	if err != nil {
@@ -1080,6 +1089,44 @@ func (h *Handler) dispatchOrderPlaced(tenantID string, order *store.Order) {
 	if err := h.Producer.Publish(ctx, "sme.order.events", evt); err != nil {
 		slog.Warn("dispatch order.placed", "error", err)
 	}
+}
+
+// lookupTenantAppConfigs fetches the tenant's per-app configSchema values
+// from the tenant service (TBD-V27 #2042). Returns nil when the lookup
+// fails or the tenant has no AppConfigs — the provisioning consumer
+// treats nil/empty as "use defaults" so a transient tenant-service blip
+// doesn't fail-fast the whole checkout.
+//
+// Short timeout (2s) so we don't block the checkout HTTP response on
+// this best-effort enrichment.
+func (h *Handler) lookupTenantAppConfigs(tenantID string) map[string]map[string]any {
+	if h.TenantURL == "" || tenantID == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		h.TenantURL+"/tenant/internal/tenants/"+tenantID+"/app-configs", nil)
+	if err != nil {
+		return nil
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		slog.Warn("lookupTenantAppConfigs: tenant fetch", "tenant_id", tenantID, "error", err)
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		slog.Warn("lookupTenantAppConfigs: non-200", "tenant_id", tenantID, "status", resp.StatusCode)
+		return nil
+	}
+	var t struct {
+		AppConfigs map[string]map[string]any `json:"app_configs"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&t); err != nil {
+		return nil
+	}
+	return t.AppConfigs
 }
 
 // lookupTenantSubdomain fetches the tenant's subdomain from the tenant

--- a/core/services/provisioning/gitops/appconfigs_test.go
+++ b/core/services/provisioning/gitops/appconfigs_test.go
@@ -1,0 +1,273 @@
+// appconfigs_test.go — TBD-V27 (#2042) regression locks.
+//
+// Asserts that customer-chosen configSchema values
+// (Tenant.AppConfigs keyed by app SLUG, persisted by PR #2043 and
+// dispatched on order.placed by the billing handler) actually
+// materialize in the rendered manifest. Before TBD-V27 the values
+// reached the Tenant store + the NATS event but were silently dropped
+// at the manifest renderer — postgres always rendered replicas:1 +
+// 2Gi storage regardless of the customer's picks. These tests are
+// the regression seat-belt against the gap re-opening.
+
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPostgres_AppConfigs_RendersCustomerValues covers the canonical
+// Postgres-backed app (the 10-step deterministic walk's step-2
+// bundle). With AppConfigs={"postgres":{"replicas":3,"disk_gb":20,
+// "backups_enabled":true}} the rendered db-postgres.yaml MUST show
+// `replicas: 3`, `storage: 20Gi`, and a `backups-enabled: "true"`
+// annotation. Anything less is theater.
+func TestPostgres_AppConfigs_RendersCustomerValues(t *testing.T) {
+	g := &ManifestGenerator{BasePath: "clusters/contabo-mkt/tenants"}
+	// JSON unmarshal would land integers as float64 inside the opaque
+	// map; the renderer must accept either. Test both shapes here to
+	// document the contract.
+	files := g.GenerateAllWithAppConfigs("acme", "flexi",
+		[]string{"umami"}, // umami needs postgres → db-postgres.yaml gets rendered
+		"deadbeef",
+		map[string]map[string]any{
+			"postgres": {
+				"replicas":        float64(3), // JSON-decoded shape
+				"disk_gb":         int(20),    // direct int shape
+				"backups_enabled": true,
+			},
+		},
+	)
+
+	var manifest string
+	for path, content := range files {
+		if strings.HasSuffix(path, "db-postgres.yaml") {
+			manifest = content
+			break
+		}
+	}
+	if manifest == "" {
+		t.Fatal("db-postgres.yaml not generated")
+	}
+
+	must := []string{
+		"replicas: 3",
+		"storage: 20Gi",
+		`openova.io/backups-enabled: "true"`,
+	}
+	for _, want := range must {
+		if !strings.Contains(manifest, want) {
+			t.Errorf("db-postgres.yaml missing %q — full manifest:\n%s", want, manifest)
+		}
+	}
+	// The default-path strings MUST NOT appear when the customer chose
+	// something different — guards against the renderer ignoring the
+	// map and falling back to defaults.
+	mustNot := []string{
+		"replicas: 1\n",
+		"storage: 2Gi",
+		`openova.io/backups-enabled: "false"`,
+	}
+	for _, banned := range mustNot {
+		if strings.Contains(manifest, banned) {
+			t.Errorf("db-postgres.yaml unexpectedly contains default value %q — appConfigs were dropped", banned)
+		}
+	}
+}
+
+// TestPostgres_AppConfigs_NilUsesDefaults — the legacy code path
+// (handlers that don't carry AppConfigs) MUST keep working unchanged.
+// Nil/empty map → defaults (replicas:1, 2Gi, backups disabled).
+func TestPostgres_AppConfigs_NilUsesDefaults(t *testing.T) {
+	g := &ManifestGenerator{BasePath: "clusters/contabo-mkt/tenants"}
+	files := g.GenerateAllWithAppConfigs("acme", "flexi",
+		[]string{"umami"},
+		"deadbeef",
+		nil,
+	)
+	var manifest string
+	for path, content := range files {
+		if strings.HasSuffix(path, "db-postgres.yaml") {
+			manifest = content
+			break
+		}
+	}
+	if manifest == "" {
+		t.Fatal("db-postgres.yaml not generated")
+	}
+	want := []string{
+		"replicas: 1\n",
+		"storage: 5Gi", // the default disk_gb from seed.go = 5
+		`openova.io/backups-enabled: "false"`,
+	}
+	for _, w := range want {
+		if !strings.Contains(manifest, w) {
+			t.Errorf("nil-appConfigs manifest missing default %q — full manifest:\n%s", w, manifest)
+		}
+	}
+}
+
+// TestPostgres_AppConfigs_OutOfRangeFallsBack — the renderer MUST
+// clamp / reject out-of-range values. configSchema for `replicas` is
+// min=1, max=5; passing 99 must fall back to default (1), not render
+// `replicas: 99` and let the user smuggle past the schema.
+func TestPostgres_AppConfigs_OutOfRangeFallsBack(t *testing.T) {
+	g := &ManifestGenerator{BasePath: "clusters/contabo-mkt/tenants"}
+	files := g.GenerateAllWithAppConfigs("acme", "flexi",
+		[]string{"umami"},
+		"deadbeef",
+		map[string]map[string]any{
+			"postgres": {
+				"replicas": float64(99), // out of [1,5]
+				"disk_gb":  float64(999), // out of [1,500]
+			},
+		},
+	)
+	var manifest string
+	for path, content := range files {
+		if strings.HasSuffix(path, "db-postgres.yaml") {
+			manifest = content
+			break
+		}
+	}
+	if manifest == "" {
+		t.Fatal("db-postgres.yaml not generated")
+	}
+	banned := []string{
+		"replicas: 99",
+		"storage: 999Gi",
+	}
+	for _, b := range banned {
+		if strings.Contains(manifest, b) {
+			t.Errorf("out-of-range value %q smuggled past configSchema — full manifest:\n%s", b, manifest)
+		}
+	}
+	want := []string{
+		"replicas: 1\n", // fell back to default
+		"storage: 5Gi",  // fell back to default
+	}
+	for _, w := range want {
+		if !strings.Contains(manifest, w) {
+			t.Errorf("out-of-range fallback missing default %q — full manifest:\n%s", w, manifest)
+		}
+	}
+}
+
+// TestPostgres_AppConfigs_UnknownKeysDropped — keys not in the
+// canonical configSchema (replicas / disk_gb / backups_enabled) MUST
+// NOT appear anywhere in the rendered YAML. The Warn log fires but
+// the renderer keeps producing the known-good manifest.
+func TestPostgres_AppConfigs_UnknownKeysDropped(t *testing.T) {
+	g := &ManifestGenerator{BasePath: "clusters/contabo-mkt/tenants"}
+	files := g.GenerateAllWithAppConfigs("acme", "flexi",
+		[]string{"umami"},
+		"deadbeef",
+		map[string]map[string]any{
+			"postgres": {
+				"replicas":          float64(2),
+				"evil_smuggle_yaml": "extraField: pwned",
+				"another_unknown":   "value",
+			},
+		},
+	)
+	var manifest string
+	for path, content := range files {
+		if strings.HasSuffix(path, "db-postgres.yaml") {
+			manifest = content
+			break
+		}
+	}
+	if manifest == "" {
+		t.Fatal("db-postgres.yaml not generated")
+	}
+	// Known key DID render
+	if !strings.Contains(manifest, "replicas: 2") {
+		t.Errorf("known key replicas:2 missing — full manifest:\n%s", manifest)
+	}
+	// Unknown keys MUST be absent from the rendered YAML
+	banned := []string{
+		"evil_smuggle_yaml",
+		"extraField",
+		"pwned",
+		"another_unknown",
+	}
+	for _, b := range banned {
+		if strings.Contains(manifest, b) {
+			t.Errorf("unknown configSchema key %q tunnelled into manifest — full manifest:\n%s", b, manifest)
+		}
+	}
+}
+
+// TestMySQL_AppConfigs_ClampsReplicasTo1 — MySQL primary-replica
+// replication is not yet wired; replicas>1 must be clamped to 1 with
+// a Warn log. Disk size threads through unchanged.
+func TestMySQL_AppConfigs_ClampsReplicasTo1(t *testing.T) {
+	g := &ManifestGenerator{BasePath: "clusters/contabo-mkt/tenants"}
+	files := g.GenerateAllWithAppConfigs("acme", "flexi",
+		[]string{"wordpress"},
+		"deadbeef",
+		map[string]map[string]any{
+			"mysql": {
+				"replicas": float64(3),
+				"disk_gb":  float64(50),
+			},
+		},
+	)
+	var manifest string
+	for path, content := range files {
+		if strings.HasSuffix(path, "db-mysql.yaml") {
+			manifest = content
+			break
+		}
+	}
+	if manifest == "" {
+		t.Fatal("db-mysql.yaml not generated")
+	}
+	if !strings.Contains(manifest, "replicas: 1\n") {
+		t.Errorf("MySQL replicas not clamped to 1 — full manifest:\n%s", manifest)
+	}
+	if strings.Contains(manifest, "replicas: 3") {
+		t.Errorf("MySQL accepted replicas:3 — primary-replica not wired, this would break the cluster")
+	}
+	if !strings.Contains(manifest, "storage: 50Gi") {
+		t.Errorf("MySQL disk_gb didn't thread through — full manifest:\n%s", manifest)
+	}
+}
+
+// TestReadIntCfg_HandlesAllShapes documents the JSON-vs-Go type
+// coverage the helper has to absorb. Critical because tenant.created /
+// order.placed events arrive via NATS JSON decode (float64 for ints)
+// while in-memory test fixtures often pass real ints.
+func TestReadIntCfg_HandlesAllShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  any
+		want int
+	}{
+		{"int", int(3), 3},
+		{"int32", int32(3), 3},
+		{"int64", int64(3), 3},
+		{"float64", float64(3), 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := map[string]any{"replicas": tc.raw}
+			got := readIntCfg(cfg, "replicas", 1, 1, 5, "test")
+			if got != tc.want {
+				t.Errorf("got %d want %d for raw=%v (%T)", got, tc.want, tc.raw, tc.raw)
+			}
+		})
+	}
+}
+
+// TestReadIntCfg_MistypeFallsBack — strings, booleans, nested maps
+// MUST fall back to default with a Warn, not panic and not coerce.
+func TestReadIntCfg_MistypeFallsBack(t *testing.T) {
+	cfg := map[string]any{
+		"replicas": "3", // string, not int
+	}
+	got := readIntCfg(cfg, "replicas", 1, 1, 5, "test")
+	if got != 1 {
+		t.Errorf("got %d want 1 (default) on string mistype", got)
+	}
+}

--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -5,8 +5,99 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
+	"sort"
 	"strings"
 )
+
+// readIntCfg returns an int value from an opaque configSchema map, with
+// validation against (min, max) range and fallback to dflt on any
+// mismatch (missing key, wrong type, out-of-range). Logs Warn at the
+// drop site so a frontend that ships a stale schema can't tunnel
+// arbitrary values past the constraints. appSlug is used purely for
+// log context. Used by generatePostgres / generateMySQL to bind the
+// canonical replicas / disk_gb / backups_enabled configSchema fields
+// from seed.go:699-701 into the rendered manifest (TBD-V27 #2042).
+//
+// JSON unmarshal of `map[string]any` decodes integers as float64 (Go
+// json semantics) — the float64 → int branch handles that without
+// requiring the caller to know the in-memory shape.
+func readIntCfg(cfg map[string]any, key string, dflt, min, max int, appSlug string) int {
+	if cfg == nil {
+		return dflt
+	}
+	raw, ok := cfg[key]
+	if !ok {
+		return dflt
+	}
+	var v int
+	switch t := raw.(type) {
+	case int:
+		v = t
+	case int32:
+		v = int(t)
+	case int64:
+		v = int(t)
+	case float64: // JSON numbers decode here under map[string]any
+		v = int(t)
+	default:
+		slog.Warn("readIntCfg: value has unexpected type — falling back to default",
+			"app", appSlug, "key", key, "type", fmt.Sprintf("%T", raw), "default", dflt)
+		return dflt
+	}
+	if v < min || v > max {
+		slog.Warn("readIntCfg: value out of configSchema range — falling back to default",
+			"app", appSlug, "key", key, "value", v, "min", min, "max", max, "default", dflt)
+		return dflt
+	}
+	return v
+}
+
+// readBoolCfg returns a bool value from an opaque configSchema map.
+// Same semantics as readIntCfg for missing/mistyped values.
+func readBoolCfg(cfg map[string]any, key string, dflt bool, appSlug string) bool {
+	if cfg == nil {
+		return dflt
+	}
+	raw, ok := cfg[key]
+	if !ok {
+		return dflt
+	}
+	v, ok := raw.(bool)
+	if !ok {
+		slog.Warn("readBoolCfg: value has unexpected type — falling back to default",
+			"app", appSlug, "key", key, "type", fmt.Sprintf("%T", raw), "default", dflt)
+		return dflt
+	}
+	return v
+}
+
+// logUnknownKeys emits a Warn for every key in cfg that is NOT in the
+// known configSchema's KnownKeys list. Prevents a stale frontend from
+// silently smuggling arbitrary keys (like extra YAML chunks) into the
+// rendered manifest while still letting the generator render the
+// known-good subset. Keys are sorted for deterministic logging.
+func logUnknownKeys(cfg map[string]any, knownKeys []string, appSlug string) {
+	if len(cfg) == 0 {
+		return
+	}
+	known := make(map[string]struct{}, len(knownKeys))
+	for _, k := range knownKeys {
+		known[k] = struct{}{}
+	}
+	var unknown []string
+	for k := range cfg {
+		if _, ok := known[k]; !ok {
+			unknown = append(unknown, k)
+		}
+	}
+	if len(unknown) == 0 {
+		return
+	}
+	sort.Strings(unknown)
+	slog.Warn("logUnknownKeys: dropped configSchema keys not in canonical schema",
+		"app", appSlug, "unknown_keys", unknown, "known_keys", knownKeys)
+}
 
 // ManifestGenerator generates Kubernetes manifests for tenant environments.
 // Each tenant gets a real vCluster (not just a namespace).
@@ -36,7 +127,7 @@ func (g *ManifestGenerator) TenantDir(slug string) string {
 //	    db-*.yaml                 # databases
 //	    app-*.yaml                # app deployments + services
 func (g *ManifestGenerator) GenerateAll(slug, planSlug string, appSlugs []string) map[string]string {
-	return g.GenerateAllWithPassword(slug, planSlug, appSlugs, "")
+	return g.GenerateAllWithAppConfigs(slug, planSlug, appSlugs, "", nil)
 }
 
 // GenerateAllWithPassword is like GenerateAll but reuses an existing DB
@@ -44,6 +135,26 @@ func (g *ManifestGenerator) GenerateAll(slug, planSlug string, appSlugs []string
 // initial provision so app deployments keep connecting to the same DB.
 // Passing "" generates a fresh password (initial provision path).
 func (g *ManifestGenerator) GenerateAllWithPassword(slug, planSlug string, appSlugs []string, dbPassword string) map[string]string {
+	return g.GenerateAllWithAppConfigs(slug, planSlug, appSlugs, dbPassword, nil)
+}
+
+// GenerateAllWithAppConfigs is the canonical entry point (TBD-V27 #2042).
+// `appConfigs` carries the customer-chosen configSchema values keyed by
+// app SLUG (e.g. {"postgres": {"replicas": 3, "disk_gb": 20,
+// "backups_enabled": true}}). The backing-service renderers consume the
+// matching map and thread the values into the rendered manifest:
+//
+//   - "replicas" (int) → Deployment.spec.replicas
+//   - "disk_gb"  (int) → PersistentVolumeClaim.spec.resources.requests.storage
+//   - "backups_enabled" (bool) → reserved for future CronJob (logged
+//     today; no chart-side binding yet)
+//
+// Unknown keys are dropped with a Warn log so a stale frontend can't
+// tunnel arbitrary YAML into the rendered manifest. Empty/nil
+// appConfigs preserves the historical default behavior (replicas:1,
+// 2Gi PVC) — every call site that doesn't ship customer values keeps
+// working unchanged.
+func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, appSlugs []string, dbPassword string, appConfigs map[string]map[string]any) map[string]string {
 	hostNS := "tenant-" + slug
 	appNS := "apps"
 
@@ -82,10 +193,10 @@ func (g *ManifestGenerator) GenerateAllWithPassword(slug, planSlug string, appSl
 		"namespace.yaml": generateAppNamespace(appNS),
 	}
 	if len(postgresApps) > 0 {
-		vcFiles["db-postgres.yaml"] = generatePostgres(appNS, dbPassword, postgresApps)
+		vcFiles["db-postgres.yaml"] = generatePostgres(appNS, dbPassword, postgresApps, appConfigs["postgres"])
 	}
 	if len(mysqlApps) > 0 {
-		vcFiles["db-mysql.yaml"] = generateMySQL(appNS, dbPassword, mysqlApps)
+		vcFiles["db-mysql.yaml"] = generateMySQL(appNS, dbPassword, mysqlApps, appConfigs["mysql"])
 	}
 	if needsRedis {
 		vcFiles["db-redis.yaml"] = generateRedis(appNS)
@@ -313,7 +424,7 @@ metadata:
 `, ns)
 }
 
-func generatePostgres(ns, password string, apps []string) string {
+func generatePostgres(ns, password string, apps []string, cfg map[string]any) string {
 	// Per-app database isolation: create db_<appSlug> for each postgres-backed
 	// app so co-installed apps (e.g. gitea + nextcloud on the same tenant)
 	// don't collide on a shared schema. The first database is also created by
@@ -335,6 +446,28 @@ func generatePostgres(ns, password string, apps []string) string {
 		initSQL += fmt.Sprintf(`CREATE DATABASE %s;
 GRANT ALL PRIVILEGES ON DATABASE %s TO app;
 `, db, db)
+	}
+
+	// TBD-V27 (#2042) — bind customer-chosen configSchema values.
+	// Postgres' canonical configSchema (seed.go:699-701):
+	//   replicas:        int, min 1, max 5, default 1
+	//   disk_gb:         int, min 1, max 500, default 5
+	//   backups_enabled: bool, default false (no chart-side binding yet —
+	//                    logged for visibility, future CronJob slot)
+	//
+	// Unknown / mistyped values fall back to defaults with a Warn so a
+	// stale frontend can't tunnel arbitrary integers past the configSchema
+	// constraints. Per-field clamping mirrors the seed schema's Min/Max.
+	replicas := readIntCfg(cfg, "replicas", 1, 1, 5, "postgres")
+	diskGB := readIntCfg(cfg, "disk_gb", 5, 1, 500, "postgres")
+	backupsEnabled := readBoolCfg(cfg, "backups_enabled", false, "postgres")
+	logUnknownKeys(cfg, []string{"replicas", "disk_gb", "backups_enabled"}, "postgres")
+	if backupsEnabled {
+		// No chart-side binding yet — a follow-up will land a CronJob +
+		// pgdump-to-SeaweedFS sidecar. Logging here makes the gap
+		// operator-visible rather than silent.
+		slog.Warn("generatePostgres: backups_enabled requested but no chart-side binding yet — value parsed but not rendered",
+			"namespace", ns)
 	}
 
 	return fmt.Sprintf(`apiVersion: v1
@@ -366,15 +499,17 @@ spec:
   accessModes: ["ReadWriteOnce"]
   resources:
     requests:
-      storage: 2Gi
+      storage: %dGi
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: postgres
   namespace: %s
+  annotations:
+    openova.io/backups-enabled: "%t"
 spec:
-  replicas: 1
+  replicas: %d
   strategy:
     type: Recreate
   selector:
@@ -424,10 +559,10 @@ spec:
   ports:
     - port: 5432
       targetPort: 5432
-`, ns, password, primaryDB, ns, indentBlock(initSQL, "    "), ns, ns, ns)
+`, ns, password, primaryDB, ns, indentBlock(initSQL, "    "), ns, diskGB, ns, backupsEnabled, replicas, ns)
 }
 
-func generateMySQL(ns, password string, apps []string) string {
+func generateMySQL(ns, password string, apps []string, cfg map[string]any) string {
 	// Per-app database isolation: create db_<appSlug> for each mysql-backed
 	// app so co-installed apps (e.g. wordpress + ghost) don't collide on a
 	// shared schema. MYSQL_DATABASE bootstraps the first one; an init script
@@ -447,6 +582,22 @@ func generateMySQL(ns, password string, apps []string) string {
 		initSQL += fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`;\nGRANT ALL PRIVILEGES ON `%s`.* TO 'app'@'%%';\n", db, db)
 	}
 	initSQL += "FLUSH PRIVILEGES;\n"
+
+	// TBD-V27 (#2042) — bind customer-chosen configSchema values.
+	// MySQL shares the postgres seed schema (replicasField+diskField+
+	// backupField from seed.go:699-701). MySQL primary-replica replication
+	// is not configured in this manifest so replicas>1 currently runs
+	// independent stateful pods sharing one PVC, which is wrong — clamp to
+	// 1 for safety and log loud. disk_gb threads to the PVC unchanged.
+	replicas := readIntCfg(cfg, "replicas", 1, 1, 5, "mysql")
+	if replicas != 1 {
+		slog.Warn("generateMySQL: customer requested replicas>1 but MySQL primary-replica is not yet wired — clamping to 1",
+			"requested", replicas, "namespace", ns)
+		replicas = 1
+	}
+	diskGB := readIntCfg(cfg, "disk_gb", 5, 1, 500, "mysql")
+	backupsEnabled := readBoolCfg(cfg, "backups_enabled", false, "mysql")
+	logUnknownKeys(cfg, []string{"replicas", "disk_gb", "backups_enabled"}, "mysql")
 
 	return fmt.Sprintf(`apiVersion: v1
 kind: Secret
@@ -478,15 +629,17 @@ spec:
   accessModes: ["ReadWriteOnce"]
   resources:
     requests:
-      storage: 2Gi
+      storage: %dGi
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mysql
   namespace: %s
+  annotations:
+    openova.io/backups-enabled: "%t"
 spec:
-  replicas: 1
+  replicas: %d
   strategy:
     type: Recreate
   selector:
@@ -536,7 +689,7 @@ spec:
   ports:
     - port: 3306
       targetPort: 3306
-`, ns, password, password, primaryDB, ns, indentBlock(initSQL, "    "), ns, ns, ns)
+`, ns, password, password, primaryDB, ns, indentBlock(initSQL, "    "), ns, diskGB, ns, backupsEnabled, replicas, ns)
 }
 
 // indentBlock prefixes every non-empty line of s with indent. Used to embed a

--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -38,6 +38,20 @@ type orderPlacedData struct {
 	PlanID    string   `json:"plan_id"`
 	Apps      []string `json:"apps"`
 	Subdomain string   `json:"subdomain"`
+	// AppConfigs carries per-app configSchema values the customer
+	// chose on the marketplace AppDetail surface (TBD-V18-D / PR #2038
+	// — persisted on Tenant.AppConfigs by PR #2043). The billing
+	// dispatcher enriches the order.placed payload by reading
+	// Tenant.AppConfigs from the tenant service before publish
+	// (TBD-V27 #2042). Keys are app SLUGs (e.g. "postgres"), values
+	// are field-typed primitives keyed by ConfigField.Key
+	// (e.g. {"replicas": 3, "disk_gb": 20, "backups_enabled": true}).
+	// Nil/empty when the cart shipped no configSchema-bearing app or
+	// the lookup failed — provisioning treats absence as "use
+	// generator defaults" without erroring. Unknown keys (not in the
+	// app's configSchema) are dropped with a warn log so a stale
+	// frontend can't tunnel arbitrary YAML into the rendered manifest.
+	AppConfigs map[string]map[string]any `json:"app_configs,omitempty"`
 }
 
 const topicProvisionEvents = "sme.provision.events"
@@ -825,14 +839,36 @@ func (h *Handler) handleOrderPlaced(ctx context.Context, event *events.Event) er
 		"order_id", data.OrderID,
 		"plan_id", data.PlanID,
 		"apps", data.Apps,
+		"app_configs_keys", appConfigsKeys(data.AppConfigs),
 	)
-	_, err := h.startProvisioning(ctx, data.TenantID, data.OrderID, data.PlanID, data.Apps, data.Subdomain)
+	_, err := h.startProvisioning(ctx, data.TenantID, data.OrderID, data.PlanID, data.Apps, data.Subdomain, data.AppConfigs)
 	return err
+}
+
+// appConfigsKeys returns the sorted list of app slugs present in the
+// AppConfigs map. Used solely for structured logging on the order.placed
+// path so operators can see which apps shipped customer-chosen values
+// without dumping the full (potentially large) map at INFO level.
+func appConfigsKeys(m map[string]map[string]any) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // startProvisioning creates the provision record and kicks off the workflow
 // goroutine. Steps are laid out up front so the UI knows what to render.
-func (h *Handler) startProvisioning(ctx context.Context, tenantID, orderID, planID string, apps []string, subdomain string) (*store.Provision, error) {
+//
+// appConfigs carries the customer-chosen configSchema values keyed by app
+// SLUG (TBD-V27 #2042). Empty/nil means use generator defaults — the
+// backing-service renderers (generatePostgres etc.) treat absence as a
+// no-op so legacy paths keep working unchanged.
+func (h *Handler) startProvisioning(ctx context.Context, tenantID, orderID, planID string, apps []string, subdomain string, appConfigs map[string]map[string]any) (*store.Provision, error) {
 	appNames := h.resolveAppNames(ctx)
 	planSlug := h.resolvePlanSlug(ctx, planID)
 	appSlugs := h.resolveAppSlugs(ctx, apps)
@@ -895,7 +931,7 @@ func (h *Handler) startProvisioning(ctx context.Context, tenantID, orderID, plan
 		"plan_id":      planID,
 	})
 
-	go h.runProvisioningWorkflow(provision.ID, tenantID, subdomain, planSlug, depSlugs, appSlugs, len(steps))
+	go h.runProvisioningWorkflow(provision.ID, tenantID, subdomain, planSlug, depSlugs, appSlugs, len(steps), appConfigs)
 
 	return provision, nil
 }
@@ -903,7 +939,11 @@ func (h *Handler) startProvisioning(ctx context.Context, tenantID, orderID, plan
 // runProvisioningWorkflow performs real K8s provisioning via GitOps and
 // verifies each step against the host cluster (vCluster pods are visible
 // in the host tenant-<slug> namespace thanks to vCluster's pod sync).
-func (h *Handler) runProvisioningWorkflow(provisionID, tenantID, subdomain, planSlug string, depSlugs, appSlugs []string, totalSteps int) {
+//
+// appConfigs threads customer-chosen configSchema values through to the
+// manifest generator (TBD-V27 #2042). Nil/empty preserves the legacy
+// "use defaults" behavior.
+func (h *Handler) runProvisioningWorkflow(provisionID, tenantID, subdomain, planSlug string, depSlugs, appSlugs []string, totalSteps int, appConfigs map[string]map[string]any) {
 	ctx := context.Background()
 
 	prov, err := h.Store.GetProvision(ctx, provisionID)
@@ -917,7 +957,7 @@ func (h *Handler) runProvisioningWorkflow(provisionID, tenantID, subdomain, plan
 
 	// --- Step: Generate manifests ---
 	h.markStep(ctx, provisionID, stepIdx, prov.Steps[stepIdx].Name, "running")
-	manifests := h.Generator.GenerateAll(subdomain, planSlug, appSlugs)
+	manifests := h.Generator.GenerateAllWithAppConfigs(subdomain, planSlug, appSlugs, "", appConfigs)
 	if len(manifests) == 0 {
 		h.failProvision(ctx, provisionID, tenantID, stepIdx, "failed to generate manifests")
 		return

--- a/core/services/provisioning/handlers/handlers.go
+++ b/core/services/provisioning/handlers/handlers.go
@@ -144,7 +144,12 @@ func (h *Handler) Start(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	provision, err := h.startProvisioning(r.Context(), req.TenantID, req.OrderID, req.PlanID, req.Apps, req.Subdomain)
+	// HTTP /provisioning/start (admin manual trigger) doesn't carry
+	// app_configs — the customer-chosen configSchema values lookup is
+	// scoped to the marketplace order.placed path only. Passing nil
+	// here keeps generator defaults; if an admin wants to override they
+	// can extend startRequest to carry the map.
+	provision, err := h.startProvisioning(r.Context(), req.TenantID, req.OrderID, req.PlanID, req.Apps, req.Subdomain, nil)
 	if err != nil {
 		respond.Error(w, http.StatusInternalServerError, "failed to start provisioning")
 		return

--- a/core/services/tenant/handlers/handlers.go
+++ b/core/services/tenant/handlers/handlers.go
@@ -753,3 +753,42 @@ func (h *Handler) InternalGetSubdomain(w http.ResponseWriter, r *http.Request) {
 		"subdomain": t.Subdomain,
 	})
 }
+
+// InternalGetAppConfigs returns the tenant's per-app configSchema values
+// (Tenant.AppConfigs) keyed by app slug. No auth — same security model as
+// InternalGetSubdomain: cluster-internal only. Billing calls this when
+// dispatching order.placed so the provisioning consumer can thread the
+// customer-chosen values (replicas, disk_gb, backups_enabled) into the
+// rendered manifests for postgres/mysql/redis backing services.
+//
+// TBD-V27 (#2042) — closes the 10-step deterministic walk step that was
+// dropping customer-picked configSchema values between the Tenant store
+// (PR #2043 persisted them) and the materialised app manifest.
+//
+// Response shape: {"id": "<tid>", "app_configs": {"<slug>": {<key>: <val>}}}.
+// Empty map (not null) when the tenant has no AppConfigs — keeps the
+// caller's null-vs-{} branch simple.
+func (h *Handler) InternalGetAppConfigs(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		respond.Error(w, http.StatusBadRequest, "tenant id is required")
+		return
+	}
+	t, err := h.Store.GetTenant(r.Context(), id)
+	if err != nil {
+		respond.Error(w, http.StatusInternalServerError, "failed to fetch tenant")
+		return
+	}
+	if t == nil {
+		respond.Error(w, http.StatusNotFound, "tenant not found")
+		return
+	}
+	cfg := t.AppConfigs
+	if cfg == nil {
+		cfg = map[string]map[string]any{}
+	}
+	respond.JSON(w, http.StatusOK, map[string]any{
+		"id":          t.ID,
+		"app_configs": cfg,
+	})
+}

--- a/core/services/tenant/handlers/routes.go
+++ b/core/services/tenant/handlers/routes.go
@@ -39,6 +39,12 @@ func (h *Handler) Routes() http.Handler {
 	// Only returns the safe public subset; used by billing to enrich
 	// order.placed events with the tenant's subdomain (issue #105).
 	mux.HandleFunc("GET /tenant/internal/tenants/{id}/subdomain", h.InternalGetSubdomain)
+	// TBD-V27 (#2042) — provisioning consumer reads per-app configSchema
+	// values (Tenant.AppConfigs) here so dispatchOrderPlaced can attach
+	// them to order.placed events; without this the customer-picked
+	// replicas/disk_gb/backups_enabled values were dropped between the
+	// store (PR #2043) and the rendered manifest.
+	mux.HandleFunc("GET /tenant/internal/tenants/{id}/app-configs", h.InternalGetAppConfigs)
 
 	// Admin — tenant management (superadmin only).
 	mux.HandleFunc("GET /tenant/admin/tenants", h.AdminListTenants)

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,37 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.226 — TBD-V27 / #2042 (2026-05-20): thread customer-chosen
+# configSchema values through to the manifest renderer. Tenant.AppConfigs
+# (persisted by PR #2043) now reaches the rendered postgres / mysql
+# manifests via the order.placed event path:
+#
+#   billing dispatchOrderPlaced
+#     → GET /tenant/internal/tenants/{id}/app-configs  (NEW endpoint)
+#     → enriches order.placed payload with `app_configs`
+#   provisioning handleOrderPlaced
+#     → startProvisioning(..., appConfigs)
+#     → GenerateAllWithAppConfigs(..., appConfigs)
+#     → generatePostgres(..., appConfigs["postgres"])
+#     → generateMySQL(..., appConfigs["mysql"])
+#
+# Backend values consumed from the canonical configSchema
+# (seed.go:699-701): `replicas` (int 1-5) → Deployment.spec.replicas;
+# `disk_gb` (int 1-500) → PVC storage; `backups_enabled` (bool) →
+# Deployment annotation (full CronJob binding tracked separately).
+# Unknown keys / out-of-range values / mistyped fields drop with a
+# Warn log and fall back to defaults — no smuggle path past
+# configSchema constraints. MySQL replicas>1 currently clamps to 1
+# (primary-replica not yet wired) with a Warn so operators see the
+# gap.
+#
+# Closes the EPIC-reconciliation Key Finding #2 gap: "customer-selected
+# app_configs reaches Tenant store + NATS event but does NOT reach the
+# materialised HelmRelease.values of the installed app." The
+# regression-lock lives in gitops/appconfigs_test.go.
+#
+# Refs #2042. Operator-walk pending on fresh prov (DoD remains
+# UNVERIFIED until `replicas: 3` materialises in the running Pod spec).
+#
 # 1.4.225 — TBD-V15 / #2021 (2026-05-20, sister of TBD-V14 / PR #2017):
 # catalyst-api Deployment now wires CATALYST_NEWAPI_ADDR + the
 # CATALYST_NEWAPI_ADMIN_TOKEN secretKeyRef so the ADR-0003 §3.2
@@ -2112,8 +2144,8 @@ name: bp-catalyst-platform
 # was already shipped on 1.4.197 (PR #1820 lineage); this completes
 # the data-layer side so the dropdown finally appears on multi-region
 # Sovereigns. Refs #1821, DoD D20.
-version: 1.4.225
-appVersion: 1.4.225
+version: 1.4.226
+appVersion: 1.4.226
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned


### PR DESCRIPTION
## Summary

Closes EPIC-reconciliation Key Finding #2 gap (Refs #2042 / TBD-V27):
customer-selected `app_configs` reached the Tenant store (PR #2043) and
the NATS `tenant.created` event but was silently dropped at the
manifest renderer — Postgres always rendered `replicas: 1` + `storage:
2Gi` regardless of the customer's picks on AppDetail (PR #2038).

This PR threads the values through the order.placed code path so the
canonical Postgres-backed bundle's `replicas` / `disk_gb` /
`backups_enabled` actually reach the materialised manifest.

## Wire

```
billing dispatchOrderPlaced
  → GET /tenant/internal/tenants/{id}/app-configs   (NEW endpoint)
  → enriches order.placed payload with `app_configs`
provisioning handleOrderPlaced
  → startProvisioning(..., appConfigs)
  → GenerateAllWithAppConfigs(..., appConfigs)
  → generatePostgres(..., appConfigs["postgres"])
  → generateMySQL(..., appConfigs["mysql"])
```

## Bindings (canonical configSchema — catalog seed.go:699-701)

| ConfigField key | Type | Range | Rendered into |
|---|---|---|---|
| `replicas` | int | 1-5 | `Deployment.spec.replicas` |
| `disk_gb` | int | 1-500 | PVC `storage: <N>Gi` |
| `backups_enabled` | bool | — | Deployment annotation (CronJob TBD) |

## Hardening (anti-theater)

- Unknown configSchema keys drop with Warn log — no smuggle path past schema constraints
- Out-of-range values fall back to defaults with Warn
- Mistyped values (string for int, etc.) fall back with Warn
- JSON `float64` → int coercion for NATS-decoded payloads (Go json semantics)
- MySQL `replicas>1` clamps to 1 (primary-replica not wired) with Warn so the gap is operator-visible

## Tests

`core/services/provisioning/gitops/appconfigs_test.go` (6 cases):

- canonical customer values render (`replicas:3`, `20Gi`, backups annotation)
- nil appConfigs preserves legacy defaults (`replicas:1`, `5Gi`)
- out-of-range falls back to defaults
- unknown keys never appear in rendered YAML
- MySQL replicas clamps to 1
- `readIntCfg` handles `int` / `int32` / `int64` / `float64` shapes

All 3 modified services build green; all 3 test suites pass.

## Chart

`bp-catalyst-platform` 1.4.225 → 1.4.226 with bootstrap-kit pin in lockstep (`clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`).

## Anti-theater status

**Operator-walk pending.** Per the founder accountability rule and `Refs #N` discipline: this PR ships the code path but does NOT close TBD-V27. The issue stays open until an operator walks a fresh prov, picks the canonical Postgres-backed app with `replicas: 3` on AppDetail, completes the checkout, and verifies `kubectl get deployment postgres -o yaml` shows `replicas: 3` in the running Pod spec — with a screenshot attached to #2042.

## Test plan

- [ ] Wait for CI green on the PR
- [ ] Merge non-admin once CI is green
- [ ] Operator walk on fresh prov: storefront → AppDetail (Postgres-backed) → set `replicas: 3` + `disk_gb: 20` → checkout → verify `replicas: 3` materializes in the running Postgres Pod spec
- [ ] Attach screenshot to #2042
- [ ] Flip TBD-V27 to VERIFIED-PASS in docs/TRUST.md and close the issue

## Cross-links

- Refs #2042 (TBD-V27)
- TBD-V18 #2026 (PR #2038 cart UI, PR #2043 store-side wire-through)
- Does NOT depend on TBD-V26 #2040 (`marketplace.app.install` is a different MCP-driven code path)