### PR TITLE
fix(bp-openbao): G111-followup — emit recovery-seed via data: not stringData: (#2718)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -77,7 +77,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.21
+      version: 1.2.22
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.2.21
+  version: 1.2.22
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -4,7 +4,7 @@ name: bp-openbao
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.2.21
+version: 1.2.22
 # 1.2.20 (G91.openbao #2655, 2026-05-31): opt in to the bp-sso-bridge
 # (G91.1 #2652) SSO framework. Top-level `sso:` block (defaults
 # enabled=true). Adds: templates/sso-oauth-source-externalsecret.yaml

--- a/platform/openbao/chart/templates/recovery-seed-bootstrap.yaml
+++ b/platform/openbao/chart/templates/recovery-seed-bootstrap.yaml
@@ -25,14 +25,26 @@ Refs #2697 (G105 cascade — this gap surfaced during the cascade walk).
 {{- $name := $seedSecret.name | default "openbao-recovery-seed" -}}
 {{- $key := $seedSecret.key | default "recovery-seed" -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $name -}}
-{{- $value := "" -}}
+{{- $valueB64 := "" -}}
 {{- if $existing -}}
-  {{- /* Re-emit existing value byte-for-byte. */ -}}
-  {{- $value = index $existing.data $key | default "" | b64dec -}}
+  {{- /*
+  Re-emit the existing base64-encoded value byte-for-byte. CRITICAL: do
+  NOT b64dec here — the underlying recovery seed (random raw bytes
+  written by `bao operator init`) CANNOT round-trip through YAML
+  `stringData:` (YAML refuses control characters in strings).
+  Live evidence from hw86 2026-06-01 22:12Z: HR Ready=False with
+  `yaml: control characters are not allowed` because the prior template
+  version decoded the value, then re-emitted into stringData. Fix: keep
+  the value base64-encoded throughout and emit into the Secret's `data:`
+  field (already base64 — YAML-safe by definition).
+  */ -}}
+  {{- $valueB64 = index $existing.data $key | default "" -}}
 {{- end -}}
-{{- if not $value -}}
-  {{- /* Fresh install OR existing Secret lacks the expected key — seed it. */ -}}
-  {{- $value = randAlphaNum 64 -}}
+{{- if not $valueB64 -}}
+  {{- /* Fresh install OR existing Secret lacks the expected key — seed it.
+     randAlphaNum 64 produces 64 ASCII alphanumeric chars; base64-encode
+     for the data: field below. */ -}}
+  {{- $valueB64 = randAlphaNum 64 | b64enc -}}
 {{- end }}
 ---
 apiVersion: v1
@@ -53,5 +65,5 @@ metadata:
     app.kubernetes.io/component: recovery-seed
     catalyst.openova.io/component: openbao-recovery-seed
 type: Opaque
-stringData:
-  {{ $key }}: {{ $value | quote }}
+data:
+  {{ $key }}: {{ $valueB64 }}


### PR DESCRIPTION
## Summary
Live evidence on hw86 (2026-06-01 22:12Z): `bp-openbao` HR Ready=False with `yaml: control characters are not allowed` because PR #2724's recovery-seed template emitted decoded random bytes into `stringData:` field.

```
Helm upgrade failed for release openbao/openbao with chart bp-openbao@1.2.21:
  error while running post render on files:
  ...stringData:{"recovery-seed":"°ä µ+edϺô\x11\x12ÝDt..."}:
  yaml: control characters are not allowed
```

The underlying recovery seed (32 random raw bytes written by `bao operator init`) CANNOT round-trip through YAML `stringData:` — YAML refuses control characters in strings.

## Fix
- **Keep base64 encoded throughout**: lookup path returns the existing `data[<key>]` value as-is (already base64); no b64dec.
- **Emit via `data:` field** which expects base64 (always YAML-safe by definition).
- **Fresh-install path** base64-encodes the `randAlphaNum 64` ASCII output for consistency.

helm template renders cleanly:
```yaml
type: Opaque
data:
  recovery-seed: ODliS2RxRWRzbUFqSTVDSXJJN21xWTVBRUFhbXJqMVpBZ1pYQVQybkY5N0FqOE9aSWw4ZTJNRkhjS2tIWTlleQ==
```

## Lockstep
- `platform/openbao/chart/Chart.yaml`: 1.2.21 → 1.2.22
- `platform/openbao/blueprint.yaml`: 1.2.21 → 1.2.22
- `clusters/_template/bootstrap-kit/08-openbao.yaml`: pin 1.2.21 → 1.2.22

## Test plan
- [ ] `helm template platform/openbao/chart` renders Secret with `data: recovery-seed: <base64>`
- [ ] Fresh install on a Sovereign reconciles bp-openbao HR to Ready=True
- [ ] Upgrade on hw86 (existing 32-byte raw recovery seed in Secret) reconciles cleanly without yaml control-char error
- [ ] `bao operator generate-root` still finds the recovery-seed value (b64-encoded round-trip is transparent to the consumer that does its own base64 decode)

Refs #2718 #2724

🤖 Generated with [Claude Code](https://claude.com/claude-code)