### PR TITLE
fix(deps-audit): bp-sandbox->bp-external-secrets edge — clears dep-graph-audit RED (#3104)

### DIFF
--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -622,6 +622,11 @@ slots:
       - bp-vcluster-helmrepo
       - bp-catalyst-platform
       - bp-harbor
+      # #3102/#3104 (2026-06-08): sandbox renders an ExternalSecret; the HR's
+      # dependsOn gained bp-external-secrets (ESO CRD/webhook ready first) — this
+      # edge was added to the HR in #3102 but not declared here, causing the
+      # dependency-graph-audit drift that's been red on main (#3104).
+      - bp-external-secrets
     wave: present
 
   # ---- Slot 62 — bp-continuum DR orchestrator (Pillar-3 unblock).


### PR DESCRIPTION
Audit red on main since #3102 added the HR edge without declaring it here. One-line reconcile, Drift 0 verified. Refs #3104 #3102