### PR TITLE
deploy: update catalyst images to 5e85e28 (manual)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.354
+      version: 1.4.355
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2338,7 +2338,7 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.354
+version: 1.4.355
 appVersion: 1.4.349
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -165,7 +165,7 @@ spec:
           # values.yaml `images.catalystApi.tag` is also bumped (but
           # unused for catalyst-api; kept for SME services that DO read
           # from values).
-          image: "ghcr.io/openova-io/openova/catalyst-api:eaf38ab"
+          image: "ghcr.io/openova-io/openova/catalyst-api:5e85e28"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -227,7 +227,7 @@ spec:
             # field so dashboards can correlate api-version <-> chart-
             # version on a single probe.
             - name: CATALYST_BUILD_SHA
-              value: "eaf38ab"
+              value: "5e85e28"
             - name: CATALYST_CHART_VERSION
               value: "1.4.95"
             - name: CORS_ORIGIN

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -25,7 +25,7 @@ spec:
           # Auto-bumped by .github/workflows/catalyst-build.yaml's deploy
           # step on every push to main, so Sovereigns AND contabo both
           # roll to the latest catalyst-ui SHA.
-          image: "ghcr.io/openova-io/openova/catalyst-ui:eaf38ab"
+          image: "ghcr.io/openova-io/openova/catalyst-ui:5e85e28"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -280,9 +280,9 @@ images:
   organization: "openova-io/openova"
   # SHA tags — bump these via CI when building new images.
   catalystApi:
-    tag: "eaf38ab"
+    tag: "5e85e28"
   catalystUi:
-    tag: "eaf38ab"
+    tag: "5e85e28"
   marketplaceApi:
     tag: "3c2f7e4"
   console:


### PR DESCRIPTION
Auto-bump on #2540 merge failed due to git push conflict with the preceding test-fix #2541. Manually pin the catalyst-api + catalyst-ui image tags to 5e85e28 (the G1+G4 merge — per-region CP cloud-init + ClusterMesh anchors) which is the latest image needed for hw38 multi-region prov.

Refs #2533 #2535