### PR TITLE
fix(bootstrap-kit): G105-followup2 — revert HR metadata.namespace to flux-system on 4 G92.x slots

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -34,8 +34,12 @@ metadata:
   name: bp-openbao
   # G92.2 #2661: HR lives in host ns `mgmt` (where bp-mgmt-vcluster
   # exports vc-mgmt Secret). helm-controller authenticates against the
-  # vCluster apiserver and installs the chart inside the vCluster.
-  namespace: mgmt
+  # G105-followup #2697 (2026-06-01): metadata.namespace reverted to
+  # flux-system. With G92.x slot-level forcing dropped, the HR no
+  # longer needs to colocate with vc-mgmt. Reverting also restores
+  # the Helm valuesFrom lookup of secrets like 'object-storage'
+  # (cloud-init seeds it in flux-system; lookup is in HR's own ns).
+  namespace: flux-system
   labels:
     catalyst.openova.io/slot: "08"
     catalyst.openova.io/vcluster: mgmt

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -34,8 +34,12 @@ metadata:
   name: bp-keycloak
   # G92.2 #2661: HR lives in host ns `mgmt` (where bp-mgmt-vcluster
   # exports vc-mgmt Secret). helm-controller authenticates against the
-  # vCluster apiserver and installs the chart inside the vCluster.
-  namespace: mgmt
+  # G105-followup #2697 (2026-06-01): metadata.namespace reverted to
+  # flux-system. With G92.x slot-level forcing dropped, the HR no
+  # longer needs to colocate with vc-mgmt. Reverting also restores
+  # the Helm valuesFrom lookup of secrets like 'object-storage'
+  # (cloud-init seeds it in flux-system; lookup is in HR's own ns).
+  namespace: flux-system
   labels:
     catalyst.openova.io/slot: "09"
     catalyst.openova.io/vcluster: mgmt

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -35,8 +35,12 @@ metadata:
   name: bp-gitea
   # G92.3 #2662: HR lives in host ns `mgmt` (where bp-mgmt-vcluster
   # exports vc-mgmt Secret). helm-controller authenticates against the
-  # vCluster apiserver and installs the chart inside the vCluster.
-  namespace: mgmt
+  # G105-followup #2697 (2026-06-01): metadata.namespace reverted to
+  # flux-system. With G92.x slot-level forcing dropped, the HR no
+  # longer needs to colocate with vc-mgmt. Reverting also restores
+  # the Helm valuesFrom lookup of secrets like 'object-storage'
+  # (cloud-init seeds it in flux-system; lookup is in HR's own ns).
+  namespace: flux-system
   labels:
     catalyst.openova.io/slot: "10"
     catalyst.openova.io/vcluster: mgmt
@@ -50,12 +54,10 @@ spec:
   # sync ships. Application-controller G92.1 Blueprint-layer pivot
   # stays; only slot-level forcing removed.
   dependsOn:
-    # bp-keycloak now lives on host (G105-followup) — no cross-ns.
+    # bp-keycloak now lives in flux-system (G105-followup #2697).
     - name: bp-keycloak
-      namespace: mgmt
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template;
     # gateway.networking.k8s.io/v1 CRDs must be registered first.
-    # Cross-ns now (bp-gateway-api stays in flux-system on host).
     - name: bp-gateway-api
       namespace: flux-system
     # bp-cnpg (issue #584): chart ships a CNPG Cluster CR;

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -76,8 +76,12 @@ metadata:
   name: bp-harbor
   # G92.3 #2662: HR lives in host ns `mgmt` (where bp-mgmt-vcluster
   # exports vc-mgmt Secret). helm-controller authenticates against the
-  # vCluster apiserver and installs the chart inside the vCluster.
-  namespace: mgmt
+  # G105-followup #2697 (2026-06-01): metadata.namespace reverted to
+  # flux-system. With G92.x slot-level forcing dropped, the HR no
+  # longer needs to colocate with vc-mgmt. Reverting also restores
+  # the Helm valuesFrom lookup of secrets like 'object-storage'
+  # (cloud-init seeds it in flux-system; lookup is in HR's own ns).
+  namespace: flux-system
   labels:
     catalyst.openova.io/slot: "19"
     catalyst.openova.io/vcluster: mgmt


### PR DESCRIPTION
PR #2715 removed slot-level `kubeConfig.secretRef` but kept `metadata.namespace=mgmt` from G92.2. Helm-controller resolves `valuesFrom` in the HR's OWN namespace — bp-harbor's `object-storage` Secret lookup failed because cloud-init seeds it in flux-system. Live evidence on hw86: `could not resolve Secret chart values reference mgmt/object-storage`. This PR reverts metadata.namespace=flux-system across all 4 G92.x slots + drops the stale cross-ns dependsOn in 10-gitea. Refs #2697