### PR TITLE
fix(ci): #2939 — Playwright Group L g117 specs boot wrong UI app (no mock backend)

### DIFF
--- a/.github/workflows/playwright-smoke.yaml
+++ b/.github/workflows/playwright-smoke.yaml
@@ -23,6 +23,7 @@ on:
     branches: [main]
     paths:
       - 'products/catalyst/bootstrap/ui/**'
+      - 'products/catalyst/console/**'
       - 'core/admin/**'
       - 'core/marketplace/**'
       - 'platform/**/blueprint.yaml'
@@ -32,6 +33,7 @@ on:
   pull_request:
     paths:
       - 'products/catalyst/bootstrap/ui/**'
+      - 'products/catalyst/console/**'
       - 'core/admin/**'
       - 'core/marketplace/**'
       - 'platform/**/blueprint.yaml'
@@ -58,6 +60,17 @@ jobs:
         working-directory: products/catalyst/bootstrap/ui
         run: npm ci
 
+      - name: Install Catalyst console dependencies
+        # The g117 MOCK-mode specs (g117-launch-silent-sso /
+        # g117-multi-instance-create) drive the products/catalyst/console
+        # Astro app — the ONLY UI that installs window.__MOCK_API__ (see
+        # console src/layouts/Layout.astro, gated on PUBLIC_MOCK_API=1) and
+        # serves the /apps/<id> + /catalog/<name>/new routes those specs
+        # navigate to. The bootstrap/ui (React) app has no mock backend, so
+        # #2944's PUBLIC_MOCK_API=1 on bootstrap/ui never reached these specs.
+        working-directory: products/catalyst/console
+        run: npm ci
+
       - name: Install Playwright dependencies
         working-directory: tests/e2e/playwright
         run: |
@@ -68,21 +81,29 @@ jobs:
         working-directory: products/catalyst/bootstrap/ui
         env:
           HOST: 0.0.0.0
-          # #2939-followup (2026-06-03): the g117-launch-silent-sso.spec.ts
-          # MOCK-mode tests (line 100+) require the UI's mock backend
-          # (window.__MOCK_API__) which only loads when Vite is started
-          # with PUBLIC_MOCK_API=1. Without this, the dev server boots
-          # in REAL-API mode, /apps/<mock-grafana-id> 401s and redirects
-          # to /login, the Launch button never renders, and the
-          # `expect(launchBtn).toBeVisible()` assertion fails. The
-          # Playwright Group L lane has been red on this since 2026-06-03
-          # 02:36Z. Setting the var unblocks 12+ MOCK-mode tests.
+          # bootstrap/ui has no mock backend today; PUBLIC_MOCK_API is a
+          # no-op here but kept harmless in case future bootstrap/ui specs
+          # add a mock installer. The g117 specs target the console app
+          # instead (booted below on :4323).
           PUBLIC_MOCK_API: "1"
         run: |
-          # Vite dev server binds 4321 by default; we keep the default so the
-          # tests' BASE_URL fallback (http://localhost:5173) works.
+          # Vite dev server binds 5173 (vite.config.ts); BASE_URL=5173 below.
           nohup npm run dev > /tmp/catalyst-ui-dev.log 2>&1 &
           echo $! > /tmp/catalyst-ui.pid
+
+      - name: Boot Catalyst console (mock backend) in background
+        working-directory: products/catalyst/console
+        env:
+          HOST: 0.0.0.0
+          # #2939 root cause: window.__MOCK_API__ is installed by the console
+          # Astro Layout when MOCK_API=1 (its dev script maps MOCK_API →
+          # PUBLIC_MOCK_API for import.meta.env). Without this the g117 specs
+          # throw `window.__MOCK_API__ not installed; PUBLIC_MOCK_API=1
+          # required`. Console binds :4323 (astro.config.mjs).
+          MOCK_API: "1"
+        run: |
+          nohup npm run dev > /tmp/catalyst-console-dev.log 2>&1 &
+          echo $! > /tmp/catalyst-console.pid
 
       - name: Wait for Catalyst UI to be ready
         run: |
@@ -98,10 +119,28 @@ jobs:
           cat /tmp/catalyst-ui-dev.log || true
           exit 1
 
+      - name: Wait for Catalyst console to be ready
+        run: |
+          # The console serves the mock Grafana app detail; probe its
+          # /apps/<mock-grafana-id> route (the fixture pre-seeds it).
+          for i in $(seq 1 60); do
+            if curl -sf -o /dev/null http://localhost:4323/apps/8a1e9bf2-7c4d-4b3a-9f1e-2c5a8d3f6e0a; then
+              echo "console ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "console failed to start in 60s — log follows:"
+          cat /tmp/catalyst-console-dev.log || true
+          exit 1
+
       - name: Run Playwright smoke
         working-directory: tests/e2e/playwright
         env:
           BASE_URL: http://localhost:5173
