### PR TITLE
feat(bp-sandbox): Pillar 4 — add blueprint.yaml + chart-tests (G117.1 W1/B3 sibling for sandbox)

### DIFF
--- a/platform/sandbox/blueprint.yaml
+++ b/platform/sandbox/blueprint.yaml
@@ -1,0 +1,152 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-sandbox
+  labels:
+    catalyst.openova.io/category: devtools
+    catalyst.openova.io/section: pts-4-sandbox
+    catalyst.openova.io/tier: catalyst-cp
+spec:
+  version: 0.3.8
+  card:
+    title: Sandbox
+    summary: |
+      Per-user in-browser coding sandbox — pty-server + agent CLI
+      (claude-code / qwen-code / cursor-agent / aider / opencode /
+      sovereign-shell) + openova-sandbox-mcp pre-wired into the User's
+      Organization (gitea repos, marketplace catalogue, llm-gateway
+      tokens). Reconciles Sandbox.sandbox.openova.io/v1 CRs into per-User
+      Sandbox sessions (StatefulSet + Service + HTTPRoute) inside the
+      Org's vCluster.
+    icon: sandbox.svg
+    category: devtools
+    tags: [sandbox, ide, devtools, mcp, claude-code, qwen-code, agents, openova]
+    documentation: products/sandbox/docs/architecture.md
+    license: AGPL-3.0-or-later
+  # `marketplace` — surfaces the card in the SME tenant catalogue so a
+  # User can land on /app?slug=sandbox and provision a personal Sandbox
+  # session. The controller itself is auto-installed by bootstrap-kit
+  # slot 19a on every Sovereign; the marketplace card represents the
+  # per-User instantiation flow (Sandbox CR creation), not a fresh
+  # Helm install.
+  visibility: marketplace
+  owner:
+    team: platform
+    contact: catalyst@openova.io
+  manifests:
+    chart: ./chart
+  # bp-sandbox sits on top of:
+  #   - bp-rtz-vcluster — vc-rtz Secret + customResources sync policy
+  #     (G92.5 #2664; the HR lives in host ns rtz but installs into
+  #     the rtz vCluster via kubeConfig.secretRef pivot).
+  #   - bp-vcluster-helmrepo — HelmRepository CR inside the rtz
+  #     vCluster the chart resolves against post-cutover.
+  #   - bp-catalyst-platform — host-substrate today (G92.3 follow-up);
+  #     the controller resolves catalyst-api via vCluster CoreDNS
+  #     forwarder.
+  #   - bp-harbor — post-handover the chart pull rewrites to
+  #     harbor.<sov-fqdn> (cutover Step-06 phase-1), so bp-harbor MUST
+  #     be Ready before the OCI fetch tries to resolve.
+  depends:
+    - blueprint: bp-rtz-vcluster
+      version: ^0.2
+    - blueprint: bp-vcluster-helmrepo
+      version: ^0.1
+    - blueprint: bp-catalyst-platform
+      version: ^1.0
+    - blueprint: bp-harbor
+      version: ^1.0
+
+  # ── G117.1: Topology declaration ────────────────────────────────────
+  # Per docs/sessions/2026-06-02-per-blueprint-topology-audit.md:
+  # The sandbox-controller itself is a stateless reconciler — its only
+  # durable state is the per-Sandbox manifests it writes to the per-Org
+  # `catalyst-tenant` Gitea repo (which is the Gitea-replicated state,
+  # not the controller's). active-hot-standby runs two controller
+  # replicas (one per RTZ region) sharing leader-election lease via the
+  # rtz-A CNPG-replicated leases CRD; switchover is leader-flip only
+  # (no data replication required on the controller plane). Each
+  # per-Sandbox session (D31 pair when SOVEREIGN_ENABLE_HOT_STANDBY=true)
+  # is replicated via the chart's own sandbox.cnpg.activeHotStandby
+  # block, not at the bp-sandbox-controller layer.
+  topology:
+    supported:
+      - active-hot-standby
+      - singleton
+    defaults:
+      multi-region: active-hot-standby
+      single-region: singleton
+    perTopology:
+      active-hot-standby:
+        replication:
+          backend: none           # stateless controller; state lives in Gitea
+          mode: async
+          lagSloSeconds: 0
+        switchover:
+          mechanism: leader-election
+          rtoSeconds: 30
+          rpoSeconds: 0
+        placement:
+          tier: rtz
+          clusters: [rtz-A, rtz-B]
+          roles:
+            rtz-A: active
+            rtz-B: passive
+      singleton:
+        placement:
+          tier: rtz
+          clusters: [rtz-A]
+          roles:
+            rtz-A: singleton
+
+  # ── G117.3: Endpoints ──────────────────────────────────────────────
+  # The Sandbox web UI is exposed per-Sandbox via HTTPRoute the
+  # controller renders (sandbox/<owner-uid>/httproute.yaml in the
+  # per-Org Gitea repo). The endpoint here is the canonical hostname
+  # template — the per-User Application's effective hostname is
+  # `sandbox-<instanceID>.<orgslug>.<sovereign-fqdn>`.
+  endpoints:
+    - name: ui
+      hostnameTemplate: "sandbox-{{.InstanceID}}.{{.OrgSlug}}.{{.SovereignFQDN}}"
+      port: 443
+      protocol: https
+      tls: true
+      visibility: public
+      launchDefault: true
+      ssoEnabled: true
+    - name: metrics
+      hostnameTemplate: ""        # ClusterIP only — controller-runtime metrics
+      port: 8080
+      protocol: http
+      tls: false
+      visibility: internal
+      launchDefault: false
+      ssoEnabled: false
+
+  # ── G117.4 + G117.5: SSO ───────────────────────────────────────────
+  # The per-Sandbox pty-server is OIDC-fronted via the per-Org KC realm
+  # (bp-sso-bridge G91.1 #2652 + G117.5 W2.C4 per-Org realm fan-out).
+  # The chart's sso-oauth-source-externalsecret.yaml materialises the
+  # client_id / client_secret / issuer_url from OpenBao at
+  # secret/sso/sandbox into a Secret the controller propagates onto
+  # every per-User pty-server Pod (silent SSO via
+  # kc_idp_hint=catalyst-pin + IDR defaultProvider=sovereign-broker
+  # per G113).
+  sso:
+    realm: "{{.OrgSlug}}"
+    protocolMapper: oidc
+    groupsClaim: groups
+    rolesFromGroup:
+      sovereign-admins: admin
+    silentLogin: true
+
+  # ── G117.6: Multi-instance ─────────────────────────────────────────
+  # One Sandbox CR per User session — every developer in every Org
+  # gets their own pty-server StatefulSet + per-Sandbox PVC + per-
+  # Sandbox token mint (newapi /admin/tokens/sandbox). Naming template
+  # mirrors the controller's sandbox/<owner-uid>/ Gitea path.
+  multiInstance:
+    enabled: true
+    maxPerOrg: 50
+    namingTemplate: "{{.AppName}}-{{.InstanceID}}"
+    isolationLevel: namespace

