### PR TITLE
feat(console): editable Endpoints tab in React AppDetail (G117.3 port)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
@@ -845,38 +845,99 @@ export async function createApplicationInstance(
   return res.json()
 }
 
-/* ─── #2742 Endpoints / Ingress (Git-IaC PR pipeline) ──────────────── */
+/* ─── #2742 (G117.3) Endpoints / Ingress (Git-IaC PR pipeline) ─────────
+ *
+ * Full editable-endpoints surface ported from the dead Svelte console
+ * (`products/catalyst/console/src/components/EndpointsTab.svelte`) into
+ * the production React tree. Backed by catalyst-api's endpoint_handler.go:
+ *
+ *   GET    /catalyst/v1/apps/{id}/endpoints         → { items: ResolvedEndpoint[] }
+ *   POST   /catalyst/v1/apps/{id}/endpoints         → EndpointPR
+ *   PATCH  /catalyst/v1/apps/{id}/endpoints/{name}  → EndpointPR
+ *   DELETE /catalyst/v1/apps/{id}/endpoints/{name}  → EndpointPR
+ *
+ * Every mutation opens a GOVERNED PR against gitea.<sov>/<org>/iac;
+ * kyverno-admission / cert-manager-precheck / dns-conflict-precheck
+ * status checks gate auto-merge (locked decision #4).
+ *
+ * CRITICAL (per memory feedback_ts_field_casing_vs_go_json_tag): every
+ * field name below MUST match the Go `json:"..."` tag VERBATIM —
+ * `res.json()` returns wire keys exactly, so a casing mismatch yields a
+ * silently-undefined field. The Go shapes are `resolvedEndpoint`,
+ * `endpointMutationRequest`, `endpointPRResponse`, and
+ * `endpointPreCheckResults` in endpoint_handler.go:78-115.
+ */
 
