### PR TITLE
fix(cloud-graph): render all topology.regions not just MaterializedRegions[0] (#3106)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/jobs.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs.go
@@ -149,21 +149,71 @@ func (h *Handler) chrootEnsureDeployment(depID string) *Deployment {
 }
 
 // chrootRegionsFromEnv parses SOVEREIGN_REGIONS_JSON (the canonical
-// regions list threaded in by bp-catalyst-platform). Returns empty
-// slice when unset or malformed — the caller falls back to the live-
-// Nodes path. The JSON shape matches the wizard's request.regions
-// array: [{provider, cloudRegion, controlPlaneSize, workerSize,
-// workerCount}, ...].
+// regions list threaded in by bp-catalyst-platform). The JSON shape
+// matches the wizard's request.regions array: [{provider, cloudRegion,
+// controlPlaneSize, workerSize, workerCount}, ...].
+//
+// Fallback (#3106): when SOVEREIGN_REGIONS_JSON is unset, empty, or an
+// empty JSON array, reconstruct the region list from the discrete
+// SOVEREIGN_PRIMARY_REGION / SOVEREIGN_REPLICA_REGION /
+// SOVEREIGN_ENABLE_HOT_STANDBY env vars (also threaded in by
+// bp-catalyst-platform from the sovereign-fqdn ConfigMap). On a
+// 2-region hot-standby Sovereign the per-Sovereign overlay reliably
+// populates primaryRegion + replicaRegion + enableHotStandby even when
+// the richer regionsJson list was never wired (caught live on hw101
+// e19b083c6db41bb0 2026-06-08: regionsJson=[] but primaryRegion=
+// hw-me-east-215-a-rtz-prod, replicaRegion=hw-me-east-215-b-rtz-prod,
+// enableHotStandby=true). Without this fallback buildTopology drops
+// into the single-cluster live-Nodes path and `/cloud?view=graph`
+// renders "Region 1/1" — only the in-cluster primary — despite the
+// substrate genuinely having both clusters. The reconstructed specs
+// carry only the region code; node/SKU detail still flows from the
+// live K8s SSE snapshot the graph merges on the UI side, so this is a
+// pure view-completeness fix (NOT cross-region provisioner
+// materialization).
 func chrootRegionsFromEnv() []provisioner.RegionSpec {
 	raw := strings.TrimSpace(os.Getenv("SOVEREIGN_REGIONS_JSON"))
-	if raw == "" {
+	if raw != "" {
+		var out []provisioner.RegionSpec
+		if err := json.Unmarshal([]byte(raw), &out); err == nil && len(out) > 0 {
+			return out
+		}
+	}
+	return chrootRegionsFromPrimaryReplicaEnv()
+}
+
+// chrootRegionsFromPrimaryReplicaEnv reconstructs the region list from
+// the discrete primary/replica region env vars. The primary region is
+// always emitted when SOVEREIGN_PRIMARY_REGION is set; the replica is
+// appended only when SOVEREIGN_ENABLE_HOT_STANDBY is truthy AND
+// SOVEREIGN_REPLICA_REGION is set and distinct from the primary.
+// Returns nil when no primary is known so the caller falls back to the
+// single-cluster live-Nodes path (legacy behaviour preserved).
+func chrootRegionsFromPrimaryReplicaEnv() []provisioner.RegionSpec {
+	primary := strings.TrimSpace(os.Getenv("SOVEREIGN_PRIMARY_REGION"))
+	if primary == "" {
 		return nil
 	}
-	var out []provisioner.RegionSpec
-	if err := json.Unmarshal([]byte(raw), &out); err != nil {
-		return nil
+	out := []provisioner.RegionSpec{{CloudRegion: primary}}
+
+	replica := strings.TrimSpace(os.Getenv("SOVEREIGN_REPLICA_REGION"))
+	if replica != "" && replica != primary && envTruthy("SOVEREIGN_ENABLE_HOT_STANDBY") {
+		out = append(out, provisioner.RegionSpec{CloudRegion: replica})
 	}
 	return out
+}
+
+// envTruthy reports whether the named env var holds a truthy value.
+// Accepts the canonical "true"/"1"/"yes"/"on" set (case-insensitive)
+// the chart stamps for boolean ConfigMap keys; everything else
+// (including unset and "false") is false.
+func envTruthy(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "true", "1", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 // chrootSeedJobsStoreIfEmpty — when the chroot Sovereign-side

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_chroot_regions_3106_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_chroot_regions_3106_test.go
@@ -1,0 +1,207 @@
+// jobs_chroot_regions_3106_test.go — unit coverage for the #3106
+// cloud-graph "Region 1/1" fix.
+//
+// On a 2-region hot-standby Sovereign the chroot catalyst-api may have
+// an empty `regionsJson` ConfigMap key (SOVEREIGN_REGIONS_JSON=[]) even
+// though the per-Sovereign overlay populates the discrete
+// primaryRegion / replicaRegion / enableHotStandby keys. Before this
+// fix chrootRegionsFromEnv returned nil in that case, buildTopology
+// dropped into the single-cluster live-Nodes path, and
+// `/cloud?view=graph` rendered only the in-cluster primary region
+// ("Region 1/1") despite both clusters genuinely existing. These tests
+// lock in: N regions of env input → N regions reconstructed, so the
+// topology loader emits one Region per region for the graph view.
+//
+// Reproduces hw101 (e19b083c6db41bb0, 2026-06-08): regionsJson=[],
+// primaryRegion=hw-me-east-215-a-rtz-prod,
+// replicaRegion=hw-me-east-215-b-rtz-prod, enableHotStandby=true.
+
+package handler
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// TestChrootRegionsFromEnv_PrimaryReplicaFallback is the core #3106
+// table: each row sets the env the chroot sees and asserts the
+// reconstructed CloudRegion list. The "regionsJson empty + 2-region
+// hot-standby" row is the exact hw101 shape that produced "Region
+// 1/1".
+func TestChrootRegionsFromEnv_PrimaryReplicaFallback(t *testing.T) {
+	cases := []struct {
+		name        string
+		regionsJSON string
+		primary     string
+		replica     string
+		hotStandby  string
+		wantRegions []string
+	}{
+		{
+			name:        "hw101 shape — empty regionsJson, 2-region hot-standby → BOTH regions",
+			regionsJSON: "[]",
+			primary:     "hw-me-east-215-a-rtz-prod",
+			replica:     "hw-me-east-215-b-rtz-prod",
+			hotStandby:  "true",
+			wantRegions: []string{"hw-me-east-215-a-rtz-prod", "hw-me-east-215-b-rtz-prod"},
+		},
+		{
+			name:        "unset regionsJson, 2-region hot-standby → BOTH regions",
+			regionsJSON: "",
+			primary:     "hz-fsn-rtz-prod",
+			replica:     "hz-hel-rtz-prod",
+			hotStandby:  "true",
+			wantRegions: []string{"hz-fsn-rtz-prod", "hz-hel-rtz-prod"},
+		},
+		{
+			name:        "hot-standby disabled → primary ONLY (no replica row)",
+			regionsJSON: "[]",
+			primary:     "hz-fsn-rtz-prod",
+			replica:     "hz-hel-rtz-prod",
+			hotStandby:  "false",
+			wantRegions: []string{"hz-fsn-rtz-prod"},
+		},
+		{
+			name:        "hot-standby unset → primary ONLY",
+			regionsJSON: "",
+			primary:     "hz-fsn-rtz-prod",
+			replica:     "hz-hel-rtz-prod",
+			hotStandby:  "",
+			wantRegions: []string{"hz-fsn-rtz-prod"},
+		},
+		{
+			name:        "single-region prov (no replica) → primary ONLY",
+			regionsJSON: "[]",
+			primary:     "hz-fsn-rtz-prod",
+			replica:     "",
+			hotStandby:  "true",
+			wantRegions: []string{"hz-fsn-rtz-prod"},
+		},
+		{
+			name:        "replica == primary (degenerate) → deduped to ONE",
+			regionsJSON: "",
+			primary:     "hz-fsn-rtz-prod",
+			replica:     "hz-fsn-rtz-prod",
+			hotStandby:  "true",
+			wantRegions: []string{"hz-fsn-rtz-prod"},
+		},
+		{
+			name:        "no primary, no regionsJson → nil (live-Nodes fallback preserved)",
+			regionsJSON: "",
+			primary:     "",
+			replica:     "hz-hel-rtz-prod",
+			hotStandby:  "true",
+			wantRegions: nil,
+		},
+		{
+			name:        "populated regionsJson WINS over primary/replica env",
+			regionsJSON: `[{"cloudRegion":"region-x","workerCount":3},{"cloudRegion":"region-y","workerCount":3},{"cloudRegion":"region-z","workerCount":3}]`,
+			primary:     "hz-fsn-rtz-prod",
+			replica:     "hz-hel-rtz-prod",
+			hotStandby:  "true",
+			wantRegions: []string{"region-x", "region-y", "region-z"},
+		},
+		{
+			name:        "malformed regionsJson falls THROUGH to primary/replica fallback",
+			regionsJSON: "{not-json",
+			primary:     "hz-fsn-rtz-prod",
+			replica:     "hz-hel-rtz-prod",
+			hotStandby:  "1",
+			wantRegions: []string{"hz-fsn-rtz-prod", "hz-hel-rtz-prod"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SOVEREIGN_REGIONS_JSON", tc.regionsJSON)
+			t.Setenv("SOVEREIGN_PRIMARY_REGION", tc.primary)
+			t.Setenv("SOVEREIGN_REPLICA_REGION", tc.replica)
+			t.Setenv("SOVEREIGN_ENABLE_HOT_STANDBY", tc.hotStandby)
+
+			got := chrootRegionsFromEnv()
+			if len(got) != len(tc.wantRegions) {
+				t.Fatalf("region count = %d (%v); want %d (%v)",
+					len(got), regionCodes(got), len(tc.wantRegions), tc.wantRegions)
+			}
+			for i, want := range tc.wantRegions {
+				if got[i].CloudRegion != want {
+					t.Fatalf("region[%d].CloudRegion = %q; want %q (full: %v)",
+						i, got[i].CloudRegion, want, regionCodes(got))
+				}
+			}
+		})
+	}
+}
+
+// TestEnvTruthy locks in the boolean-env parsing the replica gate relies
+// on — the chart stamps "true" but defense-in-depth accepts the common
+// truthy spellings, and everything else (notably "false" and unset) is
+// false.
+func TestEnvTruthy(t *testing.T) {
+	truthy := []string{"true", "TRUE", "True", "1", "yes", "YES", "on", "  true  "}
+	falsy := []string{"", "false", "FALSE", "0", "no", "off", "nope", "2"}
+	for _, v := range truthy {
+		t.Run("truthy/"+v, func(t *testing.T) {
+			t.Setenv("X_TEST_BOOL", v)
+			if !envTruthy("X_TEST_BOOL") {
+				t.Fatalf("envTruthy(%q) = false; want true", v)
+			}
+		})
+	}
+	for _, v := range falsy {
+		t.Run("falsy/"+v, func(t *testing.T) {
+			t.Setenv("X_TEST_BOOL", v)
+			if envTruthy("X_TEST_BOOL") {
+				t.Fatalf("envTruthy(%q) = true; want false", v)
+			}
+		})
+	}
+}
+
+// TestChrootEnsureDeployment_TwoRegionsFromPrimaryReplica is the
+// end-to-end proof: when the chroot synthesises its self-deployment
+// record (the path /infrastructure/topology takes on the Sovereign's
+// own console), Request.Regions carries BOTH regions. The topology
+// loader's buildTopology consumes Request.Regions and emits one Region
+// per entry, so this asserts the data the cloud-graph renders has 2
+// regions, not 1.
+func TestChrootEnsureDeployment_TwoRegionsFromPrimaryReplica(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "hw101.omantel.biz")
+	t.Setenv("SOVEREIGN_REGIONS_JSON", "[]") // the hw101 wedge: empty list
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "hw-me-east-215-a-rtz-prod")
+	t.Setenv("SOVEREIGN_REPLICA_REGION", "hw-me-east-215-b-rtz-prod")
+	t.Setenv("SOVEREIGN_ENABLE_HOT_STANDBY", "true")
+
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	dep := h.chrootEnsureDeployment("e19b083c6db41bb0")
+	if dep == nil {
+		t.Fatal("chrootEnsureDeployment returned nil — expected a synthesised record in chroot mode")
+	}
+	if len(dep.Request.Regions) != 2 {
+		t.Fatalf("synthesised Request.Regions count = %d (%v); want 2 — cloud-graph would render Region 1/%d",
+			len(dep.Request.Regions), regionCodes(dep.Request.Regions), len(dep.Request.Regions))
+	}
+	if dep.Request.Regions[0].CloudRegion != "hw-me-east-215-a-rtz-prod" {
+		t.Fatalf("region[0] = %q; want hw-me-east-215-a-rtz-prod", dep.Request.Regions[0].CloudRegion)
+	}
+	if dep.Request.Regions[1].CloudRegion != "hw-me-east-215-b-rtz-prod" {
+		t.Fatalf("region[1] = %q; want hw-me-east-215-b-rtz-prod", dep.Request.Regions[1].CloudRegion)
+	}
+	// The legacy singular Region field should anchor to the primary so
+	// the Settings page + derivePattern stay consistent.
+	if dep.Request.Region != "hw-me-east-215-a-rtz-prod" {
+		t.Fatalf("legacy Request.Region = %q; want primary hw-me-east-215-a-rtz-prod", dep.Request.Region)
+	}
+}
+
+func regionCodes(rs []provisioner.RegionSpec) []string {
+	out := make([]string, 0, len(rs))
+	for _, r := range rs {
+		out = append(out, r.CloudRegion)
+	}
+	return out
+}


### PR DESCRIPTION
Refs #3106

## Side with the bug: API loader (chroot region source), not the console adapter

The console cloud-graph adapter (`hierarchyToGraph` / `mergeGraphs`) already iterates **all** `topology.regions` and never drops a region — so the renderer was correct. The bug was that the **chroot** catalyst-api fed it a 1-region topology.

On `console.hw101.omantel.biz` (the Sovereign's own console = the chroot path) the topology is built from `chrootEnsureDeployment` → `chrootRegionsFromEnv()`, which read **only** `SOVEREIGN_REGIONS_JSON`. On hw101 (`e19b083c6db41bb0`) that ConfigMap key (`regionsJson`) was empty `[]`, so `chrootRegionsFromEnv()` returned nil, `buildTopology` fell into the **single-cluster live-Nodes path** (which only probes the in-cluster region-a Nodes), and `/cloud?view=graph` rendered **`Region 1/1`** — only `me-east-215-a` — despite the substrate genuinely having both clusters (region-a + region-b, 4+4 Ready nodes, two kubeconfigs on the PVC).

Live-verified on hw101 `sovereign-fqdn` ConfigMap:
```
regionsJson       = []                              ← the wedge
primaryRegion     = hw-me-east-215-a-rtz-prod       ← populated
replicaRegion     = hw-me-east-215-b-rtz-prod       ← populated
enableHotStandby  = true                            ← populated
```

## Fix (`internal/handler/jobs.go`, `chrootRegionsFromEnv`)

When `SOVEREIGN_REGIONS_JSON` is unset / empty / `[]`, reconstruct the region list from the discrete `SOVEREIGN_PRIMARY_REGION` + `SOVEREIGN_REPLICA_REGION` env vars (replica gated on `SOVEREIGN_ENABLE_HOT_STANDBY`). These are already wired by `bp-catalyst-platform` from the same ConfigMap and are reliably populated on a 2-region hot-standby Sovereign. `buildTopology` then emits one Region per entry, so the cloud-graph shows **both** regions.

- before: `if raw == "" { return nil }` → single-cluster live-Nodes path → Region 1/1
- after: empty/`[]`/malformed `regionsJson` falls through to primary+replica reconstruction → 2 regions

**Contained + additive** — populated `regionsJson` still wins; no-primary still returns nil so the legacy single-cluster live-Nodes fallback is preserved. This is a **view-completeness** fix only: node/SKU detail still flows from the live K8s SSE snapshot the graph merges on the UI side. It does **NOT** touch the deeper cross-region provisioner materialization (`MaterializedRegions`) — that's a separate G117 item.

The region-count chip ("Region N/M") is derived downstream from `topology.regions.length`, so no separate chip-filter change was needed — fixing the region source fixes the chip.

## Tests
- `TestChrootRegionsFromEnv_PrimaryReplicaFallback` — 9 cases incl. the exact hw101 shape + N-region-in → N-region-out, hot-standby off → 1, regionsJson-wins, malformed-falls-through.
- `TestEnvTruthy` — boolean-env parsing for the replica gate.
- `TestChrootEnsureDeployment_TwoRegionsFromPrimaryReplica` — end-to-end: synthesised `Request.Regions == 2` (the data the cloud-graph renders).

`go build ./...` + `go test ./...` green in `products/catalyst/bootstrap/api`.

Verification: PENDING — live re-walk hw101 /cloud?view=graph must show 2 regions