### PR TITLE
fix(vcluster): exportKubeConfig.server in-SAN name (drop .svc) — #3038 regression on hw92

### DIFF
--- a/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
@@ -63,7 +63,7 @@ spec:
   chart:
     spec:
       chart: bp-dmz-vcluster
-      version: 0.2.2
+      version: 0.2.3
       sourceRef:
         kind: HelmRepository
         name: bp-dmz-vcluster

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -70,7 +70,7 @@ spec:
   chart:
     spec:
       chart: bp-mgmt-vcluster
-      version: 0.2.3
+      version: 0.2.4
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
@@ -62,7 +62,7 @@ spec:
   chart:
     spec:
       chart: bp-rtz-vcluster
-      version: 0.2.3
+      version: 0.2.4
       sourceRef:
         kind: HelmRepository
         name: bp-rtz-vcluster

--- a/platform/bp-dmz-vcluster/blueprint.yaml
+++ b/platform/bp-dmz-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.2
+  version: 0.2.3
   card:
     title: DMZ vCluster
     summary: |

--- a/platform/bp-dmz-vcluster/chart/Chart.yaml
+++ b/platform/bp-dmz-vcluster/chart/Chart.yaml
@@ -19,7 +19,7 @@ name: bp-dmz-vcluster
 # 0.2.0 + bp-rtz-vcluster 0.2.0). Picks up `sync.toHost.customResources`
 # schema so DMZ vCluster-placed charts that need cross-vCluster CR sync
 # can wire it in without a follow-up chart bump.
-version: 0.2.2
+version: 0.2.3
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign DMZ

--- a/platform/bp-dmz-vcluster/chart/values.yaml
+++ b/platform/bp-dmz-vcluster/chart/values.yaml
@@ -129,7 +129,14 @@ vcluster:
     # this Secret via HelmRelease.spec.kubeConfig and got
     # `dial tcp [::1]:8443: connection refused` on every vc-dmz-targeted
     # HR (dmz/bp-coraza), holding the bootstrap-kit health gate forever.
-    # The host-side service DNS is the correct dial target.
-    server: https://dmz-vcluster.dmz.svc:443
+    # The host-side service DNS is the correct dial target. NB use the
+    # `<svc>.<ns>` short form, NOT `<svc>.<ns>.svc` — the vcluster
+    # apiserver serving cert's SANs include `dmz-vcluster.dmz` +
+    # `dmz-vcluster` but NOT `dmz-vcluster.dmz.svc` (hw92 2026-06-04: the
+    # `.svc` form #3038 first used gave helm-controller `x509:
+    # certificate is valid for ... dmz-vcluster.dmz, not
+    # dmz-vcluster.dmz.svc`). `dmz-vcluster.dmz` resolves from
+    # flux-system via the `svc.cluster.local` search domain.
+    server: https://dmz-vcluster.dmz:443
     secret:
       name: vc-dmz

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.3
+  version: 0.2.4
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -35,7 +35,7 @@ name: bp-mgmt-vcluster
 # `<inner-ns>-x-mgmt`, the host's cnpg-operator reconciles it, and
 # the resulting Service is synced back into the vCluster's view via
 # the already-enabled `sync.toHost.services`.
-version: 0.2.3
+version: 0.2.4
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -230,6 +230,6 @@ vcluster:
     # host-cluster helm-controller / per-Sovereign Kustomizations that
     # consume the mirrored kubeconfig. Point at the host-side service
     # DNS before the first vc-mgmt-targeted HR trips over it.
-    server: https://mgmt-vcluster.mgmt.svc:443
+    server: https://mgmt-vcluster.mgmt:443
     secret:
       name: vc-mgmt

--- a/platform/bp-rtz-vcluster/blueprint.yaml
+++ b/platform/bp-rtz-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.3
+  version: 0.2.4
   card:
     title: RTZ vCluster
     summary: |

