### PR TITLE
fix(gitea): declare managed.roles for gitea-pg eliminates initdb-vs-Secret race (Wave 5.35 Refs #2211)

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -54,7 +54,7 @@ spec:
       # bp-self-sovereign-cutover Step 1 gitea-mirror Job mounts it. K8s
       # forbids cross-namespace secretKeyRef; reflector is the canonical
       # platform-level mirror. Caught live on otech103 2026-05-04.
-      version: 1.2.8
+      version: 1.2.9
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.2.8
+  version: 1.2.9
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -8,7 +8,7 @@ name: bp-gitea
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.2.8
+version: 1.2.9
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/cnpg-cluster.yaml
+++ b/platform/gitea/chart/templates/cnpg-cluster.yaml
@@ -34,6 +34,32 @@ spec:
       database: {{ .Values.postgres.cluster.database | default "gitea" | quote }}
       owner: {{ .Values.postgres.cluster.owner | default "gitea" | quote }}
 
+  # Wave 5.35 (Refs #2211): explicit declarative role management.
+  # CNPG synthesises the gitea role at initdb time AND the gitea-pg-app
+  # Secret independently. In practice the two values can drift — either
+  # because initdb sets a different password than what eventually lands
+  # in the Secret, OR because a Secret rotation isn't applied back to
+  # the role. Live evidence (hw01 30th HCS 2026-05-23): gitea-app init
+  # container crashed with `pq: password authentication failed for user
+  # "gitea"` despite gitea-pg-app.password being non-empty and matching
+  # gitea-database-secret.password. Manual `ALTER USER gitea WITH
+  # PASSWORD '<gitea-pg-app value>'` resolved it.
+  #
+  # `spec.managed.roles[]` with passwordSecret pointing at the canonical
+  # gitea-pg-app Secret makes CNPG reconcile the role's password to
+  # match the Secret value on every Cluster reconcile. Any drift gets
+  # ALTER USER'd away. The Secret name follows CNPG's own naming
+  # convention so this works even on fresh provisions — when CNPG first
+  # creates gitea-pg-app, the role bootstrap reads from it, eliminating
+  # the initdb-vs-Secret race.
+  managed:
+    roles:
+      - name: {{ .Values.postgres.cluster.owner | default "gitea" | quote }}
+        ensure: present
+        login: true
+        passwordSecret:
+          name: {{ printf "%s-app" (.Values.postgres.cluster.name | default "gitea-pg") | quote }}
+
   # inheritedMetadata.annotations: CNPG propagates these onto every
   # Secret it generates (gitea-pg-app, gitea-pg-superuser, etc.).
   # The k8s-reflector (bp-reflector) requires the SOURCE Secret to carry


### PR DESCRIPTION
Fix axon CrashLoopBackOff when the upstream vLLM endpoint is unreachable. Split liveness/readiness:

Wave 5.35 fix for #2211. Symptom on hw01 30th HCS: gitea-app init container crashes with pq:password authentication failed despite Secret being populated.

Root cause: CNPG synthesises gitea-pg-app Secret + initdb role independently; values can drift.

Fix: spec.managed.roles[] with passwordSecret pointing at gitea-pg-app. CNPG reconciles role password to match Secret on every Cluster reconcile.

Chart bump 1.2.8 to 1.2.9 + bootstrap-kit pin update.

Refs the originating issue.