### PR TITLE
ci: pre-merge guard - reject Closes/Fixes/Resolves keywords in PR body unless ci-gate-exception label

### DIFF
--- a/.github/workflows/pr-body-validate.yaml
+++ b/.github/workflows/pr-body-validate.yaml
@@ -1,0 +1,105 @@
+name: PR body validate
+
+# Pre-merge guard: REJECTS PR bodies using GitHub's auto-close keywords
+# (Closes / Fixes / Resolves / Close / Fix / Resolve + #NNN) unless the
+# PR has the `ci-gate-exception` label.
+#
+# WHY THIS GUARD EXISTS
+# ---------------------
+# GitHub auto-closes the referenced issue when a PR with a closing
+# keyword merges, REGARDLESS of operator-walk evidence. Per
+# CLAUDE.md §3 rule 1:
+#
+#   "Refs #N is the default in PR bodies, not Closes #N. Auto-close on
+#    PR merge is the enemy. Issue closes only after the operator-walk-
+#    with-screenshot lands as a comment on the issue itself."
+#
+# Trust-audit agent ae6f937a (2026-05-20) found 13 of 45 PRs in one
+# trading day used `Closes`/`Fixes` and auto-closed walk-blocked issues
+# prematurely — 51% theater rate. This guard makes the violation a
+# pre-merge red check rather than a post-merge cleanup chore.
+#
+# EXCEPTION PATH
+# --------------
+# Pure CI-gate or docs-only PRs with NO operator-visible surface MAY
+# legitimately use closing keywords (the issue's definition-of-done is
+# "this PR merges", not "operator walks a surface"). To opt in, add the
+# `ci-gate-exception` label to the PR — the `labeled` / `unlabeled`
+# triggers re-run this check whenever the label set changes, so an
+# operator can add the label after the first FAIL and the check flips
+# green without forcing an empty re-push.
+#
+# REGEX RATIONALE
+# ---------------
+# Matches: ^ or whitespace, then one of the keywords, then whitespace,
+# then `#`, then digits. Mirrors GitHub's own auto-close grammar so we
+# catch exactly what GH itself would auto-close. Quoted occurrences
+# (e.g. `"Closes #N"` inside markdown code fences or quotes) bypass the
+# guard the same way GH itself ignores them — desired parity.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  no-auto-close-keywords:
+    name: Reject Closes/Fixes/Resolves in PR body (unless ci-gate-exception)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Inspect PR body for auto-close keywords
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -u
+
+          echo "PR #${PR_NUMBER}"
+          echo "Labels: ${PR_LABELS}"
+          echo "----- PR body begin -----"
+          printf '%s\n' "${PR_BODY:-(empty)}"
+          echo "----- PR body end -----"
+
+          # Detect GitHub auto-close keywords with a whitespace/start
+          # boundary, followed by whitespace and a #NNN reference.
+          # Mirrors GH's documented closing-keyword grammar.
+          PATTERN='(^|[[:space:]])(Closes|Fixes|Resolves|Close|Fix|Resolve)[[:space:]]+#[0-9]+'
+
+          if printf '%s' "${PR_BODY:-}" | grep -iqE "${PATTERN}"; then
+            echo ""
+            echo "Detected auto-close keyword (Closes/Fixes/Resolves) referencing an issue."
+            echo ""
+            if printf '%s' "${PR_LABELS}" | tr ',' '\n' | grep -qx "ci-gate-exception"; then
+              echo "Label 'ci-gate-exception' is present — guard ALLOWS this PR."
+              echo "Reminder: this exception is reserved for pure CI-gate / docs-only"
+              echo "PRs with no operator-visible surface. Anything user-facing must"
+              echo "use 'Refs #N' and stay open until the walk-with-screenshot lands."
+              exit 0
+            fi
+
+            echo "::error::PR body uses an auto-close keyword (Closes/Fixes/Resolves) but lacks the 'ci-gate-exception' label."
+            echo ""
+            echo "Per CLAUDE.md §3 rule 1 (and the OpenOva anti-theater discipline):"
+            echo "  * Default keyword in PR bodies is 'Refs #N', NOT 'Closes #N'."
+            echo "  * GitHub auto-close on merge bypasses operator-walk DoD."
+            echo "  * Issues close only after the walk-with-screenshot lands on the issue."
+            echo ""
+            echo "How to fix:"
+            echo "  1. EITHER edit the PR body — replace 'Closes #N' / 'Fixes #N' /"
+            echo "     'Resolves #N' with 'Refs #N'. The 'edited' trigger will re-run"
+            echo "     this check automatically."
+            echo "  2. OR (only if this PR has NO operator-visible surface — e.g. a"
+            echo "     pure CI-gate fix, docs-only edit, lockstep version bump) add"
+            echo "     the 'ci-gate-exception' label. The 'labeled' trigger will"
+            echo "     re-run this check and flip it green."
+            echo ""
+            echo "If unsure which path applies, default to (1) — Refs is always safe."
+            exit 1
+          fi
+
+          echo "OK — PR body does not use Closes/Fixes/Resolves keywords."


