### PR TITLE
feat(catalyst-platform): #2856 Gap 5 — ship sovereigns.catalyst.openova.io CRD

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -941,7 +941,11 @@ spec:
       # FetchFailed). Bump to 449 to force a clean source-controller
       # refetch carrying the merged controller image pins
       # (application-controller 44dedf2 etc.) so #2745 actually rolls.
-      version: 1.4.449
+      # 1.4.450 — #2856 Gap 5: ship sovereigns.catalyst.openova.io CRD
+      # so catalyst-api's CountSovereignRegions can read
+      # Sovereign.spec.regions (was returning 0 because the CRD wasn't
+      # installed — H7 walk of #2742 evidence). Refs #2856 #2742 #2737.
+      version: 1.4.450
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2506,7 +2506,24 @@ name: bp-catalyst-platform
 # artifact carrying the merged values.yaml (`applicationController.
 # image.tag: "44dedf2"` + the four other controller image bumps from
 # #2852).
-version: 1.4.449
+# 1.4.450 (#2856 Gap 5, 2026-06-03): ship the missing
+# `sovereigns.catalyst.openova.io` CRD. H7 walk of #2742 confirmed
+# `kubectl get sovereign` returned "no resources" on hw86 because the
+# Sovereign CRD was never installed — catalyst-api's
+# `Handler.detectMultiRegion` therefore returned 0 from
+# `CountSovereignRegions` on every Sovereign and fell through to the
+# (also-unset) `SOVEREIGN_REGIONS` env var, silently defeating the
+# multi-region endpoint-selection contract in locked decision #7
+# (`len(Sovereign.spec.regions) > 1`). New CRD at
+# products/catalyst/chart/crds/sovereign.yaml + chart-test fixtures
+# under crds/tests/sovereign-sample-{valid,invalid}.yaml. Spec carries
+# fqdn / deploymentId / bcpTopology / regions[].(code,role,az,provider)
+# / parentDomains[].(name,role) / provider; status carries ready /
+# regionCount / regions[] / phase / conditions[] / observedGeneration.
+# deploymentId is immutable post-create via CEL
+# x-kubernetes-validations rule (matches Application.spec.instanceId
+# pattern from #2742 W2.C2). Refs #2856 #2742 #2737.
+version: 1.4.450
 appVersion: 1.4.349
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/crds/sovereign.yaml
+++ b/products/catalyst/chart/crds/sovereign.yaml
@@ -1,0 +1,295 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sovereigns.catalyst.openova.io
+  labels:
+    app.kubernetes.io/name: catalyst
+    app.kubernetes.io/component: sovereign
+spec:
+  group: catalyst.openova.io
+  scope: Cluster
+  names:
+    kind: Sovereign
+    listKind: SovereignList
+    singular: sovereign
+    plural: sovereigns
+    shortNames:
+      - sov
+    categories:
+      - catalyst
+      - openova
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: FQDN
+          type: string
+          jsonPath: .spec.fqdn
+        - name: Topology
+          type: string
+          jsonPath: .spec.bcpTopology
+        - name: Regions
+          type: integer
+          jsonPath: .status.regionCount
+        - name: Ready
+          type: boolean
+          jsonPath: .status.ready
+        - name: DeploymentID
+          type: string
+          jsonPath: .spec.deploymentId
+          priority: 1
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: |
+            Sovereign is the K8s-native record of a Catalyst Sovereign — one
+            deployed Catalyst instance (mothership or franchised). The CR is
+            the canonical truth-source for: (a) the per-Sovereign FQDN that
+            console / api / marketplace bind to; (b) the multi-region
+            topology (regions[]) that catalyst-api's chooseTopology consults
+            via `Handler.detectMultiRegion` (locked decision #7,
+            `len(Sovereign.spec.regions) > 1` = multi-region); (c) the
+            bcpTopology declaration that pillar 3 (zero-tx-loss) gates on;
+            (d) the parent-domain pool used by per-Org tenant subdomains;
+            (e) the operator-issued deploymentId used to correlate the
+            tofu workdir on the catalyst-api PVC.
+
+            One Sovereign CR per cluster, cluster-scoped, name conventionally
+            matches the FQDN's leftmost label or `sovereign-self` for the
+            local Sovereign. The CR is created by bp-self-sovereign-cutover
+            step-01 on franchised Sovereigns, and by the mothership
+            bootstrap on the OpenOva Sovereign.
+
+            Closes Gap 5 of #2856: prior to this CRD, `kubectl get sovereign`
+            returned "no resources" on every Sovereign and catalyst-api's
+            CountSovereignRegions silently fell through to the
+            SOVEREIGN_REGIONS env var (also unset), defeating multi-region
+            endpoint selection.
+
+            Refs #2856 #2742 #2737.
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [fqdn]
+              properties:
+                fqdn:
+                  type: string
+                  description: |
+                    Canonical Sovereign FQDN (e.g. `omantel.omani.works`,
+                    `t38.omani.works`). Hosts console.<fqdn>, api.<fqdn>,
+                    marketplace.<fqdn>, and every per-Org tenant subdomain.
+                    Lowercase, RFC-1123 hostname pattern with at least one
+                    dot (no bare labels).
+                  pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)+$'
+                  maxLength: 253
+                deploymentId:
+                  type: string
+                  description: |
+                    16-char hex correlation id for the per-Sovereign tofu
+                    workdir on the catalyst-api `catalyst-api-deployments`
+                    PVC (`/deps/tofu/<deployment-id>/`). Stable for the life
+                    of the Sovereign; immutable after creation.
+                  pattern: '^[0-9a-f]{16}$'
+                  x-kubernetes-validations:
+                    - rule: 'oldSelf == "" || self == oldSelf'
+                      message: 'spec.deploymentId is immutable after creation'
+                bcpTopology:
+                  type: string
+                  description: |
+                    Business-Continuity-Planning topology the operator
+                    selected at signup. `single-region` is one region (no
+                    BCP, dev/preview only). `active-hotstandby` is the
+                    default for production — primary region serves traffic,
+                    standby is warm, failover via Continuum. `active-active`
+                    is multi-master (CNPG quorum split, all regions serve).
+                    Both BCP variants require `len(regions)>=2` per Pillar 3.
+                  enum:
+                    - single-region
+                    - active-hotstandby
+                    - active-active
+                  default: single-region
+                regions:
+                  type: array
+                  description: |
+                    Per-region declaration in operator-supplied order. The
+                    catalyst-api `Handler.detectMultiRegion` reads
+                    `len(regions)>1` to flip multi-region topology gates;
+                    application-controller's TopologyResolver consults this
+                    list to default `placementSchema.defaultOnMultiRegion`.
+
+                    Index 0 is conventionally the primary; downstream
+                    consumers must not rely on that ordering for promotion
+                    (use Continuum / status.regions for live state).
+                  items:
+                    type: object
+                    required: [code]
+                    properties:
+                      code:
+                        type: string
+                        description: |
+                          Provider-native region code (e.g. `fsn1`,
+                          `hel1`, `me-east-215-a`). Used by the OpenTofu
+                          modules and by the application-controller's
+                          per-region HelmRelease fan-out.
+                        maxLength: 64
+                      role:
+                        type: string
+                        description: |
+                          Operator-meaningful tag for the region's role in
+                          the BCP topology. Free-form; common values
+                          `primary` (index 0 default), `standby`,
+                          `active` (active-active topology).
+                        maxLength: 32
+                      az:
+                        type: string
+                        description: |
+                          Optional cloud-provider availability-zone tag.
+                          Most providers infer the AZ from `code`; pass
+                          explicit `az` only when a single region exposes
+                          multiple physically-distinct AZs (HCS
+                          `me-east-215` exposes `-a` / `-b` / `-c`).
+                        maxLength: 64
+                      provider:
+                        type: string
+                        description: |
+                          CloudProvider adapter name (hetzner / huawei /
+                          aws / gcp / azure / oci). Defaults to the
+                          Sovereign-wide `spec.provider` when absent on a
+                          per-region entry.
+                        maxLength: 32
+                  x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys: [code]
+                parentDomains:
+                  type: array
+                  description: |
+                    Pool of registered DNS domains the Sovereign-side
+                    PowerDNS is authoritative for. Exactly one entry MUST
+                    carry `role=primary` (the entry that hosts
+                    console/api/marketplace — matches `spec.fqdn`'s
+                    registered apex). Zero-or-more entries may carry
+                    `role=sme-pool` (offered to SME tenants for free
+                    subdomains). Mirrors the wire shape provisioner.go
+                    ParentDomain emits.
+                  items:
+                    type: object
+                    required: [name, role]
+                    properties:
+                      name:
+                        type: string
+                        description: Registered apex (e.g. `omani.works`).
+                        pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)+$'
+                        maxLength: 253
+                      role:
+                        type: string
+                        enum:
+                          - primary
+                          - sme-pool
+                  x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys: [name]
+                provider:
+                  type: string
+                  description: |
+                    Sovereign-wide default CloudProvider adapter name. Used
+                    as the fallback for `regions[].provider` and as the
+                    dispatch target for `bp-self-sovereign-cutover`.
+                  enum:
+                    - hetzner
+                    - huawei
+                    - aws
+                    - gcp
+                    - azure
+                    - oci
+                    - contabo
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                ready:
+                  type: boolean
+                  description: |
+                    True once the Sovereign has completed bootstrap and
+                    every declared region has reconciled at least once.
+                regionCount:
+                  type: integer
+                  description: |
+                    Materialised count of regions actually reconciled —
+                    mirrors `len(status.regions)`. Used by Console
+                    printer-columns for at-a-glance topology check.
+                  minimum: 0
+                regions:
+                  type: array
+                  description: |
+                    Per-region materialised state — populated from the
+                    provisioner's `MaterializedRegions[]` slice and refreshed
+                    on every reconcile. May lag `spec.regions[]` while a
+                    fresh region rolls.
+                  items:
+                    type: object
+                    required: [code]
+                    properties:
+                      code:
+                        type: string
+                      role:
+                        type: string
+                      ready:
+                        type: boolean
+                      kubeconfigPath:
+                        type: string
+                        description: |
+                          On-disk path to the per-region kubeconfig under
+                          `catalyst-api-deployments` PVC
+                          (`/deps/kubeconfigs/<id>-<region>-<i>.yaml`).
+                          Surface for the chroot fallback path documented
+                          in feedback_chroot_in_cluster_fallback.md.
+                      lastReconciledAt:
+                        type: string
+                        format: date-time
+                  x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys: [code]
+                phase:
+                  type: string
+                  enum:
+                    - Pending
+                    - Bootstrapping
+                    - Ready
+                    - Degraded
+                    - CutoverInProgress
+                    - Sovereign
+                conditions:
+                  type: array
+                  description: |
+                    Standard k8s conditions[] (type/status/reason/message/
+                    lastTransitionTime). Reconcilers append; readers
+                    consume via meta.IsStatusConditionTrue.
+                  items:
+                    type: object
+                    required: [type, status]
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      observedGeneration:
+                        type: integer
+                        format: int64
+                  x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys: [type]
+                observedGeneration:
+                  type: integer
+                  format: int64
+              x-kubernetes-preserve-unknown-fields: true

