### PR TITLE
fix(catalyst-api): one-shot reads bypass informer cache (Refs #2131)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -867,7 +867,21 @@ spec:
       # step.<name>.result=success directly; no rerun. Unblocks Step 09
       # (gitea-token-mint), unblocks customer-journey Phase 2 (Sandbox).
       # Refs #2132 (NOT Closes — operator walk on fresh prov required).
-      version: 1.4.234
+      # 1.4.235 — TBD-V55 / #2131 (2026-05-21): catalyst-api one-shot
+      # ConfigMap reads in the cutover handlers (readCutoverStatus +
+      # listCutoverSteps) now retry with bounded backoff (~5 s budget)
+      # on transient `apiserver not ready` (HTTP 503) responses from
+      # k3s during admission-webhook warm-up. Pre-fix t40
+      # (2026-05-21 06:38Z): POST /api/v1/sovereign/cutover/start
+      # returned HTTP 502 while bastion `kubectl get cm` succeeded —
+      # apiserver was up externally but briefly returned 503 to
+      # in-cluster discovery during cold-start. Direct typed client
+      # path retained (Inviolable Principle #14); retry wraps the
+      # existing Get/List, no new abstraction. Unblocks Pillar 5
+      # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
+      # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
+      # on fresh prov required).
+      version: 1.4.235
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/handler/cutover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover.go
@@ -364,13 +364,28 @@ type cutoverStep struct {
 // structs. An invalid ConfigMap (missing required keys, malformed
 // PodSpec YAML) is surfaced as an error so the operator can fix the
 // chart values rather than silently skipping the step.
+//
+// TBD-V55: wraps the List in the same bounded-retry helper used by
+// readCutoverStatus so a transient `apiserver not ready` during k3s
+// warmup does not surface as a 502 from /cutover/start.
 func listCutoverSteps(ctx context.Context, deps *cutoverDeps) ([]cutoverStep, error) {
 	selector := fmt.Sprintf("%s=%s,%s=%s",
 		cutoverStepPartOfLabel, cutoverStepPartOfValue,
 		cutoverStepComponentLabel, cutoverStepComponentValue,
 	)
-	cms, err := deps.core.CoreV1().ConfigMaps(deps.ns).List(ctx, metav1.ListOptions{
-		LabelSelector: selector,
+	var cms *corev1.ConfigMapList
+	err := wait.ExponentialBackoffWithContext(ctx, cutoverApiserverReadyBackoff, func(c context.Context) (bool, error) {
+		got, lerr := deps.core.CoreV1().ConfigMaps(deps.ns).List(c, metav1.ListOptions{
+			LabelSelector: selector,
+		})
+		if lerr == nil {
+			cms = got
+			return true, nil
+		}
+		if isApiserverNotReadyTransient(lerr) {
+			return false, nil
+		}
+		return false, lerr
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list cutover step ConfigMaps in %q: %w", deps.ns, err)
@@ -477,13 +492,130 @@ func stripCutoverStepPrefix(name string) string {
 
 // ── Status ConfigMap ────────────────────────────────────────────────────────
 
+// One-shot read contract (TBD-V55 / #2131)
+// ────────────────────────────────────────
+//
+// Every read in this section talks to the apiserver via the direct typed
+// client (deps.core, built in cutoverDepsFromEnv via
+// `kubernetes.NewForConfig(rest.InClusterConfig())`). These calls
+// deliberately do NOT route through k8scache's in-process informer
+// SharedInformerFactory — that factory is for streaming/list endpoints
+// (SSE, dashboard) where cache-coherency matters more than first-byte
+// latency. One-shot reads here (handful per HTTP request) belong on the
+// direct path so a freshly-booted catalyst-api Pod can answer
+// /cutover/start, /cutover/status, and /cutover/events before the
+// informer factories have finished their initial LIST + WaitForCacheSync.
+//
+// The wrinkle that motivated TBD-V55 (t40, 2026-05-21 06:38Z):
+//   POST /api/v1/sovereign/cutover/start
+//     → HTTP 502 {"error":"status-read-failed",
+//        "detail":"get status ConfigMap catalyst/self-sovereign-cutover-status:
+//                  apiserver not ready"}
+// while at the same instant `kubectl get cm` against the public LB
+// kubeconfig from the bastion succeeded. The apiserver itself was up,
+// but k3s on the Sovereign briefly returned `apiserver not ready` (HTTP
+// 503 with that exact body) to in-cluster discovery + aggregated-API
+// probes while admission webhooks finished warming. Returning 502 on a
+// transient 503 is wrong: by the time the operator's wizard re-fetches
+// 30 s later the apiserver is healthy. So one-shot reads here retry
+// with a short bounded backoff (cutoverApiserverReadyBackoff) on
+// recognised "transient apiserver-not-ready" errors and surface a
+// terminal error only after the budget elapses.
+//
+// Direct client + bounded retry is the target-state per
+// docs/PRINCIPLES.md #14 — no new abstraction, no informer-cache fall-
+// back, no defensive null-guard ladder. Just the small retry the
+// k3s-warm-up window requires.
+
+// cutoverApiserverReadyBackoff is the per-call retry schedule applied
+// to one-shot reads when the apiserver returns a transient
+// `apiserver not ready` (HTTP 503) response. The total budget is
+// ~5 s — long enough to cover the k3s admission-webhook warmup
+// observed on t40 (typically <1 s, occasionally up to 3 s), short
+// enough that a genuinely-broken apiserver still surfaces a clean
+// 502 to the operator's UI within one wizard tick.
+var cutoverApiserverReadyBackoff = wait.Backoff{
+	Steps:    5,
+	Duration: 150 * time.Millisecond,
+	Factor:   2.0,
+	Jitter:   0.1,
+	Cap:      2 * time.Second,
+}
+
+// isApiserverNotReadyTransient reports whether the err is a transient
+// "apiserver not ready" response that should be retried by a one-shot
+// read. It recognises:
+//
+//   - apierrors.IsServiceUnavailable(err) — typed 503 from client-go.
+//   - apierrors.IsTooManyRequests(err)     — typed 429 (admission rate-
+//     limit during warm-up); same backoff is appropriate.
+//   - err.Error() containing "apiserver not ready" — the literal k3s
+//     warmup body that surfaced on t40. Substring match because some
+//     client-go versions wrap the 503 as a generic StatusError with the
+//     body in .Message rather than a typed sentinel.
+//
+// NotFound, Forbidden, Unauthorized, malformed-request etc. are NOT
+// transient and must surface immediately. The retry budget caps how
+// long the handler waits in any case.
+func isApiserverNotReadyTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	if apierrors.IsServiceUnavailable(err) || apierrors.IsTooManyRequests(err) {
+		return true
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "apiserver not ready") {
+		return true
+	}
+	// k3s sometimes returns the warmup error with this prefix when the
+	// aggregated-API layer is still loading SAs; bucket it the same way.
+	if strings.Contains(msg, "the server is currently unable to handle the request") {
+		return true
+	}
+	return false
+}
+
+// getCutoverStatusConfigMap is the direct-client one-shot Get with
+// bounded retry-on-transient-503. Returns the ConfigMap, a typed
+// NotFound (caller treats as benign empty state), or a terminal error
+// after the backoff budget elapses.
+func getCutoverStatusConfigMap(ctx context.Context, deps *cutoverDeps) (*corev1.ConfigMap, error) {
+	name := cutoverStatusConfigMapName()
+	var cm *corev1.ConfigMap
+	err := wait.ExponentialBackoffWithContext(ctx, cutoverApiserverReadyBackoff, func(c context.Context) (bool, error) {
+		got, err := deps.core.CoreV1().ConfigMaps(deps.ns).Get(c, name, metav1.GetOptions{})
+		if err == nil {
+			cm = got
+			return true, nil
+		}
+		if apierrors.IsNotFound(err) {
+			// NotFound is the terminal benign case — return it so the
+			// caller's IsNotFound branch fires without burning the
+			// retry budget.
+			return false, err
+		}
+		if isApiserverNotReadyTransient(err) {
+			// Retry — apiserver still warming up.
+			return false, nil
+		}
+		// Any other error is terminal.
+		return false, err
+	})
+	return cm, err
+}
+
 // readCutoverStatus returns the status ConfigMap or a zero map if it
 // does not exist yet. NotFound is benign: the chart pre-creates it,
 // but a misordered Helm install + first-time POST /start race would
 // otherwise 503.
+//
+// TBD-V55: uses getCutoverStatusConfigMap so a transient
+// `apiserver not ready` during k3s warmup retries within a short
+// budget instead of bubbling up as a 502 to the operator's wizard.
 func readCutoverStatus(ctx context.Context, deps *cutoverDeps) (map[string]string, error) {
 	name := cutoverStatusConfigMapName()
-	cm, err := deps.core.CoreV1().ConfigMaps(deps.ns).Get(ctx, name, metav1.GetOptions{})
+	cm, err := getCutoverStatusConfigMap(ctx, deps)
 	if apierrors.IsNotFound(err) {
 		return map[string]string{}, nil
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_test.go
@@ -36,12 +36,14 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
@@ -1310,3 +1312,105 @@ func TestHandleCutoverStart_IdempotentReusesPriorCompleteJob(t *testing.T) {
 		t.Errorf("step.only-step.result = %q, want success", cm.Data["step.only-step.result"])
 	}
 }
+
+// TestHandleCutoverStatus_WorksDuringCacheWarmup proves the one-shot
+// direct-client read in /cutover/status survives a transient
+// `apiserver not ready` response during k3s warm-up — the failure mode
+// that wedged the t40 walk on 2026-05-21 06:38Z (TBD-V55 / #2131).
+//
+// The fake clientset's reactor returns an `apierrors.NewServiceUnavailable`
+// (HTTP 503) with body "apiserver not ready" on the first N Get calls,
+// then succeeds. The handler must reach inside cutoverApiserverReadyBackoff
+// and return 200 with the pre-seeded ConfigMap data, NOT a 502.
+func TestHandleCutoverStatus_WorksDuringCacheWarmup(t *testing.T) {
+	preStatus := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cutoverStatusConfigMapName(),
+			Namespace: cutoverTestNS,
+		},
+		Data: map[string]string{
+			"cutoverComplete":          "false",
+			"currentStep":              "gitea-mirror",
+			"currentStepIndex":         "0",
+			"totalSteps":               "8",
+			"progressPercent":          "0",
+			"step.gitea-mirror.result": "running",
+		},
+	}
+	h, client := fakeHandlerWithCutover(t, preStatus)
+
+	// Counter for how many times the reactor has fired so far.
+	var calls int32
+	transientFails := int32(2)
+	client.PrependReactor("get", "configmaps", func(action clienttesting.Action) (bool, k8sruntime.Object, error) {
+		ga, ok := action.(clienttesting.GetAction)
+		if !ok || ga.GetName() != cutoverStatusConfigMapName() {
+			return false, nil, nil
+		}
+		n := atomicInc(&calls)
+		if n <= transientFails {
+			// Return the exact failure mode the t40 walk hit: a 503
+			// with body "apiserver not ready". client-go surfaces this
+			// via apierrors.NewServiceUnavailable.
+			return true, nil, apierrors.NewServiceUnavailable("apiserver not ready")
+		}
+		// Fall through to the tracker so it returns the seeded ConfigMap.
+		return false, nil, nil
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereign/cutover/status", nil)
+	h.HandleCutoverStatus(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp cutoverStatusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	if resp.CurrentStep != "gitea-mirror" {
+		t.Errorf("currentStep = %q, want gitea-mirror (handler must have recovered from transient 503)", resp.CurrentStep)
+	}
+	if resp.TotalSteps != 8 {
+		t.Errorf("totalSteps = %d, want 8", resp.TotalSteps)
+	}
+	if got := atomicLoad(&calls); got <= transientFails {
+		t.Errorf("ConfigMap Get calls = %d, want > %d (handler must retry past the transient 503s)", got, transientFails)
+	}
+}
+
+// TestIsApiserverNotReadyTransient_ClassifiesK3sWarmupCorrectly proves the
+// transient-error detector recognises the exact failure modes that
+// trigger TBD-V55 (k3s apiserver returning `apiserver not ready` during
+// warm-up) and does NOT misclassify terminal errors as transient.
+func TestIsApiserverNotReadyTransient_ClassifiesK3sWarmupCorrectly(t *testing.T) {
+	cases := []struct {
+		name      string
+		err       error
+		transient bool
+	}{
+		{"nil-not-transient", nil, false},
+		{"503-service-unavailable", apierrors.NewServiceUnavailable("apiserver not ready"), true},
+		{"503-bare-message", apierrors.NewServiceUnavailable(""), true},
+		{"429-too-many-requests", apierrors.NewTooManyRequests("rate limited", 1), true},
+		{"k3s-warmup-error-literal", fmt.Errorf("apiserver not ready"), true},
+		{"k3s-warmup-error-wrapped", fmt.Errorf("get status ConfigMap: %w", fmt.Errorf("apiserver not ready")), true},
+		{"general-server-unable", fmt.Errorf("the server is currently unable to handle the request"), true},
+		{"notfound-not-transient", apierrors.NewNotFound(corev1.Resource("configmaps"), "x"), false},
+		{"forbidden-not-transient", apierrors.NewForbidden(corev1.Resource("configmaps"), "x", fmt.Errorf("no")), false},
+		{"connection-refused-not-transient", fmt.Errorf("connection refused"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isApiserverNotReadyTransient(tc.err)
+			if got != tc.transient {
+				t.Errorf("isApiserverNotReadyTransient(%v) = %v, want %v", tc.err, got, tc.transient)
+			}
+		})
+	}
+}
+
+// atomicInc / atomicLoad — local thin wrappers so the warmup test
+// reads naturally without sprinkling sync/atomic across the file.
+func atomicInc(p *int32) int32  { return atomic.AddInt32(p, 1) }
+func atomicLoad(p *int32) int32 { return atomic.LoadInt32(p) }

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2258,8 +2258,58 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.234
-appVersion: 1.4.234
+version: 1.4.235
+appVersion: 1.4.235
+# 1.4.235 — TBD-V55 / #2131 (2026-05-21): catalyst-api one-shot
+# ConfigMap reads in the bp-self-sovereign-cutover handlers now retry
+# with bounded backoff on transient `apiserver not ready` (HTTP 503)
+# responses from k3s during admission-webhook warm-up. Pre-fix on t40
+# (2026-05-21 06:38Z): POST /api/v1/sovereign/cutover/start returned
+# HTTP 502 with detail `get status ConfigMap catalyst/self-sovereign-
+# cutover-status: apiserver not ready` while bastion-via-public-LB
+# `kubectl get cm` succeeded — apiserver was up externally but
+# briefly returned 503 to in-cluster discovery + aggregated-API probes
+# during cold-start. The 502 surfaced as a Pillar 1+5 blocker (the
+# wizard's `Start cutover` CTA failed every retry until the operator
+# manually re-clicked ~30 s later, breaking the canonical
+# fresh-prov walk).
+#
+# Fix shape (Inviolable Principle #14, target-state-only): keep the
+# existing direct typed client `deps.core.CoreV1().ConfigMaps().Get`
+# — that is already NOT an informer-cache read; it is the standard
+# client-go REST path built from `rest.InClusterConfig()` —  and wrap
+# the one-shot Get + label-List in `wait.ExponentialBackoffWithContext`
+# with a ~5 s total budget (5 steps × 150 ms × 2.0 factor, cap 2 s).
+# `isApiserverNotReadyTransient` classifies HTTP 503, HTTP 429, the
+# literal `apiserver not ready` body and `the server is currently
+# unable to handle the request` as transient. NotFound, Forbidden,
+# Unauthorized, connection-refused fall through immediately. No new
+# abstraction, no informer-cache fall-back, no defensive null-guard.
+#
+# Surface area: `readCutoverStatus` (used by HandleCutoverStart /
+# HandleCutoverStatus / HandleCutoverEvents) + `listCutoverSteps`
+# (used by HandleCutoverStart) are now both resilient to the warmup
+# window. Tests: `TestHandleCutoverStatus_WorksDuringCacheWarmup`
+# (reactor injects 2× transient 503 then succeeds; handler must
+# return 200 with the seeded ConfigMap data, NOT 502) and
+# `TestIsApiserverNotReadyTransient_ClassifiesK3sWarmupCorrectly`
+# (10-case truth-table — 503 / 429 / literal-warmup-string variants
+# are transient; NotFound / Forbidden / connection-refused are not).
+# All 27 pre-existing `-run Cutover` tests still pass (`ok` from
+# `go test ./internal/handler/ -run Cutover -count=1`).
+#
+# Pure Go-side fix in
+# `products/catalyst/bootstrap/api/internal/handler/cutover.go` —
+# no chart template change. Chart version bump (1.4.234 → 1.4.235)
+# is the canonical signal that the bootstrap-kit pin needs to move;
+# clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+# `version:` field bumps in lockstep.
+#
+# Refs #2131. Closes the Pillar 5 + Pillar 1 cutover-blocker family
+# observed on t40; the next fresh prov verifies the fix when
+# `POST /cutover/start` returns 200 within the warmup window without
+# the operator manually retrying.
+#
 # 1.4.234 — TBD-V56 / #2132 (2026-05-21): fix bp-self-sovereign-cutover
 # state-machine to checkpoint Job-status into the durable ConfigMap on
 # every reconcile tick — survives catalyst-api Pod restarts mid-cutover.


### PR DESCRIPTION
## Summary

- TBD-V55 / Refs #2131: catalyst-api one-shot ConfigMap reads in the
  bp-self-sovereign-cutover handlers (`readCutoverStatus`,
  `listCutoverSteps`) now retry with bounded backoff on transient
  `apiserver not ready` (HTTP 503) responses from k3s during
  admission-webhook warm-up.
- Pure Go-side fix in
  `products/catalyst/bootstrap/api/internal/handler/cutover.go` +
  `cutover_test.go`; no chart template change. Chart bumps
  `1.4.234 → 1.4.235` in lockstep with the bootstrap-kit slot pin.
- Unblocks Pillar 5 (cutover-trigger CTA) and Pillar 1
  (voucher → onboarding chain) on the fresh-prov walk.

## t40 evidence (2026-05-21 06:38Z)

```
HTTP 502
{"detail":"get status ConfigMap catalyst/self-sovereign-cutover-status:
            apiserver not ready","error":"status-read-failed"}
```

At the same instant, bastion-via-public-LB `kubectl get cm
self-sovereign-cutover-status -n catalyst` returned the 54-key
ConfigMap. The apiserver was up externally but briefly returned
503 to in-cluster discovery + aggregated-API probes during
cold-start, while admission webhooks were still warming.

## Fix shape (Inviolable Principle #14, target-state-only)

Keep the existing direct typed client
`deps.core.CoreV1().ConfigMaps().Get` — that is already NOT an
informer-cache read; it is the standard client-go REST path built
from `rest.InClusterConfig()`. Wrap the one-shot Get + label-List
in `wait.ExponentialBackoffWithContext` with a ~5 s total budget
(5 steps × 150 ms × 2.0 factor, cap 2 s).

`isApiserverNotReadyTransient` classifies as transient:
- HTTP 503 (`apierrors.IsServiceUnavailable`)
- HTTP 429 (`apierrors.IsTooManyRequests`)
- err.Error() containing `apiserver not ready` (the literal k3s
  warmup body)
- err.Error() containing `the server is currently unable to handle
  the request`

NotFound / Forbidden / Unauthorized / connection-refused fall
through immediately. No new abstraction, no informer-cache fall-
back, no defensive null-guard.

## Per-file changes

- **`products/catalyst/bootstrap/api/internal/handler/cutover.go`**
  - Add `cutoverApiserverReadyBackoff` const + `isApiserverNotReadyTransient`
    helper + `getCutoverStatusConfigMap` wrapper.
  - `readCutoverStatus` calls `getCutoverStatusConfigMap`.
  - `listCutoverSteps` wraps its List in
    `wait.ExponentialBackoffWithContext` with the same transient classifier.
  - Top-of-section doc-comment block explicit about the
    direct-client + bounded-retry contract.

- **`products/catalyst/bootstrap/api/internal/handler/cutover_test.go`**
  - `TestHandleCutoverStatus_WorksDuringCacheWarmup` — reactor
    injects 2× transient 503 then succeeds; handler returns 200
    with seeded data, NOT 502.
  - `TestIsApiserverNotReadyTransient_ClassifiesK3sWarmupCorrectly`
    — 10-case truth-table.

- **`products/catalyst/chart/Chart.yaml`**
  - `version: 1.4.234 → 1.4.235` + `appVersion` lockstep.
  - Full changelog block explaining the fix.

- **`clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`**
  - `version: 1.4.234 → 1.4.235` (bootstrap-kit pin lockstep).

## Test plan

- [x] `cd products/catalyst/bootstrap/api && go test ./internal/handler/ -run Cutover -count=1` — all 28 tests PASS (27 pre-existing + new warmup test).
- [x] `go test ./internal/handler/ -run IsApiserverNotReadyTransient -count=1 -v` — all 10 truth-table cases PASS.
- [x] `go build ./...` — clean.
- [x] `go vet ./internal/handler/` — clean.
- [x] `helm template test-cutover products/catalyst/chart --set global.sovereignFQDN=t41.omani.works` — renders 4348 lines clean.
- [ ] **Operator walk on fresh prov (t41)**: `POST /api/v1/sovereign/cutover/start` returns 200 within the warmup window without operator manually retrying. The founder verifies + closes Refs #2131 after the walk evidence lands as a comment on the issue. Per CLAUDE.md anti-theater rule 1 — `Refs #N` is the default in PR bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)