### PR TITLE
fix(bp-cnpg-pair): switch to synchronous replication (remote_apply) for Pillar 3 zero-tx-loss (Refs #2064)

### DIFF
--- a/platform/cnpg-pair/DESIGN.md
+++ b/platform/cnpg-pair/DESIGN.md
@@ -63,8 +63,13 @@ Why 30s default:
 - Bank-tier RPO target per `docs/EPICS-1-6-unified-design.md` §9.6
   is "<5s write disruption" on operator-initiated switchover.
   Pre-checking lag <30s before switchover gives a 25s safety margin.
-- For sub-second-RPO scenarios (synchronous_commit), a future
-  Blueprint will lower this default — out of scope here.
+- For zero-RPO (synchronous_commit=remote_apply) — chart 0.1.2 SHIPS
+  this as the default replication mode (`replication.mode: sync`,
+  see §7 below). With sync mode the primary's COMMIT blocks until
+  the replica has REPLAYED the WAL, so the replica's lag is bounded
+  by the round-trip time, not the streaming buffer — the 30s
+  threshold then guards against the replica being partitioned (sync
+  ACK never returns, primary blocks) or genuinely degraded.
 
 **Per-Application override** is exposed via configSchema; cluster
 overlays may bump or lower it.
@@ -132,6 +137,82 @@ exposed via a Catalyst MigrationJob CRD) will:
 This is OUT OF SCOPE for C-DB-1; documented here so the migration-
 slice author has the design context.
 
+### 7. Synchronous replication (Pillar 3 zero-transactions-lost)
+
+Canonical claim per `CLAUDE.md §0` (Pillar 3): two independent CNPG
+clusters with ReplicaCluster sync over Cilium ClusterMesh + region-
+kill failover with **zero transactions lost**. Asynchronous-streaming
+replication CANNOT meet this claim — any in-flight transaction at
+primary-kill time is lost.
+
+Chart 0.1.2 ships synchronous replication as the **default** mode:
+
+| Knob | Default | Rendered into primary's `postgresql.parameters` |
+|---|---|---|
+| `replication.mode` | `sync` | (gates the block below) |
+| `replication.sync.commit` | `remote_apply` | `synchronous_commit: "remote_apply"` |
+| `replication.sync.numSync` | `1` | `synchronous_standby_names: "FIRST 1 (<replica-cluster-name>)"` |
+
+How the replica is identified to the primary: the replica's
+`externalClusters[].connectionParameters` opens a streaming
+replication connection whose `application_name` defaults to the
+replica Cluster CR's name (`<fullname>-replica`). PostgreSQL's
+`synchronous_standby_names` matcher then resolves the entry to the
+live walreceiver attached to that connection.
+
+#### Failure modes (documented for operators)
+
+1. **Replica unreachable / partitioned:** primary BLOCKS new
+   transactions on COMMIT until the replica's walreceiver returns
+   or the operator runs a break-glass downgrade
+   (`ALTER SYSTEM SET synchronous_standby_names = ''; SELECT
+   pg_reload_conf();`). This is by design — losing availability is
+   the price of zero-tx-loss durability. Continuum K-Cont-2's
+   switchover path treats a replica-down event as a "freeze writes
+   on primary" signal, not a "promote replica" signal (the replica
+   may be behind by more than `targetLagSeconds`).
+2. **Replica slow / WAL lag spike:** every COMMIT on the primary
+   waits for the replica's replay. On Hetzner FSN ↔ HEL (~10 ms
+   RTT) the per-commit latency is bounded by the round-trip plus
+   the replica's WAL replay time (typically <5 ms for small txs).
+   On geographically distant pairs (~100 ms RTT) every commit sees
+   that latency. Operators selecting such pairs MUST be aware of
+   the latency tax.
+3. **Async opt-out:** `replication.mode: async` exists for forensic
+   / lab use only; the rendered primary then omits both
+   `synchronous_commit` and `synchronous_standby_names` and falls
+   back to PostgreSQL's defaults (`synchronous_commit = on`, no
+   forced standbys). Production deployments MUST run `sync`.
+
+#### Why `remote_apply` (not `remote_write` or `on`)
+
+`remote_apply` requires the replica to have *replayed* the WAL
+before COMMIT returns — meaning a SELECT on the replica
+immediately after COMMIT will see the row. This is the bar required
+for Pillar 3: if the primary region dies one tick after a
+successful COMMIT, the replica already has the data visible and
+queryable. `remote_write` (replica received but didn't fsync) allows
+a replica-OS crash to lose the tx; `on` is local-fsync-only with no
+remote ordering guarantee. Operators MAY relax to `remote_write`
+via `replication.sync.commit: remote_write` if their fault model
+excludes simultaneous replica-OS crash, but the chart default is
+the strongest mode.
+
+#### Bookkeeping
+
+- Companion fix: bp-wordpress-tenant chart (which renders the same
+  pair pattern inline for tenant Postgres) carries the identical
+  synchronous block, guarded by the same `replication.mode` value
+  passed through from the Application spec.
+- Continuum K-Cont-2's switchover sequencer does NOT need to know
+  about the sync mode — it operates on the Cluster CR
+  `replica.enabled` flip; the WAL durability bar is held by the
+  primary's postgresql.conf alone.
+- Acceptance test (C-DB-3, deferred): the 1M-row + region-kill
+  assertion now becomes "count == 1_000_000 EXACTLY on the
+  promoted replica" (zero-tx-loss), no longer "within the
+  configured async-lag tolerance."
+
 ---
 
 ## Deferred — C-DB-3 acceptance test plan
@@ -162,9 +243,14 @@ shipped here. The future implementer's brief:
    auto-promote because the replica is in a different Cluster CR).
 4. **Continuum K-Cont-2 promotes** the replica via the
    replica.enabled flip.
