### PR TITLE
fix(catalyst): G105 — correct vCluster syncer-mangled name (mgmt-vcluster not mgmt)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2352,7 +2352,7 @@ name: bp-catalyst-platform
 # Blueprint placementSchema.defaultOnMultiRegion drives empty-
 # spec.placement on multi-region Sovereigns.
 # (Bumped 414 → 415 after main concurrently shipped a 1.4.414.)
-version: 1.4.421
+version: 1.4.422
 appVersion: 1.4.349
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/templates/api-deployment-kustomize.yaml
+++ b/products/catalyst/chart/templates/api-deployment-kustomize.yaml
@@ -379,7 +379,7 @@ spec:
               # G105 #2697 default flipped to the syncer-mangled name —
               # post-G92.2 nats-jetstream runs INSIDE the mgmt vCluster
               # and the host's `nats-system` namespace no longer exists.
-              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream-x-nats-system-x-mgmt.mgmt.svc.cluster.local:4222" }}'
+              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222" }}'
             # CATALYST_K8SCACHE_KUBECONFIGS_DIR — issue #321. Directory
             # the k8scache.Factory reads kubeconfigs from at startup.
             # The data-plane SharedInformerFactory opens one informer

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -371,7 +371,7 @@ spec:
               # G105 #2697 default flipped to the syncer-mangled name —
               # post-G92.2 nats-jetstream runs INSIDE the mgmt vCluster
               # and the host's `nats-system` namespace no longer exists.
-              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream-x-nats-system-x-mgmt.mgmt.svc.cluster.local:4222" }}'
+              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222" }}'
             # CATALYST_K8SCACHE_KUBECONFIGS_DIR — issue #321. Directory
             # the k8scache.Factory reads kubeconfigs from at startup.
             # The data-plane SharedInformerFactory opens one informer

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -345,7 +345,7 @@ runtime:
   # overlays MAY override (e.g. to a `keycloak.openova.com` external
   # admin endpoint, or to a Catalyst-Zero contabo URL, or back to the
   # pre-G92.2 path on Sovereigns provisioned BEFORE G92.2 landed).
-  keycloakAddr: "http://keycloak-x-keycloak-x-mgmt.mgmt.svc.cluster.local:80"
+  keycloakAddr: "http://keycloak-x-keycloak-x-mgmt-vcluster.mgmt.svc.cluster.local:80"
   # Keycloak realm the per-Org realms are nested under. Default
   # `sovereign` matches the bp-keycloak chart's auto-provisioned
   # tenant realm (the contabo mothership uses `openova` instead).
@@ -698,11 +698,11 @@ services:
       # INSIDE the mgmt vCluster (Service `nats-jetstream.nats-system`
       # in vCluster apiserver). The bp-mgmt-vcluster syncer reflects
       # it to the host as the syncer-mangled name
-      # `nats-jetstream-x-nats-system-x-mgmt.mgmt.svc.cluster.local:4222`.
+      # `nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222`.
       # Pre-G92.2 default `nats-jetstream.nats-system.svc.cluster.local:4222`
       # returned NXDOMAIN because the `nats-system` namespace no longer
       # exists on the host k3s.
-      url: "nats://nats-jetstream-x-nats-system-x-mgmt.mgmt.svc.cluster.local:4222"
+      url: "nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222"
       stream: "catalyst.events"
       subject: "catalyst.events.>"
     valkey:


### PR DESCRIPTION
## Summary

PR #2698 shipped the wrong syncer-mangled DNS segment. The bp-mgmt-vcluster chart wraps loft-sh/vcluster with the Helm release name `mgmt-vcluster`, not `mgmt`. Live evidence on hw86:

```
kubectl get svc -n mgmt
→ kube-dns-x-kube-system-x-mgmt-vcluster   ClusterIP   10.96.240.214   ...
→ mgmt-vcluster                            ClusterIP   10.96.120.97    ...
→ mgmt-vcluster-headless                   ClusterIP   None            ...
```

The syncer projects in-vCluster Services as `<service>-x-<inner-ns>-x-<release-name>.<host-ns>.svc.cluster.local`. Release name is `mgmt-vcluster` (matching StatefulSet pod `mgmt-vcluster-0`).

Corrected URLs in all 3 sites. Chart bump 1.4.421 → 1.4.422.

Refs #2697 (G105), Refs #2526