### PR TITLE
docs: move OpenOva-platform specifics into canonical docs (5-pillar DoD + domains canon + anti-pattern catalog)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,11 @@
-> **Scope of this file**: repository structure, Catalyst terminology, banned-terms, and per-component dev workflow specific to this monorepo.
+> **Scope of this file**: repository structure, Catalyst terminology, banned-terms, OpenOva-platform-specific rules, and per-component dev workflow specific to this monorepo.
 >
-> **Platform-wide working principles** for active developer sessions — anti-theater discipline, 5-pillar Definition of Done, inviolable architectural principles, GitHub disciplines, TBD-V## ticketing, sub-agent dispatch rules, microservice patterns — live in user-global `~/.claude/CLAUDE.md` (auto-loaded by Claude Code in every session). External readers without that file can rely on:
+> **Generic engineering principles** for active developer sessions — anti-theater discipline, sub-agent dispatch rules, GitHub disciplines, TBD-V## ticketing, microservice patterns — live in user-global `~/.claude/CLAUDE.md` (auto-loaded by Claude Code in every session).
+>
+> **OpenOva-platform specifics** — the 5-pillar Definition of Done, the Phase 0 / 1 / 2 deterministic test, domain canon, the anti-pattern catalog, `bp-self-sovereign-cutover`, and `openova-sandbox-mcp` auto-mount — live in `docs/` of this repo. External readers without the user-global file can rely on:
+> - [`docs/5-PILLAR-DOD.md`](docs/5-PILLAR-DOD.md) for the end-user Definition of Done + Phase 0/1/2 deterministic test
+> - [`docs/DOMAINS-CANON.md`](docs/DOMAINS-CANON.md) for Sovereign and tenant-Org FQDN patterns and forbidden test strings
+> - [`docs/ANTI-PATTERN-CATALOG.md`](docs/ANTI-PATTERN-CATALOG.md) for the OpenOva-specific theater receipts surfaced during PR review
 > - [`docs/INVIOLABLE-PRINCIPLES.md`](docs/INVIOLABLE-PRINCIPLES.md) for the engineering principles
 > - [`docs/IMPLEMENTATION-STATUS.md`](docs/IMPLEMENTATION-STATUS.md) for "what's actually built today"
 > - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the design model
