### PR TITLE
feat(blueprints): G117.1 declare topology + endpoints + sso for Catalyst CP blueprints

### DIFF
--- a/platform/alloy/blueprint.yaml
+++ b/platform/alloy/blueprint.yaml
@@ -4,6 +4,7 @@ metadata:
   name: alloy
   labels:
     catalyst.openova.io/section: pts-3-observability
+    catalyst.openova.io/tier: catalyst-cp
 spec:
   version: 1.0.1
   card:
@@ -11,3 +12,49 @@ spec:
     family: insights
     description: Grafana Alloy — telemetry collector (logs/metrics/traces, OTLP-native) for the LGTM observability stack.
     docs: https://grafana.com/docs/alloy/latest/
+
+  # ── G117.1: Topology declaration ────────────────────────────────────────
+  # Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md:
+  #   DaemonSet — stateless telemetry shipper running in every host cluster
+  #   in every node. Each cluster's Alloy ships to its co-located
+  #   Loki/Mimir/Tempo endpoints. No cross-cluster sync; node failure means
+  #   kubelet replaces the Pod.
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: none
+          mode: none
+        placement:
+          tier: ""
+          clusters: [mgmt-A, mgmt-B, dmz-A, dmz-B, rtz-A, rtz-B]
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+
+  # ── G117.3: Endpoints ──────────────────────────────────────────────────
+  # No external endpoints — DaemonSet ships telemetry out to in-cluster
+  # Loki/Mimir/Tempo via Service DNS.
+  endpoints: []
+
+  # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
+  # No user-facing surface; SSO not applicable but realm declared for
+  # admission-webhook completeness.
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    silentLogin: false
+
+  # ── G117.6: Multi-instance ─────────────────────────────────────────────
+  # Singleton DaemonSet per cluster.
+  multiInstance:
+    enabled: false

--- a/platform/catalyst-platform/blueprint.yaml
+++ b/platform/catalyst-platform/blueprint.yaml
@@ -1,0 +1,115 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-catalyst-platform
+  labels:
+    catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
+    catalyst.openova.io/tier: catalyst-cp
+spec:
+  # The umbrella Blueprint that brings up the Catalyst control plane:
+  # console, marketplace, admin, catalog-svc, projector, provisioning,
+  # environment-controller, blueprint-controller, billing. The chart bytes
+  # live in products/catalyst/chart/ (oci://ghcr.io/openova-io/bp-catalyst-platform).
+  # This blueprint.yaml is the catalog-side declaration that catalyst-api
+  # surfaces in the catalog UI and that the application-controller reads
+  # for placement / topology / endpoints / sso / multi-instance per G117.
+  version: 0.0.0   # placeholder — actual chart version pinned in clusters/<sov>/bootstrap-kit/13-bp-catalyst-platform.yaml
+  card:
+    title: Catalyst Platform
+    summary: |
+      Umbrella Blueprint for the Catalyst control plane. Brings up the
+      console, marketplace, admin, catalog-svc, projector, provisioning,
+      environment-controller, blueprint-controller, and billing services.
+      Once this Helm release is Ready, the Sovereign is fully self-sufficient:
+      the sovereign-admin logs into console.<sovereignFQDN> and proceeds
+      with Phase 2 day-1 setup. See docs/ARCHITECTURE.md §11 (Catalyst-on-
+      Catalyst) and bootstrap-kit slot 13.
+  visibility: unlisted              # mandatory infra, auto-installed by bootstrap-kit slot 13
+  manifests:
+    # Catalog-side reference to the published OCI chart artefact. The
+    # actual install path is via bootstrap-kit (Flux HelmRelease at slot
+    # 13), not via the application-controller's per-Org install path.
+    chart: oci://ghcr.io/openova-io/bp-catalyst-platform
+  depends:
+    - blueprint: bp-gitea
+    - blueprint: bp-gateway-api
+    - blueprint: bp-keycloak
+    - blueprint: bp-cnpg
+    - blueprint: bp-crossplane-claims
+
+  # ── G117.1: Topology declaration ────────────────────────────────────────
+  # Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md:
+  #   mgmt-A=Active, mgmt-B=Passive. CRDs in etcd + PG state replicated via
+  #   bp-cnpg-pair (etcd-backed via catalyst-api PG); deployments are
+  #   reconcilable from Git. Switchover: bp-continuum flips PowerDNS for
+  #   console.<sov> + api.<sov>; standby promotes once CNPG primary flips.
+  #   Note: audit-tool inferred async, but the catalyst-api PG runs on
+  #   bp-cnpg-pair `remote_apply` (sync) when active-hot-standby is in use;
+  #   we declare both topologies and let the application-controller pick
+  #   the variant matching Sovereign multi-region shape.
+  topology:
+    supported:
+      - active-hot-standby
+      - singleton
+    defaults:
+      multi-region: active-hot-standby
+      single-region: singleton
+    perTopology:
+      active-hot-standby:
+        replication:
+          backend: cnpg-pair
+          mode: sync
+          lagSloSeconds: 0
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 30
+          rpoSeconds: 0
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A, mgmt-B]
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A]
+          roles:
+            mgmt-A: singleton
+
+  # ── G117.3: Endpoints ──────────────────────────────────────────────────
+  # The umbrella exposes two operator-facing endpoints — the console SPA
+  # and the catalyst-api REST surface — both at the Sovereign root domain.
+  endpoints:
+    - name: console
+      hostnameTemplate: "console.{{.SovereignFQDN}}"
+      port: 443
+      protocol: https
+      tls: true
+      visibility: public
+      launchDefault: true
+      ssoEnabled: true
+    - name: api
+      hostnameTemplate: "api.{{.SovereignFQDN}}"
+      port: 443
+      protocol: https
+      tls: true
+      visibility: public
+      launchDefault: false
+      ssoEnabled: true
+
+  # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
+  # Catalyst console + API both consume sovereign-realm tokens (G113 IDR
+  # defaultProvider silent SSO chain, PR #2729-#2731).
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    groupsClaim: groups
+    rolesFromGroup:
+      sovereign-admins: admin
+    silentLogin: true
+
+  # ── G117.6: Multi-instance ─────────────────────────────────────────────
+  # Singleton per Sovereign — exactly one Catalyst control plane per Sovereign.
+  multiInstance:
+    enabled: false

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -4,6 +4,7 @@ metadata:
   name: bp-gitea
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
+    catalyst.openova.io/tier: catalyst-cp
 spec:
   version: 1.2.12
   card:
