### PR TITLE
docs(uat): bring UAT ledger current — hw91 failed-env status log + convergence chain

### DIFF
--- a/docs/ledger/UAT-2026-06-03.md
+++ b/docs/ledger/UAT-2026-06-03.md
@@ -15,16 +15,35 @@
 | Field | Value |
 |---|---|
 | **Product / release** | OpenOva Catalyst — Sovereign `<sovereign-fqdn>` (target: fresh prov **`hw91.omantel.biz`**, dep `38ae2b82dc325354`, 2-region `me-east-215-a`/`-b`, active-hot-standby; TLD per LE-rotation — `omani.works` cert budget exhausted by hw86–hw90) |
-| **Build under test** | catalog `main` with the complete fresh-prov hardening chain merged: #2982 / #2985 / #2989 / #2999 / #2988+#3006 / #3004 / #3007 / #3008+#2940 |
+| **Build under test** | catalog `main` with the complete fresh-prov hardening chain merged: #2982 / #2985 / #2989 / #2999 / #2988+#3006 / #3004 / #3007 / #3008+#2940, **plus the 2026-06-04 convergence layer**: #3000 (Flux `remediation.retries: -1`) / #3012 (cutover Phase-3 issuer + console-URL pivots) / #3016–#3036 (controller-pin freshness, phase1-watch ready-gate #3018, catalog-seed CRD vocab, the sso-bridge-reconciler 5-layer saga 0.2.9–0.2.14, the gitea-OIDC-hook 6-layer saga 1.2.17–1.2.22) / **#3037** (harbor digest-reset) / **#3038** (vcluster reachable-kubeconfig + bp-sandbox dependsOn ns) / **#3039** (cutover `consolePublicURL` overlay — the Step-07 FATAL) / #3040 (comment accuracy) |
 | **Environment** | `https://console.<sovereign-fqdn>` (operator console) · `https://marketplace.<sovereign-fqdn>` (customer marketplace) · `https://console.<orgslug>.<pool-tld>` (tenant console; pool = `omani.homes` / `omani.rest` / `omani.trade`) |
 | **Surface(s)** | Responsive web only. No native mobile app ships. |
 | **Tester** | founder walk (or read-only Playwright verification agent — never an agent that ships fixes) |
