### PR TITLE
fix(powerdns): zone-bootstrap budgets sized for the HCS settle window — unwedges hw91's gateway chain

### DIFF
--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -127,7 +127,7 @@ spec:
       # message read "Helm install failed for release powerdns/powerdns
       # with chart bp-powerdns@1.2.2: failed post-install: 1 error
       # occurred: * job powerdns-zone-bootstrap failed: BackoffLimitExceeded".
-      version: 1.2.7
+      version: 1.2.8
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns
@@ -142,13 +142,19 @@ spec:
   # cleanly; runtime convergence (powerdns pods becoming Ready once
   # CNPG lands) is observed via kubectl, not gated on Helm.
   install:
-    timeout: 15m
+    # 40m (hw91 2026-06-03, bp-powerdns 1.2.8): the zone-bootstrap hook's
+    # activeDeadlineSeconds went 840s -> 2100s to ride out the ~20-min
+    # HCS early-prov settle window; helm waits on hooks within THIS
+    # timeout even with disableWait, so it must exceed the hook deadline
+    # (budgets nest: innerPoll 1800s < jobDeadline 2100s < helm 2400s).
+    timeout: 40m
     disableWait: true
     remediation:
       retries: 5
       remediateLastFailure: true
   upgrade:
-    timeout: 15m
+    # 40m — same nesting rationale as install (hook deadline 2100s).
+    timeout: 40m
     disableWait: true
     remediation:
       retries: 3

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.7
+  version: 1.2.8
   card:
     title: PowerDNS
     summary: |

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -4,7 +4,7 @@ name: bp-powerdns
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.2.7
+version: 1.2.8
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/values.yaml
+++ b/platform/powerdns/chart/values.yaml
@@ -618,7 +618,18 @@ zoneBootstrap:
   # under the HR 15m wrapper cap (a Job that exceeded the HR cap would
   # leave Flux waiting forever; a Job that fits inside the HR cap lets
   # Flux's own remediation cycle reclaim the failure path).
-  activeDeadlineSeconds: 840
+  #
+  # hw91 (2026-06-03, 1.2.8): raised 840s → 2100s (35m, still under the
+  # HR upgrade timeout) together with the inner poll below. On the first
+  # zero-touch HCS prov the powerdns Pods crash-flapped ~9 restarts
+  # (~20 min) while the cluster settled; the hook Job burned its whole
+  # 600s inner budget inside that window → DeadlineExceeded → the HR
+  # upgrade FAILED — and a failed UPGRADE does not self-retry until a
+  # new chart digest arrives (unlike installs post-#2999), so the wedge
+  # held for 75+ min with PowerDNS itself healthy the whole time. The
+  # wider budget rides out the settle window; this bump IS the new
+  # digest that re-runs the hook.
+  activeDeadlineSeconds: 2100
   # apiReadyTimeoutSeconds — inner poll budget the container spends
   # waiting for http://powerdns:8081/api/v1/servers to return HTTP 200
   # before giving up.
@@ -633,8 +644,9 @@ zoneBootstrap:
   #
   # New posture: one container run, one long inner loop. This timeout
   # bounds the inner poll; restartPolicy is `Never` (the container owns
-  # the wait budget). 600s default sits below activeDeadlineSeconds=840s
-  # so the zone-creation phase retains >=240s of headroom AFTER the API
-  # comes Ready. Operators on slower clusters can raise this without
-  # forking the chart per docs/INVIOLABLE-PRINCIPLES.md #4.
-  apiReadyTimeoutSeconds: 600
+  # the wait budget). 1800s (was 600s — see hw91 note above) sits below
+  # activeDeadlineSeconds=2100s so the zone-creation phase retains
+  # >=300s of headroom AFTER the API comes Ready. Operators on slower
+  # clusters can raise this without forking the chart per
+  # docs/INVIOLABLE-PRINCIPLES.md #4.
+  apiReadyTimeoutSeconds: 1800


### PR DESCRIPTION
hw91 live: powerdns pods flapped ~20 min during early-prov settle; the zone-bootstrap hook burned its 600s budget in that window → HR **upgrade** failed → no self-retry without a new digest (the #2999 upgrade-side gap, now observed live: 75 min wedged while PowerDNS was healthy). PowerDNS gates DNS-01 → wildcard cert → gateway envoy bind → **every public hostname**, incl. the console the UAT walk needs.

Nested budgets: inner poll 1800s < job deadline 2100s < helm timeout 40m (helm waits on hooks even with disableWait). Lockstep bp-powerdns 1.2.8 (Chart + blueprint + slot 11). Chart tests green; render shows the new values.

Merge = the new digest that re-runs the hook on hw91 zero-touch.

Refs #2999 #3018

🤖 Generated with [Claude Code](https://claude.com/claude-code)