--- a/products/catalyst/chart/crds/tests/sovereign-sample-invalid.yaml
+++ b/products/catalyst/chart/crds/tests/sovereign-sample-invalid.yaml
@@ -1,0 +1,75 @@
+# Invalid samples — each violates a single field-level constraint to verify
+# the openAPIV3Schema is actually enforced at admission. Apply with
+# --validate=true (the chart test runner asserts every entry below is
+# REJECTED by `kubectl apply --dry-run=server`).
+#
+# Invalid 1 — fqdn must contain at least one dot (bare label rejected).
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Sovereign
+metadata:
+  name: bad-fqdn-no-dot
+spec:
+  fqdn: localhost
+  bcpTopology: single-region
+---
+# Invalid 2 — deploymentId must be exactly 16 hex chars.
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Sovereign
+metadata:
+  name: bad-deployment-id
+spec:
+  fqdn: bad.example.com
+  deploymentId: not-hex-too-short
+  bcpTopology: single-region
+---
+# Invalid 3 — bcpTopology enum violation.
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Sovereign
+metadata:
+  name: bad-bcp-topology
+spec:
+  fqdn: bad.example.com
+  bcpTopology: split-brain
+---
+# Invalid 4 — provider enum violation.
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Sovereign
+metadata:
+  name: bad-provider
+spec:
+  fqdn: bad.example.com
+  bcpTopology: single-region
+  provider: digitalocean
+---
+# Invalid 5 — parentDomains[].role enum violation.
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Sovereign
+metadata:
+  name: bad-parent-domain-role
+spec:
+  fqdn: bad.example.com
+  bcpTopology: single-region
+  parentDomains:
+    - name: bad.example.com
+      role: backup-only
+---
+# Invalid 6 — regions[].code missing (required).
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Sovereign
+metadata:
+  name: bad-region-no-code
+spec:
+  fqdn: bad.example.com
+  bcpTopology: active-hotstandby
+  regions:
+    - role: primary
+    - role: standby
+---
+# Invalid 7 — fqdn uppercase letters rejected (lowercase pattern).
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Sovereign
+metadata:
+  name: bad-fqdn-uppercase
+spec:
+  fqdn: BAD.Example.COM
+  bcpTopology: single-region