--- a/platform/bp-rtz-vcluster/chart/Chart.yaml
+++ b/platform/bp-rtz-vcluster/chart/Chart.yaml
@@ -20,7 +20,7 @@ name: bp-rtz-vcluster
 # RTZ vCluster hosts per-Org tenant Applications + Sandbox per DoD
 # §A4; both paths route CNPG provisioning through the host
 # cnpg-operator (G92.6 substrate per #2665) via this sync.
-version: 0.2.3
+version: 0.2.4
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign RTZ

--- a/platform/bp-rtz-vcluster/chart/values.yaml
+++ b/platform/bp-rtz-vcluster/chart/values.yaml
@@ -5,9 +5,9 @@
 
 catalystBlueprint:
   upstream:
-    chart: vcluster
-    version: "0.20.0"
-    repo: "https://charts.loft.sh"
+ (rtz/bp-sandbox). Point at the host-side service DNS.chart: vcluster
+ (rtz/bp-sandbox). Point at the host-side service DNS.version: "0.20.0"
+ (rtz/bp-sandbox). Point at the host-side service DNS.repo: "https://charts.loft.sh"
 
 global:
   imageRegistry: ""
@@ -34,95 +34,95 @@ rtzVcluster:
   # The RTZ vCluster pod MUST run on the region's own CP node so
   # tenant traffic never silently lands in a foreign region.
   nodeSelector:
-    regionLabelKey: "openova.io/region"
-    regionLabelValue: ""
+ (rtz/bp-sandbox). Point at the host-side service DNS.regionLabelKey: "openova.io/region"
+ (rtz/bp-sandbox). Point at the host-side service DNS.regionLabelValue: ""
 
   image:
-    repository: "harbor.openova.io/proxy-ghcr/loft-sh/vcluster"
-    tag: "0.21.0"
-    pullPolicy: "IfNotPresent"
+ (rtz/bp-sandbox). Point at the host-side service DNS.repository: "harbor.openova.io/proxy-ghcr/loft-sh/vcluster"
+ (rtz/bp-sandbox). Point at the host-side service DNS.tag: "0.21.0"
+ (rtz/bp-sandbox). Point at the host-side service DNS.pullPolicy: "IfNotPresent"
 
   # ── NetworkPolicy isolation baseline ──────────────────────────────
   # RTZ default-deny: tenant workloads only reach DMZ for outbound
   # routes. NO direct mgmt access (mgmt only lives on the primary —
   # MGMT calls cross-region via DMZ WG).
   networkPolicy:
-    enabled: true
-    allowedIngressNamespaces:
-      - dmz     # always present on the same region
-    allowWorldIngress: false   # tenant pods never face world directly
+ (rtz/bp-sandbox). Point at the host-side service DNS.enabled: true
+ (rtz/bp-sandbox). Point at the host-side service DNS.allowedIngressNamespaces:
+ (rtz/bp-sandbox). Point at the host-side service DNS.  - dmz     # always present on the same region
+ (rtz/bp-sandbox). Point at the host-side service DNS.allowWorldIngress: false   # tenant pods never face world directly
 
 vcluster:
   controlPlane:
