### PR TITLE
fix(cutover): #2951 — untether per-Blueprint values defaults from mothership

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -432,7 +432,10 @@ spec:
       # 0.1.50 (#2951 / #2940 ATTACK#9): Step 10 also pivots the
       # bp-sso-bridge HR image.repository host harbor.openova.io →
       # harbor.<SOVEREIGN_FQDN> (residual chart-default tether).
-      version: 0.1.50
+      # 0.1.51 (#2951 / #2940 ATTACK#9): Step 10 Phase-1c asserts all
+      # four image HRs (3 vClusters + sso-bridge) are off harbor.openova.io
+      # post-pivot; Job exits 1 on any residual mothership-Harbor tether.
+      version: 0.1.51
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/cert-manager-powerdns-webhook/chart/values.yaml
+++ b/platform/cert-manager-powerdns-webhook/chart/values.yaml
@@ -144,11 +144,20 @@ powerdns:
   # rendering entirely — see templates/clusterissuer.yaml's skip-render
   # guard. Cluster overlays may override to a different pool's endpoint.
   #
-  # #2940 (2026-06-03): Pillar 5 anti-tether — franchised Sovereigns
-  # post-bp-self-sovereign-cutover MUST override to their local
-  # `https://pdns.<sov-fqdn>` endpoint. bp-self-sovereign-cutover
-  # Step 6 (helmrepository-patches) doesn't currently rewrite this;
-  # track the gap on #2940 sub-checklist Category 2.
+  # #2940/#2951 (2026-06-04): Pillar 5 review — this `pdns.openova.io`
+  # default is an INTENTIONAL out-of-cluster ACME DNS-01 tether to
+  # contabo's central PowerDNS (the authoritative server for the
+  # omani.* pool, fronted by ns1/2/3.openova.io — see the block above),
+  # NOT a mothership-control-plane tether. Let's Encrypt validates the
+  # DNS-01 TXT records against the PUBLIC DNS chain, so the challenge
+  # MUST be written to whichever PowerDNS is authoritative for the
+  # delegated zone. bp-self-sovereign-cutover deliberately does NOT
+  # rewrite this host: pivoting it to a local `pdns.<sov-fqdn>` would
+  # break wildcard-cert issuance until the Sovereign's own PowerDNS is
+  # delegated authoritative in public DNS. Operators running a fully
+  # self-hosted authoritative DNS override this per-Sovereign once their
+  # NS delegation is committed. Tracked as the intentional-exclusion row
+  # under #2951 (not a residual mothership tether).
   host: "https://pdns.openova.io"
   # PowerDNS server ID — virtually always "localhost" per the upstream
   # API contract. Operators with a multi-tenant PowerDNS deployment

--- a/platform/powerdns/chart/values.yaml
+++ b/platform/powerdns/chart/values.yaml
@@ -364,14 +364,15 @@ dnsdist:
 #      pod, not by Traefik).
 api:
   enabled: true
-  # #2940 (2026-06-03): Pillar 5 anti-tether — this default ties the
-  # PDNS public API ingress to the mothership FQDN. Franchised
-  # Sovereigns post-bp-self-sovereign-cutover MUST override to
-  # `pdns.<sov-fqdn>` in their per-Sovereign overlay. The default is
+  # #2940/#2951 (2026-06-04): Pillar 5 anti-tether — this default ties
+  # the PDNS public API ingress to the mothership FQDN. The default is
   # kept for back-compat with pre-#2940 Sovereigns + Catalyst-Zero
-  # (contabo-mkt) installs. bp-self-sovereign-cutover Step 6
-  # (helmrepository-patches) doesn't currently rewrite this; track
-  # the gap on #2940 sub-checklist Category 2.
+  # (contabo-mkt) installs. RESOLVED for franchised Sovereigns: the
+  # `clusters/_template/bootstrap-kit/11-powerdns.yaml` overlay already
+  # sets `api.host: pdns.${SOVEREIGN_FQDN}` (substituted by Flux at
+  # reconcile), so a post-bp-self-sovereign-cutover Sovereign's live
+  # HelmRelease never carries this mothership host. No cutover-time
+  # rewrite of THIS field is needed — the per-Sovereign overlay owns it.
   host: pdns.openova.io
   path: /api
   pathType: Prefix

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.50
+  version: 0.1.51
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -394,7 +394,15 @@ name: bp-self-sovereign-cutover
 #
 # RBAC: ClusterRole gains batch.cronjobs {get,list,watch,delete} so
 # Step 01 can DELETE the live resource.
-version: 0.1.50
+#
+# 0.1.51 (#2951 / #2940 ATTACK#9): Step 10 gains a Phase-1c
+# residual-tether self-assertion. After the four image.repository
+# pivots (3 vClusters + sso-bridge), the Job re-reads each live HR's
+# spec.values and FAILS LOUDLY (exit 1) if any still references
+# harbor.openova.io — so the cutover automation itself proves the
+# mothership-Harbor untether instead of leaving a manual post-hoc grep
+# as the only acceptance gate.
+version: 0.1.51
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/10-vcluster-registry-pivot-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/10-vcluster-registry-pivot-job.yaml
@@ -342,6 +342,46 @@ data:
             echo "[vcluster-registry-pivot] live-K8s ok=${ok} skip=${skip} fail=${fail}"
             [ "${fail}" -eq 0 ] || exit 1
 