--- a/products/catalyst/chart/crds/tests/sovereign-sample-valid.yaml
+++ b/products/catalyst/chart/crds/tests/sovereign-sample-valid.yaml
@@ -1,0 +1,77 @@
+# Valid samples — cover single-region (mothership preview), active-hotstandby
+# (the canonical production shape), and active-active (multi-master). Verified
+# via:
+#   kubectl apply --dry-run=server -f sovereign-sample-valid.yaml
+# (server-side dry-run requires the CRD applied to a real cluster first.)
+#
+# Sample 1 — single-region preview Sovereign on Hetzner (default at signup).
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Sovereign
+metadata:
+  name: sovereign-self
+  labels:
+    catalyst.openova.io/sovereign: t38.omani.works
+spec:
+  fqdn: t38.omani.works
+  deploymentId: 974113d27f0e3666
+  bcpTopology: single-region
+  provider: hetzner
+  regions:
+    - code: fsn1
+      role: primary
+      provider: hetzner
+  parentDomains:
+    - name: omani.works
+      role: primary
+---
+# Sample 2 — active-hotstandby Sovereign on Huawei (the canonical production
+# shape per the H7 walk evidence). 2 regions on the wire satisfies the
+# Pillar 3 `len(regions)>=2` gate at provisioner.go:798.
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Sovereign
+metadata:
+  name: omantel
+  labels:
+    catalyst.openova.io/sovereign: omantel.omani.works
+spec:
+  fqdn: omantel.omani.works
+  deploymentId: a1b2c3d4e5f60718
+  bcpTopology: active-hotstandby
+  provider: huawei
+  regions:
+    - code: me-east-215-a
+      role: primary
+      az: az1
+      provider: huawei
+    - code: me-east-215-b
+      role: standby
+      az: az2
+      provider: huawei
+  parentDomains:
+    - name: omani.works
+      role: primary
+    - name: omani.homes
+      role: sme-pool
+    - name: omani.rest
+      role: sme-pool
+---
+# Sample 3 — active-active multi-master on Hetzner.
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Sovereign
+metadata:
+  name: openova
+spec:
+  fqdn: openova.io
+  deploymentId: deadbeefcafebabe
+  bcpTopology: active-active
+  provider: hetzner
+  regions:
+    - code: fsn1
+      role: active
+    - code: hel1
+      role: active
+    - code: nbg1
+      role: active
+  parentDomains:
+    - name: openova.io
+      role: primary