+          # g117 MOCK-mode specs read CONSOLE_BASE_URL (console app on :4323);
+          # all other Group L specs use BASE_URL (bootstrap/ui on :5173).
+          CONSOLE_BASE_URL: http://localhost:4323
           # ADMIN_BASE_URL / MARKETPLACE_BASE_URL not set — the admin and
           # marketplace specs self-skip when their respective apps aren't up,
           # which keeps this workflow lean. Booting all three apps requires
@@ -114,6 +153,9 @@ jobs:
         run: |
           if [ -f /tmp/catalyst-ui.pid ]; then
             kill "$(cat /tmp/catalyst-ui.pid)" 2>/dev/null || true
+          fi
+          if [ -f /tmp/catalyst-console.pid ]; then
+            kill "$(cat /tmp/catalyst-console.pid)" 2>/dev/null || true
           fi
 
       - name: Upload Playwright report

--- a/tests/e2e/playwright/tests/g117-launch-silent-sso.spec.ts
+++ b/tests/e2e/playwright/tests/g117-launch-silent-sso.spec.ts
@@ -47,7 +47,13 @@ import { reachable } from './_helpers'
 
 const SOV_FQDN = (process.env.SOV_FQDN || '').trim()
 const CATALYST_SESSION_COOKIE = process.env.CATALYST_SESSION_COOKIE || ''
-const BASE_URL = process.env.BASE_URL || 'http://localhost:4321'
+// MOCK-mode target is the products/catalyst/console Astro app, NOT the
+// products/catalyst/bootstrap/ui (React) app that the rest of Group L boots.
+// Only the console app installs window.__MOCK_API__ (Layout.astro, gated on
+// PUBLIC_MOCK_API=1) and serves the /apps/<id> + /catalog/<name> routes these
+// specs drive. CONSOLE_BASE_URL points at it (CI boots it on :4323 with
+// MOCK_API=1); falls back to the console dev port for local runs.
+const BASE_URL = process.env.CONSOLE_BASE_URL || 'http://localhost:4323'
 
 // Mock fixture's pre-seeded Grafana app id (see
 // products/catalyst/console/tests/e2e/fixtures/mock-blueprints.yaml).
