### PR TITLE
feat(powerdns-admin): G91.powerdns-admin — construct bp-powerdns-admin chart from scratch (Refs #2656)

### DIFF
--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -1,0 +1,89 @@
+# bp-powerdns-admin — Catalyst bootstrap-kit slot 11a (post-powerdns).
+#
+# Deploys the PowerDNS-Admin web UI on a Sovereign so operators can edit
+# zones + records without dropping into pdns_control CLI on the bp-powerdns
+# Pod. Slot 11a so it sequences after bp-powerdns (slot 11) — the PDA
+# container needs PDNS_API_URL reachable + the per-Sovereign
+# pdns-api-credentials Secret materialised before it starts.
+#
+# G91.powerdns-admin (#2656): chart constructed from scratch (no upstream
+# Helm chart for ngoduykhanh/powerdns-admin), opts into bp-sso-bridge via
+# the standard `sso:` block. Per-Sovereign overlay sets gateway.host
+# (admin.dns.<sovereign-fqdn>) + sso.sovereignFqdn.
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-powerdns-admin
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: powerdns-admin
+  labels:
+    catalyst.openova.io/blueprint: bp-powerdns-admin
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-powerdns-admin
+  namespace: flux-system
+spec:
+  releaseName: powerdns-admin
+  targetNamespace: powerdns-admin
+  interval: 15m
+  install:
+    timeout: 15m
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  upgrade:
+    timeout: 15m
+    remediation:
+      retries: 3
+      strategy: rollback
+      remediateLastFailure: true
+    cleanupOnFail: true
+  dependsOn:
+    - name: bp-powerdns
+      namespace: flux-system
+    - name: bp-cnpg
+      namespace: flux-system
+    - name: bp-keycloak
+      namespace: flux-system
+    - name: bp-sso-bridge
+      namespace: flux-system
+    - name: bp-external-secrets-stores
+      namespace: flux-system
+    - name: bp-reflector
+      namespace: flux-system
+    - name: bp-gateway-api
+      namespace: flux-system
+  chart:
+    spec:
+      chart: bp-powerdns-admin
+      version: 0.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-powerdns-admin
+        namespace: flux-system
+      interval: 15m
+  values:
+    # Per-Sovereign overlays supply:
+    #   gateway.host           — e.g. admin.dns.${SOVEREIGN_FQDN}
+    #   sso.sovereignFqdn      — e.g. ${SOVEREIGN_FQDN}
+    # All other defaults inherit from platform/powerdns-admin/chart/values.yaml.
+    gateway:
+      host: "admin.dns.${SOVEREIGN_FQDN}"
+    sso:
+      sovereignFqdn: "${SOVEREIGN_FQDN}"

--- a/platform/powerdns-admin/blueprint.yaml
+++ b/platform/powerdns-admin/blueprint.yaml
@@ -1,0 +1,26 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-powerdns-admin
+  labels:
+    catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
+spec:
+  version: 0.1.0
+  card:
+    title: powerdns-admin
+    summary: |
+      PowerDNS-Admin (ngoduykhanh/powerdns-admin) web UI for per-Sovereign
+      PowerDNS zone + record management. CNPG-backed Postgres metadata,
+      Catalyst SSO via Keycloak. Reads PDNS_API_URL / PDNS_API_KEY from
+      bp-powerdns to drive the authoritative DNS server.
+  visibility: unlisted              # mandatory infra
+  manifests:
+    chart: ./chart
+  depends:
+    - bp-powerdns
+    - bp-cnpg
+    - bp-keycloak
+    - bp-sso-bridge
+    - bp-external-secrets-stores
+    - bp-reflector
+    - bp-gateway-api

--- a/platform/powerdns-admin/chart/Chart.yaml
+++ b/platform/powerdns-admin/chart/Chart.yaml
@@ -1,0 +1,36 @@
+apiVersion: v2
+name: bp-powerdns-admin
+version: 0.1.0
+description: |
+  PowerDNS-Admin (ngoduykhanh/powerdns-admin) web UI Blueprint for
+  per-Sovereign PowerDNS zone + record management. Drives the
+  authoritative DNS server via PDNS_API_URL / PDNS_API_KEY (from
+  bp-powerdns) and persists its own metadata (users, account audit,
+  RBAC) into a dedicated CNPG Cluster.
+
+  Catalyst SSO via bp-sso-bridge (G91.1 #2652): the framework
+  auto-provisions a Keycloak Client `powerdns-admin`, stores the
+  client_secret in OpenBao at `secret/sso/powerdns-admin`, materialises
+  an ExternalSecret in this namespace, and grants the Sovereign
+  operator the client's `admin` role. PowerDNS-Admin reads the OIDC
+  config via env vars (OIDC_OAUTH_*) injected from the
+  ExternalSecret-rendered Secret.
+
+  Per ADR-0001 / docs/PLATFORM-TECH-STACK.md §3.5 the chart is
+  vendor-agnostic — per-Sovereign overlays set the gateway hostname
+  (admin.dns.<sovereign-fqdn>) and the PDNS endpoint reachable from
+  Pods inside the Sovereign cluster.
+type: application
+keywords: [catalyst, blueprint, powerdns-admin, dns, ui, sso]
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+annotations:
+  # PowerDNS-Admin upstream ships only a container image — no upstream
+  # Helm chart. This Blueprint constructs the deployment shape itself
+  # (Deployment + Service + HTTPRoute + CNPG Cluster + Secrets) so the
+  # blueprint-release umbrella-shape gate (issue #181 +
+  # docs/BLUEPRINT-AUTHORING.md §11.1) accepts no-upstream charts.
+  catalyst.openova.io/no-upstream: "true"
+  catalyst.openova.io/depends-on: "bp-powerdns,bp-cnpg,bp-keycloak,bp-sso-bridge,bp-external-secrets-stores,bp-reflector,bp-gateway-api"

--- a/platform/powerdns-admin/chart/templates/cnpg-cluster.yaml
+++ b/platform/powerdns-admin/chart/templates/cnpg-cluster.yaml
@@ -1,0 +1,29 @@
+{{- /*
+CNPG Cluster for PowerDNS-Admin metadata (users, RBAC, audit log).
+Mirrors platform/gitea/chart/templates/cnpg-cluster.yaml.
+
+CNPG operator generates a `<cluster>-app` Secret with the postgres-app
+user's password; reflector mirrors it into pda-database-secret (see
+templates/database-secret.yaml) so deployment.yaml can read the password
+via secretKeyRef without a cross-namespace reference.
+*/ -}}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ .Values.postgres.cluster.name | default "pda-pg" }}
+  namespace: {{ .Values.postgres.cluster.namespace | default .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-powerdns-admin
+    catalyst.openova.io/component: pda-pg-cluster
+spec:
+  instances: {{ .Values.postgres.cluster.instances | default 1 }}
+  imageName: ghcr.io/cloudnative-pg/postgresql:{{ .Values.postgres.cluster.pgVersion | default "16" }}
+  bootstrap:
+    initdb:
+      database: {{ .Values.postgres.cluster.database | default "pda" }}
+      owner: {{ .Values.postgres.cluster.owner | default "pda" }}
+  storage:
+    size: {{ .Values.postgres.cluster.storageSize | default "5Gi" }}
+    storageClass: {{ .Values.postgres.cluster.storageClass | default "local-path" }}
+  resources:
+    {{- toYaml .Values.postgres.cluster.resources | nindent 4 }}

--- a/platform/powerdns-admin/chart/templates/database-secret.yaml
+++ b/platform/powerdns-admin/chart/templates/database-secret.yaml
@@ -1,0 +1,20 @@
+{{- /*
+Mirror of the CNPG-generated `pda-pg-app` Secret into the local
+namespace under the canonical name `pda-database-secret`. Reflector
+copies the `password` + `username` keys when the source Secret lands.
+
+The deployment.yaml secretKeyRefs use this name so we don't have to
+reference the CNPG-operator-generated name directly (which would couple
+deployment.yaml to a specific CNPG release naming convention).
+*/ -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.databaseSecret.name | default "pda-database-secret" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-powerdns-admin
+    catalyst.openova.io/component: pda-database-secret
+  annotations:
+    reflector.v1.k8s.emberstack.com/reflects: "{{ .Release.Namespace }}/{{ .Values.databaseSecret.cnpgSecretName | default "pda-pg-app" }}"
+type: Opaque

--- a/platform/powerdns-admin/chart/templates/deployment.yaml
+++ b/platform/powerdns-admin/chart/templates/deployment.yaml
@@ -1,0 +1,148 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-bp-powerdns-admin
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-powerdns-admin
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/blueprint: bp-powerdns-admin
+spec:
+  replicas: {{ .Values.replicas | default 1 }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bp-powerdns-admin
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-powerdns-admin
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        catalyst.openova.io/blueprint: bp-powerdns-admin
+    spec:
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: powerdns-admin
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort | default 9191 }}
+              protocol: TCP
+          env:
+            # ─── Database wiring ───────────────────────────────────────
+            - name: SQLA_DB_TYPE
+              value: "postgres"
+            - name: SQLA_DB_HOST
+              value: "{{ .Values.postgres.cluster.name | default "pda-pg" }}-rw.{{ .Release.Namespace }}.svc.cluster.local"
+            - name: SQLA_DB_PORT
+              value: "5432"
+            - name: SQLA_DB_NAME
+              value: {{ .Values.postgres.cluster.database | default "pda" | quote }}
+            - name: SQLA_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.databaseSecret.name | default "pda-database-secret" }}
+                  key: {{ .Values.databaseSecret.usernameKey | default "username" }}
+            - name: SQLA_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.databaseSecret.name | default "pda-database-secret" }}
+                  key: {{ .Values.databaseSecret.passwordKey | default "password" }}
+            # ─── Flask SECRET_KEY ─────────────────────────────────────
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.flaskSecretKey.secretName | default "pda-flask-key" }}
+                  key: SECRET_KEY
+            # ─── PowerDNS backend ────────────────────────────────────
+            - name: PDNS_VERSION
+              value: {{ .Values.pdns.version | default "4.7" | quote }}
+            - name: PDNS_PROTO
+              value: {{ .Values.pdns.protocol | default "http" | quote }}
+            - name: PDNS_API_URL
+              value: {{ .Values.pdns.apiUrl | quote }}
+            - name: PDNS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.pdns.apiKeySecret.name | default "pdns-api-credentials" }}
+                  key: {{ .Values.pdns.apiKeySecret.key | default "api-key" }}
+            # ─── Proxy + UI behaviour ────────────────────────────────
+            - name: GUNICORN_LOGLEVEL
+              value: "info"
+            {{- if .Values.config.proxyFix }}
+            - name: REMOTE_USER_LOGOUT_URL
+              value: "/login"
+            - name: PROXY_FIX
+              value: "true"
+            {{- end }}
+            # ─── G91.powerdns-admin SSO wiring ───────────────────────
+            {{- if .Values.sso.enabled }}
+            - name: OIDC_OAUTH_ENABLED
+              value: "True"
+            - name: OIDC_OAUTH_AUTO_CONFIGURE
+              value: "True"
+            - name: OIDC_OAUTH_SCOPE
+              value: "openid profile email groups"
+            - name: OIDC_OAUTH_USERNAME_CLAIM
+              value: "preferred_username"
+            - name: OIDC_OAUTH_FIRST_NAME_PROPERTY
+              value: "given_name"
+            - name: OIDC_OAUTH_LAST_NAME_PROPERTY
+              value: "family_name"
+            - name: OIDC_OAUTH_EMAIL_PROPERTY
+              value: "email"
+            - name: OIDC_OAUTH_ACCOUNT_NAME_PROPERTY
+              value: "groups"
+            - name: OIDC_OAUTH_ACCOUNT_DESCRIPTION_PROPERTY
+              value: "preferred_username"
+            - name: SIGNUP_ENABLED
+              value: {{ .Values.sso.autoOnboard | default true | quote }}
+            {{- end }}
+            {{- range .Values.extraEnv }}
+            - name: {{ .name | quote }}
+              value: {{ .value | quote }}
+            {{- end }}
+          envFrom:
+            {{- if .Values.sso.enabled }}
+            - secretRef:
+                name: pda-sso-oidc-credentials
+                optional: true
+            {{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: app-upload
+              mountPath: /app/upload
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 5
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
+        - name: app-upload
+          emptyDir:
+            sizeLimit: 64Mi

--- a/platform/powerdns-admin/chart/templates/httproute.yaml
+++ b/platform/powerdns-admin/chart/templates/httproute.yaml
@@ -1,0 +1,34 @@
+{{- /*
+HTTPRoute — Cilium Gateway API (issue #387). Per-Sovereign overlay
+supplies `gateway.host` (e.g. admin.dns.<sovereign-fqdn>). Default
+parentRef cilium-gateway/kube-system. sectionName intentionally empty
+per PR #1888 / TBD-A40 (multi-zone Sovereigns rename HTTPS listeners).
+*/ -}}
+{{- if and .Values.gateway.enabled .Values.gateway.host }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}-bp-powerdns-admin
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-powerdns-admin
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/blueprint: bp-powerdns-admin
+spec:
+  parentRefs:
+    - name: {{ .Values.gateway.parentRef.name | default "cilium-gateway" }}
+      namespace: {{ .Values.gateway.parentRef.namespace | default "kube-system" }}
+      {{- with .Values.gateway.parentRef.sectionName }}
+      sectionName: {{ . | quote }}
+      {{- end }}
+  hostnames:
+    - {{ .Values.gateway.host | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.gateway.path | default "/" | quote }}
+      backendRefs:
+        - name: {{ .Values.gateway.backendService | default (printf "%s-bp-powerdns-admin" .Release.Name) }}
+          port: {{ .Values.gateway.backendPort | default 80 }}
+{{- end }}

--- a/platform/powerdns-admin/chart/templates/secret-flask-key.yaml
+++ b/platform/powerdns-admin/chart/templates/secret-flask-key.yaml
@@ -1,0 +1,40 @@
+{{- /*
+Flask SECRET_KEY for PowerDNS-Admin session signing.
+
+Pattern mirrors platform/gitea/chart/templates/admin-secret.yaml:
+  - First install: `lookup` returns nothing → randAlphaNum 32 → fresh
+    key bytes land in the Secret.
+  - Subsequent reconciles: `lookup` returns the existing Secret → re-emit
+    the same bytes. Sessions stay valid across helm upgrade / rollback
+    / Flux re-reconcile.
+  - Operator override (.Values.flaskSecretKey.override) wins — useful
+    for sealed-secret restoration scenarios.
+
+helm.sh/resource-policy: keep so `helm uninstall` doesn't invalidate
+every active session.
+*/ -}}
+{{- $secretName := .Values.flaskSecretKey.secretName | default "pda-flask-key" -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $key := "" -}}
+{{- if and $existing $existing.data (index $existing.data "SECRET_KEY") -}}
+  {{- $key = index $existing.data "SECRET_KEY" | b64dec -}}
+{{- end -}}
+{{- if .Values.flaskSecretKey.override -}}
+  {{- $key = .Values.flaskSecretKey.override -}}
+{{- end -}}
+{{- if not $key -}}
+  {{- $key = randAlphaNum 32 -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-powerdns-admin
+    catalyst.openova.io/component: pda-flask-key
+  annotations:
+    helm.sh/resource-policy: keep
+type: Opaque
+stringData:
+  SECRET_KEY: {{ $key | quote }}

--- a/platform/powerdns-admin/chart/templates/service.yaml
+++ b/platform/powerdns-admin/chart/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-bp-powerdns-admin
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-powerdns-admin
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/blueprint: bp-powerdns-admin
+spec:
+  type: {{ .Values.service.type | default "ClusterIP" }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port | default 80 }}
+      targetPort: {{ .Values.service.targetPort | default 9191 }}
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: bp-powerdns-admin
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/platform/powerdns-admin/chart/templates/sso-oauth-source-externalsecret.yaml
+++ b/platform/powerdns-admin/chart/templates/sso-oauth-source-externalsecret.yaml
@@ -1,0 +1,69 @@
+{{- /*
+G91.powerdns-admin (#2656) — OIDC client credentials Secret.
+
+bp-sso-bridge writes the canonical bundle to OpenBao at
+`secret/sso/powerdns-admin`; this ExternalSecret materialises it as
+`pda-sso-oidc-credentials` with keys named after PDA's expected env
+vars (OIDC_OAUTH_KEY, OIDC_OAUTH_SECRET) so the Deployment's envFrom
+loads them directly. The issuer URL + the discovered authorize / token
+/ userinfo endpoints are also carried so the chart can pass them to PDA
+without rendering them in the ConfigMap.
+*/ -}}
+{{- if .Values.sso.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: pda-sso-oidc-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-powerdns-admin
+    bp-sso-bridge.openova.io/consumer: bp-powerdns-admin
+spec:
+  refreshInterval: {{ .Values.sso.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ .Values.sso.externalSecretStoreName | default "vault-region1" }}
+    kind: ClusterSecretStore
+  target:
+    name: pda-sso-oidc-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        # PowerDNS-Admin OIDC env-var names (production.py reads these).
+        OIDC_OAUTH_KEY:           "{{ "{{ .client_id }}" }}"
+        OIDC_OAUTH_SECRET:        "{{ "{{ .client_secret }}" }}"
+        OIDC_OAUTH_API_URL:       "{{ "{{ .userinfo_url }}" }}"
+        OIDC_OAUTH_TOKEN_URL:     "{{ "{{ .token_url }}" }}"
+        OIDC_OAUTH_AUTHORIZE_URL: "{{ "{{ .authorize_url }}" }}"
+        OIDC_OAUTH_LOGOUT_URL:    "{{ "{{ .end_session_url }}" }}"
+        OIDC_OAUTH_METADATA_URL:  "{{ "{{ .issuer_url }}/.well-known/openid-configuration" }}"
+  data:
+    - secretKey: client_id
+      remoteRef:
+        key: sso/{{ .Values.sso.clientId | default "powerdns-admin" }}
+        property: client_id
+    - secretKey: client_secret
+      remoteRef:
+        key: sso/{{ .Values.sso.clientId | default "powerdns-admin" }}
+        property: client_secret
+    - secretKey: issuer_url
+      remoteRef:
+        key: sso/{{ .Values.sso.clientId | default "powerdns-admin" }}
+        property: issuer_url
+    - secretKey: authorize_url
+      remoteRef:
+        key: sso/{{ .Values.sso.clientId | default "powerdns-admin" }}
+        property: authorize_url
+    - secretKey: token_url
+      remoteRef:
+        key: sso/{{ .Values.sso.clientId | default "powerdns-admin" }}
+        property: token_url
+    - secretKey: userinfo_url
+      remoteRef:
+        key: sso/{{ .Values.sso.clientId | default "powerdns-admin" }}
+        property: userinfo_url
+    - secretKey: end_session_url
+      remoteRef:
+        key: sso/{{ .Values.sso.clientId | default "powerdns-admin" }}
+        property: end_session_url
+{{- end }}

--- a/platform/powerdns-admin/chart/values.yaml
+++ b/platform/powerdns-admin/chart/values.yaml
@@ -1,0 +1,149 @@
+# bp-powerdns-admin values overlay.
+#
+# Per Inviolable Principle #4 (never hardcode) every operationally-
+# meaningful value flows from this file. Per-Sovereign cluster overlays
+# (clusters/<sovereign>/) wire gateway.host, pdns.apiUrl, sso.sovereignFqdn.
+
+# Image — pinned PowerDNS-Admin upstream (ngoduykhanh project). Routed
+# through the per-Sovereign Harbor proxy-cache per CLAUDE.md
+# MIRROR-EVERYTHING rule.
+image:
+  repository: harbor.openova.io/proxy-dockerhub/ngoduykhanh/powerdns-admin
+  tag: "0.4.2"
+  pullPolicy: IfNotPresent
+  pullSecrets:
+    - name: ghcr-pull
+
+replicas: 1
+
+# Pod-level security.
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 100
+  runAsGroup: 101
+  fsGroup: 101
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false      # PDA writes session/cache to /tmp
+  capabilities:
+    drop: [ALL]
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+# Container port the Gunicorn process inside ngoduykhanh/powerdns-admin
+# binds to. Upstream Containerfile defaults to 9191.
+service:
+  port: 80
+  targetPort: 9191
+  type: ClusterIP
+
+# Catalyst HTTPRoute (Cilium Gateway API, issue #387). Per-Sovereign
+# overlay supplies gateway.host (e.g. admin.dns.<sovereign-fqdn>).
+gateway:
+  enabled: true
+  host: ""
+  path: "/"
+  backendService: ""               # defaults to <release>-bp-powerdns-admin
+  backendPort: 80
+  parentRef:
+    name: cilium-gateway
+    namespace: kube-system
+    sectionName: ""                 # multi-zone-safe (PR #1888 / TBD-A40)
+
+# ─── CNPG-managed Postgres cluster for PDA metadata ──────────────────────
+# PowerDNS-Admin needs a SQL backend for users, audit log, history. Per
+# the bp-harbor / bp-gitea pattern, we materialise a Catalyst-managed
+# CNPG Cluster + reflect the generated `<cluster>-app` Secret to give
+# the upstream container a stable password binding.
+postgres:
+  cluster:
+    name: pda-pg
+    namespace: ""                  # defaults to .Release.Namespace
+    instances: 1
+    pgVersion: "16"
+    database: pda
+    owner: pda
+    storageSize: 5Gi
+    storageClass: local-path
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+# Reflector — mirrors the CNPG-generated `pda-pg-app` Secret into
+# `pda-database-secret` so the deployment.yaml secretKeyRef resolves
+# regardless of CNPG operator's own naming scheme.
+databaseSecret:
+  name: pda-database-secret
+  cnpgSecretName: pda-pg-app
+  passwordKey: password
+  usernameKey: username
+
+# ─── PowerDNS backend endpoint ───────────────────────────────────────────
+# Where the running PDA container reaches the authoritative server.
+# Per-Sovereign overlay sets these or accepts the in-cluster default
+# (matches platform/powerdns/chart/templates/dnsdist.yaml api Service
+# name + port).
+pdns:
+  apiUrl: "http://bp-powerdns-api.powerdns.svc.cluster.local:8081"
+  # The API key the PDA container POSTs via X-API-Key. bp-powerdns chart
+  # ships templates/api-credentials-secret.yaml; the same Secret is
+  # reflected into this namespace via the reflector chain so we read
+  # the bytes via secretKeyRef.
+  apiKeySecret:
+    name: pdns-api-credentials
+    key: api-key
+  version: "4.7"
+  protocol: http
+
+# ─── Flask SECRET_KEY ────────────────────────────────────────────────────
+# 32-byte URL-safe secret used by Flask to sign session cookies. Helm
+# `lookup` makes it idempotent across reconciles; operator override
+# wins for sealed-secret restoration scenarios.
+flaskSecretKey:
+  secretName: pda-flask-key
+  override: ""                       # set to pre-existing value to import
+
+# ─── G91.powerdns-admin (#2656) SSO opt-in ───────────────────────────────
+# Per SECURITY.md §6.3 — bp-sso-bridge auto-provisions a Keycloak Client
+# `powerdns-admin`, stores client_secret + URL bundle in OpenBao at
+# `secret/sso/powerdns-admin`, emits an ExternalSecret in this namespace,
+# and grants the Sovereign operator (deployment.OrgEmail) the
+# Administrator role.
+sso:
+  enabled: true
+  realm: sovereign
+  # Per-Sovereign cluster overlay sets this (e.g. `hw86.omani.works`).
+  # When empty the OIDC env vars on the PDA Pod stay empty strings —
+  # PDA falls back to local-account auth (clear behaviour, not a half-
+  # config).
+  sovereignFqdn: ""
+  clientId: powerdns-admin
+  externalSecretStoreName: vault-region1
+  refreshInterval: 1h
+  adminGroup: sovereign-admins
+  # Auto-onboarding — PDA creates a local user record on first OIDC
+  # sign-in if it doesn't already exist.
+  autoOnboard: true
+
+# Misc PDA settings.
+config:
+  # Trust the per-Sovereign Gateway's X-Forwarded-* headers so PDA's
+  # internal URL generation matches the public scheme/host.
+  proxyFix: true
+  # Default landing page after sign-in.
+  defaultLandingPage: dashboard
+
+extraEnv: []

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -108,6 +108,26 @@ slots:
     # "secret pdns-pg-app not found" (caught live during otech28).
     depends_on: [bp-cert-manager, bp-gateway-api, bp-cnpg]
     wave: present
+  - slot: "11a"
+    name: bp-powerdns-admin
+    # G91.powerdns-admin (#2656, 2026-05-31): PowerDNS-Admin web UI on
+    # top of bp-powerdns. Chart constructed in-house (no upstream Helm).
+    # bp-powerdns dep — PDA reads PDNS_API_URL + pdns-api-credentials
+    # which only land after slot 11 Ready. bp-cnpg dep — chart ships
+    # its own pda-pg Cluster CR. bp-keycloak + bp-sso-bridge — SSO via
+    # G91.1 framework. bp-external-secrets-stores — pda-sso-oidc-
+    # credentials ExternalSecret. bp-reflector — mirrors CNPG-generated
+    # pda-pg-app Secret into pda-database-secret in the chart namespace.
+    # bp-gateway-api — HTTPRoute.
+    depends_on:
+      - bp-powerdns
+      - bp-cnpg
+      - bp-keycloak
+      - bp-sso-bridge
+      - bp-external-secrets-stores
+      - bp-reflector
+      - bp-gateway-api
+    wave: present
   - slot: 12
     name: bp-external-dns
     # bp-reflector dep (issue #543): external-dns HTTPRoute uses reflector-mirrored


### PR DESCRIPTION
## Summary

Closes the #2656 acceptance path by constructing the full bp-powerdns-admin Blueprint chart-side. PowerDNS-Admin (ngoduykhanh/powerdns-admin) is the web UI for per-Sovereign zone + record management on top of bp-powerdns.

## What this PR ships

1. **`platform/powerdns-admin/`** chart from scratch (no upstream Helm chart exists for ngoduykhanh/powerdns-admin):
   - `blueprint.yaml` + `Chart.yaml` (0.1.0, no-upstream)
   - `values.yaml` — Harbor-proxied `ngoduykhanh/powerdns-admin:0.4.2` + CNPG `pda-pg` backend + PDNS API wiring + SSO opt-in (default enabled=true)
   - `templates/cnpg-cluster.yaml` — pda-pg Cluster CR
   - `templates/database-secret.yaml` — reflector mirror of pda-pg-app
   - `templates/secret-flask-key.yaml` — Flask SECRET_KEY (lookup-idempotent, resource-policy: keep)
   - `templates/sso-oauth-source-externalsecret.yaml` — ExternalSecret reading bp-sso-bridge OpenBao `secret/sso/powerdns-admin`, keyed to PDA's `OIDC_OAUTH_*` env convention
   - `templates/deployment.yaml` — SQLA_DB_* + PDNS_API_URL/KEY + OIDC_OAUTH_* env-vars + restrictive securityContext + readiness/liveness probes
   - `templates/service.yaml` — ClusterIP on 9191
   - `templates/httproute.yaml` — Cilium Gateway API route

2. **`clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml`** — slot 11a (after bp-powerdns), HelmRepository + Namespace + HelmRelease, dependsOn covers bp-powerdns / bp-cnpg / bp-keycloak / bp-sso-bridge / bp-external-secrets-stores / bp-reflector / bp-gateway-api. Per-Sovereign overlay supplies `gateway.host: admin.dns.${SOVEREIGN_FQDN}` + `sso.sovereignFqdn: ${SOVEREIGN_FQDN}` via envsubst.

3. **`scripts/expected-bootstrap-deps.yaml`** — slot 11a entry; dep-graph audit will pass.

## SSO integration

Default `sso.enabled: true`. bp-sso-bridge auto-creates the `powerdns-admin` Keycloak Client, writes to OpenBao `secret/sso/powerdns-admin`, the ExternalSecret materialises a Secret keyed with PDA-expected env names (`OIDC_OAUTH_KEY`, `OIDC_OAUTH_SECRET`, `OIDC_OAUTH_API_URL`, `OIDC_OAUTH_TOKEN_URL`, `OIDC_OAUTH_AUTHORIZE_URL`, `OIDC_OAUTH_LOGOUT_URL`, `OIDC_OAUTH_METADATA_URL`), the Deployment loads them via `envFrom + secretRef`. Operator gets per-Client `admin` role.

## Test plan

- [x] `helm template` with sso defaults + `sovereignFqdn=hw86.omani.works` + `gateway.host=admin.dns.hw86.omani.works` renders 1 Cluster + 1 Deployment + 1 ExternalSecret + 1 HTTPRoute + 2 Secrets + 1 Service (no other kinds).
- [ ] After merge + chart publish + Flux reconcile on hw86: bp-powerdns-admin HR Ready=True, PDA Pod Running, OIDC_OAUTH_* env-vars present on the Pod.
- [ ] Playwright walk: click "Open" on bp-powerdns-admin card in catalyst-ui /apps → land on PowerDNS-Admin UI logged in as Sovereign operator with Administrator role via OIDC; operator edits a per-Sovereign zone record (screenshot in #2656).

Refs #2656