### PR TITLE
fix(bp-gitea): G117.E2E-A1 — strip tabs from AUTH_ID in sso-configure Job (1.2.15)

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -81,7 +81,7 @@ spec:
       # bp-self-sovereign-cutover Step 1 gitea-mirror Job mounts it. K8s
       # forbids cross-namespace secretKeyRef; reflector is the canonical
       # platform-level mirror. Caught live on otech103 2026-05-04.
-      version: 1.2.14
+      version: 1.2.15
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.14
+  version: 1.2.15
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -1,5 +1,16 @@
 apiVersion: v2
 name: bp-gitea
+# 1.2.15 (G117.E2E-A1 #2816, 2026-06-03): Fix `gitea-sso-configure`
+# Job AUTH_ID extraction. PR #2821 (1.2.14) unblocked the Pod-selector
+# path so the Job actually runs on hw86, exposing a long-dormant second
+# bug: `gitea admin auth list --vertical-bars` separates fields with
+# literal `|` but pads each cell with TABS (not spaces). The previous
+# awk `gsub(/ /,"",$1)` only stripped spaces, leaving `AUTH_ID="1\t"`,
+# and the next call `gitea admin auth update-oauth --id "1\t"` aborts
+# with `invalid value "1\t" for flag -id: parse error`. Hook exhausts
+# backoffLimit, Helm rolls back. Switching the awk to
+# `gsub(/[[:space:]]+/,"",$1)` strips spaces + tabs + CR. Caught live
+# on hw86 2026-06-03 after the 1.2.14 upgrade-cascade. Refs #2816.
 # 1.2.14 (G117.E2E-B1 #2818, 2026-06-03): Fix post-upgrade hook
 # `gitea-sso-configure` timing out. The configure-oauth Job hard-coded
 # `kubectl wait pod/gitea-0` and `kubectl exec gitea-0 -- gitea admin
@@ -49,7 +60,7 @@ name: bp-gitea
 # directly in Gitea as a site admin via OIDC. Local `gitea_admin` user
 # remains the break-glass account for bp-self-sovereign-cutover Step 1.
 # Per SECURITY.md §6.3 (App-level SSO).
-version: 1.2.14
+version: 1.2.15
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/sso-configure-oauth-job.yaml
+++ b/platform/gitea/chart/templates/sso-configure-oauth-job.yaml
@@ -234,9 +234,16 @@ spec:
                 gitea admin auth list --vertical-bars 2>&1 || true)"
               echo "${AUTH_LIST}"
 
+              # NOTE: `gitea admin auth list --vertical-bars` separates
+              # fields with literal `|` BUT pads each cell with TABS, not
+              # spaces — so $1 reads back as `1\t` even after stripping
+              # spaces. Strip all whitespace (spaces + tabs + CR) before
+              # use; gitea CLI rejects `--id "1\t"` with "parse error".
+              # Caught live on hw86 2026-06-03 (G117.E2E-A1 #2816)
+              # after PR #2821 made the Pod-selector fix unblock the Job.
               AUTH_ID="$(echo "${AUTH_LIST}" \
                 | awk -F '|' -v name="${AUTH_NAME}" \
-                  '$2 ~ name && $3 ~ /OAuth2/ {gsub(/ /,"",$1); print $1}' \
+                  '$2 ~ name && $3 ~ /OAuth2/ {gsub(/[[:space:]]+/,"",$1); print $1}' \
                 | head -n1 || true)"
 
               # G117.5: if the ESO-rendered Secret already carries the

