### PR TITLE
feat(bootstrap-kit): G92.4 — WAF-Coraza lands INSIDE DMZ vCluster (Refs #2663)

### DIFF
--- a/clusters/_template/bootstrap-kit/35-coraza.yaml
+++ b/clusters/_template/bootstrap-kit/35-coraza.yaml
@@ -19,14 +19,18 @@
 # is event-driven via the Flux dependsOn graph (downstream HRs check
 # Ready=True on this HR). Per session-2026-04-30 architectural decision,
 # we never use blanket `spec.timeout: Nm` watchdogs.
+#
+# G92.4 #2663 (2026-06-01): the HelmRelease installs INSIDE the DMZ
+# vCluster via Flux v2 spec.kubeConfig.secretRef → vc-dmz (kubeconfig
+# Secret exported by bp-dmz-vcluster slot 54). Per docs/SOVEREIGN-MULTI-
+# REGION-DOD.md §A4 north-south WAF lives in DMZ alongside Cilium-
+# Gateway listeners + HTTPRoutes so the L7 evaluation hook stays
+# co-located with the inbound traffic surface (no host hop). The chart
+# ships no CNPG Cluster CR + no external state, so the move is a clean
+# pivot — the HR CR itself lives in host ns `dmz` so helm-controller
+# resolves the kubeConfig Secret from the same namespace (Flux v2
+# SecretReference contract).
 
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: coraza
-  labels:
-    catalyst.openova.io/sovereign: SOVEREIGN_FQDN_PLACEHOLDER
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -44,16 +48,34 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-coraza
-  namespace: flux-system
+  # G92.4 #2663: HR lives in host ns `dmz` (where bp-dmz-vcluster
+  # exports vc-dmz Secret). helm-controller authenticates against the
+  # vCluster apiserver and installs the chart inside the vCluster.
+  namespace: dmz
   labels:
     catalyst.openova.io/slot: "35"
+    catalyst.openova.io/vcluster: dmz
 spec:
   interval: 15m
   releaseName: coraza
+  # targetNamespace = inner namespace INSIDE the dmz vCluster.
   targetNamespace: coraza
+  # vCluster pivot — helm-controller installs the chart inside dmz
+  # vCluster (Flux v2 HelmRelease v2 contract). G92.4 #2663.
+  kubeConfig:
+    secretRef:
+      name: vc-dmz
+      key: config
   dependsOn:
+    # G92.4 #2663: bp-dmz-vcluster MUST be Ready before this HR tries
+    # to install — vc-dmz Secret doesn't exist until then. Cross-ns
+    # dependsOn requires explicit `namespace:`.
+    - name: bp-dmz-vcluster
+      namespace: flux-system
     - name: bp-cilium
+      namespace: flux-system
     - name: bp-cert-manager
+      namespace: flux-system
   chart:
     spec:
       chart: bp-coraza
@@ -63,6 +85,10 @@ spec:
         name: bp-coraza
         namespace: flux-system
   install:
+    # G92.4 #2663: createNamespace=true so helm-controller provisions
+    # the inner `coraza` namespace inside the dmz vCluster on first
+    # install (no host-side Namespace YAML needed).
+    createNamespace: true
     timeout: 15m
     disableWait: true
     remediation:

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -315,7 +315,10 @@ slots:
   # ---- Tier 8 + 9: edge + apps + AI runtime (W2.K4, slots 35-48) ------------
   - slot: 35
     name: bp-coraza
-    depends_on: [bp-cilium, bp-cert-manager]
+    # G92.4 #2663 (2026-06-01): DMZ vCluster placement adds
+    # bp-dmz-vcluster as a new edge so the install gates on vc-dmz
+    # existing before helm-controller attempts the pivot.
+    depends_on: [bp-dmz-vcluster, bp-cilium, bp-cert-manager]
     wave: W2.K4
   - slot: 36
     name: bp-stunner


### PR DESCRIPTION
## Summary

First slice of the G92.4 DMZ matrix. Pivots bootstrap-kit slot 35 (bp-coraza) from host k3s to the per-region DMZ vCluster via Flux v2's `spec.kubeConfig.secretRef` contract — same pattern as the G92.2 NATS+OpenBao+Keycloak MGMT-tier ship (PR #2687).

Per `docs/SOVEREIGN-MULTI-REGION-DOD.md` §A4 the DMZ vCluster hosts the public-fronted L7 surface: Cilium-Gateway listeners + HTTPRoutes + WAF evaluation hooks. Co-locating Coraza inside the DMZ vCluster keeps the inbound-traffic L7 chain on one apiserver — no host hop between the Gateway listener Pods and the WAF-spoa evaluator Pod.

## What changed

### Slot 35 (the move)

| Slot | Component | Before | After |
|---|---|---|---|
| 35 | bp-coraza | host k3s (coraza ns) | DMZ vCluster (HR in host ns `dmz`, installs inside vCluster's `coraza`) |

Same pivot pattern as G92.2 slots 07/08/09:
- Host Namespace YAML at the top REMOVED — inner namespace created by `spec.install.createNamespace: true`.
- HR `metadata.namespace` flipped `flux-system` → `dmz` so helm-controller resolves `spec.kubeConfig.secretRef` from the same namespace as the HR (Flux v2 SecretReference contract).
- `spec.kubeConfig.secretRef: {name: vc-dmz, key: config}` — `vc-dmz` is exported by bp-dmz-vcluster slot 54.
- `dependsOn[].namespace: flux-system` qualified for every existing cross-ns reference (bp-cilium, bp-cert-manager).
- New edge `dependsOn: bp-dmz-vcluster (flux-system)` — Flux gates the first install attempt on the vCluster being Ready.
- `catalyst.openova.io/vcluster: dmz` label stamped for operator-console grouping.

### Expected DAG

Slot 35 declares `bp-dmz-vcluster` as a new edge.

## Multi-layer RCA (Principle 16)

- **Trigger**: founder hw86 ZT empty-vCluster catch (EPIC #2639).
- **Incident management**: G92.4 EPIC #2663 lists 4 components (Cilium-Gateway, WAF-Coraza, HTTPRoutes, Stalwart); this PR delivers WAF-Coraza. Cilium-Gateway stays on host (the Cilium operator + GatewayClass are substrate per G92.6 #2665). HTTPRoute CR templates are owned by the consumer charts (will pivot transitively as those charts move). Stalwart has no bootstrap-kit slot today (chart at `platform/stalwart-sovereign` but no slot — separate follow-up).
- **Defense**: `dependsOn bp-dmz-vcluster` gates every install on `vc-dmz` existing — same eliminate-silent-failure pattern as G92.2. `createNamespace=true` ensures no empty host `coraza` ns.
- **Containment**: dep-graph audit PASS (0 drift / 0 cycles).

No downstream cross-ns dep updates required — bp-coraza has zero consumers in the bootstrap-kit graph (verified via `grep "name: bp-coraza" clusters/_template/bootstrap-kit/*.yaml` returning only its own slot file).

## Test plan

- [x] `scripts/check-bootstrap-deps.sh` — PASS (0 drift, 0 cycles)
- [ ] On a fresh `hw*` prov + post-bp-dmz-vcluster-Ready: confirm bp-coraza Pod running INSIDE the dmz vCluster (`kubectl --kubeconfig <dmz-vc-kubeconfig> -n coraza get pods` non-empty) — worker-3's G104 `sovereign-3x-zero-touch-cycle.sh` is the canonical gate.

Refs #2663 #2639

🤖 Generated with [Claude Code](https://claude.com/claude-code)