### PR TITLE
fix(bp-sso-bridge): #2744 — Cilium NetPol egress port 80 → 8080 for keycloak target port (0.2.6)

### DIFF
--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -67,6 +67,13 @@ spec:
   chart:
     spec:
       chart: bp-sso-bridge
+      # 0.2.6 (#2744 H8 walk, 2026-06-03): fix Cilium egress NetworkPolicy
+      # port mismatch — chart's egress rule allow-listed only the
+      # keycloak Service port (80), but Cilium enforces on the Pod's
+      # target port (8080). Result: ALL bp-sso-bridge → keycloak admin
+      # calls timed out (curl(28)) for 24h+, blocking per-Org realm
+      # provisioning + Tier-1/2/3 client upserts. Adds 8080/TCP
+      # alongside the existing 80/TCP allow. Refs #2744 #2834.
       # 0.2.3 (G117.5c #2801, 2026-06-02): Tier-3 AppRegistration ConfigMap
       # watcher. New upsert_per_org_client + reconcile_app_registrations
       # shell functions read ConfigMaps labelled
@@ -85,7 +92,7 @@ spec:
       # 0.1.1 (G91-fu, Refs #2659, edc55c08 PR #2676): adds realm-role
       # grant + skipClientUpsert opt-out for charts whose Keycloak Client
       # is realm-imported at bp-keycloak install time (catalyst-ui etc.).
-      version: 0.2.5
+      version: 0.2.6
       sourceRef:
         kind: HelmRepository
         name: bp-sso-bridge

--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.5
+  version: 0.2.6
   card:
     title: sso-bridge
     summary: |

--- a/platform/sso-bridge/chart/Chart.yaml
+++ b/platform/sso-bridge/chart/Chart.yaml
@@ -1,6 +1,20 @@
 apiVersion: v2
 name: bp-sso-bridge
-version: 0.2.5
+version: 0.2.6
+# 0.2.6 (#2744 H8 walk, 2026-06-03): fix Cilium egress NetworkPolicy
+# port mismatch that silently broke ALL per-Org realm provisioning
+# for 24h+. The reconciler curl'd keycloak.keycloak.svc:80 (Service
+# port) and hit curl(28) connect timeouts on every tick because
+# Cilium enforces egress NetPol on the DESTINATION POD'S TARGET
+# PORT (8080 here), NOT the Service port. The chart's egress rule
+# allow-listed port 80 only → Cilium dropped 8080 traffic at
+# bp-sso-bridge's pod, silently blocking ALL Tier-1/2/3 client
+# upserts + per-Org realm imports. Fix: add `8080/TCP` to the
+# keycloak-egress port list alongside the existing `80/TCP`
+# (kept for back-compat with non-Cilium CNIs that may match on
+# Service port). Operators overriding `networkPolicy.keycloakPort`
+# in per-Sovereign overlays must enumerate the Pod target port too.
+# Pure template change; no values default change. Refs #2744 #2834.
 # 0.2.5 (G117.E2E-C1 #2816, 2026-06-03): fix sovereign-fqdn ConfigMap
 # data-key contract drift — chart default `sovereignFqdnKey: sovereignFqdn`
 # did not match the key actually emitted by bp-catalyst-platform

--- a/platform/sso-bridge/chart/templates/networkpolicy.yaml
+++ b/platform/sso-bridge/chart/templates/networkpolicy.yaml
@@ -65,6 +65,17 @@ spec:
     # overlays MAY rewrite the namespace if bp-keycloak is relocated
     # (e.g. inside the mgmt vCluster post-G92.2 — that path uses a
     # different ingress route per the syncer-mangled name from G105).
+    #
+    # 0.2.6 (#2744 H8 walk, 2026-06-03): Cilium enforces egress
+    # NetworkPolicy on the destination Pod's TARGET port, NOT the
+    # Service port. The keycloak Service is `port: 80 → targetPort:
+    # 8080`; allowing only port 80 here meant Cilium dropped all
+    # bp-sso-bridge → keycloak traffic at egress, with curl(28)
+    # connect timeouts ~24h+. Allow BOTH 80 (back-compat / non-Cilium
+    # CNI semantics where Service-port matching may apply) AND 8080
+    # (the actual Pod target port Cilium enforces on). Operators
+    # overriding `keycloakPort` in per-Sovereign overlays should
+    # ensure their override also enumerates the Pod target port.
     - to:
         - namespaceSelector:
             matchLabels:
@@ -72,6 +83,8 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.networkPolicy.keycloakPort }}
+        - protocol: TCP
+          port: 8080
     # OpenBao admin endpoint — same shape as Keycloak.
     - to:
         - namespaceSelector:


### PR DESCRIPTION
## Summary

bp-sso-bridge reconciler has been failing for **24h+** with `curl(28) Failed to connect to keycloak.keycloak.svc.cluster.local port 80 after 30000ms: Connection timed out` on every tick — silently blocking ALL Tier-1/2/3 client upserts AND per-Org realm provisioning (caught live on H8 walk).

### Root cause

**Cilium enforces egress NetworkPolicy on the destination Pod's TARGET port (8080), NOT the Service port (80)**.

The keycloak Service is `port: 80 → targetPort: 8080`. bp-sso-bridge's egress NetworkPolicy allow-listed `port: 80` (matching the chart-default `networkPolicy.keycloakPort: 80` Service port). Cilium drops the connection at the bp-sso-bridge Pod's egress BEFORE Cilium's eBPF Service DNAT rewrites the dest port → every curl times out at the Cilium drop, not at keycloak.

This is a Cilium-specific semantic (contrast: kube-proxy iptables enforces NetPol on the Service-port match BEFORE DNAT, so port-80-only allow works there). Catalyst Sovereigns ship Cilium → this latent NetPol bug shipped in production.

### Fix

Add `8080/TCP` to the keycloak egress port list alongside the existing `80/TCP` (kept for back-compat with non-Cilium CNIs that may match on Service port).

Pure template change — no values default change. Operators overriding `networkPolicy.keycloakPort` in per-Sovereign overlays must enumerate the Pod target port too.

### Files changed

| File | Change |
|---|---|
| `platform/sso-bridge/chart/templates/networkpolicy.yaml` | + 8080/TCP + inline comment block on Cilium-Pod-target-port semantics |
| `platform/sso-bridge/chart/Chart.yaml` | 0.2.5 → 0.2.6 + changelog block |
| `platform/sso-bridge/blueprint.yaml` | version sync 0.2.5 → 0.2.6 |
| `clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml` | slot pin 0.2.5 → 0.2.6 + changelog block |

## Test plan

- [ ] Wait for chart-release CI to publish `oci://ghcr.io/openova-io/bp-sso-bridge:0.2.6`
- [ ] Bump `bp-catalyst-platform` umbrella to pull 0.2.6 (next slot-bump auto-tick)
- [ ] On hw86 (or next walk Sovereign): observe bp-sso-bridge reconciler logs go from `curl(28)` timeouts to `200 OK` against `keycloak.keycloak.svc.cluster.local:80` on first tick after the new chart reconciles
- [ ] Verify per-Org realm ConfigMaps converge into actual KC realms (was blocked for 24h+)
- [ ] Verify Tier-1 OpenBao writes (sso/sovereign/<client>) appear

Refs #2744 #2834.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>