### PR TITLE
feat(catalyst-api): move Huawei creds to server-side env-var stamp (Wave 4.5, Refs #2140)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.240
+      version: 1.4.241
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -973,6 +973,33 @@ func (h *Handler) CreateDeployment(w http.ResponseWriter, r *http.Request) {
 		req.HarborRobotToken = tok
 	}
 
+	// Stamp Huawei IAM credentials from env vars when the deployment
+	// targets the Huawei provider. SAME pattern as GHCRPullToken /
+	// HarborRobotToken above — operator AK/SK lives in a Kubernetes
+	// Secret (`huawei-operator-creds` in the catalyst ns) projected
+	// into the catalyst-api Pod as CATALYST_HUAWEI_ACCESS_KEY /
+	// _SECRET_KEY / _PROJECT_ID / _REGION env vars. The wizard
+	// payload NEVER carries these — Request.Huawei* fields are
+	// `json:"-"` precisely so credential-exfiltration via wire body
+	// is structurally impossible. Validate() (called below) still
+	// requires them populated when provider=huawei; empty env =
+	// fail-fast 400 with a clear pointer to the missing K8s Secret,
+	// not a 5-minute tofu apply that crashes mid-flight.
+	if req.Provider == "huawei" {
+		if v := os.Getenv("CATALYST_HUAWEI_ACCESS_KEY"); v != "" {
+			req.HuaweiAccessKey = v
+		}
+		if v := os.Getenv("CATALYST_HUAWEI_SECRET_KEY"); v != "" {
+			req.HuaweiSecretKey = v
+		}
+		if v := os.Getenv("CATALYST_HUAWEI_PROJECT_ID"); v != "" {
+			req.HuaweiProjectID = v
+		}
+		if v := os.Getenv("CATALYST_HUAWEI_REGION"); v != "" {
+			req.HuaweiRegion = v
+		}
+	}
+
 	// Mint the deployment ID NOW (before bucket-name derivation) so the
 	// per-Sovereign Object Storage bucket name (issue #371, Fix #111) can
 	// take a deterministic suffix from it. This fixes a real Hetzner

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -250,11 +250,25 @@ type Request struct {
 	// HuaweiRegion is optional — empty defaults to the canonical HCS
 	// region "me-east-215" inside the Huawei provider adapter (see
 	// providers/huawei/provider.go defaultRegion). Operators targeting
-	// public Huawei Cloud override per-deployment.
-	HuaweiAccessKey string `json:"huaweiAccessKey,omitempty"`
-	HuaweiSecretKey string `json:"huaweiSecretKey,omitempty"`
-	HuaweiProjectID string `json:"huaweiProjectID,omitempty"`
-	HuaweiRegion    string `json:"huaweiRegion,omitempty"`
+	// public Huawei Cloud override via env-var.
+	//
+	// SECURITY: `json:"-"` — these credentials are SERVER-SIDE stamped
+	// from env vars at /api/v1/deployments POST time, NEVER accepted
+	// from the wizard payload. Mirrors the canonical pattern used for
+	// every other operator credential (DynadotAPIKey, GHCRPullToken,
+	// HarborRobotToken, PowerDNSAPIKey, PDMBasicAuth*) — operator AK/SK
+	// lives in a Kubernetes Secret on mothership (`huawei-operator-creds`),
+	// projected into the catalyst-api Pod as env vars
+	// CATALYST_HUAWEI_ACCESS_KEY / CATALYST_HUAWEI_SECRET_KEY /
+	// CATALYST_HUAWEI_PROJECT_ID / CATALYST_HUAWEI_REGION. The wire
+	// format cannot inject these — putting them in the request body is
+	// a credential-exfiltration antipattern that the v1 wire schema
+	// (PR #2143, Wave 4) inherited from the early Hetzner shape and
+	// this fix removes.
+	HuaweiAccessKey string `json:"-"`
+	HuaweiSecretKey string `json:"-"`
+	HuaweiProjectID string `json:"-"`
+	HuaweiRegion    string `json:"-"`
 
 	// Legacy singular fields. When Regions is non-empty Validate()
 	// derives these from Regions[0] so writeTfvars()'s single-region

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2293,8 +2293,8 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.240
-appVersion: 1.4.240
+version: 1.4.241
+appVersion: 1.4.241
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -458,6 +458,53 @@ spec:
                 secretKeyRef:
                   name: harbor-robot-token
                   key: token
+            # CATALYST_HUAWEI_ACCESS_KEY / _SECRET_KEY / _PROJECT_ID / _REGION
+            # — Huawei Cloud Stack (HCS) operator IAM credentials used by the
+            # Huawei provider adapter (Wave 3, PR #2142). Server-side-only:
+            # the wizard payload never carries these — Request.Huawei* are
+            # json:"-" — so the only path AK/SK reach catalyst-api is via this
+            # Secret. Mirrors the GHCR/Harbor/Dynadot/PowerDNS/PDM pattern.
+            #
+            # Required Secret shape (operator creates manually on each
+            # mothership during cloud-onboarding, NOT auto-rotated):
+            #   apiVersion: v1
+            #   kind: Secret
+            #   metadata: { name: huawei-operator-creds, namespace: catalyst }
+            #   type: Opaque
+            #   stringData:
+            #     access_key: <Huawei IAM access key>
+            #     secret_key: <Huawei IAM secret key>
+            #     project_id: <region-scoped project ID>
+            #     region:     me-east-215  # canonical HCS region; omit for public Huawei
+            #
+            # optional: true so mothership Sovereigns that never provision Huawei
+            # deployments don't require the Secret at all (Hetzner-only stays
+            # backward-compatible). If the Secret is missing, the Huawei branch
+            # of Validate() fails fast at /api/v1/deployments POST.
+            - name: CATALYST_HUAWEI_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: huawei-operator-creds
+                  key: access_key
+                  optional: true
+            - name: CATALYST_HUAWEI_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: huawei-operator-creds
+                  key: secret_key
+                  optional: true
+            - name: CATALYST_HUAWEI_PROJECT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: huawei-operator-creds
+                  key: project_id
+                  optional: true
+            - name: CATALYST_HUAWEI_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: huawei-operator-creds
+                  key: region
+                  optional: true
             # CATALYST_POWERDNS_API_KEY — contabo PowerDNS API key (PR
             # #681 followup). The value is interpolated into the new
             # Sovereign's `cert-manager/powerdns-api-credentials` Secret


### PR DESCRIPTION
## Summary
Wave 4 (#2143) introduced the Huawei provider integration but inherited an antipattern from the early Hetzner shape — operator AK/SK transmitted through the wizard POST body. Wave 4.5 closes this by moving Huawei creds to server-side env-var stamping, matching the canonical pattern every other operator credential (Dynadot/GHCR/Harbor/PowerDNS/PDM) already uses.

## Wire shape now matches every other operator credential

| Field | Pre-Wave-4.5 | Post-Wave-4.5 |
|---|---|---|
| `Request.HuaweiAccessKey` | `json:"huaweiAccessKey,omitempty"` (wire-accepted) | `json:"-"` (server-side only) |
| `Request.HuaweiSecretKey` | same | same |
| `Request.HuaweiProjectID` | same | same |
| `Request.HuaweiRegion` | same | same |

Stamped at `CreateDeployment` from `CATALYST_HUAWEI_{ACCESS_KEY,SECRET_KEY,PROJECT_ID,REGION}` env vars when `req.Provider == "huawei"`, before `Validate()`. Validation behavior unchanged: empty value still fails fast at 400 with a clear error.

## Operator runbook

Before any Huawei deployment, the operator creates a Kubernetes Secret on mothership:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: huawei-operator-creds
  namespace: catalyst
type: Opaque
stringData:
  access_key: <Huawei IAM access key>
  secret_key: <Huawei IAM secret key>
  project_id: <region-scoped project ID>
  region:     me-east-215
```

Chart projects these 4 keys as env vars into the catalyst-api Pod (`optional: true`, so Hetzner-only mothership Sovereigns stay backward-compatible — no Secret required when provider=huawei isn't used).

## Lockstep
- `Chart.yaml`: 1.4.240 → 1.4.241
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`: pin bump

## Test plan
- [x] Build + vet (CI)
- [x] Provisioner Validate tests (CI) — empty env still produces "huaweiAccessKey is required when provider=huawei"
- [x] Handler tests (CI) — req.Huawei* fields ignored from POST body, populated from env when set
- [x] `helm template` smoke (CI hollow-chart guard) — env block renders with optional secretKeyRef
- [ ] Post-merge: chart 1.4.241 publishes to GHCR; mothership rolls
- [ ] Operator creates `huawei-operator-creds` Secret on mothership
- [ ] Wave 5: provision Huawei Sovereign via wizard with EMPTY huawei fields in body

Refs #2140