### PR TITLE
fix(ci): freshness gate wrong GHCR package path + the real 237-commit organization-controller staleness it masked

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -953,7 +953,7 @@ spec:
       # preflight-blueprint-crd-cel.yaml. Flux re-applies crds/ with
       # CreateReplace on reconcile so existing Sovereigns pick it up.
       # Refs #2936.
-      version: 1.4.484
+      version: 1.4.485
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2542,7 +2542,7 @@ name: bp-catalyst-platform
 # CEL rule can never merge again. Bumping the pin so every Sovereign's
 # Flux helm-controller re-applies the corrected CRD (Flux reconciles
 # crds/ with CreateReplace, unlike raw `helm upgrade`). Refs #2936.
-version: 1.4.484
+version: 1.4.485
 appVersion: 1.4.479
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -432,7 +432,7 @@ controllers:
       # 405 to the in-cluster SA). 72e3f08 = qa-loop iter-8 Fix #42
       # (#1252 + Containerfile fix-up #1253), fixed Bug 1 (UserAccess
       # Claim namespace).
-      tag: "32050f0"
+      tag: "029a750"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:

--- a/scripts/check-controller-image-tag-freshness.sh
+++ b/scripts/check-controller-image-tag-freshness.sh
@@ -113,8 +113,19 @@ for key in "${!CTRL_PKG[@]}"; do
   # the #2851 sweep step in catalyst-build.yaml. We filter cosign
   # signature artifacts + the rolling `latest` alias, keep only true
   # 7-hex tags, and take the most-recently-updated one.
-  if ! versions_json=$(gh api "/orgs/${GHCR_ORG}/packages/container/${pkg}/versions" --paginate 2>/dev/null); then
-    echo "::error::GHCR API query failed for ${pkg} — check 'gh' auth has read:packages scope"
+  #
+  # Package PATH fix (caught on PR #3012; gate had been red on every
+  # run incl. main): the images are pushed to
+  # `ghcr.io/openova-io/openova/<pkg>` (this script's own header says
+  # so at line 27), which makes the GHCR package NAME the slash-scoped
+  # `openova/<pkg>` — and the packages API requires the slash
+  # percent-encoded (`openova%2F<pkg>`). The previous bare-`${pkg}`
+  # query 404'd ("Package not found") and the error branch mislabeled
+  # the auth-or-404 failure as staleness ("Checked 0/5; 5 stale").
+  # Both fixed: correct path + honest UNVERIFIABLE wording.
+  pkg_path="openova%2F${pkg}"
+  if ! versions_json=$(gh api "/orgs/${GHCR_ORG}/packages/container/${pkg_path}/versions" --paginate 2>/dev/null); then
+    echo "::error::GHCR API query UNVERIFIABLE for openova/${pkg} (404/auth/network — NOT a staleness verdict). Check the package path + token read:packages access."
     fail=$((fail + 1))
     continue
   fi


### PR DESCRIPTION
Two-in-one, found while unblocking PR #3012:

1. **The gate itself was broken on every run incl. main**: it queried `/packages/container/<pkg>` but images live at the slash-scoped `openova/<pkg>` package (needs `%2F`). 404 → mislabeled 'Checked 0/5; 5 stale' with a wrong auth hint. Fixed path + honest UNVERIFIABLE wording on API failure.
2. **The repaired gate instantly caught real rot**: `controllers.organization.image.tag` 237 commits behind (`32050f0` → `029a750`, verified on-main #2965 — the per-Org IaC pre-check seeding that #2742's walk depends on). Bumped + lockstep 1.4.485.

Local verification: `bash scripts/check-controller-image-tag-freshness.sh` → 5/5 checked, 0 stale, PASS (was 0/5 + false-stale).

Merge order: this first, then #3012 rebases (its 1.4.485 becomes 1.4.486).

Refs #2851 #2742

🤖 Generated with [Claude Code](https://claude.com/claude-code)