### PR TITLE
fix(prov): janitor must not reap the _shared cloud-init staging dir (#3145)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/janitor.go
+++ b/products/catalyst/bootstrap/api/internal/handler/janitor.go
@@ -598,6 +598,15 @@ func (h *Handler) cleanOrphanTofuWorkdirs(tofuWorkDir string, activeIDs map[stri
 			continue
 		}
 		id := e.Name()
+		// #3147/#3151: `_shared` is the cloud-agnostic cloud-init staging dir
+		// (a sibling of every per-deployment workdir, staged by stageModule so
+		// the `${path.module}/../_shared/` templatefile reference resolves at
+		// apply time), NOT an orphaned deployment. Deployment IDs are hex;
+		// reserved dirs are underscore-prefixed. Reaping `_shared` races the
+		// next prov's tofu plan into a "no file at ./../_shared/..." failure.
+		if strings.HasPrefix(id, "_") {
+			continue
+		}
 		if _, ok := activeIDs[id]; ok {
 			continue
 		}

--- a/products/catalyst/bootstrap/api/internal/handler/janitor_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/janitor_test.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCleanOrphanTofuWorkdirs_PreservesSharedAndActive — #3151: the janitor
+// must NOT reap the `_shared` cloud-agnostic cloud-init staging dir (#3147,
+// a sibling of every per-deployment workdir). Reaping it races the next
+// prov's tofu plan into a "no file exists at ./../_shared/..." failure
+// (observed live: hw123 wipe → `[JANITOR] orphan tofu workdir deleted: _shared`).
+// It must still preserve active deployment workdirs and reap genuine orphans.
+func TestCleanOrphanTofuWorkdirs_PreservesSharedAndActive(t *testing.T) {
+	work := t.TempDir()
+	for _, d := range []string{"_shared", "deadbeefcafe1234", "abc123activedep"} {
+		if err := os.MkdirAll(filepath.Join(work, d), 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	active := map[string]struct{}{"abc123activedep": {}}
+	deleted := h.cleanOrphanTofuWorkdirs(work, active)
+
+	mustExist := func(name string) {
+		t.Helper()
+		if _, err := os.Stat(filepath.Join(work, name)); err != nil {
+			t.Errorf("%s should be preserved, but: %v", name, err)
+		}
+	}
+	mustGone := func(name string) {
+		t.Helper()
+		if _, err := os.Stat(filepath.Join(work, name)); err == nil {
+			t.Errorf("%s should have been reaped", name)
+		}
+	}
+	mustExist("_shared")         // reserved staging dir — NEVER reaped
+	mustExist("abc123activedep") // active deployment — preserved
+	mustGone("deadbeefcafe1234") // genuine orphan — reaped
+	if deleted != 1 {
+		t.Errorf("expected 1 reap (the orphan only), got %d", deleted)
+	}
+}


### PR DESCRIPTION
Caught during the hw123 wipe — `[JANITOR] orphan tofu workdir deleted: _shared`. The janitor's `cleanOrphanTofuWorkdirs` reaps any tofu-workdir sub-dir that isn't an active deployment ID; #3147's `_shared` staging dir (sibling of every per-deployment workdir) isn't one, so it got deleted. Benign steady-state (re-staged per prov) but a **latent race**: a janitor pass inside a prov's tofu-plan window deletes `_shared` → `no file exists at ./../_shared/...` → intermittent prov failure. Fix: never reap underscore-prefixed dirs + guard test. Refs #3145