### PR TITLE
feat(compliance): wire NATS JetStream KV publisher for policy-rollup (Wave 5.44)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1890,13 +1890,21 @@ func newCompliancePolicyRollupPublisherFromEnv(log *slog.Logger) handler.PolicyR
 		return nil
 	}
 	bucket := env("CATALYST_NATS_KV_POLICY_ROLLUP_BUCKET", "policy-rollup")
+	source := env("CATALYST_SOURCE_FQDN", env("HOSTNAME", "catalyst-api"))
+	// Wave 5.44 (#2251) wired the real NATS JetStream KV publisher via
+	// internal/natspub — replacing the prior nil-returning stub. nats.go
+	// landed in catalyst-api's go.mod via TBD-D35c PR #1918 (the same
+	// dependency that backs sandbox_publisher.go).
+	p, err := natspub.NewComplianceRollupPublisher(url, bucket, source, log,
+		handler.IncrementComplianceNATSPublishFailure)
+	if err != nil {
+		log.Warn("compliance: NATS KV publisher init failed — falling back to best-effort (SSE+Prometheus only)",
+			"url", url, "bucket", bucket, "err", err)
+		return nil
+	}
 	log.Info("compliance: NATS KV publisher wired",
-		"url", url, "bucket", bucket,
-	)
-	// The actual NATS client is wired by a follow-up slice that
-	// imports nats.go. This stub keeps the wiring contract intact
-	// without forcing a Go-module dependency in this slice.
-	return nil
+		"url", url, "bucket", bucket, "source", source)
+	return p
 }
 
 // newComplianceEnvironmentPolicyResolverFromEnv builds a dynamic-

--- a/products/catalyst/bootstrap/api/internal/handler/compliance.go
+++ b/products/catalyst/bootstrap/api/internal/handler/compliance.go
@@ -2273,7 +2273,28 @@ var (
 		Name:      "policy_mode",
 		Help:      "1 for the active mode, 0 for inactive, per (policy, environment, sovereign, mode).",
 	}, []string{"policy", "environment", "sovereign", "mode"})
+
+	// catalyst_compliance_nats_publish_failures_total — counts every
+	// NATS JetStream KV publish failure from the rollup publisher
+	// (internal/natspub/compliance_rollup_publisher.go). Wave 5.44
+	// (#2251) — audit finding #5: before this, publish failures
+	// were warn-logged only, so operators had no /metrics signal
+	// beyond log scraping. Bumped via IncrementComplianceNATSPublishFailure.
+	metricComplianceNATSPublishFailures = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "catalyst",
+		Subsystem: "compliance",
+		Name:      "nats_publish_failures_total",
+		Help:      "Total NATS JetStream KV publish failures from the compliance rollup publisher.",
+	})
 )
+
+// IncrementComplianceNATSPublishFailure bumps the publish-failure
+// counter. Exported so natspub.ComplianceRollupPublisher can wire it
+// via the onPublishFailure callback without importing the prometheus
+// registry. Wave 5.44 (#2251).
+func IncrementComplianceNATSPublishFailure() {
+	metricComplianceNATSPublishFailures.Inc()
+}
 
 // complianceObserve records the score gauge + per-policy violation
 // counter increments for one Score publish.

