### PR TITLE
fix(catalyst-ui): #2873-followup — unblock catalyst-build CI

### DIFF
--- a/products/catalyst/bootstrap/ui/src/components/PinInput6.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/PinInput6.test.tsx
@@ -28,20 +28,19 @@ function getBoxes(): HTMLInputElement[] {
 }
 
 describe('PinInput6 — typing', () => {
-  it('renders 6 inputs with inputmode="numeric" and maxlength=1', () => {
+  it('renders 6 decorative boxes + 1 overlay input with inputmode="numeric" and maxlength=6', () => {
     render(<PinInput6 />)
     const boxes = getBoxes()
     expect(boxes).toHaveLength(6)
-    for (const b of boxes) {
-      expect(b.getAttribute('inputmode')).toBe('numeric')
-      expect(b.getAttribute('maxlength')).toBe('1')
-    }
+    const input = screen.getByTestId('pin-box-input') as HTMLInputElement
+    expect(input.getAttribute('inputmode')).toBe('numeric')
+    expect(input.getAttribute('maxlength')).toBe('6')
   })
 
-  it('auto-focuses the first box on mount', () => {
+  it('auto-focuses the overlay input on mount', () => {
     render(<PinInput6 />)
-    const boxes = getBoxes()
-    expect(document.activeElement).toBe(boxes[0])
+    const input = screen.getByTestId('pin-box-input') as HTMLInputElement
+    expect(document.activeElement).toBe(input)
   })
 
   it('typing a digit advances focus to the next box', () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
@@ -733,7 +733,7 @@ interface AppCardProps {
   externalURL?: string
 }
 
-function AppCard({ app, status, isService, environment, marketplacePublished, slug, onPublishedChange, externalURL }: AppCardProps) {
+function AppCard({ app, status, isService, environment, marketplacePublished, slug, onPublishedChange }: AppCardProps) {
   const stateClass = `state-${status}`
   // Chroot-aware target: on the mother monitor surface
   // (console.openova.io/sovereign/provision/<id>/...) every link MUST stay


### PR DESCRIPTION
## Summary

#2873 merge (a0af1a61) broke catalyst-build CI with TS6133 — the per-card "Open" button removal left an unused destructured `externalURL` local in `AppCard`. Build never produced the new catalyst-ui image SHA, so the chart pin never bumped, so the silent-SSO fix is still NOT deployed to hw86 (still on 4101fd5).

This PR is the trivial unblock:

1. **`AppsPage.tsx:736`** — drop `externalURL` from `AppCard` destructure (no longer read after Open button removal). Caller still passes it; `AppCardProps` still declares it for forward-compat.
2. **`PinInput6.test.tsx:31-45`** — two tests asserted against `pin-box-{i}` divs as if they were inputs. PinInput6 was refactored to single-overlay-input + 6 decorative divs on 2026-05-04 (#737) and these two tests were never updated. They were producing hard ##[error] lines in the build log that masked the real TS failure. Updated to assert against the actual `pin-box-input` overlay. The remaining 15 stale tests in the same file are pre-existing CI rot and stay soft-gated by `npm test || echo WARN` in `catalyst-build.yaml`.

## Test plan

- [x] `npx tsc --noEmit` → clean
- [x] `npx vitest run -t "renders 6 decorative"` → passes
- [x] `npx vitest run -t "auto-focuses the overlay"` → passes
- [ ] CI build catalyst-ui produces new SHA for hw86 deploy
- [ ] Auto-deploy commit updates `products/catalyst/chart/values.yaml` `catalystUi.tag`
- [ ] Flux on hw86 reconciles new bundle → Launch silent-SSO actually fires

Refs #2873 Refs #2743

🤖 Generated with [Claude Code](https://claude.com/claude-code)