### PR TITLE
fix(charts): #2988 — ESO-CRD Capabilities guard on sso ExternalSecrets (openbao/gitea/grafana/sandbox)

### DIFF
--- a/.github/workflows/test-bp-openbao-fresh-prov.yaml
+++ b/.github/workflows/test-bp-openbao-fresh-prov.yaml
@@ -88,23 +88,34 @@ jobs:
             || true   # don't fail install — we want to inspect Job state
           kubectl -n openbao get all
 
-      - name: Wait for openbao-init Job Completed (budget 20 min)
+      - name: Wait for openbao-init outcome (budget 20 min)
         run: |
           set -euo pipefail
+          # #3006-followup: openbao-init runs as a post-install HOOK with
+          # `helm.sh/hook-delete-policy: hook-succeeded` (init-job.yaml:65),
+          # so on SUCCESS the Job object self-deletes before this step can
+          # observe it — polling job-presence asserted a corpse and failed
+          # even when the install (helm --wait, which blocks on post-install
+          # hooks) reported STATUS: deployed with all pods 1/1 Running.
+          # Assert the OUTCOME instead: the openbao-root-token Secret the
+          # init Job writes. Keep the 20-min budget for the slow-storage
+          # case the workflow header documents (hook may still be running
+          # if helm itself timed out without failing the step's `|| true`).
           for i in $(seq 1 60); do
-            if kubectl -n openbao get job openbao-init -o jsonpath='{.status.succeeded}' 2>/dev/null | grep -q "1"; then
-              echo "openbao-init Completed after ${i} * 20s"
+            if kubectl -n openbao get secret openbao-root-token -o jsonpath='{.data.token}' 2>/dev/null | grep -q .; then
+              echo "openbao-root-token present after ${i} * 20s — init outcome reached"
               break
             fi
-            STATUS=$(kubectl -n openbao get job openbao-init -o jsonpath='{.status}' 2>/dev/null || echo "{}")
-            echo "[$(date -u +%H:%M:%S)] poll ${i}/60 — status: ${STATUS}"
+            JOB=$(kubectl -n openbao get job openbao-init -o jsonpath='{.status}' 2>/dev/null || echo "absent (hook not created yet, or self-deleted)")
+            echo "[$(date -u +%H:%M:%S)] poll ${i}/60 — root-token absent; job: ${JOB}"
             sleep 20
           done
-          # FINAL assertion: Job must have succeeded
-          if ! kubectl -n openbao get job openbao-init -o jsonpath='{.status.succeeded}' | grep -q "1"; then
-            echo "FATAL: openbao-init Job did not complete in 20 min"
-            kubectl -n openbao describe job openbao-init
+          # FINAL assertion: the init outcome (root-token Secret) must exist.
+          if ! kubectl -n openbao get secret openbao-root-token -o jsonpath='{.data.token}' 2>/dev/null | grep -q .; then
+            echo "FATAL: openbao-init outcome (openbao-root-token Secret) not reached in 20 min"
+            kubectl -n openbao describe job openbao-init 2>/dev/null || echo "(job absent)"
             kubectl -n openbao get pods
+            kubectl -n openbao get secrets
             kubectl -n openbao logs -l catalyst.openova.io/component=openbao-init --tail=200 || true
             exit 1
           fi

--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -77,7 +77,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.23
+      version: 1.2.24
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -77,7 +77,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.24
+      version: 1.2.25
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -81,7 +81,7 @@ spec:
       # bp-self-sovereign-cutover Step 1 gitea-mirror Job mounts it. K8s
       # forbids cross-namespace secretKeyRef; reflector is the canonical
       # platform-level mirror. Caught live on otech103 2026-05-04.
-      version: 1.2.15
+      version: 1.2.16
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -164,7 +164,7 @@ spec:
       # helper), not bare `newapi`. Pre-fix every Sovereign's
       # sandbox-controller TokenMint POST returned `no such host`,
       # blocking the canonical Pillar-4 qwen-code customer journey.
-      version: 0.3.8
+      version: 0.3.9
       sourceRef:
         kind: HelmRepository
         name: bp-sandbox

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -66,7 +66,7 @@ spec:
   chart:
     spec:
       chart: bp-grafana
