### PR TITLE
fix(huawei-module): comprehensive HCS endpoint audit + single-pass fixes (Wave 5.7, Refs #2140)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.248
+      version: 1.4.249
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -87,9 +87,13 @@ resource "huaweicloud_vpc" "region" {
 
   name = "${local.name_prefix}-${each.key}-vpc"
   cidr = local.region_vpc_cidr[each.key]
-  # tags = merge(local.common_tags, {
-  # "catalyst.openova.io/region" = each.key
-  # })  # disabled Wave 5.4: HCS tag API divergence
+  # tags disabled Wave 5.4 (HCS tag API divergence).
+
+  # HCS VPC read-back occasionally surfaces a synthesised `tags = []`
+  # even when none were sent; ignore to keep plan clean.
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "huaweicloud_vpc_subnet" "region" {
@@ -100,9 +104,14 @@ resource "huaweicloud_vpc_subnet" "region" {
   gateway_ip        = cidrhost(local.region_subnet_cidr[each.key], 1)
   vpc_id            = huaweicloud_vpc.region[each.key].id
   availability_zone = var.huawei_az
-  # tags = merge(local.common_tags, {
-  # "catalyst.openova.io/region" = each.key
-  # })  # disabled Wave 5.4: HCS tag API divergence
+  # tags disabled Wave 5.4 (HCS tag API divergence).
+
+  # HCS subnet read-back surfaces `dns_list`, `dhcp_lease_time`,
+  # `primary_dns`, `secondary_dns`, `tags` synthesised from the VPC
+  # default — ignore so subsequent plans don't churn.
+  lifecycle {
+    ignore_changes = [tags, dns_list, primary_dns, secondary_dns, dhcp_lease_time]
+  }
 }
 
 # ── Security group per region ─────────────────────────────────────────────
@@ -229,9 +238,20 @@ locals {
   # Flatten per-region CP indexes into a single ordered list so the
   # count-based EIP + ECS resources stay in lockstep. Each entry maps
   # to one CP node across all regions.
+  #
+  # Wave 5.7 (Refs #2140): per-region CP count now comes from
+  # `huawei_control_plane_count` (default 1 for HCS me-east-215). The
+  # historical fixed-3 layout (Hetzner-style HA per region) consumed
+  # 3 EIPs × N regions = 6 EIPs for a 2-region Tier-B Sovereign, which
+  # exhausted the HCS publicIp quota (10) and left no headroom for
+  # the mothership + a second Sovereign on the same HCS tenancy.
+  # Live evidence 2026-05-22T20:35Z: `error allocating EIP: The request
+  # could not be processed due to conflict in the request` was the
+  # provider's translation of the publicIp quota=10 used=10 error
+  # (verified via `eip:ListQuotas`).
   cp_nodes = flatten([
     for r in var.regions : [
-      for i in range(3) : {
+      for i in range(var.huawei_control_plane_count) : {
         region = r.code
         index  = i
         flavor = local.effective_cp_flavor[r.code]
@@ -239,10 +259,12 @@ locals {
     ]
   ])
 
-  # Same shape for workers — 2 per region per Tier-B sizing.
+  # Per-region worker count comes from `regions[].worker_count` (the
+  # cross-provider PROVIDER-INTERFACE.md §1 shape — set by the wizard
+  # / Go provisioner). Default 2 if zero (POC sizing).
   worker_nodes = flatten([
     for r in var.regions : [
-      for i in range(2) : {
+      for i in range(r.worker_count > 0 ? r.worker_count : 2) : {
         region = r.code
         index  = i
         flavor = local.effective_worker_flavor[r.code]
@@ -257,24 +279,40 @@ locals {
     for w in local.worker_nodes :
     "${w.region}-${w.index}" => w
   }
+
+  # Wave 5.7: one EIP per region, attached to that region's primary CP
+  # (index 0). Reduces the per-Sovereign EIP footprint from N_regions ×
+  # N_cps to N_regions (2 for the canonical 2-region Tier-B), fitting
+  # inside the HCS publicIp quota=10 with mothership headroom. The
+  # primary CP IS the WireGuard DMZ endpoint for its region (DOD A2 —
+  # inter-region traffic flows over public EIPs), and ClusterMesh
+  # apiserver peers dial the OTHER region's primary CP EIP. Failure of
+  # a primary CP demotes its region (k3s replica CPs continue serving
+  # the region from private IPs; cluster-internal load-balancing via
+  # Cilium); cross-region HA is preserved at the region granularity
+  # which IS the DR contract.
+  cp_eip_regions = [for r in var.regions : r.code]
 }
 
 resource "huaweicloud_vpc_eip" "cp" {
-  count = length(local.cp_nodes)
+  for_each = toset(local.cp_eip_regions)
 
   publicip {
     type = "5_bgp"
   }
   bandwidth {
-    name        = "${local.name_prefix}-${local.cp_nodes[count.index].region}-cp${local.cp_nodes[count.index].index + 1}-bw"
+    name        = "${local.name_prefix}-${each.key}-cp1-bw"
     size        = 100
     share_type  = "PER"
     charge_mode = "traffic"
   }
-  # tags = merge(local.common_tags, {
-  # "catalyst.openova.io/region" = local.cp_nodes[count.index].region
-  #     "catalyst.openova.io/role"   = "control-plane"
-  # })  # disabled Wave 5.4: HCS tag API divergence
+  # tags disabled Wave 5.4 (HCS tag-API divergence; restored once HCS TMS endpoint contract stabilises).
+
+  # HCS EIP read-back occasionally surfaces a `tags` field even when
+  # none were sent on create — pin to ignore to prevent perpetual diff.
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 # ── Cloud-init render (control-plane + worker) ────────────────────────────
@@ -347,10 +385,13 @@ resource "huaweicloud_compute_instance" "control_plane" {
     uuid = huaweicloud_vpc_subnet.region[local.cp_nodes[count.index].region].id
   }
 
-  # Attach the per-node EIP. The provider supports `eip_id` on the
-  # instance resource for direct binding without a separate
-  # `huaweicloud_compute_eip_associate`.
-  eip_id = huaweicloud_vpc_eip.cp[count.index].id
+  # Wave 5.7 (Refs #2140): only the index-0 (primary) CP of each region
+  # gets an EIP; replica CPs (index > 0 — only when
+  # huawei_control_plane_count > 1) run with private IPs only and
+  # peer ClusterMesh via the primary CP's EIP. HCS publicIp quota=10
+  # vs Hetzner-style 1-per-CP design = irreconcilable for any tenancy
+  # carrying mothership + ≥1 Sovereign.
+  eip_id = local.cp_nodes[count.index].index == 0 ? huaweicloud_vpc_eip.cp[local.cp_nodes[count.index].region].id : null
 
   user_data = local.control_plane_cloud_init
 
@@ -365,13 +406,11 @@ resource "huaweicloud_compute_instance" "control_plane" {
   system_disk_type = "SSD"
   system_disk_size = 40
 
-  # tags = merge(local.common_tags, {
-
-  # "catalyst.openova.io/region" = local.cp_nodes[count.index].region
-
-  #     "catalyst.openova.io/role"   = "control-plane"
-
-  # })  # disabled Wave 5.4: HCS tag API divergence
+  # HCS ECS read-back occasionally returns synthesised values for tags
+  # + metadata.os_type + system_disk_id; ignore so plan stays clean.
+  lifecycle {
+    ignore_changes = [tags, metadata]
+  }
 }
 
 # ── Worker ECS instances ──────────────────────────────────────────────────
@@ -400,13 +439,10 @@ resource "huaweicloud_compute_instance" "worker" {
   system_disk_type = "SSD"
   system_disk_size = 40
 
-  # tags = merge(local.common_tags, {
-
-  # "catalyst.openova.io/region" = each.value.region
-
-  #     "catalyst.openova.io/role"   = "worker"
-
-  # })  # disabled Wave 5.4: HCS tag API divergence
+  # HCS read-back divergence — see CP block lifecycle comment.
+  lifecycle {
+    ignore_changes = [tags, metadata]
+  }
 }
 
 # ── SSH key (KPS keypair) ─────────────────────────────────────────────────

--- a/infra/providers/huawei/outputs.tf
+++ b/infra/providers/huawei/outputs.tf
@@ -4,13 +4,13 @@
 # Go-side provisioner.readOutputs() is provider-agnostic.
 
 output "control_plane_ip" {
-  description = "Public EIP of the primary-region's first control-plane node. On Huawei the EIP IS the entry point (no cloud LB in Tier-B)."
-  value       = length(huaweicloud_vpc_eip.cp) > 0 ? huaweicloud_vpc_eip.cp[0].address : ""
+  description = "Public EIP of the primary-region's primary CP node. On Huawei the EIP IS the entry point (no cloud LB in Tier-B). Wave 5.7: keyed by region code."
+  value       = length(var.regions) > 0 ? huaweicloud_vpc_eip.cp[var.regions[0].code].address : ""
 }
 
 output "load_balancer_ip" {
   description = "On Huawei Tier-B we deliberately have NO cloud load-balancer; the primary CP's EIP IS the Gateway entry. Echoed as control_plane_ip so cross-provider handler code reads one field uniformly."
-  value       = length(huaweicloud_vpc_eip.cp) > 0 ? huaweicloud_vpc_eip.cp[0].address : ""
+  value       = length(var.regions) > 0 ? huaweicloud_vpc_eip.cp[var.regions[0].code].address : ""
 }
 
 output "sovereign_fqdn" {
@@ -85,10 +85,10 @@ output "region_secondaries" {
 }
 
 output "control_plane_ips_per_region" {
-  description = "Public EIPs of each region's first control-plane node, keyed by region code."
+  description = "Public EIPs of each region's primary CP node, keyed by region code. Wave 5.7: 1 EIP per region (was 1-per-CP)."
   value = {
-    for idx, r in var.regions :
-    r.code => length(huaweicloud_vpc_eip.cp) > idx ? huaweicloud_vpc_eip.cp[idx].address : ""
+    for r in var.regions :
+    r.code => huaweicloud_vpc_eip.cp[r.code].address
   }
 }
 
@@ -107,8 +107,8 @@ output "worker_ips_per_region" {
 output "clustermesh_endpoint_per_region" {
   description = "Public clustermesh-apiserver endpoint per region (CP EIP + NodePort). Cilium ClusterMesh peers dial these over DMZ-WG/mTLS."
   value = {
-    for idx, r in var.regions :
-    r.code => length(huaweicloud_vpc_eip.cp) > idx ? "${huaweicloud_vpc_eip.cp[idx].address}:32379" : ""
+    for r in var.regions :
+    r.code => "${huaweicloud_vpc_eip.cp[r.code].address}:32379"
   }
 }
 

--- a/infra/providers/huawei/tests/multi_region.tftest.hcl
+++ b/infra/providers/huawei/tests/multi_region.tftest.hcl
@@ -25,8 +25,7 @@ mock_provider "huaweicloud" {
   }
   mock_resource "huaweicloud_networking_secgroup" {
     defaults = {
-      id   = "sg-mock-1"
-      name = "sg-mock"
+      id = "sg-mock-1"
     }
   }
   mock_resource "huaweicloud_networking_secgroup_rule" {
@@ -45,13 +44,9 @@ mock_provider "huaweicloud" {
       id = "kp-mock-1"
     }
   }
-}
-
-mock_provider "aws" {
-  mock_resource "aws_s3_bucket" {
+  mock_resource "huaweicloud_obs_bucket" {
     defaults = {
-      id     = "catalyst-test-bucket"
-      bucket = "catalyst-test-bucket"
+      id = "catalyst-test-bucket"
     }
   }
 }
@@ -69,8 +64,12 @@ variables {
   parent_domains_yaml = ""
 }
 
-# Scenario 1 — Tier-B canonical two-region shape (primary + secondary).
-run "tier_b_two_regions" {
+# Scenario 1 — Tier-B canonical two-region shape (primary + secondary)
+# at the Wave 5.7 POC default (huawei_control_plane_count=1).
+# Verifies the new HCS-quota-fit footprint: 2 VPCs + 2 subnets + 2 SGs
+# + 2 EIPs (one per region — was 6 in the historical fixed-3 CP design)
+# + 2 CP ECS + 4 worker ECS + 1 OBS bucket.
+run "tier_b_two_regions_poc" {
   command = plan
 
   variables {
@@ -110,27 +109,31 @@ run "tier_b_two_regions" {
     error_message = "Tier-B must create one security group per region (expected 2)."
   }
 
-  # 6 EIPs (3 CP per region × 2 regions)
+  # Wave 5.7: 2 EIPs (one per region) — was 6 (3 CP × 2 regions) in the
+  # historical Hetzner-style fixed-3 design. The new per-region EIP keys
+  # by region code (`cp["me-east-215-a"]`) rather than CP index.
   assert {
-    condition     = length(huaweicloud_vpc_eip.cp) == 6
-    error_message = "Tier-B must create one EIP per CP node (expected 6 = 3 CP × 2 regions)."
+    condition     = length(huaweicloud_vpc_eip.cp) == 2
+    error_message = "Wave 5.7 default (1 CP/region) must create 1 EIP per region (expected 2 for 2-region Tier-B)."
   }
 
-  # 6 control-plane ECS (3 per region × 2 regions)
+  # Wave 5.7: 2 CP ECS (1 per region with huawei_control_plane_count=1).
   assert {
-    condition     = length(huaweicloud_compute_instance.control_plane) == 6
-    error_message = "Tier-B must create 3 CP ECS per region (expected 6 total)."
+    condition     = length(huaweicloud_compute_instance.control_plane) == 2
+    error_message = "Wave 5.7 POC default (huawei_control_plane_count=1) must create 1 CP ECS per region (expected 2 total)."
   }
 
-  # 4 worker ECS (2 per region × 2 regions)
+  # 4 worker ECS (regions[].worker_count=2 × 2 regions).
   assert {
     condition     = length(huaweicloud_compute_instance.worker) == 4
-    error_message = "Tier-B must create 2 worker ECS per region (expected 4 total)."
+    error_message = "Tier-B with worker_count=2 must create 2 worker ECS per region (expected 4 total)."
   }
 
-  # 1 OBS bucket per Sovereign
+  # 1 OBS bucket per Sovereign — Wave 5.5 switched from aws_s3_bucket
+  # to native huaweicloud_obs_bucket (HCS OBS does not expose
+  # GetBucketEncryption that the aws provider always probes).
   assert {
-    condition     = aws_s3_bucket.main.bucket == "catalyst-t99-omani-works-deadbeef"
+    condition     = huaweicloud_obs_bucket.main.bucket == "catalyst-t99-omani-works-deadbeef"
     error_message = "OBS bucket name must match the operator-supplied obs_bucket_name."
   }
 }
@@ -156,16 +159,50 @@ run "single_region" {
     condition     = length(huaweicloud_vpc.region) == 1
     error_message = "Single-region must create exactly 1 VPC."
   }
+  # Wave 5.7: 1 EIP per region.
   assert {
-    condition     = length(huaweicloud_vpc_eip.cp) == 3
-    error_message = "Single-region must create 3 CP EIPs."
+    condition     = length(huaweicloud_vpc_eip.cp) == 1
+    error_message = "Single-region (Wave 5.7) must create 1 CP EIP."
   }
+  # Wave 5.7: 1 CP per region (was 3).
   assert {
-    condition     = length(huaweicloud_compute_instance.control_plane) == 3
-    error_message = "Single-region must create 3 CP ECS."
+    condition     = length(huaweicloud_compute_instance.control_plane) == 1
+    error_message = "Single-region (Wave 5.7) must create 1 CP ECS (huawei_control_plane_count=1)."
   }
   assert {
     condition     = length(huaweicloud_compute_instance.worker) == 2
     error_message = "Single-region must create 2 worker ECS."
+  }
+}
+
+# Scenario 3 — HA topology (huawei_control_plane_count=3) for tenancies
+# with adequate EIP headroom (public Huawei Cloud or HCS POD enterprise
+# tier). Verifies replica CPs (index > 0) do NOT consume EIPs.
+run "ha_three_cp_per_region" {
+  command = plan
+
+  variables {
+    huawei_control_plane_count = 3
+    regions = [
+      {
+        code               = "me-east-215-a"
+        role               = "primary"
+        control_plane_size = "s7n.large.4"
+        worker_size        = "m7n.xlarge.8"
+        worker_count       = 2
+      }
+    ]
+  }
+
+  # 3 CP ECS (count=3).
+  assert {
+    condition     = length(huaweicloud_compute_instance.control_plane) == 3
+    error_message = "HA topology must create 3 CP ECS per region."
+  }
+  # Wave 5.7: still 1 EIP per region — replica CPs (index 1, 2) carry
+  # only private IPs. ClusterMesh peers dial the primary CP's EIP.
+  assert {
+    condition     = length(huaweicloud_vpc_eip.cp) == 1
+    error_message = "Wave 5.7: even in HA (count=3) only the primary CP per region gets an EIP."
   }
 }

--- a/infra/providers/huawei/variables.tf
+++ b/infra/providers/huawei/variables.tf
@@ -162,6 +162,26 @@ variable "default_worker_flavor" {
   default     = "m7n.xlarge.8"
 }
 
+variable "huawei_control_plane_count" {
+  type        = number
+  description = <<-EOT
+    Number of control-plane ECS instances per region. Wave 5.7 (Refs #2140)
+    default is 1, sized for the HCS me-east-215 publicIp quota (10) — the
+    earlier Hetzner-style fixed-3 design consumed 6 EIPs for a 2-region
+    Tier-B Sovereign and left no headroom for mothership + a second
+    Sovereign on the same tenancy (`eip:ListQuotas` confirmed
+    quota=10 used=10 on the first Wave 5 apply attempts 2026-05-22T20:35Z).
+
+    Set to 3 for HA control plane on a tenancy with sufficient EIP
+    headroom (public Huawei Cloud or HCS POD enterprise tier).
+  EOT
+  default     = 1
+  validation {
+    condition     = var.huawei_control_plane_count == 1 || var.huawei_control_plane_count == 3
+    error_message = "huawei_control_plane_count must be 1 (POC) or 3 (HA)."
+  }
+}
+
 # ── SSH ──────────────────────────────────────────────────────────────────
 
 variable "ssh_public_key" {

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,50 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.249 — Wave 5.7 / #2140 (2026-05-23) comprehensive HCS audit +
+# single-pass fixes for the Huawei OpenTofu module. After 6 incremental
+# 1-line fix PRs (#2146 #2148 #2149 #2150 #2152 #2153 — each surfacing
+# ONE divergence at a time on `tofu apply` against
+# https://*.me-east-215.kom4dc.nationalcloud.om), this wave runs a
+# comprehensive local-harness audit + ships the architecturally-correct
+# end-state in one PR:
+#
+# 1. Per-region CP count is now a variable
+#    (`huawei_control_plane_count`, default 1), not hardcoded 3.
+#    Live evidence: HCS me-east-215 `eip:ListQuotas` returns
+#    publicIp quota=10 used=10 after a 2-region Tier-B prov; the old
+#    Hetzner-style 6-EIPs-per-Sovereign design left no headroom for
+#    mothership + a second Sovereign on the same tenancy.
+# 2. One EIP per region (was 1-per-CP) — attached to that region's
+#    primary CP (index 0). Replica CPs (when count=3) carry only
+#    private IPs; ClusterMesh peers dial the primary CP's EIP. DOD
+#    A2 inter-region-over-public-IPs contract preserved.
+# 3. `regions[].worker_count` is now honoured (was ignored — module
+#    hardcoded 2). Cross-provider PROVIDER-INTERFACE.md §1 shape.
+# 4. `lifecycle.ignore_changes` blocks on `huaweicloud_vpc`,
+#    `huaweicloud_vpc_subnet`, and `huaweicloud_compute_instance` for
+#    HCS read-back fields the provider synthesises post-create (tags,
+#    dns_list, dhcp_lease_time, primary_dns, secondary_dns, metadata).
+#    Without these, a second `tofu plan` after a successful apply
+#    shows a perpetual diff.
+# 5. `huaweicloud_vpc_eip.cp` switched from `count = N` to
+#    `for_each = toset(local.cp_eip_regions)` — the resource address
+#    is now keyed by region code (`cp["me-east-215-a"]`) rather than
+#    by composite CP-list index, matching the per-region cardinality.
+#    Outputs (control_plane_ip, control_plane_ips_per_region,
+#    clustermesh_endpoint_per_region) updated to the new key shape.
+#
+# Local-harness validation: `tofu apply -parallelism=1` against the
+# real HCS endpoint, single-region (audit.omani.works on me-east-215),
+# created 15 resources cleanly (1 VPC + 1 subnet + 1 SG + 6 SG rules
+# + 1 EIP + 1 CP ECS + 2 worker ECS + 1 KPS keypair + 1 OBS bucket).
+# Idempotency confirmed: second `tofu plan` says "No changes."
+#
+# Multi-region apply blocked by physical HCS tenancy quota (VPC
+# quota=5 used=5 once mothership-hw01's 2 VPCs + bastion + default
+# are in place + the audit prov adds 1). The right fix for the
+# 2-region walk is a quota raise OR mothership cleanup — outside
+# the scope of this module bump.
+#
 # 1.4.240 — Wave 4 / #2140 (2026-05-23) wire-schema additions to
 # provisioner.Request so a POST /api/v1/sovereign/deployments body
 # can carry the Huawei AK/SK + project_id alongside the existing
@@ -2293,8 +2338,8 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.248
-appVersion: 1.4.248
+version: 1.4.249
+appVersion: 1.4.249
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +


### PR DESCRIPTION
## Summary

After 6 incremental 1-line fix PRs (#2146 #2148 #2149 #2150 #2152 #2153 — each surfacing **one** divergence at a time against `https://*.me-east-215.kom4dc.nationalcloud.om`), this wave runs a comprehensive **local-harness audit** on a bastion-side OpenTofu workdir and ships the architecturally-correct end-state in a single PR.

## What broke + why

Every `tofu apply` past the first run failed with the cryptic provider error `error allocating EIP: The request could not be processed due to conflict in the request`. Direct API query (`eip:ListQuotas`, `vpc:ListVpcs`) revealed it's not a parallelism / API-conflict at all — it's **quota arithmetic**:

| Resource | HCS quota | Used (pre-audit) | Old design / Sovereign | Fit? |
|---|---|---|---|---|
| `publicIp` | 10 | 6 (mothership-hw01) + 1 (bastion EIP) | 6 EIPs (3 CPs × 2 regions) | NO — `13 > 10` |
| `vpc` | 5 | 2 (mothership-hw01) + 2 (bastion+default) | 2 VPCs | NO — `6 > 5` (after audit prov of 1 more) |

The historical Hetzner-style fixed-3-CP-per-region design assumed unbounded per-CP EIPs — physically incompatible with HCS quotas.

## Architecturally-correct fix

1. **Per-region CP count is a variable**, default 1 for HCS POC fit (was hardcoded 3). New `huawei_control_plane_count` accepts 1 or 3.
2. **One EIP per region**, attached to the region's primary CP (index 0). `huaweicloud_vpc_eip.cp` switched from `count = length(cp_nodes)` to `for_each = toset(cp_eip_regions)` — resource now keyed by region code. Replica CPs (when count=3) carry private IPs only; ClusterMesh peers dial the OTHER region's primary CP EIP. DOD A2 inter-region-over-public-IPs preserved.
3. **`regions[].worker_count` honoured** (was ignored — module hardcoded `range(2)`). Cross-provider `PROVIDER-INTERFACE.md` §1 shape now actually drives the module.
4. **`lifecycle.ignore_changes` blocks** for HCS read-back synthesised fields the create call doesn't send (`tags`, `dns_list`, `dhcp_lease_time`, `primary_dns`, `secondary_dns`, `metadata`). Without these blocks a second `tofu plan` post-apply shows a perpetual diff.
5. **Outputs rewritten** to the new per-region EIP key shape (`control_plane_ip`, `load_balancer_ip`, `control_plane_ips_per_region`, `clustermesh_endpoint_per_region`).
6. **Tests updated** — drops the stale `aws_s3_bucket` mock (Wave 5.5 switched to native `huaweicloud_obs_bucket`); 3 scenarios verify the new footprint:
   - `tier_b_two_regions_poc` (default count=1: 2 EIPs + 2 CPs + 4 workers)
   - `single_region` (1 EIP + 1 CP + 2 workers)
   - `ha_three_cp_per_region` (count=3: still 1 EIP/region — replica CPs no EIP)

## Live-harness verification

Local `tofu apply -parallelism=1` against the real HCS endpoint, single-region audit prov:

```
Apply complete! Resources: 15 added, 0 changed, 0 destroyed.
Outputs:
  control_plane_ip = "212.72.24.30"
  obs_bucket = "audit-bucket-1779484296"
  obs_endpoint = "https://obs.me-east-215.kom4dc.nationalcloud.om"
  worker_ips_per_region = { "me-east-215-a" = ["10.20.1.235", "10.20.1.90"] }
```

Idempotency: subsequent `tofu plan` returns `No changes. Your infrastructure matches the configuration.`

`tofu test`:
```
tests/multi_region.tftest.hcl... pass
  run "tier_b_two_regions_poc"... pass
  run "single_region"... pass
  run "ha_three_cp_per_region"... pass

Success! 3 passed, 0 failed.
```

Multi-region live walk is blocked by the VPC quota=5/5 exhaustion on the current tenancy (mothership-hw01 holds 2; can't create 2 more without quota raise OR mothership cleanup — outside the scope of this module bump). The architectural fix is verified end-to-end via the single-region path.

## Lockstep

- `products/catalyst/chart/Chart.yaml`: 1.4.248 → 1.4.249 (with full prepended changelog).
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`: chart pin 1.4.248 → 1.4.249.

## What's NOT in this PR (follow-up TBDs)

- **Multi-region live walk** — requires VPC quota raise OR mothership-hw01 cleanup (founder-only decision; READ-ONLY on mothership per task contract).
- **TMS tagging restoration** — Wave 5.4 disabled all tags due to HCS TMS endpoint divergence. Once HCS exposes a stable TMS contract, re-enable as a `huaweicloud_tms_resource_tag` post-create resource.

## Test plan

- [ ] CI runs `tofu test` against `infra/providers/huawei/` and reports pass
- [ ] CI publishes `bp-catalyst-platform:1.4.249` chart artifact
- [ ] Mothership Flux reconciles to the new chart (`kubectl -n catalyst-system get hr/catalyst-platform`)
- [ ] After mothership rolls: founder triggers `POST /sovereign/api/v1/deployments` with `provider=huawei` and confirms `tofu apply` completes against the HCS endpoint without the "conflict in request" errors (single-region prov; multi-region blocked on quota)

Refs #2140

🤖 Generated with [Claude Code](https://claude.com/claude-code)