### PR TITLE
feat(bp-*): G93.3 — CNPG cluster.affinity.topologyKey=region default when instances>=2 (Refs #2668)

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -54,7 +54,7 @@ spec:
       # bp-self-sovereign-cutover Step 1 gitea-mirror Job mounts it. K8s
       # forbids cross-namespace secretKeyRef; reflector is the canonical
       # platform-level mirror. Caught live on otech103 2026-05-04.
-      version: 1.2.11
+      version: 1.2.12
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -127,7 +127,7 @@ spec:
       # message read "Helm install failed for release powerdns/powerdns
       # with chart bp-powerdns@1.2.2: failed post-install: 1 error
       # occurred: * job powerdns-zone-bootstrap failed: BackoffLimitExceeded".
-      version: 1.2.5
+      version: 1.2.6
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -109,7 +109,7 @@ spec:
       # live on otech113 2026-05-05 (issue #935 Bug 1) — Step 02 was
       # in CreateContainerConfigError for 11+ retries, blocking
       # cutover indefinitely.
-      version: 1.2.21
+      version: 1.2.22
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/_template/bootstrap-kit/56-bp-openova-flow-server.yaml
+++ b/clusters/_template/bootstrap-kit/56-bp-openova-flow-server.yaml
@@ -71,7 +71,7 @@ spec:
   chart:
     spec:
       chart: bp-openova-flow-server
-      version: 0.2.1
+      version: 0.2.2
       sourceRef:
         kind: HelmRepository
         name: bp-openova-flow-server

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -197,7 +197,7 @@ spec:
       # 1.4.41 — chore(privacy): rename the partner-named channel slot
       # to `qwenPartner` and strip partner identifiers from comments /
       # fixtures / Secret names.
-      version: 1.4.56
+      version: 1.4.57
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.2.11
+  version: 1.2.12
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -29,7 +29,7 @@ name: bp-gitea
 # directly in Gitea as a site admin via OIDC. Local `gitea_admin` user
 # remains the break-glass account for bp-self-sovereign-cutover Step 1.
 # Per SECURITY.md §6.3 (App-level SSO).
-version: 1.2.11
+version: 1.2.12
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/cnpg-cluster.yaml
+++ b/platform/gitea/chart/templates/cnpg-cluster.yaml
@@ -29,6 +29,24 @@ spec:
   instances: {{ .Values.postgres.cluster.instances | default 1 }}
   imageName: ghcr.io/cloudnative-pg/postgresql:{{ .Values.postgres.cluster.pgVersion | default "16" }}
 
+  {{- /*
+  G93.3 (Refs #2668) — when instances >= 2, default the CNPG
+  Cluster CR's affinity.topologyKey to topology.kubernetes.io/region
+  so the CNPG operator's auto-generated podAntiAffinity spreads
+  replicas across regions on Cilium ClusterMesh peers (Pillar 3 zero-
+  tx-loss). Single-instance Sovereigns skip the block so the CNPG
+  operator falls back to its upstream default (kubernetes.io/hostname,
+  preferred) and a single-node prod still schedules. Operator
+  overrides via .Values.postgres.cluster.affinity.{topologyKey,
+  podAntiAffinityType} if the chart-default is wrong for the
+  deployment shape.
+  */ -}}
+  {{- if ge (int (.Values.postgres.cluster.instances | default 1)) 2 }}
+  affinity:
+    topologyKey: {{ (default dict .Values.postgres.cluster.affinity).topologyKey | default "topology.kubernetes.io/region" | quote }}
+    podAntiAffinityType: {{ (default dict .Values.postgres.cluster.affinity).podAntiAffinityType | default "preferred" | quote }}
+  {{- end }}
+
   bootstrap:
     initdb:
       database: {{ .Values.postgres.cluster.database | default "gitea" | quote }}

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-5-storage-and-data
 spec:
-  version: 1.2.21
+  version: 1.2.22
   card:
     title: Harbor
     family: foundation

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -52,7 +52,7 @@ type: application
 # The Postgres workload Pods reconcile into the same NS as the
 # CNPG Cluster CR, NOT into cnpg-system; the prior rule could
 # never match the actual DB Pods.
-version: 1.2.21
+version: 1.2.22
 appVersion: "2.14.3"
 # 1.2.21 (G91.harbor #2654, 2026-05-31): opt in to the bp-sso-bridge
 # (G91.1 #2652) SSO framework. Top-level `sso:` block (defaults

--- a/platform/harbor/chart/templates/cnpg-cluster.yaml
+++ b/platform/harbor/chart/templates/cnpg-cluster.yaml
@@ -38,6 +38,17 @@ spec:
   instances: {{ .Values.postgres.cluster.instances | default 1 }}
   imageName: ghcr.io/cloudnative-pg/postgresql:{{ .Values.postgres.cluster.pgVersion | default "16" }}
 
+  {{- /* G93.3 (Refs #2668) — see bp-gitea cnpg-cluster.yaml for the full
+  rationale. When instances>=2, default the CNPG affinity.topologyKey
+  to topology.kubernetes.io/region so the operator's auto-generated
+  podAntiAffinity spreads replicas across regions on Cilium
+  ClusterMesh peers. */ -}}
+  {{- if ge (int (.Values.postgres.cluster.instances | default 1)) 2 }}
+  affinity:
+    topologyKey: {{ (default dict .Values.postgres.cluster.affinity).topologyKey | default "topology.kubernetes.io/region" | quote }}
+    podAntiAffinityType: {{ (default dict .Values.postgres.cluster.affinity).podAntiAffinityType | default "preferred" | quote }}
+  {{- end }}
+
   bootstrap:
     initdb:
       # Harbor connects to a DB named "registry" (upstream coreDatabase default).

--- a/platform/llm-gateway/blueprint.yaml
+++ b/platform/llm-gateway/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-6-llm-serving
 spec:
-  version: 1.0.0
+  version: 1.0.1
   card:
     title: LLM Gateway
     summary: |

--- a/platform/llm-gateway/chart/Chart.yaml
+++ b/platform/llm-gateway/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-llm-gateway
-version: 1.0.0
+version: 1.0.1
 appVersion: "v1.57.2"
 description: |
   Catalyst-curated Blueprint umbrella chart for the LLM Gateway —

--- a/platform/llm-gateway/chart/templates/cnpg-cluster.yaml
+++ b/platform/llm-gateway/chart/templates/cnpg-cluster.yaml
@@ -27,6 +27,15 @@ spec:
   {{- with .Values.catalystOverlay.cnpg.imageName }}
   imageName: {{ . | quote }}
   {{- end }}
+  {{- /* G93.3 (Refs #2668) — see bp-gitea cnpg-cluster.yaml for full
+  rationale. When instances>=2, default CNPG affinity.topologyKey to
+  topology.kubernetes.io/region for cross-region spread on Cilium
+  ClusterMesh. */ -}}
+  {{- if ge (int (.Values.catalystOverlay.cnpg.instances | default 1)) 2 }}
+  affinity:
+    topologyKey: {{ (default dict .Values.catalystOverlay.cnpg.affinity).topologyKey | default "topology.kubernetes.io/region" | quote }}
+    podAntiAffinityType: {{ (default dict .Values.catalystOverlay.cnpg.affinity).podAntiAffinityType | default "preferred" | quote }}
+  {{- end }}
   storage:
     size: {{ .Values.catalystOverlay.cnpg.storage.size }}
     {{- with .Values.catalystOverlay.cnpg.storage.storageClass }}

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-6-llm-serving
 spec:
-  version: 1.4.56
+  version: 1.4.57
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -411,7 +411,7 @@ name: bp-newapi
 # `lookup valkey.valkey.svc.cluster.local: no such host`). Same hostname
 # already documented as canonical in products/catalyst/chart/values.yaml
 # bp-cnpg-pair comments.
-version: 1.4.56
+version: 1.4.57
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/cnpg-cluster.yaml
+++ b/platform/newapi/chart/templates/cnpg-cluster.yaml
@@ -66,6 +66,15 @@ metadata:
 spec:
   instances: {{ .Values.cnpg.cluster.instances | default 1 }}
   imageName: {{ .Values.cnpg.cluster.imageName | default "ghcr.io/cloudnative-pg/postgresql:16.4" | quote }}
+  {{- /* G93.3 (Refs #2668) — see bp-gitea cnpg-cluster.yaml for full
+  rationale. When instances>=2, default CNPG affinity.topologyKey to
+  topology.kubernetes.io/region for cross-region spread on Cilium
+  ClusterMesh. */ -}}
+  {{- if ge (int (.Values.cnpg.cluster.instances | default 1)) 2 }}
+  affinity:
+    topologyKey: {{ (default dict .Values.cnpg.cluster.affinity).topologyKey | default "topology.kubernetes.io/region" | quote }}
+    podAntiAffinityType: {{ (default dict .Values.cnpg.cluster.affinity).podAntiAffinityType | default "preferred" | quote }}
+  {{- end }}
   storage:
     size: {{ .Values.cnpg.cluster.storage | default "5Gi" | quote }}
     {{- with .Values.cnpg.cluster.storageClassName }}

--- a/platform/openova-flow-server/chart/Chart.yaml
+++ b/platform/openova-flow-server/chart/Chart.yaml
@@ -5,7 +5,7 @@ name: bp-openova-flow-server
 # Opt out of the hollow-chart guard per docs/BLUEPRINT-AUTHORING.md §11.1.
 annotations:
   catalyst.openova.io/no-upstream: "true"
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.2.0"
 description: |
   Catalyst Blueprint chart for the openova-flow-server — the

--- a/platform/openova-flow-server/chart/templates/cnpg-cluster.yaml
+++ b/platform/openova-flow-server/chart/templates/cnpg-cluster.yaml
@@ -29,6 +29,16 @@ spec:
   instances: {{ .Values.postgres.cluster.instances | default 1 }}
   imageName: ghcr.io/cloudnative-pg/postgresql:{{ .Values.postgres.cluster.pgVersion | default "16" }}
 
+  {{- /* G93.3 (Refs #2668) — see bp-gitea cnpg-cluster.yaml for full
+  rationale. When instances>=2, default CNPG affinity.topologyKey to
+  topology.kubernetes.io/region for cross-region spread on Cilium
+  ClusterMesh. */ -}}
+  {{- if ge (int (.Values.postgres.cluster.instances | default 1)) 2 }}
+  affinity:
+    topologyKey: {{ (default dict .Values.postgres.cluster.affinity).topologyKey | default "topology.kubernetes.io/region" | quote }}
+    podAntiAffinityType: {{ (default dict .Values.postgres.cluster.affinity).podAntiAffinityType | default "preferred" | quote }}
+  {{- end }}
+
   bootstrap:
     initdb:
       database: {{ .Values.postgres.cluster.database | default "openova_flow" | quote }}

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.5
+  version: 1.2.6
   card:
     title: PowerDNS
     summary: |

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -4,7 +4,7 @@ name: bp-powerdns
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.2.5
+version: 1.2.6
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/templates/cnpg-cluster.yaml
+++ b/platform/powerdns/chart/templates/cnpg-cluster.yaml
@@ -42,6 +42,16 @@ spec:
   instances: {{ .Values.postgres.cluster.instances | default 1 }}
   imageName: ghcr.io/cloudnative-pg/postgresql:{{ .Values.postgres.cluster.pgVersion | default "16" }}
 
+  {{- /* G93.3 (Refs #2668) — see bp-gitea cnpg-cluster.yaml for full
+  rationale. When instances>=2, default CNPG affinity.topologyKey to
+  topology.kubernetes.io/region for cross-region spread on Cilium
+  ClusterMesh. */ -}}
+  {{- if ge (int (.Values.postgres.cluster.instances | default 1)) 2 }}
+  affinity:
+    topologyKey: {{ (default dict .Values.postgres.cluster.affinity).topologyKey | default "topology.kubernetes.io/region" | quote }}
+    podAntiAffinityType: {{ (default dict .Values.postgres.cluster.affinity).podAntiAffinityType | default "preferred" | quote }}
+  {{- end }}
+
   # Annotations CNPG propagates onto every Secret it generates
   # (pdns-pg-app, pdns-pg-superuser, etc) so Reflector mirrors
   # `pdns-pg-app` into the chart-emitted placeholder Secret

--- a/platform/temporal/blueprint.yaml
+++ b/platform/temporal/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-4-3-workflow-and-processing
 spec:
-  version: 1.0.0
+  version: 1.0.1
   card:
     title: Temporal
     summary: Durable workflow orchestration with saga + compensation. Postgres-backed (CNPG); Postgres visibility store; Web UI; Keycloak OIDC integration via `--auth-claim-mapper`.

--- a/platform/temporal/chart/Chart.yaml
+++ b/platform/temporal/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-temporal
-version: 1.0.0
+version: 1.0.1
 appVersion: "1.31.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for Temporal — durable

--- a/platform/temporal/chart/templates/cnpg-cluster.yaml
+++ b/platform/temporal/chart/templates/cnpg-cluster.yaml
@@ -31,6 +31,15 @@ spec:
   {{- with .Values.catalystOverlay.cnpg.imageName }}
   imageName: {{ . | quote }}
   {{- end }}
+  {{- /* G93.3 (Refs #2668) — see bp-gitea cnpg-cluster.yaml for full
+  rationale. When instances>=2, default CNPG affinity.topologyKey to
+  topology.kubernetes.io/region for cross-region spread on Cilium
+  ClusterMesh. */ -}}
+  {{- if ge (int (.Values.catalystOverlay.cnpg.instances | default 1)) 2 }}
+  affinity:
+    topologyKey: {{ (default dict .Values.catalystOverlay.cnpg.affinity).topologyKey | default "topology.kubernetes.io/region" | quote }}
+    podAntiAffinityType: {{ (default dict .Values.catalystOverlay.cnpg.affinity).podAntiAffinityType | default "preferred" | quote }}
+  {{- end }}
   storage:
     size: {{ .Values.catalystOverlay.cnpg.storage.size }}
     {{- with .Values.catalystOverlay.cnpg.storage.storageClass }}


### PR DESCRIPTION
## Summary

**G93.3 (EPIC #2640 → sub-issue #2668)** — When a CNPG Cluster CR has \`instances >= 2\`, default \`spec.affinity.topologyKey\` to \`topology.kubernetes.io/region\` so the CNPG operator's auto-generated podAntiAffinity spreads replicas across regions on Cilium ClusterMesh peers (Pillar 3 zero-tx-loss). Single-instance Sovereigns keep CNPG's upstream default (\`kubernetes.io/hostname\`) so single-node prod still schedules.

### Why this matters

Pre-G93.3: every CNPG Cluster CR rendered with CNPG's upstream default \`affinity.topologyKey: kubernetes.io/hostname\`. On a multi-region Sovereign provisioned via G93.1+G93.2 (active-hotstandby topology), this meant:
- CNPG operator's auto-generated podAntiAffinity tried to spread replicas across **hostnames**.
- With \`instances: 2\` on a 2-region prov where each region typically has 1 control-plane node, scheduling would either pile both replicas on the same region (defeating the purpose) or fail outright.

### Charts updated

| Chart | version | bootstrap-kit pin |
|---|---|---|
| bp-gitea | 1.2.11 → 1.2.12 | ✓ |
| bp-harbor | 1.2.21 → 1.2.22 | ✓ |
| bp-powerdns | 1.2.5 → 1.2.6 | ✓ |
| bp-newapi | 1.4.56 → 1.4.57 | ✓ |
| bp-openova-flow-server | 0.2.1 → 0.2.2 | ✓ |
| bp-llm-gateway | 1.0.0 → 1.0.1 | (Application Blueprint, no pin) |
| bp-temporal | 1.0.0 → 1.0.1 | (Application Blueprint, no pin) |

### Skipped (intentional)

- **bp-wordpress-tenant** + **bp-cnpg-pair**: both pin their Cluster CRs to a specific region via \`nodeAffinity\` (primary/replica region label), so within-region podAntiAffinity using hostname is correct. No change needed.

### Multi-layer RCA (Principle 16)

| Layer | Diagnosis |
|---|---|
| **Trigger** | CNPG upstream default \`topologyKey: kubernetes.io/hostname\` is wrong for multi-region Sovereigns; charts didn't override. |
| **Defense** | Chart-default flip on \`instances >= 2\` — operator opts in by raising instance count, the chart picks region automatically. |
| **Containment** | \`podAntiAffinityType: preferred\` (soft constraint) — single-region prov with deliberate \`instances >= 2\` still schedules (best-effort spread across hostnames). |
| **Incident management** | Operator override via \`values.yaml\` (e.g. \`.Values.postgres.cluster.affinity.topologyKey\`) is the documented escape hatch; chart comment cites this PR + the decision rationale. |

## Test plan

- [x] Inline conditional Helm logic — all 7 charts pass \`helm template\` after the edit.
- [x] Pin-sync — bootstrap-kit pins bumped in lockstep where applicable.
- [ ] CI: chart-render + helm-lint suites.
- [ ] Fresh prov (operator-walk) on 2-region HCS Sovereign — install bp-gitea with \`postgres.cluster.instances: 2\` and verify the rendered CNPG Cluster CR has \`spec.affinity.topologyKey: topology.kubernetes.io/region\` + the two CNPG Pods land in distinct regions.

## Builds on

- **G93.1 (PR #2675)** — provides SOVEREIGN_BCP_TOPOLOGY env from cloud-init.
- **G93.2 (PR #2679)** — application-controller derives effective placement.

## Follow-up

- **G93.4 #2669** — cross-region HTTPRoute geo-routing + PowerDNS lua-records.

Refs #2668

🤖 Generated with [Claude Code](https://claude.com/claude-code)