### PR TITLE
docs(sandbox): align user-journey.md + architecture.md with TBD-V30 card-protocol deferral (Refs #2057, Refs #2058)

### DIFF
--- a/products/sandbox/docs/architecture.md
+++ b/products/sandbox/docs/architecture.md
@@ -2,7 +2,7 @@
 
 This is the technical contract. It documents:
 
-1. The two surfaces (native TUI in the browser; card protocol on mobile) and how they share one persistent process.
+1. The shipped surface (native agent TUI in xterm.js, same on desktop and mobile) and the persistent process it attaches to. A second card-protocol surface for phones is **deferred — see TBD-V30 [#2057](https://github.com/openova-io/openova/issues/2057)**.
 2. The `pty-server` shim — what it does, what tmux would have done wrong.
 3. The MCP server tool catalogue (`openova-sandbox-mcp`).
 4. The four knowledge layers (static / procedural / live / corpus).
@@ -42,11 +42,15 @@ The `claude` (or `cursor-agent`, `qwen-code`, `aider`, `opencode`) **binary itse
 
 We do **not** re-implement Claude Code. We do **not** translate its output. xterm.js renders ANSI; the agent writes ANSI; they meet by accident.
 
-### Mobile — card protocol on the same session
+### Mobile — same xterm surface today; card-protocol deferred
 
-xterm on a 5" screen is unreadable. The mobile PWA opens a second WebSocket to the same `session_id` with a `mode=cards` query parameter. The pty-server then runs an in-pod card-translator that parses agent output into structured cards (`text`, `tool-call`, `diff`, `bash`, `preview-link`) and ships them as a separate JSON stream over a parallel WebSocket frame channel. The same session, two surfaces.
+Today the mobile surface is the same xterm.js attach as desktop. The phone opens a WebSocket to `WS /sessions/{id}/attach`; the pty-server replays the ring buffer on connect and streams live thereafter. Multi-device coherence is real: closing a laptop tab and reopening the same `session_id` on a phone resumes the conversation with scrollback intact.
 
-Both surfaces observe the same persistent process. Closing a tab does not stop the agent.
+A card-protocol surface for small screens (the mobile PWA opens a parallel WS with `mode=cards`; the pty-server runs an in-pod card-translator that parses agent ANSI/Ink output into structured cards — `text`, `tool-call`, `diff`, `bash`, `preview-link`) was the architectural intent but is **deferred — see TBD-V30 [#2057](https://github.com/openova-io/openova/issues/2057)**. The blocker is real: agents emit Ink/TUI-rendered ANSI frames, not structured events, so the translator would have to reverse-engineer rendered frames per-agent and re-validate against every upstream agent release. Investigation memo `/tmp/investigate-f2-card-protocol-2026-05-20.md` (audit 2026-05-20) covers the scope (1500–2500 LOC, 3–5 PR chain) and the un-park criteria.
+
+The shipped route `WS /sessions/{id}/cards` is a stub today: it wraps the same raw byte stream as `/attach` in `{"type":"raw","bytes":...}` JSON frames, with no parsing (see `pty-server/internal/server/routes.go:461-506` and the in-source comment "A future card-translator replaces the body with parsed cards"). The endpoint is preserved as a future-extension hook; no client consumes it today.
+
+Both surfaces — the shipped xterm attach and the deferred card-protocol — observe the same persistent process. Closing a tab does not stop the agent.
 
 ---
 
@@ -58,7 +62,9 @@ pty-server  (per Sandbox pod, listens on :7681)
 │                                   return session_id, write to JetStream
 ├── WS   /sessions/{id}/attach      bidi: WS bytes ↔ PTY fd
 │                                   on connect, replay ring buffer
-├── WS   /sessions/{id}/cards       JSON cards (alt surface, mobile)
+├── WS   /sessions/{id}/cards       STUB — JSON-framed raw bytes today
+│                                   (full card-translator deferred,
+│                                    TBD-V30 #2057)
 ├── POST /sessions/{id}/resize      cols/rows -> SIGWINCH
 ├── POST /sessions/{id}/signal      INT / QUIT for user-driven aborts
 └── DELETE /sessions/{id}           graceful stop, then SIGKILL

--- a/products/sandbox/docs/user-journey.md
+++ b/products/sandbox/docs/user-journey.md
@@ -146,7 +146,7 @@ The URL works on phone, tablet, laptop — anywhere the user has a browser point
 
 ### Scene 6 — Mobile handoff
 
-The developer leaves the office, opens the Sandbox PWA on their phone, taps the same session. The session is in card-protocol mode on mobile (xterm on a 5" screen is unreadable; the card-stream view is a second client into the same persistent process). They type:
+The developer leaves the office, opens `console.<orgslug>.omani.homes/sandbox/<session-id>` on their phone, and re-attaches to the same session. Today this opens the same xterm surface as desktop — the pty-server replays its ring buffer (`SANDBOX_RING_BUFFER_BYTES`, 1 MiB default, 16 MiB ceiling — TBD-V22 #1986 F1) so the scrollback is intact, then streams live. Multi-device handoff via the persistent PTY is real and shipped; a phone-friendly card-stream render of the same session is **deferred — see TBD-V30 [#2057](https://github.com/openova-io/openova/issues/2057)**. They type (cramped on a 5" screen, but functional):
 
 ```
 > the buy page is missing tier selection. tiers should render as cards
@@ -218,7 +218,7 @@ Per-Org admins see the same UI, scoped to one Org. The RBAC is the same model al
 | Same session open in two tabs | Both tabs receive the same PTY byte stream; either tab can type; that is by design. |
 | Close laptop, open phone | New WebSocket to the same `session_id`; the pty-server replays its ring buffer (default 1 MiB, operator-configurable via `SANDBOX_RING_BUFFER_BYTES` up to a 16 MiB ceiling — TBD-V22 #1986 F1) on connect, then streams live. |
 | Pod restart (rare) | PTY dies. Agent restarts via `<agent> --continue` (each agent has an equivalent flag). Conversation history in `~/.claude/projects/...` or equivalent is preserved; in-flight tool call may be lost. |
-| Same session on watch-style device | Card protocol view only — no terminal. Read-only by default, opt-in to a single-line input. |
+| Same session on watch-style device | **Deferred — TBD-V30 [#2057](https://github.com/openova-io/openova/issues/2057).** The pty-server has a stub `WS /sessions/{id}/cards` route that currently returns the same raw byte stream framed as `{"type":"raw","bytes":...}` (no parsing); a card-translator that emits typed cards (`text` / `tool-call` / `diff` / `bash` / `preview-link`) and a watch-form-factor render are post-MVP. Today the only mobile surface is the same xterm via `/attach`. |
 
 The pty-server (described in [`architecture.md`](architecture.md)) is the only piece that makes this work. **No tmux.**
 


### PR DESCRIPTION
## Summary

Aligns the canonical Sandbox user-journey + architecture docs with the **TBD-V30 #2057** decision to defer the mobile card-protocol surface, and with the actual code state confirmed by the F2 deep-wiring investigation (`/tmp/investigate-f2-card-protocol-2026-05-20.md`, 2026-05-20).

Same docs-vs-code alignment pattern as **PR #2056** (TBD-V29 SPIRE removal): the docs were aspirational; the implementation never landed; this PR demotes the claims to match what ships, with forward-pointers to the parked roadmap issue.

## What ships today

| Layer | Doc claim (before) | Reality (verified) |
|---|---|---|
| Mobile surface | "card protocol on mobile … card-stream view is a second client into the same persistent process" | Same xterm.js attach as desktop, via `WS /sessions/{id}/attach` + ring-buffer replay |
| Card-translator | "in-pod card-translator parses agent output into structured cards" | None — `products/sandbox/pty-server/internal/server/routes.go:461-506` returns `{"type":"raw","bytes":...}`; author's own comment at L462-463 says "A future card-translator replaces the body with parsed cards" |
| `/cards` endpoint | "JSON cards (alt surface, mobile)" | Stub — raw bytes JSON-framed; no parsing; no FE consumer (`grep -rn '/cards\b\|mode=cards\|cardStream\|CardView' products/catalyst/bootstrap/ui/src/` → 0 hits) |

## Scope

Docs-only. No `platform/*`, `core/*`, `products/sandbox/pty-server/*`, `clusters/*`, or `infra/*` edits. The `/cards` stub route is **retained** as an opt-in extension hook for the future Path A roadmap captured in TBD-V30 #2057.

```
 products/sandbox/docs/architecture.md | 16 +++++++++++-----
 products/sandbox/docs/user-journey.md |  4 ++--
 2 files changed, 13 insertions(+), 7 deletions(-)
```

## Anti-theater

- **No must_contain tokens** — claims removed, not hidden behind cosmetic guards.
- **Replacement reflects current code** — every demoted paragraph now points at the real route (`/attach` + ring-buffer replay) or the stub route's actual JSON shape.
- **Semantic structure preserved** — Scene 6 still narrates a mobile handoff because that part IS shipped (ring buffer replay on `/attach` reconnect across devices, per TBD-V22 #1986 F1).
- **Forward-pointer, not deletion** — TBD-V30 #2057 captures the deferred surface; this PR makes the docs say so explicitly so the next reader doesn't re-discover the gap during another audit.

## Why `Refs` not `Closes`

Per CLAUDE.md §4 anti-theater rule: `Refs #N` is the default in PR bodies; issue closes only after the founder verifies the demotion is internally consistent on the merged docs. This is a paired ship — TBD-V30 #2057 (the deferral) stays parked; TBD-V31 #2058 (this docs-alignment) ships and waits for verification.

## Test plan

- [ ] CI green (markdownlint / link-check / docs-build)
- [ ] `git diff --stat` confirms only 2 docs files changed
- [ ] Internal consistency — every remaining card-protocol mention in the two docs is now qualified with TBD-V30 #2057 or recast as the shipped xterm-attach behaviour
- [ ] No broken cross-references — TBD-V22 #1986 F1 link + TBD-V30 #2057 link both resolve

Refs #1986
Refs #2057
Refs #2058