### PR TITLE
fix(catalyst-platform): #2745 — controller image pin path drift between chart template + values.yaml

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -915,7 +915,6 @@ spec:
       # image build workflow + imagePullSecrets:[ghcr-pull] on the
       # migration Job Pod spec. Default remains enabled=false until
       # operators verify on a legacy-CR cluster.
-      version: 1.4.448
       # 1.4.445 (H9-walk follow-up #2745, 2026-06-03): bump 5 controller
       # image pins to the latest GHCR-published push-on-main builds —
       # application-controller 8d01e2f -> 44dedf2 (G117.6 + G117.2
@@ -924,7 +923,6 @@ spec:
       # 8d01e2f -> dcd2bb3, organization-controller 7ff7ea8 -> 32050f0.
       # The CI auto-image-bump workflow does not cover controller
       # images; follow-up issue tracks closing that gap.
-      version: 1.4.448
       # 1.4.447 (G117.2 #2741, 2026-06-03): operator drill-down + topology
       # picker + HTTPRoute /catalyst/ rule. Closes the H10 walk's TWO 🔴
       # BLOCKED gaps in one PR: (a) catalyst-ui HTTPRoute on console.<sov>
@@ -935,8 +933,15 @@ spec:
       # wire shape; (c) per-cluster status table surfacing
       # Application.status.perCluster[] when populated by G117.6
       # application-controller fan-out. Refs #2741 #2737 #2834.
-      version: 1.4.448
-      version: 1.4.445
+      # 1.4.449 (#2745 follow-up, 2026-06-03): collapse 4 duplicate
+      # `version:` keys (introduced by concurrent #2852/#2854/#2855
+      # merges; YAML last-key-wins left effective version pinned at
+      # 1.4.445, while the in-cluster HR observed 1.4.447 — a phantom
+      # version never published to GHCR — leaving Flux wedged on
+      # FetchFailed). Bump to 449 to force a clean source-controller
+      # refetch carrying the merged controller image pins
+      # (application-controller 44dedf2 etc.) so #2745 actually rolls.
+      version: 1.4.449
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2473,8 +2473,40 @@ name: bp-catalyst-platform
 # bp-{dmz,rtz}-vcluster + bare-string depends[] in powerdns-admin +
 # sso-bridge) are unrelated to this slice.
 # (Bumped 440 → 441 to absorb concurrent merges since PR #2825 opened.)
-version: 1.4.448
-version: 1.4.445
+# 1.4.449 — fix(catalyst-platform): collapse duplicate `version:` keys.
+# Refs #2745 #2855 #2854 #2852.
+#
+# Three concurrent PRs on 2026-06-03 (#2852 chart-bump-to-1.4.445,
+# #2855 chart-bump-to-1.4.448, #2854 chart-bump-to-1.4.445) each
+# appended a fresh `version:` key without removing the predecessor.
+# Effective state on main after all three merges:
+#
+#   products/catalyst/chart/Chart.yaml:
+#     version: 1.4.448
+#     version: 1.4.445   ← YAML last-key-wins → effective 1.4.445
+#
+#   clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml:
+#     version: 1.4.448  (×3)
+#     version: 1.4.445   ← YAML last-key-wins → effective 1.4.445
+#
+# Symptom on hw86: HR.spec.chart.version observed as 1.4.447 (a
+# phantom version that was NEVER published to GHCR — source-controller
+# returns `ChartPullError: ghcr.io/openova-io/bp-catalyst-platform:
+# 1.4.447: not found`). The HR is wedged on FetchFailed; the last
+# successfully deployed chart is 1.4.446 (pulled 2026-06-02T18:54:48Z)
+# which predates the `applicationController.image.tag: "44dedf2"`
+# fix from #2852. Net effect: application-controller Deployment
+# stays on the old `8d01e2f` image despite the values.yaml change
+# being correctly merged on main, blocking #2745 closure.
+#
+# Fix: collapse the two duplicates to a single `version: 1.4.449`
+# line, matching the same collapse in the bootstrap-kit slot. Bumping
+# to 449 (not reusing 446 / 447 / 448 which all already exist on GHCR
+# in various forms) forces source-controller to refetch a fresh OCI
+# artifact carrying the merged values.yaml (`applicationController.
+# image.tag: "44dedf2"` + the four other controller image bumps from
+# #2852).
+version: 1.4.449
 appVersion: 1.4.349
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.


### PR DESCRIPTION
## Summary

- **RCA**: Three concurrent PRs on 2026-06-03 (#2852, #2854, #2855) each appended a fresh `version:` key to `products/catalyst/chart/Chart.yaml` and `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` without removing the predecessor. YAML last-key-wins → effective version pinned at `1.4.445`. Meanwhile the in-cluster HR on hw86 observed `version: 1.4.447` — a phantom version that was never published to GHCR (source-controller returns `ChartPullError: ghcr.io/openova-io/bp-catalyst-platform:1.4.447: not found`). Flux is wedged on FetchFailed; the last successfully deployed chart is `1.4.446`, which predates the `applicationController.image.tag: "44dedf2"` fix from #2852. Net effect: the application-controller Deployment on hw86 stays on the old `8d01e2f` image even after `kubectl rollout restart` (the chart template renders from chart `1.4.446` which still pins `8d01e2f`).
- **Fix**: Collapse the duplicate `version:` keys to a single `version: 1.4.449` line in both files. Bumping to `449` (not reusing `446`/`447`/`448` which all already exist on GHCR in various forms) forces source-controller to refetch a fresh OCI artifact carrying the merged values.yaml controller image pins.
- **Trigger**: `blueprint-release.yaml` workflow's `on: push: paths: products/*/chart/**` publishes `1.4.449` to GHCR on merge.

## Evidence

`helm template` smoke render against the fixed chart:
```
$ helm template smoke products/catalyst/chart/ | grep -A1 'name: controller' | grep image
        image: "ghcr.io/openova-io/openova/application-controller:44dedf2"
```

GHCR state (no `1.4.447` artifact exists; `1.4.446` and `1.4.448` do):
```
$ gh api /orgs/openova-io/packages/container/bp-catalyst-platform/versions \
    | jq -r '.[].metadata.container.tags[]' | grep '^1\.4\.4'
1.4.448
1.4.446
```

Live HR status on hw86:
```
status:
  conditions:
  - message: 'chart pull error: ... bp-catalyst-platform:1.4.447: not found'
    reason: ChartPullError
    type: FetchFailed
```

## Test plan

- [ ] CI `blueprint-release.yaml` workflow publishes `bp-catalyst-platform:1.4.449` to GHCR.
- [ ] On hw86 (manual or via Flux poll): HR reconciles to `1.4.449`; `kubectl -n catalyst-system get deploy catalyst-application-controller -o jsonpath='{.spec.template.spec.containers[0].image}'` returns `ghcr.io/openova-io/openova/application-controller:44dedf2`.
- [ ] Sibling controllers also flip to the new pins: `blueprint-controller:100a213`, `environment-controller:32050f0`, `useraccess-controller:dcd2bb3`, `organization-controller:32050f0`.

Refs #2745 #2852 #2854 #2855.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)