### PR TITLE
test(catalyst-api): invert Huawei wire-shape tests to match Wave 4.5 contract (Refs #2140)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.241
+      version: 1.4.242
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/handler/deployments_huawei_dispatch_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments_huawei_dispatch_test.go
@@ -32,42 +32,48 @@ import (
 )
 
 // TestCreateDeployment_Huawei_DispatchesToHuaweiAdapter — happy path:
-// POST body with provider=huawei + complete AK/SK/project_id triplet
-// returns 201, the persisted deployment record carries
-// Provider="huawei", and the auto-derived ObjectStorageBucket uses the
-// Huawei adapter's BucketNameForDeployment (which today shares the
-// same naming contract as the Hetzner adapter — both implement
-// providers.ObjectStorageNamer).
+// POST body with provider=huawei (NO Huawei creds in body) + the four
+// CATALYST_HUAWEI_* env vars set returns 201, the persisted deployment
+// carries Provider="huawei" + Huawei creds stamped from env, and the
+// auto-derived ObjectStorageBucket uses the Huawei adapter's
+// BucketNameForDeployment.
+//
+// History: PR #2143 (Wave 4) v1 of this test passed AK/SK in body.
+// PR #2144 (Wave 4.5) moved Huawei creds to server-side env-var stamp
+// (matching every other operator credential — Dynadot/GHCR/Harbor/
+// PowerDNS/PDM). The body now carries deployment intent only; creds
+// live in the `huawei-operator-creds` Kubernetes Secret on mothership.
 func TestCreateDeployment_Huawei_DispatchesToHuaweiAdapter(t *testing.T) {
 	t.Setenv("DYNADOT_MANAGED_DOMAINS", "omani.works")
 	t.Setenv("CATALYST_HARBOR_ROBOT_TOKEN", "harbor_TEST_PLACEHOLDER")
+	t.Setenv("CATALYST_HUAWEI_ACCESS_KEY", "TESTAK1234567890")
+	t.Setenv("CATALYST_HUAWEI_SECRET_KEY", "TESTSKABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
+	t.Setenv("CATALYST_HUAWEI_PROJECT_ID", "0a1b2c3d4e5f6789abcd")
+	t.Setenv("CATALYST_HUAWEI_REGION", "me-east-215")
 	pdm.ResetManagedDomains()
 
 	fake := &fakePDM{}
 	h := NewWithPDM(slog.Default(), fake)
 
 	body, _ := json.Marshal(map[string]any{
-		"provider":         "huawei",
-		"sovereignFQDN":    "hcs.example.om",
+		"provider":      "huawei",
+		"sovereignFQDN": "hcs.example.om",
 		// BYO domain mode — Huawei deployments today provision against
 		// operator-owned domains; pool-mode is the Hetzner-managed
 		// .omani.works case that doesn't apply to HCS.
 		"sovereignDomainMode": "byo",
 		"sovereignSubdomain":  "hcs",
-		// Huawei credentials — required by Validate() when
-		// provider=huawei (Wave 4 wire-schema additions).
-		"huaweiAccessKey": "TESTAK1234567890",
-		"huaweiSecretKey": "TESTSKABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
-		"huaweiProjectID": "0a1b2c3d4e5f6789abcd",
-		"huaweiRegion":    "me-east-215",
-		"region":          "me-east-215",
-		"orgName":         "Example HCS Customer",
-		"orgEmail":        "ops@example.om",
-		"sshPublicKey":    "ssh-ed25519 AAAA test",
+		// NOTE: NO huaweiAccessKey / huaweiSecretKey / huaweiProjectID /
+		// huaweiRegion in body. These are json:"-" since PR #2144 —
+		// stamped from env vars at CreateDeployment time. The wizard
+		// frontend should not send them either.
+		"region":       "me-east-215",
+		"orgName":      "Example HCS Customer",
+		"orgEmail":     "ops@example.om",
+		"sshPublicKey": "ssh-ed25519 AAAA test",
 		// Object Storage credentials — Huawei OBS uses S3-compatible
-		// AK/SK; the operator supplies the same AK/SK pair as the IAM
-		// triplet today. Wave 5 may split these per the OBS-specific
-		// IAM separation.
+		// AK/SK; today these are still wizard-supplied. Wave 6 may
+		// move them to env-var stamping too.
 		"objectStorageRegion":    "me-east-215",
 		"objectStorageAccessKey": "TESTAK1234567890",
 		"objectStorageSecretKey": "TESTSKABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
@@ -93,14 +99,17 @@ func TestCreateDeployment_Huawei_DispatchesToHuaweiAdapter(t *testing.T) {
 	if dep.Request.Provider != "huawei" {
 		t.Errorf("Request.Provider = %q, want %q", dep.Request.Provider, "huawei")
 	}
-	if dep.Request.HuaweiAccessKey == "" {
-		t.Errorf("Request.HuaweiAccessKey lost during decode/persist")
+	if dep.Request.HuaweiAccessKey != "TESTAK1234567890" {
+		t.Errorf("Request.HuaweiAccessKey = %q, env-var stamp failed", dep.Request.HuaweiAccessKey)
 	}
 	if dep.Request.HuaweiSecretKey == "" {
-		t.Errorf("Request.HuaweiSecretKey lost during decode/persist")
+		t.Errorf("Request.HuaweiSecretKey empty after env-var stamp")
 	}
 	if dep.Request.HuaweiProjectID == "" {
-		t.Errorf("Request.HuaweiProjectID lost during decode/persist")
+		t.Errorf("Request.HuaweiProjectID empty after env-var stamp")
+	}
+	if dep.Request.HuaweiRegion != "me-east-215" {
+		t.Errorf("Request.HuaweiRegion = %q, want me-east-215", dep.Request.HuaweiRegion)
 	}
 
 	// Bucket derivation — Huawei adapter implements
@@ -125,12 +134,20 @@ func TestCreateDeployment_Huawei_DispatchesToHuaweiAdapter(t *testing.T) {
 }
 
 // TestCreateDeployment_Huawei_MissingAccessKey_Rejected — defensive
-// check: a body with provider=huawei but an empty huaweiAccessKey
-// must reject at /api/v1/deployments POST with 400 (not propagate
-// through to runProvisioning and fail several minutes later).
+// check: provider=huawei with NO CATALYST_HUAWEI_ACCESS_KEY env var
+// set (or set but empty) must reject at /api/v1/deployments POST with
+// 400. The wizard payload no longer carries Huawei creds (json:"-"
+// since PR #2144), so the empty-creds case translates to "operator
+// forgot to create the `huawei-operator-creds` K8s Secret" — fail-fast
+// with a clear error rather than crashing 5 min into tofu apply.
 func TestCreateDeployment_Huawei_MissingAccessKey_Rejected(t *testing.T) {
 	t.Setenv("DYNADOT_MANAGED_DOMAINS", "omani.works")
 	t.Setenv("CATALYST_HARBOR_ROBOT_TOKEN", "harbor_TEST_PLACEHOLDER")
+	// CATALYST_HUAWEI_ACCESS_KEY intentionally NOT set; the other 3
+	// are set to ensure the missing-AK is the specific cause of 400.
+	t.Setenv("CATALYST_HUAWEI_SECRET_KEY", "TESTSKABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
+	t.Setenv("CATALYST_HUAWEI_PROJECT_ID", "0a1b2c3d4e5f6789abcd")
+	t.Setenv("CATALYST_HUAWEI_REGION", "me-east-215")
 	pdm.ResetManagedDomains()
 
 	fake := &fakePDM{}
@@ -141,9 +158,6 @@ func TestCreateDeployment_Huawei_MissingAccessKey_Rejected(t *testing.T) {
 		"sovereignFQDN":          "hcs.example.om",
 		"sovereignDomainMode":    "byo",
 		"sovereignSubdomain":     "hcs",
-		"huaweiAccessKey":        "", // intentionally empty
-		"huaweiSecretKey":        "TESTSKABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
-		"huaweiProjectID":        "0a1b2c3d4e5f6789abcd",
 		"region":                 "me-east-215",
 		"orgName":                "Example",
 		"orgEmail":               "ops@example.om",

--- a/products/catalyst/bootstrap/api/internal/provisioner/provider_wire_schema_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provider_wire_schema_test.go
@@ -192,36 +192,52 @@ func TestRequestValidate_Provider_UnknownRejected(t *testing.T) {
 	}
 }
 
-// TestRequest_HuaweiSecretKey_NotSerializedInPersistedRedaction — this
-// test is the inverse of TestRequest_GHCRPullToken_NotSerialized: the
-// Huawei secret key IS serialised in the wire payload (it carries a
-// json:"huaweiSecretKey,omitempty" tag, NOT json:"-") because the
-// wizard's POST body has to ship it. The actual credential hygiene
-// happens at the internal/store.Redact boundary — that's a separate
-// test in internal/store/. Here we just pin the wire shape: a
-// populated HuaweiSecretKey lands in the marshaled JSON under the
-// expected key.
-func TestRequest_HuaweiSecretKey_SerialisedOnWire(t *testing.T) {
-	const sentinel = "TESTSK_WIRE_FORMAT_PROBE_NOT_REAL"
-	r := Request{HuaweiSecretKey: sentinel}
+// TestRequest_HuaweiCreds_NeverOnWire — after PR #2144 (Wave 4.5) the
+// Huawei IAM credentials are server-side-only: stamped from K8s Secret
+// `huawei-operator-creds` via env vars at CreateDeployment, NEVER
+// accepted from the wizard POST body. The four Huawei* fields therefore
+// carry json:"-" tags (matching DynadotAPIKey / GHCRPullToken /
+// HarborRobotToken / PowerDNSAPIKey / PDMBasicAuth* — every other
+// operator credential in the codebase). This test pins the new
+// contract: even when populated, the fields MUST NOT appear in the
+// marshaled JSON.
+//
+// History: the original v1 of this test (PR #2143, Wave 4) asserted
+// the opposite — that huaweiSecretKey IS in the wire. That was the
+// credential-exfiltration antipattern caught + fixed in #2144.
+func TestRequest_HuaweiCreds_NeverOnWire(t *testing.T) {
+	const akSentinel = "TESTAK_WIRE_FORMAT_PROBE_NOT_REAL"
+	const skSentinel = "TESTSK_WIRE_FORMAT_PROBE_NOT_REAL"
+	const pidSentinel = "TESTPID_WIRE_FORMAT_PROBE_NOT_REAL"
+	const regionSentinel = "TESTREGION_WIRE_FORMAT_PROBE_NOT_REAL"
+	r := Request{
+		HuaweiAccessKey: akSentinel,
+		HuaweiSecretKey: skSentinel,
+		HuaweiProjectID: pidSentinel,
+		HuaweiRegion:    regionSentinel,
+	}
 
 	raw, err := jsonMarshal(r)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if !strings.Contains(raw, "huaweiSecretKey") {
-		t.Errorf("Request.HuaweiSecretKey JSON tag missing: %s", raw)
+	for _, key := range []string{"huaweiAccessKey", "huaweiSecretKey", "huaweiProjectID", "huaweiRegion"} {
+		if strings.Contains(raw, key) {
+			t.Errorf("Huawei field %s leaked into wire JSON (must be json:\"-\"); got: %s", key, raw)
+		}
 	}
-	if !strings.Contains(raw, sentinel) {
-		t.Errorf("Request.HuaweiSecretKey value not in marshaled output: %s", raw)
+	for _, sentinel := range []string{akSentinel, skSentinel, pidSentinel, regionSentinel} {
+		if strings.Contains(raw, sentinel) {
+			t.Errorf("Huawei credential sentinel %q leaked into wire JSON: %s", sentinel, raw)
+		}
 	}
 }
 
-// TestRequest_HuaweiFields_OmitEmpty — empty Huawei fields must NOT
-// serialise. Two reasons: (1) the wire payload stays compact for the
-// majority of Hetzner provisions, and (2) the persisted record never
-// carries dangling empty-string credentials that a future audit might
-// mistake for a leaked cred.
+// TestRequest_HuaweiFields_OmitEmpty — defense-in-depth: even with the
+// new json:"-" tags, double-check empty Huawei fields don't appear.
+// (Redundant with the above test once json:"-" is in place; kept as a
+// regression guard if anyone re-introduces json:"huaweiAccessKey,
+// omitempty" by accident.)
 func TestRequest_HuaweiFields_OmitEmpty(t *testing.T) {
 	r := Request{} // all Huawei fields empty
 

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2293,8 +2293,8 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.241
-appVersion: 1.4.241
+version: 1.4.242
+appVersion: 1.4.242
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +


### PR DESCRIPTION
## Summary
PR #2144 (Wave 4.5) moved Huawei IAM creds to server-side env-var stamp (`json:"-"`). The Wave 4 tests asserted the OPPOSITE contract — that `huaweiSecretKey` IS in the wire JSON — which is the credential-exfiltration antipattern Wave 4.5 corrected. CI on #2144 surfaced this as `TestRequest_HuaweiSecretKey_SerialisedOnWire` FAIL.

This PR inverts the test contracts to match the now-correct shape.

## Changes
- `TestRequest_HuaweiSecretKey_SerialisedOnWire` → renamed `TestRequest_HuaweiCreds_NeverOnWire`. Asserts populated Huawei* fields produce NO wire JSON keys/values.
- `TestRequest_HuaweiFields_OmitEmpty` kept (defense-in-depth).
- `TestCreateDeployment_Huawei_DispatchesToHuaweiAdapter` — happy path now drives the 4 fields via `t.Setenv("CATALYST_HUAWEI_*", ...)`, not via body.
- `TestCreateDeployment_Huawei_MissingAccessKey_Rejected` — empty env (not empty body) → 400 with the specific missing-field error.
- `TestCreateDeployment_Huawei_UnknownProviderRejected` — unchanged.

## Lockstep
- `Chart.yaml`: 1.4.241 → 1.4.242
- bootstrap-kit pin bump

Refs #2140