### PR TITLE
feat(newapi+vllm): wire bp-vllm slot 39 + default in-cluster Qwen channel (Refs #2115)

### DIFF
--- a/clusters/_template/bootstrap-kit/39-bp-vllm.yaml
+++ b/clusters/_template/bootstrap-kit/39-bp-vllm.yaml
@@ -1,0 +1,274 @@
+# bp-vllm — Catalyst bootstrap-kit Blueprint slot 39 (AI runtime cohort).
+#
+# In-cluster vLLM inference server. OpenAI-compatible REST API on port
+# 8000. CPU-mode by default — pairs with the bp-newapi `defaultChannels.
+# vllm` channel (slot 80) to give every Sovereign a zero-cost, no-third-
+# party-contract Qwen LLM channel out of the box.
+#
+# ─── Why this slot exists (TBD-V45 / issue #2115) ─────────────────────
+#
+# Before TBD-V45 a fresh Sovereign provisioned WITHOUT a Bank Dhofar
+# commercial contract had NO working LLM channel for the canonical
+# qwen-code agent (memory `feedback_canonical_end_user_dod.md`: "qwen-
+# code routes via newapi → Sovereign-hosted Qwen, zero Anthropic
+# cost-leak"). The only seedable bp-newapi channel was
+# `qwen3.6-bankdhofar` — triple-gated on `LLM_BANK_DHOFAR_ACCOUNT_ID`
+# / `LLM_BANK_DHOFAR_CONTRACT_REF` / per-Sovereign API-key Secret. With
+# none of those present, bp-newapi's channel-seed Helm hook Job
+# suppressed entirely and the customer-facing /v1/chat/completions
+# returned 404 "channel not found" on the first qwen-code request.
+#
+# This slot closes that gap by:
+#   1. Installing vLLM in-cluster, serving Qwen2.5-Coder-1.5B-Instruct
+#      (sized to fit on a single cpx52 worker — ~3 GB CPU inference,
+#      ~5-min cold load, no GPU required).
+#   2. Pairing with slot 80's flipped `defaultChannels.vllm.enabled:
+#      ${SOVEREIGN_VLLM_ENABLED:-true}` so bp-newapi's channel-seed Job
+#      composes + POSTs a `vllm`-typed channel pointing at
+#      `http://vllm-bp-vllm.vllm.svc.cluster.local:8000/v1` on every
+#      fresh Sovereign install.
+#
+# Attestation is `in-cluster` (operator owns the model weights AND the
+# inference hardware — the Sovereign cluster). No commercial-contract
+# attestation required.
+#
+# ─── Model choice (Qwen2.5-Coder-1.5B-Instruct) ───────────────────────
+#
+# Picked for fresh-Sovereign-feasibility on the canonical cpx52 worker
+# (16 GB RAM / 6 vCPU / no GPU). The 1.5B-Instruct variant:
+#   - Fits comfortably in CPU inference (~3 GB resident + KV cache);
+#     leaves headroom for the rest of the Sovereign workload.
+#   - Cold-load time ~5 min on cpx52 — within the chart's 600s liveness
+#     initialDelaySeconds budget.
+#   - Apache-2.0-licensed open-weights from Qwen (model card:
+#     https://huggingface.co/Qwen/Qwen2.5-Coder-1.5B-Instruct) — no
+#     HuggingFace token required (public, ungated).
+#   - Coder-tuned — matches qwen-code's task profile.
+#
+# Production Sovereigns with GPU nodes overlay this slot with
+# `vllm.gpu.enabled: true` + `vllm.model: Qwen/Qwen2.5-Coder-7B-
+# Instruct` (or larger) per their accelerator capacity. The chart
+# defaults are kept dev-friendly so a fresh prov boots without
+# operator overlay tuning.
+#
+# ─── Slot 39 dependsOn rationale ──────────────────────────────────────
+#
+# The bp-vllm chart is a plain Deployment+Service — no InferenceService
+# CR, no KServe runtime, no upstream Helm subchart with hard
+# prerequisites. The pairing with bp-kserve mentioned in
+# blueprint.yaml's `depends:` block is a logical "pairs with" hint for
+# Day-2 work (running vLLM as a KServe InferenceService), NOT a hard
+# install-time requirement.
+#
+# Per the convergence-blockers playbook, declaring a non-existent
+# bootstrap-kit slot as a dependsOn target wedges the HR indefinitely
+# (Flux dependsOn waits for the dependency to reach Ready=True;
+# missing HRs never report Ready). Slot 38 (bp-kserve) is reserved in
+# scripts/expected-bootstrap-deps.yaml but has no slot file on disk
+# today, so this slot deliberately declares NO bp-kserve dep.
+#
+# bp-flux (slot 3) and bp-cilium (slot 1) are implicit cluster-bootstrap
+# deps satisfied for every slot in this kit. The chart only needs CNI
+# (Cilium) + Flux to land its Deployment + Service. No explicit
+# dependsOn entries are required for that — same pattern as bp-valkey
+# (slot 17) and bp-cnpg (slot 16) which both declare just [bp-flux].
+#
+# ─── Per-Sovereign overlay surface ────────────────────────────────────
+#
+# enabled — default-ON via ${SOVEREIGN_VLLM_ENABLED:-true} on the
+# bootstrap-kit Kustomization substitute. Operators on resource-
+# constrained Sovereigns (or those bringing their own commercial Qwen
+# contract) opt-OUT via `SOVEREIGN_VLLM_ENABLED=false`. Lockstep with
+# slot 80's `defaultChannels.vllm.enabled` so the newapi channel is
+# composed iff the vLLM Deployment is rendered.
+#
+# vllm.model — overlay to a larger Coder variant on GPU Sovereigns
+# (e.g. `Qwen/Qwen2.5-Coder-7B-Instruct` on an a100-equipped node);
+# overlay to `Qwen/Qwen2.5-Coder-32B-Instruct-AWQ` on multi-GPU
+# clusters with int4 quantization (also flip `vllm.args.quantization:
+# awq`).
+#
+# vllm.gpu.* — flip `enabled: true` on GPU Sovereigns AFTER ensuring
+# the cluster's GPU operator (nvidia-device-plugin / driver-toolkit)
+# is Ready. CPU-mode is functional but extremely slow at >1.5B
+# parameters; do NOT serve production traffic from CPU mode.
+#
+# vllm.modelCache.* — overlay to `type: pvc` + a SeaweedFS-backed
+# claim once bp-seaweedfs (slot 18) is stable on the Sovereign, so
+# model weights survive Pod restarts and rolling upgrades. The
+# default emptyDir is fine for smoke-test and dev Sovereigns where
+# a re-pull on Pod restart is acceptable; production Sovereigns
+# MUST switch to a PVC to amortize the cold-load over upgrades.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vllm
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+    catalyst.openova.io/component: ai-runtime
+    # Kyverno PSS gate: vllm container runs as uid 1000 (non-root) so
+    # the chart values match `restricted` profile defaults. No
+    # exceptions required.
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-vllm
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-vllm
+  namespace: flux-system
+  labels:
+    catalyst.openova.io/slot: "39"
+    catalyst.openova.io/component: ai-runtime
+spec:
+  interval: 15m
+  releaseName: vllm
+  targetNamespace: vllm
+  # No explicit dependsOn — see the slot-39 dependsOn rationale comment
+  # block above. The chart only needs CNI + Flux (implicit cluster-
+  # bootstrap deps).
+  chart:
+    spec:
+      chart: bp-vllm
+      # Lockstep with platform/vllm/chart/Chart.yaml `version:` and
+      # platform/vllm/blueprint.yaml `spec.version:`. The TBD-A6
+      # auto-bump hook in .github/workflows/blueprint-release.yaml
+      # keeps this in sync with chart bumps; the
+      # scripts/check-bootstrap-kit-pin-sync.sh CI gate fails the build
+      # if drift is introduced.
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-vllm
+        namespace: flux-system
+  install:
+    timeout: 15m
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    timeout: 15m
+    disableWait: true
+    remediation:
+      retries: 3
+  values:
+    # Default-ON via the bootstrap-kit Kustomization substitute. Flip
+    # to false on per-Sovereign overlays where (a) resources are too
+    # constrained for in-cluster inference OR (b) the operator is
+    # bringing a commercial Qwen contract and prefers to route 100%
+    # of traffic to the BankDhofar relay. Keep lockstep with slot 80's
+    # `defaultChannels.vllm.enabled` so the newapi channel is composed
+    # iff this Deployment is rendered.
+    vllm:
+      enabled: ${SOVEREIGN_VLLM_ENABLED:-true}
+      replicas: 1
+      # Qwen2.5-Coder-1.5B-Instruct — public Apache-2.0 Coder-tuned
+      # model, ~3 GB CPU footprint, ~5 min cold-load on cpx52. Sized
+      # for the canonical cpx52 worker with no GPU. GPU Sovereigns
+      # overlay with a larger variant per accelerator capacity.
+      model: "Qwen/Qwen2.5-Coder-1.5B-Instruct"
+      args:
+        # Context length — 8192 is well within the 1.5B model's max
+        # (32K) and keeps KV-cache memory under 1 GB for CPU
+        # inference.
+        maxModelLen: 8192
+        # CPU mode does not honor --gpu-memory-utilization; harmless
+        # default.
+        gpuMemoryUtilization: 0.9
+        dtype: "auto"
+        # No quantization for 1.5B (fits FP16 in ~3 GB); GPU
+        # Sovereigns running 7B+ on a single GPU overlay
+        # `quantization: awq` for int4 fit.
+        quantization: ""
+        tensorParallelSize: 1
+        enablePrefixCaching: false
+        extraArgs: []
+      gpu:
+        enabled: false
+        count: 1
+        nodeSelector: {}
+        tolerations: []
+      # CPU-mode resources — fits in the cpx52 envelope. GPU
+      # Sovereigns overlay vllm.gpu.enabled=true and the chart picks
+      # the bp-vllm.resources helper's GPU branch automatically.
+      resources:
+        cpu:
+          requests:
+            cpu: "2"
+            memory: "6Gi"
+          limits:
+            cpu: "4"
+            memory: "10Gi"
+        gpu:
+          requests:
+            cpu: "4"
+            memory: "16Gi"
+          limits:
+            cpu: "16"
+            memory: "64Gi"
+      # No HF token required — Qwen2.5-Coder-1.5B-Instruct is public.
+      # GPU Sovereigns running gated Llama-family models overlay
+      # huggingfaceToken.enabled=true + supply an ExternalSecret.
+      huggingfaceToken:
+        enabled: false
+      # Default emptyDir for the model cache — fresh-prov-friendly.
+      # Production Sovereigns overlay `type: pvc` + a SeaweedFS-
+      # backed claim once bp-seaweedfs (slot 18) is stable, so model
+      # weights survive Pod restarts and rolling upgrades.
+      modelCache:
+        type: emptyDir
+      # Generous liveness budget — 1.5B Qwen cold-load takes ~5 min on
+      # CPU. The chart default of 600s initialDelaySeconds matches.
+      probes:
+        liveness:
+          path: /health
+          initialDelaySeconds: 600
+          periodSeconds: 30
+          timeoutSeconds: 10
+        readiness:
+          path: /health
+          initialDelaySeconds: 60
+          periodSeconds: 15
+          timeoutSeconds: 10
+    # ClusterIP Service exposed at `vllm-bp-vllm.vllm.svc.cluster.local
+    # :8000`. Slot 80 (bp-newapi) wires its `defaultChannels.vllm.
+    # endpoint` to `http://vllm-bp-vllm.vllm.svc.cluster.local:8000/v1`
+    # which matches this exact host + port.
+    service:
+      type: ClusterIP
+      port: 8000
+      targetPort: 8000
+    # ServiceMonitor default-OFF (matches the chart default per
+    # docs/BLUEPRINT-AUTHORING.md §11.2 — observability toggles MUST
+    # default OFF on a fresh Sovereign because the
+    # monitoring.coreos.com CRD ships with kube-prometheus-stack which
+    # is an opt-in downstream chart).
+    serviceMonitor:
+      enabled: false
+    # NetworkPolicy default-OFF for now — bp-newapi's egress rule
+    # already allows traffic to the `vllm` namespace on port 8000
+    # (see platform/newapi/chart/values.yaml `networkPolicy.egress`),
+    # and Cilium's default-allow CiliumNetworkPolicy posture in
+    # the `vllm` namespace gives ingress from `newapi`. Operators
+    # tightening to default-deny overlay this on AND set
+    # `llmGatewayNamespace: newapi` so the chart's policy admits
+    # newapi → vllm traffic.
+    networkPolicy:
+      enabled: false
+      llmGatewayNamespace: "newapi"
+    hpa:
+      enabled: false

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -179,7 +179,14 @@ spec:
       # Companion to bp-catalyst-platform 1.4.225 which adds the
       # secretKeyRef itself + the corrected CATALYST_NEWAPI_ADDR
       # literal (`http://newapi-bp-newapi.newapi.svc.cluster.local:3000`).
-      version: 1.4.36
+      # 1.4.37 — TBD-V45 (#2115, 2026-05-20): channel-seed Job now
+      # also seeds the in-cluster vLLM channel when
+      # `defaultChannels.vllm.enabled=true`. The seed gate is now
+      # `or qbdReady vllmReady` (was `and qbd.enabled qbdAttReady`),
+      # so a fresh Sovereign with vllm-only enabled (no Bank Dhofar
+      # commercial contract) still seeds a working Qwen channel.
+      # Lockstep with the platform/newapi/chart bump in the same PR.
+      version: 1.4.37
       sourceRef:
         kind: HelmRepository
         name: bp-newapi
@@ -328,12 +335,49 @@ spec:
           kind: commercial-contract
           accountId: ${LLM_BANK_DHOFAR_ACCOUNT_ID:-}
           contractRef: ${LLM_BANK_DHOFAR_CONTRACT_REF:-}
+      # TBD-V45 (#2115, 2026-05-20): wired the in-cluster vLLM channel
+      # default-ON. Paired with bootstrap-kit slot 39 (bp-vllm) which
+      # installs vLLM in-cluster as `vllm-bp-vllm.vllm.svc.cluster.local
+      # :8000` serving Qwen2.5-Coder-1.5B-Instruct on CPU by default.
+      # This pair gives every fresh Sovereign a zero-cost, no-third-
+      # party-contract Qwen channel out of the box — closes the
+      # canonical-DoD gap that the only seedable channel was triple-
+      # gated on a Bank Dhofar commercial contract.
+      #
+      # Lockstep with slot 39's `enabled: ${SOVEREIGN_VLLM_ENABLED:-true}`:
+      # if the operator opts-OUT of the in-cluster vLLM Deployment
+      # (resource-constrained Sovereigns / those bringing a commercial
+      # Qwen contract), this channel also opts-OUT — the chart's
+      # channel-seed Job suppresses the vLLM POST and the customer-
+      # facing channel-router never tries to dial a dead Service.
+      #
+      # Attestation kind: `in-cluster` — operator owns BOTH the model
+      # weights (Apache-2.0 Qwen2.5-Coder, public) and the inference
+      # hardware (the Sovereign cluster). No commercial-contract
+      # attestation required (no accountId / contractRef).
       vllm:
-        enabled: false
+        enabled: ${SOVEREIGN_VLLM_ENABLED:-true}
+        # Customer-visible channel name. `qwen` matches the canonical
+        # sandbox-controller default (`SANDBOX_DEFAULT_CHANNELS=qwen`
+        # in slot 19a-bp-sandbox.yaml) so per-Sandbox token mints land
+        # on this channel by default — closing the qwen-code → vLLM
+        # path end-to-end on a fresh Sovereign with no overlay.
         name: qwen
-        endpoint: ""
+        # In-cluster Service FQDN of the bp-vllm chart. The chart's
+        # Service name resolves to `<release>-<chart>` = `vllm-bp-vllm`
+        # (release "vllm" + chart "bp-vllm" per the chart's
+        # _helpers.tpl fullname template), and slot 39's HR sets
+        # targetNamespace=vllm + releaseName=vllm. Port 8000 matches
+        # the chart's service.port.
+        endpoint: "http://vllm-bp-vllm.vllm.svc.cluster.local:8000/v1"
         models:
           - qwen3-coder
+          # Underlying upstream model id served by the bp-vllm chart's
+          # default `vllm.model` (Qwen/Qwen2.5-Coder-1.5B-Instruct).
+          # vLLM exposes the model under its bare HF id; the customer-
+          # facing `qwen3-coder` alias maps via the channel-router so
+          # callers can use either string interchangeably.
+          - Qwen/Qwen2.5-Coder-1.5B-Instruct
         attestation:
           kind: in-cluster
           owner: ${SOVEREIGN_FQDN}

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -88,6 +88,18 @@ resources:
   - 33-syft-grype.yaml
   - 34-velero.yaml
   - 35-coraza.yaml
+  # bp-vllm (slot 39) — in-cluster vLLM inference server (Qwen2.5-Coder-
+  # 1.5B-Instruct on CPU by default). Paired with bp-newapi (slot 80)
+  # `defaultChannels.vllm` to give every fresh Sovereign a zero-cost,
+  # no-third-party-contract Qwen channel out of the box.
+  #
+  # TBD-V45 (#2115, 2026-05-20): closes the canonical-DoD gap that the
+  # only seedable bp-newapi channel was triple-gated on a Bank Dhofar
+  # commercial contract. Default-ON via ${SOVEREIGN_VLLM_ENABLED:-true}
+  # on the bootstrap-kit Kustomization substitute; lockstep with slot
+  # 80's `defaultChannels.vllm.enabled` so the newapi channel is
+  # composed iff this Deployment is rendered.
+  - 39-bp-vllm.yaml
   - 49-bp-cert-manager-powerdns-webhook.yaml
   - 50-cluster-autoscaler.yaml
   # qa-loop iter-7 Fix #39 — exec fan-out (Apache Guacamole + per-node

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-6-llm-serving
 spec:
-  version: 1.4.36
+  version: 1.4.37
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,25 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.37 — TBD-V45 / #2115 (2026-05-20): channel-seed Job now also
+# seeds the in-cluster vLLM channel when
+# `defaultChannels.vllm.enabled=true`. Paired with bootstrap-kit slot
+# 39 (bp-vllm) wiring + slot 80 `defaultChannels.vllm.enabled:
+# ${SOVEREIGN_VLLM_ENABLED:-true}` to give every fresh Sovereign a
+# zero-cost, no-third-party-contract Qwen channel out of the box.
+#
+# Gate change: the seed Job's `$hasDefaults` check is now
+# `or $qbdReady $vllmReady` (was `and $qbd.enabled $qbdAttReady`), so
+# a Sovereign with vllm-only seeding (no Bank Dhofar commercial
+# contract) still renders the Job. The vLLM channel needs no upstream
+# API key (in-cluster Service) so the chart POSTs an empty `key`
+# field — NewAPI accepts this for plain OpenAI-compatible upstreams
+# that delegate auth to the network layer.
+#
+# Lockstep: also bumped platform/newapi/blueprint.yaml spec.version
+# and clusters/_template/bootstrap-kit/80-newapi.yaml chart pin to
+# 1.4.37 in the same PR (per Inviolable Principle #14 — chart-pin
+# bump in the same commit).
+#
 # 1.4.33 — TBD-V15 / #2021 (2026-05-20, sister of TBD-V14 / PR #2017):
 # the `catalyst-newapi-admin-token` ExternalSecret now reflector-
 # mirrors the rendered Secret from `newapi` into `catalyst-system`
@@ -353,7 +373,7 @@ name: bp-newapi
 # `lookup valkey.valkey.svc.cluster.local: no such host`). Same hostname
 # already documented as canonical in products/catalyst/chart/values.yaml
 # bp-cnpg-pair comments.
-version: 1.4.36
+version: 1.4.37
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/channel-seed-job.yaml
+++ b/platform/newapi/chart/templates/channel-seed-job.yaml
@@ -67,7 +67,17 @@ Issue #915, 2026-05-05.
     {{- $qbdAttReady = false -}}
   {{- end -}}
 {{- end -}}
-{{- $hasDefaults := and $qbd.enabled $qbdAttReady -}}
+{{- $qbdReady := and $qbd.enabled $qbdAttReady -}}
+{{- /* TBD-V45 (#2115, 2026-05-20): also seed the in-cluster vLLM
+       channel when defaultChannels.vllm.enabled=true. The vLLM
+       channel is in-cluster (attestation.kind=in-cluster) so it
+       needs no upstream API key — the seed Job POSTs an empty
+       string in the channel's `key` field. The seed gate fires
+       when EITHER qwenBankDhofar OR vllm is enabled (both compose
+       into effectiveChannels via _helpers.tpl). */}}
+{{- $vllm := (.Values.defaultChannels | default dict).vllm | default dict -}}
+{{- $vllmReady := and $vllm.enabled (ne (default "" $vllm.endpoint) "") -}}
+{{- $hasDefaults := or $qbdReady $vllmReady -}}
 {{- $masterKeySecret := .Values.auth.adminUI.masterKeySecret | default "" -}}
 {{- if and $cs.enabled $hasDefaults $masterKeySecret -}}
 {{- $jobName := include "bp-newapi.channelSeedJobName" . -}}
@@ -111,9 +121,13 @@ rules:
     resources: ["secrets"]
     resourceNames:
       - {{ $masterKeySecret | quote }}
-{{- if and $qbd.enabled $qbd.existingSecret }}
+{{- if and $qbdReady $qbd.existingSecret }}
       - {{ $qbd.existingSecret | quote }}
 {{- end }}
+{{- /* TBD-V45 (#2115): vLLM channel uses no upstream API key
+       (in-cluster Service auth is not required for the bp-vllm
+       chart's plain Deployment + Service). No Secret to grant
+       read access on for the vLLM seed. */}}
     verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -166,12 +180,20 @@ metadata:
 data:
   channels.json: |
     {{- $list := list }}
-    {{- if $qbd.enabled }}
+    {{- if $qbdReady }}
       {{- $list = append $list (dict
             "name"     (default "qwen3.6-bankdhofar" $qbd.name)
             "type"     "openai-compatible"
             "endpoint" $qbd.endpoint
             "models"   (default (list "qwen3.6" "qwen3-coder") $qbd.models)) }}
+    {{- end }}
+    {{- /* TBD-V45 (#2115): in-cluster vLLM audit row. */}}
+    {{- if $vllmReady }}
+      {{- $list = append $list (dict
+            "name"     (default "qwen" $vllm.name)
+            "type"     "vllm"
+            "endpoint" $vllm.endpoint
+            "models"   (default (list "qwen3-coder") $vllm.models)) }}
     {{- end }}
     {{ $list | toJson }}
 ---
@@ -255,7 +277,7 @@ spec:
                 secretKeyRef:
                   name: {{ $masterKeySecret | quote }}
                   key: MASTER_KEY
-{{- if and $qbd.enabled $qbd.existingSecret }}
+{{- if and $qbdReady $qbd.existingSecret }}
             - name: QWEN_BANKDHOFAR_KEY
               valueFrom:
                 secretKeyRef:
@@ -398,7 +420,7 @@ spec:
               }
 
               echo "Channel-seed: seeding default channels"
