### PR TITLE
fix(prov): template remaining openova.io chart/ingress tethers (#2940 Pillar 5)

### DIFF
--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -76,6 +76,10 @@ spec:
   chart:
     spec:
       chart: bp-sso-bridge
+      # 0.2.15 (#2940 Pillar 5 anti-tether, 2026-06-08): reconciler image
+      # registry host now driven by global.registryMirror (single source
+      # of truth) — see the values.global.registryMirror overlay below.
+      # Default render unchanged (harbor.openova.io). Refs #2940.
       # 0.2.8 (G117.5-followup #2914, 2026-06-03): dual-token KC mint —
       # adds master-realm token via grant_type=password against
       # /realms/master/...token using bitnami-generated admin user creds
@@ -116,7 +120,7 @@ spec:
       # 0.1.1 (G91-fu, Refs #2659, edc55c08 PR #2676): adds realm-role
       # grant + skipClientUpsert opt-out for charts whose Keycloak Client
       # is realm-imported at bp-keycloak install time (catalyst-ui etc.).
-      version: 0.2.14
+      version: 0.2.15
       sourceRef:
         kind: HelmRepository
         name: bp-sso-bridge
@@ -128,6 +132,15 @@ spec:
   # chart-value fallback breaks that residual cycle; the CM (with
   # orgEmail) still wins once it exists.
   values:
+    # #2940 Pillar 5 anti-tether: the reconciler image's registry host.
+    # Default `harbor.openova.io` (the mothership Harbor proxy-cache) keeps
+    # the bootstrap pull working out-of-the-box; the
+    # `${REGISTRY_MIRROR:=harbor.openova.io}` substitution lets a
+    # per-Sovereign overlay (or the bp-self-sovereign-cutover Step-04
+    # registry pivot, ADR-0002) re-point the host to the Sovereign's OWN
+    # Harbor in one place without editing the chart.
+    global:
+      registryMirror: ${REGISTRY_MIRROR:=harbor.openova.io}
     sovereign:
       fqdn: ${SOVEREIGN_FQDN}
   install:

--- a/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
@@ -63,7 +63,9 @@ spec:
   chart:
     spec:
       chart: bp-dmz-vcluster
-      version: 0.2.4
+      # 0.2.5 (#2940 Pillar 5): registry host driven by global.registryMirror
+      # + the ${REGISTRY_MIRROR:=harbor.openova.io} subchart substitution below.
+      version: 0.2.5
       sourceRef:
         kind: HelmRepository
         name: bp-dmz-vcluster
@@ -83,6 +85,12 @@ spec:
   # dmzVcluster.enabled — DMZ runs on every region by design (DoD A4).
   # Default-ON to deliver the topology contract on day-one.
   values:
+    # #2940 Pillar 5 anti-tether — single source of truth for the registry
+    # host the umbrella image guard composes. `${REGISTRY_MIRROR:=harbor.openova.io}`
+    # keeps bootstrap on the mothership Harbor; a per-Sovereign overlay (or
+    # the bp-self-sovereign-cutover Step-04 pivot) flips it in one place.
+    global:
+      registryMirror: ${REGISTRY_MIRROR:=harbor.openova.io}
     dmzVcluster:
       enabled: true
       hostNamespace: dmz
@@ -102,6 +110,10 @@ spec:
     vcluster:
       controlPlane:
         statefulSet:
+          # #2940 Pillar 5: the ACTUAL syncer image registry — single
+          # overlay knob for the subchart literal (can't self-template).
+          image:
+            registry: ${REGISTRY_MIRROR:=harbor.openova.io}
           scheduling:
             nodeSelector:
               openova.io/region: ${SOVEREIGN_REGION_CANONICAL_LABEL}

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -70,7 +70,9 @@ spec:
   chart:
     spec:
       chart: bp-mgmt-vcluster
-      version: 0.2.5
+      # 0.2.6 (#2940 Pillar 5): registry host driven by global.registryMirror
+      # + the ${REGISTRY_MIRROR:=harbor.openova.io} subchart substitution above.
+      version: 0.2.6
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster
@@ -100,6 +102,13 @@ spec:
   # `values.mgmtVcluster.enabled: true` only on the primary CP's
   # cloud-init).
   values:
+    # #2940 Pillar 5 anti-tether: single source of truth for the registry
+    # host the umbrella's image fail-fast guard composes. Default
+    # `harbor.openova.io` (mothership Harbor proxy-cache); a per-Sovereign
+    # overlay (or the bp-self-sovereign-cutover Step-04 registry pivot,
+    # ADR-0002) re-points to the Sovereign's OWN Harbor in one place.
+    global:
+      registryMirror: ${REGISTRY_MIRROR:=harbor.openova.io}
     mgmtVcluster:
       # Refs #2537 G9 (2026-05-28): drop the MGMT_VCLUSTER_ENABLED
       # substitute. The "follow-up PR to wire the substitute on primary
@@ -123,6 +132,14 @@ spec:
     vcluster:
       controlPlane:
         statefulSet:
+          # #2940 Pillar 5: the ACTUAL vCluster syncer image registry.
+          # The subchart values literal can't self-template off
+          # global.registryMirror, so the single overlay knob lives HERE —
+          # `${REGISTRY_MIRROR:=harbor.openova.io}` keeps the bootstrap pull
+          # on the mothership Harbor and lets a per-Sovereign overlay (or
+          # the cutover Step-04 pivot) flip it to harbor.<sovereign-fqdn>.
+          image:
+            registry: ${REGISTRY_MIRROR:=harbor.openova.io}
           scheduling:
             nodeSelector:
               openova.io/region: ${SOVEREIGN_REGION_CANONICAL_LABEL}

--- a/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
@@ -62,7 +62,9 @@ spec:
   chart:
     spec:
       chart: bp-rtz-vcluster
-      version: 0.2.5
+      # 0.2.6 (#2940 Pillar 5): registry host driven by global.registryMirror
+      # + the ${REGISTRY_MIRROR:=harbor.openova.io} subchart substitution below.
+      version: 0.2.6
       sourceRef:
         kind: HelmRepository
         name: bp-rtz-vcluster
@@ -78,6 +80,12 @@ spec:
     remediation:
       retries: 3
   values:
+    # #2940 Pillar 5 anti-tether — single source of truth for the registry
+    # host the umbrella image guard composes. `${REGISTRY_MIRROR:=harbor.openova.io}`
+    # keeps bootstrap on the mothership Harbor; a per-Sovereign overlay (or
+    # the bp-self-sovereign-cutover Step-04 pivot) flips it in one place.
+    global:
+      registryMirror: ${REGISTRY_MIRROR:=harbor.openova.io}
     rtzVcluster:
       # Refs #2537 G9 (2026-05-28): drop the RTZ_VCLUSTER_ENABLED
       # substitute (never landed — same fate as MGMT). Symmetric
@@ -92,6 +100,10 @@ spec:
     vcluster:
       controlPlane:
         statefulSet:
+          # #2940 Pillar 5: the ACTUAL syncer image registry — single
+          # overlay knob for the subchart literal (can't self-template).
+          image:
+            registry: ${REGISTRY_MIRROR:=harbor.openova.io}
           scheduling:
             nodeSelector:
               openova.io/region: ${SOVEREIGN_REGION_CANONICAL_LABEL}

--- a/platform/bp-dmz-vcluster/blueprint.yaml
+++ b/platform/bp-dmz-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.4
+  version: 0.2.5
   card:
     title: DMZ vCluster
     summary: |

--- a/platform/bp-dmz-vcluster/chart/Chart.yaml
+++ b/platform/bp-dmz-vcluster/chart/Chart.yaml
@@ -19,7 +19,14 @@ name: bp-dmz-vcluster
 # 0.2.0 + bp-rtz-vcluster 0.2.0). Picks up `sync.toHost.customResources`
 # schema so DMZ vCluster-placed charts that need cross-vCluster CR sync
 # can wire it in without a follow-up chart bump.
-version: 0.2.4
+# 0.2.5 — Refs #2940 (Pillar 5 anti-tether, 2026-06-08): registry host no
+# longer hardcoded `harbor.openova.io` as the sole source of truth. New
+# `global.registryMirror` drives the umbrella image helper;
+# `dmzVcluster.image.repository` is registry-relative; the subchart syncer
+# image registry is driven by slot 54's `${REGISTRY_MIRROR:=harbor.openova.io}`
+# substitution. Renamed the dead `global.imageRegistry`. Default render
+# byte-identical. Sibling to bp-mgmt-vcluster 0.2.6 + bp-rtz-vcluster 0.2.6.
+version: 0.2.5
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign DMZ

--- a/platform/bp-dmz-vcluster/chart/templates/_helpers.tpl
+++ b/platform/bp-dmz-vcluster/chart/templates/_helpers.tpl
@@ -38,6 +38,12 @@ catalyst.openova.io/topology-role: {{ .Values.dmzVcluster.role | quote }}
 
 {{/*
 Image fail-fast helper. Per docs/INVIOLABLE-PRINCIPLES.md #4a.
+
+#2940 Pillar 5 anti-tether: composes the image registry host from
+`.Values.global.registryMirror` (default "harbor.openova.io", single
+source of truth) + the registry-relative `.Values.dmzVcluster.image.repository`.
+Backward-compat: a repository already host-qualified (first "/"-segment
+contains "." or ":") is used verbatim and the mirror is NOT prepended.
 */}}
 {{- define "bp-dmz-vcluster.image" -}}
 {{- $tag := .Values.dmzVcluster.image.tag -}}
@@ -46,15 +52,17 @@ Image fail-fast helper. Per docs/INVIOLABLE-PRINCIPLES.md #4a.
 {{- end -}}
 {{- $repo := .Values.dmzVcluster.image.repository -}}
 {{- if not $repo -}}
-{{- fail "bp-dmz-vcluster: .Values.dmzVcluster.image.repository is empty — must point at harbor.openova.io/proxy-ghcr/loft-sh/vcluster (or per-Sovereign Harbor) per CLAUDE.md MIRROR-EVERYTHING" -}}
+{{- fail "bp-dmz-vcluster: .Values.dmzVcluster.image.repository is empty — must point at proxy-ghcr/loft-sh/vcluster (registry-relative; global.registryMirror supplies the host) per CLAUDE.md MIRROR-EVERYTHING" -}}
 {{- end -}}
-{{- $globalRegistry := .Values.global.imageRegistry | default "" -}}
-{{- if ne $globalRegistry "" -}}
-{{- $parts := splitList "/" $repo -}}
-{{- $rest := slice $parts 1 -}}
-{{- printf "%s/%s:%s" $globalRegistry (join "/" $rest) $tag -}}
-{{- else -}}
+{{- $firstSeg := first (splitList "/" $repo) -}}
+{{- if or (contains "." $firstSeg) (contains ":" $firstSeg) -}}
 {{- printf "%s:%s" $repo $tag -}}
+{{- else -}}
+{{- $mirror := .Values.global.registryMirror | default "harbor.openova.io" -}}
+{{- if not $mirror -}}
+{{- fail "bp-dmz-vcluster: .Values.global.registryMirror is empty and .Values.dmzVcluster.image.repository is host-less — set one or the other (#2940)" -}}
+{{- end -}}
+{{- printf "%s/%s:%s" $mirror $repo $tag -}}
 {{- end -}}
 {{- end }}
 

--- a/platform/bp-dmz-vcluster/chart/values.yaml
+++ b/platform/bp-dmz-vcluster/chart/values.yaml
@@ -13,8 +13,18 @@ catalystBlueprint:
     version: "0.20.0"
     repo: "https://charts.loft.sh"
 
+# ── Registry mirror (MIRROR-EVERYTHING + Pillar 5 anti-tether #2940) ──
+# Single source of truth for the registry host every image in this chart
+# pulls through. Default `harbor.openova.io` preserves bootstrap behaviour.
+# Consumed by (1) the `bp-dmz-vcluster.image` fail-fast helper for the
+# umbrella image and (2) the loft-sh subchart syncer image registry, which
+# (being a subchart values literal Helm can't self-template) is driven by
+# slot 54's `${REGISTRY_MIRROR:=harbor.openova.io}` postBuild substitution.
+# Post-bp-self-sovereign-cutover (Step-04, ADR-0002) a per-Sovereign
+# overlay flips this to `harbor.<sovereign-fqdn>`. Renamed from the dead
+# `global.imageRegistry` (loft-sh never honoured that key). #2940.
 global:
-  imageRegistry: ""
+  registryMirror: "harbor.openova.io"
 
 dmzVcluster:
   # Top-level enable gate. False by default; bootstrap-kit slot 54
@@ -39,8 +49,13 @@ dmzVcluster:
     regionLabelValue: ""
 
   # ── Image (MIRROR-EVERYTHING) ─────────────────────────────────────
+  # #2940 Pillar 5: registry-RELATIVE repository; the host is composed
+  # from `global.registryMirror` by the `bp-dmz-vcluster.image` helper.
+  # Consumed only by the umbrella fail-fast guard — the real syncer image
+  # is the subchart value below; keep them in lockstep. Backward-compat: a
+  # host-qualified repository is honoured verbatim by the helper.
   image:
-    repository: "harbor.openova.io/proxy-ghcr/loft-sh/vcluster"
+    repository: "proxy-ghcr/loft-sh/vcluster"
     tag: "0.21.0"
     pullPolicy: "IfNotPresent"
 
@@ -86,6 +101,12 @@ vcluster:
       scheduling:
         nodeSelector: {}
       image:
+        # #2940 Pillar 5: the ACTUAL vCluster syncer image. This `registry`
+        # is a subchart values literal Helm can't derive from
+        # global.registryMirror here, so `harbor.openova.io` stays as the
+        # bootstrap fallback and the single overlay knob is slot 54's
+        # `registry: ${REGISTRY_MIRROR:=harbor.openova.io}` substitution.
+        # Keep in lockstep with the umbrella dmzVcluster.image above.
         registry: harbor.openova.io
         repository: proxy-ghcr/loft-sh/vcluster
         tag: "0.21.0"

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.5
+  version: 0.2.6
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -35,7 +35,19 @@ name: bp-mgmt-vcluster
 # `<inner-ns>-x-mgmt`, the host's cnpg-operator reconciles it, and
 # the resulting Service is synced back into the vCluster's view via
 # the already-enabled `sync.toHost.services`.
-version: 0.2.5
+# 0.2.6 — Refs #2940 (Pillar 5 anti-tether, 2026-06-08): the registry
+# host is no longer hardcoded `harbor.openova.io` as the sole source of
+# truth. New `global.registryMirror` (default `harbor.openova.io`) drives
+# the umbrella image fail-fast helper; `mgmtVcluster.image.repository` is
+# now registry-relative; the loft-sh subchart's syncer image registry
+# (`vcluster.controlPlane.statefulSet.image.registry`, a subchart literal
+# Helm can't self-template) is driven by slot 58's
+# `${REGISTRY_MIRROR:=harbor.openova.io}` postBuild substitution. The
+# renamed knob replaces the dead `global.imageRegistry` (loft-sh never
+# honoured it). Default `helm template` renders byte-identical. A
+# per-Sovereign overlay / bp-self-sovereign-cutover Step-04 pivot flips
+# the host in one place. Additive value + helper change only.
+version: 0.2.6
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/templates/_helpers.tpl
+++ b/platform/bp-mgmt-vcluster/chart/templates/_helpers.tpl
@@ -39,8 +39,16 @@ catalyst.openova.io/topology-role: {{ .Values.mgmtVcluster.role | quote }}
 {{/*
 Image fail-fast helper. Per docs/INVIOLABLE-PRINCIPLES.md #4a empty
 :tag MUST fail the helm template render — we never want floating
-:latest shipping into production. Honours .Values.global.imageRegistry
-rewrite when set.
+:latest shipping into production.
+
+#2940 Pillar 5 anti-tether: composes the image registry host from
+`.Values.global.registryMirror` (default "harbor.openova.io", the single
+source of truth) + the registry-relative `.Values.mgmtVcluster.image.repository`.
+Backward-compat: if repository is ALREADY host-qualified (its first
+"/"-segment contains "." or ":", e.g. the pre-#2940 literal
+"harbor.openova.io/proxy-ghcr/loft-sh/vcluster"), it is used verbatim and
+the mirror is NOT prepended — so existing per-Sovereign overlays that set
+a full host-qualified repository keep working.
 */}}
 {{- define "bp-mgmt-vcluster.image" -}}
 {{- $tag := .Values.mgmtVcluster.image.tag -}}
@@ -49,15 +57,18 @@ rewrite when set.
 {{- end -}}
 {{- $repo := .Values.mgmtVcluster.image.repository -}}
 {{- if not $repo -}}
-{{- fail "bp-mgmt-vcluster: .Values.mgmtVcluster.image.repository is empty — must point at harbor.openova.io/proxy-ghcr/loft-sh/vcluster (or per-Sovereign Harbor) per CLAUDE.md MIRROR-EVERYTHING" -}}
+{{- fail "bp-mgmt-vcluster: .Values.mgmtVcluster.image.repository is empty — must point at proxy-ghcr/loft-sh/vcluster (registry-relative; global.registryMirror supplies the host) per CLAUDE.md MIRROR-EVERYTHING" -}}
 {{- end -}}
-{{- $globalRegistry := .Values.global.imageRegistry | default "" -}}
-{{- if ne $globalRegistry "" -}}
-{{- $parts := splitList "/" $repo -}}
-{{- $rest := slice $parts 1 -}}
-{{- printf "%s/%s:%s" $globalRegistry (join "/" $rest) $tag -}}
-{{- else -}}
+{{- $firstSeg := first (splitList "/" $repo) -}}
+{{- if or (contains "." $firstSeg) (contains ":" $firstSeg) -}}
+{{- /* repository is already host-qualified — honour it verbatim */ -}}
 {{- printf "%s:%s" $repo $tag -}}
+{{- else -}}
+{{- $mirror := .Values.global.registryMirror | default "harbor.openova.io" -}}
+{{- if not $mirror -}}
+{{- fail "bp-mgmt-vcluster: .Values.global.registryMirror is empty and .Values.mgmtVcluster.image.repository is host-less — set one or the other (#2940)" -}}
+{{- end -}}
+{{- printf "%s/%s:%s" $mirror $repo $tag -}}
 {{- end -}}
 {{- end }}
 

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -24,13 +24,35 @@ catalystBlueprint:
     version: "0.20.0"
     repo: "https://charts.loft.sh"
 
-# ─── Global registry rewrite (matches other Catalyst umbrella charts) ───
-# When set, ALL image pulls in this chart route through this registry.
-# Used post-handover when the Sovereign's own Harbor takes over the
-# proxy_cache role from contabo's central Harbor. Empty = no rewrite
-# (upstream defaults via the subchart's image keys).
+# ─── Registry mirror (MIRROR-EVERYTHING + Pillar 5 anti-tether #2940) ───
+# Single source of truth for the container-registry host every image in
+# this chart pulls through. Default `harbor.openova.io` preserves the
+# mothership/bootstrap behaviour (the central Harbor proxy-cache).
+#
+# Two consumers:
+#   1. The umbrella's own `bp-mgmt-vcluster.image` fail-fast helper
+#      (_helpers.tpl) composes `<registryMirror>/<repository>:<tag>` so the
+#      umbrella `mgmtVcluster.image.repository` no longer hardcodes the
+#      host (it's now the registry-relative `proxy-ghcr/loft-sh/vcluster`).
+#   2. The loft-sh subchart's real syncer image
+#      (`vcluster.controlPlane.statefulSet.image.registry`) — a SUBCHART
+#      values literal that Helm cannot self-template from THIS file. Slot 58
+#      drives it via `${REGISTRY_MIRROR:=harbor.openova.io}` postBuild
+#      substitution (same canonical pattern as the region-label substitute
+#      already in that slot), so a per-Sovereign overlay sets the host in
+#      ONE place. The subchart literal below stays the bootstrap fallback
+#      so `helm template` with defaults renders identically.
+#
+# Post-bp-self-sovereign-cutover (Step-04 registry pivot, ADR-0002) the
+# overlay points registryMirror at the Sovereign's OWN Harbor
+# (`harbor.<sovereign-fqdn>`) and every pull re-points in one place.
+#
+# (Renamed from the prior `global.imageRegistry` knob, which the loft-sh
+# subchart never honoured — it has no `global.imageRegistry`, only the
+# per-image `controlPlane.statefulSet.image.registry` field — so that knob
+# was dead config that produced no render effect. #2940.)
 global:
-  imageRegistry: ""
+  registryMirror: "harbor.openova.io"
 
 mgmtVcluster:
   # Top-level enable gate.
@@ -81,11 +103,18 @@ mgmtVcluster:
     regionLabelValue: ""
 
   # ── Image (MIRROR-EVERYTHING) ─────────────────────────────────────
-  # Default routes through harbor.openova.io/proxy-ghcr/... per
-  # CLAUDE.md inviolable rule. Post-handover, the per-Sovereign
-  # overlay rewrites to `harbor.<sovereign-fqdn>/proxy-ghcr/...`.
+  # #2940 Pillar 5: `repository` is now the registry-RELATIVE path only.
+  # The `bp-mgmt-vcluster.image` helper prepends `global.registryMirror`
+  # (default `harbor.openova.io`) so the registry host has ONE source of
+  # truth. Post-handover the per-Sovereign overlay flips global.registryMirror
+  # to `harbor.<sovereign-fqdn>` and this image re-points with it.
+  # NB this image ref is consumed ONLY by the umbrella's fail-fast guard
+  # (templates/namespace.yaml) — the vCluster's ACTUAL syncer image is the
+  # subchart value `vcluster.controlPlane.statefulSet.image` below; both
+  # are kept in lockstep. Backward-compat: a host-qualified repository
+  # (pre-#2940 shape) is still honoured verbatim by the helper.
   image:
-    repository: "harbor.openova.io/proxy-ghcr/loft-sh/vcluster"
+    repository: "proxy-ghcr/loft-sh/vcluster"
     tag: "0.21.0"
     pullPolicy: "IfNotPresent"
 
@@ -140,7 +169,22 @@ vcluster:
         nodeSelector: {}
       image:
         # The upstream chart's controlPlane.statefulSet.image is the
-        # vCluster syncer image. MIRROR-EVERYTHING via Harbor proxy.
+        # vCluster syncer image — the ACTUAL image the vCluster runs.
+        # MIRROR-EVERYTHING via Harbor proxy.
+        #
+        # #2940 Pillar 5 anti-tether: this `registry` is a SUBCHART values
+        # literal, which Helm cannot derive from `global.registryMirror` in
+        # this same values.yaml (subchart values can't self-template). The
+        # `harbor.openova.io` default is therefore kept here as the
+        # bootstrap fallback (so `helm template` with defaults renders
+        # identically to pre-#2940), and the single overlay knob is wired
+        # in bootstrap-kit slot 58, which sets
+        # `registry: ${REGISTRY_MIRROR:=harbor.openova.io}` via Flux
+        # postBuild.substitute — exactly the canonical pattern the
+        # SOVEREIGN_REGION_CANONICAL_LABEL substitute already uses in that
+        # slot. A per-Sovereign overlay (or the bp-self-sovereign-cutover
+        # Step-04 registry pivot, ADR-0002) re-points the host in ONE place.
+        # Keep this in lockstep with the umbrella `mgmtVcluster.image` above.
         registry: harbor.openova.io
         repository: proxy-ghcr/loft-sh/vcluster
         tag: "0.21.0"

--- a/platform/bp-rtz-vcluster/blueprint.yaml
+++ b/platform/bp-rtz-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.5
+  version: 0.2.6
   card:
     title: RTZ vCluster
     summary: |

--- a/platform/bp-rtz-vcluster/chart/Chart.yaml
+++ b/platform/bp-rtz-vcluster/chart/Chart.yaml
@@ -20,7 +20,14 @@ name: bp-rtz-vcluster
 # RTZ vCluster hosts per-Org tenant Applications + Sandbox per DoD
 # §A4; both paths route CNPG provisioning through the host
 # cnpg-operator (G92.6 substrate per #2665) via this sync.
-version: 0.2.5
+# 0.2.6 — Refs #2940 (Pillar 5 anti-tether, 2026-06-08): registry host no
+# longer hardcoded `harbor.openova.io` as the sole source of truth. New
+# `global.registryMirror` drives the umbrella image helper;
+# `rtzVcluster.image.repository` is registry-relative; the subchart syncer
+# image registry is driven by slot 59's `${REGISTRY_MIRROR:=harbor.openova.io}`
+# substitution. Renamed the dead `global.imageRegistry`. Default render
+# byte-identical. Sibling to bp-mgmt-vcluster 0.2.6 + bp-dmz-vcluster 0.2.5.
+version: 0.2.6
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign RTZ

--- a/platform/bp-rtz-vcluster/chart/templates/_helpers.tpl
+++ b/platform/bp-rtz-vcluster/chart/templates/_helpers.tpl
@@ -30,6 +30,15 @@ catalyst.openova.io/blueprint: bp-rtz-vcluster
 catalyst.openova.io/topology-role: {{ .Values.rtzVcluster.role | quote }}
 {{- end }}
 
+{{/*
+Image fail-fast helper. Per docs/INVIOLABLE-PRINCIPLES.md #4a.
+
+#2940 Pillar 5 anti-tether: composes the image registry host from
+`.Values.global.registryMirror` (default "harbor.openova.io", single
+source of truth) + the registry-relative `.Values.rtzVcluster.image.repository`.
+Backward-compat: a repository already host-qualified (first "/"-segment
+contains "." or ":") is used verbatim and the mirror is NOT prepended.
+*/}}
 {{- define "bp-rtz-vcluster.image" -}}
 {{- $tag := .Values.rtzVcluster.image.tag -}}
 {{- if not $tag -}}
@@ -37,15 +46,17 @@ catalyst.openova.io/topology-role: {{ .Values.rtzVcluster.role | quote }}
 {{- end -}}
 {{- $repo := .Values.rtzVcluster.image.repository -}}
 {{- if not $repo -}}
-{{- fail "bp-rtz-vcluster: .Values.rtzVcluster.image.repository is empty — must point at harbor.openova.io/proxy-ghcr/loft-sh/vcluster (or per-Sovereign Harbor) per CLAUDE.md MIRROR-EVERYTHING" -}}
+{{- fail "bp-rtz-vcluster: .Values.rtzVcluster.image.repository is empty — must point at proxy-ghcr/loft-sh/vcluster (registry-relative; global.registryMirror supplies the host) per CLAUDE.md MIRROR-EVERYTHING" -}}
 {{- end -}}
-{{- $globalRegistry := .Values.global.imageRegistry | default "" -}}
-{{- if ne $globalRegistry "" -}}
-{{- $parts := splitList "/" $repo -}}
-{{- $rest := slice $parts 1 -}}
-{{- printf "%s/%s:%s" $globalRegistry (join "/" $rest) $tag -}}
-{{- else -}}
+{{- $firstSeg := first (splitList "/" $repo) -}}
+{{- if or (contains "." $firstSeg) (contains ":" $firstSeg) -}}
 {{- printf "%s:%s" $repo $tag -}}
+{{- else -}}
+{{- $mirror := .Values.global.registryMirror | default "harbor.openova.io" -}}
+{{- if not $mirror -}}
+{{- fail "bp-rtz-vcluster: .Values.global.registryMirror is empty and .Values.rtzVcluster.image.repository is host-less — set one or the other (#2940)" -}}
+{{- end -}}
+{{- printf "%s/%s:%s" $mirror $repo $tag -}}
 {{- end -}}
 {{- end }}
 

--- a/platform/bp-rtz-vcluster/chart/values.yaml
+++ b/platform/bp-rtz-vcluster/chart/values.yaml
@@ -9,8 +9,18 @@ catalystBlueprint:
     version: "0.20.0"
     repo: "https://charts.loft.sh"
 
+# ── Registry mirror (MIRROR-EVERYTHING + Pillar 5 anti-tether #2940) ──
+# Single source of truth for the registry host every image in this chart
+# pulls through. Default `harbor.openova.io` preserves bootstrap behaviour.
+# Consumed by (1) the `bp-rtz-vcluster.image` fail-fast helper for the
+# umbrella image and (2) the loft-sh subchart syncer image registry, which
+# (a subchart values literal Helm can't self-template) is driven by slot
+# 59's `${REGISTRY_MIRROR:=harbor.openova.io}` postBuild substitution.
+# Post-bp-self-sovereign-cutover (Step-04, ADR-0002) a per-Sovereign
+# overlay flips this to `harbor.<sovereign-fqdn>`. Renamed from the dead
+# `global.imageRegistry` (loft-sh never honoured that key). #2940.
 global:
-  imageRegistry: ""
+  registryMirror: "harbor.openova.io"
 
 rtzVcluster:
   # Top-level enable gate.
@@ -37,8 +47,13 @@ rtzVcluster:
     regionLabelKey: "openova.io/region"
     regionLabelValue: ""
 
+  # #2940 Pillar 5: registry-RELATIVE repository; the host is composed from
+  # `global.registryMirror` by the `bp-rtz-vcluster.image` helper. Consumed
+  # only by the umbrella fail-fast guard — the real syncer image is the
+  # subchart value below; keep them in lockstep. Backward-compat: a
+  # host-qualified repository is honoured verbatim by the helper.
   image:
-    repository: "harbor.openova.io/proxy-ghcr/loft-sh/vcluster"
+    repository: "proxy-ghcr/loft-sh/vcluster"
     tag: "0.21.0"
     pullPolicy: "IfNotPresent"
 
@@ -73,6 +88,12 @@ vcluster:
       scheduling:
         nodeSelector: {}
       image:
+        # #2940 Pillar 5: the ACTUAL vCluster syncer image. This `registry`
+        # is a subchart values literal Helm can't derive from
+        # global.registryMirror here, so `harbor.openova.io` stays the
+        # bootstrap fallback and the single overlay knob is slot 59's
+        # `registry: ${REGISTRY_MIRROR:=harbor.openova.io}` substitution.
+        # Keep in lockstep with the umbrella rtzVcluster.image above.
         registry: harbor.openova.io
         repository: proxy-ghcr/loft-sh/vcluster
         tag: "0.21.0"

--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.14
+  version: 0.2.15
   card:
     title: sso-bridge
     summary: |

--- a/platform/sso-bridge/chart/Chart.yaml
+++ b/platform/sso-bridge/chart/Chart.yaml
@@ -1,6 +1,21 @@
 apiVersion: v2
 name: bp-sso-bridge
-version: 0.2.14
+version: 0.2.15
+# 0.2.15 (#2940 Pillar 5 anti-tether, 2026-06-08): the reconciler image's
+# registry host is no longer hardcoded `harbor.openova.io` in
+# `image.repository`. New `global.registryMirror` value (default
+# `harbor.openova.io`) is the SINGLE source of truth for the registry
+# host; `image.repository` is now the registry-relative path
+# (`proxy-dockerhub/alpine/k8s`); new `bp-sso-bridge.image` helper in
+# templates/_helpers.tpl composes `<mirror>/<repo>:<tag>`. Default render
+# is byte-identical to 0.2.14 (still harbor.openova.io). A per-Sovereign
+# overlay — or the bp-self-sovereign-cutover Step-04 registry pivot
+# (ADR-0002) — re-points EVERY pull by setting global.registryMirror to
+# the Sovereign's own Harbor. Backward-compat: a host-qualified
+# `image.repository` (pre-#2940 shape) is still honoured verbatim by the
+# helper. Slot 13b wires `${REGISTRY_MIRROR:=harbor.openova.io}`. Pure
+# additive value + template helper; no behaviour change at defaults.
+# Refs #2940.
 # 0.2.8 (G117.5-followup #2914, 2026-06-03): dual-token KC mint —
 # sovereign-realm SA token for in-realm operations + new master-realm
 # admin token for POST /admin/realms (per-Org realm provisioning).

--- a/platform/sso-bridge/chart/templates/_helpers.tpl
+++ b/platform/sso-bridge/chart/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{/*
+bp-sso-bridge image reference composer (#2940 Pillar 5 anti-tether).
+
+Composes the reconciler container image from:
+  - .Values.global.registryMirror  (default "harbor.openova.io")
+  - .Values.image.repository        (registry-RELATIVE path, e.g.
+                                      "proxy-dockerhub/alpine/k8s")
+  - .Values.image.tag
+
+The registry host therefore has exactly ONE source of truth
+(global.registryMirror), so a per-Sovereign overlay — or the
+bp-self-sovereign-cutover Step-04 registry pivot (ADR-0002) — re-points
+EVERY pull by setting that one value to the Sovereign's own Harbor
+(e.g. "harbor.<sovereign-fqdn>").
+
+Backward-compat: if .Values.image.repository ALREADY carries a registry
+host (its first "/"-segment contains a "." or ":", e.g. the pre-#2940
+literal "harbor.openova.io/proxy-dockerhub/alpine/k8s"), the helper uses
+it verbatim and does NOT prepend the mirror — so existing per-Sovereign
+overlays that set a full host-qualified repository keep working.
+*/}}
+{{- define "bp-sso-bridge.image" -}}
+{{- $repo := .Values.image.repository -}}
+{{- $tag := .Values.image.tag -}}
+{{- if not $repo -}}
+{{- fail "bp-sso-bridge: .Values.image.repository is empty" -}}
+{{- end -}}
+{{- if not $tag -}}
+{{- fail "bp-sso-bridge: .Values.image.tag is empty — pin a tag (MIRROR-EVERYTHING)" -}}
+{{- end -}}
+{{- $firstSeg := first (splitList "/" $repo) -}}
+{{- if or (contains "." $firstSeg) (contains ":" $firstSeg) -}}
+{{- /* repository is already host-qualified — honour it verbatim */ -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- else -}}
+{{- $mirror := .Values.global.registryMirror | default "harbor.openova.io" -}}
+{{- if not $mirror -}}
+{{- fail "bp-sso-bridge: .Values.global.registryMirror is empty and .Values.image.repository is host-less — set one or the other (#2940)" -}}
+{{- end -}}
+{{- printf "%s/%s:%s" $mirror $repo $tag -}}
+{{- end -}}
+{{- end }}

