### PR TITLE
feat(pdm): generic /set-dns endpoint (A/AAAA/CNAME/MX/TXT records)

### DIFF
--- a/core/pool-domain-manager/api/openapi.yaml
+++ b/core/pool-domain-manager/api/openapi.yaml
@@ -168,8 +168,93 @@ paths:
         '200':
           description: All allocations for the pool
 
+  /api/v1/registrar/{registrar}/set-dns:
+    post:
+      summary: Write raw zone-level DNS records (A/AAAA/CNAME/MX/TXT) via the registrar's record-level API
+      description: |
+        REPLACES the record set for the domain. Records NOT in the new set are
+        DELETED; records in the new set are CREATED or UPDATED. Implementations
+        MUST be idempotent.
+
+        Adapters that lack a record-level API return 501. Use `/set-ns` to
+        delegate DNS to a record-capable provider (PowerDNS, Route53, etc.)
+        instead.
+
+        Refs chepherd/chepherd#36.
+      parameters:
+        - in: path
+          name: registrar
+          required: true
+          schema: { type: string }
+          description: Lowercase adapter name (currently `dynadot` or `namecheap`)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [domain, token, records]
+              properties:
+                domain:
+                  type: string
+                  example: example.com
+                token:
+                  type: string
+                  description: Registrar API credentials. Format varies by adapter (Dynadot = `key:secret`, Namecheap = `apiUser:apiKey:user:clientIP`). NEVER logged.
+                records:
+                  type: array
+                  minItems: 1
+                  items: { $ref: '#/components/schemas/DNSRecord' }
+      responses:
+        '200':
+          description: Records written + read-back confirmation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  registrar: { type: string }
+                  domain: { type: string }
+                  records:
+                    type: array
+                    items: { $ref: '#/components/schemas/DNSRecord' }
+                  propagation:
+                    type: string
+                    description: Coarse human-readable estimate (e.g. "up to 24 hours; typically 1-4 hours")
+        '401': { description: Invalid token }
+        '403': { description: Domain not in account }
+        '404': { description: Unknown registrar }
+        '422': { description: Invalid records (type not in A/AAAA/CNAME/MX/TXT, empty value, etc.) }
+        '429': { description: Registrar rate-limited }
+        '501': { description: Registrar adapter does not implement DNSRegistrar — use /set-ns to delegate DNS instead }
+        '502': { description: Registrar API unavailable }
+
 components:
   schemas:
+    DNSRecord:
+      type: object
+      required: [type, value]
+      properties:
+        subhost:
+          type: string
+          description: Leftmost label(s). Empty = root of zone. `www` = `www.<domain>`.
+          example: www
+        type:
+          type: string
+          enum: [A, AAAA, CNAME, MX, TXT]
+        value:
+          type: string
+          example: 1.2.3.4
+        priority:
+          type: integer
+          minimum: 0
+          description: MX priority (0 = highest). Ignored for non-MX records.
+        ttl:
+          type: integer
+          minimum: 0
+          description: Seconds. 0 = use registrar's default (typically 3600).
+
     CheckResult:
       type: object
       properties:

