### PR TITLE
fix(bootstrap+huawei): symmetric vClusters land + per-region tls-san (Refs #2537 #2545)

### DIFF
--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -101,10 +101,12 @@ spec:
   # cloud-init).
   values:
     mgmtVcluster:
-      # Flipped on for the primary region by tofu's primary postBuild
-      # (mgmt_vcluster_enabled=true). Secondaries render this slot but
-      # tofu sets the substitute false → chart renders zero resources.
-      enabled: ${MGMT_VCLUSTER_ENABLED:=false}
+      # Refs #2537 G9 (2026-05-28): drop the MGMT_VCLUSTER_ENABLED
+      # substitute. The "follow-up PR to wire the substitute on primary
+      # only" never landed, leaving every Sovereign with mgmt-vcluster
+      # SILENTLY OFF for 2 weeks. Founder direction: symmetric topology
+      # — every region renders MGMT+RTZ+DMZ. Hardcode true.
+      enabled: true
       hostNamespace: mgmt
       vclusterName: mgmt
       role: primary

--- a/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
@@ -79,10 +79,10 @@ spec:
       retries: 3
   values:
     rtzVcluster:
-      # Flipped on by tofu's secondary-CP postBuild (rtz_vcluster_enabled=true).
-      # Primary renders this slot too but tofu sets the substitute false →
-      # chart renders zero resources on the primary.
-      enabled: ${RTZ_VCLUSTER_ENABLED:=false}
+      # Refs #2537 G9 (2026-05-28): drop the RTZ_VCLUSTER_ENABLED
+      # substitute (never landed — same fate as MGMT). Symmetric
+      # topology — every region renders MGMT+RTZ+DMZ.
+      enabled: true
       hostNamespace: rtz
       vclusterName: rtz
       role: secondary

--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -671,6 +671,7 @@ runcmd:
         --service-cidr=${service_cidr} \
         --tls-san=${sovereign_fqdn} \
         --tls-san=${primary_cp_eip} \
+        --tls-san=${my_region_eip} \
         --node-label=openova.io/region=hw-${region}-rtz-prod \
         --node-label=catalyst.openova.io/provider=huawei \
         --kube-apiserver-arg=default-watch-cache-size=200 \


### PR DESCRIPTION
Follow-ups from hw39 forensic 2026-05-28 — prov reached `status=ready` in 11min but topology was wrong:

## G9 — Bootstrap-kit slots forced `enabled: false` even after G6 flipped chart defaults

#2539 only flipped `mgmtVcluster.enabled` + `rtzVcluster.enabled` defaults in `values.yaml`. But slots 58/59 explicitly override with `enabled: ${MGMT_VCLUSTER_ENABLED:=false}` (resp. RTZ). The follow-up substitute PR that would set the var on primary/secondary roles NEVER landed (acknowledged in the slot's own comment 2026-05-16).

Result: every Sovereign for 2 weeks had MGMT + RTZ vClusters silently disabled. hw39 has only the DMZ vCluster materialised (1 ns), should have MGMT+RTZ+DMZ (3 ns per founder direction 2026-05-28).

Fix: drop the substitute, hardcode `enabled: true` in both slots.

## G10 — k3s --tls-san always primary_cp_eip → SAN-mismatch on region-b kubeconfig

`cloudinit-control-plane.tftpl:673` set `--tls-san=${primary_cp_eip}` for ALL CPs. Region-b CP's k3s cert thus included only PRIMARY's EIP. The secondary-kubeconfig PUT-back (G7) rewrites server URL to region-b's EIP, but cert doesn't cover it → mothership kubectl fails:
```
tls: failed to verify certificate: x509: certificate is valid for
10.241.1.138, 10.96.0.1, 127.0.0.1, 212.72.24.33, ::1, not 212.72.24.1
```

Fix: add a second `--tls-san=${my_region_eip}` line so each CP's cert covers its own EIP. Primary EIP stays for cross-region clustermesh.

## Tests
- `tofu test` → 3/3 pass
- Hetzner: NOT touched

Refs #2537 (G9)
Refs #2545 (G10)
Part of umbrella Refs #2532 (multi-region mimic on HCS)