### PR TITLE
feat(precheck): #2864 — cert-manager-precheck auto-PASS hostnames under wildcard Certificate

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/newapi"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/powerdns"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/precheck"
 	// Side-effect import: registers every CloudProvider adapter
 	// (hetzner + huawei stub) against internal/providers/registry
 	// at init() time. Wave 2 — the registrations are passive; no
@@ -427,11 +428,19 @@ func main() {
 	// SOVEREIGN_REGIONS env when the dynamic client is unwired or the
 	// Sovereign CRD is absent (chroot dev surface).
 	var regionsCounter func(ctx context.Context) (int, error)
+	var certLookup precheck.CertConflictLookup
 	if dynCfg, derr := rest.InClusterConfig(); derr == nil {
 		if dynClient, dcerr := dynamic.NewForConfig(dynCfg); dcerr == nil {
 			regionsCounter = func(ctx context.Context) (int, error) {
 				return handler.CountSovereignRegions(ctx, dynClient)
 			}
+			// G117 #2864 (Gap 6) — wire the production cert-manager
+			// Certificate lookup so cert-manager-precheck auto-PASSes
+			// hostnames under the Sovereign's `*.<sov-fqdn>` wildcard
+			// Certificate. Without this wire the precheck returns
+			// `lookup-unavailable` (503) and every endpoint mutation
+			// fails on a live Sovereign.
+			certLookup = handler.NewProductionCertConflictLookup(dynClient)
 		}
 	}
 	// Production WriterFactory closure — routes through the per-Handler
@@ -449,11 +458,13 @@ func main() {
 		WriterFactory:  writerFactory,
 		SovereignFQDN:  env("SOVEREIGN_FQDN", ""),
 		RegionsCounter: regionsCounter,
+		CertLookup:     certLookup,
 	})
 	log.Info("g117.3: endpoint precheck deps wired",
 		"sovereignFQDN", env("SOVEREIGN_FQDN", ""),
 		"writerFactory", "Handler.NewProductionGiteaIaCWriter (per-Org openbao token, env fallback)",
 		"regionsCounter", regionsCounter != nil,
+		"certLookup", certLookup != nil,
 	)
 
 	// EPIC-3 #1098 slice U8 — RBAC audit Bus. Owns:

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
@@ -1472,3 +1472,142 @@ func (n *noopStatusChecker) GetStatuses(_ context.Context, _, _, _ string) (map[
 
 // _ = silence unused-import linter when build tags vary.
 var _ = schema.GroupVersionResource{}
+
+// ── Production CertConflictLookup (G117 #2864 Gap 6) ────────────────
+
+// NewProductionCertConflictLookup returns a precheck.CertConflictLookup
+// that walks every cert-manager.io/v1 Certificate in the cluster and
+// matches by spec.commonName + spec.dnsNames[]. When the covering
+// Certificate uses a wildcard pattern (e.g. `*.<sov-fqdn>`) the
+// returned CertOwner sets IsWildcard=true + WildcardDomain to the
+// base domain so CheckCertManager can auto-PASS new hostnames under
+// the wildcard's scope (per G117 #2864 / Gap 6 of #2856).
+//
+// Owner labels are sourced from the Certificate's
+// `catalyst.openova.io/organization` + `catalyst.openova.io/app`
+// labels. The Sovereign-Gateway's wildcard Certificate typically
+// carries no per-Application owner labels — in that case we surface
+// (`sovereign`, `gateway`) as a deterministic placeholder so the
+// auto-PASS-by-wildcard branch fires cleanly without leaking
+// namespace/name internals into the verdict.
+//
+// Lookup precedence:
+//
+//  1. Exact match on spec.commonName (or any spec.dnsNames[] entry) —
+//     returns the owner of THAT Certificate directly. IsWildcard
+//     reflects whether the matched entry began with `*.`.
+//  2. Wildcard match: any Certificate whose commonName/dnsNames
+//     contains a `*.<base>` pattern that covers `hostname` (one
+//     label of depth, exact base-domain suffix). Returns the owner
+//     of the wildcard Certificate with IsWildcard=true +
+//     WildcardDomain=<base>.
+//  3. No match — (CertOwner{}, false, nil).
+//
+// Transport errors from the apiserver propagate as the err return so
+// CheckCertManager surfaces `lookup-failed` (HTTP 503-class). A
+// missing cert-manager CRD (chroot dev surface) returns
+// (CertOwner{}, false, nil) — no Certificates means no conflict.
+func NewProductionCertConflictLookup(dynClient dynamic.Interface) precheck.CertConflictLookup {
+	return func(ctx context.Context, hostname string) (precheck.CertOwner, bool, error) {
+		if dynClient == nil {
+			return precheck.CertOwner{}, false, errors.New("cert-manager lookup: dynamic client nil")
+		}
+		hostname = strings.ToLower(strings.TrimSpace(hostname))
+		if hostname == "" {
+			return precheck.CertOwner{}, false, nil
+		}
+		list, err := dynClient.Resource(certificateGVR).Namespace("").List(ctx, metav1.ListOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return precheck.CertOwner{}, false, nil
+			}
+			return precheck.CertOwner{}, false, fmt.Errorf("cert-manager lookup: list certificates: %w", err)
+		}
+		var wildcardHit *precheck.CertOwner
+		for i := range list.Items {
+			c := &list.Items[i]
+			cn, _, _ := unstructured.NestedString(c.Object, "spec", "commonName")
+			dnsNames, _, _ := unstructured.NestedStringSlice(c.Object, "spec", "dnsNames")
+			candidates := make([]string, 0, len(dnsNames)+1)
+			if cn != "" {
+				candidates = append(candidates, cn)
+			}
+			candidates = append(candidates, dnsNames...)
+			owner := certOwnerFromObject(c)
+			for _, name := range candidates {
+				name = strings.ToLower(strings.TrimSpace(name))
+				if name == "" {
+					continue
+				}
+				// Exact match short-circuits regardless of wildcard.
+				if name == hostname {
+					o := owner
+					o.IsWildcard = strings.HasPrefix(name, "*.")
+					if o.IsWildcard {
+						o.WildcardDomain = strings.TrimPrefix(name, "*.")
+					}
+					return o, true, nil
+				}
+				// Wildcard candidate? Stash the first hit; an exact
+				// match later in the scan still wins (continues loop).
+				if strings.HasPrefix(name, "*.") {
+					base := strings.TrimPrefix(name, "*.")
+					if wildcardCovers(hostname, base) && wildcardHit == nil {
+						o := owner
+						o.IsWildcard = true
+						o.WildcardDomain = base
+						wildcardHit = &o
+					}
+				}
+			}
+		}
+		if wildcardHit != nil {
+			return *wildcardHit, true, nil
+		}
+		return precheck.CertOwner{}, false, nil
+	}
+}
+
+// certOwnerFromObject lifts (Org, App) from the Certificate's
+// canonical catalyst.openova.io labels. Sovereign-Gateway wildcard
+// certs typically carry no per-Application labels — we surface
+// (`sovereign`, `gateway`) as a deterministic placeholder so the
+// CheckCertManager auto-PASS-by-wildcard branch (G117 #2864) fires
+// without leaking namespace/name into the verdict.
+func certOwnerFromObject(c *unstructured.Unstructured) precheck.CertOwner {
+	labels := c.GetLabels()
+	org := ""
+	app := ""
+	if labels != nil {
+		org = strings.TrimSpace(labels["catalyst.openova.io/organization"])
+		app = strings.TrimSpace(labels["catalyst.openova.io/app"])
+	}
+	if org == "" {
+		org = "sovereign"
+	}
+	if app == "" {
+		app = "gateway"
+	}
+	return precheck.CertOwner{Org: org, App: app}
+}
+
+// wildcardCovers mirrors the precheck-package wildcard-scope rule
+// (TLS spec: `*.<base>` covers ONE label of depth, not the apex). We
+// inline it here so the production lookup is self-contained and the
+// precheck package's helper stays unexported.
+func wildcardCovers(hostname, base string) bool {
+	hostname = strings.ToLower(strings.TrimSpace(hostname))
+	base = strings.ToLower(strings.TrimSpace(base))
+	if hostname == "" || base == "" {
+		return false
+	}
+	suffix := "." + base
+	if !strings.HasSuffix(hostname, suffix) {
+		return false
+	}
+	prefix := strings.TrimSuffix(hostname, suffix)
+	if prefix == "" || strings.Contains(prefix, ".") {
+		return false
+	}
+	return true
+}

--- a/products/catalyst/bootstrap/api/internal/precheck/precheck.go
+++ b/products/catalyst/bootstrap/api/internal/precheck/precheck.go
@@ -124,17 +124,41 @@ func (b Bundle) FailedStages() []string {
 // existing owner must match; otherwise the cert would be silently
 // reassigned and the previous owner's traffic would 502.
 //
+// G117 #2864 (Gap 6): When the Sovereign's Gateway carries a wildcard
+// Certificate (e.g. `*.<sov-fqdn>`) every new endpoint hostname under
+// that wildcard would otherwise be rejected as a cert-conflict because
+// the wildcard cert's owner labels (= Gateway / Sovereign infra) do
+// NOT match the per-Application endpoint mutation. Lookups MUST set
+// `IsWildcard=true` + `WildcardDomain=<base-domain>` when they find a
+// wildcard Certificate so CheckCertManager can auto-PASS new
+// hostnames under that wildcard.
+//
 // Returns:
 //   - (owner, true, nil)  — an existing Certificate covers `hostname`
-//     owned by `<org>/<app>` (in our own label vocabulary)
+//     owned by `<org>/<app>` (in our own label vocabulary). When the
+//     covering Certificate is a wildcard, owner.IsWildcard=true and
+//     owner.WildcardDomain is the base domain (e.g. "hw86.omani.works"
+//     for a `*.hw86.omani.works` cert).
 //   - ("", false, nil)    — no existing Certificate
 //   - ("", false, err)    — lookup failed; the caller treats as 503
 type CertConflictLookup func(ctx context.Context, hostname string) (owner CertOwner, exists bool, err error)
 
 // CertOwner labels a Certificate's owning Application.
+//
+// IsWildcard / WildcardDomain populated when the covering Certificate
+// is a wildcard (e.g. `*.<sov-fqdn>`). See CertConflictLookup +
+// CheckCertManager for the auto-PASS semantics this enables.
 type CertOwner struct {
 	Org string
 	App string
+	// IsWildcard is true when the discovered Certificate's spec.commonName
+	// (or any entry in spec.dnsNames[]) begins with `*.`. G117 #2864.
+	IsWildcard bool
+	// WildcardDomain is the base domain of the wildcard Certificate —
+	// the suffix after `*.`. Empty when IsWildcard=false. Example:
+	// for a Certificate covering `*.hw86.omani.works`, WildcardDomain
+	// is `hw86.omani.works`. G117 #2864.
+	WildcardDomain string
 }
 
 // DNSConflictLookup answers: is this hostname already pinned to a
@@ -197,11 +221,13 @@ func ValidateMutation(m Mutation) error {
 //
 // Pass when: no existing Certificate covers the hostname, OR an
 // existing Certificate already belongs to the same Application
-// (re-issue / update case is benign).
+// (re-issue / update case is benign), OR the existing Certificate is
+// a wildcard (`*.<base-domain>`) and the new hostname falls under
+// that base domain (G117 #2864 — Gap 6 of #2856).
 //
-// Fail when: an existing Certificate belongs to a different
-// Application — issuing a duplicate would steal the cert from the
-// existing owner.
+// Fail when: an existing non-wildcard Certificate belongs to a
+// different Application — issuing a duplicate would steal the cert
+// from the existing owner.
 //
 // 503 ("lookup-unavailable") when the wired lookup function errors.
 // The caller-side handler converts this into a precheck-pending state
@@ -236,12 +262,52 @@ func CheckCertManager(ctx context.Context, m Mutation, lookup CertConflictLookup
 	if strings.EqualFold(owner.Org, m.Org) && strings.EqualFold(owner.App, m.App) {
 		return Result{Stage: stage, Pass: true, Code: "same-owner"}
 	}
+	// G117 #2864 (Gap 6): wildcard Certificate coverage auto-PASS.
+	// When the Gateway's wildcard cert (`*.<sov-fqdn>`) already covers
+	// the new endpoint hostname, the per-Application owner-mismatch is
+	// benign — the new endpoint will reuse the wildcard cert via the
+	// Gateway and no per-Application Certificate is required.
+	if owner.IsWildcard && hostnameUnderWildcard(m.Hostname, owner.WildcardDomain) {
+		return Result{
+			Stage:   stage,
+			Pass:    true,
+			Code:    "covered-by-wildcard",
+			Message: fmt.Sprintf("hostname %q is covered by wildcard Certificate for %q", m.Hostname, "*."+owner.WildcardDomain),
+		}
+	}
 	return Result{
 		Stage:   stage,
 		Pass:    false,
 		Code:    "cert-conflict",
 		Message: fmt.Sprintf("hostname %q already has a Certificate owned by %s/%s", m.Hostname, owner.Org, owner.App),
 	}
+}
+
+// hostnameUnderWildcard reports whether `hostname` is covered by a
+// wildcard Certificate whose base domain is `base` (the suffix after
+// `*.`).
+//
+// Wildcards in cert-manager / TLS spec terms cover EXACTLY ONE label
+// of hostname depth — `*.example.com` covers `foo.example.com` but
+// NOT `foo.bar.example.com` and NOT `example.com` itself. We mirror
+// that constraint here so the precheck doesn't over-broadly approve.
+func hostnameUnderWildcard(hostname, base string) bool {
+	hostname = strings.ToLower(strings.TrimSpace(hostname))
+	base = strings.ToLower(strings.TrimSpace(base))
+	if hostname == "" || base == "" {
+		return false
+	}
+	suffix := "." + base
+	if !strings.HasSuffix(hostname, suffix) {
+		return false
+	}
+	// Strip the matching suffix and assert the remainder is exactly
+	// one DNS label (no further dots).
+	prefix := strings.TrimSuffix(hostname, suffix)
+	if prefix == "" || strings.Contains(prefix, ".") {
+		return false
+	}
+	return true
 }
 
 // CheckDNSConflict runs the dns-conflict-precheck stage.

--- a/products/catalyst/bootstrap/api/internal/precheck/precheck_test.go
+++ b/products/catalyst/bootstrap/api/internal/precheck/precheck_test.go
@@ -107,6 +107,105 @@ func TestCheckCertManager_DifferentOwner(t *testing.T) {
 	}
 }
 
+// TestCheckCertManager_HostnameUnderWildcardPasses — G117 #2864 Gap 6.
+// When the Sovereign's Gateway wildcard Certificate `*.<sov-fqdn>`
+// already covers the new endpoint hostname, the per-Application
+// owner-mismatch must be auto-PASSed with code `covered-by-wildcard`.
+func TestCheckCertManager_HostnameUnderWildcardPasses(t *testing.T) {
+	res := CheckCertManager(context.Background(),
+		Mutation{Op: OpCreate, Org: "acme", App: "wp", Name: "ui", Hostname: "grafana.hw86.omani.works"},
+		func(_ context.Context, _ string) (CertOwner, bool, error) {
+			return CertOwner{
+				Org:            "sovereign",
+				App:            "gateway",
+				IsWildcard:     true,
+				WildcardDomain: "hw86.omani.works",
+			}, true, nil
+		},
+	)
+	if !res.Pass {
+		t.Fatalf("hostname under wildcard should pass; got %+v", res)
+	}
+	if res.Code != "covered-by-wildcard" {
+		t.Fatalf("expected covered-by-wildcard; got %s", res.Code)
+	}
+	if !strings.Contains(res.Message, "grafana.hw86.omani.works") {
+		t.Fatalf("message should mention the hostname; got %q", res.Message)
+	}
+	if !strings.Contains(res.Message, "*.hw86.omani.works") {
+		t.Fatalf("message should mention the wildcard pattern; got %q", res.Message)
+	}
+}
+
+// TestCheckCertManager_HostnameOutsideWildcardFails — wildcard
+// coverage must NOT over-broadly approve hostnames that fall outside
+// the wildcard's exact one-label scope (spec: `*.example.com` covers
+// `foo.example.com` but NOT `foo.bar.example.com` and NOT
+// `example.com` itself). When the new hostname is outside the
+// wildcard's scope AND the owner mismatches, the precheck must FAIL
+// with `cert-conflict`.
+func TestCheckCertManager_HostnameOutsideWildcardFails(t *testing.T) {
+	cases := []struct {
+		name     string
+		hostname string
+		// All cases use the same wildcard cert + a mismatched owner so
+		// the test isolates the wildcard-scoping logic. Different
+		// hostnames probe different scope-violation modes.
+	}{
+		{"two-level-subdomain", "deep.grafana.hw86.omani.works"}, // *.hw86.omani.works covers ONE label only
+		{"unrelated-domain", "grafana.t99.omani.trade"},          // entirely different base
+		{"bare-base-domain", "hw86.omani.works"},                 // wildcards do NOT cover the apex
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res := CheckCertManager(context.Background(),
+				Mutation{Op: OpCreate, Org: "acme", App: "wp", Name: "ui", Hostname: c.hostname},
+				func(_ context.Context, _ string) (CertOwner, bool, error) {
+					return CertOwner{
+						Org:            "sovereign",
+						App:            "gateway",
+						IsWildcard:     true,
+						WildcardDomain: "hw86.omani.works",
+					}, true, nil
+				},
+			)
+			if res.Pass {
+				t.Fatalf("hostname outside wildcard should fail; got %+v", res)
+			}
+			if res.Code != "cert-conflict" {
+				t.Fatalf("expected cert-conflict; got %s", res.Code)
+			}
+		})
+	}
+}
+
+// TestCheckCertManager_NonWildcardSameOwnerUnchanged — regression
+// guard: the existing same-owner short-circuit path must continue to
+// short-circuit BEFORE the wildcard check. Same Org/App + same Name
+// should still PASS with `same-owner` (NOT `covered-by-wildcard`)
+// even when a wildcard cert exists alongside it.
+func TestCheckCertManager_NonWildcardSameOwnerUnchanged(t *testing.T) {
+	res := CheckCertManager(context.Background(),
+		Mutation{Op: OpUpdate, Org: "acme", App: "wp", Name: "ui", Hostname: "x.example.com"},
+		func(_ context.Context, _ string) (CertOwner, bool, error) {
+			// Owner matches — the same-owner branch wins regardless of
+			// any IsWildcard hint the lookup happens to emit.
+			return CertOwner{
+				Org:            "acme",
+				App:            "wp",
+				IsWildcard:     true,
+				WildcardDomain: "example.com",
+			}, true, nil
+		},
+	)
+	if !res.Pass {
+		t.Fatalf("same owner should pass; got %+v", res)
+	}
+	if res.Code != "same-owner" {
+		t.Fatalf("expected same-owner (short-circuit before wildcard branch); got %s", res.Code)
+	}
+}
+
 func TestCheckCertManager_LookupError(t *testing.T) {
 	res := CheckCertManager(context.Background(),
 		Mutation{Op: OpCreate, Org: "acme", App: "wp", Name: "ui", Hostname: "x.example.com"},


### PR DESCRIPTION
Refs #2864 #2856 #2742

## Summary

H7 walk of #2742 endpoints CRUD found Gap 6 of #2856: `cert-manager-precheck` rejects every endpoint hostname under `*.<sov-fqdn>` because the Gateway's wildcard Certificate already "owns" the cert under different App labels. This PR extends the precheck to detect wildcard coverage and auto-PASS hostnames that fall within the wildcard's scope.

- `precheck.CertOwner` gains `IsWildcard bool` + `WildcardDomain string` so lookups can signal a wildcard Certificate.
- `precheck.CheckCertManager` adds a new auto-PASS branch returning code `covered-by-wildcard` when a wildcard Certificate covers the new hostname. Enforces the TLS one-label scope rule (apex + multi-label depth are NOT covered).
- `handler.NewProductionCertConflictLookup` walks cert-manager.io/v1 Certificates cluster-wide via the dynamic client, matches on `spec.commonName` + `spec.dnsNames[]`, and prefers exact matches over wildcard hits.
- `cmd/api/main.go` wires the new production lookup into `EndpointPrecheckDeps.CertLookup` (was previously unwired → every mutation hit `lookup-unavailable` 503 on a live Sovereign).

## Tests

3 new unit tests added per brief — full suite green:

```
=== RUN   TestCheckCertManager_HostnameUnderWildcardPasses
--- PASS: TestCheckCertManager_HostnameUnderWildcardPasses (0.00s)
=== RUN   TestCheckCertManager_HostnameOutsideWildcardFails
=== RUN   TestCheckCertManager_HostnameOutsideWildcardFails/two-level-subdomain
=== RUN   TestCheckCertManager_HostnameOutsideWildcardFails/unrelated-domain
=== RUN   TestCheckCertManager_HostnameOutsideWildcardFails/bare-base-domain
--- PASS: TestCheckCertManager_HostnameOutsideWildcardFails (0.00s)
    --- PASS: TestCheckCertManager_HostnameOutsideWildcardFails/two-level-subdomain (0.00s)
    --- PASS: TestCheckCertManager_HostnameOutsideWildcardFails/unrelated-domain (0.00s)
    --- PASS: TestCheckCertManager_HostnameOutsideWildcardFails/bare-base-domain (0.00s)
=== RUN   TestCheckCertManager_NonWildcardSameOwnerUnchanged
--- PASS: TestCheckCertManager_NonWildcardSameOwnerUnchanged (0.00s)
PASS
ok      github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/precheck 0.029s
ok      github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler  60.738s
```

`go vet` + `go build ./...` clean across `internal/precheck/...`, `internal/handler/...`, and `cmd/api/...`.

## Test plan

- [ ] Founder walk #2742 on a live Sovereign — POST `/catalyst/v1/apps/<uid>/endpoints {hostname: "walk-2742-test.hw86.omani.works", ...}` now returns 202 (not 422 `precheck-rejected`) with `certManager: "covered-by-wildcard"` in the response body.
- [ ] Regression: posting an endpoint that DOES conflict with a non-wildcard Certificate of a different App still returns 422 `cert-conflict`.