-    distro:
-      k8s:
-        enabled: true
-    backingStore:
-      database:
-        embedded:
-          enabled: true
-    statefulSet:
-      scheduling:
-        nodeSelector: {}
-      image:
-        registry: harbor.openova.io
-        repository: proxy-ghcr/loft-sh/vcluster
-        tag: "0.21.0"
-      resources:
-        requests:
-          cpu: "200m"
-          memory: "384Mi"
-        limits:
-          cpu: "2"
-          memory: "1Gi"
-      persistence:
-        volumeClaim:
-          enabled: true
-          size: "5Gi"
-          storageClass: "local-path"
-    service:
-      enabled: true
-      spec:
-        type: ClusterIP
+ (rtz/bp-sandbox). Point at the host-side service DNS.distro:
+ (rtz/bp-sandbox). Point at the host-side service DNS.  k8s:
+ (rtz/bp-sandbox). Point at the host-side service DNS.    enabled: true
+ (rtz/bp-sandbox). Point at the host-side service DNS.backingStore:
+ (rtz/bp-sandbox). Point at the host-side service DNS.  database:
+ (rtz/bp-sandbox). Point at the host-side service DNS.    embedded:
+ (rtz/bp-sandbox). Point at the host-side service DNS.      enabled: true
+ (rtz/bp-sandbox). Point at the host-side service DNS.statefulSet:
+ (rtz/bp-sandbox). Point at the host-side service DNS.  scheduling:
+ (rtz/bp-sandbox). Point at the host-side service DNS.    nodeSelector: {}
+ (rtz/bp-sandbox). Point at the host-side service DNS.  image:
+ (rtz/bp-sandbox). Point at the host-side service DNS.    registry: harbor.openova.io
+ (rtz/bp-sandbox). Point at the host-side service DNS.    repository: proxy-ghcr/loft-sh/vcluster
+ (rtz/bp-sandbox). Point at the host-side service DNS.    tag: "0.21.0"
+ (rtz/bp-sandbox). Point at the host-side service DNS.  resources:
+ (rtz/bp-sandbox). Point at the host-side service DNS.    requests:
+ (rtz/bp-sandbox). Point at the host-side service DNS.      cpu: "200m"
+ (rtz/bp-sandbox). Point at the host-side service DNS.      memory: "384Mi"
+ (rtz/bp-sandbox). Point at the host-side service DNS.    limits:
+ (rtz/bp-sandbox). Point at the host-side service DNS.      cpu: "2"
+ (rtz/bp-sandbox). Point at the host-side service DNS.      memory: "1Gi"
+ (rtz/bp-sandbox). Point at the host-side service DNS.  persistence:
+ (rtz/bp-sandbox). Point at the host-side service DNS.    volumeClaim:
+ (rtz/bp-sandbox). Point at the host-side service DNS.      enabled: true
+ (rtz/bp-sandbox). Point at the host-side service DNS.      size: "5Gi"
+ (rtz/bp-sandbox). Point at the host-side service DNS.      storageClass: "local-path"
+ (rtz/bp-sandbox). Point at the host-side service DNS.service:
+ (rtz/bp-sandbox). Point at the host-side service DNS.  enabled: true
+ (rtz/bp-sandbox). Point at the host-side service DNS.  spec:
+ (rtz/bp-sandbox). Point at the host-side service DNS.    type: ClusterIP
 
   sync:
