### PR TITLE
feat(catalyst-platform): G117.E2E-B3 — promote G117 fields into Blueprint CRD admission

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -898,7 +898,11 @@ spec:
       # patch can flip catalyst-api image to harbor-proxy URL passing
       # the harbor-proxy-pull admission policy. Kustomize-mode sibling
       # api-deployment-kustomize.yaml (literal) handles contabo-mkt.
-      version: 1.4.440
+      # 1.4.441 (G117.E2E-B3 #2740 #2745 #2737, 2026-06-03): promote
+      # G117 fields (spec.topology / endpoints / sso / multiInstance)
+      # into the Blueprint CRD openAPIV3Schema so runtime admission
+      # gates them — preserve-unknown no longer silently swallows.
+      version: 1.4.441
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2367,21 +2367,31 @@ name: bp-catalyst-platform
 # Blueprint placementSchema.defaultOnMultiRegion drives empty-
 # spec.placement on multi-region Sovereigns.
 # (Bumped 414 → 415 after main concurrently shipped a 1.4.414.)
-# 1.4.436 (G117.E2E-B3 #2740 #2745 #2737, 2026-06-03): promote the G117
-# fields (spec.topology, spec.endpoints, spec.sso, spec.multiInstance)
-# from JSON-schema-only into the Blueprint CRD openAPIV3Schema in
-# products/catalyst/chart/crds/blueprint.yaml. W1.B1 + W2.C2 shipped
-# the Go types + JSON-schema gate but the CRD manifest never gained
-# these fields — runtime admission silently swallowed them through
-# the parent spec's x-kubernetes-preserve-unknown-fields. This bump
-# makes admission gate the canonical contract (variant-specific
-# required keys via inlined per-variant sub-schemas; K8s structural
-# schemas forbid $ref so each of the 4 BCP variants repeats the
-# same three sub-blocks via YAML anchor). 83/87 of-tree blueprints
-# validate clean; 4 pre-existing failures (placementSchema bounds in
+# 1.4.436-anchor (G117.E2E-B3 #2740 #2745 #2737, 2026-06-03): comment
+# block landed via PR #2823's lockstep but the actual CRD content
+# (this slice) ships under 1.4.438 below. Kept here for blame anchor.
+# 1.4.438 (G117.E2E-B3 #2740 #2745 #2737, 2026-06-03): the actual CRD
+# manifest change — promote spec.topology / spec.endpoints / spec.sso
+# / spec.multiInstance into products/catalyst/chart/crds/blueprint.yaml's
+# openAPIV3Schema. W1.B1 + W2.C2 landed the Go types + JSON-schema gate
+# but the CRD manifest never gained these fields, so runtime admission
+# silently swallowed them via the parent spec's
+# x-kubernetes-preserve-unknown-fields. Server-side dry-run validation
+# against a live K8s API (1.30) confirms: all 7 invalid samples
+# rejected with admission errors at the exact field path
+# (spec.topology.supported[1] / spec.topology.defaults.single-region /
+# spec.endpoints[0].protocol / spec.sso.realm /
+# spec.multiInstance.isolationLevel); valid samples + 8 representative
+# in-tree blueprints (loki/grafana/gitea/harbor/keycloak/openbao/cnpg/
+# cilium) accepted. K8s structural-schema rules: $ref forbidden →
+# each of the 4 BCP variants inlines via YAML anchor; uniqueItems
+# forbidden → replaced with x-kubernetes-list-type: set (O(n) hash
+# rather than O(n²) ban). 83/87 in-tree blueprint.yaml files validate
+# clean; 4 pre-existing failures (placementSchema bounds in
 # bp-{dmz,rtz}-vcluster + bare-string depends[] in powerdns-admin +
 # sso-bridge) are unrelated to this slice.
-version: 1.4.440
+# (Bumped 440 → 441 to absorb concurrent merges since PR #2825 opened.)
+version: 1.4.441
 appVersion: 1.4.349
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/crds/blueprint.yaml
+++ b/products/catalyst/chart/crds/blueprint.yaml
@@ -327,6 +327,238 @@ spec:
                 outputs:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                # ── G117 EPIC fields — promoted from JSON schema ────────
