### PR TITLE
chore(cnpg): --log-level=debug to surface the silent exit-2 crash

### DIFF
--- a/clusters/_template/bootstrap-kit/16-cnpg.yaml
+++ b/clusters/_template/bootstrap-kit/16-cnpg.yaml
@@ -63,7 +63,7 @@ spec:
       # CA written to MutatingWebhookConfiguration caBundle → x509
       # verify failed → all Cluster CR admissions denied. G53
       # webhook-gate remains as readiness signal.
-      version: 1.0.7
+      version: 1.0.8
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg

--- a/platform/cnpg/blueprint.yaml
+++ b/platform/cnpg/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-4-1-data-services
 spec:
-  version: 1.0.7
+  version: 1.0.8
   card:
     title: CloudNativePG
     summary: |

--- a/platform/cnpg/chart/Chart.yaml
+++ b/platform/cnpg/chart/Chart.yaml
@@ -8,7 +8,7 @@ name: bp-cnpg
 # kind of certificate") → bp-catalyst-platform + bp-newapi Helm
 # install denied. Trust upstream operator's self-managed cert flow;
 # G53 webhook-gate Job remains as the readiness signal.
-version: 1.0.7
+version: 1.0.8
 description: |
   Catalyst-curated Blueprint umbrella chart for CloudNativePG. Depends on
   the upstream `cloudnative-pg` chart as a Helm subchart so

--- a/platform/cnpg/chart/values.yaml
+++ b/platform/cnpg/chart/values.yaml
@@ -134,6 +134,17 @@ cloudnative-pg:
       failureThreshold: 30
       periodSeconds: 5
 
+  # TEMP debug-logging (#2989/cnpg-followup — caught live on hw90): the
+  # operator exits code 2 SILENTLY ~after the "Kubernetes system metadata"
+  # log (NOT OOMKilled, node has memory, webhook cert mounted) →
+  # CrashLoopBackOff that wedges the cascade (bp-openbao→bp-sso-bridge→
+  # bp-catalyst-platform all dependsOn bp-cnpg). At default info level the
+  # log dies at "system metadata" with no reason. --log-level=debug surfaces
+  # WHICH startup step fails (webhook bind / leader election / cert load) so
+  # the real cause is collected, not guessed. Remove once root-caused.
+  additionalArgs:
+    - "--log-level=debug"
+
 # ─── Catalyst-managed overlay values consumed by templates/ ───────────────
 
 # G53 (Refs #2604, 2026-05-30): webhook-gate Job + RBAC defaults.


### PR DESCRIPTION
#2995 didn't fix hw90's cnpg crashloop (hard exit-2, not OOM, not probe). Add --log-level=debug to collect the real cause from the next restart instead of guessing again. TEMP. Refs #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)