### PR TITLE
fix(bp-network-policies): add smoke-render-mode=default-off + bump 1.0.1 → 1.0.2 (Refs #2088)

### DIFF
--- a/platform/network-policies/blueprint.yaml
+++ b/platform/network-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.0.1
+  version: 1.0.2
   card:
     title: Network Policies (zero-trust baseline)
     summary: |

--- a/platform/network-policies/chart/Chart.yaml
+++ b/platform/network-policies/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-network-policies
-version: 1.0.1
+version: 1.0.2
 description: |
   Catalyst zero-trust default-deny CiliumClusterwideNetworkPolicy +
   allow-templates for control-plane namespaces, intra-namespace traffic,
@@ -12,11 +12,24 @@ maintainers:
   - name: OpenOva Catalyst
     email: catalyst@openova.io
 
-# Opt out of the hollow-chart guard (Blueprint-Release workflow / issue #181):
-# this chart legitimately ships only Catalyst-authored CRs (default-deny
-# CiliumClusterwideNetworkPolicy + allow-templates that target the
-# cilium.io CRDs installed by bp-cilium). It has NO upstream Helm
-# subchart to bundle. Same shape as bp-kyverno-policies (PR #2023) and
-# bp-continuum (PR #2081).
+# Annotations:
+#
+# - catalyst.openova.io/no-upstream: "true"
+#   Opt out of the hollow-chart guard (Blueprint-Release workflow / issue
+#   #181): this chart legitimately ships only Catalyst-authored CRs
+#   (default-deny CiliumClusterwideNetworkPolicy + allow-templates that
+#   target the cilium.io CRDs installed by bp-cilium). It has NO upstream
+#   Helm subchart to bundle. Same shape as bp-kyverno-policies (PR #2023)
+#   and bp-continuum (PR #2081).
+#
+# - catalyst.openova.io/smoke-render-mode: default-off
+#   The chart's `enabled` master gate defaults to false (see blueprint.yaml
+#   configSchema.enabled.default: false — installing this Blueprint is a
+#   no-op until the operator opts in). The Blueprint-Release smoke-render
+#   step does `helm template` with default values; without this annotation
+#   it errors with "Rendered output is suspiciously short (1 lines)" and
+#   dead-reserves the version. Same pattern as bp-continuum (PR #2081)
+#   which has the identical default-off shape.
 annotations:
   catalyst.openova.io/no-upstream: "true"
+  catalyst.openova.io/smoke-render-mode: default-off


### PR DESCRIPTION
## Summary

PR #2090 merged at `82997ff4` bumped `bp-network-policies` to `1.0.1` with the `no-upstream` annotation, but the post-merge Blueprint Release workflow ([run 26149240537](https://github.com/openova-io/openova/actions/runs/26149240537)) **FAILED** at the smoke-render step:

```
Rendered 1 lines to /tmp/render/bp-network-policies-1.0.1.default.yaml
##[error]Rendered output is suspiciously short (1 lines). A working
umbrella with an upstream subchart should produce many more
resources. (For charts that are intentionally default-off, set
annotations.catalyst.openova.io/smoke-render-mode: "default-off"
in Chart.yaml.)
```

Verified: `curl ghcr.io/v2/openova-io/bp-network-policies/manifests/1.0.1` returns **404** — the version is now dead-reserved.

(`axon:0.1.1` published cleanly — `200` — because its templates render non-empty by default; `axon` does NOT need this annotation.)

## Root cause

`bp-network-policies`' `configSchema.enabled.default` is `false` (see `platform/network-policies/blueprint.yaml`). The chart is a no-op until the operator opts in per-Sovereign — documented in the chart description and `docs/INVIOLABLE-PRINCIPLES.md #4`. With default values, `helm template` produces only a 1-line comment header.

Same pattern as `bp-continuum`, which sets `catalyst.openova.io/smoke-render-mode: default-off` for the same reason (see `products/continuum/chart/Chart.yaml:51`).

## Change

```diff
 apiVersion: v2
 name: bp-network-policies
-version: 1.0.1
+version: 1.0.2
 …
+# - catalyst.openova.io/smoke-render-mode: default-off
+#   The chart's `enabled` master gate defaults to false (see blueprint.yaml
+#   configSchema.enabled.default: false — installing this Blueprint is a
+#   no-op until the operator opts in). The Blueprint-Release smoke-render
+#   step does `helm template` with default values; without this annotation
+#   it errors with "Rendered output is suspiciously short (1 lines)" and
+#   dead-reserves the version. Same pattern as bp-continuum (PR #2081)
+#   which has the identical default-off shape.
 annotations:
   catalyst.openova.io/no-upstream: "true"
+  catalyst.openova.io/smoke-render-mode: default-off
```

Lockstep `blueprint.yaml`:

```diff
 spec:
-  version: 1.0.1
+  version: 1.0.2
```

No bootstrap-kit pin exists for `bp-network-policies` (verified via grep across `clusters/`), so no pin lockstep needed.

## Validation

```
$ helm lint platform/network-policies/chart
==> Linting platform/network-policies/chart
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

$ bash scripts/check-chart-annotations.sh platform/network-policies/chart/Chart.yaml
  ✓ platform/network-policies/chart/Chart.yaml — no-upstream:true (Catalyst-authored only, OK)
Checked: 1 chart(s)
Hollow:  0 chart(s)
```

## Post-merge gates (Inviolable Principle #13)

This PR uses `Refs #2088`, NOT `Closes`. Issue closes only after:

1. Blueprint-Release CI on this PR's merge SHA succeeds (no smoke-render failure).
2. `crane manifest ghcr.io/openova-io/bp-network-policies:1.0.2` returns a manifest JSON (not 404 / NAME_UNKNOWN).

## Test plan

- [x] `helm lint` clean
- [x] `scripts/check-chart-annotations.sh` pass for the changed Chart.yaml
- [ ] Blueprint-Release CI publishes `oci://ghcr.io/openova-io/bp-network-policies:1.0.2` on merge
- [ ] `curl` to `ghcr.io/v2/openova-io/bp-network-policies/manifests/1.0.2` returns 200 + manifest JSON

Refs #2088 (TBD-V36 — bp-network-policies hollow-chart annotation)
Refs #2090 (the original PR that dead-reserved 1.0.1 — `axon:0.1.1` from that PR published OK, only `bp-network-policies:1.0.1` is dead)
Refs #2081 (bp-continuum — same default-off pattern)
Refs #2087 (the pre-merge guard PR)

Generated with [Claude Code](https://claude.com/claude-code)