### PR TITLE
fix(bootstrap-kit): G105-followup4 — cross-ns cleanup (10 slots + 07-nats-jetstream)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -83,9 +83,7 @@ spec:
     # ordering puts cutover after these two come up.
     # G92.3 #2662 (2026-06-01): both HRs moved to host ns `mgmt`.
     - name: bp-gitea
-      namespace: mgmt
     - name: bp-harbor
-      namespace: mgmt
     # NB on issue #1871 (TBD-A24 cutover↔gateway circular deadlock):
     # PR #1875 initially added `- name: sovereign-tls` to this list.
     # That fix was UNRESOLVABLE in Flux: HelmRelease.dependsOn can

--- a/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
@@ -32,11 +32,10 @@ kind: HelmRelease
 metadata:
   name: bp-nats-jetstream
   # G92.2 #2661: HR lives in host ns `mgmt` (where bp-mgmt-vcluster
-  # exports vc-mgmt Secret). helm-controller authenticates against the
-  # vCluster apiserver and installs the chart inside the vCluster.
-  # The inner namespace `nats-system` is created INSIDE the vCluster
-  # via spec.install.createNamespace below.
-  namespace: mgmt
+  # G105-followup4 #2697 (2026-06-01): metadata.namespace reverted
+  # to flux-system. G92.x slot-level forcing dropped (see slot
+  # 09-keycloak.yaml header comment for the rationale).
+  namespace: flux-system
   labels:
     catalyst.openova.io/slot: "07"
     catalyst.openova.io/vcluster: mgmt
@@ -50,14 +49,10 @@ spec:
   # cluster.local` natively via vCluster CoreDNS.
   targetNamespace: nats-system
   # vCluster pivot — helm-controller pulls the kubeconfig from the
-  # vc-mgmt Secret in this HR's own namespace and installs the chart
-  # INSIDE the mgmt vCluster (Flux v2 HelmRelease v2 contract).
-  # G92.2 #2661.
-  kubeConfig:
-    secretRef:
-      name: vc-mgmt
-      key: config
-  # G92.2: bp-mgmt-vcluster (slot 58) MUST be Ready before this HR
+  # G105-followup4 #2697 (2026-06-01): kubeConfig.secretRef removed
+  # (G92.x slot-level forcing dropped, see slot 09-keycloak.yaml for
+  # the chain RCA). bp-nats-jetstream installs on host.
+  # G105-followup-note: bp-mgmt-vcluster (slot 58) MUST be Ready before this HR
   # tries to install — otherwise vc-mgmt doesn't exist and the
   # kubeConfig lookup fails. bp-mgmt-vcluster lives in flux-system so
   # the dep is cross-namespace and needs an explicit `namespace:`.

--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -61,7 +61,6 @@ spec:
       namespace: flux-system
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
-      namespace: mgmt
     - name: bp-sso-bridge
       namespace: flux-system
     - name: bp-external-secrets-stores

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -58,7 +58,6 @@ spec:
   dependsOn:
     # G92.3 #2662 (2026-06-01): bp-gitea HR moved to host ns `mgmt`.
     - name: bp-gitea
-      namespace: mgmt
     # bp-gateway-api (issue #503): umbrella chart ships catalyst-ui +
     # catalyst-api HTTPRoute templates; gateway.networking.k8s.io/v1
     # CRDs must be registered first.
@@ -74,7 +73,6 @@ spec:
     # the umbrella install, eliminating the race.
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
-      namespace: mgmt
     - name: bp-cnpg
     # bp-crossplane-claims (chart-roll-rca iter-15, 2026-05-10): owns the
     # access.openova.io/v1alpha1 XRD that qa-fixtures UserAccess CRs

--- a/clusters/_template/bootstrap-kit/15-external-secrets.yaml
+++ b/clusters/_template/bootstrap-kit/15-external-secrets.yaml
@@ -56,7 +56,6 @@ spec:
   dependsOn:
     # G92.2 #2661 (2026-06-01): bp-openbao HR moved to host ns `mgmt`.
     - name: bp-openbao
-      namespace: mgmt
     - name: bp-cert-manager
   chart:
     spec:

--- a/clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml
+++ b/clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml
@@ -48,7 +48,6 @@ spec:
     - name: bp-external-secrets
     # G92.2 #2661 (2026-06-01): bp-openbao HR moved to host ns `mgmt`.
     - name: bp-openbao
-      namespace: mgmt
   chart:
     spec:
       chart: bp-external-secrets-stores

--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -96,7 +96,6 @@ spec:
     # Sandbox MVP without manual Day-2 add-app re-introduction.
     # G92.3 #2662 (2026-06-01): bp-harbor HR moved to host ns `mgmt`.
     - name: bp-harbor
-      namespace: mgmt
   chart:
     spec:
       chart: sandbox

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -60,7 +60,6 @@ spec:
     - name: bp-tempo
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
-      namespace: mgmt
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template;
     # gateway.networking.k8s.io/v1 CRDs must be registered first.
     - name: bp-gateway-api

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -78,7 +78,6 @@ spec:
     - name: bp-cert-manager
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
-      namespace: mgmt
     - name: bp-sealed-secrets
     - name: bp-seaweedfs
     - name: bp-k8s-ws-proxy

--- a/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+++ b/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
@@ -106,7 +106,6 @@ spec:
     - name: bp-catalyst-platform
     # G92.2 #2661 (2026-06-01): bp-nats-jetstream HR moved to host ns `mgmt`.
     - name: bp-nats-jetstream
-      namespace: mgmt
     - name: bp-powerdns
   chart:
     spec:

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -67,9 +67,7 @@ spec:
     # G92.2 #2661 (2026-06-01): bp-openbao + bp-keycloak HRs moved to
     # host ns `mgmt`.
     - name: bp-openbao
-      namespace: mgmt
     - name: bp-keycloak
-      namespace: mgmt
     - name: bp-cnpg
   chart:
     spec:


### PR DESCRIPTION
PRs #2715/#2717/#2719 reverted G92.x placement on the 5 main slots, but TEN other slot files still carried stale `namespace: mgmt` cross-ns dependsOn entries (caught live on hw86: bp-grafana / bp-guacamole / bp-sandbox / bp-continuum all Ready=False with `unable to get mgmt/bp-keycloak dependency: helmreleases not found`). This PR drops them all. Also reverts 07-nats-jetstream metadata.namespace + kubeConfig.secretRef. Refs #2697