### PR TITLE
feat(bp-kyverno-policies): bootstrap-mode override (Wave 5.90 phase 2a)

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -42,7 +42,7 @@ spec:
   chart:
     spec:
       chart: bp-kyverno-policies
-      version: 1.0.2
+      version: 1.0.3
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.2
+  version: 1.0.3
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -19,7 +19,7 @@ description: |
   ClusterPolicy CRs. CRDs are provided by the engine chart's upstream
   Kyverno subchart at slot 27.
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/templates/_helpers.tpl
+++ b/platform/kyverno-policies/chart/templates/_helpers.tpl
@@ -1,0 +1,44 @@
+{{- /*
+bp-kyverno-policies — shared template helpers.
+
+Wave 5.90 phase 2 (#2436) introduces a global `bootstrapMode` toggle
+that overrides every per-policy `action` (Audit | Enforce) to Audit
+while a Sovereign is still mid-Phase-1. The post-handover mechanism
+(catalyst-api sets `compliancePolicies.bootstrapMode: false` on the
+HelmRelease values, Flux reconciles, Helm upgrades the policies to
+their canonical Enforce/Audit defaults) lets governance policies be
+authored once with their target-state action without blocking Phase 1
+bootstrap.
+
+Why this matters: when a fresh Sovereign installs bp-kyverno-policies
+mid-Phase-1, many bp-* workloads have not yet rendered their
+annotations / replica counts / probe configs / Harbor image refs.
+Policies in Enforce mode then fail-closed on Pod admission, wedging
+bp-keycloak / bp-cnpg / etc., cascading to a deadlocked Phase 1
+(observed live on d3c6268c 2026-05-24T20:30Z — root cause for
+Wave 5.90 #2436). Audit mode is non-blocking; PolicyReport rows still
+emit for the Compliance Dashboard, but admission passes.
+*/ -}}
+
+{{- /*
+bp-kyverno-policies.action — resolves the effective validationFailureAction
+for a single ClusterPolicy.
+
+  - When `.Values.compliancePolicies.bootstrapMode` is true (default for
+    fresh Sovereigns), returns "Audit" regardless of the per-policy
+    canonical action.
+  - When false (post-handover Catalyst flips it), returns the per-policy
+    canonical action (.policy), defaulting to "Audit" when unset.
+
+Usage in a ClusterPolicy template:
+
+  spec:
+    validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.<name>.action) }}
+*/ -}}
+{{- define "bp-kyverno-policies.action" -}}
+{{- if .ctx.Values.compliancePolicies.bootstrapMode -}}
+Audit
+{{- else -}}
+{{- .policy | default "Audit" -}}
+{{- end -}}
+{{- end -}}

--- a/platform/kyverno-policies/chart/templates/baseline/01-multi-replica.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/01-multi-replica.yaml
@@ -34,7 +34,7 @@ metadata:
       voluntary disruptions (node drains, rolling updates) can preserve
       at least one healthy replica.
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.multiReplica.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.multiReplica.action) }}
   background: true
   rules:
     - name: replicas-at-least-two

--- a/platform/kyverno-policies/chart/templates/baseline/02-pdb.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/02-pdb.yaml
@@ -39,7 +39,7 @@ metadata:
       to the workload's full replica count) wedges every voluntary
       disruption. This policy rejects PDBs whose maxUnavailable is 0.
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.pdb.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.pdb.action) }}
   background: true
   rules:
     - name: pdb-maxunavailable-not-zero

--- a/platform/kyverno-policies/chart/templates/baseline/03-topology-spread.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/03-topology-spread.yaml
@@ -36,7 +36,7 @@ metadata:
       or topology.kubernetes.io/zone, so a single host or AZ failure
       can't take down every replica.
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.topologySpread.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.topologySpread.action) }}
   background: true
   rules:
     - name: workload-must-declare-spread

--- a/platform/kyverno-policies/chart/templates/baseline/04-probes.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/04-probes.yaml
@@ -33,7 +33,7 @@ metadata:
       probes, kubelet can't detect a wedged process and Service can't
       gate traffic during startup.
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.probesPresent.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.probesPresent.action) }}
   background: true
   rules:
     - name: containers-must-have-liveness-and-readiness

