### PR TITLE
fix(bp-keycloak): G117.E2E-A7 #2816 — extend varchar(255) trim to tenant + per-Org realm templates

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -114,7 +114,14 @@ spec:
       # it to the SHA-256 seed, atomically rotating every derived SSO
       # client secret on next helm upgrade. Empty default preserves
       # render-stability + back-compat. Refs #2789.
-      version: 1.4.15
+      # 1.4.15 (G117.E2E-A1 #2816, 2026-06-03): trim Tier-2 sovereign-realm
+      # client descriptions (powerdns-admin, hubble-ui) below varchar(255)
+      # so keycloak-config-cli stops crashing on every upgrade. Refs #2816.
+      # 1.4.16 (G117.E2E-A7 #2816, 2026-06-03): extends the trim to the
+      # tenant-realm + per-Org-realm templates that PR #2824 left
+      # unaddressed. The per-Org case is the gating fix for the W2.C4
+      # cross-Org silent-SSO walk on hw86. Refs #2816 #2744.
+      version: 1.4.16
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.15
+  version: 1.4.16
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,5 +1,20 @@
 apiVersion: v2
 name: bp-keycloak
+# 1.4.16 (G117.E2E-A7 #2816, 2026-06-03): trim two MORE realm-import
+# descriptions PR #2824 (1.4.15) missed because its regression test only
+# covered configmap-sovereign-realm.yaml. The varchar(255) cap applies
+# to EVERY realm-import the chart can emit, not just the sovereign one:
+#   - configmap-tenant-realm.yaml stalwart client          288 → 137
+#   - configmap-per-org-realms.yaml "first broker login auto
+#     link" flow (per-Org realm, G117.5 W2.C4 fan-out)     266 →  99
+# The per-Org one is the gating fix for G117.E2E-A7: when bp-sso-bridge's
+# `provision_org_realm` POSTs a per-Org realm via the Admin API, the
+# 266-char flow description was triggering the same `varchar(255)`
+# constraint error on the per-Org realm row insert. Caught while
+# attempting the W2.C4 walk on hw86.
+# Extends tests/g117-e2e-realm-client-description-255-cap.sh (added in
+# PR #2824) to cover all 3 realm-config templates so future descriptions
+# can't regress this on any code path. Refs #2816 #2744.
 # 1.4.15 (G117.E2E-A1 #2816, 2026-06-03): truncate two Tier-2 client
 # descriptions that exceeded the Keycloak DB schema's varchar(255) cap on
 # `public.CLIENT.DESCRIPTION`. Reproduces the same anti-pattern as PR
