### PR TITLE
fix(gitea): real CLI flag --use-custom-urls — first-ever execution of the kc_idp_hint path exposed a phantom flag

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -81,7 +81,7 @@ spec:
       # bp-self-sovereign-cutover Step 1 gitea-mirror Job mounts it. K8s
       # forbids cross-namespace secretKeyRef; reflector is the canonical
       # platform-level mirror. Caught live on otech103 2026-05-04.
-      version: 1.2.19
+      version: 1.2.20
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.19
+  version: 1.2.20
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -60,7 +60,7 @@ name: bp-gitea
 # directly in Gitea as a site admin via OIDC. Local `gitea_admin` user
 # remains the break-glass account for bp-self-sovereign-cutover Step 1.
 # Per SECURITY.md §6.3 (App-level SSO).
-version: 1.2.19
+version: 1.2.20
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/sso-configure-oauth-job.yaml
+++ b/platform/gitea/chart/templates/sso-configure-oauth-job.yaml
@@ -158,7 +158,7 @@ spec:
             - name: POD_SELECTOR
               value: {{ printf "app.kubernetes.io/name=gitea,app.kubernetes.io/instance=%s" .Release.Name | quote }}
             # G117.5 #2744 — IDP_HINT toggles whether we pass the
-            # hinted authorize_url via --auth-url + --use-custom-url-
+            # hinted authorize_url via --auth-url + --use-custom-urls
             # mapping. When non-empty the Job reads the
             # already-hinted `authorize_url` key out of
             # gitea-oauth-source-credentials and constructs the explicit
@@ -282,7 +282,7 @@ spec:
                 | head -n1 || true)"
 
               # G117.5: if the ESO-rendered Secret already carries the
-              # hinted authorize_url, use --use-custom-url-mapping +
+              # hinted authorize_url, use --use-custom-urls +
               # --auth-url so the IDP hint reaches KC. Otherwise fall
               # back to auto-discover.
               AUTH_URL_FILE="/etc/sso-bundle/authorize_url"
@@ -302,7 +302,7 @@ spec:
                   --provider openidConnect
                   --key "${OAUTH_KEY}"
                   --secret "${OAUTH_SECRET}"
-                  --use-custom-url-mapping
+                  --use-custom-urls
                   --custom-auth-url "${AUTH_URL}"
                   --custom-token-url "${TOKEN_URL}"
                   --custom-profile-url "${USERINFO_URL}"


### PR DESCRIPTION
1.2.19's round-logging caught it verbatim on hw91: `flag provided but not defined: -use-custom-url-mapping`. The G117.5 wiring used a flag that doesn't exist in gitea's CLI (`--use-custom-urls` is real; the three `--custom-*-url` companions were already correct) — and tonight is the first time any prov ever reached this code. Lockstep 1.2.20; 4/4 suites.

This is the last deterministic failer visible in the configure path — next attempt: rounds succeed → helm SUCCESS → gitea=True → console.

Refs #2989 #2744

🤖 Generated with [Claude Code](https://claude.com/claude-code)