### PR TITLE
fix(flux): re-release 1.2.6 — version-pin-replay test path stale (G20 follow-up)

### DIFF
--- a/clusters/_template/bootstrap-kit/03-flux.yaml
+++ b/clusters/_template/bootstrap-kit/03-flux.yaml
@@ -77,7 +77,7 @@ spec:
       # 1.2.4 captures stderr to a temp file and emits structured
       # `[A66]` log lines (detection / success / failure-with-stderr).
       # RBAC was already correct in 1.2.3.
-      version: 1.2.5
+      version: 1.2.6
       sourceRef:
         kind: HelmRepository
         name: bp-flux

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.370
+      version: 1.4.371
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/flux/blueprint.yaml
+++ b/platform/flux/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.5
+  version: 1.2.6
   card:
     title: flux
     summary: GitOps reconciler. One per vcluster (source + kustomize + helm controllers); host-level Flux per host cluster watches its bp-* OCI sources.

--- a/platform/flux/chart/Chart.yaml
+++ b/platform/flux/chart/Chart.yaml
@@ -41,7 +41,7 @@ name: bp-flux
 # verbs grant exists); the silent failure was diagnostic-blind, not
 # RBAC-blind. The Chart.yaml bump here exists so the bootstrap-kit
 # pin auto-sync hook propagates the new image into fresh provs.
-version: 1.2.5
+version: 1.2.6
 description: |
   Catalyst-curated Blueprint umbrella chart for Flux. Depends on the
   upstream `flux2` chart (fluxcd-community) as a Helm subchart so

--- a/platform/flux/chart/tests/version-pin-replay.sh
+++ b/platform/flux/chart/tests/version-pin-replay.sh
@@ -33,7 +33,7 @@ CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
 # runs against a /tmp fake chart but still needs to validate against the
 # real repo's cloud-init template).
 REPO_ROOT="${REPO_ROOT:-$(cd "$CHART_DIR/../../.." && pwd)}"
-CLOUDINIT_TPL="$REPO_ROOT/infra/hetzner/cloudinit-control-plane.tftpl"
+CLOUDINIT_TPL="$REPO_ROOT/infra/providers/hetzner/cloudinit-control-plane.tftpl"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2338,7 +2338,7 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.370
+version: 1.4.371
 appVersion: 1.4.349
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.


### PR DESCRIPTION
G20 1.2.5 never published. Test path stale. Bump to 1.2.6. Refs #2566