### PR TITLE
fix(bootstrap-kit): per-region HR suspend on secondary CPs (G2)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -59,7 +59,13 @@ metadata:
     # this HR lands in Phase 2 (Cutover) on the canvas, NOT Phase 1.
     catalyst.openova.io/slot: "06a"
     catalyst.openova.io/component: cutover
+    catalyst.openova.io/region-role: primary
 spec:
+  # G2 (Refs #2574, 2026-05-29): primary-only HR — bp-self-sovereign-
+  # cutover installs the per-Sovereign cutover orchestration on the
+  # primary CP only (cutoverComplete state lives on the mothership-side
+  # MGMT vCluster). Secondary CPs MUST NOT run cutover.
+  suspend: ${SECONDARY_HR_SUSPEND:=false}
   interval: 15m
   releaseName: self-sovereign-cutover
   # targetNamespace = catalyst because the catalyst-api cutover endpoint

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -41,7 +41,17 @@ metadata:
     # Ready=True the Sovereign is fully self-sufficient.
     catalyst.openova.io/slot: "13"
     catalyst.openova.io/component: catalyst-platform
+    catalyst.openova.io/region-role: primary
 spec:
+  # G2 (Refs #2574, 2026-05-29): bp-catalyst-platform is mothership-only.
+  # On a secondary CP this HR must NOT install — the Sovereign control
+  # plane (catalyst-api / catalyst-ui / controllers / catalyst-catalog /
+  # marketplace-api) belongs in the primary region's MGMT vCluster.
+  # SECONDARY_HR_SUSPEND substitute renders "true" on every secondary
+  # CP's cloud-init (sovereign_region_role != "primary") and "false" on
+  # the primary CP, suspending this HR cluster-side without touching
+  # the chart catalog.
+  suspend: ${SECONDARY_HR_SUSPEND:=false}
   interval: 15m
   releaseName: catalyst-platform
   targetNamespace: catalyst-system

--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -47,7 +47,13 @@ metadata:
   labels:
     catalyst.openova.io/slot: "19a"
     catalyst.openova.io/component: sandbox-controller
+    catalyst.openova.io/region-role: primary
 spec:
+  # G2 (Refs #2574, 2026-05-29): primary-only HR — bp-sandbox depends
+  # on bp-catalyst-platform (slot 13) which is also primary-only.
+  # Per docs/SOVEREIGN-MULTI-REGION-DOD.md §A4, Sandbox lives in the
+  # primary MGMT vCluster only.
+  suspend: ${SECONDARY_HR_SUSPEND:=false}
   interval: 15m
   releaseName: sandbox
   targetNamespace: catalyst-system

--- a/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+++ b/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
@@ -87,9 +87,15 @@ metadata:
   labels:
     catalyst.openova.io/slot: "62"
     catalyst.openova.io/component: continuum-controller
+    catalyst.openova.io/region-role: primary
     openova.io/category: customer-facing-capability
     openova.io/epic: "6"
 spec:
+  # G2 (Refs #2574, 2026-05-29): primary-only HR — continuum-controller
+  # is part of the Catalyst control plane and must run only in the
+  # primary region's MGMT vCluster. SECONDARY_HR_SUSPEND="true" on
+  # secondary CPs suspends this HR; "false" on primary lets it install.
+  suspend: ${SECONDARY_HR_SUSPEND:=false}
   interval: 15m
   releaseName: continuum
   # targetNamespace = catalyst-system to colocate with the other

--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -464,6 +464,15 @@ write_files:
             # Huawei. Without suspend, install Helm-times-out after 15m
             # each → blocks Phase 1 completion.
             HCLOUD_HR_SUSPEND: "true"
+            # G2 (Refs #2574, 2026-05-29): per-region HR suspension for
+            # mothership-only slots (13-bp-catalyst-platform, 19a-bp-
+            # sandbox, 06a-bp-self-sovereign-cutover, 62-bp-continuum).
+            # SOVEREIGN_REGION_ROLE is rendered per-CP by tofu's
+            # cp_cloud_init_by_region map — primary CP gets "primary",
+            # each secondary CP gets "secondary". This Terraform-side
+            # ternary flips the substitute to "true" only when the CP
+            # is NOT the primary.
+            SECONDARY_HR_SUSPEND: "${sovereign_region_role == "primary" ? "false" : "true"}"
             # G3 (Refs #2534, 2026-05-29): clustermesh-apiserver Service
             # cannot be type=LoadBalancer on HCS — there is no in-cluster
             # cloud-controller-manager that materialises a Service-level


### PR DESCRIPTION
Refs #2574. Ship phase of G2 (audit was scaffold). Adds `suspend: ${SECONDARY_HR_SUSPEND:=false}` to 4 mothership-only slots (bp-catalyst-platform, bp-continuum, bp-sandbox, bp-self-sovereign-cutover) + wires SECONDARY_HR_SUSPEND on Huawei cloudinit postBuild substitute (true on secondaries, false on primary).

## Test plan
- [ ] CI green
- [ ] hw53 (in flight) Phase 1 cascade: primary region installs slots 06a/13/19a/62; secondary region region-b does NOT install them (`kubectl --kubeconfig <region-b> get hr bp-catalyst-platform` should show suspended)
- [ ] sovereign-dod-verify.sh extended in follow-up to assert per-region slot conformance