### PR TITLE
fix(sso-bridge): explicit in-cluster kubeconfig — kubectl was silently hitting localhost:8080 the whole time

### DIFF
--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -116,7 +116,7 @@ spec:
       # 0.1.1 (G91-fu, Refs #2659, edc55c08 PR #2676): adds realm-role
       # grant + skipClientUpsert opt-out for charts whose Keycloak Client
       # is realm-imported at bp-keycloak install time (catalyst-ui etc.).
-      version: 0.2.12
+      version: 0.2.13
       sourceRef:
         kind: HelmRepository
         name: bp-sso-bridge

--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.12
+  version: 0.2.13
   card:
     title: sso-bridge
     summary: |

--- a/platform/sso-bridge/chart/Chart.yaml
+++ b/platform/sso-bridge/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-sso-bridge
-version: 0.2.12
+version: 0.2.13
 # 0.2.8 (G117.5-followup #2914, 2026-06-03): dual-token KC mint —
 # sovereign-realm SA token for in-realm operations + new master-realm
 # admin token for POST /admin/realms (per-Org realm provisioning).

--- a/platform/sso-bridge/chart/templates/configmap-reconciler.yaml
+++ b/platform/sso-bridge/chart/templates/configmap-reconciler.yaml
@@ -71,6 +71,31 @@ data:
     # See chart Chart.yaml description for the contract.
     set -uo pipefail
 
+    # 0.2.13 (hw91 ROOT CAUSE of every reconciler kubectl failure on this
+    # prov): kubectl fell back to http://localhost:8080 — in-cluster
+    # config was not engaging, so EVERY kubectl since the framework
+    # shipped returned empty/refused here ("couldn't get current server
+    # API group list ... localhost:8080"), masked as "CM missing" warns
+    # and discovered-0 ticks by 2>/dev/null. Stop depending on env
+    # injection entirely: synthesize an explicit kubeconfig from the
+    # mounted ServiceAccount (token + CA + namespace are always present
+    # — openbao_login already reads the same mount) and export it.
+    # Correct in all worlds; /tmp is the chart's writable emptyDir.
+    SA_DIR=/var/run/secrets/kubernetes.io/serviceaccount
+    export KUBECONFIG=/tmp/sso-bridge-kubeconfig
+    KAPI="https://${KUBERNETES_SERVICE_HOST:-kubernetes.default.svc}:${KUBERNETES_SERVICE_PORT:-443}"
+    kubectl config set-cluster in-cluster \
+      --server="${KAPI}" \
+      --certificate-authority="${SA_DIR}/ca.crt" >/dev/null
+    kubectl config set-credentials sa \
+      --token="$(cat "${SA_DIR}/token")" >/dev/null
+    kubectl config set-context in-cluster --cluster=in-cluster --user=sa \
+      --namespace="$(cat "${SA_DIR}/namespace")" >/dev/null
+    kubectl config use-context in-cluster >/dev/null
+    kubectl version --request-timeout=10s >/dev/null 2>&1 \
+      && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) | kubeconfig bootstrap OK (server=${KAPI})" \
+      || echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) | WARN: kubeconfig bootstrap probe failed (server=${KAPI}) — ticks will retry" >&2
+
     : "${KC_REALM:?KC_REALM must be set}"
     : "${KC_ADDR:?KC_ADDR must be set}"
     : "${KC_SA_CLIENT_ID:?KC_SA_CLIENT_ID must be set}"
@@ -949,6 +974,10 @@ data:
       # no Sovereign FQDN ConfigMap) still touch the file because the
       # reconciler IS alive, just degraded upstream.
       touch /tmp/sso-bridge-last-tick
+
+      # 0.2.13: bound SA tokens rotate (~1h) — refresh the synthesized
+      # kubeconfig's credential each tick so long-lived pods keep working.
+      kubectl config set-credentials sa --token="$(cat "${SA_DIR}/token")" >/dev/null 2>&1 || true
 
       mint_kc_token || { warn "skipping tick (no KC token)"; sleep "${INTERVAL_SECONDS}"; continue; }
       openbao_login || { warn "skipping tick (no OpenBao token)"; sleep "${INTERVAL_SECONDS}"; continue; }


### PR DESCRIPTION
0.2.12's narration + unsuppressed stderr finally showed it verbatim on hw91: `Get \"http://localhost:8080/api\" ... connection refused` — in-cluster config never engaged in this pod, so **every reconciler kubectl since G91.1 shipped** has returned refused/empty, masked by `2>/dev/null` as 'CM missing' and 'discovered 0'. The reconciler has never successfully kubectl'd on a fresh prov; hw86's manual recovery masked the whole class.

Fix: synthesize the kubeconfig explicitly from the SA mount (token+CA+namespace — the same files `openbao_login` already reads), `export KUBECONFIG`, one narrated bootstrap probe, per-tick token refresh for bound-token rotation. Works regardless of why env injection failed.

Lockstep 0.2.13; 5/5 suites; `bash -n` OK. Expected on hw91 within minutes of merge: `kubeconfig bootstrap OK` → `discovered 6` → sso keys written → gitea hook completes → convergence → console.

Refs #2744 #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)