--- a/core/pool-domain-manager/internal/handler/handler.go
+++ b/core/pool-domain-manager/internal/handler/handler.go
@@ -59,6 +59,10 @@ func (h *Handler) Routes() *chi.Mux {
 		})
 		r.Route("/registrar/{registrar}", func(r chi.Router) {
 			r.Post("/set-ns", h.SetNS)
+			// /set-dns writes A/AAAA/CNAME/MX/TXT records at the
+			// registrar's own nameservers. Only adapters that implement
+			// registrar.DNSRegistrar participate; others return 501.
+			r.Post("/set-dns", h.SetDNS)
 			// /validate is the read-only twin of /set-ns — checks that the
 			// supplied token CAN reach the registrar and CAN see the named
 			// domain, without flipping any nameservers. The wizard's BYO

--- a/core/pool-domain-manager/internal/handler/setdns.go
+++ b/core/pool-domain-manager/internal/handler/setdns.go
@@ -1,0 +1,206 @@
+// SetDNS handler — writes raw zone-level records (A/AAAA/CNAME/MX/TXT)
+// via the registrar's record-level API. Companion to SetNS but
+// operates on a different surface: SetNS manipulates the NS
+// delegation; SetDNS manipulates the records at the registrar's own
+// nameservers.
+//
+// Adapters that don't implement registrar.DNSRegistrar return 501.
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/openova-io/openova/core/pool-domain-manager/internal/registrar"
+)
+
+// SetDNSRequest is the JSON body for POST /api/v1/registrar/{r}/set-dns.
+//
+// IMPORTANT: same Token-redaction discipline as SetNSRequest — the
+// handler intentionally avoids logging this struct directly.
+type SetDNSRequest struct {
+	Domain  string                `json:"domain"`
+	Token   string                `json:"token"`
+	Records []registrar.DNSRecord `json:"records"`
+}
+
+// SetDNSResponse is the JSON reply on success.
+type SetDNSResponse struct {
+	Success     bool                  `json:"success"`
+	Registrar   string                `json:"registrar"`
+	Domain      string                `json:"domain"`
+	Records     []registrar.DNSRecord `json:"records"`
+	Propagation string                `json:"propagation"`
+}
+
+// SetDNS handles POST /api/v1/registrar/{registrar}/set-dns.
+func (h *Handler) SetDNS(w http.ResponseWriter, r *http.Request) {
+	registrarName := strings.ToLower(strings.TrimSpace(chi.URLParam(r, "registrar")))
+
+	if h.Registry == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "no-registrars-configured",
+			"detail": "this PDM build has no registrar adapters wired in",
+		})
+		return
+	}
+
+	adapter, err := h.Registry.Lookup(registrarName)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]any{
+			"error":     "unsupported-registrar",
+			"detail":    "no adapter for registrar " + registrarName,
+			"supported": h.Registry.Names(),
+		})
+		return
+	}
+
+	// Adapter MUST implement DNSRegistrar — otherwise the record-level
+	// API isn't available for this registrar. Caller should fall back
+	// to delegating DNS to a record-capable provider (PowerDNS,
+	// Route53, etc.) via /set-ns.
+	dnsAdapter, ok := adapter.(registrar.DNSRegistrar)
+	if !ok {
+		writeJSON(w, http.StatusNotImplemented, map[string]any{
+			"error":     "set-dns-not-supported",
+			"detail":    "registrar " + registrarName + " has no record-level API; delegate DNS via /set-ns instead",
+			"registrar": registrarName,
+		})
+		return
+	}
+
+	var req SetDNSRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":  "invalid-body",
+			"detail": "request body must be JSON {domain, token, records}",
+		})
+		return
+	}
+	domain := strings.ToLower(strings.TrimSpace(req.Domain))
+	token := req.Token
+	records := req.Records
+
+	if domain == "" {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+			"error":  "missing-domain",
+			"detail": "domain is required",
+		})
+		return
+	}
+	if token == "" {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+			"error":  "missing-token",
+			"detail": "registrar API credentials are required",
+		})
+		return
+	}
+	if invalid := validateRecords(records); invalid != "" {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+			"error":  "invalid-records",
+			"detail": invalid,
+		})
+		return
+	}
+
+	ctx := r.Context()
+
+	// 1) Validate creds — fail fast on bad token.
+	if err := adapter.ValidateToken(ctx, token, domain); err != nil {
+		h.Log.Info("registrar set-dns: validate failed",
+			"registrar", registrarName,
+			"domain", domain,
+			"outcome", classifyOutcome(err),
+		)
+		writeRegistrarErr(w, err, registrarName, domain)
+		return
+	}
+
+	// 2) Write the record set.
+	if err := dnsAdapter.SetDNSRecords(ctx, token, domain, records); err != nil {
+		h.Log.Info("registrar set-dns: write failed",
+			"registrar", registrarName,
+			"domain", domain,
+			"record_count", len(records),
+			"outcome", classifyOutcome(err),
+		)
+		writeRegistrarErr(w, err, registrarName, domain)
+		return
+	}
+
+	// 3) Read back to confirm. Optional — providers vary in their
+	//    propagation lag for read-after-write. Empty result is fine
+	//    when the provider doesn't honour read-after-write.
+	confirmed, _ := dnsAdapter.GetDNSRecords(ctx, token, domain)
+
+	h.Log.Info("registrar set-dns: ok",
+		"registrar", registrarName,
+		"domain", domain,
+		"record_count_requested", len(records),
+		"record_count_confirmed", len(confirmed),
+	)
+	writeJSON(w, http.StatusOK, SetDNSResponse{
+		Success:     true,
+		Registrar:   registrarName,
+		Domain:      domain,
+		Records:     confirmed,
+		Propagation: propagationHint(registrarName),
+	})
+}
+
+// validateRecords runs the structural checks that don't need a
+// network round-trip. Returns an empty string when all records are
+// well-formed, or a human-readable reason when one isn't.
+func validateRecords(records []registrar.DNSRecord) string {
+	if len(records) == 0 {
+		return "records must be a non-empty array"
+	}
+	supported := map[string]bool{
+		"A": true, "AAAA": true, "CNAME": true, "MX": true, "TXT": true,
+	}
+	for i, rec := range records {
+		t := strings.ToUpper(strings.TrimSpace(rec.Type))
+		if !supported[t] {
+			return "record[" + itoa(i) + "].type must be one of A/AAAA/CNAME/MX/TXT (got " + rec.Type + ")"
+		}
+		if strings.TrimSpace(rec.Value) == "" {
+			return "record[" + itoa(i) + "].value is required"
+		}
+		if t == "MX" && rec.Priority < 0 {
+			return "record[" + itoa(i) + "].priority must be >= 0 for MX records"
+		}
+		if rec.TTL < 0 {
+			return "record[" + itoa(i) + "].ttl must be >= 0"
+		}
+	}
+	return ""
+}
+
+// itoa avoids importing strconv just for the validator's error
+// strings — the validator runs once per request so the trade-off is
+// fine for keeping the import set minimal.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/core/pool-domain-manager/internal/handler/setdns_test.go
+++ b/core/pool-domain-manager/internal/handler/setdns_test.go
@@ -1,0 +1,150 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	registrar "github.com/openova-io/openova/core/pool-domain-manager/internal/registrar"
+)
+
+// fakeDNSAdapter is the fakeAdapter + DNSRegistrar conformance.
+type fakeDNSAdapter struct {
+	fakeAdapter
+	dnsErr     error
+	gotRecords []registrar.DNSRecord
+	storedSet  []registrar.DNSRecord
+}
+
+func (f *fakeDNSAdapter) SetDNSRecords(ctx context.Context, token, domain string, records []registrar.DNSRecord) error {
+	f.gotToken = token
+	f.gotDomain = domain
+	f.gotRecords = records
+	if f.dnsErr != nil {
+		return f.dnsErr
+	}
+	f.storedSet = records
+	return nil
+}
+
+func (f *fakeDNSAdapter) GetDNSRecords(ctx context.Context, token, domain string) ([]registrar.DNSRecord, error) {
+	return f.storedSet, nil
+}
+
+// Compile-time conformance check.
+var _ registrar.DNSRegistrar = (*fakeDNSAdapter)(nil)
+
+func doSetDNS(t *testing.T, h *Handler, registrarName string, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Route("/registrar/{registrar}", func(r chi.Router) {
+			r.Post("/set-dns", h.SetDNS)
+		})
+	})
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/registrar/"+registrarName+"/set-dns", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+// newDNSTestHandler wires a fakeDNSAdapter into a Handler.
+func newDNSTestHandler(t *testing.T, adapter *fakeDNSAdapter) *Handler {
+	t.Helper()
+	log, _ := captureLogger()
+	h := &Handler{Log: log}
+	h.SetRegistry(registrar.Registry{adapter.name: adapter})
+	return h
+}
+
+func TestSetDNS_HappyPath(t *testing.T) {
+	a := &fakeDNSAdapter{fakeAdapter: fakeAdapter{name: "dynadot"}}
+	h := newDNSTestHandler(t, a)
+
+	body := `{
+		"domain": "example.com",
+		"token": "` + supersecretToken + `",
+		"records": [
+			{"subhost": "", "type": "A", "value": "1.2.3.4", "ttl": 3600},
+			{"subhost": "www", "type": "CNAME", "value": "example.com."},
+			{"subhost": "", "type": "MX", "value": "mail.example.com", "priority": 10},
+			{"subhost": "_acme-challenge", "type": "TXT", "value": "abc123"}
+		]
+	}`
+	rec := doSetDNS(t, h, "dynadot", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if len(a.gotRecords) != 4 {
+		t.Errorf("adapter saw %d records, want 4", len(a.gotRecords))
+	}
+	if a.gotDomain != "example.com" {
+		t.Errorf("adapter saw domain %q, want example.com", a.gotDomain)
+	}
+}
+
+func TestSetDNS_UnsupportedRegistrar_501(t *testing.T) {
+	// fakeAdapter (without DNSRegistrar mixin) → 501 Not Implemented.
+	a := &fakeAdapter{name: "godaddy"}
+	log, _ := captureLogger()
+	h := &Handler{Log: log}
+	h.SetRegistry(registrar.Registry{a.name: a})
+
+	body := `{"domain":"example.com","token":"x","records":[{"type":"A","value":"1.2.3.4"}]}`
+	rec := doSetDNS(t, h, "godaddy", body)
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d body=%s, want 501", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "set-dns-not-supported") {
+		t.Errorf("body missing error key, got %s", rec.Body.String())
+	}
+}
+
+func TestSetDNS_UnknownRegistrar_404(t *testing.T) {
+	a := &fakeDNSAdapter{fakeAdapter: fakeAdapter{name: "dynadot"}}
+	h := newDNSTestHandler(t, a)
+	body := `{"domain":"example.com","token":"x","records":[{"type":"A","value":"1.2.3.4"}]}`
+	rec := doSetDNS(t, h, "neverheard", body)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestSetDNS_BadRecordType_422(t *testing.T) {
+	a := &fakeDNSAdapter{fakeAdapter: fakeAdapter{name: "dynadot"}}
+	h := newDNSTestHandler(t, a)
+	body := `{"domain":"example.com","token":"x","records":[{"type":"SRV","value":"x"}]}`
+	rec := doSetDNS(t, h, "dynadot", body)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d body=%s, want 422", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "invalid-records") {
+		t.Errorf("body missing error key, got %s", rec.Body.String())
+	}
+}
+
+func TestSetDNS_EmptyRecords_422(t *testing.T) {
+	a := &fakeDNSAdapter{fakeAdapter: fakeAdapter{name: "dynadot"}}
+	h := newDNSTestHandler(t, a)
+	body := `{"domain":"example.com","token":"x","records":[]}`
+	rec := doSetDNS(t, h, "dynadot", body)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", rec.Code)
+	}
+}
+
+func TestSetDNS_MissingDomain_422(t *testing.T) {
+	a := &fakeDNSAdapter{fakeAdapter: fakeAdapter{name: "dynadot"}}
+	h := newDNSTestHandler(t, a)
+	body := `{"domain":"","token":"x","records":[{"type":"A","value":"1.2.3.4"}]}`
+	rec := doSetDNS(t, h, "dynadot", body)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", rec.Code)
+	}
+}

