### PR TITLE
feat(vclusters): symmetric MGMT+RTZ on every region (Refs #2537)

### DIFF
--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -70,7 +70,7 @@ spec:
   chart:
     spec:
       chart: bp-mgmt-vcluster
-      version: 0.1.0
+      version: 0.1.1
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
@@ -62,7 +62,7 @@ spec:
   chart:
     spec:
       chart: bp-rtz-vcluster
-      version: 0.1.0
+      version: 0.1.1
       sourceRef:
         kind: HelmRepository
         name: bp-rtz-vcluster

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.1.0
+  version: 0.1.1
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -4,9 +4,11 @@ name: bp-mgmt-vcluster
 # (sovereign-multi-region-DoD invariant #4). Founder ruling
 # 2026-05-16: every Sovereign must materialise the MGMT + DMZ + RTZ
 # vCluster topology before convergence is declared. Slot 58 in the
-# bootstrap-kit (renders ONLY on the primary region — secondaries
-# render bp-dmz-vcluster + bp-rtz-vcluster instead).
-version: 0.1.0
+# bootstrap-kit.
+# 0.1.1 — Refs #2537: default `mgmtVcluster.enabled` flipped false→true
+# so every region renders the MGMT vCluster (symmetric topology
+# supersedes asymmetric A4).
+version: 0.1.1
 appVersion: "0.20.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -33,11 +33,18 @@ global:
   imageRegistry: ""
 
 mgmtVcluster:
-  # Top-level enable gate. When false, NO resources render. The
-  # bootstrap-kit Kustomization sets this true via postBuild.substitute
-  # ONLY on the primary region (see clusters/_template/bootstrap-kit/
-  # 58-bp-mgmt-vcluster.yaml).
-  enabled: false
+  # Top-level enable gate.
+  #
+  # Founder direction 2026-05-28 (Refs #2537): every region runs the
+  # symmetric triad MGMT+RTZ+DMZ. The historical asymmetric A4 contract
+  # (primary=MGMT+DMZ, secondary=DMZ+RTZ) is superseded — the
+  # SOVEREIGN_REGION_ROLE gate that would have flipped this on only on
+  # primary regions never landed, and is no longer needed.
+  #
+  # Default ON: this slot renders on every region of every Sovereign.
+  # Operators who want to opt out (single-region SME tier) flip this
+  # to false via per-Sovereign overlay.
+  enabled: true
 
   # ── Topology identity ───────────────────────────────────────────────
   # Host namespace this vCluster's pods land in (inside the HOST k3s).

--- a/platform/bp-rtz-vcluster/blueprint.yaml
+++ b/platform/bp-rtz-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.1.0
+  version: 0.1.1
   card:
     title: RTZ vCluster
     summary: |

--- a/platform/bp-rtz-vcluster/chart/Chart.yaml
+++ b/platform/bp-rtz-vcluster/chart/Chart.yaml
@@ -3,11 +3,12 @@ name: bp-rtz-vcluster
 # 0.1.0 — initial implementation of DoD A4 vCluster topology
 # (sovereign-multi-region-DoD invariant #4). Founder ruling
 # 2026-05-16: every secondary region must materialise an RTZ
-# vCluster for regional tenant workloads + caches.
-#
-# Slot 59 in the bootstrap-kit (renders ONLY on secondary regions —
-# primaries host MGMT + DMZ, secondaries host DMZ + RTZ).
-version: 0.1.0
+# vCluster for regional tenant workloads + caches. Slot 59 in the
+# bootstrap-kit.
+# 0.1.1 — Refs #2537: default `rtzVcluster.enabled` flipped false→true
+# so every region renders the RTZ vCluster (symmetric topology
+# supersedes asymmetric A4).
+version: 0.1.1
 appVersion: "0.20.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign RTZ

--- a/platform/bp-rtz-vcluster/chart/values.yaml
+++ b/platform/bp-rtz-vcluster/chart/values.yaml
@@ -13,9 +13,17 @@ global:
   imageRegistry: ""
 
 rtzVcluster:
-  # Top-level enable gate. False by default; bootstrap-kit slot 59
-  # postBuild.substitute flips it on ONLY for secondary regions.
-  enabled: false
+  # Top-level enable gate.
+  #
+  # Founder direction 2026-05-28 (Refs #2537): every region runs the
+  # symmetric triad MGMT+RTZ+DMZ. The historical asymmetric A4 contract
+  # (primary=MGMT+DMZ, secondary=DMZ+RTZ) is superseded — the
+  # SOVEREIGN_REGION_ROLE gate that would have flipped this on only on
+  # secondary regions never landed, and is no longer needed.
+  #
+  # Default ON: this slot renders on every region of every Sovereign.
+  # Operators who want to opt out flip via per-Sovereign overlay.
+  enabled: true
 
   # ── Topology identity ───────────────────────────────────────────────
   hostNamespace: rtz


### PR DESCRIPTION
Founder direction 2026-05-28: 2 regions identical, both running 3 vClusters (MGMT + RTZ + DMZ). Supersedes asymmetric A4 contract.

## Background

The original A4 contract (`docs/DOD.md`) said primary=MGMT+DMZ, secondary=DMZ+RTZ — with the asymmetry gated by a `SOVEREIGN_REGION_ROLE` postBuild.substitute introduced 2026-05-16. **That substitute key never landed**. Both bp-mgmt-vcluster and bp-rtz-vcluster have been silently OFF on every Sovereign as a result (defaults `enabled: false` waiting on a substitute that was never wired). Today's Sovereigns therefore render only the DMZ vCluster (slot 54). This PR fixes the missed contract by adopting the simpler, symmetric topology.

## Changes
- `platform/bp-mgmt-vcluster/chart/values.yaml` → `mgmtVcluster.enabled` default false → **true**
- `platform/bp-rtz-vcluster/chart/values.yaml` → `rtzVcluster.enabled` default false → **true**
- Lockstep bumps 0.1.0 → 0.1.1 in both chart `Chart.yaml` + `blueprint.yaml` + bootstrap-kit pin (58-bp-mgmt-vcluster.yaml + 59-bp-rtz-vcluster.yaml)

## Topology after this PR

Every region of every Sovereign reconciles:
- DMZ vCluster (slot 54, already on)
- **MGMT vCluster (slot 58, this PR turns on)**
- **RTZ vCluster (slot 59, this PR turns on)**

For a 2-region Sovereign that's **6 vClusters total**, identical shape per region.

## Scope
- Hetzner: same change applies — Hetzner Sovereigns will start rendering MGMT+RTZ vClusters on every region.
- Existing single-region Sovereigns: same change — they get 1 extra MGMT + 1 extra RTZ vCluster, both nodeSelector-pinned to their CP node. Operators wanting legacy single-region SME shape can flip these false in per-Sovereign overlay.

Refs #2537 (G6)
Part of umbrella Refs #2532 (multi-region mimic on HCS)