### PR DESCRIPTION
## Summary

Closes Gap 5 of #2856. The H7 walk of #2742 endpoints CRUD found that
`kubectl get sovereign` returned "no resources" on hw86 because the
`sovereigns.catalyst.openova.io` CRD was never shipped. catalyst-api's
`Handler.detectMultiRegion(ctx, dynClient)` therefore got 0 from
`CountSovereignRegions` on every Sovereign and silently fell through to
the (also-unset) `SOVEREIGN_REGIONS` env var, defeating the multi-region
endpoint-selection contract in locked decision #7
(`len(Sovereign.spec.regions) > 1`).

## What lands

- `products/catalyst/chart/crds/sovereign.yaml` — Sovereign v1alpha1
  CRD (cluster-scoped, group `catalyst.openova.io`, kind `Sovereign`,
  plural `sovereigns`, short `sov`) with full openAPIV3Schema mirrored
  from `products/catalyst/bootstrap/api/internal/provisioner/provisioner.go`:
  - `spec.fqdn` — canonical Sovereign FQDN (lowercase hostname pattern,
    must contain at least one dot)
  - `spec.deploymentId` — 16-char hex correlation id, immutable after
    create via CEL `x-kubernetes-validations` (matches the W2.C2 pattern
    on `Application.spec.instanceId`)
  - `spec.bcpTopology` — enum `{single-region, active-hotstandby,
    active-active}` matching `provisioner.go:180`
  - `spec.regions[]` — `(code, role, az, provider)` per region;
    `x-kubernetes-list-type: map`, keyed by `code`
  - `spec.parentDomains[]` — `(name, role)` where role enum is
    `{primary, sme-pool}`; map list-type keyed by `name`
  - `spec.provider` — Sovereign-wide CloudProvider default
  - `status.{ready, regionCount, regions[], phase, conditions[],
    observedGeneration}` — standard k8s conditions[] + materialised
    region state mirroring `#2853 MaterializedRegions[]`
  - 6 printer columns: `FQDN / Topology / Regions / Ready /
    DeploymentID / Age`
