### PR TITLE
docs(uat): repoint hw89→hw90 + refresh verdict to true fresh-prov state

### DIFF
--- a/docs/ledger/UAT-2026-06-03.md
+++ b/docs/ledger/UAT-2026-06-03.md
@@ -13,12 +13,12 @@
 | Field | Value |
 |---|---|
 | **Product / release** | OpenOva Catalyst — Sovereign `<sovereign-fqdn>` (target: fresh prov `hw90`, 2-region `me-east-215-a`/`-b`, active-hot-standby) |
-| **Build under test** | catalog `main@4db218f3` |
+| **Build under test** | catalog `main` (incl. fresh-prov fixes #2982 / #2985 / #2989 / #2995) |
 | **Environment** | `https://console.<sovereign-fqdn>` (operator console) · `https://marketplace.<sovereign-fqdn>` (customer marketplace) |
 | **Surface(s)** | Responsive web (operator console + customer marketplace). No native mobile app ships. |
 | **Tester** | `@p0-474-lonely` (UAT executor sub-agent) |
 | **Walk date** | 2026-06-03 |
-| **Overall verdict** | ⛔ **BLOCKED** — the live walk target `hw89` never came up: its Phase-1 cascade terminally stalled on a 3-way SSO-bootstrap deadlock ([#2989](https://github.com/openova-io/openova/issues/2989)), so `console.hw89.omani.works` does not resolve (verified HTTP 000). A fresh prov `hw90` is being raised; every live-UI row below is ⛔ until it reaches `ready`, at which point each ⛔ becomes a real ✅/❌ with a committed screenshot. **This is a truthful could-not-attempt outcome — not a pass and not a fail of the product UI.** |
+| **Overall verdict** | ⛔ **BLOCKED** — no live console yet. The first zero-touch prov (`hw89`) stalled on the #2989 SSO-bootstrap deadlock (now **fixed**, #2994). The current prov **`hw90`** *cleared* that deadlock but surfaced further fresh-prov issues being fix-forwarded **via the catalog only** (cnpg operator startup-probe too tight for HCS → fixed #2995; crossplane-init + image-pulls under investigation), so `console.hw90.omani.works` is not yet up (HTTP 000). **Zero-touch note:** hw90 has been used to *expose* this bug-chain — it is treated as a **failed environment**; the clean zero-touch acceptance comes from a *final* prov that reconciles to `ready` with **zero manual intervention**. Every live-UI row is ⛔ until that prov is `ready`; **truthful could-not-attempt — not a pass, not a product-UI fail.** |
 
 ---
 
@@ -28,7 +28,7 @@
 
 Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the executor is **read-only** on the product and **never closes the issue**; report the screen you saw, not the one you expected; "looks right from the code" is banned.
 
-> **Why this walk is BLOCKED, honestly:** a clean zero-touch prov (`hw89`) was raised to walk these journeys. Its Phase-1 reconcile self-healed two real bugs (#2982, #2985) then **terminally stalled** on a 3-way SSO-bootstrap deadlock ([#2989](https://github.com/openova-io/openova/issues/2989)): `bp-gitea` can't install without an `sso/gitea` secret that `bp-sso-bridge` can't write until `bp-catalyst-platform`→`bp-gitea` is up. The console (catalyst-platform) never reaches Ready and `console.<sovereign-fqdn>` does not resolve. Re-walk on `hw90` once #2989 lands and the prov goes `ready`.
+> **Why this walk is BLOCKED, honestly:** clean zero-touch provs were raised to walk these journeys, and they surfaced a *chain* of real fresh-prov bugs — each fixed **at the source (catalog) only**, never by hand-patching the cluster (a single manual fix fails the zero-touch contract): #2982 (dmz host-namespaces), #2985 (external-secrets↔openbao deadlock), #2989 (the 3-way gitea→catalyst-platform→sso-bridge SSO-bootstrap deadlock — `bp-gitea` can't install without an `sso/gitea` secret `bp-sso-bridge` couldn't write), and #2995 (cnpg operator startup-probe too tight for slow HCS nodes → CrashLoopBackOff). hw89 died on #2989; hw90 cleared it and exposed the cnpg + crossplane + image-pull layer. The console (`bp-catalyst-platform`) does not reach Ready until that whole chain clears, so `console.<sovereign-fqdn>` does not resolve. **Re-walk on the first prov that reaches `ready` with zero manual touch** — that is the acceptance environment.
 
 ---
 
@@ -53,10 +53,10 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [marketplace.`<sovereign-fqdn>`/redeem?code=`<CODE>`](https://marketplace.hw89.omani.works/redeem) | Open the redeem link from the email | "Validating voucher…" spinner, then a **Voucher valid** card showing the **OMR credit** amount + the code | ⛔ | — |
+| 1 | [marketplace.`<sovereign-fqdn>`/redeem?code=`<CODE>`](https://marketplace.hw90.omani.works/redeem) | Open the redeem link from the email | "Validating voucher…" spinner, then a **Voucher valid** card showing the **OMR credit** amount + the code | ⛔ | — |
 | 2 | Redeem preview | Tap **Sign up to redeem** | Advances to the plan wizard at **/plans** — the code is carried into checkout | ⛔ | — |
 
-- **Journey verdict:** ⛔ **BLOCKED** — marketplace not reachable (`hw89` console never came up, [#2989](https://github.com/openova-io/openova/issues/2989)).
+- **Journey verdict:** ⛔ **BLOCKED** — marketplace not reachable (`hw90` console never came up, [#2989](https://github.com/openova-io/openova/issues/2989)).
 
 ### TC-02 — Pick a plan, apps and domain *(web · customer · Pillar 1, Phase 1b)*
 
@@ -66,9 +66,9 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [marketplace.`<sovereign-fqdn>`/plans](https://marketplace.hw89.omani.works/plans) | On **Pick a plan**, tap a plan card, tap **Continue** | Advances to **Build your stack** (/apps) | ⛔ | — |
-| 2 | [/apps](https://marketplace.hw89.omani.works/apps) | Select one or more apps (each tagged **FREE**), tap **Continue** | Advances to **Setup & extras** (/addons) | ⛔ | — |
-| 3 | [/addons](https://marketplace.hw89.omani.works/addons) | Under **Your domain**, type a subdomain (e.g. `my-company`) in the **Subdomain** field; pick any add-ons | Subdomain accepted (≥3 chars, no "Subdomain must be at least 3 characters" warning); **Checkout** button enabled | ⛔ | — |
+| 1 | [marketplace.`<sovereign-fqdn>`/plans](https://marketplace.hw90.omani.works/plans) | On **Pick a plan**, tap a plan card, tap **Continue** | Advances to **Build your stack** (/apps) | ⛔ | — |
+| 2 | [/apps](https://marketplace.hw90.omani.works/apps) | Select one or more apps (each tagged **FREE**), tap **Continue** | Advances to **Setup & extras** (/addons) | ⛔ | — |
+| 3 | [/addons](https://marketplace.hw90.omani.works/addons) | Under **Your domain**, type a subdomain (e.g. `my-company`) in the **Subdomain** field; pick any add-ons | Subdomain accepted (≥3 chars, no "Subdomain must be at least 3 characters" warning); **Checkout** button enabled | ⛔ | — |
 
 - **Journey verdict:** ⛔ **BLOCKED** — marketplace down ([#2989](https://github.com/openova-io/openova/issues/2989)).
 
@@ -80,7 +80,7 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [marketplace.`<sovereign-fqdn>`/bcp](https://marketplace.hw89.omani.works/bcp) | Read the **Business continuity** step — *"Pick how your database should survive a regional outage"* | Two **Topology** cards: **Single-region** (FREE) and **active-hot-standby** | ⛔ | — |
+| 1 | [marketplace.`<sovereign-fqdn>`/bcp](https://marketplace.hw90.omani.works/bcp) | Read the **Business continuity** step — *"Pick how your database should survive a regional outage"* | Two **Topology** cards: **Single-region** (FREE) and **active-hot-standby** | ⛔ | — |
 | 2 | /bcp Topology | Select the **active-hot-standby** card | A **primary region** and a **replica region** picker appear; the two must differ | ⛔ | — |
 | 3 | /bcp | Pick a primary region and a different replica region, tap **Continue** | Advances to **Review & launch** (/review); the form refuses identical regions | ⛔ | — |
 
@@ -94,8 +94,8 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [marketplace.`<sovereign-fqdn>`/review](https://marketplace.hw89.omani.works/review) | On **Review & launch**, check **Your stack**, **Tenant** URL and **Monthly total**, tap **Checkout** | Advances to the **Checkout** page | ⛔ | — |
-| 2 | [/checkout](https://marketplace.hw89.omani.works/checkout) | Under **Sign in to continue**, type the customer email, tap to send the code | "A 6-digit code was sent to `<email>`" + a 6-box PIN input | ⛔ | — |
+| 1 | [marketplace.`<sovereign-fqdn>`/review](https://marketplace.hw90.omani.works/review) | On **Review & launch**, check **Your stack**, **Tenant** URL and **Monthly total**, tap **Checkout** | Advances to the **Checkout** page | ⛔ | — |
+| 2 | [/checkout](https://marketplace.hw90.omani.works/checkout) | Under **Sign in to continue**, type the customer email, tap to send the code | "A 6-digit code was sent to `<email>`" + a 6-box PIN input | ⛔ | — |
 | 3 | /checkout PIN | Type the 6-digit code | Account verified — the **Tenant name** + **Subdomain** + **Order summary** (with voucher **Credit available** applied) render | ⛔ | — |
 | 4 | /checkout | Confirm tenant name, tap **Create** | "Setting up your tenant" → auto-redirect to the new Organization console at **console.`<orgslug>`.`<pool-tld>`** — no "could not provision user record" error | ⛔ | — |
 
@@ -109,8 +109,8 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [console.`<orgslug>`.`<pool-tld>`/dashboard](https://console.hw89.omani.works/dashboard) | Look at the dashboard | The Organization's resource overview renders — not an empty/error page | ⛔ | — |
-| 2 | [/apps](https://console.hw89.omani.works/apps) | Open the **Apps** view | The apps chosen in TC-02 appear as cards, each showing a status badge (Running / Installing) | ⛔ | — |
+| 1 | [console.`<orgslug>`.`<pool-tld>`/dashboard](https://console.hw90.omani.works/dashboard) | Look at the dashboard | The Organization's resource overview renders — not an empty/error page | ⛔ | — |
+| 2 | [/apps](https://console.hw90.omani.works/apps) | Open the **Apps** view | The apps chosen in TC-02 appear as cards, each showing a status badge (Running / Installing) | ⛔ | — |
 
 - **Journey verdict:** ⛔ **BLOCKED** — console down.
 
@@ -124,10 +124,10 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [console.`<sovereign-fqdn>`/login](https://console.hw89.omani.works/login) | Type the operator email, tap **Sign in** | Advances to **/login/verify** — email shown + a 6-box PIN input | ⛔ | — |
-| 2 | [/login/verify](https://console.hw89.omani.works/login/verify) | Type / paste the 6-digit PIN | Auto-submits on the 6th digit → lands on **/dashboard**, authenticated | ⛔ | — |
+| 1 | [console.`<sovereign-fqdn>`/login](https://console.hw90.omani.works/login) | Type the operator email, tap **Sign in** | Advances to **/login/verify** — email shown + a 6-box PIN input | ⛔ | — |
+| 2 | [/login/verify](https://console.hw90.omani.works/login/verify) | Type / paste the 6-digit PIN | Auto-submits on the 6th digit → lands on **/dashboard**, authenticated | ⛔ | — |
 
-- **Journey verdict:** ⛔ **BLOCKED** — `console.hw89.omani.works` returns HTTP 000 (host down, [#2989](https://github.com/openova-io/openova/issues/2989)).
+- **Journey verdict:** ⛔ **BLOCKED** — `console.hw90.omani.works` returns HTTP 000 (host down, [#2989](https://github.com/openova-io/openova/issues/2989)).
 
 ### TC-07 — Operator dashboard shows the Sovereign *(web · operator · D16 / D22)*
 
@@ -137,8 +137,8 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/dashboard](https://console.hw89.omani.works/dashboard) | Read the dashboard treemap | The Sovereign's resources render grouped by region — no stuck spinners, no "0/0" everywhere | ⛔ | — |
-| 2 | [/settings](https://console.hw89.omani.works/settings) | Open **Settings** | Real values for Region, Capacity, Control-plane size, Created timestamp, Deployment ID, Pool subdomain — not `—` placeholders | ⛔ | — |
+| 1 | [/dashboard](https://console.hw90.omani.works/dashboard) | Read the dashboard treemap | The Sovereign's resources render grouped by region — no stuck spinners, no "0/0" everywhere | ⛔ | — |
+| 2 | [/settings](https://console.hw90.omani.works/settings) | Open **Settings** | Real values for Region, Capacity, Control-plane size, Created timestamp, Deployment ID, Pool subdomain — not `—` placeholders | ⛔ | — |
 
 - **Journey verdict:** ⛔ **BLOCKED** — console down.
 
@@ -150,8 +150,8 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/bss](https://console.hw89.omani.works/bss) | Open the **BSS** landing from the sidebar | KPI dashboard + a section grid including **Vouchers** | ⛔ | — |
-| 2 | [/bss/vouchers](https://console.hw89.omani.works/bss/vouchers) | Tap **Issue** | An Issue modal with **code**, **credit (OMR)**, **description**, **max redemptions**, **recipient email** fields | ⛔ | — |
+| 1 | [/bss](https://console.hw90.omani.works/bss) | Open the **BSS** landing from the sidebar | KPI dashboard + a section grid including **Vouchers** | ⛔ | — |
+| 2 | [/bss/vouchers](https://console.hw90.omani.works/bss/vouchers) | Tap **Issue** | An Issue modal with **code**, **credit (OMR)**, **description**, **max redemptions**, **recipient email** fields | ⛔ | — |
 | 3 | Issue modal | Fill the fields, submit | The new voucher appears in the voucher table with a **Status** pill — and is emailed to the recipient | ⛔ | — |
 
 - **Journey verdict:** ⛔ **BLOCKED** — console down.
@@ -164,7 +164,7 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/catalog/grafana](https://console.hw89.omani.works/catalog/grafana) | Open a Blueprint class page (e.g. Grafana) | The Blueprint header + supported-topology list + an instance table; a **+ New instance** affordance for multi-instance Blueprints | ⛔ | — |
+| 1 | [/catalog/grafana](https://console.hw90.omani.works/catalog/grafana) | Open a Blueprint class page (e.g. Grafana) | The Blueprint header + supported-topology list + an instance table; a **+ New instance** affordance for multi-instance Blueprints | ⛔ | — |
 
 - **Journey verdict:** ⛔ **BLOCKED** — console down.
 
@@ -176,7 +176,7 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/install/grafana](https://console.hw89.omani.works/install/grafana) | Open the install form for the Blueprint | An auto-generated config form (from the Blueprint's schema) + a **Topology** selector | ⛔ | — |
+| 1 | [/install/grafana](https://console.hw90.omani.works/install/grafana) | Open the install form for the Blueprint | An auto-generated config form (from the Blueprint's schema) + a **Topology** selector | ⛔ | — |
 | 2 | /install/grafana | Try to pick a topology the Blueprint doesn't support | The unsupported option is **disabled/blocked inline** with a helper note; the form won't submit it | ⛔ | — |
 | 3 | /install/grafana | Fill the form, pick a supported topology, submit | A status modal shows the install progressing; on done, **Open Apps** lands back on **/apps** with the new instance present | ⛔ | — |
 
@@ -190,9 +190,9 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/apps](https://console.hw89.omani.works/apps) | Tap an app card | **/app/`<name>`** opens on the **Overview** tab with a status badge (e.g. ● Running) — not "deployment id malformed" | ⛔ | — |
-| 2 | [/app/`<name>`](https://console.hw89.omani.works/app/grafana) | Open the **Topology** tab | The placement tree shows clusters/nodes under **both** `me-east-215-a` AND `me-east-215-b`; topology reads **active-hot-standby** for HA apps | ⛔ | — |
-| 3 | [/jobs](https://console.hw89.omani.works/jobs) | Open the **Jobs** view | Every job is in a terminal state (0 pending, 0 running); per-region prefixes are visible for a multi-region Sovereign | ⛔ | — |
+| 1 | [/apps](https://console.hw90.omani.works/apps) | Tap an app card | **/app/`<name>`** opens on the **Overview** tab with a status badge (e.g. ● Running) — not "deployment id malformed" | ⛔ | — |
+| 2 | [/app/`<name>`](https://console.hw90.omani.works/app/grafana) | Open the **Topology** tab | The placement tree shows clusters/nodes under **both** `me-east-215-a` AND `me-east-215-b`; topology reads **active-hot-standby** for HA apps | ⛔ | — |
+| 3 | [/jobs](https://console.hw90.omani.works/jobs) | Open the **Jobs** view | Every job is in a terminal state (0 pending, 0 running); per-region prefixes are visible for a multi-region Sovereign | ⛔ | — |
 
 - **Journey verdict:** ⛔ **BLOCKED** — console down.
 
@@ -204,7 +204,7 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/app/grafana](https://console.hw89.omani.works/app/grafana) | On the app detail, find the **Launch** button on an SSO-enabled endpoint | A **Launch →** button (not a bare endpoint URL) | ⛔ | — |
+| 1 | [/app/grafana](https://console.hw90.omani.works/app/grafana) | On the app detail, find the **Launch** button on an SSO-enabled endpoint | A **Launch →** button (not a bare endpoint URL) | ⛔ | — |
 | 2 | /app/grafana | Tap **Launch →** | A new tab opens the app **already signed in** — no Keycloak login form appears | ⛔ | — |
 
 - **Journey verdict:** ⛔ **BLOCKED** — console down. *(Silent-SSO chain has 5 stacked layers; re-walk verifies all of them at once.)*
@@ -217,7 +217,7 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/apps/`<id>`/endpoints](https://console.hw89.omani.works/apps) | Tap **+ New endpoint**, fill the dialog, submit | Banner *"Change submitted as PR `<link>`"* with a clickable PR URL | ⛔ | — |
+| 1 | [/apps/`<id>`/endpoints](https://console.hw90.omani.works/apps) | Tap **+ New endpoint**, fill the dialog, submit | Banner *"Change submitted as PR `<link>`"* with a clickable PR URL | ⛔ | — |
 | 2 | The linked PR | Open the PR link from the banner | PR is open with the 3 gating checks (`kyverno-admission`, `cert-manager-precheck`, `dns-conflict-precheck`) and auto-merges on green | ⛔ | — |
 
 - **Journey verdict:** ⛔ **BLOCKED** — console down. *(PR-page step is the one allowed off-console hop — it's a link the user clicks from the banner, not a terminal action.)*
@@ -232,7 +232,7 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/sandbox](https://console.hw89.omani.works/sandbox) | Look at the agent grid | A grid of agent cards including **qwen-code** (the default, zero cloud-cost leak) and **claude-code** | ⛔ | — |
+| 1 | [/sandbox](https://console.hw90.omani.works/sandbox) | Look at the agent grid | A grid of agent cards including **qwen-code** (the default, zero cloud-cost leak) and **claude-code** | ⛔ | — |
 | 2 | /sandbox | Tap **qwen-code** to start a session | A session opens at **/sandbox/`<id>`** — the AI assistant is ready, no credential/setup prompt | ⛔ | — |
 | 3 | In the session | Ask in plain language: *"list my organization's applications"* | The agent answers with **your Org's actual apps** (org-aware, via its auto-mounted knowledge) — not a permission error and not "I have no access" | ⛔ | — |
 
@@ -248,7 +248,7 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/dashboard](https://console.hw89.omani.works/dashboard) | Find the Sovereignty card | A status badge reading **Tethered** + an **Achieve True Sovereignty** button | ⛔ | — |
+| 1 | [/dashboard](https://console.hw90.omani.works/dashboard) | Find the Sovereignty card | A status badge reading **Tethered** + an **Achieve True Sovereignty** button | ⛔ | — |
 | 2 | Sovereignty card | Tap **Achieve True Sovereignty** | An explanation modal warns the cutover is irreversible and runs a 10-minute egress-block self-test; a confirm button | ⛔ | — |
 | 3 | Confirm modal | Confirm | A progress card mounts showing the cutover steps running | ⛔ | — |
 | 4 | Sovereignty progress card | Wait for the egress-block hold to complete | The badge flips to **Sovereign**; the egress-block self-test shows passed | ⛔ | — |
@@ -278,7 +278,7 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 | TC-15 | web | operator | 5 | Sovereignty cutover | 4 | 0 | 0 | 0 | 4 | ⛔ |
 | | | | | **Total** | **39** | **0** | **0** | **0** | **39** | |
 
-**Overall verdict:** ⛔ **BLOCKED** — zero journeys walkable: the live target `hw89` never came up (stalled on [#2989](https://github.com/openova-io/openova/issues/2989)). This is a truthful "could-not-attempt" outcome, **not** a fail of the product UI and **not** a pass. Re-walk on a fresh prov (`hw90`) once #2989 is fixed and it reaches `ready`; every ⛔ above then becomes a real ✅/❌ with a committed screenshot.
+**Overall verdict:** ⛔ **BLOCKED** — zero journeys walkable: no prov has reached `ready` yet. The fresh-prov bug-chain is being cleared at the source (#2982 → #2985 → #2989 → #2995 → crossplane/image-pulls next), each fix via the catalog only (no manual cluster touch — that would fail zero-touch). hw90 is a deliberately **failed environment** used to expose the chain. This is a truthful "could-not-attempt" outcome, **not** a fail of the product UI and **not** a pass. Re-walk on the first prov that reaches `ready` **hands-off**; every ⛔ above then becomes a real ✅/❌ with a committed screenshot.
 
 ---
 


### PR DESCRIPTION
Repoints the live target to hw90 + corrects the verdict/why-blocked to the accurate #2982→#2985→#2989→#2995 bug-chain, with the zero-touch contract note. Refs #2742

🤖 Generated with [Claude Code](https://claude.com/claude-code)