### PR TITLE
fix(flux): disable upstream flux2 NetworkPolicies — Cilium misinterprets egress:[{}] (G20)

### DIFF
--- a/clusters/_template/bootstrap-kit/03-flux.yaml
+++ b/clusters/_template/bootstrap-kit/03-flux.yaml
@@ -77,7 +77,7 @@ spec:
       # 1.2.4 captures stderr to a temp file and emits structured
       # `[A66]` log lines (detection / success / failure-with-stderr).
       # RBAC was already correct in 1.2.3.
-      version: 1.2.4
+      version: 1.2.5
       sourceRef:
         kind: HelmRepository
         name: bp-flux

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.367
+      version: 1.4.368
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/flux/blueprint.yaml
+++ b/platform/flux/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.4
+  version: 1.2.5
   card:
     title: flux
     summary: GitOps reconciler. One per vcluster (source + kustomize + helm controllers); host-level Flux per host cluster watches its bp-* OCI sources.

--- a/platform/flux/chart/Chart.yaml
+++ b/platform/flux/chart/Chart.yaml
@@ -41,7 +41,7 @@ name: bp-flux
 # verbs grant exists); the silent failure was diagnostic-blind, not
 # RBAC-blind. The Chart.yaml bump here exists so the bootstrap-kit
 # pin auto-sync hook propagates the new image into fresh provs.
-version: 1.2.4
+version: 1.2.5
 description: |
   Catalyst-curated Blueprint umbrella chart for Flux. Depends on the
   upstream `flux2` chart (fluxcd-community) as a Helm subchart so

--- a/platform/flux/chart/values.yaml
+++ b/platform/flux/chart/values.yaml
@@ -104,6 +104,22 @@ catalyst:
 # 64Mi to keep scheduler footprint small on small CPs.
 flux2:
   installCRDs: true
+  # G20 (Refs #2566, 2026-05-28): disable flux2's bundled NetworkPolicies.
+  # Upstream flux2 chart 2.14.1 renders `flux-system/allow-egress` with
+  # `egress: [{}]` (intended "allow all egress"). On Cilium 1.16 in
+  # `enable-policy: default` mode, the empty rule object is interpreted
+  # as denying world egress from selected pods — source-controller
+  # cannot reach github.com to clone bootstrap-kit source. Caught on
+  # hw47: 30+ min of `dial tcp 20.205.243.166:443: i/o timeout` errors
+  # while a default-ns pod on the SAME node had full egress.
+  #
+  # bp-network-policies' default-deny + allow-system-namespaces CCNPs
+  # cover the same zero-trust intent declaratively + correctly
+  # (flux-system is in allowSystemNamespaces). Disabling the flux2-
+  # bundled NPs avoids the double-policy + Cilium-misinterpret
+  # collision.
+  policies:
+    create: false
   sourceController:
     resources:
       requests: { cpu: 50m, memory: 64Mi }

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2338,7 +2338,7 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.367
+version: 1.4.368
 appVersion: 1.4.349
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.


### PR DESCRIPTION
## Summary
- Refs #2566
- flux2/2.14.1 NP egress:[{}] → Cilium 1.16 deny-world on flux-system pods
- Caught on hw47: source-controller stuck 30+ min on github.com TCP timeout
- Fix: disable flux2.policies.create (bp-network-policies covers zero-trust)

## Why this didn't bite hw41/hw42/hw46
Possibly intermittent — earlier provs may have hit a Cilium policy-cache window where the NP wasn't yet enforced. Verified deterministic on hw47.

## Test plan
- [ ] CI green
- [ ] Chart cascade lands
- [ ] hw48 fresh prov; sovereign-dod-verify returns green