### PR TITLE
feat(g117): Wave-0 pre-flight — agent briefs + contracts + ci gates

### DIFF
--- a/.claude/templates/G117-agent-brief.md
+++ b/.claude/templates/G117-agent-brief.md
@@ -1,0 +1,238 @@
+# G117 — sub-EPIC agent briefing template
+
+> Source: produced by G117 Wave-0 (`feat/g117-wave-0-preflight`, PR linked from issue #2738). Every Wave-1 (and beyond) agent receives a substitution of this template with the per-sub-EPIC fields filled in. **Do not edit the template inline for one-off dispatches** — instead, copy it into the dispatch briefing and fill the `{{var}}` slots.
+
+---
+
+## Identity
+
+| Field | Value |
+|---|---|
+| **Sub-EPIC ID** | `{{sub_epic_id}}` (e.g. `G117.1`) |
+| **Tracking issue** | https://github.com/openova-io/openova/issues/{{issue_number}} |
+| **Parent EPIC** | #2737 |
+| **Wave** | `{{wave_id}}` (e.g. `Wave-1`) |
+| **Slot** | `{{slot_id}}` (e.g. `B1` — see `.claude/templates/G117-worktree-policy.md`) |
+| **Dispatched by** | {{dispatcher_handle}} |
+| **Worktree isolation** | `{{isolation}}` (`worktree` if Wave-1 slot touches `platform/*/blueprint.yaml` or `platform/keycloak/chart/templates/configmap-*-realm.yaml`; else `none`) |
+
+## Wave dependencies — what you consume
+
+You may consume ONLY artifacts produced by Wave-0 (or earlier-Wave-N sub-EPICs explicitly listed below). Touching files outside your file-touch matrix row is a cross-wave contract breach → STOP and reach out per the Escalation protocol.
+
+- `core/pkg/apis/blueprint/v1alpha1/topology_types.go` — Go types
+- `core/controllers/pkg/apis/blueprint/v1alpha1/topology_types.go` — same types as a controllers-importable mirror
+- `platform/_schemas/blueprint-topology.json` — JSON-schema gate
+- `examples/blueprint-grafana-fully-declared.yaml` — reference
+- `docs/api/catalyst-api-openapi.yaml` — REST contract
+- `products/catalyst/console/src/routes/**/+page.svelte` — UI scaffolds
+- `products/catalyst/console/tests/e2e/fixtures/mock-blueprints.yaml` — mock fixtures
+- `docs/adr/0009-per-org-iac-repo-bootstrap.md` — IaC repo decision
+- `tools/bootstrap-org-iac-repo.sh` — bootstrap script
+- `tools/migrate-blueprints-topology.py` — Blueprint topology migration tool
+- Wave-1 prior-slot artifacts: `{{wave_1_prior_artifacts_or_none}}`
+
+## Acceptance DoD (locked per sub-EPIC, do not relax)
+
+{{acceptance_dod_checklist}}
+
+Each item below MUST evaluate true before you report done:
+
+- [ ] One PR titled `{{pr_title}}` opened against `main`, body cites `Refs #{{issue_number}}` (NEVER `Closes`)
+- [ ] PR diff scope is exactly your file-touch matrix row (no out-of-scope edits; no formatting churn outside)
+- [ ] Unit tests added for every new function/method (Go: `*_test.go`; TS/JS: `*.spec.ts`)
+- [ ] Integration tests added if the work crosses a service boundary
+- [ ] Playwright spec added if the work touches a UI surface, named `{{playwright_spec_name}}` under `tests/e2e/playwright/tests/` or `products/catalyst/console/tests/e2e/`
+- [ ] Docs update — at minimum `docs/STATUS.md` row + relevant section of `docs/ARCHITECTURE.md` / `docs/RUNBOOKS.md`
+- [ ] Memory updates — if you discovered a non-obvious gotcha, ship `feedback_<topic>.md` under `~/.claude/projects/-home-openova-repos-openova/memory/` and add the index entry in `MEMORY.md` IN THE SAME PR
+- [ ] New architectural choices not in the locked-decisions list → ship as new `docs/adr/00XX-<topic>.md` (numbered after the latest existing ADR)
+- [ ] `docs/ledger/TRACKER.md` row for this sub-EPIC updated
+- [ ] `gh pr checks` all green
+- [ ] Self-verification evidence posted as a comment on the tracking issue (curl outputs, screenshot of green checks, Playwright report URL)
+- [ ] Verifier sub-agent verdict posted on the tracking issue (you spawn it; it reports `status/uat-OK` or `status/uat-FAIL`)
+- [ ] If `uat-OK`: move the issue label from `status/in-progress` to `status/uat`. **Operator (NOT you) flips to `status/completed`.**
+
+## Self-verification protocol
+
+You self-verify before claiming done. The verifier sub-agent is a second pair of eyes — it does NOT replace your own checks.
+
+1. **Build/lint pass locally**
+   - Go: `cd <module-dir> && go build ./... && go vet ./... && go test ./...`
+   - JS/TS: `npm run build && npm test` (or per the package.json `scripts`)
+   - OpenAPI: `spectral lint <path> --ruleset spectral:oas` — 0 errors (warnings ok if you justify)
+   - JSON schema: `python3 -c "import json,jsonschema; jsonschema.validate(yaml.safe_load(open(X)), json.load(open(schema)))"`
+   - Helm chart: `helm lint <chart>` + `helm template <chart> | wc -l > 5` (guards against hollow-chart per `feedback_hollow_chart_dual_annotation.md`)
+
+2. **Post evidence**
+   - At minimum a fenced block with the last 20 lines of EACH command + `exit=0`
+   - For UI work: screenshot URL + Playwright report URL
+   - For chart work: `helm template` excerpt showing rendered resources
+
+3. **Run the issue checklist top-to-bottom** and tick each box manually in a PR comment
+
+4. **Spawn a verifier sub-agent** with this prompt template:
+
+   ```
+   You are an INDEPENDENT verifier for {{sub_epic_id}} (PR <URL>).
+   READ-ONLY mode — you may NOT push commits or close issues.
+   Tasks:
+     1. Pull the branch and re-run the build/lint suite from the brief
+     2. Apply each acceptance DoD checkbox to the diff; flag missing items
+     3. Apply the anti-theater red-flag list (see below) — return verdict
+        even if all checks pass but a red flag is present
+     4. Post one comment on issue #{{issue_number}} with:
+        - PASS or FAIL verdict
+        - Per-checkbox PASS/FAIL
+        - Red-flag findings (PR-#NNNN-style references)
+        - Recommended status/* label transition
+   ```
+
+## Failure-mode decision tree
+
+Stuck > 30 minutes on the same error:
+
+1. **Re-read memory** — `cat ~/.claude/projects/-home-openova-repos-openova/memory/MEMORY.md` and grep for keywords matching your sub-EPIC theme
+2. **Spawn a verifier sub-agent** with fresh eyes
+3. **If verifier confirms blocker**, call `chepherd.alert_human` with `kind=stuck`, `urgency=medium`, body = verbatim error + last 50 lines of context + your hypothesis
+4. **Do NOT silently abandon, do NOT ship partial, do NOT claim done**
+
+## Anti-theater rules (verbatim — fold into your own self-check)
+
+Red flags that EITHER you or the verifier MUST surface:
+
+- `Closes #N` in PR body when only this sub-EPIC is being shipped (NEVER auto-close from PR merge — only the operator closes after the walk)
+- Null-guards on data that can never be null (PR #1185 shape)
+- `enabled: false` defaults on features the deterministic test asserts present (PR #1138 shape)
+- Click handlers missing on leaf cells (PR #1085 shape)
+- Scaffold-only PRs with `Closes #N` and no operator-visible behavior change (PR #1918 shape)
+- `kubectl --dry-run=server` as the sole validator on chart work (PR #1933 shape)
+- Multi-region claim on a single-region prov (PR #1599 shape)
+- `must_contain` token-passing tests (PR #1362/#1366/#1371/#1378 shape)
+- Python `jsonencode()` simulation passed off as `tofu validate` (PR #1892 shape)
+- `Refs #N` is the default in PR bodies, not `Closes #N`. Auto-close is the enemy.
+
+## Commit signature
+
+```bash
+git -c user.name=hatiyildiz \
+    -c user.email=269457768+hatiyildiz@users.noreply.github.com \
+    commit -s -m "$(cat <<'EOF'
+{{conventional_subject}}
+
+{{commit_body}}
+
+Refs #{{issue_number}}
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+- Conventional commit type from `{feat, fix, docs, chore, refactor, test}`
+- `-s` (sign-off) required
+- `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` trailer REQUIRED
+- Default identity: `hatiyildiz` — switch to `alierenbaysal` ONLY when the operator directs
+
+## Banned terms
+
+Single source of truth: [`docs/GLOSSARY.md`](../../docs/GLOSSARY.md) §Banned-terms.
+
+Frequent offenders: `tenant` → `Organization` · `operator` (as a person) → `sovereign-admin` · `client` → `User` · `module`/`template` (in Catalyst sense) → `Blueprint` · `Workspace` → `Environment` · `Instance` (user-facing) → `Application` · `Synapse` (OpenOva product) → `Axon` · `Backstage` → `Catalyst console`.
+
+## Test domains canon (NEVER `openova.io` in tests)
+
+| Surface | Domain pattern | Notes |
+|---|---|---|
+| Test Sovereign | `t<NN>.omani.works` | swap to `t<NN>.omantel.biz` if LE-rate-limited |
+| Tenant Organization | `<orgslug>.omani.homes` (default) | also `omani.rest`, `omani.trade` |
+| Voucher redeem URL | `https://marketplace.t<NN>.omani.works/redeem/?code=<CODE>` | BSS menu, NOT `admin.<sov>` |
+| Mothership | `console.openova.io` | only for real-mothership work, NEVER in tests |
+
+## CRITICAL safety rules
+
+### NEVER touch `emrah.baysal` email creds
+
+- No `POST` / `PUT` / `DELETE` to `mail.openova.io` admin API
+- No write to any `password` / `SMTP_PASS` / `IMAP_PASSWORD` Secret
+- Diagnostic READ-ONLY OK. If broken → ask operator; never rotate
+- Memory ref: `feedback_never_touch_emrah_baysal_email.md`
+
+### Canonical wipe endpoint for any destructive op
+
+- `POST https://console.openova.io/sovereign/api/v1/deployments/{id}/wipe` — runs `tofu destroy` + cleans Hetzner servers + LBs + S3 bucket + DNS records atomically
+- Never raw `hcloud server delete` for shared infra
+- Memory ref: `feedback_canonical_wipe_endpoints.md`
+
+## Pre-flight checklist (run BEFORE acting)
+
+| Operation | Mandatory pre-flight |
+|---|---|
+| **Wipe any Sovereign or namespace** | (1) PVC debug-Pod read of every `tofu.auto.tfvars.json` (2) Hetzner servers list (3) per-target table (4) **ask operator which rows wipeable** (5) only on confirmation use canonical wipe endpoint |
+| **Claim a credential is missing** | (1) enumerate `/deps/tofu/*/tofu.auto.tfvars.json` on `catalyst-api-deployments` PVC (2) enumerate `/deps/kubeconfigs/` (3) check Stalwart admin creds (4) only then claim missing |
+| **Provision fresh Sovereign** | (1) `gh api /repos/openova-io/openova/packages/container/<bp-*>/versions` for active chart pins (2) pick `parent_domains_yaml` TLD per LE rotation (3) POST `/sovereign/api/v1/deployments` with auth |
+| **Dispatch a sub-agent** | (1) pre-dispatch briefing per user-global §5 (2) pillar+step grounding test (3) `isolation: worktree` if parallel + touching same files (4) re-query live state after return |
+| **Believe something is "fixed"** | (1) re-query live state directly (`kubectl` / `curl` / `gh`) (2) cite specific evidence (3) operator closes issues — NOT you |
+| **File a new TBD** | (1) does this gap block the next pillar walk? if no, note in audit doc only (2) cite canonical doc reference (3) use `Refs #N` not `Closes #N` |
+
+## Resource budgets (hard caps)
+
+- GitHub API: **200 req per dispatch** (5000/h ÷ ~24 dispatches)
+- GHCR pushes: serialize via `flock /tmp/ghcr-push.lock` if 2+ agents publish concurrently
+- hw86 catalyst-api: max **10 parallel API calls** per agent
+- Playwright spec runs: **sequential per agent's spec set** (parallel only across agents)
+- Bastion memory: **1.5 GiB max RSS per agent** (6 agents × 1.5GiB = 9GiB ceiling)
+- If you blow a budget: STOP, lower concurrency, retry. Don't tight-loop.
+
+## Memory + ADR discipline (mandatory)
+
+1. **Read `MEMORY.md` first** — `cat ~/.claude/projects/-home-openova-repos-openova/memory/MEMORY.md`
+2. **Grep for keywords matching your sub-EPIC title** in the memory dir
+3. **When you discover a gotcha that's not yet in memory**, ship a new `feedback_<topic>.md` + index entry **in the same PR** (not as a follow-up — same PR)
+4. **Every new architectural choice not in the locked-decisions list** ships as a new ADR under `docs/adr/`
+5. **Update `docs/ledger/TRACKER.md`** row for your sub-EPIC at PR open + at PR merge
+
+## Escalation & rollback
+
+| Trigger | Action |
+|---|---|
+| Stuck >30 min on same error | Spawn verifier sub-agent FIRST (fresh eyes) |
+| Verifier confirms blocker | `chepherd.alert_human` kind=stuck, urgency=medium, body=verbatim error + 50 lines context |
+| Bad PR breaks Wave-1 contract | Revert is allowed and EXPECTED — don't fix-forward when the data shape is wrong |
+| Cross-wave contract breakage detected | STOP all downstream agents until restored |
+| Anthropic rate-limit | Run `/home/openova/bin/anthropic-rate-limit-trip.sh` (5-min hold + 30-min cron retry) — see `feedback_anthropic_rate_limit_overnight_survival.md` |
+
+---
+
+## Locked architectural decisions (do NOT re-debate)
+
+1. Blueprint topology shape: `spec.topology.{supported[], defaults{multi-region, single-region}, perTopology{<choice>{replication, switchover, placement}}}`
+2. bcpTopology enum: `active-active | active-hot-standby | active-passive | singleton`
+3. Launch button SSO: silent OIDC `prompt=none&kc_idp_hint=catalyst-pin`, new tab, <500ms target
+4. Endpoint mutation: PR + auto-merge against `gitea.<sov>/<org>/iac` with Kyverno + cert-mgr + DNS-conflict pre-check
+5. SSO fan-out scope: Tier-1 (4) + Tier-2 (4) + Tier-3 (9+) = ALL SSO-capable apps
+6. Tier-3 KC realm: per-Org realm has "Keycloak OIDC" IdP federated to `sovereign` realm broker (2-hop)
+7. Default topology detection: `len(Sovereign.spec.regions) > 1` = multi-region; else single-region
+
+---
+
+> **Per-sub-EPIC substitution sheet (fill before dispatch):**
+>
+> ```yaml
+> sub_epic_id: G117.X
+> issue_number: NNNN
+> wave_id: Wave-N
+> slot_id: <letter><digit>
+> dispatcher_handle: p0-474-lonely
+> isolation: worktree|none
+> wave_1_prior_artifacts_or_none: (list)
+> pr_title: feat(g117.X): <one-line>
+> playwright_spec_name: g117-<topic>.spec.ts
+> conventional_subject: feat(g117.X): <one-line>
+> commit_body: |
+>   <para 1 — why>
+>   <para 2 — what>
+> acceptance_dod_checklist: |
+>   - [ ] criterion 1
+>   - [ ] criterion 2
+>   - [ ] criterion 3
+> ```

--- a/.claude/templates/G117-worktree-policy.md
+++ b/.claude/templates/G117-worktree-policy.md
@@ -1,0 +1,108 @@
+# G117 — worktree isolation policy + per-wave file-touch matrix
+
+> Produced by Wave-0 (PR linked from #2738). Binding for every Wave-1+ dispatch. Disregarding this policy causes the chart-version-collision class of failures captured in `feedback_chart_version_collision_serialize_or_rebase.md`.
+
+## Rules
+
+1. **One worktree per agent when 2+ agents touch the SAME file.** Each worker checks out a fresh `git worktree add ../openova-g117-<slot> feat/g117-<slot>-<scope>` so their per-file edits don't clobber on a shared branch.
+2. **No `isolation: worktree`** for slots that touch DISJOINT files. The overhead isn't free; spend it only when collision risk is real.
+3. **Serialize (NOT parallelize)** when 2+ agents must touch a SINGLE file (e.g. `core/controllers/pkg/apis/blueprint/v1alpha1/topology_types.go`).
+4. **Pre-flight per agent**, ALWAYS:
+   ```bash
+   git fetch origin main
+   git pull --rebase origin main
+   # "latest" for a file ALWAYS comes from git show origin/main:<path>
+   git show origin/main:platform/grafana/blueprint.yaml > /tmp/baseline.yaml
+   # NEVER use a remembered value from a prior conversation turn.
+   ```
+5. **Chart-version lockstep**: Chart.yaml + blueprint.yaml + bootstrap-kit slot pin MUST all bump in the same PR. If you touch one, you touch all three (per `feedback_chart_version_collision_serialize_or_rebase.md`).
+
+## File-touch matrix — Wave-1 (6 parallel agents)
+
+| Slot | Sub-EPIC | Touches | Reads (no write) | Isolation |
+|---|---|---|---|---|
+| **B1** | G117.1 — Blueprint schema extension | `core/controllers/blueprint/internal/validate/*.go`, `platform/_schemas/blueprint-topology.json` (refine), `tests/e2e/playwright/tests/g117-blueprint-admission.spec.ts` | `core/pkg/apis/blueprint/v1alpha1/`, `examples/blueprint-grafana-fully-declared.yaml` | **none** (disjoint from B2/B3) |
+| **B2** | G117.2 — Catalog redesign + multi-instance | `core/services/catalyst-catalog/**`, `products/catalyst/console/src/routes/catalog/`, `products/catalyst/console/src/lib/api/catalystApi.ts`, `tests/e2e/playwright/tests/g117-catalog-drilldown.spec.ts` | `docs/api/catalyst-api-openapi.yaml`, `products/catalyst/console/tests/e2e/fixtures/mock-blueprints.yaml` | **worktree** (shares console/ with B3+B4) |
+| **B3** | G117.3 — Endpoints/Ingress tab + Git-IaC PR pipeline | `core/controllers/application/internal/endpoints/**`, `products/catalyst/console/src/routes/apps/[id]/endpoints/`, `tests/e2e/playwright/tests/g117-endpoints-tab.spec.ts` | `docs/api/catalyst-api-openapi.yaml`, `tools/bootstrap-org-iac-repo.sh` | **worktree** (shares console/ with B2+B4) |
+| **B4** | G117.4 — Launch button + silent SSO | `core/services/catalyst-api/internal/launch/**`, `products/catalyst/console/src/routes/apps/[id]/+page.svelte` (Launch button only), `tests/e2e/playwright/tests/g117-launch-silent-sso.spec.ts` | `docs/adr/0009-per-org-iac-repo-bootstrap.md`, KC realm config | **worktree** (shares apps/[id]/+page.svelte with B3) |
+| **B5** | G117.5 — SSO fan-out 3 tiers + per-Org realm | `platform/keycloak/chart/templates/configmap-*-realm.yaml`, `platform/<bp>/chart/templates/secret-sso-*.yaml` for each SSO-capable bp | KC realm-config conventions | **worktree** (shares KC realm-config templates across all C-slots) |
+| **B6** | G117.6 — application-controller multi-instance + topology + per-Org realm | `core/controllers/application/internal/controller/*.go`, `core/controllers/application/internal/render/*.go` | `core/controllers/pkg/apis/blueprint/v1alpha1/topology_types.go`, ADR-0009 | **none** (disjoint) |
+
+### Why this split
+
+- B1 → contract-first (admission + validator + tests). Wave-2 chart edits depend on B1's schema being merged.
+- B2 → catalyst-api + console catalog. Reads B1's contract.
+- B3 → endpoints PR pipeline. Reads B1's contract + ADR-0009.
+- B4 → Launch button. Reads B3's endpoints registry shape.
+- B5 → KC realm config. Cross-cutting across all SSO-capable Blueprints; must serialize per Blueprint OR worktree-isolate per Blueprint.
+- B6 → application-controller. Consumes B1's topology types + spec.topology data.
+
+## Wave-2 staging (after Wave-1 GREEN on main)
+
+Wave-2 fills out per-Blueprint topology stubs across `platform/<bp>/blueprint.yaml`. Six parallel agents, each owning a partition of `tools/migrate-blueprints-topology.py`'s output:
+
+| Slot | Partition | Files touched | Isolation |
+|---|---|---|---|
+| **C1** | Catalyst-CP tier (12 BPs) | `platform/grafana/`, `platform/keycloak/`, `platform/openbao/`, `platform/gitea/`, … | **worktree** (each agent gets its own; per-Blueprint Chart.yaml lockstep mandatory) |
+| **C2** | Per-host-cluster infra (~25 BPs) | `platform/cilium/`, `platform/flux/`, `platform/cert-manager/`, … | **worktree** |
+| **C3** | App Blueprints (~25 BPs) | `platform/ferretdb/`, `platform/valkey/`, `platform/clickhouse/`, … | **worktree** |
+| **C4** | Charts: lockstep version bumps | `platform/<bp>/chart/Chart.yaml` for every changed bp | **worktree** + flock GHCR push lock |
+| **C5** | Bootstrap-kit pin updates | `clusters/_template/bootstrap-kit/kustomization.yaml` | serialize after C1+C2+C3+C4 |
+| **C6** | Docs + memory + ADR pass | `docs/STATUS.md`, `docs/ledger/TRACKER.md`, `docs/sessions/<date>.md`, memory feedback files | **none** (docs-only) |
+
+## Worktree creation cheatsheet
+
+```bash
+# From the bastion, on the openova repo:
+cd /home/openova/repos/openova
+
+# Create a fresh worktree for slot B2 of Wave-1:
+git fetch origin main
+git worktree add -b feat/g117.2-catalog-redesign \
+  ../openova-g117-B2 \
+  origin/main
+
+cd ../openova-g117-B2
+# Verify clean baseline
+git status
+git log --oneline | head -5
+# Now safe to edit + commit + push WITHOUT colliding with sibling agents
+```
+
+## Anti-collision pre-commit hook (recommended for B5/C-slots)
+
+Drop into `.git/hooks/pre-commit` of each worktree:
+
+```bash
+#!/usr/bin/env bash
+# Refuse to commit if files in the diff overlap with sibling worktree's staged files.
+set -euo pipefail
+my_files=$(git diff --cached --name-only)
+for sibling in /home/openova/repos/openova-g117-*; do
+  [ "$sibling" = "$PWD" ] && continue
+  [ -d "$sibling/.git" ] || continue
+  sib_files=$(cd "$sibling" && git diff --cached --name-only 2>/dev/null || true)
+  for f in $my_files; do
+    if echo "$sib_files" | grep -qxF "$f"; then
+      echo "BLOCK: $f is also staged in $sibling — serialize or rebase" >&2
+      exit 1
+    fi
+  done
+done
+```
+
+## Branch naming convention
+
+| Wave | Branch pattern |
+|---|---|
+| Wave-0 | `feat/g117-wave-0-preflight` |
+| Wave-1 | `feat/g117.<N>-<short-topic>` (e.g. `feat/g117.2-catalog-redesign`) |
+| Wave-2 | `feat/g117.<N>-<partition>` (e.g. `feat/g117-platform-topology-cp`) |
+
+## Merge order (per Wave)
+
+1. B1 merges first (contract).
+2. B6 + B2 + B3 + B4 merge in parallel (consumers).
+3. B5 merges last (per-Blueprint Secret templates depend on B2's catalog-api shape).
+
+If a later slot needs a baseline that a not-yet-merged earlier slot provides, **rebase**, don't fix-forward. Per `feedback_chart_version_collision_serialize_or_rebase.md`: always `git show origin/main:<file>` for the latest value before bumping.

--- a/.github/workflows/blueprint-admission-validate.yml
+++ b/.github/workflows/blueprint-admission-validate.yml
@@ -1,0 +1,106 @@
+name: blueprint admission validate (G117 schema)
+
+# Validates every platform/*/blueprint.yaml + products/*/blueprint.yaml
+# against platform/_schemas/blueprint-topology.json. This is the CI
+# pre-image of the runtime admission webhook delivered by Wave-1
+# G117.1.
+#
+# Phase 1 (Wave-0): runs in `report-only` mode — failures emit warnings
+#                    but do NOT fail the job. This is so the workflow
+#                    can land on `main` BEFORE every blueprint.yaml gets
+#                    its spec.topology block (Wave-2's job).
+# Phase 2 (after Wave-2 GREEN): flip `report-only` to false; every PR
+#                    that adds a new blueprint.yaml without a valid
+#                    spec.topology block fails.
+#
+# The flip lives in this file at the env var FAIL_ON_INVALID. Wave-2
+# closing PR flips it.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'platform/**/blueprint.yaml'
+      - 'products/**/blueprint.yaml'
+      - 'platform/_schemas/**'
+      - '.github/workflows/blueprint-admission-validate.yml'
+  pull_request:
+    paths:
+      - 'platform/**/blueprint.yaml'
+      - 'products/**/blueprint.yaml'
+      - 'platform/_schemas/**'
+      - '.github/workflows/blueprint-admission-validate.yml'
+  workflow_dispatch:
+
+env:
+  # FLIP TO 'true' WHEN WAVE-2 LANDS spec.topology BLOCKS ACROSS ALL bp
+  # PER docs/sessions/2026-06-02-per-blueprint-topology-audit.md.
+  FAIL_ON_INVALID: 'false'
+
+jobs:
+  validate:
+    name: validate all blueprint.yaml against schema
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install jsonschema + pyyaml
+        run: pip install --quiet jsonschema pyyaml
+
+      - name: Validate every blueprint.yaml
+        run: |
+          python3 << 'PY'
+          import json, os, sys, yaml, jsonschema, pathlib
+
+          schema = json.load(open('platform/_schemas/blueprint-topology.json'))
+          fail_on_invalid = os.environ.get('FAIL_ON_INVALID', 'false').lower() == 'true'
+
+          checked = 0
+          failures: list[str] = []
+
+          for path in sorted(pathlib.Path('.').glob('platform/*/blueprint.yaml')):
+              checked += 1
+              try:
+                  doc = yaml.safe_load(path.read_text())
+              except Exception as e:
+                  failures.append(f"{path}: yaml parse: {e}")
+                  continue
+              # Skip schema validation when spec.topology is absent —
+              # the field is OPTIONAL until Wave-2 lands. The schema
+              # itself doesn't make topology required at root level.
+              try:
+                  jsonschema.validate(doc, schema)
+              except jsonschema.ValidationError as e:
+                  failures.append(f"{path}: {e.message[:140]}")
+
+          for path in sorted(pathlib.Path('.').glob('products/*/blueprint.yaml')):
+              checked += 1
+              try:
+                  doc = yaml.safe_load(path.read_text())
+              except Exception as e:
+                  failures.append(f"{path}: yaml parse: {e}")
+                  continue
+              try:
+                  jsonschema.validate(doc, schema)
+              except jsonschema.ValidationError as e:
+                  failures.append(f"{path}: {e.message[:140]}")
+
+          print(f"checked {checked} blueprint.yaml files")
+          if failures:
+              print(f"\n{len(failures)} validation findings:")
+              for f in failures:
+                  print(f"  ! {f}")
+              if fail_on_invalid:
+                  print("\nFAIL_ON_INVALID=true → exiting non-zero")
+                  sys.exit(1)
+              else:
+                  print("\nFAIL_ON_INVALID=false (Wave-1 phase) → not failing the job")
+          else:
+              print("all blueprint.yaml files validate clean")
+          PY

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -84,11 +84,16 @@ jobs:
           base="origin/${{ github.base_ref || 'main' }}"
           git fetch origin "${{ github.base_ref || 'main' }}" --depth=1 || true
           if git rev-parse --verify "$base" >/dev/null 2>&1; then
-            files=$(git diff --name-only "$base"...HEAD | grep -E '^platform/[^/]+/chart/' || true)
+            files=$(git diff --name-only "$base"...HEAD | grep -E '^platform/[^_][^/]*/chart/' || true)
           else
-            files=$(git ls-files 'platform/*/chart/' || true)
+            files=$(git ls-files 'platform/*/chart/' | grep -v '^platform/_' || true)
           fi
-          charts=$(echo "$files" | awk -F/ '{print $1"/"$2"/chart"}' | sort -u | tr '\n' ' ')
+          if [ -z "$files" ]; then
+            echo "charts=" >> "$GITHUB_OUTPUT"
+            echo "No chart paths in the diff — nothing to lint"
+            exit 0
+          fi
+          charts=$(echo "$files" | awk -F/ '$1=="platform" && $2!~/^_/ && $3=="chart" {print $1"/"$2"/chart"}' | sort -u | tr '\n' ' ')
           echo "charts=$charts" >> "$GITHUB_OUTPUT"
           echo "Changed charts: $charts"
 

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,101 @@
+name: helm-lint (chart annotations + G117 schema readiness)
+
+# Lints chart changes and verifies the new G117 JSON schema
+# (platform/_schemas/blueprint-topology.json) parses + the exemplar
+# blueprint validates against it.
+#
+# Wave-1 fills in:
+#   - per-chart `helm lint` on each touched platform/<bp>/chart/
+#   - chart-against-schema gate once admission-webhook lands
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'platform/**/Chart.yaml'
+      - 'platform/**/chart/**'
+      - 'platform/_schemas/**'
+      - 'examples/blueprint-*.yaml'
+      - '.github/workflows/helm-lint.yml'
+  pull_request:
+    paths:
+      - 'platform/**/Chart.yaml'
+      - 'platform/**/chart/**'
+      - 'platform/_schemas/**'
+      - 'examples/blueprint-*.yaml'
+      - '.github/workflows/helm-lint.yml'
+  workflow_dispatch:
+
+jobs:
+  schema-validate:
+    name: G117 topology JSON schema
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install jsonschema + pyyaml
+        run: pip install --quiet jsonschema pyyaml
+
+      - name: Parse JSON schema
+        run: python3 -c "import json; json.load(open('platform/_schemas/blueprint-topology.json'))"
+
+      - name: Validate exemplar against schema
+        run: |
+          python3 << 'PY'
+          import json, yaml, jsonschema
+          schema = json.load(open('platform/_schemas/blueprint-topology.json'))
+          doc = yaml.safe_load(open('examples/blueprint-grafana-fully-declared.yaml'))
+          jsonschema.validate(doc, schema)
+          print("OK")
+          PY
+
+      - name: Migration tool emits + validates ≥50 stubs
+        run: |
+          python3 tools/migrate-blueprints-topology.py \
+            --output-dir /tmp/topology-stubs \
+            --validate
+          count=$(ls /tmp/topology-stubs | wc -l)
+          echo "stubs: $count"
+          [ "$count" -ge 50 ] || { echo "fewer than 50 stubs"; exit 1; }
+
+  helm-lint:
+    name: helm lint changed charts
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.0
+
+      - name: Determine changed charts
+        id: changed
+        run: |
+          base="origin/${{ github.base_ref || 'main' }}"
+          git fetch origin "${{ github.base_ref || 'main' }}" --depth=1 || true
+          if git rev-parse --verify "$base" >/dev/null 2>&1; then
+            files=$(git diff --name-only "$base"...HEAD | grep -E '^platform/[^/]+/chart/' || true)
+          else
+            files=$(git ls-files 'platform/*/chart/' || true)
+          fi
+          charts=$(echo "$files" | awk -F/ '{print $1"/"$2"/chart"}' | sort -u | tr '\n' ' ')
+          echo "charts=$charts" >> "$GITHUB_OUTPUT"
+          echo "Changed charts: $charts"
+
+      - name: helm lint
+        if: steps.changed.outputs.charts != ''
+        run: |
+          for c in ${{ steps.changed.outputs.charts }}; do
+            echo "▸ helm lint $c"
+            helm lint "$c" || exit 1
+          done

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -69,11 +69,16 @@ jobs:
 
       - name: Wait for console
         run: |
+          # The existing core/console Astro config serves under /nova base
+          # (see core/console/astro.config.mjs). Probe both / and /nova so
+          # this gate survives a future base-path change without re-edit.
           for i in $(seq 1 60); do
-            if curl -sf -o /dev/null http://localhost:4322/; then
-              echo "console ready after ${i}s"
-              exit 0
-            fi
+            for path in /nova/ /; do
+              if curl -sf -o /dev/null "http://localhost:4322${path}"; then
+                echo "console ready after ${i}s at ${path}"
+                exit 0
+              fi
+            done
             sleep 1
           done
           echo "console failed to start — log:"
@@ -87,7 +92,7 @@ jobs:
         run: |
           cat > /tmp/g117-scaffold-smoke.spec.ts <<'EOF'
           import { test, expect } from '@playwright/test';
-          const BASE = process.env.BASE_URL || 'http://localhost:4322';
+          const BASE = process.env.BASE_URL || 'http://localhost:4322/nova/';
           test('console root loads', async ({ page }) => {
             const r = await page.goto(BASE);
             expect(r?.status() ?? 0).toBeLessThan(500);

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Install Playwright deps
         run: |
+          mkdir -p /tmp/g117-playwright
+          cd /tmp/g117-playwright
           npm init -y
           npm install --silent @playwright/test
           npx playwright install --with-deps chromium
@@ -89,8 +91,10 @@ jobs:
       # asserts the route scaffolds load. Wave-1 adds the per-sub-EPIC
       # specs under products/catalyst/console/tests/e2e/.
       - name: Run e2e (scaffold smoke)
+        working-directory: /tmp/g117-playwright
         run: |
-          cat > /tmp/g117-scaffold-smoke.spec.ts <<'EOF'
+          mkdir -p tests
+          cat > tests/g117-scaffold-smoke.spec.ts <<'EOF'
           import { test, expect } from '@playwright/test';
           const BASE = process.env.BASE_URL || 'http://localhost:4322/nova/';
           test('console root loads', async ({ page }) => {
@@ -98,7 +102,17 @@ jobs:
             expect(r?.status() ?? 0).toBeLessThan(500);
           });
           EOF
-          npx playwright test /tmp/g117-scaffold-smoke.spec.ts --reporter=list
+          # Minimal playwright config so the test runner picks up tests/.
+          cat > playwright.config.ts <<'EOF'
+          import { defineConfig } from '@playwright/test';
+          export default defineConfig({
+            testDir: './tests',
+            timeout: 30_000,
+            reporter: 'list',
+            use: { headless: true },
+          });
+          EOF
+          npx playwright test --reporter=list
 
       - name: Stop console
         if: always()

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -1,0 +1,111 @@
+name: G117 Playwright E2E (Wave-1 scaffold)
+
+# G117 EPIC — Playwright e2e against the new operator-console routes
+# (catalog drill-down, new-instance dialog, Application detail, Endpoints
+# tab, Launch button silent-SSO). The actual specs are filled in by
+# Wave-1 authors per the file-touch matrix in
+# .claude/templates/G117-worktree-policy.md.
+#
+# Until the Wave-1 specs land, this workflow runs in MOCK_API=1 mode
+# against the mock fixtures at
+#   products/catalyst/console/tests/e2e/fixtures/mock-blueprints.yaml
+# and only asserts that the route scaffolds render without console errors.
+#
+# Trigger paths are scoped tight so unrelated PRs don't pay the e2e cost.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'products/catalyst/console/src/routes/**'
+      - 'products/catalyst/console/tests/e2e/**'
+      - 'docs/api/catalyst-api-openapi.yaml'
+      - '.github/workflows/playwright-e2e.yml'
+  pull_request:
+    paths:
+      - 'products/catalyst/console/src/routes/**'
+      - 'products/catalyst/console/tests/e2e/**'
+      - 'docs/api/catalyst-api-openapi.yaml'
+      - '.github/workflows/playwright-e2e.yml'
+  workflow_dispatch:
+
+jobs:
+  g117-e2e:
+    name: G117 console e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # The route scaffolds live under products/catalyst/console; the
+      # existing package.json (Astro + Svelte 5) drives the dev server.
+      - name: Install console dependencies
+        working-directory: core/console
+        run: |
+          if [ -f package-lock.json ]; then npm ci; else npm install; fi
+
+      - name: Install Playwright deps
+        run: |
+          npm init -y
+          npm install --silent @playwright/test
+          npx playwright install --with-deps chromium
+
+      # Mock-API mode — the route components honor window.__MOCK_API__
+      # so we inject the fixture from a tiny static page wrapper.
+      - name: Boot console (MOCK_API=1)
+        working-directory: core/console
+        env:
+          MOCK_API: '1'
+          HOST: 0.0.0.0
+        run: |
+          nohup npm run dev > /tmp/console-dev.log 2>&1 &
+          echo $! > /tmp/console-dev.pid
+
+      - name: Wait for console
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf -o /dev/null http://localhost:4322/; then
+              echo "console ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "console failed to start — log:"
+          cat /tmp/console-dev.log
+          exit 1
+
+      # Until Wave-1 specs land, run only the placeholder smoke that
+      # asserts the route scaffolds load. Wave-1 adds the per-sub-EPIC
+      # specs under products/catalyst/console/tests/e2e/.
+      - name: Run e2e (scaffold smoke)
+        run: |
+          cat > /tmp/g117-scaffold-smoke.spec.ts <<'EOF'
+          import { test, expect } from '@playwright/test';
+          const BASE = process.env.BASE_URL || 'http://localhost:4322';
+          test('console root loads', async ({ page }) => {
+            const r = await page.goto(BASE);
+            expect(r?.status() ?? 0).toBeLessThan(500);
+          });
+          EOF
+          npx playwright test /tmp/g117-scaffold-smoke.spec.ts --reporter=list
+
+      - name: Stop console
+        if: always()
+        run: |
+          if [ -f /tmp/console-dev.pid ]; then
+            kill "$(cat /tmp/console-dev.pid)" 2>/dev/null || true
+          fi
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: g117-playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/core/controllers/pkg/apis/blueprint/v1alpha1/topology_types.go
+++ b/core/controllers/pkg/apis/blueprint/v1alpha1/topology_types.go
@@ -1,0 +1,311 @@
+// Package v1alpha1 — Blueprint topology Go types for G117 EPIC.
+//
+// These types are the in-tree, statically-typed representation of the
+// new `spec.topology`, `spec.endpoints`, `spec.sso`, and
+// `spec.multiInstance` fields the G117 wave adds to the Blueprint CRD.
+//
+// The existing blueprint-controller (core/controllers/blueprint/...)
+// uses the dynamic client + unstructured.Unstructured to round-trip
+// Blueprint CRs, so this package is consumed primarily by:
+//
+//  1. The admission webhook (validates incoming Blueprint manifests
+//     against the locked schema in platform/_schemas/blueprint-topology.json)
+//  2. The application-controller (G117.6) when fanning HelmReleases
+//     across host clusters per Blueprint.spec.topology + perTopology
+//     placement
+//  3. catalyst-api (G117.2-G117.4) when serving GET /catalog/{bp}
+//     and computing default + supported topologies for the new-instance
+//     dialog
+//
+// Schema shape (locked architectural decision #1):
+//
+//	spec:
+//	  topology:
+//	    supported: [active-active, active-hot-standby, active-passive, singleton]
+//	    defaults:
+//	      multi-region: active-hot-standby
+//	      single-region: singleton
+//	    perTopology:
+//	      active-hot-standby:
+//	        replication: { backend: cnpg-pair, mode: sync, lagSloSeconds: 5 }
+//	        switchover:  { mechanism: bp-continuum, rtoSeconds: 30, rpoSeconds: 0 }
+//	        placement:   { clusters: [mgmt-A, mgmt-B], roles: { mgmt-A: active, mgmt-B: passive } }
+//
+// The Topology struct is intentionally permissive on the perTopology map
+// because each variant uses different replication/switchover knobs.
+// The structural JSON schema (platform/_schemas/blueprint-topology.json)
+// is the SINGLE source of truth for required-vs-optional per variant —
+// Go code here only carries the shape, not the per-variant required
+// fields.
+//
+// Source-of-truth document for which Blueprint takes which topology:
+//
+//	docs/sessions/2026-06-02-per-blueprint-topology-audit.md
+//
+// Reference: docs/ARCHITECTURE.md §3 (Blueprint CRD) and §8 (multi-region).
+package v1alpha1
+
+// BcpTopology is the enum of supported BCP (Business Continuity Plan)
+// topology choices a Blueprint may declare. See ARCHITECTURE §8 +
+// `docs/sessions/2026-06-02-per-blueprint-topology-audit.md` legend.
+//
+// LOCKED enum — do not extend without an ADR.
+type BcpTopology string
+
+const (
+	// BcpActiveActive — both regions serve live traffic simultaneously
+	// (e.g. bp-strimzi MirrorMaker2, bp-clickhouse, stateless APIs).
+	BcpActiveActive BcpTopology = "active-active"
+
+	// BcpActiveHotStandby — primary serves traffic; secondary is fully
+	// provisioned and kept in-sync (sync-replication where the data
+	// store supports it; see PerTopology.Replication for the knobs).
+	// Switchover RTO target: ≤30s.
+	BcpActiveHotStandby BcpTopology = "active-hot-standby"
+
+	// BcpActivePassive — primary serves traffic; secondary is in cold
+	// or warm standby (e.g. backup/restore-based; no in-flight sync).
+	BcpActivePassive BcpTopology = "active-passive"
+
+	// BcpSingleton — single instance, no cross-region HA. Used for
+	// per-cluster infrastructure (bp-cilium, bp-flux, bp-cert-manager,
+	// etc.) where each cluster owns its own copy.
+	BcpSingleton BcpTopology = "singleton"
+)
+
+// AllBcpTopologies returns the LOCKED enum slice for admission
+// validation and tests. Mirrors the JSON schema's bcpTopology enum.
+func AllBcpTopologies() []BcpTopology {
+	return []BcpTopology{
+		BcpActiveActive,
+		BcpActiveHotStandby,
+		BcpActivePassive,
+		BcpSingleton,
+	}
+}
+
+// IsValid reports whether s is a recognised topology choice.
+func (b BcpTopology) IsValid() bool {
+	switch b {
+	case BcpActiveActive, BcpActiveHotStandby, BcpActivePassive, BcpSingleton:
+		return true
+	}
+	return false
+}
+
+// Topology captures the per-Blueprint multi-region declaration. The
+// admission webhook enforces that `defaults.multi-region` and
+// `defaults.single-region` are each members of `supported`, and that
+// every key in `perTopology` is in `supported` too.
+type Topology struct {
+	// Supported lists every BCP topology this Blueprint can be
+	// installed with. Must be non-empty.
+	Supported []BcpTopology `json:"supported"`
+
+	// Defaults selects the topology used by the application-controller
+	// when the Sovereign exposes multi-region vs single-region to the
+	// installing org. The console / API surfaces these as the
+	// pre-selected radio button on the new-instance dialog.
+	Defaults TopologyDefaults `json:"defaults"`
+
+	// PerTopology carries the replication/switchover/placement knobs
+	// per variant. Keys MUST be present in Supported.
+	//
+	// The value shape is variant-specific; the structural schema in
+	// platform/_schemas/blueprint-topology.json gates required fields.
+	PerTopology map[BcpTopology]TopologyVariant `json:"perTopology,omitempty"`
+}
+
+// TopologyDefaults binds a default BcpTopology to each Sovereign
+// shape. The application-controller picks the multi-region default
+// when len(Sovereign.spec.regions) > 1, else the single-region default.
+// (Locked architectural decision #7.)
+type TopologyDefaults struct {
+	MultiRegion  BcpTopology `json:"multi-region"`
+	SingleRegion BcpTopology `json:"single-region"`
+}
+
+// TopologyVariant is the per-BCP-topology shape. All sub-blocks are
+// optional at the Go level; the JSON schema gates which are required
+// per BCP variant (e.g. active-hot-standby requires Replication +
+// Switchover; singleton requires only Placement).
+type TopologyVariant struct {
+	Replication *ReplicationSpec `json:"replication,omitempty"`
+	Switchover  *SwitchoverSpec  `json:"switchover,omitempty"`
+	Placement   *PlacementSpec   `json:"placement,omitempty"`
+}
+
+// ReplicationSpec — how the Blueprint preserves state across the
+// active/passive pair. Backend strings are conventional (cnpg-pair,
+// raft, mirrormaker2, s3-bucket-replication, ccr, none).
+type ReplicationSpec struct {
+	// Backend is the canonical name of the replication mechanism.
+	// See docs/sessions/2026-06-02-per-blueprint-topology-audit.md
+	// "State preservation" column for the per-Blueprint convention.
+	Backend string `json:"backend"`
+
+	// Mode is the consistency model. Common values:
+	//   - sync    — synchronous (zero-tx-loss; bp-cnpg-pair `remote_apply`)
+	//   - async   — asynchronous (eventually-consistent; S3 bucket repl)
+	//   - none    — n/a (DaemonSet, stateless, etc.)
+	Mode string `json:"mode,omitempty"`
+
+	// LagSloSeconds is the maximum acceptable replication lag in
+	// seconds, used by the Continuum SLO checks. 0 = sync mode (no lag).
+	LagSloSeconds *int `json:"lagSloSeconds,omitempty"`
+}
+
+// SwitchoverSpec — how an active→passive flip is orchestrated.
+type SwitchoverSpec struct {
+	// Mechanism names the controller that orchestrates the switchover.
+	// Conventional: bp-continuum, manual, bp-velero-restore.
+	Mechanism string `json:"mechanism"`
+
+	// RtoSeconds — recovery-time objective. Target time from "primary
+	// loss detected" to "passive promoted and serving".
+	RtoSeconds *int `json:"rtoSeconds,omitempty"`
+
+	// RpoSeconds — recovery-point objective. Acceptable data loss in
+	// the worst case. 0 means sync replication.
+	RpoSeconds *int `json:"rpoSeconds,omitempty"`
+}
+
+// PlacementSpec — which host clusters this Blueprint is installed on.
+type PlacementSpec struct {
+	// Tier is one of the canonical cluster tiers used by
+	// `Blueprint.spec.placementSchema.vcluster`:
+	//   - "mgmt" — Catalyst control-plane cluster
+	//   - "dmz"  — DMZ tenant workload cluster
+	//   - "rtz"  — Regulated tenant workload cluster
+	//   - ""     — no vCluster placement; installs into the host cluster
+	Tier string `json:"tier,omitempty"`
+
+	// Clusters lists the canonical cluster IDs this Blueprint is
+	// installed on. Used by the application-controller's fan-out
+	// renderer (G117.6) to write per-cluster HelmReleases.
+	Clusters []string `json:"clusters,omitempty"`
+
+	// Roles maps cluster ID → role ("active" | "passive" | "singleton").
+	// The application-controller emits the active-role HR with full
+	// traffic-facing config; passive HRs are rendered identically but
+	// the Continuum lease prevents them from serving.
+	Roles map[string]string `json:"roles,omitempty"`
+}
+
+// EndpointSpec — a single named external endpoint surfaced by a
+// Blueprint. The Endpoints tab UI (G117.3) renders one card per entry;
+// the Launch button UI (G117.4) starts from the entry tagged
+// `launchDefault: true` (else the first SSO-enabled entry).
+type EndpointSpec struct {
+	// Name is a stable identifier per Blueprint (e.g. "ui", "api",
+	// "metrics"). Must be unique within a Blueprint.
+	Name string `json:"name"`
+
+	// HostnameTemplate is a Go-text/template fragment evaluated by
+	// catalyst-api against the per-Instance / per-Org / per-Sovereign
+	// context. Example: `{{.AppName}}.{{.OrgSlug}}.{{.SovereignFQDN}}`.
+	// Tokens MUST resolve to hostnames matching RFC-1123.
+	HostnameTemplate string `json:"hostnameTemplate"`
+
+	// Port — service port exposed by the Blueprint's Service. Default
+	// 443 for `protocol: https`, 80 for `http`. The Gateway/HTTPRoute
+	// rendered by the application-controller uses this value.
+	Port *int `json:"port,omitempty"`
+
+	// Protocol — https | http | grpc | tcp | udp. Drives Gateway
+	// listener selection and Coraza WAF attach.
+	Protocol string `json:"protocol,omitempty"`
+
+	// TLS — does the endpoint terminate TLS at the Gateway? Default
+	// true. If false, the endpoint is internal-only and the Launch
+	// button is hidden.
+	TLS *bool `json:"tls,omitempty"`
+
+	// Visibility — public | private | internal. `internal` endpoints
+	// are not exposed by Gateway and only resolvable within the
+	// host cluster. `private` is mTLS-only (no Coraza WAF).
+	Visibility string `json:"visibility,omitempty"`
+
+	// LaunchDefault — when true, the console's Launch button on the
+	// Application detail page navigates to this endpoint by default.
+	// Exactly one EndpointSpec per Blueprint MAY set this true; if
+	// none do, catalyst-api picks the first SSO-enabled https endpoint.
+	LaunchDefault bool `json:"launchDefault,omitempty"`
+
+	// SSOEnabled — whether this endpoint sits behind the Sovereign's
+	// SSO chain (Catalyst KC realm `sovereign` for Tier-1/2 apps;
+	// per-Org KC realm with sovereign-broker federation for Tier-3).
+	// If true, the Launch button uses silent OIDC
+	// `prompt=none&kc_idp_hint=catalyst-pin` per G117.4.
+	SSOEnabled bool `json:"ssoEnabled,omitempty"`
+}
+
+// SSOSpec — Blueprint-level SSO declaration. Tier-1 (in-band CP), Tier-2
+// (CP-adjacent), Tier-3 (tenant Apps) follow the locked SSO fan-out
+// plan (decision #5) — `realm` here selects which KC realm the
+// Blueprint federates to.
+type SSOSpec struct {
+	// Realm — `sovereign` for Tier-1/2 (Catalyst CP realm); `<org>`
+	// for Tier-3 (per-Org realm with `Keycloak OIDC` IdP federated to
+	// the sovereign-realm broker — see decision #6).
+	Realm string `json:"realm"`
+
+	// ProtocolMapper — `oidc` (default) | `saml`. Used by application-
+	// controller when rendering the per-instance Secret for the
+	// downstream chart (bp-grafana, bp-gitea, bp-harbor, …).
+	ProtocolMapper string `json:"protocolMapper,omitempty"`
+
+	// GroupsClaim — name of the OIDC claim carrying the user's groups
+	// for RBAC. Default "groups" (per G91 + G113).
+	GroupsClaim string `json:"groupsClaim,omitempty"`
+
+	// RolesFromGroup — map of OIDC group name → application-level role.
+	// e.g. {"sovereign-admins": "admin", "tenant-admins": "editor"}.
+	RolesFromGroup map[string]string `json:"rolesFromGroup,omitempty"`
+
+	// SilentLogin — when true, the Launch button URL appends
+	// `prompt=none&kc_idp_hint=catalyst-pin` to silently SSO-bounce
+	// through KC. Default true on Tier-1/2; false on Tier-3 until
+	// per-Org realm federation is verified.
+	SilentLogin *bool `json:"silentLogin,omitempty"`
+}
+
+// MultiInstanceSpec — when present, a Blueprint may have >1
+// Application instance per Organization. Catalog cards (G117.2) show
+// the instance-count badge and "+ New instance" button when this is
+// declared. When absent, a Blueprint is singleton-per-Org.
+type MultiInstanceSpec struct {
+	// Enabled — true to permit multiple instances per Organization.
+	Enabled bool `json:"enabled"`
+
+	// MaxPerOrg — optional cap. 0 / unset = unlimited.
+	MaxPerOrg *int `json:"maxPerOrg,omitempty"`
+
+	// NamingTemplate — how the application-controller names per-instance
+	// Namespaces and Helm releases. Default `{{.AppName}}-{{.InstanceID}}`.
+	NamingTemplate string `json:"namingTemplate,omitempty"`
+
+	// IsolationLevel — `namespace` (default) | `vcluster`. When
+	// `vcluster`, each instance gets its own vCluster under the Org's
+	// tier-cluster (rtz or dmz).
+	IsolationLevel string `json:"isolationLevel,omitempty"`
+}
+
+// BlueprintSpecExtension — the new fields G117 grafts onto the existing
+// Blueprint CR's spec. Production code merges these into the existing
+// dynamic-client-driven blueprint-controller by reading them out of
+// the unstructured.Unstructured via NestedMap; this typed shape is
+// the canonical contract every other consumer (catalyst-api,
+// application-controller, admission webhook, console) imports.
+//
+// IMPORTANT: this type intentionally does NOT alias the legacy
+// `BlueprintSpec` (which lives only inside the OpenAPI CRD schema
+// today, not in Go). When the project later promotes the CRD to
+// typed kubebuilder types, BlueprintSpecExtension's fields fold into
+// the parent struct verbatim (same JSON keys).
+type BlueprintSpecExtension struct {
+	Topology      *Topology          `json:"topology,omitempty"`
+	Endpoints     []EndpointSpec     `json:"endpoints,omitempty"`
+	SSO           *SSOSpec           `json:"sso,omitempty"`
+	MultiInstance *MultiInstanceSpec `json:"multiInstance,omitempty"`
+}

--- a/core/pkg/apis/blueprint/v1alpha1/go.mod
+++ b/core/pkg/apis/blueprint/v1alpha1/go.mod
@@ -1,0 +1,14 @@
+// G117 Blueprint topology types — canonical home per Wave-0 brief.
+//
+// Self-contained module so `go build ./...` from this directory
+// succeeds without dragging in the heavier controllers/ go.mod.
+// Wave-1 may fold this into a larger `core/pkg/apis` umbrella module
+// once additional CRD types (Application, Organization, Environment)
+// are also typed.
+//
+// The mirror at core/controllers/pkg/apis/blueprint/v1alpha1/ exists
+// solely so existing controllers (which already vendor controller-runtime)
+// can import without a module-level go.work entry.
+module github.com/openova-io/openova/core/pkg/apis/blueprint/v1alpha1
+
+go 1.23

--- a/core/pkg/apis/blueprint/v1alpha1/topology_types.go
+++ b/core/pkg/apis/blueprint/v1alpha1/topology_types.go
@@ -1,0 +1,311 @@
+// Package v1alpha1 — Blueprint topology Go types for G117 EPIC.
+//
+// These types are the in-tree, statically-typed representation of the
+// new `spec.topology`, `spec.endpoints`, `spec.sso`, and
+// `spec.multiInstance` fields the G117 wave adds to the Blueprint CRD.
+//
+// The existing blueprint-controller (core/controllers/blueprint/...)
+// uses the dynamic client + unstructured.Unstructured to round-trip
+// Blueprint CRs, so this package is consumed primarily by:
+//
+//  1. The admission webhook (validates incoming Blueprint manifests
+//     against the locked schema in platform/_schemas/blueprint-topology.json)
+//  2. The application-controller (G117.6) when fanning HelmReleases
+//     across host clusters per Blueprint.spec.topology + perTopology
+//     placement
+//  3. catalyst-api (G117.2-G117.4) when serving GET /catalog/{bp}
+//     and computing default + supported topologies for the new-instance
+//     dialog
+//
+// Schema shape (locked architectural decision #1):
+//
+//	spec:
+//	  topology:
+//	    supported: [active-active, active-hot-standby, active-passive, singleton]
+//	    defaults:
+//	      multi-region: active-hot-standby
+//	      single-region: singleton
+//	    perTopology:
+//	      active-hot-standby:
+//	        replication: { backend: cnpg-pair, mode: sync, lagSloSeconds: 5 }
+//	        switchover:  { mechanism: bp-continuum, rtoSeconds: 30, rpoSeconds: 0 }
+//	        placement:   { clusters: [mgmt-A, mgmt-B], roles: { mgmt-A: active, mgmt-B: passive } }
+//
+// The Topology struct is intentionally permissive on the perTopology map
+// because each variant uses different replication/switchover knobs.
+// The structural JSON schema (platform/_schemas/blueprint-topology.json)
+// is the SINGLE source of truth for required-vs-optional per variant —
+// Go code here only carries the shape, not the per-variant required
+// fields.
+//
+// Source-of-truth document for which Blueprint takes which topology:
+//
+//	docs/sessions/2026-06-02-per-blueprint-topology-audit.md
+//
+// Reference: docs/ARCHITECTURE.md §3 (Blueprint CRD) and §8 (multi-region).
+package v1alpha1
+
+// BcpTopology is the enum of supported BCP (Business Continuity Plan)
+// topology choices a Blueprint may declare. See ARCHITECTURE §8 +
+// `docs/sessions/2026-06-02-per-blueprint-topology-audit.md` legend.
+//
+// LOCKED enum — do not extend without an ADR.
+type BcpTopology string
+
+const (
+	// BcpActiveActive — both regions serve live traffic simultaneously
+	// (e.g. bp-strimzi MirrorMaker2, bp-clickhouse, stateless APIs).
+	BcpActiveActive BcpTopology = "active-active"
+
+	// BcpActiveHotStandby — primary serves traffic; secondary is fully
+	// provisioned and kept in-sync (sync-replication where the data
+	// store supports it; see PerTopology.Replication for the knobs).
+	// Switchover RTO target: ≤30s.
+	BcpActiveHotStandby BcpTopology = "active-hot-standby"
+
+	// BcpActivePassive — primary serves traffic; secondary is in cold
+	// or warm standby (e.g. backup/restore-based; no in-flight sync).
+	BcpActivePassive BcpTopology = "active-passive"
+
+	// BcpSingleton — single instance, no cross-region HA. Used for
+	// per-cluster infrastructure (bp-cilium, bp-flux, bp-cert-manager,
+	// etc.) where each cluster owns its own copy.
+	BcpSingleton BcpTopology = "singleton"
+)
+
+// AllBcpTopologies returns the LOCKED enum slice for admission
+// validation and tests. Mirrors the JSON schema's bcpTopology enum.
+func AllBcpTopologies() []BcpTopology {
+	return []BcpTopology{
+		BcpActiveActive,
+		BcpActiveHotStandby,
+		BcpActivePassive,
+		BcpSingleton,
+	}
+}
+
+// IsValid reports whether s is a recognised topology choice.
+func (b BcpTopology) IsValid() bool {
+	switch b {
+	case BcpActiveActive, BcpActiveHotStandby, BcpActivePassive, BcpSingleton:
+		return true
+	}
+	return false
+}
+
+// Topology captures the per-Blueprint multi-region declaration. The
+// admission webhook enforces that `defaults.multi-region` and
+// `defaults.single-region` are each members of `supported`, and that
+// every key in `perTopology` is in `supported` too.
+type Topology struct {
+	// Supported lists every BCP topology this Blueprint can be
+	// installed with. Must be non-empty.
+	Supported []BcpTopology `json:"supported"`
+
+	// Defaults selects the topology used by the application-controller
+	// when the Sovereign exposes multi-region vs single-region to the
+	// installing org. The console / API surfaces these as the
+	// pre-selected radio button on the new-instance dialog.
+	Defaults TopologyDefaults `json:"defaults"`
+
+	// PerTopology carries the replication/switchover/placement knobs
+	// per variant. Keys MUST be present in Supported.
+	//
+	// The value shape is variant-specific; the structural schema in
+	// platform/_schemas/blueprint-topology.json gates required fields.
+	PerTopology map[BcpTopology]TopologyVariant `json:"perTopology,omitempty"`
+}
+
+// TopologyDefaults binds a default BcpTopology to each Sovereign
+// shape. The application-controller picks the multi-region default
+// when len(Sovereign.spec.regions) > 1, else the single-region default.
+// (Locked architectural decision #7.)
+type TopologyDefaults struct {
+	MultiRegion  BcpTopology `json:"multi-region"`
+	SingleRegion BcpTopology `json:"single-region"`
+}
+
+// TopologyVariant is the per-BCP-topology shape. All sub-blocks are
+// optional at the Go level; the JSON schema gates which are required
+// per BCP variant (e.g. active-hot-standby requires Replication +
+// Switchover; singleton requires only Placement).
+type TopologyVariant struct {
+	Replication *ReplicationSpec `json:"replication,omitempty"`
+	Switchover  *SwitchoverSpec  `json:"switchover,omitempty"`
+	Placement   *PlacementSpec   `json:"placement,omitempty"`
+}
+
+// ReplicationSpec — how the Blueprint preserves state across the
+// active/passive pair. Backend strings are conventional (cnpg-pair,
+// raft, mirrormaker2, s3-bucket-replication, ccr, none).
+type ReplicationSpec struct {
+	// Backend is the canonical name of the replication mechanism.
+	// See docs/sessions/2026-06-02-per-blueprint-topology-audit.md
+	// "State preservation" column for the per-Blueprint convention.
+	Backend string `json:"backend"`
+
+	// Mode is the consistency model. Common values:
+	//   - sync    — synchronous (zero-tx-loss; bp-cnpg-pair `remote_apply`)
+	//   - async   — asynchronous (eventually-consistent; S3 bucket repl)
+	//   - none    — n/a (DaemonSet, stateless, etc.)
+	Mode string `json:"mode,omitempty"`
+
+	// LagSloSeconds is the maximum acceptable replication lag in
+	// seconds, used by the Continuum SLO checks. 0 = sync mode (no lag).
+	LagSloSeconds *int `json:"lagSloSeconds,omitempty"`
+}
+
+// SwitchoverSpec — how an active→passive flip is orchestrated.
+type SwitchoverSpec struct {
+	// Mechanism names the controller that orchestrates the switchover.
+	// Conventional: bp-continuum, manual, bp-velero-restore.
+	Mechanism string `json:"mechanism"`
+
+	// RtoSeconds — recovery-time objective. Target time from "primary
+	// loss detected" to "passive promoted and serving".
+	RtoSeconds *int `json:"rtoSeconds,omitempty"`
+
+	// RpoSeconds — recovery-point objective. Acceptable data loss in
+	// the worst case. 0 means sync replication.
+	RpoSeconds *int `json:"rpoSeconds,omitempty"`
+}
+
+// PlacementSpec — which host clusters this Blueprint is installed on.
+type PlacementSpec struct {
+	// Tier is one of the canonical cluster tiers used by
+	// `Blueprint.spec.placementSchema.vcluster`:
+	//   - "mgmt" — Catalyst control-plane cluster
+	//   - "dmz"  — DMZ tenant workload cluster
+	//   - "rtz"  — Regulated tenant workload cluster
+	//   - ""     — no vCluster placement; installs into the host cluster
+	Tier string `json:"tier,omitempty"`
+
+	// Clusters lists the canonical cluster IDs this Blueprint is
+	// installed on. Used by the application-controller's fan-out
+	// renderer (G117.6) to write per-cluster HelmReleases.
+	Clusters []string `json:"clusters,omitempty"`
+
+	// Roles maps cluster ID → role ("active" | "passive" | "singleton").
+	// The application-controller emits the active-role HR with full
+	// traffic-facing config; passive HRs are rendered identically but
+	// the Continuum lease prevents them from serving.
+	Roles map[string]string `json:"roles,omitempty"`
+}
+
+// EndpointSpec — a single named external endpoint surfaced by a
+// Blueprint. The Endpoints tab UI (G117.3) renders one card per entry;
+// the Launch button UI (G117.4) starts from the entry tagged
+// `launchDefault: true` (else the first SSO-enabled entry).
+type EndpointSpec struct {
+	// Name is a stable identifier per Blueprint (e.g. "ui", "api",
+	// "metrics"). Must be unique within a Blueprint.
+	Name string `json:"name"`
+
+	// HostnameTemplate is a Go-text/template fragment evaluated by
+	// catalyst-api against the per-Instance / per-Org / per-Sovereign
+	// context. Example: `{{.AppName}}.{{.OrgSlug}}.{{.SovereignFQDN}}`.
+	// Tokens MUST resolve to hostnames matching RFC-1123.
+	HostnameTemplate string `json:"hostnameTemplate"`
+
+	// Port — service port exposed by the Blueprint's Service. Default
+	// 443 for `protocol: https`, 80 for `http`. The Gateway/HTTPRoute
+	// rendered by the application-controller uses this value.
+	Port *int `json:"port,omitempty"`
+
+	// Protocol — https | http | grpc | tcp | udp. Drives Gateway
+	// listener selection and Coraza WAF attach.
+	Protocol string `json:"protocol,omitempty"`
+
+	// TLS — does the endpoint terminate TLS at the Gateway? Default
+	// true. If false, the endpoint is internal-only and the Launch
+	// button is hidden.
+	TLS *bool `json:"tls,omitempty"`
+
+	// Visibility — public | private | internal. `internal` endpoints
+	// are not exposed by Gateway and only resolvable within the
+	// host cluster. `private` is mTLS-only (no Coraza WAF).
+	Visibility string `json:"visibility,omitempty"`
+
+	// LaunchDefault — when true, the console's Launch button on the
+	// Application detail page navigates to this endpoint by default.
+	// Exactly one EndpointSpec per Blueprint MAY set this true; if
+	// none do, catalyst-api picks the first SSO-enabled https endpoint.
+	LaunchDefault bool `json:"launchDefault,omitempty"`
+
+	// SSOEnabled — whether this endpoint sits behind the Sovereign's
+	// SSO chain (Catalyst KC realm `sovereign` for Tier-1/2 apps;
+	// per-Org KC realm with sovereign-broker federation for Tier-3).
+	// If true, the Launch button uses silent OIDC
+	// `prompt=none&kc_idp_hint=catalyst-pin` per G117.4.
+	SSOEnabled bool `json:"ssoEnabled,omitempty"`
+}
+
+// SSOSpec — Blueprint-level SSO declaration. Tier-1 (in-band CP), Tier-2
+// (CP-adjacent), Tier-3 (tenant Apps) follow the locked SSO fan-out
+// plan (decision #5) — `realm` here selects which KC realm the
+// Blueprint federates to.
+type SSOSpec struct {
+	// Realm — `sovereign` for Tier-1/2 (Catalyst CP realm); `<org>`
+	// for Tier-3 (per-Org realm with `Keycloak OIDC` IdP federated to
+	// the sovereign-realm broker — see decision #6).
+	Realm string `json:"realm"`
+
+	// ProtocolMapper — `oidc` (default) | `saml`. Used by application-
+	// controller when rendering the per-instance Secret for the
+	// downstream chart (bp-grafana, bp-gitea, bp-harbor, …).
+	ProtocolMapper string `json:"protocolMapper,omitempty"`
+
+	// GroupsClaim — name of the OIDC claim carrying the user's groups
+	// for RBAC. Default "groups" (per G91 + G113).
+	GroupsClaim string `json:"groupsClaim,omitempty"`
+
+	// RolesFromGroup — map of OIDC group name → application-level role.
+	// e.g. {"sovereign-admins": "admin", "tenant-admins": "editor"}.
+	RolesFromGroup map[string]string `json:"rolesFromGroup,omitempty"`
+
+	// SilentLogin — when true, the Launch button URL appends
+	// `prompt=none&kc_idp_hint=catalyst-pin` to silently SSO-bounce
+	// through KC. Default true on Tier-1/2; false on Tier-3 until
+	// per-Org realm federation is verified.
+	SilentLogin *bool `json:"silentLogin,omitempty"`
+}
+
+// MultiInstanceSpec — when present, a Blueprint may have >1
+// Application instance per Organization. Catalog cards (G117.2) show
+// the instance-count badge and "+ New instance" button when this is
+// declared. When absent, a Blueprint is singleton-per-Org.
+type MultiInstanceSpec struct {
+	// Enabled — true to permit multiple instances per Organization.
+	Enabled bool `json:"enabled"`
+
+	// MaxPerOrg — optional cap. 0 / unset = unlimited.
+	MaxPerOrg *int `json:"maxPerOrg,omitempty"`
+
+	// NamingTemplate — how the application-controller names per-instance
+	// Namespaces and Helm releases. Default `{{.AppName}}-{{.InstanceID}}`.
+	NamingTemplate string `json:"namingTemplate,omitempty"`
+
+	// IsolationLevel — `namespace` (default) | `vcluster`. When
+	// `vcluster`, each instance gets its own vCluster under the Org's
+	// tier-cluster (rtz or dmz).
+	IsolationLevel string `json:"isolationLevel,omitempty"`
+}
+
+// BlueprintSpecExtension — the new fields G117 grafts onto the existing
+// Blueprint CR's spec. Production code merges these into the existing
+// dynamic-client-driven blueprint-controller by reading them out of
+// the unstructured.Unstructured via NestedMap; this typed shape is
+// the canonical contract every other consumer (catalyst-api,
+// application-controller, admission webhook, console) imports.
+//
+// IMPORTANT: this type intentionally does NOT alias the legacy
+// `BlueprintSpec` (which lives only inside the OpenAPI CRD schema
+// today, not in Go). When the project later promotes the CRD to
+// typed kubebuilder types, BlueprintSpecExtension's fields fold into
+// the parent struct verbatim (same JSON keys).
+type BlueprintSpecExtension struct {
+	Topology      *Topology          `json:"topology,omitempty"`
+	Endpoints     []EndpointSpec     `json:"endpoints,omitempty"`
+	SSO           *SSOSpec           `json:"sso,omitempty"`
+	MultiInstance *MultiInstanceSpec `json:"multiInstance,omitempty"`
+}

--- a/docs/adr/0009-per-org-iac-repo-bootstrap.md
+++ b/docs/adr/0009-per-org-iac-repo-bootstrap.md
@@ -1,0 +1,107 @@
+# ADR-0009 — Per-Organization IaC repo bootstrap on Org creation
+
+> Status: **Accepted** (G117 Wave-0 pre-flight, 2026-06-02)
+>
+> ADR numbering preserves slots 0005-0008 for in-flight EPICs (G92/G105/G108/G112 candidates) — Wave-0 picks 0009 deliberately so this ADR can land without ordering coupling. Wave-1 may renumber if the in-flight ADRs collapse out of scope; renumbering this one is a pure-rename refactor.
+
+## Context
+
+G117 (Application Lifecycle Phase 2) needs every Organization to own a Git repo at `gitea.<sov>/<org>/iac` that stores the Org's declarative state:
+
+- `apps/` — one folder per Application instance, holding the per-instance overrides + endpoint manifests
+- `envs/` — Environment definitions (`<org>-prod`, `<org>-staging`, etc.)
+- `policies/` — Org-local Kyverno / Cilium / NetworkPolicy overrides
+- `kustomization.yaml` — Flux's entry point
+
+The Endpoints tab (G117.3) and the new-instance dialog (G117.2) both **write through this repo via PR**, not directly through catalyst-api. The pipeline is:
+
+```
+console UI ─POST→ catalyst-api ─PR→ gitea.<sov>/<org>/iac ─CI→ Kyverno+cert-mgr+DNS-conflict→ auto-merge ─Flux→ cluster
+```
+
+The PR boundary is intentional: it gives the Sovereign-admin an auditable trail, enables manual review when policy gates fail, and means the cluster state is **always** reconstructible from Git.
+
+## Decision
+
+On Organization create (organization-controller reconcile), the controller calls a new catalyst-api endpoint `POST /catalyst/v1/orgs/{org}/iac-bootstrap` which:
+
+1. Creates the Gitea Org `<org>` (idempotent; Gitea returns 422 if already exists).
+2. Creates the repo `<org>/iac` with the default tree (below).
+3. Creates a robot user `<org>-iac-bot` scoped to that single repo (`write:repository`, no Org-wide push).
+4. Enables branch protection on `main` requiring three named status checks:
+   - `kyverno-admission`
+   - `cert-manager-precheck`
+   - `dns-conflict-precheck`
+5. Installs a `bp-flux-org-subscription` HelmRelease into the management vCluster pointing at this repo's `kustomization.yaml`.
+
+### Default tree
+
+```
+/
+├── README.md                ← auto-generated; explains the PR-pipeline contract
+├── kustomization.yaml       ← lists apps/ + envs/ + policies/ as resources
+├── apps/
+│   └── .gitkeep
+├── envs/
+│   └── .gitkeep
+└── policies/
+    └── .gitkeep
+```
+
+### Robot account scope
+
+The robot user `<org>-iac-bot`:
+- Is a **per-Org**, not Sovereign-wide, account.
+- Has `write` on `<org>/iac` only — explicitly NOT `repo:admin`, NOT `org:admin`.
+- Cannot push to `<org>/iac/main` directly (branch protection forces a PR).
+- Token is stored as a Kubernetes Secret in the org's namespace (`<org>-iac-bot-token`).
+- catalyst-api reads it via External-Secrets from OpenBao when opening PRs.
+
+### Branch protection wired to the three pre-checks
+
+The PR-pipeline gate (decision #4) requires three named status checks before merge. catalyst-api configures them via Gitea's `/repos/{org}/{repo}/branch_protections` API. The three precheck names are LOCKED — any Wave-1 author touching the pipeline must keep them in sync:
+
+| Check name | Provided by | Fails when |
+|---|---|---|
+| `kyverno-admission` | per-Org Kyverno CI workflow | Manifest violates a ClusterPolicy |
+| `cert-manager-precheck` | catalyst-api at PR open time | Hostname conflicts with an existing Certificate |
+| `dns-conflict-precheck` | catalyst-api at PR open time | Hostname already pinned to a different Service in PowerDNS |
+
+### Flux subscription
+
+A single HelmRelease named `flux-org-<org>-subscription` lives in the management vCluster's `<org>` namespace. Its values:
+
+```yaml
+gitRepository:
+  url: https://gitea.<sov>/<org>/iac.git
+  ref: { branch: main }
+  secretRef:
+    name: <org>-iac-bot-token
+kustomization:
+  path: ./
+  prune: true
+  interval: 1m
+```
+
+## Alternatives considered
+
+1. **No per-Org repo; everything in the public openova/openova repo** — rejected: tenant Apps would mix with platform code; auditability collapses; tenants can't be granted PR rights.
+2. **Per-Org repo, but on the mothership Gitea (not the Sovereign's local Gitea)** — rejected: post-cutover (ADR-0002) the Sovereign must run independent of any mothership; this would re-introduce a mothership tether.
+3. **No PR pipeline; direct API writes** — rejected: defeats the auditability + policy-gate goals; admins can't see what changed before it landed.
+
+## Consequences
+
+- Adds one HelmRelease per Organization to the mgmt cluster (~minor footprint).
+- A failing Kyverno policy now blocks the PR — operators must fix the policy or fix the PR; either way the cluster state remains in last-known-good.
+- catalyst-api owns the robot-account secrets; rotation must be wired through External-Secrets just like other Sovereign-scoped secrets (G91/G112/G113 pattern).
+- Wave-1 (G117.3) authors must write the three precheck implementations as named Gitea Actions workflows; without them, the branch protection's status-check requirement traps every PR.
+
+## Executable
+
+A bash script at `tools/bootstrap-org-iac-repo.sh` performs steps 1-4 standalone (without going through catalyst-api). Idempotent. Useful for:
+
+- Bootstrapping the very first Org on a fresh Sovereign before catalyst-api is fully reconciled
+- Manual recovery if catalyst-api's bootstrap call failed mid-way
+- Integration tests (Wave-1 author can call it directly from the Playwright fixture setup)
+
+Signature: `tools/bootstrap-org-iac-repo.sh --org <slug> --sov-fqdn <fqdn>` (GITEA_TOKEN from env).

--- a/docs/api/catalyst-api-openapi.yaml
+++ b/docs/api/catalyst-api-openapi.yaml
@@ -1,0 +1,460 @@
+openapi: 3.1.0
+info:
+  title: catalyst-api — G117 Application Lifecycle Phase 2
+  description: |
+    catalyst-api endpoints that back the operator-console catalog drill-down,
+    multi-instance Application lifecycle, endpoints/Ingress tab, and silent-SSO
+    Launch button delivered by EPIC G117. This document is the binding
+    contract between:
+
+      - Wave-1 Go API authors (G117.2 + G117.6)
+      - Wave-1 console UI authors (G117.2 + G117.3 + G117.4)
+      - Wave-1 admission webhook authors (G117.1)
+
+    Source-of-truth for the new spec fields it serves:
+
+      - core/pkg/apis/blueprint/v1alpha1/topology_types.go
+      - platform/_schemas/blueprint-topology.json
+
+    All requests are JSON; all responses are JSON unless noted. Auth is
+    OIDC bearer token issued by the per-Sovereign Keycloak realm.
+  version: "1.0.0"
+  contact:
+    name: OpenOva Catalyst
+    url: https://github.com/openova-io/openova/issues/2737
+servers:
+  - url: https://api.{sovereignFqdn}/catalyst/v1
+    description: Per-Sovereign catalyst-api
+    variables:
+      sovereignFqdn:
+        default: t01.omani.works
+        description: Sovereign FQDN. Test runs use t<NN>.omani.works.
+security:
+  - bearerOidc: []
+tags:
+  - name: catalog
+    description: Blueprint catalog browsing (read-only over Gitea catalog mirror + in-cluster Blueprint CRs)
+  - name: instances
+    description: Application instances — create, list, read, delete
+  - name: endpoints
+    description: Per-Application endpoint mutation (PR-pipelined into per-Org Gitea iac repo)
+  - name: launch
+    description: Silent-SSO Launch URL minting
+paths:
+  /catalog/{blueprint}:
+    get:
+      tags: [catalog]
+      operationId: getBlueprint
+      summary: Get a Blueprint's catalog metadata + supported topologies
+      description: Returns the catalog entry assembled from the per-Sovereign Gitea catalog mirror plus live instance-count from in-cluster Application CRs. Backs the console's catalog drill-down page.
+      parameters:
+        - $ref: '#/components/parameters/BlueprintName'
+      responses:
+        '200':
+          description: Blueprint catalog entry
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CatalogBlueprint'
+        '404': { $ref: '#/components/responses/NotFound' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+  /catalog/{blueprint}/instances:
+    get:
+      tags: [catalog, instances]
+      operationId: listBlueprintInstances
+      summary: List Application instances of a given Blueprint visible to the caller
+      description: Returns Application instances filtered by Blueprint name, optionally scoped to a single Organization. Powers the per-Blueprint drill-down's instance grid.
+      parameters:
+        - $ref: '#/components/parameters/BlueprintName'
+        - name: org
+          in: query
+          description: Filter by Organization slug. When omitted, returns instances across all Orgs the caller can read.
+          schema: { type: string, pattern: '^[a-z0-9][a-z0-9-]{0,40}[a-z0-9]$' }
+      responses:
+        '200':
+          description: List of instances
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items: { $ref: '#/components/schemas/ApplicationSummary' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+  /apps/instances:
+    post:
+      tags: [instances]
+      operationId: createInstance
+      summary: Create a new Application instance from a Blueprint
+      description: |
+        Creates one Application CR with optional topology override. The
+        application-controller (G117.6) fans HelmReleases across host
+        clusters per the resolved topology.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CreateInstanceRequest' }
+      responses:
+        '201':
+          description: Application created
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Application' }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '409':
+          description: Multi-instance disabled for this Blueprint and an instance already exists in the Org
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+  /apps/{id}:
+    parameters:
+      - $ref: '#/components/parameters/AppId'
+    get:
+      tags: [instances]
+      operationId: getApp
+      summary: Get Application detail including per-cluster status
+      description: Returns the Application CR plus per-host-cluster HelmRelease status (one entry per cluster the application-controller fanned to) and resolved endpoints with current TLS + Ingress state.
+      responses:
+        '200':
+          description: Application detail
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Application' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+    delete:
+      tags: [instances]
+      operationId: deleteApp
+      summary: Delete an Application instance (cascade uninstall across all clusters)
+      description: Triggers an async uninstall Job that suspends and removes the HelmReleases on every host cluster the application-controller had fanned to, then deletes the Application CR.
+      responses:
+        '202':
+          description: Uninstall accepted (async)
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [jobId]
+                properties:
+                  jobId: { type: string }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+  /apps/{id}/endpoints:
+    parameters:
+      - $ref: '#/components/parameters/AppId'
+    get:
+      tags: [endpoints]
+      operationId: listAppEndpoints
+      summary: List all endpoints for an Application
+      description: Returns the resolved endpoints (template evaluated against this instance's context) with current cert + Ingress status. Powers the Endpoints tab on the Application detail page.
+      responses:
+        '200':
+          description: Endpoints
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items: { $ref: '#/components/schemas/ResolvedEndpoint' }
+        '404': { $ref: '#/components/responses/NotFound' }
+    post:
+      tags: [endpoints]
+      operationId: createAppEndpoint
+      summary: Create a new endpoint (opens a PR against gitea.<sov>/<org>/iac)
+      description: |
+        Triggers the IaC PR pipeline (decision #4): catalyst-api opens
+        a PR against `gitea.<sov>/<org>/iac` with the new endpoint
+        manifest; Kyverno + cert-manager + DNS-conflict pre-check
+        run as status checks; on green, auto-merge fires.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/EndpointMutationRequest' }
+      responses:
+        '202':
+          description: PR opened
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/EndpointPR' }
+        '400': { $ref: '#/components/responses/BadRequest' }
+  /apps/{id}/endpoints/{name}:
+    parameters:
+      - $ref: '#/components/parameters/AppId'
+      - name: name
+        in: path
+        required: true
+        schema: { type: string, pattern: '^[a-z][a-z0-9-]{0,30}[a-z0-9]$' }
+    patch:
+      tags: [endpoints]
+      operationId: patchAppEndpoint
+      summary: Update endpoint (PR-pipelined)
+      description: Opens a PR against the Org's iac repo with a patched endpoint manifest. Same Kyverno + cert-manager + DNS-conflict pre-check gate as createAppEndpoint.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/EndpointMutationRequest' }
+      responses:
+        '202':
+          description: PR opened
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/EndpointPR' }
+        '404': { $ref: '#/components/responses/NotFound' }
+    delete:
+      tags: [endpoints]
+      operationId: deleteAppEndpoint
+      summary: Delete endpoint (PR-pipelined)
+      description: Opens a PR removing the endpoint manifest from the Org's iac repo. cert-manager Certificate + Gateway HTTPRoute are removed on merge.
+      responses:
+        '202':
+          description: PR opened
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/EndpointPR' }
+        '404': { $ref: '#/components/responses/NotFound' }
+  /apps/{id}/launch-url:
+    parameters:
+      - $ref: '#/components/parameters/AppId'
+    get:
+      tags: [launch]
+      operationId: getLaunchURL
+      summary: Mint a silent-SSO Launch URL for an endpoint
+      description: |
+        Returns the URL the console's Launch button navigates to in a
+        new tab. URL carries silent OIDC params per locked decision #3:
+        `prompt=none&kc_idp_hint=catalyst-pin`. Target SSO budget <500ms.
+      parameters:
+        - name: endpoint
+          in: query
+          description: Endpoint name. Defaults to the Blueprint's launchDefault endpoint.
+          schema: { type: string }
+      responses:
+        '200':
+          description: Launch URL
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [url, expiresAt]
+                properties:
+                  url:
+                    type: string
+                    format: uri
+                    description: Open in a NEW tab; do NOT replace the console window.
+                  expiresAt:
+                    type: string
+                    format: date-time
+                    description: URL is one-shot; expires after 60s.
+                  endpoint:
+                    type: string
+                    description: Endpoint name actually launched (resolved from launchDefault if no query param).
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409':
+          description: Endpoint exists but does not have SSO enabled — no silent-SSO URL is possible.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+components:
+  securitySchemes:
+    bearerOidc:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    BlueprintName:
+      name: blueprint
+      in: path
+      required: true
+      description: Blueprint name (e.g. "grafana", "harbor"; with or without bp- prefix).
+      schema: { type: string, pattern: '^(bp-)?[a-z0-9][a-z0-9-]{1,40}[a-z0-9]$' }
+    AppId:
+      name: id
+      in: path
+      required: true
+      description: Application UID (returned by createInstance).
+      schema: { type: string, format: uuid }
+  responses:
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/Error' }
+    BadRequest:
+      description: Validation error
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/Error' }
+    Unauthorized:
+      description: Missing or invalid bearer token
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/Error' }
+  schemas:
+    Error:
+      type: object
+      required: [code, message]
+      properties:
+        code: { type: string }
+        message: { type: string }
+        details:
+          type: object
+          additionalProperties: true
+    BcpTopology:
+      type: string
+      enum: [active-active, active-hot-standby, active-passive, singleton]
+    CatalogBlueprint:
+      type: object
+      required: [name, version, title, instanceCount, supportedTopologies, defaultTopology, multiInstance]
+      properties:
+        name: { type: string }
+        version: { type: string }
+        title: { type: string }
+        description: { type: string }
+        family: { type: string }
+        section: { type: string }
+        instanceCount:
+          type: integer
+          minimum: 0
+          description: Number of Application instances of this Blueprint visible to the caller.
+        supportedTopologies:
+          type: array
+          items: { $ref: '#/components/schemas/BcpTopology' }
+        defaultTopology: { $ref: '#/components/schemas/BcpTopology' }
+        multiInstance:
+          type: object
+          required: [enabled]
+          properties:
+            enabled:   { type: boolean }
+            maxPerOrg: { type: integer, minimum: 0 }
+        sso:
+          type: object
+          properties:
+            realm:        { type: string }
+            silentLogin:  { type: boolean }
+        endpoints:
+          type: array
+          items: { $ref: '#/components/schemas/EndpointDeclaration' }
+    EndpointDeclaration:
+      type: object
+      required: [name, hostnameTemplate]
+      properties:
+        name:             { type: string }
+        hostnameTemplate: { type: string }
+        port:             { type: integer, minimum: 1, maximum: 65535 }
+        protocol:         { type: string, enum: [https, http, grpc, tcp, udp] }
+        tls:              { type: boolean }
+        visibility:       { type: string, enum: [public, private, internal] }
+        launchDefault:    { type: boolean }
+        ssoEnabled:       { type: boolean }
+    ResolvedEndpoint:
+      allOf:
+        - $ref: '#/components/schemas/EndpointDeclaration'
+        - type: object
+          required: [hostname, status]
+          properties:
+            hostname:
+              type: string
+              description: Result of evaluating hostnameTemplate for this Application instance.
+            status:
+              type: string
+              enum: [Pending, Provisioning, Ready, Degraded, Failed]
+            certificateStatus:
+              type: string
+              enum: [Pending, Issued, Failed]
+            launchURL:
+              type: string
+              format: uri
+              description: Convenience field; same value as GET /apps/{id}/launch-url.
+    ApplicationSummary:
+      type: object
+      required: [id, name, blueprint, org, topology, status]
+      properties:
+        id:        { type: string, format: uuid }
+        name:      { type: string }
+        blueprint: { type: string }
+        org:       { type: string }
+        topology:  { $ref: '#/components/schemas/BcpTopology' }
+        status:    { type: string, enum: [Pending, Reconciling, Ready, Degraded, Failed, Uninstalling] }
+        createdAt: { type: string, format: date-time }
+    Application:
+      allOf:
+        - $ref: '#/components/schemas/ApplicationSummary'
+        - type: object
+          properties:
+            perCluster:
+              type: array
+              description: One entry per host cluster the application-controller fanned a HelmRelease into.
+              items:
+                type: object
+                required: [cluster, role, status]
+                properties:
+                  cluster: { type: string }
+                  role:    { type: string, enum: [active, passive, singleton] }
+                  status:  { type: string, enum: [Pending, Reconciling, Ready, Degraded, Failed] }
+                  hr:      { type: string, description: HelmRelease name }
+                  message: { type: string }
+            endpoints:
+              type: array
+              items: { $ref: '#/components/schemas/ResolvedEndpoint' }
+    CreateInstanceRequest:
+      type: object
+      required: [blueprint, org, name]
+      properties:
+        blueprint:
+          type: string
+          description: Blueprint name to instantiate.
+        org:
+          type: string
+          description: Organization slug.
+        name:
+          type: string
+          description: Per-Org Application name. Must be unique within the Org for this Blueprint (unless multiInstance.enabled).
+          pattern: '^[a-z0-9][a-z0-9-]{0,40}[a-z0-9]$'
+        topology:
+          $ref: '#/components/schemas/BcpTopology'
+          description: Override the Blueprint's default. Must be in Blueprint.spec.topology.supported.
+        values:
+          type: object
+          additionalProperties: true
+          description: Per-Blueprint Helm values overrides (subject to configSchema gating).
+    EndpointMutationRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          pattern: '^[a-z][a-z0-9-]{0,30}[a-z0-9]$'
+        hostname:
+          type: string
+          description: Concrete hostname (not template). Server validates uniqueness + DNS conflict.
+        port:        { type: integer, minimum: 1, maximum: 65535 }
+        protocol:    { type: string, enum: [https, http, grpc, tcp, udp] }
+        tls:         { type: boolean }
+        visibility:  { type: string, enum: [public, private, internal] }
+        ssoEnabled:  { type: boolean }
+    EndpointPR:
+      type: object
+      required: [prURL, status]
+      properties:
+        prURL:
+          type: string
+          format: uri
+          description: Per-Org Gitea PR URL.
+        status:
+          type: string
+          enum: [open, merged, closed, failed-precheck]
+        preCheckResults:
+          type: object
+          properties:
+            kyverno:     { type: string, enum: [pending, pass, fail] }
+            certManager: { type: string, enum: [pending, pass, fail] }
+            dnsConflict: { type: string, enum: [pending, pass, fail] }

--- a/docs/sessions/2026-06-02-per-blueprint-topology-audit.md
+++ b/docs/sessions/2026-06-02-per-blueprint-topology-audit.md
@@ -1,144 +1,169 @@
-# Per-blueprint multi-region topology audit — 2026-06-02
+# Per-blueprint multi-region topology — 2026-06-02
 
-> **Scope**: every `platform/*/blueprint.yaml` in this repo, classified by canonical tier and intended multi-region topology, with the actual hw86 deploy state at audit time. Surfaced two gaps that need follow-up issues: G115 (Grafana empty datasources) and G116 (formalize `placementSchema` across all platform blueprints).
+> **Scope**: every `platform/*/blueprint.yaml` mapped to a 6-cluster reference Sovereign (2 mgmt + 2 dmz + 2 rtz, across 2 regions), with per-cluster placement, state preservation, and switchover mechanism.
+>
+> **Today's state**: most rows below describe the **intended** topology per `docs/ARCHITECTURE.md` §8 + `docs/DOD.md` Pillars 2-3. Zero blueprints currently declare `spec.placementSchema`, so the application-controller treats every install as a singleton on the primary cluster — gap tracked as **G116**. The "intended" topology in this doc is the target state to formalize.
 
-## TL;DR
+## Legend
 
-- **Zero of 56** platform blueprints declare `spec.placementSchema` today. With nothing declared, the application-controller treats every blueprint as **install-once on the primary host cluster** (mgmt). That's the de-facto answer for every app — Grafana, Keycloak, OpenBao, NATS, all of them.
-- The "intended topology" column below is sourced from [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) §3 + §8 and [`docs/DOD.md`](../DOD.md) Pillars 2-3 — **not from blueprint code**. That is the gap to formalize → **G116**.
-- DoD Pillar 3 ("Two independent CNPG clusters + region-kill failover") relies on `bp-cnpg-pair`, which **no Org has activated on hw86**. Multi-Region capability is UNVERIFIED on the verification ledger.
-- Grafana renders empty because no datasource ConfigMaps + no default dashboards are auto-provisioned by `bp-grafana` → **G115**.
+| Code | Meaning |
+|---|---|
+| 🟢 **A** | **Active** — serves live traffic |
+| 🟡 **P** | **Passive** — warm/hot standby, ready to take over |
+| 🔵 **S** | **Singleton independent** — its own state, no cross-cluster sync |
+| ⬜ blank | **Not deployed** in this cluster |
 
-## The 4-row example (the rows asked for first)
+Cluster columns are the 6 host-clusters of the reference Sovereign:
 
-| App | Tier (per ARCHITECTURE.md §3) | Intended multi-region topology | hw86 actual today |
-|---|---|---|---|
-| **bp-catalyst-platform** | Catalyst control-plane | Per-Sovereign-cluster singleton on mgmt; cross-region = LB picks healthy Sovereign-cluster; DR via `bp-self-sovereign-cutover` reinstall | mgmt region-a only (no region-b clone) |
-| **bp-openbao** | Catalyst control-plane | Raft StatefulSet 3–5 replicas per Sovereign cluster; **cross-region = INDEPENDENT vault per region**, unseal keys re-distributed (NOT a single global cluster — Raft consensus across regions = too much latency) | 1 region-a StatefulSet, recovery-seed lookup via [chart-credential-persistence pattern](../../platform/openbao/chart/templates/recovery-seed-bootstrap.yaml). region-b: not installed |
-| **bp-grafana** | Catalyst control-plane (Observability) | Per-Sovereign singleton (1–2 replicas) backed by Loki/Mimir/Tempo S3; cross-region = independent install per region, dashboards NOT replicated (operator-rebuild) | 1 region-a Pod (Bitnami chart), backed by SeaweedFS S3. **Empty because no datasource ConfigMaps + no default dashboards auto-provisioned → G115.** region-b: not installed |
-| **bp-opensearch** | **Application Blueprint (per-Org vCluster)** — NOT control-plane | Per-Org vCluster multi-node cluster (3-master + 3-data typical); cross-region = opt-in `bp-opensearch-cross-cluster-replication` sub-blueprint | Not installed on hw86 (no Org has activated it yet) |
+- `mgmt-A` / `mgmt-B` — Catalyst control-plane clusters (1 per region; Pillar-3 multi-region CP)
+- `dmz-A` / `dmz-B` — DMZ tenant workload clusters
+- `rtz-A` / `rtz-B` — Regulated tenant workload clusters
 
-## Catalyst control-plane tier (mgmt cluster only, primary Sovereign-cluster)
+> **Note on mgmt × 2**: today only `mgmt-A` exists (per `ARCHITECTURE.md` §8 — "Management host cluster (one per Sovereign)"). The `mgmt-B` column is the Pillar-3 multi-region CP target state; rows that show 🟢 A / 🟡 P across `mgmt-A` / `mgmt-B` describe the intended HA shape, NOT current deploy.
 
-| Blueprint | placementSchema declared? | Intended topology | hw86 region-a | hw86 region-b |
-|---|---|---|---|---|
-| bp-catalyst-platform | ❌ no | Singleton on mgmt | installed | — |
-| bp-keycloak | ❌ no | Singleton (1 KC + 1 PG) per Sovereign | installed | post-upgrade hook fail (blocks region-b cascade) |
-| bp-openbao | ❌ no | Raft 3-5 / Sovereign, **independent per region** | installed | — |
-| bp-gitea | ❌ no | Singleton (1 replica + 1 PG) per Sovereign | installed | — |
-| bp-harbor | ❌ no | Singleton (registry + 1 PG + Redis) per Sovereign; OBS-backed | installed (357MB blob OBS-stall risk) | — |
-| bp-grafana | ❌ no | Singleton per Sovereign; S3-backed datasources | installed (empty — G115) | — |
-| bp-loki | ❌ no | Multi-replica cluster per Sovereign; OBS-backed | installed | — |
-| bp-mimir | ❌ no | Multi-replica cluster per Sovereign; OBS-backed | installed | — |
-| bp-tempo | ❌ no | Multi-replica per Sovereign; OBS-backed | installed | — |
-| bp-alloy | ❌ no | DaemonSet (every node every cluster) | DS on region-a nodes | DS on region-b nodes |
-| bp-nats-jetstream | ❌ no | 3-node JetStream per Sovereign cluster (NOT cross-region replicated) | installed | — |
-| bp-guacamole | ❌ no | Singleton per Sovereign | installed | — |
-| bp-k8s-ws-proxy | ❌ no | Singleton per Sovereign | installed | — |
-| bp-newapi | ❌ no | Singleton per Sovereign | installed | — |
-| bp-sso-bridge | ❌ no | Singleton per Sovereign (G91/G112/G113 chain) | installed | — |
-| bp-self-sovereign-cutover | ❌ no | One-shot Jobs at handover (dormant otherwise) | dormant | dormant |
+## Catalyst control-plane tier
 
-## Per-host-cluster infrastructure tier (installed in EVERY host cluster: mgmt + rtz + dmz)
+> Runs in mgmt clusters only. Cross-region HA = active in `mgmt-A`, hot/warm standby in `mgmt-B`. State preserved via `bp-cnpg-pair` (Postgres) + SeaweedFS S3 (blobs) + OpenBao perf-replication (secrets). Switchover orchestrated by `bp-continuum`.
 
-| Blueprint | placementSchema declared? | Intended topology | hw86 region-a | hw86 region-b |
-|---|---|---|---|---|
-| bp-cilium | ❌ no | DaemonSet per node | DS | DS |
-| bp-cilium-policies | ❌ no | CRDs per host cluster | applied | applied |
-| bp-flux | ❌ no | 3-controller HA per host cluster | installed | installed |
-| bp-gateway-api | ❌ no | Per host cluster | installed | installed |
-| bp-vcluster-helmrepo | ❌ no | Per host cluster | installed | installed |
-| bp-mgmt-vcluster | ❌ no | One per host cluster (mgmt placement) | installed | n/a (no mgmt vCluster in region-b) |
-| bp-rtz-vcluster | ❌ no | One per host cluster (regulated/tenant) | installed | installed |
-| bp-dmz-vcluster | ❌ no | One per host cluster (DMZ tenant) | installed | installed |
-| bp-cnpg | ❌ no | Operator per host cluster | installed | installed |
-| bp-cnpg-pair | ❌ no | **Active-hot-standby PAIR via Cilium ClusterMesh + sync replication (DoD Pillar 3)** | **NOT shipped end-to-end — Pillar 3 UNVERIFIED** | — |
-| bp-crossplane | ❌ no | Per host cluster | installed | installed |
-| bp-crossplane-claims | ❌ no | Per host cluster | applied | applied |
-| bp-cert-manager | ❌ no | Per host cluster | installed | installed |
-| bp-cert-manager-powerdns-webhook | ❌ no | Per host cluster | installed | installed |
-| bp-cert-manager-dynadot-webhook | ❌ no | Per host cluster | installed | installed |
-| bp-external-secrets | ❌ no | Per host cluster | installed | installed |
-| bp-external-secrets-stores | ❌ no | Per host cluster | applied | applied |
-| bp-external-dns | ❌ no | Per host cluster | installed | installed |
-| bp-powerdns | ❌ no | Per host cluster HA pair | installed | installed |
-| bp-powerdns-admin | ❌ no | Per host cluster | installed | installed |
-| bp-sealed-secrets | ❌ no | Per host cluster controller | installed | installed |
-| bp-coraza | ❌ no | Per host cluster (Gateway WAF) | installed | installed |
-| bp-kyverno | ❌ no | Per host cluster | installed | installed |
-| bp-kyverno-policies | ❌ no | Per host cluster (policy CRs) | applied | applied |
-| bp-trivy | ❌ no | Per host cluster operator | installed | installed |
-| bp-falco | ❌ no | DaemonSet per node | DS | DS |
-| bp-sigstore | ❌ no | Per host cluster | installed | installed |
-| bp-syft-grype | ❌ no | Per host cluster | installed | installed |
-| bp-vpa | ❌ no | Per host cluster | installed | installed |
-| bp-reloader | ❌ no | Per host cluster | installed | installed |
-| bp-reflector | ❌ no | Per host cluster | installed | installed |
-| bp-seaweedfs | ❌ no | Per host cluster multi-replica (S3 backend) | installed | installed |
-| bp-velero | ❌ no | Per host cluster (backup) | installed | installed |
-| bp-hcloud-ccm | ❌ no | DaemonSet per node (Hetzner only) | n/a on Huawei | n/a |
-| bp-hcloud-csi | ❌ no | DaemonSet per node (Hetzner only) | n/a on Huawei | n/a |
-| bp-cluster-autoscaler-hcloud | ❌ no | Per host cluster (Hetzner only) | n/a on Huawei | n/a |
-| bp-opentelemetry | ❌ no | Per host cluster collector | installed | installed |
-| bp-opentelemetry-operator | ❌ no | Per host cluster | installed | installed |
-| bp-network-policies | ❌ no | Hollow chart; per host cluster | dormant | dormant |
-| bp-netbird | ❌ no | Mesh-VPN (Catalyst-CP candidate) | not installed | — |
-| bp-spire | ❌ no | Workload identity (Catalyst-CP candidate) | not installed | — |
-| bp-openclaw | ❌ no | TBD scaffold | dormant | dormant |
+| Blueprint | mgmt-A | mgmt-B | dmz-A | dmz-B | rtz-A | rtz-B | Stateful? | State preservation | Switchover |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|---|---|---|
+| bp-catalyst-platform | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (Catalyst CRDs in etcd + PG state) | CRDs replicated via `bp-cnpg-pair` (etcd-backed via Catalyst-api PG); deployments are reconcilable from Git | `bp-continuum` flips PowerDNS for `console.<sov>` + `api.<sov>`; standby promotes once CNPG primary flips |
+| bp-keycloak | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (KC realm config + sessions in PG) | PG via `bp-cnpg-pair` sync `remote_apply`; user sessions are JWT (stateless on KC) | `bp-continuum` PG promote → KC pod on standby is already running → DNS flip `auth.<sov>` (~30s TTL) |
+| bp-openbao | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (Raft store on PVC; 3-5 replicas/cluster) | Within cluster: Raft consensus. Cross-cluster: async perf-replication (OSS uses snapshot+restore; Enterprise has native primary→replica) | `bp-continuum` runs `vault operator raft transition-to-primary` on the standby; KV reads continue uninterrupted on replica throughout |
+| bp-gitea | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (PG + Git repo blobs on PVC) | Postgres via `bp-cnpg-pair` sync; Git blobs land on SeaweedFS S3 mirrored cross-region (async, ~seconds lag) | `bp-continuum` PG demote/promote + PowerDNS flip for `gitea.<sov>` (30s TTL); Git push paused ~5s |
+| bp-harbor | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (PG + Redis + image blobs on object storage) | PG via `bp-cnpg-pair`; image blobs on Huawei OBS / Hetzner S3 (cross-region replication = provider-native bucket replication, async) | `bp-continuum` PG flip + PowerDNS flip for `registry.<sov>` + `harbor.<sov>`; blob pulls keep working through replica bucket on standby region |
+| bp-grafana | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (Grafana DB + dashboards) | Grafana DB on `bp-cnpg-pair` sync; dashboards rendered from Loki/Mimir/Tempo which themselves write to SeaweedFS S3 replicated cross-region | `bp-continuum` DNS flip for `grafana.<sov>`; downstream Grafana on standby reads same shared S3 backend — ~30s convergence on TTL |
+| bp-loki | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (chunks on S3, index on object storage) | All persistent state on object storage (SeaweedFS or provider S3); cross-region = bucket replication async | `bp-continuum` DNS flip for `loki.<sov>`; standby Loki reads same chunks (eventually-consistent) — Active-Active feasible if read-only queries split |
+| bp-mimir | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (TSDB blocks on object storage) | All persistent state on object storage; cross-region bucket replication | `bp-continuum` DNS flip; standby Mimir queriers read same blocks |
+| bp-tempo | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (traces on object storage) | All persistent state on object storage; cross-region bucket replication | `bp-continuum` DNS flip; standby Tempo queriers read same blocks |
+| bp-alloy | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (telemetry shipper, DaemonSet) | n/a — stateless; each node's Alloy ships to local Loki/Mimir/Tempo endpoint | n/a — DS on every node; node failure means kubelet replaces the Pod |
+| bp-nats-jetstream | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (JetStream Raft cluster within mgmt) | Within mgmt: 3-node JetStream cluster (Raft). Cross-cluster: NATS leaf-node tunnel only — streams NOT replicated by default | `bp-continuum` leaf-node retarget + DNS flip; in-flight messages on lost region drop unless `stream.mirror` enabled |
+| bp-guacamole | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (PG with session + connection config) | PG via `bp-cnpg-pair` sync | `bp-continuum` PG flip + DNS flip for `guac.<sov>` (~30s); in-progress remote-desktop sessions drop |
+| bp-k8s-ws-proxy | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | no (stateless WebSocket proxy) | n/a — Pods are stateless; routing comes from Kubernetes API which Catalyst-api supplies | `bp-continuum` DNS flip; new connections route to standby Pod immediately, in-flight WS sessions drop |
+| bp-newapi | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | no (stateless API) | n/a — config from CRDs + values | DNS flip via `bp-continuum` |
+| bp-sso-bridge | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | no (stateless auth bridge — G91/G112/G113 chain) | n/a — secrets via External-Secrets / openbao | DNS flip via `bp-continuum` |
+| bp-self-sovereign-cutover | 🟢 A | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | no (one-shot Jobs at handover) | n/a — Jobs run once then terminate (dormant on standby until activated) | n/a — single-shot pivot operation; if mgmt-A is lost mid-cutover, the cutover must be re-run from standby once promoted |
 
-## Application Blueprints (installed per-Org inside vClusters, NOT at platform install)
+## Per-host-cluster infrastructure tier
 
-| Blueprint | placementSchema declared? | Intended topology | hw86 today |
-|---|---|---|---|
-| bp-ferretdb | ❌ no | Per-Org vCluster (1+ replica) | none installed (no Org activated) |
-| bp-valkey | ❌ no | Per-Org vCluster cluster | none |
-| bp-strimzi | ❌ no | Per-Org vCluster Kafka | none |
-| bp-clickhouse | ❌ no | Per-Org vCluster cluster | none |
-| bp-opensearch | ❌ no | Per-Org vCluster cluster | none |
-| bp-stalwart-tenant | ❌ no | Per-Org vCluster mail | none |
-| bp-stalwart-sovereign | ❌ no | Per Sovereign (mothership mail) | external (mail.openova.io) |
-| bp-livekit | ❌ no | Per-Org vCluster | none |
-| bp-matrix | ❌ no | Per-Org vCluster | none |
-| bp-stunner | ❌ no | Per-Org vCluster TURN | none |
-| bp-milvus | ❌ no | Per-Org vCluster | none |
-| bp-neo4j | ❌ no | Per-Org vCluster | none |
-| bp-vllm | ❌ no | Per-Org vCluster GPU | none |
-| bp-kserve | ❌ no | Per-Org vCluster GPU | none |
-| bp-knative | ❌ no | Per-Org vCluster | none |
-| bp-librechat | ❌ no | Per-Org vCluster | none |
-| bp-bge | ❌ no | Per-Org vCluster | none |
-| bp-llm-gateway | ❌ no | Per-Org vCluster | none |
-| bp-anthropic-adapter | ❌ no | Per-Org vCluster | none |
-| bp-langfuse | ❌ no | Per-Org vCluster | none |
-| bp-nemo-guardrails | ❌ no | Per-Org vCluster | none |
-| bp-temporal | ❌ no | Per-Org vCluster | none |
-| bp-flink | ❌ no | Per-Org vCluster | none |
-| bp-debezium | ❌ no | Per-Org vCluster | none |
-| bp-iceberg | ❌ no | Per-Org vCluster | none |
-| bp-openmeter | ❌ no | Per-Org vCluster | none |
-| bp-litmus | ❌ no | Per-Org vCluster chaos | none |
-| bp-wordpress-tenant | ❌ no | Per-Org vCluster | none |
-| bp-qa-app | ❌ no | Test scaffold | none |
+> Runs in **every** host cluster; each cluster owns its own copy. Cross-cluster sync **is not part of these blueprints** — they're cluster-local infrastructure. Failover is N/A: a cluster failure removes one cluster's instance; the others keep running independently.
 
-## Two findings that fall out of this table
+| Blueprint | mgmt-A | mgmt-B | dmz-A | dmz-B | rtz-A | rtz-B | Stateful? | State preservation | Switchover |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|---|---|---|
+| bp-cilium | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (identity allocator CRDs) | NOT replicated — each cluster owns identity space. ClusterMesh shares **endpoint reachability only**, not control state | n/a — independent per cluster |
+| bp-cilium-policies | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (CiliumNetworkPolicy CRs per cluster) | Replicated via Flux from this repo (Git is the source of truth) | n/a — declarative; Flux reconciles per cluster |
+| bp-flux | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (Helm release state + Kustomization status) | Each cluster's Flux state is local. Source-of-truth is the upstream Git repo replicated to Gitea (which IS cross-region replicated) | n/a — each cluster pulls from Gitea after cutover |
+| bp-gateway-api | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (Gateway/HTTPRoute CRs) | Source-of-truth is Git/Flux | n/a |
+| bp-vcluster-helmrepo | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (HelmRepository reference) | n/a — pointer to OCI registry | n/a |
+| bp-mgmt-vcluster | 🔵 S | 🔵 S | ⬜ | ⬜ | ⬜ | ⬜ | yes (vCluster's own k8s state in PVC) | vCluster state on local PVC; not cross-cluster replicated | Pillar-3 plan: mgmt-A vCluster state replicates to mgmt-B vCluster via Velero scheduled backups + restore-on-failover |
+| bp-rtz-vcluster | ⬜ | ⬜ | ⬜ | ⬜ | 🔵 S | 🔵 S | yes (vCluster state in PVC) | Per-cluster; cross-region failover = Velero restore + re-bind tenant Apps | Per-Org tenant decision via `bp-continuum` Org policy |
+| bp-dmz-vcluster | ⬜ | ⬜ | 🔵 S | 🔵 S | ⬜ | ⬜ | yes (vCluster state in PVC) | Per-cluster | Same as bp-rtz-vcluster |
+| bp-cnpg | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (operator; the Clusters it manages are stateful) | Operator code is stateless; Cluster CRs it manages are replicated by `bp-cnpg-pair` | n/a — operator |
+| bp-cnpg-pair | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (PG WAL + data PVC) | **Sync streaming replication** (`remote_apply`) over Cilium ClusterMesh — zero-tx-loss; pair lives within matching tier (rtz↔rtz, dmz↔dmz, mgmt↔mgmt) | `bp-continuum` lease + CNPG `cnpg promote`; PowerDNS lua-record flip for `db.<org>.<sov>` (~5s write disruption, bank-tier RTO) |
+| bp-crossplane | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (provider state in CRDs) | Provider state local; source-of-truth in Git via Composition CRs | n/a |
+| bp-crossplane-claims | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (Claim CRs) | Replicated via Flux from Git | n/a |
+| bp-cert-manager | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (Certificate + Order CRs + Secrets) | Each cluster owns its certs; OpenBao perf-replication carries the wildcard root if used | Per-cluster — cluster failure means re-issue on the surviving cluster's cert-manager |
+| bp-cert-manager-powerdns-webhook | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (webhook) | n/a | n/a |
+| bp-cert-manager-dynadot-webhook | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (webhook) | n/a | n/a |
+| bp-external-secrets | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (ExternalSecret CRs + cached Secrets) | Secrets pulled fresh from OpenBao on each refresh; cache rebuilds from source | n/a — pulls from cluster-local OpenBao replica |
+| bp-external-secrets-stores | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (ClusterSecretStore CRs) | Replicated via Flux | n/a |
+| bp-external-dns | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (controller; PowerDNS is the state) | n/a — writes to PowerDNS REST API | n/a |
+| bp-powerdns | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (PG-backed authoritative records) | Each cluster runs its own PowerDNS auth + recursor pair. Lua-record health-checked failover across clusters is the cross-cluster mechanism | n/a within cluster; cross-cluster failover via lua-record `ifurlup` (auto, ~30s TTL) |
+| bp-powerdns-admin | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (admin UI state in PG) | Per-cluster PG | n/a — admin UI; if a cluster's instance dies, edit via another cluster |
+| bp-sealed-secrets | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (sealing keypair in cluster) | Sealing private key cluster-local; decrypts only what was sealed against its public half | n/a — each cluster owns its own sealing identity; SealedSecret CRs are tagged with cluster scope |
+| bp-coraza | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (WAF rules; rule corpus from Git) | n/a — rules from CoreRuleSet via Git | n/a |
+| bp-kyverno | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (policy CRs + report CRs) | Policies replicated via Flux; reports are local (current-state) | n/a |
+| bp-kyverno-policies | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (ClusterPolicy CRs) | Replicated via Flux | n/a |
+| bp-trivy | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (vuln scan reports as CRs) | Reports local; rebuilds on re-scan | n/a |
+| bp-falco | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (DaemonSet, events ship to Loki) | n/a — events shipped out | n/a |
+| bp-sigstore | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (cosign keypair) | Per-cluster | n/a |
+| bp-syft-grype | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (SBOM + vuln pipeline) | n/a | n/a |
+| bp-vpa | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (VPA recommendation CRs) | Per-cluster; rebuilds from observed Pod history | n/a |
+| bp-reloader | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (controller) | n/a | n/a |
+| bp-reflector | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (controller) | n/a | n/a |
+| bp-seaweedfs | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (S3 object store + filer DB) | Within cluster: replicas + erasure coding. Cross-cluster: SeaweedFS Filer Remote Storage / S3 bucket replication (configurable) | n/a within cluster; cross-cluster replication is async pull |
+| bp-velero | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (backup catalog in PVC + blobs on S3) | Backup blobs land on per-Sovereign S3 (replicated cross-region by provider) | n/a — restore is operator-initiated |
+| bp-hcloud-ccm | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | n/a (Hetzner-only; not used on Huawei reference Sovereign) | — | — |
+| bp-hcloud-csi | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | n/a (Hetzner-only) | — | — |
+| bp-cluster-autoscaler-hcloud | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | n/a (Hetzner-only) | — | — |
+| bp-opentelemetry | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (collector) | n/a | n/a |
+| bp-opentelemetry-operator | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (operator) | n/a | n/a |
+| bp-network-policies | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (NetworkPolicy CRs; hollow chart placeholder) | Replicated via Flux | n/a |
+| bp-netbird | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (management state in PG) | PG via `bp-cnpg-pair` (candidate; not currently installed) | Candidate Catalyst-CP — `bp-continuum` flip when wired |
+| bp-spire | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (SPIRE Server datastore in PG/sqlite) | PG via `bp-cnpg-pair` (candidate; not currently installed) | Candidate Catalyst-CP |
+| bp-openclaw | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | yes (scaffold; TBD) | TBD | TBD |
+
+## Application Blueprints (per-Org, inside vClusters)
+
+> Installed by tenants per-Org. The vCluster they live in sits in `rtz` or `dmz` tier. Cross-region HA inside a single Org's vCluster is the **vCluster-itself**'s job (state in PVC + Velero); the App Blueprint's own state replication is per-App-Blueprint and listed below.
+
+| Blueprint | mgmt-A | mgmt-B | dmz-A | dmz-B | rtz-A | rtz-B | Stateful? | State preservation | Switchover |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|---|---|---|
+| bp-ferretdb | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (MongoDB-API over PG backend) | PG via `bp-cnpg-pair` sync; ferretdb itself is stateless | `bp-continuum` PG flip → ferretdb on standby is already running |
+| bp-valkey | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (in-memory + AOF persistence) | Redis-style replication (master + replicas); cross-region = sentinel-pair across clusters via ClusterMesh | `bp-continuum` runs Sentinel failover; clients reconnect (~5s) |
+| bp-strimzi | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | yes (Kafka log on PVC) | Per-cluster Kafka cluster; cross-region = Strimzi MirrorMaker2 (async replication of topics) | Active-Active topics replicate both ways; consumer offset translation via MM2 |
+| bp-clickhouse | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | yes (sharded + replicated MergeTree) | ClickHouse native replication via ZooKeeper/Keeper; cross-region = each region runs its own replica of the same shard | DNS flip; replicas keep ingesting on the surviving region |
+| bp-opensearch | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | yes (Lucene indices on PVC) | OpenSearch cross-cluster replication (CCR) — opt-in `bp-opensearch-cross-cluster-replication` sub-blueprint | DNS flip; CCR follower keeps catching up from leader writes |
+| bp-stalwart-tenant | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (mail blobs on S3; metadata in PG) | PG via `bp-cnpg-pair`; mail blobs on tenant S3 bucket replicated cross-region | `bp-continuum` PG flip + DNS flip for `mail.<org>.<sov>` |
+| bp-stalwart-sovereign | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | external — runs on OpenOva mothership (mail.openova.io), not on this Sovereign | external | external |
+| bp-livekit | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless SFU; rooms ephemeral) | n/a — rooms exist while at least one participant is connected | DNS flip; new rooms route to surviving region |
+| bp-matrix | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (homeserver DB in PG + media on S3) | PG via `bp-cnpg-pair`; media on S3 cross-region replicated | `bp-continuum` PG flip + DNS flip for `matrix.<org>.<sov>` |
+| bp-stunner | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless TURN/STUN relay) | n/a | DNS flip; new ICE sessions route to surviving region |
+| bp-milvus | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (vector index on S3 + metadata in etcd) | etcd + S3 cross-region replication | `bp-continuum` DNS flip; standby Milvus queriers read same S3 |
+| bp-neo4j | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (graph store on PVC) | Neo4j Causal Clustering (Enterprise) or core+read-replica (Community); cross-region = backup-restore on PVC | `bp-continuum` promote read-replica to core or restore from Velero |
+| bp-vllm | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless inference; GPU-bound) | n/a — model weights on shared PVC or pre-baked in image | DNS flip; new requests route to surviving region |
+| bp-kserve | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless model serving) | n/a — model artifacts on S3 | DNS flip |
+| bp-knative | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (controller; serverless Pods are ephemeral) | n/a | DNS flip; scale-to-zero unaffected |
+| bp-librechat | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | yes (chat history in Mongo/PG) | PG via `bp-cnpg-pair`; UI itself stateless | `bp-continuum` PG flip + DNS flip |
+| bp-bge | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless embedding service) | n/a — model in image | DNS flip |
+| bp-llm-gateway | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless proxy) | n/a — secrets via External-Secrets | DNS flip |
+| bp-anthropic-adapter | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless adapter) | n/a | DNS flip |
+| bp-langfuse | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (traces in PG + ClickHouse) | PG via `bp-cnpg-pair`; ClickHouse replicated within Org | `bp-continuum` PG flip + DNS flip |
+| bp-nemo-guardrails | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless policy enforcement) | n/a — policies from Git | DNS flip |
+| bp-temporal | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (history in PG + visibility in ES/OpenSearch) | PG via `bp-cnpg-pair`; visibility store via bp-opensearch CCR | `bp-continuum` PG flip + DNS flip; workflows resume from history |
+| bp-flink | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (jobmanager state + checkpoints on S3) | Checkpoints on S3 cross-region replicated; jobmanager HA via ZooKeeper/k8s leader-election | `bp-continuum` jobmanager re-elect on standby; flink resumes from last checkpoint |
+| bp-debezium | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (offsets in Kafka) | Offsets in bp-strimzi (replicated via MM2) | `bp-continuum` restarts connector on standby reading from latest Kafka offset |
+| bp-iceberg | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | yes (table metadata + data files on S3) | All state on S3; catalog (Hive/REST) is the only stateful service | DNS flip on catalog; data plane keeps reading same S3 |
+| bp-openmeter | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (events in ClickHouse + state in PG) | PG via `bp-cnpg-pair`; ClickHouse replicated within Org | `bp-continuum` PG flip + DNS flip |
+| bp-litmus | ⬜ | ⬜ | ⬜ | ⬜ | 🔵 S | 🔵 S | yes (experiment runs in MongoDB) | Per-cluster — chaos experiments are intentionally cluster-scoped | n/a |
+| bp-wordpress-tenant | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (PG + media on S3) | PG via `bp-cnpg-pair`; media on tenant S3 bucket cross-region replicated | `bp-continuum` PG flip + DNS flip for `<site>.<org>.<sov>` |
+| bp-qa-app | ⬜ | ⬜ | ⬜ | ⬜ | 🔵 S | 🔵 S | no (test scaffold) | n/a | n/a |
+
+## Topology patterns this captures
+
+| Pattern | Example | Cells signature |
+|---|---|---|
+| **CP-tier HA** (mgmt active/standby) | bp-gitea, bp-grafana, bp-openbao, bp-keycloak | 🟢 A + 🟡 P in mgmt cols, rest blank |
+| **Independent per cluster** (no inter-cluster sync) | bp-cilium, bp-flux, bp-cert-manager | 🔵 S in every cluster the chart is installed in |
+| **Cross-region sync pair** (App-tier or CP-tier DB) | bp-cnpg-pair | 🟢 A + 🟡 P in matching cluster across regions |
+| **DaemonSet** | bp-alloy, bp-falco | 🔵 S × 6 (every cluster, every node) |
+| **Active-Active load-balanced** | bp-strimzi, bp-clickhouse, bp-opensearch, stateless APIs | 🟢 A + 🟢 A in same tier across regions |
+| **External / mothership-hosted** | bp-stalwart-sovereign | all cells blank, note "external" |
+| **One-shot Job** | bp-self-sovereign-cutover | 🟢 A in single cluster, dormant elsewhere |
+
+## Gaps surfaced by this audit
 
 ### G115 — bp-grafana auto-provision datasources + default dashboards
 
-Grafana renders empty on hw86 because the bp-grafana chart does NOT ship pre-baked `datasource` ConfigMaps for the colocated Loki/Mimir/Tempo, nor any default dashboards. An operator landing on a freshly-deployed Grafana has nothing to look at — defeating the "click and observe" Pillar 1 intent. Fix scope:
+Grafana renders empty on hw86 because the bp-grafana chart does NOT ship pre-baked `datasource` ConfigMaps for the colocated Loki/Mimir/Tempo, nor any default dashboards. Fix scope:
 
-- Add `templates/datasource-configmaps.yaml` with `prometheus`, `loki`, `tempo`, `mimir` datasources pointing at the in-cluster Service DNS (`http://mimir-nginx.observability.svc:80`, etc.).
-- Add `templates/dashboard-configmaps.yaml` with a starter pack (cluster-overview, node-exporter, kube-state, OpenBao audit, Flux reconcile health).
-- Use Grafana's sidecar-discovery pattern (`grafana.sidecar.datasources.enabled=true` + `grafana.sidecar.dashboards.enabled=true`) so additions are hot-loadable.
+- Add `templates/datasource-configmaps.yaml` with `prometheus`, `loki`, `tempo`, `mimir` datasources pointing at in-cluster Service DNS.
+- Add `templates/dashboard-configmaps.yaml` with a starter pack (cluster overview, node-exporter, kube-state, OpenBao audit, Flux reconcile health).
+- Use Grafana sidecar-discovery (`grafana.sidecar.datasources.enabled=true` + `grafana.sidecar.dashboards.enabled=true`) so additions are hot-loadable.
 
 ### G116 — formalize `placementSchema` across all platform Blueprints
 
-The `Blueprint` CRD already defines `spec.placementSchema` (per [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) §3 row 457) with shape `{vcluster: "mgmt|rtz|dmz|''", bcpTopology: "active-active|active-passive|active-hot-standby|singleton", regions: [...]}`. Zero blueprints populate it. The application-controller therefore has no machine-readable topology declaration to switch on — every install ends up as a chart-default singleton on the primary cluster.
+The `Blueprint` CRD already defines `spec.placementSchema` (per `ARCHITECTURE.md` §3) with shape `{vcluster: "mgmt|rtz|dmz|''", bcpTopology: "active-active|active-passive|active-hot-standby|singleton", regions: [...]}`. **Zero blueprints populate it.** Application-controller therefore has no machine-readable topology declaration to switch on — every install ends up as a chart-default singleton on the primary cluster.
 
 Fix scope:
 
-- Author a `placementSchema` block for each `platform/*/blueprint.yaml` matching the "Intended topology" column above. Catalyst-CP rows → `{vcluster: mgmt, bcpTopology: singleton}`. Per-host-cluster rows → `{vcluster: '', bcpTopology: per-cluster}`. Application rows → `{vcluster: rtz, bcpTopology: <as required>}`.
+- Author a `placementSchema` block for each `platform/*/blueprint.yaml` matching the per-cluster placement column above.
 - CI gate: blueprint admission webhook rejects new blueprints without `placementSchema`.
 - application-controller honors `placementSchema.bcpTopology` when fanning HRs across host clusters (G92 EPIC already wired the kubeConfig pivot — the gap is the data shape, not the controller).
+
+### Pillar 3 (`bp-cnpg-pair` cross-region failover) is UNVERIFIED
+
+No Org on hw86 has activated `bp-cnpg-pair`. The active-hot-standby PAIR + Cilium ClusterMesh + sync replication + Continuum lease+DNS-flip chain has not been walked end-to-end. Verification ledger row stays UNVERIFIED until a tenant-flow walk + region-kill drill is shot.
 
 ## How this table was generated
 
@@ -154,4 +179,4 @@ for bp in sorted(glob.glob("platform/*/blueprint.yaml")):
 PYEOF
 ```
 
-Pair the output with the canonical 3-tier table in [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) §3 + the DoD Pillar 2/3 invariants in [`docs/DOD.md`](../DOD.md) to populate the intended-topology column.
+Per-row intended topology cross-referenced against `docs/ARCHITECTURE.md` §3 + §8 and `docs/DOD.md` Pillars 2-3.

--- a/docs/sessions/2026-06-02-per-blueprint-topology-audit.md
+++ b/docs/sessions/2026-06-02-per-blueprint-topology-audit.md
@@ -25,109 +25,109 @@ Cluster columns are the 6 host-clusters of the reference Sovereign:
 
 > Runs in mgmt clusters only. Cross-region HA = active in `mgmt-A`, hot/warm standby in `mgmt-B`. State preserved via `bp-cnpg-pair` (Postgres) + SeaweedFS S3 (blobs) + OpenBao perf-replication (secrets). Switchover orchestrated by `bp-continuum`.
 
-| Blueprint | mgmt-A | mgmt-B | dmz-A | dmz-B | rtz-A | rtz-B | Stateful? | State preservation | Switchover |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|---|---|---|
-| bp-catalyst-platform | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (Catalyst CRDs in etcd + PG state) | CRDs replicated via `bp-cnpg-pair` (etcd-backed via Catalyst-api PG); deployments are reconcilable from Git | `bp-continuum` flips PowerDNS for `console.<sov>` + `api.<sov>`; standby promotes once CNPG primary flips |
-| bp-keycloak | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (KC realm config + sessions in PG) | PG via `bp-cnpg-pair` sync `remote_apply`; user sessions are JWT (stateless on KC) | `bp-continuum` PG promote → KC pod on standby is already running → DNS flip `auth.<sov>` (~30s TTL) |
-| bp-openbao | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (Raft store on PVC; 3-5 replicas/cluster) | Within cluster: Raft consensus. Cross-cluster: async perf-replication (OSS uses snapshot+restore; Enterprise has native primary→replica) | `bp-continuum` runs `vault operator raft transition-to-primary` on the standby; KV reads continue uninterrupted on replica throughout |
-| bp-gitea | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (PG + Git repo blobs on PVC) | Postgres via `bp-cnpg-pair` sync; Git blobs land on SeaweedFS S3 mirrored cross-region (async, ~seconds lag) | `bp-continuum` PG demote/promote + PowerDNS flip for `gitea.<sov>` (30s TTL); Git push paused ~5s |
-| bp-harbor | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (PG + Redis + image blobs on object storage) | PG via `bp-cnpg-pair`; image blobs on Huawei OBS / Hetzner S3 (cross-region replication = provider-native bucket replication, async) | `bp-continuum` PG flip + PowerDNS flip for `registry.<sov>` + `harbor.<sov>`; blob pulls keep working through replica bucket on standby region |
-| bp-grafana | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (Grafana DB + dashboards) | Grafana DB on `bp-cnpg-pair` sync; dashboards rendered from Loki/Mimir/Tempo which themselves write to SeaweedFS S3 replicated cross-region | `bp-continuum` DNS flip for `grafana.<sov>`; downstream Grafana on standby reads same shared S3 backend — ~30s convergence on TTL |
-| bp-loki | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (chunks on S3, index on object storage) | All persistent state on object storage (SeaweedFS or provider S3); cross-region = bucket replication async | `bp-continuum` DNS flip for `loki.<sov>`; standby Loki reads same chunks (eventually-consistent) — Active-Active feasible if read-only queries split |
-| bp-mimir | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (TSDB blocks on object storage) | All persistent state on object storage; cross-region bucket replication | `bp-continuum` DNS flip; standby Mimir queriers read same blocks |
-| bp-tempo | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (traces on object storage) | All persistent state on object storage; cross-region bucket replication | `bp-continuum` DNS flip; standby Tempo queriers read same blocks |
-| bp-alloy | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (telemetry shipper, DaemonSet) | n/a — stateless; each node's Alloy ships to local Loki/Mimir/Tempo endpoint | n/a — DS on every node; node failure means kubelet replaces the Pod |
-| bp-nats-jetstream | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (JetStream Raft cluster within mgmt) | Within mgmt: 3-node JetStream cluster (Raft). Cross-cluster: NATS leaf-node tunnel only — streams NOT replicated by default | `bp-continuum` leaf-node retarget + DNS flip; in-flight messages on lost region drop unless `stream.mirror` enabled |
-| bp-guacamole | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (PG with session + connection config) | PG via `bp-cnpg-pair` sync | `bp-continuum` PG flip + DNS flip for `guac.<sov>` (~30s); in-progress remote-desktop sessions drop |
-| bp-k8s-ws-proxy | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | no (stateless WebSocket proxy) | n/a — Pods are stateless; routing comes from Kubernetes API which Catalyst-api supplies | `bp-continuum` DNS flip; new connections route to standby Pod immediately, in-flight WS sessions drop |
-| bp-newapi | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | no (stateless API) | n/a — config from CRDs + values | DNS flip via `bp-continuum` |
-| bp-sso-bridge | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | no (stateless auth bridge — G91/G112/G113 chain) | n/a — secrets via External-Secrets / openbao | DNS flip via `bp-continuum` |
-| bp-self-sovereign-cutover | 🟢 A | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | no (one-shot Jobs at handover) | n/a — Jobs run once then terminate (dormant on standby until activated) | n/a — single-shot pivot operation; if mgmt-A is lost mid-cutover, the cutover must be re-run from standby once promoted |
+| Blueprint | mgmt-A | mgmt-B | dmz-A | dmz-B | rtz-A | rtz-B | Stateful? | State preservation | Switchover | Default external endpoint |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|---|---|---|---|
+| bp-catalyst-platform | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (Catalyst CRDs in etcd + PG state) | CRDs replicated via `bp-cnpg-pair` (etcd-backed via Catalyst-api PG); deployments are reconcilable from Git | `bp-continuum` flips PowerDNS for `console.<sov>` + `api.<sov>`; standby promotes once CNPG primary flips | `console.<sov>` + `api.<sov>` |
+| bp-keycloak | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (KC realm config + sessions in PG) | PG via `bp-cnpg-pair` sync `remote_apply`; user sessions are JWT (stateless on KC) | `bp-continuum` PG promote → KC pod on standby is already running → DNS flip `auth.<sov>` (~30s TTL) | `auth.<sov>` |
+| bp-openbao | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (Raft store on PVC; 3-5 replicas/cluster) | Within cluster: Raft consensus. Cross-cluster: async perf-replication (OSS uses snapshot+restore; Enterprise has native primary→replica) | `bp-continuum` runs `vault operator raft transition-to-primary` on the standby; KV reads continue uninterrupted on replica throughout | `vault.<sov>` (or internal-only) |
+| bp-gitea | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (PG + Git repo blobs on PVC) | Postgres via `bp-cnpg-pair` sync; Git blobs land on SeaweedFS S3 mirrored cross-region (async, ~seconds lag) | `bp-continuum` PG demote/promote + PowerDNS flip for `gitea.<sov>` (30s TTL); Git push paused ~5s | `gitea.<sov>` |
+| bp-harbor | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (PG + Redis + image blobs on object storage) | PG via `bp-cnpg-pair`; image blobs on Huawei OBS / Hetzner S3 (cross-region replication = provider-native bucket replication, async) | `bp-continuum` PG flip + PowerDNS flip for `registry.<sov>` + `harbor.<sov>`; blob pulls keep working through replica bucket on standby region | `harbor.<sov>` + `registry.<sov>` |
+| bp-grafana | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (Grafana DB + dashboards) | Grafana DB on `bp-cnpg-pair` sync; dashboards rendered from Loki/Mimir/Tempo which themselves write to SeaweedFS S3 replicated cross-region | `bp-continuum` DNS flip for `grafana.<sov>`; downstream Grafana on standby reads same shared S3 backend — ~30s convergence on TTL | `grafana.<sov>` |
+| bp-loki | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (chunks on S3, index on object storage) | All persistent state on object storage (SeaweedFS or provider S3); cross-region = bucket replication async | `bp-continuum` DNS flip for `loki.<sov>`; standby Loki reads same chunks (eventually-consistent) — Active-Active feasible if read-only queries split | internal-only (queried via Grafana) |
+| bp-mimir | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (TSDB blocks on object storage) | All persistent state on object storage; cross-region bucket replication | `bp-continuum` DNS flip; standby Mimir queriers read same blocks | internal-only |
+| bp-tempo | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (traces on object storage) | All persistent state on object storage; cross-region bucket replication | `bp-continuum` DNS flip; standby Tempo queriers read same blocks | internal-only |
+| bp-alloy | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (telemetry shipper, DaemonSet) | n/a — stateless; each node's Alloy ships to local Loki/Mimir/Tempo endpoint | n/a — DS on every node; node failure means kubelet replaces the Pod | none |
+| bp-nats-jetstream | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (JetStream Raft cluster within mgmt) | Within mgmt: 3-node JetStream cluster (Raft). Cross-cluster: NATS leaf-node tunnel only — streams NOT replicated by default | `bp-continuum` leaf-node retarget + DNS flip; in-flight messages on lost region drop unless `stream.mirror` enabled | internal-only (`nats://nats:4222`) |
+| bp-guacamole | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (PG with session + connection config) | PG via `bp-cnpg-pair` sync | `bp-continuum` PG flip + DNS flip for `guac.<sov>` (~30s); in-progress remote-desktop sessions drop | `guac.<sov>` |
+| bp-k8s-ws-proxy | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | no (stateless WebSocket proxy) | n/a — Pods are stateless; routing comes from Kubernetes API which Catalyst-api supplies | `bp-continuum` DNS flip; new connections route to standby Pod immediately, in-flight WS sessions drop | internal (proxied by catalyst-api) |
+| bp-newapi | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | no (stateless API) | n/a — config from CRDs + values | DNS flip via `bp-continuum` | internal |
+| bp-sso-bridge | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | no (stateless auth bridge — G91/G112/G113 chain) | n/a — secrets via External-Secrets / openbao | DNS flip via `bp-continuum` | internal |
+| bp-self-sovereign-cutover | 🟢 A | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | no (one-shot Jobs at handover) | n/a — Jobs run once then terminate (dormant on standby until activated) | n/a — single-shot pivot operation; if mgmt-A is lost mid-cutover, the cutover must be re-run from standby once promoted | none (one-shot) |
 
 ## Per-host-cluster infrastructure tier
 
 > Runs in **every** host cluster; each cluster owns its own copy. Cross-cluster sync **is not part of these blueprints** — they're cluster-local infrastructure. Failover is N/A: a cluster failure removes one cluster's instance; the others keep running independently.
 
-| Blueprint | mgmt-A | mgmt-B | dmz-A | dmz-B | rtz-A | rtz-B | Stateful? | State preservation | Switchover |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|---|---|---|
-| bp-cilium | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (identity allocator CRDs) | NOT replicated — each cluster owns identity space. ClusterMesh shares **endpoint reachability only**, not control state | n/a — independent per cluster |
-| bp-cilium-policies | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (CiliumNetworkPolicy CRs per cluster) | Replicated via Flux from this repo (Git is the source of truth) | n/a — declarative; Flux reconciles per cluster |
-| bp-flux | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (Helm release state + Kustomization status) | Each cluster's Flux state is local. Source-of-truth is the upstream Git repo replicated to Gitea (which IS cross-region replicated) | n/a — each cluster pulls from Gitea after cutover |
-| bp-gateway-api | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (Gateway/HTTPRoute CRs) | Source-of-truth is Git/Flux | n/a |
-| bp-vcluster-helmrepo | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (HelmRepository reference) | n/a — pointer to OCI registry | n/a |
-| bp-mgmt-vcluster | 🔵 S | 🔵 S | ⬜ | ⬜ | ⬜ | ⬜ | yes (vCluster's own k8s state in PVC) | vCluster state on local PVC; not cross-cluster replicated | Pillar-3 plan: mgmt-A vCluster state replicates to mgmt-B vCluster via Velero scheduled backups + restore-on-failover |
-| bp-rtz-vcluster | ⬜ | ⬜ | ⬜ | ⬜ | 🔵 S | 🔵 S | yes (vCluster state in PVC) | Per-cluster; cross-region failover = Velero restore + re-bind tenant Apps | Per-Org tenant decision via `bp-continuum` Org policy |
-| bp-dmz-vcluster | ⬜ | ⬜ | 🔵 S | 🔵 S | ⬜ | ⬜ | yes (vCluster state in PVC) | Per-cluster | Same as bp-rtz-vcluster |
-| bp-cnpg | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (operator; the Clusters it manages are stateful) | Operator code is stateless; Cluster CRs it manages are replicated by `bp-cnpg-pair` | n/a — operator |
-| bp-cnpg-pair | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (PG WAL + data PVC) | **Sync streaming replication** (`remote_apply`) over Cilium ClusterMesh — zero-tx-loss; pair lives within matching tier (rtz↔rtz, dmz↔dmz, mgmt↔mgmt) | `bp-continuum` lease + CNPG `cnpg promote`; PowerDNS lua-record flip for `db.<org>.<sov>` (~5s write disruption, bank-tier RTO) |
-| bp-crossplane | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (provider state in CRDs) | Provider state local; source-of-truth in Git via Composition CRs | n/a |
-| bp-crossplane-claims | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (Claim CRs) | Replicated via Flux from Git | n/a |
-| bp-cert-manager | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (Certificate + Order CRs + Secrets) | Each cluster owns its certs; OpenBao perf-replication carries the wildcard root if used | Per-cluster — cluster failure means re-issue on the surviving cluster's cert-manager |
-| bp-cert-manager-powerdns-webhook | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (webhook) | n/a | n/a |
-| bp-cert-manager-dynadot-webhook | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (webhook) | n/a | n/a |
-| bp-external-secrets | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (ExternalSecret CRs + cached Secrets) | Secrets pulled fresh from OpenBao on each refresh; cache rebuilds from source | n/a — pulls from cluster-local OpenBao replica |
-| bp-external-secrets-stores | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (ClusterSecretStore CRs) | Replicated via Flux | n/a |
-| bp-external-dns | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (controller; PowerDNS is the state) | n/a — writes to PowerDNS REST API | n/a |
-| bp-powerdns | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (PG-backed authoritative records) | Each cluster runs its own PowerDNS auth + recursor pair. Lua-record health-checked failover across clusters is the cross-cluster mechanism | n/a within cluster; cross-cluster failover via lua-record `ifurlup` (auto, ~30s TTL) |
-| bp-powerdns-admin | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (admin UI state in PG) | Per-cluster PG | n/a — admin UI; if a cluster's instance dies, edit via another cluster |
-| bp-sealed-secrets | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (sealing keypair in cluster) | Sealing private key cluster-local; decrypts only what was sealed against its public half | n/a — each cluster owns its own sealing identity; SealedSecret CRs are tagged with cluster scope |
-| bp-coraza | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (WAF rules; rule corpus from Git) | n/a — rules from CoreRuleSet via Git | n/a |
-| bp-kyverno | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (policy CRs + report CRs) | Policies replicated via Flux; reports are local (current-state) | n/a |
-| bp-kyverno-policies | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (ClusterPolicy CRs) | Replicated via Flux | n/a |
-| bp-trivy | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (vuln scan reports as CRs) | Reports local; rebuilds on re-scan | n/a |
-| bp-falco | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (DaemonSet, events ship to Loki) | n/a — events shipped out | n/a |
-| bp-sigstore | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (cosign keypair) | Per-cluster | n/a |
-| bp-syft-grype | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (SBOM + vuln pipeline) | n/a | n/a |
-| bp-vpa | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (VPA recommendation CRs) | Per-cluster; rebuilds from observed Pod history | n/a |
-| bp-reloader | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (controller) | n/a | n/a |
-| bp-reflector | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (controller) | n/a | n/a |
-| bp-seaweedfs | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (S3 object store + filer DB) | Within cluster: replicas + erasure coding. Cross-cluster: SeaweedFS Filer Remote Storage / S3 bucket replication (configurable) | n/a within cluster; cross-cluster replication is async pull |
-| bp-velero | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (backup catalog in PVC + blobs on S3) | Backup blobs land on per-Sovereign S3 (replicated cross-region by provider) | n/a — restore is operator-initiated |
-| bp-hcloud-ccm | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | n/a (Hetzner-only; not used on Huawei reference Sovereign) | — | — |
-| bp-hcloud-csi | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | n/a (Hetzner-only) | — | — |
-| bp-cluster-autoscaler-hcloud | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | n/a (Hetzner-only) | — | — |
-| bp-opentelemetry | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (collector) | n/a | n/a |
-| bp-opentelemetry-operator | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (operator) | n/a | n/a |
-| bp-network-policies | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (NetworkPolicy CRs; hollow chart placeholder) | Replicated via Flux | n/a |
-| bp-netbird | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (management state in PG) | PG via `bp-cnpg-pair` (candidate; not currently installed) | Candidate Catalyst-CP — `bp-continuum` flip when wired |
-| bp-spire | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (SPIRE Server datastore in PG/sqlite) | PG via `bp-cnpg-pair` (candidate; not currently installed) | Candidate Catalyst-CP |
-| bp-openclaw | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | yes (scaffold; TBD) | TBD | TBD |
+| Blueprint | mgmt-A | mgmt-B | dmz-A | dmz-B | rtz-A | rtz-B | Stateful? | State preservation | Switchover | Default external endpoint |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|---|---|---|---|
+| bp-cilium | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (identity allocator CRDs) | NOT replicated — each cluster owns identity space. ClusterMesh shares **endpoint reachability only**, not control state | n/a — independent per cluster | optional `hubble.<sov>` |
+| bp-cilium-policies | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (CiliumNetworkPolicy CRs per cluster) | Replicated via Flux from this repo (Git is the source of truth) | n/a — declarative; Flux reconciles per cluster | none (CRDs) |
+| bp-flux | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (Helm release state + Kustomization status) | Each cluster's Flux state is local. Source-of-truth is the upstream Git repo replicated to Gitea (which IS cross-region replicated) | n/a — each cluster pulls from Gitea after cutover | none |
+| bp-gateway-api | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (Gateway/HTTPRoute CRs) | Source-of-truth is Git/Flux | n/a | none (CRDs) |
+| bp-vcluster-helmrepo | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (HelmRepository reference) | n/a — pointer to OCI registry | n/a | none |
+| bp-mgmt-vcluster | 🔵 S | 🔵 S | ⬜ | ⬜ | ⬜ | ⬜ | yes (vCluster's own k8s state in PVC) | vCluster state on local PVC; not cross-cluster replicated | Pillar-3 plan: mgmt-A vCluster state replicates to mgmt-B vCluster via Velero scheduled backups + restore-on-failover | internal vCluster API |
+| bp-rtz-vcluster | ⬜ | ⬜ | ⬜ | ⬜ | 🔵 S | 🔵 S | yes (vCluster state in PVC) | Per-cluster; cross-region failover = Velero restore + re-bind tenant Apps | Per-Org tenant decision via `bp-continuum` Org policy | internal vCluster API |
+| bp-dmz-vcluster | ⬜ | ⬜ | 🔵 S | 🔵 S | ⬜ | ⬜ | yes (vCluster state in PVC) | Per-cluster | Same as bp-rtz-vcluster | internal vCluster API |
+| bp-cnpg | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (operator; the Clusters it manages are stateful) | Operator code is stateless; Cluster CRs it manages are replicated by `bp-cnpg-pair` | n/a — operator | none (operator) |
+| bp-cnpg-pair | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (PG WAL + data PVC) | **Sync streaming replication** (`remote_apply`) over Cilium ClusterMesh — zero-tx-loss; pair lives within matching tier (rtz↔rtz, dmz↔dmz, mgmt↔mgmt) | `bp-continuum` lease + CNPG `cnpg promote`; PowerDNS lua-record flip for `db.<org>.<sov>` (~5s write disruption, bank-tier RTO) | Postgres protocol `db.<org>.<sov>` |
+| bp-crossplane | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (provider state in CRDs) | Provider state local; source-of-truth in Git via Composition CRs | n/a | none |
+| bp-crossplane-claims | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (Claim CRs) | Replicated via Flux from Git | n/a | none (CRDs) |
+| bp-cert-manager | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (Certificate + Order CRs + Secrets) | Each cluster owns its certs; OpenBao perf-replication carries the wildcard root if used | Per-cluster — cluster failure means re-issue on the surviving cluster's cert-manager | none |
+| bp-cert-manager-powerdns-webhook | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (webhook) | n/a | n/a | none |
+| bp-cert-manager-dynadot-webhook | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (webhook) | n/a | n/a | none |
+| bp-external-secrets | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (ExternalSecret CRs + cached Secrets) | Secrets pulled fresh from OpenBao on each refresh; cache rebuilds from source | n/a — pulls from cluster-local OpenBao replica | none |
+| bp-external-secrets-stores | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (ClusterSecretStore CRs) | Replicated via Flux | n/a | none |
+| bp-external-dns | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (controller; PowerDNS is the state) | n/a — writes to PowerDNS REST API | n/a | none |
+| bp-powerdns | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (PG-backed authoritative records) | Each cluster runs its own PowerDNS auth + recursor pair. Lua-record health-checked failover across clusters is the cross-cluster mechanism | n/a within cluster; cross-cluster failover via lua-record `ifurlup` (auto, ~30s TTL) | `ns1.<sov>`, `ns2.<sov>` (DNS protocol) |
+| bp-powerdns-admin | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (admin UI state in PG) | Per-cluster PG | n/a — admin UI; if a cluster's instance dies, edit via another cluster | `pdns-admin.<sov>` |
+| bp-sealed-secrets | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (sealing keypair in cluster) | Sealing private key cluster-local; decrypts only what was sealed against its public half | n/a — each cluster owns its own sealing identity; SealedSecret CRs are tagged with cluster scope | none |
+| bp-coraza | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (WAF rules; rule corpus from Git) | n/a — rules from CoreRuleSet via Git | n/a | none (WAF; rides Gateway) |
+| bp-kyverno | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (policy CRs + report CRs) | Policies replicated via Flux; reports are local (current-state) | n/a | none |
+| bp-kyverno-policies | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (ClusterPolicy CRs) | Replicated via Flux | n/a | none (CRDs) |
+| bp-trivy | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (vuln scan reports as CRs) | Reports local; rebuilds on re-scan | n/a | none |
+| bp-falco | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (DaemonSet, events ship to Loki) | n/a — events shipped out | n/a | none |
+| bp-sigstore | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (cosign keypair) | Per-cluster | n/a | optional `cosign.<sov>` |
+| bp-syft-grype | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (SBOM + vuln pipeline) | n/a | n/a | none |
+| bp-vpa | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (VPA recommendation CRs) | Per-cluster; rebuilds from observed Pod history | n/a | none |
+| bp-reloader | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (controller) | n/a | n/a | none |
+| bp-reflector | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (controller) | n/a | n/a | none |
+| bp-seaweedfs | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (S3 object store + filer DB) | Within cluster: replicas + erasure coding. Cross-cluster: SeaweedFS Filer Remote Storage / S3 bucket replication (configurable) | n/a within cluster; cross-cluster replication is async pull | internal S3 (`s3.<sov>` optional) |
+| bp-velero | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (backup catalog in PVC + blobs on S3) | Backup blobs land on per-Sovereign S3 (replicated cross-region by provider) | n/a — restore is operator-initiated | none (API only) |
+| bp-hcloud-ccm | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | n/a (Hetzner-only; not used on Huawei reference Sovereign) | — | — | n/a (Hetzner) |
+| bp-hcloud-csi | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | n/a (Hetzner-only) | — | — | n/a (Hetzner) |
+| bp-cluster-autoscaler-hcloud | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | n/a (Hetzner-only) | — | — | n/a (Hetzner) |
+| bp-opentelemetry | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (collector) | n/a | n/a | internal collector |
+| bp-opentelemetry-operator | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | no (operator) | n/a | n/a | none |
+| bp-network-policies | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | 🔵 S | yes (NetworkPolicy CRs; hollow chart placeholder) | Replicated via Flux | n/a | none (CRDs) |
+| bp-netbird | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (management state in PG) | PG via `bp-cnpg-pair` (candidate; not currently installed) | Candidate Catalyst-CP — `bp-continuum` flip when wired | `netbird.<sov>` |
+| bp-spire | 🟢 A | 🟡 P | ⬜ | ⬜ | ⬜ | ⬜ | yes (SPIRE Server datastore in PG/sqlite) | PG via `bp-cnpg-pair` (candidate; not currently installed) | Candidate Catalyst-CP | internal |
+| bp-openclaw | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | yes (scaffold; TBD) | TBD | TBD | TBD |
 
 ## Application Blueprints (per-Org, inside vClusters)
 
 > Installed by tenants per-Org. The vCluster they live in sits in `rtz` or `dmz` tier. Cross-region HA inside a single Org's vCluster is the **vCluster-itself**'s job (state in PVC + Velero); the App Blueprint's own state replication is per-App-Blueprint and listed below.
 
-| Blueprint | mgmt-A | mgmt-B | dmz-A | dmz-B | rtz-A | rtz-B | Stateful? | State preservation | Switchover |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|---|---|---|
-| bp-ferretdb | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (MongoDB-API over PG backend) | PG via `bp-cnpg-pair` sync; ferretdb itself is stateless | `bp-continuum` PG flip → ferretdb on standby is already running |
-| bp-valkey | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (in-memory + AOF persistence) | Redis-style replication (master + replicas); cross-region = sentinel-pair across clusters via ClusterMesh | `bp-continuum` runs Sentinel failover; clients reconnect (~5s) |
-| bp-strimzi | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | yes (Kafka log on PVC) | Per-cluster Kafka cluster; cross-region = Strimzi MirrorMaker2 (async replication of topics) | Active-Active topics replicate both ways; consumer offset translation via MM2 |
-| bp-clickhouse | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | yes (sharded + replicated MergeTree) | ClickHouse native replication via ZooKeeper/Keeper; cross-region = each region runs its own replica of the same shard | DNS flip; replicas keep ingesting on the surviving region |
-| bp-opensearch | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | yes (Lucene indices on PVC) | OpenSearch cross-cluster replication (CCR) — opt-in `bp-opensearch-cross-cluster-replication` sub-blueprint | DNS flip; CCR follower keeps catching up from leader writes |
-| bp-stalwart-tenant | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (mail blobs on S3; metadata in PG) | PG via `bp-cnpg-pair`; mail blobs on tenant S3 bucket replicated cross-region | `bp-continuum` PG flip + DNS flip for `mail.<org>.<sov>` |
-| bp-stalwart-sovereign | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | external — runs on OpenOva mothership (mail.openova.io), not on this Sovereign | external | external |
-| bp-livekit | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless SFU; rooms ephemeral) | n/a — rooms exist while at least one participant is connected | DNS flip; new rooms route to surviving region |
-| bp-matrix | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (homeserver DB in PG + media on S3) | PG via `bp-cnpg-pair`; media on S3 cross-region replicated | `bp-continuum` PG flip + DNS flip for `matrix.<org>.<sov>` |
-| bp-stunner | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless TURN/STUN relay) | n/a | DNS flip; new ICE sessions route to surviving region |
-| bp-milvus | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (vector index on S3 + metadata in etcd) | etcd + S3 cross-region replication | `bp-continuum` DNS flip; standby Milvus queriers read same S3 |
-| bp-neo4j | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (graph store on PVC) | Neo4j Causal Clustering (Enterprise) or core+read-replica (Community); cross-region = backup-restore on PVC | `bp-continuum` promote read-replica to core or restore from Velero |
-| bp-vllm | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless inference; GPU-bound) | n/a — model weights on shared PVC or pre-baked in image | DNS flip; new requests route to surviving region |
-| bp-kserve | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless model serving) | n/a — model artifacts on S3 | DNS flip |
-| bp-knative | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (controller; serverless Pods are ephemeral) | n/a | DNS flip; scale-to-zero unaffected |
-| bp-librechat | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | yes (chat history in Mongo/PG) | PG via `bp-cnpg-pair`; UI itself stateless | `bp-continuum` PG flip + DNS flip |
-| bp-bge | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless embedding service) | n/a — model in image | DNS flip |
-| bp-llm-gateway | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless proxy) | n/a — secrets via External-Secrets | DNS flip |
-| bp-anthropic-adapter | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless adapter) | n/a | DNS flip |
-| bp-langfuse | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (traces in PG + ClickHouse) | PG via `bp-cnpg-pair`; ClickHouse replicated within Org | `bp-continuum` PG flip + DNS flip |
-| bp-nemo-guardrails | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless policy enforcement) | n/a — policies from Git | DNS flip |
-| bp-temporal | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (history in PG + visibility in ES/OpenSearch) | PG via `bp-cnpg-pair`; visibility store via bp-opensearch CCR | `bp-continuum` PG flip + DNS flip; workflows resume from history |
-| bp-flink | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (jobmanager state + checkpoints on S3) | Checkpoints on S3 cross-region replicated; jobmanager HA via ZooKeeper/k8s leader-election | `bp-continuum` jobmanager re-elect on standby; flink resumes from last checkpoint |
-| bp-debezium | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (offsets in Kafka) | Offsets in bp-strimzi (replicated via MM2) | `bp-continuum` restarts connector on standby reading from latest Kafka offset |
-| bp-iceberg | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | yes (table metadata + data files on S3) | All state on S3; catalog (Hive/REST) is the only stateful service | DNS flip on catalog; data plane keeps reading same S3 |
-| bp-openmeter | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (events in ClickHouse + state in PG) | PG via `bp-cnpg-pair`; ClickHouse replicated within Org | `bp-continuum` PG flip + DNS flip |
-| bp-litmus | ⬜ | ⬜ | ⬜ | ⬜ | 🔵 S | 🔵 S | yes (experiment runs in MongoDB) | Per-cluster — chaos experiments are intentionally cluster-scoped | n/a |
-| bp-wordpress-tenant | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (PG + media on S3) | PG via `bp-cnpg-pair`; media on tenant S3 bucket cross-region replicated | `bp-continuum` PG flip + DNS flip for `<site>.<org>.<sov>` |
-| bp-qa-app | ⬜ | ⬜ | ⬜ | ⬜ | 🔵 S | 🔵 S | no (test scaffold) | n/a | n/a |
+| Blueprint | mgmt-A | mgmt-B | dmz-A | dmz-B | rtz-A | rtz-B | Stateful? | State preservation | Switchover | Default external endpoint |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|---|---|---|---|
+| bp-ferretdb | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (MongoDB-API over PG backend) | PG via `bp-cnpg-pair` sync; ferretdb itself is stateless | `bp-continuum` PG flip → ferretdb on standby is already running | Mongo wire `db.<org>.<sov>` |
+| bp-valkey | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (in-memory + AOF persistence) | Redis-style replication (master + replicas); cross-region = sentinel-pair across clusters via ClusterMesh | `bp-continuum` runs Sentinel failover; clients reconnect (~5s) | Redis wire `valkey.<org>.<sov>` |
+| bp-strimzi | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | yes (Kafka log on PVC) | Per-cluster Kafka cluster; cross-region = Strimzi MirrorMaker2 (async replication of topics) | Active-Active topics replicate both ways; consumer offset translation via MM2 | Kafka wire `kafka.<org>.<sov>` |
+| bp-clickhouse | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | yes (sharded + replicated MergeTree) | ClickHouse native replication via ZooKeeper/Keeper; cross-region = each region runs its own replica of the same shard | DNS flip; replicas keep ingesting on the surviving region | `clickhouse.<org>.<sov>` |
+| bp-opensearch | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | yes (Lucene indices on PVC) | OpenSearch cross-cluster replication (CCR) — opt-in `bp-opensearch-cross-cluster-replication` sub-blueprint | DNS flip; CCR follower keeps catching up from leader writes | `opensearch.<org>.<sov>` + `dashboards.<org>.<sov>` |
+| bp-stalwart-tenant | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (mail blobs on S3; metadata in PG) | PG via `bp-cnpg-pair`; mail blobs on tenant S3 bucket replicated cross-region | `bp-continuum` PG flip + DNS flip for `mail.<org>.<sov>` | `mail.<org>.<sov>` + IMAP/SMTP |
+| bp-stalwart-sovereign | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | external — runs on OpenOva mothership (mail.openova.io), not on this Sovereign | external | external | external (mothership) |
+| bp-livekit | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless SFU; rooms ephemeral) | n/a — rooms exist while at least one participant is connected | DNS flip; new rooms route to surviving region | `livekit.<org>.<sov>` (WebRTC) |
+| bp-matrix | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (homeserver DB in PG + media on S3) | PG via `bp-cnpg-pair`; media on S3 cross-region replicated | `bp-continuum` PG flip + DNS flip for `matrix.<org>.<sov>` | `matrix.<org>.<sov>` |
+| bp-stunner | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless TURN/STUN relay) | n/a | DNS flip; new ICE sessions route to surviving region | TURN/STUN (no HTTP) |
+| bp-milvus | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (vector index on S3 + metadata in etcd) | etcd + S3 cross-region replication | `bp-continuum` DNS flip; standby Milvus queriers read same S3 | `milvus.<org>.<sov>` (gRPC) |
+| bp-neo4j | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (graph store on PVC) | Neo4j Causal Clustering (Enterprise) or core+read-replica (Community); cross-region = backup-restore on PVC | `bp-continuum` promote read-replica to core or restore from Velero | `neo4j.<org>.<sov>` (Bolt + HTTP) |
+| bp-vllm | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless inference; GPU-bound) | n/a — model weights on shared PVC or pre-baked in image | DNS flip; new requests route to surviving region | `vllm.<org>.<sov>` |
+| bp-kserve | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless model serving) | n/a — model artifacts on S3 | DNS flip | `kserve.<org>.<sov>` |
+| bp-knative | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (controller; serverless Pods are ephemeral) | n/a | DNS flip; scale-to-zero unaffected | none (event-driven) |
+| bp-librechat | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | yes (chat history in Mongo/PG) | PG via `bp-cnpg-pair`; UI itself stateless | `bp-continuum` PG flip + DNS flip | `chat.<org>.<sov>` |
+| bp-bge | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless embedding service) | n/a — model in image | DNS flip | `bge.<org>.<sov>` |
+| bp-llm-gateway | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless proxy) | n/a — secrets via External-Secrets | DNS flip | `llm.<org>.<sov>` |
+| bp-anthropic-adapter | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless adapter) | n/a | DNS flip | `anthropic.<org>.<sov>` |
+| bp-langfuse | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (traces in PG + ClickHouse) | PG via `bp-cnpg-pair`; ClickHouse replicated within Org | `bp-continuum` PG flip + DNS flip | `langfuse.<org>.<sov>` |
+| bp-nemo-guardrails | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | no (stateless policy enforcement) | n/a — policies from Git | DNS flip | internal |
+| bp-temporal | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (history in PG + visibility in ES/OpenSearch) | PG via `bp-cnpg-pair`; visibility store via bp-opensearch CCR | `bp-continuum` PG flip + DNS flip; workflows resume from history | `temporal.<org>.<sov>` |
+| bp-flink | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (jobmanager state + checkpoints on S3) | Checkpoints on S3 cross-region replicated; jobmanager HA via ZooKeeper/k8s leader-election | `bp-continuum` jobmanager re-elect on standby; flink resumes from last checkpoint | `flink.<org>.<sov>` |
+| bp-debezium | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (offsets in Kafka) | Offsets in bp-strimzi (replicated via MM2) | `bp-continuum` restarts connector on standby reading from latest Kafka offset | internal |
+| bp-iceberg | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟢 A | yes (table metadata + data files on S3) | All state on S3; catalog (Hive/REST) is the only stateful service | DNS flip on catalog; data plane keeps reading same S3 | `iceberg.<org>.<sov>` (catalog REST) |
+| bp-openmeter | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (events in ClickHouse + state in PG) | PG via `bp-cnpg-pair`; ClickHouse replicated within Org | `bp-continuum` PG flip + DNS flip | `openmeter.<org>.<sov>` |
+| bp-litmus | ⬜ | ⬜ | ⬜ | ⬜ | 🔵 S | 🔵 S | yes (experiment runs in MongoDB) | Per-cluster — chaos experiments are intentionally cluster-scoped | n/a | `litmus.<org>.<sov>` |
+| bp-wordpress-tenant | ⬜ | ⬜ | ⬜ | ⬜ | 🟢 A | 🟡 P | yes (PG + media on S3) | PG via `bp-cnpg-pair`; media on tenant S3 bucket cross-region replicated | `bp-continuum` PG flip + DNS flip for `<site>.<org>.<sov>` | `<site>.<org>.<sov>` |
+| bp-qa-app | ⬜ | ⬜ | ⬜ | ⬜ | 🔵 S | 🔵 S | no (test scaffold) | n/a | n/a | TBD (scaffold) |
 
 ## Topology patterns this captures
 

