### PR TITLE
fix(bootstrap-kit,huawei): G28 — Gateway listener ports via envsubst (HCS=30443/30080)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -395,8 +395,15 @@ metadata:
 spec:
   gatewayClassName: cilium
   listeners:
+    # G28 (Refs #2570, 2026-05-29): Listener ports are provider-aware
+    # envsubst placeholders. Hetzner sovereigns bind cilium-envoy on
+    # host:443/:80 directly (LB targets node:443/:80). HCS sovereigns
+    # bind cilium-envoy on host:30443/:30080 because the HCS ELB pool
+    # members target NodePort range 30000-32767 and translate ingress
+    # 443→30443 + 80→30080. Defaults preserve Hetzner zero-touch
+    # behavior; Huawei cloudinit postBuild overrides them.
     - name: https
-      port: 443
+      port: ${SOVEREIGN_GATEWAY_HTTPS_PORT:=443}
       protocol: HTTPS
       hostname: "*.${SOVEREIGN_FQDN}"
       tls:
@@ -408,14 +415,14 @@ spec:
         namespaces:
           from: All
     - name: http
-      port: 80
+      port: ${SOVEREIGN_GATEWAY_HTTP_PORT:=80}
       protocol: HTTP
       hostname: "*.${SOVEREIGN_FQDN}"
       allowedRoutes:
         namespaces:
           from: All
     - name: apex-https
-      port: 443
+      port: ${SOVEREIGN_GATEWAY_HTTPS_PORT:=443}
       protocol: HTTPS
       hostname: "${SOVEREIGN_FQDN}"
       tls:

--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -486,6 +486,18 @@ write_files:
             # to LoadBalancer + empty NodePort number).
             CLUSTERMESH_SERVICE_TYPE: "NodePort"
             CLUSTERMESH_NODE_PORT: "31333"
+            # G28 (Refs #2570, 2026-05-29): Gateway listener ports on
+            # HCS bind cilium-envoy to NodePort range 30000-32767. The
+            # tofu-provisioned HCS ELB (main.tf) maps public ingress
+            # 443→30443 + 80→30080 to pool members on those NodePorts.
+            # bootstrap-kit/01-cilium.yaml's Gateway carries the
+            # ${SOVEREIGN_GATEWAY_HTTPS_PORT:=443} envsubst placeholder
+            # (default Hetzner 443/80; overridden here for HCS).
+            # Without this override, cilium-envoy binds host:443 + host:80
+            # but HCS ELB pool members target 30443/30080 → ELB pool
+            # health-check fails → TCP 443 from public BLOCKED forever.
+            SOVEREIGN_GATEWAY_HTTPS_PORT: "30443"
+            SOVEREIGN_GATEWAY_HTTP_PORT: "30080"
             # Wave 5.110 (#2462): bastion mirror endpoint for harbor.openova.io.
             # bp-self-sovereign-cutover's registry-pivot DaemonSet rewrites
             # /etc/rancher/k3s/registries.yaml with upstream→harbor.openova.io


### PR DESCRIPTION
## Summary

- bootstrap-kit/01-cilium.yaml Gateway listeners now use envsubst placeholders `${SOVEREIGN_GATEWAY_HTTPS_PORT:=443}` + `${SOVEREIGN_GATEWAY_HTTP_PORT:=80}` (default = Hetzner zero-touch)
- Huawei cloudinit overrides them to 30443 / 30080 to match the HCS ELB pool member NodePort range

## Root Cause

On HCS the public ELB targets cilium-envoy on host-bound NodePorts 30443/30080 (per `infra/providers/huawei/main.tf` elb_pool_member). bootstrap-kit hardcoded the Gateway to port 443/80, so cilium-envoy bound host:443 while the ELB members forwarded to host:30443 — public TCP 443 has been BLOCKED on every HCS prov from hw45 onward.

sovereign-tls/cilium-gateway.yaml renders correct 30443 listeners via PARENT_DOMAINS_LISTENERS_YAML, but both Kustomizations share the kustomize-controller SSA field-manager, so whichever reconciled later (5-min interval) kept overwriting the other. The Gateway in cluster bore label `kustomize.toolkit.fluxcd.io/name: bootstrap-kit` with port=443 — bootstrap-kit kept winning.

With this fix both Kustomizations SSA the same listener values → no flip-flop conflict → cilium-envoy binds host:30443 → ELB health-checks pass → public TCP 443 reaches the Sovereign Console.

## Test plan

- [x] Diff verified on hw54 working tree
- [ ] After auto-bump, hw55 zero-touch prov shows: cilium-envoy bound host:30443 AND public TCP 443 OPEN to ELB EIP within ~12min of phase1Outcome=ready
- [ ] sovereign-dod-verify.sh L5 (HTTPS surfaces) returns GREEN with valid LE prod cert

Refs #2570

🤖 Generated with [Claude Code](https://claude.com/claude-code)