### PR TITLE
fix(huawei-module): gate PUT-back by hostname not IP (Wave 5.10, Refs #2140)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.251
+      version: 1.4.252
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -278,17 +278,20 @@ runcmd:
   # — and the resulting kubeconfig's client cert is signed by a CA the
   # primary region's apiserver doesn't trust (HTTP 401 on every reach
   # from catalyst-api Phase-1 watch — caught live on a7decee7f4b171ea
-  # 2026-05-22T22:14Z). Gate via private-IP match: only the host whose
-  # primary interface IP equals `cp_private_ip` (= the primary region's
-  # CP1 .2 address, known at tofu render time) does the PUT-back. The
-  # PUT URL targets the primary region's EIP per Wave 5.8.
+  # 2026-05-22T22:14Z). Gate via HOSTNAME match (Wave 5.10) — only the
+  # host whose hostname equals `primary_cp_hostname` (=
+  # `catalyst-<fqdn-slug>-<primary-region>-cp1`, deterministic via the
+  # ECS `name` attribute) executes the PUT-back. Wave 5.9's prior gate
+  # used cp_private_ip but HCS DHCP doesn't assign deterministic .2
+  # addresses (saw worker IPs .230/.50 on 747841cadcf90f7e); no CP
+  # matched, no PUT-back fired, Phase-1 timed out.
   #
-  # Multi-region kubeconfig federation (catalyst-api dashboard fan-out
-  # per region) is a Wave 6+ follow-up — see Hetzner's PUT-back which
-  # uses a per-region URL suffix (#1579 chroot endpoint pattern).
+  # The PUT URL targets the primary region's EIP per Wave 5.8.
+  # Multi-region kubeconfig federation (per-region PUT-back for
+  # catalyst-api dashboard fan-out) is Wave 6+.
   - |
-    LOCAL_IP=$(ip -4 -j route get 8.8.8.8 2>/dev/null | jq -r '.[0].prefsrc // empty')
-    if [ -n "${deployment_id}" ] && [ -n "${kubeconfig_bearer_token}" ] && [ "$LOCAL_IP" = "${cp_private_ip}" ]; then
+    HOSTNAME=$(hostname)
+    if [ -n "${deployment_id}" ] && [ -n "${kubeconfig_bearer_token}" ] && [ "$HOSTNAME" = "${primary_cp_hostname}" ]; then
       sed "s|server: https://127.0.0.1:6443|server: https://${primary_cp_eip}:6443|" /etc/rancher/k3s/k3s.yaml \
         > /tmp/kubeconfig-rewritten.yaml
       curl -sf -X PUT \

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -362,6 +362,14 @@ locals {
     # deterministically across all CPs and metadata-service shape
     # divergences across cloud stacks.
     primary_cp_eip = huaweicloud_vpc_eip.cp[local.region_keys[0]].publicip.0.ip_address
+    # Primary CP's hostname — used by cloud-init to gate the kubeconfig
+    # PUT-back to ONLY the primary region's CP1 (Wave 5.10, Refs #2140).
+    # Wave 5.9 attempted private-IP match (cp_private_ip = subnet .2)
+    # but HCS DHCP doesn't assign .2 deterministically (workers got
+    # .230 + .50 on 747841cadcf90f7e 2026-05-22T22:53Z); no CP's local
+    # IP matched, no PUT-back happened, Phase-1 timed out. Hostname is
+    # deterministic since the ECS resource sets it via `name`.
+    primary_cp_hostname = "${local.name_prefix}-${local.region_keys[0]}-cp1"
     cluster_cidr        = "10.42.0.0/16"
     service_cidr        = "10.96.0.0/16"
     gitops_repo_url     = var.gitops_repo_url

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2338,8 +2338,8 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.251
-appVersion: 1.4.251
+version: 1.4.252
+appVersion: 1.4.252
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +


### PR DESCRIPTION
HCS DHCP doesn't assign deterministic IPs; gate primary-CP PUT-back via hostname match. Chart 1.4.251→1.4.252.