### PR TITLE
fix(cutover): gate auto-trigger on handover completion — stop fresh-prov registry half-pivot (#3052)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -435,7 +435,10 @@ spec:
       # 0.1.51 (#2951 / #2940 ATTACK#9): Step 10 Phase-1c asserts all
       # four image HRs (3 vClusters + sso-bridge) are off harbor.openova.io
       # post-pivot; Job exits 1 on any residual mothership-Harbor tether.
-      version: 0.1.53
+      # 0.1.54 (#3052): auto-trigger Job handles catalyst-api's new HTTP
+      # 425 handover-completion gate — the cutover no longer half-pivots
+      # the registry at bootstrap on a fresh, un-handed-over prov.
+      version: 0.1.54
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.53
+  version: 0.1.54
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -402,7 +402,19 @@ name: bp-self-sovereign-cutover
 # harbor.openova.io — so the cutover automation itself proves the
 # mothership-Harbor untether instead of leaving a manual post-hoc grep
 # as the only acceptance gate.
-version: 0.1.53
+#
+# 0.1.54 (#3052): auto-trigger Job handles HTTP 425 from catalyst-api's
+# new handover-completion gate. On a FRESH prov the post-install hook
+# fires at bootstrap — long before handover — and without the gate the
+# cutover half-pivoted the registry (rewrote ghcr-pull → local Harbor)
+# while Flux still pulled the catalog from ghcr.io and the local Harbor
+# wasn't serving yet, breaking every fresh chart pull and wedging
+# bootstrap-kit (hw93 2026-06-04: bp-kyverno 1.3.4 SourceNotReady "no
+# auth config for ghcr.io", console 000). catalyst-api now returns 425
+# until the tofu-phase0-archive is sealed at handover; this Job treats
+# 425 as the EXPECTED benign pre-handover path (clear log, exit 0). The
+# cutover still auto-fires post-handover (founder rule #933 preserved).
+version: 0.1.54
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/10-auto-trigger-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/10-auto-trigger-job.yaml
@@ -249,6 +249,20 @@ spec:
                   # failure. CTA still works via the operator session.
                   exit 0
                   ;;
+                425)
+                  # Handover-completion gate (catalyst-api
+                  # cutover_internal.go). On a FRESH prov this hook fires
+                  # at bootstrap — long before handover — and catalyst-api
+                  # correctly refuses to start the cutover engine until the
+                  # tofu-phase0-archive is sealed at handover. This is the
+                  # EXPECTED, BENIGN path on every fresh prov: it prevents
+                  # the registry half-pivot that used to wedge bootstrap-kit
+                  # (hw93 2026-06-04). The cutover auto-fires post-handover
+                  # when the same trigger is re-POSTed and the gate is open.
+                  echo "[auto-trigger] cutover deferred: this Sovereign has not been handed over yet (HTTP 425). EXPECTED pre-handover — no engine started; the cutover auto-fires once handover seals the tofu archive."
+                  cat /tmp/trigger.json 2>/dev/null || true
+                  exit 0
+                  ;;
                 *)
                   echo "[auto-trigger] unexpected status ${code}"
                   cat /tmp/trigger.json 2>/dev/null || true

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_internal.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_internal.go
@@ -20,7 +20,7 @@
 //
 // This file adds a SECOND endpoint:
 //
-//   POST /api/v1/internal/cutover/trigger
+//	POST /api/v1/internal/cutover/trigger
 //
 // …that lives OUTSIDE the RequireSession group and validates the
 // caller via a Kubernetes TokenReview against the bearer token
@@ -29,23 +29,23 @@
 // path (/var/run/secrets/kubernetes.io/serviceaccount/token) and
 // passes it on the request. The endpoint then:
 //
