### PR TITLE
fix(bootstrap-kit): #2870-followup — drop duplicate velero Namespace decl

### DIFF
--- a/clusters/_template/bootstrap-kit/34a-bp-velero-hcs.yaml
+++ b/clusters/_template/bootstrap-kit/34a-bp-velero-hcs.yaml
@@ -41,13 +41,16 @@
 # from var.obs_*, so the valuesFrom list below is byte-identical to
 # slot 34's. Only the chart name + HelmRepository ref differ.
 
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: velero
-  labels:
-    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+# 2026-06-03: Namespace/velero was previously declared here BUT also
+# declared in slot 34 (Hetzner-Velero), causing kustomize build to fail
+# with "may not add resource with an already registered id:
+# Namespace.v1/velero" on EVERY Sovereign — froze HR pins repo-wide
+# because the bootstrap-kit Kustomization couldn't apply. The pair
+# invariant (at most ONE of slot 34 / slot 34a active at runtime, via
+# HR suspend) does NOT extend to static Namespace decls. Removed here;
+# the HR uses install.createNamespace: true so the velero namespace
+# materialises on the active provider (Hetzner uses slot 34, HCS uses
+# slot 34a) without the duplicate. Refs #2737-followup.
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -87,6 +90,7 @@ spec:
   # BackupStorageLocation reaching `Available` — a runtime-convergence
   # event that Flux observes via the BSL CR phase, not via Helm `--wait`.
   install:
+    createNamespace: true
     timeout: 15m
     disableWait: true
     remediation:


### PR DESCRIPTION
## Summary

PR #2870 (bp-velero-hcs) introduced `clusters/_template/bootstrap-kit/34a-bp-velero-hcs.yaml` with a static `Namespace/velero`. Slot 34 (`34-velero.yaml`, Hetzner) ALSO ships the same Namespace decl. The pair invariant is "at most ONE of slot 34 / slot 34a runs at runtime via HR suspend" — but the static Namespace decls were unconditionally listed in both files. Kustomize build fails for every Sovereign:

```
may not add resource with an already registered id:
Namespace.v1.[noGrp]/velero.[noNs]
```

**Blast radius**: this froze the `bootstrap-kit` Kustomization on EVERY Sovereign repo-wide. No HR pin updates flow → the silent-SSO fix from #2873 + #2874 cannot deploy to hw86 even though the auto-bump commit landed on main. The Monitor I armed on hw86's catalyst-ui image SHA caught this — image stuck on stale pins because the chart-version bump can't apply.

## Fix

Drop the Namespace from slot 34a, rely on `HelmRelease.install.createNamespace: true`. Same runtime outcome on HCS Sovereigns (slot 34a active); slot 34 keeps its Namespace decl for Hetzner Sovereigns.

## Test plan

- [x] `kubectl kustomize clusters/_template/bootstrap-kit/` builds clean locally
- [ ] After merge: hw86 `bootstrap-kit` Kustomization reaches Ready=True
- [ ] hw86 `bp-catalyst-platform` HR upgrades to chart 1.4.454 → catalyst-ui rolls to `0b79691`
- [ ] Founder PIN-walk on hw86 confirms Launch button now appends `prompt=none&kc_idp_hint=catalyst-pin`

Refs #2870 Refs #2873 Refs #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)