### PR TITLE
fix(console): EndpointsTab shows a note (not an inert form) for bootstrap apps

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/EndpointsTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/EndpointsTab.tsx
@@ -140,15 +140,30 @@ export function EndpointsTab({
         ) : null}
       </section>
 
-      <EditEndpointForm
-        appUID={appUID}
-        defaultHostname={rows[0]?.hostname ?? fallbackHost}
-        defaultName={rows[0]?.name ?? applicationName}
-        defaultTls={rows[0]?.tls !== false}
-        isExisting={items.length > 0}
-        disabled={!appUID}
-        onMutated={() => qc.invalidateQueries({ queryKey: ['app-endpoints', appUID] })}
-      />
+      {appUID ? (
+        <EditEndpointForm
+          appUID={appUID}
+          defaultHostname={rows[0]?.hostname ?? fallbackHost}
+          defaultName={rows[0]?.name ?? applicationName}
+          defaultTls={rows[0]?.tls !== false}
+          isExisting={items.length > 0}
+          disabled={false}
+          onMutated={() => qc.invalidateQueries({ queryKey: ['app-endpoints', appUID] })}
+        />
+      ) : (
+        <section
+          className="section"
+          data-testid="sov-section-endpoint-edit-unavailable"
+          style={{ marginTop: '0.8rem' }}
+        >
+          <h3 style={{ fontSize: '0.9rem', margin: '0 0 0.3rem' }}>Edit endpoint</h3>
+          <p className="section-hint" style={{ margin: 0 }}>
+            Endpoint editing via a governed Git-IaC PR is available for catalog-installed
+            Applications. This is a bootstrap-kit component (no catalog instance), so its endpoints
+            are managed directly in the Sovereign&rsquo;s GitOps repo rather than from this tab.
+          </p>
+        </section>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Caught in the live #2742 POST walk: bootstrap components (bp-gitea etc.) have no console-side appUID, so the edit form rendered with a permanently-disabled 'Raise PR' button + no explanation. Now: real form when appUID present; a clear 'editing is available for catalog-installed Applications' note otherwise. `Refs #2742`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)