### PR TITLE
fix(sso-bridge,kyverno-policies): G109-followup — NetworkPolicy + namespace exclude (Refs #2705)

### DIFF
--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.27
+  version: 1.0.28
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -81,7 +81,7 @@ type: application
 # while keeping proxy-cache for anonymous public registries.
 # Lockstep with bp-self-sovereign-cutover 0.1.43 (Step 03 Phase A
 # skopeo native-push + Step 07 REGISTRY drops /proxy-ghcr/ suffix).
-version: 1.0.27
+version: 1.0.28
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/values.yaml
+++ b/platform/kyverno-policies/chart/values.yaml
@@ -94,6 +94,18 @@ compliancePolicies:
       - dmz
       - mgmt
       - rtz
+      # G109 #2705 (2026-06-01): bp-sso-bridge reconciler is single-writer
+      # by design (parallel ticks would race the Keycloak Client upserts +
+      # OpenBao secret writes). `multiReplica` / `pdb` / `topologySpread` /
+      # `hpa` policies would reject the chart's `replicas: 1`. A future
+      # leader-election + fencing refactor could enable replicas>=2; until
+      # then exempt the namespace. The per-workload
+      # `policies.kyverno.io/exempt` annotation in the chart's
+      # `deploymentAnnotations` is documentation-only — catalyst Kyverno
+      # policies key on namespace-list exclusion (this anchor), not
+      # per-workload annotation. Code-reviewer agent surfaced this gap
+      # 2026-06-01T13:35Z (G109 review verdict PASS-with-caveats).
+      - sso-bridge
 
   pdb:
     enabled: true

--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 0.2.0
+  version: 0.2.1
   card:
     title: sso-bridge
     summary: |

--- a/platform/sso-bridge/chart/Chart.yaml
+++ b/platform/sso-bridge/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-sso-bridge
-version: 0.2.0
+version: 0.2.1
 # 0.1.1 (G91.catalyst-console-admin-self-grant #2659, 2026-05-31):
 # extends the reconcile loop with:
 #   - `grant_operator_realm_roles` — grants the operator user the

--- a/platform/sso-bridge/chart/templates/networkpolicy.yaml
+++ b/platform/sso-bridge/chart/templates/networkpolicy.yaml
@@ -1,0 +1,83 @@
+{{- /*
+NetworkPolicy for the bp-sso-bridge reconciler.
+
+G109 #2705 / G109-followup (2026-06-01) — Code-reviewer agent surfaced
+that Kyverno `networkpolicy-present` policy (baseline/14) rejects any
+namespace without a NetworkPolicy. Chart 0.2.0 hardened the Deployment
+but did NOT add a NetworkPolicy template — the `sso-bridge` namespace
+would fail admission on a Sovereign with default policy enforcement.
+
+The reconciler needs egress to exactly four endpoints:
+  - K8s apiserver (kubectl list HRs, write ExternalSecret CRs)
+  - Cluster DNS (resolve in-cluster Service names)
+  - Keycloak admin endpoint (mint SA token, upsert Client, grant roles)
+  - OpenBao admin endpoint (login via K8s SA auth, write KV2 secret)
+
+Ingress: NONE. The reconciler exposes no listener (the /metrics endpoint
+referenced in `prometheus.io/scrape` annotation is a future enhancement
+per chart 0.2.0 hardening; today the annotation is intent-only).
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the policy is
+operator-tunable via `.Values.networkPolicy.*` knobs.
+*/}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bp-sso-bridge
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-sso-bridge
+    app.kubernetes.io/name: sso-bridge-reconciler
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: sso-bridge-reconciler
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress:
+    # Cluster DNS — every other egress dest is resolved by name.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Kubernetes API — reconciler lists HRs cluster-wide + writes
+    # ExternalSecret CRs into each app's namespace.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443
+    # Keycloak admin endpoint — same namespace selector as
+    # bp-keycloak's NetworkPolicy ingress allow-list. Per-Sovereign
+    # overlays MAY rewrite the namespace if bp-keycloak is relocated
+    # (e.g. inside the mgmt vCluster post-G92.2 — that path uses a
+    # different ingress route per the syncer-mangled name from G105).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.keycloakNamespace | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.keycloakPort }}
+    # OpenBao admin endpoint — same shape as Keycloak.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.openbaoNamespace | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.openbaoPort }}
+{{- end }}

--- a/platform/sso-bridge/chart/values.yaml
+++ b/platform/sso-bridge/chart/values.yaml
@@ -165,10 +165,30 @@ podLabels:
 # Workload-level compliance exemption annotation for the Deployment.
 # G109 #2705: the reconciler is a single-writer Bash script and CANNOT run
 # with replicas > 1 (parallel ticks would race the Keycloak Client upserts
-# + OpenBao writes). Kyverno's `replicas-at-least-two` policy violates this
-# correctness constraint, so we exempt the workload via the standard
-# annotation Kyverno recognises (per docs/RUNBOOKS.md §kyverno-exemption).
-# Operators may force-enable multi-replica via leaderElection-and-fencing
-# in a future chart version; this is the today's-correct shape.
+# + OpenBao writes). The catalyst Kyverno policies use namespace-list
+# exclusion (NOT per-workload annotation), so the actual exemption ships
+# in `platform/kyverno-policies/chart/values.yaml` `complianceDefaultExcludes`
+# (added in G109-followup). This annotation is kept as DOCUMENTATION of
+# intent for operators reading the manifest. A future leader-election +
+# fencing refactor could enable replicas>=2; the namespace-exclusion stays
+# either way for `pdb`, `topologySpread`, `hpa-effective` policies.
 deploymentAnnotations:
   policies.kyverno.io/exempt: "replicas-at-least-two"
+
+# NetworkPolicy for the reconciler.
+#
+# G109-followup #2705 (2026-06-01): Kyverno baseline policy
+# `networkpolicy-present` (baseline/14) rejects any namespace without a
+# NetworkPolicy. Chart 0.2.0 hardened the Deployment but did NOT ship a
+# NetworkPolicy template. Reviewer-agent verdict 2026-06-01T13:35Z flagged
+# the gap. This block configures the egress allow-list.
+#
+# Default keycloak/openbao Namespaces match the platform charts.
+# Post-G92.2 placement may move these inside the mgmt vCluster — operators
+# rewrite via per-Sovereign overlay in that case.
+networkPolicy:
+  enabled: true
+  keycloakNamespace: keycloak
+  keycloakPort: 80
+  openbaoNamespace: openbao
+  openbaoPort: 8200


### PR DESCRIPTION
## Summary

Reviewer-agent verdict on G109 PR #2707 was **PASS-with-caveats**. Two gaps:

1. **Per-workload `policies.kyverno.io/exempt` doesn't match catalyst's policies** — they use namespace-list exclusion (`complianceDefaultExcludes`), not per-workload annotation. `replicas: 1` Deployment would still be rejected by multiReplica + pdb + topologySpread + hpa policies on Enforce.

2. **No NetworkPolicy in sso-bridge ns** — Kyverno baseline policy `networkpolicy-present` (baseline/14) rejects any namespace without one.

## Fix

1. Add `sso-bridge` to `platform/kyverno-policies/chart/values.yaml` `complianceDefaultExcludes` (alongside vcluster ns).
2. New `platform/sso-bridge/chart/templates/networkpolicy.yaml` with Egress allow-list (K8s API, cluster DNS, Keycloak admin, OpenBao admin) + Ingress: [].

## Chart bumps

- bp-sso-bridge 0.2.0 → 0.2.1 (new NetworkPolicy template + networkPolicy values block)
- bp-kyverno-policies 1.0.27 → 1.0.28 (namespace exclude)

## Verification

- [x] `helm template sso-bridge platform/sso-bridge/chart` renders clean (30219 bytes, NetworkPolicy resource present)
- [ ] After merge: fresh prov's sso-bridge ns passes `networkpolicy-present` + Deployment passes `multiReplica`/`pdb`/`topologySpread`/`hpa-effective` without manual namespace label override

Refs #2705 (G109 — closes the PASS-with-caveats path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)