### PR TITLE
ci: elevate hollow-chart guard to pre-merge check (Refs #2086 / #2080)

### DIFF
--- a/.github/workflows/check-chart-annotations.yaml
+++ b/.github/workflows/check-chart-annotations.yaml
@@ -1,0 +1,146 @@
+name: Chart-annotations guard (pre-merge hollow-chart check)
+
+# PRE-MERGE replica of GUARD 1 in .github/workflows/blueprint-release.yaml.
+#
+# Catches hollow-chart violations (a chart with NO `dependencies:` entry
+# AND no `catalyst.openova.io/no-upstream: "true"` opt-out annotation)
+# BEFORE the PR merges. Without this gate, the violation only surfaces
+# at the post-merge Blueprint Release workflow — by which point the
+# version in Chart.yaml is "dead-reserved" (the merge SHA owns it but
+# no GHCR tag ever publishes) and recovery requires a follow-up
+# version-bump-and-annotate PR.
+#
+# Recurrence history that motivated promoting this guard to pre-merge:
+#   - bp-cert-manager:1.0.0   (issue #181 — guard origin)
+#   - bp-crossplane-claims    (historical)
+#   - bp-kyverno-policies     (PR #2023)
+#   - bp-continuum:0.1.1      (PR #2072 dead-pinned, fix PR #2081, TBD-V34 / #2080)
+#
+# Per CLAUDE.md anti-pattern catalogue + Inviolable Principle #13
+# (chart-pin bumps must match a published GHCR tag): every dead-reserved
+# version is a chart-pin lockstep break.
+#
+# Per CLAUDE.md "every workflow MUST be event-driven, NEVER scheduled":
+# this workflow is push-on-merge (belt-and-braces) + pull_request-on-touch.
+# There is no `schedule:` trigger; ad-hoc reruns go through
+# workflow_dispatch.
+#
+# Scoping note — only CHANGED charts are checked in PRs. Pre-existing
+# hollow charts (bp-network-policies, axon as of 2026-05-20) are NOT
+# blocked by this guard until a PR actually touches them; the post-
+# merge Blueprint Release workflow continues to fail-loudly on their
+# next publish attempt regardless. This keeps the guard zero-noise for
+# unrelated PRs while still catching every new chart introduction or
+# version-bump that would dead-reserve a tag.
+
+on:
+  pull_request:
+    paths:
+      - 'platform/*/chart/Chart.yaml'
+      - 'products/*/chart/Chart.yaml'
+      - 'scripts/check-chart-annotations.sh'
+      - '.github/workflows/check-chart-annotations.yaml'
+  push:
+    branches: [main]
+    paths:
+      - 'platform/*/chart/Chart.yaml'
+      - 'products/*/chart/Chart.yaml'
+      - 'scripts/check-chart-annotations.sh'
+      - '.github/workflows/check-chart-annotations.yaml'
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: 'Scope: changed (PR diff) or all (every chart in the tree)'
+        required: false
+        type: choice
+        default: changed
+        options:
+          - changed
+          - all
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Chart-annotations guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Need both sides of the PR diff to enumerate changed charts.
+          # PR runs already get `refs/pull/N/merge` with 2 commits; push
+          # runs need a depth >= 2 so HEAD~1 resolves.
+          fetch-depth: 2
+
+      - name: Install yq (declared-deps parser)
+        run: |
+          # Same yq pin as the post-merge Blueprint Release workflow —
+          # awk/grep on YAML is fragile and would let a subtly malformed
+          # Chart.yaml slip past the guard. Keep the version in sync with
+          # .github/workflows/blueprint-release.yaml.
+          sudo wget -qO /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+
+      - name: Detect changed chart manifests
+        id: changed
+        run: |
+          set -euo pipefail
+          # workflow_dispatch with scope=all → run over every chart.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] \
+              && [ "${{ inputs.scope }}" = "all" ]; then
+            echo "scope=all" >> "$GITHUB_OUTPUT"
+            echo "charts=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # PR runs: compare against the merge base.
+          # push-to-main runs: compare against the previous commit.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+            head_sha="${{ github.event.pull_request.head.sha }}"
+            # actions/checkout@v4 doesn't fetch the base by default for
+            # shallow clones; fetch just enough to diff.
+            git fetch --no-tags --depth=1 origin "$base_sha" 2>/dev/null || true
+            range="${base_sha}...${head_sha}"
+          else
+            range="HEAD~1...HEAD"
+          fi
+
+          echo "Diffing range: $range"
+          changed=$(git diff --name-only "$range" 2>/dev/null \
+                    | grep -E '^(platform|products)/[^/]+/chart/Chart\.yaml$' \
+                    | sort -u || true)
+          echo "Changed Chart.yaml files:"
+          echo "$changed"
+
+          # Multi-line outputs need the EOF-heredoc form.
+          {
+            echo "scope=changed"
+            echo "charts<<EOF"
+            echo "$changed"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run hollow-chart guard
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.changed.outputs.scope }}" = "all" ]; then
+            echo "Scope: all (workflow_dispatch override)"
+            bash scripts/check-chart-annotations.sh
+            exit $?
+          fi
+
+          # Scope: changed. Empty list = no chart manifests touched → skip.
+          charts="${{ steps.changed.outputs.charts }}"
+          if [ -z "$charts" ]; then
+            echo "No Chart.yaml files changed in this PR — guard skipped."
+            exit 0
+          fi
+
+          # shellcheck disable=SC2086
+          echo "$charts" | xargs -r bash scripts/check-chart-annotations.sh