+                # Source of truth: platform/_schemas/blueprint-topology.json
+                # Go types: core/pkg/apis/blueprint/v1alpha1/topology_types.go
+                # G117.E2E-B3 (#2740 #2745 #2737): W1.B1 + W2.C2 landed
+                # the Go-types + JSON-schema gate but the CRD manifest
+                # never gained these fields, so runtime admission did
+                # NOT gate them — preserve-unknown silently swallowed
+                # them. This block makes admission see + validate the
+                # G117 contract on every Sovereign (hw86 + downstream).
+                topology:
+                  type: object
+                  description: |
+                    Per-Blueprint multi-region declaration. Admission
+                    enforces defaults.multi-region + defaults.single-region
+                    are members of supported, and every key in perTopology
+                    is in supported.
+                  required: [supported, defaults]
+                  properties:
+                    supported:
+                      type: array
+                      minItems: 1
+                      # K8s structural-schema forbids `uniqueItems: true`
+                      # (quadratic-complexity ban); use the structural-
+                      # schema equivalent x-kubernetes-list-type: set
+                      # which the API server enforces in O(n) via hash.
+                      x-kubernetes-list-type: set
+                      items:
+                        type: string
+                        enum:
+                          - active-active
+                          - active-hot-standby
+                          - active-passive
+                          - singleton
+                    defaults:
+                      type: object
+                      required: [multi-region, single-region]
+                      properties:
+                        multi-region:
+                          type: string
+                          enum:
+                            - active-active
+                            - active-hot-standby
+                            - active-passive
+                            - singleton
+                        single-region:
+                          type: string
+                          enum:
+                            - active-active
+                            - active-hot-standby
+                            - active-passive
+                            - singleton
+                    perTopology:
+                      type: object
+                      description: |
+                        Per-variant replication / switchover / placement
+                        knobs. Each variant repeats the same three
+                        sub-schemas — K8s structural CRD schemas forbid
+                        $ref so each variant is inlined via YAML anchor.
+                      properties:
+                        active-active:
+                          type: object
+                          required: [replication, placement]
+                          properties:
+                            replication: &REPLICATION_SPEC
+                              type: object
+                              required: [backend]
+                              properties:
+                                backend:
+                                  type: string
+                                  enum:
+                                    - cnpg-pair
+                                    - raft
+                                    - mirrormaker2
+                                    - s3-bucket-replication
+                                    - ccr
+                                    - sentinel
+                                    - velero
+                                    - filer-remote-storage
+                                    - openbao-perf-replication
+                                    - flux-git
+                                    - none
+                                mode:
+                                  type: string
+                                  enum: [sync, async, none]
+                                lagSloSeconds:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 86400
+                            switchover: &SWITCHOVER_SPEC
+                              type: object
+                              required: [mechanism]
+                              properties:
+                                mechanism:
+                                  type: string
+                                  enum:
+                                    - bp-continuum
+                                    - manual
+                                    - bp-velero-restore
+                                    - lua-record
+                                    - mm2-symmetric
+                                    - ccr-promote
+                                    - raft-transition
+                                    - sentinel-failover
+                                    - none
+                                rtoSeconds:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 86400
+                                rpoSeconds:
+                                  type: integer
+                                  minimum: 0
+                                  maximum: 86400
+                            placement: &PLACEMENT_SPEC
+                              type: object
+                              properties:
+                                tier:
+                                  type: string
+                                  enum: [mgmt, dmz, rtz, ""]
+                                clusters:
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                  items:
+                                    type: string
+                                    pattern: '^(mgmt|dmz|rtz)-[A-Z0-9]+$'
+                                roles:
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                    enum: [active, passive, singleton]
+                        active-hot-standby:
+                          type: object
+                          required: [replication, switchover, placement]
+                          properties:
+                            replication: *REPLICATION_SPEC
+                            switchover: *SWITCHOVER_SPEC
+                            placement: *PLACEMENT_SPEC
+                        active-passive:
+                          type: object
+                          required: [replication, switchover, placement]
+                          properties:
+                            replication: *REPLICATION_SPEC
+                            switchover: *SWITCHOVER_SPEC
+                            placement: *PLACEMENT_SPEC
+                        singleton:
+                          type: object
+                          required: [placement]
+                          properties:
+                            replication: *REPLICATION_SPEC
+                            switchover: *SWITCHOVER_SPEC
+                            placement: *PLACEMENT_SPEC
+                endpoints:
+                  type: array
+                  description: |
+                    Named external endpoints surfaced by this Blueprint.
+                    The Endpoints tab UI (G117.3) renders one card per
+                    entry; the Launch button UI (G117.4) starts from
+                    launchDefault=true (else first ssoEnabled https).
+                  items:
+                    type: object
+                    required: [name, hostnameTemplate]
+                    properties:
+                      name:
+                        type: string
+                        pattern: '^[a-z][a-z0-9-]{0,30}[a-z0-9]$'
+                      hostnameTemplate:
+                        type: string
+                        minLength: 1
+                        maxLength: 253
+                        description: |
+                          Go text/template emitting an RFC-1123 hostname
+                          after evaluation. Tokens: {{.AppName}}
+                          {{.InstanceID}} {{.OrgSlug}} {{.SovereignFQDN}}
+                          {{.ClusterID}}.
+                      port:
+                        type: integer
+                        minimum: 1
+                        maximum: 65535
+                      protocol:
+                        type: string
+                        enum: [https, http, grpc, tcp, udp]
+                      tls:
+                        type: boolean
+                      visibility:
+                        type: string
+                        enum: [public, private, internal]
+                      launchDefault:
+                        type: boolean
+                      ssoEnabled:
+                        type: boolean
+                sso:
+                  type: object
+                  description: |
+                    Blueprint-level SSO declaration. Tier-1/2 use realm
+                    `sovereign`; Tier-3 use per-Org realm via
+                    `{{.OrgSlug}}` template token.
+                  required: [realm]
+                  properties:
+                    realm:
+                      type: string
+                      enum: [sovereign, '{{.OrgSlug}}']
+                    protocolMapper:
+                      type: string
+                      enum: [oidc, saml]
+                    groupsClaim:
+                      type: string
+                    rolesFromGroup:
+                      type: object
+                      additionalProperties:
+                        type: string
+                    silentLogin:
+                      type: boolean
+                multiInstance:
+                  type: object
+                  description: |
+                    When enabled, a Blueprint may have >1 Application
+                    instance per Organization. Catalog cards show the
+                    instance-count badge + "+ New instance" button.
+                    When absent / enabled=false, a Blueprint is
+                    singleton-per-Org.
+                  required: [enabled]
+                  properties:
+                    enabled:
+                      type: boolean
+                    maxPerOrg:
+                      type: integer
+                      minimum: 0
+                      maximum: 1000
+                    namingTemplate:
+                      type: string
+                    isolationLevel:
+                      type: string
+                      enum: [namespace, vcluster]
               x-kubernetes-preserve-unknown-fields: true
             status:
               type: object

