### PR TITLE
fix(cloud-init): #2842 — provision harbor.openova.io robot token into registries.yaml

### DIFF
--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -92,6 +92,25 @@ write_files:
         "212.72.24.20:5002":
           tls:
             insecure_skip_verify: true
+        # #2842 (2026-06-03) — STRUCTURAL fix for "401 on every uncached pull".
+        # G3 RCA: every hw86 node's /var/lib/rancher/k3s/agent/etc/containerd/
+        # certs.d/<host>/hosts.toml mirrors 7 public registries through
+        # https://harbor.openova.io/v2/proxy-<host>, BUT containerd had no
+        # credentials for harbor.openova.io → 401 on every uncached pull →
+        # containerd stale-ingest-lock loop (live evidence on wea28e1: 3
+        # ingest dirs locked 18+ min, catalyst-api Pod ContainerCreating 25+
+        # min, ~451MB orphan blobs). PR #2845 removed mis-aimed mirrors
+        # (ghcr.io via :5003 etc.) as containment; THIS block is the defense:
+        # provision the harbor robot credentials so any path that resolves to
+        # harbor.openova.io (k3s-injected hosts.toml, direct image ref, or
+        # an upstream chart that hardcodes harbor.openova.io/proxy-*)
+        # authenticates successfully against the upstream Harbor proxy-cache
+        # projects. Same pattern as hetzner/cloudinit-control-plane.tftpl
+        # lines 392-396 (issue #557 Step 2).
+        "harbor.openova.io":
+          auth:
+            username: "robot$openova-bot"
+            password: "${harbor_robot_token}"
 
   # ── Sovereign metadata file (parsed by phase1 watchers) ───────────────
   - path: /var/lib/catalyst/sovereign.json

--- a/infra/providers/huawei/cloudinit-worker.tftpl
+++ b/infra/providers/huawei/cloudinit-worker.tftpl
@@ -69,6 +69,19 @@ write_files:
         "212.72.24.20:5002":
           tls:
             insecure_skip_verify: true
+        # #2842 (2026-06-03) — STRUCTURAL fix for "401 on every uncached pull".
+        # Mirrors cloudinit-control-plane.tftpl. G3 RCA: every hw86 node has
+        # /var/lib/rancher/k3s/agent/etc/containerd/certs.d/<host>/hosts.toml
+        # mirroring 7 public registries through https://harbor.openova.io,
+        # but containerd had no creds → 401 → stale-ingest-lock loop. Defense:
+        # seed harbor robot credentials so direct-to-harbor.openova.io paths
+        # (chart-injected image refs, k3s hosts.toml, autoscaler-spawned
+        # workers) authenticate. Same pattern as hetzner/cloudinit-control-
+        # plane.tftpl lines 392-396.
+        "harbor.openova.io":
+          auth:
+            username: "robot$openova-bot"
+            password: "${harbor_robot_token}"
 
   - path: /etc/sysctl.d/99-catalyst-inotify.conf
     permissions: '0644'

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -568,6 +568,12 @@ locals {
       # all collapse to single-region. Huawei CCM doesn't stamp
       # standard topology labels by default; cloudinit fills the gap.
       region = r.code
+      # #2842 (2026-06-03): harbor robot token for the registries.yaml
+      # `configs.harbor.openova.io.auth` block — without this, every
+      # uncached pull of an upstream image referencing harbor.openova.io
+      # 401s and containerd loops on stale-ingest-locks. Mirrors the CP
+      # template binding (line 788).
+      harbor_robot_token = var.harbor_robot_token
     }), "/(?m)^[ ]*#( |$).*\n/", "")
   }
 


### PR DESCRIPTION
## Summary

Structural defense for the harbor.openova.io mirror 401 / containerd
stale-ingest-lock cascade caught live on hw86 (wea28e1) during the G3
walk.

- Add `configs."harbor.openova.io".auth` block (username
  `robot$openova-bot` + `${harbor_robot_token}`) to
  `infra/providers/huawei/cloudinit-control-plane.tftpl` and
  `infra/providers/huawei/cloudinit-worker.tftpl`. Mirrors the existing
  Hetzner pattern (`infra/providers/hetzner/cloudinit-control-plane.tftpl`
  lines 392-396).
- Wire `harbor_robot_token = var.harbor_robot_token` into the
  Huawei worker template binding (`local.worker_cloud_init_by_region`,
  `infra/providers/huawei/main.tf` line ~570). The control-plane binding
  already carried it (line 788).

## RCA (from issue #2842 + G3 walk)

Every hw86 node has
`/var/lib/rancher/k3s/agent/etc/containerd/certs.d/<host>/hosts.toml`
configured to mirror 7 public registries (ghcr.io, docker.io,
registry.k8s.io, gcr.io, quay.io, xpkg.upbound.io, public.ecr.aws)
through `https://harbor.openova.io/v2/proxy-<host>`. But
`/etc/rancher/k3s/registries.yaml` carries no `auth:` block for
`harbor.openova.io` → containerd 401s on every uncached pull →
stale-ingest-lock loops.

Live evidence on wea28e1:
- 3 ingest dirs locked 18+ min (sha 38880fa2 / f3930125 / 26e791ed)
- ~451MB orphan blobs
- catalyst-api Pod ContainerCreating 25+ min pulling
  `ghcr.io/openova-io/openova/catalyst-api:<sha>`
- PVCs are local-path RWO node-pinned, so Pods cannot migrate

PR #2845 removed mis-aimed bastion-proxy mirror entries (:5003
ghcr-proxy / :5004 kyverno-proxy / :5005 quay-proxy) as containment.
THIS PR ships the structural defense so even where charts / k3s /
upstream image refs resolve to `harbor.openova.io` directly,
containerd carries the robot credentials.

## Why no upstream caller change

`provisioner.go:2204` already passes
`"harbor_robot_token": req.HarborRobotToken` into
`tofu.auto.tfvars.json`, and `var.harbor_robot_token` is already
declared in both `huawei/variables.tf:286` and
`hetzner/variables.tf:843`. The wiring was complete to the CP template
only — this PR extends it to the worker template too.

## Test plan

- [ ] `tofu validate` clean on both `infra/providers/huawei/` and
      `infra/providers/hetzner/`
- [ ] Fresh Huawei Sovereign prov → SSH to any worker node → `cat
      /etc/rancher/k3s/registries.yaml` shows non-empty `auth:` block
      for `harbor.openova.io`
- [ ] Pull a fresh image from `harbor.openova.io/proxy-ghcr/…` on a
      worker — succeeds without 401, no stale-ingest-lock left behind
- [ ] catalyst-api Pod becomes Ready within 5 minutes on a clean node

Refs #2842 #2845 #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)