### PR TITLE
chore(pins): bump organization-controller to c363dd1 (deploys #3101, greens freshness guard)

### DIFF
--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -440,7 +440,7 @@ controllers:
       # 405 to the in-cluster SA). 72e3f08 = qa-loop iter-8 Fix #42
       # (#1252 + Containerfile fix-up #1253), fixed Bug 1 (UserAccess
       # Claim namespace).
-      tag: "029a750"
+      tag: "c363dd1"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:


### PR DESCRIPTION
Org-controller pin was >50 commits behind GHCR (freshness guard red on main). c363dd1 = latest GHCR = #3101 per-Org-realm controller. Deploys #3101, unblocks #3084 validation. Refs #3084 #3101