### PR TITLE
feat(bp-powerdns): G93.4 — per-Application geo-failover lua-record values seam (Refs #2669)

### DIFF
--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -127,7 +127,7 @@ spec:
       # message read "Helm install failed for release powerdns/powerdns
       # with chart bp-powerdns@1.2.2: failed post-install: 1 error
       # occurred: * job powerdns-zone-bootstrap failed: BackoffLimitExceeded".
-      version: 1.2.6
+      version: 1.2.7
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.6
+  version: 1.2.7
   card:
     title: PowerDNS
     summary: |

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -4,7 +4,7 @@ name: bp-powerdns
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.2.6
+version: 1.2.7
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/templates/geo-failover-configmap.yaml
+++ b/platform/powerdns/chart/templates/geo-failover-configmap.yaml
@@ -1,0 +1,96 @@
+{{- /*
+G93.4 (Refs #2669) — geo-failover-spec ConfigMap.
+
+Records the operator's per-Application geo-failover intent (hostname +
+primary/replica IP + healthcheck URL) so:
+
+  1. The admin console's Geo-Failover page can render the configured
+     entries WITHOUT calling the PowerDNS API.
+  2. The application-controller (follow-up workstream) can derive entries
+     from Application CR `status.regions[].externalIP` + `spec.hostname`
+     and merge into this ConfigMap declaratively.
+  3. A future zone-bootstrap-job extension consumes this ConfigMap as
+     the source of truth for the LUA-record write loop (current PR
+     ships the data shape only; the API-call loop lands in a follow-up
+     to keep this PR's blast radius minimal).
+
+Render-time defaults: per-record `healthCheck.interval` / `.timeout` fall
+back to chart-level `geoFailover.defaultProbeIntervalSeconds` /
+`defaultProbeTimeoutSeconds` so a minimal operator payload
+(`hostname`, `primaryIP`, `replicaIP`, `healthCheck.url`) is sufficient.
+
+Render-time validation: empty hostname / missing IP / missing healthcheck
+URL fails the template render with a clear actionable error rather than
+landing a half-formed ConfigMap that downstream consumers would silently
+skip.
+
+Skipped entirely when `.Values.geoFailover.enabled=false` OR
+`.Values.geoFailover.records` is empty — zero side effects for the
+single-region case.
+*/}}
+{{- if and .Values.geoFailover.enabled (gt (len (default (list) .Values.geoFailover.records)) 0) }}
+{{- $ttl := default 300 .Values.geoFailover.ttl }}
+{{- $defaultInterval := default 10 .Values.geoFailover.defaultProbeIntervalSeconds }}
+{{- $defaultTimeout := default 2 .Values.geoFailover.defaultProbeTimeoutSeconds }}
+{{- $entries := list }}
+{{- range $i, $rec := .Values.geoFailover.records }}
+  {{- if not $rec.hostname }}
+    {{- fail (printf "geoFailover.records[%d].hostname is required" $i) }}
+  {{- end }}
+  {{- if not $rec.primaryIP }}
+    {{- fail (printf "geoFailover.records[%d].primaryIP is required (hostname=%q)" $i $rec.hostname) }}
+  {{- end }}
+  {{- if not $rec.replicaIP }}
+    {{- fail (printf "geoFailover.records[%d].replicaIP is required (hostname=%q) — single-region failover is not a failover" $i $rec.hostname) }}
+  {{- end }}
+  {{- if not (and $rec.healthCheck $rec.healthCheck.url) }}
+    {{- fail (printf "geoFailover.records[%d].healthCheck.url is required (hostname=%q)" $i $rec.hostname) }}
+  {{- end }}
+  {{- $interval := default $defaultInterval $rec.healthCheck.interval }}
+  {{- $timeout := default $defaultTimeout $rec.healthCheck.timeout }}
+  {{- $entry := dict
+      "hostname" $rec.hostname
+      "primaryIP" $rec.primaryIP
+      "replicaIP" $rec.replicaIP
+      "ttl" (default $ttl $rec.ttl)
+      "healthCheck" (dict
+        "url" $rec.healthCheck.url
+        "interval" $interval
+        "timeout" $timeout
+      )
+  }}
+  {{- $entries = append $entries $entry }}
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: powerdns-geo-failover-spec
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-powerdns.labels" . | nindent 4 }}
+    catalyst.openova.io/component: geo-failover
+  annotations:
+    catalyst.openova.io/comment: |
+      G93.4 (Refs #2669) — per-Application geo-failover intent.
+      Renders the canonical LUA-record body for each entry so a
+      follow-up zone-bootstrap-job loop can write them via the
+      PowerDNS API without re-rendering. Admin console reads the
+      `entries.json` key to populate the Geo-Failover page.
+data:
+  entries.json: |
+    {{ $entries | toJson }}
+  # Pre-rendered LUA-record bodies, one per entry. The canonical
+  # PowerDNS lua-record shape for active-hotstandby failover:
+  #
+  #   <hostname>.  <ttl>  IN  LUA  A  "ifurlup('<url>', {'<primary>', '<replica>'}, {timeout=<timeout>, interval=<interval>})"
+  #
+  # `ifurlup` probes the URL on the configured interval; returns
+  # primaryIP while the probe passes, falls through to replicaIP
+  # otherwise. Multiple entries in the {{`{...}`}} table act as a
+  # priority list — leftmost is preferred. See:
+  # https://doc.powerdns.com/authoritative/lua-records/functions.html#ifurlup
+  records.txt: |
+    {{- range $entry := $entries }}
+    {{ $entry.hostname }}.  {{ $entry.ttl }}  IN  LUA  A  "ifurlup('{{ $entry.healthCheck.url }}', {'{{ $entry.primaryIP }}', '{{ $entry.replicaIP }}'}, {timeout={{ $entry.healthCheck.timeout }}, interval={{ $entry.healthCheck.interval }}})"
+    {{- end }}
+{{- end }}

--- a/platform/powerdns/chart/values.yaml
+++ b/platform/powerdns/chart/values.yaml
@@ -491,6 +491,72 @@ crossplane:
 #       role: sme-pool
 zones: []
 
+# ─── Geo-failover lua-records (G93.4, Refs #2669) ────────────────────────
+# Per-Application geo-failover via PowerDNS lua-records (the `ifurlup`
+# pattern). When a multi-region Sovereign installs an Application that
+# wants cross-region failover (Pillar 3 zero-tx-loss for stateless
+# Application HRs), the operator (or the application-controller in a
+# follow-up workstream) declares each entry here:
+#
+#   geoFailover:
+#     records:
+#       - hostname: app.example.com   # FQDN to publish (must be in `zones`)
+#         primaryIP: "10.0.1.10"     # primary region's HTTPRoute backend IP
+#         replicaIP: "10.0.2.10"     # replica region's HTTPRoute backend IP
+#         healthCheck:
+#           url: "https://app.example.com/healthz"
+#           interval: 10              # seconds between probes
+#           timeout: 2                # per-probe timeout
+#
+# The zone-bootstrap Job (Phase 2 of this PR — separate commit) walks
+# this list and writes lua-records of the canonical form:
+#
+#   <hostname>.  300  IN  LUA  A  "ifurlup('<healthcheck>',{'<primaryIP>','<replicaIP>'})"
+#
+# At resolve time PowerDNS's lua-record engine probes the healthcheck
+# URL — when the primary returns 2xx, replies with primaryIP; when it
+# returns non-2xx or times out, replies with replicaIP. The DNS TTL
+# (300s default) caps the cutover window. See PowerDNS upstream docs:
+# https://doc.powerdns.com/authoritative/lua-records/index.html
+#
+# `enable-lua-records=yes` is already on in this chart's pdns.conf
+# (values.yaml ~L244) so no operator action is needed to flip it.
+#
+# Default empty: a single-region Sovereign or a multi-region Sovereign
+# without per-Application geo-failover configured renders zero
+# lua-records (zero regression). The companion ConfigMap
+# `powerdns-geo-failover-spec` records the operator's intent for
+# downstream automation + the admin console's Geo-Failover page.
+#
+# Multi-layer RCA (Principle 16): pre-G93.4 the only multi-region
+# failover mechanism was Cilium ClusterMesh, which only works for
+# in-cluster traffic; cross-region failover for EXTERNAL traffic
+# (browsers, mobile apps, third-party integrations) required manual
+# operator action against PowerDNS API. lua-records make the
+# failover declarative + driven by Application CR state.
+geoFailover:
+  # Toggle the geo-failover spec ConfigMap + (Phase 2) the
+  # zone-bootstrap-job lua-record loop. Default true so any operator
+  # populating `records` below opts in; flip false to suppress the
+  # spec ConfigMap entirely.
+  enabled: true
+  # Per-Application failover entries. Empty list = no records
+  # rendered, no Job runs. Validation: each entry MUST have
+  # hostname, primaryIP, replicaIP, healthCheck.url — the zone-
+  # bootstrap-job's lua-record loop fails fast on missing fields.
+  records: []
+  # Default TTL for the rendered LUA A-records. The DNS TTL caps the
+  # cutover window — lower = faster failover, more authoritative-
+  # server load. PowerDNS upstream recommends 300s for lua-records
+  # with sub-minute healthcheck intervals.
+  ttl: 300
+  # Default healthcheck poll interval (seconds) when the per-entry
+  # `healthCheck.interval` is omitted.
+  defaultProbeIntervalSeconds: 10
+  # Default healthcheck per-probe timeout (seconds) when the per-entry
+  # `healthCheck.timeout` is omitted.
+  defaultProbeTimeoutSeconds: 2
+
 # ─── Zone bootstrap Job ───────────────────────────────────────────────────
 # Helm hook Job that creates every entry in `zones` above against the
 # in-cluster PowerDNS REST API. Renders as a Helm post-install,post-upgrade


### PR DESCRIPTION
## Summary

**G93.4 (EPIC #2640 → sub-issue #2669)** — Foundational seam for cross-region HTTPRoute geo-failover via PowerDNS lua-records (the \`ifurlup\` pattern). The bp-powerdns chart's pdns.conf already enables \`enable-lua-records=yes\`; this PR adds the operator-facing values shape that records per-Application failover intent and pre-renders the canonical LUA-record body for each entry.

### What ships

1. **New \`geoFailover.records[]\` values block** — operator declares per-Application failover entries:
   \`\`\`yaml
   geoFailover:
     records:
       - hostname: app.example.com
         primaryIP: \"10.0.1.10\"
         replicaIP: \"10.0.2.10\"
         healthCheck:
           url: \"https://app.example.com/healthz\"
           interval: 10       # optional; default from .Values.geoFailover.defaultProbeIntervalSeconds
           timeout: 2         # optional; default from .Values.geoFailover.defaultProbeTimeoutSeconds
   \`\`\`
2. **New \`powerdns-geo-failover-spec\` ConfigMap** (rendered ONLY when records is non-empty):
   - \`entries.json\`: structured list for the admin console's Geo-Failover page to read WITHOUT calling PowerDNS API.
   - \`records.txt\`: pre-rendered LUA A-record bodies for each entry, ready for a follow-up zone-bootstrap-job loop to PATCH into the PowerDNS API.
3. **Fail-fast template validation** — missing \`hostname\` / \`primaryIP\` / \`replicaIP\` / \`healthCheck.url\` errors clearly at render time with the offending entry index + hostname.
4. **Chart 1.2.6 → 1.2.7** + blueprint 1.2.6 → 1.2.7 + bootstrap-kit slot 11 pin in lockstep.

### Canonical LUA-record shape (per PowerDNS upstream)

\`\`\`
<hostname>.  300  IN  LUA  A  \"ifurlup('<url>', {'<primary>', '<replica>'}, {timeout=2, interval=10})\"
\`\`\`

At resolve time PowerDNS's lua-record engine probes the healthcheck URL — returns primaryIP while the probe passes, falls through to replicaIP when the probe fails. DNS TTL caps the cutover window; default 300s. See [PowerDNS docs](https://doc.powerdns.com/authoritative/lua-records/functions.html#ifurlup).

### Multi-layer RCA (Principle 16)

| Layer | Diagnosis |
|---|---|
| **Trigger** | Pre-G93.4 cross-region failover for EXTERNAL traffic (browsers, mobile, third-party) required manual operator action against PowerDNS API; the chart shipped no opt-in seam. ClusterMesh only covers in-cluster traffic. |
| **Defense** | Declarative values block makes per-Application failover describable in source. |
| **Containment** | Fail-fast template render rejects half-formed entries (missing IP / URL) so a typo in values.yaml is caught at install time, not at first failover event. |
| **Incident management** | The \`powerdns-geo-failover-spec\` ConfigMap is the durable record of operator intent — admin console reads it, operator can \`kubectl describe\` it, follow-up zone-bootstrap-job consumes it without re-rendering. |

## Test plan

- [x] \`helm template\` with a sample entry — ConfigMap renders correctly with entries.json + records.txt.
- [x] \`helm template\` with missing primaryIP — fails fast with actionable error.
- [x] \`helm template\` with no records — skips the ConfigMap entirely (zero regression for single-region Sovereigns).
- [ ] CI: chart-render + helm-lint.
- [ ] Fresh prov (operator-walk) on multi-region HCS Sovereign — populate \`geoFailover.records\` and verify ConfigMap lands; manually PATCH the \`records.txt\` content into the PowerDNS zone and confirm dig resolves to primaryIP, then take primary down and confirm dig resolves to replicaIP.

## Follow-up scope (separate PRs)

- **Phase 2** — extend \`zone-bootstrap-job\` to PATCH the LUA records into each zone via PowerDNS API at install / upgrade time.
- **Phase 3** — application-controller derives entries[] from Application CR \`status.regions[].externalIP\` + \`spec.hostname\` and merges into this ConfigMap declaratively (so operators never hand-edit the \`geoFailover.records\` list).
- **per-app HTTPRoute pattern** (separate workstream) — each chart's HTTPRoute can declare backendRefs across regions; today only the DNS-level failover (this PR) is canonical.

## Builds on

- **G93.1 (#2675)** — SOVEREIGN_BCP_TOPOLOGY env from cloud-init.
- **G93.2 (#2679)** — application-controller derives effective placement; future Phase 3 of G93.4 reads Application CR status.
- **G93.3 (#2680 ✅ merged)** — CNPG cross-region podAntiAffinity defaults.

Refs #2669

🤖 Generated with [Claude Code](https://claude.com/claude-code)