### PR TITLE
fix(cnpg): bump memory limit 512Mi→1Gi to prevent silent init OOM (G17)

### DIFF
--- a/clusters/_template/bootstrap-kit/16-cnpg.yaml
+++ b/clusters/_template/bootstrap-kit/16-cnpg.yaml
@@ -57,7 +57,7 @@ spec:
   chart:
     spec:
       chart: bp-cnpg
-      version: 1.0.1
+      version: 1.0.2
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg

--- a/platform/cnpg/blueprint.yaml
+++ b/platform/cnpg/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-4-1-data-services
 spec:
-  version: 1.0.1
+  version: 1.0.2
   card:
     title: CloudNativePG
     summary: |

--- a/platform/cnpg/chart/Chart.yaml
+++ b/platform/cnpg/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cnpg
-version: 1.0.1
+version: 1.0.2
 description: |
   Catalyst-curated Blueprint umbrella chart for CloudNativePG. Depends on
   the upstream `cloudnative-pg` chart as a Helm subchart so

--- a/platform/cnpg/chart/values.yaml
+++ b/platform/cnpg/chart/values.yaml
@@ -44,11 +44,19 @@ cloudnative-pg:
   replicaCount: 1
 
   resources:
+    # G17 (Refs #2557, 2026-05-28): bumped memory 256/512Mi → 512Mi/1Gi.
+    # cnpg-cloudnative-pg v1.29.0 OOM'd during init on a fresh cluster at
+    # 512Mi limit — Go runtime exited code 2 right after "Kubernetes system
+    # metadata" log, before binding webhook port. Caught on hw45 multi-
+    # region prov: Flux helm install kept retrying for 30+ min, masking
+    # the real cause. Verified fix by live-patching the deployment to 1Gi
+    # → cnpg pod Ready in 60s. Phase 1 unblocks 18 dependent HRs (gitea,
+    # keycloak, openbao, powerdns, harbor, grafana, etc.).
     requests:
       cpu: 100m
-      memory: 256Mi
-    limits:
       memory: 512Mi
+    limits:
+      memory: 1Gi
 
   # PodMonitor for the operator — DEFAULT OFF.
   #


### PR DESCRIPTION
## Summary
- Refs #2557
- cnpg 1.29.0 silently OOM'd at 512Mi during init → exitCode 2 ~25s in, no panic logged
- Live-patched the deployment to 1Gi memory → cnpg ready in 60s

## Root cause (4-layer)
| Layer | Finding |
|---|---|
| Trigger | Go runtime heap exhaustion during CRD/informer discovery init |
| Incident-mgmt | Flux 15-min helm install timeout → uninstall → reinstall cycle masked the cause |
| Defense | Chart limit too tight for the init phase |
| Containment | Bump limits 256/512Mi → 512Mi/1Gi |

## Caught on
hw45 multi-region prov stuck at Phase 1 for 90 min. 18 dependent HRs (gitea, keycloak, openbao, powerdns, harbor, grafana, external-secrets, …) waiting on bp-cnpg.

## Test plan
- [ ] CI passes
- [ ] Chart auto-bump cascade lands
- [ ] Next fresh prov reaches Phase 1 with cnpg installing in < 90s on first try