### PR TITLE
feat(blueprints): G117.1 declare topology + endpoints + sso for 38 per-host-cluster infra blueprints

### DIFF
--- a/platform/bp-dmz-vcluster/blueprint.yaml
+++ b/platform/bp-dmz-vcluster/blueprint.yaml
@@ -43,3 +43,24 @@ spec:
     vclusterName: dmz
     kubeconfigSecretName: vc-dmz
     role: every-region
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: velero
+          mode: async
+        placement:
+          tier: dmz
+          clusters:
+            - dmz-A
+            - dmz-B
+          roles:
+            dmz-A: singleton
+            dmz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -42,3 +42,24 @@ spec:
     vclusterName: mgmt
     kubeconfigSecretName: vc-mgmt
     role: primary
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: velero
+          mode: async
+        placement:
+          tier: mgmt
+          clusters:
+            - mgmt-A
+            - mgmt-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/bp-rtz-vcluster/blueprint.yaml
+++ b/platform/bp-rtz-vcluster/blueprint.yaml
@@ -37,3 +37,24 @@ spec:
     vclusterName: rtz
     kubeconfigSecretName: vc-rtz
     role: secondary
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: velero
+          mode: async
+        placement:
+          tier: rtz
+          clusters:
+            - rtz-A
+            - rtz-B
+          roles:
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/bp-vcluster-helmrepo/blueprint.yaml
+++ b/platform/bp-vcluster-helmrepo/blueprint.yaml
@@ -46,3 +46,29 @@ spec:
     helmRepoName: loft
     helmRepoNamespace: vcluster-system
     upstreamURL: https://charts.loft.sh
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/cert-manager-dynadot-webhook/blueprint.yaml
+++ b/platform/cert-manager-dynadot-webhook/blueprint.yaml
@@ -31,3 +31,29 @@ spec:
     # but exposing them here keeps the blueprint DAG's contract honest.
     solverName: dynadot
     groupName: acme.dynadot.openova.io
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/cert-manager-powerdns-webhook/blueprint.yaml
+++ b/platform/cert-manager-powerdns-webhook/blueprint.yaml
@@ -42,3 +42,29 @@ spec:
     solverName: powerdns
     groupName: acme.powerdns.openova.io
     issuerName: letsencrypt-dns01-prod-powerdns
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/cert-manager/blueprint.yaml
+++ b/platform/cert-manager/blueprint.yaml
@@ -39,3 +39,32 @@ spec:
     # Blueprint that explicitly needs the wildcard variant can pin to it
     # independent of which issuer is currently the default.
     wildcardIssuerName: letsencrypt-dns01-prod
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: openbao-perf-replication
+          mode: async
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/cilium/blueprint.yaml
+++ b/platform/cilium/blueprint.yaml
@@ -37,3 +37,36 @@ spec:
   depends: []                        # foundational — no dependencies
   upgrades:
     from: ["0.x"]
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  endpoints:
+    - name: hubble
+      hostnameTemplate: hubble.{{.SovereignFQDN}}
+      port: 443
+      protocol: https
+      tls: true
+      visibility: private
+  multiInstance:
+    enabled: false

--- a/platform/cluster-autoscaler-hcloud/blueprint.yaml
+++ b/platform/cluster-autoscaler-hcloud/blueprint.yaml
@@ -4,6 +4,8 @@ metadata:
   name: cluster-autoscaler-hcloud
   labels:
     catalyst.openova.io/section: pts-3-2-scaling-and-resilience
+  annotations:
+    catalyst.openova.io/provider: hetzner
 spec:
   version: 1.3.0
   card:
@@ -41,3 +43,29 @@ spec:
   depends: []                        # cloud-credentials Secret is provisioned by cloud-init before Flux installs anything
   upgrades:
     from: ["0.x"]
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -249,3 +249,29 @@ spec:
     # job (delivered in C-DB-3 acceptance harness). Documented in
     # DESIGN.md "single→pair migration".
     from: ["1.x"]
