### PR TITLE
fix(bootstrap-kit): install remediation retries -1 — environmental transients must not permanently wedge zero-touch provs

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -97,7 +97,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/01a-gateway-api.yaml
+++ b/clusters/_template/bootstrap-kit/01a-gateway-api.yaml
@@ -96,7 +96,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/02-cert-manager.yaml
+++ b/clusters/_template/bootstrap-kit/02-cert-manager.yaml
@@ -63,7 +63,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/03-flux.yaml
+++ b/clusters/_template/bootstrap-kit/03-flux.yaml
@@ -94,7 +94,7 @@ spec:
     # reconciles). Without this, the very first reconcile would error
     # with "object already exists" on every Flux controller Deployment.
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/04-crossplane.yaml
+++ b/clusters/_template/bootstrap-kit/04-crossplane.yaml
@@ -49,7 +49,18 @@ spec:
   install:
     timeout: 15m
     remediation:
-      retries: 3
+      # -1 = retry indefinitely (#2999, caught live on hw90/#2998): with the
+      # old `retries: 3`, an environmental transient (node-level kubelet mount
+      # dysfunction in the HCS early-prov window) outlasted the ~4×15m budget
+      # and helm-controller went TERMINAL ("exceeded maximum retries: cannot
+      # remediate failed release") — permanently wedging a zero-touch prov even
+      # after the node settled. Only a human spec-bump could clear it, which is
+      # a zero-touch failure by definition. With -1 the HR keeps retrying until
+      # the env settles or a catalog fix lands (a new chart/values digest still
+      # resets state and applies immediately, so the GitOps self-heal path is
+      # unchanged). Pace is bounded by the install timeout + HR interval.
+      # Applied across all bootstrap-kit slots that used the default 3.
+      retries: -1
   upgrade:
     timeout: 15m
     remediation:

--- a/clusters/_template/bootstrap-kit/05-sealed-secrets.yaml
+++ b/clusters/_template/bootstrap-kit/05-sealed-secrets.yaml
@@ -47,7 +47,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/05a-reflector.yaml
+++ b/clusters/_template/bootstrap-kit/05a-reflector.yaml
@@ -60,7 +60,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -444,7 +444,7 @@ spec:
     disableWait: true
     timeout: 30m
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     disableWait: true
     timeout: 30m

--- a/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
@@ -80,7 +80,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -97,7 +97,7 @@ spec:
     disableWait: true
     timeout: 15m
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     disableWait: true
     timeout: 15m

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -98,7 +98,7 @@ spec:
     disableWait: true
     timeout: 15m
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     disableWait: true
     timeout: 15m

--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -45,7 +45,7 @@ spec:
   install:
     timeout: 15m
     remediation:
-      retries: 3
+      retries: -1
       remediateLastFailure: true
   upgrade:
     timeout: 15m

--- a/clusters/_template/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/_template/bootstrap-kit/12-external-dns.yaml
@@ -76,7 +76,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1012,7 +1012,7 @@ spec:
     disableWait: true
     timeout: 30m
     remediation:
-      retries: 3
+      retries: -1
       remediateLastFailure: true
   upgrade:
     disableWait: true

--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -125,7 +125,7 @@ spec:
     timeout: 5m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 5m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/14-crossplane-claims.yaml
+++ b/clusters/_template/bootstrap-kit/14-crossplane-claims.yaml
@@ -72,7 +72,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/15-external-secrets.yaml
+++ b/clusters/_template/bootstrap-kit/15-external-secrets.yaml
@@ -81,7 +81,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml
+++ b/clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml
@@ -91,7 +91,7 @@ spec:
     disableWait: true
     timeout: 15m
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     disableWait: true
     timeout: 15m

--- a/clusters/_template/bootstrap-kit/16-cnpg.yaml
+++ b/clusters/_template/bootstrap-kit/16-cnpg.yaml
@@ -88,7 +88,7 @@ spec:
   install:
     timeout: 15m
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     remediation:

--- a/clusters/_template/bootstrap-kit/17-valkey.yaml
+++ b/clusters/_template/bootstrap-kit/17-valkey.yaml
@@ -66,7 +66,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/18-seaweedfs.yaml
+++ b/clusters/_template/bootstrap-kit/18-seaweedfs.yaml
@@ -72,7 +72,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -177,7 +177,7 @@ spec:
     timeout: 10m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 10m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/19c-opentelemetry-operator.yaml
+++ b/clusters/_template/bootstrap-kit/19c-opentelemetry-operator.yaml
@@ -66,7 +66,7 @@ spec:
   install:
     timeout: 15m
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     remediation:

--- a/clusters/_template/bootstrap-kit/20-opentelemetry.yaml
+++ b/clusters/_template/bootstrap-kit/20-opentelemetry.yaml
@@ -68,7 +68,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/21-alloy.yaml
+++ b/clusters/_template/bootstrap-kit/21-alloy.yaml
@@ -67,7 +67,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/22-loki.yaml
+++ b/clusters/_template/bootstrap-kit/22-loki.yaml
@@ -64,7 +64,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/23-mimir.yaml
+++ b/clusters/_template/bootstrap-kit/23-mimir.yaml
@@ -64,7 +64,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/24-tempo.yaml
+++ b/clusters/_template/bootstrap-kit/24-tempo.yaml
@@ -62,7 +62,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -75,7 +75,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/26-network-policies.yaml
+++ b/clusters/_template/bootstrap-kit/26-network-policies.yaml
@@ -71,7 +71,7 @@ spec:
     timeout: 5m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 5m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/27-kyverno.yaml
