### PR TITLE
feat(catalyst-api): wire evaluators.Engine (Wave 5.65b)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/evaluators_wire.go
+++ b/products/catalyst/bootstrap/api/cmd/api/evaluators_wire.go
@@ -1,0 +1,163 @@
+// evaluators_wire.go — Wave 5.65b (#2337 / #1096): wires the custom-
+// evaluator Engine to the running k8scache.Factory.
+//
+// Per the design in `internal/k8scache/evaluators/evaluators.go`:
+//
+//   - Engine subscribes to Factory SSE for trigger-based re-evaluations
+//     (Pod ADD/MODIFY → re-run all evaluators on the new state).
+//   - Engine ticks on a fixed cadence (Config.TickInterval) to re-sweep
+//     every cluster, catching drift that doesn't surface as an event.
+//   - Each evaluator emits zero or more SyntheticReport rows; the
+//     Publisher fanout pushes them onto the same SSE stream the UI's
+//     useComplianceStream hook reads. The handler/compliance.go
+//     aggregator joins these synthetic rows with Kyverno-emitted
+//     PolicyReports + EnvironmentPolicy weights to produce per-resource
+//     + per-Application + per-Organization scores.
+//
+// Adapter layout:
+//
+//   - resolveSnapshot — per-clusterID closure over Factory.List
+//   - subscribe       — converts Factory.Subscribe's <-chan k8scache.Event
+//                       into <-chan evaluators.Event (Engine's wire type)
+//   - publisher       — bridges evaluators.SyntheticReport → Factory.Publish
+//                       (wraps each as a Catalyst-canonical Event)
+//
+// Failure modes: any wire-up error is non-fatal — the caller logs +
+// continues with custom evaluators disabled, but Kyverno-emitted
+// PolicyReports still flow through the existing aggregator.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache/evaluators"
+)
+
+// wireEvaluatorEngine builds + starts the evaluators.Engine over the
+// running k8scache.Factory. Returns nil on success. On error, caller
+// logs and continues without custom evaluators.
+func wireEvaluatorEngine(ctx context.Context, log *slog.Logger, factory *k8scache.Factory) error {
+	if factory == nil {
+		return fmt.Errorf("nil factory")
+	}
+
+	cfg := evaluators.Config{Logger: log}
+
+	evals := []evaluators.Evaluator{
+		evaluators.NewHPAEvaluator(cfg),
+		evaluators.NewOTelEvaluator(cfg),
+		evaluators.NewHubbleEvaluator(cfg),
+		evaluators.NewHarborEvaluator(cfg),
+		evaluators.NewFluxEvaluator(cfg),
+	}
+
+	// resolveSnapshot: Engine asks for cluster X's Snapshot. Adapter
+	// wraps Factory.List with a fixed clusterID. Returns the list of
+	// kinds the snapshot supports (used by Engine to skip evaluators
+	// whose required kinds aren't watched).
+	resolveSnapshot := func(clusterID string) (evaluators.Snapshot, []string, error) {
+		snap := &factorySnapshot{factory: factory, clusterID: clusterID}
+		// Engine doesn't filter on this list today; pass empty to opt in
+		// to all evaluators. Future: query Factory.Registry().Kinds().
+		return snap, nil, nil
+	}
+
+	// subscribe: Engine asks for an event channel; adapter wires
+	// Factory.Subscribe + converts each k8scache.Event to evaluators.Event.
+	subscribe := func(kinds map[string]struct{}) (<-chan evaluators.Event, func()) {
+		// Factory.Subscribe takes a `user` for SAR-based RBAC filtering;
+		// the evaluator engine runs server-side so we use a sentinel
+		// internal user that bypasses tenant filtering.
+		src, cancel := factory.Subscribe("system:catalyst-evaluator", kinds)
+		out := make(chan evaluators.Event, cap(src))
+		go func() {
+			defer close(out)
+			for ev := range src {
+				if ev.Object == nil {
+					continue
+				}
+				out <- evaluators.Event{
+					Cluster: ev.Cluster,
+					Kind:    ev.Kind,
+					Object:  ev.Object,
+				}
+			}
+		}()
+		return out, cancel
+	}
+
+	pub := factoryPublisher{factory: factory, log: log}
+
+	engine, err := evaluators.NewEngine(cfg, evals, pub, resolveSnapshot, subscribe)
+	if err != nil {
+		return fmt.Errorf("NewEngine: %w", err)
+	}
+
+	go func() {
+		if err := engine.Run(ctx); err != nil && ctx.Err() == nil {
+			log.Warn("evaluators: engine.Run returned error", "err", err)
+		}
+	}()
+
+	return nil
+}
+
+// factorySnapshot adapts k8scache.Factory.List to the evaluators.Snapshot
+// read interface for a single clusterID.
+type factorySnapshot struct {
+	factory   *k8scache.Factory
+	clusterID string
+}
+
+func (s *factorySnapshot) List(kindName string, sel labels.Selector) ([]*unstructured.Unstructured, error) {
+	objs, _, err := s.factory.List(s.clusterID, kindName, sel)
+	return objs, err
+}
+
+// factoryPublisher bridges evaluators.SyntheticReport to the Factory's
+// SSE fanout (Factory.Publish takes a k8scache.Event). The synthetic
+// report's PolicyReport-like shape is wrapped as an Event with
+// Kind="policyreport" so the existing handler/compliance.go aggregator
+// treats it identically to a Kyverno-emitted PolicyReport CR.
+type factoryPublisher struct {
+	factory *k8scache.Factory
+	log     *slog.Logger
+}
+
+func (p factoryPublisher) Publish(clusterID string, report evaluators.SyntheticReport) {
+	// SyntheticReport carries the policy verdict + target ref; wrap as
+	// a synthetic PolicyReport-shaped unstructured so the existing
+	// handler/compliance.go aggregator treats it identically to a
+	// Kyverno-emitted PolicyReport CR (Kind="policyreport" + the
+	// per-policy result in spec.results[]).
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("wgpolicyk8s.io/v1alpha2")
+	obj.SetKind("PolicyReport")
+	obj.SetNamespace(report.Namespace)
+	// Synthetic PolicyReport name = "<policy>-<targetUID>" so per-
+	// workload reports don't collide; matches the Kyverno convention.
+	name := fmt.Sprintf("%s-%s", report.Policy, report.Resource.UID)
+	obj.SetName(name)
+	obj.Object["spec"] = map[string]interface{}{
+		"results": []interface{}{
+			map[string]interface{}{
+				"policy":  report.Policy,
+				"rule":    report.Rule,
+				"result":  string(report.Result),
+				"message": report.Message,
+			},
+		},
+	}
+	p.factory.Publish(k8scache.Event{
+		Cluster: clusterID,
+		Kind:    "policyreport",
+		Type:    k8scache.EventModified,
+		Object:  obj,
+	})
+}

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -253,6 +253,23 @@ func main() {
 			compliance.Start(ctx)
 			h.SetComplianceHandler(compliance)
 			log.Info("compliance: aggregator started")
+
+			// Wave 5.65b (#2337, #1096) — custom evaluator Engine.
+			// HPA-effective / OTel-injected / Hubble-flows-seen /
+			// image-via-Harbor-proxy / Crossplane-managed-by-flux —
+			// emit synthetic PolicyReport-like rows alongside Kyverno
+			// PolicyReports so the scorecard aggregator treats them
+			// uniformly. Engine subscribes to Factory SSE for trigger
+			// re-evaluations + ticks for full sweeps.
+			if err := wireEvaluatorEngine(ctx, log, k8sFactory); err != nil {
+				log.Warn("evaluators: engine wire-up failed; custom evaluators disabled",
+					"err", err,
+				)
+			} else {
+				log.Info("evaluators: engine started",
+					"evaluators", []string{"hpa", "otel", "hubble", "harbor", "flux"},
+				)
+			}
 		}
 	}
 

