### PR TITLE
fix(ui): G110 — host-aware topology detection (no more /sovereign/* HTTP 405 on Sovereign clusters)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/shared/config/urls.test.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/config/urls.test.ts
@@ -8,7 +8,7 @@
  * absolute URLs through untouched so callers can opt in to cross-origin.
  */
 
-import { describe, it, expect } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { API_BASE, apiUrl, BASE, path } from './urls'
 
 describe('shared/config/urls', () => {
@@ -75,5 +75,58 @@ describe('shared/config/urls', () => {
         expect(apiUrl(apiUrl(x))).toBe(apiUrl(x))
       }
     })
+  })
+
+  /**
+   * G110 #2706 (2026-06-01) — host-aware topology detection regression
+   * guards. The path-only check in the prior implementation caused an
+   * operator on `console.<sov-fqdn>/sovereign/login` to get BASE =
+   * '/sovereign/' and every fetch POST returned nginx HTTP 405. The new
+   * implementation requires BOTH the path prefix AND the contabo host.
+   * These tests pin the per-input → BASE mapping by re-importing the
+   * module under different window.location stubs.
+   */
+  describe('BASE — G110 host-aware topology detection (#2706)', () => {
+    // BASE is evaluated at module-load time; reset module cache BEFORE
+    // each test so the dynamic import re-evaluates the IIFE with the
+    // current window stub. Without resetModules in beforeEach, the
+    // first test sees the module-load BASE (captured by the static
+    // `import` at the top of this file) and silently fails.
+    beforeEach(() => {
+      vi.resetModules()
+    })
+    afterEach(() => {
+      vi.unstubAllGlobals()
+      vi.resetModules()
+    })
+
+    const cases: Array<{ host: string; pathname: string; expected: string }> = [
+      // Catalyst-Zero on contabo — both signals match → /sovereign/
+      { host: 'console.openova.io', pathname: '/sovereign/login', expected: '/sovereign/' },
+      { host: 'console.openova.io', pathname: '/sovereign/deployments', expected: '/sovereign/' },
+
+      // Catalyst-Zero on contabo — operator lands on root path → '/'
+      { host: 'console.openova.io', pathname: '/', expected: '/' },
+
+      // Sovereign cluster — operator on canonical path → '/'
+      { host: 'console.hw86.omani.works', pathname: '/login', expected: '/' },
+      { host: 'console.t38.omani.works', pathname: '/', expected: '/' },
+
+      // Sovereign cluster — operator on stale-bookmark /sovereign path.
+      // Pre-G110 this returned '/sovereign/' and broke all API POSTs.
+      // Post-G110: '/'.
+      { host: 'console.hw86.omani.works', pathname: '/sovereign/login', expected: '/' },
+      { host: 'console.t38.omani.works', pathname: '/sovereign/deployments', expected: '/' },
+    ]
+
+    for (const { host, pathname, expected } of cases) {
+      it(`host=${host} pathname=${pathname} → BASE=${expected}`, async () => {
+        vi.stubGlobal('window', {
+          location: { host, pathname },
+        })
+        const mod = await import('./urls')
+        expect(mod.BASE).toBe(expected)
+      })
+    }
   })
 })

--- a/products/catalyst/bootstrap/ui/src/shared/config/urls.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/config/urls.ts
@@ -28,12 +28,50 @@
  * Runtime base path, normalized to always end with '/'.
  *
  * On contabo-mkt (Catalyst-Zero): window.location.pathname starts with
- * '/sovereign' → BASE = '/sovereign/'.
- * On Sovereign clusters: BASE = '/'.
+ * '/sovereign' AND window.location.host is `console.openova.io` →
+ * BASE = '/sovereign/'.
+ * On Sovereign clusters: BASE = '/' regardless of pathname.
+ *
+ * G110 #2706 (2026-06-01): the path-only check was too permissive — an
+ * operator who lands on `https://console.<sov-fqdn>/sovereign/login`
+ * (stale bookmark, copy-paste, or wrong external link) would get
+ * BASE = '/sovereign/' and every fetch POST would hit nginx HTTP 405
+ * because the Sovereign's HTTPRoute doesn't strip a `/sovereign` prefix
+ * the way contabo's Traefik does. Live evidence on hw86 2026-06-01T13:25Z:
+ *
+ *   POST /sovereign/api/v1/auth/pin/issue → HTTP 405 (nginx)
+ *   POST /api/v1/auth/pin/issue → HTTP 200 (PIN sent)
+ *
+ * The host-aware check is the canonical fix: only Catalyst-Zero on
+ * contabo serves the UI under `/sovereign/*` via Traefik strip-prefix,
+ * and that's identified by the `console.openova.io` host. Any other
+ * host (`console.<sov-fqdn>`) is a Sovereign cluster where BASE = '/'.
+ *
+ * Future host names that might surface for Catalyst-Zero (e.g. a
+ * staging contabo `staging.openova.io`) can be added to the
+ * CATALYST_ZERO_HOSTS list below — keep it explicit, never a regex
+ * (per docs/INVIOLABLE-PRINCIPLES.md #4 against silent regex drift).
  */
+const CATALYST_ZERO_HOSTS: ReadonlyArray<string> = [
+  'console.openova.io',
+]
+
+const isCatalystZeroHost = (host: string): boolean =>
+  CATALYST_ZERO_HOSTS.includes(host)
+
 export const BASE: string = (() => {
-  if (typeof window !== 'undefined' && window.location.pathname.startsWith('/sovereign')) {
-    return '/sovereign/'
+  if (typeof window !== 'undefined') {
+    // G110: require BOTH the path prefix AND the contabo host before
+    // claiming Catalyst-Zero. Path-only check was the root-cause for
+    // the hw86 `/sovereign/login` → HTTP 405 chain.
+    if (
+      window.location.pathname.startsWith('/sovereign') &&
+      isCatalystZeroHost(window.location.host)
+    ) {
+      return '/sovereign/'
+    }
+    // Sovereign cluster (or any non-contabo host) — BASE = '/'.
+    return '/'
   }
   // Build-time fallback (SSR / jsdom / unit tests without window).
   const _rawBase = import.meta.env.BASE_URL


### PR DESCRIPTION
## Summary

Path-only `BASE` detection in `urls.ts:34-41` was too permissive. Operator on `console.<sov-fqdn>/sovereign/login` (stale bookmark / copy-paste) got `BASE = '/sovereign/'` → every POST hit nginx HTTP 405.

Live evidence on hw86 2026-06-01T13:25Z:

```
POST /sovereign/api/v1/auth/pin/issue → HTTP 405 (nginx)
POST /api/v1/auth/pin/issue → HTTP 200 (PIN sent)
```

## Fix

New `CATALYST_ZERO_HOSTS` allow-list (initially `console.openova.io`). `BASE = '/sovereign/'` requires BOTH the path prefix AND the contabo host. Any other host = Sovereign → `BASE = '/'`.

## Tests

7 new regression cases in `urls.test.ts` with `vi.stubGlobal` + dynamic `import()` re-evaluation. **17/17 tests pass**.

## Verification

- [x] `npx vitest run src/shared/config/urls.test.ts` — 17 passed
- [ ] After merge: `console.hw86.omani.works/sovereign/login` works correctly (Sovereign cluster — BASE='/' → API POSTs hit the real catalyst-api at /api/v1)
- [ ] After merge: `console.openova.io/sovereign/login` continues to work as Catalyst-Zero (unchanged)

Refs #2706 (G110), Refs #2697 (G105 chain — UI-layer sibling of catalyst-api URL flip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)