### PR TITLE
docs(claude): add user-global pointer + scope-clarification at top

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,12 @@
+> **Scope of this file**: repository structure, Catalyst terminology, banned-terms, and per-component dev workflow specific to this monorepo.
+>
+> **Platform-wide working principles** for active developer sessions — anti-theater discipline, 5-pillar Definition of Done, inviolable architectural principles, GitHub disciplines, TBD-V## ticketing, sub-agent dispatch rules, microservice patterns — live in user-global `~/.claude/CLAUDE.md` (auto-loaded by Claude Code in every session). External readers without that file can rely on:
+> - [`docs/INVIOLABLE-PRINCIPLES.md`](docs/INVIOLABLE-PRINCIPLES.md) for the engineering principles
+> - [`docs/IMPLEMENTATION-STATUS.md`](docs/IMPLEMENTATION-STATUS.md) for "what's actually built today"
+> - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the design model
+
+---
+
 # OpenOva (Public Repo) — Codebase Guide for Claude
 
 This is the **public, open-source** OpenOva repository. It hosts the Catalyst platform code and Blueprint catalog.


### PR DESCRIPTION
## Summary

Per founder direction 2026-05-20: platform-wide working principles (anti-theater discipline, 5-pillar Definition of Done, inviolable architectural principles, GitHub disciplines, TBD-V## ticketing, sub-agent dispatch rules, microservice patterns) live in **user-global `~/.claude/CLAUDE.md`** auto-loaded by Claude Code in every active developer session.

This repo's `CLAUDE.md` stays focused on its proper scope:
- Repository structure
- Catalyst / Sovereign / Organization terminology
- Banned-terms list
- Per-component dev workflow + commit conventions

For external readers without the user-global file, the new top block points them at:
- [`docs/INVIOLABLE-PRINCIPLES.md`](docs/INVIOLABLE-PRINCIPLES.md) — engineering principles
- [`docs/IMPLEMENTATION-STATUS.md`](docs/IMPLEMENTATION-STATUS.md) — what's actually built today
- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — design model

## Diff shape

Single-file, additive-only — prepends a 9-line scope-clarification block before the existing `# OpenOva (Public Repo) — Codebase Guide for Claude` heading. No other content modified.

## Test plan

- [x] All 3 referenced doc files exist (`docs/INVIOLABLE-PRINCIPLES.md`, `docs/IMPLEMENTATION-STATUS.md`, `docs/ARCHITECTURE.md`)
- [x] `git diff` shows only the prepended block
- [x] Existing heading and subsequent sections untouched