### PR TITLE
fix(bp-cilium): per-container apparmor:unconfined for HCS Kom4DC init-container nsenter

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -109,6 +109,42 @@ spec:
       envoyConfig:
         enabled: true
       l7Proxy: true
+      # Wave 5.127 (#TBD-hw30-apparmor): explicit per-container apparmor
+      # annotations on the agent DaemonSet pods. Why this is mandatory on
+      # HCS Kom4DC (and likely any host with cri-containerd.apparmor.d in
+      # enforce mode + kernel.yama.ptrace_scope=1):
+      #
+      # The agent's `mount-cgroup` initContainer runs:
+      #   nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt
+      # to bootstrap the host-side cgroup v2 mount at /run/cilium/cgroupv2.
+      # Opening /proc/1/ns/cgroup requires ptrace_may_access on PID 1.
+      # Even with SYS_PTRACE+SYS_ADMIN+SYS_CHROOT in the container's
+      # CapEff, the default cri-containerd.apparmor.d profile DENIES the
+      # ptrace operation. Result: `nsenter: cannot open
+      # /hostproc/1/ns/cgroup: Permission denied` → mount-cgroup
+      # Init:CrashLoopBackOff → cilium-agent never starts → cilium-envoy
+      # on that node has no xDS source → Gateway listener never binds on
+      # that node's :30443/:30080 → ELB health-check flips that node's
+      # member OFFLINE → tail-latency request gets routed to a worker
+      # whose envoy isn't serving → connection-refused/timeout on TLS.
+      #
+      # The upstream chart sets pod-level
+      # `spec.securityContext.appArmorProfile.type: Unconfined` (the
+      # post-v1.30 modern API). On k3s 1.31 this pod-level field does
+      # NOT propagate to init containers. The deprecated per-container
+      # annotation (still honored through v1.31) is the only form that
+      # works for init containers. Verified live on hw29 cp1 2026-05-27:
+      # before the annotations 3 of 8 cilium agents Init:CrashLoopBackOff
+      # with the nsenter error; after the annotations all 8 Ready 1/1
+      # and HTTPS 200 stable on all ELB members.
+      podAnnotations:
+        container.apparmor.security.beta.kubernetes.io/cilium-agent: unconfined
+        container.apparmor.security.beta.kubernetes.io/config: unconfined
+        container.apparmor.security.beta.kubernetes.io/mount-cgroup: unconfined
+        container.apparmor.security.beta.kubernetes.io/apply-sysctl-overwrites: unconfined
+        container.apparmor.security.beta.kubernetes.io/mount-bpf-fs: unconfined
+        container.apparmor.security.beta.kubernetes.io/clean-cilium-state: unconfined
+        container.apparmor.security.beta.kubernetes.io/install-cni-binaries: unconfined
       prometheus:
         enabled: false
         serviceMonitor:


### PR DESCRIPTION
## Summary
- `clusters/_template/bootstrap-kit/01-cilium.yaml`: add 7 per-container `container.apparmor.security.beta.kubernetes.io/<name>: unconfined` annotations to `cilium.podAnnotations`. This makes `mount-cgroup`, `apply-sysctl-overwrites`, `mount-bpf-fs`, `clean-cilium-state`, `install-cni-binaries`, `cilium-agent`, `config` all run `Unconfined` against the host `cri-containerd.apparmor.d` profile.

## Why
On HCS Kom4DC Ubuntu 22.04.2 (kernel 5.15.0-76-generic, k3s 1.31.4+k3s1, Cilium 1.16.5), the agent's `mount-cgroup` init runs `nsenter --cgroup=/hostproc/1/ns/cgroup …` which requires `ptrace_may_access` on host PID 1. The default `cri-containerd.apparmor.d` profile (enforce mode) DENIES this ptrace even with SYS_PTRACE+SYS_ADMIN in CapEff. The upstream chart sets pod-level `securityContext.appArmorProfile.type: Unconfined` (the modern post-v1.30 API), but this does NOT propagate to init containers via k3s 1.31 kubelet — only the deprecated annotation form does.

Without this fix, every `kubectl rollout restart ds/cilium` or chart bump leaves N workers Init:CrashLoopBackOff → cilium-envoy on those workers has no xDS source → Gateway listener never binds → ELB health flips members OFFLINE → tail-latency requests hit a worker whose envoy isn't serving → HTTPS connection refused/timeout on `console.<sovereign-fqdn>`.

Verified runtime patch on hw29 cp1 2026-05-27: before annotations, 3 of 8 cilium agents Init:CrashLoopBackOff (workers w2/w5/w6); after, all 8 Ready 1/1 + HTTPS 200 stable on all 9 ELB members + sign-in PIN issue 200.

## Test plan
- [ ] hw30 fresh prov reaches HTTPS 200 + LE prod cert + PIN issue 200 zero-touch.
- [ ] `kubectl --kubeconfig hw30 -n kube-system rollout restart ds/cilium` completes with 0 pods entering `Init:CrashLoopBackOff`.
- [ ] All ELB members stay ONLINE during the rollout.

Refs #2475

🤖 Generated with [Claude Code](https://claude.com/claude-code)