--- a/products/catalyst/chart/crds/tests/blueprint-sample-invalid.yaml
+++ b/products/catalyst/chart/crds/tests/blueprint-sample-invalid.yaml
@@ -31,3 +31,72 @@ spec:
   version: 1.0.0
   card:
     summary: A card without a title.
+---
+# ── G117 EPIC invalid samples — exercise the 4 new schema branches ──
+# Third invalid — topology.supported has an unknown BCP value.
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-bad-topology-enum
+spec:
+  version: 1.0.0
+  card:
+    title: bad topology enum
+  topology:
+    supported: [active-hot-standby, foo-bar]
+    defaults:
+      multi-region: active-hot-standby
+      single-region: singleton
+---
+# Fourth invalid — topology.defaults missing required single-region.
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-bad-topology-required
+spec:
+  version: 1.0.0
+  card:
+    title: bad topology required
+  topology:
+    supported: [singleton]
+    defaults:
+      multi-region: singleton
+---
+# Fifth invalid — endpoint protocol not in enum + name violates pattern.
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-bad-endpoint
+spec:
+  version: 1.0.0
+  card:
+    title: bad endpoint
+  endpoints:
+    - name: BadCaps
+      hostnameTemplate: ''
+      protocol: smtp
+---
+# Sixth invalid — sso.realm not in enum.
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-bad-sso
+spec:
+  version: 1.0.0
+  card:
+    title: bad sso
+  sso:
+    realm: random-realm
+---
+# Seventh invalid — multiInstance.isolationLevel not in enum.
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-bad-multi
+spec:
+  version: 1.0.0
+  card:
+    title: bad multi-instance
+  multiInstance:
+    enabled: true
+    isolationLevel: vm

--- a/products/catalyst/chart/crds/tests/blueprint-sample-valid.yaml
+++ b/products/catalyst/chart/crds/tests/blueprint-sample-valid.yaml
@@ -74,6 +74,61 @@ spec:
     metrics: prometheus
     logs: stdout
     traces: otlp
+  # ── G117 EPIC: topology + endpoints + sso + multiInstance ──────
+  # Exercises the four new openAPIV3Schema branches added in
+  # bp-catalyst-platform 1.4.438. A valid Blueprint may declare all
+  # four; admission rejects on enum/required violations.
+  topology:
+    supported:
+      - active-hot-standby
+      - singleton
+    defaults:
+      multi-region: active-hot-standby
+      single-region: singleton
+    perTopology:
+      active-hot-standby:
+        replication:
+          backend: cnpg-pair
+          mode: sync
+          lagSloSeconds: 5
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 30
+          rpoSeconds: 0
+        placement:
+          tier: rtz
+          clusters: [rtz-A, rtz-B]
+          roles:
+            rtz-A: active
+            rtz-B: passive
+      singleton:
+        placement:
+          tier: rtz
+          clusters: [rtz-A]
+          roles:
+            rtz-A: singleton
+  endpoints:
+    - name: ui
+      hostnameTemplate: '{{.AppName}}.{{.OrgSlug}}.{{.SovereignFQDN}}'
+      port: 443
+      protocol: https
+      tls: true
+      visibility: public
+      launchDefault: true
+      ssoEnabled: true
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    groupsClaim: groups
+    rolesFromGroup:
+      sovereign-admins: admin
+      tenant-admins: editor
+    silentLogin: true
+  multiInstance:
+    enabled: true
+    maxPerOrg: 100
+    namingTemplate: '{{.AppName}}-{{.InstanceID}}'
+    isolationLevel: namespace
 ---
 # Legacy v1alpha1 form with manifests.chart short-form must also pass.
 apiVersion: catalyst.openova.io/v1alpha1


