### PR TITLE
fix(bp-openbao): Step 2a KEY_COUNT uses grep -c . (Wave 5.67)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -54,7 +54,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.17
+      version: 1.2.18
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.2.17
+  version: 1.2.18
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -4,7 +4,7 @@ name: bp-openbao
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.2.17
+version: 1.2.18
 description: |
   Catalyst-curated Blueprint umbrella chart for OpenBao. Depends on the
   upstream `openbao` chart as a Helm subchart so `helm dependency build`

--- a/platform/openbao/chart/templates/init-job.yaml
+++ b/platform/openbao/chart/templates/init-job.yaml
@@ -235,7 +235,15 @@ spec:
                   if [ -z "$UNSEAL_THRESHOLD" ] || [ "$UNSEAL_THRESHOLD" -lt 1 ] 2>/dev/null; then
                     UNSEAL_THRESHOLD=1
                   fi
-                  KEY_COUNT=$(wc -l < /tmp/.unseal-keys | tr -d ' ')
+                  # Wave 5.67 (#2295, 2026-05-24): match Step 3's grep -c .
+                  # which counts NON-EMPTY lines regardless of trailing newline.
+                  # `wc -l` here was a latent bug — base64 -d of a single-key
+                  # payload yields the key bytes WITHOUT a terminal \n, so
+                  # `wc -l` returned 0 + the idempotent path FAILed with
+                  # "persisted 0 key(s) but threshold=1" even though sed -n
+                  # "${I}p" below would correctly retrieve the key. Caught
+                  # by line-aware audit against Step 3's robust pattern.
+                  KEY_COUNT=$(grep -c . /tmp/.unseal-keys 2>/dev/null || echo 0)
                   if [ "$KEY_COUNT" -lt "$UNSEAL_THRESHOLD" ]; then
                     echo "[openbao-init] FATAL: persisted $KEY_COUNT key(s) but threshold=$UNSEAL_THRESHOLD"
                     exit 1


### PR DESCRIPTION
Latent bug — wc -l undercounts unseal keys without trailing newline; the idempotent-unseal path FATAL-exited before applying any key. Refs #2295