### PR TITLE
fix(huawei-module): worker_cloud_init_b64 references the per-region map (Wave 5.13 follow-up, Refs #2140)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.254
+      version: 1.4.255
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -413,7 +413,7 @@ locals {
     catalyst_api_url           = var.catalyst_api_url
     enable_unattended_upgrades = var.enable_unattended_upgrades
     enable_fail2ban            = var.enable_fail2ban
-    worker_cloud_init_b64      = base64encode(local.worker_cloud_init)
+    worker_cloud_init_b64      = base64encode(local.worker_cloud_init_by_region[var.regions[0].code])
   }), "/(?m)^[ ]*#( |$).*\n/", "")
 }
 

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2338,8 +2338,8 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.254
-appVersion: 1.4.254
+version: 1.4.255
+appVersion: 1.4.255
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +


### PR DESCRIPTION
Wave 5.13 missed updating line 416; tofu validate error. Chart 1.4.254→1.4.255.