### PR TITLE
fix(catalyst-api janitor): skip orphan-EIP sweep on active deployments (G15)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/janitor.go
+++ b/products/catalyst/bootstrap/api/internal/handler/janitor.go
@@ -218,7 +218,7 @@ func (h *Handler) runJanitorPass(tofuWorkDir string, failedMaxAge, wipedMaxAge t
 	// prefix and deletes any status=DOWN + unbound ones across all
 	// known HCS tfvars on the PVC. Idempotent + safe during active provs
 	// (bound + ACTIVE EIPs are never touched).
-	stats.OrphanEIPs = h.cleanOrphanEIPsHuawei(tofuWorkDir)
+	stats.OrphanEIPs = h.cleanOrphanEIPsHuawei(tofuWorkDir, activeIDs)
 
 	h.log.Info("[JANITOR] pass complete",
 		"durationMs", int(time.Since(startedAt).Milliseconds()),
@@ -378,7 +378,7 @@ func (h *Handler) cleanOrphanKubeconfigs(activeIDs map[string]struct{}) int {
 //
 // Returns the number of EIPs deleted. Returns 0 + logs on any error.
 // Safe to call even when no huawei deployment exists (no-op).
-func (h *Handler) cleanOrphanEIPsHuawei(tofuWorkDir string) int {
+func (h *Handler) cleanOrphanEIPsHuawei(tofuWorkDir string, activeIDs map[string]struct{}) int {
 	if tofuWorkDir == "" {
 		return 0
 	}
@@ -435,7 +435,20 @@ func (h *Handler) cleanOrphanEIPsHuawei(tofuWorkDir string) int {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	deleted, err := hp.SweepOrphanEIPs(ctx, ak, sk, projectID, region, func(msg string) {
+	// G15 (Refs #2553): build the set of 8-char deployment-ID prefixes
+	// for every ACTIVE deployment (in-memory + on-disk record). Pass it
+	// to SweepOrphanEIPs so freshly-created EIPs (status=DOWN, unbound)
+	// from an in-flight tofu apply are NOT eaten by the orphan sweep.
+	// The Huawei bandwidth name convention is:
+	//   catalyst-<sovereign-dashed>-<8charDepIDPrefix>-<purpose>-bw
+	// so we can correlate by the 8-char prefix.
+	activePrefixes := map[string]struct{}{}
+	for id := range activeIDs {
+		if len(id) >= 8 {
+			activePrefixes[id[:8]] = struct{}{}
+		}
+	}
+	deleted, err := hp.SweepOrphanEIPs(ctx, ak, sk, projectID, region, activePrefixes, func(msg string) {
 		h.log.Info("[JANITOR] " + msg)
 	})
 	if err != nil {

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
@@ -1405,7 +1405,7 @@ func deleteEIP(ctx context.Context, client *http.Client, hw hwCreds, region, id 
 // Intended caller: the periodic janitor (handler/janitor.go). Idempotent
 // + safe to run during active provisioning: bound EIPs (port_id set)
 // AND active EIPs (status=ACTIVE/BOUND) are never touched.
-func (p *Provider) SweepOrphanEIPs(ctx context.Context, ak, sk, projectID, region string, progress func(msg string)) (int, error) {
+func (p *Provider) SweepOrphanEIPs(ctx context.Context, ak, sk, projectID, region string, activeDepIDPrefixes map[string]struct{}, progress func(msg string)) (int, error) {
 	if progress == nil {
 		progress = func(string) {}
 	}
@@ -1441,6 +1441,26 @@ func (p *Provider) SweepOrphanEIPs(ctx context.Context, ak, sk, projectID, regio
 		}
 		if !strings.HasPrefix(e.BandwidthName, "catalyst-") {
 			continue
+		}
+		// G15 (Refs #2553): skip EIPs whose bandwidth_name carries the
+		// 8-char prefix of any ACTIVE deployment. Format the renderer
+		// uses: catalyst-<sovereign-dashed>-<8charDepIDPrefix>-<purpose>-bw
+		// (e.g. catalyst-hw43-omani-works-5b413990-elb-primary-bw).
+		// Without this guard the sweep eats freshly-created EIPs from
+		// in-flight `tofu apply` runs — they sit DOWN+unbound for the
+		// few minutes between EIP allocation and ECS/NAT bind.
+		if len(activeDepIDPrefixes) > 0 {
+			skip := false
+			for prefix := range activeDepIDPrefixes {
+				if strings.Contains(e.BandwidthName, "-"+prefix+"-") {
+					skip = true
+					break
+				}
+			}
+			if skip {
+				progress(fmt.Sprintf("sweep orphan EIP %s (bw=%s): skipped (active deployment)", e.Address, e.BandwidthName))
+				continue
+			}
 		}
 		if err := deleteEIP(ctx, client, hw, region, e.ID); err != nil {
 			progress(fmt.Sprintf("sweep orphan EIP %s (bw=%s): DELETE failed: %v", e.Address, e.BandwidthName, err))


### PR DESCRIPTION
## Summary
- Refs #2553
- Janitor's `SweepOrphanEIPs` ran every 5 min and ate freshly-created EIPs from in-flight `tofu apply` because they sit DOWN + port_id="" for the few minutes between EIP allocation and ECS/NAT bind — exactly the orphan signature.
- Caught on hw43 (`5b4139903388dc01`) at 14:17:57Z: 2 of 5 EIPs deleted mid-apply, breaking the provision.
- Fix: `SweepOrphanEIPs` grows an `activeDepIDPrefixes` set parameter; caller derives it from `activeIDSet()`. EIPs whose `bandwidth_name` contains `-<8charDepIDPrefix>-` are skipped + logged.

## Why this matters
This is in the same family as #2545/#2550 G13 (wipe sweep needed bandwidth_name + alias filter). Both bugs stem from the same root: "we don't have a stable identifier on HCS EIPs". The bandwidth name is the only reliable correlation key, but it must be parsed properly.

## Mitigation in place
Mothership catalyst-api Deployment env: `CATALYST_JANITOR_ENABLED=false` set 2026-05-28 14:34Z. Will be re-enabled after this image rolls and the chart auto-bump propagates.

## Verification
- `go build ./...` passes
- `go test ./internal/handler/... ./internal/providers/huawei/...` passes
- Post-merge: re-enable Janitor on mothership; provision a fresh Huawei Sovereign and confirm Janitor logs "skipped (active deployment)" for in-flight EIPs.

## Test plan
- [ ] Wait for chart auto-bump deploy commit
- [ ] Roll mothership catalyst-api to new SHA
- [ ] `kubectl set env -n catalyst deployment/catalyst-api CATALYST_JANITOR_ENABLED-` (unset)
- [ ] Wait 5-min janitor cycle; confirm "skipped (active deployment)" in logs
- [ ] hw43 fresh attempt completes Phase 0 + Phase 1 without EIP loss