### PR TITLE
fix(cutover): #2940 — pivot remaining catalyst-api tether seams in Step 07 Phase 3

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -435,7 +435,7 @@ spec:
       # 0.1.51 (#2951 / #2940 ATTACK#9): Step 10 Phase-1c asserts all
       # four image HRs (3 vClusters + sso-bridge) are off harbor.openova.io
       # post-pivot; Job exits 1 on any residual mothership-Harbor tether.
-      version: 0.1.51
+      version: 0.1.52
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -953,7 +953,7 @@ spec:
       # preflight-blueprint-crd-cel.yaml. Flux re-applies crds/ with
       # CreateReplace on reconcile so existing Sovereigns pick it up.
       # Refs #2936.
-      version: 1.4.485
+      version: 1.4.486
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.51
+  version: 0.1.52
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -402,7 +402,7 @@ name: bp-self-sovereign-cutover
 # harbor.openova.io — so the cutover automation itself proves the
 # mothership-Harbor untether instead of leaving a manual post-hoc grep
 # as the only acceptance gate.
-version: 0.1.51
+version: 0.1.52
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
@@ -83,6 +83,14 @@ data:
             value: {{ .Values.gitea.org | quote }}
           - name: GITEA_REPO
             value: {{ .Values.gitea.repo | quote }}
+          # #2940 Phase 3 (2026-06-03): the Sovereign's own public
+          # console URL — the pivot target for the catalyst-api env
+          # seams (pin/handover-JWT issuers + runtime-config console +
+          # api-public URLs). Overlay supplies
+          # https://console.${SOVEREIGN_FQDN} (same convention as
+          # sovereign.harborPublicURL / giteaPublicURL above).
+          - name: CONSOLE_PUBLIC_URL
+            value: {{ .Values.sovereign.consolePublicURL | quote }}
         command: ["/bin/sh", "-c"]
         args:
           - |
@@ -204,7 +212,67 @@ data:
             kubectl rollout status "deploy/${DEPLOYMENT_NAME}" \
               -n "${DEPLOYMENT_NAMESPACE}" \
               --timeout=300s