--- a/core/pool-domain-manager/internal/registrar/dynadot/setdns.go
+++ b/core/pool-domain-manager/internal/registrar/dynadot/setdns.go
@@ -1,0 +1,223 @@
+// SetDNSRecords / GetDNSRecords — implements registrar.DNSRegistrar
+// for Dynadot using the set_dns2 + domain_info commands.
+//
+// Dynadot's set_dns2 command separates record types by scope:
+//   - main_record_typeN / main_record_valueN / main_record_ttlN
+//     → records on the root of the zone (@)
+//   - sub_record_typeN / sub_recordN / sub_record_valueN / sub_record_ttlN
+//     → records on a subdomain (the sub_recordN field carries the
+//       leftmost label(s))
+//   - mx_priorityN → MX priority parallel to the *_record arrays
+//
+// The implementation packs the caller's []DNSRecord into these
+// parallel arrays. SetDNSRecords is a full REPLACE — any record
+// not in the caller's list is removed from Dynadot's zone, per the
+// SetDNSRecords contract documented in registrar.go.
+
+package dynadot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/openova-io/openova/core/pool-domain-manager/internal/registrar"
+)
+
+// SetDNSRecords implements registrar.DNSRegistrar.
+//
+// Wire shape (subset, ordered by Dynadot api3.json):
+//
+//	command            = "set_dns2"
+//	domain             = <fqdn>
+//	main_record_typeN  = A | AAAA | CNAME | MX | TXT   (root records)
+//	main_record_valueN = <data>                         (per type)
+//	main_record_ttlN   = <seconds>                      (0 → default)
+//	mx_priority0       = <int>                          (only when type=MX)
+//	sub_recordN        = <leftmost-label>               (subdomain records)
+//	sub_record_typeN   = A | AAAA | CNAME | MX | TXT
+//	sub_record_valueN  = <data>
+//	sub_record_ttlN    = <seconds>
+//	sub_mx_priorityN   = <int>                          (only when type=MX)
+func (a *Adapter) SetDNSRecords(ctx context.Context, token, domain string, records []registrar.DNSRecord) error {
+	key, secret, err := parseToken(token)
+	if err != nil {
+		return err
+	}
+
+	params := url.Values{}
+	params.Set("key", key)
+	params.Set("secret", secret)
+	params.Set("command", "set_dns2")
+	params.Set("domain", domain)
+
+	var mainIdx, subIdx int
+	for _, rec := range records {
+		t := strings.ToUpper(strings.TrimSpace(rec.Type))
+		sub := strings.ToLower(strings.TrimSpace(rec.Subhost))
+		val := strings.TrimSpace(rec.Value)
+		if val == "" {
+			return fmt.Errorf("dynadot: record value is required (type=%s subhost=%q)", t, sub)
+		}
+		if sub == "" || sub == "@" {
+			// Root record — main_record_*
+			params.Set(fmt.Sprintf("main_record_type%d", mainIdx), t)
+			params.Set(fmt.Sprintf("main_record%d", mainIdx), val)
+			if rec.TTL > 0 {
+				params.Set(fmt.Sprintf("main_record_ttl%d", mainIdx), itoa(rec.TTL))
+			}
+			if t == "MX" {
+				params.Set(fmt.Sprintf("main_mx_priority%d", mainIdx), itoa(rec.Priority))
+			}
+			mainIdx++
+			continue
+		}
+		// Subdomain record — sub_record_*
+		params.Set(fmt.Sprintf("sub_record%d", subIdx), sub)
+		params.Set(fmt.Sprintf("sub_record_type%d", subIdx), t)
+		params.Set(fmt.Sprintf("sub_record_value%d", subIdx), val)
+		if rec.TTL > 0 {
+			params.Set(fmt.Sprintf("sub_record_ttl%d", subIdx), itoa(rec.TTL))
+		}
+		if t == "MX" {
+			params.Set(fmt.Sprintf("sub_mx_priority%d", subIdx), itoa(rec.Priority))
+		}
+		subIdx++
+	}
+
+	body, err := a.do(ctx, params)
+	if err != nil {
+		return err
+	}
+	// set_dns2 live response shape per Dynadot api3.json docs:
+	//   {"SetDns2Response":{"ResponseCode":0,"Status":"success"}}
+	var raw struct {
+		SetDns2Response struct {
+			respHeader
+		} `json:"SetDns2Response"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return fmt.Errorf("dynadot: parse set_dns2: %w", err)
+	}
+	return classifyDynadotError(raw.SetDns2Response.respHeader)
+}
+
+// GetDNSRecords reads back the current record set via Dynadot's
+// `domain_info` command. The response includes a NameServerSettings
+// block + a DnsType / Records block. We translate the per-record
+// Dynadot shape into the provider-agnostic registrar.DNSRecord.
+//
+// Returns an empty slice (not nil, not error) when the zone has no
+// records — that's a valid state for a fresh domain.
+func (a *Adapter) GetDNSRecords(ctx context.Context, token, domain string) ([]registrar.DNSRecord, error) {
+	key, secret, err := parseToken(token)
+	if err != nil {
+		return nil, err
+	}
+
+	params := url.Values{}
+	params.Set("key", key)
+	params.Set("secret", secret)
+	params.Set("command", "domain_info")
+	params.Set("domain", domain)
+
+	body, err := a.do(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	// domain_info response shape (subset):
+	//   {"DomainInfoResponse": {
+	//      "ResponseCode": 0,
+	//      "DomainInfoContent": {
+	//        "NameServerSettings": {
+	//          "Type": "Dynadot DNS",
+	//          "MainDomains": [{ "RecordType": "A", "Value": "1.2.3.4", "Ttl": 3600 }, ...],
+	//          "Subdomains":  [{ "Subhost": "www", "RecordType": "CNAME", "Value": "example.com", "Ttl": 3600 }, ...]
+	//        }
+	//      }
+	//   }}
+	var raw struct {
+		DomainInfoResponse struct {
+			respHeader
+			DomainInfoContent struct {
+				NameServerSettings struct {
+					MainDomains []struct {
+						RecordType string      `json:"RecordType"`
+						Value      string      `json:"Value"`
+						Ttl        json.Number `json:"Ttl"`
+						MxPriority json.Number `json:"MxPriority"`
+					} `json:"MainDomains"`
+					Subdomains []struct {
+						Subhost    string      `json:"Subhost"`
+						RecordType string      `json:"RecordType"`
+						Value      string      `json:"Value"`
+						Ttl        json.Number `json:"Ttl"`
+						MxPriority json.Number `json:"MxPriority"`
+					} `json:"Subdomains"`
+				} `json:"NameServerSettings"`
+			} `json:"DomainInfoContent"`
+		} `json:"DomainInfoResponse"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("dynadot: parse domain_info: %w", err)
+	}
+	if e := classifyDynadotError(raw.DomainInfoResponse.respHeader); e != nil {
+		return nil, e
+	}
+
+	settings := raw.DomainInfoResponse.DomainInfoContent.NameServerSettings
+	out := make([]registrar.DNSRecord, 0, len(settings.MainDomains)+len(settings.Subdomains))
+	for _, m := range settings.MainDomains {
+		ttl, _ := m.Ttl.Int64()
+		prio, _ := m.MxPriority.Int64()
+		out = append(out, registrar.DNSRecord{
+			Subhost:  "",
+			Type:     strings.ToUpper(m.RecordType),
+			Value:    m.Value,
+			TTL:      int(ttl),
+			Priority: int(prio),
+		})
+	}
+	for _, s := range settings.Subdomains {
+		ttl, _ := s.Ttl.Int64()
+		prio, _ := s.MxPriority.Int64()
+		out = append(out, registrar.DNSRecord{
+			Subhost:  s.Subhost,
+			Type:     strings.ToUpper(s.RecordType),
+			Value:    s.Value,
+			TTL:      int(ttl),
+			Priority: int(prio),
+		})
+	}
+	return out, nil
+}
+
+// itoa avoids importing strconv just for the URL-param encoding —
+// the encoder runs once per record so the trade-off is minimal.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// Compile-time check that *Adapter implements DNSRegistrar.
+var _ registrar.DNSRegistrar = (*Adapter)(nil)

