### PR TITLE
feat(catalyst-ui/resources): light up YamlEditor + MetricsPanel + ResourceActions widgets (Refs #1099)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -818,11 +818,20 @@ spec:
       # dropped. New endpoint GET /tenant/internal/tenants/{id}/app-configs
       # on tenant service for the billing lookup.
       #
+      # 1.4.229 — #1099 EPIC-4 Group A trust-recovery audit lockdown
+      # (2026-05-20, follow-up to PR #2059's Events fix). Audit
+      # verdict: YamlEditor + MetricsPanel + ResourceActions are
+      # ALREADY-LIT (each has its own REST data path + the backend
+      # handlers are wired in cmd/api/main.go). Ships UI integration
+      # tests that lock the mount points so a future refactor of
+      # ResourceDetailPage cannot silently re-introduce dark widgets.
+      # Refs #1099 (NOT Closes — operator walk required).
+      #
       # 1.4.228 — #1099 EPIC-4 Slice R4 follow-up: extend the
       # resource-detail page's k8s SSE subscription to include the
       # `event` kind so the EventsPanel surfaces live K8s Events
       # instead of perpetually rendering empty-state.
-      version: 1.4.228
+      version: 1.4.229
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailPage.widgets.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/ResourceDetailPage.widgets.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * ResourceDetailPage.widgets.test.tsx — EPIC #1099 Group A trust-recovery
+ * audit lockdown (Refs #1099, follow-up to PR #2059's Events fix).
+ *
+ * After PR #2059 lit up EventsPanel by extending `GRAPH_K8S_KINDS` with
+ * `event`, this file locks the other three Group A widgets in the
+ * resource-detail page (YamlEditor, MetricsPanel, ResourceActions)
+ * against the same class of "dark widget" regression — i.e. a future
+ * refactor accidentally muting a panel because its mount point was
+ * removed from `ResourceDetailPage`.
+ *
+ * Investigation reference: PR #2059 root-caused EventsPanel as
+ * "DARK-VIA-KINDS-OMISSION". The audit of the remaining widgets
+ * concluded ALREADY-LIT for all 3:
+ *
+ *   - YamlEditor — receives `obj` from `getResource` REST (independent
+ *     of `useK8sCacheStream`), backend wired in `cmd/api/main.go:818,
+ *     826, 833, 834`, full validate/apply with flux→PR routing.
+ *
+ *   - MetricsPanel — direct REST via `getResourceMetrics`, backend
+ *     wired at `cmd/api/main.go:817`, metrics-server + mimir clients
+ *     with operator-readable "Metrics unavailable" fallback.
+ *
+ *   - ResourceActions — direct REST via scale/restart/delete, backends
+ *     wired at `cmd/api/main.go:820, 827, 835`, type-the-name
+ *     confirmation modal already in place (no one-click delete).
+ *
+ * These integration assertions complement the unit tests in
+ * `widgets/cloud-list/{YamlEditor,MetricsPanel,ResourceActions}.test.tsx`
+ * — those cover widget behaviour in isolation; THIS file pins the
+ * MOUNT POINT (the `ResourceDetailPage` tab/Overview rendering)
+ * so a future refactor cannot accidentally re-introduce theater.
+ */
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+
+import { ResourceDetailPage } from './ResourceDetailPage'
+import type { K8sObject } from '@/widgets/architecture-graph/useK8sCacheStream'
+
+const sampleDeployment: K8sObject = {
+  apiVersion: 'apps/v1',
+  kind: 'Deployment',
+  metadata: {
+    name: 'wp',
+    namespace: 'default',
+    uid: 'uid-dep',
+    creationTimestamp: '2026-05-10T10:00:00Z',
+    labels: { app: 'wp' },
+  },
+  spec: { replicas: 3, selector: { matchLabels: { app: 'wp' } } } as Record<string, unknown>,
+  status: { readyReplicas: 3, availableReplicas: 3 } as Record<string, unknown>,
+}
+
+afterEach(() => cleanup())
+beforeEach(() => {
+  // MetricsPanel and YamlEditor fire REST calls on mount; stub fetch so
+  // the assertions only need to observe the panel test-ids, not the
+  // ultimate REST response. The widgets' own unit tests cover the
+  // network-success / network-error branches.
+  global.fetch = vi.fn().mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        kind: 'deployment',
+        namespace: 'default',
+        name: 'wp',
+        current: { cpuMilli: 0, memBytes: 0 },
+        series: [],
+        source: 'unavailable',
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ),
+  )
+})
+
+describe('ResourceDetailPage — Group A widget mount points (Refs #1099, follow-up to PR #2059)', () => {
+  it('Overview tab mounts ResourceActions inline for a tier-admin operator', () => {
+    render(
+      <ResourceDetailPage
+        deploymentId="dep"
+        basePath="/cloud"
+        kind="deployment"
+        ns="default"
+        name="wp"
+        tab="overview"
+        initialObj={sampleDeployment}
+        isTierAdmin={true}
+      />,
+    )
+    // ResourceActions widget present (would render `resource-actions-disabled`
+    // banner if isTierAdmin was false — the not-dark assertion is the
+    // visible action surface, not the disabled banner).
+    expect(screen.getByTestId('resource-actions')).toBeTruthy()
+    // Scale + Restart + Delete buttons all render for a Deployment.
+    expect(screen.getByTestId('resource-actions-scale')).toBeTruthy()
+    expect(screen.getByTestId('resource-actions-restart')).toBeTruthy()
+    expect(screen.getByTestId('resource-actions-delete')).toBeTruthy()
+  })
+
+  it('Overview tab shows the disabled banner when caller is not tier-admin (server is still authoritative)', () => {
+    render(
+      <ResourceDetailPage
+        deploymentId="dep"
+        basePath="/cloud"
+        kind="deployment"
+        ns="default"
+        name="wp"
+        tab="overview"
+        initialObj={sampleDeployment}
+        isTierAdmin={false}
+      />,
+    )
+    expect(screen.getByTestId('resource-actions-disabled')).toBeTruthy()
+    // Action buttons hidden client-side; server-side authorization
+    // remains the source of truth per INVIOLABLE-PRINCIPLES.md #5.
+    expect(screen.queryByTestId('resource-actions-scale')).toBeNull()
+    expect(screen.queryByTestId('resource-actions-restart')).toBeNull()
+    expect(screen.queryByTestId('resource-actions-delete')).toBeNull()
+  })
+
+  it('Delete button opens a type-the-name confirmation modal (no one-click delete)', () => {
+    render(
+      <ResourceDetailPage
+        deploymentId="dep"
+        basePath="/cloud"
+        kind="deployment"
+        ns="default"
+        name="wp"
+        tab="overview"
+        initialObj={sampleDeployment}
+        isTierAdmin={true}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('resource-actions-delete'))
+    const modal = screen.getByTestId('resource-actions-delete-modal')
+    expect(modal).toBeTruthy()
+    // Commit button is disabled until the name is typed exactly — the
+    // type-the-name gate is the canonical destructive-action defence
+    // for #1099. Locking it here ensures a future refactor cannot
+    // silently downgrade to a one-click delete.
+    const commit = screen.getByTestId('resource-actions-delete-commit') as HTMLButtonElement
+    expect(commit.disabled).toBe(true)
+  })
+
+  it('Metrics tab mounts MetricsPanel (initial fetch fires; tab is not dark)', async () => {
+    render(
+      <ResourceDetailPage
+        deploymentId="dep"
+        basePath="/cloud"
+        kind="deployment"
+        ns="default"
+        name="wp"
+        tab="metrics"
+        initialObj={sampleDeployment}
+      />,
+    )
+    // The widget initially renders its loading state, then transitions
+    // to either `metrics-panel` (lit) or `metrics-panel-unavailable`
+    // (metrics-server not installed). Both are operator-visible — the
+    // dark anti-pattern would be no test-id rendering at all.
+    await waitFor(() => {
+      const lit =
+        screen.queryByTestId('metrics-panel') ||
+        screen.queryByTestId('metrics-panel-unavailable') ||
+        screen.queryByTestId('metrics-panel-error') ||
+        screen.queryByTestId('metrics-panel-loading')
+      expect(lit).not.toBeNull()
+    })
+    // Fetch should have fired against the metrics endpoint — the
+    // dark-via-no-fetch anti-pattern (component renders empty without
+    // ever calling the API) is the explicit regression we want to
+    // pin against.
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    expect(fetchMock).toHaveBeenCalled()
+    const url = fetchMock.mock.calls[0][0] as string
+    expect(url).toMatch(/\/k8s\/metrics\/deployment\/default\/wp/)
+  })
+
+  it('YAML tab mounts YamlEditor with seeded textarea (initial seed from initialObj is non-empty)', () => {
+    render(
+      <ResourceDetailPage
+        deploymentId="dep"
+        basePath="/cloud"
+        kind="deployment"
+        ns="default"
+        name="wp"
+        tab="yaml"
+        initialObj={sampleDeployment}
+      />,
+    )
+    expect(screen.getByTestId('yaml-editor')).toBeTruthy()
+    // The textarea must seed from the live object so the operator can
+    // see the resource's current shape — the dark anti-pattern would
+    // be an empty textarea on a populated resource.
+    const textarea = screen.getByTestId('yaml-editor-textarea') as HTMLTextAreaElement
+    expect(textarea.value.length).toBeGreaterThan(0)
+    expect(textarea.value).toContain('Deployment')
+    expect(textarea.value).toContain('wp')
+    // Validate + Apply buttons mount unconditionally — the server is
+    // the authoritative gate per INVIOLABLE-PRINCIPLES.md #5.
+    expect(screen.getByTestId('yaml-editor-validate')).toBeTruthy()
+    expect(screen.getByTestId('yaml-editor-apply')).toBeTruthy()
+  })
+})

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2169,8 +2169,44 @@ name: bp-catalyst-platform
 # was already shipped on 1.4.197 (PR #1820 lineage); this completes
 # the data-layer side so the dropdown finally appears on multi-region
 # Sovereigns. Refs #1821, DoD D20.
