### PR TITLE
fix(huawei-module): HCS endpoint coverage + disable tag-API (Wave 5.4, Refs #2140)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.245
+      version: 1.4.246
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -87,9 +87,9 @@ resource "huaweicloud_vpc" "region" {
 
   name = "${local.name_prefix}-${each.key}-vpc"
   cidr = local.region_vpc_cidr[each.key]
-  tags = merge(local.common_tags, {
-    "catalyst.openova.io/region" = each.key
-  })
+  # tags = merge(local.common_tags, {
+  # "catalyst.openova.io/region" = each.key
+  # })  # disabled Wave 5.4: HCS tag API divergence
 }
 
 resource "huaweicloud_vpc_subnet" "region" {
@@ -100,9 +100,9 @@ resource "huaweicloud_vpc_subnet" "region" {
   gateway_ip        = cidrhost(local.region_subnet_cidr[each.key], 1)
   vpc_id            = huaweicloud_vpc.region[each.key].id
   availability_zone = var.huawei_az
-  tags = merge(local.common_tags, {
-    "catalyst.openova.io/region" = each.key
-  })
+  # tags = merge(local.common_tags, {
+  # "catalyst.openova.io/region" = each.key
+  # })  # disabled Wave 5.4: HCS tag API divergence
 }
 
 # ── Security group per region ─────────────────────────────────────────────
@@ -271,10 +271,10 @@ resource "huaweicloud_vpc_eip" "cp" {
     share_type  = "PER"
     charge_mode = "traffic"
   }
-  tags = merge(local.common_tags, {
-    "catalyst.openova.io/region" = local.cp_nodes[count.index].region
-    "catalyst.openova.io/role"   = "control-plane"
-  })
+  # tags = merge(local.common_tags, {
+  # "catalyst.openova.io/region" = local.cp_nodes[count.index].region
+  #     "catalyst.openova.io/role"   = "control-plane"
+  # })  # disabled Wave 5.4: HCS tag API divergence
 }
 
 # ── Cloud-init render (control-plane + worker) ────────────────────────────
@@ -356,10 +356,13 @@ resource "huaweicloud_compute_instance" "control_plane" {
 
   key_pair = huaweicloud_kps_keypair.main.name
 
-  tags = merge(local.common_tags, {
-    "catalyst.openova.io/region" = local.cp_nodes[count.index].region
-    "catalyst.openova.io/role"   = "control-plane"
-  })
+  # tags = merge(local.common_tags, {
+
+  # "catalyst.openova.io/region" = local.cp_nodes[count.index].region
+
+  #     "catalyst.openova.io/role"   = "control-plane"
+
+  # })  # disabled Wave 5.4: HCS tag API divergence
 }
 
 # ── Worker ECS instances ──────────────────────────────────────────────────
@@ -384,10 +387,13 @@ resource "huaweicloud_compute_instance" "worker" {
 
   key_pair = huaweicloud_kps_keypair.main.name
 
-  tags = merge(local.common_tags, {
-    "catalyst.openova.io/region" = each.value.region
-    "catalyst.openova.io/role"   = "worker"
-  })
+  # tags = merge(local.common_tags, {
+
+  # "catalyst.openova.io/region" = each.value.region
+
+  #     "catalyst.openova.io/role"   = "worker"
+
+  # })  # disabled Wave 5.4: HCS tag API divergence
 }
 
 # ── SSH key (KPS keypair) ─────────────────────────────────────────────────
@@ -411,5 +417,5 @@ resource "huaweicloud_kps_keypair" "main" {
 resource "aws_s3_bucket" "main" {
   bucket = var.obs_bucket_name
 
-  tags = local.common_tags
+  # tags = local.common_tags  # disabled Wave 5.4: HCS tag API divergence
 }

--- a/infra/providers/huawei/versions.tf
+++ b/infra/providers/huawei/versions.tf
@@ -62,6 +62,15 @@ provider "huaweicloud" {
     obs = "https://obs.${var.huawei_region}.kom4dc.nationalcloud.om"
     elb = "https://elb.${var.huawei_region}.kom4dc.nationalcloud.om"
     tms = "https://tms.${var.huawei_region}.kom4dc.nationalcloud.om"
+
+    # KMS / KPS (Key Pair Service) — needed for huaweicloud_kps_keypair
+    # which registers the operator-supplied SSH key for ECS attachment.
+    # Without this override the provider falls back to
+    # kms.<region>.myhuaweicloud.com (public Huawei Cloud) which the
+    # on-prem HCS deployment can't reach. Caught live on 8f711cae
+    # 2026-05-22T19:52Z: `dial tcp: lookup kms.me-east-215.
+    # myhuaweicloud.com: no such host`.
+    kms = "https://kms.${var.huawei_region}.kom4dc.nationalcloud.om"
   }
 
   insecure = var.huawei_insecure

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2293,8 +2293,8 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.245
-appVersion: 1.4.245
+version: 1.4.246
+appVersion: 1.4.246
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +


### PR DESCRIPTION
Add kms endpoint to provider endpoints block. Disable tags assignments (HCS tag-API divergence; cosmetic, deferred to Wave 6). Chart 1.4.245→1.4.246.