### PR TITLE
fix(bp-sandbox): visibility marketplace → listed (unblock catalyst-ui builds)

### DIFF
--- a/platform/sandbox/blueprint.yaml
+++ b/platform/sandbox/blueprint.yaml
@@ -29,7 +29,7 @@ spec:
   # slot 19a on every Sovereign; the marketplace card represents the
   # per-User instantiation flow (Sandbox CR creation), not a fresh
   # Helm install.
-  visibility: marketplace
+  visibility: listed
   owner:
     team: platform
     contact: catalyst@openova.io


### PR DESCRIPTION
PR #2850 shipped visibility=marketplace but TS BlueprintVisibility enum only allows listed|unlisted|private. Every catalyst-build since has failed at TS compile → no new catalyst-ui images for 1h+ → hw86 SPA frozen on 2ae493f without Launch button + multi-instance UI. Founder caught 5 UI bugs all traced to this.

Refs #2850 #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)