### PR TITLE
ci: wrap build-workflow deploy push in pull-rebase retry loop (Refs #2062)

### DIFF
--- a/.github/actions/deploy-bump/action.yaml
+++ b/.github/actions/deploy-bump/action.yaml
@@ -1,0 +1,162 @@
+# Composite action: deploy-bump
+#
+# Stages a set of file paths, commits them on `main` with a supplied
+# commit message, and pushes to `origin/main` through a pull --rebase
+# retry loop so concurrent build-workflow deploy jobs do not silently
+# lose the push race.
+#
+# Background (TBD-V32 / openova-io/openova#2062):
+# Build workflows that ended their deploy step with a bare `git push`
+# (catalyst-build, marketplace-api-build, marketplace-build, ...) or
+# with a single pre-push `git pull --rebase --autostash` (the
+# *-controller family) lost the deploy commit silently whenever two
+# build workflows committed within ~2 min of each other. The remote
+# rejected the second push with:
+#
+#   ! [rejected]  main -> main (fetch first)
+#
+# and the workflow exited red with the auto-bump commit never landing.
+# Concrete damage: PR #2050 (V16 admin-token wiring) shipped image
+# `829474a` to GHCR but the chart values.yaml stayed pinned at
+# `5ed4995` — operators installed an old image while the source on
+# `main` already had the new wiring.
+#
+# This composite action concentrates the race-recovery logic in ONE
+# place so every workflow uses the same battle-tested loop and any
+# future improvement only needs to ship here.
+#
+# Loop shape (5 attempts, capped sleeps):
+#
+#   for i in 1 2 3 4 5; do
+#     git push origin HEAD:main && break
+#     git fetch origin main
+#     git pull --rebase --autostash origin main
+#     sleep $((i * 2))
+#   done
+#
+# `fetch` before `pull --rebase` ensures we always see the latest
+# remote tip even if the previous attempt's `pull --rebase` left the
+# local main pointer stale. `--autostash` survives modified working
+# tree between push attempts (rare, but harmless). The capped sleep
+# (2/4/6/8/10s) keeps the loop bounded at ~30s of backoff total.
+#
+# Inputs are deliberately minimal — every caller passes a comma- or
+# whitespace-separated list of paths to stage and a commit message.
+# Outputs let callers gate the follow-up steps (blueprint-release
+# workflow_dispatch, ledger update, etc.) on whether the push
+# actually shipped.
+
+name: deploy-bump
+description: |
+  Stage, commit, and race-safe push a chart-pin / image-tag bump to
+  origin/main with a pull --rebase retry loop.
+
+inputs:
+  paths:
+    description: |
+      Whitespace- (or newline-) separated list of file paths to
+      `git add` before committing. Required.
+    required: true
+  commit-message:
+    description: |
+      Commit message to use when there are staged changes.
+      Required.
+    required: true
+  max-attempts:
+    description: |
+      Number of push attempts before giving up. Default 5.
+    required: false
+    default: "5"
+  user-name:
+    description: |
+      Git author name for the deploy commit. Default
+      `github-actions[bot]`.
+    required: false
+    default: "github-actions[bot]"
+  user-email:
+    description: |
+      Git author email for the deploy commit. Default
+      `github-actions[bot]@users.noreply.github.com`.
+    required: false
+    default: "github-actions[bot]@users.noreply.github.com"
+
+outputs:
+  pushed:
+    description: |
+      `true` if a commit was created AND pushed successfully,
+      `false` if there were no staged changes (no-op) OR every push
+      attempt failed.
+    value: ${{ steps.run.outputs.pushed }}
+  commit-sha:
+    description: |
+      Full SHA of the deploy commit (empty when `pushed=false`).
+    value: ${{ steps.run.outputs.commit_sha }}
+
+runs:
+  using: composite
+  steps:
+    - id: run
+      shell: bash
+      env:
+        DEPLOY_BUMP_PATHS: ${{ inputs.paths }}
+        DEPLOY_BUMP_MESSAGE: ${{ inputs.commit-message }}
+        DEPLOY_BUMP_MAX_ATTEMPTS: ${{ inputs.max-attempts }}
+        DEPLOY_BUMP_USER_NAME: ${{ inputs.user-name }}
+        DEPLOY_BUMP_USER_EMAIL: ${{ inputs.user-email }}
+      run: |
+        set -euo pipefail
+
+        git config user.name  "${DEPLOY_BUMP_USER_NAME}"
+        git config user.email "${DEPLOY_BUMP_USER_EMAIL}"
+
+        # Stage every requested path. xargs handles whitespace- and
+        # newline-separated input identically and re-raises non-zero
+        # exit codes from `git add` so a typo'd path fails loudly.
+        # shellcheck disable=SC2086
+        echo "${DEPLOY_BUMP_PATHS}" | xargs git add --
+
+        if git diff --staged --quiet; then
+          echo "deploy-bump: no staged changes — skipping commit/push."
+          echo "pushed=false"   >> "$GITHUB_OUTPUT"
+          echo "commit_sha="   >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        git commit -m "${DEPLOY_BUMP_MESSAGE}"
+        COMMIT_SHA="$(git rev-parse HEAD)"
+        echo "deploy-bump: committed ${COMMIT_SHA}"
+
+        # Pull --rebase retry loop. Without this, two parallel build
+        # workflows committing within ~2 min of each other will see
+        # the second `git push` rejected with
+        # `[rejected] main -> main (fetch first)` and the auto-bump
+        # commit is lost (TBD-V32 / openova-io/openova#2062).
+        MAX="${DEPLOY_BUMP_MAX_ATTEMPTS:-5}"
+        pushed=false
+        for i in $(seq 1 "${MAX}"); do
+          if git push origin HEAD:main; then
+            pushed=true
+            break
+          fi
+          echo "deploy-bump: push attempt ${i}/${MAX} failed — rebasing and retrying."
+          git fetch origin main
+          # `|| true` keeps the loop alive when the rebase has nothing
+          # to replay (e.g. our commit is still ahead of origin but
+          # the push raced on a transient network hiccup).
+          git pull --rebase --autostash origin main || true
+          sleep "$((i * 2))"
+        done
+
+        if [ "${pushed}" != "true" ]; then
+          echo "deploy-bump: all ${MAX} push attempts failed." >&2
+          echo "pushed=false" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
+          exit 1
+        fi
+
+        # Re-resolve HEAD: a successful rebase between attempts may
+        # have changed the commit SHA we landed.
+        FINAL_SHA="$(git rev-parse HEAD)"
+        echo "deploy-bump: pushed ${FINAL_SHA} to origin/main."
+        echo "pushed=true" >> "$GITHUB_OUTPUT"
+        echo "commit_sha=${FINAL_SHA}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/admin-build.yaml
+++ b/.github/workflows/admin-build.yaml
@@ -60,15 +60,12 @@ jobs:
             sed -i "s|image: ${IMAGE}:.*|image: ${IMAGE}:${SHA}|" "$FILE"
           fi
 
+      # TBD-V32 / openova-io/openova#2062 — race-safe push via the shared
+      # composite action. The previous 3-attempt inline loop omitted
+      # `git fetch` before `git pull --rebase`, so back-to-back races
+      # against the same stale local tip could still fail.
       - name: Commit and push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          SHA=$(echo $GITHUB_SHA | head -c 7)
-          git add products/
-          git diff --staged --quiet && echo "No changes" && exit 0
-          git commit -m "deploy: update Catalyst admin image to ${SHA}"
-          for i in 1 2 3; do
-            git push && break
-            git pull --rebase
-          done
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: products/catalyst/chart/templates/sme-services/admin.yaml
+          commit-message: "deploy: update Catalyst admin image to ${{ needs.build.outputs.sha_short }}"

--- a/.github/workflows/build-application-controller.yaml
+++ b/.github/workflows/build-application-controller.yaml
@@ -176,25 +176,17 @@ jobs:
           echo "values.yaml after bump:"
           grep -A4 "^  application:" "${VALUES}" | head -10
 
+      # TBD-V32 / openova-io/openova#2062 — race-safe push via the shared
+      # composite action. The previous single `git pull --rebase
+      # --autostash` before the push only covered ONE race window;
+      # back-to-back commits between rebase and push still lost the bump.
       - name: Commit and push values.yaml bump
         id: deploy_commit
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        env:
-          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet products/catalyst/chart/values.yaml; then
-            echo "no values.yaml change — already pinned to ${SHA_SHORT}"
-            echo "pushed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git add products/catalyst/chart/values.yaml
-          git commit -m "deploy: bump application-controller image to ${SHA_SHORT}"
-          # Pull-rebase to avoid races with parallel build commits.
-          git pull --rebase --autostash origin main || true
-          git push origin HEAD:main
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: products/catalyst/chart/values.yaml
+          commit-message: "deploy: bump application-controller image to ${{ steps.vars.outputs.sha_short }}"
 
       # GitHub Actions does NOT trigger workflows from bot pushes by
       # default (anti-recursion safeguard). The bot commit above changes

--- a/.github/workflows/build-blueprint-controller.yaml
+++ b/.github/workflows/build-blueprint-controller.yaml
@@ -184,22 +184,12 @@ jobs:
       - name: Commit and push values.yaml bump
         id: deploy_commit
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        env:
-          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet products/catalyst/chart/values.yaml; then
-            echo "no values.yaml change — already pinned to ${SHA_SHORT}"
-            echo "pushed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git add products/catalyst/chart/values.yaml
-          git commit -m "deploy: bump blueprint-controller image to ${SHA_SHORT}"
-          # Pull-rebase to avoid races with parallel build commits.
-          git pull --rebase --autostash origin main || true
-          git push origin HEAD:main
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
+        # TBD-V32 / openova-io/openova#2062 — race-safe push via the
+        # shared composite action.
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: products/catalyst/chart/values.yaml
+          commit-message: "deploy: bump blueprint-controller image to ${{ steps.vars.outputs.sha_short }}"
 
       # GitHub Actions does NOT trigger workflows from bot pushes by
       # default (anti-recursion safeguard). Without this dispatch the

--- a/.github/workflows/build-bp-guacamole.yaml
+++ b/.github/workflows/build-bp-guacamole.yaml
@@ -154,26 +154,16 @@ jobs:
           echo "Chart.yaml version: ${current} -> ${next}"
           echo "CHART_NEW_VERSION=${next}" >> "$GITHUB_ENV"
 
+      # TBD-V32 / openova-io/openova#2062 — race-safe push via the shared
+      # composite action.
       - name: Commit and push chart bump
         id: deploy_commit
-        env:
-          UPSTREAM_VER: ${{ steps.vars.outputs.upstream_version }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "${CHART_VALUES}" "${CHART_YAML}"
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-            echo "pushed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git commit -m "deploy: bump bp-guacamole upstream ${UPSTREAM_VER} chart ${CHART_NEW_VERSION}"
-          for i in 1 2 3; do
-            git push && break
-            git pull --rebase
-          done
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: |
+            ${{ env.CHART_VALUES }}
+            ${{ env.CHART_YAML }}
+          commit-message: "deploy: bump bp-guacamole upstream ${{ steps.vars.outputs.upstream_version }} chart ${{ env.CHART_NEW_VERSION }}"
 
       - name: Trigger blueprint-release for the chart bump
         if: steps.deploy_commit.outputs.pushed == 'true'

--- a/.github/workflows/build-bp-newapi.yaml
+++ b/.github/workflows/build-bp-newapi.yaml
@@ -150,26 +150,16 @@ jobs:
           echo "Chart.yaml: version ${current} -> ${next}, appVersion -> ${app_ver}"
           echo "CHART_NEW_VERSION=${next}" >> "$GITHUB_ENV"
 
+      # TBD-V32 / openova-io/openova#2062 — race-safe push via the shared
+      # composite action.
       - name: Commit and push chart bump
         id: deploy_commit
-        env:
-          UPSTREAM_VER: ${{ steps.vars.outputs.upstream_version }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "${CHART_VALUES}" "${CHART_YAML}"
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-            echo "pushed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git commit -m "deploy: bump bp-newapi upstream ${UPSTREAM_VER} chart ${CHART_NEW_VERSION}"
-          for i in 1 2 3; do
-            git push && break
-            git pull --rebase
-          done
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: |
+            ${{ env.CHART_VALUES }}
+            ${{ env.CHART_YAML }}
+          commit-message: "deploy: bump bp-newapi upstream ${{ steps.vars.outputs.upstream_version }} chart ${{ env.CHART_NEW_VERSION }}"
 
       - name: Trigger blueprint-release for the chart bump
         if: steps.deploy_commit.outputs.pushed == 'true'

--- a/.github/workflows/build-continuum-controller.yaml
+++ b/.github/workflows/build-continuum-controller.yaml
@@ -250,22 +250,12 @@ jobs:
       - name: Commit and push values.yaml bump
         id: deploy_commit
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        env:
-          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet products/continuum/chart/values.yaml; then
-            echo "no values.yaml change — already pinned to ${SHA_SHORT}"
-            echo "pushed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git add products/continuum/chart/values.yaml
-          git commit -m "deploy: bump continuum-controller image to ${SHA_SHORT}"
-          # Pull-rebase to avoid races with parallel build commits.
-          git pull --rebase --autostash origin main || true
-          git push origin HEAD:main
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
+        # TBD-V32 / openova-io/openova#2062 — race-safe push via the
+        # shared composite action.
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: products/continuum/chart/values.yaml
+          commit-message: "deploy: bump continuum-controller image to ${{ steps.vars.outputs.sha_short }}"
 
       # GitHub Actions does NOT trigger workflows from bot pushes by
       # default (anti-recursion safeguard). Without this dispatch the

--- a/.github/workflows/build-environment-controller.yaml
+++ b/.github/workflows/build-environment-controller.yaml
@@ -178,22 +178,12 @@ jobs:
       - name: Commit and push values.yaml bump
         id: deploy_commit
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        env:
-          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet products/catalyst/chart/values.yaml; then
-            echo "no values.yaml change — already pinned to ${SHA_SHORT}"
-            echo "pushed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git add products/catalyst/chart/values.yaml
-          git commit -m "deploy: bump environment-controller image to ${SHA_SHORT}"
-          # Pull-rebase to avoid races with parallel build commits.
-          git pull --rebase --autostash origin main || true
-          git push origin HEAD:main
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
+        # TBD-V32 / openova-io/openova#2062 — race-safe push via the
+        # shared composite action.
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: products/catalyst/chart/values.yaml
+          commit-message: "deploy: bump environment-controller image to ${{ steps.vars.outputs.sha_short }}"
 
       # GitHub Actions does NOT trigger workflows from bot pushes by
       # default (anti-recursion safeguard). Without this dispatch the

--- a/.github/workflows/build-k8s-ws-proxy.yaml
+++ b/.github/workflows/build-k8s-ws-proxy.yaml
@@ -172,26 +172,16 @@ jobs:
           # bumping minors), but the patch bump is automatic.
           echo "CHART_NEW_VERSION=${next}" >> "$GITHUB_ENV"
 
+      # TBD-V32 / openova-io/openova#2062 — race-safe push via the shared
+      # composite action.
       - name: Commit and push chart bump
         id: deploy_commit
-        env:
-          SHA_SHORT: ${{ needs.build.outputs.sha_short }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "${CHART_VALUES}" "${CHART_YAML}"
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-            echo "pushed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git commit -m "deploy: bump bp-k8s-ws-proxy to image ${SHA_SHORT} chart ${CHART_NEW_VERSION}"
-          for i in 1 2 3; do
-            git push && break
-            git pull --rebase
-          done
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: |
+            ${{ env.CHART_VALUES }}
+            ${{ env.CHART_YAML }}
+          commit-message: "deploy: bump bp-k8s-ws-proxy to image ${{ needs.build.outputs.sha_short }} chart ${{ env.CHART_NEW_VERSION }}"
 
       # Per #712: GITHUB_TOKEN-authored commits do NOT re-trigger
       # workflows, so blueprint-release would not auto-fire on the

--- a/.github/workflows/build-openova-flow-adapter-flux.yaml
+++ b/.github/workflows/build-openova-flow-adapter-flux.yaml
@@ -144,24 +144,15 @@ jobs:
           echo "values.yaml after bump:"
           grep -A1 "^  image:" "${VALUES}" | head -6
 
+      # TBD-V32 / openova-io/openova#2062 — race-safe push via the shared
+      # composite action.
       - name: Commit and push values.yaml bump
         id: deploy_commit
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        env:
-          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet platform/openova-flow-emitter/chart/values.yaml; then
-            echo "no values.yaml change — already pinned to ${SHA_SHORT}"
-            echo "pushed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git add platform/openova-flow-emitter/chart/values.yaml
-          git commit -m "chore(deploy): bump openova-flow-adapter-flux image to ${SHA_SHORT} [skip ci]"
-          git pull --rebase --autostash origin main || true
-          git push origin HEAD:main
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: platform/openova-flow-emitter/chart/values.yaml
+          commit-message: "chore(deploy): bump openova-flow-adapter-flux image to ${{ steps.vars.outputs.sha_short }} [skip ci]"
 
       - name: Dispatch blueprint-release for chart re-publish
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && steps.deploy_commit.outputs.pushed == 'true'

--- a/.github/workflows/build-openova-flow-server.yaml
+++ b/.github/workflows/build-openova-flow-server.yaml
@@ -171,24 +171,13 @@ jobs:
       - name: Commit and push values.yaml bump
         id: deploy_commit
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        env:
-          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet platform/openova-flow-server/chart/values.yaml; then
-            echo "no values.yaml change — already pinned to ${SHA_SHORT}"
-            echo "pushed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git add platform/openova-flow-server/chart/values.yaml
-          # `[skip ci]` keeps blueprint-release from re-firing twice
-          # (we explicitly dispatch it below — see the next step).
-          git commit -m "chore(deploy): bump openova-flow-server image to ${SHA_SHORT} [skip ci]"
-          # Pull-rebase to avoid races with parallel build commits.
-          git pull --rebase --autostash origin main || true
-          git push origin HEAD:main
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
+        # TBD-V32 / openova-io/openova#2062 — race-safe push via the
+        # shared composite action. `[skip ci]` keeps blueprint-release
+        # from re-firing twice (it is explicitly dispatched below).
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: platform/openova-flow-server/chart/values.yaml
+          commit-message: "chore(deploy): bump openova-flow-server image to ${{ steps.vars.outputs.sha_short }} [skip ci]"
 
       # GitHub Actions does NOT trigger workflows from GITHUB_TOKEN bot
       # pushes by default (anti-recursion safeguard). The bot commit

--- a/.github/workflows/build-organization-controller.yaml
+++ b/.github/workflows/build-organization-controller.yaml
@@ -180,22 +180,12 @@ jobs:
       - name: Commit and push values.yaml bump
         id: deploy_commit
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        env:
-          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet products/catalyst/chart/values.yaml; then
-            echo "no values.yaml change — already pinned to ${SHA_SHORT}"
-            echo "pushed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git add products/catalyst/chart/values.yaml
-          git commit -m "deploy: bump organization-controller image to ${SHA_SHORT}"
-          # Pull-rebase to avoid races with parallel build commits.
-          git pull --rebase --autostash origin main || true
-          git push origin HEAD:main
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
+        # TBD-V32 / openova-io/openova#2062 — race-safe push via the
+        # shared composite action.
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: products/catalyst/chart/values.yaml
+          commit-message: "deploy: bump organization-controller image to ${{ steps.vars.outputs.sha_short }}"
 
       # GitHub Actions does NOT trigger workflows from bot pushes by
       # default (anti-recursion safeguard). Without this dispatch the

--- a/.github/workflows/build-projector.yaml
+++ b/.github/workflows/build-projector.yaml
@@ -195,22 +195,12 @@ jobs:
       - name: Commit and push values.yaml bump
         id: deploy_commit
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        env:
-          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet products/catalyst/chart/values.yaml; then
-            echo "no values.yaml change — already pinned to ${SHA_SHORT}"
-            echo "pushed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git add products/catalyst/chart/values.yaml
-          git commit -m "deploy: bump projector image to ${SHA_SHORT}"
-          # Pull-rebase to avoid races with parallel build commits.
-          git pull --rebase --autostash origin main || true
-          git push origin HEAD:main
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
+        # TBD-V32 / openova-io/openova#2062 — race-safe push via the
+        # shared composite action.
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: products/catalyst/chart/values.yaml
+          commit-message: "deploy: bump projector image to ${{ steps.vars.outputs.sha_short }}"
 
       # GitHub Actions does NOT trigger workflows from bot pushes by
       # default (anti-recursion safeguard). Without this dispatch the

--- a/.github/workflows/build-sandbox-controller.yaml
+++ b/.github/workflows/build-sandbox-controller.yaml
@@ -171,20 +171,11 @@ jobs:
           echo "values.yaml after bump:"
           yq eval '.image' "${CHART_VALUES}"
 
+      # TBD-V32 / openova-io/openova#2062 — race-safe push via the shared
+      # composite action.
       - name: Commit and push values.yaml bump
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        env:
-          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet "${CHART_VALUES}"; then
-            echo "no values.yaml change — already pinned to ${SHA_SHORT}"
-            exit 0
-          fi
-          git add "${CHART_VALUES}"
-          git commit -m "deploy: bump sandbox-controller image to ${SHA_SHORT}"
-          # Pull-rebase to avoid races with parallel build commits.
-          git pull --rebase --autostash origin main || true
-          git push origin HEAD:main
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: ${{ env.CHART_VALUES }}
+          commit-message: "deploy: bump sandbox-controller image to ${{ steps.vars.outputs.sha_short }}"

--- a/.github/workflows/build-sandbox-mcp-server.yaml
+++ b/.github/workflows/build-sandbox-mcp-server.yaml
@@ -174,20 +174,11 @@ jobs:
           echo "values.yaml after bump:"
           yq eval '.runtime.mcpImage' "${CHART_VALUES}"
 
+      # TBD-V32 / openova-io/openova#2062 — race-safe push via the shared
+      # composite action.
       - name: Commit and push values.yaml bump
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        env:
-          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet "${CHART_VALUES}"; then
-            echo "no values.yaml change — already pinned to ${SHA_SHORT}"
-            exit 0
-          fi
-          git add "${CHART_VALUES}"
-          git commit -m "deploy: bump sandbox-mcp-server image to ${SHA_SHORT}"
-          # Pull-rebase to avoid races with parallel build commits.
-          git pull --rebase --autostash origin main || true
-          git push origin HEAD:main
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: ${{ env.CHART_VALUES }}
+          commit-message: "deploy: bump sandbox-mcp-server image to ${{ steps.vars.outputs.sha_short }}"

--- a/.github/workflows/build-sandbox-pty-server.yaml
+++ b/.github/workflows/build-sandbox-pty-server.yaml
@@ -186,20 +186,11 @@ jobs:
           echo "values.yaml after bump:"
           yq eval '.runtime.ptyServerImage' "${CHART_VALUES}"
 
+      # TBD-V32 / openova-io/openova#2062 — race-safe push via the shared
+      # composite action.
       - name: Commit and push values.yaml bump
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        env:
-          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet "${CHART_VALUES}"; then
-            echo "no values.yaml change — already pinned to ${SHA_SHORT}"
-            exit 0
-          fi
-          git add "${CHART_VALUES}"
-          git commit -m "deploy: bump sandbox-pty-server image to ${SHA_SHORT}"
-          # Pull-rebase to avoid races with parallel build commits.
-          git pull --rebase --autostash origin main || true
-          git push origin HEAD:main
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: ${{ env.CHART_VALUES }}
+          commit-message: "deploy: bump sandbox-pty-server image to ${{ steps.vars.outputs.sha_short }}"

--- a/.github/workflows/catalyst-build.yaml
+++ b/.github/workflows/catalyst-build.yaml
@@ -476,31 +476,31 @@ jobs:
           # old image while the Sovereign provisioning churned through
           # the same SHA being fixed downstream).
 
+      # values.yaml + the two literal-image templates (api-deployment,
+      # ui-deployment) are bumped together so:
+      #   - Sovereigns get the new SHA via the next OCI chart publish
+      #     (blueprint-release fires below).
+      #   - contabo's Kustomize-path Flux reconciles the bumped literal
+      #     within 10 min.
+      # Both surfaces converge on the same SHA on every push.
+      #
+      # TBD-V32 / openova-io/openova#2062: the previous bare `git push`
+      # silently lost the deploy commit when a parallel build workflow
+      # raced this push. PR #2050 (V16 admin-token wiring) shipped the
+      # catalyst-api image to GHCR at 829474a but the values.yaml /
+      # template pins never landed because of this race. The
+      # `./.github/actions/deploy-bump` composite action centralises a
+      # 5-attempt `pull --rebase` retry loop so every deploy job
+      # converges instead of dropping the bump on the floor.
       - name: Commit and push manifest updates
         id: deploy_commit
-        env:
-          SHA_SHORT: ${{ needs.build-ui.outputs.sha_short }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          # values.yaml + the two literal-image templates (api-deployment,
-          # ui-deployment) are bumped together so:
-          #   - Sovereigns get the new SHA via the next OCI chart publish
-          #     (blueprint-release fires below).
-          #   - contabo's Kustomize-path Flux reconciles the bumped literal
-          #     within 10 min.
-          # Both surfaces converge on the same SHA on every push.
-          git add products/catalyst/chart/values.yaml \
-                  products/catalyst/chart/templates/api-deployment.yaml \
-                  products/catalyst/chart/templates/ui-deployment.yaml
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-            echo "pushed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git commit -m "deploy: update catalyst images to ${SHA_SHORT}"
-          git push
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: |
+            products/catalyst/chart/values.yaml
+            products/catalyst/chart/templates/api-deployment.yaml
+            products/catalyst/chart/templates/ui-deployment.yaml
+          commit-message: "deploy: update catalyst images to ${{ needs.build-ui.outputs.sha_short }}"
 
       # Closes #712. The push above is made by GITHUB_TOKEN; per GitHub
       # Actions design, commits authored by GITHUB_TOKEN do NOT re-trigger

--- a/.github/workflows/console-build.yaml
+++ b/.github/workflows/console-build.yaml
@@ -60,15 +60,10 @@ jobs:
             sed -i "s|image: ${IMAGE}:.*|image: ${IMAGE}:${SHA}|" "$FILE"
           fi
 
+      # TBD-V32 / openova-io/openova#2062 — race-safe push via the shared
+      # composite action.
       - name: Commit and push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          SHA=$(echo $GITHUB_SHA | head -c 7)
-          git add products/
-          git diff --staged --quiet && echo "No changes" && exit 0
-          git commit -m "deploy: update Catalyst console image to ${SHA}"
-          for i in 1 2 3; do
-            git push && break
-            git pull --rebase
-          done
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: products/catalyst/chart/templates/sme-services/console.yaml
+          commit-message: "deploy: update Catalyst console image to ${{ needs.build.outputs.sha_short }}"

--- a/.github/workflows/marketplace-api-build.yaml
+++ b/.github/workflows/marketplace-api-build.yaml
@@ -62,13 +62,11 @@ jobs:
           echo "Updated manifest to SHA ${SHA_SHORT}:"
           grep "image:" "${DEPLOY_DIR}/deployment.yaml"
 
+      # TBD-V32 / openova-io/openova#2062 — race-safe push via the shared
+      # composite action so concurrent build workflows do not lose the
+      # auto-bump commit to `[rejected] main -> main (fetch first)`.
       - name: Commit and push manifest updates
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add products/
-          git diff --staged --quiet && echo "No changes to commit" && exit 0
-          git commit -m "deploy: update Catalyst marketplace-api image to ${SHA_SHORT}"
-          git push
-        env:
-          SHA_SHORT: ${{ needs.build.outputs.sha_short }}
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: products/catalyst/chart/templates/marketplace-api/deployment.yaml
+          commit-message: "deploy: update Catalyst marketplace-api image to ${{ needs.build.outputs.sha_short }}"

--- a/.github/workflows/marketplace-build.yaml
+++ b/.github/workflows/marketplace-build.yaml
@@ -61,15 +61,10 @@ jobs:
             echo "Updated marketplace to SHA ${SHA}"
           fi
 
+      # TBD-V32 / openova-io/openova#2062 — race-safe push via the shared
+      # composite action.
       - name: Commit and push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          SHA=$(echo $GITHUB_SHA | head -c 7)
-          git add products/
-          git diff --staged --quiet && echo "No changes" && exit 0
-          git commit -m "deploy: update Catalyst marketplace image to ${SHA}"
-          for i in 1 2 3; do
-            git push && break
-            git pull --rebase
-          done
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: products/catalyst/chart/templates/sme-services/marketplace.yaml
+          commit-message: "deploy: update Catalyst marketplace image to ${{ needs.build.outputs.sha_short }}"

--- a/.github/workflows/services-build.yaml
+++ b/.github/workflows/services-build.yaml
@@ -227,7 +227,18 @@ jobs:
           NEXT="${{ steps.rewrite.outputs.next_version }}"
           git commit -m "deploy: update sme service images to ${SHA} + bump chart to ${NEXT}"
 
-          for i in 1 2 3; do
+          # TBD-V32 / openova-io/openova#2062 — race-safe push loop.
+          # NOTE: this workflow deliberately does NOT use the shared
+          # `./.github/actions/deploy-bump` composite action. The rewrite
+          # closure above bumps the chart semver `patch` segment on every
+          # iteration so a rebased push lands at chart `vN.M.P+2` instead
+          # of `+1` — that re-bump only happens correctly inside this
+          # inline loop because the composite action treats files as
+          # opaque and would replay the SAME staged diff on every retry,
+          # which would lose to the parallel run that bumped the same
+          # patch number first. Bumping the max-attempts ceiling from 3
+          # to 5 matches the composite action default.
+          for i in 1 2 3 4 5; do
             if git push; then
               echo "pushed=true" >> "$GITHUB_OUTPUT"
               echo "next_version=${NEXT}" >> "$GITHUB_OUTPUT"
@@ -244,8 +255,9 @@ jobs:
               exit 0
             fi
             git commit -m "deploy: update sme service images to ${SHA} + bump chart to ${NEXT}"
+            sleep $((i * 2))
           done
-          echo "push failed after 3 attempts"
+          echo "push failed after 5 attempts"
           exit 1
 
       # GITHUB_TOKEN-authored pushes do NOT re-trigger workflows by

--- a/.github/workflows/useraccess-controller-build.yaml
+++ b/.github/workflows/useraccess-controller-build.yaml
@@ -162,25 +162,15 @@ jobs:
           echo "values.yaml after bump:"
           grep -A4 "^  useraccess:" "${VALUES}" | head -10
 
+      # TBD-V32 / openova-io/openova#2062 — race-safe push via the shared
+      # composite action.
       - name: Commit and push values.yaml bump
         id: deploy_commit
         if: github.ref == 'refs/heads/main'
-        env:
-          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet products/catalyst/chart/values.yaml; then
-            echo "no values.yaml change — already pinned to ${SHA_SHORT}"
-            echo "pushed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git add products/catalyst/chart/values.yaml
-          git commit -m "deploy: bump useraccess-controller image to ${SHA_SHORT}"
-          # Pull-rebase to avoid races with parallel build commits.
-          git pull --rebase --autostash origin main || true
-          git push origin HEAD:main
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: products/catalyst/chart/values.yaml
+          commit-message: "deploy: bump useraccess-controller image to ${{ steps.vars.outputs.sha_short }}"
 
       # GitHub Actions does NOT trigger workflows from bot pushes by
       # default (anti-recursion safeguard). Without this dispatch the


### PR DESCRIPTION
## Summary

TBD-V32 / Refs #2062. **Critical bug**: every `.github/workflows/*build*.yaml` deploy job lost its auto-bump commit silently when two build workflows committed to `main` within ~2 min of each other. The image landed in GHCR but the chart `values.yaml` / template SHA-pin commit was rejected with `! [rejected] main -> main (fetch first)` and lost.

**Concrete operational damage** (per issue + sweep extension): PR #2050 shipped catalyst-api image `829474a` to GHCR (V16 admin-token wiring in `cmd/api/main.go` + `internal/newapi/client.go`), but the `deploy: update catalyst images to 829474a` commit never landed on `main`. Operators installing the current chart kept getting the previous catalyst-build success (`5ed4995`), missing the entire admin-token wiring.

## What this PR does

- Adds a shared composite action `.github/actions/deploy-bump/action.yaml` that runs a **5-attempt `pull --rebase` retry loop** with `git fetch` before each rebase and exponential 2/4/6/8/10s backoff (~30s total). Inputs: `paths`, `commit-message`, optional `max-attempts`/`user-name`/`user-email`. Outputs: `pushed` (bool) and `commit-sha`.
- Refactors 20 of 21 build workflows to use the composite action, replacing 311 lines of duplicated bash with 163 lines of action invocations.
- `services-build.yaml` is the documented exception — its retry loop re-runs an inline `rewrite()` closure that bumps the chart semver patch on every iteration, which the composite action cannot do because it treats files as opaque. The inline loop stays, but bumps the ceiling from 3 to 5 attempts + adds the matching backoff sleep.

## Workflows touched

**Group A** (was bare `git push`, the actual culprit for #2050):
- catalyst-build.yaml, marketplace-api-build.yaml

**Group B** (had 3-retry inline loop without `git fetch` between rebases):
- admin-build.yaml, console-build.yaml, marketplace-build.yaml, build-bp-guacamole.yaml, build-bp-newapi.yaml, build-k8s-ws-proxy.yaml

**Group C** (had single pre-push `git pull --rebase --autostash` — only covers ONE race window):
- build-application-controller.yaml, build-blueprint-controller.yaml, build-continuum-controller.yaml, build-environment-controller.yaml, build-organization-controller.yaml, build-projector.yaml, build-openova-flow-server.yaml, build-openova-flow-adapter-flux.yaml, build-sandbox-controller.yaml, build-sandbox-mcp-server.yaml, build-sandbox-pty-server.yaml, useraccess-controller-build.yaml

**Group D** (custom rewrite-on-retry — kept inline, documented):
- services-build.yaml

## Verification

- `actionlint -shellcheck= .github/workflows/*.yaml` clean across all modified workflows (the only remaining warning is the pre-existing `cosmetic-guards.yaml:48 if: false` constant condition, unrelated).
- All 21 modified workflows and the new composite action pass `yaml.safe_load` parse.
- The composite action's `outputs.pushed` keeps the existing `if: steps.deploy_commit.outputs.pushed == 'true'` gate working on every `Trigger blueprint-release` downstream step (14 of the 20 modified workflows rely on this).

## Test plan

- [ ] Watch the next two build workflows that fire within ~2 min of each other on `main` — both should successfully push their deploy commits (no `[rejected]` errors).
- [ ] Confirm the `Trigger blueprint-release for the chart bump` step still fires in workflows that have one (it reads `steps.deploy_commit.outputs.pushed`, which the composite action now sets).
- [ ] After observed convergence on a real race, flip TBD-V32 #2062 from UNVERIFIED to VERIFIED-PASS on `docs/TRUST.md`.

## Post-merge follow-up

`Refs #2062` deliberately — per the anti-theater discipline, the issue closes only after observed race-recovery in a real CI run, not on this PR's merge. Separately:

- PR #2050's V16 admin-token wiring is still NOT in the deployed catalyst-api image. After this PR merges, the next controller-source PR that triggers `catalyst-build.yaml` will ride the new retry loop and pull #2050's wiring forward. If urgent, a manual chart-pin commit on `main` against `products/catalyst/chart/values.yaml` (bumping `catalystApi.tag` to `829474a`) will force the deploy.

Generated with Claude Code (https://claude.com/claude-code)