### PR TITLE
fix(catalyst-api): lower Huawei minWorkers clamp 8 → 3 (Refs #2536)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -1012,16 +1012,23 @@ func (h *Handler) CreateDeployment(w http.ResponseWriter, r *http.Request) {
 		if v := os.Getenv("CATALYST_HUAWEI_REGION"); v != "" {
 			req.HuaweiRegion = v
 		}
-		// Wave 5.121 (#2467): Huawei s7n.large.4 (2vCPU/8GB) needs ≥8
-		// workers for the full bp-catalyst-platform stack to fit.
+		// Wave 5.121 (#2467): historical minWorkers=8 for s7n.large.4
+		// (2vCPU/8GB) Huawei stack — needed because the smaller worker
+		// flavor couldn't fit bp-catalyst-platform's Pod requests with
+		// fewer nodes.
 		//
-		// Wave 5.146 (hw30 RCA 2026-05-27): we no longer use s7n.large.4
-		// for CP (variables.tf default flipped to m7n.large.8 because
-		// HCS Kom4DC exhausted s7n.large.4 capacity). Worker flavor stays
-		// m7n.xlarge.8 (4vCPU/32GB). minWorkers stays at 8 to keep CPU
-		// budget for bp-catalyst-platform's Pod requests until a
-		// flavor-aware right-sizing pass lands.
-		minWorkers := 8
+		// Wave 5.146 (2026-05-27): CP flavor flipped to m7n.large.8
+		// (2vCPU/16GB), worker flavor stays m7n.xlarge.8 (4vCPU/32GB).
+		// The original 8-worker floor was load-bearing only for the
+		// undersized flavor — at m7n.xlarge.8 a 3-worker per-region
+		// floor fits the bootstrap-kit with headroom.
+		//
+		// Refs #2536 (2026-05-28, founder direction): symmetric
+		// MGMT+RTZ+DMZ vClusters (Refs #2537) on 2 regions × 3 workers
+		// = 6 ECS workers Sovereign-wide. That's the HCS Tier-B cost-fit
+		// target and what the wizard's default sends. Honour
+		// `workerCount=3` end-to-end (do not silently clamp up to 8).
+		minWorkers := 3
 		if req.WorkerCount < minWorkers {
 			req.WorkerCount = minWorkers
 		}


### PR DESCRIPTION
Server-side companion to #2538. The tofu module's default went 4→3 in #2538; the catalyst-api handler's clamp at `deployments.go:1025` (`minWorkers := 8`) was silently rewriting any client `workerCount<8` back to 8 on Huawei provs.

Verified live on hw38 deployment `67a01c53d4e54c1d` (2026-05-27T22:10Z): POST body sent `workerCount: 3` per region; saved record came back with `workerCount: 8`.

The clamp was set in Wave 5.121 when CP+worker used s7n.large.4 (2vCPU/8GB). Wave 5.146 flipped to m7n.large.8 CP + m7n.xlarge.8 workers (4vCPU/32GB) — 3 workers fits bp-catalyst-platform with headroom.

## Scope
- `products/catalyst/bootstrap/api/internal/handler/deployments.go:1024` — `minWorkers := 8` → `minWorkers := 3`
- Hetzner: not touched (clamp is inside the Huawei provider switch case)

Refs #2536 (G5 follow-up)
Part of umbrella Refs #2532