### PR TITLE
feat(catalyst): G117.2 #2741 — multi-instance drill-down + topology picker + HTTPRoute /catalyst/ rule

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -906,7 +906,7 @@ spec:
       # image build workflow + imagePullSecrets:[ghcr-pull] on the
       # migration Job Pod spec. Default remains enabled=false until
       # operators verify on a legacy-CR cluster.
-      version: 1.4.446
+      version: 1.4.448
       # 1.4.445 (H9-walk follow-up #2745, 2026-06-03): bump 5 controller
       # image pins to the latest GHCR-published push-on-main builds —
       # application-controller 8d01e2f -> 44dedf2 (G117.6 + G117.2
@@ -915,7 +915,18 @@ spec:
       # 8d01e2f -> dcd2bb3, organization-controller 7ff7ea8 -> 32050f0.
       # The CI auto-image-bump workflow does not cover controller
       # images; follow-up issue tracks closing that gap.
-      version: 1.4.446
+      version: 1.4.448
+      # 1.4.447 (G117.2 #2741, 2026-06-03): operator drill-down + topology
+      # picker + HTTPRoute /catalyst/ rule. Closes the H10 walk's TWO 🔴
+      # BLOCKED gaps in one PR: (a) catalyst-ui HTTPRoute on console.<sov>
+      # now forwards PathPrefix /catalyst/ to catalyst-api (was falling
+      # through to React shell); (b) AppDetail.tsx Instances section +
+      # "+ New instance" topology-picker dialog POSTing to
+      # /catalyst/v1/apps/instances per instances.CreateInstanceRequest
+      # wire shape; (c) per-cluster status table surfacing
+      # Application.status.perCluster[] when populated by G117.6
+      # application-controller fan-out. Refs #2741 #2737 #2834.
+      version: 1.4.448
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
@@ -663,3 +663,138 @@ export async function editPRBlueprint(
   }
   return res.json()
 }
