### PR TITLE
fix(prov): runcmd sh rejects arithmetic-expansion — use expr (#3129); + wipe tfvars preserve (#3140)

### DIFF
--- a/infra/providers/huawei/cloudinit-control-plane.tftpl
+++ b/infra/providers/huawei/cloudinit-control-plane.tftpl
@@ -935,7 +935,7 @@ runcmd:
     # github, blowing the 15min kubeconfigArrivalTimeout so the kubeconfig PUT (~1348)
     # landed too late -> Phase-1 'did not PUT'. Cap the TOTAL seed at 120s + `timeout 20`
     # each apply; the kubeconfig PUT MUST win. Deferred CRDs are re-applied by Flux.
-    _gwnow=$$(date +%s); GW_CRD_DEADLINE=$$(( _gwnow + 120 ))
+    _gwnow=$$(date +%s); GW_CRD_DEADLINE=$$(expr $$_gwnow + 120)
     for crd in gatewayclasses gateways httproutes grpcroutes referencegrants; do
       for attempt in 1 2 3 4 5; do
         [ $$(date +%s) -ge $$GW_CRD_DEADLINE ] && { echo "G65: 120s gateway-CRD deadline hit; deferring to Flux (protects kubeconfig PUT, #3129)"; break 2; }
@@ -1140,7 +1140,7 @@ runcmd:
     # Standard channel CRDs (Wave 5.19 + retry hardening from Wave 5.28).
     # #3129 FIX: cap the TOTAL of this 2nd CRD section at 180s (deferred CRDs are
     # re-applied by Flux) so it cannot push the kubeconfig PUT past the 15min budget.
-    _gwnow2=$$(date +%s); GW_CRD_DEADLINE2=$$(( _gwnow2 + 180 ))
+    _gwnow2=$$(date +%s); GW_CRD_DEADLINE2=$$(expr $$_gwnow2 + 180)
     for crd in gatewayclasses gateways httproutes grpcroutes referencegrants; do
       for attempt in 1 2 3 4 5; do
         [ $$(date +%s) -ge $$GW_CRD_DEADLINE2 ] && { echo "G65: 180s CRD-section deadline hit; deferring to Flux (#3129)"; break 2; }

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1860,7 +1860,22 @@ func (p *Provisioner) Destroy(ctx context.Context, req Request, events chan<- Ev
 	if err := stageModule(modulePath, deployDir); err != nil {
 		return fmt.Errorf("stage tofu module: %w", err)
 	}
-	if err := writeTfvars(deployDir, req); err != nil {
+	// #3140: the wipe-time req is often reconstructed without the topology
+	// (regions/ssh_public_key/org_email/obs_bucket_name). Overwriting the
+	// complete provision-time tofu.auto.tfvars.json with it makes `tofu destroy`
+	// fail variable-validation, forcing the providerPurge fallback. For Huawei
+	// (creds are env-injected via CATALYST_HUAWEI_*, not the tfvars file), when
+	// req lacks the regions AND the complete file is already present, PRESERVE
+	// it instead of clobbering. Hetzner keeps the re-write (its token is
+	// re-prompted into req at wipe time). A partially-cleaned workdir (file
+	// removed) still falls through to writeTfvars.
+	tfvarsPath := filepath.Join(deployDir, "tofu.auto.tfvars.json")
+	_, tfvarsStatErr := os.Stat(tfvarsPath)
+	preserveExistingTfvars := strings.EqualFold(strings.TrimSpace(req.Provider), "huawei") &&
+		len(req.Regions) == 0 && tfvarsStatErr == nil
+	if preserveExistingTfvars {
+		emit("tofu-destroy", "info", "#3140: preserving complete provision-time tofu.auto.tfvars.json (wipe req lacks topology)")
+	} else if err := writeTfvars(deployDir, req); err != nil {
 		return fmt.Errorf("write tfvars: %w", err)
 	}
 


### PR DESCRIPTION
## #3129 root cause (git-confirmed) + fix

The cloud-init **runcmd runs under the image's /bin/sh**, which rejects **POSIX arithmetic expansion** (the dollar-double-paren form) with 'Syntax error: ( unexpected' — aborting the whole runcmd **before** the kubeconfig PUT, so the catalyst-api Phase-1 watch times out with 'did not PUT its kubeconfig'.

**git proof:** the first arithmetic-expansion ever added to this .tftpl was **#3130** (92b93d23) — exactly when the Phase-1 failures began. hw104 converged pre-#3130; hw105/106/107/108 all failed after. #3135/#3136 inherited the same construct (hw107 line 324, hw108 line 322 — identical 'runcmd: 74'). Command-substitution works (the readyz loop's seq runs); only arithmetic-expansion fails. bash + newer dash + busybox-ash all accept it, so bash -n missed it across 3 PRs — only the #3132 self-uploaded log caught it.

**Fix:** the 2 runcmd deadline SET lines compute via expr (command-sub + external binary) instead of arithmetic-expansion. The flux i*5 echo is in a systemd unit (separate shell), unaffected.

## #3140 (folded in)
Provisioner.Destroy re-wrote tofu.auto.tfvars.json from the wipe-time req (missing regions/ssh_key/org_email/obs_bucket_name) so tofu destroy failed validation, forcing the providerPurge fallback. Now preserves the complete provision-time file for Huawei when req lacks the topology.

Refs #3129 #3140