### PR TITLE
fix(huawei-module): break tofu DAG cycle (Wave 5.16, Refs #2166)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.256
+      version: 1.4.257
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -413,7 +413,18 @@ locals {
     catalyst_api_url           = var.catalyst_api_url
     enable_unattended_upgrades = var.enable_unattended_upgrades
     enable_fail2ban            = var.enable_fail2ban
-    worker_cloud_init_b64      = base64encode(local.worker_cloud_init_by_region[var.regions[0].code])
+    # Wave 5.16 (Refs #2140): empty placeholder. The CP cloud-init bakes
+    # worker-cloud-init.b64 into /var/lib/catalyst/ for the bp-cluster-
+    # autoscaler-hcloud blueprint to consume on scale-out. On Huawei
+    # that blueprint is disabled (Hetzner-only), so the bake isn't
+    # load-bearing for the POC. Referencing local.worker_cloud_init_by_region
+    # here created a tofu DAG cycle:
+    #   control_plane_cloud_init → worker_cloud_init_by_region →
+    #   cp_primary_private_ip_by_region → huaweicloud_compute_instance.
+    #   control_plane → user_data (= control_plane_cloud_init).
+    # Wave 6+ may serve the worker template via a Huawei-AS hook that
+    # fetches it from a tofu-OBS object instead of pre-baking on the CP.
+    worker_cloud_init_b64 = ""
   }), "/(?m)^[ ]*#( |$).*\n/", "")
 }
 

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2338,8 +2338,8 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.256
-appVersion: 1.4.256
+version: 1.4.257
+appVersion: 1.4.257
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +


### PR DESCRIPTION
15th attempt cycle: control_plane_cloud_init → worker_cloud_init_by_region → CP IP → CP user_data. Empty worker_cloud_init_b64 (autoscaler is Hetzner-only). Chart 1.4.256→1.4.257.