### PR TITLE
fix(continuum): annotate Chart.yaml catalyst.openova.io/no-upstream=true (Refs #2080)

### DIFF
--- a/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+++ b/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
@@ -103,13 +103,17 @@ spec:
   chart:
     spec:
       chart: bp-continuum
-      # 0.1.1 — first published version. 0.1.0 was never pushed to GHCR
-      # despite Chart.yaml claiming so; the chart sat in-tree without a
-      # bootstrap-kit slot to pin it, so blueprint-release.yaml never
-      # bumped past the initial commit's no-op detect step. Bumping to
-      # 0.1.1 in the same PR as this slot forces a fresh publish and
-      # the auto-bump-pin hook (TBD-A6) lands the matching pin write.
-      version: 0.1.1
+      # 0.1.2 — TBD-V34 republish. 0.1.1 (PR #2072) was tagged in-tree
+      # but never landed in GHCR; Blueprint Release run 26144858280
+      # failed the hollow-chart guard at the "Verify upstream subcharts
+      # present in working tree" step (Chart.yaml had NO dependencies
+      # and lacked the catalyst.openova.io/no-upstream annotation).
+      # 0.1.2 adds the no-upstream opt-out + a fresh version bump to
+      # force a re-publish. Pin moves in lockstep per Inviolable
+      # Principle #13 (chart-pin bumps must match a GHCR tag that
+      # exists — verified post-merge via crane manifest before any
+      # fresh-prov walk).
+      version: 0.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-continuum

--- a/products/continuum/chart/Chart.yaml
+++ b/products/continuum/chart/Chart.yaml
@@ -7,15 +7,22 @@ description: |
   switchover sequence). Slice K-Cont-1 of EPIC-6 (#1101) ships the
   product skeleton; K-Cont-2 fills the reconcile loop.
 type: application
-# 0.1.1 (Pillar-3 unblock #2065, 2026-05-20): first PUBLISHED version.
+# 0.1.2 (TBD-V34, 2026-05-20): re-publish after PR #2072's Blueprint
+# Release run (#26144858280) failed the hollow-chart guard. 0.1.1 was
+# tagged in-tree but never landed in GHCR because this chart declares
+# NO `dependencies:` (controller-only chart, no upstream helm subchart
+# to bundle). Same shape as bp-kyverno-policies (PR #2023) and bp-
+# crossplane-claims — opt out via `catalyst.openova.io/no-upstream:
+# "true"` (added to annotations below in this same edit). Bumping
+# 0.1.1 → 0.1.2 forces a fresh publish; bootstrap-kit slot 62 pin
+# moves to 0.1.2 in lockstep (Inviolable Principle #13).
+#
+# 0.1.1 (Pillar-3 unblock #2065, 2026-05-20): first attempt at a
+# PUBLISHED version — never reached GHCR; see above.
 # 0.1.0 sat in-tree without a bootstrap-kit slot to pin it, so the
 # blueprint-release workflow's `detect changed paths` step never had
-# reason to re-run and the chart was never pushed to GHCR. Bumping the
-# pin in lockstep with the new slot file (clusters/_template/bootstrap-
-# kit/62-bp-continuum.yaml) makes blueprint-release publish the chart
-# on this PR's merge; the auto-bump-pin hook (TBD-A6) then converges
-# the slot pin via a no-op (already matches).
-version: 0.1.1
+# reason to re-run and the chart was never pushed to GHCR.
+version: 0.1.2
 appVersion: "0.1.0"
 home: https://openova.io
 sources:
@@ -36,6 +43,18 @@ annotations:
   openova.io/category: customer-facing-capability
   openova.io/epic: "6"
   openova.io/depends-on: bp-cnpg-pair,bp-powerdns,pdm
+  # no-upstream: this chart legitimately ships only Catalyst-authored
+  # resources (controller Deployment + RBAC + Service + NetworkPolicy
+  # — see templates/). The Continuum CRD lives in products/catalyst/
+  # chart/crds/continuum.yaml and is installed by bp-catalyst-platform
+  # (slot 13) to avoid the helm-controller / kustomize-controller
+  # ownership flap on duplicated CRDs (see crds/README.md). There is
+  # no upstream Helm subchart to bundle. Same shape as bp-kyverno-
+  # policies (PR #2023) and bp-crossplane-claims. Without this
+  # annotation the Blueprint-Release hollow-chart guard (issue #181)
+  # rejects publish — proven by failed workflow run 26144858280
+  # (commit 53f510b9, PR #2072 merge, 2026-05-20T06:11:02Z).
+  catalyst.openova.io/no-upstream: "true"
   # smoke-render-mode: default-off — bp-continuum's chart ships
   # `continuum.enabled: false` as its default; helm template with
   # default values legitimately renders zero resources (per chart


### PR DESCRIPTION
## Summary

Adds `catalyst.openova.io/no-upstream: "true"` annotation to `products/continuum/chart/Chart.yaml` so the Blueprint-Release CI hollow-chart guard (issue #181) allows the chart to publish, and bumps the chart + bootstrap-kit pin to `0.1.2` in lockstep to force a fresh publish (0.1.1 never reached GHCR).

## Root cause (TBD-V34 / #2080)

PR #2072 (Pillar-3 unblock, Refs #2065) merged at 2026-05-20T06:10:59Z. The post-merge Blueprint Release workflow run [26144858280](https://github.com/openova-io/openova/actions/runs/26144858280) **FAILED** at the `build (products/continuum)` job's step "Verify upstream subcharts present in working tree (post-dependency-build)":

```
##[error]Chart products/continuum/chart/Chart.yaml declares NO
  dependencies. Every Blueprint umbrella chart at platform/<name>/chart/
  MUST declare its upstream chart under `dependencies:` per
  docs/BLUEPRINT-AUTHORING.md §11.1 Umbrella shape. See issue #181.
  (To opt out for charts that legitimately ship only Catalyst-authored
   CRs, set annotations.catalyst.openova.io/no-upstream: "true".)
```

The `Helm push to GHCR` step and everything downstream was skipped. `crane manifest ghcr.io/openova-io/bp-continuum:0.1.1` returns NAME_UNKNOWN. The bootstrap-kit slot 62 pin at 0.1.1 is dead — any fresh-prov walk hits `ArtifactFailed` at slot 62 and Pillar-3 (Continuum DR orchestrator) cannot install.

## Why this chart is legitimately no-upstream

Same shape as PR #2023 (bp-kyverno-policies) and bp-crossplane-claims: the chart ships only Catalyst-authored resources (controller Deployment + RBAC + Service + NetworkPolicy — see `products/continuum/chart/templates/`). The `Continuum.dr.openova.io/v1` CRD lives in `products/catalyst/chart/crds/continuum.yaml` and is installed by bp-catalyst-platform (slot 13) to avoid the helm-controller / kustomize-controller ownership flap on duplicated CRDs (see `products/continuum/chart/crds/README.md`). There is no upstream Helm subchart to bundle.

## Change

```diff
 annotations:
   openova.io/product: continuum
   openova.io/category: customer-facing-capability
   openova.io/epic: "6"
   openova.io/depends-on: bp-cnpg-pair,bp-powerdns,pdm
+  # no-upstream: this chart legitimately ships only Catalyst-authored
+  # resources (controller Deployment + RBAC + Service + NetworkPolicy).
+  # Same shape as bp-kyverno-policies (PR #2023) and bp-crossplane-claims.
+  catalyst.openova.io/no-upstream: "true"
   catalyst.openova.io/smoke-render-mode: default-off
-version: 0.1.1
+version: 0.1.2
```

Lockstep bump in `clusters/_template/bootstrap-kit/62-bp-continuum.yaml`:

```diff
-      version: 0.1.1
+      version: 0.1.2
```

## Validation

```
$ helm lint products/continuum/chart
==> Linting products/continuum/chart
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

$ bash scripts/check-bootstrap-kit-pin-sync.sh | grep continuum
  OK   bp-continuum: chart=0.1.2 pin=0.1.2

$ bash scripts/check-bootstrap-deps.sh | grep continuum
  [P] slot 62  bp-continuum  <-- bp-catalyst-platform bp-nats-jetstream bp-powerdns
```

## Post-merge gate (Inviolable Principle #13 / anti-theater rule)

This PR uses `Refs #2080`, NOT `Closes #2080`. Issue #2080 closes only after:

1. Blueprint Release CI on this PR's merge SHA succeeds (no hollow-chart guard failure this time).
2. `crane manifest ghcr.io/openova-io/bp-continuum:0.1.2` returns a manifest JSON (not NAME_UNKNOWN).
3. Fresh-prov walk lands slot 62 `kubectl get hr -n flux-system bp-continuum` → Ready=True.

## Test plan

- [x] `helm lint` clean
- [x] `helm template` (default-off render) renders 0 resources per the smoke-render-mode annotation
- [x] `scripts/check-bootstrap-kit-pin-sync.sh` reports `OK bp-continuum: chart=0.1.2 pin=0.1.2`
- [x] `scripts/check-bootstrap-deps.sh` reports slot 62 dependsOn intact
- [ ] Blueprint-Release CI publishes `oci://ghcr.io/openova-io/bp-continuum:0.1.2` on merge
- [ ] `crane manifest ghcr.io/openova-io/bp-continuum:0.1.2` returns 200 + manifest JSON
- [ ] Fresh-prov walk: slot 62 HelmRelease Ready=True

Refs #2080 (TBD-V34), Refs #2065 (TBD-V14), Refs #2072 (the dead-pin PR), Refs #2023 (the precedent fix), Refs #181 (hollow-chart guard origin)