### PR TITLE
fix(huawei-tofu): #2940 — PDNS_API_HOST cloud-init var (anti-tether)

### DIFF
--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -573,7 +573,12 @@ write_files:
             # pdns.openova.io → 212.72.24.20). Keeping the URL as the
             # canonical pdns.openova.io preserves TLS cert validation;
             # bastion's nginx SNI-proxy passes through the real cert.
-            PDNS_API_HOST: "https://pdns.openova.io"
+            #
+            # #2940 (2026-06-03): tofu var override hook. Operators of
+            # franchised Sovereigns post-cutover need to repoint at
+            # their own PDNS host. Default keeps the mothership URL
+            # for back-compat with pre-cutover provs.
+            PDNS_API_HOST: "${pdns_api_host}"
             PARENT_DOMAINS_YAML: |
               ${parent_domains_yaml}
             # Wave 5.24 (Refs #2163) — cilium k8sServiceHost must be the

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -637,6 +637,8 @@ locals {
       deployment_id       = var.deployment_id
       org_name            = var.org_name
       org_email           = var.org_email
+      # #2940 (2026-06-03): per-Sovereign PDNS endpoint override.
+      pdns_api_host = var.pdns_api_host
       # Refs #2533 — G1: per-CP region (was always var.regions[0].code,
       # baking primary's region into EVERY CP's cloud-init).
       region                = r.code

--- a/infra/providers/huawei/variables.tf
+++ b/infra/providers/huawei/variables.tf
@@ -29,6 +29,16 @@ variable "sovereign_fqdn" {
   }
 }
 
+# #2940 (2026-06-03): per-Sovereign PowerDNS API endpoint override.
+# Default keeps the mothership URL for back-compat with pre-cutover
+# provs. Franchised Sovereigns set this in tofu.auto.tfvars.json to
+# their post-cutover local PDNS hostname.
+variable "pdns_api_host" {
+  type        = string
+  default     = "https://pdns.openova.io"
+  description = "PowerDNS API endpoint URL. Mothership default; franchised Sovereigns override post-cutover."
+}
+
 variable "regions" {
   type = list(object({
     code               = string


### PR DESCRIPTION
Closes Category 5 of UAT Wave-2 anti-tether sweep. New tofu var pdns_api_host (default mothership for back-compat). Tests 3/3 green. Refs #2940