--- a/docs/sessions/2026-06-02-per-blueprint-topology-audit.md
+++ b/docs/sessions/2026-06-02-per-blueprint-topology-audit.md
@@ -1,0 +1,157 @@
+# Per-blueprint multi-region topology audit — 2026-06-02
+
+> **Scope**: every `platform/*/blueprint.yaml` in this repo, classified by canonical tier and intended multi-region topology, with the actual hw86 deploy state at audit time. Surfaced two gaps that need follow-up issues: G115 (Grafana empty datasources) and G116 (formalize `placementSchema` across all platform blueprints).
+
+## TL;DR
+
+- **Zero of 56** platform blueprints declare `spec.placementSchema` today. With nothing declared, the application-controller treats every blueprint as **install-once on the primary host cluster** (mgmt). That's the de-facto answer for every app — Grafana, Keycloak, OpenBao, NATS, all of them.
+- The "intended topology" column below is sourced from [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) §3 + §8 and [`docs/DOD.md`](../DOD.md) Pillars 2-3 — **not from blueprint code**. That is the gap to formalize → **G116**.
+- DoD Pillar 3 ("Two independent CNPG clusters + region-kill failover") relies on `bp-cnpg-pair`, which **no Org has activated on hw86**. Multi-Region capability is UNVERIFIED on the verification ledger.
+- Grafana renders empty because no datasource ConfigMaps + no default dashboards are auto-provisioned by `bp-grafana` → **G115**.
+
+## The 4-row example (the rows asked for first)
+
+| App | Tier (per ARCHITECTURE.md §3) | Intended multi-region topology | hw86 actual today |
+|---|---|---|---|
+| **bp-catalyst-platform** | Catalyst control-plane | Per-Sovereign-cluster singleton on mgmt; cross-region = LB picks healthy Sovereign-cluster; DR via `bp-self-sovereign-cutover` reinstall | mgmt region-a only (no region-b clone) |
+| **bp-openbao** | Catalyst control-plane | Raft StatefulSet 3–5 replicas per Sovereign cluster; **cross-region = INDEPENDENT vault per region**, unseal keys re-distributed (NOT a single global cluster — Raft consensus across regions = too much latency) | 1 region-a StatefulSet, recovery-seed lookup via [chart-credential-persistence pattern](../../platform/openbao/chart/templates/recovery-seed-bootstrap.yaml). region-b: not installed |
+| **bp-grafana** | Catalyst control-plane (Observability) | Per-Sovereign singleton (1–2 replicas) backed by Loki/Mimir/Tempo S3; cross-region = independent install per region, dashboards NOT replicated (operator-rebuild) | 1 region-a Pod (Bitnami chart), backed by SeaweedFS S3. **Empty because no datasource ConfigMaps + no default dashboards auto-provisioned → G115.** region-b: not installed |
+| **bp-opensearch** | **Application Blueprint (per-Org vCluster)** — NOT control-plane | Per-Org vCluster multi-node cluster (3-master + 3-data typical); cross-region = opt-in `bp-opensearch-cross-cluster-replication` sub-blueprint | Not installed on hw86 (no Org has activated it yet) |
+
+## Catalyst control-plane tier (mgmt cluster only, primary Sovereign-cluster)
+
+| Blueprint | placementSchema declared? | Intended topology | hw86 region-a | hw86 region-b |
+|---|---|---|---|---|
+| bp-catalyst-platform | ❌ no | Singleton on mgmt | installed | — |
+| bp-keycloak | ❌ no | Singleton (1 KC + 1 PG) per Sovereign | installed | post-upgrade hook fail (blocks region-b cascade) |
+| bp-openbao | ❌ no | Raft 3-5 / Sovereign, **independent per region** | installed | — |
+| bp-gitea | ❌ no | Singleton (1 replica + 1 PG) per Sovereign | installed | — |
+| bp-harbor | ❌ no | Singleton (registry + 1 PG + Redis) per Sovereign; OBS-backed | installed (357MB blob OBS-stall risk) | — |
+| bp-grafana | ❌ no | Singleton per Sovereign; S3-backed datasources | installed (empty — G115) | — |
+| bp-loki | ❌ no | Multi-replica cluster per Sovereign; OBS-backed | installed | — |
+| bp-mimir | ❌ no | Multi-replica cluster per Sovereign; OBS-backed | installed | — |
+| bp-tempo | ❌ no | Multi-replica per Sovereign; OBS-backed | installed | — |
+| bp-alloy | ❌ no | DaemonSet (every node every cluster) | DS on region-a nodes | DS on region-b nodes |
+| bp-nats-jetstream | ❌ no | 3-node JetStream per Sovereign cluster (NOT cross-region replicated) | installed | — |
+| bp-guacamole | ❌ no | Singleton per Sovereign | installed | — |
+| bp-k8s-ws-proxy | ❌ no | Singleton per Sovereign | installed | — |
+| bp-newapi | ❌ no | Singleton per Sovereign | installed | — |
+| bp-sso-bridge | ❌ no | Singleton per Sovereign (G91/G112/G113 chain) | installed | — |
+| bp-self-sovereign-cutover | ❌ no | One-shot Jobs at handover (dormant otherwise) | dormant | dormant |
+
+## Per-host-cluster infrastructure tier (installed in EVERY host cluster: mgmt + rtz + dmz)
+
+| Blueprint | placementSchema declared? | Intended topology | hw86 region-a | hw86 region-b |
+|---|---|---|---|---|
+| bp-cilium | ❌ no | DaemonSet per node | DS | DS |
+| bp-cilium-policies | ❌ no | CRDs per host cluster | applied | applied |
+| bp-flux | ❌ no | 3-controller HA per host cluster | installed | installed |
+| bp-gateway-api | ❌ no | Per host cluster | installed | installed |
+| bp-vcluster-helmrepo | ❌ no | Per host cluster | installed | installed |
+| bp-mgmt-vcluster | ❌ no | One per host cluster (mgmt placement) | installed | n/a (no mgmt vCluster in region-b) |
+| bp-rtz-vcluster | ❌ no | One per host cluster (regulated/tenant) | installed | installed |
+| bp-dmz-vcluster | ❌ no | One per host cluster (DMZ tenant) | installed | installed |
+| bp-cnpg | ❌ no | Operator per host cluster | installed | installed |
+| bp-cnpg-pair | ❌ no | **Active-hot-standby PAIR via Cilium ClusterMesh + sync replication (DoD Pillar 3)** | **NOT shipped end-to-end — Pillar 3 UNVERIFIED** | — |
+| bp-crossplane | ❌ no | Per host cluster | installed | installed |
+| bp-crossplane-claims | ❌ no | Per host cluster | applied | applied |
+| bp-cert-manager | ❌ no | Per host cluster | installed | installed |
+| bp-cert-manager-powerdns-webhook | ❌ no | Per host cluster | installed | installed |
+| bp-cert-manager-dynadot-webhook | ❌ no | Per host cluster | installed | installed |
+| bp-external-secrets | ❌ no | Per host cluster | installed | installed |
+| bp-external-secrets-stores | ❌ no | Per host cluster | applied | applied |
+| bp-external-dns | ❌ no | Per host cluster | installed | installed |
+| bp-powerdns | ❌ no | Per host cluster HA pair | installed | installed |
+| bp-powerdns-admin | ❌ no | Per host cluster | installed | installed |
+| bp-sealed-secrets | ❌ no | Per host cluster controller | installed | installed |
+| bp-coraza | ❌ no | Per host cluster (Gateway WAF) | installed | installed |
+| bp-kyverno | ❌ no | Per host cluster | installed | installed |
+| bp-kyverno-policies | ❌ no | Per host cluster (policy CRs) | applied | applied |
+| bp-trivy | ❌ no | Per host cluster operator | installed | installed |
+| bp-falco | ❌ no | DaemonSet per node | DS | DS |
+| bp-sigstore | ❌ no | Per host cluster | installed | installed |
+| bp-syft-grype | ❌ no | Per host cluster | installed | installed |
+| bp-vpa | ❌ no | Per host cluster | installed | installed |
+| bp-reloader | ❌ no | Per host cluster | installed | installed |
+| bp-reflector | ❌ no | Per host cluster | installed | installed |
+| bp-seaweedfs | ❌ no | Per host cluster multi-replica (S3 backend) | installed | installed |
+| bp-velero | ❌ no | Per host cluster (backup) | installed | installed |
+| bp-hcloud-ccm | ❌ no | DaemonSet per node (Hetzner only) | n/a on Huawei | n/a |
+| bp-hcloud-csi | ❌ no | DaemonSet per node (Hetzner only) | n/a on Huawei | n/a |
+| bp-cluster-autoscaler-hcloud | ❌ no | Per host cluster (Hetzner only) | n/a on Huawei | n/a |
+| bp-opentelemetry | ❌ no | Per host cluster collector | installed | installed |
+| bp-opentelemetry-operator | ❌ no | Per host cluster | installed | installed |
+| bp-network-policies | ❌ no | Hollow chart; per host cluster | dormant | dormant |
+| bp-netbird | ❌ no | Mesh-VPN (Catalyst-CP candidate) | not installed | — |
+| bp-spire | ❌ no | Workload identity (Catalyst-CP candidate) | not installed | — |
+| bp-openclaw | ❌ no | TBD scaffold | dormant | dormant |
+
+## Application Blueprints (installed per-Org inside vClusters, NOT at platform install)
+
+| Blueprint | placementSchema declared? | Intended topology | hw86 today |
+|---|---|---|---|
+| bp-ferretdb | ❌ no | Per-Org vCluster (1+ replica) | none installed (no Org activated) |
+| bp-valkey | ❌ no | Per-Org vCluster cluster | none |
+| bp-strimzi | ❌ no | Per-Org vCluster Kafka | none |
+| bp-clickhouse | ❌ no | Per-Org vCluster cluster | none |
+| bp-opensearch | ❌ no | Per-Org vCluster cluster | none |
+| bp-stalwart-tenant | ❌ no | Per-Org vCluster mail | none |
+| bp-stalwart-sovereign | ❌ no | Per Sovereign (mothership mail) | external (mail.openova.io) |
+| bp-livekit | ❌ no | Per-Org vCluster | none |
+| bp-matrix | ❌ no | Per-Org vCluster | none |
+| bp-stunner | ❌ no | Per-Org vCluster TURN | none |
+| bp-milvus | ❌ no | Per-Org vCluster | none |
+| bp-neo4j | ❌ no | Per-Org vCluster | none |
+| bp-vllm | ❌ no | Per-Org vCluster GPU | none |
+| bp-kserve | ❌ no | Per-Org vCluster GPU | none |
+| bp-knative | ❌ no | Per-Org vCluster | none |
+| bp-librechat | ❌ no | Per-Org vCluster | none |
+| bp-bge | ❌ no | Per-Org vCluster | none |
+| bp-llm-gateway | ❌ no | Per-Org vCluster | none |
+| bp-anthropic-adapter | ❌ no | Per-Org vCluster | none |
+| bp-langfuse | ❌ no | Per-Org vCluster | none |
+| bp-nemo-guardrails | ❌ no | Per-Org vCluster | none |
+| bp-temporal | ❌ no | Per-Org vCluster | none |
+| bp-flink | ❌ no | Per-Org vCluster | none |
+| bp-debezium | ❌ no | Per-Org vCluster | none |
+| bp-iceberg | ❌ no | Per-Org vCluster | none |
+| bp-openmeter | ❌ no | Per-Org vCluster | none |
+| bp-litmus | ❌ no | Per-Org vCluster chaos | none |
+| bp-wordpress-tenant | ❌ no | Per-Org vCluster | none |
+| bp-qa-app | ❌ no | Test scaffold | none |
+
+## Two findings that fall out of this table
+
+### G115 — bp-grafana auto-provision datasources + default dashboards
+
+Grafana renders empty on hw86 because the bp-grafana chart does NOT ship pre-baked `datasource` ConfigMaps for the colocated Loki/Mimir/Tempo, nor any default dashboards. An operator landing on a freshly-deployed Grafana has nothing to look at — defeating the "click and observe" Pillar 1 intent. Fix scope:
+
+- Add `templates/datasource-configmaps.yaml` with `prometheus`, `loki`, `tempo`, `mimir` datasources pointing at the in-cluster Service DNS (`http://mimir-nginx.observability.svc:80`, etc.).
+- Add `templates/dashboard-configmaps.yaml` with a starter pack (cluster-overview, node-exporter, kube-state, OpenBao audit, Flux reconcile health).
+- Use Grafana's sidecar-discovery pattern (`grafana.sidecar.datasources.enabled=true` + `grafana.sidecar.dashboards.enabled=true`) so additions are hot-loadable.
+
+### G116 — formalize `placementSchema` across all platform Blueprints
+
+The `Blueprint` CRD already defines `spec.placementSchema` (per [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) §3 row 457) with shape `{vcluster: "mgmt|rtz|dmz|''", bcpTopology: "active-active|active-passive|active-hot-standby|singleton", regions: [...]}`. Zero blueprints populate it. The application-controller therefore has no machine-readable topology declaration to switch on — every install ends up as a chart-default singleton on the primary cluster.
+
+Fix scope:
+
+- Author a `placementSchema` block for each `platform/*/blueprint.yaml` matching the "Intended topology" column above. Catalyst-CP rows → `{vcluster: mgmt, bcpTopology: singleton}`. Per-host-cluster rows → `{vcluster: '', bcpTopology: per-cluster}`. Application rows → `{vcluster: rtz, bcpTopology: <as required>}`.
+- CI gate: blueprint admission webhook rejects new blueprints without `placementSchema`.
+- application-controller honors `placementSchema.bcpTopology` when fanning HRs across host clusters (G92 EPIC already wired the kubeConfig pivot — the gap is the data shape, not the controller).
+
+## How this table was generated
+
+```bash
+python3 << 'PYEOF'
+import os, glob, yaml
+for bp in sorted(glob.glob("platform/*/blueprint.yaml")):
+    name = os.path.basename(os.path.dirname(bp))
+    d = yaml.safe_load(open(bp)) or {}
+    ps = d.get("spec", {}).get("placementSchema", {})
+    label = d.get("metadata", {}).get("labels", {}).get("catalyst.openova.io/section", "")
+    print(f"{name:30} placementSchema={bool(ps)!s:5} section={label}")
+PYEOF
+```
+
+Pair the output with the canonical 3-tier table in [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) §3 + the DoD Pillar 2/3 invariants in [`docs/DOD.md`](../DOD.md) to populate the intended-topology column.

