### PR TITLE
fix(cloudinit): strip flux-bundled NetworkPolicies on bootstrap (G22)

### DIFF
--- a/infra/providers/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/providers/hetzner/cloudinit-control-plane.tftpl
@@ -1924,6 +1924,17 @@ runcmd:
   # CI gate `platform/flux/chart/tests/version-pin-replay.sh` rejects
   # divergence between this URL's version and the chart's subchart pin.
   - 'curl -fsSL https://github.com/fluxcd/flux2/releases/download/v2.4.0/install.yaml | kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f -'
+  # G22 (Refs #2572, 2026-05-29): strip flux-bundled NetworkPolicies.
+  # The upstream install.yaml creates flux-system/{allow-egress,
+  # allow-scraping,allow-webhooks}. On Cilium 1.16 default mode, the
+  # empty `egress: [{}]` rule is interpreted as deny-world → source-
+  # controller can't reach github.com to clone bootstrap-kit. bp-network-
+  # policies (slot 30) provides correct zero-trust via CCNPs with flux-
+  # system in allowSystemNamespaces, so no security regression. (Huawei
+  # cloudinit uses `flux install --network-policy=false` for the same
+  # effect; here we delete post-apply since this code path uses the
+  # upstream install.yaml directly.)
+  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml -n flux-system delete networkpolicy allow-egress allow-scraping allow-webhooks --ignore-not-found || true'
   - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml -n flux-system wait --for=condition=Available --timeout=300s deployment --all'
 
   # ── flux-system/ghcr-pull Secret (applied BEFORE GitRepository) ──────

--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -903,7 +903,24 @@ runcmd:
       done
     done
 
-  - KUBECONFIG=/etc/rancher/k3s/k3s.yaml flux install --components=source-controller,kustomize-controller,helm-controller,notification-controller || true
+  # G22 (Refs #2572, 2026-05-29): --network-policy=false.
+  # `flux install` defaults to creating flux-system/{allow-egress,
+  # allow-scraping,allow-webhooks} NetworkPolicies that select all flux-
+  # system pods. On Cilium 1.16 in enable-policy=default mode the empty
+  # `egress: [{}]` rule is interpreted as deny-world → source-controller
+  # cannot reach github.com to clone the bootstrap-kit GitRepository.
+  # Caught on hw47, hw50 (30+ min of `dial tcp github.com:443: i/o
+  # timeout` from inside source-controller pod while default-ns pods
+  # on the same node had full egress).
+  #
+  # G20 (#2566) tried to fix this by setting flux2.policies.create=false
+  # in our bp-flux chart values — but those NPs are NOT created by the
+  # chart; they are created by `flux install` itself (this line).
+  # Real fix: pass --network-policy=false to the bootstrap.
+  # bp-network-policies (slot 30) provides the proper zero-trust posture
+  # via CCNPs with flux-system in allowSystemNamespaces, so no security
+  # regression.
+  - KUBECONFIG=/etc/rancher/k3s/k3s.yaml flux install --components=source-controller,kustomize-controller,helm-controller,notification-controller --network-policy=false || true
   # Wave 5.29 (Refs #2163): substitute the tofu-baked CILIUM_K8S_SERVICE_HOST
   # placeholder with the CP's ACTUAL private IP. HCS DHCP non-deterministic —
   # cidrhost(subnet, 2) baked at tofu-render-time is wrong (CP actually


### PR DESCRIPTION
## Summary
- Refs #2572
- G20's fix-site was wrong (chart vs cloud-init). Real source of flux NPs is the upstream bootstrap.
- Huawei: `flux install --network-policy=false`
- Hetzner: post-apply `kubectl delete netpol allow-egress allow-scraping allow-webhooks`

## Test plan
- [ ] CI green
- [ ] catalyst-api image rebuild + roll to mothership
- [ ] hw51 fresh prov reaches Phase 1 cascade (source-controller can clone github)
- [ ] sovereign-dod-verify.sh runs green