### PR TITLE
fix(sso-bridge): #2989 residual — FQDN fallback unblocks Tier-1 SSO writes before catalyst-platform

### DIFF
--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -116,11 +116,20 @@ spec:
       # 0.1.1 (G91-fu, Refs #2659, edc55c08 PR #2676): adds realm-role
       # grant + skipClientUpsert opt-out for charts whose Keycloak Client
       # is realm-imported at bp-keycloak install time (catalyst-ui etc.).
-      version: 0.2.8
+      version: 0.2.9
       sourceRef:
         kind: HelmRepository
         name: bp-sso-bridge
         namespace: flux-system
+  # #2989 residual (0.2.9): the reconciler needs the Sovereign FQDN
+  # BEFORE bp-catalyst-platform ships the sovereign-fqdn ConfigMap —
+  # gitea's post-install SSO hook starves on the sso/gitea key the
+  # reconciler writes, and catalyst-platform dependsOn gitea. The
+  # chart-value fallback breaks that residual cycle; the CM (with
+  # orgEmail) still wins once it exists.
+  values:
+    sovereign:
+      fqdn: ${SOVEREIGN_FQDN}
   install:
     timeout: 5m
     disableWait: true

--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.8
+  version: 0.2.9
   card:
     title: sso-bridge
     summary: |

--- a/platform/sso-bridge/chart/Chart.yaml
+++ b/platform/sso-bridge/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-sso-bridge
-version: 0.2.8
+version: 0.2.9
 # 0.2.8 (G117.5-followup #2914, 2026-06-03): dual-token KC mint —
 # sovereign-realm SA token for in-realm operations + new master-realm
 # admin token for POST /admin/realms (per-Org realm provisioning).

--- a/platform/sso-bridge/chart/templates/configmap-reconciler.yaml
+++ b/platform/sso-bridge/chart/templates/configmap-reconciler.yaml
@@ -196,8 +196,18 @@ data:
     }
 
     sovereign_fqdn() {
-      kubectl get cm "${SOVEREIGN_FQDN_CM_NAME}" -n "${SOVEREIGN_FQDN_CM_NS}" \
-        -o jsonpath="{.data.${SOVEREIGN_FQDN_SOVEREIGN_FQDN_KEY}}" 2>/dev/null || true
+      # #2989 residual (hw91 2026-06-04, 0.2.9): the CM ships with
+      # bp-catalyst-platform, but gitea's post-install SSO hook needs the
+      # sso/gitea OpenBao key THIS tick writes — and catalyst-platform
+      # dependsOn gitea. Reading ONLY the CM re-created the #2989
+      # deadlock one layer down (reconciler skipped every tick for 3h20m
+      # on hw91 while gitea's hook starved). Fall back to the chart-value
+      # FQDN (slot 13b envsubsts ${SOVEREIGN_FQDN}) so Tier-1 writes run
+      # pre-catalyst-platform; only the orgEmail grant stays deferred.
+      local v
+      v="$(kubectl get cm "${SOVEREIGN_FQDN_CM_NAME}" -n "${SOVEREIGN_FQDN_CM_NS}" \
+        -o jsonpath="{.data.${SOVEREIGN_FQDN_SOVEREIGN_FQDN_KEY}}" 2>/dev/null || true)"
+      if [ -n "${v}" ]; then printf '%s' "${v}"; else printf '%s' "${SOVEREIGN_FQDN_FALLBACK:-}"; fi
     }
 
     upsert_client() {

--- a/platform/sso-bridge/chart/templates/deployment.yaml
+++ b/platform/sso-bridge/chart/templates/deployment.yaml
@@ -124,6 +124,10 @@ spec:
               value: {{ .Values.operator.sovereignFqdnConfigMap.sovereignFqdnKey | quote }}
             - name: OPERATOR_EMAIL_OVERRIDE
               value: {{ .Values.operator.emailOverride | quote }}
+            # #2989 residual (0.2.9): chart-value FQDN fallback so ticks
+            # run before catalyst-platform ships the sovereign-fqdn CM.
+            - name: SOVEREIGN_FQDN_FALLBACK
+              value: {{ .Values.sovereign.fqdn | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/platform/sso-bridge/chart/values.yaml
+++ b/platform/sso-bridge/chart/values.yaml
@@ -211,3 +211,16 @@ networkPolicy:
   keycloakPort: 80
   openbaoNamespace: openbao
   openbaoPort: 8200
+
+# #2989 residual (0.2.9): the Sovereign's own FQDN as a chart value, used
+# by the reconciler as fallback when the sovereign-fqdn ConfigMap (shipped
+# by bp-catalyst-platform) does not exist yet. Without this fallback the
+# reconciler skipped EVERY tick pre-catalyst-platform — re-creating the
+# #2989 deadlock one layer down: gitea's post-install SSO hook starves on
+# the sso/gitea OpenBao key this reconciler writes, catalyst-platform
+# dependsOn gitea, and the CM ships with catalyst-platform. Slot 13b
+# supplies the real value via envsubst ${SOVEREIGN_FQDN}; empty default
+# keeps smoke renders clean (reconciler then degrades to the old
+# CM-only behavior).
+sovereign:
+  fqdn: ""


### PR DESCRIPTION
hw91 live: reconciler skipped **every tick for 3h20m** ('sovereign-fqdn ConfigMap missing') — the CM ships with catalyst-platform, which dependsOn gitea, whose **post-install SSO hook** starves on the `sso/gitea` key those ticks write. PR #2994 cut the Flux edge; this CM-read was the same deadlock one layer down (helm-hook layer).

Fix: `sovereign_fqdn()` falls back to the chart-value FQDN (`sovereign.fqdn`, envsubst'd in slot 13b) — Tier-1/2/3 writes run pre-catalyst-platform; only the orgEmail grant stays CM-deferred (making #2994's rationale actually true). CM wins when present.

Lockstep 0.2.9. Chart suites green; rendered reconciler `bash -n` OK; both render paths verified. On merge: publish → hw91's sso-bridge upgrades → first tick writes `sso/gitea` → ExternalSecret syncs → gitea's hook Job completes → gitea Ready → catalyst-platform → console.

Refs #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)