+
+/* ── G117.2 #2741 — Multi-instance Application surface ─────────────
+ *
+ * Wire shapes mirror catalyst-api's `internal/instances.CreateInstanceRequest`
+ * and the OpenAPI `Application` / `ApplicationSummary` projections at
+ * `internal/handler/endpoint_handler.go:117-142`.
+ *
+ *   GET  /catalyst/v1/catalog/{blueprint}/instances[?org=]
+ *        → ListBlueprintInstancesResponse
+ *
+ *   POST /catalyst/v1/apps/instances
+ *        body: CreateApplicationInstanceRequest
+ *        → CreateApplicationInstanceResponse
+ *
+ * The path lives under /catalyst/v1/ (not /api/v1/) — the bp-catalyst-
+ * platform HTTPRoute (PR #2741 chart bump 1.4.447) wires
+ * PathPrefix /catalyst/ on the console hostname to forward to the
+ * catalyst-api Service. Prior to that bump the prefix fell through to
+ * the React shell and returned index.html.
+ */
+
+/** Mirrors `applicationSummary` at endpoint_handler.go:117. */
+export interface ApplicationInstanceSummary {
+  id: string
+  name: string
+  blueprint: string
+  org: string
+  topology: string
+  status: string
+  createdAt?: string
+}
+
+/** Mirrors `application` at endpoint_handler.go:130 (Summary + perCluster). */
+export interface ApplicationInstance extends ApplicationInstanceSummary {
+  perCluster?: ApplicationClusterStatus[]
+}
+
+/** Mirrors `applicationClusterStatus` at endpoint_handler.go:136. */
+export interface ApplicationClusterStatus {
+  cluster: string
+  role: string
+  status: string
+  hr?: string
+  message?: string
+}
+
+/** Mirrors `listInstancesResponse` at endpoint_handler.go:153. */
+export interface ListBlueprintInstancesResponse {
+  items: ApplicationInstanceSummary[]
+}
+
+/**
+ * Mirrors `instances.CreateInstanceRequest` at
+ * products/catalyst/bootstrap/api/internal/instances/create.go.
+ *
+ * `blueprint`, `org`, `name` are required. `topology` is optional —
+ * server falls back to the Blueprint's per-Sovereign topology default
+ * (single-region vs multi-region per locked decision #7). `values`
+ * carries the Blueprint configSchema parameters; per-app form
+ * surfaces those in the topology-picker dialog as a JSON-Schema-driven
+ * form (out of scope for the v1 dialog — see PR follow-up TBD).
+ */
+export interface CreateApplicationInstanceRequest {
+  blueprint: string
+  org: string
+  name: string
+  topology?: string
+  isolationLevel?: 'namespace' | 'vcluster'
+  values?: Record<string, unknown>
+}
+
+/** Mirrors `application` 201-response body at endpoint_handler.go:729. */
+export interface CreateApplicationInstanceResponse extends ApplicationInstance {}
+
+/**
+ * getApplicationInstances — list every Application installed from a
+ * given Blueprint. Returns the empty-items envelope on 404. Throws on
+ * other 4xx/5xx so genuine network / auth issues surface.
+ *
+ * `appUID` is unused by the wire path (the listing is per-Blueprint,
+ * not per-Application) but the FE call-site threads it as a stable
+ * cache key so multiple AppDetail tabs with the same Blueprint share
+ * the same in-flight request.
+ */
+export async function getApplicationInstances(
+  blueprint: string,
+  opts: { org?: string } = {},
+): Promise<ListBlueprintInstancesResponse> {
+  const bp = blueprint.replace(/^bp-/, '')
+  const params = new URLSearchParams()
+  if (opts.org) params.set('org', opts.org)
+  const qs = params.toString()
+  const url = `${API_BASE}/catalyst/v1/catalog/${encodeURIComponent(bp)}/instances${qs ? '?' + qs : ''}`
+  const res = await authedFetch(url, { headers: { Accept: 'application/json' } })
+  if (res.status === 404) return { items: [] }
+  if (!res.ok) {
+    throw new Error(`getApplicationInstances: HTTP ${res.status}`)
+  }
+  return res.json()
+}
+
+/**
+ * createApplicationInstance — POST /catalyst/v1/apps/instances.
+ *
+ * On 4xx the server returns a typed error body
+ * `{code: string, message: string}`. The error message surfaces verbatim
+ * so the dialog can render the operator-meaningful copy (e.g.
+ * "max instances per Org exceeded", "isolationLevel not in {namespace,
+ * vcluster}").
+ */
+export async function createApplicationInstance(
+  body: CreateApplicationInstanceRequest,
+): Promise<CreateApplicationInstanceResponse> {
+  const res = await authedFetch(`${API_BASE}/catalyst/v1/apps/instances`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    let code = ''
+    let message = `HTTP ${res.status}`
+    try {
+      const detail = (await res.json()) as { code?: string; message?: string }
+      if (detail?.code) code = detail.code
+      if (detail?.message) message = detail.message
+    } catch {
+      /* fall through */
+    }
+    const err = new Error(message) as Error & { status?: number; code?: string }
+    err.status = res.status
+    err.code = code
+    throw err
+  }
+  return res.json()
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
@@ -40,7 +40,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { useParams, Link } from '@tanstack/react-router'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useWizardStore } from '@/entities/deployment/store'
 import { PortalShell } from './PortalShell'
 import { JobsTable } from './JobsTable'
@@ -52,7 +52,16 @@ import { findComponent } from '@/pages/wizard/steps/componentGroups'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import { API_BASE } from '@/shared/config/urls'
 import type { ApplicationStatus } from './eventReducer'
-import { getApplication, getLaunchURL, type ApplicationDetailResponse } from '@/lib/catalog.api'
+import {
+  getApplication,
+  getLaunchURL,
+  getApplicationInstances,
+  createApplicationInstance,
+  getCatalogItemVersion,
+  type ApplicationDetailResponse,
+  type ApplicationInstanceSummary,
+  type CreateApplicationInstanceRequest,
+} from '@/lib/catalog.api'
 import { ComplianceTab } from './AppDetail/ComplianceTab'
 import { MembersTab } from './AppDetail/MembersTab'
 import { TopologyTab } from './AppDetail/TopologyTab'
