### PR TITLE
fix(sso-bridge): CiliumNetworkPolicy toEntities kube-apiserver — K8s NetworkPolicy structurally cannot allow the k3s apiserver

### DIFF
--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -116,7 +116,7 @@ spec:
       # 0.1.1 (G91-fu, Refs #2659, edc55c08 PR #2676): adds realm-role
       # grant + skipClientUpsert opt-out for charts whose Keycloak Client
       # is realm-imported at bp-keycloak install time (catalyst-ui etc.).
-      version: 0.2.13
+      version: 0.2.14
       sourceRef:
         kind: HelmRepository
         name: bp-sso-bridge

--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.13
+  version: 0.2.14
   card:
     title: sso-bridge
     summary: |

--- a/platform/sso-bridge/chart/Chart.yaml
+++ b/platform/sso-bridge/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-sso-bridge
-version: 0.2.13
+version: 0.2.14
 # 0.2.8 (G117.5-followup #2914, 2026-06-03): dual-token KC mint —
 # sovereign-realm SA token for in-realm operations + new master-realm
 # admin token for POST /admin/realms (per-Org realm provisioning).

--- a/platform/sso-bridge/chart/templates/cilium-networkpolicy-apiserver.yaml
+++ b/platform/sso-bridge/chart/templates/cilium-networkpolicy-apiserver.yaml
@@ -1,0 +1,42 @@
+{{- /*
+0.2.14 (hw91 — the endpoint of the localhost:8080 saga): the K8s
+NetworkPolicy egress rule for the API server selects
+`default ns + podSelector component=apiserver` — but on k3s the
+apiserver is a HOST PROCESS, not a pod; Cilium classifies traffic to it
+as the special `kube-apiserver` ENTITY, which no K8s NetworkPolicy
+selector (podSelector / namespaceSelector / ipBlock — see the 0.2.7
+finding: ipBlock 0.0.0.0/0 also excludes it) can express. Result: ALL
+egress from this namespace to 10.96.0.1:443 was dropped — kubectl's
+in-cluster path never worked, surfacing first as the localhost:8080
+fallback and then, post-0.2.13, as the narrated bootstrap-probe
+failure against the correct server.
+
+CiliumNetworkPolicy toEntities is the canonical expression. Gated on
+the cilium.io/v2 Capabilities check (the #2988 idiom) so the chart
+still installs on CRD-less clusters (kind CI) where the K8s
+NetworkPolicy below is not enforced by an identity-aware agent anyway.
+*/ -}}
+{{- if and .Values.networkPolicy.enabled (.Capabilities.APIVersions.Has "cilium.io/v2") }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: sso-bridge-reconciler-apiserver
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: sso-bridge
+    app.kubernetes.io/component: reconciler
+    catalyst.openova.io/component: sso-bridge-netpol
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sso-bridge-reconciler
+  egress:
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+{{- end }}


### PR DESCRIPTION
0.2.13's bootstrap probe narrated the terminal fact: TCP to `10.96.0.1:443` is dropped from the reconciler pod. Root: on k3s the apiserver is a **host process** — Cilium classifies it as the `kube-apiserver` **entity**, unmatchable by any K8s NetworkPolicy selector (podSelector misses; per the 0.2.7 finding, `ipBlock 0.0.0.0/0` misses too). The namespace's API egress has been policy-dropped since the netpol shipped — the floor under the whole localhost:8080 saga.

Fix: `CiliumNetworkPolicy` with `toEntities: [kube-apiserver]` (6443+443), selector matched to the reconciler pods, `cilium.io/v2` Capabilities-gated (#2988 idiom). Lockstep 0.2.14; 5/5 suites; both render paths verified.

Expected on hw91 within minutes of merge: `kubeconfig bootstrap OK` → `discovered 6` → keys → gitea hook → convergence → console.

Refs #2744 #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)