### PR TITLE
fix(cnpg): pre-mint webhook-cert via cert-manager (G21)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -881,7 +881,7 @@ spec:
       # cutover-trigger CTA + Pillar 1 voucher→onboarding chain on
       # the fresh-prov walk. Refs #2131 (NOT Closes — operator walk
       # on fresh prov required).
-      version: 1.4.372
+      version: 1.4.373
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/16-cnpg.yaml
+++ b/clusters/_template/bootstrap-kit/16-cnpg.yaml
@@ -57,7 +57,7 @@ spec:
   chart:
     spec:
       chart: bp-cnpg
-      version: 1.0.3
+      version: 1.0.4
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg

--- a/platform/cnpg/blueprint.yaml
+++ b/platform/cnpg/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-4-1-data-services
 spec:
-  version: 1.0.3
+  version: 1.0.4
   card:
     title: CloudNativePG
     summary: |

--- a/platform/cnpg/chart/Chart.yaml
+++ b/platform/cnpg/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cnpg
-version: 1.0.3
+version: 1.0.4
 description: |
   Catalyst-curated Blueprint umbrella chart for CloudNativePG. Depends on
   the upstream `cloudnative-pg` chart as a Helm subchart so

--- a/platform/cnpg/chart/templates/webhook-cert-bootstrap.yaml
+++ b/platform/cnpg/chart/templates/webhook-cert-bootstrap.yaml
@@ -1,0 +1,189 @@
+{{/*
+G21 (Refs #2570, 2026-05-28): pre-mint the cnpg webhook TLS Secret via
+cert-manager so it exists BEFORE the cnpg-cloudnative-pg Deployment is
+applied. Without this, cnpg's chart relies on the cnpg operator to
+self-bootstrap its own webhook cert at runtime — but the cnpg pod
+declares its `webhook-certificates` Secret mount as `optional: true`.
+Under apiserver load (busy Phase-1 install storm), kubelet's Secret
+list-watch can't sync the Secret to the kubelet's cache within the
+default mount deadline. The mount silently falls back to an empty
+tmpfs, cnpg reads empty tls.crt, and the process exits with code 2
+(no panic stacktrace, no OOMKilled — the failure is invisible).
+
+Symptom signature on every failed HCS prov (hw45, hw46, hw48, hw49):
+- Warning FailedMount: failed to sync secret cache: timed out waiting
+- cnpg pod created (admission passed)
+- "Kubernetes system metadata" log emitted, then silent exit 2
+- ~25s container lifetime
+- reason=Error (NOT OOMKilled) → not memory pressure
+
+Why hw41/hw42 worked, hw45+ failed: earlier-session Phase-1 had less
+admission-webhook load (fewer Kyverno policies, fewer concurrent HRs).
+Apiserver served the Secret list-watch fast enough that kubelet's
+cache had cnpg-webhook-cert before pod creation. After Wave 5.151+
+added more Kyverno policies, apiserver got slower → race lost → cnpg
+crashloops. The G17/G17b memory bumps did NOTHING because memory was
+never the issue.
+
+Fix: cert-manager-managed Certificate that produces cnpg-webhook-cert
+deterministically + a pre-install Helm-hook Job that polls until the
+Secret exists, ensuring the Deployment only goes up after the volume
+mount target is guaranteed present.
+
+Three resources:
+  1. Issuer (self-signed bootstrap) — selfsigned-ca pattern for the
+     webhook serving cert. The cnpg operator can rotate this cert
+     later if it wants; the bootstrap-issued cert just has to be
+     valid at install time.
+  2. Certificate (cnpg-webhook-cert-bootstrap) — produces the Secret
+     named `cnpg-webhook-cert` with the canonical CN +
+     SubjectAltNames that the cnpg webhook-service expects.
+  3. Pre-install Job that waits until kubectl can read the Secret,
+     blocking the Deployment install via hook weight ordering.
+
+Required: bp-cert-manager (chart 1.2.x+) must be Ready before bp-cnpg
+installs. The bootstrap-kit dependsOn chain already enforces this.
+*/}}
+{{- if .Values.webhookCertBootstrap.enabled -}}
+---
+# 1. Self-signed Issuer (bootstrap-only)
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: cnpg-webhook-bootstrap-issuer
+  namespace: cnpg-system
+  labels:
+    app.kubernetes.io/name: bp-cnpg
+    app.kubernetes.io/component: webhook-cert-bootstrap
+    catalyst.openova.io/policy-domain: webhook-tls
+  annotations:
+    # Install BEFORE the Deployment so the Secret exists when cnpg
+    # pods get scheduled. helm.sh/hook-weight orders the hook
+    # resources among themselves; the Deployment (no hook) installs
+    # AFTER all pre-install hooks complete.
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  selfSigned: {}
+---
+# 2. Certificate producing the webhook Secret
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cnpg-webhook-cert-bootstrap
+  namespace: cnpg-system
+  labels:
+    app.kubernetes.io/name: bp-cnpg
+    app.kubernetes.io/component: webhook-cert-bootstrap
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "2"
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  secretName: cnpg-webhook-cert
+  # cnpg-cloudnative-pg's webhook server checks the cert validity at
+  # startup. 1 year duration matches cnpg's own rotation cadence.
+  duration: {{ .Values.webhookCertBootstrap.certDuration | default "8760h" }}
+  renewBefore: {{ .Values.webhookCertBootstrap.certRenewBefore | default "720h" }}
+  commonName: cnpg-webhook-service.cnpg-system.svc
+  dnsNames:
+    - cnpg-webhook-service.cnpg-system.svc
+    - cnpg-webhook-service.cnpg-system.svc.cluster.local
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: cnpg-webhook-bootstrap-issuer
+    kind: Issuer
+---
+# 3. Pre-install Job that BLOCKS the Deployment until kubelet can read
+#    the Secret. Helm waits for the Job to complete before installing
+#    the rest of the chart (the Deployment + Service + RBAC).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cnpg-webhook-cert-wait
+  namespace: cnpg-system
+  labels:
+    app.kubernetes.io/name: bp-cnpg
+    app.kubernetes.io/component: webhook-cert-bootstrap
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "3"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 60
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-cnpg
+        app.kubernetes.io/component: webhook-cert-bootstrap-wait
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: cnpg-webhook-cert-wait
+      containers:
+        - name: wait
+          image: {{ .Values.webhookCertBootstrap.kubectlImage | default "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.31.4" }}
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              echo "G21: waiting for Secret cnpg-system/cnpg-webhook-cert ..."
+              for i in $(seq 1 60); do
+                if kubectl -n cnpg-system get secret cnpg-webhook-cert -o jsonpath='{.data.tls\.crt}' 2>/dev/null | base64 -d 2>/dev/null | grep -q "BEGIN CERTIFICATE"; then
+                  echo "G21: Secret ready after ${i} polls; cnpg can now safely volume-mount it."
+                  exit 0
+                fi
+                echo "G21: poll ${i}/60 — Secret not ready, sleeping 5s ..."
+                sleep 5
+              done
+              echo "G21: TIMEOUT — Secret never appeared. cert-manager may be down." >&2
+              exit 1
+---
+# RBAC for the wait Job (read-only on Secrets)
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cnpg-webhook-cert-wait
+  namespace: cnpg-system
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cnpg-webhook-cert-wait
+  namespace: cnpg-system
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["cnpg-webhook-cert"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cnpg-webhook-cert-wait
+  namespace: cnpg-system
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cnpg-webhook-cert-wait
+subjects:
+  - kind: ServiceAccount
+    name: cnpg-webhook-cert-wait
+    namespace: cnpg-system
+{{- end -}}

--- a/platform/cnpg/chart/values.yaml
+++ b/platform/cnpg/chart/values.yaml
@@ -12,6 +12,19 @@
 # meaningful value is configurable; cluster overlays in clusters/<sovereign>/
 # may override any of these without rebuilding the Blueprint OCI artifact.
 
+# G21 (Refs #2570, 2026-05-28): pre-mint cnpg-webhook-cert Secret via
+# cert-manager so cnpg's Deployment volume mount has a valid Secret
+# to consume at pod-creation time. See
+# templates/webhook-cert-bootstrap.yaml for the rationale (kubelet
+# Secret-cache sync race under apiserver load).
+webhookCertBootstrap:
+  enabled: true
+  certDuration: 8760h
+  certRenewBefore: 720h
+  # Pinned to the in-Sovereign Harbor proxy-cache per
+  # docs/INVIOLABLE-PRINCIPLES.md image-source rule.
+  kubectlImage: harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.31.4
+
 global:
   # When set, ALL image pulls in this chart route through this registry.
   # Used post-handover when the Sovereign's own Harbor takes over the

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2338,7 +2338,7 @@ name: bp-catalyst-platform
 #
 # Refs #1099 (NOT Closes — operator walk + screenshot is the DoD per
 # CLAUDE.md §0).
-version: 1.4.372
+version: 1.4.373
 appVersion: 1.4.349
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.


### PR DESCRIPTION
Refs #2570. Real RCA: kubelet Secret-cache race under apiserver load, NOT memory. Three wrong G17 iterations later, this is the actual fix.

## Test plan
- [ ] CI green
- [ ] Chart cascade
- [ ] hw50 fresh prov: sovereign-dod-verify.sh returns green