### PR TITLE
fix(marketplace): fold pending-voucher credit into checkout (100%-voucher -> credit-only path)

### DIFF
--- a/core/marketplace/src/components/CheckoutStep.svelte
+++ b/core/marketplace/src/components/CheckoutStep.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { sendMagicLink, verifyMagicLink, getMe, createTenant, getMyOrgs, createCheckout, startProvisioning, getProvisionByTenant, checkSlug, getPlans, getAddons, getCreditBalance, setAuthTokens, setActiveOrg, setActiveOrgSlug, type User, type Provision, type Plan, type AddOn } from '../lib/api';
+  import { sendMagicLink, verifyMagicLink, getMe, createTenant, getMyOrgs, createCheckout, startProvisioning, getProvisionByTenant, checkSlug, getPlans, getAddons, getCreditBalance, redeemVoucherPreview, setAuthTokens, setActiveOrg, setActiveOrgSlug, type User, type Provision, type Plan, type AddOn } from '../lib/api';
   import { readCart, clearCart } from '../lib/cart';
   import { formatOMR } from '../lib/currency';
   import { consoleHref } from '../lib/config';
@@ -163,12 +163,22 @@
   $effect(() => {
     if (!user) return;
     creditError = null;
-    getCreditBalance()
-      .then(b => { creditBaisa = b.credit_baisa || 0; })
-      .catch((e) => {
-        creditError = e instanceof Error ? e.message : String(e);
-        console.error('[checkout] getCreditBalance failed — voucher credit will not apply:', e);
-      });
+    // Effective credit = committed ledger balance + the pending voucher's grant.
+    // The voucher (promoCode) only COMMITS at the /billing/checkout POST, so for a
+    // fresh 100%-voucher order the ledger balance alone is 0 — without folding in
+    // the voucher preview here, creditCovers stays false and the UI shows the card
+    // path even though the backend's CreditOnlyCheckout would cover it (#3057).
+    const code = promoCode.trim();
+    Promise.all([
+      getCreditBalance()
+        .then(b => b.credit_baisa || 0)
+        .catch((e) => {
+          creditError = e instanceof Error ? e.message : String(e);
+          console.error('[checkout] getCreditBalance failed — voucher credit will not apply:', e);
+          return 0;
+        }),
+      code ? redeemVoucherPreview(code).then(p => p?.credit_baisa ?? 0).catch(() => 0) : Promise.resolve(0),
+    ]).then(([ledger, voucher]) => { creditBaisa = ledger + voucher; });
   });
 
   const creditCovers = $derived(creditBaisa >= totalCost && totalCost > 0);

--- a/core/marketplace/src/lib/api.ts
+++ b/core/marketplace/src/lib/api.ts
@@ -273,6 +273,44 @@ export const getCreditBalance = async (): Promise<CreditBalance> => {
   return { credit_baisa, entries };
 };
 
+export type VoucherPreview = {
+  code: string;
+  credit_baisa: number;
+  description: string;
+  active: boolean;
+  accepting_redemptions: boolean;
+};
+
+// Preview the credit a voucher would grant WITHOUT redeeming it, so checkout can
+// reflect a pending voucher's credit in the cart BEFORE the /billing/checkout
+// commit (the redeem itself commits at checkout). Returns null on unknown/invalid
+// (404) or non-redeemable/capped (410) codes — only a live, redeemable voucher's
+// credit should pre-apply. credit_omr is whole OMR; normalised to baisa per #85.
+export const redeemVoucherPreview = async (code: string): Promise<VoucherPreview | null> => {
+  try {
+    const raw = await request<{
+      code: string;
+      credit_omr?: number;
+      credit_baisa?: number;
+      description?: string;
+      active?: boolean;
+      accepting_redemptions?: boolean;
+    }>('/billing/vouchers/redeem-preview', {
+      method: 'POST',
+      body: JSON.stringify({ code }),
+    });
+    return {
+      code: raw.code,
+      credit_baisa: typeof raw.credit_baisa === 'number' ? raw.credit_baisa : Math.round((raw.credit_omr ?? 0) * 1000),
+      description: raw.description ?? '',
+      active: raw.active ?? false,
+      accepting_redemptions: raw.accepting_redemptions ?? false,
+    };
+  } catch {
+    return null;
+  }
+};
+
 // Provisioning
 export const getProvisionStatus = (id: string) =>
   request<Provision>(`/provisioning/status/${id}`);


### PR DESCRIPTION
**Root** (reviewer-led, via the reachable marketplace): a 100%-voucher order rendered the Stripe card path because `creditCovers` (CheckoutStep.svelte) gated on the committed `credit_ledger` balance only — but the voucher commits at the `/billing/checkout` POST, so the pre-checkout ledger balance is 0 -> `creditCovers=false` -> card path, even though the backend `CreditOnlyCheckout` covers it. **Fix:** the credit `$effect` now folds in the pending voucher's preview credit via a new `redeemVoucherPreview` binding (`POST /billing/vouchers/redeem-preview`, baisa-normalised), merged cleanly with #3076's creditError surfacing. A covering voucher -> `creditCovers=true` -> credit-only path. Unblocks the org-creation walk gating #2744 per-Org realm + #2742 POST. `Refs #3057`. Clean redo of conflict-broken #3083. Owed: live UI walk on the reachable marketplace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)