### PR TITLE
fix(bp-keycloak): #2744 — extend catalyst-kc-sa-credentials reflector to sso-bridge ns (resolve empty target Secret)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -121,7 +121,16 @@ spec:
       # tenant-realm + per-Org-realm templates that PR #2824 left
       # unaddressed. The per-Org case is the gating fix for the W2.C4
       # cross-Org silent-SSO walk on hw86. Refs #2816 #2744.
-      version: 1.4.16
+      # 1.4.17 (G117.5c #2744 H21, 2026-06-03): extend
+      # catalyst-kc-sa-credentials reflector whitelist on the source
+      # Secret to include `sso-bridge` ns alongside `catalyst-system`.
+      # Unblocks bp-sso-bridge reconciler Pod which had been stuck in
+      # CreateContainerConfigError because the local stub Secret stayed
+      # empty (DATA: 0) — reflector refused to copy from a source that
+      # didn't list `sso-bridge` in its allow + auto namespaces. Caught
+      # live H18 walk on hw86 2026-06-03 (H21 RCA). Companion to
+      # PR #2849 (NetPol port-8080 fix). Refs #2744 #2849 #2856.
+      version: 1.4.17
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.16
+  version: 1.4.17
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,5 +1,22 @@
 apiVersion: v2
 name: bp-keycloak
+# 1.4.17 (G117.5c #2744 H21, 2026-06-03): extend
+# catalyst-kc-sa-credentials reflector whitelist to include `sso-bridge`
+# namespace alongside the existing `catalyst-system` entry. The source
+# Secret in keycloak ns previously only allowed reflection into
+# catalyst-system; the bp-sso-bridge chart's stub mirror Secret
+# (platform/sso-bridge/chart/templates/secret-kc-credentials-mirror.yaml,
+# carrying `reflector.v1.k8s.emberstack.com/reflects:
+# keycloak/catalyst-kc-sa-credentials`) was rejected by reflector because
+# `sso-bridge` was absent from BOTH `reflection-allowed-namespaces` AND
+# `reflection-auto-namespaces` on the source — the stub Secret stayed
+# at DATA: 0, the sso-bridge-reconciler Pod hit
+# CreateContainerConfigError, and G117.5c per-Org realm fan-out + Tier-3
+# AppRegistration watcher couldn't reach Keycloak. Caught live H18 walk
+# on hw86 2026-06-03 (H21 RCA). Companion to PR #2849 (NetPol port-8080
+# fix on the sso-bridge → keycloak reach path): #2849 unblocks the L4
+# reach, this PR fills in the L7 credential bundle the reconciler needs
+# to authenticate. Refs #2744 #2849 #2856.
 # 1.4.16 (G117.E2E-A7 #2816, 2026-06-03): trim two MORE realm-import
 # descriptions PR #2824 (1.4.15) missed because its regression test only
 # covered configmap-sovereign-realm.yaml. The varchar(255) cap applies
@@ -135,7 +152,7 @@ name: bp-keycloak
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.4.16
+version: 1.4.17
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -896,13 +896,23 @@ metadata:
       cluster overlay to pin a known value (e.g. for sealed-secret
       replication scenarios).
     # Reflector cross-namespace mirror — catalyst-api lives in
-    # catalyst-system (bootstrap-kit slot 13). Auto-mirror so the
-    # destination Secret materialises as soon as catalyst-system
-    # namespace exists, even if bp-keycloak installs first.
+    # catalyst-system (bootstrap-kit slot 13) AND bp-sso-bridge's
+    # reconciler runs in `sso-bridge` (G117.5c Tier-3 AppRegistration
+    # watcher). Both downstream namespaces MUST be in the allow- +
+    # auto- whitelists or reflector refuses to copy the source bytes
+    # into their stub mirror Secrets. Caught live H18 walk on hw86
+    # 2026-06-03: sso-bridge stub stayed empty (DATA: 0), reconciler
+    # Pod stuck in CreateContainerConfigError. bp-sso-bridge's stub
+    # template platform/sso-bridge/chart/templates/
+    # secret-kc-credentials-mirror.yaml carries the corresponding
+    # `reflector.v1.k8s.emberstack.com/reflects:
+    # keycloak/catalyst-kc-sa-credentials` annotation — extending the
+    # source-side whitelist here is the missing other-half. Refs #2744
+    # #2856.
     reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "catalyst-system"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "catalyst-system,sso-bridge"
     reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "catalyst-system"
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "catalyst-system,sso-bridge"
 type: Opaque
 stringData:
   addr: {{ $kcAddr | quote }}


