### PR TITLE
fix(catalyst-api): #2880-followup — cluster-fallback bp- prefix retry

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/catalog_client_cluster_fallback.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_client_cluster_fallback.go
@@ -196,6 +196,17 @@ func (c *chainedCatalogClient) listFromCluster(ctx context.Context) ([]CatalogBl
 // getFromCluster looks up a Blueprint CR by name. When `version` is
 // non-empty the version field on the CR must match exactly; an "latest"
 // or empty version returns whatever's in spec.version.
+//
+// G117 #2880-followup (2026-06-03): callers pass the bare blueprint name
+// (e.g. "grafana") because catalyst-catalog's HTTP API uses the bare
+// form. The chart-seeded CRs in templates/catalog-seed/blueprints.yaml
+// are named with the canonical `bp-` prefix (e.g. "bp-grafana") per
+// docs/NAMING §Blueprint. Try both forms so the cluster fallback works
+// for the common case where upstream is unreachable and the chart's
+// fixtures are the only path to a working install. Caught live on hw86
+// 2026-06-03 — `getFromCluster(ctx, "grafana", "")` returned
+// ErrBlueprintNotFound for `kubectl get blueprint bp-grafana` because
+// the bare-name lookup never matched the `bp-`-prefixed CR.
 func (c *chainedCatalogClient) getFromCluster(ctx context.Context, name, version string) (*CatalogBlueprint, error) {
 	if c.dyn == nil {
 		return nil, ErrBlueprintNotFound
@@ -207,6 +218,17 @@ func (c *chainedCatalogClient) getFromCluster(ctx context.Context, name, version
 	if err != nil {
 		if isVersionNotServed(err) {
 			obj, err = c.dyn.Resource(blueprintCRGVRAlpha1()).Get(ctx, name, metav1.GetOptions{})
+		}
+	}
+	// Retry with the canonical `bp-` prefix when the bare name missed.
+	if err != nil && apierrors.IsNotFound(err) && !strings.HasPrefix(name, "bp-") {
+		bpName := "bp-" + name
+		obj2, err2 := c.dyn.Resource(blueprintCRGVR()).Get(ctx, bpName, metav1.GetOptions{})
+		if err2 != nil && isVersionNotServed(err2) {
+			obj2, err2 = c.dyn.Resource(blueprintCRGVRAlpha1()).Get(ctx, bpName, metav1.GetOptions{})
+		}
+		if err2 == nil {
+			obj, err = obj2, nil
 		}
 	}
 	if err != nil {

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_client_cluster_fallback_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_client_cluster_fallback_test.go
@@ -147,6 +147,27 @@ func TestChainedCatalogClient_Get_ClusterNotFoundWhenUpstream404(t *testing.T) {
 	}
 }
 
+func TestChainedCatalogClient_Get_RetryWithBpPrefix(t *testing.T) {
+	// G117 #2880-followup: chart-seeded Blueprint CRs are named `bp-<name>`
+	// (per docs/NAMING §Blueprint) but the catalog Get is called with the
+	// bare form (`<name>`). Pre-fix, the cluster fallback's bare-name
+	// lookup missed every bp-prefixed CR — making the fallback useless on
+	// hw86 where catalog-sovereign upstream is unreachable. Post-fix,
+	// the fallback retries with the `bp-` prefix when the bare name 404s.
+	upstreamHTTPErr := errors.New("catalog get: upstream 502 gitea unreachable")
+	c := &chainedCatalogClient{
+		upstream: &stubCatalogClient{getErr: upstreamHTTPErr},
+		dyn:      fakeBlueprintDynClient(t, "bp-grafana"), // CR is `bp-grafana`
+	}
+	bp, err := c.Get(context.Background(), "grafana", "") // call with bare
+	if err != nil {
+		t.Fatalf("expected bp-prefix retry to find bp-grafana for bare 'grafana', got err: %v", err)
+	}
+	if bp == nil || bp.Name != "bp-grafana" {
+		t.Fatalf("expected bp.Name=bp-grafana, got %+v", bp)
+	}
+}
+
 func TestChainedCatalogClient_GetVersion_FallbackOnUpstreamNon404(t *testing.T) {
 	// Mirror of Get's broadened-fallback behavior on GetVersion.
 	upstreamHTTPErr := errors.New("catalog getversion: upstream 502")


### PR DESCRIPTION
Live walk after #2880 deploy proved the broadened-fallback was necessary but not sufficient. Chart-seeded CRs are named bp-<name> but the catalog Get is called with bare <name>. Retry with bp- prefix when bare name 404s.

Verified: 6/6 tests pass.

Refs #2880 Refs #2879 Refs #2743 Refs #2737