--- a/docs/BLUEPRINT-AUTHORING.md
+++ b/docs/BLUEPRINT-AUTHORING.md
@@ -417,14 +417,15 @@ The fix is structural: the published OCI artifact's `<chart_name>/charts/` direc
 
 ### What CI enforces
 
-`.github/workflows/blueprint-release.yaml` runs four hollow-chart guards on every publish:
+Two guards run on every chart change. The pre-merge guard is the **primary** line of defence; the post-merge guards are belt-and-braces structural verification at publish time.
 
-| Stage | Guard | Failure mode caught |
-|---|---|---|
-| After `helm dependency build` | Working-tree `chart/charts/<dep>-<ver>.tgz` (or unpacked `chart/charts/<dep>/Chart.yaml`) exists for every `dependencies:` entry. | Missing/wrong repo URL, dependency-build silently skipped a dep. |
-| After `helm package` | `tar -tzf` listing of the produced `.tgz` contains `<chart_name>/charts/<dep>-<ver>.tgz` (or unpacked) for every `dependencies:` entry. | `.helmignore` mishap, packaging-time stripping. |
-| After `helm push` | `helm pull` round-trips the artifact from GHCR; the pulled `.tgz` listing again contains every declared subchart. | Registry-side path mangling, OCI manifest rewriting. |
-| Always | `helm template` smoke render with default values produces non-trivial output; rendered manifests uploaded as workflow artifact for forensics. | Render-broken templates, schema violations, missing required values. |
+| When | Workflow | Guard | Failure mode caught |
+|---|---|---|---|
+| **Pre-merge (PR)** | `.github/workflows/check-chart-annotations.yaml` → `scripts/check-chart-annotations.sh` | For every changed `platform/*/chart/Chart.yaml` or `products/*/chart/Chart.yaml`: chart MUST EITHER declare a non-empty `dependencies:` block OR carry the annotation `catalyst.openova.io/no-upstream: "true"`. | The hollow shape itself, **before the chart version is dead-reserved by a failed publish.** Three real recurrences pre-2026-05-20 each needed a follow-up version-bump PR; pre-merge catches the violation while the version in `Chart.yaml` can still be edited in place. |
+| After `helm dependency build` | `.github/workflows/blueprint-release.yaml` GUARD 1 | Working-tree `chart/charts/<dep>-<ver>.tgz` (or unpacked `chart/charts/<dep>/Chart.yaml`) exists for every `dependencies:` entry. | Missing/wrong repo URL, dependency-build silently skipped a dep. |
+| After `helm package` | `.github/workflows/blueprint-release.yaml` GUARD 2 | `tar -tzf` listing of the produced `.tgz` contains `<chart_name>/charts/<dep>-<ver>.tgz` (or unpacked) for every `dependencies:` entry. | `.helmignore` mishap, packaging-time stripping. |
+| After `helm push` | `.github/workflows/blueprint-release.yaml` GUARD 3 | `helm pull` round-trips the artifact from GHCR; the pulled `.tgz` listing again contains every declared subchart. | Registry-side path mangling, OCI manifest rewriting. |
+| Always | `.github/workflows/blueprint-release.yaml` smoke | `helm template` smoke render with default values produces non-trivial output; rendered manifests uploaded as workflow artifact for forensics. | Render-broken templates, schema violations, missing required values. |
 
 **Any single guard failing fails the whole publish job.** A hollow Blueprint can never reach a Sovereign through the sanctioned CI path.
 