-            echo "[catalyst-api-env-patch] done"
+
+            # ---- Phase 3 (#2940, 2026-06-03): pivot the remaining ----
+            # catalyst-api mothership env seams. The VERIFIED-PARTIAL
+            # review found that Phases 1-2 only flip the image registry
+            # + the GitOps repo URL: the PIN/handover-JWT issuers and
+            # the runtime-config console/api-public URLs kept their
+            # mothership back-compat defaults, so the 10-min
+            # deny-egress hold could pass while tokens still carried a
+            # mothership `iss` and CORS/public-URL pointed home. Each
+            # pivot below ends in a read-back assert (Step-10-Phase-1c
+            # pattern): any openova.io residue is FATAL — Pillar 5
+            # independence not met.
+            if [ -z "${CONSOLE_PUBLIC_URL}" ] || echo "${CONSOLE_PUBLIC_URL}" | grep -q "example.local"; then
+              echo "[catalyst-api-env-patch] FATAL Phase 3: sovereign.consolePublicURL not overlaid (got '${CONSOLE_PUBLIC_URL}') — supply https://console.<sovereign-fqdn>" >&2
+              exit 1
+            fi
+
+            # 3a. runtime-config ConfigMap keys (CORS_ORIGIN +
+            # CATALYST_SOVEREIGN_URL read sovereign-console-url;
+            # CATALYST_API_PUBLIC_URL reads sovereign-api-public-url —
+            # all via configMapKeyRef, so the CM is the single seam).
+            kubectl patch configmap catalyst-runtime-config \
+              -n "${DEPLOYMENT_NAMESPACE}" \
+              --type merge \
+              -p "{\"data\":{\"sovereign-console-url\":\"${CONSOLE_PUBLIC_URL}\",\"sovereign-api-public-url\":\"${CONSOLE_PUBLIC_URL}/sovereign\"}}"
+
+            # 3b. issuer envs (auth.go pinIssuer + main.go handover-JWT
+            # issuer read these; the in-code openova.io constants are
+            # fallbacks ONLY when the env is unset).
+            kubectl set env "deploy/${DEPLOYMENT_NAME}" \
+              -n "${DEPLOYMENT_NAMESPACE}" \
+              "CATALYST_PIN_ISSUER=${CONSOLE_PUBLIC_URL}" \
+              "CATALYST_HANDOVER_JWT_ISSUER=${CONSOLE_PUBLIC_URL}"
+            kubectl rollout status "deploy/${DEPLOYMENT_NAME}" \
+              -n "${DEPLOYMENT_NAMESPACE}" \
+              --timeout=300s
+
+            # 3c. Read-back asserts — live values, not intentions.
+            for KEY in sovereign-console-url sovereign-api-public-url; do
+              LIVE=$(kubectl get configmap catalyst-runtime-config \
+                -n "${DEPLOYMENT_NAMESPACE}" \
+                -o jsonpath="{.data['${KEY}']}" 2>/dev/null || echo "")
+              case "${LIVE}" in
+                *openova.io*|"")
+                  echo "[catalyst-api-env-patch] FATAL Phase 3: runtime-config ${KEY}='${LIVE}' still mothership/empty — Pillar 5 independence not met" >&2
+                  exit 1 ;;
+              esac
+              echo "[catalyst-api-env-patch] Phase 3 OK: ${KEY}=${LIVE}"
+            done
+            for VAR in CATALYST_PIN_ISSUER CATALYST_HANDOVER_JWT_ISSUER; do
+              LIVE=$(kubectl get deploy "${DEPLOYMENT_NAME}" \
+                -n "${DEPLOYMENT_NAMESPACE}" \
+                -o jsonpath="{.spec.template.spec.containers[0].env[?(@.name=='${VAR}')].value}" 2>/dev/null || echo "")
+              case "${LIVE}" in
+                *openova.io*|"")
+                  echo "[catalyst-api-env-patch] FATAL Phase 3: ${VAR}='${LIVE}' still mothership/empty — Pillar 5 independence not met" >&2
+                  exit 1 ;;
+              esac
+              echo "[catalyst-api-env-patch] Phase 3 OK: ${VAR}=${LIVE}"
+            done
+            echo "[catalyst-api-env-patch] done (Phases 1-3 complete)"
         resources:
           requests: { cpu: 50m, memory: 64Mi }
           limits:   { memory: 256Mi }

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -637,4 +637,40 @@ if ! grep -q '"xpkg.upbound.io"' "$TMP/render.yaml"; then
 fi
 echo "  PASS (Step-11 wired to pivot Provider CRs to local Harbor proxy-xpkg)"
 
+
+echo "[cutover-contract] Case 23: Step-07 Phase 3 pivots catalyst-api issuer envs + runtime-config URLs (#2940)"
+# The #2940 VERIFIED-PARTIAL review found Step-07 only patched
+# CATALYST_GITOPS_REPO_URL: the PIN/handover-JWT issuers and the
+# catalyst-runtime-config console/api-public URL keys kept mothership
+# defaults, so a cutover could pass the egress hold while every token
+# still carried a mothership `iss`. Phase 3 pivots all four seams and
+# read-back-asserts zero openova.io residue (FATAL otherwise).
+if ! grep -q 'CONSOLE_PUBLIC_URL' "$TMP/render.yaml"; then
+  echo "FAIL: Step-07 missing CONSOLE_PUBLIC_URL wiring (#2940 Phase 3)" >&2
+  exit 1
+fi
+for var in CATALYST_PIN_ISSUER CATALYST_HANDOVER_JWT_ISSUER; do
+  if ! grep -q "${var}" "$TMP/render.yaml"; then
+    echo "FAIL: Step-07 Phase 3 missing issuer pivot for ${var} (#2940)" >&2
+    exit 1
+  fi
+done
+for key in sovereign-console-url sovereign-api-public-url; do
+  if ! grep -q "${key}" "$TMP/render.yaml"; then
+    echo "FAIL: Step-07 Phase 3 missing runtime-config pivot for ${key} (#2940)" >&2
+    exit 1
+  fi
+done
+# The read-back assert must FAIL FATAL on mothership residue.
+if ! grep -q 'Pillar 5 independence not met' "$TMP/render.yaml"; then
+  echo "FAIL: Step-07 Phase 3 missing read-back FATAL assert (#2940)" >&2
+  exit 1
+fi
+# The example-default guard must be present (unconfigured overlay = FATAL).
+if ! grep -q 'consolePublicURL not overlaid' "$TMP/render.yaml"; then
+  echo "FAIL: Step-07 Phase 3 missing example-default guard (#2940)" >&2
+  exit 1
+fi
+echo "  PASS (Step-07 Phase 3 pivots issuers + runtime-config URLs with read-back asserts)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -49,6 +49,15 @@ sovereign:
   giteaInternalURL: "http://gitea-http.gitea.svc.cluster.local:3000"
   # ↓ overlay supplies https://gitea.${SOVEREIGN_FQDN} (informational; jobs use internal URL).
   giteaPublicURL: "https://gitea.example.local"
