### PR TITLE
fix(deploy-bump): G29 — eliminate silent-no-op race by re-applying snapshot instead of pull-rebase (Refs #2584)

### DIFF
--- a/.github/actions/deploy-bump/action.yaml
+++ b/.github/actions/deploy-bump/action.yaml
@@ -109,16 +109,64 @@ runs:
         git config user.name  "${DEPLOY_BUMP_USER_NAME}"
         git config user.email "${DEPLOY_BUMP_USER_EMAIL}"
 
-        # Stage every requested path. xargs handles whitespace- and
-        # newline-separated input identically and re-raises non-zero
-        # exit codes from `git add` so a typo'd path fails loudly.
+        # G29 #2584 (2026-06-01): snapshot the intended file contents
+        # BEFORE we commit. On a push race, the prior `pull --rebase
+        # --autostash || true` had a silent failure mode where:
+        #
+        #   1. Push attempt 1 rejected because a concurrent build's
+        #      deploy-bump landed first.
+        #   2. `git pull --rebase --autostash` hit a conflict on the
+        #      same line (both build workflows touched values.yaml's
+        #      catalystApi/catalystUi `tag:` line).
+        #   3. The rebase exited non-zero, leaving HEAD at origin/main
+        #      and our deploy commit unapplied.
+        #   4. The `|| true` swallowed the failure.
+        #   5. Push attempt 2 sent HEAD:main where HEAD = origin/main.
+        #      Git reports "Everything up-to-date" and reports SUCCESS.
+        #   6. `pushed=true` returned by the action; workflow proceeded
+        #      to dispatch blueprint-release. Operators saw a green CI
+        #      run and assumed the bump shipped.
+        #   7. But values.yaml on main carried the OTHER concurrent
+        #      build's SHA, not ours. Operators downstream installed
+        #      the wrong image.
+        #
+        # Live damage: G28 #2584 incident — e39a9bc8 (cloudinit fix-
+        # forward, the critical tofu-template escape) appeared to
+        # deploy successfully but values.yaml stayed at 9b07b9a; the
+        # next prov FAILED with the very error e39a9bc8 was meant to
+        # fix. Lead had to manually `workflow_dispatch` Build & Deploy
+        # to recover.
+        #
+        # Fix: instead of trying to rebase our commit across a race,
+        # we (a) snapshot the intended file contents up-front, then
+        # (b) on every push retry, hard-reset to the latest origin/main
+        # AND re-apply the snapshot. The action becomes
+        # state-machine-shaped: "make origin/main have these file
+        # contents, with this commit message." Conflicts can't drop
+        # the bump because there IS no rebase — every retry starts
+        # fresh from origin/main and re-applies the intent on top.
+        INTENT_DIR="${RUNNER_TEMP:-/tmp}/deploy-bump-intent-$$"
+        mkdir -p "${INTENT_DIR}"
+        SNAPSHOTTED_PATHS=()
+        # shellcheck disable=SC2086
+        for p in $(echo "${DEPLOY_BUMP_PATHS}"); do
+          if [ -e "${p}" ]; then
+            mkdir -p "${INTENT_DIR}/$(dirname "${p}")"
+            cp "${p}" "${INTENT_DIR}/${p}"
+            SNAPSHOTTED_PATHS+=("${p}")
+          fi
+        done
+        echo "deploy-bump: snapshotted ${#SNAPSHOTTED_PATHS[@]} path(s) into ${INTENT_DIR}"
+
+        # Initial check — if nothing actually changed vs HEAD, exit
+        # early with pushed=false (idempotent re-runs).
         # shellcheck disable=SC2086
         echo "${DEPLOY_BUMP_PATHS}" | xargs git add --
-
         if git diff --staged --quiet; then
           echo "deploy-bump: no staged changes — skipping commit/push."
           echo "pushed=false"   >> "$GITHUB_OUTPUT"
           echo "commit_sha="   >> "$GITHUB_OUTPUT"
+          rm -rf "${INTENT_DIR}"
           exit 0
         fi
 
@@ -126,11 +174,6 @@ runs:
         COMMIT_SHA="$(git rev-parse HEAD)"
         echo "deploy-bump: committed ${COMMIT_SHA}"
 
-        # Pull --rebase retry loop. Without this, two parallel build
-        # workflows committing within ~2 min of each other will see
-        # the second `git push` rejected with
-        # `[rejected] main -> main (fetch first)` and the auto-bump
-        # commit is lost (TBD-V32 / openova-io/openova#2062).
         MAX="${DEPLOY_BUMP_MAX_ATTEMPTS:-5}"
         pushed=false
         for i in $(seq 1 "${MAX}"); do
@@ -138,14 +181,49 @@ runs:
             pushed=true
             break
           fi
-          echo "deploy-bump: push attempt ${i}/${MAX} failed — rebasing and retrying."
+          echo "deploy-bump: push attempt ${i}/${MAX} failed — refetching + re-applying snapshot."
+
+          # Recover from any prior iteration that may have left a
+          # rebase / cherry-pick / merge in progress. Best-effort: if
+          # there's nothing to abort, the command returns non-zero
+          # and we ignore it.
+          git rebase --abort 2>/dev/null || true
+          git cherry-pick --abort 2>/dev/null || true
+          git merge --abort 2>/dev/null || true
+
+          # Fetch latest origin/main and hard-reset HEAD onto it. This
+          # discards our local deploy commit; we re-create it from the
+          # snapshot below, which guarantees the values.yaml /
+          # template / Chart.yaml content we intended is what reaches
+          # main (regardless of what the racing deploy committed).
           git fetch origin main
-          # `|| true` keeps the loop alive when the rebase has nothing
-          # to replay (e.g. our commit is still ahead of origin but
-          # the push raced on a transient network hiccup).
-          git pull --rebase --autostash origin main || true
+          git reset --hard origin/main
+
+          # Re-apply the snapshotted intent.
+          for p in "${SNAPSHOTTED_PATHS[@]}"; do
+            src="${INTENT_DIR}/${p}"
+            if [ -f "${src}" ]; then
+              mkdir -p "$(dirname "${p}")"
+              cp "${src}" "${p}"
+            fi
+          done
+
+          # shellcheck disable=SC2086
+          echo "${DEPLOY_BUMP_PATHS}" | xargs git add --
+          if git diff --staged --quiet; then
+            # The racing deploy already pushed identical content (rare
+            # but possible — both jobs computed the same SHA short for
+            # the same git tree). Accept as no-op success.
+            echo "deploy-bump: intent matches origin/main after refetch on attempt ${i} — accepting as no-op success."
+            pushed=true
+            break
+          fi
+
+          git commit -m "${DEPLOY_BUMP_MESSAGE}"
           sleep "$((i * 2))"
         done
+
+        rm -rf "${INTENT_DIR}"
 
         if [ "${pushed}" != "true" ]; then
           echo "deploy-bump: all ${MAX} push attempts failed." >&2
@@ -154,9 +232,24 @@ runs:
           exit 1
         fi
 
-        # Re-resolve HEAD: a successful rebase between attempts may
-        # have changed the commit SHA we landed.
+        # Re-resolve HEAD: each retry recreates the commit, so the
+        # SHA we landed may differ from the one we first committed.
         FINAL_SHA="$(git rev-parse HEAD)"
-        echo "deploy-bump: pushed ${FINAL_SHA} to origin/main."
+
+        # G29 #2584 post-push verification: confirm the SHA we report
+        # in `commit-sha` is actually on origin/main. Catches the
+        # narrow case where the loop break fired on a `Everything
+        # up-to-date` push (which would have meant HEAD == origin/main
+        # pre-push and our deploy commit is still local-only).
+        git fetch origin main
+        REMOTE_SHA="$(git rev-parse origin/main)"
+        if ! git merge-base --is-ancestor "${FINAL_SHA}" "${REMOTE_SHA}"; then
+          echo "deploy-bump: ERROR — FINAL_SHA ${FINAL_SHA} is not an ancestor of origin/main ${REMOTE_SHA}; the silent-no-op race fired." >&2
+          echo "pushed=false" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=${FINAL_SHA}" >> "$GITHUB_OUTPUT"
+          exit 1
+        fi
+
+        echo "deploy-bump: pushed ${FINAL_SHA} to origin/main (verified)."
         echo "pushed=true" >> "$GITHUB_OUTPUT"
         echo "commit_sha=${FINAL_SHA}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/deploy-bump/test-basic.sh
+++ b/.github/actions/deploy-bump/test-basic.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# G29 #2584 verification — single-commit happy path (no race). Asserts
+# deploy-bump's logic still works without the race recovery path firing.
+#
+# Run: bash .github/actions/deploy-bump/test-basic.sh
+# Exit 0: happy path verified.
+# Exit 1: regression.
+
+set -euo pipefail
+
+WORK="${TMPDIR:-/tmp}/deploy-bump-basic-test-$$"
+trap 'rm -rf "${WORK}"' EXIT
+mkdir -p "${WORK}"
+
+# Bare upstream + seed commit.
+( cd "${WORK}" && git init -b main --bare upstream.git >/dev/null )
+SEED="${WORK}/seed"
+# `git clone -b main` against an empty bare repo errors; fall back to
+# a plain clone which inits an empty working tree, then make the seed
+# commit on a fresh main branch and push it.
+git clone "${WORK}/upstream.git" "${SEED}" >/dev/null 2>&1
+cat > "${SEED}/values.yaml" <<'YAML'
+images:
+  catalystApi:
+    tag: "OLD"
+YAML
+( cd "${SEED}"
+  git config user.name  "seed"
+  git config user.email "seed@test.local"
+  git checkout -b main 2>/dev/null || git switch -c main 2>/dev/null || true
+  git add values.yaml
+  git commit -m "seed" >/dev/null
+  git push -u origin main >/dev/null 2>&1
+)
+
+# Worker — single-commit happy path: clone, bump tag, run deploy-bump.
+WORK_C="${WORK}/wf-c"
+git clone -b main "${WORK}/upstream.git" "${WORK_C}" >/dev/null 2>&1
+sed -i 's/tag: "OLD"/tag: "abc1234"/' "${WORK_C}/values.yaml"
+
+export DEPLOY_BUMP_PATHS="values.yaml"
+export DEPLOY_BUMP_MESSAGE="deploy: update to abc1234"
+export DEPLOY_BUMP_MAX_ATTEMPTS="5"
+export DEPLOY_BUMP_USER_NAME="wf-c"
+export DEPLOY_BUMP_USER_EMAIL="wf-c@test.local"
+export RUNNER_TEMP="${WORK}/runner-temp"
+mkdir -p "${RUNNER_TEMP}"
+
+ACTION_BODY="$(awk '/^      run: \|$/{flag=1; next} flag' "$(dirname "$0")/action.yaml")"
+GITHUB_OUTPUT="${WORK}/gh-output" ; export GITHUB_OUTPUT
+touch "${GITHUB_OUTPUT}"
+
+( cd "${WORK_C}" && eval "${ACTION_BODY}" ) || {
+  echo "TEST FAIL: deploy-bump basic path exited non-zero" >&2
+  exit 1
+}
+
+# Verify upstream's main now has tag "abc1234".
+CHECK="${WORK}/check"
+git clone -b main "${WORK}/upstream.git" "${CHECK}" >/dev/null 2>&1
+ACTUAL_TAG="$(grep 'tag:' "${CHECK}/values.yaml" | sed -E 's/.*"([^"]+)".*/\1/')"
+
+if [ "${ACTUAL_TAG}" != "abc1234" ]; then
+  echo "TEST FAIL: basic path didn't land the bump." >&2
+  echo "  expected = abc1234, actual = ${ACTUAL_TAG}" >&2
+  exit 1
+fi
+
+if ! grep -q '^pushed=true$' "${GITHUB_OUTPUT}"; then
+  echo "TEST FAIL: action didn't report pushed=true on basic path" >&2
+  exit 1
+fi
+
+# Idempotency check: running deploy-bump a second time with the same
+# intent should report pushed=false (no staged changes after re-checkout).
+WORK_D="${WORK}/wf-d"
+git clone -b main "${WORK}/upstream.git" "${WORK_D}" >/dev/null 2>&1
+# values.yaml already at abc1234. No bump applied; run the action.
+> "${GITHUB_OUTPUT}"
+( cd "${WORK_D}" && eval "${ACTION_BODY}" ) || {
+  echo "TEST FAIL: idempotent re-run exited non-zero" >&2
+  exit 1
+}
+if ! grep -q '^pushed=false$' "${GITHUB_OUTPUT}"; then
+  echo "TEST FAIL: idempotent re-run should report pushed=false" >&2
+  cat "${GITHUB_OUTPUT}" >&2
+  exit 1
+fi
+
+echo "PASS: basic + idempotent paths verified."

--- a/.github/actions/deploy-bump/test-race.sh
+++ b/.github/actions/deploy-bump/test-race.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# G29 #2584 verification — simulates the e39a9bc8 silent-no-op race
+# against deploy-bump's logic and asserts the post-fix action does
+# NOT lose the intended bump.
+#
+# Race shape (live damage 2026-05-29T16:39Z):
+#   1. Build A produces SHA "9b07b9a", workflow A's deploy-bump
+#      commits + pushes bb6b850a (values.yaml: tag="9b07b9a").
+#   2. Build B (fix-forward) produces SHA "e39a9bc", workflow B's
+#      deploy-bump starts AFTER bb6b850a landed.
+#   3. Workflow B's checkout was at the e39a9bc8 SHA (pre-bb6b850a),
+#      its awk-bump set values.yaml: tag="e39a9bc".
+#   4. PRE-FIX: deploy-bump's `git pull --rebase --autostash || true`
+#      hit a conflict on the `tag:` line, exited non-zero, HEAD reset
+#      to origin/main (= bb6b850a). `|| true` swallowed the failure.
+#      Push attempt 2 sent HEAD:main where HEAD == origin/main →
+#      "Everything up-to-date" SUCCESS. Workflow B reported pushed=true.
+#      main's values.yaml stayed at tag="9b07b9a"; the e39a9bc8 fix
+#      never deployed.
+#
+# This script reproduces the race by orchestrating two simultaneous
+# pushes against a bare repo. With the post-fix action, workflow B's
+# intent ("e39a9bc") MUST end up on main even though workflow A landed
+# its commit first.
+#
+# Run: bash .github/actions/deploy-bump/test-race.sh
+# Exit 0: race-safety verified.
+# Exit 1: deploy-bump silently dropped the bump (regression to pre-fix).
+
+set -euo pipefail
+
+WORK="${TMPDIR:-/tmp}/deploy-bump-race-test-$$"
+trap 'rm -rf "${WORK}"' EXIT
+mkdir -p "${WORK}"
+
+# -- Set up a bare "remote" + initial commit with values.yaml on tag "OLD"
+( cd "${WORK}" && git init -b main --bare upstream.git >/dev/null )
+
+SEED="${WORK}/seed"
+git clone -b main "${WORK}/upstream.git" "${SEED}" 2>/dev/null || git clone "${WORK}/upstream.git" "${SEED}" >/dev/null 2>&1
+cat > "${SEED}/values.yaml" <<'YAML'
+images:
+  catalystApi:
+    tag: "OLD"
+YAML
+( cd "${SEED}"
+  git config user.name  "seed"
+  git config user.email "seed@test.local"
+  git checkout -b main 2>/dev/null || true
+  git add values.yaml
+  git commit -m "seed" >/dev/null
+  git push -u origin main >/dev/null 2>&1
+)
+
+# -- Workflow A (the racing winner) — clones, bumps tag → "9b07b9a", pushes.
+WORK_A="${WORK}/wf-a"
+git clone -b main "${WORK}/upstream.git" "${WORK_A}" >/dev/null 2>&1
+sed -i 's/tag: "OLD"/tag: "9b07b9a"/' "${WORK_A}/values.yaml"
+( cd "${WORK_A}"
+  git config user.name  "wf-a"
+  git config user.email "wf-a@test.local"
+  git add values.yaml
+  git commit -m "deploy: update to 9b07b9a" >/dev/null
+  git push origin HEAD:main >/dev/null
+)
+
+# -- Workflow B (the fix-forward that LOST its commit in the e39a9bc8 incident).
+#    Clones at the seed SHA (= origin/main BEFORE wf-a landed), then bumps tag
+#    → "e39a9bc". By the time deploy-bump pushes, origin/main has advanced to
+#    wf-a's commit — the exact race shape that triggered the silent no-op.
+WORK_B="${WORK}/wf-b"
+git clone -b main "${WORK}/upstream.git" "${WORK_B}" >/dev/null 2>&1
+# Simulate "checkout was at the seed SHA before wf-a landed": reset to the
+# parent commit so the working tree mirrors the original pre-race state.
+( cd "${WORK_B}"
+  git reset --hard HEAD~1 2>/dev/null || true  # no-op if seed is the only commit
+)
+sed -i 's/tag: "OLD"/tag: "e39a9bc"/; s/tag: "9b07b9a"/tag: "e39a9bc"/' "${WORK_B}/values.yaml"
+
+# -- Now invoke the deploy-bump LOGIC against WORK_B. We inline the action's
+#    shell body verbatim so the test exercises the same code the workflow
+#    runs in production.
+export DEPLOY_BUMP_PATHS="values.yaml"
+export DEPLOY_BUMP_MESSAGE="deploy: update to e39a9bc"
+export DEPLOY_BUMP_MAX_ATTEMPTS="5"
+export DEPLOY_BUMP_USER_NAME="wf-b"
+export DEPLOY_BUMP_USER_EMAIL="wf-b@test.local"
+export RUNNER_TEMP="${WORK}/runner-temp"
+mkdir -p "${RUNNER_TEMP}"
+
+ACTION_BODY="$(awk '/^      run: \|$/{flag=1; next} flag' "$(dirname "$0")/action.yaml")"
+GITHUB_OUTPUT="${WORK}/gh-output" ; export GITHUB_OUTPUT
+touch "${GITHUB_OUTPUT}"
+
+( cd "${WORK_B}" && eval "${ACTION_BODY}" ) || {
+  echo "TEST FAIL: deploy-bump action body exited non-zero" >&2
+  exit 1
+}
+
+# -- Verify main's values.yaml ends with tag="e39a9bc" (wf-b's intent), NOT
+#    tag="9b07b9a" (wf-a's value that pre-fix silently overwrote wf-b).
+CHECK="${WORK}/check"
+git clone "${WORK}/upstream.git" "${CHECK}" >/dev/null 2>&1
+ACTUAL_TAG="$(grep 'tag:' "${CHECK}/values.yaml" | sed -E 's/.*"([^"]+)".*/\1/')"
+
+if [ "${ACTUAL_TAG}" != "e39a9bc" ]; then
+  echo "TEST FAIL: race-safe deploy-bump silently dropped wf-b's bump." >&2
+  echo "  expected values.yaml tag = e39a9bc" >&2
+  echo "  actual                   = ${ACTUAL_TAG}" >&2
+  echo "  GITHUB_OUTPUT:" >&2
+  cat "${GITHUB_OUTPUT}" >&2
+  exit 1
+fi
+
+# -- Verify the action reported pushed=true.
+if ! grep -q '^pushed=true$' "${GITHUB_OUTPUT}"; then
+  echo "TEST FAIL: action did not report pushed=true on race success" >&2
+  cat "${GITHUB_OUTPUT}" >&2
+  exit 1
+fi
+
+echo "PASS: race-safety verified — wf-b's intended bump landed on main even"
+echo "      though wf-a's deploy commit landed first."


### PR DESCRIPTION
## Summary

Closes G29 #2584 by eliminating the silent-no-op race in `.github/actions/deploy-bump/action.yaml`. Live damage 2026-05-29T16:39Z: G28 fix-forward commit `e39a9bc8` appeared to deploy successfully but `values.yaml` on main stayed pinned at the racing commit's SHA (`9b07b9a`). The next prov FAILED with the very tofu-template error `e39a9bc8` was meant to fix. Lead manually `workflow_dispatch`ed Build & Deploy to recover.

## Root cause

`deploy-bump`'s `git pull --rebase --autostash || true` swallowed rebase conflicts. The shape:

1. Push attempt 1 rejected (concurrent deploy `bb6b850a` already landed bumping the same `tag:` line).
2. `git pull --rebase --autostash` hit a conflict on `values.yaml`.
3. Rebase exited non-zero; HEAD reset to `origin/main` (= `bb6b850a`), the deploy commit unapplied. The `|| true` masked the failure.
4. Push attempt 2: `HEAD == origin/main` → `Everything up-to-date` SUCCESS. Loop broke with `pushed=true`.
5. Action reported `pushed=true`, `commit_sha = origin/main`'s SHA. Workflow proceeded to dispatch `blueprint-release`.
6. `main`'s `values.yaml` had the OTHER deploy's content, not ours. CI ran green; operators downstream installed the wrong image.

## Fix shape

Replace the rebase-based retry with a **snapshot-and-reapply** loop:

```
BEFORE the initial commit:
  snapshot every intended path's content → $RUNNER_TEMP/deploy-bump-intent-$$

ON each push retry:
  abort any in-progress rebase / cherry-pick / merge
  hard-reset HEAD to origin/main          # discard our deploy commit
  re-apply the snapshot                   # the bump was in the snapshot, not the commit
  re-stage, re-commit, push

POST push success:
  verify: git merge-base --is-ancestor FINAL_SHA origin/main
```

Conflicts can't drop the bump because there IS no rebase — every retry starts fresh from `origin/main` and re-applies the intent on top.

## What changed

| File | Change |
|---|---|
| `.github/actions/deploy-bump/action.yaml` | Replace rebase loop with snapshot-and-reapply loop + post-push ancestor verification |
| `.github/actions/deploy-bump/test-race.sh` | NEW — simulates the e39a9bc8 race shape; asserts the bumped tag actually lands on main |
| `.github/actions/deploy-bump/test-basic.sh` | NEW — single-commit happy path + idempotent re-run |

The action's input/output interface is **unchanged**; every caller works unmodified (catalyst-build, marketplace-api-build, marketplace-build, controller-build matrix, etc.).

## Verification

Both tests pass locally:

```
$ bash .github/actions/deploy-bump/test-race.sh
deploy-bump: push attempt 1/5 failed — refetching + re-applying snapshot.
deploy-bump: pushed 126fb2acd5a1989f16fcd35763b2e95b46495782 to origin/main (verified).
PASS: race-safety verified — wf-b's intended bump landed on main even
      though wf-a's deploy commit landed first.

$ bash .github/actions/deploy-bump/test-basic.sh
deploy-bump: pushed 8e45d7bbb9f16d69ac859a6af25d4f488743899a to origin/main (verified).
deploy-bump: no staged changes — skipping commit/push.
PASS: basic + idempotent paths verified.
```

The race test replays the e39a9bc8 incident shape exactly: workflow A bumps `tag → "9b07b9a"` and pushes first, workflow B (clone state = pre-A) bumps `tag → "e39a9bc"` and runs deploy-bump. PRE-fix the test would have ended with `main`'s `values.yaml` at `"9b07b9a"` (silent drop). POST-fix `main` carries `"e39a9bc"`.

## Multi-layer RCA (Principle 16)

- **Trigger**: G28 fix-forward racing the G27 deploy commit; the same line of `values.yaml` bumped in both, conflict ensued.
- **Incident management**: G29 #2584 filed; lead containment was a manual `workflow_dispatch` to ship `e39a9bc8`'s image.
- **Defense**: the snapshot-and-reapply loop is structurally race-safe — it can't silently drop the bump because there's no rebase to fail. Post-push ancestor verification is the regression-trap.
- **Containment**: `test-race.sh` + `test-basic.sh` ship alongside the fix; both are runnable locally so the next dev who touches the action re-verifies before merging.

## Test plan

- [x] `bash .github/actions/deploy-bump/test-race.sh` — PASS
- [x] `bash .github/actions/deploy-bump/test-basic.sh` — PASS
- [ ] After merge: monitor next concurrent-deploy event (any catalyst-build + a parallel controller build) — confirm the second deploy job lands its actual SHA, not the prior's. The post-push ancestor verification would exit `1` on regression.

Refs #2584

🤖 Generated with [Claude Code](https://claude.com/claude-code)
