### PR TITLE
fix(bootstrap-kit): suspend Hetzner-provider-only HRs on HCS Sovereigns (bp-cluster-autoscaler-hcloud, bp-hcloud-ccm, bp-velero)

### DIFF
--- a/clusters/_template/bootstrap-kit/34-velero.yaml
+++ b/clusters/_template/bootstrap-kit/34-velero.yaml
@@ -6,6 +6,22 @@
 # which is reserved as a POSIX→S3 buffer for legacy POSIX-only writers
 # and is not in the minimal Sovereign set.
 #
+# INTENTIONALLY SUSPENDED on non-Hetzner providers (e.g. HCS / Huawei).
+# `kubectl get hr bp-velero` showing empty READY/STATUS columns on a
+# HCS Sovereign is BY DESIGN — Flux does not reconcile suspended HRs,
+# so no Ready condition is ever written. See
+# `${HCLOUD_HR_SUSPEND:=false}` gate on `spec.suspend` below (Wave
+# 5.102 / PR #2447). The cloudinit at
+# `infra/providers/huawei/cloudinit-control-plane.tftpl` substitutes
+# HCLOUD_HR_SUSPEND="true" on HCS Sovereigns; the Hetzner cloudinit
+# leaves the default (false). The verify script at
+# `scripts/sovereign-dod-verify.sh` correctly EXCLUDES this HR from
+# REQUIRED_HRs and from the Ready=False tally — no action needed.
+# Velero on Hetzner targets Hetzner Object Storage via the s3-* keys
+# of `flux-system/object-storage`; an HCS-native equivalent that
+# targets Huawei OBS is tracked as a Wave 6 follow-up so backups are
+# still mandatory on every Sovereign, just via a different chart.
+#
 # Wrapper chart: platform/velero/chart/ (umbrella over upstream
 # vmware-tanzu/velero chart, Catalyst-curated values under the `velero:`
 # key + a vendor-AGNOSTIC `objectStorage.s3.*` section that ships the

--- a/clusters/_template/bootstrap-kit/50-cluster-autoscaler.yaml
+++ b/clusters/_template/bootstrap-kit/50-cluster-autoscaler.yaml
@@ -5,6 +5,21 @@
 # (bp-cert-manager-powerdns-webhook) — to preserve the existing
 # numbering plan.
 #
+# INTENTIONALLY SUSPENDED on non-Hetzner providers (e.g. HCS / Huawei).
+# `kubectl get hr bp-cluster-autoscaler-hcloud` showing empty
+# READY/STATUS columns is BY DESIGN — Flux does not reconcile suspended
+# HRs, so no Ready condition is ever written. See
+# `${HCLOUD_HR_SUSPEND:=false}` gate on `spec.suspend` below (Wave
+# 5.102 / PR #2447). The cloudinit at
+# `infra/providers/huawei/cloudinit-control-plane.tftpl` substitutes
+# HCLOUD_HR_SUSPEND="true" on HCS Sovereigns; the Hetzner cloudinit
+# leaves the default (false). The verify script at
+# `scripts/sovereign-dod-verify.sh` correctly EXCLUDES this HR from
+# REQUIRED_HRs and from the Ready=False tally — no action needed.
+# Do NOT investigate this HR's empty status on HCS Sovereigns; that
+# is the correct end-state. An HCS-native autoscaler equivalent is
+# tracked as a Wave 6 follow-up.
+#
 # Adds and removes Hetzner Cloud worker nodes on demand in response to
 # `FailedScheduling` events on the Sovereign's k3s cluster. Bounded by
 # the `min`/`max` node-group config the operator picked at launch.

--- a/clusters/_template/bootstrap-kit/55-bp-hcloud-ccm.yaml
+++ b/clusters/_template/bootstrap-kit/55-bp-hcloud-ccm.yaml
@@ -3,6 +3,19 @@
 # (slot 50) and bp-hcloud-csi (slot 51, when present) — the full
 # Hetzner-cloud-direct trio.
 #
