### PR TITLE
chore(repo): designated artifacts/ dir + root-junk gitignore guard + UAT as UI-walk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,18 @@ test-results/
 # Debug screenshots dumped at the repo ROOT (e.g. hw86-*.png, walk-*.png).
 # Root-anchored (/*.png) so it does NOT touch brand/, docs/, or chart icon PNGs.
 /*.png
+/*.jpg
+/*.jpeg
+/*.gif
+/*.webp
+/*.log
+
+# Designated transient-artifacts dir (founder directive 2026-06-03): ALL
+# throwaway files — screenshots, scratch, debug dumps — live under artifacts/,
+# NEVER the repo root. Only the README (which documents the rule) is tracked.
+# Keepable walk/UAT evidence goes in docs/sessions/<date>-<topic>/evidence/.
+/artifacts/*
+!/artifacts/README.md
 
 # Editor / OS / temp junk.
 *.bak

--- a/artifacts/README.md
+++ b/artifacts/README.md
@@ -1,0 +1,16 @@
+# `artifacts/` — designated home for transient files
+
+**Rule (founder directive 2026-06-03): NEVER drop screenshots, logs, test
+output, or any throwaway file in the repository root. It is a shame on the
+repo.** Everything transient has a home here or under `docs/sessions/`.
+
+| Kind of file | Where it goes | Tracked? |
+|---|---|---|
+| Throwaway debug screenshots, scratch dumps | `artifacts/screenshots/`, `artifacts/scratch/` | **No** — gitignored |
+| Playwright MCP session dumps | `.playwright-mcp/` | No — gitignored |
+| Playwright test-runner output | `test-results/` | No — gitignored |
+| **Walk / UAT evidence you WANT to keep** (proof a case passed) | `docs/sessions/<YYYY-MM-DD>-<topic>/evidence/` | **Yes** — committed with its session report |
+
+Everything in `artifacts/` except this README is gitignored. If a screenshot
+is real acceptance evidence, move it into the dated `docs/sessions/.../evidence/`
+folder and commit it there — do not leave it loose in `artifacts/` or root.

--- a/docs/ledger/UAT-2026-06-03.md
+++ b/docs/ledger/UAT-2026-06-03.md
@@ -1,189 +1,121 @@
-# OpenOva — User Acceptance Test (UAT) — 2026-06-03
+# OpenOva Catalyst — User Acceptance Test (UAT) walkthrough — 2026-06-03
 
-> **How to use this document.** Walk it top to bottom. Each **test case** gives you (a) the exact links to click and steps to follow, (b) what we already verified so you know what to expect, and (c) a **Result** box to tick. Click the links, do the steps, tick ☑ PASS or ☒ FAIL. Where a case is code-only (no UI), the "steps" are a single copy-paste command.
+> **This is a click-by-click acceptance walk.** Every row is **one UI action**: open a link → do the thing → check what's on screen → tick ☑/☒. Walk the tables top-to-bottom. You should never need to read code to accept a case — if a row needs a terminal, it's flagged 🖥️ and the appendix holds it.
 >
-> **Method:** 17 parallel verification agents + an independent zero-theater audit produced the evidence below. Every "we verified" claim is backed by a merged PR, a file:line, or a passing test — **but PR-merge ≠ accepted.** Acceptance is *your* walk. That's what this doc is for.
->
-> Living state: [`docs/ledger/TRACKER.md`](TRACKER.md) · [`docs/ledger/TRUST.md`](TRUST.md). Detailed per-section evidence: [`docs/sessions/2026-06-03-uat-acceptance/`](../sessions/2026-06-03-uat-acceptance/).
+> **The contract:** PR-merge ≠ accepted. **Your walk is acceptance.** Issues stay **open** until *you* close them after walking the relevant row.
 
 ---
 
-## 0 · Setup — the Sovereign under test
+## 0 · Log in once (do this first)
 
-| | |
-|---|---|
-| **Sovereign** | `hw88.omani.works` — fresh 2-region (me-east-215-a + me-east-215-b) active-hot-standby prov, 2026-06-03 |
-| **Deployment id** | `10228182416a724f` |
-| **Operator console** | **https://console.hw88.omani.works** |
-| **Marketplace** | **https://marketplace.hw88.omani.works** |
-| **Live prov status** | **https://console.openova.io/sovereign/deployments** (watch hw88 reach `ready`) |
-| **Login** | PIN flow — open the console, enter operator email `emrah.baysal@openova.io`, receive the 6-digit PIN by mail, enter it. (Break-glass: a handover-JWT can be minted from the mothership PVC key if PIN mail isn't wired.) |
+| # | Go to | Then do | You should see | Result |
+|---|---|---|---|---|
+| 0.1 | **https://console.hw88.omani.works/login** | Type operator email `emrah.baysal@openova.io`, click **Sign in** | Page advances to **/login/verify** with your email shown as a pill + a 6-box PIN input | ☐ |
+| 0.2 | (PIN arrives by mail) | Type / paste the **6-digit code** | Auto-submits on the 6th digit; you land on **/dashboard**, authenticated — *no* "could not provision user record" error | ☐ |
 