-{{- if $qbd.enabled }}
+{{- if $qbdReady }}
               # ── Channel #1: Qwen3.6 @ BankDhofar (#915) ────────────
               # NewAPI's `type` field for OpenAI-compatible upstreams is
               # "openai" (constants/channel_type.go ChannelTypeOpenAI).
@@ -412,6 +434,26 @@ spec:
                 {{ $qbd.endpoint | quote }} \
                 {{ join "," (default (list "qwen3.6" "qwen3-coder") $qbd.models) | quote }} \
                 "${QWEN_BANKDHOFAR_KEY}"
+{{- end }}
+{{- if $vllmReady }}
+              # ── Channel: In-cluster vLLM (TBD-V45 / #2115) ─────────
+              # Sovereign-hosted Qwen via the bp-vllm Deployment (bootstrap
+              # -kit slot 39). The bp-vllm chart's plain Deployment +
+              # Service exposes an OpenAI-compatible REST API on port
+              # 8000; from NewAPI's channel-router perspective this looks
+              # identical to any other OpenAI-compatible upstream, so we
+              # POST it as type=openai (same registry value as the
+              # commercial Qwen channels above). Empty `key` field —
+              # the vLLM Service requires no upstream auth (CNI-level
+              # NetworkPolicy admits newapi → vllm:8000; in-cluster
+              # Service auth is a Day-2 hardening exercise tracked
+              # separately, not blocking the default-on Qwen channel).
+              seed_channel \
+                {{ (default "qwen" $vllm.name) | quote }} \
+                "openai" \
+                {{ $vllm.endpoint | quote }} \
+                {{ join "," (default (list "qwen3-coder") $vllm.models) | quote }} \
+                ""
 {{- end }}
 
               echo "Channel-seed: complete."

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -270,7 +270,17 @@ slots:
     wave: W2.K4
   - slot: 39
     name: bp-vllm
