### PR TITLE
fix(huawei-module): enable Flannel default to unblock CNI bootstrap (Wave 5.11, Refs #2140)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.252
+      version: 1.4.253
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -218,16 +218,28 @@ runcmd:
   - systemctl enable --now fail2ban
 %{ endif ~}
 
-  # 2. Install k3s server (no flannel — Cilium replaces it). Cluster +
-  #    service CIDRs are pinned per-region to avoid ClusterMesh peer
-  #    collisions (DoD D11).
+  # 2. Install k3s server (Wave 5.11 Refs #2140 — Flannel ENABLED,
+  #    default vxlan backend). Cluster + service CIDRs are pinned
+  #    per-region to avoid ClusterMesh peer collisions (DoD D11).
+  #
+  # Wave 3 disabled Flannel (`--flannel-backend=none`) intending Cilium
+  # to replace it via Flux. The result was a chicken-and-egg deadlock:
+  # k3s node stayed NotReady (`cni plugin not initialized`) → Flux
+  # controller Pods stuck Pending (FailedScheduling on not-ready taint)
+  # → bp-cilium HelmRelease never deployed → node never became Ready.
+  # Caught live on c455045f2fd139a4 2026-05-22T23:24Z (Phase 1 saw 0
+  # HelmReleases in 15min).
+  #
+  # Re-enabling Flannel default lets the CP become Ready, Flux schedule,
+  # the bootstrap-kit Kustomization reconcile. The bp-cilium HelmRelease
+  # later in the bootstrap-kit chain replaces Flannel as the active CNI
+  # via Cilium's chained-CNI install path. Cilium ClusterMesh
+  # (multi-region peer) is Wave 6+ — not required for the POC walk.
   - |
     curl -sfL https://get.k3s.io | \
       INSTALL_K3S_VERSION=${k3s_version} \
       K3S_TOKEN=${k3s_token} \
       INSTALL_K3S_EXEC="server \
-        --flannel-backend=none \
-        --disable-network-policy \
         --disable=traefik \
         --disable=servicelb \
         --cluster-cidr=${cluster_cidr} \

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2338,8 +2338,8 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.252
-appVersion: 1.4.252
+version: 1.4.253
+appVersion: 1.4.253
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +


### PR DESCRIPTION
Chicken-and-egg CNI bootstrap broken in Wave 3. Re-enable Flannel default; Cilium replaces it via Flux later. Chart 1.4.252→1.4.253.