### PR TITLE
fix(huawei-module): seed Gateway API CRDs in cloud-init (Wave 5.19, Refs #2174)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.259
+      version: 1.4.260
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -265,6 +265,20 @@ runcmd:
   - |
     curl -sfL https://github.com/fluxcd/flux2/releases/download/v2.4.0/flux_2.4.0_linux_amd64.tar.gz \
       | tar -xz -C /usr/local/bin flux
+
+  # 4a. Pre-install Gateway API CRDs (Wave 5.19 Refs #2140). bp-cilium's
+  # chart references GatewayClass + HTTPRoute resources but bp-gateway-api
+  # (which installs the CRDs) `dependsOn: bp-cilium` — circular dep means
+  # bp-cilium fails to install on every fresh prov with `no matches for
+  # kind "GatewayClass" in version "gateway.networking.k8s.io/v1"`. Wave
+  # 5.12 patched live; Wave 5.19 seeds at cloud-init time so the CRDs
+  # are present BEFORE Flux tries any HelmRelease.
+  - |
+    for crd in gatewayclasses gateways httproutes grpcroutes referencegrants; do
+      KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f \
+        "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.0/config/crd/standard/gateway.networking.k8s.io_$${crd}.yaml" || true
+    done
+
   - KUBECONFIG=/etc/rancher/k3s/k3s.yaml flux install --components=source-controller,kustomize-controller,helm-controller,notification-controller || true
   - KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f /var/lib/catalyst/manifests/10-flux-source.yaml
 

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2338,8 +2338,8 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.259
-appVersion: 1.4.259
+version: 1.4.260
+appVersion: 1.4.260
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +


### PR DESCRIPTION
Permanent fix for Wave 5.12 live patch — bp-cilium↔bp-gateway-api circular dep. CRDs apply at cloud-init time before Flux. Chart 1.4.259→1.4.260.