### PR TITLE
deploy(catalyst-catalog): bump image tag → 3e05e85 (PR #2889 ship)

### DIFF
--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -652,7 +652,13 @@ services:
       # land via the catalyst-catalog-image-built repository_dispatch
       # hop (catalyst-catalog-build.yaml notify job → downstream
       # bumper PR).
-      tag: "9763286"
+      # 2026-06-03: bumped 9763286 → 3e05e85 to ship PR #2889 (#2879
+      # Sovereign source monorepo-layout fallback) — auto-bump didn't
+      # fire because the catalyst-catalog-image-built repository_dispatch
+      # hop isn't yet wired into catalyst-build.yaml's sweep step (same
+      # #2851 class of bug). Manual stamp until the dispatcher CI fix
+      # ships.
+      tag: "3e05e85"
       pullPolicy: IfNotPresent
     replicas: 1
     # Gitea endpoint — empty defaults to in-cluster Service URL.


### PR DESCRIPTION
Manual image-pin bump for PR #2889. Same #2851 class — auto-bump dispatcher doesn't include catalyst-catalog. Refs #2889 #2879 #2851