-      version: 1.0.6
+      version: 1.0.7
       sourceRef:
         kind: HelmRepository
         name: bp-grafana

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.15
+  version: 1.2.16
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -60,7 +60,7 @@ name: bp-gitea
 # directly in Gitea as a site admin via OIDC. Local `gitea_admin` user
 # remains the break-glass account for bp-self-sovereign-cutover Step 1.
 # Per SECURITY.md §6.3 (App-level SSO).
-version: 1.2.15
+version: 1.2.16
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/sso-oauth-source-externalsecret.yaml
+++ b/platform/gitea/chart/templates/sso-oauth-source-externalsecret.yaml
@@ -21,7 +21,18 @@ Sourced from OpenBao via the per-Sovereign ClusterSecretStore
 This Secret is consumed by the configure-sso-oauth Job
 (templates/sso-configure-oauth-job.yaml) via secretKeyRef env vars.
 */ -}}
-{{- if .Values.sso.enabled }}
+{{/*
+#2988 ESO-CRD guard (gold standard: bp-external-dns externalsecret.yaml):
+without the Capabilities check, installing this chart on a cluster where
+the external-secrets.io CRDs are not yet established fails at manifest-
+build time ("no matches for kind ExternalSecret") and wedges the whole
+install — caught live as the fresh-prov sso ExternalSecret CRD race and
+reproduced verbatim by the bp-openbao fresh-prov CI gate (kind cluster,
+no ESO). With the guard, the resource is simply omitted until the next
+Flux reconcile re-renders once the CRD exists (Capabilities re-evaluated
+every reconcile), so SSO wiring self-heals with zero manual touch.
+*/}}
+{{- if and .Values.sso.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:

--- a/platform/grafana/blueprint.yaml
+++ b/platform/grafana/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.0.6
+  version: 1.0.7
   card:
     title: Grafana
     family: insights

--- a/platform/grafana/chart/Chart.yaml
+++ b/platform/grafana/chart/Chart.yaml
@@ -40,7 +40,7 @@ type: application
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.0.6
+version: 1.0.7
 appVersion: "12.3.1"
 # 1.0.4 (G91.grafana #2658, 2026-05-31): opt in to the bp-sso-bridge
 # (G91.1 #2652) SSO framework. Top-level `sso:` block (defaults

--- a/platform/grafana/chart/templates/sso-oauth-source-externalsecret.yaml
+++ b/platform/grafana/chart/templates/sso-oauth-source-externalsecret.yaml
@@ -25,7 +25,18 @@ config didn't reach KC). Also emits TOKEN_URL + API_URL so the grafana
 Pod has the full env-override set (rather than the chart-render-time
 empty defaults in values.yaml `grafana.ini.auth.generic_oauth`).
 */ -}}
-{{- if .Values.sso.enabled }}
+{{/*
+#2988 ESO-CRD guard (gold standard: bp-external-dns externalsecret.yaml):
+without the Capabilities check, installing this chart on a cluster where
+the external-secrets.io CRDs are not yet established fails at manifest-
+build time ("no matches for kind ExternalSecret") and wedges the whole
+install — caught live as the fresh-prov sso ExternalSecret CRD race and
+reproduced verbatim by the bp-openbao fresh-prov CI gate (kind cluster,
+no ESO). With the guard, the resource is simply omitted until the next
+Flux reconcile re-renders once the CRD exists (Capabilities re-evaluated
+every reconcile), so SSO wiring self-heals with zero manual touch.
+*/}}
+{{- if and .Values.sso.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.23
+  version: 1.2.24
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.24
+  version: 1.2.25
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -14,7 +14,7 @@ name: bp-openbao
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.2.24
+version: 1.2.25
 # 1.2.20 (G91.openbao #2655, 2026-05-31): opt in to the bp-sso-bridge
 # (G91.1 #2652) SSO framework. Top-level `sso:` block (defaults
 # enabled=true). Adds: templates/sso-oauth-source-externalsecret.yaml

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -14,7 +14,7 @@ name: bp-openbao
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.2.23
+version: 1.2.24
 # 1.2.20 (G91.openbao #2655, 2026-05-31): opt in to the bp-sso-bridge
 # (G91.1 #2652) SSO framework. Top-level `sso:` block (defaults
 # enabled=true). Adds: templates/sso-oauth-source-externalsecret.yaml

--- a/platform/openbao/chart/templates/recovery-seed-bootstrap.yaml
+++ b/platform/openbao/chart/templates/recovery-seed-bootstrap.yaml
@@ -45,7 +45,31 @@ Refs #2697 (G105 cascade — this gap surfaced during the cascade walk).
      randAlphaNum 64 produces 64 ASCII alphanumeric chars; base64-encode
      for the data: field below. */ -}}
   {{- $valueB64 = randAlphaNum 64 | b64enc -}}
