### PR TITLE
fix(sso): stop stamping UPDATE_PASSWORD on PIN users + Open button in hero (#3150)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/keycloak/client.go
+++ b/products/catalyst/bootstrap/api/internal/keycloak/client.go
@@ -248,10 +248,13 @@ func (c *Client) createUser(ctx context.Context, saToken, email string) (string,
 		"username":      email,
 		"emailVerified": true,
 		"enabled":       true,
-		"requiredActions": []string{
-			"UPDATE_PASSWORD",
-			"CONFIGURE_PASSKEY",
-		},
+		// NO requiredActions. PIN/IDP operators never set a local
+		// password or passkey — they authenticate via the PIN flow and
+		// the catalyst-pin IDP. Stamping UPDATE_PASSWORD / CONFIGURE_PASSKEY
+		// here forced Keycloak to interrupt EVERY silent-SSO launch with
+		// an "activate your account / change your password" required-action
+		// page (#3150), so the console "Open" never landed in the app.
+		"requiredActions": []string{},
 	}
 
 	body, err := json.Marshal(payload)

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
@@ -450,6 +450,17 @@ export function AppDetail({ disableStream = false }: AppDetailProps = {}) {
               <span data-testid="app-detail-name">{componentId}</span>{' '}
               <span className="hero-subtitle">— {app.title}</span>
             </h1>
+            {appExternalURL ? (
+              <div
+                className="hero-launch"
+                style={{ display: 'flex', alignItems: 'center', gap: '0.6rem', margin: '0.5rem 0 0.6rem' }}
+              >
+                <LaunchButton appUID={launchKey} fallbackURL={appExternalURL} />
+                <span style={{ fontSize: '0.8rem', opacity: 0.7 }}>
+                  single-click sign-in — lands you in {app.title} already logged in
+                </span>
+              </div>
+            ) : null}
             <p className="hero-tagline">{app.description || app.familyName}</p>
             <div className="hero-meta">
               <span className="chip chip-cat">{app.familyName}</span>


### PR DESCRIPTION
Two operator-reported gaps from the grafana silent-SSO walk on hw124.

## 1. FUNCTIONAL (the blocker)
catalyst-api's `keycloak.createUser` stamped `requiredActions: [UPDATE_PASSWORD, CONFIGURE_PASSKEY]` on **every** user it provisions. PIN/IDP operators never set a local password or passkey, so Keycloak interrupted **every** silent-SSO launch with an *"activate your account / change your password"* page:
```
auth.<sov>/realms/sovereign/login-actions/required-action?execution=UPDATE_PASSWORD&client_id=grafana
```
The console "Open" reached Keycloak (launch + OIDC-init path work) but never landed in the app. **Remove the requiredActions.** (Already cleared live on the operator's hw124 account via the admin API so they can test now; this stops it recurring + fixes every future user.)

## 2. COSMETIC
The Open button only lived in the Overview tab's External-URL row. Add a prominent launch button to the app **hero** (right under the title) so single-click silent-SSO is the obvious header action.

FE typechecks clean; catalyst-api `go build` clean.

Refs #3150