--- a/platform/kyverno-policies/chart/templates/baseline/05-resource-requests.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/05-resource-requests.yaml
@@ -30,7 +30,7 @@ metadata:
       pressure and can't be reasoned about for capacity planning or
       per-Org cost rollups.
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.resourceRequests.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.resourceRequests.action) }}
   background: true
   rules:
     - name: containers-must-declare-cpu-memory-requests

--- a/platform/kyverno-policies/chart/templates/baseline/06-resource-limits.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/06-resource-limits.yaml
@@ -30,7 +30,7 @@ metadata:
       resources.limits.memory. Without limits, a single Pod can
       exhaust a node and starve neighbors.
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.resourceLimits.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.resourceLimits.action) }}
   background: true
   rules:
     - name: containers-must-declare-cpu-memory-limits

--- a/platform/kyverno-policies/chart/templates/baseline/07-pvc-expansion.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/07-pvc-expansion.yaml
@@ -33,7 +33,7 @@ metadata:
       allowVolumeExpansion=true so storage can grow without rebuilding
       the volume.
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.pvcExpansion.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.pvcExpansion.action) }}
   background: true
   rules:
     - name: storageclass-must-allow-expansion

--- a/platform/kyverno-policies/chart/templates/baseline/08-hpa-effective.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/08-hpa-effective.yaml
@@ -37,7 +37,7 @@ metadata:
       Pod count) is checked by the compliance-aggregator's hpa.go
       evaluator (slice W2).
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.hpaEffective.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.hpaEffective.action) }}
   background: true
   rules:
     - name: hpa-minreplicas-positive

--- a/platform/kyverno-policies/chart/templates/baseline/09-cilium-l7-mtls.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/09-cilium-l7-mtls.yaml
@@ -38,7 +38,7 @@ metadata:
       "is there an actual selecting CNP/CCNP" check lives in the W2
       hubble evaluator.
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.ciliumL7Mtls.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.ciliumL7Mtls.action) }}
   background: true
   rules:
     - name: cilium-enforced-label

--- a/platform/kyverno-policies/chart/templates/baseline/10-flux-managed.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/10-flux-managed.yaml
@@ -38,7 +38,7 @@ metadata:
       Direct kubectl apply is rejected — IaC-first per
       docs/INVIOLABLE-PRINCIPLES.md #3.
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.fluxManaged.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.fluxManaged.action) }}
   background: true
   rules:
     - name: workload-must-be-flux-managed

--- a/platform/kyverno-policies/chart/templates/baseline/11-harbor-proxy.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/11-harbor-proxy.yaml
@@ -36,7 +36,7 @@ metadata:
       registry. Operator configures the allowed regex via
       .Values.compliancePolicies.harborProxyPull.allowedRegistryRegex.
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.harborProxyPull.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.harborProxyPull.action) }}
   background: true
   rules:
     - name: image-must-be-from-harbor-proxy

--- a/platform/kyverno-policies/chart/templates/baseline/12-image-tag-pinned.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/12-image-tag-pinned.yaml
@@ -31,7 +31,7 @@ metadata:
       a @sha256: digest). Floating tags break SHA-pinned audit trails
       and reproducibility.
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.imageTagPinned.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.imageTagPinned.action) }}
   background: true
   rules:
     - name: image-must-have-explicit-tag

--- a/platform/kyverno-policies/chart/templates/baseline/13-prometheus-scrape.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/13-prometheus-scrape.yaml
@@ -32,7 +32,7 @@ metadata:
       OR the workload labels declare monitoring.coreos.com/managed=true
       indicating an operator-managed PodMonitor / ServiceMonitor exists.
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.prometheusScrape.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.prometheusScrape.action) }}
   background: true
   rules:
     - name: workload-must-be-scrape-targeted

--- a/platform/kyverno-policies/chart/templates/baseline/14-networkpolicy-present.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/14-networkpolicy-present.yaml
@@ -31,7 +31,7 @@ metadata:
       Namespaces must contain at least one NetworkPolicy or
       CiliumNetworkPolicy so east-west traffic is mediated.
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.networkpolicyPresent.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.networkpolicyPresent.action) }}
   background: true
   rules:
     - name: namespace-must-have-networkpolicy

