### PR TITLE
fix(blueprints): G117.1 — add platform/ scaffolds for external-dns + reflector + cilium-policies

### DIFF
--- a/platform/cilium-policies/blueprint.yaml
+++ b/platform/cilium-policies/blueprint.yaml
@@ -1,0 +1,60 @@
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-cilium-policies
+  labels:
+    catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
+spec:
+  # G117.1-followup (Refs #2749, 2026-06-02): initial spec.topology
+  # declaration AND fresh chart scaffold. Per
+  # docs/sessions/2026-06-02-per-blueprint-topology-audit.md row 54
+  # (bp-cilium-policies): per-host-cluster singleton, replicated via
+  # Flux from Git (the source-of-truth is the Catalyst monorepo;
+  # Flux pulls them onto every cluster).
+  #
+  # CRDs-only chart — emits CiliumNetworkPolicy + CiliumClusterwideNetwork
+  # Policy CRs. The CRDs themselves are installed by bp-cilium (the
+  # engine chart). This chart MUST install AFTER bp-cilium so the
+  # apiserver's RESTMapper has learned cilium.io/v2.CiliumNetworkPolicy
+  # before Helm tries to apply the policy CRs (same CRD-ordering shape
+  # that bp-kyverno-policies addresses for Kyverno; see Issue #2019).
+  version: 1.0.0
+  card:
+    title: Cilium Policy Library
+    family: networking
+    description: |
+      Catalyst-authored CiliumNetworkPolicy / CiliumClusterwideNetwork
+      Policy CR library. Per-cluster network microsegmentation overlay
+      on top of bp-cilium (the engine) and bp-network-policies (the
+      default-deny baseline). Future per-Application allow rules will
+      be authored here.
+    docs: https://docs.cilium.io/en/stable/security/policy/
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: flux-git
+          mode: async
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/cilium-policies/chart/Chart.yaml
+++ b/platform/cilium-policies/chart/Chart.yaml
@@ -1,0 +1,55 @@
+apiVersion: v2
+name: bp-cilium-policies
+# G117.1-followup (Refs #2749, 2026-06-02): initial fresh scaffold.
+# CRDs-only chart that emits CiliumNetworkPolicy /
+# CiliumClusterwideNetworkPolicy CR overlays on top of bp-cilium
+# (which installs the cilium.io CRDs themselves). Same architectural
+# split as bp-kyverno (engine) + bp-kyverno-policies (policy library):
+# splitting prevents the CRD install-ordering race where Helm tries to
+# apply policy CRs before the apiserver RESTMapper has learned the
+# corresponding CRDs (see Issue #2019 for the canonical RCA on
+# Kyverno; the same pattern applies to Cilium).
+#
+# This scaffold ships ONE placeholder template (a documented allow-
+# intra-namespace CR gated by .Values.enabled=false). Real per-
+# Application policies will land in follow-up PRs as the application-
+# controller starts emitting CiliumNetworkPolicy CRs from
+# Blueprint.spec.networking.egress declarations.
+version: 1.0.0
+appVersion: "1.0.0"
+description: |
+  Catalyst Blueprint chart that ships the CiliumNetworkPolicy / Cilium
+  ClusterwideNetworkPolicy CR library — Catalyst-authored
+  microsegmentation overlay on top of bp-cilium (engine) +
+  bp-network-policies (default-deny baseline).
+
+  Split from bp-cilium (predecessor: policies would have shipped in-tree
+  with the engine) for the same CRD-ordering reason that bp-kyverno-
+  policies was split from bp-kyverno per Issue #2019 — the apiserver
+  RESTMapper must learn cilium.io/v2.CiliumNetworkPolicy before Helm
+  applies the policy CRs.
+type: application
+keywords: [catalyst, blueprint, cilium, network-policy, microsegmentation]
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+# Annotations:
+#
+# - catalyst.openova.io/no-upstream: "true"
+#   Opt out of the hollow-chart guard (Blueprint-Release workflow / issue
+#   #181): this chart legitimately ships only Catalyst-authored CRs that
+#   target the cilium.io CRDs installed by bp-cilium. It has NO upstream
+#   Helm subchart to bundle. Same shape as bp-kyverno-policies +
+#   bp-network-policies + bp-crossplane-claims.
+#
+# - catalyst.openova.io/smoke-render-mode: "default-off"
+#   The initial scaffold defaults `.Values.enabled` to false (operator
+#   opts in explicitly when ready to ship CR policies). With default
+#   values the chart renders zero CRs (just header comments), tripping
+#   the smoke-render guard. Marking smoke-render-mode=default-off tells
+#   the guard to render with `--set enabled=true` instead. Removed once
+#   real per-Application CRs land and the default flips.
+annotations:
+  catalyst.openova.io/no-upstream: "true"
+  catalyst.openova.io/smoke-render-mode: "default-off"

