### PR TITLE
fix(gitea): --auto-discover-url required even with --use-custom-urls — round 7's verbatim catch

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -81,7 +81,7 @@ spec:
       # bp-self-sovereign-cutover Step 1 gitea-mirror Job mounts it. K8s
       # forbids cross-namespace secretKeyRef; reflector is the canonical
       # platform-level mirror. Caught live on otech103 2026-05-04.
-      version: 1.2.20
+      version: 1.2.21
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.20
+  version: 1.2.21
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -60,7 +60,7 @@ name: bp-gitea
 # directly in Gitea as a site admin via OIDC. Local `gitea_admin` user
 # remains the break-glass account for bp-self-sovereign-cutover Step 1.
 # Per SECURITY.md §6.3 (App-level SSO).
-version: 1.2.20
+version: 1.2.21
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/sso-configure-oauth-job.yaml
+++ b/platform/gitea/chart/templates/sso-configure-oauth-job.yaml
@@ -302,6 +302,14 @@ spec:
                   --provider openidConnect
                   --key "${OAUTH_KEY}"
                   --secret "${OAUTH_SECRET}"
+                  # 1.2.21 (hw91, caught by the round-logging on the
+                  # path's second-ever execution): gitea's add-oauth
+                  # VALIDATES --auto-discover-url for openidConnect
+                  # regardless of --use-custom-urls ("invalid Auto
+                  # Discovery URL:" with an empty value when omitted).
+                  # The custom mapping supplements discovery, it does
+                  # not replace it.
+                  --auto-discover-url "${AUTO_DISCOVER_URL}"
                   --use-custom-urls
                   --custom-auth-url "${AUTH_URL}"
                   --custom-token-url "${TOKEN_URL}"


### PR DESCRIPTION
The patient hook's round-logging caught defect #2 on this never-before-executed path: gitea validates `--auto-discover-url` for openidConnect regardless of `--use-custom-urls` ('invalid Auto Discovery URL:' empty). Passed in both branches now. Lockstep 1.2.21; 4/4 suites.

Refs #2989 #2744

🤖 Generated with [Claude Code](https://claude.com/claude-code)