### PR TITLE
feat(console): G117.4 #2743 AC3 — Launch button calls /apps/{id}/launch-url

### DIFF
--- a/core/console/src/components/AppDetail.svelte
+++ b/core/console/src/components/AppDetail.svelte
@@ -2,7 +2,7 @@
   import PortalShell from './PortalShell.svelte';
   import {
     getApps, getProvisionStatus, getMyOrgs, installApp, uninstallApp, getUninstallPreview,
-    getBackingServices,
+    getBackingServices, getLaunchURL,
     type User, type Org, type CatalogApp, type Provision, type ConfigField, type UninstallPreview,
     type BackingService,
   } from '../lib/api';
@@ -138,7 +138,7 @@
         } catch {}
       }
       if (msg.startsWith('501')) {
-        modal = { mode: 'add', message: 'Day-2 installs are launching soon — we will email you when live.' };
+        modal = { mode: 'add', message: 'Day-2 installs ship soon — we will email you when live.' };
         modal.pending = false;
         return;
       }
@@ -161,7 +161,7 @@
     } catch (e: any) {
       const msg = e?.message ?? '';
       if (msg.startsWith('501')) {
-        modal = { mode: 'remove', message: 'Day-2 removal is launching soon — we will email you when live.' };
+        modal = { mode: 'remove', message: 'Day-2 removal ships soon — we will email you when live.' };
         modal.pending = false;
         return;
       }
@@ -192,9 +192,54 @@
     confirmUnderstood && app && typedSlug.trim() === app.slug
   );
 
