### PR TITLE
fix(gitea): G117.E2E-B1 — resolve Pod by label selector in SSO configure hook (bp-gitea 1.2.14)

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -81,7 +81,7 @@ spec:
       # bp-self-sovereign-cutover Step 1 gitea-mirror Job mounts it. K8s
       # forbids cross-namespace secretKeyRef; reflector is the canonical
       # platform-level mirror. Caught live on otech103 2026-05-04.
-      version: 1.2.13
+      version: 1.2.14
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.13
+  version: 1.2.14
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -1,5 +1,16 @@
 apiVersion: v2
 name: bp-gitea
+# 1.2.14 (G117.E2E-B1 #2818, 2026-06-03): Fix post-upgrade hook
+# `gitea-sso-configure` timing out. The configure-oauth Job hard-coded
+# `kubectl wait pod/gitea-0` and `kubectl exec gitea-0 -- gitea admin
+# auth ...`, but the upstream gitea-charts/gitea 10.5.0 chart renders a
+# Deployment (templates/gitea/deployment.yaml), not a StatefulSet, so
+# the live Pod is `gitea-<rs-hash>-<id>` and the index-name lookup
+# never matches. The Job now resolves the live Pod by label selector
+# (`app.kubernetes.io/name=gitea,app.kubernetes.io/instance=<release>`)
+# — takes the first Pod with `Ready=True`, also keeps the Job correct
+# if the operator flips the upstream chart into its StatefulSet mode.
+# Refs #2737 (G117 EPIC) / #2818.
 # 1.2.13 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via
 # kc_idp_hint=catalyst-pin. ExternalSecret now appends the hint to the
 # `authorize_url` written into gitea-oauth-source-credentials; the
@@ -38,7 +49,7 @@ name: bp-gitea
 # directly in Gitea as a site admin via OIDC. Local `gitea_admin` user
 # remains the break-glass account for bp-self-sovereign-cutover Step 1.
 # Per SECURITY.md §6.3 (App-level SSO).
-version: 1.2.13
+version: 1.2.14
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/sso-configure-oauth-job.yaml
+++ b/platform/gitea/chart/templates/sso-configure-oauth-job.yaml
@@ -17,9 +17,15 @@ When this fires:
   - post-upgrade (updates if sovereignFqdn changed or secret rotated;
     update-oauth on an unchanged source is a no-op)
 
-The Job calls into the gitea-0 Pod via `kubectl exec` rather than
+The Job calls into the live gitea Pod via `kubectl exec` rather than
 running gitea CLI in its own container so we avoid pinning a gitea
-image version here.
+image version here. The Pod is discovered by label selector
+(`app.kubernetes.io/name=gitea,app.kubernetes.io/instance=<release>`)
+rather than the hard-coded `gitea-0` index — upstream gitea 10.5.0
+renders a Deployment (ReplicaSet → `gitea-<hash>-<id>`), not a
+StatefulSet, so the index name is wrong (G117.E2E-B1 #2818). The
+selector-based lookup also keeps the Job correct if the operator
+opts the upstream chart into its StatefulSet mode.
 */ -}}
 {{- if and .Values.sso.enabled .Values.sso.sovereignFqdn }}
 apiVersion: v1
@@ -134,6 +140,13 @@ spec:
               value: {{ .Values.sso.restrictedGroup | default "" | quote }}
             - name: GITEA_NAMESPACE
               value: {{ .Release.Namespace | quote }}
+            # G117.E2E-B1 #2818 — selector for the live gitea Pod.
+            # Upstream chart 10.5.0 renders a Deployment (ReplicaSet pod
+            # name = gitea-<hash>-<id>), so the legacy hard-coded
+            # `gitea-0` index never matched on default-config Sovereigns.
+            # The Job now resolves the live Pod by these labels.
+            - name: POD_SELECTOR
+              value: {{ printf "app.kubernetes.io/name=gitea,app.kubernetes.io/instance=%s" .Release.Name | quote }}
             # G117.5 #2744 — IDP_HINT toggles whether we pass the
             # hinted authorize_url via --auth-url + --use-custom-url-
             # mapping. When non-empty the Job reads the
@@ -181,31 +194,43 @@ spec:
               echo "  ADMIN_GROUP=${ADMIN_GROUP}"
               echo "  GITEA_NAMESPACE=${GITEA_NAMESPACE}"
               echo "  IDP_HINT=${IDP_HINT}"
+              echo "  POD_SELECTOR=${POD_SELECTOR}"
 
