### PR TITLE
fix(bootstrap-kit): publish bp-continuum:0.1.2 + lockstep pin slot 62 (Refs #2121, Refs #2080)

### DIFF
--- a/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+++ b/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
@@ -103,13 +103,17 @@ spec:
   chart:
     spec:
       chart: bp-continuum
-      # 0.1.1 — first published version. 0.1.0 was never pushed to GHCR
-      # despite Chart.yaml claiming so; the chart sat in-tree without a
-      # bootstrap-kit slot to pin it, so blueprint-release.yaml never
-      # bumped past the initial commit's no-op detect step. Bumping to
-      # 0.1.1 in the same PR as this slot forces a fresh publish and
-      # the auto-bump-pin hook (TBD-A6) lands the matching pin write.
-      version: 0.1.1
+      # 0.1.2 — TBD-V34 republish. 0.1.1 (PR #2072) was tagged in-tree
+      # but never landed in GHCR; Blueprint Release run 26144858280
+      # failed the hollow-chart guard at the "Verify upstream subcharts
+      # present in working tree" step (Chart.yaml had NO dependencies
+      # and lacked the catalyst.openova.io/no-upstream annotation).
+      # 0.1.2 adds the no-upstream opt-out + a fresh version bump to
+      # force a re-publish. Pin moves in lockstep per Inviolable
+      # Principle #13 (chart-pin bumps must match a GHCR tag that
+      # exists — verified post-merge via crane manifest before any
+      # fresh-prov walk).
+      version: 0.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-continuum

--- a/products/continuum/chart/Chart.yaml
+++ b/products/continuum/chart/Chart.yaml
@@ -7,15 +7,22 @@ description: |
   switchover sequence). Slice K-Cont-1 of EPIC-6 (#1101) ships the
   product skeleton; K-Cont-2 fills the reconcile loop.
 type: application
-# 0.1.1 (Pillar-3 unblock #2065, 2026-05-20): first PUBLISHED version.
+# 0.1.2 (TBD-V34, 2026-05-20): re-publish after PR #2072's Blueprint
+# Release run (#26144858280) failed the hollow-chart guard. 0.1.1 was
+# tagged in-tree but never landed in GHCR because this chart declares
+# NO `dependencies:` (controller-only chart, no upstream helm subchart
+# to bundle). Same shape as bp-kyverno-policies (PR #2023) and bp-
+# crossplane-claims — opt out via `catalyst.openova.io/no-upstream:
+# "true"` (added to annotations below in this same edit). Bumping
+# 0.1.1 → 0.1.2 forces a fresh publish; bootstrap-kit slot 62 pin
+# moves to 0.1.2 in lockstep (Inviolable Principle #13).
+#
+# 0.1.1 (Pillar-3 unblock #2065, 2026-05-20): first attempt at a
+# PUBLISHED version — never reached GHCR; see above.
 # 0.1.0 sat in-tree without a bootstrap-kit slot to pin it, so the
 # blueprint-release workflow's `detect changed paths` step never had
-# reason to re-run and the chart was never pushed to GHCR. Bumping the
-# pin in lockstep with the new slot file (clusters/_template/bootstrap-
-# kit/62-bp-continuum.yaml) makes blueprint-release publish the chart
-# on this PR's merge; the auto-bump-pin hook (TBD-A6) then converges
-# the slot pin via a no-op (already matches).
-version: 0.1.1
+# reason to re-run and the chart was never pushed to GHCR.
+version: 0.1.2
 appVersion: "0.1.0"
 home: https://openova.io
 sources:
@@ -36,6 +43,18 @@ annotations:
   openova.io/category: customer-facing-capability
   openova.io/epic: "6"
   openova.io/depends-on: bp-cnpg-pair,bp-powerdns,pdm
+  # no-upstream: this chart legitimately ships only Catalyst-authored
+  # resources (controller Deployment + RBAC + Service + NetworkPolicy
+  # — see templates/). The Continuum CRD lives in products/catalyst/
+  # chart/crds/continuum.yaml and is installed by bp-catalyst-platform
+  # (slot 13) to avoid the helm-controller / kustomize-controller
+  # ownership flap on duplicated CRDs (see crds/README.md). There is
+  # no upstream Helm subchart to bundle. Same shape as bp-kyverno-
+  # policies (PR #2023) and bp-crossplane-claims. Without this
+  # annotation the Blueprint-Release hollow-chart guard (issue #181)
+  # rejects publish — proven by failed workflow run 26144858280
+  # (commit 53f510b9, PR #2072 merge, 2026-05-20T06:11:02Z).
+  catalyst.openova.io/no-upstream: "true"
   # smoke-render-mode: default-off — bp-continuum's chart ships
   # `continuum.enabled: false` as its default; helm template with
   # default values legitimately renders zero resources (per chart

--- a/products/continuum/chart/blueprint.yaml
+++ b/products/continuum/chart/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     openova.io/category: customer-facing-capability
 spec:
-  version: 0.1.1
+  version: 0.1.2
   card:
     title: Continuum
     summary: |


### PR DESCRIPTION
## Summary

**Unblocks t39 (and every fresh prov) at slot 62.** Cherry-picks the no-upstream annotation + 0.1.1->0.1.2 chart bump + slot 62 pin bump that PR #2081 staged but never merged. With this PR, the Blueprint Release CI will publish `oci://ghcr.io/openova-io/bp-continuum:0.1.2` to GHCR for the first time, and slot 62's HelmRelease will reconcile Ready=True on the next fresh prov.

Refs #2121 (TBD-V49, the walk-blocker filed at t39 20:08Z)
Refs #2080 (TBD-V34, the original recovery ticket)
Refs #2072 (the dead-pin PR whose post-merge CI failed)

## Phase-1 diagnosis (per Refs #2121 recipe)

| Check | Result |
|-------|--------|
| `gh api orgs/openova-io/packages/container/bp-continuum/versions` | 404 - package not found (never published) |
| `clusters/_template/bootstrap-kit/62-bp-continuum.yaml` chart version on origin/main | `0.1.1` |
| `products/continuum/chart/Chart.yaml` version on origin/main | `0.1.1` (no `no-upstream` annotation) |
| Last Blueprint Release for products/continuum (run 26144858280, commit `53f510b9`) | FAILED at hollow-chart guard - no `dependencies:` and no `catalyst.openova.io/no-upstream` opt-out |

This is gap class **C** per the task taxonomy: chart exists in-tree but release CI rejected publish; no published version to fall back to. Fix forward by adding the opt-out annotation + forcing a fresh publish via version bump.

## Why this chart legitimately has no upstream subchart

`products/continuum/chart/templates/` ships only Catalyst-authored resources (controller Deployment + RBAC + Service + NetworkPolicy). The `Continuum.dr.openova.io/v1` CRD lives in `products/catalyst/chart/crds/continuum.yaml` and is installed by bp-catalyst-platform slot 13 (avoiding the helm-controller / kustomize-controller CRD-ownership flap). There is no upstream Helm subchart to bundle.

Same shape as bp-kyverno-policies (PR #2023) and bp-crossplane-claims. The `catalyst.openova.io/no-upstream: "true"` annotation is the documented escape hatch for this exact case (see `.github/workflows/blueprint-release.yaml` GUARD 1).

## Changes (3 files)

```diff
# products/continuum/chart/Chart.yaml
-version: 0.1.1
+version: 0.1.2
 annotations:
+  catalyst.openova.io/no-upstream: "true"
   catalyst.openova.io/smoke-render-mode: default-off
```

```diff
# products/continuum/chart/blueprint.yaml
-  version: 0.1.1
+  version: 0.1.2
```

```diff
# clusters/_template/bootstrap-kit/62-bp-continuum.yaml
-      version: 0.1.1
+      version: 0.1.2
```

Lockstep per Inviolable Principle #13/14: Chart.yaml + blueprint.yaml + bootstrap-kit pin all move together.

## Local validation

- `helm lint products/continuum/chart` -> clean (1 chart, 0 failed)
- `helm template products/continuum/chart` (default-off) -> 1 line (header comment only); `smoke-render-mode: default-off` annotation opts out of the <5-line guard
- `bash scripts/check-bootstrap-kit-pin-sync.sh | grep continuum` -> `OK bp-continuum: chart=0.1.2 pin=0.1.2`
- `bash scripts/check-bootstrap-deps.sh | grep continuum` -> `[P] slot 62 bp-continuum <-- bp-catalyst-platform bp-nats-jetstream bp-powerdns`

## Provenance

Cherry-picked from the abandoned branch `fix-continuum-no-upstream-annotation` (PR #2081, closed 2026-05-20T07:51:46Z without merge or follow-up). The fix was correctly authored; only the merge step was missed in the parallel landings of #2087 (pre-merge hollow-chart guard) + #2090 (bp-network-policies/bp-axon annotations).

## Post-merge gate (`Refs` not `Closes` per anti-theater rule)

Do NOT auto-close #2121. The walk-blocker resolves only after:

1. Blueprint Release CI on this PR's merge SHA succeeds with `Helm push to GHCR` step completed.
2. `crane manifest ghcr.io/openova-io/bp-continuum:0.1.2` returns 200 + manifest JSON.
3. t39 (Deployment `ac474f8012fb5d2b`) shows `kubectl get hr -n flux-system bp-continuum` -> `Ready=True`, then `Kustomization/bootstrap-kit Ready=True`, then `Kustomization/sovereign-tls Ready=True`, then `handoverFiredAt` populated.

Only at that point do issues #2121 and #2080 become eligible for manual closure by the founder (per anti-theater rule, agents never auto-close).

## Test plan

- [x] `helm lint` clean
- [x] `helm template` default-off renders header only; smoke-render-mode annotation in place
- [x] `check-bootstrap-kit-pin-sync.sh` reports `OK bp-continuum: chart=0.1.2 pin=0.1.2`
- [x] `check-bootstrap-deps.sh` reports slot 62 dependsOn intact
- [ ] Blueprint Release CI on merge SHA succeeds (hollow-chart guard passes, helm push completes)
- [ ] `crane manifest ghcr.io/openova-io/bp-continuum:0.1.2` returns manifest JSON
- [ ] t39 slot 62 HelmRelease Ready=True -> bootstrap-kit Ready -> sovereign-tls Ready -> handover fires

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
