### PR TITLE
feat(catalyst-platform): G91.catalyst-console-admin-self-grant — operator gets catalyst-admin realm-role (Refs #2659)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -969,6 +969,38 @@ spec:
   # for console/admin/api. All chart-level Catalyst service config (image refs,
   # OTel endpoints, NATS subjects) lives in products/catalyst/chart/values.yaml.
   values:
+    # G91.catalyst-console-admin-self-grant (#2659): the Sovereign operator
+    # (deployment.OrgEmail; from the sovereign-fqdn ConfigMap orgEmail key)
+    # is auto-granted the realm-role `catalyst-admin` (composite over
+    # catalyst-{viewer,developer,operator,admin,owner} per
+    # platform/keycloak/chart/templates/configmap-sovereign-realm.yaml).
+    #
+    # `skipClientUpsert: true` is mandatory — the `catalyst-ui` Keycloak
+    # Client is created by the realm import at bp-keycloak install time
+    # (PKCE public client, exact redirectUris, exact webOrigins). If
+    # bp-sso-bridge tried to upsert it, the PUT would clobber that
+    # pre-existing definition. The opt-out shipped in
+    # bp-sso-bridge 0.1.1 (G91-fu, Refs #2659, edc55c08) gates exactly
+    # this case — `skipClientUpsert: true` makes bp-sso-bridge skip the
+    # per-Client upsert + ExternalSecret + per-Client `admin` grant path
+    # and ONLY run grant_operator_realm_roles.
+    #
+    # clientId is set to `catalyst-ui` to match the realm-import Client.
+    # bp-sso-bridge does not consult clientId when skipClientUpsert=true
+    # (it only feeds the labels/logs); the realm-role grant is per-user
+    # not per-client.
+    #
+    # realm-role `catalyst-admin` exists in the realm import (see
+    # configmap-sovereign-realm.yaml composite-role chain). If a future
+    # realm re-architecture drops the role, the grant is a no-op (the
+    # framework's lookup returns 404 and logs a WARN — non-fatal).
+    sso:
+      enabled: true
+      realm: sovereign
+      clientId: catalyst-ui
+      skipClientUpsert: true
+      realmRolesGranted:
+        - catalyst-admin
     # G87 #2634: multi-region CNPG instances default (1 single-region, 2 multi).
     # Applies to sme-services' CNPG cluster (sme-pg).
     sme:


### PR DESCRIPTION
## Summary

Closes the #2659 acceptance path: the Sovereign operator (deployment.OrgEmail) lands in the operator console as a Catalyst Admin on first OIDC sign-in, with no per-Sovereign manual realm-role mapping.

## What this PR ships

Adds an `sso:` block under `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` `.spec.values`:

```yaml
sso:
  enabled: true
  realm: sovereign
  clientId: catalyst-ui
  skipClientUpsert: true
  realmRolesGranted:
    - catalyst-admin
```

- **`skipClientUpsert: true`** is mandatory — the `catalyst-ui` Keycloak Client is created by the realm import at bp-keycloak install time (PKCE public client, exact redirectUris, exact webOrigins). Without the opt-out bp-sso-bridge would try to upsert that Client and CLOBBER the realm-import definition. The opt-out shipped in bp-sso-bridge 0.1.1 (G91-fu, edc55c08) gates exactly this case.
- **`realmRolesGranted: [catalyst-admin]`** triggers `bp-sso-bridge.grant_operator_realm_roles()` which idempotently POSTs the realm-role-mapping. `catalyst-admin` is the composite role granting viewer + developer + operator + admin + owner per `platform/keycloak/chart/templates/configmap-sovereign-realm.yaml`.

## Why safe to ship default-on

- `skipClientUpsert: true` prevents Client clobber.
- Realm-role grant is idempotent (Keycloak swallows duplicate role-mappings).
- No-op until operator user materialises in the realm — bp-sso-bridge defers gracefully with a WARN log on missing user.
- Missing realm-role returns 404 + WARN (framework-tolerated, non-fatal).

## Dependencies

- bp-sso-bridge 0.1.1 (edc55c08) — must be installed + Pod reconciled ≥1× AFTER the HR-values change reaches the apiserver.
- Pre-existing realm Client `catalyst-ui` (already shipped via the realm import).

## Test plan

- [x] Single-file change to `13-bp-catalyst-platform.yaml`; no chart bump (bp-catalyst-platform code unchanged, change lives in the per-Sovereign Flux overlay layer).
- [ ] After merge + Flux reconcile on hw86: `kubectl get hr -n flux-system bp-catalyst-platform -o jsonpath='{.spec.values.sso}'` shows the new block.
- [ ] bp-sso-bridge Pod log on next tick: `granted realm-role 'catalyst-admin' to <operator-email>`.
- [ ] Keycloak admin UI on hw86: operator user's `realm roles` lists `catalyst-admin`.
- [ ] Playwright walk: click "Open" on catalyst-console card in catalyst-ui /apps → land in operator console as Catalyst Admin via OIDC (screenshot in #2659).

Refs #2659