### PR TITLE
fix(catalyst-api): emit Huawei-shaped tfvars keys for first-prov fix (Wave 5.1, Refs #2140)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.242
+      version: 1.4.243
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1681,6 +1681,32 @@ func writeTfvars(deployDir string, req Request) error {
 			region = "me-east-215"
 		}
 		vars["huawei_region"] = region
+
+		// The Huawei OpenTofu module at infra/providers/huawei/variables.tf
+		// declares a different variable schema for the OBS bucket
+		// (`obs_bucket_name`) and the parent-domains payload
+		// (`parent_domains_yaml`, literal YAML inline-array string) than
+		// the Hetzner module. Mirror the canonical Hetzner-shaped values
+		// into the Huawei-shaped keys so the same tfvars file satisfies
+		// both module schemas without per-provider duplication elsewhere.
+		// The Hetzner-shaped keys remain in the tfvars file as harmless
+		// undeclared-variable warnings under provider=huawei (OpenTofu
+		// treats unknown tfvars as warn, not error — confirmed live in
+		// dc19ea76 prov trace, 2026-05-22).
+		vars["obs_bucket_name"] = req.ObjectStorageBucket
+
+		if len(req.ParentDomains) > 0 {
+			var sb strings.Builder
+			sb.WriteString("[")
+			for i, pd := range req.ParentDomains {
+				if i > 0 {
+					sb.WriteString(", ")
+				}
+				fmt.Fprintf(&sb, "{name: %q, role: %q}", pd.Name, pd.Role)
+			}
+			sb.WriteString("]")
+			vars["parent_domains_yaml"] = sb.String()
+		}
 	}
 
 	raw, err := json.MarshalIndent(vars, "", "  ")

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2293,8 +2293,8 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.242
-appVersion: 1.4.242
+version: 1.4.243
+appVersion: 1.4.243
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +


### PR DESCRIPTION
## Summary
First-prov on the Huawei adapter (`dc19ea76 hw01.omani.works`, 2026-05-22T19:29:06Z) failed at `tofu plan`:
```
Error: No value for required variable
on variables.tf line 240:
240: variable "obs_bucket_name" {
```

The Huawei OpenTofu module declares a slightly different variable schema for the bucket name + parent-domains payload. writeTfvars now mirrors the canonical Hetzner-shaped values into the Huawei-shaped keys when `req.Provider=="huawei"`. The Hetzner-shaped keys remain as harmless undeclared-variable warnings (OpenTofu treats unknown tfvars as warn, not error).

## Lockstep
`Chart.yaml`: 1.4.242 → 1.4.243

Refs #2140