### PR TITLE
fix(catalyst): G113-followup — stop emitting broken kcBrokerURL (KC rejects with Invalid Request)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -767,17 +767,29 @@ func (h *Handler) HandlePinVerify(w http.ResponseWriter, r *http.Request) {
 		"expires_in", cookieMaxAge,
 	)
 
-	// G113 #2725 Option B Step 3: if the OIDC provider is enabled,
-	// compute the KC identity-broker URL so catalyst-ui can navigate
-	// the browser through the brokered OIDC flow. After that one-time
-	// roundtrip, auth.<sov-fqdn> holds the realm session cookie and
-	// every subsequent per-app SSO redirect is silent.
+	// G113 #2725 followup (hw86 2026-06-02 20:35Z): the kcBrokerURL
+	// plumbing originally introduced in PR #2727 emitted a URL of the
+	// form `/realms/<realm>/broker/<alias>/login?kc_idp_hint=...` which
+	// Keycloak REJECTS as `invalidRequestMessage` on direct invocation
+	// (that endpoint is session-scoped — needs session_code/client_id/
+	// tab_id from an active KC auth flow). Live evidence from hw86 KC
+	// log: `IDENTITY_PROVIDER_LOGIN_ERROR error="invalidRequestMessage"
+	// identity_provider="catalyst-pin"` when catalyst-ui hard-navigated
+	// the user there post-PIN.
+	//
+	// With the bp-keycloak realm import now binding the Identity
+	// Provider Redirector execution to `defaultProvider=catalyst-pin`
+	// (PR #2730), the realm-session bootstrap happens naturally on the
+	// FIRST per-app SSO redirect (Grafana/Gitea/Harbor/OpenBao) — KC
+	// auto-delegates to catalyst-pin IdP which finds the catalyst_session
+	// cookie set by PIN verify, mints a code, and KC drops the realm
+	// session cookie. No separate pre-flight broker call needed.
+	//
+	// Returning empty `KCBrokerURL` makes catalyst-ui's VerifyPinPage
+	// skip the (broken) hard-navigation and proceed to /dashboard. The
+	// field stays in the JSON shape (omitempty) so a stale catalyst-ui
+	// image that still checks for it continues to work.
 	resp := pinVerifyResponse{OK: true}
-	if os.Getenv("CATALYST_OIDC_PROVIDER_ENABLED") == "true" {
-		if brokerURL := buildKCBrokerURL(r); brokerURL != "" {
-			resp.KCBrokerURL = brokerURL
-		}
-	}
 
 	writeJSON(w, http.StatusOK, resp)
 }


### PR DESCRIPTION
## Summary
On hw86 2026-06-02 20:35Z, founder hit `console.hw86.omani.works` post-PIN and got Keycloak's "Invalid Request" error page. Live KC log:

\`\`\`
WARN [org.keycloak.events] type="IDENTITY_PROVIDER_LOGIN_ERROR"
     realmName="sovereign" clientId="null" userId="null"
     ipAddress="5.21.76.248" error="invalidRequestMessage"
     identity_provider="catalyst-pin"
ERROR [org.keycloak.services.resources.IdentityBrokerService] invalidRequestMessage
\`\`\`

## Root cause
PR #2727's `buildKCBrokerURL` emits:
\`\`\`
https://auth.<fqdn>/realms/<realm>/broker/<alias>/login?kc_idp_hint=...&redirect_uri=...
\`\`\`

That endpoint is **session-scoped** in KC — it requires `session_code` + `client_id` + `tab_id` query params populated ONLY mid-flow by KC itself. Direct invocation (which is what catalyst-ui does via `window.location.replace(body.kcBrokerURL)`) → KC rejects as `invalidRequestMessage`.

## Fix
- `HandlePinVerify` no longer sets `resp.KCBrokerURL`. The field stays in the response shape (omitempty) for forward-compat with already-deployed catalyst-ui images that look for it.
- VerifyPinPage's existing branch `if (body.kcBrokerURL) { window.location.replace(...) }` is now a no-op (kcBrokerURL absent) → falls through to `/dashboard` normally.
- The realm-session bootstrap happens naturally on first per-app SSO click via the Identity Provider Redirector (PR #2730 just merged).

## Test plan
- [ ] PIN-login on hw86 → catalyst_session cookie set → land on /dashboard (no KC "Invalid Request")
- [ ] Click Grafana → KC auth_url → IDR delegates to catalyst-pin IdP → catalyst-api /oidc/auth sees catalyst_session → mints code → KC drops realm session → silent SSO ✓
- [ ] Same for Gitea / Harbor / OpenBao
- [ ] Fresh prov walk per #636 task

Refs #2725 #2727 #2730

🤖 Generated with [Claude Code](https://claude.com/claude-code)