### PR TITLE
feat(catalyst-ui): G113 — Sovereign SSO button on LoginPage (closes double-login gap)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/auth/LoginPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/LoginPage.tsx
@@ -16,6 +16,8 @@ import { Button } from '@/shared/ui/button'
 import { Input } from '@/shared/ui/input'
 import { API_BASE } from '@/shared/config/urls'
 import { sanitizeNextParam } from '@/app/auth-gate'
+import { DETECTED_MODE } from '@/shared/lib/detectMode'
+import { initiateLogin } from '@/shared/lib/oidc'
 
 type State = 'idle' | 'sending' | 'error'
 
@@ -168,6 +170,48 @@ export function LoginPage() {
           </div>
         )}
 
+        {/*
+          G113 #2725 (2026-06-02): on Sovereign mode, show the canonical
+          "Sign in with Sovereign SSO" button as the PRIMARY path. The
+          existing catalyst-ui Keycloak PKCE client is already registered
+          in the sovereign realm (bp-keycloak/templates/configmap-
+          sovereign-realm.yaml). initiateLogin() in shared/lib/oidc.ts
+          stores PKCE verifier in sessionStorage and 302s to
+          auth.<sov-fqdn>/realms/sovereign/protocol/openid-connect/auth.
+          After the operator signs in there ONCE, the Keycloak realm
+          cookie on auth.<sov-fqdn> is the canonical browser session —
+          every subsequent click into grafana/gitea/harbor/openbao
+          reuses it silently (no double-login).
+
+          The PIN form remains below as a fallback for (a) first-time
+          invitations where the operator's KC user record doesn't exist
+          yet, and (b) passwordless-recovery when the realm KC session
+          has expired and password-reset isn't available.
+
+          Catalyst-Zero mode (console.openova.io) keeps PIN as the only
+          path — there's no per-Sovereign Keycloak realm cookie to
+          carry into apps on that side.
+        */}
+        {DETECTED_MODE.mode === 'sovereign' && DETECTED_MODE.sovereignFQDN && (
+          <>
+            <Button
+              type="button"
+              size="lg"
+              className="mt-1 w-full"
+              data-testid="login-sso"
+              onClick={() => initiateLogin(DETECTED_MODE.sovereignFQDN!)}
+            >
+              Sign in with Sovereign SSO
+              <ArrowRight className="h-4 w-4" />
+            </Button>
+            <div className="my-2 flex items-center gap-3 text-[12px] text-[var(--color-text-dim)]">
+              <div className="h-px flex-1 bg-[var(--color-border)]" />
+              <span>or use a one-time PIN</span>
+              <div className="h-px flex-1 bg-[var(--color-border)]" />
+            </div>
+          </>
+        )}
+
         <form onSubmit={onSubmit} className="flex flex-col gap-4" noValidate>
           <Input
             label="Email"
@@ -183,6 +227,7 @@ export function LoginPage() {
 
           <Button
             type="submit"
+            variant={DETECTED_MODE.mode === 'sovereign' ? 'outline' : 'primary'}
             loading={state === 'sending'}
             disabled={state === 'sending' || !email.trim()}
             size="lg"


### PR DESCRIPTION
## Summary

On Sovereign mode (`DETECTED_MODE.mode === 'sovereign'`), the `LoginPage` now surfaces a primary **"Sign in with Sovereign SSO"** button above the PIN form. The button calls the already-existing `initiateLogin(sovereignFQDN)` helper from `shared/lib/oidc.ts` to start a PKCE flow against the already-registered `catalyst-ui` Keycloak client.

After the operator signs in at Keycloak ONCE, the KC realm session cookie on `auth.<sov-fqdn>` is the canonical browser session — every subsequent click into Grafana/Gitea/Harbor/OpenBao reuses it silently (no more username+password prompt at the second app).

## Why (G113 RCA)

Founder flagged 2026-06-02 ~08:10Z (#2725): after PIN-signing-in to `console.hw86`, clicking Grafana redirected through Keycloak and Keycloak asked for username+password AGAIN. Root cause: catalyst-api's `EnsureUser` is a server-side `client_credentials` grant — it never drops a KC session cookie in the operator's browser, so the per-app SSO redirect has no auth state to reuse.

This PR fixes that by putting the operator's browser through Keycloak directly, so the KC realm cookie lands and carries to all `*.<sov-fqdn>` apps.

## Changes

- `products/catalyst/bootstrap/ui/src/pages/auth/LoginPage.tsx` — add SSO button (gated on Sovereign mode) + import `DETECTED_MODE` + `initiateLogin`. PIN form retained as fallback (variant=`outline` to deemphasize on Sovereign mode).

## Pre-existing pieces wired together (no new helpers)

- `shared/lib/oidc.ts` `initiateLogin()` — already implemented (PKCE verifier + challenge + sessionStorage + 302 to KC).
- `shared/lib/oidc.ts` `handleCallback()` — already wired in `AuthCallbackPage.tsx` at `/auth/callback`.
- `bp-keycloak/templates/configmap-sovereign-realm.yaml` `catalyst-ui` client — already registered as `publicClient: true` PKCE with `redirectUris: ["https://console.{{ .Values.sovereignFQDN }}/*"]`.

## Test plan

- [x] `tsc --noEmit` PASSES (exit 0)
- [x] `vitest src/pages/auth/LoginPage.test.tsx` 9/9 tests pass
- [ ] Playwright walk on hw86: navigate to `https://console.hw86.omani.works/login`, confirm SSO button is rendered, click it → expect redirect to `https://auth.hw86.omani.works/realms/sovereign/protocol/openid-connect/auth?client_id=catalyst-ui&...` → enter creds → land on `https://console.hw86.omani.works/auth/callback?code=...` → handleCallback exchanges code → operator on `/console/dashboard`. Then click Grafana → expect SILENT redirect (no KC login prompt) → land authenticated.

## Refs

- Refs #2725 (G113 EPIC — the double-login gap)
- Refs #2646 (G91 — SSO end-to-end target state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)