-    depends_on: [bp-kserve]
+    # TBD-V45 (#2115, 2026-05-20): bp-vllm landed as a standalone
+    # Deployment+Service vLLM runtime (NOT a KServe InferenceService).
+    # The chart needs only CNI + Flux (implicit cluster-bootstrap deps);
+    # the bp-kserve dep was a forward-declaration from the original
+    # W2.K4 paper plan that anticipated KServe-routed inference.
+    # bp-kserve (slot 38) has no bootstrap-kit slot file on disk today,
+    # so declaring it as a dependsOn would wedge bp-vllm's HR indefinitely
+    # (Flux dependsOn waits for Ready=True; missing HRs never report).
+    # When bp-kserve later lands as a real slot, this dep can be
+    # re-introduced + bp-vllm can be re-wrapped as a KServe ServingRuntime.
+    depends_on: []
     wave: W2.K4
   - slot: 40
     name: bp-llm-gateway


### PR DESCRIPTION
## Summary

Closes the canonical-DoD gap that the only seedable bp-newapi channel was triple-gated on a Bank Dhofar commercial contract. A fresh Sovereign provisioned WITHOUT the contract had NO working LLM channel for the canonical qwen-code agent (memory `feedback_canonical_end_user_dod.md`: *"qwen-code routes via newapi → Sovereign-hosted Qwen, zero Anthropic cost-leak"*).

