### PR TITLE
fix(kyverno): cert-manager-issued TLS + wait-for-secret initContainer (TBD-V53 #2128)

### DIFF
--- a/clusters/_template/bootstrap-kit/27-kyverno.yaml
+++ b/clusters/_template/bootstrap-kit/27-kyverno.yaml
@@ -13,10 +13,17 @@
 #     mesh substrate to receive AdmissionReview requests from the apiserver.
 #     Cilium is the root of the Catalyst-Zero DAG; until it is Ready the
 #     apiserver→webhook path is not reachable and Kyverno install is racy.
-#
-# No further dependsOn: Kyverno installs its own CRDs and does not require
-# cert-manager (it auto-generates admission webhook TLS via its built-in
-# certificate controller).
+#   - bp-cert-manager — TBD-V53 #2128 root-cause fix. Kyverno 1.3.0+ uses
+#     cert-manager to provision its admission-webhook TLS Secret BEFORE the
+#     kyverno main container starts (see platform/kyverno/chart/values.yaml
+#     comment on certManager.enabled). Without this dependsOn the Helm
+#     release can apply while cert-manager's controller / cainjector /
+#     webhook are still rolling out — the Certificate CR is created but
+#     stays Issuing, the wait-for-tls-secret initContainer pins the kyverno
+#     Pod in Init forever, and the bootstrap-kit Kustomization wedges on
+#     the cert-manager → kyverno chain. bp-cert-manager is slot 02 (well
+#     above slot 27) and exposes Ready=True only after its webhook serves
+#     correctly, so the dependsOn is sequential not just topological.
 
 ---
 apiVersion: v1
@@ -51,10 +58,14 @@ spec:
   targetNamespace: kyverno
   dependsOn:
     - name: bp-cilium
+    - name: bp-cert-manager
   chart:
     spec:
       chart: bp-kyverno
-      version: 1.2.1
+      # 1.3.0 (TBD-V53 #2128): cold-start race fix — cert-manager-issued
+      # TLS + wait-for-tls-secret initContainer. See chart Chart.yaml for
+      # the full root-cause analysis.
+      version: 1.3.0
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno/blueprint.yaml
+++ b/platform/kyverno/blueprint.yaml
@@ -5,7 +5,10 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.2.1
+  # 1.3.0 (TBD-V53 #2128): Cold-start race fix — cert-manager-issued TLS
+  # + extraInitContainer that blocks main container until the secret is
+  # populated. See platform/kyverno/chart/Chart.yaml for the full rationale.
+  version: 1.3.0
   card:
     title: Kyverno
     family: guardian

--- a/platform/kyverno/chart/Chart.yaml
+++ b/platform/kyverno/chart/Chart.yaml
@@ -12,7 +12,12 @@ description: |
   HA mode runs four controllers (admission, background, cleanup, reports);
   solo-Sovereign default is replicas=1 each.
 type: application
-version: 1.2.1
+# 1.3.0 (TBD-V53 #2128): Cold-start race fix — admission-controller TLS
+# now provisioned by cert-manager BEFORE the kyverno binary starts, and
+# an extraInitContainer blocks the main container until the secret has a
+# populated tls.crt. Eliminates the apiserver→webhook TLS handshake EOF
+# that wedged bootstrap-kit on every fresh-prov Sovereign.
+version: 1.3.0
 appVersion: "v1.18.0"
 keywords: [catalyst, blueprint, kyverno, policy, admission, security]
 maintainers:

--- a/platform/kyverno/chart/values.yaml
+++ b/platform/kyverno/chart/values.yaml
@@ -48,6 +48,104 @@ kyverno:
     serviceMonitor:
       enabled: false
 
+    # TBD-V53 #2128 — Cold-start race fix.
+    #
+    # PROBLEM: With the upstream default (admissionController.certManager.enabled=
+    # false, admissionController.createSelfSignedCert=false), Kyverno generates
+    # its own admission-webhook TLS cert AT RUNTIME inside the main container.
+    # During the boot window the kube-apiserver sees a registered ValidatingWebhook
+    # Configuration but the kyverno-svc TCP endpoint can't yet complete a TLS
+    # handshake — `TLS handshake error from <apiserver>:<port>: EOF`. The kyverno
+    # binary exits cleanly (code 0) to retry; kubelet restarts; each restart
+    # races again. Concurrently the Flux bootstrap-kit Kustomization's dry-run
+    # apply (e.g. Namespace/alloy) calls the same webhook → 502 → the entire
+    # bootstrap-kit wedges on a fresh-prov Sovereign. Verified live on t40 today
+    # (6 restarts in 67 min, bootstrap-kit still "Reconciliation in progress").
+    #
+    # FIX: Provision the TLS cert via cert-manager BEFORE Kyverno starts.
+    # bp-cert-manager is bootstrap-kit slot 02 and bp-kyverno is slot 27 with
+    # an explicit dependsOn (see clusters/_template/bootstrap-kit/27-kyverno.yaml),
+    # so cert-manager is guaranteed Ready by the time this chart installs.
+    # certManager.createSelfSignedIssuer=true (the upstream default when
+    # certManager.enabled=true) makes the chart self-contained — it creates its
+    # own ClusterIssuer + Issuer chain so no external Issuer is required.
+    certManager:
+      enabled: true
+      # Self-signed ClusterIssuer + CA chain shipped by the upstream chart.
+      # The whole TLS lineage is internal to kyverno; the webhook caBundle is
+      # cainjector-mutated from the Certificate's CA into the
+      # ValidatingWebhookConfiguration at runtime.
+      createSelfSignedIssuer: true
+
+    # GUARD against the kyverno main container racing apiserver webhook calls
+    # before the cert-manager-issued Secret has actually been populated. Even
+    # with certManager.enabled=true the Certificate CR may be Issuing for ~10-30s
+    # on a cold cluster (selfsigned-issuer → CA cert → Issuer → leaf cert chain).
+    # The init container polls the Secret; once `data.tls.crt` is non-empty the
+    # main container proceeds. Bounded by k8s pod startup timeout (no infinite
+    # block — fails into CrashLoop if cert-manager is broken, which is louder
+    # than a silent webhook-EOF cycle).
+    extraInitContainers:
+      - name: wait-for-tls-secret
+        # curlimages/curl is the canonical small image used across the
+        # Catalyst Blueprint catalog for in-cluster polling init containers
+        # (matches platform/k8s-ws-proxy + platform/wordpress-tenant). Per the
+        # MIRROR-EVERYTHING inviolable rule (PR #163), the image is pulled
+        # through harbor.openova.io's proxy-dockerhub library so air-gapped
+        # Sovereigns work without DockerHub egress. Per Sovereign overlays
+        # may rewrite via global.imageRegistry once Sovereign-local Harbor
+        # takes over the proxy_cache role post-cutover.
+        image: harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1
+        imagePullPolicy: IfNotPresent
+        # The secret name follows the upstream chart's naming convention:
+        #   <kyverno.admission-controller.serviceName>.<kyverno.namespace>.svc.kyverno-tls-pair
+        # With the Catalyst release name `kyverno` in namespace `kyverno`, that
+        # resolves to `kyverno-svc.kyverno.svc.kyverno-tls-pair`. The kube-apiserver
+        # path is the in-cluster Kubernetes API, reachable from any Pod's
+        # service-account token at https://kubernetes.default.svc.
+        command:
+          - sh
+          - -c
+          - |
+            set -eu
+            TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+            CACERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            NS="${KYVERNO_NAMESPACE:-kyverno}"
+            SECRET="kyverno-svc.${NS}.svc.kyverno-tls-pair"
+            URL="https://kubernetes.default.svc/api/v1/namespaces/${NS}/secrets/${SECRET}"
+            echo "wait-for-tls-secret: polling ${URL} for non-empty data.tls.crt"
+            i=0
+            until crt="$(curl -sS --cacert "${CACERT}" -H "Authorization: Bearer ${TOKEN}" "${URL}" 2>/dev/null \
+                          | sed -n 's/.*"tls\.crt":[[:space:]]*"\([^"]*\)".*/\1/p')" \
+                  && [ -n "${crt}" ] && [ "${crt}" != "null" ]; do
+              i=$((i+1))
+              if [ "${i}" -gt 120 ]; then
+                echo "wait-for-tls-secret: TIMEOUT after ~10min — cert-manager has not issued ${SECRET}"
+                exit 1
+              fi
+              sleep 5
+            done
+            echo "wait-for-tls-secret: secret ${SECRET} has tls.crt — proceeding."
+        env:
+          - name: KYVERNO_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65532
+
   backgroundController:
     replicas: 1
     image:

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -210,7 +210,11 @@ slots:
   # ---- Tier 7: security + policy (W2.K3, slots 27-34) -----------------------
   - slot: 27
     name: bp-kyverno
-    depends_on: [bp-cilium]
+    # bp-cert-manager dep (TBD-V53 #2128, PR #2129, kyverno 1.3.0): the
+    # admission-controller's TLS cert is now cert-manager-issued before the
+    # kyverno binary starts, eliminating the cold-start TLS handshake EOF
+    # race. cert-manager Ready is sequential, not just topological.
+    depends_on: [bp-cilium, bp-cert-manager]
     wave: W2.K3
   - slot: 27a
     name: bp-kyverno-policies


### PR DESCRIPTION
## Summary

Eliminates the cold-start race between bp-kyverno admission-controller and the kube-apiserver webhook calls that wedged bootstrap-kit on every fresh-prov Sovereign.

## Root cause (verified live on t40 + t39)

Upstream chart defaults leave Kyverno's admission-webhook TLS cert un-issued at install time — the `kyverno` binary generates it **at runtime inside the main container**. During the boot window the kube-apiserver sees a registered `ValidatingWebhookConfiguration` but the `kyverno-svc` TCP endpoint cannot complete a TLS handshake:

```
TLS handshake error from 10.42.0.47:36792: EOF
```

The kyverno binary then exits cleanly (code 0) to retry; kubelet restarts; each restart races again. Concurrently the Flux bootstrap-kit Kustomization's dry-run apply (e.g. `Namespace/alloy`) calls the same webhook → 502 → bootstrap-kit wedges.

t40 today (dep `be5b43a8f5033a77`): 6 restarts in 67 min, bootstrap-kit still "Reconciliation in progress" after 67 min, `console.t40.omantel.biz` returned HTTP 000 (no Gateway, no cert).

## Fix (target-state per `docs/PRINCIPLES.md` #14)

1. **Enable cert-manager integration in the upstream chart** — `admissionController.certManager.enabled=true`. The chart's `createSelfSignedIssuer=true` (default when certManager is enabled) ships a self-contained ClusterIssuer → CA Certificate → Issuer → leaf Certificate chain. No external Issuer required.
2. **Add `extraInitContainers: wait-for-tls-secret`** — polls the kube-apiserver until `kyverno-svc.kyverno.svc.kyverno-tls-pair` Secret has a non-empty `data.tls.crt`. Bounded (~10 min) so a broken cert-manager surfaces as CrashLoop rather than silent webhook-EOF cycling.
3. **HelmRelease `dependsOn: bp-cert-manager`** — cert-manager is bootstrap-kit slot 02 and exposes Ready=True only after its webhook serves. The HR now waits for cert-manager Ready before installing.

## Lockstep version bumps

| File | Before | After |
|---|---|---|
| `platform/kyverno/chart/Chart.yaml` `version` | 1.2.1 | 1.3.0 |
| `platform/kyverno/blueprint.yaml` `spec.version` | 1.2.1 | 1.3.0 |
| `clusters/_template/bootstrap-kit/27-kyverno.yaml` `chart.spec.version` | 1.2.1 | 1.3.0 |

## Helm template proof

```console
$ helm template kyverno platform/kyverno/chart --namespace kyverno | \
  grep -E "kind: Certificate|kind: ClusterIssuer|kind: Issuer|name: wait-for-tls-secret|tlsSecretName"
    kind: ClusterIssuer
  name: kyverno-selfsigned-issuer
kind: Certificate
kind: Issuer
kind: Certificate
            - --tlsSecretName=kyverno-svc.kyverno.svc.kyverno-tls-pair
          name: wait-for-tls-secret

$ helm lint platform/kyverno/chart
1 chart(s) linted, 0 chart(s) failed
```

The Certificate's `spec.secretName: kyverno-svc.kyverno.svc.kyverno-tls-pair` matches the secret the initContainer polls AND the main container's `--tlsSecretName` arg — round-trip verified.

## Why Option A (initContainer) over B (startupProbe) / C (HR dependsOn only)

- **Option B** (startupProbe) needs upstream kyverno binary to read cert lazily — it doesn't (it eagerly errors at cert load). Not landable without an upstream PR.
- **Option C** (HR `dependsOn` only) — cert-manager being Ready ≠ kyverno's Certificate CR being Issued. The CR takes 10-30s after cert-manager is ready (selfsigned → CA → leaf chain). HR-level `dependsOn` does NOT wait for that.
- **Option A** (initContainer) bounds the wait inside the Pod, where the actual race is. Smallest blast radius, no upstream contribution required, no other chart touched.

## Test plan

- [x] `helm template` renders cert-manager Certificate + Issuer + ClusterIssuer + wait-for-tls-secret initContainer (output above)
- [x] `helm lint` clean
- [x] Cluster bootstrap-kit drift workflow is warn-only — per-Sovereign manifests (`omantel.omani.works`, `otech.omani.works`) intentionally NOT touched; the canonical pin lives in `_template/`
- [ ] Fresh-prov Sovereign reaches `handoverFiredAt` within 20 min with **zero** kyverno admission-controller restarts — verified by operator walk on `t41` (or next free TLD per `omani.works ↔ omantel.biz` rotation)

## Follow-up

A sibling TBD-V54 tracks the upstream contribution: patch `kyverno` so `/health/liveness` returns 503 (rather than exit cleanly) until the TLS keypair is loaded. Eliminates the race even without cert-manager. Larger surface — separately tracked.

## DoD per `docs/DOD.md`

This is Pillar-5 substrate (`bp-self-sovereign-cutover`). Closes the substrate stability gap that's wedged tonight's walk. Unblocks every Pillar walk that depends on a fresh-prov Sovereign reaching handover within 20 min.

Refs #2128

🤖 Generated with [Claude Code](https://claude.com/claude-code)