### PR DESCRIPTION
## Summary

Adds a pre-merge CI guard (`.github/workflows/pr-body-validate.yaml`) that REJECTS any PR whose body contains GitHub auto-close keywords (the six closing keywords followed by an issue number reference) unless the PR carries the new `ci-gate-exception` label.

- Plugs the "merge auto-closes the issue regardless of operator-walk evidence" gap that produced today's 51% theater rate (13 of 45 PRs auto-closed walk-blocked issues; surfaced by trust-audit agent `ae6f937a`).
- Encodes CLAUDE.md section 3 rule 1: `Refs` is the default; closing keywords are reserved for pure CI-gate / docs-only PRs with no operator-visible surface.
- Workflow triggers on `opened`, `edited`, `reopened`, `synchronize`, `labeled`, `unlabeled` so both PR-body edits AND label changes re-trigger the check (no empty re-push needed to flip a FAIL to PASS after adding the exception label).

## Workflow logic

1. Read PR body + label list from the `pull_request` event payload.
2. Grep body with a GitHub-parity regex (the six closing keywords with a whitespace-or-start boundary and a `#NNN` reference).
3. If no match -> PASS.
4. If match AND label list contains `ci-gate-exception` -> PASS (with reminder log).
5. If match AND no exception label -> FAIL with explicit "edit body to use Refs OR add the label" guidance.

## Exception label

Already created on the repo via `gh label create ci-gate-exception --color FFA500`.

## Regex test plan (13 cases, all pass locally)

POSITIVE (must match): the six keywords at start-of-line, lowercase, indented, multi-line, short forms.

NEGATIVE (must not match): the `Refs` keyword, prose mentions without an issue-number, URL fragments with no whitespace boundary, current PR bodies that use the canonical `Refs` style.

(Concrete sample strings are deliberately omitted from THIS PR body so the guard does not trip on its own description.)

## Test plan for the live guard

- [ ] CI runs on this PR itself and passes (this PR body uses `Refs`, not a closing keyword).
- [ ] Negative E2E: open a draft test PR with a closing keyword + issue number in the body and no label -> the `no-auto-close-keywords` check FAILS.
- [ ] Recovery E2E: add the `ci-gate-exception` label to that draft -> the `labeled` trigger re-runs and the check PASSES.
- [ ] In-flight PRs that already use `Refs` (e.g. PR 2081) pass without churn.

## Non-goals

- Does NOT auto-reopen the 23 issues already prematurely auto-closed (trust-audit agent has that scope).
- Does NOT bypass the guard for any author including the operator's own PRs - the rule applies to everyone.
- Does NOT replace the future walk-verifier-driven auto-close-when-walk-passes automation - that is a separate concern.

Refs #1094

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
