### PR TITLE
feat(catalyst-ui): #2741 — Catalog class drill-down React port

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/globals.css
+++ b/products/catalyst/bootstrap/ui/src/app/globals.css
@@ -401,3 +401,90 @@
     box-shadow: 0 0 24px color-mix(in srgb, var(--color-brand-500) 30%, transparent);
   }
 }
+
+/* ─── G117.2 #2741 — Catalog drill-down (CatalogDetail.tsx) ──────── */
+.catalog-drilldown {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.25rem;
+}
+.catalog-drilldown .bp-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  background: var(--color-surface-1);
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--color-surface-border);
+  border-radius: 6px;
+}
+.catalog-drilldown .bp-header h2 { margin: 0; }
+.catalog-drilldown .desc { color: var(--color-text-secondary); margin: 0.4rem 0 0; }
+.catalog-drilldown .badges { display: flex; gap: 0.4rem; flex-wrap: wrap; }
+.catalog-drilldown .badge {
+  background: var(--color-surface-2);
+  color: var(--color-text-primary);
+  padding: 0.15rem 0.5rem;
+  border-radius: 3px;
+  font-size: 0.75rem;
+}
+.catalog-drilldown .topologies ul {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+.catalog-drilldown .topologies li code,
+.catalog-drilldown table code {
+  background: var(--color-surface-2);
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+}
+.catalog-drilldown .instances-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.catalog-drilldown .btn-new {
+  display: inline-block;
+  padding: 0.45rem 0.9rem;
+  background: var(--color-brand-500);
+  color: white;
+  border-radius: 4px;
+  text-decoration: none;
+  font-size: 0.85rem;
+}
+.catalog-drilldown .btn-new:hover { filter: brightness(1.1); }
+.catalog-drilldown .hint {
+  color: var(--color-text-secondary);
+  font-style: italic;
+  font-size: 0.85rem;
+}
+.catalog-drilldown table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.5rem;
+  background: var(--color-surface-1);
+}
+.catalog-drilldown th,
+.catalog-drilldown td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--color-surface-border);
+  text-align: left;
+  font-size: 0.9rem;
+}
+.catalog-drilldown .status {
+  font-size: 0.75rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+}
+.catalog-drilldown .status-ready { background: rgba(34, 197, 94, 0.18); color: #15803d; }
+.catalog-drilldown .status-pending,
+.catalog-drilldown .status-reconciling,
+.catalog-drilldown .status-installing { background: rgba(234, 179, 8, 0.18); color: #b45309; }
+.catalog-drilldown .status-failed,
+.catalog-drilldown .status-degraded { background: rgba(239, 68, 68, 0.18); color: #b91c1c; }
+.catalog-drilldown .empty { color: var(--color-text-secondary); font-style: italic; }
+.catalog-drilldown .error { color: #b91c1c; }

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -63,6 +63,7 @@ import { MarketplaceProductPage } from '@/pages/marketplace/MarketplaceProductPa
 import { ProvisionPage } from '@/pages/provision/ProvisionPage'
 import { AppsPage } from '@/pages/sovereign/AppsPage'
 import { AppDetail } from '@/pages/sovereign/AppDetail'
+import { CatalogDetail } from '@/pages/sovereign/CatalogDetail'
 import { InstallPage } from '@/pages/sovereign/InstallPage'
 import { JobsPage } from '@/pages/sovereign/JobsPage'
 import { JobDetail } from '@/pages/sovereign/JobDetail'
@@ -1235,6 +1236,18 @@ const consoleJobsRoute = createRoute({
   path: '/jobs',
   component: JobsPage,
 })
+// G117.2 #2741 — Catalog class drill-down (chroot Sovereign Console).
+// `/catalog/$blueprintName` renders the CLASS page: header + topology
+// list + per-Blueprint instance table + "+ New instance" affordance for
+// multi-instance Blueprints. Distinct from `/apps` (instance grid) and
+// `/app/$componentId` (single-instance detail). Ports the abandoned
+// Astro+Svelte scaffold at products/catalyst/console/src/routes/catalog
+// /[name]/+page.svelte to the production React UI.
+const consoleCatalogDetailRoute = createRoute({
+  getParentRoute: () => consoleLayoutRoute,
+  path: '/catalog/$blueprintName',
+  component: CatalogDetail,
+})
 // Jobs timeline (Gantt-style retrospective) — chroot Sovereign Console.
 // MUST be registered BEFORE the dynamic $jobId route below so TanStack
 // Router resolves `/jobs/timeline` to this surface, not to JobDetail with
@@ -2080,6 +2093,7 @@ const routeTree = rootRoute.addChildren([
     consoleDashboardRoute,
     consoleAppsRoute,
     consoleAppDetailRoute,
+    consoleCatalogDetailRoute,
     consoleInstallRoute,
     consoleInstallBlueprintRoute,
     consoleJobsRoute,

--- a/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
@@ -146,6 +146,41 @@ export async function getCatalogItemVersion(name: string, version: string): Prom
   return res.json()
 }
 
+/* ── G117.2 #2741 — Blueprint-class drill-down ────────────────────── */
+
+/** Wire shape from `GET /catalyst/v1/catalog/{blueprint}/instances`.
+ * Mirrors `applicationSummary` in catalyst-api/endpoint_handler.go:117. */
+export interface BlueprintInstance {
+  id: string
+  name: string
+  blueprint: string
+  org: string
+  topology: string
+  status: string
+  createdAt?: string
+}
+
+interface ListBlueprintInstancesResponse {
+  items: BlueprintInstance[]
+}
+
+export async function listBlueprintInstances(
+  blueprint: string,
+  opts: { org?: string } = {},
+): Promise<BlueprintInstance[]> {
+  const bare = blueprint.replace(/^bp-/, '')
+  const params = new URLSearchParams()
+  if (opts.org) params.set('org', opts.org)
+  const qs = params.toString()
+  const url = `${API_BASE}/catalyst/v1/catalog/${encodeURIComponent(bare)}/instances${qs ? '?' + qs : ''}`
+  const res = await authedFetch(url, { headers: { Accept: 'application/json' } })
+  if (!res.ok) {
+    throw new Error(`listBlueprintInstances: HTTP ${res.status}`)
+  }
+  const body = (await res.json()) as ListBlueprintInstancesResponse
+  return body.items ?? []
+}
+
 /* ── REST calls (install + preview + status) ─────────────────────── */
 
 /**

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
@@ -1,0 +1,223 @@
+import { useParams, Link } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+
+import {
+  getCatalogItem,
+  listBlueprintInstances,
+  type CatalogItem,
+  type BlueprintInstance,
+} from '@/lib/catalog.api'
+
+/**
+ * G117.2 #2741 — Catalog drill-down (class detail).
+ *
+ * Route: `/catalog/$blueprintName` (under consoleLayoutRoute).
+ *
+ * Renders the per-Blueprint CLASS page — header with metadata, list of
+ * instances, "+ New instance" action. NOT the per-instance view (that
+ * is `/app/$componentId` → AppDetail).
+ *
+ * Ports the Astro+Svelte scaffold at
+ * `products/catalyst/console/src/routes/catalog/[name]/+page.svelte`
+ * to the production React UI. The scaffold never reached operators
+ * because the catalyst-ui Containerfile copies only `bootstrap/ui/`.
+ *
+ * Backed by:
+ *   GET /api/v1/catalog/{name}                        → CatalogItem
+ *   GET /catalyst/v1/catalog/{blueprint}/instances    → BlueprintInstance[]
+ */
+export function CatalogDetail() {
+  const { blueprintName } = useParams({ strict: false }) as { blueprintName?: string }
+  const name = (blueprintName ?? '').replace(/^bp-/, '')
+
+  const catalogQuery = useQuery<CatalogItem>({
+    queryKey: ['catalog-item', name],
+    queryFn: () => getCatalogItem(name),
+    enabled: !!name,
+    staleTime: 30_000,
+    retry: 1,
+  })
+
+  const instancesQuery = useQuery<BlueprintInstance[]>({
+    queryKey: ['blueprint-instances', name],
+    queryFn: () => listBlueprintInstances(name),
+    enabled: !!name,
+    staleTime: 15_000,
+    refetchInterval: 15_000,
+    retry: 1,
+  })
+
+  if (!name) {
+    return (
+      <section className="catalog-drilldown" data-testid="catalog-drilldown">
+        <p className="error" data-testid="catalog-error">missing blueprint name</p>
+      </section>
+    )
+  }
+
+  if (catalogQuery.isLoading) {
+    return (
+      <section className="catalog-drilldown" data-testid="catalog-drilldown" data-blueprint={name}>
+        <p data-testid="catalog-loading">Loading {name}…</p>
+      </section>
+    )
+  }
+
+  if (catalogQuery.isError) {
+    return (
+      <section className="catalog-drilldown" data-testid="catalog-drilldown" data-blueprint={name}>
+        <p className="error" data-testid="catalog-error">
+          {(catalogQuery.error as Error)?.message ?? 'load failed'}
+        </p>
+      </section>
+    )
+  }
+
+  const cat = catalogQuery.data!
+  const instances = instancesQuery.data ?? []
+  const multiInstance = readMultiInstance(cat)
+  const topologies = readTopologies(cat)
+  const defaultTopology = readDefaultTopology(cat)
+
+  return (
+    <section
+      className="catalog-drilldown"
+      data-testid="catalog-drilldown"
+      data-blueprint={name}
+    >
+      <header className="bp-header">
+        <div>
+          <h2 data-testid="catalog-title">{cat.card?.title ?? name}</h2>
+          <p className="desc">{cat.card?.description ?? ''}</p>
+        </div>
+        <div className="badges">
+          <span className="badge" data-testid="catalog-version">v{cat.version}</span>
+          {cat.card?.family ? (
+            <span className="badge" data-testid="catalog-family">{cat.card.family}</span>
+          ) : null}
+          <span
+            className="badge"
+            data-testid={multiInstance ? 'badge-multi-instance' : 'badge-singleton'}
+          >
+            {multiInstance ? 'multi-instance' : 'singleton-per-Org'}
+          </span>
+        </div>
+      </header>
+
+      {topologies.length > 0 ? (
+        <section className="topologies">
+          <h3>Supported topologies</h3>
+          <ul>
+            {topologies.map((t) => (
+              <li key={t}>
+                <code>{t}</code>
+                {t === defaultTopology ? <em> (default)</em> : null}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <section className="instances">
+        <header className="instances-header">
+          <h3>Instances ({instances.length})</h3>
+          {multiInstance ? (
+            <Link
+              to={'/catalog/$blueprintName/new' as never}
+              params={{ blueprintName: name } as never}
+              className="btn-new"
+              data-testid="btn-new-instance"
+            >
+              + New instance
+            </Link>
+          ) : instances.length === 0 ? (
+            <Link
+              to={'/catalog/$blueprintName/new' as never}
+              params={{ blueprintName: name } as never}
+              className="btn-new"
+              data-testid="btn-install-singleton"
+            >
+              Install
+            </Link>
+          ) : (
+            <span className="hint">Singleton-per-Org — already installed.</span>
+          )}
+        </header>
+
+        {instances.length === 0 ? (
+          <p className="empty">No instances yet.</p>
+        ) : (
+          <table data-testid="instance-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Org</th>
+                <th>Topology</th>
+                <th>Status</th>
+                <th>Created</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {instances.map((inst) => (
+                <tr key={inst.id} data-testid={`instance-row-${inst.id}`}>
+                  <td>
+                    <Link
+                      to={'/app/$componentId' as never}
+                      params={{ componentId: `bp-${inst.blueprint}` } as never}
+                      data-testid={`instance-link-${inst.id}`}
+                    >
+                      {inst.name}
+                    </Link>
+                  </td>
+                  <td>{inst.org}</td>
+                  <td><code>{inst.topology}</code></td>
+                  <td>
+                    <span className={`status status-${inst.status.toLowerCase()}`}>
+                      {inst.status}
+                    </span>
+                  </td>
+                  <td>{inst.createdAt ?? ''}</td>
+                  <td>
+                    <Link
+                      to={'/app/$componentId' as never}
+                      params={{ componentId: `bp-${inst.blueprint}` } as never}
+                      search={{ tab: 'endpoints' } as never}
+                    >
+                      Endpoints
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </section>
+  )
+}
+
+function readMultiInstance(cat: CatalogItem): boolean {
+  const raw = cat.raw as Record<string, unknown> | undefined
+  const spec = (raw?.spec as Record<string, unknown> | undefined) ?? undefined
+  const mi = spec?.multiInstance as { enabled?: boolean } | undefined
+  return !!mi?.enabled
+}
+
+function readTopologies(cat: CatalogItem): string[] {
+  const modes = cat.placementSchema?.modes
+  if (Array.isArray(modes) && modes.length > 0) return modes
+  const raw = cat.raw as Record<string, unknown> | undefined
+  const spec = (raw?.spec as Record<string, unknown> | undefined) ?? undefined
+  const topology = spec?.topology as { supported?: string[] } | undefined
+  return topology?.supported ?? []
+}
+
+function readDefaultTopology(cat: CatalogItem): string {
+  const def = cat.placementSchema?.default
+  if (typeof def === 'string' && def) return def
+  const raw = cat.raw as Record<string, unknown> | undefined
+  const spec = (raw?.spec as Record<string, unknown> | undefined) ?? undefined
+  const topology = spec?.topology as { default?: string } | undefined
+  return topology?.default ?? ''
+}


### PR DESCRIPTION
## Summary

V2 brutal verifier on reopened #2741 confirmed live on hw86 that the production React UI (`catalyst-ui:0b79691`) has **no `/catalog/*` routes** — the Astro+Svelte scaffold at `products/catalyst/console/src/routes/catalog/[name]/+page.svelte` never shipped to operators because the catalyst-ui Containerfile copies only `bootstrap/ui/`.

This PR ports the class-detail page — the founder's exact complaint about "mixing the catalogs (blueprints which were supposed to only the list of instance) and you made it again equivalent to deployments."

## Changes

- **`catalog.api.ts`** — new `listBlueprintInstances(name)` calls existing catalyst-api endpoint `GET /catalyst/v1/catalog/{blueprint}/instances` (HandleListBlueprintInstances). Wire shape `BlueprintInstance` mirrors Go `applicationSummary` json tags verbatim per the lessons-learned memory.
- **`CatalogDetail.tsx`** — new class-detail page:
  - Header (title + version + family + `multi-instance` / `singleton-per-Org` badge)
  - Supported topologies list (from `placementSchema.modes`)
  - Instances table with link to AppDetail + Endpoints sub-link
  - "+ New instance" affordance (multi-instance) or "Install" (singleton, empty) or "already installed" (singleton, present)
- **`router.tsx`** — new `consoleCatalogDetailRoute` at `/catalog/$blueprintName` under `consoleLayoutRoute` (sibling of `/apps`, `/app/$componentId`).
- **`globals.css`** — scoped `.catalog-drilldown` styles using existing CSS-var palette.

## Architectural reminder

This is the CLASS page — one per Blueprint. The route at `/apps` continues to be the per-instance grid. `/app/$componentId` continues to be the single-instance detail. The three surfaces don't overlap:
- `/apps`           → all installed instances across classes
- `/catalog/$name`  → THIS PR — one class + its instances + "+ New"
- `/app/$id`        → one specific instance

## Out of scope (focused-PR discipline — follow-up tracked)

- `/catalog` index (class listing) — separate PR
- `/catalog/$name/new` instance-create form — separate PR
- Vitest+RTL unit tests for CatalogDetail — separate PR with MSW round-trips

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] After merge: `catalyst-ui` rebuild + chart pin bump
- [ ] Founder walk on hw86: navigate to `/catalog/grafana` → see class header + (empty) instances table + "+ New instance" button when multi-instance
- [ ] Network panel confirms two GET calls: `/api/v1/catalog/grafana` + `/catalyst/v1/catalog/grafana/instances`

Refs #2741 Refs #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)