-> ⏳ **hw88 is provisioning as this doc is written.** Phase 0 (Huawei infra) is complete; Phase 1 (bootstrap-kit) is reconciling. The UI test cases below go live the moment it reaches `ready`/handover. The **code-only** test cases (marked 🖥️) you can run right now against the repo.
+*Break-glass if PIN mail isn't wired:* mint a handover-JWT from the mothership PVC key and open the console with it (see Appendix A). Stay logged in for every table below.
 
-**Legend:** ☐ not yet walked · ☑ PASS · ☒ FAIL · 🌐 needs the live hw88 console · 🖥️ runnable now (command) · 🔬 needs post-cutover state
+> ⚠️ **Live-target note (2026-06-03).** hw88 was **manually unwedged** during bring-up (a zero-touch violation) and has since been **wiped** on founder order. The `hw88.omani.works` URLs below are therefore **templates** — repoint `<sovereign-fqdn>` at the next **clean** prov (one that reconciles to `ready` with **zero** manual touch on the #2982-fixed catalog) before walking. Watch **https://console.openova.io/sovereign/deployments** for that prov to go green. The 🖥️ terminal rows and Appendix C automated checks are walkable now regardless.
 
 ---
 
-## 1 · Pillar 1 — Marketplace + Voucher Onboarding
+## 1 · Pillar 1 — Onboard a customer (voucher → Organization → console)
 
-### TC-1.1 — Redeem a voucher and land in signup 🌐
-**Steps**
-1. Open **https://marketplace.hw88.omani.works/redeem/?code=`<VOUCHER>`**
-2. Confirm the voucher preview renders (plan + credit in OMR).
-3. Click **Redeem** → you're carried into the 6-step wizard (Plans → Apps → Add-ons → BCP → Review → Checkout).
+| # | Go to | Then do | You should see | Result |
+|---|---|---|---|---|
+| 1.1 | **https://console.hw88.omani.works/bss** | Look at the KPI strip | 4 cards: **Billing MRR · Orders pending · Vouchers active · Tenants active** | ☐ |
+| 1.2 | **/bss/vouchers** | Click **Issue**; in the modal fill **Code** (≥16 chars), **Credit (OMR)**, **Max redemptions**, **Recipient email**; click **Issue** | The new voucher appears in the table with a green **active** status pill | ☐ |
+| 1.3 | Voucher row | Click the row → drawer opens | Drawer shows the code + a **Revoke** action; revoking warns "only NEW redemptions will be blocked" | ☐ |
+| 1.4 ⚠️ | **https://marketplace.hw88.omani.works/redeem/?code=`<the code>`** | Open the customer redeem link | Voucher preview (plan + OMR credit) → **Redeem** carries you into signup. **⚠️ Honest flag:** the customer-facing redeem page is served by the *marketplace projector* (`core/marketplace`), **not** the operator console — confirm it renders; if it 404s, that surface isn't wired yet and this row is a **FAIL to file**, not a pass. | ☐ |
+| 1.5 | (after redeem/signup completes) | Back in **/bss/tenants**, refresh | The new **Organization** appears as an active tenant (organization-controller bootstrapped its Keycloak group + Gitea Org + per-Org IaC repo) | ☐ |
 
-**Expected** — voucher validates, credit shown, wizard opens. No `openova.io`/`admin.<fqdn>` legacy URLs.
-**We verified** — redeem handler `core/services/gateway/main.go`; single-use enforced by DB primary key + transactional checkout; voucher min-entropy 16 chars + `/checkout` rate-limit 5/60s (PR #2953/#2954). Field-proven on hw78 (81/81, 2026-05-31).
-**Result:** ☐
-
-### TC-1.2 — Complete signup → Organization created 🌐
-**Steps**
-1. In the wizard, fill company + email + **pick BCP topology** + region.
-2. Click through Review → **Checkout**.
-3. Watch for the Organization to be created.
-
-**Expected** — an `Organization` CR is created; organization-controller bootstraps the per-Org Keycloak group + Gitea Org + per-Org IaC repo.
-**We verified** — organization-controller IaC bootstrap (`core/controllers/organization/internal/iacbootstrap/bootstrap.go`); KC dial fixed to `keycloak.keycloak.svc:80` (#2895) + controllers auto-roll on config change (#2928).
-**Result:** ☐
-
-### TC-1.3 — Reach the operator console via PIN silent-SSO 🌐
-**Steps**
-1. Open **https://console.hw88.omani.works**
-2. Enter `emrah.baysal@openova.io` → receive PIN → enter it.
-3. You land on the operator console, authenticated.
-
-**Expected** — PIN login works; no error like "could not provision user record".
-**We verified** — catalyst-pin IDR `defaultProvider`; PIN issuer now env-driven (`CATALYST_PIN_ISSUER`, PR #2947) so a franchised Sovereign stamps its own issuer.
-**Result:** ☐
+*Evidence behind the screens:* redeem handler `core/services/gateway/main.go`; single-use enforced by DB PK + transactional checkout; voucher min-entropy 16 + `/checkout` rate-limit 5/60s (#2953/#2954); org-controller IaC bootstrap `core/controllers/organization/internal/iacbootstrap/bootstrap.go`; KC dial fixed `keycloak.keycloak.svc:80` (#2895).
 
 ---
 
-## 2 · Pillar 2 — Multi-region BCP at signup
+## 2 · Pillar 2 — Multi-region BCP chosen at signup
 
-### TC-2.1 — Both regions actually materialize 🖥️ (already proven on hw88!)
-**Steps** — on the mothership:
-```
-kubectl --kubeconfig ~/.kube/<hw88> get nodes -L topology.kubernetes.io/region
-```
-**Expected** — nodes labelled with **both** `me-east-215-a` AND `me-east-215-b`. No silent single-region.
-**We verified** — admission gate `provisioner.go:798` rejects active-hot-standby + <2 regions; partial-region detection uniform across Hetzner+Huawei (`normalisePerRegionKeys`, PR #2917); 10/10 Hetzner + 3/3 Huawei tofu tests green. **hw88 just materialized BOTH regions in Phase 0 — first live proof.**
-**Result:** ☐
+This is a **wizard** journey (mothership provisioning UI). For an *already-provisioned* hw88 you verify the *result* (rows 2.3–2.4); to walk the *choice*, use the wizard (rows 2.1–2.2).
 
-### TC-2.2 — bp-continuum auto-enabled on the multi-region prov 🖥️
-**Steps**
-```
-kubectl --kubeconfig ~/.kube/<hw88> get hr bp-continuum -n flux-system -o jsonpath='{.spec.values.continuum.enabled}'
-```
-**Expected** — `true` (auto-flipped because len(regions)>1).
-**We verified** — cloud-init emits `CONTINUUM_ENABLED` from region count, both providers (PR #2923); chart prereq-guard initContainer (PR #2925).
-**Result:** ☐
+| # | Go to | Then do | You should see | Result |
+|---|---|---|---|---|
+| 2.1 | **https://console.openova.io/wizard** | Click through **Org → Topology** step | The **Topology** step offers region count + HA; picking 2 regions enables multi-region topologies | ☐ |
+| 2.2 | Topology picker | Select the **active-hot-standby** radio | Helper text: *"Region-A serves; region-B mirrored and ready for failover"* (radios: active-active / **active-hot-standby** / active-passive / singleton) | ☐ |
+| 2.3 🖥️ | terminal | `kubectl --kubeconfig ~/.kube/<hw88> get nodes -L topology.kubernetes.io/region` | Nodes labelled with **both** `me-east-215-a` AND `me-east-215-b` — no silent single-region. *(hw88 materialized both regions in Phase 0 — first live proof of the multi-region tofu fixes.)* | ☐ |
+| 2.4 🖥️ | terminal | `kubectl --kubeconfig ~/.kube/<hw88> get hr bp-continuum -n flux-system -o jsonpath='{.spec.values.continuum.enabled}'` | `true` — auto-flipped because len(regions)>1 (#2923/#2925) | ☐ |
 
 ---
 
 ## 3 · Pillar 3 — Two CNPG clusters + region-kill failover
 
-### TC-3.1 — Every CNPG cluster is multi-instance 🖥️
-**Steps**
-```
-kubectl --kubeconfig ~/.kube/<hw88> get cluster.postgresql.cnpg.io -A -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,INSTANCES:.spec.instances
-```
-**Expected** — every CNPG `Cluster` shows `instances: 2` (not 1).
-**We verified** — `SOVEREIGN_CNPG_INSTANCES` threaded to all CNPG charts; switchover sequencer (`core/controllers/continuum/internal/switchover/`) has PDM+NATS step timeouts so failover holds ≤60s RTO (PR #2957, tests green).
-**Result:** ☐
-
-### TC-3.2 — Region-kill failover (the real DR test) 🌐🖥️
-**Steps**
-1. Note the primary region. Kill it (stop region-a CP via the Huawei console **or** scale its CNPG primary to 0).
-2. Watch `kubectl get continuum -A` + the lua-record flip.
-3. Confirm the app stays up on region-b within ~60s, zero data loss.
-
-**Expected** — Continuum CR switches primary→replica, HTTPRoute drains, lua-record flips, ≤60s recovery.
-**We verified** — full K-Cont-2 7-step sequencer (not a stub); failover-readiness probe observes real WAL lag.
-**Result:** ☐
+| # | Go to | Then do | You should see | Result |
+|---|---|---|---|---|
+| 3.1 🖥️ | terminal | `kubectl --kubeconfig ~/.kube/<hw88> get cluster.postgresql.cnpg.io -A -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,INST:.spec.instances` | **Every** CNPG `Cluster` shows `INST: 2` (never 1) — `SOVEREIGN_CNPG_INSTANCES` threaded to all CNPG charts | ☐ |
+| 3.2 | **/dashboard** → note the live primary region | Kill region-A (Huawei console: stop region-a CP, **or** scale its CNPG primary to 0) | Dashboard shows region-A unhealthy | ☐ |
+| 3.3 | **/dashboard** (watch ~60s) | Observe the Continuum failover | Continuum CR switches primary→replica, HTTPRoute drains, lua-record flips; app stays up on region-B within **≤60s**, zero data loss (#2957 PDM+NATS step timeouts) | ☐ |
 
 ---
 
-## 4 · Pillar 4 — Sandbox + auto-mounted MCP
+## 4 · Pillar 4 — Sandbox with auto-mounted org-knowledge MCP
 
-### TC-4.1 — Launch a Sandbox 🌐
-**Steps**
-1. Console → **Sandbox** → **New Sandbox**.
-2. Wait for the session pod to reach Ready.
-3. Open the shell.
-
-**Expected** — interactive shell with `openova-sandbox-mcp` auto-mounted (`/etc/mcp/servers.json` lists it).
-**We verified** — MCP server real (54 tools, stdio JSON-RPC), bundled in the pty-server image.
-**Result:** ☐
-
-### TC-4.2 — AI assistant sees full Org knowledge 🌐
-**Steps** — from inside the Sandbox shell:
-```
-mcp-cli openova-sandbox-mcp k8s.read.list --group apps.openova.io --resource applications --namespace <org>
-```
-**Expected** — returns the Org's Applications (or empty list) — **NOT** `403 Forbidden`.
-**We verified** — Sandbox SA RBAC granted read on `apps.openova.io` / `catalyst.openova.io` / `orgs.openova.io` (PR #2952); Playwright coverage added (PR #2959, not yet run live).
-**Result:** ☐
+| # | Go to | Then do | You should see | Result |
+|---|---|---|---|---|
+| 4.1 | **https://console.hw88.omani.works/sandbox** | Look at the agent grid | 6 agent cards: **aider · claude-code · cursor-agent · little-coder · opencode · qwen-code** | ☐ |
+| 4.2 | Click **claude-code** | A session starts → lands on **/sandbox/`<id>`** | An **xterm terminal** attaches (WebSocket to pty-server); shell is interactive | ☐ |
+| 4.3 | In the shell | `cat /etc/mcp/servers.json` | Lists **openova-sandbox-mcp** (auto-mounted, 54 tools, stdio JSON-RPC) | ☐ |
+| 4.4 | In the shell | `mcp-cli openova-sandbox-mcp k8s.read.list --group apps.openova.io --resource applications --namespace <org>` | Returns the Org's Applications (or empty list) — **NOT** `403 Forbidden` (Sandbox SA RBAC #2952) | ☐ |
 
 ---
 
-## 5 · Pillar 5 — Sovereign independence (post-cutover)
+## 5 · Pillar 5 — Sovereign independence (post-cutover) 🔬
 
-### TC-5.1 — Run bp-self-sovereign-cutover 🌐🔬
-**Steps**
-1. Console → trigger cutover (or `POST /sovereign/api/v1/internal/cutover/trigger`).
-2. Watch the 11 sequential Jobs.
-
-**Expected** — all 11 Jobs succeed; `cutoverComplete=true` only after the 10-min deny-egress hold reconciles green.
-**We verified** — chart ships 11 Jobs + the 600s egress-hold; `cutoverComplete` gate enforced only on full success.
-**Result:** ☐
-
-### TC-5.2 — Zero mothership tethers after cutover 🔬
-**Steps**
-```
-kubectl --kubeconfig ~/.kube/<hw88> get hr -A -o yaml | grep -i 'harbor.openova.io'
-```
-**Expected** — **zero** matches outside the intentional pre-cutover ghcr.io catalog-fetch (ADR-0002).
-**We verified** — cutover Step now pivots bp-sso-bridge image host off mothership Harbor (PR #2962); Go `pinIssuer` + Huawei PDNS host + CORS origin all de-hardcoded (PR #2947/#2948/#2949/#2950).
-**Result:** ☐
+| # | Go to | Then do | You should see | Result |
+|---|---|---|---|---|
+| 5.1 | **/settings** (or `POST /sovereign/api/v1/internal/cutover/trigger`) | Trigger **bp-self-sovereign-cutover** | The cutover Jobs start | ☐ |
+| 5.2 | **/jobs** | Watch the sequential cutover Jobs | All Jobs succeed; `cutoverComplete=true` **only** after the final 10-min deny-egress hold reconciles green | ☐ |
+| 5.3 🖥️ | terminal | `kubectl --kubeconfig ~/.kube/<hw88> get hr -A -o yaml \| grep -i 'harbor.openova.io'` | **Zero** matches outside the intentional pre-cutover ghcr.io catalog-fetch (ADR-0002) — bp-sso-bridge image host pivoted off mothership (#2962); issuer/PDNS/CORS de-hardcoded (#2947–#2950) | ☐ |
 
 ---
 
-## 6 · G117 — Application-Lifecycle features
+## 6 · G117 — Application lifecycle in the console
 
-### TC-6.1 — Silent-SSO "Launch" button 🌐
-**Steps**
-1. Console → **Apps** → open an installed app (Grafana).
-2. Click **Launch**.
+| # | Go to | Then do | You should see | Result |
+|---|---|---|---|---|
+| 6.1 | **/apps** → click an installed app (e.g. **Grafana**) → **/app/grafana** | Read the tab strip | Tabs: **Overview · Topology · Resources · Compliance · Logs · Settings · Members · Jobs · Dependencies** | ☐ |
+| 6.2 | On **/app/grafana** | Click **Launch →** | A new tab opens Grafana **already authenticated** — *no* Keycloak login form (silent-SSO `kc_idp_hint=catalyst-pin&prompt=none`; 5-layer chain #2873–#2895) | ☐ |
+| 6.3 | Repeat **Launch →** for one app per tier | T1 Grafana/Gitea/Harbor · T2 Guacamole/PowerDNS-admin/**Hubble-UI** · T3 Matrix/LibreChat | All land authenticated; **Hubble-UI now requires OIDC** (was unauthenticated — #2967 closed the hole) | ☐ |
+| 6.4 | **/catalog/grafana** | Click **+ New instance** → **/catalog/grafana/new** | Form: **Instance name**, **Organization slug**, **Topology** radios, optional **Endpoint hostname**, **Create instance** button | ☐ |
+| 6.5 | On **/catalog/grafana/new** | Fill name + org, pick **active-hot-standby**, click **Create instance** | Redirects to **/apps/`<id>`** for the new instance (multi-instance create) | ☐ |
+| 6.6 | **/apps/`<id>`/endpoints** | Click **+ New endpoint**, fill the dialog, click **Save — open PR** | Green banner: *"Change submitted as PR `<link>` — auto-merges on green"* | ☐ |
+| 6.7 | Open **gitea.hw88.omani.works/`<org>`/iac** | Find the PR from 6.6 | PR is open; the **3 status checks** (`kyverno-admission`, `cert-manager-precheck`, `dns-conflict-precheck`) run and it **auto-merges** (#2965 seeded the missing `.gitea/workflows/iac-prechecks.yml`) | ☐ |
+| 6.8 🖥️ | terminal | apply a Blueprint whose `topology.defaults.multi-region` isn't in `supported[]` (snippet in Appendix B) | **HTTP 422**: *"topology.defaults.multi-region must be a member of topology.supported[]"* (CEL `blueprint.yaml:353` #2958) | ☐ |
 
-**Expected** — a new tab opens Grafana **already authenticated** — no Keycloak login form.
-**We verified** — `AppDetail.tsx` calls `/catalyst/v1/apps/{uid}/launch-url` with `kc_idp_hint=catalyst-pin&prompt=none`; 5-layer SSO chain fixed across PRs #2873–#2895.
-**Result:** ☐
+---
 
-### TC-6.2 — 3-tier SSO fan-out (incl. Hubble UI now gated) 🌐
-**Steps** — Launch one app from each tier: Grafana/Gitea/Harbor (T1), Guacamole/PowerDNS-admin/**Hubble-UI** (T2), Matrix/LibreChat (T3). Each should land authenticated.
-**Expected** — silent login on all; **Hubble UI now requires OIDC** (was unauthenticated).
-**We verified** — per-tier OIDC clients in realm-import; **Hubble UI oauth2-proxy enforcement shipped (PR #2967)**, closing an unauthenticated-exposure hole.
-**Result:** ☐
+## Acceptance summary (fill as you walk)
 
-### TC-6.3 — Per-Org realm 2-hop SSO 🌐
-**Steps** — sign in as a user of `<org>`; confirm you transit `auth.hw88.omani.works/realms/<org>/broker/sovereign-broker/endpoint` and land without a KC form.
-**We verified** — dual-token KC mint (master-realm token for `POST /admin/realms`), bp-keycloak 1.4.18 + bp-sso-bridge 0.2.8 (PR #2918); chart-tests pass.
-**Result:** ☐
+| Section | UI rows | Walked | Pass | Fail |
+|---|---|---|---|---|
+| 0 — Login | 2 | | | |
+| Pillar 1 — Onboarding | 5 | | | |
+| Pillar 2 — Multi-region BCP | 4 | | | |
+| Pillar 3 — CNPG failover | 3 | | | |
+| Pillar 4 — Sandbox + MCP | 4 | | | |
+| Pillar 5 — Cutover | 3 | | | |
+| G117 — App lifecycle | 8 | | | |
+| **Total** | **29** | | | |
 
-### TC-6.4 — Endpoints tab → Git-IaC PR pipeline 🌐
-**Steps**
-1. Console → an App → **Endpoints** tab → add/edit an endpoint.
-2. Open `gitea.hw88.omani.works/<org>/iac` → confirm a PR opened.
-3. Confirm the 3 status checks (`kyverno-admission`, `cert-manager-precheck`, `dns-conflict-precheck`) run and the PR auto-merges.
+> Replace each `☐` with ☑/☒ as you walk. For a FAIL, drop the symptom + a screenshot link inline and keep the issue **open**.
 
-**Expected** — endpoint mutation → gitea PR → 3 checks green → auto-merge.
-**We verified** — **PR #2965 seeded the missing `.gitea/workflows/iac-prechecks.yml`** that was trapping every PR forever; org-controller seeds it into the per-Org repo at bootstrap.
-**Result:** ☐
+---
 
-### TC-6.5 — Malformed Blueprint rejected at admission 🖥️
-**Steps**
-```
+## Appendix A — break-glass login (PIN mail not wired)
+
+Mint a 5-min handover-JWT from the mothership PVC signing key (`/deps/handover-jwt-private.pem`, RS256, `iss=https://console.openova.io`, your email as `sub`) and open `https://console.hw88.omani.works/?token=<jwt>`. This is the operator break-glass, not the customer path.
+
+## Appendix B — malformed-Blueprint snippet (row 6.8)
+
+```bash
 kubectl --kubeconfig ~/.kube/<hw88> apply -f - <<'EOF'
 apiVersion: catalyst.openova.io/v1
 kind: Blueprint
@@ -192,59 +124,36 @@ spec:
   topology: {supported: [singleton], defaults: {multi-region: active-active, single-region: singleton}}
 EOF
 ```
-**Expected** — **HTTP 422** rejected: "topology.defaults.multi-region must be a member of topology.supported[]".
-**We verified** — CEL cross-field validation `blueprint.yaml:353` (PR #2958) + Application rto/rpo/minReplicas bounds (PR #2960).
-**Result:** ☐
 
----
+## Appendix C — automated checks already green (code-side, not a UI walk)
 
-## 7 · Security & reliability hardening (run-now checks 🖥️)
+These were code-verified on `main` (independent audit: zero theater) and run live 2026-06-03. They back the UI rows but are **not** acceptance themselves — your walk above is.
 
-> These are code-verified on `main` (independent audit: **8/8 present, zero theater**). **All 8 were executed live on 2026-06-03 09:38Z — results in the Result column.** You can re-run any command yourself to confirm.
-
-| # | Hardening | Confirm command | Expect | Result (ran 2026-06-03) |
+| # | Hardening | Confirm command | Expect | Ran 2026-06-03 |
 |---|---|---|---|---|
-| 7.1 | Sandbox RBAC (#2952) | `grep -c 'apps.openova.io' core/controllers/sandbox/internal/gitops/manifests.go` | ≥1 | **☑ PASS** (1) |
-| 7.2 | Patch-script reload not masked (#2956) | `grep -c 'exit 4' tools/patch-existing-nodes-registries-yaml.sh` | ≥1 | **☑ PASS** (exit-4 guard present, no `\|\| true` mask) |
-| 7.3 | Switchover timeouts (#2957) | `cd core/controllers/continuum && go test ./internal/switchover/...` | ok | **☑ PASS** (`ok … switchover 0.018s`) |
-| 7.4 | bp-vpa Cilium trap (#2946) | `helm template platform/vpa/chart --set vpaOverlay.networkPolicy.enabled=true \| grep -vE '^\s*#' \| grep -c ipBlock` | 0 | **☑ PASS** (0 live ipBlock keys) |
-| 7.5 | KC master Secret keep (#2945) | `grep -c 'helm.sh/resource-policy: keep' platform/keycloak/chart/templates/configmap-sovereign-realm.yaml` | ≥1 | **☑ PASS** (1) |
-| 7.6 | Voucher entropy + rate-limit (#2953/#2954) | `cd core/services/billing && go test ./handlers/...` | ok | **☑ PASS** (`TestCheckoutRateLimiter_2941` PASS; full pkg `ok`) |
-| 7.7 | Harbor mirror token, all 4 cloud-inits (#2966) | `grep -l harbor_robot_token infra/providers/*/cloudinit-*.tftpl \| wc -l` | 4 | **☑ PASS** (4/4) |
-| 7.8 | Catalog-seed lockstep (#2926/#2927) | `bash scripts/check-catalog-seed-lockstep.sh` | PASS | **☑ PASS** (0 drift) |
+| C.1 | Sandbox RBAC (#2952) | `grep -c 'apps.openova.io' core/controllers/sandbox/internal/gitops/manifests.go` | ≥1 | ☑ (1) |
+| C.2 | Patch-script reload not masked (#2956) | `grep -c 'exit 4' tools/patch-existing-nodes-registries-yaml.sh` | ≥1 | ☑ |
+| C.3 | Switchover timeouts (#2957) | `cd core/controllers/continuum && go test ./internal/switchover/...` | ok | ☑ |
+| C.4 | bp-vpa Cilium trap (#2946) | `helm template platform/vpa/chart --set vpaOverlay.networkPolicy.enabled=true \| grep -vE '^\s*#' \| grep -c ipBlock` | 0 | ☑ |
+| C.5 | KC master Secret keep (#2945) | `grep -c 'helm.sh/resource-policy: keep' platform/keycloak/chart/templates/configmap-sovereign-realm.yaml` | ≥1 | ☑ |
+| C.6 | Voucher entropy + rate-limit (#2953/#2954) | `cd core/services/billing && go test ./handlers/...` | ok | ☑ (`TestCheckoutRateLimiter_2941` PASS) |
+| C.7 | Harbor mirror token, all 4 cloud-inits (#2966) | `grep -l harbor_robot_token infra/providers/*/cloudinit-*.tftpl \| wc -l` | 4 | ☑ |
+| C.8 | Catalog-seed lockstep (#2926/#2927) | `bash scripts/check-catalog-seed-lockstep.sh` | PASS | ☑ |
+| C.9 | Fresh-prov wedge fix (#2981/#2982) | host namespaces dmz/mgmt/rtz declared in bootstrap-kit slot 00 | present | ☑ |
 
-**§7 acceptance: 8/8 ☑ PASS — verified live, ready for your sign-off.**
+## Appendix D — UI route reference (so you can trust the links above)
 
----
-
-## 8 · Repository quality (deep-clean — accept the housekeeping 🖥️)
-
-| Area | Confirm | Expect |
+| Surface | Route | Source |
 |---|---|---|
-| Rubbish purged (#2968) | `git ls-files '*.png' \| grep -vE '^(docs/\|brand/\|products/.*ui)'` | empty |
-| Legacy doc dirs gone (#2969/#2974) | `ls docs/lessons-learned docs/proposals docs/runbooks 2>&1` | not found |
-| Debugging cookbook folded in (#2974) | `grep -n 'Debugging cookbook' docs/RUNBOOKS.md` | §12 present |
-| ADR-0009 indexed (#2972) | `grep -c '0009' docs/adr/README.md` | ≥1 |
-| Dead doc-links repaired (#2973) | open the 7 canonical docs — no dead `docs/*.md` links | clean |
+| Login / PIN | `/login` → `/login/verify` | `bootstrap/ui/src/pages/auth/{LoginPage,VerifyPinPage}.tsx` |
+| Dashboard | `/dashboard` | sovereign console chroot |
+| Apps grid / App detail | `/apps`, `/app/<id>` | `bootstrap/ui/src/pages/sovereign/AppDetail.tsx` |
+| Catalog / new instance | `/catalog/<name>`, `/catalog/<name>/new` | `console/src/routes/catalog/[name]/new/+page.svelte` + `TopologyPicker.svelte` |
+| Endpoints | `/apps/<id>/endpoints` | `console/src/components/EndpointsTab.svelte` |
+| Sandbox | `/sandbox`, `/sandbox/<id>` | `bootstrap/ui/src/pages/sovereign/sandbox/SandboxLanding.tsx` |
+| BSS / Vouchers | `/bss`, `/bss/vouchers` | `bootstrap/ui/src/pages/sovereign/bss/{BssLandingPage,VouchersPage}.tsx` |
+| Provisioning wizard | `/wizard` | `bootstrap/ui/src/pages/wizard/WizardPage.tsx` |
 
 ---
 
-## Acceptance summary (fill as you walk)
-
-| Section | Cases | Walked | Pass | Fail |
-|---|---|---|---|---|
-| Pillar 1 — Marketplace/voucher | 3 | | | |
-| Pillar 2 — Multi-region BCP | 2 | | | |
-| Pillar 3 — CNPG failover | 2 | | | |
-| Pillar 4 — Sandbox + MCP | 2 | | | |
-| Pillar 5 — Cutover independence | 2 | | | |
-| G117 features | 5 | | | |
-| Hardening (run-now) | 8 | | | |
-| Repo quality | 5 | | | |
-| **Total** | **29** | | | |
-
-> When you've walked a case, replace its `☐` with ☑/☒ and (for failures) drop the symptom + a screenshot link inline. The issues stay **open** until you close them after this walk — that's the contract.
-
----
-
-_Generated 2026-06-03 from 17 parallel verification agents + independent audit. Per-section evidence with file:line in [`docs/sessions/2026-06-03-uat-acceptance/`](../sessions/2026-06-03-uat-acceptance/)._
+_Generated 2026-06-03. UI routes/labels sourced from the live console + bootstrap UI codebases (file:line in Appendix D). Living state: [`TRACKER.md`](TRACKER.md) · [`TRUST.md`](TRUST.md)._


### PR DESCRIPTION
**Founder directive 2026-06-03:** no transient files in the repo root — designated folder structure required.

## Changes
- `artifacts/` — designated home for throwaway files (screenshots/scratch/logs). Only `artifacts/README.md` tracked; rest gitignored.
- `docs/sessions/<date>-<topic>/evidence/` — committed home for keepable walk/UAT evidence.
- `.gitignore` root guard broadened to `/*.{png,jpg,jpeg,gif,webp,log}` + `/artifacts/*`.
- Pruned 19 leaked agent worktrees (32→13).
- `UAT-2026-06-03.md` rewritten as a **click-by-click UI-walk** — every row is one console action (open URL → click → see → tick); routes/labels sourced from the real console + bootstrap UI (Appendix D). hw88 noted **wiped**; URLs are templates for the next clean zero-touch prov.

🤖 Generated with [Claude Code](https://claude.com/claude-code)