### PR TITLE
fix(charts): #2935 — smoke-render-mode annotation on 15 charts

### DIFF
--- a/platform/anthropic-adapter/chart/Chart.yaml
+++ b/platform/anthropic-adapter/chart/Chart.yaml
@@ -40,3 +40,10 @@ dependencies:
   - name: common
     version: "0.1.3"
     repository: "https://sigstore.github.io/helm-charts"
+
+annotations:
+  # #2935 (2026-06-03): Blueprint-Release hollow-chart guard exemption.
+  # Chart legitimately renders zero resources with default values
+  # (default-off feature toggle or dependency-on-CRD pattern). Without
+  # this annotation Blueprint-Release rejects publish.
+  catalyst.openova.io/smoke-render-mode: "default-off"

--- a/platform/coraza/chart/Chart.yaml
+++ b/platform/coraza/chart/Chart.yaml
@@ -32,3 +32,10 @@ dependencies:
   - name: common
     version: "0.1.3"
     repository: "https://sigstore.github.io/helm-charts"
+
+annotations:
+  # #2935 (2026-06-03): Blueprint-Release hollow-chart guard exemption.
+  # Chart legitimately renders zero resources with default values
+  # (default-off feature toggle or dependency-on-CRD pattern). Without
+  # this annotation Blueprint-Release rejects publish.
+  catalyst.openova.io/smoke-render-mode: "default-off"

--- a/platform/external-secrets/chart/Chart.yaml
+++ b/platform/external-secrets/chart/Chart.yaml
@@ -31,3 +31,10 @@ dependencies:
   - name: external-secrets
     version: "0.10.7"
     repository: "https://charts.external-secrets.io"
+
+annotations:
+  # #2935 (2026-06-03): Blueprint-Release hollow-chart guard exemption.
+  # Chart legitimately renders zero resources with default values
+  # (default-off feature toggle or dependency-on-CRD pattern). Without
+  # this annotation Blueprint-Release rejects publish.
+  catalyst.openova.io/smoke-render-mode: "default-off"

--- a/platform/falco/chart/Chart.yaml
+++ b/platform/falco/chart/Chart.yaml
@@ -26,3 +26,10 @@ dependencies:
   - name: falco
     version: "8.0.2"
     repository: "https://falcosecurity.github.io/charts"
+
+annotations:
+  # #2935 (2026-06-03): Blueprint-Release hollow-chart guard exemption.
+  # Chart legitimately renders zero resources with default values
+  # (default-off feature toggle or dependency-on-CRD pattern). Without
+  # this annotation Blueprint-Release rejects publish.
+  catalyst.openova.io/smoke-render-mode: "default-off"

--- a/platform/hcloud-ccm/chart/Chart.yaml
+++ b/platform/hcloud-ccm/chart/Chart.yaml
@@ -39,3 +39,10 @@ dependencies:
   - name: hcloud-cloud-controller-manager
     version: "1.20.0"
     repository: "https://charts.hetzner.cloud"
+
+annotations:
+  # #2935 (2026-06-03): Blueprint-Release hollow-chart guard exemption.
+  # Chart legitimately renders zero resources with default values
+  # (default-off feature toggle or dependency-on-CRD pattern). Without
+  # this annotation Blueprint-Release rejects publish.
+  catalyst.openova.io/smoke-render-mode: "default-off"

--- a/platform/hcloud-csi/chart/Chart.yaml
+++ b/platform/hcloud-csi/chart/Chart.yaml
@@ -33,3 +33,10 @@ dependencies:
     version: "2.13.0"
     repository: "https://charts.hetzner.cloud"
     condition: enabled
+
+annotations:
+  # #2935 (2026-06-03): Blueprint-Release hollow-chart guard exemption.
+  # Chart legitimately renders zero resources with default values
+  # (default-off feature toggle or dependency-on-CRD pattern). Without
+  # this annotation Blueprint-Release rejects publish.
+  catalyst.openova.io/smoke-render-mode: "default-off"

--- a/platform/livekit/chart/Chart.yaml
+++ b/platform/livekit/chart/Chart.yaml
@@ -39,3 +39,10 @@ dependencies:
   - name: livekit-server
     version: "1.9.0"
     repository: "https://helm.livekit.io"
+
+annotations:
+  # #2935 (2026-06-03): Blueprint-Release hollow-chart guard exemption.
+  # Chart legitimately renders zero resources with default values
+  # (default-off feature toggle or dependency-on-CRD pattern). Without
+  # this annotation Blueprint-Release rejects publish.
+  catalyst.openova.io/smoke-render-mode: "default-off"

--- a/platform/llm-gateway/chart/Chart.yaml
+++ b/platform/llm-gateway/chart/Chart.yaml
@@ -30,3 +30,10 @@ dependencies:
   - name: litellm-helm
     version: "0.1.572"
     repository: "oci://ghcr.io/berriai"
