### PR TITLE
fix(catalyst-api): resume Phase-1 watch off conventional kubeconfig path after a roll (#3153)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -670,10 +671,7 @@ func (h *Handler) releaseOrphanedReservation(deploymentID, poolDomain, subdomain
 // resume is the safer-default action because the helmwatch is
 // idempotent (it just observes HelmRelease.status).
 func (h *Handler) shouldResumePhase1(dep *Deployment, rec store.Record) bool {
-	if dep.Result == nil || dep.Result.KubeconfigPath == "" {
-		return false
-	}
-	if dep.Result.Phase1FinishedAt != nil {
+	if dep.Result != nil && dep.Result.Phase1FinishedAt != nil {
 		return false
 	}
 	// Phase-0 in-flight statuses are rewritten to "failed" by
@@ -685,9 +683,32 @@ func (h *Handler) shouldResumePhase1(dep *Deployment, rec store.Record) bool {
 	if isPhase0InFlightStatus(rec.Status) {
 		return false
 	}
-	if _, err := os.Stat(dep.Result.KubeconfigPath); err != nil {
+	// #3153: resolve the kubeconfig path with a CONVENTIONAL fallback.
+	// Result.KubeconfigPath carries json `omitempty` and can be lost on a
+	// rehydrated record when a mothership roll persists the deployment
+	// before PutKubeconfig stamped the path — but the kubeconfig FILE itself
+	// survives on the PVC at <kubeconfigsDir>/<id>.yaml. Without this
+	// fallback the resume is skipped and the operator goes permanently blind
+	// to convergence after ANY catalyst-api roll (image bump, OOM, node
+	// maintenance). Resuming read-only is harmless; skipping it is the bug.
+	kubeconfigPath := ""
+	if dep.Result != nil {
+		kubeconfigPath = dep.Result.KubeconfigPath
+	}
+	if kubeconfigPath == "" && h.kubeconfigsDir != "" {
+		kubeconfigPath = filepath.Join(h.kubeconfigsDir, dep.ID+".yaml")
+	}
+	if kubeconfigPath == "" {
 		return false
 	}
+	if _, err := os.Stat(kubeconfigPath); err != nil {
+		return false
+	}
+	// Make sure the resumed watch + StreamLogs see the resolved path.
+	if dep.Result == nil {
+		dep.Result = &provisioner.Result{}
+	}
+	dep.Result.KubeconfigPath = kubeconfigPath
 	return true
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/deployments_resume_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments_resume_test.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+// TestShouldResumePhase1_ConventionalKubeconfigFallback is the #3153 guard:
+// after a mothership roll the rehydrated record can lose Result.KubeconfigPath
+// (json `omitempty`), but the kubeconfig FILE survives on the PVC. The Phase-1
+// watch MUST still resume off the conventional path — otherwise a single roll
+// blinds the operator to convergence for the rest of the prov.
+func TestShouldResumePhase1_ConventionalKubeconfigFallback(t *testing.T) {
+	dir := t.TempDir()
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil)), kubeconfigsDir: dir}
+	rec := store.Record{Status: "phase1-watching"}
+
+	// (1) Result == nil (path omitted entirely) but the kubeconfig file exists
+	//     on the PVC → MUST resume, and must stamp the resolved path so the
+	//     watch + StreamLogs can use it.
+	id := "90a98a78f35846a3"
+	want := filepath.Join(dir, id+".yaml")
+	if err := os.WriteFile(want, []byte("apiVersion: v1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dep := &Deployment{ID: id}
+	if !h.shouldResumePhase1(dep, rec) {
+		t.Fatalf("#3153 regression: expected resume via conventional kubeconfig fallback, got false")
+	}
+	if dep.Result == nil || dep.Result.KubeconfigPath != want {
+		t.Errorf("resume must stamp the resolved kubeconfig path; got %+v", dep.Result)
+	}
+
+	// (2) No kubeconfig file anywhere → must NOT resume.
+	if h.shouldResumePhase1(&Deployment{ID: "deadbeefdeadbeef"}, rec) {
+		t.Errorf("must NOT resume when no kubeconfig file exists")
+	}
+
+	// (3) Phase-0 in-flight → never resumable, even if a file happens to exist.
+	p0 := "p0p0p0p0p0p0p0p0"
+	if err := os.WriteFile(filepath.Join(dir, p0+".yaml"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if h.shouldResumePhase1(&Deployment{ID: p0}, store.Record{Status: "tofu-applying"}) {
+		t.Errorf("must NOT resume a phase-0-in-flight deployment")
+	}
+}


### PR DESCRIPTION
Restores provisioning-convergence visibility after a mothership roll. `shouldResumePhase1` gated the watch resume on `Result.KubeconfigPath`, which carries `omitempty` and is lost on a rehydrated record when the roll persists before PutKubeconfig stamps it → resume skipped → operator blind for the rest of the prov. Fix: conventional-path fallback (`<kubeconfigsDir>/<id>.yaml`) + stamp the resolved path. Additive, guard-tested. **Do not merge until the active hw124 prov converges** (merging rolls the mothership). Refs #3145 #3153