### PR TITLE
fix(ci): #2851 — extend auto-image-bump workflow to cover all 5 controller images

### DIFF
--- a/.github/workflows/catalyst-build.yaml
+++ b/.github/workflows/catalyst-build.yaml
@@ -598,6 +598,115 @@ jobs:
           # old image while the Sovereign provisioning churned through
           # the same SHA being fixed downstream).
 
+      # #2851 (2026-06-03) — controller-image freshness sweep.
+      #
+      # Background: each of the 5 Group C controllers (application /
+      # blueprint / environment / organization / useraccess) has its
+      # OWN build workflow that auto-bumps its OWN values.yaml tag on
+      # push-to-main. In theory the chart converges. In practice the
+      # H9 walk on 2026-06-03 caught 4 of 5 controllers pinned to
+      # `8d01e2f` (G93.2-era, pre-G117.6) for weeks — every per-
+      # controller auto-bump that fired between G93.2 and G117.6
+      # silently dropped: bot-author push race against parallel deploy
+      # commits, dispatch step skipped because the controller's PR
+      # also touched core/console/ (so the catalyst-build path filter
+      # fired first), Chart.yaml bump landing on a non-image commit
+      # that masked the controller bump, etc. Result: chart shipped a
+      # binary BEFORE G117.6 PR #2790 → application-controller had
+      # NO topology fan-out + NO multi-instance fields. Same root
+      # class as PR #2854/#2865 PIN-login outage (catalyst-api shipping
+      # at `2ae493f` — a SHA BEFORE PR #2854's env rename).
+      #
+      # Defense: every catalyst-build deploy step now ALSO sweeps the
+      # 5 controller pins by resolving the LATEST pushed SHA tag from
+      # GHCR for each controller package and stamping it into
+      # values.yaml. This is belt-and-braces — controllers also retain
+      # their own auto-bump, but the catalyst-build sweep guarantees
+      # that *every* time the catalyst chart re-publishes, controller
+      # pins are at most as stale as the latest pushed image. Since
+      # blueprint-release fires from this same job, the chart and the
+      # controller pins re-sync on every catalyst-build run.
+      #
+      # GHCR API: `/orgs/openova-io/packages/container/<name>/versions`
+      # — pattern already used by scripts/check-bootstrap-kit-pin-
+      # sync.sh:332. Returns versions sorted by created_at desc.
+      # `updated_at` of the topmost non-`sha256-` tag = latest pushed
+      # image. We extract its short-SHA tag (7-hex) and stamp it.
+      - name: '#2851 — Sweep controller image tags from latest GHCR pushes'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          VALUES="products/catalyst/chart/values.yaml"
+
+          # Per-controller mapping: values-key (under `controllers:`)
+          # → GHCR package name. Add new controllers here when they
+          # land in core/controllers/ and have a build-*-controller
+          # workflow registered in scripts/check-controller-workflow-
+          # uniformity.sh.
+          declare -A CTRL_PKG=(
+            [application]=application-controller
+            [blueprint]=blueprint-controller
+            [environment]=environment-controller
+            [organization]=organization-controller
+            [useraccess]=useraccess-controller
+          )
+
+          bumped=0
+          for key in "${!CTRL_PKG[@]}"; do
+            pkg="${CTRL_PKG[$key]}"
+            # Query GHCR for the most-recently-pushed tag. We filter
+            # out cosign signature artifacts (sha256-…) and the
+            # rolling `latest` tag (which is just an alias, not a
+            # SHA-pinnable target per Principle #4a). The remaining
+            # entries are 7-hex short SHAs stamped by the per-
+            # controller build workflow. Take the first 7-hex hit on
+            # the highest-`updated_at` version → that's the latest
+            # main-HEAD push.
+            tag=$(gh api "/orgs/openova-io/packages/container/${pkg}/versions" --paginate 2>/dev/null \
+              | jq -r '[.[] | {u:.updated_at, tags:(.metadata.container.tags // [])}]
+                       | sort_by(.u) | reverse
+                       | .[].tags[]?' 2>/dev/null \
+              | grep -vE '^(sha256-|latest$)' \
+              | grep -E '^[0-9a-f]{7}$' \
+              | head -1 || true)
+
+            if [ -z "${tag}" ]; then
+              echo "WARN: GHCR returned no 7-hex tag for ${pkg} — skipping controller bump (chart will keep current pin)."
+              continue
+            fi
+
+            # Read the current pin from values.yaml so we can no-op
+            # if already in sync (avoids needless commits).
+            cur=$(awk -v k="${key}" '
+              /^controllers:/ { in_c=1 }
+              in_c && $0 ~ "^  " k ":" { in_k=1; next }
+              in_c && /^  [a-z]/ && !($0 ~ "^  " k ":") { in_k=0 }
+              in_k && /^      tag:/ {
+                match($0, /"[^"]*"/); print substr($0, RSTART+1, RLENGTH-2); exit
+              }
+            ' "${VALUES}")
+
+            if [ "${cur}" = "${tag}" ]; then
+              echo "OK: controllers.${key}.image.tag already at ${tag}"
+              continue
+            fi
+
+            # Awk patch mirrors the per-controller workflow's bump
+            # (build-organization-controller.yaml lines 170-176 et
+            # al.) so chart-side semantics stay identical.
+            awk -v k="${key}" -v sha="${tag}" '
+              /^controllers:/ { in_c=1 }
+              in_c && $0 ~ "^  " k ":" { print; in_k=1; next }
+              in_c && /^  [a-z]/ && !($0 ~ "^  " k ":") { in_k=0 }
+              in_k && /^      tag:/ { sub(/"[^"]*"/, "\"" sha "\""); in_k=0 }
+              { print }
+            ' "${VALUES}" > "${VALUES}.tmp" && mv "${VALUES}.tmp" "${VALUES}"
+            echo "BUMPED: controllers.${key}.image.tag ${cur} -> ${tag}"
+            bumped=$((bumped + 1))
+          done
+          echo "#2851 sweep: bumped ${bumped}/5 controller pin(s) to latest GHCR."
+
       # values.yaml + the two literal-image templates (api-deployment,
       # ui-deployment) are bumped together so:
       #   - Sovereigns get the new SHA via the next OCI chart publish
@@ -624,7 +733,7 @@ jobs:
             products/catalyst/chart/templates/api-deployment-kustomize.yaml
             products/catalyst/chart/templates/ui-deployment.yaml
             products/catalyst/chart/Chart.yaml
-          commit-message: "deploy: update catalyst images to ${{ needs.build-ui.outputs.sha_short }}"
+          commit-message: "deploy: update catalyst images to ${{ needs.build-ui.outputs.sha_short }} (+ #2851 controller sweep)"
 
       # Closes #712. The push above is made by GITHUB_TOKEN; per GitHub
       # Actions design, commits authored by GITHUB_TOKEN do NOT re-trigger

--- a/.github/workflows/check-controller-image-tag-freshness.yaml
+++ b/.github/workflows/check-controller-image-tag-freshness.yaml
@@ -1,0 +1,66 @@
+name: Controller-image-tag freshness guard
+
+# Defense for #2851 (2026-06-03) — pre-merge guard that fails if any of
+# the 5 Group C controller image tags in
+# products/catalyst/chart/values.yaml is more than 50 commits behind
+# the latest pushed image on GHCR.
+#
+# Background
+# ----------
+# Each controller has its own build-*-controller.yaml that auto-bumps
+# its OWN values.yaml tag on push-to-main (TBD-A69 / PRs #2005 #2012).
+# Despite that, the H9-walk on 2026-06-03 caught 4 of 5 controllers
+# pinned to `8d01e2f` (G93.2-era, pre-G117.6) for weeks — per-
+# controller auto-bumps had silently dropped on race / dispatch-skip /
+# Chart.yaml masking. Same root class as PR #2854/#2865 PIN-login
+# outage (catalyst-api shipping `2ae493f` BEFORE PR #2854's env
+# rename).
+#
+# This workflow runs the freshness check on every PR that touches
+# products/catalyst/chart/values.yaml (so PRs that manually bump pins
+# get caught) AND on every push to main (so the post-merge state is
+# audited even when the PR itself didn't touch values.yaml — e.g.
+# blueprint-release.yaml races). The catalyst-build.yaml #2851 sweep
+# step closes the gap proactively on every build; this guard is the
+# belt-and-braces gate that fails any merge re-introducing a stale
+# pin.
+#
+# Per `feedback_inviolable_principles.md`: event-driven only, NO cron.
+
+on:
+  pull_request:
+    paths:
+      - 'products/catalyst/chart/values.yaml'
+      - 'scripts/check-controller-image-tag-freshness.sh'
+      - '.github/workflows/check-controller-image-tag-freshness.yaml'
+  push:
+    branches: [main]
+    paths:
+      - 'products/catalyst/chart/values.yaml'
+      - 'scripts/check-controller-image-tag-freshness.sh'
+      - '.github/workflows/check-controller-image-tag-freshness.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  check:
+    name: Controller-image-tag freshness
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Need full history so `git rev-list <pin>..<latest>` can
+          # compute the lag. PR shallow clones drop the per-controller
+          # commits we're counting against.
+          fetch-depth: 0
+
+      - name: Run controller-image-tag freshness check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAX_LAG_COMMITS: '50'
+        run: bash scripts/check-controller-image-tag-freshness.sh

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -400,10 +400,12 @@ controllers:
       # 7ff7ea8 (2026-06-02) which itself superseded c9b58ea (TBD-A68
       # / #1997, 2026-05-20). Picks up the latest organization-
       # controller main-HEAD push including G117.2/G117.3b iac-bootstrap.
-      # The CI auto-image-bump workflow covers catalystApi/catalystUi/
-      # marketplaceApi/console only — controller images drift through
-      # chart bumps until a manual edit lands. Follow-up issue tracks
-      # closing that gap.
+      # #2851 (2026-06-03): controller pins are now auto-bumped by
+      # (a) each build-*-controller.yaml's own auto-bump step and
+      # (b) the catalyst-build.yaml #2851 sweep step on every catalyst
+      # rebuild, plus (c) the controller-image-tag freshness guard
+      # (scripts/check-controller-image-tag-freshness.sh) fails any PR
+      # that lets a controller pin drift > 50 commits behind GHCR.
       # Previously: c9b58ea = TBD-A68 fix (#1997, 2026-05-20) — picks
       # up PR #1910's gitea-client fix (POST /api/v1/orgs instead of
       # the admin-only /api/v1/admin/orgs endpoint that returned HTTP
@@ -444,9 +446,8 @@ controllers:
       repository: "ghcr.io/openova-io/openova/environment-controller"
       # 32050f0 = H9-walk follow-up (#2745, 2026-06-03) — bumped from
       # 8d01e2f (2026-05-31) to the latest environment-controller main-
-      # HEAD push (2026-06-02). The CI auto-image-bump workflow covers
-      # catalystApi/catalystUi/marketplaceApi/console only — controller
-      # images drift through chart bumps until a manual edit lands.
+      # HEAD push (2026-06-02). #2851 sweep + freshness guard now
+      # keeps this pin in sync — see organization-controller note above.
       # Previously: a3ba200 = qa-loop iter-8 Fix #42 follow-up (#1257)
       # — adds EnsureBranch before PutFile so Gitea's branch-missing
       # 404 (mapped to ErrRepoNotFound by the client) no longer dead-
@@ -516,10 +517,9 @@ controllers:
       # 44dedf2 = H9-walk follow-up (#2745, 2026-06-03) — bumped from
       # 8d01e2f (G93.2 era, pre-G117.6). 44dedf2 is the latest main-
       # HEAD push (2026-06-02) and contains G117.6 PR #2790 (commit
-      # 67e23a55) + G117.2 multi-instance fields. The CI auto-image-
-      # bump workflow covers catalystApi/catalystUi/marketplaceApi/
-      # console only — controller tags must be bumped manually until
-      # the gap is closed (follow-up issue tracked alongside this PR).
+      # 67e23a55) + G117.2 multi-instance fields. #2851 closed the
+      # drift gap — see organization-controller note above for the
+      # 3-layer defense (own auto-bump + catalyst-build sweep + guard).
       # Previously: a3ba200 = qa-loop iter-8 Fix #42 follow-up (#1257)
       # — drops cross-namespace ownerRef on the host-side Flux CRs
       # (was being silently GC'd by the K8s collector because
@@ -580,9 +580,8 @@ controllers:
       # SHA pinned to the latest GHCR-published push-on-main build per
       # docs/INVIOLABLE-PRINCIPLES.md #4a. dcd2bb3 = H9-walk follow-up
       # (#2745, 2026-06-03) — bumped from 8d01e2f (2026-05-31) to the
-      # latest useraccess-controller main-HEAD push (2026-06-02). The
-      # CI auto-image-bump workflow does not cover controller images;
-      # tracked as follow-up alongside this PR.
+      # latest useraccess-controller main-HEAD push (2026-06-02).
+      # #2851 closed the drift gap (auto-bump + sweep + freshness guard).
       tag: "dcd2bb3"
       pullPolicy: IfNotPresent
     replicas: 1

--- a/scripts/check-controller-image-tag-freshness.sh
+++ b/scripts/check-controller-image-tag-freshness.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# check-controller-image-tag-freshness.sh
+#
+# Defense for #2851 (2026-06-03) — pre-merge guard that fails if any of
+# the 5 Group C controller image tags in
+# products/catalyst/chart/values.yaml is more than $MAX_LAG_COMMITS
+# behind the latest pushed image on GHCR (default: 50 commits).
+#
+# Background
+# ----------
+# Each controller has its own build-*-controller.yaml workflow that
+# auto-bumps its OWN values.yaml tag on push-to-main (added in PRs
+# #2005 / #2012 / TBD-A69). Despite that, the H9-walk on 2026-06-03
+# caught 4 of 5 controllers pinned to `8d01e2f` — G93.2-era, pre-
+# G117.6 — for weeks. Per-controller auto-bumps had silently dropped
+# on race / dispatch-skip / Chart.yaml masking. Same root class as PR
+# #2854/#2865 PIN-login outage (catalyst-api shipping at `2ae493f` —
+# a SHA BEFORE PR #2854's env rename).
+#
+# Defense (this script)
+# ---------------------
+# For each of `application | blueprint | environment | organization |
+# useraccess`:
+#   1. Read the current `controllers.<name>.image.tag` from
+#      products/catalyst/chart/values.yaml.
+#   2. Query GHCR for the latest pushed 7-hex SHA tag of
+#      `ghcr.io/openova-io/openova/<name>-controller`.
+#   3. Count `git rev-list <pin>..<latest>` — if the count exceeds
+#      MAX_LAG_COMMITS (default 50), fail loudly.
+#
+# Per Inviolable Principle #4a (chart-pin bumps must match a published
+# GHCR tag): a controller pin behind main HEAD by >50 commits is a
+# silent regression in production charts. Catalyst-build's #2851 sweep
+# step closes the gap on every build; this script is the belt-and-
+# braces gate that fails any PR that introduces (or re-introduces) a
+# stale pin manually.
+#
+# Mirrors scripts/check-bootstrap-kit-pin-sync.sh:332 for the GHCR API
+# call and scripts/check-controller-workflow-uniformity.sh for the
+# fail-loudly shape (single script, no external deps beyond
+# grep/awk/jq/gh).
+#
+# Env knobs:
+#   MAX_LAG_COMMITS   default 50  — fail threshold (commits behind).
+#   VALUES_YAML       default products/catalyst/chart/values.yaml.
+#   GHCR_ORG          default openova-io.
+#   SKIP_GHCR         default ""   — set to any value to skip GHCR
+#                                    queries (offline/dev use only).
+#
+# Exit codes:
+#   0 — every controller pin is within MAX_LAG_COMMITS of latest GHCR.
+#   1 — at least one pin is stale OR a GHCR query failed.
+#   2 — local repo doesn't have the pinned SHA (need full fetch).
+
+set -euo pipefail
+
+MAX_LAG_COMMITS="${MAX_LAG_COMMITS:-50}"
+VALUES_YAML="${VALUES_YAML:-products/catalyst/chart/values.yaml}"
+GHCR_ORG="${GHCR_ORG:-openova-io}"
+SKIP_GHCR="${SKIP_GHCR:-}"
+
+# Controllers covered. Add new entries here when a new controller lands
+# in core/controllers/ and is added to scripts/check-controller-
+# workflow-uniformity.sh's CONTROLLERS list. The values-key (LHS) MUST
+# match the `controllers.<key>:` block in values.yaml; the GHCR
+# package name (RHS) MUST match the `ghcr.io/openova-io/openova/<rhs>`
+# repository pushed by build-<rhs>.yaml.
+declare -A CTRL_PKG=(
+  [application]=application-controller
+  [blueprint]=blueprint-controller
+  [environment]=environment-controller
+  [organization]=organization-controller
+  [useraccess]=useraccess-controller
+)
+
+if [ ! -f "${VALUES_YAML}" ]; then
+  echo "::error::values.yaml not found at ${VALUES_YAML}"
+  exit 1
+fi
+
+fail=0
+checked=0
+
+for key in "${!CTRL_PKG[@]}"; do
+  pkg="${CTRL_PKG[$key]}"
+
+  # 1) Current pin from values.yaml. Reuses the same awk shape as the
+  # build-*-controller bump steps so a values.yaml structural change
+  # affects this script + the bump steps together (single point of
+  # truth).
+  pin=$(awk -v k="${key}" '
+    /^controllers:/ { in_c=1 }
+    in_c && $0 ~ "^  " k ":" { in_k=1; next }
+    in_c && /^  [a-z]/ && !($0 ~ "^  " k ":") { in_k=0 }
+    in_k && /^      tag:/ {
+      match($0, /"[^"]*"/); print substr($0, RSTART+1, RLENGTH-2); exit
+    }
+  ' "${VALUES_YAML}")
+
+  if [ -z "${pin}" ]; then
+    echo "::error::could not parse controllers.${key}.image.tag from ${VALUES_YAML}"
+    fail=$((fail + 1))
+    continue
+  fi
+
+  if [ -n "${SKIP_GHCR}" ]; then
+    echo "  SKIP-GHCR  ${key}-controller pin=${pin}  (SKIP_GHCR set)"
+    checked=$((checked + 1))
+    continue
+  fi
+
+  # 2) Latest GHCR-pushed 7-hex tag for this controller. Same shape as
+  # the #2851 sweep step in catalyst-build.yaml. We filter cosign
+  # signature artifacts + the rolling `latest` alias, keep only true
+  # 7-hex tags, and take the most-recently-updated one.
+  if ! versions_json=$(gh api "/orgs/${GHCR_ORG}/packages/container/${pkg}/versions" --paginate 2>/dev/null); then
+    echo "::error::GHCR API query failed for ${pkg} — check 'gh' auth has read:packages scope"
+    fail=$((fail + 1))
+    continue
+  fi
+
+  latest=$(echo "${versions_json}" \
+    | jq -r '[.[] | {u:.updated_at, tags:(.metadata.container.tags // [])}]
+             | sort_by(.u) | reverse
+             | .[].tags[]?' 2>/dev/null \
+    | grep -vE '^(sha256-|latest$)' \
+    | grep -E '^[0-9a-f]{7}$' \
+    | head -1 || true)
+
+  if [ -z "${latest}" ]; then
+    echo "::warning::no 7-hex GHCR tag found for ${pkg} — skipping freshness check (package may be brand-new)"
+    checked=$((checked + 1))
+    continue
+  fi
+
+  # Both sides are 7-hex short SHAs — need to resolve them to full git
+  # objects to count the lag. Local repo MUST have main fetched.
+  if ! git cat-file -e "${pin}^{commit}" 2>/dev/null; then
+    echo "::error::pin SHA ${pin} for ${pkg} not in local repo — fetch main first (try: git fetch origin main --unshallow)"
+    fail=$((fail + 1))
+    continue
+  fi
+  if ! git cat-file -e "${latest}^{commit}" 2>/dev/null; then
+    echo "::warning::latest GHCR SHA ${latest} for ${pkg} not in local repo — comparing strings only"
+    if [ "${pin}" = "${latest}" ]; then
+      echo "  OK         ${pkg}:${pin} (matches latest GHCR)"
+    else
+      echo "::error::${pkg}: pinned ${pin}, latest GHCR is ${latest} (and not in local repo — likely stale)"
+      fail=$((fail + 1))
+    fi
+    checked=$((checked + 1))
+    continue
+  fi
+
+  # 3) Lag count via `git rev-list`. If pin == latest, lag = 0.
+  if [ "${pin}" = "${latest}" ]; then
+    lag=0
+  else
+    # `pin..latest` = commits reachable from latest but not from pin.
+    # If pin is ahead (rare — manual debug bump?), count is 0 and we
+    # don't flag it; the operator is intentionally on a newer image.
+    lag=$(git rev-list --count "${pin}..${latest}" 2>/dev/null || echo "??")
+  fi
+
+  if [ "${lag}" = "??" ]; then
+    echo "::warning::could not compute lag for ${pkg} (pin=${pin} latest=${latest}) — possible non-linear history"
+  elif [ "${lag}" -gt "${MAX_LAG_COMMITS}" ]; then
+    echo "::error::${pkg}: pinned ${pin} is ${lag} commits behind latest GHCR ${latest} (threshold: ${MAX_LAG_COMMITS})"
+    echo "::error::  bump in ${VALUES_YAML}: controllers.${key}.image.tag \"${latest}\""
+    fail=$((fail + 1))
+  else
+    echo "  OK         ${pkg}:${pin} (lag=${lag}, latest=${latest})"
+  fi
+  checked=$((checked + 1))
+done
+
+echo
+echo "Checked ${checked}/${#CTRL_PKG[@]} controller pin(s); ${fail} stale."
+
+if [ "${fail}" -gt 0 ]; then
+  echo
+  echo "FAIL: at least one controller image pin in ${VALUES_YAML} is stale"
+  echo "by more than ${MAX_LAG_COMMITS} commits relative to the latest"
+  echo "GHCR push. This is the #2851 H9-walk class — chart will ship a"
+  echo "binary missing recent features (e.g. G117.6 topology fan-out)."
+  echo
+  echo "Defenses:"
+  echo "  - catalyst-build.yaml's #2851 sweep step bumps every controller"
+  echo "    pin to the latest GHCR tag on every catalyst-build run."
+  echo "  - Each build-*-controller.yaml workflow auto-bumps its own pin"
+  echo "    on push-to-main (TBD-A69 / PR #2005/#2012)."
+  echo
+  echo "Manual fix: edit ${VALUES_YAML} to set the stale tag(s) to the"
+  echo "value(s) shown above (or kick the catalyst-build workflow:"
+  echo "  gh workflow run 'catalyst-build.yaml' --ref main"
+  echo "which will perform the sweep + open the deploy commit)."
+  exit 1
+fi
+
+echo "PASS: every controller image pin is within ${MAX_LAG_COMMITS} commits of latest GHCR."


### PR DESCRIPTION
## Summary

Closes the **controller-image-pin drift hazard** that caused the H9-walk on 2026-06-03 to catch 4 of 5 controllers pinned to `8d01e2f` (G93.2-era, pre-G117.6) for weeks — same root class as the PIN-login outage today, where chart shipped `catalystApi.tag=2ae493f` (a binary BEFORE PR #2854's env rename).

The bug: per-controller auto-bump steps exist (TBD-A69 / PRs #2005 #2012) but silently dropped on race, dispatch-skip, or Chart.yaml masking. Result: chart shipped binaries missing recent features (G117.6 topology fan-out, G117.2 multi-instance fields).

## Three-layer defense

1. **catalyst-build.yaml `#2851` sweep step** (new) — every catalyst-build deploy run resolves the latest pushed 7-hex SHA from GHCR for each of the 5 controllers and stamps it into `controllers.<key>.image.tag` in `products/catalyst/chart/values.yaml`. Belt-and-braces re-sync on every catalyst rebuild.
2. **Per-controller `build-*-controller.yaml` auto-bumps** — existing TBD-A69 path stays in place as the proactive trigger.
3. **`check-controller-image-tag-freshness.yaml` + `scripts/check-controller-image-tag-freshness.sh`** (new) — pre-merge guard that fails any PR (or post-merge audit) when a controller pin is more than 50 commits behind the latest GHCR push.

## Files touched

- `.github/workflows/catalyst-build.yaml` — adds `#2851 — Sweep controller image tags from latest GHCR pushes` step before the deploy-bump commit; updates commit message to mention the sweep.
- `.github/workflows/check-controller-image-tag-freshness.yaml` (new) — PR + push-on-main + workflow_dispatch.
- `scripts/check-controller-image-tag-freshness.sh` (new) — same GHCR-API pattern as `scripts/check-bootstrap-kit-pin-sync.sh:332`; same fail-loudly shape as `scripts/check-controller-workflow-uniformity.sh`.
- `products/catalyst/chart/values.yaml` — comment refresh (4 of 5 controller blocks had outdated "CI auto-image-bump workflow covers catalystApi/catalystUi only" notes).

## Concrete evidence motivating this fix

- **H9-walk 2026-06-03** (issue body) — `application/blueprint/environment/useraccess` all pinned to `8d01e2f`, organization at `7ff7ea8`. Manually bumped in PR #2852.
- **PIN-login outage today** — chart shipped `catalystApi.tag=2ae493f`, a binary BEFORE PR #2854's env rename. PR #2865 patched the symptom (manual `ff778a36` bump) but the STRUCTURAL gap was the same drift class.

## Test plan

- [ ] Merge this PR; observe the next `catalyst-build` run on main — the `#2851 — Sweep controller image tags from latest GHCR pushes` step should fire and log `OK: controllers.<key>.image.tag already at <sha>` for all 5 controllers (no bumps needed because PR #2852 already brought them current).
- [ ] On a subsequent push that updates only one controller, verify the catalyst-build sweep picks up the bumped controller's new SHA and rolls the chart even though the catalyst-build was triggered by an unrelated UI change.
- [ ] Manually revert one controller pin in values.yaml to a pre-G117 SHA in a draft PR; confirm `check-controller-image-tag-freshness.yaml` fails the PR with a clear `pinned X is N commits behind latest GHCR Y` error.

## Notes

- Uses `Refs` not `Closes` per CLAUDE.md anti-pattern catalog — the operator walk on the next chart bump is needed to verify the CI fix actually triggers end-to-end.
- No non-catalyst image tags bumped; no founder credential changes.

Refs #2851 #2852 #2854 #2865

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>