### PR TITLE
feat(provisioning): generalize bp-cnpg-pair install path beyond WP-only (Refs #2068)

### DIFF
--- a/core/services/catalog/handlers/seed.go
+++ b/core/services/catalog/handlers/seed.go
@@ -699,10 +699,21 @@ func (h *Handler) seedSystemApps(ctx context.Context) {
 	replicasField := store.ConfigField{Key: "replicas", Label: "Replicas", Type: "int", Default: 1, Min: intPtr(1), Max: intPtr(5), Description: "Number of database instances in the cluster.", Advanced: false}
 	diskField := store.ConfigField{Key: "disk_gb", Label: "Storage (GB)", Type: "int", Default: 5, Min: intPtr(1), Max: intPtr(500), Description: "Persistent volume size per replica.", Advanced: false}
 	backupField := store.ConfigField{Key: "backups_enabled", Label: "Daily backups", Type: "bool", Default: false, Description: "Enable daily backups to object storage.", Advanced: true}
+	// Pillar-3 active-hot-standby (TBD-V17 #2068). When the customer
+	// flips active_hot_standby on AND picks distinct primary/replica
+	// regions, the provisioning gitops emit the bp-cnpg-pair
+	// HelmRelease shape instead of the single-Pod legacy postgres
+	// Deployment — primary + replica CNPG Cluster CRs across two
+	// regions with synchronous WAL streaming over Cilium ClusterMesh.
+	// Default-OFF so every existing customer keeps the historical
+	// single-cluster shape with zero regression.
+	activeHotStandbyField := store.ConfigField{Key: "active_hot_standby", Label: "Active-hot-standby (multi-region DR)", Type: "bool", Default: false, Description: "Primary + replica Postgres across two regions with synchronous replication. Requires distinct primary_region and replica_region.", Advanced: true}
+	primaryRegionField := store.ConfigField{Key: "primary_region", Label: "Primary region", Type: "string", Description: "Region key for the primary Cluster (e.g. hz-fsn-rtz-prod). Required when active_hot_standby=true.", Advanced: true}
+	replicaRegionField := store.ConfigField{Key: "replica_region", Label: "Replica region", Type: "string", Description: "Region key for the replica Cluster — MUST differ from primary_region.", Advanced: true}
 
 	systemApps := []store.App{
 		{Slug: "mysql", Name: "MySQL", Tagline: "Relational database engine", Description: "Managed MySQL backing store. Provisioned automatically when required by an app dependency.", Category: "database", Icon: "\U0001F5C4", IconBg: "#00758F", System: true, Kind: "service", Shareable: true, Free: true, RamMB: 256, CpuMilli: 200, DiskGB: 5, HelmChart: "mysql", HelmRepo: "https://charts.bitnami.com/bitnami", ConfigSchema: []store.ConfigField{replicasField, diskField, backupField}, CreatedAt: now, UpdatedAt: now},
-		{Slug: "postgres", Name: "PostgreSQL", Tagline: "Advanced open-source relational database", Description: "Managed PostgreSQL backing store. Provisioned automatically when required by an app dependency.", Category: "database", Icon: "\U0001F418", IconBg: "#336791", System: true, Kind: "service", Shareable: true, Free: true, RamMB: 256, CpuMilli: 200, DiskGB: 5, HelmChart: "postgresql", HelmRepo: "https://charts.bitnami.com/bitnami", ConfigSchema: []store.ConfigField{replicasField, diskField, backupField}, CreatedAt: now, UpdatedAt: now},
+		{Slug: "postgres", Name: "PostgreSQL", Tagline: "Advanced open-source relational database", Description: "Managed PostgreSQL backing store. Provisioned automatically when required by an app dependency.", Category: "database", Icon: "\U0001F418", IconBg: "#336791", System: true, Kind: "service", Shareable: true, Free: true, RamMB: 256, CpuMilli: 200, DiskGB: 5, HelmChart: "postgresql", HelmRepo: "https://charts.bitnami.com/bitnami", ConfigSchema: []store.ConfigField{replicasField, diskField, backupField, activeHotStandbyField, primaryRegionField, replicaRegionField}, CreatedAt: now, UpdatedAt: now},
 		{Slug: "redis", Name: "Redis", Tagline: "In-memory key-value cache", Description: "Managed Redis backing cache. Provisioned automatically when required by an app dependency.", Category: "database", Icon: "R", IconBg: "#DC382D", System: true, Kind: "service", Shareable: true, Free: true, RamMB: 128, CpuMilli: 100, DiskGB: 1, HelmChart: "redis", HelmRepo: "https://charts.bitnami.com/bitnami", ConfigSchema: []store.ConfigField{{Key: "replicas", Label: "Replicas", Type: "int", Default: 1, Min: intPtr(1), Max: intPtr(3), Description: "Number of Redis instances.", Advanced: false}, {Key: "persistence", Label: "Persistence", Type: "bool", Default: true, Description: "Persist data to disk (disable for pure cache).", Advanced: true}}, CreatedAt: now, UpdatedAt: now},
 	}
 

--- a/core/services/provisioning/gitops/appconfigs_test.go
+++ b/core/services/provisioning/gitops/appconfigs_test.go
@@ -271,3 +271,220 @@ func TestReadIntCfg_MistypeFallsBack(t *testing.T) {
 		t.Errorf("got %d want 1 (default) on string mistype", got)
 	}
 }
+
+// TestPostgres_AppConfigs_ActiveHotStandby_GenericApp — TBD-V17
+// (#2068). The Pillar-3 cluster-pair install path MUST trigger for a
+// NON-WordPress postgres-backed marketplace app (this test uses
+// `umami`, which is one of the canonical non-WP postgres-backed apps
+// in seed.go:60-92). Before #2068 the bp-cnpg-pair Cluster CRs were
+// emitted ONLY by bp-wordpress-tenant's inline cnpg-cluster.yaml
+// template — every non-WP customer journey through Pillar 3 was
+// silently broken, and the audit at /tmp/audit-pillar3-cnpg-2026-05-
+// 20.md flagged this gap.
+//
+// With active_hot_standby=true + distinct primary_region/replica_region,
+// the rendered output MUST:
+//
+//	1. Emit `db-cnpg-pair.yaml` (the bp-cnpg-pair HelmRelease + its
+//	   companion HelmRepository + postgres-credentials Secret).
+//	2. NOT emit `db-postgres.yaml` (the legacy single-Pod Deployment
+//	   would collide on `postgres` Service name and credentials Secret).
+//	3. Carry the customer-chosen region pair into the HelmRelease values.
+func TestPostgres_AppConfigs_ActiveHotStandby_GenericApp(t *testing.T) {
+	g := &ManifestGenerator{BasePath: "clusters/contabo-mkt/tenants"}
+	files := g.GenerateAllWithAppConfigs("acme", "flexi",
+		[]string{"umami"}, // umami → postgres-backed, non-WordPress
+		"deadbeef",
+		map[string]map[string]any{
+			"postgres": {
+				"active_hot_standby": true,
+				"primary_region":     "hz-fsn-rtz-prod",
+				"replica_region":     "hz-hel-rtz-prod",
+				"replicas":           float64(3),
+				"disk_gb":            float64(50),
+			},
+		},
+	)
+
+	var pairManifest, legacyManifest string
+	for path, content := range files {
+		if strings.HasSuffix(path, "db-cnpg-pair.yaml") {
+			pairManifest = content
+		}
+		if strings.HasSuffix(path, "db-postgres.yaml") {
+			legacyManifest = content
+		}
+	}
+	if pairManifest == "" {
+		t.Fatal("db-cnpg-pair.yaml NOT generated when active_hot_standby=true — Pillar 3 install path broken")
+	}
+	if legacyManifest != "" {
+		t.Errorf("legacy db-postgres.yaml ALSO generated alongside cluster-pair — would collide on `postgres` Service")
+	}
+	must := []string{
+		"chart: bp-cnpg-pair",
+		"region: hz-fsn-rtz-prod", // primary
+		"region: hz-hel-rtz-prod", // replica
+		"instances: 3",
+		"size: 50Gi",
+		"database: db_umami", // per-app database name
+	}
+	for _, want := range must {
+		if !strings.Contains(pairManifest, want) {
+			t.Errorf("db-cnpg-pair.yaml missing %q — full manifest:\n%s", want, pairManifest)
+		}
+	}
+}
+
+// TestPostgres_AppConfigs_ActiveHotStandby_OFF — when the customer
+// hasn't opted in (default behavior, every pre-#2068 tenant) the
+// generic install path MUST NOT trigger. The legacy single-cluster
+// generatePostgres() rendering applies unchanged.
+func TestPostgres_AppConfigs_ActiveHotStandby_OFF(t *testing.T) {
+	g := &ManifestGenerator{BasePath: "clusters/contabo-mkt/tenants"}
+	files := g.GenerateAllWithAppConfigs("acme", "flexi",
+		[]string{"umami"},
+		"deadbeef",
+		map[string]map[string]any{
+			"postgres": {
+				"replicas": float64(2),
+				"disk_gb":  float64(10),
+				// active_hot_standby absent → defaults to false
+			},
+		},
+	)
+	for path := range files {
+		if strings.HasSuffix(path, "db-cnpg-pair.yaml") {
+			t.Errorf("db-cnpg-pair.yaml emitted with active_hot_standby unset — should default-OFF")
+		}
+	}
+	var legacy string
+	for path, content := range files {
+		if strings.HasSuffix(path, "db-postgres.yaml") {
+			legacy = content
+		}
+	}
+	if legacy == "" {
+		t.Fatal("legacy db-postgres.yaml missing — default-OFF path broken")
+	}
+}
+
+// TestPostgres_AppConfigs_ActiveHotStandby_InvalidRegionPair — when
+// the operator opts in but doesn't supply distinct primary/replica
+// regions (either empty or identical), the renderer MUST fall back to
+// the single-cluster shape rather than emit a bp-cnpg-pair HelmRelease
+// the chart's `required` template guard would reject at install time.
+// Symmetric with the WP-tenant path (sme_tenant_gitops.go:560).
+func TestPostgres_AppConfigs_ActiveHotStandby_InvalidRegionPair(t *testing.T) {
+	cases := []struct {
+		name           string
+		primary        string
+		replica        string
+		wantClusterPair bool
+	}{
+		{"identical regions", "hz-fsn-rtz-prod", "hz-fsn-rtz-prod", false},
+		{"empty primary", "", "hz-hel-rtz-prod", false},
+		{"empty replica", "hz-fsn-rtz-prod", "", false},
+		{"both empty", "", "", false},
+		{"valid pair", "hz-fsn-rtz-prod", "hz-hel-rtz-prod", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &ManifestGenerator{BasePath: "clusters/contabo-mkt/tenants"}
+			files := g.GenerateAllWithAppConfigs("acme", "flexi",
+				[]string{"umami"},
+				"deadbeef",
+				map[string]map[string]any{
+					"postgres": {
+						"active_hot_standby": true,
+						"primary_region":     tc.primary,
+						"replica_region":     tc.replica,
+					},
+				},
+			)
+			gotPair := false
+			gotLegacy := false
+			for path := range files {
+				if strings.HasSuffix(path, "db-cnpg-pair.yaml") {
+					gotPair = true
+				}
+				if strings.HasSuffix(path, "db-postgres.yaml") {
+					gotLegacy = true
+				}
+			}
+			if gotPair != tc.wantClusterPair {
+				t.Errorf("cluster-pair emitted=%v want=%v", gotPair, tc.wantClusterPair)
+			}
+			if tc.wantClusterPair && gotLegacy {
+				t.Errorf("legacy single-cluster ALSO emitted alongside cluster-pair — would collide")
+			}
+			if !tc.wantClusterPair && !gotLegacy {
+				t.Errorf("legacy single-cluster missing on fallback path — graceful degradation broken")
+			}
+		})
+	}
+}
+
+// TestPostgres_AppConfigs_ActiveHotStandby_ReplicasClamped — the
+// bp-cnpg-pair chart's configSchema floor for instances is 3 (per
+// platform/cnpg-pair/blueprint.yaml — active-hotstandby HA needs a
+// 3-node quorum per region to survive a Pod loss without read-only
+// degradation). When the customer picks replicas=1 or 2 we clamp to 3
+// and log loud rather than render a HelmRelease the chart's `minimum`
+// guard would reject.
+func TestPostgres_AppConfigs_ActiveHotStandby_ReplicasClamped(t *testing.T) {
+	g := &ManifestGenerator{BasePath: "clusters/contabo-mkt/tenants"}
+	files := g.GenerateAllWithAppConfigs("acme", "flexi",
+		[]string{"umami"},
+		"deadbeef",
+		map[string]map[string]any{
+			"postgres": {
+				"active_hot_standby": true,
+				"primary_region":     "hz-fsn-rtz-prod",
+				"replica_region":     "hz-hel-rtz-prod",
+				"replicas":           float64(1), // below the bp-cnpg-pair floor of 3
+			},
+		},
+	)
+	var pairManifest string
+	for path, content := range files {
+		if strings.HasSuffix(path, "db-cnpg-pair.yaml") {
+			pairManifest = content
+		}
+	}
+	if pairManifest == "" {
+		t.Fatal("db-cnpg-pair.yaml not generated")
+	}
+	if !strings.Contains(pairManifest, "instances: 3") {
+		t.Errorf("replicas=1 not clamped to instances:3 — full manifest:\n%s", pairManifest)
+	}
+	if strings.Contains(pairManifest, "instances: 1") {
+		t.Errorf("instances:1 leaked into rendered HelmRelease — chart's minimum:3 guard would reject install")
+	}
+}
+
+// TestReadStringCfg_HandlesNilAndMistype documents the contract of the
+// new readStringCfg helper (added by #2068 for the cnpg-pair region
+// pair pickups). Mirrors the readIntCfg / readBoolCfg coverage.
+func TestReadStringCfg_HandlesNilAndMistype(t *testing.T) {
+	if got := readStringCfg(nil, "primary_region", "default", "test"); got != "default" {
+		t.Errorf("nil cfg: got %q want default", got)
+	}
+	cfg := map[string]any{
+		"primary_region": float64(42), // wrong type
+		"replica_region": "hz-hel-rtz-prod",
+		"empty_string":   "",
+	}
+	if got := readStringCfg(cfg, "primary_region", "fallback", "test"); got != "fallback" {
+		t.Errorf("mistype: got %q want fallback", got)
+	}
+	if got := readStringCfg(cfg, "replica_region", "fallback", "test"); got != "hz-hel-rtz-prod" {
+		t.Errorf("valid: got %q want hz-hel-rtz-prod", got)
+	}
+	if got := readStringCfg(cfg, "missing_key", "dflt", "test"); got != "dflt" {
+		t.Errorf("missing: got %q want dflt", got)
+	}
+	if got := readStringCfg(cfg, "empty_string", "dflt", "test"); got != "" {
+		t.Errorf("empty string is a valid value: got %q want empty", got)
+	}
+}