--- a/core/pool-domain-manager/internal/registrar/dynadot/setdns_test.go
+++ b/core/pool-domain-manager/internal/registrar/dynadot/setdns_test.go
@@ -1,0 +1,161 @@
+package dynadot
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/openova-io/openova/core/pool-domain-manager/internal/registrar"
+)
+
+// TestSetDNSRecords_HappyPath — verifies the URL params Dynadot's
+// set_dns2 sees match the records we passed. Root-vs-subdomain split
+// uses the main_record_* vs sub_record_* arrays per api3.json.
+func TestSetDNSRecords_HappyPath(t *testing.T) {
+	var captured url.Values
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.Query()
+		// canonical set_dns2 success envelope
+		_, _ = w.Write([]byte(`{"SetDns2Response":{"ResponseCode":0,"Status":"success"}}`))
+	})
+
+	records := []registrar.DNSRecord{
+		{Subhost: "", Type: "A", Value: "1.2.3.4", TTL: 3600},
+		{Subhost: "www", Type: "CNAME", Value: "example.com.", TTL: 600},
+		{Subhost: "", Type: "MX", Value: "mail.example.com", Priority: 10},
+		{Subhost: "_acme-challenge", Type: "TXT", Value: "abc123def"},
+	}
+	if err := a.SetDNSRecords(context.Background(), "key:secret", "example.com", records); err != nil {
+		t.Fatalf("SetDNSRecords: %v", err)
+	}
+
+	if got := captured.Get("command"); got != "set_dns2" {
+		t.Errorf("command = %q, want set_dns2", got)
+	}
+	if got := captured.Get("domain"); got != "example.com" {
+		t.Errorf("domain = %q, want example.com", got)
+	}
+	// Root A
+	if got := captured.Get("main_record_type0"); got != "A" {
+		t.Errorf("main_record_type0 = %q, want A", got)
+	}
+	if got := captured.Get("main_record0"); got != "1.2.3.4" {
+		t.Errorf("main_record0 = %q, want 1.2.3.4", got)
+	}
+	if got := captured.Get("main_record_ttl0"); got != "3600" {
+		t.Errorf("main_record_ttl0 = %q, want 3600", got)
+	}
+	// Root MX (after the A) — index 1 in main_record_*
+	if got := captured.Get("main_record_type1"); got != "MX" {
+		t.Errorf("main_record_type1 = %q, want MX", got)
+	}
+	if got := captured.Get("main_mx_priority1"); got != "10" {
+		t.Errorf("main_mx_priority1 = %q, want 10", got)
+	}
+	// Subdomain CNAME — first sub_record_* slot (index 0)
+	if got := captured.Get("sub_record0"); got != "www" {
+		t.Errorf("sub_record0 = %q, want www", got)
+	}
+	if got := captured.Get("sub_record_type0"); got != "CNAME" {
+		t.Errorf("sub_record_type0 = %q, want CNAME", got)
+	}
+	// Subdomain TXT — second sub_record_* slot (index 1)
+	if got := captured.Get("sub_record1"); got != "_acme-challenge" {
+		t.Errorf("sub_record1 = %q, want _acme-challenge", got)
+	}
+	if got := captured.Get("sub_record_value1"); got != "abc123def" {
+		t.Errorf("sub_record_value1 = %q, want abc123def", got)
+	}
+}
+
+// TestSetDNSRecords_DynadotError — error envelope maps to ErrInvalidToken.
+func TestSetDNSRecords_DynadotError(t *testing.T) {
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"SetDns2Response":{"ResponseCode":"-1","Status":"error","Error":"login failed"}}`))
+	})
+	err := a.SetDNSRecords(context.Background(), "key:secret", "example.com",
+		[]registrar.DNSRecord{{Subhost: "", Type: "A", Value: "1.2.3.4"}})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+// TestGetDNSRecords_HappyPath — domain_info response with both main +
+// subdomain records gets parsed into a flat []DNSRecord. Subhost ""
+// for main records, populated for subdomain records.
+func TestGetDNSRecords_HappyPath(t *testing.T) {
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("command"); got != "domain_info" {
+			t.Errorf("command = %q, want domain_info", got)
+		}
+		_, _ = w.Write([]byte(`{
+			"DomainInfoResponse": {
+				"ResponseCode": 0,
+				"Status": "success",
+				"DomainInfoContent": {
+					"NameServerSettings": {
+						"MainDomains": [
+							{"RecordType": "A", "Value": "1.2.3.4", "Ttl": 3600, "MxPriority": 0},
+							{"RecordType": "MX", "Value": "mail.example.com", "Ttl": 3600, "MxPriority": 10}
+						],
+						"Subdomains": [
+							{"Subhost": "www", "RecordType": "CNAME", "Value": "example.com.", "Ttl": 600, "MxPriority": 0},
+							{"Subhost": "_acme-challenge", "RecordType": "TXT", "Value": "abc", "Ttl": 60, "MxPriority": 0}
+						]
+					}
+				}
+			}
+		}`))
+	})
+	got, err := a.GetDNSRecords(context.Background(), "key:secret", "example.com")
+	if err != nil {
+		t.Fatalf("GetDNSRecords: %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("got %d records, want 4", len(got))
+	}
+	// First two are MainDomains → empty Subhost
+	if got[0].Subhost != "" || got[0].Type != "A" || got[0].Value != "1.2.3.4" {
+		t.Errorf("MainDomains[0] mismatch: %+v", got[0])
+	}
+	if got[1].Type != "MX" || got[1].Priority != 10 {
+		t.Errorf("MainDomains[1] MX/priority mismatch: %+v", got[1])
+	}
+	// Next two are Subdomains → populated Subhost
+	if got[2].Subhost != "www" || got[2].Type != "CNAME" {
+		t.Errorf("Subdomains[0] mismatch: %+v", got[2])
+	}
+	if got[3].Subhost != "_acme-challenge" || got[3].Type != "TXT" {
+		t.Errorf("Subdomains[1] mismatch: %+v", got[3])
+	}
+}
+
+// TestGetDNSRecords_EmptyZone — a freshly-created domain with no
+// records should return an empty (non-nil) slice + no error.
+func TestGetDNSRecords_EmptyZone(t *testing.T) {
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"DomainInfoResponse": {
+				"ResponseCode": 0,
+				"Status": "success",
+				"DomainInfoContent": {
+					"NameServerSettings": {
+						"MainDomains": [],
+						"Subdomains": []
+					}
+				}
+			}
+		}`))
+	})
+	got, err := a.GetDNSRecords(context.Background(), "key:secret", "example.com")
+	if err != nil {
+		t.Fatalf("GetDNSRecords: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected non-nil empty slice, got nil")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 records, got %d", len(got))
+	}
+}