@@ -120,7 +135,7 @@ name: bp-keycloak
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.4.15
+version: 1.4.16
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/configmap-per-org-realms.yaml
+++ b/platform/keycloak/chart/templates/configmap-per-org-realms.yaml
@@ -219,7 +219,7 @@ data:
         },
         {
           "alias": "first broker login auto link",
-          "description": "G113 #2725 Bug-6 carryover: auto-link federated identity to existing realm user by email match without SMTP confirmation. Required because the sovereign-broker IdP federates a realm user whose email may already exist in the Org realm (e.g. operator pre-provisioned).",
+          "description": "G113 #2725 Bug-6 carryover: auto-link federated identity to existing realm user by email match (no SMTP).",
           "providerId": "basic-flow",
           "topLevel": true,
           "builtIn": false,

--- a/platform/keycloak/chart/templates/configmap-tenant-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-tenant-realm.yaml
@@ -358,7 +358,7 @@ data:
         {
           "clientId": {{ ($t.stalwart.clientID | default "stalwart") | quote }},
           "name": "Stalwart (SME tenant — mail server OIDC)",
-          "description": "Confidential OIDC client for the SME tenant's Stalwart mail server. serviceAccountsEnabled=true so the directory.keycloak backend can use client_credentials to introspect IMAP/SMTP tokens; standardFlowEnabled=true so the webmail UI can do auth-code login. Single client covers both flows.",
+          "description": "Confidential OIDC client for SME tenant Stalwart mail (client_credentials for IMAP/SMTP introspect + auth-code for webmail).",
           "enabled": true,
           "publicClient": false,
           "standardFlowEnabled": true,

--- a/platform/keycloak/chart/tests/g117-e2e-realm-client-description-255-cap.sh
+++ b/platform/keycloak/chart/tests/g117-e2e-realm-client-description-255-cap.sh
@@ -17,6 +17,16 @@
 # added in PR #2802. This test asserts the cap at render time so the bug
 # is caught BEFORE it reaches a live Sovereign.
 #
+# Covers all THREE realm-config templates so the cap is enforced on every
+# realm-shape the chart can emit:
+#   1. configmap-sovereign-realm.yaml — central `sovereign` realm
+#   2. configmap-tenant-realm.yaml     — SME-tenant single-realm mode
+#   3. configmap-per-org-realms.yaml   — per-Org realm fan-out (G117.5 W2.C4)
+# The original 2824 fix covered #1 only; per-Org realms (#3) hit the same
+# cap at runtime when bp-sso-bridge's `provision_org_realm` POSTs them via
+# the Admin API. Caught while attempting G117.E2E-A7 per-Org realm walk
+# on hw86.
+#
 # Cap = 255 chars per JDBC `varchar(255)` definition; Keycloak's source:
 #   https://github.com/keycloak/keycloak/blob/main/model/jpa/src/main/resources/META-INF/jpa-changelog-1.0.0.Final.xml
 #   <column name="DESCRIPTION" type="VARCHAR(255)"/>
@@ -31,57 +41,98 @@ trap 'rm -rf "$TMP"' EXIT
 
 helm="${HELM_BIN:-helm}"
 
-# Render with a representative sovereignFQDN so every templated description
-# (none currently template the FQDN into description, but render anyway in
-# case future descriptions do).
+# Audit one rendered realm JSON for descriptions exceeding the varchar(255)
+# cap on CLIENT.DESCRIPTION + AUTHENTICATION_FLOW.DESCRIPTION columns.
+#
+# Args: $1 = label for output messages, $2 = path to realm JSON file
+audit_realm() {
+  local label="$1"
+  local realm_json="$2"
+  local fails
+  # Walk each section explicitly — `def descs: [...]` with generator
+  # expressions inside the array collapses to 0 elements (the array
+  # constructor doesn't `..` over generator output the way one might
+  # expect), so split the three sections into one jq call each.
+  fails=$( {
+    jq -r '
+      (.clients // [])[]
+      | select((.description // "" | length) > 255)
+      | "client=\(.clientId) length=\(.description | length) chars (>255 KC schema cap)"
+    ' "$realm_json"
+    jq -r '
+      (.authenticationFlows // [])[]
+      | select((.description // "" | length) > 255)
+      | "flow=\(.alias) length=\(.description | length) chars (>255 KC schema cap)"
+    ' "$realm_json"
+    jq -r '
+      (.authenticatorConfig // [])[]
+      | select((.description // "" | length) > 255)
+      | "authenticatorConfig=\(.alias) length=\(.description | length) chars (>255 KC schema cap)"
+    ' "$realm_json"
+  } )
+  if [ -n "$fails" ]; then
+    echo "FAIL ($label): one or more realm-import descriptions exceed Keycloak's varchar(255) cap:"
+    echo "$fails" | sed 's/^/  /'
+    return 1
+  fi
+  echo "  PASS ($label): all descriptions ≤255 chars."
+  # warn about close-to-cap entries
+  {
+    jq -r '
+      (.clients // [])[]
+      | select((.description // "" | length) > 200)
+      | "    warn: client=\(.clientId) length=\(.description | length) (close to 255-cap)"
+    ' "$realm_json"
+    jq -r '
+      (.authenticationFlows // [])[]
+      | select((.description // "" | length) > 200)
+      | "    warn: flow=\(.alias) length=\(.description | length) (close to 255-cap)"
+    ' "$realm_json"
+  } || true
+  return 0
+}
+
+echo "[g117-e2e-realm-client-description-255-cap] Auditing all 3 realm-config templates"
+
+# ── 1. Sovereign realm (always rendered when sovereignRealm.enabled, default) ──
 "$helm" template smoke "$CHART_DIR" \
   --set sovereignFQDN=hw00.omani.works \
   --show-only templates/configmap-sovereign-realm.yaml \
-  > "$TMP/render.yaml" 2>/dev/null
-
-# Extract the realm JSON from the ConfigMap.
+  > "$TMP/sov.yaml" 2>/dev/null
 yq -r 'select(.kind == "ConfigMap") | .data["sovereign-realm.json"]' \
-  "$TMP/render.yaml" > "$TMP/realm.json"
+  "$TMP/sov.yaml" > "$TMP/sov-realm.json"
+audit_realm "sovereign realm" "$TMP/sov-realm.json" || exit 1
 
-# For every client + authenticationFlow + every other entity that carries
-# `description`, assert the value is ≤255 chars.
-fails=$(jq -r '
-  def descs:
-    [
-      (.clients // [])[]
-        | { kind: "client", id: .clientId, desc: (.description // "") },
-      (.authenticationFlows // [])[]
-        | { kind: "flow", id: .alias, desc: (.description // "") },
-      (.authenticatorConfig // [])[]
-        | { kind: "authenticatorConfig", id: .alias, desc: (.description // "") }
-    ];
-  descs[]
-  | select((.desc | length) > 255)
-  | "\(.kind)=\(.id) length=\(.desc | length) chars (>255 KC schema cap)"
-' "$TMP/realm.json")
-
-if [ -n "$fails" ]; then
-  echo "FAIL: one or more realm-import descriptions exceed Keycloak's varchar(255) cap:"
-  echo "$fails" | sed 's/^/  /'
-  echo
-  echo "Any of these will abort the keycloak-config-cli post-install/post-upgrade"
-  echo "Job with PSQLException and the whole bp-keycloak HR will roll back."
-  echo "Truncate the offending description to ≤255 chars (current pattern: keep"
-  echo "the first sentence of the original rationale + drop the parenthetical"
-  echo "implementation notes — they belong in the YAML comment above, not in the"
-  echo "realm-import body)."
-  exit 1
+# ── 2. Tenant realm (SME-tenant mode — mutually exclusive with sovereign) ────
+"$helm" template smoke "$CHART_DIR" \
+  --set sovereignFQDN=hw00.omani.works \
+  --set sovereignRealm.enabled=false \
+  --set realmConfig.tenant.enabled=true \
+  --set realmConfig.tenant.realmName=acme \
+  --set realmConfig.tenant.displayName="Acme SME Tenant" \
+  --show-only templates/configmap-tenant-realm.yaml \
+  > "$TMP/tenant.yaml" 2>/dev/null || true
+if [ -s "$TMP/tenant.yaml" ] && yq -e 'select(.kind == "ConfigMap")' "$TMP/tenant.yaml" >/dev/null 2>&1; then
+  yq -r 'select(.kind == "ConfigMap") | .data["sovereign-realm.json"] // .data["tenant-realm.json"] // .data["realm.json"]' \
+    "$TMP/tenant.yaml" > "$TMP/tenant-realm.json"
+  audit_realm "tenant realm" "$TMP/tenant-realm.json" || exit 1
+else
+  echo "  SKIP (tenant realm): tenant-mode render did not produce a ConfigMap (chart toggles differ)"
 fi
 
-# Report the close-to-cap descriptions for awareness, but don't fail.
-echo "[g117-e2e-realm-client-description-255-cap] All descriptions ≤255 chars."
-jq -r '
-  def descs:
-    [
-      (.clients // [])[] | { id: .clientId, len: (.description // "" | length) }
-    ];
-  descs[]
-  | select(.len > 200)
-  | "  warn: client=\(.id) length=\(.len) (close to 255-cap)"
-' "$TMP/realm.json" || true
-echo "PASS"
+# ── 3. Per-Org realms (G117.5 W2.C4 fan-out — only when tenantRealms[] set) ──
+"$helm" template smoke "$CHART_DIR" \
+  --set sovereignFQDN=hw00.omani.works \
+  --set 'tenantRealms[0].slug=acme-test' \
+  --set 'tenantRealms[0].displayName=Acme Test Org' \
+  --show-only templates/configmap-per-org-realms.yaml \
+  > "$TMP/perorg.yaml" 2>/dev/null
+if [ -s "$TMP/perorg.yaml" ] && yq -e 'select(.kind == "ConfigMap")' "$TMP/perorg.yaml" >/dev/null 2>&1; then
+  yq -r 'select(.kind == "ConfigMap") | .data["org-realm.json"]' \
+    "$TMP/perorg.yaml" > "$TMP/perorg-realm.json"
+  audit_realm "per-Org realm (acme-test)" "$TMP/perorg-realm.json" || exit 1
+else
+  echo "  SKIP (per-Org realm): chart did not render any per-Org ConfigMap"
+fi
+
+echo "[g117-e2e-realm-client-description-255-cap] ALL CASES PASS"


### PR DESCRIPTION
## Refs #2816 #2744 #2737

PR [#2824](https://github.com/openova-io/openova/pull/2824) (bp-keycloak 1.4.15) fixed two oversized descriptions in `configmap-sovereign-realm.yaml` and added a regression test — but the test only covered that single template. Two more oversized descriptions still ship in:

| File | Field | Was | Now |
|---|---|---|---|
| `configmap-tenant-realm.yaml` | `stalwart` client | **288** | 137 |
| `configmap-per-org-realms.yaml` | `first broker login auto link` flow | **266** | 99 |

## Why this is the required fix for G117.E2E-A7

`per-Org-realms` is the canonical W2.C4 fan-out template (one ConfigMap per Catalyst Organization in `.Values.tenantRealms[]`). When `bp-sso-bridge`'s `provision_org_realm` reconciler POSTs the per-Org realm to the KC Admin API, the 266-char flow description triggers the same `varchar(255)` constraint as the sovereign-realm issue #2824 fixed — same `PSQLException`, same realm-create failure, same E2E walk failure.

This was caught attempting the cross-Org silent-SSO walk on hw86 immediately after #2824 merged. Without this fix, the walk fails the moment `tenantRealms[]` is populated.

The tenant-realm `stalwart` case is the SME-tenant single-realm mode (e.g. omantel-fleet Sovereigns) — same shape, would block first install of any new SME-tenant Sovereign.

## Extended regression test

`tests/g117-e2e-realm-client-description-255-cap.sh` now audits all 3 realm-config templates:

1. `configmap-sovereign-realm.yaml` (was already covered by #2824)
2. `configmap-tenant-realm.yaml` (**NEW** — skips cleanly if chart toggles don't render it in smoke mode)
3. `configmap-per-org-realms.yaml` (**NEW** — rendered with one `tenantRealms[]` entry)

### Bonus jq fix

The original test's jq pipeline silently passed against an oversized description:

```jq
def descs:
  [ (.clients // [])[]    | { ... },
    (.authenticationFlows // [])[] | { ... } ];   # <- bug: array constructor doesn't iterate generators
```

`def descs: [ ... ]` with generator expressions inside the array constructor collapses to 0 elements. Confirmed empirically:

```
$ jq -r 'def descs: [(.clients // [])[] | { ... }, (.authenticationFlows // [])[] | { ... }]; descs | length' realm.json
0   # <- always 0, regardless of actual array sizes
```

Replaced with 3 explicit `jq` calls per section. Verified negative-test now catches the 266-char per-Org description:

```
$ bash tests/g117-e2e-realm-client-description-255-cap.sh platform/keycloak/chart
[g117-e2e-realm-client-description-255-cap] Auditing all 3 realm-config templates
  PASS (sovereign realm): all descriptions <=255 chars.
    warn: client=guacamole length=225 (close to 255-cap)
  SKIP (tenant realm): tenant-mode render did not produce a ConfigMap (chart toggles differ)
FAIL (per-Org realm (acme-test)): one or more realm-import descriptions exceed Keycloak's varchar(255) cap:
  flow=first broker login auto link length=266 chars (>255 KC schema cap)
$ echo $?
1
```

## Lockstep version bumps (3 files)

| File | Was | Now |
|---|---|---|
| `platform/keycloak/chart/Chart.yaml` | 1.4.15 | 1.4.16 |
| `platform/keycloak/blueprint.yaml` | 1.4.15 | 1.4.16 |
| `clusters/_template/bootstrap-kit/09-keycloak.yaml` | 1.4.15 | 1.4.16 |

## Self-verification (local)

- All 9 keycloak chart tests PASS (incl. extended regression):
  ```
  PASS g117-5b-secret-rotation-salt.sh
  PASS g117-5-tier1-sso-clients.sh
  PASS g117-5-tier2-sso-clients.sh
  PASS g117-e2e-realm-client-description-255-cap.sh
  PASS g117-w2c4-per-org-realm.sh
  PASS httproute-render.sh
  PASS observability-toggle.sh
  PASS oidc-kubectl-client.sh
  PASS tenant-realm-oidc-clients.sh
  ```
- `helm lint platform/keycloak/chart --set sovereignFQDN=smoke.omani.works` exits 0
- Negative test confirms the regression test would now reject the regression

## Test plan

- [x] All 9 chart tests PASS locally (positive + negative)
- [ ] Blueprint Release publishes `bp-keycloak:1.4.16` to GHCR
- [ ] hw86 Flux reconciles bp-keycloak HR to Ready=True on 1.4.16
- [ ] hw86 per-Org realm walk: populate `tenantRealms: [{slug: acme-test}, {slug: beta-test}]` in the bp-keycloak HR values, observe both `keycloak-config-cli` realm imports succeed AND bp-sso-bridge `provision_org_realm` POSTs both Org realms to the Admin API without 500

## Follow-up after merge

The G117.E2E-A7 cross-Org silent-SSO walk resumes after 1.4.16 lands in GHCR + hw86 reconciles. The walk plan is staged at `/tmp/g117-e2e-walk-plan.md` (Phase 2 onward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)