### PR TITLE
fix(infra): #2840 — Hetzner cloud-init missing SOVEREIGN_CNPG_INSTANCES

### DIFF
--- a/infra/providers/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/providers/hetzner/cloudinit-control-plane.tftpl
@@ -541,6 +541,17 @@ write_files:
             # sovereign_fqdn (rendered in main.tf via coalesce()).
             PARENT_DOMAINS_YAML: '${parent_domains_yaml}'
             # (commentary block-31-line-1059 → docs/cloudinit-hetzner-notes.md, 13 lines stripped)
+            # G87 #2840 (2026-06-03): per-CNPG-cluster instance count.
+            # Multi-region Sovereigns set this to 2 so every CNPG cluster
+            # spreads across regions via the topology-region anti-affinity
+            # the bootstrap-kit slots reference as `$${SOVEREIGN_CNPG_INSTANCES:=1}`.
+            # Single-region keeps 1. Mirrors the Huawei cloud-init template's
+            # equivalent at infra/providers/huawei/cloudinit-control-plane.tftpl:626.
+            # Caught live on hw86 (Huawei) 2026-06-03 — the Kustomization
+            # substitute map didn't include this key, so all CNPG clusters
+            # defaulted to instances=1 despite multi-region intent. Hetzner
+            # template missed it too; this fix lockstep-adds.
+            SOVEREIGN_CNPG_INSTANCES: "${sovereign_cnpg_instances}"
             CLUSTER_MESH_NAME: "${cluster_mesh_name}"
             CLUSTER_MESH_ID: "${cluster_mesh_id}"
             # 2026-05-15 DoD A3 wiring: bp-cilium chart defaults

--- a/infra/providers/hetzner/main.tf
+++ b/infra/providers/hetzner/main.tf
@@ -709,6 +709,15 @@ locals {
     bcp_topology       = var.bcp_topology
     enable_hot_standby = var.enable_hot_standby
 
+    # #2840 (2026-06-03): per-CNPG-cluster instance count. Mirrors
+    # infra/providers/huawei/main.tf:695. Multi-region Sovereigns get
+    # 2 instances per CNPG cluster so the operator can spread across
+    # regions via podAntiAffinity. Single-region keeps 1. The
+    # bootstrap-kit substitute map references this via
+    # `SOVEREIGN_CNPG_INSTANCES: "$${sovereign_cnpg_instances}"` —
+    # see cloudinit-control-plane.tftpl PR-companion to this var.
+    sovereign_cnpg_instances = length(var.regions) > 1 ? "2" : "1"
+
     # Multi-domain Sovereign (issue #827). When the wizard supplies an
     # explicit parent-domain list, use it verbatim. Otherwise default to a
     # single-zone array derived from sovereign_fqdn so legacy single-zone


### PR DESCRIPTION
Hetzner template + tofu were missing the var that the Huawei template had. Multi-region Sovereigns silently default CNPG to instances=1. Adds the missing pair. Refs #2840