--- a/platform/sso-bridge/chart/templates/deployment.yaml
+++ b/platform/sso-bridge/chart/templates/deployment.yaml
@@ -42,7 +42,10 @@ spec:
         {{- toYaml .Values.securityContext | nindent 8 }}
       containers:
         - name: reconciler
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          # #2940 Pillar 5: registry host is composed from
+          # global.registryMirror (single source of truth) by the
+          # bp-sso-bridge.image helper — no hardcoded harbor.openova.io.
+          image: "{{ include "bp-sso-bridge.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           # G109 #2705: container-level securityContext is mandatory under
           # PodSecurity restricted (Pod-level alone doesn't satisfy

--- a/platform/sso-bridge/chart/values.yaml
+++ b/platform/sso-bridge/chart/values.yaml
@@ -3,6 +3,22 @@
 # Per Inviolable Principle #4 (never hardcode): every operational knob
 # flows from this file or from the per-Sovereign sovereign-fqdn ConfigMap.
 
+# ── Registry mirror (MIRROR-EVERYTHING + Pillar 5 anti-tether #2940) ──
+# Single source of truth for the container-registry host the reconciler
+# image pulls through. Default `harbor.openova.io` preserves the
+# mothership/bootstrap behaviour (the central Harbor proxy-cache). The
+# image `repository` below is composed from THIS value by
+# templates/deployment.yaml (`bp-sso-bridge.image` helper) — the host is
+# no longer hardcoded inside the image ref. Post-bp-self-sovereign-cutover
+# (Step-04 registry pivot, ADR-0002) a per-Sovereign overlay sets this to
+# the Sovereign's OWN Harbor (e.g. `harbor.<sovereign-fqdn>`) and the pull
+# re-points in ONE place. Slot 13b wires
+# `global.registryMirror: ${REGISTRY_MIRROR:=harbor.openova.io}` so the
+# bootstrap default is the mothership Harbor and a per-Sovereign overlay
+# (or post-cutover envsubst) flips it.
+global:
+  registryMirror: "harbor.openova.io"
+
 # Enable/disable the entire framework. Operator overlays may flip to false
 # during incident response (e.g. Keycloak realm import in flux); shipping
 # default = true because the framework is mandatory infra per SECURITY.md