### PR DESCRIPTION
## Summary

Source-side fix for empty `sso-bridge/catalyst-kc-sa-credentials` Secret blocking G117.5c per-Org KC realm walk. Caught live during H18 walk on hw86 2026-06-03 (H21 RCA).

Adds `sso-bridge` to BOTH whitelists on the source Secret in `keycloak` ns:
- `reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces`
- `reflector.v1.k8s.emberstack.com/reflection-auto-namespaces`

## Root cause (H21 RCA — 2-layer infra block per H18 walk)

bp-sso-bridge chart already ships a stub mirror Secret in `sso-bridge` ns
carrying the inbound annotation:

```yaml
# platform/sso-bridge/chart/templates/secret-kc-credentials-mirror.yaml
annotations:
  reflector.v1.k8s.emberstack.com/reflects: "keycloak/catalyst-kc-sa-credentials"
```

But reflector enforces the **source-side whitelist** before copying bytes
into ANY mirror — and the source Secret in `keycloak` ns only permitted
`catalyst-system`:

```yaml
# platform/keycloak/chart/templates/configmap-sovereign-realm.yaml (BEFORE)
reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "catalyst-system"
reflector.v1.k8s.emberstack.com/reflection-auto-namespaces:    "catalyst-system"
```

Result on hw86:
- `keycloak/catalyst-kc-sa-credentials` — populated (4 keys: addr/realm/client-id/client-secret).
- `sso-bridge/catalyst-kc-sa-credentials` — DATA: 0 (stub never filled by reflector — sso-bridge not whitelisted at source).
- `sso-bridge-reconciler-55f88b7f74-nkkr2` — `CreateContainerConfigError` for 9m+ because the secretRef mount resolved to an empty Secret.

This is the **L7 credential bundle** half of the unblock. The **L4 reach**
to `keycloak.keycloak.svc.cluster.local:8080` was the other half — already
fixed by PR #2849 (NetPol port-8080). Together they re-enable the G117.5c
Tier-3 AppRegistration watcher.

## Diff scope

```
clusters/_template/bootstrap-kit/09-keycloak.yaml    | slot pin 1.4.16 → 1.4.17
platform/keycloak/blueprint.yaml                     | version  1.4.16 → 1.4.17
platform/keycloak/chart/Chart.yaml                   | version  1.4.16 → 1.4.17 + changelog block
platform/keycloak/chart/templates/configmap-sovereign-realm.yaml | annotations extended
```

Render verified locally:

```
$ helm template test platform/keycloak/chart --set sovereignFQDN=hw86.omani.works | \
    grep -A40 "name: catalyst-kc-sa-credentials" | grep reflection
    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "catalyst-system,sso-bridge"
    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "catalyst-system,sso-bridge"
```

Per-Sovereign overlays (`clusters/omantel.omani.works`, `clusters/otech.omani.works`) are intentionally NOT bumped — they pin older chart versions (1.4.1, 1.3.0) for compatibility.

## Test plan

- [ ] Reconcile bp-keycloak 1.4.17 on hw86 — `flux reconcile hr bp-keycloak`.
- [ ] Re-inspect source Secret:
      `kubectl -n keycloak get secret catalyst-kc-sa-credentials -o yaml | grep reflection-`
      should now show `catalyst-system,sso-bridge` in both allow + auto lists.
- [ ] Within ~5s of source-Secret update, the sso-bridge mirror should populate:
      `kubectl -n sso-bridge get secret catalyst-kc-sa-credentials -o jsonpath='{.data}'`
      must return 4 base64-encoded keys (addr/realm/client-id/client-secret).
- [ ] sso-bridge reconciler Pod transitions out of CreateContainerConfigError → Running.
- [ ] Reconciler can hit `keycloak.keycloak.svc.cluster.local:8080/realms/sovereign` (combined with #2849 NetPol fix).
- [ ] catalyst-system mirror unchanged (catalyst-api keeps reading its existing copy).

## Linked

Refs #2744 #2849 #2856