-| **Walk date** | begins the moment hw91 reconciles `ready` with **zero manual intervention** |
-| **Overall verdict** | ☐ **NOT WALKED** — hw91 provisioning (started 2026-06-03T21:10Z). Per the zero-touch contract, hw88/hw89/hw90 were failed exposure environments (all wiped, zero-orphan verified); hw91 is the first prov on the catalog that carries every fix in the chain. |
+| **Walk date** | **not yet begun** — hw91 became a failed env (see Status log); begins the moment a fresh prov reconciles to a serving console with **zero manual intervention** |
+| **Overall verdict** | ☐ **NOT WALKED** — hw91 (started 2026-06-03T21:10Z) reached premature `ready` (#3018) then surfaced a stacked convergence-blocker chain; all blockers root-caused + fixed at catalog source, but hw91 itself wedged **unrecoverably** as a failed env (cutover Step-07 half-pivot deadlock — fix #3039 merged, but hw91 can't self-heal due to the registry chicken-and-egg). **Per the zero-touch contract hw91 is a failed exposure env (read-only use only).** The walk requires a **fresh prov** carrying #3037/#3038/#3039 — pending founder go (wipe+re-prov, or Hetzner). See Status log below. |
 
 **Result legend** (exactly one per Result cell): ✅ PASS *(evidence required)* · ❌ FAIL *(file defect, leave issue open)* · ⛔ BLOCKED *(couldn't attempt)* · ⏭️ N/A · ☐ NOT WALKED.
 
 **Rules:** no ✅ without a committed screenshot link (`docs/sessions/<date>/evidence/`); walk top-to-bottom; the executor is **read-only** on the product and **never closes the issue**; report the screen you saw, not the one you expected; "looks right from the code" is banned; any manual cluster intervention fails the environment (fix at catalog source only).
+
+---
+
+## Status log — hw91 prov (the zero-touch exposure run)
+
+> The walk has **not started** because no environment has yet reconciled to a serving console zero-touch. This log records what hw91 exposed, in order. Per founder doctrine each item is a catalog-source fix; hw91 was used read-only to expose, never hand-patched.
+
+| When (UTC, 2026-06-04) | What | Resolution |
+|---|---|---|
+| ~00:15 | hw91 flipped `status=ready` at 39/54 HRs with console TCP-closed — **premature ready** | phase1-watcher hardened: `ready` only on explicit OutcomeReady, timeout → failed (#3018 → PR #3020) |
+| ~01:00–05:00 | **bp-sso-bridge** had never worked on any fresh prov — its `kubectl` silently hit `localhost:8080` since G91.1, masked by `2>/dev/null` as "discovered 0 HRs" | 5-layer fix 0.2.9–0.2.14: SA-mount kubeconfig synthesis, bounded calls, phase narration, CiliumNetworkPolicy `toEntities: [kube-apiserver]`, KC `manage-clients` role |
+| ~03:00–06:00 | **gitea OIDC post-install hook** (a never-executed path) yielded one defect per abstraction layer | 6-layer fix 1.2.17–1.2.22: DB-password ref, wait budgets, patient retry loop, real `--use-custom-urls` flag, `--auto-discover-url`, in-cluster KC discovery (the bootstrap-circle breaker) |
+| ~06:30 | catalyst-platform install failed on catalog-seed CRD vocab (placement `clusters[]` + `cnpg-pair` enum) | PR #3036, validated via live `--dry-run=server` (14/14 seed CRs pass) |
+| ~07:00 | **bp-harbor** stuck `installFailures=6` with a 9 h-stale ESO-webhook error — helm-controller backoff wedge | digest-reset marker bump 1.2.24 (**#3037**) |
+| ~07:35 | bootstrap-kit health gated on two **host-namespace** HRs (`dmz/bp-coraza`, `rtz/bp-sandbox`) invisible to `-n flux-system` counts: vcluster exported `localhost:8443` kubeconfig + a namespace-less `dependsOn` | **#3038** — `exportKubeConfig.server` pinned to service DNS; `namespace: flux-system` on the dependsOn |
+| ~07:20–08:15 | **The terminal blocker.** Cutover auto-fired at bootstrap (`trigger.auto`, founder rule) and FATAL'd at Step 07 on a missing `sovereign.consolePublicURL` overlay (a #3012 regression) → engine halted → registry tether **half-pivoted** (ghcr.io creds stripped, URLs not rewritten) → every fresh chart pull 401'd → HR count regressed 51→44 | **#3039** — `consolePublicURL: https://console.${SOVEREIGN_FQDN}` overlay (the missing lockstep half of #3012); #3040 corrects the mechanism comment |
+| ~08:15 → now | hw91 is **unrecoverable**: the cutover that would heal the registry is gated on harbor → vcluster → the broken registry it would heal (chicken-and-egg). Confirmed failed env. | Fix stack independently reviewed **SOUND**; acceptance requires a **fresh prov**. Pending founder decision (wipe hw91 + re-prov omantel, or fresh Hetzner prov). |
+
+**UAT issue status (all four code-complete + reviewer VERIFIED-PASS, awaiting only the live walk):** #2742 (TC-18 endpoint→PR propagation), #2744 (TC-17 Tier-1 silent-SSO), #2940 (TC-26 post-cutover regression / 18-tether audit — re-verified code-complete 2026-06-04), #2951 (cutover Step-6 per-Blueprint defaults). All remain `status/uat`; none walked, because every surface returns HTTP `000` (gateway never bound — 5 Playwright timeouts + 4 curl probes logged). They close only after the founder's walk-with-screenshot, per [`../../CLAUDE.md`](../../CLAUDE.md) Rule 6.
 
 ---
 
@@ -403,7 +422,7 @@ Visit each URL in a tab; each must render **its app page** — not 404, not a bl
 | V — Pillar 3 failover | TC-22…23 | ☐ |
 | VI — Pillar 5 cutover | TC-24…26 | ☐ |
 
-**Overall verdict:** ☐ **NOT WALKED** — begins when `hw91.omantel.biz` reconciles `ready` with zero manual intervention. Failed environments (hw88/89/90 class) may be used read-only to expose issues, never as acceptance.
+**Overall verdict:** ☐ **NOT WALKED** — hw91 joined the hw88/89/90 failed-env class (cutover Step-07 half-pivot, unrecoverable; see Status log). Begins when a **fresh prov** carrying #3037/#3038/#3039 reconciles to a serving console with zero manual intervention. Failed environments may be used read-only to expose issues, never as acceptance.
 
 ---
 


### PR DESCRIPTION
The founder flagged the UAT ledger as 12h stale. It froze at the `hw91 provisioning started 21:10Z` snapshot while the zero-touch exposure run uncovered + fixed a stacked convergence-blocker chain and hw91 ultimately wedged as a failed env.

This update:
- **Build under test** — adds the 2026-06-04 layer (#3000/#3012/#3016–#3036/#3037/#3038/#3039/#3040).
- **Walk date + Overall verdict** (head + Summary) — hw91 is now an unrecoverable failed env (cutover Step-07 half-pivot); the walk needs a fresh prov.
- **New Status log table** — the ordered blockers hw91 exposed, each with its catalog-source fix, + the four UAT issues' code-complete/awaiting-walk state.

No TC rows changed — none have been walked (every surface returns HTTP `000`; gateway never bound).

Refs #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)