### PR TITLE
fix(cutover): #2938 — Step-09 idempotent re-runs (validity probe + unique mint names, no active-token DELETE)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -435,7 +435,7 @@ spec:
       # 0.1.51 (#2951 / #2940 ATTACK#9): Step 10 Phase-1c asserts all
       # four image HRs (3 vClusters + sso-bridge) are off harbor.openova.io
       # post-pivot; Job exits 1 on any residual mothership-Harbor tether.
-      version: 0.1.52
+      version: 0.1.53
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.52
+  version: 0.1.53
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -402,7 +402,7 @@ name: bp-self-sovereign-cutover
 # harbor.openova.io — so the cutover automation itself proves the
 # mothership-Harbor untether instead of leaving a manual post-hoc grep
 # as the only acceptance gate.
-version: 0.1.52
+version: 0.1.53
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/09-gitea-token-mint-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/09-gitea-token-mint-job.yaml
@@ -151,26 +151,45 @@ data:
               fi
             fi
 
-            # ── 2. Idempotent delete of any pre-existing token ────────────
-            # Gitea returns 422 "name has already been used" if the
-            # token name is already in use. On a re-run (chart upgrade,
-            # operator-triggered cutover replay) we MUST clear stale
-            # state before re-minting, otherwise the Pod exits non-zero
-            # and the cutover engine reports a failed step despite the
-            # steady-state being correct. DELETE is idempotent — Gitea
-            # returns 404 if the token doesn't exist, which we swallow.
+            # ── 2. Re-run no-op probe (#2938) ─────────────────────────────
+            # OLD behavior (idempotency VIOLATION, UAT Wave-2 ATTACK#7):
+            # delete-then-mint on every run. On a cutover replay the
+            # DELETE invalidated the token live workloads were using;
+            # between the Secret patch and the rollout-restart serving
+            # new Pods, every holder of the old token got hard 401s with
+            # NO recovery path (token gone server-side).
             #
-            # Gitea 1.22 API: DELETE /api/v1/users/{username}/tokens/{name}
-            # (NOT /admin/users/...) — the basic-auth'd caller must be
-            # the same user as {username}. gitea_admin authenticating as
-            # itself is the canonical path.
-            echo "[gitea-token-mint] purging any stale token named ${TOKEN_NAME}"
-            curl -fsS -u "${GITEA_USERNAME}:${GITEA_PASSWORD}" \
-              -X DELETE \
-              -H "Accept: application/json" \
-              "${api_url}/users/${GITEA_USERNAME}/tokens/${TOKEN_NAME}" \
-              >/dev/null 2>&1 || true
-            echo "[gitea-token-mint] stale-token purge complete (404 on first run is expected)"
+            # NEW contract: if the destination Secret already holds a
+            # token Gitea still accepts, steady-state is correct — exit 0
+            # WITHOUT touching anything (no delete, no mint, no rollout).
+            # Probe = GET /api/v1/user authenticated WITH that token
+            # (valid for any live token; 401 → revoked/invalid).
+            existing_token=$(kubectl -n "${DEST_SECRET_NAMESPACE}" get secret "${DEST_SECRET_NAME}" \
+              -o jsonpath="{.data.${DEST_SECRET_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || true)
+            if [ -n "${existing_token}" ]; then
+              probe_code=$(curl -s -o /dev/null -w '%{http_code}' \
+                -H "Authorization: token ${existing_token}" \
+                -H "Accept: application/json" \
+                "${api_url}/user" 2>/dev/null || echo "000")
+              if [ "${probe_code}" = "200" ]; then
+                echo "[gitea-token-mint] existing token in ${DEST_SECRET_NAMESPACE}/${DEST_SECRET_NAME} is VALID — re-run is a no-op (#2938: re-runs must not break working state)"
+                exit 0
+              fi
+              echo "[gitea-token-mint] existing-token probe returned ${probe_code} — minting a replacement"
+            else
+              echo "[gitea-token-mint] no existing token in destination Secret — first run"
+            fi
+
+            # ── 2b. Unique per-run token name (#2938 Option 2) ───────────
+            # Mint under base-name + epoch nonce instead of delete-then-
+            # reuse: old tokens are NEVER invalidated by a re-run, so any
+            # Pod still holding one keeps working until its own rollout
+            # completes. Orphaned old tokens are inert (rotated out of
+            # the Secret, unused); the shared base-name prefix keeps the
+            # Gitea token list auditable. This also removes the 422
+            # name-collision the old DELETE existed to clear.
+            TOKEN_NAME="${TOKEN_NAME}-$(date +%s)"
+            echo "[gitea-token-mint] minting under unique name ${TOKEN_NAME}"
 
             # ── 3. Mint a fresh token ────────────────────────────────────
             # POST /api/v1/users/{username}/tokens body:

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -673,4 +673,24 @@ if ! grep -q 'consolePublicURL not overlaid' "$TMP/render.yaml"; then
 fi
 echo "  PASS (Step-07 Phase 3 pivots issuers + runtime-config URLs with read-back asserts)"
 
+
+echo "[cutover-contract] Case 24: Step-09 re-run no-op probe + unique token name (#2938)"
+# The old delete-then-mint rotated the live token on every re-run —
+# holders of the old token got unrecoverable 401s (UAT Wave-2 ATTACK#7).
+# Contract: a validity probe short-circuits re-runs; minting uses a
+# unique per-run name; and NO DELETE of the active token ever happens.
+if ! grep -q 're-run is a no-op' "$TMP/render.yaml"; then
+  echo "FAIL: Step-09 missing the re-run no-op probe (#2938)" >&2
+  exit 1
+fi
+if ! grep -q 'minting under unique name' "$TMP/render.yaml"; then
+  echo "FAIL: Step-09 missing the unique per-run token name (#2938)" >&2
+  exit 1
+fi
+if grep -A20 'gitea-token-mint' "$TMP/render.yaml" | grep -q 'X DELETE.*tokens/'; then
+  echo "FAIL: Step-09 still DELETEs the active token (#2938 regression)" >&2
+  exit 1
+fi
+echo "  PASS (Step-09: validity probe short-circuits re-runs; unique mint name; no active-token DELETE)"
+
 echo "[cutover-contract] All gates green."


### PR DESCRIPTION
Implements the issue's preferred **Option 2** + acceptance criterion exactly: re-running cutover when the destination Secret's token is still valid is a **no-op** (probe: `GET /api/v1/user` with the stored token → 200 → exit 0 untouched); when minting is needed, the name is unique-per-run (`<base>-<epoch>`), so **old tokens are never invalidated** and active workloads keep working through their own rollout. The DELETE that caused the unrecoverable-401 window (ATTACK#7) is gone — its 422-collision rationale disappears with unique names.

`cutover-contract.sh` **Case 24** locks all three properties (probe present, unique name, no active-token DELETE). Lockstep 0.1.53. Suite green; rendered Step-09 shell `bash -n` OK. Live re-run proof = a second cutover trigger on a converged Sovereign (UAT TC-24+ environment).

Refs #2938

🤖 Generated with [Claude Code](https://claude.com/claude-code)