### PR TITLE
fix(marketplace): surface silent credit-balance fetch failure on org-checkout

### DIFF
--- a/core/marketplace/src/components/CheckoutStep.svelte
+++ b/core/marketplace/src/components/CheckoutStep.svelte
@@ -152,9 +152,23 @@
   // `totalCost` (also baisa) stays in the same unit — no more omr→baisa
   // conversion inline.
   let creditBaisa = $state<number>(0);
+  // Org-checkout (Pillar 1): a voucher-redeemed credit applies through
+  // `creditCovers` below, which depends on this fetch. The prior silent
+  // `.catch(() => {})` swallowed any failure, leaving creditBaisa=0 → the
+  // voucher never applies and the total never drops to 0 (the
+  // disabled-Purchase / "voucher not applying" symptom seen on the
+  // org-checkout walk). Surface the error so the real root (credit API
+  // failure vs voucher not crediting the balance) is visible, not masked.
+  let creditError = $state<string | null>(null);
   $effect(() => {
     if (!user) return;
-    getCreditBalance().then(b => { creditBaisa = b.credit_baisa || 0; }).catch(() => {});
+    creditError = null;
+    getCreditBalance()
+      .then(b => { creditBaisa = b.credit_baisa || 0; })
+      .catch((e) => {
+        creditError = e instanceof Error ? e.message : String(e);
+        console.error('[checkout] getCreditBalance failed — voucher credit will not apply:', e);
+      });
   });
 
   const creditCovers = $derived(creditBaisa >= totalCost && totalCost > 0);
@@ -663,6 +677,11 @@
               {:else if creditPartial}
                 <p class="text-xs text-[var(--color-text-dim)]">Credit is applied first; the remainder is charged to your card.</p>
               {/if}
+            {/if}
+            {#if creditError}
+              <p class="text-xs text-[var(--color-danger)]">
+                Couldn't load your voucher credit ({creditError}) — a redeemed voucher may not be reflected in the total above. Retry, or re-redeem the voucher if you expected free credit.
+              </p>
             {/if}
           </div>
         </div>


### PR DESCRIPTION
## What

Replaces a silent `.catch(() => {})` on the org-checkout credit-balance fetch with a surfaced error (console + operator-visible inline message).

## Why

The org-checkout Purchase walk stalls — the total never drops despite a redeemed voucher (the "Purchase button disabled / voucher not applying" symptom from the UAT). Tracing `CheckoutStep.svelte`: the Purchase button itself gates on cart contents, but a **voucher credit applies via `creditCovers`** (line 160), which derives from `creditBaisa` — fetched by `getCreditBalance()`. The prior `getCreditBalance().then(...).catch(() => {})` **silently swallowed any failure**, leaving `creditBaisa=0`, so the voucher never applies and the total never drops. The real root (credit API failing vs the voucher-redeem not crediting the balance) was completely masked.

## How

- `creditError` state captures the failure; `console.error` logs it; an inline `text-danger` message tells the operator the voucher credit couldn't load and the total may not reflect it.
- This is a **diagnostic-surfacing fix** (anti-pattern: silent error swallowing on a path the deterministic org-checkout test depends on). It does not itself fix the underlying credit-API/voucher-redeem flow — it makes the root visible so the next org-checkout walk shows *why* the credit is 0 instead of silently stalling.

## Scope

`Refs #3057` (voucher/onboarding flow). Surfacing-only; the underlying credit-or-voucher backend fix follows once the surfaced error identifies which side fails on a walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)