### PR TITLE
fix(sovereign-tls): escape cert-guard shell vars for Flux postBuild.substitute

### DIFF
--- a/clusters/_template/sovereign-tls/cert-stuck-nextprivatekey-guard.yaml
+++ b/clusters/_template/sovereign-tls/cert-stuck-nextprivatekey-guard.yaml
@@ -120,13 +120,13 @@ spec:
             - |
               set -eu
               CERT="sovereign-wildcard-tls-${SOVEREIGN_FQDN_DASHED}"
-              echo "[cert-nextkey-guard] watching kube-system/${CERT} for the #3066 nextPrivateKey loop"
+              echo "[cert-nextkey-guard] watching kube-system/$${CERT} for the #3066 nextPrivateKey loop"
               cooldown=0
               for round in $(seq 1 14); do
-                ready=$(kubectl -n kube-system get certificate "${CERT}" \
+                ready=$(kubectl -n kube-system get certificate "$${CERT}" \
                   -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
-                if [ "${ready}" = "True" ]; then
-                  echo "[cert-nextkey-guard] ${CERT} Ready=True — healthy, exiting"
+                if [ "$${ready}" = "True" ]; then
+                  echo "[cert-nextkey-guard] $${CERT} Ready=True — healthy, exiting"
                   exit 0
                 fi
                 # Post-break cooldown (reviewer note, PR #3069): immediately
@@ -134,7 +134,7 @@ spec:
                 # has a fresh temp Secret + zero CRs (sub-second gap before
                 # cert-manager creates the new CR). Skip detection for one
                 # round so we never re-break a cert that is recovering.
-                if [ "${cooldown}" = "1" ]; then
+                if [ "$${cooldown}" = "1" ]; then
                   cooldown=0
                   echo "[cert-nextkey-guard] post-break cooldown round — letting cert-manager re-issue before re-checking"
                   sleep 60
@@ -144,7 +144,7 @@ spec:
                 # owns them via the cert-manager.io/next-private-key label).
                 temps=$(kubectl -n kube-system get secret \
                   -l cert-manager.io/next-private-key=true -o name 2>/dev/null \
-                  | grep "${CERT}" || true)
+                  | grep "$${CERT}" || true)
                 # CRITICAL: the #3066 loop never creates a CertificateRequest
                 # at all — cert-manager loops on the temp Secret BEFORE the
                 # CR step. So the stuck signature is ZERO CertificateRequests
@@ -152,26 +152,26 @@ spec:
                 # slow DNS-01 issuance legitimately has a PENDING CR for
                 # minutes, and disturbing it would break a healthy cert.
                 cr_count=$(kubectl -n kube-system get certificaterequest -o name 2>/dev/null \
-                  | grep -c "${CERT}" || true)
+                  | grep -c "$${CERT}" || true)
                 # Grace: give a normal issuance ~3 min for its CR to appear.
-                if [ "${round}" -ge 3 ] && [ -n "${temps}" ] && [ "${cr_count:-0}" = "0" ]; then
-                  echo "[cert-nextkey-guard] STUCK signature (round ${round}): nextPrivateKey temp secret present, ZERO CertificateRequests (loop never reached the CR step). Breaking the loop."
-                  echo "${temps}" | while IFS= read -r s; do
-                    [ -n "${s}" ] && kubectl -n kube-system delete "${s}" --ignore-not-found=true || true
+                if [ "$${round}" -ge 3 ] && [ -n "$${temps}" ] && [ "$${cr_count:-0}" = "0" ]; then
+                  echo "[cert-nextkey-guard] STUCK signature (round $${round}): nextPrivateKey temp secret present, ZERO CertificateRequests (loop never reached the CR step). Breaking the loop."
+                  echo "$${temps}" | while IFS= read -r s; do
+                    [ -n "$${s}" ] && kubectl -n kube-system delete "$${s}" --ignore-not-found=true || true
                   done
-                  for cr in $(kubectl -n kube-system get certificaterequest -o name 2>/dev/null | grep "${CERT}" || true); do
-                    kubectl -n kube-system delete "${cr}" --ignore-not-found=true || true
+                  for cr in $(kubectl -n kube-system get certificaterequest -o name 2>/dev/null | grep "$${CERT}" || true); do
+                    kubectl -n kube-system delete "$${cr}" --ignore-not-found=true || true
                   done
-                  kubectl -n kube-system annotate certificate "${CERT}" \
+                  kubectl -n kube-system annotate certificate "$${CERT}" \
                     "cert-nextkey-guard.openova.io/broke-loop-at=$(date +%s)" --overwrite 2>/dev/null || true
                   echo "[cert-nextkey-guard] cleared temp secret(s) + stuck CR(s); cert-manager will re-issue from a clean slate"
                   cooldown=1
                 fi
                 sleep 60
               done
-              echo "[cert-nextkey-guard] ${CERT} still not Ready after ~14m — emitting diagnostics (best-effort, not failing the Kustomization)" >&2
-              kubectl -n kube-system get certificate "${CERT}" -o yaml 2>&1 | tail -40 >&2 || true
-              kubectl -n kube-system get certificaterequest,secret 2>&1 | grep "${CERT}" >&2 || true
+              echo "[cert-nextkey-guard] $${CERT} still not Ready after ~14m — emitting diagnostics (best-effort, not failing the Kustomization)" >&2
+              kubectl -n kube-system get certificate "$${CERT}" -o yaml 2>&1 | tail -40 >&2 || true
+              kubectl -n kube-system get certificaterequest,secret 2>&1 | grep "$${CERT}" >&2 || true
               exit 0
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## What

Escapes the shell variables in the `#3066` cert-nextkey-guard (`clusters/_template/sovereign-tls/cert-stuck-nextprivatekey-guard.yaml`) so Flux `postBuild.substitute` stops clobbering them.

## Why

`Refs #3066` — the guard (shipped in PR #3069) lives in the `sovereign-tls` overlay, which Flux `postBuild.substitute` processes (it replaces every `${...}`, emptying any var not in its substitution set). My guard used single-`$` shell vars (`${CERT}`, `${ready}`, `${round}`, `${temps}`, `${cooldown}`, `${cr_count}`, …), so Flux replaced them all with empty strings at apply time.

**Caught live on hw99** (the chart auto-reconciled within minutes of the #3069 merge): the guard pod logged `watching kube-system/` (empty `CERT`) + 14× `sh: out of range`, then timed out as a **no-op** — the #3066 protection never actually ran. Harmless (it exits 0 on timeout, never touches the cert) but the guard provided zero protection.

## How

Escape every shell-var reference as `$${VAR}` so Flux emits a literal `${VAR}` that bash evaluates at Job runtime — the exact pattern the sibling `cilium-envoy-tls-restart-job.yaml` documents at its line 207 (`$${SECRET_NS}` etc.). The two genuine Flux vars (`${SOVEREIGN_FQDN}` labels, `${SOVEREIGN_FQDN_DASHED}` in the cert name) stay single-`$` so Flux still substitutes them. `kubectl kustomize` builds clean; verified 10 `$${CERT}` + zero single-`$` shell refs + Flux vars intact.

## Verification owed

`Refs #3066` — stays `status/in-progress`; the guard's *correct* operation (detect a real `nextPrivateKey` loop and break it) still needs the loop-trigger walk, but this restores it from no-op to functional. The fix auto-reconciles to hw99 on merge; next pod-run should log the real cert name + `Ready=True — exiting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)