+  # ↓ overlay required for real cutover (uses ${SOVEREIGN_FQDN}).
+  #    #2940 Phase 3: Step 07 pivots the catalyst-api issuer envs
+  #    (CATALYST_PIN_ISSUER / CATALYST_HANDOVER_JWT_ISSUER) + the
+  #    catalyst-runtime-config console/api-public URL keys to this
+  #    value, then read-back-asserts zero openova.io residue. The Job
+  #    FAILS FATAL if left at the example default — a cutover that
+  #    skipped the issuer pivot would pass the egress hold while every
+  #    token still carried a mothership `iss`.
+  consolePublicURL: "https://console.example.local"
 
 # Upstream openova-io read-only public clone — the source for cutover
 # step 01. Step-1 calls Gitea's /repos/migrate API with mirror=true so

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2542,7 +2542,7 @@ name: bp-catalyst-platform
 # CEL rule can never merge again. Bumping the pin so every Sovereign's
 # Flux helm-controller re-applies the corrected CRD (Flux reconciles
 # crds/ with CreateReplace, unlike raw `helm upgrade`). Refs #2936.
-version: 1.4.485
+version: 1.4.486
 appVersion: 1.4.479
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -362,15 +362,24 @@ spec:
             # docs/INVIOLABLE-PRINCIPLES.md #4 this is runtime
             # configuration; air-gapped franchises override it
             # without code change.
-            # #2940 (2026-06-03): URL-path "/sovereign" suffix kept as a
-            # literal; the host portion is sourced from
-            # catalyst-runtime-config sovereign-console-url. Pre-#2940
-            # this whole value was the hardcoded mothership URL.
-            # Operator override seam: catalystApi.env additional-env
-            # patch in the per-Sovereign HelmRelease overlay (dual-mode
-            # contract — see CATALYST_POWERDNS_API_URL block above).
+            # #2940 (2026-06-03, VERIFIED-PARTIAL reviewer catch): the
+            # prior revision carried a fix-comment claiming the host was
+            # "sourced from catalyst-runtime-config" while the value:
+            # below was still the inline mothership literal — an
+            # aspirational-comment-over-unfixed-value anti-pattern. Now
+            # genuinely a configMapKeyRef: the key is
+            # sovereign-api-public-url in catalyst-runtime-config
+            # (default runtime.sovereignAPIPublicURL — the mothership
+            # URL survives ONLY as the back-compat default), and
+            # bp-self-sovereign-cutover Step 07 Phase 3 pivots it to the
+            # Sovereign's own console URL at cutover with a read-back
+            # assert. Operator override seam unchanged (per-Sovereign
+            # HelmRelease overlay sets runtime.sovereignAPIPublicURL).
             - name: CATALYST_API_PUBLIC_URL
-              value: https://console.openova.io/sovereign
+              valueFrom:
+                configMapKeyRef:
+                  name: catalyst-runtime-config
+                  key: sovereign-api-public-url
             # CATALYST_NATS_URL — TBD-D35c (issue #1776). When set, the
             # catalyst-api dials this NATS endpoint and publishes the
             # `catalyst.tenant.sandbox_requested` envelope on every

--- a/products/catalyst/chart/templates/configmap-catalyst-runtime-config.yaml
+++ b/products/catalyst/chart/templates/configmap-catalyst-runtime-config.yaml
@@ -42,3 +42,9 @@ data:
   # configMapKeyRef. Override via runtime.sovereignConsoleURL in
   # per-Sovereign overlay or bp-self-sovereign-cutover Step 7.
   sovereign-console-url: {{ .Values.runtime.sovereignConsoleURL | quote }}
