### PR TITLE
docs(g117): Wave-2 SSO fan-out — Tier-2 + Tier-3 chart audit + per-app patch plans

### DIFF
--- a/docs/sessions/2026-06-02-G117-sso-fanout-audit/00-summary.md
+++ b/docs/sessions/2026-06-02-G117-sso-fanout-audit/00-summary.md
@@ -1,0 +1,108 @@
+# G117.5 Wave-2 SSO fan-out — Tier-2 + Tier-3 chart audit summary
+
+> **Refs**: EPIC #2737 · G117.5 #2744 · G117 Wave-0 brief at `.claude/templates/G117-agent-brief.md`
+> **Memory inputs**: `feedback_g113_sso_idr_defaultprovider_fix.md` · `feedback_sso_manual_recovery_procedure.md` · `feedback_chart_credential_persistence_defense.md`
+> **Topology cross-ref**: `docs/sessions/2026-06-02-per-blueprint-topology-audit.md`
+
+## Apps audited — 13 total (4 Tier-2 + 9 Tier-3)
+
+### Tier-2 (federate to `sovereign` realm directly — single hop)
+
+| App | Chart on `main` | Audit verdict | Est. patch (LoC) |
+|---|---|---|---|
+| `bp-guacamole` | `0.1.31` | **PARTIAL** — OIDC env vars wired, SealedSecret placeholder, divergent `catalyst` realm-patch ConfigMap to remove | +32 / -93 |
+| `bp-powerdns-admin` | `0.1.0` | **GOOD** — ExternalSecret + envFrom complete, only `kc_idp_hint` query-param append needed | +4 / -1 |
+| `bp-cilium` (Hubble UI) | `1.3.6` | **SCAFFOLD-ONLY** — HTTPRoute exists, OIDC enforcement absent; needs full oauth2-proxy sidecar | +117 / -2 |
+| `bp-sigstore` | `1.0.0` | **NO UI EXISTS — DROP** (policy-controller admission webhook only) | 0 |
+
+**Tier-2 fan-out reduces to 3 active apps after sigstore drop.**
+
+### Tier-3 (federate to per-Org realm via 2-hop — per-Org realm → sovereign realm broker → catalyst-pin)
+
+| App | Chart on `main` | Audit verdict | Est. patch (LoC) |
+|---|---|---|---|
+| `bp-matrix` | `1.0.1` | **PARTIAL** — `oidc.*` values block + upstream subchart path exist; AppRegistration + ExternalSecret + 2-hop wiring missing | +75 / -5 |
+| `bp-langfuse` | `1.0.0` | **NONE** — full SSO stack to author | +80 / 0 |
+| `bp-temporal` | `1.0.1` | **PARTIAL** — JWT validation done, Web UI OIDC client missing | +95 / -15 |
+| `bp-librechat` | `1.0.0` | **GOOD** — full OPENID_* envFrom; only ExternalSecret + AppRegistration + auto-derive missing | +62 / -4 |
+| `bp-opensearch` | (no chart) | **CHART DOES NOT EXIST — DROP** | 0 (deferred under G118.1) |
+| `bp-openmeter` | `1.0.1` | **NONE** — API-only (reclassify Tier-3-API: JWT-validation only, no browser flow) | +50 / 0 |
+| `bp-litmus` | `1.0.0` | **NONE + WEAK upstream OIDC — DEFER** under G118.3 | 0 (recommended) |
+| `bp-wordpress-tenant` | `0.3.2` | **BEST IN TIER-3** — full chain via `openid-connect-generic` plugin; minimal patches needed | +67 / -3 |
+| `bp-iceberg` | (no chart) | **CHART DOES NOT EXIST — DROP** | 0 (deferred under G118.2) |
+
+**Tier-3 fan-out reduces to 6 active apps after opensearch / litmus / iceberg drops** (matrix, langfuse, temporal, librechat, openmeter, wordpress-tenant).
+
+## Rollup — SSO chart-readiness across all 13 apps
+
+| Verdict | Count | Apps |
+|---|---|---|
+| **GOOD** (most wiring present; small chart patches) | 2 | bp-powerdns-admin, bp-librechat |
+| **BEST** (canonical reference chart for tier) | 1 | bp-wordpress-tenant |
+| **PARTIAL** (50-80% wiring; medium patches) | 3 | bp-guacamole, bp-matrix, bp-temporal |
+| **SCAFFOLD-ONLY** (decorative gate, real enforcement absent) | 1 | bp-cilium (Hubble UI) |
+| **NONE** (zero OIDC chart wiring) | 2 | bp-langfuse, bp-openmeter |
+| **DROP — no UI** | 1 | bp-sigstore |
+| **DROP — chart does not exist** | 2 | bp-opensearch, bp-iceberg |
+| **DEFER — upstream weak / image rebuild needed** | 1 | bp-litmus |
+
+## Wave-2 active worklist after drops + defers
+
+**9 apps to ship SSO patches for in Wave-2:**
+
+- Tier-2: bp-guacamole, bp-powerdns-admin, bp-cilium (Hubble UI)
+- Tier-3 (browser flow): bp-matrix, bp-langfuse, bp-temporal, bp-librechat, bp-wordpress-tenant
+- Tier-3-API (token validation only): bp-openmeter
+
+## Total estimated chart-patch size — Wave-2 SSO fan-out
+
+| Tier | Apps | Lines added | Lines removed | Net |
+|---|---|---|---|---|
+| Tier-2 | 3 | ~153 | ~96 | ~+57 |
+| Tier-3 browser-flow | 5 | ~379 | ~27 | ~+352 |
+| Tier-3-API | 1 | ~50 | 0 | +50 |
+| **Total Wave-2** | **9** | **~582** | **~123** | **~+459** |
+
+## Cross-cutting Wave-2 prerequisites (out of B5 scope, but blocking)
+
+These must land in adjacent slots BEFORE Wave-2 SSO fan-out can succeed end-to-end:
+
+1. **`platform/keycloak/chart/templates/configmap-per-org-realm.yaml`** (Wave-2.C4 — owned by KC chart maintainer slot).
+   - Per-Org realm JSON template parameterized by Org slug.
+   - Identity Provider entry `sovereign-broker` pointing at `https://auth.<sov>/realms/sovereign`.
+   - Identity Provider Redirector authenticationConfig binding `defaultProvider: sovereign-broker` on per-Org realm browser flow (G113 IDR pattern from PR #2730).
+   - `clients[]` array populated by reading `sso.openova.io/app-registration: <client-id>` labeled ConfigMaps in the Org's namespace.
+
+2. **`bp-sso-bridge` reconciler extension** — watches `AppRegistration` ConfigMaps (Option B), mints KC clients in per-Org realm via admin API, writes `client_secret` to OpenBao at `sso/<realm>/<clientId>`. Owned by a separate Wave-2 sub-EPIC.
+
+3. **Sovereign realm `clients[]` extension** — for each per-Org realm, a `org-<slug>-broker` confidential client in the sovereign realm so the per-Org realm can call sovereign realm's authorize endpoint AS a client. Owned by Wave-2.C4 alongside #1.
+
+4. **catalyst-api `org` clientScope mapper enforcement** — sovereign realm already emits `org_id` claim per `configmap-sovereign-realm.yaml:254-275`. Wave-2 must ensure per-Org realm's `firstBrokerLoginFlow` validates this claim equals the realm's expected Org before linking accounts.
+
+5. **`helm.sh/resource-policy: keep` Secret pattern** for every per-app SSO Secret (per `feedback_chart_credential_persistence_defense.md`) — codified across all 5 Tier-3 browser-flow apps.
+
+## Recommended Wave-2 split (parallel-agent dispatch shape)
+
+See `wave-2-dispatch-recommendations.md` in this directory.
+
+## Anti-theater red-flags surfaced during this audit
+
+Per `feedback_six_pillars_target_state_no_workaround.md` and the G117 brief's anti-theater list:
+
+1. **`bp-cilium` Hubble UI `auth: oidc` annotation is decorative** (`hubble-ui-httproute.yaml:52`) — comment at line 27-33 admits the OIDC layer was never wired. Wave-2 MUST not perpetuate the gate-without-enforcement pattern.
+2. **`bp-guacamole` divergent realm-patch ConfigMap** targets a `catalyst` realm (`keycloak-realm-config.yaml:42`) — the G117 codified realm is `sovereign`. Two realms can't both be active; one is dead code. Wave-2 DELETES the dead template, not patch-around.
+3. **`bp-sigstore` listed in Tier-2 brief without a UI** — Wave-2 must escalate the brief mismatch back to G117 EPIC #2737 rather than fabricate a SSO target.
+4. **`bp-opensearch` / `bp-iceberg` charts don't exist** — Wave-2 must not pretend they do. Topology audit row in `2026-06-02-per-blueprint-topology-audit.md` is aspirational; STATUS.md should reflect reality.
+5. **`bp-litmus` upstream OIDC is experimental + needs custom frontend image** — Wave-2 must not ship a partial wiring that lands `OIDC_ENABLED=true` env vars on a chart whose UI doesn't have the SSO button.
+
+These match the brief's red-flag list and should appear verbatim in the verifier sub-agent's checklist.
+
+## Banned-terms compliance
+
+Per `docs/GLOSSARY.md` §Banned-terms — this audit consistently uses `Organization` / `org` / `org-<slug>` per the codified per-Org realm naming (locked decision #6). Legacy `sme-<subdomain>` naming surfaces in the `bp-wordpress-tenant` chart and is called out for harmonization in that audit doc.
+
+## Memory + ADR discipline
+
+This audit doc itself is a session artifact, not memory. Per `feedback_amnesia_antipatterns_2026_05_20.md` L8, gaps surfaced are NOT each their own TBD — they consolidate under the existing G117.5 #2744 and the recommended drops/defers map to fresh sub-EPIC numbers (G118.1, G118.2, G118.3).
+
+If Wave-2 implementation surfaces non-obvious gotchas not yet in memory, ship `feedback_<topic>.md` IN THE SAME PR per the G117 brief Memory discipline rule.

--- a/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-2/bp-cilium.md
+++ b/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-2/bp-cilium.md
@@ -1,0 +1,130 @@
+# Tier-2 SSO audit — `bp-cilium` (Hubble UI)
+
+> Federates to: `sovereign` realm (single hop) — Catalyst-CP admin UI tier.
+> Chart path: `platform/cilium/chart/`
+> Chart version on `main`: `1.3.6` (Chart.yaml:49)
+> Topology row (audit doc): per-host-cluster singleton (`hubble.<sov>` exposed only on mgmt-A by default)
+
+## Current SSO state — **SCAFFOLD-ONLY** (HTTPRoute exists, OIDC enforcement does not)
+
+Hubble UI's per-Sovereign exposure is implemented at the HTTPRoute level. The chart documents an `auth: oidc` knob but **does not actually emit any OIDC filter, secret, or env-var wiring**. Hubble UI itself is a static SPA + backend with no native OIDC client — enforcement must happen at the gateway/proxy boundary.
+
+| Surface | Status | File:line |
+|---|---|---|
+| HTTPRoute exposing Hubble UI through Cilium Gateway | PRESENT | `platform/cilium/chart/templates/hubble-ui-httproute.yaml:1-67` |
+| `catalystOverlay.hubbleUI.auth: oidc` knob | PRESENT but DECORATIVE — only emitted as an HTTPRoute annotation, no filter attached | `platform/cilium/chart/values.yaml:313` + `hubble-ui-httproute.yaml:52` |
+| Realm-patch ConfigMap / KC client registration | MISSING entirely | n/a |
+| Per-app SSO Secret | MISSING entirely | n/a |
+| OIDC enforcement filter (oauth2-proxy sidecar, Envoy ext_authz, Cilium L7 OIDC filter) | MISSING | n/a |
+| `kc_idp_hint=catalyst-pin` injection | N/A (no OIDC layer to inject into yet) | n/a |
+
+Chart comment at `hubble-ui-httproute.yaml:27-33` explicitly acknowledges the gap:
+
+> "The OIDC enforcement at the gateway boundary is NOT yet wired here — Cilium's L7 OIDC filter is the target (configured via CiliumEnvoyConfig or HTTPRoute filter once bp-keycloak ships the realm). For Phase-0 this template gives EPIC-5 the seam to extend; today the route forwards unauthenticated, so flipping the gate without the OIDC layer leaves Hubble UI publicly accessible."
+
+## Required Wave-2 patch plan
+
+### 1. OIDC enforcement strategy — oauth2-proxy sidecar (recommended)
+
+Hubble UI's upstream chart has no `oidc` block. The canonical Catalyst pattern for "wrap an OIDC-unaware backend in silent SSO" is an **oauth2-proxy sidecar** in front of the Hubble UI Service, fronted by the HTTPRoute. Alternative is a CiliumEnvoyConfig with the OIDC filter — heavier and ties Hubble's auth lifecycle to envoy proxy reload.
+
+Wave-2 SSO agent ships:
+
+- New template `platform/cilium/chart/templates/hubble-ui-oauth2-proxy-deployment.yaml` — `quay.io/oauth2-proxy/oauth2-proxy:v7.7.x` Deployment with envFrom pointing at the per-app SSO Secret.
+- New template `platform/cilium/chart/templates/hubble-ui-oauth2-proxy-service.yaml` — ClusterIP Service on `:4180`.
+- Patch `platform/cilium/chart/templates/hubble-ui-httproute.yaml` `backendRefs` from `hubble-ui:80` → `hubble-ui-oauth2-proxy:4180`.
+
+### 2. Per-app SSO Secret materialization (new template)
+
+Add `platform/cilium/chart/templates/secret-sso-hubble-credentials.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hubble-ui-sso-oidc-credentials
+  namespace: {{ .Values.catalystOverlay.hubbleUI.serviceRef.namespace }}  # kube-system
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    catalyst.openova.io/blueprint: bp-cilium
+    catalyst.openova.io/component: hubble-ui-sso
+type: Opaque
+stringData:
+  # oauth2-proxy env-var names
+  OAUTH2_PROXY_CLIENT_ID: "hubble-ui"
+  OAUTH2_PROXY_CLIENT_SECRET: {{ (lookup "v1" "Secret" "kube-system" "hubble-ui-sso-oidc-credentials").data.OAUTH2_PROXY_CLIENT_SECRET | default (randAlphaNum 32 | b64enc) | b64dec | quote }}
+  OAUTH2_PROXY_COOKIE_SECRET: {{ randAlphaNum 32 | b64enc | quote }}  # rotate-tolerant
+  OAUTH2_PROXY_OIDC_ISSUER_URL: "https://auth.{{ required "sovereign.fqdn required" .Values.sovereign.fqdn }}/realms/sovereign"
+  OAUTH2_PROXY_REDIRECT_URL: "https://hubble.{{ .Values.sovereign.fqdn }}/oauth2/callback"
+  OAUTH2_PROXY_LOGIN_URL: "https://auth.{{ .Values.sovereign.fqdn }}/realms/sovereign/protocol/openid-connect/auth?kc_idp_hint=catalyst-pin"
+```
+
+oauth2-proxy reads `OAUTH2_PROXY_LOGIN_URL` and uses it verbatim (it does NOT re-derive from discovery), so this is the kc_idp_hint injection point.
+
+### 3. Required KC client config (additions to `configmap-sovereign-realm.yaml` `clients[]` array)
+
+```jsonc
+{
+  "clientId": "hubble-ui",
+  "name": "Cilium Hubble UI (Sovereign network observability)",
+  "enabled": true,
+  "publicClient": false,
+  "secret": "<materialized-via-helper>",
+  "standardFlowEnabled": true,
+  "directAccessGrantsEnabled": false,
+  "redirectUris": ["https://hubble.{{ .Values.sovereignFQDN }}/oauth2/callback"],
+  "webOrigins": ["https://hubble.{{ .Values.sovereignFQDN }}"],
+  "defaultClientScopes": ["web-origins","acr","profile","roles","email","groups"],
+  "attributes": {"access.token.lifespan": "900"}
+}
+```
+
+### 4. `kc_idp_hint=catalyst-pin` injection point
+
+`OAUTH2_PROXY_LOGIN_URL` env in the Secret above (Step 2). oauth2-proxy 7.7+ honors a fully-formed login URL with query params.
+
+### 5. NetworkPolicy + namespace placement note
+
+Hubble UI lives in `kube-system` per `01-cilium.yaml` `targetNamespace`. The oauth2-proxy sidecar Deployment + Service + Secret must ALL land in `kube-system` to allow same-namespace ClusterIP routing without cross-namespace ReferenceGrants. Wave-2 SSO agent honors `.Values.catalystOverlay.hubbleUI.serviceRef.namespace` consistently across all 3 new templates.
+
+## 4-hop curl probe (verification)
+
+```
+HOP1: GET https://hubble.<sov-fqdn>/  (no cookie)
+      → 302 → https://hubble.<sov-fqdn>/oauth2/start?rd=%2F
+HOP2: GET HOP1 (jar)
+      → 302 → https://auth.<sov-fqdn>/realms/sovereign/protocol/openid-connect/auth?client_id=hubble-ui&kc_idp_hint=catalyst-pin&...
+HOP3: GET HOP2 (jar w/ catalyst_session)
+      → 303 → https://auth.<sov-fqdn>/realms/sovereign/broker/catalyst-pin/login?session_code=...
+HOP4: GET HOP3 (jar)
+      → 303 → https://api.<sov-fqdn>/oidc/auth?... → 302 back through KC broker callback
+HOP5: GET final redirect (jar)
+      → 302 → https://hubble.<sov-fqdn>/oauth2/callback?code=...&state=...
+HOP6: GET HOP5 (jar) → 302 → https://hubble.<sov-fqdn>/  (oauth2-proxy sets session cookie, proxies to Hubble UI)
+```
+
+Six hops because oauth2-proxy adds 2 (start + callback). All 4 OIDC hops in the middle are silent (HTTP 302/303 chain with no HTML rendered).
+
+If HOP1 returns 200 instead of 302: oauth2-proxy Deployment not Ready OR HTTPRoute still points at `hubble-ui:80` directly (Wave-2 backendRefs patch missed). If HOP6 returns 401: client_secret mismatch (chart-cred Defense pattern).
+
+## Chart-patch size estimate
+
+| File | Lines added | Lines removed |
+|---|---|---|
+| `platform/cilium/chart/templates/hubble-ui-oauth2-proxy-deployment.yaml` (new) | ~60 | 0 |
+| `platform/cilium/chart/templates/hubble-ui-oauth2-proxy-service.yaml` (new) | ~15 | 0 |
+| `platform/cilium/chart/templates/secret-sso-hubble-credentials.yaml` (new) | ~25 | 0 |
+| `platform/cilium/chart/templates/hubble-ui-httproute.yaml` | ~2 (backendRefs swap) | ~2 |
+| `platform/cilium/chart/values.yaml` | ~15 (new `catalystOverlay.hubbleUI.oauth2Proxy.{image,resources}` block + `sovereign.fqdn` ref) | 0 |
+| **Total per app** | **~117** | **~2** |
+
+LARGEST Tier-2 patch by ~3× because OIDC enforcement layer is entirely new. Chart bump: `1.3.6 → 1.4.0` (minor — additive feature, oauth2-proxy is opt-in via existing `hubbleUI.auth: oidc` gate). Lockstep: `Chart.yaml` + `blueprint.yaml` + bootstrap-kit slot pin.
+
+## Risk note — Hubble UI ON by default
+
+Today `catalystOverlay.hubbleUI.enabled: false` chart-side, but `clusters/_template/bootstrap-kit/01-cilium.yaml` flips it ON for every Sovereign. **Wave-2 PR must NOT regress: oauth2-proxy MUST gate the same enable bit so a fresh prov never exposes Hubble UI unauthenticated**. The current `auth: oidc` annotation is decorative; the SECOND a Sovereign reconciles bp-cilium 1.4.0 the proxy MUST be in front. Recommend a hollow-chart-style render-gate in `tests/`:
+
+```bash
+helm template ... --set catalystOverlay.hubbleUI.enabled=true ... | yq 'select(.kind == "HTTPRoute" and .metadata.name == "hubble-ui") | .spec.rules[].backendRefs[].name' | grep oauth2-proxy
+```

--- a/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-2/bp-guacamole.md
+++ b/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-2/bp-guacamole.md
@@ -1,0 +1,114 @@
+# Tier-2 SSO audit — `bp-guacamole`
+
+> Federates to: `sovereign` realm (single hop) — Catalyst-CP admin UI tier.
+> Chart path: `platform/guacamole/chart/`
+> Chart version on `main`: `0.1.31` (Chart.yaml:51)
+> Topology row (audit doc): mgmt-A/A, mgmt-B/P (Catalyst-CP HA pair)
+
+## Current SSO state — PARTIAL
+
+Guacamole already ships the bulk of the OIDC chart wiring. What is in place vs. what Wave-2 must extend:
+
+| Surface | Status | File:line |
+|---|---|---|
+| `oidc.*` values block (issuer / clientId / clientSecretRef / redirectURI / groupsClaim) | PRESENT | `platform/guacamole/chart/values.yaml:118-136` |
+| Deployment env vars `OPENID_*` populated from values + secretKeyRef | PRESENT | `platform/guacamole/chart/templates/guacamole-deployment.yaml:42-65` |
+| Per-app SSO Secret materialization | PARTIAL — uses **SealedSecret placeholder** (operator must `kubeseal` the value) | `platform/guacamole/chart/templates/keycloak-client-secret.yaml:25-42` |
+| Realm-patch ConfigMap (`catalyst.openova.io/keycloak-config: realm-patch`) for KC client registration | PRESENT but DIVERGENT — targets a `catalyst` realm and a separate post-deploy Job (NOT the `sovereign-realm-config` ConfigMap that Wave-1.B6/PR #2730 codified the IDR pattern in) | `platform/guacamole/chart/templates/keycloak-realm-config.yaml:24-90` |
+| `kc_idp_hint=catalyst-pin` injection on the auth URL | MISSING — `OPENID_AUTHORIZATION_ENDPOINT` lacks the query param | `platform/guacamole/chart/templates/guacamole-deployment.yaml:45-46` |
+| `helm.sh/resource-policy: keep` on per-app SSO Secret | MISSING (SealedSecret only; no kept Secret with `lookup`-or-generate) | n/a |
+| Default `oidc.issuer` derivation from `sovereign.fqdn` | MISSING — operator-supplied; empty default fails-fast via `_helpers.tpl bp-guacamole.oidcIssuer` | `platform/guacamole/chart/values.yaml:123` |
+
+## Required Wave-2 patch plan
+
+### 1. Per-app SSO Secret materialization (new template)
+
+Add `platform/guacamole/chart/templates/secret-sso-oidc-credentials.yaml` following the pattern from `platform/openbao/chart/templates/recovery-seed-bootstrap.yaml` (`lookup`-or-generate + `helm.sh/resource-policy: keep`):
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: guacamole-sso-oidc-credentials
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    catalyst.openova.io/blueprint: bp-guacamole
+    catalyst.openova.io/component: sso-credentials
+type: Opaque
+stringData:
+  client_id: {{ .Values.guacamole.oidc.clientId | quote }}
+  # lookup-or-generate pattern
+  client_secret: {{ (lookup "v1" "Secret" .Release.Namespace "guacamole-sso-oidc-credentials").data.client_secret | default (randAlphaNum 32 | b64enc) | b64dec | quote }}
+  issuer_url: "https://auth.{{ required "sovereign.fqdn required for SSO" .Values.sovereign.fqdn }}/realms/sovereign"
+```
+
+### 2. Required KC client config (additions to `platform/keycloak/chart/templates/configmap-sovereign-realm.yaml` `clients[]` array — owned by Wave-2 SSO agent, NOT touched by this audit PR)
+
+```jsonc
+{
+  "clientId": "guacamole",
+  "name": "Apache Guacamole (Sovereign admin UI)",
+  "enabled": true,
+  "publicClient": false,
+  "secret": "<materialized-via-lookup>",
+  "standardFlowEnabled": true,
+  "directAccessGrantsEnabled": false,
+  "redirectUris": ["https://guac.{{ .Values.sovereignFQDN }}/*"],
+  "webOrigins": ["https://guac.{{ .Values.sovereignFQDN }}"],
+  "defaultClientScopes": ["web-origins","acr","profile","roles","email","groups","org"],
+  "attributes": {
+    "access.token.lifespan": "900",
+    "post.logout.redirect.uris": "https://guac.{{ .Values.sovereignFQDN }}/*"
+  }
+}
+```
+
+### 3. `kc_idp_hint=catalyst-pin` injection point (chart edit)
+
+Patch `platform/guacamole/chart/templates/guacamole-deployment.yaml:45-46`:
+
+```yaml
+- name: OPENID_AUTHORIZATION_ENDPOINT
+  value: "{{ include "bp-guacamole.oidcIssuer" . }}/protocol/openid-connect/auth?kc_idp_hint=catalyst-pin"
+```
+
+> **Defense-in-depth note:** per `feedback_g113_sso_idr_defaultprovider_fix.md` the IDR `defaultProvider` config bound on the `sovereign` realm browser flow (PR #2730) makes per-app `kc_idp_hint` optional — but each app SHOULD still pass it for explicit hinting + post-cutover resilience (PINs the realm to one IdP even if the realm-import IDR config drifts).
+
+### 4. Existing realm-patch ConfigMap — DECOMMISSION
+
+`platform/guacamole/chart/templates/keycloak-realm-config.yaml` registers Guacamole against a `catalyst` realm via a separate post-deploy Job. That pattern PRECEDES the Wave-1 codification of the `sovereign` realm import in `configmap-sovereign-realm.yaml`. Wave-2 SSO agent will:
+
+1. Delete `keycloak-realm-config.yaml` (it would race with the consolidated realm-import).
+2. Move the `clientId: guacamole` registration into `configmap-sovereign-realm.yaml` `clients[]`.
+3. Update `values.yaml` `oidc.issuer` default to derive from `sovereign.fqdn` (drop the operator-supplied requirement; add `sovereign.fqdn` to the values block).
+
+## 4-hop curl probe (verification)
+
+After Wave-2 patches land + fresh-prov reconciles:
+
+```
+HOP1: GET https://guac.<sov-fqdn>/guacamole/api/ext/openid/login
+      → 302 → https://auth.<sov-fqdn>/realms/sovereign/protocol/openid-connect/auth?client_id=guacamole&kc_idp_hint=catalyst-pin&...
+HOP2: GET HOP1 (with cookie jar holding catalyst_session)
+      → 303 → https://auth.<sov-fqdn>/realms/sovereign/broker/catalyst-pin/login?session_code=...&client_id=guacamole&tab_id=...
+HOP3: GET HOP2 (with jar)
+      → 303 → https://api.<sov-fqdn>/oidc/auth?scope=openid+email+profile+groups&state=...
+HOP4: GET HOP3 (with jar)
+      → 302 → https://guac.<sov-fqdn>/guacamole/  (silent SSO success)
+```
+
+If HOP2 returns 200 (login form HTML) → IDR `defaultProvider` config did not take. Clear realm cache via `POST /admin/realms/sovereign/clear-realm-cache`. If HOP4 returns 401 → client_secret mismatch between rendered Secret and KC realm import (chart-credential-persistence Defense pattern from `feedback_chart_credential_persistence_defense.md`).
+
+## Chart-patch size estimate
+
+| File | Lines added | Lines removed |
+|---|---|---|
+| `platform/guacamole/chart/templates/secret-sso-oidc-credentials.yaml` (new) | ~25 | 0 |
+| `platform/guacamole/chart/templates/guacamole-deployment.yaml` | ~2 | ~1 |
+| `platform/guacamole/chart/values.yaml` | ~5 (add `sovereign.fqdn` block) | ~2 (drop required-operator-supplied default) |
+| `platform/guacamole/chart/templates/keycloak-realm-config.yaml` | 0 | ~90 (delete entire file) |
+| **Total per app** | **~32** | **~93** |
+
+Chart bump: `0.1.31 → 0.2.0` (breaking — realm-config file removed). Lockstep: `Chart.yaml` + `blueprint.yaml` + bootstrap-kit slot pin (per `feedback_chart_version_collision_serialize_or_rebase.md`).

--- a/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-2/bp-powerdns-admin.md
+++ b/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-2/bp-powerdns-admin.md
@@ -1,0 +1,101 @@
+# Tier-2 SSO audit — `bp-powerdns-admin`
+
+> Federates to: `sovereign` realm (single hop) — Catalyst-CP admin UI tier.
+> Chart path: `platform/powerdns-admin/chart/`
+> Chart version on `main`: `0.1.0` (Chart.yaml:3)
+> Topology row (audit doc): per-host-cluster singleton (`pdns-admin.<sov>`)
+
+## Current SSO state — **GOOD** (best Tier-2 starting position)
+
+`bp-powerdns-admin` already implements the canonical SSO chart-side wiring expected by the Wave-1.B6 Tier-1 pattern. The chart was authored under the G91.powerdns-admin (#2656) work with bp-sso-bridge integration in mind.
+
+| Surface | Status | File:line |
+|---|---|---|
+| `sso.*` values block (enabled / realm / sovereignFqdn / clientId / externalSecretStoreName / adminGroup / autoOnboard) | PRESENT | `platform/powerdns-admin/chart/values.yaml:119-139` |
+| Deployment OIDC env vars (`OIDC_OAUTH_*`) populated from envFrom | PRESENT | `platform/powerdns-admin/chart/templates/deployment.yaml:88-120` |
+| Per-app SSO Secret materialization | PRESENT via **ExternalSecret** (pulls from OpenBao at `sso/powerdns-admin`) | `platform/powerdns-admin/chart/templates/sso-oauth-source-externalsecret.yaml:12-69` |
+| Realm-client registration | MISSING from `configmap-sovereign-realm.yaml`. Chart assumes `bp-sso-bridge` writes the OpenBao bundle + provisions the KC client at runtime | n/a |
+| `kc_idp_hint=catalyst-pin` injection | MISSING — `OIDC_OAUTH_AUTHORIZE_URL` is templated from KC discovery, no query param appended | `platform/powerdns-admin/chart/templates/sso-oauth-source-externalsecret.yaml:37` |
+| Direct `lookup`-or-generate Secret + `helm.sh/resource-policy: keep` | NOT NEEDED (ExternalSecret path supersedes; OpenBao is the durable cred store) | n/a |
+| Default `sovereignFqdn` derivation | MISSING — operator-supplied; empty value disables OIDC (graceful fallback) | `platform/powerdns-admin/chart/values.yaml:132` |
+
+## Required Wave-2 patch plan
+
+### 1. Per-app SSO Secret materialization — already done (no change)
+
+The ExternalSecret at `platform/powerdns-admin/chart/templates/sso-oauth-source-externalsecret.yaml` is the canonical materialization. **Wave-2 must NOT add a parallel `lookup`-or-generate Secret** — it would race with the External-Secrets Operator's `creationPolicy: Owner`.
+
+Wave-2 still owns: the `bp-sso-bridge` reconciler must write the `sso/powerdns-admin` OpenBao path on Org boot. That work is OUT OF SCOPE for B5 and lives under separate G117.X.
+
+### 2. Required KC client config (additions to `platform/keycloak/chart/templates/configmap-sovereign-realm.yaml` `clients[]` array)
+
+```jsonc
+{
+  "clientId": "powerdns-admin",
+  "name": "PowerDNS-Admin (Sovereign DNS UI)",
+  "enabled": true,
+  "publicClient": false,
+  "secret": "<bp-sso-bridge writes to OpenBao; realm import reads same value via shared template helper>",
+  "standardFlowEnabled": true,
+  "directAccessGrantsEnabled": false,
+  "redirectUris": [
+    "https://pdns-admin.{{ .Values.sovereignFQDN }}/oidc/authorized",
+    "https://pdns-admin.{{ .Values.sovereignFQDN }}/*"
+  ],
+  "webOrigins": ["https://pdns-admin.{{ .Values.sovereignFQDN }}"],
+  "defaultClientScopes": ["web-origins","acr","profile","roles","email","groups","org"],
+  "attributes": {
+    "access.token.lifespan": "900",
+    "post.logout.redirect.uris": "https://pdns-admin.{{ .Values.sovereignFQDN }}/*"
+  }
+}
+```
+
+> The `secret` value should be derived from a shared `_helpers.tpl` named template (mirror `bp-keycloak.pinBrokerClientSecret` from PR #2730) so the realm-import value + the OpenBao-stored value never drift. Wave-2 SSO agent will introduce `bp-keycloak.appClientSecret` helper.
+
+### 3. `kc_idp_hint=catalyst-pin` injection point (chart edit)
+
+PowerDNS-Admin's `OIDC_OAUTH_AUTO_CONFIGURE=True` consumes the OIDC discovery doc for endpoints. There is no Flask-side knob to append a query param post-discovery. Two options:
+
+**Option A (preferred — chart edit):** override `OIDC_OAUTH_AUTHORIZE_URL` explicitly in the ExternalSecret template and append `?kc_idp_hint=catalyst-pin`:
+
+```yaml
+# platform/powerdns-admin/chart/templates/sso-oauth-source-externalsecret.yaml:37 (patch)
+OIDC_OAUTH_AUTHORIZE_URL: "{{ "{{ .authorize_url }}" }}?kc_idp_hint=catalyst-pin"
+```
+
+**Option B (preferred — bp-sso-bridge edit):** `bp-sso-bridge` reconciler writes `authorize_url` to OpenBao with the query param already appended. This decouples the kc_idp_hint convention from per-app chart logic but increases the SSO bridge contract surface.
+
+Recommendation: **Option A** for B5 scope (chart-local, no bridge contract change). If bp-sso-bridge gains a `kcIdpHint` field in its CRD later, Option B can supersede.
+
+### 4. `sovereign.fqdn` derivation default
+
+Patch `platform/powerdns-admin/chart/values.yaml:132` so the default derives from `Release.Namespace` env or accepts an envsubst at install time. Maintain empty-default fallback behavior (graceful local-account-only auth).
+
+## 4-hop curl probe (verification)
+
+```
+HOP1: GET https://pdns-admin.<sov-fqdn>/login
+      → 302 → https://auth.<sov-fqdn>/realms/sovereign/protocol/openid-connect/auth?client_id=powerdns-admin&kc_idp_hint=catalyst-pin&...
+HOP2: GET HOP1 (jar w/ catalyst_session)
+      → 303 → https://auth.<sov-fqdn>/realms/sovereign/broker/catalyst-pin/login?session_code=...&client_id=powerdns-admin&tab_id=...
+HOP3: GET HOP2 (jar)
+      → 303 → https://api.<sov-fqdn>/oidc/auth?scope=openid+profile+email+groups&state=...
+HOP4: GET HOP3 (jar)
+      → 302 → https://pdns-admin.<sov-fqdn>/oidc/authorized?code=...&state=...
+HOP5: GET HOP4 (jar) → 302 → https://pdns-admin.<sov-fqdn>/dashboard  (silent SSO success)
+```
+
+Note: PDA uses Authlib's OIDC flow with an explicit `/oidc/authorized` callback path (NOT the bare `/`). HOP4's callback endpoint mints the PDA Flask session cookie and 302s to the post-login landing page (`config.defaultLandingPage: dashboard`).
+
+If HOP1 → 200 (login form): `sso.enabled=false` OR ExternalSecret never materialized (verify with `kubectl -n powerdns-admin get externalsecret pda-sso-oidc-credentials` SyncedStatus). If HOP2 → 200: IDR `defaultProvider` config not bound on realm (Wave-1.B6 codification not deployed). If HOP4 → 400 invalid_grant: client_secret mismatch between OpenBao bundle and KC realm-import.
+
+## Chart-patch size estimate
+
+| File | Lines added | Lines removed |
+|---|---|---|
+| `platform/powerdns-admin/chart/templates/sso-oauth-source-externalsecret.yaml` | ~1 (append `?kc_idp_hint=catalyst-pin` to authorize_url) | ~1 |
+| `platform/powerdns-admin/chart/values.yaml` | ~3 (add default-derivation note) | 0 |
+| **Total per app** | **~4** | **~1** |
+
+Smallest chart-patch in scope. Chart bump: `0.1.0 → 0.1.1`. Lockstep: `Chart.yaml` + `blueprint.yaml` + bootstrap-kit slot pin.

--- a/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-2/bp-sigstore.md
+++ b/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-2/bp-sigstore.md
@@ -1,0 +1,50 @@
+# Tier-2 SSO audit — `bp-sigstore`
+
+> Federates to: `sovereign` realm (single hop) — Catalyst-CP admin UI tier.
+> Chart path: `platform/sigstore/chart/`
+> Chart version on `main`: `1.0.0` (Chart.yaml:15)
+> Topology row (audit doc): per-host-cluster singleton (optional `cosign.<sov>` per audit row)
+
+## Current SSO state — **NONE — UI surface DOES NOT EXIST**
+
+The G117 dispatch brief lists this as "bp-sigstore (cosign UI)" but **Sigstore Policy Controller has no UI**. The chart is exclusively a `sigstore/policy-controller` subchart wrapper — a Kubernetes admission webhook that verifies Cosign signatures, in-toto attestations, and SBOMs at admission time. There is no user-facing surface to federate.
+
+| Surface | Status | File:line |
+|---|---|---|
+| User-facing HTTP UI in the chart | **DOES NOT EXIST** | n/a |
+| HTTPRoute / Ingress | NONE | (chart has zero `templates/`; values has `sigstoreOverlay.networkPolicy: enabled=false` placeholder only — values.yaml:62-68) |
+| OIDC values block | NONE | n/a |
+| KC client registration | N/A | n/a |
+
+The `policy-controller` subchart ships only:
+- `policy-controller` Deployment (webhook + controller-manager)
+- ValidatingWebhookConfiguration
+- ClusterImagePolicy CRD
+- Service for the webhook backplane (not user-facing; only the apiserver calls it)
+
+`appVersion: "0.13.1"` (Chart.yaml:16) is the policy-controller webhook server, NOT a Cosign UI.
+
+## What the audit doc Section §Per-host-cluster row likely meant
+
+The audit doc lists `bp-sigstore` with `optional cosign.<sov>` external endpoint. This might refer to one of:
+
+1. **`fulcio-server`** — Sigstore certificate authority (issues short-lived certs for keyless signing). Not in this chart; would require new `bp-fulcio` Blueprint. Fulcio DOES have an OIDC flow but as an *issuer-side* OAuth provider (Fulcio consumes user OIDC ID-tokens to mint signing certs).
+2. **`rekor-server`** — Sigstore transparency log. Has a read-only API endpoint at `rekor.<sov>` typical pattern, but no UI and no auth (the log is intentionally public).
+3. **A speculative "Cosign UI" surface** — no such thing exists in OSS Sigstore today.
+
+## Required Wave-2 action — **DEFER / DOCUMENT AS NO-OP**
+
+`bp-sigstore` is OUT OF SCOPE for G117.5 Tier-2 SSO fan-out because there is no UI surface. Wave-2 SSO agent should:
+
+1. NOT add any SSO templates to `platform/sigstore/chart/`.
+2. NOT add a `sigstore` clientId to `configmap-sovereign-realm.yaml`.
+3. Update `docs/sessions/2026-06-02-per-blueprint-topology-audit.md` row 79 (`bp-sigstore`) to drop the `optional cosign.<sov>` external endpoint note (replace with `none`).
+4. If a Sigstore-stack UI is ever introduced (e.g. via `bp-fulcio` or `bp-rekor-ui`), open a fresh sub-EPIC under G117.5 to wire SSO at that point.
+
+## Recommendation for B5 dispatch
+
+Drop `bp-sigstore` from the Tier-2 fan-out worklist. Reduces Tier-2 from 4 apps to **3 apps** (guacamole, powerdns-admin, cilium-hubble-ui).
+
+## Chart-patch size estimate
+
+**Zero** — no chart edit. Only documentation update to `docs/sessions/2026-06-02-per-blueprint-topology-audit.md` row 79 (separate from the SSO fan-out PR).

--- a/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-iceberg.md
+++ b/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-iceberg.md
@@ -1,0 +1,45 @@
+# Tier-3 SSO audit — `bp-iceberg` (catalog REST UI)
+
+> Federates to: per-Org realm via 2-hop (per-Org realm → `sovereign` realm broker → catalyst-pin IdP).
+> Chart path: `platform/iceberg/` (**SCAFFOLD-ONLY — no chart subdir on `main`**)
+> Topology row (audit doc): rtz-A 🟢 A / rtz-B 🟢 A (App-tier active-active — all data on S3)
+
+## Current SSO state — **CHART DOES NOT EXIST**
+
+```bash
+$ ls /home/openova/repos/openova/platform/iceberg/
+README.md
+```
+
+`platform/iceberg/` is README-only. No `chart/` subdir, no `blueprint.yaml`. The audit doc row at `docs/sessions/2026-06-02-per-blueprint-topology-audit.md:126` is **aspirational** — Wave-2 SSO fan-out cannot wire SSO to a non-existent chart.
+
+Furthermore, the audit doc lists the "endpoint" as `iceberg.<org>.<sov>` (catalog REST) — Iceberg has multiple potential "UI" surfaces:
+
+1. **REST catalog API** (`iceberg-rest-fixture` upstream) — JSON HTTP API, not a UI; OIDC support is via Bearer-token validation (resource-server pattern, NOT browser OIDC client flow).
+2. **Hive Metastore-style catalog** — no UI.
+3. **Tabular.io / Apache Polaris / Lakekeeper** — third-party Iceberg catalog implementations with web UIs and full OIDC, but each is a different upstream chart.
+
+The dispatch brief calls this "catalog REST UI" which is ambiguous — REST API doesn't have a UI in the conventional sense. SSO for a REST catalog is JWT/token-validation, not browser-redirect.
+
+## Recommendation
+
+Wave-2 SSO agent should **NOT** attempt to add SSO templates to `platform/iceberg/`. Three follow-ups:
+
+1. **Document the gap** in `docs/STATUS.md` — `bp-iceberg` is design-stage, not built. Note the ambiguity about which Iceberg catalog implementation is targeted (recommend Apache Polaris for OIDC parity with the rest of Tier-3).
+2. **Open a fresh sub-EPIC** (`G118.2 — bp-iceberg chart`) to pick a catalog implementation + author the chart.
+3. **When the chart lands**:
+   - If REST-only catalog: SSO is **JWT validation only** — KC discovery URL in catalog config + Resource Server bearer-token check. NO browser OIDC client flow, NO AppRegistration ConfigMap, NO `kc_idp_hint` injection (no browser redirect). Maps to Tier-2 of a NEW classification ("API-only with JWT validation") — different audit row structure.
+   - If Apache Polaris (has UI): standard Tier-3 pattern from `bp-langfuse.md` / `bp-temporal.md`.
+
+## Estimated chart-patch size (when chart exists, Polaris case)
+
+| File | Lines added | Lines removed |
+|---|---|---|
+| `platform/iceberg/chart/templates/sso-externalsecret.yaml` (new) | ~30 | 0 |
+| `platform/iceberg/chart/templates/sso-app-registration.yaml` (new) | ~25 | 0 |
+| `platform/iceberg/chart/values.yaml` (Polaris OIDC config) | ~25 | 0 |
+| **Estimated total** | **~80** | **0** |
+
+## DROP from Wave-2 worklist
+
+Reduces Tier-3 from 9 apps to **7 apps** when combined with bp-opensearch drop (matrix, langfuse, temporal, librechat, openmeter, litmus, wordpress-tenant).

--- a/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-langfuse.md
+++ b/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-langfuse.md
@@ -1,0 +1,192 @@
+# Tier-3 SSO audit — `bp-langfuse`
+
+> Federates to: per-Org realm via 2-hop (per-Org realm → `sovereign` realm broker → catalyst-pin IdP).
+> Chart path: `platform/langfuse/chart/`
+> Chart version on `main`: `1.0.0` (Chart.yaml:37)
+> Topology row (audit doc): rtz-A 🟢 A / rtz-B 🟡 P (App-tier CP-HA pair)
+
+## Current SSO state — **NONE**
+
+The chart wires bp-cnpg / bp-valkey / bp-clickhouse / bp-seaweedfs deps but has **zero OIDC values, zero KC client wiring, zero templates referencing auth**. Langfuse upstream supports OIDC via `next-auth` provider env vars (`AUTH_KEYCLOAK_ISSUER`, `AUTH_KEYCLOAK_CLIENT_ID`, `AUTH_KEYCLOAK_CLIENT_SECRET`).
+
+| Surface | Status | File:line |
+|---|---|---|
+| `oidc.*` / `sso.*` / `auth.*` values block | MISSING | n/a |
+| upstream `langfuse.langfuse.additionalEnv[]` block exposing AUTH_* vars | MISSING | n/a (chart has no `additionalEnv` pass-through) |
+| Per-app SSO Secret materialization | MISSING | n/a |
+| Per-Org realm registration | MISSING | n/a |
+| `kc_idp_hint=catalyst-pin` injection | MISSING | n/a |
+
+## Upstream chart OIDC handle
+
+Per `langfuse/langfuse-k8s` chart 1.5.x, the way to inject env vars is via `langfuse.additionalEnv[]` or `langfuse.envFrom[]`. The upstream container reads (from langfuse 3.x source):
+
+- `AUTH_KEYCLOAK_ISSUER` — full realm URL
+- `AUTH_KEYCLOAK_CLIENT_ID` — string
+- `AUTH_KEYCLOAK_CLIENT_SECRET` — string (also accepts `_FILE` variant for mounted secret)
+- `AUTH_KEYCLOAK_REQUIRE_EMAIL_VERIFICATION` — bool
+- `AUTH_KEYCLOAK_ALLOW_ACCOUNT_LINKING` — bool
+
+next-auth Keycloak provider derives `authorization_endpoint` from issuer's `.well-known/openid-configuration`, which means `kc_idp_hint` must be injected differently — see Step 3 below.
+
+## Required Wave-2 patch plan
+
+### 1. New `oidc.*` values block
+
+Add to `platform/langfuse/chart/values.yaml` after the `langfuseOverlay:` block:
+
+```yaml
+# ─── SSO via per-Org Keycloak realm (G117.5) ───────────────────────────
+oidc:
+  enabled: false                  # default OFF until per-Org realm exists
+  realm: ""                       # operator-supplied: "org-<slug>"
+  clientId: "langfuse"
+  externalSecretStoreName: "vault-region1"
+  refreshInterval: 1h
+  # Override authorization_endpoint to force kc_idp_hint=sovereign-broker
+  # (next-auth's Keycloak provider doesn't add it natively)
+  overrideAuthorizationEndpoint: true
+```
+
+### 2. Per-app SSO Secret materialization (new template)
+
+Add `platform/langfuse/chart/templates/sso-externalsecret.yaml`:
+
+```yaml
+{{- if .Values.oidc.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: langfuse-sso-oidc-credentials
+  namespace: {{ .Release.Namespace }}
+spec:
+  refreshInterval: {{ .Values.oidc.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ .Values.oidc.externalSecretStoreName }}
+    kind: ClusterSecretStore
+  target:
+    name: langfuse-sso-oidc-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        AUTH_KEYCLOAK_ISSUER:                  "https://auth.{{ .Values.sovereign.fqdn }}/realms/{{ .Values.oidc.realm }}"
+        AUTH_KEYCLOAK_CLIENT_ID:               "{{ .Values.oidc.clientId }}"
+        AUTH_KEYCLOAK_CLIENT_SECRET:           "{{ "{{ .client_secret }}" }}"
+        AUTH_KEYCLOAK_REQUIRE_EMAIL_VERIFICATION: "true"
+        AUTH_KEYCLOAK_ALLOW_ACCOUNT_LINKING:      "true"
+        # next-auth NEXTAUTH_URL — required for callback host derivation
+        NEXTAUTH_URL: "https://langfuse.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}"
+  data:
+    - secretKey: client_secret
+      remoteRef:
+        key: sso/{{ .Values.oidc.realm }}/{{ .Values.oidc.clientId }}
+        property: client_secret
+{{- end }}
+```
+
+### 3. AppRegistration ConfigMap (new template)
+
+Add `platform/langfuse/chart/templates/sso-app-registration.yaml`:
+
+```yaml
+{{- if .Values.oidc.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bp-langfuse-sso-registration
+  namespace: {{ .Release.Namespace }}
+  labels:
+    sso.openova.io/app-registration: langfuse
+data:
+  client.json: |
+    {
+      "clientId": "{{ .Values.oidc.clientId }}",
+      "name": "Langfuse ({{ .Values.org.slug }})",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "redirectUris": ["https://langfuse.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}/api/auth/callback/keycloak"],
+      "webOrigins": ["https://langfuse.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}"],
+      "defaultClientScopes": ["web-origins","profile","email","groups"]
+    }
+  realm: "{{ .Values.oidc.realm }}"
+{{- end }}
+```
+
+### 4. `kc_idp_hint` injection — IDR `defaultProvider` on per-Org realm
+
+Because next-auth's Keycloak provider derives the authorize URL from discovery (NOT from a configurable env), the `kc_idp_hint` cannot be appended client-side. The ONLY way to silent-SSO through to the sovereign realm is to have the per-Org realm's IDR `defaultProvider=sovereign-broker` bound — same pattern as Tier-1 codification in PR #2730.
+
+This means `kc_idp_hint` per-app injection is a NO-OP for Langfuse — the redirect chain auto-delegates because the per-Org realm IDR is bound. Wave-2 SSO agent ships the IDR config in `configmap-per-org-realm.yaml` (owned by bp-keycloak chart, Wave-2.C4).
+
+### 5. Wire envFrom in upstream subchart values
+
+Extend `platform/langfuse/chart/values.yaml` `langfuse.langfuse` block:
+
+```yaml
+langfuse:
+  langfuse:
+    # ... existing ...
+    additionalEnv:
+      # Selectively pull AUTH_* + NEXTAUTH_URL from the per-app Secret
+      - name: AUTH_KEYCLOAK_ISSUER
+        valueFrom:
+          secretKeyRef: {name: langfuse-sso-oidc-credentials, key: AUTH_KEYCLOAK_ISSUER, optional: true}
+      - name: AUTH_KEYCLOAK_CLIENT_ID
+        valueFrom:
+          secretKeyRef: {name: langfuse-sso-oidc-credentials, key: AUTH_KEYCLOAK_CLIENT_ID, optional: true}
+      - name: AUTH_KEYCLOAK_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef: {name: langfuse-sso-oidc-credentials, key: AUTH_KEYCLOAK_CLIENT_SECRET, optional: true}
+      - name: NEXTAUTH_URL
+        valueFrom:
+          secretKeyRef: {name: langfuse-sso-oidc-credentials, key: NEXTAUTH_URL, optional: true}
+```
+
+Verify upstream chart 1.5.28 supports `additionalEnv` (it does per `langfuse-k8s` README — fall back to `envFrom: [{secretRef: {name: langfuse-sso-oidc-credentials}}]` if not).
+
+## 2-hop verification curl chain (8 hops)
+
+```
+HOP1: GET https://langfuse.<org>.<sov-fqdn>/auth/sign-in
+      → 302 → https://langfuse.<org>.<sov-fqdn>/api/auth/signin/keycloak
+HOP2: POST HOP1 (CSRF token via prior fetch)
+      → 302 → https://auth.<sov-fqdn>/realms/<org-realm>/protocol/openid-connect/auth?client_id=langfuse&...
+HOP3: GET HOP2 (jar w/ catalyst_session)
+      → 303 → https://auth.<sov-fqdn>/realms/<org-realm>/broker/sovereign-broker/login?session_code=...
+      (per-Org realm IDR auto-delegates because defaultProvider=sovereign-broker bound)
+HOP4-HOP7: 2-hop chain through sovereign realm → catalyst-pin → /oidc/auth → callback back to per-Org realm
+HOP8: GET final redirect (jar)
+      → 302 → https://langfuse.<org>.<sov-fqdn>/api/auth/callback/keycloak?code=...&state=...
+HOP9: → 200 → langfuse session cookie set, redirect to dashboard
+```
+
+next-auth's POST sign-in is a CSRF-protected handshake — initial probe needs `GET /api/auth/csrf` first, then `POST /api/auth/signin/keycloak` with the csrfToken in the body.
+
+## Cross-Org isolation test
+
+```bash
+# Org-A user session, hit Org-B Langfuse:
+curl -ks -b /tmp/org-a-jar -c /tmp/org-a-jar -L --max-redirs 20 \
+  "https://langfuse.org-b.<sov-fqdn>/api/auth/signin/keycloak"
+
+# Expected: chain bounces through https://auth.<sov-fqdn>/realms/org-b/...
+# Org-A's catalyst_session is bridge-valid in sovereign realm but Org-B's realm has NO session for this user
+# → KC sovereign realm session is reused (silent SSO succeeds at sovereign level)
+# → per-Org realm sees a sovereign-broker token with user attributes
+# → per-Org realm's firstBrokerLoginFlow MUST gate on org_id claim matching the realm's org
+# REQUIRED: Auto-link MUST fail if id_token's org_id != "org-b" → user lands at consent screen OR error
+```
+
+## Chart-patch size estimate
+
+| File | Lines added | Lines removed |
+|---|---|---|
+| `platform/langfuse/chart/templates/sso-externalsecret.yaml` (new) | ~30 | 0 |
+| `platform/langfuse/chart/templates/sso-app-registration.yaml` (new) | ~20 | 0 |
+| `platform/langfuse/chart/values.yaml` | ~30 (oidc.* block + additionalEnv block) | 0 |
+| **Total per app** | **~80** | **0** |
+
+Chart bump: `1.0.0 → 1.1.0` (minor — additive SSO feature). Lockstep: `Chart.yaml` + `blueprint.yaml` + bootstrap-kit slot pin.

--- a/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-librechat.md
+++ b/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-librechat.md
@@ -1,0 +1,160 @@
+# Tier-3 SSO audit — `bp-librechat`
+
+> Federates to: per-Org realm via 2-hop (per-Org realm → `sovereign` realm broker → catalyst-pin IdP).
+> Chart path: `platform/librechat/chart/`
+> Chart version on `main`: `1.0.0` (Chart.yaml:3)
+> Topology row (audit doc): rtz-A 🟢 A / rtz-B 🟢 A (App-tier active-active, stateless once Mongo wire backend = FerretDB on CNPG)
+
+## Current SSO state — **GOOD** (chart-side OIDC envFromis done; only per-Org wiring + AppRegistration missing)
+
+The chart was authored with Keycloak SSO in mind — the deployment.yaml already pipes `OPENID_*` env vars from a Secret reference. Comparable to bp-powerdns-admin starting position.
+
+| Surface | Status | File:line |
+|---|---|---|
+| `keycloak.*` values block (enabled / issuer / clientId / scope / callbackPath / buttonLabel / existingSecret / allowSocialLogin) | PRESENT | `platform/librechat/chart/values.yaml:114-129` |
+| Deployment env vars OPENID_*, populated from secretKeyRef | PRESENT | `platform/librechat/chart/templates/deployment.yaml:130-158` |
+| Per-app SSO Secret materialization | MISSING — operator-supplied `existingSecret` only; no chart-side `lookup`-or-generate; no ExternalSecret pattern | `platform/librechat/chart/values.yaml:127` |
+| Per-Org realm registration | MISSING (no AppRegistration ConfigMap) | n/a |
+| `kc_idp_hint=catalyst-pin` injection | MISSING — `OPENID_ISSUER` is the discovery base; LibreChat derives auth URL from `.well-known/openid-configuration` | `platform/librechat/chart/templates/deployment.yaml:136-137` |
+| Auto-derive `issuer` from `sovereign.fqdn` | MISSING — operator-supplied; empty default disables OIDC (graceful) | `platform/librechat/chart/values.yaml:120` |
+
+## Required Wave-2 patch plan
+
+### 1. Per-app SSO Secret materialization (new template — ExternalSecret pattern)
+
+Add `platform/librechat/chart/templates/sso-externalsecret.yaml`:
+
+```yaml
+{{- if .Values.keycloak.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: librechat-oidc
+  namespace: {{ .Release.Namespace }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-region1
+    kind: ClusterSecretStore
+  target:
+    name: librechat-oidc
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        OPENID_CLIENT_SECRET:  "{{ "{{ .client_secret }}" }}"
+        # LibreChat needs an explicit 32-byte+ session secret distinct from
+        # the OIDC client secret. Generate once + persist via bp-sso-bridge.
+        OPENID_SESSION_SECRET: "{{ "{{ .session_secret }}" }}"
+  data:
+    - secretKey: client_secret
+      remoteRef:
+        key: sso/{{ .Values.org.realm }}/librechat
+        property: client_secret
+    - secretKey: session_secret
+      remoteRef:
+        key: sso/{{ .Values.org.realm }}/librechat
+        property: session_secret
+{{- end }}
+```
+
+Patch `values.yaml:127` so `existingSecret` defaults to `librechat-oidc` (matching the ExternalSecret target). Operator override remains possible.
+
+### 2. AppRegistration ConfigMap (new template)
+
+Add `platform/librechat/chart/templates/sso-app-registration.yaml`:
+
+```yaml
+{{- if .Values.keycloak.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bp-librechat-sso-registration
+  namespace: {{ .Release.Namespace }}
+  labels:
+    sso.openova.io/app-registration: librechat
+data:
+  client.json: |
+    {
+      "clientId": "librechat",
+      "name": "LibreChat ({{ .Values.org.slug }})",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "redirectUris": ["https://chat.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}/oauth/openid/callback"],
+      "webOrigins": ["https://chat.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}"],
+      "defaultClientScopes": ["web-origins","openid","profile","email","groups"]
+    }
+  realm: "{{ .Values.org.realm }}"
+{{- end }}
+```
+
+### 3. Auto-derive `issuer` from `sovereign.fqdn` + `org.realm`
+
+Patch `platform/librechat/chart/values.yaml:118-121`:
+
+```yaml
+keycloak:
+  enabled: true
+  # Auto-derived when empty: https://auth.{{ sovereign.fqdn }}/realms/{{ org.realm }}
+  issuer: ""
+  clientId: "librechat"
+```
+
+Patch `platform/librechat/chart/templates/deployment.yaml:136-137`:
+
+```yaml
+- name: OPENID_ISSUER
+  value: "{{ .Values.keycloak.issuer | default (printf "https://auth.%s/realms/%s" .Values.sovereign.fqdn .Values.org.realm) }}"
+```
+
+### 4. `kc_idp_hint` injection
+
+Same as Langfuse / Temporal — LibreChat (openid-client npm package internally) derives authorize_url from discovery. Append `?kc_idp_hint=sovereign-broker` is non-trivial without a `customAuthorizationParams` override in LibreChat's config. Per-Org realm IDR `defaultProvider=sovereign-broker` (codified in Wave-2.C4 `configmap-per-org-realm.yaml`) is the canonical hop-2 trigger.
+
+Optional defense-in-depth: LibreChat 0.7+ supports `OPENID_REQUIRED_ROLE` env var. Wave-2 can add `OPENID_REQUIRED_ROLE: "org-{{ .Values.org.slug }}-user"` to reject any token that didn't pass through the org-realm flow (catches mis-federated tokens).
+
+## 2-hop verification curl chain (8-9 hops)
+
+```
+HOP1: GET https://chat.<org>.<sov-fqdn>/oauth/openid
+      → 302 → https://auth.<sov-fqdn>/realms/<org-realm>/protocol/openid-connect/auth?client_id=librechat&...
+HOP2: GET HOP1 (jar w/ catalyst_session)
+      → 303 → https://auth.<sov-fqdn>/realms/<org-realm>/broker/sovereign-broker/login?session_code=...
+      (per-Org realm IDR auto-delegates)
+HOP3-HOP7: 2-hop chain through sovereign realm → catalyst-pin → /oidc/auth → broker callbacks
+HOP8: GET final redirect (jar)
+      → 302 → https://chat.<org>.<sov-fqdn>/oauth/openid/callback?code=...&state=...
+HOP9: → 302 → https://chat.<org>.<sov-fqdn>/c/new  (LibreChat session cookie set, redirect to chat home)
+```
+
+## Cross-Org isolation test
+
+```bash
+curl -ksI -b /tmp/org-a-jar -L --max-redirs 20 \
+  "https://chat.org-b.<sov-fqdn>/oauth/openid"
+
+# Expected: chain bounces through https://auth.<sov-fqdn>/realms/org-b/...
+# Org-A's sovereign-realm catalyst_session is valid but Org-B realm has NO matching user
+# → per-Org realm firstBrokerLoginFlow MUST gate on org_id claim
+# REQUIRED: chain ends at consent screen OR error page when org_id != "org-b"
+```
+
+LibreChat additionally honors `OPENID_REQUIRED_ROLE` — if set to `org-{slug}-user`, an org-a-issued token (without org-b-user role) will be rejected at callback even if signature validates.
+
+## Chart-patch size estimate
+
+| File | Lines added | Lines removed |
+|---|---|---|
+| `platform/librechat/chart/templates/sso-externalsecret.yaml` (new) | ~30 | 0 |
+| `platform/librechat/chart/templates/sso-app-registration.yaml` (new) | ~20 | 0 |
+| `platform/librechat/chart/templates/deployment.yaml` | ~2 (issuer auto-derive) | ~1 |
+| `platform/librechat/chart/values.yaml` | ~10 (sovereign.fqdn + org.{slug,realm} refs + existingSecret default flip) | ~3 |
+| **Total per app** | **~62** | **~4** |
+
+Chart bump: `1.0.0 → 1.1.0` (minor — additive). Lockstep: `Chart.yaml` + `blueprint.yaml` + bootstrap-kit slot pin.
+
+## Gotcha — MongoDB user-doc auto-creation race
+
+LibreChat creates a user document in MongoDB on first SSO sign-in. With multi-region Active-Active (audit doc shows rtz-A 🟢 A / rtz-B 🟢 A), simultaneous logins from the same user against both regions can race to create duplicate docs (FerretDB / Mongo wire). Wave-2 should consider adding a unique index on `users.email` via post-install Job — separate from SSO scope but discovered during this audit.

--- a/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-litmus.md
+++ b/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-litmus.md
@@ -1,0 +1,76 @@
+# Tier-3 SSO audit — `bp-litmus` (LitmusChaos ChaosCenter)
+
+> Federates to: per-Org realm via 2-hop (per-Org realm → `sovereign` realm broker → catalyst-pin IdP).
+> Chart path: `platform/litmus/chart/`
+> Chart version on `main`: `1.0.0` (Chart.yaml:15)
+> Topology row (audit doc): rtz-A 🔵 S / rtz-B 🔵 S (App-tier per-cluster singleton — chaos experiments are intentionally cluster-scoped)
+
+## Current SSO state — **NONE**
+
+| Surface | Status | File:line |
+|---|---|---|
+| `oidc.*` / `sso.*` values block | MISSING | n/a |
+| Upstream chart OIDC handle (`litmus.server.authServer.OIDC_*`) | NOT WIRED (chart has no `templates/`; values lacks any auth-server OIDC block) | n/a |
+| Per-app SSO Secret materialization | MISSING | n/a |
+| Per-Org realm registration | MISSING | n/a |
+| `kc_idp_hint=catalyst-pin` injection | MISSING | n/a |
+
+## Upstream chart OIDC handle — **WEAK / EXPERIMENTAL**
+
+LitmusChaos's auth-server (`litmuschaos/litmusportal-auth-server` 3.28) supports OIDC via env vars (verified in upstream source 3.x line):
+
+- `OIDC_PROVIDER` — discovery URL
+- `OIDC_CLIENT_ID`
+- `OIDC_CLIENT_SECRET`
+- `OIDC_REDIRECT_URI`
+- `OIDC_ENABLED` — bool
+
+**But:** as of 3.28, LitmusChaos OIDC integration is upstream-experimental and the role-mapping plane (KC group → ChaosCenter project role) is manual. The ChaosCenter UI does NOT have a "Sign in with Keycloak" button by default — it requires upstream config + a custom build of the frontend image to surface the SSO button.
+
+## Required Wave-2 patch plan — **DEFERRED v0 / minimal v1**
+
+### Option A — full SSO wiring (NOT recommended for B5)
+
+Would require:
+
+1. New `templates/sso-externalsecret.yaml` ExternalSecret pulling from `sso/<org-realm>/litmus`.
+2. New `templates/sso-app-registration.yaml` registering `litmus` client in per-Org realm.
+3. Upstream chart values overlay extending `litmus.server.authServer.env[]` with OIDC_* envs.
+4. Custom ChaosCenter frontend image with SSO button or post-install Job that patches the login UI ConfigMap.
+5. Role-mapping job that maps KC `org-{slug}-admins` group → ChaosCenter `Owner` role on the org's default project.
+
+Estimated patch: ~150 lines + a new image build pipeline. **Out of B5 scope.**
+
+### Option B — local-account auth only, document as KNOWN GAP (recommended for B5)
+
+LitmusChaos chart-side stays as-is. Cluster-admin-tier operators authenticate to ChaosCenter via the chart-auto-generated `admin` user (password in `litmus-portal-admin-secret`). Document the SSO gap as a follow-up under a fresh `G118.3 — bp-litmus full SSO` sub-EPIC, gated on:
+
+- Upstream LitmusChaos 4.x (planned 2026Q3) which is expected to land first-class OIDC.
+- An optional Catalyst-side `bp-litmus-sso-wrapper` chart that fronts ChaosCenter with oauth2-proxy (same pattern as `bp-cilium` Hubble UI).
+
+### Recommendation
+
+**Wave-2 SSO agent should SKIP `bp-litmus`** for the v1 fan-out and document the gap. The chart will not regress, and the topology row in `2026-06-02-per-blueprint-topology-audit.md:128` already says "n/a" for switchover (chaos experiments are cluster-local).
+
+## Verification probe (current state — confirms gap, not SSO success)
+
+```bash
+# Today's state — ChaosCenter login form returns 200 (local-account only)
+curl -ksI "https://litmus.<org>.<sov-fqdn>/auth/login"
+# Expected: HTTP/2 200 (HTML login form, NOT a 302 redirect to KC)
+
+# After Option A would land — Expected: HTTP/2 302 → https://auth.<sov-fqdn>/realms/<org-realm>/protocol/openid-connect/auth?...
+```
+
+## Chart-patch size estimate
+
+| Option | Files | Lines added | Lines removed |
+|---|---|---|---|
+| **Option A — full SSO (DEFERRED)** | 3 new templates + values.yaml + new image | ~150 + image pipeline | 0 |
+| **Option B — defer with docs (recommended)** | 0 chart changes | 0 | 0 |
+
+If Wave-2 picks Option B, lockstep: zero (no chart bump). Only `docs/sessions/2026-06-02-per-blueprint-topology-audit.md` row 128 gets a note. Track follow-up in `docs/ledger/TRACKER.md`.
+
+## DROP from active Wave-2 worklist
+
+Reduces Tier-3 active patch count from 8 to **7 apps** (matrix, langfuse, temporal, librechat, openmeter [API-only], wordpress-tenant; + bp-litmus deferred under G118.3).

--- a/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-matrix.md
+++ b/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-matrix.md
@@ -1,0 +1,232 @@
+# Tier-3 SSO audit — `bp-matrix` (Synapse)
+
+> Federates to: per-Org realm via 2-hop (per-Org realm → `sovereign` realm broker → catalyst-pin IdP).
+> Chart path: `platform/matrix/chart/` (folder + chart confirmed)
+> Chart version on `main`: `1.0.1` (Chart.yaml:3)
+> Topology row (audit doc): rtz-A 🟢 A / rtz-B 🟡 P (App-tier, per-Org vCluster, CP-tier HA pair on rtz)
+
+## Current SSO state — **PARTIAL** (values block + upstream chart path exist; per-app Secret + 2-hop wiring + realm registration missing)
+
+Synapse natively supports OIDC via `homeserver.yaml` `oidc_providers[]`. The chart exposes a Catalyst-overlay `oidc.*` block that the upstream `matrix-synapse` chart consumes via `extraConfig.oidc_providers`. The wiring lives there — no Catalyst-authored template materializes it.
+
+| Surface | Status | File:line |
+|---|---|---|
+| `oidc.*` values block (enabled / issuer / clientId / scopes / existingSecret) | PRESENT | `platform/matrix/chart/values.yaml:159-168` |
+| Synapse `oidc_providers[]` config emission | INDIRECT — depends on per-Sovereign overlay piping `oidc.*` into upstream `extraConfig.oidc_providers` (NOT auto-emitted by Catalyst overlay templates today) | n/a |
+| Per-app SSO Secret materialization | MISSING — operator-supplied `existingSecret` only; no chart-side `lookup`-or-generate | `platform/matrix/chart/values.yaml:168` |
+| Per-Org realm registration | MISSING entirely (no per-Org realm template exists in `platform/keycloak/chart/templates/` yet — Wave-2.C4 lands it) | n/a |
+| `kc_idp_hint=catalyst-pin` injection | MISSING — Synapse `oidc_providers[].authorization_endpoint` would need explicit query param (Synapse honors it verbatim) | n/a |
+| Cross-Org isolation | UNDEFINED — Wave-2 must enforce that Org-A's matrix instance trusts only Org-A's per-Org realm | n/a |
+
+## Per-Org realm — 2-hop federation pattern (locked architecture, decision #6)
+
+Each Org gets its own KC realm (`org-<slug>`) with a `Keycloak OIDC` Identity Provider entry that brokers to the `sovereign` realm's broker. The flow:
+
+```
+User → Matrix /_matrix/client/v3/login/sso/redirect
+    → Matrix 302 to https://auth.<sov>/realms/org-<slug>/protocol/openid-connect/auth?client_id=matrix-synapse&kc_idp_hint=sovereign-broker
+    → per-Org realm IDR fires → 303 to https://auth.<sov>/realms/org-<slug>/broker/sovereign-broker/login?session_code=...
+    → per-Org KC server-side calls sovereign realm's authorize endpoint → silent SSO chain as Tier-1 (sovereign realm → catalyst-pin IdP)
+    → catalyst-api /oidc/token mints code → per-Org realm gets id_token → per-Org realm mints its OWN id_token for matrix-synapse client
+    → 302 back to Matrix /_synapse/client/oidc/callback?code=...&state=...
+    → Matrix logs user in silently
+```
+
+## Per-Org realm client registration mechanism
+
+Each Org's realm carries a `matrix-synapse` client. The realm itself is **provisioned by application-controller at Application install time** (not by the bp-matrix chart) — per locked decision #6, the per-Org realm is a one-realm-per-Org primitive owned by the bp-sso-bridge reconciler. The bp-matrix chart's only realm-side input is a ClientRegistrationConfigMap (or equivalent CRD) that bp-sso-bridge reads to mint the client when the App is installed.
+
+Two viable mechanisms:
+
+**Option A — `bp-sso-bridge` AppRegistration CRD (cleaner):** bp-matrix chart emits a `AppRegistration` CR (apiVersion `sso.openova.io/v1alpha1`) declaring its OIDC client requirements. bp-sso-bridge reconciler reads it, calls per-Org realm KC admin API, mints client, writes secret to OpenBao at `sso/org-<slug>/matrix-synapse`. ExternalSecret in matrix ns materializes K8s Secret.
+
+**Option B — chart-side ConfigMap with label (faster):** bp-matrix chart emits a ConfigMap labeled `sso.openova.io/app-registration: matrix-synapse` carrying client config JSON. bp-sso-bridge watches ConfigMaps with this label and does the same work as Option A.
+
+Recommendation: **Option B for V1** (less new CRD surface), promote to **Option A for V2** once 3+ Tier-3 apps share the pattern and the contract stabilizes.
+
+## Required Wave-2 patch plan
+
+### 1. Per-app SSO Secret materialization (new template — ExternalSecret pattern)
+
+Add `platform/matrix/chart/templates/sso-externalsecret.yaml`:
+
+```yaml
+{{- if .Values.oidc.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: matrix-oidc-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-matrix
+    bp-sso-bridge.openova.io/consumer: bp-matrix
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-region1
+    kind: ClusterSecretStore
+  target:
+    name: matrix-oidc-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: OIDC_CLIENT_SECRET
+      remoteRef:
+        key: sso/org-{{ .Values.org.slug }}/matrix-synapse
+        property: client_secret
+{{- end }}
+```
+
+### 2. Chart-side AppRegistration ConfigMap (new template — Option B)
+
+Add `platform/matrix/chart/templates/sso-app-registration.yaml`:
+
+```yaml
+{{- if .Values.oidc.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bp-matrix-sso-registration
+  namespace: {{ .Release.Namespace }}
+  labels:
+    sso.openova.io/app-registration: matrix-synapse
+data:
+  client.json: |
+    {
+      "clientId": "matrix-synapse",
+      "name": "Matrix Synapse ({{ .Values.org.slug }})",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "redirectUris": ["https://matrix.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}/_synapse/client/oidc/callback"],
+      "webOrigins": ["https://matrix.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}"],
+      "defaultClientScopes": ["web-origins","profile","email","groups"],
+      "attributes": {"access.token.lifespan": "900"}
+    }
+  realm: "org-{{ .Values.org.slug }}"
+{{- end }}
+```
+
+### 3. Synapse `oidc_providers[]` config emission with `kc_idp_hint`
+
+Wave-2 SSO agent extends `platform/matrix/chart/values.yaml:140-150` `matrix-synapse.extraConfig` (upstream subchart) to render `homeserver.yaml` `oidc_providers[]` with explicit query-param injection. Patch shape:
+
+```yaml
+matrix-synapse:
+  extraConfig:
+    oidc_providers:
+      - idp_id: "catalyst-pin"
+        idp_name: "Catalyst Sign-In"
+        issuer: "https://auth.{{ .Values.sovereign.fqdn }}/realms/org-{{ .Values.org.slug }}"
+        client_id: "matrix-synapse"
+        client_secret_path: "/secrets/oidc/OIDC_CLIENT_SECRET"  # mounted from matrix-oidc-credentials Secret
+        scopes: ["openid", "profile", "email", "groups"]
+        # CRITICAL: explicit authorization_endpoint with kc_idp_hint forces silent SSO through the per-Org realm's IDR
+        authorization_endpoint: "https://auth.{{ .Values.sovereign.fqdn }}/realms/org-{{ .Values.org.slug }}/protocol/openid-connect/auth?kc_idp_hint=sovereign-broker"
+        token_endpoint: "https://auth.{{ .Values.sovereign.fqdn }}/realms/org-{{ .Values.org.slug }}/protocol/openid-connect/token"
+        user_mapping_provider:
+          config:
+            localpart_template: "{{ "{{ user.preferred_username }}" }}"
+            display_name_template: "{{ "{{ user.name }}" }}"
+            email_template: "{{ "{{ user.email }}" }}"
+```
+
+### 4. Per-Org realm config (template owned by bp-keycloak, NOT bp-matrix)
+
+Wave-2.C4 ships `platform/keycloak/chart/templates/configmap-per-org-realm.yaml` rendered once per Org with shape:
+
+```jsonc
+{
+  "realm": "org-<slug>",
+  "enabled": true,
+  "identityProviders": [
+    {
+      "alias": "sovereign-broker",
+      "providerId": "oidc",
+      "enabled": true,
+      "trustEmail": true,
+      "config": {
+        "clientId": "org-<slug>-broker",
+        "clientSecret": "<helper-derived>",
+        "authorizationUrl": "https://auth.<sov>/realms/sovereign/protocol/openid-connect/auth?kc_idp_hint=catalyst-pin",
+        "tokenUrl": "https://auth.<sov>/realms/sovereign/protocol/openid-connect/token",
+        "issuer": "https://auth.<sov>/realms/sovereign",
+        "defaultScope": "openid email profile groups"
+      }
+    }
+  ],
+  "authenticatorConfig": [
+    {"alias": "sovereign-broker-redirector", "config": {"defaultProvider": "sovereign-broker"}}
+  ],
+  "authenticationFlows": [
+    {"alias": "browser", "authenticationExecutions": [
+      {"authenticator": "identity-provider-redirector", "authenticatorConfig": "sovereign-broker-redirector", "requirement": "ALTERNATIVE", "priority": 25},
+      {"flowAlias": "forms", "requirement": "ALTERNATIVE", "priority": 30, "autheticatorFlow": true}
+    ]}
+  ],
+  "clients": [...]   // populated from each AppRegistration ConfigMap in the Org's namespace
+}
+```
+
+The sovereign realm side ALSO needs a matching client registration `org-<slug>-broker` (so the per-Org realm can authenticate AS a client of the sovereign realm). That client lands in `configmap-sovereign-realm.yaml` `clients[]` array.
+
+## 2-hop verification curl chain
+
+Eight hops total (4 per realm):
+
+```
+HOP1: GET https://matrix.<org>.<sov-fqdn>/_matrix/client/v3/login/sso/redirect?redirectUrl=https://element.<org>.<sov-fqdn>
+      → 302 → https://auth.<sov-fqdn>/realms/org-<slug>/protocol/openid-connect/auth?client_id=matrix-synapse&kc_idp_hint=sovereign-broker&...
+HOP2: GET HOP1 (jar w/ catalyst_session)
+      → 303 → https://auth.<sov-fqdn>/realms/org-<slug>/broker/sovereign-broker/login?session_code=...
+HOP3: GET HOP2 (jar)
+      → 302 → https://auth.<sov-fqdn>/realms/sovereign/protocol/openid-connect/auth?client_id=org-<slug>-broker&kc_idp_hint=catalyst-pin&...
+HOP4: GET HOP3 (jar)
+      → 303 → https://auth.<sov-fqdn>/realms/sovereign/broker/catalyst-pin/login?session_code=...
+HOP5: GET HOP4 (jar)
+      → 303 → https://api.<sov-fqdn>/oidc/auth?...
+HOP6: GET HOP5 (jar)
+      → 302 → KC sovereign broker callback (drops sovereign realm session cookie)
+HOP7: GET HOP6 (jar)
+      → 302 → KC per-Org realm broker callback (drops per-Org realm session cookie)
+HOP8: GET HOP7 (jar)
+      → 302 → https://matrix.<org>.<sov-fqdn>/_synapse/client/oidc/callback?code=...&state=...
+HOP9: GET HOP8 (jar)
+      → 200 — Matrix session established, redirect to original Element URL with login_token
+```
+
+## Cross-Org isolation test
+
+```bash
+# Setup: 2 orgs (org-a, org-b), 1 Matrix App per Org, 1 user per Org realm
+# Test: org-a's user attempts to SSO into matrix.org-b.<sov-fqdn>
+
+curl -ksI -b /tmp/org-a-session-jar -c /tmp/org-a-session-jar \
+  "https://matrix.org-b.<sov-fqdn>/_matrix/client/v3/login/sso/redirect" \
+  -L --max-redirs 20
+
+# Expected: chain bounces to https://auth.<sov-fqdn>/realms/org-b/... → org-a user has NO session in org-b realm
+# → KC returns either 200 (login form because org-a user not in org-b) OR 302 to org-b realm consent
+# → Synapse callback receives id_token issued by org-b realm with org_id="org-b" claim
+# → Synapse user_mapping_provider rejects (localpart already exists OR claim mismatch)
+# REQUIRED: user authenticated to org-a CANNOT log into matrix.org-b URL without going through org-b's IdP flow
+```
+
+If the chain succeeds with the org-a session cookie, the per-Org realm broker config leaked sovereign-realm session bleed-through — STOP and fix the sovereign-realm broker's `syncMode: FORCE` + per-Org realm `firstBrokerLoginFlow=auto-link-by-email-IF-AND-ONLY-IF-org-claim-matches`.
+
+## Chart-patch size estimate
+
+| File | Lines added | Lines removed |
+|---|---|---|
+| `platform/matrix/chart/templates/sso-externalsecret.yaml` (new) | ~25 | 0 |
+| `platform/matrix/chart/templates/sso-app-registration.yaml` (new) | ~20 | 0 |
+| `platform/matrix/chart/values.yaml` | ~30 (extraConfig.oidc_providers shape + org.slug + sovereign.fqdn refs) | ~5 |
+| `platform/matrix/chart/templates/deployment.yaml` patch — N/A (upstream chart owns deployment) | 0 | 0 |
+| **Total per app** | **~75** | **~5** |
+
+Chart bump: `1.0.1 → 1.1.0` (minor — adds SSO opt-in, no breaking change for off-by-default deploys). Lockstep: `Chart.yaml` + `blueprint.yaml` + bootstrap-kit slot pin.
+
+## Gotchas
+
+- Synapse OIDC requires `client_secret_path` (file) NOT `client_secret` (string) in 1.151+. The ExternalSecret-rendered Secret must be MOUNTED as a file at `/secrets/oidc/OIDC_CLIENT_SECRET`, NOT envFrom. Wave-2 patch MUST add a volume + volumeMount for this.
+- Synapse rejects multiple `idp_id` collisions on reload; ensure the per-Org realm's `org-<slug>` value doesn't collide with a hardcoded `idp_id: "keycloak"` from chart values.yaml:161 — drop the `idp_id` default or namespace it.

--- a/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-openmeter.md
+++ b/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-openmeter.md
@@ -1,0 +1,150 @@
+# Tier-3 SSO audit — `bp-openmeter`
+
+> Federates to: per-Org realm via 2-hop (per-Org realm → `sovereign` realm broker → catalyst-pin IdP).
+> Chart path: `platform/openmeter/chart/`
+> Chart version on `main`: `1.0.1` (Chart.yaml:3)
+> Topology row (audit doc): rtz-A 🟢 A / rtz-B 🟡 P (App-tier CP-HA pair)
+
+## Current SSO state — **NONE**
+
+| Surface | Status | File:line |
+|---|---|---|
+| `oidc.*` / `sso.*` / `auth.*` values block | MISSING | n/a |
+| Upstream `openmeter.config.auth.*` overrides | EMPTY — `openmeter.config: {}` placeholder only | `platform/openmeter/chart/values.yaml:102` |
+| Per-app SSO Secret materialization | MISSING | n/a |
+| Per-Org realm registration | MISSING | n/a |
+| `kc_idp_hint=catalyst-pin` injection | MISSING | n/a |
+
+## Upstream chart OIDC handle — **AMBIGUOUS / WEAK**
+
+OpenMeter's upstream chart (`oci://ghcr.io/openmeterio/helm-charts/openmeter` v1.0.0-beta.213) doesn't ship a dedicated OIDC block. OpenMeter's binary at this version is **API-first** with the UI being a separate `openmeter-cloud` product that's NOT open-source.
+
+The OSS OpenMeter API supports auth via OIDC bearer tokens but the config surface is:
+
+- `OPENMETER_AUTH_OIDC_ISSUER` — discovery URL
+- `OPENMETER_AUTH_OIDC_AUDIENCE` — expected audience claim
+- `OPENMETER_AUTH_OIDC_REQUIRED_SCOPES` — comma-separated
+
+This is a **JWT validation surface (resource server)**, NOT a browser OIDC client. There is **no UI to silent-SSO into** — only an API to authorize.
+
+## Reclassification recommendation
+
+`bp-openmeter` belongs in a NEW classification:
+
+> **Tier-3-API** — API-only services that validate bearer tokens. No browser redirect. No AppRegistration ConfigMap. No `kc_idp_hint`. Wave-2 wires JWT validation env vars only.
+
+## Required Wave-2 patch plan (reduced — API-only tier)
+
+### 1. Extend `openmeter.config` for OIDC JWT validation
+
+Patch `platform/openmeter/chart/values.yaml:102`:
+
+```yaml
+openmeter:
+  config:
+    auth:
+      oidc:
+        enabled: true
+        # Auto-derived when empty: https://auth.{{ sovereign.fqdn }}/realms/{{ org.realm }}
+        issuer: ""
+        audience: "openmeter"
+        requiredScopes: "openmeter:read,openmeter:write"
+```
+
+### 2. ConfigMap-driven config — likely an envFrom on the OpenMeter API Deployment
+
+Inspect upstream chart's API Deployment for env conventions. Wave-2 may need to ship a values overlay:
+
+```yaml
+openmeter:
+  api:
+    extraEnv:
+      - name: OPENMETER_AUTH_OIDC_ISSUER
+        value: "https://auth.{{ .Values.sovereign.fqdn }}/realms/{{ .Values.org.realm }}"
+      - name: OPENMETER_AUTH_OIDC_AUDIENCE
+        value: "openmeter"
+      - name: OPENMETER_AUTH_OIDC_REQUIRED_SCOPES
+        value: "openmeter:read,openmeter:write"
+```
+
+If upstream chart doesn't honor `extraEnv` on the API Deployment, Wave-2 must either upstream a chart PR OR add a Catalyst-side patch via Kyverno mutate or post-render Job.
+
+### 3. Per-app SSO **client** registration (still needed)
+
+Even though there's no browser flow, OpenMeter clients (other services calling its API) need an OIDC client_credentials grant against the per-Org realm. Wave-2 adds an AppRegistration ConfigMap that registers a **service-account client**:
+
+```yaml
+{{- if .Values.openmeter.config.auth.oidc.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bp-openmeter-sso-registration
+  namespace: {{ .Release.Namespace }}
+  labels:
+    sso.openova.io/app-registration: openmeter-api
+data:
+  client.json: |
+    {
+      "clientId": "openmeter",
+      "name": "OpenMeter ({{ .Values.org.slug }})",
+      "enabled": true,
+      "publicClient": false,
+      "serviceAccountsEnabled": true,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "redirectUris": [],
+      "webOrigins": [],
+      "defaultClientScopes": ["roles","openmeter:read","openmeter:write"]
+    }
+  realm: "{{ .Values.org.realm }}"
+{{- end }}
+```
+
+### 4. No per-app SSO Secret materialization needed for the API server itself
+
+The API server only validates tokens — it doesn't hold a client_secret. Service-account credentials for OpenMeter clients (other Apps calling OpenMeter) are minted by their own ExternalSecrets in their own namespaces. **Wave-2 does NOT add an ExternalSecret to `platform/openmeter/`**.
+
+### 5. No `kc_idp_hint` injection
+
+N/A — no browser flow.
+
+## Verification probe (NOT 4-hop chain — single curl JWT-validation test)
+
+```bash
+# Mint a service-account token for openmeter client
+TOKEN=$(curl -sk -X POST \
+  "https://auth.<sov-fqdn>/realms/<org-realm>/protocol/openid-connect/token" \
+  -d "client_id=openmeter&client_secret=<sec>&grant_type=client_credentials&scope=openmeter:read" \
+  | jq -r .access_token)
+
+# Present to OpenMeter API
+curl -sk -H "Authorization: Bearer $TOKEN" \
+  "https://openmeter.<org>.<sov-fqdn>/api/v1/meters"
+# Expected: 200 with meter list (JWT validated, scopes extracted, request authorized)
+
+# Cross-Org isolation
+TOKEN_A=$(curl ... org-a realm ...)
+curl -sk -H "Authorization: Bearer $TOKEN_A" \
+  "https://openmeter.org-b.<sov-fqdn>/api/v1/meters"
+# Expected: 401 — token issuer (org-a realm) doesn't match API server's expected issuer (org-b realm)
+```
+
+## Chart-patch size estimate
+
+| File | Lines added | Lines removed |
+|---|---|---|
+| `platform/openmeter/chart/templates/sso-app-registration.yaml` (new) | ~25 | 0 |
+| `platform/openmeter/chart/values.yaml` (config.auth.oidc.* block + api.extraEnv) | ~25 | 0 |
+| **Total per app** | **~50** | **0** |
+
+Smaller than other Tier-3 apps because no browser flow. Chart bump: `1.0.1 → 1.1.0` (minor — additive). Lockstep: `Chart.yaml` + `blueprint.yaml` + bootstrap-kit slot pin.
+
+## Risk
+
+If upstream `openmeter` chart 1.0.0-beta.213 doesn't expose `api.extraEnv` (some beta charts don't), Wave-2 must either:
+
+1. PR upstream — slow.
+2. Add a Kustomize patch in `catalystOverlay` (still chart-rendered) — fragile across upstream version bumps.
+3. Add a post-install Job that `kubectl patch` the Deployment to inject env vars — least invasive.
+
+Wave-2 should verify upstream chart shape BEFORE committing the patch direction. `helm pull oci://ghcr.io/openmeterio/helm-charts/openmeter --version 1.0.0-beta.213 --untar` and grep templates.

--- a/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-opensearch.md
+++ b/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-opensearch.md
@@ -1,0 +1,41 @@
+# Tier-3 SSO audit — `bp-opensearch` (OpenSearch Dashboards)
+
+> Federates to: per-Org realm via 2-hop (per-Org realm → `sovereign` realm broker → catalyst-pin IdP).
+> Chart path: `platform/opensearch/` (**SCAFFOLD-ONLY — no chart subdir on `main`**)
+> Topology row (audit doc): rtz-A 🟢 A / rtz-B 🟢 A (App-tier active-active via CCR)
+
+## Current SSO state — **CHART DOES NOT EXIST**
+
+```bash
+$ ls /home/openova/repos/openova/platform/opensearch/
+README.md
+```
+
+`platform/opensearch/` is README-only. No `chart/` subdir, no `blueprint.yaml`. The audit doc row at `docs/sessions/2026-06-02-per-blueprint-topology-audit.md:106` is **aspirational** — Wave-2 SSO fan-out cannot wire SSO to a non-existent chart.
+
+## Recommendation
+
+Wave-2 SSO agent should **NOT** attempt to add SSO templates to `platform/opensearch/`. Two follow-ups:
+
+1. **Document the gap** in `docs/STATUS.md` — `bp-opensearch` is design-stage, not built.
+2. **Open a fresh sub-EPIC** (e.g. `G118.1 — bp-opensearch chart`) to author the chart umbrella around `opensearch-project/helm-charts` (`opensearch` + `opensearch-dashboards`). SSO wiring follows the standard Tier-3 pattern documented in this audit suite (see `bp-langfuse.md` or `bp-temporal.md`).
+3. **When `bp-opensearch` chart lands**, the SSO patch plan is:
+   - OpenSearch Dashboards `opensearch_security.openid.connect_url` = `https://auth.<sov>/realms/<org-realm>/.well-known/openid-configuration`
+   - OpenSearch Dashboards `opensearch_security.openid.client_id` = `opensearch-dashboards`
+   - Per-app SSO Secret via ExternalSecret pattern (`sso/<org-realm>/opensearch-dashboards`)
+   - AppRegistration ConfigMap labeled `sso.openova.io/app-registration: opensearch-dashboards`
+   - OpenSearch security plugin role-mapping from KC groups → OpenSearch roles (`all_access`, `kibana_user`, etc.) — same as Grafana team-sync pattern in G91
+
+## Estimated chart-patch size (when chart exists)
+
+| File | Lines added | Lines removed |
+|---|---|---|
+| `platform/opensearch/chart/templates/sso-externalsecret.yaml` (new) | ~30 | 0 |
+| `platform/opensearch/chart/templates/sso-app-registration.yaml` (new) | ~25 | 0 |
+| `platform/opensearch/chart/values.yaml` (`opensearch-dashboards.config.opensearch_dashboards_yml.opensearch_security.openid.*` overrides) | ~25 | 0 |
+| `platform/opensearch/chart/templates/security-config-job.yaml` (OpenSearch security plugin role-mapping bootstrap, new) | ~50 | 0 |
+| **Estimated total** | **~130** | **0** |
+
+## DROP from Wave-2 worklist
+
+Reduces Tier-3 from 9 apps to **8 apps** (matrix, langfuse, temporal, librechat, openmeter, litmus, wordpress-tenant; iceberg also drops — see `bp-iceberg.md`).

--- a/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-temporal.md
+++ b/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-temporal.md
@@ -1,0 +1,190 @@
+# Tier-3 SSO audit — `bp-temporal`
+
+> Federates to: per-Org realm via 2-hop (per-Org realm → `sovereign` realm broker → catalyst-pin IdP).
+> Chart path: `platform/temporal/chart/`
+> Chart version on `main`: `1.0.1` (Chart.yaml:3)
+> Topology row (audit doc): rtz-A 🟢 A / rtz-B 🟡 P (App-tier CP-HA pair)
+
+## Current SSO state — **PARTIAL** (JWT validation chart-side; OIDC client flow for the Web UI is the gap)
+
+Temporal is unusual: it has TWO auth surfaces, and the chart wires only one of them.
+
+| Surface | Status | File:line |
+|---|---|---|
+| Temporal frontend gRPC **JWT validation** (`server.config.authorization.jwtKeyProvider`) | PRESENT chart-side — `catalystOverlay.auth.keycloak.{issuer,realm,clientId,jwksUri}` populates `bp-temporal-keycloak-oidc` ConfigMap consumed by upstream chart | `platform/temporal/chart/values.yaml:183-202` + `templates/keycloak-oidc-config.yaml:16-36` |
+| Temporal Web UI **browser OIDC client** (`temporal.web.config.auth.*`) | MISSING entirely — no Web UI OIDC config block in values, no envFrom on web Deployment | n/a |
+| Per-app SSO Secret materialization | MISSING (no Secret template) | n/a |
+| Per-Org realm registration | MISSING (no AppRegistration ConfigMap) | n/a |
+| `kc_idp_hint=catalyst-pin` injection | MISSING | n/a |
+
+Upstream `temporalio/web` (Temporal UI Server) supports OIDC SSO via env vars or config file (`TEMPORAL_AUTH_*` family). Without these, the Web UI is unauthenticated AND the frontend gRPC requires JWT tokens — net result: a UI user CAN browse the UI but every API call fails. That's the gap Wave-2 must close.
+
+## Required Wave-2 patch plan
+
+### 1. Extend chart-side OIDC for Web UI
+
+Add `temporal.web.additionalEnv[]` to `platform/temporal/chart/values.yaml` (block currently ends at line 142, ingress disabled — extend before):
+
+```yaml
+temporal:
+  web:
+    enabled: true
+    replicaCount: 1
+    # ... existing ...
+    additionalEnv:
+      - name: TEMPORAL_AUTH_ENABLED
+        value: "true"
+      - name: TEMPORAL_AUTH_PROVIDER_URL
+        valueFrom:
+          secretKeyRef: {name: temporal-sso-oidc-credentials, key: PROVIDER_URL, optional: true}
+      - name: TEMPORAL_AUTH_CLIENT_ID
+        valueFrom:
+          secretKeyRef: {name: temporal-sso-oidc-credentials, key: CLIENT_ID, optional: true}
+      - name: TEMPORAL_AUTH_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef: {name: temporal-sso-oidc-credentials, key: CLIENT_SECRET, optional: true}
+      - name: TEMPORAL_AUTH_CALLBACK_URL
+        value: "https://temporal.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}/auth/sso/callback"
+      - name: TEMPORAL_AUTH_SCOPES
+        value: "openid,profile,email,groups"
+```
+
+### 2. Per-app SSO Secret (new template — ExternalSecret pattern)
+
+Add `platform/temporal/chart/templates/sso-externalsecret.yaml`:
+
+```yaml
+{{- if .Values.catalystOverlay.auth.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: temporal-sso-oidc-credentials
+  namespace: {{ .Release.Namespace }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-region1
+    kind: ClusterSecretStore
+  target:
+    name: temporal-sso-oidc-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        PROVIDER_URL:  "https://auth.{{ .Values.sovereign.fqdn }}/realms/{{ .Values.catalystOverlay.auth.keycloak.realm }}"
+        CLIENT_ID:     "{{ .Values.catalystOverlay.auth.keycloak.clientId }}"
+        CLIENT_SECRET: "{{ "{{ .client_secret }}" }}"
+  data:
+    - secretKey: client_secret
+      remoteRef:
+        key: sso/{{ .Values.catalystOverlay.auth.keycloak.realm }}/{{ .Values.catalystOverlay.auth.keycloak.clientId }}
+        property: client_secret
+{{- end }}
+```
+
+### 3. AppRegistration ConfigMap (new template)
+
+Add `platform/temporal/chart/templates/sso-app-registration.yaml`:
+
+```yaml
+{{- if .Values.catalystOverlay.auth.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bp-temporal-sso-registration
+  namespace: {{ .Release.Namespace }}
+  labels:
+    sso.openova.io/app-registration: temporal-frontend
+data:
+  client.json: |
+    {
+      "clientId": "{{ .Values.catalystOverlay.auth.keycloak.clientId | default "temporal-frontend" }}",
+      "name": "Temporal Web UI ({{ .Values.org.slug }})",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "redirectUris": ["https://temporal.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}/auth/sso/callback"],
+      "webOrigins": ["https://temporal.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}"],
+      "defaultClientScopes": ["web-origins","profile","email","groups"]
+    }
+  realm: "{{ .Values.catalystOverlay.auth.keycloak.realm }}"
+{{- end }}
+```
+
+### 4. Auto-derive `auth.keycloak.{issuer,jwksUri}` from realm + sovereign.fqdn
+
+Patch `platform/temporal/chart/templates/keycloak-oidc-config.yaml:29` to derive these from a single `sovereign.fqdn` + `realm` value (drop operator burden of pasting 4 URLs):
+
+```yaml
+data:
+  auth.yaml: |
+    global:
+      authorization:
+        jwtKeyProvider:
+          keySourceURIs:
+            - "https://auth.{{ .Values.sovereign.fqdn }}/realms/{{ .Values.catalystOverlay.auth.keycloak.realm }}/protocol/openid-connect/certs"
+          refreshInterval: 1h
+        permissionsClaimName: permissions
+        authorizer: default
+        claimMapper: {{ .Values.catalystOverlay.auth.keycloak.claimMapper | quote }}
+        issuer: "https://auth.{{ .Values.sovereign.fqdn }}/realms/{{ .Values.catalystOverlay.auth.keycloak.realm }}"
+        audience: {{ .Values.catalystOverlay.auth.keycloak.clientId | quote }}
+```
+
+### 5. `kc_idp_hint` injection
+
+Same as Langfuse: the Temporal Web UI's OAuth library derives the authorize URL from discovery. `kc_idp_hint` cannot be passed per-request. Silent SSO depends on per-Org realm IDR `defaultProvider=sovereign-broker` being bound — Wave-2.C4 owns that template.
+
+## 2-hop verification curl chain (8 hops)
+
+```
+HOP1: GET https://temporal.<org>.<sov-fqdn>/
+      → 302 → https://temporal.<org>.<sov-fqdn>/auth/sso/login
+HOP2: GET HOP1 (jar)
+      → 302 → https://auth.<sov-fqdn>/realms/<org-realm>/protocol/openid-connect/auth?client_id=temporal-frontend&...
+HOP3-HOP6: 2-hop chain through per-Org realm IDR → sovereign realm → catalyst-pin → /oidc/auth → sovereign callback → per-Org callback
+HOP7: → 302 → https://temporal.<org>.<sov-fqdn>/auth/sso/callback?code=...&state=...
+HOP8: → 302 → https://temporal.<org>.<sov-fqdn>/  (silent SSO)
+```
+
+For the gRPC frontend probe (separate from Web UI):
+
+```bash
+# Mint a sovereign realm token, present to Temporal frontend gRPC
+TOKEN=$(curl -sk -X POST "https://auth.<sov>/realms/<org-realm>/protocol/openid-connect/token" \
+  -d "client_id=temporal-frontend&client_secret=<sec>&grant_type=client_credentials" | jq -r .access_token)
+grpcurl -H "Authorization: Bearer $TOKEN" temporal.<org>.<sov-fqdn>:7233 temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo
+# Expected: 200 with SystemInfoResponse — JWT validated, claims extracted
+```
+
+## Cross-Org isolation test
+
+The Temporal frontend's `audience` MUST match the per-Org realm's client name. An org-A-issued token (aud=temporal-frontend, iss=https://auth.<sov>/realms/org-a) presented to org-b's temporal frontend MUST be rejected by `jwtKeyProvider` because:
+
+1. The JWKS URL for org-b's frontend points at `realms/org-b/.../certs` — won't validate signature from org-a realm.
+2. The `issuer` config field for org-b's frontend is `realms/org-b` — issuer mismatch.
+
+Verify:
+
+```bash
+TOKEN_A=$(curl ... org-a realm ...)
+grpcurl -H "Authorization: Bearer $TOKEN_A" temporal.org-b.<sov-fqdn>:7233 ...
+# Expected: 401 Unauthenticated, error_description=token signature verification failed
+```
+
+## Chart-patch size estimate
+
+| File | Lines added | Lines removed |
+|---|---|---|
+| `platform/temporal/chart/templates/sso-externalsecret.yaml` (new) | ~30 | 0 |
+| `platform/temporal/chart/templates/sso-app-registration.yaml` (new) | ~20 | 0 |
+| `platform/temporal/chart/templates/keycloak-oidc-config.yaml` | ~5 (URL derivation) | ~5 |
+| `platform/temporal/chart/values.yaml` | ~40 (`temporal.web.additionalEnv[]` block + auto-derive realm + sovereign.fqdn refs) | ~10 (drop separate jwksUri/issuer requirement) |
+| **Total per app** | **~95** | **~15** |
+
+Chart bump: `1.0.1 → 1.1.0` (minor — Web UI SSO is additive, gRPC JWT validation behavior unchanged when default off). Lockstep: `Chart.yaml` + `blueprint.yaml` + bootstrap-kit slot pin.
+
+## Gotcha — `temporalio/ui-server` env-var name flip
+
+Temporal's official UI server (`temporalio/ui-server`) renamed env vars across 2.x → 2.20+: `TEMPORAL_AUTH_*` was the 2.5+ shape; pre-2.5 used `TEMPORAL_UI_AUTH_*`. The chart's `appVersion: "1.31.0"` corresponds to Temporal server 1.31.0 — the upstream `temporal` chart 1.2.0 ships ui-server image 2.20+ which uses `TEMPORAL_AUTH_*`. If a per-Sovereign overlay pins an older ui-server image, the env-var names must flip.

--- a/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-wordpress-tenant.md
+++ b/docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-wordpress-tenant.md
@@ -1,0 +1,168 @@
+# Tier-3 SSO audit — `bp-wordpress-tenant`
+
+> Federates to: per-Org realm via 2-hop (per-Org realm → `sovereign` realm broker → catalyst-pin IdP).
+> Chart path: `platform/wordpress-tenant/chart/`
+> Chart version on `main`: `0.3.2` (Chart.yaml:71)
+> Topology row (audit doc): rtz-A 🟢 A / rtz-B 🟡 P (App-tier CP-HA pair)
+
+## Current SSO state — **BEST IN TIER-3** (full SSO chain via `openid-connect-generic` WP plugin)
+
+This chart was authored under issue #915 (SME multi-tenant SSO) with a complete OIDC flow already wired. WordPress's `openid-connect-generic` plugin is installed + activated + configured by a post-install Job using `wp-cli`. The chart was DESIGNED for the per-Org realm model.
+
+| Surface | Status | File:line |
+|---|---|---|
+| `oidc.*` values block (enabled / issuerURL / clientId / clientSecretName / defaultRole / identityKey / roleMapping / cliImage) | PRESENT | `platform/wordpress-tenant/chart/values.yaml:262-323` |
+| Legacy back-compat `keycloak.*` alias | PRESENT | `platform/wordpress-tenant/chart/values.yaml:331-335` |
+| Post-install Job that runs `wp plugin install openid-connect-generic --activate` + `wp option update openid_connect_generic_settings` | PRESENT | `platform/wordpress-tenant/chart/templates/oidc-config-job.yaml` |
+| Per-app SSO Secret materialization | PARTIAL — values declares `clientSecretName: wordpress-oidc-client-secret` but chart does NOT emit the Secret; assumes it lands via PR #918 bp-keycloak tenant-realm ConfigMap render OR via per-Sovereign overlay's SealedSecret | `platform/wordpress-tenant/chart/values.yaml:288` |
+| Per-Org realm registration | EXPECTED EXTERNAL — chart relies on `bp-keycloak` `configmap-tenant-realm.yaml` (Wave-2.C4) to register the `wordpress` client in the per-Org realm + emit the matching Secret | `platform/keycloak/chart/templates/configmap-tenant-realm.yaml` (exists per `ls`) |
+| `kc_idp_hint=catalyst-pin` injection | MISSING — `oidc.issuerURL` is the discovery base; `openid-connect-generic` plugin derives `authorize_url` from discovery | `platform/wordpress-tenant/chart/values.yaml:279` |
+| Cross-Org isolation | PER-vCLUSTER + PER-Org REALM — each tenant gets its own vCluster + its own KC realm (`sme-<subdomain>`) | architectural (#915) |
+
+## Realm name divergence — `sme-<subdomain>` vs `org-<slug>`
+
+The existing chart uses realm names like `sme-acme` (per `configmap-tenant-realm.yaml`). The G117 locked-decision #6 uses `org-<slug>`. Wave-2 must reconcile this:
+
+**Option A — rename in chart values:** `oidc.realmName: "org-<slug>"` default; deprecate `sme-*` naming. Touches `wordpress-tenant` + `keycloak` (configmap-tenant-realm.yaml) + the orchestrator emit at `core/services/catalyst-api/internal/handler/sme_tenant_gitops.go` (`smeTenantBPWordPress`).
+
+**Option B — keep `sme-*` as an alias for tenant-mode realms:** treat `sme-<subdomain>` and `org-<slug>` as the same thing depending on Org class. Document the equivalence and harmonize later.
+
+Recommendation: **Option B for v1** (no chart churn, no orchestrator emit changes); **Option A in a follow-up** once Tier-3 fan-out stabilizes the per-Org realm shape across 5+ apps.
+
+## Required Wave-2 patch plan — **MINIMAL** (chart is already 90% there)
+
+### 1. `kc_idp_hint` injection — `openid-connect-generic` plugin supports it via `endpoint_login` override
+
+Patch the `wp option update openid_connect_generic_settings` payload in `templates/oidc-config-job.yaml` to set `endpoint_login` explicitly with `?kc_idp_hint=sovereign-broker` appended:
+
+```php
+'endpoint_login' => '{{ trimSuffix "/" .Values.oidc.issuerURL }}/protocol/openid-connect/auth?kc_idp_hint=sovereign-broker',
+```
+
+(Other endpoints — `endpoint_userinfo`, `endpoint_token`, `endpoint_end_session` — keep discovery-derived defaults.)
+
+### 2. Per-app SSO Secret materialization — chart-side `lookup`-or-generate (NEW template)
+
+The chart today assumes the Secret `wordpress-oidc-client-secret` is materialized externally. Wave-2 adds a defensive chart-side Secret template that:
+
+- Is `helm.sh/resource-policy: keep` annotated.
+- Uses `lookup`-or-generate fallback so a fresh-prov Sovereign without bp-sso-bridge online still gets a stable client_secret.
+- Is OVERRIDDEN by the bp-keycloak tenant-realm reconcile when it lands.
+
+Add `platform/wordpress-tenant/chart/templates/sso-secret.yaml`:
+
+```yaml
+{{- if .Values.oidc.enabled }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace .Values.oidc.clientSecretName -}}
+{{- $clientSecret := "" -}}
+{{- if $existing -}}{{- $clientSecret = index $existing.data "client-secret" | b64dec -}}{{- end -}}
+{{- if not $clientSecret -}}{{- $clientSecret = randAlphaNum 32 -}}{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.oidc.clientSecretName }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    catalyst.openova.io/blueprint: bp-wordpress-tenant
+type: Opaque
+stringData:
+  client-secret: {{ $clientSecret | quote }}
+{{- end }}
+```
+
+### 3. AppRegistration ConfigMap (new template — for bp-sso-bridge consumption)
+
+Add `platform/wordpress-tenant/chart/templates/sso-app-registration.yaml`:
+
+```yaml
+{{- if .Values.oidc.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bp-wordpress-tenant-sso-registration
+  namespace: {{ .Release.Namespace }}
+  labels:
+    sso.openova.io/app-registration: wordpress
+data:
+  client.json: |
+    {
+      "clientId": "{{ .Values.oidc.clientId }}",
+      "name": "WordPress ({{ .Values.smeDomain }})",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "redirectUris": ["https://wordpress.{{ .Values.smeDomain }}/wp-admin/admin-ajax.php?action=openid-connect-authorize"],
+      "webOrigins": ["https://wordpress.{{ .Values.smeDomain }}"],
+      "defaultClientScopes": ["web-origins","profile","email","groups"]
+    }
+  realm: "{{ .Values.org.realm | default (printf "sme-%s" .Values.smeSubdomain) }}"
+{{- end }}
+```
+
+### 4. Auto-derive `oidc.issuerURL` from `sovereign.fqdn` + `org.realm`
+
+Patch `platform/wordpress-tenant/chart/values.yaml:279`:
+
+```yaml
+oidc:
+  # Auto-derived when empty: https://auth.{{ sovereign.fqdn }}/realms/{{ org.realm | default sme-<subdomain> }}
+  issuerURL: ""
+```
+
+Add corresponding `default` logic in `_helpers.tpl` `oidcIssuerURL`.
+
+## 2-hop verification curl chain (8 hops)
+
+```
+HOP1: GET https://wordpress.<smeDomain>/wp-login.php?loginform=openid-connect&action=openid-connect-authorize
+      → 302 → https://auth.<sov-fqdn>/realms/<org-realm>/protocol/openid-connect/auth?client_id=wordpress&kc_idp_hint=sovereign-broker&...
+HOP2: GET HOP1 (jar w/ catalyst_session)
+      → 303 → https://auth.<sov-fqdn>/realms/<org-realm>/broker/sovereign-broker/login?session_code=...
+HOP3-HOP7: 2-hop chain through sovereign realm → catalyst-pin → /oidc/auth → callbacks
+HOP8: GET final (jar)
+      → 302 → https://wordpress.<smeDomain>/wp-admin/admin-ajax.php?action=openid-connect-authorize&code=...&state=...
+HOP9: → 302 → https://wordpress.<smeDomain>/wp-admin/  (WordPress session cookie set)
+```
+
+## Cross-Org isolation test
+
+```bash
+# Org-A user session, hit Org-B WordPress:
+curl -ks -b /tmp/org-a-jar -L --max-redirs 20 \
+  "https://wordpress.org-b.<sov-fqdn>/wp-login.php?loginform=openid-connect&action=openid-connect-authorize"
+
+# Expected: bounces through https://auth.<sov-fqdn>/realms/<org-b-realm>/...
+# `openid-connect-generic` plugin matches users by `identityKey: preferred_username`
+# Org-A's preferred_username may or may not exist in Org-B realm
+# REQUIRED: WP plugin must verify `org_id` claim matches expected — if it doesn't,
+#            user lands at WP login form (NOT auto-logged-in to org-b WP)
+```
+
+Note: today's chart's `openid-connect-generic` config doesn't enforce an `org_id` claim check — Wave-2 should add `roleMapping` / `acl_enabled=1` gating on the `org` claim that PR #2725 emits in the sovereign realm `org` clientScope. Without this, cross-Org token replay COULD log a user in (containment gap; track as follow-up under G117.X tenant-isolation hardening).
+
+## Chart-patch size estimate
+
+| File | Lines added | Lines removed |
+|---|---|---|
+| `platform/wordpress-tenant/chart/templates/sso-secret.yaml` (new) | ~25 | 0 |
+| `platform/wordpress-tenant/chart/templates/sso-app-registration.yaml` (new) | ~25 | 0 |
+| `platform/wordpress-tenant/chart/templates/oidc-config-job.yaml` (kc_idp_hint append) | ~2 | ~1 |
+| `platform/wordpress-tenant/chart/templates/_helpers.tpl` (auto-derive issuerURL) | ~10 | 0 |
+| `platform/wordpress-tenant/chart/values.yaml` | ~5 (sovereign.fqdn / org.realm refs) | ~2 |
+| **Total per app** | **~67** | **~3** |
+
+Chart bump: `0.3.2 → 0.4.0` (minor → minor: API surface unchanged for existing overlays; `oidc.*` block extended; back-compat `keycloak.*` alias preserved per existing chart pattern). Lockstep: `Chart.yaml` + `blueprint.yaml` + bootstrap-kit slot pin.
+
+## Strength — chart already implements many Tier-3 idioms
+
+The bp-wordpress-tenant chart is the canonical reference for Tier-3 SSO patterns in this audit:
+
+- Post-install Job for app-side config (vs assuming app chart natively supports OIDC env vars).
+- Per-tenant Keycloak realm separation (per `configmap-tenant-realm.yaml`).
+- Idempotent `wp-cli` calls (`wp plugin is-installed` before install).
+- Back-compat values alias for orchestrator-emit lag.
+
+Wave-2 SSO agents authoring Langfuse / Temporal / LibreChat / etc. should crib from this chart.

--- a/docs/sessions/2026-06-02-G117-sso-fanout-audit/wave-2-dispatch-recommendations.md
+++ b/docs/sessions/2026-06-02-G117-sso-fanout-audit/wave-2-dispatch-recommendations.md
@@ -1,0 +1,139 @@
+# Wave-2 SSO fan-out — concrete dispatch plan
+
+> Consumes `00-summary.md` of this directory. Aligns with `G117-worktree-policy.md` Wave-2 staging (slot C-N file-touch matrix).
+> Per-slot worktree isolation MANDATORY because every slot touches `platform/<bp>/chart/templates/` AND must serialize against `platform/keycloak/chart/templates/configmap-per-org-realm.yaml` writes from Slot C4.
+
+## Active worklist after audit drops/defers (9 apps)
+
+```
+Tier-2 (3):  bp-guacamole, bp-powerdns-admin, bp-cilium(Hubble UI)
+Tier-3 (5):  bp-matrix, bp-langfuse, bp-temporal, bp-librechat, bp-wordpress-tenant
+Tier-3-API (1): bp-openmeter
+```
+
+## Recommended split — 3 parallel agents (B5/D1, B5/D2, B5/D3 slot scheme)
+
+Sub-agent cap floor 2, ceiling 3 per `feedback_cap_2_3_business_priority_gate.md`. 3 slots used here because:
+
+- All slots are end-user-DoD pillar work (Pillar 4 — Sandbox + auto-mount across all SSO-capable apps; Pillar 1 — Org onboarding into multi-app silent SSO).
+- The 9-app worklist splits cleanly into disjoint chart sets — zero file overlap across slots, no worktree-conflict risk.
+- Slot 4 (Wave-2.C4 KC realm-config) is a serializing prereq, NOT one of these 3 SSO fan-out slots.
+
+### Slot **D1 — Tier-2 small + Tier-3-API** (LOW complexity, fast win)
+
+**Apps:** bp-powerdns-admin, bp-openmeter
+**Why pair:** Both are smallest-LoC, lowest-risk patches. bp-powerdns-admin is +4/-1 (one query-param append + auto-derive default). bp-openmeter is +50/0 (no browser flow, just JWT validation config + service-account AppRegistration). Combined ~55 LoC delta, ~2 chart bumps.
+**Files touched:**
+
+- `platform/powerdns-admin/chart/templates/sso-oauth-source-externalsecret.yaml`
+- `platform/powerdns-admin/chart/values.yaml`
+- `platform/powerdns-admin/chart/Chart.yaml` (0.1.0 → 0.1.1)
+- `platform/powerdns-admin/blueprint.yaml` (version lockstep)
+- `platform/openmeter/chart/templates/sso-app-registration.yaml` (new)
+- `platform/openmeter/chart/values.yaml`
+- `platform/openmeter/chart/Chart.yaml` (1.0.1 → 1.1.0)
+- `platform/openmeter/blueprint.yaml`
+- `clusters/_template/bootstrap-kit/<slot>-powerdns-admin.yaml` + `<slot>-openmeter.yaml` pin bumps
+
+**Estimated PR size:** ~55 lines added, ~1 removed across 9 files.
+**Isolation:** worktree `feat/g117-5-sso-fan-out-d1`.
+**Dependencies:** None hard-blocking — bp-powerdns-admin already integrates with bp-sso-bridge; bp-openmeter is JWT-validation-only.
+**Verifier:** Independent sub-agent runs `helm template` + `helm lint` on both charts; verifies AppRegistration ConfigMap label + Secret references resolve.
+
+### Slot **D2 — Tier-2 medium + Tier-3 GOOD** (MEDIUM complexity, browser-flow stack)
+
+**Apps:** bp-guacamole, bp-librechat, bp-wordpress-tenant
+**Why pair:** bp-librechat + bp-wordpress-tenant are the two Tier-3 charts with full OPENID_* envFrom wiring already in place — small patches needed (~60-70 LoC each). bp-guacamole is the largest Tier-2 patch but its complexity is mostly DELETING the divergent realm-patch ConfigMap (a routine cleanup).
+**Files touched:**
+
+- `platform/guacamole/chart/templates/secret-sso-oidc-credentials.yaml` (new)
+- `platform/guacamole/chart/templates/keycloak-realm-config.yaml` (DELETE)
+- `platform/guacamole/chart/templates/guacamole-deployment.yaml` (kc_idp_hint append)
+- `platform/guacamole/chart/values.yaml` + `Chart.yaml` (0.1.31 → 0.2.0) + `blueprint.yaml`
+- `platform/librechat/chart/templates/sso-externalsecret.yaml` (new)
+- `platform/librechat/chart/templates/sso-app-registration.yaml` (new)
+- `platform/librechat/chart/templates/deployment.yaml` (auto-derive)
+- `platform/librechat/chart/values.yaml` + `Chart.yaml` (1.0.0 → 1.1.0) + `blueprint.yaml`
+- `platform/wordpress-tenant/chart/templates/sso-secret.yaml` (new)
+- `platform/wordpress-tenant/chart/templates/sso-app-registration.yaml` (new)
+- `platform/wordpress-tenant/chart/templates/oidc-config-job.yaml` (kc_idp_hint append)
+- `platform/wordpress-tenant/chart/templates/_helpers.tpl` (auto-derive)
+- `platform/wordpress-tenant/chart/values.yaml` + `Chart.yaml` (0.3.2 → 0.4.0) + `blueprint.yaml`
+- `clusters/_template/bootstrap-kit/<3 slot pin bumps>`
+
+**Estimated PR size:** ~170 added, ~100 removed (the bulk of the removal is bp-guacamole's deleted realm-patch ConfigMap).
+**Isolation:** worktree `feat/g117-5-sso-fan-out-d2`.
+**Dependencies:** Soft — Wave-2.C4 per-Org realm template should land first OR bp-sso-bridge reconciler must be ready to consume AppRegistration ConfigMaps before fresh-prov verification. If C4 not ready, charts still install (chart-side Secret materialization via `lookup`-or-generate covers the gap).
+**Verifier:** Independent sub-agent runs `helm template` on all 3 charts; verifies no rendered Secret leaks plaintext into ConfigMap; checks `helm.sh/resource-policy: keep` annotation present on per-app SSO Secrets.
+
+### Slot **D3 — Tier-2 large + Tier-3 NONE + Tier-3 PARTIAL** (HIGH complexity, biggest patches)
+
+**Apps:** bp-cilium (Hubble UI), bp-langfuse, bp-matrix, bp-temporal
+**Why grouped:** Largest chart edits — bp-cilium is +117/-2 (oauth2-proxy sidecar + Service + Secret + HTTPRoute backendRefs swap). bp-langfuse is +80/0 (full SSO stack from scratch). bp-matrix is +75/-5 (Synapse OIDC providers + 2-hop). bp-temporal is +95/-15 (Web UI OIDC + auto-derive). Together ~370 LoC delta across 4 charts.
+**Files touched:**
+
+- bp-cilium: 4 new templates + httproute patch + values + Chart.yaml (1.3.6 → 1.4.0) + blueprint.yaml
+- bp-langfuse: 2 new templates + values + Chart.yaml (1.0.0 → 1.1.0) + blueprint.yaml
+- bp-matrix: 2 new templates + values (extraConfig + sovereign.fqdn) + Chart.yaml (1.0.1 → 1.1.0) + blueprint.yaml
+- bp-temporal: 2 new templates + keycloak-oidc-config patch + values + Chart.yaml (1.0.1 → 1.1.0) + blueprint.yaml
+- 4 bootstrap-kit slot pin bumps
+
+**Estimated PR size:** ~370 added, ~25 removed across ~25 files.
+**Isolation:** worktree `feat/g117-5-sso-fan-out-d3`.
+**Dependencies:** HARD — bp-cilium oauth2-proxy MUST gate Hubble UI exposure (`catalystOverlay.hubbleUI.enabled=true` already on by default in bootstrap-kit; without oauth2-proxy in front, fresh prov regresses to publicly-accessible Hubble). bp-matrix Synapse needs `client_secret_path` (file, not env) — volume mount must be added. Wave-2.C4 per-Org realm template SHOULD be ready before fresh-prov verification.
+**Verifier:** Independent sub-agent runs `helm template` for each chart with realistic per-Sovereign overlay values; verifies HTTPRoute backendRefs after bp-cilium edit point at oauth2-proxy Service (NOT direct hubble-ui Service); verifies Matrix Synapse Pod spec has a volume mount for `/secrets/oidc/`.
+
+## Serialization & cross-slot contract
+
+- **All 3 slots depend on Wave-2.C4** (`platform/keycloak/chart/templates/configmap-per-org-realm.yaml`) for end-to-end fresh-prov verification, but chart-side `helm template` + lint can proceed without C4 done.
+- **Bootstrap-kit `clusters/_template/bootstrap-kit/kustomization.yaml`** must be touched by EACH slot to pin the updated chart versions. Per Wave-2.C5 staging in `G117-worktree-policy.md`, this serializes AFTER C1+C2+C3+C4. For SSO fan-out, each slot's PR ships its own pin bump; Wave-2.C5 reconciles the total bootstrap-kit update.
+- **GHCR push lock** — per worktree policy, `flock /tmp/ghcr-push.lock` if 2+ slots publish OCI artifacts concurrently. With 3 slots × ~3 charts each (~9 GHCR pushes), serialize via the flock to avoid GHCR rate-limit + race conditions.
+
+## Anti-collision pre-commit hook (recommended)
+
+Per `G117-worktree-policy.md` §"Anti-collision pre-commit hook". Each Wave-2 SSO slot's worktree drops the hook into `.git/hooks/pre-commit`. Refuses to commit if files in the diff overlap with sibling worktree's staged files.
+
+Slot D1 / D2 / D3 chart sets are DISJOINT, so the hook should never fire — but it catches accidental scope creep (e.g. if a slot edits `platform/keycloak/chart/`, the hook surfaces a likely Wave-2.C4 contract breach).
+
+## Pre-dispatch briefing template for each Wave-2 slot
+
+Per `feedback_pre_dispatch_briefing_required.md` 4-line pattern:
+
+```
+DISPATCHING Wave-2 SSO Slot D<N> — <app list>
+PROBLEM:    G117 Wave-2 SSO fan-out — current chart wiring per audit/tier-<N>/<app>.md
+REMEDIATION: ship per-app chart patches per `wave-2-dispatch-recommendations.md` Slot D<N>
+EXPECTED:   PR titled `feat(g117.5): Wave-2 SSO Slot D<N> — <app list>` opens, all charts helm-template green, verifier sub-agent verdict `status/uat-OK` on #2744
+```
+
+## Estimated wall-clock for Wave-2
+
+- D1 (small): ~2-3h agent time
+- D2 (medium): ~4-5h
+- D3 (large): ~6-8h
+- C4 prereq (per-Org realm config): ~3-4h
+- C5 bootstrap-kit pin sweep: ~30 min
+
+If C4 + D1/D2/D3 dispatch in parallel and C4 races to finish first, total wall-clock ~8h. Verifier loop adds ~1-2h per slot. Fresh-prov walk + 9-app silent-SSO verification (Playwright at `tests/e2e/playwright/tests/g117-sso-fanout-tier1-2-3.spec.ts`) adds ~1h.
+
+## Post-merge — verification gate
+
+Per G117 brief Acceptance DoD:
+
+1. PR opens cleanly, `gh pr checks` all green.
+2. Verifier sub-agent verdict posted on #2744.
+3. Fresh-prov walk: PIN-login at `console.<sov>` → dashboard → click Launch on each of the 9 apps → silent SSO (zero password prompts) → screenshot evidence per app.
+4. HAR capture of the 4-hop / 8-hop curl chains per app, attached as PR artifact.
+5. Cross-Org isolation test for the 5 Tier-3 browser-flow apps — Org-A user MUST NOT auth into Org-B's app instance.
+
+## Open follow-ups (fresh sub-EPIC numbers)
+
+| Sub-EPIC | Topic | Source |
+|---|---|---|
+| G118.1 | bp-opensearch chart authorship (currently scaffold-only) | `tier-3/bp-opensearch.md` |
+| G118.2 | bp-iceberg chart authorship (currently scaffold-only) — pick Polaris vs REST-only | `tier-3/bp-iceberg.md` |
+| G118.3 | bp-litmus full SSO wrapper (needs ChaosCenter frontend or oauth2-proxy fronting) | `tier-3/bp-litmus.md` |
+| G117.X | bp-sigstore — remove from G117.5 Tier-2 (no UI); update audit doc row 79 | `tier-2/bp-sigstore.md` |
+| G117.X | Per-Org realm naming — harmonize `sme-<subdomain>` → `org-<slug>` (back-compat alias period) | `tier-3/bp-wordpress-tenant.md` |
+
+These are noted, NOT pre-filed per `feedback_amnesia_antipatterns_2026_05_20.md` L8 ("Filing N TBDs while DoD = 0/5 = open-count inflation"). Open them when Wave-2 ships green AND a maintainer is ready to pick them up.


### PR DESCRIPTION
## Refs #2744 · Refs EPIC #2737

G117.5 Aux-2 dispatch — read-only audit of every Tier-2 + Tier-3 SSO-capable blueprint chart. Produces a per-app patch plan Wave-2's SSO fan-out agents will execute. Zero chart changes — docs-only.

## Deliverables

`docs/sessions/2026-06-02-G117-sso-fanout-audit/`:
- `00-summary.md` — rollup + total Wave-2 chart-patch size estimate (~+459 LoC net across 9 active apps after drops)
- `wave-2-dispatch-recommendations.md` — concrete 3-slot parallel-agent dispatch plan (D1 small / D2 medium / D3 large) sized 55/170/370 LoC each
- `tier-2/<app>.md` × 4 (bp-guacamole, bp-powerdns-admin, bp-cilium [Hubble UI], bp-sigstore)
- `tier-3/<app>.md` × 9 (bp-matrix, bp-langfuse, bp-temporal, bp-librechat, bp-opensearch, bp-openmeter, bp-litmus, bp-wordpress-tenant, bp-iceberg)

## Summary findings

| Verdict | Count | Apps |
|---|---|---|
| GOOD / BEST | 3 | bp-powerdns-admin, bp-librechat, bp-wordpress-tenant |
| PARTIAL | 3 | bp-guacamole, bp-matrix, bp-temporal |
| SCAFFOLD-ONLY (real enforcement absent) | 1 | bp-cilium (Hubble UI) |
| NONE (full SSO stack to author) | 2 | bp-langfuse, bp-openmeter (API-only) |
| DROP — no UI | 1 | bp-sigstore |
| DROP — chart does not exist | 2 | bp-opensearch, bp-iceberg |
| DEFER — upstream weak | 1 | bp-litmus |

Wave-2 active worklist drops 13 → 9 apps.

## Each per-app file has

- Current SSO state with file:line references to the existing chart wiring
- Required Wave-2 chart-patch plan (new templates / values edits with concrete YAML samples)
- 4-hop (Tier-2) or 8-hop (Tier-3) curl verification probe with expected HTTP codes
- Cross-Org isolation test (Tier-3 only) per locked decision #6
- Chart-patch size estimate + chart bump version + lockstep callouts

## Anti-theater red-flags surfaced

1. `bp-cilium` Hubble UI `auth: oidc` annotation is decorative (chart admits the gap at `hubble-ui-httproute.yaml:27-33`); Wave-2 MUST not perpetuate gate-without-enforcement
2. `bp-guacamole` divergent realm-patch ConfigMap targets dead `catalyst` realm; DELETE not patch-around
3. `bp-sigstore` listed in brief without a UI — escalate brief mismatch
4. `bp-opensearch` / `bp-iceberg` charts don't exist; topology audit row is aspirational
5. `bp-litmus` upstream OIDC is experimental + needs frontend rebuild — don't ship partial wiring

## Test plan

- [x] All 15 files commit cleanly; `gh pr checks` should pass docs-only gates (markdown lint, link check)
- [ ] Wave-2 SSO agents read this audit before dispatch; per-slot briefs cite `docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-N/<app>.md`
- [ ] Verifier sub-agent reviews this PR for completeness — 13 per-app files + summary + dispatch recs all present
- [ ] Independent verifier verdict posted on #2744 per G117 brief Self-verification protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)