### PR TITLE
fix(crd): add ssoInitPath to Blueprint endpoint schema — unprune silent-SSO launch (#3150)

### DIFF
--- a/docs/sessions/2026-06-09/sso-pathfinder-grafana.md
+++ b/docs/sessions/2026-06-09/sso-pathfinder-grafana.md
@@ -57,6 +57,22 @@ Two files, BOTH required:
 
 > 🔑 **Replication gotcha #1:** the in-cluster Blueprint CR is what the launch-url reads. For apps seeded by `catalog-seed/blueprints.yaml` (grafana, keycloak, guacamole, …) you MUST edit that file (coordinate with the catalog agent). For apps whose CR comes from elsewhere (harbor, openbao, powerdns-admin, netbird are NOT in catalog-seed today — see §5), find where their Blueprint CR is sourced first (`kubectl get blueprints.catalyst.openova.io <name> -o yaml` shows `metadata.annotations` / `managedFields` pointing at the owner).
 
+### 2c-bis. ⚠️ CRD schema — `ssoInitPath` MUST be in the Blueprint CRD (else it's pruned)
+
+**The pathfinder MISSED this and it broke the live walk.** `Blueprint`'s endpoint schema in `products/catalyst/chart/crds/blueprint.yaml` is structural with NO `x-kubernetes-preserve-unknown-fields`. If `ssoInitPath` is not declared in the CRD, the API server **prunes** it on every apply — the seed ships it, Helm applies it, the **live CR silently loses it**, and `buildLaunchURL` falls back to the legacy app-root URL. The launch-url returns the OLD shape and the app shows its login form, with NO error anywhere.
+
+**FIXED in #3163:** `ssoInitPath` added beside `ssoEnabled` in the shared (anchored) endpoint schema → covers BOTH `v1` and `v1alpha1`. **The 6 follow-on agents do NOT touch the CRD again — it's done once for all apps.**
+
+**BUT — existing Sovereigns need a direct CRD apply.** Helm `crds/` are **install-only**; a chart upgrade does NOT update the CRD. So on hw124 (and any existing Sovereign) you MUST run, once:
+```bash
+kubectl --kubeconfig /tmp/hw124.kubeconfig apply -f products/catalyst/chart/crds/blueprint.yaml
+```
+Then the seed CR's `ssoInitPath` stops being pruned. **Verify it persisted** before trusting the launch-url:
+```bash
+kubectl get blueprints.catalyst.openova.io bp-<app> -o json | python3 -c "import sys,json;print([e.get('ssoInitPath') for e in json.load(sys.stdin)['spec']['endpoints'] if e.get('name')=='ui'])"
+# must print your path, not [None]
+```
+
 ### 2d. Contract — `docs/api/catalyst-api-openapi.yaml`
 
 Added `ssoInitPath` to `EndpointDeclaration` and documented the launch-url's dual-id resolution (uid OR blueprint name) + the two URL shapes.

--- a/products/catalyst/chart/crds/blueprint.yaml
+++ b/products/catalyst/chart/crds/blueprint.yaml
@@ -568,6 +568,16 @@ spec:
                         type: boolean
                       ssoEnabled:
                         type: boolean
+                      ssoInitPath:
+                        type: string
+                        maxLength: 512
+                        description: |
+                          App-local OIDC-init route the console "Open"
+                          launch lands the browser on (e.g. Grafana
+                          `/login/generic_oauth`, Harbor `/c/oidc/login`),
+                          which 302s to Keycloak with the app's pre-baked
+                          kc_idp_hint for silent SSO. Empty/absent →
+                          legacy app-root launch. (#3150)
                 sso:
                   type: object
                   description: |


### PR DESCRIPTION
## Problem
#3161 added `ssoInitPath` to the blueprint source, catalog-seed CR, catalyst-api handler, and OpenAPI — but **not the Blueprint CRD endpoint schema**. The schema is structural with no `x-kubernetes-preserve-unknown-fields`, so the API server **pruned** `ssoInitPath` on every apply. The seed shipped it, Helm applied it, the live CR silently lost it, and `buildLaunchURL` fell back to the legacy app-root URL → grafana launch still landed on its login form.

## Fix
Add `ssoInitPath` (string, maxLength 512) beside `ssoEnabled` in the shared (anchored) endpoint schema → covers both `v1` and `v1alpha1`.

## Validated live on hw124 (after applying CRD + re-seeding the bp-grafana CR)
```
launch-url bp-grafana → https://grafana.hw124.omani.works/login/generic_oauth   (was app-root)
that path           → 302 auth.hw124.omani.works/realms/sovereign/...?kc_idp_hint=catalyst-pin&client_id=grafana
```

## NOTE — existing Sovereigns
Helm `crds/` are **install-only** (a chart upgrade does not update the CRD). Existing Sovereigns need a direct `kubectl apply -f products/catalyst/chart/crds/blueprint.yaml` (done on hw124). Fresh provs get it from the chart on install.

This is the **shared unblock** for every `ssoInitPath` app — the 6 follow-on apps (harbor, openbao, guacamole, powerdns-admin, netbird, console) only add their own endpoint `ssoInitPath`; they do not touch the CRD again.

Refs #3150