### PR TITLE
fix(catalyst-api): derive Huawei region role from index — vet fix (Wave 5.3, Refs #2140)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.244
+      version: 1.4.245
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1716,11 +1716,22 @@ func writeTfvars(deployDir string, req Request) error {
 		// controlPlaneSize, workerSize, workerCount, role). Project the
 		// wire shape to the Huawei tofu shape so the same Request feeds
 		// both modules.
+		// Role derived from index per the canonical multi-region contract:
+		// index 0 = primary, index > 0 = secondary. RegionSpec itself does
+		// NOT carry a Role field — the wire JSON's `role` key is silently
+		// dropped during decode (see struct at line 159). The Hetzner module
+		// uses the same index-based convention via its main.tf for_each;
+		// here we just materialise the role string for the Huawei module's
+		// validator (variables.tf:32 contains(["primary","secondary"], r.role)).
 		hwRegions := make([]map[string]any, 0, len(req.Regions))
-		for _, r := range req.Regions {
+		for i, r := range req.Regions {
+			role := "secondary"
+			if i == 0 {
+				role = "primary"
+			}
 			hwRegions = append(hwRegions, map[string]any{
 				"code":               r.CloudRegion,
-				"role":               r.Role,
+				"role":               role,
 				"control_plane_size": r.ControlPlaneSize,
 				"worker_size":        r.WorkerSize,
 				"worker_count":       r.WorkerCount,

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2293,8 +2293,8 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.244
-appVersion: 1.4.244
+version: 1.4.245
+appVersion: 1.4.245
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +


### PR DESCRIPTION
PR #2148 referenced r.Role on RegionSpec which has no Role field. Derive from index (0=primary, >0=secondary). Chart 1.4.244→1.4.245.