@@ -13,3 +14,65 @@ spec:
   manifests:
     chart: ./chart
   depends: []
+
+  # ── G117.1: Topology declaration ────────────────────────────────────────
+  # Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md:
+  #   mgmt-A=Active, mgmt-B=Passive. Postgres via bp-cnpg-pair sync; Git
+  #   blobs land on SeaweedFS S3 mirrored cross-region (async, ~seconds).
+  #   Switchover: bp-continuum PG demote/promote + PowerDNS flip for
+  #   gitea.<sov> (30s TTL); Git push paused ~5s.
+  topology:
+    supported:
+      - active-hot-standby
+      - singleton
+    defaults:
+      multi-region: active-hot-standby
+      single-region: singleton
+    perTopology:
+      active-hot-standby:
+        replication:
+          backend: cnpg-pair
+          mode: sync
+          lagSloSeconds: 0
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 30
+          rpoSeconds: 0
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A, mgmt-B]
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A]
+          roles:
+            mgmt-A: singleton
+
+  # ── G117.3: Endpoints ──────────────────────────────────────────────────
+  endpoints:
+    - name: ui
+      hostnameTemplate: "gitea.{{.SovereignFQDN}}"
+      port: 443
+      protocol: https
+      tls: true
+      visibility: public
+      launchDefault: true
+      ssoEnabled: true
+
+  # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    groupsClaim: groups
+    rolesFromGroup:
+      sovereign-admins: admin
+      gitea-admins: admin
+    silentLogin: true
+
+  # ── G117.6: Multi-instance ─────────────────────────────────────────────
+  # Singleton per Sovereign — one Gitea per Catalyst control plane.
+  multiInstance:
+    enabled: false

--- a/platform/grafana/blueprint.yaml
+++ b/platform/grafana/blueprint.yaml
@@ -4,6 +4,7 @@ metadata:
   name: grafana
   labels:
     catalyst.openova.io/section: pts-3-observability
+    catalyst.openova.io/tier: catalyst-cp
 spec:
   version: 1.0.4
   card:
@@ -11,3 +12,64 @@ spec:
     family: insights
     description: Visualization and dashboarding for the LGTM observability stack (Loki/Grafana/Tempo/Mimir).
     docs: https://grafana.com/docs/grafana/latest/
