### PR TITLE
feat(charts): G117.5 Tier-3 SSO codification Part 1 (matrix + langfuse + temporal + librechat)

### DIFF
--- a/clusters/omantel.omani.works/bootstrap-kit/26-langfuse.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/26-langfuse.yaml
@@ -69,7 +69,7 @@ spec:
   chart:
     spec:
       chart: bp-langfuse
-      version: 1.0.0
+      version: 1.1.0
       sourceRef:
         kind: HelmRepository
         name: bp-langfuse

--- a/clusters/otech.omani.works/bootstrap-kit/26-langfuse.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/26-langfuse.yaml
@@ -69,7 +69,7 @@ spec:
   chart:
     spec:
       chart: bp-langfuse
-      version: 1.0.0
+      version: 1.1.0
       sourceRef:
         kind: HelmRepository
         name: bp-langfuse

--- a/platform/langfuse/blueprint.yaml
+++ b/platform/langfuse/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-observability
 spec:
-  version: 1.0.0
+  version: 1.1.0
   card:
     title: Langfuse
     family: insights

--- a/platform/langfuse/chart/Chart.yaml
+++ b/platform/langfuse/chart/Chart.yaml
@@ -34,7 +34,7 @@ description: |
   All four bundled deploys are disabled by default; per-Sovereign overlays
   wire the external endpoints + Secret references.
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "3.171.0"
 keywords: [catalyst, blueprint, langfuse, observability, llm, ai]
 maintainers:

