### PR TITLE
fix(catalyst): G113-followup — derive OIDC issuer from SOVEREIGN_FQDN

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -492,6 +492,18 @@ func main() {
 	// install-order isn't a problem).
 	if os.Getenv("CATALYST_OIDC_PROVIDER_ENABLED") == "true" {
 		issuerURL := env("CATALYST_OIDC_PROVIDER_ISSUER_URL", "")
+		// G113-followup: chart used to template the issuer from
+		// .Values.sovereign.fqdn which is nil (the path doesn't exist
+		// in values.yaml — the real Sovereign FQDN arrives via the
+		// sovereign-fqdn ConfigMap on the SOVEREIGN_FQDN env). When
+		// CATALYST_OIDC_PROVIDER_ISSUER_URL is empty but SOVEREIGN_FQDN
+		// is set, derive `https://api.<fqdn>` here so the chart can
+		// drop the broken templated value entirely.
+		if issuerURL == "" {
+			if fqdn := os.Getenv("SOVEREIGN_FQDN"); fqdn != "" {
+				issuerURL = "https://api." + fqdn
+			}
+		}
 		clientSecret := os.Getenv("CATALYST_PIN_BROKER_CLIENT_SECRET")
 		if signer := h.GetHandoverSigner(); signer != nil && issuerURL != "" && clientSecret != "" {
 			oidcProv := &oidcprovider.Provider{

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -639,12 +639,14 @@ spec:
             # "env set but signer / issuer / secret missing").
             - name: CATALYST_OIDC_PROVIDER_ENABLED
               value: "true"
-            - name: CATALYST_OIDC_PROVIDER_ISSUER_URL
-              # api.<sov-fqdn> is the public origin where /oidc/* mounts
-              # (same HTTPRoute as /api/v1/*, see bootstrap/api/HTTPRoute
-              # in this chart). Empty on catalyst-zero — the gate above
-              # then short-circuits.
-              value: {{ printf "https://api.%s" .Values.sovereign.fqdn | quote }}
+            # CATALYST_OIDC_PROVIDER_ISSUER_URL intentionally omitted:
+            # main.go derives it from SOVEREIGN_FQDN (sovereign-fqdn
+            # ConfigMap, set later in this env list) — `https://api.<fqdn>`.
+            # The earlier `.Values.sovereign.fqdn` template was broken —
+            # no such Values path; rendered as `%!s(<nil>)` live, which
+            # was overridden via `kubectl set env` on hw86 (2026-06-02).
+            # On catalyst-zero SOVEREIGN_FQDN is empty so the OIDC routes
+            # short-circuit, matching the prior behaviour.
             - name: CATALYST_PIN_BROKER_CLIENT_ID
               value: "catalyst-pin"
             - name: CATALYST_PIN_BROKER_CLIENT_SECRET


### PR DESCRIPTION
## Summary
- Chart `api-deployment.yaml:647` used `.Values.sovereign.fqdn` which doesn't exist in `values.yaml` (only top-level `sovereignFQDN`). The literal env var rendered as `%!s(<nil>)` on the live hw86 prov, breaking the kcBrokerURL the catalyst-api OIDC provider emits in the PIN-verify response.
- Caught live 2026-06-02 ~08:30Z: PIN-login succeeded, but the browser was redirected to a malformed `https://api.%!s(<nil>)/...` URL. Mitigated live via `kubectl set env CATALYST_OIDC_PROVIDER_ISSUER_URL=https://api.hw86.omani.works` — this PR makes the fix durable so the next HelmRelease reconcile doesn't re-break SSO.

## Fix
- `cmd/api/main.go`: when `CATALYST_OIDC_PROVIDER_ISSUER_URL` is empty but `SOVEREIGN_FQDN` is set, derive `https://api.<fqdn>` at boot.
- chart `templates/api-deployment.yaml`: drop the broken `value: {{ printf "https://api.%s" .Values.sovereign.fqdn | quote }}` line in favour of the Go-side derivation. `SOVEREIGN_FQDN` is already wired into the same Deployment via the `sovereign-fqdn` ConfigMap (lines 853-858), so no new env plumbing is needed. On catalyst-zero (no ConfigMap) `SOVEREIGN_FQDN` is empty and the OIDC routes short-circuit — matches the previous gating behaviour.

## Test plan
- [ ] `helm template products/catalyst/chart --set sovereign.fqdn=foo` no longer emits the `%!s(<nil>)` env var line.
- [ ] On hw86, next HR reconcile keeps `CATALYST_OIDC_PROVIDER_ISSUER_URL` empty AND the catalyst-api log shows `oidc-provider: routes wired issuer=https://api.hw86.omani.works`.
- [ ] PIN→Grafana flow completes silently.

Refs #2725 #2727

🤖 Generated with [Claude Code](https://claude.com/claude-code)