+
+  # ── G117.1: Topology declaration ────────────────────────────────────────
+  # Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md:
+  #   mgmt-A=Active, mgmt-B=Passive; Grafana DB on bp-cnpg-pair sync;
+  #   dashboards backed by Loki/Mimir/Tempo (S3 bucket replicated cross-region).
+  topology:
+    supported:
+      - active-hot-standby
+      - singleton
+    defaults:
+      multi-region: active-hot-standby
+      single-region: singleton
+    perTopology:
+      active-hot-standby:
+        replication:
+          backend: cnpg-pair
+          mode: sync
+          lagSloSeconds: 0
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 30
+          rpoSeconds: 0
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A, mgmt-B]
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A]
+          roles:
+            mgmt-A: singleton
+
+  # ── G117.3: Endpoints ──────────────────────────────────────────────────
+  endpoints:
+    - name: ui
+      hostnameTemplate: "grafana.{{.SovereignFQDN}}"
+      port: 443
+      protocol: https
+      tls: true
+      visibility: public
+      launchDefault: true
+      ssoEnabled: true
+
+  # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    groupsClaim: groups
+    rolesFromGroup:
+      sovereign-admins: admin
+      grafana-editors: editor
+      grafana-viewers: viewer
+    silentLogin: true
+
+  # ── G117.6: Multi-instance ─────────────────────────────────────────────
+  # CP-tier singleton-per-Sovereign: one Grafana per Sovereign.
+  multiInstance:
+    enabled: false

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     catalyst.openova.io/category: platform
+    catalyst.openova.io/tier: catalyst-cp
 spec:
   version: 0.1.31
   card:
@@ -49,3 +50,63 @@ spec:
       version: ^1
     - blueprint: bp-k8s-ws-proxy
       version: ^0
+
+  # ── G117.1: Topology declaration ────────────────────────────────────────
+  # Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md:
+  #   mgmt-A=Active, mgmt-B=Passive. PG (session + connection config) via
+  #   bp-cnpg-pair sync. Switchover: bp-continuum PG flip + DNS flip for
+  #   guac.<sov> (~30s); in-progress remote-desktop sessions drop.
+  topology:
+    supported:
+      - active-hot-standby
+      - singleton
+    defaults:
+      multi-region: active-hot-standby
+      single-region: singleton
+    perTopology:
+      active-hot-standby:
+        replication:
+          backend: cnpg-pair
+          mode: sync
+          lagSloSeconds: 0
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 30
+          rpoSeconds: 0
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A, mgmt-B]
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A]
+          roles:
+            mgmt-A: singleton
+
+  # ── G117.3: Endpoints ──────────────────────────────────────────────────
+  endpoints:
+    - name: ui
+      hostnameTemplate: "guac.{{.SovereignFQDN}}"
+      port: 443
+      protocol: https
+      tls: true
+      visibility: public
+      launchDefault: true
+      ssoEnabled: true
+
+  # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    groupsClaim: groups
+    rolesFromGroup:
+      sovereign-admins: admin
+    silentLogin: true
+
+  # ── G117.6: Multi-instance ─────────────────────────────────────────────
+  # Singleton per Sovereign per ADR-0001 §11.
+  multiInstance:
+    enabled: false

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -4,6 +4,7 @@ metadata:
   name: harbor
   labels:
     catalyst.openova.io/section: pts-3-5-storage-and-data
+    catalyst.openova.io/tier: catalyst-cp
 spec:
   version: 1.2.22
   card:
@@ -49,7 +50,7 @@ spec:
         default: false
         description: Enable OIDC SSO via Catalyst Keycloak. Default off — opt in via per-Sovereign overlay once bp-keycloak has reconciled.
   placementSchema:
-    modes: [single-region]           # one Harbor per host cluster, no cross-region replication
+    modes: [single-region]           # legacy field — superseded by spec.topology below; kept for backward compatibility with the existing application-controller path
     default: single-region
     minRegions: 1
     maxRegions: 1
@@ -67,3 +68,77 @@ spec:
     # POSIX-only writers and is not in the minimal Sovereign set.
   upgrades:
     from: ["0.x", "1.0.x"]
+
+  # ── G117.1: Topology declaration ────────────────────────────────────────
+  # Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md:
+  #   mgmt-A=Active, mgmt-B=Passive. PG via bp-cnpg-pair sync; image blobs
+  #   on cloud-native S3 (cross-region replication = provider-native bucket
+  #   replication, async). Switchover: bp-continuum PG flip + PowerDNS flip
+  #   for registry.<sov> + harbor.<sov>; blob pulls keep working through
+  #   replica bucket on standby region.
+  topology:
+    supported:
+      - active-hot-standby
+      - singleton
+    defaults:
+      multi-region: active-hot-standby
+      single-region: singleton
+    perTopology:
+      active-hot-standby:
+        replication:
+          backend: cnpg-pair
+          mode: sync
+          lagSloSeconds: 0
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 30
+          rpoSeconds: 0
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A, mgmt-B]
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A]
+          roles:
+            mgmt-A: singleton
+
+  # ── G117.3: Endpoints ──────────────────────────────────────────────────
+  # Audit row: harbor.<sov> (UI/API) + registry.<sov> (OCI pull/push).
+  endpoints:
+    - name: ui
+      hostnameTemplate: "harbor.{{.SovereignFQDN}}"
+      port: 443
+      protocol: https
+      tls: true
+      visibility: public
+      launchDefault: true
+      ssoEnabled: true
+    - name: registry
+      hostnameTemplate: "registry.{{.SovereignFQDN}}"
+      port: 443
+      protocol: https
+      tls: true
+      visibility: public
+      launchDefault: false
+      ssoEnabled: false   # OCI clients authenticate via robot accounts / OIDC token endpoint, not silent SSO
+
+  # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    groupsClaim: groups
+    rolesFromGroup:
+      sovereign-admins: admin
+      harbor-admins: admin
+      harbor-developers: developer
+      harbor-guests: guest
+    silentLogin: true
+
+  # ── G117.6: Multi-instance ─────────────────────────────────────────────
+  # Singleton per Sovereign — one Harbor per Catalyst control plane.
+  multiInstance:
+    enabled: false

