### PR TITLE
fix(bootstrap-kit): dedup Namespace opentelemetry — owned by slot 19c (Wave 5.41c)

### DIFF
--- a/clusters/_template/bootstrap-kit/20-opentelemetry.yaml
+++ b/clusters/_template/bootstrap-kit/20-opentelemetry.yaml
@@ -24,13 +24,10 @@
 # accept exports. The HelmRelease itself reports Ready as soon as
 # manifests apply cleanly; runtime convergence is observed via kubectl.
 
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: opentelemetry
-  labels:
-    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+# Namespace `opentelemetry` is declared by slot 19c
+# (19c-opentelemetry-operator.yaml). Wave 5.41 chart-split moved the
+# Namespace there since 19c installs first. Kustomize forbids duplicate
+# Namespace resources across the resources: list.
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/clusters/otech.omani.works/bootstrap-kit/20-opentelemetry.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/20-opentelemetry.yaml
@@ -24,13 +24,8 @@
 # accept exports. The HelmRelease itself reports Ready as soon as
 # manifests apply cleanly; runtime convergence is observed via kubectl.
 
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: opentelemetry
-  labels:
-    catalyst.openova.io/sovereign: otech.omani.works
+# Namespace `opentelemetry` is declared by slot 19c
+# (19c-opentelemetry-operator.yaml). Wave 5.41 chart-split moved it.
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository


### PR DESCRIPTION
Wave 5.41 chart-split (PR #2229) + 5.41b kustomization-add (PR #2230) caused kustomize duplicate Namespace error on hw01. Removing duplicate from slot 20; Namespace ownership stays with slot 19c. Refs #2227 Refs #2215.