### PR TITLE
fix(catalyst): catalog-seed Blueprints conform to their own CRD — the install-blocking admission failures on hw91

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -953,7 +953,7 @@ spec:
       # preflight-blueprint-crd-cel.yaml. Flux re-applies crds/ with
       # CreateReplace on reconcile so existing Sovereigns pick it up.
       # Refs #2936.
-      version: 1.4.488
+      version: 1.4.489
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2542,7 +2542,7 @@ name: bp-catalyst-platform
 # CEL rule can never merge again. Bumping the pin so every Sovereign's
 # Flux helm-controller re-applies the corrected CRD (Flux reconciles
 # crds/ with CreateReplace, unlike raw `helm upgrade`). Refs #2936.
-version: 1.4.488
+version: 1.4.489
 appVersion: 1.4.479
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -279,7 +279,7 @@ spec:
     perTopology:
       active-hot-standby:
         replication:
-          backend: cnpg-streaming-replication
+          backend: cnpg-pair
           mode: async
           lagSloSeconds: 30
         switchover:
@@ -287,11 +287,20 @@ spec:
           rtoSeconds: 60
           rpoSeconds: 30
         placement:
+          # 1.4.489 (hw91): the seed predated the Blueprint CRD's
+          # canonical placement vocabulary (pattern
+          # ^(mgmt|dmz|rtz)-[A-Z0-9]+$, enforced server-side since
+          # #2958/#3007) — 'primary-region'/'replica-region' failed
+          # admission and blocked the ENTIRE bp-catalyst-platform
+          # install ("Blueprint bp-cnpg-pair is invalid"). Canonical
+          # form per platform/bp-rtz-vcluster/blueprint.yaml: the CNPG
+          # pair lives in the runtime zone of each region, active in A,
+          # passive (replica) in B.
           tier: ""
-          clusters: [primary-region, replica-region]
+          clusters: [rtz-A, rtz-B]
           roles:
-            primary-region: active
-            replica-region: passive
+            rtz-A: active
+            rtz-B: passive
   endpoints: []
   configSchema:
     type: object
@@ -1128,7 +1137,7 @@ spec:
     perTopology:
       active-passive:
         replication:
-          backend: bp-cnpg-pair
+          backend: cnpg-pair
           mode: async
           lagSloSeconds: 30
         switchover:


### PR DESCRIPTION
First-ever bp-catalyst-platform install past gitea failed at seed-CR admission: three values predate the canonical vocabulary the CRD now enforces (#2958/#3007 doing their job). Placement → `rtz-A/rtz-B` (canonical pattern), two `replication.backend` values → `cnpg-pair` (enum). **Validated against hw91's live apiserver: all 14 seed CRs pass `--dry-run=server`** (the exact admission that rejected them). Lockstep 1.4.489.

On merge: catalyst-platform's retry installs clean → Ready → continuum/cutover → sovereign-tls → console-200 → the UAT walk.

Refs #2936 #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)