### PR TITLE
fix(prov): populate sovereign.regionsJson from Request.Regions (#3110 canonical fix)

### DIFF
--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -612,6 +612,28 @@ write_files:
             # Continuity Plan row + the BSS-menu DR posture chip.
             SOVEREIGN_ENABLE_HOT_STANDBY: "${enable_hot_standby}"
             SOVEREIGN_BCP_TOPOLOGY: "${bcp_topology}"
+            # #3110 — canonical multi-region RegionSpec[] JSON. The HCS
+            # port silently omitted this key (and CONFIGURED_REGIONS_YAML
+            # below) pre-#3110, so the chart's `$${SOVEREIGN_REGIONS_JSON:-}`
+            # envsubst resolved to literal empty → `.Values.sovereign.
+            # regionsJson` defaulted to `[]` → the sovereign-fqdn ConfigMap
+            # shipped `regionsJson=[]` on EVERY HCS Sovereign (caught live
+            # on hw101). catalyst-api jobs.go chrootRegionsFromEnv reads
+            # this env to seed Request.Regions on the chroot Deployment so
+            # /cloud?view=graph renders the full multi-region tree (DoD
+            # D5) instead of falling to #3109's discrete primary/replica
+            # reconstruction. main.tf re-keys var.regions into the
+            # canonical RegionSpec JSON shape (cloudRegion=hw-<code>-rtz-
+            # prod) — see the templatefile() call's sovereign_regions_json
+            # arg. Single-quoted so YAML treats the JSON braces as a
+            # literal scalar — same pattern as PARENT_DOMAINS_YAML.
+            SOVEREIGN_REGIONS_JSON: '${sovereign_regions_json}'
+            # #3110 — YAML inline-list literal of the canonical region
+            # labels this Sovereign was provisioned with. Chart joins it
+            # into the comma-separated `configuredRegions` ConfigMap key
+            # for the Dashboard SovereignCard + ClusterMesh chips. `[]` on
+            # single-region. Single-quoted (JSON-flow is a YAML superset).
+            SOVEREIGN_CONFIGURED_REGIONS_YAML: '${sovereign_configured_regions_yaml}'
             # Refs #2533 — G1: per-CP region role. The shared
             # bootstrap-kit overlays (e.g. bp-cnpg-pair primary/replica
             # placement) gate on this; primary CP renders "primary",

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -676,6 +676,57 @@ locals {
       region_canonical_label         = "hw-${r.code}-rtz-prod"
       primary_region_canonical_label = "hw-${var.regions[0].code}-rtz-prod"
       replica_region_canonical_label = length(var.regions) > 1 ? "hw-${var.regions[1].code}-rtz-prod" : ""
+      # #3110 — canonical regionsJson population (HCS port).
+      # sovereign_regions_json — full multi-region RegionSpec[] JSON
+      # literal threaded into bp-catalyst-platform's
+      # .Values.sovereign.regionsJson via the bootstrap-kit slot 13
+      # postBuild.substitute `SOVEREIGN_REGIONS_JSON`. catalyst-api on
+      # the Sovereign side reads it via the `sovereign-fqdn` ConfigMap
+      # env `SOVEREIGN_REGIONS_JSON` (jobs.go chrootRegionsFromEnv) to
+      # seed Request.Regions on the chroot Deployment, so
+      # /infrastructure/topology + /cloud?view=graph return the full
+      # multi-region tree (DoD D5) WITHOUT relying on #3109's discrete
+      # primary/replica fallback. The Hetzner port has had this since
+      # TBD-A15/#1844; the HCS port silently omitted it, so every HCS
+      # Sovereign landed `regionsJson=[]` (caught live on hw101
+      # e19b083c6db41bb0 2026-06-08) and fell to #3109's fallback.
+      #
+      # CRITICAL field-name remap: Hetzner's `var.regions` object uses
+      # the Go RegionSpec JSON field names verbatim (cloudRegion /
+      # controlPlaneSize / workerSize / workerCount) so Hetzner can
+      # `jsonencode(var.regions)` directly. The HCS `var.regions` object
+      # uses different field names (code / role / control_plane_size /
+      # worker_size / worker_count — see variables.tf), so a raw
+      # jsonencode would emit `code`-keyed objects the catalyst-api
+      # consumer (RegionSpec json.Unmarshal) can't read → CloudRegion=""
+      # for every entry. We therefore re-key each region into the
+      # canonical RegionSpec JSON shape here. `cloudRegion` is set to the
+      # 4-segment canonical label `hw-<code>-rtz-prod` (NOT the bare
+      # `code`) so it matches the format the discrete
+      # SOVEREIGN_PRIMARY_REGION / SOVEREIGN_REPLICA_REGION substitutes
+      # (and #3109's fallback) already emit — keeping both paths
+      # byte-consistent in the chroot region list. provider="huawei".
+      sovereign_regions_json = jsonencode([
+        for rr in var.regions : {
+          provider         = "huawei"
+          cloudRegion      = "hw-${rr.code}-rtz-prod"
+          controlPlaneSize = rr.control_plane_size
+          workerSize       = rr.worker_size
+          workerCount      = rr.worker_count
+        }
+      ])
+      # sovereign_configured_regions_yaml — JSON-flow inline-list literal
+      # of the canonical region labels this Sovereign was provisioned
+      # with (e.g. `["hw-me-east-215-a-rtz-prod","hw-me-east-215-b-rtz-prod"]`).
+      # Threaded into bootstrap-kit slot 13's
+      # `sovereign.configuredRegions: ${SOVEREIGN_CONFIGURED_REGIONS_YAML:-[]}`
+      # substitute. The chart's sovereign-fqdn ConfigMap joins this list
+      # into the comma-separated `configuredRegions` key for the
+      # catalyst-ui Dashboard SovereignCard + Networking → ClusterMesh
+      # chips. Empty `[]` on a back-compat single-region prov.
+      sovereign_configured_regions_yaml = jsonencode([
+        for rr in var.regions : "hw-${rr.code}-rtz-prod"
+      ])
       # G93.1 (Refs #2666) — BCP topology threading. The Huawei
       # cloud-init template adds SOVEREIGN_ENABLE_HOT_STANDBY +
       # SOVEREIGN_BCP_TOPOLOGY to the Kustomization

--- a/infra/providers/huawei/tests/multi_region.tftest.hcl
+++ b/infra/providers/huawei/tests/multi_region.tftest.hcl
@@ -175,6 +175,136 @@ run "single_region" {
   }
 }
 
+# Scenario 4 (#3110) — the rendered primary-CP cloud-init carries the
+# canonical SOVEREIGN_REGIONS_JSON substitute populated from var.regions.
+# Pre-#3110 the HCS port omitted this key entirely, so the bootstrap-kit
+# Kustomization's `$${SOVEREIGN_REGIONS_JSON:-}` resolved empty → the
+# bp-catalyst-platform chart shipped `regionsJson=[]` in the sovereign-
+# fqdn ConfigMap on every HCS Sovereign (caught live on hw101), forcing
+# #3109's discrete primary/replica fallback. These asserts pin the
+# canonical fix: regionsJson is non-empty, re-keyed into the Go RegionSpec
+# JSON shape (cloudRegion, NOT the HCS-native `code`), and uses the
+# 4-segment canonical region label so it matches the discrete
+# SOVEREIGN_PRIMARY_REGION / SOVEREIGN_REPLICA_REGION format.
+run "regions_json_populated_3110" {
+  command = plan
+
+  variables {
+    regions = [
+      {
+        code               = "me-east-215-a"
+        role               = "primary"
+        control_plane_size = "s7n.large.4"
+        worker_size        = "m7n.xlarge.8"
+        worker_count       = 2
+      },
+      {
+        code               = "me-east-215-b"
+        role               = "secondary"
+        control_plane_size = "s7n.large.4"
+        worker_size        = "m7n.xlarge.8"
+        worker_count       = 3
+      }
+    ]
+  }
+
+  # SOVEREIGN_REGIONS_JSON key is present and NON-empty (`[]` is the bug).
+  assert {
+    condition = strcontains(
+      local.cp_cloud_init_by_region["me-east-215-a"],
+      "SOVEREIGN_REGIONS_JSON:"
+    )
+    error_message = "Primary-CP cloud-init must emit the SOVEREIGN_REGIONS_JSON substitute key (#3110)."
+  }
+  # The empty-array regression must NOT appear (single-quoted JSON-flow).
+  assert {
+    condition = !strcontains(
+      local.cp_cloud_init_by_region["me-east-215-a"],
+      "SOVEREIGN_REGIONS_JSON: '[]'"
+    )
+    error_message = "SOVEREIGN_REGIONS_JSON must be populated, not the empty-array `[]` regression (#3110/#3106)."
+  }
+  # Both regions appear in the JSON, in the canonical 4-segment label form
+  # (cloudRegion=hw-<code>-rtz-prod), matching the discrete primary/replica
+  # substitutes — NOT the bare HCS `code`.
+  assert {
+    condition = strcontains(
+      local.cp_cloud_init_by_region["me-east-215-a"],
+      "hw-me-east-215-a-rtz-prod"
+    )
+    error_message = "regionsJson must carry the primary region's canonical label hw-me-east-215-a-rtz-prod (#3110)."
+  }
+  assert {
+    condition = strcontains(
+      local.cp_cloud_init_by_region["me-east-215-a"],
+      "hw-me-east-215-b-rtz-prod"
+    )
+    error_message = "regionsJson must carry the replica region's canonical label hw-me-east-215-b-rtz-prod (#3110)."
+  }
+  # The Go RegionSpec field name `cloudRegion` must be present — proves the
+  # HCS-native `code`/`control_plane_size` keys were re-mapped so
+  # catalyst-api's RegionSpec json.Unmarshal can read it.
+  assert {
+    condition = strcontains(
+      local.cp_cloud_init_by_region["me-east-215-a"],
+      "\"cloudRegion\""
+    )
+    error_message = "regionsJson must use the Go RegionSpec field name cloudRegion (re-keyed from HCS `code`) so catalyst-api can unmarshal it (#3110)."
+  }
+  # Per-region SKU detail (worker_count) is threaded through, so the full
+  # RegionSpec[] (not just region names) reaches the chroot.
+  assert {
+    condition = strcontains(
+      local.cp_cloud_init_by_region["me-east-215-a"],
+      "\"workerCount\":3"
+    )
+    error_message = "regionsJson must carry per-region SKU detail (replica workerCount=3) — full RegionSpec[], not just region names (#3110)."
+  }
+  # Companion key — configuredRegions list also populated with canonical
+  # labels for the Dashboard SovereignCard + ClusterMesh chips.
+  assert {
+    condition = strcontains(
+      local.cp_cloud_init_by_region["me-east-215-a"],
+      "SOVEREIGN_CONFIGURED_REGIONS_YAML:"
+    )
+    error_message = "Primary-CP cloud-init must emit SOVEREIGN_CONFIGURED_REGIONS_YAML (#3110)."
+  }
+}
+
+# Scenario 5 (#3110) — single-region Sovereign still emits a populated,
+# 1-entry regionsJson (NOT empty), so a 1-region HCS prov also surfaces
+# its region in /cloud without the discrete fallback.
+run "regions_json_single_region_3110" {
+  command = plan
+
+  variables {
+    regions = [
+      {
+        code               = "me-east-215-a"
+        role               = "primary"
+        control_plane_size = "s7n.large.4"
+        worker_size        = "m7n.xlarge.8"
+        worker_count       = 2
+      }
+    ]
+  }
+
+  assert {
+    condition = !strcontains(
+      local.cp_cloud_init_by_region["me-east-215-a"],
+      "SOVEREIGN_REGIONS_JSON: '[]'"
+    )
+    error_message = "Single-region HCS prov must still emit a populated regionsJson, not `[]` (#3110)."
+  }
+  assert {
+    condition = strcontains(
+      local.cp_cloud_init_by_region["me-east-215-a"],
+      "hw-me-east-215-a-rtz-prod"
+    )
+    error_message = "Single-region regionsJson must carry the region's canonical label (#3110)."
+  }
+}
+
 # Scenario 3 — HA topology (huawei_control_plane_count=3) for tenancies
 # with adequate EIP headroom (public Huawei Cloud or HCS POD enterprise
 # tier). Verifies replica CPs (index > 0) do NOT consume EIPs.


### PR DESCRIPTION
Refs #3110 #3109

## What

Canonical fix for `regionsJson=[]` on **Huawei (HCS)** Sovereigns. The Hetzner cloud-init path already populated `SOVEREIGN_REGIONS_JSON` end-to-end (TBD-A15/#1844); the HCS port silently omitted it, so the `sovereign-fqdn` ConfigMap shipped `regionsJson=[]` on every HCS Sovereign — exactly what forced #3109's discrete primary/replica chroot fallback.

### Root cause (Huawei-specific)

- `infra/providers/huawei/main.tf` CP `templatefile()` call did **not** pass `sovereign_regions_json` / `sovereign_configured_regions_yaml`.
- `infra/providers/huawei/cloudinit-control-plane.tftpl` bootstrap-kit substitute block had `SOVEREIGN_PRIMARY_REGION` / `SOVEREIGN_REPLICA_REGION` / `SOVEREIGN_ENABLE_HOT_STANDBY` but **no** `SOVEREIGN_REGIONS_JSON` key.

→ chart's `${SOVEREIGN_REGIONS_JSON:-}` resolved empty → `.Values.sovereign.regionsJson` defaulted `[]` → ConfigMap `regionsJson=[]` (caught live hw101 `e19b083c6db41bb0`).

### Fix

- **main.tf**: thread `sovereign_regions_json` + `sovereign_configured_regions_yaml` into the CP cloudinit `templatefile()` args.
- **cloudinit-control-plane.tftpl**: emit both keys in the bootstrap-kit `postBuild.substitute` map.

**Full RegionSpec[] (not just region names).** Each entry carries `provider`, `cloudRegion`, `controlPlaneSize`, `workerSize`, `workerCount`.

**Field-name remap (load-bearing).** Hetzner's `var.regions` already uses the Go `RegionSpec` JSON field names (`cloudRegion`/`controlPlaneSize`/…) so it can `jsonencode(var.regions)` directly. The HCS `var.regions` object uses `code`/`role`/`control_plane_size`/`worker_size`/`worker_count`, so a raw jsonencode would emit `code`-keyed objects catalyst-api's `RegionSpec` `json.Unmarshal` can't read (`CloudRegion=""`). main.tf therefore **re-keys** each region into the canonical RegionSpec shape, with `cloudRegion = hw-<code>-rtz-prod` (the 4-segment canonical label — matching the discrete `SOVEREIGN_PRIMARY_REGION`/`REPLICA_REGION` format and #3109's fallback, keeping both chroot paths byte-consistent).

Rendered output (verified via standalone `tofu apply`):
```json
[{"cloudRegion":"hw-me-east-215-a-rtz-prod","controlPlaneSize":"s7n.large.4","provider":"huawei","workerCount":2,"workerSize":"m7n.xlarge.8"},
 {"cloudRegion":"hw-me-east-215-b-rtz-prod","controlPlaneSize":"s7n.large.4","provider":"huawei","workerCount":3,"workerSize":"m7n.xlarge.8"}]
```

#3109's `chrootRegionsFromPrimaryReplicaEnv` fallback is **left intact** (defense in depth); this canonical path means it is now rarely hit on HCS.

## Tests

- `infra/providers/huawei/tests/multi_region.tftest.hcl`: 2 new `run` blocks asserting the rendered primary-CP cloud-init carries a **non-empty** `SOVEREIGN_REGIONS_JSON` (NOT `[]`), uses the canonical labels + the Go `cloudRegion` field name, and threads per-region SKU detail (`workerCount:3`), for both 2-region and single-region requests.
- `go build ./...` + targeted `go test ./internal/{handler,provisioner}/...` green in `products/catalyst/bootstrap/api` (Go untouched — change is Tofu-only).

## Verification

Verification: PENDING — fresh prov must show regionsJson non-empty