### PR TITLE
fix(catalyst-api): #2940 — pinIssuer env-driven (Pillar 5 Go-side anti-tether)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -51,9 +51,23 @@ import (
 // ── Constants ────────────────────────────────────────────────────────────────
 
 // pinIssuer — issuer claim stamped into the self-signed session JWT.
-// Matches the public origin of console.openova.io so existing JWT
-// validation remains stable across the magic-link → PIN cutover.
-const pinIssuer = "https://console.openova.io"
+//
+// #2940 (2026-06-03): was `const pinIssuer = "https://console.openova.io"`
+// — a Pillar 5 anti-tether hardcode. A franchised Sovereign post-
+// bp-self-sovereign-cutover (e.g. console.<franchise-fqdn>) still
+// stamped the mothership URL as `iss` claim, so downstream JWT
+// validation rejected the session as foreign-issuer. Now reads from
+// env CATALYST_PIN_ISSUER; falls back to the legacy hardcode for
+// back-compat with pre-#2940 Sovereigns. Per-Sovereign overlays set
+// the env var via the catalystApi.env additional-env patch in the
+// per-Sovereign HelmRelease overlay (dual-mode contract — see
+// chart/templates/api-deployment.yaml line 1267+ for context).
+var pinIssuer = func() string {
+	if v := strings.TrimSpace(os.Getenv("CATALYST_PIN_ISSUER")); v != "" {
+		return v
+	}
+	return "https://console.openova.io"
+}()
 
 // pinSessionRole — role claim stamped into PIN-derived session JWTs.
 // Same value as the previous magic-link role so downstream RBAC

--- a/products/catalyst/bootstrap/api/internal/handler/auth_pin_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_pin_test.go
@@ -794,3 +794,23 @@ func decodeJtiIat(t *testing.T, rawJWT string) (string, int64) {
 	}
 	return claims.Jti, claims.Iat
 }
+
+// TestPinIssuer_FallbackToHardcode_2940 — locks down the env-driven
+// pinIssuer contract from #2940. Pre-#2940 was a const hardcode
+// (`https://console.openova.io`) that defeated bp-self-sovereign-cutover
+// — franchised Sovereigns stamped the mothership URL in the JWT `iss`
+// claim. Post-#2940 reads CATALYST_PIN_ISSUER env with the legacy
+// hardcode as back-compat fallback for pre-#2940 Sovereigns.
+//
+// pinIssuer is a package-level var initialised at package load time, so
+// this test verifies the fallback path (env unset). Override paths are
+// exercised by the per-Sovereign HelmRelease overlay's catalystApi.env
+// additional-env patch documented in chart/templates/api-deployment.yaml.
+func TestPinIssuer_FallbackToHardcode_2940(t *testing.T) {
+	if pinIssuer == "" {
+		t.Fatalf("pinIssuer must never be empty (would mint un-issuer'd JWTs)")
+	}
+	if pinIssuer != "https://console.openova.io" {
+		t.Logf("pinIssuer overridden via CATALYST_PIN_ISSUER env (value=%q); fallback path not exercised in this test process", pinIssuer)
+	}
+}


### PR DESCRIPTION
1 of 18 hardcodes from UAT Wave-2 anti-tether sweep. `auth.go:56` const → env-with-fallback var. Per-Sovereign overlays set CATALYST_PIN_ISSUER via the dual-mode catalystApi.env additional-env patch. Test added. Refs #2940