### PR TITLE
fix(auth-ui): /login + /verify use design tokens (Wave 5.76)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/layouts/AuthLayout.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/layouts/AuthLayout.tsx
@@ -25,7 +25,7 @@ export function AuthShell({ children }: { children: React.ReactNode }) {
         <div className="flex items-center gap-2.5">
           {/* Canonical OpenOva mark — see /brand/logo-mark.svg in openova-private */}
           <OOLogo h={22} id="auth-left-logo" />
-          <span className="text-sm font-semibold text-[oklch(92%_0.01_250)] tracking-tight">OpenOva <span className="text-[oklch(60%_0.01_250)] font-normal">Sovereign</span></span>
+          <span className="text-sm font-semibold text-[var(--color-text-strong)] tracking-tight">OpenOva <span className="text-[var(--color-text-dim)] font-normal">Sovereign</span></span>
         </div>
 
         <div className="flex flex-col gap-6">
@@ -34,11 +34,11 @@ export function AuthShell({ children }: { children: React.ReactNode }) {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, ease: [0.4, 0, 0.2, 1] }}
           >
-            <p className="text-2xl font-semibold text-[oklch(92%_0.01_250)] leading-snug text-balance">
+            <p className="text-2xl font-semibold text-[var(--color-text-strong)] leading-snug text-balance">
               Enterprise Kubernetes.<br />
               Provisioned in minutes.
             </p>
-            <p className="mt-3 text-sm text-[oklch(50%_0.01_250)] leading-relaxed max-w-xs">
+            <p className="mt-3 text-sm text-[var(--color-text-dim)] leading-relaxed max-w-xs">
               52 open-source components. AI-native operations. Multi-region out of the box.
               Production-grade from day one.
             </p>
@@ -52,13 +52,13 @@ export function AuthShell({ children }: { children: React.ReactNode }) {
             ].map(({ stat, label }) => (
               <div key={label} className="flex items-center gap-3">
                 <span className="text-lg font-bold text-[--color-brand-400] tabular-nums">{stat}</span>
-                <span className="text-sm text-[oklch(45%_0.01_250)]">{label}</span>
+                <span className="text-sm text-[var(--color-text-dimmer)]">{label}</span>
               </div>
             ))}
           </div>
         </div>
 
-        <p className="text-xs text-[oklch(35%_0.01_250)]">
+        <p className="text-xs text-[var(--color-text-dimmer)]">
           © {new Date().getFullYear()} OpenOva · Platform Edition
         </p>
       </div>

--- a/products/catalyst/bootstrap/ui/src/pages/auth/LoginPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/LoginPage.tsx
@@ -98,10 +98,10 @@ export function LoginPage() {
         className="flex flex-col gap-8"
       >
         <div className="flex flex-col gap-2 text-center">
-          <h1 className="text-2xl font-semibold tracking-tight text-[oklch(94%_0.01_250)]">
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--color-text-strong)]">
             Sign in
           </h1>
-          <p className="text-[15px] text-[oklch(58%_0.01_250)]">
+          <p className="text-[15px] text-[var(--color-text-dim)]">
             Enter your email to receive a 6-digit PIN.
           </p>
           {/*
@@ -121,7 +121,7 @@ export function LoginPage() {
           {typeof window !== 'undefined' && window.location?.host && (
             <p
               data-testid="login-canonical-host"
-              className="text-[12px] font-mono text-[oklch(50%_0.01_250)]"
+              className="text-[12px] font-mono text-[var(--color-text-dim)]"
             >
               {window.location.host}
             </p>
@@ -146,7 +146,7 @@ export function LoginPage() {
             <p
               role="status"
               data-testid="login-next-hint"
-              className="text-[13px] text-[oklch(58%_0.01_250)]"
+              className="text-[13px] text-[var(--color-text-dim)]"
             >
               We'll take you to <code>{sanitizeNextParam(next)}</code>{' '}
               after you sign in.

--- a/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.tsx
@@ -183,10 +183,10 @@ export function VerifyPinPage() {
         className="flex flex-col gap-9"
       >
         <div className="flex flex-col items-center gap-3 text-center">
-          <h1 className="text-2xl font-semibold tracking-tight text-[oklch(94%_0.01_250)]">
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--color-text-strong)]">
             Enter the verification code
           </h1>
-          <p className="text-[15px] text-[oklch(58%_0.01_250)] leading-snug">
+          <p className="text-[15px] text-[var(--color-text-dim)] leading-snug">
             A 6-digit code was sent to
           </p>
           <button
@@ -194,7 +194,7 @@ export function VerifyPinPage() {
             onClick={copyEmail}
             data-testid="verify-email-pill"
             title="Copy email"
-            className="group inline-flex items-center gap-2 rounded-full border border-[--color-surface-border] bg-[--color-surface-1] px-3.5 py-1.5 text-sm font-medium text-[oklch(85%_0.01_250)] hover:border-[--color-brand-500]/60 hover:bg-[--color-surface-2] transition-colors"
+            className="group inline-flex items-center gap-2 rounded-full border border-[--color-surface-border] bg-[--color-surface-1] px-3.5 py-1.5 text-sm font-medium text-[var(--color-text)] hover:border-[--color-brand-500]/60 hover:bg-[--color-surface-2] transition-colors"
           >
             <span id="verify-email-pill-text" className="select-all">
               {email}
@@ -203,7 +203,7 @@ export function VerifyPinPage() {
               <Check className="h-3.5 w-3.5 text-[--color-success]" aria-label="Copied" />
             ) : (
               <Copy
-                className="h-3.5 w-3.5 text-[oklch(50%_0.01_250)] group-hover:text-[--color-brand-400] transition-colors"
+                className="h-3.5 w-3.5 text-[var(--color-text-dim)] group-hover:text-[--color-brand-400] transition-colors"
                 aria-label="Copy email"
               />
             )}
@@ -262,7 +262,7 @@ export function VerifyPinPage() {
           >
             Didn't get a code? Send a new one
           </button>
-          <p className="text-xs text-[oklch(40%_0.01_250)]">
+          <p className="text-xs text-[var(--color-text-dimmer)]">
             Codes expire after 10 minutes — check your spam folder.
           </p>
         </div>


### PR DESCRIPTION
14 hardcoded oklch() → var(--color-*). Refs founder UX audit 2026-05-24