@@ -99,10 +105,14 @@ test.describe('G117.4 #2743 AC4 — Launch silent-SSO', () => {
   // ─────────────────────────────────────────────────────────────────────
   test.describe('MOCK mode', () => {
     test.skip(!!SOV_FQDN, 'MOCK walk runs only when SOV_FQDN is unset')
+    // page.goto uses the project baseURL (the shared Group L BASE_URL =
+    // bootstrap/ui), but the mock backend lives in the console app. Override
+    // baseURL for this block so relative gotos hit the console (CONSOLE_BASE_URL).
+    test.use({ baseURL: BASE_URL })
 
     test.beforeEach(async ({ page }) => {
       const ok = await reachable(BASE_URL)
-      test.skip(!ok, `console dev server not reachable at ${BASE_URL} — start with PUBLIC_MOCK_API=1 npm run dev`)
+      test.skip(!ok, `console dev server not reachable at ${BASE_URL} — start with MOCK_API=1 npm run dev`)
       await stubWindowOpen(page)
     })
 

--- a/tests/e2e/playwright/tests/g117-multi-instance-create.spec.ts
+++ b/tests/e2e/playwright/tests/g117-multi-instance-create.spec.ts
@@ -27,9 +27,15 @@
 // declare grafana as multi-instance and we lean on that.
 
 import { test, expect } from '@playwright/test'
+import { reachable } from './_helpers'
 
 const SOV_FQDN = (process.env.SOV_FQDN || '').trim()
 const CATALYST_TOKEN = process.env.CATALYST_TOKEN || ''
+// MOCK-mode target is the products/catalyst/console Astro app (installs
+// window.__MOCK_API__ + serves /catalog/<name>/new), NOT the bootstrap/ui
+// React app the rest of Group L boots. CI boots console on :4323 with
+// MOCK_API=1; CONSOLE_BASE_URL points at it.
+const CONSOLE_BASE_URL = process.env.CONSOLE_BASE_URL || 'http://localhost:4323'
 
 test.describe('G117.2 W2.C2 — multi-instance create flow', () => {
   test.describe('LIVE mode (SOV_FQDN set)', () => {
@@ -75,6 +81,14 @@ test.describe('G117.2 W2.C2 — multi-instance create flow', () => {
 
   test.describe('MOCK mode (PR-time CI)', () => {
     test.skip(!!SOV_FQDN, 'Mock walk runs only when SOV_FQDN is unset')
+    // Drive the console mock app (CONSOLE_BASE_URL) rather than the shared
+    // Group L baseURL — only the console installs window.__MOCK_API__.
+    test.use({ baseURL: CONSOLE_BASE_URL })
+
+    test.beforeEach(async () => {
+      const ok = await reachable(CONSOLE_BASE_URL)
+      test.skip(!ok, `console dev server not reachable at ${CONSOLE_BASE_URL} — start with MOCK_API=1 npm run dev`)
+    })
 
     test('catalog drill-down for multi-instance grafana exposes "+ New instance"', async ({ page }) => {
       // The console mock backend at products/catalyst/console exposes
@@ -98,9 +112,12 @@ test.describe('G117.2 W2.C2 — multi-instance create flow', () => {
       const names = ['obs-1', 'obs-2', 'obs-3']
       for (const name of names) {
         await page.goto('/catalog/grafana/new')
-        await page.getByTestId('input-app-name').fill(name)
-        await page.getByTestId('input-app-org').fill('acme')
-        await page.getByTestId('btn-create-instance').click()
+        // Testids match the console new-instance form
+        // (products/catalyst/console/src/routes/catalog/[name]/new/+page.svelte):
+        // instance-name / instance-org / instance-submit.
+        await page.getByTestId('instance-name').fill(name)
+        await page.getByTestId('instance-org').fill('acme')
+        await page.getByTestId('instance-submit').click()
         // Mock backend redirects to /apps/<id> on success.
         await expect(page).toHaveURL(/\/apps\/[A-Za-z0-9-]+/)
       }


### PR DESCRIPTION
## Root cause

The two red Group L specs — `g117-launch-silent-sso` and `g117-multi-instance-create` — throw:

```
window.__MOCK_API__ not installed; PUBLIC_MOCK_API=1 required
```
(`tests/e2e/playwright/tests/g117-launch-silent-sso.spec.ts:183`)

because they drive the **wrong UI app**. `window.__MOCK_API__` is installed **only** by `products/catalyst/console` (Astro), in `src/layouts/Layout.astro`, gated on `PUBLIC_MOCK_API=1`. That console app also serves the `/apps/<id>` + `/catalog/<name>/new` routes these specs navigate to.

But the `playwright-smoke` workflow boots `products/catalyst/bootstrap/ui` (a React/Vite app on :5173), which has **no mock backend at all** (`grep -rn __MOCK_API__ products/catalyst/bootstrap/ui/src` → nothing).

So #2944's `PUBLIC_MOCK_API=1` on the bootstrap/ui boot step was a **no-op for these specs** — the var reached a dev server that never reads it. The g117 specs hit `BASE_URL` (5173) expecting a mock backend that lives on a different app/port (console, 4323).

## Fix

- **Workflow**: also `npm ci` + boot `products/catalyst/console` with `MOCK_API=1` (its dev script maps `MOCK_API` → `PUBLIC_MOCK_API` for Astro `import.meta.env`) on :4323, wait for its mock `/apps/<grafana-id>` route, and pass `CONSOLE_BASE_URL=http://localhost:4323` to the Playwright step. bootstrap/ui still boots on :5173 for the rest of Group L.
- **Specs**: the g117 MOCK-mode `describe` blocks now `test.use({ baseURL: CONSOLE_BASE_URL })` so relative `page.goto()` hits the console; they read `CONSOLE_BASE_URL` for the `reachable()`-skip gate and self-skip cleanly when console isn't up (matches sibling-spec pattern).
- **g117-multi-instance-create**: fixed three stale testids that never matched the console new-instance form — `input-app-name`/`input-app-org`/`btn-create-instance` → `instance-name`/`instance-org`/`instance-submit` (the actual testids in `console src/routes/catalog/[name]/new/+page.svelte`).
- **Trigger paths**: add `products/catalyst/console/**` to push + pull_request.

## Verification (local)

Booted `MOCK_API=1 npm run dev` for `products/catalyst/console` (:4323) and ran both specs against it via `CONSOLE_BASE_URL` — **4/4 g117 MOCK tests pass, stable across 3 consecutive runs**. Full Group L suite: **11 passed / 0 failed** (bootstrap/ui-dependent specs self-skip locally; they execute in CI where :5173 is up). Workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).

Refs #2939 #2944

🤖 Generated with [Claude Code](https://claude.com/claude-code)