### PR TITLE
fix(chart-tests): unblock Blueprint Release for bp-keycloak 1.4.14 + bp-sso-bridge 0.2.4

### DIFF
--- a/platform/keycloak/chart/tests/g117-5b-secret-rotation-salt.sh
+++ b/platform/keycloak/chart/tests/g117-5b-secret-rotation-salt.sh
@@ -20,7 +20,7 @@ extract_secret() {
     --set "sso.tier1ClientSecretSalt=$salt" \
     --show-only templates/configmap-sovereign-realm.yaml \
     2>/dev/null \
-    | yq -r '.data["realm.json"]' \
+    | yq -r 'select(.kind == "ConfigMap") | .data["sovereign-realm.json"]' \
     | jq -r "$jq_path"
 }
 

--- a/platform/sso-bridge/chart/tests/g117-w2c4-provision-org-realm.sh
+++ b/platform/sso-bridge/chart/tests/g117-w2c4-provision-org-realm.sh
@@ -30,7 +30,7 @@
 
 set -euo pipefail
 
-CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+CHART_DIR="$(cd "${1:-$(dirname "$0")/..}" && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 


### PR DESCRIPTION
## Refs #2816 Refs #2806 Refs #2815 Refs #2744

**Two chart-test bugs are independently blocking Blueprint Release publish** for `bp-keycloak 1.4.14` and `bp-sso-bridge 0.2.4`. PR #2815 fixed only ONE of them (the sibling test `g117-5c-app-registration-watcher.sh`). The other sibling and the keycloak rotation-salt test still fail in CI.

**Impact**: hw86 has 9 HelmReleases ready=False — the entire SSO stack is dormant because the per-Org realm code from PR #2794/#2804/#2808 (G117.5 W2.C4 + W3.D2) is unreachable. G117.E2E-A7 cannot proceed until publish succeeds.

## Bugs fixed (both 1-line)

### 1. `platform/keycloak/chart/tests/g117-5b-secret-rotation-salt.sh`

Original: `yq -r '.data["realm.json"]'` returns `null` →  `jq` exits 5 with `parse error: Invalid numeric literal`.

Two root causes:
- `--show-only templates/configmap-sovereign-realm.yaml` emits TWO documents (a Secret AND a ConfigMap). Need `select(.kind == "ConfigMap")`.
- The ConfigMap's data key is `sovereign-realm.json`, NOT `realm.json`. The 7 sibling tests all use the correct key — PR #2806 introduced this drift.

Fix: `yq -r 'select(.kind == "ConfigMap") | .data["sovereign-realm.json"]'`

### 2. `platform/sso-bridge/chart/tests/g117-w2c4-provision-org-realm.sh`

Same anti-pattern as PR #2815:
```
CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"   # $1 stays RELATIVE
cd "$CHART_DIR"
helm template smoke "$CHART_DIR" 2>/dev/null > ...   # resolves relative to NEW cwd → fails silently
```

CI invokes with relative `$1` (`platform/sso-bridge/chart`) → helm template silently fails → script exits 1 with no log output (suppressed by `2>/dev/null`).

Fix: `CHART_DIR="$(cd "${1:-$(dirname "$0")/..}" && pwd)"` — resolve before `cd`, exact pattern from PR #2815.

## Verification

All four invocation modes pass for both tests:

| Test | rel-arg (CI) | abs-arg | no-arg |
|---|---|---|---|
| `g117-w2c4-provision-org-realm.sh` | 12/12 PASS | OK | OK |
| `g117-5b-secret-rotation-salt.sh` | 5/5 PASS | OK | OK |

## Why two bugs in one PR

Both gate the same Blueprint Release pipeline; both are 1-line targeted fixes to test scripts only (no chart/template changes); shipping separately serializes the unblock by an extra workflow round-trip. The bp-sso-bridge fix is the exact carryover from PR #2815 that was missed; the bp-keycloak fix is what issue #2816's body identified as required.

## Follow-up after merge

1. Workflow_dispatch reruns of Blueprint Release for both charts (push won't fire it; the new commits are in this same branch, not main HEAD).
2. Flux force-reconcile on hw86 once both new chart versions land in GHCR.
3. Resume G117.E2E-A7 per-Org realm E2E walk on hw86 (the actual mandate this session).

## Test plan

- [x] Local: `bash platform/sso-bridge/chart/tests/g117-w2c4-provision-org-realm.sh platform/sso-bridge/chart` → 12/12 PASS
- [x] Local: `bash platform/keycloak/chart/tests/g117-5b-secret-rotation-salt.sh platform/keycloak/chart` → 5/5 PASS
- [x] Regression: absolute-path + no-arg invocations both PASS for both tests
- [ ] CI: Blueprint Release for `platform/keycloak/chart` succeeds → bp-keycloak 1.4.14 lands in GHCR
- [ ] CI: Blueprint Release for `platform/sso-bridge/chart` succeeds → bp-sso-bridge 0.2.4 lands in GHCR
- [ ] hw86 Flux reconciles bp-keycloak + bp-sso-bridge HRs to Ready=True
- [ ] Downstream HRs (bp-catalyst-platform, bp-grafana, bp-newapi, bp-self-sovereign-cutover, bp-guacamole, bp-continuum) cascade back to Ready=True

🤖 Generated with [Claude Code](https://claude.com/claude-code)