### PR TITLE
fix(newapi): pin metering-sidecar to a SHA, not :latest (ImagePullBackOff on hw99)

### DIFF
--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.61
+  version: 1.4.62
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -411,7 +411,7 @@ name: bp-newapi
 # `lookup valkey.valkey.svc.cluster.local: no such host`). Same hostname
 # already documented as canonical in products/catalyst/chart/values.yaml
 # bp-cnpg-pair comments.
-version: 1.4.61
+version: 1.4.62
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -890,7 +890,12 @@ meteringSidecar:
     # services-build CI publishes this image alongside the SME services
     # on every push to core/services/metering-sidecar/**.
     repository: ghcr.io/openova-io/openova/services-metering-sidecar
-    tag: "latest"
+    # Pinned SHA, not :latest — a mutable :latest tag forces a fresh manifest
+    # resolve on every reschedule, which ImagePullBackOff'd newapi on hw99
+    # (live 2026-06-07) when the :latest pull transiently failed. 41e02c8 is
+    # the most-recent services-build publish (= the content :latest pointed
+    # at); a fixed digest with IfNotPresent is deterministic + cache-friendly.
+    tag: "41e02c8"
     pullPolicy: IfNotPresent
   # The sidecar listens on this port; the Service routes traffic
   # (port 3000) → sidecar → newapi:3000-on-127.0.0.1. We expose the


### PR DESCRIPTION
newapi ImagePullBackOff'd on hw99 (live) pulling `services-metering-sidecar:latest`. Mutable `:latest` re-resolves the manifest on every reschedule → a transient ghcr pull wedges the pod. Pin to `41e02c8` (most-recent publish = current :latest content); deterministic + cache-friendly, per the no-:latest anti-pattern. Chart 1.4.61→1.4.62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)