### PR TITLE
fix(vcluster): reachable exported kubeconfig server + bp-sandbox dependsOn namespace

### DIFF
--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -95,7 +95,13 @@ spec:
     # rather than removal so the slot remains available for Wave 11
     # Sandbox MVP without manual Day-2 add-app re-introduction.
     # G92.3 #2662 (2026-06-01): bp-harbor HR moved to host ns `mgmt`.
+    # hw91 2026-06-04: Flux resolves a namespace-less dependsOn entry in
+    # the HR's OWN namespace (rtz here) — this entry resolved to
+    # rtz/bp-harbor, which does not exist (bp-harbor lives in
+    # flux-system), wedging bp-sandbox at "unable to get 'rtz/bp-harbor'
+    # dependency" and holding the bootstrap-kit health gate forever.
     - name: bp-harbor
+      namespace: flux-system
   chart:
     spec:
       chart: sandbox

--- a/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
@@ -63,7 +63,7 @@ spec:
   chart:
     spec:
       chart: bp-dmz-vcluster
-      version: 0.2.1
+      version: 0.2.2
       sourceRef:
         kind: HelmRepository
         name: bp-dmz-vcluster

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -70,7 +70,7 @@ spec:
   chart:
     spec:
       chart: bp-mgmt-vcluster
-      version: 0.2.2
+      version: 0.2.3
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
@@ -62,7 +62,7 @@ spec:
   chart:
     spec:
       chart: bp-rtz-vcluster
-      version: 0.2.2
+      version: 0.2.3
       sourceRef:
         kind: HelmRepository
         name: bp-rtz-vcluster

--- a/platform/bp-dmz-vcluster/blueprint.yaml
+++ b/platform/bp-dmz-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.1
+  version: 0.2.2
   card:
     title: DMZ vCluster
     summary: |

--- a/platform/bp-dmz-vcluster/chart/Chart.yaml
+++ b/platform/bp-dmz-vcluster/chart/Chart.yaml
@@ -19,7 +19,7 @@ name: bp-dmz-vcluster
 # 0.2.0 + bp-rtz-vcluster 0.2.0). Picks up `sync.toHost.customResources`
 # schema so DMZ vCluster-placed charts that need cross-vCluster CR sync
 # can wire it in without a follow-up chart bump.
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign DMZ

--- a/platform/bp-dmz-vcluster/chart/values.yaml
+++ b/platform/bp-dmz-vcluster/chart/values.yaml
@@ -123,5 +123,13 @@ vcluster:
   # can reconcile DMZ-vCluster-targeted resources.
   exportKubeConfig:
     context: vcluster
+    # hw91 2026-06-04: without an explicit server, vcluster exports its
+    # default `https://localhost:8443` — only dialable from inside the
+    # vcluster pod. helm-controller (flux-system, host cluster) reads
+    # this Secret via HelmRelease.spec.kubeConfig and got
+    # `dial tcp [::1]:8443: connection refused` on every vc-dmz-targeted
+    # HR (dmz/bp-coraza), holding the bootstrap-kit health gate forever.
+    # The host-side service DNS is the correct dial target.
+    server: https://dmz-vcluster.dmz.svc:443
     secret:
       name: vc-dmz

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.2
+  version: 0.2.3
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -35,7 +35,7 @@ name: bp-mgmt-vcluster
 # `<inner-ns>-x-mgmt`, the host's cnpg-operator reconciles it, and
 # the resulting Service is synced back into the vCluster's view via
 # the already-enabled `sync.toHost.services`.
-version: 0.2.2
+version: 0.2.3
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -225,5 +225,11 @@ vcluster:
   # can reconcile MGMT-vCluster-targeted resources.
   exportKubeConfig:
     context: vcluster
+    # hw91 2026-06-04: same defect as bp-dmz-vcluster — the default
+    # exported server is `https://localhost:8443`, unusable by the
+    # host-cluster helm-controller / per-Sovereign Kustomizations that
+    # consume the mirrored kubeconfig. Point at the host-side service
+    # DNS before the first vc-mgmt-targeted HR trips over it.
+    server: https://mgmt-vcluster.mgmt.svc:443
     secret:
       name: vc-mgmt

--- a/platform/bp-rtz-vcluster/blueprint.yaml
+++ b/platform/bp-rtz-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.2
+  version: 0.2.3
   card:
     title: RTZ vCluster
     summary: |

--- a/platform/bp-rtz-vcluster/chart/Chart.yaml
+++ b/platform/bp-rtz-vcluster/chart/Chart.yaml
@@ -20,7 +20,7 @@ name: bp-rtz-vcluster
 # RTZ vCluster hosts per-Org tenant Applications + Sandbox per DoD
 # §A4; both paths route CNPG provisioning through the host
 # cnpg-operator (G92.6 substrate per #2665) via this sync.
-version: 0.2.2
+version: 0.2.3
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign RTZ

--- a/platform/bp-rtz-vcluster/chart/values.yaml
+++ b/platform/bp-rtz-vcluster/chart/values.yaml
@@ -132,5 +132,10 @@ vcluster:
   # can reconcile RTZ-vCluster-targeted resources.
   exportKubeConfig:
     context: vcluster
+    # hw91 2026-06-04: same defect as bp-dmz-vcluster — the default
+    # exported server is `https://localhost:8443`, unusable by the
+    # host-cluster helm-controller that reconciles vc-rtz-targeted HRs
+    # (rtz/bp-sandbox). Point at the host-side service DNS.
+    server: https://rtz-vcluster.rtz.svc:443
     secret:
       name: vc-rtz


### PR DESCRIPTION
The two HRs actually holding bootstrap-kit's health gate on hw91 (invisible to flux-system-scoped counts — they live in host namespaces `dmz`/`rtz`):

| HR | Error | Root cause | Fix |
|---|---|---|---|
| `dmz/bp-coraza` | `dial tcp [::1]:8443: connection refused` | `exportKubeConfig.server` unset → vcluster exports `localhost:8443`, unusable by host-side helm-controller | pin `server: https://<name>-vcluster.<ns>.svc:443` (verified live) in all 3 vcluster charts |
| `rtz/bp-sandbox` | `unable to get 'rtz/bp-harbor' dependency: not found` | namespace-less `dependsOn` resolves in the HR's own namespace | `namespace: flux-system` |

bp-mgmt-vcluster gets the same server pin before its first consumer hits it. Lockstep bumps: dmz 0.2.2, rtz 0.2.3, mgmt 0.2.3 (Chart.yaml + blueprint.yaml + slot pins). helm lint green ×3.

After this: bootstrap-kit health passes → sovereign-tls → gateway → console-200 → the UAT walk.

Refs #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)