### PR TITLE
fix(grafana-test): G117.E2E-D5 — Tempo HTTP port 3100→3200 in chart test

### DIFF
--- a/platform/grafana/chart/tests/g115-datasources-dashboards.sh
+++ b/platform/grafana/chart/tests/g115-datasources-dashboards.sh
@@ -65,7 +65,7 @@ for d in docs:
 want = {
     'Prometheus': 'http://mimir-nginx.mimir.svc.cluster.local:80/prometheus',
     'Loki':       'http://loki.loki.svc.cluster.local:3100',
-    'Tempo':      'http://tempo.tempo.svc.cluster.local:3100',
+    'Tempo':      'http://tempo.tempo.svc.cluster.local:3200',
 }
 for name, url in want.items():
     if name not in found:


### PR DESCRIPTION
## Summary
- One-line flip: `g115-datasources-dashboards.sh:68` asserts Tempo `:3100`, but PR #2800 already bumped `values.yaml:300` to `:3200`. Every `bp-grafana` Blueprint Release since PR #2800 fails at chart-test → no 1.0.6+ on GHCR → hw86 HR stuck `SourceNotReady`.

## Test plan
- [x] Blueprint Release CI runs chart-test on this branch
- [ ] After merge: GHCR `bp-grafana:1.0.6` appears
- [ ] hw86 `bp-grafana` HR transitions `SourceNotReady` → `Ready`

Refs #2740 #2745

🤖 Generated with [Claude Code](https://claude.com/claude-code)