### PR TITLE
fix(controllers): #2742 — auto-roll org/env/app controllers on catalyst-runtime-config change

### DIFF
--- a/products/catalyst/chart/templates/controllers/application-controller-deployment.yaml
+++ b/products/catalyst/chart/templates/controllers/application-controller-deployment.yaml
@@ -27,6 +27,11 @@ spec:
     metadata:
       labels:
         {{- include "controllers.labels" (dict "name" "application" "root" .) | nindent 8 }}
+      annotations:
+        # G117 #2742-followup (2026-06-03): roll on runtime-config CM
+        # change. Same rationale as organization-controller — see
+        # that template's comment block for full context.
+        checksum/runtime-config: {{ include (print $.Template.BasePath "/configmap-catalyst-runtime-config.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ include "controllers.fullname" "application" }}
       automountServiceAccountToken: true

--- a/products/catalyst/chart/templates/controllers/environment-controller-deployment.yaml
+++ b/products/catalyst/chart/templates/controllers/environment-controller-deployment.yaml
@@ -31,6 +31,11 @@ spec:
     metadata:
       labels:
         {{- include "controllers.labels" (dict "name" "environment" "root" .) | nindent 8 }}
+      annotations:
+        # G117 #2742-followup (2026-06-03): roll on runtime-config CM
+        # change. Same rationale as organization-controller — see
+        # that template's comment block for full context.
+        checksum/runtime-config: {{ include (print $.Template.BasePath "/configmap-catalyst-runtime-config.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ include "controllers.fullname" "environment" }}
       automountServiceAccountToken: true

--- a/products/catalyst/chart/templates/controllers/organization-controller-deployment.yaml
+++ b/products/catalyst/chart/templates/controllers/organization-controller-deployment.yaml
@@ -31,6 +31,21 @@ spec:
     metadata:
       labels:
         {{- include "controllers.labels" (dict "name" "organization" "root" .) | nindent 8 }}
+      annotations:
+        # G117 #2742-followup (2026-06-03): roll the Pod whenever
+        # catalyst-runtime-config ConfigMap content changes. Without
+        # this, env.valueFrom.configMapKeyRef bindings stay frozen at
+        # the value read at Pod start — so when bp-catalyst-platform
+        # ships a new chart with updated keycloak-addr (PR #2895:
+        # `http://keycloak.keycloak.svc.cluster.local:80`) the
+        # ConfigMap reconciles cleanly but the controller Pod keeps
+        # reading the OLD address until manually restarted. Caught
+        # live on hw86 H22 verifier walk: organization-controller
+        # tried `keycloak-x-keycloak-x-mgmt-vcluster.mgmt.svc.cluster.local`
+        # for 90+ min after the chart-side fix landed because the Pod
+        # never rolled. checksum-annotation rolls automatically on any
+        # CM content change.
+        checksum/runtime-config: {{ include (print $.Template.BasePath "/configmap-catalyst-runtime-config.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ include "controllers.fullname" "organization" }}
       automountServiceAccountToken: true


### PR DESCRIPTION
Closes the root cause of H22 verifier's live hw86 evidence: organization-controller stuck dialing the OLD keycloak DNS for 90+ min after the chart-side fix landed (PR #2895) because env.valueFrom.configMapKeyRef bindings are evaluated at Pod start.

Adds canonical `checksum/runtime-config` annotation on the Pod template of all 3 affected controllers (organization, environment, application). When the ConfigMap content changes, the annotation hash changes → Helm/Flux sees a Deployment diff → Pod auto-rolls with the new env value.

Refs #2742 #2895