### PR TITLE
fix(ci/build-continuum-controller): rework fail-fast guard to test with explicit empty tag override

### DIFF
--- a/.github/workflows/build-continuum-controller.yaml
+++ b/.github/workflows/build-continuum-controller.yaml
@@ -128,10 +128,24 @@ jobs:
 
       - name: helm template — fail-fast on empty image.tag
         run: |
+          # Per Inviolable Principle #4a the chart MUST fail-fast at
+          # render time when `continuum.enabled=true` and `image.tag`
+          # is empty (no `:latest` ever). This guard exercises that
+          # contract with an EXPLICIT `--set continuum.image.tag=""`
+          # override so it remains valid regardless of whatever SHA
+          # the auto-bump step (further down this workflow) has
+          # committed into products/continuum/chart/values.yaml on
+          # main. Pre-fix the guard relied on the committed default
+          # being empty — once the first auto-bump landed (PR #2012)
+          # the committed tag became non-empty, helm template stopped
+          # failing, and this step started tripping the "should-have-
+          # failed" assertion in every subsequent PR (TBD-V32 #2062
+          # blocker on PR #2063).
           set +e
           helm template bp-continuum products/continuum/chart/ \
             --namespace openova-system \
-            --set continuum.enabled=true 2>&1 | tee /tmp/render.out
+            --set continuum.enabled=true \
+            --set continuum.image.tag="" 2>&1 | tee /tmp/render.out
           rc=${PIPESTATUS[0]}
           set -e
           if [ "$rc" -eq 0 ]; then


### PR DESCRIPTION
## Summary

The `Build continuum-controller` workflow's `helm template — fail-fast on empty image.tag` step relied on the committed default `continuum.image.tag` in `products/continuum/chart/values.yaml` being empty to exercise the chart's render-time fail-fast contract (per Inviolable Principle #4a — no `:latest` in production).

Once the workflow's own auto-bump step (added in TBD-A69 #2006) landed its first deploy commit (PR #2012 set tag to `e72efb8`), the committed default became non-empty. `helm template ... --set continuum.enabled=true` now renders successfully, the guard's "expected to FAIL" assertion trips, and every subsequent PR touching `products/continuum/**` is blocked from merging.

## Root cause

- BEFORE auto-bump: tag empty → helm template fails → guard expects fail → PASS
- AFTER PR #2012 auto-bump: tag is `e72efb8` → helm template succeeds → guard expects fail → FAIL

The guard's logic was inverted vs the new steady state.

## Fix shape

Pass `--set continuum.image.tag=""` to the guard's `helm template` invocation so the contract is exercised regardless of what auto-bump has committed into `values.yaml` on main. Inline comment documents the failure history.

Workflow-only change — no chart bump, no `values.yaml` edit. The committed `tag: "e72efb8"` is correct (auto-bump worked); the guard was the broken thing.

## Validation

Local reproduction of the exact CI guard logic:

```
$ helm template bp-continuum products/continuum/chart/ \
    --namespace openova-system \
    --set continuum.enabled=true \
    --set continuum.image.tag=""
Error: execution error at (bp-continuum/templates/deployment.yaml:40:20): continuum.image.tag is empty — CI must stamp a SHA before render. Per docs/INVIOLABLE-PRINCIPLES.md #4a no :latest is permitted.
helm rc=1
grep "image.tag is empty" matched
```

Both guard assertions now pass.

`actionlint` clean for the changed step (only pre-existing SC2086 warning on line 78's `sha_short` echo, unrelated).

## Test plan

- [ ] CI on this PR: `Build continuum-controller / build` passes (fail-fast guard step green)
- [ ] After merge, rebase PR #2063 → its `Build continuum-controller` re-run should pass
- [ ] No other build-*-controller workflow has the same guard pattern (grep'd: only build-continuum-controller.yaml uses this `expected helm template to FAIL` invariant)

Refs #2062