### PR TITLE
fix(console): split catalog class page from instance page + always-visible Open button (G117.2/.4 React-tree port)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -681,6 +681,18 @@ const provisionAppRoute = createRoute({
   beforeLoad: provisionAuthGuard,
 })
 
+// #3090 — CATALOG / class page in the mothership provision tree. Mirrors
+// provisionAppRoute but renders CatalogDetail (instances list + "+ New
+// instance"). AppsPage's Catalog-tab cards on the provision monitor
+// surface build `/provision/$deploymentId/catalog/$blueprintName`; the
+// chroot equivalent is consoleCatalogDetailRoute at `/catalog/$blueprintName`.
+const provisionCatalogDetailRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/provision/$deploymentId/catalog/$blueprintName',
+  component: CatalogDetail,
+  beforeLoad: provisionAuthGuard,
+})
+
 // Global jobs list — table view (issue #204 founder spec). Each row is
 // a clickable link that navigates to the per-job detail page.
 const provisionJobsRoute = createRoute({
@@ -2077,6 +2089,7 @@ const routeTree = rootRoute.addChildren([
   deploymentsListRoute,
   provisionRoute,
   provisionAppRoute,
+  provisionCatalogDetailRoute,
   provisionInstallRoute,
   provisionInstallBlueprintRoute,
   provisionJobsRoute,

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.test.tsx
@@ -85,8 +85,10 @@ afterEach(() => cleanup())
 describe('AppDetail — hero', () => {
   it('renders the hero with the Application title', async () => {
     renderDetail('d-1', 'bp-cilium')
-    expect(await screen.findByTestId('sov-hero')).toBeTruthy()
-    expect(screen.getByText('Cilium')).toBeTruthy()
+    const hero = await screen.findByTestId('sov-hero')
+    // The hero renders the title as "— Cilium" (em-dash subtitle), so an
+    // exact getByText('Cilium') misses; assert on the hero's text content.
+    expect(hero.textContent).toContain('Cilium')
   })
 
   it('back link points to the dashboard', async () => {
@@ -163,6 +165,10 @@ describe('AppDetail — matrix-canonical tab seam (TC-036 + TC-106)', () => {
       'app-tab-logs',
       'app-tab-settings',
       'app-tab-members',
+      // `endpoints` ships in the strip after Members (EndpointsTab) — the
+      // expected list had drifted from the rendered tablist. Kept in
+      // canonical position so the order assertion matches reality.
+      'app-tab-endpoints',
       'app-tab-jobs',
       'app-tab-dependencies',
     ])
@@ -222,5 +228,75 @@ describe('AppDetail — matrix-canonical tab seam (TC-036 + TC-106)', () => {
     expect(depTab.getAttribute('aria-selected')).toBe('true')
     expect(screen.queryByTestId('app-tab-overview-panel')).toBeNull()
     expect(screen.queryByTestId('app-tab-dependencies-panel')).toBeTruthy()
+  })
+})
+
+/**
+ * #3090 — AppDetail is the per-INSTANCE page. The class-level instances
+ * list + "+ New instance" button moved to the CLASS page (CatalogDetail).
+ * The instance page must NOT render them; it must still surface the
+ * "Open" button (silent-SSO Launch) when the Application has an external
+ * URL.
+ */
+describe('AppDetail — #3090 instance page (no class content; Open button)', () => {
+  // URL-aware fetch: the application GET returns a body carrying
+  // externalURL so the Open button renders; everything else (the SSE
+  // history replay) returns the empty envelope.
+  function installAppFetch(externalURL: string | undefined) {
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('/applications/')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              name: 'cilium',
+              namespace: 'kube-system',
+              blueprint: 'bp-cilium',
+              phase: 'Ready',
+              conditions: [],
+              ...(externalURL ? { externalURL } : {}),
+            }),
+        } as unknown as Response)
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ events: [], state: undefined, done: false }),
+      } as unknown as Response)
+    }) as typeof fetch
+  }
+
+  it('does NOT render the class instances-list or "+ New instance" button', async () => {
+    installAppFetch(undefined)
+    renderDetail('d-1', 'bp-cilium')
+    await screen.findByTestId('sov-hero')
+    // The class-page widgets must be absent on the instance page.
+    expect(screen.queryByTestId('btn-new-instance')).toBeNull()
+    expect(screen.queryByTestId('sov-section-instances')).toBeNull()
+    expect(screen.queryByTestId('sov-instances-table')).toBeNull()
+    expect(screen.queryByTestId('dialog-new-instance')).toBeNull()
+  })
+
+  it('renders the "Open" button on the Overview tab when an external URL is present', async () => {
+    installAppFetch('https://gitea.t99.omani.works')
+    renderDetail('d-1', 'bp-cilium')
+    // Overview tab is the default landing tab.
+    await screen.findByTestId('app-tab-overview-panel')
+    const openBtn = await screen.findByTestId('btn-launch-app')
+    expect(openBtn).toBeTruthy()
+    // Founder relabel "Launch →" → "Open".
+    expect(openBtn.textContent).toContain('Open')
+    expect(openBtn.textContent).not.toContain('Launch')
+    // The external-URL row is the gate that surfaces the button.
+    expect(screen.getByTestId('app-detail-overview-external-url')).toBeTruthy()
+  })
+
+  it('hides the "Open" button when the Application has no external URL', async () => {
+    installAppFetch(undefined)
+    renderDetail('d-1', 'bp-cilium')
+    await screen.findByTestId('app-tab-overview-panel')
+    expect(screen.queryByTestId('btn-launch-app')).toBeNull()
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
@@ -40,7 +40,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { useParams, Link } from '@tanstack/react-router'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { useWizardStore } from '@/entities/deployment/store'
 import { PortalShell } from './PortalShell'
 import { JobsTable } from './JobsTable'
@@ -56,13 +56,10 @@ import {
   getApplication,
   getLaunchURL,
   getApplicationInstances,
-  createApplicationInstance,
-  getCatalogItemVersion,
   type ApplicationDetailResponse,
-  type ApplicationInstanceSummary,
-  type CreateApplicationInstanceRequest,
 } from '@/lib/catalog.api'
 import { ComplianceTab } from './AppDetail/ComplianceTab'
+import { PerClusterTable } from './AppDetail/InstancesSection'
 import { MembersTab } from './AppDetail/MembersTab'
 import { TopologyTab } from './AppDetail/TopologyTab'
 import { ResourcesTab } from './AppDetail/ResourcesTab'
@@ -547,26 +544,43 @@ export function AppDetail({ disableStream = false }: AppDetailProps = {}) {
         </div>
 
         {/*
-          G117.2 #2741 (2026-06-03) — Instances section + "+ New
-          instance" button. Lists every Application installed from this
-          Blueprint (one row per instance) via GET
-          /catalyst/v1/catalog/{blueprint}/instances, plus a "+ New
-          instance" button that opens the topology picker dialog. The
-          section also renders the local Application CR's
-          `status.perCluster[]` as a per-cluster status table for the
-          CURRENT instance (shows the fan-out across host clusters per
-          G117.6 application-controller).
-
-          AppDetail in G117 is the CLASS surface (one card per
-          Blueprint) — every concrete install is one row in this
-          section. The class/instance split is the deterministic
-          contract H10 walk verifies.
+          #3090 (2026-06-08) — AppDetail is the per-INSTANCE surface, NOT
+          the class surface. The class-level instances list + "+ New
+          instance" button moved to the CATALOG / class page
+          (`/catalog/$blueprintName` → CatalogDetail). What MUST stay here
+          is this one instance's own per-cluster fan-out status
+          (`status.perCluster[]` surfaced as `regionStatuses`): the
+          operator on an instance page still needs to see where THIS
+          instance is running across host clusters (G117.6
+          application-controller). Rendered via the shared PerClusterTable
+          (extracted with InstancesSection) so the row markup stays in one
+          place. No instances list, no New-instance button — those belong
+          to the class page.
         */}
-        <InstancesSection
-          blueprint={app.id}
-          appUID={appUID}
-          perCluster={apiApp?.regionStatuses}
-        />
+        {apiApp?.regionStatuses && apiApp.regionStatuses.length > 0 ? (
+          <section
+            className="section"
+            data-testid="sov-section-percluster"
+            style={{ marginTop: '0.6rem' }}
+          >
+            <h2 style={{ margin: '0 0 0.4rem' }}>
+              Per-cluster fan-out
+              {appUID ? (
+                <span
+                  style={{
+                    marginLeft: '0.5rem',
+                    fontSize: '0.7rem',
+                    color: 'var(--color-text-dim)',
+                    fontWeight: 400,
+                  }}
+                >
+                  (uid {appUID.slice(0, 8)})
+                </span>
+              ) : null}
+            </h2>
+            <PerClusterTable perCluster={apiApp.regionStatuses} />
+          </section>
+        ) : null}
 
         {/*
           Tab strip — matrix-canonical order + matrix-canonical
@@ -1037,556 +1051,10 @@ function LaunchButton({
         padding: '0.15rem 0.55rem',
         fontSize: '0.85rem',
       }}
-      aria-label="Launch app via silent SSO"
+      aria-label="Open app via silent SSO"
     >
-      {pending ? 'Launching…' : 'Launch →'}
+      {pending ? 'Opening…' : 'Open'}
     </button>
-  )
-}
-
-/* ─── G117.2 #2741 Instances section + topology picker ──────────── */
-
-/**
- * InstancesSection — G117.2 #2741 (2026-06-03). Renders TWO blocks:
- *
- * 1. A flat list of every Application installed from this Blueprint
- *    (one row per concrete instance) via
- *    GET /catalyst/v1/catalog/{blueprint}/instances. This is the class
- *    → instance drill-down H10 walk required: the AppDetail surface is
- *    the CLASS card; each row is a concrete instance the operator can
- *    drill into.
- *
- * 2. A "+ New instance" button that opens the topology-picker dialog.
- *    The button carries data-testid="btn-new-instance" so the H10 walk
- *    Playwright spec can locate it deterministically.
- *
- * 3. (When `perCluster` is populated) a per-cluster fan-out table for
- *    the CURRENT Application (status.perCluster[] surfaced via the
- *    existing applications.go `regionStatuses` field). Each row shows
- *    cluster + role + status + hr (if present), so the operator sees
- *    where the instance is running across host clusters per G117.6
- *    application-controller fan-out.
- *
- * On 404 / empty list, the list block renders an empty-state with the
- * "+ New instance" button still active so the operator can install the
- * first instance.
- */
-function InstancesSection({
-  blueprint,
-  appUID,
-  perCluster,
-}: {
-  blueprint: string
-  appUID: string
-  perCluster?: Array<Record<string, unknown>>
-}) {
-  const [dialogOpen, setDialogOpen] = useState(false)
-  const qc = useQueryClient()
-
-  const instancesQuery = useQuery({
-    queryKey: ['blueprint-instances', blueprint],
-    queryFn: () => getApplicationInstances(blueprint),
-    enabled: !!blueprint,
-    staleTime: 15_000,
-    refetchInterval: 15_000,
-    retry: 1,
-  })
-
-  const items: ApplicationInstanceSummary[] = instancesQuery.data?.items ?? []
-
-  return (
-    <section
-      className="section"
-      data-testid="sov-section-instances"
-      style={{ marginTop: '0.6rem' }}
-    >
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          marginBottom: '0.4rem',
-        }}
-      >
-        <h2 style={{ margin: 0 }}>Instances</h2>
-        <button
-          type="button"
-          data-testid="btn-new-instance"
-          onClick={() => setDialogOpen(true)}
-          className="btn btn-primary"
-          style={{
-            padding: '0.3rem 0.8rem',
-            fontSize: '0.82rem',
-            background: 'var(--color-accent)',
-            color: 'white',
-            border: '0',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            fontWeight: 600,
-          }}
-          aria-label="Create a new instance of this Blueprint"
-        >
-          + New instance
-        </button>
-      </div>
-
-      {instancesQuery.isPending ? (
-        <p
-          className="section-hint"
-          data-testid="sov-instances-loading"
-          style={{ margin: 0 }}
-        >
-          Loading instances…
-        </p>
-      ) : items.length === 0 ? (
-        <p
-          className="section-hint"
-          data-testid="sov-instances-empty"
-          style={{ margin: 0 }}
-        >
-          No instances of this Blueprint installed yet. Click "+ New
-          instance" to create the first one.
-        </p>
-      ) : (
-        <table
-          data-testid="sov-instances-table"
-          style={{
-            width: '100%',
-            borderCollapse: 'collapse',
-            fontSize: '0.82rem',
-          }}
-        >
-          <thead>
-            <tr style={{ textAlign: 'left', color: 'var(--color-text-dim)' }}>
-              <th style={{ padding: '0.3rem 0.4rem' }}>Name</th>
-              <th style={{ padding: '0.3rem 0.4rem' }}>Instance ID</th>
-              <th style={{ padding: '0.3rem 0.4rem' }}>Org</th>
-              <th style={{ padding: '0.3rem 0.4rem' }}>Topology</th>
-              <th style={{ padding: '0.3rem 0.4rem' }}>Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {items.map((inst) => (
-              <tr
-                key={inst.id || inst.name}
-                data-testid={`sov-instance-row-${inst.name}`}
-              >
-                <td style={{ padding: '0.3rem 0.4rem' }}>
-                  <code>{inst.name}</code>
-                </td>
-                <td
-                  style={{ padding: '0.3rem 0.4rem', color: 'var(--color-text-dim)' }}
-                >
-                  <code>{inst.id ? inst.id.slice(0, 8) : '—'}</code>
-                </td>
-                <td style={{ padding: '0.3rem 0.4rem' }}>{inst.org}</td>
-                <td style={{ padding: '0.3rem 0.4rem' }}>{inst.topology}</td>
-                <td style={{ padding: '0.3rem 0.4rem' }}>
-                  <span className="chip chip-cat">{inst.status}</span>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
-
-      {instancesQuery.isError ? (
-        <p
-          className="section-hint"
-          data-testid="sov-instances-error"
-          style={{ margin: '0.4rem 0 0', color: 'var(--color-danger)' }}
-        >
-          Failed to load instances:{' '}
-          {(instancesQuery.error as Error)?.message ?? 'unknown error'}
-        </p>
-      ) : null}
-
-      {/* Per-cluster fan-out for the CURRENT Application (G117.6) */}
-      {perCluster && perCluster.length > 0 ? (
-        <div style={{ marginTop: '0.8rem' }} data-testid="sov-percluster-block">
-          <h3
-            style={{
-              fontSize: '0.85rem',
-              margin: '0 0 0.3rem',
-              color: 'var(--color-text-strong)',
-            }}
-          >
-            Per-cluster fan-out
-            {appUID ? (
-              <span
-                style={{
-                  marginLeft: '0.5rem',
-                  fontSize: '0.7rem',
-                  color: 'var(--color-text-dim)',
-                  fontWeight: 400,
-                }}
-              >
-                (uid {appUID.slice(0, 8)})
-              </span>
-            ) : null}
-          </h3>
-          <table
-            data-testid="sov-percluster-table"
-            style={{
-              width: '100%',
-              borderCollapse: 'collapse',
-              fontSize: '0.78rem',
-            }}
-          >
-            <thead>
-              <tr style={{ textAlign: 'left', color: 'var(--color-text-dim)' }}>
-                <th style={{ padding: '0.25rem 0.4rem' }}>Cluster</th>
-                <th style={{ padding: '0.25rem 0.4rem' }}>Role</th>
-                <th style={{ padding: '0.25rem 0.4rem' }}>Status</th>
-                <th style={{ padding: '0.25rem 0.4rem' }}>HR</th>
-              </tr>
-            </thead>
-            <tbody>
-              {perCluster.map((row, idx) => {
-                const cluster = String(row.cluster ?? row.region ?? '—')
-                const role = String(row.role ?? '—')
-                const status = String(row.status ?? '—')
-                const hr = String(row.hr ?? row.helmRelease ?? '')
-                return (
-                  <tr
-                    key={`${cluster}-${idx}`}
-                    data-testid={`sov-percluster-row-${cluster}`}
-                  >
-                    <td style={{ padding: '0.25rem 0.4rem' }}>
-                      <code>{cluster}</code>
-                    </td>
-                    <td style={{ padding: '0.25rem 0.4rem' }}>{role}</td>
-                    <td style={{ padding: '0.25rem 0.4rem' }}>{status}</td>
-                    <td
-                      style={{
-                        padding: '0.25rem 0.4rem',
-                        color: 'var(--color-text-dim)',
-                      }}
-                    >
-                      {hr || '—'}
-                    </td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
-        </div>
-      ) : null}
-
-      {dialogOpen ? (
-        <NewInstanceDialog
-          blueprint={blueprint}
-          onClose={() => setDialogOpen(false)}
-          onCreated={() => {
-            setDialogOpen(false)
-            qc.invalidateQueries({ queryKey: ['blueprint-instances', blueprint] })
-          }}
-        />
-      ) : null}
-    </section>
-  )
-}
-
-/**
- * NewInstanceDialog — G117.2 #2741 topology-picker dialog. Opens on
- * "+ New instance" click. Fields:
- *
- *  - name (string, lowercase k8s-name)
- *  - org (string, free-text; defaults to "" — operator types the Org
- *    slug they're installing into. TBD-followup: replace with a real
- *    Org picker once the OrgList endpoint is wired into the FE).
- *  - topology (radio: singleton / active-hot-standby / active-active /
- *    active-passive, gated by Blueprint.spec.topology.supported[] from
- *    getCatalogItemVersion). Defaults to the Blueprint's preferred
- *    default if exposed.
- *
- * On submit POSTs to /catalyst/v1/apps/instances via
- * createApplicationInstance. On 4xx error message renders inline; on
- * 201 the dialog closes and the parent invalidates the instances
- * cache.
- */
-function NewInstanceDialog({
-  blueprint,
-  onClose,
-  onCreated,
-}: {
-  blueprint: string
-  onClose: () => void
-  onCreated: () => void
-}) {
-  const [name, setName] = useState('')
-  const [org, setOrg] = useState('')
-  const [topology, setTopology] = useState<string>('')
-  const [submitting, setSubmitting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  // Resolve the Blueprint's supported topologies via the catalog
-  // version endpoint. We don't have a fixed version pin from the
-  // AppDetail context, so call `getCatalogItem` first to read the
-  // latest version and then re-fetch with that version for the
-  // configSchema. For the dialog we only need `raw.spec.topology`, so
-  // a single getCatalogItemVersion call against the latest version is
-  // sufficient.
-  const bpName = blueprint.replace(/^bp-/, '')
-  const bpQuery = useQuery({
-    queryKey: ['catalog-item-latest', bpName],
-    queryFn: async () => {
-      // First fetch — get the latest version pin.
-      const { getCatalogItem } = await import('@/lib/catalog.api')
-      const latest = await getCatalogItem(bpName)
-      // Second fetch — get the full raw spec (topology, configSchema).
-      const full = await getCatalogItemVersion(bpName, latest.version)
-      return full
-    },
-    staleTime: 60_000,
-    retry: 1,
-  })
-
-  const supportedTopologies = useMemo<string[]>(() => {
-    const raw = bpQuery.data?.raw as
-      | { spec?: { topology?: { supported?: string[]; defaults?: Record<string, string> } } }
-      | undefined
-    const list = raw?.spec?.topology?.supported ?? []
-    if (!Array.isArray(list)) return []
-    return list.filter((s) => typeof s === 'string')
-  }, [bpQuery.data])
-
-  const defaultTopology = useMemo<string>(() => {
-    const raw = bpQuery.data?.raw as
-      | { spec?: { topology?: { defaults?: Record<string, string> } } }
-      | undefined
-    const defs = raw?.spec?.topology?.defaults
-    // Prefer multi-region default if set; else single-region; else
-    // first supported entry.
-    return defs?.['multi-region'] ?? defs?.['single-region'] ?? supportedTopologies[0] ?? ''
-  }, [bpQuery.data, supportedTopologies])
-
-  useEffect(() => {
-    if (!topology && defaultTopology) {
-      setTopology(defaultTopology)
-    }
-  }, [defaultTopology, topology])
-
-  async function onSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    if (submitting) return
-    setError(null)
-    setSubmitting(true)
-    try {
-      const body: CreateApplicationInstanceRequest = {
-        blueprint: bpName,
-        org: org.trim(),
-        name: name.trim(),
-      }
-      if (topology) body.topology = topology
-      await createApplicationInstance(body)
-      onCreated()
-    } catch (err) {
-      const e = err as Error & { code?: string; status?: number }
-      const code = e.code ? ` (${e.code})` : ''
-      setError(`${e.message}${code}`)
-    } finally {
-      setSubmitting(false)
-    }
-  }
-
-  return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="new-instance-dialog-title"
-      data-testid="dialog-new-instance"
-      style={{
-        position: 'fixed',
-        inset: 0,
-        background: 'rgba(0,0,0,0.5)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 1000,
-      }}
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose()
-      }}
-    >
-      <form
-        onSubmit={onSubmit}
-        style={{
-          background: 'var(--color-surface)',
-          color: 'var(--color-text)',
-          border: '1px solid var(--color-border)',
-          borderRadius: '8px',
-          padding: '1.2rem',
-          minWidth: '420px',
-          maxWidth: '520px',
-          boxShadow: '0 10px 40px rgba(0,0,0,0.3)',
-        }}
-      >
-        <h3
-          id="new-instance-dialog-title"
-          style={{ margin: '0 0 0.8rem', fontSize: '1.05rem' }}
-        >
-          New instance of {bpName}
-        </h3>
-
-        <label
-          style={{ display: 'block', marginBottom: '0.6rem', fontSize: '0.85rem' }}
-        >
-          <span style={{ display: 'block', marginBottom: '0.2rem' }}>
-            Instance name
-          </span>
-          <input
-            type="text"
-            data-testid="input-instance-name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-            pattern="^[a-z0-9][a-z0-9-]{0,40}[a-z0-9]$"
-            title="Lowercase letters, digits, and dashes; 2-42 chars; no leading/trailing dash"
-            placeholder="my-instance"
-            style={{
-              width: '100%',
-              padding: '0.4rem 0.6rem',
-              background: 'var(--color-bg)',
-              color: 'var(--color-text)',
-              border: '1px solid var(--color-border)',
-              borderRadius: '4px',
-              fontSize: '0.85rem',
-            }}
-          />
-        </label>
-
-        <label
-          style={{ display: 'block', marginBottom: '0.6rem', fontSize: '0.85rem' }}
-        >
-          <span style={{ display: 'block', marginBottom: '0.2rem' }}>
-            Organization
-          </span>
-          <input
-            type="text"
-            data-testid="input-instance-org"
-            value={org}
-            onChange={(e) => setOrg(e.target.value)}
-            required
-            placeholder="acme"
-            style={{
-              width: '100%',
-              padding: '0.4rem 0.6rem',
-              background: 'var(--color-bg)',
-              color: 'var(--color-text)',
-              border: '1px solid var(--color-border)',
-              borderRadius: '4px',
-              fontSize: '0.85rem',
-            }}
-          />
-        </label>
-
-        <fieldset
-          style={{
-            border: '1px solid var(--color-border)',
-            borderRadius: '4px',
-            padding: '0.5rem 0.7rem',
-            marginBottom: '0.6rem',
-          }}
-        >
-          <legend style={{ fontSize: '0.8rem', padding: '0 0.3rem' }}>
-            Topology
-          </legend>
-          {bpQuery.isPending ? (
-            <p style={{ fontSize: '0.78rem', margin: 0, color: 'var(--color-text-dim)' }}>
-              Loading…
-            </p>
-          ) : supportedTopologies.length === 0 ? (
-            <p
-              style={{ fontSize: '0.78rem', margin: 0, color: 'var(--color-text-dim)' }}
-              data-testid="topology-radio-empty"
-            >
-              Blueprint does not declare supported topologies — server will
-              pick the default.
-            </p>
-          ) : (
-            supportedTopologies.map((t) => (
-              <label
-                key={t}
-                style={{
-                  display: 'block',
-                  fontSize: '0.82rem',
-                  padding: '0.15rem 0',
-                  cursor: 'pointer',
-                }}
-              >
-                <input
-                  type="radio"
-                  name="topology"
-                  value={t}
-                  checked={topology === t}
-                  onChange={() => setTopology(t)}
-                  data-testid={`topology-radio-${t}`}
-                  style={{ marginRight: '0.4rem' }}
-                />
-                {t}
-              </label>
-            ))
-          )}
-        </fieldset>
-
-        {error ? (
-          <p
-            data-testid="dialog-error"
-            style={{
-              color: 'var(--color-danger)',
-              fontSize: '0.8rem',
-              margin: '0 0 0.6rem',
-            }}
-          >
-            {error}
-          </p>
-        ) : null}
-
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'flex-end',
-            gap: '0.5rem',
-          }}
-        >
-          <button
-            type="button"
-            data-testid="btn-cancel-instance"
-            onClick={onClose}
-            disabled={submitting}
-            style={{
-              padding: '0.35rem 0.8rem',
-              background: 'transparent',
-              color: 'var(--color-text)',
-              border: '1px solid var(--color-border)',
-              borderRadius: '4px',
-              fontSize: '0.82rem',
-              cursor: 'pointer',
-            }}
-          >
-            Cancel
-          </button>
-          <button
-            type="submit"
-            data-testid="btn-submit-instance"
-            disabled={submitting || !name || !org}
-            style={{
-              padding: '0.35rem 0.8rem',
-              background: 'var(--color-accent)',
-              color: 'white',
-              border: '0',
-              borderRadius: '4px',
-              fontSize: '0.82rem',
-              cursor: submitting ? 'not-allowed' : 'pointer',
-              fontWeight: 600,
-            }}
-          >
-            {submitting ? 'Creating…' : 'Create instance'}
-          </button>
-        </div>
-      </form>
-    </div>
   )
 }
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
@@ -1,0 +1,590 @@
+/**
+ * InstancesSection + NewInstanceDialog — G117.2 #2741 CLASS-page widgets.
+ *
+ * These two components belong to the CATALOG / class surface
+ * (`/catalog/$blueprintName` → CatalogDetail), NOT the per-instance
+ * surface (`/app/$componentId` → AppDetail). They were originally
+ * inlined in AppDetail.tsx, which made AppDetail wrongly render the
+ * class instances-list + "+ New instance" button on what is supposed to
+ * be a single deployed-instance page (#3090). Extracted here so both the
+ * class page (CatalogDetail) can own them and AppDetail can drop the
+ * class-level content while keeping its own per-cluster fan-out view.
+ *
+ * Backed by:
+ *   GET  /catalyst/v1/catalog/{blueprint}/instances → instances list
+ *   POST /catalyst/v1/apps/instances                → create instance
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from '@tanstack/react-router'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  getApplicationInstances,
+  createApplicationInstance,
+  getCatalogItemVersion,
+  type ApplicationInstanceSummary,
+  type CreateApplicationInstanceRequest,
+} from '@/lib/catalog.api'
+
+/**
+ * InstancesSection — renders the per-Blueprint instances list (one row
+ * per concrete install) plus a "+ New instance" button that opens the
+ * topology-picker dialog inline (no navigation). This is the class →
+ * instance drill-down the H10 walk requires: the CLASS surface lists
+ * every concrete instance the operator can drill into.
+ *
+ * The optional `perCluster` block is preserved for callers that still
+ * want to surface a CURRENT-Application fan-out table here, but the
+ * canonical home for per-cluster status of a single instance is now the
+ * instance page (AppDetail) itself — CatalogDetail does not pass it.
+ *
+ * On 404 / empty list, the list block renders an empty-state with the
+ * "+ New instance" button still active so the operator can install the
+ * first instance.
+ */
+export function InstancesSection({
+  blueprint,
+  appUID,
+  perCluster,
+}: {
+  blueprint: string
+  appUID?: string
+  perCluster?: Array<Record<string, unknown>>
+}) {
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const qc = useQueryClient()
+
+  const instancesQuery = useQuery({
+    queryKey: ['blueprint-instances', blueprint],
+    queryFn: () => getApplicationInstances(blueprint),
+    enabled: !!blueprint,
+    staleTime: 15_000,
+    refetchInterval: 15_000,
+    retry: 1,
+  })
+
+  const items: ApplicationInstanceSummary[] = instancesQuery.data?.items ?? []
+
+  return (
+    <section
+      className="section"
+      data-testid="sov-section-instances"
+      style={{ marginTop: '0.6rem' }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: '0.4rem',
+        }}
+      >
+        <h2 style={{ margin: 0 }}>Instances</h2>
+        <button
+          type="button"
+          data-testid="btn-new-instance"
+          onClick={() => setDialogOpen(true)}
+          className="btn btn-primary"
+          style={{
+            padding: '0.3rem 0.8rem',
+            fontSize: '0.82rem',
+            background: 'var(--color-accent)',
+            color: 'white',
+            border: '0',
+            borderRadius: '6px',
+            cursor: 'pointer',
+            fontWeight: 600,
+          }}
+          aria-label="Create a new instance of this Blueprint"
+        >
+          + New instance
+        </button>
+      </div>
+
+      {instancesQuery.isPending ? (
+        <p
+          className="section-hint"
+          data-testid="sov-instances-loading"
+          style={{ margin: 0 }}
+        >
+          Loading instances…
+        </p>
+      ) : items.length === 0 ? (
+        <p
+          className="section-hint"
+          data-testid="sov-instances-empty"
+          style={{ margin: 0 }}
+        >
+          No instances of this Blueprint installed yet. Click "+ New
+          instance" to create the first one.
+        </p>
+      ) : (
+        <table
+          data-testid="sov-instances-table"
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontSize: '0.82rem',
+          }}
+        >
+          <thead>
+            <tr style={{ textAlign: 'left', color: 'var(--color-text-dim)' }}>
+              <th style={{ padding: '0.3rem 0.4rem' }}>Name</th>
+              <th style={{ padding: '0.3rem 0.4rem' }}>Instance ID</th>
+              <th style={{ padding: '0.3rem 0.4rem' }}>Org</th>
+              <th style={{ padding: '0.3rem 0.4rem' }}>Topology</th>
+              <th style={{ padding: '0.3rem 0.4rem' }}>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((inst) => (
+              <tr
+                key={inst.id || inst.name}
+                data-testid={`sov-instance-row-${inst.name}`}
+              >
+                <td style={{ padding: '0.3rem 0.4rem' }}>
+                  {/* #3090 — instance rows drill into the INSTANCE page
+                      `/app/$componentId`. The Application instance is
+                      addressed by its Blueprint-scoped component id
+                      (`bp-<blueprint>`), matching consoleAppDetailRoute. */}
+                  <Link
+                    to={'/app/$componentId' as never}
+                    params={{ componentId: `bp-${inst.blueprint}` } as never}
+                    data-testid={`sov-instance-link-${inst.name}`}
+                  >
+                    <code>{inst.name}</code>
+                  </Link>
+                </td>
+                <td
+                  style={{ padding: '0.3rem 0.4rem', color: 'var(--color-text-dim)' }}
+                >
+                  <code>{inst.id ? inst.id.slice(0, 8) : '—'}</code>
+                </td>
+                <td style={{ padding: '0.3rem 0.4rem' }}>{inst.org}</td>
+                <td style={{ padding: '0.3rem 0.4rem' }}>{inst.topology}</td>
+                <td style={{ padding: '0.3rem 0.4rem' }}>
+                  <span className="chip chip-cat">{inst.status}</span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {instancesQuery.isError ? (
+        <p
+          className="section-hint"
+          data-testid="sov-instances-error"
+          style={{ margin: '0.4rem 0 0', color: 'var(--color-danger)' }}
+        >
+          Failed to load instances:{' '}
+          {(instancesQuery.error as Error)?.message ?? 'unknown error'}
+        </p>
+      ) : null}
+
+      {/* Per-cluster fan-out for the CURRENT Application (G117.6) —
+          optional; CatalogDetail does not pass `perCluster`. */}
+      {perCluster && perCluster.length > 0 ? (
+        <div style={{ marginTop: '0.8rem' }} data-testid="sov-percluster-block">
+          <h3
+            style={{
+              fontSize: '0.85rem',
+              margin: '0 0 0.3rem',
+              color: 'var(--color-text-strong)',
+            }}
+          >
+            Per-cluster fan-out
+            {appUID ? (
+              <span
+                style={{
+                  marginLeft: '0.5rem',
+                  fontSize: '0.7rem',
+                  color: 'var(--color-text-dim)',
+                  fontWeight: 400,
+                }}
+              >
+                (uid {appUID.slice(0, 8)})
+              </span>
+            ) : null}
+          </h3>
+          <PerClusterTable perCluster={perCluster} />
+        </div>
+      ) : null}
+
+      {dialogOpen ? (
+        <NewInstanceDialog
+          blueprint={blueprint}
+          onClose={() => setDialogOpen(false)}
+          onCreated={() => {
+            setDialogOpen(false)
+            qc.invalidateQueries({ queryKey: ['blueprint-instances', blueprint] })
+          }}
+        />
+      ) : null}
+    </section>
+  )
+}
+
+/**
+ * PerClusterTable — renders an Application's `status.perCluster[]`
+ * fan-out (cluster + role + status + hr) as a compact table. Shared so
+ * BOTH the class-page InstancesSection (optional) and the per-instance
+ * AppDetail page can surface the same view for a single Application
+ * without duplicating the row markup (#3090).
+ */
+export function PerClusterTable({
+  perCluster,
+}: {
+  perCluster: Array<Record<string, unknown>>
+}) {
+  return (
+    <table
+      data-testid="sov-percluster-table"
+      style={{
+        width: '100%',
+        borderCollapse: 'collapse',
+        fontSize: '0.78rem',
+      }}
+    >
+      <thead>
+        <tr style={{ textAlign: 'left', color: 'var(--color-text-dim)' }}>
+          <th style={{ padding: '0.25rem 0.4rem' }}>Cluster</th>
+          <th style={{ padding: '0.25rem 0.4rem' }}>Role</th>
+          <th style={{ padding: '0.25rem 0.4rem' }}>Status</th>
+          <th style={{ padding: '0.25rem 0.4rem' }}>HR</th>
+        </tr>
+      </thead>
+      <tbody>
+        {perCluster.map((row, idx) => {
+          const cluster = String(row.cluster ?? row.region ?? '—')
+          const role = String(row.role ?? '—')
+          const status = String(row.status ?? '—')
+          const hr = String(row.hr ?? row.helmRelease ?? '')
+          return (
+            <tr
+              key={`${cluster}-${idx}`}
+              data-testid={`sov-percluster-row-${cluster}`}
+            >
+              <td style={{ padding: '0.25rem 0.4rem' }}>
+                <code>{cluster}</code>
+              </td>
+              <td style={{ padding: '0.25rem 0.4rem' }}>{role}</td>
+              <td style={{ padding: '0.25rem 0.4rem' }}>{status}</td>
+              <td
+                style={{
+                  padding: '0.25rem 0.4rem',
+                  color: 'var(--color-text-dim)',
+                }}
+              >
+                {hr || '—'}
+              </td>
+            </tr>
+          )
+        })}
+      </tbody>
+    </table>
+  )
+}
+
+/**
+ * NewInstanceDialog — G117.2 #2741 topology-picker dialog. Opens on
+ * "+ New instance" click. Fields:
+ *
+ *  - name (string, lowercase k8s-name)
+ *  - org (string, free-text; defaults to "" — operator types the Org
+ *    slug they're installing into. TBD-followup: replace with a real
+ *    Org picker once the OrgList endpoint is wired into the FE).
+ *  - topology (radio: singleton / active-hot-standby / active-active /
+ *    active-passive, gated by Blueprint.spec.topology.supported[] from
+ *    getCatalogItemVersion). Defaults to the Blueprint's preferred
+ *    default if exposed.
+ *
+ * On submit POSTs to /catalyst/v1/apps/instances via
+ * createApplicationInstance. On 4xx error message renders inline; on
+ * 201 the dialog closes and the parent invalidates the instances
+ * cache.
+ */
+export function NewInstanceDialog({
+  blueprint,
+  onClose,
+  onCreated,
+}: {
+  blueprint: string
+  onClose: () => void
+  onCreated: () => void
+}) {
+  const [name, setName] = useState('')
+  const [org, setOrg] = useState('')
+  const [topology, setTopology] = useState<string>('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Resolve the Blueprint's supported topologies via the catalog
+  // version endpoint. We don't have a fixed version pin from the
+  // AppDetail context, so call `getCatalogItem` first to read the
+  // latest version and then re-fetch with that version for the
+  // configSchema. For the dialog we only need `raw.spec.topology`, so
+  // a single getCatalogItemVersion call against the latest version is
+  // sufficient.
+  const bpName = blueprint.replace(/^bp-/, '')
+  const bpQuery = useQuery({
+    queryKey: ['catalog-item-latest', bpName],
+    queryFn: async () => {
+      // First fetch — get the latest version pin.
+      const { getCatalogItem } = await import('@/lib/catalog.api')
+      const latest = await getCatalogItem(bpName)
+      // Second fetch — get the full raw spec (topology, configSchema).
+      const full = await getCatalogItemVersion(bpName, latest.version)
+      return full
+    },
+    staleTime: 60_000,
+    retry: 1,
+  })
+
+  const supportedTopologies = useMemo<string[]>(() => {
+    const raw = bpQuery.data?.raw as
+      | { spec?: { topology?: { supported?: string[]; defaults?: Record<string, string> } } }
+      | undefined
+    const list = raw?.spec?.topology?.supported ?? []
+    if (!Array.isArray(list)) return []
+    return list.filter((s) => typeof s === 'string')
+  }, [bpQuery.data])
+
+  const defaultTopology = useMemo<string>(() => {
+    const raw = bpQuery.data?.raw as
+      | { spec?: { topology?: { defaults?: Record<string, string> } } }
+      | undefined
+    const defs = raw?.spec?.topology?.defaults
+    // Prefer multi-region default if set; else single-region; else
+    // first supported entry.
+    return defs?.['multi-region'] ?? defs?.['single-region'] ?? supportedTopologies[0] ?? ''
+  }, [bpQuery.data, supportedTopologies])
+
+  useEffect(() => {
+    if (!topology && defaultTopology) {
+      setTopology(defaultTopology)
+    }
+  }, [defaultTopology, topology])
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (submitting) return
+    setError(null)
+    setSubmitting(true)
+    try {
+      const body: CreateApplicationInstanceRequest = {
+        blueprint: bpName,
+        org: org.trim(),
+        name: name.trim(),
+      }
+      if (topology) body.topology = topology
+      await createApplicationInstance(body)
+      onCreated()
+    } catch (err) {
+      const e = err as Error & { code?: string; status?: number }
+      const code = e.code ? ` (${e.code})` : ''
+      setError(`${e.message}${code}`)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="new-instance-dialog-title"
+      data-testid="dialog-new-instance"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <form
+        onSubmit={onSubmit}
+        style={{
+          background: 'var(--color-surface)',
+          color: 'var(--color-text)',
+          border: '1px solid var(--color-border)',
+          borderRadius: '8px',
+          padding: '1.2rem',
+          minWidth: '420px',
+          maxWidth: '520px',
+          boxShadow: '0 10px 40px rgba(0,0,0,0.3)',
+        }}
+      >
+        <h3
+          id="new-instance-dialog-title"
+          style={{ margin: '0 0 0.8rem', fontSize: '1.05rem' }}
+        >
+          New instance of {bpName}
+        </h3>
+
+        <label
+          style={{ display: 'block', marginBottom: '0.6rem', fontSize: '0.85rem' }}
+        >
+          <span style={{ display: 'block', marginBottom: '0.2rem' }}>
+            Instance name
+          </span>
+          <input
+            type="text"
+            data-testid="input-instance-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            pattern="^[a-z0-9][a-z0-9-]{0,40}[a-z0-9]$"
+            title="Lowercase letters, digits, and dashes; 2-42 chars; no leading/trailing dash"
+            placeholder="my-instance"
+            style={{
+              width: '100%',
+              padding: '0.4rem 0.6rem',
+              background: 'var(--color-bg)',
+              color: 'var(--color-text)',
+              border: '1px solid var(--color-border)',
+              borderRadius: '4px',
+              fontSize: '0.85rem',
+            }}
+          />
+        </label>
+
+        <label
+          style={{ display: 'block', marginBottom: '0.6rem', fontSize: '0.85rem' }}
+        >
+          <span style={{ display: 'block', marginBottom: '0.2rem' }}>
+            Organization
+          </span>
+          <input
+            type="text"
+            data-testid="input-instance-org"
+            value={org}
+            onChange={(e) => setOrg(e.target.value)}
+            required
+            placeholder="acme"
+            style={{
+              width: '100%',
+              padding: '0.4rem 0.6rem',
+              background: 'var(--color-bg)',
+              color: 'var(--color-text)',
+              border: '1px solid var(--color-border)',
+              borderRadius: '4px',
+              fontSize: '0.85rem',
+            }}
+          />
+        </label>
+
+        <fieldset
+          style={{
+            border: '1px solid var(--color-border)',
+            borderRadius: '4px',
+            padding: '0.5rem 0.7rem',
+            marginBottom: '0.6rem',
+          }}
+        >
+          <legend style={{ fontSize: '0.8rem', padding: '0 0.3rem' }}>
+            Topology
+          </legend>
+          {bpQuery.isPending ? (
+            <p style={{ fontSize: '0.78rem', margin: 0, color: 'var(--color-text-dim)' }}>
+              Loading…
+            </p>
+          ) : supportedTopologies.length === 0 ? (
+            <p
+              style={{ fontSize: '0.78rem', margin: 0, color: 'var(--color-text-dim)' }}
+              data-testid="topology-radio-empty"
+            >
+              Blueprint does not declare supported topologies — server will
+              pick the default.
+            </p>
+          ) : (
+            supportedTopologies.map((t) => (
+              <label
+                key={t}
+                style={{
+                  display: 'block',
+                  fontSize: '0.82rem',
+                  padding: '0.15rem 0',
+                  cursor: 'pointer',
+                }}
+              >
+                <input
+                  type="radio"
+                  name="topology"
+                  value={t}
+                  checked={topology === t}
+                  onChange={() => setTopology(t)}
+                  data-testid={`topology-radio-${t}`}
+                  style={{ marginRight: '0.4rem' }}
+                />
+                {t}
+              </label>
+            ))
+          )}
+        </fieldset>
+
+        {error ? (
+          <p
+            data-testid="dialog-error"
+            style={{
+              color: 'var(--color-danger)',
+              fontSize: '0.8rem',
+              margin: '0 0 0.6rem',
+            }}
+          >
+            {error}
+          </p>
+        ) : null}
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: '0.5rem',
+          }}
+        >
+          <button
+            type="button"
+            data-testid="btn-cancel-instance"
+            onClick={onClose}
+            disabled={submitting}
+            style={{
+              padding: '0.35rem 0.8rem',
+              background: 'transparent',
+              color: 'var(--color-text)',
+              border: '1px solid var(--color-border)',
+              borderRadius: '4px',
+              fontSize: '0.82rem',
+              cursor: 'pointer',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            data-testid="btn-submit-instance"
+            disabled={submitting || !name || !org}
+            style={{
+              padding: '0.35rem 0.8rem',
+              background: 'var(--color-accent)',
+              color: 'white',
+              border: '0',
+              borderRadius: '4px',
+              fontSize: '0.82rem',
+              cursor: submitting ? 'not-allowed' : 'pointer',
+              fontWeight: 600,
+            }}
+          >
+            {submitting ? 'Creating…' : 'Create instance'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.test.tsx
@@ -21,6 +21,7 @@ import {
   createMemoryHistory,
   Outlet,
 } from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AppsPage } from './AppsPage'
 import { useWizardStore } from '@/entities/deployment/store'
 import { INITIAL_WIZARD_STATE } from '@/entities/deployment/model'
@@ -44,6 +45,12 @@ function renderProvision(deploymentId: string) {
     path: '/provision/$deploymentId/app/$componentId',
     component: () => <div data-testid="app-detail-target" />,
   })
+  // #3090 — Catalog-tab cards must link to the CLASS page.
+  const catalogDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/catalog/$blueprintName',
+    component: () => <div data-testid="catalog-detail-target" />,
+  })
   const jobsRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/provision/$deploymentId/jobs',
@@ -54,12 +61,27 @@ function renderProvision(deploymentId: string) {
     path: '/wizard',
     component: () => <div data-testid="wizard-target" />,
   })
-  const tree = rootRoute.addChildren([provisionRoute, detailRoute, jobsRoute, wizardRoute])
+  const tree = rootRoute.addChildren([
+    provisionRoute,
+    detailRoute,
+    catalogDetailRoute,
+    jobsRoute,
+    wizardRoute,
+  ])
   const router = createRouter({
     routeTree: tree,
     history: createMemoryHistory({ initialEntries: [`/provision/${deploymentId}`] }),
   })
-  return render(<RouterProvider router={router} />)
+  // AppsPage's liveAppsQuery (useQuery, enabled on Sovereign mode) needs a
+  // QueryClient in context even when disabled — mirror AppsPage.handover.test.
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
 }
 
 beforeEach(() => {
@@ -173,5 +195,38 @@ describe('AppsPage — card grid', () => {
     expect(after.length).toBeLessThan(before.length)
     // Still see Cilium.
     expect(after.some((c) => c.getAttribute('data-testid') === 'sov-app-card-bp-cilium')).toBe(true)
+  })
+})
+
+describe('AppsPage — #3090 per-tab card link target (class vs instance)', () => {
+  it('Deployments-tab card links to the INSTANCE page /app/$id', async () => {
+    renderProvision('d-1')
+    // Deployments tab is active by default; bootstrap-kit apps (cilium)
+    // always count as deployed so the card is present.
+    const card = await screen.findByTestId('sov-app-card-bp-cilium')
+    expect(card.getAttribute('href')).toBe('/provision/d-1/app/bp-cilium')
+  })
+
+  it('Catalog-tab card links to the CLASS page /catalog/$blueprint', async () => {
+    renderProvision('d-1')
+    fireEvent.click(await screen.findByTestId('sov-tab-catalog'))
+    const card = await screen.findByTestId('sov-app-card-bp-cilium')
+    expect(card.getAttribute('href')).toBe('/provision/d-1/catalog/bp-cilium')
+  })
+
+  it('the SAME blueprint card resolves to DIFFERENT targets per tab', async () => {
+    renderProvision('d-1')
+    // Deployments first.
+    const onDeployments = (
+      await screen.findByTestId('sov-app-card-bp-cilium')
+    ).getAttribute('href')
+    // Flip to Catalog.
+    fireEvent.click(screen.getByTestId('sov-tab-catalog'))
+    const onCatalog = (
+      await screen.findByTestId('sov-app-card-bp-cilium')
+    ).getAttribute('href')
+    expect(onDeployments).not.toBe(onCatalog)
+    expect(onDeployments).toContain('/app/bp-cilium')
+    expect(onCatalog).toContain('/catalog/bp-cilium')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
@@ -636,6 +636,7 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
               <AppCard
                 key={app.id}
                 app={app}
+                isCatalog={tab === 'catalog'}
                 environment={environment}
                 externalURL={externalURL}
                 status={(() => {
@@ -697,6 +698,16 @@ interface AppCardProps {
   app: ApplicationDescriptor
   status: ApplicationStatus
   /**
+   * #3090 — which tab this card is rendered under. On the Catalog tab a
+   * card is a Blueprint CLASS and must link to the class page
+   * `/catalog/$blueprint` (instances list + "New instance"). On the
+   * Deployments tab a card is a concrete INSTANCE and must link to the
+   * instance page `/app/$id` (Open button, no New-instance). Before this
+   * split BOTH tabs hard-linked to `/app/$id`, so the class page was
+   * unreachable and the instance page wrongly showed class content.
+   */
+  isCatalog: boolean
+  /**
    * Mirror of canonical `is-service`. The wizard catalog doesn't carry
    * an explicit service flag yet — keep the prop so adding one later
    * is a one-line change. For now, every card is treated as an
@@ -733,7 +744,7 @@ interface AppCardProps {
   externalURL?: string
 }
 
-function AppCard({ app, status, isService, environment, marketplacePublished, slug, onPublishedChange }: AppCardProps) {
+function AppCard({ app, status, isCatalog, isService, environment, marketplacePublished, slug, onPublishedChange }: AppCardProps) {
   const stateClass = `state-${status}`
   // Chroot-aware target: on the mother monitor surface
   // (console.openova.io/sovereign/provision/<id>/...) every link MUST stay
@@ -741,12 +752,18 @@ function AppCard({ app, status, isService, environment, marketplacePublished, sl
   // produces the broken /sovereign/app/<id> path the founder hit on
   // otech122. On the Sovereign's adult hostname the deploymentId is
   // implicit so /app/<id> is correct.
+  //
+  // #3090 — per-tab segment: a Catalog card opens the CLASS page
+  // (`/catalog/$blueprint`), a Deployments card opens the INSTANCE page
+  // (`/app/$id`). Same chroot/provision chroot-scoping logic, only the
+  // path segment differs.
   const params = useParams({ strict: false }) as { deploymentId?: string }
   const depId = params.deploymentId ?? ''
+  const seg = isCatalog ? 'catalog' : 'app'
   const target =
     DETECTED_MODE.mode === 'sovereign' || !depId
-      ? `/app/${app.id}`
-      : `/provision/${depId}/app/${app.id}`
+      ? `/${seg}/${app.id}`
+      : `/provision/${depId}/${seg}/${app.id}`
   return (
     <Link
       to={target as never}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * CatalogDetail.test.tsx — #3090 lock-in for the CLASS page.
+ *
+ * The Catalog / class page (`/catalog/$blueprintName`) renders:
+ *   • Blueprint header (title + version + multi-instance badge)
+ *   • Supported topologies
+ *   • The installed-instances list (one row per concrete install)
+ *   • A "+ New instance" button that opens the topology-picker dialog
+ *     INLINE (no navigation to a /new route — that route 404'd before).
+ *
+ * Instance rows link to the INSTANCE page `/app/$componentId`.
+ *
+ * This is the production React tree (products/catalyst/bootstrap/ui) —
+ * it replaces the abandoned Astro+Svelte console scaffold whose specs
+ * lived under products/catalyst/console (never shipped).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { CatalogDetail } from './CatalogDetail'
+
+const GRAFANA_CATALOG = {
+  name: 'grafana',
+  version: '1.0.5',
+  card: { title: 'Grafana', description: 'Dashboards', family: 'observability' },
+  origin: 'upstream',
+  source: 'gitea',
+  raw: {
+    spec: {
+      multiInstance: { enabled: true },
+      topology: {
+        supported: ['singleton', 'active-hot-standby'],
+        default: 'singleton',
+        defaults: { 'single-region': 'singleton' },
+      },
+    },
+  },
+}
+
+const GRAFANA_INSTANCES = {
+  items: [
+    {
+      id: 'aaaaaaaa-1111',
+      name: 'obs-1',
+      blueprint: 'grafana',
+      org: 'acme',
+      topology: 'singleton',
+      status: 'Ready',
+    },
+    {
+      id: 'bbbbbbbb-2222',
+      name: 'obs-2',
+      blueprint: 'grafana',
+      org: 'acme',
+      topology: 'singleton',
+      status: 'Ready',
+    },
+  ],
+}
+
+function installCatalogFetch() {
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (url.includes('/instances')) {
+      return jsonRes(GRAFANA_INSTANCES)
+    }
+    // /catalog/grafana and /catalog/grafana/versions/<v> both return the
+    // catalog item (the dialog fetches the version variant for topology).
+    if (url.includes('/catalog/')) {
+      return jsonRes(GRAFANA_CATALOG)
+    }
+    return jsonRes({})
+  }) as typeof fetch
+}
+
+function jsonRes(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  } as unknown as Response)
+}
+
+function renderCatalog(blueprintName: string) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const catalogRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/catalog/$blueprintName',
+    component: CatalogDetail,
+  })
+  // Instance rows link here.
+  const appRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/app/$componentId',
+    component: () => <div data-testid="app-detail-target" />,
+  })
+  const tree = rootRoute.addChildren([catalogRoute, appRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: [`/catalog/${blueprintName}`] }),
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  installCatalogFetch()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('CatalogDetail — #3090 class page', () => {
+  it('renders the Blueprint header + multi-instance badge', async () => {
+    renderCatalog('grafana')
+    expect((await screen.findByTestId('catalog-title')).textContent).toContain('Grafana')
+    expect(screen.getByTestId('catalog-version').textContent).toContain('v1.0.5')
+    expect(screen.getByTestId('badge-multi-instance')).toBeTruthy()
+  })
+
+  it('renders the supported-topologies list', async () => {
+    renderCatalog('grafana')
+    await screen.findByTestId('catalog-title')
+    expect(screen.getByText('singleton')).toBeTruthy()
+    expect(screen.getByText('active-hot-standby')).toBeTruthy()
+  })
+
+  it('renders the instances list (one row per install) + "+ New instance" button', async () => {
+    renderCatalog('grafana')
+    // The shared InstancesSection drives the list.
+    expect(await screen.findByTestId('sov-section-instances')).toBeTruthy()
+    expect(await screen.findByTestId('sov-instances-table')).toBeTruthy()
+    expect(screen.getByTestId('sov-instance-row-obs-1')).toBeTruthy()
+    expect(screen.getByTestId('sov-instance-row-obs-2')).toBeTruthy()
+    expect(screen.getByTestId('btn-new-instance')).toBeTruthy()
+  })
+
+  it('instance rows link to the INSTANCE page /app/$componentId', async () => {
+    renderCatalog('grafana')
+    const link = await screen.findByTestId('sov-instance-link-obs-1')
+    expect(link.getAttribute('href')).toBe('/app/bp-grafana')
+  })
+
+  it('"+ New instance" opens the topology dialog INLINE (no navigation, no 404)', async () => {
+    renderCatalog('grafana')
+    const btn = await screen.findByTestId('btn-new-instance')
+    // No href — it is a button, not a link to a /new route (the old
+    // `/catalog/$blueprintName/new` link 404'd).
+    expect(btn.getAttribute('href')).toBeNull()
+    fireEvent.click(btn)
+    // The dialog mounts in-place; we did NOT navigate away to the
+    // instance page (no /new route, no /app route reached).
+    expect(await screen.findByTestId('dialog-new-instance')).toBeTruthy()
+    expect(screen.queryByTestId('app-detail-target')).toBeNull()
+    // The class page itself is still mounted under the dialog.
+    expect(screen.getByTestId('catalog-drilldown')).toBeTruthy()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
@@ -1,30 +1,35 @@
-import { useParams, Link } from '@tanstack/react-router'
+import { useParams } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
 
-import {
-  getCatalogItem,
-  listBlueprintInstancesByName,
-  type CatalogItem,
-  type ApplicationInstanceSummary,
-} from '@/lib/catalog.api'
+import { getCatalogItem, type CatalogItem } from '@/lib/catalog.api'
+import { InstancesSection } from './AppDetail/InstancesSection'
 
 /**
  * G117.2 #2741 — Catalog drill-down (class detail).
  *
- * Route: `/catalog/$blueprintName` (under consoleLayoutRoute).
+ * Route: `/catalog/$blueprintName` (under consoleLayoutRoute) + the
+ * `/provision/$deploymentId/catalog/$blueprintName` chroot/provision
+ * variant.
  *
- * Renders the per-Blueprint CLASS page — header with metadata, list of
- * instances, "+ New instance" action. NOT the per-instance view (that
- * is `/app/$componentId` → AppDetail).
+ * Renders the per-Blueprint CLASS page — header with metadata, supported
+ * topologies, the list of installed instances, and a "+ New instance"
+ * action. NOT the per-instance view (that is `/app/$componentId` →
+ * AppDetail).
  *
- * Ports the Astro+Svelte scaffold at
- * `products/catalyst/console/src/routes/catalog/[name]/+page.svelte`
- * to the production React UI. The scaffold never reached operators
- * because the catalyst-ui Containerfile copies only `bootstrap/ui/`.
+ * #3090: this page was registered but ORPHANED — every app card (Catalog
+ * AND Deployments tab) hard-linked to `/app/$id`, so the class page was
+ * never reached and the instance page wrongly rendered the class
+ * instances-list + "+ New instance" button. AppsPage now links Catalog
+ * cards here. The instances list + New-instance dialog are the shared
+ * `InstancesSection` (lifted out of AppDetail) so the class behaviour
+ * lives in exactly one place; the "+ New instance" button opens the
+ * topology-picker dialog INLINE (no navigation) — the previous
+ * `/catalog/$blueprintName/new` link had no route and 404'd.
  *
  * Backed by:
  *   GET /api/v1/catalog/{name}                        → CatalogItem
  *   GET /catalyst/v1/catalog/{blueprint}/instances    → BlueprintInstance[]
+ *        (fetched inside InstancesSection)
  */
 export function CatalogDetail() {
   const { blueprintName } = useParams({ strict: false }) as { blueprintName?: string }
@@ -35,15 +40,6 @@ export function CatalogDetail() {
     queryFn: () => getCatalogItem(name),
     enabled: !!name,
     staleTime: 30_000,
-    retry: 1,
-  })
-
-  const instancesQuery = useQuery<ApplicationInstanceSummary[]>({
-    queryKey: ['blueprint-instances', name],
-    queryFn: () => listBlueprintInstancesByName(name),
-    enabled: !!name,
-    staleTime: 15_000,
-    refetchInterval: 15_000,
     retry: 1,
   })
 
@@ -74,7 +70,6 @@ export function CatalogDetail() {
   }
 
   const cat = catalogQuery.data!
-  const instances = instancesQuery.data ?? []
   const multiInstance = readMultiInstance(cat)
   const topologies = readTopologies(cat)
   const defaultTopology = readDefaultTopology(cat)
@@ -118,81 +113,10 @@ export function CatalogDetail() {
         </section>
       ) : null}
 
-      <section className="instances">
-        <header className="instances-header">
-          <h3>Instances ({instances.length})</h3>
-          {multiInstance ? (
-            <Link
-              to={'/catalog/$blueprintName/new' as never}
-              params={{ blueprintName: name } as never}
-              className="btn-new"
-              data-testid="btn-new-instance"
-            >
-              + New instance
-            </Link>
-          ) : instances.length === 0 ? (
-            <Link
-              to={'/catalog/$blueprintName/new' as never}
-              params={{ blueprintName: name } as never}
-              className="btn-new"
-              data-testid="btn-install-singleton"
-            >
-              Install
-            </Link>
-          ) : (
-            <span className="hint">Singleton-per-Org — already installed.</span>
-          )}
-        </header>
-
-        {instances.length === 0 ? (
-          <p className="empty">No instances yet.</p>
-        ) : (
-          <table data-testid="instance-table">
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Org</th>
-                <th>Topology</th>
-                <th>Status</th>
-                <th>Created</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {instances.map((inst) => (
-                <tr key={inst.id} data-testid={`instance-row-${inst.id}`}>
-                  <td>
-                    <Link
-                      to={'/app/$componentId' as never}
-                      params={{ componentId: `bp-${inst.blueprint}` } as never}
-                      data-testid={`instance-link-${inst.id}`}
-                    >
-                      {inst.name}
-                    </Link>
-                  </td>
-                  <td>{inst.org}</td>
-                  <td><code>{inst.topology}</code></td>
-                  <td>
-                    <span className={`status status-${inst.status.toLowerCase()}`}>
-                      {inst.status}
-                    </span>
-                  </td>
-                  <td>{inst.createdAt ?? ''}</td>
-                  <td>
-                    <Link
-                      to={'/app/$componentId' as never}
-                      params={{ componentId: `bp-${inst.blueprint}` } as never}
-                      search={{ tab: 'endpoints' } as never}
-                    >
-                      Endpoints
-                    </Link>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </section>
+      {/* #3090 — shared CLASS-page instances list + "+ New instance"
+          (inline topology-picker dialog). Instance rows link to the
+          INSTANCE page `/app/$componentId`. */}
+      <InstancesSection blueprint={`bp-${name}`} />
     </section>
   )
 }

--- a/tests/e2e/playwright/tests/g117-launch-silent-sso.spec.ts
+++ b/tests/e2e/playwright/tests/g117-launch-silent-sso.spec.ts
@@ -104,6 +104,14 @@ test.describe('G117.4 #2743 AC4 — Launch silent-SSO', () => {
   // SKIPPED only if the console dev server isn't reachable.
   // ─────────────────────────────────────────────────────────────────────
   test.describe('MOCK mode', () => {
+    // #3090: this MOCK block drives the RETIRED Astro+Svelte console
+    // (products/catalyst/console) mock backend. That tree is never
+    // shipped. The production React instance page keeps the
+    // `btn-launch-app` testid + silent-SSO behaviour (relabelled
+    // "Launch →" → "Open"), covered by unit tests in bootstrap/ui; the
+    // real silent-SSO walk is the LIVE-mode block below (SOV_FQDN). Skip
+    // the dead-tree mock walk.
+    test.skip(true, '#3090 — retired Svelte console surface; LIVE-mode block below is the real walk')
     test.skip(!!SOV_FQDN, 'MOCK walk runs only when SOV_FQDN is unset')
     // page.goto uses the project baseURL (the shared Group L BASE_URL =
     // bootstrap/ui), but the mock backend lives in the console app. Override

--- a/tests/e2e/playwright/tests/g117-multi-instance-create.spec.ts
+++ b/tests/e2e/playwright/tests/g117-multi-instance-create.spec.ts
@@ -80,6 +80,17 @@ test.describe('G117.2 W2.C2 — multi-instance create flow', () => {
   })
 
   test.describe('MOCK mode (PR-time CI)', () => {
+    // #3090: this MOCK block drives the RETIRED Astro+Svelte console
+    // (products/catalyst/console) and asserts the old class-page model
+    // (btn-new-instance href='/catalog/grafana/new', a /catalog/.../new
+    // route, redirect to /apps/<id>). That tree is never shipped (no
+    // Containerfile copies it) — it's the bug that hid the broken
+    // class/instance split. The production React tree
+    // (products/catalyst/bootstrap/ui) replaces the /new route with an
+    // inline NewInstanceDialog; the equivalent coverage now lives in
+    // CatalogDetail.test.tsx + AppsPage.test.tsx. Skip the dead-tree walk
+    // (LIVE-mode API coverage below is unaffected).
+    test.skip(true, '#3090 — retired Svelte console surface; see CatalogDetail.test.tsx in bootstrap/ui')
     test.skip(!!SOV_FQDN, 'Mock walk runs only when SOV_FQDN is unset')
     // Drive the console mock app (CONSOLE_BASE_URL) rather than the shared
     // Group L baseURL — only the console installs window.__MOCK_API__.


### PR DESCRIPTION
## What

Splits the **Catalog (class) page** from the **Instance page** in the production React console (`products/catalyst/bootstrap/ui/`), and makes the **Open** button always visible on the instance page when the Application has an external URL. Ports the G117.2/.4 two-page model into the React tree — it previously lived only in the never-shipped Astro+Svelte scaffold (`products/catalyst/console/`, no Containerfile), which is the bug that hid this.

### Before (bug)
Catalog-tab cards AND Deployments-tab cards both hard-linked to `/app/$id`. So the registered `CatalogDetail` class page was orphaned, and the instance page wrongly rendered the class instances-list + "+ New instance" button while hiding the Open button.

### After (two distinct pages)
- **(A) CATALOG / class page** `/catalog/$blueprint` (+ provision/chroot variants) → Blueprint header + supported topologies + installed-instances list + "+ New instance". Instance rows link to `/app/$id`. No instance detail.
- **(B) INSTANCE page** `/app/$id` → the one deployed instance, with an **Open** button (1-click silent SSO) when it has an external URL, and **NO** "New instance" button. Keeps this instance's per-cluster fan-out (`status.perCluster[]`).

## Per-file summary
- `src/pages/sovereign/AppsPage.tsx` — `AppCard` gains an `isCatalog` prop; per-tab link segment (`catalog` → class page, `app` → instance page) with the same chroot/provision scoping logic.
- `src/pages/sovereign/AppDetail.tsx` — drop the class-level `InstancesSection` + `NewInstanceDialog` render; render a small inline per-cluster fan-out (shared `PerClusterTable`) for THIS instance; relabel `LaunchButton` "Launch →" → "Open" (testid `btn-launch-app` + silent-SSO unchanged). Imports trimmed.
- `src/pages/sovereign/AppDetail/InstancesSection.tsx` **(new)** — shared module exporting `InstancesSection` + `NewInstanceDialog` + `PerClusterTable` (lifted from AppDetail). Instance rows link to `/app/$componentId`.
- `src/pages/sovereign/CatalogDetail.tsx` — delegates the instances list + New-instance to the shared `InstancesSection`; removed its bespoke table + the dead `/catalog/$blueprintName/new` links.
- `src/app/router.tsx` — add `/provision/$deploymentId/catalog/$blueprintName` → `CatalogDetail` (the chroot `/catalog/$blueprintName` already existed and is now reachable).
- `src/pages/sovereign/CatalogDetail.test.tsx` **(new)** + `AppsPage.test.tsx` + `AppDetail.test.tsx` — React-tree tests: Catalog-tab card → `/catalog/$bp`, Deployment-tab card → `/app/$id`, CatalogDetail renders instances list + New-instance, AppDetail has NO New-instance, instance page shows "Open" when externalURL present. Also repaired a pre-existing `AppsPage.test` QueryClientProvider gap and a stale AppDetail order/title assertion.
- `tests/e2e/playwright/tests/g117-launch-silent-sso.spec.ts` + `g117-multi-instance-create.spec.ts` — skipped the **MOCK-mode** blocks that drove the retired Svelte console (`products/catalyst/console`) and asserted the old `/catalog/.../new` route model; the LIVE-mode walks (real API / real Sovereign) are unaffected.

## Step 2 decision — inline dialog (not a new route)
`CatalogDetail`'s "+ New instance" previously linked to `/catalog/$blueprintName/new`, which has **no route** (404). I chose **(b) open the existing `NewInstanceDialog` inline** rather than adding a `/new` route: no navigation, reuses the existing component, and the shared `InstancesSection` already owns the dialog. The button now opens the topology-picker in-place.

## Checks
- `npm run typecheck` — clean.
- `npm run build` — green (only pre-existing chunk-size + INEFFECTIVE_DYNAMIC_IMPORT warnings).
- Changed test files: **46 passing** (AppsPage + AppDetail + CatalogDetail).
- Full UI suite: failures dropped **86 → 73**. All remaining failures are pre-existing on `main` in this env (StepComponents catalog data drift, ExecPanel/ParentDomains/SettingsPage/UserAccessEdit env/QueryClient) and do not import any changed module.

## Notes / line-number drift
The brief's line numbers were slightly off from the live file (it had evolved): the `InstancesSection` render was at ~565-569 (not 563-567), the `appExternalURL` gate at ~1704 (not 1692), and the AppDetail tablist already includes an `endpoints` tab (the order test's expected array had drifted and was updated to match).

Verification: PENDING — dispatcher to walk live on hw99

Refs #2741 #2743 #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)
