### PR TITLE
fix(bp-newapi): force Pod rollout on sandboxBridge change (Wave 5.57c)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -197,7 +197,7 @@ spec:
       # 1.4.41 — chore(privacy): rename the partner-named channel slot
       # to `qwenPartner` and strip partner identifiers from comments /
       # fixtures / Secret names.
-      version: 1.4.45
+      version: 1.4.46
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-6-llm-serving
 spec:
-  version: 1.4.45
+  version: 1.4.46
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -402,7 +402,7 @@ name: bp-newapi
 # `lookup valkey.valkey.svc.cluster.local: no such host`). Same hostname
 # already documented as canonical in products/catalyst/chart/values.yaml
 # bp-cnpg-pair comments.
-version: 1.4.45
+version: 1.4.46
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -67,6 +67,17 @@ spec:
       annotations:
         # Roll the pod when channel/policy config changes.
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        # Wave 5.57c (#2303, 2026-05-24): roll the Pod whenever the
+        # sandboxBridge image or port changes — without this, a chart
+        # upgrade that ONLY changes the sidecar (image tag bump, port,
+        # securityContext) leaves the running Pod untouched because the
+        # checksum/config above only covers the configmap and the rest
+        # of the Pod spec is "diff-equivalent" to Helm's eyes. Caught
+        # live on hw01: chart 1.4.45 shipped the sandbox-bridge sidecar
+        # but the bp-newapi Pod kept running the 2-container 1.4.44
+        # spec (no bridge), so sandbox-controller's POST :8080 hit
+        # nothing → context deadline exceeded.
+        checksum/sandbox-bridge: {{ toYaml .Values.sandboxBridge | sha256sum }}
     spec:
       serviceAccountName: {{ include "bp-newapi.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
Closes the gap on hw01 where chart 1.4.45 reconciled but the Pod kept the 1.4.44 spec. Adds checksum/sandbox-bridge annotation derived from sha256 of .Values.sandboxBridge. Refs #2303