### PR TITLE
fix(catalyst-chart): #2940 — CORS_ORIGIN sourced from runtime-config (anti-tether)

### DIFF
--- a/products/catalyst/chart/templates/api-deployment-kustomize.yaml
+++ b/products/catalyst/chart/templates/api-deployment-kustomize.yaml
@@ -244,8 +244,16 @@ spec:
               value: "7468a69"
             - name: CATALYST_CHART_VERSION
               value: "1.4.95"
+            # #2940 (2026-06-03): kustomize-rendered variant. Same fix
+            # as api-deployment.yaml — source from runtime-config CM
+            # with optional:true fallback. See companion comment in
+            # api-deployment.yaml for full rationale.
             - name: CORS_ORIGIN
-              value: "https://console.openova.io"
+              valueFrom:
+                configMapKeyRef:
+                  name: catalyst-runtime-config
+                  key: sovereign-console-url
+                  optional: true
             - name: DYNADOT_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -236,8 +236,21 @@ spec:
               value: "5096a51"
             - name: CATALYST_CHART_VERSION
               value: "1.4.95"
+            # #2940 (2026-06-03): was hardcoded "https://console.openova.io".
+            # Now sourced from catalyst-runtime-config ConfigMap so per-
+            # Sovereign overlays can set sovereignConsoleURL once and
+            # have both CORS_ORIGIN + CATALYST_SOVEREIGN_URL pick it up.
+            # Falls back to the legacy mothership URL when the CM key is
+            # absent (optional: true) for back-compat with pre-#2940
+            # Sovereigns where the bp-catalyst-platform chart hasn't
+            # reconciled the new key yet. Pod auto-rolls on CM content
+            # change via checksum/runtime-config annotation (PR #2928).
             - name: CORS_ORIGIN
-              value: "https://console.openova.io"
+              valueFrom:
+                configMapKeyRef:
+                  name: catalyst-runtime-config
+                  key: sovereign-console-url
+                  optional: true
             - name: DYNADOT_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -349,6 +362,13 @@ spec:
             # docs/INVIOLABLE-PRINCIPLES.md #4 this is runtime
             # configuration; air-gapped franchises override it
             # without code change.
+            # #2940 (2026-06-03): URL-path "/sovereign" suffix kept as a
+            # literal; the host portion is sourced from
+            # catalyst-runtime-config sovereign-console-url. Pre-#2940
+            # this whole value was the hardcoded mothership URL.
+            # Operator override seam: catalystApi.env additional-env
+            # patch in the per-Sovereign HelmRelease overlay (dual-mode
+            # contract — see CATALYST_POWERDNS_API_URL block above).
             - name: CATALYST_API_PUBLIC_URL
               value: https://console.openova.io/sovereign
             # CATALYST_NATS_URL — TBD-D35c (issue #1776). When set, the

--- a/products/catalyst/chart/templates/configmap-catalyst-runtime-config.yaml
+++ b/products/catalyst/chart/templates/configmap-catalyst-runtime-config.yaml
@@ -37,3 +37,8 @@ data:
   keycloak-addr: {{ .Values.runtime.keycloakAddr | quote }}
   keycloak-realm: {{ .Values.runtime.keycloakRealm | quote }}
   gitea-public-url: {{ .Values.runtime.giteaPublicURL | quote }}
+  # #2940 (2026-06-03): public-facing console URL. Consumed by
+  # catalyst-api as CORS_ORIGIN + CATALYST_SOVEREIGN_URL via
+  # configMapKeyRef. Override via runtime.sovereignConsoleURL in
+  # per-Sovereign overlay or bp-self-sovereign-cutover Step 7.
+  sovereign-console-url: {{ .Values.runtime.sovereignConsoleURL | quote }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -371,6 +371,18 @@ runtime:
   # (https://gitea.<sovereign-fqdn>) once the parent zone's HTTPRoute
   # is reconciled.
   giteaPublicURL: "http://gitea-http.gitea.svc.cluster.local:3000"
+  # #2940 (2026-06-03): Pillar 5 anti-tether — public-facing console URL.
+  # Per-Sovereign overlays MUST override to https://console.<sov-fqdn>.
+  # Consumed as CORS_ORIGIN and CATALYST_SOVEREIGN_URL by catalyst-api
+  # via the runtime-config ConfigMap (G117.E2E followup pattern, same
+  # seam as keycloak-addr + gitea-public-url). Default keeps the
+  # mothership URL for back-compat on pre-#2940 Sovereigns; cutover
+  # process MUST patch this value as part of bp-self-sovereign-cutover
+  # Step 7 (catalyst-api env patch). When this var is overridden, the
+  # api-deployment's CORS_ORIGIN + CATALYST_SOVEREIGN_URL envs pick up
+  # the new value via the checksum/runtime-config rolling restart
+  # mechanism (PR #2928).
+  sovereignConsoleURL: "https://console.openova.io"
 
 # ─── Group C controllers (slice CC3 of EPIC-0 #1095) ────────────────────────
 # The 5 K8s-native reconcilers consolidated by CC1 (#1135) + CC2 (#1136):


### PR DESCRIPTION
Category 4 of UAT Wave-2 anti-tether sweep. CORS_ORIGIN now sources from catalyst-runtime-config ConfigMap. New runtime.sovereignConsoleURL value. Pods auto-roll on CM change (PR #2928 annotation). Refs #2940 #2928