### PR TITLE
fix(marketplace): checkout button reads 'Launch' for voucher-covered orders

### DIFF
--- a/core/marketplace/src/components/CheckoutStep.svelte
+++ b/core/marketplace/src/components/CheckoutStep.svelte
@@ -771,7 +771,7 @@
           {#if checkoutLoading}
             <div class="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"></div>
             Processing…
-          {:else if totalCost === 0}
+          {:else if totalCost === 0 || creditCovers}
             Launch my tenant
             <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6"/>


### PR DESCRIPTION
The Purchase button text keyed on `totalCost === 0`, so a voucher-covered order (`creditCovers`, totalCost>0) mislabeled as 'Purchase · <amount>' implying a card charge — though the backend settles it free from credit. Gate the 'Launch my tenant' label on `totalCost === 0 || creditCovers`. Pairs with #3076. `Refs #3057`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)