--- a/platform/k8s-ws-proxy/blueprint.yaml
+++ b/platform/k8s-ws-proxy/blueprint.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
     catalyst.openova.io/category: platform
+    catalyst.openova.io/tier: catalyst-cp
 spec:
   version: 0.1.14
   card:
@@ -39,3 +40,54 @@ spec:
   depends:
     - blueprint: bp-sealed-secrets
       version: ^1
+
+  # ── G117.1: Topology declaration ────────────────────────────────────────
+  # Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md:
+  #   mgmt-A=Active, mgmt-B=Passive. Stateless WebSocket proxy — routing
+  #   comes from Kubernetes API which Catalyst-api supplies. Switchover:
+  #   bp-continuum DNS flip; new connections route to standby Pod
+  #   immediately, in-flight WS sessions drop.
+  topology:
+    supported:
+      - active-passive
+      - singleton
+    defaults:
+      multi-region: active-passive
+      single-region: singleton
+    perTopology:
+      active-passive:
+        replication:
+          backend: none
+          mode: none
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 5
+          rpoSeconds: 0
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A, mgmt-B]
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A]
+          roles:
+            mgmt-A: singleton
+
+  # ── G117.3: Endpoints ──────────────────────────────────────────────────
+  # internal-only — proxied by catalyst-api; not exposed via Gateway.
+  endpoints: []
+
+  # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
+  # No direct user-facing surface; HMAC-signed upstream auth (not OIDC).
+  # Realm declared for admission-webhook completeness.
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    silentLogin: false
+
+  # ── G117.6: Multi-instance ─────────────────────────────────────────────
+  multiInstance:
+    enabled: false

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -4,6 +4,7 @@ metadata:
   name: bp-keycloak
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
+    catalyst.openova.io/tier: catalyst-cp
 spec:
   version: 1.4.9
   card:
@@ -13,3 +14,66 @@ spec:
   manifests:
     chart: ./chart
   depends: []
+
+  # ── G117.1: Topology declaration ────────────────────────────────────────
+  # Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md:
+  #   mgmt-A=Active, mgmt-B=Passive. KC realm config + sessions in PG
+  #   replicated via bp-cnpg-pair sync (remote_apply); user sessions are
+  #   JWT (stateless on KC). Switchover: PG promote → KC pod on standby is
+  #   already running → DNS flip auth.<sov> (~30s TTL).
+  topology:
+    supported:
+      - active-hot-standby
+      - singleton
+    defaults:
+      multi-region: active-hot-standby
+      single-region: singleton
+    perTopology:
+      active-hot-standby:
+        replication:
+          backend: cnpg-pair
+          mode: sync
+          lagSloSeconds: 0
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 30
+          rpoSeconds: 0
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A, mgmt-B]
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A]
+          roles:
+            mgmt-A: singleton
+
+  # ── G117.3: Endpoints ──────────────────────────────────────────────────
+  endpoints:
+    - name: ui
+      hostnameTemplate: "auth.{{.SovereignFQDN}}"
+      port: 443
+      protocol: https
+      tls: true
+      visibility: public
+      launchDefault: true
+      ssoEnabled: false   # KC is itself the IdP, not a downstream SSO consumer
+
+  # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
+  # KC is the source of truth for the `sovereign` realm. Operators land
+  # in the admin console via direct auth, not silent SSO through itself.
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    groupsClaim: groups
+    rolesFromGroup:
+      sovereign-admins: admin
+    silentLogin: false
+
+  # ── G117.6: Multi-instance ─────────────────────────────────────────────
+  # Singleton per Sovereign — one Keycloak per Catalyst control plane.
+  multiInstance:
+    enabled: false

