### PR TITLE
chore(readmes): component README accuracy vs canonical docs (deep-clean SLICE 5)

### DIFF
--- a/platform/cilium/README.md
+++ b/platform/cilium/README.md
@@ -535,9 +535,9 @@ opt in by setting:
 - `spec.values.cilium.clustermesh.apiserver.service.{type,nodePort}`
 
 The cluster.id allocation across the OpenOva fleet is tracked in
-[`docs/CLUSTERMESH-CLUSTER-IDS.md`](../../docs/CLUSTERMESH-CLUSTER-IDS.md).
-Every PR that adds a new peer MUST also claim a row in that registry
-in the same commit.
+[`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) §8.7 (ClusterMesh ID
+assignment). Every PR that adds a new peer MUST also claim a row in that
+registry in the same commit.
 
 ---
 

--- a/platform/openbao/README.md
+++ b/platform/openbao/README.md
@@ -195,7 +195,7 @@ If the primary region fails, a replica is explicitly promoted (sovereign-admin a
 ## Bootstrap Procedure
 
 1. Catalyst bootstrap (Phase 0 of Sovereign provisioning) deploys OpenBao as **independent Raft cluster per region** (no stretched cluster — see [`docs/SECURITY.md`](../../docs/SECURITY.md) §5).
-2. **Auto-unseal flow (issue #316, chart v1.2.0+):** Cloud-init on the control-plane node generates a 32-byte recovery seed, writes it to a single-use K8s Secret `openbao-recovery-seed` in the `openbao` namespace. The bp-openbao Helm chart's post-install init Job (hook weight 5) consumes the seed, calls `bao operator init -recovery-shares=1 -recovery-threshold=1`, persists the recovery key inside OpenBao's auto-unseal config, and deletes the seed Secret on success. The recovery key + root token live ONLY inside OpenBao's Raft state — never in a K8s Secret. Subsequent pod restarts unseal automatically without operator intervention. Set `autoUnseal.enabled=true` (default off; cluster overlay flips it on per-Sovereign).
+2. **Auto-unseal flow (issue #316, chart v1.2.0+):** Cloud-init on the control-plane node generates a 32-byte recovery seed, writes it to a single-use K8s Secret `openbao-recovery-seed` in the `openbao` namespace. The bp-openbao Helm chart's post-install init Job (hook weight 5) consumes the seed, calls `bao operator init -recovery-shares=1 -recovery-threshold=1`, persists the recovery key inside OpenBao's auto-unseal config, and deletes the seed Secret on success. The recovery key + root token live ONLY inside OpenBao's Raft state — never in a K8s Secret. Subsequent pod restarts unseal automatically without sovereign-admin intervention. Set `autoUnseal.enabled=true` (default off; cluster overlay flips it on per-Sovereign).
 3. **Kubernetes auth bootstrap (issue #316):** A second post-install Job (hook weight 10) enables the Kubernetes auth method, mounts kv-v2 at `secret/`, writes the `external-secrets-read` policy, and binds the `external-secrets` role to the ESO ServiceAccount in `external-secrets-system`. ESO's ClusterSecretStore `vault-region1` (platform/external-secrets) authenticates via this role on every secret read. Configure under `autoUnseal.kubernetesAuth.*`.
 4. Cross-region async perf replication is configured for read availability and DR.
 5. ESO configured with local-region ClusterSecretStores; cross-region reads via the same workload SVID.
@@ -210,7 +210,7 @@ If the primary region fails, a replica is explicitly promoted (sovereign-admin a
 | **A. Shamir + cloud-init seed** | **Default for solo Sovereign — implemented in chart v1.2.0.** No managed-KMS dependency; the recovery key is generated on the control-plane at provision time and persisted only inside OpenBao's own Raft state. |
 | B. Transit-seal via peer OpenBao | Multi-region tier-1 corporate cluster (one Sovereign unseals another). Out of scope for omantel/single-region. |
 | C. Cloud-KMS auto-unseal (AWS KMS, GCP KMS, Azure Key Vault) | When the Sovereign runs on a hyperscaler that provides managed-KMS. Hetzner has no managed-KMS — Option A is the only viable path on Hetzner. |
-| D. Operator-supplied recovery shards (air-gap) | Documented in [`docs/SECURITY.md`](../../docs/SECURITY.md). Used when no automated boot-time secret pipeline is acceptable. |
+| D. Sovereign-admin-supplied recovery shards (air-gap) | Documented in [`docs/SECURITY.md`](../../docs/SECURITY.md). Used when no automated boot-time secret pipeline is acceptable. |
 
 ---
 

--- a/platform/self-sovereign-cutover/chart/README.md
+++ b/platform/self-sovereign-cutover/chart/README.md
@@ -17,14 +17,14 @@ step completes.
 Per the parent-epic scope-correction comment, the cutover trigger is
 **post-handover**, not Phase-1.5:
 
-- The operator clicks **"Achieve True Sovereignty"** in the admin console, OR
-- `catalyst-api` auto-fires after the first successful operator login on
+- The `sovereign-admin` clicks **"Achieve True Sovereignty"** in the operator console, OR
+- `catalyst-api` auto-fires after the first successful sovereign-admin login on
   the new Sovereign (configurable via `.Values.trigger.auto`, default
   `false`).
 
 A handed-over Sovereign therefore starts soft-tethered (still pulling
 through `harbor.openova.io`) and becomes hard-independent only after the
-operator chooses or after the auto-fire grace period.
+`sovereign-admin` chooses or after the auto-fire grace period.
 
 ## Step inventory
 

--- a/platform/sso-bridge/README.md
+++ b/platform/sso-bridge/README.md
@@ -3,7 +3,7 @@
 **What:** Auto-provisions a Keycloak OIDC Client for every Catalyst
 Blueprint that opts in via `sso.enabled: true`, distributes the client
 secret through OpenBao + External Secrets Operator, and grants the
-Sovereign operator the application's `admin` role.
+`sovereign-admin` the application's `admin` role.
 
 **Role in Catalyst:** Mandatory infra. Implements the App-level SSO
 contract from [`docs/SECURITY.md`](../../docs/SECURITY.md) §6.3.
@@ -34,8 +34,8 @@ That's it. bp-sso-bridge owns:
   in the app's namespace; bp-external-secrets writes a regular K8s
   Secret with keys `client_id`, `client_secret`, `issuer_url`,
   `authorize_url`, `token_url`, `userinfo_url`, `end_session_url`
-- Granting the Sovereign operator the application's `admin` role —
-  operator email is sourced from the per-Sovereign `sovereign-fqdn`
+- Granting the `sovereign-admin` the application's `admin` role —
+  the admin email is sourced from the per-Sovereign `sovereign-fqdn`
   ConfigMap key `orgEmail` (set by catalyst-api Phase-1 watcher from
   `deployment.request.OrgEmail`)
 
@@ -68,8 +68,8 @@ On each tick:
    - upsert Keycloak Client (POST new / PUT existing)
    - PUT `secret/sso/<clientId>` in OpenBao with full URL bundle
    - apply ExternalSecret CR in the HR's namespace
-   - grant operator the client's `admin` role (best-effort — deferred if
-     operator user not yet provisioned in the realm)
+   - grant the `sovereign-admin` the client's `admin` role (best-effort —
+     deferred if the sovereign-admin user not yet provisioned in the realm)
 5. Sweep `bp-sso-bridge.openova.io/managed=true` ExternalSecrets whose
    `client-id` label is no longer in the managed set; delete those.
 

--- a/products/catalyst/README.md
+++ b/products/catalyst/README.md
@@ -12,7 +12,7 @@ This product directory contains:
 - `chart/templates/marketplace-api/` — manifests for the Go marketplace-api backend (sourced from `core/marketplace-api/`).
 - `bootstrap/{ui,api}/` — the source code for catalyst-ui and catalyst-api (deployed via the catalyst-build CI workflow).
 
-For the unified architecture and the wizard's target shape, see [`docs/PROVISIONING-PLAN.md`](../../docs/PROVISIONING-PLAN.md), [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md), and [`docs/SOVEREIGN-PROVISIONING.md`](../../docs/SOVEREIGN-PROVISIONING.md).
+For the unified architecture and the wizard's target shape, see [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) and the provisioning runbook in [`docs/RUNBOOKS.md`](../../docs/RUNBOOKS.md). (The legacy `docs/PROVISIONING-PLAN.md` and `docs/SOVEREIGN-PROVISIONING.md` were consolidated into these under the lean-docs strategy.)
 
 ---
 
@@ -22,7 +22,7 @@ A Flux Kustomization on the Catalyst-Zero cluster (Contabo k3s) reconciles `prod
 
 Image registry: `ghcr.io/openova-io/openova/{catalyst-ui,catalyst-api,console,admin,marketplace,marketplace-api}:<sha>`.
 
-## Migration status (per `docs/PROVISIONING-PLAN.md`)
+## Migration status (per `docs/ARCHITECTURE.md`)
 
 | Component | Source location | Image | Status |
 |---|---|---|---|

--- a/products/continuum/chart/README.md
+++ b/products/continuum/chart/README.md
@@ -21,7 +21,7 @@ K-Cont-3 wires the lease witness (Cloudflare KV per SRE.md §2.4, with
 ## Install
 
 ```bash
-# Default-OFF gate keeps the controller stopped until the operator
+# Default-OFF gate keeps the controller stopped until the sovereign-admin
 # installs bp-cnpg-pair + bp-powerdns and configures the witness.
 helm install bp-continuum ./products/continuum/chart \
   --namespace openova-system \
@@ -56,7 +56,7 @@ The K-Cont-2 reconciler will:
 2. Acquire / renew the lease via the witness (kind from
    `spec.leaseClient.kind`).
 3. Watch CNPG `cnpg.io/cluster.replicationLag` per replica.
-4. On switchover (operator-initiated or auto-failover when health
+4. On switchover (sovereign-admin-initiated or auto-failover when health
    check + witness quorum agree primary is unreachable), execute the
    sequence in `docs/ARCHITECTURE.md` §9.3.
 5. Patch status (phase, primaryRegion, leaseHolder, leaseExpiresAt,
@@ -66,7 +66,7 @@ The K-Cont-2 reconciler will:
 
 1. `docs/ARCHITECTURE.md` §9 (full Continuum DR spec)
 2. `docs/SRE.md` §2 (DR runbook + lease witness pattern)
-3. `docs/MULTI-REGION-DNS.md` (lua-record DNS pattern)
+3. `docs/ARCHITECTURE.md` §8 (PowerDNS lua-record geo + health-checked failover DNS pattern)
 4. `products/catalyst/chart/crds/continuum.yaml` (CRD shape)
 5. `core/controllers/continuum/DESIGN.md` (this slice's design notes)
 6. `core/controllers/internal/placement/` (Plan + RegionPlan — reuse


### PR DESCRIPTION
Audit + surgical fixes to high-traffic per-component READMEs against the README rule-of-thumb (CLAUDE.md) and the canonical `docs/GLOSSARY.md` + `docs/ARCHITECTURE.md`. Part of the founder-directed exemplary-repo deep-clean (SLICE 5).

## Fixes

### Stale doc links (targets consolidated under the lean-docs strategy)
- `platform/cilium/README.md` — `docs/CLUSTERMESH-CLUSTER-IDS.md` → `docs/ARCHITECTURE.md` §8.7 (ClusterMesh ID assignment; content was merged there 2026-05-20)
- `products/catalyst/README.md` — `docs/PROVISIONING-PLAN.md` + `docs/SOVEREIGN-PROVISIONING.md` (both deleted) → `docs/ARCHITECTURE.md` + `docs/RUNBOOKS.md`; legacy names retained as code-span mentions for traceability
- `products/continuum/chart/README.md` — `docs/MULTI-REGION-DNS.md` → `docs/ARCHITECTURE.md` §8 (PowerDNS lua-record failover)

### Banned terminology (operator-as-person → `sovereign-admin`, per GLOSSARY §Banned-terms)
- `platform/sso-bridge/README.md`, `platform/self-sovereign-cutover/chart/README.md`, `products/continuum/chart/README.md`, `platform/openbao/README.md`
- Deliberately left intact: K8s Operator-pattern, External Secrets **Operator**, the CLI subcommand `bao operator init`, and OTel operator image refs — those are technical terms exempt per GLOSSARY.

## Audited-clean (no change needed)
cnpg, keycloak, gitea, harbor, axon READMEs — accurate headers, correct canonical links, no banned platform-terms (keycloak's "tenant" is explicitly the PSD2-TPP sense; harbor's "instance" is a deployed-software instance, both exempt).

## Verify
- `git diff --stat`: 6 files, 18/18 ±
- All code fences balanced; no remaining stale `docs/*.md` links in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)