### PR TITLE
docs(uat): repoint UAT to hw91 — hw90 wiped, hw91 provisioning on complete chain

### DIFF
--- a/docs/ledger/UAT-2026-06-03.md
+++ b/docs/ledger/UAT-2026-06-03.md
@@ -12,14 +12,14 @@
 
 | Field | Value |
 |---|---|
-| **Product / release** | OpenOva Catalyst — Sovereign `<sovereign-fqdn>` (target: fresh prov `hw90`, 2-region `me-east-215-a`/`-b`, active-hot-standby) |
-| **Build under test** | catalog `main` (incl. fresh-prov fixes #2982 / #2985 / #2989 / #3004 / #3007 / #3008; #2999 install-remediation in PR #3000; #2988 + #3006 in PR #3003) |
-| **Status as of** | **2026-06-03T18:55Z** — hw90 still **29/54 HRs Ready**; cert-manager OOM (#3004) fixed+merged+self-healed live, but the **cnpg trunk wedge persists** so the console path is still down; live status detail in the verdict row below |
+| **Product / release** | OpenOva Catalyst — Sovereign `<sovereign-fqdn>` (target: fresh prov **`hw91.omantel.biz`**, dep `38ae2b82dc325354`, 2-region `me-east-215-a`/`-b`, active-hot-standby; TLD per LE-rotation — `omani.works` cert budget exhausted by hw86–hw90) |
+| **Build under test** | catalog `main` with the COMPLETE fresh-prov hardening chain **merged**: #2982 (host-ns) / #2985 (ESO deadlock) / #2989 (SSO deadlock) / #2999 (install retries -1, 54 slots) / #2988+#3006 (openbao guard + seed-skip) / #3004 (cert-manager OOM) / #3007 (Blueprint CEL) / #3008+#2940 (cutover untether) |
+| **Status as of** | **2026-06-03T21:15Z** — **hw90 WIPED** (failed env; full janitor sweep: 8 ECS + 2 NAT + ELB cascade + 2 VPCs, zero-orphan verified — only the bastion remains) and **hw91 PROVISIONING** (`38ae2b82dc325354`, HTTP 201 at 21:10Z) on the first catalog that carries the whole hardening chain. Every ⛔ below re-walks the moment hw91 reconciles `ready` hands-off |
 | **Environment** | `https://console.<sovereign-fqdn>` (operator console) · `https://marketplace.<sovereign-fqdn>` (customer marketplace) |
 | **Surface(s)** | Responsive web (operator console + customer marketplace). No native mobile app ships. |
 | **Tester** | `@p0-474-lonely` (UAT executor sub-agent) |
 | **Walk date** | 2026-06-03 |
-| **Overall verdict** | ⛔ **BLOCKED** — no live console yet. The first zero-touch prov (`hw89`) stalled on the #2989 SSO-bootstrap deadlock (now **fixed**, #2994). The current prov **`hw90`** *cleared* that deadlock and sits at **29/54 HRs Ready**. Layer-2/3 chain (all read-only diagnosed; every fix catalog-only, Flux self-heal): **(a) cnpg operator crash-flaps** — exit 2 after a silent hang at the startup-probe budget = informer cache-sync timeout, node-level API-watch dysfunction (NOT the probe; the earlier #2995 probe-widening was a wrong guess, honestly recorded). This is the **trunk** of the console path (gitea → catalyst-platform → console, ~13 HRs) and is **still wedged** as of 18:55Z (50+ restarts) — no catalog fix shipped on speculation, environmental signature. **(b) cert-manager controller OOMKilled at 256Mi** (#3004) — was the cluster's only OOMKilled container; starved the whole webhook tier (sigstore/ESO/otel/kyverno-cleanup) of TLS certs. **FIXED → PR #3005 merged → self-healed live on hw90** (256Mi→1Gi, controller now 1/1 Running 0 restarts; captured). **(c)** crossplane + mimir installs exhausted their Flux retry budget *inside* the dysfunction window and went **permanently terminal** ("exceeded maximum retries") — systemic zero-touch gap, fix `install.remediation.retries: -1` (54 slots) in **#2999 / PR #3000**. **(d)** crossplane #2998 RCA corrected (environmental; cert fix withdrawn before shipping). **(e)** the openbao fresh-prov CI gate (PR #3003) surfaced **two more latent wedges for the NEXT prov's openbao slot**: #2988 (sso ExternalSecrets lacked the ESO-CRD Capabilities guard) + #3006 (chart-managed recovery-seed Secret collided with the cloud-init one) — both fixed in PR #3003. `console.hw90.omani.works` remains HTTP 000. **Zero-touch note:** hw90 is a **failed environment** used only to *expose* this chain; clean acceptance comes from a *final* prov reconciling to `ready` with **zero manual intervention**. Every live-UI row is ⛔ until then; **truthful could-not-attempt — not a pass, not a product-UI fail.** |
+| **Overall verdict** | ⛔ **BLOCKED** — no live console yet. The first zero-touch prov (`hw89`) stalled on the #2989 SSO-bootstrap deadlock (now **fixed**, #2994). The current prov **`hw90`** *cleared* that deadlock and sits at **29/54 HRs Ready**. Layer-2/3 chain (all read-only diagnosed; every fix catalog-only, Flux self-heal): **(a) cnpg operator crash-flaps** — exit 2 after a silent hang at the startup-probe budget = informer cache-sync timeout, node-level API-watch dysfunction (NOT the probe; the earlier #2995 probe-widening was a wrong guess, honestly recorded). This is the **trunk** of the console path (gitea → catalyst-platform → console, ~13 HRs) and is **still wedged** as of 18:55Z (50+ restarts) — no catalog fix shipped on speculation, environmental signature. **(b) cert-manager controller OOMKilled at 256Mi** (#3004) — was the cluster's only OOMKilled container; starved the whole webhook tier (sigstore/ESO/otel/kyverno-cleanup) of TLS certs. **FIXED → PR #3005 merged → self-healed live on hw90** (256Mi→1Gi, controller now 1/1 Running 0 restarts; captured). **(c)** crossplane + mimir installs exhausted their Flux retry budget *inside* the dysfunction window and went **permanently terminal** ("exceeded maximum retries") — systemic zero-touch gap, fix `install.remediation.retries: -1` (54 slots) in **#2999 / PR #3000**. **(d)** crossplane #2998 RCA corrected (environmental; cert fix withdrawn before shipping). **(e)** the openbao fresh-prov CI gate (PR #3003) surfaced **two more latent wedges for the NEXT prov's openbao slot**: #2988 (sso ExternalSecrets lacked the ESO-CRD Capabilities guard) + #3006 (chart-managed recovery-seed Secret collided with the cloud-init one) — both fixed in PR #3003. **hw90 endgame:** its cnpg trunk wedge stayed environmental to the end (50+ restarts, no catalog fix shippable on evidence) — declared failed, **wiped + zero-orphan-verified 21:05Z**, and **hw91 (`hw91.omantel.biz`) is provisioning** on the first catalog carrying every fix above. **Zero-touch note:** failed envs expose; they never accept. Acceptance = the first prov that reconciles `ready` with **zero manual intervention** — every live-UI row is ⛔ until then; **truthful could-not-attempt — not a pass, not a product-UI fail.** |
 
 ---
 
@@ -54,10 +54,10 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [marketplace.`<sovereign-fqdn>`/redeem?code=`<CODE>`](https://marketplace.hw90.omani.works/redeem) | Open the redeem link from the email | "Validating voucher…" spinner, then a **Voucher valid** card showing the **OMR credit** amount + the code | ⛔ | — |
+| 1 | [marketplace.`<sovereign-fqdn>`/redeem?code=`<CODE>`](https://marketplace.hw91.omantel.biz/redeem) | Open the redeem link from the email | "Validating voucher…" spinner, then a **Voucher valid** card showing the **OMR credit** amount + the code | ⛔ | — |
 | 2 | Redeem preview | Tap **Sign up to redeem** | Advances to the plan wizard at **/plans** — the code is carried into checkout | ⛔ | — |
 
-- **Journey verdict:** ⛔ **BLOCKED** — marketplace not reachable (`hw90` console never came up, [#2989](https://github.com/openova-io/openova/issues/2989)).
+- **Journey verdict:** ⛔ **BLOCKED** — marketplace not reachable; awaiting `hw91` reaching `ready` (prior provs: hw89 died on [#2989](https://github.com/openova-io/openova/issues/2989), hw90 on the environmental cnpg wedge).
 
 ### TC-02 — Pick a plan, apps and domain *(web · customer · Pillar 1, Phase 1b)*
 
@@ -67,9 +67,9 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [marketplace.`<sovereign-fqdn>`/plans](https://marketplace.hw90.omani.works/plans) | On **Pick a plan**, tap a plan card, tap **Continue** | Advances to **Build your stack** (/apps) | ⛔ | — |
-| 2 | [/apps](https://marketplace.hw90.omani.works/apps) | Select one or more apps (each tagged **FREE**), tap **Continue** | Advances to **Setup & extras** (/addons) | ⛔ | — |
-| 3 | [/addons](https://marketplace.hw90.omani.works/addons) | Under **Your domain**, type a subdomain (e.g. `my-company`) in the **Subdomain** field; pick any add-ons | Subdomain accepted (≥3 chars, no "Subdomain must be at least 3 characters" warning); **Checkout** button enabled | ⛔ | — |
+| 1 | [marketplace.`<sovereign-fqdn>`/plans](https://marketplace.hw91.omantel.biz/plans) | On **Pick a plan**, tap a plan card, tap **Continue** | Advances to **Build your stack** (/apps) | ⛔ | — |
+| 2 | [/apps](https://marketplace.hw91.omantel.biz/apps) | Select one or more apps (each tagged **FREE**), tap **Continue** | Advances to **Setup & extras** (/addons) | ⛔ | — |
+| 3 | [/addons](https://marketplace.hw91.omantel.biz/addons) | Under **Your domain**, type a subdomain (e.g. `my-company`) in the **Subdomain** field; pick any add-ons | Subdomain accepted (≥3 chars, no "Subdomain must be at least 3 characters" warning); **Checkout** button enabled | ⛔ | — |
 
 - **Journey verdict:** ⛔ **BLOCKED** — marketplace down ([#2989](https://github.com/openova-io/openova/issues/2989)).
 
@@ -81,7 +81,7 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [marketplace.`<sovereign-fqdn>`/bcp](https://marketplace.hw90.omani.works/bcp) | Read the **Business continuity** step — *"Pick how your database should survive a regional outage"* | Two **Topology** cards: **Single-region** (FREE) and **active-hot-standby** | ⛔ | — |
+| 1 | [marketplace.`<sovereign-fqdn>`/bcp](https://marketplace.hw91.omantel.biz/bcp) | Read the **Business continuity** step — *"Pick how your database should survive a regional outage"* | Two **Topology** cards: **Single-region** (FREE) and **active-hot-standby** | ⛔ | — |
 | 2 | /bcp Topology | Select the **active-hot-standby** card | A **primary region** and a **replica region** picker appear; the two must differ | ⛔ | — |
 | 3 | /bcp | Pick a primary region and a different replica region, tap **Continue** | Advances to **Review & launch** (/review); the form refuses identical regions | ⛔ | — |
 
@@ -95,8 +95,8 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [marketplace.`<sovereign-fqdn>`/review](https://marketplace.hw90.omani.works/review) | On **Review & launch**, check **Your stack**, **Tenant** URL and **Monthly total**, tap **Checkout** | Advances to the **Checkout** page | ⛔ | — |
-| 2 | [/checkout](https://marketplace.hw90.omani.works/checkout) | Under **Sign in to continue**, type the customer email, tap to send the code | "A 6-digit code was sent to `<email>`" + a 6-box PIN input | ⛔ | — |
+| 1 | [marketplace.`<sovereign-fqdn>`/review](https://marketplace.hw91.omantel.biz/review) | On **Review & launch**, check **Your stack**, **Tenant** URL and **Monthly total**, tap **Checkout** | Advances to the **Checkout** page | ⛔ | — |
+| 2 | [/checkout](https://marketplace.hw91.omantel.biz/checkout) | Under **Sign in to continue**, type the customer email, tap to send the code | "A 6-digit code was sent to `<email>`" + a 6-box PIN input | ⛔ | — |
 | 3 | /checkout PIN | Type the 6-digit code | Account verified — the **Tenant name** + **Subdomain** + **Order summary** (with voucher **Credit available** applied) render | ⛔ | — |
 | 4 | /checkout | Confirm tenant name, tap **Create** | "Setting up your tenant" → auto-redirect to the new Organization console at **console.`<orgslug>`.`<pool-tld>`** — no "could not provision user record" error | ⛔ | — |
 
@@ -110,8 +110,8 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [console.`<orgslug>`.`<pool-tld>`/dashboard](https://console.hw90.omani.works/dashboard) | Look at the dashboard | The Organization's resource overview renders — not an empty/error page | ⛔ | — |
-| 2 | [/apps](https://console.hw90.omani.works/apps) | Open the **Apps** view | The apps chosen in TC-02 appear as cards, each showing a status badge (Running / Installing) | ⛔ | — |
+| 1 | [console.`<orgslug>`.`<pool-tld>`/dashboard](https://console.hw91.omantel.biz/dashboard) | Look at the dashboard | The Organization's resource overview renders — not an empty/error page | ⛔ | — |
+| 2 | [/apps](https://console.hw91.omantel.biz/apps) | Open the **Apps** view | The apps chosen in TC-02 appear as cards, each showing a status badge (Running / Installing) | ⛔ | — |
 
 - **Journey verdict:** ⛔ **BLOCKED** — console down.
 
@@ -125,10 +125,10 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [console.`<sovereign-fqdn>`/login](https://console.hw90.omani.works/login) | Type the operator email, tap **Sign in** | Advances to **/login/verify** — email shown + a 6-box PIN input | ⛔ | — |
-| 2 | [/login/verify](https://console.hw90.omani.works/login/verify) | Type / paste the 6-digit PIN | Auto-submits on the 6th digit → lands on **/dashboard**, authenticated | ⛔ | — |
+| 1 | [console.`<sovereign-fqdn>`/login](https://console.hw91.omantel.biz/login) | Type the operator email, tap **Sign in** | Advances to **/login/verify** — email shown + a 6-box PIN input | ⛔ | — |
+| 2 | [/login/verify](https://console.hw91.omantel.biz/login/verify) | Type / paste the 6-digit PIN | Auto-submits on the 6th digit → lands on **/dashboard**, authenticated | ⛔ | — |
 
-- **Journey verdict:** ⛔ **BLOCKED** — `console.hw90.omani.works` returns HTTP 000 (host down, [#2989](https://github.com/openova-io/openova/issues/2989)).
+- **Journey verdict:** ⛔ **BLOCKED** — `console.hw91.omantel.biz` returns HTTP 000 (host down, [#2989](https://github.com/openova-io/openova/issues/2989)).
 
 ### TC-07 — Operator dashboard shows the Sovereign *(web · operator · D16 / D22)*
 
@@ -138,8 +138,8 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/dashboard](https://console.hw90.omani.works/dashboard) | Read the dashboard treemap | The Sovereign's resources render grouped by region — no stuck spinners, no "0/0" everywhere | ⛔ | — |
-| 2 | [/settings](https://console.hw90.omani.works/settings) | Open **Settings** | Real values for Region, Capacity, Control-plane size, Created timestamp, Deployment ID, Pool subdomain — not `—` placeholders | ⛔ | — |
+| 1 | [/dashboard](https://console.hw91.omantel.biz/dashboard) | Read the dashboard treemap | The Sovereign's resources render grouped by region — no stuck spinners, no "0/0" everywhere | ⛔ | — |
+| 2 | [/settings](https://console.hw91.omantel.biz/settings) | Open **Settings** | Real values for Region, Capacity, Control-plane size, Created timestamp, Deployment ID, Pool subdomain — not `—` placeholders | ⛔ | — |
 
 - **Journey verdict:** ⛔ **BLOCKED** — console down.
 
@@ -151,8 +151,8 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/bss](https://console.hw90.omani.works/bss) | Open the **BSS** landing from the sidebar | KPI dashboard + a section grid including **Vouchers** | ⛔ | — |
-| 2 | [/bss/vouchers](https://console.hw90.omani.works/bss/vouchers) | Tap **Issue** | An Issue modal with **code**, **credit (OMR)**, **description**, **max redemptions**, **recipient email** fields | ⛔ | — |
+| 1 | [/bss](https://console.hw91.omantel.biz/bss) | Open the **BSS** landing from the sidebar | KPI dashboard + a section grid including **Vouchers** | ⛔ | — |
+| 2 | [/bss/vouchers](https://console.hw91.omantel.biz/bss/vouchers) | Tap **Issue** | An Issue modal with **code**, **credit (OMR)**, **description**, **max redemptions**, **recipient email** fields | ⛔ | — |
 | 3 | Issue modal | Fill the fields, submit | The new voucher appears in the voucher table with a **Status** pill — and is emailed to the recipient | ⛔ | — |
 
 - **Journey verdict:** ⛔ **BLOCKED** — console down.
@@ -165,7 +165,7 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/catalog/grafana](https://console.hw90.omani.works/catalog/grafana) | Open a Blueprint class page (e.g. Grafana) | The Blueprint header + supported-topology list + an instance table; a **+ New instance** affordance for multi-instance Blueprints | ⛔ | — |
+| 1 | [/catalog/grafana](https://console.hw91.omantel.biz/catalog/grafana) | Open a Blueprint class page (e.g. Grafana) | The Blueprint header + supported-topology list + an instance table; a **+ New instance** affordance for multi-instance Blueprints | ⛔ | — |
 
 - **Journey verdict:** ⛔ **BLOCKED** — console down.
 
@@ -177,7 +177,7 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/install/grafana](https://console.hw90.omani.works/install/grafana) | Open the install form for the Blueprint | An auto-generated config form (from the Blueprint's schema) + a **Topology** selector | ⛔ | — |
+| 1 | [/install/grafana](https://console.hw91.omantel.biz/install/grafana) | Open the install form for the Blueprint | An auto-generated config form (from the Blueprint's schema) + a **Topology** selector | ⛔ | — |
 | 2 | /install/grafana | Try to pick a topology the Blueprint doesn't support | The unsupported option is **disabled/blocked inline** with a helper note; the form won't submit it | ⛔ | — |
 | 3 | /install/grafana | Fill the form, pick a supported topology, submit | A status modal shows the install progressing; on done, **Open Apps** lands back on **/apps** with the new instance present | ⛔ | — |
 
@@ -191,9 +191,9 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/apps](https://console.hw90.omani.works/apps) | Tap an app card | **/app/`<name>`** opens on the **Overview** tab with a status badge (e.g. ● Running) — not "deployment id malformed" | ⛔ | — |
-| 2 | [/app/`<name>`](https://console.hw90.omani.works/app/grafana) | Open the **Topology** tab | The placement tree shows clusters/nodes under **both** `me-east-215-a` AND `me-east-215-b`; topology reads **active-hot-standby** for HA apps | ⛔ | — |
-| 3 | [/jobs](https://console.hw90.omani.works/jobs) | Open the **Jobs** view | Every job is in a terminal state (0 pending, 0 running); per-region prefixes are visible for a multi-region Sovereign | ⛔ | — |
+| 1 | [/apps](https://console.hw91.omantel.biz/apps) | Tap an app card | **/app/`<name>`** opens on the **Overview** tab with a status badge (e.g. ● Running) — not "deployment id malformed" | ⛔ | — |
+| 2 | [/app/`<name>`](https://console.hw91.omantel.biz/app/grafana) | Open the **Topology** tab | The placement tree shows clusters/nodes under **both** `me-east-215-a` AND `me-east-215-b`; topology reads **active-hot-standby** for HA apps | ⛔ | — |
+| 3 | [/jobs](https://console.hw91.omantel.biz/jobs) | Open the **Jobs** view | Every job is in a terminal state (0 pending, 0 running); per-region prefixes are visible for a multi-region Sovereign | ⛔ | — |
 
 - **Journey verdict:** ⛔ **BLOCKED** — console down.
 
@@ -205,7 +205,7 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/app/grafana](https://console.hw90.omani.works/app/grafana) | On the app detail, find the **Launch** button on an SSO-enabled endpoint | A **Launch →** button (not a bare endpoint URL) | ⛔ | — |
+| 1 | [/app/grafana](https://console.hw91.omantel.biz/app/grafana) | On the app detail, find the **Launch** button on an SSO-enabled endpoint | A **Launch →** button (not a bare endpoint URL) | ⛔ | — |
 | 2 | /app/grafana | Tap **Launch →** | A new tab opens the app **already signed in** — no Keycloak login form appears | ⛔ | — |
 
 - **Journey verdict:** ⛔ **BLOCKED** — console down. *(Silent-SSO chain has 5 stacked layers; re-walk verifies all of them at once.)*
@@ -218,7 +218,7 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/apps/`<id>`/endpoints](https://console.hw90.omani.works/apps) | Tap **+ New endpoint**, fill the dialog, submit | Banner *"Change submitted as PR `<link>`"* with a clickable PR URL | ⛔ | — |
+| 1 | [/apps/`<id>`/endpoints](https://console.hw91.omantel.biz/apps) | Tap **+ New endpoint**, fill the dialog, submit | Banner *"Change submitted as PR `<link>`"* with a clickable PR URL | ⛔ | — |
 | 2 | The linked PR | Open the PR link from the banner | PR is open with the 3 gating checks (`kyverno-admission`, `cert-manager-precheck`, `dns-conflict-precheck`) and auto-merges on green | ⛔ | — |
 
 - **Journey verdict:** ⛔ **BLOCKED** — console down. *(PR-page step is the one allowed off-console hop — it's a link the user clicks from the banner, not a terminal action.)*
@@ -233,7 +233,7 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/sandbox](https://console.hw90.omani.works/sandbox) | Look at the agent grid | A grid of agent cards including **qwen-code** (the default, zero cloud-cost leak) and **claude-code** | ⛔ | — |
+| 1 | [/sandbox](https://console.hw91.omantel.biz/sandbox) | Look at the agent grid | A grid of agent cards including **qwen-code** (the default, zero cloud-cost leak) and **claude-code** | ⛔ | — |
 | 2 | /sandbox | Tap **qwen-code** to start a session | A session opens at **/sandbox/`<id>`** — the AI assistant is ready, no credential/setup prompt | ⛔ | — |
 | 3 | In the session | Ask in plain language: *"list my organization's applications"* | The agent answers with **your Org's actual apps** (org-aware, via its auto-mounted knowledge) — not a permission error and not "I have no access" | ⛔ | — |
 
@@ -249,7 +249,7 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/dashboard](https://console.hw90.omani.works/dashboard) | Find the Sovereignty card | A status badge reading **Tethered** + an **Achieve True Sovereignty** button | ⛔ | — |
+| 1 | [/dashboard](https://console.hw91.omantel.biz/dashboard) | Find the Sovereignty card | A status badge reading **Tethered** + an **Achieve True Sovereignty** button | ⛔ | — |
 | 2 | Sovereignty card | Tap **Achieve True Sovereignty** | An explanation modal warns the cutover is irreversible and runs a 10-minute egress-block self-test; a confirm button | ⛔ | — |
 | 3 | Confirm modal | Confirm | A progress card mounts showing the cutover steps running | ⛔ | — |
 | 4 | Sovereignty progress card | Wait for the egress-block hold to complete | The badge flips to **Sovereign**; the egress-block self-test shows passed | ⛔ | — |
@@ -279,7 +279,7 @@ Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the execu
 | TC-15 | web | operator | 5 | Sovereignty cutover | 4 | 0 | 0 | 0 | 4 | ⛔ |
 | | | | | **Total** | **39** | **0** | **0** | **0** | **39** | |
 
-**Overall verdict:** ⛔ **BLOCKED** — zero journeys walkable: no prov has reached `ready` yet. The fresh-prov bug-chain is being cleared at the source (#2982 → #2985 → #2989 → #2995 → crossplane/image-pulls next), each fix via the catalog only (no manual cluster touch — that would fail zero-touch). hw90 is a deliberately **failed environment** used to expose the chain. This is a truthful "could-not-attempt" outcome, **not** a fail of the product UI and **not** a pass. Re-walk on the first prov that reaches `ready` **hands-off**; every ⛔ above then becomes a real ✅/❌ with a committed screenshot.
+**Overall verdict:** ⛔ **BLOCKED** — zero journeys walkable yet: no prov has reached `ready`. The fresh-prov bug-chain was cleared at the source, catalog-only (#2982 → #2985 → #2989 → #2999 → #2988/#3006 → #3004 → #3007 → #3008/#2940 — ALL merged; cnpg + crossplane were environmental, no speculative fix shipped). hw88/hw89/hw90 were exposure envs — all failed, all wiped zero-orphan. **hw91 (`hw91.omantel.biz`) is the first prov on the complete chain and is provisioning now.** This is a truthful "could-not-attempt" outcome, **not** a fail of the product UI and **not** a pass. Re-walk the moment hw91 reaches `ready` **hands-off**; every ⛔ above then becomes a real ✅/❌ with a committed screenshot.
 
 ---
 


### PR DESCRIPTION
hw90 (failed env) wiped via janitor sweep, zero-orphan verified (only bastion remains). hw91 (`38ae2b82dc325354`, `hw91.omantel.biz` — TLD per LE rotation) provisioning on the first catalog with the complete hardening chain merged. All journey URLs + metadata + verdicts repointed; ⛔ rows re-walk when hw91 reconciles ready hands-off.

Refs #2999 #3004

🤖 Generated with [Claude Code](https://claude.com/claude-code)