### PR TITLE
fix(catalyst-platform): G117.E2E-D6 — disable applicationsInstanceId migration default (catalyst-migrator image absent on GHCR)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2366,7 +2366,7 @@ name: bp-catalyst-platform
 # validate clean; 4 pre-existing failures (placementSchema bounds in
 # bp-{dmz,rtz}-vcluster + bare-string depends[] in powerdns-admin +
 # sso-bridge) are unrelated to this slice.
-version: 1.4.438
+version: 1.4.439
 appVersion: 1.4.349
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1718,23 +1718,13 @@ security:
 # Per PR #2795 (G117.2 multi-instance Application CRD): backfill spec.instanceId
 # on legacy Application CRs that pre-date the immutable-id field.
 #
-# Defaults align with the chart-side Job emitter at
-# templates/migrate-applications-instanceId-job.yaml. Operators can disable
-# specific migrations via per-Sovereign valuesFrom overlay if they want to
-# defer the backfill to a separate ops window.
+# Default = disabled. The migrator image (catalyst-migrator) is not yet
+# published to GHCR; enabling without the image causes ImagePullBackOff on
+# the post-upgrade Helm hook and stalls the chart roll. Per-Sovereign
+# overlays can flip enabled=true once the image lands.
 migrations:
   applicationsInstanceId:
-    enabled: true
-    dryRun: false
-    serviceAccountName: catalyst-application-migrator
-    image: ghcr.io/openova-io/catalyst-migrator:0.1.0
-
-# ── Migrations (post-install / post-upgrade Helm-hook Jobs) ──────────────
-# Per PR #2795 (G117.2 multi-instance Application CRD): backfill spec.instanceId
-# on legacy Application CRs that pre-date the immutable-id field.
-migrations:
-  applicationsInstanceId:
-    enabled: true
+    enabled: false
     dryRun: false
     serviceAccountName: catalyst-application-migrator
     image: ghcr.io/openova-io/catalyst-migrator:0.1.0


### PR DESCRIPTION
## Summary
- `migrations.applicationsInstanceId.enabled` flipped `true → false` because `catalyst-migrator:0.1.0` is unpublished (GHCR 403). Enabling caused ImagePullBackOff on the post-install Helm hook → stalled chart upgrade → frozen cascade on hw86.
- Deduplicated the values block (PR #2823 introduced two identical blocks).
- Bump 1.4.438 → 1.4.439 for distinct Flux pickup.

## Test plan
- [x] Live evidence on hw86: `catalyst-platform-migrate-applications-instance-id-fsfrx ImagePullBackOff` for 9m+ blocks chart upgrade
- [ ] After merge: GHCR `bp-catalyst-platform:1.4.439` publishes
- [ ] hw86 `bp-catalyst-platform` HR reconciles Ready=True
- [ ] catalyst-api Pod reaches Ready, `/auth/handover` returns 302 (not 503)

Refs #2745 #2819

🤖 Generated with [Claude Code](https://claude.com/claude-code)