### PR TITLE
feat(nats-jetstream): flip catalystStreams.enabled default true (Wave 5.50, closes #2278)

### DIFF
--- a/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
@@ -42,7 +42,7 @@ spec:
   chart:
     spec:
       chart: bp-nats-jetstream
-      version: 1.3.0
+      version: 1.3.1
       sourceRef:
         kind: HelmRepository
         name: bp-nats-jetstream

--- a/platform/nats-jetstream/blueprint.yaml
+++ b/platform/nats-jetstream/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.3.0
+  version: 1.3.1
   card:
     title: nats-jetstream
     summary: Event spine for the Catalyst control plane. JetStream Streams + KV + Object Store via bundled nack JetStream Controller (Wave 5.45 #2254). Per-Organization Accounts. Replaces what was previously specified as Redpanda + Valkey for the control plane.

--- a/platform/nats-jetstream/chart/Chart.yaml
+++ b/platform/nats-jetstream/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-nats-jetstream
-version: 1.3.0
+version: 1.3.1
 description: |
   Catalyst-curated Blueprint umbrella chart for NATS JetStream. Depends
   on TWO upstream subcharts:

--- a/platform/nats-jetstream/chart/values.yaml
+++ b/platform/nats-jetstream/chart/values.yaml
@@ -69,7 +69,16 @@ nats:
 # Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every retention
 # value is a variable and operator-overrideable.
 catalystStreams:
-  enabled: false
+  # Wave 5.50 (#2278) flipped default false -> true. Catalyst's compliance
+  # scorer (#1096 Wave 5.44 NATS KV publisher), idempotency keys
+  # (HTTP write paths), and DR-lease witness (#1101 Continuum) all
+  # depend on the 3 KV buckets that kv-buckets.yaml renders. Without
+  # this gate flipped, those buckets never materialise → Wave 5.44
+  # publisher Put auto-creates the bucket on first use but loses the
+  # chart-defined TTL/maxBytes config. Per-Sovereign overlays MAY set
+  # `false` to opt-out, but the default Sovereign experience requires
+  # these primitives.
+  enabled: true
   # JetStream replication factor. R=3 is the bank-tier default for
   # in-region quorum; the DR Mirror to a second region is a separate
   # follow-up wired by Continuum (#1101).


### PR DESCRIPTION
Single-line default flip unblocks Wave 5.44 KV publisher full DoD. Lockstep 1.3.0→1.3.1. Refs #1096 #2278 #2251.