### PR TITLE
fix(tests): #2988 follow-up — chart tests advertise the ESO CRD; publishes unblock; hw91 self-heals

### DIFF
--- a/platform/gitea/chart/tests/g117-5-sso-tier1.sh
+++ b/platform/gitea/chart/tests/g117-5-sso-tier1.sh
@@ -24,7 +24,19 @@ trap 'rm -rf "${tmpdir}"' EXIT
 
 "$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
 
-"$helm" template smoke "$chart_dir" --set sso.sovereignFqdn=smoke.omani.works 2>/dev/null > "${tmpdir}/default.yaml"
+# #2988: the sso ExternalSecret is gated on the ESO-CRD Capabilities
+# check (omitted when the CRD is absent so installs cannot fail at
+# manifest-build). Assert BOTH sides of that contract: render WITH the
+# CRD advertised for the positive cases, and a guard render WITHOUT it
+# that must omit the ExternalSecret.
+"$helm" template smoke "$chart_dir" --set sso.sovereignFqdn=smoke.omani.works --api-versions "external-secrets.io/v1beta1" 2>/dev/null > "${tmpdir}/default.yaml"
+"$helm" template smoke "$chart_dir" --set sso.sovereignFqdn=smoke.omani.works 2>/dev/null > "${tmpdir}/no-eso-crd.yaml"
+
+echo "[g117-5-sso-tier1] Case 0 (#2988): ExternalSecret omitted when ESO CRD absent"
+if grep -q "kind: ExternalSecret" "${tmpdir}/no-eso-crd.yaml"; then
+  echo "FAIL: ExternalSecret rendered without external-secrets.io/v1beta1 — #2988 guard regressed" >&2; exit 1
+fi
+echo "  PASS"
 
 # Case 1: ExternalSecret with correct target name
 echo "[g117-5-sso-tier1] Case 1: ExternalSecret 'gitea-oauth-source-credentials' renders"

--- a/platform/grafana/chart/tests/g115-datasources-dashboards.sh
+++ b/platform/grafana/chart/tests/g115-datasources-dashboards.sh
@@ -34,7 +34,16 @@ trap 'rm -rf "${tmpdir}"' EXIT
 "$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
 
 # Render with defaults once + write to disk for repeated reads by python.
-"$helm" template smoke "$chart_dir" 2>/dev/null > "${tmpdir}/default.yaml"
+# #2988: the sso ExternalSecret is Capabilities-gated on the ESO CRD —
+# advertise it so Case 7 can assert the env-override Secret contents,
+# and keep a no-CRD render to assert the omit side of the contract.
+"$helm" template smoke "$chart_dir" --api-versions "external-secrets.io/v1beta1" 2>/dev/null > "${tmpdir}/default.yaml"
+"$helm" template smoke "$chart_dir" 2>/dev/null > "${tmpdir}/no-eso-crd.yaml"
+echo "[g115-datasources-dashboards] Case 0 (#2988): ExternalSecret omitted when ESO CRD absent"
+if grep -q "kind: ExternalSecret" "${tmpdir}/no-eso-crd.yaml"; then
+  echo "FAIL: ExternalSecret rendered without external-secrets.io/v1beta1 — #2988 guard regressed" >&2; exit 1
+fi
+echo "  PASS"
 
 # ── Case 1: Sidecar discovery is enabled in default values ─────────────
 echo "[g115-datasources-dashboards] Case 1: sidecar discovery enabled by default"

--- a/platform/openbao/chart/tests/g117-5-sso-tier1.sh
+++ b/platform/openbao/chart/tests/g117-5-sso-tier1.sh
@@ -27,7 +27,19 @@ trap 'rm -rf "${tmpdir}"' EXIT
 
 "$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
 