@@ -23,8 +39,17 @@ enabled: true
 # image (~50MB) and is the canonical chart-side bash tooling image for
 # the rest of the OpenOva catalog post-G109. MIRROR-EVERYTHING via the
 # Harbor proxy-cache.
+#
+# #2940 (Pillar 5 anti-tether): `repository` is now the registry-RELATIVE
+# path only (`proxy-dockerhub/alpine/k8s`). templates/deployment.yaml's
+# `bp-sso-bridge.image` helper prepends `global.registryMirror`
+# (default `harbor.openova.io`) so the registry host has exactly ONE
+# source of truth. A bare `repository` with a leading registry host (the
+# pre-#2940 shape) is still honoured by the helper for backward-compat
+# (it only prepends the mirror when repository has no `.`/`:` host
+# segment) — but the canonical shape going forward is host-less here.
 image:
-  repository: harbor.openova.io/proxy-dockerhub/alpine/k8s
+  repository: proxy-dockerhub/alpine/k8s
   tag: "1.30.0"
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## What

Removes `harbor.openova.io` as the **sole source of truth** for the
container-registry host in the three vCluster charts + `bp-sso-bridge`,
replacing each hardcoded literal with a single `global.registryMirror`
knob (default `harbor.openova.io`, so the mothership/bootstrap render is
**byte-identical to today**). A per-Sovereign overlay — or the
`bp-self-sovereign-cutover` Step-04 registry pivot (ADR-0002) — now
re-points **every** pull in one place to the Sovereign's own Harbor.

