### PR TITLE
fix(catalyst-platform): catalyst-api/ui image tag — 7-char short SHA (GHCR push format)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -945,7 +945,7 @@ spec:
       # so catalyst-api's CountSovereignRegions can read
       # Sovereign.spec.regions (was returning 0 because the CRD wasn't
       # installed — H7 walk of #2742 evidence). Refs #2856 #2742 #2737.
-      version: 1.4.451
+      version: 1.4.452
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2523,7 +2523,7 @@ name: bp-catalyst-platform
 # deploymentId is immutable post-create via CEL
 # x-kubernetes-validations rule (matches Application.spec.instanceId
 # pattern from #2742 W2.C2). Refs #2856 #2742 #2737.
-version: 1.4.451
+version: 1.4.452
 appVersion: 1.4.349
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -294,9 +294,9 @@ images:
     # new chart emits only the new name, so handoverSigner never
     # initialises and /api/v1/auth/pin/issue returns 503 "handover
     # signer unavailable". ff778a36 reads both names with fallback.
-    tag: "ff778a36"
+    tag: "ff778a3"
   catalystUi:
-    tag: "ff778a36"
+    tag: "ff778a3"
   marketplaceApi:
     tag: "3c2f7e4"
   console:


### PR DESCRIPTION
Hotfix to PR #2865 — used 8-char merge SHA but GHCR images are tagged with 7-char short SHA. ImagePullBackOff broke PIN login again. Refs #2737 #2865

🤖 Generated with [Claude Code](https://claude.com/claude-code)