### PR TITLE
fix(marketplace): scope Sandbox plans out of the generic plan picker (#3156)

### DIFF
--- a/core/marketplace/src/lib/api.ts
+++ b/core/marketplace/src/lib/api.ts
@@ -108,7 +108,13 @@ async function tryRefresh(): Promise<void> {
 // and must NOT duplicate into this Org-provisioning picker (#3156).
 export const getPlans = async (): Promise<Plan[]> => {
   const raw = await request<any[]>('/catalog/plans?product=generic');
-  return raw.map(p => ({
+  return raw
+    // Safety net: drop any product-scoped row client-side too, so the
+    // picker stays generic-only even against an older catalog-service
+    // that doesn't yet honour ?product= (#3156). product_slug is omitted
+    // (omitempty) for generic tiers, so falsy === keep.
+    .filter(p => !p.product_slug)
+    .map(p => ({
     id: p.id,
     slug: p.slug || p.name?.toLowerCase() || '',
     name: p.name,

--- a/core/marketplace/src/lib/api.ts
+++ b/core/marketplace/src/lib/api.ts
@@ -103,8 +103,11 @@ async function tryRefresh(): Promise<void> {
 }
 
 // Catalog
+// Scope to generic compute tiers (S/M/L/XL/Flexi). Product-scoped plans
+// (e.g. Sandbox Free/Pro/Ent, ProductSlug="sandbox") have their own flow
+// and must NOT duplicate into this Org-provisioning picker (#3156).
 export const getPlans = async (): Promise<Plan[]> => {
-  const raw = await request<any[]>('/catalog/plans');
+  const raw = await request<any[]>('/catalog/plans?product=generic');
   return raw.map(p => ({
     id: p.id,
     slug: p.slug || p.name?.toLowerCase() || '',

--- a/core/services/catalog/handlers/handlers.go
+++ b/core/services/catalog/handlers/handlers.go
@@ -234,15 +234,49 @@ func (h *Handler) GetBundle(w http.ResponseWriter, r *http.Request) {
 // Public — Plans
 // ---------------------------------------------------------------------------
 
-// ListPlans returns all plans.
+// ListPlans returns plans, optionally scoped by product via ?product=.
+//
+//	GET /catalog/plans                  — every plan (back-compat: the
+//	                                      tenant service's GetPlan walks
+//	                                      this list to resolve a plan by
+//	                                      slug, including the sandbox-*
+//	                                      tiers — see core/services/tenant/
+//	                                      catalog/client.go). Changing the
+//	                                      default would break sandbox
+//	                                      checkout with "plan_id not found".
+//	GET /catalog/plans?product=generic  — only unscoped compute tiers
+//	                                      (ProductSlug==""); the marketplace
+//	                                      Org-provisioning picker uses this
+//	                                      so product-scoped tiers (e.g.
+//	                                      Sandbox Free/Pro/Ent) do not
+//	                                      duplicate alongside S/M/L/XL/Flexi.
+//	GET /catalog/plans?product=sandbox  — only the Sandbox product tiers.
 func (h *Handler) ListPlans(w http.ResponseWriter, r *http.Request) {
 	plans, err := h.Store.ListPlans(r.Context())
 	if err != nil {
 		respond.Error(w, http.StatusInternalServerError, "failed to list plans")
 		return
 	}
+	plans = filterPlansByProduct(plans, r.URL.Query().Get("product"))
 	w.Header().Set("Cache-Control", "public, max-age=300")
 	respond.OK(w, plans)
+}
+
+// filterPlansByProduct scopes a plan list by the ?product= query value.
+// An empty product returns the list unchanged (back-compat). The reserved
+// keyword "generic" selects the unscoped compute tiers (ProductSlug=="");
+// any other value matches Plan.ProductSlug verbatim.
+func filterPlansByProduct(plans []store.Plan, product string) []store.Plan {
+	if product == "" {
+		return plans
+	}
+	filtered := make([]store.Plan, 0, len(plans))
+	for _, p := range plans {
+		if (product == "generic" && p.ProductSlug == "") || p.ProductSlug == product {
+			filtered = append(filtered, p)
+		}
+	}
+	return filtered
 }
 
 // ---------------------------------------------------------------------------

--- a/core/services/catalog/handlers/plans_filter_test.go
+++ b/core/services/catalog/handlers/plans_filter_test.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/openova-io/openova/core/services/catalog/store"
+)
+
+// TestFilterPlansByProduct guards the ?product= scoping that keeps
+// product-scoped tiers (Sandbox Free/Pro/Ent) out of the generic
+// Org-provisioning plan picker while preserving the unfiltered default
+// the tenant service's GetPlan slug-walk depends on (#3156).
+func TestFilterPlansByProduct(t *testing.T) {
+	plans := []store.Plan{
+		{Slug: "s", ProductSlug: ""},
+		{Slug: "m", ProductSlug: ""},
+		{Slug: "l", ProductSlug: ""},
+		{Slug: "xl", ProductSlug: ""},
+		{Slug: "flexi", ProductSlug: ""},
+		{Slug: "sandbox-free", ProductSlug: "sandbox"},
+		{Slug: "sandbox-pro", ProductSlug: "sandbox"},
+		{Slug: "sandbox-ent", ProductSlug: "sandbox"},
+	}
+
+	// Empty product → unchanged. The tenant service's GetPlan walks this
+	// full list to resolve a sandbox-* slug; filtering the default would
+	// break sandbox checkout with "plan_id not found".
+	if got := filterPlansByProduct(plans, ""); len(got) != len(plans) {
+		t.Fatalf(`product="" len = %d, want %d (back-compat)`, len(got), len(plans))
+	}
+
+	// generic → only unscoped compute tiers (what the marketplace picker
+	// requests). No sandbox row may leak.
+	generic := filterPlansByProduct(plans, "generic")
+	if len(generic) != 5 {
+		t.Fatalf("product=generic len = %d, want 5", len(generic))
+	}
+	for _, p := range generic {
+		if p.ProductSlug != "" {
+			t.Errorf("generic filter leaked product-scoped plan %q (ProductSlug=%q)", p.Slug, p.ProductSlug)
+		}
+	}
+
+	// sandbox → only the Sandbox product tiers.
+	sandbox := filterPlansByProduct(plans, "sandbox")
+	if len(sandbox) != 3 {
+		t.Fatalf("product=sandbox len = %d, want 3", len(sandbox))
+	}
+	for _, p := range sandbox {
+		if p.ProductSlug != "sandbox" {
+			t.Errorf("sandbox filter leaked %q (ProductSlug=%q)", p.Slug, p.ProductSlug)
+		}
+	}
+
+	// Unknown product → empty, never a panic.
+	if got := filterPlansByProduct(plans, "nope"); len(got) != 0 {
+		t.Errorf("product=nope len = %d, want 0", len(got))
+	}
+}


### PR DESCRIPTION
## Problem
The marketplace `/plans/` Org-provisioning picker renders **8 plans**: the 5 generic compute tiers (S/M/L/XL/Flexi) **plus** the 3 Sandbox product tiers (Sandbox Free/Pro/Ent). The Sandbox tiers visually duplicate the compute tiers (Sandbox Pro 2vCPU/4GB ≈ S; Sandbox Ent 8vCPU/16GB ≈ L) and don't belong in the generic picker.

## Root cause
`store.Plan.ProductSlug` already separates generic (`""`) from product-scoped (`"sandbox"`) plans — the field was **added specifically so the picker could filter by product** (documented in `seed_test.go: TestExpectedSandboxPlans_Shape`) — but the filter was never wired in. `ListPlans` returned every plan unfiltered and the storefront rendered all of them.

## Fix
Opt-in `?product=` scope on `GET /catalog/plans` (**default unchanged** so the tenant service's `GetPlan` slug-walk in `tenant/catalog/client.go` still resolves `sandbox-*` slugs — deleting rows or changing the default would break sandbox checkout):

| Request | Returns |
|---|---|
| `/catalog/plans` | all plans (back-compat) |
| `/catalog/plans?product=generic` | only S/M/L/XL/Flexi (`ProductSlug==""`) |
| `/catalog/plans?product=sandbox` | only Sandbox Free/Pro/Ent |

Storefront `getPlans()` now requests `?product=generic`.

## Why not delete the Sandbox rows
`sandbox_consumer.go` stamps the customer-picked sandbox slug onto the Sandbox CR; `GetPlan(slug)` walks the unfiltered list to resolve it. The rows must stay — they just shouldn't appear in the generic Org-provisioning picker.

## Tests
- `TestFilterPlansByProduct` — empty→8, generic→5 (no sandbox leak), sandbox→3, unknown→0
- `TestExpectedSandboxPlans_Shape` still green (ProductSlug contract intact)
- `go build ./...` clean in the catalog module

## Verification (post-deploy on a live Sovereign)
- [ ] `/api/catalog/plans?product=generic` → 5 rows
- [ ] `/api/catalog/plans?product=sandbox` → 3 rows
- [ ] `/api/catalog/plans` → 8 rows (unchanged)
- [ ] marketplace `/plans/` shows only S/M/L/XL/Flexi

Refs #3156

🤖 Generated with [Claude Code](https://claude.com/claude-code)