This PR ships the architecture-correct fix: install vLLM in-cluster as bootstrap-kit slot 39 + flip bp-newapi's `defaultChannels.vllm` to enabled-by-default with the in-cluster endpoint. Zero third-party contract required.

## What changes (lockstep, single commit per Inviolable Principle #14)

| File | Change |
| --- | --- |
| `clusters/_template/bootstrap-kit/39-bp-vllm.yaml` | NEW slot — HelmRelease `bp-vllm@1.0.0` (already published on GHCR), `targetNamespace: vllm`, gate `${SOVEREIGN_VLLM_ENABLED:-true}`, model `Qwen/Qwen2.5-Coder-1.5B-Instruct`, CPU mode, single replica, no PVC (emptyDir cache) |
| `clusters/_template/bootstrap-kit/80-newapi.yaml` | Flip `defaultChannels.vllm.enabled: false` → `${SOVEREIGN_VLLM_ENABLED:-true}`. Wire endpoint `http://vllm-bp-vllm.vllm.svc.cluster.local:8000/v1` + `attestation.kind: in-cluster` + `owner: ${SOVEREIGN_FQDN}` (no commercial-contract gate). Chart pin 1.4.36 → 1.4.37 |
| `clusters/_template/bootstrap-kit/kustomization.yaml` | Add `39-bp-vllm.yaml` to resources |
| `scripts/expected-bootstrap-deps.yaml` | Slot 39 `depends_on: []` (was `[bp-kserve]`). KServe slot has no on-disk file — declaring it would wedge bp-vllm's HR. Re-introduce when bp-kserve lands |
| `platform/newapi/chart/Chart.yaml` | 1.4.36 → 1.4.37 + 1.4.37 history block |
| `platform/newapi/blueprint.yaml` | spec.version 1.4.36 → 1.4.37 (lockstep) |
| `platform/newapi/chart/templates/channel-seed-job.yaml` | Seed gate `and qbd.enabled qbdAttReady` → `or qbdReady vllmReady`. New `seed_channel` call for vLLM with empty `key` field (in-cluster, no upstream auth). Audit ConfigMap `channels.json` now lists both channels when both enabled. RBAC `resourceNames` gates qbd Secret on `$qbdReady` (was `$qbd.enabled`) |

