### PR TITLE
fix(pillar5): template hardcoded openova.io tethers via per-Sovereign value (#2940)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -22,11 +22,11 @@ import (
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/giteapr"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
-	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/oidcprovider"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/keycloak"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/natspub"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/newapi"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/oidcprovider"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/powerdns"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/precheck"
@@ -105,7 +105,15 @@ func main() {
 	}
 	if keyPath != "" {
 		pubKeyPath := env("CATALYST_HANDOVER_PUBKEY_PATH", keyPath+".pub.jwk")
-		issuer := env("CATALYST_HANDOVER_JWT_ISSUER", "https://console.openova.io")
+		// #2940 (Pillar 5): the mothership-default literal lives in exactly one
+		// place — handoverjwt.DefaultIssuer() — which reads
+		// CATALYST_HANDOVER_JWT_ISSUER and falls back to the Catalyst-Zero
+		// origin only when unset. Passing the resolved value (rather than a
+		// second hardcoded "https://console.openova.io" here) keeps the
+		// per-Sovereign override seam honoured and avoids a drift-prone
+		// duplicate tether literal. Empty env → DefaultIssuer() → mothership
+		// origin (Catalyst-Zero byte-unchanged).
+		issuer := handoverjwt.DefaultIssuer()
 		signer, err := handoverjwt.LoadOrGenerate(keyPath, pubKeyPath, issuer, 5*time.Minute)
 		if err != nil {
 			log.Warn("handoverjwt: keypair init failed; MintHandoverToken will return 503",
@@ -583,11 +591,11 @@ func main() {
 		clientSecret := os.Getenv("CATALYST_PIN_BROKER_CLIENT_SECRET")
 		if signer := h.GetHandoverSigner(); signer != nil && issuerURL != "" && clientSecret != "" {
 			oidcProv := &oidcprovider.Provider{
-				IssuerURL:                  issuerURL,
-				ExpectedClientID:           env("CATALYST_PIN_BROKER_CLIENT_ID", "catalyst-pin"),
-				ExpectedClientSecret:       clientSecret,
-				Signer:                     signer,
-				SessionSubjectFromCookie:   makeSessionValidator(signer, log),
+				IssuerURL:                issuerURL,
+				ExpectedClientID:         env("CATALYST_PIN_BROKER_CLIENT_ID", "catalyst-pin"),
+				ExpectedClientSecret:     clientSecret,
+				Signer:                   signer,
+				SessionSubjectFromCookie: makeSessionValidator(signer, log),
 			}
 			r.Get("/oidc/.well-known/openid-configuration", oidcProv.Discovery)
 			r.Get("/oidc/auth", oidcProv.Auth)

--- a/products/catalyst/bootstrap/api/internal/handoverjwt/signer.go
+++ b/products/catalyst/bootstrap/api/internal/handoverjwt/signer.go
@@ -19,8 +19,8 @@
 //
 //   - On first boot (key file absent), LoadOrGenerate() generates a fresh
 //     RSA-2048 keypair and writes:
-//     • private key PEM  → keyPath  (mode 0600)
-//     • public JWK JSON  → pubKeyPath (mode 0644)
+//   - private key PEM  → keyPath  (mode 0600)
+//   - public JWK JSON  → pubKeyPath (mode 0644)
 //   - Subsequent restarts load the existing files (idempotent).
 //
 // # JWT shape (canonical — Agent C must accept exactly this)
@@ -58,6 +58,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -71,10 +72,31 @@ const (
 	// DefaultTTL — 5-minute window per the JWT contract in the issue brief.
 	DefaultTTL = 5 * time.Minute
 
-	// DefaultIssuer — the Catalyst-Zero console origin.
-	// Overridable via CATALYST_HANDOVER_JWT_ISSUER.
-	DefaultIssuer = "https://console.openova.io"
+	// mothershipIssuer — the Catalyst-Zero (mothership) console origin. This
+	// is the LAST-RESORT fallback only: it keeps Catalyst-Zero byte-unchanged
+	// when neither the caller nor the env supplies an issuer. A franchised
+	// Sovereign post-bp-self-sovereign-cutover MUST NOT stamp this URL as the
+	// `iss` claim — see DefaultIssuer() + #2940 (Pillar 5 anti-tether).
+	mothershipIssuer = "https://console.openova.io"
 )
+
+// DefaultIssuer resolves the JWT issuer used when the caller passes an empty
+// issuer to New / LoadOrGenerate.
+//
+// #2940 (Pillar 5): previously a bare `const DefaultIssuer =
+// "https://console.openova.io"` — a mothership-tether hardcode. A franchised
+// Sovereign that constructed a Signer without an explicit issuer would stamp
+// the mothership origin as the `iss` claim, so downstream validation rejected
+// the token as foreign-issuer. Now it reads CATALYST_HANDOVER_JWT_ISSUER
+// first (the same env the chart api-deployment supplies from the per-Sovereign
+// runtime-config / cutover Step-07 pivot) and only falls back to the
+// mothership origin when that env is unset — keeping Catalyst-Zero unchanged.
+func DefaultIssuer() string {
+	if v := strings.TrimSpace(os.Getenv("CATALYST_HANDOVER_JWT_ISSUER")); v != "" {
+		return v
+	}
+	return mothershipIssuer
+}
 
 // Claims is the exact JWT claim shape Agent C must accept.
 // Custom fields use lowercase JSON keys per RFC 7519 §4 convention.
@@ -110,7 +132,7 @@ type Signer struct {
 // returns a Signer ready to mint tokens.
 func New(privPEM []byte, issuer string, ttl time.Duration) (*Signer, error) {
 	if issuer == "" {
-		issuer = DefaultIssuer
+		issuer = DefaultIssuer()
 	}
 	if ttl <= 0 {
 		ttl = DefaultTTL

--- a/products/catalyst/bootstrap/api/internal/handoverjwt/signer_test.go
+++ b/products/catalyst/bootstrap/api/internal/handoverjwt/signer_test.go
@@ -237,3 +237,53 @@ func (randReaderForSmallKeyTest) Read(b []byte) (int, error) {
 	}
 	return len(b), nil
 }
+
+// TestDefaultIssuer_EnvOverride is the #2940 (Pillar 5) anti-tether assertion:
+// DefaultIssuer() must honour CATALYST_HANDOVER_JWT_ISSUER when set (a
+// franchised Sovereign overriding the mothership origin) and fall back to the
+// Catalyst-Zero origin only when the env is unset (keeping the mothership
+// byte-unchanged). A Signer constructed with an empty issuer must stamp the
+// resolved value as the `iss` claim.
+func TestDefaultIssuer_EnvOverride(t *testing.T) {
+	// Mothership default — env unset.
+	t.Setenv("CATALYST_HANDOVER_JWT_ISSUER", "")
+	if got := DefaultIssuer(); got != mothershipIssuer {
+		t.Errorf("env-unset: DefaultIssuer()=%q want %q", got, mothershipIssuer)
+	}
+
+	// Sovereign override — env set to a franchise console origin.
+	const sovIssuer = "https://console.t99.omani.works"
+	t.Setenv("CATALYST_HANDOVER_JWT_ISSUER", sovIssuer)
+	if got := DefaultIssuer(); got != sovIssuer {
+		t.Errorf("env-set: DefaultIssuer()=%q want %q", got, sovIssuer)
+	}
+
+	// Whitespace-only env is treated as unset (falls back to mothership).
+	t.Setenv("CATALYST_HANDOVER_JWT_ISSUER", "   ")
+	if got := DefaultIssuer(); got != mothershipIssuer {
+		t.Errorf("whitespace env: DefaultIssuer()=%q want %q", got, mothershipIssuer)
+	}
+
+	// End-to-end: New("",...) with the env set must stamp the override as iss.
+	t.Setenv("CATALYST_HANDOVER_JWT_ISSUER", sovIssuer)
+	priv, _, err := GenerateKeypair()
+	if err != nil {
+		t.Fatalf("GenerateKeypair: %v", err)
+	}
+	s, err := New(priv, "", DefaultTTL)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	tok, err := s.MintToken("t99.omani.works", "dep-99", "sub-1", "a@b.c")
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+	parsed, _, err := jwt.NewParser().ParseUnverified(tok, jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("ParseUnverified: %v", err)
+	}
+	claims := parsed.Claims.(jwt.MapClaims)
+	if iss, _ := claims["iss"].(string); iss != sovIssuer {
+		t.Errorf("minted iss=%q want %q (mothership tether leaked into Sovereign token)", iss, sovIssuer)
+	}
+}


### PR DESCRIPTION
Refs #2940

Pillar 5 (cutover independence) — template the remaining hardcoded `console.openova.io` handover-JWT issuer tether via a per-Sovereign value, with `console.openova.io` preserved as the **mothership default** so Catalyst-Zero is byte-unchanged.

**Verification: PENDING — runtime cutover egress-block proof (TC-16) on hw100.** Not runtime-verified. Security-critical — review-gated, do NOT auto-merge.

## What changed (Go-only — no chart change was needed)

| Tether (before) | After |
|---|---|
| `internal/handoverjwt/signer.go:76` — `const DefaultIssuer = "https://console.openova.io"` (fired on every `New("",…)` / `LoadOrGenerate(…,"",…)` empty-issuer path, ignoring the per-Sovereign override env) | `func DefaultIssuer() string` reading `CATALYST_HANDOVER_JWT_ISSUER` first, falling back to the single-source `mothershipIssuer` const only when unset. |
| `cmd/api/main.go:108` — `issuer := env("CATALYST_HANDOVER_JWT_ISSUER", "https://console.openova.io")` (a *second* duplicate literal) | `issuer := handoverjwt.DefaultIssuer()` — delegates the mothership default to the one helper; no duplicate tether literal. |
| (new) | `signer_test.go` — `TestDefaultIssuer_EnvOverride`: env-set → franchise origin; env-unset/whitespace → mothership; end-to-end minted-token `iss` carries the override (no mothership leak). |

After this change, `signer.go` holds exactly ONE `console.openova.io` literal (the `mothershipIssuer` fallback), and `main.go` holds ZERO non-comment occurrences.

## Lockstep (the #1 risk per ADR-0002 / the #3012→#3039 half-pivot regression)

**No new slot-06a overlay line is required.** The env this code reads — `CATALYST_HANDOVER_JWT_ISSUER` — is **already** pivoted at cutover by `bp-self-sovereign-cutover` Step-07 (`platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml:247`) from `.Values.sovereign.consolePublicURL`, which is **already** overlaid in `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` (`consolePublicURL: https://console.${SOVEREIGN_FQDN}`). This PR introduces **no new overlay-value consumer** — it only makes an *already-pivoted* env authoritative on one additional code path. So there is no consumer-without-producer half-pivot risk.

helm-template proof that the existing lockstep is intact (cutover chart):
- **default** render → `CONSOLE_PUBLIC_URL value: "https://console.example.local"` (placeholder; Step-07 FATALs on the `example.local` guard to force the overlay).
- **override** `--set sovereign.consolePublicURL=https://console.t99.omani.works` → renders `https://console.t99.omani.works` and Step-07 sets `CATALYST_HANDOVER_JWT_ISSUER=${CONSOLE_PUBLIC_URL}`.

## Other #2940 tethers audited — already-handled or intentional (NOT touched, with reason)

- `internal/handler/auth.go:56` `pinIssuer` — **already** an env-aware `var`-func (`CATALYST_PIN_ISSUER`). Briefing said leave it.
- `products/catalyst/chart/templates/api-deployment.yaml` `CORS_ORIGIN` / `CATALYST_API_PUBLIC_URL` / `CATALYST_KC_REDIRECT_URI` — **already** `configMapKeyRef` from `catalyst-runtime-config` (`sovereign-console-url` / `sovereign-api-public-url`) + pivoted by Step-07. The 5 remaining `console.openova.io` strings in this file are all in **comments** (verified). `CATALYST_SOVEREIGN_URL` is not a real env (comment only).
- `ingress.yaml`, `ingress-console-tls.yaml`, `sme-services/ingress.yaml`, `api-deployment-kustomize.yaml` — **`.helmignore`-excluded**: Contabo-mkt / Catalyst-Zero ONLY (Sovereigns use Cilium Gateway, not Traefik). The Sovereign-rendered route `templates/httproute.yaml` already templates `${SOVEREIGN_FQDN}` with **zero** `console.openova.io`. These hosts are the mothership's OWN host — correct by design, not Sovereign tethers.
- `infra/providers/huawei/cloudinit-control-plane.tftpl:576` — **already** `PDNS_API_HOST: "${pdns_api_host}"` (tofu var, default `https://pdns.openova.io`, declared in `variables.tf:36`). The other `harbor./pdns./ns*.openova.io` refs there are the Huawei bastion-mirror CoreDNS overrides (`212.72.24.20`) — intentional pre-cutover bastion routing.
- `platform/powerdns/chart/values.yaml:367,383` + `platform/cert-manager-powerdns-webhook/chart/values.yaml:146,161` (`pdns.openova.io`) — **intentional** out-of-cluster ACME DNS-01 tether to the authoritative PowerDNS for the omani.* pool (LE validates TXT against public DNS). Documented exclusion under #2951; cutover deliberately does NOT rewrite; per-Sovereign overlay `11-powerdns.yaml` sets `pdns.${SOVEREIGN_FQDN}`.
- `platform/bp-{dmz,mgmt,rtz}-vcluster/chart/values.yaml` + `platform/sso-bridge/chart/values.yaml` (`harbor.openova.io/proxy-*` image repos) — **intentional** pre-cutover bootstrap (Sovereign has no local Harbor at bootstrap); pivoted to `harbor.<SOVEREIGN_FQDN>` by cutover Step-10 (vcluster-registry-pivot + sso-bridge, chart 0.1.36/0.1.50). Static templating would break bootstrap pulls.

## Validation
- `go build ./...` → clean.
- `go vet ./internal/handoverjwt/... ./cmd/api/...` → clean.
- `go test ./internal/handoverjwt/...` → PASS (incl. new `TestDefaultIssuer_EnvOverride`).
- `go test ./internal/handler/...` → PASS (the 3 signer-constructing suites: auth_handover / auth_pin / phase1_watch_handover).
- `gofmt -l` on touched files → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