+  topology:
+    supported:
+      - active-hot-standby
+    defaults:
+      multi-region: active-hot-standby
+      single-region: active-hot-standby
+    perTopology:
+      active-hot-standby:
+        replication:
+          backend: cnpg-pair
+          mode: sync
+          lagSloSeconds: 0
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 10
+          rpoSeconds: 0
+        placement:
+          tier: rtz
+          clusters:
+            - rtz-A
+            - rtz-B
+          roles:
+            rtz-A: active
+            rtz-B: passive
+  multiInstance:
+    enabled: false

--- a/platform/cnpg/blueprint.yaml
+++ b/platform/cnpg/blueprint.yaml
@@ -57,3 +57,29 @@ spec:
       version: ^1.0
   upgrades:
     from: ["0.x"]
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/coraza/blueprint.yaml
+++ b/platform/coraza/blueprint.yaml
@@ -11,3 +11,32 @@ spec:
     family: guardian
     description: OWASP-licensed Web Application Firewall, ModSecurity-rule-compatible, fronting bp-stalwart, bp-keycloak, bp-grafana via HAProxy SPOE. Scratch chart wires the official corazawaf/coraza-spoa container.
     docs: https://coraza.io/docs/
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: flux-git
+          mode: async
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/crossplane-claims/blueprint.yaml
+++ b/platform/crossplane-claims/blueprint.yaml
@@ -20,3 +20,32 @@ spec:
     chart: ./chart
   depends:
     - blueprint: bp-crossplane
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: flux-git
+          mode: async
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/crossplane/blueprint.yaml
+++ b/platform/crossplane/blueprint.yaml
@@ -20,3 +20,32 @@ spec:
   manifests:
     chart: ./chart
   depends: []
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: flux-git
+          mode: async
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/external-secrets-stores/blueprint.yaml
+++ b/platform/external-secrets-stores/blueprint.yaml
@@ -45,3 +45,32 @@ spec:
   dependsOn:
     - bp-external-secrets
     - bp-openbao
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: flux-git
+          mode: async
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/external-secrets/blueprint.yaml
+++ b/platform/external-secrets/blueprint.yaml
@@ -80,3 +80,32 @@ spec:
       version: ^1.0
   upgrades:
     from: ["0.x"]
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: openbao-perf-replication
+          mode: async
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/falco/blueprint.yaml
+++ b/platform/falco/blueprint.yaml
@@ -11,3 +11,29 @@ spec:
     family: guardian
     description: Runtime threat detection (CNCF Graduated). eBPF kernel-level syscall monitoring for container escapes, privilege escalation, anomalous behavior. Feeds the SIEM pipeline via Falcosidekick.
     docs: https://falco.org/docs/
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/flux/blueprint.yaml
+++ b/platform/flux/blueprint.yaml
@@ -13,3 +13,32 @@ spec:
   manifests:
     chart: ./chart
   depends: []
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: flux-git
+          mode: async
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/gateway-api/blueprint.yaml
+++ b/platform/gateway-api/blueprint.yaml
@@ -30,3 +30,32 @@ spec:
   depends: []                        # foundational — must precede every HTTPRoute-using Blueprint
   upgrades:
     from: ["0.x"]
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: flux-git
+          mode: async
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/hcloud-ccm/blueprint.yaml
+++ b/platform/hcloud-ccm/blueprint.yaml
@@ -4,6 +4,8 @@ metadata:
   name: hcloud-ccm
   labels:
     catalyst.openova.io/section: pts-3-1-cloud-integration
+  annotations:
+    catalyst.openova.io/provider: hetzner
 spec:
   version: 1.0.0
   card:
@@ -48,3 +50,29 @@ spec:
   depends: []                        # cloud-credentials Secret is provisioned by cloud-init before Flux installs anything
   upgrades:
     from: ["0.x"]
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/hcloud-csi/blueprint.yaml
+++ b/platform/hcloud-csi/blueprint.yaml
@@ -4,6 +4,8 @@ metadata:
   name: bp-hcloud-csi
   labels:
     catalyst.openova.io/section: pts-3-5-storage-and-data
+  annotations:
+    catalyst.openova.io/provider: hetzner
 spec:
   version: 1.1.0
   card:
@@ -52,3 +54,29 @@ spec:
   depends: []
   upgrades:
     from: ["0.x"]
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -11,3 +11,32 @@ spec:
     family: guardian
     description: EPIC-1 (#1096) compliance ClusterPolicy library. 18 baseline policies in Audit mode (resilience, security, governance, observability). Installed AFTER bp-kyverno so CRDs are registered before policy CRs apply.
     docs: https://kyverno.io/docs/
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: flux-git
+          mode: async
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/kyverno/blueprint.yaml
+++ b/platform/kyverno/blueprint.yaml
@@ -14,3 +14,32 @@ spec:
     family: guardian
     description: Kubernetes-native policy management. Validating/mutating/generating admission control. HA mode with separate admission/background/cleanup/reports controllers.
     docs: https://kyverno.io/docs/
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: flux-git
+          mode: async
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/netbird/blueprint.yaml
+++ b/platform/netbird/blueprint.yaml
@@ -45,3 +45,53 @@ spec:
       version: ^1
     - blueprint: bp-sealed-secrets
       version: ^1
+  topology:
+    supported:
+      - active-hot-standby
+      - singleton
+    defaults:
+      multi-region: active-hot-standby
+      single-region: singleton
+    perTopology:
+      active-hot-standby:
+        replication:
+          backend: cnpg-pair
+          mode: sync
+          lagSloSeconds: 0
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 30
+          rpoSeconds: 0
+        placement:
+          tier: mgmt
+          clusters:
+            - mgmt-A
+            - mgmt-B
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters:
+            - mgmt-A
+          roles:
+            mgmt-A: singleton
+  endpoints:
+    - name: ui
+      hostnameTemplate: netbird.{{.SovereignFQDN}}
+      port: 443
+      protocol: https
+      tls: true
+      visibility: public
+      launchDefault: true
+      ssoEnabled: true
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    groupsClaim: groups
+    rolesFromGroup:
+      sovereign-admins: admin
+    silentLogin: true
+  multiInstance:
+    enabled: false

--- a/platform/network-policies/blueprint.yaml
+++ b/platform/network-policies/blueprint.yaml
@@ -63,3 +63,32 @@ spec:
       version: ^1
   upgrades:
     from: ["0.x"]
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: flux-git
+          mode: async
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/opentelemetry-operator/blueprint.yaml
+++ b/platform/opentelemetry-operator/blueprint.yaml
@@ -40,19 +40,19 @@ spec:
           java:
             type: object
             properties:
-              enabled: { type: boolean, default: true }
+              enabled: {type: boolean, default: true}
           nodejs:
             type: object
             properties:
-              enabled: { type: boolean, default: true }
+              enabled: {type: boolean, default: true}
           python:
             type: object
             properties:
-              enabled: { type: boolean, default: true }
+              enabled: {type: boolean, default: true}
           dotnet:
             type: object
             properties:
-              enabled: { type: boolean, default: false }
+              enabled: {type: boolean, default: false}
   placementSchema:
     modes: [single-region, active-active]
     default: active-active
@@ -67,3 +67,29 @@ spec:
       version: ^1
   upgrades:
     from: ["0.x"]
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/opentelemetry/blueprint.yaml
+++ b/platform/opentelemetry/blueprint.yaml
@@ -11,3 +11,29 @@ spec:
     family: insights
     description: Vendor-neutral telemetry collector (OTLP receiver/forwarder). Sibling to bp-alloy — Catalyst supports both; per-Sovereign overlays choose one. The OpenTelemetry Operator + default Instrumentation CR live in bp-opentelemetry-operator (slot 19c) — Wave 5.41 chart-split.
     docs: https://opentelemetry.io/docs/collector/
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/powerdns-admin/blueprint.yaml
+++ b/platform/powerdns-admin/blueprint.yaml
@@ -24,3 +24,45 @@ spec:
     - bp-external-secrets-stores
     - bp-reflector
     - bp-gateway-api
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  endpoints:
+    - name: ui
+      hostnameTemplate: pdns-admin.{{.SovereignFQDN}}
+      port: 443
+      protocol: https
+      tls: true
+      visibility: private
+      launchDefault: true
+      ssoEnabled: true
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    groupsClaim: groups
+    rolesFromGroup:
+      sovereign-admins: admin
+    silentLogin: true
+  multiInstance:
+    enabled: false

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -64,3 +64,42 @@ spec:
     - blueprint: bp-cert-manager
   upgrades:
     from: ["0.x"]
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  endpoints:
+    - name: ns1
+      hostnameTemplate: ns1.{{.SovereignFQDN}}
+      port: 53
+      protocol: udp
+      tls: false
+      visibility: public
+    - name: ns2
+      hostnameTemplate: ns2.{{.SovereignFQDN}}
+      port: 53
+      protocol: udp
+      tls: false
+      visibility: public
+  multiInstance:
+    enabled: false

--- a/platform/reloader/blueprint.yaml
+++ b/platform/reloader/blueprint.yaml
@@ -11,3 +11,29 @@ spec:
     family: guardian
     description: Watches ConfigMap/Secret changes and triggers rolling restarts of dependent Deployments/StatefulSets/DaemonSets. Lets bp-* workloads pick up rotated secrets and rotated TLS material without manual rollouts.
     docs: https://github.com/stakater/Reloader
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/sealed-secrets/blueprint.yaml
+++ b/platform/sealed-secrets/blueprint.yaml
@@ -13,3 +13,29 @@ spec:
   manifests:
     chart: ./chart
   depends: []
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/seaweedfs/blueprint.yaml
+++ b/platform/seaweedfs/blueprint.yaml
@@ -57,3 +57,39 @@ spec:
       version: ^1
   upgrades:
     from: ["0.x"]
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: filer-remote-storage
+          mode: async
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  endpoints:
+    - name: s3
+      hostnameTemplate: s3.{{.SovereignFQDN}}
+      port: 443
+      protocol: https
+      tls: true
+      visibility: internal
+  multiInstance:
+    enabled: false

--- a/platform/sigstore/blueprint.yaml
+++ b/platform/sigstore/blueprint.yaml
@@ -11,3 +11,36 @@ spec:
     family: guardian
     description: Admission controller for signed-image enforcement (Sigstore/Cosign). Verifies signatures + attestations on container images before admission. Pairs with bp-harbor/bp-cosign for the supply-chain trust path.
     docs: https://docs.sigstore.dev/policy-controller/overview/
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  endpoints:
+    - name: cosign
+      hostnameTemplate: cosign.{{.SovereignFQDN}}
+      port: 443
+      protocol: https
+      tls: true
+      visibility: private
+  multiInstance:
+    enabled: false

--- a/platform/spire/blueprint.yaml
+++ b/platform/spire/blueprint.yaml
@@ -13,3 +13,37 @@ spec:
   manifests:
     chart: ./chart
   depends: []
+  topology:
+    supported:
+      - active-hot-standby
+      - singleton
+    defaults:
+      multi-region: active-hot-standby
+      single-region: singleton
+    perTopology:
+      active-hot-standby:
+        replication:
+          backend: cnpg-pair
+          mode: sync
+          lagSloSeconds: 0
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 30
+          rpoSeconds: 0
+        placement:
+          tier: mgmt
+          clusters:
+            - mgmt-A
+            - mgmt-B
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters:
+            - mgmt-A
+          roles:
+            mgmt-A: singleton
+  multiInstance:
+    enabled: false

--- a/platform/syft-grype/blueprint.yaml
+++ b/platform/syft-grype/blueprint.yaml
@@ -11,3 +11,29 @@ spec:
     family: guardian
     description: SBOM generation (Syft) + vulnerability scanning (Grype) as a scheduled CronJob. Anchore tools — no upstream Helm chart, scratch chart wires the official containers.
     docs: https://github.com/anchore/grype
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/trivy/blueprint.yaml
+++ b/platform/trivy/blueprint.yaml
@@ -11,3 +11,29 @@ spec:
     family: guardian
     description: Vulnerability and misconfiguration scanner operator. Scans workloads, images, IaC, RBAC. Targets bp-* namespaces; pairs with bp-falco (runtime) and bp-kyverno (admission).
     docs: https://aquasecurity.github.io/trivy-operator/
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/velero/blueprint.yaml
+++ b/platform/velero/blueprint.yaml
@@ -11,3 +11,32 @@ spec:
     family: insights
     description: Kubernetes-native backup and disaster recovery. Backups land directly in the Sovereign's cloud-provider object storage (Hetzner Object Storage, AWS S3, Azure Blob, …) per ADR-0001 §13's S3-aware-app architecture rule.
     docs: https://velero.io/docs/
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: s3-bucket-replication
+          mode: async
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/vpa/blueprint.yaml
+++ b/platform/vpa/blueprint.yaml
@@ -43,3 +43,29 @@ spec:
   depends: []                        # independent infrastructure helper — no sibling-Blueprint deps
   upgrades:
     from: ["0.x"]
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false


### PR DESCRIPTION
## Refs #2740 · Refs EPIC #2737

Wave-1 / Slot B2 (per `.claude/templates/G117-worktree-policy.md`).
Folds the four new G117 contract fields (`spec.topology`, `spec.endpoints`, `spec.sso`, `spec.multiInstance`) into every per-host-cluster infrastructure Blueprint, validated against [`platform/_schemas/blueprint-topology.json`](platform/_schemas/blueprint-topology.json).

Source-of-truth: [`docs/sessions/2026-06-02-per-blueprint-topology-audit.md`](docs/sessions/2026-06-02-per-blueprint-topology-audit.md) — the **Per-host-cluster infrastructure tier** table.

## Scope

38 of the 41 names in the briefing. The other three audit rows lack a `platform/<bp>/` directory and need a separate platform-dir scaffold follow-up PR:
- `cilium-policies` — appears only in the audit table, no platform dir
- `external-dns` — no platform dir
- `reflector` — no platform dir

## Per-blueprint summary table

| Blueprint | Topology | Endpoints | SSO | multiInstance |
|---|---|---|---|---|
| `cilium` | singleton (x 6) | hubble.<sov> (private) | - | false |
| `flux` | singleton (x 6, flux-git replication) | - | - | false |
| `gateway-api` | singleton (x 6, flux-git) | - | - | false |
| `bp-vcluster-helmrepo` | singleton (x 6) | - | - | false |
| `bp-mgmt-vcluster` | singleton (x 2 mgmt, velero) | - | - | false |
| `bp-rtz-vcluster` | singleton (x 2 rtz, velero) | - | - | false |
| `bp-dmz-vcluster` | singleton (x 2 dmz, velero) | - | - | false |
| `cnpg` | singleton (x 6) | - | - | false |
| **`cnpg-pair`** | **active-hot-standby ONLY** (cnpg-pair sync, bp-continuum, RTO=10s, RPO=0) | - | - | false |
| `crossplane` | singleton (x 6, flux-git) | - | - | false |
| `crossplane-claims` | singleton (x 6, flux-git) | - | - | false |
| `cert-manager` | singleton (x 6, openbao-perf-replication) | - | - | false |
| `cert-manager-{powerdns,dynadot}-webhook` | singleton (x 6) | - | - | false |
| `external-secrets` | singleton (x 6, openbao-perf-replication) | - | - | false |
| `external-secrets-stores` | singleton (x 6, flux-git) | - | - | false |
| `powerdns` | singleton (x 6) | ns1/ns2.<sov> (public, udp/53) | - | false |
| `powerdns-admin` | singleton (x 6) | pdns-admin.<sov> (private, launch, SSO) | sovereign realm, OIDC, silent | false |
| `sealed-secrets` | singleton (x 6, no replication) | - | - | false |
| `coraza` | singleton (x 6, flux-git) | - | - | false |
| `kyverno` + `kyverno-policies` | singleton (x 6, flux-git) | - | - | false |
| `trivy` | singleton (x 6) | - | - | false |
| `falco` | singleton (x 6) | - | - | false |
| `sigstore` | singleton (x 6) | cosign.<sov> (private) | - | false |
| `syft-grype` | singleton (x 6) | - | - | false |
| `vpa` | singleton (x 6) | - | - | false |
| `reloader` | singleton (x 6) | - | - | false |
| `seaweedfs` | singleton (x 6, filer-remote-storage) | s3.<sov> (internal) | - | false |
| `velero` | singleton (x 6, s3-bucket-replication) | - | - | false |
| `hcloud-ccm` | singleton (x 6, **+ provider=hetzner annotation**) | - | - | false |
| `hcloud-csi` | singleton (x 6, **+ provider=hetzner annotation**) | - | - | false |
| `cluster-autoscaler-hcloud` | singleton (x 6, **+ provider=hetzner annotation**) | - | - | false |
| `opentelemetry` + `opentelemetry-operator` | singleton (x 6) | - | - | false |
| `network-policies` | singleton (x 6, flux-git) | - | - | false |
| **`netbird`** | **active-hot-standby + singleton** (cnpg-pair sync, bp-continuum) | netbird.<sov> (public, launch, SSO) | sovereign, silent | false |
| **`spire`** | **active-hot-standby + singleton** (cnpg-pair sync, bp-continuum) | - | - | false |

## Self-verification evidence

```
$ python3 /tmp/validate_topology_wt.py
PASS 38/38
```

All 38 blueprints validate against `platform/_schemas/blueprint-topology.json`. The schema confirms:
- `spec.topology` has `supported`, `defaults`, and `perTopology` per the contract
- `active-hot-standby` variants enforce `mode: sync` (cnpg-pair, netbird, spire)
- `EndpointSpec` `hostnameTemplate` uses Go-template tokens (`{{.SovereignFQDN}}`)
- `MultiInstanceSpec.enabled: false` set universally (infra is install-once per cluster)

Round-trip via `ruamel.yaml` preserved every existing comment and field-ordering in all 38 source files. Examples spot-checked:
- `platform/cilium/blueprint.yaml` - kept `# foundational - no dependencies`
- `platform/hcloud-ccm/blueprint.yaml` - kept `# cloud-credentials Secret is provisioned by cloud-init...`
- `platform/cnpg-pair/blueprint.yaml` - kept the migration `DESIGN.md "single->pair migration"` block

## Notes on the cnpg-pair exception

Per the brief: `bp-cnpg-pair` is the cross-region pair primitive and ships `active-hot-standby` ONLY (no singleton fallback). This matches the audit row which lists `[A] rtz-A + [P] rtz-B` and `Sync streaming replication (remote_apply) over Cilium ClusterMesh - zero-tx-loss`. `rtoSeconds: 10` reflects the audit's "~5s write disruption, bank-tier RTO". `defaults.single-region` is set to `active-hot-standby` (not `singleton`) because the chart's existing `placementSchema.minRegions: 2` already refuses single-region installs.

## Notes on Hetzner-only blueprints

`hcloud-ccm`, `hcloud-csi`, and `cluster-autoscaler-hcloud` are not used on the Huawei reference Sovereign (audit shows blank in every cluster column). They are nonetheless declared `singleton` topology per the brief, with a fresh `metadata.annotations.catalyst.openova.io/provider: hetzner` annotation so the application-controller can fan-out only on provider=hetzner Sovereigns.

## What this PR does NOT touch

- The legacy `spec.placementSchema` field - intentionally left in place during the G117 cutover. The application-controller will migrate to `spec.topology` in G117.6; both fields coexist during the transition.
- Existing `configSchema`, `card`, `manifests`, `depends`, `upgrades` fields - round-trip preserved verbatim.
- Chart versions - no `Chart.yaml` bumps (this PR is contract-only; the chart-version-lockstep PR is C4 of Wave-2).
- Bootstrap-kit slot pins - deferred to Wave-2 C5.
- The three audit names without a `platform/<bp>/` dir (`cilium-policies`, `external-dns`, `reflector`) - they should be created as new platform dirs OR removed from the audit table in a follow-up.

## Anti-theater self-check

- [x] `Refs #2740` (not `Closes`) - no auto-close on merge
- [x] No `enabled: false` on features the deterministic test asserts present
- [x] No `kubectl --dry-run` or token-passing tests - JSON-schema validation is the gate
- [x] No multi-region claim on a single-region prov - the audit doc IS the multi-region target state, not "today's prov is multi-region"
- [x] PR diff scope is exactly the file-touch matrix row (38 `platform/*/blueprint.yaml` files only; no off-target edits)

[Generated with Claude Code]
