### PR TITLE
feat(marketplace): Pillar 2 BCP wizard step writes to cart.appConfigs.postgres (Refs #2133, builds on TBD-V17 #2068)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -846,6 +846,15 @@ spec:
       # Removes ~2.1 KiB from cloud-init on 4-zone SME-pool Sovereigns
       # (omantel.biz + .omani.{homes,rest,trade}); brings t39-class
       # provisions back under Hetzner's 32 KiB user_data cap.
+      # 1.4.233 — TBD-V57 / #2133 (2026-05-21) Pillar 2: marketplace
+      # BCP wizard step lands so the customer can signal
+      # active-hot-standby + region pair at signup. Single source of
+      # truth = existing snake_case cart.appConfigs.postgres.* keys
+      # the gitops generator @ gitops.go:240-251 already consumes;
+      # zero backend touches, the round-trip test
+      # tenant_created_wire_test.go (commit 56e04ac8a) keeps guarding
+      # the wire shape. Refs #2133 (NOT Closes — operator walk on
+      # fresh prov required).
       version: 1.4.233
       sourceRef:
         kind: HelmRepository

--- a/core/marketplace/src/components/AddonsStep.svelte
+++ b/core/marketplace/src/components/AddonsStep.svelte
@@ -247,7 +247,7 @@
 
 <div class="float-nav">
   <a href="/apps" class="float-back">&larr; Apps</a>
-  <a href="/review" class="float-cta">Review Order &rarr;</a>
+  <a href="/bcp" class="float-cta">Continue &rarr;</a>
 </div>
 
 <style>

--- a/core/marketplace/src/components/BCPStep.svelte
+++ b/core/marketplace/src/components/BCPStep.svelte
@@ -1,0 +1,391 @@
+<script lang="ts">
+  // TBD-V57 (#2133) — Pillar 2 BCP topology picker. This is the
+  // marketplace wizard surface that lets the customer signal "I want
+  // active-hot-standby across two regions" at signup. The backend
+  // round-trip is ALREADY canonical via snake_case
+  // cart.appConfigs.postgres.{active_hot_standby, primary_region,
+  // replica_region} — every layer below (catalog seed, tenant publisher
+  // wire format, provisioning gitops generator, bp-cnpg-pair chart)
+  // consumes those exact field keys today. The previous audit at
+  // /tmp/audit-pillar3-cnpg-2026-05-20.md confirmed end-to-end wiring;
+  // the only missing piece was THIS UX surface so the customer could
+  // populate the fields. Adding a sibling Order.enable_hot_standby
+  // schema field (proposed in the original #2133 plan) would create two
+  // sources of truth and break the round-trip test in
+  // core/services/tenant/handlers/tenant_created_wire_test.go — the
+  // commit 56e04ac8a explicitly locked the contract.
+  //
+  // Files this component touches:
+  //   - cart.appConfigs.postgres.active_hot_standby (bool)
+  //   - cart.appConfigs.postgres.primary_region    (string)
+  //   - cart.appConfigs.postgres.replica_region    (string)
+  //
+  // The downstream consumer at
+  // core/services/provisioning/gitops/gitops.go:240-251 reads exactly
+  // these three keys; an invalid pair (identical regions, missing
+  // primary, missing replica) falls back to the single-cluster shape
+  // and logs a Warn — symmetric with the operator-opt-in InvalidRegionPair
+  // test in appconfigs_test.go.
+  //
+  // Regions list — TODO follow-up: when the catalog service exposes
+  // GET /v1/catalog/regions returning the Sovereign's primary +
+  // secondary regions, swap REGIONS to a fetched list. For now the
+  // canonical t-N defaults are hardcoded; smaller blast radius than
+  // shipping a stub endpoint that would itself be theatre.
+  import { readCart, setAppConfig } from '../lib/cart';
+
+  // Canonical Sovereign region keys — matches the values gitops
+  // appconfigs_test.go::TestPostgres_AppConfigs_ActiveHotStandby_GenericApp
+  // exercises ("hz-fsn-rtz-prod" / "hz-hel-rtz-prod") + adds nbg as the
+  // third region the t-N fresh-prov topology bring up. If a Sovereign
+  // wants a different set, the catalog/regions endpoint is the right
+  // injection point (see TODO above). hz-fsn = Falkenstein, hz-hel =
+  // Helsinki, hz-nbg = Nuremberg — all Hetzner BBs the canonical
+  // multi-region prov uses.
+  const REGIONS: { key: string; label: string }[] = [
+    { key: 'hz-fsn-rtz-prod', label: 'Falkenstein (hz-fsn)' },
+    { key: 'hz-hel-rtz-prod', label: 'Helsinki (hz-hel)' },
+    { key: 'hz-nbg-rtz-prod', label: 'Nuremberg (hz-nbg)' },
+  ];
+
+  // Helper: pull the current postgres slot from cart.appConfigs and
+  // apply defaults so the form is always populated even on first
+  // visit. Single source of truth: every read + write goes through
+  // setAppConfig() (which merges, not replaces), so AppDetail.svelte's
+  // separate seed of replicas/disk_gb/backups_enabled isn't clobbered.
+  let cart = $state(readCart());
+  const initialPg = (cart.appConfigs ?? {}).postgres ?? {};
+  let enabled = $state<boolean>(Boolean(initialPg.active_hot_standby));
+  let primaryRegion = $state<string>(
+    typeof initialPg.primary_region === 'string' && initialPg.primary_region !== ''
+      ? initialPg.primary_region
+      : REGIONS[0].key,
+  );
+  let replicaRegion = $state<string>(
+    typeof initialPg.replica_region === 'string' && initialPg.replica_region !== ''
+      ? initialPg.replica_region
+      : REGIONS[1].key,
+  );
+
+  // Mirror gitops's InvalidRegionPair check so the customer can't ship
+  // a config the provisioning generator would silently degrade. This
+  // surface fires a hard validation error on the wizard rather than
+  // letting the customer pay for active-hot-standby + then discover
+  // post-checkout that the provisioner fell back to single-cluster.
+  const regionsValid = $derived(!enabled || (primaryRegion !== '' && replicaRegion !== '' && primaryRegion !== replicaRegion));
+
+  // Persist on every change. setAppConfig MERGES with the existing
+  // postgres slot (AppDetail.svelte may have already seeded
+  // replicas/disk_gb/backups_enabled) so we never blow those away.
+  // The cart is the buffer between wizard steps — no submit needed.
+  function persist() {
+    const current = (readCart().appConfigs ?? {}).postgres ?? {};
+    const next: Record<string, number | string | boolean> = { ...current };
+    next.active_hot_standby = enabled;
+    if (enabled) {
+      next.primary_region = primaryRegion;
+      next.replica_region = replicaRegion;
+    } else {
+      // When OFF, drop the region picks so the gitops fallback path
+      // (legacy single-cluster generatePostgres) runs cleanly. Empty
+      // values match the OFF path in
+      // appconfigs_test.go::TestPostgres_AppConfigs_ActiveHotStandby_OFF.
+      delete (next as Record<string, unknown>).primary_region;
+      delete (next as Record<string, unknown>).replica_region;
+    }
+    cart = setAppConfig('postgres', next);
+  }
+
+  // Re-persist whenever the form mutates. $effect runs after every
+  // mutation of the tracked $state values, which is exactly the cart
+  // discipline the rest of the marketplace follows (mirror of
+  // AddonsStep.persistTLD on TLD select).
+  $effect(() => {
+    void enabled;
+    void primaryRegion;
+    void replicaRegion;
+    persist();
+  });
+</script>
+
+<div class="bcp-page">
+  <div class="bcp-hero">
+    <h1>Business continuity</h1>
+    <p>Pick how your database should survive a regional outage</p>
+  </div>
+
+  <!-- Topology radio: single-region (default) vs active-hot-standby -->
+  <section class="bcp-section">
+    <div class="bcp-head">
+      <h2>Topology</h2>
+      <span class="bcp-note">Optional</span>
+    </div>
+    <div class="topology-grid">
+      <label class="topology-card {!enabled ? 'selected' : ''}">
+        <input
+          type="radio"
+          name="topology"
+          checked={!enabled}
+          onchange={() => { enabled = false; }}
+        />
+        <div class="topology-body">
+          <div class="topology-title-row">
+            <strong>Single-region</strong>
+            <span class="topology-price free">FREE</span>
+          </div>
+          <p>One Postgres cluster in your primary region. Daily backups via the optional add-on. Recovery time after a regional outage: hours.</p>
+        </div>
+      </label>
+
+      <label class="topology-card {enabled ? 'selected' : ''}">
+        <input
+          type="radio"
+          name="topology"
+          checked={enabled}
+          onchange={() => { enabled = true; }}
+        />
+        <div class="topology-body">
+          <div class="topology-title-row">
+            <strong>Active-hot-standby</strong>
+            <span class="topology-price">+OMR 5.000 / mo</span>
+          </div>
+          <p>Primary + synchronous replica across two distinct regions over Cilium ClusterMesh. RTO 30s, RPO 5s. Zero-tx-loss failover when a region goes dark.</p>
+        </div>
+      </label>
+    </div>
+  </section>
+
+  <!-- Region pickers — only rendered when active-hot-standby is on -->
+  {#if enabled}
+    <section class="bcp-section">
+      <div class="bcp-head">
+        <h2>Regions</h2>
+        <span class="bcp-note">Primary and replica must differ</span>
+      </div>
+      <div class="region-grid">
+        <div class="region-field">
+          <label for="primary-region">Primary region</label>
+          <select
+            id="primary-region"
+            class="region-select"
+            bind:value={primaryRegion}
+          >
+            {#each REGIONS as r}
+              <option value={r.key}>{r.label}</option>
+            {/each}
+          </select>
+          <p class="region-hint">Writes land here. Apps connect to the primary's read-write endpoint.</p>
+        </div>
+        <div class="region-field">
+          <label for="replica-region">Replica region</label>
+          <select
+            id="replica-region"
+            class="region-select"
+            bind:value={replicaRegion}
+          >
+            {#each REGIONS as r}
+              <option value={r.key}>{r.label}</option>
+            {/each}
+          </select>
+          <p class="region-hint">Hot standby ready to take writes within 30 seconds if the primary region goes dark.</p>
+        </div>
+      </div>
+      {#if !regionsValid}
+        <p class="region-error" role="alert">Primary and replica regions must differ — pick two distinct regions to enable active-hot-standby.</p>
+      {/if}
+    </section>
+  {/if}
+</div>
+
+<div class="float-nav">
+  <a href="/addons" class="float-back">&larr; Add-ons</a>
+  <a
+    href={regionsValid ? '/review' : '#'}
+    class="float-cta {regionsValid ? '' : 'disabled'}"
+    aria-disabled={!regionsValid}
+    onclick={(e) => { if (!regionsValid) e.preventDefault(); }}
+  >
+    Review Order &rarr;
+  </a>
+</div>
+
+<style>
+  .bcp-page { max-width: 900px; margin: 0 auto; padding: 0 1.25rem 4.5rem; }
+
+  .bcp-hero { text-align: center; margin-bottom: 0.75rem; }
+  .bcp-hero h1 {
+    font-size: clamp(1.2rem, 2.2vw, 1.5rem);
+    color: var(--color-text-strong);
+    margin: 0.25rem 0 0.2rem;
+    font-weight: 700;
+  }
+  .bcp-hero p {
+    color: var(--color-text-dim);
+    font-size: 0.85rem;
+    margin: 0;
+  }
+
+  /* Sections — mirrors AddonsStep .ao-section so the design system
+     stays consistent. No bespoke chrome. */
+  .bcp-section {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 1rem 1.1rem;
+    margin-bottom: 0.75rem;
+  }
+  .bcp-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 0.65rem;
+  }
+  .bcp-head h2 { font-size: 0.95rem; color: var(--color-text-strong); margin: 0; font-weight: 600; }
+  .bcp-note { color: var(--color-text-dim); font-size: 0.78rem; }
+
+  /* Topology cards — mirrors .extra-tile pattern. Two-card grid that
+     collapses to single column on narrow viewports. */
+  .topology-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.6rem;
+  }
+  @media (max-width: 640px) { .topology-grid { grid-template-columns: 1fr; } }
+  .topology-card {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.6rem;
+    padding: 0.85rem 0.95rem;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+    cursor: pointer;
+    transition: border-color 0.15s, background 0.15s;
+  }
+  .topology-card:hover { border-color: var(--color-text-dim); }
+  .topology-card.selected {
+    border-color: var(--color-accent);
+    background: color-mix(in srgb, var(--color-accent) 4%, var(--color-bg));
+  }
+  .topology-card input[type="radio"] {
+    margin-top: 0.25rem;
+    accent-color: var(--color-accent);
+    flex-shrink: 0;
+  }
+  .topology-body { flex: 1; min-width: 0; }
+  .topology-title-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
+  }
+  .topology-body strong {
+    color: var(--color-text-strong);
+    font-size: 0.92rem;
+  }
+  .topology-body p {
+    margin: 0;
+    color: var(--color-text-dim);
+    font-size: 0.78rem;
+    line-height: 1.45;
+  }
+  .topology-price {
+    padding: 0.15rem 0.55rem;
+    border-radius: 4px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+    color: var(--color-accent);
+  }
+  .topology-price.free {
+    background: color-mix(in srgb, var(--color-success) 15%, transparent);
+    color: var(--color-success);
+  }
+
+  /* Region pickers */
+  .region-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+  @media (max-width: 640px) { .region-grid { grid-template-columns: 1fr; } }
+  .region-field { display: flex; flex-direction: column; gap: 0.35rem; }
+  .region-field label {
+    color: var(--color-text-strong);
+    font-size: 0.82rem;
+    font-weight: 600;
+  }
+  .region-select {
+    padding: 0.5rem 0.65rem;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    color: var(--color-text);
+    font: inherit;
+    font-size: 0.85rem;
+    appearance: auto;
+  }
+  .region-select:focus { outline: 2px solid var(--color-accent); border-color: transparent; }
+  .region-hint {
+    margin: 0;
+    color: var(--color-text-dim);
+    font-size: 0.74rem;
+    line-height: 1.45;
+  }
+  .region-error {
+    margin: 0.6rem 0 0;
+    color: var(--color-danger, #ef4444);
+    font-size: 0.8rem;
+    font-weight: 500;
+  }
+
+  /* Floating nav pill — duplicated from AddonsStep so this surface
+     inherits the same chrome. No new tokens. */
+  .float-nav {
+    position: fixed;
+    bottom: 1.25rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: color-mix(in srgb, var(--color-surface) 95%, transparent);
+    backdrop-filter: blur(12px);
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    padding: 0.35rem 0.4rem 0.35rem 0.6rem;
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+  }
+  .float-back {
+    color: var(--color-text-dim);
+    text-decoration: none;
+    font-size: 0.82rem;
+    font-weight: 500;
+    padding: 0.4rem 0.6rem;
+    white-space: nowrap;
+  }
+  .float-back:hover { color: var(--color-text-strong); }
+  .float-cta {
+    padding: 0.55rem 1.4rem;
+    background: var(--color-accent);
+    color: #fff;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.88rem;
+    white-space: nowrap;
+    box-shadow: 0 2px 8px color-mix(in srgb, var(--color-accent) 25%, transparent);
+    transition: filter 0.15s;
+  }
+  .float-cta:hover { filter: brightness(0.9); }
+  .float-cta.disabled {
+    background: color-mix(in srgb, var(--color-text-dim) 35%, transparent);
+    color: var(--color-text-dim);
+    cursor: not-allowed;
+    box-shadow: none;
+    pointer-events: auto;
+  }
+  .float-cta.disabled:hover { filter: none; }
+</style>

--- a/core/marketplace/src/components/Header.svelte
+++ b/core/marketplace/src/components/Header.svelte
@@ -38,12 +38,17 @@
     try { localStorage.setItem('sme-theme', next); } catch {}
   }
 
+  // TBD-V57 (#2133) — Pillar 2 BCP topology picker landed as step 4
+  // between Add-ons and Review. Customer signals active-hot-standby +
+  // region pair via cart.appConfigs.postgres.* (snake_case, single
+  // source of truth — matches gitops consumer + tenant.created wire).
   const steps = [
     { num: 1, label: 'Plan', href: '/plans' },
     { num: 2, label: 'Stack', href: '/apps' },
     { num: 3, label: 'Add-ons', href: '/addons' },
-    { num: 4, label: 'Review', href: '/review' },
-    { num: 5, label: 'Checkout', href: '/checkout' },
+    { num: 4, label: 'Topology', href: '/bcp' },
+    { num: 5, label: 'Review', href: '/review' },
+    { num: 6, label: 'Checkout', href: '/checkout' },
   ];
 
   $effect(() => {

--- a/core/marketplace/src/components/ReviewStep.svelte
+++ b/core/marketplace/src/components/ReviewStep.svelte
@@ -370,7 +370,7 @@
     </div>
 
     <div class="float-nav">
-      <a href="/addons" class="float-back">&larr; Setup</a>
+      <a href="/bcp" class="float-back">&larr; Topology</a>
     </div>
   {/if}
 </div>

--- a/core/marketplace/src/pages/bcp.astro
+++ b/core/marketplace/src/pages/bcp.astro
@@ -1,0 +1,7 @@
+---
+import Layout from '../layouts/Layout.astro';
+import BCPStep from '../components/BCPStep.svelte';
+---
+<Layout title="Business Continuity" step={4}>
+  <BCPStep client:load />
+</Layout>

--- a/core/marketplace/src/pages/checkout.astro
+++ b/core/marketplace/src/pages/checkout.astro
@@ -2,6 +2,6 @@
 import Layout from '../layouts/Layout.astro';
 import CheckoutStep from '../components/CheckoutStep.svelte';
 ---
-<Layout title="Checkout" step={5}>
+<Layout title="Checkout" step={6}>
   <CheckoutStep client:load />
 </Layout>

--- a/core/marketplace/src/pages/review.astro
+++ b/core/marketplace/src/pages/review.astro
@@ -2,6 +2,6 @@
 import Layout from '../layouts/Layout.astro';
 import ReviewStep from '../components/ReviewStep.svelte';
 ---
-<Layout title="Review Your Order" step={4}>
+<Layout title="Review Your Order" step={5}>
   <ReviewStep client:load />
 </Layout>

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,28 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.233 — TBD-V57 / #2133 (2026-05-21) Pillar 2: ship the
+# marketplace BCP wizard step so the customer can actually signal
+# active-hot-standby + region pair at signup. Single source of truth
+# is the existing snake_case `cart.appConfigs.postgres.{active_hot_
+# standby, primary_region, replica_region}` — every backend layer
+# (catalog seed @ seed.go:710-712, tenant.created wire publisher,
+# provisioning gitops generator @ gitops.go:240-251, bp-cnpg-pair
+# chart) was already consuming these exact keys; the only missing
+# piece was a UX surface so the customer could populate them. New
+# files: core/marketplace/src/pages/bcp.astro + components/
+# BCPStep.svelte. Updated: Header.svelte 5→6 wizard steps, AddonsStep
+# Continue→/bcp, ReviewStep Back→/bcp, review.astro step=5,
+# checkout.astro step=6. NO backend touches — the round-trip test
+# tenant_created_wire_test.go (commit 56e04ac8a) + the 4
+# appconfigs_test.go cases keep guarding the contract.
+#
+# 1.4.232 — #2118 (TBD-V48): render Cilium Gateway listener YAML
+# in the chart (templates/sovereign-tls-vars-cm.yaml) so cloud-init
+# no longer carries the O(N)-per-parent-zone listener block.
+# Removes ~2.1 KiB from cloud-init on 4-zone SME-pool Sovereigns
+# (omantel.biz + .omani.{homes,rest,trade}); brings t39-class
+# provisions back under Hetzner's 32 KiB user_data cap.
+#
 # 1.4.230 — TBD-V15 / #2066 (2026-05-20) Pillar 3: emit a per-tenant
 # Continuum.dr.openova.io/v1 CR alongside the bp-wordpress-tenant
 # HelmRelease whenever SOVEREIGN_ENABLE_HOT_STANDBY=true and two


### PR DESCRIPTION
## Summary

- Ships the missing Pillar 2 BCP wizard surface (TBD-V57 #2133): a new step between `/addons` and `/review` where the customer signals **single-region vs active-hot-standby** and picks a primary/replica region pair.
- **UI-only.** Single source of truth = existing snake_case `cart.appConfigs.postgres.{active_hot_standby, primary_region, replica_region}`. Every backend layer (catalog seed @ `seed.go:710-712`, tenant.created wire publisher, provisioning gitops generator @ `gitops.go:240-251`, bp-cnpg-pair chart) already consumes these exact keys — the only missing piece was the UX to populate them.
- Re-diagnosis ref: https://github.com/openova-io/openova/issues/2133#issuecomment-4505814425 — the previous 4-layer scope (adding `Order.enable_hot_standby` etc.) would have duplicated state and broken the round-trip test in `core/services/tenant/handlers/tenant_created_wire_test.go` (commit `56e04ac8a`).

## What lands

| File | Change |
|---|---|
| `core/marketplace/src/pages/bcp.astro` | NEW — wizard step=4 page |
| `core/marketplace/src/components/BCPStep.svelte` | NEW — topology radio + region pickers + InvalidRegionPair validation mirror |
| `core/marketplace/src/components/Header.svelte` | 5 → 6 wizard steps ("Topology" label) |
| `core/marketplace/src/components/AddonsStep.svelte` | Continue → `/bcp` (was `/review`) |
| `core/marketplace/src/components/ReviewStep.svelte` | Back → `/bcp` (was `/addons`) |
| `core/marketplace/src/pages/review.astro` | `step={5}` (was 4) |
| `core/marketplace/src/pages/checkout.astro` | `step={6}` (was 5) |
| `products/catalyst/chart/Chart.yaml` | 1.4.232 → 1.4.233 |
| `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` | pin → 1.4.233 |

## NO backend changes

Per re-diagnosis #2133:
- ❌ NO `enable_hot_standby` field on `Order` struct
- ❌ NO billing pricing line items (the `+OMR 5.000` badge is informational; cost is implicit via larger Clusters)
- ❌ NO tenant service handler touches
- ❌ NO provisioning service / gitops generator touches
- ❌ NO bp-cnpg-pair or bp-continuum chart touches

The `+5 OMR` chip is an informational badge today. When billing decides to surface BCP as a line item, that's an orthogonal change that can read from the same snake_case fields.

## Regions list (TODO follow-up)

The catalog service exposes no `/v1/catalog/regions` endpoint today. Per the task brief's "smaller blast radius" guidance: canonical t-N defaults are hardcoded in `BCPStep.svelte` (`hz-fsn-rtz-prod` / `hz-hel-rtz-prod` / `hz-nbg-rtz-prod`) with a TODO comment in the head explaining the swap when the endpoint lands. Filing a follow-up ticket is NOT part of this PR (per L8 of `feedback_amnesia_antipatterns_2026_05_20.md` — don't inflate without a concrete gap; the gap is named in-line).

## Validation evidence

```
$ cd core/marketplace && npm run build
[build] 10 page(s) built in 41.61s — dist/bcp/index.html present
[build] Complete!

$ go test ./core/services/tenant/handlers/ -run TestTenantCreatedWire
ok  github.com/openova-io/openova/core/services/tenant/handlers
  TestTenantCreatedWire_PublisherToConsumer_RoundTrip  PASS
  TestTenantCreatedWire_EmptyEmailOmitted_StillDecodes PASS
  TestTenantCreatedWire_AppConfigs_RoundTrip            PASS
  TestTenantCreatedWire_EmptyAppConfigs_Omitted         PASS

$ go test ./core/services/provisioning/gitops/ -run "TestPostgres_AppConfigs_ActiveHotStandby|TestReadStringCfg"
ok  github.com/openova-io/openova/core/services/provisioning/gitops
  TestPostgres_AppConfigs_ActiveHotStandby_GenericApp         PASS
  TestPostgres_AppConfigs_ActiveHotStandby_OFF                PASS
  TestPostgres_AppConfigs_ActiveHotStandby_InvalidRegionPair  PASS (5 subtests)
  TestPostgres_AppConfigs_ActiveHotStandby_ReplicasClamped    PASS
  TestReadStringCfg_HandlesNilAndMistype                      PASS

$ helm lint products/catalyst/chart
1 chart(s) linted, 0 chart(s) failed
```

## Test plan

- [ ] CI green (chart-lint, marketplace-build, unit tests)
- [ ] Fresh prov on next t-N — operator walks /plans → /apps → /addons → **/bcp** → /review → /checkout, flips topology to active-hot-standby, picks `hz-fsn-rtz-prod` + `hz-hel-rtz-prod`, observes the rendered tenant manifests carry `db-cnpg-pair.yaml` (NOT `db-postgres.yaml`) per the existing gitops contract.
- [ ] Same fresh prov: customer stays on single-region default → renders `db-postgres.yaml` only (no regression).

Refs #2133 — NOT Closes; founder closes after fresh-prov walk verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)