### PR TITLE
fix(prov): reloader watches provisioning-github-token so catalyst-api picks up gitea PAT (#3122)

### DIFF
--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -85,8 +85,12 @@ metadata:
     # then fails the audience check with 401 "invalid audience" (caught live on
     # otech62, 2026-05-03). Reloader rolls the Deployment when those resources
     # land, fixing the race without requiring strict Flux dependsOn ordering.
+    # provisioning-github-token added (#3122): same pattern — the gitea-PAT mirror
+    # populates GITHUB_TOKEN only after the PAT mint (a later Flux reconcile), so the
+    # Pod must restart then to pick up CATALYST_GITOPS_TOKEN, else Org-creation
+    # (POST /sme/tenants) fails "gitops token unconfigured" (caught live hw104 2026-06-08).
     configmap.reloader.stakater.com/reload: "sovereign-fqdn"
-    secret.reloader.stakater.com/reload: "handover-jwt-public"
+    secret.reloader.stakater.com/reload: "handover-jwt-public,provisioning-github-token"
 spec:
   replicas: 1
   # Recreate strategy is required because the deployments PVC is RWO


### PR DESCRIPTION
Live #3122 verification on hw104 found the residual: #3123 (REPO_URL→local Gitea) works and the gitea PAT is minted (catalyst-gitea-token len=40), but provisioning-github-token/GITHUB_TOKEN renders empty until a later Flux reconcile (after the PAT mint), and catalyst-api reads CATALYST_GITOPS_TOKEN as a start-time secretKeyRef env. Reloader watched sovereign-fqdn + handover-jwt-public but NOT provisioning-github-token, so the Pod never restarted to pick up the populated token, and POST /sme/tenants fails 'gitops token unconfigured'.

Fix: add provisioning-github-token to secret.reloader.stakater.com/reload (same race-fix pattern as the existing entries). Annotation-value-only change, strategy-flip-safe. Refs #3122