### PR TITLE
feat(bp-newapi): sandbox-bridge sidecar (Wave 5.57)

### DIFF
--- a/.github/workflows/build-bp-newapi-sandbox-bridge.yaml
+++ b/.github/workflows/build-bp-newapi-sandbox-bridge.yaml
@@ -1,0 +1,144 @@
+name: Build bp-newapi sandbox-bridge
+
+# Builds the sandbox-bridge sidecar image — the Catalyst-side bridge
+# handler for POST /admin/tokens/sandbox (Wave 5.57, Refs #2303).
+#
+# Pre-Wave-5.57 the Go handler at platform/newapi/internal/handler/
+# was orphan code: complete implementation + unit tests + go.mod, but
+# no `cmd/main.go`, no Dockerfile, no CI workflow → never built into
+# an image → never deployed. The sandbox-controller posts to
+# `<newapiBaseURL>/admin/tokens/sandbox` and reached the upstream
+# Calcium-Ion binary, which has no such route and returns its default
+# HTML 404 page (the "decode response: invalid character '<'" failure
+# observed on hw01 2026-05-24).
+#
+# This workflow:
+#   1. Builds the Go binary from platform/newapi/internal/handler/cmd/
+#      sandbox-bridge using its co-located Dockerfile (multi-stage,
+#      distroless static base, nonroot user, :8080).
+#   2. Pushes to ghcr.io/openova-io/openova/newapi-sandbox-bridge tagged
+#      with the commit SHA + `latest`.
+#   3. Bumps platform/newapi/chart/values.yaml `sandboxBridge.image.tag`
+#      to the new SHA.
+#   4. Bumps platform/newapi/chart/Chart.yaml `version` patch level +
+#      dispatches blueprint-release so a fresh bp-newapi:<semver> OCI
+#      artifact carries the new sidecar tag.
+#
+# Triggers on any change under platform/newapi/internal/handler/** so
+# bridge-only PRs (no chart change) also re-publish the sidecar.
+
+on:
+  push:
+    paths:
+      - 'platform/newapi/internal/handler/**'
+      - '.github/workflows/build-bp-newapi-sandbox-bridge.yaml'
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  BRIDGE_IMAGE: ghcr.io/openova-io/openova/newapi-sandbox-bridge
+  BRIDGE_CTX: platform/newapi/internal/handler
+  CHART_VALUES: platform/newapi/chart/values.yaml
+  CHART_YAML: platform/newapi/chart/Chart.yaml
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      actions: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute image tag
+        id: tag
+        run: |
+          set -euo pipefail
+          short_sha="${GITHUB_SHA::7}"
+          echo "tag=${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "Will tag bridge image: ${BRIDGE_IMAGE}:${short_sha}"
+
+      - name: Build + push sandbox-bridge image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.BRIDGE_CTX }}
+          file: ${{ env.BRIDGE_CTX }}/Dockerfile
+          push: true
+          tags: |
+            ${{ env.BRIDGE_IMAGE }}:${{ steps.tag.outputs.tag }}
+            ${{ env.BRIDGE_IMAGE }}:latest
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Bump sandbox-bridge tag in values.yaml
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          yq eval -i ".sandboxBridge.image.repository = \"${BRIDGE_IMAGE}\"" "${CHART_VALUES}"
+          yq eval -i ".sandboxBridge.image.tag = \"${NEW_TAG}\"" "${CHART_VALUES}"
+          echo "values.yaml after update:"
+          yq eval '.sandboxBridge.image' "${CHART_VALUES}"
+
+      - name: Bump Chart.yaml patch version
+        run: |
+          set -euo pipefail
+          current=$(yq eval '.version' "${CHART_YAML}")
+          IFS='.' read -r major minor patch <<<"${current}"
+          next="${major}.${minor}.$((patch + 1))"
+          yq eval -i ".version = \"${next}\"" "${CHART_YAML}"
+          echo "Chart.yaml: version ${current} -> ${next}"
+          echo "CHART_NEW_VERSION=${next}" >> "$GITHUB_ENV"
+
+      - name: Commit and push chart bump
+        id: deploy_commit
+        uses: ./.github/actions/deploy-bump
+        with:
+          paths: |
+            ${{ env.CHART_VALUES }}
+            ${{ env.CHART_YAML }}
+          commit-message: "deploy: bump bp-newapi sandbox-bridge ${{ steps.tag.outputs.tag }} chart ${{ env.CHART_NEW_VERSION }} (Wave 5.57)"
+
+      - name: Trigger blueprint-release
+        if: steps.deploy_commit.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run blueprint-release.yaml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f blueprint=newapi \
+            -f tree=platform
+          echo "blueprint-release dispatched for platform/newapi @ main"
+
+      - name: Summary
+        run: |
+          {
+            echo "## bp-newapi sandbox-bridge published"
+            echo ""
+            echo "- Image: \`${BRIDGE_IMAGE}:${{ steps.tag.outputs.tag }}\`"
+            echo "- Chart bumped to: \`${CHART_NEW_VERSION:-unchanged}\`"
+            echo "- Refs #2303 (Wave 5.57)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -215,6 +215,58 @@ spec:
           resources:
             {{- toYaml .Values.newapi.resources | nindent 12 }}
 
+        {{- if .Values.sandboxBridge.enabled }}
+        # ── Sandbox-bridge sidecar (#2303, Wave 5.57) ───────────
+        # Catalyst-side bridge handler at POST /admin/tokens/sandbox.
+        # The upstream Calcium-Ion binary doesn't ship this route, so
+        # without this sidecar sandbox-controller's token-mint call
+        # hits the binary's default 404 HTML page (the "decode
+        # response: invalid character '<'" failure mode on hw01
+        # 2026-05-24). The sidecar serves the same Secret-mounted
+        # signing key + admin secret as the in-binary code path
+        # would.
+        - name: sandbox-bridge
+          image: "{{ .Values.sandboxBridge.image.repository }}:{{ .Values.sandboxBridge.image.tag }}"
+          imagePullPolicy: {{ .Values.sandboxBridge.image.pullPolicy }}
+          ports:
+            - name: bridge
+              containerPort: {{ .Values.sandboxBridge.port }}
+              protocol: TCP
+          env:
+            - name: BRIDGE_LISTEN
+              value: ":{{ .Values.sandboxBridge.port }}"
+            - name: NEWAPI_TOKEN_SIGNING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.sandboxTokenSigningKey.name }}
+                  key: SIGNING_KEY
+            - name: NEWAPI_ADMIN_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.sandboxTokenSigningKey.name }}
+                  key: ADMIN_SECRET
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.sandboxBridge.port }}
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.sandboxBridge.port }}
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.sandboxBridge.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.sandboxBridge.securityContext | nindent 12 }}
+        {{- end }}
+
         {{- if .Values.meteringSidecar.enabled }}
         # ── Metering sidecar (#798) ─────────────────────────────
         # Transparent reverse proxy in front of NewAPI. Observes

