### PR TITLE
Wave 5.128+5.129: HCS-specific tofu fixes (ELB lifecycle, parallelism cap)

### DIFF
--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -823,6 +823,26 @@ resource "huaweicloud_elb_loadbalancer" "primary" {
   ipv4_eip_id       = huaweicloud_vpc_eip.elb_primary.id
   availability_zone = [var.huawei_az]
   description       = "Catalyst Sovereign ${var.sovereign_fqdn} — Wave 5.98 Cilium-Gateway-API 443→30443 + 80→30080 routing"
+
+  # Wave 5.128 (hw30 fix-forward 2026-05-27): ignore_changes on flavor IDs.
+  # The huaweicloud provider sends `l4_flavor_id: null` + `l7_flavor_id: null`
+  # on PUT when neither is explicitly set in the resource block (HCS auto-
+  # picks flavors at create-time, and the provider's update path doesn't
+  # round-trip them on subsequent plans). HCS rejects with ELB.8959 "Not
+  # allowed to update both l4_flavor_id and l7_flavor_id to null or empty".
+  # Caught on hw30 #4 + hw29 Wave 5.122 — every tofu apply that touches
+  # any child of the LB (member port change, listener update) cascades to
+  # an attempted LB PUT that fails the apply.
+  #
+  # Flavor IDs are immutable post-create — ignore them so subsequent plans
+  # don't churn. If we ever need to resize the LB, the canonical path is
+  # tofu taint + recreate, not in-place flavor update.
+  lifecycle {
+    ignore_changes = [
+      l4_flavor_id,
+      l7_flavor_id,
+    ]
+  }
 }
 
 resource "huaweicloud_elb_pool" "https" {

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1187,7 +1187,17 @@ func (p *Provisioner) Provision(ctx context.Context, req Request, events chan<- 
 	}
 
 	emit("tofu-apply", "info", "Applying — this provisions real Hetzner resources, please wait")
-	if err := p.runTofu(ctx, deployDir, []string{"apply", "-input=false", "-no-color", "-auto-approve", "tfplan"}, emit); err != nil {
+	// Wave 5.129 (hw30 fix-forward 2026-05-27): cap tofu parallelism at 2.
+	// Default 10 fanned out 8+ worker ECS creates simultaneously, which
+	// overloaded the HCS scheduler's CollectInfoTask and returned
+	// `Common.0021: CollectInfoTask-fail: Sub job fail!` on 4 of 8
+	// workers on hw30 #4. Cap=2 lets the scheduler keep up with worker
+	// creates while still parallelising independent resource graphs
+	// (VPC + subnet + SG + KPS keypair + OBS bucket all create together).
+	// CP creates serialised by the for_each chain naturally; only the
+	// parallel WORKER fanout was overloading HCS.
+	applyArgs := []string{"apply", "-input=false", "-no-color", "-auto-approve", "-parallelism=2", "tfplan"}
+	if err := p.runTofu(ctx, deployDir, applyArgs, emit); err != nil {
 		return nil, fmt.Errorf("tofu apply: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- **Wave 5.128 (#2478)**: `huaweicloud_elb_loadbalancer.primary` gets `lifecycle.ignore_changes = [l4_flavor_id, l7_flavor_id]`. HCS auto-picks flavors at create-time; the huaweicloud tofu provider's update path sends both as null, HCS rejects with `ELB.8959 "Not allowed to update both l4_flavor_id and l7_flavor_id to null or empty"`. Caught on hw29 Wave 5.122 + hw30 #4.
- **Wave 5.129 (#2479)**: catalyst-api's tofu apply invocation gains `-parallelism=2`. Default 10 fans out 8 worker ECS creates simultaneously → overloads HCS scheduler → `Common.0021: CollectInfoTask-fail` on multiple workers. Cap=2 lets HCS keep up; independent resource graphs still create concurrently.

## Test plan
- [ ] hw30 fresh prov reaches Phase 0 GREEN on first try (no `ELB.8959`, no `Common.0021`).
- [ ] Phase 0 apply duration stays under 8 min (parallelism=2 should add only ~3 min vs default 10).

Refs #2478 #2479

🤖 Generated with [Claude Code](https://claude.com/claude-code)