### PR TITLE
fix(kyverno): webhook-gate timeout 300s→1200s + slot 15m→30m — slow-egress fresh-prov Stall

### DIFF
--- a/clusters/_template/bootstrap-kit/27-kyverno.yaml
+++ b/clusters/_template/bootstrap-kit/27-kyverno.yaml
@@ -68,7 +68,7 @@ spec:
       # closes META-AUDIT 1 sub-class 3 — kyverno admission webhook
       # registered before kyverno-svc Pod ready blocks own Secret CREATE
       # via failurePolicy: Fail. Verified deadlock on hw62 v14 06:11Z.
-      version: 1.3.3
+      version: 1.3.4
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno
@@ -80,12 +80,12 @@ spec:
   # past the point where downstream HRs could legitimately reconcile.
   # disableWait lets Flux mark this Ready as soon as manifests apply.
   install:
-    timeout: 15m
+    timeout: 30m
     disableWait: true
     remediation:
       retries: -1
   upgrade:
-    timeout: 15m
+    timeout: 30m
     disableWait: true
     remediation:
       retries: 3

--- a/platform/kyverno/blueprint.yaml
+++ b/platform/kyverno/blueprint.yaml
@@ -8,7 +8,7 @@ spec:
   # 1.3.0 (TBD-V53 #2128): Cold-start race fix — cert-manager-issued TLS
   # + extraInitContainer that blocks main container until the secret is
   # populated. See platform/kyverno/chart/Chart.yaml for the full rationale.
-  version: 1.3.3
+  version: 1.3.4
   card:
     title: Kyverno
     family: guardian

--- a/platform/kyverno/chart/Chart.yaml
+++ b/platform/kyverno/chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # an extraInitContainer blocks the main container until the secret has a
 # populated tls.crt. Eliminates the apiserver→webhook TLS handshake EOF
 # that wedged bootstrap-kit on every fresh-prov Sovereign.
-version: 1.3.3
+version: 1.3.4
 appVersion: "v1.18.0"
 keywords: [catalyst, blueprint, kyverno, policy, admission, security]
 maintainers:

--- a/platform/kyverno/chart/templates/webhook-gate-hook.yaml
+++ b/platform/kyverno/chart/templates/webhook-gate-hook.yaml
@@ -75,7 +75,12 @@ META-AUDIT 1 catalog.
 {{- $svcName := (($gate.service).name) | default "kyverno-svc" -}}
 {{- $svcNs := (($gate.service).namespace) | default "kyverno" -}}
 {{- $secretName := $gate.tlsSecretName | default "kyverno-svc.kyverno.svc.kyverno-tls-pair" -}}
-{{- $timeout := $gate.timeoutSeconds | default 300 -}}
+{{- /* hw93 2026-06-04: 300s was too short on a throttled-egress fresh prov —
+       kyverno's image + cert-manager Secret took ~15 min, the gate timed out,
+       backoffLimit:0 → hook failed → upgrade failed → MissingRollbackTarget →
+       HR Stalled → bootstrap-kit health failed → sovereign-tls → console 000.
+       Raised to 1200s (20 min) to tolerate slow image pulls on cold provs. */ -}}
+{{- $timeout := $gate.timeoutSeconds | default 1200 -}}
 {{- $interval := $gate.intervalSeconds | default 2 -}}
 {{- $image := $gate.image | default "bitnamilegacy/kubectl:1.30.7" -}}
 {{- $pullPolicy := $gate.imagePullPolicy | default "IfNotPresent" -}}


### PR DESCRIPTION
**Live blocker on hw93** (first prov to reach this layer). bp-kyverno post-upgrade `webhook-gate` hook (`backoffLimit:0`, 300s budget) timed out because kyverno's image + cert took ~15 min through the throttled HCS egress → hook failed → upgrade failed → `MissingRollbackTarget` → **HR Stalled** → bootstrap-kit health failed → sovereign-tls → `console=000`.

Kyverno is actually healthy; the gate just timed out. Fix: gate 300→1200s, slot timeout 15m→30m, bp-kyverno 1.3.3→1.3.4 (digest reset clears the Stall; re-run gate passes instantly). hw93 self-heals (GitHub source).

Refs #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)