### PR TITLE
fix(charts): add no-upstream annotation to bp-network-policies + axon (Refs #2088, Refs #2089)

### DIFF
--- a/platform/network-policies/blueprint.yaml
+++ b/platform/network-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.0.0
+  version: 1.0.1
   card:
     title: Network Policies (zero-trust baseline)
     summary: |

--- a/platform/network-policies/chart/Chart.yaml
+++ b/platform/network-policies/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-network-policies
-version: 1.0.0
+version: 1.0.1
 description: |
   Catalyst zero-trust default-deny CiliumClusterwideNetworkPolicy +
   allow-templates for control-plane namespaces, intra-namespace traffic,
@@ -11,3 +11,12 @@ keywords: [catalyst, blueprint, network-policy, cilium, zero-trust]
 maintainers:
   - name: OpenOva Catalyst
     email: catalyst@openova.io
+
+# Opt out of the hollow-chart guard (Blueprint-Release workflow / issue #181):
+# this chart legitimately ships only Catalyst-authored CRs (default-deny
+# CiliumClusterwideNetworkPolicy + allow-templates that target the
+# cilium.io CRDs installed by bp-cilium). It has NO upstream Helm
+# subchart to bundle. Same shape as bp-kyverno-policies (PR #2023) and
+# bp-continuum (PR #2081).
+annotations:
+  catalyst.openova.io/no-upstream: "true"

--- a/products/axon/chart/Chart.yaml
+++ b/products/axon/chart/Chart.yaml
@@ -2,5 +2,14 @@ apiVersion: v2
 name: axon
 description: OpenAI-compatible API gateway backed by Claude Agent SDK
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
+
+# Opt out of the hollow-chart guard (Blueprint-Release workflow / issue #181):
+# this chart legitimately ships only Catalyst-authored resources
+# (Deployment + Service + Ingress + Valkey sidecar + token-refresh
+# CronJob). It is a product chart with NO upstream Helm subchart to
+# bundle. Same shape as bp-kyverno-policies (PR #2023) and bp-continuum
+# (PR #2081).
+annotations:
+  catalyst.openova.io/no-upstream: "true"


### PR DESCRIPTION
## Summary

Pre-emptively annotate two hollow charts flagged by PR #2087's `--all` scan so the next chart-bump doesn't dead-reserve a version on the post-merge Blueprint Release guard (same failure mode that hit `bp-continuum:0.1.1` and required PR #2081 to bump 0.1.1 → 0.1.2).

Same shape as PR #2023 (bp-kyverno-policies) and PR #2081 (bp-continuum) — both target charts legitimately ship only Catalyst-authored resources with NO upstream Helm subchart to bundle.

## Root cause (TBD-V36 / TBD-V37)

PR #2087 elevated the hollow-chart guard to a **pre-merge** check (only fails on CHANGED `Chart.yaml` files). The `--all` scan flagged 3 pre-existing hollow charts:

1. `bp-continuum:0.1.1` — being fixed in PR #2081
2. `bp-network-policies:1.0.0` — this PR (TBD-V36 / #2088)
3. `axon:0.1.0` — this PR (TBD-V37 / #2089)

Without this fix, the NEXT bump of either chart trips the post-merge Blueprint Release guard, the version is dead-reserved, and a follow-up bump-and-fix PR is required (like #2072 → #2081 for continuum).

## Why both charts are legitimately no-upstream

**`bp-network-policies`** — ships only Catalyst-authored CRs: default-deny `CiliumClusterwideNetworkPolicy` + allow-templates for control-plane namespaces, intra-namespace traffic, and CoreDNS egress (see `platform/network-policies/chart/templates/`). All targets the `cilium.io` CRDs installed by `bp-cilium`. No upstream Helm subchart exists.

**`axon`** — product chart shipping only Catalyst-authored resources: `Deployment` + `Service` + `Ingress` + Valkey sidecar (`valkey-deployment.yaml` + `valkey-service.yaml` + `valkey-pvc.yaml`) + `token-refresh-cronjob.yaml`. It is the OpenAI-compatible API gateway backed by Claude Agent SDK; the chart is purely Catalyst-authored. No upstream Helm subchart exists.

## Changes

### `bp-network-policies` (Refs #2088 / TBD-V36)

- `platform/network-policies/chart/Chart.yaml` — add `annotations.catalyst.openova.io/no-upstream: "true"` + bump `version` 1.0.0 → 1.0.1
- `platform/network-policies/blueprint.yaml` — bump `spec.version` 1.0.0 → 1.0.1 (lockstep, Principle #14)

### `axon` (Refs #2089 / TBD-V37)

- `products/axon/chart/Chart.yaml` — add `annotations.catalyst.openova.io/no-upstream: "true"` + bump `version` 0.1.0 → 0.1.1

## No bootstrap-kit pins exist for either chart

Verified via grep across `clusters/`:

```
$ grep -rln 'bp-network-policies' clusters/   # → empty
$ grep -rln 'chart: axon\|name: axon$' clusters/  # → empty
```

Neither chart is currently referenced in `clusters/_template/bootstrap-kit/`. No pin lockstep needed (Principle #14 satisfied vacuously).

## Validation

```
$ helm lint platform/network-policies/chart    # 1 chart(s) linted, 0 chart(s) failed
$ helm lint products/axon/chart                 # 1 chart(s) linted, 0 chart(s) failed
$ helm package platform/network-policies/chart  # → bp-network-policies-1.0.1.tgz
$ helm package products/axon/chart              # → axon-0.1.1.tgz

$ bash scripts/check-chart-annotations.sh   # using PR #2087's script
…
  ✓ platform/network-policies/chart/Chart.yaml — no-upstream:true (Catalyst-authored only, OK)
  ✓ products/axon/chart/Chart.yaml           — no-upstream:true (Catalyst-authored only, OK)
…
Checked: 81 chart(s)
Hollow:  1 chart(s)   # → only products/continuum/chart/Chart.yaml remains, fixed by open PR #2081
```

## Post-merge gates (Inviolable Principle #13 / anti-theater rule)

This PR uses `Refs #2088` + `Refs #2089`, NOT `Closes`. Issues close only after:

1. Blueprint-Release CI on merge SHA succeeds for both charts (no hollow-chart guard failure).
2. `crane manifest ghcr.io/openova-io/bp-network-policies:1.0.1` returns a manifest JSON.
3. `crane manifest ghcr.io/openova-io/axon:0.1.1` returns a manifest JSON.

## Test plan

- [x] `helm lint` clean for both charts
- [x] `helm package` clean for both charts (`bp-network-policies-1.0.1.tgz`, `axon-0.1.1.tgz`)
- [x] PR #2087 pre-merge guard would pass both Chart.yaml diffs
- [x] `scripts/check-chart-annotations.sh` full-repo scan: only `products/continuum:0.1.1` remains as the 1 known hollow (fixed by open PR #2081)
- [ ] Blueprint-Release CI publishes `oci://ghcr.io/openova-io/bp-network-policies:1.0.1` on merge
- [ ] Blueprint-Release CI publishes `oci://ghcr.io/openova-io/axon:0.1.1` on merge
- [ ] `crane manifest` returns 200 + manifest JSON for both tags
- [ ] `#2088` + `#2089` closed by operator only after the two `crane manifest` checks pass

Refs #2088 (TBD-V36 — bp-network-policies)
Refs #2089 (TBD-V37 — axon)
Refs #2087 (the pre-merge guard PR that flagged both)
Refs #2081 (sibling fix — bp-continuum)
Refs #2023 (precedent — bp-kyverno-policies)
Refs #181  (hollow-chart guard origin)

Generated with [Claude Code](https://claude.com/claude-code)