--- a/platform/gitea/chart/tests/g117-e2e-a1-auth-id-tab-strip.sh
+++ b/platform/gitea/chart/tests/g117-e2e-a1-auth-id-tab-strip.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# bp-gitea — G117.E2E-A1 #2816 regression guard for the
+# `gitea admin auth list --vertical-bars` AUTH_ID parsing.
+#
+# Bug: the post-install/post-upgrade `gitea-sso-configure` Job runs
+#   AUTH_ID=$(echo "$AUTH_LIST" | awk -F '|' '... { gsub(/ /,"",$1); print $1 }' )
+# which strips SPACES from the first column but not TABS. `gitea admin
+# auth list --vertical-bars` separates cells with literal `|` but pads
+# each cell with TABS — so $1 reads back as `1\t`, and the subsequent
+# `gitea admin auth update-oauth --id "1\t"` aborts with
+#   invalid value "1\t" for flag -id: parse error
+# Hook exhausts backoffLimit, Helm rolls back the bp-gitea HR, and
+# the entire downstream cascade (bp-catalyst-platform → bp-sso-bridge →
+# everything else) stalls Ready=False.
+#
+# Caught live on hw86 2026-06-03 after PR #2821 (1.2.14) unblocked the
+# Pod-selector path so the Job actually ran. Same shape of stripped-
+# whitespace mismatch as the awk parsing in old Bitnami chart helpers.
+#
+# Fix: strip all whitespace with gsub(/[[:space:]]+/, "", $1).
+#
+# Usage: bash tests/g117-e2e-a1-auth-id-tab-strip.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="$(cd "${1:-$(dirname "$0")/..}" && pwd)"
+
+# Sample real `gitea admin auth list --vertical-bars` output (tab-padded
+# per Gitea source: cmd/admin_auth.go writes "%d\t|%s\t\t|%s\t|%v\t").
+SAMPLE_LIST="$(printf 'ID\t|Name\t\t|Type\t|Enabled\n1\t|openova-sso\t|OAuth2\t|true\n')"
+
+# Extract the awk one-liner used in templates/sso-configure-oauth-job.yaml.
+# We assert it strips ALL whitespace from $1 (not just spaces), so the
+# resulting AUTH_ID is the bare "1" without trailing tab.
+AUTH_ID="$(printf '%s\n' "$SAMPLE_LIST" \
+  | awk -F '|' -v name="openova-sso" \
+    '$2 ~ name && $3 ~ /OAuth2/ {gsub(/[[:space:]]+/,"",$1); print $1}' \
+  | head -n1)"
+
+if [ "$AUTH_ID" != "1" ]; then
+  echo "FAIL: awk extraction produced AUTH_ID='${AUTH_ID}' (expected bare '1' without whitespace)"
+  echo "  This means \`gitea admin auth update-oauth --id \"\${AUTH_ID}\"\` will fail with"
+  echo "  \`invalid value \"\${AUTH_ID}\" for flag -id: parse error\`."
+  exit 1
+fi
+echo "PASS 1: awk extraction strips tabs+spaces from AUTH_ID (got '${AUTH_ID}')"
+
+# Sanity check: the actual template ALSO uses [[:space:]]+ (not just bare " "),
+# so the live Job runs the same logic as this unit test.
+if ! grep -qF 'gsub(/[[:space:]]+/,"",$1)' \
+     "$CHART_DIR/templates/sso-configure-oauth-job.yaml"; then
+  echo "FAIL: configure-oauth-job.yaml does not use gsub(/[[:space:]]+/,...) for AUTH_ID extraction"
+  echo "  The chart template has drifted from this test's contract — re-apply the"
+  echo "  whitespace-strip pattern to the AUTH_ID awk script and re-run."
+  exit 1
+fi
+echo "PASS 2: chart template uses the same gsub(/[[:space:]]+/,...) idiom"
+
+echo
+echo "[g117-e2e-a1-auth-id-tab-strip] ALL CASES PASS"


### PR DESCRIPTION
## Refs #2816 #2737 #2818 #2821

PR #2821 (bp-gitea 1.2.14) made the Pod-selector lookup correct so the `gitea-sso-configure` post-install/post-upgrade Job actually executes on hw86. That unblocked a **second long-dormant bug**: the awk extraction for `AUTH_ID` from `gitea admin auth list --vertical-bars` stripped only **spaces** from `$1`, but the gitea CLI formats every cell with **TAB** padding. `AUTH_ID` came back as `1\t` and the next call:

```
gitea admin auth update-oauth --id "1\t" --name openova-sso ...
```

aborted with `invalid value "1\t" for flag -id: parse error`. The hook exhausted backoffLimit, Helm rolled back to 1.2.13, and `bp-catalyst-platform` / `bp-self-sovereign-cutover` / `bp-sso-bridge` / `bp-continuum` stalled Ready=False on `dependency 'flux-system/bp-gitea' is not ready`.

## Live evidence (hw86, 2026-06-03)

```
ID    |Name           |Type   |Enabled
1     |openova-sso    |OAuth2 |true
[2026-06-02T16:33:17Z] updating OAuth source id=1       ('openova-sso')...
Defaulted container "gitea" out of: gitea, init-directories (init), init-app-ini (init), configure-gitea (init)
Command error: invalid value "1\t" for flag -id: parse error
Incorrect Usage: invalid value "1\t" for flag -id: parse error
command terminated with exit code 1
```

## Fix

`templates/sso-configure-oauth-job.yaml` line 239:

```diff
-                  '$2 ~ name && $3 ~ /OAuth2/ {gsub(/ /,"",$1); print $1}' \
+                  '$2 ~ name && $3 ~ /OAuth2/ {gsub(/[[:space:]]+/,"",$1); print $1}' \
```

`[[:space:]]+` strips tabs + spaces + CR. No template/CRD/RBAC churn.

## Regression guard

New `platform/gitea/chart/tests/g117-e2e-a1-auth-id-tab-strip.sh` asserts (1) the awk pattern strips tabs from a representative `gitea admin auth list --vertical-bars` output, and (2) the chart template still uses the `[[:space:]]+` form (so the unit test stays anchored to the live script).

## Lockstep bump

`bp-gitea` 1.2.14 → 1.2.15 (Chart.yaml + blueprint.yaml + bootstrap-kit slot 10 pin).

## Test plan

- [x] Local: new chart test PASSes (`gsub` strips tabs, template uses the `[[:space:]]+` form)
- [x] Local: `helm lint` PASS
- [ ] CI: Blueprint Release publishes `bp-gitea:1.2.15` to GHCR
- [ ] hw86: `kubectl -n gitea get job/gitea-sso-configure` Complete (not BackoffLimitExceeded)
- [ ] hw86: bp-gitea HR Ready=True on 1.2.15
- [ ] hw86: bp-catalyst-platform / bp-sso-bridge / bp-self-sovereign-cutover / bp-continuum cascade unblocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
