### PR TITLE
fix(bp-catalyst-platform): G117.E2E-B2 — add missing migrations defaults (unblocks 1.4.435 publish + 44dedf2 image roll)

### DIFF
--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1713,3 +1713,33 @@ security:
       - catalyst
       - flux-system
       - kube-system
+
+# ─── Chart-driven schema migrations (G117.2, PR #2795) ────────────────────
+# Hook Jobs that backfill or transform existing CRs after a chart upgrade.
+# Each migration is opt-in (default `enabled: false`) so the smoke-render
+# path does not require migration artifacts to be staged and the same
+# chart bytes can ship to brand-new Sovereigns where the migration is a
+# no-op anyway. Operators flip `enabled: true` on a per-Sovereign overlay
+# when an in-place backfill is required.
+#
+# applicationsInstanceId: G117 W2.C2 (PR #2795) — backfills
+# spec.instanceId / spec.isolationLevel / spec.namingTemplate on every
+# pre-existing Application CR. Idempotent: the script
+# `tools/migrate-applications-instanceId.py` skips any CR that already
+# carries a non-empty spec.instanceId.
+migrations:
+  applicationsInstanceId:
+    enabled: false
+    # ServiceAccount + matching ClusterRole/Binding minted by the
+    # template (narrow scope: get/list/patch on
+    # applications.apps.openova.io across all namespaces).
+    serviceAccountName: catalyst-application-migrator
+    # Migrator image — defaults to a known-published tag. Operators
+    # may pin a per-Sovereign override when a newer migrator is
+    # required (e.g. additional fields backfilled in a later chart
+    # version).
+    image: ghcr.io/openova-io/catalyst-migrator:0.1.0
+    # Dry-run prints the patches that WOULD be applied without
+    # mutating any CR. Useful for first-time operator verification
+    # before flipping `enabled: true` in a real run.
+    dryRun: false


### PR DESCRIPTION
## Summary

PR #2795 (G117.2) added `migrate-applications-instanceId-job.yaml` referencing `.Values.migrations.applicationsInstanceId.*` (6 sites) but never added the matching values block. Blueprint Release run 26818459580 (push for commit `e5d2397` `deploy: update catalyst images to 44dedf2`) **failed** the `Helm template smoke render` step with:

```
Error: template: bp-catalyst-platform/templates/migrate-applications-instanceId-job.yaml:1:14:
  executing "..." at <.Values.migrations.applicationsInstanceId.enabled>:
  nil pointer evaluating interface {}.applicationsInstanceId
```

Chart `1.4.435` is therefore **absent on GHCR** (manifest probe `HTTP 404`) and hw86 catalyst-api is pinned at `e1cd849` (pre-PR #2752 / #2792 / #2795 / #2800). None of the G117.2 / G117.3 / G117.5 / G117.6 codepaths are reachable until this lands.

## Fix

Add `migrations.applicationsInstanceId` defaults to `values.yaml` with `enabled: false` (opt-in). The migration Job + RBAC + ConfigMap are only rendered when an operator flips `enabled: true` on a per-Sovereign overlay — matches the documented intent in the template header (idempotent post-install/post-upgrade backfill).

## Test plan

- [x] Local helm 3.16.3 smoke render with default values: 4395 lines, migration job NOT rendered (default-off)
- [x] Local render with `--set migrations.applicationsInstanceId.enabled=true`: 6 references to `catalyst-application-migrator` (Job + SA + ClusterRole + binding + ConfigMap)
- [ ] CI Blueprint Release `Helm template smoke render` step green for chart `1.4.435`
- [ ] CI `Helm push to GHCR` step uploads `1.4.435` manifest
- [ ] GHCR manifest probe `HTTP 200` for `1.4.435`
- [ ] Auto-bump-pin step bumps `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` `version: 1.4.433` → `1.4.435`
- [ ] hw86 Flux reconciles bp-catalyst-platform to `1.4.435`, catalyst-api Pod rolls to image SHA `44dedf2`
- [ ] `curl https://api.hw86.omani.works/api/v1/version` returns `"sha":"44dedf2"`
- [ ] `curl https://api.hw86.omani.works/catalyst/v1/apps/instances` returns 401 (auth required, NOT 404) — G117.3 endpoint live

## Coordination notes

- No chart-version bump — chart `1.4.435` is absent on GHCR, the next Blueprint Release re-publishes the corrected bytes under the same version slot.
- Avoids race with concurrent 1.4.436 work in flight on `fix/g117-e2e-b3-crd-promote-fields` (CRD schema promotion).
- B1 PR #2821 (gitea Pod-selector fix) is independent — bp-catalyst-platform reconciles regardless of bp-gitea state once the chart is publishable.

Refs #2819 (this issue) · Refs #2737 (G117 EPIC) · Refs #2795 (G117.2 PR that introduced the gap) · Refs #2800 (chart bump that triggered the failed release) · Refs #2821 (B1 sibling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)