### PR TITLE
fix(cutover): wire sovereign.consolePublicURL — the Step-07 FATAL halting cutover mid-pivot

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -469,6 +469,19 @@ spec:
       harborPublicURL: https://registry.${SOVEREIGN_FQDN}
       giteaInternalURL: http://gitea-http.gitea.svc.cluster.local:3000
       giteaPublicURL: https://gitea.${SOVEREIGN_FQDN}
+      # G... (#2989, 2026-06-04): Step 07 (catalyst-api-env-patch, Phase 3
+      # of PR #3012) pivots CATALYST_PIN_ISSUER + CATALYST_HANDOVER_JWT_
+      # ISSUER + the two runtime-config public-URL keys to this value and
+      # FATALs ("Pillar 5 independence not met") if it is still the chart
+      # default `https://console.example.local`. PR #3012 added that
+      # assertion but never added the overlay line here — so the cutover
+      # engine FATAL'd at Step 07 on EVERY prov, halting the sequence with
+      # the registry tether half-pivoted (Step 04 strips ghcr.io from
+      # ghcr-pull, but Step 06's HelmRepository URL rewrite — which runs
+      # after 07 in engine order — never executes → all fresh chart pulls
+      # 401 with "no auth config for ghcr.io"). Caught live on hw91. This
+      # is the missing lockstep half of #3012; mirror of harbor/giteaPublicURL.
+      consolePublicURL: https://console.${SOVEREIGN_FQDN}
     # Wave 5.110 (#2462): bastion mirror endpoint for harbor.openova.io,
     # substituted from cloudinit's flux-system/bastion-mirror Secret
     # (Huawei provider only; Hetzner leaves the var empty → chart skips


### PR DESCRIPTION
## Root cause (live hw91)

The sovereignty cutover auto-fires at bootstrap (`trigger.auto: true`, founder rule — post-install/post-upgrade hook). On hw91 it fired when bp-harbor briefly readied, and its engine FATAL'd at Step 07:

```
[catalyst-api-env-patch] FATAL Phase 3: sovereign.consolePublicURL not overlaid (got 'https://console.example.local') — supply https://console.<sovereign-fqdn>
```

PR #3012 added that Step-07 assertion (Phase 3 pivots PIN/handover issuers + runtime-config public-URL keys to `consolePublicURL`) **but never added the overlay line** to slot 06a's `values.sovereign` block. So the cutover FATAL'd at Step 07 on **every** prov.

## Why it wedges convergence

Step 04 strips `ghcr.io` from the `ghcr-pull` Secret; the FATAL at Step 07 halts the sequence with the registry tether **half-pivoted** (creds on local registry, every HelmRepository URL still `oci://ghcr.io/openova-io`). Every fresh chart pull then 401s: `failed to configure login options: no auth config for 'ghcr.io'`. HR count regressed 51→44 live.

## Fix

One overlay line, mirroring the sibling `harborPublicURL`/`giteaPublicURL`:
```yaml
consolePublicURL: https://console.${SOVEREIGN_FQDN}
```

The missing lockstep half of #3012. Unbreaks cutover Step 07 on every prov.

Refs #2989 Refs #3012

🤖 Generated with [Claude Code](https://claude.com/claude-code)