### PR TITLE
fix(huawei-module): bake primary CP EIP into kubeconfig + tls-san (Wave 5.8, Refs #2140)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.249
+      version: 1.4.250
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -233,6 +233,7 @@ runcmd:
         --cluster-cidr=${cluster_cidr} \
         --service-cidr=${service_cidr} \
         --tls-san=${sovereign_fqdn} \
+        --tls-san=${primary_cp_eip} \
         --node-label=openova.io/region=hw-${region}-rtz-prod \
         --node-label=catalyst.openova.io/provider=huawei" \
       sh -
@@ -256,13 +257,21 @@ runcmd:
   - KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f /var/lib/catalyst/manifests/10-flux-source.yaml
 
   # 5. PUT-back kubeconfig to catalyst-api (issue #183 Option D).
+  #
+  # The apiserver URL inside the PUT'd kubeconfig MUST be the primary
+  # CP's EIP so the mothership (cross-cloud Contabo) can reach it on
+  # 6443. We get the EIP from the OpenTofu module via the template
+  # variable `primary_cp_eip` (Wave 5.8) — tofu knows the EIP
+  # deterministically at render time (the huaweicloud_vpc_eip.cp
+  # resource is created before the ECS instance). Previously the
+  # template tried to fetch the EIP from the HCS OpenStack metadata
+  # service (`169.254.169.254/openstack/latest/meta_data.json`
+  # `.public_ipv4_address`), but HCS doesn't populate that field, and
+  # the `ip route get 8.8.8.8` fallback returned the PRIVATE subnet IP
+  # (10.30.1.70 on 4bb37cbbb1e23ba8 2026-05-22T21:42Z).
   - |
     if [ -n "${deployment_id}" ] && [ -n "${kubeconfig_bearer_token}" ]; then
-      EIP=$(curl -s http://169.254.169.254/openstack/latest/meta_data.json | jq -r '.public_ipv4_address // .access_ip // empty')
-      if [ -z "$EIP" ]; then
-        EIP=$(ip -4 -j route get 8.8.8.8 2>/dev/null | jq -r '.[0].prefsrc // empty')
-      fi
-      sed "s|server: https://127.0.0.1:6443|server: https://$EIP:6443|" /etc/rancher/k3s/k3s.yaml \
+      sed "s|server: https://127.0.0.1:6443|server: https://${primary_cp_eip}:6443|" /etc/rancher/k3s/k3s.yaml \
         > /tmp/kubeconfig-rewritten.yaml
       curl -sf -X PUT \
         -H "Authorization: Bearer ${kubeconfig_bearer_token}" \

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -345,6 +345,23 @@ locals {
     k3s_version         = var.k3s_version
     k3s_token           = sha256("${var.huawei_project_id}/${var.sovereign_fqdn}/k3s-bootstrap")
     cp_private_ip       = cidrhost(local.region_subnet_cidr[local.region_keys[0]], 2)
+    # Primary CP's EIP — Wave 5.8 (Refs #2140). The kubeconfig PUT-back
+    # from cloud-init must use this EIP, not the private VPC IP, so the
+    # remote mothership (cross-cloud Contabo) can reach the new
+    # Sovereign's apiserver on 6443. The previous template fetched the
+    # EIP from the HCS OpenStack metadata service
+    # (169.254.169.254/openstack/latest/meta_data.json
+    # `.public_ipv4_address`), but HCS doesn't populate that field;
+    # the fallback heuristic (`ip route get 8.8.8.8`) returned the
+    # private subnet IP, baking it into the PUT'd kubeconfig.
+    # Catalyst-api's Phase-1 watch then tried `https://10.30.1.70:6443`
+    # from the mothership Pod (Contabo) and timed out: caught live on
+    # 4bb37cbbb1e23ba8 2026-05-22T21:42Z. By passing the EIP at template
+    # render time (tofu knows it; it just created the EIP), the
+    # template-rendered `sed` substitution uses the right address
+    # deterministically across all CPs and metadata-service shape
+    # divergences across cloud stacks.
+    primary_cp_eip = huaweicloud_vpc_eip.cp[local.region_keys[0]].publicip.0.ip_address
     cluster_cidr        = "10.42.0.0/16"
     service_cidr        = "10.96.0.0/16"
     gitops_repo_url     = var.gitops_repo_url

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2338,8 +2338,8 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.249
-appVersion: 1.4.249
+version: 1.4.250
+appVersion: 1.4.250
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +


### PR DESCRIPTION
Phase 0 succeeded on 8th attempt; Phase-1 stuck because kubeconfig PUT'd with private subnet IP (HCS metadata service doesn't expose .public_ipv4_address). Pass primary_cp_eip from tofu into the cloud-init template — deterministic + no metadata-service dependency. Chart 1.4.249→1.4.250.