### PR TITLE
fix(catalyst-ui): #2741-followup — drop /api/ prefix on /catalyst/v1/* calls

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
@@ -28,7 +28,7 @@
  * distinction is resolved at config-time, not in components.
  */
 
-import { API_BASE } from '@/shared/config/urls'
+import { API_BASE, BASE } from '@/shared/config/urls'
 import { authedFetch } from '@/shared/lib/authedFetch'
 
 /* ── Wire types ──────────────────────────────────────────────────── */
@@ -162,7 +162,13 @@ export async function listBlueprintInstancesByName(
   const params = new URLSearchParams()
   if (opts.org) params.set('org', opts.org)
   const qs = params.toString()
-  const url = `${API_BASE}/catalyst/v1/catalog/${encodeURIComponent(bare)}/instances${qs ? '?' + qs : ''}`
+  // The /catalyst/v1/... route group is registered WITHOUT the /api/
+  // prefix at cmd/api/main.go:1412 (HandleListBlueprintInstances). Use
+  // BASE (not API_BASE) so we don't ship /api/catalyst/v1/... which chi
+  // doesn't match and which returns 404 (caught live on hw86 walk
+  // 2026-06-03 after #2876 deploy — CatalogDetail's instancesQuery
+  // surfaced the 404 in the rendered error state).
+  const url = `${BASE}catalyst/v1/catalog/${encodeURIComponent(bare)}/instances${qs ? '?' + qs : ''}`
   const res = await authedFetch(url, { headers: { Accept: 'application/json' } })
   if (!res.ok) {
     throw new Error(`listBlueprintInstancesByName: HTTP ${res.status}`)


### PR DESCRIPTION
## Summary

Authenticated walk on hw86 (via handover-JWT bypass per verifier-recommended path) caught the catalog drilldown's `listBlueprintInstancesByName` shipping a 404 against `/api/catalyst/v1/catalog/{name}/instances`. The chi route is registered at `/catalyst/v1/catalog/{blueprint}/instances` WITHOUT the `/api/` prefix (cmd/api/main.go:1412). The 7 routes in that group are the only ones in catalyst-api without `/api/` — distinct from the 225 `/api/v1/...` routes.

Fix uses `BASE` instead of `API_BASE` so the URL resolves correctly.

## Evidence

LIVE walk via `fetch` from authenticated browser context:
```
GET /catalyst/v1/catalog/grafana/instances → 200
{"items":[{"id":"0732b69e-...","name":"walk2742-app","blueprint":"grafana","org":"walk2742","topology":"single-region","status":"Pending","createdAt":"2026-06-02T18:54:11Z"}]}
```

vs the broken (pre-fix) call:
```
GET /api/catalyst/v1/catalog/grafana/instances → 404
```

## Test plan

- [ ] After deploy: navigate to `/catalog/grafana` on hw86 with auth → instances table shows `walk2742-app` row
- [ ] No 404 in catalyst-api logs for `/api/catalyst/v1/...` paths

Note: there's also a separate 502 on `GET /api/v1/catalog/grafana` (catalyst-api → gitea returns HTTP 401 fetching `catalog-sovereign/grafana/contents/blueprint.yaml`). That's a backend gitea-token issue, not a UI bug. Filing as separate follow-up.

Refs #2741 Refs #2876

🤖 Generated with [Claude Code](https://claude.com/claude-code)