### PR TITLE
fix(huawei-module): scope resource names by deployment_id to avoid HCS conflict (Wave 5.26, Refs #2191)

### DIFF
--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -69,8 +69,21 @@ locals {
 
   # Canonical resource-name prefix that the orphan-purge sweep (Go-side
   # at internal/providers/huawei/ Wave 3) will look for. Pattern mirrors
-  # Hetzner's `catalyst-<fqdn-slug>`.
-  name_prefix = "catalyst-${local.fqdn_slug}"
+  # Hetzner's `catalyst-<fqdn-slug>` BUT also includes the first 8 hex
+  # chars of the deployment_id so re-provisioning the same FQDN never
+  # collides on resource names (HCS rejects same-name KPS keypair / VPC /
+  # OBS bucket / EIP / NAT with HTTP 409 "could not be processed due to
+  # conflict in the request").
+  #
+  # Wave 5.26 (Refs #2191): caught live on 20th attempt 51fcc636d958c26a
+  # — KPS keypair "catalyst-hw01-omani-works-key" collided with the
+  # orphaned keypair from 19th attempt c5da3542 that was not cleaned up
+  # because manual SSH-debug had broken tofu state on the prior prov.
+  #
+  # The orphan-purge sweep (Go-side ListServers / OBS bucket sweep) keys
+  # off TMS tag `catalyst.openova.io/deployment-id`, not the name —
+  # different per-prov names do NOT break orphan cleanup.
+  name_prefix = "catalyst-${local.fqdn_slug}-${substr(var.deployment_id, 0, 8)}"
 
   # Canonical TMS tags per PROVIDER-INTERFACE.md §3 (label conventions).
   # Same key shape as Hetzner; Huawei TMS happens to accept k=v lists.


### PR DESCRIPTION
## Summary
- Wave 5.26 — append \`substr(var.deployment_id, 0, 8)\` to \`local.name_prefix\` so resource names (KPS keypair, OBS bucket, VPC, subnet, EIP, NAT, secgroup, ECS hosts) are deployment-scoped, not just FQDN-scoped.
- Caught live on 20th attempt \`51fcc636d958c26a\`: \`Error: error creating KPS keypair: The request could not be processed due to conflict in the request\` — 19th attempt c5da3542 left orphaned resources after manual SSH-debug broke tofu state.
- Orphan-purge sweep keys off TMS tag \`catalyst.openova.io/deployment-id\`, not name — re-provisioning the same FQDN cleanly is by-design.

## Test plan
- [x] tofu validate (manual on debug Pod)
- [ ] 21st deployment provisions cleanly with new naming
- [ ] Cilium agents boot Running 1/1 on fresh prov (Wave 5.25 host-gw verified end-to-end)

Refs #2163 (parent Wave 5)
Refs #2191