--- a/platform/loki/blueprint.yaml
+++ b/platform/loki/blueprint.yaml
@@ -4,6 +4,7 @@ metadata:
   name: loki
   labels:
     catalyst.openova.io/section: pts-3-observability
+    catalyst.openova.io/tier: catalyst-cp
 spec:
   version: 1.0.0
   card:
@@ -11,3 +12,58 @@ spec:
     family: insights
     description: Log aggregation backend for the LGTM observability stack. Single-binary mode for solo Sovereign; scalable mode is a values toggle.
     docs: https://grafana.com/docs/loki/latest/
+
+  # ── G117.1: Topology declaration ────────────────────────────────────────
+  # Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md:
+  #   mgmt-A=Active, mgmt-B=Passive; chunks + index on object storage
+  #   (cross-region S3 bucket replication async). Not active-hot-standby
+  #   because replication mode is async (schema constrains active-hot-standby
+  #   to sync); active-active feasible if read-only queries split, but the
+  #   audit calls out async/eventual-consistency so active-passive is the
+  #   honest default.
+  topology:
+    supported:
+      - active-passive
+      - singleton
+    defaults:
+      multi-region: active-passive
+      single-region: singleton
+    perTopology:
+      active-passive:
+        replication:
+          backend: s3-bucket-replication
+          mode: async
+          lagSloSeconds: 60
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 60
+          rpoSeconds: 60
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A, mgmt-B]
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A]
+          roles:
+            mgmt-A: singleton
+
+  # ── G117.3: Endpoints ──────────────────────────────────────────────────
+  # internal-only — queried by Grafana via in-cluster Service DNS.
+  endpoints: []
+
+  # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
+  # No direct user-facing endpoint; SSO realm still declared so Loki's
+  # multi-tenancy header (X-Scope-OrgID) maps from sovereign-realm claims.
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    groupsClaim: groups
+    silentLogin: true
+
+  # ── G117.6: Multi-instance ─────────────────────────────────────────────
+  multiInstance:
+    enabled: false

--- a/platform/mimir/blueprint.yaml
+++ b/platform/mimir/blueprint.yaml
@@ -4,6 +4,7 @@ metadata:
   name: mimir
   labels:
     catalyst.openova.io/section: pts-3-observability
+    catalyst.openova.io/tier: catalyst-cp
 spec:
   version: 1.0.5
   card:
@@ -11,3 +12,52 @@ spec:
     family: insights
     description: Horizontally scalable, highly available Prometheus-compatible metrics storage for the LGTM observability stack.
     docs: https://grafana.com/docs/mimir/latest/
+
+  # ── G117.1: Topology declaration ────────────────────────────────────────
+  # Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md:
+  #   mgmt-A=Active, mgmt-B=Passive; TSDB blocks on object storage; cross-
+  #   region S3 bucket replication async. Same shape as Loki/Tempo.
+  topology:
+    supported:
+      - active-passive
+      - singleton
+    defaults:
+      multi-region: active-passive
+      single-region: singleton
+    perTopology:
+      active-passive:
+        replication:
+          backend: s3-bucket-replication
+          mode: async
+          lagSloSeconds: 60
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 60
+          rpoSeconds: 60
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A, mgmt-B]
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A]
+          roles:
+            mgmt-A: singleton
+
+  # ── G117.3: Endpoints ──────────────────────────────────────────────────
+  # internal-only — queried by Grafana via in-cluster Service DNS.
+  endpoints: []
+
+  # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    groupsClaim: groups
+    silentLogin: true
+
+  # ── G117.6: Multi-instance ─────────────────────────────────────────────
+  multiInstance:
+    enabled: false

--- a/platform/nats-jetstream/blueprint.yaml
+++ b/platform/nats-jetstream/blueprint.yaml
@@ -4,6 +4,7 @@ metadata:
   name: bp-nats-jetstream
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
+    catalyst.openova.io/tier: catalyst-cp
 spec:
   version: 1.3.3
   card:
@@ -13,3 +14,56 @@ spec:
   manifests:
     chart: ./chart
   depends: []
