### PR TITLE
fix(huawei-module): port Hetzner Secret-seeding cloud-init blocks (Wave 5.34, Refs #2208)

### DIFF
--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -168,6 +168,61 @@ write_files:
     content: |
       ${handover_jwt_public_key}
 
+  # Wave 5.34 (Refs #2208): cert-manager/powerdns-api-credentials Secret.
+  # bp-cert-manager-powerdns-webhook reads X-API-Key from this Secret to
+  # authenticate against contabo's authoritative PowerDNS for omani.works.
+  # Without this, DNS-01 challenges hang and the wildcard cert never issues.
+  - path: /var/lib/catalyst/manifests/04-powerdns-api-credentials.yaml
+    permissions: '0600'
+    content: |
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: powerdns-api-credentials
+        namespace: cert-manager
+      type: Opaque
+      data:
+        api-key: ${base64encode(powerdns_api_key)}
+
+  # Wave 5.34 (Refs #2208): flux-system/pdm-basicauth Secret. The
+  # catalyst-api Pod reads CATALYST_PDM_BASIC_AUTH_USER/PASS via
+  # secretKeyRef into pdm-basicauth in catalyst-system. Reflector
+  # mirrors out of flux-system to sme,catalyst,catalyst-system,gitea,
+  # harbor (canonical pattern).
+  - path: /var/lib/catalyst/manifests/05-pdm-basicauth-secret.yaml
+    permissions: '0600'
+    content: |
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: pdm-basicauth
+        namespace: flux-system
+        annotations:
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "sme,catalyst,catalyst-system,gitea,harbor"
+          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "sme,catalyst,catalyst-system,gitea,harbor"
+      type: Opaque
+      data:
+        username: ${base64encode(pdm_basic_auth_user)}
+        password: ${base64encode(pdm_basic_auth_pass)}
+
+  # Wave 5.34 (Refs #2208): catalyst-system/catalyst-handover-jwt-public
+  # Secret. Mounted at /etc/catalyst/handover-jwt-public/public.jwk by the
+  # catalyst-api Pod. GET /auth/handover returns "server misconfiguration:
+  # public key unavailable" when this is absent (otech48 incident).
+  - path: /var/lib/catalyst/manifests/06-handover-jwt-public-secret.yaml
+    permissions: '0600'
+    content: |
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: catalyst-handover-jwt-public
+        namespace: catalyst-system
+      type: Opaque
+      data:
+        public.jwk: ${base64encode(handover_jwt_public_key)}
+
   # ── Flux GitRepository + Kustomization seed ───────────────────────────
   - path: /var/lib/catalyst/manifests/10-flux-source.yaml
     permissions: '0644'
@@ -324,6 +379,17 @@ runcmd:
   - KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f /var/lib/catalyst/manifests/01-ghcr-pull-secret.yaml
   - KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f /var/lib/catalyst/manifests/02-cloud-credentials-secret.yaml
   - KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f /var/lib/catalyst/manifests/03-object-storage-secret.yaml
+
+  # Wave 5.34 (Refs #2208): port Hetzner Secret-seeding pattern to Huawei.
+  # Without these Secrets, bp-cert-manager-powerdns-webhook DNS-01 challenge
+  # hangs (wildcard cert never issues → HTTPS gateway listener stays
+  # Programmed=False), pdmFlipNS returns 401 against mothership PDM, and
+  # the catalyst-api Pod's handover-JWT verification fails.
+  - KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl create namespace cert-manager --dry-run=client -o yaml | KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f -
+  - KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f /var/lib/catalyst/manifests/04-powerdns-api-credentials.yaml
+  - KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f /var/lib/catalyst/manifests/05-pdm-basicauth-secret.yaml
+  - KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl create namespace catalyst-system --dry-run=client -o yaml | KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f -
+  - KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f /var/lib/catalyst/manifests/06-handover-jwt-public-secret.yaml
 
   # 4. Install Flux + apply the GitRepository + Kustomization seed.
   - |

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -584,6 +584,11 @@ locals {
     catalyst_api_url           = var.catalyst_api_url
     enable_unattended_upgrades = var.enable_unattended_upgrades
     enable_fail2ban            = var.enable_fail2ban
+    # Wave 5.34 (Refs #2208): Sovereign-side Secret seeds (powerdns DNS-01
+    # cert challenge + PDM basic-auth Day-2 calls). Mirror Hetzner pattern.
+    powerdns_api_key           = var.powerdns_api_key
+    pdm_basic_auth_user        = var.pdm_basic_auth_user
+    pdm_basic_auth_pass        = var.pdm_basic_auth_pass
     # Wave 5.16 (Refs #2140): empty placeholder. The CP cloud-init bakes
     # worker-cloud-init.b64 into /var/lib/catalyst/ for the bp-cluster-
     # autoscaler-hcloud blueprint to consume on scale-out. On Huawei

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -586,9 +586,9 @@ locals {
     enable_fail2ban            = var.enable_fail2ban
     # Wave 5.34 (Refs #2208): Sovereign-side Secret seeds (powerdns DNS-01
     # cert challenge + PDM basic-auth Day-2 calls). Mirror Hetzner pattern.
-    powerdns_api_key           = var.powerdns_api_key
-    pdm_basic_auth_user        = var.pdm_basic_auth_user
-    pdm_basic_auth_pass        = var.pdm_basic_auth_pass
+    powerdns_api_key    = var.powerdns_api_key
+    pdm_basic_auth_user = var.pdm_basic_auth_user
+    pdm_basic_auth_pass = var.pdm_basic_auth_pass
     # Wave 5.16 (Refs #2140): empty placeholder. The CP cloud-init bakes
     # worker-cloud-init.b64 into /var/lib/catalyst/ for the bp-cluster-
     # autoscaler-hcloud blueprint to consume on scale-out. On Huawei

--- a/infra/providers/huawei/variables.tf
+++ b/infra/providers/huawei/variables.tf
@@ -259,6 +259,43 @@ variable "enable_fail2ban" {
   default     = true
 }
 
+# ── Wave 5.34 (Refs #2208): Sovereign-side Secret seeds ─────────────────
+# Mirror Hetzner cloud-init pattern. Provisioner (provisioner.go) writes
+# these into tofu.auto.tfvars.json regardless of provider; without these
+# variable declarations the Huawei cloudinit-control-plane.tftpl could not
+# reference ${powerdns_api_key} et al.
+
+variable "powerdns_api_key" {
+  type        = string
+  sensitive   = true
+  description = <<-EOT
+    Contabo central PowerDNS API key. Seeded into the Sovereign's
+    cert-manager/powerdns-api-credentials Secret so
+    bp-cert-manager-powerdns-webhook can write DNS-01 challenge TXT
+    records to contabo's authoritative omani.works zone. Empty = wildcard
+    cert never issues (HTTPS listener stays Programmed=False).
+  EOT
+  default     = ""
+}
+
+variable "pdm_basic_auth_user" {
+  type        = string
+  sensitive   = true
+  description = <<-EOT
+    Pool-Domain-Manager basic-auth username. Seeded into the Sovereign's
+    flux-system/pdm-basicauth Secret; Reflector mirrors to catalyst-system.
+    catalyst-api mounts via secretKeyRef for Day-2 add-parent-domain calls.
+  EOT
+  default     = ""
+}
+
+variable "pdm_basic_auth_pass" {
+  type        = string
+  sensitive   = true
+  description = "PDM basic-auth password. Paired with pdm_basic_auth_user."
+  default     = ""
+}
+
 # ── OBS bucket (S3-protocol; mirrors Hetzner object-storage_* triplet) ───
 
 variable "obs_bucket_name" {


### PR DESCRIPTION
## Summary

Wave 5.34 — port the 3 missing Secret-seed blocks from Hetzner cloud-init to Huawei. These are the canonical Hetzner pattern but the Huawei tftpl was left out because the variables were never declared in Huawei's `variables.tf`.

## What ships
1. `variables.tf` — add `powerdns_api_key`, `pdm_basic_auth_user`, `pdm_basic_auth_pass` (sensitive, default `""`).
2. `main.tf` — wire the 3 new vars into the `templatefile()` call.
3. `cloudinit-control-plane.tftpl` — add 3 write_files Secret manifests + 4 runcmd `kubectl apply` lines + 2 namespace pre-creates.

## Why this matters

Symptom on hw01.omani.works 27th cluster (post Wave 5.33 #2206 gateway-bind fix):
- cert-manager controller log: `secrets "powerdns-api-credentials" not found`
- wildcard cert never issues → HTTPS gateway listener stays `Programmed=False`
- console.hw01.omani.works HTTPS = 000 (HTTP works = 200, gitea HTTP 200 from public)

Provisioner already writes `powerdns_api_key` etc. into tofu.auto.tfvars.json regardless of provider (`provisioner.go:1546/1579/1580`), but Huawei's variables.tf never declared them so tofu silently ignored the values. This PR fixes the missing wiring.

## Test plan
- [ ] PR merges; chart auto-bumps
- [ ] Next provision applies the 3 Secrets at CP boot
- [ ] cert-manager DNS-01 challenge succeeds
- [ ] sovereign-wildcard cert Ready=True
- [ ] Gateway HTTPS listener Programmed=True
- [ ] console.hw01.omani.works HTTPS → 200

Refs #2208
Refs #2163, #2205

🤖 Generated with [Claude Code](https://claude.com/claude-code)