+            # ---- Phase 1c: residual-tether self-assertion (#2951 / #2940 ATTACK#9) ----
+            #
+            # The four image.repository pivots above (3 vClusters + sso-bridge)
+            # are the ONLY chart-default `harbor.openova.io` tethers this step
+            # owns. Assert directly against live HR state that none of them
+            # still resolves to mothership Harbor, so the cutover Job itself
+            # FAILS LOUDLY rather than leaving a manual post-hoc
+            # `kubectl get hr -A -o yaml | grep harbor.openova.io` as the only
+            # acceptance gate (the VERIFIED-PARTIAL finding on #2940: "the
+            # cutover automation does not assert the pivots actually landed").
+            #
+            # Scope note (Pillar 5 / ADR-0002): we ONLY assert the four image
+            # tethers. We deliberately do NOT flag:
+            #   * powerdns `api.host` — the `11-powerdns.yaml` overlay already
+            #     templates `pdns.${SOVEREIGN_FQDN}` (no live harbor ref).
+            #   * cert-manager-powerdns-webhook `powerdns.host` — an INTENTIONAL
+            #     out-of-cluster ACME DNS-01 tether to contabo's central
+            #     PowerDNS; rewriting it would break wildcard-cert issuance.
+            #   * ghcr.io/openova-io chart-fetch URLs — ADR-0002 cold-start path.
+            residual=0
+            for hr_name in bp-mgmt-vcluster bp-rtz-vcluster bp-dmz-vcluster bp-sso-bridge; do
+              kubectl get helmrelease "${hr_name}" -n "${HELMRELEASE_NAMESPACE}" >/dev/null 2>&1 || continue
+              hr_values=$(kubectl get helmrelease "${hr_name}" -n "${HELMRELEASE_NAMESPACE}" \
+                -o jsonpath='{.spec.values}' 2>/dev/null || echo "")
+              case "${hr_values}" in
+                *harbor.openova.io*)
+                  echo "[vcluster-registry-pivot] RESIDUAL-TETHER ${hr_name}: spec.values still references harbor.openova.io" >&2
+                  residual=$((residual+1))
+                  ;;
+                *)
+                  echo "[vcluster-registry-pivot] CLEAN ${hr_name}: no harbor.openova.io in spec.values"
+                  ;;
+              esac
+            done
+            if [ "${residual}" -ne 0 ]; then
+              echo "[vcluster-registry-pivot] FATAL: ${residual} HelmRelease(s) still tethered to mothership Harbor after pivot — Pillar 5 independence not met" >&2
+              exit 1
+            fi
+            echo "[vcluster-registry-pivot] residual-tether assertion PASS (0 of 4 image HRs on harbor.openova.io)"
+
             # ---- Phase 2: push YAML edit to local Gitea ----
             #
             # bootstrap-kit Kustomization reconciles HelmRelease YAML

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -544,7 +544,21 @@ if ! grep -q '13b-bp-sso-bridge.yaml' "$TMP/render.yaml"; then
   echo "FAIL: Step-10 missing bp-sso-bridge Gitea-injection seam (#2951)" >&2
   exit 1
 fi
-echo "  PASS (Step-10 wired to pivot vCluster + sso-bridge HRs to local Harbor)"
+# #2951 (#2940 ATTACK#9, VERIFIED-PARTIAL follow-up): Step-10 must ALSO
+# self-assert that, post-pivot, none of the four image HRs still resolves
+# to harbor.openova.io. Without this Phase-1c the only acceptance gate was
+# a manual `kubectl get hr -A | grep harbor.openova.io` — the cutover Job
+# itself never failed loudly on a residual tether. Guard that the
+# assertion loop AND the FATAL exit-1 on residual!=0 are both present.
+if ! grep -q 'RESIDUAL-TETHER' "$TMP/render.yaml"; then
+  echo "FAIL: Step-10 missing Phase-1c residual-tether self-assertion (#2951)" >&2
+  exit 1
+fi
+if ! grep -q 'Pillar 5 independence not met' "$TMP/render.yaml"; then
+  echo "FAIL: Step-10 residual-tether assertion does not fail loudly on a remaining harbor.openova.io ref (#2951)" >&2
+  exit 1
+fi
+echo "  PASS (Step-10 wired to pivot vCluster + sso-bridge HRs to local Harbor + asserts zero residual mothership-Harbor tether)"
 
 echo "[cutover-contract] Case 22: Step-11 crossplane-provider-pivot patches Provider CRs (TBD-V24 MISS-3)"
 # Chart <0.1.37 shipped NO Crossplane Provider package pivot. Result:


### PR DESCRIPTION
## #2951 — untether per-Blueprint values defaults from mothership

UAT Wave-2 ATTACK#9 (#2940) flagged 6 chart `values.yaml` defaults pointing at mothership URLs. This PR reconciles each against current `main` (post-#2962), fixes the one genuine automation gap, and de-stales the now-misleading default comments.

