### PR TITLE
fix(bootstrap-kit): sysctl DS for cilium-envoy hostNetwork bind (Wave 5.33, Refs #2205)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -368,3 +368,67 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+---
+# Wave 5.33 (Refs #2205): cilium-envoy in hostNetwork mode cannot bind 0.0.0.0:80 or :443.
+# Root cause: cilium-envoy-starter (pid 1, has CapEff=0x201400 incl. NET_BIND_SERVICE) exec's
+# the actual cilium-envoy worker (pid 7) with CapEff=0 — caps deliberately dropped by the
+# starter shim. Despite runAsUser=0, a process with empty CapEff cannot bind privileged ports
+# unless the host kernel's net.ipv4.ip_unprivileged_port_start sysctl is lowered to <=80.
+# Default is 1024 → bind('0.0.0.0:80') = EACCES → xDS NACK loop → no Gateway listener →
+# every console.${SOVEREIGN_FQDN} URL HTTP 000.
+#
+# Fix: a tiny privileged DaemonSet that sets the sysctl on each node at boot via chroot /host.
+# The container exits 0 after the write; restartPolicy=Always keeps the Pod alive (sleep infinity)
+# so the kubelet reports Ready. Re-applied on every node reboot via the same DS.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sysctl-envoy-bind
+  namespace: kube-system
+  labels:
+    catalyst.openova.io/slot: "01"
+spec:
+  selector:
+    matchLabels:
+      app: sysctl-envoy-bind
+  template:
+    metadata:
+      labels:
+        app: sysctl-envoy-bind
+    spec:
+      hostNetwork: true
+      hostPID: true
+      tolerations:
+        - operator: Exists
+      initContainers:
+        - name: set-sysctl
+          image: busybox:1.36
+          securityContext:
+            privileged: true
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              chroot /host sysctl -w net.ipv4.ip_unprivileged_port_start=80
+              chroot /host sh -c 'grep -q "^net.ipv4.ip_unprivileged_port_start" /etc/sysctl.d/99-cilium-envoy-bind.conf 2>/dev/null || echo "net.ipv4.ip_unprivileged_port_start = 80" > /etc/sysctl.d/99-cilium-envoy-bind.conf'
+              echo "sysctl applied: $(chroot /host cat /proc/sys/net/ipv4/ip_unprivileged_port_start)"
+          volumeMounts:
+            - name: host-root
+              mountPath: /host
+      containers:
+        - name: pause
+          image: busybox:1.36
+          command: ["/bin/sh", "-c", "sleep infinity"]
+          resources:
+            requests:
+              cpu: 1m
+              memory: 4Mi
+            limits:
+              cpu: 10m
+              memory: 16Mi
+      volumes:
+        - name: host-root
+          hostPath:
+            path: /
+            type: Directory


### PR DESCRIPTION
## Summary

Wave 5.33 — unblocks Cilium Gateway listeners on Huawei Cloud Stack (and any node where cilium-envoy runs in hostNetwork mode).

**Root cause** (verified on hw01.omani.works 27th deployment `e521726137adb8d8`):
- cilium-envoy DS has `runAsUser=0` and `capabilities.add: [NET_BIND_SERVICE]` — pid 1 (`cilium-envoy-starter`) shows `CapEff=0x201400` (NET_ADMIN+SYS_ADMIN+NET_BIND_SERVICE).
- The starter shim deliberately drops all caps before exec'ing the envoy worker — pid 7 (`cilium-envoy`) shows `CapEff=0`.
- With empty CapEff and the host's `net.ipv4.ip_unprivileged_port_start=1024`, `bind('0.0.0.0:80')` returns EACCES.
- xDS NACK loop: `cannot bind '0.0.0.0:80': Permission denied` → no Gateway listener → every `*.${SOVEREIGN_FQDN}` URL HTTP 000.

**Fix**: add a tiny privileged DaemonSet (`sysctl-envoy-bind`) at bootstrap-kit slot 01 that runs on every node, sets `net.ipv4.ip_unprivileged_port_start=80` via `chroot /host sysctl`, persists it in `/etc/sysctl.d/99-cilium-envoy-bind.conf` (survives node reboot), then `sleep infinity` so the kubelet keeps it alive.

**Why a DaemonSet not cloud-init**: each Sovereign installs Cilium post-handover via Flux on a stable bootstrap-kit, not via cloud-init. The DS lives next to bp-cilium so the sysctl is in place before any Gateway listener is reconciled.

## Verification

Pre-fix (27th cluster `e521726137adb8d8`):
- 3/3 nodes Ready, 3/3 Cilium agents Running
- Cross-node pod ping 0% loss 0.45ms (Wave 5.30+5.31 verified)
- 32+/53 HRs Ready including bp-catalyst-platform
- **Blocker**: cilium-envoy xDS NACK loop, all gateway URLs HTTP 000

Post-fix expectation:
- DS pods Running on all 3 nodes
- `cat /proc/sys/net/ipv4/ip_unprivileged_port_start` = 80 on each node
- cilium-envoy CEC listener binds 0.0.0.0:80 + 0.0.0.0:443
- `curl --resolve console.hw01.omani.works:443:<cp1-host-ip> https://console.hw01.omani.works/healthz` → HTTP 200

## Test plan
- [ ] PR merges, chart auto-bumps, image lands in GHCR
- [ ] Bootstrap-kit re-rendered on 27th cluster (or next provision triggers it)
- [ ] DS pods Ready on all 3 nodes
- [ ] Envoy CEC listener bound (`ss -tln` shows 0.0.0.0:80 + 0.0.0.0:443)
- [ ] Console.hw01.omani.works HTTPS 200 → Pillar 1 walk can proceed

Refs #2205

🤖 Generated with [Claude Code](https://claude.com/claude-code)