### PR TITLE
fix(bp-grafana): G117.E2E-A1 — update Tempo URL test 3100→3200 to match chart 1.0.6

### DIFF
--- a/platform/grafana/chart/tests/g115-datasources-dashboards.sh
+++ b/platform/grafana/chart/tests/g115-datasources-dashboards.sh
@@ -65,7 +65,10 @@ for d in docs:
 want = {
     'Prometheus': 'http://mimir-nginx.mimir.svc.cluster.local:80/prometheus',
     'Loki':       'http://loki.loki.svc.cluster.local:3100',
-    'Tempo':      'http://tempo.tempo.svc.cluster.local:3100',
+    # Tempo: port 3200 is the http-query API (3100 is Loki's gRPC/HTTP);
+    # values.yaml line 300 + Chart.yaml comment line 17 codify the 3100→3200
+    # correction shipped in bp-grafana 1.0.6 (PR #2800). Test must match.
+    'Tempo':      'http://tempo.tempo.svc.cluster.local:3200',
 }
 for name, url in want.items():
     if name not in found:


### PR DESCRIPTION
## Refs #2816 #2737 #2800

PR #2800 corrected the Tempo HTTP-query API port `3100 → 3200` in `values.yaml` line 300 + `Chart.yaml` release notes (bp-grafana 1.0.6), but did NOT update `chart/tests/g115-datasources-dashboards.sh` which still asserted the old `3100`. Blueprint Release for PR #2800 (sha=44dedf2) failed at the chart-test step, so **bp-grafana 1.0.6 was never published to GHCR**.

## Live evidence (hw86)

```
$ kubectl -n flux-system get hr bp-grafana
NAME         AGE    READY   STATUS
bp-grafana   2d5h   False   HelmChart 'flux-system/flux-system-bp-grafana' is not ready:
                            chart pull error: failed to download chart for remote reference:
                            failed to get 'oci://ghcr.io/openova-io/bp-grafana:1.0.6':
                            ghcr.io/openova-io/bp-grafana:1.0.6: not found
```

```
$ gh api /orgs/openova-io/packages/container/bp-grafana/versions | jq '.[].metadata.container.tags' | grep -v sha
1.0.1
1.0.2
1.0.3
1.0.4
1.0.5
# (no 1.0.6)
```

## Fix

One-line update in the test expectation (no chart-source change):

```diff
-    'Tempo':      'http://tempo.tempo.svc.cluster.local:3100',
+    'Tempo':      'http://tempo.tempo.svc.cluster.local:3200',
```

3200 is the Tempo http-query API port; 3100 is Loki's port (Loki keeps 3100 in this test).

Same shape as PR #2817 (chart-test bugs unblocking Blueprint Release).

## Test plan

- [x] Local: `bash platform/grafana/chart/tests/g115-datasources-dashboards.sh` all 7 cases PASS
- [ ] CI: Blueprint Release publishes `bp-grafana:1.0.6` to GHCR
- [ ] hw86: `bp-grafana` HR Ready=True on 1.0.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
