### PR TITLE
fix(cutover): fire cutover engine on handover seal so it runs post-handover (#933)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/cutover_internal.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_internal.go
@@ -126,6 +126,35 @@ func requireHandoverForCutover() bool {
 	return !strings.EqualFold(strings.TrimSpace(os.Getenv(envRequireHandoverForCutover)), "false")
 }
 
+// envFireCutoverOnHandover gates whether ReceiveTofuArchive fires the
+// cutover engine immediately after sealing the Phase-0 archive. See
+// fireCutoverOnHandover.
+const envFireCutoverOnHandover = "CATALYST_FIRE_CUTOVER_ON_HANDOVER"
+
+// fireCutoverOnHandover reports whether sealing the tofu-phase0-archive at
+// handover should auto-fire the cutover engine (issue #933 / #3052). Default
+// TRUE — the founder rule is "handover is not done until cutover has run; no
+// operator click required", and the in-cluster auto-trigger Helm hook only
+// fires once at bootstrap (where it correctly defers via the handover gate),
+// so WITHOUT this nothing re-fires the engine post-handover and the cutover
+// stays dormant forever. Set CATALYST_FIRE_CUTOVER_ON_HANDOVER=false to keep
+// the cutover a deliberate operator action (the BSS "Achieve True
+// Sovereignty" CTA still works). Runtime-overridable per docs/PRINCIPLES.md #4.
+func fireCutoverOnHandover() bool {
+	return !strings.EqualFold(strings.TrimSpace(os.Getenv(envFireCutoverOnHandover)), "false")
+}
+
+// fireCutoverEngine dispatches to the test seam (spawnCutoverEngineFn) when
+// one is wired, otherwise to the real h.spawnCutoverEngine. Every caller
+// goes through here so production behaviour and test assertions share one
+// entry point.
+func (h *Handler) fireCutoverEngine(ctx context.Context, deps *cutoverDeps, source string) (cutoverSpawnResult, error) {
+	if h.spawnCutoverEngineFn != nil {
+		return h.spawnCutoverEngineFn(ctx, deps, source)
+	}
+	return h.spawnCutoverEngine(ctx, deps, source)
+}
+
 // sovereignHandoverComplete reports whether THIS Sovereign has received
 // the Phase-0 OpenTofu archive from the mothership — the durable,
 // Sovereign-side signal that ownership has transferred. handover.go's
@@ -304,18 +333,64 @@ func (h *Handler) HandleCutoverInternalTrigger(w http.ResponseWriter, r *http.Re
 	h.runCutoverFromTrigger(w, r, deps, "internal")
 }
 
-// runCutoverFromTrigger is the shared engine-spawn path used by both
-// HandleCutoverStart (operator-session) and HandleCutoverInternalTrigger
-// (in-cluster SA token). The split keeps cutover.go's HTTP handler
-// readable while making the auth-edge swap a single-call site change.
-func (h *Handler) runCutoverFromTrigger(w http.ResponseWriter, r *http.Request, deps *cutoverDeps, source string) {
-	status, err := readCutoverStatus(r.Context(), deps)
+// cutoverSpawnOutcome enumerates the terminal decisions spawnCutoverEngine
+// can reach. The HTTP wrapper (runCutoverFromTrigger) maps each to the same
+// status code + body it emitted before the engine-spawn tail was extracted;
+// the async handover-seal path (ReceiveTofuArchive) only cares about
+// started vs not-started and logs the rest.
+type cutoverSpawnOutcome int
+
+const (
+	// cutoverSpawnStarted — a fresh engine goroutine was launched.
+	cutoverSpawnStarted cutoverSpawnOutcome = iota
+	// cutoverSpawnAlreadyComplete — cutoverComplete=true; idempotent no-op.
+	cutoverSpawnAlreadyComplete
+	// cutoverSpawnHandoverIncomplete — source="internal" + handover gate
+	// closed (no tofu-phase0-archive). Benign defer on a fresh prov.
+	cutoverSpawnHandoverIncomplete
+	// cutoverSpawnNoSteps — no cutover-step ConfigMaps found.
+	cutoverSpawnNoSteps
+	// cutoverSpawnAlreadyRunning — another goroutine holds the run flag.
+	cutoverSpawnAlreadyRunning
+)
+
+// cutoverSpawnResult carries the outcome of spawnCutoverEngine plus the
+// data the HTTP layer needs to reconstruct its byte-identical responses
+// (the status map for the already-complete / started snapshots, and the
+// resolved step names + count). A non-nil err means a hard failure
+// (status-read / handover-check / step-discovery) the caller surfaces as
+// a 502; outcome is then meaningless.
+type cutoverSpawnResult struct {
+	outcome cutoverSpawnOutcome
+	// status is the status ConfigMap snapshot read before the decision —
+	// used to build the already-complete 200 body. For the started case it
+	// is re-read post-spawn so cutoverStartedAt is reflected.
+	status map[string]string
+	// stepNames + totalSteps populate the started 200 snapshot.
+	stepNames  []string
+	totalSteps int
+}
+
+// spawnCutoverEngine is the w-less engine-spawn core shared by the
+// operator endpoint (HandleCutoverStart), the in-cluster auto-trigger
+// (HandleCutoverInternalTrigger, via runCutoverFromTrigger), AND the
+// post-handover archive-seal path (ReceiveTofuArchive). It performs the
+// SAME sequence the old runCutoverFromTrigger tail did — cutoverComplete
+// idempotency short-circuit, the source-gated handover-completion check,
+// step discovery, the in-process running-flag claim, and the detached
+// engine goroutine — but returns a typed result instead of writing HTTP.
+//
+// The behaviour is byte-identical to the pre-extraction tail; the only
+// new axis is `source`: the handover gate applies ONLY to
+// source="internal" (the bootstrap-time Helm post-install hook that can
+// fire before handover). source="operator" (human CTA behind
+// RequireSession) and source="handover" (ReceiveTofuArchive, where the
+// tofu-phase0-archive is sealed BY DEFINITION at the call site) are
+// deliberate post-handover actions and skip the gate.
+func (h *Handler) spawnCutoverEngine(ctx context.Context, deps *cutoverDeps, source string) (cutoverSpawnResult, error) {
+	status, err := readCutoverStatus(ctx, deps)
 	if err != nil {
-		writeJSON(w, http.StatusBadGateway, map[string]string{
-			"error":  "status-read-failed",
-			"detail": err.Error(),
-		})
-		return
+		return cutoverSpawnResult{}, fmt.Errorf("status-read-failed: %w", err)
 	}
 
 	if status["cutoverComplete"] == "true" {
@@ -325,9 +400,11 @@ func (h *Handler) runCutoverFromTrigger(w http.ResponseWriter, r *http.Request, 
 			Level:   "info",
 			Message: fmt.Sprintf("cutover already complete; %s trigger is a no-op", source),
 		})
-		resp := buildCutoverStatusResponseFromMap(status, listStepNamesFromStatus(status))
-		writeJSON(w, http.StatusOK, resp)
-		return
+		return cutoverSpawnResult{
+			outcome:   cutoverSpawnAlreadyComplete,
+			status:    status,
+			stepNames: listStepNamesFromStatus(status),
+		}, nil
 	}
 
 	// Handover-completion gate (fresh-prov registry half-pivot).
@@ -347,57 +424,45 @@ func (h *Handler) runCutoverFromTrigger(w http.ResponseWriter, r *http.Request, 
 	// The cutover is a POST-handover operation. The durable Sovereign-side
 	// handover marker is the tofu-phase0-archive secret, sealed in OpenBao
 	// by ReceiveTofuArchive ONLY when the mothership POSTs the archive at
-	// handover. Until it exists, refuse with 425 Too Early — which the
-	// auto-trigger Job treats as benign (its case-* arm exits 0, so the
-	// chart install completes and the HR goes Ready with NO engine start).
-	// Placed AFTER the cutoverComplete short-circuit so an already-done
-	// cutover keeps its idempotent 200. The operator CTA path is NOT
-	// routed here, so a human clicking "Achieve True Sovereignty" behind
-	// RequireSession is never gated — a deliberate post-handover action.
+	// handover. Until it exists, refuse — which the auto-trigger Job treats
+	// as benign (its case-* arm exits 0, so the chart install completes and
+	// the HR goes Ready with NO engine start). Placed AFTER the
+	// cutoverComplete short-circuit so an already-done cutover keeps its
+	// idempotent 200.
+	//
+	// Only source="internal" is gated. The operator CTA path
+	// (source="operator", behind RequireSession) and the handover-seal
+	// path (source="handover", inside ReceiveTofuArchive where the archive
+	// is sealed by definition) are deliberate post-handover actions — gating
+	// them would be wrong: handover seals the archive THEN fires the engine,
+	// so re-checking the gate it just satisfied is redundant, and a
+	// read-after-write race against OpenBao could falsely defer it (issue
+	// #933 / #3052 — the bug was that NOTHING fired the engine after the
+	// seal, leaving the cutover dormant forever).
 	if source == "internal" && requireHandoverForCutover() {
-		handedOver, herr := h.sovereignHandoverComplete(r.Context())
+		handedOver, herr := h.sovereignHandoverComplete(ctx)
 		if herr != nil {
-			writeJSON(w, http.StatusBadGateway, map[string]string{
-				"error":  "handover-check-failed",
-				"detail": herr.Error(),
-			})
-			return
+			return cutoverSpawnResult{}, fmt.Errorf("handover-check-failed: %w", herr)
 		}
 		if !handedOver {
 			h.log.Info("internal cutover trigger deferred: handover not complete",
 				"detail", "tofu-phase0-archive absent in OpenBao — Sovereign not yet handed over; auto-trigger is benign pre-handover",
 			)
-			writeJSON(w, http.StatusTooEarly, map[string]string{
-				"error":  "handover-incomplete",
-				"detail": "cutover deferred: this Sovereign has not been handed over yet (tofu-phase0-archive not present in OpenBao). The cutover auto-fires post-handover; deferring is expected and benign on a fresh prov.",
-			})
-			return
+			return cutoverSpawnResult{outcome: cutoverSpawnHandoverIncomplete}, nil
 		}
 	}
 
-	steps, err := listCutoverSteps(r.Context(), deps)
+	steps, err := listCutoverSteps(ctx, deps)
 	if err != nil {
-		writeJSON(w, http.StatusBadGateway, map[string]string{
-			"error":  "step-discovery-failed",
-			"detail": err.Error(),
-		})
-		return
+		return cutoverSpawnResult{}, fmt.Errorf("step-discovery-failed: %w", err)
 	}
 	if len(steps) == 0 {
-		writeJSON(w, http.StatusFailedDependency, map[string]string{
-			"error":  "no-steps-found",
-			"detail": fmt.Sprintf("no cutover-step ConfigMaps found in namespace %q — bp-self-sovereign-cutover not installed?", deps.ns),
-		})
-		return
+		return cutoverSpawnResult{outcome: cutoverSpawnNoSteps}, nil
 	}
 
 	bus := h.cutoverBusFor()
 	if !bus.tryStartRun() {
-		writeJSON(w, http.StatusConflict, map[string]string{
-			"error":  "cutover-in-progress",
-			"detail": "a cutover is already running on this catalyst-api Pod",
-		})
-		return
+		return cutoverSpawnResult{outcome: cutoverSpawnAlreadyRunning}, nil
 	}
 
 	// Run the engine with a context independent of the request so a
@@ -405,12 +470,70 @@ func (h *Handler) runCutoverFromTrigger(w http.ResponseWriter, r *http.Request, 
 	// cutoverStepTimeout on each step bounds the overall runtime.
 	go h.runCutover(context.Background(), deps, steps)
 
-	freshStatus, _ := readCutoverStatus(r.Context(), deps)
+	freshStatus, _ := readCutoverStatus(ctx, deps)
 	stepNames := make([]string, 0, len(steps))
 	for _, s := range steps {
 		stepNames = append(stepNames, s.stepName)
 	}
-	resp := buildCutoverStatusResponseFromMap(freshStatus, stepNames)
-	resp.TotalSteps = len(steps)
-	writeJSON(w, http.StatusOK, resp)
+	return cutoverSpawnResult{
+		outcome:    cutoverSpawnStarted,
+		status:     freshStatus,
+		stepNames:  stepNames,
+		totalSteps: len(steps),
+	}, nil
+}
+
+// runCutoverFromTrigger is the shared engine-spawn path used by both
+// HandleCutoverStart (operator-session) and HandleCutoverInternalTrigger
+// (in-cluster SA token). The split keeps cutover.go's HTTP handler
+// readable while making the auth-edge swap a single-call site change.
+//
+// It is now a thin HTTP adapter over spawnCutoverEngine: it maps the typed
+// (cutoverSpawnResult, err) back to the EXACT status codes + bodies it
+// produced before the engine-spawn core was extracted. Behaviour through
+// HandleCutoverStart and HandleCutoverInternalTrigger is unchanged.
+func (h *Handler) runCutoverFromTrigger(w http.ResponseWriter, r *http.Request, deps *cutoverDeps, source string) {
+	res, err := h.fireCutoverEngine(r.Context(), deps, source)
+	if err != nil {
+		// Preserve the three distinct 502 error codes by inspecting the
+		// wrapped sentinel prefix spawnCutoverEngine attached.
+		msg := err.Error()
+		code := "status-read-failed"
+		switch {
+		case strings.HasPrefix(msg, "handover-check-failed:"):
+			code = "handover-check-failed"
+		case strings.HasPrefix(msg, "step-discovery-failed:"):
+			code = "step-discovery-failed"
+		}
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  code,
+			"detail": errors.Unwrap(err).Error(),
+		})
+		return
+	}
+
+	switch res.outcome {
+	case cutoverSpawnAlreadyComplete:
+		resp := buildCutoverStatusResponseFromMap(res.status, res.stepNames)
+		writeJSON(w, http.StatusOK, resp)
+	case cutoverSpawnHandoverIncomplete:
+		writeJSON(w, http.StatusTooEarly, map[string]string{
+			"error":  "handover-incomplete",
+			"detail": "cutover deferred: this Sovereign has not been handed over yet (tofu-phase0-archive not present in OpenBao). The cutover auto-fires post-handover; deferring is expected and benign on a fresh prov.",
+		})
+	case cutoverSpawnNoSteps:
+		writeJSON(w, http.StatusFailedDependency, map[string]string{
+			"error":  "no-steps-found",
+			"detail": fmt.Sprintf("no cutover-step ConfigMaps found in namespace %q — bp-self-sovereign-cutover not installed?", deps.ns),
+		})
+	case cutoverSpawnAlreadyRunning:
+		writeJSON(w, http.StatusConflict, map[string]string{
+			"error":  "cutover-in-progress",
+			"detail": "a cutover is already running on this catalyst-api Pod",
+		})
+	default: // cutoverSpawnStarted
+		resp := buildCutoverStatusResponseFromMap(res.status, res.stepNames)
+		resp.TotalSteps = res.totalSteps
+		writeJSON(w, http.StatusOK, resp)
+	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/audit"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
-	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/flowemit"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
@@ -285,6 +285,12 @@ type Handler struct {
 	// kubernetes.Interface + namespace pair the cutover engine reads
 	// from. Production leaves this nil and cutoverDepsFromEnv runs.
 	cutoverDepsFactory CutoverDepsFactory
+	// spawnCutoverEngineFn — test-only seam over spawnCutoverEngine so the
+	// handover-archive-seal path (ReceiveTofuArchive, issue #933/#3052) can
+	// assert the engine is fired exactly once WITHOUT standing up the real
+	// engine + cluster. Production leaves this nil and fireCutoverEngine
+	// dispatches to the real h.spawnCutoverEngine.
+	spawnCutoverEngineFn func(ctx context.Context, deps *cutoverDeps, source string) (cutoverSpawnResult, error)
 
 	// ── Unified RBAC SME-tier (issue #802, ADR-0003) ────────────────────────
 	// tenantRegistry — host → tenant lookup table backing the public

--- a/products/catalyst/bootstrap/api/internal/handler/handover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handover.go
@@ -113,12 +113,12 @@ type finaliseResponse struct {
 // renders as a checklist. Step 4 (rotate / delete kubeconfig + record)
 // fans out into three sub-fields so partial success surfaces clearly.
 type finaliseStepsCompleted struct {
-	HandoverEventEmitted     bool `json:"handoverEventEmitted"`
-	HelmwatchCancelled       bool `json:"helmwatchCancelled"`
-	TofuArchiveSubmitted     bool `json:"tofuArchiveSubmitted"`
-	TofuWorkdirRemoved       bool `json:"tofuWorkdirRemoved"`
-	KubeconfigRemoved        bool `json:"kubeconfigRemoved"`
-	DeploymentRecordRemoved  bool `json:"deploymentRecordRemoved"`
+	HandoverEventEmitted    bool `json:"handoverEventEmitted"`
+	HelmwatchCancelled      bool `json:"helmwatchCancelled"`
+	TofuArchiveSubmitted    bool `json:"tofuArchiveSubmitted"`
+	TofuWorkdirRemoved      bool `json:"tofuWorkdirRemoved"`
+	KubeconfigRemoved       bool `json:"kubeconfigRemoved"`
+	DeploymentRecordRemoved bool `json:"deploymentRecordRemoved"`
 }
 
 // FinaliseHandover handles POST /api/v1/handover/finalise/{id}. It runs
@@ -273,8 +273,8 @@ func (h *Handler) FinaliseHandover(w http.ResponseWriter, r *http.Request) {
 // tofuArchiveRequest is the body the Catalyst-Zero side POSTs to the
 // new Sovereign's /api/v1/handover/tofu-archive endpoint.
 type tofuArchiveRequest struct {
-	DeploymentID  string            `json:"deploymentId"`
-	SovereignFQDN string            `json:"sovereignFqdn"`
+	DeploymentID  string `json:"deploymentId"`
+	SovereignFQDN string `json:"sovereignFqdn"`
 	// Files maps each path (relative to the original workdir) to a
 	// base64-encoded blob of the file contents.
 	Files map[string]string `json:"files"`
@@ -385,6 +385,54 @@ func (h *Handler) ReceiveTofuArchive(w http.ResponseWriter, r *http.Request) {
 		"sovereignFqdn", body.SovereignFQDN,
 		"secretPath", "secret/catalyst/tofu-phase0-archive",
 	)
+
+	// Fire the Self-Sovereignty Cutover engine now that the durable
+	// handover marker is sealed (issue #933 / #3052).
+	// ──────────────────────────────────────────────────────────────────
+	// The cutover's in-cluster auto-trigger (bp-self-sovereign-cutover's
+	// Helm post-install hook → HandleCutoverInternalTrigger, source=
+	// "internal") fires ONCE at chart-install (bootstrap). On a fresh prov
+	// that is long before handover, so it correctly defers at the
+	// handover-completion gate (425 Too Early) and the HR goes Ready with
+	// NO engine start. Nothing else re-fires the engine after the mothership
+	// POSTs the archive HERE — so without this hook the cutover stays
+	// dormant forever and TC-16 (the deny-egress proof, issue #2940) can
+	// never pass.
+	//
+	// We seal the archive THEN fire: the archive is present by definition at
+	// this point, so the engine runs with source="handover" (gate skipped —
+	// re-checking the marker we just wrote would be redundant and could race
+	// the OpenBao read). The spawn is async (background context) so a slow
+	// multi-step cutover never blocks the handover 200; the operator polls
+	// /cutover/status or /cutover/events for progress. A Sovereign WITHOUT
+	// the cutover chart installed (cutoverDepsFor errors, or no step
+	// ConfigMaps) still succeeds the handover — the fire is best-effort.
+	//
+	// Runtime-overridable per docs/PRINCIPLES.md #4: set
+	// CATALYST_FIRE_CUTOVER_ON_HANDOVER=false to keep the cutover a
+	// deliberate operator action (the BSS CTA still fires it).
+	if fireCutoverOnHandover() {
+		deps, derr := h.cutoverDepsFor()
+		if derr != nil {
+			h.log.Info("handover seal: cutover auto-fire skipped (cutover not configured on this Sovereign)",
+				"detail", derr.Error(),
+			)
+		} else {
+			go func() {
+				res, ferr := h.fireCutoverEngine(context.Background(), deps, "handover")
+				if ferr != nil {
+					h.log.Error("handover seal: cutover engine fire failed",
+						"err", ferr,
+					)
+					return
+				}
+				h.log.Info("handover seal: cutover engine fired",
+					"outcome", res.outcome,
+				)
+			}()
+		}
+	}
+
 	writeJSON(w, http.StatusOK, tofuArchiveResponse{
 		OK:         true,
 		StoredAt:   storedAt,

--- a/products/catalyst/bootstrap/api/internal/handler/handover_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handover_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -413,6 +415,135 @@ func TestReceiveTofuArchive_ValidationErrors(t *testing.T) {
 				t.Errorf("expected 400; got %d (%s)", rec.Code, rec.Body.String())
 			}
 		})
+	}
+}
+
+// TestReceiveTofuArchive_FiresCutoverEngineOnSeal is the issue #933 / #3052
+// regression guard: a successful Phase-0 archive seal at handover must
+// auto-fire the cutover engine exactly once with source="handover", so the
+// post-handover cutover (and TC-16's deny-egress proof, #2940) is no longer
+// dormant. The engine itself is replaced by a seam (spawnCutoverEngineFn) so
+// the test asserts the fire WITHOUT standing up the real 8-step engine.
+//
+// The fire is async (a goroutine), so the seam closes a buffered channel /
+// records the call under a mutex; the test waits on a short deadline.
+func TestReceiveTofuArchive_FiresCutoverEngineOnSeal(t *testing.T) {
+	h := newTestHandler(t)
+
+	// Real OpenBao seam (httptest) so the seal succeeds and returns 200.
+	bao := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer bao.Close()
+	c := openbao.New(bao.URL, "test-token")
+	c.HTTP = bao.Client()
+	h.SetOpenBao(c)
+
+	// A deps factory so cutoverDepsFor() succeeds (a Sovereign WITH the
+	// cutover chart installed). The fake clientset is unused by the seam.
+	h.SetCutoverDepsFactory(func() (*cutoverDeps, error) {
+		return &cutoverDeps{ns: "catalyst"}, nil
+	})
+
+	// Engine seam: record every call (source + count) under a mutex and
+	// signal completion via a channel so the async goroutine is observable.
+	var (
+		mu     sync.Mutex
+		calls  int
+		gotSrc string
+		fired  = make(chan struct{}, 1)
+	)
+	h.spawnCutoverEngineFn = func(_ context.Context, _ *cutoverDeps, source string) (cutoverSpawnResult, error) {
+		mu.Lock()
+		calls++
+		gotSrc = source
+		mu.Unlock()
+		select {
+		case fired <- struct{}{}:
+		default:
+		}
+		return cutoverSpawnResult{outcome: cutoverSpawnStarted}, nil
+	}
+
+	body, _ := json.Marshal(tofuArchiveRequest{
+		DeploymentID:  "dep-933",
+		SovereignFQDN: "t99.omani.works",
+		CapturedAt:    "2026-06-08T00:00:00Z",
+		Files: map[string]string{
+			"terraform.tfstate": base64.StdEncoding.EncodeToString([]byte(`{"v":1}`)),
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/handover/tofu-archive", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ReceiveTofuArchive(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("seal status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Wait for the async fire.
+	select {
+	case <-fired:
+	case <-time.After(5 * time.Second):
+		t.Fatal("cutover engine was not fired within 5s of a successful archive seal")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 1 {
+		t.Errorf("spawnCutoverEngine called %d times, want exactly 1", calls)
+	}
+	if gotSrc != "handover" {
+		t.Errorf("spawnCutoverEngine source = %q, want %q (gate must be skipped on the handover-seal path)", gotSrc, "handover")
+	}
+}
+
+// TestReceiveTofuArchive_SealSucceedsWhenCutoverNotConfigured proves the
+// best-effort contract: a Sovereign without the cutover chart (cutoverDepsFor
+// errors) STILL completes the handover with 200, and the engine is NOT fired.
+// A handover must never fail just because the cutover surface is absent.
+func TestReceiveTofuArchive_SealSucceedsWhenCutoverNotConfigured(t *testing.T) {
+	h := newTestHandler(t)
+
+	bao := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer bao.Close()
+	c := openbao.New(bao.URL, "test-token")
+	c.HTTP = bao.Client()
+	h.SetOpenBao(c)
+
+	// Deps factory returns an error → cutover not configured on this
+	// Sovereign. The async fire branch must be skipped entirely.
+	h.SetCutoverDepsFactory(func() (*cutoverDeps, error) {
+		return nil, errors.New("cutover: in-cluster config unavailable")
+	})
+
+	var fired int32
+	h.spawnCutoverEngineFn = func(_ context.Context, _ *cutoverDeps, _ string) (cutoverSpawnResult, error) {
+		atomic.AddInt32(&fired, 1)
+		return cutoverSpawnResult{}, nil
+	}
+
+	body, _ := json.Marshal(tofuArchiveRequest{
+		DeploymentID:  "dep-933b",
+		SovereignFQDN: "t99.omani.works",
+		Files: map[string]string{
+			"terraform.tfstate": base64.StdEncoding.EncodeToString([]byte(`{"v":1}`)),
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/handover/tofu-archive", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ReceiveTofuArchive(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("seal status = %d, want 200 (handover must succeed without cutover chart); body=%s", rec.Code, rec.Body.String())
+	}
+	// Give any (erroneously-spawned) goroutine a moment to run, then assert
+	// the engine was never fired.
+	time.Sleep(100 * time.Millisecond)
+	if n := atomic.LoadInt32(&fired); n != 0 {
+		t.Errorf("cutover engine fired %d times when cutover not configured, want 0", n)
 	}
 }
 


### PR DESCRIPTION
## The dormant-cutover gap

The Self-Sovereignty Cutover (`bp-self-sovereign-cutover`) never ran after handover, so TC-16 — the deny-egress proof (#2940) — could never pass.

Trace:
- `bootstrap/api/internal/handler/handover.go` `ReceiveTofuArchive` seals the Phase-0 OpenTofu archive to OpenBao at `secret/catalyst/tofu-phase0-archive` and returns 200, but **never fired the cutover engine**.
- The cutover's only auto-fire path is `bp-self-sovereign-cutover`'s Helm post-install hook → `HandleCutoverInternalTrigger` (`source="internal"`). That hook fires **once at chart-install** (bootstrap). On a fresh prov that is long before handover, so it correctly defers at the handover-completion gate (`425 Too Early`) — its shell `case-*` arm exits 0, the HelmRelease goes Ready with **no engine start**.
- Nothing re-fired the engine after the archive was sealed at handover, so the cutover stayed **dormant forever**.

## The fix — extract + async-fire

1. **Extract** the engine-spawn tail of `runCutoverFromTrigger` into a new `w`-less method:
   ```go
   func (h *Handler) spawnCutoverEngine(ctx context.Context, deps *cutoverDeps, source string) (cutoverSpawnResult, error)
   ```
   It preserves the EXACT sequence the old tail ran — `cutoverComplete` short-circuit, the source-gated handover-completion check, step discovery, the in-process running-flag claim (`tryStartRun`), and the detached engine goroutine — and returns a typed `cutoverSpawnResult` instead of writing HTTP. The idempotency / running-flag / event-bus-publish behaviour is unchanged.

2. **Rewrite** `runCutoverFromTrigger` as a thin HTTP adapter that maps `(cutoverSpawnResult, err)` back to the byte-identical responses it produced before: `200` started, `200` cutoverComplete short-circuit, `425` handover gate (`source="internal"` only), `424` no-steps, `409` already-running, and the three distinct `502`s (`status-read-failed` / `handover-check-failed` / `step-discovery-failed`). Behaviour through `HandleCutoverStart` (a separate untouched inline path) and `HandleCutoverInternalTrigger` is unchanged — the existing cutover tests assert this and stay green.

3. **Async-fire on seal**: in `ReceiveTofuArchive`, after the seal succeeds and before the 200 write, fetch `deps` via `h.cutoverDepsFor()` and `go func(){ h.spawnCutoverEngine(context.Background(), deps, "handover") }()`. `spawnCutoverEngine` treats `source="handover"` like the operator path — it does **not** re-apply the handover-completion gate (the archive is sealed by definition at this call site; re-checking the marker just written would be redundant and could race the OpenBao read). A Sovereign **without** the cutover chart installed (`cutoverDepsFor` errors) still succeeds the handover — the fire is best-effort. The spawn is async so a slow multi-step cutover never blocks the handover `200`.

4. **Runtime gate** (docs/PRINCIPLES.md #4): the new behaviour is behind `CATALYST_FIRE_CUTOVER_ON_HANDOVER` (default `true`) so an operator can disable it and keep the cutover a deliberate BSS-CTA action.

## Tests

Added to `handover_test.go` (engine replaced by a function-field seam so the assertions need no real engine + cluster):

- `TestReceiveTofuArchive_FiresCutoverEngineOnSeal` — a successful seal fires `spawnCutoverEngine` **exactly once** with `source="handover"`.
- `TestReceiveTofuArchive_SealSucceedsWhenCutoverNotConfigured` — when `cutoverDepsFor()` errors, the handover still returns `200` and the engine is **not** fired.

## Verification

```
$ go build ./...            # products/catalyst/bootstrap/api → clean
$ go test ./...             # whole module → all ok (internal/handler 60s ok)
$ go test ./internal/handler/ -run 'Cutover|ReceiveTofuArchive|Handover' -race   # green, no data races
```

The cutover engine wedges a Sovereign if broken (registry half-pivot), so the full existing `cutover_internal_test.go` + `cutover_test.go` suites were re-run and pass unchanged.

The runtime TC-16 walk is **not** claimed here — that needs a handed-over prov and a separate operator-walk-with-screenshot.

Refs #933 #3052 #2940
