### PR TITLE
fix(bp-keycloak): G113 #2725 — codify IDR defaultProvider for silent SSO

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -90,7 +90,7 @@ spec:
       # outer hook-wait accommodates the inner 15m availability window.
       # 1.4.3 (issue #129): bumped keycloakConfigCli.availabilityCheck.timeout
       # 120s → 600s + backoffLimit 1 → 5 (fresh-install wedge).
-      version: 1.4.8
+      version: 1.4.9
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.4.8
+  version: 1.4.9
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,5 +1,19 @@
 apiVersion: v2
 name: bp-keycloak
+# 1.4.9 (G113 #2725 followup, 2026-06-02): codify the runtime KC fix
+# discovered while debugging hw86 silent-SSO. The sovereign realm import
+# now ships `authenticatorConfig: [{alias: catalyst-pin-redirector,
+# config: {defaultProvider: catalyst-pin}}]` + an `authenticationFlows`
+# override on the `browser` flow that binds that config to the
+# `identity-provider-redirector` execution. Without this, even with
+# `kc_idp_hint=catalyst-pin` passed by each per-app SSO config, KC
+# silently fell through to the username/password form. Live evidence
+# 2026-06-02 12:08Z: 4-hop no-cookie SSO probe failed → POST
+# /admin/realms/sovereign/authentication/executions/{id}/config with the
+# same payload returned HTTP 201 → next probe verified 4-hop chain
+# end-to-end (Grafana → KC realm auth 303 → KC broker /catalyst-pin/login
+# 303 → catalyst-api /oidc/auth 303 → console /login 302 on no-cookie).
+# Refs #2725.
 # 1.4.8 (G112 #2721, 2026-06-01): postgresql.auth.existingSecret pivot —
 # new templates/postgresql-credentials.yaml materialises a stable
 # `keycloak-postgresql` Secret via lookup-or-generate +
@@ -10,7 +24,7 @@ name: bp-keycloak
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.4.8
+version: 1.4.9
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -400,6 +400,45 @@ data:
           }
         ]
       },
+      {{- /*
+      G113 #2725 followup (hw86 2026-06-02 12:08Z): the realm's default
+      "browser" authentication flow includes an "Identity Provider
+      Redirector" execution at level=0 ALTERNATIVE, but ships WITHOUT
+      an authenticationConfig bound — so even with `kc_idp_hint=catalyst-pin`
+      on the auth URL, KC silently falls through to the username/password
+      form. The runtime-only fix on hw86 was:
+        POST /admin/realms/sovereign/authentication/executions/<id>/config
+        {"alias":"catalyst-pin-redirector","config":{"defaultProvider":"catalyst-pin"}}
+      The codified equivalent in this realm import is the
+      `authenticatorConfig` array below + the matching
+      `authenticationFlows[].executions[].authenticatorConfig: catalyst-pin-redirector`
+      reference. KC's realm-import reader binds the config to the
+      execution by alias. Verify post-deploy via the 4-hop no-cookie
+      probe documented in TRACKER row 2026-06-02 12:08Z.
+      */ -}}
+      "authenticatorConfig": [
+        {
+          "alias": "catalyst-pin-redirector",
+          "config": {
+            "defaultProvider": "catalyst-pin"
+          }
+        }
+      ],
+      "authenticationFlows": [
+        {
+          "alias": "browser",
+          "description": "Default browser flow with catalyst-pin IdP auto-delegation (G113 #2725).",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": true,
+          "authenticationExecutions": [
+            { "authenticator": "auth-cookie", "requirement": "ALTERNATIVE", "priority": 10, "autheticatorFlow": false },
+            { "authenticator": "auth-spnego", "requirement": "DISABLED", "priority": 20, "autheticatorFlow": false },
+            { "authenticator": "identity-provider-redirector", "authenticatorConfig": "catalyst-pin-redirector", "requirement": "ALTERNATIVE", "priority": 25, "autheticatorFlow": false },
+            { "flowAlias": "forms", "requirement": "ALTERNATIVE", "priority": 30, "autheticatorFlow": true }
+          ]
+        }
+      ],
       "identityProviders": [
         {{- /*
         G113 #2725 Option B Step 4 (2026-06-02): register catalyst-api


### PR DESCRIPTION
## Summary
Codifies the runtime KC fix discovered while debugging hw86 silent-SSO (2026-06-02 12:08Z). The sovereign realm import now ships an `authenticatorConfig` + `authenticationFlows` override that binds the `identity-provider-redirector` execution to a `defaultProvider=catalyst-pin` config — without this, even with `kc_idp_hint=catalyst-pin` on every per-app SSO `auth_url`, KC silently rendered the username/password form.

## Pre-fix observation
The default browser flow's Identity Provider Redirector execution at level=0 ALTERNATIVE has NO `authenticationConfig` bound out of the box, so `kc_idp_hint` was ignored.

## Post-fix evidence (live on hw86 after manual POST of identical payload)
```
Hop 1: GET https://grafana.hw86.omani.works/login/generic_oauth → 302 → KC realm auth (with kc_idp_hint)
Hop 2: GET hop1 (cookie jar)                                    → 303 → /broker/catalyst-pin/login?session_code=...
Hop 3: GET hop2 (cookie jar)                                    → 303 → https://api.hw86.omani.works/oidc/auth?scope=...
Hop 4: GET hop3 (cookie jar, no catalyst_session)               → 302 → console /login?next=<encoded>
```
With a real PIN-issued `catalyst_session` cookie, Hop 4 mints a one-time code → KC realm session → all subsequent per-app SSO clicks silent.

## Lockstep
- `platform/keycloak/chart/Chart.yaml`: 1.4.8 → 1.4.9
- `platform/keycloak/blueprint.yaml`: 1.4.8 → 1.4.9
- `clusters/_template/bootstrap-kit/09-keycloak.yaml`: pin 1.4.8 → 1.4.9

## Test plan
- [ ] `helm template platform/keycloak/chart --set sovereignFQDN=hw86.omani.works` renders realm JSON cleanly (parsed: `authenticatorConfig` + `authenticationFlows[browser]` + `identityProviders[catalyst-pin]` all present)
- [ ] Fresh prov: `POST /admin/realms/sovereign/authentication/flows/browser/executions` shows IDR with `authenticationConfig` bound (no manual POST needed)
- [ ] 4-hop SSO probe completes the chain without falling through to KC login form

Refs #2725 #2727 #2729

🤖 Generated with [Claude Code](https://claude.com/claude-code)