### PR TITLE
fix(cnpg): widen operator startup-probe 30s→150s for slow HCS nodes

### DIFF
--- a/clusters/_template/bootstrap-kit/16-cnpg.yaml
+++ b/clusters/_template/bootstrap-kit/16-cnpg.yaml
@@ -63,7 +63,7 @@ spec:
       # CA written to MutatingWebhookConfiguration caBundle → x509
       # verify failed → all Cluster CR admissions denied. G53
       # webhook-gate remains as readiness signal.
-      version: 1.0.6
+      version: 1.0.7
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg

--- a/platform/cnpg/blueprint.yaml
+++ b/platform/cnpg/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-4-1-data-services
 spec:
-  version: 1.0.6
+  version: 1.0.7
   card:
     title: CloudNativePG
     summary: |

--- a/platform/cnpg/chart/Chart.yaml
+++ b/platform/cnpg/chart/Chart.yaml
@@ -8,7 +8,7 @@ name: bp-cnpg
 # kind of certificate") → bp-catalyst-platform + bp-newapi Helm
 # install denied. Trust upstream operator's self-managed cert flow;
 # G53 webhook-gate Job remains as the readiness signal.
-version: 1.0.6
+version: 1.0.7
 description: |
   Catalyst-curated Blueprint umbrella chart for CloudNativePG. Depends on
   the upstream `cloudnative-pg` chart as a Helm subchart so

--- a/platform/cnpg/chart/values.yaml
+++ b/platform/cnpg/chart/values.yaml
@@ -120,6 +120,19 @@ cloudnative-pg:
   # Webhook is enabled by default in upstream — keep it that way (CNPG
   # uses the webhook to validate Cluster CRs). cert-manager (bp-cert-
   # manager) provides the TLS cert per Sovereign convention.
+  webhook:
+    # HCS startup-probe widening (#2989-followup — caught live on hw90).
+    # Upstream default is failureThreshold 6 × periodSeconds 5 = 30s. On
+    # slow HCS Kom4DC nodes the operator's leader-election + webhook-server
+    # (:9443) bind exceeds 30s, so the startup probe kills the operator
+    # before /readyz responds → CrashLoopBackOff ("failed startup probe")
+    # that wedges the whole cascade (bp-openbao → bp-sso-bridge →
+    # bp-catalyst-platform all dependsOn bp-cnpg). 30 × 5 = 150s gives
+    # ample headroom; the probe only runs at startup, so there's no
+    # steady-state cost.
+    startupProbe:
+      failureThreshold: 30
+      periodSeconds: 5
 
 # ─── Catalyst-managed overlay values consumed by templates/ ───────────────
 


### PR DESCRIPTION
Caught live on hw90: bp-cnpg operator CrashLoopBackOff wedges the cascade at 29/56 (openbao→sso-bridge→catalyst-platform all dependsOn cnpg). Events: 'failed startup probe' — the operator is alive but :9443 /readyz doesn't bind within the 30s window on slow HCS nodes. Override failureThreshold 6→30 (150s). Memory already 2Gi (not OOM), cert valid+mounted — purely a probe-timing fix. Lockstep bp-cnpg 1.0.6→1.0.7.

Refs #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)