`Refs #2940` (Pillar 5 anti-tether). **Not** `Closes` — verification pending.

## Tethers fixed (file:line)

### 1. vCluster image repos (`harbor.openova.io/proxy-ghcr/loft-sh/vcluster` + `registry: harbor.openova.io`)
The umbrella's `*Vcluster.image` value is only consumed by a fail-fast
guard (`namespace.yaml`: `$_ := include "...image"`); the **actual**
vCluster syncer image is the loft-sh **subchart** value
`vcluster.controlPlane.statefulSet.image.{registry,repository}`. The
loft-sh chart has **no** `global.imageRegistry` — only its own
`controlPlane.advanced.defaultImageRegistry` (which would over-broadly
rewrite the `registry.k8s.io` distro images too and break the bootstrap
Harbor proxy), so that path is unsafe. A subchart values literal also
can't self-template off the umbrella's `global.registryMirror`.

Resolution (canonical, mirrors the `${SOVEREIGN_REGION_CANONICAL_LABEL}`
substitute already in these slots):
- `platform/bp-mgmt-vcluster/chart/values.yaml`: `global.registryMirror`
  added (renames dead `global.imageRegistry`); umbrella
  `mgmtVcluster.image.repository` → registry-relative `proxy-ghcr/loft-sh/vcluster`;
  subchart `image.registry` literal kept as bootstrap fallback.