-"$helm" template smoke "$chart_dir" --set sso.sovereignFqdn=smoke.omani.works 2>/dev/null > "${tmpdir}/default.yaml"
+# #2988: the sso ExternalSecret is gated on the ESO-CRD Capabilities
+# check (omitted when the CRD is absent so installs cannot fail at
+# manifest-build). Assert BOTH sides of that contract: render WITH the
+# CRD advertised for the positive cases, and a guard render WITHOUT it
+# that must omit the ExternalSecret.
+"$helm" template smoke "$chart_dir" --set sso.sovereignFqdn=smoke.omani.works --api-versions "external-secrets.io/v1beta1" 2>/dev/null > "${tmpdir}/default.yaml"
+"$helm" template smoke "$chart_dir" --set sso.sovereignFqdn=smoke.omani.works 2>/dev/null > "${tmpdir}/no-eso-crd.yaml"
+
+echo "[g117-5-sso-tier1] Case 0 (#2988): ExternalSecret omitted when ESO CRD absent"
+if grep -q "kind: ExternalSecret" "${tmpdir}/no-eso-crd.yaml"; then
+  echo "FAIL: ExternalSecret rendered without external-secrets.io/v1beta1 — #2988 guard regressed" >&2; exit 1
+fi
+echo "  PASS"
 
 echo "[g117-5-sso-tier1] Case 1: ExternalSecret 'openbao-sso-oidc-credentials' renders"
 grep -q 'name: openbao-sso-oidc-credentials' "${tmpdir}/default.yaml" || {

--- a/platform/sandbox/chart/tests/g117-sandbox-render.sh
+++ b/platform/sandbox/chart/tests/g117-sandbox-render.sh
@@ -62,11 +62,15 @@ fi
 echo "  PASS — 0 Kinds rendered (chart respects enabled=false default-off contract)."
 
 echo "[g117-sandbox-render] Case 2: enabled=true render emits the canonical 6 Kinds"
+# #2988: sso ExternalSecret is Capabilities-gated on the ESO CRD —
+# advertise it for the canonical-Kinds assertion; a separate no-CRD
+# render asserts the omit side (install must not fail at manifest-build).
 "$HELM" template smoke-sandbox . \
   --set enabled=true \
   --set env.hostCluster=hz-fsn-rtz-prod \
   --set env.sovereignFQDN=smoke.omani.works \
   --set runtime.newapiURL=https://newapi.smoke.omani.works/v1 \
+  --api-versions "external-secrets.io/v1beta1" \
   > "$TMP/on.yaml" 2> "$TMP/on.err" || {
     echo "FAIL: enabled=true render errored — chart broke under canonical inputs." >&2
     cat "$TMP/on.err" >&2
@@ -117,3 +121,16 @@ fi
 echo "  PASS — Deployment carries all canonical SANDBOX_* env vars."
 
 echo "[g117-sandbox-render] All bp-sandbox chart-render gates green."
+
+echo "[g117-sandbox-render] Case 2b (#2988): ExternalSecret omitted when ESO CRD absent"
+"$HELM" template smoke-sandbox . \
+  --set enabled=true \
+  --set env.hostCluster=hz-fsn-rtz-prod \
+  --set env.sovereignFQDN=smoke.omani.works \
+  --set runtime.newapiURL=https://newapi.smoke.omani.works/v1 \
+  > "$TMP/on-nocrd.yaml" 2>/dev/null || true
+if grep -qE "^kind: ExternalSecret$" "$TMP/on-nocrd.yaml"; then
+  echo "FAIL: ExternalSecret rendered without external-secrets.io/v1beta1 — #2988 guard regressed" >&2
+  exit 1
+fi
+echo "  PASS"


### PR DESCRIPTION
**The missing lockstep piece of PR #3003** — the guard changed render semantics but the four charts' own test suites weren't updated, so `blueprint-release`'s test gate blocked all four chart publishes. hw91 (first-ever zero-touch `ready` prov, 65 min) wedged at `bp-gitea:1.2.16 not found` etc.

- Positive cases now render with `--api-versions "external-secrets.io/v1beta1"`.
- NEW negative cases (openbao/gitea Case 0, grafana Case 0, sandbox Case 2b) assert the omit-without-CRD side — the #2988 guard is itself regression-protected now.
- All four suites verified green locally (the publish gate's exact check).

On merge: blueprint-release publishes 1.2.25/1.2.16/1.0.7/0.3.9 → hw91's Flux pulls them on its next reconcile → the 3 wedged HRs + their dependents self-heal, zero cluster touch.

Refs #2988

🤖 Generated with [Claude Code](https://claude.com/claude-code)