### PR TITLE
fix(huawei-module): real image UUID default + native OBS bucket resource (Wave 5.5, Refs #2140)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.246
+      version: 1.4.247
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -414,8 +414,20 @@ resource "huaweicloud_kps_keypair" "main" {
 # pattern Wave 4 plans to extract. Keeping the aws-provider path keeps
 # the bucket purge code one shape across providers.
 
-resource "aws_s3_bucket" "main" {
+# OBS bucket via the native `huaweicloud_obs_bucket` resource.
+#
+# Wave 5.5 (Refs #2140) — switched from `aws_s3_bucket` because the aws
+# provider's auto-refresh always issues GetBucketEncryption against the
+# bucket, and HCS OBS does not expose that API (returns 404
+# NoSuchEncryptionConfiguration on deployment 0bbf240540c9351b
+# 2026-05-22T20:08Z). The Huawei-native resource doesn't call any
+# SSE-config side-read, so the bucket creates cleanly. Cross-cloud
+# bucket-purge symmetry stays intact — the Go-side purge talks vanilla
+# S3 protocol against the same OBS endpoint regardless of which
+# Terraform resource minted the bucket.
+resource "huaweicloud_obs_bucket" "main" {
   bucket = var.obs_bucket_name
+  acl    = "private"
 
-  # tags = local.common_tags  # disabled Wave 5.4: HCS tag API divergence
+  # tags disabled per Wave 5.4 — HCS tag-API divergence
 }

--- a/infra/providers/huawei/outputs.tf
+++ b/infra/providers/huawei/outputs.tf
@@ -55,14 +55,14 @@ output "obs_region" {
 
 output "obs_bucket" {
   description = "Per-Sovereign OBS bucket name."
-  value       = aws_s3_bucket.main.bucket
+  value       = huaweicloud_obs_bucket.main.bucket
 }
 
 # PROVIDER-INTERFACE.md §2 — canonical s3_buckets list (drives the wipe
 # handler's per-deployment bucket purge).
 output "s3_buckets" {
   description = "Names of object-storage buckets the module created. Drives wipe-handler bucket purge."
-  value       = [aws_s3_bucket.main.bucket]
+  value       = [huaweicloud_obs_bucket.main.bucket]
 }
 
 # ── Per-region structured outputs ────────────────────────────────────────
@@ -116,6 +116,6 @@ output "s3_bucket_per_region" {
   description = "OBS bucket name per region. Tier-B uses ONE bucket for the Sovereign; emitted as a map for cross-provider uniformity."
   value = {
     for r in var.regions :
-    r.code => aws_s3_bucket.main.bucket
+    r.code => huaweicloud_obs_bucket.main.bucket
   }
 }

--- a/infra/providers/huawei/variables.tf
+++ b/infra/providers/huawei/variables.tf
@@ -133,17 +133,21 @@ variable "huawei_insecure" {
 variable "image_id" {
   type        = string
   description = <<-EOT
-    Huawei IMS image ID. Default `ec509d3b-...` is the operator-confirmed
-    Ubuntu 22.04 server 64bit (40 GB) image in HCS region me-east-215.
-    Operators on public Huawei Cloud override via wizard input.
+    Huawei IMS image ID. Default is the operator-confirmed live
+    `Ubuntu 22.04 server 64bit (40 GB)` image at HCS me-east-215
+    (queried via IMS API 2026-05-22T20:08Z, gold imagetype). Public
+    Huawei Cloud or rotated HCS images override via wizard input.
 
-    The 32-char placeholder default below is the OPERATOR-CONFIRMED
-    "Ubuntu 22.04 server 64bit, 40GB" id at the HCS endpoint; the
     catalyst-api writes the resolved value into tofu.auto.tfvars.json
     at provision time so a stale baked-in default never blocks a fresh
-    image rotation.
+    image rotation. The default below is the live ID — NOT a placeholder.
+
+    Wave 5.5 (Refs #2140): the prior placeholder
+    `ec509d3b-0000-0000-0000-000000000000` triggered ECS create failure
+    `Ecs.0304 No image found with ID ec509d3b-0000-0000-0000-000000000000`
+    on deployment 0bbf240540c9351b. Real UUID baked here.
   EOT
-  default     = "ec509d3b-0000-0000-0000-000000000000"
+  default     = "ec509d3b-e2c5-40b8-987b-ce9623d67a88"
 }
 
 variable "default_control_plane_flavor" {

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2293,8 +2293,8 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.246
-appVersion: 1.4.246
+version: 1.4.247
+appVersion: 1.4.247
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +


### PR DESCRIPTION
Wave 5.5: replace placeholder image_id default with live UUID + switch aws_s3_bucket → huaweicloud_obs_bucket (HCS OBS doesn't expose GetBucketEncryption). Chart 1.4.246→1.4.247.