### PR TITLE
test(huawei-wipe): extract + unit-test the ProviderPurge dedup (#3065)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/provider.go
@@ -354,19 +354,9 @@ func (p *Provider) Wipe(ctx context.Context, spec providers.WipeSpec, progress f
 	// Dedup ProviderPurge — across the retry passes a resource that took
 	// more than one pass to delete (listed-then-failed, then deleted on a
 	// later pass) gets appended more than once, so the success report would
-	// over-count it. Collapse each kind to unique names. (#3070 reviewer
-	// note, sharper now that maxPurgePasses=6.)
-	for k, names := range out.ProviderPurge {
-		seen := map[string]bool{}
-		uniq := names[:0]
-		for _, n := range names {
-			if !seen[n] {
-				seen[n] = true
-				uniq = append(uniq, n)
-			}
-		}
-		out.ProviderPurge[k] = uniq
-	}
+	// over-count it. Extracted to a tested helper (#3070 reviewer note,
+	// sharper now that maxPurgePasses=6).
+	dedupProviderPurge(out)
 
 	// Step 3 — OBS bucket purge (best effort).
 	endpoint := fmt.Sprintf("obs.%s.kom4dc.nationalcloud.om", region)
@@ -382,6 +372,29 @@ func (p *Provider) Wipe(ctx context.Context, spec providers.WipeSpec, progress f
 	}
 
 	return out, nil
+}
+
+// dedupProviderPurge collapses each ProviderPurge kind to unique names.
+// The verify-and-re-purge retry (Wipe) can append the same resource name
+// on more than one pass — listed-then-delete-failed on an early pass, then
+// deleted on a later pass — which would over-count the success report
+// (sharper now that maxPurgePasses=6). In-place dedup preserves order and
+// reuses each slice's backing array. (#3070 reviewer note; #3065.)
+func dedupProviderPurge(out *providers.WipeResult) {
+	if out == nil {
+		return
+	}
+	for k, names := range out.ProviderPurge {
+		seen := make(map[string]bool, len(names))
+		uniq := names[:0]
+		for _, n := range names {
+			if !seen[n] {
+				seen[n] = true
+				uniq = append(uniq, n)
+			}
+		}
+		out.ProviderPurge[k] = uniq
+	}
 }
 
 // verifyZeroOrphans walks every cleanup-bearing resource kind and

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/provider_test.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/provider_test.go
@@ -257,3 +257,42 @@ func TestBucketNamePrefix(t *testing.T) {
 		t.Fatalf("BucketNamePrefixForSovereign = %q, want %q", got, want)
 	}
 }
+
+// TestDedupProviderPurge — #3065. The verify-and-re-purge retry can append a
+// resource name to ProviderPurge on more than one pass (delete-failed early,
+// deleted on a later pass); dedupProviderPurge must collapse each kind to
+// unique names while preserving first-seen order.
+func TestDedupProviderPurge(t *testing.T) {
+	out := &providers.WipeResult{
+		ProviderPurge: map[string][]string{
+			"networks":     {"vpc-a", "vpc-a", "vpc-b"},        // vpc-a deleted on a later pass → dup
+			"nat_gateways": {"nat-1"},                          // single, unchanged
+			"floating_ips": {"1.2.3.4", "5.6.7.8", "1.2.3.4"}, // dup, out of order
+			"empty":        {},
+		},
+	}
+	dedupProviderPurge(out)
+
+	want := map[string][]string{
+		"networks":     {"vpc-a", "vpc-b"},
+		"nat_gateways": {"nat-1"},
+		"floating_ips": {"1.2.3.4", "5.6.7.8"},
+		"empty":        {},
+	}
+	for k, w := range want {
+		g := out.ProviderPurge[k]
+		if len(g) != len(w) {
+			t.Fatalf("dedup[%s] = %v (len %d), want %v (len %d)", k, g, len(g), w, len(w))
+		}
+		for i := range w {
+			if g[i] != w[i] {
+				t.Errorf("dedup[%s][%d] = %q, want %q (first-seen order must be preserved)", k, i, g[i], w[i])
+			}
+		}
+	}
+}
+
+// TestDedupProviderPurge_NilSafe — the helper must no-op on a nil result.
+func TestDedupProviderPurge_NilSafe(t *testing.T) {
+	dedupProviderPurge(nil)
+}


### PR DESCRIPTION
The #3078 wipe-retry ProviderPurge dedup shipped inline + untested. Extract to `dedupProviderPurge(out)` + cover it (collapses per-kind duplicates from multi-pass deletes, preserves first-seen order, nil-safe). `go test` green. `Refs #3065`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)