### PR TITLE
fix(gitea): sso-configure hook budgets — its 10m wait lost to gitea's 8-12m per-attempt Ready time, every time

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -81,7 +81,7 @@ spec:
       # bp-self-sovereign-cutover Step 1 gitea-mirror Job mounts it. K8s
       # forbids cross-namespace secretKeyRef; reflector is the canonical
       # platform-level mirror. Caught live on otech103 2026-05-04.
-      version: 1.2.17
+      version: 1.2.18
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.17
+  version: 1.2.18
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -60,7 +60,7 @@ name: bp-gitea
 # directly in Gitea as a site admin via OIDC. Local `gitea_admin` user
 # remains the break-glass account for bp-self-sovereign-cutover Step 1.
 # Per SECURITY.md §6.3 (App-level SSO).
-version: 1.2.17
+version: 1.2.18
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/sso-configure-oauth-job.yaml
+++ b/platform/gitea/chart/templates/sso-configure-oauth-job.yaml
@@ -96,9 +96,19 @@ metadata:
     "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  # 1.2.18 (hw91 2026-06-04): budgets renested for the remediation-retry
+  # reality. Each helm attempt re-creates the CNPG cluster (~5-6m
+  # teardown+initdb) and gitea's init can ride a 5m CrashLoop backoff
+  # before its first post-DB retry — the gitea Pod is Ready ~8-12m into
+  # the attempt. The old 10m inner wait + 15m activeDeadline expired
+  # JUST short every time -> BackoffLimitExceeded -> install failed ->
+  # uninstall -> identical race next attempt, forever. One patient
+  # container run owns the wait (powerdns zone-bootstrap posture,
+  # #3019): inner wait 25m < job deadline 27m < helm timeout 30m
+  # (slot 10, PR #3030).
   backoffLimit: 3
   ttlSecondsAfterFinished: 600
-  activeDeadlineSeconds: 900
+  activeDeadlineSeconds: 1620
   template:
     metadata:
       labels:
@@ -203,11 +213,11 @@ spec:
               # never matches and the hook always times out.
               #
               # Wait for at least one Ready Pod matching the selector
-              # (up to 10 min — first install races bp-cnpg + ESO + the
+              # (up to 25 min — first install races bp-cnpg + ESO + the
               # upstream init container).
               GITEA_POD=""
               echo "[$(date -u +%FT%TZ)] waiting for a Ready gitea Pod (selector=${POD_SELECTOR})..."
-              for i in $(seq 1 60); do
+              for i in $(seq 1 150); do
                 GITEA_POD="$(kubectl get pod -n "${GITEA_NAMESPACE}" \
                   -l "${POD_SELECTOR}" \
                   -o jsonpath='{range .items[?(@.status.phase=="Running")]}{.metadata.name}{"\t"}{range .status.conditions[?(@.type=="Ready")]}{.status}{end}{"\n"}{end}' \
@@ -217,12 +227,12 @@ spec:
                   echo "[$(date -u +%FT%TZ)] selected pod=${GITEA_POD} (Ready)."
                   break
                 fi
-                echo "  attempt $i/60: no Ready pod matching selector; sleeping 10s..."
+                echo "  attempt $i/150: no Ready pod matching selector; sleeping 10s..."
                 sleep 10
               done
 
               if [ -z "${GITEA_POD}" ]; then
-                echo "FATAL: no Ready gitea Pod matched selector '${POD_SELECTOR}' within 10 min." >&2
+                echo "FATAL: no Ready gitea Pod matched selector '${POD_SELECTOR}' within 25 min." >&2
                 echo "  current pods in namespace:" >&2
                 kubectl get pod -n "${GITEA_NAMESPACE}" -l "${POD_SELECTOR}" >&2 || true
                 exit 1


### PR DESCRIPTION
The terminal layer: every attempt dies on `job gitea-sso-configure failed: BackoffLimitExceeded`. The hook's 10m Ready-wait + 15m deadline expire just short of gitea's actual per-attempt Ready time (~8-12m: CNPG re-bootstrap + init backoff + migrations). Renested per the #3019 posture: wait 25m < deadline 27m < helm 30m (#3030). Lockstep 1.2.18; 4/4 suites green.

With every other layer fixed (keys pre-synced, auth correct, DB healthy), this hook was the only remaining failer — next attempt should complete: gitea Ready → catalyst-platform → tail → console.

Refs #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)