### PR TITLE
feat(bootstrap-kit): G91 — wire sso.sovereignFqdn envsubst across 5 G91-opted-in HRs (Refs #2646)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -90,6 +90,13 @@ spec:
   values:
     gateway:
       host: bao.${SOVEREIGN_FQDN}
+    # G91.openbao (#2655) — wire bp-sso-bridge framework. The chart-side
+    # continuous reconciler Deployment computes OIDC discovery + redirect
+    # URLs from sovereignFqdn. Empty default leaves the reconciler logging
+    # "ESO Secret keys not yet present"; the envsubst below activates it
+    # zero-touch on every fresh Sovereign.
+    sso:
+      sovereignFqdn: ${SOVEREIGN_FQDN}
     autoUnseal:
       enabled: true
       # Issue #517 (cont): the chart's init-job.yaml + auth-bootstrap-job.yaml

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -76,6 +76,13 @@ spec:
   values:
     global:
       sovereignFQDN: ${SOVEREIGN_FQDN}
+    # G91.gitea (#2653) — wire bp-sso-bridge framework. The chart-side
+    # post-install Job needs sovereignFqdn to compute the OIDC
+    # autoDiscoverUrl at chart-template time. Empty default in the
+    # chart values short-circuits the configure-oauth Job; the envsubst
+    # below makes SSO work zero-touch on every fresh Sovereign.
+    sso:
+      sovereignFqdn: ${SOVEREIGN_FQDN}
     # G87 #2634 (2026-06-01): multi-region Sovereigns default CNPG
     # instances to 2 so the operator spreads across regions via
     # topology.kubernetes.io/region antiAffinity. Single-region falls

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -175,6 +175,11 @@ spec:
   values:
     gateway:
       host: registry.${SOVEREIGN_FQDN}
+    # G91.harbor (#2654) — wire bp-sso-bridge framework. The chart-side
+    # post-install Job PUTs /api/v2.0/configurations with
+    # auth_mode=oidc_auth + oidc_endpoint computed from sovereignFqdn.
+    sso:
+      sovereignFqdn: ${SOVEREIGN_FQDN}
     # G87 #2634: multi-region CNPG instances default (1 single-region, 2 multi).
     postgres:
       cluster:

--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -187,6 +187,13 @@ spec:
   # pin (single source of truth, INVIOLABLE-PRINCIPLES.md #4a).
   values:
     enabled: ${SANDBOX_ENABLED:-true}
+    # G91.sandbox (#2657) — wire bp-sso-bridge framework. The chart-side
+    # SANDBOX_SSO_* env-vars on the sandbox-controller Pod are sourced
+    # from the ExternalSecret-rendered Secret + .Values.sso.sovereignFqdn
+    # is what the follow-up sandbox-controller code uses to compute the
+    # per-Sandbox pty-server OIDC redirect URI.
+    sso:
+      sovereignFqdn: ${SOVEREIGN_FQDN}
     env:
       hostCluster: ${SOVEREIGN_REGION_CANONICAL_LABEL}
       sovereignFQDN: ${SOVEREIGN_FQDN}

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -87,3 +87,11 @@ spec:
   values:
     gateway:
       host: grafana.${SOVEREIGN_FQDN}
+    # G91.grafana (#2658) — wire bp-sso-bridge framework. The chart-side
+    # grafana.ini.auth.generic_oauth block computes auth_url / token_url /
+    # api_url from sovereignFqdn. Without this envsubst, the Grafana
+    # sign-in OAuth attempt errors with empty URLs (clear behaviour, not
+    # half-config); with the envsubst SSO works zero-touch on every
+    # fresh Sovereign.
+    sso:
+      sovereignFqdn: ${SOVEREIGN_FQDN}


### PR DESCRIPTION
## Summary

Activates zero-touch SSO end-to-end on every fresh Sovereign by wiring `.spec.values.sso.sovereignFqdn=\${SOVEREIGN_FQDN}` into the five G91-opted-in bootstrap-kit HRs.

Each app's chart already defaults `sso.enabled: true` and consumes `sso.sovereignFqdn` at chart-template time to compute OIDC `autoDiscoverUrl` / `authorize_url` / `token_url` / redirect URIs. Without the envsubst those URLs render empty and the per-chart fallback path engages:

| Chart | Without sovereignFqdn |
|---|---|
| bp-gitea | configure-oauth Job suppressed; SSO sign-in unavailable |
| bp-harbor | configure-oauth Job suppressed; `auth_mode` stays `db_auth` |
| bp-openbao | sso-configure Deployment loops logging "ESO Secret keys not yet present" |
| bp-grafana | `grafana.ini.auth.generic_oauth` URLs empty; PKCE sign-in errors |
| bp-sandbox | SANDBOX_SSO_* env-vars present but sovereignFqdn empty for the follow-up controller code |

After this PR, `\${SOVEREIGN_FQDN}` envsubst at cloud-init time fills the value per-Sovereign — bp-sso-bridge tick auto-provisions the per-app Keycloak Client + ExternalSecret + operator-admin grant; each app's chart-side glue picks up the discovery URLs from `sso.sovereignFqdn` and SSO functions on first click of "Open" in catalyst-ui /apps.

## Files changed (5)

- `clusters/_template/bootstrap-kit/10-gitea.yaml`
- `clusters/_template/bootstrap-kit/19-harbor.yaml`
- `clusters/_template/bootstrap-kit/08-openbao.yaml`
- `clusters/_template/bootstrap-kit/25-grafana.yaml`
- `clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml`

No chart bumps required — each app's chart code is unchanged; only the per-Sovereign Flux overlay layer changes. Companion to PR #2678 (bp-catalyst-platform's sso block already shipped) and PR #2681 (bp-powerdns-admin HR has the block built-in from creation).

## Test plan

- [x] Five-file change; no chart-level edits, no HR drift in dep-graph audit.
- [ ] After merge + Flux reconcile on hw86: `kubectl get hr -n flux-system bp-gitea -o jsonpath='{.spec.values.sso.sovereignFqdn}'` returns `hw86.omani.works` (and same for harbor/openbao/grafana/sandbox).
- [ ] bp-sso-bridge tick reads the new value; per-app Keycloak Clients land in the realm with correct redirectURIs.
- [ ] Operator clicks "Open" on each app card in catalyst-ui /apps → lands authenticated as Sovereign operator with admin role.

Refs #2646 G91 EPIC, #2652, #2653, #2654, #2655, #2657, #2658