### PR DESCRIPTION
## Summary

- bp-catalyst-platform 1.4.437 → 1.4.438: promote spec.topology / spec.endpoints / spec.sso / spec.multiInstance into the Blueprint CRD's openAPIV3Schema so the live K8s admission gates the G117 contract instead of silently swallowing the fields through preserve-unknown.
- bootstrap-kit slot 13 pin moves to 1.4.438 in lockstep.
- 5 new invalid-sample cases + 1 expanded valid-sample case in `products/catalyst/chart/crds/tests/` exercise the new enum / required-field gates.

## Why

A3 + A8 verifiers on hw86 found that `kubectl get crd blueprints.catalyst.openova.io -o yaml` showed spec keys = `[card, configSchema, consoleUI, depends, manifests, observability, outputs, owner, placementSchema, rotation, upgrades, version, visibility]` — **none** of the four G117 keys present. W1.B1 (Go types, #2740) + W2.C2 (JSON-schema gate, #2745) had landed but the CRD manifest itself was never updated. Runtime admission therefore did nothing to enforce the G117 contract — every Blueprint with bad `spec.topology` enum / missing required `defaults.single-region` / bad `endpoints[].protocol` / bad `sso.realm` / bad `multiInstance.isolationLevel` was admitted unconditionally.

## K8s structural-schema constraints encountered (and resolved)

- **`$ref` forbidden** in CRD structural schemas → the four BCP-topology variants reuse `&REPLICATION_SPEC` / `&SWITCHOVER_SPEC` / `&PLACEMENT_SPEC` via YAML anchors, inlining each variant.
- **`uniqueItems: true` forbidden** (quadratic-complexity ban) → replaced with `x-kubernetes-list-type: set` which gives the same guarantee in O(n) via hash.
- **Do NOT rely on `x-kubernetes-preserve-unknown-fields`** for the G117 fields per the task's hard rule — preserve-unknown is the bug we're fixing.

## Test plan

- [x] `kubectl apply --dry-run=server -f products/catalyst/chart/crds/blueprint.yaml` — accepts (live K8s 1.30).
- [x] Valid sample + bp-legacy-test admitted: `kubectl apply --dry-run=server -f products/catalyst/chart/crds/tests/blueprint-sample-valid.yaml` → 2 created.
- [x] All 7 invalid samples rejected with admission errors at the precise field path:
  - `spec.topology.supported[1]: Unsupported value "foo-bar"`
  - `spec.topology.defaults.single-region: Required value`
  - `spec.endpoints[0].protocol: Unsupported value "smtp"`
  - `spec.endpoints[0].name: Invalid value "BadCaps": ... should match '^[a-z][a-z0-9-]{0,30}[a-z0-9]$'`
  - `spec.endpoints[0].hostnameTemplate: ... should be at least 1 chars long`
  - `spec.sso.realm: Unsupported value "random-realm": supported values: "sovereign", "{{.OrgSlug}}"`
  - `spec.multiInstance.isolationLevel: Unsupported value "vm"`
- [x] 8 representative in-tree blueprints (loki / grafana / gitea / harbor / keycloak / openbao / cnpg / cilium) admit cleanly against the new CRD.
- [x] 83/87 of-tree blueprint.yaml files validate clean (4 pre-existing failures unrelated: placementSchema bounds in `bp-{dmz,rtz}-vcluster`, bare-string `depends[]` in `powerdns-admin` + `sso-bridge` — captured for follow-up).
- [ ] **After Flux reconciles 1.4.438 on hw86**, verify:
  ```
  kubectl --kubeconfig <hw86> get crd blueprints.catalyst.openova.io \
    -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties}' \
    | jq 'keys' | grep -E "topology|endpoints|sso|multiInstance"
  ```
- [ ] Founder walks `kubectl apply` of the G117 invalid samples directly on hw86 to confirm live admission rejects.

## Application CRD note

`products/catalyst/chart/crds/application.yaml` already carries `spec.instanceId` (with CEL `x-kubernetes-validations` immutability rule `oldSelf == "" || self == oldSelf`), `spec.isolationLevel` (enum: namespace / vcluster), and `spec.namingTemplate` from PR #2795 (G117.2 W2.C2). No change needed there. The A8 verifier's "missing fields" finding for Application is likely a stale-CRD-on-hw86 issue that resolves once 1.4.438 reconciles.

Refs #2740 #2745 #2737