### PR TITLE
fix(catalyst-api): #2879 — broaden catalog cluster-fallback to non-404 upstream errors

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/catalog_client_cluster_fallback.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_client_cluster_fallback.go
@@ -111,29 +111,58 @@ func (c *chainedCatalogClient) List(ctx context.Context, org, sessionToken strin
 }
 
 func (c *chainedCatalogClient) Get(ctx context.Context, name, sessionToken string) (*CatalogBlueprint, error) {
+	var upstreamErr error
 	if c.upstream != nil {
 		bp, err := c.upstream.Get(ctx, name, sessionToken)
 		if err == nil {
 			return bp, nil
 		}
-		if !errors.Is(err, ErrBlueprintNotFound) {
-			return nil, err
-		}
+		upstreamErr = err
 	}
-	return c.getFromCluster(ctx, name, "")
+	// G117 #2879 (2026-06-03): try the cluster fallback on ANY upstream
+	// error, not just ErrBlueprintNotFound. Pre-fix the fallback only fired
+	// on a definitive 404 — but on hw86 the gitea catalog-sovereign Org
+	// doesn't exist (bp-self-sovereign-cutover gitea-mirror Job never
+	// ran), so every catalog Get returned upstream HTTP 401/502 and the
+	// fallback was bypassed. Result: chart-seeded Blueprint CRs (which
+	// EXIST in-cluster via templates/catalog-seed/blueprints.yaml) were
+	// invisible to the install + launch-url handlers, /catalyst/v1/apps/
+	// {uid}/launch-url returned 503, and the operator's Launch button
+	// silently degraded to a plain externalURL with no SSO query string.
+	// Caught live this session via authenticated Playwright walk.
+	//
+	// If the cluster ALSO doesn't have the Blueprint, surface the
+	// upstream error (when present) so the underlying gitea/org/Network
+	// problem stays debuggable instead of getting masked behind a generic
+	// "not found".
+	bp, clusterErr := c.getFromCluster(ctx, name, "")
+	if clusterErr == nil {
+		return bp, nil
+	}
+	if errors.Is(clusterErr, ErrBlueprintNotFound) && upstreamErr != nil && !errors.Is(upstreamErr, ErrBlueprintNotFound) {
+		return nil, upstreamErr
+	}
+	return nil, clusterErr
 }
 
 func (c *chainedCatalogClient) GetVersion(ctx context.Context, name, version, sessionToken string) (*CatalogBlueprint, error) {
+	var upstreamErr error
 	if c.upstream != nil {
 		bp, err := c.upstream.GetVersion(ctx, name, version, sessionToken)
 		if err == nil {
 			return bp, nil
 		}
-		if !errors.Is(err, ErrBlueprintNotFound) {
-			return nil, err
-		}
+		upstreamErr = err
 	}
-	return c.getFromCluster(ctx, name, version)
+	// G117 #2879 (2026-06-03): same broadened-fallback rationale as Get.
+	bp, clusterErr := c.getFromCluster(ctx, name, version)
+	if clusterErr == nil {
+		return bp, nil
+	}
+	if errors.Is(clusterErr, ErrBlueprintNotFound) && upstreamErr != nil && !errors.Is(upstreamErr, ErrBlueprintNotFound) {
+		return nil, upstreamErr
+	}
+	return nil, clusterErr
 }
 
 // listFromCluster enumerates Blueprint CRs from the chroot's apiserver.


### PR DESCRIPTION
## Summary

Authenticated live walk on hw86 caught the silent-SSO chain still broken AFTER PR #2873's URL-casing fix shipped. Root cause traced to `chainedCatalogClient` only falling back to in-cluster Blueprint CRs on `ErrBlueprintNotFound` (definitive 404). On hw86 — and likely any Sovereign whose `catalog-sovereign` gitea Org never got bootstrapped (#2879) — every catalog Get returns upstream HTTP 401/502 wrapping `user does not exist [uid: 0, name: ]`. That isn't ErrBlueprintNotFound, so the fallback never fires.

Result: chart-seeded Blueprint CRs from `templates/catalog-seed/blueprints.yaml` (which DO exist in-cluster) are invisible to the install + launch-url handlers, /catalyst/v1/apps/{uid}/launch-url returns 503, and the operator's Launch button silently degrades to a plain externalURL with no SSO query string.

## Reproduction (this turn, hw86)

```bash
$ curl -sb cookie /catalyst/v1/apps/0732b69e-cc5f-40ff-976a-3f9dd6d75b18/launch-url
{
  "code": "blueprint-unavailable",
  "message": "catalog get: upstream 502 ... GET /api/v1/repos/catalog-sovereign/grafana/contents/blueprint.yaml ... HTTP 401: user does not exist [uid: 0, name: ]"
}
```

LaunchButton on AppDetail rendered correctly, but window.open captured (via Playwright intercept):
```js
{ url: "https://grafana.hw86.omani.works", target: "_blank", features: "noopener,noreferrer" }
```
— NO `prompt=none` OR `kc_idp_hint=catalyst-pin`.

## Fix

`chainedCatalogClient.Get` + `.GetVersion`: try the cluster fallback on ANY upstream error, not just `ErrBlueprintNotFound`. If the cluster ALSO returns ErrBlueprintNotFound AND upstream had a non-404 error, surface the upstream error so the underlying gitea/Org/Network problem stays debuggable instead of getting masked as a generic "not found".

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/handler/...` clean
- [ ] After deploy: walk Launch button on hw86 → captured window.open URL carries `prompt=none&kc_idp_hint=catalyst-pin`
- [ ] Re-walk `/catalog/grafana` on hw86 → CatalogDetail renders class header (no longer 502 error)

The deeper fix (creating the missing gitea catalog-sovereign Org on hw86) stays tracked at #2879. This PR makes the cluster fallback resilient against that class of upstream failure repo-wide.

Refs #2879 Refs #2743 Refs #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)