### PR TITLE
fix(huawei): per-region CP cloud-init + ClusterMesh anchors (Refs #2533 #2535)

### DIFF
--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -511,7 +511,7 @@ write_files:
             # Kustomization's `cluster.name=$${CLUSTER_MESH_NAME:=}` +
             # `cluster.id=$${CLUSTER_MESH_ID:=0}` envsubst (the $$ escape
             # protects the placeholder from rendering at templatefile()
-            # time so Flux's envsubst sees the literal ${VAR} marker).
+            # time so Flux's envsubst sees the literal $${VAR} marker).
             CLUSTER_MESH_NAME: "${cluster_mesh_name}"
             CLUSTER_MESH_ID: "${cluster_mesh_id}"
       ---

--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -501,6 +501,19 @@ write_files:
             QA_PRIMARY_REGION: "${primary_region_canonical_label}"
             SOVEREIGN_PRIMARY_REGION: "${primary_region_canonical_label}"
             SOVEREIGN_REPLICA_REGION: "${replica_region_canonical_label}"
+            # Refs #2533 — G1: per-CP region role. The shared
+            # bootstrap-kit overlays (e.g. bp-cnpg-pair primary/replica
+            # placement) gate on this; primary CP renders "primary",
+            # each secondary CP renders "secondary".
+            SOVEREIGN_REGION_ROLE: "${sovereign_region_role}"
+            # Refs #2535 — G4: Cilium ClusterMesh peer anchors. The
+            # 01-cilium.yaml HelmRelease reads these via the bootstrap-kit
+            # Kustomization's `cluster.name=$${CLUSTER_MESH_NAME:=}` +
+            # `cluster.id=$${CLUSTER_MESH_ID:=0}` envsubst (the $$ escape
+            # protects the placeholder from rendering at templatefile()
+            # time so Flux's envsubst sees the literal ${VAR} marker).
+            CLUSTER_MESH_NAME: "${cluster_mesh_name}"
+            CLUSTER_MESH_ID: "${cluster_mesh_id}"
       ---
       # Wave 5.88 (#2432) — sovereign-tls Kustomization. Port of the
       # canonical Hetzner registration (cloudinit-control-plane.tftpl:1252-1376)

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -566,131 +566,181 @@ locals {
     }), "/(?m)^[ ]*#( |$).*\n/", "")
   }
 