@@ -518,6 +527,28 @@ export function AppDetail({ disableStream = false }: AppDetailProps = {}) {
         </div>
 
         {/*
+          G117.2 #2741 (2026-06-03) — Instances section + "+ New
+          instance" button. Lists every Application installed from this
+          Blueprint (one row per instance) via GET
+          /catalyst/v1/catalog/{blueprint}/instances, plus a "+ New
+          instance" button that opens the topology picker dialog. The
+          section also renders the local Application CR's
+          `status.perCluster[]` as a per-cluster status table for the
+          CURRENT instance (shows the fan-out across host clusters per
+          G117.6 application-controller).
+
+          AppDetail in G117 is the CLASS surface (one card per
+          Blueprint) — every concrete install is one row in this
+          section. The class/instance split is the deterministic
+          contract H10 walk verifies.
+        */}
+        <InstancesSection
+          blueprint={app.id}
+          appUID={appUID}
+          perCluster={apiApp?.regionStatuses}
+        />
+
+        {/*
           Tab strip — matrix-canonical order + matrix-canonical
           test-ids. The `app-tab-{name}` ids are the matrix's primary
           contract (TC-106). Each button also carries an
@@ -980,6 +1011,552 @@ function LaunchButton({
     >
       {pending ? 'Launching…' : 'Launch →'}
     </button>
+  )
+}
+
+/* ─── G117.2 #2741 Instances section + topology picker ──────────── */
+
+/**
+ * InstancesSection — G117.2 #2741 (2026-06-03). Renders TWO blocks:
+ *
+ * 1. A flat list of every Application installed from this Blueprint
+ *    (one row per concrete instance) via
+ *    GET /catalyst/v1/catalog/{blueprint}/instances. This is the class
+ *    → instance drill-down H10 walk required: the AppDetail surface is
+ *    the CLASS card; each row is a concrete instance the operator can
+ *    drill into.
+ *
+ * 2. A "+ New instance" button that opens the topology-picker dialog.
+ *    The button carries data-testid="btn-new-instance" so the H10 walk
+ *    Playwright spec can locate it deterministically.
+ *
+ * 3. (When `perCluster` is populated) a per-cluster fan-out table for
+ *    the CURRENT Application (status.perCluster[] surfaced via the
+ *    existing applications.go `regionStatuses` field). Each row shows
+ *    cluster + role + status + hr (if present), so the operator sees
+ *    where the instance is running across host clusters per G117.6
+ *    application-controller fan-out.
+ *
+ * On 404 / empty list, the list block renders an empty-state with the
+ * "+ New instance" button still active so the operator can install the
+ * first instance.
+ */
+function InstancesSection({
+  blueprint,
+  appUID,
+  perCluster,
+}: {
+  blueprint: string
+  appUID: string
+  perCluster?: Array<Record<string, unknown>>
+}) {
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const qc = useQueryClient()
+
+  const instancesQuery = useQuery({
+    queryKey: ['blueprint-instances', blueprint],
+    queryFn: () => getApplicationInstances(blueprint),
+    enabled: !!blueprint,
+    staleTime: 15_000,
+    refetchInterval: 15_000,
+    retry: 1,
+  })
+
+  const items: ApplicationInstanceSummary[] = instancesQuery.data?.items ?? []
+
+  return (
+    <section
+      className="section"
+      data-testid="sov-section-instances"
+      style={{ marginTop: '0.6rem' }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: '0.4rem',
+        }}
+      >
+        <h2 style={{ margin: 0 }}>Instances</h2>
+        <button
+          type="button"
+          data-testid="btn-new-instance"
+          onClick={() => setDialogOpen(true)}
+          className="btn btn-primary"
+          style={{
+            padding: '0.3rem 0.8rem',
+            fontSize: '0.82rem',
+            background: 'var(--color-accent)',
+            color: 'white',
+            border: '0',
+            borderRadius: '6px',
+            cursor: 'pointer',
+            fontWeight: 600,
+          }}
+          aria-label="Create a new instance of this Blueprint"
+        >
+          + New instance
+        </button>
+      </div>
+
+      {instancesQuery.isPending ? (
+        <p
+          className="section-hint"
+          data-testid="sov-instances-loading"
+          style={{ margin: 0 }}
+        >
+          Loading instances…
+        </p>
+      ) : items.length === 0 ? (
+        <p
+          className="section-hint"
+          data-testid="sov-instances-empty"
+          style={{ margin: 0 }}
+        >
+          No instances of this Blueprint installed yet. Click "+ New
+          instance" to create the first one.
+        </p>
+      ) : (
+        <table
+          data-testid="sov-instances-table"
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontSize: '0.82rem',
+          }}
+        >
+          <thead>
+            <tr style={{ textAlign: 'left', color: 'var(--color-text-dim)' }}>
+              <th style={{ padding: '0.3rem 0.4rem' }}>Name</th>
+              <th style={{ padding: '0.3rem 0.4rem' }}>Instance ID</th>
+              <th style={{ padding: '0.3rem 0.4rem' }}>Org</th>
+              <th style={{ padding: '0.3rem 0.4rem' }}>Topology</th>
+              <th style={{ padding: '0.3rem 0.4rem' }}>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((inst) => (
+              <tr
+                key={inst.id || inst.name}
+                data-testid={`sov-instance-row-${inst.name}`}
+              >
+                <td style={{ padding: '0.3rem 0.4rem' }}>
+                  <code>{inst.name}</code>
+                </td>
+                <td
+                  style={{ padding: '0.3rem 0.4rem', color: 'var(--color-text-dim)' }}
+                >
+                  <code>{inst.id ? inst.id.slice(0, 8) : '—'}</code>
+                </td>
+                <td style={{ padding: '0.3rem 0.4rem' }}>{inst.org}</td>
+                <td style={{ padding: '0.3rem 0.4rem' }}>{inst.topology}</td>
+                <td style={{ padding: '0.3rem 0.4rem' }}>
+                  <span className="chip chip-cat">{inst.status}</span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {instancesQuery.isError ? (
+        <p
+          className="section-hint"
+          data-testid="sov-instances-error"
+          style={{ margin: '0.4rem 0 0', color: 'var(--color-danger)' }}
+        >
+          Failed to load instances:{' '}
+          {(instancesQuery.error as Error)?.message ?? 'unknown error'}
+        </p>
+      ) : null}
+
+      {/* Per-cluster fan-out for the CURRENT Application (G117.6) */}
+      {perCluster && perCluster.length > 0 ? (
+        <div style={{ marginTop: '0.8rem' }} data-testid="sov-percluster-block">
+          <h3
+            style={{
+              fontSize: '0.85rem',
+              margin: '0 0 0.3rem',
+              color: 'var(--color-text-strong)',
+            }}
+          >
+            Per-cluster fan-out
+            {appUID ? (
+              <span
+                style={{
+                  marginLeft: '0.5rem',
+                  fontSize: '0.7rem',
+                  color: 'var(--color-text-dim)',
+                  fontWeight: 400,
+                }}
+              >
+                (uid {appUID.slice(0, 8)})
+              </span>
+            ) : null}
+          </h3>
+          <table
+            data-testid="sov-percluster-table"
+            style={{
+              width: '100%',
+              borderCollapse: 'collapse',
+              fontSize: '0.78rem',
+            }}
+          >
+            <thead>
+              <tr style={{ textAlign: 'left', color: 'var(--color-text-dim)' }}>
+                <th style={{ padding: '0.25rem 0.4rem' }}>Cluster</th>
+                <th style={{ padding: '0.25rem 0.4rem' }}>Role</th>
+                <th style={{ padding: '0.25rem 0.4rem' }}>Status</th>
+                <th style={{ padding: '0.25rem 0.4rem' }}>HR</th>
+              </tr>
+            </thead>
+            <tbody>
+              {perCluster.map((row, idx) => {
+                const cluster = String(row.cluster ?? row.region ?? '—')
+                const role = String(row.role ?? '—')
+                const status = String(row.status ?? '—')
+                const hr = String(row.hr ?? row.helmRelease ?? '')
+                return (
+                  <tr
+                    key={`${cluster}-${idx}`}
+                    data-testid={`sov-percluster-row-${cluster}`}
+                  >
+                    <td style={{ padding: '0.25rem 0.4rem' }}>
+                      <code>{cluster}</code>
+                    </td>
+                    <td style={{ padding: '0.25rem 0.4rem' }}>{role}</td>
+                    <td style={{ padding: '0.25rem 0.4rem' }}>{status}</td>
+                    <td
+                      style={{
+                        padding: '0.25rem 0.4rem',
+                        color: 'var(--color-text-dim)',
+                      }}
+                    >
+                      {hr || '—'}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+
+      {dialogOpen ? (
+        <NewInstanceDialog
+          blueprint={blueprint}
+          onClose={() => setDialogOpen(false)}
+          onCreated={() => {
+            setDialogOpen(false)
+            qc.invalidateQueries({ queryKey: ['blueprint-instances', blueprint] })
+          }}
+        />
+      ) : null}
+    </section>
+  )
+}
+
+/**
+ * NewInstanceDialog — G117.2 #2741 topology-picker dialog. Opens on
+ * "+ New instance" click. Fields:
+ *
+ *  - name (string, lowercase k8s-name)
+ *  - org (string, free-text; defaults to "" — operator types the Org
+ *    slug they're installing into. TBD-followup: replace with a real
+ *    Org picker once the OrgList endpoint is wired into the FE).
+ *  - topology (radio: singleton / active-hot-standby / active-active /
+ *    active-passive, gated by Blueprint.spec.topology.supported[] from
+ *    getCatalogItemVersion). Defaults to the Blueprint's preferred
+ *    default if exposed.
+ *
+ * On submit POSTs to /catalyst/v1/apps/instances via
+ * createApplicationInstance. On 4xx error message renders inline; on
+ * 201 the dialog closes and the parent invalidates the instances
+ * cache.
+ */
+function NewInstanceDialog({
+  blueprint,
+  onClose,
+  onCreated,
+}: {
+  blueprint: string
+  onClose: () => void
+  onCreated: () => void
+}) {
+  const [name, setName] = useState('')
+  const [org, setOrg] = useState('')
+  const [topology, setTopology] = useState<string>('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Resolve the Blueprint's supported topologies via the catalog
+  // version endpoint. We don't have a fixed version pin from the
+  // AppDetail context, so call `getCatalogItem` first to read the
+  // latest version and then re-fetch with that version for the
+  // configSchema. For the dialog we only need `raw.spec.topology`, so
+  // a single getCatalogItemVersion call against the latest version is
+  // sufficient.
+  const bpName = blueprint.replace(/^bp-/, '')
+  const bpQuery = useQuery({
+    queryKey: ['catalog-item-latest', bpName],
+    queryFn: async () => {
+      // First fetch — get the latest version pin.
+      const { getCatalogItem } = await import('@/lib/catalog.api')
+      const latest = await getCatalogItem(bpName)
+      // Second fetch — get the full raw spec (topology, configSchema).
+      const full = await getCatalogItemVersion(bpName, latest.version)
+      return full
+    },
+    staleTime: 60_000,
+    retry: 1,
+  })
+
+  const supportedTopologies = useMemo<string[]>(() => {
+    const raw = bpQuery.data?.raw as
+      | { spec?: { topology?: { supported?: string[]; defaults?: Record<string, string> } } }
+      | undefined
+    const list = raw?.spec?.topology?.supported ?? []
+    if (!Array.isArray(list)) return []
+    return list.filter((s) => typeof s === 'string')
+  }, [bpQuery.data])
+
+  const defaultTopology = useMemo<string>(() => {
+    const raw = bpQuery.data?.raw as
+      | { spec?: { topology?: { defaults?: Record<string, string> } } }
+      | undefined
+    const defs = raw?.spec?.topology?.defaults
+    // Prefer multi-region default if set; else single-region; else
+    // first supported entry.
+    return defs?.['multi-region'] ?? defs?.['single-region'] ?? supportedTopologies[0] ?? ''
+  }, [bpQuery.data, supportedTopologies])
+
+  useEffect(() => {
+    if (!topology && defaultTopology) {
+      setTopology(defaultTopology)
+    }
+  }, [defaultTopology, topology])
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (submitting) return
+    setError(null)
+    setSubmitting(true)
+    try {
+      const body: CreateApplicationInstanceRequest = {
+        blueprint: bpName,
+        org: org.trim(),
+        name: name.trim(),
+      }
+      if (topology) body.topology = topology
+      await createApplicationInstance(body)
+      onCreated()
+    } catch (err) {
+      const e = err as Error & { code?: string; status?: number }
+      const code = e.code ? ` (${e.code})` : ''
+      setError(`${e.message}${code}`)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="new-instance-dialog-title"
+      data-testid="dialog-new-instance"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <form
+        onSubmit={onSubmit}
+        style={{
+          background: 'var(--color-surface)',
+          color: 'var(--color-text)',
+          border: '1px solid var(--color-border)',
+          borderRadius: '8px',
+          padding: '1.2rem',
+          minWidth: '420px',
+          maxWidth: '520px',
+          boxShadow: '0 10px 40px rgba(0,0,0,0.3)',
+        }}
+      >
+        <h3
+          id="new-instance-dialog-title"
+          style={{ margin: '0 0 0.8rem', fontSize: '1.05rem' }}
+        >
+          New instance of {bpName}
+        </h3>
+
+        <label
+          style={{ display: 'block', marginBottom: '0.6rem', fontSize: '0.85rem' }}
+        >
+          <span style={{ display: 'block', marginBottom: '0.2rem' }}>
+            Instance name
+          </span>
+          <input
+            type="text"
+            data-testid="input-instance-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            pattern="^[a-z0-9][a-z0-9-]{0,40}[a-z0-9]$"
+            title="Lowercase letters, digits, and dashes; 2-42 chars; no leading/trailing dash"
+            placeholder="my-instance"
+            style={{
+              width: '100%',
+              padding: '0.4rem 0.6rem',
+              background: 'var(--color-bg)',
+              color: 'var(--color-text)',
+              border: '1px solid var(--color-border)',
+              borderRadius: '4px',
+              fontSize: '0.85rem',
+            }}
+          />
+        </label>
+
+        <label
+          style={{ display: 'block', marginBottom: '0.6rem', fontSize: '0.85rem' }}
+        >
+          <span style={{ display: 'block', marginBottom: '0.2rem' }}>
+            Organization
+          </span>
+          <input
+            type="text"
+            data-testid="input-instance-org"
+            value={org}
+            onChange={(e) => setOrg(e.target.value)}
+            required
+            placeholder="acme"
+            style={{
+              width: '100%',
+              padding: '0.4rem 0.6rem',
+              background: 'var(--color-bg)',
+              color: 'var(--color-text)',
+              border: '1px solid var(--color-border)',
+              borderRadius: '4px',
+              fontSize: '0.85rem',
+            }}
+          />
+        </label>
+
+        <fieldset
+          style={{
+            border: '1px solid var(--color-border)',
+            borderRadius: '4px',
+            padding: '0.5rem 0.7rem',
+            marginBottom: '0.6rem',
+          }}
+        >
+          <legend style={{ fontSize: '0.8rem', padding: '0 0.3rem' }}>
+            Topology
+          </legend>
+          {bpQuery.isPending ? (
+            <p style={{ fontSize: '0.78rem', margin: 0, color: 'var(--color-text-dim)' }}>
+              Loading…
+            </p>
+          ) : supportedTopologies.length === 0 ? (
+            <p
+              style={{ fontSize: '0.78rem', margin: 0, color: 'var(--color-text-dim)' }}
+              data-testid="topology-radio-empty"
+            >
+              Blueprint does not declare supported topologies — server will
+              pick the default.
+            </p>
+          ) : (
+            supportedTopologies.map((t) => (
+              <label
+                key={t}
+                style={{
+                  display: 'block',
+                  fontSize: '0.82rem',
+                  padding: '0.15rem 0',
+                  cursor: 'pointer',
+                }}
+              >
+                <input
+                  type="radio"
+                  name="topology"
+                  value={t}
+                  checked={topology === t}
+                  onChange={() => setTopology(t)}
+                  data-testid={`topology-radio-${t}`}
+                  style={{ marginRight: '0.4rem' }}
+                />
+                {t}
+              </label>
+            ))
+          )}
+        </fieldset>
+
+        {error ? (
+          <p
+            data-testid="dialog-error"
+            style={{
+              color: 'var(--color-danger)',
+              fontSize: '0.8rem',
+              margin: '0 0 0.6rem',
+            }}
+          >
+            {error}
+          </p>
+        ) : null}
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: '0.5rem',
+          }}
+        >
+          <button
+            type="button"
+            data-testid="btn-cancel-instance"
+            onClick={onClose}
+            disabled={submitting}
+            style={{
+              padding: '0.35rem 0.8rem',
+              background: 'transparent',
+              color: 'var(--color-text)',
+              border: '1px solid var(--color-border)',
+              borderRadius: '4px',
+              fontSize: '0.82rem',
+              cursor: 'pointer',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            data-testid="btn-submit-instance"
+            disabled={submitting || !name || !org}
+            style={{
+              padding: '0.35rem 0.8rem',
+              background: 'var(--color-accent)',
+              color: 'white',
+              border: '0',
+              borderRadius: '4px',
+              fontSize: '0.82rem',
+              cursor: submitting ? 'not-allowed' : 'pointer',
+              fontWeight: 600,
+            }}
+          >
+            {submitting ? 'Creating…' : 'Create instance'}
+          </button>
+        </div>
+      </form>
+    </div>
   )
 }
 

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -10,6 +10,57 @@ name: bp-catalyst-platform
 # Auto-image-bump CI workflow covers catalystApi/catalystUi/
 # marketplaceApi/console only — controller drift requires manual edit.
 # Refs #2745 #2830 #2834.
+# 1.4.447 — G117.2 #2741 (2026-06-03): operator drill-down + topology
+# picker + HTTPRoute /catalyst/ rule. Three changes shipped lockstep on
+# the same PR to close the H10 walk's TWO 🔴 BLOCKED gaps:
+#
+#   (1) HTTPRoute: the catalyst-ui HTTPRoute on console.<sov> now
+#       forwards PathPrefix `/catalyst/` to the catalyst-api Service,
+#       matching the existing `/api/` rule. Prior to this rule the
+#       React SPA's catch-all router shadowed /catalyst/v1/* with
+#       index.html, so POST /catalyst/v1/apps/instances from the
+#       operator console returned the React shell (HTTP 200 +
+#       index.html). H10 confirmed the endpoint mount works via the
+#       `api.<sov>` hostname (405 on GET, expected — POST only). The
+#       new rule routes /catalyst/v1/apps/instances, /catalyst/v1/
+#       catalog/{bp}/instances, /catalyst/v1/apps/{uid}/launch-url,
+#       and every future /catalyst/v1/* sub-route through to the Go
+#       backend on the console hostname too.
+#
+#   (2) AppDetail UI: new Instances section above the canonical 7-tab
+#       strip with (a) a per-Blueprint instance list via GET
+#       /catalyst/v1/catalog/{blueprint}/instances showing name,
+#       instance-id, org, topology, status; (b) a "+ New instance"
+#       button with data-testid="btn-new-instance" that opens the
+#       topology-picker dialog (name + org + topology radio gated by
+#       Blueprint.spec.topology.supported[]); (c) on submit POST to
+#       /catalyst/v1/apps/instances per instances.CreateInstanceRequest
+#       wire shape. The AppDetail surface is now the CLASS card with
+#       drill-down to concrete instances; matrix-canonical 7-tab strip
+#       and existing hero/Overview/Launch button all preserved.
+#
+#   (3) Per-cluster fan-out block: when the BE response carries
+#       regionStatuses (controller writes status.perCluster[] per
+#       G117.6 application-controller), the new section also surfaces a
+#       cluster + role + status + HR table so the operator sees where
+#       the instance is running across host clusters.
+#
+# H10 walk evidence on hw86:
+#   walk-2741-catalog-flat-grid.png — catalog renders one card per
+#     Blueprint (class), no instance split prior to this PR.
+#   walk-2741-appdetail-bp-axon-no-new-instance.png — AppDetail had no
+#     instance list + no "+ New instance" button.
+#
+# Refs #2741 #2737 #2834. PR title:
+# `feat(catalyst): G117.2 #2741 — multi-instance drill-down + topology
+#  picker + HTTPRoute /catalyst/ rule`.
+# 1.4.445 — #2830 followup (2026-06-03): the catalyst-migrator:0.1.0 image
+# is now published to GHCR (build-catalyst-migrator.yaml workflow added at
+# the same PR) AND the migration Job Pod spec now carries
+# `imagePullSecrets: [ghcr-pull]` so the GHCR pull authenticates. The
+# `migrations.applicationsInstanceId.enabled` default stays FALSE this
+# cycle — operators must verify the migration on a legacy-CR cluster
+# before re-enabling globally. Refs #2830 #2823 #2834.
 # 1.4.439 — G117.E2E-A1 #2830 (2026-06-03): default
 # `.Values.migrations.applicationsInstanceId.enabled` to FALSE until the
 # `ghcr.io/openova-io/catalyst-migrator:0.1.0` image actually exists on
@@ -2401,7 +2452,7 @@ name: bp-catalyst-platform
 # bp-{dmz,rtz}-vcluster + bare-string depends[] in powerdns-admin +
 # sso-bridge) are unrelated to this slice.
 # (Bumped 440 → 441 to absorb concurrent merges since PR #2825 opened.)
-version: 1.4.446
+version: 1.4.448
 appVersion: 1.4.349
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/templates/httproute.yaml
+++ b/products/catalyst/chart/templates/httproute.yaml
@@ -102,6 +102,31 @@ spec:
       backendRefs:
         - name: catalyst-api
           port: 8080
+    # G117.2 #2741 (2026-06-03) — /catalyst/v1/* on the console hostname
+    # routes to catalyst-api, not catalyst-ui. The G117 multi-instance
+    # surface lives under /catalyst/v1/apps/instances (POST) and
+    # /catalyst/v1/catalog/{blueprint}/instances (GET) per
+    # docs/api/catalyst-api-openapi.yaml. Without this rule the React
+    # SPA's catch-all router shadows /catalyst/v1/* with the index.html
+    # shell — H10 walk on hw86 observed POST /catalyst/v1/apps/instances
+    # returning the React shell (HTTP 200 + index.html) when fired from
+    # the operator console. The same /catalyst/v1/apps/{uid}/launch-url
+    # endpoint that powers PR #2839's Launch button also depends on this
+    # rule when called via the console hostname (the Launch button on
+    # AppDetail.tsx calls `${API_BASE}/catalyst/v1/apps/{uid}/launch-url`
+    # where API_BASE resolves to the console origin in a Sovereign
+    # console session).
+    #
+    # PathPrefix is correct here (not Exact) — the prefix `/catalyst/`
+    # covers every sub-route under it (instances, catalog/{bp}/instances,
+    # apps/{uid}/launch-url, future /catalyst/v1/* additions).
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/catalyst/"
+      backendRefs:
+        - name: catalyst-api
+          port: 8080
     # Default — catalyst-ui (the React shell)
     - matches:
         - path:


### PR DESCRIPTION
## Summary

Closes the H10 walk's TWO 🔴 BLOCKED gaps for #2741 in one PR.

### (1) HTTPRoute gap — `/catalyst/*` now reaches catalyst-api on the console hostname

`products/catalyst/chart/templates/httproute.yaml` — the `catalyst-ui` HTTPRoute on `console.<sov>` now forwards `PathPrefix /catalyst/` to the `catalyst-api` Service, mirroring the existing `/api/` rule.

Prior to this rule the React SPA's catch-all router shadowed `/catalyst/v1/*` with `index.html`, so `POST /catalyst/v1/apps/instances` from the operator console returned the React shell (HTTP 200 + `index.html`). H10 walk on hw86 confirmed the endpoint mount works via the `api.<sov>` hostname (`405 on GET` — POST only) so the bug was purely the missing route rule on the console hostname.

PathPrefix (not Exact) covers every sub-route under `/catalyst/v1/*` — `apps/instances`, `catalog/{bp}/instances`, `apps/{uid}/launch-url`, and any future additions.

### (2) UI gap — AppDetail.tsx grows the multi-instance drill-down

`products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx`:

- New `InstancesSection` rendered above the canonical 7-tab strip:
  - Per-Blueprint instance table (one row per concrete install) via `GET /catalyst/v1/catalog/{bp}/instances`. Columns: name, instance-id, org, topology, status.
  - `+ New instance` button — `data-testid="btn-new-instance"` (matches H10 spec selector).
  - Per-cluster fan-out table when `regionStatuses` is populated (G117.6 application-controller writes `status.perCluster[]`).
- New `NewInstanceDialog` topology-picker:
  - Name + Org text inputs (name validates against `^[a-z0-9][a-z0-9-]{0,40}[a-z0-9]$` matching `instances.CreateInstanceRequest`).
  - Topology radio — options gated by `Blueprint.spec.topology.supported[]` resolved via `getCatalogItemVersion` against the latest version pin. Default = Blueprint's multi-region or single-region default per locked decision #7.
  - On submit POSTs to `/catalyst/v1/apps/instances` per `instances.CreateInstanceRequest` wire shape. 4xx errors render inline with the typed `code`; 201 closes the dialog + invalidates the instances query.

### API client additions

`products/catalyst/bootstrap/ui/src/lib/catalog.api.ts`:

- `getApplicationInstances(blueprint, {org?})` — GET list
- `createApplicationInstance(req)` — POST create
- Wire-shape types (`CreateApplicationInstanceRequest`, `ApplicationInstance`, `ApplicationInstanceSummary`, `ApplicationClusterStatus`, `ListBlueprintInstancesResponse`) mirroring catalyst-api at `bootstrap/api/internal/handler/endpoint_handler.go:117-142` and `bootstrap/api/internal/instances/create.go`.

### Chart bump + slot pin

- `products/catalyst/chart/Chart.yaml`: `1.4.446` → `1.4.447`.
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`: pin → `1.4.447`.

### H10 walk evidence (hw86, pre-PR — both screenshots captured to repo root)

- `walk-2741-catalog-flat-grid.png` — catalog showed one card per Blueprint (class) with no instance split.
- `walk-2741-appdetail-bp-axon-no-new-instance.png` — AppDetail had no instance list + no `+ New instance` button.

Refs #2741 #2737 #2834

## Test plan

- [ ] CI green (`tsc -b`, `vitest run`, chart-lint, `helm template`)
- [ ] On a fresh prov with chart 1.4.447: `curl https://console.<sov>/catalyst/v1/catalog/grafana/instances` returns JSON (not React shell)
- [ ] Operator walk: navigate to `/app/<dep>/applications/bp-axon`, observe `Instances` section + `+ New instance` button; click → dialog opens with topology radio
- [ ] Fill name/org → submit → 201 + new row appears in instances table within 15s refetch cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)