-5. **Assert no data loss** within RPO: query the new primary,
-   assert count == 1_000_000 (no async-replication tail loss
-   beyond the configured `targetLagSeconds`).
+5. **Assert no data loss** (zero-tx-loss bar, chart 0.1.2+):
+   query the new primary, assert count == 1_000_000 EXACTLY.
+   Synchronous replication (`replication.mode: sync`,
+   `synchronous_commit: remote_apply`) guarantees every committed
+   tx is replayed on the replica before COMMIT returns; the
+   replica-promote path therefore loses zero transactions on
+   region-kill. (Async-mode runs of the same fixture document a
+   bounded tail loss; sync-mode runs do not.)
 6. **Restore the original region**, run the failback path
    (Continuum K-Cont-2 manual-approval gate), assert the original
    primary becomes the new replica.

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.1.1
+  version: 0.1.2
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -139,6 +139,48 @@ spec:
               the primary region's reads inside the region and
               falls through to the replica region only when no
               local primary backend exists.
+      replication:
+        type: object
+        properties:
+          mode:
+            type: string
+            enum: [sync, async]
+            default: sync
+            description: |
+              Replication MODE.
+
+              `sync` (DEFAULT, canonical for Pillar 3 zero-tx-loss):
+              configures the primary CNPG Cluster CR with
+              `synchronous_commit = remote_apply` and
+              `synchronous_standby_names = FIRST 1 (<replica>)`.
+              COMMIT on the primary blocks until the replica has
+              replayed the WAL. This is the bar required for
+              region-kill failover with zero transactions lost.
+
+              `async` (forensic/lab only): leaves the primary at
+              PostgreSQL's default async streaming. In-flight
+              transactions at primary-kill time are LOST.
+              Production deployments MUST use `sync`.
+          sync:
+            type: object
+            properties:
+              commit:
+                type: string
+                enum: [on, remote_write, remote_apply]
+                default: remote_apply
+                description: |
+                  PostgreSQL `synchronous_commit` level (strongest
+                  durability = `remote_apply`: replica must have
+                  REPLAYED the WAL before COMMIT returns).
+              numSync:
+                type: integer
+                minimum: 1
+                maximum: 3
+                default: 1
+                description: |
+                  Number of synchronous standbys required to ACK
+                  COMMIT. For a 2-region pair (primary + 1 replica)
+                  the canonical value is 1.
       image:
         type: object
         required: [tag]