--- a/core/pool-domain-manager/internal/registrar/namecheap/setdns.go
+++ b/core/pool-domain-manager/internal/registrar/namecheap/setdns.go
@@ -1,0 +1,171 @@
+// SetDNSRecords / GetDNSRecords — implements registrar.DNSRegistrar
+// for Namecheap using the namecheap.domains.dns.setHosts +
+// namecheap.domains.dns.getHosts XML API.
+//
+// Wire shape per https://www.namecheap.com/support/api/methods/domains-dns/set-hosts/
+//
+//   POST  ?ApiUser=<u>&ApiKey=<k>&UserName=<u>&ClientIp=<ip>
+//        &Command=namecheap.domains.dns.setHosts
+//        &SLD=<example>
+//        &TLD=<com>
+//        &HostName1=@        &RecordType1=A      &Address1=1.2.3.4   &TTL1=3600
+//        &HostName2=www      &RecordType2=CNAME  &Address2=example.com.
+//        &HostName3=@        &RecordType3=MX     &Address3=mail.example.com   &MXPref3=10
+//        &HostName4=_acme-challenge   &RecordType4=TXT   &Address4=abc123
+//
+// Namecheap REQUIRES the domain to be using Namecheap's NameServers
+// (the default "PrivateEmail" / "BasicDNS" setting) for setHosts to
+// take effect. If the customer's SetNameservers list points elsewhere,
+// setHosts returns an error from the Namecheap side.
+
+package namecheap
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/openova-io/openova/core/pool-domain-manager/internal/registrar"
+)
+
+// SetDNSRecords implements registrar.DNSRegistrar.
+func (a *Adapter) SetDNSRecords(ctx context.Context, token, domain string, records []registrar.DNSRecord) error {
+	c, err := parseToken(token)
+	if err != nil {
+		return err
+	}
+	sld, tld, err := splitDomain(domain)
+	if err != nil {
+		return err
+	}
+
+	params := url.Values{}
+	params.Set("SLD", sld)
+	params.Set("TLD", tld)
+
+	for i, rec := range records {
+		t := strings.ToUpper(strings.TrimSpace(rec.Type))
+		val := strings.TrimSpace(rec.Value)
+		if val == "" {
+			return fmt.Errorf("namecheap: record value is required (idx=%d type=%s)", i, t)
+		}
+		host := strings.TrimSpace(rec.Subhost)
+		if host == "" {
+			host = "@"
+		}
+		// 1-indexed per Namecheap API.
+		n := strconv.Itoa(i + 1)
+		params.Set("HostName"+n, host)
+		params.Set("RecordType"+n, t)
+		params.Set("Address"+n, val)
+		if rec.TTL > 0 {
+			params.Set("TTL"+n, strconv.Itoa(rec.TTL))
+		}
+		if t == "MX" {
+			params.Set("MXPref"+n, strconv.Itoa(rec.Priority))
+			params.Set("EmailType", "MX")
+		}
+	}
+
+	body, err := a.do(ctx, c, "namecheap.domains.dns.setHosts", params)
+	if err != nil {
+		return err
+	}
+	var env errResponse
+	if err := xml.Unmarshal(body, &env); err != nil {
+		return fmt.Errorf("namecheap: parse setHosts: %w", err)
+	}
+	return classifyEnvelope(env)
+}
+
+// GetDNSRecords reads via namecheap.domains.dns.getHosts.
+func (a *Adapter) GetDNSRecords(ctx context.Context, token, domain string) ([]registrar.DNSRecord, error) {
+	c, err := parseToken(token)
+	if err != nil {
+		return nil, err
+	}
+	sld, tld, err := splitDomain(domain)
+	if err != nil {
+		return nil, err
+	}
+	params := url.Values{}
+	params.Set("SLD", sld)
+	params.Set("TLD", tld)
+	body, err := a.do(ctx, c, "namecheap.domains.dns.getHosts", params)
+	if err != nil {
+		return nil, err
+	}
+
+	// getHosts response shape:
+	//   <ApiResponse Status="OK">
+	//     <CommandResponse>
+	//       <DomainDNSGetHostsResult ...>
+	//         <host Name="@" Type="A"  Address="1.2.3.4" TTL="3600" MXPref="10"/>
+	//         <host Name="www" Type="CNAME" Address="example.com." TTL="600"/>
+	//         ...
+	//       </DomainDNSGetHostsResult>
+	//     </CommandResponse>
+	//   </ApiResponse>
+	var raw struct {
+		XMLName xml.Name `xml:"ApiResponse"`
+		Status  string   `xml:"Status,attr"`
+		Errors  struct {
+			Error []struct {
+				Number string `xml:"Number,attr"`
+				Value  string `xml:",chardata"`
+			} `xml:"Error"`
+		} `xml:"Errors"`
+		CommandResponse struct {
+			Result struct {
+				Hosts []struct {
+					Name    string `xml:"Name,attr"`
+					Type    string `xml:"Type,attr"`
+					Address string `xml:"Address,attr"`
+					TTL     string `xml:"TTL,attr"`
+					MXPref  string `xml:"MXPref,attr"`
+				} `xml:"host"`
+			} `xml:"DomainDNSGetHostsResult"`
+		} `xml:"CommandResponse"`
+	}
+	if err := xml.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("namecheap: parse getHosts: %w", err)
+	}
+	if strings.ToUpper(raw.Status) != "OK" {
+		// Build an errResponse inline so we can re-use classifyEnvelope.
+		var env errResponse
+		env.Status = raw.Status
+		for _, e := range raw.Errors.Error {
+			env.Errors.Error = append(env.Errors.Error, struct {
+				Number string `xml:"Number,attr"`
+				Value  string `xml:",chardata"`
+			}{Number: e.Number, Value: e.Value})
+		}
+		if e := classifyEnvelope(env); e != nil {
+			return nil, e
+		}
+	}
+
+	out := make([]registrar.DNSRecord, 0, len(raw.CommandResponse.Result.Hosts))
+	for _, h := range raw.CommandResponse.Result.Hosts {
+		sub := h.Name
+		if sub == "@" {
+			sub = ""
+		}
+		ttl, _ := strconv.Atoi(h.TTL)
+		prio, _ := strconv.Atoi(h.MXPref)
+		out = append(out, registrar.DNSRecord{
+			Subhost:  sub,
+			Type:     strings.ToUpper(h.Type),
+			Value:    h.Address,
+			TTL:      ttl,
+			Priority: prio,
+		})
+	}
+	return out, nil
+}
+
+// Compile-time interface check.
+var _ registrar.DNSRegistrar = (*Adapter)(nil)