+  # #2940 (2026-06-03): public origin a provisioning Sovereign's
+  # cloud-init PUTs its kubeconfig back to (CATALYST_API_PUBLIC_URL via
+  # configMapKeyRef in api-deployment.yaml). Mothership URL is ONLY the
+  # back-compat default; bp-self-sovereign-cutover Step 7 Phase 3
+  # pivots it to the Sovereign's own console URL post-handover.
+  sovereign-api-public-url: {{ .Values.runtime.sovereignAPIPublicURL | quote }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -383,6 +383,14 @@ runtime:
   # the new value via the checksum/runtime-config rolling restart
   # mechanism (PR #2928).
   sovereignConsoleURL: "https://console.openova.io"
+  # #2940 (2026-06-03): Pillar 5 anti-tether — public origin a
+  # provisioning Sovereign's cloud-init PUTs its kubeconfig back to
+  # (CATALYST_API_PUBLIC_URL). Same seam pattern as sovereignConsoleURL
+  # directly above: mothership URL is ONLY the back-compat default;
+  # per-Sovereign overlays override to https://console.<sov-fqdn>/sovereign,
+  # and bp-self-sovereign-cutover Step 7 Phase 3 pivots it at cutover
+  # with a read-back assert.
+  sovereignAPIPublicURL: "https://console.openova.io/sovereign"
 
 # ─── Group C controllers (slice CC3 of EPIC-0 #1095) ────────────────────────
 # The 5 K8s-native reconcilers consolidated by CC1 (#1135) + CC2 (#1136):


### PR DESCRIPTION
## What — the 3 seams the VERIFIED-PARTIAL review left open

| Seam (reviewer finding) | Fix |
|---|---|
| `api-deployment.yaml:373` — `CATALYST_API_PUBLIC_URL` inline mothership literal under an aspirational fix-comment | Genuine `configMapKeyRef` → new `catalyst-runtime-config` key `sovereign-api-public-url` (default `runtime.sovereignAPIPublicURL`; mothership URL survives only as the back-compat default) |
| Step 07 only patches `CATALYST_GITOPS_REPO_URL` — issuers + CORS/public-URL never pivot, so the egress hold can pass while tokens still carry a mothership `iss` | New **Phase 3**: pivots `CATALYST_PIN_ISSUER` + `CATALYST_HANDOVER_JWT_ISSUER` envs and the runtime-config `sovereign-console-url` + `sovereign-api-public-url` keys to the Sovereign's own console URL (new `sovereign.consolePublicURL` overlay seam — **FATAL if left at the example default**), each followed by a read-back assert: any `openova.io` residue → `FATAL: Pillar 5 independence not met` |
| powerdns / cert-manager-powerdns-webhook values defaults | Per merged PR #3008: overlay-templated (`pdns.${SOVEREIGN_FQDN}`) / intentional external ACME DNS-01 tether — re-verified, not contradicted |

`cutover-contract.sh` **Case 23** guards all of it (CONSOLE_PUBLIC_URL wiring, both issuer pivots, both CM-key pivots, the FATAL read-back, the example-default guard).

Lockstep: bp-catalyst-platform **1.4.485** (Chart + slot 13), bp-self-sovereign-cutover **0.1.52** (Chart + blueprint + slot 06a).

## Verification (code-side)

- `helm template` products/catalyst → `CATALYST_API_PUBLIC_URL` renders as the configMapKeyRef; CM renders both keys.
- Full cutover contract suite green incl. new Case 23.
- Step-07 inner Job shell (extracted from the rendered podSpec ConfigMap) passes `bash -n`; Phase 3 present.
- No NEW `openova.io` literals — the two remaining in touched files are the documented back-compat values defaults.

## Live-cutover-only

That Phase 3's read-backs PASS on a genuinely pivoted cluster (would FATAL today on any cluster still carrying mothership values), and that a token minted post-cutover carries the Sovereign's own `iss`. Needs a franchised Sovereign reaching Step 07 — none live today.

Refs #2940 #2951

🤖 Generated with [Claude Code](https://claude.com/claude-code)
