### PR TITLE
docs(charts): #2940 — flag PDNS values defaults as Pillar 5 anti-tether gotchas

### DIFF
--- a/platform/cert-manager-powerdns-webhook/chart/values.yaml
+++ b/platform/cert-manager-powerdns-webhook/chart/values.yaml
@@ -143,6 +143,12 @@ powerdns:
   # override. Empty string causes the chart to skip ClusterIssuer
   # rendering entirely — see templates/clusterissuer.yaml's skip-render
   # guard. Cluster overlays may override to a different pool's endpoint.
+  #
+  # #2940 (2026-06-03): Pillar 5 anti-tether — franchised Sovereigns
+  # post-bp-self-sovereign-cutover MUST override to their local
+  # `https://pdns.<sov-fqdn>` endpoint. bp-self-sovereign-cutover
+  # Step 6 (helmrepository-patches) doesn't currently rewrite this;
+  # track the gap on #2940 sub-checklist Category 2.
   host: "https://pdns.openova.io"
   # PowerDNS server ID — virtually always "localhost" per the upstream
   # API contract. Operators with a multi-tenant PowerDNS deployment

--- a/platform/powerdns/chart/values.yaml
+++ b/platform/powerdns/chart/values.yaml
@@ -364,6 +364,14 @@ dnsdist:
 #      pod, not by Traefik).
 api:
   enabled: true
+  # #2940 (2026-06-03): Pillar 5 anti-tether — this default ties the
+  # PDNS public API ingress to the mothership FQDN. Franchised
+  # Sovereigns post-bp-self-sovereign-cutover MUST override to
+  # `pdns.<sov-fqdn>` in their per-Sovereign overlay. The default is
+  # kept for back-compat with pre-#2940 Sovereigns + Catalyst-Zero
+  # (contabo-mkt) installs. bp-self-sovereign-cutover Step 6
+  # (helmrepository-patches) doesn't currently rewrite this; track
+  # the gap on #2940 sub-checklist Category 2.
   host: pdns.openova.io
   path: /api
   pathType: Prefix


### PR DESCRIPTION
Docs-only annotation on platform/powerdns + cert-manager-powerdns-webhook values.yaml. No logic change. Refs #2940