### PR TITLE
fix(crd): #2936 — Blueprint topology cross-field CEL admission rules

### DIFF
--- a/.github/workflows/preflight-blueprint-crd-cel.yaml
+++ b/.github/workflows/preflight-blueprint-crd-cel.yaml
@@ -1,0 +1,170 @@
+name: Preflight — Blueprint CRD CEL admission (real apiserver)
+
+# Issue #2936 — Blueprint CRD topology cross-field CEL admission.
+#
+# The blueprint-admission-validate.yml job validates blueprint.yaml
+# SOURCE files against a JSON Schema using the python `jsonschema`
+# library. That library does NOT evaluate `x-kubernetes-validations`
+# CEL expressions at all — only a real kube-apiserver compiles + runs
+# them. As a result, PR #2958 shipped topology CEL rules that FAILED
+# to compile on a real apiserver (the CRD itself was rejected at apply
+# time), and nothing in CI caught it.
+#
+# This preflight closes that hole. It:
+#   1. Applies products/catalyst/chart/crds/blueprint.yaml to a real
+#      kind apiserver — proving the CRD (incl. every CEL rule) compiles.
+#   2. Applies the blueprint-sample-valid.yaml fixture — every document
+#      MUST be accepted.
+#   3. Applies each document of blueprint-sample-invalid.yaml in
+#      isolation — every document MUST be rejected (HTTP 422). This
+#      includes the #2936 cross-field cases where defaults / perTopology
+#      reference a topology absent from supported[] (a structurally
+#      well-typed CR that ONLY the CEL rule rejects).
+#
+# Event-driven only (CLAUDE.md). workflow_dispatch for ad-hoc re-runs.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'products/catalyst/chart/crds/blueprint.yaml'
+      - 'products/catalyst/chart/crds/tests/blueprint-sample-*.yaml'
+      - '.github/workflows/preflight-blueprint-crd-cel.yaml'
+  pull_request:
+    paths:
+      - 'products/catalyst/chart/crds/blueprint.yaml'
+      - 'products/catalyst/chart/crds/tests/blueprint-sample-*.yaml'
+      - '.github/workflows/preflight-blueprint-crd-cel.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    name: Blueprint CRD CEL admission on real apiserver
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up kind
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: blueprint-crd-cel
+          version: v0.25.0
+          node_image: kindest/node:v1.30.6
+
+      - name: Install Blueprint CRD (proves every CEL rule compiles)
+        # A real apiserver compiles every x-kubernetes-validations CEL
+        # expression at CRD-apply time. A malformed rule (e.g. bracket
+        # indexing a struct, or .all() over named-properties) makes this
+        # step fail — which is exactly what we want CI to catch.
+        run: |
+          kubectl apply -f products/catalyst/chart/crds/blueprint.yaml
+          kubectl wait --for=condition=Established --timeout=60s \
+            crd/blueprints.catalyst.openova.io
+
+      - name: Valid fixture — every document MUST be accepted
+        run: |
+          echo "Applying blueprint-sample-valid.yaml (server-side dry-run)…"
+          kubectl apply --dry-run=server \
+            -f products/catalyst/chart/crds/tests/blueprint-sample-valid.yaml
+          echo "PASS: all valid Blueprint documents accepted by admission"
+
+      - name: Invalid fixture — EVERY document MUST be rejected
+        # kubectl apply on a multi-doc file stops at the first error and
+        # the remaining docs aren't reported, so split the file and apply
+        # each document independently. Every one must be rejected; a single
+        # acceptance fails the job. This guarantees the cross-field CEL
+        # rules (#2936) actually fire — a structurally valid CR whose
+        # defaults/perTopology reference a topology absent from supported[]
+        # is only caught by CEL.
+        run: |
+          set -u
+          INVALID="products/catalyst/chart/crds/tests/blueprint-sample-invalid.yaml"
+          tmpdir="$(mktemp -d)"
+          # csplit on the YAML document separator; produces one file per doc.
+          awk -v dir="$tmpdir" '
+            BEGIN { n=0; f=sprintf("%s/doc-%03d.yaml", dir, n) }
+            /^---[[:space:]]*$/ { n++; f=sprintf("%s/doc-%03d.yaml", dir, n); next }
+            { print > f }
+          ' "$INVALID"
+
+          fail=0
+          checked=0
+          for doc in "$tmpdir"/doc-*.yaml; do
+            # Skip docs that are only comments / whitespace.
+            if ! grep -q 'kind:[[:space:]]*Blueprint' "$doc"; then
+              continue
+            fi
+            checked=$((checked+1))
+            name="$(awk '/^[[:space:]]*name:/{print $2; exit}' "$doc")"
+            out="$(kubectl apply --dry-run=server -f "$doc" 2>&1)" && rc=0 || rc=$?
+            if [ "$rc" -eq 0 ]; then
+              echo "FAIL: invalid document '${name}' was ACCEPTED — admission gap!"
+              echo "----- offending document -----"
+              cat "$doc"
+              fail=1
+            else
+              echo "OK (rejected): ${name}"
+              echo "    └─ $(echo "$out" | head -1)"
+            fi
+          done
+          echo "checked ${checked} invalid documents"
+          if [ "$checked" -eq 0 ]; then
+            echo "FAIL: no invalid documents were checked — fixture parsing broke"
+            exit 1
+          fi
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+          echo "PASS: every invalid Blueprint document rejected by admission"
+
+      - name: Cross-field CEL spot-check — explicit accept + reject pair
+        # Belt-and-suspenders: assert the EXACT #2936 acceptance criterion.
+        # (a) defaults.multi-region NOT in supported[] → rejected with the
+        #     CEL message. (b) the same CR with multi-region added to
+        #     supported[] → accepted. Proves the rule discriminates on the
+        #     cross-field relationship, not on some unrelated structural
+        #     error.
+        run: |
+          set -u
+          reject_cr="$(cat <<'EOF'
+          apiVersion: catalyst.openova.io/v1
+          kind: Blueprint
+          metadata: {name: cel-spotcheck-reject}
+          spec:
+            version: 1.0.0
+            card: {title: spotcheck reject}
+            topology:
+              supported: [singleton]
+              defaults: {multi-region: active-active, single-region: singleton}
+          EOF
+          )"
+          accept_cr="$(cat <<'EOF'
+          apiVersion: catalyst.openova.io/v1
+          kind: Blueprint
+          metadata: {name: cel-spotcheck-accept}
+          spec:
+            version: 1.0.0
+            card: {title: spotcheck accept}
+            topology:
+              supported: [active-active, singleton]
+              defaults: {multi-region: active-active, single-region: singleton}
+          EOF
+          )"
+
+          out="$(printf '%s' "$reject_cr" | kubectl apply --dry-run=server -f - 2>&1)" && rc=0 || rc=$?
+          if [ "$rc" -eq 0 ]; then
+            echo "FAIL: cross-field reject CR was accepted"
+            exit 1
+          fi
+          echo "$out" | grep -q 'topology.defaults.multi-region must be a member of topology.supported' \
+            || { echo "FAIL: rejection did not carry the expected CEL message:"; echo "$out"; exit 1; }
+          echo "PASS (reject): ${out}"
+
+          printf '%s' "$accept_cr" | kubectl apply --dry-run=server -f - \
+            || { echo "FAIL: cross-field accept CR was rejected"; exit 1; }
+          echo "PASS (accept): supported[] superset of defaults accepted"

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -945,7 +945,15 @@ spec:
       # so catalyst-api's CountSovereignRegions can read
       # Sovereign.spec.regions (was returning 0 because the CRD wasn't
       # installed — H7 walk of #2742 evidence). Refs #2856 #2742 #2737.