## Chart bump table

| Chart | Before | After | Pin sync |
| --- | --- | --- | --- |
| `bp-vllm` | 1.0.0 | 1.0.0 (unchanged) | NEW pin at slot 39 |
| `bp-newapi` | 1.4.36 | 1.4.37 | Chart.yaml + blueprint.yaml + slot 80 pin all bumped lockstep |

GHCR tag `ghcr.io/openova-io/bp-vllm:1.0.0` already published (sha256 `0c07143f2a765d17e8b6d1b44e9d2eb4152523783996f5c7cd524e8d8fdfac6c`, 2026-04-30). The bp-newapi 1.4.37 tag publishes post-merge via the blueprint-release.yaml auto-bump hook (Inviolable Principle #13).

## Why Qwen2.5-Coder-1.5B-Instruct

Sized for the canonical cpx52 worker (16 GB RAM / 6 vCPU / no GPU). 1.5B-Instruct:
- Fits comfortably in CPU inference (~3 GB resident + KV cache)
- Cold-load time ~5 min on cpx52 — within chart liveness 600s budget
- Apache-2.0 public open-weights — no HF token required
- Coder-tuned — matches qwen-code's task profile

Production GPU Sovereigns overlay with `vllm.gpu.enabled=true` + `vllm.model=Qwen/Qwen2.5-Coder-7B-Instruct` per accelerator capacity. Chart defaults stay dev-friendly so a fresh prov boots without overlay tuning.

## Pre-merge validation (worktree at origin/main + 7 staged files)

- `scripts/check-bootstrap-deps.sh` — PASS (0 drift, 0 cycles, slot 39 `[P]resent` with no deps)
- `scripts/check-bootstrap-kit-pin-sync.sh` (full sweep) — PASS (53/53 in sync incl. `bp-vllm@1.0.0` + `bp-newapi@1.4.37`)
- `scripts/check-bootstrap-kit-pin-sync.sh --changed-only --base origin/main` — PASS
- `scripts/check-chart-annotations.sh` against both touched charts — PASS GUARD 1 (deps declared) + GUARD 2 (173-line vllm render, 456-line newapi render)
- `helm template platform/vllm/chart` — renders Namespace/Deployment/Service/ConfigMap/SA cleanly
- `helm template platform/newapi/chart` across 3 states (vllm-only enabled / both enabled / neither enabled) — all render correctly; `channels.json` audit list matches expectation; channel-seed Job suppresses when no defaults enabled
- `yq eval` + `envsubst` parse cleanly across 39, 80, kustomization

## Failure mode this closes (from #2115)

On a fresh `t<NN>.omani.works` Sovereign WITHOUT a Bank Dhofar commercial contract:
1. Fresh prov converges
2. bp-newapi reconciles; channel-seed Job suppresses (Bank Dhofar gates not satisfied); NewAPI Postgres `channels` table empty
3. User signs up → Sandbox → qwen-code
4. sandbox-controller mints per-Sandbox token with `allowed_channels=["qwen"]`
5. qwen-code fires `POST /v1/chat/completions {model: qwen3-coder}`
6. NewAPI router → 0 rows → **404 `channel not found`**. End-to-end FAIL.

After this PR: step 2 now ALSO renders the vLLM Deployment (slot 39) + seeds the in-cluster vLLM channel via the seed Job → step 6 returns a working completion from the in-cluster Qwen2.5-Coder-1.5B model.

## Test plan (operator-walk)

The issue stays OPEN until the founder walks the surface on a fresh `t<NN>.omani.works` prov with this PR merged and attaches a screenshot to #2115. Per CLAUDE.md §3 rule 1 this PR uses `Refs #2115` (not `Closes`).

Walk checklist (matches #2115 acceptance criteria):
- [ ] `kubectl get pods -n vllm` — `vllm-bp-vllm-xxx` Running 1/1 within ~10 min of converge (model cold-load gate)
- [ ] `kubectl exec -n newapi deploy/newapi-bp-newapi -- curl -s http://localhost:3000/api/channel | jq '.data[].name'` returns at least `"qwen"`
- [ ] Login → Sandbox → create qwen-code Sandbox → ask "what is 2+2" → completes successfully **without** Bank Dhofar contract / **without** Anthropic key
- [ ] Screenshot attached to #2115

## Repos Touched

- `openova-io/openova` (this repo): 7 files listed in the bump table above. No other repos.

## Follow-ups (out of scope for this PR — file separately if Pillar-N critical)

- `bp-bge` (slot 42) has the same chart-exists-but-no-slot pattern (embeddings)
- `core/controllers/sandbox/internal/controller/sandbox_controller.go:139` hardcoded single-channel comment is now factually correct ("qwen today") but the multi-channel design follow-up tracked separately
- Future GPU-Sovereign overlay docs (recommended `vllm.model` + `quantization` for 7B/32B variants per accelerator class)

Refs #2115

🤖 Generated with [Claude Code](https://claude.com/claude-code)