### PR TITLE
fix(sso-bridge): G117.5c-followup — add session_secret to per-Org bundle (closes #2807)

### DIFF
--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -85,7 +85,7 @@ spec:
       # 0.1.1 (G91-fu, Refs #2659, edc55c08 PR #2676): adds realm-role
       # grant + skipClientUpsert opt-out for charts whose Keycloak Client
       # is realm-imported at bp-keycloak install time (catalyst-ui etc.).
-      version: 0.2.3
+      version: 0.2.4
       sourceRef:
         kind: HelmRepository
         name: bp-sso-bridge

--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.3
+  version: 0.2.4
   card:
     title: sso-bridge
     summary: |

--- a/platform/sso-bridge/chart/Chart.yaml
+++ b/platform/sso-bridge/chart/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: bp-sso-bridge
-version: 0.2.3
+version: 0.2.4
+# 0.2.4 (G117.5c-followup #2807, 2026-06-02): extend Tier-3 per-Org
+# OpenBao bundle to include `session_secret` so librechat's
+# OPENID_SESSION_SECRET env var resolves via ExternalSecret. Derived
+# deterministically from sha256(clientId|session|realm|client_secret)
+# — render-stable across reconcile ticks, distinct from client_secret,
+# and never rotates on its own. Other Tier-3 apps that don't reference
+# the key just ignore it. Refs #2807.
 # 0.2.3 (G117.5c #2801, 2026-06-02): Tier-3 AppRegistration ConfigMap
 # watcher. Two new bash functions in templates/configmap-reconciler.yaml:
 #   - upsert_per_org_client: for one ConfigMap labelled

--- a/platform/sso-bridge/chart/templates/configmap-reconciler.yaml
+++ b/platform/sso-bridge/chart/templates/configmap-reconciler.yaml
@@ -793,15 +793,25 @@ data:
       # ExternalSecret can resolve. The bundle shape matches the
       # Tier-3 sso-externalsecret.yaml templates (client_id +
       # client_secret + issuer_url, plus the standard discovery URLs).
-      local issuer
+      #
+      # G117.5c-followup #2807: librechat's ExternalSecret references
+      # `property: session_secret` (for OPENID_SESSION_SECRET env var)
+      # which the original W3.D5 bundle did not emit. Derive it
+      # deterministically from cid+realm+client_secret so it is stable
+      # across reconcile ticks AND distinct from client_secret. Other
+      # Tier-3 apps that don't reference this key just ignore it.
+      local issuer session_secret
       issuer="https://auth.$(sovereign_fqdn)/realms/${realm}"
+      session_secret="$(printf '%s|session|%s|%s' "${cid}" "${realm}" "${secret}" | sha256sum | awk '{print $1}')"
       local bundle
       bundle="$(jq -nc \
         --arg cid "${cid}" \
         --arg secret "${secret}" \
+        --arg session "${session_secret}" \
         --arg issuer "${issuer}" \
         --arg realm "${realm}" \
-        '{client_id:$cid, client_secret:$secret, issuer_url:$issuer, realm:$realm,
+        '{client_id:$cid, client_secret:$secret, session_secret:$session,
+          issuer_url:$issuer, realm:$realm,
           authorize_url:($issuer+"/protocol/openid-connect/auth"),
           token_url:($issuer+"/protocol/openid-connect/token"),
           userinfo_url:($issuer+"/protocol/openid-connect/userinfo"),

--- a/platform/sso-bridge/chart/tests/g117-5c-fu-session-secret-bundle.sh
+++ b/platform/sso-bridge/chart/tests/g117-5c-fu-session-secret-bundle.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# G117.5c-followup #2807 — bp-sso-bridge: session_secret added to per-Org
+# OpenBao bundle so librechat's OPENID_SESSION_SECRET resolves via
+# ExternalSecret.
+#
+# Asserts:
+#   1. The rendered configmap-reconciler.yaml script contains a
+#      session_secret derivation (sha256 of `clientId|session|realm|client_secret`)
+#   2. The jq bundle expression includes `session_secret:$session`
+#   3. The derivation is render-stable (same inputs → same value)
+#   4. session_secret is DISTINCT from client_secret for the same client
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$CHART_DIR"
+
+RENDERED="$(helm template smoke "$CHART_DIR" --show-only templates/configmap-reconciler.yaml 2>/dev/null)"
+
+echo "=== G117.5c-followup session_secret bundle tests ==="
+
+# Test 1: session_secret derivation present
+if ! echo "$RENDERED" | grep -q 'session_secret="\$('; then
+  echo "FAIL 1: session_secret derivation not found in rendered reconciler"
+  exit 1
+fi
+echo "PASS 1: session_secret derivation present"
+
+# Test 2: jq bundle includes session_secret:$session
+if ! echo "$RENDERED" | grep -q 'session_secret:\$session'; then
+  echo "FAIL 2: jq bundle expression missing session_secret:\$session"
+  exit 1
+fi
+echo "PASS 2: jq bundle includes session_secret"
+
+# Test 3: derivation uses sha256 + the |session| delimiter
+if ! echo "$RENDERED" | grep -qE 'sha256sum.*\|session\||\\\|session\\\|.*sha256sum'; then
+  if ! echo "$RENDERED" | grep -q 'session|.*sha256sum'; then
+    # Multi-line — verify presence of both elements
+    echo "$RENDERED" | grep -q 'sha256sum' || { echo "FAIL 3: sha256sum not in derivation"; exit 1; }
+    echo "$RENDERED" | grep -q '|session|' || { echo "FAIL 3: |session| delimiter not in derivation"; exit 1; }
+  fi
+fi
+echo "PASS 3: derivation uses sha256 + |session| delimiter"
+
+# Test 4: Verify the derivation logic produces a DISTINCT value from client_secret
+# (smoke test the bash logic in isolation)
+test_cid="librechat"
+test_realm="acme"
+test_client_secret="abc123def456"
+computed_session="$(printf '%s|session|%s|%s' "$test_cid" "$test_realm" "$test_client_secret" | sha256sum | awk '{print $1}')"
+if [ "$computed_session" = "$test_client_secret" ]; then
+  echo "FAIL 4: session_secret happened to equal client_secret — that's a hash collision"
+  exit 1
+fi
+if [ -z "$computed_session" ] || [ ${#computed_session} -ne 64 ]; then
+  echo "FAIL 4: session_secret not a valid sha256 hex digest (len=${#computed_session})"
+  exit 1
+fi
+echo "PASS 4: derivation produces a valid sha256 distinct from client_secret"
+
+# Test 5: Idempotency — same inputs produce same value
+computed_session2="$(printf '%s|session|%s|%s' "$test_cid" "$test_realm" "$test_client_secret" | sha256sum | awk '{print $1}')"
+if [ "$computed_session" != "$computed_session2" ]; then
+  echo "FAIL 5: same inputs produced different session_secret values"
+  exit 1
+fi
+echo "PASS 5: derivation is render-stable (idempotent)"
+
+echo "=== ALL TESTS PASS ==="


### PR DESCRIPTION
## Refs #2807 #2744 #2737

W3.D5 verifier (PR #2804) flagged: bp-librechat's ExternalSecret references `property: session_secret` for `OPENID_SESSION_SECRET` env var, but the new Tier-3 AppRegistration bundle didn't emit it. Env var resolves empty until this fix lands.

## Fix

Extends `upsert_per_org_client` bundle in `configmap-reconciler.yaml` with `session_secret`, derived deterministically as `sha256(clientId|session|realm|client_secret)` — render-stable across reconcile ticks, distinct from `client_secret`, and never rotates on its own. Other Tier-3 apps that don't reference the key just ignore it.

## Files (5 changed, +91/-5)

- `platform/sso-bridge/chart/templates/configmap-reconciler.yaml` — bundle extended
- `platform/sso-bridge/chart/Chart.yaml` 0.2.3 → 0.2.4
- `platform/sso-bridge/blueprint.yaml` 0.2.3 → 0.2.4
- `clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml` pin 0.2.3 → 0.2.4
- NEW: `platform/sso-bridge/chart/tests/g117-5c-fu-session-secret-bundle.sh` (5 cases all PASS locally)

## Test plan

- [x] `helm template smoke platform/sso-bridge/chart --show-only templates/configmap-reconciler.yaml` renders cleanly
- [x] 5-case chart test all PASS
- [ ] Operator fresh-prov walk on a Sovereign with librechat installed in 1 Org confirms OPENID_SESSION_SECRET non-empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)