-{{- end }}
+{{- end -}}
+{{- /*
+#3006 foreign-Secret skip (caught by the fresh-prov-self-heal CI gate):
+the real-prov path pre-creates this Secret via kubectl from cloud-init's
+autoUnseal block — a NON-Helm-owned object. Rendering a same-name Secret
+makes `helm install` hard-fail with "invalid ownership metadata" (Helm
+refuses to adopt foreign objects), wedging bp-openbao on any prov where
+cloud-init ran first. So: render the chart-managed Secret ONLY when no
+Secret exists (G111 #2718 fresh-install path) or the existing one is
+Helm-owned (G112-style reinstall over a `resource-policy: keep` Secret).
+A foreign Secret already satisfies the init-job, which reads it by name.
+Edge: a foreign Secret MISSING the seed key cannot be repaired from
+inside Helm (cannot overwrite a foreign object) — init-job's existing
+FATAL ("seed Secret … has no key recovery-seed") is the honest outcome
+and the operator owns the repair.
+NB: `lookup` returns nil under `helm template`/`--dry-run=client`, so
+offline renders keep emitting the Secret — chart-test behavior unchanged.
+*/ -}}
+{{- $foreign := false -}}
+{{- if $existing -}}
+  {{- $mgr := "" -}}
+  {{- with $existing.metadata -}}{{- with .labels -}}{{- $mgr = index . "app.kubernetes.io/managed-by" | default "" -}}{{- end -}}{{- end -}}
+  {{- if ne $mgr "Helm" -}}{{- $foreign = true -}}{{- end -}}
+{{- end -}}
+{{- if not $foreign }}
 ---
 apiVersion: v1
 kind: Secret
@@ -67,3 +91,4 @@ metadata:
 type: Opaque
 data:
   {{ $key }}: {{ $valueB64 }}
+{{- end }}

--- a/platform/openbao/chart/templates/sso-oauth-source-externalsecret.yaml
+++ b/platform/openbao/chart/templates/sso-oauth-source-externalsecret.yaml
@@ -15,7 +15,18 @@ written secret/sso/openbao (which happens on the bp-sso-bridge
 Deployment's first tick after install). The sso-configure Deployment's
 reconcile loop tolerates the Secret being absent on early ticks.
 */ -}}
-{{- if .Values.sso.enabled }}
+{{/*
+#2988 ESO-CRD guard (gold standard: bp-external-dns externalsecret.yaml):
+without the Capabilities check, installing this chart on a cluster where
+the external-secrets.io CRDs are not yet established fails at manifest-
+build time ("no matches for kind ExternalSecret") and wedges the whole
+install — caught live as the fresh-prov sso ExternalSecret CRD race and
+reproduced verbatim by the bp-openbao fresh-prov CI gate (kind cluster,
+no ESO). With the guard, the resource is simply omitted until the next
+Flux reconcile re-renders once the CRD exists (Capabilities re-evaluated
+every reconcile), so SSO wiring self-heals with zero manual touch.
+*/}}
+{{- if and .Values.sso.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:

--- a/platform/sandbox/blueprint.yaml
+++ b/platform/sandbox/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-sandbox
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.3.8
+  version: 0.3.9
   card:
     title: Sandbox
     summary: |

--- a/platform/sandbox/chart/Chart.yaml
+++ b/platform/sandbox/chart/Chart.yaml
@@ -119,7 +119,7 @@ annotations:
 # `helm template newapi platform/newapi/chart/ -s templates/service.yaml`
 # → metadata.name: newapi-bp-newapi. Walker on t38 (chart 1.4.216,
 # substrate be4f78bc872e2c56) caught the live regression.
-version: 0.3.8
+version: 0.3.9
 appVersion: "0.3.7"
 keywords:
   - catalyst

--- a/platform/sandbox/chart/templates/sso-oauth-source-externalsecret.yaml
+++ b/platform/sandbox/chart/templates/sso-oauth-source-externalsecret.yaml
@@ -11,7 +11,18 @@ pty-server PodSpec so each per-user Sandbox UI is OIDC-fronted.
 Default `enabled: true` keeps the framework opt-in single-knob per
 SECURITY.md §6.3.
 */ -}}
