### PR TITLE
fix(bp-keycloak): G113 #2725 Bug-6 — codify first-broker-login auto-link (bypass SMTP)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -90,7 +90,12 @@ spec:
       # outer hook-wait accommodates the inner 15m availability window.
       # 1.4.3 (issue #129): bumped keycloakConfigCli.availabilityCheck.timeout
       # 120s → 600s + backoffLimit 1 → 5 (fresh-install wedge).
-      version: 1.4.10
+      # 1.4.11 (G113 #2725 Bug-6, 2026-06-02): realm import adds the
+      # `first broker login auto link` custom flow + switches catalyst-pin
+      # IdP's firstBrokerLoginFlowAlias to it — bypasses KC SMTP for
+      # first-broker-login email-collision handling on Sovereigns whose
+      # KC SMTP is not yet wired.
+      version: 1.4.11
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.10
+  version: 1.4.11
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,5 +1,18 @@
 apiVersion: v2
 name: bp-keycloak
+# 1.4.11 (G113 #2725 Bug-6 codification, 2026-06-02): codify the runtime
+# pre-link workaround for KC first-broker-login flow. The default flow
+# fires `idp-confirm-link` (REQUIRED) + `Verify Existing Account by Email`
+# whenever the federated catalyst-pin user collides by email with an
+# existing realm user — both steps require KC SMTP. On Sovereigns whose
+# KC SMTP is not yet wired up the broker callback hangs. Runtime
+# workaround on hw86 was per-user POST /admin/realms/sovereign/users/
+# {id}/federated-identity/{alias} (HTTP 204) — manual pre-link. Codified
+# equivalent: a new custom top-level authentication flow `first broker
+# login auto link` with only `idp-create-user-if-unique` (ALT) +
+# `idp-auto-link` (ALT). The catalyst-pin IdP's firstBrokerLoginFlowAlias
+# now points at it; trustEmail=true (already set) makes the auto-link
+# trigger on email match WITHOUT any SMTP or user prompt. Refs #2725.
 # 1.4.10 (G117.5 #2744, 2026-06-02): Tier-1 silent-SSO clients codified
 # in the sovereign realm-import. New entries appended to clients[]:
 #   - grafana       (redirectUris: https://grafana.<sov-fqdn>/*)
@@ -40,7 +53,7 @@ name: bp-keycloak
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.4.10
+version: 1.4.11
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -618,6 +618,36 @@ data:
             { "authenticator": "identity-provider-redirector", "authenticatorConfig": "catalyst-pin-redirector", "requirement": "ALTERNATIVE", "priority": 25, "autheticatorFlow": false },
             { "flowAlias": "forms", "requirement": "ALTERNATIVE", "priority": 30, "autheticatorFlow": true }
           ]
+        },
+        {{- /*
+        G113 #2725 Bug-6 codification (hw86 2026-06-02): KC's DEFAULT
+        "first broker login" flow runs `idp-confirm-link` (REQUIRED) +
+        `Verify Existing Account by Email` (ALTERNATIVE) whenever the
+        federated user collides with an existing realm user by email.
+        Both steps require a working SMTP relay; on Sovereigns where KC
+        SMTP is not yet wired they 500 with "Failed to send email" and
+        the broker callback hangs. Runtime workaround on hw86 was
+        POST /admin/realms/sovereign/users/{id}/federated-identity/{alias}
+        (HTTP 204) per IdP user — manual pre-linking.
+
+        Codified equivalent below: a custom top-level flow with ONLY
+        two ALTERNATIVE executions — create-user-if-unique then
+        idp-auto-link. With trustEmail=true on the catalyst-pin IdP
+        (set further down) KC auto-links the federated identity to an
+        existing realm user by email match WITHOUT prompting the user
+        or sending any email. The IdP's firstBrokerLoginFlowAlias
+        below points at this flow.
+        */ -}}
+        {
+          "alias": "first broker login auto link",
+          "description": "G113 #2725: auto-link federated identity to existing realm user by email match without SMTP confirmation. Used by catalyst-pin IdP.",
+          "providerId": "basic-flow",
+          "topLevel": true,
+          "builtIn": false,
+          "authenticationExecutions": [
+            { "authenticator": "idp-create-user-if-unique", "requirement": "ALTERNATIVE", "priority": 10, "autheticatorFlow": false },
+            { "authenticator": "idp-auto-link", "requirement": "ALTERNATIVE", "priority": 20, "autheticatorFlow": false }
+          ]
         }
       ],
       "identityProviders": [
@@ -656,7 +686,7 @@ data:
           "addReadTokenRoleOnCreate": false,
           "authenticateByDefault": false,
           "linkOnly": false,
-          "firstBrokerLoginFlowAlias": "first broker login",
+          "firstBrokerLoginFlowAlias": "first broker login auto link",
           "config": {
             "clientId": "catalyst-pin",
             {{- /*


### PR DESCRIPTION
## Summary

Bug-6 of the G113 silent-SSO 6-bug cascade (`Refs #2725`). Codifies the runtime per-user pre-link workaround that hw86 needed because KC's default `first broker login` flow requires SMTP whenever the federated catalyst-pin user collides with an existing realm user by email.

## What this PR ships

1. **New custom KC authentication flow `first broker login auto link`** in the sovereign realm import (`platform/keycloak/chart/templates/configmap-sovereign-realm.yaml`):
   - `idp-create-user-if-unique` — ALTERNATIVE, priority 10
   - `idp-auto-link` — ALTERNATIVE, priority 20
   - No `idp-confirm-link`, no `Verify Existing Account by Email`, no user prompt, **no SMTP dependency**.

2. **catalyst-pin IdP `firstBrokerLoginFlowAlias`** switched from the built-in `"first broker login"` to the new `"first broker login auto link"`. With `trustEmail=true` (already set on the IdP per PR #2730) KC will auto-link the federated identity to any existing realm user by email match WITHOUT prompting or sending email.

3. **Lockstep version bumps**:
   - `platform/keycloak/chart/Chart.yaml` 1.4.9 → 1.4.10
   - `platform/keycloak/blueprint.yaml` 1.4.9 → 1.4.10
   - `clusters/_template/bootstrap-kit/09-keycloak.yaml` 1.4.9 → 1.4.10

## Why

`#2725` independent verdict (sub-agent `a07cf8a43bcd546a0`) called Bug-6 out as the only G113 cascade bug without a codifying PR. Without this change, every fresh-prov of a Sovereign whose KC SMTP isn't wired up will silent-SSO fail at the first broker callback that collides on email — exactly the symptom hw86 hit. Runtime workaround was per-user admin-API `POST /admin/realms/sovereign/users/{id}/federated-identity/{alias}` — operationally fragile.

## Test plan

- [ ] CI helm-lint passes (no schema breakage on the new flow JSON)
- [ ] CI chart-publish bumps `bp-keycloak:1.4.10` to GHCR
- [ ] Fresh-prov walk on a Sovereign with KC SMTP intentionally unwired: PIN-verify → click Grafana → 4-hop SSO completes silently without the "Failed to send email" KC log line
- [ ] Verify on hw86 by removing the manual federated-identity pre-link for the test account, redeploying with chart 1.4.10, re-walking SSO

Refs #2725.

🤖 Generated with [Claude Code](https://claude.com/claude-code)