--- a/scripts/check-chart-annotations.sh
+++ b/scripts/check-chart-annotations.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# check-chart-annotations.sh — PRE-MERGE hollow-chart guard.
+#
+# Authoritative spec: .github/workflows/blueprint-release.yaml GUARD 1
+# (issue #181). This script is the PRE-MERGE replica of GUARD 1 so
+# hollow-chart violations are caught on `pull_request` BEFORE the chart
+# version is "dead-reserved" by a failed post-merge publish.
+#
+# Background — three real-world recurrences caught by the post-merge
+# guard, each cost a version-bump-and-follow-up-PR cycle:
+#
+#   1. bp-cert-manager:1.0.0  — the original incident (issue #181)
+#   2. bp-crossplane-claims   — fixed by adding the no-upstream annotation
+#   3. bp-kyverno-policies    — PR #2023, same shape
+#   4. bp-continuum:0.1.1     — PR #2072 merged red, requiring PR #2081
+#                               to bump 0.1.1 → 0.1.2 with the annotation
+#
+# Per CLAUDE.md anti-pattern catalogue + Inviolable-Principle #13
+# (chart-pin bumps must match a published GHCR tag): pre-merge catches
+# the violation while the chart version can still be edited in place.
+#
+# What this script checks (per chart at platform/*/chart/Chart.yaml AND
+# products/*/chart/Chart.yaml):
+#
+#   For every chart with NO `dependencies:` entry (or `dependencies: []`),
+#   the chart MUST set the opt-out annotation:
+#
+#     annotations:
+#       catalyst.openova.io/no-upstream: "true"
+#
+#   The annotation is the explicit "this chart legitimately ships only
+#   Catalyst-authored CRs / Deployments / RBAC, no upstream Helm subchart"
+#   declaration. Without the annotation, the post-merge Blueprint Release
+#   workflow's GUARD 1 will reject the publish — and by then the version
+#   in Chart.yaml is reserved-dead.
+#
+# Charts WITH a non-empty `dependencies:` block always pass this guard
+# (the post-merge GUARDs 2 and 3 verify the subchart actually got pulled
+# and survived the OCI round-trip — those checks need the GHCR push and
+# stay post-merge).
+#
+# Usage:
+#   scripts/check-chart-annotations.sh                    # all charts
+#   scripts/check-chart-annotations.sh path/to/Chart.yaml # specific chart(s)
+#
+# Exit codes:
+#   0  — all charts pass
+#   1  — one or more hollow charts (missing annotation + no deps)
+#   2  — input/parse/usage error
+#
+# Dependencies: bash, yq (mikefarah, v4+), find.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Locate repo root so the tool works from any cwd.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Require yq (the post-merge guard uses yq for the exact same reason —
+# awk/grep on YAML is fragile and would let a subtly malformed Chart.yaml
+# slip past the guard).
+# ---------------------------------------------------------------------------
+if ! command -v yq >/dev/null 2>&1; then
+  echo "ERROR: yq (mikefarah, v4+) is required but not on PATH." >&2
+  echo "Install: https://github.com/mikefarah/yq" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Build the list of Chart.yaml files to check.
+#
+# If args were passed, use them. Otherwise enumerate every chart under
+# platform/*/chart/Chart.yaml + products/*/chart/Chart.yaml — the exact
+# same path scope as the Blueprint Release workflow's path-trigger filter.
+# ---------------------------------------------------------------------------
+declare -a CHARTS=()
+if [ "$#" -gt 0 ]; then
+  CHARTS=("$@")
+else
+  while IFS= read -r f; do
+    CHARTS+=("$f")
+  done < <(find "$REPO_ROOT/platform" "$REPO_ROOT/products" \
+              -mindepth 3 -maxdepth 3 \
+              -path '*/chart/Chart.yaml' -type f 2>/dev/null | sort)
+fi
+
+if [ "${#CHARTS[@]}" -eq 0 ]; then
+  echo "No Chart.yaml files found to check."
+  exit 0
+fi
+
+echo "Checking ${#CHARTS[@]} chart(s) for the hollow-chart guard…"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Per-chart check. Mirror of GUARD 1 in blueprint-release.yaml.
+# ---------------------------------------------------------------------------
+hollow=0
+checked=0
+for chart_yaml in "${CHARTS[@]}"; do
+  if [ ! -f "$chart_yaml" ]; then
+    echo "  ⚠  $chart_yaml — not a file, skipping"
+    continue
+  fi
+
+  rel_path="${chart_yaml#$REPO_ROOT/}"
+  checked=$((checked + 1))
+
+  # yq returns "" / "null" for absent keys; the post-merge guard treats
+  # the // "" fallback as "absent". `length // 0` returns 0 for both an
+  # absent block and `dependencies: []`.
+  dep_count=$(yq '.dependencies | length // 0' "$chart_yaml")
+  no_upstream=$(yq '.annotations["catalyst.openova.io/no-upstream"] // ""' "$chart_yaml")
+
+  if [ "$dep_count" -gt 0 ]; then
+    echo "  ✓ $rel_path — declares $dep_count upstream dep(s)"
+    continue
+  fi
+
+  if [ "$no_upstream" = "true" ]; then
+    echo "  ✓ $rel_path — no-upstream:true (Catalyst-authored only, OK)"
+    continue
+  fi
+
+  # Hollow chart detected.
+  hollow=$((hollow + 1))
+  cat >&2 <<EOF
+
+::error file=$rel_path,title=Hollow chart::Chart $rel_path declares NO dependencies and is NOT annotated with \`catalyst.openova.io/no-upstream: "true"\`.
+
+Every Blueprint umbrella chart at platform/<name>/chart/ or
+products/<name>/chart/ MUST EITHER:
+
+  (a) declare its upstream chart under \`dependencies:\` per
+      docs/BLUEPRINT-AUTHORING.md §11.1 (Umbrella shape), OR
+
+  (b) opt out for charts that legitimately ship only Catalyst-authored
+      resources (CRs / Deployment / RBAC / Service / NetworkPolicy) by
+      setting the annotation:
+
+        annotations:
+          catalyst.openova.io/no-upstream: "true"
+
+Why this is enforced PRE-merge: the post-merge Blueprint Release workflow
+will reject the publish AFTER the version is locked into the merged
+Chart.yaml — at which point the version is dead-reserved and requires a
+follow-up bump-and-fix PR (see TBD-V34 / issue #2080 for the third
+recurrence: bp-continuum:0.1.1).
+
+Precedent fixes:
+  - PR #2023  (bp-kyverno-policies)
+  - PR #2081  (bp-continuum)
+  - bp-crossplane-claims  (historical)
+
+See issue #181 for the post-merge guard origin and
+.github/workflows/blueprint-release.yaml GUARD 1 for the canonical logic.
+EOF
+done
+
+# ---------------------------------------------------------------------------
+# Summary + exit.
+# ---------------------------------------------------------------------------
+echo ""
+echo "──────────────────────────────────────────────────────────────"
+echo "Checked: $checked chart(s)"
+echo "Hollow:  $hollow chart(s)"
+echo "──────────────────────────────────────────────────────────────"
+
+if [ "$hollow" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Promotes the hollow-chart guard (issue #181) from post-merge (`.github/workflows/blueprint-release.yaml` GUARD 1, runs after merge) to **pre-merge** (`pull_request` trigger). Catches violations **before** the chart version is dead-reserved by a failed publish — the real-world failure mode that has now recurred four times (cert-manager / crossplane-claims / kyverno-policies / continuum) and required four follow-up version-bump PRs.

## Recurrence history

| # | Chart | Incident |
|---|---|---|
| 1 | `bp-cert-manager:1.0.0` | Original incident (issue #181). Phase 1 broke on every Sovereign — no upstream cert-manager bytes. |
| 2 | `bp-crossplane-claims`  | Catalyst-authored-only chart; needed the `catalyst.openova.io/no-upstream: "true"` annotation. |
| 3 | `bp-kyverno-policies`   | PR #2023 — same shape. |
| 4 | `bp-continuum:0.1.1`    | PR #2072 → fix #2081 / TBD-V34 #2080. `0.1.1` is currently dead-pinned in `clusters/_template/bootstrap-kit/62-bp-continuum.yaml`; fresh-prov hits `ArtifactFailed` at slot 62, Pillar 3 blocked. |

Each recurrence is an **Inviolable-Principle #13** lockstep break (chart-pin vs published GHCR tag drift) — the merged `Chart.yaml: version` is reserved-dead the moment the post-merge guard rejects publish, requiring a SEPARATE bump-and-annotate PR.

## Shape

| File | Purpose |
|---|---|
| `scripts/check-chart-annotations.sh` | Guard logic, byte-for-byte mirror of `.github/workflows/blueprint-release.yaml` GUARD 1 (lines 193–251). Same `yq` parser version, same fallback semantics (`length // 0`, `// ""`). Accepts a path list; if empty, scans every `platform/*/chart/Chart.yaml` + `products/*/chart/Chart.yaml`. |
| `.github/workflows/check-chart-annotations.yaml` | `pull_request` trigger. Diffs against PR base SHA, filters for changed `Chart.yaml`, feeds the script. `workflow_dispatch` `scope: all` runs over the whole tree for ad-hoc audits. |
| `docs/BLUEPRINT-AUTHORING.md` §11.1 | "What CI enforces" table updated — pre-merge guard now listed as the primary line of defence; post-merge guards stay as belt-and-braces structural verification at publish time. |

