### PR TITLE
fix(console): provisioning jobs labelled 'Provision Hetzner' on every cloud (#3145)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/components/LogPane.fallback.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/LogPane.fallback.test.tsx
@@ -46,7 +46,7 @@ describe('LogPane — Bug #481 fallbackLines path', () => {
       <LogPane
         executionId={null}
         fallbackLines={SAMPLE_LINES}
-        jobTitle="Provision Hetzner — terraform init"
+        jobTitle="Provision infrastructure — terraform init"
         statusLabel="Succeeded"
         statusTone="succeeded"
         onClose={() => {}}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/jobs.ts
@@ -79,12 +79,15 @@ export interface Job {
   noAppLink: boolean
 }
 
+// #3152: provider-agnostic labels — the same OpenTofu jobs run for every
+// cloud (Hetzner, Huawei, AWS, …) under the cloud-agnostic model, so the UI
+// must NOT hardcode "Hetzner" (it mislabelled live Huawei provs as Hetzner).
 const TOFU_PHASE_LABELS: Record<string, string> = {
-  'tofu-init':   'Provision Hetzner — terraform init',
-  'tofu-plan':   'Provision Hetzner — terraform plan',
-  'tofu-apply':  'Provision Hetzner — terraform apply',
-  'tofu-output': 'Provision Hetzner — terraform output',
-  'tofu':        'Provision Hetzner — runtime events',
+  'tofu-init':   'Provision infrastructure — terraform init',
+  'tofu-plan':   'Provision infrastructure — terraform plan',
+  'tofu-apply':  'Provision infrastructure — terraform apply',
+  'tofu-output': 'Provision infrastructure — terraform output',
+  'tofu':        'Provision infrastructure — runtime events',
 }
 
 /** Derive Job UI status from an Application status enum. */

--- a/products/catalyst/bootstrap/ui/src/test/fixtures/jobs.fixture.ts
+++ b/products/catalyst/bootstrap/ui/src/test/fixtures/jobs.fixture.ts
@@ -45,7 +45,7 @@ import {
 const LEAVES: Job[] = [
   {
     id: 'job-tofu-init',
-    jobName: 'Provision Hetzner — terraform init',
+    jobName: 'Provision infrastructure — terraform init',
     type: 'install',
     appId: 'infrastructure',
     parentId: GROUP_PHASE_0,
@@ -58,7 +58,7 @@ const LEAVES: Job[] = [
   },
   {
     id: 'job-tofu-plan',
-    jobName: 'Provision Hetzner — terraform plan',
+    jobName: 'Provision infrastructure — terraform plan',
     type: 'install',
     appId: 'infrastructure',
     parentId: GROUP_PHASE_0,
@@ -71,7 +71,7 @@ const LEAVES: Job[] = [
   },
   {
     id: 'job-tofu-apply',
-    jobName: 'Provision Hetzner — terraform apply',
+    jobName: 'Provision infrastructure — terraform apply',
     type: 'install',
     appId: 'infrastructure',
     parentId: GROUP_PHASE_0,
@@ -84,7 +84,7 @@ const LEAVES: Job[] = [
   },
   {
     id: 'job-tofu-output',
-    jobName: 'Provision Hetzner — terraform output',
+    jobName: 'Provision infrastructure — terraform output',
     type: 'install',
     appId: 'infrastructure',
     parentId: GROUP_PHASE_0,


### PR DESCRIPTION
The provisioning jobs view hardcoded `'Provision Hetzner — terraform …'` in `TOFU_PHASE_LABELS` — so a live **Huawei** prov (hw124, me-east-215) showed 'Provision Hetzner'. A per-cloud string on a cloud-agnostic surface. Fix: provider-agnostic 'Provision infrastructure — …'. Fixtures + LogPane prop updated. Refs #3145