-version: 1.4.228
-appVersion: 1.4.228
+# 1.4.229 — #1099 EPIC-4 Group A trust-recovery audit lockdown
+# (2026-05-20, follow-up to PR #2059's Events fix). Per the brief: after
+# PR #2059 lit EventsPanel by extending GRAPH_K8S_KINDS with `event`,
+# audit the 3 remaining Group A widgets (YamlEditor, MetricsPanel,
+# ResourceActions) for the same "dark widget" anti-pattern.
+#
+# Audit verdict: ALREADY-LIT for all 3.
+#   - YamlEditor receives `obj` from getResource REST (not from the
+#     useK8sCacheStream snapshot), backend wired at cmd/api/main.go:818,
+#     826, 833, 834; full validate/apply with flux→PR routing for
+#     managed-by=flux + direct apply for managed-by=manual.
+#   - MetricsPanel direct-REST via getResourceMetrics, backend wired at
+#     cmd/api/main.go:817; metrics-server + mimir clients with an
+#     operator-readable "Metrics unavailable" fallback when neither
+#     source is wired.
+#   - ResourceActions direct-REST via scale/restart/delete, backends
+#     wired at cmd/api/main.go:820/827/835; type-the-name confirmation
+#     modal already in place (no one-click delete).
+#
+# This bump ships UI integration tests that LOCK the mount points so a
+# future refactor of ResourceDetailPage cannot silently re-introduce
+# theater. Specifically:
+#   - Overview tab mounts ResourceActions (assert presence + scale/
+#     restart/delete buttons for a Deployment).
+#   - isTierAdmin=false produces resource-actions-disabled banner with
+#     all action buttons hidden — server gate remains authoritative.
+#   - Delete button opens the type-the-name confirmation modal with
+#     the commit button disabled until the name is typed exactly.
+#   - Metrics tab mounts MetricsPanel + fires the REST fetch (the dark
+#     anti-pattern would be no fetch firing on tab activation).
+#   - YAML tab mounts YamlEditor with a non-empty seeded textarea
+#     (the dark anti-pattern would be an empty textarea on a populated
+#     resource).
+#
+# Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
+# CLAUDE.md §0).
+version: 1.4.229
+appVersion: 1.4.229
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned


