### PR TITLE
fix(catalyst-ui): #2876-followup — dedupe ListBlueprintInstancesResponse

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
@@ -148,26 +148,16 @@ export async function getCatalogItemVersion(name: string, version: string): Prom
 
 /* ── G117.2 #2741 — Blueprint-class drill-down ────────────────────── */
 
-/** Wire shape from `GET /catalyst/v1/catalog/{blueprint}/instances`.
- * Mirrors `applicationSummary` in catalyst-api/endpoint_handler.go:117. */
-export interface BlueprintInstance {
-  id: string
-  name: string
-  blueprint: string
-  org: string
-  topology: string
-  status: string
-  createdAt?: string
-}
-
-interface ListBlueprintInstancesResponse {
-  items: BlueprintInstance[]
-}
-
-export async function listBlueprintInstances(
+/**
+ * GET /catalyst/v1/catalog/{blueprint}/instances → ApplicationInstanceSummary[].
+ * The wire envelope type `ListBlueprintInstancesResponse` is declared
+ * below alongside `ApplicationInstanceSummary` (line ~748); this fn
+ * unwraps the `items` field for callers that just want the list.
+ */
+export async function listBlueprintInstancesByName(
   blueprint: string,
   opts: { org?: string } = {},
-): Promise<BlueprintInstance[]> {
+): Promise<ApplicationInstanceSummary[]> {
   const bare = blueprint.replace(/^bp-/, '')
   const params = new URLSearchParams()
   if (opts.org) params.set('org', opts.org)
@@ -175,7 +165,7 @@ export async function listBlueprintInstances(
   const url = `${API_BASE}/catalyst/v1/catalog/${encodeURIComponent(bare)}/instances${qs ? '?' + qs : ''}`
   const res = await authedFetch(url, { headers: { Accept: 'application/json' } })
   if (!res.ok) {
-    throw new Error(`listBlueprintInstances: HTTP ${res.status}`)
+    throw new Error(`listBlueprintInstancesByName: HTTP ${res.status}`)
   }
   const body = (await res.json()) as ListBlueprintInstancesResponse
   return body.items ?? []

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
@@ -3,9 +3,9 @@ import { useQuery } from '@tanstack/react-query'
 
 import {
   getCatalogItem,
-  listBlueprintInstances,
+  listBlueprintInstancesByName,
   type CatalogItem,
-  type BlueprintInstance,
+  type ApplicationInstanceSummary,
 } from '@/lib/catalog.api'
 
 /**
@@ -38,9 +38,9 @@ export function CatalogDetail() {
     retry: 1,
   })
 
-  const instancesQuery = useQuery<BlueprintInstance[]>({
+  const instancesQuery = useQuery<ApplicationInstanceSummary[]>({
     queryKey: ['blueprint-instances', name],
-    queryFn: () => listBlueprintInstances(name),
+    queryFn: () => listBlueprintInstancesByName(name),
     enabled: !!name,
     staleTime: 15_000,
     refetchInterval: 15_000,


### PR DESCRIPTION
PR #2876's build-ui failed with TS2395 — I declared a duplicate `ListBlueprintInstancesResponse` interface (line 163) but catalog.api.ts already had one at line 748 alongside the canonical `ApplicationInstanceSummary`. Local tsc merged them silently; CI tsc rejected. Fix uses the canonical types.

Refs #2876 Refs #2741