### PR TITLE
chore(harbor): digest reset — the last gate before full hw91 convergence

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -138,7 +138,7 @@ spec:
       # live on otech113 2026-05-05 (issue #935 Bug 1) — Step 02 was
       # in CreateContainerConfigError for 11+ retries, blocking
       # cutover indefinitely.
-      version: 1.2.23
+      version: 1.2.24
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.23
+  version: 1.2.24
   card:
     title: Harbor
     family: foundation

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -52,7 +52,7 @@ type: application
 # The Postgres workload Pods reconcile into the same NS as the
 # CNPG Cluster CR, NOT into cnpg-system; the prior rule could
 # never match the actual DB Pods.
-version: 1.2.23
+version: 1.2.24
 appVersion: "2.14.3"
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now


### PR DESCRIPTION
bp-harbor: `installFailures=6`, zero attempts in 2h, frozen error referencing an ESO-webhook state that healed 9h ago — the stuck-failed-release shape. Marker bump per the session's proven unstick pattern. Harbor is the final domino: its Ready → cutover → bootstrap-kit → sovereign-tls → gateway → console-200 → the UAT walk.

Refs #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)