### PR TITLE
fix(huawei-module): bash-wrap fragile cloud-init lines (Wave 5.18, Refs #2171)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.258
+      version: 1.4.259
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -212,10 +212,10 @@ write_files:
 runcmd:
   # 1. Apply sysctl for inotify limits + harden sshd
   - sysctl --system
-  - systemctl reload ssh || true
+  - ["bash", "-c", "systemctl reload ssh || true"]
 
 %{ if enable_fail2ban ~}
-  - systemctl enable --now fail2ban || true
+  - ["bash", "-c", "systemctl enable --now fail2ban || true"]
 %{ endif ~}
 
   # 2. Install k3s server (Wave 5.11 Refs #2140 — Flannel ENABLED,

--- a/infra/providers/huawei/cloudinit-worker.tftpl
+++ b/infra/providers/huawei/cloudinit-worker.tftpl
@@ -35,9 +35,9 @@ write_files:
 
 runcmd:
   - sysctl --system
-  - systemctl reload ssh || true
+  - ["bash", "-c", "systemctl reload ssh || true"]
 %{ if enable_fail2ban ~}
-  - systemctl enable --now fail2ban || true
+  - ["bash", "-c", "systemctl enable --now fail2ban || true"]
 %{ endif ~}
 
   # Join the k3s control-plane at the region's local CP (private IP

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2338,8 +2338,8 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.258
-appVersion: 1.4.258
+version: 1.4.259
+appVersion: 1.4.259
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +


### PR DESCRIPTION
Wave 5.17 `|| true` failed because cloud-init runcmd uses exec-list semantics, not shell. Wrap in ["bash","-c",...] form. Chart 1.4.258→1.4.259.