### PR TITLE
fix(opentelemetry): bp-opentelemetry 1.1.2 — replicaCount at root, resources under manager (Wave 5.39)

### DIFF
--- a/clusters/_template/bootstrap-kit/20-opentelemetry.yaml
+++ b/clusters/_template/bootstrap-kit/20-opentelemetry.yaml
@@ -61,7 +61,7 @@ spec:
   chart:
     spec:
       chart: bp-opentelemetry
-      version: 1.1.1
+      version: 1.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-opentelemetry

--- a/clusters/otech.omani.works/bootstrap-kit/20-opentelemetry.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/20-opentelemetry.yaml
@@ -59,7 +59,7 @@ spec:
   chart:
     spec:
       chart: bp-opentelemetry
-      version: 1.1.1
+      version: 1.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-opentelemetry

--- a/platform/opentelemetry/blueprint.yaml
+++ b/platform/opentelemetry/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-observability
 spec:
-  version: 1.1.1
+  version: 1.1.2
   card:
     title: OpenTelemetry Collector + Operator
     family: insights

--- a/platform/opentelemetry/chart/Chart.yaml
+++ b/platform/opentelemetry/chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   OTLP traffic from in-cluster apps) — DaemonSet / StatefulSet are values
   toggles for node-level collection / WAL persistence respectively.
 type: application
-version: 1.1.1
+version: 1.1.2
 appVersion: "0.150.1"
 keywords: [catalyst, blueprint, opentelemetry, otlp, observability, telemetry, collector, operator, instrumentation]
 maintainers:

--- a/platform/opentelemetry/chart/values.yaml
+++ b/platform/opentelemetry/chart/values.yaml
@@ -106,6 +106,10 @@ opentelemetry-collector:
 # CRs" gap.
 opentelemetry-operator:
   enabled: true
+  # Replica count for the operator-controller-manager Deployment.
+  # Upstream chart key is `replicaCount` at the ROOT of the subchart's
+  # values (NOT `replicas`, NOT under `manager.*`). Wave 5.39 fix.
+  replicaCount: 1
   manager:
     image:
       repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
@@ -113,11 +117,11 @@ opentelemetry-operator:
     collectorImage:
       repository: otel/opentelemetry-collector-contrib
       tag: "0.150.1"
-    # Modest defaults at solo-Sovereign scale. The upstream chart's JSON
-    # schema rejects `resources` + `replicaCount` at root — they live
-    # under `manager.*` (Wave 5.38 fix; CI failed Helm template smoke
-    # render on 1.1.0 with "Additional property resources is not allowed").
-    replicas: 1
+    # Resources for the manager container.
+    # Upstream schema places `resources` under `manager:` (NOT at root).
+    # Wave 5.36 placed it at root → schema rejected. Wave 5.38 also moved
+    # replicas under manager which is ALSO rejected. Wave 5.39 fix:
+    # resources under manager.resources, replicaCount stays at root.
     resources:
       limits:
         cpu: 200m


### PR DESCRIPTION
## Summary

Wave 5.38 (PR #2220) over-corrected the Wave 5.36 schema issue. Re-reading the original error carefully:

```
opentelemetry-operator:
- (root): Additional property resources is not allowed
```

Only `resources` was rejected at root — `replicaCount` was always fine. Wave 5.38 moved BOTH under `manager` AND renamed `replicaCount` → `replicas`. Upstream schema rejects `replicas` under manager too:

```
opentelemetry-operator:
- manager: Additional property replicas is not allowed
```

## Correct shape (Wave 5.39)

| Key | Location |
|---|---|
| `replicaCount: 1` | ROOT of opentelemetry-operator: subchart |
| `manager.resources: {limits, requests}` | under `manager.*` |

## Lockstep bump 1.1.1 → 1.1.2

| File | Change |
|---|---|
| `platform/opentelemetry/chart/values.yaml` | `replicas: 1` (under manager) → `replicaCount: 1` (at root) |
| `platform/opentelemetry/chart/Chart.yaml` | 1.1.1 → 1.1.2 |
| `platform/opentelemetry/blueprint.yaml` | 1.1.1 → 1.1.2 |
| `clusters/_template/bootstrap-kit/20-opentelemetry.yaml` | 1.1.1 → 1.1.2 |
| `clusters/otech.omani.works/bootstrap-kit/20-opentelemetry.yaml` | 1.1.1 → 1.1.2 |

## DoD

- Blueprint Release CI `Helm template smoke render` PASSES
- bp-opentelemetry:1.1.2 published to GHCR
- hw01 next deploy → opentelemetry-operator + Instrumentation CRD installed

Refs #1094
Refs #2221

🤖 Generated with [Claude Code](https://claude.com/claude-code)