## Scoping decision (important)

**Only CHANGED charts in the PR diff are evaluated.** There are currently 3 pre-existing hollow charts on `main`:

- `platform/network-policies/chart/Chart.yaml` (`bp-network-policies`, v1.0.0)
- `products/axon/chart/Chart.yaml` (`axon`, v0.1.0)
- `products/continuum/chart/Chart.yaml` (`bp-continuum`, v0.1.1 — being fixed in PR #2081)

By design this guard does **NOT** retroactively block unrelated PRs touching those charts; the post-merge Blueprint Release workflow's GUARDs 1/2/3 continue to fail-loudly on their next publish attempt regardless. This is additive pre-merge defence catching *new* chart introductions and version-bumps.

Per task hard-rule: "DO NOT bundle other CI improvements in this PR" — the 2 stale offenders (bp-network-policies, axon) should be filed as separate TBDs.

## Validation

- [x] **Negative case**: `bash scripts/check-chart-annotations.sh products/continuum/chart/Chart.yaml` → exit 1 with `::error file=…,title=Hollow chart::` GitHub annotation
- [x] **Positive case**: `bash scripts/check-chart-annotations.sh products/catalyst/chart/Chart.yaml platform/cilium/chart/Chart.yaml` → exit 0 (catalyst opts out via annotation; cilium declares one upstream dep)
- [x] **Tree scan**: 81 charts checked, 3 hollow flagged (matches the known pre-existing offenders)
- [ ] CI on this PR runs the new workflow on its own `pull_request` event (workflow path-trigger covers itself + scripts/)
- [ ] **Deliberate failing-test PR** (post-merge): open a throw-away PR that adds a hollow chart → pre-merge guard FAILS as expected. TBD-V35 #2086 closes only after operator confirms.

## Coordination with PR #2081

PR #2081 (the bp-continuum:0.1.2 fix-forward) is open and unaffected by this PR. The new pre-merge guard *would have* caught PR #2072 (the predecessor that dead-reserved bp-continuum:0.1.1) — the exact recurrence that motivated this work. If #2081 merges before this PR, that's fine; if this PR merges before #2081 and #2081's `Chart.yaml` change is touched, the guard will check it (it already carries the annotation per the diff, so it will pass).

## Refs

- Refs #2086 (TBD-V35 — this work item)
- Refs #2080 (TBD-V34 — the dead-reserved bp-continuum:0.1.1 incident)
- Refs #2081 (the bp-continuum fix-forward PR — pre-merge guard would have caught its predecessor PR #2072)
- Refs #181  (post-merge hollow-chart guard origin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)