### PR TITLE
fix(sso-bridge): G117.E2E-C1 — sovereign-fqdn key contract drift (Refs #2816 #2737 #2743 #2744)

### DIFF
--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -85,7 +85,7 @@ spec:
       # 0.1.1 (G91-fu, Refs #2659, edc55c08 PR #2676): adds realm-role
       # grant + skipClientUpsert opt-out for charts whose Keycloak Client
       # is realm-imported at bp-keycloak install time (catalyst-ui etc.).
-      version: 0.2.4
+      version: 0.2.5
       sourceRef:
         kind: HelmRepository
         name: bp-sso-bridge

--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.4
+  version: 0.2.5
   card:
     title: sso-bridge
     summary: |

--- a/platform/sso-bridge/chart/Chart.yaml
+++ b/platform/sso-bridge/chart/Chart.yaml
@@ -1,6 +1,22 @@
 apiVersion: v2
 name: bp-sso-bridge
-version: 0.2.4
+version: 0.2.5
+# 0.2.5 (G117.E2E-C1 #2816, 2026-06-03): fix sovereign-fqdn ConfigMap
+# data-key contract drift — chart default `sovereignFqdnKey: sovereignFqdn`
+# did not match the key actually emitted by bp-catalyst-platform
+# (`fqdn`). Result: bp-sso-bridge `sovereign_fqdn()` returned empty on
+# every tick, the loop logged `WARN: sovereign-fqdn ConfigMap missing;
+# skipping tick` every 6 min, and Tier-1 OpenBao writes + per-Org realm
+# reconciliation never happened. Caught live on hw86 (E2E-A6 4-hop SSO
+# probe found token-exchange returning `unauthorized_client` because
+# chart-side OIDC secrets — md5 32-hex via lookup-or-generate — never
+# converged with KC realm-imported secrets — sha256 64-hex). Fix is
+# values.yaml default only; no template/script changes; operators that
+# already override sovereignFqdnKey in per-Sovereign overlays are
+# unaffected. New chart test
+# `tests/g117-e2e-a1-sovereign-fqdn-key-contract.sh` guards against
+# future drift by asserting the chart default matches the emitter key.
+# Refs #2816 #2737 #2743 #2744 #2683.
 # 0.2.4 (G117.5c-followup #2807, 2026-06-02): extend Tier-3 per-Org
 # OpenBao bundle to include `session_secret` so librechat's
 # OPENID_SESSION_SECRET env var resolves via ExternalSecret. Derived

--- a/platform/sso-bridge/chart/tests/g117-e2e-a1-sovereign-fqdn-key-contract.sh
+++ b/platform/sso-bridge/chart/tests/g117-e2e-a1-sovereign-fqdn-key-contract.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# bp-sso-bridge — G117.E2E-C1 #2816 sovereign-fqdn key contract guard.
+#
+# Asserts two contracts that, when broken, silently disable the
+# bp-sso-bridge reconciler:
+#
+#   (1) The rendered Deployment env `SOVEREIGN_FQDN_SOVEREIGN_FQDN_KEY`
+#       defaults to "fqdn" — matching the canonical key that
+#       bp-catalyst-platform emits at
+#       products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml:48
+#       (`fqdn: {{ .Values.global.sovereignFQDN | quote }}`).
+#
+#   (2) That env value can be overridden via --set
+#       operator.sovereignFqdnConfigMap.sovereignFqdnKey=... (defense-
+#       in-depth for operators that pin a per-Sovereign overlay).
+#
+#   (3) The reconcile.sh script still reads the live ConfigMap via the
+#       `${SOVEREIGN_FQDN_SOVEREIGN_FQDN_KEY}` indirection — otherwise
+#       (1) and (2) become dead code.
+#
+#   (4) The chart default for sovereignFqdnKey in values.yaml matches the
+#       canonical key emitted by the catalyst-platform sovereign-fqdn
+#       ConfigMap template — caught by comparing both side-by-side from
+#       the source files.
+#
+# Why this guard exists:
+#   G91.1 (PR #2683) shipped a default `sovereignFqdnKey: sovereignFqdn`
+#   that does NOT exist in any sovereign-fqdn ConfigMap on any live
+#   Sovereign. The reconcile loop's `sovereign_fqdn()` helper used
+#   jsonpath `{.data.${SOVEREIGN_FQDN_SOVEREIGN_FQDN_KEY}}` and silently
+#   returned empty on every tick, so the loop logged
+#   `sovereign-fqdn ConfigMap missing; skipping tick` every 6 minutes
+#   and skipped the Tier-1 OpenBao + per-Org-realm reconciler calls
+#   entirely. Caught on hw86 2026-06-03 (G117.E2E-A6 4-hop SSO probe)
+#   where grafana + gitea token-exchange returned `unauthorized_client`
+#   because chart-side OIDC secrets (md5-derived 32-hex) never
+#   converged with KC realm-imported secrets (sha256-derived 64-hex).
+#
+# Usage: bash tests/g117-e2e-a1-sovereign-fqdn-key-contract.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="$(cd "${1:-$(dirname "$0")/..}" && pwd)"
+REPO_ROOT="$(cd "$CHART_DIR/../../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+helm="${HELM_BIN:-helm}"
+
+CATALYST_CM="$REPO_ROOT/products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml"
+
+# ── Case 1: chart default renders SOVEREIGN_FQDN_SOVEREIGN_FQDN_KEY=fqdn ──
+"$helm" template smoke "$CHART_DIR" 2>/dev/null > "$TMP/default.yaml"
+
+# Extract the env block containing the key, then verify the next line's
+# value is "fqdn". The shape is:
+#     - name: SOVEREIGN_FQDN_SOVEREIGN_FQDN_KEY
+#       value: "fqdn"
+grep_ctx() { grep -A1 "name: SOVEREIGN_FQDN_SOVEREIGN_FQDN_KEY" "$1" | tail -n1; }
+
+default_line="$(grep_ctx "$TMP/default.yaml" | tr -d '[:space:]')"
+if [ "$default_line" != 'value:"fqdn"' ]; then
+  echo "FAIL: default SOVEREIGN_FQDN_SOVEREIGN_FQDN_KEY env != \"fqdn\"" >&2
+  echo "      got: $default_line" >&2
+  echo "      (canonical key on every Sovereign is sovereign-fqdn data.fqdn —" >&2
+  echo "       see products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml:48)" >&2
+  exit 1
+fi
+
+# ── Case 2: explicit override is honoured ────────────────────────────────
+"$helm" template smoke "$CHART_DIR" \
+  --set operator.sovereignFqdnConfigMap.sovereignFqdnKey=customKeyName \
+  2>/dev/null > "$TMP/override.yaml"
+
+override_line="$(grep_ctx "$TMP/override.yaml" | tr -d '[:space:]')"
+if [ "$override_line" != 'value:"customKeyName"' ]; then
+  echo "FAIL: --set override of sovereignFqdnKey not honoured" >&2
+  echo "      got: $override_line" >&2
+  exit 1
+fi
+
+# ── Case 3: the reconcile.sh script still reads the env var ──────────────
+# Guard against accidental drop of the indirection — the bash function
+# `sovereign_fqdn()` must dereference $SOVEREIGN_FQDN_SOVEREIGN_FQDN_KEY
+# via jsonpath, otherwise overrides + the default become dead code.
+if ! grep -q 'jsonpath="{.data.${SOVEREIGN_FQDN_SOVEREIGN_FQDN_KEY}}"' "$TMP/default.yaml"; then
+  echo "FAIL: reconcile.sh no longer reads sovereign-fqdn via" >&2
+  echo "      \${SOVEREIGN_FQDN_SOVEREIGN_FQDN_KEY} indirection" >&2
+  exit 1
+fi
+
+# ── Case 4: chart-default key matches catalyst-platform emitter key ──────
+# Compare what we ship as the default vs what the catalyst-platform
+# chart actually writes into the live ConfigMap. Drift on EITHER side
+# (rename the data key in catalyst, OR forget to retune the bridge
+# default) breaks SSO silently on every Sovereign.
+if [ ! -f "$CATALYST_CM" ]; then
+  echo "SKIP: catalyst-platform sovereign-fqdn ConfigMap template not at" >&2
+  echo "      $CATALYST_CM (repo layout changed?)" >&2
+  echo "      Case 4 cross-chart guard cannot run." >&2
+else
+  sso_key="$(awk '/sovereignFqdnKey: [a-zA-Z]/{print $2; exit}' "$CHART_DIR/values.yaml")"
+  catalyst_key="$(grep -E '^  [a-zA-Z]+: \{\{ \.Values\.global\.sovereignFQDN' "$CATALYST_CM" \
+    | awk -F: '{print $1}' | tr -d ' ')"
+
+  if [ -z "$sso_key" ] || [ -z "$catalyst_key" ]; then
+    echo "FAIL: could not extract one of the keys" >&2
+    echo "      sso_key='$sso_key' catalyst_key='$catalyst_key'" >&2
+    exit 1
+  fi
+
+  if [ "$sso_key" != "$catalyst_key" ]; then
+    echo "FAIL: cross-chart key drift detected." >&2
+    echo "  bp-sso-bridge      values.yaml sovereignFqdnKey:   '$sso_key'" >&2
+    echo "  bp-catalyst-platform sovereign-fqdn ConfigMap key: '$catalyst_key'" >&2
+    echo "  These MUST match. Fix whichever side drifted." >&2
+    exit 1
+  fi
+fi
+
+echo "PASS: sovereign-fqdn key contract"
+echo "      default='fqdn', override honoured, indirection preserved, cross-chart match"

--- a/platform/sso-bridge/chart/values.yaml
+++ b/platform/sso-bridge/chart/values.yaml
@@ -79,7 +79,18 @@ operator:
     name: sovereign-fqdn
     namespace: catalyst-system
     orgEmailKey: orgEmail
-    sovereignFqdnKey: sovereignFqdn
+    # The canonical data key in the sovereign-fqdn ConfigMap is `fqdn`
+    # (emitted by products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml:48
+    # via `fqdn: {{ .Values.global.sovereignFQDN | quote }}`). The legacy
+    # default `sovereignFqdn` shipped in G91.1 (PR #2683) does not exist on
+    # any Sovereign — the reconcile loop's `sovereign_fqdn()` returns empty,
+    # logs `sovereign-fqdn ConfigMap missing; skipping tick` every tick, and
+    # the Tier-1 OpenBao writes (sso/<app>) + per-Org-realm reconciler calls
+    # never happen. Caught live on hw86 2026-06-03 (G117.E2E-A6 verdict)
+    # where bp-gitea + bp-grafana token-exchange failed with
+    # `unauthorized_client` because chart-side OIDC secrets (md5 32-hex)
+    # never converged with KC-realm-imported secrets (sha256 64-hex).
+    sovereignFqdnKey: fqdn
 
 # Resource budget for the reconcile loop Pod. ~10 apps reconciled per tick
 # is the steady-state, all calls go through in-cluster Services, the


### PR DESCRIPTION
## Summary

- **P0 fire**: bp-sso-bridge reconciler has not ticked in 27h on hw86. Root cause: ConfigMap-key contract drift between `bp-sso-bridge` and `bp-catalyst-platform`.
- **Diagnosis** (per G117.E2E-A6 verdict): bp-sso-bridge reads jsonpath `{.data.${SOVEREIGN_FQDN_SOVEREIGN_FQDN_KEY}}` with env `=sovereignFqdn` (G91.1 PR #2683 default), but bp-catalyst-platform emits the ConfigMap with key `fqdn` (products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml:48). `sovereign_fqdn()` returns empty → loop logs `WARN: sovereign-fqdn ConfigMap missing; skipping tick` every 6 min → Tier-1 OpenBao writes never happen.
- **Cascade**: chart-side OIDC secrets (md5-shaped 32-hex via lookup-or-generate) never converge with KC realm-imported secrets (sha256-derived 64-hex) → grafana + gitea token-exchange returns `unauthorized_client`. openbao PASSes only because it federates via realm-config IDR defaultProvider (no bridge-distributed Secret needed).

## Fix

Picked option (a) from the brief — change the bp-sso-bridge default `sovereignFqdnKey: sovereignFqdn` → `fqdn`. Verified via `grep -rn` across `platform/ products/ core/` that the ONLY consumer of `operator.sovereignFqdnConfigMap.sovereignFqdnKey` is the bp-sso-bridge deployment template itself — no other reader, so single-key (option a) is strictly simpler than dual-key emission (option b).

Files:
- `platform/sso-bridge/chart/values.yaml` — flip the default
- `platform/sso-bridge/chart/Chart.yaml` — 0.2.4 → 0.2.5 with full changelog entry
- `platform/sso-bridge/blueprint.yaml` — `version: 0.2.5` lockstep
- `platform/sso-bridge/chart/tests/g117-e2e-a1-sovereign-fqdn-key-contract.sh` — new regression guard

No template / reconcile.sh / Go code changes. Operators with per-Sovereign overlays that already set `operator.sovereignFqdnConfigMap.sovereignFqdnKey` are unaffected.

## Regression guard

The new chart test enforces 4 cases against silent re-breakage:

1. Chart default renders env `SOVEREIGN_FQDN_SOVEREIGN_FQDN_KEY=fqdn`
2. `--set` override is honoured
3. `reconcile.sh` still reads via `${SOVEREIGN_FQDN_SOVEREIGN_FQDN_KEY}` indirection
4. Cross-chart: chart default matches `bp-catalyst-platform` emitter key

Drift on EITHER side now fails CI.

## Test plan

- [x] `helm lint platform/sso-bridge/chart/` clean
- [x] `helm template smoke …` renders `value: "fqdn"`
- [x] All 4 chart tests in `platform/sso-bridge/chart/tests/` pass locally
- [ ] **Operator walk on hw86** after GHCR republish + Flux force-reconcile of bp-sso-bridge:
  - [ ] `kubectl -n sso-bridge logs <pod> --tail=20` shows successful tick (no `ConfigMap missing`)
  - [ ] Chart-side OIDC secrets converge with KC realm secrets within ~5 min after first tick
  - [ ] G117.E2E-A6 4-hop SSO probe for grafana + gitea PASS
  - [ ] Re-walk gates A6's harbor + Tier-3 surfaces

## Refs

Refs #2816 — G117.E2E-A1 hw86 stabilisation tracker
Refs #2737 — G117 EPIC roll-up
Refs #2743 — Catalyst console Launch + endpoints UI (consumes silent SSO)
Refs #2744 — G117.5 W2.C4 per-Org realm reconciler (also gated by `sovereign_fqdn()`)
Refs #2683 — G91.1 (origin of the wrong default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)