-  function openRunning(org: Org) {
+  // G117.4 #2743 AC3 — Launch button → calls catalyst-api
+  // `GET /catalyst/v1/apps/{id}/launch-url` to mint a silent-SSO URL
+  // (carries `prompt=none` + `kc_idp_hint=catalyst-pin`) and opens it
+  // in a new tab with `noopener,noreferrer`. The catalyst-api handler
+  // takes the installed-Application UID — for the SME tenant flow that
+  // is the catalog `app.id` echoed back through `provision.apps[]`.
+  // If we cannot resolve a per-install id OR the API errors (404 / 409
+  // / 503), we fall back to the previous direct-URL behavior so the
+  // user still gets *somewhere* to land.
+  function fallbackOpenRunning(org: Org) {
     if (!app) return;
-    window.open(`https://${org.slug}.omani.rest/${app.slug}`, '_blank');
+    window.open(`https://${org.slug}.omani.rest/${app.slug}`, '_blank', 'noopener,noreferrer');
+  }
+
+  async function launchApp(org: Org) {
+    if (!app) return;
+    // Prefer the installed instance UID from the provision record; fall
+    // back to org.apps[] (same shape) and finally the catalog id.
+    const installedId =
+      (provision?.apps ?? []).find((id) => id === app!.id) ||
+      (org.apps ?? []).find((id) => id === app!.id) ||
+      app.id;
+    if (!installedId) {
+      fallbackOpenRunning(org);
+      return;
+    }
+    try {
+      const resp = await getLaunchURL(installedId);
+      if (resp && resp.url) {
+        window.open(resp.url, '_blank', 'noopener,noreferrer');
+        return;
+      }
+      fallbackOpenRunning(org);
+    } catch (e: any) {
+      const msg = (e?.message ?? '') as string;
+      // Parsed format: "<status>:<code>:<message>"
+      if (msg.startsWith('409')) {
+        flash(`${app.name}: SSO not enabled for this endpoint`, 'error');
+      } else if (msg.startsWith('404')) {
+        flash(`${app.name}: launch endpoint not found`, 'error');
+      } else if (msg.startsWith('503')) {
+        flash(`${app.name}: cluster unavailable, retrying via direct URL`, 'error');
+        fallbackOpenRunning(org);
+      } else {
+        // Network or unexpected — fall back so the user is not stranded.
+        fallbackOpenRunning(org);
+      }
+    }
   }
 </script>
 
@@ -242,7 +287,11 @@
                 {isInstalling ? 'Installing…' : 'Uninstalling…'}
               </button>
             {:else if isInstalled}
-              <button class="btn btn-primary" onclick={() => org && openRunning(org)}>Open app &rarr;</button>
+              <button
+                class="btn btn-primary"
+                data-testid="btn-launch-app"
+                onclick={() => org && launchApp(org)}
+              >Launch &rarr;</button>
               <button class="btn btn-danger-outline" onclick={() => org && openRemoveModal(org.id)}>Remove</button>
             {:else}
               <button class="btn btn-primary" onclick={() => (modal = { mode: 'add' })}>+ Install</button>
@@ -329,7 +378,7 @@
             <h2>Configuration</h2>
             <p class="section-hint">Tune {app.name} for your workload. Defaults work for most teams.</p>
 
-            <div class="info-banner soft">Day-2 configuration is launching soon — edits will be enabled then.</div>
+            <div class="info-banner soft">Day-2 configuration ships soon — edits will be enabled then.</div>
 
             <div class="config-grid">
               {#each basicFields as f (f.key)}

--- a/core/console/src/lib/api.ts
+++ b/core/console/src/lib/api.ts
@@ -274,6 +274,51 @@ export const uninstallApp = (orgId: string, slug: string) =>
     { method: 'DELETE' },
   );
 
+// G117.4 #2743 AC3 — Launch button calls catalyst-api which mints the
+// signed silent-SSO URL (carries `prompt=none` + `kc_idp_hint=catalyst-pin`).
+// The handler lives on the catalyst-api at `/catalyst/v1/apps/{id}/launch-url`
+// (NOT under the SME `/api` namespace), so we bypass `request()` and hit
+// the route directly from the same origin.
+//
+// Error surfaces (per `endpoint_handler.go:HandleGetLaunchURL`):
+//   - 404 `endpoint-not-found`     — Blueprint has no such endpoint
+//   - 409 `sso-not-enabled`        — endpoint exists but ssoEnabled=false
+//   - 503 `cluster-unavailable`    — k8s client / blueprint fetch failed
+//
+// Callers should catch + fall back to a direct-URL open or toast the error.
+export interface LaunchURLResponse {
+  url: string;
+  expiresAt: string;
+  endpoint?: string;
+}
+
+export const getLaunchURL = async (
+  appId: string,
+  endpoint?: string,
+): Promise<LaunchURLResponse> => {
+  const qs = endpoint ? `?endpoint=${encodeURIComponent(endpoint)}` : '';
+  const path = `/catalyst/v1/apps/${encodeURIComponent(appId)}/launch-url${qs}`;
+  const token = localStorage.getItem('sme-token');
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+  const res = await fetch(path, { headers });
+  if (!res.ok) {
+    let code = `${res.status}`;
+    let message = res.statusText;
+    try {
+      const body = await res.json();
+      if (body && typeof body === 'object') {
+        code = body.code || code;
+        message = body.message || message;
+      }
+    } catch { /* non-JSON body, keep status */ }
+    throw new Error(`${res.status}:${code}:${message}`);
+  }
+  return res.json();
+};
+
 // Backing services (databases, caches, queues) inventory per tenant. Merges
 // catalog metadata with live pod status from provisioning so the console can
 // render name/version/endpoint + a Running/Pending/Failed pill in one call.


### PR DESCRIPTION
## Summary

- core/console SME-tenant AppDetail page now renders **`Launch →`** (was `Open app →`) on every installed app. The handler calls catalyst-api `GET /catalyst/v1/apps/{id}/launch-url` and opens the returned silent-SSO URL (`prompt=none&kc_idp_hint=catalyst-pin`) in a new tab via `window.open(url, '_blank', 'noopener,noreferrer')`.
- New typed helper `getLaunchURL(appId, endpoint?)` + `LaunchURLResponse` interface in `core/console/src/lib/api.ts`. Bypasses `request()` because the catalyst-api launch-URL route lives at `/catalyst/v1/...`, not under the SME `/api/...` namespace. Bearer token is attached for AuthN; 404 / 409 / 503 are parsed and surfaced as `"<status>:<code>:<message>"`.
- Button carries `data-testid="btn-launch-app"` per the brief.
- Three "launching soon" placeholders renamed to "ships soon" / "ship soon" so the word "launching" no longer collides with the real Launch keyword.
- Graceful error handling: 409 sso-not-enabled / 404 endpoint-not-found → toast; 503 cluster-unavailable / network errors → fall back to the previous direct-URL behavior so the user is never stranded.

## Files

- `core/console/src/lib/api.ts` — `getLaunchURL` helper + `LaunchURLResponse` interface.
- `core/console/src/components/AppDetail.svelte` — `launchApp(org)` handler, button label + testid, copy fix.

## Test plan

- [x] `cd core/console && npx svelte-check` — touched files produce **0 new errors** (4 pre-existing errors in `AppsPage.svelte` / `BillingPage.svelte` are unchanged).
- [ ] Manual: install any app on a tenant, click `Launch →` — new tab opens at the silent-SSO URL.
- [ ] Manual: query `getByTestId('btn-launch-app')` from Playwright once #2743 AC4 spec lands.
- [ ] Manual: simulate 503 from catalyst-api — UI falls back to direct URL with a toast.

Refs #2743

🤖 Generated with [Claude Code](https://claude.com/claude-code)