### PR TITLE
fix(ui): drop unused appUID binding in OverviewPanel — unblocks #3150 deploy build

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
@@ -1092,7 +1092,11 @@ function OverviewPanel({
   appPrimaryRegion,
   appLastReconciled,
   appExternalURL,
-  appUID,
+  // appUID stays in OverviewPanelProps (passed by the parent for type
+  // symmetry) but is intentionally NOT destructured here: the Launch
+  // button now keys on `launchKey` (#3150), which equals appUID for
+  // CR-backed apps and the blueprint/release name for bootstrap-kit HR
+  // apps. Binding appUID without using it trips the build's noUnusedLocals.
   launchKey,
   isServiceApp,
   compState,


### PR DESCRIPTION
The #3150 merge (eece3ada) broke the production UI image build: `OverviewPanel` destructured `appUID` but the Launch button now keys on `launchKey`, so `appUID` was unused → `tsc -b` (noUnusedLocals) failed with TS6133. Local `tsc --noEmit` did not flag it; the build tsconfig is stricter.

Fix: drop the unused `appUID` destructure binding (prop stays in `OverviewPanelProps`, parent still passes it). `tsc -b` clean, 28 AppDetail tests pass.

This unblocks the deploy-bot from publishing the catalyst-api/ui images carrying the #3150 silent-SSO fix so hw124 can be rolled.

Refs #3150

🤖 Generated with [Claude Code](https://claude.com/claude-code)