### PR TITLE
docs(uat): rev 2 — comprehensive 26-TC backlog-derived walk, sandbox excluded

### DIFF
--- a/docs/ledger/UAT-2026-06-03.md
+++ b/docs/ledger/UAT-2026-06-03.md
@@ -1,10 +1,12 @@
-# UAT — OpenOva Catalyst — 2026-06-03
+# UAT — OpenOva Catalyst — 2026-06-03 (rev 2, comprehensive)
 
 > **Standard User-Acceptance-Test walk** — the real OpenOva Catalyst end-user journeys filled into the UAT standard template ([`UAT-TEMPLATE.md`](UAT-TEMPLATE.md)).
 >
-> **Golden rule — this document is 100% the end-user's experience.** Every step is something a person does with their thumb or mouse on the shipped UI. No terminal, no `kubectl`, no API calls, no log greps, no code reading — those are the dev team's job (see *Out of scope*). A non-technical tester must be able to follow every row verbatim.
+> **Golden rule — this document is 100% the end-user's experience.** Every step is something a person does with their thumb or mouse on the shipped UI. No terminal, no `kubectl`, no API calls, no log greps, no code reading — those are the dev team's job (see Appendix A). A non-technical tester must be able to follow every row verbatim.
 >
-> **Journey order mirrors the DoD** ([`../DOD.md`](../DOD.md)) — Phase 0 → Phase 1 → Phase 2 across the 5 pillars, **customer journeys first** (redeem → plan wizard → BCP → checkout → org online), **operator journeys second** (PIN sign-in → catalog → install → launch → endpoints → multi-region → failover), **sovereignty cutover last**. Personas are grouped; within each persona, what happens first comes first.
+> **Walk order = the deterministic test** ([`../DOD.md`](../DOD.md) §2) — the ONLY order a fresh prov can actually be walked in: handover lands the operator first (D0), the operator issues the voucher (Phase 0), only then can a customer redeem it (Phase 1), day-2 operator journeys follow, the region-kill (D31) and the sovereignty cutover (§7) come last because both mutate the environment.
+>
+> **Scope ruling (founder, 2026-06-03):** Pillar 4 / Sandbox is **excluded** from this UAT. Pillars 1, 2, 3, 5 are covered in full. Wire-level proofs (counter-test, egress capture, HR state) are companions in Appendix A — they are **automated, NOT acceptance**.
 
 ---
 
@@ -13,292 +15,418 @@
 | Field | Value |
 |---|---|
 | **Product / release** | OpenOva Catalyst — Sovereign `<sovereign-fqdn>` (target: fresh prov **`hw91.omantel.biz`**, dep `38ae2b82dc325354`, 2-region `me-east-215-a`/`-b`, active-hot-standby; TLD per LE-rotation — `omani.works` cert budget exhausted by hw86–hw90) |