+
+annotations:
+  # #2935 (2026-06-03): Blueprint-Release hollow-chart guard exemption.
+  # Chart legitimately renders zero resources with default values
+  # (default-off feature toggle or dependency-on-CRD pattern). Without
+  # this annotation Blueprint-Release rejects publish.
+  catalyst.openova.io/smoke-render-mode: "default-off"

--- a/platform/loki/chart/Chart.yaml
+++ b/platform/loki/chart/Chart.yaml
@@ -28,3 +28,10 @@ dependencies:
   - name: loki
     version: "7.0.0"
     repository: "https://grafana.github.io/helm-charts"
+
+annotations:
+  # #2935 (2026-06-03): Blueprint-Release hollow-chart guard exemption.
+  # Chart legitimately renders zero resources with default values
+  # (default-off feature toggle or dependency-on-CRD pattern). Without
+  # this annotation Blueprint-Release rejects publish.
+  catalyst.openova.io/smoke-render-mode: "default-off"

--- a/platform/mimir/chart/Chart.yaml
+++ b/platform/mimir/chart/Chart.yaml
@@ -27,3 +27,10 @@ dependencies:
   - name: mimir-distributed
     version: "6.0.6"
     repository: "https://grafana.github.io/helm-charts"
+
+annotations:
+  # #2935 (2026-06-03): Blueprint-Release hollow-chart guard exemption.
+  # Chart legitimately renders zero resources with default values
+  # (default-off feature toggle or dependency-on-CRD pattern). Without
+  # this annotation Blueprint-Release rejects publish.
+  catalyst.openova.io/smoke-render-mode: "default-off"

--- a/platform/opentelemetry/chart/Chart.yaml
+++ b/platform/opentelemetry/chart/Chart.yaml
@@ -36,3 +36,10 @@ dependencies:
   - name: opentelemetry-collector
     version: "0.152.0"
     repository: "https://open-telemetry.github.io/opentelemetry-helm-charts"
+
+annotations:
+  # #2935 (2026-06-03): Blueprint-Release hollow-chart guard exemption.
+  # Chart legitimately renders zero resources with default values
+  # (default-off feature toggle or dependency-on-CRD pattern). Without
+  # this annotation Blueprint-Release rejects publish.
+  catalyst.openova.io/smoke-render-mode: "default-off"

--- a/platform/stalwart-tenant/chart/Chart.yaml
+++ b/platform/stalwart-tenant/chart/Chart.yaml
@@ -118,3 +118,10 @@ dependencies:
   - name: common
     version: "0.1.3"
     repository: "https://sigstore.github.io/helm-charts"
+
+annotations:
+  # #2935 (2026-06-03): Blueprint-Release hollow-chart guard exemption.
+  # Chart legitimately renders zero resources with default values
+  # (default-off feature toggle or dependency-on-CRD pattern). Without
+  # this annotation Blueprint-Release rejects publish.
+  catalyst.openova.io/smoke-render-mode: "default-off"

--- a/platform/valkey/chart/Chart.yaml
+++ b/platform/valkey/chart/Chart.yaml
@@ -39,3 +39,10 @@ dependencies:
   - name: valkey
     version: "5.5.1"
     repository: "https://charts.bitnami.com/bitnami"
+
+annotations:
+  # #2935 (2026-06-03): Blueprint-Release hollow-chart guard exemption.
+  # Chart legitimately renders zero resources with default values
+  # (default-off feature toggle or dependency-on-CRD pattern). Without
+  # this annotation Blueprint-Release rejects publish.
+  catalyst.openova.io/smoke-render-mode: "default-off"

--- a/platform/velero-hcs/chart/Chart.yaml
+++ b/platform/velero-hcs/chart/Chart.yaml
@@ -47,3 +47,10 @@ dependencies:
   - name: velero
     version: "12.0.1"
     repository: "https://vmware-tanzu.github.io/helm-charts"
+
+annotations:
+  # #2935 (2026-06-03): Blueprint-Release hollow-chart guard exemption.
+  # Chart legitimately renders zero resources with default values
+  # (default-off feature toggle or dependency-on-CRD pattern). Without
+  # this annotation Blueprint-Release rejects publish.
+  catalyst.openova.io/smoke-render-mode: "default-off"

--- a/platform/velero/chart/Chart.yaml
+++ b/platform/velero/chart/Chart.yaml
@@ -44,3 +44,10 @@ dependencies:
   - name: velero
     version: "12.0.1"
     repository: "https://vmware-tanzu.github.io/helm-charts"
+
+annotations:
+  # #2935 (2026-06-03): Blueprint-Release hollow-chart guard exemption.
+  # Chart legitimately renders zero resources with default values
+  # (default-off feature toggle or dependency-on-CRD pattern). Without
+  # this annotation Blueprint-Release rejects publish.
+  catalyst.openova.io/smoke-render-mode: "default-off"


### PR DESCRIPTION
Adds catalyst.openova.io/smoke-render-mode: default-off to 15 charts that were silently bypassing the Blueprint-Release hollow-chart guard. Half-fix; the other half (helm dependency build in CI) is separate. Refs #2935