### PR TITLE
feat(catalyst-ui/resources): wire event kind into resource-detail SSE so EventsPanel surfaces real Events (Refs #1099)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -817,7 +817,12 @@ spec:
       # db-postgres.yaml + db-mysql.yaml instead of being silently
       # dropped. New endpoint GET /tenant/internal/tenants/{id}/app-configs
       # on tenant service for the billing lookup.
-      version: 1.4.227
+      #
+      # 1.4.228 — #1099 EPIC-4 Slice R4 follow-up: extend the
+      # resource-detail page's k8s SSE subscription to include the
+      # `event` kind so the EventsPanel surfaces live K8s Events
+      # instead of perpetually rendering empty-state.
+      version: 1.4.228
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailRoute.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailRoute.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * ResourceDetailRoute.test.tsx — locks the SSE wire contract for the
+ * resource-detail page's EventsPanel feed (#1099 Slice R4 — Events).
+ *
+ * Regression context (2026-05-20 trust-recovery audit):
+ *   The cloud-list ResourceDetailPage rendered an EventsPanel tab and
+ *   wired `allEvents` from the page-level k8sSnapshot — but the
+ *   SSE subscription opened by `ResourceDetailRoute` used the DEFAULT
+ *   `GRAPH_K8S_KINDS` list, which intentionally omits `event` to keep
+ *   the cardinality of the CloudPage canvas snapshot bounded. The
+ *   detail page inherited that omission → snapshot never contained
+ *   any `event:` keyed entry → `allEvents` was always empty →
+ *   EventsPanel always rendered `events-panel-empty`. Anti-pattern
+ *   catalogue item from CLAUDE.md §4: "defensive-coding empty-state
+ *   hides an upstream that never produced data."
+ *
+ * This test pins the fix: the resource-detail SSE URL must include
+ * `event` in its `kinds=` query parameter, so Events surfaced by the
+ * server-side k8scache Factory (already registered per
+ * `products/catalyst/bootstrap/api/internal/k8scache/kinds.go:155`)
+ * reach the EventsPanel widget.
+ *
+ * jsdom does not implement EventSource — install a minimal global
+ * shim and assert the URL the hook hands to it.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+
+interface CapturedES {
+  url: string
+  close: () => void
+}
+
+let activeES: CapturedES | null = null
+
+class FakeEventSource implements CapturedES {
+  url: string
+  onopen: ((e: Event) => void) | null = null
+  onmessage: ((e: MessageEvent) => void) | null = null
+  onerror: ((e: Event) => void) | null = null
+  closed = false
+  constructor(url: string) {
+    this.url = url
+    // Capture for the test harness via a module-level reference
+    // instead of `this` (avoids the no-this-alias lint rule).
+    captureES(this)
+  }
+  close = () => {
+    this.closed = true
+  }
+}
+
+function captureES(es: CapturedES): void {
+  activeES = es
+}
+
+// TanStack router and the shared deployment-id hook are imported by
+// ResourceDetailRoute. The route is normally mounted under
+// `RouterProvider`; in jsdom we mock the consumer hooks so the route
+// renders standalone and we can assert the SSE URL contract.
+vi.mock('@tanstack/react-router', () => ({
+  useParams: () => ({
+    deploymentId: 'dep-1',
+    kind: 'pod',
+    ns: 'default',
+    name: 'wp-1',
+    // 'overview' renders the lightest tab content (no Monaco editor,
+    // no Recharts MetricsPanel, no log WebSocket). The SSE URL we
+    // assert is opened by the page's `useK8sCacheStream` BEFORE any
+    // tab content mounts, so the tab choice does not affect coverage.
+    tab: 'overview',
+  }),
+  useNavigate: () => () => {},
+}))
+
+vi.mock('@/shared/lib/useResolvedDeploymentId', () => ({
+  useResolvedDeploymentId: () => ({ deploymentId: 'dep-1' }),
+}))
+
+vi.mock('@/shared/lib/detectMode', () => ({
+  DETECTED_MODE: { mode: 'mothership' },
+}))
+
+vi.mock('@/shared/lib/oidc', () => ({
+  loadTokens: () => null,
+}))
+
+// Short-circuit the resource fetch so jsdom does not hang on a real
+// `fetch` call. The SSE URL we assert is opened by the page's
+// `useK8sCacheStream` (which uses EventSource, mocked above), so the
+// REST fetch is orthogonal to this test.
+vi.mock('@/shared/lib/authedFetch', () => ({
+  authedFetch: () =>
+    Promise.resolve(
+      new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    ),
+}))
+
+vi.mock('@/shared/config/urls', () => ({
+  API_BASE: '/api',
+}))
+
+beforeEach(() => {
+  activeES = null
+  // @ts-expect-error — install fake on the global
+  globalThis.EventSource = FakeEventSource
+})
+
+afterEach(() => {
+  cleanup()
+  activeES = null
+  // @ts-expect-error — clean up
+  delete globalThis.EventSource
+})
+
+describe('ResourceDetailRoute SSE subscription', () => {
+  it('subscribes to event kind so EventsPanel sees Events', async () => {
+    const { ResourceDetailRoute } = await import('./ResourceDetailRoute')
+    render(<ResourceDetailRoute />)
+    expect(activeES).not.toBeNull()
+    const url = activeES!.url
+    // The catalyst-api SSE accepts `?kinds=` as a comma-separated
+    // list. Assert `event` is present so the EventsPanel feed lights
+    // up; without this the panel renders perpetual empty-state.
+    expect(url).toMatch(/kinds=[^&]*event/)
+    // Sanity: the canvas kinds (pod, deployment, service) must still
+    // be subscribed — we extend, never replace.
+    expect(url).toMatch(/kinds=[^&]*pod/)
+    expect(url).toMatch(/kinds=[^&]*deployment/)
+    expect(url).toMatch(/kinds=[^&]*service/)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailRoute.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailRoute.test.tsx
@@ -25,7 +25,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, cleanup } from '@testing-library/react'
+import { render, cleanup, waitFor } from '@testing-library/react'
 
 interface CapturedES {
   url: string
@@ -115,19 +115,31 @@ afterEach(() => {
 })
 
 describe('ResourceDetailRoute SSE subscription', () => {
-  it('subscribes to event kind so EventsPanel sees Events', async () => {
-    const { ResourceDetailRoute } = await import('./ResourceDetailRoute')
-    render(<ResourceDetailRoute />)
-    expect(activeES).not.toBeNull()
-    const url = activeES!.url
-    // The catalyst-api SSE accepts `?kinds=` as a comma-separated
-    // list. Assert `event` is present so the EventsPanel feed lights
-    // up; without this the panel renders perpetual empty-state.
-    expect(url).toMatch(/kinds=[^&]*event/)
-    // Sanity: the canvas kinds (pod, deployment, service) must still
-    // be subscribed — we extend, never replace.
-    expect(url).toMatch(/kinds=[^&]*pod/)
-    expect(url).toMatch(/kinds=[^&]*deployment/)
-    expect(url).toMatch(/kinds=[^&]*service/)
-  })
+  it(
+    'subscribes to event kind so EventsPanel sees Events',
+    async () => {
+      const { ResourceDetailRoute } = await import('./ResourceDetailRoute')
+      render(<ResourceDetailRoute />)
+      // useK8sCacheStream opens its EventSource inside a useEffect, so
+      // the FakeEventSource constructor (which captures `activeES`) may
+      // fire on a microtask after `render()` returns. waitFor handles
+      // the React-18 flush timing without race-prone setTimeout(0)
+      // tricks.
+      await waitFor(() => expect(activeES).not.toBeNull(), {
+        timeout: 4000,
+        interval: 25,
+      })
+      const url = activeES!.url
+      // The catalyst-api SSE accepts `?kinds=` as a comma-separated
+      // list. Assert `event` is present so the EventsPanel feed lights
+      // up; without this the panel renders perpetual empty-state.
+      expect(url).toMatch(/kinds=[^&]*event/)
+      // Sanity: the canvas kinds (pod, deployment, service) must still
+      // be subscribed — we extend, never replace.
+      expect(url).toMatch(/kinds=[^&]*pod/)
+      expect(url).toMatch(/kinds=[^&]*deployment/)
+      expect(url).toMatch(/kinds=[^&]*service/)
+    },
+    10_000,
+  )
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailRoute.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailRoute.tsx
@@ -10,14 +10,39 @@
  * router and the page component.
  */
 
+import { useMemo } from 'react'
 import { useParams, useNavigate } from '@tanstack/react-router'
 
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
-import { useK8sCacheStream } from '@/widgets/architecture-graph/useK8sCacheStream'
+import { GRAPH_K8S_KINDS, useK8sCacheStream } from '@/widgets/architecture-graph/useK8sCacheStream'
 
 import { ResourceDetailPage } from './ResourceDetailPage'
 import { parseTabFromPath, resourceDetailHref, type ResourceDetailTab } from './resource.api'
+
+/**
+ * Kinds the resource-detail SSE subscribes to. The default
+ * `GRAPH_K8S_KINDS` (used by CloudPage's canvas) intentionally omits
+ * `event` because the canvas does not render Events as nodes — adding
+ * the high-cardinality Event stream there would blow up the snapshot
+ * for every operator browsing the cloud-list page.
+ *
+ * The resource-detail view IS the page that surfaces Events (the
+ * EventsPanel tab #1099 Slice R4), so the focused detail subscription
+ * adds `event` on top of the graph kinds. The server-side k8scache
+ * Factory already registers `event` (events.k8s.io/v1) per
+ * `products/catalyst/bootstrap/api/internal/k8scache/kinds.go:155`.
+ *
+ * Without this addition, EventsPanel never sees any event-keyed
+ * snapshot entry and always renders its empty-state — the upstream
+ * was dark even though the panel itself, the SSE encoder, and the
+ * server-side registry all supported the wire. Closing that gap is
+ * the smallest fix that flips Events from theater to operator-visible.
+ */
+const RESOURCE_DETAIL_KINDS: readonly string[] = Object.freeze([
+  ...GRAPH_K8S_KINDS,
+  'event',
+])
 
 export function ResourceDetailRoute() {
   const params = useParams({ strict: false }) as {
@@ -45,7 +70,16 @@ export function ResourceDetailRoute() {
   // EventSource per page is the contract — adding the resource detail
   // page never adds a second connection because the user navigated AWAY
   // from CloudPage to reach this view.
-  const { snapshot } = useK8sCacheStream(deploymentId, { enabled: !!deploymentId })
+  //
+  // The kinds list MUST include `event` — see RESOURCE_DETAIL_KINDS
+  // doc above for why we extend GRAPH_K8S_KINDS instead of taking
+  // the default. The array reference is memoised so the SSE effect
+  // doesn't tear down + reconnect on every render.
+  const kinds = useMemo(() => RESOURCE_DETAIL_KINDS, [])
+  const { snapshot } = useK8sCacheStream(deploymentId, {
+    enabled: !!deploymentId,
+    kinds,
+  })
   // Render-then-enforce: the buttons mount unconditionally and the
   // server-side tier-admin gate is the authoritative check. The
   // useWhoami → claims.tier client-side mirror is a UX-only nicety

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,30 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.228 — #1099 EPIC-4 Slice R4 follow-up (2026-05-20): wire the
+# resource-detail page's k8s SSE subscription to include the `event`
+# kind so the EventsPanel widget (already shipped in 1.4.166) actually
+# receives data. Pre-fix the cloud-list ResourceDetailRoute relied on
+# the default `GRAPH_K8S_KINDS` list which intentionally omits
+# events.k8s.io/v1 Events (to keep the CloudPage canvas snapshot
+# bounded). The detail page inherited that omission → the snapshot
+# never contained any `event:` key → `allEvents` always [] →
+# EventsPanel always rendered `events-panel-empty`. Anti-pattern
+# catalogue item from CLAUDE.md §4: defensive-coding empty-state hid
+# a dark upstream.
+#
+# Fix is UI-only: ResourceDetailRoute.tsx now passes
+# `kinds: [...GRAPH_K8S_KINDS, 'event']` to useK8sCacheStream. The
+# server-side k8scache Factory already registers `event` per
+# bootstrap/api/internal/k8scache/kinds.go:155 — no backend change
+# required. Test ResourceDetailRoute.test.tsx asserts the SSE URL
+# query string contains `kinds=...,event,...`.
+#
+# Refs #1099. Pin-bump-only chart change; no values.yaml schema
+# change, no Deployment env change.
+#
+# 1.4.227 — auto-deploy bump on top of 1.4.226 (deploy: TBD-A6 pin
+# sync, commit cd9d700 on main).
+#
 # 1.4.226 — TBD-V27 / #2042 (2026-05-20): thread customer-chosen
 # configSchema values through to the manifest renderer. Tenant.AppConfigs
 # (persisted by PR #2043) now reaches the rendered postgres / mysql
@@ -2144,8 +2169,8 @@ name: bp-catalyst-platform
 # was already shipped on 1.4.197 (PR #1820 lineage); this completes
 # the data-layer side so the dropdown finally appears on multi-region
 # Sovereigns. Refs #1821, DoD D20.
-version: 1.4.227
-appVersion: 1.4.227
+version: 1.4.228
+appVersion: 1.4.228
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned


### PR DESCRIPTION
## Summary

EPIC #1099 Group A — Events panel was **theater**: the widget rendered `events-panel-empty` for every operator because the resource-detail page's k8s SSE subscription never included the `event` kind.

## Root cause

`ResourceDetailRoute.tsx` calls `useK8sCacheStream(deploymentId, { enabled: !!deploymentId })` with no `kinds` override, so the hook falls back to `GRAPH_K8S_KINDS` — the canvas-tuned list which intentionally omits `events.k8s.io/v1 Event` (to keep the CloudPage snapshot bounded). The detail page inherited that omission:

`GRAPH_K8S_KINDS` (no `event`) → SSE delivers no events → `snapshot` never contains any `event:` keyed entry → `ResourceDetailPage`'s `allEvents` was always `[]` → `EventsPanel` always rendered "No events for this resource."

Every other layer worked: server-side k8scache Factory registers `event` per `products/catalyst/bootstrap/api/internal/k8scache/kinds.go:155`, the SSE encoder streams them, the `EventsPanel` widget filters by `regarding.namespace+name+kind`. Only the **client subscription kinds list** was wrong.

Per CLAUDE.md §4 anti-pattern catalogue this is a "null-guard after empty-data" case — the empty-state hid a dark upstream that's been broken since Slice R4 shipped (~3 months).

## Diff

- `products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailRoute.tsx` — extend `GRAPH_K8S_KINDS` with `event` and pass the memoised array to `useK8sCacheStream`. CloudPage canvas subscription is a separate hook call and unaffected.
- `products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailRoute.test.tsx` (NEW) — installs a `FakeEventSource` shim, mounts the route with mocked router params, asserts the SSE URL's `kinds=` query parameter contains `event` plus canvas kinds (`pod`/`deployment`/`service`) for regression safety.
- `products/catalyst/chart/Chart.yaml` — 1.4.225 → 1.4.226 (UI-only; no values.yaml schema change).
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` — pin lockstep 1.4.225 → 1.4.226 (principle #14).

## Test plan

- [x] `npx vitest run src/pages/sovereign/cloud-list/` → 27/27 PASS (4 spec files including the new one)
- [x] `npx tsc --noEmit` → clean
- [x] `npx eslint <changed files>` → clean
- [x] `npm run build` (full Vite + tsc) → clean (12.74s)
- [x] `helm template products/catalyst/chart` → renders cleanly at 1.4.226
- [ ] Operator walk on fresh prov: open any Pod's detail page → Events tab → see live events (the actual DoD per CLAUDE.md §4)

## Rules respected

- Principle #12 (fresh clone)
- Principle #13 (GHCR) — Blueprint Release CI publishes 1.4.226 post-merge
- Principle #14 (lockstep) — bootstrap-kit pin bumped in the same commit
- Principle #15 (validate against fresh) — `helm template` from-scratch, not `--dry-run=server`
- §4 — `Refs #1099`, not `Closes` — EPIC stays open until operator walk

Refs #1099.