+# INTENTIONALLY SUSPENDED on non-Hetzner providers (e.g. HCS / Huawei).
+# `kubectl get hr bp-hcloud-ccm` showing empty READY/STATUS columns is
+# BY DESIGN — Flux does not reconcile suspended HRs, so no Ready
+# condition is ever written. See `${HCLOUD_HR_SUSPEND:=false}` gate on
+# `spec.suspend` below (Wave 5.102 / PR #2447). The cloudinit at
+# `infra/providers/huawei/cloudinit-control-plane.tftpl` substitutes
+# HCLOUD_HR_SUSPEND="true" on HCS Sovereigns; the Hetzner cloudinit
+# leaves the default (false). The verify script at
+# `scripts/sovereign-dod-verify.sh` correctly EXCLUDES this HR from
+# REQUIRED_HRs and from the Ready=False tally — no action needed.
+# Do NOT investigate this HR's empty status on HCS Sovereigns; that
+# is the correct end-state.
+#
 # Wires hcloud-cloud-controller-manager into the cluster as the canonical
 # Hetzner cloud-provider integration. Without this CCM running:
 #   - Node providerID stays as k3s://<node-name> (kube-controller-manager


### PR DESCRIPTION
## Summary

Clarifies that the 3 Hetzner-provider-only bootstrap-kit HRs — `bp-cluster-autoscaler-hcloud` (slot 50), `bp-hcloud-ccm` (slot 55), `bp-velero` (slot 34) — are **intentionally suspended** on non-Hetzner Sovereigns (HCS / Huawei) by the existing Wave 5.102 (#2447) `${HCLOUD_HR_SUSPEND:=false}` envsubst gate. `kubectl get hr` rendering empty `READY`/`STATUS` columns for these 3 HRs on hw86 is the **correct end-state** — Flux upstream does not write a `Ready` condition for suspended HRs.

## What changed

Adds a prominent `INTENTIONALLY SUSPENDED on non-Hetzner providers` header block to each of the 3 slot files (44 insertions, 0 deletions). The header explains:
- the empty `kubectl get hr` columns are by design
- cross-references the existing envsubst gate, the cloudinit substitution, and the `scripts/sovereign-dod-verify.sh` exclusions (which already correctly handle these)
- instructs future operators **not** to investigate the empty status

No behavior change. Pure code-comment / operator-readability improvement to prevent recurring investigations.

## Why this is documentation-only

The provider-aware suspend logic was already shipped in Wave 5.102 / PR #2447:
- `clusters/_template/bootstrap-kit/{34,50,55}-*.yaml` already gate `spec.suspend` on `${HCLOUD_HR_SUSPEND:=false}`
- `infra/providers/huawei/cloudinit-control-plane.tftpl` already substitutes `HCLOUD_HR_SUSPEND="true"` on HCS
- `scripts/sovereign-dod-verify.sh` already excludes the 3 HRs from `REQUIRED_HRs` (lines 161-180) and from the `Ready=False` tally with reason=Suspended check (lines 211-213)

Verified live on hw86 (HCS me-east-215, provider=huawei):
```
bp-cluster-autoscaler-hcloud   suspend=true   conditions=null
bp-hcloud-ccm                  suspend=true   conditions=null
bp-velero                      suspend=true   conditions=null
```
All 49 other HRs `Ready=True`.

## Velero follow-up

The slot-34 header explicitly notes that Velero is mandatory on every Sovereign for backups, and an HCS-native equivalent (Velero with Huawei OBS backend) is tracked as a Wave 6 follow-up. The current Wave-5 state on HCS suspends backups — this PR does NOT change that; it only documents it so the gap is visible.

Refs #2737

## Test plan

- [x] `git diff --stat` shows 3 files, 44 insertions, 0 deletions
- [x] All 3 slot files contain `INTENTIONALLY SUSPENDED` header
- [x] Live verification on hw86 (suspend=true, all other 49 HRs Ready=True)
- [ ] Operator-side: next time `kubectl get hr` shows empty READY for these 3, the slot-file header explains why before investigation is started