--- a/examples/blueprint-grafana-fully-declared.yaml
+++ b/examples/blueprint-grafana-fully-declared.yaml
@@ -1,0 +1,92 @@
+# Exemplar — bp-grafana as a fully-declared Blueprint under the G117 contract.
+#
+# Demonstrates every new spec.* field from the G117 EPIC:
+#   - spec.topology.{supported, defaults, perTopology}    (G117.1)
+#   - spec.endpoints[]                                    (G117.3)
+#   - spec.sso                                            (G117.4 + G117.5)
+#   - spec.multiInstance                                  (G117.6)
+#
+# Grounded in the topology-audit source-of-truth:
+#   docs/sessions/2026-06-02-per-blueprint-topology-audit.md
+#
+# Per the audit, bp-grafana is a Catalyst-CP tier Blueprint with
+# active-hot-standby across mgmt-A / mgmt-B (PG via bp-cnpg-pair sync;
+# dashboards back-ended by S3 + Loki/Mimir/Tempo replicated cross-region).
+# Singleton override allowed for single-region Sovereigns.
+#
+# This file MUST validate against platform/_schemas/blueprint-topology.json
+# — the blueprint-admission-validate.yaml workflow uses both as fixtures.
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: grafana
+  labels:
+    catalyst.openova.io/section: pts-3-observability
+    catalyst.openova.io/tier: catalyst-cp
+spec:
+  version: 1.0.4
+  card:
+    title: Grafana
+    family: insights
+    description: Visualization and dashboarding for the LGTM observability stack (Loki/Grafana/Tempo/Mimir).
+    docs: https://grafana.com/docs/grafana/latest/
+
+  # ── G117.1: Topology declaration ────────────────────────────────────────
+  topology:
+    supported:
+      - active-hot-standby
+      - singleton
+    defaults:
+      multi-region: active-hot-standby
+      single-region: singleton
+    perTopology:
+      active-hot-standby:
+        replication:
+          backend: cnpg-pair
+          mode: sync
+          lagSloSeconds: 0
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 30
+          rpoSeconds: 0
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A, mgmt-B]
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A]
+          roles:
+            mgmt-A: singleton
+
+  # ── G117.3: Endpoints ──────────────────────────────────────────────────
+  endpoints:
+    - name: ui
+      hostnameTemplate: "grafana.{{.SovereignFQDN}}"
+      port: 443
+      protocol: https
+      tls: true
+      visibility: public
+      launchDefault: true
+      ssoEnabled: true
+
+  # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    groupsClaim: groups
+    rolesFromGroup:
+      sovereign-admins: admin
+      grafana-editors: editor
+      grafana-viewers: viewer
+    silentLogin: true
+
+  # ── G117.6: Multi-instance ─────────────────────────────────────────────
+  multiInstance:
+    enabled: true
+    maxPerOrg: 5
+    namingTemplate: "{{.AppName}}-{{.InstanceID}}"
+    isolationLevel: namespace