--- a/platform/sandbox/chart/tests/g117-sandbox-render.sh
+++ b/platform/sandbox/chart/tests/g117-sandbox-render.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# bp-sandbox chart-render guard (G117.1 Pillar-4 sibling for sandbox).
+#
+# Verifies the two canonical render contracts for the sandbox-controller
+# chart (Wave 1 + Wave 8):
+#
+#   Case 1 — enabled=false (chart default):
+#     Every templated resource is gated `{{- if .Values.enabled }}` so a
+#     Sovereign that hasn't flipped the bootstrap-kit slot 19a substitute
+#     SANDBOX_ENABLED=true must render ZERO resources. This is also the
+#     contract Chart.yaml's `catalyst.openova.io/smoke-render-mode:
+#     default-off` annotation tells blueprint-release.yaml to expect.
+#
+#   Case 2 — enabled=true (with the three Inviolable-Principle-#4a
+#     `required` env vars supplied):
+#     Renders the canonical Wave-1 control-plane (Deployment, Service,
+#     ServiceAccount, ClusterRole, ClusterRoleBinding) PLUS the G91
+#     bp-sso-bridge bundle (ExternalSecret) — 6 distinct Kubernetes
+#     Kinds. Any drift (a forgotten `enabled` guard, a removed
+#     ExternalSecret, a renamed kind) fails this gate before the OCI
+#     artifact is published.
+#
+# Why this guard exists:
+#   - F6 audit (2026-06-03) reported "Pillar 4 NOT SHIPPED" because
+#     platform/sandbox/blueprint.yaml + chart/tests/ were missing — H3
+#     confirmed the wiring (slot 19a, chart 0.3.8, default-ON via
+#     envsubst) was correct but the chart-test guard was absent, so a
+#     regression in templates/*.yaml (e.g. dropping the `if .Values.
+#     enabled` guard, or losing the ExternalSecret in a refactor) would
+#     ship silently. This script closes that gap.
+#
+# Usage: bash tests/g117-sandbox-render.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+HELM="${HELM_BIN:-helm}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+# No subcharts on bp-sandbox today, but keep the build-deps step for
+# forward-compat with future umbrella refactors (mirrors keycloak/tests/
+# observability-toggle.sh).
+if [ -f Chart.lock ] && [ ! -d charts ]; then
+  "$HELM" dependency build >/dev/null 2>&1 || true
+fi
+
+echo "[g117-sandbox-render] Case 1: default render (enabled=false) → 0 resources"
+"$HELM" template smoke-sandbox . > "$TMP/default.yaml" 2> "$TMP/default.err" || {
+  echo "FAIL: default render errored — chart default values are not template-clean." >&2
+  cat "$TMP/default.err" >&2
+  exit 1
+}
+kinds_default=$(grep -cE "^kind: " "$TMP/default.yaml" || true)
+if [ "$kinds_default" -ne 0 ]; then
+  echo "FAIL: default render (enabled=false) emitted $kinds_default resource(s) — every template MUST be gated on .Values.enabled." >&2
+  grep -E "^kind: " "$TMP/default.yaml" | sort -u >&2
+  exit 1
+fi
+echo "  PASS — 0 Kinds rendered (chart respects enabled=false default-off contract)."
+
+echo "[g117-sandbox-render] Case 2: enabled=true render emits the canonical 6 Kinds"
+"$HELM" template smoke-sandbox . \
+  --set enabled=true \
+  --set env.hostCluster=hz-fsn-rtz-prod \
+  --set env.sovereignFQDN=smoke.omani.works \
+  --set runtime.newapiURL=https://newapi.smoke.omani.works/v1 \
+  > "$TMP/on.yaml" 2> "$TMP/on.err" || {
+    echo "FAIL: enabled=true render errored — chart broke under canonical inputs." >&2
+    cat "$TMP/on.err" >&2
+    exit 1
+  }
+
+required_kinds=(
+  "Deployment"
+  "ServiceAccount"
+  "ClusterRole"
+  "ClusterRoleBinding"
+  "Service"
+  "ExternalSecret"
+)
+missing=()
+for k in "${required_kinds[@]}"; do
+  if ! grep -qE "^kind: ${k}$" "$TMP/on.yaml"; then
+    missing+=( "$k" )
+  fi
+done
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "FAIL: enabled=true render is missing required Kind(s): ${missing[*]}" >&2
+  echo "Rendered Kinds:" >&2
+  grep -E "^kind: " "$TMP/on.yaml" | sort -u >&2
+  exit 1
+fi
+echo "  PASS — all 6 canonical Kinds rendered: ${required_kinds[*]}"
+
+# Spot-check the controller Deployment carries the canonical
+# Inviolable-Principle-#4a env names the controller code reads.
+echo "[g117-sandbox-render] Case 3: Deployment env carries canonical SANDBOX_* contract names"
+required_env=(
+  "CATALYST_HOST_CLUSTER"
+  "CATALYST_SOVEREIGN_FQDN"
+  "SANDBOX_PTY_SERVER_IMAGE"
+  "SANDBOX_NEWAPI_URL"
+)
+missing_env=()
+for e in "${required_env[@]}"; do
+  if ! grep -qE "name: ${e}$" "$TMP/on.yaml"; then
+    missing_env+=( "$e" )
+  fi
+done
+if [ "${#missing_env[@]}" -gt 0 ]; then
+  echo "FAIL: Deployment is missing required env var(s) the controller reads: ${missing_env[*]}" >&2
+  exit 1
+fi
+echo "  PASS — Deployment carries all canonical SANDBOX_* env vars."
+
+echo "[g117-sandbox-render] All bp-sandbox chart-render gates green."