-  control_plane_cloud_init = replace(templatefile("${path.module}/cloudinit-control-plane.tftpl", {
-    sovereign_fqdn      = var.sovereign_fqdn
-    sovereign_fqdn_slug = local.fqdn_slug
-    deployment_id       = var.deployment_id
-    org_name            = var.org_name
-    org_email           = var.org_email
-    region              = var.regions[0].code
-    huawei_region       = var.huawei_region
-    huawei_az           = var.huawei_az
-    k3s_version         = var.k3s_version
-    k3s_token           = sha256("${var.huawei_project_id}/${var.sovereign_fqdn}/k3s-bootstrap")
-    cp_private_ip       = cidrhost(local.region_subnet_cidr[local.region_keys[0]], 2)
-    # Wave 5.56 (Refs #2296) — canonical region labels for the
-    # bootstrap-kit substitute map. Hetzner provider sets these; the
-    # Huawei port missed them, leaving bp-sandbox + downstream HRs
-    # stuck on empty hostCluster. Format mirrors Hetzner pattern:
-    # `hu-<region>-rtz-prod` for replica role, `-mgmt-prod` for primary.
-    region_canonical_label         = "hu-${var.regions[0].code}-rtz-prod"
-    primary_region_canonical_label = "hu-${var.regions[0].code}-rtz-prod"
-    replica_region_canonical_label = length(var.regions) > 1 ? "hu-${var.regions[1].code}-rtz-prod" : ""
-    # Primary CP's EIP — Wave 5.8 (Refs #2140). The kubeconfig PUT-back
-    # from cloud-init must use this EIP, not the private VPC IP, so the
-    # remote mothership (cross-cloud Contabo) can reach the new
-    # Sovereign's apiserver on 6443. The previous template fetched the
-    # EIP from the HCS OpenStack metadata service
-    # (169.254.169.254/openstack/latest/meta_data.json
-    # `.public_ipv4_address`), but HCS doesn't populate that field;
-    # the fallback heuristic (`ip route get 8.8.8.8`) returned the
-    # private subnet IP, baking it into the PUT'd kubeconfig.
-    # Catalyst-api's Phase-1 watch then tried `https://10.30.1.70:6443`
-    # from the mothership Pod (Contabo) and timed out: caught live on
-    # 4bb37cbbb1e23ba8 2026-05-22T21:42Z. By passing the EIP at template
-    # render time (tofu knows it; it just created the EIP), the
-    # template-rendered `sed` substitution uses the right address
-    # deterministically across all CPs and metadata-service shape
-    # divergences across cloud stacks.
-    primary_cp_eip = huaweicloud_vpc_eip.cp[local.region_keys[0]].publicip.0.ip_address
-    # Wave 5.98 (#2447) — Huawei ELB EIP. Sovereign FQDN points HERE,
-    # NOT at the CP EIP. ELB does 443→30443 + 80→30080 to cilium-envoy.
-    elb_eip = huaweicloud_vpc_eip.elb_primary.publicip.0.ip_address
-    # Primary CP's hostname — used by cloud-init to gate the kubeconfig
-    # PUT-back to ONLY the primary region's CP1 (Wave 5.10, Refs #2140).
-    # Wave 5.9 attempted private-IP match (cp_private_ip = subnet .2)
-    # but HCS DHCP doesn't assign .2 deterministically (workers got
-    # .230 + .50 on 747841cadcf90f7e 2026-05-22T22:53Z); no CP's local
-    # IP matched, no PUT-back happened, Phase-1 timed out. Hostname is
-    # deterministic since the ECS resource sets it via `name`.
-    #
-    # Wave 5.148 (hw30 #23 fix-forward 2026-05-27): MUST mirror the CP
-    # name salt that Wave 5.144 introduced — otherwise the hostname-match
-    # gate in cloudinit-control-plane.tftpl (line ~938
-    # `if [ "$HOSTNAME" = "${primary_cp_hostname}" ]`) never fires and
-    # the kubeconfig PUT-back never happens. hw30 #23 reached Phase 0
-    # complete but Phase 1 stalled here because primary_cp_hostname was
-    # still the un-salted form. Mirror formula = same sha256(deployment_id
-    # + region + 'cp' + index + retry_attempt) → first 6 hex chars.
-    primary_cp_hostname = "${local.name_prefix}-${local.region_keys[0]}-cp1-${substr(sha256("${var.deployment_id}-${local.region_keys[0]}-cp0-${var.retry_attempt}"), 0, 6)}"
-    # Wave 5.74 (#2399, founder ask 2026-05-24): per-region CP-1 hostname
-    # map so the cloud-init secondary-kubeconfig PUT-back block can
-    # match each CP to its own region key. JSON-encoded for shell-side
-    # awk/jq parsing. Format: {"<region-key>": "<cp1-hostname>"}.
-    # Wave 5.148: same salt mirroring.
-    region_cp_hostname_map_json = jsonencode({
-      for rk in local.region_keys :
-      rk => "${local.name_prefix}-${rk}-cp1-${substr(sha256("${var.deployment_id}-${rk}-cp0-${var.retry_attempt}"), 0, 6)}"
-    })
-    # Primary region key — for the SAME-region match: the primary CP
-    # PUTs to /api/v1/deployments/{id}/kubeconfig, secondary CPs PUT
-    # to /api/v1/sovereign/secondary-kubeconfig with regionKey body.
-    primary_region_key = local.region_keys[0]
-    # Per-region CP EIP map — secondary CPs rewrite their kubeconfig's
-    # server URL with their own region's EIP before PUT-back.
-    region_cp_eip_map_json = jsonencode({
-      for rk in local.region_keys :
-      rk => huaweicloud_vpc_eip.cp[rk].publicip.0.ip_address
-    })
-    cluster_cidr    = "10.42.0.0/16"
-    service_cidr    = "10.96.0.0/16"
-    gitops_repo_url = var.gitops_repo_url
-    gitops_branch   = var.gitops_branch
-    parent_domains_yaml = coalesce(
-      var.parent_domains_yaml,
-      format("[{name: \"%s\", role: \"primary\"}]", var.sovereign_fqdn)
+  # ── Per-region Cilium ClusterMesh anchors (Refs #2535 — G4) ───────────
+  # Mirror Hetzner main.tf: primary inherits var.cluster_mesh_{name,id};
+  # secondaries derive name = "<sovereign-stem>-<region-stem-no-digits>"
+  # and id = primary + 1 + secondary-index. Auto-derive when var is empty.
+  primary_cluster_mesh_name_effective = (
+    var.cluster_mesh_name != "" ? var.cluster_mesh_name :
+    "${split(".", var.sovereign_fqdn)[0]}-${replace(local.region_keys[0], "/[0-9]+/", "")}"
+  )
+  primary_cluster_mesh_id_effective = (
+    var.cluster_mesh_id > 0 ? var.cluster_mesh_id : 1
+  )
+  cluster_mesh_name_by_region = {
+    for idx, r in var.regions :
+    r.code => (
+      idx == 0 ? local.primary_cluster_mesh_name_effective :
+      "${split(".", var.sovereign_fqdn)[0]}-${replace(r.code, "/[0-9]+/", "")}"
     )
-    ghcr_pull_username         = local.ghcr_pull_username
-    ghcr_pull_token            = var.ghcr_pull_token
-    ghcr_pull_auth_b64         = local.ghcr_pull_auth_b64
-    obs_endpoint               = "https://obs.${var.huawei_region}.kom4dc.nationalcloud.om"
-    obs_region                 = var.huawei_region
-    obs_bucket_name            = var.obs_bucket_name
-    obs_access_key             = var.huawei_access_key
-    obs_secret_key             = var.huawei_secret_key
-    handover_jwt_public_key    = var.handover_jwt_public_key
-    kubeconfig_bearer_token    = var.kubeconfig_bearer_token
-    catalyst_api_url           = var.catalyst_api_url
-    enable_unattended_upgrades = var.enable_unattended_upgrades
-    enable_fail2ban            = var.enable_fail2ban
-    # Wave 5.34 (Refs #2208): Sovereign-side Secret seeds (powerdns DNS-01
-    # cert challenge + PDM basic-auth Day-2 calls). Mirror Hetzner pattern.
-    powerdns_api_key    = var.powerdns_api_key
-    pdm_basic_auth_user = var.pdm_basic_auth_user
-    pdm_basic_auth_pass = var.pdm_basic_auth_pass
-    # Wave 5.118 (#2462): harbor-robot-token for catalyst-api REQUIRED
-    # secretKeyRef. Mirror Hetzner pattern (issue #557 followup).
-    harbor_robot_token = var.harbor_robot_token
-    # Wave 5.16 (Refs #2140): empty placeholder. The CP cloud-init bakes
-    # worker-cloud-init.b64 into /var/lib/catalyst/ for the bp-cluster-
-    # autoscaler-hcloud blueprint to consume on scale-out. On Huawei
-    # that blueprint is disabled (Hetzner-only), so the bake isn't
-    # load-bearing for the POC. Referencing local.worker_cloud_init_by_region
-    # here created a tofu DAG cycle:
-    #   control_plane_cloud_init → worker_cloud_init_by_region →
-    #   cp_primary_private_ip_by_region → huaweicloud_compute_instance.
-    #   control_plane → user_data (= control_plane_cloud_init).
-    # Wave 6+ may serve the worker template via a Huawei-AS hook that
-    # fetches it from a tofu-OBS object instead of pre-baking on the CP.
-    worker_cloud_init_b64 = ""
-    # Wave 5.88 (#2432): wildcard cert issuer selector + marketplace flag
-    # for the sovereign-tls Kustomization (Huawei port of the canonical
-    # Hetzner registration). When wildcard_cert_use_staging=true → LE
-    # staging issuer (no 5/168h rate-limit, useful for repeated reprov);
-    # default false → real-trusted production cert.
-    wildcard_cert_issuer = var.wildcard_cert_use_staging == "true" ? "letsencrypt-dns01-staging-powerdns" : "letsencrypt-dns01-prod-powerdns"
-    marketplace_enabled  = var.marketplace_enabled
-  }), "/(?m)^[ ]*#( |$).*\n/", "")
+  }
+  cluster_mesh_id_by_region = {
+    for idx, r in var.regions :
+    r.code => (idx == 0 ? local.primary_cluster_mesh_id_effective : local.primary_cluster_mesh_id_effective + idx)
+  }
+  region_role_by_region = {
+    for idx, r in var.regions :
+    r.code => (idx == 0 ? "primary" : "secondary")
+  }
+
+  # ── Per-region control-plane cloud-init (Refs #2533 — G1) ────────────
+  # Each CP gets its OWN region's cloud-init render so per-region node
+  # labels, ClusterMesh anchors, cp_private_ip, and region role are
+  # baked into the bootstrap. Mirrors Hetzner's
+  # local.secondary_region_cloud_init pattern, but as a single map keyed
+  # by region (the count-based control_plane resource looks up by
+  # local.cp_nodes[count.index].region).
+  cp_cloud_init_by_region = {
+    for r in var.regions :
+    r.code => replace(templatefile("${path.module}/cloudinit-control-plane.tftpl", {
+      sovereign_fqdn      = var.sovereign_fqdn
+      sovereign_fqdn_slug = local.fqdn_slug
+      deployment_id       = var.deployment_id
+      org_name            = var.org_name
+      org_email           = var.org_email
+      # Refs #2533 — G1: per-CP region (was always var.regions[0].code,
+      # baking primary's region into EVERY CP's cloud-init).
+      region                = r.code
+      sovereign_region_role = local.region_role_by_region[r.code]
+      # Refs #2535 — G4: emit CLUSTER_MESH_NAME + CLUSTER_MESH_ID for
+      # the bootstrap-kit Kustomization's `${CLUSTER_MESH_NAME:=}` +
+      # `${CLUSTER_MESH_ID:=0}` envsubst keys. Without these, Cilium
+      # ClusterMesh stays silently disabled (single-cluster no-op) and
+      # Pillar 3 region-kill failover is impossible.
+      cluster_mesh_name = local.cluster_mesh_name_by_region[r.code]
+      cluster_mesh_id   = tostring(local.cluster_mesh_id_by_region[r.code])
+      huawei_region     = var.huawei_region
+      huawei_az         = var.huawei_az
+      k3s_version       = var.k3s_version
+      k3s_token         = sha256("${var.huawei_project_id}/${var.sovereign_fqdn}/k3s-bootstrap")
+      # Per-CP region's own subnet first-IP (was hardcoded to primary's
+      # subnet, leaking primary's IP onto secondary CPs).
+      cp_private_ip = cidrhost(local.region_subnet_cidr[r.code], 2)
+      # Wave 5.56 (Refs #2296) — canonical region labels for the
+      # bootstrap-kit substitute map. Hetzner provider sets these; the
+      # Huawei port missed them, leaving bp-sandbox + downstream HRs
+      # stuck on empty hostCluster. Format mirrors Hetzner pattern:
+      # `hu-<region>-rtz-prod` for replica role, `-mgmt-prod` for primary.
+      # G1: now per-region (was always primary).
+      region_canonical_label         = "hu-${r.code}-rtz-prod"
+      primary_region_canonical_label = "hu-${var.regions[0].code}-rtz-prod"
+      replica_region_canonical_label = length(var.regions) > 1 ? "hu-${var.regions[1].code}-rtz-prod" : ""
+      # Primary CP's EIP — Wave 5.8 (Refs #2140). The kubeconfig PUT-back
+      # from cloud-init must use this EIP, not the private VPC IP, so the
+      # remote mothership (cross-cloud Contabo) can reach the new
+      # Sovereign's apiserver on 6443. The previous template fetched the
+      # EIP from the HCS OpenStack metadata service
+      # (169.254.169.254/openstack/latest/meta_data.json
+      # `.public_ipv4_address`), but HCS doesn't populate that field;
+      # the fallback heuristic (`ip route get 8.8.8.8`) returned the
+      # private subnet IP, baking it into the PUT'd kubeconfig.
+      # Catalyst-api's Phase-1 watch then tried `https://10.30.1.70:6443`
+      # from the mothership Pod (Contabo) and timed out: caught live on
+      # 4bb37cbbb1e23ba8 2026-05-22T21:42Z. By passing the EIP at template
+      # render time (tofu knows it; it just created the EIP), the
+      # template-rendered `sed` substitution uses the right address
+      # deterministically across all CPs and metadata-service shape
+      # divergences across cloud stacks.
+      primary_cp_eip = huaweicloud_vpc_eip.cp[local.region_keys[0]].publicip.0.ip_address
+      # Wave 5.98 (#2447) — Huawei ELB EIP. Sovereign FQDN points HERE,
+      # NOT at the CP EIP. ELB does 443→30443 + 80→30080 to cilium-envoy.
+      elb_eip = huaweicloud_vpc_eip.elb_primary.publicip.0.ip_address
+      # Primary CP's hostname — used by cloud-init to gate the kubeconfig
+      # PUT-back to ONLY the primary region's CP1 (Wave 5.10, Refs #2140).
+      # Wave 5.9 attempted private-IP match (cp_private_ip = subnet .2)
+      # but HCS DHCP doesn't assign .2 deterministically (workers got
+      # .230 + .50 on 747841cadcf90f7e 2026-05-22T22:53Z); no CP's local
+      # IP matched, no PUT-back happened, Phase-1 timed out. Hostname is
+      # deterministic since the ECS resource sets it via `name`.
+      #
+      # Wave 5.148 (hw30 #23 fix-forward 2026-05-27): MUST mirror the CP
+      # name salt that Wave 5.144 introduced — otherwise the hostname-match
+      # gate in cloudinit-control-plane.tftpl (line ~938
+      # `if [ "$HOSTNAME" = "${primary_cp_hostname}" ]`) never fires and
+      # the kubeconfig PUT-back never happens. hw30 #23 reached Phase 0
+      # complete but Phase 1 stalled here because primary_cp_hostname was
+      # still the un-salted form. Mirror formula = same sha256(deployment_id
+      # + region + 'cp' + index + retry_attempt) → first 6 hex chars.
+      primary_cp_hostname = "${local.name_prefix}-${local.region_keys[0]}-cp1-${substr(sha256("${var.deployment_id}-${local.region_keys[0]}-cp0-${var.retry_attempt}"), 0, 6)}"
+      # Wave 5.74 (#2399, founder ask 2026-05-24): per-region CP-1 hostname
+      # map so the cloud-init secondary-kubeconfig PUT-back block can
+      # match each CP to its own region key. JSON-encoded for shell-side
+      # awk/jq parsing. Format: {"<region-key>": "<cp1-hostname>"}.
+      # Wave 5.148: same salt mirroring.
+      region_cp_hostname_map_json = jsonencode({
+        for rk in local.region_keys :
+        rk => "${local.name_prefix}-${rk}-cp1-${substr(sha256("${var.deployment_id}-${rk}-cp0-${var.retry_attempt}"), 0, 6)}"
+      })
+      # Primary region key — for the SAME-region match: the primary CP
+      # PUTs to /api/v1/deployments/{id}/kubeconfig, secondary CPs PUT
+      # to /api/v1/sovereign/secondary-kubeconfig with regionKey body.
+      primary_region_key = local.region_keys[0]
+      # Per-region CP EIP map — secondary CPs rewrite their kubeconfig's
+      # server URL with their own region's EIP before PUT-back.
+      region_cp_eip_map_json = jsonencode({
+        for rk in local.region_keys :
+        rk => huaweicloud_vpc_eip.cp[rk].publicip.0.ip_address
+      })
+      cluster_cidr    = "10.42.0.0/16"
+      service_cidr    = "10.96.0.0/16"
+      gitops_repo_url = var.gitops_repo_url
+      gitops_branch   = var.gitops_branch
+      parent_domains_yaml = coalesce(
+        var.parent_domains_yaml,
+        format("[{name: \"%s\", role: \"primary\"}]", var.sovereign_fqdn)
+      )
+      ghcr_pull_username         = local.ghcr_pull_username
+      ghcr_pull_token            = var.ghcr_pull_token
+      ghcr_pull_auth_b64         = local.ghcr_pull_auth_b64
+      obs_endpoint               = "https://obs.${var.huawei_region}.kom4dc.nationalcloud.om"
+      obs_region                 = var.huawei_region
+      obs_bucket_name            = var.obs_bucket_name
+      obs_access_key             = var.huawei_access_key
+      obs_secret_key             = var.huawei_secret_key
+      handover_jwt_public_key    = var.handover_jwt_public_key
+      kubeconfig_bearer_token    = var.kubeconfig_bearer_token
+      catalyst_api_url           = var.catalyst_api_url
+      enable_unattended_upgrades = var.enable_unattended_upgrades
+      enable_fail2ban            = var.enable_fail2ban
+      # Wave 5.34 (Refs #2208): Sovereign-side Secret seeds (powerdns DNS-01
+      # cert challenge + PDM basic-auth Day-2 calls). Mirror Hetzner pattern.
+      powerdns_api_key    = var.powerdns_api_key
+      pdm_basic_auth_user = var.pdm_basic_auth_user
+      pdm_basic_auth_pass = var.pdm_basic_auth_pass
+      # Wave 5.118 (#2462): harbor-robot-token for catalyst-api REQUIRED
+      # secretKeyRef. Mirror Hetzner pattern (issue #557 followup).
+      harbor_robot_token = var.harbor_robot_token
+      # Wave 5.16 (Refs #2140): empty placeholder. The CP cloud-init bakes
+      # worker-cloud-init.b64 into /var/lib/catalyst/ for the bp-cluster-
+      # autoscaler-hcloud blueprint to consume on scale-out. On Huawei
+      # that blueprint is disabled (Hetzner-only), so the bake isn't
+      # load-bearing for the POC. Referencing local.worker_cloud_init_by_region
+      # here created a tofu DAG cycle:
+      #   control_plane_cloud_init → worker_cloud_init_by_region →
+      #   cp_primary_private_ip_by_region → huaweicloud_compute_instance.
+      #   control_plane → user_data (= control_plane_cloud_init).
+      # Wave 6+ may serve the worker template via a Huawei-AS hook that
+      # fetches it from a tofu-OBS object instead of pre-baking on the CP.
+      worker_cloud_init_b64 = ""
+      # Wave 5.88 (#2432): wildcard cert issuer selector + marketplace flag
+      # for the sovereign-tls Kustomization (Huawei port of the canonical
+      # Hetzner registration). When wildcard_cert_use_staging=true → LE
+      # staging issuer (no 5/168h rate-limit, useful for repeated reprov);
+      # default false → real-trusted production cert.
+      wildcard_cert_issuer = var.wildcard_cert_use_staging == "true" ? "letsencrypt-dns01-staging-powerdns" : "letsencrypt-dns01-prod-powerdns"
+      marketplace_enabled  = var.marketplace_enabled
+    }), "/(?m)^[ ]*#( |$).*\n/", "")
+  }
 }
 
 # ── Control-plane ECS instances ───────────────────────────────────────────