--- a/platform/cilium-policies/chart/templates/00-placeholder.yaml
+++ b/platform/cilium-policies/chart/templates/00-placeholder.yaml
@@ -1,0 +1,45 @@
+{{- /*
+bp-cilium-policies — placeholder template.
+
+G117.1-followup (Refs #2749, 2026-06-02): initial scaffold. This file
+exists so `helm template` renders non-empty output when the chart is
+installed with `--set enabled=true`, satisfying the smoke-render guard
+(per feedback_hollow_chart_dual_annotation.md). The CR it emits is the
+canonical "allow intra-namespace traffic" pattern — a safe baseline
+that does NOT change cluster behavior beyond what bp-network-policies
+already enforces, and is intentionally not selected onto any workload
+unless the operator overrides .Values.policies.allowIntraNamespace.
+
+Real per-Application policies will replace this scaffold as
+application-controller emits CiliumNetworkPolicy CRs from
+Blueprint.spec.networking.egress declarations.
+*/ -}}
+{{- if .Values.enabled -}}
+{{- $intra := index .Values.policies "allowIntraNamespace" | default dict -}}
+{{- if $intra.enabled -}}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-intra-namespace
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-cilium-policies.labels" . | nindent 4 }}
+    catalyst.openova.io/policy-tier: intra-namespace
+spec:
+  description: |
+    Allow Pod-to-Pod traffic within the same namespace. Placeholder
+    scaffold from bp-cilium-policies (G117.1-followup). Operator
+    enables via .Values.policies.allowIntraNamespace.enabled=true.
+  endpointSelector:
+    matchLabels:
+      {{- if hasKey $intra "matchLabels" }}
+      {{- toYaml $intra.matchLabels | nindent 6 }}
+      {{- else }}
+      {}
+      {{- end }}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/platform/cilium-policies/chart/templates/_helpers.tpl
+++ b/platform/cilium-policies/chart/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+{{- /*
+bp-cilium-policies — shared template helpers.
+
+G117.1-followup (Refs #2749, 2026-06-02): initial scaffold.
+*/ -}}
+
+{{- /*
+Standard Catalyst label set stamped on every CiliumNetworkPolicy /
+CiliumClusterwideNetworkPolicy CR rendered by this chart. Mirrors the
+label-emission helper from bp-kyverno-policies + bp-network-policies.
+*/ -}}
+{{- define "bp-cilium-policies.labels" -}}
+app.kubernetes.io/name: bp-cilium-policies
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+catalyst.openova.io/blueprint: bp-cilium-policies
+{{- end -}}

--- a/platform/cilium-policies/chart/values.yaml
+++ b/platform/cilium-policies/chart/values.yaml
@@ -1,0 +1,34 @@
+# bp-cilium-policies values — Catalyst CiliumNetworkPolicy overlay.
+#
+# G117.1-followup (Refs #2749, 2026-06-02): initial scaffold. Defaults
+# OFF — operator opts in once per-Application policies are authored.
+# Activating this chart on a fresh Sovereign without policy content
+# would render zero CRs (no-op), which is the intentional initial
+# state.
+#
+# Schema mirrors bp-kyverno-policies and bp-network-policies — the
+# top-level `enabled` gate plus per-policy nested maps for the policy
+# library that will follow in subsequent PRs.
+
+# Master gate. Default OFF — opt-in until real policy content lands.
+# Operator flips to true per Sovereign overlay (or via the umbrella
+# bp-catalyst-platform values) once a per-Application allow-rule
+# library is ready to ship. With `enabled: false` the chart renders
+# only the header comment in the placeholder template — installation
+# is a no-op (does NOT sever any traffic).
+enabled: false
+
+# Per-policy gates. Each entry is a nested map keyed by a stable
+# policy name; populated as real policies are authored. Schema per
+# policy (proposed, finalised when first real policy lands):
+#
+#   <name>:
+#     enabled: bool                  # required — gate
+#     description: string            # operator-facing rationale
+#     mode: "audit" | "enforce"      # default audit
+#     selector: {...}                # CiliumNetworkPolicy endpointSelector
+#     ingress: [...]                 # CiliumNetworkPolicy ingress rules
+#     egress: [...]                  # CiliumNetworkPolicy egress rules
+#
+# Until populated, this map exists for documentation only.
+policies: {}

