### PR TITLE
fix(prov): retry tofu apply on HuaweiCloud inconsistent-result flake (#3142)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1641,7 +1641,15 @@ func (p *Provisioner) Provision(ctx context.Context, req Request, events chan<- 
 			// just created but NAT API hasn't propagated it yet. The time_sleep
 			// resource in main.tf guards the canonical path; this catch handles
 			// any residual race (e.g. concurrent apply, slow HCS cell).
-			strings.Contains(errStr, "VPC.2030")
+			strings.Contains(errStr, "VPC.2030") ||
+			// #3142 (hw110 2026-06-08): HuaweiCloud provider read-after-create
+			// flake — "Provider produced inconsistent result after apply ... root
+			// object was present, but now absent" on compute_instance.worker. The
+			// instance IS created; the provider's post-apply read flaked. A re-plan
+			// reads it back and the re-apply reconciles (no-op or minor update);
+			// existing ACTIVE workers are name-protected by lifecycle.ignore_changes.
+			// hw110 died here with NO retry because this string wasn't matched.
+			strings.Contains(errStr, "Provider produced inconsistent result after apply")
 		if attempt < maxApplyRetries && isTransient {
 			// Wave 5.145 — early-abort detection. Extract resource
 			// addresses from the error string ("with huaweicloud_...


### PR DESCRIPTION
hw110 died at tofu apply on the HuaweiCloud provider read-after-create flake ('Provider produced inconsistent result after apply ... root object was present, but now absent') on two worker instances. The existing apply-retry matched HCS codes (Common.0021/EIP/VPC/VPC.2030) but not this provider-consistency string, so the prov got zero retries and failed at infrastructure before the cloud-init/Phase-1 (#3129/#3141) ran.

Fix: add the string to isTransient so the existing 6x re-plan+re-apply reconciles it (the worker IS created, readable on re-plan; ACTIVE workers name-protected by ignore_changes).

Refs #3142 #3129