- `_helpers.tpl` `bp-mgmt-vcluster.image`: now composes
  `<registryMirror>/<repository>:<tag>` (host-qualified repo honoured
  verbatim for back-compat).
- `clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml`: adds
  `global.registryMirror: ${REGISTRY_MIRROR:=harbor.openova.io}` +
  `vcluster.controlPlane.statefulSet.image.registry: ${REGISTRY_MIRROR:=harbor.openova.io}`.
- Same trio for **bp-dmz-vcluster** (slot 54) and **bp-rtz-vcluster** (slot 59).

### 2. sso-bridge (`harbor.openova.io/proxy-dockerhub/alpine/k8s`)
`platform/sso-bridge/chart/templates/deployment.yaml:45` is a real
template consuming `.Values.image.repository`. Fixed cleanly:
- `values.yaml`: `global.registryMirror` added; `image.repository` →
  registry-relative `proxy-dockerhub/alpine/k8s`.
- new `templates/_helpers.tpl` `bp-sso-bridge.image` composes the host.
- `deployment.yaml`: now `image: "{{ include "bp-sso-bridge.image" . }}"`.
- `clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml`: adds
  `global.registryMirror: ${REGISTRY_MIRROR:=harbor.openova.io}`.

## Tethers LEFT (documented intentional exclusions)