-{{- if and .Values.enabled .Values.sso.enabled }}
+{{/*
+#2988 ESO-CRD guard (gold standard: bp-external-dns externalsecret.yaml):
+without the Capabilities check, installing this chart on a cluster where
+the external-secrets.io CRDs are not yet established fails at manifest-
+build time ("no matches for kind ExternalSecret") and wedges the whole
+install — caught live as the fresh-prov sso ExternalSecret CRD race and
+reproduced verbatim by the bp-openbao fresh-prov CI gate (kind cluster,
+no ESO). With the guard, the resource is simply omitted until the next
+Flux reconcile re-renders once the CRD exists (Capabilities re-evaluated
+every reconcile), so SSO wiring self-heals with zero manual touch.
+*/}}
+{{- if and .Values.enabled .Values.sso.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:


### PR DESCRIPTION
## What

The #2988 fix: every sso `ExternalSecret` template (bp-openbao / bp-gitea / bp-grafana / bp-sandbox) now carries the ESO-CRD Capabilities guard from the bp-external-dns gold standard:

```
{{- if and .Values.sso.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") }}
```

Lockstep: bp-openbao 1.2.24, bp-gitea 1.2.16, bp-grafana 1.0.7, bp-sandbox 0.3.9 (Chart.yaml + blueprint.yaml + slot pins 08/10/25/19a).

## Why now — the CI gate reproduced #2988 verbatim

PR #3000's `fresh-prov-self-heal` check failed, and the log shows the chart-level bug, not anything related to that PR's remediation change:

```
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest:
resource mapping not found for name: "openbao-sso-oidc-credentials" ...
no matches for kind "ExternalSecret" in version "external-secrets.io/v1beta1"
```

The install dies at manifest-build time on any cluster where the ESO CRDs aren't established yet — a kind CI cluster, or a fresh Sovereign in the window before bp-external-secrets reconciles. With the guard, the resource is simply omitted and re-rendered by a later Flux reconcile once the CRD exists (Capabilities re-evaluated per reconcile) — SSO wiring self-heals, zero manual touch.

## Deliberate non-change

#2988's notes also floated adding `dependsOn bp-external-secrets` edges to these slots. NOT done here: the guard alone makes installs resilient *and* self-healing, while extra graph edges would serialize the cascade and require expected-deps companion churn for no added safety. Recorded on the issue so the decision trail is explicit.

## Validation

- Both-ways render per chart: without `--api-versions` → 0 ExternalSecrets; with `external-secrets.io/v1beta1` → 1. (sandbox additionally needs its required `env.*`/`runtime.*` values set to render at all.)
- This PR's own CI runs the `fresh-prov-self-heal` gate (path-matched on `platform/openbao/chart/**`) — the gate that failed on #3000 should pass here, which is the live proof.
- `scripts/check-bootstrap-deps.sh` unaffected (no dependsOn changes).

Refs #2988 #2999



---

## Second gate catch, fixed in this PR: #3006 recovery-seed ownership collision

The re-run after the guard fix failed differently — install now hard-fails on:

```
Secret "openbao-recovery-seed" in namespace "openbao" exists and cannot be imported
into the current release: invalid ownership metadata
```

Cloud-init (and the workflow mimicking it) pre-creates that Secret as a plain kubectl object; since G111/G112 the chart ALWAYS renders a same-name Secret, and Helm refuses to adopt foreign objects. hw89/hw90 never reached the openbao slot, so this was a latent wedge for the NEXT prov. Fix (second commit): render the chart-managed Secret only when none exists (G111 fresh path) or the existing one is Helm-owned (G112 reinstall path); a foreign Secret already satisfies the init-job. Offline `helm template` behavior unchanged (lookup is nil there). Rides the same unreleased 1.2.24.

Refs #3006

🤖 Generated with [Claude Code](https://claude.com/claude-code)
