### PR TITLE
fix(bootstrap-kit): G105-followup — revert G92.2 vCluster placement on 4 slots (Refs #2697 #2646)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -42,20 +42,15 @@ metadata:
 spec:
   interval: 15m
   releaseName: openbao
-  # targetNamespace = inner namespace INSIDE the mgmt vCluster.
   targetNamespace: openbao
-  # vCluster pivot — helm-controller installs the chart inside mgmt
-  # vCluster (Flux v2 HelmRelease v2 contract). G92.2 #2661.
-  kubeConfig:
-    secretRef:
-      name: vc-mgmt
-      key: config
+  # G105-followup #2697 (2026-06-01) — G92.2 #2661 placement REVERTED.
+  # Same rationale as 09-keycloak: vCluster lacks ExternalSecret + the
+  # mgmt namespace inside itself for Helm release storage. Caught live
+  # on hw86 2026-06-01: bp-openbao stuck on `Could not determine release
+  # state ... dial tcp localhost:8443: connect: connection refused`.
+  # Application-controller G92.1 Blueprint-layer pivot stays; slot-level
+  # forcing removed until vCluster CRD sync ships.
   dependsOn:
-    # G92.2 #2661: bp-mgmt-vcluster MUST be Ready before this HR tries
-    # to install — vc-mgmt Secret doesn't exist until then. Cross-ns
-    # dependsOn requires explicit `namespace:`.
-    - name: bp-mgmt-vcluster
-      namespace: flux-system
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template at
     # platform/openbao/chart/templates/httproute.yaml; the
     # gateway.networking.k8s.io/v1 CRDs MUST be registered before this

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -42,20 +42,19 @@ metadata:
 spec:
   interval: 15m
   releaseName: keycloak
-  # targetNamespace = inner namespace INSIDE the mgmt vCluster.
   targetNamespace: keycloak
-  # vCluster pivot — helm-controller installs the chart inside mgmt
-  # vCluster (Flux v2 HelmRelease v2 contract). G92.2 #2661.
-  kubeConfig:
-    secretRef:
-      name: vc-mgmt
-      key: config
+  # G105-followup #2697 (2026-06-01) — G92.2 #2661 placement REVERTED.
+  # bp-keycloak was moved INSIDE the mgmt vCluster, but the vCluster
+  # doesn't yet sync Gateway API CRDs / ExternalSecret CRDs / mgmt ns
+  # back to host, so the chart's HTTPRoute + ExternalSecret resources
+  # fail admission inside the vCluster with `no matches for kind
+  # "HTTPRoute" in version "gateway.networking.k8s.io/v1"`. The
+  # application-controller G92.1 #2674 pivot at the Blueprint layer
+  # STAYS — only this slot's hard-coded kubeConfig.secretRef is removed
+  # so the chart installs on HOST until vCluster CRD sync ships.
+  # Caught live on hw86 2026-06-01: founder PIN-sign-in fails → cascade →
+  # grafana shows local login → no SSO.
   dependsOn:
-    # G92.2 #2661: bp-mgmt-vcluster MUST be Ready before this HR tries
-    # to install — vc-mgmt Secret doesn't exist until then. Cross-ns
-    # dependsOn requires explicit `namespace:`.
-    - name: bp-mgmt-vcluster
-      namespace: flux-system
     - name: bp-cert-manager
       namespace: flux-system
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template;

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -43,21 +43,14 @@ metadata:
 spec:
   interval: 15m
   releaseName: gitea
-  # targetNamespace = inner namespace INSIDE the mgmt vCluster.
   targetNamespace: gitea
-  # vCluster pivot — helm-controller installs the chart inside mgmt
-  # vCluster (Flux v2 HelmRelease v2 contract). G92.3 #2662.
-  kubeConfig:
-    secretRef:
-      name: vc-mgmt
-      key: config
+  # G105-followup #2697 (2026-06-01) — G92.3 #2662 placement REVERTED.
+  # vCluster lacks Gateway API + ExternalSecret CRDs and the mgmt
+  # namespace inside itself. App installs on HOST until vCluster CRD
+  # sync ships. Application-controller G92.1 Blueprint-layer pivot
+  # stays; only slot-level forcing removed.
   dependsOn:
-    # G92.3 #2662 (2026-06-01): bp-mgmt-vcluster MUST be Ready before
-    # this HR tries to install — vc-mgmt Secret + the customResources
-    # sync policy both materialise from that release.
-    - name: bp-mgmt-vcluster
-      namespace: flux-system
-    # G92.2 #2661: bp-keycloak HR lives in host ns `mgmt`.
+    # bp-keycloak now lives on host (G105-followup) — no cross-ns.
     - name: bp-keycloak
       namespace: mgmt
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template;

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -92,14 +92,12 @@ spec:
   # within the 33min observation window. Same META-AUDIT 1 class as G44.
   interval: 1m
   releaseName: harbor
-  # targetNamespace = inner namespace INSIDE the mgmt vCluster.
   targetNamespace: harbor
-  # vCluster pivot — helm-controller installs the chart inside mgmt
-  # vCluster (Flux v2 HelmRelease v2 contract). G92.3 #2662.
-  kubeConfig:
-    secretRef:
-      name: vc-mgmt
-      key: config
+  # G105-followup #2697 (2026-06-01) — G92.3 #2662 placement REVERTED.
+  # vCluster lacks Gateway API + ExternalSecret CRDs + the mgmt
+  # namespace inside itself. App installs on HOST until vCluster CRD
+  # sync ships. Application-controller G92.1 Blueprint-layer pivot
+  # stays; only slot-level forcing removed.
   # Harbor depends on:
   #   - bp-cnpg(16): registry metadata DB (postgresql.cnpg.io/v1.Cluster).
   #   - bp-cert-manager(02): registry endpoint TLS via ClusterIssuer.


### PR DESCRIPTION
## Summary

Founder live walk on hw86 2026-06-01: grafana shows local login (not Keycloak SSO redirect), no External URL on /apps. Root cause traced through chain — **G92.2/G92.3 slot-level kubeConfig.secretRef forcing** on bp-keycloak/openbao/gitea/harbor.

The 4 charts were routed INTO the mgmt vCluster via slot-level `kubeConfig.secretRef: vc-mgmt`, but the vCluster lacks the CRDs each chart needs:

- `gateway.networking.k8s.io/v1.HTTPRoute` (bp-keycloak/gitea/harbor)
- `external-secrets.io/v1beta1.ExternalSecret` (bp-openbao/gitea/etc.)
- `mgmt` namespace inside the vCluster (Helm release storage)

→ Helm install fails → HR Ready=False → cascades through bp-sso-bridge → Grafana never gets OIDC creds → falls back to local login.

## Cascade evidence on hw86

| Component | State | Why |
|---|---|---|
| bp-keycloak HR | Ready=False (`dial tcp [::1]:8443: refused`) | Trying to install inside vCluster, can't reach apiserver |
| bp-sso-bridge HR | Ready=False (`dependency 'mgmt/bp-keycloak' is not ready`) | Cascade |
| sso-bridge-reconciler Pod | NotFound | HR blocked |
| Keycloak `sovereign` realm clients | catalyst-api-server + catalyst-ui + kubectl ONLY | No per-app upserts ever ran |
| gitea/harbor/openbao Pods | 0 | Charts never installed |
| grafana-sso-oidc-credentials Secret | Empty | ExternalSecret has no OpenBao to read from |
| Grafana login UI | Local username/password | grafana.ini auth.generic_oauth has empty creds |
| /apps Open button | Hidden | `app.externalURL && status === 'installed'` both false |

## Fix

Revert the slot-level `kubeConfig.secretRef` block + `bp-mgmt-vcluster` cross-ns dependsOn entry on:

- `clusters/_template/bootstrap-kit/08-openbao.yaml`
- `clusters/_template/bootstrap-kit/09-keycloak.yaml`
- `clusters/_template/bootstrap-kit/10-gitea.yaml`
- `clusters/_template/bootstrap-kit/19-harbor.yaml`

Apps install on HOST where Gateway API + ExternalSecret CRDs work natively.

**What STAYS**:
- application-controller G92.1 #2674 Blueprint-layer pivot logic (per-Org Applications still route via that layer)
- bp-mgmt-vcluster chart 0.2.2 substrate
- G92.6 K22 Kyverno policy

**Re-enable** when bp-mgmt-vcluster's `sync.toHost.customResources` covers Gateway API + ExternalSecret CRDs AND the chart creates the `mgmt` namespace inside the vCluster (G92.x follow-up).

## Test plan

- [x] YAML parse OK on all 4 files
- [ ] After merge: bootstrap-kit Kustomization reconciles → bp-keycloak / bp-openbao / bp-gitea / bp-harbor install on HOST (where they were pre-G92.2). bp-sso-bridge cascade unblocks → reconciler Pod runs → per-app Keycloak Clients created → ExternalSecrets populated → Grafana SSO works → /apps Open buttons render

Refs #2697 (G105 chain), Refs #2646 (G91 EPIC root install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)