-              # Wait for gitea Pod Ready (up to 10 min — first install
-              # races bp-cnpg + ESO + the upstream init container).
-              echo "[$(date -u +%FT%TZ)] waiting for gitea Pod Ready..."
+              # G117.E2E-B1 #2818: Resolve the live gitea Pod by label
+              # selector. Upstream gitea 10.5.0 renders a Deployment
+              # (ReplicaSet pod name = gitea-<hash>-<id>), not a
+              # StatefulSet, so the legacy hard-coded `gitea-0` lookup
+              # never matches and the hook always times out.
+              #
+              # Wait for at least one Ready Pod matching the selector
+              # (up to 10 min — first install races bp-cnpg + ESO + the
+              # upstream init container).
+              GITEA_POD=""
+              echo "[$(date -u +%FT%TZ)] waiting for a Ready gitea Pod (selector=${POD_SELECTOR})..."
               for i in $(seq 1 60); do
-                if kubectl get pod gitea-0 -n "${GITEA_NAMESPACE}" >/dev/null 2>&1; then
-                  if kubectl wait --for=condition=Ready pod/gitea-0 \
-                       -n "${GITEA_NAMESPACE}" --timeout=10s >/dev/null 2>&1; then
-                    echo "[$(date -u +%FT%TZ)] gitea-0 is Ready."
-                    break
-                  fi
+                GITEA_POD="$(kubectl get pod -n "${GITEA_NAMESPACE}" \
+                  -l "${POD_SELECTOR}" \
+                  -o jsonpath='{range .items[?(@.status.phase=="Running")]}{.metadata.name}{"\t"}{range .status.conditions[?(@.type=="Ready")]}{.status}{end}{"\n"}{end}' \
+                  2>/dev/null \
+                  | awk -F '\t' '$2=="True" {print $1; exit}' || true)"
+                if [ -n "${GITEA_POD}" ]; then
+                  echo "[$(date -u +%FT%TZ)] selected pod=${GITEA_POD} (Ready)."
+                  break
                 fi
-                echo "  attempt $i/60: gitea-0 not yet Ready; sleeping 10s..."
+                echo "  attempt $i/60: no Ready pod matching selector; sleeping 10s..."
                 sleep 10
               done
 
-              if ! kubectl wait --for=condition=Ready pod/gitea-0 \
-                   -n "${GITEA_NAMESPACE}" --timeout=10s >/dev/null 2>&1; then
-                echo "FATAL: gitea-0 did not become Ready within 10 min." >&2
+              if [ -z "${GITEA_POD}" ]; then
+                echo "FATAL: no Ready gitea Pod matched selector '${POD_SELECTOR}' within 10 min." >&2
+                echo "  current pods in namespace:" >&2
+                kubectl get pod -n "${GITEA_NAMESPACE}" -l "${POD_SELECTOR}" >&2 || true
                 exit 1
               fi
 
               # Idempotency: check if an OAuth source with this name exists.
-              echo "[$(date -u +%FT%TZ)] checking existing auth sources..."
-              AUTH_LIST="$(kubectl exec -n "${GITEA_NAMESPACE}" gitea-0 -- \
+              echo "[$(date -u +%FT%TZ)] checking existing auth sources (via pod ${GITEA_POD})..."
+              AUTH_LIST="$(kubectl exec -n "${GITEA_NAMESPACE}" "${GITEA_POD}" -- \
                 gitea admin auth list --vertical-bars 2>&1 || true)"
               echo "${AUTH_LIST}"
 
@@ -262,16 +287,16 @@ spec:
 
               if [ -z "${AUTH_ID}" ]; then
                 echo "[$(date -u +%FT%TZ)] adding new OAuth source '${AUTH_NAME}'..."
-                kubectl exec -n "${GITEA_NAMESPACE}" gitea-0 -- \
+                kubectl exec -n "${GITEA_NAMESPACE}" "${GITEA_POD}" -- \
                   gitea admin auth add-oauth --name "${AUTH_NAME}" "${COMMON_ARGS[@]}"
               else
                 echo "[$(date -u +%FT%TZ)] updating OAuth source id=${AUTH_ID} ('${AUTH_NAME}')..."
-                kubectl exec -n "${GITEA_NAMESPACE}" gitea-0 -- \
+                kubectl exec -n "${GITEA_NAMESPACE}" "${GITEA_POD}" -- \
                   gitea admin auth update-oauth --id "${AUTH_ID}" --name "${AUTH_NAME}" "${COMMON_ARGS[@]}"
               fi
 
               echo "[$(date -u +%FT%TZ)] OAuth source configured. Final list:"
-              kubectl exec -n "${GITEA_NAMESPACE}" gitea-0 -- gitea admin auth list
+              kubectl exec -n "${GITEA_NAMESPACE}" "${GITEA_POD}" -- gitea admin auth list
       volumes:
         - name: tmp
           emptyDir:

--- a/platform/gitea/chart/tests/g117-5-sso-tier1.sh
+++ b/platform/gitea/chart/tests/g117-5-sso-tier1.sh
@@ -81,4 +81,24 @@ if ! grep -A1 'name: IDP_HINT' "${tmpdir}/optout.yaml" | grep -q 'value: ""'; th
 fi
 echo "  PASS"
 
+# Case 6 (G117.E2E-B1 #2818): post-upgrade hook must NOT hard-code
+# pod/gitea-0 — upstream gitea 10.5.0 renders a Deployment, not a
+# StatefulSet, so the index-name lookup never matches and the hook
+# times out. Job must instead resolve the live Pod by label selector.
+echo "[g117-5-sso-tier1] Case 6: configure-oauth Job does not hard-code pod/gitea-0"
+if grep -q 'pod/gitea-0\|exec.*gitea-0' "${tmpdir}/default.yaml"; then
+  echo "FAIL: configure-oauth Job still references the hard-coded pod/gitea-0 name." >&2
+  echo "  upstream gitea 10.5.0 renders a Deployment; pod is gitea-<rs-hash>-<id>." >&2
+  exit 1
+fi
+if ! grep -q 'name: POD_SELECTOR' "${tmpdir}/default.yaml"; then
+  echo "FAIL: configure-oauth Job missing POD_SELECTOR env var (label-based discovery)." >&2
+  exit 1
+fi
+if ! grep -q 'app.kubernetes.io/name=gitea,app.kubernetes.io/instance=' "${tmpdir}/default.yaml"; then
+  echo "FAIL: POD_SELECTOR does not carry the canonical gitea label selector." >&2
+  exit 1
+fi
+echo "  PASS"
+
 echo "[bp-gitea G117.5 Tier-1 SSO] All cases PASS"


### PR DESCRIPTION
## Summary

- bp-gitea 1.2.13 post-upgrade hook `gitea-sso-configure` was hard-coded to `pod/gitea-0`, but upstream `gitea-charts/gitea 10.5.0` renders a Deployment (not a StatefulSet), so the live Pod name is `gitea-<rs-hash>-<id>`. The Job's `kubectl wait pod/gitea-0` always missed, the 10-min retry loop timed out, and Helm declared `* timed out waiting for the condition`, rolling bp-gitea back to 1.2.12 on every Sovereign that overlay-set `sso.sovereignFqdn`. This blocked the bp-catalyst-platform → bp-continuum → bp-self-sovereign-cutover cascade on hw86.
- Fix: replace hard-coded `gitea-0` with selector-based discovery — `app.kubernetes.io/name=gitea,app.kubernetes.io/instance=<release>` plus first-Ready-Pod filtering. Works whether upstream renders a Deployment (current default) or a StatefulSet.
- Lockstep bump `bp-gitea 1.2.13 → 1.2.14` across Chart.yaml + blueprint.yaml + bootstrap-kit slot pin. Chart test `tests/g117-5-sso-tier1.sh` extended with Case 6 asserting no `gitea-0` literal in rendered Job + presence of `POD_SELECTOR` env.

## RCA — why this hid until G117.5

Template gate is `{{- if and .Values.sso.enabled .Values.sso.sovereignFqdn }}`. Initial 1.2.11 installs left `sso.sovereignFqdn: ""` so the Job never rendered — the `gitea-0` bug was latent. The G117.5 #2787 PR coincided with per-Sovereign overlays finally wiring `sso.sovereignFqdn: <fqdn>`, so the Job rendered for the first time on the upgrade path and exposed the latent bug as `RetriesExceeded` after 4 attempts.

## Test plan

- [x] `bash platform/gitea/chart/tests/g117-5-sso-tier1.sh` — Cases 1–6 PASS
- [x] `bash platform/gitea/chart/tests/httproute-render.sh` — green
- [x] `bash platform/gitea/chart/tests/observability-toggle.sh` — green
- [x] `helm template smoke platform/gitea/chart --set sso.sovereignFqdn=hw86.omani.works` renders 24 manifests; no `pod/gitea-0` literal, POD_SELECTOR env present.
- [ ] **Post-merge cascade walk on hw86 (afc8800bc03751c6)**: force Flux reconcile bp-gitea → expect `Ready=True chartVersion=1.2.14`. Then bp-catalyst-platform + bp-continuum + bp-self-sovereign-cutover follow Ready=True. Founder posts evidence on #2818 + #2737.

Refs #2737 (G117 EPIC), Refs #2818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)