### PR TITLE
fix(bootstrap-kit): break bp-external-secrets↔bp-openbao deadlock (#2985)

### DIFF
--- a/clusters/_template/bootstrap-kit/15-external-secrets.yaml
+++ b/clusters/_template/bootstrap-kit/15-external-secrets.yaml
@@ -54,8 +54,17 @@ spec:
   #   - bp-cert-manager(02): ESO's admission webhook needs a TLS cert.
   #     bp-cert-manager provides the ClusterIssuer that signs it.
   dependsOn:
-    # G92.2 #2661 (2026-06-01): bp-openbao HR moved to host ns `mgmt`.
-    - name: bp-openbao
+    # MUST NOT dependOn bp-openbao. openbao's chart ships an ExternalSecret
+    # (sso-oauth-source-externalsecret.yaml, gated on sso.enabled) that needs
+    # THIS HR's external-secrets.io CRD. Depending on openbao here creates a
+    # deadlock: openbao install fails ("no matches for kind ExternalSecret …
+    # ensure CRDs are installed first") so it never goes Ready, while this HR
+    # waits forever on openbao → fresh prov wedges at ~38/56 HRs (caught live
+    # on hw89 2026-06-03). The ESO CONTROLLER only needs cert-manager (its
+    # admission webhook's TLS cert). The openbao-backed SecretStore binding
+    # lives on bp-external-secrets-stores (slot 15a), which correctly
+    # dependsOn BOTH bp-external-secrets AND bp-openbao. Reverts the errant
+    # G92.2 #2661 dep that introduced the cycle.
     - name: bp-cert-manager
   chart:
     spec:


### PR DESCRIPTION
Fresh-prov deadlock caught live on hw89 (#2985): cascade wedged at 38/56 because bp-external-secrets dependsOn bp-openbao, but openbao ships an ExternalSecret needing the ESO CRD. Removing the errant dep (the openbao binding stays on bp-external-secrets-stores slot 15a) breaks the cycle.

Sibling of #2982. Validated by hw89 self-healing once this lands on main (Flux re-syncs the catalog — zero manual cluster touch).

Refs #2985

🤖 Generated with [Claude Code](https://claude.com/claude-code)