### PR TITLE
fix(huawei-module): make cloud-init resilient to fail2ban absence (Wave 5.17, Refs #2168)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.257
+      version: 1.4.258
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -215,7 +215,7 @@ runcmd:
   - systemctl reload ssh || true
 
 %{ if enable_fail2ban ~}
-  - systemctl enable --now fail2ban
+  - systemctl enable --now fail2ban || true
 %{ endif ~}
 
   # 2. Install k3s server (Wave 5.11 Refs #2140 — Flannel ENABLED,

--- a/infra/providers/huawei/cloudinit-worker.tftpl
+++ b/infra/providers/huawei/cloudinit-worker.tftpl
@@ -37,7 +37,7 @@ runcmd:
   - sysctl --system
   - systemctl reload ssh || true
 %{ if enable_fail2ban ~}
-  - systemctl enable --now fail2ban
+  - systemctl enable --now fail2ban || true
 %{ endif ~}
 
   # Join the k3s control-plane at the region's local CP (private IP
@@ -53,4 +53,5 @@ runcmd:
         --node-label=catalyst.openova.io/provider=huawei" \
       sh -
 
+  - mkdir -p /var/lib/catalyst
   - touch /var/lib/catalyst/worker-bootstrap-complete

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2338,8 +2338,8 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.257
-appVersion: 1.4.257
+version: 1.4.258
+appVersion: 1.4.258
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +


### PR DESCRIPTION
Workers couldn't install k3s because fail2ban-enable failed first and halted runcmd. Add || true + mkdir. Chart 1.4.257→1.4.258.