### PR TITLE
fix(gitea): DB password direct from CNPG's gitea-pg-app — kills the deterministic first-install bake race

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -81,7 +81,7 @@ spec:
       # bp-self-sovereign-cutover Step 1 gitea-mirror Job mounts it. K8s
       # forbids cross-namespace secretKeyRef; reflector is the canonical
       # platform-level mirror. Caught live on otech103 2026-05-04.
-      version: 1.2.16
+      version: 1.2.17
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.16
+  version: 1.2.17
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -60,7 +60,7 @@ name: bp-gitea
 # directly in Gitea as a site admin via OIDC. Local `gitea_admin` user
 # remains the break-glass account for bp-self-sovereign-cutover Step 1.
 # Per SECURITY.md §6.3 (App-level SSO).
-version: 1.2.16
+version: 1.2.17
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/values.yaml
+++ b/platform/gitea/chart/values.yaml
@@ -90,16 +90,33 @@ gitea:
       enabled: false
       serviceMonitor:
         enabled: false
-    # Inject DB password from the reflector-managed gitea-database-secret.
-    # Reflector copies `gitea-pg-app` (CNPG-generated) into
-    # `gitea-database-secret`; the `password` key holds the postgres user
-    # password. GITEA__database__PASSWD overrides the empty value in
-    # gitea.config.database above.
+    # Inject DB password DIRECTLY from CNPG's own `gitea-pg-app` Secret
+    # (basic-auth type, carries the `password` key). CNPG owns BOTH the
+    # database role's password and this Secret, so they can never drift.
+    #
+    # hw91 root-cause (2026-06-03, 1.2.17): the previous indirection —
+    # secretKeyRef on the synced/kept `gitea-database-secret` — lost a
+    # DETERMINISTIC start race on every fresh install attempt: helm
+    # creates the sync Job and the gitea Deployment simultaneously; the
+    # pod's fast init chain (init-directories → init-app-ini) bakes
+    # app.ini from the env snapshot within seconds, while the sync Job
+    # needs an image pull + run to copy CNPG's fresh password into the
+    # kept (stale, `resource-policy: keep`) gitea-database-secret.
+    # Completed init containers never re-run, so the pod stayed poisoned
+    # with the previous attempt's password for its whole lifetime →
+    # configure-gitea `pq: password authentication failed` → install
+    # timeout → uninstall → CNPG regenerates → identical race on the
+    # next attempt. Observed identically on install attempts 4, 5 and 6
+    # on hw91 (the first prov ever to reach this slot's first-install
+    # path). Pointing at the CNPG-owned Secret removes the race class
+    # entirely; gitea-database-secret + its sync Job remain for the
+    # OTHER consumers documented in database-secret-sync-job.yaml
+    # (harbor's env binding shape).
     additionalConfigFromEnvs:
       - name: GITEA__database__PASSWD
         valueFrom:
           secretKeyRef:
-            name: gitea-database-secret
+            name: gitea-pg-app
             key: password
     # G91.gitea (#2653) — upstream chart's per-provider OAuth list.
     # Empty default; bp-gitea ships a Helm post-install hook Job


### PR DESCRIPTION
hw91 (first prov ever to reach bp-gitea's first-install path) failed install attempts 4/5/6 **identically**: the pod's init chain bakes `app.ini` from the env snapshot seconds after creation, while the `database-secret-sync` Job (created simultaneously) still needs an image pull to freshen the kept `gitea-database-secret` with CNPG's newly-generated password — completed init containers never re-run, so every fresh-install pod is born poisoned: `pq: password authentication failed` → timeout → uninstall → regenerate → same race. Evidence chain on the live monitors (attempts 4–6, secrets-vs-DB alignment checks).

Fix: point `GITEA__database__PASSWD` at **`gitea-pg-app`** — CNPG owns both the role password and that Secret; drift/races structurally impossible. The synced secret + Job remain for their other consumers (harbor env shape).

Lockstep bp-gitea 1.2.17. All 4 chart suites green. On merge: publish → hw91's next install attempt picks 1.2.17 → gitea converges → catalyst-platform → console → the UAT walk.

Refs #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)