### PR TITLE
fix(cloud-init): #2922 PR-A — auto-enable bp-continuum on multi-region provs

### DIFF
--- a/infra/providers/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/providers/hetzner/cloudinit-control-plane.tftpl
@@ -552,6 +552,16 @@ write_files:
             # defaulted to instances=1 despite multi-region intent. Hetzner
             # template missed it too; this fix lockstep-adds.
             SOVEREIGN_CNPG_INSTANCES: "${sovereign_cnpg_instances}"
+            # #2922 (2026-06-03): auto-enable bp-continuum (slot 62) on
+            # multi-region Sovereigns so the DR orchestrator + Continuum
+            # CR ship live by default. Single-region keeps `false` (the
+            # admission gate at catalyst-api Validate() already rejects
+            # bcpTopology=active-hot-standby + len(regions)<2). Closes
+            # #2840 acceptance criterion #3 on the substrate side; the
+            # bp-continuum chart's prerequisite guard (PR-B of #2922,
+            # still pending) protects against operator-overlay flips
+            # without bp-cnpg-pair installed.
+            CONTINUUM_ENABLED: "${continuum_enabled}"
             CLUSTER_MESH_NAME: "${cluster_mesh_name}"
             CLUSTER_MESH_ID: "${cluster_mesh_id}"
             # 2026-05-15 DoD A3 wiring: bp-cilium chart defaults

--- a/infra/providers/hetzner/main.tf
+++ b/infra/providers/hetzner/main.tf
@@ -717,6 +717,12 @@ locals {
     # `SOVEREIGN_CNPG_INSTANCES: "$${sovereign_cnpg_instances}"` —
     # see cloudinit-control-plane.tftpl PR-companion to this var.
     sovereign_cnpg_instances = length(var.regions) > 1 ? "2" : "1"
+    # #2922 (2026-06-03): auto-enable bp-continuum when multi-region.
+    # Single-region keeps "false" (admission gate already rejects
+    # bcpTopology=active-hot-standby + len(regions)<2 at the
+    # catalyst-api boundary). bp-continuum chart's prerequisite guard
+    # (PR-B of #2922, pending) protects against premature flip.
+    continuum_enabled = length(var.regions) > 1 ? "true" : "false"
 
     # Multi-domain Sovereign (issue #827). When the wizard supplies an
     # explicit parent-domain list, use it verbatim. Otherwise default to a
@@ -1403,6 +1409,12 @@ locals {
       # ARE multi-region by construction at this point), `1` for
       # singleton (never reached on secondary path, defensive default).
       sovereign_cnpg_instances = length(var.regions) > 1 ? "2" : "1"
+    # #2922 (2026-06-03): auto-enable bp-continuum when multi-region.
+    # Single-region keeps "false" (admission gate already rejects
+    # bcpTopology=active-hot-standby + len(regions)<2 at the
+    # catalyst-api boundary). bp-continuum chart's prerequisite guard
+    # (PR-B of #2922, pending) protects against premature flip.
+    continuum_enabled = length(var.regions) > 1 ? "true" : "false"
     }), "/(?m)^[ ]*#( |$).*\n/", "")
   }
 

--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -624,6 +624,14 @@ write_files:
             # creation (true BCP cross-region failover) is a separate
             # application-controller workstream tracked in #2634.
             SOVEREIGN_CNPG_INSTANCES: "${sovereign_cnpg_instances}"
+            # #2922 (2026-06-03): auto-enable bp-continuum (slot 62) on
+            # multi-region Sovereigns so the DR orchestrator + Continuum
+            # CR ship live by default. Single-region keeps `false`
+            # (admission gate already rejects active-hot-standby +
+            # len(regions)<2 at the catalyst-api boundary). Mirrors
+            # Hetzner cloud-init template equivalent. Closes #2840
+            # acceptance criterion #3 on the substrate side.
+            CONTINUUM_ENABLED: "${continuum_enabled}"
             # Refs #2535 — G4: Cilium ClusterMesh peer anchors. The
             # 01-cilium.yaml HelmRelease reads these via the bootstrap-kit
             # Kustomization's `cluster.name=$${CLUSTER_MESH_NAME:=}` +

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -693,6 +693,9 @@ locals {
       # across-regions affinity. Single-region keeps the existing
       # instances=1 default.
       sovereign_cnpg_instances = length(var.regions) > 1 ? "2" : "1"
+      # #2922 (2026-06-03): auto-enable bp-continuum on multi-region.
+      # Single-region keeps "false". Mirrors Hetzner main.tf equivalent.
+      continuum_enabled = length(var.regions) > 1 ? "true" : "false"
       # Primary CP's EIP — Wave 5.8 (Refs #2140). The kubeconfig PUT-back
       # from cloud-init must use this EIP, not the private VPC IP, so the
       # remote mothership (cross-cloud Contabo) can reach the new


### PR DESCRIPTION
## Closes #2840 AC#3 substrate-side

#2840 acceptance criterion #3: 'bp-continuum HelmRelease is rendered with enabled: true'. Pre-this-PR no Sovereign (Hetzner or Huawei) emitted CONTINUUM_ENABLED in its bootstrap-kit substitute map; the slot default `${CONTINUUM_ENABLED:-false}` ALWAYS won.

## Fix

Both cloud-init templates (`infra/providers/{hetzner,huawei}/cloudinit-control-plane.tftpl`) now thread `continuum_enabled` via templatefile() vars derived from `length(var.regions)`:
- `len > 1` → "true" (multi-region active-hot-standby/active-active by construction)
- `len = 1` → "false" (catalyst-api Validate() admission gate rejects active-hot-standby + len<2 already)

## Defense-in-depth still pending (PR-B of #2922)

bp-continuum chart prerequisite guard — Ready=False with reason=PrerequisitesMissing when CNPG ClusterPair CRs absent. Until PR-B ships, the chart's own `continuum.enabled: false` values default IS the backstop (see `62-bp-continuum.yaml:148-151` comment).

## Verification

```
$ tofu -chdir=infra/providers/hetzner test
Success! 10 passed, 0 failed.

$ tofu -chdir=infra/providers/huawei test
Success! 3 passed, 0 failed.
```

Refs #2922 #2840

🤖 Generated with [Claude Code](https://claude.com/claude-code)