@@ -158,8 +200,12 @@ spec:
 
   placementSchema:
     # The cluster-pair IS the placement — primary + replica are the
-    # two regions. CNPG's replication model is asynchronous-streaming
-    # primary + 1 replica region; multi-replica-region (active-
+    # two regions. Replication is SYNCHRONOUS by default
+    # (`synchronous_commit = remote_apply` + `synchronous_standby_names
+    # = FIRST 1 (<replica>)`) to honour the Pillar 3 zero-transactions-
+    # lost claim. Operators may opt down to asynchronous streaming via
+    # `replication.mode: async` for forensic / lab use; production
+    # deployments MUST stay on `sync`. Multi-replica-region (active-
     # active for Postgres) is out of scope per master-brief §9.6.
     modes: [active-hotstandby]
     minRegions: 2

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-cnpg-pair
-version: 0.1.1
-appVersion: "0.1.1"
+version: 0.1.2
+appVersion: "0.1.2"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair
   across two Hetzner regions. Companions the existing `bp-cnpg`
@@ -32,6 +32,23 @@ description: |
 
   Changelog
   ─────────
+  0.1.2 (2026-05-20, Pillar 3 zero-tx-loss fix, Refs #2064)
+    - Default replication MODE is now SYNCHRONOUS
+      (`replication.mode: sync` + `synchronous_commit: remote_apply`
+      + `synchronous_standby_names: FIRST 1 (<replica>)`). The
+      asynchronous-streaming default in chart 0.1.1 could not honour
+      the canonical Pillar 3 claim of "zero transactions lost" on
+      region-kill failover; chart 0.1.2 closes that gap.
+    - New configSchema knob `replication.mode` (sync|async,
+      default sync) + `replication.sync.commit` + `.sync.numSync`.
+    - `async` mode kept for forensic / lab use only; production
+      deployments MUST stay on `sync`. See DESIGN.md §7 for the
+      failure-mode disclosure (replica-unreachable → primary blocks
+      writes, replica RTT → per-commit latency tax).
+    - Render-gate test extended: assert `synchronous_commit` +
+      `synchronous_standby_names` present on primary by default;
+      assert both ABSENT when `replication.mode=async`.
+
   0.1.1 (2026-05-09, qa-loop iter-6 fix-33, #1101)
     - Fix: drop hand-rendered service-replication.yaml; the replication
       Service is now declared via primary CNPG Cluster's

--- a/platform/cnpg-pair/chart/templates/primary-cluster.yaml
+++ b/platform/cnpg-pair/chart/templates/primary-cluster.yaml
@@ -76,6 +76,28 @@ spec:
       max_wal_senders: "10"
       max_replication_slots: "10"
       wal_level: "logical"
+      {{- /*
+      Synchronous replication (Pillar 3 zero-tx-loss).
+
+      `synchronous_commit = remote_apply` blocks the primary's COMMIT
+      until the replica has REPLAYED the WAL (strongest durability;
+      replica-side SELECTs see the row before COMMIT returns).
+
+      `synchronous_standby_names = FIRST 1 (<replica-cluster-name>)`
+      tells PostgreSQL to require an ACK from one standby connection
+      whose application_name matches the replica Cluster CR's name.
+      CNPG's externalCluster streaming connection from the replica
+      defaults application_name to the replica Cluster CR's name, so
+      this Just Works for the bp-cnpg-pair shape.
+
+      Mode "async" exists for forensic / lab use only; the rendered
+      manifest then omits both parameters and falls back to the
+      PostgreSQL default (synchronous_commit=on, no standbys forced).
+      */ -}}
+      {{- if eq (default "sync" .Values.cnpgPair.replication.mode) "sync" }}
+      synchronous_commit: {{ default "remote_apply" .Values.cnpgPair.replication.sync.commit | quote }}
+      synchronous_standby_names: {{ printf "FIRST %d (%s)" (int (default 1 .Values.cnpgPair.replication.sync.numSync)) (include "cnpg-pair.replicaName" .) | quote }}
+      {{- end }}
 
   # ── Replication-source Service (managed by CNPG, annotated for ──────
   #   Cilium ClusterMesh global routing) ──────────────────────────────

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -147,6 +147,19 @@ grep -qE 'host: .*-mesh$' "$TMP/enabled.yaml" || {
   grep -nE 'host:' "$TMP/enabled.yaml" >&2
   exit 1
 }
+# Pillar 3 (chart 0.1.2): synchronous replication MUST be the default.
+# The primary's postgresql.parameters block carries:
+#   synchronous_commit: "remote_apply"
+#   synchronous_standby_names: "FIRST 1 (<replica-name>)"
+grep -q 'synchronous_commit: "remote_apply"' "$TMP/enabled.yaml" || {
+  echo "FAIL: primary Cluster CR missing synchronous_commit=remote_apply (Pillar 3 zero-tx-loss default)." >&2
+  exit 1
+}
+grep -qE 'synchronous_standby_names: "FIRST 1 \(.+-replica\)"' "$TMP/enabled.yaml" || {
+  echo "FAIL: primary Cluster CR missing synchronous_standby_names referencing the replica Cluster name." >&2
+  grep -nE 'synchronous_standby_names' "$TMP/enabled.yaml" >&2
+  exit 1
+}
 echo "  PASS ($GOT resources)"
 
 # ── Case 3: missing image.tag fails fast ─────────────────────────
@@ -218,6 +231,30 @@ print(yaml.safe_dump_all(nontest))
 PYEOF
 if sed 's/#.*//' "$TMP/nomesh-nontest.yaml" | grep -q 'service\.cilium\.io/global'; then
   echo "FAIL: clusterMesh disabled but service.cilium.io/global annotation still rendered." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 6: replication.mode=async omits synchronous_* parameters ─
+# Chart 0.1.2: the synchronous block exists ONLY when mode=sync.
+# Forensic / lab overlays opting into async MUST get a primary
+# Cluster CR with no synchronous_commit / synchronous_standby_names
+# entries (PG falls back to defaults).
+echo "[render] Case 6: replication.mode=async omits synchronous_* parameters"
+helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.primary.region=hz-fsn-rtz-prod \
+  --set cnpgPair.replica.region=hz-hel-rtz-prod \
+  --set cnpgPair.image.tag=16.3-23 \
+  --set cnpgPair.replication.mode=async \
+  > "$TMP/async.yaml" 2> "$TMP/async.err" || {
+  echo "FAIL: async-mode render errored:" >&2
+  cat "$TMP/async.err" >&2
+  exit 1
+}
+if grep -q "synchronous_commit\|synchronous_standby_names" "$TMP/async.yaml"; then
+  echo "FAIL: replication.mode=async leaked synchronous_* parameters into the manifest." >&2
+  grep -nE "synchronous_(commit|standby_names)" "$TMP/async.yaml" >&2
   exit 1
 fi
 echo "  PASS"

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -75,6 +75,55 @@ cnpgPair:
     # NotReady, surfacing the lag in the UI's status panel.
     timeoutSeconds: 60
 
+  # ── Replication MODE — sync (DEFAULT) vs async ────────────────────
+  # CANONICAL PILLAR-3 CLAIM (CLAUDE.md §0): "zero transactions lost".
+  # Asynchronous-streaming replication CANNOT meet this claim — any
+  # in-flight transaction at primary-kill time is lost. Synchronous
+  # replication (PostgreSQL `synchronous_commit = remote_apply` +
+  # `synchronous_standby_names = "FIRST 1 (<replica>)"`) blocks the
+  # primary's COMMIT until the replica has REPLAYED the WAL, which is
+  # the bar required for zero-tx-loss on region-kill failover.
+  #
+  # Trade-off (must be disclosed to operators):
+  #   - Every commit waits one round-trip to the replica region. On
+  #     Hetzner FSN <-> HEL the RTT is ~10ms; on geographically
+  #     distant pairs (e.g. EU <-> US) the RTT may reach ~100ms and
+  #     EVERY transaction sees that latency.
+  #   - If the replica is unreachable, the primary BLOCKS WRITES
+  #     until the replica recovers (or the operator runs a documented
+  #     `ALTER SYSTEM SET synchronous_standby_names = ''` break-glass
+  #     to downgrade to async, with explicit RPO loss acceptance).
+  #     This is by design — losing availability is the price of
+  #     zero-tx-loss durability.
+  #
+  # Mode "async" exists for forensic / lab use only; production
+  # deployments MUST run "sync" to honour the pillar.
+  replication:
+    mode: sync
+
+    # Synchronous knobs — applied to the primary CNPG Cluster CR's
+    # postgresql.parameters block when mode=sync.
+    sync:
+      # PostgreSQL synchronous_commit level. Options (least to most
+      # durable):
+      #   - "on"          (default for PG): WAL flushed to disk on
+      #                    primary AND replica before COMMIT returns.
+      #   - "remote_write": replica has received but not necessarily
+      #                    flushed WAL to disk. Allows replica-side
+      #                    OS crash to lose tx. NOT canonical.
+      #   - "remote_apply": replica has REPLAYED the WAL (visible to
+      #                    SELECTs on the replica) before COMMIT
+      #                    returns. STRONGEST DURABILITY — canonical
+      #                    for Pillar 3 zero-tx-loss.
+      # Stick with remote_apply unless an overlay has a specific RPO
+      # reason to relax.
+      commit: remote_apply
+      # Number of synchronous standbys required to acknowledge before
+      # COMMIT returns. For a 2-region pair (primary + 1 replica),
+      # 1 is canonical. Increase only when the topology has multiple
+      # replicas in distinct fault domains.
+      numSync: 1
+
   # ── Cilium ClusterMesh ────────────────────────────────────────────
   # Multi-region transport. Per ADR-0001 §9 ClusterMesh is the ONLY
   # canonical inter-region transport for replication traffic. Setting

--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: tenant-app
     catalyst.openova.io/section: pts-7-sme-tenant
 spec:
-  version: 0.3.1
+  version: 0.3.2
   card:
     title: WordPress Tenant
     summary: |

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -54,7 +54,21 @@ name: bp-wordpress-tenant
 #     marketplace voucher → org wizard (D29) can present a
 #     "Postgres topology" picker instead of a boolean.
 #   - Companion to catalog-seed bp-cnpg-pair Blueprint CR (Refs TBD-E8b).
-version: 0.3.1
+# 0.3.2 (Pillar 3 zero-tx-loss, 2026-05-20, Refs #2064):
+#   - When `database.mode=active-hot-standby`, the rendered primary
+#     CNPG Cluster CR now carries `synchronous_commit: "remote_apply"`
+#     + `synchronous_standby_names: "FIRST 1 (<replica>)"` in its
+#     postgresql.parameters block by DEFAULT. Mirrors bp-cnpg-pair
+#     chart 0.1.2. The previous asynchronous-streaming default could
+#     NOT honour the canonical Pillar 3 claim of "zero transactions
+#     lost" on region-kill failover — chart 0.3.2 closes that gap.
+#   - New `pg.activeHotStandby.replication.{mode,sync.commit,
+#     sync.numSync}` block in values.yaml. Mode `async` exists for
+#     forensic / lab use only; production deployments MUST use `sync`.
+#   - Operator-facing trade-off (documented in values.yaml + DESIGN
+#     of bp-cnpg-pair §7): primary BLOCKS new writes when replica is
+#     unreachable; every COMMIT pays the inter-region RTT.
+version: 0.3.2
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one

--- a/platform/wordpress-tenant/chart/templates/cnpg-cluster.yaml
+++ b/platform/wordpress-tenant/chart/templates/cnpg-cluster.yaml
@@ -120,6 +120,30 @@ spec:
       max_wal_senders: "10"
       max_replication_slots: "10"
       wal_level: "logical"
+      {{- /*
+      Synchronous replication (Pillar 3 zero-tx-loss).
+
+      Mirrors bp-cnpg-pair chart 0.1.2. The canonical claim of "zero
+      transactions lost" on region-kill failover REQUIRES synchronous
+      replication; asynchronous-streaming loses any in-flight tx at
+      primary-kill time.
+
+      `synchronous_commit = remote_apply` blocks the primary's COMMIT
+      until the replica has REPLAYED the WAL (strongest durability).
+      `synchronous_standby_names = FIRST 1 (<replica>)` requires an
+      ACK from one standby whose application_name matches the replica
+      Cluster CR's name; CNPG's externalCluster streaming connection
+      uses the replica Cluster CR name as application_name by default,
+      so this Just Works for the bp-wordpress-tenant pair shape.
+
+      Mode "async" exists for forensic / lab use only; the rendered
+      manifest then omits both parameters and falls back to PG defaults.
+      */ -}}
+      {{- $replMode := default "sync" .Values.pg.activeHotStandby.replication.mode }}
+      {{- if eq $replMode "sync" }}
+      synchronous_commit: {{ default "remote_apply" .Values.pg.activeHotStandby.replication.sync.commit | quote }}
+      synchronous_standby_names: {{ printf "FIRST %d (%s)" (int (default 1 .Values.pg.activeHotStandby.replication.sync.numSync)) (include "bp-wordpress-tenant.cnpgPairReplicaName" .) | quote }}
+      {{- end }}
       {{- end }}
 
   resources:

--- a/platform/wordpress-tenant/chart/tests/active-hot-standby-render.sh
+++ b/platform/wordpress-tenant/chart/tests/active-hot-standby-render.sh
@@ -151,6 +151,8 @@ for c in clusters:
         mesh_anno = anno.get("service.cilium.io/global", "")
     pg_params = ((spec.get("postgresql") or {}).get("parameters") or {})
     has_hot_standby = "hot_standby" in pg_params
+    sync_commit = pg_params.get("synchronous_commit", "")
+    sync_standby = pg_params.get("synchronous_standby_names", "")
     affinity_regions = []
     aff = (spec.get("affinity") or {}).get("nodeAffinity") or {}
     rdsi = (aff.get("requiredDuringSchedulingIgnoredDuringExecution") or {})
@@ -171,6 +173,8 @@ for c in clusters:
     print(f"EXT_HOST={ext_host}")
     print(f"MESH_ANNO={mesh_anno}")
     print(f"HAS_HOT_STANDBY={has_hot_standby}")
+    print(f"SYNC_COMMIT={sync_commit}")
+    print(f"SYNC_STANDBY={sync_standby}")
 PYEOF
 then
   echo "FAIL: enabled render output failed to parse as YAML" >&2
@@ -229,6 +233,21 @@ grep -q '^MESH_ANNO=true$' "$TMP/primary-facts" || {
 }
 grep -q '^HAS_INITDB=True$' "$TMP/primary-facts" || {
   echo "FAIL: primary Cluster missing bootstrap.initdb." >&2
+  cat "$TMP/primary-facts" >&2
+  exit 1
+}
+# Pillar 3 (chart 0.3.2): synchronous replication MUST be the default
+# on the primary when database.mode=active-hot-standby. The primary's
+# postgresql.parameters block carries:
+#   synchronous_commit: "remote_apply"
+#   synchronous_standby_names: "FIRST 1 (wordpress-db-replica)"
+grep -q '^SYNC_COMMIT=remote_apply$' "$TMP/primary-facts" || {
+  echo "FAIL: primary Cluster missing synchronous_commit=remote_apply (Pillar 3 zero-tx-loss default)." >&2
+  cat "$TMP/primary-facts" >&2
+  exit 1
+}
+grep -q '^SYNC_STANDBY=FIRST 1 (wordpress-db-replica)$' "$TMP/primary-facts" || {
+  echo "FAIL: primary Cluster missing synchronous_standby_names=FIRST 1 (wordpress-db-replica)." >&2
   cat "$TMP/primary-facts" >&2
   exit 1
 }
@@ -350,6 +369,29 @@ fi
 if ! grep -q '^MESH_ANNOS=0$' "$TMP/nomesh-summary"; then
   echo "FAIL: clusterMesh disabled but service.cilium.io/global annotation still rendered." >&2
   cat "$TMP/nomesh-summary" >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 6: replication.mode=async omits synchronous_* parameters ─
+# Chart 0.3.2: the synchronous block exists ONLY when mode=sync.
+# Forensic / lab overlays opting into async MUST get a primary
+# Cluster CR with no synchronous_commit / synchronous_standby_names
+# entries (PG falls back to defaults).
+echo "[d31-render] Case 6: replication.mode=async omits synchronous_* parameters"
+helm template smoke-wp . "${COMMON_SET[@]}" "${API_VERSIONS[@]}" \
+  --set "pg.activeHotStandby.enabled=true" \
+  --set "pg.activeHotStandby.primaryRegion=hz-fsn-rtz-prod" \
+  --set "pg.activeHotStandby.replicaRegion=hz-hel-rtz-prod" \
+  --set "pg.activeHotStandby.replication.mode=async" \
+  > "$TMP/async.yaml" 2> "$TMP/async.err" || {
+  echo "FAIL: async-mode render errored:" >&2
+  cat "$TMP/async.err" >&2
+  exit 1
+}
+if grep -q "synchronous_commit\|synchronous_standby_names" "$TMP/async.yaml"; then
+  echo "FAIL: replication.mode=async leaked synchronous_* parameters into the manifest." >&2
+  grep -nE "synchronous_(commit|standby_names)" "$TMP/async.yaml" >&2
   exit 1
 fi
 echo "  PASS"

--- a/platform/wordpress-tenant/chart/values.yaml
+++ b/platform/wordpress-tenant/chart/values.yaml
@@ -223,6 +223,26 @@ pg:
       # (replica region has zero `cnpg-role=primary` backends so its
       # WAL traffic ALWAYS crosses the mesh to the primary region).
       affinity: local
+    # Replication MODE — sync (DEFAULT) vs async. Mirrors bp-cnpg-pair
+    # 0.1.2 + DESIGN.md §7. The canonical Pillar 3 claim of "zero
+    # transactions lost" on region-kill failover REQUIRES synchronous
+    # replication; the previous async-streaming default could not
+    # honour it. `replication.mode: sync` renders
+    # `synchronous_commit: remote_apply` + `synchronous_standby_names:
+    # FIRST 1 (<replica-cluster-name>)` into the primary CNPG Cluster
+    # CR's `postgresql.parameters`. `async` exists for forensic / lab
+    # use only; production deployments MUST stay on `sync`.
+    #
+    # Trade-off (operator-disclosure): every COMMIT on the primary
+    # waits for the replica to REPLAY the WAL — bounded by the
+    # inter-region RTT (Hetzner FSN<->HEL ~10 ms). If the replica is
+    # unreachable, the primary BLOCKS new writes until recovery or
+    # an explicit break-glass downgrade.
+    replication:
+      mode: sync
+      sync:
+        commit: remote_apply
+        numSync: 1
     # NOTE: instances/storage/resources are NOT re-declared here. The
     # primary + replica BOTH inherit from `database.cluster.{instances,
     # storageSize,storageClass,resources}` above so the operator wizard

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -119,7 +119,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "section": "pts-9-disaster-recovery",
       "depends": [
         "bp-cnpg",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -166,7 +166,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "section": "pts-9-disaster-recovery",
     "depends": [
       "bp-cnpg",


### PR DESCRIPTION
## Summary

Closes the headline finding from the Pillar 3 audit (`/tmp/audit-pillar3-cnpg-2026-05-20.md`, surface #9 verdict `WIRED-INCORRECT`): the canonical claim in `CLAUDE.md §0` — _"2 independent CNPG clusters with ReplicaCluster sync ... + region-kill failover with **zero transactions lost**"_ — is **unachievable** with asynchronous-streaming replication. Chart 0.1.1 ran async-streaming as the default, admitted verbatim in `platform/cnpg-pair/blueprint.yaml:161`, and `DESIGN.md:66` deferred `synchronous_commit` to "a future Blueprint."

This PR ships the synchronous default in both surfaces where the pair is rendered:

- **`bp-cnpg-pair` chart 0.1.1 → 0.1.2** — primary's `postgresql.parameters` block now renders `synchronous_commit: "remote_apply"` + `synchronous_standby_names: "FIRST 1 (<replica-cluster-name>)"` by default.
- **`bp-wordpress-tenant` chart 0.3.1 → 0.3.2** — the actual deployed install path (per audit surface #11) gets the same block in `database.mode=active-hot-standby` mode.

The replica Cluster CR's `externalClusters[]` streaming connection uses its own Cluster name as the PostgreSQL `application_name`, so `synchronous_standby_names: "FIRST 1 (<replica>)"` resolves to the live walreceiver attached to that connection.

## Disclosures (per Principle #2 — _no compromise from quality_)

These are documented in `values.yaml` + `DESIGN.md §7` so operators see them at install time:

- **Replica unreachable → primary BLOCKS writes.** By design — losing availability is the price of zero-tx-loss durability. Operators have a documented `ALTER SYSTEM SET synchronous_standby_names = ''` break-glass with explicit RPO loss acceptance.
- **Every COMMIT pays the inter-region RTT.** Hetzner FSN ↔ HEL ~10 ms; geographically distant pairs (~100 ms) tax every transaction.
- **`replication.mode: async` opt-out** kept for forensic / lab use only; production deployments **MUST** use `sync`.

## What this PR does NOT do (intentionally — `Refs #2064` not `Closes`)

- **Does not deploy `bp-continuum`** — that's TBD-V14 / #2065. Without the controller, sync replication alone won't trigger automatic failover; this PR fixes the **data-loss CLAIM** (WAL durability bar), the orchestrator piece is separate.
- **Does not ship the D31 acceptance test** — 1M-row + region-kill + count==1M assertion is #2067.
- **Does not close #2064.** Operator walk on a fresh multi-region prov with a counter-incrementing region-kill test is required per `CLAUDE.md §4` anti-theater rule. Issue closes after the verification screenshot.

## Lockstep version bumps (Principle #14)

| File | Old | New |
|---|---|---|
| `platform/cnpg-pair/chart/Chart.yaml` | 0.1.1 | 0.1.2 |
| `platform/wordpress-tenant/chart/Chart.yaml` | 0.3.1 | 0.3.2 |
| `products/catalyst/bootstrap/api/internal/catalog/blueprints.json` (bp-cnpg-pair entry) | 0.1.1 | 0.1.2 |
| `products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts` (bp-cnpg-pair entry) | 0.1.1 | 0.1.2 |

`bp-cnpg-pair` is not in `scripts/expected-bootstrap-deps.yaml` (per audit surface #11 — only renders inline via `bp-wordpress-tenant` today), and `bp-wordpress-tenant` is pinned at `version: "*"` in `sme_tenant_gitops.go`, so no bootstrap-kit slot needs touching.

## Validation (Principle #15)

- `helm template` renders the synchronous block on both charts' primaries (verified locally; sample line: `synchronous_standby_names: "FIRST 1 (wordpress-db-replica)"`).
- `kubectl apply --dry-run=client` succeeds on the rendered manifest (NOT server-side — server lies when the CRD is pre-installed, per PR #1933 regression).
- `helm lint` clean.
- `tests/cnpg-pair-render.sh`: **6/6 PASS** (5 pre-existing + new Case 6 for async mode).
- `tests/active-hot-standby-render.sh`: **6/6 PASS** (5 pre-existing + new Case 6, plus 2 new sync-block assertions in Case 2).

## Test plan

- [ ] CI green on both chart-render gates (`platform/cnpg-pair/chart/tests/cnpg-pair-render.sh` + `platform/wordpress-tenant/chart/tests/active-hot-standby-render.sh`).
- [ ] CI green on the Blueprint Release workflow (chart-publish, GHCR `oci://ghcr.io/openova-io/blueprints/bp-cnpg-pair:0.1.2` materialises).
- [ ] Once `bp-continuum` + acceptance-test PRs land (#2065 + #2067), an operator runs the D31 walk on a fresh multi-region prov:
  - 1M-row write to primary
  - Confirm replica row-count == 1_000_000 via mesh service
  - Kill primary region
  - Continuum K-Cont-2 promotes replica
  - Confirm count on new primary == 1_000_000 **EXACTLY** (zero-tx-loss bar; chart 0.1.1 async would lose the tail)
  - Screenshot lands as a comment on #2064 (operator-walk DoD)

Refs #2064
Refs #1831