### Per-default decision table

| File | Old default | New behavior | How cutover covers it |
|---|---|---|---|
| `platform/powerdns/chart/values.yaml` `api.host` | `pdns.openova.io` | Value unchanged (back-compat default); comment corrected to record that the gap is RESOLVED | `clusters/_template/bootstrap-kit/11-powerdns.yaml:168` overlay already sets `api.host: pdns.${SOVEREIGN_FQDN}` (Flux-substituted). Live HR on a franchised Sovereign never carries the mothership host — no cutover-time rewrite of this field needed. |
| `platform/cert-manager-powerdns-webhook/chart/values.yaml` `powerdns.host` | `https://pdns.openova.io` | Value unchanged; comment clarified as an INTENTIONAL external dependency | Deliberately NOT rewritten by cutover. This is the ACME DNS-01 endpoint; LE validates TXT records against the PUBLIC DNS chain, so challenges must be written to whichever PowerDNS is authoritative for the delegated zone. Pivoting to a local host would break wildcard-cert issuance until the Sovereign's own NS delegation is committed. Intentional-exclusion row. |
| `platform/bp-mgmt-vcluster/chart/values.yaml` `image.repository` | `harbor.openova.io/proxy-ghcr/...` | Value unchanged (pre-cutover central proxy-cache, ADR-0002 cold-start) | Cutover Step 10 (`vcluster-registry-pivot`) already pivots host `harbor.openova.io` -> `harbor.${SOVEREIGN_FQDN}` (since chart 0.1.36). NOW also asserted clean by the new Phase-1c. |
| `platform/bp-dmz-vcluster/chart/values.yaml` `image.repository` | `harbor.openova.io/proxy-ghcr/...` | Value unchanged (ADR-0002 cold-start) | Same Step 10 pivot + Phase-1c assertion. |
| `platform/bp-rtz-vcluster/chart/values.yaml` `image.repository` | `harbor.openova.io/proxy-ghcr/...` | Value unchanged (ADR-0002 cold-start) | Same Step 10 pivot + Phase-1c assertion. |
| `platform/sso-bridge/chart/values.yaml` `image.repository` | `harbor.openova.io/proxy-dockerhub/...` | Value unchanged (ADR-0002 cold-start) | Cutover Step 10 pivots it (added #2962). NOW also asserted clean by the new Phase-1c. |

### The genuine gap closed here

The #2940 VERIFIED-PARTIAL review found that the cutover automation never asserted the image pivots actually landed — leaving a manual `kubectl get hr -A | grep harbor.openova.io` as the only acceptance gate. Step 10 now gains a **Phase-1c residual-tether self-assertion**: after the four `image.repository` pivots it re-reads each live HelmRelease's `spec.values` and exits 1 (FATAL, "Pillar 5 independence not met") if any still resolves to `harbor.openova.io`. The cutover Job now proves the mothership-Harbor untether itself.

Lockstep bump `bp-self-sovereign-cutover` 0.1.50 -> 0.1.51 (Chart.yaml + blueprint.yaml + slot 06a pin). Contract-test Case 21 extended with two guards.

### Verification (code-side)

- `helm template` renders all cutover templates clean (3733 lines).
- Embedded Step-10 shell command passes `bash -n` (the real `set -eu` script with the new Phase-1c block).
- `chart/tests/cutover-contract.sh` — all gates green, including the extended Case 21 (`asserts zero residual mothership-Harbor tether`).
- powerdns + cert-manager-powerdns-webhook edits are comment-only; the `host:` value lines are byte-identical, so before/after `helm template` is unchanged.
- Touched-values grep: residual `openova.io` hits in the three touched values files are all intentional (back-compat powerdns default + the intentional ACME DNS-01 host + the cutover's own `mothershipHarborURL`/`egressBlockHosts`/cold-start container images, which the cutover pivots FROM, not a tether to remove).

### Live-cutover-only verifiable

This is a Kubernetes Job shell-script change with no UI surface. The following can only be proven on a fresh franchised Sovereign that has provisioned AND run `bp-self-sovereign-cutover`:

- That Phase-1c's `kubectl get helmrelease ... -o jsonpath='{.spec.values}'` reads the post-pivot value correctly and the assertion PASSes on a genuinely-pivoted cluster (and would have FAILed pre-fix).
- The acceptance grep `kubectl get hr -A -o yaml | grep -i harbor.openova.io` returns ZERO matches outside the intentional pre-cutover ghcr.io/openova-io catalog-fetch path (ADR-0002).

### Consistency with #2940

No conflict with #2940's pending fixes. #2940's remaining items (`CATALYST_API_PUBLIC_URL` inline literal, exercising the `CATALYST_PIN_ISSUER`/`CATALYST_HANDOVER_JWT_ISSUER`/`CORS_ORIGIN` env seams via Step 07) are catalyst-api env tethers in a different cutover step and a different file set — untouched here. This PR stays scoped to ATTACK#9 Category 2 (chart values defaults) and the Step-10 image-pivot assertion.

Refs #2951 #2940

🤖 Generated with [Claude Code](https://claude.com/claude-code)