-//   1. Calls authentication.k8s.io/v1 TokenReview to validate the
-//      token bytes against the cluster's authentication chain. The
-//      apiserver returns the authenticated user (typically
-//      `system:serviceaccount:<ns>:<sa-name>`) plus a list of groups.
-//      This is the ONLY supported way to verify a bearer token came
-//      from a valid in-cluster ServiceAccount — manual JWT parsing
-//      would skip rotation, audience checking, and revocation.
+//  1. Calls authentication.k8s.io/v1 TokenReview to validate the
+//     token bytes against the cluster's authentication chain. The
+//     apiserver returns the authenticated user (typically
+//     `system:serviceaccount:<ns>:<sa-name>`) plus a list of groups.
+//     This is the ONLY supported way to verify a bearer token came
+//     from a valid in-cluster ServiceAccount — manual JWT parsing
+//     would skip rotation, audience checking, and revocation.
 //
-//   2. Checks the username matches the canonical cutover-runner SA:
-//      `system:serviceaccount:<ns>:bp-self-sovereign-cutover-runner`
-//      (override via CATALYST_INTERNAL_CUTOVER_SA_USERNAME for test
-//      and per-Sovereign re-naming).
+//  2. Checks the username matches the canonical cutover-runner SA:
+//     `system:serviceaccount:<ns>:bp-self-sovereign-cutover-runner`
+//     (override via CATALYST_INTERNAL_CUTOVER_SA_USERNAME for test
+//     and per-Sovereign re-naming).
 //
-//   3. Delegates to the same engine logic as HandleCutoverStart —
-//      idempotency, in-process running flag, and goroutine spawn are
-//      shared. The two endpoints are alternative entry points to the
-//      SAME state machine; the only difference is auth surface.
+//  3. Delegates to the same engine logic as HandleCutoverStart —
+//     idempotency, in-process running flag, and goroutine spawn are
+//     shared. The two endpoints are alternative entry points to the
+//     SAME state machine; the only difference is auth surface.
 //
 // Why not skip auth entirely for in-cluster callers
 // ─────────────────────────────────────────────────
@@ -73,20 +73,21 @@
 // ─────────────
 // Every value is runtime-overridable per docs/INVIOLABLE-PRINCIPLES.md #4:
 //
-//   CATALYST_INTERNAL_CUTOVER_SA_USERNAME
-//     Required SA username (e.g.
-//     "system:serviceaccount:catalyst:bp-self-sovereign-cutover-runner").
-//     Default = system:serviceaccount:<CATALYST_CUTOVER_NAMESPACE>:bp-self-sovereign-cutover-runner.
+//	CATALYST_INTERNAL_CUTOVER_SA_USERNAME
+//	  Required SA username (e.g.
+//	  "system:serviceaccount:catalyst:bp-self-sovereign-cutover-runner").
+//	  Default = system:serviceaccount:<CATALYST_CUTOVER_NAMESPACE>:bp-self-sovereign-cutover-runner.
 //
-//   CATALYST_INTERNAL_CUTOVER_SA_USERNAMES
-//     Optional comma-separated list of additional accepted SA usernames.
-//     Empty by default. Used for test fixtures and per-Sovereign
-//     re-naming. Both the singular and plural forms are honoured;
-//     either one matching is sufficient.
+//	CATALYST_INTERNAL_CUTOVER_SA_USERNAMES
+//	  Optional comma-separated list of additional accepted SA usernames.
+//	  Empty by default. Used for test fixtures and per-Sovereign
+//	  re-naming. Both the singular and plural forms are honoured;
+//	  either one matching is sufficient.
 package handler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -94,6 +95,8 @@ import (
 
 	authnv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
 )
 
 // Default suffix appended to the cutover namespace to compute the
@@ -107,6 +110,43 @@ const (
 	envInternalCutoverSAUsername  = "CATALYST_INTERNAL_CUTOVER_SA_USERNAME"
 	envInternalCutoverSAUsernames = "CATALYST_INTERNAL_CUTOVER_SA_USERNAMES"
 )
