### PR TITLE
fix(catalyst-platform): bump catalystApi+Ui image pins to ff778a36 (handover signer)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -945,7 +945,7 @@ spec:
       # so catalyst-api's CountSovereignRegions can read
       # Sovereign.spec.regions (was returning 0 because the CRD wasn't
       # installed — H7 walk of #2742 evidence). Refs #2856 #2742 #2737.
-      version: 1.4.450
+      version: 1.4.451
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2523,7 +2523,7 @@ name: bp-catalyst-platform
 # deploymentId is immutable post-create via CEL
 # x-kubernetes-validations rule (matches Application.spec.instanceId
 # pattern from #2742 W2.C2). Refs #2856 #2742 #2737.
-version: 1.4.450
+version: 1.4.451
 appVersion: 1.4.349
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -288,9 +288,15 @@ images:
   organization: "openova-io/openova"
   # SHA tags — bump these via CI when building new images.
   catalystApi:
-    tag: "2ae493f"
+    # 2026-06-03: bumped 2ae493f → ff778a36. Binary 2ae493f predates
+    # PR #2854 env rename (CATALYST_HANDOVER_KEY_PATH →
+    # CATALYST_HANDOVER_SIGNER_PATH) and only reads the legacy name;
+    # new chart emits only the new name, so handoverSigner never
+    # initialises and /api/v1/auth/pin/issue returns 503 "handover
+    # signer unavailable". ff778a36 reads both names with fallback.
+    tag: "ff778a36"
   catalystUi:
-    tag: "2ae493f"
+    tag: "ff778a36"
   marketplaceApi:
     tag: "3c2f7e4"
   console:


### PR DESCRIPTION
## Summary
Chart shipped `catalystApi.tag=2ae493f` which is a binary BEFORE PR #2854's env rename — `/api/v1/auth/pin/issue` returns 503 'handover signer unavailable'. Bump to `ff778a36` which has the env fallback.

## Live evidence (hw86)
- Pre-bump: POST /api/v1/auth/pin/issue → 503 'CATALYST_HANDOVER_KEY_PATH not set'
- After `kubectl set image` to `latest` (ff778a36): 'handoverjwt: signer ready' log + POST → 200 with requestId

Refs #2737 #2851 #2854

🤖 Generated with [Claude Code](https://claude.com/claude-code)