### PR TITLE
fix(huawei-module): add SOVEREIGN_REGION_CANONICAL_LABEL substitute (Wave 5.56, closes #2296)

### DIFF
--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -266,6 +266,16 @@ write_files:
             # stuck "Establishing connection to apiserver
             # host=https://10.0.1.2:6443" then timeout.
             CILIUM_K8S_SERVICE_HOST: "${cp_private_ip}"
+            # Wave 5.56 (Refs #2296) — Sovereign-wide canonical region
+            # labels. 19a-bp-sandbox.yaml's hostCluster + 13-bp-catalyst-
+            # platform.yaml's primaryRegion both substitute these. Hetzner
+            # cloud-init port sets them; the Huawei port missed them.
+            # bp-sandbox HR upgrade fails with hostCluster MUST be set if
+            # SOVEREIGN_REGION_CANONICAL_LABEL is empty.
+            SOVEREIGN_REGION_CANONICAL_LABEL: "${region_canonical_label}"
+            QA_PRIMARY_REGION: "${primary_region_canonical_label}"
+            SOVEREIGN_PRIMARY_REGION: "${primary_region_canonical_label}"
+            SOVEREIGN_REPLICA_REGION: "${replica_region_canonical_label}"
 
   # ── Worker cloud-init for autoscaler (issue #921 analogue) ────────────
   - path: /var/lib/catalyst/worker-cloud-init.b64

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -538,6 +538,14 @@ locals {
     k3s_version         = var.k3s_version
     k3s_token           = sha256("${var.huawei_project_id}/${var.sovereign_fqdn}/k3s-bootstrap")
     cp_private_ip       = cidrhost(local.region_subnet_cidr[local.region_keys[0]], 2)
+    # Wave 5.56 (Refs #2296) — canonical region labels for the
+    # bootstrap-kit substitute map. Hetzner provider sets these; the
+    # Huawei port missed them, leaving bp-sandbox + downstream HRs
+    # stuck on empty hostCluster. Format mirrors Hetzner pattern:
+    # `hu-<region>-rtz-prod` for replica role, `-mgmt-prod` for primary.
+    region_canonical_label         = "hu-${var.regions[0].code}-rtz-prod"
+    primary_region_canonical_label = "hu-${var.regions[0].code}-rtz-prod"
+    replica_region_canonical_label = length(var.regions) > 1 ? "hu-${var.regions[1].code}-rtz-prod" : ""
     # Primary CP's EIP — Wave 5.8 (Refs #2140). The kubeconfig PUT-back
     # from cloud-init must use this EIP, not the private VPC IP, so the
     # remote mothership (cross-cloud Contabo) can reach the new


### PR DESCRIPTION
Single-block addition to Huawei cloud-init substitute map. Unblocks bp-sandbox on hw01. Refs #2296 #1094.