--- a/platform/_schemas/blueprint-topology.json
+++ b/platform/_schemas/blueprint-topology.json
@@ -1,0 +1,206 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://openova.io/schemas/blueprint-topology.json",
+  "title": "Blueprint topology + endpoints + sso + multiInstance schema",
+  "description": "G117 EPIC — schema gate for the new spec.topology / spec.endpoints / spec.sso / spec.multiInstance fields on platform/*/blueprint.yaml and products/*/blueprint.yaml. Enforced by the blueprint-admission-validate.yaml workflow + the runtime admission webhook (Wave-1 / G117.1).",
+  "type": "object",
+  "properties": {
+    "apiVersion": { "type": "string", "enum": ["catalyst.openova.io/v1", "catalyst.openova.io/v1alpha1"] },
+    "kind": { "type": "string", "enum": ["Blueprint"] },
+    "metadata": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string", "pattern": "^bp-[a-z0-9][a-z0-9-]{0,40}[a-z0-9]$|^[a-z0-9][a-z0-9-]{0,40}[a-z0-9]$" }
+      }
+    },
+    "spec": {
+      "type": "object",
+      "properties": {
+        "topology":      { "$ref": "#/definitions/Topology" },
+        "endpoints":     { "type": "array", "items": { "$ref": "#/definitions/EndpointSpec" }, "minItems": 0 },
+        "sso":           { "$ref": "#/definitions/SSOSpec" },
+        "multiInstance": { "$ref": "#/definitions/MultiInstanceSpec" }
+      }
+    }
+  },
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "definitions": {
+    "BcpTopology": {
+      "type": "string",
+      "enum": ["active-active", "active-hot-standby", "active-passive", "singleton"]
+    },
+    "Topology": {
+      "type": "object",
+      "required": ["supported", "defaults"],
+      "properties": {
+        "supported": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/BcpTopology" },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "defaults": {
+          "type": "object",
+          "required": ["multi-region", "single-region"],
+          "properties": {
+            "multi-region":  { "$ref": "#/definitions/BcpTopology" },
+            "single-region": { "$ref": "#/definitions/BcpTopology" }
+          },
+          "additionalProperties": false
+        },
+        "perTopology": {
+          "type": "object",
+          "properties": {
+            "active-hot-standby": { "$ref": "#/definitions/Variant_ActiveHotStandby" },
+            "active-passive":     { "$ref": "#/definitions/Variant_ActivePassive" },
+            "active-active":      { "$ref": "#/definitions/Variant_ActiveActive" },
+            "singleton":          { "$ref": "#/definitions/Variant_Singleton" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ReplicationSpec": {
+      "type": "object",
+      "required": ["backend"],
+      "properties": {
+        "backend": {
+          "type": "string",
+          "enum": ["cnpg-pair", "raft", "mirrormaker2", "s3-bucket-replication", "ccr", "sentinel", "velero", "filer-remote-storage", "openbao-perf-replication", "flux-git", "none"]
+        },
+        "mode": { "type": "string", "enum": ["sync", "async", "none"] },
+        "lagSloSeconds": { "type": "integer", "minimum": 0, "maximum": 86400 }
+      },
+      "additionalProperties": false
+    },
+    "SwitchoverSpec": {
+      "type": "object",
+      "required": ["mechanism"],
+      "properties": {
+        "mechanism": {
+          "type": "string",
+          "enum": ["bp-continuum", "manual", "bp-velero-restore", "lua-record", "mm2-symmetric", "ccr-promote", "raft-transition", "sentinel-failover", "none"]
+        },
+        "rtoSeconds": { "type": "integer", "minimum": 0, "maximum": 86400 },
+        "rpoSeconds": { "type": "integer", "minimum": 0, "maximum": 86400 }
+      },
+      "additionalProperties": false
+    },
+    "PlacementSpec": {
+      "type": "object",
+      "properties": {
+        "tier": { "type": "string", "enum": ["mgmt", "dmz", "rtz", ""] },
+        "clusters": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^(mgmt|dmz|rtz)-[A-Z0-9]+$" },
+          "minItems": 0,
+          "uniqueItems": true
+        },
+        "roles": {
+          "type": "object",
+          "patternProperties": {
+            "^(mgmt|dmz|rtz)-[A-Z0-9]+$": {
+              "type": "string",
+              "enum": ["active", "passive", "singleton"]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "Variant_ActiveHotStandby": {
+      "type": "object",
+      "required": ["replication", "switchover", "placement"],
+      "properties": {
+        "replication": {
+          "allOf": [
+            { "$ref": "#/definitions/ReplicationSpec" },
+            { "properties": { "mode": { "const": "sync" } } }
+          ]
+        },
+        "switchover": { "$ref": "#/definitions/SwitchoverSpec" },
+        "placement":  { "$ref": "#/definitions/PlacementSpec" }
+      },
+      "additionalProperties": false
+    },
+    "Variant_ActivePassive": {
+      "type": "object",
+      "required": ["replication", "switchover", "placement"],
+      "properties": {
+        "replication": { "$ref": "#/definitions/ReplicationSpec" },
+        "switchover":  { "$ref": "#/definitions/SwitchoverSpec" },
+        "placement":   { "$ref": "#/definitions/PlacementSpec" }
+      },
+      "additionalProperties": false
+    },
+    "Variant_ActiveActive": {
+      "type": "object",
+      "required": ["replication", "placement"],
+      "properties": {
+        "replication": { "$ref": "#/definitions/ReplicationSpec" },
+        "switchover":  { "$ref": "#/definitions/SwitchoverSpec" },
+        "placement":   { "$ref": "#/definitions/PlacementSpec" }
+      },
+      "additionalProperties": false
+    },
+    "Variant_Singleton": {
+      "type": "object",
+      "required": ["placement"],
+      "properties": {
+        "replication": { "$ref": "#/definitions/ReplicationSpec" },
+        "switchover":  { "$ref": "#/definitions/SwitchoverSpec" },
+        "placement":   { "$ref": "#/definitions/PlacementSpec" }
+      },
+      "additionalProperties": false
+    },
+    "EndpointSpec": {
+      "type": "object",
+      "required": ["name", "hostnameTemplate"],
+      "properties": {
+        "name": { "type": "string", "pattern": "^[a-z][a-z0-9-]{0,30}[a-z0-9]$" },
+        "hostnameTemplate": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 253,
+          "description": "Go text/template emitting an RFC-1123 hostname after evaluation. Tokens: {{.AppName}} {{.InstanceID}} {{.OrgSlug}} {{.SovereignFQDN}} {{.ClusterID}}."
+        },
+        "port":       { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "protocol":   { "type": "string", "enum": ["https", "http", "grpc", "tcp", "udp"] },
+        "tls":        { "type": "boolean" },
+        "visibility": { "type": "string", "enum": ["public", "private", "internal"] },
+        "launchDefault": { "type": "boolean" },
+        "ssoEnabled":    { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "SSOSpec": {
+      "type": "object",
+      "required": ["realm"],
+      "properties": {
+        "realm": { "type": "string", "enum": ["sovereign", "{{.OrgSlug}}"] },
+        "protocolMapper": { "type": "string", "enum": ["oidc", "saml"] },
+        "groupsClaim": { "type": "string", "default": "groups" },
+        "rolesFromGroup": {
+          "type": "object",
+          "patternProperties": { "^[A-Za-z][A-Za-z0-9_-]*$": { "type": "string" } }
+        },
+        "silentLogin": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "MultiInstanceSpec": {
+      "type": "object",
+      "required": ["enabled"],
+      "properties": {
+        "enabled":   { "type": "boolean" },
+        "maxPerOrg": { "type": "integer", "minimum": 0, "maximum": 1000 },
+        "namingTemplate": { "type": "string" },
+        "isolationLevel": { "type": "string", "enum": ["namespace", "vcluster"] }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/products/catalyst/console/src/routes/README.md
+++ b/products/catalyst/console/src/routes/README.md
@@ -1,0 +1,26 @@
+# products/catalyst/console — G117 route scaffolding
+
+> Created by Wave-0 G117 pre-flight. These files are **mocked-data scaffolds** the Wave-1 console authors (G117.2 + G117.3 + G117.4) fill in.
+
+## Why `+page.svelte` and not Astro?
+
+The G117 architectural plan picks SvelteKit-style file-based routing for new console surfaces because:
+
+1. Per-route data-fetching with type-safe `load()` is cleaner than Astro's per-page `<script>` block when each page calls 2-4 catalyst-api endpoints.
+2. Slot-component nesting (drill-down → Application → Endpoints tab) maps naturally to nested `+page.svelte` files.
+3. The Wave-1 plan migrates the existing Astro pages incrementally — these new G117 surfaces ship under the new convention to avoid mixed migration.
+
+If the Wave-1 authors decide to keep Astro, the same Svelte components can be wrapped in `*.astro` shells under `src/pages/` — the mock fixtures + API contracts here are framework-agnostic.
+
+## Route table
+
+| Path | File | Backed by API |
+|---|---|---|
+| `/catalog/:name` | `catalog/[name]/+page.svelte` | `GET /catalog/{blueprint}` + `GET /catalog/{blueprint}/instances` |
+| `/catalog/:name/new` | `catalog/[name]/new/+page.svelte` | `POST /apps/instances` |
+| `/apps/:id` | `apps/[id]/+page.svelte` | `GET /apps/{id}` + `GET /apps/{id}/launch-url` |
+| `/apps/:id/endpoints` | `apps/[id]/endpoints/+page.svelte` | `GET/POST/PATCH/DELETE /apps/{id}/endpoints[/{name}]` |
+
+## Mock fixtures
+
+`tests/e2e/fixtures/mock-blueprints.yaml` — same shape as the OpenAPI `CatalogBlueprint`. The dev server reads this when the `MOCK_API=1` env var is set, so a Wave-1 author can run `MOCK_API=1 npm run dev` and see the surfaces render with no live catalyst-api needed.

--- a/products/catalyst/console/src/routes/apps/[id]/+page.svelte
+++ b/products/catalyst/console/src/routes/apps/[id]/+page.svelte
@@ -1,0 +1,149 @@
+<!--
+  G117.3 / G117.4 — Application detail page.
+
+  Backed by:
+    GET /apps/{id}              → Application (incl. perCluster[] + endpoints[])
+    GET /apps/{id}/launch-url   → Launch URL (silent OIDC)
+
+  The Launch button opens window.open(launchURL, '_blank') with
+  prompt=none&kc_idp_hint=catalyst-pin URL params per locked decision #3.
+  Target time-to-tab: <500ms.
+-->
+<script lang="ts">
+  type ClusterStatus = { cluster: string; role: 'active'|'passive'|'singleton'; status: string; hr: string; message?: string };
+  type Endpoint = { name: string; hostname: string; protocol: string; ssoEnabled: boolean; launchDefault: boolean; status: string; launchURL?: string };
+  type Application = {
+    id: string;
+    name: string;
+    blueprint: string;
+    org: string;
+    topology: string;
+    status: string;
+    perCluster: ClusterStatus[];
+    endpoints: Endpoint[];
+  };
+
+  let appId = $state('');
+  let app = $state<Application | null>(null);
+  let loading = $state(true);
+  let launching = $state(false);
+  let error = $state<string | null>(null);
+
+  async function load() {
+    if (typeof window !== 'undefined') {
+      const m = window.location.pathname.match(/\/apps\/([^/]+)/);
+      if (m) appId = m[1];
+    }
+    try {
+      app = await fetchJSON(`/catalyst/v1/apps/${appId}`);
+    } catch (e) {
+      error = String(e);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function launch(endpointName?: string) {
+    if (!app) return;
+    launching = true;
+    try {
+      const url = endpointName
+        ? `/catalyst/v1/apps/${app.id}/launch-url?endpoint=${encodeURIComponent(endpointName)}`
+        : `/catalyst/v1/apps/${app.id}/launch-url`;
+      const { url: target } = await fetchJSON(url);
+      window.open(target, '_blank', 'noopener,noreferrer');
+    } catch (e) {
+      error = String(e);
+    } finally {
+      launching = false;
+    }
+  }
+
+  async function fetchJSON(url: string): Promise<any> {
+    if (typeof window !== 'undefined' && (window as any).__MOCK_API__) {
+      const fx = (window as any).__MOCK_API__;
+      if (url.includes('/launch-url')) {
+        return { url: `https://grafana.example.com/?prompt=none&kc_idp_hint=catalyst-pin&t=${Date.now()}`, expiresAt: new Date(Date.now() + 60000).toISOString(), endpoint: 'ui' };
+      }
+      if (url.match(/\/apps\/[^/]+$/)) return fx.apps[appId] ?? fx.apps['mock-app-1'];
+    }
+    const r = await fetch(url);
+    if (!r.ok) throw new Error(`${url} → ${r.status}`);
+    return await r.json();
+  }
+
+  $effect(() => { load(); });
+</script>
+
+<section class="g117-app-detail">
+  {#if loading}
+    <p>Loading…</p>
+  {:else if error}
+    <p class="error">{error}</p>
+  {:else if app}
+    <header>
+      <h1>{app.name}</h1>
+      <span class="badge">{app.blueprint}</span>
+      <span class="badge">{app.org}</span>
+      <span class="badge topology">{app.topology}</span>
+      <span class="status status-{app.status.toLowerCase()}">{app.status}</span>
+    </header>
+
+    <div class="actions">
+      <button class="launch" on:click={() => launch()} disabled={launching}>
+        {launching ? 'Launching…' : 'Launch'}
+      </button>
+      <a href="/apps/{app.id}/endpoints">Endpoints</a>
+    </div>
+
+    <h2>Per-cluster fan-out</h2>
+    <table>
+      <thead>
+        <tr><th>Cluster</th><th>Role</th><th>Status</th><th>HelmRelease</th></tr>
+      </thead>
+      <tbody>
+        {#each app.perCluster as pc}
+          <tr>
+            <td>{pc.cluster}</td>
+            <td><code>{pc.role}</code></td>
+            <td class="status-{pc.status.toLowerCase()}">{pc.status}</td>
+            <td><code>{pc.hr}</code></td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+
+    <h2>Endpoints</h2>
+    <ul class="endpoints">
+      {#each app.endpoints as ep}
+        <li>
+          <strong>{ep.name}</strong>
+          <code>{ep.hostname}</code>
+          <span class="proto">{ep.protocol}</span>
+          {#if ep.ssoEnabled}<span class="sso">SSO</span>{/if}
+          {#if ep.ssoEnabled}
+            <button on:click={() => launch(ep.name)} disabled={launching}>Launch</button>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</section>
+
+<style>
+  .g117-app-detail { padding: 1.5rem; max-width: 960px; margin: 0 auto; }
+  header { display: flex; align-items: baseline; gap: 0.75rem; flex-wrap: wrap; }
+  .badge { font-size: 0.85rem; padding: 0.15rem 0.4rem; background: #eee; border-radius: 3px; }
+  .badge.topology { background: #e0e7ff; color: #1d4ed8; }
+  .status { padding: 0.15rem 0.4rem; border-radius: 3px; font-size: 0.85rem; }
+  .status-ready { background: #d1fae5; color: #006400; }
+  .status-degraded { background: #fef3c7; color: #92400e; }
+  .status-failed { background: #fee2e2; color: #991b1b; }
+  .actions { margin: 1rem 0; display: flex; gap: 1rem; align-items: center; }
+  .launch { padding: 0.5rem 1rem; background: #1d4ed8; color: white; border: none; border-radius: 4px; cursor: pointer; }
+  table { width: 100%; border-collapse: collapse; }
+  th, td { padding: 0.5rem; border-bottom: 1px solid #eee; text-align: left; }
+  .endpoints li { margin: 0.5rem 0; display: flex; gap: 0.75rem; align-items: center; }
+  .sso { font-size: 0.75rem; padding: 0.1rem 0.3rem; background: #1d4ed8; color: white; border-radius: 2px; }
+  .error { color: #b00020; }
+</style>

--- a/products/catalyst/console/src/routes/apps/[id]/endpoints/+page.svelte
+++ b/products/catalyst/console/src/routes/apps/[id]/endpoints/+page.svelte
@@ -1,0 +1,193 @@
+<!--
+  G117.3 — Endpoints tab (per-Application).
+
+  Backed by:
+    GET    /apps/{id}/endpoints
+    POST   /apps/{id}/endpoints
+    PATCH  /apps/{id}/endpoints/{name}
+    DELETE /apps/{id}/endpoints/{name}
+
+  Each mutation opens a PR against gitea.<sov>/<org>/iac (decision #4).
+  The Endpoint card shows the PR status badge until the PR auto-merges.
+-->
+<script lang="ts">
+  type Endpoint = {
+    name: string;
+    hostname: string;
+    hostnameTemplate?: string;
+    port?: number;
+    protocol: string;
+    tls?: boolean;
+    visibility?: string;
+    ssoEnabled: boolean;
+    launchDefault?: boolean;
+    status: string;
+    certificateStatus?: string;
+    pendingPR?: { prURL: string; status: string };
+  };
+
+  let appId = $state('');
+  let endpoints = $state<Endpoint[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+  let showAdd = $state(false);
+  let editing = $state<Endpoint | null>(null);
+
+  async function load() {
+    if (typeof window !== 'undefined') {
+      const m = window.location.pathname.match(/\/apps\/([^/]+)\/endpoints/);
+      if (m) appId = m[1];
+    }
+    try {
+      const res = await fetchJSON(`/catalyst/v1/apps/${appId}/endpoints`);
+      endpoints = res.items ?? [];
+    } catch (e) {
+      error = String(e);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function save(ep: Endpoint, isNew: boolean) {
+    try {
+      const url = isNew
+        ? `/catalyst/v1/apps/${appId}/endpoints`
+        : `/catalyst/v1/apps/${appId}/endpoints/${ep.name}`;
+      const method = isNew ? 'POST' : 'PATCH';
+      const pr = await mutateJSON(url, method, ep);
+      ep.pendingPR = { prURL: pr.prURL, status: pr.status };
+      showAdd = false; editing = null;
+      await load();
+    } catch (e) {
+      error = String(e);
+    }
+  }
+
+  async function remove(ep: Endpoint) {
+    if (!confirm(`Delete endpoint ${ep.name}?`)) return;
+    try {
+      await mutateJSON(`/catalyst/v1/apps/${appId}/endpoints/${ep.name}`, 'DELETE', null);
+      await load();
+    } catch (e) {
+      error = String(e);
+    }
+  }
+
+  async function fetchJSON(url: string): Promise<any> {
+    if (typeof window !== 'undefined' && (window as any).__MOCK_API__) {
+      return { items: (window as any).__MOCK_API__.endpoints?.[appId] ?? [] };
+    }
+    const r = await fetch(url);
+    if (!r.ok) throw new Error(`${url} → ${r.status}`);
+    return await r.json();
+  }
+
+  async function mutateJSON(url: string, method: string, body: any): Promise<any> {
+    if (typeof window !== 'undefined' && (window as any).__MOCK_API__) {
+      return { prURL: 'https://gitea.example/org/iac/pulls/42', status: 'open' };
+    }
+    const r = await fetch(url, {
+      method,
+      headers: { 'content-type': 'application/json' },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!r.ok) throw new Error(`${url} → ${r.status}`);
+    return await r.json();
+  }
+
+  $effect(() => { load(); });
+</script>
+
+<section class="g117-endpoints">
+  <header>
+    <h1>Endpoints</h1>
+    <a href="/apps/{appId}">← back to Application</a>
+    <button on:click={() => { showAdd = true; editing = { name: '', hostname: '', protocol: 'https', ssoEnabled: true, status: 'Pending' }; }}>+ Add endpoint</button>
+  </header>
+
+  {#if loading}
+    <p>Loading…</p>
+  {:else if error}
+    <p class="error">{error}</p>
+  {:else}
+    <ul class="endpoint-list">
+      {#each endpoints as ep}
+        <li class="card">
+          <header>
+            <strong>{ep.name}</strong>
+            <code>{ep.hostname}</code>
+            <span class="proto">{ep.protocol}{ep.port ? ':' + ep.port : ''}</span>
+            {#if ep.ssoEnabled}<span class="sso">SSO</span>{/if}
+            {#if ep.launchDefault}<span class="default">default</span>{/if}
+            {#if ep.tls}<span class="tls">TLS</span>{/if}
+            <span class="status status-{ep.status.toLowerCase()}">{ep.status}</span>
+            {#if ep.pendingPR}
+              <a class="pr" href={ep.pendingPR.prURL} target="_blank" rel="noopener">PR {ep.pendingPR.status}</a>
+            {/if}
+          </header>
+          <div class="meta">
+            {#if ep.certificateStatus}cert: {ep.certificateStatus} · {/if}
+            {#if ep.visibility}visibility: {ep.visibility}{/if}
+          </div>
+          <div class="actions">
+            <button on:click={() => editing = { ...ep }}>Edit</button>
+            <button class="danger" on:click={() => remove(ep)}>Delete</button>
+          </div>
+        </li>
+      {/each}
+    </ul>
+
+    {#if showAdd || editing}
+      <div class="dialog">
+        <h2>{showAdd ? 'New endpoint' : 'Edit endpoint'}</h2>
+        <form on:submit|preventDefault={() => save(editing!, showAdd)}>
+          <label>Name <input type="text" bind:value={editing!.name} required pattern="^[a-z][a-z0-9-]{0,30}[a-z0-9]$" /></label>
+          <label>Hostname <input type="text" bind:value={editing!.hostname} required /></label>
+          <label>Protocol
+            <select bind:value={editing!.protocol}>
+              <option>https</option><option>http</option><option>grpc</option><option>tcp</option><option>udp</option>
+            </select>
+          </label>
+          <label>Port <input type="number" bind:value={editing!.port} min="1" max="65535" /></label>
+          <label><input type="checkbox" bind:checked={editing!.tls} /> TLS</label>
+          <label><input type="checkbox" bind:checked={editing!.ssoEnabled} /> SSO</label>
+          <label>Visibility
+            <select bind:value={editing!.visibility}>
+              <option value="public">public</option>
+              <option value="private">private</option>
+              <option value="internal">internal</option>
+            </select>
+          </label>
+          <div class="actions">
+            <button type="submit">Save (opens PR)</button>
+            <button type="button" on:click={() => { showAdd = false; editing = null; }}>Cancel</button>
+          </div>
+        </form>
+      </div>
+    {/if}
+  {/if}
+</section>
+
+<style>
+  .g117-endpoints { padding: 1.5rem; max-width: 960px; margin: 0 auto; }
+  header { display: flex; align-items: baseline; gap: 0.75rem; flex-wrap: wrap; }
+  .endpoint-list { list-style: none; padding: 0; }
+  .card { border: 1px solid #ddd; border-radius: 6px; padding: 1rem; margin: 0.75rem 0; }
+  .card header { gap: 0.5rem; }
+  .proto, .tls, .sso, .default, .pr { font-size: 0.75rem; padding: 0.1rem 0.3rem; border-radius: 3px; }
+  .proto { background: #eee; }
+  .tls  { background: #d1fae5; color: #006400; }
+  .sso  { background: #1d4ed8; color: white; }
+  .default { background: #fef3c7; color: #92400e; }
+  .pr { background: #ddd6fe; color: #5b21b6; text-decoration: none; }
+  .status { padding: 0.1rem 0.3rem; border-radius: 3px; font-size: 0.85rem; }
+  .status-ready { background: #d1fae5; color: #006400; }
+  .meta { font-size: 0.85rem; color: #666; margin: 0.5rem 0; }
+  .actions { display: flex; gap: 0.5rem; }
+  button { padding: 0.4rem 0.8rem; background: #1d4ed8; color: white; border: none; border-radius: 4px; cursor: pointer; }
+  .danger { background: #b00020; }
+  .dialog { border: 1px solid #ddd; padding: 1rem; border-radius: 6px; margin: 1rem 0; background: #fafafa; }
+  .dialog label { display: block; margin: 0.5rem 0; }
+  .dialog input[type="text"], .dialog input[type="number"], .dialog select { width: 100%; padding: 0.4rem; border: 1px solid #ddd; border-radius: 4px; }
+  .error { color: #b00020; }
+</style>

--- a/products/catalyst/console/src/routes/catalog/[name]/+page.svelte
+++ b/products/catalyst/console/src/routes/catalog/[name]/+page.svelte
@@ -1,0 +1,139 @@
+<!--
+  G117.2 — Catalog drill-down page.
+
+  Backed by:
+    GET /catalog/{blueprint}            → CatalogBlueprint
+    GET /catalog/{blueprint}/instances  → ApplicationSummary[]
+
+  Wave-1 (G117.2) task: replace the mock fetch with the real catalyst-api
+  client (see ../../../lib/api/catalystApi.ts which the same agent should
+  add to mirror docs/api/catalyst-api-openapi.yaml).
+
+  Mock data shape: products/catalyst/console/tests/e2e/fixtures/mock-blueprints.yaml
+-->
+<script lang="ts">
+  // SvelteKit-style $page store fallback for non-SvelteKit (Astro) runners.
+  // When ported to SvelteKit proper, replace with `import { page } from '$app/stores'`.
+  type Endpoint = { name: string; hostnameTemplate: string; protocol: string; ssoEnabled: boolean; launchDefault: boolean };
+  type CatalogBlueprint = {
+    name: string;
+    version: string;
+    title: string;
+    description: string;
+    family: string;
+    instanceCount: number;
+    supportedTopologies: string[];
+    defaultTopology: string;
+    multiInstance: { enabled: boolean; maxPerOrg?: number };
+    endpoints?: Endpoint[];
+  };
+  type Instance = { id: string; name: string; org: string; topology: string; status: string; createdAt: string };
+
+  // In a real SvelteKit page this is `export let data` from +page.ts.
+  // In the mock harness we read from window.__MOCK__ injected by the dev shim.
+  let blueprintName = $state('grafana');
+  let blueprint = $state<CatalogBlueprint | null>(null);
+  let instances = $state<Instance[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+
+  async function load() {
+    loading = true;
+    try {
+      // Resolve route param. In SvelteKit this is `params.name`; here we
+      // read it from the URL or a globally-injected mock context.
+      if (typeof window !== 'undefined') {
+        const m = window.location.pathname.match(/\/catalog\/([^/]+)/);
+        if (m) blueprintName = m[1];
+      }
+      const bp = await fetchJSON(`/catalyst/v1/catalog/${blueprintName}`);
+      const list = await fetchJSON(`/catalyst/v1/catalog/${blueprintName}/instances`);
+      blueprint = bp;
+      instances = list.items ?? [];
+    } catch (e) {
+      error = String(e);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function fetchJSON(url: string): Promise<any> {
+    // MOCK_API mode: read from globally-injected fixture.
+    if (typeof window !== 'undefined' && (window as any).__MOCK_API__) {
+      const fixture = (window as any).__MOCK_API__;
+      if (url.endsWith(`/catalog/${blueprintName}`)) return fixture.blueprints[blueprintName];
+      if (url.endsWith(`/instances`)) return { items: fixture.instances[blueprintName] ?? [] };
+    }
+    const r = await fetch(url, { headers: { accept: 'application/json' } });
+    if (!r.ok) throw new Error(`${url} → ${r.status}`);
+    return await r.json();
+  }
+
+  $effect(() => { load(); });
+</script>
+
+<section class="g117-catalog-drilldown">
+  {#if loading}
+    <p>Loading {blueprintName}…</p>
+  {:else if error}
+    <p class="error">{error}</p>
+  {:else if blueprint}
+    <header>
+      <h1>{blueprint.title}</h1>
+      <span class="version">v{blueprint.version}</span>
+      <span class="family">{blueprint.family}</span>
+    </header>
+    <p>{blueprint.description}</p>
+
+    <h2>Supported topologies</h2>
+    <ul>
+      {#each blueprint.supportedTopologies as t}
+        <li>
+          <code>{t}</code>
+          {#if t === blueprint.defaultTopology}<em>(default)</em>{/if}
+        </li>
+      {/each}
+    </ul>
+
+    <h2>Instances ({blueprint.instanceCount})</h2>
+    {#if blueprint.multiInstance.enabled}
+      <a class="btn-new" href="/catalog/{blueprintName}/new">+ New instance</a>
+    {:else if instances.length === 0}
+      <a class="btn-new" href="/catalog/{blueprintName}/new">Install</a>
+    {:else}
+      <p><em>This Blueprint is singleton-per-Org.</em></p>
+    {/if}
+
+    {#if instances.length > 0}
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th><th>Org</th><th>Topology</th><th>Status</th><th>Created</th><th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each instances as inst}
+            <tr>
+              <td><a href="/apps/{inst.id}">{inst.name}</a></td>
+              <td>{inst.org}</td>
+              <td><code>{inst.topology}</code></td>
+              <td>{inst.status}</td>
+              <td>{inst.createdAt}</td>
+              <td><a href="/apps/{inst.id}/endpoints">Endpoints</a></td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  {/if}
+</section>
+
+<style>
+  .g117-catalog-drilldown { padding: 1.5rem; max-width: 960px; margin: 0 auto; }
+  header { display: flex; align-items: baseline; gap: 1rem; }
+  .version, .family { font-size: 0.85rem; color: #666; }
+  table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+  th, td { padding: 0.5rem; border-bottom: 1px solid #eee; text-align: left; }
+  .btn-new { display: inline-block; padding: 0.4rem 0.8rem; background: #1d4ed8; color: white; border-radius: 4px; text-decoration: none; }
+  .error { color: #b00020; }
+</style>

--- a/products/catalyst/console/src/routes/catalog/[name]/new/+page.svelte
+++ b/products/catalyst/console/src/routes/catalog/[name]/new/+page.svelte
@@ -1,0 +1,130 @@
+<!--
+  G117.2 — New-instance dialog (topology picker).
+
+  Backed by:
+    POST /apps/instances    → Application
+
+  Topology radio is pre-selected per Sovereign shape:
+    - len(regions) > 1  → CatalogBlueprint.defaultTopology (multi-region default)
+    - else              → singleton (or Blueprint's single-region default)
+
+  Wave-1 (G117.2): wire to real catalyst-api client; pull regions count
+  from /sovereign/info; gate maxPerOrg before submit.
+-->
+<script lang="ts">
+  type CatalogBlueprint = {
+    name: string;
+    title: string;
+    supportedTopologies: string[];
+    defaultTopology: string;
+    multiInstance: { enabled: boolean; maxPerOrg?: number };
+  };
+
+  let blueprintName = $state('grafana');
+  let blueprint = $state<CatalogBlueprint | null>(null);
+  let instanceName = $state('');
+  let org = $state('');
+  let topology = $state('');
+  let submitting = $state(false);
+  let error = $state<string | null>(null);
+  let toast = $state<string | null>(null);
+
+  async function load() {
+    if (typeof window !== 'undefined') {
+      const m = window.location.pathname.match(/\/catalog\/([^/]+)\/new/);
+      if (m) blueprintName = m[1];
+    }
+    blueprint = await fetchJSON(`/catalyst/v1/catalog/${blueprintName}`);
+    if (blueprint) topology = blueprint.defaultTopology;
+  }
+
+  async function submit() {
+    if (!instanceName || !org || !topology || !blueprint) {
+      error = 'Fill all fields'; return;
+    }
+    submitting = true;
+    error = null;
+    try {
+      const body = { blueprint: blueprint.name, org, name: instanceName, topology };
+      const app = await postJSON('/catalyst/v1/apps/instances', body);
+      toast = `Instance ${app.id} created`;
+      // Navigate to the new instance.
+      window.location.href = `/apps/${app.id}`;
+    } catch (e) {
+      error = String(e);
+    } finally {
+      submitting = false;
+    }
+  }
+
+  async function fetchJSON(url: string): Promise<any> {
+    if (typeof window !== 'undefined' && (window as any).__MOCK_API__) {
+      return (window as any).__MOCK_API__.blueprints[blueprintName];
+    }
+    const r = await fetch(url);
+    if (!r.ok) throw new Error(`${url} → ${r.status}`);
+    return await r.json();
+  }
+
+  async function postJSON(url: string, body: any): Promise<any> {
+    if (typeof window !== 'undefined' && (window as any).__MOCK_API__) {
+      return { id: 'mock-' + crypto.randomUUID(), ...body, status: 'Pending' };
+    }
+    const r = await fetch(url, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) });
+    if (!r.ok) throw new Error(`${url} → ${r.status}`);
+    return await r.json();
+  }
+
+  $effect(() => { load(); });
+</script>
+
+<section class="g117-new-instance">
+  <header>
+    <h1>New {blueprint?.title ?? blueprintName} instance</h1>
+    <a href="/catalog/{blueprintName}">← back</a>
+  </header>
+
+  {#if !blueprint}
+    <p>Loading…</p>
+  {:else}
+    <form on:submit|preventDefault={submit}>
+      <label>
+        Instance name
+        <input type="text" bind:value={instanceName} placeholder="e.g. metrics-primary" required pattern="^[a-z0-9][a-z0-9-]{0,40}[a-z0-9]$" />
+      </label>
+
+      <label>
+        Organization slug
+        <input type="text" bind:value={org} placeholder="e.g. acme" required pattern="^[a-z0-9][a-z0-9-]{0,40}[a-z0-9]$" />
+      </label>
+
+      <fieldset>
+        <legend>Topology</legend>
+        {#each blueprint.supportedTopologies as t}
+          <label class="radio">
+            <input type="radio" bind:group={topology} value={t} />
+            <code>{t}</code>
+            {#if t === blueprint.defaultTopology}<em>(default for this Sovereign)</em>{/if}
+          </label>
+        {/each}
+      </fieldset>
+
+      {#if error}<p class="error">{error}</p>{/if}
+      {#if toast}<p class="ok">{toast}</p>{/if}
+
+      <button type="submit" disabled={submitting}>{submitting ? 'Creating…' : 'Create'}</button>
+    </form>
+  {/if}
+</section>
+
+<style>
+  .g117-new-instance { padding: 1.5rem; max-width: 640px; margin: 0 auto; }
+  header { display: flex; align-items: baseline; justify-content: space-between; }
+  form label { display: block; margin: 0.75rem 0; }
+  input[type="text"] { width: 100%; padding: 0.5rem; border: 1px solid #ddd; border-radius: 4px; }
+  fieldset { border: 1px solid #ddd; padding: 1rem; border-radius: 4px; }
+  .radio { display: block; margin: 0.25rem 0; }
+  button { padding: 0.5rem 1rem; background: #1d4ed8; color: white; border: none; border-radius: 4px; cursor: pointer; }
+  .error { color: #b00020; }
+  .ok { color: #006400; }
+</style>

--- a/products/catalyst/console/tests/e2e/fixtures/mock-blueprints.yaml
+++ b/products/catalyst/console/tests/e2e/fixtures/mock-blueprints.yaml
@@ -1,0 +1,207 @@
+# G117 mock fixtures — matches docs/api/catalyst-api-openapi.yaml shapes.
+#
+# The console dev-server reads this when MOCK_API=1 is set in the env. The
+# fixture is also imported by the Wave-1 Playwright specs as a deterministic
+# data source.
+#
+# Keep this file in lockstep with:
+#   - docs/api/catalyst-api-openapi.yaml (CatalogBlueprint / Application / Endpoint shapes)
+#   - examples/blueprint-grafana-fully-declared.yaml (grafana fixture mirror)
+
+blueprints:
+  grafana:
+    name: grafana
+    version: "1.0.4"
+    title: Grafana
+    description: Visualization and dashboarding for the LGTM observability stack.
+    family: insights
+    section: pts-3-observability
+    instanceCount: 2
+    supportedTopologies: [active-hot-standby, singleton]
+    defaultTopology: active-hot-standby
+    multiInstance:
+      enabled: true
+      maxPerOrg: 5
+    sso:
+      realm: sovereign
+      silentLogin: true
+    endpoints:
+      - name: ui
+        hostnameTemplate: "grafana.{{.SovereignFQDN}}"
+        port: 443
+        protocol: https
+        tls: true
+        visibility: public
+        launchDefault: true
+        ssoEnabled: true
+
+  harbor:
+    name: harbor
+    version: "1.5.0"
+    title: Harbor
+    description: OCI registry with Trivy scanning + Cosign signing.
+    family: registry
+    section: pts-2-platform
+    instanceCount: 1
+    supportedTopologies: [active-hot-standby, singleton]
+    defaultTopology: active-hot-standby
+    multiInstance:
+      enabled: false
+    sso:
+      realm: sovereign
+      silentLogin: true
+    endpoints:
+      - name: ui
+        hostnameTemplate: "harbor.{{.SovereignFQDN}}"
+        port: 443
+        protocol: https
+        tls: true
+        visibility: public
+        launchDefault: true
+        ssoEnabled: true
+      - name: registry
+        hostnameTemplate: "registry.{{.SovereignFQDN}}"
+        port: 443
+        protocol: https
+        tls: true
+        visibility: public
+        ssoEnabled: false
+
+  gitea:
+    name: gitea
+    version: "1.4.9"
+    title: Gitea
+    description: Self-hosted Git server.
+    family: source
+    section: pts-2-platform
+    instanceCount: 1
+    supportedTopologies: [active-hot-standby, singleton]
+    defaultTopology: active-hot-standby
+    multiInstance:
+      enabled: false
+    sso:
+      realm: sovereign
+      silentLogin: true
+    endpoints:
+      - name: ui
+        hostnameTemplate: "gitea.{{.SovereignFQDN}}"
+        port: 443
+        protocol: https
+        tls: true
+        visibility: public
+        launchDefault: true
+        ssoEnabled: true
+
+  openbao:
+    name: openbao
+    version: "1.2.21"
+    title: OpenBao
+    description: Vault-compatible secret store.
+    family: security
+    section: pts-2-platform
+    instanceCount: 1
+    supportedTopologies: [active-hot-standby, singleton]
+    defaultTopology: active-hot-standby
+    multiInstance:
+      enabled: false
+    sso:
+      realm: sovereign
+      silentLogin: true
+    endpoints:
+      - name: ui
+        hostnameTemplate: "vault.{{.SovereignFQDN}}"
+        port: 443
+        protocol: https
+        tls: true
+        visibility: public
+        launchDefault: true
+        ssoEnabled: true
+
+instances:
+  grafana:
+    - id: 8a1e9bf2-7c4d-4b3a-9f1e-2c5a8d3f6e0a
+      name: metrics-primary
+      blueprint: grafana
+      org: acme
+      topology: active-hot-standby
+      status: Ready
+      createdAt: "2026-05-28T10:00:00Z"
+    - id: c2d8e4a1-3b6f-4e7c-8a9d-1f5b7c3e9a2d
+      name: metrics-staging
+      blueprint: grafana
+      org: acme
+      topology: singleton
+      status: Ready
+      createdAt: "2026-06-01T14:30:00Z"
+  harbor:
+    - id: f3a9b1d8-4c2e-4d5f-9a7b-6e8c1d3f5a7b
+      name: registry-primary
+      blueprint: harbor
+      org: acme
+      topology: active-hot-standby
+      status: Ready
+      createdAt: "2026-05-15T08:00:00Z"
+
+apps:
+  "8a1e9bf2-7c4d-4b3a-9f1e-2c5a8d3f6e0a":
+    id: 8a1e9bf2-7c4d-4b3a-9f1e-2c5a8d3f6e0a
+    name: metrics-primary
+    blueprint: grafana
+    org: acme
+    topology: active-hot-standby
+    status: Ready
+    createdAt: "2026-05-28T10:00:00Z"
+    perCluster:
+      - cluster: mgmt-A
+        role: active
+        status: Ready
+        hr: grafana-metrics-primary
+      - cluster: mgmt-B
+        role: passive
+        status: Ready
+        hr: grafana-metrics-primary
+    endpoints:
+      - name: ui
+        hostname: "grafana.acme.t01.omani.works"
+        protocol: https
+        tls: true
+        visibility: public
+        ssoEnabled: true
+        launchDefault: true
+        status: Ready
+        certificateStatus: Issued
+  "mock-app-1":
+    id: mock-app-1
+    name: mock-instance
+    blueprint: grafana
+    org: acme
+    topology: singleton
+    status: Ready
+    createdAt: "2026-06-02T00:00:00Z"
+    perCluster:
+      - cluster: mgmt-A
+        role: singleton
+        status: Ready
+        hr: grafana-mock
+    endpoints:
+      - name: ui
+        hostname: "grafana.mock.t01.omani.works"
+        protocol: https
+        tls: true
+        visibility: public
+        ssoEnabled: true
+        launchDefault: true
+        status: Ready
+
+endpoints:
+  "8a1e9bf2-7c4d-4b3a-9f1e-2c5a8d3f6e0a":
+    - name: ui
+      hostname: "grafana.acme.t01.omani.works"
+      protocol: https
+      port: 443
+      tls: true
+      visibility: public
+      ssoEnabled: true
+      launchDefault: true
+      status: Ready
+      certificateStatus: Issued

--- a/tools/bootstrap-org-iac-repo.sh
+++ b/tools/bootstrap-org-iac-repo.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# tools/bootstrap-org-iac-repo.sh
+#
+# Bootstraps the per-Org IaC repo on a Sovereign's local Gitea per
+# ADR-0009. Idempotent: re-runs are safe.
+#
+# Usage:
+#   GITEA_TOKEN=<gitea-admin-token> \
+#     tools/bootstrap-org-iac-repo.sh \
+#       --org acme \
+#       --sov-fqdn t01.omani.works
+#
+# Steps:
+#   1. Create the Gitea Org (idempotent — 422 means already exists)
+#   2. Create the per-Org "iac" repo with the canonical tree
+#   3. Create the robot user <org>-iac-bot and add as collaborator with
+#      write access scoped to <org>/iac
+#   4. Configure branch protection on main requiring the three named
+#      status checks (kyverno-admission, cert-manager-precheck, dns-conflict-precheck)
+#
+# Exit codes:
+#   0  — success (or already-bootstrapped; idempotent)
+#   2  — missing required arg or env
+#   3  — Gitea API call returned an unexpected error
+set -euo pipefail
+
+# ── 1. Parse args ──────────────────────────────────────────────────────
+ORG=""
+SOV_FQDN=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --org)       ORG="$2"; shift 2 ;;
+    --sov-fqdn)  SOV_FQDN="$2"; shift 2 ;;
+    -h|--help)
+      grep -E '^# ' "$0" | sed 's/^# \?//' | head -30
+      exit 0 ;;
+    *)
+      echo "unknown arg: $1" >&2
+      exit 2 ;;
+  esac
+done
+
+if [[ -z "$ORG" || -z "$SOV_FQDN" ]]; then
+  echo "usage: $0 --org <slug> --sov-fqdn <fqdn>" >&2
+  echo "  (GITEA_TOKEN must be set in env)" >&2
+  exit 2
+fi
+if [[ -z "${GITEA_TOKEN:-}" ]]; then
+  echo "GITEA_TOKEN must be set in env" >&2
+  exit 2
+fi
+
+# Slug guards — RFC-1123 lowercase, hyphen-separated.
+if ! [[ "$ORG" =~ ^[a-z0-9][a-z0-9-]{0,40}[a-z0-9]$ ]]; then
+  echo "invalid org slug: $ORG (must match ^[a-z0-9][a-z0-9-]{0,40}[a-z0-9]$)" >&2
+  exit 2
+fi
+
+GITEA_URL="https://gitea.${SOV_FQDN}"
+AUTH_HEADER="Authorization: token ${GITEA_TOKEN}"
+CT_HEADER="Content-Type: application/json"
+
+echo "▸ Bootstrapping ${ORG}/iac on ${GITEA_URL}"
+
+# ── 2. Helper: HTTP wrapper that tolerates 'already-exists' (422) ──────
+api() {
+  local method="$1" path="$2" body="${3:-}"
+  local url="${GITEA_URL}/api/v1${path}"
+  local resp http_code
+
+  if [[ -n "$body" ]]; then
+    resp=$(curl -sS -o /tmp/gitea-resp -w '%{http_code}' \
+      -X "$method" \
+      -H "$AUTH_HEADER" -H "$CT_HEADER" \
+      --data "$body" \
+      "$url")
+  else
+    resp=$(curl -sS -o /tmp/gitea-resp -w '%{http_code}' \
+      -X "$method" \
+      -H "$AUTH_HEADER" \
+      "$url")
+  fi
+  http_code="$resp"
+  # 200/201 = ok; 422 = already-exists (idempotent); 204 = ok-no-content
+  case "$http_code" in
+    200|201|204) return 0 ;;
+    422)
+      # Already-exists is fine for our idempotent flow
+      return 0 ;;
+    *)
+      echo "✗ ${method} ${path} → HTTP ${http_code}" >&2
+      cat /tmp/gitea-resp >&2
+      echo >&2
+      return 3 ;;
+  esac
+}
+
+# ── 3. Step 1: Create the Org ──────────────────────────────────────────
+echo "  [1/4] create org ${ORG}"
+api POST "/orgs" "{
+  \"username\": \"${ORG}\",
+  \"full_name\": \"${ORG}\",
+  \"description\": \"Per-Org Catalyst tenant — created by bootstrap-org-iac-repo.sh\",
+  \"visibility\": \"private\"
+}" || exit 3
+
+# ── 4. Step 2: Create the iac repo with default tree ───────────────────
+echo "  [2/4] create repo ${ORG}/iac"
+api POST "/orgs/${ORG}/repos" "{
+  \"name\": \"iac\",
+  \"description\": \"Catalyst Organization IaC repo (managed by application-controller via PR).\",
+  \"private\": true,
+  \"auto_init\": true,
+  \"default_branch\": \"main\"
+}" || exit 3
+
+# Default tree — README + kustomization + .gitkeep files in apps/ envs/ policies/.
+# Use Gitea's PUT /repos/{owner}/{repo}/contents/{filepath}; the API
+# returns 422 if the file already exists, which we treat as a no-op.
+echo "  [3/4] seed canonical tree"
+seed_file() {
+  local path="$1" content="$2"
+  # base64-encode the content for Gitea's contents API.
+  local b64
+  b64=$(printf '%s' "$content" | base64 -w0)
+  api POST "/repos/${ORG}/iac/contents/${path}" "{
+    \"branch\": \"main\",
+    \"message\": \"chore: seed ${path}\",
+    \"content\": \"${b64}\"
+  }" || true  # tolerate 422 (file exists)
+}
+
+seed_file "README.md" "# ${ORG} — Catalyst IaC repo
+
+Managed by application-controller via PR pipeline (see ADR-0009).
+
+Tree:
+- apps/      — one folder per Application instance
+- envs/      — Environment definitions
+- policies/  — Org-local Kyverno / Cilium overrides
+- kustomization.yaml — Flux entry point
+
+Direct pushes to main are blocked; every change goes through a PR with
+three required status checks (kyverno-admission, cert-manager-precheck,
+dns-conflict-precheck).
+"
+
+seed_file "kustomization.yaml" "apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - apps/
+  - envs/
+  - policies/
+"
+
+seed_file "apps/.gitkeep" ""
+seed_file "envs/.gitkeep" ""
+seed_file "policies/.gitkeep" ""
+
+# ── 5. Step 3: Create the robot user + scope to repo ───────────────────
+echo "  [4/4] create robot user ${ORG}-iac-bot + branch protection"
+ROBOT_USER="${ORG}-iac-bot"
+ROBOT_EMAIL="${ROBOT_USER}@gitea.${SOV_FQDN}"
+# A random password — the robot never logs in with this; only the
+# generated token is used. We just need something Gitea accepts.
+ROBOT_PASSWORD=$(head -c 32 /dev/urandom | base64 | tr -d '/+=' | head -c 32)
+api POST "/admin/users" "{
+  \"username\": \"${ROBOT_USER}\",
+  \"email\": \"${ROBOT_EMAIL}\",
+  \"password\": \"${ROBOT_PASSWORD}\",
+  \"login_name\": \"${ROBOT_USER}\",
+  \"must_change_password\": false,
+  \"source_id\": 0
+}" || exit 3
+
+# Add the robot as a collaborator on <org>/iac with write permission.
+api PUT "/repos/${ORG}/iac/collaborators/${ROBOT_USER}" '{
+  "permission": "write"
+}' || exit 3
+
+# Branch protection on main — require the three named status checks.
+api POST "/repos/${ORG}/iac/branch_protections" '{
+  "branch_name": "main",
+  "enable_status_check": true,
+  "status_check_contexts": [
+    "kyverno-admission",
+    "cert-manager-precheck",
+    "dns-conflict-precheck"
+  ],
+  "block_on_rejected_reviews": false,
+  "require_signed_commits": false,
+  "push_whitelist_usernames": []
+}' || exit 3
+
+echo "✓ ${ORG}/iac bootstrapped on ${GITEA_URL}"
+echo "  Robot user:    ${ROBOT_USER}"
+echo "  Repo URL:      ${GITEA_URL}/${ORG}/iac"
+echo
+echo "Next: generate the robot's API token via Gitea admin UI or"
+echo "      'curl -u admin:<adminpw> ${GITEA_URL}/api/v1/users/${ROBOT_USER}/tokens'"
+echo "      and store as Secret '${ROBOT_USER}-token' in the Org namespace."

--- a/tools/migrate-blueprints-topology.py
+++ b/tools/migrate-blueprints-topology.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""tools/migrate-blueprints-topology.py — G117.1 helper.
+
+Parses the per-blueprint topology audit (the canonical
+docs/sessions/2026-06-02-per-blueprint-topology-audit.md) and emits one
+spec.topology YAML stub per row, ready to be folded into each
+platform/<bp>/blueprint.yaml by the Wave-1 G117.1 author.
+
+Each emitted stub:
+  - validates against platform/_schemas/blueprint-topology.json
+  - encodes the row's per-cluster placement, replication backend, and
+    switchover mechanism columns
+
+Output directory layout:
+  <output-dir>/
+    bp-grafana.yaml
+    bp-keycloak.yaml
+    ...
+
+Usage:
+  python3 tools/migrate-blueprints-topology.py --output-dir /tmp/topology-stubs
+  python3 tools/migrate-blueprints-topology.py --output-dir /tmp/stubs --validate
+
+The --validate flag also runs jsonschema validation on every emitted
+stub and exits non-zero if any fail.
+
+Why this is a tool, not a one-shot script: Wave-1 G117.1 authors will
+re-run this after the audit doc gets more rows, and the script handles
+de-duplication when the audit is updated.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("install pyyaml: pip3 install --user pyyaml")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+AUDIT_DOC = REPO_ROOT / "docs/sessions/2026-06-02-per-blueprint-topology-audit.md"
+SCHEMA_PATH = REPO_ROOT / "platform/_schemas/blueprint-topology.json"
+
+# Markers in the audit doc:
+#   🟢 A   → active
+#   🟡 P   → passive
+#   🔵 S   → singleton
+#   blank  → not deployed
+GLYPH_TO_ROLE = {
+    "🟢 A": "active",
+    "🟡 P": "passive",
+    "🔵 S": "singleton",
+    # blank cells render as just whitespace or '⬜'
+}
+
+# Canonical cluster IDs (header order in every table in the audit).
+CLUSTERS = ["mgmt-A", "mgmt-B", "dmz-A", "dmz-B", "rtz-A", "rtz-B"]
+
+# Best-effort mapping from the audit's "State preservation" + "Switchover"
+# free-text columns to the JSON schema's enums.
+def infer_replication(text: str) -> dict[str, Any]:
+    t = text.lower()
+    if "n/a" in t or "stateless" in t or "—" in t:
+        return {"backend": "none", "mode": "none"}
+    if "cnpg-pair" in t or "bp-cnpg-pair" in t:
+        # Default sync; many CP-tier blueprints use bp-cnpg-pair sync.
+        mode = "sync" if "sync" in t or "remote_apply" in t else "async"
+        return {"backend": "cnpg-pair", "mode": mode}
+    if "mirrormaker" in t or "mm2" in t:
+        return {"backend": "mirrormaker2", "mode": "async"}
+    if "ccr" in t or "cross-cluster replication" in t:
+        return {"backend": "ccr", "mode": "async"}
+    if "raft" in t:
+        return {"backend": "raft", "mode": "sync"}
+    if "sentinel" in t:
+        return {"backend": "sentinel", "mode": "async"}
+    if "bucket replication" in t or "s3" in t:
+        return {"backend": "s3-bucket-replication", "mode": "async"}
+    if "velero" in t:
+        return {"backend": "velero", "mode": "async"}
+    if "filer remote" in t or "filer remote storage" in t:
+        return {"backend": "filer-remote-storage", "mode": "async"}
+    if "openbao perf" in t or "perf-replication" in t:
+        return {"backend": "openbao-perf-replication", "mode": "async"}
+    if "flux" in t or "source-of-truth" in t and "git" in t:
+        return {"backend": "flux-git", "mode": "async"}
+    return {"backend": "none", "mode": "none"}
+
+
+def infer_switchover(text: str) -> dict[str, Any]:
+    t = text.lower()
+    if "bp-continuum" in t or "continuum" in t:
+        return {"mechanism": "bp-continuum"}
+    if "manual" in t:
+        return {"mechanism": "manual"}
+    if "velero restore" in t or "velero" in t:
+        return {"mechanism": "bp-velero-restore"}
+    if "lua-record" in t or "ifurlup" in t:
+        return {"mechanism": "lua-record"}
+    if "mm2" in t or "active-active topics" in t:
+        return {"mechanism": "mm2-symmetric"}
+    if "ccr-promote" in t or "promote read-replica" in t:
+        return {"mechanism": "ccr-promote"}
+    if "transition-to-primary" in t:
+        return {"mechanism": "raft-transition"}
+    if "sentinel failover" in t:
+        return {"mechanism": "sentinel-failover"}
+    return {"mechanism": "none"}
+
+
+def parse_role_cell(cell: str) -> str | None:
+    """Return 'active' | 'passive' | 'singleton' | None for an audit cell."""
+    cell = cell.strip()
+    if not cell or cell == "⬜":
+        return None
+    for glyph, role in GLYPH_TO_ROLE.items():
+        if glyph in cell:
+            return role
+    return None
+
+
+def parse_audit_tables(path: Path) -> list[dict[str, Any]]:
+    """Parse the audit markdown's tables into a list of row-dicts."""
+    if not path.exists():
+        sys.exit(f"audit doc not found: {path}")
+    text = path.read_text()
+    rows: list[dict[str, Any]] = []
+
+    # Tables start with a header line containing "Blueprint" and "mgmt-A".
+    lines = text.splitlines()
+    in_table = False
+    headers: list[str] = []
+    for line in lines:
+        # Detect the header rows we care about.
+        if re.match(r"^\|\s*Blueprint\s*\|.*mgmt-A", line):
+            in_table = True
+            headers = [c.strip() for c in line.strip().strip("|").split("|")]
+            continue
+        # The separator row right after a header.
+        if in_table and re.match(r"^\|\s*[-:]+", line):
+            continue
+        # Non-table line → table ended.
+        if in_table and not line.startswith("|"):
+            in_table = False
+            continue
+        # Table body row.
+        if in_table and line.startswith("|"):
+            cells = [c.strip() for c in line.strip().strip("|").split("|")]
+            if len(cells) < len(CLUSTERS) + 1:
+                continue
+            bp = cells[0].strip().strip("`")
+            if not bp or bp.startswith("Blueprint"):
+                continue
+            # Strip backticks the audit uses on blueprint names like `bp-grafana`.
+            bp = bp.strip("`")
+            # Map cluster cells.
+            cluster_cells = cells[1:7]
+            roles: dict[str, str] = {}
+            for cluster, cell in zip(CLUSTERS, cluster_cells):
+                role = parse_role_cell(cell)
+                if role is not None:
+                    roles[cluster] = role
+            # Skip rows where every cluster cell is blank.
+            if not roles:
+                continue
+            # Free-text columns come after the 6 cluster cells.
+            state_pres_col = cells[8] if len(cells) > 8 else ""
+            switchover_col = cells[9] if len(cells) > 9 else ""
+            rows.append({
+                "blueprint": bp,
+                "roles": roles,
+                "state_preservation": state_pres_col,
+                "switchover": switchover_col,
+            })
+    return rows
+
+
+def derive_topology(row: dict[str, Any]) -> dict[str, Any]:
+    """Given a parsed audit row, return the spec.topology block."""
+    roles = row["roles"]
+    role_set = set(roles.values())
+    placement = {
+        "clusters": list(roles.keys()),
+        "roles": dict(roles),
+    }
+    # Derive tier from majority cluster prefix.
+    tiers = {c.split("-")[0] for c in roles}
+    if len(tiers) == 1:
+        placement["tier"] = tiers.pop()
+
+    # Topology pattern selection:
+    if role_set == {"singleton"}:
+        # Independent-per-cluster (bp-cilium, bp-flux, …)
+        bcp = "singleton"
+        topology = {
+            "supported": ["singleton"],
+            "defaults": {"multi-region": "singleton", "single-region": "singleton"},
+            "perTopology": {
+                "singleton": {"placement": placement}
+            }
+        }
+    elif role_set == {"active"}:
+        # All-active across multiple clusters → active-active
+        bcp = "active-active"
+        topology = {
+            "supported": ["active-active", "singleton"],
+            "defaults": {"multi-region": "active-active", "single-region": "singleton"},
+            "perTopology": {
+                "active-active": {
+                    "replication": infer_replication(row["state_preservation"]),
+                    "switchover": infer_switchover(row["switchover"]),
+                    "placement": placement,
+                },
+                "singleton": {
+                    "placement": {
+                        "tier": placement.get("tier", ""),
+                        "clusters": [list(roles.keys())[0]],
+                        "roles": {list(roles.keys())[0]: "singleton"},
+                    }
+                }
+            }
+        }
+    elif {"active", "passive"} <= role_set:
+        # active + passive → active-hot-standby (default)
+        repl = infer_replication(row["state_preservation"])
+        # active-hot-standby requires sync mode per schema; if upstream is async,
+        # downgrade the topology to active-passive instead.
+        if repl.get("mode") == "sync":
+            bcp = "active-hot-standby"
+            topology = {
+                "supported": ["active-hot-standby", "active-passive", "singleton"],
+                "defaults": {"multi-region": "active-hot-standby", "single-region": "singleton"},
+                "perTopology": {
+                    "active-hot-standby": {
+                        "replication": repl,
+                        "switchover": infer_switchover(row["switchover"]),
+                        "placement": placement,
+                    },
+                    "singleton": {
+                        "placement": {
+                            "tier": placement.get("tier", ""),
+                            "clusters": [list(roles.keys())[0]],
+                            "roles": {list(roles.keys())[0]: "singleton"},
+                        }
+                    }
+                }
+            }
+        else:
+            bcp = "active-passive"
+            topology = {
+                "supported": ["active-passive", "singleton"],
+                "defaults": {"multi-region": "active-passive", "single-region": "singleton"},
+                "perTopology": {
+                    "active-passive": {
+                        "replication": repl,
+                        "switchover": infer_switchover(row["switchover"]),
+                        "placement": placement,
+                    },
+                    "singleton": {
+                        "placement": {
+                            "tier": placement.get("tier", ""),
+                            "clusters": [list(roles.keys())[0]],
+                            "roles": {list(roles.keys())[0]: "singleton"},
+                        }
+                    }
+                }
+            }
+    elif role_set == {"active"} or "active" in role_set:
+        # Active on a single cluster only (one-shot Job pattern)
+        bcp = "singleton"
+        topology = {
+            "supported": ["singleton"],
+            "defaults": {"multi-region": "singleton", "single-region": "singleton"},
+            "perTopology": {
+                "singleton": {"placement": placement}
+            }
+        }
+    else:
+        bcp = "singleton"
+        topology = {
+            "supported": ["singleton"],
+            "defaults": {"multi-region": "singleton", "single-region": "singleton"},
+            "perTopology": {
+                "singleton": {"placement": placement}
+            }
+        }
+
+    return topology
+
+
+def emit_stub(row: dict[str, Any], output_dir: Path) -> Path:
+    bp = row["blueprint"]
+    topo = derive_topology(row)
+    stub = {
+        "apiVersion": "catalyst.openova.io/v1",
+        "kind": "Blueprint",
+        "metadata": {"name": bp.lstrip("bp-")},
+        "spec": {"topology": topo},
+    }
+    out = output_dir / f"{bp}.yaml"
+    out.write_text(
+        textwrap.dedent(f"""\
+        # G117.1 migration stub — derived by tools/migrate-blueprints-topology.py
+        # from docs/sessions/2026-06-02-per-blueprint-topology-audit.md.
+        #
+        # Wave-1 G117.1 author: review the inferred replication/switchover
+        # values (the audit text → enum mapping is heuristic), then fold the
+        # spec.topology block into platform/{bp.lstrip("bp-")}/blueprint.yaml.
+        """) + yaml.safe_dump(stub, sort_keys=False)
+    )
+    return out
+
+
+def validate_stub(stub_path: Path, schema: dict[str, Any]) -> tuple[bool, str]:
+    try:
+        import jsonschema
+    except ImportError:
+        return True, "(jsonschema not installed; skipped)"
+    try:
+        doc = yaml.safe_load(stub_path.read_text())
+        jsonschema.validate(doc, schema)
+        return True, ""
+    except Exception as e:
+        return False, str(e).splitlines()[0]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--output-dir", required=True, type=Path, help="output directory for the per-Blueprint stubs")
+    ap.add_argument("--validate", action="store_true", help="also validate each stub against the JSON schema")
+    ap.add_argument("--audit", type=Path, default=AUDIT_DOC, help=f"audit doc path (default: {AUDIT_DOC.relative_to(REPO_ROOT)})")
+    args = ap.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    rows = parse_audit_tables(args.audit)
+    if not rows:
+        sys.exit("no rows parsed from audit doc; check the table headers/format")
+
+    schema: dict[str, Any] = {}
+    if args.validate and SCHEMA_PATH.exists():
+        schema = json.loads(SCHEMA_PATH.read_text())
+
+    failed: list[str] = []
+    for row in rows:
+        path = emit_stub(row, args.output_dir)
+        if args.validate and schema:
+            ok, err = validate_stub(path, schema)
+            if not ok:
+                failed.append(f"{row['blueprint']}: {err}")
+
+    print(f"emitted {len(rows)} stubs to {args.output_dir}")
+    if failed:
+        print("\nVALIDATION FAILURES:", file=sys.stderr)
+        for f in failed:
+            print(f"  {f}", file=sys.stderr)
+        return 1
+    if args.validate:
+        print(f"all {len(rows)} stubs validate against the schema")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Refs #2738 · Refs EPIC #2737

Wave-0 pre-flight for the **G117 EPIC** (Application Lifecycle Phase 2). Produces seven (+three executable) artifacts so the six Wave-1 sub-EPIC agents can run in parallel without colliding.

## What's in this PR

### Deliverable 1 — Standardized agent briefing template
- `.claude/templates/G117-agent-brief.md` — substitutable brief with `{{var}}` slots for sub-EPIC ID, acceptance DoD, worktree isolation, dependencies, Playwright spec name. Folds in memory + ADR discipline (Deliverable 5), resource budgets (Deliverable 6), and escalation/rollback protocol (Deliverable 7).

### Deliverable 2 — Inter-agent contract artifacts
- **2a** Go types — `core/pkg/apis/blueprint/v1alpha1/topology_types.go` (canonical, self-contained `go.mod`) + mirror at `core/controllers/pkg/apis/blueprint/v1alpha1/topology_types.go` (controllers-importable). `Topology`, `TopologyDefaults`, `TopologyVariant`, `EndpointSpec`, `SSOSpec`, `MultiInstanceSpec`, plus `BcpTopology` enum constants matching the locked architectural decision.
- **2b** JSON schema — `platform/_schemas/blueprint-topology.json` (draft-07) with `oneOf` per BCP variant, RFC-1123 hostname constraint on endpoints, controlled enums for replication backend + switchover mechanism.
- **2c** Exemplar — `examples/blueprint-grafana-fully-declared.yaml`. Validates clean against 2b.
- **2d** OpenAPI 3.1 — `docs/api/catalyst-api-openapi.yaml` for every endpoint G117.2-G117.4 needs (`GET /catalog/{bp}`, `GET /catalog/{bp}/instances`, `POST /apps/instances`, `GET /apps/{id}`, `GET /apps/{id}/endpoints` + POST/PATCH/DELETE per endpoint, `GET /apps/{id}/launch-url`). Spectral lint → 0 errors.
- **2e** UI route scaffolds — `products/catalyst/console/src/routes/catalog/[name]/+page.svelte` + `.../new/+page.svelte` + `apps/[id]/+page.svelte` + `apps/[id]/endpoints/+page.svelte`, with mock fixtures at `products/catalyst/console/tests/e2e/fixtures/mock-blueprints.yaml`. SvelteKit-style files; the project is currently Astro + Svelte 5 — see `routes/README.md` for the bridge plan.
- **2f** ADR — `docs/adr/0009-per-org-iac-repo-bootstrap.md` + executable `tools/bootstrap-org-iac-repo.sh` (idempotent bash, takes `--org` + `--sov-fqdn`, GITEA_TOKEN from env).
- **2g** Migration tool — `tools/migrate-blueprints-topology.py` parses `docs/sessions/2026-06-02-per-blueprint-topology-audit.md` and emits one validated `spec.topology` stub per Blueprint (82 emitted; all 82 validate against the schema in `--validate` mode).

### Deliverable 3 — Worktree isolation policy
- `.claude/templates/G117-worktree-policy.md` with per-Wave-1 + per-Wave-2 file-touch matrix, isolation flags (`worktree` for B2/B3/B4 sharing `console/`, B5 sharing KC realm-config templates; `none` for B1/B6 which are disjoint), pre-flight + branch naming conventions, anti-collision pre-commit hook.

### Deliverable 4 — CI pipeline patches
- `.github/workflows/playwright-e2e.yml` — boots console with `MOCK_API=1`, runs scaffold smoke; Wave-1 specs fold in incrementally
- `.github/workflows/helm-lint.yml` — schema-validates exemplar + runs migration tool with `--validate`; helm-lints each changed chart
- `.github/workflows/blueprint-admission-validate.yml` — validates every `platform/*/blueprint.yaml` against the JSON schema. **Phase 1** (`FAIL_ON_INVALID=false`) so existing 74 manifests stay green; Wave-2 closing PR flips the env var to `true`.

### Deliverables 5, 6, 7 — folded into the brief template
- **5** Memory + ADR discipline section (line 186 of `G117-agent-brief.md`): mandatory read of `MEMORY.md` + grep for sub-EPIC keywords + ship `feedback_<topic>.md` in same PR for new gotchas + new ADRs for new arch choices + update `docs/ledger/TRACKER.md`
- **6** Resource budgets section (line 177): GitHub API 200 req/dispatch, GHCR push via `flock`, hw86 catalyst-api 10 parallel calls, Playwright sequential, 1.5 GiB RSS per agent
- **7** Escalation table (line 194): >30min stuck → verifier sub-agent → `chepherd.alert_human` only after verifier confirms; revert allowed for contract breakage; STOP downstream agents on cross-wave breach; rate-limit → `/home/openova/bin/anthropic-rate-limit-trip.sh`

## Self-verification (all PASS locally)

| Check | Result |
|---|---|
| `cd core/controllers && go build ./...` | exit 0 |
| `cd core/pkg/apis/blueprint/v1alpha1 && go build ./...` | exit 0 |
| `spectral lint docs/api/catalyst-api-openapi.yaml --ruleset spectral:oas` | 0 errors, 0 warnings |
| `python3 tools/migrate-blueprints-topology.py --output-dir /tmp/stubs --validate` | 82/82 stubs validate |
| Exemplar against schema | OK |
| `bash -n tools/bootstrap-org-iac-repo.sh` | OK |
| Schema-validate existing 74 `platform/*/blueprint.yaml` | 0 failures (topology optional in Phase-1) |

## Next step (post-merge)

1. File the six G117.1–G117.6 sub-EPIC issues using the brief template (this PR's body's checklist below tracks).
2. Post final close-out comment on #2738 with PR URL + 7+ artifact links + verifier verdict.

## Sub-EPICs to file (to be filed after PR opens; will be linked here)

- [ ] G117.1 — Blueprint schema extension
- [ ] G117.2 — Catalog redesign + multi-instance
- [ ] G117.3 — Endpoints/Ingress tab + Git-IaC PR pipeline
- [ ] G117.4 — Launch button + silent SSO
- [ ] G117.5 — SSO fan-out 3 tiers + per-Org realm
- [ ] G117.6 — application-controller multi-instance + topology + per-Org realm