### PR TITLE
fix(opentelemetry): Instrumentation CR as Helm post-install hook (Wave 5.40)

### DIFF
--- a/clusters/_template/bootstrap-kit/20-opentelemetry.yaml
+++ b/clusters/_template/bootstrap-kit/20-opentelemetry.yaml
@@ -61,7 +61,7 @@ spec:
   chart:
     spec:
       chart: bp-opentelemetry
-      version: 1.1.2
+      version: 1.1.3
       sourceRef:
         kind: HelmRepository
         name: bp-opentelemetry

--- a/clusters/otech.omani.works/bootstrap-kit/20-opentelemetry.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/20-opentelemetry.yaml
@@ -59,7 +59,7 @@ spec:
   chart:
     spec:
       chart: bp-opentelemetry
-      version: 1.1.2
+      version: 1.1.3
       sourceRef:
         kind: HelmRepository
         name: bp-opentelemetry

--- a/platform/opentelemetry/blueprint.yaml
+++ b/platform/opentelemetry/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-observability
 spec:
-  version: 1.1.2
+  version: 1.1.3
   card:
     title: OpenTelemetry Collector + Operator
     family: insights

--- a/platform/opentelemetry/chart/Chart.yaml
+++ b/platform/opentelemetry/chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   OTLP traffic from in-cluster apps) — DaemonSet / StatefulSet are values
   toggles for node-level collection / WAL persistence respectively.
 type: application
-version: 1.1.2
+version: 1.1.3
 appVersion: "0.150.1"
 keywords: [catalyst, blueprint, opentelemetry, otlp, observability, telemetry, collector, operator, instrumentation]
 maintainers:

--- a/platform/opentelemetry/chart/templates/default-instrumentation.yaml
+++ b/platform/opentelemetry/chart/templates/default-instrumentation.yaml
@@ -31,6 +31,17 @@ metadata:
   labels:
     catalyst.openova.io/blueprint: bp-opentelemetry
     catalyst.openova.io/component: default-instrumentation
+  annotations:
+    # Apply this CR via a Helm post-install/post-upgrade hook so it lands
+    # AFTER the opentelemetry-operator subchart's manifests (including the
+    # Instrumentation CRD) are deployed AND the Operator pod has reconciled
+    # the CRD into the API server. Without these hooks, on first install
+    # OR on upgrade from <1.1.0, Helm tries to apply this CR before the
+    # CRD is registered → "no matches for kind Instrumentation". Wave 5.40
+    # surfaced this on hw01 during Wave 5.36 walk.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   exporter:
     endpoint: {{ $inst.exporterEndpoint | quote }}


### PR DESCRIPTION
## Summary

UAT walk of #2215 on hw01 (2026-05-24T01:28Z) surfaced HR upgrade failure after Wave 5.39 (#2222) made bp-opentelemetry:1.1.2 available:

```
$ kubectl get hr bp-opentelemetry -n flux-system -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}'
Helm upgrade failed for release opentelemetry/opentelemetry with chart bp-opentelemetry@1.1.2:
resource mapping not found for name: "default" namespace: "opentelemetry" from "":
no matches for kind "Instrumentation" in version "opentelemetry.io/v1alpha1"
ensure CRDs are installed first
```

## Root cause

Helm 3 does NOT install subchart CRDs on UPGRADE (only on first install). bp-opentelemetry was originally installed at 1.0.0 (no Operator subchart). When it upgrades to 1.1.x:
1. Helm tries to apply the rendered manifests including the Catalyst overlay's `Instrumentation` CR
2. But the `Instrumentation` CRD ships via the Operator subchart's `crds/` dir (not auto-applied on upgrade)
3. API server has no mapping for `kind: Instrumentation` → release rolls back → Operator never deploys

## Fix (Wave 5.40)

Annotate `templates/default-instrumentation.yaml` as a Helm post-install/post-upgrade hook with weight 10. Helm applies hooks AFTER the regular release manifests reconcile, including the Operator subchart's CRD setup (which the Operator pod auto-installs).

```yaml
metadata:
  annotations:
    helm.sh/hook: post-install,post-upgrade
    helm.sh/hook-weight: "10"
    helm.sh/hook-delete-policy: before-hook-creation
```

## Changes (lockstep 1.1.2 → 1.1.3)

| File | Change |
|---|---|
| `platform/opentelemetry/chart/templates/default-instrumentation.yaml` | Add Helm post-install/post-upgrade hook annotations |
| `platform/opentelemetry/chart/Chart.yaml` | 1.1.2 → 1.1.3 |
| `platform/opentelemetry/blueprint.yaml` | 1.1.2 → 1.1.3 |
| `clusters/_template/bootstrap-kit/20-opentelemetry.yaml` | 1.1.2 → 1.1.3 |
| `clusters/otech.omani.works/bootstrap-kit/20-opentelemetry.yaml` | 1.1.2 → 1.1.3 |

## DoD (re-walk #2215 after merge)

- bp-opentelemetry:1.1.3 published to GHCR
- hw01 HR upgrade succeeds (no more "no matches for kind Instrumentation")
- `kubectl get crd | grep instrumentation` returns `instrumentations.opentelemetry.io`
- `kubectl get instrumentation -n opentelemetry default` returns the rendered CR
- `kubectl get pods -n opentelemetry` shows opentelemetry-operator-controller-manager Running

Refs #1094
Refs #2224
Refs #2215

🤖 Generated with [Claude Code](https://claude.com/claude-code)