-| **Build under test** | catalog `main` with the COMPLETE fresh-prov hardening chain **merged**: #2982 (host-ns) / #2985 (ESO deadlock) / #2989 (SSO deadlock) / #2999 (install retries -1, 54 slots) / #2988+#3006 (openbao guard + seed-skip) / #3004 (cert-manager OOM) / #3007 (Blueprint CEL) / #3008+#2940 (cutover untether) |
-| **Status as of** | **2026-06-03T21:15Z** — **hw90 WIPED** (failed env; full janitor sweep: 8 ECS + 2 NAT + ELB cascade + 2 VPCs, zero-orphan verified — only the bastion remains) and **hw91 PROVISIONING** (`38ae2b82dc325354`, HTTP 201 at 21:10Z) on the first catalog that carries the whole hardening chain. Every ⛔ below re-walks the moment hw91 reconciles `ready` hands-off |
-| **Environment** | `https://console.<sovereign-fqdn>` (operator console) · `https://marketplace.<sovereign-fqdn>` (customer marketplace) |
-| **Surface(s)** | Responsive web (operator console + customer marketplace). No native mobile app ships. |
-| **Tester** | `@p0-474-lonely` (UAT executor sub-agent) |
-| **Walk date** | 2026-06-03 |
-| **Overall verdict** | ⛔ **BLOCKED** — no live console yet. The first zero-touch prov (`hw89`) stalled on the #2989 SSO-bootstrap deadlock (now **fixed**, #2994). The current prov **`hw90`** *cleared* that deadlock and sits at **29/54 HRs Ready**. Layer-2/3 chain (all read-only diagnosed; every fix catalog-only, Flux self-heal): **(a) cnpg operator crash-flaps** — exit 2 after a silent hang at the startup-probe budget = informer cache-sync timeout, node-level API-watch dysfunction (NOT the probe; the earlier #2995 probe-widening was a wrong guess, honestly recorded). This is the **trunk** of the console path (gitea → catalyst-platform → console, ~13 HRs) and is **still wedged** as of 18:55Z (50+ restarts) — no catalog fix shipped on speculation, environmental signature. **(b) cert-manager controller OOMKilled at 256Mi** (#3004) — was the cluster's only OOMKilled container; starved the whole webhook tier (sigstore/ESO/otel/kyverno-cleanup) of TLS certs. **FIXED → PR #3005 merged → self-healed live on hw90** (256Mi→1Gi, controller now 1/1 Running 0 restarts; captured). **(c)** crossplane + mimir installs exhausted their Flux retry budget *inside* the dysfunction window and went **permanently terminal** ("exceeded maximum retries") — systemic zero-touch gap, fix `install.remediation.retries: -1` (54 slots) in **#2999 / PR #3000**. **(d)** crossplane #2998 RCA corrected (environmental; cert fix withdrawn before shipping). **(e)** the openbao fresh-prov CI gate (PR #3003) surfaced **two more latent wedges for the NEXT prov's openbao slot**: #2988 (sso ExternalSecrets lacked the ESO-CRD Capabilities guard) + #3006 (chart-managed recovery-seed Secret collided with the cloud-init one) — both fixed in PR #3003. **hw90 endgame:** its cnpg trunk wedge stayed environmental to the end (50+ restarts, no catalog fix shippable on evidence) — declared failed, **wiped + zero-orphan-verified 21:05Z**, and **hw91 (`hw91.omantel.biz`) is provisioning** on the first catalog carrying every fix above. **Zero-touch note:** failed envs expose; they never accept. Acceptance = the first prov that reconciles `ready` with **zero manual intervention** — every live-UI row is ⛔ until then; **truthful could-not-attempt — not a pass, not a product-UI fail.** |
-
----
-
-## How to read & fill this document
+| **Build under test** | catalog `main` with the complete fresh-prov hardening chain merged: #2982 / #2985 / #2989 / #2999 / #2988+#3006 / #3004 / #3007 / #3008+#2940 |
+| **Environment** | `https://console.<sovereign-fqdn>` (operator console) · `https://marketplace.<sovereign-fqdn>` (customer marketplace) · `https://console.<orgslug>.<pool-tld>` (tenant console; pool = `omani.homes` / `omani.rest` / `omani.trade`) |
+| **Surface(s)** | Responsive web only. No native mobile app ships. |
+| **Tester** | founder walk (or read-only Playwright verification agent — never an agent that ships fixes) |
+| **Walk date** | begins the moment hw91 reconciles `ready` with **zero manual intervention** |
+| **Overall verdict** | ☐ **NOT WALKED** — hw91 provisioning (started 2026-06-03T21:10Z). Per the zero-touch contract, hw88/hw89/hw90 were failed exposure environments (all wiped, zero-orphan verified); hw91 is the first prov on the catalog that carries every fix in the chain. |
 
 **Result legend** (exactly one per Result cell): ✅ PASS *(evidence required)* · ❌ FAIL *(file defect, leave issue open)* · ⛔ BLOCKED *(couldn't attempt)* · ⏭️ N/A · ☐ NOT WALKED.
 
-Rules: no ✅ without a committed screenshot link; walk top-to-bottom; the executor is **read-only** on the product and **never closes the issue**; report the screen you saw, not the one you expected; "looks right from the code" is banned.
-
-> **Why this walk is BLOCKED, honestly:** clean zero-touch provs were raised to walk these journeys, and they surfaced a *chain* of real fresh-prov bugs — each fixed **at the source (catalog) only**, never by hand-patching the cluster (a single manual fix fails the zero-touch contract): #2982 (dmz host-namespaces), #2985 (external-secrets↔openbao deadlock), #2989 (the 3-way gitea→catalyst-platform→sso-bridge SSO-bootstrap deadlock — `bp-gitea` can't install without an `sso/gitea` secret `bp-sso-bridge` couldn't write). hw89 died on #2989; hw90 cleared it and exposed layer 2: cnpg operator crash-flapping on an informer cache-sync timeout (node-level API-watch dysfunction in the HCS early-prov window — the same environmental flavor as crossplane's #2998 FailedMount), plus a **systemic zero-touch gap**: Flux install remediation exhausts its retry budget inside such a window and goes permanently terminal, so the prov can never self-heal even after the environment settles — fixed by #2999 / PR #3000 (`retries: -1`). The console (`bp-catalyst-platform`) does not reach Ready until that whole chain clears, so `console.<sovereign-fqdn>` does not resolve. **Re-walk on the first prov that reaches `ready` with zero manual touch** — that is the acceptance environment.
+**Rules:** no ✅ without a committed screenshot link (`docs/sessions/<date>/evidence/`); walk top-to-bottom; the executor is **read-only** on the product and **never closes the issue**; report the screen you saw, not the one you expected; "looks right from the code" is banned; any manual cluster intervention fails the environment (fix at catalog source only).
 
 ---
 
-## Surface-specific authoring rules
+## Coverage contract
 
-**Web (responsive):** *"Screen you're on"* = the URL (linked); *"What you do"* = the visible button/field label; *"What you must see"* = the resulting URL/screen/toast. Catalyst ships no native mobile app, so there are no app-store / gesture / permission journeys.
+Every committed end-user behavior for pillars 1, 2, 3, 5 maps to a TC row below. Cross-reference:
 
----
+| Committed behavior | Source of commitment | TC |
+|---|---|---|
+| Handover auto-redirect, no FQDN typing | DoD **D0** | TC-01 |
+| PIN login chain | DoD D2/D3/D4 | TC-02 |
+| Operator pre-seeded owner-tier; settings real values; route hygiene | DoD D21/D22/D23/D24 | TC-03 |
+| Marketplace enabled, zero-touch | DoD **D27** | TC-04 |
+| One-click voucher issuance + email | DoD **D28**, §5.4 O1–O2 | TC-05 |
+| Canonical redeem URL + validity card (+ bad-code rejection, #2941) | DoD Phase 1a, Pillar 1 | TC-06 |
+| Plan + app selection | Pillar 1, §5.5 | TC-07 |
+| Free-subdomain picker from operator pool | DoD **D30** | TC-08 |
+| BCP topology choice **at signup** | **Pillar 2** (acceptance row) | TC-09 |
+| Zero-touch org provisioning off a voucher | DoD **D29**, #2000 integrity | TC-10 |
+| Org online: tenant console + TLS + first app SSO "Open" | DoD Phase 1c/2a, §5.5 step 7 | TC-11 |
+| Operator sees the new tenant (BSS) | DoD §5.4 O3 | TC-12 |
+| Multi-region dashboard + cloud views | DoD D5/D15/D16 | TC-13 |
+| Jobs terminal + region filter | DoD D6/D20 | TC-14 |
+| Catalog class/instance split | #2741 (G117) | TC-15 |
+| **3 coexisting instances** of one Blueprint | #2737 DoD #5, #2745 | TC-16 |
+| Launch silent-SSO — Tier-1 sweep (grafana, gitea, harbor, openbao) | #2743, #2744, G113 | TC-17 |
+| Endpoint edit → governed Git PR → **full propagation < 2 min** | #2742, #2737 DoD #4, ADR-0009 | TC-18 |
+| RBAC surfaces render real data | EPIC-3, D21 | TC-19 |
+| Operator-facing hostnames all serve | DoD **D25** | TC-20 |
+| **Cross-Org realm isolation** (two Orgs, distinct sessions) | #2744, #2737 DoD #6 | TC-21 |
+| CNPG-backed app, active-hot-standby, both regions visible | DoD **D31** (UI side), Pillar 3 | TC-22 |
+| Region-kill: app stays reachable (RTO ≤ 30 s) | DoD D31 + §6, Pillar 3 | TC-23 |
+| "Achieve True Sovereignty" CTA + modal | Pillar 5, DoD §7 step 2 | TC-24 |
+| Cutover completes: badge flips, egress self-test green | Pillar 5, DoD §7 steps 3–5 | TC-25 |
+| **Post-cutover regression** (PIN, SSO, tenant, marketplace still work) | #2940 (the `iss`-tether attack) | TC-26 |
 
-## Test journeys
-
-> Ordered as the platform is actually experienced: **Phase 1 customer onboarding** (TC-01…TC-05), then **Phase 0/1 operator onboarding + management** (TC-06…TC-13), then **Phase 2 sandbox** (TC-14), then **Pillar 5 sovereignty** (TC-15). Customer = persona P5 (SME End User). Operator = persona P2 (`sovereign-admin`).
-
----
-
-### TC-01 — Redeem a voucher *(web · customer · Pillar 1, Phase 1a)*
-
-- **Persona:** First-time SME customer emailed a voucher code, on their phone.
-- **Goal:** *"As a new customer, I want to open my voucher link and see what credit I've been given, so that I can start signing up."*
-- **Surface:** Responsive web (mobile Safari).
-- **Preconditions:** A valid unredeemed voucher code; the voucher email in the inbox.
-
-| # | Screen you're on | What you do | What you must see | Result | Evidence |
-|---|---|---|---|---|---|
-| 1 | [marketplace.`<sovereign-fqdn>`/redeem?code=`<CODE>`](https://marketplace.hw91.omantel.biz/redeem) | Open the redeem link from the email | "Validating voucher…" spinner, then a **Voucher valid** card showing the **OMR credit** amount + the code | ⛔ | — |
-| 2 | Redeem preview | Tap **Sign up to redeem** | Advances to the plan wizard at **/plans** — the code is carried into checkout | ⛔ | — |
-
-- **Journey verdict:** ⛔ **BLOCKED** — marketplace not reachable; awaiting `hw91` reaching `ready` (prior provs: hw89 died on [#2989](https://github.com/openova-io/openova/issues/2989), hw90 on the environmental cnpg wedge).
-
-### TC-02 — Pick a plan, apps and domain *(web · customer · Pillar 1, Phase 1b)*
-
-- **Persona:** Same SME customer continuing the signup wizard.
-- **Goal:** *"As a customer, I want to choose my plan, the apps I need and my free subdomain, so that my Organization is set up the way I want."*
-- **Surface:** Responsive web. **Preconditions:** arrived from TC-01 (or browsing `/plans` directly).
-
-| # | Screen you're on | What you do | What you must see | Result | Evidence |
-|---|---|---|---|---|---|
-| 1 | [marketplace.`<sovereign-fqdn>`/plans](https://marketplace.hw91.omantel.biz/plans) | On **Pick a plan**, tap a plan card, tap **Continue** | Advances to **Build your stack** (/apps) | ⛔ | — |
-| 2 | [/apps](https://marketplace.hw91.omantel.biz/apps) | Select one or more apps (each tagged **FREE**), tap **Continue** | Advances to **Setup & extras** (/addons) | ⛔ | — |
-| 3 | [/addons](https://marketplace.hw91.omantel.biz/addons) | Under **Your domain**, type a subdomain (e.g. `my-company`) in the **Subdomain** field; pick any add-ons | Subdomain accepted (≥3 chars, no "Subdomain must be at least 3 characters" warning); **Checkout** button enabled | ⛔ | — |
-
-- **Journey verdict:** ⛔ **BLOCKED** — marketplace down ([#2989](https://github.com/openova-io/openova/issues/2989)).
-
-### TC-03 — Choose multi-region BCP topology at signup *(web · customer · Pillar 2, Phase 1b)*
-
-- **Persona:** Same SME customer, on the **Business continuity** step.
-- **Goal:** *"As a customer, I want to pick active-hot-standby across two regions, so that my data survives a regional outage."*
-- **Surface:** Responsive web. **Preconditions:** on the wizard at the BCP step (after Add-ons).
-
-| # | Screen you're on | What you do | What you must see | Result | Evidence |
-|---|---|---|---|---|---|
-| 1 | [marketplace.`<sovereign-fqdn>`/bcp](https://marketplace.hw91.omantel.biz/bcp) | Read the **Business continuity** step — *"Pick how your database should survive a regional outage"* | Two **Topology** cards: **Single-region** (FREE) and **active-hot-standby** | ⛔ | — |
-| 2 | /bcp Topology | Select the **active-hot-standby** card | A **primary region** and a **replica region** picker appear; the two must differ | ⛔ | — |
-| 3 | /bcp | Pick a primary region and a different replica region, tap **Continue** | Advances to **Review & launch** (/review); the form refuses identical regions | ⛔ | — |
-
-- **Journey verdict:** ⛔ **BLOCKED** — marketplace down. *(This is the Pillar 2 acceptance surface — BCP chosen at signup, not as a Day-2 upgrade.)*
-
-### TC-04 — Review and complete checkout *(web · customer · Pillar 1, Phase 1b–c)*
-
-- **Persona:** Same SME customer finishing signup.
-- **Goal:** *"As a customer, I want to review my order, sign in with a PIN and create my Organization, so that my Sovereign account goes live."*
-- **Surface:** Responsive web. **Preconditions:** completed TC-02 + TC-03; email access for the 6-digit code.
-
-| # | Screen you're on | What you do | What you must see | Result | Evidence |
-|---|---|---|---|---|---|
-| 1 | [marketplace.`<sovereign-fqdn>`/review](https://marketplace.hw91.omantel.biz/review) | On **Review & launch**, check **Your stack**, **Tenant** URL and **Monthly total**, tap **Checkout** | Advances to the **Checkout** page | ⛔ | — |
-| 2 | [/checkout](https://marketplace.hw91.omantel.biz/checkout) | Under **Sign in to continue**, type the customer email, tap to send the code | "A 6-digit code was sent to `<email>`" + a 6-box PIN input | ⛔ | — |
-| 3 | /checkout PIN | Type the 6-digit code | Account verified — the **Tenant name** + **Subdomain** + **Order summary** (with voucher **Credit available** applied) render | ⛔ | — |
-| 4 | /checkout | Confirm tenant name, tap **Create** | "Setting up your tenant" → auto-redirect to the new Organization console at **console.`<orgslug>`.`<pool-tld>`** — no "could not provision user record" error | ⛔ | — |
-
-- **Journey verdict:** ⛔ **BLOCKED** — marketplace/console down ([#2989](https://github.com/openova-io/openova/issues/2989)).
-
-### TC-05 — Customer's Organization is online *(web · customer · Pillar 1, Phase 2a)*
-
-- **Persona:** SME customer landing in their new tenant console for the first time.
-- **Goal:** *"As a customer, I want to see my apps running on my own dashboard, so that I know my plan is live."*
-- **Surface:** Responsive web. **Preconditions:** completed TC-04; on `console.<orgslug>.<pool-tld>`.
-
-| # | Screen you're on | What you do | What you must see | Result | Evidence |
-|---|---|---|---|---|---|
-| 1 | [console.`<orgslug>`.`<pool-tld>`/dashboard](https://console.hw91.omantel.biz/dashboard) | Look at the dashboard | The Organization's resource overview renders — not an empty/error page | ⛔ | — |
-| 2 | [/apps](https://console.hw91.omantel.biz/apps) | Open the **Apps** view | The apps chosen in TC-02 appear as cards, each showing a status badge (Running / Installing) | ⛔ | — |
-
-- **Journey verdict:** ⛔ **BLOCKED** — console down.
+Deliberate exclusions are listed in Appendix B with reasons. Anything user-facing and committed that is NOT in this table or Appendix B is a defect of this document — file it.
 
 ---
 
-### TC-06 — Operator signs in with a PIN *(web · operator · Phase 0a / D3)*
+## Part I — Handover & operator first-touch
 
-- **Persona:** `sovereign-admin` opening the operator console for the first time post-handover.
-- **Goal:** *"As the operator, I want to sign in with email + PIN, so that I can manage my Sovereign."*
-- **Surface:** Responsive web. **Preconditions:** operator email enrolled as owner-tier; mailbox access.
+### TC-01 — Handover auto-redirect *(web · operator · D0)*
 
-| # | Screen you're on | What you do | What you must see | Result | Evidence |
-|---|---|---|---|---|---|
-| 1 | [console.`<sovereign-fqdn>`/login](https://console.hw91.omantel.biz/login) | Type the operator email, tap **Sign in** | Advances to **/login/verify** — email shown + a 6-box PIN input | ⛔ | — |
-| 2 | [/login/verify](https://console.hw91.omantel.biz/login/verify) | Type / paste the 6-digit PIN | Auto-submits on the 6th digit → lands on **/dashboard**, authenticated | ⛔ | — |
-
-- **Journey verdict:** ⛔ **BLOCKED** — `console.hw91.omantel.biz` returns HTTP 000 (host down, [#2989](https://github.com/openova-io/openova/issues/2989)).
-
-### TC-07 — Operator dashboard shows the Sovereign *(web · operator · D16 / D22)*
-
-- **Persona:** Operator confirming their Sovereign is real after sign-in.
-- **Goal:** *"As the operator, I want my dashboard and settings to show my real Sovereign, so that I trust it provisioned correctly."*
-- **Surface:** Responsive web. **Preconditions:** signed in (TC-06).
+- **Persona:** P2 `sovereign-admin` who just submitted the provision wizard, watching the progress page.
+- **Goal:** *"As the operator, when my Sovereign is ready I want to land on its console automatically, without copying or typing any FQDN."*
+- **Preconditions:** deployment `38ae2b82dc325354` provisioning; operator signed in on the mothership.
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/dashboard](https://console.hw91.omantel.biz/dashboard) | Read the dashboard treemap | The Sovereign's resources render grouped by region — no stuck spinners, no "0/0" everywhere | ⛔ | — |
-| 2 | [/settings](https://console.hw91.omantel.biz/settings) | Open **Settings** | Real values for Region, Capacity, Control-plane size, Created timestamp, Deployment ID, Pool subdomain — not `—` placeholders | ⛔ | — |
+| 1 | [console.openova.io/sovereign/provision/38ae2b82dc325354](https://console.openova.io/sovereign/provision/38ae2b82dc325354) | Watch the provisioning progress page (no clicks) | Per-region stage rows advance; **no stage stuck Pending after handover fires**; `Apps` / `Handover` rows reach Succeeded (or n/a) | ☐ | — |
+| 2 | Same page, at `ready` | Do nothing — wait | Browser **auto-redirects** to the Sovereign Console (`/auth/handover?token=…` → console) — you never type `hw91.omantel.biz` | ☐ | — |
 
-- **Journey verdict:** ⛔ **BLOCKED** — console down.
+- **Journey verdict:** ☐
 
-### TC-08 — Operator issues a voucher from BSS *(web · operator · Phase 0c / D28)*
+### TC-02 — Operator PIN sign-in *(web · operator · D2/D3/D4)*
 
-- **Persona:** Operator onboarding a tenant via the **BSS** menu.
-- **Goal:** *"As the operator, I want to issue a voucher for a customer, so that they can self-onboard."*
-- **Surface:** Responsive web. **Preconditions:** signed in as owner-tier.
+- **Preconditions:** TC-01 done, or operator opens the console URL directly in a fresh browser.
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/bss](https://console.hw91.omantel.biz/bss) | Open the **BSS** landing from the sidebar | KPI dashboard + a section grid including **Vouchers** | ⛔ | — |
-| 2 | [/bss/vouchers](https://console.hw91.omantel.biz/bss/vouchers) | Tap **Issue** | An Issue modal with **code**, **credit (OMR)**, **description**, **max redemptions**, **recipient email** fields | ⛔ | — |
-| 3 | Issue modal | Fill the fields, submit | The new voucher appears in the voucher table with a **Status** pill — and is emailed to the recipient | ⛔ | — |
+| 1 | [console.hw91.omantel.biz](https://console.hw91.omantel.biz) | Open the URL | Page loads over **publicly-trusted TLS** (no browser warning) and shows **"Sign in"** with *"Enter your email to receive a 6-digit PIN."* | ☐ | — |
+| 2 | Sign in | Type the operator email, tap **Send code** | Advances to the PIN entry screen, email shown | ☐ | — |
+| 3 | PIN entry | Type / paste the 6-digit PIN from the email | Auto-submits on the 6th digit → lands on **/dashboard**, authenticated | ☐ | — |
+| 4 | /dashboard | Refresh the browser (F5) | Still signed in — no re-PIN within session TTL (D14) | ☐ | — |
 
-- **Journey verdict:** ⛔ **BLOCKED** — console down.
+- **UI source:** `LoginPage.tsx:101` ("Sign in" + subtitle), `VerifyPinPage.tsx` (6-digit auto-submit).
+- **Journey verdict:** ☐
 
-### TC-09 — Operator browses the catalog *(web · operator · Phase 1 / D27)*
-
-- **Persona:** Operator looking for an app to install.
-- **Goal:** *"As the operator, I want to browse the catalog, so that I can find an app to add to my Sovereign."*
-- **Surface:** Responsive web. **Preconditions:** signed in.
+### TC-03 — First-touch sanity *(web · operator · D21/D22/D23/D24)*
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/catalog/grafana](https://console.hw91.omantel.biz/catalog/grafana) | Open a Blueprint class page (e.g. Grafana) | The Blueprint header + supported-topology list + an instance table; a **+ New instance** affordance for multi-instance Blueprints | ⛔ | — |
+| 1 | /dashboard | Look at the URL bar after login | You are on **/dashboard** — NOT `/wizard` (D23) | ☐ | — |
+| 2 | Sidebar | Scan the sidebar entries | NO mothership-only views: no fleet dashboard, no "+ New deployment" (D24) | ☐ | — |
+| 3 | [/users](https://console.hw91.omantel.biz/users) | Open **User Access** | The operator who just PIN-logged-in is listed with **tier=owner** and their email — list NOT empty (D21) | ☐ | — |
+| 4 | [/settings](https://console.hw91.omantel.biz/settings) | Open **Settings** | Real values for Region, Capacity, Control-plane size, Created, Deployment ID, Pool subdomain — no `—` placeholders, no "API PENDING" (D22) | ☐ | — |
 
-- **Journey verdict:** ⛔ **BLOCKED** — console down.
-
-### TC-10 — Operator installs an app *(web · operator · Phase 1 / D19)*
-
-- **Persona:** Operator adding a new application instance.
-- **Goal:** *"As the operator, I want to install an app and pick its topology, so that it's placed across my regions."*
-- **Surface:** Responsive web. **Preconditions:** signed in.
-
-| # | Screen you're on | What you do | What you must see | Result | Evidence |
-|---|---|---|---|---|---|
-| 1 | [/install/grafana](https://console.hw91.omantel.biz/install/grafana) | Open the install form for the Blueprint | An auto-generated config form (from the Blueprint's schema) + a **Topology** selector | ⛔ | — |
-| 2 | /install/grafana | Try to pick a topology the Blueprint doesn't support | The unsupported option is **disabled/blocked inline** with a helper note; the form won't submit it | ⛔ | — |
-| 3 | /install/grafana | Fill the form, pick a supported topology, submit | A status modal shows the install progressing; on done, **Open Apps** lands back on **/apps** with the new instance present | ⛔ | — |
-
-- **Journey verdict:** ⛔ **BLOCKED** — console down.
-
-### TC-11 — Operator sees an app's health and both regions *(web · operator · Pillar 3 / D31 visibility)*
-
-- **Persona:** Operator confirming an installed app is healthy and genuinely 2-region.
-- **Goal:** *"As the operator, I want to see an app's status and its placement across both regions, so that I trust my BCP is real."*
-- **Surface:** Responsive web. **Preconditions:** signed in; at least one app installed (TC-10).
-
-| # | Screen you're on | What you do | What you must see | Result | Evidence |
-|---|---|---|---|---|---|
-| 1 | [/apps](https://console.hw91.omantel.biz/apps) | Tap an app card | **/app/`<name>`** opens on the **Overview** tab with a status badge (e.g. ● Running) — not "deployment id malformed" | ⛔ | — |
-| 2 | [/app/`<name>`](https://console.hw91.omantel.biz/app/grafana) | Open the **Topology** tab | The placement tree shows clusters/nodes under **both** `me-east-215-a` AND `me-east-215-b`; topology reads **active-hot-standby** for HA apps | ⛔ | — |
-| 3 | [/jobs](https://console.hw91.omantel.biz/jobs) | Open the **Jobs** view | Every job is in a terminal state (0 pending, 0 running); per-region prefixes are visible for a multi-region Sovereign | ⛔ | — |
-
-- **Journey verdict:** ⛔ **BLOCKED** — console down.
-
-### TC-12 — Operator launches an app with one tap (silent SSO) *(web · operator · Pillar 1+4 / D4)*
-
-- **Persona:** Operator opening Grafana from the console.
-- **Goal:** *"As the operator, I want to tap Launch and land in Grafana already signed in, so that I don't re-enter a password."*
-- **Surface:** Responsive web. **Preconditions:** signed in; an SSO-enabled app installed.
-
-| # | Screen you're on | What you do | What you must see | Result | Evidence |
-|---|---|---|---|---|---|
-| 1 | [/app/grafana](https://console.hw91.omantel.biz/app/grafana) | On the app detail, find the **Launch** button on an SSO-enabled endpoint | A **Launch →** button (not a bare endpoint URL) | ⛔ | — |
-| 2 | /app/grafana | Tap **Launch →** | A new tab opens the app **already signed in** — no Keycloak login form appears | ⛔ | — |
-
-- **Journey verdict:** ⛔ **BLOCKED** — console down. *(Silent-SSO chain has 5 stacked layers; re-walk verifies all of them at once.)*
-
-### TC-13 — Operator edits an endpoint → governed Git PR *(web · operator · Pillar 1 / #2742)*
-
-- **Persona:** Operator changing an app's published endpoint.
-- **Goal:** *"As the operator, I want an endpoint change to open a reviewed PR, so that infra changes are governed and auto-merge on green."*
-- **Surface:** Responsive web. **Preconditions:** signed in; an app with an Endpoints surface.
-
-| # | Screen you're on | What you do | What you must see | Result | Evidence |
-|---|---|---|---|---|---|
-| 1 | [/apps/`<id>`/endpoints](https://console.hw91.omantel.biz/apps) | Tap **+ New endpoint**, fill the dialog, submit | Banner *"Change submitted as PR `<link>`"* with a clickable PR URL | ⛔ | — |
-| 2 | The linked PR | Open the PR link from the banner | PR is open with the 3 gating checks (`kyverno-admission`, `cert-manager-precheck`, `dns-conflict-precheck`) and auto-merges on green | ⛔ | — |
-
-- **Journey verdict:** ⛔ **BLOCKED** — console down. *(PR-page step is the one allowed off-console hop — it's a link the user clicks from the banner, not a terminal action.)*
+- **UI source:** `UserAccessListPage.tsx` ("User Access"), `SettingsPage.tsx`.
+- **Journey verdict:** ☐
 
 ---
 
-### TC-14 — Customer asks the org-aware AI sandbox a question *(web · customer · Pillar 4, Phase 2b–d)*
+## Part II — Phase 0: operator issues a voucher (Pillar 1)
 
-- **Persona:** SME customer (or operator) using the in-console AI sandbox.
-- **Goal:** *"As a user, I want an AI agent that already knows my Organization, so that I can ask about my apps without pasting any credentials."*
-- **Surface:** Responsive web. **Preconditions:** signed in to the tenant or operator console.
+### TC-04 — Marketplace is live *(web · operator · D27)*
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/sandbox](https://console.hw91.omantel.biz/sandbox) | Look at the agent grid | A grid of agent cards including **qwen-code** (the default, zero cloud-cost leak) and **claude-code** | ⛔ | — |
-| 2 | /sandbox | Tap **qwen-code** to start a session | A session opens at **/sandbox/`<id>`** — the AI assistant is ready, no credential/setup prompt | ⛔ | — |
-| 3 | In the session | Ask in plain language: *"list my organization's applications"* | The agent answers with **your Org's actual apps** (org-aware, via its auto-mounted knowledge) — not a permission error and not "I have no access" | ⛔ | — |
+| 1 | [marketplace.hw91.omantel.biz](https://marketplace.hw91.omantel.biz) | Open the URL | Marketplace landing renders with a **non-empty catalog** — not 404, not a "marketplace disabled" stub (zero-touch default, D27) | ☐ | — |
 
-- **Journey verdict:** ⛔ **BLOCKED** — console down. *(Pillar 4 acceptance is the org-aware answer in step 3 — the user never pastes a credential. The in-browser terminal plumbing is dev-team detail, not a UAT row.)*
+- **Journey verdict:** ☐
 
----
+### TC-05 — Issue a voucher from BSS *(web · operator · D28, Phase 0)*
 
-### TC-15 — Operator achieves true sovereignty (cutover) *(web · operator · Pillar 5, Phase 5)*
-
-- **Persona:** Operator running the post-handover sovereignty cutover.
-- **Goal:** *"As the operator, I want to cut my Sovereign loose from the mothership and see it confirmed independent, so that I'm not tethered upstream."*
-- **Surface:** Responsive web. **Preconditions:** signed in as owner-tier; Sovereign post-handover, still tethered.
+- **Goal:** *"As the operator, I issue a prepaid voucher to a customer in one click — no terminal, no API."*
 
 | # | Screen you're on | What you do | What you must see | Result | Evidence |
 |---|---|---|---|---|---|
-| 1 | [/dashboard](https://console.hw91.omantel.biz/dashboard) | Find the Sovereignty card | A status badge reading **Tethered** + an **Achieve True Sovereignty** button | ⛔ | — |
-| 2 | Sovereignty card | Tap **Achieve True Sovereignty** | An explanation modal warns the cutover is irreversible and runs a 10-minute egress-block self-test; a confirm button | ⛔ | — |
-| 3 | Confirm modal | Confirm | A progress card mounts showing the cutover steps running | ⛔ | — |
-| 4 | Sovereignty progress card | Wait for the egress-block hold to complete | The badge flips to **Sovereign**; the egress-block self-test shows passed | ⛔ | — |
+| 1 | Sidebar | Tap **BSS** | **"BSS — Business Support Systems"** landing: KPI strip + section grid incl. **Vouchers** and **Tenants** | ☐ | — |
+| 2 | [/bss/vouchers](https://console.hw91.omantel.biz/bss/vouchers) | Tap **+ Issue voucher** | Modal **"Issue voucher"** with fields: **Code** (e.g. `LAUNCH2026`), **Credit (OMR)**, **Description (optional)**, **Max redemptions (optional)**, **Recipient email (optional)** | ☐ | — |
+| 3 | Issue voucher modal | Fill Code + Credit + the test recipient email, tap **Issue voucher** | Button shows "Issuing…", modal closes, new row appears in the voucher table with status **Active** | ☐ | — |
+| 4 | Recipient inbox | Open the voucher email | Email arrived via the **Sovereign's own SMTP**; link is exactly `https://marketplace.hw91.omantel.biz/redeem/?code=<CODE>` (slash before `?` mandatory) | ☐ | — |
 
-- **Journey verdict:** ⛔ **BLOCKED** — console down. *(No cutover claim without the egress-block proof — the badge flip in step 4 is the acceptance signal.)*
-
----
-
-## Roll-up
-
-| TC | Surface | Persona | Pillar | Journey | Steps | Walked | ✅ | ❌ | ⛔ | Verdict |
-|---|---|---|---|---|---|---|---|---|---|---|
-| TC-01 | web | customer | 1 | Redeem a voucher | 2 | 0 | 0 | 0 | 2 | ⛔ |
-| TC-02 | web | customer | 1 | Pick plan, apps, domain | 3 | 0 | 0 | 0 | 3 | ⛔ |
-| TC-03 | web | customer | 2 | Multi-region BCP at signup | 3 | 0 | 0 | 0 | 3 | ⛔ |
-| TC-04 | web | customer | 1 | Review + checkout | 4 | 0 | 0 | 0 | 4 | ⛔ |
-| TC-05 | web | customer | 1 | Org is online | 2 | 0 | 0 | 0 | 2 | ⛔ |
-| TC-06 | web | operator | — | PIN sign-in | 2 | 0 | 0 | 0 | 2 | ⛔ |
-| TC-07 | web | operator | — | Dashboard + settings real | 2 | 0 | 0 | 0 | 2 | ⛔ |
-| TC-08 | web | operator | 1 | Issue voucher (BSS) | 3 | 0 | 0 | 0 | 3 | ⛔ |
-| TC-09 | web | operator | 1 | Browse catalog | 1 | 0 | 0 | 0 | 1 | ⛔ |
-| TC-10 | web | operator | 1 | Install an app | 3 | 0 | 0 | 0 | 3 | ⛔ |
-| TC-11 | web | operator | 3 | App health + both regions | 3 | 0 | 0 | 0 | 3 | ⛔ |
-| TC-12 | web | operator | 1+4 | Launch app (silent SSO) | 2 | 0 | 0 | 0 | 2 | ⛔ |
-| TC-13 | web | operator | 1 | Endpoint → Git-IaC PR | 2 | 0 | 0 | 0 | 2 | ⛔ |
-| TC-14 | web | customer | 4 | Sandbox org-aware AI | 3 | 0 | 0 | 0 | 3 | ⛔ |
-| TC-15 | web | operator | 5 | Sovereignty cutover | 4 | 0 | 0 | 0 | 4 | ⛔ |
-| | | | | **Total** | **39** | **0** | **0** | **0** | **39** | |
-
-**Overall verdict:** ⛔ **BLOCKED** — zero journeys walkable yet: no prov has reached `ready`. The fresh-prov bug-chain was cleared at the source, catalog-only (#2982 → #2985 → #2989 → #2999 → #2988/#3006 → #3004 → #3007 → #3008/#2940 — ALL merged; cnpg + crossplane were environmental, no speculative fix shipped). hw88/hw89/hw90 were exposure envs — all failed, all wiped zero-orphan. **hw91 (`hw91.omantel.biz`) is the first prov on the complete chain and is provisioning now.** This is a truthful "could-not-attempt" outcome, **not** a fail of the product UI and **not** a pass. Re-walk the moment hw91 reaches `ready` **hands-off**; every ⛔ above then becomes a real ✅/❌ with a committed screenshot.
+- **UI source:** `BssLandingPage.tsx`, `VouchersPage.tsx:136` (list), `:529-615` (modal fields verbatim).
+- **Journey verdict:** ☐
 
 ---
 
-## Defects found during this walk
+## Part III — Phase 1: customer onboarding (Pillars 1 + 2)
 
-> Only what blocked the user-facing walk. (Code-level fresh-prov bugs are tracked separately, not as UAT rows.)
+### TC-06 — Redeem the voucher *(web · customer · Phase 1a)*
 
-| Defect | Step | What the user saw | Severity | Ticket |
+- **Persona:** P5 SME customer (Ahmed) on his phone, opening the email.
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | [marketplace…/redeem/?code=`<CODE>`](https://marketplace.hw91.omantel.biz/redeem) | Open the redeem link from the email | **"Voucher valid"** card with the **OMR credit** amount + the code | ☐ | — |
+| 2 | Redeem page (negative path) | Edit the URL to a garbage code and reload | **"Voucher not valid"** state — clear message, no crash, no credit shown (#2941 hardening) | ☐ | — |
+| 3 | Back on the valid voucher card | Tap **Sign up to redeem** | Advances to **Pick a plan** (/plans); code carried to checkout | ☐ | — |
+
+- **UI source:** `redeem.astro` (states: "No voucher code" / "Voucher not valid" / "Campaign ended" / "Voucher valid").
+- **Journey verdict:** ☐
+
+### TC-07 — Pick plan and apps *(web · customer · Pillar 1)*
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | [/plans](https://marketplace.hw91.omantel.biz/plans) | On **"Pick a plan"**, tap a plan card, tap Continue | Advances to **"Build your stack"** (/apps) | ☐ | — |
+| 2 | [/apps](https://marketplace.hw91.omantel.biz/apps) | Select at least one **Postgres-backed** app (the canonical bundle), tap Continue | Advances to **"Setup & extras"** (/addons) | ☐ | — |
+
+- **UI source:** `PlanStep.svelte` ("Pick a plan"), `AppsStep.svelte` ("Build your stack").
+- **Journey verdict:** ☐
+
+### TC-08 — Choose the free subdomain *(web · customer · D30)*
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | [/addons](https://marketplace.hw91.omantel.biz/addons) | On **"Setup & extras"**, find **Your domain** | Subdomain field + a **pool picker** offering the operator-curated TLDs (`omani.homes` / `omani.rest` / `omani.trade`) — pool from config, not hardcoded (D30) | ☐ | — |
+| 2 | Your domain | Type a 2-character subdomain | Inline rejection ("at least 3 characters") — Continue stays blocked | ☐ | — |
+| 3 | Your domain | Type a valid subdomain (e.g. `muscatpharmacy`), pick any **Optional extras**, Continue | Subdomain accepted; advances to **Business continuity** (/bcp) | ☐ | — |
+
+- **UI source:** `AddonsStep.svelte` ("Setup & extras", "Optional extras").
+- **Journey verdict:** ☐
+
+### TC-09 — Choose BCP topology at signup *(web · customer · **Pillar 2 acceptance**)*
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | [/bcp](https://marketplace.hw91.omantel.biz/bcp) | Read the step | Heading **"Business continuity"** + *"Pick how your database should survive a regional outage"*; two topology cards: **Single-region** and **Active-hot-standby** | ☐ | — |
+| 2 | Topology cards | Tap **Active-hot-standby** | **Primary region** and **Replica region** pickers appear, each with real region names | ☐ | — |
+| 3 | Region pickers (negative path) | Pick the SAME region for both | Inline error **"Primary and replica must differ"** — Continue blocked | ☐ | — |
+| 4 | Region pickers | Pick two different regions, Continue | Advances to **"Review & launch"** (/review) | ☐ | — |
+
+- **UI source:** `BCPStep.svelte` (all quoted strings verbatim).
+- **Journey verdict:** ☐ *(This is the Pillar-2 acceptance surface — BCP chosen at signup, never a Day-2 upgrade.)*
+
+### TC-10 — Review, checkout, create the Organization *(web · customer · D29)*
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | [/review](https://marketplace.hw91.omantel.biz/review) | On **"Review & launch"**, check **Your stack**, **Plan**, **Expected usage**, **Tenant** | All reflect the choices made in TC-07/08/09, incl. the two regions and the voucher credit | ☐ | — |
+| 2 | /review | Tap Checkout | Advances to **"Checkout"** | ☐ | — |
+| 3 | [/checkout](https://marketplace.hw91.omantel.biz/checkout) | Sign in: type the customer email, request the code, enter the 6-digit PIN | PIN accepted; the voucher **credit is applied** to the total | ☐ | — |
+| 4 | Checkout | Confirm | **"Setting up your tenant"** progress, then **"Your tenant is ready!"** — never "Provisioning failed" (D29: zero operator touch) | ☐ | — |
+
+- **UI source:** `ReviewStep.svelte` ("Review & launch", "Your stack", "Plan", "Expected usage", "Tenant"), `CheckoutStep.svelte` ("Checkout", "Setting up your tenant", "Your tenant is ready!").
+- **Journey verdict:** ☐
+
+### TC-11 — The Organization is online *(web · customer · Phase 1c + 2a)*
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | "Your tenant is ready!" | Follow the tenant link (or auto-redirect) | Lands on `https://console.<orgslug>.<pool-tld>` with **publicly-trusted TLS** on the chosen subdomain (D30 closure) | ☐ | — |
+| 2 | Tenant console | PIN-login as the customer | **Dashboard renders** (Phase 2a) — not an empty/error page | ☐ | — |
+| 3 | Tenant apps view | Look at the app cards | The apps chosen in TC-07 appear as cards with status badges that go green (~minutes) | ☐ | — |
+| 4 | A green app card | Tap **Open** | The app itself opens, **already signed in** via the Org's realm — no separate login form (§5.5 step 7) | ☐ | — |
+
+- **Journey verdict:** ☐
+
+### TC-12 — Operator sees the new tenant *(web · operator · O3)*
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | [/bss/tenants](https://console.hw91.omantel.biz/bss/tenants) | Open **BSS → Tenants** | The new Organization appears with its chosen pool subdomain | ☐ | — |
+| 2 | [/bss/vouchers](https://console.hw91.omantel.biz/bss/vouchers) | Find the issued voucher row, expand it | Drawer shows **Redemptions** incremented exactly once (#2000: decrement only on checkout success) | ☐ | — |
+
+- **Journey verdict:** ☐
+
+---
+
+## Part IV — Operator day-2 console (G117 + D-gates)
+
+### TC-13 — Multi-region dashboard & cloud views *(web · operator · D5/D15/D16)*
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | [/dashboard](https://console.hw91.omantel.biz/dashboard) | Set Layer-1 = Cluster | **One bubble per region** (2 on hw91) — not a single merged Sovereign bubble (D16) | ☐ | — |
+| 2 | /dashboard | Set Layer-2 = Namespace | Namespace bubbles render **within** each cluster bubble | ☐ | — |
+| 3 | [/cloud?view=graph](https://console.hw91.omantel.biz/cloud?view=graph) | Read the kind chips | **All regions** present, no stuck spinners (D5); no kind chip shows `0/0` for resources that exist (D15) | ☐ | — |
+| 4 | /cloud, any resource cell | Click a leaf cell | Drill-down opens the resource detail — clicks work on leaves (PR #1085 anti-pattern guard) | ☐ | — |
+
+- **Journey verdict:** ☐
+
+### TC-14 — Jobs are terminal and region-filterable *(web · operator · D6/D20)*
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | [/jobs](https://console.hw91.omantel.biz/jobs) | Open **Jobs** | **0 pending, 0 running** — every job in a terminal state (D6, post-convergence) | ☐ | — |
+| 2 | /jobs | Read job rows | Per-region prefixes visible on a multi-region Sovereign; the filter narrows to one region (D20) | ☐ | — |
+
+- **Journey verdict:** ☐
+
+### TC-15 — Catalog: class page and instance table *(web · operator · #2741)*
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | [/apps](https://console.hw91.omantel.biz/apps) | Open **Applications**, switch to the **Catalog** tab | Blueprint **class** cards (one per Blueprint, NOT one per instance) | ☐ | — |
+| 2 | A class card (e.g. Grafana) | Click it | **Catalog detail**: Blueprint header + **supported-topology list** + an **instance table** + a **"+ New instance"** affordance | ☐ | — |
+
+- **UI source:** `AppsPage.tsx:6` (tabs "Deployments"/"Catalog"), `CatalogDetail.tsx` ("+ New instance").
+- **Journey verdict:** ☐
+
+### TC-16 — Three coexisting instances of one Blueprint *(web · operator · #2737 DoD #5)*
+
+- **Goal:** *"As the operator, I can run three Grafanas side-by-side, each with its own URL and storage."*
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | Catalog detail (Grafana) | Tap **+ New instance**, complete the install form, repeat **twice more** (3 total) | Each install accepted — no name-collision crash; 409 with a clear message only on a genuinely duplicate name | ☐ | — |
+| 2 | Catalog detail (Grafana) | Read the instance table | **3 rows**, each with its own name + status | ☐ | — |
+| 3 | Each instance row | Open each instance's detail → its endpoint | **3 distinct URLs**, each serving its own Grafana (change a dashboard in one — the others unchanged) | ☐ | — |
+
+- **Journey verdict:** ☐
+
+### TC-17 — Launch silent-SSO: Tier-1 sweep *(web · operator · #2743/#2744)*
+
+- **Goal:** *"Every Launch click opens the app already signed-in — no Keycloak form, ever."*
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | App detail — **Grafana** | Tap **Launch →** | New tab opens **already signed in** (silent SSO `prompt=none&kc_idp_hint=catalyst-pin`) — no login form, < ~1 s | ☐ | — |
+| 2 | App detail — **Gitea** | Tap **Launch →** | Same: signed-in Gitea, no form | ☐ | — |
+| 3 | App detail — **Harbor** | Tap **Launch →** | Same: signed-in Harbor, no form | ☐ | — |
+| 4 | App detail — **OpenBao** | Tap **Launch →** | OpenBao opens authenticated via OIDC (architectural note: no kc_idp_hint pin — one redirect hop allowed, but **no credential prompt**) | ☐ | — |
+
+- **UI source:** `AppDetail.tsx` LaunchButton ("Launch →", aria "Launch app via silent SSO").
+- **Coverage note:** Tier-2/Tier-3 apps (13 more, #2744) follow the same contract; walk any 2 as a sample and record which.
+- **Journey verdict:** ☐
+
+### TC-18 — Endpoint edit → governed PR → full propagation *(web · operator · #2742, #2737 DoD #4)*
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | App detail → Connection | Rename an endpoint (e.g. `grafana` → `metrics`), save | UI confirms the change was submitted **as a Git PR** — not applied silently | ☐ | — |
+| 2 | Gitea (via TC-17 step 2 session) | Open the Org's `iac` repo → Pull requests | The PR exists with **3 named checks**: `kyverno-admission`, `cert-manager-precheck`, `dns-conflict-precheck` | ☐ | — |
+| 3 | The PR | Watch checks complete | All 3 green → PR **auto-merges** | ☐ | — |
+| 4 | Browser, ≤ 2 min after merge | Open `https://metrics.<…>` (the NEW name) | New FQDN serves with **valid TLS** and **silent SSO still works** (redirect_uri followed the rename) — full propagation, not just PR-open | ☐ | — |
+
+- **Journey verdict:** ☐
+
+### TC-19 — RBAC surfaces *(web · operator · EPIC-3)*
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | [/rbac/roles](https://console.hw91.omantel.biz/rbac/roles) | Open **Keycloak Roles** | Real role catalog renders (not empty/error) | ☐ | — |
+| 2 | [/rbac/matrix](https://console.hw91.omantel.biz/rbac/matrix) | Open **Access matrix** | Subjects × roles grid with the owner-tier operator visible | ☐ | — |
+| 3 | [/users/new](https://console.hw91.omantel.biz/users/new) | Create a second operator user (Name, Email, Roles), save | Success toast → user appears in **User Access** list | ☐ | — |
+
+- **Journey verdict:** ☐
+
+### TC-20 — Operator-facing hostname sweep *(web · operator · D25)*
+
+Visit each URL in a tab; each must render **its app page** — not 404, not a blank stub, not a dev hostname:
+
+| # | URL | Must see | Result | Evidence |
 |---|---|---|---|---|
-| Console/marketplace never reachable — Sovereign never finished provisioning | All TCs | `console.<sovereign-fqdn>` does not load (HTTP 000) | P0 | [#2989](https://github.com/openova-io/openova/issues/2989) |
+| 1 | `https://keycloak.hw91.omantel.biz` | Keycloak page | ☐ | — |
+| 2 | `https://openbao.hw91.omantel.biz` | OpenBao UI | ☐ | — |
+| 3 | `https://grafana.hw91.omantel.biz` | Grafana (login or SSO) | ☐ | — |
+| 4 | `https://gitea.hw91.omantel.biz` | Gitea | ☐ | — |
+| 5 | `https://harbor.hw91.omantel.biz` / `registry.…` | Harbor | ☐ | — |
+| 6 | `https://guacamole.hw91.omantel.biz` | Guacamole | ☐ | — |
+| 7 | `https://marketplace.hw91.omantel.biz` | Marketplace | ☐ | — |
+
+- **Journey verdict:** ☐
+
+### TC-21 — Cross-Org realm isolation *(web · two customers · #2744, #2737 DoD #6)*
+
+- **Preconditions:** A second voucher (repeat TC-05) redeemed into a **second Organization** (repeat TC-06…TC-11 minimally).
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | Browser profile A | Sign in to Org-A's console | Org-A dashboard | ☐ | — |
+| 2 | Same profile A | Open Org-B's console URL | **A fresh sign-in is demanded** — Org-A's session does NOT open Org-B (separate realms) | ☐ | — |
+| 3 | Profile A, Org-A's Grafana vs Org-B's Grafana | Open both app URLs | Org-A's opens signed-in; Org-B's demands sign-in — per-Org SSO isolation holds | ☐ | — |
+
+- **Journey verdict:** ☐
 
 ---
 
-## Out of scope (handled by the dev team, NOT walked here)
+## Part V — Pillar 3: region-kill failover (D31)
 
-- Unit / integration / contract tests, CI pipelines.
-- `kubectl` / API / SQL / log-grep / HelmRelease-status verification with no on-screen surface — including the CNPG region-kill **counter-test** (D31), the cutover **egress-block Hubble/NetworkPolicy capture** (Pillar 5), and the sandbox **MCP-tool / pty-server attach** internals. The user-facing *outcomes* of those (app stays reachable after failover; badge flips to **Sovereign**; the agent answers org-aware) ARE walked above; the wire-level proofs are the dev team's separate evidence.
-- Source-code reading, file:line citations, the fresh-prov ordering fixes (#2982 / #2985 / #2989) — those are dev-team bugs, verified by re-running the walk above once the console is up, not by inspecting code here.
+### TC-22 — Install a CNPG-backed app in active-hot-standby *(web · customer · D31 setup)*
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | Tenant marketplace/catalog | Pick a CNPG-backed app (e.g. WordPress/Ghost), choose **active hot-standby**, install | Install starts; app card progresses to green | ☐ | — |
+| 2 | App detail → Topology | Read the placement | The app shows under **both regions** — primary + replica, topology reads **active-hot-standby** | ☐ | — |
+| 3 | The app's FQDN | Open it | App serves with trusted TLS | ☐ | — |
+
+- **Journey verdict:** ☐
+
+### TC-23 — Region-kill: the app survives *(web · customer+operator · D31)*
+
+- **Preconditions:** TC-22 green. The **kill itself** is a dev-team action via the cloud-provider API (a REAL region kill — Appendix A.1); the walker observes only URLs.
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | The app's FQDN | Confirm it serves, note the time | HTTP 200, content loads | ☐ | — |
+| 2 | (Dev team kills the primary region) | Keep refreshing the app URL | Service resumes within **≤ 30 s** — same FQDN, no manual DNS change | ☐ | — |
+| 3 | Operator /dashboard | Read the region bubbles | Failed region shows unhealthy; surviving region carries the app | ☐ | — |
+| 4 | The app | Log in / use it | Data written before the kill is **all present** (zero loss — wire proof in Appendix A.1) | ☐ | — |
+
+- **Journey verdict:** ☐
 
 ---
 
-_A copy of [`UAT-TEMPLATE.md`](UAT-TEMPLATE.md). Every row is one thumb/mouse action a real user could repeat, ordered to mirror [`../DOD.md`](../DOD.md) Phase 0 → 1 → 2 across the 5 pillars. Re-walk on the next `ready` Sovereign; the executor records the verdict on the issue and never closes it._
+## Part VI — Pillar 5: sovereignty cutover (§7)
+
+> **Known coverage finding (filed during doc authoring):** the production console does **not yet mount** the Sovereignty card — the "Achieve True Sovereignty" CTA exists only at the layout-free harness route `/sovereignty/preview` (#793; `router.tsx:1140-1142`, widget `SovereigntyCard.tsx`). Until the card is mounted on a production page (Dashboard or Settings), TC-24 step 1 walks the harness route and the missing mount is an ❌ against the committed §7 step-2 surface.
+
+### TC-24 — Trigger the cutover *(web · operator · §7 step 2)*
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | The Sovereignty surface (production mount; fallback `/sovereignty/preview`) | Read the card | **"Sovereignty status"** with badge **"Soft-tethered to mothership"** + primary CTA **"Achieve True Sovereignty"** | ☐ | — |
+| 2 | The card | Tap **Achieve True Sovereignty** | An explanation modal opens first — the cutover is **irreversible**; nothing starts without confirmation | ☐ | — |
+| 3 | The modal | Confirm | Progress card appears; steps advance (e.g. **Mirrored commit**, **Harbor projects**, …, **Egress test**) — 8 sequential steps, no manual touch | ☐ | — |
+
+- **UI source:** `SovereigntyCard.tsx` (badge texts, CTA, `data-testid="cutover-start-button"`, step labels).
+- **Journey verdict:** ☐
+
+### TC-25 — Cutover completes *(web · operator · §7 steps 4–5)*
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | Progress card | Wait through the final step | **"Egress test"** runs the 10-minute deny-egress hold and passes | ☐ | — |
+| 2 | Sovereignty card | Read the badge | Flips to **"Independent"** — `cutoverComplete=true` with the hold timestamp | ☐ | — |
+
+- **Journey verdict:** ☐ *(Wire-level egress + HR-green proofs: Appendix A.2 — companions, not substitutes.)*
+
+### TC-26 — Post-cutover regression: nothing broke *(web · operator+customer · #2940)*
+
+- **Goal:** *"Independence must not cost a single working flow"* — the #2940 attack is a cutover that 'succeeds' while tokens still carry a mothership issuer, silently breaking SSO.
+
+| # | Screen you're on | What you do | What you must see | Result | Evidence |
+|---|---|---|---|---|---|
+| 1 | Fresh browser | PIN-login at console.hw91.omantel.biz | Works exactly as in TC-02 — the PIN/JWT issuer is now the Sovereign's own | ☐ | — |
+| 2 | App detail — Grafana | Tap **Launch →** | Silent SSO still works — no login form, no redirect loop | ☐ | — |
+| 3 | Tenant console | Customer PIN-login + open an app | Tenant flows unaffected | ☐ | — |
+| 4 | Marketplace | Open /redeem with a fresh voucher | Voucher flow still works end-to-end post-cutover | ☐ | — |
+
+- **Journey verdict:** ☐
+
+---
+
+## Summary
+
+| Part | TCs | Verdict |
+|---|---|---|
+| I — Handover & first-touch | TC-01…03 | ☐ |
+| II — Phase 0 voucher | TC-04…05 | ☐ |
+| III — Phase 1 customer | TC-06…12 | ☐ |
+| IV — Operator day-2 | TC-13…21 | ☐ |
+| V — Pillar 3 failover | TC-22…23 | ☐ |
+| VI — Pillar 5 cutover | TC-24…26 | ☐ |
+
+**Overall verdict:** ☐ **NOT WALKED** — begins when `hw91.omantel.biz` reconciles `ready` with zero manual intervention. Failed environments (hw88/89/90 class) may be used read-only to expose issues, never as acceptance.
+
+---
+
+## Appendix A — wire-level companions (automated, **NOT acceptance**)
+
+These are dev-team evidence procedures that accompany specific TCs. They never replace a UI row.
+
+- **A.1 — D31 counter-test** (companion to TC-23): monotonic `INSERT … RETURNING id` writer @100 ms through the kill; pass = no gap/replay, RTO ≤ 30 s; failover by `failover-controller` from the Continuum CR, never manual DNS. Kill modes: cloud-API instance destroy or NetworkPolicy region isolation. (DoD §6.)
+- **A.2 — Egress-block proof** (companion to TC-25): Hubble/NetworkPolicy capture showing zero allowed flows to `github.com` / `ghcr.io` / `harbor.openova.io` for the full 10-minute hold + HelmReleases all Ready at minute 0 and minute 10. (DoD §7.)
+- **A.3 — Convergence gates D8–D12** (precondition to the whole walk): all HRs Ready, ClusterMesh OK, inter-region pod-to-pod, LB-only services.
+- **A.4 — D34 newapi**: org-scoped JWT → `POST /v1/chat/completions` round-trip to the partner-hosted Qwen backend, no cloud-LLM egress.
+- **A.5 — D35 NATS**: voucher→redeem publish/consume round-trip ≤ 2 s.
+
+## Appendix B — committed but deliberately not walked here
+
+| Item | Why excluded | Tracking |
+|---|---|---|
+| Pillar 4 — Sandbox + `openova-sandbox-mcp` (Phase 2b–2e, D32/D33) | **Founder ruling 2026-06-03**: out of this UAT's scope | DoD §1 Pillar 4; regression contract: `tests/e2e/sandbox-mcp-contract.sh` (#2930) |
+| Corporate Git journeys (J7–J9: Blueprint authoring, promotion approvals — Layla §5.7) | Git surface is design-stage per STATUS.md §5 — not walkable | DoD §5.7 |
+| Compliance scorecard depth (EPIC-1 dashboards beyond render) | Needs policy/Falco data seeded; tertiary operator-debugger surface per CLAUDE.md §pillar-rules | `/sre/compliance`, `/sec/compliance` routes exist |
+| Voucher rate-limit/entropy hardening beyond the bad-code row | Rate-limit behavior not UI-observable deterministically | #2941 |
+| Tier-2/Tier-3 silent-SSO full 17-app sweep | Tier-1 (4 apps) + 2-app sample walked in TC-17; full sweep is a Playwright regression, not a human walk | #2744 |
+
+---
+
+*Authored 2026-06-03 (rev 2). Sources: DoD §§1-7 (gates D0–D35), STATUS.md, ARCHITECTURE.md §10, G117 EPIC #2737 family, TRUST.md ledger; all UI labels verified against `core/marketplace/src/` and `products/catalyst/bootstrap/ui/src/` at main.*


### PR DESCRIPTION
Full rewrite per founder directive (test cases were not comprehensive, did not cover the committed backlog, and wrongly included sandbox).

**What changed:**
- **26 TCs** (was 15) in 6 parts, ordered by the deterministic test (DoD §2) — the only order a fresh prov can actually be walked in (old doc's customer-first order was unwalkable: the voucher doesn't exist before Phase 0).
- **Coverage contract table**: every committed behavior (D-gates, pillars 1/2/3/5, G117 #2737 family) → TC mapping; anything missing is by definition a doc defect.
- **Added coverage** previously absent: D0 handover auto-redirect, first-touch sanity (D21-D24), 3-coexisting-instances, Tier-1 silent-SSO sweep (4 apps), endpoint-rename full propagation (<2 min, not just PR-open), RBAC surfaces, D25 hostname sweep, cross-Org realm isolation (needs 2nd Org), post-cutover regression (the #2940 attack), negative paths.
- **Sandbox removed** (founder scope ruling) — tracked in Appendix B with its regression-contract pointer.
- **Appendix A**: wire-level companions explicitly marked 'automated, NOT acceptance'. **Appendix B**: deliberate exclusions with reasons.
- **Honest finding logged in TC-24**: the 'Achieve True Sovereignty' card has no production mount — only the /sovereignty/preview harness (#793).
- All labels verified against real UI code (`core/marketplace/src/`, `products/catalyst/bootstrap/ui/src/`) with per-TC source references.

Walk begins when hw91.omantel.biz (dep 38ae2b82dc325354, provisioning) reconciles ready hands-off.

Refs #2737 #2744 #2742 #2940

🤖 Generated with [Claude Code](https://claude.com/claude-code)