--- a/platform/external-dns/blueprint.yaml
+++ b/platform/external-dns/blueprint.yaml
@@ -1,0 +1,56 @@
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-external-dns
+  labels:
+    catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
+spec:
+  # G117.1-followup (Refs #2749, 2026-06-02): initial spec.topology
+  # declaration. Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md
+  # row 70 (bp-external-dns): per-host-cluster singleton, stateless
+  # controller (PowerDNS holds the authoritative records, not ExternalDNS).
+  # Runs on every host cluster across all 6 substrate cluster slots
+  # (mgmt-A/B, dmz-A/B, rtz-A/B). Each instance writes to its local
+  # PowerDNS auth replica via the webhook provider; no cross-cluster
+  # replication primitive — the source of truth is PowerDNS state
+  # (replicated by bp-powerdns lua-records + PG-backed pair).
+  version: 1.1.8
+  card:
+    title: ExternalDNS
+    family: networking
+    description: |
+      Synchronizes Kubernetes Gateway/Service/Ingress resources with the
+      per-Sovereign PowerDNS authoritative server (and any external cloud
+      DNS providers — Cloudflare, Route53, Hetzner DNS, Dynadot via the
+      Catalyst webhook). Health-checked geo-failover responses are owned
+      by PowerDNS lua-records, NOT by ExternalDNS.
+    docs: https://kubernetes-sigs.github.io/external-dns/
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: none
+          mode: none
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/reflector/blueprint.yaml
+++ b/platform/reflector/blueprint.yaml
@@ -1,0 +1,55 @@
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-reflector
+  labels:
+    catalyst.openova.io/section: pts-3-3-security-and-policy
+spec:
+  # G117.1-followup (Refs #2749, 2026-06-02): initial spec.topology
+  # declaration. Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md
+  # row 83 (bp-reflector): per-host-cluster singleton, stateless
+  # controller. Reflector mirrors Kubernetes Secrets and ConfigMaps
+  # across namespaces by watching reflector.v1.k8s.emberstack.com/*
+  # annotations. Each cluster runs its own instance — there is no
+  # cross-cluster state to replicate (the source Secret/ConfigMap is
+  # already replicated by whatever Blueprint owns it, e.g.
+  # flux-system/ghcr-pull Secret created by bp-flux).
+  version: 1.0.0
+  card:
+    title: Reflector
+    family: guardian
+    description: |
+      Mirrors Kubernetes Secrets and ConfigMaps across namespaces via
+      reflector.v1.k8s.emberstack.com/* annotations. Eliminates the
+      cross-namespace secret propagation gap that previously caused
+      ImagePullBackOff on every new tenant namespace (issue #543).
+    docs: https://github.com/emberstack/kubernetes-reflector
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: none
+          mode: none
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false


### PR DESCRIPTION
## Refs #2749 #2737

Closes the platform/ scaffold gap surfaced by W1.B2 verifier on PR #2746 against the audit doc `docs/sessions/2026-06-02-per-blueprint-topology-audit.md`. Three audit rows had no `platform/<x>/blueprint.yaml` backing them — they could not ship a `spec.topology` block without first having the scaffold to write into.

## Summary

- **`platform/external-dns/blueprint.yaml`** (NEW) — per audit row 70: per-host-cluster singleton, stateless controller (PowerDNS holds the authoritative records). `spec.topology` lists all 6 substrate cluster slots as `singleton` roles, `replication.backend: none`.
- **`platform/reflector/blueprint.yaml`** (NEW) — per audit row 83: same per-host-cluster singleton, stateless controller shape.
- **`platform/cilium-policies/{Chart.yaml,values.yaml,templates/,blueprint.yaml}`** (NEW — fresh scaffold; directory did not exist) — per audit row 54: replicated via Flux. CRDs-only chart that emits CiliumNetworkPolicy CRs on top of `bp-cilium` (engine). Architectural split mirrors `bp-kyverno-policies` vs `bp-kyverno` (Issue #2019) — avoids the CRD apiserver-RESTMapper race. One placeholder template (allow-intra-namespace) gated by `.Values.enabled=false` (default OFF); annotated with both `no-upstream` + `smoke-render-mode=default-off` per `feedback_hollow_chart_dual_annotation.md`.

## Validation

- All 3 new `blueprint.yaml` validate against `platform/_schemas/blueprint-topology.json` using the workflow's exact loader. Full sweep across all 87 `platform/*/blueprint.yaml` files passes with 0 failures.
- `helm lint platform/cilium-policies/chart/` — 0 errors (1 INFO about optional `icon`).
- `helm template --set enabled=true --set policies.allowIntraNamespace.enabled=true` renders a valid `CiliumNetworkPolicy` CR (`apiVersion: cilium.io/v2`, correct labels, endpointSelector); default render emits the expected zero-resources output (smoke-render-mode=default-off).

## Test plan

- [ ] CI `blueprint admission validate (G117 schema)` workflow passes for the 3 new files
- [ ] CI `helm-lint` workflow passes for the new `platform/cilium-policies/chart/`
- [ ] Verifier sub-agent reviews and posts verdict on issue #2749
- [ ] Operator (NOT the agent) flips issue #2749 from `status/in-progress` → `status/uat` → `status/completed` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)