### PR TITLE
fix(catalyst): G105 — flip KC + NATS default URLs to vCluster syncer-mangled names post-G92.2 (Refs #2697)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2352,7 +2352,7 @@ name: bp-catalyst-platform
 # Blueprint placementSchema.defaultOnMultiRegion drives empty-
 # spec.placement on multi-region Sovereigns.
 # (Bumped 414 → 415 after main concurrently shipped a 1.4.414.)
-version: 1.4.420
+version: 1.4.421
 appVersion: 1.4.349
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/templates/api-deployment-kustomize.yaml
+++ b/products/catalyst/chart/templates/api-deployment-kustomize.yaml
@@ -376,7 +376,10 @@ spec:
             # allowedPlatformNamespaces (see network-policies/
             # baseline-catalyst-system.yaml) so no extra CNP is needed.
             - name: CATALYST_NATS_URL
-              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream.nats-system.svc.cluster.local:4222" }}'
+              # G105 #2697 default flipped to the syncer-mangled name —
+              # post-G92.2 nats-jetstream runs INSIDE the mgmt vCluster
+              # and the host's `nats-system` namespace no longer exists.
+              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream-x-nats-system-x-mgmt.mgmt.svc.cluster.local:4222" }}'
             # CATALYST_K8SCACHE_KUBECONFIGS_DIR — issue #321. Directory
             # the k8scache.Factory reads kubeconfigs from at startup.
             # The data-plane SharedInformerFactory opens one informer

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -368,7 +368,10 @@ spec:
             # allowedPlatformNamespaces (see network-policies/
             # baseline-catalyst-system.yaml) so no extra CNP is needed.
             - name: CATALYST_NATS_URL
-              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream.nats-system.svc.cluster.local:4222" }}'
+              # G105 #2697 default flipped to the syncer-mangled name —
+              # post-G92.2 nats-jetstream runs INSIDE the mgmt vCluster
+              # and the host's `nats-system` namespace no longer exists.
+              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream-x-nats-system-x-mgmt.mgmt.svc.cluster.local:4222" }}'
             # CATALYST_K8SCACHE_KUBECONFIGS_DIR — issue #321. Directory
             # the k8scache.Factory reads kubeconfigs from at startup.
             # The data-plane SharedInformerFactory opens one informer

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -326,8 +326,26 @@ images:
 runtime:
   # Keycloak admin API base URL. Consumed as CATALYST_KC_ADDR by
   # organization-controller (per-Org realm provisioning via the KC
-  # Admin API).
-  keycloakAddr: "http://keycloak.keycloak.svc.cluster.local:80"
+  # Admin API) AND by catalyst-api (operator PIN-issue → KC EnsureUser).
+  #
+  # G105 #2697 (2026-06-01): post-G92.2 #2687, bp-keycloak's HR carries
+  # `placementSchema.vcluster: mgmt` so application-controller (G92.1
+  # #2674) routes the chart INSIDE the mgmt vCluster via Flux's
+  # `kubeConfig.secretRef`. The chart's Service `Service keycloak.keycloak`
+  # then lives inside the vCluster apiserver, NOT on host k3s. The
+  # bp-mgmt-vcluster `sync.toHost.services.enabled: true` syncer reflects
+  # the Service back to the host with the canonical syncer-mangled name
+  # `<service>-x-<inner-ns>-x-<vcluster-name>.<host-ns>.svc.cluster.local`.
+  # Pre-G92.2 default `keycloak.keycloak.svc.cluster.local:80` returns
+  # NXDOMAIN because the host's `keycloak` namespace no longer exists —
+  # PIN sign-in fails with `could not provision user record` (caught
+  # live on hw86 2026-06-01).
+  #
+  # The new default points at the syncer-mangled name. Per-Sovereign
+  # overlays MAY override (e.g. to a `keycloak.openova.com` external
+  # admin endpoint, or to a Catalyst-Zero contabo URL, or back to the
+  # pre-G92.2 path on Sovereigns provisioned BEFORE G92.2 landed).
+  keycloakAddr: "http://keycloak-x-keycloak-x-mgmt.mgmt.svc.cluster.local:80"
   # Keycloak realm the per-Org realms are nested under. Default
   # `sovereign` matches the bp-keycloak chart's auto-provisioned
   # tenant realm (the contabo mothership uses `openova` instead).
@@ -673,10 +691,18 @@ services:
     # k8scache.Factory).
     clusterID: ""
     nats:
-      # In-cluster NATS JetStream Service URL. Namespace is `nats-system`
-      # (see clusters/_template/bootstrap-kit/07-nats-jetstream.yaml) —
-      # previous default of `.nats-jetstream.svc` was an NXDOMAIN bug.
-      url: "nats://nats-jetstream.nats-system.svc.cluster.local:4222"
+      # In-cluster NATS JetStream Service URL.
+      #
+      # G105 #2697 (2026-06-01): post-G92.2 #2687, bp-nats-jetstream's
+      # HR carries `placementSchema.vcluster: mgmt` so the chart lives
+      # INSIDE the mgmt vCluster (Service `nats-jetstream.nats-system`
+      # in vCluster apiserver). The bp-mgmt-vcluster syncer reflects
+      # it to the host as the syncer-mangled name
+      # `nats-jetstream-x-nats-system-x-mgmt.mgmt.svc.cluster.local:4222`.
+      # Pre-G92.2 default `nats-jetstream.nats-system.svc.cluster.local:4222`
+      # returned NXDOMAIN because the `nats-system` namespace no longer
+      # exists on the host k3s.
+      url: "nats://nats-jetstream-x-nats-system-x-mgmt.mgmt.svc.cluster.local:4222"
       stream: "catalyst.events"
       subject: "catalyst.events.>"
     valkey:


### PR DESCRIPTION
## Summary

Closes G105 #2697 Front B. Founder caught PIN sign-in on hw86 returning \`could not provision user record\` 2026-06-01.

**Root cause**: G92.2 #2687 moved bp-keycloak (+ bp-nats-jetstream + bp-openbao) INSIDE the mgmt vCluster via \`placementSchema.vcluster: mgmt\`. The chart's Services now live in the vCluster apiserver, NOT on host k3s. The host's \`keycloak\` / \`nats-system\` namespaces no longer exist. catalyst-api on host hit NXDOMAIN on every PIN-issue → KC EnsureUser call.

**Fix**: flip the chart's three KC/NATS URL defaults to the canonical vCluster syncer-mangled host names (\`<service>-x-<inner-ns>-x-<vcluster-name>.<host-ns>.svc.cluster.local\`). bp-mgmt-vcluster's \`sync.toHost.services.enabled: true\` already projects the Services; this commit makes catalyst-api consume them at the correct name.

### Changed defaults

| Key | Before | After |
|---|---|---|
| \`runtime.keycloakAddr\` | \`http://keycloak.keycloak.svc.cluster.local:80\` | \`http://keycloak-x-keycloak-x-mgmt.mgmt.svc.cluster.local:80\` |
| \`spec.eventBus.kafka.nats.url\` | \`nats://nats-jetstream.nats-system.svc.cluster.local:4222\` | \`nats://nats-jetstream-x-nats-system-x-mgmt.mgmt.svc.cluster.local:4222\` |
| \`catalystApi.natsURL\` default in \`api-deployment{,-kustomize}.yaml\` | \`nats://nats-jetstream.nats-system.svc.cluster.local:4222\` | \`nats://nats-jetstream-x-nats-system-x-mgmt.mgmt.svc.cluster.local:4222\` |

Per-Sovereign overlays MAY override (e.g. operators on Sovereigns provisioned BEFORE G92.2 landed can pin back to the legacy paths until they re-provision).

## Multi-layer RCA (Principle 16)

- **Trigger**: G92.2 #2687 moved bp-keycloak inside mgmt vCluster without flipping the catalyst chart's runtime URL defaults. The Blueprint placementSchema landed (G92.1 #2674) but the cross-chart coherence checker didn't.
- **Incident management**: hw86 PIN sign-in returns generic UI copy ("could not provision user record") — the underlying DNS NXDOMAIN is logged but invisible to the operator without log access.
- **Defense**: this commit flips the defaults so every fresh prov post-this-chart-bump resolves the Service correctly via the syncer projection.
- **Containment**: G105 #2697 stays open for the matrix-coherence audit work (Fronts A + C: chart-pair lint + canonical placement of catalyst-api INSIDE mgmt vCluster). When G92.2 moves bp-catalyst-platform inside mgmt vCluster the syncer-mangled names become irrelevant because both producer + consumer share the vCluster's DNS namespace.

## Test plan

- [x] \`grep -rn 'keycloak.keycloak.svc' products/catalyst/chart/\` returns only documentation references after this change.
- [ ] After merge: catalyst-api auto-deploy fires; \`kubectl exec -n catalyst-system <api-pod> -- getent hosts keycloak-x-keycloak-x-mgmt.mgmt.svc.cluster.local\` resolves (once bp-keycloak's in-vCluster Service is up).
- [ ] After merge: PIN sign-in on hw86 (or any post-G92.2 Sovereign with bp-keycloak Ready inside the vCluster) returns the 6-digit code email instead of "could not provision user record".
- [ ] Re-run \`sovereign-dod-verify.sh\` against any post-G92.2 fresh prov — L4 catalyst-system/catalyst-api container Ready holds, L5 auth.\<fqdn\> serves Keycloak.

Refs #2697 (G105)
Refs #2526 (north-star — every fresh prov hits this dead-end at Phase 1 until this fix lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)