-      version: 1.4.482
+      # 1.4.483 — #2936: fix the Blueprint topology cross-field CEL rules
+      # (PR #2958 shipped a form the apiserver rejected at CRD-apply time;
+      # never reached a Sovereign because the pin wasn't bumped). Corrected
+      # to Kubernetes hyphen-escaped struct dot-access + has()-guarded
+      # per-key perTopology rules; verified on a real apiserver + gated by
+      # preflight-blueprint-crd-cel.yaml. Flux re-applies crds/ with
+      # CreateReplace on reconcile so existing Sovereigns pick it up.
+      # Refs #2936.
+      version: 1.4.483
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2523,7 +2523,26 @@ name: bp-catalyst-platform
 # deploymentId is immutable post-create via CEL
 # x-kubernetes-validations rule (matches Application.spec.instanceId
 # pattern from #2742 W2.C2). Refs #2856 #2742 #2737.
-version: 1.4.482
+# 1.4.483 (#2936, 2026-06-04): fix(blueprint-crd) the topology
+# cross-field CEL rules shipped by PR #2958 (#2936) were SYNTACTICALLY
+# INVALID and the apiserver REJECTED the whole CRD at apply time — but
+# #2958 never bumped this version/pin so the broken CRD never reached a
+# Sovereign, and its only validator was `helm template --include-crds`,
+# which renders YAML without compiling CEL. Two CEL-modelling traps:
+# (1) `defaults` is a named-properties STRUCT, so `self.defaults
+# ['multi-region']` bracket-indexing has no overload — Kubernetes
+# escapes hyphens for dot-access, so the rule is now
+# `self.defaults.multi__dash__region in self.supported`; (2)
+# `perTopology` is likewise a STRUCT, so `.all(k, ...)` is illegal
+# (`cannot be range of a comprehension`) — replaced with four explicit
+# has()-guarded per-key membership rules. Verified compiling +
+# accepting/rejecting on a real kind v1.30 apiserver, plus a new
+# .github/workflows/preflight-blueprint-crd-cel.yaml gate that applies
+# the CRD + crds/tests fixtures to a real apiserver so a future broken
+# CEL rule can never merge again. Bumping the pin so every Sovereign's
+# Flux helm-controller re-applies the corrected CRD (Flux reconciles
+# crds/ with CreateReplace, unlike raw `helm upgrade`). Refs #2936.
+version: 1.4.483
 appVersion: 1.4.479
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/crds/blueprint.yaml
+++ b/products/catalyst/chart/crds/blueprint.yaml
@@ -350,13 +350,52 @@ spec:
                   # CRD admission means the apiserver rejects the CR at submit
                   # time with HTTP 422 — operator gets immediate feedback
                   # instead of "applied but stuck Pending".
