### PR TITLE
fix(kyverno-policies): replace JMESPath concat() with two foreach (G19)

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -42,7 +42,7 @@ spec:
   chart:
     spec:
       chart: bp-kyverno-policies
-      version: 1.0.14
+      version: 1.0.15
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.14
+  version: 1.0.15
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -19,7 +19,7 @@ description: |
   ClusterPolicy CRs. CRDs are provided by the engine chart's upstream
   Kyverno subchart at slot 27.
 type: application
-version: 1.0.14
+version: 1.0.15
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/templates/baseline/11-harbor-proxy.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/11-harbor-proxy.yaml
@@ -79,12 +79,35 @@ spec:
           # (probably an init container or admission-time-injected sidecar)
           # has an image that the [?image] truthiness filter doesn't catch
           # — e.g. an empty-string image OR a missing image on initContainers
-          # which weren't in the list expression at all. Belt-and-braces:
-          # extend the list expression to also cover initContainers, AND add
-          # a preconditions guard so the deny block only evaluates when
-          # element.image is a non-empty string (Kyverno preconditions short-
-          # circuit deny eval entirely if false).
-          - list: "(request.object.spec.containers || request.object.spec.template.spec.containers || [])[?image] | concat(@, (request.object.spec.initContainers || request.object.spec.template.spec.initContainers || [])[?image])"
+          # which weren't in the list expression at all.
+          #
+          # G19 (Refs #2563, 2026-05-28): the previous cut used JMESPath
+          # `concat(@, ...)` to union containers + initContainers, but
+          # Kyverno's bundled go-jmespath does NOT include the `concat`
+          # function — every admission errored with:
+          #   "failed to evaluate list: JMESPath query failed: unknown
+          #    function: concat"
+          # → policy.failurePolicy=Fail → catalyst-api Deployment patches
+          # rejected cluster-wide → bp-catalyst-platform stuck in Helm
+          # rollback failure. Caught on hw46 multi-region (deployment
+          # ba79375bdd69c46c) blocking bp-continuum + bp-sandbox cascade.
+          #
+          # Fix: split into TWO foreach entries — one for containers, one
+          # for initContainers. No concat needed; each foreach iterates
+          # its own list. Preconditions still skip empty/nil images.
+          - list: "(request.object.spec.containers || request.object.spec.template.spec.containers || [])[?image]"
+            preconditions:
+              all:
+                - key: '{{ `{{ element.image || ` }}{{ printf "%q" "" }}{{ ` }}` }}'
+                  operator: NotEquals
+                  value: ""
+            deny:
+              conditions:
+                all:
+                  - key: '{{ printf `{{ regex_match(%q, element.image) }}` .Values.compliancePolicies.harborProxyPull.allowedRegistryRegex }}'
+                    operator: Equals
+                    value: false
+          - list: "(request.object.spec.initContainers || request.object.spec.template.spec.initContainers || [])[?image]"
             preconditions:
               all:
                 - key: '{{ `{{ element.image || ` }}{{ printf "%q" "" }}{{ ` }}` }}'


### PR DESCRIPTION
## Summary
- Refs #2563
- Kyverno bundled go-jmespath has no `concat` function
- Policy failurePolicy=Fail → all Deployment patches blocked → bp-catalyst-platform rollback stuck on hw46
- Fix: two foreach entries (containers, initContainers)

## Verified
G18 verifier on hw46 reported `bp-catalyst-platform Ready=False` with this exact Kyverno error. Post-merge a fresh prov should clear.

## Test plan
- [ ] CI passes
- [ ] Chart auto-bump
- [ ] hw47 fresh prov reaches verifier 100% green