### PR DESCRIPTION
## Summary

EPIC #1099 Group A trust-recovery audit lockdown — follow-up to PR #2059's EventsPanel fix.

PR #2059 root-caused EventsPanel as **DARK-VIA-KINDS-OMISSION**: `ResourceDetailRoute` opened its k8s SSE with the default `GRAPH_K8S_KINDS` list (canvas-tuned, intentionally omits Events). The fix extended kinds with `event`.

This PR audits the **3 remaining Group A widgets** for the same class of "dark widget" anti-pattern.

## Audit verdict — ALREADY-LIT for all 3

| Widget | Data path | Backend wired | Defence |
|---|---|---|---|
| **YamlEditor** | `getResource()` REST (page-level fetch, NOT the SSE snapshot) | `cmd/api/main.go:818 / 826 / 833 / 834` (get / scale / dry-run / apply) | flux→PR routing, side-by-side diff, dry-run validate before apply |
| **MetricsPanel** | `getResourceMetrics()` REST direct | `cmd/api/main.go:817` (metrics-server + mimir clients) | Operator-readable "Metrics unavailable" fallback when neither source wired |
| **ResourceActions** | `scaleResource` / `restartResource` / `deleteResource` REST direct | `cmd/api/main.go:820 / 827 / 835` (scale / restart / delete) | Type-the-name confirmation modal before DELETE; commit button disabled until name typed exactly |

