### PR TITLE
fix(vcluster-HRs): storageNamespace=targetNamespace for bp-coraza + bp-sandbox

### DIFF
--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -68,6 +68,13 @@ spec:
   releaseName: sandbox
   # targetNamespace = inner namespace INSIDE the rtz vCluster.
   targetNamespace: catalyst-system
+  # hw92 2026-06-04: pin storageNamespace = targetNamespace, else
+  # helm-controller defaults it to the HR's own namespace (`rtz`) and
+  # fails `namespaces "rtz" not found` storing the release inside the
+  # vCluster (createNamespace only creates the target `catalyst-system`).
+  # Same latent defect as bp-coraza, masked until the #3038/#3043
+  # vCluster-kubeconfig SAN fix made the apiserver reachable.
+  storageNamespace: catalyst-system
   # vCluster pivot — helm-controller installs the chart inside rtz
   # vCluster (Flux v2 HelmRelease v2 contract). G92.5 #2664.
   kubeConfig:

--- a/clusters/_template/bootstrap-kit/35-coraza.yaml
+++ b/clusters/_template/bootstrap-kit/35-coraza.yaml
@@ -60,6 +60,16 @@ spec:
   releaseName: coraza
   # targetNamespace = inner namespace INSIDE the dmz vCluster.
   targetNamespace: coraza
+  # hw92 2026-06-04: storageNamespace MUST be set, else helm-controller
+  # defaults it to the HR's own namespace (`dmz`) and tries to store the
+  # release secret in a `dmz` namespace INSIDE the vCluster — which
+  # createNamespace does NOT create (it only creates the target
+  # `coraza`). Result: `Helm install failed ... namespaces "dmz" not
+  # found`. This was masked on every prior prov because the vCluster
+  # kubeconfig server was never reachable (localhost → SAN-mismatch,
+  # #3038/#3043), so bp-coraza never reached the release-store stage.
+  # Pin storage to the (created) target namespace = vanilla-helm behaviour.
+  storageNamespace: coraza
   # vCluster pivot — helm-controller installs the chart inside dmz
   # vCluster (Flux v2 HelmRelease v2 contract). G92.4 #2663.
   kubeConfig:


### PR DESCRIPTION
Caught live on hw92 once #3043 made the dmz/rtz vCluster apiservers reachable for the first time. bp-coraza failed `namespaces "dmz" not found`: helm-controller defaults `storageNamespace` to the HR's own namespace (`dmz`/`rtz`) and stores the release secret there inside the vCluster, but `createNamespace` only provisions the *target* (`coraza`/`catalyst-system`). Never seen before because the vCluster kubeconfig was never reachable (localhost → .svc SAN-mismatch) so neither HR reached the release-store stage.

Fix: `storageNamespace: <target>`. Slot-file HR change → applies via Flux; hw92 self-heals (still on GitHub source).

Refs #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)