+
+  # ── G117.1: Topology declaration ────────────────────────────────────────
+  # Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md:
+  #   mgmt-A=Active, mgmt-B=Passive. Within mgmt: 3-node JetStream cluster
+  #   (Raft). Cross-cluster: NATS leaf-node tunnel only — streams NOT
+  #   replicated by default. Switchover: bp-continuum leaf-node retarget +
+  #   DNS flip; in-flight messages on lost region drop unless stream.mirror
+  #   enabled.
+  topology:
+    supported:
+      - active-passive
+      - singleton
+    defaults:
+      multi-region: active-passive
+      single-region: singleton
+    perTopology:
+      active-passive:
+        replication:
+          backend: raft
+          mode: sync
+          lagSloSeconds: 0
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 30
+          rpoSeconds: 60
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A, mgmt-B]
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A]
+          roles:
+            mgmt-A: singleton
+
+  # ── G117.3: Endpoints ──────────────────────────────────────────────────
+  # internal-only — `nats://nats:4222` from in-cluster clients.
+  endpoints: []
+
+  # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
+  # NATS client auth is account/credential-based (NKEYS / JWTs), not OIDC.
+  # Realm declared for admission-webhook completeness; no silent login.
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    silentLogin: false
+
+  # ── G117.6: Multi-instance ─────────────────────────────────────────────
+  multiInstance:
+    enabled: false

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-6-llm-serving
+    catalyst.openova.io/tier: catalyst-cp
 spec:
   version: 1.4.58
   card:
@@ -272,3 +273,59 @@ spec:
   observability:
     metrics: prometheus
     logs: stdout
+
+  # ── G117.1: Topology declaration ────────────────────────────────────────
+  # Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md:
+  #   mgmt-A=Active, mgmt-B=Passive. Stateless API; config from CRDs +
+  #   values. DB persistence lives in bp-cnpg-pair (out-of-scope here).
+  #   Switchover: bp-continuum DNS flip.
+  topology:
+    supported:
+      - active-passive
+      - singleton
+    defaults:
+      multi-region: active-passive
+      single-region: singleton
+    perTopology:
+      active-passive:
+        replication:
+          backend: cnpg-pair
+          mode: sync
+          lagSloSeconds: 0
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 30
+          rpoSeconds: 0
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A, mgmt-B]
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A]
+          roles:
+            mgmt-A: singleton
+
+  # ── G117.3: Endpoints ──────────────────────────────────────────────────
+  # Per audit row: internal — exposed via Catalyst's API ingress (api.<sov>)
+  # not as a standalone external hostname.
+  endpoints: []
+
+  # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
+  # NewAPI admin UI gated by KC OIDC; customer-API uses Catalyst-issued
+  # API keys (not OIDC).
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    groupsClaim: groups
+    rolesFromGroup:
+      sovereign-admins: admin
+    silentLogin: true
+
+  # ── G117.6: Multi-instance ─────────────────────────────────────────────
+  # Singleton per Sovereign — one NewAPI instance per Sovereign control plane.
+  multiInstance:
+    enabled: false

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -4,6 +4,7 @@ metadata:
   name: bp-openbao
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
+    catalyst.openova.io/tier: catalyst-cp
 spec:
   version: 1.2.22
   card:
@@ -13,3 +14,69 @@ spec:
   manifests:
     chart: ./chart
   depends: []
+
+  # ── G117.1: Topology declaration ────────────────────────────────────────
+  # Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md:
+  #   mgmt-A=Active, mgmt-B=Passive. Within cluster: Raft consensus
+  #   (3-5 replicas). Cross-cluster: async perf-replication (OSS uses
+  #   snapshot+restore). Switchover: `bao operator raft transition-to-primary`
+  #   on the standby; KV reads continue uninterrupted on replica throughout.
+  #   Active-hot-standby disallowed by schema (requires sync mode); OpenBao
+  #   OSS perf-replication is async-only.
+  topology:
+    supported:
+      - active-passive
+      - singleton
+    defaults:
+      multi-region: active-passive
+      single-region: singleton
+    perTopology:
+      active-passive:
+        replication:
+          backend: openbao-perf-replication
+          mode: async
+          lagSloSeconds: 30
+        switchover:
+          mechanism: raft-transition
+          rtoSeconds: 60
+          rpoSeconds: 30
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A, mgmt-B]
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A]
+          roles:
+            mgmt-A: singleton
+
+  # ── G117.3: Endpoints ──────────────────────────────────────────────────
+  # Per audit: `vault.<sov>` or internal-only. Default to private (mTLS,
+  # no Coraza WAF); operator may publish via per-Sovereign overlay.
+  endpoints:
+    - name: api
+      hostnameTemplate: "vault.{{.SovereignFQDN}}"
+      port: 8200
+      protocol: https
+      tls: true
+      visibility: private
+      launchDefault: true
+      ssoEnabled: true
+
+  # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
+  # OpenBao OIDC auth method federated to sovereign realm (G91 manual
+  # recovery + G112 chart-cred persistence — see memory).
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    groupsClaim: groups
+    rolesFromGroup:
+      sovereign-admins: admin
+    silentLogin: true
+
+  # ── G117.6: Multi-instance ─────────────────────────────────────────────
+  multiInstance:
+    enabled: false

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -4,6 +4,7 @@ metadata:
   name: bp-self-sovereign-cutover
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
+    catalyst.openova.io/tier: catalyst-cp
 spec:
   version: 0.1.49
   card:
