### PR TITLE
feat(bootstrap-kit): G92.2 — NATS+OpenBao+Keycloak land INSIDE MGMT vCluster (Refs #2661)

### DIFF
--- a/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
@@ -3,14 +3,17 @@
 # Wrapper chart: platform/nats-jetstream/chart/
 # Catalyst-curated values: platform/nats-jetstream/chart/values.yaml
 # Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# G92.2 #2661 (2026-06-01): the HelmRelease installs INSIDE the MGMT
+# vCluster via Flux v2 spec.kubeConfig.secretRef → vc-mgmt (kubeconfig
+# Secret exported by bp-mgmt-vcluster slot 58). Per docs/SOVEREIGN-
+# MULTI-REGION-DOD.md §A4 the control-plane event bus lives in MGMT
+# so it's co-located with catalyst-api / openova-flow-server / sme-
+# services — all consumers reach NATS via in-vCluster DNS without
+# touching the host. The HR CR itself lives in host ns `mgmt` so
+# helm-controller resolves the kubeConfig Secret from the same
+# namespace (Flux v2 SecretReference contract).
 
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: nats-system
-  labels:
-    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -28,17 +31,39 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-nats-jetstream
-  namespace: flux-system
+  # G92.2 #2661: HR lives in host ns `mgmt` (where bp-mgmt-vcluster
+  # exports vc-mgmt Secret). helm-controller authenticates against the
+  # vCluster apiserver and installs the chart inside the vCluster.
+  # The inner namespace `nats-system` is created INSIDE the vCluster
+  # via spec.install.createNamespace below.
+  namespace: mgmt
   labels:
     catalyst.openova.io/slot: "07"
+    catalyst.openova.io/vcluster: mgmt
 spec:
   interval: 15m
   releaseName: nats-jetstream
+  # targetNamespace = the inner namespace INSIDE the mgmt vCluster.
+  # The vCluster syncer maps it back to host as
+  # `<inner>-x-nats-system-x-mgmt` — the Catalyst-side consumers stay
+  # inside the vCluster and resolve `nats-jetstream.nats-system.svc.
+  # cluster.local` natively via vCluster CoreDNS.
   targetNamespace: nats-system
-  # No dependsOn: bp-spire was dropped (PR #665, founder direction
-  # 2026-05-03 — Cilium WireGuard mesh handles east-west mTLS).
-  # NATS no longer needs SVID-based auth; the kernel-level WireGuard
-  # encryption between every pod covers the in-flight traffic.
+  # vCluster pivot — helm-controller pulls the kubeconfig from the
+  # vc-mgmt Secret in this HR's own namespace and installs the chart
+  # INSIDE the mgmt vCluster (Flux v2 HelmRelease v2 contract).
+  # G92.2 #2661.
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
+  # G92.2: bp-mgmt-vcluster (slot 58) MUST be Ready before this HR
+  # tries to install — otherwise vc-mgmt doesn't exist and the
+  # kubeConfig lookup fails. bp-mgmt-vcluster lives in flux-system so
+  # the dep is cross-namespace and needs an explicit `namespace:`.
+  dependsOn:
+    - name: bp-mgmt-vcluster
+      namespace: flux-system
   chart:
     spec:
       chart: bp-nats-jetstream
@@ -52,6 +77,11 @@ spec:
   # cold start. Helm install completes when manifests apply; downstream
   # dependsOn checks Ready=True independently. Replaces PR #221 timeout.
   install:
+    # G92.2 #2661: createNamespace=true so helm-controller provisions
+    # the inner `nats-system` namespace inside the mgmt vCluster on
+    # first install (no host-side Namespace YAML needed — the inner
+    # namespace is the vCluster's view).
+    createNamespace: true
     timeout: 15m
     disableWait: true
     remediation:

--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -3,14 +3,18 @@
 # Wrapper chart: platform/openbao/chart/
 # Catalyst-curated values: platform/openbao/chart/values.yaml
 # Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# G92.2 #2661 (2026-06-01): the HelmRelease installs INSIDE the MGMT
+# vCluster via Flux v2 spec.kubeConfig.secretRef → vc-mgmt (kubeconfig
+# Secret exported by bp-mgmt-vcluster slot 58). Per docs/SOVEREIGN-
+# MULTI-REGION-DOD.md §A4 the secret backend lives in MGMT so it's
+# co-located with catalyst-api / sme-services. The HR CR itself lives
+# in host ns `mgmt` so helm-controller resolves the kubeConfig Secret
+# from the same namespace (Flux v2 SecretReference contract). The
+# bp-cnpg-backed audit/storage adjuncts continue to use the host's
+# CNPG-operator-reconciled Service via cross-vCluster DNS (vCluster
+# CoreDNS forwards unknown queries to host kube-dns).
 
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openbao
-  labels:
-    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -28,20 +32,37 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-openbao
-  namespace: flux-system
+  # G92.2 #2661: HR lives in host ns `mgmt` (where bp-mgmt-vcluster
+  # exports vc-mgmt Secret). helm-controller authenticates against the
+  # vCluster apiserver and installs the chart inside the vCluster.
+  namespace: mgmt
   labels:
     catalyst.openova.io/slot: "08"
+    catalyst.openova.io/vcluster: mgmt
 spec:
   interval: 15m
   releaseName: openbao
+  # targetNamespace = inner namespace INSIDE the mgmt vCluster.
   targetNamespace: openbao
+  # vCluster pivot — helm-controller installs the chart inside mgmt
+  # vCluster (Flux v2 HelmRelease v2 contract). G92.2 #2661.
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   dependsOn:
+    # G92.2 #2661: bp-mgmt-vcluster MUST be Ready before this HR tries
+    # to install — vc-mgmt Secret doesn't exist until then. Cross-ns
+    # dependsOn requires explicit `namespace:`.
+    - name: bp-mgmt-vcluster
+      namespace: flux-system
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template at
     # platform/openbao/chart/templates/httproute.yaml; the
     # gateway.networking.k8s.io/v1 CRDs MUST be registered before this
     # HelmRelease applies or install fails with `no matches for kind
-    # HTTPRoute`.
+    # HTTPRoute`. G92.2: bp-gateway-api lives on host (flux-system).
     - name: bp-gateway-api
+      namespace: flux-system
     # bp-cnpg (issue #512): the OpenBao 3-node Raft post-install init Job
     # (Helm hook weight 5) runs `bao operator init` and seals/unseals via
     # Kubernetes auth; both paths require the cnpg PostgreSQL backing the
@@ -50,7 +71,10 @@ spec:
     # otech16 (2026-05-02): even with timeout=15m, the hook raced cnpg
     # coming up. Adding the explicit dep makes Flux wait for bp-cnpg
     # Ready=True before starting bp-openbao install. See issue #512.
+    # G92.2: bp-cnpg stays host-substrate (G92.6 #2665) so the dep is
+    # cross-ns (flux-system).
     - name: bp-cnpg
+      namespace: flux-system
   chart:
     spec:
       chart: bp-openbao
@@ -67,6 +91,10 @@ spec:
   # initialised — the init hook drives that out-of-band). Replaces
   # PR #221 spec.timeout: 15m.
   install:
+    # G92.2 #2661: createNamespace=true so helm-controller provisions
+    # the inner `openbao` namespace inside the mgmt vCluster on first
+    # install.
+    createNamespace: true
     disableWait: true
     timeout: 15m
     remediation:

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -3,14 +3,18 @@
 # Wrapper chart: platform/keycloak/chart/
 # Catalyst-curated values: platform/keycloak/chart/values.yaml
 # Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# G92.2 #2661 (2026-06-01): the HelmRelease installs INSIDE the MGMT
+# vCluster via Flux v2 spec.kubeConfig.secretRef → vc-mgmt (kubeconfig
+# Secret exported by bp-mgmt-vcluster slot 58). Per docs/SOVEREIGN-
+# MULTI-REGION-DOD.md §A4 user identity (IdP) lives in MGMT so the
+# Keycloak admin URL is co-located with catalyst-api / openova-flow-
+# server. The Keycloak chart ships its own bundled Bitnami postgresql
+# subchart (NOT a CNPG Cluster CR), so the move is clean — no
+# cross-vCluster CR reconciler is needed. The HR CR itself lives in
+# host ns `mgmt` so helm-controller resolves the kubeConfig Secret
+# from the same namespace (Flux v2 SecretReference contract).
 
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: keycloak
-  labels:
-    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -28,18 +32,36 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-keycloak
-  namespace: flux-system
+  # G92.2 #2661: HR lives in host ns `mgmt` (where bp-mgmt-vcluster
+  # exports vc-mgmt Secret). helm-controller authenticates against the
+  # vCluster apiserver and installs the chart inside the vCluster.
+  namespace: mgmt
   labels:
     catalyst.openova.io/slot: "09"
+    catalyst.openova.io/vcluster: mgmt
 spec:
   interval: 15m
   releaseName: keycloak
+  # targetNamespace = inner namespace INSIDE the mgmt vCluster.
   targetNamespace: keycloak
+  # vCluster pivot — helm-controller installs the chart inside mgmt
+  # vCluster (Flux v2 HelmRelease v2 contract). G92.2 #2661.
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   dependsOn:
+    # G92.2 #2661: bp-mgmt-vcluster MUST be Ready before this HR tries
+    # to install — vc-mgmt Secret doesn't exist until then. Cross-ns
+    # dependsOn requires explicit `namespace:`.
+    - name: bp-mgmt-vcluster
+      namespace: flux-system
     - name: bp-cert-manager
+      namespace: flux-system
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template;
     # gateway.networking.k8s.io/v1 CRDs must be registered first.
     - name: bp-gateway-api
+      namespace: flux-system
   chart:
     spec:
       chart: bp-keycloak
@@ -98,6 +120,10 @@ spec:
   # retry is sufficient for that. Job-level vs. HR-level retry is the
   # correct separation per the bitnami subchart's design.
   install:
+    # G92.2 #2661: createNamespace=true so helm-controller provisions
+    # the inner `keycloak` namespace inside the mgmt vCluster on first
+    # install.
+    createNamespace: true
     disableWait: true
     timeout: 30m
     remediation:

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -37,7 +37,11 @@ spec:
   releaseName: gitea
   targetNamespace: gitea
   dependsOn:
+    # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`
+    # (it installs INSIDE the mgmt vCluster). Cross-ns dependsOn
+    # requires explicit `namespace:`.
     - name: bp-keycloak
+      namespace: mgmt
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template;
     # gateway.networking.k8s.io/v1 CRDs must be registered first.
     - name: bp-gateway-api

--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -59,8 +59,9 @@ spec:
       namespace: flux-system
     - name: bp-cnpg
       namespace: flux-system
+    # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
-      namespace: flux-system
+      namespace: mgmt
     - name: bp-sso-bridge
       namespace: flux-system
     - name: bp-external-secrets-stores

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -70,7 +70,9 @@ spec:
     # Phase-8a-preflight otech16 (2026-05-02): adding bp-keycloak +
     # bp-cnpg here makes Flux wait for both Ready=True before starting
     # the umbrella install, eliminating the race.
+    # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
+      namespace: mgmt
     - name: bp-cnpg
     # bp-crossplane-claims (chart-roll-rca iter-15, 2026-05-10): owns the
     # access.openova.io/v1alpha1 XRD that qa-fixtures UserAccess CRs

--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -52,8 +52,12 @@ spec:
   releaseName: sso-bridge
   targetNamespace: sso-bridge
   dependsOn:
+    # G92.2 #2661 (2026-06-01): bp-keycloak + bp-openbao HRs moved to
+    # host ns `mgmt` (they install INSIDE the mgmt vCluster).
     - name: bp-keycloak
+      namespace: mgmt
     - name: bp-openbao
+      namespace: mgmt
     - name: bp-catalyst-platform
   chart:
     spec:

--- a/clusters/_template/bootstrap-kit/15-external-secrets.yaml
+++ b/clusters/_template/bootstrap-kit/15-external-secrets.yaml
@@ -54,7 +54,9 @@ spec:
   #   - bp-cert-manager(02): ESO's admission webhook needs a TLS cert.
   #     bp-cert-manager provides the ClusterIssuer that signs it.
   dependsOn:
+    # G92.2 #2661 (2026-06-01): bp-openbao HR moved to host ns `mgmt`.
     - name: bp-openbao
+      namespace: mgmt
     - name: bp-cert-manager
   chart:
     spec:

--- a/clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml
+++ b/clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml
@@ -46,7 +46,9 @@ spec:
   # ClusterSecretStore points at).
   dependsOn:
     - name: bp-external-secrets
+    # G92.2 #2661 (2026-06-01): bp-openbao HR moved to host ns `mgmt`.
     - name: bp-openbao
+      namespace: mgmt
   chart:
     spec:
       chart: bp-external-secrets-stores

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -58,7 +58,9 @@ spec:
     - name: bp-loki
     - name: bp-mimir
     - name: bp-tempo
+    # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
+      namespace: mgmt
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template;
     # gateway.networking.k8s.io/v1 CRDs must be registered first.
     - name: bp-gateway-api

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -76,7 +76,9 @@ spec:
   dependsOn:
     - name: bp-cilium
     - name: bp-cert-manager
+    # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
+      namespace: mgmt
     - name: bp-sealed-secrets
     - name: bp-seaweedfs
     - name: bp-k8s-ws-proxy

--- a/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+++ b/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
@@ -104,7 +104,9 @@ spec:
   targetNamespace: catalyst-system
   dependsOn:
     - name: bp-catalyst-platform
+    # G92.2 #2661 (2026-06-01): bp-nats-jetstream HR moved to host ns `mgmt`.
     - name: bp-nats-jetstream
+      namespace: mgmt
     - name: bp-powerdns
   chart:
     spec:

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -64,8 +64,12 @@ spec:
   #     PostgresqlInstance claim once cnpg is Ready. The DSN is mounted
   #     into NewAPI via `database.existingSecret` (operator-set).
   dependsOn:
+    # G92.2 #2661 (2026-06-01): bp-openbao + bp-keycloak HRs moved to
+    # host ns `mgmt`.
     - name: bp-openbao
+      namespace: mgmt
     - name: bp-keycloak
+      namespace: mgmt
     - name: bp-cnpg
   chart:
     spec:

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -74,7 +74,11 @@ slots:
     wave: present
   - slot: 7
     name: bp-nats-jetstream
-    depends_on: []
+    # G92.2 #2661 (2026-06-01): MGMT vCluster placement. HR carries
+    # spec.kubeConfig.secretRef → vc-mgmt + dependsOn bp-mgmt-vcluster
+    # so the install gates on the vCluster being Ready (otherwise the
+    # kubeconfig Secret doesn't exist and helm-controller errors).
+    depends_on: [bp-mgmt-vcluster]
     wave: present
   - slot: 8
     name: bp-openbao
@@ -83,12 +87,17 @@ slots:
     # bp-cnpg dep (issue #512): post-install init hook (`bao operator init`)
     # races cnpg readiness on a fresh Sovereign, hitting the 15m install
     # timeout. Explicit dep makes Flux wait for cnpg Ready=True first.
-    depends_on: [bp-gateway-api, bp-cnpg]
+    # G92.2 #2661 (2026-06-01): MGMT vCluster placement adds
+    # bp-mgmt-vcluster as a new edge — vc-mgmt Secret must exist
+    # before helm-controller can pivot into the vCluster apiserver.
+    depends_on: [bp-mgmt-vcluster, bp-gateway-api, bp-cnpg]
     wave: present
   - slot: 9
     name: bp-keycloak
     # bp-gateway-api dep (issue #503): chart ships an HTTPRoute template.
-    depends_on: [bp-cert-manager, bp-gateway-api]
+    # G92.2 #2661 (2026-06-01): MGMT vCluster placement adds
+    # bp-mgmt-vcluster as a new edge.
+    depends_on: [bp-mgmt-vcluster, bp-cert-manager, bp-gateway-api]
     wave: present
   - slot: 10
     name: bp-gitea


### PR DESCRIPTION
## Summary

First slice of the G92 placement matrix (EPIC #2639). Pivots bootstrap-kit slots 07 / 08 / 09 from host k3s to the per-region MGMT vCluster via Flux v2's `spec.kubeConfig.secretRef` contract. The application-controller foundation shipped in [PR #2674 G92.1 #2660](https://github.com/openova-io/openova/pull/2674) (merged at `0dae4166`) makes this safe at the per-tenant Application level; this PR opts the substrate-side bp-* HRs in.

Per `docs/SOVEREIGN-MULTI-REGION-DOD.md` §A4 the three vClusters partition control-plane workloads. NATS (event spine), OpenBao (secret backend), and Keycloak (IdP) are all MGMT-tier — co-located with catalyst-api / catalyst-ui / openova-flow-server so their in-vCluster DNS resolves natively without crossing the host boundary.

## What changed

### Slots 07 / 08 / 09 (the moves)

| Slot | Component | Before | After |
|---|---|---|---|
| 07 | bp-nats-jetstream | host k3s | MGMT vCluster (HR in host ns `mgmt`, installs inside vCluster's `nats-system`) |
| 08 | bp-openbao | host k3s | MGMT vCluster |
| 09 | bp-keycloak | host k3s | MGMT vCluster |

For each slot:
- Host-side `Namespace` YAML at the top REMOVED — the inner namespace is created INSIDE the vCluster via `spec.install.createNamespace: true` (target-state shape per Principle 1).
- HR `metadata.namespace` flipped `flux-system` → `mgmt` so helm-controller resolves `spec.kubeConfig.secretRef` from the same namespace as the HR (Flux v2 SecretReference contract).
- `spec.kubeConfig.secretRef: {name: vc-mgmt, key: config}` added — `vc-mgmt` is exported by bp-mgmt-vcluster slot 58.
- `dependsOn[].namespace: flux-system` added to every existing cross-ns reference.
- New edge `dependsOn: bp-mgmt-vcluster (flux-system)` — Flux gates the first install attempt on the vCluster being Ready.
- `catalyst.openova.io/vcluster: mgmt` label stamped for operator-console grouping.

### Downstream cross-ns dep updates (10 slots)

Every slot that depends on one of the moved HRs now qualifies with `namespace: mgmt`: 10-gitea, 11a-bp-powerdns-admin, 13-bp-catalyst-platform, 13b-bp-sso-bridge, 15-external-secrets, 15a-external-secrets-stores, 25-grafana, 52-bp-guacamole, 62-bp-continuum, 80-newapi.

### Expected DAG

Slots 7 / 8 / 9 declare `bp-mgmt-vcluster` as a new edge so the dep-graph audit passes.

## Multi-layer RCA (Principle 16)

- **Trigger**: founder caught hw86 with all bp-* HRs targeting host k3s; the three per-region vClusters stood empty. EPIC #2639.
- **Incident management**: G92 EPIC split 6-ways; G92.1 #2660 shipped the application-controller foundation 2026-06-01 (PR #2674); THIS PR delivers G92.2 slice 1 of 4 (NATS + OpenBao + Keycloak). bp-catalyst-platform (slot 13) deferred.
- **Defense**: `dependsOn bp-mgmt-vcluster` gates every install on `vc-mgmt` existing, eliminating the silent-failure mode. `createNamespace=true` removes host-side `Namespace` YAML.
- **Containment**: dep-graph audit guardrail PASS (0 drift, 0 cycles).

## Queued for follow-up

Slot 13 (`bp-catalyst-platform`) stays on host in this PR — its umbrella chart ships CNPG `Cluster` CRs that the host cnpg-operator must reconcile (G92.6 substrate). The follow-up PR will need either:
- (a) bp-mgmt-vcluster vCluster subchart bump to v0.21+ for `sync.toHost.customResources`; or
- (b) catalyst-api host-kubeconfig mount for Flux GitRepository/Kustomization writes.

See [EPIC #2639 architectural breakdown](https://github.com/openova-io/openova/issues/2639#issuecomment-4588010722).

## Test plan

- [x] `scripts/check-bootstrap-deps.sh` — PASS (0 drift, 0 cycles)
- [ ] On a fresh `hw*` prov + post-bp-mgmt-vcluster-Ready: confirm bp-keycloak / bp-openbao / bp-nats-jetstream Pods running INSIDE the mgmt vCluster — worker-3's G104 `sovereign-3x-zero-touch-cycle.sh` is the canonical gate.

Refs #2661 #2639

🤖 Generated with [Claude Code](https://claude.com/claude-code)