### PR TITLE
feat(catalyst-api): G117.4 #2743 — populate metadata.uid in GET-Application response

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -967,6 +967,18 @@ func isValidK8sName(s string) bool {
 type applicationDetailResponse struct {
 	Name             string                   `json:"name"`
 	Namespace        string                   `json:"namespace"`
+	// UID — the Application CR's metadata.uid, lifted verbatim from
+	// the dynamic-client object. Required by the Catalyst Console's
+	// Launch button (PR #2839, G117.4): the FE calls
+	// `GET /catalyst/v1/apps/{uid}/launch-url` to obtain a
+	// silent-SSO front-door URL (`prompt=none&kc_idp_hint=catalyst-pin`).
+	// Without this field the FE has nothing to key the launch-url
+	// lookup on and falls back to direct externalURL on every click,
+	// defeating the silent-SSO codepath. Empty when the response is
+	// synthesised from a HelmRelease (bootstrap-kit installs with no
+	// companion Application CR — those have no Application UID).
+	// Refs #2743 #2834 #2839.
+	UID              string                   `json:"uid"`
 	Blueprint        string                   `json:"blueprint,omitempty"`
 	Version          string                   `json:"version,omitempty"`
 	EnvironmentRef   string                   `json:"environmentRef,omitempty"`
@@ -1096,6 +1108,7 @@ func (h *Handler) HandleApplicationGet(w http.ResponseWriter, r *http.Request) {
 	resp := applicationDetailResponse{
 		Name:       obj.GetName(),
 		Namespace:  obj.GetNamespace(),
+		UID:        string(obj.GetUID()),
 		Conditions: []map[string]interface{}{},
 	}
 	if v, ok, _ := unstructured.NestedString(obj.Object, "spec", "blueprintRef", "name"); ok {

--- a/products/catalyst/bootstrap/api/internal/handler/applications_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 
@@ -675,3 +676,64 @@ func TestHandleApplicationInstall_502OnCatalogUpstreamError(t *testing.T) {
 //    client surfaces AlreadyExists naturally for duplicate Create), but
 //    keep the import-check by referencing once.
 var _ = apierrors.IsConflict
+
+// TestHandleApplicationGet_PopulatesUID — Refs #2743 #2834 #2839.
+//
+// PR #2839 (G117.4 containment) added the Catalyst Console Launch
+// button which calls `GET /catalyst/v1/apps/{uid}/launch-url` to
+// obtain a silent-SSO front-door URL. The console resolves `{uid}`
+// from the `ApplicationDetailResponse.uid` field returned by
+// `GET /sovereigns/{id}/applications/{name}`. Prior to this change
+// the backend response omitted `metadata.uid` entirely, so the FE
+// fell back to direct externalURL on every click and the
+// silent-SSO codepath was never exercised.
+//
+// This test seeds an Application CR with a known UID, calls the GET
+// handler, and asserts the response body contains the exact UID
+// under the `uid` JSON key. Failure mode = field absent or wrong
+// value → FE Launch button degrades to fallback URL.
+func TestHandleApplicationGet_PopulatesUID(t *testing.T) {
+	const wantUID = "01abcdef-0123-4567-89ab-cdef01234567"
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	app := &unstructured.Unstructured{}
+	app.SetAPIVersion("apps.openova.io/v1")
+	app.SetKind("Application")
+	app.SetName("wp-prod")
+	app.SetNamespace("acme")
+	app.SetUID(k8stypes.UID(wantUID))
+	_ = unstructured.SetNestedField(app.Object, "Ready", "status", "phase")
+	factory, _ := fakeApplicationDynamicFactory(app)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-app-get-uid")
+
+	register := func(r chi.Router, hh *Handler) {
+		r.Get("/api/v1/sovereigns/{id}/applications/{name}", hh.HandleApplicationGet)
+	}
+	rec := callUserAccess(t, h, http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/applications/wp-prod", nil, register)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Decode-and-check on the typed struct guards the Go field name +
+	// JSON tag together.
+	var resp applicationDetailResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.UID != wantUID {
+		t.Fatalf("uid (typed): got %q want %q", resp.UID, wantUID)
+	}
+	if resp.Name != "wp-prod" || resp.Namespace != "acme" {
+		t.Fatalf("name/ns: got %q/%q", resp.Name, resp.Namespace)
+	}
+
+	// Substring-check on the raw JSON guards the wire-shape — the
+	// json tag must literally render as `"uid":"<uid>"` (not `"UID"`,
+	// not `"metadata":{"uid":...}`). PR #2839's FE TS interface keys
+	// on `uid`.
+	if !strings.Contains(rec.Body.String(), `"uid":"`+wantUID+`"`) {
+		t.Fatalf("expected `\"uid\":\"%s\"` in JSON; got %s", wantUID, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

- Add `UID string` (`json:"uid"`) to `applicationDetailResponse` and populate from `obj.GetUID()` in `HandleApplicationGet`
- Without this field, PR #2839's Catalyst Console Launch button has nothing to key `GET /catalyst/v1/apps/{uid}/launch-url` on, so it falls back to direct `externalURL` on every click and the silent-SSO codepath (`prompt=none&kc_idp_hint=catalyst-pin`) never fires
- New unit test `TestHandleApplicationGet_PopulatesUID` asserts both the typed struct field AND raw JSON wire-shape carry `"uid":"<uid>"`

## Wiring

`HandleApplicationGet` (`products/catalyst/bootstrap/api/internal/handler/applications.go:1044`) reads the Application CR via the dynamic client and marshals into `applicationDetailResponse`. The CR's `metadata.uid` was being discarded. Lifted into the response struct so the FE can resolve it.

Mirrors existing patterns:
- `applications_update.go:432` — `UID: string(updated.GetUID())`
- `k8s_resource_tree.go:235` — `uid := string(obj.GetUID())`

For the `synthesiseAppFromHelmRelease` fallback (bootstrap-kit installs with no Application CR), `UID` is left empty — those apps have no Application UID so `findApplicationByUID` can't resolve them anyway, and the FE will keep falling back to `externalURL` for them (correct behaviour).

## Test plan

- [x] `go test ./products/catalyst/bootstrap/api/internal/handler/... -run TestHandleApplicationGet_PopulatesUID -v` PASS
- [x] Full handler test suite PASS (`go test ./internal/handler/...` — 61s, no failures)
- [x] Full `products/catalyst/bootstrap/api/...` module PASS (no failures across all packages)
- [ ] Founder walk on a live Sovereign: open Catalyst Console → app detail → click Launch → observe browser navigates to `kc_idp_hint=catalyst-pin&prompt=none` redirect chain (not direct externalURL fallback)

## Why `Refs` not `Closes`

#2743 (G117.4 EPIC) is operator-walk-gated per docs/PRINCIPLES.md anti-pattern catalog (PR-merge ≠ pillar shipped). This PR is the backend half of the launch-button fix; FE half ships in PR #2839; closure depends on founder walk landing on the issue.

Refs #2743 #2834 #2839

🤖 Generated with [Claude Code](https://claude.com/claude-code)