### PR TITLE
fix(prov): stage _shared cloud-init sibling into tofu workdir (#3145 hw119 hotfix)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/provisioner/cloudinit_path_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/cloudinit_path_test.go
@@ -62,6 +62,38 @@ func readCloudInit(t *testing.T) string {
 	return string(raw)
 }
 
+// TestStageModule_StagesSharedSibling is the structural guard for #3145/#3146.
+// The cloud-init template references ${path.module}/../_shared/..., so the
+// provisioner MUST stage infra/providers/_shared/ as a sibling of the
+// per-deployment workdir — otherwise `tofu plan` fails with
+// "no file exists at ./../_shared/cloudinit-control-plane.tftpl" (caught LIVE
+// on hw119 2026-06-09, AFTER tofu test + the render harness passed, because
+// both run in-repo where _shared is already a sibling). Only staging like the
+// provisioner does catches this gap — hence this test.
+func TestStageModule_StagesSharedSibling(t *testing.T) {
+	providersDir := filepath.Dir(modulePath(t)) // <repo>/infra/providers
+	huaweiSrc := filepath.Join(providersDir, "huawei")
+	if _, err := os.Stat(huaweiSrc); err != nil {
+		t.Skipf("huawei module not found: %v", err)
+	}
+	work := t.TempDir()
+	deployDir := filepath.Join(work, "dep-test")
+	if err := os.MkdirAll(deployDir, 0o700); err != nil {
+		t.Fatalf("mkdir deployDir: %v", err)
+	}
+	if err := stageModule(huaweiSrc, deployDir); err != nil {
+		t.Fatalf("stageModule: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(deployDir, "main.tf")); err != nil {
+		t.Errorf("provider main.tf not staged into workdir: %v", err)
+	}
+	// _shared must land as a sibling of deployDir so ${path.module}/../_shared/ resolves.
+	shared := filepath.Join(work, "_shared", "cloudinit-control-plane.tftpl")
+	if _, err := os.Stat(shared); err != nil {
+		t.Errorf("#3145 regression: _shared not staged as workdir sibling (%s): %v — tofu plan would fail 'no file exists at ./../_shared/...'", shared, err)
+	}
+}
+
 // TestCloudInit_GitRepositoryIgnoreSelectsTemplate proves the
 // GitRepository's `spec.ignore` selects the shared `clusters/_template`
 // tree, NOT a per-FQDN directory. Issue #218's failure mode was the

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -2693,6 +2693,34 @@ func bumpRetryAttempt(deployDir string, newAttempt int) error {
 // .terraform/ + state, and so OpenTofu's working-directory model works as
 // expected.
 func stageModule(src, dst string) error {
+	if err := copyTfFiles(src, dst); err != nil {
+		return err
+	}
+	// #3145: the cloud-agnostic cloud-init lives in infra/providers/_shared/
+	// and each provider module references it via
+	// templatefile("${path.module}/../_shared/cloudinit-control-plane.tftpl").
+	// In-repo that resolves (sibling dir), but the per-deployment tofu workdir
+	// stages ONLY the provider module, so `../_shared/` would be missing at
+	// apply time (caught live on hw119: "no file exists at ./../_shared/..."").
+	// Stage _shared as a sibling of the workdir so the cross-module reference
+	// resolves identically in-repo and at prov time.
+	sharedSrc := filepath.Join(filepath.Dir(src), "_shared")
+	if fi, err := os.Stat(sharedSrc); err == nil && fi.IsDir() {
+		sharedDst := filepath.Join(filepath.Dir(dst), "_shared")
+		if err := os.MkdirAll(sharedDst, 0o700); err != nil {
+			return err
+		}
+		if err := copyTfFiles(sharedSrc, sharedDst); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// copyTfFiles copies the .tf/.tftpl files from src into dst (non-recursive),
+// skipping unchanged files. Shared by the provider-module + _shared staging
+// (#3145) so both go through one code path.
+func copyTfFiles(src, dst string) error {
 	entries, err := os.ReadDir(src)
 	if err != nil {
 		return err


### PR DESCRIPTION
Hotfix for #3146: the cloud-agnostic `_shared` template failed `tofu plan` on the first real prov (hw119) — `no file exists at ./../_shared/cloudinit-control-plane.tftpl`. The provisioner's `stageModule` copies only the provider module's own files into the isolated workdir, so the `${path.module}/../_shared/` cross-module reference was missing at apply time. tofu test + the render harness missed it because they run in-repo where `_shared` is already a sibling.

Fix: `stageModule` now also stages `infra/providers/_shared/` as a sibling of the workdir (via a shared `copyTfFiles` helper). Structural guard `TestStageModule_StagesSharedSibling` stages like the provisioner and asserts `_shared` lands — catches exactly this class. Build + provisioner tests green.

Refs #3145