### 3. powerdns hosts (`pdns.openova.io`) — INTENTIONAL, not a mothership-control tether
- `platform/powerdns/chart/values.yaml:383` (`api.host`): bootstrap-kit
  **slot 11 already overlays** `host: pdns.${SOVEREIGN_FQDN}` — verified
  at `clusters/_template/bootstrap-kit/11-powerdns.yaml:174`. The chart
  default is the Catalyst-Zero/contabo-mkt back-compat value; a
  franchised Sovereign's live HR never carries it. The in-values
  `#2940/#2951` comment already documents this.
- `platform/cert-manager-powerdns-webhook/chart/values.yaml:161`
  (`powerdns.host`): an **architectural out-of-cluster ACME DNS-01
  tether** to the central authoritative PowerDNS. Let's Encrypt
  validates DNS-01 TXT against the **public** DNS chain, so the
  challenge MUST go to whichever PowerDNS is authoritative for the
  delegated zone. `clusters/_template/bootstrap-kit/49-...webhook.yaml`
  (lines 28-52) + the in-values `#2940/#2951` comment both confirm
  `bp-self-sovereign-cutover` deliberately does **not** rewrite this
  (pivoting it would break wildcard-cert issuance until the Sovereign's
  own PowerDNS is delegated authoritative in public DNS).