+                  #
+                  # #2936 follow-up (2026-06-04): the first form of these rules
+                  # (shipped via PR #2958) FAILED to compile on a real
+                  # kube-apiserver — the CRD itself was rejected at apply time.
+                  # Two CEL-modelling traps caused it, neither of which the
+                  # jsonschema-based blueprint-admission-validate.yml CI job can
+                  # catch (jsonschema does NOT evaluate x-kubernetes-validations
+                  # CEL at all). Fixes:
+                  #   1. `defaults` is declared with named `properties`, so the
+                  #      CEL type-checker treats it as a STRUCT, not a map.
+                  #      Struct fields whose names are not valid CEL identifiers
+                  #      (the hyphenated `multi-region` / `single-region`) cannot
+                  #      be reached with `['...']` bracket indexing — that
+                  #      overload only exists for map/dyn types. Kubernetes
+                  #      escapes such names for dot-access: `-` → `__dash__`.
+                  #      Hence `self.defaults.multi__dash__region`.
+                  #   2. `perTopology` is likewise declared with named
+                  #      `properties` → STRUCT, so `.all(k, ...)` is illegal
+                  #      ("cannot be range of a comprehension"). Its key-set is
+                  #      the fixed 4-value topology enum, so each variant is
+                  #      checked explicitly under a `has()` guard instead.
+                  # Verified compiling + accepting/rejecting against a real
+                  # kind v1.30 apiserver — see PR body.
                   x-kubernetes-validations:
-                    - rule: "self.defaults['multi-region'] in self.supported"
+                    - rule: "self.defaults.multi__dash__region in self.supported"
                       message: "topology.defaults.multi-region must be a member of topology.supported[]"
-                    - rule: "self.defaults['single-region'] in self.supported"
+                    - rule: "self.defaults.single__dash__region in self.supported"
                       message: "topology.defaults.single-region must be a member of topology.supported[]"