--- a/core/pool-domain-manager/internal/registrar/namecheap/setdns_test.go
+++ b/core/pool-domain-manager/internal/registrar/namecheap/setdns_test.go
@@ -1,0 +1,133 @@
+package namecheap
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/openova-io/openova/core/pool-domain-manager/internal/registrar"
+)
+
+// TestSetDNSRecords_HappyPath — verifies the setHosts URL params
+// Namecheap's API sees match the records we passed.
+func TestSetDNSRecords_HappyPath(t *testing.T) {
+	var captured url.Values
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.Query()
+		// canonical setHosts success envelope
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+<Errors/>
+<CommandResponse Type="namecheap.domains.dns.setHosts">
+<DomainDNSSetHostsResult Domain="example.com" IsSuccess="true"/>
+</CommandResponse>
+</ApiResponse>`))
+	})
+
+	records := []registrar.DNSRecord{
+		{Subhost: "", Type: "A", Value: "1.2.3.4", TTL: 3600},
+		{Subhost: "www", Type: "CNAME", Value: "example.com."},
+		{Subhost: "", Type: "MX", Value: "mail.example.com", Priority: 10},
+		{Subhost: "_acme-challenge", Type: "TXT", Value: "abc123"},
+	}
+	err := a.SetDNSRecords(context.Background(),
+		"user:apikey:user:127.0.0.1", "example.com", records)
+	if err != nil {
+		t.Fatalf("SetDNSRecords: %v", err)
+	}
+
+	if got := captured.Get("Command"); got != "namecheap.domains.dns.setHosts" {
+		t.Errorf("Command = %q, want setHosts", got)
+	}
+	if got := captured.Get("SLD"); got != "example" {
+		t.Errorf("SLD = %q, want example", got)
+	}
+	if got := captured.Get("TLD"); got != "com" {
+		t.Errorf("TLD = %q, want com", got)
+	}
+	// 1-indexed per Namecheap convention
+	if got := captured.Get("HostName1"); got != "@" {
+		t.Errorf("HostName1 = %q, want @", got)
+	}
+	if got := captured.Get("RecordType1"); got != "A" {
+		t.Errorf("RecordType1 = %q, want A", got)
+	}
+	if got := captured.Get("Address1"); got != "1.2.3.4" {
+		t.Errorf("Address1 = %q, want 1.2.3.4", got)
+	}
+	if got := captured.Get("HostName2"); got != "www" {
+		t.Errorf("HostName2 = %q, want www", got)
+	}
+	if got := captured.Get("RecordType3"); got != "MX" {
+		t.Errorf("RecordType3 = %q, want MX", got)
+	}
+	if got := captured.Get("MXPref3"); got != "10" {
+		t.Errorf("MXPref3 = %q, want 10", got)
+	}
+	if got := captured.Get("HostName4"); got != "_acme-challenge" {
+		t.Errorf("HostName4 = %q, want _acme-challenge", got)
+	}
+}
+
+// TestGetDNSRecords_HappyPath — getHosts XML round-trips into a flat
+// []DNSRecord.
+func TestGetDNSRecords_HappyPath(t *testing.T) {
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("Command"); got != "namecheap.domains.dns.getHosts" {
+			t.Errorf("Command = %q, want getHosts", got)
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK">
+<Errors/>
+<CommandResponse Type="namecheap.domains.dns.getHosts">
+<DomainDNSGetHostsResult Domain="example.com">
+<host HostId="1" Name="@" Type="A" Address="1.2.3.4" TTL="3600" MXPref="10"/>
+<host HostId="2" Name="www" Type="CNAME" Address="example.com." TTL="600"/>
+<host HostId="3" Name="@" Type="MX" Address="mail.example.com" TTL="3600" MXPref="10"/>
+<host HostId="4" Name="_acme-challenge" Type="TXT" Address="abc" TTL="60"/>
+</DomainDNSGetHostsResult>
+</CommandResponse>
+</ApiResponse>`))
+	})
+	got, err := a.GetDNSRecords(context.Background(),
+		"user:apikey:user:127.0.0.1", "example.com")
+	if err != nil {
+		t.Fatalf("GetDNSRecords: %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("got %d records, want 4", len(got))
+	}
+	// '@' maps to empty Subhost
+	if got[0].Subhost != "" {
+		t.Errorf("got[0].Subhost = %q, want empty", got[0].Subhost)
+	}
+	if got[0].Type != "A" || got[0].Value != "1.2.3.4" {
+		t.Errorf("got[0] mismatch: %+v", got[0])
+	}
+	if got[1].Subhost != "www" || got[1].Type != "CNAME" {
+		t.Errorf("got[1] mismatch: %+v", got[1])
+	}
+	if got[2].Type != "MX" || got[2].Priority != 10 {
+		t.Errorf("got[2] MX mismatch: %+v", got[2])
+	}
+}
+
+// TestSetDNSRecords_NamecheapError — error envelope maps to non-nil error.
+func TestSetDNSRecords_NamecheapError(t *testing.T) {
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="ERROR">
+<Errors><Error Number="1011102">API Key is invalid</Error></Errors>
+</ApiResponse>`))
+	})
+	err := a.SetDNSRecords(context.Background(),
+		"user:apikey:user:127.0.0.1", "example.com",
+		[]registrar.DNSRecord{{Subhost: "", Type: "A", Value: "1.2.3.4"}})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a record-level DNS write surface to pool-domain-manager.

Currently the registrar surface only exposes `SetNameservers` (NS delegation) and `GlueRegistrar` (out-of-bailiwick NS hosts at Dynadot). Neither lets a Sovereign write raw A/AAAA/CNAME/MX/TXT records at the registrar's own nameservers.

After this PR, a Sovereign that hasn't delegated DNS away can write MX/SPF/DKIM records for mail verification, or `_acme-challenge` TXT records for ACME DNS-01 challenge, without flipping the NS delegation.

## Commits

| SHA | What |
|---|---|
| `b4386504` | `registrar.DNSRegistrar` interface + `DNSRecord` shape |
| `5b24f052` | HTTP handler at `POST /api/v1/registrar/{r}/set-dns` |
| `40ab15d3` | Dynadot adapter: `SetDNSRecords` + `GetDNSRecords` via `set_dns2` + `domain_info` |

## Wire shape

```
POST /api/v1/registrar/dynadot/set-dns
{
  \"domain\": \"example.com\",
  \"token\": \"<dynadot key:secret>\",
  \"records\": [
    {\"subhost\": \"\", \"type\": \"A\", \"value\": \"1.2.3.4\", \"ttl\": 3600},
    {\"subhost\": \"www\", \"type\": \"CNAME\", \"value\": \"example.com\"},
    {\"subhost\": \"\", \"type\": \"MX\", \"value\": \"mail.example.com\", \"priority\": 10},
    {\"subhost\": \"_acme-challenge\", \"type\": \"TXT\", \"value\": \"abc123\"}
  ]
}
```

## Privacy / safety

- Token-redaction discipline matches `SetNS`: never logs the request body; logs `{registrar, domain, record_count, outcome}` only.
- Same typed error mapping (`ErrInvalidToken` → 401, `ErrDomainNotInAccount` → 403, `ErrRateLimited` → 429, `ErrAPIUnavailable` → 502).
- Adapters that don't implement `DNSRegistrar` return 501 — operator should delegate DNS away via `/set-ns` instead.

## Tests

- Dynadot adapter tests forthcoming in a follow-up commit on this branch (httptest fake serving the `set_dns2` + `domain_info` response shapes).
- Handler-level integration test wired into the existing `internal/handler/*_test.go` harness.

## Refs

- chepherd/chepherd#36 — \"v0.2: upstream PR — pool-domain-manager 'set-dns' endpoint (generic DNS records, not just NS)\"

## Test plan

- [ ] CI green
- [ ] Dynadot adapter unit tests (next commit)
- [ ] Manual smoke against staging Dynadot account