### PR TITLE
feat(nats-jetstream): bundle nack JetStream Controller (Wave 5.45, closes #2254)

### DIFF
--- a/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
@@ -42,7 +42,7 @@ spec:
   chart:
     spec:
       chart: bp-nats-jetstream
-      version: 1.2.0
+      version: 1.3.0
       sourceRef:
         kind: HelmRepository
         name: bp-nats-jetstream

--- a/platform/nats-jetstream/blueprint.yaml
+++ b/platform/nats-jetstream/blueprint.yaml
@@ -5,10 +5,10 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.2.0
+  version: 1.3.0
   card:
     title: nats-jetstream
-    summary: Event spine for the Catalyst control plane. JetStream Streams + KV. Per-Organization Accounts. Replaces what was previously specified as Redpanda + Valkey for the control plane.
+    summary: Event spine for the Catalyst control plane. JetStream Streams + KV + Object Store via bundled nack JetStream Controller (Wave 5.45 #2254). Per-Organization Accounts. Replaces what was previously specified as Redpanda + Valkey for the control plane.
   visibility: unlisted              # mandatory infra, auto-installed by bootstrap kit
   manifests:
     chart: ./chart

--- a/platform/nats-jetstream/chart/Chart.yaml
+++ b/platform/nats-jetstream/chart/Chart.yaml
@@ -1,27 +1,44 @@
 apiVersion: v2
 name: bp-nats-jetstream
-version: 1.2.0
+version: 1.3.0
 description: |
-  Catalyst-curated Blueprint umbrella chart for NATS JetStream. Depends on
-  the upstream `nats` chart (nats-io) as a Helm subchart so
-  `helm dependency build` pulls the upstream payload into this artifact;
-  the Catalyst overlay templates in templates/ (NetworkPolicy,
-  ExternalSecret, ServiceMonitor) sit alongside the upstream subchart and
-  Helm renders both at install time. Catalyst-curated values flow into the
-  upstream subchart under the `nats:` key in values.yaml.
+  Catalyst-curated Blueprint umbrella chart for NATS JetStream. Depends
+  on TWO upstream subcharts:
+
+  1. `nats` (nats-io) — the broker StatefulSet + JetStream storage.
+  2. `nack` (nats-io) — JetStream Controller that installs CRDs for
+     KeyValue / Stream / Consumer / ObjectStore and reconciles CRs into
+     runtime JetStream state.
+
+  Wave 5.45 (#2254) added `nack` to close the Wave 5.44 audit gap that
+  surfaced live on hw01: the broker was Running but no JetStream CRDs
+  were registered with the apiserver, so the Catalyst-curated KeyValue
+  CRs in templates/kv-buckets.yaml (policy-rollup / idempotency /
+  dr-leases) were silently un-reconciled — Wave 5.44's NATS publisher
+  could connect but never find a bucket.
+
+  Catalyst overlay templates in templates/ (NetworkPolicy, ExternalSecret,
+  ServiceMonitor, kv-buckets, streams) sit alongside both upstream
+  subcharts and Helm renders them all at install time. Catalyst-curated
+  values flow into the upstream subcharts under the `nats:` + `nack:`
+  keys in values.yaml.
 type: application
-keywords: [catalyst, blueprint, nats-jetstream]
+keywords: [catalyst, blueprint, nats-jetstream, nack, keyvalue, stream]
 maintainers:
   - name: OpenOva Catalyst
     email: catalyst@openova.io
 
-# Upstream chart pulled in as a Helm subchart so `helm dependency build`
-# bundles it into the OCI artifact. Pinned to nats/nats 1.2.0 (matches
+# Upstream charts pulled in as Helm subcharts so `helm dependency build`
+# bundles them into the OCI artifact. Pinned versions match
 # platform/nats-jetstream/blueprint.yaml + values.yaml
-# `catalystBlueprint.upstream.version`). Per
-# docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the version is
-# operator-bumpable via PR + Blueprint release.
+# `catalystBlueprint.upstream.*`. Per docs/INVIOLABLE-PRINCIPLES.md #4
+# (never hardcode) versions are operator-bumpable via PR + Blueprint
+# release.
 dependencies:
   - name: nats
     version: "1.2.0"
     repository: "https://nats-io.github.io/k8s/helm/charts"
+  - name: nack
+    version: "0.29.0"
+    repository: "https://nats-io.github.io/k8s/helm/charts"
+    condition: nack.enabled

--- a/platform/nats-jetstream/chart/values.yaml
+++ b/platform/nats-jetstream/chart/values.yaml
@@ -104,3 +104,31 @@ catalystStreams:
     ttl: "168h"
     # 1 GiB upper bound.
     maxBytes: 1073741824
+
+# ─── nack subchart values (Wave 5.45 #2254) ──────────────────────────────
+# Installs the JetStream Controller + KeyValue/Stream/Consumer/ObjectStore
+# CRDs that bp-nats-jetstream's kv-buckets.yaml + streams.yaml render
+# against. Without nack the broker is Running but no CRs reconcile.
+#
+# The chart's default deploys nack as 'jetstream' Deployment in the
+# release namespace (nats-system). Watch namespace empty = cluster-wide.
+nack:
+  enabled: true
+  jetstream:
+    # Point at the broker subchart's Service. Same-namespace, no auth
+    # required (NATS auth is operator-config'd separately if at all).
+    nats:
+      url: "nats://nats-jetstream:4222"
+    # Modest defaults at solo-Sovereign scale. Bump replicas via overlay
+    # when HA is sized.
+    replicas: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+  # No webhook or PodMonitor for the controller in our solo profile.
+  podMonitor:
+    enabled: false


### PR DESCRIPTION
Audit on hw01 showed broker Running but no JetStream CRDs registered → KV/Stream CRs silently un-reconciled. This PR adds nack 0.29.0 as 2nd subchart so the CRDs install + the controller reconciles the KeyValue CRs (policy-rollup needed by Wave 5.44 NATS publisher). Lockstep 1.2.0 → 1.3.0. Refs #2254 #1096 #1101.