### PR TITLE
fix(cilium clustermesh): NodePort 31333 on HCS — type=LoadBalancer never materialises (G3)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -231,6 +231,14 @@ spec:
             # the cloud-Hetzner default is now A3-compliant out of the
             # box.
             type: ${CLUSTERMESH_SERVICE_TYPE:=LoadBalancer}
+            # G3 (Refs #2534, 2026-05-29): per-region NodePort number when
+            # type=NodePort. Empty string means k8s assigns a random
+            # NodePort in 30000-32767; HCS provider's cloud-init pins
+            # `CLUSTERMESH_NODE_PORT: "31333"` (matching the HCS security-
+            # group ingress rule in infra/providers/huawei/main.tf) so the
+            # peer-dial address is stable + deterministic. Hetzner leaves
+            # this empty (LB pattern doesn't need it).
+            nodePort: ${CLUSTERMESH_NODE_PORT:=}
             # Hetzner CCM requires location OR network-zone annotation
             # to allocate the LB. ${HCLOUD_LB_LOCATION} flows from the
             # bootstrap-kit Kustomization substitute, set by the

--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -464,6 +464,19 @@ write_files:
             # Huawei. Without suspend, install Helm-times-out after 15m
             # each → blocks Phase 1 completion.
             HCLOUD_HR_SUSPEND: "true"
+            # G3 (Refs #2534, 2026-05-29): clustermesh-apiserver Service
+            # cannot be type=LoadBalancer on HCS — there is no in-cluster
+            # cloud-controller-manager that materialises a Service-level
+            # LB (the tofu-provisioned ELB at infra/providers/huawei/
+            # main.tf serves only the public Cilium Gateway 443/80).
+            # Per docs/SOVEREIGN-MULTI-REGION-DOD.md A3 ruling adapted
+            # for HCS: peers dial the CP node's EIP on the deterministic
+            # NodePort 31333. HCS security group ingress for tcp/31333
+            # on CP nodes is added in main.tf (G3 follow-on).
+            # Hetzner keeps type=LoadBalancer (its substitute defaults
+            # to LoadBalancer + empty NodePort number).
+            CLUSTERMESH_SERVICE_TYPE: "NodePort"
+            CLUSTERMESH_NODE_PORT: "31333"
             # Wave 5.110 (#2462): bastion mirror endpoint for harbor.openova.io.
             # bp-self-sovereign-cutover's registry-pivot DaemonSet rewrites
             # /etc/rancher/k3s/registries.yaml with upstream→harbor.openova.io


### PR DESCRIPTION
Refs #2534. HCS has no Service-level LB controller; clustermesh-apiserver Service was pending forever. NodePort + existing SG ingress 30000-32767 = peer-dial works. Hetzner unaffected (defaults preserved).