-    toHost:
-      services:
-        enabled: true
-      ingresses:
-        enabled: false
-      persistentVolumeClaims:
-        enabled: true
-      configMaps:
-        enabled: true
-      secrets:
-        enabled: true
-      # G92.5 #2664 (2026-06-01) — CNPG `Cluster` CR sync vCluster → host.
-      # Mirrors the policy bp-mgmt-vcluster 0.2.1 ships (PR #2692). The
-      # RTZ vCluster hosts per-Org tenant Applications + Sandbox per
-      # docs/SOVEREIGN-MULTI-REGION-DOD.md §A4; both paths route
-      # PostgreSQL provisioning through the host cnpg-operator (G92.6
-      # substrate per #2665) via this sync policy:
-      #
-      #   - Tenant Applications: application-controller (G92.1 #2660,
-      #     PR #2674) renders the per-Application HR with
-      #     placementSchema.vcluster=rtz; the chart's CNPG Cluster CR
-      #     lands in vCluster's apiserver and reflects to host via
-      #     this policy.
-      #   - Sandbox: sandbox-controller's per-Sandbox CNPG Cluster CR
-      #     dispatch (slot 19a `sandbox.db.provision` block, D31
-      #     active-hot-standby aware) lands in vCluster, reflects to
-      #     host the same way.
-      customResources:
-        clusters.postgresql.cnpg.io:
-          enabled: true
-        poolers.postgresql.cnpg.io:
-          enabled: true
-        scheduledbackups.postgresql.cnpg.io:
-          enabled: true
-    fromHost:
-      ingressClasses:
-        enabled: true
+ (rtz/bp-sandbox). Point at the host-side service DNS.toHost:
+ (rtz/bp-sandbox). Point at the host-side service DNS.  services:
+ (rtz/bp-sandbox). Point at the host-side service DNS.    enabled: true
+ (rtz/bp-sandbox). Point at the host-side service DNS.  ingresses:
+ (rtz/bp-sandbox). Point at the host-side service DNS.    enabled: false
+ (rtz/bp-sandbox). Point at the host-side service DNS.  persistentVolumeClaims:
+ (rtz/bp-sandbox). Point at the host-side service DNS.    enabled: true
+ (rtz/bp-sandbox). Point at the host-side service DNS.  configMaps:
+ (rtz/bp-sandbox). Point at the host-side service DNS.    enabled: true
+ (rtz/bp-sandbox). Point at the host-side service DNS.  secrets:
+ (rtz/bp-sandbox). Point at the host-side service DNS.    enabled: true
+ (rtz/bp-sandbox). Point at the host-side service DNS.  # G92.5 #2664 (2026-06-01) — CNPG `Cluster` CR sync vCluster → host.
+ (rtz/bp-sandbox). Point at the host-side service DNS.  # Mirrors the policy bp-mgmt-vcluster 0.2.1 ships (PR #2692). The
+ (rtz/bp-sandbox). Point at the host-side service DNS.  # RTZ vCluster hosts per-Org tenant Applications + Sandbox per
+ (rtz/bp-sandbox). Point at the host-side service DNS.  # docs/SOVEREIGN-MULTI-REGION-DOD.md §A4; both paths route
+ (rtz/bp-sandbox). Point at the host-side service DNS.  # PostgreSQL provisioning through the host cnpg-operator (G92.6
+ (rtz/bp-sandbox). Point at the host-side service DNS.  # substrate per #2665) via this sync policy:
+ (rtz/bp-sandbox). Point at the host-side service DNS.  #
+ (rtz/bp-sandbox). Point at the host-side service DNS.  #   - Tenant Applications: application-controller (G92.1 #2660,
+ (rtz/bp-sandbox). Point at the host-side service DNS.  #     PR #2674) renders the per-Application HR with
+ (rtz/bp-sandbox). Point at the host-side service DNS.  #     placementSchema.vcluster=rtz; the chart's CNPG Cluster CR
+ (rtz/bp-sandbox). Point at the host-side service DNS.  #     lands in vCluster's apiserver and reflects to host via
+ (rtz/bp-sandbox). Point at the host-side service DNS.  #     this policy.
+ (rtz/bp-sandbox). Point at the host-side service DNS.  #   - Sandbox: sandbox-controller's per-Sandbox CNPG Cluster CR
+ (rtz/bp-sandbox). Point at the host-side service DNS.  #     dispatch (slot 19a `sandbox.db.provision` block, D31
+ (rtz/bp-sandbox). Point at the host-side service DNS.  #     active-hot-standby aware) lands in vCluster, reflects to
+ (rtz/bp-sandbox). Point at the host-side service DNS.  #     host the same way.
+ (rtz/bp-sandbox). Point at the host-side service DNS.  customResources:
+ (rtz/bp-sandbox). Point at the host-side service DNS.    clusters.postgresql.cnpg.io:
+ (rtz/bp-sandbox). Point at the host-side service DNS.      enabled: true
+ (rtz/bp-sandbox). Point at the host-side service DNS.    poolers.postgresql.cnpg.io:
+ (rtz/bp-sandbox). Point at the host-side service DNS.      enabled: true
+ (rtz/bp-sandbox). Point at the host-side service DNS.    scheduledbackups.postgresql.cnpg.io:
+ (rtz/bp-sandbox). Point at the host-side service DNS.      enabled: true
+ (rtz/bp-sandbox). Point at the host-side service DNS.fromHost:
+ (rtz/bp-sandbox). Point at the host-side service DNS.  ingressClasses:
+ (rtz/bp-sandbox). Point at the host-side service DNS.    enabled: true
 
   # Writes a host-namespace Secret named `vc-rtz` containing a kubeconfig
   # for the vCluster's apiserver. The Sovereign-side handler