-/** One exposed HTTPRoute for an Application. Mirrors the Go
- *  `endpointSummary` (endpoint_handler.go). */
-export interface EndpointSummary {
+export type EndpointProtocol = 'https' | 'http' | 'grpc' | 'tcp' | 'udp'
+export type EndpointVisibility = 'public' | 'private' | 'internal'
+
+/**
+ * ResolvedEndpoint mirrors the Go `resolvedEndpoint` (endpoint_handler.go:102)
+ * VERBATIM. `status`/`name`/`hostname` are always present; the rest are
+ * `omitempty` on the wire so they may be absent.
+ */
+export interface ResolvedEndpoint {
   name: string
-  hostnameTemplate?: string
+  hostnameTemplate: string
   hostname: string
-  protocol?: string
+  port?: number
+  protocol?: EndpointProtocol
   tls?: boolean
+  visibility?: EndpointVisibility
+  launchDefault?: boolean
+  ssoEnabled?: boolean
   status: string
+  certificateStatus?: string
+  launchURL?: string
 }
 
+/**
+ * EndpointSummary — retained as a back-compat alias of ResolvedEndpoint
+ * for any existing importer. New code should use ResolvedEndpoint.
+ */
+export type EndpointSummary = ResolvedEndpoint
+
+/** Mirrors Go `listEndpointsResponse` (endpoint_handler.go:157). */
 export interface ListEndpointsResponse {
-  items: EndpointSummary[]
+  items: ResolvedEndpoint[]
 }
 
-/** Body of POST/PATCH /apps/{id}/endpoints — Go `endpointMutationRequest`. */
+/**
+ * EndpointMutationRequest mirrors the Go `endpointMutationRequest`
+ * (endpoint_handler.go:78). `name` IS serialised in the POST body — the
+ * backend's precheck.ValidateMutation REQUIRES a non-empty, RFC-1123-ish
+ * endpoint name on create (`^[a-z][a-z0-9-]{0,30}[a-z0-9]$`). On PATCH the
+ * name is taken from the path param, so the body may omit it.
+ */
 export interface EndpointMutationRequest {
-  /** Only used by PATCH path-param; not serialized in the body. */
-  name?: string
+  name: string
   hostname?: string
-  protocol?: string
+  port?: number
+  protocol?: EndpointProtocol
   tls?: boolean
+  visibility?: EndpointVisibility
+  ssoEnabled?: boolean
 }
 
-/** Response of POST/PATCH — Go shape carries the raised governed PR URL. */
-export interface EndpointMutationResponse {
+/** Mirrors Go `endpointPreCheckResults` (endpoint_handler.go:95). */
+export interface EndpointPreCheckResults {
+  kyverno?: string
+  certManager?: string
+  dnsConflict?: string
+}
+
+/**
+ * EndpointPR mirrors the Go `endpointPRResponse` (endpoint_handler.go:89).
+ * `status` is one of `open` | `merged` | `closed` | `failed-precheck`.
+ */
+export interface EndpointPR {
   prURL: string
   status: string
-  preCheckResults?: Record<string, unknown>
+  preCheckResults?: EndpointPreCheckResults
 }
+
+/** Back-compat alias — older call-sites import `EndpointMutationResponse`. */
+export type EndpointMutationResponse = EndpointPR
 
 /**
  * listEndpoints — GET /catalyst/v1/apps/{id}/endpoints.
@@ -891,36 +952,90 @@ export async function listEndpoints(appId: string): Promise<ListEndpointsRespons
   return res.json()
 }
 
+/** Shared typed-error decode for the endpoint mutation calls. */
+async function endpointMutationError(res: Response): Promise<Error & { status?: number; code?: string }> {
+  let message = `HTTP ${res.status}`
+  let code = ''
+  try {
+    const detail = (await res.json()) as { code?: string; message?: string }
+    if (detail?.message) message = detail.message
+    if (detail?.code) code = detail.code
+  } catch {
+    /* non-JSON body — keep the HTTP-status message */
+  }
+  const err = new Error(message) as Error & { status?: number; code?: string }
+  err.status = res.status
+  err.code = code
+  return err
+}
+
 /**
- * mutateEndpoint — POST (create) or PATCH (edit, by name) an endpoint.
- * The backend raises a governed Git-IaC pull request and returns its
- * URL + the precheck results; the caller renders `prURL` as a "View PR"
- * link. On 4xx the typed `{code, message}` body surfaces verbatim.
+ * createAppEndpoint — POST /catalyst/v1/apps/{id}/endpoints.
+ * Opens a governed Git-IaC PR for a NEW endpoint. The full body is sent
+ * (name + hostname + port + protocol + tls + visibility + ssoEnabled);
+ * `name` is REQUIRED by the backend precheck.
+ */
+export async function createAppEndpoint(
+  appId: string,
+  body: EndpointMutationRequest,
+): Promise<EndpointPR> {
+  const url = `${BASE}catalyst/v1/apps/${encodeURIComponent(appId)}/endpoints`
+  const res = await authedFetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw await endpointMutationError(res)
+  return res.json()
+}
+
+/**
+ * patchAppEndpoint — PATCH /catalyst/v1/apps/{id}/endpoints/{name}.
+ * Opens a governed Git-IaC PR editing an EXISTING endpoint. The endpoint
+ * name is the path param (immutable); the body carries the new values.
+ */
+export async function patchAppEndpoint(
+  appId: string,
+  name: string,
+  body: EndpointMutationRequest,
+): Promise<EndpointPR> {
+  const url = `${BASE}catalyst/v1/apps/${encodeURIComponent(appId)}/endpoints/${encodeURIComponent(name)}`
+  const res = await authedFetch(url, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw await endpointMutationError(res)
+  return res.json()
+}
+
+/**
+ * deleteAppEndpoint — DELETE /catalyst/v1/apps/{id}/endpoints/{name}.
+ * Opens a governed Git-IaC PR removing the endpoint manifest (the
+ * cert-manager Certificate + Gateway HTTPRoute are removed on merge).
+ */
+export async function deleteAppEndpoint(appId: string, name: string): Promise<EndpointPR> {
+  const url = `${BASE}catalyst/v1/apps/${encodeURIComponent(appId)}/endpoints/${encodeURIComponent(name)}`
+  const res = await authedFetch(url, {
+    method: 'DELETE',
+    headers: { Accept: 'application/json' },
+  })
+  if (!res.ok) throw await endpointMutationError(res)
+  return res.json()
+}
+
+/**
+ * mutateEndpoint — back-compat convenience wrapper kept for the prior
+ * call-site shape. POST (create) when `opts.name` is absent, PATCH (edit
+ * by name) when present. Prefer the explicit createAppEndpoint /
+ * patchAppEndpoint for new code.
  */
 export async function mutateEndpoint(
   appId: string,
   body: EndpointMutationRequest,
   opts: { name?: string } = {},
-): Promise<EndpointMutationResponse> {
-  const isEdit = !!opts.name
-  const base = `${BASE}catalyst/v1/apps/${encodeURIComponent(appId)}/endpoints`
-  const url = isEdit ? `${base}/${encodeURIComponent(opts.name!)}` : base
-  const res = await authedFetch(url, {
-    method: isEdit ? 'PATCH' : 'POST',
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-    body: JSON.stringify({ hostname: body.hostname, protocol: body.protocol, tls: body.tls }),
-  })
-  if (!res.ok) {
-    let message = `HTTP ${res.status}`
-    try {
-      const detail = (await res.json()) as { code?: string; message?: string }
-      if (detail?.message) message = detail.message
-    } catch {
-      /* fall through */
-    }
-    const err = new Error(message) as Error & { status?: number }
-    err.status = res.status
-    throw err
-  }
-  return res.json()
+): Promise<EndpointPR> {
+  return opts.name
+    ? patchAppEndpoint(appId, opts.name, body)
+    : createAppEndpoint(appId, body)
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/EndpointsTab.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/EndpointsTab.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * EndpointsTab.test.tsx — unit tests for the G117.3 (#2742) editable
+ * Endpoints/Ingress tab ported from the dead Svelte console into the
+ * production React tree.
+ *
+ * The catalog.api module is mocked so no network is hit; the tests
+ * assert the CRUD wiring (list → New → create PR, Edit → patch PR,
+ * Delete → delete PR) and that the mutation body carries the full,
+ * correctly-cased fields the Go handler requires (notably `name` on
+ * create — precheck.ValidateMutation rejects an empty endpoint name).
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { EndpointsTab } from './EndpointsTab'
+import type { ResolvedEndpoint, EndpointPR } from '@/lib/catalog.api'
+
+/* ── Mock the API client ─────────────────────────────────────────────── */
+
+const listEndpoints = vi.fn()
+const createAppEndpoint = vi.fn()
+const patchAppEndpoint = vi.fn()
+const deleteAppEndpoint = vi.fn()
+
+vi.mock('@/lib/catalog.api', () => ({
+  listEndpoints: (...a: unknown[]) => listEndpoints(...a),
+  createAppEndpoint: (...a: unknown[]) => createAppEndpoint(...a),
+  patchAppEndpoint: (...a: unknown[]) => patchAppEndpoint(...a),
+  deleteAppEndpoint: (...a: unknown[]) => deleteAppEndpoint(...a),
+}))
+
+function withProviders(node: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{node}</QueryClientProvider>
+}
+
+const SAMPLE_EP: ResolvedEndpoint = {
+  name: 'web',
+  hostnameTemplate: '{AppName}.{OrgSlug}.omani.homes',
+  hostname: 'shop.acme.omani.homes',
+  port: 443,
+  protocol: 'https',
+  tls: true,
+  visibility: 'public',
+  ssoEnabled: true,
+  launchDefault: true,
+  status: 'Ready',
+}
+
+const SAMPLE_PR: EndpointPR = {
+  prURL: 'https://gitea.t99.omani.works/acme/iac/pulls/7',
+  status: 'open',
+  preCheckResults: { kyverno: 'pass', certManager: 'pass', dnsConflict: 'pass' },
+}
+
+function renderTab(overrides: Partial<React.ComponentProps<typeof EndpointsTab>> = {}) {
+  return render(
+    withProviders(
+      <EndpointsTab
+        applicationName="shop"
+        appUID="uid-123"
+        externalURL=""
+        sovereignFQDN="t99.omani.works"
+        {...overrides}
+      />,
+    ),
+  )
+}
+
+beforeEach(() => {
+  listEndpoints.mockReset().mockResolvedValue({ items: [SAMPLE_EP] })
+  createAppEndpoint.mockReset().mockResolvedValue(SAMPLE_PR)
+  patchAppEndpoint.mockReset().mockResolvedValue(SAMPLE_PR)
+  deleteAppEndpoint.mockReset().mockResolvedValue(SAMPLE_PR)
+})
+afterEach(() => cleanup())
+
+describe('EndpointsTab', () => {
+  it('lists endpoints from the API with name + hostname + sso', async () => {
+    renderTab()
+    expect(await screen.findByTestId('sov-endpoints-table')).toBeTruthy()
+    expect(screen.getByTestId('sov-endpoint-row-shop.acme.omani.homes')).toBeTruthy()
+    expect(screen.getByText('web')).toBeTruthy()
+    expect(screen.getByText('shop.acme.omani.homes')).toBeTruthy()
+    // "+ New endpoint" is available when appUID is present.
+    expect(screen.getByTestId('endpoint-new')).toBeTruthy()
+  })
+
+  it('opens the create dialog with the PR-consequence warning + all inputs', async () => {
+    renderTab()
+    await screen.findByTestId('sov-endpoints-table')
+    fireEvent.click(screen.getByTestId('endpoint-new'))
+    expect(screen.getByTestId('endpoint-dialog')).toBeTruthy()
+    expect(screen.getByTestId('endpoint-consequence').textContent).toMatch(/governed Git-IaC pull request/i)
+    expect(screen.getByTestId('endpoint-input-name')).toBeTruthy()
+    expect(screen.getByTestId('endpoint-input-hostname')).toBeTruthy()
+    expect(screen.getByTestId('endpoint-input-protocol')).toBeTruthy()
+    expect(screen.getByTestId('endpoint-input-port')).toBeTruthy()
+    expect(screen.getByTestId('endpoint-input-visibility')).toBeTruthy()
+    expect(screen.getByTestId('endpoint-input-tls')).toBeTruthy()
+    expect(screen.getByTestId('endpoint-input-sso')).toBeTruthy()
+  })
+
+  it('create submits the full body INCLUDING name and surfaces the PR banner', async () => {
+    renderTab()
+    await screen.findByTestId('sov-endpoints-table')
+    fireEvent.click(screen.getByTestId('endpoint-new'))
+
+    fireEvent.change(screen.getByTestId('endpoint-input-name'), { target: { value: 'api' } })
+    fireEvent.change(screen.getByTestId('endpoint-input-hostname'), {
+      target: { value: 'api.acme.omani.homes' },
+    })
+    fireEvent.change(screen.getByTestId('endpoint-input-port'), { target: { value: '8443' } })
+    fireEvent.submit(screen.getByTestId('endpoint-save').closest('form')!)
+
+    await waitFor(() => expect(createAppEndpoint).toHaveBeenCalledTimes(1))
+    const [uid, body] = createAppEndpoint.mock.calls[0]
+    expect(uid).toBe('uid-123')
+    // The Go precheck REQUIRES a non-empty name on create.
+    expect(body.name).toBe('api')
+    expect(body.hostname).toBe('api.acme.omani.homes')
+    expect(body.port).toBe(8443)
+    expect(body.protocol).toBe('https')
+    expect(body.visibility).toBe('public')
+
+    // PR banner appears with the returned prURL.
+    const banner = await screen.findByTestId('endpoint-pr-banner')
+    expect(banner.textContent).toMatch(/Change submitted as PR/i)
+    expect(screen.getByTestId('endpoint-pr-banner-link').getAttribute('href')).toBe(SAMPLE_PR.prURL)
+  })
+
+  it('edit opens prefilled, disables the name field, and PATCHes by name', async () => {
+    renderTab()
+    await screen.findByTestId('sov-endpoints-table')
+    fireEvent.click(screen.getByTestId('endpoint-edit-web'))
+
+    const nameInput = screen.getByTestId('endpoint-input-name') as HTMLInputElement
+    expect(nameInput.value).toBe('web')
+    expect(nameInput.disabled).toBe(true)
+    const hostInput = screen.getByTestId('endpoint-input-hostname') as HTMLInputElement
+    expect(hostInput.value).toBe('shop.acme.omani.homes')
+
+    fireEvent.change(hostInput, { target: { value: 'shop2.acme.omani.homes' } })
+    fireEvent.submit(screen.getByTestId('endpoint-save').closest('form')!)
+
+    await waitFor(() => expect(patchAppEndpoint).toHaveBeenCalledTimes(1))
+    const [uid, name, body] = patchAppEndpoint.mock.calls[0]
+    expect(uid).toBe('uid-123')
+    expect(name).toBe('web')
+    expect(body.hostname).toBe('shop2.acme.omani.homes')
+    expect(createAppEndpoint).not.toHaveBeenCalled()
+  })
+
+  it('delete opens the confirm dialog and calls deleteAppEndpoint', async () => {
+    renderTab()
+    await screen.findByTestId('sov-endpoints-table')
+    fireEvent.click(screen.getByTestId('endpoint-delete-web'))
+
+    expect(screen.getByTestId('endpoint-delete-dialog')).toBeTruthy()
+    expect(screen.getByTestId('endpoint-consequence').textContent).toMatch(/removing the\s+endpoint manifest/i)
+
+    fireEvent.click(screen.getByTestId('endpoint-delete-confirm'))
+    await waitFor(() => expect(deleteAppEndpoint).toHaveBeenCalledTimes(1))
+    expect(deleteAppEndpoint.mock.calls[0]).toEqual(['uid-123', 'web'])
+  })
+
+  it('surfaces a mutation error inside the dialog without closing it', async () => {
+    createAppEndpoint.mockRejectedValueOnce(new Error('hostname already in use'))
+    renderTab()
+    await screen.findByTestId('sov-endpoints-table')
+    fireEvent.click(screen.getByTestId('endpoint-new'))
+    fireEvent.change(screen.getByTestId('endpoint-input-name'), { target: { value: 'api' } })
+    fireEvent.change(screen.getByTestId('endpoint-input-hostname'), {
+      target: { value: 'dup.acme.omani.homes' },
+    })
+    fireEvent.submit(screen.getByTestId('endpoint-save').closest('form')!)
+
+    const err = await screen.findByTestId('endpoint-dialog-error')
+    expect(err.textContent).toMatch(/hostname already in use/i)
+    // Dialog stays open so the operator can correct + retry.
+    expect(screen.getByTestId('endpoint-dialog')).toBeTruthy()
+  })
+
+  it('falls back to a read-only externalURL row (no Edit/Delete) when the API returns none', async () => {
+    listEndpoints.mockResolvedValue({ items: [] })
+    renderTab({ externalURL: 'https://shop.acme.omani.homes/' })
+    await screen.findByTestId('sov-endpoints-table')
+    expect(screen.getByTestId('sov-endpoint-row-shop.acme.omani.homes')).toBeTruthy()
+    // Synthesized fallback rows are not editable (no backing manifest).
+    expect(screen.queryByTestId('endpoint-edit-shop')).toBeNull()
+    expect(screen.queryByTestId('endpoint-delete-shop')).toBeNull()
+    // But "New endpoint" is still offered.
+    expect(screen.getByTestId('endpoint-new')).toBeTruthy()
+  })
+
+  it('shows the bootstrap-kit notice when there is no appUID', async () => {
+    renderTab({ appUID: '' })
+    expect(await screen.findByTestId('sov-section-endpoint-edit-unavailable')).toBeTruthy()
+    expect(screen.queryByTestId('endpoint-new')).toBeNull()
+    expect(listEndpoints).not.toHaveBeenCalled()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/EndpointsTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/EndpointsTab.tsx
@@ -1,34 +1,46 @@
 /**
- * EndpointsTab — Application Endpoints/Ingress surface (issue #2742).
+ * EndpointsTab — Application Endpoints/Ingress surface (issue #2742, G117.3).
  *
- * The app-detail strip had no Endpoints tab — UAT TC-18 + the live hw99
- * walk (2026-06-07) confirmed it absent. This tab now renders, per
+ * Full editable-endpoints CRUD ported from the dead Svelte console
+ * (`products/catalyst/console/src/components/EndpointsTab.svelte`) into
+ * the production React tree. The app-detail strip had no working
+ * Endpoints CRUD — UAT TC-18 + the live hw99 walk (2026-06-07) confirmed
+ * it absent / read-only. This tab now renders, per
  * docs/INVIOLABLE-PRINCIPLES.md #1 (target-state shape on first paint):
  *
- *   1. The Application's exposed HTTPRoutes via
+ *   1. The Application's resolved endpoints via
  *      GET /catalyst/v1/apps/{id}/endpoints (falls back to the
  *      catalyst-api `externalURL` while the list loads / for apps that
- *      only surface a single front-door).
- *   2. An edit form that mutates an endpoint's hostname / TLS via
- *      POST|PATCH /apps/{id}/endpoints — the backend raises a GOVERNED
- *      Git-IaC pull request (kyverno-admission / cert-manager-precheck /
- *      dns-conflict-precheck status checks gate the merge) and returns
- *      its URL, which we render as a clickable "View PR" link plus the
- *      precheck results. This replaces the prior `pending-api` marker —
- *      the catalyst-api handler (endpoint_handler.go) + giteapr writer
- *      already back this flow.
+ *      only surface a single front-door HTTPRoute).
+ *   2. New / Edit / Delete actions. Each mutation opens a GOVERNED
+ *      Git-IaC pull request (POST|PATCH|DELETE /apps/{id}/endpoints) —
+ *      kyverno-admission / cert-manager-precheck / dns-conflict-precheck
+ *      status checks gate the auto-merge. Before every mutation the
+ *      operator sees the PR-consequence dialog; after submit, the
+ *      raised PR URL surfaces in a banner (`endpoint-pr-banner`).
  *
  * Per #4 every URL flows through catalog.api helpers, never a literal.
+ * Per memory feedback_ts_field_casing_vs_go_json_tag the wire types
+ * (ResolvedEndpoint / EndpointMutationRequest / EndpointPR) match the Go
+ * json tags verbatim.
  */
 
-import { useEffect, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   listEndpoints,
-  mutateEndpoint,
-  type EndpointSummary,
-  type EndpointMutationResponse,
+  createAppEndpoint,
+  patchAppEndpoint,
+  deleteAppEndpoint,
+  type ResolvedEndpoint,
+  type EndpointMutationRequest,
+  type EndpointPR,
+  type EndpointProtocol,
+  type EndpointVisibility,
 } from '@/lib/catalog.api'
+
+const PROTOCOLS: EndpointProtocol[] = ['https', 'http', 'grpc', 'tcp', 'udp']
+const VISIBILITIES: EndpointVisibility[] = ['public', 'private', 'internal']
 
 interface EndpointsTabProps {
   applicationName: string
@@ -38,6 +50,8 @@ interface EndpointsTabProps {
   externalURL: string
   sovereignFQDN: string | null
 }
+
+type DialogMode = 'closed' | 'create' | 'edit' | 'delete'
 
 export function EndpointsTab({
   applicationName,
@@ -55,26 +69,182 @@ export function EndpointsTab({
     retry: 1,
   })
 
-  const items: EndpointSummary[] = endpointsQuery.data?.items ?? []
+  const items: ResolvedEndpoint[] = endpointsQuery.data?.items ?? []
   const fallbackHost = externalURL
     ? externalURL.replace(/^https?:\/\//, '').replace(/\/$/, '')
     : ''
-  // Synthesize a single row from externalURL when the API returns none
-  // (apps that only expose a front-door HTTPRoute).
-  const rows: EndpointSummary[] =
+  // Synthesize a single read-only row from externalURL when the API
+  // returns none (apps that only expose a front-door HTTPRoute). Such a
+  // synthesized row has no backing endpoint manifest, so it is NOT
+  // editable/deletable — only "New endpoint" applies.
+  const synthesized = items.length === 0 && !!fallbackHost
+  const rows: ResolvedEndpoint[] =
     items.length > 0
       ? items
-      : fallbackHost
-        ? [{ name: applicationName, hostname: fallbackHost, protocol: 'https', tls: true, status: 'Ready' }]
+      : synthesized
+        ? [
+            {
+              name: applicationName,
+              hostnameTemplate: fallbackHost,
+              hostname: fallbackHost,
+              protocol: 'https',
+              tls: true,
+              status: 'Ready',
+            },
+          ]
         : []
+
+  const [dialogMode, setDialogMode] = useState<DialogMode>('closed')
+  const [working, setWorking] = useState<EndpointMutationRequest>({ name: '' })
+  const [editingName, setEditingName] = useState<string | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null)
+  const [lastPR, setLastPR] = useState<EndpointPR | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  function refresh() {
+    qc.invalidateQueries({ queryKey: ['app-endpoints', appUID] })
+  }
+
+  function openCreate() {
+    setWorking({
+      name: '',
+      hostname: '',
+      port: 443,
+      protocol: 'https',
+      tls: true,
+      visibility: 'public',
+      ssoEnabled: true,
+    })
+    setEditingName(null)
+    setError(null)
+    setDialogMode('create')
+  }
+
+  function openEdit(ep: ResolvedEndpoint) {
+    setWorking({
+      name: ep.name,
+      hostname: ep.hostname,
+      port: ep.port,
+      protocol: ep.protocol,
+      tls: ep.tls,
+      visibility: ep.visibility,
+      ssoEnabled: ep.ssoEnabled,
+    })
+    setEditingName(ep.name)
+    setError(null)
+    setDialogMode('edit')
+  }
+
+  function openDelete(name: string) {
+    setDeleteTarget(name)
+    setError(null)
+    setDialogMode('delete')
+  }
+
+  function cancel() {
+    setDialogMode('closed')
+    setEditingName(null)
+    setDeleteTarget(null)
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    if (submitting) return
+    setError(null)
+    setSubmitting(true)
+    try {
+      const pr =
+        dialogMode === 'edit' && editingName
+          ? await patchAppEndpoint(appUID, editingName, working)
+          : await createAppEndpoint(appUID, working)
+      setLastPR(pr)
+      setDialogMode('closed')
+      setEditingName(null)
+      refresh()
+    } catch (err) {
+      setError((err as Error)?.message ?? 'mutation failed')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function confirmDelete() {
+    if (!deleteTarget || submitting) return
+    setError(null)
+    setSubmitting(true)
+    try {
+      const pr = await deleteAppEndpoint(appUID, deleteTarget)
+      setLastPR(pr)
+      setDialogMode('closed')
+      setDeleteTarget(null)
+      refresh()
+    } catch (err) {
+      setError((err as Error)?.message ?? 'delete failed')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const canEdit = !!appUID && !synthesized
 
   return (
     <div data-testid="app-tab-endpoints-body">
       <section className="section" data-testid="sov-section-endpoints">
-        <h2 style={{ margin: '0 0 0.4rem' }}>Endpoints &amp; Ingress</h2>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            gap: '0.5rem',
+            marginBottom: '0.4rem',
+          }}
+        >
+          <h2 style={{ margin: 0 }}>Endpoints &amp; Ingress ({rows.length})</h2>
+          {appUID ? (
+            <button
+              type="button"
+              data-testid="endpoint-new"
+              onClick={openCreate}
+              className="btn btn-primary"
+              style={{ padding: '0.35rem 0.7rem', fontSize: '0.82rem', fontWeight: 600 }}
+            >
+              + New endpoint
+            </button>
+          ) : null}
+        </div>
         <p className="section-hint" style={{ margin: '0 0 0.6rem' }}>
           External HTTPRoute(s) exposing <code>{applicationName}</code> on this Sovereign.
+          Changes raise a governed Git-IaC pull request.
         </p>
+
+        {lastPR ? (
+          <p
+            data-testid="endpoint-pr-banner"
+            className="section-hint"
+            style={{
+              margin: '0 0 0.6rem',
+              padding: '0.4rem 0.6rem',
+              borderRadius: '4px',
+              background: 'var(--color-surface, #1e1b4b)',
+            }}
+          >
+            Change submitted as PR{' '}
+            {lastPR.prURL ? (
+              <a
+                href={lastPR.prURL}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-testid="endpoint-pr-banner-link"
+              >
+                {lastPR.prURL}
+              </a>
+            ) : (
+              <strong>{lastPR.status}</strong>
+            )}{' '}
+            — auto-merges on green Kyverno + cert-manager + DNS-conflict checks.
+          </p>
+        ) : null}
 
         {endpointsQuery.isPending && !!appUID ? (
           <p className="section-hint" data-testid="sov-endpoints-loading" style={{ margin: 0 }}>
@@ -87,9 +257,11 @@ export function EndpointsTab({
           >
             <thead>
               <tr style={{ textAlign: 'left', color: 'var(--color-text-dim)' }}>
+                <th style={{ padding: '0.3rem 0.4rem' }}>Name</th>
                 <th style={{ padding: '0.3rem 0.4rem' }}>Hostname</th>
-                <th style={{ padding: '0.3rem 0.4rem' }}>Kind</th>
+                <th style={{ padding: '0.3rem 0.4rem' }}>Proto</th>
                 <th style={{ padding: '0.3rem 0.4rem' }}>TLS</th>
+                <th style={{ padding: '0.3rem 0.4rem' }}>SSO</th>
                 <th style={{ padding: '0.3rem 0.4rem' }}>Status</th>
                 <th style={{ padding: '0.3rem 0.4rem' }}></th>
               </tr>
@@ -98,18 +270,30 @@ export function EndpointsTab({
               {rows.map((ep) => (
                 <tr key={ep.name || ep.hostname} data-testid={`sov-endpoint-row-${ep.hostname}`}>
                   <td style={{ padding: '0.3rem 0.4rem' }}>
+                    <strong>{ep.name}</strong>
+                    {ep.launchDefault ? (
+                      <span className="chip" style={{ marginLeft: '0.3rem' }}>
+                        default
+                      </span>
+                    ) : null}
+                  </td>
+                  <td style={{ padding: '0.3rem 0.4rem' }}>
                     <code>{ep.hostname}</code>
                   </td>
-                  <td style={{ padding: '0.3rem 0.4rem' }}>HTTPRoute</td>
+                  <td style={{ padding: '0.3rem 0.4rem' }}>
+                    {ep.protocol ?? 'https'}
+                    {ep.port ? `:${ep.port}` : ''}
+                  </td>
                   <td style={{ padding: '0.3rem 0.4rem' }}>
                     {ep.tls === false ? 'none' : "Let's Encrypt"}
                   </td>
+                  <td style={{ padding: '0.3rem 0.4rem' }}>{ep.ssoEnabled ? 'yes' : 'no'}</td>
                   <td style={{ padding: '0.3rem 0.4rem' }}>
                     <span className="chip chip-cat">{ep.status || 'Ready'}</span>
                   </td>
-                  <td style={{ padding: '0.3rem 0.4rem' }}>
+                  <td style={{ padding: '0.3rem 0.4rem', whiteSpace: 'nowrap' }}>
                     <a
-                      href={`https://${ep.hostname}`}
+                      href={`${ep.tls === false ? 'http' : 'https'}://${ep.hostname}`}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="chip chip-cat"
@@ -117,6 +301,28 @@ export function EndpointsTab({
                     >
                       Open &rarr;
                     </a>
+                    {canEdit ? (
+                      <>
+                        <button
+                          type="button"
+                          data-testid={`endpoint-edit-${ep.name}`}
+                          onClick={() => openEdit(ep)}
+                          className="chip"
+                          style={{ marginLeft: '0.3rem', cursor: 'pointer' }}
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          data-testid={`endpoint-delete-${ep.name}`}
+                          onClick={() => openDelete(ep.name)}
+                          className="chip"
+                          style={{ marginLeft: '0.3rem', cursor: 'pointer', color: 'var(--color-danger)' }}
+                        >
+                          Delete
+                        </button>
+                      </>
+                    ) : null}
                   </td>
                 </tr>
               ))}
@@ -138,163 +344,285 @@ export function EndpointsTab({
             Failed to load endpoints: {(endpointsQuery.error as Error)?.message ?? 'unknown error'}
           </p>
         ) : null}
-      </section>
 
-      {appUID ? (
-        <EditEndpointForm
-          appUID={appUID}
-          defaultHostname={rows[0]?.hostname ?? fallbackHost}
-          defaultName={rows[0]?.name ?? applicationName}
-          defaultTls={rows[0]?.tls !== false}
-          isExisting={items.length > 0}
-          disabled={false}
-          onMutated={() => qc.invalidateQueries({ queryKey: ['app-endpoints', appUID] })}
-        />
-      ) : (
-        <section
-          className="section"
-          data-testid="sov-section-endpoint-edit-unavailable"
-          style={{ marginTop: '0.8rem' }}
-        >
-          <h3 style={{ fontSize: '0.9rem', margin: '0 0 0.3rem' }}>Edit endpoint</h3>
-          <p className="section-hint" style={{ margin: 0 }}>
+        {!appUID ? (
+          <p
+            className="section-hint"
+            data-testid="sov-section-endpoint-edit-unavailable"
+            style={{ margin: '0.6rem 0 0' }}
+          >
             Endpoint editing via a governed Git-IaC PR is available for catalog-installed
             Applications. This is a bootstrap-kit component (no catalog instance), so its endpoints
             are managed directly in the Sovereign&rsquo;s GitOps repo rather than from this tab.
           </p>
+        ) : null}
+      </section>
+
+      {/* ─── Create / Edit dialog ─────────────────────────────────────── */}
+      {dialogMode === 'create' || dialogMode === 'edit' ? (
+        <EndpointDialog
+          mode={dialogMode}
+          editingName={editingName}
+          working={working}
+          setWorking={setWorking}
+          submitting={submitting}
+          error={error}
+          onSubmit={submit}
+          onCancel={cancel}
+        />
+      ) : dialogMode === 'delete' ? (
+        <section
+          className="section"
+          role="dialog"
+          aria-modal="true"
+          data-testid="endpoint-delete-dialog"
+          style={{ marginTop: '0.8rem' }}
+        >
+          <h3 style={{ fontSize: '0.95rem', margin: '0 0 0.4rem' }}>
+            Delete endpoint {deleteTarget}?
+          </h3>
+          <p
+            className="section-hint"
+            data-testid="endpoint-consequence"
+            style={{
+              margin: '0 0 0.6rem',
+              padding: '0.4rem 0.6rem',
+              borderLeft: '3px solid var(--color-warning, #b45309)',
+              borderRadius: '3px',
+              background: 'var(--color-surface, #2a2440)',
+            }}
+          >
+            This opens a PR against <code>gitea.&lt;sov&gt;/&lt;org&gt;/iac</code> removing the
+            endpoint manifest. The cert-manager Certificate + Gateway HTTPRoute are removed on merge.
+          </p>
+          <div style={{ display: 'flex', gap: '0.5rem' }}>
+            <button
+              type="button"
+              data-testid="endpoint-delete-confirm"
+              onClick={confirmDelete}
+              disabled={submitting}
+              className="btn"
+              style={{
+                padding: '0.4rem 0.8rem',
+                fontSize: '0.82rem',
+                fontWeight: 600,
+                color: '#fff',
+                background: 'var(--color-danger, #b00020)',
+              }}
+            >
+              {submitting ? 'Raising PR…' : 'Delete — open PR'}
+            </button>
+            <button
+              type="button"
+              data-testid="endpoint-dialog-cancel"
+              onClick={cancel}
+              disabled={submitting}
+              className="btn"
+              style={{ padding: '0.4rem 0.8rem', fontSize: '0.82rem' }}
+            >
+              Cancel
+            </button>
+          </div>
+          {error ? (
+            <p
+              data-testid="endpoint-dialog-error"
+              style={{ margin: '0.5rem 0 0', fontSize: '0.82rem', color: 'var(--color-danger)' }}
+            >
+              {error}
+            </p>
+          ) : null}
         </section>
-      )}
+      ) : null}
     </div>
   )
 }
 
-/* ─── Edit endpoint → governed Git-IaC PR ───────────────────────────── */
+/* ─── Create / Edit endpoint dialog → governed Git-IaC PR ─────────────── */
 
-function EditEndpointForm({
-  appUID,
-  defaultHostname,
-  defaultName,
-  defaultTls,
-  isExisting,
-  disabled,
-  onMutated,
+function EndpointDialog({
+  mode,
+  editingName,
+  working,
+  setWorking,
+  submitting,
+  error,
+  onSubmit,
+  onCancel,
 }: {
-  appUID: string
-  defaultHostname: string
-  defaultName: string
-  defaultTls: boolean
-  isExisting: boolean
-  disabled: boolean
-  onMutated: () => void
+  mode: 'create' | 'edit'
+  editingName: string | null
+  working: EndpointMutationRequest
+  setWorking: React.Dispatch<React.SetStateAction<EndpointMutationRequest>>
+  submitting: boolean
+  error: string | null
+  onSubmit: (e: React.FormEvent) => void
+  onCancel: () => void
 }) {
-  const [hostname, setHostname] = useState(defaultHostname)
-  const [tls, setTls] = useState(defaultTls)
-  const [submitting, setSubmitting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [result, setResult] = useState<EndpointMutationResponse | null>(null)
-
-  // Re-sync from props once the endpoints query resolves — the row's
-  // real hostname/TLS arrive after the initial '' fallback render, and
-  // useState only reads the prop on first mount (reviewer note, PR #3071).
-  useEffect(() => {
-    setHostname(defaultHostname)
-  }, [defaultHostname])
-  useEffect(() => {
-    setTls(defaultTls)
-  }, [defaultTls])
-
-  async function onSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    if (submitting || disabled) return
-    setError(null)
-    setResult(null)
-    setSubmitting(true)
-    try {
-      // PATCH an existing endpoint by name; POST a new one when the row
-      // is the synthesized externalURL fallback (no real endpoint file
-      // yet) so we create rather than write a file named after the app
-      // (reviewer note #2, PR #3071).
-      const resp = await mutateEndpoint(
-        appUID,
-        { hostname: hostname.trim(), tls },
-        isExisting ? { name: defaultName } : {},
-      )
-      setResult(resp)
-      onMutated()
-    } catch (err) {
-      setError((err as Error)?.message ?? 'mutation failed')
-    } finally {
-      setSubmitting(false)
-    }
-  }
+  const inputStyle = useMemo<React.CSSProperties>(
+    () => ({
+      width: '100%',
+      padding: '0.4rem 0.6rem',
+      background: 'var(--color-bg)',
+      color: 'var(--color-text)',
+      border: '1px solid var(--color-border)',
+      borderRadius: '4px',
+      fontSize: '0.82rem',
+      marginTop: '0.2rem',
+    }),
+    [],
+  )
 
   return (
-    <section className="section" data-testid="sov-section-endpoint-edit" style={{ marginTop: '0.8rem' }}>
-      <h3 style={{ fontSize: '0.9rem', margin: '0 0 0.3rem' }}>Edit endpoint</h3>
-      <p className="section-hint" style={{ margin: '0 0 0.5rem' }}>
-        Changing the hostname or TLS raises a <strong>governed Git-IaC pull request</strong> against
-        this Sovereign&rsquo;s local Gitea (kyverno-admission / cert-manager-precheck /
-        dns-conflict-precheck status checks gate the merge).
+    <section
+      className="section"
+      role="dialog"
+      aria-modal="true"
+      data-testid="endpoint-dialog"
+      style={{ marginTop: '0.8rem' }}
+    >
+      <h3 style={{ fontSize: '0.95rem', margin: '0 0 0.4rem' }}>
+        {mode === 'create' ? 'New endpoint' : `Edit endpoint ${editingName}`}
+      </h3>
+      <p
+        className="section-hint"
+        data-testid="endpoint-consequence"
+        style={{
+          margin: '0 0 0.6rem',
+          padding: '0.4rem 0.6rem',
+          borderLeft: '3px solid var(--color-warning, #b45309)',
+          borderRadius: '3px',
+          background: 'var(--color-surface, #2a2440)',
+        }}
+      >
+        Submitting this opens a <strong>governed Git-IaC pull request</strong> against{' '}
+        <code>gitea.&lt;sov&gt;/&lt;org&gt;/iac</code>. Kyverno + cert-manager + DNS-conflict checks
+        gate the auto-merge; if a check fails the PR stays open for operator review.
       </p>
-      <form onSubmit={onSubmit} style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
-        <input
-          type="text"
-          data-testid="input-endpoint-hostname"
-          value={hostname}
-          onChange={(e) => setHostname(e.target.value)}
-          placeholder="app.example.omani.homes"
-          required
-          style={{
-            flex: '1 1 280px',
-            padding: '0.4rem 0.6rem',
-            background: 'var(--color-bg)',
-            color: 'var(--color-text)',
-            border: '1px solid var(--color-border)',
-            borderRadius: '4px',
-            fontSize: '0.82rem',
-          }}
-        />
-        <label style={{ fontSize: '0.8rem', display: 'flex', alignItems: 'center', gap: '0.3rem' }}>
+      <form onSubmit={onSubmit} style={{ display: 'grid', gap: '0.5rem', maxWidth: '460px' }}>
+        <label style={{ fontSize: '0.82rem' }}>
+          Name
           <input
-            type="checkbox"
-            data-testid="input-endpoint-tls"
-            checked={tls}
-            onChange={(e) => setTls(e.target.checked)}
+            type="text"
+            data-testid="endpoint-input-name"
+            required
+            pattern="^[a-z][a-z0-9-]{0,30}[a-z0-9]$"
+            value={working.name}
+            disabled={mode === 'edit'}
+            onChange={(e) => setWorking((w) => ({ ...w, name: e.target.value }))}
+            placeholder="web"
+            style={inputStyle}
           />
-          TLS
         </label>
-        <button
-          type="submit"
-          data-testid="btn-endpoint-raise-pr"
-          disabled={submitting || disabled}
-          className="btn btn-primary"
-          style={{ padding: '0.4rem 0.8rem', fontSize: '0.82rem', fontWeight: 600 }}
-        >
-          {submitting ? 'Raising PR…' : 'Raise PR'}
-        </button>
+        <label style={{ fontSize: '0.82rem' }}>
+          Hostname
+          <input
+            type="text"
+            data-testid="endpoint-input-hostname"
+            required
+            value={working.hostname ?? ''}
+            onChange={(e) => setWorking((w) => ({ ...w, hostname: e.target.value }))}
+            placeholder="app.example.omani.homes"
+            style={inputStyle}
+          />
+        </label>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <label style={{ fontSize: '0.82rem', flex: 1 }}>
+            Protocol
+            <select
+              data-testid="endpoint-input-protocol"
+              value={working.protocol ?? 'https'}
+              onChange={(e) =>
+                setWorking((w) => ({ ...w, protocol: e.target.value as EndpointProtocol }))
+              }
+              style={inputStyle}
+            >
+              {PROTOCOLS.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={{ fontSize: '0.82rem', flex: 1 }}>
+            Port
+            <input
+              type="number"
+              data-testid="endpoint-input-port"
+              min={1}
+              max={65535}
+              value={working.port ?? ''}
+              onChange={(e) =>
+                setWorking((w) => ({
+                  ...w,
+                  port: e.target.value === '' ? undefined : Number(e.target.value),
+                }))
+              }
+              style={inputStyle}
+            />
+          </label>
+          <label style={{ fontSize: '0.82rem', flex: 1 }}>
+            Visibility
+            <select
+              data-testid="endpoint-input-visibility"
+              value={working.visibility ?? 'public'}
+              onChange={(e) =>
+                setWorking((w) => ({ ...w, visibility: e.target.value as EndpointVisibility }))
+              }
+              style={inputStyle}
+            >
+              {VISIBILITIES.map((v) => (
+                <option key={v} value={v}>
+                  {v}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
+          <label style={{ fontSize: '0.82rem', display: 'flex', alignItems: 'center', gap: '0.3rem' }}>
+            <input
+              type="checkbox"
+              data-testid="endpoint-input-tls"
+              checked={working.tls ?? true}
+              onChange={(e) => setWorking((w) => ({ ...w, tls: e.target.checked }))}
+            />
+            TLS
+          </label>
+          <label style={{ fontSize: '0.82rem', display: 'flex', alignItems: 'center', gap: '0.3rem' }}>
+            <input
+              type="checkbox"
+              data-testid="endpoint-input-sso"
+              checked={working.ssoEnabled ?? false}
+              onChange={(e) => setWorking((w) => ({ ...w, ssoEnabled: e.target.checked }))}
+            />
+            SSO enabled
+          </label>
+        </div>
+        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.2rem' }}>
+          <button
+            type="submit"
+            data-testid="endpoint-save"
+            disabled={submitting}
+            className="btn btn-primary"
+            style={{ padding: '0.4rem 0.8rem', fontSize: '0.82rem', fontWeight: 600 }}
+          >
+            {submitting ? 'Raising PR…' : 'Save — open PR'}
+          </button>
+          <button
+            type="button"
+            data-testid="endpoint-dialog-cancel"
+            onClick={onCancel}
+            disabled={submitting}
+            className="btn"
+            style={{ padding: '0.4rem 0.8rem', fontSize: '0.82rem' }}
+          >
+            Cancel
+          </button>
+        </div>
       </form>
-
-      {result ? (
-        <p data-testid="sov-endpoint-pr-result" style={{ margin: '0.5rem 0 0', fontSize: '0.82rem' }}>
-          PR raised ({result.status}):{' '}
-          {result.prURL ? (
-            <a href={result.prURL} target="_blank" rel="noopener noreferrer" data-testid="sov-endpoint-pr-link">
-              View PR &rarr;
-            </a>
-          ) : (
-            'pending'
-          )}
-          {result.preCheckResults && Object.keys(result.preCheckResults).length > 0 ? (
-            <span style={{ marginLeft: '0.5rem', color: 'var(--color-text-dim)' }}>
-              · prechecks: {Object.keys(result.preCheckResults).length}
-            </span>
-          ) : null}
-        </p>
-      ) : null}
-
       {error ? (
         <p
-          data-testid="sov-endpoint-edit-error"
+          data-testid="endpoint-dialog-error"
           style={{ margin: '0.5rem 0 0', fontSize: '0.82rem', color: 'var(--color-danger)' }}
         >
           {error}


### PR DESCRIPTION
## What

Ports the full **editable Endpoints/Ingress CRUD** from the dead Svelte console (`products/catalyst/console/src/components/EndpointsTab.svelte` — that tree has no Containerfile and never shipped) into the **production React console** at `products/catalyst/bootstrap/ui`.

The production React `EndpointsTab` previously only listed endpoints + offered a single hostname/TLS edit form. This brings it to the agreed Svelte UX:

- List endpoints with full fields (name, hostname, proto:port, TLS, SSO, status, `launchDefault`).
- **New / Edit / Delete** actions.
- A **PR-consequence dialog** before every mutation (warns the operator that a governed Git-IaC PR will be opened).
- An **`endpoint-pr-banner`** surfacing the raised PR URL after submit.
- Read-only `externalURL` fallback row (no Edit/Delete) for front-door-only apps; bootstrap-kit notice when there's no Application UID.

## Backend (already complete — no Go changes here)

`products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go` + `internal/precheck` + `internal/giteapr`. Each mutation opens a PR against `gitea.<sov>/<org>/iac` gated by 3 status checks (kyverno-admission / cert-manager-precheck / dns-conflict-precheck).

## API routes wired (client side)

All behind `RequireSession`, registered **without** the `/api/` prefix (`/catalyst/v1` rule), so the client uses `BASE` not `API_BASE`:

| Method | Path | Response |
|---|---|---|
| GET | `/catalyst/v1/apps/{id}/endpoints` | `{ items: ResolvedEndpoint[] }` |
| POST | `/catalyst/v1/apps/{id}/endpoints` | `EndpointPR` |
| PATCH | `/catalyst/v1/apps/{id}/endpoints/{name}` | `EndpointPR` |
| DELETE | `/catalyst/v1/apps/{id}/endpoints/{name}` | `EndpointPR` |

## Files

- `products/catalyst/bootstrap/ui/src/lib/catalog.api.ts` — `ResolvedEndpoint` / `EndpointMutationRequest` / `EndpointPR` / `EndpointPreCheckResults` now mirror the Go `json:"..."` tags **verbatim** (per memory `feedback_ts_field_casing_vs_go_json_tag`). New `createAppEndpoint` / `patchAppEndpoint` / `deleteAppEndpoint`; `mutateEndpoint` kept as a back-compat wrapper.
- `products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/EndpointsTab.tsx` — rebuilt as full CRUD (prop signature unchanged, so `AppDetail.tsx` invocation is untouched).
- `products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/EndpointsTab.test.tsx` — new (8 tests).

## Critical casing fix

The Go `precheck.ValidateMutation` **requires** a non-empty endpoint `name` on create (`^[a-z][a-z0-9-]{0,30}[a-z0-9]$`). The prior `mutateEndpoint` serialized only `{hostname, protocol, tls}` and **dropped `name`**, which would have 400'd every create. The create path now sends the full body including `name`; a test asserts it.

## Tests

8 Vitest/RTL tests against the **React** tree (not the dead Svelte console): list, create (asserts `name` in the POST body + PR banner), edit (PATCH by name, name field disabled), delete confirm, mutation-error stays in dialog, `externalURL` read-only fallback, bootstrap-kit no-`appUID` notice.

- `npm run typecheck` → clean
- `npm run build` → clean (`✓ built`)
- targeted `vitest run` (EndpointsTab + AppDetail + no-hardcoded-api guardrail) → 37 passed

## Verification

**Verification: PENDING — TC-G4 live-walk on hw100.** This PR is NOT live-verified; the editable tab needs an operator walk on a fresh prov (create/edit/delete an endpoint, confirm the governed PR opens in the per-Org `iac` repo).

Refs #2742

🤖 Generated with [Claude Code](https://claude.com/claude-code)
