### PR TITLE
fix(nats-jetstream): Stream spec.name dot-fix (Wave 5.51, closes #2280)

### DIFF
--- a/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
@@ -42,7 +42,7 @@ spec:
   chart:
     spec:
       chart: bp-nats-jetstream
-      version: 1.3.1
+      version: 1.3.2
       sourceRef:
         kind: HelmRepository
         name: bp-nats-jetstream

--- a/platform/nats-jetstream/blueprint.yaml
+++ b/platform/nats-jetstream/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.3.1
+  version: 1.3.2
   card:
     title: nats-jetstream
     summary: Event spine for the Catalyst control plane. JetStream Streams + KV + Object Store via bundled nack JetStream Controller (Wave 5.45 #2254). Per-Organization Accounts. Replaces what was previously specified as Redpanda + Valkey for the control plane.

--- a/platform/nats-jetstream/chart/Chart.yaml
+++ b/platform/nats-jetstream/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-nats-jetstream
-version: 1.3.1
+version: 1.3.2
 description: |
   Catalyst-curated Blueprint umbrella chart for NATS JetStream. Depends
   on TWO upstream subcharts:

--- a/platform/nats-jetstream/chart/templates/streams.yaml
+++ b/platform/nats-jetstream/chart/templates/streams.yaml
@@ -29,7 +29,10 @@ metadata:
   labels: {{- include "catalyst-nats.labels" . | nindent 4 }}
     catalyst.openova.io/stream: audit
 spec:
-  name: catalyst.audit
+  # Wave 5.51 (#2280): nack validates spec.name against ^[^.*>]*$ —
+  # no dots allowed in the Stream name. Subjects below keep dots
+  # (those use NATS subject hierarchy which is fine).
+  name: catalyst-audit
   servers:
     - {{ include "catalyst-nats.servers" . }}
   subjects:
@@ -53,7 +56,8 @@ metadata:
   labels: {{- include "catalyst-nats.labels" . | nindent 4 }}
     catalyst.openova.io/stream: events
 spec:
-  name: catalyst.events
+  # Wave 5.51 (#2280) dot-fix — see catalyst-audit above.
+  name: catalyst-events
   servers:
     - {{ include "catalyst-nats.servers" . }}
   subjects:
@@ -73,7 +77,8 @@ metadata:
   labels: {{- include "catalyst-nats.labels" . | nindent 4 }}
     catalyst.openova.io/stream: billing
 spec:
-  name: catalyst.billing
+  # Wave 5.51 (#2280) dot-fix — see catalyst-audit above.
+  name: catalyst-billing
   servers:
     - {{ include "catalyst-nats.servers" . }}
   subjects:


### PR DESCRIPTION
Pre-existing chart bug surfaced by Wave 5.45 nack validation. catalyst.X → catalyst-X spec.name. Lockstep 1.3.1→1.3.2. Refs #1096 #2280.