### PR TITLE
fix(cert-manager): right-size controller memory 256Mi -> 1Gi

### DIFF
--- a/clusters/_template/bootstrap-kit/02-cert-manager.yaml
+++ b/clusters/_template/bootstrap-kit/02-cert-manager.yaml
@@ -49,7 +49,7 @@ spec:
       # next-private-key informer-cache race that blocks Certificate
       # issuance on HCS provs (verified live hw54 15:07Z). Plus
       # CVE-2025-22871/22870/22872 fixes.
-      version: 1.2.4
+      version: 1.2.5
       sourceRef:
         kind: HelmRepository
         name: bp-cert-manager

--- a/platform/cert-manager/blueprint.yaml
+++ b/platform/cert-manager/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.2.4
+  version: 1.2.5
   card:
     title: cert-manager
     summary: TLS certificate automation. Lets Encrypt issuer with Dynadot DNS-01 for omani.works pool, HTTP-01 for BYO domains.

--- a/platform/cert-manager/chart/Chart.yaml
+++ b/platform/cert-manager/chart/Chart.yaml
@@ -14,7 +14,7 @@ name: bp-cert-manager
 # Per CLAUDE.md inviolable rule, ALL chart-hook references MUST be
 # explicit Harbor proxy-cache form — not just rely on the node-level
 # containerd mirror in registries.yaml.
-version: 1.2.4
+version: 1.2.5
 description: |
   Catalyst-curated Blueprint umbrella chart for cert-manager. Depends on the
   upstream `cert-manager` chart (Jetstack) as a Helm subchart so

--- a/platform/cert-manager/chart/values.yaml
+++ b/platform/cert-manager/chart/values.yaml
@@ -71,9 +71,20 @@ cert-manager:
   resources:
     requests:
       cpu: 50m
-      memory: 64Mi
-    limits:
       memory: 256Mi
+    limits:
+      # G17-class right-size (caught live on hw90, 2026-06-03): the
+      # controller was the cluster's ONLY OOMKilled container (26 kills at
+      # 256Mi). The full bootstrap-kit now carries far more Certificate /
+      # CertificateRequest / Order objects than when 256Mi was set
+      # (per-app SSO + G117 endpoints), and the controller's informer
+      # caches grow with them. A dead cert-manager starves every
+      # webhook-serving component of its TLS Secret (sigstore / ESO /
+      # otel-operator / kyverno-cleanup all crash-loop cert-less) and
+      # wedges the fresh-prov cascade cluster-wide. 1Gi gives the same
+      # 4× headroom step G17 applied to cnpg for the identical failure
+      # shape.
+      memory: 1Gi
   webhook:
     resources:
       requests:


### PR DESCRIPTION
Live hw90 evidence on #3004: controller is the cluster's only OOMKilled container (26 kills at 256Mi); a dead cert-manager starves sigstore/ESO/otel/kyverno-cleanup webhook servers of TLS certs and wedges the cascade. G17-class right-size: limits 1Gi, requests 256Mi. Lockstep bp-cert-manager 1.2.5 (Chart + blueprint + slot 02 pin). Render-verified (`helm template` shows the new resources block).

Zero-spend validation: hw90 GitRepo sync rolls the controller at 1Gi → OOM kills should stop → cert-starved tier recovers. Will record the observed delta on #3004.

Refs #3004 #2999

🤖 Generated with [Claude Code](https://claude.com/claude-code)