### PR TITLE
fix(continuum): #2922 PR-B — prerequisite-check initContainer guards against missing bp-cnpg-pair

### DIFF
--- a/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+++ b/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
@@ -115,12 +115,19 @@ spec:
       # failed the hollow-chart guard at the "Verify upstream subcharts
       # present in working tree" step (Chart.yaml had NO dependencies
       # and lacked the catalyst.openova.io/no-upstream annotation).
+      # 0.1.3 (#2922 PR-B, 2026-06-03): adds prerequisite-check
+      # initContainer that probes for bp-cnpg-pair (audit ConfigMap
+      # label catalyst.openova.io/audit-config=true). If absent it
+      # sleeps + exits non-zero with a clear log line so `kubectl
+      # logs` surfaces the missing Pillar-3 prerequisite instead of
+      # a controller crash. Pairs with PR #2923 cloud-init auto-emit
+      # of CONTINUUM_ENABLED on multi-region.
       # 0.1.2 adds the no-upstream opt-out + a fresh version bump to
       # force a re-publish. Pin moves in lockstep per Inviolable
       # Principle #13 (chart-pin bumps must match a GHCR tag that
       # exists — verified post-merge via crane manifest before any
       # fresh-prov walk).
-      version: 0.1.2
+      version: 0.1.3
       sourceRef:
         kind: HelmRepository
         name: bp-continuum

--- a/products/continuum/chart/Chart.yaml
+++ b/products/continuum/chart/Chart.yaml
@@ -7,6 +7,23 @@ description: |
   switchover sequence). Slice K-Cont-1 of EPIC-6 (#1101) ships the
   product skeleton; K-Cont-2 fills the reconcile loop.
 type: application
+# 0.1.3 (#2922 PR-B, 2026-06-03): prerequisite-check initContainer.
+# bp-continuum's reconcile loop assumes bp-cnpg-pair has been
+# installed (Pillar-3 acceptance criterion #1 of #2840). If an
+# operator overlay flips continuum.enabled=true without bp-cnpg-pair,
+# the controller would crash on missing CNPG Cluster CR pairs. New
+# initContainer probes for bp-cnpg-pair's audit ConfigMap (label
+# catalyst.openova.io/audit-config=true) cluster-wide; if absent it
+# sleeps 5 min + exits non-zero with a clear log line so `kubectl
+# logs` surfaces the missing prerequisite instead of a confusing
+# controller stack trace. Pairs with PR #2923 (cloud-init auto-emit
+# of CONTINUUM_ENABLED on multi-region) — fresh multi-region provs
+# that DO have bp-cnpg-pair installed pass through immediately.
+# Operators can disable the guard via
+# .Values.continuum.prerequisiteCheck.enabled=false (e.g. for
+# chart unit tests or air-gapped offline evaluation). Pure additive
+# template; no values-default change for existing consumers.
+# Refs #2922 #2840.
 # 0.1.2 (TBD-V34, 2026-05-20): re-publish after PR #2072's Blueprint
 # Release run (#26144858280) failed the hollow-chart guard. 0.1.1 was
 # tagged in-tree but never landed in GHCR because this chart declares
@@ -22,7 +39,7 @@ type: application
 # 0.1.0 sat in-tree without a bootstrap-kit slot to pin it, so the
 # blueprint-release workflow's `detect changed paths` step never had
 # reason to re-run and the chart was never pushed to GHCR.
-version: 0.1.2
+version: 0.1.3
 appVersion: "0.1.0"
 home: https://openova.io
 sources:

--- a/products/continuum/chart/templates/deployment.yaml
+++ b/products/continuum/chart/templates/deployment.yaml
@@ -35,6 +35,37 @@ spec:
         runAsGroup: 65534
         seccompProfile:
           type: RuntimeDefault
+      {{- if .Values.continuum.prerequisiteCheck.enabled }}
+      # #2922 PR-B prerequisite-guard initContainer — see values.yaml
+      # comment block on continuum.prerequisiteCheck for full rationale.
+      initContainers:
+        - name: prerequisite-check
+          image: {{ .Values.continuum.prerequisiteCheck.image | default "harbor.openova.io/proxy-dockerhub/alpine/k8s:1.30.0" | quote }}
+          imagePullPolicy: {{ .Values.continuum.image.pullPolicy | default "IfNotPresent" }}
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              echo "[prerequisite-check] probing for bp-cnpg-pair audit ConfigMap cluster-wide..."
+              pair_count="$(kubectl get cm -A -l catalyst.openova.io/audit-config=true --no-headers 2>/dev/null | wc -l)"
+              if [ "$pair_count" -eq 0 ]; then
+                echo "[prerequisite-check] FAIL: no bp-cnpg-pair installation detected."
+                echo "[prerequisite-check] bp-continuum reconcile loop requires bp-cnpg-pair (Pillar-3 #2840 AC#1)."
+                echo "[prerequisite-check] Either install bp-cnpg-pair OR set continuum.enabled=false."
+                echo "[prerequisite-check] Sleeping 5 min before retry (operator can scale Deployment to 0 to silence)."
+                sleep 300
+                exit 1
+              fi
+              echo "[prerequisite-check] PASS: found $pair_count bp-cnpg-pair installation(s); main container will start."
+          resources:
+            {{- toYaml (.Values.continuum.prerequisiteCheck.resources | default (dict "requests" (dict "cpu" "10m" "memory" "32Mi") "limits" (dict "cpu" "100m" "memory" "64Mi"))) | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      {{- end }}
       containers:
         - name: controller
           image: {{ include "continuum.image" (dict "root" .) | quote }}

--- a/products/continuum/chart/values.yaml
+++ b/products/continuum/chart/values.yaml
@@ -45,6 +45,28 @@ continuum:
   leaderElection:
     enabled: true
 
+  # G117.pillar-3-followup #2922 PR-B (2026-06-03): init container
+  # probe that asserts bp-cnpg-pair is installed BEFORE the main
+  # controller starts. Without bp-cnpg-pair the reconcile loop has no
+  # CNPG cluster pair to switch over → controller crash-loops on
+  # missing CRs. The probe sleeps + exits non-zero with a clear log
+  # line when prerequisites are missing, so `kubectl logs` surfaces
+  # the gap instead of a confusing controller stack trace. Operators
+  # CAN disable this guard via prerequisiteCheck.enabled=false (e.g.
+  # for chart unit tests or air-gapped offline reconcile evaluation).
+  prerequisiteCheck:
+    enabled: true
+    # Default image carries kubectl + sh — overridable for air-gapped
+    # mirrors with stricter image-source policies.
+    image: harbor.openova.io/proxy-dockerhub/alpine/k8s:1.30.0
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
Completes the #2922 2-PR sequence. PR #2923 auto-enabled bp-continuum on multi-region provs; PR-B guards against operator-overlay flips without bp-cnpg-pair installed.

Implementation:
- bp-continuum 0.1.2 → 0.1.3
- New initContainer probes for cluster-wide ConfigMaps labeled `catalyst.openova.io/audit-config=true` (emitted by bp-cnpg-pair's audit-config.yaml).
- If absent: sleeps 5 min + exits non-zero with clear log line so `kubectl logs` surfaces the gap.
- Existing ClusterRole already covers cluster-wide `configmaps:list`.
- Opt-out via `continuum.prerequisiteCheck.enabled=false`.

Render verified for both states (guard-on shows initContainer + 7 prerequisite-check refs; guard-off shows 0).

Refs #2922 #2840