### PR TITLE
fix(ci): #2935 — helm dependency build before chart package/render

### DIFF
--- a/.github/workflows/blueprint-release.yaml
+++ b/.github/workflows/blueprint-release.yaml
@@ -202,9 +202,39 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
             --username "${{ github.actor }}" --password-stdin
 
+      # ──────────────────────────────────────────────────────────────
+      # Helm dependency build — bundle the upstream subchart (#2935)
+      # ──────────────────────────────────────────────────────────────
+      # UAT Wave-2 ATTACK#4 found 24/34 charts fail `helm template`
+      # because their declared upstream subchart was never bundled into
+      # chart/charts/. `helm dependency build` resolves every entry in
+      # Chart.yaml `dependencies:` and writes the .tgz into chart/charts/
+      # BEFORE the package/render guards below run. PR #2955 (first half
+      # of #2935) annotated the default-off charts so the hollow-chart
+      # smoke guard stops false-passing them; this step is the other half
+      # — without the build, GUARD 1 / GUARD 2 / smoke-render all fail.
+      #
+      # Guarded on the presence of a `dependencies:` block: a chart that
+      # legitimately ships only Catalyst-authored CRs (no-upstream:true)
+      # has nothing to resolve, and `helm dependency build` is a clean
+      # no-op there (exit 0). We skip it explicitly so the build log
+      # reads cleanly and a future `helm dependency build` behaviour
+      # change on no-deps charts can't surprise the pipeline. For charts
+      # that DO declare dependencies, real resolution failures surface
+      # loudly (no `|| true`) — a chart that can't pull its subchart must
+      # NOT proceed to publish as a hollow artifact.
       - name: Helm dependency build
         if: steps.chart.outputs.skip != 'true'
-        run: helm dependency build "${{ matrix.path }}/chart"
+        run: |
+          set -euo pipefail
+          chart_dir="${{ matrix.path }}/chart"
+          dep_count=$(yq '.dependencies | length // 0' "$chart_dir/Chart.yaml")
+          if [ "$dep_count" -eq 0 ]; then
+            echo "Chart $chart_dir declares no dependencies — skipping helm dependency build."
+            exit 0
+          fi
+          echo "Resolving $dep_count declared dependency/dependencies for $chart_dir"
+          helm dependency build "$chart_dir"
 
       # ──────────────────────────────────────────────────────────────
       # GUARD 1 — hollow-chart check on the working tree


### PR DESCRIPTION
Second half of #2935 (Helm chart hygiene).

## What
Guards + hardens the `Helm dependency build` step in `blueprint-release.yaml` so it runs `helm dependency build` for every chart with a `dependencies:` block **before** the package / smoke-render guards, bundling the upstream subchart into `chart/charts/`. Charts with no `dependencies:` block (`no-upstream: "true"`) skip cleanly; charts that DO declare deps surface real resolution failures loudly (no `|| true`).

## Why
UAT Wave-2 ATTACK#4 found 24/34 charts fail `helm template` because the declared upstream subchart was never bundled in `charts/`. PR #2955 (first half) annotated the default-off charts so the hollow-chart smoke guard stops false-passing them; this PR is the other half so the subchart is actually present at package/render time.

## Investigation note
`blueprint-release.yaml` already carried an unconditional `helm dependency build` step (since 2026-04-28). This PR makes it explicit + guarded per the issue's "Fix option 1" intent: it skips no-deps charts cleanly and keeps fail-loud behaviour for real dep-pull failures. The pre-merge guard `scripts/check-chart-annotations.sh` already runs dep-build conditionally; this aligns the post-merge release workflow to the same shape.

## Verified locally
- `platform/loki/chart`: `helm dependency build && helm template . > /dev/null` → RENDER_OK (was RENDER_FAIL with "missing in charts/ directory: loki" before dep-build).
- `platform/velero/chart`: same → RENDER_OK.
- Workflow YAML parses: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/blueprint-release.yaml'))"` → OK.

Refs #2935