### PR TITLE
fix(prov): cache tofu providers + retry init on transient github failures (#3126)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -963,7 +963,13 @@ spec:
       # against the local Gitea pre-cutover (the secretKeyRef couldn't be
       # inline-templated in api-deployment.yaml — fix lives in the Secret
       # population). Refs #3122 #866 #2737.
-      version: 1.4.516
+      # 1.4.517 — #3126: catalyst-api sets CATALYST_TF_PLUGIN_CACHE_DIR
+      # (/var/lib/catalyst/tofu-plugin-cache on the persistent deployments
+      # PVC) so OpenTofu providers download from github release-assets once
+      # and are reused on every later prov, surviving a transient CDN 504 at
+      # tofu-init; paired with a Go-side bounded retry on `tofu init`.
+      # Refs #3126.
+      version: 1.4.517
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1345,6 +1345,32 @@ type Provisioner struct {
 	// posture as the harbor-robot-token Empty-Token path.
 	PDMBasicAuthUser string
 	PDMBasicAuthPass string
+
+	// TofuPluginCacheDir is the OpenTofu provider plugin cache directory
+	// (#3126). Set as TF_PLUGIN_CACHE_DIR on every `tofu` exec so the
+	// provider binaries (huaweicloud, hetznercloud, dynadot, ...) are
+	// downloaded from github release-assets ONCE and reused by every
+	// subsequent provision regardless of region/provider.
+	//
+	// Why this matters: OpenTofu providers are hosted as binaries on
+	// github release-assets (302 → release-assets.githubusercontent.com,
+	// a Fastly/Azure-Blob CDN). `tofu init` fetches the zip + SHA256SUMS
+	// + .sig from there. The catalyst-api uses a FRESH per-deployment
+	// workdir, so without a shared plugin cache EVERY prov re-downloads
+	// every provider from scratch — any transient github/CDN 504 then
+	// kills a full 2-region prov at init (caught live: the CDN edge
+	// returned intermittent 504s to the mothership; `tofu init` retries
+	// only 2× internally then aborts).
+	//
+	// Mounted on the PERSISTENT catalyst-api-deployments PVC (same volume
+	// the per-deployment workdir lives on) so the cache survives Pod
+	// rolls and is shared across deployments. Read once at New() from
+	// CATALYST_TF_PLUGIN_CACHE_DIR (default /var/lib/catalyst/tofu-plugin-cache);
+	// runtime-overridable per docs/PRINCIPLES.md #4. Empty disables the
+	// cache (falls back to per-workdir download — the pre-#3126
+	// behaviour) so air-gapped operators pinning a provider mirror are
+	// unaffected.
+	TofuPluginCacheDir string
 }
 
 // New returns a Provisioner with paths read from environment.
@@ -1369,13 +1395,18 @@ func New() *Provisioner {
 		// resolveModulePath() which swaps the trailing directory to match
 		// req.Provider. The env-mounted override remains authoritative when
 		// set (air-gap operators pinning a custom module location).
-		ModulePath:       env("CATALYST_TOFU_MODULE_PATH", "/infra/providers/hetzner"),
-		WorkDir:          env("CATALYST_TOFU_WORKDIR", "/var/lib/catalyst/tofu"),
-		GHCRPullToken:    os.Getenv("CATALYST_GHCR_PULL_TOKEN"),
-		HarborRobotToken: os.Getenv("CATALYST_HARBOR_ROBOT_TOKEN"),
-		PowerDNSAPIKey:   os.Getenv("CATALYST_POWERDNS_API_KEY"),
-		PDMBasicAuthUser: os.Getenv("CATALYST_PDM_BASIC_AUTH_USER"),
-		PDMBasicAuthPass: os.Getenv("CATALYST_PDM_BASIC_AUTH_PASS"),
+		ModulePath: env("CATALYST_TOFU_MODULE_PATH", "/infra/providers/hetzner"),
+		WorkDir:    env("CATALYST_TOFU_WORKDIR", "/var/lib/catalyst/tofu"),
+		// #3126 — provider plugin cache on the persistent deployments PVC
+		// (sibling of WorkDir's /var/lib/catalyst/tofu). First prov fills
+		// it; every later prov reuses the cached providers with zero
+		// github release-asset fetches. See the field doc on Provisioner.
+		TofuPluginCacheDir: env("CATALYST_TF_PLUGIN_CACHE_DIR", "/var/lib/catalyst/tofu-plugin-cache"),
+		GHCRPullToken:      os.Getenv("CATALYST_GHCR_PULL_TOKEN"),
+		HarborRobotToken:   os.Getenv("CATALYST_HARBOR_ROBOT_TOKEN"),
+		PowerDNSAPIKey:     os.Getenv("CATALYST_POWERDNS_API_KEY"),
+		PDMBasicAuthUser:   os.Getenv("CATALYST_PDM_BASIC_AUTH_USER"),
+		PDMBasicAuthPass:   os.Getenv("CATALYST_PDM_BASIC_AUTH_PASS"),
 	}
 }
 
