### PR TITLE
feat(catalyst-migrator): #2830 — build + publish catalyst-migrator:0.1.0 image + imagePullSecrets fix

### DIFF
--- a/.github/workflows/build-catalyst-migrator.yaml
+++ b/.github/workflows/build-catalyst-migrator.yaml
@@ -1,0 +1,158 @@
+name: Build catalyst-migrator
+
+# catalyst-migrator — runtime image for one-shot Catalyst schema-migration
+# Jobs. Currently consumed by the bp-catalyst-platform post-install/
+# post-upgrade Helm hook Job that backfills G117 W2.C2 fields on legacy
+# Application CRs.
+#
+# Why this workflow exists (Refs #2830):
+#   bp-catalyst-platform 1.4.438 (PR #2823) added the migration Job
+#   referencing `ghcr.io/openova-io/catalyst-migrator:0.1.0`. The image
+#   was never published. PR #2831 (1.4.439) flipped the default to
+#   `enabled: false` to unblock the cascade. This workflow finally
+#   ships the image so the chart default can flip back to true on a
+#   later cycle once operators have verified the migration on a legacy-
+#   CR cluster.
+#
+# Per docs/PRINCIPLES.md #4a (GitHub Actions is the only build path) +
+# event-driven (no cron). Multi-arch (linux/amd64 + linux/arm64) since
+# Sovereigns increasingly run on ARM bare-metal where it's cheaper.
+
+on:
+  push:
+    paths:
+      - 'products/catalyst-migrator/**'
+      - 'products/catalyst/chart/files/migrate-applications-instanceId.py'
+      - '.github/workflows/build-catalyst-migrator.yaml'
+    branches: [main]
+  pull_request:
+    paths:
+      - 'products/catalyst-migrator/**'
+      - '.github/workflows/build-catalyst-migrator.yaml'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Semver tag to publish (e.g. 0.1.0). Always pushed alongside <short-sha>.'
+        required: false
+        default: '0.1.0'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/openova-io/catalyst-migrator
+  CONTEXT: products/catalyst-migrator
+  # Default semver tag — bump alongside the chart consumer's pinned
+  # `migrations.applicationsInstanceId.image` value.
+  DEFAULT_RELEASE_TAG: '0.1.0'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # id-token write — cosign keyless (Sigstore OIDC).
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve release tag
+        id: vars
+        run: |
+          set -euo pipefail
+          short_sha="${GITHUB_SHA::7}"
+          release_tag="${{ inputs.release_tag }}"
+          release_tag="${release_tag:-${DEFAULT_RELEASE_TAG}}"
+          echo "sha_short=${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
+          echo "Will publish ${IMAGE}:${short_sha} + ${IMAGE}:${release_tag} + ${IMAGE}:latest"
+
+      - name: Set up QEMU (multi-arch emulation)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # On pull_request we stop after a local single-arch build to keep
+      # PR CI cheap. Image push + multi-arch + sign only on main.
+      - name: Build (PR dry-run, no push)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.CONTEXT }}
+          file: ${{ env.CONTEXT }}/Dockerfile
+          push: false
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build + push multi-arch image
+        id: build
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.CONTEXT }}
+          file: ${{ env.CONTEXT }}/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.vars.outputs.sha_short }}
+            ${{ env.IMAGE }}:${{ steps.vars.outputs.release_tag }}
+            ${{ env.IMAGE }}:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/openova-io/openova
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.title=catalyst-migrator
+            org.opencontainers.image.description=Runtime image for one-shot Catalyst CR schema migrations (python3 + kubectl).
+            org.opencontainers.image.version=${{ steps.vars.outputs.release_tag }}
+          # provenance=false: same containerd 1.7.x quirk on k3s as the
+          # rest of our build-* workflows — SBOM attest handled by cosign
+          # below instead of buildkit's native provenance manifest.
+          provenance: false
+          sbom: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image with cosign (keyless)
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      - name: Attest SBOM
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign attest --yes \
+            --predicate <(echo '{"sbom":"in-toto-spdx attached at build time"}') \
+            --type spdx \
+            "${IMAGE}@${DIGEST}"
+
+      - name: Summary
+        if: github.event_name != 'pull_request'
+        run: |
+          {
+            echo "## catalyst-migrator published"
+            echo ""
+            echo "- Image: \`${IMAGE}:${{ steps.vars.outputs.release_tag }}\`"
+            echo "- Sha tag: \`${IMAGE}:${{ steps.vars.outputs.sha_short }}\`"
+            echo "- Platforms: \`linux/amd64\`, \`linux/arm64\`"
+            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
+            echo "- Refs #2830 (post-publish, operators may flip \`migrations.applicationsInstanceId.enabled=true\`)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -902,7 +902,11 @@ spec:
       # G117 fields (spec.topology / endpoints / sso / multiInstance)
       # into the Blueprint CRD openAPIV3Schema so runtime admission
       # gates them — preserve-unknown no longer silently swallows.
-      version: 1.4.444
+      # 1.4.445 (#2830 followup, 2026-06-03): ships catalyst-migrator:0.1.0
+      # image build workflow + imagePullSecrets:[ghcr-pull] on the
+      # migration Job Pod spec. Default remains enabled=false until
+      # operators verify on a legacy-CR cluster.
+      version: 1.4.445
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst-migrator/Dockerfile
+++ b/products/catalyst-migrator/Dockerfile
@@ -1,0 +1,64 @@
+# catalyst-migrator — minimal runtime image for one-shot Catalyst schema
+# migration Jobs (currently: G117 W2.C2 backfill of spec.instanceId /
+# spec.isolationLevel / spec.namingTemplate on legacy Application CRs).
+#
+# Why a dedicated image?
+#   The bp-catalyst-platform chart's `migrate-applications-instanceId-job.yaml`
+#   delivers the script via ConfigMap and mounts it at /opt/migrations/.
+#   The Pod just needs (a) a working python3 stdlib and (b) the kubectl
+#   client binary so the script can shell out for CR patches. The Catalyst
+#   controllers' own images are Distroless-static — no python, no kubectl —
+#   so they cannot host this Job.
+#
+# Image surface (kept intentionally small):
+#   - Alpine base (smaller than python:3.x-slim, no dpkg dance for kubectl)
+#   - python3 from Alpine's apk (pure stdlib only — the script uses
+#     `subprocess`, `json`, `argparse`, `sys`, no pip deps)
+#   - kubectl pinned to v1.31.4 (matches the cluster API server floor
+#     that bp-cilium ships in our supported Sovereigns 2026-06)
+#   - runs as UID 65532 (nonroot), readOnlyRootFilesystem-compatible
+#     (the script writes only to stdout)
+#
+# Refs #2830 — script + Job are shipped by bp-catalyst-platform 1.4.438;
+# this image is the missing GHCR artifact that the Job pulls.
+
+FROM alpine:3.20
+
+ARG KUBECTL_VERSION=v1.31.4
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
+# Tini for proper PID-1 signal handling on Job termination.
+# ca-certificates so kubectl can talk TLS to the in-cluster API server
+# (the projected serviceaccount-token CA bundle is layered at runtime).
+RUN apk add --no-cache \
+        ca-certificates \
+        python3 \
+        tini \
+        curl \
+    && curl -fsSLo /usr/local/bin/kubectl \
+        "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl" \
+    && chmod 0755 /usr/local/bin/kubectl \
+    && apk del curl \
+    && rm -rf /var/cache/apk/* \
+    && kubectl version --client=true
+
+# Non-root user matching the Job Pod spec
+# (runAsUser: 65532 / runAsNonRoot: true).
+RUN addgroup -S -g 65532 catalyst \
+    && adduser -S -u 65532 -G catalyst -h /home/catalyst catalyst
+
+USER 65532:65532
+WORKDIR /home/catalyst
+
+# Default ENTRYPOINT runs through tini so SIGTERM from kubelet reaches
+# the python process cleanly during eviction. The actual command is
+# supplied by the bp-catalyst-platform Job template
+# (/usr/bin/python3 /opt/migrations/migrate-applications-instanceId.py).
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["/usr/bin/python3", "--version"]
+
+LABEL org.opencontainers.image.source="https://github.com/openova-io/openova"
+LABEL org.opencontainers.image.title="catalyst-migrator"
+LABEL org.opencontainers.image.description="Runtime image for one-shot Catalyst CR schema migrations (python3 + kubectl)."
+LABEL org.opencontainers.image.licenses="Apache-2.0"

--- a/products/catalyst-migrator/README.md
+++ b/products/catalyst-migrator/README.md
@@ -1,0 +1,55 @@
+# catalyst-migrator
+
+Minimal runtime image for one-shot Catalyst schema-migration `Job`s.
+
+## What it is
+
+A small Alpine-based image bundling `python3` (stdlib only) + `kubectl`.
+It exists so the bp-catalyst-platform chart's Helm-hook migration `Job`s
+have a known, signed runtime to execute against — the Catalyst control-plane
+images themselves are Distroless-static and cannot host python.
+
+| Field | Value |
+|------:|:------|
+| Image | `ghcr.io/openova-io/catalyst-migrator` |
+| Tag pattern | `0.1.0`, `<short-sha>`, `latest` |
+| Base | `alpine:3.20` |
+| Platforms | `linux/amd64`, `linux/arm64` |
+| Signing | Cosign keyless (Sigstore) |
+| User | UID/GID `65532` (nonroot) |
+
+## What it runs
+
+Currently exactly one consumer:
+
+- bp-catalyst-platform -> `templates/migrate-applications-instanceId-job.yaml`
+  -> runs `/usr/bin/python3 /opt/migrations/migrate-applications-instanceId.py`
+  (script mounted via ConfigMap; see `products/catalyst/chart/files/`).
+
+The Job is the G117 W2.C2 backfill that adds `spec.instanceId`,
+`spec.isolationLevel`, and `spec.namingTemplate` to legacy `Application` CRs.
+
+## How it ships
+
+- Source: this directory (`products/catalyst-migrator/Dockerfile`).
+- CI: `.github/workflows/build-catalyst-migrator.yaml`. Triggers on any
+  push to `products/catalyst-migrator/**` or
+  `products/catalyst/chart/files/migrate-*.py`. Multi-arch build,
+  publishes `:0.1.0` + `:<short-sha>` + `:latest`, cosign-signed.
+- Registry: `ghcr.io/openova-io/catalyst-migrator:<tag>`. Public read.
+
+## How to use it (operators)
+
+The chart defaults `migrations.applicationsInstanceId.enabled=false`
+because the image was historically absent (Refs #2830). With the image
+now published, operators with legacy Application CRs can opt in via
+per-Sovereign Helm overlay:
+
+```yaml
+migrations:
+  applicationsInstanceId:
+    enabled: true
+    dryRun: false  # first pass with true to log planned patches
+```
+
+Refs #2830 #2823.

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,12 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.445 — #2830 followup (2026-06-03): the catalyst-migrator:0.1.0 image
+# is now published to GHCR (build-catalyst-migrator.yaml workflow added at
+# the same PR) AND the migration Job Pod spec now carries
+# `imagePullSecrets: [ghcr-pull]` so the GHCR pull authenticates. The
+# `migrations.applicationsInstanceId.enabled` default stays FALSE this
+# cycle — operators must verify the migration on a legacy-CR cluster
+# before re-enabling globally. Refs #2830 #2823 #2834.
 # 1.4.439 — G117.E2E-A1 #2830 (2026-06-03): default
 # `.Values.migrations.applicationsInstanceId.enabled` to FALSE until the
 # `ghcr.io/openova-io/catalyst-migrator:0.1.0` image actually exists on
@@ -2391,7 +2398,7 @@ name: bp-catalyst-platform
 # bp-{dmz,rtz}-vcluster + bare-string depends[] in powerdns-admin +
 # sso-bridge) are unrelated to this slice.
 # (Bumped 440 → 441 to absorb concurrent merges since PR #2825 opened.)
-version: 1.4.444
+version: 1.4.445
 appVersion: 1.4.349
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/templates/migrate-applications-instanceId-job.yaml
+++ b/products/catalyst/chart/templates/migrate-applications-instanceId-job.yaml
@@ -38,6 +38,17 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ .Values.migrations.applicationsInstanceId.serviceAccountName | default "catalyst-application-migrator" }}
+      # #2830 — `ghcr.io/openova-io/catalyst-migrator` is hosted on GHCR,
+      # which still 403s anonymous pulls under our org policy. Mirror the
+      # `imagePullSecrets: [ghcr-pull]` pattern used by api-deployment.yaml
+      # so the Job Pod can authenticate against the org-wide pull Secret
+      # that Flux already projects into the catalyst-system namespace.
+      # Without this, ImagePullBackOff blocks the Helm hook -> backoffLimit
+      # exhausts -> bp-catalyst-platform HR rolls back -> bp-sso-bridge /
+      # bp-continuum stall on dependency-not-ready (the original #2830
+      # cascade on hw86 2026-06-03).
+      imagePullSecrets:
+        - name: ghcr-pull
       containers:
         - name: migrate
           image: {{ .Values.migrations.applicationsInstanceId.image | default "ghcr.io/openova-io/catalyst-migrator:0.1.0" | quote }}


### PR DESCRIPTION
## Summary

Closes the catalyst-migrator-image gap from #2830 by actually shipping the missing artifact (Option (A) of the issue's suggested fix scope).

- **New image source**: `products/catalyst-migrator/Dockerfile` — Alpine 3.20 + python3 (stdlib only) + kubectl v1.31.4 + tini, nonroot UID 65532, `readOnlyRootFilesystem`-compatible. Small surface; the bp-catalyst-platform chart already delivers the migration script via ConfigMap and only needs a runtime that can execute it.
- **New CI workflow**: `.github/workflows/build-catalyst-migrator.yaml` — multi-arch (`linux/amd64` + `linux/arm64`) GHCR publish with cosign keyless signing + SBOM attest, mirroring the existing `build-blueprint-controller.yaml` pattern. Tags `:0.1.0` + `:<short-sha>` + `:latest`.
- **imagePullSecrets fix** on `migrate-applications-instanceId-job.yaml` — the Pod spec previously had no `imagePullSecrets`; even with the image published, GHCR 403s anonymous pulls under our org policy. Mirrors the `[{name: ghcr-pull}]` pattern that `api-deployment.yaml` already uses for catalyst-api.
- **Chart lockstep**: `bp-catalyst-platform` 1.4.444 -> 1.4.445; bootstrap-kit slot 13 pin updated to match.

## What this does NOT do

- Does NOT flip `migrations.applicationsInstanceId.enabled` back to true. The default stays FALSE this cycle. Once CI publishes the image (first push to `main` after this lands; can also be `workflow_dispatch`-triggered manually), operators with legacy Application CRs can opt in via per-Sovereign overlay:
  ```yaml
  migrations:
    applicationsInstanceId:
      enabled: true
      dryRun: true   # first pass — log planned patches without applying
  ```
- Does NOT touch the migration script itself (`products/catalyst/chart/files/migrate-applications-instanceId.py`).
- Does NOT close #2830. Operators need to verify the migration end-to-end on a real legacy-CR cluster first; closure follows that walk per the founder rule.

## Test plan

- [ ] CI workflow `Build catalyst-migrator` runs and publishes `ghcr.io/openova-io/catalyst-migrator:0.1.0` + `:<sha>` + `:latest` (multi-arch).
- [ ] `gh api /orgs/openova-io/packages/container/catalyst-migrator` returns 200 (was 404 per #2830).
- [ ] `cosign verify ghcr.io/openova-io/catalyst-migrator:0.1.0 --certificate-identity-regexp ...` succeeds.
- [ ] On a fresh Sovereign with legacy Application CRs and per-Sovereign overlay `migrations.applicationsInstanceId.enabled=true`, the post-upgrade Job goes Complete (not ImagePullBackOff) and patches CRs with `spec.instanceId`/`spec.isolationLevel`/`spec.namingTemplate`.
- [ ] bp-sso-bridge + bp-continuum remain Ready throughout the bp-catalyst-platform upgrade (no rollback cascade as observed on hw86 2026-06-03).

Refs #2830 #2823 #2834.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>