+
+// envRequireHandoverForCutover gates the in-cluster auto-trigger on
+// handover completion. See requireHandoverForCutover.
+const envRequireHandoverForCutover = "CATALYST_CUTOVER_REQUIRE_HANDOVER"
+
+// requireHandoverForCutover reports whether the in-cluster auto-trigger
+// must verify this Sovereign has been handed over before it starts the
+// cutover engine. Default TRUE (founder principle: the cutover is a
+// post-handover operation). Set CATALYST_CUTOVER_REQUIRE_HANDOVER=false
+// only for test fixtures or a deliberate operator-forced demo cutover on
+// a converged-but-not-yet-handed-over prov. Runtime-overridable per
+// docs/PRINCIPLES.md #4.
+func requireHandoverForCutover() bool {
+	return !strings.EqualFold(strings.TrimSpace(os.Getenv(envRequireHandoverForCutover)), "false")
+}
+
+// sovereignHandoverComplete reports whether THIS Sovereign has received
+// the Phase-0 OpenTofu archive from the mothership — the durable,
+// Sovereign-side signal that ownership has transferred. handover.go's
+// ReceiveTofuArchive seals it at secret/catalyst/tofu-phase0-archive
+// (KV-v2) on a successful handover POST; its ABSENCE means the Sovereign
+// is still soft-tethered (pre-handover). A nil OpenBao client (e.g.
+// Catalyst-Zero, which is never itself a cutover subject) reads as
+// not-handed-over so the gate stays closed.
+func (h *Handler) sovereignHandoverComplete(ctx context.Context) (bool, error) {
+	if h.openbao == nil {
+		return false, nil
+	}
+	data, err := h.openbao.GetKVv2(ctx, "secret", "catalyst/tofu-phase0-archive")
+	if err != nil {
+		if errors.Is(err, openbao.ErrSecretNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return len(data) > 0, nil
+}
 
 // expectedInternalCutoverUsernames returns the set of acceptable SA
 // usernames a TokenReview may resolve to. Order is:
@@ -258,7 +298,9 @@ func (h *Handler) HandleCutoverInternalTrigger(w http.ResponseWriter, r *http.Re
 	}
 
 	// Reuse the operator-side engine path. The state machine is
-	// identical regardless of which endpoint kicked it off.
+	// identical regardless of which endpoint kicked it off. The
+	// handover-completion gate lives inside runCutoverFromTrigger so an
+	// already-complete cutover still returns its idempotent 200 first.
 	h.runCutoverFromTrigger(w, r, deps, "internal")
 }
 
@@ -286,6 +328,51 @@ func (h *Handler) runCutoverFromTrigger(w http.ResponseWriter, r *http.Request, 
 		resp := buildCutoverStatusResponseFromMap(status, listStepNamesFromStatus(status))
 		writeJSON(w, http.StatusOK, resp)
 		return
+	}
+
+	// Handover-completion gate (fresh-prov registry half-pivot).
+	// ──────────────────────────────────────────────────────────
+	// The in-cluster auto-trigger (source="internal") is a Helm
+	// post-install hook on bp-self-sovereign-cutover, so it fires at
+	// chart-INSTALL time — which on a fresh prov is bootstrap, long
+	// before handover. Without this gate the cutover half-pivots the
+	// registry (rewrites the ghcr-pull Secret to the local Harbor) while
+	// Flux still pulls the catalog from GitHub (ghcr.io URLs) and the
+	// local Harbor is not yet serving — breaking every FRESH chart pull
+	// and wedging bootstrap-kit. Verified live hw93 2026-06-04: bp-kyverno
+	// 1.3.4 stuck SourceNotReady "no auth config for 'ghcr.io' in
+	// docker-registry Secret 'ghcr-pull'", cutover-egress-block-test
+	// Failed, console 000.
+	//
+	// The cutover is a POST-handover operation. The durable Sovereign-side
+	// handover marker is the tofu-phase0-archive secret, sealed in OpenBao
+	// by ReceiveTofuArchive ONLY when the mothership POSTs the archive at
+	// handover. Until it exists, refuse with 425 Too Early — which the
+	// auto-trigger Job treats as benign (its case-* arm exits 0, so the
+	// chart install completes and the HR goes Ready with NO engine start).
+	// Placed AFTER the cutoverComplete short-circuit so an already-done
+	// cutover keeps its idempotent 200. The operator CTA path is NOT
+	// routed here, so a human clicking "Achieve True Sovereignty" behind
+	// RequireSession is never gated — a deliberate post-handover action.
+	if source == "internal" && requireHandoverForCutover() {
+		handedOver, herr := h.sovereignHandoverComplete(r.Context())
+		if herr != nil {
+			writeJSON(w, http.StatusBadGateway, map[string]string{
+				"error":  "handover-check-failed",
+				"detail": herr.Error(),
+			})
+			return
+		}
+		if !handedOver {
+			h.log.Info("internal cutover trigger deferred: handover not complete",
+				"detail", "tofu-phase0-archive absent in OpenBao — Sovereign not yet handed over; auto-trigger is benign pre-handover",
+			)
+			writeJSON(w, http.StatusTooEarly, map[string]string{
+				"error":  "handover-incomplete",
+				"detail": "cutover deferred: this Sovereign has not been handed over yet (tofu-phase0-archive not present in OpenBao). The cutover auto-fires post-handover; deferring is expected and benign on a fresh prov.",
+			})
+			return
+		}
 	}
 
 	steps, err := listCutoverSteps(r.Context(), deps)

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_internal_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_internal_test.go
@@ -35,7 +35,24 @@ import (
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
 )
+
+// withHandoverArchive points the Handler's OpenBao client at a fake
+// server that serves the tofu-phase0-archive secret — i.e. simulates a
+// Sovereign that HAS been handed over, so the cutover handover-gate
+// (sovereignHandoverComplete) opens. Torn down at test end.
+func withHandoverArchive(t *testing.T, h *Handler) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// KV-v2 read envelope: {"data":{"data":{...}}}.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"data":{"archive":"dGVzdA==","sovereignFQDN":"hw-test.example.com"}}}`))
+	}))
+	t.Cleanup(srv.Close)
+	h.openbao = &openbao.Client{Addr: srv.URL, Token: "test-token", HTTP: srv.Client()}
+}
 
 // installTokenReviewReactor wires a reactor that approves any
 // TokenReview create call by returning Authenticated=true with the