@@ -23,8 +28,96 @@ In order:
 2. [`docs/IMPLEMENTATION-STATUS.md`](docs/IMPLEMENTATION-STATUS.md) — what's built today vs what's design. Read before claiming any feature exists.
 3. [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — Catalyst target architecture.
 4. [`docs/NAMING-CONVENTION.md`](docs/NAMING-CONVENTION.md) — naming patterns.
+5. [`docs/5-PILLAR-DOD.md`](docs/5-PILLAR-DOD.md) — the end-user Definition of Done. Every dispatch must move at least one pillar.
+6. [`docs/DOMAINS-CANON.md`](docs/DOMAINS-CANON.md) — Sovereign / tenant-Org FQDN patterns and forbidden test strings.
+7. [`docs/ANTI-PATTERN-CATALOG.md`](docs/ANTI-PATTERN-CATALOG.md) — OpenOva-specific theater receipts. Scan diffs for these shapes during PR review.
+8. [`docs/INVIOLABLE-PRINCIPLES.md`](docs/INVIOLABLE-PRINCIPLES.md) — the 15 inviolable engineering principles.
 
-These four together define the model + implementation reality. Any contradiction in older docs is to be treated as outdated and updated to match these.
+These define the model + implementation reality + the rules of engagement. Any contradiction in older docs is to be treated as outdated and updated to match these.
+
+---
+
+## Platform-specific rules (OpenOva-only)
+
+These rules are specific to the OpenOva platform and supplement the
+**generic engineering rules** in user-global `~/.claude/CLAUDE.md`.
+
+### Definition of Done — 5-pillar end-user contract
+
+Every dispatch must advance at least one of the 5 inseparable pillars or one
+deterministic step in Phase 0 / 1 / 2 of [`docs/5-PILLAR-DOD.md`](docs/5-PILLAR-DOD.md):
+
+1. Marketplace + voucher onboarding (Phase 0 + Phase 1 a–c)
+2. Multi-region BCP topology choice at signup (Phase 1 b)
+3. Two independent CNPG clusters + region-kill failover (Phase 1 b + orthogonal D31)
+4. Sandbox + auto-mounted `openova-sandbox-mcp` with full org knowledge (Phase 2 a–e)
+5. Sovereign independence post-`bp-self-sovereign-cutover` (Principle #11 + ADR-0002)
+
+Operator-console polish, cosmetic-guard re-enables, treemap drill-down quality,
+jobs region filter, admin sidebar nav — **none of these are pillar work.** They
+are tertiary operator-debugger surfaces. Never let them displace pillar work.
+
+A pillar is **shipped** when an operator walks a **fresh prov** through the
+pillar-relevant steps and produces a screenshot + non-empty wire-capture +
+working downstream artifact. PR merge ≠ pillar shipped.
+
+### Domains canon — never `openova.io` in tests
+
+Test provs and tenant Organizations use the domains listed in
+[`docs/DOMAINS-CANON.md`](docs/DOMAINS-CANON.md):
+
+- Test Sovereign: `t<NN>.omani.works` (or `t<NN>.omantel.biz` if LE-rate-limited)
+- Tenant Organization: `<orgslug>.omani.homes` (default), `omani.rest`, or `omani.trade`
+- Voucher redeem URL: `https://marketplace.t<NN>.omani.works/redeem/?code=<CODE>`
+
+**Forbidden in tests:** `openova.io`, `omantel.openova.io`, `Nova Cloud`, `eventforge.io`.
+The legacy `admin.<sovereign-fqdn>` subdomain for voucher operations is dead —
+voucher and billing operations live in the operator console's **BSS menu**.
+
+### Anti-theater discipline during PR review
+
+Per [`docs/ANTI-PATTERN-CATALOG.md`](docs/ANTI-PATTERN-CATALOG.md), defensive-coding
+patterns are **not** approval — they are clues to investigate. Red flags to hunt:
+
+- Null-guards on empty data (PR #1185 shape)
+- `enabled: false` defaults on features the deterministic test asserts present (PR #1138 shape)
+- Click handlers missing on leaf cells (PR #1085 shape)
+- `Closes #N` on a scaffold-only PR with no operator-visible behavior change (PR #1918 shape)
+- `kubectl --dry-run=server` against a running cluster as the only validator (PR #1933 shape)
+- Multi-region claim on a single-region prov (PR #1599 shape)
+- `must_contain` token-passing tests (PR #1362/#1366/#1371/#1378 shape)
+- Python `jsonencode()` simulation passed off as `tofu validate` (PR #1892 shape)
+
+`Refs #N` is the default in PR bodies, not `Closes #N`. Auto-close on PR merge
+is the enemy. The issue closes only after the operator-walk-with-screenshot
+lands as a comment on the issue itself.
+
+### Sovereignty cutover — `bp-self-sovereign-cutover`
+
+A franchised Sovereign is tethered to the OpenOva mothership in 8 places (full
+list in [`docs/5-PILLAR-DOD.md`](docs/5-PILLAR-DOD.md) §Pillar 5 and
+[`docs/adr/0002-post-handover-sovereignty-cutover.md`](docs/adr/0002-post-handover-sovereignty-cutover.md)).
+`bp-self-sovereign-cutover` installs dormant at bootstrap-kit slot 06a during
+Phase 1 and runs eight sequential Jobs post-handover that pivot all 8 tethers.
+The final step is a **10-minute deny-egress NetworkPolicy hold** against
+`github.com`, `ghcr.io`, and `harbor.openova.io`. `cutoverComplete=true` is set
+only if the cluster reconciles green during this hold. No cutover claim
+without the egress-block proof.
+
+### Customer-sync — Gitea mirroring
+
+Each Sovereign's Gitea mirrors the public catalog from this repo on the
+operator's chosen schedule (default daily; air-gapped Sovereigns mirror via
+offline media). See §Customer Sync below for the mapping. After cutover, every
+Flux reconcile pulls **exclusively** from the local Gitea + Harbor.
+
+### Verification ledger — `docs/TRUST.md`
+
+Every claimed-done surface lives in [`docs/TRUST.md`](docs/TRUST.md) in one of
+four states: 🔴 UNVERIFIED (default) · 🟢 VERIFIED-PASS · ⛔ VERIFIED-FAIL · 🟡
+VERIFIED-PARTIAL. Every PR against a surface flips it back to UNVERIFIED
+until re-walked. Verification agents are READ-ONLY — they may not ship PRs to
+make their own walks pass.
 
 ---
 

--- a/docs/5-PILLAR-DOD.md
+++ b/docs/5-PILLAR-DOD.md
@@ -1,0 +1,192 @@
+# 5-Pillar Definition of Done
+
+**Status:** Authoritative. **Updated:** 2026-05-20.
+
+This document is the **end-user Definition of Done** for the Catalyst platform.
+Every dispatch in this repo must answer:
+
+> Which of the 5 pillars does this work move forward, and which deterministic step (Phase 0 / 1 / 2) does it advance?
+
+If the answer is "none," **the work is wrong — pick differently.**
+
+The 5 pillars are **inseparable** — none alone is a viable platform.
+Pillar work is **strictly tertiary** to operator-console polish, cosmetic-guards
+re-enable, treemap drill-down quality, jobs region filter, admin sidebar nav, etc.
+
+For domain conventions used in every test, see [`DOMAINS-CANON.md`](DOMAINS-CANON.md).
+For the per-PR walk choreography, see [`WALK-RUNBOOK-2026-05-20.md`](WALK-RUNBOOK-2026-05-20.md).
+For multi-region BCP gates, see [`SOVEREIGN-MULTI-REGION-DOD.md`](SOVEREIGN-MULTI-REGION-DOD.md).
+For the architectural principles each pillar enforces, see [`INVIOLABLE-PRINCIPLES.md`](INVIOLABLE-PRINCIPLES.md).
+
+---
+
+## The 5 inseparable pillars
+
+| # | Pillar | What "shipped" looks like |
+|---|---|---|
+| **1** | **Marketplace + voucher onboarding** | Anonymous visitor reaches the operator-branded marketplace → picks the canonical Postgres-backed bundle → completes signup (email + 6-digit PIN magic-link) → Organization CR created. |
+| **2** | **Multi-region BCP topology choice at signup** | Wizard exposes region/topology choice during signup; customer picks N regions; system provisions across all N in one pass. Not a Day-2 upgrade. |
+| **3** | **Two independent CNPG clusters with ReplicaCluster sync + region-kill failover** | One CNPG cluster per region; synchronous `ReplicaCluster` replication over Cilium ClusterMesh on the DMZ WireGuard-over-public-IPs data plane; region-kill test passes with zero transactions lost. |
+| **4** | **Sandbox + auto-mounted MCP plugin with full org knowledge** | Sandbox launches the chosen agent CLI; **`openova-sandbox-mcp` auto-mounts at session start** with every org resource (apps, vClusters, conn-strings via OpenBao+SPIRE SVID, Gitea repos, IAM, region health). User pastes zero credentials. Agent answers prompts with full org context and mutates resources via MCP tool calls. |
+| **5** | **Sovereign independence post-cutover** | After `bp-self-sovereign-cutover` runs, zero egress to `harbor.openova.io`, `ghcr.io/openova-io`, or `github.com/openova-io` — proved by a 10-minute deny-egress NetworkPolicy hold (Principle #11). |
+
+---
+
+## The deterministic test — Phase 0 / 1 / 2
+
+The test is **deterministic** — one fresh prov, one run, all phases pass in order.
+No retries, no "works if you wait longer."
+
+### Phase 0 — Operator issues voucher via BSS
+
+Voucher operations live in the operator console's **BSS menu** (Business Support
+System), **NOT in any `admin.<sovereign-fqdn>` subdomain**. The legacy `admin.*`
+references in older docs/agents are outdated.
+
+| Step | Action | URL / Outcome |
+|---|---|---|
+| 0a | Operator logs in to the Sovereign Console | `https://console.t<NN>.omani.works` |
+| 0b | Navigate to the **BSS menu** | Sidebar → BSS (NOT `admin.<fqdn>/...`) |
+| 0c | Issue voucher | Voucher artifact created + delivered to recipient via Sovereign outbound SMTP |
+
+### Phase 1 — Customer redeems voucher (Postgres-backed app onboarding)
+
+| Step | Action | URL / Outcome |
+|---|---|---|
+| 1a | Customer receives voucher email | Canonical URL pattern per `core/services/notification/templates/templates.go`: `https://marketplace.t<NN>.omani.works/redeem/?code=<CODE>` (**slash before `?` is mandatory**) |
+| 1b | Customer redeems → checkout → picks the Postgres-backed bundle | Org provisions across the 2 chosen regions with **2 independent CNPG clusters** (ReplicaCluster sync over ClusterMesh on the WG-public-IP DMZ data plane) |
+| 1c | Org URL after signup | `https://console.<orgslug>.omani.homes` (default pool TLD; pool also has `omani.rest` and `omani.trade` per `core/services/parent-domain/sovereign_parent_domains.go`) |
+
+### Phase 2 — Customer launches Sandbox; agent provisions an additional app via MCP
+
+**This is the most important test.** It exercises Pillar 4 end-to-end and
+proves that an agent acting on behalf of the tenant can mutate the
+Organization's resources entirely through the auto-mounted MCP plugin —
+without the user typing any credential.
+
+| Step | Action | Outcome |
+|---|---|---|
+| 2a | Tenant logs in at `console.<orgslug>.omani.homes` | Dashboard renders |
+| 2b | Opens **Sandbox** | Sandbox session launches with agent set to **`qwen-code`** (NOT claude-code — `qwen-code` routes through newapi → Sovereign-hosted Qwen, **zero Anthropic cost leak**) |
+| 2c | `openova-sandbox-mcp` auto-mounts at session start | 49 MCP tools available with zero user-typed config (full handler set per `products/sandbox/mcp-server/internal/tools/registry.go`) |
+| 2d | Customer prompts qwen-code to provision an **additional application** in their Organization | Agent uses MCP tools (`sandbox.db.provision`, `sandbox.auth.provisionRealm`, `marketplace.app.install`, etc.) — new app CNPG cluster + namespace + HelmRelease + Gitea repo materialise |
+| 2e | New app reachable | At `<newapp>.<orgslug>.omani.homes` |
+
+### Orthogonal — D31 region-kill BCP failover
+
+Run **in parallel** with Phase 0/1/2 to exercise Pillar 3:
+
+| Action | Pass criterion |
+|---|---|
+| Kill primary region while the Org is running (instance destroy or NetworkPolicy isolation) | `failover-controller` flips traffic ≤ 30 s; replica CNPG promotes via `ReplicaCluster`; Cilium ClusterMesh keeps inter-region pod-to-pod alive; **zero transactions lost** (verified by a counter incrementing through the failover) |
+
+See [`SOVEREIGN-MULTI-REGION-DOD.md`](SOVEREIGN-MULTI-REGION-DOD.md) D31 for the
+full verifier procedure and the multi-region architecture invariants A1–A6.
+
+---
+
+## Mapping each pillar to the deterministic steps
+
+| Pillar | Steps it covers |
+|---|---|
+| Pillar 1 — Marketplace + signup | Phase 0 (all), Phase 1 step 1a (voucher email), Phase 1 step 1b (redeem + checkout), Phase 1 step 1c (post-signup landing) |
+| Pillar 2 — Multi-region BCP at signup | Phase 1 step 1b (wizard region-selection step) |
+| Pillar 3 — 2 CNPG clusters + region-kill failover | Phase 1 step 1b (provisioning the 2 clusters), orthogonal D31 (the kill test) |
+| Pillar 4 — Sandbox + auto-mounted MCP | Phase 2 steps 2a–2e |
+| Pillar 5 — Sovereign independence | Implicit in all of the above; verified separately by the `bp-self-sovereign-cutover` 10-minute deny-egress hold (see below + Principle #11) |
+
+---
+
+## Pillar 5 — `bp-self-sovereign-cutover` and the 8-tether pivot
+
+A franchised Sovereign emerging from Phase 1 is operationally tethered to the
+OpenOva mothership in **eight** places (full map in
+[`ADR-0002`](adr/0002-post-handover-sovereignty-cutover.md) §2.1 and in
+[`ARCHITECTURE.md`](ARCHITECTURE.md) §11.1):
+
+| # | Tether | Phase |
+|---|---|---|
+| 1 | Flux `GitRepository.url = github.com/openova-io/openova` | P0 |
+| 2 | containerd `registries.yaml` rewrites every upstream registry → `https://harbor.openova.io` | P0 |
+| 3 | OCI `HelmRepository` urls = `oci://ghcr.io/openova-io` | P0 |
+| 4 | `catalyst-api` env fallback to `https://github.com/openova-io/openova` | P0 |
+| 5 | `flux-system/ghcr-pull` Secret seeded for private GHCR pulls | P0 |
+| 6 | Crossplane provider packages from `xpkg.upbound.io` | P1 |
+| 7 | Catalyst-authored images = `ghcr.io/openova-io/openova/*` | P0 |
+| 8 | OS package mirrors during cloud-init (`apt`, `get.k3s.io`) | P2 (cold-start only) |
+
+**`bp-self-sovereign-cutover`** installs **dormant** at bootstrap-kit slot 06a
+during Phase 1 and is triggered post-handover by the operator's
+"Achieve True Sovereignty" CTA. Eight sequential Jobs pivot the tethers in
+dependency order; the **final step is a 10-minute deny-egress NetworkPolicy
+hold** against `github.com`, `ghcr.io`, and `harbor.openova.io`. The only
+condition under which `cutoverComplete=true` is set is that the cluster
+reconciles green during this hold. **No cutover claim without the
+egress-block proof.**
+
+See [`ADR-0002`](adr/0002-post-handover-sovereignty-cutover.md) for the full
+architecture, alternatives considered, and the per-step contract.
+
+---
+
+## Pillar 4 — `openova-sandbox-mcp` auto-mount mechanism
+
+When a Sandbox session attaches, the `sandbox-pty-server` (per
+`products/sandbox/pty-server/`) writes the chosen agent's `mcp.json` config to
+every canonical agent-config path (claude-code, qwen-code, opencode, aider,
+cline) and starts the MCP server as a stdio subprocess of the agent process.
+The server exposes 49 handlers grouped under namespaces such as
+`sandbox.db.*`, `sandbox.auth.*`, `marketplace.app.*`, `sandbox.git.*`,
+`sandbox.iam.*`, etc. (full registry in
+`products/sandbox/mcp-server/internal/tools/registry.go`).
+
+Authentication is SPIFFE/SPIRE-issued SVID — the agent's caller-identity is the
+tenant Organization's workload identity, never a long-lived API key. The agent
+never sees credentials; the MCP tool calls carry the SVID.
+
+Per Principle #1 (the waterfall is the contract) and Principle #2 (never
+compromise from quality), Pillar 4 is **not** "we'll ship a stub MCP server now
+and wire real tools later." A Sandbox session that boots without the full 49
+tools is Pillar 4 unshipped, regardless of how good the chrome looks.
+
+---
+
+## Customer-sync — how each Sovereign gets the catalog
+
+Each franchised Sovereign's Gitea **mirrors** the public catalog from this
+repo (`openova-io/openova`):
+
+```
+GitHub (openova-io/openova)              Per-Sovereign Gitea (mirrored)
+─────────────────────────────              ───────────────────────────────
+platform/cilium/        ────sync────>    gitea.<location-code>.<sovereign-domain>/catalog/bp-cilium/
+products/cortex/        ────sync────>    gitea.<location-code>.<sovereign-domain>/catalog/bp-cortex/
+...
+```
+
+Sovereigns pull on their own schedule (default daily). Air-gapped Sovereigns
+mirror via offline media. After `bp-self-sovereign-cutover` completes, the
+Sovereign's Flux reconciles **exclusively** from its local Gitea + Harbor — never
+back to `github.com/openova-io` or `ghcr.io/openova-io` (Principle #11).
+
+---
+
+## What "shipped" means
+
+A pillar is **shipped** when an operator (or a read-only Playwright
+verification agent — never a verification agent that ships fixes) walks a
+**fresh prov** through the pillar-relevant steps and produces:
+
+1. A **screenshot** (`.playwright-mcp/t<NN>-<surface>-<YYYY-MM-DD>.png`)
+2. A **non-empty wire-level capture** (log line, curl output, kubectl output,
+   or HAR file)
+3. A **working downstream artifact** (the new app reachable, the failover
+   counter intact, the egress-block proof recorded)
+
+One PR landing **does not** ship a pillar. One walk-with-screenshot does.
+Every PR against a surface flips that surface back to 🔴 UNVERIFIED in
+[`TRUST.md`](TRUST.md) until re-walked.
+
+See [`WALK-RUNBOOK-2026-05-20.md`](WALK-RUNBOOK-2026-05-20.md) for the per-PR
+walk choreography and [`ANTI-PATTERN-CATALOG.md`](ANTI-PATTERN-CATALOG.md) for
+the failure-modes operators must hunt for during the walk.

--- a/docs/ANTI-PATTERN-CATALOG.md
+++ b/docs/ANTI-PATTERN-CATALOG.md
@@ -1,0 +1,208 @@
+# Anti-Pattern Catalog
+
+**Status:** Authoritative. **Updated:** 2026-05-20.
+
+This catalog records **OpenOva-platform-specific** anti-patterns — concrete PR
+receipts of failure modes that have shipped, hidden in plain sight in PR diffs,
+or compounded into theater. Each entry exists so the **next** review of the
+same shape catches the bug before it ships.
+
+For the engineering principles each anti-pattern violates, see
+[`INVIOLABLE-PRINCIPLES.md`](INVIOLABLE-PRINCIPLES.md).
+For the cycle-level retrospective these receipts feed, see the latest
+`SESSION-*.md` and `trust-audit-*.md` docs in this directory.
+For the verification ledger these flips back to `🔴 UNVERIFIED`, see
+[`TRUST.md`](TRUST.md).
+
+---
+
+## How to use this file during PR review
+
+When reviewing a PR, scan the diff for **the shape** of each anti-pattern
+below. Defensive-coding patterns are the canary — they almost always mean
+something upstream is broken and the diff is bandaging the symptom.
+
+The hard rule (CLAUDE.md §4): **defensive-coding patterns trigger
+investigation, NOT approval.**
+
+---
+
+## Catalog
+
+### A1 — Null-guard after empty-data crash
+
+| | |
+|---|---|
+| **Example** | PR #1185 (Compliance tab) |
+| **Theater duration before catch** | 10 days |
+| **Shape** | Dashboard crashes when upstream data is empty → diff adds a `?? []` / `?? {}` / `cursor: 'default'` guard so the empty-state renders politely. |
+| **Why this is wrong** | The guard hides the upstream break. The right question is **"why is the data empty?"** A working Sovereign should produce data. The guard turns a loud failure into a silent zero-state. |
+| **Right fix shape** | Trace the upstream pipeline. The empty data is the bug; rendering an empty state for it is the theater. |
+
+### A2 — Feature-flag off by default
+
+| | |
+|---|---|
+| **Example** | PR #1138 (`bp-kyverno` `values.yaml` — 18 of 19 compliance ClusterPolicies gated off) |
+| **Theater duration before catch** | 11 days |
+| **Shape** | A blueprint's `values.yaml` ships every feature with `enabled: false` and is then claimed as "shipped." Sovereigns provision with the feature absent; nobody notices because no test asserts the feature is *on*. |
+| **Why this is wrong** | "Installed" ≠ "applied." Kyverno without its policies enforces nothing; the Compliance tab reports 0/19 forever. |
+| **Right fix shape** | Defaults must match the deterministic test contract. If the test expects "19 policies enforcing," the blueprint default must ship 19 enabled. Feature-off defaults need an explicit operator-visible toggle, not silent absence. |
+
+### A3 — Click handler missing on leaf cells
+
+| | |
+|---|---|
+| **Example** | PR #1085 (treemap drill-down) |
+| **Theater duration before catch** | 11 days |
+| **Shape** | A 100-line diff with a 3-line bug visible in plain context. The onClick handler is wired on container cells but not on the leaf cells the operator actually needs to click. PR is approved on the "looks good" of the chrome. |
+| **Why this is wrong** | The bug is in the diff. Reviewer-fatigue defense — "this PR is too big to read every line" — is dead. CLAUDE.md §4 rule 6: if a PR is too big to review carefully, split it before merging. |
+| **Right fix shape** | Slow down, read every line. Click handlers must terminate at the leaf that triggers the action. |
+
+### A4 — `enabled: !wizardApp` query gate
+
+| | |
+|---|---|
+| **Example** | PR #1160 (AppDetail page — fetch gated by `!wizardApp`) |
+| **Theater duration before catch** | 10 days |
+| **Shape** | The data fetch is gated by a boolean computed from the previous step (`wizardApp`, `isLoading`, `isReady`, etc.). For some real operator paths the boolean is truthy in a way that keeps the fetch permanently off. |
+| **Why this is wrong** | Gating-on-other-state is fragile. The query should run when the inputs are present, not when an upstream sibling state happens to be falsy. |
+| **Right fix shape** | The query's `enabled` predicate should be a positive assertion on the inputs the query actually needs (`!!appName && !!targetNamespace`), not a negative assertion on an unrelated piece of state. |
+
+### A5 — `Closes #N` on a scaffold-only PR
+
+| | |
+|---|---|
+| **Example** | PR #1918 (NATS scaffolding — interface + env-driven constructor that returns nil) |
+| **Theater duration before catch** | Issue auto-closed without the concrete binding shipping |
+| **Shape** | The PR adds the type definitions, the constructor wiring, and the env-var lookup — but the constructor returns nil when the env var is unset (default), so production gets the no-op. PR uses `Closes #N`; the issue auto-closes on merge. |
+| **Why this is wrong** | The platform behavior the issue tracked **does not change** when the PR merges. The issue should stay open until the concrete binding ships. CLAUDE.md §4 rule 1: **`Refs #N` is the default in PR bodies, not `Closes #N`.** Auto-close on merge is the enemy. |
+| **Right fix shape** | Use `Refs #N` until a follow-up PR ships the binding that makes the surface produce the operator-visible behavior. Reopen the issue if it auto-closed. |
+
+### A6 — `kubectl --dry-run=server` against a running cluster
+
+| | |
+|---|---|
+| **Example** | PR #1933 (`bp-kyverno` install) |
+| **Theater duration before catch** | Broke fresh-prov install the same day as the trust collapse it was a "fix" for |
+| **Shape** | PR claims "validated against `kubectl apply --dry-run=server`" — but the dry-run was run against a cluster where the relevant CRDs were already installed (from previous reconciliations). The dry-run passes; the fresh-prov install fails because the CRDs aren't there yet. |
+| **Why this is wrong** | `kubectl --dry-run=server` against a running cluster **lies** when the CRDs the manifest references are pre-installed. The cluster's schema check accepts the manifest; a fresh cluster wouldn't. CLAUDE.md §4 rule 2: validate against fresh state, not stable state. |
+| **Right fix shape** | Chart/CRD/bootstrap-kit changes MUST be validated by `helm install` from scratch (Kind, fresh prov), or by `kubectl apply --dry-run=server` against a cluster known to lack the CRDs. See [`INVIOLABLE-PRINCIPLES.md`](INVIOLABLE-PRINCIPLES.md) §15. |
+
+### A7 — Multi-region claim on a single-region prov
+
+| | |
+|---|---|
+| **Example** | PR #1599 (treemap fan-out) |
+| **Theater duration before catch** | Never tested on the topology it claimed to work on |
+| **Shape** | PR claims "renders multi-region correctly." The prov used to validate has a single region. The single-region path masquerades as multi-region success because the fan-out is a no-op when N=1. |
+| **Why this is wrong** | Multi-region BCP is Pillar 2. Tests on a single-region prov **cannot** prove Pillar 2 works. CLAUDE.md §4 rule 2: validate on the topology the PR claims to support. |
+| **Right fix shape** | Multi-region claims must be validated on a multi-region prov (N≥2 regions, ideally N=3 per [`SOVEREIGN-MULTI-REGION-DOD.md`](SOVEREIGN-MULTI-REGION-DOD.md) A1). The PR body must cite the prov ID + region count + per-region pass/fail. |
+
+### A8 — `must_contain` token-passing test churn
+
+| | |
+|---|---|
+| **Examples** | PRs #1362, #1366, #1371, #1378 |
+| **Theater duration before catch** | Tests pass on DOM that contains the right strings but no behavior |
+| **Shape** | A test asserts `expect(page.locator('body')).toContainText('Voucher issued')`. Earlier tests fail; later tests "pass" because someone added the literal string `Voucher issued` to a status banner that renders regardless of whether anything happened. |
+| **Why this is wrong** | The test no longer measures what it claims to measure. The pass condition has been moved from "the operation succeeded" to "the right string appears." See CLAUDE.md §4 anti-pattern catalogue. |
+| **Right fix shape** | Behavior tests must measure behavior (the DB row was written, the XHR returned 200 with a non-empty body, the downstream resource exists). Token-passing tests must be deleted, not patched. |
+
+### A9 — Chart-publish break via `Chart.yaml` corruption
+
+| | |
+|---|---|
+| **Example** | PR #1932 → cleanup PR #1937 |
+| **Theater duration before catch** | Caught the same day; chart publish was silently broken until #1937 |
+| **Shape** | An auto-applied edit prepends YAML to `Chart.yaml` and deletes the existing `apiVersion:` + `name:` keys in the process. CI's chart-publish job fails, but the failure is in a pre-existing-red queue that's been bypassed. |
+| **Why this is wrong** | `Chart.yaml` is the chart's identity. CLAUDE.md §4 rule 5: no admin-merge through red CI. "Pre-existing failure" is not a bypass. |
+| **Right fix shape** | Fix the failing CI check **before** the next PR rides on top of it. Audit every edit that touches `Chart.yaml` for required-keys preservation. |
+
+### A10 — Walker reports a verdict for a surface it never navigated to
+
+| | |
+|---|---|
+| **Example** | Commit ad94ebe2 (caught by audit commit af4537d2) |
+| **Theater duration before catch** | One audit cycle |
+| **Shape** | A Playwright walker reports `D27 PASS — marketplace renders` but the API-request log shows the walker never issued a request to `/marketplace`. The verdict is fabricated by a code path that conflates "no error" with "test passed." |
+| **Why this is wrong** | The walker's job is to **prove** the surface works by interacting with it. A walker that doesn't navigate cannot produce a verdict. CLAUDE.md §4 rule 7: verification agents are READ-ONLY and their output is screenshot + comment + ledger row only — fabricated verdicts are worse than no verdict. |
+| **Right fix shape** | Every walker assertion must be backed by a captured XHR (HAR file) or a captured screenshot at the relevant route. No XHR + no screenshot = no verdict. |
+
+### A11 — `HelmRelease.spec.dependsOn` referencing a non-HR resource
+
+| | |
+|---|---|
+| **Example** | PR #1875 (TBD-A24 cutover deadlock fix) |
+| **Theater duration before catch** | Deadlocked t27 until the empirical realization |
+| **Shape** | A `HelmRelease.spec.dependsOn` lists a `Kustomization` (or any non-HR kind). helm-controller silently does nothing with the cross-kind reference; the dependency is never enforced. The HR proceeds out-of-order and deadlocks the cluster. |
+| **Why this is wrong** | `HelmRelease.spec.dependsOn` references **only** other HelmReleases. Empirical verbatim from helm-controller on violation: `unable to get 'flux-system/<name>' dependency: helmreleases.helm.toolkit.fluxcd.io "<name>" not found` (retries every 30s forever, never resolves). |
+| **Right fix shape** | For cross-kind ordering, use `Kustomization.spec.dependsOn` (which **does** support cross-kind), or ship a "wait-HelmRelease" (tiny chart with a Job that runs `kubectl wait …`) and depend on **that** HR. See [`INVIOLABLE-PRINCIPLES.md`](INVIOLABLE-PRINCIPLES.md) §14. |
+
+### A12 — Chart-pin bump to a tag that doesn't exist on GHCR
+
+| | |
+|---|---|
+| **Example** | PR #1869 (TBD-A48 drift incident — pinned `bp-self-sovereign-cutover:0.1.4` before the chart was published) |
+| **Theater duration before catch** | Hours of `ImagePullBackOff` on every fresh prov |
+| **Shape** | A `HelmRelease.spec.chart.spec.version` is bumped to `<X.Y.Z>` and committed to main while the OCI artifact at `oci://ghcr.io/.../bp-<name>:<X.Y.Z>` has never been built. Source-side version-equality (Chart.yaml says `0.1.4`) is **not** proof of publication. |
+| **Why this is wrong** | Flux retries `ImagePullBackOff` forever; the cluster looks half-rolled-out. The pin commits to main pointed at a tag that doesn't exist. |
+| **Right fix shape** | Before committing a pin bump, `crane manifest oci://ghcr.io/openova-io/openova/bp-<name>:<new-version>` must return a non-empty response. CI should gate the deploy commit on a "tag exists on GHCR" check. See [`INVIOLABLE-PRINCIPLES.md`](INVIOLABLE-PRINCIPLES.md) §13. |
+
+### A13 — Python `jsonencode()` simulation passed off as `tofu validate`
+
+| | |
+|---|---|
+| **Example** | PR #1892 (TBD-A32 listener wildcard depth) |
+| **Theater duration before catch** | Every fresh prov failed at 23s into `tofu apply` until the real fix landed in #1894 |
+| **Shape** | PR description says "verified via Python `json.dumps()` simulation." But tofu HCL's type-unification rule rejects the ternary expression at plan-time. A Python `json.dumps` of a dict will happily emit any structure; HCL's evaluator refuses heterogeneous shapes that Python never noticed. |
+| **Why this is wrong** | The JSON parser is not the HCL evaluator. Simulating IaC with a foreign language's tooling is theater. |
+| **Right fix shape** | For `.tf` / `.tftpl` changes, run `tofu init && tofu validate` (or `tofu plan` if vars are available) in the same workdir before opening the PR. Paste the `Success! The configuration is valid.` line into the PR description. See [`INVIOLABLE-PRINCIPLES.md`](INVIOLABLE-PRINCIPLES.md) §15. |
+
+### A14 — Bulk-template "not-on-pillar-path" closure overriding live evidence
+
+| | |
+|---|---|
+| **Examples** | #1741, #1819, #1882 (caught in `trust-audit-2026-05-20.md`) |
+| **Theater duration before catch** | Issue closed with a still-failing walk-report 2 hours earlier on the same issue |
+| **Shape** | An issue is closed with a canned "not on pillar path" comment despite an earlier comment on the same issue containing concrete still-failing evidence (`sme-gateway-unreachable`, "Keeping open; eligible for the cosmetic-cleanup batch," etc.). |
+| **Why this is wrong** | The bulk-template comment is a productivity prop, not a closure rationale. CLAUDE.md §4 anti-theater rule: a closure must reference concrete evidence that the AC is met — not "this isn't pillar work right now." |
+| **Right fix shape** | Reopen the issue. Either fix the surface (closure with evidence) or label it `status/parked` and leave it open. Parking is a legitimate state; theater-closure is not. |
+
+### A15 — Stable-state walk passed off as fresh-prov walk
+
+| | |
+|---|---|
+| **Example** | #1819 (DoD D18 closed citing a t22 treemap-renders observation, when the issue body required a NEXT-fresh-prov zero-touch walk) |
+| **Theater duration before catch** | One audit cycle |
+| **Shape** | An issue's AC explicitly says "passes zero-touch on the next fresh provision." The closure cites a walk on an existing long-running prov where state has accumulated through prior remediations. The behavior the AC tests is not reproducible from scratch. |
+| **Why this is wrong** | "Works on a stable prov" ≠ "works zero-touch on a fresh prov." The whole point of fresh-prov DoD is to catch environment-hardcoding and remediation-debt that hide on long-running provs. |
+| **Right fix shape** | Walks for fresh-prov AC items must be conducted on a fresh prov (the prov ID, chart version, and verified-at timestamp must all appear in the closing comment). |
+
+---
+
+## Cross-cutting flags that trigger a "stop and investigate" pass
+
+Per CLAUDE.md §4 rule 4, any of the following in a diff is **not** approval —
+it's a clue to hunt the upstream cause:
+
+- Null-guards on data that the spec says should never be empty
+- `?? 'default'` / `?? []` / `?? {}` fallbacks on values the upstream is supposed to produce
+- `enabled: false` defaults on features the deterministic test asserts present
+- `cursor: 'default'` style guards on interactive surfaces
+- Snapshot-empty-frames (test fixtures that assert "no items rendered")
+- `must_contain` token-passing tests (see A8)
+- "Pre-existing red" CI bypasses (see A9)
+- `Closes #N` on a PR that does not produce operator-visible behavior change (see A5)
+- Test data containing `openova.io`, `Nova Cloud`, `eventforge.io` (see [`DOMAINS-CANON.md`](DOMAINS-CANON.md))
+
+---
+
+## How this catalog grows
+
+Every PR-review that catches an instance of a known anti-pattern: log it
+against the existing entry (a one-line addendum is fine).
+
+Every PR-review that catches a **new** shape of failure: add an entry here with
+the PR number, the shape description, why it's wrong, and the right fix shape.
+The catalog grows so the next session catches it sooner.

--- a/docs/DOMAINS-CANON.md
+++ b/docs/DOMAINS-CANON.md
@@ -1,0 +1,106 @@
+# Domains Canon
+
+**Status:** Authoritative. **Updated:** 2026-05-20.
+
+This document is the **single source of truth** for FQDN patterns used in
+Catalyst test provs and tenant Organizations. Every test, walk, agent
+dispatch, and provisioning request must use the patterns below.
+
+For the surfaces these domains front, see [`5-PILLAR-DOD.md`](5-PILLAR-DOD.md)
+Phase 0 / 1 / 2.
+For the multi-region DNS architecture see
+[`MULTI-REGION-DNS.md`](MULTI-REGION-DNS.md) and
+[`PLATFORM-POWERDNS.md`](PLATFORM-POWERDNS.md).
+For the naming primitives (clusters, vClusters, Organizations, Environments,
+Applications) see [`NAMING-CONVENTION.md`](NAMING-CONVENTION.md).
+
+---
+
+## Test-Sovereign FQDNs
+
+| Layer | Pattern | Notes |
+|---|---|---|
+| Sovereign (test) | `t<NN>.omani.works` | `<NN>` increments with every fresh prov (t39, t40, …). |
+| Sovereign (test fallback) | `t<NN>.omantel.biz` | Use when `omani.works` hits a Let's Encrypt rate limit. Swap weekly. |
+| Sovereign Console | `console.t<NN>.omani.works` | Operator-facing console UI. |
+| Marketplace | `marketplace.t<NN>.omani.works` | Customer-facing storefront for the operator-curated catalog. |
+| Operator services | `keycloak.t<NN>.omani.works`, `openbao.t<NN>.omani.works`, `openova-flow.t<NN>.omani.works`, `prometheus.t<NN>.omani.works`, `mimir.t<NN>.omani.works`, `loki.t<NN>.omani.works`, `tempo.t<NN>.omani.works`, `argo.t<NN>.omani.works`, `workspaces.t<NN>.omani.works`, `harbor.t<NN>.omani.works`, `registry.t<NN>.omani.works`, `guacamole.t<NN>.omani.works` | Per [`SOVEREIGN-MULTI-REGION-DOD.md`](SOVEREIGN-MULTI-REGION-DOD.md) D25. |
+
+**Voucher operations live in the operator console's BSS menu, NOT in any
+`admin.<sovereign-fqdn>` subdomain.** The legacy `admin.*` references in older
+docs and agents are outdated.
+
+---
+
+## Tenant-Organization FQDNs
+
+Tenant Organizations receive a free subdomain from an **operator-curated pool**
+allocated at signup. The pool population is defined in
+`core/services/parent-domain/sovereign_parent_domains.go` (the canonical Go
+source — pool TLDs are not hardcoded in tests).
+
+| Pattern | Example | Notes |
+|---|---|---|
+| `<orgslug>.omani.homes` | `acme.omani.homes` | **Default** — first NS-ready entry in registration order per `core/services/sme/sme_tenant.go:514-521`. |
+| `<orgslug>.omani.rest` | `acme.omani.rest` | Pool alternate. |
+| `<orgslug>.omani.trade` | `acme.omani.trade` | Pool alternate. **Note: singular `trade`, not `trades`** — earlier docs that said `omani.trades` are wrong. |
+
+The tenant console URL pattern is `console.<orgslug>.<pool-tld>` — e.g.
+`console.acme.omani.homes`. Additional tenant-installed apps are reachable
+at `<newapp>.<orgslug>.<pool-tld>` — e.g. `notes.acme.omani.homes`.
+
+---
+
+## Voucher redeem URL
+
+The canonical voucher-email link pattern (per
+`core/services/notification/templates/templates.go`):
+
+```
+https://marketplace.t<NN>.omani.works/redeem/?code=<CODE>
+```
+
+**The slash before `?` is mandatory** — both URL ends are part of the
+Phase 1 step 1a contract and must be byte-for-byte stable.
+
+---
+
+## Forbidden in tests
+
+The following strings must **never** appear in test code, test data,
+operator-walk runbooks, fresh-prov provisioning bodies, or any artifact
+that exercises the 5-Pillar deterministic path:
+
+- `openova.io` — and any subdomain (`console.openova.io`, `marketplace.openova.io`, etc.)
+- `omantel.openova.io` — legacy operator-sample FQDN, dead
+- `eventforge.io` — never an OpenOva domain; never the canonical app name
+- `Nova Cloud` — never the operator brand for the test stack
+
+`openova.io` is reserved for the **OpenOva marketing site** (the
+`openova-private/website/` repo) and the **mothership control plane** during
+Phase 0 + Phase 1 cold-start. After
+[`bp-self-sovereign-cutover`](adr/0002-post-handover-sovereignty-cutover.md)
+runs, every reference to `openova.io` from a franchised Sovereign is a
+Principle #11 violation.
+
+---
+
+## Domain hygiene checks
+
+`docs/trust-audit-*.md` and PR review hunt for:
+
+1. **`openova.io` leaks in test data** — any `*_test.go` / `*.spec.ts` /
+   `*.feature` literal containing `openova.io` is a leak.
+2. **Hardcoded operator FQDNs** — any code path that pins the operator domain
+   to a literal instead of reading it from a runtime parameter
+   (`SOVEREIGN_FQDN`, `--sovereign-fqdn`, etc.). See
+   [`INVIOLABLE-PRINCIPLES.md`](INVIOLABLE-PRINCIPLES.md) §4 (never hardcode).
+3. **Tenant-Org URL pattern drift** — any path that emits
+   `<orgslug>.openova.io` or `<orgslug>.<sovereign-fqdn>` instead of
+   `<orgslug>.<pool-tld>`. The pool TLD is the source of truth.
+4. **`admin.<sovereign-fqdn>` references** — voucher and billing operations
+   live in the BSS menu inside the operator console; an `admin.*` subdomain
+   means a stale reference.
+
+When in doubt, defer to [`GLOSSARY.md`](GLOSSARY.md) and the Go source files
+named above.


### PR DESCRIPTION
## Summary

Founder direction 2026-05-20 restructures the CLAUDE.md hierarchy:

- `~/.claude/CLAUDE.md` (user-global) → **generic engineering principles only**
- `openova-io/openova/CLAUDE.md` (platform monorepo) → **OpenOva-platform specifics**
- Per-Sovereign repos (`openova-private` etc.) → **instance-specific only**

This PR relocates the OpenOva-platform specifics that were previously mixed into user-global and scattered across `WALK-RUNBOOK-2026-05-20.md`, `SESSION-2026-05-19-20-TRUST-RECOVERY.md`, audit docs, and `INVIOLABLE-PRINCIPLES.md` into three new canonical docs:

- **`docs/5-PILLAR-DOD.md`** — 5 inseparable pillars + Phase 0/1/2 deterministic test + 8-tether pivot (Pillar 5) + sandbox-MCP auto-mount (Pillar 4) + customer-sync via Gitea mirroring + orthogonal D31 region-kill test
- **`docs/DOMAINS-CANON.md`** — test-Sovereign FQDNs (`t<NN>.omani.works`), tenant-Org pool TLDs (`omani.homes` / `omani.rest` / `omani.trade`), canonical voucher URL, forbidden test strings (`openova.io`, `Nova Cloud`, `omantel.openova.io`, `eventforge.io`, `admin.<sovereign-fqdn>`)
- **`docs/ANTI-PATTERN-CATALOG.md`** — 15 OpenOva-specific anti-pattern entries with concrete PR receipts (`#1085`, `#1138`, `#1185`, `#1160`, `#1918`, `#1933`, `#1599`, `#1362`-`#1378`, `#1932`/`#1937`, walker-without-navigation, `#1875` HR-dependsOn-cross-kind, `#1869` chart-pin to missing GHCR tag, `#1892` Python `jsonencode` as `tofu validate`, `#1741`/`#1819`/`#1882` bulk-template closure, stable-state walk passed off as fresh-prov walk)

Also updates `CLAUDE.md`:

- Top-of-file scoping pointer now distinguishes **generic engineering rules** (user-global) from **OpenOva-platform specifics** (this repo)
- Reading order extended with the 3 new docs + `INVIOLABLE-PRINCIPLES`
- New section **"Platform-specific rules (OpenOva-only)"** links to the 3 new docs and summarises the rules of engagement (DoD, domains, anti-theater discipline, cutover, customer-sync, TRUST ledger)

All cross-references resolve. No content duplicated — the new docs reference `INVIOLABLE-PRINCIPLES.md`, `SOVEREIGN-MULTI-REGION-DOD.md`, `WALK-RUNBOOK-2026-05-20.md`, and `ADR-0002` rather than restating them.

Augments TBD-V33 #2077 (governance ledger migration) — does not conflict.

## Test plan

- [x] All internal markdown links resolve (`for path in ...; test -e docs/$path`)
- [x] `CLAUDE.md` reading-order section lists the 3 new docs
- [x] No content duplicated — references `INVIOLABLE-PRINCIPLES.md` §11/§13/§14/§15 and `ADR-0002` rather than restating
- [x] No `openova.io`, `Nova Cloud`, `eventforge.io` in any test snippet
- [ ] CI green
- [ ] Founder confirms scoping pointer reads correctly

Refs #2083
Refs #2077