### PR TITLE
fix(catalyst-api): #2840 — normalise Hetzner per-region keys before partial-region detection

### DIFF
--- a/products/catalyst/bootstrap/api/internal/provisioner/partial_region_materialisation_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/partial_region_materialisation_test.go
@@ -187,3 +187,106 @@ func TestResult_MaterializedRegions_Exposed(t *testing.T) {
 		t.Errorf("missing set = %v, want [me-east-215-b]", declared)
 	}
 }
+
+// Test 7 (#2840-followup, 2026-06-03) — Hetzner key format pass-through
+// via normalisePerRegionKeys. Hetzner emits the per-region map keyed by
+// `<cloudRegion>-<index>` for secondaries + literal `primary` for the
+// primary CP; detectPartialRegionMaterialisation expects cloudRegion
+// keys. Verify the normaliser collapses both shapes correctly so a
+// healthy 3-region Hetzner prov is NOT mis-classified as fully-missing.
+func TestNormalisePerRegionKeys_HetznerThreeRegionHealthy(t *testing.T) {
+	declared := []RegionSpec{
+		{Provider: "hetzner", CloudRegion: "nbg1"},
+		{Provider: "hetzner", CloudRegion: "fsn1"},
+		{Provider: "hetzner", CloudRegion: "hel1"},
+	}
+	hetznerShape := map[string]string{
+		"primary": "100.100.100.10",
+		"fsn1-1":  "100.100.100.20",
+		"hel1-2":  "100.100.100.30",
+	}
+	normalised := normalisePerRegionKeys(declared, hetznerShape)
+	want := map[string]string{
+		"nbg1": "100.100.100.10",
+		"fsn1": "100.100.100.20",
+		"hel1": "100.100.100.30",
+	}
+	for k, v := range want {
+		if got := normalised[k]; got != v {
+			t.Errorf("normalised[%q] = %q, want %q", k, got, v)
+		}
+	}
+	// And the downstream detection must see ZERO missing.
+	materialised, missing := detectPartialRegionMaterialisation(declared, normalised)
+	if len(missing) != 0 {
+		t.Errorf("missing = %v, want empty (every declared region came up)", missing)
+	}
+	if len(materialised) != 3 {
+		t.Errorf("materialised = %v, want all 3 regions", materialised)
+	}
+}
+
+// Test 8 — Hetzner partial-region shape: primary + one secondary
+// materialised, second secondary missing. detection must name the
+// missing cloudRegion correctly even though the input keys carried
+// the suffixed Hetzner format.
+func TestNormalisePerRegionKeys_HetznerPartialThirdRegionMissing(t *testing.T) {
+	declared := []RegionSpec{
+		{Provider: "hetzner", CloudRegion: "nbg1"},
+		{Provider: "hetzner", CloudRegion: "fsn1"},
+		{Provider: "hetzner", CloudRegion: "hel1"},
+	}
+	hetznerShape := map[string]string{
+		"primary": "100.100.100.10",
+		"fsn1-1":  "100.100.100.20",
+		// hel1-2 deliberately missing (capacity cascade).
+	}
+	normalised := normalisePerRegionKeys(declared, hetznerShape)
+	_, missing := detectPartialRegionMaterialisation(declared, normalised)
+	if len(missing) != 1 || missing[0] != "hel1" {
+		t.Errorf("missing = %v, want [hel1]", missing)
+	}
+}
+
+// Test 9 — Same-region duplicates (legal Hetzner stacking): fsn1-mgmt
+// + fsn1-dataplane both materialised. Collapses to one fsn1 entry;
+// detection must treat declared duplicate as satisfied by the single
+// normalised entry (first-non-empty wins).
+func TestNormalisePerRegionKeys_HetznerSameRegionDuplicates(t *testing.T) {
+	declared := []RegionSpec{
+		{Provider: "hetzner", CloudRegion: "fsn1"},
+		{Provider: "hetzner", CloudRegion: "fsn1"},
+	}
+	hetznerShape := map[string]string{
+		"primary": "100.100.100.10",
+		"fsn1-1":  "100.100.100.20",
+	}
+	normalised := normalisePerRegionKeys(declared, hetznerShape)
+	if normalised["fsn1"] == "" {
+		t.Errorf("normalised[fsn1] should be non-empty, got %v", normalised)
+	}
+	_, missing := detectPartialRegionMaterialisation(declared, normalised)
+	if len(missing) != 0 {
+		t.Errorf("missing = %v, want empty (stacked duplicate counts as satisfied)", missing)
+	}
+}
+
+// Test 10 — Huawei pass-through: keys already in cloudRegion form; the
+// normaliser must not mangle them (no '-' suffix stripping, no
+// 'primary' remap when the key isn't literal 'primary').
+func TestNormalisePerRegionKeys_HuaweiPassThrough(t *testing.T) {
+	declared := []RegionSpec{
+		{Provider: "huawei", CloudRegion: "me-east-215-a"},
+		{Provider: "huawei", CloudRegion: "me-east-215-b"},
+	}
+	huaweiShape := map[string]string{
+		"me-east-215-a": "100.100.100.10",
+		"me-east-215-b": "100.100.100.20",
+	}
+	normalised := normalisePerRegionKeys(declared, huaweiShape)
+	for code, ip := range huaweiShape {
+		if got := normalised[code]; got != ip {
+			t.Errorf("normalised[%q] = %q, want %q (Huawei keys must pass through)", code, got, ip)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1201,6 +1201,63 @@ func (e *PartialRegionMaterialisationError) Error() string {
 // Request.Regions[] MUST have a corresponding entry in
 // control_plane_ips_per_region with a non-empty EIP. Anything less is
 // a partial-failure that breaks the topology promise.
+// normalisePerRegionKeys collapses the two on-the-wire shapes of
+// `control_plane_ips_per_region` into the cloudRegion-keyed shape that
+// detectPartialRegionMaterialisation expects:
+//
+//   - Huawei: keys are already cloudRegion (e.g. "me-east-215-a"); passed
+//     through unchanged.
+//   - Hetzner: keys are `<cloudRegion>-<index>` for secondaries (e.g.
+//     "fsn1-1", "hel1-2") + literal "primary" for the primary CP.
+//     "primary" is mapped to declaredRegions[0].CloudRegion; each
+//     suffixed key is mapped to the leading cloudRegion segment.
+//
+// Duplicate cloudRegions (legal Hetzner same-region-stacking case —
+// fsn1-mgmt + fsn1-dataplane) collapse with first-non-empty-wins so a
+// healthy stack reads as "materialised" without false-negative.
+// Empty-string values are skipped (an empty EIP is not a working CP).
+//
+// Pure function; safe to unit-test against literal maps. Refs #2840.
+func normalisePerRegionKeys(declaredRegions []RegionSpec, perRegion map[string]string) map[string]string {
+	if len(perRegion) == 0 {
+		return perRegion
+	}
+	out := make(map[string]string, len(perRegion))
+	primaryCode := ""
+	if len(declaredRegions) > 0 {
+		primaryCode = strings.TrimSpace(declaredRegions[0].CloudRegion)
+	}
+	for k, v := range perRegion {
+		if strings.TrimSpace(v) == "" {
+			continue
+		}
+		code := k
+		if k == "primary" && primaryCode != "" {
+			code = primaryCode
+		} else if idx := strings.LastIndexByte(k, '-'); idx > 0 {
+			// Hetzner secondaries: "<cloudRegion>-<index>" — strip the
+			// numeric trailing segment if it parses as an int. Keep the
+			// raw key when the suffix isn't numeric (defensive against
+			// future key formats).
+			suffix := k[idx+1:]
+			allDigit := suffix != ""
+			for _, r := range suffix {
+				if r < '0' || r > '9' {
+					allDigit = false
+					break
+				}
+			}
+			if allDigit {
+				code = k[:idx]
+			}
+		}
+		if existing, ok := out[code]; !ok || existing == "" {
+			out[code] = v
+		}
+	}
+	return out
+}
+
 func detectPartialRegionMaterialisation(declaredRegions []RegionSpec, perRegion map[string]string) (materialised []string, missing []string) {
 	materialised = make([]string, 0, len(perRegion))
 	declared := make(map[string]struct{}, len(declaredRegions))
@@ -1663,17 +1720,19 @@ func (p *Provisioner) Provision(ctx context.Context, req Request, events chan<- 
 	// Sovereign is single-region under the hood.
 	//
 	// Detection runs only when the operator declared >=2 regions AND
-	// the per-provider readback populated a per-region map. As of
-	// 2026-06-03 (#2840 follow-up) BOTH Huawei and Hetzner emit
-	// `control_plane_ips_per_region` keyed by the operator-supplied
-	// cloudRegion value (Hetzner used to expose a secondaries-only
-	// `_by_region` map that detection skipped silently — see
-	// infra/providers/hetzner/outputs.tf for the added parity output).
-	// When the post-condition fails we return a typed
-	// PartialRegionMaterialisationError carrying the partial Result —
-	// the handler stamps Deployment.status = "partial-failure" but
-	// does NOT auto-`tofu destroy`. The operator decides.
-	materialised, missing := detectPartialRegionMaterialisation(req.Regions, out.ControlPlaneIPsPerRegion)
+	// the per-provider readback populated a per-region map. Huawei
+	// emits `control_plane_ips_per_region` keyed by cloudRegion verbatim;
+	// Hetzner emits the same output name but keyed by `<cloudRegion>-<index>`
+	// for secondaries + literal `primary` for the primary CP (the
+	// same-region-duplicates test constraint — fsn1-mgmt + fsn1-dataplane
+	// are legal). normalisePerRegionKeys() collapses both shapes to the
+	// cloudRegion form before detection runs. When the post-condition
+	// fails we return a typed PartialRegionMaterialisationError carrying
+	// the partial Result — the handler stamps Deployment.status =
+	// "partial-failure" but does NOT auto-`tofu destroy`. The operator
+	// decides.
+	normalisedPerRegion := normalisePerRegionKeys(req.Regions, out.ControlPlaneIPsPerRegion)
+	materialised, missing := detectPartialRegionMaterialisation(req.Regions, normalisedPerRegion)
 	declared := make([]string, 0, len(req.Regions))
 	for _, r := range req.Regions {
 		if code := strings.TrimSpace(r.CloudRegion); code != "" {


### PR DESCRIPTION
## Critical follow-up to #2911 + #2916

PR #2911 added Hetzner's `control_plane_ips_per_region` output; #2916 re-keyed it to `<cloudRegion>-<index>` + literal `primary` to satisfy the same-region-duplicates contract.

But `detectPartialRegionMaterialisation` does:
```go
if ip, ok := perRegion[code]; ok && strings.TrimSpace(ip) != "" {
    materialised = append(materialised, code)
} else {
    missing = append(missing, code)
}
```

where `code = r.CloudRegion`. The lookup MISSES on Hetzner's new key shape — every declared cloudRegion evaluates as MISSING even on healthy provs → false-positive PartialRegionMaterialisationError → **blocks every multi-region Hetzner Sovereign from reaching ready**.

## Fix

New `normalisePerRegionKeys()` collapses both wire shapes to cloudRegion-keyed form before detection:

- `primary` → `declaredRegions[0].CloudRegion` (the canonical primary)
- `<cloudRegion>-<index>` → strip trailing numeric suffix
- Huawei keys (already cloudRegion form) pass through unchanged
- Duplicate cloudRegions: first-non-empty-wins (legal Hetzner stacking case)
- Empty IPs skipped (empty EIP ≠ working CP)

## Tests

4 new unit tests in `partial_region_materialisation_test.go`:
- `TestNormalisePerRegionKeys_HetznerThreeRegionHealthy`
- `TestNormalisePerRegionKeys_HetznerPartialThirdRegionMissing`
- `TestNormalisePerRegionKeys_HetznerSameRegionDuplicates`
- `TestNormalisePerRegionKeys_HuaweiPassThrough`

All 10 partial-region tests pass green.

Refs #2840

🤖 Generated with [Claude Code](https://claude.com/claude-code)