### PR TITLE
fix(bootstrap-kit): G105-followup3 — bp-sso-bridge dependsOn ns alignment to flux-system

### DIFF
--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -52,12 +52,10 @@ spec:
   releaseName: sso-bridge
   targetNamespace: sso-bridge
   dependsOn:
-    # G92.2 #2661 (2026-06-01): bp-keycloak + bp-openbao HRs moved to
-    # host ns `mgmt` (they install INSIDE the mgmt vCluster).
+    # G105-followup2 #2697 (2026-06-01): bp-keycloak + bp-openbao HRs
+    # reverted to flux-system ns (G92.x slot-level forcing dropped).
     - name: bp-keycloak
-      namespace: mgmt
     - name: bp-openbao
-      namespace: mgmt
     - name: bp-catalyst-platform
   chart:
     spec:


### PR DESCRIPTION
PR #2717 moved bp-keycloak + bp-openbao HRs back to flux-system. 13b-bp-sso-bridge.yaml dependsOn still pointed at mgmt → `unable to get mgmt/bp-keycloak dependency: helmreleases not found` on hw86. Refs #2697