### PR TITLE
feat(sandbox/pty-server): configurable ring buffer, default 1 MiB (Refs #1986 F1)

### DIFF
--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -68,6 +68,21 @@ spec:
   chart:
     spec:
       chart: sandbox
+      # 0.3.6 (TBD-V22 #1986 F1, 2026-05-20): expose a configurable PTY-
+      # stdout replay ring buffer (default 1 MiB, up from a hardcoded
+      # 256 KiB literal). Pre-fix the documented multi-device "close
+      # laptop, open phone" replay claim (user-journey.md Scene 6) was
+      # unbacked because the buffer rolled in well under a minute on a
+      # real coding-agent session. Adds SANDBOX_RING_BUFFER_BYTES env
+      # var on the sandbox-controller Deployment (chart value
+      # `runtime.ringBufferBytes`) and on every per-Sandbox pty-server
+      # StatefulSet (controller-threaded). pty-server clamps operator-
+      # set values above 16 MiB (MaxRingBytes) + logs the clamp.
+      # Memory-budget reasoning: 16 MiB × 10 concurrent sessions = 160
+      # MiB worst-case, well under typical Sandbox Pod memory limits.
+      # Additive; no breaking changes to existing operator overlays.
+      # Rebased on top of PR #2052 (0.3.5 A4 dispatch).
+      #
       # 0.3.5 (TBD-P4 A4 #1986, 2026-05-20): controller now dispatches
       # per Sandbox.spec.agentCatalogue[0]. The pty-server StatefulSet
       # renders SANDBOX_DEFAULT_AGENT into container env so the
@@ -118,7 +133,7 @@ spec:
       # helper), not bare `newapi`. Pre-fix every Sovereign's
       # sandbox-controller TokenMint POST returned `no such host`,
       # blocking the canonical Pillar-4 qwen-code customer journey.
-      version: 0.3.5
+      version: 0.3.6
       sourceRef:
         kind: HelmRepository
         name: bp-sandbox

--- a/core/controllers/sandbox/cmd/sandbox-controller/main.go
+++ b/core/controllers/sandbox/cmd/sandbox-controller/main.go
@@ -73,6 +73,16 @@ func main() {
 	byosSecretPrefix := envOr("SANDBOX_BYOS_SECRET_PREFIX", "sandbox-byos-claude-code")
 	idleTimeoutMinutes := envOrInt("SANDBOX_IDLE_TIMEOUT_MINUTES", 30)
 
+	// TBD-V22 #1986 F1 (2026-05-20) — replay ring buffer size in bytes.
+	// 0 (the default when SANDBOX_RING_BUFFER_BYTES is unset / empty /
+	// non-integer / non-positive) leaves the per-Sandbox pty-server
+	// StatefulSet without the env var, so pty-server falls back to its
+	// own session.DefaultRingBytes (1 MiB). Chart default in
+	// platform/sandbox/chart/values.yaml::runtime.ringBufferBytes also
+	// emits 1048576 explicitly so the operator-visible env var is set
+	// out of the box.
+	ringBufferBytes := envOrInt("SANDBOX_RING_BUFFER_BYTES", 0)
+
 	// Wave 9 — NewAPI bridge wiring. Two env vars carry the bridge URL +
 	// admin bearer used by the controller to call POST
 	// /admin/tokens/sandbox (catalyst-api bridge handler, PR #1638).
@@ -170,6 +180,7 @@ func main() {
 		LLMGatewayTokenSecret: llmGatewayTokenSecret,
 		BYOSSecretPrefix:      byosSecretPrefix,
 		IdleTimeoutMinutes:    idleTimeoutMinutes,
+		RingBufferBytes:       ringBufferBytes,
 		NewAPIClient:          newapiClient,
 		DefaultChannels:       defaultChannels,
 		EnableHotStandby:      enableHotStandby,
@@ -268,6 +279,7 @@ func main() {
 		"llm_gateway_token_secret", llmGatewayTokenSecret,
 		"byos_secret_prefix", byosSecretPrefix,
 		"idle_timeout_minutes", idleTimeoutMinutes,
+		"ring_buffer_bytes", ringBufferBytes,
 		"newapi_wired", newapiClient != nil,
 		"default_channels", defaultChannels,
 	)

--- a/core/controllers/sandbox/internal/controller/sandbox_controller.go
+++ b/core/controllers/sandbox/internal/controller/sandbox_controller.go
@@ -77,6 +77,14 @@ type Reconciler struct {
 	BYOSSecretPrefix      string
 	IdleTimeoutMinutes    int
 
+	// RingBufferBytes — pty-server PTY-stdout replay buffer size, in
+	// bytes. Sourced from SANDBOX_RING_BUFFER_BYTES (controller env via
+	// bp-sandbox values `runtime.ringBufferBytes`). Zero ⇒ controller
+	// omits SANDBOX_RING_BUFFER_BYTES on the per-Sandbox pty-server
+	// StatefulSet, leaving the pty-server's process default
+	// (session.DefaultRingBytes = 1 MiB). TBD-V22 #1986 F1 (2026-05-20).
+	RingBufferBytes int
+
 	// D31 active-hot-standby — Sovereign-level toggle + region pair the
 	// controller threads from its chart env (SOVEREIGN_ENABLE_HOT_STANDBY,
 	// SOVEREIGN_PRIMARY_REGION, SOVEREIGN_REPLICA_REGION) into every
@@ -294,6 +302,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		LLMGatewayTokenSecret: r.LLMGatewayTokenSecret,
 		BYOSSecretPrefix:      r.BYOSSecretPrefix,
 		IdleTimeoutMinutes:    r.IdleTimeoutMinutes,
+		RingBufferBytes:       r.RingBufferBytes,
 		IdleScalingDisabled:   sb.Spec.IdleScaling != nil && !sb.Spec.IdleScaling.Enabled,
 		NewAPIToken:           tokenValue,
 		NewAPITokenSecretName: fmt.Sprintf("sandbox-%s-newapi-token", ownerUID),

--- a/core/controllers/sandbox/internal/controller/sandbox_controller_test.go
+++ b/core/controllers/sandbox/internal/controller/sandbox_controller_test.go
@@ -1061,6 +1061,71 @@ func TestReconcile_NewAPI_CapabilitiesSpecOverride(t *testing.T) {
 	}
 }
 
+// TBD-V22 #1986 F1 (2026-05-20) — verify the SANDBOX_RING_BUFFER_BYTES
+// env var is emitted on the per-Sandbox pty-server StatefulSet ONLY when
+// the controller has a non-zero RingBufferBytes (sourced from
+// SANDBOX_RING_BUFFER_BYTES on the controller's own env, see
+// cmd/sandbox-controller/main.go). Zero ⇒ omit (pty-server falls back
+// to its own session.DefaultRingBytes). Non-zero ⇒ stamp the value as
+// the env var so the pty-server's LoadDefaultRingBytesFromEnv consumes
+// it at startup.
+func TestReconcile_RingBufferBytes_OmittedWhenZero(t *testing.T) {
+	t.Parallel()
+	sb := sampleSandbox()
+	r, gs := makeReconciler(t, sb)
+	// r.RingBufferBytes defaults to 0 in makeReconciler.
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sb.Name, Namespace: sb.Namespace},
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	prefix := "acme/catalyst-tenant/sandbox/ceo-at-acme-com/"
+	gs.mu.Lock()
+	entry, ok := gs.files[prefix+"statefulset-pty-server.yaml"]
+	gs.mu.Unlock()
+	if !ok {
+		t.Fatalf("expected rendered statefulset-pty-server.yaml")
+	}
+	ss := string(entry.content)
+	if strings.Contains(ss, "SANDBOX_RING_BUFFER_BYTES") {
+		t.Errorf("expected NO SANDBOX_RING_BUFFER_BYTES env var when RingBufferBytes=0; got rendered output:\n%s", ss)
+	}
+}
+
+func TestReconcile_RingBufferBytes_EmittedWhenNonZero(t *testing.T) {
+	t.Parallel()
+	sb := sampleSandbox()
+	r, gs := makeReconciler(t, sb)
+	// 2 MiB — distinct from the pty-server's default (1 MiB) so the
+	// emitted value is unambiguously the controller's, not a noop default.
+	r.RingBufferBytes = 2 << 20 // 2097152
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sb.Name, Namespace: sb.Namespace},
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	prefix := "acme/catalyst-tenant/sandbox/ceo-at-acme-com/"
+	gs.mu.Lock()
+	entry, ok := gs.files[prefix+"statefulset-pty-server.yaml"]
+	gs.mu.Unlock()
+	if !ok {
+		t.Fatalf("expected rendered statefulset-pty-server.yaml")
+	}
+	ss := string(entry.content)
+	for _, want := range []string{
+		"- name: SANDBOX_RING_BUFFER_BYTES",
+		`value: "2097152"`,
+	} {
+		if !strings.Contains(ss, want) {
+			t.Errorf("statefulset-pty-server.yaml missing %q", want)
+		}
+	}
+}
+
 func gsKeys(gs *giteaServer) []string {
 	gs.mu.Lock()
 	defer gs.mu.Unlock()

--- a/core/controllers/sandbox/internal/gitops/manifests.go
+++ b/core/controllers/sandbox/internal/gitops/manifests.go
@@ -61,6 +61,17 @@ type Inputs struct {
 	PreviewDomain         string
 	AgentCatalogue        []string
 	PtyServerImage        string
+	// RingBufferBytes is the replay-buffer size in bytes the controller
+	// stamps into the pty-server StatefulSet via the
+	// SANDBOX_RING_BUFFER_BYTES env var. The pty-server reads it on
+	// process start and applies to every newly-spawned PTY session.
+	// Zero ⇒ omit the env var (pty-server falls back to its
+	// session.DefaultRingBytes — currently 1 MiB). TBD-V22 #1986 F1
+	// (2026-05-20) — pre-fix the buffer was a hardcoded 256 KiB literal
+	// in pty-server with no upstream knob, defeating the multi-device
+	// "close laptop, open phone" replay claim in user-journey.md
+	// Scene 6 for any real coding-agent session.
+	RingBufferBytes       int
 	// MCPImage — DEPRECATED post TBD-P4 B2 (2026-05-20). The
 	// per-Sandbox MCP Deployment was removed; the openova-sandbox-mcp
 	// binary now ships inside the pty-server image and is launched
@@ -450,6 +461,17 @@ spec:
           env:
             - name: PTY_SERVER_ADDR
               value: ":7681"
+            # TBD-V22 #1986 F1 (2026-05-20) — replay ring buffer size
+            # consumed by pty-server's session.LoadDefaultRingBytesFromEnv.
+            # Zero/empty leaves the pty-server default intact (1 MiB).
+            # Operator overrides flow chart values → controller env →
+            # gitops.Inputs.RingBufferBytes → this var. Sized for the
+            # multi-device handoff path documented in
+            # products/sandbox/docs/user-journey.md Scene 6.
+            {{- if gt .RingBufferBytes 0 }}
+            - name: SANDBOX_RING_BUFFER_BYTES
+              value: {{ .RingBufferBytes | quote }}
+            {{- end }}
             - name: SANDBOX_OWNER_UID
               value: {{ .OwnerUID | quote }}
             - name: SANDBOX_OWNER_EMAIL

--- a/platform/sandbox/chart/Chart.yaml
+++ b/platform/sandbox/chart/Chart.yaml
@@ -24,6 +24,27 @@ annotations:
   # (see issue #181 + docs/BLUEPRINT-AUTHORING.md §11.1).
   catalyst.openova.io/no-upstream: "true"
   catalyst.openova.io/smoke-render-mode: "default-off"
+# 0.3.6 (TBD-V22 #1986 F1, 2026-05-20): expose a configurable PTY-stdout
+# replay ring buffer (default 1 MiB, up from a hardcoded 256 KiB
+# literal). Adds two new env vars: on the sandbox-controller Deployment
+# (SANDBOX_RING_BUFFER_BYTES, sourced from values
+# `runtime.ringBufferBytes`) and on every per-Sandbox pty-server
+# StatefulSet (same name, threaded by the controller via
+# gitops.Inputs.RingBufferBytes). The pty-server's session package now
+# exposes DefaultRingBytes + LoadDefaultRingBytesFromEnv + a 16 MiB
+# MaxRingBytes ceiling (operator-misconfiguration safety; clamped +
+# logged). Closes Pillar-4 audit finding F1: the documented multi-
+# device "close laptop, open phone" replay claim
+# (products/sandbox/docs/user-journey.md Scene 6) was unbacked at
+# 256 KiB because a real Plan-mode / file-listing / multi-turn agent
+# session rolls the buffer in well under a minute. Memory-budget
+# reasoning: 16 MiB × 10 concurrent PTY sessions = 160 MiB worst-case,
+# well under typical Sandbox Pod memory limits. No CRD changes;
+# additive only, no breaking changes to existing operator overlays.
+# Bootstrap-kit pin lockstep at
+# clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml 0.3.5 → 0.3.6.
+# Rebased on top of PR #2052 (0.3.5 A4 dispatch).
+#
 # 0.3.5 (TBD-P4 A4 #1986, 2026-05-20): controller now dispatches per
 # Sandbox.spec.agentCatalogue[0]. The pty-server StatefulSet renders
 # SANDBOX_DEFAULT_AGENT into the container env so pty-server's
@@ -98,8 +119,8 @@ annotations:
 # `helm template newapi platform/newapi/chart/ -s templates/service.yaml`
 # → metadata.name: newapi-bp-newapi. Walker on t38 (chart 1.4.216,
 # substrate be4f78bc872e2c56) caught the live regression.
-version: 0.3.5
-appVersion: "0.3.5"
+version: 0.3.6
+appVersion: "0.3.6"
 keywords:
   - catalyst
   - sandbox

--- a/platform/sandbox/chart/templates/deployment.yaml
+++ b/platform/sandbox/chart/templates/deployment.yaml
@@ -89,6 +89,14 @@ spec:
               value: {{ .Values.runtime.byosSecretPrefix | default "sandbox-byos-claude-code" | quote }}
             - name: SANDBOX_IDLE_TIMEOUT_MINUTES
               value: {{ .Values.runtime.idleTimeoutMinutes | default 30 | quote }}
+            # TBD-V22 #1986 F1 (2026-05-20) — per-PTY replay ring buffer
+            # size. Default 1 MiB (1048576). The controller reads this
+            # env var and stamps it into the per-Sandbox pty-server
+            # StatefulSet via gitops.Inputs.RingBufferBytes →
+            # SANDBOX_RING_BUFFER_BYTES on the pty-server Pod. See
+            # session.LoadDefaultRingBytesFromEnv in pty-server.
+            - name: SANDBOX_RING_BUFFER_BYTES
+              value: {{ .Values.runtime.ringBufferBytes | default 1048576 | int | quote }}
             # Wave 9 — NewAPI bridge wiring. The controller calls
             # POST /admin/tokens/sandbox to mint per-Sandbox HS256
             # bearers; without these two env vars wired the controller

--- a/platform/sandbox/chart/values.yaml
+++ b/platform/sandbox/chart/values.yaml
@@ -93,6 +93,20 @@ runtime:
   byosSecretPrefix: "sandbox-byos-claude-code"
   # Idle timeout (minutes) — architecture.md §7.
   idleTimeoutMinutes: 30
+  # TBD-V22 #1986 F1 (2026-05-20) — per-PTY replay ring buffer size in
+  # BYTES. The pty-server retains the trailing tail of PTY stdout so a
+  # newly-attaching client (the canonical "close laptop, open phone"
+  # multi-device handoff path in user-journey.md Scene 6) replays a
+  # meaningful slice of the recent terminal context before joining the
+  # live stream. Pre-fix the size was a hardcoded 256 KiB literal in
+  # pty-server (no upstream knob), which on a real coding-agent session
+  # rolled in well under a minute — the multi-device replay claim was
+  # unbacked. New default is 1 MiB; pty-server clamps operator-set
+  # values above 16 MiB (MaxRingBytes) and logs the clamp. Zero / unset
+  # leaves the pty-server's own session.DefaultRingBytes intact (also
+  # 1 MiB) — both layers default to the same value so there is no
+  # silent skew between operator-not-set and operator-set-to-default.
+  ringBufferBytes: 1048576
 # Secret holding the Gitea PAT the controller authenticates with.
 # Defaults to the same Secret organization-controller uses
 # (catalyst-gitea-token / key=token) — single source of truth per

--- a/products/sandbox/docs/architecture.md
+++ b/products/sandbox/docs/architecture.md
@@ -26,7 +26,7 @@ The `claude` (or `cursor-agent`, `qwen-code`, `aider`, `opencode`) **binary itse
 │   ├─ ANSI renderer (canvas/DOM)  │  WS   │   ├─ opens a PTY                         │
 │   ├─ keyboard -> bytes ──────────┼──────►│   ├─ writes WS frames to PTY stdin       │
 │   ├─ scrollback buffer           │◄──────┤   ├─ reads PTY stdout, fans out to WS    │
-│   └─ resize events               │       │   ├─ ring buffer (256 KB) for replay     │
+│   └─ resize events               │       │   ├─ ring buffer (1 MiB default) for replay│
 │                                  │       │   └─ SIGWINCH on browser resize          │
 └──────────────────────────────────┘       │              │                           │
                                            │              ▼ spawns once per session   │

--- a/products/sandbox/docs/user-journey.md
+++ b/products/sandbox/docs/user-journey.md
@@ -216,7 +216,7 @@ Per-Org admins see the same UI, scoped to one Org. The RBAC is the same model al
 | Action | Surface |
 |---|---|
 | Same session open in two tabs | Both tabs receive the same PTY byte stream; either tab can type; that is by design. |
-| Close laptop, open phone | New WebSocket to the same `session_id`; the pty-server replays its ring buffer (~256 KB) on connect, then streams live. |
+| Close laptop, open phone | New WebSocket to the same `session_id`; the pty-server replays its ring buffer (default 1 MiB, operator-configurable via `SANDBOX_RING_BUFFER_BYTES` up to a 16 MiB ceiling — TBD-V22 #1986 F1) on connect, then streams live. |
 | Pod restart (rare) | PTY dies. Agent restarts via `<agent> --continue` (each agent has an equivalent flag). Conversation history in `~/.claude/projects/...` or equivalent is preserved; in-flight tool call may be lost. |
 | Same session on watch-style device | Card protocol view only — no terminal. Read-only by default, opt-in to a single-line input. |
 

--- a/products/sandbox/pty-server/cmd/pty-server/main.go
+++ b/products/sandbox/pty-server/cmd/pty-server/main.go
@@ -26,6 +26,18 @@ func main() {
 		addr = ":7681"
 	}
 
+	// TBD-V22 (#1986 F1, 2026-05-20) — apply SANDBOX_RING_BUFFER_BYTES
+	// override before any Session.New runs. Empty / non-integer leaves
+	// the package default (1 MiB) intact. Values above session.MaxRingBytes
+	// are clamped and the clamp is logged so an operator-misconfigured
+	// excessive value surfaces visibly instead of silently consuming Pod
+	// memory.
+	ringBytes, clamped := session.LoadDefaultRingBytesFromEnv()
+	if clamped {
+		log.Printf("pty-server: SANDBOX_RING_BUFFER_BYTES clamped to MaxRingBytes (%d) — operator-set value above the ceiling", session.MaxRingBytes)
+	}
+	log.Printf("pty-server: replay ring buffer default = %d bytes (~%d KiB)", ringBytes, ringBytes/1024)
+
 	mgr := session.NewManager()
 	h := server.New(mgr)
 

--- a/products/sandbox/pty-server/internal/server/routes.go
+++ b/products/sandbox/pty-server/internal/server/routes.go
@@ -172,6 +172,12 @@ type createRequest struct {
 	Cwd  string `json:"cwd,omitempty"`
 	Rows uint16 `json:"rows,omitempty"`
 	Cols uint16 `json:"cols,omitempty"`
+
+	// RingBytes overrides the per-session replay-buffer size (bytes).
+	// Zero ⇒ pty-server process default (session.DefaultRingBytes, set
+	// at startup from SANDBOX_RING_BUFFER_BYTES). Operator escape hatch;
+	// the FE default-paint path never sets this. TBD-V22 #1986 F1.
+	RingBytes int `json:"ringBytes,omitempty"`
 }
 
 type sessionDTO struct {
@@ -260,11 +266,12 @@ func buildSpecFromCreateRequest(req createRequest) (session.Spec, int, map[strin
 	}
 
 	return session.Spec{
-		Command: argv,
-		Env:     envSlice,
-		Cwd:     cwd,
-		Rows:    req.Rows,
-		Cols:    req.Cols,
+		Command:   argv,
+		Env:       envSlice,
+		Cwd:       cwd,
+		Rows:      req.Rows,
+		Cols:      req.Cols,
+		RingBytes: req.RingBytes,
 	}, 0, nil
 }
 

--- a/products/sandbox/pty-server/internal/session/buffer.go
+++ b/products/sandbox/pty-server/internal/session/buffer.go
@@ -4,10 +4,19 @@
 // any number of concurrent WebSocket subscribers (browser tabs, mobile
 // card-mode clients).
 //
-// The ring buffer here keeps the last 256 KiB of PTY output so a newly
-// attaching client can replay the recent screen before joining the
-// live stream — see architecture.md §1 "ring buffer (256 KB) for
-// replay" and §2 "Replay last N KB on reconnect".
+// The ring buffer here keeps the trailing tail of PTY output so a
+// newly attaching client can replay the recent terminal context
+// before joining the live stream — see architecture.md §1 "ring
+// buffer for replay" and §2 "Replay last N KB on reconnect" and the
+// canonical "close laptop, open phone" multi-device handoff path in
+// user-journey.md Scene 6.
+//
+// Default capacity is [DefaultRingBytes] (1 MiB); operators may
+// override via SANDBOX_RING_BUFFER_BYTES at pty-server startup. See
+// session.go documentation for the rationale + memory-budget
+// reasoning. Pre-TBD-V22 (#1986 F1, 2026-05-20) the default was a
+// hardcoded 256 KiB literal which on a real agent session rolled
+// in well under a minute, defeating the multi-device replay claim.
 package session
 
 import "sync"
@@ -25,8 +34,10 @@ type RingBuffer struct {
 	pos  int // next write position
 }
 
-// NewRingBuffer returns a ring of the given capacity in bytes.
-// The default Sandbox session uses 256 KiB (262_144).
+// NewRingBuffer returns a ring of the given capacity in bytes. Use
+// [DefaultRingBytes] (1 MiB) for the canonical Sandbox session default;
+// callers that pass <= 0 get a 1-byte ring (preserves prior behaviour
+// and protects make([]byte, …) from a zero-or-negative size).
 func NewRingBuffer(capacity int) *RingBuffer {
 	if capacity <= 0 {
 		capacity = 1

--- a/products/sandbox/pty-server/internal/session/buffer_test.go
+++ b/products/sandbox/pty-server/internal/session/buffer_test.go
@@ -1,0 +1,137 @@
+// buffer_test.go — coverage for the replay ring buffer + the
+// SANDBOX_RING_BUFFER_BYTES env-driven default (TBD-V22 #1986 F1,
+// 2026-05-20). The Session lifecycle proper (PTY + child process)
+// needs /bin/sh + a TTY and is exercised end-to-end in integration
+// tests; this file isolates the ring + env-loader so they're
+// reachable from `go test` in any container.
+package session
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRingBuffer_WriteShortAndSnapshot(t *testing.T) {
+	t.Parallel()
+	r := NewRingBuffer(16)
+	n, err := r.Write([]byte("hello"))
+	if err != nil || n != 5 {
+		t.Fatalf("write short: n=%d err=%v", n, err)
+	}
+	if got := r.Len(); got != 5 {
+		t.Fatalf("len after short write: got %d want 5", got)
+	}
+	if got := r.Snapshot(); !bytes.Equal(got, []byte("hello")) {
+		t.Fatalf("snapshot short: got %q", got)
+	}
+}
+
+func TestRingBuffer_WrapPreservesChronologicalOrder(t *testing.T) {
+	t.Parallel()
+	r := NewRingBuffer(8)
+	// Write 13 bytes into an 8-byte ring — last 8 must survive in
+	// chronological order.
+	r.Write([]byte("ABCDEFGHIJKLM"))
+	if got := r.Len(); got != 8 {
+		t.Fatalf("len after wrap: got %d want 8", got)
+	}
+	want := []byte("FGHIJKLM")
+	if got := r.Snapshot(); !bytes.Equal(got, want) {
+		t.Fatalf("snapshot after wrap: got %q want %q", got, want)
+	}
+}
+
+func TestRingBuffer_RejectsZeroCapacity(t *testing.T) {
+	t.Parallel()
+	// NewRingBuffer(<=0) must NOT panic on make([]byte, n) — it
+	// promotes to capacity 1 so the ring is at least usable for a
+	// degenerate single-byte stream.
+	r := NewRingBuffer(0)
+	if r == nil {
+		t.Fatal("NewRingBuffer(0) returned nil")
+	}
+	r.Write([]byte("xyz"))
+	if got := r.Len(); got != 1 {
+		t.Fatalf("zero-cap promoted len: got %d want 1", got)
+	}
+	if got := r.Snapshot(); !bytes.Equal(got, []byte("z")) {
+		t.Fatalf("zero-cap promoted snapshot: got %q want %q", got, "z")
+	}
+}
+
+func TestDefaultRingBytes_OneMiB(t *testing.T) {
+	// Pre-TBD-V22 the default was 256 KiB which on a real agent
+	// session rolled in well under a minute. The new default is
+	// 1 MiB — large enough to cover several minutes of typical
+	// agent output, small enough to be trivial against per-Pod
+	// memory budgets. This test is a guardrail against an accidental
+	// downward revert.
+	if DefaultRingBytes != 1<<20 {
+		t.Fatalf("DefaultRingBytes: got %d want %d (1 MiB)", DefaultRingBytes, 1<<20)
+	}
+}
+
+func TestLoadDefaultRingBytesFromEnv_Unset(t *testing.T) {
+	t.Setenv("SANDBOX_RING_BUFFER_BYTES", "")
+	// Reset to known-good before the test so a prior parallel test
+	// hasn't moved DefaultRingBytes.
+	prev := DefaultRingBytes
+	DefaultRingBytes = 1 << 20
+	t.Cleanup(func() { DefaultRingBytes = prev })
+
+	got, clamped := LoadDefaultRingBytesFromEnv()
+	if got != 1<<20 || clamped {
+		t.Fatalf("unset env: got (%d,%v) want (%d,false)", got, clamped, 1<<20)
+	}
+}
+
+func TestLoadDefaultRingBytesFromEnv_HonorsValidValue(t *testing.T) {
+	prev := DefaultRingBytes
+	t.Cleanup(func() { DefaultRingBytes = prev })
+
+	t.Setenv("SANDBOX_RING_BUFFER_BYTES", "524288")
+	got, clamped := LoadDefaultRingBytesFromEnv()
+	if got != 524288 || clamped {
+		t.Fatalf("valid env: got (%d,%v) want (524288,false)", got, clamped)
+	}
+	if DefaultRingBytes != 524288 {
+		t.Fatalf("DefaultRingBytes after env: got %d want 524288", DefaultRingBytes)
+	}
+}
+
+func TestLoadDefaultRingBytesFromEnv_ClampsAboveCeiling(t *testing.T) {
+	prev := DefaultRingBytes
+	t.Cleanup(func() { DefaultRingBytes = prev })
+
+	t.Setenv("SANDBOX_RING_BUFFER_BYTES", "999999999") // ~1 GiB
+	got, clamped := LoadDefaultRingBytesFromEnv()
+	if got != MaxRingBytes || !clamped {
+		t.Fatalf("ceiling clamp: got (%d,%v) want (%d,true)", got, clamped, MaxRingBytes)
+	}
+	if DefaultRingBytes != MaxRingBytes {
+		t.Fatalf("DefaultRingBytes after clamp: got %d want %d", DefaultRingBytes, MaxRingBytes)
+	}
+}
+
+func TestLoadDefaultRingBytesFromEnv_RejectsGarbage(t *testing.T) {
+	prev := DefaultRingBytes
+	DefaultRingBytes = 1 << 20
+	t.Cleanup(func() { DefaultRingBytes = prev })
+
+	for _, raw := range []string{"abc", "-100", "0", " "} {
+		t.Run(strings.ReplaceAll(raw, " ", "_space_"), func(t *testing.T) {
+			t.Setenv("SANDBOX_RING_BUFFER_BYTES", raw)
+			got, clamped := LoadDefaultRingBytesFromEnv()
+			if got != 1<<20 || clamped {
+				t.Fatalf("garbage %q: got (%d,%v) want (%d,false)", raw, got, clamped, 1<<20)
+			}
+		})
+	}
+}
+
+func TestMaxRingBytes_SixteenMiB(t *testing.T) {
+	if MaxRingBytes != 16<<20 {
+		t.Fatalf("MaxRingBytes: got %d want %d (16 MiB)", MaxRingBytes, 16<<20)
+	}
+}

--- a/products/sandbox/pty-server/internal/session/session.go
+++ b/products/sandbox/pty-server/internal/session/session.go
@@ -5,12 +5,73 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	"github.com/creack/pty"
 )
+
+// DefaultRingBytes is the per-session replay-buffer capacity used when a
+// caller leaves [Spec.RingBytes] zero. The default is sized so a freshly-
+// attaching client (the canonical "close laptop, open phone" multi-device
+// handoff path documented in products/sandbox/docs/user-journey.md
+// Scene 6) replays a meaningful slice of the recent terminal context
+// rather than just the last screen.
+//
+// History: pre-TBD-V22 (#1986 F1, 2026-05-20) this was a hardcoded
+// 256 KiB literal, which on a real Plan-mode / file-listing / multi-turn
+// agent session rolls in well under a minute — the multi-device replay
+// claim in user-journey.md was unbacked. The default is now 1 MiB
+// (1_048_576) — enough for several minutes of typical agent output, and
+// trivially small against the per-Sandbox pty-server Pod memory budget
+// (one ring per live PTY; ten concurrent sessions consume 10 MiB).
+//
+// Operators may override via the SANDBOX_RING_BUFFER_BYTES env var read
+// in [LoadDefaultRingBytesFromEnv] at pty-server startup. The package
+// also exposes the package-level variable directly so tests can set it
+// without going through env. The HARD upper bound (16 MiB) exists to
+// stop a misconfigured operator from making a single ring dominate the
+// pty-server Pod's memory; values above the bound are clamped + logged
+// (see [LoadDefaultRingBytesFromEnv]).
+var DefaultRingBytes = 1 << 20 // 1 MiB
+
+// MaxRingBytes is the hard ceiling enforced by [LoadDefaultRingBytesFromEnv].
+// Per-Pod memory budget rationale: at 16 MiB × 10 concurrent sessions = 160
+// MiB worst-case, still well under typical Sandbox Pod memory limits
+// (architecture.md §1 sizing). Operators wanting larger replay windows
+// should instead persist conversation history via the agent's own
+// `--continue` flag (user-journey.md Scene 6 "Pod restart" row), not
+// inflate the in-memory ring.
+const MaxRingBytes = 16 << 20 // 16 MiB
+
+// LoadDefaultRingBytesFromEnv reads SANDBOX_RING_BUFFER_BYTES and, when
+// set to a positive integer, updates [DefaultRingBytes]. Empty / non-
+// integer / non-positive values leave the default unchanged. Values
+// above [MaxRingBytes] are clamped (and the clamp is announced to the
+// caller via the returned (effective, clamped) tuple so the pty-server
+// can log the decision at startup).
+//
+// Called once from cmd/pty-server/main.go on process start; safe to
+// call again from tests via t.Setenv + this function.
+func LoadDefaultRingBytesFromEnv() (effective int, clamped bool) {
+	raw := strings.TrimSpace(os.Getenv("SANDBOX_RING_BUFFER_BYTES"))
+	if raw == "" {
+		return DefaultRingBytes, false
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return DefaultRingBytes, false
+	}
+	if n > MaxRingBytes {
+		DefaultRingBytes = MaxRingBytes
+		return MaxRingBytes, true
+	}
+	DefaultRingBytes = n
+	return n, false
+}
 
 // ErrClosed indicates the Session has already exited (graceful or
 // forced) and no further writes / signals / resizes will succeed.
@@ -64,7 +125,12 @@ type Spec struct {
 	// SIGWINCH-triggering Resize() calls once it knows its viewport.
 	Rows uint16
 	Cols uint16
-	// RingBytes is the replay buffer size; defaults to 256 KiB.
+	// RingBytes is the replay buffer size in bytes. Zero ⇒
+	// [DefaultRingBytes] (1 MiB, overridable via
+	// SANDBOX_RING_BUFFER_BYTES at pty-server startup). The buffer
+	// holds the trailing tail of PTY stdout for replay on new client
+	// attach — see products/sandbox/docs/user-journey.md Scene 6
+	// "Mobile handoff".
 	RingBytes int
 }
 
@@ -82,7 +148,7 @@ func New(id string, spec Spec) (*Session, error) {
 		spec.Cols = 80
 	}
 	if spec.RingBytes == 0 {
-		spec.RingBytes = 256 * 1024
+		spec.RingBytes = DefaultRingBytes
 	}
 
 	cmd := exec.Command(spec.Command[0], spec.Command[1:]...)


### PR DESCRIPTION
## Summary

Pillar-4 audit finding **F1** (`/tmp/audit-pillar4-deep-wiring-2026-05-20.md` Surface F): the pty-server PTY-stdout replay buffer was a hardcoded 256 KiB literal in `products/sandbox/pty-server/internal/session/session.go:84-86` with no upstream knob. The documented multi-device "close laptop, open phone" handoff (`products/sandbox/docs/user-journey.md` Scene 6) is unbacked at that size — a real Plan-mode / file-listing / multi-turn agent session produces 50-500 KiB per minute, so the buffer rolls in well under a minute on every non-trivial session.

## Decision

**UNDERSIZED-FOR-CLAIM** (mild). New default = **1 MiB**, fully operator-configurable via `SANDBOX_RING_BUFFER_BYTES`, hard ceiling of **16 MiB** (`session.MaxRingBytes`) with clamp + log to catch operator misconfiguration.

## Files

**pty-server:**
- `internal/session/session.go` — `DefaultRingBytes` (1 MiB), `MaxRingBytes` (16 MiB), `LoadDefaultRingBytesFromEnv` helper
- `internal/session/buffer.go` — updated doc comments
- `cmd/pty-server/main.go` — calls env loader at startup
- `internal/server/routes.go` — `createRequest.ringBytes` operator escape hatch
- `internal/session/buffer_test.go` *(new)* — 9 unit tests

**sandbox-controller:**
- `internal/gitops/manifests.go` — `Inputs.RingBufferBytes` + StatefulSet template emits `SANDBOX_RING_BUFFER_BYTES` only when non-zero
- `internal/controller/sandbox_controller.go` — `Reconciler.RingBufferBytes` wired
- `internal/controller/sandbox_controller_test.go` — 2 new tests
- `cmd/sandbox-controller/main.go` — reads `SANDBOX_RING_BUFFER_BYTES`

**Chart + bootstrap-kit:**
- `platform/sandbox/chart/values.yaml` — `runtime.ringBufferBytes: 1048576`
- `platform/sandbox/chart/templates/deployment.yaml` — emits env var
- `platform/sandbox/chart/Chart.yaml` — 0.3.4 → **0.3.5**
- `clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml` — pin 0.3.4 → **0.3.5** (lockstep)

**Docs:**
- `products/sandbox/docs/user-journey.md` Scene 6
- `products/sandbox/docs/architecture.md` §1 diagram

## Memory-budget reasoning

16 MiB × 10 concurrent PTY sessions = 160 MiB worst-case per pty-server Pod, well under typical Sandbox Pod memory limits. The hard ceiling exists to catch a misconfigured operator setting wildly oversized values.

## Validation

- `go test ./products/sandbox/pty-server/...` **PASSES**
- `go test ./core/controllers/sandbox/...` **PASSES** (incl. 2 new RingBufferBytes tests)
- `go vet ./core/controllers/sandbox/...` **clean**
- `helm template` confirms `SANDBOX_RING_BUFFER_BYTES = "1048576"` default + `"4194304"` overlay override
- Did NOT use `kubectl --dry-run=server` (principle #15)
- Fresh clone per principle #12

## Test plan

- [ ] CI green (unit + helm-template)
- [ ] On t39 fresh prov: confirm pty-server Pod has `SANDBOX_RING_BUFFER_BYTES=1048576`
- [ ] Operator walk Scene 6: open session → produce 500 KB of output → reattach → confirm the FULL session replays

## Out of scope

This PR addresses **F1 only**. Other Pillar-4 audit findings (A1, B1, B2, C1, D1, D2, E2, F2) remain tracked on **#1986**.

Refs #1986