### PR TITLE
fix(kyverno): make webhook-gate non-fatal — stop the serving-layer cascade (#3145)

### DIFF
--- a/clusters/_template/bootstrap-kit/27-kyverno.yaml
+++ b/clusters/_template/bootstrap-kit/27-kyverno.yaml
@@ -68,7 +68,7 @@ spec:
       # closes META-AUDIT 1 sub-class 3 — kyverno admission webhook
       # registered before kyverno-svc Pod ready blocks own Secret CREATE
       # via failurePolicy: Fail. Verified deadlock on hw62 v14 06:11Z.
-      version: 1.3.5
+      version: 1.3.6
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno/blueprint.yaml
+++ b/platform/kyverno/blueprint.yaml
@@ -8,7 +8,8 @@ spec:
   # 1.3.0 (TBD-V53 #2128): Cold-start race fix — cert-manager-issued TLS
   # + extraInitContainer that blocks main container until the secret is
   # populated. See platform/kyverno/chart/Chart.yaml for the full rationale.
-  version: 1.3.5
+  # 1.3.6 (#3149): webhook-gate non-fatal — no more fatal-hook→stuck-uninstall cascade.
+  version: 1.3.6
   card:
     title: Kyverno
     family: guardian

--- a/platform/kyverno/chart/Chart.yaml
+++ b/platform/kyverno/chart/Chart.yaml
@@ -17,7 +17,14 @@ type: application
 # an extraInitContainer blocks the main container until the secret has a
 # populated tls.crt. Eliminates the apiserver→webhook TLS handshake EOF
 # that wedged bootstrap-kit on every fresh-prov Sovereign.
-version: 1.3.5
+# 1.3.6 (#3149): webhook-gate is now NON-FATAL on timeout (exit 0, not exit 1).
+# A fatal gate triggered Flux install-remediation → uninstall → kyverno's own
+# webhook blocks its deletion → HR stuck → bootstrap-kit never holds →
+# sovereign-tls blocked → console 000 (hw07/hw08/hw62/hw93/hw95/hw123). The
+# gate stays a slow-warm DETECTOR (waits the full budget, logs loudly) but
+# never wedges the cluster; downstream admission-needers gate on their own
+# cert-wait + G50 retries. This is the "DEEPER FIX still owed" from the G54 header.
+version: 1.3.6
 appVersion: "v1.18.0"
 keywords: [catalyst, blueprint, kyverno, policy, admission, security]
 maintainers:

--- a/platform/kyverno/chart/templates/webhook-gate-hook.yaml
+++ b/platform/kyverno/chart/templates/webhook-gate-hook.yaml
@@ -179,7 +179,8 @@ spec:
                 echo "Attempt ${attempt}: endpoints=${ep_count} tls_crt_len=${tls_len}; sleeping ${INTERVAL_SECONDS}s."
                 sleep "${INTERVAL_SECONDS}"
               done
-              echo "FATAL: kyverno self-referential gate did not clear within ${TIMEOUT_SECONDS}s." >&2
+              echo "WARNING: kyverno self-referential gate did not clear within ${TIMEOUT_SECONDS}s — proceeding NON-FATALLY (#3149)." >&2
+              echo "Rationale (the DEEPER FIX the G54 header called for): a fatal exit here makes Helm mark the post-install/upgrade FAILED → Flux install-remediation UNINSTALLS → kyverno's own admission webhook (failurePolicy: Fail) blocks deletion of its resources → HR stuck StateError 'uninstalling', unrecoverable → the last HRs never all-Ready so bootstrap-kit never holds stable → sovereign-tls blocked → Gateway never Programmed → console 000 (hw07/hw08/hw62/hw93/hw95/hw123). That cascade is STRICTLY WORSE than letting bp-kyverno go Ready while kyverno finishes warming: downstream admission-needing HRs (bp-cnpg + dependents) gate on their OWN cert-wait + G50 retries, so a not-yet-serving kyverno is absorbed by retry, NOT by failing this hook. The gate stays a slow-warm DETECTOR (it still waits up to the full budget and logs loudly), but never a cluster-wedging fatal." >&2
               echo "Diagnose with:" >&2
               echo "  kubectl -n ${WEBHOOK_NS} get pods -l app.kubernetes.io/component=admission-controller" >&2
               echo "  kubectl -n ${WEBHOOK_NS} get endpoints ${WEBHOOK_SVC}" >&2
@@ -188,5 +189,5 @@ spec:
               echo "  kubectl get certificaterequest -n ${WEBHOOK_NS}" >&2
               echo "" >&2
               echo "Self-referential bootstrap deadlock hint: if Pods CrashLoopBackOff on missing Secret, cert-manager may be unable to CREATE the Secret because the Kyverno admission webhook itself is blocking Secret admissions (failurePolicy: Fail). Check whether cert-manager queue is jammed with CertificateRequests Ready=True but Secret never written cluster-wide." >&2
-              exit 1
+              exit 0
 {{- end }}


### PR DESCRIPTION
The fatal kyverno webhook-gate hook (backoffLimit:0, exit 1) is the root cause of recurring `console 000` on cold provs (hw07/hw08/hw62/hw93/hw95/hw123). On a slow kyverno warm-up the gate fails → Flux remediation uninstalls → kyverno's own webhook blocks its deletion → HR stuck → bootstrap-kit never holds → `sovereign-tls` (wildcard cert + LB-IPAM pool + gateway nodePort pin + coredns DNS-01 override) blocked → Gateway never Programmed → 000.

Fix = the documented 'DEEPER FIX still owed' from the G54 header: gate is now **non-fatal** (exit 0 on timeout, still waits the full budget + logs loudly). Downstream admission-needers retry, so the race is absorbed, never wedging. chart 1.3.5→1.3.6. Refs #3145