Each has its own REST data path independent of the SSE subscription that failed Events. Each has unit tests in `widgets/cloud-list/{YamlEditor,MetricsPanel,ResourceActions}.test.tsx`. Each has the destructive-action defence (or N/A — only ResourceActions is destructive).

## What this PR ships

A new integration test file **`ResourceDetailPage.widgets.test.tsx`** that pins the **mount points** in `ResourceDetailPage` so a future refactor cannot accidentally re-introduce theater by removing a widget from the tab rendering.

5 new tests:

- Overview tab mounts `ResourceActions` inline (scale + restart + delete buttons visible for a Deployment)
- `isTierAdmin=false` produces `resource-actions-disabled` banner with all action buttons hidden (server gate authoritative per INVIOLABLE-PRINCIPLES.md #5)
- Delete button opens type-the-name confirmation modal with commit button disabled until name typed exactly
- Metrics tab mounts `MetricsPanel` AND fires the REST fetch (dark anti-pattern = no fetch on tab activation)
- YAML tab mounts `YamlEditor` with a non-empty seeded textarea (dark anti-pattern = empty textarea on populated resource)

All 5 GREEN. Pre-existing `ExecPanel.test.tsx` failures (WebSocket race in jsdom) verified independent — same test fails on clean `origin/main` before this branch's changes.

## Chart bump (lockstep per Principle #14)

- `products/catalyst/chart/Chart.yaml` 1.4.228 → 1.4.229
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` pin → 1.4.229

UI-only change; no backend or chart-template behavioural change. Tests pin existing widget mount contracts.

## Validation

- `npx vitest run ResourceDetailPage.widgets.test.tsx` → 5/5 GREEN
- `npx vitest run src/widgets/cloud-list/ src/pages/sovereign/cloud-list/` → 72/73 GREEN (1 pre-existing ExecPanel flake)
- `helm template test products/catalyst/chart/` → renders cleanly
- Did NOT use `--dry-run=server` (Principle #15)

## Test plan

- [ ] CI green on all required checks
- [ ] Operator walk on a fresh multi-region prov: navigate to `/cloud/resource/deployment/<ns>/<name>/overview` and verify Scale/Restart/Delete buttons are visible and the Delete modal requires typing the name
- [ ] Operator walk: navigate to `.../metrics` and verify MetricsPanel shows either real sparklines (with metrics-server wired) or the "Metrics unavailable" fallback (not a blank tab)
- [ ] Operator walk: navigate to `.../yaml` and verify the textarea is seeded with the live K8s object's YAML
- [ ] Issue #1099 stays OPEN until operator-walk + screenshot lands on the issue (Refs, NOT Closes)

Refs #1099 — operator walk + screenshot is the DoD per CLAUDE.md §0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)