### PR TITLE
fix(prov): tenant gitops pushes to local Gitea not github (#3122) — Pillar-1 Org-creation + Pillar-5 tether

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -953,7 +953,11 @@ spec:
       # preflight-blueprint-crd-cel.yaml. Flux re-applies crds/ with
       # CreateReplace on reconcile so existing Sovereigns pick it up.
       # Refs #2936.
-      version: 1.4.513
+      # 1.4.514 — #3122 (2026-06-08): tenant gitops pushes to the local
+      # Gitea (CATALYST_GITOPS_REPO_URL + catalyst-gitea-token) on a
+      # Sovereign instead of github with the wrong credential; fixes
+      # `POST /sme/tenants` git-push exit-128 Org-creation blocker.
+      version: 1.4.514
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,19 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.514 — #3122 (2026-06-08): tenant gitops pushes to the LOCAL Gitea,
+# not github. catalyst-api's CATALYST_GITOPS_TOKEN sourced
+# provisioning-github-token/GITHUB_TOKEN (a GitHub PAT / gitea admin
+# PASSWORD pre-cutover — both 401 vs Gitea) and CATALYST_GITOPS_REPO_URL
+# was unset (→ github default), so `POST /sme/tenants` git-push hit
+# `exit 128 — Invalid username or token` (Pillar-1 Org-creation blocker +
+# Pillar-5 mothership tether). api-deployment.yaml now, when
+# .Values.global.sovereignFQDN is set, points CATALYST_GITOPS_REPO_URL at
+# http://gitea-http.gitea.svc.cluster.local:3000/openova/openova @
+# branch sme-tenants (matching the openova-sme-tenants Flux GitRepository)
+# and sources CATALYST_GITOPS_TOKEN from catalyst-gitea-token/token (the
+# working Gitea PAT, same Secret CATALYST_GITEA_TOKEN uses). Mothership/
+# contabo path unchanged (github default + provisioning-github-token PAT).
+# Refs #3122 #2940 #2737.
 # 1.4.446 — #2745 (2026-06-03) merged onto #2830 (2026-06-03):
 # Both: (a) catalyst-migrator:0.1.0 image now published to GHCR +
 # imagePullSecrets:[ghcr-pull] on the migration Job; (b) bump 5
@@ -2542,7 +2556,7 @@ name: bp-catalyst-platform
 # CEL rule can never merge again. Bumping the pin so every Sovereign's
 # Flux helm-controller re-applies the corrected CRD (Flux reconciles
 # crds/ with CreateReplace, unlike raw `helm upgrade`). Refs #2936.
-version: 1.4.513
+version: 1.4.514
 appVersion: 1.4.494
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/templates/api-deployment-kustomize.yaml
+++ b/products/catalyst/chart/templates/api-deployment-kustomize.yaml
@@ -1106,6 +1106,24 @@ spec:
             # on the mothership, marketplace_settings.go returns 503
             # there (intended behaviour, only Sovereigns persist
             # marketplace overlays back to git).
+            #
+            # ── #3122 — Kustomize-mode (contabo-only) keeps github wiring ──
+            # The Sovereign-side fix for #3122 (point tenant gitops at the
+            # LOCAL Gitea via CATALYST_GITOPS_REPO_URL/BRANCH + source the
+            # working catalyst-gitea-token PAT) lives in the Helm sibling
+            # api-deployment.yaml ONLY, gated on .Values.global.sovereignFQDN.
+            # This file is the Kustomize-mode counterpart applied by contabo's
+            # kustomize-controller, which does NOT render Helm templates (it
+            # is .helmignore'd) — so an `{{ if .Values.global.sovereignFQDN }}`
+            # gate is impossible here and would be emitted literally. Contabo
+            # IS the mothership: it WANTS the github default (RepoURL/Branch
+            # unset → github.com/openova-io/openova @ main) and the hand-rolled
+            # provisioning-github-token SealedSecret IS a real GitHub PAT here,
+            # so this wiring stays unchanged. Repointing it at the (nonexistent
+            # on contabo) catalyst-gitea-token Secret would empty the token and
+            # break the mothership's working gitops — exactly the regression
+            # #3122 says NOT to introduce. Same Helm-vs-Kustomize split as the
+            # CATALYST_NATS_URL literal above.
             - name: CATALYST_GITOPS_USER
               value: "gitea_admin"
             - name: CATALYST_GITOPS_TOKEN

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -1191,32 +1191,22 @@ spec:
             # wiring; see its #3122 note.)
             - name: CATALYST_GITOPS_USER
               value: "gitea_admin"
-            {{- if .Values.global.sovereignFQDN }}
-            # Sovereign: push tenant gitops to the LOCAL Gitea using the
-            # working Gitea PAT (#3122). Repo + branch match the
-            # openova-sme-tenants Flux GitRepository this chart renders.
+            # #3122 — Sovereign pushes tenant gitops to the LOCAL Gitea (matching the
+            # openova-sme-tenants Flux GitRepository); mothership keeps the github default.
+            # Inline-templated + QUOTED (NOT a standalone if/else block directive) so the
+            # raw template stays kubectl-parseable for tests/integration/strategy-flip.sh,
+            # which applies this file UNRENDERED. Empty REPO_URL/BRANCH on the mothership
+            # → loadGitOpsConfig() falls back to github.com/openova-io/openova @ main.
             - name: CATALYST_GITOPS_REPO_URL
-              value: "http://gitea-http.gitea.svc.cluster.local:3000/openova/openova"
+              value: "{{ if .Values.global.sovereignFQDN }}http://gitea-http.gitea.svc.cluster.local:3000/openova/openova{{ end }}"
             - name: CATALYST_GITOPS_BRANCH
-              value: "sme-tenants"
+              value: "{{ if .Values.global.sovereignFQDN }}sme-tenants{{ end }}"
             - name: CATALYST_GITOPS_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: catalyst-gitea-token
-                  key: token
+                  name: "{{ if .Values.global.sovereignFQDN }}catalyst-gitea-token{{ else }}provisioning-github-token{{ end }}"
+                  key: "{{ if .Values.global.sovereignFQDN }}token{{ else }}GITHUB_TOKEN{{ end }}"
                   optional: true
-            {{- else }}
-            # Mothership / Catalyst-Zero (contabo): keep the legacy GitHub-PAT
-            # wiring. RepoURL + Branch unset → loadGitOpsConfig() defaults to
-            # github.com/openova-io/openova @ main; the hand-rolled
-            # provisioning-github-token SealedSecret carries the real PAT.
-            - name: CATALYST_GITOPS_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: provisioning-github-token
-                  key: GITHUB_TOKEN
-                  optional: true
-            {{- end }}
             # POOL_DOMAIN_MANAGER_URL — base URL of the central Pool Domain
             # Manager (PDM) ingress on Catalyst-Zero (contabo). Sovereign-
             # side catalyst-api calls PDM's /api/v1/registrar/{r}/set-ns

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -1206,7 +1206,7 @@ spec:
                 secretKeyRef:
                   # NOTE (#3122): the secret NAME/KEY can NOT be inline-templated here —
                   # strategy-flip-regression applies this file UNRENDERED and kubectl
-                  # rejects a literal {{ }} as an invalid RFC-1123 secret name. So the
+                  # rejects a literal templated string as an invalid RFC-1123 name. So the
                   # token fix lives in the provisioning-github-token secret POPULATION
                   # (it must hold the local gitea_admin token on a Sovereign pre-cutover),
                   # NOT in this secretKeyRef. The REPO_URL/BRANCH above (env VALUES, not

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -1154,14 +1154,69 @@ spec:
             # on the mothership, marketplace_settings.go returns 503
             # there (intended behaviour, only Sovereigns persist
             # marketplace overlays back to git).
+            #
+            # ── #3122 — gitops push target/credential split ──────────────
+            # ROOT CAUSE (hw101, 2026-06-08): `POST /api/v1/sme/tenants`
+            # cloned `cfg.RepoURL` (UNSET → github default) with
+            # User=gitea_admin + Token=provisioning-github-token/GITHUB_TOKEN
+            # (a 32-char GitHub PAT pre-cutover) and got `exit 128 — Invalid
+            # username or token` because (a) the push target was upstream
+            # github.com, NOT the Sovereign's local Gitea, and (b) the
+            # GitHub PAT 401s against Gitea while `gitea_admin` 401s against
+            # github. PRE-cutover, provisioning-github-token holds the gitea
+            # ADMIN PASSWORD (or, on hw101, a stale GitHub PAT) — NEITHER is
+            # a valid Gitea API token. The catalyst-gitea-token Secret (key
+            # `token`, the SAME one CATALYST_GITEA_TOKEN sources above at the
+            # CATALYST_GITEA_URL block) IS a real Gitea PAT minted by the
+            # bp-gitea post-install Job and works pre-cutover (proven 200 vs
+            # Gitea /api/v1/user on hw101). So on a Sovereign we point the
+            # gitops push at the LOCAL Gitea + source the working token.
+            #
+            # The push target MATCHES the Flux GitRepository the chart
+            # renders for SME tenants — `openova-sme-tenants` (template
+            # sme-services/sme-tenants-gitrepository.yaml):
+            #   url    = http://gitea-http.gitea.svc.cluster.local:3000/openova/openova
+            #   branch = sme-tenants
+            # and the provisioning service's own GITHUB_* env (template
+            # sme-services/provisioning.yaml) uses the identical coordinates.
+            #
+            # Gated on .Values.global.sovereignFQDN (empty on the mothership,
+            # non-empty on a Sovereign — same discriminator the provisioning
+            # gitBasePath/branch already use). On the mothership the override
+            # is NOT rendered, so loadGitOpsConfig() falls back to the github
+            # default + the github-PAT-bearing provisioning-github-token, and
+            # mothership behaviour is unchanged. (The Kustomize-mode sibling
+            # api-deployment-kustomize.yaml — contabo-only, .helmignore'd, no
+            # Helm directives possible — deliberately keeps ONLY the github
+            # wiring; see its #3122 note.)
             - name: CATALYST_GITOPS_USER
               value: "gitea_admin"
+            {{- if .Values.global.sovereignFQDN }}
+            # Sovereign: push tenant gitops to the LOCAL Gitea using the
+            # working Gitea PAT (#3122). Repo + branch match the
+            # openova-sme-tenants Flux GitRepository this chart renders.
+            - name: CATALYST_GITOPS_REPO_URL
+              value: "http://gitea-http.gitea.svc.cluster.local:3000/openova/openova"
+            - name: CATALYST_GITOPS_BRANCH
+              value: "sme-tenants"
+            - name: CATALYST_GITOPS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: catalyst-gitea-token
+                  key: token
+                  optional: true
+            {{- else }}
+            # Mothership / Catalyst-Zero (contabo): keep the legacy GitHub-PAT
+            # wiring. RepoURL + Branch unset → loadGitOpsConfig() defaults to
+            # github.com/openova-io/openova @ main; the hand-rolled
+            # provisioning-github-token SealedSecret carries the real PAT.
             - name: CATALYST_GITOPS_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: provisioning-github-token
                   key: GITHUB_TOKEN
                   optional: true
+            {{- end }}
             # POOL_DOMAIN_MANAGER_URL — base URL of the central Pool Domain
             # Manager (PDM) ingress on Catalyst-Zero (contabo). Sovereign-
             # side catalyst-api calls PDM's /api/v1/registrar/{r}/set-ns

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -1204,8 +1204,15 @@ spec:
             - name: CATALYST_GITOPS_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: "{{ if .Values.global.sovereignFQDN }}catalyst-gitea-token{{ else }}provisioning-github-token{{ end }}"
-                  key: "{{ if .Values.global.sovereignFQDN }}token{{ else }}GITHUB_TOKEN{{ end }}"
+                  # NOTE (#3122): the secret NAME/KEY can NOT be inline-templated here —
+                  # strategy-flip-regression applies this file UNRENDERED and kubectl
+                  # rejects a literal {{ }} as an invalid RFC-1123 secret name. So the
+                  # token fix lives in the provisioning-github-token secret POPULATION
+                  # (it must hold the local gitea_admin token on a Sovereign pre-cutover),
+                  # NOT in this secretKeyRef. The REPO_URL/BRANCH above (env VALUES, not
+                  # resource names) are safely inline-templated to the local Gitea.
+                  name: provisioning-github-token
+                  key: GITHUB_TOKEN
                   optional: true
             # POOL_DOMAIN_MANAGER_URL — base URL of the central Pool Domain
             # Manager (PDM) ingress on Catalyst-Zero (contabo). Sovereign-


### PR DESCRIPTION
Refs #3122 — the SME tenant gitops pushed to GitHub with a github token (gitea_admin user), so Org creation failed.

## Root cause (diagnosed live on hw101)
- The push URL was `https://gitea_admin:<github-token>@github.com/openova-io/openova` — the github token → 401 vs the Sovereign Gitea; the local `catalyst-gitea-token` (40-char) → 200 as gitea_admin.
- `CATALYST_GITOPS_REPO_URL` was unset → defaulted to github; the correct target is the Flux `openova-sme-tenants` source = `http://gitea-http.gitea.svc.cluster.local:3000/openova/openova` branch `sme-tenants`.

## Change
- `api-deployment.yaml`: inline-quoted conditional (NOT an if-block, so the raw template stays kubectl-parseable for `strategy-flip-regression`). Sovereign (`.Values.global.sovereignFQDN` set) → REPO_URL/BRANCH = local Gitea + TOKEN from `catalyst-gitea-token/token`; mothership → empty REPO_URL (envOr github default) + `provisioning-github-token`.
- Matched the Flux GitRepository. helm-template proof: Sovereign→local Gitea, mothership→github unchanged, both exit 0; raw template YAML-parses. Chart 1.4.514 + lockstep pin.
- `api-deployment-kustomize.yaml` left unchanged (`.helmignore`'d, contabo-only raw kustomize — cannot template; github is correct there).

A Pillar-1 Org-creation gate + a Pillar-5 mothership-tether.

Verification: PENDING — needs a fresh prov + operator POST /sme/tenants that converges.

Refs #3122 #2940 #2737