--- a/platform/newapi/chart/templates/networkpolicy.yaml
+++ b/platform/newapi/chart/templates/networkpolicy.yaml
@@ -39,6 +39,14 @@ spec:
         - port: {{ .Values.meteringSidecar.port }}
           protocol: TCP
         {{- end }}
+        {{- if .Values.sandboxBridge.enabled }}
+        # Sandbox-bridge sidecar (#2303, Wave 5.57) — POST
+        # /admin/tokens/sandbox served by the bridge handler on
+        # this port; reachable by the same caller set as the
+        # primary http port (catalyst-system + traefik).
+        - port: {{ .Values.sandboxBridge.port }}
+          protocol: TCP
+        {{- end }}
   egress:
     {{- if .Values.meteringSidecar.enabled }}
     # Metering sidecar emits to NATS JetStream (#798 + #795

--- a/platform/newapi/chart/templates/service.yaml
+++ b/platform/newapi/chart/templates/service.yaml
@@ -33,6 +33,16 @@ spec:
       targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
     {{- end }}
+    {{- if .Values.sandboxBridge.enabled }}
+    # Sandbox-bridge sidecar (#2303, Wave 5.57) — POST
+    # /admin/tokens/sandbox served by the Go bridge handler in
+    # platform/newapi/internal/handler. The sandbox-controller's
+    # NewAPI client targets `<svc>:bridge`.
+    - name: bridge
+      port: {{ .Values.sandboxBridge.port }}
+      targetPort: {{ .Values.sandboxBridge.port }}
+      protocol: TCP
+    {{- end }}
   selector:
     {{- include "bp-newapi.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -833,6 +833,39 @@ hpa:
 # do NOT want metering set `meteringSidecar.enabled: false` in the per-
 # Sovereign overlay (only valid in regulated environments where every
 # channel carries its own out-of-band ledger).
+
+# Sandbox-bridge sidecar (Wave 5.57, Refs #2303). Catalyst-side bridge
+# handler for POST /admin/tokens/sandbox — the upstream Calcium-Ion
+# binary has no such route, so without this sidecar sandbox-controller's
+# token-mint call hits the binary's default 404 HTML page (the "decode
+# response: invalid character '<'" failure mode observed on hw01
+# 2026-05-24). Built by .github/workflows/build-bp-newapi-sandbox-
+# bridge.yaml from platform/newapi/internal/handler.
+sandboxBridge:
+  enabled: true
+  image:
+    repository: ghcr.io/openova-io/openova/newapi-sandbox-bridge
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  port: 8080
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    capabilities:
+      drop: [ALL]
+    seccompProfile:
+      type: RuntimeDefault
+
 meteringSidecar:
   enabled: true
   image:

--- a/platform/newapi/internal/handler/Dockerfile
+++ b/platform/newapi/internal/handler/Dockerfile
@@ -1,0 +1,21 @@
+# sandbox-bridge sidecar image — Catalyst-side bridge handler for
+# POST /admin/tokens/sandbox (Wave 5.57, Refs #2303).
+#
+# Multi-stage Go build → distroless static base.
+# Built by .github/workflows/build-bp-newapi-sandbox-bridge.yaml on
+# every push touching platform/newapi/internal/handler/**.
+
+FROM golang:1.22-alpine AS build
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/sandbox-bridge ./cmd/sandbox-bridge
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /out/sandbox-bridge /sandbox-bridge
+USER nonroot:nonroot
+EXPOSE 8080
+ENTRYPOINT ["/sandbox-bridge"]

--- a/platform/newapi/internal/handler/cmd/sandbox-bridge/main.go
+++ b/platform/newapi/internal/handler/cmd/sandbox-bridge/main.go
@@ -1,0 +1,87 @@
+// sandbox-bridge — sidecar binary serving the
+// /admin/tokens/sandbox bridge handler defined in
+// platform/newapi/internal/handler (PR #1638 SandboxToken).
+//
+// Runs as a sidecar in the bp-newapi Pod alongside the upstream
+// Calcium-Ion newapi binary + the metering-sidecar. The Pod's
+// Service exposes this listener on a second port so the
+// sandbox-controller (catalyst-system in each Sovereign's vCluster)
+// can POST a per-Sandbox token-mint request without touching the
+// upstream binary, which has no such route and returns its default
+// HTML 404 page (root cause of Wave 5.57 #2303).
+//
+// Listener layout
+//
+//	:8080  POST /admin/tokens/sandbox  → handler.Handler.SandboxToken
+//	:8080  GET  /metrics               → promhttp.Handler (scrape target)
+//	:8080  GET  /healthz               → 200 OK (kubelet probe)
+//
+// Env contract
+//
+//	NEWAPI_TOKEN_SIGNING_KEY  required — HS256 mint key (same Secret
+//	                          as the upstream Calcium-Ion binary).
+//	NEWAPI_ADMIN_SECRET       required — bearer the sandbox-controller
+//	                          presents. Same Secret, `ADMIN_SECRET` key.
+//	BRIDGE_LISTEN             optional — listen address, default ":8080".
+//
+// Refs #2303, Wave 5.57.
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/openova-io/openova/platform/newapi/internal/handler"
+)
+
+func main() {
+	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	h, err := handler.NewHandlerFromEnv(log)
+	if err != nil {
+		log.Error("bridge: config error at start", "err", err)
+		os.Exit(1)
+	}
+
+	addr := os.Getenv("BRIDGE_LISTEN")
+	if addr == "" {
+		addr = ":8080"
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/admin/tokens/sandbox", h.SandboxToken)
+	mux.Handle("/metrics", handler.MetricsHandler())
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		log.Info("bridge: listening", "addr", addr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Error("bridge: ListenAndServe", "err", err)
+			os.Exit(1)
+		}
+	}()
+
+	<-ctx.Done()
+	log.Info("bridge: shutting down")
+	shutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_ = srv.Shutdown(shutCtx)
+}

--- a/platform/sandbox/chart/values.yaml
+++ b/platform/sandbox/chart/values.yaml
@@ -53,7 +53,15 @@ env:
   # Wave-9 token mint. Verified with `helm template newapi
   # platform/newapi/chart/ -s templates/service.yaml` → renders
   # `metadata.name: newapi-bp-newapi`.
-  newapiBaseURL: "http://newapi-bp-newapi.newapi.svc.cluster.local:3000"
+  # Wave 5.57 (#2303): the /admin/tokens/sandbox bridge handler runs as
+  # a SIDECAR in the bp-newapi Pod on :8080, NOT inside the upstream
+  # Calcium-Ion binary on :3000. Pre-fix the controller posted to :3000
+  # and hit the upstream binary's default HTML 404 page → JSON-decode
+  # failed with "invalid character '<'" (hw01 walk 2026-05-24). The bp-
+  # newapi Service exposes a second port `bridge: 8080` (Wave 5.57,
+  # platform/newapi/chart/templates/service.yaml) which targets the
+  # sandbox-bridge sidecar.
+  newapiBaseURL: "http://newapi-bp-newapi.newapi.svc.cluster.local:8080"
   # Comma-separated list of NewAPI channel names every freshly-minted
   # Sandbox token is allowed to target. The controller refuses to mint
   # tokens with an empty channel set (NoAllowedChannels condition on


### PR DESCRIPTION
## Summary

Wave 5.57 — ship the sandbox-bridge sidecar that serves the orphan Go handler at \`platform/newapi/internal/handler\` (PR #1638's SandboxToken).

## Root cause

The bridge handler is complete Go code with unit tests + go.mod but had no \`cmd/main.go\`, no Dockerfile, no CI workflow → never built into an image, never deployed. sandbox-controller's POST hit the upstream Calcium-Ion binary which returned HTML 404. Surface failure on hw01 2026-05-24: \`TokenMintFailed: newapi: decode response: invalid character '<' looking for beginning of value\`.

## Fix shape (Path A — sidecar)

| File | Purpose |
|---|---|
| \`platform/newapi/internal/handler/cmd/sandbox-bridge/main.go\` | Executable entrypoint. SandboxToken + /metrics + /healthz on :8080. |
| \`platform/newapi/internal/handler/Dockerfile\` | Multi-stage Go build → distroless static nonroot. |
| \`.github/workflows/build-bp-newapi-sandbox-bridge.yaml\` | Build + push \`ghcr.io/openova-io/openova/newapi-sandbox-bridge:<sha>\`; bump chart; dispatch blueprint-release. |
| \`platform/newapi/chart/templates/deployment.yaml\` | Add sandbox-bridge sidecar container. |
| \`platform/newapi/chart/templates/service.yaml\` | Expose port \`bridge: 8080\` on bp-newapi Service. |
| \`platform/newapi/chart/templates/networkpolicy.yaml\` | Allow ingress on 8080 from same caller set. |
| \`platform/newapi/chart/values.yaml\` | \`sandboxBridge\` stanza with default-on + distroless securityContext. |
| \`platform/sandbox/chart/values.yaml\` | newapiBaseURL :3000 → :8080. |

## Verification
- \`go build ./cmd/sandbox-bridge\` compiles, 12.7MB binary
- \`go vet ./...\` clean
- \`helm template\` renders 3 Service ports, Deployment with sandbox-bridge container, NetworkPolicy ingress 8080

## Walk-evidence path (post-merge)

After CI publishes the sidecar image + chart auto-bump + Flux reconciles on hw01:
1. Sandbox create on \`console.hw01.omani.works/sandbox\` → all 6 stages reach \`done\` (including \`newapi Token\`)
2. pty terminal opens with Qwen Code
3. Screenshot to \`docs/sessions/2026-05-24-wave-5-57-walk/\`

Refs #2303 (Wave 5.57); follows #2299 (Wave 5.57a NetworkPolicy fix).