@@ -732,7 +782,7 @@ resource "huaweicloud_compute_instance" "control_plane" {
   # carrying mothership + ≥1 Sovereign.
   eip_id = local.cp_nodes[count.index].index == 0 ? huaweicloud_vpc_eip.cp[local.cp_nodes[count.index].region].id : null
 
-  user_data = local.control_plane_cloud_init
+  user_data = local.cp_cloud_init_by_region[local.cp_nodes[count.index].region]
 
   key_pair = huaweicloud_kps_keypair.main.name
 

--- a/infra/providers/huawei/variables.tf
+++ b/infra/providers/huawei/variables.tf
@@ -418,3 +418,23 @@ variable "retry_attempt" {
     idempotent — same names, same scheduler decisions.
   EOT
 }
+
+# ── Cilium ClusterMesh anchors (Refs #2535 — G4) ───────────────────────
+# Mirror the Hetzner provider's variables.tf shape. The primary region
+# inherits these directly; secondary regions derive their own name+id
+# in main.tf locals (see cluster_mesh_name_by_region).
+variable "cluster_mesh_name" {
+  type        = string
+  default     = ""
+  description = "Cilium ClusterMesh peer name for this Sovereign's primary region (e.g. hw37-a). Empty = auto-derive from sovereign FQDN stem. Allocated via docs/CLUSTERMESH-CLUSTER-IDS.md."
+}
+
+variable "cluster_mesh_id" {
+  type        = number
+  default     = 0
+  description = "Cilium ClusterMesh peer id for this Sovereign's primary region (1-255 unique within a mesh; 0 = auto-allocate from sovereign deployment_id hash). Allocated via docs/CLUSTERMESH-CLUSTER-IDS.md."
+  validation {
+    condition     = var.cluster_mesh_id >= 0 && var.cluster_mesh_id <= 255
+    error_message = "cluster_mesh_id must be 0 (auto-allocate) or 1-255 (peer id)."
+  }
+}


### PR DESCRIPTION
Combined G1 + G4 fix for the multi-region mimic on HCS. Both files touched are the same Tofu module + cloud-init template, so they ship together to avoid an intermediate broken state.

## Bug
hw37 (deployment a1065d9051e269b4, wiped 2026-05-27) showed the architectural break: tofu created VPCs + ECS instances in both regions `me-east-215-a` and `me-east-215-b`, but only the `-a` cluster bootstrapped at the K8s plane. The 8 `-b` workers + 1 `-b` CP were paid-for orphans never joining any k3s cluster.

Root cause: `infra/providers/huawei/main.tf:569` rendered `local.control_plane_cloud_init` ONCE with `region = var.regions[0].code` (always primary), then assigned that single value to every CP via `count.user_data`. Secondary CPs booted with:
- `region_canonical_label = "hu-me-east-215-a-rtz-prod"` (wrong region)
- `cp_private_ip = cidrhost(local.region_subnet_cidr[primary-region], 2)` (wrong subnet)
- `CLUSTER_MESH_NAME / CLUSTER_MESH_ID` never emitted → cilium-chart's `cluster.name=""` + `cluster.id=0` → silent ClusterMesh disable

## Fix (this PR)
1. Convert `local.control_plane_cloud_init` (single value) → `local.cp_cloud_init_by_region` (map keyed by region code).
2. Each region renders the same template with that region's own context.
3. Pass three new template inputs: `sovereign_region_role`, `cluster_mesh_name`, `cluster_mesh_id`. Per-region derived in main.tf via new locals (`primary_cluster_mesh_name_effective`, `cluster_mesh_name_by_region`, `cluster_mesh_id_by_region`, `region_role_by_region`).
4. CP resource `user_data` looks up per-CP region from `local.cp_nodes[count.index].region`.
5. Cloudinit template emits `CLUSTER_MESH_NAME`, `CLUSTER_MESH_ID`, `SOVEREIGN_REGION_ROLE` into the bootstrap-kit Kustomization postBuild.substitute block.
6. `variables.tf` gains `cluster_mesh_name` + `cluster_mesh_id` (default empty/0 = auto-derive). Mirror of Hetzner provider's shape.

## Validation
```
$ tofu init -backend=false   # OK
$ tofu validate              # Success! The configuration is valid.
```

## Scope
- `infra/providers/huawei/main.tf`
- `infra/providers/huawei/variables.tf`
- `infra/providers/huawei/cloudinit-control-plane.tftpl`
- Hetzner: NOT touched
- Resource addresses preserved (still `huaweicloud_compute_instance.control_plane[N]`)

Refs #2533 (G1 — per-region CP cloud-init)
Refs #2535 (G4 — emit CLUSTER_MESH_NAME / CLUSTER_MESH_ID)
Part of umbrella Refs #2532 (multi-region mimic on HCS)