### PR TITLE
fix(bp-keycloak): G112 — stable postgres pwd via existingSecret + keep policy

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -90,7 +90,7 @@ spec:
       # outer hook-wait accommodates the inner 15m availability window.
       # 1.4.3 (issue #129): bumped keycloakConfigCli.availabilityCheck.timeout
       # 120s → 600s + backoffLimit 1 → 5 (fresh-install wedge).
-      version: 1.4.7
+      version: 1.4.8
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.4.7
+  version: 1.4.8
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,10 +1,16 @@
 apiVersion: v2
 name: bp-keycloak
+# 1.4.8 (G112 #2721, 2026-06-01): postgresql.auth.existingSecret pivot —
+# new templates/postgresql-credentials.yaml materialises a stable
+# `keycloak-postgresql` Secret via lookup-or-generate +
+# helm.sh/resource-policy: keep. Eliminates the password-mismatch
+# crashloop when bp-keycloak HR re-installs while the postgres STS
+# volumeClaimTemplate PVC persists (caught live hw86 2026-06-01).
 # 1.4.6 (Fix #1902, TBD-A40, 2026-05-19): omit HTTPRoute parentRef
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.4.7
+version: 1.4.8
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/postgresql-credentials.yaml
+++ b/platform/keycloak/chart/templates/postgresql-credentials.yaml
@@ -1,0 +1,63 @@
+{{/*
+G112 #2721 Defense fix — stable PostgreSQL password for the embedded
+keycloak-postgresql subchart, so HR re-installs do not regenerate the
+password while the StatefulSet PVC persists the OLD password and
+Keycloak crashloops with `password authentication failed for user
+"keycloak"`.
+
+Pattern (matches catalystApiServerClientSecret upstream): on first
+install, lookup any pre-existing Secret OR generate fresh random
+passwords; on every subsequent install/upgrade, reuse the persisted
+Secret values. `helm.sh/resource-policy: keep` ensures helm uninstall
+NEVER drops the Secret — only an explicit operator-deleted Secret +
+PVC wipe ever rotates the password.
+
+Bitnami postgresql subchart accepts this via:
+  keycloak.postgresql.auth.existingSecret: keycloak-postgresql
+which is wired in values.yaml. Required Secret keys (per Bitnami):
+  - password           — application user (keycloak.postgresql.auth.username)
+  - postgres-password  — postgres admin
+Optional:
+  - replication-password (replication.enabled — not used by Catalyst)
+
+Caught live on hw86 2026-06-01: bp-keycloak HR re-installed multiple
+times during cascade reconciliation; each install regenerated the
+Secret while the postgres data dir retained the OLD password →
+CrashLoopBackOff for 30+ min blocking bp-gitea / bp-grafana / bp-harbor
+/ bp-sso-bridge / bp-catalyst-platform. Containment was manual PVC
+wipe (memory feedback_sso_manual_recovery_procedure.md); THIS is the
+canonical Defense.
+*/}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace "keycloak-postgresql" }}
+{{- $pgPassword := "" }}
+{{- $pgAdminPassword := "" }}
+{{- if $existing }}
+  {{- $pgPassword = index $existing.data "password" | b64dec }}
+  {{- $pgAdminPassword = index $existing.data "postgres-password" | b64dec }}
+{{- else }}
+  {{- $pgPassword = randAlphaNum 32 }}
+  {{- $pgAdminPassword = randAlphaNum 32 }}
+{{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-postgresql
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # `helm.sh/resource-policy: keep` — helm uninstall must NEVER drop
+    # this Secret. The postgres StatefulSet's volumeClaimTemplate-owned
+    # PVC `data-keycloak-postgresql-0` already persists across uninstall,
+    # so the password MUST persist alongside it. Together they form a
+    # consistent (data, credential) pair across the full install /
+    # uninstall / re-install lifecycle.
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/instance: keycloak
+    app.kubernetes.io/component: primary
+    catalyst.openova.io/component: keycloak-postgresql
+type: Opaque
+stringData:
+  password: {{ $pgPassword | quote }}
+  postgres-password: {{ $pgAdminPassword | quote }}

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -223,6 +223,18 @@ keycloak:
     auth:
       username: keycloak
       database: keycloak
+      # G112 #2721 (2026-06-01): point the Bitnami postgresql subchart at
+      # the catalyst-owned `keycloak-postgresql` Secret materialised by
+      # templates/postgresql-credentials.yaml. The catalyst template uses
+      # lookup-or-generate + helm.sh/resource-policy: keep, so the
+      # password persists across HR uninstall/reinstall — matching the
+      # STS volumeClaimTemplate PVC which also persists. Without this,
+      # the subchart auto-generates a fresh random password on every
+      # reinstall while the PVC retains the OLD password → Keycloak
+      # CrashLoopBackOff "FATAL: password authentication failed".
+      # Caught live on hw86 2026-06-01 blocking the entire bp-* cascade
+      # (memory feedback_sso_manual_recovery_procedure.md).
+      existingSecret: "keycloak-postgresql"
     image:
       registry: docker.io
       repository: bitnamilegacy/postgresql

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -87,28 +87,29 @@ slots:
     # bp-cnpg dep (issue #512): post-install init hook (`bao operator init`)
     # races cnpg readiness on a fresh Sovereign, hitting the 15m install
     # timeout. Explicit dep makes Flux wait for cnpg Ready=True first.
-    # G92.2 #2661 (2026-06-01): MGMT vCluster placement adds
-    # bp-mgmt-vcluster as a new edge — vc-mgmt Secret must exist
-    # before helm-controller can pivot into the vCluster apiserver.
-    depends_on: [bp-mgmt-vcluster, bp-gateway-api, bp-cnpg]
+    # G92.2 #2661 (2026-06-01): MGMT vCluster placement added
+    # bp-mgmt-vcluster as a new edge — REVERTED by G105-followup
+    # PR #2697/#2715/#2717/#2719/#2720 (vCluster lacks Gateway API +
+    # ExternalSecret CRDs + mgmt namespace inside itself). App installs
+    # on HOST until vCluster CRD sync ships. bp-mgmt-vcluster edge
+    # dropped to match the live slot 08-openbao.yaml.
+    depends_on: [bp-gateway-api, bp-cnpg]
     wave: present
   - slot: 9
     name: bp-keycloak
     # bp-gateway-api dep (issue #503): chart ships an HTTPRoute template.
-    # G92.2 #2661 (2026-06-01): MGMT vCluster placement adds
-    # bp-mgmt-vcluster as a new edge.
-    depends_on: [bp-mgmt-vcluster, bp-cert-manager, bp-gateway-api]
+    # G92.2 #2661 (2026-06-01): MGMT vCluster placement added
+    # bp-mgmt-vcluster — REVERTED by G105-followup (see slot 8 note).
+    depends_on: [bp-cert-manager, bp-gateway-api]
     wave: present
   - slot: 10
     name: bp-gitea
     # bp-gateway-api dep (issue #503): chart ships an HTTPRoute template.
     # bp-cnpg dep (issue #584): chart ships a CNPG Cluster CR; postgresql.cnpg.io/v1
     # CRD must be registered before bp-gitea applies so Capabilities gate fires.
-    # G92.3 #2662 (2026-06-01): MGMT vCluster placement adds
-    # bp-mgmt-vcluster as a new edge — vc-mgmt Secret + the
-    # sync.toHost.customResources policy both materialise from that
-    # release before bp-gitea's helm-controller pivot can succeed.
-    depends_on: [bp-mgmt-vcluster, bp-keycloak, bp-gateway-api, bp-cnpg]
+    # G92.3 #2662 (2026-06-01): MGMT vCluster placement added
+    # bp-mgmt-vcluster — REVERTED by G105-followup (see slot 8 note).
+    depends_on: [bp-keycloak, bp-gateway-api, bp-cnpg]
     wave: present
   - slot: 11
     name: bp-powerdns


### PR DESCRIPTION
## Summary

- **Chart bump**: `bp-keycloak` 1.4.7 → 1.4.8
- **New template** `templates/postgresql-credentials.yaml` materialises a stable `keycloak-postgresql` Secret via Helm `lookup`-or-generate + `helm.sh/resource-policy: keep`, so password persists across HR uninstall while the postgres STS `volumeClaimTemplate` PVC also persists.
- **`values.yaml`** wires `keycloak.postgresql.auth.existingSecret = keycloak-postgresql` so the Bitnami postgres subchart consumes the catalyst-owned Secret instead of auto-generating a fresh password every install.

## Why (multi-layer RCA per Principle 16)

- **Trigger**: every `bp-keycloak` HR re-install regenerated the postgres password Secret. The STS PVC `data-keycloak-postgresql-0` is preserved across `helm uninstall` (k8s standard for STS volumeClaimTemplates), so the data dir keeps the OLD password. Keycloak then CrashLoopBackOffs with `FATAL: password authentication failed for user "keycloak"`.
- **Incident**: caught live on hw86 2026-06-01 — bp-keycloak HR install timed out, helm-controller triggered remediation = `helm uninstall`+`install`, and every retry regenerated a new password while the postgres PVC kept the old one. Cascade was deadlocked for 30+ min blocking `bp-gitea` / `bp-grafana` / `bp-harbor` / `bp-sso-bridge` / `bp-catalyst-platform`.
- **Defense (THIS PR)**: pin the password in a Catalyst-owned Secret with `helm.sh/resource-policy: keep` and reference it via `auth.existingSecret`. The Bitnami subchart accepts this and never auto-generates.
- **Containment**: manual PVC wipe via `kubectl scale sts → 0 / delete pvc / scale → 1`. Documented in memory `feedback_sso_manual_recovery_procedure.md`. Once this PR ships, manual containment is no longer needed for fresh provisions.

## Test plan

- [x] `helm template platform/keycloak/chart --set sovereignFQDN=test.omani.works` renders cleanly
- [x] Verified the rendered keycloak StatefulSet mounts password from `name: keycloak-postgresql, key: password`
- [ ] Fresh prov on a new HCS Sovereign — confirm bp-keycloak install converges without manual PVC wipe even after intentional HR re-install
- [ ] Operator-walk: navigate console.<sov-fqdn>, log in via PIN flow → reach /app/bp-grafana

## Refs

- Refs #2721
- Caught live on hw86: see [TRACKER row 2026-06-01 15:55Z](docs/ledger/TRACKER.md)
- Memory: `feedback_sso_manual_recovery_procedure.md` (the manual containment runbook this Defense fix obviates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)