### PR TITLE
fix(huawei-sigv3): canonicalURI always trailing-slash (Wave 5.91)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/providers/huawei/sigv3.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/sigv3.go
@@ -159,13 +159,37 @@ func canonicalHeaders(h http.Header) (string, string) {
 }
 
 // canonicalURI returns the path component encoded per the signing
-// spec — a leading slash, trailing slash if the original URI had
-// one. Spec is identical to AWS SigV4.
+// spec. Spec is AWS SigV4 compatible with one HCS divergence: HCS
+// expects the canonical URI to ALWAYS end with `/` (even when the
+// request URI itself does not), per the empirical error response
+// returned by HCS endpoints:
+//
+//	{"error_msg":"...verify aksk signature fail, canonical_request:
+//	GET|/v1/<project>/publicips/||host:vpc.<region>.kom4dc...|x-sdk-
+//	date:<ts>||host;x-sdk-date|<bodyHash>"}
+//
+// Note the trailing `/` after `publicips` in the server's expected
+// canonical-request — even though the actual request URI was
+// `/v1/<project>/publicips` without trailing slash. Pre-Wave-5.91
+// this function returned `u.EscapedPath()` verbatim, missing the
+// trailing slash, causing every Huawei orphan-sweep API call to
+// fail with HTTP 401 verify-aksk-signature-fail. Surfaced live on
+// the d3c6268c wipe (#2423 / #2428 Bug 2) — wipe handler's orphan
+// sweep silently no-op'd because every ECS/VPC/EIP/SG list call
+// 401'd, leaving Huawei resources alive after the wipe.
+//
+// Spec reference: AWS SigV4 + HCS-specific trailing-slash convention
+// verified by 7+ successful API calls from a Python reference
+// implementation (see /tmp/huawei-sigv3.py in the #2423 walk).
 func canonicalURI(u *url.URL) string {
 	if u == nil || u.Path == "" {
 		return "/"
 	}
-	return u.EscapedPath()
+	p := u.EscapedPath()
+	if !strings.HasSuffix(p, "/") {
+		p += "/"
+	}
+	return p
 }
 
 // canonicalQueryString builds the sorted key=val canonical form.

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/sigv3_test.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/sigv3_test.go
@@ -1,0 +1,45 @@
+// sigv3_test.go — pins the canonical URI trailing-slash convention
+// per Wave 5.91 (#2428 Bug 2 fix).
+//
+// HCS expects canonical-request URIs to ALWAYS end with `/`, even when
+// the request URI itself does not. The Wave 5.91 fix at sigv3.go's
+// canonicalURI handles this; this test pins the behavior so a future
+// "spec-compliance" refactor doesn't silently regress.
+
+package huawei
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestCanonicalURI_AlwaysTrailingSlash(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty url returns root", "", "/"},
+		{"already-trailing-slash preserved", "https://vpc.example.com/v1/projects/", "/v1/projects/"},
+		{"trailing-slash-appended for HCS", "https://vpc.example.com/v1/projects/abc/publicips", "/v1/projects/abc/publicips/"},
+		{"deep path gets trailing-slash", "https://ecs.example.com/v1/proj/cloudservers/detail", "/v1/proj/cloudservers/detail/"},
+		{"root-only stays root", "https://api.example.com/", "/"},
+		{"path-with-uuid trailing-slash", "https://vpc.example.com/v1/proj/vpcs/abc-123-def", "/v1/proj/vpcs/abc-123-def/"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var u *url.URL
+			if c.in != "" {
+				var err error
+				u, err = url.Parse(c.in)
+				if err != nil {
+					t.Fatalf("parse %q: %v", c.in, err)
+				}
+			}
+			got := canonicalURI(u)
+			if got != c.want {
+				t.Errorf("canonicalURI(%q) = %q; want %q", c.in, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refs #2428 Bug 2 #2423 — closes the canonical-URI shape divergence that broke Huawei orphan-sweep. Build + tests PASS.