### PR TITLE
feat(bp-newapi): allow ingress from catalyst-system (Wave 5.57a)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -197,7 +197,7 @@ spec:
       # 1.4.41 — chore(privacy): rename the partner-named channel slot
       # to `qwenPartner` and strip partner identifiers from comments /
       # fixtures / Secret names.
-      version: 1.4.42
+      version: 1.4.43
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-6-llm-serving
 spec:
-  version: 1.4.42
+  version: 1.4.43
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -402,7 +402,7 @@ name: bp-newapi
 # `lookup valkey.valkey.svc.cluster.local: no such host`). Same hostname
 # already documented as canonical in products/catalyst/chart/values.yaml
 # bp-cnpg-pair comments.
-version: 1.4.42
+version: 1.4.43
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/networkpolicy.yaml
+++ b/platform/newapi/chart/templates/networkpolicy.yaml
@@ -17,6 +17,18 @@ spec:
         - namespaceSelector:
             matchLabels:
               {{- toYaml .Values.networkPolicy.ingress.fromNamespaceLabels | nindent 14 }}
+        {{- /* Wave 5.57a (#2299) — also allow ingress from additional
+              namespaces listed in .Values.networkPolicy.ingress.allowedFromNamespaces.
+              Catalyst Sovereigns route Cilium Gateway through HTTPRoute
+              hosts; sandbox-controller (catalyst-system) calls newapi
+              admin tokens API directly. Without this list-form, only
+              traefik NS could reach newapi. Each entry is a NS name
+              string; templated into a separate namespaceSelector entry. */}}
+        {{- range .Values.networkPolicy.ingress.allowedFromNamespaces }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . | quote }}
+        {{- end }}
       ports:
         - port: {{ .Values.newapi.port }}
           protocol: TCP

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -766,6 +766,14 @@ networkPolicy:
   ingress:
     fromNamespaceLabels:
       kubernetes.io/metadata.name: traefik
+    # Wave 5.57a (#2299) — additional namespaces allowed to call newapi
+    # ingress, rendered as additional namespaceSelector entries by the
+    # template. catalyst-system contains sandbox-controller which calls
+    # /admin/tokens/sandbox for per-Sandbox token mint. Operator can add
+    # more namespaces per-Sovereign overlay without overriding the
+    # primary fromNamespaceLabels.
+    allowedFromNamespaces:
+      - catalyst-system
   egress:
     # NOTE: bp-cnpg egress is NOT listed here — it is rendered
     # directly in templates/networkpolicy.yaml when `.Values.cnpg.enabled`


### PR DESCRIPTION
## Summary

Wave 5.57a — adds list-form `networkPolicy.ingress.allowedFromNamespaces` to bp-newapi chart so additional namespaces (catalyst-system by default) can call newapi's admin endpoints. Pre-fix, ingress was hardcoded to traefik only, so catalyst-api's sandbox-controller hit a NetworkPolicy drop when calling `/admin/tokens/sandbox` for per-Sandbox token mint.

## Changes (lockstep 1.4.42 -> 1.4.43)
- `platform/newapi/chart/templates/networkpolicy.yaml` — add `{{- range ... allowedFromNamespaces }}` block
- `platform/newapi/chart/values.yaml` — add default `allowedFromNamespaces: [catalyst-system]`
- `platform/newapi/chart/Chart.yaml` — version 1.4.42 -> 1.4.43
- `platform/newapi/blueprint.yaml` — spec.version 1.4.42 -> 1.4.43
- `clusters/_template/bootstrap-kit/80-newapi.yaml` — chart pin 1.4.42 -> 1.4.43

## Verification
- `helm template newapi platform/newapi/chart` renders BOTH `traefik` and `catalyst-system` namespaceSelectors under `ingress[0].from[]` on port 3000.

Refs #2299