### PR TITLE
fix(catalyst-platform): G117.E2E-B2 — add migrations values block (closes #2819)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2352,7 +2352,21 @@ name: bp-catalyst-platform
 # Blueprint placementSchema.defaultOnMultiRegion drives empty-
 # spec.placement on multi-region Sovereigns.
 # (Bumped 414 → 415 after main concurrently shipped a 1.4.414.)
-version: 1.4.435
+# 1.4.436 (G117.E2E-B3 #2740 #2745 #2737, 2026-06-03): promote the G117
+# fields (spec.topology, spec.endpoints, spec.sso, spec.multiInstance)
+# from JSON-schema-only into the Blueprint CRD openAPIV3Schema in
+# products/catalyst/chart/crds/blueprint.yaml. W1.B1 + W2.C2 shipped
+# the Go types + JSON-schema gate but the CRD manifest never gained
+# these fields — runtime admission silently swallowed them through
+# the parent spec's x-kubernetes-preserve-unknown-fields. This bump
+# makes admission gate the canonical contract (variant-specific
+# required keys via inlined per-variant sub-schemas; K8s structural
+# schemas forbid $ref so each of the 4 BCP variants repeats the
+# same three sub-blocks via YAML anchor). 83/87 of-tree blueprints
+# validate clean; 4 pre-existing failures (placementSchema bounds in
+# bp-{dmz,rtz}-vcluster + bare-string depends[] in powerdns-admin +
+# sso-bridge) are unrelated to this slice.
+version: 1.4.437
 appVersion: 1.4.349
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1713,3 +1713,28 @@ security:
       - catalyst
       - flux-system
       - kube-system
+
+# ── Migrations (post-install / post-upgrade Helm-hook Jobs) ──────────────
+# Per PR #2795 (G117.2 multi-instance Application CRD): backfill spec.instanceId
+# on legacy Application CRs that pre-date the immutable-id field.
+#
+# Defaults align with the chart-side Job emitter at
+# templates/migrate-applications-instanceId-job.yaml. Operators can disable
+# specific migrations via per-Sovereign valuesFrom overlay if they want to
+# defer the backfill to a separate ops window.
+migrations:
+  applicationsInstanceId:
+    enabled: true
+    dryRun: false
+    serviceAccountName: catalyst-application-migrator
+    image: ghcr.io/openova-io/catalyst-migrator:0.1.0
+
+# ── Migrations (post-install / post-upgrade Helm-hook Jobs) ──────────────
+# Per PR #2795 (G117.2 multi-instance Application CRD): backfill spec.instanceId
+# on legacy Application CRs that pre-date the immutable-id field.
+migrations:
+  applicationsInstanceId:
+    enabled: true
+    dryRun: false
+    serviceAccountName: catalyst-application-migrator
+    image: ghcr.io/openova-io/catalyst-migrator:0.1.0


### PR DESCRIPTION
## Refs #2819 #2737

bp-catalyst-platform 1.4.435+ smoke render fails because PR #2795's Helm-hook Job (templates/migrate-applications-instanceId-job.yaml) references `.Values.migrations.applicationsInstanceId.*` which was never declared in values.yaml. Default render → nil pointer → blueprint-release publish blocked.

## Fix
Adds the missing values block with sensible defaults matching the template's fallback defaults. Chart bump 1.4.436 → 1.4.437.

## Test plan
- [x] Local: `helm template smoke products/catalyst/chart --show-only templates/migrate-applications-instanceId-job.yaml` renders cleanly
- [ ] CI Blueprint Release for bp-catalyst-platform 1.4.437 succeeds
- [ ] hw86 Flux pulls 1.4.437 + reconciles
- [ ] Unblocks #2741, #2742, #2745 walks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)