--- a/platform/kyverno-policies/chart/templates/baseline/15-otel-injected.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/15-otel-injected.yaml
@@ -34,7 +34,7 @@ metadata:
       `instrumentation.opentelemetry.io/inject-*: "true"` annotation on
       the Pod template (auto-injection by the OTel operator).
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.otelInjected.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.otelInjected.action) }}
   background: true
   rules:
     - name: workload-must-be-otel-instrumented

--- a/platform/kyverno-policies/chart/templates/baseline/17-runasnonroot-readonlyrootfs.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/17-runasnonroot-readonlyrootfs.yaml
@@ -30,7 +30,7 @@ metadata:
       Pods must declare runAsNonRoot=true at Pod or container level
       AND every container must set readOnlyRootFilesystem=true.
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.runAsNonRootReadonlyRootFs.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.runAsNonRootReadonlyRootFs.action) }}
   background: true
   rules:
     - name: pod-level-or-container-level-runasnonroot

--- a/platform/kyverno-policies/chart/templates/baseline/18-cosign-verified.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/18-cosign-verified.yaml
@@ -35,7 +35,7 @@ metadata:
       verifying public key (or Sigstore Rekor URL) is operator-supplied
       per Sovereign overlay.
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.cosignVerified.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.cosignVerified.action) }}
   background: false
   rules:
     - name: cosign-verify

--- a/platform/kyverno-policies/chart/templates/baseline/19-secret-not-in-env.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/19-secret-not-in-env.yaml
@@ -35,7 +35,7 @@ metadata:
       *KEY* / *SECRET* must use valueFrom.secretKeyRef, not a
       plaintext value.
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.secretNotInEnv.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.secretNotInEnv.action) }}
   background: true
   rules:
     - name: deny-plaintext-secret-env

--- a/platform/kyverno-policies/chart/templates/baseline/20-backup-configured.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/20-backup-configured.yaml
@@ -40,7 +40,7 @@ metadata:
       `velero.io/backup-volumes` on the owning Pod template OR label
       `velero.io/managed-by-schedule` on the PVC itself.
 spec:
-  validationFailureAction: {{ .Values.compliancePolicies.backupConfigured.action | default "Audit" }}
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.backupConfigured.action) }}
   background: true
   rules:
     - name: pvc-must-be-velero-backed

--- a/platform/kyverno-policies/chart/values.yaml
+++ b/platform/kyverno-policies/chart/values.yaml
@@ -29,6 +29,25 @@
 #
 # Per docs/INVIOLABLE-PRINCIPLES.md #4 — every value is overridable.
 compliancePolicies:
+  # Wave 5.90 phase 2 (#2436) — bootstrap-mode override.
+  #
+  # When true (DEFAULT, fresh-prov posture), every policy's effective
+  # validationFailureAction is forced to "Audit" regardless of its
+  # per-policy canonical action. PolicyReport rows still emit (visible
+  # in the Compliance Dashboard), but admission passes — no Pod-create
+  # gets fail-closed-blocked during Phase 1 bootstrap.
+  #
+  # The catalyst-api post-handover hook flips this to false once the
+  # Sovereign reaches handover-complete; Flux re-reconciles bp-kyverno-
+  # policies; Helm upgrades the ClusterPolicies to their canonical
+  # Enforce mode where the per-policy values declare it.
+  #
+  # Manual operator override (skip the post-handover auto-flip):
+  #   --set compliancePolicies.bootstrapMode=false
+  # to install all policies at their canonical action immediately
+  # (NOT recommended on fresh prov — see #2436 multi-layer RCA).
+  bootstrapMode: true
+
   # K1 baseline policies
   #
   # Default = enabled: true with action: Audit (permissive). Per #1929 the


### PR DESCRIPTION
Refs #2436 #2437 — defense piece of admission-webhook cascade deadlock. Chart-side: helper + 19 template patches + values toggle. Helm-template smoke verified both modes. Lockstep 2.0.4→2.0.5. Phase 2b (catalyst-api post-handover hook) separate.