@@ -131,11 +131,11 @@ vcluster:
   # `rtz-vcluster-kubeconfig` so per-Sovereign Flux Kustomization CRs
   # can reconcile RTZ-vCluster-targeted resources.
   exportKubeConfig:
-    context: vcluster
-    # hw91 2026-06-04: same defect as bp-dmz-vcluster — the default
-    # exported server is `https://localhost:8443`, unusable by the
-    # host-cluster helm-controller that reconciles vc-rtz-targeted HRs
-    # (rtz/bp-sandbox). Point at the host-side service DNS.
-    server: https://rtz-vcluster.rtz.svc:443
-    secret:
-      name: vc-rtz
+ (rtz/bp-sandbox). Point at the host-side service DNS.context: vcluster
+ (rtz/bp-sandbox). Point at the host-side service DNS.# hw91 2026-06-04: same defect as bp-dmz-vcluster — the default
+ (rtz/bp-sandbox). Point at the host-side service DNS.# exported server is `https://localhost:8443`, unusable by the
+ (rtz/bp-sandbox). Point at the host-side service DNS.# host-cluster helm-controller that reconciles vc-rtz-targeted HRs
+ (rtz/bp-sandbox). Point at the host-side service DNS.# (rtz/bp-sandbox). Point at the host-side service DNS.
+ (rtz/bp-sandbox). Point at the host-side service DNS.server: https://rtz-vcluster.rtz:443
+ (rtz/bp-sandbox). Point at the host-side service DNS.secret:
+ (rtz/bp-sandbox). Point at the host-side service DNS.  name: vc-rtz

--- a/platform/bp-rtz-vcluster/chart/values.yaml
+++ b/platform/bp-rtz-vcluster/chart/values.yaml
@@ -5,9 +5,9 @@
 
 catalystBlueprint:
   upstream:
- (rtz/bp-sandbox). Point at the host-side service DNS.chart: vcluster
- (rtz/bp-sandbox). Point at the host-side service DNS.version: "0.20.0"
- (rtz/bp-sandbox). Point at the host-side service DNS.repo: "https://charts.loft.sh"
+    chart: vcluster
+    version: "0.20.0"
+    repo: "https://charts.loft.sh"
 
 global:
   imageRegistry: ""
@@ -34,95 +34,95 @@ rtzVcluster:
   # The RTZ vCluster pod MUST run on the region's own CP node so
   # tenant traffic never silently lands in a foreign region.
   nodeSelector:
- (rtz/bp-sandbox). Point at the host-side service DNS.regionLabelKey: "openova.io/region"
- (rtz/bp-sandbox). Point at the host-side service DNS.regionLabelValue: ""
+    regionLabelKey: "openova.io/region"
+    regionLabelValue: ""
 
   image:
- (rtz/bp-sandbox). Point at the host-side service DNS.repository: "harbor.openova.io/proxy-ghcr/loft-sh/vcluster"
- (rtz/bp-sandbox). Point at the host-side service DNS.tag: "0.21.0"
- (rtz/bp-sandbox). Point at the host-side service DNS.pullPolicy: "IfNotPresent"
+    repository: "harbor.openova.io/proxy-ghcr/loft-sh/vcluster"
+    tag: "0.21.0"
+    pullPolicy: "IfNotPresent"
 
   # ── NetworkPolicy isolation baseline ──────────────────────────────
   # RTZ default-deny: tenant workloads only reach DMZ for outbound
   # routes. NO direct mgmt access (mgmt only lives on the primary —
   # MGMT calls cross-region via DMZ WG).
   networkPolicy:
- (rtz/bp-sandbox). Point at the host-side service DNS.enabled: true
- (rtz/bp-sandbox). Point at the host-side service DNS.allowedIngressNamespaces:
- (rtz/bp-sandbox). Point at the host-side service DNS.  - dmz     # always present on the same region
- (rtz/bp-sandbox). Point at the host-side service DNS.allowWorldIngress: false   # tenant pods never face world directly
+    enabled: true
+    allowedIngressNamespaces:
+      - dmz     # always present on the same region
+    allowWorldIngress: false   # tenant pods never face world directly
 
 vcluster:
   controlPlane:
- (rtz/bp-sandbox). Point at the host-side service DNS.distro:
- (rtz/bp-sandbox). Point at the host-side service DNS.  k8s:
- (rtz/bp-sandbox). Point at the host-side service DNS.    enabled: true
- (rtz/bp-sandbox). Point at the host-side service DNS.backingStore:
- (rtz/bp-sandbox). Point at the host-side service DNS.  database:
- (rtz/bp-sandbox). Point at the host-side service DNS.    embedded:
- (rtz/bp-sandbox). Point at the host-side service DNS.      enabled: true
- (rtz/bp-sandbox). Point at the host-side service DNS.statefulSet:
- (rtz/bp-sandbox). Point at the host-side service DNS.  scheduling:
- (rtz/bp-sandbox). Point at the host-side service DNS.    nodeSelector: {}
- (rtz/bp-sandbox). Point at the host-side service DNS.  image:
- (rtz/bp-sandbox). Point at the host-side service DNS.    registry: harbor.openova.io
- (rtz/bp-sandbox). Point at the host-side service DNS.    repository: proxy-ghcr/loft-sh/vcluster
- (rtz/bp-sandbox). Point at the host-side service DNS.    tag: "0.21.0"
- (rtz/bp-sandbox). Point at the host-side service DNS.  resources:
- (rtz/bp-sandbox). Point at the host-side service DNS.    requests:
- (rtz/bp-sandbox). Point at the host-side service DNS.      cpu: "200m"
- (rtz/bp-sandbox). Point at the host-side service DNS.      memory: "384Mi"
- (rtz/bp-sandbox). Point at the host-side service DNS.    limits:
- (rtz/bp-sandbox). Point at the host-side service DNS.      cpu: "2"
- (rtz/bp-sandbox). Point at the host-side service DNS.      memory: "1Gi"
- (rtz/bp-sandbox). Point at the host-side service DNS.  persistence:
- (rtz/bp-sandbox). Point at the host-side service DNS.    volumeClaim:
- (rtz/bp-sandbox). Point at the host-side service DNS.      enabled: true
- (rtz/bp-sandbox). Point at the host-side service DNS.      size: "5Gi"
- (rtz/bp-sandbox). Point at the host-side service DNS.      storageClass: "local-path"
- (rtz/bp-sandbox). Point at the host-side service DNS.service:
- (rtz/bp-sandbox). Point at the host-side service DNS.  enabled: true
- (rtz/bp-sandbox). Point at the host-side service DNS.  spec:
- (rtz/bp-sandbox). Point at the host-side service DNS.    type: ClusterIP
+    distro:
+      k8s:
+        enabled: true
+    backingStore:
+      database:
+        embedded:
+          enabled: true
+    statefulSet:
+      scheduling:
+        nodeSelector: {}
+      image:
+        registry: harbor.openova.io
+        repository: proxy-ghcr/loft-sh/vcluster
+        tag: "0.21.0"
+      resources:
+        requests:
+          cpu: "200m"
+          memory: "384Mi"
+        limits:
+          cpu: "2"
+          memory: "1Gi"
+      persistence:
+        volumeClaim:
+          enabled: true
+          size: "5Gi"
+          storageClass: "local-path"
+    service:
+      enabled: true
+      spec:
+        type: ClusterIP
 
   sync:
- (rtz/bp-sandbox). Point at the host-side service DNS.toHost:
- (rtz/bp-sandbox). Point at the host-side service DNS.  services:
- (rtz/bp-sandbox). Point at the host-side service DNS.    enabled: true
- (rtz/bp-sandbox). Point at the host-side service DNS.  ingresses:
- (rtz/bp-sandbox). Point at the host-side service DNS.    enabled: false
- (rtz/bp-sandbox). Point at the host-side service DNS.  persistentVolumeClaims:
- (rtz/bp-sandbox). Point at the host-side service DNS.    enabled: true
- (rtz/bp-sandbox). Point at the host-side service DNS.  configMaps:
- (rtz/bp-sandbox). Point at the host-side service DNS.    enabled: true
- (rtz/bp-sandbox). Point at the host-side service DNS.  secrets:
- (rtz/bp-sandbox). Point at the host-side service DNS.    enabled: true
- (rtz/bp-sandbox). Point at the host-side service DNS.  # G92.5 #2664 (2026-06-01) — CNPG `Cluster` CR sync vCluster → host.
- (rtz/bp-sandbox). Point at the host-side service DNS.  # Mirrors the policy bp-mgmt-vcluster 0.2.1 ships (PR #2692). The
- (rtz/bp-sandbox). Point at the host-side service DNS.  # RTZ vCluster hosts per-Org tenant Applications + Sandbox per
- (rtz/bp-sandbox). Point at the host-side service DNS.  # docs/SOVEREIGN-MULTI-REGION-DOD.md §A4; both paths route
- (rtz/bp-sandbox). Point at the host-side service DNS.  # PostgreSQL provisioning through the host cnpg-operator (G92.6
- (rtz/bp-sandbox). Point at the host-side service DNS.  # substrate per #2665) via this sync policy:
- (rtz/bp-sandbox). Point at the host-side service DNS.  #
- (rtz/bp-sandbox). Point at the host-side service DNS.  #   - Tenant Applications: application-controller (G92.1 #2660,
- (rtz/bp-sandbox). Point at the host-side service DNS.  #     PR #2674) renders the per-Application HR with
- (rtz/bp-sandbox). Point at the host-side service DNS.  #     placementSchema.vcluster=rtz; the chart's CNPG Cluster CR
- (rtz/bp-sandbox). Point at the host-side service DNS.  #     lands in vCluster's apiserver and reflects to host via
- (rtz/bp-sandbox). Point at the host-side service DNS.  #     this policy.
- (rtz/bp-sandbox). Point at the host-side service DNS.  #   - Sandbox: sandbox-controller's per-Sandbox CNPG Cluster CR
- (rtz/bp-sandbox). Point at the host-side service DNS.  #     dispatch (slot 19a `sandbox.db.provision` block, D31
- (rtz/bp-sandbox). Point at the host-side service DNS.  #     active-hot-standby aware) lands in vCluster, reflects to
- (rtz/bp-sandbox). Point at the host-side service DNS.  #     host the same way.
- (rtz/bp-sandbox). Point at the host-side service DNS.  customResources:
- (rtz/bp-sandbox). Point at the host-side service DNS.    clusters.postgresql.cnpg.io:
- (rtz/bp-sandbox). Point at the host-side service DNS.      enabled: true
- (rtz/bp-sandbox). Point at the host-side service DNS.    poolers.postgresql.cnpg.io:
- (rtz/bp-sandbox). Point at the host-side service DNS.      enabled: true
- (rtz/bp-sandbox). Point at the host-side service DNS.    scheduledbackups.postgresql.cnpg.io:
- (rtz/bp-sandbox). Point at the host-side service DNS.      enabled: true
- (rtz/bp-sandbox). Point at the host-side service DNS.fromHost:
- (rtz/bp-sandbox). Point at the host-side service DNS.  ingressClasses:
- (rtz/bp-sandbox). Point at the host-side service DNS.    enabled: true
+    toHost:
+      services:
+        enabled: true
+      ingresses:
+        enabled: false
+      persistentVolumeClaims:
+        enabled: true
+      configMaps:
+        enabled: true
+      secrets:
+        enabled: true
+      # G92.5 #2664 (2026-06-01) — CNPG `Cluster` CR sync vCluster → host.
+      # Mirrors the policy bp-mgmt-vcluster 0.2.1 ships (PR #2692). The
+      # RTZ vCluster hosts per-Org tenant Applications + Sandbox per
+      # docs/SOVEREIGN-MULTI-REGION-DOD.md §A4; both paths route
+      # PostgreSQL provisioning through the host cnpg-operator (G92.6
+      # substrate per #2665) via this sync policy:
+      #
+      #   - Tenant Applications: application-controller (G92.1 #2660,
+      #     PR #2674) renders the per-Application HR with
+      #     placementSchema.vcluster=rtz; the chart's CNPG Cluster CR
+      #     lands in vCluster's apiserver and reflects to host via
+      #     this policy.
+      #   - Sandbox: sandbox-controller's per-Sandbox CNPG Cluster CR
+      #     dispatch (slot 19a `sandbox.db.provision` block, D31
+      #     active-hot-standby aware) lands in vCluster, reflects to
+      #     host the same way.
+      customResources:
+        clusters.postgresql.cnpg.io:
+          enabled: true
+        poolers.postgresql.cnpg.io:
+          enabled: true
+        scheduledbackups.postgresql.cnpg.io:
+          enabled: true
+    fromHost:
+      ingressClasses:
+        enabled: true
 
   # Writes a host-namespace Secret named `vc-rtz` containing a kubeconfig
   # for the vCluster's apiserver. The Sovereign-side handler
