### PR TITLE
fix(hetzner-tofu): #2840 — control_plane_ips_per_region output parity for partial-region detection

### DIFF
--- a/infra/providers/hetzner/outputs.tf
+++ b/infra/providers/hetzner/outputs.tf
@@ -85,3 +85,32 @@ output "secondary_region_keys" {
   description = "Stable keys of every secondary region the module provisioned, in deterministic insertion order. Joined with var.regions[1+] by the catalyst-api when projecting per-region status into the deployment record."
   value       = keys(local.secondary_regions)
 }
+
+# G117 #2840-followup (2026-06-03): unified per-region CP-IP map that
+# INCLUDES the primary region, matching the Huawei provider's
+# `control_plane_ips_per_region` shape. The catalyst-api provisioner's
+# partial-region-materialisation defense (provisioner.go:1648) reads
+# this exact key name to detect silently-degraded multi-region provs;
+# without this output the Hetzner path skipped the check entirely
+# (`len(out.ControlPlaneIPsPerRegion) > 0` evaluated false) and a
+# multi-region Hetzner Sovereign that lost a region to a quota /
+# capacity cascade would have passed the post-apply gate with the
+# same silent single-region degradation that hit hw86 on HCS.
+#
+# Keyed by the operator-supplied `cloudRegion` value verbatim so the
+# catalyst-api's region-code comparison works the same on both
+# providers. The primary entry's value is identical to `control_plane_ip`
+# above; secondary entries are pulled from the same hcloud_server
+# resource the `_by_region` output already references.
+output "control_plane_ips_per_region" {
+  description = "Per-region primary control-plane public IPv4, keyed by the operator's cloudRegion value. Includes BOTH primary AND secondary regions. Mirrors the Huawei provider's same-named output so the catalyst-api partial-region detection works uniformly. Refs #2840."
+  value = merge(
+    {
+      (var.region) = hcloud_server.control_plane.ipv4_address
+    },
+    {
+      for k, v in local.secondary_regions :
+      v.cloudRegion => hcloud_server.secondary_control_plane[k].ipv4_address
+    }
+  )
+}


### PR DESCRIPTION
## Gap

`provisioner.go:1695` partial-region-materialisation defense reads tofu output `control_plane_ips_per_region` (Huawei convention) to detect silently-degraded multi-region provs. Hetzner only exposed `control_plane_ips_by_region` (secondaries only, primary excluded), so:

```go
if len(declared) >= 2 && len(out.ControlPlaneIPsPerRegion) > 0 && len(missing) > 0 {
    // PartialRegionMaterialisationError ...
}
```

The middle clause `len(out.ControlPlaneIPsPerRegion) > 0` evaluated **false** on Hetzner → check skipped entirely → a multi-region Hetzner Sovereign that loses a region to a Hetzner Cloud quota or capacity cascade would have shipped the same silent single-region degradation that hit hw86 on HCS.

## Fix

`infra/providers/hetzner/outputs.tf`: add `control_plane_ips_per_region` output that includes **both primary AND secondary** regions, matching Huawei's same-named output shape. Keyed by the operator-supplied `cloudRegion` value verbatim so the catalyst-api's region-code comparison works uniformly.

Pure additive — `_by_region` ships unchanged for any consumer that already reads it.

## Walk

Next fresh Hetzner multi-region prov (e.g. `{primary_region: fsn1, regions: [{cloudRegion: fsn1}, {cloudRegion: ash}]}`) — `tofu output -json | jq .control_plane_ips_per_region` returns a 2-entry map with both region codes as keys. If one region fails to materialize at apply time, the catalyst-api fires PartialRegionMaterialisationError instead of marking the deployment ready.

Refs #2840

🤖 Generated with [Claude Code](https://claude.com/claude-code)