### PR TITLE
feat(huawei): debug-ssh toggle for recovery flows (Wave 5.82)

### DIFF
--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -234,6 +234,24 @@ resource "huaweicloud_networking_secgroup_rule" "ingress_icmp" {
   description       = "ICMP (path-MTU + ping diagnostics)"
 }
 
+# Wave 5.82 (Refs #2419): optional 22/tcp ingress for recovery-script SSH.
+# Off by default (canonical posture). Toggle via `debug_ssh_enabled = true`
+# in tfvars when running Wave 5.75 recovery-script flow; toggle back when
+# done. Keeps secgroup-rule lifecycle in tofu state instead of drifting
+# via manual Huawei console fiddling.
+resource "huaweicloud_networking_secgroup_rule" "ingress_22_debug" {
+  for_each = var.debug_ssh_enabled ? { for r in var.regions : r.code => r } : {}
+
+  security_group_id = huaweicloud_networking_secgroup.region[each.key].id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = var.debug_ssh_remote_cidr
+  description       = "SSH (debug-ssh-toggle ON via debug_ssh_enabled=true)"
+}
+
 # Wave 5.30 (Refs #2163): Cilium tunnel/health/encryption ports — node↔node
 # encap and cilium-health checks must be reachable for pod-to-pod traffic
 # across nodes. Without these rules, Cilium VXLAN encap packets (or

--- a/infra/providers/huawei/variables.tf
+++ b/infra/providers/huawei/variables.tf
@@ -312,3 +312,34 @@ variable "obs_bucket_name" {
     error_message = "OBS bucket name must be 3-63 chars, lowercase alphanumeric + hyphens, starting + ending with alphanumeric."
   }
 }
+
+# ── Debug SSH toggle (Wave 5.82 #2419, recovery-script unblock) ──────────
+# Default `false`: the canonical Sovereign posture has NO port 22 ingress
+# on the per-region security group (operator never needs SSH in steady
+# state — k3s + Cilium handle everything inside the cluster, mothership
+# observability covers Day-2). When a recovery flow needs SSH (Wave 5.75
+# manual secondary-kubeconfig PUT-back via `scripts/hw01-recover-
+# secondary-kubeconfig.sh`), the operator flips this to `true` + runs
+# `tofu apply`, runs the script, then flips back + re-applies. The
+# secgroup-rule lifecycle stays in tofu state — no manual Huawei console
+# fiddling that would drift state.
+
+variable "debug_ssh_enabled" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+    When true, opens 22/tcp ingress on every region's security group
+    from `debug_ssh_remote_cidr`. Default false (canonical posture).
+    Flip true to enable recovery-script SSH; flip back after recovery.
+  EOT
+}
+
+variable "debug_ssh_remote_cidr" {
+  type        = string
+  default     = "0.0.0.0/0"
+  description = <<-EOT
+    CIDR allowed to reach 22/tcp when `debug_ssh_enabled = true`.
+    Default 0.0.0.0/0 (broad — relies on key-only SSH auth). Tighten
+    to the bastion /32 in tfvars when running recovery from a known IP.
+  EOT
+}


### PR DESCRIPTION
Refs #2419 #2401 — unblocks recovery-script SSH without manual secgroup mutation. See commit body for full flow.