### PR TITLE
fix(huawei-module): pass real CP private IP to workers (Wave 5.13, Refs #2140)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.253
+      version: 1.4.254
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -324,14 +324,36 @@ resource "huaweicloud_vpc_eip" "cp" {
 # fresh-prov against either cloud without per-provider trimming.
 
 locals {
-  worker_cloud_init = replace(templatefile("${path.module}/cloudinit-worker.tftpl", {
-    sovereign_fqdn             = var.sovereign_fqdn
-    k3s_version                = var.k3s_version
-    k3s_token                  = sha256("${var.huawei_project_id}/${var.sovereign_fqdn}/k3s-bootstrap")
-    cp_private_ip              = cidrhost(local.region_subnet_cidr[local.region_keys[0]], 2)
-    enable_unattended_upgrades = var.enable_unattended_upgrades
-    enable_fail2ban            = var.enable_fail2ban
-  }), "/(?m)^[ ]*#( |$).*\n/", "")
+  # Wave 5.13 (Refs #2140): per-region worker cloud-init render with the
+  # ACTUAL CP private IP per region (not the wrong `cidrhost(subnet,2)`
+  # assumption). HCS DHCP does not assign deterministic .2 addresses —
+  # workers on 974113d27f0e3666 tried to join 10.20.1.2 but the CP was
+  # at a DHCP-assigned address. Only 1 node ever joined (the CP itself)
+  # → Pods Pending with "Insufficient cpu" because the single CP had
+  # no worker capacity. Use the resource attribute `access_ip_v4` for
+  # the deterministic correct IP. Tofu DAG creates CPs first, then
+  # renders worker cloud-init, then creates workers.
+  #
+  # Map keyed by region code so the for_each worker resource can pick
+  # its OWN region's CP IP.
+  cp_primary_private_ip_by_region = {
+    for r in var.regions :
+    r.code => huaweicloud_compute_instance.control_plane[
+      index([for n in local.cp_nodes : "${n.region}-${n.index}"], "${r.code}-0")
+    ].access_ip_v4
+  }
+
+  worker_cloud_init_by_region = {
+    for r in var.regions :
+    r.code => replace(templatefile("${path.module}/cloudinit-worker.tftpl", {
+      sovereign_fqdn             = var.sovereign_fqdn
+      k3s_version                = var.k3s_version
+      k3s_token                  = sha256("${var.huawei_project_id}/${var.sovereign_fqdn}/k3s-bootstrap")
+      cp_private_ip              = local.cp_primary_private_ip_by_region[r.code]
+      enable_unattended_upgrades = var.enable_unattended_upgrades
+      enable_fail2ban            = var.enable_fail2ban
+    }), "/(?m)^[ ]*#( |$).*\n/", "")
+  }
 
   control_plane_cloud_init = replace(templatefile("${path.module}/cloudinit-control-plane.tftpl", {
     sovereign_fqdn      = var.sovereign_fqdn
@@ -456,7 +478,9 @@ resource "huaweicloud_compute_instance" "worker" {
     uuid = huaweicloud_vpc_subnet.region[each.value.region].id
   }
 
-  user_data = local.worker_cloud_init
+  # Wave 5.13 (Refs #2140): per-region cloud-init render with the ACTUAL
+  # CP private IP for THIS region (not the wrong subnet+2 assumption).
+  user_data = local.worker_cloud_init_by_region[each.value.region]
 
   key_pair = huaweicloud_kps_keypair.main.name
 

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2338,8 +2338,8 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.253
-appVersion: 1.4.253
+version: 1.4.254
+appVersion: 1.4.254
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +


### PR DESCRIPTION
Workers can't find the CP at hardcoded subnet+2 because HCS DHCP non-deterministic. Use tofu attribute. Same root cause class as Wave 5.10. Chart 1.4.253→1.4.254.