### PR TITLE
fix(console): guard 8 unauth-accessible catalyst-zero routes -> /login?next= (Refs #3086)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -424,7 +424,20 @@ const appRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/app',
   component: AppLayout,
-  beforeLoad: ({ location }) => {
+  beforeLoad: async ({ location }) => {
+    // #3086 — catalyst-zero (console.openova.io) short-circuits the
+    // central rootBeforeLoad gate (router.tsx:230 returns when
+    // DETECTED_MODE.mode !== 'sovereign'), so the `/app/*` fleet
+    // surfaces (dashboard / install / sre / sec compliance) rendered
+    // to anonymous deep-links instead of bouncing to /login?next=.
+    // Run the canonical provisionAuthGuard at the SHARED `/app` parent
+    // so every child inherits the gate. The guard is a no-op on
+    // Sovereign clusters (they manage their own OIDC auth), so the
+    // mode-aware canonicalisation redirects below still run unchanged.
+    // The already-guarded `/app/$deploymentId/*` children re-run the
+    // guard redundantly — harmless (a second 401 probe just re-throws
+    // the same redirect).
+    await provisionAuthGuard()
     if (DETECTED_MODE.mode === 'sovereign') {
       // D17/D17b walkthrough on t132 2026-05-17: the previous
       // strip-`/app`-prefix-and-redirect logic broke /app/<componentId>
@@ -705,6 +718,11 @@ const provisionDecommissionRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/decommission/$deploymentId',
   component: DecommissionPage,
+  // #3086 — this surface renders a DESTRUCTIVE wipe form. It must never
+  // be reachable by an anonymous deep-link on catalyst-zero; gate it with
+  // the canonical provisionAuthGuard (401 → /login?next=, no-op on
+  // Sovereign clusters which run their own OIDC auth).
+  beforeLoad: provisionAuthGuard,
 })
 
 /* ── Cloud (issue #350) ─────────────────────────────────────────
@@ -1125,6 +1143,11 @@ const legacyProvisionRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/provision/legacy/$deploymentId',
   component: ProvisionPage,
+  // #3086 — the legacy DAG provision view is per-deployment operator
+  // state; gate it like every other /provision/* surface so an
+  // anonymous catalyst-zero deep-link bounces to /login?next= instead
+  // of rendering. No-op on Sovereign clusters.
+  beforeLoad: provisionAuthGuard,
 })
 
 // Design showcase


### PR DESCRIPTION
Refs #3086

## Problem

`console.openova.io` runs in `catalyst-zero` mode. The central `/login?next=` gate in `rootBeforeLoad` (router.tsx:230) short-circuits there (`if (DETECTED_MODE.mode !== 'sovereign') return`), so it never runs for catalyst-zero. An audit found 8 routes with NO `beforeLoad` guard that therefore rendered a 404/error/destructive page to an **unauthenticated** deep-link instead of redirecting to `/login?next=`.

## Fix

Attach the canonical `provisionAuthGuard` (router.tsx ≈513-559 — probes `/whoami`, on 401 does `throw redirect({ to: '/login', search: { next } })`) so each of these 8 routes now redirects to `/login` on unauth, identical to the already-guarded `/provision/$deploymentId/*` and `/app/$deploymentId/*` routes.

`rootBeforeLoad`'s mode short-circuit is **unchanged** (deliberately — flipping it would over-redirect catalyst-zero public routes like /wizard, /success, /marketplace).

### Routes guarded

| # | Route | Component | How |
|---|-------|-----------|-----|
| 1 | `/app/dashboard` | DashboardPage | parent `appRoute` guard |
| 2 | `/app/dashboard/applications` | CrossSovereignView | parent `appRoute` guard |
| 3 | `/app/dashboard/treemap` | FleetTreemap | parent `appRoute` guard |
| 4 | `/app/install` + `/app/install/$blueprintName` | InstallPage | parent `appRoute` guard |
| 5 | `/app/sre/compliance` | SREDashboardPage | parent `appRoute` guard |
| 6 | `/app/sec/compliance` | SecLeadDashboardPage | parent `appRoute` guard |
| 7 | `/decommission/$deploymentId` (destructive wipe form — highest priority) | DecommissionPage | per-route guard |
| 8 | `/provision/legacy/$deploymentId` | ProvisionPage | per-route guard |

The 6 `/app/*` fleet routes are covered by attaching the guard to their **shared parent** `appRoute` (composed first, then the existing mode-aware canonicalisation redirect runs unchanged — `provisionAuthGuard` is a no-op on Sovereign clusters). This also cleanly covers any future `/app/*` fleet surface. The already-guarded `/app/$deploymentId/*` children re-run the guard redundantly — harmless. Routes 7 and 8 are not children of `appRoute`, so they get a per-route `beforeLoad: provisionAuthGuard`.

## Verification

- `npx tsc --noEmit` in `products/catalyst/bootstrap/ui` — clean (exit 0).
- Confirmed all 8 routes now resolve a `beforeLoad` chain that calls `provisionAuthGuard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)