+++ b/clusters/_template/bootstrap-kit/27-kyverno.yaml
@@ -83,7 +83,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -77,7 +77,7 @@ spec:
     timeout: 10m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 10m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/28-reloader.yaml
+++ b/clusters/_template/bootstrap-kit/28-reloader.yaml
@@ -63,7 +63,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/29-vpa.yaml
+++ b/clusters/_template/bootstrap-kit/29-vpa.yaml
@@ -62,7 +62,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/30-trivy.yaml
+++ b/clusters/_template/bootstrap-kit/30-trivy.yaml
@@ -67,7 +67,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/31-falco.yaml
+++ b/clusters/_template/bootstrap-kit/31-falco.yaml
@@ -65,7 +65,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/32-sigstore.yaml
+++ b/clusters/_template/bootstrap-kit/32-sigstore.yaml
@@ -67,7 +67,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/33-syft-grype.yaml
+++ b/clusters/_template/bootstrap-kit/33-syft-grype.yaml
@@ -64,7 +64,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/34-velero.yaml
+++ b/clusters/_template/bootstrap-kit/34-velero.yaml
@@ -105,7 +105,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/34a-bp-velero-hcs.yaml
+++ b/clusters/_template/bootstrap-kit/34a-bp-velero-hcs.yaml
@@ -94,7 +94,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/35-coraza.yaml
+++ b/clusters/_template/bootstrap-kit/35-coraza.yaml
@@ -92,7 +92,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/39-bp-vllm.yaml
+++ b/clusters/_template/bootstrap-kit/39-bp-vllm.yaml
@@ -159,7 +159,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/49-bp-cert-manager-powerdns-webhook.yaml
+++ b/clusters/_template/bootstrap-kit/49-bp-cert-manager-powerdns-webhook.yaml
@@ -110,7 +110,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/50-cluster-autoscaler.yaml
+++ b/clusters/_template/bootstrap-kit/50-cluster-autoscaler.yaml
@@ -125,7 +125,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
+++ b/clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
@@ -91,7 +91,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -151,7 +151,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
@@ -72,7 +72,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/55-bp-hcloud-ccm.yaml
+++ b/clusters/_template/bootstrap-kit/55-bp-hcloud-ccm.yaml
@@ -105,7 +105,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/57-bp-openova-flow-emitter.yaml
+++ b/clusters/_template/bootstrap-kit/57-bp-openova-flow-emitter.yaml
@@ -60,7 +60,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -79,7 +79,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
@@ -71,7 +71,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/60-bp-vcluster-helmrepo.yaml
+++ b/clusters/_template/bootstrap-kit/60-bp-vcluster-helmrepo.yaml
@@ -90,7 +90,7 @@ spec:
     timeout: 5m
     disableWait: false
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 5m
     disableWait: false

--- a/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+++ b/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
@@ -136,7 +136,7 @@ spec:
     timeout: 10m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 10m
     disableWait: true

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -212,7 +212,7 @@ spec:
     timeout: 15m
     disableWait: true
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     timeout: 15m
     disableWait: true


### PR DESCRIPTION
## What

Sweep `install.remediation.retries: 3 → -1` (retry indefinitely) across the 54 bootstrap-kit slots that used the default. Upgrade blocks and the deliberate per-slot tunings (`09-keycloak` 1; `19-harbor`/`11-powerdns`/`56-bp-openova-flow-server` 5) are untouched. One RCA comment added at `04-crossplane.yaml` (where the failure was caught); net diff is otherwise 54 one-line changes.

## Why

Pulled the #2998 open thread ("why did Flux never recycle the frozen crossplane release?") on hw90 read-only. helm-controller's own log answers it:

```
15:05:23 running 'install'    (timeout 15m)   → context deadline exceeded
15:20:37 running 'uninstall'  (remediation 1)
15:21:03 running 'install'                    → context deadline exceeded
15:36:12 running 'uninstall'  (remediation 2)
15:36:34 running 'install'                    → context deadline exceeded
15:51:42 ERROR terminal error: exceeded maximum retries: cannot remediate failed release
```

`installFailures=4` (initial + 3 retries) — remediation worked exactly as configured, burned its ~46-min budget entirely inside the node's kubelet-mount dysfunction window (#2998 corrected RCA: environmental, not chart), then went terminal. The node settled afterwards; the secrets existed; one fresh attempt would have succeeded — but with the budget exhausted, only a human spec-bump resets the counter. On a zero-touch prov that is a permanent wedge, i.e. zero-touch failure by definition.

With `-1` the HR keeps retrying (pace bounded by the 15m install timeout + HR interval). A new chart/values digest still resets state and applies immediately, so the catalog-fix self-heal path validated live on #2982/#2985/#2989 is unchanged; the only remaining terminal state is "catalog is wrong", which a catalog change cures.

## Validation

- YAML parse: all 60 slot files OK.
- Diff audit: every hunk is an install-block `retries:` line (upgrade blocks: 55×`3` + outliers intact).
- `scripts/check-bootstrap-deps.sh` unaffected (dependsOn untouched; script checks deps only).
- Live, zero-spend: hw90's GitRepo 1-min sync pulls this; the digest change resets `bp-crossplane`'s exhausted counter → fresh install on the now-settled node. Will report the observed result on #2999. (hw90 remains a **failed** env per the zero-touch doctrine — this only uses it to validate the self-heal path and expose later layers.)

Refs #2999 #2998

🤖 Generated with [Claude Code](https://claude.com/claude-code)