-                    - rule: "!has(self.perTopology) || self.perTopology.all(k, k in self.supported)"
-                      message: "every key in topology.perTopology must be a member of topology.supported[]"
+                    # perTopology key ⊆ supported[]. Struct (named-properties)
+                    # type forbids comprehension ranging, so each of the 4
+                    # topology-enum keys is checked explicitly under a has()
+                    # guard. A key present in perTopology but absent from
+                    # supported[] is rejected at admission.
+                    # The outer `has(self.perTopology)` guard is required: CEL
+                    # cannot traverse into `self.perTopology.<key>` when
+                    # `perTopology` itself is absent (it raises "no such key"
+                    # rather than short-circuiting), so each rule must first
+                    # confirm the parent exists.
+                    - rule: "!has(self.perTopology) || !has(self.perTopology.active__dash__active) || ('active-active' in self.supported)"
+                      message: "topology.perTopology.active-active requires 'active-active' in topology.supported[]"
+                    - rule: "!has(self.perTopology) || !has(self.perTopology.active__dash__hot__dash__standby) || ('active-hot-standby' in self.supported)"
+                      message: "topology.perTopology.active-hot-standby requires 'active-hot-standby' in topology.supported[]"
+                    - rule: "!has(self.perTopology) || !has(self.perTopology.active__dash__passive) || ('active-passive' in self.supported)"
+                      message: "topology.perTopology.active-passive requires 'active-passive' in topology.supported[]"
+                    - rule: "!has(self.perTopology) || !has(self.perTopology.singleton) || ('singleton' in self.supported)"
+                      message: "topology.perTopology.singleton requires 'singleton' in topology.supported[]"
                   properties:
                     supported:
                       type: array

--- a/products/catalyst/chart/crds/tests/blueprint-sample-invalid.yaml
+++ b/products/catalyst/chart/crds/tests/blueprint-sample-invalid.yaml
@@ -100,3 +100,51 @@ spec:
   multiInstance:
     enabled: true
     isolationLevel: vm
+---
+# Eighth invalid (#2936) — cross-field CEL: topology.defaults.multi-region
+# is a LEGAL enum value but is NOT a member of topology.supported[]. Every
+# field is individually well-typed, so only the topology-level
+# x-kubernetes-validations CEL rule catches it. Pre-#2936 this slipped
+# past CRD admission and only surfaced at blueprint-controller reconcile
+# time as Ready=False. Expected apiserver message:
+#   "topology.defaults.multi-region must be a member of topology.supported[]"
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-bad-topology-defaults-not-supported
+spec:
+  version: 1.0.0
+  card:
+    title: defaults references a topology absent from supported[]
+  topology:
+    supported: [singleton]
+    defaults:
+      multi-region: active-active
+      single-region: singleton
+---
+# Ninth invalid (#2936) — cross-field CEL: topology.perTopology has a key
+# (active-active) that is a LEGAL enum value but is NOT in supported[].
+# Caught only by the per-key perTopology CEL rules. Expected message:
+#   "topology.perTopology.active-active requires 'active-active' in topology.supported[]"
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-bad-topology-pertopology-not-supported
+spec:
+  version: 1.0.0
+  card:
+    title: perTopology key absent from supported[]
+  topology:
+    supported: [singleton]
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      active-active:
+        replication:
+          backend: cnpg-pair
+        placement:
+          tier: rtz
+      singleton:
+        placement:
+          tier: rtz


### PR DESCRIPTION
## Summary

The Blueprint topology cross-field CEL rules added by PR #2958 (Refs #2936) were **syntactically invalid** — a real kube-apiserver **rejects the entire Blueprint CRD at apply time**. They never reached a Sovereign because #2958 did not bump the chart version / bootstrap-kit pin, and the only validator on that PR was `helm template --include-crds`, which renders YAML but does **not** compile CEL (PR #1933-shape: dry-render presented as real validation).

This PR fixes the CEL, proves it on a real apiserver, and adds the CI gate that would have caught the original breakage.

### Root cause — two CEL-modelling traps

1. `topology.defaults` is declared with named `properties`, so CEL treats it as a **struct**, not a map. `self.defaults['multi-region']` has no bracket-index overload on a struct, and the hyphenated names are not valid CEL identifiers for dot-access. Kubernetes escapes such names (`-` → `__dash__`), so the rule is now `self.defaults.multi__dash__region in self.supported`.
2. `topology.perTopology` is likewise a named-properties **struct**, so `self.perTopology.all(k, ...)` is illegal (`cannot be range of a comprehension`). Replaced with four explicit per-key membership rules, each guarded by `!has(self.perTopology) || !has(self.perTopology.<key>)`.

### How this reaches existing Sovereigns

The Blueprint CRD ships in the chart's `crds/` directory and is delivered to Sovereigns via the `bp-catalyst-platform` Flux `HelmRelease`. Flux's helm-controller reconciles `crds/` with the default `CreateReplace` policy on every reconcile, so the corrected CRD **does** reach running Sovereigns — unlike a raw `helm upgrade`, which skips the `crds/` directory on upgrade. This PR bumps `bp-catalyst-platform` **1.4.482 → 1.4.483** in both `products/catalyst/chart/Chart.yaml` and the bootstrap-kit slot pin so the next reconcile picks up the fix.

