### PR TITLE
fix(bootstrap-kit): add slot 19c-opentelemetry-operator.yaml to kustomization resources (Wave 5.41b)

### DIFF
--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -72,6 +72,12 @@ resources:
   # bp-harbor (slot 19). Chart installs DORMANT — catalyst-api stamps
   # Jobs only on operator-driven cutover trigger.
   - 06a-bp-self-sovereign-cutover.yaml
+  # bp-opentelemetry-operator (slot 19c) — Wave 5.41 chart-split (#2227).
+  # Installs Operator + Instrumentation CRD BEFORE bp-opentelemetry (slot
+  # 20) creates the Catalyst default Instrumentation CR. Eliminates the
+  # Helm-3-doesn't-install-subchart-CRDs-on-upgrade race that broke hw01
+  # across Waves 5.36/5.38/5.39/5.40.
+  - 19c-opentelemetry-operator.yaml
   - 20-opentelemetry.yaml
   - 21-alloy.yaml
   - 22-loki.yaml


### PR DESCRIPTION
Trivial follow-up to Wave 5.41 (PR #2229): the new slot 19c file was on disk but missing from kustomization.yaml's explicit resources list. hw01 Flux reconciled at the latest SHA but never applied the new HR → bp-opentelemetry stuck on unresolved dependsOn. Refs #2227 Refs #2215.