--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -72,6 +72,29 @@ func readBoolCfg(cfg map[string]any, key string, dflt bool, appSlug string) bool
 	return v
 }
 
+// readStringCfg returns a string value from an opaque configSchema
+// map. Same semantics as readIntCfg / readBoolCfg for missing/mistyped
+// values. Used by the active-hot-standby cnpg-pair path (TBD-V17 #2068)
+// to thread `primary_region` / `replica_region` picks from the
+// Postgres-backed app's configSchema into the rendered bp-cnpg-pair
+// HelmRelease.
+func readStringCfg(cfg map[string]any, key, dflt, appSlug string) string {
+	if cfg == nil {
+		return dflt
+	}
+	raw, ok := cfg[key]
+	if !ok {
+		return dflt
+	}
+	v, ok := raw.(string)
+	if !ok {
+		slog.Warn("readStringCfg: value has unexpected type — falling back to default",
+			"app", appSlug, "key", key, "type", fmt.Sprintf("%T", raw), "default", dflt)
+		return dflt
+	}
+	return v
+}
+
 // logUnknownKeys emits a Warn for every key in cfg that is NOT in the
 // known configSchema's KnownKeys list. Prevents a stale frontend from
 // silently smuggling arbitrary keys (like extra YAML chunks) into the
@@ -193,7 +216,42 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 		"namespace.yaml": generateAppNamespace(appNS),
 	}
 	if len(postgresApps) > 0 {
-		vcFiles["db-postgres.yaml"] = generatePostgres(appNS, dbPassword, postgresApps, appConfigs["postgres"])
+		// TBD-V17 (#2068) — Pillar 3 generic install path for
+		// bp-cnpg-pair. When the customer's Postgres-backed app
+		// configSchema declares `active_hot_standby: true` AND a valid
+		// distinct primary_region / replica_region pair, render a
+		// bp-cnpg-pair HelmRelease (primary + replica CNPG Cluster CR
+		// across two regions, synchronous WAL streaming over Cilium
+		// ClusterMesh) instead of the single-Pod legacy postgres
+		// Deployment. Applies to EVERY postgres-backed app in the
+		// marketplace (Umami / NocoDB / Gitea / Plane / Twenty /
+		// Listmonk / Chatwoot / canonical Postgres-backed bundle), not
+		// just bp-wordpress-tenant — that was the audit gap closed by
+		// this PR.
+		//
+		// Default-OFF: when active_hot_standby is absent or false (the
+		// historical default for every tenant pre-#2068) the legacy
+		// generatePostgres() path runs unchanged — zero regression for
+		// any existing customer. Same for malformed region picks
+		// (identical primary/replica, or either missing): fall back to
+		// single-cluster shape rather than rendering a HelmRelease
+		// bp-cnpg-pair's `required` template guard would reject.
+		pgCfg := appConfigs["postgres"]
+		enableHA := readBoolCfg(pgCfg, "active_hot_standby", false, "postgres")
+		primaryRegion := strings.TrimSpace(readStringCfg(pgCfg, "primary_region", "", "postgres"))
+		replicaRegion := strings.TrimSpace(readStringCfg(pgCfg, "replica_region", "", "postgres"))
+		if enableHA && primaryRegion != "" && replicaRegion != "" && primaryRegion != replicaRegion {
+			vcFiles["db-cnpg-pair.yaml"] = generateCNPGPair(appNS, dbPassword, postgresApps, pgCfg, primaryRegion, replicaRegion)
+		} else {
+			if enableHA {
+				// Operator opted in but didn't supply distinct region
+				// pair — log loud so the gap is operator-visible rather
+				// than silently degrading to single-cluster.
+				slog.Warn("provisioning/gitops: active_hot_standby requested but region pair invalid — falling back to single-cluster postgres",
+					"app", "postgres", "primary_region", primaryRegion, "replica_region", replicaRegion)
+			}
+			vcFiles["db-postgres.yaml"] = generatePostgres(appNS, dbPassword, postgresApps, pgCfg)
+		}
 	}
 	if len(mysqlApps) > 0 {
 		vcFiles["db-mysql.yaml"] = generateMySQL(appNS, dbPassword, mysqlApps, appConfigs["mysql"])
@@ -461,7 +519,13 @@ GRANT ALL PRIVILEGES ON DATABASE %s TO app;
 	replicas := readIntCfg(cfg, "replicas", 1, 1, 5, "postgres")
 	diskGB := readIntCfg(cfg, "disk_gb", 5, 1, 500, "postgres")
 	backupsEnabled := readBoolCfg(cfg, "backups_enabled", false, "postgres")
-	logUnknownKeys(cfg, []string{"replicas", "disk_gb", "backups_enabled"}, "postgres")
+	// active_hot_standby / primary_region / replica_region are picked
+	// up upstream in GenerateAllWithAppConfigs (#2068 generic cnpg-pair
+	// install path). Adding them to the known-keys list here avoids a
+	// false-positive "unknown key" Warn when the customer chose the
+	// single-cluster shape but the orchestrator still threaded the
+	// per-app config through.
+	logUnknownKeys(cfg, []string{"replicas", "disk_gb", "backups_enabled", "active_hot_standby", "primary_region", "replica_region"}, "postgres")
 	if backupsEnabled {
 		// No chart-side binding yet — a follow-up will land a CronJob +
 		// pgdump-to-SeaweedFS sidecar. Logging here makes the gap
@@ -560,6 +624,166 @@ spec:
     - port: 5432
       targetPort: 5432
 `, ns, password, primaryDB, ns, indentBlock(initSQL, "    "), ns, diskGB, ns, backupsEnabled, replicas, ns)
+}
+
+// generateCNPGPair renders the bp-cnpg-pair HelmRelease — the Pillar-3
+// active-hot-standby Postgres install path for any postgres-backed
+// marketplace app (TBD-V17 #2068). Before this PR the cluster-pair
+// pattern existed only inline inside bp-wordpress-tenant's
+// templates/cnpg-cluster.yaml; non-WP customer apps (Umami / NocoDB /
+// Gitea / Plane / Twenty / Listmonk / Chatwoot / the canonical
+// Postgres-backed bundle from CLAUDE.md §0 step 1b) had no install
+// path to the cluster-pair shape, breaking Pillar 3 for every
+// non-WordPress customer journey.
+//
+// The HelmRelease is targetNamespace=apps (matches the legacy
+// generatePostgres deployment's ns + the postgres-credentials Secret
+// the app expects) and chart-pinned via the bp-cnpg-pair HelmRepository
+// the bootstrap-kit publishes on the tenant vCluster. Per-app database
+// names (db_<appSlug>) are wired via cnpgPair.primary.bootstrap and
+// per-database SQL extension blocks so co-installed postgres-backed
+// apps still see their own database.
+//
+// The chart's own values.yaml (platform/cnpg-pair/chart/values.yaml)
+// ships:
+//   - replication.mode: sync (synchronous remote_apply per #2064 ship)
+//   - replication.sync.commit: remote_apply
+//   - replication.sync.numSync: 1
+//   - clusterMesh.enabled: true
+//   - clusterMesh.affinity: local
+//
+// We rely on those defaults rather than overriding so per-Sovereign
+// overlays remain free to relax for forensic / lab runs. Our overlay
+// supplies ONLY the per-app surface (region pair, instance counts,
+// storage size, bootstrap db/owner credentials Secret).
+//
+// Image tag is intentionally NOT set here — the bp-cnpg-pair chart's
+// values.yaml fail-fasts on an empty image.tag (Principle #4a) so the
+// per-Sovereign overlay MUST pin a SHA digest. Leaving it empty in the
+// orchestrator output keeps the contract that overlay layer is the
+// single owner of image pins.
+func generateCNPGPair(ns, password string, apps []string, cfg map[string]any, primaryRegion, replicaRegion string) string {
+	sortedApps := sortStrings(append([]string{}, apps...))
+	primaryDB := "appdb"
+	if len(sortedApps) > 0 {
+		primaryDB = "db_" + sortedApps[0]
+	}
+
+	// configSchema knobs (same range gates as the legacy postgres
+	// path so a customer who flips active_hot_standby on doesn't see
+	// a different validation surface for `replicas` / `disk_gb`).
+	// `replicas` here maps to CNPG `instances` per region; min 3 is
+	// the bp-cnpg-pair chart's own configSchema floor for primary
+	// (active-hotstandby HA requires a 3-node quorum per region). If
+	// the customer chose 1-2 we clamp to 3 and log loud so the gap is
+	// operator-visible.
+	requested := readIntCfg(cfg, "replicas", 3, 1, 5, "postgres")
+	instances := requested
+	if instances < 3 {
+		slog.Warn("generateCNPGPair: replicas < 3 incompatible with active-hot-standby quorum — clamping to 3",
+			"app", "postgres", "requested", requested, "clamped", 3)
+		instances = 3
+	}
+	// Storage: CNPG ships its own PVC management per Cluster CR, so
+	// we surface disk_gb 1:1 (default matches bp-cnpg-pair chart
+	// default of 100Gi when customer doesn't pick — but we default to
+	// the configSchema's 5GB floor for predictability + parity with
+	// the legacy single-cluster path).
+	diskGB := readIntCfg(cfg, "disk_gb", 5, 1, 500, "postgres")
+
+	return fmt.Sprintf(`# bp-cnpg-pair — Pillar-3 active-hot-standby install path for
+# postgres-backed marketplace apps (TBD-V17 #2068). Renders the
+# primary + replica CNPG Cluster CR pair across the two regions the
+# customer picked at signup. Synchronous WAL replication over Cilium
+# ClusterMesh; failover-readiness probe + audit ConfigMap wired by the
+# chart's own templates (platform/cnpg-pair/chart/templates/*).
+#
+# postgres-credentials Secret carries the same shape the legacy
+# single-cluster path emits so co-installed marketplace apps' env
+# bindings (POSTGRES_HOST=postgres, POSTGRES_USER=app, etc.) keep
+# working. The Service the apps connect to is the primary Cluster
+# CR's bootstrap-managed RW endpoint (cnpgPair.primary.bootstrap.database
+# = primary DB name).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+  namespace: %s
+type: Opaque
+stringData:
+  POSTGRES_USER: app
+  POSTGRES_PASSWORD: "%s"
+  POSTGRES_DB: %s
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-cnpg-pair
+  namespace: %s
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-cnpg-pair
+  namespace: %s
+  labels:
+    catalyst.openova.io/component: cnpg-pair
+    openova.io/category: customer-facing-capability
+    openova.io/pillar: "3"
+spec:
+  interval: 15m
+  releaseName: cnpg-pair
+  targetNamespace: %s
+  chart:
+    spec:
+      chart: bp-cnpg-pair
+      # 0.1.2 — first version with synchronous replication default
+      # (remote_apply, numSync=1 — #2064 ship). Pinned via the
+      # bootstrap-kit slot when one lands (currently install via the
+      # vCluster HelmRepository above).
+      version: 0.1.2
+      sourceRef:
+        kind: HelmRepository
+        name: bp-cnpg-pair
+        namespace: %s
+  install:
+    timeout: 15m
+    remediation:
+      retries: 3
+  upgrade:
+    timeout: 15m
+    remediation:
+      retries: 3
+  values:
+    cnpgPair:
+      enabled: true
+      primary:
+        region: %s
+        instances: %d
+        storage:
+          size: %dGi
+          storageClass: hcloud-volumes
+        bootstrap:
+          database: %s
+          owner: app
+      replica:
+        region: %s
+        instances: %d
+        storage:
+          size: %dGi
+          storageClass: hcloud-volumes
+      # replication.mode + clusterMesh + audit defaults come from the
+      # chart's own values.yaml (sync remote_apply + numSync=1 +
+      # clusterMesh.enabled + audit subjects). Per-Sovereign overlays
+      # may patch values via Flux postBuild substitute; we intentionally
+      # do NOT override here.
+`, ns, password, primaryDB, ns, ns, ns, ns, primaryRegion, instances, diskGB, primaryDB, replicaRegion, instances, diskGB)
 }
 
 func generateMySQL(ns, password string, apps []string, cfg map[string]any) string {


### PR DESCRIPTION
## Summary

Pillar-3 audit (`/tmp/audit-pillar3-cnpg-2026-05-20.md`) flagged that `bp-cnpg-pair` was install-path-only for WordPress tenants — the cluster-pair Cluster CRs were emitted exclusively by `bp-wordpress-tenant`'s inline `templates/cnpg-cluster.yaml`. Every other postgres-backed marketplace app (Umami / NocoDB / Gitea / Plane / Twenty / Listmonk / Chatwoot / the canonical Postgres-backed bundle from CLAUDE.md §0 step 1b) had NO install path to the active-hot-standby shape — Pillar 3 was silently broken for every non-WordPress customer journey.

This PR generalizes the install path in the provisioning gitops renderer:

- `core/services/provisioning/gitops/gitops.go` — when a customer's Postgres-backed app configSchema declares `active_hot_standby: true` plus a distinct `primary_region`/`replica_region` pair, the renderer now emits `db-cnpg-pair.yaml` (the `bp-cnpg-pair` HelmRelease + companion HelmRepository + `postgres-credentials` Secret) INSTEAD OF the legacy single-Pod `db-postgres.yaml`. The chart's own values.yaml defaults (sync `remote_apply` replication, ClusterMesh enabled, audit subjects) ship through unchanged — we override ONLY per-app surface (region pair, instance count, storage size, bootstrap database name).
- `core/services/catalog/handlers/seed.go` — adds the three new configSchema fields (`active_hot_standby`/`primary_region`/`replica_region`) to the canonical `postgres` app so the marketplace frontend can surface the HA picker on any postgres-backed bundle.

### Defensive degradation paths

- **Invalid region pair** (identical, or either empty): fall back to the single-cluster shape rather than emit a HelmRelease the chart's `required` template guard would reject at install time. Mirrors `sme_tenant_gitops.go:560`.
- **Replicas-floor clamping**: `bp-cnpg-pair`'s configSchema floor for instances is 3 (quorum-per-region for HA). Customer picks of `replicas=1` or 2 are clamped to 3 and Warn-logged.
- **Default-OFF**: customers who don't flip the new toggle keep the historical single-Pod postgres Deployment with zero regression. `TestPostgres_AppConfigs_ActiveHotStandby_OFF` locks that contract.

### Pillar-3 code-side completeness

This PR + the other Pillar-3 code-side pieces (already merged or in flight) make the CODE side complete:

- #2064 sync replication — merged (`7b31736`)
- #2065 `bp-continuum` bootstrap slot — merged (`53f510b`)
- #2066 `Continuum` CR per-app — in flight
- **#2068 (this PR)** — generic install path for non-WP postgres-backed apps

Only #2067 (D31 acceptance test) + the operator-walk-with-screenshot on a fresh non-WP postgres-backed customer app remain to flip the issue to VERIFIED-PASS per CLAUDE.md §4 anti-theater rules.

### Chart bump?

No chart bump needed. The change is contained inside the `core/services/{provisioning,catalog}` Go modules, which the `core/services/**` image-build workflow rebuilds + SHA-pins on the deploy commit. The `bp-catalyst-platform` `Chart.yaml` templates are unchanged so its version stays at 1.4.229.

## Test plan

- [x] `go test ./core/services/provisioning/gitops/... -count=1` PASSES (5 new tests + the existing TBD-V27 #2042 regression locks unchanged)
- [x] `go test ./core/services/provisioning/... -count=1` PASSES
- [x] `go test ./core/services/catalog/... -count=1` PASSES
- [x] `go vet` on both modules clean
- [x] `helm template bp-cnpg-pair` chart 0.1.2 renders the expected NetworkPolicy / ConfigMap / failover-readiness Deployment / Cluster CR pair (image.tag pinned via overlay layer per Principle #4a)
- [ ] Fresh-prov walk: provision a non-WP postgres-backed app (Umami) with `active_hot_standby=true` + a 2-region pair, confirm `db-cnpg-pair.yaml` materializes in the tenant overlay, the 2 CNPG Cluster CRs reach `Ready=true`, and replication health flips green
- [ ] D31 zero-tx-loss test (#2067) — kill primary region, confirm Continuum flips traffic to replica with zero tx loss

Refs #2068
Refs #1831

🤖 Generated with [Claude Code](https://claude.com/claude-code)