### PR TITLE
feat(sandbox): G91.sandbox — bp-sandbox opts into bp-sso-bridge framework (Refs #2657)

### DIFF
--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -139,7 +139,7 @@ spec:
       # helper), not bare `newapi`. Pre-fix every Sovereign's
       # sandbox-controller TokenMint POST returned `no such host`,
       # blocking the canonical Pillar-4 qwen-code customer journey.
-      version: 0.3.7
+      version: 0.3.8
       sourceRef:
         kind: HelmRepository
         name: bp-sandbox

--- a/platform/sandbox/chart/Chart.yaml
+++ b/platform/sandbox/chart/Chart.yaml
@@ -119,7 +119,7 @@ annotations:
 # `helm template newapi platform/newapi/chart/ -s templates/service.yaml`
 # → metadata.name: newapi-bp-newapi. Walker on t38 (chart 1.4.216,
 # substrate be4f78bc872e2c56) caught the live regression.
-version: 0.3.7
+version: 0.3.8
 appVersion: "0.3.7"
 keywords:
   - catalyst

--- a/platform/sandbox/chart/templates/deployment.yaml
+++ b/platform/sandbox/chart/templates/deployment.yaml
@@ -185,6 +185,41 @@ spec:
             - name: {{ $k | quote }}
               value: {{ $v | quote }}
             {{- end }}
+            {{- /* G91.sandbox (#2657) — SSO env wiring. The
+                   sandbox-controller reads these env vars and (follow-up:
+                   core/controllers/sandbox/) propagates them into the
+                   per-Sandbox pty-server PodSpec for OIDC-fronted UI auth.
+                   secretRef is `optional: true` so a fresh-prov Sovereign
+                   where bp-sso-bridge hasn't yet materialised the
+                   ExternalSecret does NOT crash the controller. */ -}}
+            {{- if .Values.sso.enabled }}
+            - name: SANDBOX_SSO_ENABLED
+              value: "true"
+            - name: SANDBOX_SSO_REALM
+              value: {{ .Values.sso.realm | default "sovereign" | quote }}
+            - name: SANDBOX_SSO_SOVEREIGN_FQDN
+              value: {{ .Values.sso.sovereignFqdn | default "" | quote }}
+            - name: SANDBOX_SSO_ADMIN_GROUP
+              value: {{ .Values.sso.adminGroup | default "sovereign-admins" | quote }}
+            - name: SANDBOX_SSO_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: sandbox-sso-oidc-credentials
+                  key: client_id
+                  optional: true
+            - name: SANDBOX_SSO_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: sandbox-sso-oidc-credentials
+                  key: client_secret
+                  optional: true
+            - name: SANDBOX_SSO_ISSUER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: sandbox-sso-oidc-credentials
+                  key: issuer_url
+                  optional: true
+            {{- end }}
           ports:
             - name: metrics
               containerPort: 8080

--- a/platform/sandbox/chart/templates/sso-oauth-source-externalsecret.yaml
+++ b/platform/sandbox/chart/templates/sso-oauth-source-externalsecret.yaml
@@ -1,0 +1,44 @@
+{{- /*
+G91.sandbox (#2657) — OIDC client credentials Secret.
+
+bp-sso-bridge (G91.1 #2652) writes the canonical OIDC client bundle into
+OpenBao at `secret/sso/sandbox` (or whatever .Values.sso.clientId is).
+This ExternalSecret materialises the bundle into a Secret in the
+sandbox-controller's namespace; the sandbox-controller reads the keys
+via env vars on its Pod and propagates them into the per-Sandbox
+pty-server PodSpec so each per-user Sandbox UI is OIDC-fronted.
+
+Default `enabled: true` keeps the framework opt-in single-knob per
+SECURITY.md §6.3.
+*/ -}}
+{{- if and .Values.enabled .Values.sso.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: sandbox-sso-oidc-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-sandbox
+    bp-sso-bridge.openova.io/consumer: bp-sandbox
+spec:
+  refreshInterval: {{ .Values.sso.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ .Values.sso.externalSecretStoreName | default "vault-region1" }}
+    kind: ClusterSecretStore
+  target:
+    name: sandbox-sso-oidc-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: client_id
+      remoteRef:
+        key: sso/{{ .Values.sso.clientId | default "sandbox" }}
+        property: client_id
+    - secretKey: client_secret
+      remoteRef:
+        key: sso/{{ .Values.sso.clientId | default "sandbox" }}
+        property: client_secret
+    - secretKey: issuer_url
+      remoteRef:
+        key: sso/{{ .Values.sso.clientId | default "sandbox" }}
+        property: issuer_url
+{{- end }}

--- a/platform/sandbox/chart/values.yaml
+++ b/platform/sandbox/chart/values.yaml
@@ -263,3 +263,39 @@ mcp:
       name: ""
       key: "token"
 extraEnv: {}
+
+# ─── G91.sandbox (#2657) SSO opt-in ───────────────────────────────────────
+# Per SECURITY.md §6.3 every Application Blueprint declares SSO support
+# with a single value. bp-sso-bridge (G91.1 #2652) watches every HR with
+# `sso.enabled: true` and reconciles a Keycloak Client + OpenBao
+# `secret/sso/sandbox` + ExternalSecret in this namespace.
+#
+# bp-sandbox propagates the resulting Secret into the sandbox-controller
+# Pod as three env vars (SANDBOX_SSO_CLIENT_ID, SANDBOX_SSO_CLIENT_SECRET,
+# SANDBOX_SSO_ISSUER_URL); the controller in turn injects them into the
+# per-Sandbox pty-server PodSpec so each user Sandbox UI is OIDC-fronted
+# without a per-Sandbox Keycloak Client (one parent Client + per-user
+# subject = scales cleanly).
+#
+# G91.sandbox-controller follow-up: the sandbox-controller Go code at
+# core/controllers/sandbox/ must learn to read these env vars and stamp
+# them onto the per-Sandbox pty-server's container env. This chart
+# change is the seam; the controller code follow-up wires the runtime
+# half. The env vars are present + unused until that lands.
+sso:
+  enabled: true
+  realm: sovereign
+  # Per-Sovereign cluster overlay sets this (e.g. `hw86.omani.works`).
+  # When empty the SSO env vars on the controller Pod are empty strings,
+  # and the controller's follow-up code path will skip OIDC injection
+  # (fail-open to local Sandbox auth) rather than half-configuring.
+  sovereignFqdn: ""
+  # OIDC client ID — defaults to "sandbox" (bp-sso-bridge strips "bp-"
+  # from the HR name).
+  clientId: sandbox
+  externalSecretStoreName: vault-region1
+  refreshInterval: 1h
+  # Realm group the controller honors as Sandbox admin (full UI). The
+  # Sovereign operator (deployment.OrgEmail) is auto-added by the realm
+  # import.
+  adminGroup: sovereign-admins

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -28,21 +28,23 @@ slots:
   # ---- Tier 0-4: present today (post-PR-247 baseline) -----------------------
   - slot: 1
     name: bp-cilium
-    # Refs #2650 dep-graph reconcile (2026-06-01): bp-cilium installs the
-    # cilium-gateway controller and enables gatewayAPI.enabled=true. That
-    # requires the upstream Gateway API CRDs to be present — installed by
-    # bp-gateway-api at slot 1a. So bp-cilium dependsOn bp-gateway-api.
-    # Earlier expected-deps had the edge reversed (gateway-api → cilium)
-    # which contradicted both the actual on-disk HR config and the
-    # canonical install order documented in issue #503.
+    # G65 (META-AUDIT 1 sub-class 11, #2105 / #2106): Cilium 1.16's
+    # `gatewayAPI.enabled=true` controller fails to start with `CRD
+    # gateway.networking.k8s.io/v1.Gateway not found` unless the
+    # upstream Kubernetes Gateway API CRDs are already registered with
+    # the apiserver. The cleanest fix is dep ordering — install
+    # bp-gateway-api FIRST (slot 1a's chart is CRD-only and has no
+    # cluster-network requirement), then bp-cilium. Same shape as
+    # bp-crossplane-claims dependsOn bp-crossplane (CRD provider →
+    # CRD consumer).
     depends_on: [bp-gateway-api]
     wave: present
   - slot: 1a
     name: bp-gateway-api
     # Upstream Kubernetes Gateway API CRDs (Standard channel — issue #503).
-    # Pure CRD install; no controller, no dependencies. bp-cilium installs
-    # the cilium-gateway controller that USES these CRDs via
-    # gatewayAPI.enabled=true (slot 1 dependsOn this slot).
+    # G65 (2026-05-31): bp-gateway-api ships first (no upstream cluster
+    # dep) and bp-cilium gates on its Ready. This chart is CRD-only +
+    # tiny so it converges before bp-cilium's controller image pull.
     depends_on: []
     wave: present
   - slot: 2


### PR DESCRIPTION
## Summary

Sixth app in the G91 SSO chain. Ships the chart-side seam for OIDC auth on the Pillar-4 qwen-code Sandbox UI; the sandbox-controller Go code wiring lands as G91.sandbox-controller follow-up.

## What this PR ships

1. **values.yaml top-level `sso:` block** (defaults `enabled: true`, gated additionally by chart's `.Values.enabled`).
2. **templates/sso-oauth-source-externalsecret.yaml** — ExternalSecret reading bp-sso-bridge's OpenBao `secret/sso/sandbox` bundle into `sandbox-sso-oidc-credentials` Secret (keys `client_id`, `client_secret`, `issuer_url`).
3. **deployment.yaml extends** with SSO env vars on the sandbox-controller Pod (`SANDBOX_SSO_*`), with `optional: true` secretKeyRefs so a fresh-prov Sovereign where bp-sso-bridge hasn't yet materialised the Secret does NOT crash the controller.
4. **Lockstep bumps**: Chart.yaml 0.3.7 → 0.3.8 + clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml pin 0.3.7 → 0.3.8.

## Why no post-install Job

Unlike G91.gitea/G91.harbor/G91.openbao, Sandbox doesn't have its own auth UI to configure — every per-Sandbox pty-server UI is rendered dynamically by the controller per Sandbox CR. The OIDC wiring happens at runtime when the controller stamps the pty-server's PodSpec, not at chart-install time.

## Follow-up scope (separate PR)

**G91.sandbox-controller** — `core/controllers/sandbox/` reads the `SANDBOX_SSO_*` env vars and propagates `OIDC_ENABLED/OIDC_ISSUER_URL/OIDC_CLIENT_ID/OIDC_CLIENT_SECRET/OIDC_ADMIN_GROUP` into the per-Sandbox pty-server PodSpec env, plus pty-server's HTTPRoute / browser wrapper handles the OIDC auth-code redirect.

## Test plan

- [x] `helm template` with `enabled=true + sso defaults` renders 1 ExternalSecret + 7 `SANDBOX_SSO_*` env-var name references on the controller Deployment
- [x] `helm template` with `enabled=false` collapses to zero rendered resources (no regression)
- [ ] After CI merge + chart publish, hw86 cluster overlay sets `sso.sovereignFqdn=hw86.omani.works` + verify SSO env vars present on sandbox-controller Pod
- [ ] After G91.sandbox-controller follow-up, click "Open" on bp-sandbox card in catalyst-ui /apps → land in Sandbox pty-server UI logged in as Sovereign operator with admin role via OIDC (Playwright walk + screenshot)

Refs #2657