### PR TITLE
feat(bootstrap-kit): G92.5 — Sandbox + per-Org CNPG land INSIDE RTZ vCluster (Refs #2664)

### DIFF
--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -43,23 +43,47 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-sandbox
-  namespace: flux-system
+  # G92.5 #2664 (2026-06-01): HR lives in host ns `rtz` (where
+  # bp-rtz-vcluster exports vc-rtz Secret). helm-controller
+  # authenticates against the RTZ vCluster apiserver and installs the
+  # chart inside the vCluster. Per docs/SOVEREIGN-MULTI-REGION-DOD.md
+  # §A4 Sandbox is RTZ-tier (tenant zone) — co-located with per-Org
+  # tenant Applications + per-Org CNPG. The chart's per-Sandbox CNPG
+  # Cluster CR dispatch (sandbox.db.provision block) lands in vCluster,
+  # reflects to host via bp-rtz-vcluster 0.2.1 customResources policy.
+  #
+  # The older "Sandbox lives in primary MGMT vCluster only" assumption
+  # is retired — G92 EPIC supersedes. Dep on bp-catalyst-platform
+  # (host-substrate today, per G92.3 follow-up) is now cross-cluster:
+  # the controller inside RTZ vCluster resolves catalyst-api via the
+  # vCluster CoreDNS forwarder.
+  namespace: rtz
   labels:
     catalyst.openova.io/slot: "19a"
     catalyst.openova.io/component: sandbox-controller
-    catalyst.openova.io/region-role: primary
+    catalyst.openova.io/vcluster: rtz
 spec:
-  # G2 (Refs #2574, 2026-05-29): primary-only HR — bp-sandbox depends
-  # on bp-catalyst-platform (slot 13) which is also primary-only.
-  # Per docs/SOVEREIGN-MULTI-REGION-DOD.md §A4, Sandbox lives in the
-  # primary MGMT vCluster only.
   suspend: ${SECONDARY_HR_SUSPEND:=false}
   interval: 15m
   releaseName: sandbox
+  # targetNamespace = inner namespace INSIDE the rtz vCluster.
   targetNamespace: catalyst-system
+  # vCluster pivot — helm-controller installs the chart inside rtz
+  # vCluster (Flux v2 HelmRelease v2 contract). G92.5 #2664.
+  kubeConfig:
+    secretRef:
+      name: vc-rtz
+      key: config
   dependsOn:
+    # G92.5 #2664 (2026-06-01): bp-rtz-vcluster MUST be Ready before
+    # this HR tries to install — vc-rtz Secret + the customResources
+    # sync policy both materialise from that release.
+    - name: bp-rtz-vcluster
+      namespace: flux-system
     - name: bp-vcluster-helmrepo
+      namespace: flux-system
     - name: bp-catalyst-platform
+      namespace: flux-system
     # bp-harbor (slot 19, Wave 11 convergence fix 2026-05-18) — sandbox's
     # chart pull goes through harbor.<sov-fqdn> after the post-handover
     # cutover Step-06 phase-1 HelmRepository URL rewrite. Without this
@@ -70,7 +94,9 @@ spec:
     # Wave 7 #1610 (bp-hcloud-csi, REMOVED) but resolved by sequencing
     # rather than removal so the slot remains available for Wave 11
     # Sandbox MVP without manual Day-2 add-app re-introduction.
+    # G92.3 #2662 (2026-06-01): bp-harbor HR moved to host ns `mgmt`.
     - name: bp-harbor
+      namespace: mgmt
   chart:
     spec:
       chart: sandbox
@@ -145,6 +171,10 @@ spec:
         name: bp-sandbox
         namespace: flux-system
   install:
+    # G92.5 #2664: createNamespace=true so helm-controller provisions
+    # the inner `catalyst-system` namespace inside the rtz vCluster on
+    # first install.
+    createNamespace: true
     timeout: 10m
     disableWait: true
     remediation:

--- a/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
@@ -62,7 +62,7 @@ spec:
   chart:
     spec:
       chart: bp-rtz-vcluster
-      version: 0.2.0
+      version: 0.2.1
       sourceRef:
         kind: HelmRepository
         name: bp-rtz-vcluster

--- a/platform/bp-rtz-vcluster/blueprint.yaml
+++ b/platform/bp-rtz-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.0
+  version: 0.2.1
   card:
     title: RTZ vCluster
     summary: |

--- a/platform/bp-rtz-vcluster/chart/Chart.yaml
+++ b/platform/bp-rtz-vcluster/chart/Chart.yaml
@@ -14,7 +14,13 @@ name: bp-rtz-vcluster
 # schema so RTZ vCluster-placed tenant Applications (G92.5 #2664) +
 # per-Org CNPG can wire CR sync to the host cnpg-operator without a
 # follow-up chart bump.
-version: 0.2.0
+# 0.2.1 — Refs #2664/#2639 (G92.5 EPIC, 2026-06-01): values.yaml now
+# declares `vcluster.sync.toHost.customResources` for the 3 CNPG CR
+# kinds — mirrors the bp-mgmt-vcluster 0.2.1 policy (PR #2692). The
+# RTZ vCluster hosts per-Org tenant Applications + Sandbox per DoD
+# §A4; both paths route CNPG provisioning through the host
+# cnpg-operator (G92.6 substrate per #2665) via this sync.
+version: 0.2.1
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign RTZ

--- a/platform/bp-rtz-vcluster/chart/values.yaml
+++ b/platform/bp-rtz-vcluster/chart/values.yaml
@@ -97,6 +97,29 @@ vcluster:
         enabled: true
       secrets:
         enabled: true
+      # G92.5 #2664 (2026-06-01) — CNPG `Cluster` CR sync vCluster → host.
+      # Mirrors the policy bp-mgmt-vcluster 0.2.1 ships (PR #2692). The
+      # RTZ vCluster hosts per-Org tenant Applications + Sandbox per
+      # docs/SOVEREIGN-MULTI-REGION-DOD.md §A4; both paths route
+      # PostgreSQL provisioning through the host cnpg-operator (G92.6
+      # substrate per #2665) via this sync policy:
+      #
+      #   - Tenant Applications: application-controller (G92.1 #2660,
+      #     PR #2674) renders the per-Application HR with
+      #     placementSchema.vcluster=rtz; the chart's CNPG Cluster CR
+      #     lands in vCluster's apiserver and reflects to host via
+      #     this policy.
+      #   - Sandbox: sandbox-controller's per-Sandbox CNPG Cluster CR
+      #     dispatch (slot 19a `sandbox.db.provision` block, D31
+      #     active-hot-standby aware) lands in vCluster, reflects to
+      #     host the same way.
+      customResources:
+        clusters.postgresql.cnpg.io:
+          enabled: true
+        poolers.postgresql.cnpg.io:
+          enabled: true
+        scheduledbackups.postgresql.cnpg.io:
+          enabled: true
     fromHost:
       ingressClasses:
         enabled: true

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -587,7 +587,12 @@ slots:
   #     sequencing rather than removal so the slot remains available.
   - slot: "19a"
     name: bp-sandbox
+    # G92.5 #2664 (2026-06-01): RTZ vCluster placement adds
+    # bp-rtz-vcluster as a new edge — vc-rtz Secret + the
+    # sync.toHost.customResources policy both materialise from that
+    # release before sandbox's helm-controller pivot can succeed.
     depends_on:
+      - bp-rtz-vcluster
       - bp-vcluster-helmrepo
       - bp-catalyst-platform
       - bp-harbor


### PR DESCRIPTION
## Summary

Closes G92.5 of the EPIC #2639 placement matrix. Two-step PR:

1. **bp-rtz-vcluster 0.2.1** — adds `vcluster.sync.toHost.customResources` for the 3 CNPG CR kinds, mirroring the bp-mgmt-vcluster 0.2.1 policy shipped in PR #2692.
2. **bp-sandbox slot 19a pivot** — installs INSIDE the per-region RTZ vCluster via Flux v2's `spec.kubeConfig.secretRef → vc-rtz`. Same pattern as the prior G92.x ships (#2687 / #2688 / #2692).

The Tenant-Applications + per-Org-CNPG portion of G92.5 is already delivered by the G92.1 application-controller foundation (PR #2674 → `0dae4166`): Blueprint authors set `spec.placementSchema.vcluster: rtz` and the controller renders the per-Application HR with `kubeConfig.secretRef → vc-rtz`. Step 1 of this PR adds the chart-side CNPG sync policy that makes that path safe for CNPG-backed tenant Blueprints.

## How the RTZ CNPG sync works

```
RTZ vCluster                       host k3s
─────────────                      ──────────────────────
sandbox-controller dispatches      
per-Sandbox CNPG Cluster:          
  postgresql.cnpg.io/v1            
  Cluster: sandbox-pg-<uuid>       syncer mirrors →  sandbox-pg-<uuid>
  (inside catalyst-system ns)                        in catalyst-system-x-rtz
                                                              │
                                                              ▼
                                                     cnpg-operator (host
                                                     substrate per G92.6
                                                     #2665) reconciles,
                                                     creates StatefulSet
                                                              │
                                                              ▼
                                                     Service: sandbox-pg-rw  ← mirrored
                                                     back to vCluster's view via the
                                                     already-enabled sync.toHost.services
                                                              │
                                                              ▼
                                                     per-Sandbox Pod inside vCluster
                                                     resolves sandbox-pg-rw.catalyst-
                                                     system.svc.cluster.local natively
```

Per-Org tenant Application path is structurally identical — application-controller renders the HR's CNPG Cluster CR; the same sync policy reflects it to host.

## Topology contract update (slot 19a)

The slot 19a comment block previously claimed *"Sandbox lives in the primary MGMT vCluster only"* — retired here. G92 EPIC supersedes the older A4 assumption: Sandbox is TENANT-tier and lives in every region's RTZ vCluster alongside per-Org Applications + per-Org CNPG instances. The `catalyst.openova.io/region-role: primary` label is removed in lockstep. The `SECONDARY_HR_SUSPEND` substitute is kept for back-compat with overlays that pin it explicitly, but its semantic is now "operator opt-out per-region" rather than "secondary-region gating".

## What changed

### Commit 1: `bp-rtz-vcluster` 0.2.1 (the CNPG sync policy)

| File | Old | New |
|---|---|---|
| `platform/bp-rtz-vcluster/chart/values.yaml` | no `customResources` block | adds `clusters` + `poolers` + `scheduledbackups` sync policies |
| `platform/bp-rtz-vcluster/chart/Chart.yaml` `version` | 0.2.0 | 0.2.1 |
| `platform/bp-rtz-vcluster/blueprint.yaml` `spec.version` | 0.2.0 | 0.2.1 |
| `clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml` pin | 0.2.0 | 0.2.1 |

Verified locally: `helm dependency build` + `helm template --set rtzVcluster.enabled=true` both succeed.

### Commit 2: Slot 19a (bp-sandbox) pivot to RTZ vCluster

- HR `metadata.namespace` flipped `flux-system` → `rtz`.
- `spec.kubeConfig.secretRef: {name: vc-rtz, key: config}` added.
- `dependsOn[].namespace` qualified for cross-ns deps; bp-rtz-vcluster added as the gating edge; bp-harbor moved to `namespace: mgmt` (lockstep with G92.3 PR #2692).
- `catalyst.openova.io/vcluster: rtz` label stamped; `catalyst.openova.io/region-role: primary` label removed (Sandbox now tenant-tier on every region's RTZ vCluster).
- `install.createNamespace: true` so the inner `catalyst-system` namespace is created on first install inside the vCluster.
- `scripts/expected-bootstrap-deps.yaml`: slot 19a declares `bp-rtz-vcluster` as the new edge.

## Multi-layer RCA (Principle 16)

- **Trigger**: G92.5 #2664 — founder ZT empty-vCluster catch (EPIC #2639). PRs #2687 (G92.2 NATS+OpenBao+Keycloak) + #2688 (G92.4 Coraza) shipped CNPG-free pivots; PR #2690 (vcluster subchart bump) unlocked the v0.21 schema; PR #2692 (G92.3 gitea+harbor with bp-mgmt-vcluster 0.2.1) shipped the MGMT-tier CNPG-backed path. This PR closes the RTZ-tier equivalent.
- **Incident management**: Sandbox specifically — re-classified from MGMT-tier to RTZ-tier per the G92 EPIC matrix. The bp-catalyst-platform dep stays host-substrate (its move is a separate follow-up that needs catalyst-api's host-kubeconfig mount story).
- **Defense**: `dependsOn bp-rtz-vcluster` gates every install on `vc-rtz` + the `customResources` sync policy existing. The chart's per-Sandbox CNPG dispatch evaluates the same Capabilities gate as the chart-templated CNPG Cluster CRs in bp-gitea / bp-harbor (G92.3) — TRUE inside vCluster because the syncer mirrors host-side CRD registrations.
- **Containment**: dep-graph audit PASS (0 drift / 0 cycles / 70 declared / 57 present). pin-sync-audit PASS for the 0.2.1 bump.

## Test plan

- [x] `scripts/check-bootstrap-deps.sh` — PASS
- [x] `scripts/check-bootstrap-kit-pin-sync.sh --changed-only --base origin/main` — PASS
- [x] `helm dependency build` + `helm template --set rtzVcluster.enabled=true` on `bp-rtz-vcluster` 0.2.1 — render succeeds
- [ ] On a fresh `hw*` prov + post-bp-rtz-vcluster-Ready: confirm sandbox-controller Pod running INSIDE the rtz vCluster, and a Sandbox CR successfully provisions a per-Sandbox CNPG Cluster that reconciles on host. Worker-3's G104 `sovereign-3x-zero-touch-cycle.sh` is the canonical gate.

Refs #2664 #2639

🤖 Generated with [Claude Code](https://claude.com/claude-code)
