### PR TITLE
fix(huawei): Wave 5.131 extend ELB lifecycle.ignore_changes

### DIFF
--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -841,6 +841,15 @@ resource "huaweicloud_elb_loadbalancer" "primary" {
     ignore_changes = [
       l4_flavor_id,
       l7_flavor_id,
+      # Wave 5.131 (hw30 fix-forward 2026-05-27): provider also sends
+      # null for vpc_id + ipv4_eip_id on subsequent plans (same shape
+      # as the flavor-id bug — HCS auto-pins both at create, provider's
+      # update path doesn't round-trip them). Apply errors:
+      #   * vpc_id can't be updated, <existing> -> ""
+      #   * ipv4_eip_id can't be updated, <existing> -> ""
+      # Both are immutable post-create; ignore them.
+      vpc_id,
+      ipv4_eip_id,
     ]
   }
 }


### PR DESCRIPTION
Extends Wave 5.128 to cover vpc_id + ipv4_eip_id which provider also sends null on update plans. Caught on hw30 #6 retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)