--- a/products/catalyst/bootstrap/api/internal/natspub/compliance_rollup_publisher.go
+++ b/products/catalyst/bootstrap/api/internal/natspub/compliance_rollup_publisher.go
@@ -1,0 +1,179 @@
+// Package natspub — compliance_rollup_publisher.go: concrete NATS JetStream
+// KV binding for the compliance aggregator's `policy-rollup` history per
+// ADR-0001 §3.
+//
+// Provenance: Wave 5.44 (#2251) follow-up to the audit finding that
+// `main.go:1884-1900` `newCompliancePolicyRollupPublisherFromEnv` returned
+// nil unconditionally even when `CATALYST_NATS_URL` was set, with the
+// comment "actual NATS client is wired by a follow-up slice that imports
+// nats.go". This is that follow-up slice. nats.go landed in catalyst-api's
+// go.mod via TBD-D35c (PR #1918 chain → sandbox_publisher.go); the same
+// dependency now backs this KV publisher.
+//
+// Why JetStream KV (not core publish like sandbox_publisher.go):
+//
+//   - The aggregator needs REPLAYABLE history — operators reopening
+//     /compliance/scorecard after a catalyst-api restart expect the most
+//     recent score, not a recompute lag from k8scache rehydration. KV's
+//     latest-value-per-key semantics map directly.
+//   - SSE consumers can replay by ListKeys + Get on startup; core
+//     publish + at-most-once would lose this.
+//   - The aggregator's Put rate is low (one per scope-change event, not
+//     per K8s event) so JetStream's per-message overhead is negligible.
+//
+// Bucket name `policy-rollup` is fixed per ADR-0001 §3 + EPIC #1096 step 6.
+// Provisioning of the bucket itself lives in bp-nats-jetstream's chart
+// (slice H4); this publisher is consumer-side and auto-creates the bucket
+// on first Put if missing (idempotent — re-create on existing returns
+// success).
+package natspub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler"
+)
+
+// jsKV is the minimal `nats.KeyValue` surface the publisher uses. The
+// interface lets unit tests substitute a fake without bringing up an
+// embedded NATS+JetStream server (mirrors the sandbox_publisher.go
+// fake-only test style — see compliance_rollup_publisher_test.go).
+type jsKV interface {
+	// Put writes value at key. Mirrors `nats.KeyValue`.Put — returns
+	// the revision on success, error on broker / auth failure.
+	Put(key string, value []byte) (uint64, error)
+}
+
+// ComplianceRollupPublisher implements handler.PolicyRollupPublisher
+// against a NATS JetStream KV bucket. The zero value is NOT useable —
+// construct via NewComplianceRollupPublisher.
+type ComplianceRollupPublisher struct {
+	kv     jsKV
+	log    *slog.Logger
+	bucket string
+
+	// publish-failure counter for the catalyst_compliance_nats_publish_
+	// failures_total metric (audit finding #5). Wired by the handler
+	// package's metric registration in compliance.go; we just bump it
+	// on every Put error so an operator gets a /metrics signal beyond
+	// the warn-log.
+	onFailure func()
+
+	// Read at startup; never mutated. Used in log lines to disambiguate
+	// multi-Sovereign mothership operation.
+	source string
+
+	// connClose is invoked by Close. Set when this publisher owns the
+	// underlying connection (production wiring); left nil when an
+	// already-open connection is injected.
+	closeMu sync.Mutex
+	connClose func()
+}
+
+// Compile-time assertion that the impl satisfies the handler interface.
+var _ handler.PolicyRollupPublisher = (*ComplianceRollupPublisher)(nil)
+
+// NewComplianceRollupPublisher dials NATS at url, opens (or creates) the
+// JetStream KV bucket, and returns a ready publisher. Caller owns Close.
+//
+// onPublishFailure is a callback invoked on every Put error so the caller
+// can bump a Prometheus counter without coupling natspub to the metrics
+// registry. Pass nil to skip.
+//
+// Returns (nil, err) on dial / JetStream / bucket-open failure; the
+// caller should log + fall back to a nil PolicyRollupPublisher (the
+// aggregator runs in best-effort mode without replayable history).
+func NewComplianceRollupPublisher(
+	url string,
+	bucket string,
+	source string,
+	log *slog.Logger,
+	onPublishFailure func(),
+) (*ComplianceRollupPublisher, error) {
+	if url == "" {
+		return nil, errors.New("natspub: CATALYST_NATS_URL is empty")
+	}
+	if bucket == "" {
+		bucket = "policy-rollup"
+	}
+	nc, err := nats.Connect(url,
+		nats.Name(fmt.Sprintf("catalyst-api/compliance-rollup/%s", source)),
+		nats.Timeout(10*time.Second),
+		nats.ReconnectWait(2*time.Second),
+		nats.MaxReconnects(-1),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("natspub: nats.Connect: %w", err)
+	}
+	js, err := nc.JetStream()
+	if err != nil {
+		nc.Close()
+		return nil, fmt.Errorf("natspub: nc.JetStream: %w", err)
+	}
+	kv, err := js.KeyValue(bucket)
+	if err != nil {
+		// Bucket not provisioned yet — try create. Idempotent on retry
+		// (CreateKeyValue returns the existing handle if it already
+		// exists with matching config).
+		kv, err = js.CreateKeyValue(&nats.KeyValueConfig{
+			Bucket:      bucket,
+			Description: "catalyst-api compliance score rollup history (ADR-0001 §3)",
+			History:     5, // keep last 5 revisions per key for short-window replay
+			Storage:     nats.FileStorage,
+		})
+		if err != nil {
+			nc.Close()
+			return nil, fmt.Errorf("natspub: open/create KV %q: %w", bucket, err)
+		}
+	}
+	p := &ComplianceRollupPublisher{
+		kv:        kv,
+		log:       log.With("component", "compliance-rollup-publisher", "bucket", bucket),
+		bucket:    bucket,
+		onFailure: onPublishFailure,
+		source:    source,
+		connClose: nc.Close,
+	}
+	p.log.Info("NATS KV publisher ready", "url", url, "source", source)
+	return p, nil
+}
+
+// Put writes value at key. Errors are logged + counted but never
+// propagated to the aggregator — a transient NATS outage must NEVER
+// wedge the in-process scorecard hot path (per compliance.go:944-959
+// best-effort contract).
+//
+// Returning the error here would surface it to the handler's
+// recomputeAndPublish which logs+continues; this method does the same
+// in-line so the failure-counter increments at the source.
+func (p *ComplianceRollupPublisher) Put(ctx context.Context, key string, value []byte) error {
+	if p == nil || p.kv == nil {
+		return errors.New("natspub: publisher closed")
+	}
+	if _, err := p.kv.Put(key, value); err != nil {
+		p.log.Warn("KV Put failed", "key", key, "err", err)
+		if p.onFailure != nil {
+			p.onFailure()
+		}
+		return fmt.Errorf("natspub: kv.Put %q: %w", key, err)
+	}
+	return nil
+}
+
+// Close terminates the underlying NATS connection. Safe to call
+// multiple times.
+func (p *ComplianceRollupPublisher) Close() {
+	p.closeMu.Lock()
+	defer p.closeMu.Unlock()
+	if p.connClose != nil {
+		p.connClose()
+		p.connClose = nil
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/natspub/compliance_rollup_publisher_test.go
+++ b/products/catalyst/bootstrap/api/internal/natspub/compliance_rollup_publisher_test.go
@@ -1,0 +1,97 @@
+package natspub
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+)
+
+// fakeKV implements jsKV with controllable Put behavior + invocation
+// recording so tests can verify Put-call shape + failure-path metric.
+type fakeKV struct {
+	puts      []fakeKVPut
+	putErr    error
+	putCalled int
+}
+
+type fakeKVPut struct {
+	key   string
+	value []byte
+}
+
+func (f *fakeKV) Put(key string, value []byte) (uint64, error) {
+	f.putCalled++
+	if f.putErr != nil {
+		return 0, f.putErr
+	}
+	f.puts = append(f.puts, fakeKVPut{key: key, value: append([]byte(nil), value...)})
+	return uint64(len(f.puts)), nil
+}
+
+func newTestPublisher(t *testing.T, kv jsKV, onFailure func()) *ComplianceRollupPublisher {
+	t.Helper()
+	return &ComplianceRollupPublisher{
+		kv:        kv,
+		log:       slog.Default(),
+		bucket:    "policy-rollup",
+		onFailure: onFailure,
+		source:    "test",
+	}
+}
+
+func TestPut_HappyPath_WritesToKV(t *testing.T) {
+	kv := &fakeKV{}
+	p := newTestPublisher(t, kv, nil)
+
+	err := p.Put(context.Background(), "sovereign-hw01.omani.works",
+		[]byte(`{"score":46,"numerator":274,"denominator":592}`))
+	if err != nil {
+		t.Fatalf("Put returned err: %v", err)
+	}
+	if kv.putCalled != 1 {
+		t.Errorf("Put called %d times; want 1", kv.putCalled)
+	}
+	if got := kv.puts[0].key; got != "sovereign-hw01.omani.works" {
+		t.Errorf("key=%q; want sovereign-hw01.omani.works", got)
+	}
+}
+
+func TestPut_KVError_LogsAndBumpsFailureCounter(t *testing.T) {
+	kv := &fakeKV{putErr: errors.New("nats: connection lost")}
+	failures := 0
+	p := newTestPublisher(t, kv, func() { failures++ })
+
+	err := p.Put(context.Background(), "app:keycloak", []byte(`{"score":44}`))
+	if err == nil {
+		t.Fatal("Put returned nil err; want wrapped kv error")
+	}
+	if failures != 1 {
+		t.Errorf("failure callback fired %d times; want 1", failures)
+	}
+}
+
+func TestPut_NilCallback_SafeOnError(t *testing.T) {
+	kv := &fakeKV{putErr: errors.New("broker stalled")}
+	p := newTestPublisher(t, kv, nil) // no callback
+
+	if err := p.Put(context.Background(), "k", []byte("v")); err == nil {
+		t.Fatal("expected err propagation")
+	}
+	// no panic → pass
+}
+
+func TestPut_NilPublisher_ReturnsClosedError(t *testing.T) {
+	var p *ComplianceRollupPublisher
+	if err := p.Put(context.Background(), "k", []byte("v")); err == nil {
+		t.Fatal("nil receiver Put should error")
+	}
+}
+
+func TestNewComplianceRollupPublisher_EmptyURL_Errors(t *testing.T) {
+	_, err := NewComplianceRollupPublisher("", "policy-rollup", "test",
+		slog.Default(), nil)
+	if err == nil {
+		t.Fatal("expected error for empty URL")
+	}
+}


### PR DESCRIPTION
## Summary

EPIC #1096 Group C step 3 + ADR-0001 §3 mandated a NATS `policy-rollup` KV bucket for replayable compliance score history. Audit (2026-05-24T04:46Z) found `main.go:1884-1900` newCompliancePolicyRollupPublisherFromEnv returning **nil unconditionally** with the comment *"actual NATS client is wired by a follow-up slice that imports nats.go"*. This PR IS that follow-up slice — nats.go landed in catalyst-api's go.mod via TBD-D35c PR #1918.

## Changes

| File | Change |
|---|---|
| `products/catalyst/bootstrap/api/internal/natspub/compliance_rollup_publisher.go` (NEW) | Concrete `ComplianceRollupPublisher` implementing `handler.PolicyRollupPublisher` against nats.go JetStream KeyValue. Auto-creates bucket on first Put if absent (idempotent). |
| `products/catalyst/bootstrap/api/internal/natspub/compliance_rollup_publisher_test.go` (NEW) | 5 table tests: happy path / KV error / nil callback / nil publisher / empty URL. All pass with fake jsKV. |
| `products/catalyst/bootstrap/api/internal/handler/compliance.go` | Add `metricComplianceNATSPublishFailures` Counter + exported `IncrementComplianceNATSPublishFailure` hook (closes audit finding #5). |
| `products/catalyst/bootstrap/api/cmd/api/main.go` | Replace nil-returning stub with `natspub.NewComplianceRollupPublisher` call; wire `CATALYST_NATS_URL` + `CATALYST_NATS_KV_POLICY_ROLLUP_BUCKET` + `CATALYST_SOURCE_FQDN`/`HOSTNAME` envs + `IncrementComplianceNATSPublishFailure` callback. |

## DoD (live verification on next hw01 deploy)

- `kubectl exec -n nats-jetstream nats-jetstream-0 -- nats kv get policy-rollup --all` returns recent score rows
- Restart catalyst-api → `/compliance/scorecard` replays same values from KV (no recompute lag)
- `/metrics` exposes `catalyst_compliance_nats_publish_failures_total`

Refs #1096
Refs #2251

🤖 Generated with [Claude Code](https://claude.com/claude-code)