### PR TITLE
deploy(bp-catalyst-platform): bump 1.4.364→1.4.365 for bp-cnpg 1.0.3 (G17c)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.364
+      version: 1.4.365
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2338,7 +2338,7 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.364
+version: 1.4.365
 appVersion: 1.4.349
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.


### PR DESCRIPTION
Bumps bp-catalyst-platform chart so its embedded bootstrap-kit snapshot references the new bp-cnpg 1.0.3 (G17b memory fix). Without this, fresh Sovereigns provisioned by catalyst-api keep installing the broken bp-cnpg 1.0.1 with 512Mi limit. Refs #2557