### PR TITLE
fix(bootstrap-kit): declare dmz/mgmt/rtz host namespaces — fresh-prov wedge (#2981)

### DIFF
--- a/clusters/_template/bootstrap-kit/00-vcluster-host-namespaces.yaml
+++ b/clusters/_template/bootstrap-kit/00-vcluster-host-namespaces.yaml
@@ -1,0 +1,40 @@
+# vCluster host namespaces — MUST exist before any HelmRelease object that
+# declares `metadata.namespace: {dmz,mgmt,rtz}`.
+#
+# WHY THIS FILE EXISTS (fresh-prov wedge, caught live on hw88 2026-06-03):
+# bp-coraza (slot 35) and bp-sandbox (slot 19a) place their HelmRelease
+# *objects* in the vCluster host namespaces `dmz` / `rtz` (that is where
+# bp-{dmz,mgmt,rtz}-vcluster export the `vc-<ns>` kubeConfig Secret those
+# HRs pivot through — see 35-coraza.yaml). Those host namespaces were only
+# created implicitly, and *later*, by the vcluster HRs' helm
+# `createNamespace`. But Flux applies the whole bootstrap-kit Kustomization
+# as one server-side apply: the coraza/sandbox HR objects are applied in the
+# same pass, BEFORE the vcluster HR has run, so they fail with
+# `namespaces "dmz" not found`. A single failed object fails the ENTIRE
+# reconcile → inventory stays at 0 HRs → the prov wedges forever, retrying
+# every 5m. Declaring the host namespaces explicitly here (Flux applies
+# Namespace kinds before everything else) guarantees they exist in the first
+# pass; the later vcluster helm `createNamespace` is then a no-op (idempotent).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dmz
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+    catalyst.openova.io/vcluster: dmz
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mgmt
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+    catalyst.openova.io/vcluster: mgmt
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rtz
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+    catalyst.openova.io/vcluster: rtz

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -5,6 +5,11 @@ kind: Kustomization
 # dependsOn declarations for actual install order. Listing in canonical
 # Phase 0 sequence per SOVEREIGN-PROVISIONING.md §3.
 resources:
+  # Slot 00 — vCluster host namespaces (dmz/mgmt/rtz). MUST be first so the
+  # host namespaces exist before bp-coraza (35) / bp-sandbox (19a) HR objects
+  # that live in them are applied. Prevents the fresh-prov atomic-apply wedge
+  # caught on hw88 2026-06-03 (see file header for the full RCA).
+  - 00-vcluster-host-namespaces.yaml
   - 01-cilium.yaml
   - 01a-gateway-api.yaml
   - 02-cert-manager.yaml


### PR DESCRIPTION
Fixes the fresh-prov wedge caught live on hw88 (#2981): bootstrap-kit applied 0 HelmReleases because bp-coraza/bp-sandbox HR objects live in `dmz`/`rtz` host namespaces that were never declared, failing the atomic Flux apply.

New slot `00-vcluster-host-namespaces.yaml` declares `dmz`/`mgmt`/`rtz` (Flux applies Namespace kinds first), unblocking the cascade.

**Validation:** code-side here; the true zero-touch proof is a FRESH prov on this catalog reconciling to ready with no manual touch (hw88 was manually unwedged and is contaminated).

Refs #2981

🤖 Generated with [Claude Code](https://claude.com/claude-code)