### PR TITLE
fix(catalyst-api): remove event SharedInformer (Refs #2125, root-cause of #2123)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.236
+      version: 1.4.237
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go
@@ -1048,7 +1048,7 @@ spec:
     #
     # Per Inviolable Principle #4 (never hardcode) the endpoint + key are
     # operator-supplied via the Kubernetes Secret
-    # `newapi-channel-qwen-partner` carrying keys API_KEY (upstream API
+    # ` + "`newapi-channel-qwen-partner`" + ` carrying keys API_KEY (upstream API
     # bearer) and BASE_URL (upstream OpenAI-compatible endpoint URL),
     # plus per-Sovereign ExternalSecret + attestation values that the
     # operator overlays at tenant-create time. See docs/RUNBOOKS.md
@@ -1065,7 +1065,7 @@ spec:
         # Endpoint defaults empty — operator overlay supplies the
         # upstream URL at tenant-create time (or via ExternalSecret
         # mirror of newapi-channel-qwen-partner key BASE_URL). The
-        # chart's `assertChannelAttestation` gate refuses to render the
+        # chart's ` + "`assertChannelAttestation`" + ` gate refuses to render the
         # channel until the operator overlay populates this value.
         endpoint: ""
         models:

--- a/products/catalyst/bootstrap/api/internal/k8scache/factory.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/factory.go
@@ -243,23 +243,23 @@ type Factory struct {
 
 type clusterState struct {
 	id string
-	// factory — default dynamicinformer factory; watches every Kind
-	// with no LIST bound. Suitable for low/medium-cardinality kinds
-	// (Pod, Service, Deployment, vCluster, Crossplane managed-resources)
-	// where the per-cluster object count is bounded.
+	// factory — the dynamicinformer factory for this cluster. Watches
+	// every registered Kind with no per-Kind LIST bound.
+	//
+	// TBD-V50 (#2125): the separate `boundedFactory` previously created
+	// here for HighCardinality kinds (event) was removed because the
+	// containment-only approach left the in-process WATCH store growing
+	// unbounded — every received event was retained for the lifetime of
+	// the Pod, so even with a 5000-row initial-LIST cap the watch keeps
+	// accumulating and the Pod still OOM-cycled. The fix is upstream
+	// (remove event from DefaultKinds entirely; consumers hit the
+	// apiserver directly with Limit + FieldSelector) — see kinds.go.
+	// Every Kind still in DefaultKinds has a naturally-bounded population
+	// (Pods/Nodes/Services/Deployments/etc.) so a single unbounded factory
+	// is correct again.
 	factory dynamicinformer.DynamicSharedInformerFactory
-	// boundedFactory — used ONLY for Kinds flagged HighCardinality=true
-	// in the registry (today: event). The filtered factory applies a
-	// `tweakListOptions` that sets `Limit: 5000` on the initial LIST so
-	// the in-process cache cannot exceed ~50 MB heap per cluster for
-	// these kinds. WATCH then streams new events on top of that
-	// bounded baseline, also bounded by the K8s server-side event TTL
-	// (~1h). Prevents the catalyst-api OOM-cycle on multi-region
-	// Sovereigns caused by ~55K events × N regions × ~30KB Go-struct
-	// overhead (~5GB heap vs 4GB Pod limit).
-	boundedFactory dynamicinformer.DynamicSharedInformerFactory
-	dyn            dynamic.Interface
-	core           kubernetes.Interface
+	dyn     dynamic.Interface
+	core    kubernetes.Interface
 	informers     map[string]cache.SharedIndexInformer // keyed by Kind.Name
 	indexers      map[string]cache.Indexer             // keyed by Kind.Name
 	synced        map[string]bool                      // keyed by Kind.Name
@@ -525,25 +525,20 @@ func (f *Factory) AddCluster(c ClusterRef) error {
 		}
 	}
 
-	// tweakListOptions applied to HighCardinality kinds (event).
-	// Limit=5000 caps the initial LIST at ~50 MB heap regardless of
-	// how many events accumulate on the apiserver between catalyst-api
-	// restarts. The WATCH that follows is naturally bounded by the
-	// apiserver's event TTL (~1h default).
-	boundedTweak := func(opts *metav1.ListOptions) {
-		opts.Limit = 5000
-	}
+	// TBD-V50 (#2125): the separate filtered factory for HighCardinality
+	// kinds was removed — see clusterState godoc above and kinds.go for
+	// the architectural rationale. Every Kind in DefaultKinds now has a
+	// naturally-bounded population, so one unbounded factory is correct.
 	cs := &clusterState{
-		id:             c.ID,
-		dyn:            dyn,
-		core:           core,
-		factory:        dynamicinformer.NewDynamicSharedInformerFactory(dyn, f.cfg.Resync),
-		boundedFactory: dynamicinformer.NewFilteredDynamicSharedInformerFactory(dyn, f.cfg.Resync, metav1.NamespaceAll, boundedTweak),
-		informers:      map[string]cache.SharedIndexInformer{},
-		indexers:       map[string]cache.Indexer{},
-		synced:         map[string]bool{},
-		lastEventAt:    map[string]time.Time{},
-		stop:           make(chan struct{}),
+		id:          c.ID,
+		dyn:         dyn,
+		core:        core,
+		factory:     dynamicinformer.NewDynamicSharedInformerFactory(dyn, f.cfg.Resync),
+		informers:   map[string]cache.SharedIndexInformer{},
+		indexers:    map[string]cache.Indexer{},
+		synced:      map[string]bool{},
+		lastEventAt: map[string]time.Time{},
+		stop:        make(chan struct{}),
 	}
 
 	// Spawn one informer per registered kind. AddCluster MUST stay
@@ -563,14 +558,13 @@ func (f *Factory) AddCluster(c ClusterRef) error {
 	// path — so the contabo mothership boot blocked while iterating
 	// dead clusters. Removed.
 	for _, k := range f.registry.All() {
-		// HighCardinality kinds (event) route through boundedFactory
-		// so the in-process cache cannot OOM the catalyst-api Pod.
-		// All other kinds use the default unbounded factory.
-		informerFactory := cs.factory
-		if k.HighCardinality {
-			informerFactory = cs.boundedFactory
-		}
-		inf := informerFactory.ForResource(k.GVR).Informer()
+		// TBD-V50 (#2125): no more per-Kind routing — every Kind uses the
+		// single unbounded factory because every Kind in DefaultKinds has
+		// a naturally-bounded population. Events (the only kind that ever
+		// grew unbounded) are no longer registered at all; consumers
+		// query the apiserver directly. See kinds.go for the architectural
+		// rationale.
+		inf := cs.factory.ForResource(k.GVR).Informer()
 		k := k // capture per-iteration
 		_, err := inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj any) {
@@ -696,7 +690,6 @@ func (f *Factory) Start(ctx context.Context) error {
 		// fan-out goroutine below: when f.stop closes (Factory.Stop),
 		// every per-cluster stop channel closes too.
 		cs.factory.Start(cs.stop)
-		cs.boundedFactory.Start(cs.stop)
 		cs := cs
 		go func() {
 			select {

--- a/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
@@ -272,6 +272,63 @@ func TestRegistry_AllAndNames(t *testing.T) {
 	}
 }
 
+// TestDefaultKinds_NoEventInformerRegistered guards TBD-V50 (#2125):
+// Kubernetes Events MUST NOT be registered in DefaultKinds because the
+// SharedInformer abstraction stores every received event for the
+// lifetime of the Pod — an unbounded write-store on a write-once stream.
+// PR #2124 (V49) attempted a 5000-row LIST bound (containment only) but
+// the watch that followed kept accumulating new events, so the
+// catalyst-api Pod still OOM-cycled (178 restarts in 20h on mothership
+// image d9e678f, exit 137 OOMKilled — see TBD-V50 evidence).
+//
+// Architecturally-correct fix: events are read directly from the
+// apiserver with FieldSelector + Limit by the two existing consumers
+// (handler/compliance_runtime.go listFalcoK8sEvents,
+// handler/sovereign.go HandleSovereignJobs). New consumers MUST follow
+// the same pattern — no cache, no informer.
+//
+// A regression that re-registers `event` here will cause an immediate
+// recurrence of the OOM-cycle on any multi-region Sovereign, so this
+// test pins the invariant.
+func TestDefaultKinds_NoEventInformerRegistered(t *testing.T) {
+	for _, k := range DefaultKinds {
+		// Forbidden short name.
+		if k.Name == "event" {
+			t.Fatalf("TBD-V50 (#2125): DefaultKinds must not register %q — "+
+				"events are unbounded; consumers must hit apiserver "+
+				"directly via EventsV1().Events().List(FieldSelector, Limit). "+
+				"See kinds.go for the architectural rationale.", k.Name)
+		}
+		// Forbidden GVR (catches a `Name: "ev"` or similar bypass).
+		if k.GVR.Group == "events.k8s.io" && k.GVR.Resource == "events" {
+			t.Fatalf("TBD-V50 (#2125): DefaultKinds must not register the "+
+				"events.k8s.io/v1 Events GVR (registered as kind %q). "+
+				"See kinds.go for the architectural rationale.", k.Name)
+		}
+		// Forbidden legacy core/v1 Events GVR (apiserver still serves it).
+		if k.GVR.Group == "" && k.GVR.Resource == "events" {
+			t.Fatalf("TBD-V50 (#2125): DefaultKinds must not register the "+
+				"core/v1 Events GVR (registered as kind %q). "+
+				"See kinds.go for the architectural rationale.", k.Name)
+		}
+	}
+}
+
+// TestRegistry_DropsEventAlias is a companion to
+// TestDefaultKinds_NoEventInformerRegistered: the kubectl short-form
+// `ev` alias was removed in the same commit because the underlying
+// `event` Kind is no longer registered. Re-introducing the alias
+// would be a misleading dead-link (Get("ev") would return Kind{} +
+// false, but the alias presence implies it should resolve).
+func TestRegistry_DropsEventAlias(t *testing.T) {
+	if singular, ok := kindShortAliases["ev"]; ok {
+		t.Fatalf("TBD-V50 (#2125): kindShortAliases must not contain %q → %q "+
+			"because the target Kind is no longer registered (events are "+
+			"served via direct apiserver List). Remove the alias to keep "+
+			"the registry truthful.", "ev", singular)
+	}
+}
+
 // ── factory.go ───────────────────────────────────────────────────
 
 // fakeClients constructs a (dynamic, typed) pair seeded with the

--- a/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
@@ -60,20 +60,6 @@ type Kind struct {
 	// Secret. ConfigMap data is treated as PII-adjacent and also
 	// stripped (see redactObject).
 	Sensitive bool
-
-	// HighCardinality — true for kinds whose object count grows
-	// unboundedly on a busy cluster (Kubernetes `event` accumulates
-	// ~tens of thousands per hour). The informer for these kinds is
-	// created from a SEPARATE filtered factory that bounds the initial
-	// LIST with `Limit: 5000`, so the in-process cache cannot blow the
-	// catalyst-api memory budget on a multi-region Sovereign.
-	//
-	// Without this bound, a 3-region Sovereign accumulates ~5GB Go heap
-	// for the event-cache alone (~55K events × 3 regions × ~30KB per
-	// parsed struct), exceeding the 4Gi Pod memory limit → OOMKill
-	// loop → apiserver-not-ready downstream → marketplace/console
-	// 5xx — the symptom that wedged tonight's t39 walk.
-	HighCardinality bool
 }
 
 // DefaultKinds is the built-in registry — every Sovereign starts with
@@ -157,16 +143,26 @@ var DefaultKinds = []Kind{
 	// fanout streams these too. ClusterPolicy is cluster-scoped.
 	{Name: "clusterpolicy", GVR: schema.GroupVersionResource{Group: "kyverno.io", Version: "v1", Resource: "clusterpolicies"}, Namespaced: false},
 
-	// EPIC-4 Slice R4 (#1099) — Events panel feed.
+	// TBD-V50 (#2125) — Kubernetes Events deliberately NOT registered.
 	//
-	// Kubernetes Events live at events.k8s.io/v1 (the modern API; the
-	// legacy core/v1 Events GVR is still served but the new group is
-	// canonical from K8s 1.19+). The Events panel filters Events by
-	// `involvedObject.namespace` + `involvedObject.name` matching the
-	// focused resource — client-side filter happens in the EventsPanel
-	// widget; the server-side stream surface (existing ?fieldSelector=
-	// grammar) supports metadata-level filtering today.
-	{Name: "event", GVR: schema.GroupVersionResource{Group: "events.k8s.io", Version: "v1", Resource: "events"}, Namespaced: true, HighCardinality: true},
+	// Events are a write-once / read-rare resource that the kube-apiserver
+	// already keeps bounded via `--event-ttl=1h` (default). The
+	// SharedInformer abstraction, in contrast, stores every event it
+	// receives for the lifetime of the Pod — an unbounded write-store on
+	// a write-once stream. PR #2124 (V49) attempted to contain the bleed
+	// with a 5000-row initial-LIST cap, but the watch that follows kept
+	// accumulating new events and catalyst-api still OOM-cycled (178
+	// restarts in 20h on the mothership, image d9e678f).
+	//
+	// Architecturally-correct fix: do NOT register `event` as a cached
+	// kind at all. Consumers that need event data already issue direct
+	// apiserver `EventsV1().Events(ns).List(FieldSelector + Limit)` calls
+	// (see handler/compliance_runtime.go listFalcoK8sEvents and
+	// handler/sovereign.go HandleSovereignJobs). New consumers MUST follow
+	// the same pattern — no cache, no informer, no boundedFactory.
+	//
+	// The regression test TestFactory_NoEventInformerRegistered in
+	// k8scache_test.go enforces this invariant.
 
 	// QA-loop iter-2 Fix #17 — CRDs surfaced through /k8s/{kind} need
 	// matching registry entries; otherwise the handler returns
@@ -352,7 +348,9 @@ var kindShortAliases = map[string]string{
 	"rs":     "replicaset",
 	"ing":    "ingress",
 	"ep":     "endpointslice",
-	"ev":     "event",
+	// TBD-V50 (#2125) — `ev` → `event` alias removed because `event` is
+	// no longer cached (see kinds.go above). Consumers that need event
+	// data hit the apiserver directly via EventsV1().Events().List().
 	// QA-loop iter-4 Fix #24 — `kubectl get crd` and `kubectl get crds`
 	// are the conventional ergonomic forms operators reach for. The
 	// plural-alias index handles "customresourcedefinitions" naturally

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,23 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.237 — TBD-V50 / #2125 (2026-05-22) Root-cause OOM-cycle on
+# mothership catalyst-api (178 restarts in 20h, exit 137 OOMKilled,
+# image d9e678f w/ V49 baked in). PR #2124's bounded LIST 5000-page
+# fix was containment only — the WATCH that followed the LIST kept
+# accumulating events for the lifetime of the Pod (every restart
+# replays full LIST + watch resync; memory climbs back; next OOM in
+# ~10 min). Architecturally-correct fix: do NOT register `event` as
+# a cached kind at all. Events are write-once / read-rare; the
+# SharedInformer abstraction (which retains every event for Pod
+# lifetime) is the wrong shape. Consumers that need event data
+# already hit the apiserver directly via EventsV1().Events().List
+# (FieldSelector + Limit) — see handler/compliance_runtime.go
+# listFalcoK8sEvents + handler/sovereign.go HandleSovereignJobs.
+# Removes: event Kind from DefaultKinds, HighCardinality field,
+# boundedFactory machinery, `ev` short alias.
+# Adds: TestDefaultKinds_NoEventInformerRegistered regression test
+# + TestRegistry_DropsEventAlias to pin the invariant.
+#
 # 1.4.233 — TBD-V57 / #2133 (2026-05-21) Pillar 2: ship the
 # marketplace BCP wizard step so the customer can actually signal
 # active-hot-standby + region pair at signup. Single source of truth
@@ -2258,7 +2276,7 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.236
+version: 1.4.237
 appVersion: 1.4.236
 # 1.4.235 — TBD-V55 / #2131 (2026-05-21): catalyst-api one-shot
 # ConfigMap reads in the bp-self-sovereign-cutover handlers now retry


### PR DESCRIPTION
## Summary

PR #2124 (V49) bounded the initial event-LIST with `Limit: 5000`. That was containment only — the watch that follows the LIST kept accumulating new events, so `catalyst-api` still OOM-cycled. **Live mothership evidence as of 2026-05-22**: Pod `catalyst-api-5c9c8d446b-qzm24` on image `d9e678f` (V49 + V55 baked in) — **178 restarts in ~20h uptime, last exit OOMKilled (137)** against 4Gi limit.

This PR removes Kubernetes `event` from the cached kinds entirely. Events are write-once / read-rare; the SharedInformer (which retains every received event for Pod lifetime) is the wrong abstraction. Every other kind in `DefaultKinds` has a naturally-bounded population, so the `boundedFactory` machinery added by #2124 is no longer needed and is removed.

## Anti-pattern avoidance (CLAUDE.md §4 Principle #14)

- NOT a mem-limit bump (containment, not target-state)
- NOT a cache-TTL knob (events should not be cached at all)
- NOT a silent break of consumers — Falco handler + sovereign-jobs handler already hit the apiserver directly via `EventsV1().Events().List(FieldSelector, Limit)`; cutover-driver ClusterRole keeps `events.k8s.io get/list/watch`

## Per-file changes

- `products/catalyst/bootstrap/api/internal/k8scache/kinds.go`
  - drop `event` Kind from `DefaultKinds`
  - drop `HighCardinality bool` field on Kind struct
  - drop `"ev" → "event"` kubectl short alias (target Kind gone)
- `products/catalyst/bootstrap/api/internal/k8scache/factory.go`
  - drop `clusterState.boundedFactory` field + `boundedTweak` builder
  - drop HighCardinality routing in `AddCluster` informer loop
  - drop `cs.boundedFactory.Start(cs.stop)` call in `Start`
- `products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go`
  - **new** `TestDefaultKinds_NoEventInformerRegistered` — fails if any Kind maps to `events.k8s.io/v1` events OR legacy `core/v1` events GVR
  - **new** `TestRegistry_DropsEventAlias` — fails if `"ev"` alias re-introduced
- `products/catalyst/chart/Chart.yaml` — version `1.4.236 → 1.4.237` with TBD-V50 changelog block
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` — lockstep pin `1.4.236 → 1.4.237`

## Consumers (verified, all pre-existing apiserver-direct)

- `handler/compliance_runtime.go::listFalcoK8sEvents` — `dyn.Resource(events).List(FieldSelector="reportingController=falcosidekick", Limit)`
- `handler/sovereign.go::HandleSovereignJobs` — `core.CoreV1().Events("").List(FieldSelector="type=Warning", Limit=100)`
- `handler/k8s.go::flattenK8sListItems("event", …)` — pure data-shaping function for whoever passes events in; called by tests + retained for direct apiserver flows

Frontend: `grep -rn "kind=event|kinds=event|/k8s/event|EventsPanel" core/console/src/` → zero matches.

## Test plan

- [ ] CI: `go test ./products/catalyst/bootstrap/api/internal/k8scache/... -count=1` green — including new `TestDefaultKinds_NoEventInformerRegistered` + `TestRegistry_DropsEventAlias`
- [ ] CI: `go build ./products/catalyst/bootstrap/api/...` clean
- [ ] CI: `check-chart-annotations` + `helm lint products/catalyst/chart` green
- [ ] **Post-merge fresh-prov walk** (operator DoD per CLAUDE.md §0): bootstrap-kit pin `1.4.237` baked, mothership catalyst-api uptime > 24h with zero OOMKilled exits on the same image SHA
- [ ] Falco handler + sovereign-jobs `Events` row still render real Kubernetes Events on the walk Sovereign

## Refs

- Refs #2125 (TBD-V50 — RCA Layer 1: identify residual event-flood triggers)
- Refs #2123 (TBD-V49 — original OOM-cycle thread; this PR is the target-state replacement for the containment-only fix in #2124)
- Refs #2020 (original mothership event-flood symptom thread)

`Refs` (NOT `Closes`) per CLAUDE.md §3.1 — issue closes only after operator walks the fresh prov + screenshots > 24h mothership uptime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)