### PR TITLE
fix(hetzner-tofu): #2842 — seed harbor mirror auth on Hetzner worker nodes

### DIFF
--- a/infra/providers/hetzner/cloudinit-worker.tftpl
+++ b/infra/providers/hetzner/cloudinit-worker.tftpl
@@ -78,6 +78,52 @@ write_files:
       backend = systemd
 %{ endif ~}
 
+  # ── containerd registry mirrors + harbor auth ────────────────────────
+  # #2842 (2026-06-03): worker nodes were MISSING this file entirely — only
+  # the control-plane template (cloudinit-control-plane.tftpl lines 362-396)
+  # wrote it. Result: every Hetzner worker pulled images direct (no harbor
+  # cache) AND had no credentials for `harbor.openova.io`, so any chart or
+  # manifest that hardcodes a `harbor.openova.io/proxy-*` reference (or any
+  # mirror-rewritten pull) 401'd → containerd stale-ingest-lock loop. The
+  # k3s agent does NOT inherit the server's registries.yaml; each node reads
+  # its own local file. This block is byte-identical to the control-plane
+  # template (issue #557 Step 2 + #2868) so the harbor robot token is seeded
+  # at bootstrap on EVERY node, fresh provs included.
+  - path: /etc/rancher/k3s/registries.yaml
+    permissions: '0600'
+    content: |
+      mirrors:
+        "docker.io":
+          endpoint:
+            - "https://harbor.openova.io"
+          rewrite:
+            "(.*)": "proxy-dockerhub/$1"
+        "quay.io":
+          endpoint:
+            - "https://harbor.openova.io"
+          rewrite:
+            "(.*)": "proxy-quay/$1"
+        "gcr.io":
+          endpoint:
+            - "https://harbor.openova.io"
+          rewrite:
+            "(.*)": "proxy-gcr/$1"
+        "registry.k8s.io":
+          endpoint:
+            - "https://harbor.openova.io"
+          rewrite:
+            "(.*)": "proxy-k8s/$1"
+        "ghcr.io":
+          endpoint:
+            - "https://harbor.openova.io"
+          rewrite:
+            "(.*)": "proxy-ghcr/$1"
+      configs:
+        "harbor.openova.io":
+          auth:
+            username: "robot$openova-bot"
+            password: "${harbor_robot_token}"
+
 runcmd:
   - swapoff -a
   - sed -i '/swap/d' /etc/fstab

--- a/infra/providers/hetzner/main.tf
+++ b/infra/providers/hetzner/main.tf
@@ -636,6 +636,7 @@ locals {
     cp_private_ip              = "10.0.1.2" # First static IP in the subnet — control plane
     enable_unattended_upgrades = var.enable_unattended_upgrades
     enable_fail2ban            = var.enable_fail2ban
+    harbor_robot_token         = var.harbor_robot_token # #2842: seed harbor mirror auth on worker nodes
   }), "/(?m)^[ ]*#( |$).*\n/", "")
 
   # Strip ALL pure-comment lines (any indent) from the rendered cloud-init
@@ -1433,6 +1434,7 @@ locals {
       cp_private_ip              = local.secondary_region_cp_ips[k]
       enable_unattended_upgrades = var.enable_unattended_upgrades
       enable_fail2ban            = var.enable_fail2ban
+      harbor_robot_token         = var.harbor_robot_token # #2842: seed harbor mirror auth on worker nodes
     }), "/(?m)^[ ]*#( |$).*\n/", "")
   }
 }


### PR DESCRIPTION
## Problem

`infra/providers/hetzner/cloudinit-worker.tftpl` was the **only** one of the 4 cloud-init templates (Hetzner CP, Hetzner worker, Huawei CP, Huawei worker) that wrote **no** `/etc/rancher/k3s/registries.yaml` at all — no harbor mirror, no `harbor.openova.io` robot-token `auth:` block.

k3s agents do **not** inherit the server's `registries.yaml`; each node reads its own local file. So fresh Hetzner **worker** nodes:
- pulled images direct (no harbor proxy-cache benefit), and
- had **no credentials** for `harbor.openova.io` → any mirror-rewritten or hardcoded `harbor.openova.io/proxy-*` pull 401'd into the containerd stale-ingest-lock loop that bit hw86 (the exact #2842 symptom).

PR #2868 fixed the **Huawei** CP+worker templates and the Hetzner **CP** template already carried the block (issue #557). The Hetzner **worker** was the residual gap.

## Fix

- Add the `registries.yaml` `write_files` block to `cloudinit-worker.tftpl`, byte-identical to the control-plane template (`cloudinit-control-plane.tftpl` lines 362-396).
- Thread `var.harbor_robot_token` into **both** worker `templatefile()` invocations in `main.tf` (primary region + secondary-region for_each).

## Validation

- `tofu -chdir=infra/providers/hetzner fmt` — clean (no drift).
- `tofu -chdir=infra/providers/hetzner test` — **10/10 pass**. Size guardrails (30 KiB cloud-init cap) hold for both primary + secondary worker. The "error message refers to sensitive values" warnings are benign — the guardrail's `error_message` interpolates a `local` that now transitively contains the sensitive token; the CP guardrails already carried this.

## Residual (operator)

Existing fleet nodes (hw86) still need `tools/patch-existing-nodes-registries-yaml.sh` run by the operator — they predate this template. This PR only fixes **fresh provs**.

Refs #2842

🤖 Generated with [Claude Code](https://claude.com/claude-code)