@@ -131,11 +131,11 @@ vcluster:
   # `rtz-vcluster-kubeconfig` so per-Sovereign Flux Kustomization CRs
   # can reconcile RTZ-vCluster-targeted resources.
   exportKubeConfig:
- (rtz/bp-sandbox). Point at the host-side service DNS.context: vcluster
- (rtz/bp-sandbox). Point at the host-side service DNS.# hw91 2026-06-04: same defect as bp-dmz-vcluster — the default
- (rtz/bp-sandbox). Point at the host-side service DNS.# exported server is `https://localhost:8443`, unusable by the
- (rtz/bp-sandbox). Point at the host-side service DNS.# host-cluster helm-controller that reconciles vc-rtz-targeted HRs
- (rtz/bp-sandbox). Point at the host-side service DNS.# (rtz/bp-sandbox). Point at the host-side service DNS.
- (rtz/bp-sandbox). Point at the host-side service DNS.server: https://rtz-vcluster.rtz:443
- (rtz/bp-sandbox). Point at the host-side service DNS.secret:
- (rtz/bp-sandbox). Point at the host-side service DNS.  name: vc-rtz
+    context: vcluster
+    # hw91 2026-06-04: same defect as bp-dmz-vcluster — the default
+    # exported server is `https://localhost:8443`, unusable by the
+    # host-cluster helm-controller that reconciles vc-rtz-targeted HRs
+    # (rtz/bp-sandbox). Point at the host-side service DNS.
+    server: https://rtz-vcluster.rtz:443
+    secret:
+      name: vc-rtz


### PR DESCRIPTION
**Live regression caught on hw92.** PR #3038 set exportKubeConfig.server to `https://<name>-vcluster.<ns>.svc:443`, but the vcluster apiserver cert SANs do not include the `.svc` form:

```
x509: certificate is valid for ..., dmz-vcluster, dmz-vcluster.dmz, ..., not dmz-vcluster.dmz.svc
```

So #3038 swapped the `localhost:8443` connection-refused for a TLS SAN mismatch — `dmz/bp-coraza` + `rtz/bp-sandbox` stayed False, wedging bootstrap-kit health at 47/56 → no gateway → `console=000`.

The cert SANs DO include `<svc>` and `<svc>.<ns>` (the error itself confirms `dmz-vcluster.dmz`). Fix: drop `.svc` → `https://<name>-vcluster.<ns>:443` — in the SAN set, and resolvable from the flux-system helm-controller pod via the `svc.cluster.local` search domain. dmz 0.2.3 / rtz 0.2.4 / mgmt 0.2.4 (Chart + blueprint + slot pins).

hw92 is still on GitHub source (cutover waits on bp-gitea), so it self-heals zero-touch from this fix.

Refs #2989