### PR TITLE
fix(cnpg): bump memory limit 1Gi→2Gi for runtime OOM (G17b)

### DIFF
--- a/clusters/_template/bootstrap-kit/16-cnpg.yaml
+++ b/clusters/_template/bootstrap-kit/16-cnpg.yaml
@@ -57,7 +57,7 @@ spec:
   chart:
     spec:
       chart: bp-cnpg
-      version: 1.0.2
+      version: 1.0.3
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg

--- a/platform/cnpg/blueprint.yaml
+++ b/platform/cnpg/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-4-1-data-services
 spec:
-  version: 1.0.2
+  version: 1.0.3
   card:
     title: CloudNativePG
     summary: |

--- a/platform/cnpg/chart/Chart.yaml
+++ b/platform/cnpg/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cnpg
-version: 1.0.2
+version: 1.0.3
 description: |
   Catalyst-curated Blueprint umbrella chart for CloudNativePG. Depends on
   the upstream `cloudnative-pg` chart as a Helm subchart so

--- a/platform/cnpg/chart/values.yaml
+++ b/platform/cnpg/chart/values.yaml
@@ -44,19 +44,21 @@ cloudnative-pg:
   replicaCount: 1
 
   resources:
-    # G17 (Refs #2557, 2026-05-28): bumped memory 256/512Mi → 512Mi/1Gi.
-    # cnpg-cloudnative-pg v1.29.0 OOM'd during init on a fresh cluster at
-    # 512Mi limit — Go runtime exited code 2 right after "Kubernetes system
-    # metadata" log, before binding webhook port. Caught on hw45 multi-
-    # region prov: Flux helm install kept retrying for 30+ min, masking
-    # the real cause. Verified fix by live-patching the deployment to 1Gi
-    # → cnpg pod Ready in 60s. Phase 1 unblocks 18 dependent HRs (gitea,
-    # keycloak, openbao, powerdns, harbor, grafana, etc.).
+    # G17 (Refs #2557, 2026-05-28): bumped memory.
+    # 1st cut: 256/512Mi → 512Mi/1Gi unblocked init-OOM (exit code 2 ~25s
+    # after "Kubernetes system metadata" log). But 1Gi limit hit RUNTIME
+    # OOM on hw45 after cnpg started reconciling Cluster CRs (1-2 restarts
+    # within 10 min) → webhook 502 → bp-gitea + bp-harbor + bp-openbao
+    # install failures.
+    # 2nd cut (G17b): bump to 1Gi/2Gi for steady-state headroom. cnpg
+    # operator's informer cache + watch handlers + leader election +
+    # validating-webhook server collectively need > 1Gi when the cluster
+    # has multiple Postgres Clusters across multiple namespaces.
     requests:
       cpu: 100m
-      memory: 512Mi
-    limits:
       memory: 1Gi
+    limits:
+      memory: 2Gi
 
   # PodMonitor for the operator — DEFAULT OFF.
   #


### PR DESCRIPTION
## Summary
- Refs #2557 (follow-up to #2558)
- G17 (1Gi) fixed init-OOM. But runtime OOM hits at 1Gi when Phase 1 cascade races to create multiple Cluster CRs simultaneously.
- Bump to 1Gi requests / 2Gi limit.

## Caught on
hw45 multi-region Phase 1: cnpg restarting every 5 min on 1Gi → bp-gitea + bp-harbor + bp-openbao install attempts hit "502 Bad Gateway" calling cnpg webhook.

## Test plan
- [ ] CI passes
- [ ] Chart auto-bump cascade lands
- [ ] hw45 Flux pulls new bp-cnpg → applies 2Gi → cnpg stable → dependent HRs install