### PR TITLE
feat(bp-*): HTTPRoute render smoke fan-out — batch A (Wave 5.85)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -54,7 +54,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.18
+      version: 1.2.19
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -65,7 +65,7 @@ spec:
       # outer hook-wait accommodates the inner 15m availability window.
       # 1.4.3 (issue #129): bumped keycloakConfigCli.availabilityCheck.timeout
       # 120s → 600s + backoffLimit 1 → 5 (fresh-install wedge).
-      version: 1.4.6
+      version: 1.4.7
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -54,7 +54,7 @@ spec:
       # bp-self-sovereign-cutover Step 1 gitea-mirror Job mounts it. K8s
       # forbids cross-namespace secretKeyRef; reflector is the canonical
       # platform-level mirror. Caught live on otech103 2026-05-04.
-      version: 1.2.9
+      version: 1.2.10
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -101,7 +101,7 @@ spec:
       # live on otech113 2026-05-05 (issue #935 Bug 1) — Step 02 was
       # in CreateContainerConfigError for 11+ retries, blocking
       # cutover indefinitely.
-      version: 1.2.19
+      version: 1.2.20
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -65,7 +65,7 @@ spec:
   chart:
     spec:
       chart: bp-grafana
-      version: 1.0.2
+      version: 1.0.3
       sourceRef:
         kind: HelmRepository
         name: bp-grafana

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.2.9
+  version: 1.2.10
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -8,7 +8,7 @@ name: bp-gitea
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.2.9
+version: 1.2.10
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/tests/httproute-render.sh
+++ b/platform/gitea/chart/tests/httproute-render.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# bp-gitea — HTTPRoute render audit (Wave 5.85 #2425).
+#
+# Verifies the chart renders a Cilium Gateway HTTPRoute when the
+# bootstrap-kit overlay flips `gateway.enabled: true` + sets
+# `gateway.host`. The default-values CI smoke does NOT exercise this
+# path because the chart defaults `gateway.enabled` to false (correct
+# for standalone-install on non-Catalyst clusters). Without this guard
+# a regression in `templates/httproute.yaml` (gate condition, hostname
+# templating, parentRef typo) ships fresh-prov NXDOMAIN to every
+# Sovereign + only surfaces on operator walk — exactly the #2421
+# symptom that drove Wave 5.84 for bp-newapi.
+#
+# Cases:
+#   1. Overlay-enabled render — HTTPRoute kind present with correct
+#      hostname
+#   2. parentRefs cite canonical Cilium Gateway
+#      (`cilium-gateway` in `kube-system`)
+#   3. Default-off path — no HTTPRoute kind in render output
+#      (silent-skip behaviour preserved for standalone-install
+#      contexts on non-Catalyst clusters)
+#   4. Operator host override propagates correctly
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+# ── Case 1: HTTPRoute renders with overlay-enabled values ─────────────
+echo "[bp-gitea] Case 1: overlay-enabled render — HTTPRoute present + correct hostname"
+out=$("$helm" template smoke "$chart_dir" \
+        --set gateway.enabled=true \
+        --set gateway.host=gitea.smoke.omani.works 2>&1)
+
+route_block=$(echo "$out" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
+if [ -z "$route_block" ]; then
+  echo "FAIL: HTTPRoute did not render with gateway.enabled=true + gateway.host"
+  echo "(would surface on fresh Sovereign prov as NXDOMAIN for gitea.<fqdn>)"
+  exit 1
+fi
+if ! echo "$route_block" | grep -q "gitea.smoke.omani.works"; then
+  echo "FAIL: HTTPRoute hostname does not match gateway.host"
+  echo "$route_block"
+  exit 1
+fi
+echo "[bp-gitea] Case 1: PASS"
+
+# ── Case 2: parentRefs cite canonical Cilium Gateway ──────────────────
+echo "[bp-gitea] Case 2: parentRefs cite 'cilium-gateway' in 'kube-system'"
+if ! echo "$route_block" | grep -q "name: \"cilium-gateway\""; then
+  echo "FAIL: HTTPRoute parentRefs do not cite name=cilium-gateway"
+  exit 1
+fi
+if ! echo "$route_block" | grep -q "namespace: \"kube-system\""; then
+  echo "FAIL: HTTPRoute parentRefs do not cite namespace=kube-system"
+  exit 1
+fi
+echo "[bp-gitea] Case 2: PASS"
+
+# ── Case 3: default-off path — HTTPRoute absent ───────────────────────
+echo "[bp-gitea] Case 3: default-off path — HTTPRoute not rendered"
+out_default=$("$helm" template smoke "$chart_dir" 2>&1)
+if echo "$out_default" | grep -q "^kind: HTTPRoute$"; then
+  echo "FAIL: HTTPRoute should NOT render when gateway.enabled is unset (default)"
+  exit 1
+fi
+echo "[bp-gitea] Case 3: PASS"
+
+# ── Case 4: operator host override propagates ─────────────────────────
+echo "[bp-gitea] Case 4: operator override of gateway.host"
+out_override=$("$helm" template smoke "$chart_dir" \
+        --set gateway.enabled=true \
+        --set gateway.host=custom.smoke.example 2>&1)
+
+route_block_override=$(echo "$out_override" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
+if ! echo "$route_block_override" | grep -q "custom.smoke.example"; then
+  echo "FAIL: explicit gateway.host override not propagated to HTTPRoute hostnames"
+  exit 1
+fi
+if echo "$route_block_override" | grep -q "gitea.smoke.omani.works"; then
+  echo "FAIL: explicit override leaked the case-1 hostname"
+  exit 1
+fi
+echo "[bp-gitea] Case 4: PASS"
+
+echo "[bp-gitea] All HTTPRoute render cases PASS"

--- a/platform/grafana/blueprint.yaml
+++ b/platform/grafana/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-observability
 spec:
-  version: 1.0.2
+  version: 1.0.3
   card:
     title: Grafana
     family: insights

--- a/platform/grafana/chart/Chart.yaml
+++ b/platform/grafana/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.0.2
+version: 1.0.3
 appVersion: "12.3.1"
 keywords: [catalyst, blueprint, grafana, observability, dashboards]
 maintainers:

--- a/platform/grafana/chart/tests/httproute-render.sh
+++ b/platform/grafana/chart/tests/httproute-render.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# bp-grafana — HTTPRoute render audit (Wave 5.85 #2425).
+#
+# Verifies the chart renders a Cilium Gateway HTTPRoute when the
+# bootstrap-kit overlay flips `gateway.enabled: true` + sets
+# `gateway.host`. The default-values CI smoke does NOT exercise this
+# path because the chart defaults `gateway.enabled` to false (correct
+# for standalone-install on non-Catalyst clusters). Without this guard
+# a regression in `templates/httproute.yaml` (gate condition, hostname
+# templating, parentRef typo) ships fresh-prov NXDOMAIN to every
+# Sovereign + only surfaces on operator walk — exactly the #2421
+# symptom that drove Wave 5.84 for bp-newapi.
+#
+# Cases:
+#   1. Overlay-enabled render — HTTPRoute kind present with correct
+#      hostname
+#   2. parentRefs cite canonical Cilium Gateway
+#      (`cilium-gateway` in `kube-system`)
+#   3. Default-off path — no HTTPRoute kind in render output
+#      (silent-skip behaviour preserved for standalone-install
+#      contexts on non-Catalyst clusters)
+#   4. Operator host override propagates correctly
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+# ── Case 1: HTTPRoute renders with overlay-enabled values ─────────────
+echo "[bp-grafana] Case 1: overlay-enabled render — HTTPRoute present + correct hostname"
+out=$("$helm" template smoke "$chart_dir" \
+        --set gateway.enabled=true \
+        --set gateway.host=grafana.smoke.omani.works 2>&1)
+
+route_block=$(echo "$out" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
+if [ -z "$route_block" ]; then
+  echo "FAIL: HTTPRoute did not render with gateway.enabled=true + gateway.host"
+  echo "(would surface on fresh Sovereign prov as NXDOMAIN for grafana.<fqdn>)"
+  exit 1
+fi
+if ! echo "$route_block" | grep -q "grafana.smoke.omani.works"; then
+  echo "FAIL: HTTPRoute hostname does not match gateway.host"
+  echo "$route_block"
+  exit 1
+fi
+echo "[bp-grafana] Case 1: PASS"
+
+# ── Case 2: parentRefs cite canonical Cilium Gateway ──────────────────
+echo "[bp-grafana] Case 2: parentRefs cite 'cilium-gateway' in 'kube-system'"
+if ! echo "$route_block" | grep -q "name: \"cilium-gateway\""; then
+  echo "FAIL: HTTPRoute parentRefs do not cite name=cilium-gateway"
+  exit 1
+fi
+if ! echo "$route_block" | grep -q "namespace: \"kube-system\""; then
+  echo "FAIL: HTTPRoute parentRefs do not cite namespace=kube-system"
+  exit 1
+fi
+echo "[bp-grafana] Case 2: PASS"
+
+# ── Case 3: default-off path — HTTPRoute absent ───────────────────────
+echo "[bp-grafana] Case 3: default-off path — HTTPRoute not rendered"
+out_default=$("$helm" template smoke "$chart_dir" 2>&1)
+if echo "$out_default" | grep -q "^kind: HTTPRoute$"; then
+  echo "FAIL: HTTPRoute should NOT render when gateway.enabled is unset (default)"
+  exit 1
+fi
+echo "[bp-grafana] Case 3: PASS"
+
+# ── Case 4: operator host override propagates ─────────────────────────
+echo "[bp-grafana] Case 4: operator override of gateway.host"
+out_override=$("$helm" template smoke "$chart_dir" \
+        --set gateway.enabled=true \
+        --set gateway.host=custom.smoke.example 2>&1)
+
+route_block_override=$(echo "$out_override" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
+if ! echo "$route_block_override" | grep -q "custom.smoke.example"; then
+  echo "FAIL: explicit gateway.host override not propagated to HTTPRoute hostnames"
+  exit 1
+fi
+if echo "$route_block_override" | grep -q "grafana.smoke.omani.works"; then
+  echo "FAIL: explicit override leaked the case-1 hostname"
+  exit 1
+fi
+echo "[bp-grafana] Case 4: PASS"
+
+echo "[bp-grafana] All HTTPRoute render cases PASS"

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-5-storage-and-data
 spec:
-  version: 1.2.19
+  version: 1.2.20
   card:
     title: Harbor
     family: foundation

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -52,7 +52,7 @@ type: application
 # The Postgres workload Pods reconcile into the same NS as the
 # CNPG Cluster CR, NOT into cnpg-system; the prior rule could
 # never match the actual DB Pods.
-version: 1.2.19
+version: 1.2.20
 appVersion: "2.14.3"
 keywords: [catalyst, blueprint, harbor, oci, registry, container]
 maintainers:

--- a/platform/harbor/chart/tests/httproute-render.sh
+++ b/platform/harbor/chart/tests/httproute-render.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# bp-harbor — HTTPRoute render audit (Wave 5.85 #2425).
+#
+# Verifies the chart renders a Cilium Gateway HTTPRoute when the
+# bootstrap-kit overlay flips `gateway.enabled: true` + sets
+# `gateway.host`. The default-values CI smoke does NOT exercise this
+# path because the chart defaults `gateway.enabled` to false (correct
+# for standalone-install on non-Catalyst clusters). Without this guard
+# a regression in `templates/httproute.yaml` (gate condition, hostname
+# templating, parentRef typo) ships fresh-prov NXDOMAIN to every
+# Sovereign + only surfaces on operator walk — exactly the #2421
+# symptom that drove Wave 5.84 for bp-newapi.
+#
+# Cases:
+#   1. Overlay-enabled render — HTTPRoute kind present with correct
+#      hostname
+#   2. parentRefs cite canonical Cilium Gateway
+#      (`cilium-gateway` in `kube-system`)
+#   3. Default-off path — no HTTPRoute kind in render output
+#      (silent-skip behaviour preserved for standalone-install
+#      contexts on non-Catalyst clusters)
+#   4. Operator host override propagates correctly
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+# ── Case 1: HTTPRoute renders with overlay-enabled values ─────────────
+echo "[bp-harbor] Case 1: overlay-enabled render — HTTPRoute present + correct hostname"
+out=$("$helm" template smoke "$chart_dir" \
+        --set gateway.enabled=true \
+        --set gateway.host=harbor.smoke.omani.works 2>&1)
+
+route_block=$(echo "$out" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
+if [ -z "$route_block" ]; then
+  echo "FAIL: HTTPRoute did not render with gateway.enabled=true + gateway.host"
+  echo "(would surface on fresh Sovereign prov as NXDOMAIN for harbor.<fqdn>)"
+  exit 1
+fi
+if ! echo "$route_block" | grep -q "harbor.smoke.omani.works"; then
+  echo "FAIL: HTTPRoute hostname does not match gateway.host"
+  echo "$route_block"
+  exit 1
+fi
+echo "[bp-harbor] Case 1: PASS"
+
+# ── Case 2: parentRefs cite canonical Cilium Gateway ──────────────────
+echo "[bp-harbor] Case 2: parentRefs cite 'cilium-gateway' in 'kube-system'"
+if ! echo "$route_block" | grep -q "name: \"cilium-gateway\""; then
+  echo "FAIL: HTTPRoute parentRefs do not cite name=cilium-gateway"
+  exit 1
+fi
+if ! echo "$route_block" | grep -q "namespace: \"kube-system\""; then
+  echo "FAIL: HTTPRoute parentRefs do not cite namespace=kube-system"
+  exit 1
+fi
+echo "[bp-harbor] Case 2: PASS"
+
+# ── Case 3: default-off path — HTTPRoute absent ───────────────────────
+echo "[bp-harbor] Case 3: default-off path — HTTPRoute not rendered"
+out_default=$("$helm" template smoke "$chart_dir" 2>&1)
+if echo "$out_default" | grep -q "^kind: HTTPRoute$"; then
+  echo "FAIL: HTTPRoute should NOT render when gateway.enabled is unset (default)"
+  exit 1
+fi
+echo "[bp-harbor] Case 3: PASS"
+
+# ── Case 4: operator host override propagates ─────────────────────────
+echo "[bp-harbor] Case 4: operator override of gateway.host"
+out_override=$("$helm" template smoke "$chart_dir" \
+        --set gateway.enabled=true \
+        --set gateway.host=custom.smoke.example 2>&1)
+
+route_block_override=$(echo "$out_override" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
+if ! echo "$route_block_override" | grep -q "custom.smoke.example"; then
+  echo "FAIL: explicit gateway.host override not propagated to HTTPRoute hostnames"
+  exit 1
+fi
+if echo "$route_block_override" | grep -q "harbor.smoke.omani.works"; then
+  echo "FAIL: explicit override leaked the case-1 hostname"
+  exit 1
+fi
+echo "[bp-harbor] Case 4: PASS"
+
+echo "[bp-harbor] All HTTPRoute render cases PASS"

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.4.6
+  version: 1.4.7
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -4,7 +4,7 @@ name: bp-keycloak
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.4.6
+version: 1.4.7
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/tests/httproute-render.sh
+++ b/platform/keycloak/chart/tests/httproute-render.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# bp-keycloak — HTTPRoute render audit (Wave 5.85 #2425).
+#
+# Verifies the chart renders a Cilium Gateway HTTPRoute when the
+# bootstrap-kit overlay flips `gateway.enabled: true` + sets
+# `gateway.host`. The default-values CI smoke does NOT exercise this
+# path because the chart defaults `gateway.enabled` to false (correct
+# for standalone-install on non-Catalyst clusters). Without this guard
+# a regression in `templates/httproute.yaml` (gate condition, hostname
+# templating, parentRef typo) ships fresh-prov NXDOMAIN to every
+# Sovereign + only surfaces on operator walk — exactly the #2421
+# symptom that drove Wave 5.84 for bp-newapi.
+#
+# Cases:
+#   1. Overlay-enabled render — HTTPRoute kind present with correct
+#      hostname
+#   2. parentRefs cite canonical Cilium Gateway
+#      (`cilium-gateway` in `kube-system`)
+#   3. Default-off path — no HTTPRoute kind in render output
+#      (silent-skip behaviour preserved for standalone-install
+#      contexts on non-Catalyst clusters)
+#   4. Operator host override propagates correctly
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+# ── Case 1: HTTPRoute renders with overlay-enabled values ─────────────
+echo "[bp-keycloak] Case 1: overlay-enabled render — HTTPRoute present + correct hostname"
+out=$("$helm" template smoke "$chart_dir" \
+        --set gateway.enabled=true \
+        --set gateway.host=keycloak.smoke.omani.works 2>&1)
+
+route_block=$(echo "$out" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
+if [ -z "$route_block" ]; then
+  echo "FAIL: HTTPRoute did not render with gateway.enabled=true + gateway.host"
+  echo "(would surface on fresh Sovereign prov as NXDOMAIN for keycloak.<fqdn>)"
+  exit 1
+fi
+if ! echo "$route_block" | grep -q "keycloak.smoke.omani.works"; then
+  echo "FAIL: HTTPRoute hostname does not match gateway.host"
+  echo "$route_block"
+  exit 1
+fi
+echo "[bp-keycloak] Case 1: PASS"
+
+# ── Case 2: parentRefs cite canonical Cilium Gateway ──────────────────
+echo "[bp-keycloak] Case 2: parentRefs cite 'cilium-gateway' in 'kube-system'"
+if ! echo "$route_block" | grep -q "name: \"cilium-gateway\""; then
+  echo "FAIL: HTTPRoute parentRefs do not cite name=cilium-gateway"
+  exit 1
+fi
+if ! echo "$route_block" | grep -q "namespace: \"kube-system\""; then
+  echo "FAIL: HTTPRoute parentRefs do not cite namespace=kube-system"
+  exit 1
+fi
+echo "[bp-keycloak] Case 2: PASS"
+
+# ── Case 3: default-off path — HTTPRoute absent ───────────────────────
+echo "[bp-keycloak] Case 3: default-off path — HTTPRoute not rendered"
+out_default=$("$helm" template smoke "$chart_dir" 2>&1)
+if echo "$out_default" | grep -q "^kind: HTTPRoute$"; then
+  echo "FAIL: HTTPRoute should NOT render when gateway.enabled is unset (default)"
+  exit 1
+fi
+echo "[bp-keycloak] Case 3: PASS"
+
+# ── Case 4: operator host override propagates ─────────────────────────
+echo "[bp-keycloak] Case 4: operator override of gateway.host"
+out_override=$("$helm" template smoke "$chart_dir" \
+        --set gateway.enabled=true \
+        --set gateway.host=custom.smoke.example 2>&1)
+
+route_block_override=$(echo "$out_override" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
+if ! echo "$route_block_override" | grep -q "custom.smoke.example"; then
+  echo "FAIL: explicit gateway.host override not propagated to HTTPRoute hostnames"
+  exit 1
+fi
+if echo "$route_block_override" | grep -q "keycloak.smoke.omani.works"; then
+  echo "FAIL: explicit override leaked the case-1 hostname"
+  exit 1
+fi
+echo "[bp-keycloak] Case 4: PASS"
+
+echo "[bp-keycloak] All HTTPRoute render cases PASS"

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.2.18
+  version: 1.2.19
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -4,7 +4,7 @@ name: bp-openbao
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.2.18
+version: 1.2.19
 description: |
   Catalyst-curated Blueprint umbrella chart for OpenBao. Depends on the
   upstream `openbao` chart as a Helm subchart so `helm dependency build`

--- a/platform/openbao/chart/tests/httproute-render.sh
+++ b/platform/openbao/chart/tests/httproute-render.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# bp-openbao — HTTPRoute render audit (Wave 5.85 #2425).
+#
+# Verifies the chart renders a Cilium Gateway HTTPRoute when the
+# bootstrap-kit overlay flips `gateway.enabled: true` + sets
+# `gateway.host`. The default-values CI smoke does NOT exercise this
+# path because the chart defaults `gateway.enabled` to false (correct
+# for standalone-install on non-Catalyst clusters). Without this guard
+# a regression in `templates/httproute.yaml` (gate condition, hostname
+# templating, parentRef typo) ships fresh-prov NXDOMAIN to every
+# Sovereign + only surfaces on operator walk — exactly the #2421
+# symptom that drove Wave 5.84 for bp-newapi.
+#
+# Cases:
+#   1. Overlay-enabled render — HTTPRoute kind present with correct
+#      hostname
+#   2. parentRefs cite canonical Cilium Gateway
+#      (`cilium-gateway` in `kube-system`)
+#   3. Default-off path — no HTTPRoute kind in render output
+#      (silent-skip behaviour preserved for standalone-install
+#      contexts on non-Catalyst clusters)
+#   4. Operator host override propagates correctly
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+# ── Case 1: HTTPRoute renders with overlay-enabled values ─────────────
+echo "[bp-openbao] Case 1: overlay-enabled render — HTTPRoute present + correct hostname"
+out=$("$helm" template smoke "$chart_dir" \
+        --set gateway.enabled=true \
+        --set gateway.host=openbao.smoke.omani.works 2>&1)
+
+route_block=$(echo "$out" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
+if [ -z "$route_block" ]; then
+  echo "FAIL: HTTPRoute did not render with gateway.enabled=true + gateway.host"
+  echo "(would surface on fresh Sovereign prov as NXDOMAIN for openbao.<fqdn>)"
+  exit 1
+fi
+if ! echo "$route_block" | grep -q "openbao.smoke.omani.works"; then
+  echo "FAIL: HTTPRoute hostname does not match gateway.host"
+  echo "$route_block"
+  exit 1
+fi
+echo "[bp-openbao] Case 1: PASS"
+
+# ── Case 2: parentRefs cite canonical Cilium Gateway ──────────────────
+echo "[bp-openbao] Case 2: parentRefs cite 'cilium-gateway' in 'kube-system'"
+if ! echo "$route_block" | grep -q "name: \"cilium-gateway\""; then
+  echo "FAIL: HTTPRoute parentRefs do not cite name=cilium-gateway"
+  exit 1
+fi
+if ! echo "$route_block" | grep -q "namespace: \"kube-system\""; then
+  echo "FAIL: HTTPRoute parentRefs do not cite namespace=kube-system"
+  exit 1
+fi
+echo "[bp-openbao] Case 2: PASS"
+
+# ── Case 3: default-off path — HTTPRoute absent ───────────────────────
+echo "[bp-openbao] Case 3: default-off path — HTTPRoute not rendered"
+out_default=$("$helm" template smoke "$chart_dir" 2>&1)
+if echo "$out_default" | grep -q "^kind: HTTPRoute$"; then
+  echo "FAIL: HTTPRoute should NOT render when gateway.enabled is unset (default)"
+  exit 1
+fi
+echo "[bp-openbao] Case 3: PASS"
+
+# ── Case 4: operator host override propagates ─────────────────────────
+echo "[bp-openbao] Case 4: operator override of gateway.host"
+out_override=$("$helm" template smoke "$chart_dir" \
+        --set gateway.enabled=true \
+        --set gateway.host=custom.smoke.example 2>&1)
+
+route_block_override=$(echo "$out_override" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
+if ! echo "$route_block_override" | grep -q "custom.smoke.example"; then
+  echo "FAIL: explicit gateway.host override not propagated to HTTPRoute hostnames"
+  exit 1
+fi
+if echo "$route_block_override" | grep -q "openbao.smoke.omani.works"; then
+  echo "FAIL: explicit override leaked the case-1 hostname"
+  exit 1
+fi
+echo "[bp-openbao] Case 4: PASS"
+
+echo "[bp-openbao] All HTTPRoute render cases PASS"


### PR DESCRIPTION
Refs #2425 #2421 — 5-chart batch (gitea/grafana/harbor/keycloak/openbao) lockstep bump + smoke fan-out per the Wave 5.84 pattern. Batch B (3 charts) + C (1 chart) follow.