### PR TITLE
fix(catalyst-chart): #2744 — catalog-seed lockstep CI guard + 6 caught drifts

### DIFF
--- a/.github/workflows/check-catalog-seed-lockstep.yaml
+++ b/.github/workflows/check-catalog-seed-lockstep.yaml
@@ -1,0 +1,46 @@
+name: catalog-seed lockstep guard
+
+# Asserts that every chart-seed Blueprint with a platform/<name>/blueprint.yaml
+# source declares matching topology.supported[], endpoints[].name[], and
+# sso.realm fields. The chart-seed is the in-cluster fallback path when
+# bp-catalog-client cannot reach the gitea catalog-sovereign repo (404).
+# Drift here silently breaks the Launch button on the affected Blueprint
+# under that fallback path.
+#
+# See scripts/check-catalog-seed-lockstep.sh for the check + the 14/14
+# initial lockstep sweep (PRs #2906-#2909 + #2883-#2905).
+#
+# Refs G117 #2744.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'products/catalyst/chart/templates/catalog-seed/blueprints.yaml'
+      - 'platform/**/blueprint.yaml'
+      - 'scripts/check-catalog-seed-lockstep.sh'
+      - '.github/workflows/check-catalog-seed-lockstep.yaml'
+  pull_request:
+    paths:
+      - 'products/catalyst/chart/templates/catalog-seed/blueprints.yaml'
+      - 'platform/**/blueprint.yaml'
+      - 'scripts/check-catalog-seed-lockstep.sh'
+      - '.github/workflows/check-catalog-seed-lockstep.yaml'
+  workflow_dispatch:
+
+jobs:
+  lockstep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install yq + helm
+        run: |
+          set -e
+          # yq v4 (mikefarah/yq) — the lockstep script uses v4 syntax.
+          sudo wget -q https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64 -O /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+          # helm is pre-installed on ubuntu-latest runners, but be defensive.
+          helm version --short || curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+      - name: Run catalog-seed lockstep check
+        run: bash scripts/check-catalog-seed-lockstep.sh

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -108,7 +108,7 @@ spec:
       launchDefault: true
       ssoEnabled: true
   sso:
-    realm: sovereign
+    realm: "{{ "{{" }}.OrgSlug{{ "}}" }}"
     protocolMapper: oidc
     silentLogin: true
   multiInstance:
@@ -272,12 +272,12 @@ spec:
   # K-Cont-2 (operator-triggered promotion).
   topology:
     supported:
-      - active-passive
+      - active-hot-standby
     defaults:
-      multi-region: active-passive
-      single-region: active-passive
+      multi-region: active-hot-standby
+      single-region: active-hot-standby
     perTopology:
-      active-passive:
+      active-hot-standby:
         replication:
           backend: cnpg-streaming-replication
           mode: async
@@ -979,7 +979,7 @@ spec:
       launchDefault: true
       ssoEnabled: true
   sso:
-    realm: sovereign
+    realm: "{{ "{{" }}.OrgSlug{{ "}}" }}"
     protocolMapper: oidc
     silentLogin: true
   configSchema:
@@ -1069,7 +1069,7 @@ spec:
       launchDefault: true
       ssoEnabled: true
   sso:
-    realm: sovereign
+    realm: "{{ "{{" }}.OrgSlug{{ "}}" }}"
     protocolMapper: oidc
     silentLogin: true
   configSchema:
@@ -1246,7 +1246,7 @@ spec:
       launchDefault: true
       ssoEnabled: true
   sso:
-    realm: sovereign
+    realm: "{{ "{{" }}.OrgSlug{{ "}}" }}"
     protocolMapper: oidc
     silentLogin: true
   configSchema:
@@ -1329,7 +1329,7 @@ spec:
       launchDefault: true
       ssoEnabled: true
   sso:
-    realm: sovereign
+    realm: "{{ "{{" }}.OrgSlug{{ "}}" }}"
     protocolMapper: oidc
     silentLogin: true
   configSchema:

--- a/scripts/check-catalog-seed-lockstep.sh
+++ b/scripts/check-catalog-seed-lockstep.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# scripts/check-catalog-seed-lockstep.sh
+#
+# G117 #2744 lockstep guard — asserts that every Blueprint in
+# products/catalyst/chart/templates/catalog-seed/blueprints.yaml that
+# has a corresponding platform/<name>/blueprint.yaml source declares
+# matching topology.supported[] + endpoints[].name[] + sso.realm
+# fields.
+#
+# Why: the catalog-seed is the in-cluster fallback path the bp-catalog-
+# client uses when the gitea catalog-sovereign repo 404s. The 14/14
+# lockstep sweep (PRs #2906-#2909 + #2883-#2905) brought every chart-
+# seed entry into alignment with its platform/ source. Without this
+# guard, the NEXT edit to either side can drift undetected — a missing
+# endpoints[] entry on the chart-seed silently breaks the Launch
+# button on that Blueprint when gitea is unreachable.
+#
+# Exit codes:
+#   0 — every chart-seed entry with a platform/ source matches
+#   1 — at least one drift detected (output names which Blueprint +
+#       which field)
+#   2 — missing required tool (yq) or input files
+#
+# Usage:
+#   ./scripts/check-catalog-seed-lockstep.sh
+#
+# CI integration: invoked by .github/workflows/check-catalog-seed-lockstep.yaml
+# on every push/PR touching either tree.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CHART_SEED="${REPO_ROOT}/products/catalyst/chart/templates/catalog-seed/blueprints.yaml"
+PLATFORM_DIR="${REPO_ROOT}/platform"
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "ERROR: yq not installed (apt-get install yq OR brew install yq)" >&2
+  exit 2
+fi
+if [ ! -f "$CHART_SEED" ]; then
+  echo "ERROR: chart-seed not found at $CHART_SEED" >&2
+  exit 2
+fi
+
+helm="${HELM_BIN:-helm}"
+if ! command -v "$helm" >/dev/null 2>&1; then
+  echo "ERROR: helm not installed" >&2
+  exit 2
+fi
+
+# Render the chart-seed via helm so the {{ "{{" }} escape tokens collapse
+# to literal {{ ... }} runtime placeholders (the same shape consumers
+# read). We isolate the catalog-seed/blueprints.yaml output.
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+( cd "${REPO_ROOT}/products/catalyst/chart" && "$helm" template . --show-only templates/catalog-seed/blueprints.yaml ) > "$TMP/rendered.yaml"
+
+# Split rendered docs on `---` and iterate.
+fail=0
+checked=0
+skipped_no_source=0
+
+# Use yq to extract each Blueprint's name; iterate.
+bp_names="$(yq eval-all 'select(.kind == "Blueprint") | .metadata.name' "$TMP/rendered.yaml" | sort -u)"
+for bp_name in $bp_names; do
+  bp_short="${bp_name#bp-}"
+  source_file="${PLATFORM_DIR}/${bp_short}/blueprint.yaml"
+  if [ ! -f "$source_file" ]; then
+    skipped_no_source=$((skipped_no_source + 1))
+    continue
+  fi
+  checked=$((checked + 1))
+
+  # Extract topology.supported[] from BOTH sides + compare sorted.
+  seed_topo="$(yq eval-all "select(.kind == \"Blueprint\" and .metadata.name == \"$bp_name\") | .spec.topology.supported[]?" "$TMP/rendered.yaml" 2>/dev/null | sort -u || true)"
+  src_topo="$(yq eval '.spec.topology.supported[]?' "$source_file" 2>/dev/null | sort -u || true)"
+  if [ -n "$src_topo" ] && [ "$seed_topo" != "$src_topo" ]; then
+    echo "DRIFT: $bp_name topology.supported[]:"
+    echo "  chart-seed: $(echo "$seed_topo" | tr '\n' ',' | sed 's/,$//')"
+    echo "  platform/ : $(echo "$src_topo" | tr '\n' ',' | sed 's/,$//')"
+    fail=1
+  fi
+
+  # Extract endpoints[].name + ssoEnabled status (where applicable).
+  seed_eps="$(yq eval-all "select(.kind == \"Blueprint\" and .metadata.name == \"$bp_name\") | .spec.endpoints[]?.name" "$TMP/rendered.yaml" 2>/dev/null | sort -u || true)"
+  src_eps="$(yq eval '.spec.endpoints[]?.name' "$source_file" 2>/dev/null | sort -u || true)"
+  if [ "$seed_eps" != "$src_eps" ]; then
+    echo "DRIFT: $bp_name endpoints[].name:"
+    echo "  chart-seed: $(echo "$seed_eps" | tr '\n' ',' | sed 's/,$//')"
+    echo "  platform/ : $(echo "$src_eps" | tr '\n' ',' | sed 's/,$//')"
+    fail=1
+  fi
+
+  # Extract sso.realm (presence + value) — both empty = OK; one-side-only = drift.
+  seed_realm="$(yq eval-all "select(.kind == \"Blueprint\" and .metadata.name == \"$bp_name\") | .spec.sso.realm // \"\"" "$TMP/rendered.yaml" 2>/dev/null || true)"
+  src_realm="$(yq eval '.spec.sso.realm // ""' "$source_file" 2>/dev/null || true)"
+  if [ "$seed_realm" != "$src_realm" ]; then
+    echo "DRIFT: $bp_name sso.realm:"
+    echo "  chart-seed: '$seed_realm'"
+    echo "  platform/ : '$src_realm'"
+    fail=1
+  fi
+done
+
+echo
+echo "── Summary ──"
+echo "checked: $checked   skipped (no platform/ source): $skipped_no_source   fail: $fail"
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "Drift detected. Either:"
+  echo "  - update products/catalyst/chart/templates/catalog-seed/blueprints.yaml to match platform/<bp>/blueprint.yaml, OR"
+  echo "  - update platform/<bp>/blueprint.yaml to match the chart-seed entry."
+  echo "The chart-seed is the in-cluster fallback path when gitea catalog-sovereign 404s — keeping them aligned is the contract."
+  exit 1
+fi
+echo "PASS: every chart-seed Blueprint with a platform/ source declares matching topology + endpoints + sso fields."


### PR DESCRIPTION
Adds a CI-level lockstep guard for the chart-seed Blueprint catalog AND fixes the 6 real drifts the new check immediately caught from the 14/14 lockstep sweep.

**Guard**: `scripts/check-catalog-seed-lockstep.sh` + `.github/workflows/check-catalog-seed-lockstep.yaml` — asserts every chart-seed Blueprint with a `platform/<name>/blueprint.yaml` source declares matching `topology.supported[]` + `endpoints[].name[]` + `sso.realm` fields. Triggers on chart-seed + platform/`blueprint.yaml` edits.

**Drifts fixed**:
1. bp-cnpg-pair: `topology.supported=active-passive` → `active-hot-standby` (matches platform source).
2-6. bp-wordpress-tenant + bp-opensearch + bp-temporal + bp-langfuse + bp-llm-gateway: `sso.realm=sovereign` → `'{{.OrgSlug}}'` (Tier-3 per-Org apps — the chart-seed value was wrong, would have broken per-Org isolation under the gitea-fallback path).

Post-fix script output:
```
checked: 11   skipped (no platform/ source): 4   fail: 0
PASS
```

Refs #2744

🤖 Generated with [Claude Code](https://claude.com/claude-code)