- `products/catalyst/chart/crds/tests/sovereign-sample-valid.yaml` —
  3 valid samples (single-region preview, active-hotstandby production,
  active-active multi-master)
- `products/catalyst/chart/crds/tests/sovereign-sample-invalid.yaml` —
  7 invalid samples each violating exactly one constraint
  (no-dot fqdn, non-hex deploymentId, bad bcpTopology, bad provider,
  bad parentDomain role, missing region code, uppercase fqdn)
- `products/catalyst/chart/Chart.yaml` — version `1.4.449 → 1.4.450`
  with full changelog comment
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` —
  matching slot pin bump

Per docs/PRINCIPLES.md anti-theater rule + the open #2856 walk: this PR
ships `Refs`, NOT `Closes` — operator walk on a fresh prov is the
closure trigger, not PR merge.

Refs #2856 #2742 #2737

## Test plan

- [ ] `helm template` renders the CRD with valid openAPIV3Schema
- [ ] `kubectl apply --dry-run=server -f products/catalyst/chart/crds/sovereign.yaml`
      on a real cluster accepts the CRD
- [ ] `kubectl apply --dry-run=server -f products/catalyst/chart/crds/tests/sovereign-sample-valid.yaml`
      accepts all 3 samples
- [ ] `kubectl apply --dry-run=server -f products/catalyst/chart/crds/tests/sovereign-sample-invalid.yaml`
      rejects all 7 samples at the expected field path
- [ ] On a fresh prov, post-bp-catalyst-platform reconcile:
      `kubectl get sovereign` returns at least the bootstrap-seeded
      Sovereign CR (created by `bp-self-sovereign-cutover` step-01 OR a
      mothership bootstrap follow-up — out of scope for this PR)
- [ ] H7 re-walk of #2742: catalyst-api `Handler.detectMultiRegion`
      reads `len(spec.regions) > 1` correctly without falling through
      to the env-var path
- [ ] Operator walks the Sovereign drill-down in the Catalyst console
      (depends on a follow-up that seeds the `sovereign-self` CR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)