### PR TITLE
fix(huawei-module): worker runcmd single shell block (Wave 5.20, Refs #2176)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.260
+      version: 1.4.261
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/infra/providers/huawei/cloudinit-worker.tftpl
+++ b/infra/providers/huawei/cloudinit-worker.tftpl
@@ -34,24 +34,24 @@ write_files:
       MaxAuthTries 3
 
 runcmd:
-  - sysctl --system
-  - ["bash", "-c", "systemctl reload ssh || true"]
-%{ if enable_fail2ban ~}
-  - ["bash", "-c", "systemctl enable --now fail2ban || true"]
-%{ endif ~}
-
-  # Join the k3s control-plane at the region's local CP (private IP
-  # 10.x.1.2 inside the workers' VPC). Same `K3S_URL` pattern Hetzner
-  # workers use — the CP's private IP is stable within the region's
-  # /24 subnet.
+  # Wave 5.20: single shell block — cloud-init runcmd list-form had two
+  # silent halts on HCS Ubuntu image: (1) apt-get install fails because
+  # the mirror is unreachable so fail2ban package isn't installed,
+  # (2) bash-wrapped `systemctl enable --now fail2ban` either halts
+  # subshell or has env weirdness. One literal-block shell command
+  # makes the order explicit: sysctl --system → skip-on-error fail2ban
+  # enable → k3s install (the load-bearing step) → mkdir+touch.
   - |
+    set +e
+    sysctl --system
+    systemctl reload ssh 2>/dev/null || true
+    systemctl enable --now fail2ban 2>/dev/null || true
     curl -sfL https://get.k3s.io | \
       INSTALL_K3S_VERSION=${k3s_version} \
       K3S_TOKEN=${k3s_token} \
       K3S_URL=https://${cp_private_ip}:6443 \
-      INSTALL_K3S_EXEC="agent \
-        --node-label=catalyst.openova.io/provider=huawei" \
+      INSTALL_K3S_EXEC="agent --node-label=catalyst.openova.io/provider=huawei" \
       sh -
+    mkdir -p /var/lib/catalyst
+    touch /var/lib/catalyst/worker-bootstrap-complete
 
-  - mkdir -p /var/lib/catalyst
-  - touch /var/lib/catalyst/worker-bootstrap-complete

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2338,8 +2338,8 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.260
-appVersion: 1.4.260
+version: 1.4.261
+appVersion: 1.4.261
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.
 # Adds the OpenTofu module at infra/providers/huawei/ (VPC + Subnet +


### PR DESCRIPTION
Cloud-init halts on bash-wrap list form. Single shell block w/ set +e. Chart 1.4.260→1.4.261.