### 4. ingress hosts (`console.openova.io`) — Contabo-mkt ONLY, `.helmignore`'d
`products/catalyst/chart/templates/ingress.yaml`,
`ingress-console-tls.yaml`, `sme-services/ingress.yaml` are headed
"Contabo-mkt only ... Sovereigns skip via `.helmignore`" and are listed
in `products/catalyst/chart/.helmignore` (Sovereigns use the Cilium
gateway, not Traefik). **Verified**: `helm template products/catalyst/chart`
renders **zero** `console-sovereign` / `console-openova-tls` resources —
those templates produce nothing on a franchised Sovereign, so they are
not franchised tethers. (The 2 `console.openova.io` values that DO render
— `sovereignConsoleURL`/`sovereignAPIPublicURL` ConfigMap keys — are the
already-done #2940 `CORS_ORIGIN`/`CATALYST_SOVEREIGN_URL` seam, not
part of this PR.)

## Interplay with bp-self-sovereign-cutover Step-04

The `harbor.openova.io` defaults are the **bootstrap** registry (mothership
Harbor proxy-cache). After cutover, Step-04 re-points the registry to the
Sovereign's local Harbor: a per-Sovereign overlay sets
`global.registryMirror` / `REGISTRY_MIRROR` to `harbor.<sovereign-fqdn>`,
and these charts compose the new host from that one value (the static
default is only the pre-cutover bootstrap value).