### PR DESCRIPTION
## Summary

Closes the two artefact gaps F6's audit conflated with "Pillar 4 NOT SHIPPED". H3's deep-walk confirmed bootstrap-kit slot 19a is wired correctly (chart 0.3.8 default-ON via envsubst, deps on bp-rtz-vcluster + bp-vcluster-helmrepo + bp-catalyst-platform + bp-harbor) — but the sibling artefacts every other platform chart carries (top-level `blueprint.yaml` + `chart/tests/*.sh` under blueprint-release.yaml's gate) were absent.

- **NEW `platform/sandbox/blueprint.yaml`** — full G117.1 W1/B3 shape mirroring keycloak + wordpress-tenant siblings: version 0.3.8 lockstep, marketplace visibility (so SME tenants see the card at `/app?slug=sandbox`), depends list matches slot 19a dependsOn, topology = `active-hot-standby` + `singleton` (stateless controller, switchover by leader-election), per-Org SSO realm, multiInstance enabled (one Sandbox CR per User session).
- **NEW `platform/sandbox/chart/tests/g117-sandbox-render.sh`** — three blueprint-release.yaml gate cases: (1) default render with `enabled=false` → 0 Kinds; (2) `enabled=true` → 6 canonical Kinds (Deployment / ServiceAccount / ClusterRole / ClusterRoleBinding / Service / ExternalSecret); (3) Deployment carries the 4 canonical SANDBOX_* env names the Go controller reads. All 3 green locally on helm v3.16.3.

## What this PR is NOT

- Does NOT modify `clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml` (slot pin + envsubst already correct per H3).
- Does NOT bump chart `Chart.yaml` (blueprint.yaml is external metadata; blueprint-release.yaml does not version-gate on it).
- Does NOT touch bp-catalyst-platform deps (architecture pattern is bootstrap-kit slot, not Helm subchart).

## Live-walk finding (out of scope; separate follow-up needed)

`kubectl --kubeconfig /tmp/hw86.kubeconfig -n rtz get hr bp-sandbox` returns:

```
status.conditions:
  Ready=False  DependencyNotReady  "unable to get 'rtz/bp-harbor' dependency:
  helmreleases.helm.toolkit.fluxcd.io 'bp-harbor' not found"
```

Slot 19a's `dependsOn: bp-harbor` entry lacks a `namespace:` qualifier, so Flux resolves it within the HR's own namespace (`rtz`) — but bp-harbor actually lives in `flux-system` (per G92.3 #2662 host-ns move). This blocks Sandbox runtime on hw86 today and needs a one-line fix to slot 19a's `dependsOn: - name: bp-harbor` → add `namespace: flux-system`. Brief explicitly scoped THIS PR away from slot-19a modifications; filing as a TBD follow-up.

## Test plan

- [x] `bash platform/sandbox/chart/tests/g117-sandbox-render.sh` → all 3 cases PASS locally.
- [ ] CI: blueprint-release.yaml runs the new chart-test under the chart-tests gate.
- [ ] CI: helm template smoke-render of the chart succeeds (already smoke-render-mode=default-off; new test covers the enabled-render side).
- [ ] After this PR merges + fresh prov: blueprint listing API returns `bp-sandbox` with `topology / endpoints / sso / multiInstance` populated alongside keycloak / wordpress-tenant.

Refs #2737 #2834

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)