### PR TITLE
feat(bp-kyverno-policies): G92.6 — K22 substrate-stays-on-host policy (Refs #2665)

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -63,7 +63,7 @@ spec:
       # Pending forever post-Phase-2b bootstrapMode flip → dashboard
       # vCluster grouping shows only "host" → Pillar 4 (Sandbox) silent
       # broken.
-      version: 1.0.26
+      version: 1.0.27
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.26
+  version: 1.0.27
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -1,5 +1,12 @@
 apiVersion: v2
 name: bp-kyverno-policies
+# 1.0.27 (G92.6 #2665, 2026-06-01): new K22 substrate-stays-on-host
+# ClusterPolicy. Per docs/DOD.md §A4 the substrate components (Cilium,
+# Flux, Kyverno, cert-manager, ESO, CNPG-operator, vCluster-syncers)
+# MUST install on host k3s, never inside a vCluster. The policy fail-
+# closes any HelmRelease whose metadata.name matches a substrate
+# Blueprint AND whose spec.kubeConfig field is set — catches misuse
+# of the G92.1 (#2660) vcluster-placement seam against substrate.
 description: |
   Catalyst Blueprint chart that ships the EPIC-1 (#1096) compliance policy
   library — 20 ClusterPolicy templates rendered against Kyverno CRDs that
@@ -74,7 +81,7 @@ type: application
 # while keeping proxy-cache for anonymous public registries.
 # Lockstep with bp-self-sovereign-cutover 0.1.43 (Step 03 Phase A
 # skopeo native-push + Step 07 REGISTRY drops /proxy-ghcr/ suffix).
-version: 1.0.26
+version: 1.0.27
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/templates/baseline/22-substrate-on-host.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/22-substrate-on-host.yaml
@@ -1,0 +1,102 @@
+{{/*
+K22 — substrate-stays-on-host (architecture invariant, A4).
+
+G92.6 (Refs #2665) — enforces docs/DOD.md §A4: "vCluster topology:
+primary region = MGMT+DMZ; each secondary region = DMZ+RTZ. Cross-
+vCluster intra-region traffic stays inside host k3s via Cilium."
+
+Substrate components (Cilium-agent, Flux, Kyverno, cert-manager, ESO,
+CNPG-operator, vCluster-syncers) operate against host-k3s primitives:
+- Cilium-agent runs as a DaemonSet on every host node (CNI).
+- Flux reconciles HelmReleases on the host kube-apiserver.
+- Kyverno's admission webhook is registered with the host kube-apiserver.
+- cert-manager's ClusterIssuer is cluster-scoped on the host.
+- ESO's ExternalSecret CR is cluster-scoped on the host.
+- CNPG-operator reconciles cnpg.io/Cluster CRs on the host (its CRDs
+  ship with the operator).
+- vCluster-syncers create vClusters; the syncers themselves run on
+  the host.
+
+If any of these were installed INSIDE a vCluster (via HelmRelease.spec.
+kubeConfig.secretRef pointing at the vCluster's admin kubeconfig from
+G92.1 #2660), the substrate would lose its hostside view: Cilium-agent
+would not run as a DaemonSet on host nodes (only on the vCluster's
+phantom nodes), Flux would only reconcile inside the vCluster's
+namespace projection, Kyverno's webhook would intercept only vCluster-
+syncer'd Pods (not the real workloads), etc. The Sovereign would
+silently degrade.
+
+This policy fail-closes any HelmRelease whose `metadata.name` matches
+a substrate Blueprint AND whose `spec.kubeConfig` field is set —
+i.e., any attempt to install substrate into a vCluster instead of the
+host k3s. The G92.1 vcluster-placement seam stays intact for non-
+substrate Blueprints (the per-Org marketplace apps that LEGITIMATELY
+install into a vCluster); the policy only catches misconfigured
+substrate.
+
+Mode: Enforce per-canonical (gated by bootstrapMode override per
+Wave 5.90 #2436). The substrate placement contract is architectural —
+operator override via `excludeNamespaces` is intentional escape hatch
+when an air-gapped Sovereign has bespoke substrate placement
+requirements. Per docs/INVIOLABLE-PRINCIPLES.md #4 every value
+overridable via .Values.compliancePolicies.substrateOnHost.*.
+*/}}
+{{- if .Values.compliancePolicies.substrateOnHost.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: substrate-stays-on-host
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: architecture
+  annotations:
+    policies.kyverno.io/title: Substrate Blueprints must install on host k3s
+    policies.kyverno.io/category: catalyst-architecture-invariant
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      The substrate components listed in docs/DOD.md §A4 (Cilium-agent,
+      Flux, Kyverno, cert-manager, ESO, CNPG-operator, vCluster-syncers)
+      MUST install on the host k3s cluster, never inside a vCluster.
+      A HelmRelease for one of these Blueprints with `spec.kubeConfig`
+      set indicates a misconfigured G92.1 vcluster-placement override.
+spec:
+  validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.substrateOnHost.action) }}
+  background: true
+  rules:
+    - name: helmrelease-no-vcluster-kubeconfig-for-substrate
+      match:
+        any:
+          - resources:
+              kinds:
+                - HelmRelease
+              names:
+                {{- range $name := .Values.compliancePolicies.substrateOnHost.substrateBlueprints }}
+                - {{ $name | quote }}
+                {{- end }}
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.substrateOnHost.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: >-
+          {{ `{{request.object.kind}}/{{request.object.metadata.name}}` }} is
+          a substrate Blueprint and MUST install on the host k3s cluster.
+          Detected `spec.kubeConfig.secretRef` set — this would install the
+          substrate INTO a vCluster, violating docs/DOD.md §A4 architecture
+          invariant. The G92.1 vcluster-placement seam (Refs #2660) is for
+          non-substrate marketplace applications only. Remove the
+          `spec.kubeConfig` block on this HelmRelease, OR — if your
+          Sovereign legitimately requires bespoke substrate placement —
+          add the namespace to
+          .Values.compliancePolicies.substrateOnHost.excludeNamespaces.
+        pattern:
+          spec:
+            # Forbid `spec.kubeConfig` entirely for substrate HRs. Kyverno
+            # negation pattern `X(field): "null"` enforces field absence.
+            =(kubeConfig): "null"
+{{- end }}

--- a/platform/kyverno-policies/chart/values.yaml
+++ b/platform/kyverno-policies/chart/values.yaml
@@ -256,6 +256,56 @@ compliancePolicies:
     action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
+  # G92.6 (Refs #2665, 2026-06-01) — substrate-stays-on-host
+  # architecture invariant policy. Per docs/DOD.md §A4 the substrate
+  # components (Cilium-agent, Flux, Kyverno, cert-manager, ESO,
+  # CNPG-operator, vCluster-syncers) MUST install on the host k3s
+  # cluster, never inside a vCluster. The G92.1 (#2660) vcluster-
+  # placement seam allowed any HelmRelease to opt into vCluster
+  # installation via `spec.kubeConfig.secretRef`; a misconfigured
+  # substrate HR using that seam would silently degrade the Sovereign
+  # (Cilium-agent only running on vCluster's phantom nodes, Flux
+  # reconciling only inside the vCluster's projection, etc.).
+  #
+  # This policy fail-closes any HelmRelease whose `metadata.name`
+  # matches a substrate Blueprint AND whose `spec.kubeConfig` field is
+  # set. Default action: Enforce (architectural invariant — not a soft
+  # compliance recommendation). Operators on an air-gapped Sovereign
+  # with bespoke substrate placement can override per-namespace via
+  # excludeNamespaces.
+  substrateOnHost:
+    enabled: true
+    action: Enforce
+    # Substrate Blueprints — the canonical name set documented in
+    # docs/DOD.md §A4. Operators MAY extend this list when shipping
+    # a custom substrate component (rare); MUST NOT shrink it because
+    # every name here protects an A4 invariant.
+    substrateBlueprints:
+      - bp-cilium
+      - bp-flux
+      - bp-kyverno
+      - bp-kyverno-policies
+      - bp-cert-manager
+      - bp-cert-manager-powerdns-webhook
+      - bp-cert-manager-dynadot-webhook
+      - bp-external-secrets
+      - bp-cnpg
+      - bp-cnpg-pair
+      - bp-mgmt-vcluster
+      - bp-dmz-vcluster
+      - bp-rtz-vcluster
+      - bp-vcluster-helmrepo
+    # Per-namespace escape hatch. The 3 vCluster syncer namespaces
+    # (dmz/mgmt/rtz) legitimately host the bp-*-vcluster syncer
+    # StatefulSets — the syncers themselves land on host k3s via
+    # the bp-*-vcluster HR (which is itself substrate-on-host), but
+    # their namespaces are carved out so per-Sovereign overlays
+    # that re-deploy a syncer don't trip the policy.
+    excludeNamespaces:
+      - dmz
+      - mgmt
+      - rtz
+
   # G98 (Refs #2644, 2026-06-01) — MUTATE policy that auto-stamps
   # `catalyst.openova.io/application` label on Pods cluster-wide.
   # Without this label, the Compliance scorecard's per-Application


### PR DESCRIPTION
## Summary

**G92.6 (Refs #2665)** — New K22 Kyverno ClusterPolicy enforces docs/DOD.md §A4: substrate components (Cilium-agent, Flux, Kyverno, cert-manager, ESO, CNPG-operator, vCluster-syncers) MUST install on host k3s, never inside a vCluster.

### Why this matters

G92.1 (#2660) added a `VClusterPlacements` seam that lets HelmReleases opt into vCluster installation via \`spec.kubeConfig.secretRef\`. A misconfigured substrate HR using that seam silently degrades the Sovereign:
- Cilium-agent would only run on the vCluster's phantom nodes (not host) — no CNI on host.
- Flux would only reconcile inside the vCluster's projection — substrate HRs added later never sync.
- Kyverno's webhook would intercept only vCluster-syncer'd Pods — host-side Pods bypass admission.
- cert-manager / ESO / CNPG-operator CRDs would only register inside the vCluster.

### What ships

1. **New ClusterPolicy** \`substrate-stays-on-host\` at \`platform/kyverno-policies/chart/templates/baseline/22-substrate-on-host.yaml\` — fail-closes any HelmRelease whose \`metadata.name\` matches a substrate Blueprint AND whose \`spec.kubeConfig\` field is set.
2. **Operator-extendable substrate set** in \`values.yaml\`:
   - \`bp-cilium\`, \`bp-flux\`, \`bp-kyverno\`, \`bp-kyverno-policies\`
   - \`bp-cert-manager\` + 2 DNS webhook variants
   - \`bp-external-secrets\`
   - \`bp-cnpg\`, \`bp-cnpg-pair\`
   - \`bp-mgmt-vcluster\`, \`bp-dmz-vcluster\`, \`bp-rtz-vcluster\`, \`bp-vcluster-helmrepo\`
3. **Bootstrap-mode aware** — Audit during fresh-prov (admission passes, PolicyReport emits); Enforce post-handover (catalyst-api flips compliancePolicies.bootstrapMode → false).
4. **Per-namespace escape hatch** — default \`excludeNamespaces: [dmz, mgmt, rtz]\` so the vCluster syncer namespaces don't trip the policy (the syncers themselves are substrate-on-host, but their namespaces host the vCluster proxy StatefulSets).
5. Chart \`1.0.26 → 1.0.27\` + blueprint.yaml + bootstrap-kit slot 27a pin lockstep.

### Multi-layer RCA (Principle 16)

| Layer | Diagnosis |
|---|---|
| **Trigger** | G92.1 (#2660) added an unconstrained vcluster-placement seam. Without a guard, a chart author opting bp-cilium into a vCluster would silently degrade the Sovereign. |
| **Defense** | Declarative architectural invariant policy. Substrate set is operator-visible in values.yaml so future substrate components can be added in one place. |
| **Containment** | \`bootstrapMode=true\` (default fresh-prov) keeps the policy non-blocking; post-handover flip to false enforces architecturally. |
| **Incident management** | PolicyReport row is the durable diagnostic surface for an operator who tried to install substrate into a vCluster — they see the policy name + the offending HR. |

## Test plan

- [x] \`helm template\` with default values — policy renders correctly in Audit mode.
- [x] \`helm template --set compliancePolicies.bootstrapMode=false\` — policy renders in Enforce mode.
- [x] \`helm lint\` — passes (only the standard \"icon recommended\" info note).
- [ ] CI: chart-render + helm-lint suites.
- [ ] Fresh prov (operator-walk) on any Sovereign — confirm the policy installs at slot 27a; attempt to install \`bp-cilium\` with \`spec.kubeConfig.secretRef\` and confirm the post-handover Enforce flip blocks admission with the expected message.

## Builds on / Complements

- **G92.1 (#2660 merged)** — VClusterPlacements seam this policy guards.
- **G92.2 / G92.3 / G92.4** — companion vCluster placement matrix work shipping in parallel.

Refs #2665

🤖 Generated with [Claude Code](https://claude.com/claude-code)