## helm-template proof (default == today; override re-points)

vCluster (all 3, identical results):
```
DEFAULT :  image: "harbor.openova.io/proxy-ghcr/loft-sh/vcluster:0.21.0"
OVERRIDE:  image: "harbor.t99.omani.works/proxy-ghcr/loft-sh/vcluster:0.21.0"
           (--set global.registryMirror=harbor.t99.omani.works
            --set vcluster.controlPlane.statefulSet.image.registry=harbor.t99.omani.works)
```
(`registry.k8s.io/kube-*` distro images are unchanged — a pre-existing
MIRROR-EVERYTHING gap deliberately not addressed here (a separate
follow-up); they were never mirrored.)

sso-bridge:
```
DEFAULT :  image: "harbor.openova.io/proxy-dockerhub/alpine/k8s:1.30.0"
OVERRIDE:  image: "harbor.t99.omani.works/proxy-dockerhub/alpine/k8s:1.30.0"
```

Suites: all 3 vcluster `chart/tests/render.sh` PASS (incl. empty-tag
fail-fast); `helm template products/catalyst/chart` renders (5084 lines);
`scripts/check-bootstrap-kit-pin-sync.sh` PASS (58 pairs).

## Version bumps (lockstep Chart.yaml + blueprint.yaml + slot pin)
bp-mgmt-vcluster `0.2.6`, bp-rtz-vcluster `0.2.6`, bp-dmz-vcluster `0.2.5`,
bp-sso-bridge `0.2.15`.

## Could NOT cleanly template
The loft-sh subchart's syncer `image.registry` is a **subchart values
literal**, which Helm does not template from the umbrella's own
`values.yaml`. It is therefore driven via the bootstrap-kit slot's
`${REGISTRY_MIRROR}` postBuild substitution (canonical) rather than a pure
in-chart helper; the chart-level literal remains the bootstrap fallback so
default renders are byte-identical. This is the same overlay seam the
region-label substitute already uses in those slots.

**Verification: PENDING — fresh prov + cutover egress test.**

Refs #2940

🤖 Generated with [Claude Code](https://claude.com/claude-code)
