### PR TITLE
fix(nats-jetstream): sub-gate Streams default-OFF — CATALYST_SME overlap (Wave 5.52)

### DIFF
--- a/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
@@ -42,7 +42,7 @@ spec:
   chart:
     spec:
       chart: bp-nats-jetstream
-      version: 1.3.2
+      version: 1.3.3
       sourceRef:
         kind: HelmRepository
         name: bp-nats-jetstream

--- a/platform/nats-jetstream/blueprint.yaml
+++ b/platform/nats-jetstream/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.3.2
+  version: 1.3.3
   card:
     title: nats-jetstream
     summary: Event spine for the Catalyst control plane. JetStream Streams + KV + Object Store via bundled nack JetStream Controller (Wave 5.45 #2254). Per-Organization Accounts. Replaces what was previously specified as Redpanda + Valkey for the control plane.

--- a/platform/nats-jetstream/chart/Chart.yaml
+++ b/platform/nats-jetstream/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-nats-jetstream
-version: 1.3.2
+version: 1.3.3
 description: |
   Catalyst-curated Blueprint umbrella chart for NATS JetStream. Depends
   on TWO upstream subcharts:

--- a/platform/nats-jetstream/chart/templates/streams.yaml
+++ b/platform/nats-jetstream/chart/templates/streams.yaml
@@ -20,7 +20,18 @@ are NOT shipped here — they are created dynamically by organization-
 controller (slice C1) and application-controller (slice C4) at install
 time so they can scale per tenant.
 */}}
-{{- if .Values.catalystStreams.enabled -}}
+{{- /*
+  Wave 5.52 (#2283) gate: separately from catalystStreams.enabled (which
+  drives kv-buckets.yaml + the entire JetStream KV family), the 3
+  Stream CRs are gated on `streamsEnabled` because they architecturally
+  conflict with the in-code CATALYST_SME wildcard stream
+  (subjects `catalyst.>` declared in core/services/shared/events/nats.go).
+  Surfaced live on hw01 2026-05-24T06:30Z when both attempted to claim
+  overlapping subjects. Default-OFF preserves the current production
+  shape; operators opt-in only when migrating sme/billing to the 3-stream
+  model per original ADR-0001 §6 design.
+*/ -}}
+{{- if and .Values.catalystStreams.enabled .Values.catalystStreams.streamsEnabled -}}
 ---
 apiVersion: jetstream.nats.io/v1beta2
 kind: Stream

--- a/platform/nats-jetstream/chart/values.yaml
+++ b/platform/nats-jetstream/chart/values.yaml
@@ -79,6 +79,17 @@ catalystStreams:
   # `false` to opt-out, but the default Sovereign experience requires
   # these primitives.
   enabled: true
+  # Wave 5.52 (#2283) sub-gate: the 3 chart-managed Streams
+  # (catalyst-audit / catalyst-events / catalyst-billing) architecturally
+  # conflict with the in-code CATALYST_SME wildcard stream that
+  # core/services/shared/events/nats.go declares with subjects
+  # `catalyst.>`. Default-OFF preserves the current production shape
+  # (CATALYST_SME + FilterSubject consumers per t20 fix). Operators
+  # opt-in only when migrating sme/billing to the 3-stream model per
+  # original ADR-0001 §6 design. Surfaced live on hw01 2026-05-24T06:30Z
+  # when Wave 5.50 rolled chart 1.3.1 and both attempted to claim
+  # overlapping subjects → upgrade ROLLBACK fired.
+  streamsEnabled: false
   # JetStream replication factor. R=3 is the bank-tier default for
   # in-region quorum; the DR Mirror to a second region is a separate
   # follow-up wired by Continuum (#1101).


### PR DESCRIPTION
Path 1 smaller-change fix for CATALYST_SME subject overlap surfaced by Wave 5.50/5.51. Refs #2283 #1096.