### PR TITLE
docs(cutover): encode #2951 decision in Step-06 — no chart-values rewrite belongs here

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -438,7 +438,7 @@ spec:
       # 0.1.54 (#3052): auto-trigger Job handles catalyst-api's new HTTP
       # 425 handover-completion gate — the cutover no longer half-pivots
       # the registry at bootstrap on a fresh, un-handed-over prov.
-      version: 0.1.55
+      version: 0.1.56
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.55
+  version: 0.1.56
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -414,7 +414,7 @@ name: bp-self-sovereign-cutover
 # until the tofu-phase0-archive is sealed at handover; this Job treats
 # 425 as the EXPECTED benign pre-handover path (clear log, exit 0). The
 # cutover still auto-fires post-handover (founder rule #933 preserved).
-version: 0.1.55
+version: 0.1.56
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -22,6 +22,22 @@ Three phases run in this Job:
   Phase 2  Push the YAML edit to local Gitea so the bootstrap-kit
            Kustomization reconcile doesn't revert Phase 1 within ~1m.
 
+SCOPE — what this step does NOT touch (#2951 decision record):
+  This step rewrites HelmRepository spec.url (the chart SOURCE: ghcr.io
+  → local Harbor) ONLY. It deliberately does NOT rewrite per-Blueprint
+  chart-VALUES image tethers (e.g. bp-{rtz,mgmt,dmz}-vcluster values.yaml
+  `repository: harbor.openova.io/proxy-ghcr/loft-sh/vcluster`). Those are
+  left verbatim and handled by:
+    - Step 03 (harbor-prewarm): skopeo-pushes every running Pod's image,
+      incl. the vcluster image, into the local Harbor BEFORE egress is cut.
+    - Step 04 (registry-pivot): containerd registries.yaml v2 redirects
+      `harbor.openova.io` → local Harbor at image-pull time.
+  Adding a sed of those chart-values here would be a NO-OP that breaks the
+  intended cache pattern (the PR #3067 shape — it rewrites the Harbor
+  proxy-cache, not a real mothership tether). End-to-end correctness is
+  verified by Step 08's real egressDeny (#3072 / #2940), not a values sed.
+  See #2951.
+
 Image phase: post.
 */ -}}
 apiVersion: v1


### PR DESCRIPTION
`Refs #2951` — #2951 asks whether Step-06 should rewrite per-Blueprint chart-VALUES image tethers. It should NOT: Step-06 rewrites HelmRepository `spec.url` (chart source) only; the `harbor.openova.io/proxy-ghcr/*` chart-values tethers are handled by **Step-03 harbor-prewarm** (skopeo-pushes every Pod image into local Harbor before egress is cut) + **Step-04 registry-pivot** (containerd mirror). A sed there = the #3067 no-op that rewrites the intended cache. Encoded as a Step-06 header SCOPE comment so it isn't re-introduced; verified end-to-end by Step-08's real egressDeny (#3072). Chart 0.1.55→0.1.56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)