### PR TITLE
fix(catalyst-api): reduce mem request 512Mi → 192Mi for mothership scheduling (Refs #2164)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.255
+      version: 1.4.256
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2338,8 +2338,8 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.255
-appVersion: 1.4.255
+version: 1.4.256
+appVersion: 1.4.256
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -1373,7 +1373,7 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 512Mi
+              memory: 192Mi
             limits:
               # tofu provider plugins (hcloud ~80MB, dynadot ~30MB) + state +
               # plan files easily exceed the prior 64Mi cap. 1Gi was the


### PR DESCRIPTION
Mothership Contabo 12GB couldn't fit catalyst-api Pod. Lower request, limit stays 4Gi. Chart 1.4.255→1.4.256.