@@ -1517,7 +1548,7 @@ func (p *Provisioner) Provision(ctx context.Context, req Request, events chan<- 
 	}
 
 	emit("tofu-init", "info", "Initialising OpenTofu working directory")
-	if err := p.runTofu(ctx, deployDir, []string{"init", "-input=false", "-no-color"}, emit); err != nil {
+	if err := p.runTofuInitWithRetry(ctx, deployDir, emit); err != nil {
 		return nil, fmt.Errorf("tofu init: %w", err)
 	}
 
@@ -1854,6 +1885,117 @@ func (p *Provisioner) Destroy(ctx context.Context, req Request, events chan<- Ev
 	return nil
 }
 
+// tofuInitMaxAttempts / tofuInitBaseBackoff control the bounded
+// retry-with-exponential-backoff applied to `tofu init` (#3126). 4
+// attempts at 5s/15s/45s (base 5s, ×3 growth) ride out a short github
+// release-asset CDN blip even on a COLD plugin cache; on a warm cache the
+// first attempt needs zero github fetches and never sleeps. Package-level
+// so the unit test can reference the same growth contract.
+const (
+	tofuInitMaxAttempts   = 4
+	tofuInitBaseBackoff   = 5 * time.Second
+	tofuInitBackoffGrowth = 3
+)
+
+// isTransientInitFailure reports whether a `tofu init` error string looks
+// like a provider-install / network-class failure that a retry could
+// clear (#3126), as opposed to a deterministic configuration error
+// (bad provider constraint, malformed backend block) where retrying is
+// pointless. The markers are the substrings OpenTofu emits when the
+// github release-asset CDN flakes or a registry/network hop times out:
+//
+//   - "Failed to install provider"      — the umbrella init error
+//   - "Failed to query available provider packages"
+//   - "could not query provider registry"
+//   - "504" / "Gateway Timeout"         — the actual CDN edge status
+//   - "502" / "Bad Gateway" / "503" / "Service Unavailable"
+//   - "failed to retrieve" / "error fetching" — checksum/zip fetch leg
+//   - "TLS handshake timeout" / "i/o timeout" / "connection reset"
+//   - "timeout" / "temporary failure" / "no such host" (DNS blip)
+//   - "EOF" / "unexpected EOF"          — truncated CDN response
+//
+// Matching is case-insensitive so "gateway timeout" and "Gateway Timeout"
+// both qualify. A real config error (e.g. "Invalid provider requirements"
+// without any network marker) does NOT match and is surfaced immediately.
+func isTransientInitFailure(errStr string) bool {
+	s := strings.ToLower(errStr)
+	markers := []string{
+		"failed to install provider",
+		"failed to query available provider",
+		"could not query provider registry",
+		"failed to retrieve",
+		"error fetching",
+		"504",
+		"gateway timeout",
+		"502",
+		"bad gateway",
+		"503",
+		"service unavailable",
+		"tls handshake timeout",
+		"i/o timeout",
+		"connection reset",
+		"connection refused",
+		"temporary failure",
+		"no such host",
+		"timeout",
+		"unexpected eof",
+		"eof",
+	}
+	for _, m := range markers {
+		if strings.Contains(s, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// retryTofuInit runs `runOnce` (a single `tofu init`) with bounded
+// retry-with-exponential-backoff, retrying ONLY on transient
+// provider-install/network failures per isTransientInitFailure (#3126).
+// `sleep` is injected so the unit test can pass a no-op instead of
+// actually waiting 5s+15s+45s. Returns nil on the first success; the
+// last error otherwise. A non-transient (config) error returns
+// immediately without consuming the remaining attempts.
+func retryTofuInit(ctx context.Context, runOnce func() error, sleep func(time.Duration), emit func(string, string, string)) error {
+	var lastErr error
+	for attempt := 1; attempt <= tofuInitMaxAttempts; attempt++ {
+		err := runOnce()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if attempt >= tofuInitMaxAttempts || !isTransientInitFailure(err.Error()) {
+			break
+		}
+		// Stop early if the caller's context is already done — no point
+		// sleeping through a backoff we'll abort anyway.
+		if ctx.Err() != nil {
+			break
+		}
+		backoff := tofuInitBaseBackoff
+		for i := 1; i < attempt; i++ {
+			backoff *= tofuInitBackoffGrowth
+		}
+		emit("tofu-init", "warn", fmt.Sprintf(
+			"transient provider-install/network failure on tofu init (likely github release-asset CDN blip) — attempt %d/%d, retrying in %s: %v",
+			attempt, tofuInitMaxAttempts, backoff, err,
+		))
+		sleep(backoff)
+	}
+	return lastErr
+}
+
+// runTofuInitWithRetry wraps the real `tofu init` exec in retryTofuInit
+// so a short github/CDN outage at provider-download time no longer fails
+// the whole prov (#3126). Layer 2 of the #3126 fix; layer 1 is the
+// TF_PLUGIN_CACHE_DIR wired in runTofu (which means attempt 1 usually
+// needs ZERO github fetches once the cache is warm).
+func (p *Provisioner) runTofuInitWithRetry(ctx context.Context, deployDir string, emit func(string, string, string)) error {
+	return retryTofuInit(ctx, func() error {
+		return p.runTofu(ctx, deployDir, []string{"init", "-input=false", "-no-color"}, emit)
+	}, time.Sleep, emit)
+}
+
 // runTofu executes `tofu <args>` in deployDir, streaming stdout/stderr lines
 // as Events to the wizard.
 func (p *Provisioner) runTofu(ctx context.Context, deployDir string, args []string, emit func(string, string, string)) error {
@@ -1868,6 +2010,23 @@ func (p *Provisioner) runTofu(ctx context.Context, deployDir string, args []stri
 		"TF_INPUT=false",
 		"TF_IN_AUTOMATION=true",
 	)
+	// #3126 — point OpenTofu at the shared, persistent provider plugin
+	// cache so providers are fetched from github release-assets ONCE and
+	// reused on every subsequent prov (the per-deployment workdir is
+	// fresh each time, so without this every prov cold-downloads every
+	// provider and a transient github/CDN 504 fails the whole apply at
+	// init). MkdirAll is idempotent + cheap; OpenTofu refuses to use a
+	// non-existent TF_PLUGIN_CACHE_DIR (it errors rather than creating
+	// it), so we must create it ourselves. On MkdirAll failure we log +
+	// continue WITHOUT the cache var (degrade to per-workdir download —
+	// the pre-#3126 behaviour) rather than failing the prov outright.
+	if cacheDir := strings.TrimSpace(p.TofuPluginCacheDir); cacheDir != "" {
+		if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+			emit("tofu-init", "warn", fmt.Sprintf("provider plugin cache dir %q unavailable (%v) — falling back to per-workdir provider download", cacheDir, err))
+		} else {
+			cmd.Env = append(cmd.Env, "TF_PLUGIN_CACHE_DIR="+cacheDir)
+		}
+	}
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/products/catalyst/bootstrap/api/internal/provisioner/tofu_init_retry_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/tofu_init_retry_test.go
@@ -1,0 +1,218 @@
+// Package provisioner — unit tests for the #3126 tofu-init resilience
+// layer: retry-with-backoff on transient github/CDN provider-install
+// failures, the transient-vs-config error classifier, and the
+// TF_PLUGIN_CACHE_DIR wiring in New().
+//
+// These are white-box tests (package provisioner) so they can drive the
+// unexported retryTofuInit / isTransientInitFailure helpers with an
+// injected runOnce + a no-op sleep — no real `tofu` binary is exec'd.
+package provisioner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// noopSleep is the injected sleeper so retries don't actually wait
+// 5s+15s+45s during the test run.
+func noopSleep(time.Duration) {}
+
+// discardEmit drops progress events.
+func discardEmit(string, string, string) {}
+
+// TestRetryTofuInit_RetriesTransientThenSucceeds asserts the wrapper
+// retries on a transient (CDN 504 / provider-install) failure and
+// eventually returns nil once the underlying init succeeds — and that it
+// took exactly the expected number of attempts.
+func TestRetryTofuInit_RetriesTransientThenSucceeds(t *testing.T) {
+	calls := 0
+	// Fail the first 2 attempts with a github-release-asset-CDN-shaped
+	// error, then succeed on the 3rd.
+	runOnce := func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("tofu init failed: exit status 1 | stderr: Error: Failed to install provider\n\nError while installing huaweicloud/huaweicloud v1.62.1: 504 Gateway Timeout retrieving https://release-assets.githubusercontent.com/...")
+		}
+		return nil
+	}
+
+	err := retryTofuInit(context.Background(), runOnce, noopSleep, discardEmit)
+	if err != nil {
+		t.Fatalf("expected eventual success, got error: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected exactly 3 attempts (2 transient failures + 1 success), got %d", calls)
+	}
+}
+
+// TestRetryTofuInit_DoesNotRetryConfigError asserts a deterministic
+// configuration error (NO network/CDN marker) is surfaced immediately
+// without consuming the remaining attempts — retrying a bad provider
+// constraint would only waste backoff time.
+func TestRetryTofuInit_DoesNotRetryConfigError(t *testing.T) {
+	calls := 0
+	runOnce := func() error {
+		calls++
+		return errors.New("tofu init failed: exit status 1 | stderr: Error: Invalid provider requirements\n\nProvider \"registry.terraform.io/foo/bar\" is required but the given constraint \">= 99.0\" matches no versions")
+	}
+
+	err := retryTofuInit(context.Background(), runOnce, noopSleep, discardEmit)
+	if err == nil {
+		t.Fatal("expected the config error to be returned, got nil")
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 attempt for a non-transient config error (no retry), got %d", calls)
+	}
+	if !strings.Contains(err.Error(), "Invalid provider requirements") {
+		t.Fatalf("expected the original config error to surface, got: %v", err)
+	}
+}
+
+// TestRetryTofuInit_GivesUpAfterMaxAttempts asserts that a transient
+// failure which never clears stops after tofuInitMaxAttempts and returns
+// the last error (it does NOT loop forever).
+func TestRetryTofuInit_GivesUpAfterMaxAttempts(t *testing.T) {
+	calls := 0
+	runOnce := func() error {
+		calls++
+		return errors.New("Failed to install provider: 504 Gateway Timeout")
+	}
+
+	err := retryTofuInit(context.Background(), runOnce, noopSleep, discardEmit)
+	if err == nil {
+		t.Fatal("expected a terminal error after exhausting retries, got nil")
+	}
+	if calls != tofuInitMaxAttempts {
+		t.Fatalf("expected exactly %d attempts (bounded), got %d", tofuInitMaxAttempts, calls)
+	}
+}
+
+// TestRetryTofuInit_FirstAttemptSuccessNoRetry asserts the happy path
+// (warm plugin cache → init succeeds first try) does exactly one call
+// and never sleeps.
+func TestRetryTofuInit_FirstAttemptSuccessNoRetry(t *testing.T) {
+	calls := 0
+	slept := 0
+	runOnce := func() error { calls++; return nil }
+	sleep := func(time.Duration) { slept++ }
+
+	if err := retryTofuInit(context.Background(), runOnce, sleep, discardEmit); err != nil {
+		t.Fatalf("expected first-attempt success, got: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 attempt on the happy path, got %d", calls)
+	}
+	if slept != 0 {
+		t.Fatalf("expected zero backoff sleeps on the happy path, got %d", slept)
+	}
+}
+
+// TestRetryTofuInit_StopsOnCancelledContext asserts that once the
+// caller's context is cancelled we stop retrying instead of sleeping
+// through the remaining backoffs.
+func TestRetryTofuInit_StopsOnCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	runOnce := func() error {
+		calls++
+		// Cancel after the first failure so the retry loop sees a done
+		// context before the second attempt.
+		cancel()
+		return errors.New("Failed to install provider: connection reset by peer")
+	}
+
+	err := retryTofuInit(ctx, runOnce, noopSleep, discardEmit)
+	if err == nil {
+		t.Fatal("expected the last transient error to surface after context cancel, got nil")
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 attempt before honouring the cancelled context, got %d", calls)
+	}
+}
+
+// TestIsTransientInitFailure_Matrix locks the transient-vs-deterministic
+// classifier: every network/CDN-class marker must qualify for retry, and
+// a pure config error must NOT.
+func TestIsTransientInitFailure_Matrix(t *testing.T) {
+	transient := []string{
+		"Error: Failed to install provider",
+		"Failed to query available provider packages",
+		"could not query provider registry registry.terraform.io",
+		"504 Gateway Timeout",
+		"received 502 Bad Gateway from release-assets.githubusercontent.com",
+		"503 Service Unavailable",
+		"net/http: TLS handshake timeout",
+		"read tcp: i/o timeout",
+		"connection reset by peer",
+		"dial tcp: connect: connection refused",
+		"Temporary failure in name resolution",
+		"no such host",
+		"context deadline exceeded: timeout",
+		"unexpected EOF",
+		"failed to retrieve: checksum mismatch download interrupted",
+		"error fetching checksums",
+	}
+	for _, s := range transient {
+		if !isTransientInitFailure(s) {
+			t.Errorf("expected %q to be classified TRANSIENT (retryable), but it was not", s)
+		}
+	}
+
+	deterministic := []string{
+		"Error: Invalid provider requirements",
+		"Error: Unsupported argument",
+		"Error: Reference to undeclared input variable",
+		"Backend configuration changed: a migration is required",
+	}
+	for _, s := range deterministic {
+		if isTransientInitFailure(s) {
+			t.Errorf("expected %q to be classified DETERMINISTIC (no retry), but it matched a transient marker", s)
+		}
+	}
+}
+
+// TestNew_DefaultsTofuPluginCacheDir asserts New() defaults the plugin
+// cache to the persistent deployments-PVC path when the env is unset.
+func TestNew_DefaultsTofuPluginCacheDir(t *testing.T) {
+	t.Setenv("CATALYST_TF_PLUGIN_CACHE_DIR", "")
+	p := New()
+	if got, want := p.TofuPluginCacheDir, "/var/lib/catalyst/tofu-plugin-cache"; got != want {
+		t.Fatalf("default TofuPluginCacheDir = %q, want %q", got, want)
+	}
+}
+
+// TestNew_TofuPluginCacheDirOverride asserts the env var overrides the
+// default (docs/PRINCIPLES.md #4 — runtime-configurable, never hardcoded).
+func TestNew_TofuPluginCacheDirOverride(t *testing.T) {
+	t.Setenv("CATALYST_TF_PLUGIN_CACHE_DIR", "/mnt/iac/plugin-cache")
+	p := New()
+	if got, want := p.TofuPluginCacheDir, "/mnt/iac/plugin-cache"; got != want {
+		t.Fatalf("override TofuPluginCacheDir = %q, want %q", got, want)
+	}
+}
+
+// TestRunTofu_SetsPluginCacheEnv asserts that runTofu actually exports
+// TF_PLUGIN_CACHE_DIR (and creates the directory) when the Provisioner
+// carries a cache path. We exercise this by pointing the cache at a temp
+// dir and asserting the dir gets created; the `tofu` exec itself fails
+// fast (binary absent in CI) which is fine — the MkdirAll side effect is
+// what we assert, and it runs before exec.
+func TestRunTofu_CreatesPluginCacheDir(t *testing.T) {
+	tmp := t.TempDir()
+	cacheDir := tmp + "/plugin-cache"
+	p := &Provisioner{TofuPluginCacheDir: cacheDir}
+
+	// runTofu will try to exec `tofu` and almost certainly fail (no
+	// binary in the unit-test sandbox), but MkdirAll(cacheDir) happens
+	// BEFORE the exec, so the directory must exist afterwards regardless
+	// of the exec outcome.
+	_ = p.runTofu(context.Background(), tmp, []string{"version"}, discardEmit)
+
+	if fi, err := os.Stat(cacheDir); err != nil || !fi.IsDir() {
+		t.Fatalf("expected runTofu to create plugin cache dir %q, stat err=%v", cacheDir, err)
+	}
+}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,13 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.517 — #3126 (2026-06-08) — provisioner resilience to transient github
+# failures at tofu-init: catalyst-api now sets CATALYST_TF_PLUGIN_CACHE_DIR
+# (=/var/lib/catalyst/tofu-plugin-cache, a sibling subdir of the existing
+# tofu workdir on the persistent catalyst-api-deployments PVC) so OpenTofu
+# providers are fetched from github release-assets ONCE and reused on every
+# subsequent prov. Pairs with a Go-side retry-with-backoff on `tofu init`
+# (4 attempts, 5s/15s/45s, transient-network-only). No new volumeMount —
+# the cache lives on the already-mounted /var/lib/catalyst volume. Refs #3126.
 # 1.4.516 — #3122 (2026-06-08) — credential half: provisioning-github-token
 # now mirrors the REAL Gitea PAT (catalyst-gitea-token/token), not the gitea
 # admin PASSWORD. 1.4.514 fixed CATALYST_GITOPS_REPO_URL/BRANCH (env VALUES)
@@ -2573,7 +2581,7 @@ name: bp-catalyst-platform
 # CEL rule can never merge again. Bumping the pin so every Sovereign's
 # Flux helm-controller re-applies the corrected CRD (Flux reconciles
 # crds/ with CreateReplace, unlike raw `helm upgrade`). Refs #2936.
-version: 1.4.516
+version: 1.4.517
 appVersion: 1.4.494
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -309,6 +309,28 @@ spec:
             # provide write access to /var/lib/catalyst (PVC mountPath).
             - name: CATALYST_TOFU_WORKDIR
               value: /var/lib/catalyst/tofu
+            # CATALYST_TF_PLUGIN_CACHE_DIR — OpenTofu provider plugin cache
+            # (#3126). Exported as TF_PLUGIN_CACHE_DIR on every `tofu` exec
+            # so provider binaries (huaweicloud, hetznercloud, dynadot, ...)
+            # are downloaded from github release-assets ONCE and reused by
+            # every later prov. The catalyst-api uses a FRESH per-deployment
+            # workdir, so WITHOUT a shared cache every prov cold-downloads
+            # every provider from github — and a transient
+            # release-assets.githubusercontent.com CDN 504 (OpenTofu retries
+            # only 2× internally then aborts) fails the whole 2-region prov
+            # at `tofu init`. Caught live: the CDN edge returned intermittent
+            # 504s to the mothership.
+            #
+            # Sub-directory of the SAME catalyst PVC mount (/var/lib/catalyst,
+            # claim catalyst-api-deployments) that already backs the tofu
+            # workdir above — persistent across Pod rolls, no extra
+            # volumeMount needed. The provisioner MkdirAll's it before init.
+            # LITERAL value (dual-mode Helm/Kustomize contract — no Helm
+            # template directives in this file's `value:` fields; see the
+            # SOVEREIGN_FQDN block below). Runtime-overridable per
+            # docs/PRINCIPLES.md #4.
+            - name: CATALYST_TF_PLUGIN_CACHE_DIR
+              value: /var/lib/catalyst/tofu-plugin-cache
             # CATALYST_DEPLOYMENTS_DIR — flat-file store for deployment
             # records (one JSON file per deployment id). Backed by the
             # PVC mount below so deployments persist across Pod


### PR DESCRIPTION
## Root cause

OpenTofu providers are hosted as **binaries on github release-assets**. For huaweicloud, `tofu init` downloads the zip + `SHA256SUMS` + `.sig` from `github.com/huaweicloud/terraform-provider-huaweicloud/releases/download/...`, which **302-redirects to `release-assets.githubusercontent.com`** — a Fastly/Azure-Blob CDN. Tonight that CDN edge returned **intermittent 504s** to the mothership; OpenTofu retries only **2× internally** then aborts `tofu init`, failing the whole deployment.

The killer: the catalyst-api provisioner uses a **fresh per-deployment workdir with no provider cache**, so **every single prov re-downloaded every provider from github from scratch**. Any transient github / CDN blip therefore killed a full 2-region prov at init.

## The fix — two layers

**1. Provider cache (`TF_PLUGIN_CACHE_DIR`) — primary.**
The `Provisioner` now carries `TofuPluginCacheDir` (read at `New()` from `CATALYST_TF_PLUGIN_CACHE_DIR`, default `/var/lib/catalyst/tofu-plugin-cache`). `runTofu` `MkdirAll`s it and exports `TF_PLUGIN_CACHE_DIR` on **every** `tofu` exec (init/plan/apply/output/destroy). The path is a **sibling subdir of the existing tofu workdir** on the **persistent `catalyst-api-deployments` PVC** (already mounted at `/var/lib/catalyst`) — so **no new volumeMount**, and the cache survives Pod rolls + is shared across deployments. First prov downloads each provider once; every subsequent prov (any region/provider) reuses the cache with **zero github hits**. Empty value disables the cache (pre-#3126 behaviour) so air-gapped mirror operators are unaffected.

**2. Retry-with-backoff on `tofu init` — secondary.**
The single init call is now wrapped in `retryTofuInit` — **4 attempts, exponential backoff 5s / 15s / 45s** — that retries **only** on provider-install / network-class failures (`isTransientInitFailure` matches `Failed to install provider`, `504` / `Gateway Timeout`, `502`/`503`, `failed to retrieve`/`error fetching`, TLS/io timeouts, connection reset/refused, DNS blips, `EOF`), and **never** on deterministic config errors. This survives a short CDN blip even on a **cold** cache. `sleep` is injected for testability; the loop also bails early on a cancelled context.

## Chart

The catalyst-api Deployment gains the `CATALYST_TF_PLUGIN_CACHE_DIR` env (plain **literal** `value:` — dual-mode Helm/Kustomize contract, no template directives, RFC-1123-safe per the strategy-flip constraint; `api-deployment.yaml`'s gitops env block + resource names untouched). `Chart.yaml` `version` + bootstrap-kit slot-13 pin bumped **1.4.516 → 1.4.517** in lockstep.

## Tests

White-box unit tests (no real `tofu` exec — `runOnce` + `sleep` injected):
- `TestRetryTofuInit_RetriesTransientThenSucceeds` — 2 transient 504s then success → asserts retried + eventually succeeded (exactly 3 calls).
- `TestRetryTofuInit_DoesNotRetryConfigError` — `Invalid provider requirements` → asserts **1 call, no retry**, original error surfaced.
- `TestRetryTofuInit_GivesUpAfterMaxAttempts` — never-clearing transient → bounded at 4 attempts.
- `TestRetryTofuInit_FirstAttemptSuccessNoRetry` — warm cache happy path → 1 call, 0 sleeps.
- `TestRetryTofuInit_StopsOnCancelledContext` — cancelled ctx → stops retrying.
- `TestIsTransientInitFailure_Matrix` — locks the transient-vs-deterministic classifier (16 transient markers qualify; 4 config errors do not).
- `TestNew_DefaultsTofuPluginCacheDir` / `TestNew_TofuPluginCacheDirOverride` — default + env override.
- `TestRunTofu_CreatesPluginCacheDir` — `runTofu` creates the cache dir before exec.

```
$ go build ./...        # products/catalyst/bootstrap/api
BUILD EXIT: 0

$ go test ./...         # products/catalyst/bootstrap/api — full suite
ok  .../internal/provisioner            0.042s
ok  .../internal/handler                60.466s
ok  .../internal/helmwatch              15.598s
...  (all packages ok)
TEST EXIT: 0

$ helm template catalyst-platform .                                   # mothership
exit: 0   (5158 lines, no stderr)
$ helm template catalyst-platform . --set global.imageRegistry=...     # Sovereign
exit: 0   (5158 lines, no stderr)
  - name: CATALYST_TF_PLUGIN_CACHE_DIR
    value: /var/lib/catalyst/tofu-plugin-cache
```

## Where things live
- `TF_PLUGIN_CACHE_DIR` set in `products/catalyst/bootstrap/api/internal/provisioner/provisioner.go` `runTofu` (env append after `TF_IN_AUTOMATION`); path read in `New()`; persistent path `/var/lib/catalyst/tofu-plugin-cache` on PVC `catalyst-api-deployments`.
- Retry wrapper: `retryTofuInit` + `runTofuInitWithRetry` + `isTransientInitFailure` in the same file; called from `Provision` in place of the bare `runTofu(... "init" ...)`.

Refs #3126
