### PR TITLE
fix(sso-bridge): #2861 — Cilium reserved:world vs kube-apiserver identity mismatch

### DIFF
--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -67,6 +67,13 @@ spec:
   chart:
     spec:
       chart: bp-sso-bridge
+      # 0.2.7 (#2861 RCA, 2026-06-03): fix Cilium `reserved:world` vs
+      # `reserved:kube-apiserver` identity mismatch on the kube-API
+      # egress rule. `ipBlock 0.0.0.0/0` excluded the apiserver
+      # identity → every `kubectl get cm sovereign-fqdn` tick was
+      # dropped at Cilium policy verdict. Replaced with explicit
+      # default/component=apiserver podSelector. Unblocks per-Org
+      # realm provisioning on hw86. Refs #2861 #2744.
       # 0.2.6 (#2744 H8 walk, 2026-06-03): fix Cilium egress NetworkPolicy
       # port mismatch — chart's egress rule allow-listed only the
       # keycloak Service port (80), but Cilium enforces on the Pod's
@@ -92,7 +99,7 @@ spec:
       # 0.1.1 (G91-fu, Refs #2659, edc55c08 PR #2676): adds realm-role
       # grant + skipClientUpsert opt-out for charts whose Keycloak Client
       # is realm-imported at bp-keycloak install time (catalyst-ui etc.).
-      version: 0.2.6
+      version: 0.2.7
       sourceRef:
         kind: HelmRepository
         name: bp-sso-bridge

--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.6
+  version: 0.2.7
   card:
     title: sso-bridge
     summary: |

--- a/platform/sso-bridge/chart/Chart.yaml
+++ b/platform/sso-bridge/chart/Chart.yaml
@@ -1,6 +1,29 @@
 apiVersion: v2
 name: bp-sso-bridge
-version: 0.2.6
+version: 0.2.7
+# 0.2.7 (#2861 RCA, 2026-06-03): fix Cilium identity-mismatch on the
+# kube-apiserver egress rule. The chart shipped `ipBlock: 0.0.0.0/0`
+# for kube-API egress, which Cilium translates into the
+# `reserved:world` identity. `reserved:world` EXCLUDES the special
+# `reserved:kube-apiserver` identity assigned to in-cluster
+# kube-apiserver Pods → every reconciler tick that called
+# `kubectl get cm sovereign-fqdn` got `Policy denied identity
+# 15466798->kube-apiserver` at the Cilium datapath. DNS still
+# worked because the kube-dns rule uses namespaceSelector
+# (identity-resolved through pod-labels, not ipBlock).
+#
+# Symptom on hw86: bp-sso-bridge logged `skipping tick` every 6
+# minutes from 01:33Z onward; per-Org realm provisioning stalled;
+# 4 prior containment attempts (cilium-agent restart, Pod restart,
+# cordon+reschedule, delete CNP) did not help because none of them
+# changed the NetworkPolicy rule that produced the verdict.
+#
+# Fix: replace the `ipBlock 0.0.0.0/0` rule with two narrower rules:
+#   (a) explicit `default/component=apiserver,provider=kubernetes`
+#       podSelector on ports 6443 + 443 (k3s + kubeadm Pod labels);
+#   (b) namespaceSelector: {} on port 443 to keep ExternalSecret CR
+#       writes flowing to per-app namespaces.
+# Pure template change; no values-default change. Refs #2861 #2744.
 # 0.2.6 (#2744 H8 walk, 2026-06-03): fix Cilium egress NetworkPolicy
 # port mismatch that silently broke ALL per-Org realm provisioning
 # for 24h+. The reconciler curl'd keycloak.keycloak.svc:80 (Service

--- a/platform/sso-bridge/chart/templates/networkpolicy.yaml
+++ b/platform/sso-bridge/chart/templates/networkpolicy.yaml
@@ -52,14 +52,36 @@ spec:
           port: 53
     # Kubernetes API — reconciler lists HRs cluster-wide + writes
     # ExternalSecret CRs into each app's namespace.
+    #
+    # 0.2.7 (#2861 RCA, 2026-06-03): Cilium translates `ipBlock 0.0.0.0/0`
+    # into the `reserved:world` identity, which EXCLUDES the special
+    # `reserved:kube-apiserver` identity. Result: every egress to
+    # kube-apiserver (10.96.0.1:443 → kube-api Pod :6443) was dropped
+    # with `Policy denied identity 15466798->kube-apiserver`. DNS worked
+    # because the kube-dns rule uses namespaceSelector, not ipBlock.
+    # Fix: select the kube-apiserver Pod directly via its k3s/kubeadm
+    # labels in the `default` namespace; keep a broad namespaceSelector
+    # fallback for cross-namespace ExternalSecret CR writes (which hit
+    # the apiserver Service IP too but resolve through cluster-internal
+    # identities the broad selector covers).
     - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: default
+          podSelector:
+            matchLabels:
+              component: apiserver
+              provider: kubernetes
+      ports:
+        - protocol: TCP
+          port: 6443
+        - protocol: TCP
+          port: 443
+    - to:
+        - namespaceSelector: {}
       ports:
         - protocol: TCP
           port: 443
-        - protocol: TCP
-          port: 6443
     # Keycloak admin endpoint — same namespace selector as
     # bp-keycloak's NetworkPolicy ingress allow-list. Per-Sovereign
     # overlays MAY rewrite the namespace if bp-keycloak is relocated


### PR DESCRIPTION
## Root cause (definitive)

Chart NetworkPolicy used `ipBlock: 0.0.0.0/0` for kube-API egress. Cilium translates this into the `reserved:world` identity, which **excludes** the special `reserved:kube-apiserver` identity assigned to in-cluster kube-apiserver Pods.

`cilium monitor --type drop --type policy-verdict` captured the drop live:
```
Policy verdict log: flow ... local EP ID 2482, remote ID kube-apiserver,
proto 6, egress, action deny, ... identity 15466798->kube-apiserver
```

DNS still worked because the kube-dns rule uses `namespaceSelector` (Pod-label identity resolution), not `ipBlock`.

## Why 4 prior containments failed

cilium-agent restart, Pod restart, cordon+reschedule, delete CNP — none of them changed the NetworkPolicy rule producing the verdict. The drop is a deterministic policy decision baked in by the chart-rendered NP.

## Fix

`platform/sso-bridge/chart/templates/networkpolicy.yaml`:
- Replace `ipBlock 0.0.0.0/0` with explicit `default/component=apiserver,provider=kubernetes` podSelector on ports 6443 + 443 (k3s + kubeadm Pod label convention).
- Add `namespaceSelector: {}` on port 443 for cross-namespace ExternalSecret CR writes.

Lockstep: chart 0.2.6 → 0.2.7 + `platform/sso-bridge/blueprint.yaml` + `clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml` pins.

## Walk

Operator walk on hw86 after merge + Flux reconcile:
1. `kubectl -n sso-bridge logs deploy/bp-sso-bridge-reconciler --tail=20` — should NO longer see `skipping tick` every 6 min.
2. `kubectl -n kube-system exec <cilium-pod> -- cilium monitor --type policy-verdict` while reconciler runs — should show `action allow identity ID->kube-apiserver` for the SYN.
3. Per-Org realm provisioning should resume; `kubectl -A get cm -l catalyst.openova.io/per-org-realm=true` Org realms appear in KC.

Refs #2861 #2744

🤖 Generated with [Claude Code](https://claude.com/claude-code)