@@ -80,6 +97,9 @@ func TestHandleCutoverInternalTrigger_HappyPath(t *testing.T) {
 	// — matches what TokenReview returns from the chart's mounted
 	// SA token in production.
 	installTokenReviewReactor(t, client, "system:serviceaccount:catalyst:bp-self-sovereign-cutover-runner")
+	// A handed-over Sovereign: the tofu-phase0-archive is sealed, so the
+	// handover-completion gate opens and the auto-trigger runs the engine.
+	withHandoverArchive(t, h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/internal/cutover/trigger", nil)
@@ -211,5 +231,74 @@ func TestHandleCutoverInternalTrigger_WrongMethodReturns405(t *testing.T) {
 	}
 	if got := rec.Header().Get("Allow"); got != "POST" {
 		t.Errorf("Allow header = %q, want POST", got)
+	}
+}
+
+// TestHandleCutoverInternalTrigger_DefersWhenNotHandedOver is the core
+// fresh-prov regression guard: a valid auto-trigger on a Sovereign that
+// has NOT been handed over (no tofu-phase0-archive in OpenBao) must
+// REFUSE to start the engine — 425 Too Early, zero Jobs created. Without
+// this gate the bootstrap auto-trigger half-pivots the registry and
+// wedges bootstrap-kit (hw93 2026-06-04).
+func TestHandleCutoverInternalTrigger_DefersWhenNotHandedOver(t *testing.T) {
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-01-gitea-mirror", "gitea-mirror", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+		makeCutoverStepCM("cutover-step-02-harbor-projects", "harbor-projects", 2, cutoverModeJob, minimalPodSpecYAML, ""),
+	}
+	h, client := fakeHandlerWithCutover(t, objs...)
+	installTokenReviewReactor(t, client, "system:serviceaccount:catalyst:bp-self-sovereign-cutover-runner")
+	// h.openbao is nil → sovereignHandoverComplete returns false → gate closed.
+
+	jobCreates := 0
+	client.PrependReactor("create", "jobs", func(_ clienttesting.Action) (bool, k8sruntime.Object, error) {
+		jobCreates++
+		return false, nil, nil
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/internal/cutover/trigger", nil)
+	req.Header.Set("Authorization", "Bearer fake-sa-token-bytes")
+	h.HandleCutoverInternalTrigger(rec, req)
+
+	if rec.Code != http.StatusTooEarly {
+		t.Fatalf("status = %d, want 425 (handover-incomplete); body=%s", rec.Code, rec.Body.String())
+	}
+	if jobCreates != 0 {
+		t.Errorf("created %d Jobs while handover incomplete, want 0 — that is the registry half-pivot", jobCreates)
+	}
+}
+
+// TestHandleCutoverInternalTrigger_EnvOverrideBypassesGate proves the
+// CATALYST_CUTOVER_REQUIRE_HANDOVER=false escape hatch lets a deliberate
+// forced-demo cutover run on a converged-but-not-handed-over prov.
+func TestHandleCutoverInternalTrigger_EnvOverrideBypassesGate(t *testing.T) {
+	t.Setenv(envRequireHandoverForCutover, "false")
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-01-gitea-mirror", "gitea-mirror", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+	}
+	h, client := fakeHandlerWithCutover(t, objs...)
+	installJobReactor(t, client, batchv1.JobComplete)
+	installTokenReviewReactor(t, client, "system:serviceaccount:catalyst:bp-self-sovereign-cutover-runner")
+	// openbao nil + env override=false → gate skipped, engine runs.
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/internal/cutover/trigger", nil)
+	req.Header.Set("Authorization", "Bearer fake-sa-token-bytes")
+	h.HandleCutoverInternalTrigger(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (gate bypassed by env); body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Drain the engine goroutine so it doesn't outlive the test.
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		bus := h.cutoverBusFor()
+		bus.mu.Lock()
+		running := bus.running
+		bus.mu.Unlock()
+		if !running {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
## What

Adds a **handover-completion gate** to catalyst-api's in-cluster cutover trigger so the sovereignty cutover can no longer fire at **bootstrap** on a fresh, un-handed-over prov.

## Why

`bp-self-sovereign-cutover`'s auto-trigger is a Helm **post-install hook** → it fires at chart-install time = **bootstrap**, long before handover (the chart header literally says *"Installs DORMANT"*; `trigger.auto: true` violated that). On hw93 (2026-06-04, fresh zero-touch prov) it half-pivoted the registry:

- rewrote the `ghcr-pull` Secret → local Harbor, but Flux (still pulling the catalog from GitHub with `ghcr.io` URLs) **reverted** the HelmRepository URL patches while the Secret (not Git-managed) **stuck** pivoted;
- net: Secret→Harbor, HelmRepos→`ghcr.io`, local Harbor not serving → every **fresh** chart pull failed. `bp-kyverno` 1.3.4 stuck `SourceNotReady "no auth config for 'ghcr.io'"`, `bootstrap-kit` never went Ready, console served `000`.

## How

- **`cutover_internal.go`** — `runCutoverFromTrigger` refuses the in-cluster auto-trigger (source `internal`) with **`425 Too Early`** unless `secret/catalyst/tofu-phase0-archive` exists in OpenBao (the durable Sovereign-side handover marker, sealed by `ReceiveTofuArchive` at handover). Placed *after* the `cutoverComplete` short-circuit so an already-done cutover keeps its idempotent 200. The operator CTA path is never routed here → unchanged. Override: `CATALYST_CUTOVER_REQUIRE_HANDOVER=false`.
- **`bp-self-sovereign-cutover` 0.1.54** — auto-trigger Job handles 425 as the expected, benign pre-handover path (clear log, `exit 0`).
- Founder rule #933 preserved: the cutover still **auto-fires post-handover** with no operator click — the same trigger succeeds once the gate opens.

## Verified

- `go test ./internal/handler/` — full package green (61s), incl. 3 new tests: defers-when-not-handed-over (425, **zero Jobs created**), env-override-bypass, handed-over happy-path.
- `gofmt` clean, `go build ./...` clean.
- `helm lint` clean; `helm template` confirms the 425 case renders with `trigger.auto=true` and the Job is fully suppressed (dormant) with `trigger.auto=false`.

## Not in this PR

Does **not** un-wedge hw93 (its cutover already ran; that env is failed per zero-touch doctrine). Acceptance is a **fresh** zero-touch prov on the gate-bearing catalyst-api image reaching console-200 with no manual touch, then a real-handover-then-cutover walk.

Refs #3052 #2940 #2951
