### PR TITLE
feat(catalyst-api): G117 #2840 — detect partial-region materialisation + emit PartialFailure status

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -77,7 +77,7 @@ const EventBufferCap = 10000
 // channel).
 type Deployment struct {
 	ID         string
-	Status     string // pending | provisioning | tofu-applying | flux-bootstrapping | phase1-watching | ready | failed
+	Status     string // pending | provisioning | tofu-applying | flux-bootstrapping | phase1-watching | ready | failed | partial-failure
 	Request    provisioner.Request
 	Result     *provisioner.Result
 	Error      string
@@ -854,6 +854,16 @@ func (d *Deployment) State() map[string]any {
 		// `tofu-output` event was lost in producer-channel overflow.
 		if d.Result.Phase1Outcome != "" {
 			out["phase1Outcome"] = d.Result.Phase1Outcome
+		}
+		// G117 #2840 — surface the per-region materialisation breakdown
+		// at the top level so the operator-console deployments table can
+		// render "1 of 2 regions materialised: me-east-215-a (missing:
+		// me-east-215-b)" without unwrapping Result. Emitted whenever
+		// the slice is non-empty (i.e. for every multi-region prov, not
+		// just partial-failure rows — operator-console builds the
+		// missing-set diff against the declared Regions[]).
+		if len(d.Result.MaterializedRegions) > 0 {
+			out["materializedRegions"] = d.Result.MaterializedRegions
 		}
 		// Issue #923 — lift the live Phase-1 substate to the top
 		// level so the Sovereign Admin's wizard banner can render
@@ -1717,6 +1727,32 @@ func (h *Handler) runProvisioning(dep *Deployment) {
 	close(producer)
 	<-teeDone
 
+	// G117 #2840 — partial-region materialisation post-condition.
+	//
+	// The provisioner returns a typed PartialRegionMaterialisationError
+	// when `tofu apply` succeeded internally but the per-region readback
+	// shows fewer regions came up than the wizard declared. The error
+	// carries a non-nil Result with whatever DID land so the catalyst-
+	// api can render a meaningful "partial-failure" state instead of an
+	// opaque "failed" pill.
+	//
+	// We deliberately do NOT auto-`tofu destroy` here — that's destructive
+	// and may abandon a partial-prov the operator wants to retain (a
+	// single-region Sovereign with usable workers may be cheaper to keep
+	// than to wipe + retry against an unhealthy HCS cell). Instead we
+	// stamp Status = "partial-failure", populate Result.MaterializedRegions
+	// for the operator console, and emit a clear event. PDM commit + the
+	// Phase-1 watch are SKIPPED — the topology promise (active-hotstandby)
+	// is broken so promoting DNS or watching helm-releases would lie about
+	// the Sovereign's actual posture.
+	var partialErr *provisioner.PartialRegionMaterialisationError
+	isPartialFailure := errors.As(err, &partialErr)
+	if isPartialFailure && result == nil && partialErr.Result != nil {
+		// Defensive — partialErr.Result is the source of truth even if
+		// the provisioner ever changed the (result, err) wire shape.
+		result = partialErr.Result
+	}
+
 	// Stamp the Phase-0 lifecycle Jobs into terminal state so the
 	// JobsTable's Started/Finished/Duration columns populate without
 	// waiting for Phase-1 events. Failure stamps the in-flight phase
@@ -1739,12 +1775,30 @@ func (h *Handler) runProvisioning(dep *Deployment) {
 
 	// Capture Phase-0 outcome under the lock.
 	dep.mu.Lock()
-	if err != nil {
+	switch {
+	case isPartialFailure:
+		// G117 #2840 — operator-actionable terminal state. Renders a
+		// "partial-failure" pill in the wizard + operator-console
+		// deployments table. The detailed missing/materialised
+		// breakdown lives on the Result so the BSS console can build a
+		// drill-down view.
+		dep.FinishedAt = time.Now()
+		dep.Status = "partial-failure"
+		dep.Error = err.Error()
+		dep.Result = result
+		h.log.Error("partial-region materialisation — Pillar 2+3 violated, operator action required",
+			"id", dep.ID,
+			"sovereignFQDN", result.SovereignFQDN,
+			"declaredRegions", partialErr.DeclaredRegions,
+			"materializedRegions", partialErr.MaterializedRegions,
+			"missingRegions", partialErr.MissingRegions,
+		)
+	case err != nil:
 		dep.FinishedAt = time.Now()
 		dep.Status = "failed"
 		dep.Error = err.Error()
 		h.log.Error("provision failed", "id", dep.ID, "err", err)
-	} else {
+	default:
 		dep.Status = "phase1-watching"
 		dep.Result = result
 		h.log.Info("phase 0 complete; phase 1 watch starting",
@@ -1781,6 +1835,13 @@ func (h *Handler) runProvisioning(dep *Deployment) {
 	//
 	// On Phase-0 failure (no LB IP), Release is called instead so the
 	// reservation TTL doesn't have to expire to free the name.
+	//
+	// G117 #2840 — partial-failure ALSO releases the PDM reservation
+	// and skips the parent-zone write. The Sovereign's topology promise
+	// is broken; publishing DNS would point the public FQDN at a
+	// single-region cluster claiming to be multi-region, which is worse
+	// than no DNS at all. The operator decides whether to retain the
+	// partial prov + re-publish DNS manually, or wipe + retry.
 	if err == nil && result != nil {
 		h.commitPDMWithRetry(dep, result)
 		// Parent-zone A records — BYO Sovereigns (operator-owned
@@ -1802,6 +1863,12 @@ func (h *Handler) runProvisioning(dep *Deployment) {
 	// it terminates, it writes ComponentStates + Phase1FinishedAt
 	// onto dep.Result and flips Status to ready (or leaves failed
 	// alone if Phase 0 already failed).
+	//
+	// G117 #2840 — partial-failure ALSO skips the Phase-1 watch. The
+	// chart's bp-* HRs render under the assumption of N regions; with
+	// only 1 region materialised the install would either fail or
+	// (worse) silently downgrade to single-region CNPG. The Sovereign
+	// is operator-owned at this point — no automatic retry.
 	if err == nil && result != nil {
 		h.runPhase1Watch(dep)
 	}

--- a/products/catalyst/bootstrap/api/internal/provisioner/partial_region_materialisation_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/partial_region_materialisation_test.go
@@ -1,0 +1,189 @@
+// partial_region_materialisation_test.go — G117 #2840 unit coverage
+// for the post-condition that rejects a partial-region `tofu apply`.
+//
+// Background: hw86 declared 2 region codes (me-east-215-a +
+// me-east-215-b) in tofu.auto.tfvars.json but only `-a` materialised
+// because HCS Common.0021 quota cascade silently refused `-b`. The
+// admission gate at Validate() correctly rejects single-region
+// active-hotstandby SUBMISSIONS, but the downstream tofu-apply
+// partial-failure has no defense — `tofu apply` returns nil-error
+// when the per-region resource block evaluates to an empty `for`
+// expression. The catalyst-api then promoted DNS + ran the Phase-1
+// watch on a Sovereign that violates Pillar 2 (multi-region BCP) +
+// Pillar 3 (zero-tx-loss).
+//
+// These tests pin the observable behaviours that close that gap:
+//
+//  1. detectPartialRegionMaterialisation produces a stable
+//     (materialised, missing) split when N declared > M materialised.
+//  2. Returns empty missing-slice when every declared region came up
+//     (the happy path must not false-positive).
+//  3. The PartialRegionMaterialisationError carries the Result so the
+//     handler can stamp Status="partial-failure" without re-running tofu.
+//  4. errors.As round-trips through a wrapped error so the handler's
+//     errors.As(&partialErr) path works even if the provisioner ever
+//     wraps the typed error in an additional fmt.Errorf("...: %w").
+package provisioner
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Test 1 — the canonical hw86 shape: 2 declared, 1 materialised,
+// 1 missing. detectPartialRegionMaterialisation must enumerate
+// materialised in declaration order and report the missing code.
+func TestDetectPartialRegionMaterialisation_2DeclaredOneMissing(t *testing.T) {
+	declared := []RegionSpec{
+		{Provider: "huawei", CloudRegion: "me-east-215-a"},
+		{Provider: "huawei", CloudRegion: "me-east-215-b"},
+	}
+	perRegion := map[string]string{
+		"me-east-215-a": "100.100.100.10",
+		// me-east-215-b deliberately missing — HCS Common.0021.
+	}
+	materialised, missing := detectPartialRegionMaterialisation(declared, perRegion)
+	if len(materialised) != 1 || materialised[0] != "me-east-215-a" {
+		t.Errorf("materialised = %v, want [me-east-215-a]", materialised)
+	}
+	if len(missing) != 1 || missing[0] != "me-east-215-b" {
+		t.Errorf("missing = %v, want [me-east-215-b]", missing)
+	}
+}
+
+// Test 2 — happy path: both declared regions came up. Must produce
+// nil missing-slice so the caller's `len(missing) > 0` gate doesn't
+// false-positive on a fully-materialised prov.
+func TestDetectPartialRegionMaterialisation_HappyPath(t *testing.T) {
+	declared := []RegionSpec{
+		{Provider: "huawei", CloudRegion: "me-east-215-a"},
+		{Provider: "huawei", CloudRegion: "me-east-215-b"},
+	}
+	perRegion := map[string]string{
+		"me-east-215-a": "100.100.100.10",
+		"me-east-215-b": "100.100.100.20",
+	}
+	materialised, missing := detectPartialRegionMaterialisation(declared, perRegion)
+	if len(materialised) != 2 {
+		t.Errorf("materialised = %v, want both regions", materialised)
+	}
+	if len(missing) != 0 {
+		t.Errorf("missing = %v, want empty (every declared region came up)", missing)
+	}
+}
+
+// Test 3 — empty per-region map (zero regions materialised). Every
+// declared region must show up as missing so the operator can see the
+// total wipeout, not just a per-region diff.
+func TestDetectPartialRegionMaterialisation_NothingMaterialised(t *testing.T) {
+	declared := []RegionSpec{
+		{Provider: "huawei", CloudRegion: "me-east-215-a"},
+		{Provider: "huawei", CloudRegion: "me-east-215-b"},
+	}
+	perRegion := map[string]string{}
+	materialised, missing := detectPartialRegionMaterialisation(declared, perRegion)
+	if len(materialised) != 0 {
+		t.Errorf("materialised = %v, want empty (no per-region readback)", materialised)
+	}
+	if len(missing) != 2 {
+		t.Errorf("missing = %v, want both regions", missing)
+	}
+}
+
+// Test 4 — per-region map with an EMPTY string IP (tofu rendered the
+// resource address but the EIP allocation returned a blank). Treat as
+// missing — an empty IP is not a working CP node.
+func TestDetectPartialRegionMaterialisation_EmptyIPCountsAsMissing(t *testing.T) {
+	declared := []RegionSpec{
+		{Provider: "huawei", CloudRegion: "me-east-215-a"},
+		{Provider: "huawei", CloudRegion: "me-east-215-b"},
+	}
+	perRegion := map[string]string{
+		"me-east-215-a": "100.100.100.10",
+		"me-east-215-b": "", // partial — EIP allocation never completed.
+	}
+	_, missing := detectPartialRegionMaterialisation(declared, perRegion)
+	if len(missing) != 1 || missing[0] != "me-east-215-b" {
+		t.Errorf("missing = %v, want [me-east-215-b] (empty IP must count as missing)", missing)
+	}
+}
+
+// Test 5 — the typed error formats with the declared/materialised/missing
+// breakdown so the operator-console drill-down has the data it needs.
+func TestPartialRegionMaterialisationError_FormatsBreakdown(t *testing.T) {
+	err := &PartialRegionMaterialisationError{
+		DeclaredRegions:     []string{"me-east-215-a", "me-east-215-b"},
+		MaterializedRegions: []string{"me-east-215-a"},
+		MissingRegions:      []string{"me-east-215-b"},
+		Result:              &Result{SovereignFQDN: "hw86.omani.works"},
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"me-east-215-a",
+		"me-east-215-b",
+		"partial-region",
+		"Pillar 2",
+		"Pillar 3",
+		"Common.0021",
+		"#2840",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("Error() = %q, missing substring %q", msg, want)
+		}
+	}
+}
+
+// Test 6 — errors.As round-trips through a wrapped error so the
+// handler-side errors.As(&partialErr) path in runProvisioning works
+// even if the provisioner ever wraps the typed error in an additional
+// fmt.Errorf("...: %w").
+func TestPartialRegionMaterialisationError_ErrorsAs(t *testing.T) {
+	original := &PartialRegionMaterialisationError{
+		DeclaredRegions:     []string{"me-east-215-a", "me-east-215-b"},
+		MaterializedRegions: []string{"me-east-215-a"},
+		MissingRegions:      []string{"me-east-215-b"},
+		Result:              &Result{SovereignFQDN: "hw86.omani.works"},
+	}
+	wrapped := &wrappedErr{inner: original}
+	var got *PartialRegionMaterialisationError
+	if !errors.As(wrapped, &got) {
+		t.Fatalf("errors.As(wrapped, &PartialRegionMaterialisationError{}) = false, want true")
+	}
+	if got != original {
+		t.Errorf("errors.As unwrapped to %v, want pointer-equal original", got)
+	}
+}
+
+// wrappedErr exists only to verify errors.As traverses Unwrap().
+type wrappedErr struct{ inner error }
+
+func (w *wrappedErr) Error() string { return "wrapped: " + w.inner.Error() }
+func (w *wrappedErr) Unwrap() error { return w.inner }
+
+// Test 7 — the simulated end-to-end shape the catalyst-api will see:
+// build a partial Result + a PartialRegionMaterialisationError, then
+// assert that downstream consumers can read MaterializedRegions off
+// the Result (operator-console drill-down contract).
+func TestResult_MaterializedRegions_Exposed(t *testing.T) {
+	result := &Result{
+		SovereignFQDN:       "hw86.omani.works",
+		ControlPlaneIP:      "100.100.100.10",
+		LoadBalancerIP:      "100.100.100.99",
+		MaterializedRegions: []string{"me-east-215-a"},
+	}
+	if len(result.MaterializedRegions) != 1 || result.MaterializedRegions[0] != "me-east-215-a" {
+		t.Errorf("Result.MaterializedRegions = %v, want [me-east-215-a]", result.MaterializedRegions)
+	}
+	// Operator-console diff: declared - materialised = missing.
+	declared := map[string]struct{}{"me-east-215-a": {}, "me-east-215-b": {}}
+	for _, m := range result.MaterializedRegions {
+		delete(declared, m)
+	}
+	if len(declared) != 1 {
+		t.Fatalf("declared - materialised has %d entries, want 1", len(declared))
+	}
+	if _, ok := declared["me-east-215-b"]; !ok {
+		t.Errorf("missing set = %v, want [me-east-215-b]", declared)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1109,6 +1109,19 @@ type Result struct {
 	// the 5-second auto-redirect timer.
 	HandoverFiredAt *time.Time `json:"handoverFiredAt,omitempty"`
 
+	// MaterializedRegions — list of region codes that actually came up
+	// after `tofu apply` returned. Sourced from the per-provider
+	// per-region output map (Huawei: `control_plane_ips_per_region`).
+	// Populated for every multi-region prov; for single-region provs
+	// it is either nil (single-region path doesn't read the map) or a
+	// 1-entry slice (when the operator submitted Regions[0] only). The
+	// catalyst-api uses len(MaterializedRegions) vs len(Request.Regions)
+	// to detect the G117 #2840 partial-region cascade where the HCS
+	// scheduler refused the secondary region (typically Common.0021 /
+	// quota cap) and the prov silently degraded from active-hotstandby
+	// to single-region.
+	MaterializedRegions []string `json:"materializedRegions,omitempty"`
+
 	// HandoverURL — fully-qualified handover redirect URL (issues
 	// #764 + #768). Shape:
 	//
@@ -1126,6 +1139,95 @@ type Result struct {
 	// "Open Sovereign console" path (POST
 	// /deployments/{id}/mint-handover-token).
 	HandoverURL string `json:"handoverURL,omitempty"`
+}
+
+// PartialRegionMaterialisationError is returned by Provision when
+// `tofu apply` completed without a Go-side error but the per-provider
+// per-region readback shows fewer regions came up than the wizard
+// declared (len(Result.MaterializedRegions) < len(req.Regions)).
+//
+// The typed error carries the partial Result so the catalyst-api can
+// stamp Deployment.status = "partial-failure" with a useful breakdown
+// — it does NOT auto-`tofu destroy`, which would abandon a partial
+// infra the operator may want to retain for forensic / cost / quota
+// reasons (per G117 #2840: "auto-rollback is destructive and may
+// abandon a partial-prov the operator wants to keep").
+//
+// The handler-side flow on encountering this error is documented in
+// handler/deployments.go::runProvisioning (search for
+// PartialRegionMaterialisationError).
+type PartialRegionMaterialisationError struct {
+	// DeclaredRegions — the region codes the operator submitted via
+	// Request.Regions[].CloudRegion, in declaration order.
+	DeclaredRegions []string
+	// MaterializedRegions — the region codes that have a non-empty
+	// primary-CP EIP after `tofu apply`, in declaration order.
+	MaterializedRegions []string
+	// MissingRegions — DeclaredRegions \ MaterializedRegions, in
+	// declaration order. The operator console renders this list.
+	MissingRegions []string
+	// Result — non-nil; the partial-success Result with whatever
+	// outputs DID land (so the catalyst-api still has the LB IP, the
+	// primary CP IP, the materialized region list, etc.). The caller
+	// MUST NOT proceed to commitPDMWithRetry / runPhase1Watch on this
+	// Result because the topology promise (active-hotstandby) is
+	// broken — but the data is useful for the operator-console
+	// PartialFailure render.
+	Result *Result
+}
+
+func (e *PartialRegionMaterialisationError) Error() string {
+	return fmt.Sprintf(
+		"partial-region materialisation: declared %d regions %v, only %d materialised %v (missing: %v) — "+
+			"likely HCS Common.0021 / quota cascade. Sovereign violates Pillar 2 (multi-region BCP) + Pillar 3 "+
+			"(zero-tx-loss). Operator action required: inspect HCS quotas + decide whether to retain the partial "+
+			"prov (single-region usable) or wipe + retry. Auto-destroy was NOT performed (operator decision per G117 #2840).",
+		len(e.DeclaredRegions), e.DeclaredRegions,
+		len(e.MaterializedRegions), e.MaterializedRegions,
+		e.MissingRegions,
+	)
+}
+
+// detectPartialRegionMaterialisation compares the operator's declared
+// regions (req.Regions[].CloudRegion) against the per-region readback
+// from tofu (out.ControlPlaneIPsPerRegion keys) and returns the
+// materialised + missing sets.
+//
+// Returns the materialised-regions slice (always non-nil — empty when
+// the readback was empty) and the missing-regions slice (nil when
+// every declared region came up).
+//
+// Per G117 #2840 the post-condition is: every region declared in
+// Request.Regions[] MUST have a corresponding entry in
+// control_plane_ips_per_region with a non-empty EIP. Anything less is
+// a partial-failure that breaks the topology promise.
+func detectPartialRegionMaterialisation(declaredRegions []RegionSpec, perRegion map[string]string) (materialised []string, missing []string) {
+	materialised = make([]string, 0, len(perRegion))
+	declared := make(map[string]struct{}, len(declaredRegions))
+	for _, r := range declaredRegions {
+		code := strings.TrimSpace(r.CloudRegion)
+		if code == "" {
+			continue
+		}
+		declared[code] = struct{}{}
+		if ip, ok := perRegion[code]; ok && strings.TrimSpace(ip) != "" {
+			materialised = append(materialised, code)
+		} else {
+			missing = append(missing, code)
+		}
+	}
+	// Also append any materialised codes that weren't in the declared
+	// set (defensive — tofu shouldn't produce these, but if it did we
+	// want them visible in the operator-console PartialFailure view).
+	for code, ip := range perRegion {
+		if strings.TrimSpace(ip) == "" {
+			continue
+		}
+		if _, ok := declared[code]; !ok {
+			materialised = append(materialised, code)
+		}
+	}
+	return materialised, missing
 }
 
 // Provisioner runs `tofu init && tofu apply` against the canonical
@@ -1543,13 +1645,69 @@ func (p *Provisioner) Provision(ctx context.Context, req Request, events chan<- 
 
 	emit("flux-bootstrap", "info", "Cloud-init has bootstrapped Flux + Crossplane in the new cluster — Flux will now reconcile clusters/"+req.SovereignFQDN+"/ from the public OpenOva monorepo, installing the 11-component bootstrap kit and bp-catalyst-platform umbrella in dependency order. The wizard's progress page will poll Flux Kustomizations on the new cluster for steady-state.")
 
-	return &Result{
-		SovereignFQDN:  req.SovereignFQDN,
-		ControlPlaneIP: out.ControlPlaneIP,
-		LoadBalancerIP: out.LoadBalancerIP,
-		ConsoleURL:     fmt.Sprintf("https://console.%s", req.SovereignFQDN),
-		GitOpsRepoURL:  fmt.Sprintf("https://gitea.%s", req.SovereignFQDN),
-	}, nil
+	// G117 #2840 — post-condition partial-region rollback defense.
+	//
+	// `tofu apply` returning nil-error guarantees the OpenTofu state is
+	// internally consistent — NOT that every declared region produced
+	// a working primary CP node. On HCS Kom4DC the scheduler can
+	// silently refuse a secondary region when a per-AZ/per-flavor cell
+	// is unhealthy (Common.0021 / quota cascade); the per-region
+	// resource block then evaluates to an empty `for` expression, the
+	// per-region EIP map output ends up with fewer entries than
+	// expected, and tofu happily reports SUCCESS.
+	//
+	// Without this gate the deployment proceeds to commitPDMWithRetry +
+	// runPhase1Watch on a Sovereign that violates Pillar 2 (multi-region
+	// BCP) + Pillar 3 (zero-tx-loss) — exactly what happened on hw86
+	// (Refs #2840). Operator sees a green "ready" wizard pill but the
+	// Sovereign is single-region under the hood.
+	//
+	// Detection runs only when the operator declared >=2 regions AND
+	// the per-provider readback populated a per-region map (Huawei does;
+	// Hetzner exposes a differently-keyed map and is on a separate
+	// follow-up). When the post-condition fails we return a typed
+	// PartialRegionMaterialisationError carrying the partial Result —
+	// the handler stamps Deployment.status = "partial-failure" but
+	// does NOT auto-`tofu destroy`. The operator decides.
+	materialised, missing := detectPartialRegionMaterialisation(req.Regions, out.ControlPlaneIPsPerRegion)
+	declared := make([]string, 0, len(req.Regions))
+	for _, r := range req.Regions {
+		if code := strings.TrimSpace(r.CloudRegion); code != "" {
+			declared = append(declared, code)
+		}
+	}
+
+	result := &Result{
+		SovereignFQDN:       req.SovereignFQDN,
+		ControlPlaneIP:      out.ControlPlaneIP,
+		LoadBalancerIP:      out.LoadBalancerIP,
+		ConsoleURL:          fmt.Sprintf("https://console.%s", req.SovereignFQDN),
+		GitOpsRepoURL:       fmt.Sprintf("https://gitea.%s", req.SovereignFQDN),
+		MaterializedRegions: materialised,
+	}
+
+	// Only enforce when the operator declared >=2 regions AND the
+	// per-provider readback was populated (single-region Hetzner and
+	// any pre-G117 readback that didn't surface the map skip the
+	// check). The admission gate at Validate() already rejects a
+	// SUBMISSION of bcpTopology=active-hotstandby + len(regions)<2;
+	// this gate catches the downstream tofu-apply partial.
+	if len(declared) >= 2 && len(out.ControlPlaneIPsPerRegion) > 0 && len(missing) > 0 {
+		emit("tofu-apply", "error", fmt.Sprintf(
+			"G117 #2840 partial-region materialisation detected — declared %d regions %v, only %d materialised %v (missing %v). "+
+				"Marking deployment as partial-failure; auto-destroy was NOT performed so the operator can inspect the partial infra "+
+				"and decide whether to retain it (single-region usable) or wipe + retry against a different AZ/flavor.",
+			len(declared), declared, len(materialised), materialised, missing,
+		))
+		return result, &PartialRegionMaterialisationError{
+			DeclaredRegions:     declared,
+			MaterializedRegions: materialised,
+			MissingRegions:      missing,
+			Result:              result,
+		}
+	}
+
+	return result, nil
 }
 
 // Destroy runs `tofu destroy -auto-approve` against the per-deployment
@@ -1730,6 +1888,19 @@ func streamLines(r io.Reader, phase, level string, emit func(string, string, str
 type tofuOutputs struct {
 	ControlPlaneIP string `json:"control_plane_ip"`
 	LoadBalancerIP string `json:"load_balancer_ip"`
+	// ControlPlaneIPsPerRegion — map<region-code, primary-CP-EIP>.
+	// Populated by the Huawei module's `control_plane_ips_per_region`
+	// output (one entry per region in var.regions). Empty for legacy
+	// single-region Hetzner deployments and for Hetzner multi-region
+	// deployments (which expose a different shape via
+	// control_plane_ips_by_region keyed by "<region>-<index>"). G117
+	// #2840 reads this to detect partial-region materialisation: a
+	// 2-region declaration that produces only 1 map entry means the
+	// HCS scheduler refused to allocate the secondary region (typically
+	// Common.0021 / quota cascade) and the prov has silently degraded
+	// to single-region — which violates Pillar 2 (multi-region BCP) +
+	// Pillar 3 (zero-tx-loss).
+	ControlPlaneIPsPerRegion map[string]string `json:"control_plane_ips_per_region"`
 }
 
 func (p *Provisioner) readOutputs(ctx context.Context, deployDir string) (*tofuOutputs, error) {
@@ -1756,9 +1927,33 @@ func (p *Provisioner) readOutputs(ctx context.Context, deployDir string) (*tofuO
 		}
 		return ""
 	}
+	// asStringMap decodes a tofu `map(string)` output into a Go
+	// map[string]string. Missing-key, wrong-type, and nil-value entries
+	// are silently skipped so a partially-materialised apply still
+	// surfaces the keys that DID land (which is the whole point of the
+	// G117 #2840 partial-region detection — we need to enumerate what
+	// came up before we can name what didn't).
+	asStringMap := func(key string) map[string]string {
+		v, ok := raw[key]
+		if !ok || v.Value == nil {
+			return nil
+		}
+		m, ok := v.Value.(map[string]any)
+		if !ok {
+			return nil
+		}
+		out := make(map[string]string, len(m))
+		for k, val := range m {
+			if s, ok := val.(string); ok && s != "" {
+				out[k] = s
+			}
+		}
+		return out
+	}
 	return &tofuOutputs{
-		ControlPlaneIP: asString("control_plane_ip"),
-		LoadBalancerIP: asString("load_balancer_ip"),
+		ControlPlaneIP:           asString("control_plane_ip"),
+		LoadBalancerIP:           asString("load_balancer_ip"),
+		ControlPlaneIPsPerRegion: asStringMap("control_plane_ips_per_region"),
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

Adds a post-condition check after `tofu apply` that compares declared regions
against the per-region readback. When fewer regions came up than were declared
(the hw86 shape — `tofu apply` returned nil-error but HCS Common.0021 silently
refused the secondary region), the catalyst-api now:

- Returns a typed `PartialRegionMaterialisationError` from `provisioner.Provision`
- Stamps `Deployment.status = "partial-failure"` (new state)
- Populates `Result.MaterializedRegions[]` for the operator console drill-down
- Skips PDM commit + Phase-1 watch (publishing DNS or watching helm-releases
  on a broken-topology Sovereign would lie about its posture)
- Does **NOT** auto-`tofu destroy` — that's destructive and may abandon a
  partial prov the operator wants to retain. Operator decides via the BSS console.

## Root cause this defends

hw86's `tofu.auto.tfvars.json` correctly declared 2 region codes
(`me-east-215-a` + `me-east-215-b`) but only `-a` materialised because HCS
Common.0021 / quota cascade silently refused `-b`. The existing admission gate
at `provisioner.go:798` correctly rejects single-region active-hotstandby
SUBMISSIONS, but had no defense for the downstream `tofu apply` partial-failure.
Sovereign appeared green but violated Pillar 2 (multi-region BCP) + Pillar 3
(zero-tx-loss).

## Files touched

- `products/catalyst/bootstrap/api/internal/provisioner/provisioner.go`
  - Add `Result.MaterializedRegions []string`
  - Add `tofuOutputs.ControlPlaneIPsPerRegion map[string]string` + `asStringMap` decoder
  - Add `PartialRegionMaterialisationError` typed error
  - Add `detectPartialRegionMaterialisation()` helper
  - Add post-condition gate at end of `Provision()`
- `products/catalyst/bootstrap/api/internal/handler/deployments.go`
  - `runProvisioning` catches typed error → stamps `Status = "partial-failure"`
  - Gate updated comment for PDM commit + Phase-1 watch skip
  - `State()` lifts `materializedRegions` to top-level
  - Status comment lists new `partial-failure` state
- `products/catalyst/bootstrap/api/internal/provisioner/partial_region_materialisation_test.go` (NEW)
  - 7 unit tests covering happy path, partial, nothing-materialised, empty-IP-as-missing, error formatting, `errors.As` round-trip, Result-field exposure

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/provisioner/` — 7/7 new tests + all existing provisioner tests PASS
- [x] `go test ./internal/handler/` — full handler suite PASS (59.474s)
- [ ] Operator-walk on a real Sovereign that triggers a 2-region declaration with HCS partial-failure to confirm UI renders `partial-failure` pill (gated behind founder schedule)

Refs #2840 #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)