### PR TITLE
fix(huawei): secondary-kubeconfig PUT-back awk parser → direct tf-render (Refs #2545)

### DIFF
--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -989,19 +989,20 @@ runcmd:
   # JSON body {deploymentId, regionKey, kubeconfigYaml} per the
   # secondaryKubeconfigRequest schema.
   - |
+    # Refs #2545 — G7: replace the broken awk-based JSON reverse-lookup
+    # (it returned the prior hostname instead of the region key when region
+    # names appear as both keys + value-fragments — hw38 forensic 2026-05-28)
+    # with direct template variables. Each CP cloud-init is now rendered
+    # per-region (G1, Refs #2533), so MY_REGION/MY_EIP can be hard-baked
+    # by tofu — no awk required.
     HOSTNAME=$(hostname)
-    REGION_CP_MAP='${region_cp_hostname_map_json}'
-    REGION_EIP_MAP='${region_cp_eip_map_json}'
     PRIMARY_HOST='${primary_cp_hostname}'
     PRIMARY_REGION='${primary_region_key}'
+    MY_REGION='${my_region_key}'
+    MY_EIP='${my_region_eip}'
     if [ -n "${deployment_id}" ] && [ -n "${kubeconfig_bearer_token}" ] && [ "$HOSTNAME" != "$PRIMARY_HOST" ]; then
-      # Resolve THIS CP's region key by reverse-lookup in the map.
-      # Map is {"region-a": "hostname-a", "region-b": "hostname-b"}; we
-      # find the key whose value matches our hostname. Pure POSIX awk.
-      MY_REGION=$(echo "$REGION_CP_MAP" | awk -v h="$HOSTNAME" 'BEGIN{FS="[\":,{} ]+"} {for(i=1;i<=NF;i++) if($i==h) print $(i-2)}' | head -1)
-      MY_EIP=$(echo "$REGION_EIP_MAP" | awk -v rk="$MY_REGION" 'BEGIN{FS="[\":,{} ]+"} {for(i=1;i<=NF;i++) if($i==rk) print $(i+2)}' | head -1)
       if [ -n "$MY_REGION" ] && [ -n "$MY_EIP" ] && [ "$MY_REGION" != "$PRIMARY_REGION" ]; then
-        echo "Wave 5.74: secondary kubeconfig PUT-back from region=$MY_REGION eip=$MY_EIP"
+        echo "Wave 5.74 G7: secondary kubeconfig PUT-back from region=$MY_REGION eip=$MY_EIP host=$HOSTNAME"
         sed "s|server: https://127.0.0.1:6443|server: https://$MY_EIP:6443|" /etc/rancher/k3s/k3s.yaml \
           > /tmp/kubeconfig-secondary.yaml
         # Wrap kubeconfig YAML inside JSON envelope (handler decodes

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -689,6 +689,13 @@ locals {
         for rk in local.region_keys :
         rk => huaweicloud_vpc_eip.cp[rk].publicip.0.ip_address
       })
+      # Refs #2545 — G7: per-CP region key + EIP, baked at render time.
+      # Replaces the broken awk JSON reverse-lookup that silently failed
+      # on hw38 because region names appeared as both keys + value-stems.
+      # Each CP cloud-init render uses its OWN region's values (no map
+      # lookup needed at boot).
+      my_region_key   = r.code
+      my_region_eip   = huaweicloud_vpc_eip.cp[r.code].publicip.0.ip_address
       cluster_cidr    = "10.42.0.0/16"
       service_cidr    = "10.96.0.0/16"
       gitops_repo_url = var.gitops_repo_url


### PR DESCRIPTION
## Root cause (hw38 forensic 2026-05-28)
On hw38 region-b CP, the cloud-init secondary-kubeconfig PUT-back block silently skipped. `cloud-init-output.log` shows ZERO "Wave 5.74" lines. The pre-existing awk-based JSON reverse-lookup is broken because region-key strings contain characters in its split regex `[":,{} ]+`.

Reproduced live on region-b CP:
```
REGION_CP_MAP='{"me-east-215-a":"...-me-east-215-a-cp1-...","me-east-215-b":"...-me-east-215-b-cp1-..."}'
awk … prints $(i-2) when value matches → returns
  '...-me-east-215-a-cp1-...'  (the PRIOR hostname, NOT the region key)
```

MY_EIP lookup then fails (no match for the wrong region key), the inner guard `[ -n "$MY_EIP" ]` skips silently. Mothership never receives the region-b kubeconfig → Phase 1 watcher only sees region-a → 13-chart cascade failure on hw38.

## Fix
Replace awk reverse-lookup with two new template inputs baked into the cloud-init at tofu render time:
- `my_region_key` = `r.code` (passed per-CP in the `cp_cloud_init_by_region` map render)
- `my_region_eip` = `huaweicloud_vpc_eip.cp[r.code].publicip.0.ip_address`

Each CP cloud-init now has its OWN region's values directly — no map parsing at boot.

## Validation
```
tofu validate → Success! The configuration is valid.
tofu test     → 3/3 pass (tier_b_two_regions_poc, single_region, ha_three_cp_per_region)
```

## Scope
- `infra/providers/huawei/cloudinit-control-plane.tftpl` (replace awk block)
- `infra/providers/huawei/main.tf` (add `my_region_key` + `my_region_eip` to render args)
- Hetzner: not touched

Refs #2545 (G7)
Part of umbrella Refs #2532 (multi-region mimic on HCS)