--- a/products/catalyst/bootstrap/api/internal/k8scache/evaluators/evaluators.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/evaluators/evaluators.go
@@ -298,17 +298,17 @@ type Engine struct {
 
 	// subscribe maps a (user, kinds) pair to a channel. Production
 	// wires to Factory.Subscribe.
-	subscribe func(kinds map[string]struct{}) (<-chan eventLite, func())
+	subscribe func(kinds map[string]struct{}) (<-chan Event, func())
 
 	mu      sync.Mutex
 	started bool
 }
 
-// eventLite is the engine's internal copy of k8scache.Event minus the
+// Event is the engine's internal copy of k8scache.Event minus the
 // EventType — the engine only cares about ADD / MODIFY for the trigger
 // path. DELETE is handled implicitly: when a target disappears from
 // the Indexer, the next tick stops emitting reports for it.
-type eventLite struct {
+type Event struct {
 	Cluster string
 	Kind    string
 	Object  *unstructured.Unstructured
@@ -317,7 +317,7 @@ type eventLite struct {
 // NewEngine wires an Engine without starting it.
 func NewEngine(cfg Config, evals []Evaluator, pub Publisher,
 	resolveSnapshot func(clusterID string) (Snapshot, []string, error),
-	subscribe func(kinds map[string]struct{}) (<-chan eventLite, func()),
+	subscribe func(kinds map[string]struct{}) (<-chan Event, func()),
 ) (*Engine, error) {
 	if cfg.Logger == nil {
 		return nil, errors.New("evaluators: Config.Logger is required")
@@ -562,14 +562,14 @@ func formatLabelMap(m map[string]string) string {
 }
 
 // SubscribeAdapter wraps a k8scache.Factory.Subscribe call into the
-// engine's eventLite channel. Production code in the catalyst-api
+// engine's Event channel. Production code in the catalyst-api
 // `cmd/api/main.go` wires this. Exposed here so tests can construct
 // an Engine without depending on the full Factory.
-type SubscribeAdapter func(kinds map[string]struct{}) (<-chan eventLite, func())
+type SubscribeAdapter func(kinds map[string]struct{}) (<-chan Event, func())
 
-// EventLiteFromUnstructured is a test convenience to build eventLite
+// EventFromUnstructured is a test convenience to build Event
 // values without exposing the unexported field. Used by the table
 // tests in evaluators_test.go.
-func EventLiteFromUnstructured(cluster, kind string, obj *unstructured.Unstructured) eventLite {
-	return eventLite{Cluster: cluster, Kind: kind, Object: obj}
+func EventFromUnstructured(cluster, kind string, obj *unstructured.Unstructured) Event {
+	return Event{Cluster: cluster, Kind: kind, Object: obj}
 }

--- a/products/catalyst/bootstrap/api/internal/k8scache/evaluators/evaluators_test.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/evaluators/evaluators_test.go
@@ -575,7 +575,7 @@ func TestEngine_PublishesOnSubscribedEvent(t *testing.T) {
 	rec := &recorder{}
 	pod := uPod("acme", "app", withContainerImages("harbor.openova.io/proxy/x:1"))
 
-	eventCh := make(chan eventLite, 4)
+	eventCh := make(chan Event, 4)
 	cfg := Config{
 		Logger:       quietLogger(),
 		HarborDomain: "harbor.openova.io",
@@ -586,7 +586,7 @@ func TestEngine_PublishesOnSubscribedEvent(t *testing.T) {
 		[]Evaluator{NewHarborEvaluator(cfg)},
 		rec,
 		func(_ string) (Snapshot, []string, error) { return &fakeSnapshot{}, nil, nil },
-		func(_ map[string]struct{}) (<-chan eventLite, func()) {
+		func(_ map[string]struct{}) (<-chan Event, func()) {
 			return eventCh, func() {}
 		},
 	)
@@ -598,7 +598,7 @@ func TestEngine_PublishesOnSubscribedEvent(t *testing.T) {
 	done := make(chan struct{})
 	go func() { _ = eng.Run(ctx); close(done) }()
 
-	eventCh <- eventLite{Cluster: "alpha", Kind: "pod", Object: pod}
+	eventCh <- Event{Cluster: "alpha", Kind: "pod", Object: pod}
 
 	deadline := time.After(2 * time.Second)
 	for {
@@ -634,7 +634,7 @@ func TestEngine_TickerEvaluatesAllPodsAcrossClusters(t *testing.T) {
 		"alpha": {by: map[string][]*unstructured.Unstructured{"pod": {pod1}}},
 		"beta":  {by: map[string][]*unstructured.Unstructured{"pod": {pod2}}},
 	}
-	eventCh := make(chan eventLite, 1)
+	eventCh := make(chan Event, 1)
 
 	cfg := Config{
 		Logger:       quietLogger(),
@@ -655,7 +655,7 @@ func TestEngine_TickerEvaluatesAllPodsAcrossClusters(t *testing.T) {
 			}
 			return s, nil, nil
 		},
-		func(_ map[string]struct{}) (<-chan eventLite, func()) {
+		func(_ map[string]struct{}) (<-chan Event, func()) {
 			return eventCh, func() {}
 		},
 	)
@@ -721,7 +721,7 @@ func TestEngine_RejectsInvalidConfig(t *testing.T) {
 	}
 	if _, err := NewEngine(cfgOK, nil, &recorder{},
 		func(string) (Snapshot, []string, error) { return nil, nil, nil },
-		func(map[string]struct{}) (<-chan eventLite, func()) { return nil, nil }); err == nil {
+		func(map[string]struct{}) (<-chan Event, func()) { return nil, nil }); err == nil {
 		t.Fatalf("empty evaluator slice should error")
 	}
 }
@@ -730,10 +730,10 @@ func TestEngine_DoubleRunRefused(t *testing.T) {
 	cfg := Config{Logger: quietLogger()}
 	cfg.defaults()
 	rec := &recorder{}
-	eventCh := make(chan eventLite)
+	eventCh := make(chan Event)
 	eng, err := NewEngine(cfg, []Evaluator{NewFluxEvaluator(cfg)}, rec,
 		func(string) (Snapshot, []string, error) { return &fakeSnapshot{}, nil, nil },
-		func(map[string]struct{}) (<-chan eventLite, func()) {
+		func(map[string]struct{}) (<-chan Event, func()) {
 			return eventCh, func() {}
 		},
 	)
@@ -750,10 +750,10 @@ func TestEngine_DoubleRunRefused(t *testing.T) {
 }
 
 // Sanity that the package's helper conversions don't drop fields.
-func TestEventLiteFromUnstructured(t *testing.T) {
+func TestEventFromUnstructured(t *testing.T) {
 	pod := uPod("ns", "n")
-	ev := EventLiteFromUnstructured("alpha", "pod", pod)
+	ev := EventFromUnstructured("alpha", "pod", pod)
 	if ev.Cluster != "alpha" || ev.Kind != "pod" || ev.Object != pod {
-		t.Fatalf("EventLiteFromUnstructured dropped a field: %+v", ev)
+		t.Fatalf("EventFromUnstructured dropped a field: %+v", ev)
 	}
 }


### PR DESCRIPTION
Engine framework existed but was never instantiated — Wave 5.65b adds the wire-up + renames eventLite→Event so external pkgs can implement subscribe. Refs #2337 #1096