### PR TITLE
fix(prov): exp-backoff cloud-init github-CRD retries to survive sustained github incidents (#3129)

### DIFF
--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -905,22 +905,28 @@ runcmd:
       sleep 5
     done
     for crd in gatewayclasses gateways httproutes grpcroutes referencegrants; do
-      for attempt in 1 2 3 4 5; do
+      for attempt in 1 2 3 4 5 6 7 8 9 10; do
         if KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f \
           "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.0/config/crd/standard/gateway.networking.k8s.io_$${crd}.yaml"; then
           break
         fi
-        echo "G65: gateway-api CRD $${crd} apply attempt $${attempt}/5 failed; retrying in 5s"
-        sleep 5
+        # #3129: exponential backoff capped at 30s (~3.5min total over 10 tries)
+        # so a SUSTAINED raw.githubusercontent incident is survived instead of
+        # aborting cloud-init after ~25s (which fails Phase-1 / the kubeconfig PUT).
+        backoff=$$(( attempt * 5 )); [ $$backoff -gt 30 ] && backoff=30
+        echo "G65: gateway-api CRD $${crd} apply attempt $${attempt}/10 failed; retrying in $${backoff}s"
+        sleep $$backoff
       done
     done
-    for attempt in 1 2 3 4 5; do
+    for attempt in 1 2 3 4 5 6 7 8 9 10; do
       if KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f \
         "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.0/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml"; then
         break
       fi
-      echo "G65: tlsroutes CRD apply attempt $${attempt}/5 failed; retrying in 5s"
-      sleep 5
+      # #3129: exponential backoff capped at 30s, see the standard-CRD loop above.
+      backoff=$$(( attempt * 5 )); [ $$backoff -gt 30 ] && backoff=30
+      echo "G65: tlsroutes CRD apply attempt $${attempt}/10 failed; retrying in $${backoff}s"
+      sleep $$backoff
     done
     # G24 (Refs #2575, 2026-05-29): bpf.masquerade=true (line 736) is the
     # critical missing flag that was silently absent from Huawei's --set-
@@ -1105,23 +1111,27 @@ runcmd:
     done
     # Standard channel CRDs (Wave 5.19 + retry hardening from Wave 5.28).
     for crd in gatewayclasses gateways httproutes grpcroutes referencegrants; do
-      for attempt in 1 2 3 4 5; do
+      for attempt in 1 2 3 4 5 6 7 8 9 10; do
         if KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f \
           "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.0/config/crd/standard/gateway.networking.k8s.io_$${crd}.yaml"; then
           break
         fi
-        echo "CRD $${crd} apply attempt $${attempt}/5 failed; retrying in 5s"
-        sleep 5
+        # #3129: exponential backoff capped at 30s (see the pre-cilium seed block).
+        backoff=$$(( attempt * 5 )); [ $$backoff -gt 30 ] && backoff=30
+        echo "CRD $${crd} apply attempt $${attempt}/10 failed; retrying in $${backoff}s"
+        sleep $$backoff
       done
     done
     # Experimental channel — tlsroutes (Wave 5.23 Refs #2163) with Wave 5.28 retry.
-    for attempt in 1 2 3 4 5; do
+    for attempt in 1 2 3 4 5 6 7 8 9 10; do
       if KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f \
         "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.2.0/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml"; then
         break
       fi
-      echo "tlsroutes CRD apply attempt $${attempt}/5 failed; retrying in 5s"
-      sleep 5
+      # #3129: exponential backoff capped at 30s (see the pre-cilium seed block).
+      backoff=$$(( attempt * 5 )); [ $$backoff -gt 30 ] && backoff=30
+      echo "tlsroutes CRD apply attempt $${attempt}/10 failed; retrying in $${backoff}s"
+      sleep $$backoff
     done
     # Wave 5.89 (Refs #2434) — Cilium Envoy CRDs. cilium-agent on startup
     # blocks indefinitely waiting for `ciliumenvoyconfigs.cilium.io` +
@@ -1137,13 +1147,15 @@ runcmd:
     # repo breaks the race the same way Wave 5.19 broke the Gateway API
     # CRD race for bp-cilium.
     for crd in ciliumenvoyconfigs ciliumclusterwideenvoyconfigs; do
-      for attempt in 1 2 3 4 5; do
+      for attempt in 1 2 3 4 5 6 7 8 9 10; do
         if KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f \
           "https://raw.githubusercontent.com/cilium/cilium/v1.16.5/pkg/k8s/apis/cilium.io/client/crds/v2/$${crd}.yaml"; then
           break
         fi
-        echo "Cilium CRD $${crd} apply attempt $${attempt}/5 failed; retrying in 5s"
-        sleep 5
+        # #3129: exponential backoff capped at 30s (Cilium CRDs are also github-hosted).
+        backoff=$$(( attempt * 5 )); [ $$backoff -gt 30 ] && backoff=30
+        echo "Cilium CRD $${crd} apply attempt $${attempt}/10 failed; retrying in $${backoff}s"
+        sleep $$backoff
       done
     done
 


### PR DESCRIPTION
The huawei control-plane cloud-init applies gateway-api + Cilium envoy CRDs from raw.githubusercontent with a 5x flat-5s retry (~25s). A sustained github incident (like 2026-06-08's release-asset-CDN one) exhausts that and aborts cloud-init before the kubeconfig PUT → Phase-1 fail ('cluster did not PUT its kubeconfig', hw102's failure mode).

Fix: all 5 github-CRD retry loops (2 gateway-api seed blocks + the Cilium envoy-CRD pre-seed) lengthened from 5x flat-5s to 10x exponential backoff capped at 30s (~3.5min total). Pure retry-window change, no logic change. Companion to #3126/#3128 (which fixed the mothership tofu-init half). Refs #3129