--- a/platform/langfuse/chart/templates/sso-app-registration.yaml
+++ b/platform/langfuse/chart/templates/sso-app-registration.yaml
@@ -1,0 +1,48 @@
+{{- /*
+G117.5 W3.D2 (#2744) — Langfuse AppRegistration ConfigMap.
+
+bp-sso-bridge reconciler watches ConfigMaps labelled
+`sso.openova.io/app-registration=<client-id>` and mints the matching
+OIDC client in the per-Org Keycloak realm (named by `org.slug`) at
+Application install time. The client's `client_secret` is PUT to
+OpenBao at `secret/sso/<org-slug>/langfuse` where the companion
+ExternalSecret (sso-externalsecret.yaml) reads it.
+
+Redirect URI matches the bp-langfuse blueprint.yaml endpoint hostname
+template `langfuse.{{`{{`}}.OrgSlug{{`}}`}}.{{`{{`}}.SovereignFQDN{{`}}`}}`
++ NextAuth's canonical Keycloak callback path
+`/api/auth/callback/keycloak`.
+*/ -}}
+{{- /*
+Rendered only when oidc.enabled=true AND org.slug + sovereign.fqdn +
+oidc.realm are all set. Default smoke-renders skip cleanly.
+*/ -}}
+{{- if and .Values.oidc.enabled .Values.org.slug .Values.sovereign.fqdn .Values.oidc.realm }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bp-langfuse-sso-registration
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-langfuse
+    sso.openova.io/app-registration: langfuse
+    catalyst.openova.io/org-slug: {{ .Values.org.slug | quote }}
+data:
+  realm: {{ .Values.oidc.realm | quote }}
+  client.json: |
+    {
+      "clientId": {{ .Values.oidc.clientId | default "langfuse" | quote }},
+      "name": "Langfuse ({{ .Values.org.slug }})",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "redirectUris": [
+        "https://langfuse.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}/api/auth/callback/keycloak"
+      ],
+      "webOrigins": [
+        "https://langfuse.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}"
+      ],
+      "defaultClientScopes": ["web-origins", "profile", "email", "groups"]
+    }
+{{- end }}

--- a/platform/langfuse/chart/templates/sso-externalsecret.yaml
+++ b/platform/langfuse/chart/templates/sso-externalsecret.yaml
@@ -1,0 +1,58 @@
+{{- /*
+G117.5 W3.D2 (#2744) — Langfuse OIDC client credentials Secret.
+
+bp-sso-bridge mints the per-Org realm client `langfuse` at App install
+time and PUTs the canonical bundle to OpenBao at
+`secret/sso/<org-slug>/langfuse`. This ExternalSecret materialises it
+as `langfuse-sso-oidc-credentials` and shapes the keys to the
+NextAuth Keycloak provider env-var names Langfuse 3.x reads
+(`AUTH_KEYCLOAK_*`) plus the `NEXTAUTH_URL` needed for callback host
+derivation. Langfuse `langfuse.langfuse.additionalEnv[]` references
+this Secret with `optional: true` so the chart installs cleanly even
+before bp-sso-bridge has reconciled the per-Org realm.
+
+next-auth derives `authorization_endpoint` from issuer discovery
+(`.well-known/openid-configuration`), so per-request `kc_idp_hint`
+cannot be appended client-side. Silent 2-hop SSO depends on the per-Org
+realm's Identity Provider Redirector having
+`defaultProvider=sovereign-broker` bound (bp-keycloak W2.C4 PR #2794).
+*/ -}}
+{{- /*
+Rendered only when oidc.enabled=true AND oidc.realm + sovereign.fqdn +
+org.slug are all set — bp-sso-bridge needs all three to mint the Org's
+KC client. Default smoke-renders (empty paths) skip cleanly.
+*/ -}}
+{{- if and .Values.oidc.enabled .Values.oidc.realm .Values.sovereign.fqdn .Values.org.slug }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: langfuse-sso-oidc-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-langfuse
+    bp-sso-bridge.openova.io/consumer: bp-langfuse
+spec:
+  refreshInterval: {{ .Values.oidc.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ .Values.oidc.externalSecretStoreName | default "vault-region1" }}
+    kind: ClusterSecretStore
+  target:
+    name: langfuse-sso-oidc-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        # NextAuth Keycloak provider env-var names (langfuse 3.x reads these).
+        AUTH_KEYCLOAK_ISSUER:                     "https://auth.{{ .Values.sovereign.fqdn }}/realms/{{ .Values.oidc.realm }}"
+        AUTH_KEYCLOAK_CLIENT_ID:                  {{ .Values.oidc.clientId | default "langfuse" | quote }}
+        AUTH_KEYCLOAK_CLIENT_SECRET:              "{{ "{{ .client_secret }}" }}"
+        AUTH_KEYCLOAK_REQUIRE_EMAIL_VERIFICATION: "true"
+        AUTH_KEYCLOAK_ALLOW_ACCOUNT_LINKING:      "true"
+        # next-auth NEXTAUTH_URL — required for callback host derivation.
+        NEXTAUTH_URL:                             "https://langfuse.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}"
+  data:
+    - secretKey: client_secret
+      remoteRef:
+        key: sso/{{ .Values.oidc.realm }}/{{ .Values.oidc.clientId | default "langfuse" }}
+        property: client_secret
+{{- end }}

--- a/platform/langfuse/chart/values.yaml
+++ b/platform/langfuse/chart/values.yaml
@@ -75,6 +75,49 @@ langfuse:
     serviceAccount:
       create: true
 
+    # ─── G117.5 (W3.D2 #2744) Tier-3 SSO — env from per-app Secret ─────
+    # next-auth Keycloak provider reads AUTH_KEYCLOAK_* env vars at
+    # process start; sourcing them via secretKeyRef with `optional: true`
+    # keeps the Pod installable on a fresh Sovereign before bp-sso-bridge
+    # has reconciled the per-Org realm + minted the langfuse client.
+    additionalEnv:
+      - name: AUTH_KEYCLOAK_ISSUER
+        valueFrom:
+          secretKeyRef:
+            name: langfuse-sso-oidc-credentials
+            key: AUTH_KEYCLOAK_ISSUER
+            optional: true
+      - name: AUTH_KEYCLOAK_CLIENT_ID
+        valueFrom:
+          secretKeyRef:
+            name: langfuse-sso-oidc-credentials
+            key: AUTH_KEYCLOAK_CLIENT_ID
+            optional: true
+      - name: AUTH_KEYCLOAK_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: langfuse-sso-oidc-credentials
+            key: AUTH_KEYCLOAK_CLIENT_SECRET
+            optional: true
+      - name: AUTH_KEYCLOAK_REQUIRE_EMAIL_VERIFICATION
+        valueFrom:
+          secretKeyRef:
+            name: langfuse-sso-oidc-credentials
+            key: AUTH_KEYCLOAK_REQUIRE_EMAIL_VERIFICATION
+            optional: true
+      - name: AUTH_KEYCLOAK_ALLOW_ACCOUNT_LINKING
+        valueFrom:
+          secretKeyRef:
+            name: langfuse-sso-oidc-credentials
+            key: AUTH_KEYCLOAK_ALLOW_ACCOUNT_LINKING
+            optional: true
+      - name: NEXTAUTH_URL
+        valueFrom:
+          secretKeyRef:
+            name: langfuse-sso-oidc-credentials
+            key: NEXTAUTH_URL
+            optional: true
+
   # PostgreSQL — Catalyst routes via cnpg.io/Cluster (bp-cnpg). The
   # bundled Bitnami subchart is OFF; per-Sovereign overlays MUST set
   # `postgresql.host` to the cnpg `<cluster>-rw` Service and reference a
@@ -160,3 +203,31 @@ langfuseOverlay:
       size: 20Gi
   networkPolicy:
     enabled: false
+
+# ─── G117.5 (W3.D2 #2744) Tier-3 SSO — per-Org realm wiring ──────────────
+# Catalyst Organization slug + Sovereign FQDN drive the per-Org realm
+# name + AppRegistration ConfigMap + NEXTAUTH_URL host derivation.
+# application-controller materialises these from the Org + Sovereign at
+# Application install time; values shown are placeholders so `helm
+# template` smoke-renders cleanly without `--set`.
+org:
+  slug: ""                              # e.g. "acme" — Org slug (also = per-Org KC realm name)
+sovereign:
+  fqdn: ""                              # e.g. "openova.example.com" (per-Sovereign overlay)
+
+# Catalyst-side OIDC config — materialised as a per-app ExternalSecret +
+# AppRegistration ConfigMap consumed by bp-sso-bridge; Langfuse 3.x
+# next-auth Keycloak provider reads AUTH_KEYCLOAK_* env vars from the
+# Secret via `langfuse.langfuse.additionalEnv[]` (see block below).
+#
+# Silent 2-hop SSO (per-Org realm → sovereign realm broker → catalyst-
+# pin) requires the per-Org realm's Identity Provider Redirector to have
+# `defaultProvider=sovereign-broker` bound — shipped by bp-keycloak
+# W2.C4 PR #2794. next-auth derives authorize/token URLs from issuer
+# discovery; per-request kc_idp_hint is a no-op here.
+oidc:
+  enabled: false                        # default OFF until per-Org realm exists
+  realm: ""                             # operator-supplied or = .Values.org.slug
+  clientId: "langfuse"
+  externalSecretStoreName: "vault-region1"
+  refreshInterval: "1h"

--- a/platform/librechat/blueprint.yaml
+++ b/platform/librechat/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: application
     catalyst.openova.io/section: pts-4-7-application-tier-chat-ui
 spec:
-  version: 1.0.0
+  version: 1.1.0
   card:
     title: LibreChat
     summary: |

--- a/platform/librechat/chart/Chart.yaml
+++ b/platform/librechat/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-librechat
-version: 1.0.0
+version: 1.1.0
 appVersion: "0.7.5"
 description: |
   Catalyst Blueprint scratch chart for LibreChat — multi-LLM chat UI.

--- a/platform/librechat/chart/templates/deployment.yaml
+++ b/platform/librechat/chart/templates/deployment.yaml
@@ -133,8 +133,15 @@ spec:
               value: {{ .Values.keycloak.allowSocialLogin | quote }}
             - name: ALLOW_SOCIAL_REGISTRATION
               value: {{ .Values.keycloak.allowSocialRegistration | quote }}
+            # G117.5 W3.D2 (#2744): auto-derive OPENID_ISSUER from
+            # sovereign.fqdn + org.realm when keycloak.issuer is empty.
+            # Falls back to the literal `keycloak.issuer` if pre-set.
+            {{- $issuer := .Values.keycloak.issuer -}}
+            {{- if and (not $issuer) .Values.sovereign.fqdn .Values.org.realm -}}
+              {{- $issuer = printf "https://auth.%s/realms/%s" .Values.sovereign.fqdn .Values.org.realm -}}
+            {{- end }}
             - name: OPENID_ISSUER
-              value: {{ .Values.keycloak.issuer | quote }}
+              value: {{ $issuer | quote }}
             - name: OPENID_CLIENT_ID
               value: {{ .Values.keycloak.clientId | quote }}
             - name: OPENID_SCOPE

--- a/platform/librechat/chart/templates/sso-app-registration.yaml
+++ b/platform/librechat/chart/templates/sso-app-registration.yaml
@@ -1,0 +1,50 @@
+{{- /*
+G117.5 W3.D2 (#2744) — LibreChat AppRegistration ConfigMap.
+
+bp-sso-bridge reconciler watches ConfigMaps labelled
+`sso.openova.io/app-registration=<client-id>` and mints the matching
+OIDC client in the per-Org Keycloak realm (named by `org.realm`, which
+defaults to the Org slug per bp-keycloak's `tenantRealms[].slug`
+convention) at Application install time. The client's `client_secret`
++ `session_secret` are PUT to OpenBao at
+`secret/sso/<org-slug>/librechat` where the companion ExternalSecret
+(sso-externalsecret.yaml) reads them.
+
+Redirect URI matches the bp-librechat blueprint.yaml endpoint hostname
+template `chat.{{`{{`}}.OrgSlug{{`}}`}}.{{`{{`}}.SovereignFQDN{{`}}`}}`
++ LibreChat's canonical OIDC callback path
+`/oauth/openid/callback` (matches `.Values.keycloak.callbackPath`).
+*/ -}}
+{{- /*
+Rendered only when keycloak.enabled=true AND org.slug + org.realm +
+sovereign.fqdn are all set. Default smoke-renders skip cleanly.
+*/ -}}
+{{- if and .Values.keycloak.enabled .Values.org.slug .Values.org.realm .Values.sovereign.fqdn }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bp-librechat-sso-registration
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-librechat
+    sso.openova.io/app-registration: librechat
+    catalyst.openova.io/org-slug: {{ .Values.org.slug | quote }}
+data:
+  realm: {{ .Values.org.realm | quote }}
+  client.json: |
+    {
+      "clientId": {{ .Values.keycloak.clientId | default "librechat" | quote }},
+      "name": "LibreChat ({{ .Values.org.slug }})",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "redirectUris": [
+        "https://chat.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}{{ .Values.keycloak.callbackPath | default "/oauth/openid/callback" }}"
+      ],
+      "webOrigins": [
+        "https://chat.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}"
+      ],
+      "defaultClientScopes": ["web-origins", "openid", "profile", "email", "groups"]
+    }
+{{- end }}

--- a/platform/librechat/chart/templates/sso-externalsecret.yaml
+++ b/platform/librechat/chart/templates/sso-externalsecret.yaml
@@ -1,0 +1,59 @@
+{{- /*
+G117.5 W3.D2 (#2744) — LibreChat OIDC client credentials Secret.
+
+bp-sso-bridge mints the per-Org realm client `librechat` at App install
+time and PUTs the canonical bundle to OpenBao at
+`secret/sso/<org-slug>/librechat`. This ExternalSecret materialises it
+as `librechat-oidc` with the two keys the LibreChat Deployment
+references via secretKeyRef: `OPENID_CLIENT_SECRET` (the OIDC client
+secret minted by KC) and `OPENID_SESSION_SECRET` (a distinct 32-byte
+session token persisted by bp-sso-bridge alongside the client secret).
+
+The keys `OPENID_CLIENT_SECRET` + `OPENID_SESSION_SECRET` match the
+existing references in templates/deployment.yaml so flipping
+`keycloak.existingSecret` to `librechat-oidc` (the new default) lets
+the Deployment env wire straight through.
+
+Silent 2-hop SSO (per-Org realm → sovereign realm broker → catalyst-
+pin) requires the per-Org realm's Identity Provider Redirector to have
+`defaultProvider=sovereign-broker` bound — shipped by bp-keycloak
+W2.C4 PR #2794. LibreChat (openid-client npm package) derives
+authorize/token URLs from issuer discovery; per-request kc_idp_hint is
+a no-op here.
+*/ -}}
+{{- /*
+Rendered only when keycloak.enabled=true AND org.realm is set. Default
+smoke-renders (empty org.realm) skip cleanly.
+*/ -}}
+{{- if and .Values.keycloak.enabled .Values.org.realm }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: librechat-oidc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-librechat
+    bp-sso-bridge.openova.io/consumer: bp-librechat
+spec:
+  refreshInterval: {{ .Values.keycloak.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ .Values.keycloak.externalSecretStoreName | default "vault-region1" }}
+    kind: ClusterSecretStore
+  target:
+    name: librechat-oidc
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        OPENID_CLIENT_SECRET:  "{{ "{{ .client_secret }}" }}"
+        OPENID_SESSION_SECRET: "{{ "{{ .session_secret }}" }}"
+  data:
+    - secretKey: client_secret
+      remoteRef:
+        key: sso/{{ .Values.org.realm }}/{{ .Values.keycloak.clientId | default "librechat" }}
+        property: client_secret
+    - secretKey: session_secret
+      remoteRef:
+        key: sso/{{ .Values.org.realm }}/{{ .Values.keycloak.clientId | default "librechat" }}
+        property: session_secret
+{{- end }}

--- a/platform/librechat/chart/values.yaml
+++ b/platform/librechat/chart/values.yaml
@@ -15,6 +15,22 @@ catalystBlueprint:
     images:
       librechat: "ghcr.io/danny-avila/librechat"
 
+# ─── G117.5 (W3.D2 #2744) Tier-3 SSO — per-Org realm wiring ──────────────
+# Catalyst Organization slug + realm name + Sovereign FQDN drive the
+# AppRegistration ConfigMap, the per-app ExternalSecret OpenBao path,
+# and the auto-derived `OPENID_ISSUER` env var. application-controller
+# materialises these from the Org + Sovereign at Application install
+# time; values shown are placeholders so `helm template` smoke-renders
+# cleanly without `--set`.
+org:
+  slug: ""                              # e.g. "acme" — Org slug (also Subdomain segment)
+  # Per-Org KC realm name — defaults to the Org slug (matches bp-keycloak
+  # `tenantRealms[].slug` becoming the realm name). Operator may override
+  # for non-standard realm naming.
+  realm: ""
+sovereign:
+  fqdn: ""                              # e.g. "openova.example.com" (per-Sovereign overlay)
+
 # ─── LibreChat application ───────────────────────────────────────────────
 librechat:
   enabled: true
@@ -113,20 +129,34 @@ embeddings:
 
 # ─── Keycloak OIDC SSO ───────────────────────────────────────────────────
 # LibreChat speaks the standard OpenID Connect protocol — point at a
-# Keycloak realm. Issuer/clientId/clientSecret are operator-supplied via
-# ExternalSecret; nothing is hardcoded.
+# Keycloak realm. The G117.5 W3.D2 (#2744) Tier-3 SSO pattern wires
+# LibreChat to a per-Org KC realm (named by `.Values.org.realm`, which
+# defaults to `.Values.org.slug`); the realm's Identity Provider
+# Redirector (`defaultProvider=sovereign-broker`, bp-keycloak W2.C4
+# PR #2794) auto-delegates to the sovereign realm broker → catalyst-pin
+# for silent SSO.
 keycloak:
   enabled: true
-  issuer: ""                      # e.g. "https://keycloak.<loc>.<sovereign>/realms/<org>"
+  # G117.5 W3.D2 (#2744): issuer auto-derives from `sovereign.fqdn` +
+  # `org.realm` when empty — drop operator burden of pasting the URL.
+  # Per-Sovereign overlay can still pin an explicit issuer for non-
+  # standard topologies. Auto = https://auth.<sovereign.fqdn>/realms/<org.realm>
+  issuer: ""
   clientId: "librechat"
-  scope: "openid profile email"
+  scope: "openid profile email groups"
   callbackPath: "/oauth/openid/callback"
-  buttonLabel: "Sign in with Keycloak"
-  # ExternalSecret carrying client secret + (optional) session secret.
-  # Required keys: OPENID_CLIENT_SECRET, OPENID_SESSION_SECRET.
-  existingSecret: ""              # e.g. "librechat-oidc"
+  buttonLabel: "Sign in with Catalyst"
+  # ExternalSecret carrying client secret + session secret. The chart-
+  # rendered ExternalSecret (sso-externalsecret.yaml) defaults to
+  # `librechat-oidc`. Operators may override to keep legacy Secret
+  # names. Required keys: OPENID_CLIENT_SECRET, OPENID_SESSION_SECRET.
+  existingSecret: "librechat-oidc"
   allowSocialLogin: true
   allowSocialRegistration: true
+  # G117.5 W3.D2 (#2744): per-app ExternalSecret store + refresh cadence.
+  # Defaults match the platform-wide bp-openbao store.
+  externalSecretStoreName: "vault-region1"
+  refreshInterval: "1h"
 
 # ─── App credentials (LibreChat-internal) ────────────────────────────────
 # CREDS_KEY (32-byte hex), CREDS_IV (16-byte hex), JWT_SECRET, and

--- a/platform/matrix/blueprint.yaml
+++ b/platform/matrix/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: application
     catalyst.openova.io/section: pts-4-5-communication
 spec:
-  version: 1.0.1
+  version: 1.1.0
   card:
     title: Matrix (Synapse)
     summary: |

--- a/platform/matrix/chart/Chart.yaml
+++ b/platform/matrix/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-matrix
-version: 1.0.1
+version: 1.1.0
 appVersion: "1.151.0"
 description: |
   Catalyst Blueprint umbrella chart for Synapse — the reference Matrix

--- a/platform/matrix/chart/templates/sso-app-registration.yaml
+++ b/platform/matrix/chart/templates/sso-app-registration.yaml
@@ -1,0 +1,57 @@
+{{- /*
+G117.5 W3.D2 (#2744) — Matrix Synapse AppRegistration ConfigMap.
+
+bp-sso-bridge reconciler watches ConfigMaps labelled
+`sso.openova.io/app-registration=<client-id>` and mints the matching
+OIDC client in the per-Org Keycloak realm (named by `org.slug`) at
+Application install time. The client's `client_secret` is then PUT to
+OpenBao at `secret/sso/<org-slug>/matrix-synapse` where the companion
+ExternalSecret (sso-externalsecret.yaml) reads it.
+
+The realm name is the Org slug (lower-case alnum + hyphens; matches the
+realm-name convention emitted by bp-keycloak's
+configmap-per-org-realms.yaml — `tenantRealms[].slug` becomes the
+realm).
+
+Redirect URI matches the bp-matrix blueprint.yaml endpoint hostname
+template (matrix.{{`{{`}}.OrgSlug{{`}}`}}.{{`{{`}}.SovereignFQDN{{`}}`}})
++ Synapse's canonical OIDC callback path
+`/_synapse/client/oidc/callback`.
+*/ -}}
+{{- /*
+Rendered only when oidc.enabled=true AND org.slug + sovereign.fqdn +
+oidc.realm are all set — bp-sso-bridge needs all three to mint the
+Org's KC client. Default smoke-renders (empty paths) skip cleanly.
+*/ -}}
+{{- if and .Values.oidc.enabled .Values.org.slug .Values.sovereign.fqdn .Values.oidc.realm }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bp-matrix-sso-registration
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-matrix
+    sso.openova.io/app-registration: matrix-synapse
+    catalyst.openova.io/org-slug: {{ .Values.org.slug | quote }}
+data:
+  realm: {{ .Values.oidc.realm | quote }}
+  client.json: |
+    {
+      "clientId": {{ .Values.oidc.clientId | default "matrix-synapse" | quote }},
+      "name": "Matrix Synapse ({{ .Values.org.slug }})",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "redirectUris": [
+        "https://matrix.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}/_synapse/client/oidc/callback"
+      ],
+      "webOrigins": [
+        "https://matrix.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}"
+      ],
+      "defaultClientScopes": ["web-origins", "profile", "email", "groups"],
+      "attributes": {
+        "access.token.lifespan": "900"
+      }
+    }
+{{- end }}

--- a/platform/matrix/chart/templates/sso-externalsecret.yaml
+++ b/platform/matrix/chart/templates/sso-externalsecret.yaml
@@ -1,0 +1,55 @@
+{{- /*
+G117.5 W3.D2 (#2744) — Matrix Synapse OIDC client credentials Secret.
+
+bp-sso-bridge mints the per-Org realm client `matrix-synapse` at App
+install time and PUTs the canonical bundle to OpenBao at
+`secret/sso/<org-slug>/matrix-synapse`. This ExternalSecret materialises
+it as `matrix-oidc-credentials` so the Synapse Pod can mount the
+`OIDC_CLIENT_SECRET` key as a file at `/secrets/oidc/OIDC_CLIENT_SECRET`
+(Synapse 1.151+ requires `client_secret_path`, NOT `client_secret`).
+
+Per the audit (docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/
+bp-matrix.md §Gotchas), the Secret MUST be MOUNTED as a file, not
+exposed via envFrom — the per-Sovereign overlay wires the volume mount
+on the upstream matrix-synapse subchart's Pod spec.
+
+The 2-hop federation chain (per-Org realm → sovereign realm broker →
+catalyst-pin) is driven by the per-Org realm's Identity Provider
+Redirector defaultProvider config (shipped by bp-keycloak W2.C4
+PR #2794) — NO query-param injection needed here.
+*/ -}}
+{{- /*
+Rendered only when oidc.enabled=true AND oidc.realm is set — the per-Org
+realm name is the OpenBao key segment, so without it the ExternalSecret
+would point at an unresolvable path. application-controller materialises
+oidc.realm from the Org slug at App install time; default smoke-renders
+(empty oidc.realm) skip this resource cleanly.
+*/ -}}
+{{- if and .Values.oidc.enabled .Values.oidc.realm }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: matrix-oidc-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-matrix
+    bp-sso-bridge.openova.io/consumer: bp-matrix
+spec:
+  refreshInterval: {{ .Values.oidc.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ .Values.oidc.externalSecretStoreName | default "vault-region1" }}
+    kind: ClusterSecretStore
+  target:
+    name: matrix-oidc-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        # Synapse 1.151+ reads the secret via client_secret_path (file mount).
+        OIDC_CLIENT_SECRET: "{{ "{{ .client_secret }}" }}"
+  data:
+    - secretKey: client_secret
+      remoteRef:
+        key: sso/{{ .Values.oidc.realm }}/{{ .Values.oidc.clientId | default "matrix-synapse" }}
+        property: client_secret
+{{- end }}

--- a/platform/matrix/chart/values.yaml
+++ b/platform/matrix/chart/values.yaml
@@ -63,6 +63,33 @@ matrix-synapse:
     # accounts (registration handled in Keycloak).
     enable_registration: false
     enable_registration_without_verification: false
+    # ─── G117.5 (W3.D2 #2744) Tier-3 SSO — oidc_providers[] ────────────
+    # Empty by default; the per-Sovereign overlay (application-controller
+    # materialises this from the Org slug + Sovereign FQDN at App install
+    # time) appends a single oidc_providers entry of the shape:
+    #
+    #   oidc_providers:
+    #     - idp_id: catalyst-pin
+    #       idp_name: "Catalyst Sign-In"
+    #       issuer: "https://auth.<sov-fqdn>/realms/<org-slug>"
+    #       client_id: matrix-synapse
+    #       client_secret_path: /secrets/oidc/OIDC_CLIENT_SECRET
+    #       scopes: ["openid", "profile", "email", "groups"]
+    #       user_mapping_provider:
+    #         config:
+    #           localpart_template: "{{ user.preferred_username }}"
+    #           display_name_template: "{{ user.name }}"
+    #           email_template: "{{ user.email }}"
+    #
+    # Synapse derives authorization_endpoint/token_endpoint via discovery
+    # at .well-known/openid-configuration on the issuer; the per-Org KC
+    # realm's Identity Provider Redirector with
+    # defaultProvider=sovereign-broker (bp-keycloak W2.C4 PR #2794)
+    # auto-delegates to the sovereign realm broker → catalyst-pin without
+    # requiring kc_idp_hint in the URL. See
+    # docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/bp-matrix.md
+    # §2-hop verification curl chain for the full 8-hop probe.
+    oidc_providers: []
 
   # ─── Postgres backend — bp-cnpg (external) ─────────────────────────────
   # Disable the bundled bitnami/postgresql; route Synapse at the bp-cnpg
@@ -152,20 +179,52 @@ matrix-synapse:
 # ─── Catalyst-overlay knobs (consumed by templates/ in this chart) ───────
 # All DEFAULT OFF per docs/BLUEPRINT-AUTHORING.md §11.2.
 
-# Catalyst-side OIDC config — applied via the upstream chart's
-# `extraConfig.oidc_providers` block at install time. Operator's
-# per-Sovereign overlay supplies the actual issuer URL + ExternalSecret
-# holding the client secret. Default OFF until operator wires Keycloak.
+# ─── G117.5 (W3.D2 #2744) Tier-3 SSO — per-Org realm wiring ──────────────
+# Catalyst Organization slug + Sovereign FQDN drive the per-Org realm
+# name, AppRegistration ConfigMap, and the Synapse OIDC callback URL.
+# application-controller materialises these from the Org + Sovereign at
+# Application install time; values shown are placeholders so `helm
+# template` smoke-renders cleanly without `--set`.
+org:
+  slug: ""                              # e.g. "acme" — Org slug (also = per-Org KC realm name)
+sovereign:
+  fqdn: ""                              # e.g. "openova.example.com" (per-Sovereign overlay)
+
+# Catalyst-side OIDC config — emitted into the upstream matrix-synapse
+# subchart's `extraConfig.oidc_providers[]` block + materialised as a
+# per-app ExternalSecret + AppRegistration ConfigMap consumed by
+# bp-sso-bridge.
+#
+# 2-hop federation (per-Org realm → sovereign realm broker → catalyst-pin)
+# is driven by per-Org realm Identity Provider Redirector defaultProvider
+# config emitted by bp-keycloak (W2.C4 PR #2794) — no per-request
+# kc_idp_hint needed; Synapse derives authorize/token URLs from issuer
+# discovery.
 oidc:
   enabled: true
-  idpId: "keycloak"
-  idpName: "Keycloak"
-  issuer: ""                            # operator-supplied (e.g. https://keycloak.<loc>.<sovereign-domain>/realms/<org>)
+  idpId: "catalyst-pin"                 # Synapse-side providers[].idp_id (collision-free vs legacy "keycloak")
+  idpName: "Catalyst Sign-In"
+  # Per-Org realm name — defaults to the Org slug. The audit (bp-matrix.md
+  # §Per-Org realm) locks each Org to its own KC realm named after the
+  # slug; bp-keycloak's configmap-per-org-realms.yaml emits a realm with
+  # `realm: <slug>` for each tenantRealms entry.
+  realm: ""                             # operator-supplied or = .Values.org.slug
   clientId: "matrix-synapse"
-  scopes: ["openid", "profile", "email"]
-  # ExternalSecret name carrying client_secret. Required key:
-  # OIDC_CLIENT_SECRET. Operator-supplied.
-  existingSecret: ""                    # e.g. "matrix-oidc-credentials"
+  scopes: ["openid", "profile", "email", "groups"]
+  # Per-Sovereign overlay may override the ClusterSecretStore name +
+  # refresh interval. Defaults match the platform-wide bp-openbao store.
+  externalSecretStoreName: "vault-region1"
+  refreshInterval: "1h"
+  # ExternalSecret name carrying client_secret. The chart-rendered
+  # ExternalSecret (sso-externalsecret.yaml) defaults to
+  # `matrix-oidc-credentials`; operators may override here to keep
+  # legacy Secret names.
+  existingSecret: "matrix-oidc-credentials"
+  # Secret mount path — Synapse 1.151+ requires `client_secret_path`
+  # (file), NOT `client_secret` (string). Per-Sovereign overlay wires a
+  # volume mount on the synapse Pod that exposes the Secret key at this
+  # path.
+  clientSecretMountPath: "/secrets/oidc"
 
 # Federation toggle — Catalyst-overlay marker. The actual federation
 # behaviour is gated by upstream chart values + the homeserver.yaml

--- a/platform/temporal/blueprint.yaml
+++ b/platform/temporal/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-4-3-workflow-and-processing
 spec:
-  version: 1.0.1
+  version: 1.1.0
   card:
     title: Temporal
     summary: Durable workflow orchestration with saga + compensation. Postgres-backed (CNPG); Postgres visibility store; Web UI; Keycloak OIDC integration via `--auth-claim-mapper`.

--- a/platform/temporal/chart/Chart.yaml
+++ b/platform/temporal/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-temporal
-version: 1.0.1
+version: 1.1.0
 appVersion: "1.31.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for Temporal — durable

--- a/platform/temporal/chart/templates/keycloak-oidc-config.yaml
+++ b/platform/temporal/chart/templates/keycloak-oidc-config.yaml
@@ -12,8 +12,22 @@ bp-keycloak is reconciled. Keeping it off by default keeps the chart
 installable on a fresh Sovereign before the IDP tier is up
 (docs/BLUEPRINT-AUTHORING.md §11.2 spirit — every cross-tier dependency
 defaults off).
+
+G117.5 W3.D2 (#2744): issuer + jwksUri auto-derive from
+`.Values.sovereign.fqdn` + `.Values.catalystOverlay.auth.keycloak.realm`
+to drop the operator burden of pasting 4 URLs. Per-Sovereign overlay
+need only set `sovereign.fqdn` + `catalystOverlay.auth.keycloak.realm`
+(typically = the Org slug); the chart computes the canonical URLs.
+Operators can still override `issuer` / `jwksUri` explicitly for
+non-standard topologies.
 */ -}}
-{{- if .Values.catalystOverlay.auth.enabled }}
+{{- /* Skip-render when realm or fqdn are missing — auto-derivation needs both. */ -}}
+{{- if and .Values.catalystOverlay.auth.enabled .Values.catalystOverlay.auth.keycloak.realm .Values.sovereign.fqdn }}
+{{- $kc := .Values.catalystOverlay.auth.keycloak -}}
+{{- $sov := .Values.sovereign.fqdn -}}
+{{- $realm := $kc.realm -}}
+{{- $issuer := default (printf "https://auth.%s/realms/%s" $sov $realm) $kc.issuer -}}
+{{- $jwks := default (printf "https://auth.%s/realms/%s/protocol/openid-connect/certs" $sov $realm) $kc.jwksUri -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -26,11 +40,11 @@ data:
       authorization:
         jwtKeyProvider:
           keySourceURIs:
-            - {{ .Values.catalystOverlay.auth.keycloak.jwksUri | quote }}
+            - {{ $jwks | quote }}
           refreshInterval: 1h
         permissionsClaimName: permissions
         authorizer: default
-        claimMapper: {{ .Values.catalystOverlay.auth.keycloak.claimMapper | quote }}
-        issuer: {{ .Values.catalystOverlay.auth.keycloak.issuer | quote }}
-        audience: {{ .Values.catalystOverlay.auth.keycloak.clientId | quote }}
+        claimMapper: {{ $kc.claimMapper | quote }}
+        issuer: {{ $issuer | quote }}
+        audience: {{ $kc.clientId | quote }}
 {{- end }}

--- a/platform/temporal/chart/templates/sso-app-registration.yaml
+++ b/platform/temporal/chart/templates/sso-app-registration.yaml
@@ -1,0 +1,53 @@
+{{- /*
+G117.5 W3.D2 (#2744) — Temporal AppRegistration ConfigMap.
+
+bp-sso-bridge reconciler watches ConfigMaps labelled
+`sso.openova.io/app-registration=<client-id>` and mints the matching
+OIDC client in the per-Org Keycloak realm (named by `org.slug`) at
+Application install time. The client's `client_secret` is PUT to
+OpenBao at `secret/sso/<org-slug>/temporal-frontend` where the
+companion ExternalSecret (sso-externalsecret.yaml) reads it.
+
+A single per-Org realm client (`temporal-frontend`) is shared between
+the Web UI browser flow and the frontend gRPC JWT validator
+(audience = clientId).
+
+Redirect URI matches the bp-temporal blueprint.yaml endpoint hostname
+template `temporal.{{`{{`}}.OrgSlug{{`}}`}}.{{`{{`}}.SovereignFQDN{{`}}`}}`
++ temporalio/ui-server's canonical SSO callback path
+`/auth/sso/callback`.
+*/ -}}
+{{- /*
+Rendered only when catalystOverlay.auth.enabled=true AND
+catalystOverlay.auth.keycloak.realm + sovereign.fqdn + org.slug are all
+set. Default smoke-renders skip cleanly.
+*/ -}}
+{{- if and .Values.catalystOverlay.auth.enabled .Values.catalystOverlay.auth.keycloak.realm .Values.sovereign.fqdn .Values.org.slug }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bp-temporal-sso-registration
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-temporal
+    sso.openova.io/app-registration: temporal-frontend
+    catalyst.openova.io/org-slug: {{ .Values.org.slug | quote }}
+data:
+  realm: {{ .Values.catalystOverlay.auth.keycloak.realm | quote }}
+  client.json: |
+    {
+      "clientId": {{ .Values.catalystOverlay.auth.keycloak.clientId | default "temporal-frontend" | quote }},
+      "name": "Temporal Web UI ({{ .Values.org.slug }})",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "redirectUris": [
+        "https://temporal.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}/auth/sso/callback"
+      ],
+      "webOrigins": [
+        "https://temporal.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}"
+      ],
+      "defaultClientScopes": ["web-origins", "profile", "email", "groups"]
+    }
+{{- end }}

--- a/platform/temporal/chart/templates/sso-externalsecret.yaml
+++ b/platform/temporal/chart/templates/sso-externalsecret.yaml
@@ -1,0 +1,57 @@
+{{- /*
+G117.5 W3.D2 (#2744) — Temporal Web UI OIDC client credentials Secret.
+
+bp-sso-bridge mints the per-Org realm client `temporal-frontend` at App
+install time and PUTs the canonical bundle to OpenBao at
+`secret/sso/<org-slug>/temporal-frontend`. This ExternalSecret
+materialises it as `temporal-sso-oidc-credentials` shaped to the
+Temporal Web UI (`temporalio/ui-server` 2.20+) env-var names
+`TEMPORAL_AUTH_*`.
+
+The frontend gRPC's JWT validation (kept chart-side via
+`templates/keycloak-oidc-config.yaml`) reads the same realm's JWKS
+endpoint; the Web UI flow + frontend gRPC share a single per-Org realm
+client (audience = clientId).
+
+Silent 2-hop SSO (per-Org realm → sovereign realm broker → catalyst-
+pin) requires the per-Org realm's Identity Provider Redirector to have
+`defaultProvider=sovereign-broker` bound — shipped by bp-keycloak
+W2.C4 PR #2794. The Web UI OAuth library derives authorize/token URLs
+from issuer discovery; per-request kc_idp_hint is a no-op here.
+*/ -}}
+{{- /*
+Rendered only when catalystOverlay.auth.enabled=true AND
+catalystOverlay.auth.keycloak.realm + sovereign.fqdn + org.slug are all
+set. Default smoke-renders (off-by-default) skip cleanly.
+*/ -}}
+{{- if and .Values.catalystOverlay.auth.enabled .Values.catalystOverlay.auth.keycloak.realm .Values.sovereign.fqdn .Values.org.slug }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: temporal-sso-oidc-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-temporal
+    bp-sso-bridge.openova.io/consumer: bp-temporal
+spec:
+  refreshInterval: {{ .Values.catalystOverlay.auth.keycloak.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ .Values.catalystOverlay.auth.keycloak.externalSecretStoreName | default "vault-region1" }}
+    kind: ClusterSecretStore
+  target:
+    name: temporal-sso-oidc-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        # temporalio/ui-server 2.20+ TEMPORAL_AUTH_* env-var names.
+        PROVIDER_URL:  "https://auth.{{ .Values.sovereign.fqdn }}/realms/{{ .Values.catalystOverlay.auth.keycloak.realm }}"
+        CLIENT_ID:     {{ .Values.catalystOverlay.auth.keycloak.clientId | default "temporal-frontend" | quote }}
+        CLIENT_SECRET: "{{ "{{ .client_secret }}" }}"
+        CALLBACK_URL:  "https://temporal.{{ .Values.org.slug }}.{{ .Values.sovereign.fqdn }}/auth/sso/callback"
+  data:
+    - secretKey: client_secret
+      remoteRef:
+        key: sso/{{ .Values.catalystOverlay.auth.keycloak.realm }}/{{ .Values.catalystOverlay.auth.keycloak.clientId | default "temporal-frontend" }}
+        property: client_secret
+{{- end }}

--- a/platform/temporal/chart/values.yaml
+++ b/platform/temporal/chart/values.yaml
@@ -18,6 +18,17 @@
 catalystBlueprint:
   upstream: { chart: temporal, version: "1.2.0", repo: "https://go.temporal.io/helm-charts" }
 
+# ─── G117.5 (W3.D2 #2744) Tier-3 SSO — per-Org realm wiring ──────────────
+# Catalyst Organization slug + Sovereign FQDN drive the per-Org realm
+# name, AppRegistration ConfigMap, and the Web UI OIDC callback URL.
+# application-controller materialises these from the Org + Sovereign at
+# Application install time; values shown are placeholders so `helm
+# template` smoke-renders cleanly without `--set`.
+org:
+  slug: ""                              # e.g. "acme" — Org slug (also = per-Org KC realm name)
+sovereign:
+  fqdn: ""                              # e.g. "openova.example.com" (per-Sovereign overlay)
+
 # ─── Upstream chart values (subchart key: temporal) ───────────────────────
 # Upstream chart 1.2.0 is a major rewrite vs the historical 0.x line:
 # the per-datastore top-level keys (`cassandra:`, `mysql:`, `postgresql:`,
@@ -140,6 +151,42 @@ temporal:
     # via Cilium Gateway / HTTPRoute, not chart-rendered Ingress.
     ingress:
       enabled: false
+    # ─── G117.5 (W3.D2 #2744) Tier-3 SSO — Web UI OIDC env ─────────────
+    # temporalio/ui-server 2.20+ reads TEMPORAL_AUTH_* env vars at
+    # process start; sourcing them via secretKeyRef with `optional: true`
+    # keeps the Pod installable on a fresh Sovereign before bp-sso-bridge
+    # has reconciled the per-Org realm + minted the temporal-frontend
+    # client. The frontend gRPC's JWT validator (auth.yaml, see
+    # templates/keycloak-oidc-config.yaml) shares the same realm + audience.
+    additionalEnv:
+      - name: TEMPORAL_AUTH_ENABLED
+        value: "true"
+      - name: TEMPORAL_AUTH_PROVIDER_URL
+        valueFrom:
+          secretKeyRef:
+            name: temporal-sso-oidc-credentials
+            key: PROVIDER_URL
+            optional: true
+      - name: TEMPORAL_AUTH_CLIENT_ID
+        valueFrom:
+          secretKeyRef:
+            name: temporal-sso-oidc-credentials
+            key: CLIENT_ID
+            optional: true
+      - name: TEMPORAL_AUTH_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: temporal-sso-oidc-credentials
+            key: CLIENT_SECRET
+            optional: true
+      - name: TEMPORAL_AUTH_CALLBACK_URL
+        valueFrom:
+          secretKeyRef:
+            name: temporal-sso-oidc-credentials
+            key: CALLBACK_URL
+            optional: true
+      - name: TEMPORAL_AUTH_SCOPES
+        value: "openid,profile,email,groups"
 
   # Admintools pod — operators run `tctl namespace register` and ad-hoc
   # administration through this pod (`kubectl exec -it temporal-admintools
@@ -195,11 +242,19 @@ catalystOverlay:
   auth:
     enabled: false
     keycloak:
-      issuer: ""        # https://keycloak.<env>.<sovereign-domain>/realms/<realm>
-      realm: ""         # e.g. "temporal" or the Sovereign's master realm
-      clientId: ""      # e.g. "temporal-frontend"
-      jwksUri: ""       # https://keycloak.<env>.<sovereign-domain>/realms/<realm>/protocol/openid-connect/certs
+      # G117.5 W3.D2 (#2744): `issuer` + `jwksUri` auto-derive from
+      # `.Values.sovereign.fqdn` + `realm` when left empty — operator
+      # need only set `realm` (typically = the Org slug). Per-Sovereign
+      # overlay can still pin explicit URLs for non-standard topologies.
+      issuer: ""        # auto = https://auth.<sovereign.fqdn>/realms/<realm>
+      realm: ""         # e.g. the Org slug — per-Org KC realm name (W2.C4)
+      clientId: "temporal-frontend"
+      jwksUri: ""       # auto = https://auth.<sovereign.fqdn>/realms/<realm>/protocol/openid-connect/certs
       claimMapper: "default"   # default | noop | <fully-qualified-go-type>
+      # G117.5 W3.D2 (#2744): per-app ExternalSecret store + refresh
+      # cadence. Defaults match the platform-wide bp-openbao store.
+      externalSecretStoreName: "vault-region1"
+      refreshInterval: "1h"
 
   # ─── NetworkPolicy ───────────────────────────────────────────────────
   # DEFAULT FALSE — flip via per-cluster overlay once a baseline


### PR DESCRIPTION
## Summary

Codifies the per-Org Keycloak realm SSO pattern across the four Tier-3 browser-flow apps — Matrix (Synapse), Langfuse, Temporal Web UI, LibreChat — closing the chart-side gap identified by the G117 audit (`docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/`).

Builds on:
- **W2.C4 PR #2794** — bp-keycloak `configmap-per-org-realms.yaml` ships per-Org realms with `defaultProvider=sovereign-broker` Identity Provider Redirector binding.
- **G113 PR #2730** — sovereign realm IDR `defaultProvider=catalyst-pin` binding.

End result is a 2-hop silent SSO chain (per-Org realm → sovereign realm broker → catalyst-pin → catalyst-api `/oidc/auth`) that holds session cookies in BOTH realms after first PIN-login and reuses them for every subsequent app.

## Per-chart additions (4 apps × 3 deliverables)

| Chart | New templates | Edits |
|---|---|---|
| bp-matrix | `sso-externalsecret.yaml` (Synapse `OIDC_CLIENT_SECRET` file mount), `sso-app-registration.yaml` | values.yaml — `org.slug` + `sovereign.fqdn` + new `oidc.*` block + documented `extraConfig.oidc_providers[]` overlay shape; Chart.yaml 1.0.1 → 1.1.0; blueprint.yaml 1.0.1 → 1.1.0 |
| bp-langfuse | `sso-externalsecret.yaml` (NextAuth `AUTH_KEYCLOAK_*` + `NEXTAUTH_URL`), `sso-app-registration.yaml` | values.yaml — `org.slug` + `sovereign.fqdn` + new `oidc.*` block + `langfuse.langfuse.additionalEnv[]` sourcing each `AUTH_KEYCLOAK_*` from the per-app Secret with `optional: true`; Chart.yaml 1.0.0 → 1.1.0; blueprint.yaml 1.0.0 → 1.1.0; omantel + otech overlay pin bumps |
| bp-temporal | `sso-externalsecret.yaml` (Temporal Web UI `TEMPORAL_AUTH_*`), `sso-app-registration.yaml` | values.yaml — `org.slug` + `sovereign.fqdn` + `temporal.web.additionalEnv[]` for `TEMPORAL_AUTH_*` + extended `catalystOverlay.auth.keycloak` block; `keycloak-oidc-config.yaml` auto-derives `issuer` + `jwksUri` from `sovereign.fqdn` + `realm`; Chart.yaml 1.0.1 → 1.1.0; blueprint.yaml 1.0.1 → 1.1.0 |
| bp-librechat | `sso-externalsecret.yaml` (LibreChat `OPENID_CLIENT_SECRET` + `OPENID_SESSION_SECRET`), `sso-app-registration.yaml` | values.yaml — `org.slug` + `org.realm` + `sovereign.fqdn` + new `keycloak.externalSecretStoreName`/`refreshInterval`; deployment.yaml auto-derives `OPENID_ISSUER` from `sovereign.fqdn` + `org.realm` when `keycloak.issuer` is empty; existingSecret default flipped to `librechat-oidc`; Chart.yaml 1.0.0 → 1.1.0; blueprint.yaml 1.0.0 → 1.1.0 |

All `sso-*` templates are soft-gated on the presence of org slug/realm + sovereign FQDN so default `helm template` smoke renders cleanly without `--set`.

## What this PR does NOT change

- **bp-keycloak** — already landed via W2.C4 PR #2794 (per-Org realm template).
- **bp-sso-bridge reconciler** — the consumer of the `sso.openova.io/app-registration` label is part of the W2.C4 family; this PR only emits the ConfigMaps it reads.
- **Bootstrap-kit slot pins** — these 4 charts are Application-tier Blueprints installed at App creation, not bootstrap-time slots. Only the existing per-Sovereign overlay pins for bp-langfuse (omantel/otech) get bumped.

## Test plan

- [x] `helm dependency build` succeeds on all 4 charts (matrix-synapse 3.12.25, langfuse 1.5.28, temporal 1.2.0, sigstore common 0.1.3).
- [x] `helm template` + `helm lint` clean on all 4 charts in **both** default-values mode and SSO-enabled mode (`--set` of `org.slug`/`org.realm`/`sovereign.fqdn`/`oidc.enabled`/`catalystOverlay.auth.enabled`).
- [x] Existing `tests/observability-toggle.sh` passes on bp-matrix, bp-temporal, bp-librechat.
- [x] Confirmed `OPENID_ISSUER` auto-derives to `https://auth.<sov>/realms/<org>` when both inputs set, and renders empty (`""`) when either is missing (no `https://auth./realms/` corruption).
- [x] Confirmed Temporal `keycloak-oidc-config.yaml` renders `keySourceURIs` + `issuer` + `audience` from auto-derived URLs.
- [ ] **Founder PIN-walk** — fresh prov, login at `console.t<NN>.omani.works`, navigate to Matrix / Langfuse / Temporal / LibreChat App URLs; verify each lands authenticated with **zero password prompts** (silent 2-hop SSO).
- [ ] **HAR capture** of the 8-9 hop curl chain per app (per audit `2-hop verification curl chain` sections).
- [ ] **Cross-Org isolation** — Org-A user attempts auth on Org-B app instance; rejected at issuer/JWKS mismatch.

## References

- Audit: `docs/sessions/2026-06-02-G117-sso-fanout-audit/tier-3/{bp-matrix,bp-langfuse,bp-temporal,bp-librechat}.md`
- Dispatch plan: `docs/sessions/2026-06-02-G117-sso-fanout-audit/wave-2-dispatch-recommendations.md` Slot D2/D3
- Memory: `feedback_g113_sso_idr_defaultprovider_fix.md`, `feedback_chart_credential_persistence_defense.md`
- Related: W2.C4 PR #2794 (per-Org realm config), G113 PR #2730 (sovereign IDR), parent EPIC #2737

Refs #2744
Refs #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)