### PR TITLE
fix(bp-{mgmt,dmz,rtz}-vcluster): G108 — bump image tag 0.20.0 → 0.21.0 (subchart bump didn't update values)

### DIFF
--- a/platform/bp-dmz-vcluster/chart/Chart.yaml
+++ b/platform/bp-dmz-vcluster/chart/Chart.yaml
@@ -19,7 +19,7 @@ name: bp-dmz-vcluster
 # 0.2.0 + bp-rtz-vcluster 0.2.0). Picks up `sync.toHost.customResources`
 # schema so DMZ vCluster-placed charts that need cross-vCluster CR sync
 # can wire it in without a follow-up chart bump.
-version: 0.2.0
+version: 0.2.1
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign DMZ

--- a/platform/bp-dmz-vcluster/chart/values.yaml
+++ b/platform/bp-dmz-vcluster/chart/values.yaml
@@ -41,7 +41,7 @@ dmzVcluster:
   # ── Image (MIRROR-EVERYTHING) ─────────────────────────────────────
   image:
     repository: "harbor.openova.io/proxy-ghcr/loft-sh/vcluster"
-    tag: "0.20.0"
+    tag: "0.21.0"
     pullPolicy: "IfNotPresent"
 
   # ── NetworkPolicy isolation baseline ──────────────────────────────
@@ -81,7 +81,7 @@ vcluster:
       image:
         registry: harbor.openova.io
         repository: proxy-ghcr/loft-sh/vcluster
-        tag: "0.20.0"
+        tag: "0.21.0"
       resources:
         requests:
           cpu: "200m"

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -35,7 +35,7 @@ name: bp-mgmt-vcluster
 # `<inner-ns>-x-mgmt`, the host's cnpg-operator reconciles it, and
 # the resulting Service is synced back into the vCluster's view via
 # the already-enabled `sync.toHost.services`.
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -86,7 +86,7 @@ mgmtVcluster:
   # overlay rewrites to `harbor.<sovereign-fqdn>/proxy-ghcr/...`.
   image:
     repository: "harbor.openova.io/proxy-ghcr/loft-sh/vcluster"
-    tag: "0.20.0"
+    tag: "0.21.0"
     pullPolicy: "IfNotPresent"
 
   # ── NetworkPolicy isolation baseline ───────────────────────────
@@ -135,7 +135,7 @@ vcluster:
         # vCluster syncer image. MIRROR-EVERYTHING via Harbor proxy.
         registry: harbor.openova.io
         repository: proxy-ghcr/loft-sh/vcluster
-        tag: "0.20.0"
+        tag: "0.21.0"
       resources:
         requests:
           cpu: "200m"

--- a/platform/bp-rtz-vcluster/chart/Chart.yaml
+++ b/platform/bp-rtz-vcluster/chart/Chart.yaml
@@ -20,7 +20,7 @@ name: bp-rtz-vcluster
 # RTZ vCluster hosts per-Org tenant Applications + Sandbox per DoD
 # §A4; both paths route CNPG provisioning through the host
 # cnpg-operator (G92.6 substrate per #2665) via this sync.
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign RTZ

--- a/platform/bp-rtz-vcluster/chart/values.yaml
+++ b/platform/bp-rtz-vcluster/chart/values.yaml
@@ -39,7 +39,7 @@ rtzVcluster:
 
   image:
     repository: "harbor.openova.io/proxy-ghcr/loft-sh/vcluster"
-    tag: "0.20.0"
+    tag: "0.21.0"
     pullPolicy: "IfNotPresent"
 
   # ── NetworkPolicy isolation baseline ──────────────────────────────
@@ -67,7 +67,7 @@ vcluster:
       image:
         registry: harbor.openova.io
         repository: proxy-ghcr/loft-sh/vcluster
-        tag: "0.20.0"
+        tag: "0.21.0"
       resources:
         requests:
           cpu: "200m"


### PR DESCRIPTION
## Summary

PR #2690 + #2691 bumped the loft-sh/vcluster Chart.yaml dep to 0.21.0 for the `sync.toHost.customResources` schema (G92.3). But values.yaml still carried two explicit `tag: "0.20.0"` overrides that pinned the runtime image to the OLD binary.

**Live evidence on hw86 2026-06-01** after the cascade unblock — vCluster Pod crashloops:

```
error unmarshaling JSON: json: unknown field "connector"
```

`connector` is a 0.21.0-only schema entry that the chart now emits (the umbrella renders 0.21.0 schema from the Chart.yaml dep) but the running binary at `harbor.openova.io/proxy-ghcr/loft-sh/vcluster:0.20.0` rejects.

## Changed

| Chart | values.yaml lines | Chart.yaml |
|---|---|---|
| bp-mgmt-vcluster | 89, 138 (tag) | 0.2.1 → 0.2.2 |
| bp-dmz-vcluster | 44, 84 (tag) | 0.2.0 → 0.2.1 |
| bp-rtz-vcluster | 42, 70 (tag) | 0.2.1 → 0.2.2 |

All 3 charts kept in sibling lockstep per the PR #2690 / PR #2691 pattern.

Refs #2697 (G105 cascade), Refs #2526 (north-star)