### PR TITLE
fix(sso-bridge): chart-test relative-path bug breaks Blueprint Release publish

### DIFF
--- a/platform/sso-bridge/chart/tests/g117-5c-app-registration-watcher.sh
+++ b/platform/sso-bridge/chart/tests/g117-5c-app-registration-watcher.sh
@@ -37,7 +37,7 @@
 
 set -euo pipefail
 
-CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+CHART_DIR="$(cd "${1:-$(dirname "$0")/..}" && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 


### PR DESCRIPTION
## Refs #2801 #2807 #2737

`g117-5c-app-registration-watcher.sh` accepted relative `$1` from the CI runner (`platform/sso-bridge/chart`), did `cd $CHART_DIR` then `helm template smoke $CHART_DIR` — second call resolves relative to the new cwd which doesn't exist → exits 1 in 3ms.

**Impact**: Blueprint Release for bp-sso-bridge **0.2.4** (PR #2808) FAILED at the chart-test step. GHCR has 0.2.2 / 0.2.3 only. hw86 Flux can't pull the chart → bp-sso-bridge HR ready=False → cascade-failure across bp-keycloak / bp-catalyst-platform / bp-grafana / bp-newapi / bp-self-sovereign-cutover.

## Fix (1 line)
`CHART_DIR="${1:-$(cd ... && pwd)}"` → `CHART_DIR="$(cd "${1:-$(dirname $0)/..}" && pwd)"` — resolves $1 to absolute via `cd && pwd` BEFORE cd, matching the pattern in g117-w2c4-per-org-realm.sh (already fixed in PR #2802).

## Why this matters
hw86 reconcile cascade is broken: 9 HRs ready=False, all gated on bp-keycloak / bp-sso-bridge / bp-gitea. Founder login flow is degraded until publish succeeds + Flux reconciles.

## Test plan
- [x] Local run: `bash platform/sso-bridge/chart/tests/g117-5c-app-registration-watcher.sh platform/sso-bridge/chart` PASSes all 13 cases
- [ ] Blueprint Release workflow succeeds → bp-sso-bridge 0.2.4 lands on GHCR
- [ ] hw86 Flux reconciles bp-sso-bridge HR to Ready=True
- [ ] Downstream HRs (bp-keycloak, bp-grafana, etc.) cascade back to Ready=True
EOF
)