## Verification — real kind v1.30 apiserver (verbatim)

### CRD installs (proves every CEL rule compiles)
Before the fix, the same `kubectl apply` failed:
```
The CustomResourceDefinition "blueprints.catalyst.openova.io" is invalid:
* ...x-kubernetes-validations[0].rule: compilation failed: ERROR: <input>:1:14:
  found no matching overload for '_[_]' applied to '(selfType.defaults, string)'
  | self.defaults['multi-region'] in self.supported
* ...x-kubernetes-validations[2].rule: compilation failed: ERROR: <input>:1:31:
  expression of type 'selfType.perTopology' cannot be range of a comprehension
  | !has(self.perTopology) || self.perTopology.all(k, k in self.supported)
```
After the fix (rendered via `helm template --include-crds`, applied to the apiserver):
```
customresourcedefinition.apiextensions.k8s.io/blueprints.catalyst.openova.io created
customresourcedefinition.apiextensions.k8s.io/blueprints.catalyst.openova.io condition met
```

### (i) Valid CR → ACCEPTED
```
blueprint.catalyst.openova.io/bp-valid created (server dry run)
```

### (ii) `defaults.multi-region` NOT in `supported[]` → REJECTED
```
The Blueprint "bp-defaults-bad" is invalid: spec.topology: Invalid value: "object": topology.defaults.multi-region must be a member of topology.supported[]
```

### (iii) Misspelled enum `active-hotstandby` → REJECTED (enum gate, before CEL)
```
The Blueprint "bp-misspelled" is invalid:
* spec.topology.defaults.multi-region: Unsupported value: "active-hotstandby": supported values: "active-active", "active-hot-standby", "active-passive", "singleton"
* spec.topology.supported[0]: Unsupported value: "active-hotstandby": supported values: "active-active", "active-hot-standby", "active-passive", "singleton"
```

### (iv) `perTopology` key `active-active` NOT in `supported[]` → REJECTED (CEL)
```
The Blueprint "bp-pertopo-bad" is invalid: spec.topology: Invalid value: "object": topology.perTopology.active-active requires 'active-active' in topology.supported[]
```

### Existing fixtures still behave (server dry-run)
`blueprint-sample-valid.yaml` — both documents accepted. `blueprint-sample-invalid.yaml` — all 9 documents rejected (the 7 pre-existing + 2 new cross-field cases):
```
OK rejected: bp-bad
OK rejected: bp-bad-2
OK rejected: bp-bad-topology-enum
OK rejected: bp-bad-topology-required
OK rejected: bp-bad-endpoint
OK rejected: bp-bad-sso
OK rejected: bp-bad-multi
OK rejected: bp-bad-topology-defaults-not-supported       | topology.defaults.multi-region must be a member of topology.supported[]
OK rejected: bp-bad-topology-pertopology-not-supported    | topology.perTopology.active-active requires 'active-active' in topology.supported[]
checked=9 fail=0
```

## Files touched

- `products/catalyst/chart/crds/blueprint.yaml` — corrected the 3 → 6 topology CEL rules (hyphen-escaped struct dot-access + per-key has()-guarded perTopology rules).
- `products/catalyst/chart/crds/tests/blueprint-sample-invalid.yaml` — 2 new invalid documents covering the cross-field gap.
- `.github/workflows/preflight-blueprint-crd-cel.yaml` — **new** gate: applies the CRD + fixtures to a real kind apiserver, asserting accept/reject. Closes the hole that let #2958 merge (the jsonschema-based `blueprint-admission-validate.yml` cannot evaluate CEL).
- `products/catalyst/chart/Chart.yaml` + `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` — bump 1.4.482 → 1.4.483 so existing Sovereigns re-apply the corrected CRD via Flux.

## Scope note

This PR addresses gap #1 of #2936 (the Blueprint CRD topology cross-field rules) only. The Application CRD bounds (rto/rpo/minReplicas, gap #3/#4) were already handled by merged PR #2960; the policy-CRD selector gaps (#5) remain tracked on the issue and are not promoted here to keep the change focused on the Blueprint topology contract.

Refs #2936
