### PR TITLE
fix(cutover): Step-06 rewrites harbor.openova.io registry tether to local Harbor

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -438,7 +438,11 @@ spec:
       # 0.1.54 (#3052): auto-trigger Job handles catalyst-api's new HTTP
       # 425 handover-completion gate — the cutover no longer half-pivots
       # the registry at bootstrap on a fresh, un-handed-over prov.
-      version: 0.1.54
+      # 0.1.55 (#2940/#2951): Step-06 Phase-2.6 surgically rewrites the
+      # harbor.openova.io registry tether in the bootstrap-kit IaC to the
+      # local Harbor host (preserves catalyst.openova.io/* CRD API groups +
+      # label keys — only the harbor.* registry hostname is pivoted).
+      version: 0.1.55
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.54
+  version: 0.1.55
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -414,7 +414,7 @@ name: bp-self-sovereign-cutover
 # until the tofu-phase0-archive is sealed at handover; this Job treats
 # 425 as the EXPECTED benign pre-handover path (clear log, exit 0). The
 # cutover still auto-fires post-handover (founder rule #933 preserved).
-version: 0.1.54
+version: 0.1.55
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -673,6 +673,41 @@ data:
               echo "[helmrepository-patches] Phase-2.5 SKIP: ${catalyst_yaml} not present in local mirror"
             fi
 
+            # ---- Phase 2.6: rewrite harbor.openova.io registry tethers
+            # to the local Harbor (#2940 / #2951) ----
+            #
+            # Per-Blueprint HelmRelease values in the bootstrap-kit IaC
+            # carry `harbor.openova.io/proxy-ghcr/...` image-repo literals
+            # (the vcluster charts' image.repository + registry defaults,
+            # plus any chart pinning an explicit registry per the
+            # MIRROR-EVERYTHING rule). Step-04's containerd mirror redirects
+            # these at pull time, but Principle #11 forbids the post-cutover
+            # cluster from carrying ANY mothership-domain reference — a
+            # textual harbor.openova.io is a standing tether that would
+            # re-authenticate against upstream the moment the mirror config
+            # is lost. Rewrite every harbor.openova.io literal in the
+            # bootstrap-kit IaC to the local Harbor host so the post-cutover
+            # IaC is mothership-free.
+            #
+            # SURGICAL: only the `harbor.openova.io` registry hostname is
+            # rewritten. The catalyst.openova.io / access.openova.io /
+            # sandbox.openova.io / sso.openova.io CRD API groups + label
+            # keys (e.g. openova.io/region) are platform API identifiers
+            # (like k8s.io) and MUST be preserved verbatim — rewriting them
+            # would break every CR, label selector and admission policy.
+            # The trailing `.openova.io` boundary in the sed pattern ensures
+            # `harbor.openova.io` matches but `catalyst.openova.io` never
+            # does (different leading label). Idempotent: a re-run finds no
+            # harbor.openova.io left → no-op.
+            harbor_tether_edits=0
+            for f in $(grep -rlE "harbor\.openova\.io" "${target_dir}" 2>/dev/null || true); do
+              sed -i "s,harbor\.openova\.io,${harbor_host},g" "${f}"
+              harbor_tether_edits=$((harbor_tether_edits+1))
+              echo "[helmrepository-patches] Phase-2.6 rewrote harbor.openova.io -> ${harbor_host} in ${f}"
+            done
+            echo "[helmrepository-patches] Phase-2.6 harbor-tether edits=${harbor_tether_edits}"
+            edited=$((edited+harbor_tether_edits))
+
             if [ "${edited}" -eq 0 ]; then
               echo "[helmrepository-patches] no edits — already pivoted in Gitea or upstream prefix not present"
               # Don't fail; phase-1 already succeeded.


### PR DESCRIPTION
## What

New **Phase-2.6** in the cutover's Step-06 (`06-helmrepository-patches-job`) surgically rewrites the `harbor.openova.io` registry tether in the bootstrap-kit IaC to the local Harbor host (`harbor.<sov-fqdn>`) during the cutover's git-push phase.

## Why

`Refs #2940` `Refs #2951` — UAT Wave-2 found the bootstrap-kit IaC carries **10 `harbor.openova.io` literals** (the `bp-{rtz,dmz,mgmt}-vcluster` charts' `image.repository` + `registry` defaults per the MIRROR-EVERYTHING rule). Step-04's containerd mirror redirects these at pull time, but **Principle #11** forbids the post-cutover cluster from carrying *any* mothership-domain reference — a textual `harbor.openova.io` is a standing tether that would re-authenticate against upstream the moment the mirror config is lost.

## How (surgical)

Only the `harbor.openova.io` **registry hostname** is rewritten. The `catalyst.openova.io/*`, `access.openova.io`, `sandbox.openova.io`, `sso.openova.io` CRD **API groups + label keys** (e.g. `openova.io/region`) are platform API identifiers like `k8s.io` and are **preserved verbatim** — rewriting them would break every CR, label selector and admission policy. The `harbor.` leading label in the sed pattern guarantees `catalyst.openova.io` never matches. Idempotent (a re-run finds none left → no-op); counted into Step-06's `edited` so it's committed + pushed to local Gitea.

## Verification owed (not closing the issue)

This is one slice of #2940/#2951 — the `harbor.openova.io` registry tether. The `pdns.openova.io` (7) / `mail.openova.io` (4) / `console.openova.io` (2) tethers need their correct local-endpoint mappings and follow in a second slice. Issue stays `status/in-progress`; closes only after an egress-block walk on a fresh post-cutover prov shows zero `harbor.openova.io` residual.

Chart 0.1.54 → 0.1.55 (chart + blueprint + bootstrap-kit slot pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)