### PR TITLE
fix(bp-catalyst-platform): G117.E2E-A1 — default migration Job to disabled until image exists (1.4.439)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -898,7 +898,7 @@ spec:
       # patch can flip catalyst-api image to harbor-proxy URL passing
       # the harbor-proxy-pull admission policy. Kustomize-mode sibling
       # api-deployment-kustomize.yaml (literal) handles contabo-mkt.
-      version: 1.4.438
+      version: 1.4.439
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,20 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.439 — G117.E2E-A1 #2830 (2026-06-03): default
+# `.Values.migrations.applicationsInstanceId.enabled` to FALSE until the
+# `ghcr.io/openova-io/catalyst-migrator:0.1.0` image actually exists on
+# GHCR. Currently the package is 404 on GHCR (`gh api ...catalyst-migrator
+# = Package not found`) so the post-install/post-upgrade hook Job
+# `catalyst-platform-migrate-applications-instance-id` is stuck in
+# ImagePullBackOff → exhausts backoffLimit:3 → Helm rolls back the entire
+# bp-catalyst-platform HR → bp-sso-bridge + bp-continuum + everything else
+# downstream stalls Ready=False on `dependency 'flux-system/bp-
+# catalyst-platform' is not ready`. Caught live on hw86 2026-06-03 while
+# unblocking the G117.E2E-A1 cascade. Operators that have built+published
+# the migrator image themselves can re-enable via per-Sovereign overlay
+# `migrations.applicationsInstanceId.enabled: true`. Once #2830 closes
+# (image published + imagePullSecrets wired into Pod spec) this default
+# flips back to true. Refs #2830 #2737 #2816 #2795 #2823.
 # 1.4.249 — Wave 5.7 / #2140 (2026-05-23) comprehensive HCS audit +
 # single-pass fixes for the Huawei OpenTofu module. After 6 incremental
 # 1-line fix PRs (#2146 #2148 #2149 #2150 #2152 #2153 — each surfacing
@@ -2366,7 +2381,7 @@ name: bp-catalyst-platform
 # validate clean; 4 pre-existing failures (placementSchema bounds in
 # bp-{dmz,rtz}-vcluster + bare-string depends[] in powerdns-admin +
 # sso-bridge) are unrelated to this slice.
-version: 1.4.438
+version: 1.4.439
 appVersion: 1.4.349
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1722,9 +1722,17 @@ security:
 # templates/migrate-applications-instanceId-job.yaml. Operators can disable
 # specific migrations via per-Sovereign valuesFrom overlay if they want to
 # defer the backfill to a separate ops window.
+# NOTE: this block appears twice in this file because PR #2795 + PR #2823
+# both added it; Helm keeps the last definition, so both must stay aligned.
+# Default is `enabled: false` because the image
+# `ghcr.io/openova-io/catalyst-migrator:0.1.0` is NOT (yet) published to GHCR
+# (#2830). Operators that have built+published the migrator image can flip
+# this to true via per-Sovereign valuesFrom overlay. Once #2830 closes
+# (image published + imagePullSecrets wired into the Pod template), flip
+# this default back to true.
 migrations:
   applicationsInstanceId:
-    enabled: true
+    enabled: false
     dryRun: false
     serviceAccountName: catalyst-application-migrator
     image: ghcr.io/openova-io/catalyst-migrator:0.1.0
@@ -1732,9 +1740,13 @@ migrations:
 # ── Migrations (post-install / post-upgrade Helm-hook Jobs) ──────────────
 # Per PR #2795 (G117.2 multi-instance Application CRD): backfill spec.instanceId
 # on legacy Application CRs that pre-date the immutable-id field.
+#
+# Duplicate of the block above — Helm keeps the LAST `migrations:` map seen
+# (per YAML merge semantics) so this is the effective default. Flipped to
+# `enabled: false` per #2830 — see comment above the previous block.
 migrations:
   applicationsInstanceId:
-    enabled: true
+    enabled: false
     dryRun: false
     serviceAccountName: catalyst-application-migrator
     image: ghcr.io/openova-io/catalyst-migrator:0.1.0


### PR DESCRIPTION
## Refs #2830 #2737 #2816 #2795 #2823

PR #2823 (`bp-catalyst-platform` 1.4.438) added a post-install/post-upgrade Helm-hook Job `catalyst-platform-migrate-applications-instance-id` whose Pod template references `ghcr.io/openova-io/catalyst-migrator:0.1.0` with `enabled: true` by default. **That image is NOT published to GHCR**:

```
$ gh api /orgs/openova-io/packages/container/catalyst-migrator
{"message":"Package not found.","status":"404"}
```

On every bp-catalyst-platform upgrade the Job goes `ImagePullBackOff`, exhausts `backoffLimit: 3`, Helm rolls back, and the entire downstream cascade (`bp-sso-bridge`, `bp-continuum`, the per-Org realm reconciler, …) stays Ready=False on `dependency 'flux-system/bp-catalyst-platform' is not ready`. Caught live on hw86 2026-06-03 while unblocking the G117.E2E-A1 cascade.

## Bug stack

1. **Image missing on GHCR** — tracked in #2830.
2. **Pod spec lacks `imagePullSecrets: [{name: ghcr-pull}]`** — would 403 even if the image existed but were private.
3. **`migrations:` block duplicated** in `products/catalyst/chart/values.yaml` (PR #2795 + PR #2823 both added it, the second unaware of the first). Helm keeps the last definition; both must stay aligned. Now comment-anchored on both blocks.

## Fix (this PR)

Flip both `enabled: true` → `enabled: false` in `values.yaml` so fresh installs / upgrades no longer hit the missing image. Operators with their own published migrator image can re-enable via per-Sovereign overlay `migrations.applicationsInstanceId.enabled: true`. Once #2830 closes (image published + imagePullSecrets wired into Pod spec) this default flips back to true.

Lockstep bump: `bp-catalyst-platform` 1.4.438 → 1.4.439 (Chart.yaml + bootstrap-kit slot 13 pin).

## Test plan

- [x] Local: `helm lint products/catalyst/chart` PASS
- [x] Local: `helm template smoke products/catalyst/chart` renders **0** migrate-applications-instance-id Jobs
- [ ] CI: Blueprint Release publishes `bp-catalyst-platform:1.4.439` to GHCR
- [ ] hw86: bp-catalyst-platform HR Ready=True on 1.4.439
- [ ] hw86: bp-sso-bridge + bp-continuum cascade Ready=True

🤖 Generated with [Claude Code](https://claude.com/claude-code)
