### PR TITLE
fix(huawei-cloudinit): #2842 — remove broken ghcr.io/quay.io/reg.kyverno.io anonymous proxy mirrors

### DIFF
--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -60,9 +60,21 @@ write_files:
       # registry-1.docker.io upstream). Wave 5.105 tried :5000/v2/proxy-dockerhub
       # but containerd appends /v2/<image> → double-/v2/ → 404. The :5002 proxy
       # serves /v2/<image> directly, matching containerd canonical mirror semantics.
-      # Wave 5.109 (#2462 follow-up): extend mirror set to cover ghcr.io,
-      # reg.kyverno.io, quay.io via dedicated bastion proxies :5003/:5004/:5005.
-      # See cloudinit-worker.tftpl Wave 5.109 comment for full rationale.
+      #
+      # #2842 (2026-06-03) — REMOVED ghcr.io / reg.kyverno.io / quay.io mirror
+      # entries (previously bastion :5003/:5004/:5005). RCA: the bastion proxies
+      # are anonymous-only registry:2 instances; they CANNOT authenticate against
+      # private packages under `ghcr.io/openova-io/*`. Live evidence on hw86
+      # wea28e1: containerd looped on stale-ingest-lock for 25+ min against
+      # ghcr.io/openova-io/catalyst-api after :5003 returned HTTP 401, and the
+      # catalyst-api Pod stayed in CreateContainerConfigError. Direct pull (no
+      # mirror rewrite) uses the per-namespace `ghcr-pull` Secret seeded above
+      # (reflector-mirrored to every workload namespace) and succeeds in seconds.
+      # reg.kyverno.io + quay.io are purely public — direct pull is canonical.
+      # harbor.openova.io mirror is KEPT because :5000 has a working
+      # `harbor-robot-token` via the reflected Secret. docker.io /
+      # registry-1.docker.io mirrors are KEPT because :5002 is a public-image
+      # cache (no auth required).
       mirrors:
         "harbor.openova.io":
           endpoint:
@@ -73,29 +85,11 @@ write_files:
         "registry-1.docker.io":
           endpoint:
             - "http://212.72.24.20:5002"
-        "ghcr.io":
-          endpoint:
-            - "http://212.72.24.20:5003"
-        "reg.kyverno.io":
-          endpoint:
-            - "http://212.72.24.20:5004"
-        "quay.io":
-          endpoint:
-            - "http://212.72.24.20:5005"
       configs:
         "212.72.24.20:5000":
           tls:
             insecure_skip_verify: true
         "212.72.24.20:5002":
-          tls:
-            insecure_skip_verify: true
-        "212.72.24.20:5003":
-          tls:
-            insecure_skip_verify: true
-        "212.72.24.20:5004":
-          tls:
-            insecure_skip_verify: true
-        "212.72.24.20:5005":
           tls:
             insecure_skip_verify: true
 

--- a/infra/providers/huawei/cloudinit-worker.tftpl
+++ b/infra/providers/huawei/cloudinit-worker.tftpl
@@ -37,15 +37,21 @@ write_files:
       # intermittently (`dial tcp: lookup production.cloudfront.docker.com: Try
       # again`) → ImagePullBackOff → CNPG postgres init never completes → bp-gitea/
       # bp-catalyst-platform/sov-tls cascading FAIL (hw07 49d43efbaf2a46c2 evidence).
-      # Wave 5.109 (#2462 follow-up): extend mirror set to cover ghcr.io
-      # (cnpg/flux-controllers/openova-flow/trivy/aquasec all live there),
-      # reg.kyverno.io (kyverno admission + reports controllers), quay.io
-      # (cert-manager/jetstack and future Calico/Tigera). All flow through
-      # dedicated bastion registry:2 proxies — :5003/:5004/:5005 spun up
-      # alongside the existing :5000 (harbor.openova.io) + :5002 (docker.io).
-      # Live evidence: hw09 6d9eb655 + hw10 4284fe92 — bp-cnpg stuck in
-      # ImagePullBackOff on cnpg-cloudnative-pg:1.29.0 (ghcr.io) → cascading
-      # bp-openbao/bp-gitea/bp-catalyst-platform.
+      #
+      # #2842 (2026-06-03) — REMOVED ghcr.io / reg.kyverno.io / quay.io mirror
+      # entries (previously bastion :5003/:5004/:5005). RCA: the bastion proxies
+      # are anonymous-only registry:2 instances; they CANNOT authenticate against
+      # private packages under `ghcr.io/openova-io/*`. Live evidence on hw86
+      # wea28e1: containerd looped on stale-ingest-lock for 25+ min against
+      # ghcr.io/openova-io/catalyst-api after :5003 returned HTTP 401, and the
+      # catalyst-api Pod stayed in CreateContainerConfigError. Direct pull (no
+      # mirror rewrite) uses the per-namespace `ghcr-pull` Secret reflector-
+      # mirrored from flux-system and succeeds in seconds. reg.kyverno.io +
+      # quay.io are purely public — direct pull is the canonical path.
+      # harbor.openova.io mirror is KEPT because :5000 has a working
+      # `harbor-robot-token` via the reflected Secret. docker.io /
+      # registry-1.docker.io mirrors are KEPT because :5002 is a public-image
+      # cache (no auth required).
       mirrors:
         "harbor.openova.io":
           endpoint:
@@ -56,29 +62,11 @@ write_files:
         "registry-1.docker.io":
           endpoint:
             - "http://212.72.24.20:5002"
-        "ghcr.io":
-          endpoint:
-            - "http://212.72.24.20:5003"
-        "reg.kyverno.io":
-          endpoint:
-            - "http://212.72.24.20:5004"
-        "quay.io":
-          endpoint:
-            - "http://212.72.24.20:5005"
       configs:
         "212.72.24.20:5000":
           tls:
             insecure_skip_verify: true
         "212.72.24.20:5002":
-          tls:
-            insecure_skip_verify: true
-        "212.72.24.20:5003":
-          tls:
-            insecure_skip_verify: true
-        "212.72.24.20:5004":
-          tls:
-            insecure_skip_verify: true
-        "212.72.24.20:5005":
           tls:
             insecure_skip_verify: true
 


### PR DESCRIPTION
## Summary

The Huawei cloud-init `registries.yaml` previously rewrote pulls for `ghcr.io` / `reg.kyverno.io` / `quay.io` through bastion proxies at `:5003` / `:5004` / `:5005` (Wave 5.109). Those proxies are **anonymous-only registry:2 instances** and **cannot authenticate** against private packages under `ghcr.io/openova-io/*`.

This PR removes those three mirror entries (and their `configs:` TLS-skip stanzas) from both the control-plane and worker cloud-init templates, restoring direct pull (which uses the per-namespace `ghcr-pull` Secret that the control-plane cloud-init already seeds).

## Live RCA evidence — #2842 (hw86 wea28e1)

G3 walked the catalyst-api Pod 25-minute hang on hw86. Root cause: bastion proxy at `212.72.24.20:5003` (ghcr-proxy) is anonymous-only — cannot fetch private `ghcr.io/openova-io/*` packages → returns HTTP 401 → containerd stuck in stale-ingest-lock loop on `ghcr.io/openova-io/catalyst-api`. G3 hand-patched `/var/lib/rancher/k3s/agent/etc/containerd/certs.d/ghcr.io/hosts.toml` on `wea28e1` to remove the broken mirror — pull succeeded immediately.

This PR codifies that fix so future provs don't reproduce the bug.

## Behavior

| Registry | Pre-PR | Post-PR | Why |
|---|---|---|---|
| `harbor.openova.io` | mirror :5000 | **mirror :5000** (KEPT) | bastion has working `harbor-robot-token`; Sovereign-local OCI artifacts |
| `docker.io` / `registry-1.docker.io` | mirror :5002 | **mirror :5002** (KEPT) | public-image cache, no auth required |
| `ghcr.io` | mirror :5003 (anon, HTTP 401 on private) | **direct pull** (uses `ghcr-pull` Secret) | per-namespace `ghcr-pull` Secret is reflector-mirrored from flux-system to every workload namespace (Wave 5.95); direct pull authenticates correctly |
| `reg.kyverno.io` | mirror :5004 (anon) | **direct pull** | purely public, no benefit from anon mirror |
| `quay.io` | mirror :5005 (anon) | **direct pull** | purely public, no benefit from anon mirror |

## Out of scope

- **Hetzner side**: Hetzner cloud-init does not configure these mirror entries (uses `harbor.openova.io` directly). Separate audit issue per #2842.
- **Bastion proxy decommission**: this PR leaves the bastion :5003/:5004/:5005 registry:2 instances running. They are harmless now that no Sovereign rewrites traffic to them; cleanup is a separate operational task.

## Validation

- Both files' `registries.yaml` content block parses as valid YAML via `python3 -c yaml.safe_load`.
- Diff: 2 files changed, 30 insertions, 48 deletions.
- Added inline `#2842` RCA comment above the remaining mirror entries in both templates so future hands don't re-add the broken entries.

## Test plan

- [ ] Fresh Huawei prov (next dispatched Sovereign) reaches catalyst-api Ready without the 25-min ghcr.io stale-ingest-lock loop.
- [ ] `kubectl -n catalyst-system logs <catalyst-api-pod>` shows no `401 Unauthorized` against `212.72.24.20:5003` during image pull.
- [ ] `crictl -r unix:///run/k3s/containerd/containerd.sock pull ghcr.io/openova-io/catalyst-api:<tag>` from a CP node succeeds without bastion mirror.

Refs #2842 #2840 #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)