@@ -25,3 +26,42 @@ spec:
   depends:
     - blueprint: bp-gitea
     - blueprint: bp-harbor
+
+  # ── G117.1: Topology declaration ────────────────────────────────────────
+  # Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md:
+  #   mgmt-A=Active ONLY. One-shot Jobs at handover (dormant on standby
+  #   until activated). No cross-cluster sync; if mgmt-A is lost mid-cutover
+  #   the cutover must be re-run from standby once promoted.
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: none
+          mode: none
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A]
+          roles:
+            mgmt-A: singleton
+
+  # ── G117.3: Endpoints ──────────────────────────────────────────────────
+  # No external endpoint — one-shot Jobs only.
+  endpoints: []
+
+  # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
+  # Trigger flow gated through catalyst-api auth; no direct user surface
+  # on bp-self-sovereign-cutover itself.
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    silentLogin: false
+
+  # ── G117.6: Multi-instance ─────────────────────────────────────────────
+  # One-shot per Sovereign — installs exactly once, runs to completion.
+  multiInstance:
+    enabled: false

--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -4,6 +4,7 @@ metadata:
   name: bp-sso-bridge
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
+    catalyst.openova.io/tier: catalyst-cp
 spec:
   version: 0.2.1
   card:
@@ -23,3 +24,53 @@ spec:
     - bp-keycloak
     - bp-openbao
     - bp-external-secrets-stores
+
+  # ── G117.1: Topology declaration ────────────────────────────────────────
+  # Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md:
+  #   mgmt-A=Active, mgmt-B=Passive. Stateless auth bridge (G91/G112/G113
+  #   chain). Secrets via External-Secrets / openbao — no per-Pod state.
+  #   Switchover: bp-continuum DNS flip.
+  topology:
+    supported:
+      - active-passive
+      - singleton
+    defaults:
+      multi-region: active-passive
+      single-region: singleton
+    perTopology:
+      active-passive:
+        replication:
+          backend: none
+          mode: none
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 30
+          rpoSeconds: 0
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A, mgmt-B]
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A]
+          roles:
+            mgmt-A: singleton
+
+  # ── G117.3: Endpoints ──────────────────────────────────────────────────
+  # internal-only — reconciler runs cluster-wide; no exposed HTTP surface.
+  endpoints: []
+
+  # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
+  # sso-bridge IS the SSO plumbing layer; it federates other apps to the
+  # sovereign realm. It does not itself have a user-facing login.
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    silentLogin: false
+
+  # ── G117.6: Multi-instance ─────────────────────────────────────────────
+  multiInstance:
+    enabled: false

--- a/platform/tempo/blueprint.yaml
+++ b/platform/tempo/blueprint.yaml
@@ -4,6 +4,7 @@ metadata:
   name: tempo
   labels:
     catalyst.openova.io/section: pts-3-observability
+    catalyst.openova.io/tier: catalyst-cp
 spec:
   version: 1.0.0
   card:
@@ -11,3 +12,52 @@ spec:
     family: insights
     description: Distributed tracing backend for the LGTM observability stack. Single-binary mode for solo Sovereign; tempo-distributed is a values toggle.
     docs: https://grafana.com/docs/tempo/latest/
+
+  # ── G117.1: Topology declaration ────────────────────────────────────────
+  # Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md:
+  #   mgmt-A=Active, mgmt-B=Passive; traces on object storage; cross-region
+  #   S3 bucket replication async. Same shape as Loki/Mimir.
+  topology:
+    supported:
+      - active-passive
+      - singleton
+    defaults:
+      multi-region: active-passive
+      single-region: singleton
+    perTopology:
+      active-passive:
+        replication:
+          backend: s3-bucket-replication
+          mode: async
+          lagSloSeconds: 60
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 60
+          rpoSeconds: 60
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A, mgmt-B]
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters: [mgmt-A]
+          roles:
+            mgmt-A: singleton
+
+  # ── G117.3: Endpoints ──────────────────────────────────────────────────
+  # internal-only — queried by Grafana via in-cluster Service DNS.
+  endpoints: []
+
+  # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    groupsClaim: groups
+    silentLogin: true
+
+  # ── G117.6: Multi-instance ─────────────────────────────────────────────
+  multiInstance:
+    enabled: false


### PR DESCRIPTION
## Summary

Adds `spec.topology`, `spec.endpoints`, `spec.sso`, and `spec.multiInstance` to all **16 Catalyst-CP-tier Blueprint manifests** so the application-controller (G117.6) and the new admission webhook (G117.1) have machine-readable per-Blueprint multi-region placement, endpoint, and SSO contracts to switch on.

