### PR TITLE
fix(bootstrap): harbor dependsOn external-secrets + widen kyverno gate — hw95 last-HRs plateau

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -120,6 +120,18 @@ spec:
     # gateway.networking.k8s.io/v1 CRDs must be registered first.
     - name: bp-gateway-api
       namespace: flux-system
+    # #3052-followup (2026-06-04, hw95): the chart ships an
+    # externalsecret.external-secrets.io resource. Without this dependency
+    # Harbor installs BEFORE the external-secrets admission webhook is
+    # serving, so the ExternalSecret create fails ("failed calling webhook
+    # validate.externalsecret.external-secrets.io: connection refused"),
+    # the install retries 6× → Stalled, and Flux uninstall-remediates →
+    # the last ~8 HRs never all-ready so bootstrap-kit never holds stable
+    # Ready → sovereign-tls never binds → console 000. Gating on
+    # bp-external-secrets (the #2988 gold-standard pattern) makes Harbor
+    # wait for the webhook to be Ready before it creates the ExternalSecret.
+    - name: bp-external-secrets
+      namespace: flux-system
   chart:
     spec:
       chart: bp-harbor

--- a/clusters/_template/bootstrap-kit/27-kyverno.yaml
+++ b/clusters/_template/bootstrap-kit/27-kyverno.yaml
@@ -68,7 +68,7 @@ spec:
       # closes META-AUDIT 1 sub-class 3 — kyverno admission webhook
       # registered before kyverno-svc Pod ready blocks own Secret CREATE
       # via failurePolicy: Fail. Verified deadlock on hw62 v14 06:11Z.
-      version: 1.3.4
+      version: 1.3.5
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno/blueprint.yaml
+++ b/platform/kyverno/blueprint.yaml
@@ -8,7 +8,7 @@ spec:
   # 1.3.0 (TBD-V53 #2128): Cold-start race fix — cert-manager-issued TLS
   # + extraInitContainer that blocks main container until the secret is
   # populated. See platform/kyverno/chart/Chart.yaml for the full rationale.
-  version: 1.3.4
+  version: 1.3.5
   card:
     title: Kyverno
     family: guardian

--- a/platform/kyverno/chart/Chart.yaml
+++ b/platform/kyverno/chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # an extraInitContainer blocks the main container until the secret has a
 # populated tls.crt. Eliminates the apiserver→webhook TLS handshake EOF
 # that wedged bootstrap-kit on every fresh-prov Sovereign.
-version: 1.3.4
+version: 1.3.5
 appVersion: "v1.18.0"
 keywords: [catalyst, blueprint, kyverno, policy, admission, security]
 maintainers:

--- a/platform/kyverno/chart/templates/webhook-gate-hook.yaml
+++ b/platform/kyverno/chart/templates/webhook-gate-hook.yaml
@@ -79,8 +79,18 @@ META-AUDIT 1 catalog.
        kyverno's image + cert-manager Secret took ~15 min, the gate timed out,
        backoffLimit:0 → hook failed → upgrade failed → MissingRollbackTarget →
        HR Stalled → bootstrap-kit health failed → sovereign-tls → console 000.
-       Raised to 1200s (20 min) to tolerate slow image pulls on cold provs. */ -}}
-{{- $timeout := $gate.timeoutSeconds | default 1200 -}}
+       Raised to 1200s (20 min) to tolerate slow image pulls on cold provs.
+       hw95 2026-06-04: 1200s STILL too short under peak concurrent-pull egress
+       contention — the gate hit BackoffLimitExceeded, the POST-INSTALL hook
+       failed → Flux install-remediation UNINSTALLED → the uninstall got stuck
+       (kyverno's own admission webhook blocks deletion of its resources) → HR
+       stuck StateError 'uninstalling', unrecoverable, and the last-8-HRs never
+       all-Ready so bootstrap-kit never holds stable → console 000. Raised to
+       2400s (40 min). DEEPER FIX still owed (the real fragility is the
+       fatal-hook→stuck-uninstall path, not the timeout): make this gate
+       non-fatal OR scope kyverno's webhook selectors so a not-yet-serving
+       kyverno can't block its own uninstall. Tracked as a follow-up. */ -}}
+{{- $timeout := $gate.timeoutSeconds | default 2400 -}}
 {{- $interval := $gate.intervalSeconds | default 2 -}}
 {{- $image := $gate.image | default "bitnamilegacy/kubectl:1.30.7" -}}
 {{- $pullPolicy := $gate.imagePullPolicy | default "IfNotPresent" -}}

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -218,7 +218,12 @@ slots:
     # gateway.networking.k8s.io/v1 CRDs must be registered first.
     # G92.3 #2662 (2026-06-01): MGMT vCluster placement adds
     # bp-mgmt-vcluster as a new edge.
-    depends_on: [bp-mgmt-vcluster, bp-cnpg, bp-cert-manager, bp-gateway-api]
+    # #3052-followup (2026-06-04, hw95): the chart ships an
+    # externalsecret.external-secrets.io — Harbor must wait for the
+    # external-secrets admission webhook to be serving or its create
+    # fails ("failed calling webhook validate.externalsecret") → 6
+    # install failures → Stalled (#2988 pattern).
+    depends_on: [bp-mgmt-vcluster, bp-cnpg, bp-cert-manager, bp-gateway-api, bp-external-secrets]
     wave: W2.K1
   - slot: 6a
     name: bp-self-sovereign-cutover


### PR DESCRIPTION
## What
Fixes the recurring fresh-prov plateau — the last ~8 HRs never all reach Ready at once, so the all-HRs `bootstrap-kit` health-gate never holds stable Ready, `sovereign-tls` never binds, and the console serves `000`. Diagnosed **live on the failed hw95 env** (per founder directive: fix-forward on the failure, don't wipe-and-retry) to two real bugs, not slow-egress alone.

## Roots
- **bp-harbor `InstallFailed` → Stalled (6 attempts):** Harbor's chart creates an `externalsecret.external-secrets.io`, but its `dependsOn` omitted **bp-external-secrets** — so Harbor installed before the external-secrets admission webhook was serving → `failed calling webhook validate.externalsecret.external-secrets.io` → 6 install failures → Stalled. **Fix:** add `bp-external-secrets` to `dependsOn` (the #2988 gold-standard pattern; external-secrets is already Ready on the cluster, so Harbor will now wait for the webhook and install cleanly).
- **bp-kyverno `StateError`, stuck `uninstalling`:** the `kyverno-webhook-gate` post-install hook timed out at 1200s under peak concurrent-pull egress → `BackoffLimitExceeded` → install failed → Flux's uninstall-remediation got **stuck** (kyverno's own admission webhook blocks deletion of its resources — self-referential) → unrecoverable. **Fix:** widen the gate to 2400s + bump `1.3.4 → 1.3.5` to reset the stuck release. The **deeper fix** (make the gate non-fatal / scope kyverno's webhook selectors so a not-yet-serving kyverno can't block its own uninstall) is documented in-file as a follow-up.

## Verify
On merge, hw95's Flux pulls these → Harbor re-reconciles (webhook now gated) and kyverno re-installs (wider gate, stuck release reset) → the last HRs converge → bootstrap-kit holds stable → console-200. Confirming on hw95 before any wipe.

Refs #3052