Today every install ends up as a chart-default singleton on the primary cluster because no Blueprint declares the new fields. Wave-1 G117.1 closes the data-shape side of gap **G116** so downstream Wave-1+ slots have something to consume.

Each manifest is grounded in the per-row Catalyst-CP table of [`docs/sessions/2026-06-02-per-blueprint-topology-audit.md`](../blob/feat/g117-1-topology-catalyst-cp/docs/sessions/2026-06-02-per-blueprint-topology-audit.md) and cross-checked against [`examples/blueprint-grafana-fully-declared.yaml`](../blob/feat/g117-1-topology-catalyst-cp/examples/blueprint-grafana-fully-declared.yaml).

All 16 files validate against [`platform/_schemas/blueprint-topology.json`](../blob/feat/g117-1-topology-catalyst-cp/platform/_schemas/blueprint-topology.json).

### Per-Blueprint declarations

| Blueprint | Topology supported | Default (multi / single-region) | Endpoint hosts | SSO enabled |
|---|---|---|---|---|
| catalyst-platform | active-hot-standby, singleton | active-hot-standby / singleton | `console.<sov>`, `api.<sov>` | yes (silent) |
| keycloak | active-hot-standby, singleton | active-hot-standby / singleton | `auth.<sov>` | n/a (is the IdP) |
| openbao | active-passive, singleton | active-passive / singleton | `vault.<sov>` (private) | yes (silent) |
| gitea | active-hot-standby, singleton | active-hot-standby / singleton | `gitea.<sov>` | yes (silent) |
| harbor | active-hot-standby, singleton | active-hot-standby / singleton | `harbor.<sov>`, `registry.<sov>` | yes on UI, no on registry |
| grafana | active-hot-standby, singleton | active-hot-standby / singleton | `grafana.<sov>` | yes (silent) |
| loki | active-passive, singleton | active-passive / singleton | internal-only | yes (silent) |
| mimir | active-passive, singleton | active-passive / singleton | internal-only | yes (silent) |
| tempo | active-passive, singleton | active-passive / singleton | internal-only | yes (silent) |
| alloy | singleton (all 6 clusters) | singleton / singleton | none (DaemonSet) | no |
| nats-jetstream | active-passive, singleton | active-passive / singleton | internal-only | no (NKEYS/JWT auth) |
| guacamole | active-hot-standby, singleton | active-hot-standby / singleton | `guac.<sov>` | yes (silent) |
| k8s-ws-proxy | active-passive, singleton | active-passive / singleton | internal-only | no (HMAC) |
| newapi | active-passive, singleton | active-passive / singleton | internal (via api.<sov>) | yes (silent) |
| sso-bridge | active-passive, singleton | active-passive / singleton | internal-only | no (is the SSO plumbing) |
| self-sovereign-cutover | singleton | singleton / singleton | none (one-shot Jobs) | no |

### Replication / switchover summary

- **cnpg-pair sync (active-hot-standby, RTO=30s, RPO=0)**: catalyst-platform, keycloak, gitea, harbor, grafana, guacamole
- **s3-bucket-replication async (active-passive, RTO=60s, RPO=60s)**: loki, mimir, tempo
- **openbao-perf-replication async (active-passive, raft-transition, RTO=60s, RPO=30s)**: openbao
- **raft sync within cluster (active-passive, bp-continuum, RTO=30s, RPO=60s)**: nats-jetstream
- **stateless (active-passive, bp-continuum DNS flip)**: sso-bridge, k8s-ws-proxy, newapi
- **DaemonSet singleton**: alloy
- **one-shot singleton**: self-sovereign-cutover

### What this does NOT change

- No chart bytes modified; no Helm release behavior change today
- Existing `placementSchema` legacy field kept where present (additive)
- Bootstrap-kit pins unchanged (Wave-2 lockstep)
- `platform/catalyst-platform/blueprint.yaml` is a NEW catalog-side declaration for the umbrella; chart bytes still ship from `products/catalyst/chart/`

## Test plan

- [x] All 16 files validate against `platform/_schemas/blueprint-topology.json` (jsonschema lib)
- [x] Each `defaults.{multi-region, single-region}` is a member of `supported`
- [x] Each `perTopology` key is a member of `supported`
- [x] Schema enum compliance for `placement.tier`, `placement.roles.*`, `replication.backend`, `switchover.mechanism`
- [x] No banned terms (test domains) introduced — only legitimate `catalyst.openova.io/*` API group references
- [x] No `Closes #N` in PR body (per Refs-default rule)
- [ ] `gh pr checks` → all green (blueprint-admission-validate workflow + build + helm lint + banned-terms gates)
- [ ] Independent verifier sub-agent posts `status/uat-OK` on #2740

Refs #2740