### PR TITLE
fix(ui): unmistakable "Open <App>" launch button in the AppDetail header (#3150)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.test.tsx
@@ -283,14 +283,23 @@ describe('AppDetail — #3090 instance page (no class content; Open button)', ()
     installAppFetch('https://gitea.t99.omani.works')
     renderDetail('d-1', 'bp-cilium')
     // Overview tab is the default landing tab.
-    await screen.findByTestId('app-tab-overview-panel')
-    const openBtn = await screen.findByTestId('btn-launch-app')
+    const overviewPanel = await screen.findByTestId('app-tab-overview-panel')
+    // #3150 — the launch button now renders TWICE (the prominent hero CTA
+    // in the header AND the inline button next to the Overview external-URL
+    // row), both carrying data-testid="btn-launch-app". Scope to the
+    // Overview panel so this Overview-tab assertion targets exactly one.
+    const openBtn = await within(overviewPanel).findByTestId('btn-launch-app')
     expect(openBtn).toBeTruthy()
     // Founder relabel "Launch →" → "Open".
     expect(openBtn.textContent).toContain('Open')
     expect(openBtn.textContent).not.toContain('Launch')
     // The external-URL row is the gate that surfaces the button.
     expect(screen.getByTestId('app-detail-overview-external-url')).toBeTruthy()
+    // The prominent hero CTA also renders, reading "Open <App>" (#3150
+    // — founder demanded an unmistakable, app-named header button).
+    const heroLaunch = await screen.findByTestId('hero-launch')
+    const heroBtn = within(heroLaunch).getByTestId('btn-launch-app')
+    expect(heroBtn.textContent).toContain('Open')
   })
 
   it('hides the "Open" button when the Application has no external URL', async () => {
@@ -361,8 +370,11 @@ describe('AppDetail — #3090 instance page (no class content; Open button)', ()
 
     try {
       renderDetail('d-1', 'bp-grafana')
-      await screen.findByTestId('app-tab-overview-panel')
-      const openBtn = await screen.findByTestId('btn-launch-app')
+      const overviewPanel = await screen.findByTestId('app-tab-overview-panel')
+      // #3150 — two launch buttons now render (hero CTA + inline). Either
+      // drives the same silent-SSO path; scope to the Overview-tab inline
+      // one so this assertion targets exactly one button.
+      const openBtn = await within(overviewPanel).findByTestId('btn-launch-app')
       fireEvent.click(openBtn)
       // Allow the async getLaunchURL + window.open microtasks to settle.
       await new Promise((r) => setTimeout(r, 0))

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
@@ -451,13 +451,16 @@ export function AppDetail({ disableStream = false }: AppDetailProps = {}) {
               <span className="hero-subtitle">— {app.title}</span>
             </h1>
             {appExternalURL ? (
-              <div
-                className="hero-launch"
-                style={{ display: 'flex', alignItems: 'center', gap: '0.6rem', margin: '0.5rem 0 0.6rem' }}
-              >
-                <LaunchButton appUID={launchKey} fallbackURL={appExternalURL} />
-                <span style={{ fontSize: '0.8rem', opacity: 0.7 }}>
-                  single-click sign-in — lands you in {app.title} already logged in
+              <div className="hero-launch" data-testid="hero-launch">
+                <LaunchButton
+                  appUID={launchKey}
+                  fallbackURL={appExternalURL}
+                  appLabel={app.title}
+                  variant="hero"
+                />
+                <span className="hero-launch-hint">
+                  Single-click sign-in — lands you in {app.title} <strong>already
+                  logged in</strong>. No second login.
                 </span>
               </div>
             ) : null}
@@ -1065,9 +1068,29 @@ async function launchAppViaSSO(launchKey: string, fallbackURL: string): Promise<
 function LaunchButton({
   appUID,
   fallbackURL,
+  /**
+   * #3150 — the concrete app name (e.g. "Grafana") so the hero CTA reads
+   * "↗ Open Grafana" instead of a bare "Open". The founder flagged the
+   * plain label twice as too-subtle; an app-relevant label + the `hero`
+   * variant styling below make it the unmistakable header CTA. Falls back
+   * to a plain "Open" when no label is supplied (the Overview-tab inline
+   * instance next to the External-URL row).
+   */
+  appLabel,
+  /**
+   * `hero` renders the large, accent-filled primary CTA used in the
+   * AppDetail header (self-styled via the `.hero-launch-btn` class in
+   * APP_DETAIL_CSS). The shared `.btn-primary` rule lives in AppsPage's
+   * page-scoped <style> and does NOT reach this page — which is exactly
+   * why the prior `btn btn-primary` button rendered unstyled and subtle.
+   * `inline` keeps the compact Overview-tab button.
+   */
+  variant = 'inline',
 }: {
   appUID: string
   fallbackURL: string
+  appLabel?: string
+  variant?: 'hero' | 'inline'
 }) {
   const [pending, setPending] = useState(false)
   const onClick = async (e: React.MouseEvent) => {
@@ -1080,21 +1103,26 @@ function LaunchButton({
       setPending(false)
     }
   }
+  const openLabel = appLabel ? `Open ${appLabel}` : 'Open'
+  const isHero = variant === 'hero'
   return (
     <button
       type="button"
       data-testid="btn-launch-app"
       onClick={onClick}
       disabled={pending}
-      className="btn btn-primary launch-button"
-      style={{
-        padding: '0.4rem 0.95rem',
-        fontSize: '0.95rem',
-        fontWeight: 600,
-      }}
-      aria-label="Open app via single-click silent SSO"
+      className={isHero ? 'hero-launch-btn' : 'btn btn-primary launch-button'}
+      style={
+        isHero
+          ? undefined
+          : { padding: '0.4rem 0.95rem', fontSize: '0.95rem', fontWeight: 600 }
+      }
+      aria-label={`${openLabel} — single-click silent sign-in, no second login`}
     >
-      {pending ? 'Opening…' : '↗ Open'}
+      <span aria-hidden="true" className={isHero ? 'hero-launch-icon' : undefined}>
+        ↗
+      </span>{' '}
+      {pending ? 'Opening…' : openLabel}
     </button>
   )
 }
@@ -1500,6 +1528,42 @@ const APP_DETAIL_CSS = `
 .hero-subtitle { color: var(--color-text-dim); font-weight: 500; font-size: 0.95rem; }
 .hero-tagline { margin: 0.25rem 0 0.6rem; color: var(--color-text-dim); font-size: 0.9rem; }
 .hero-meta { display: flex; gap: 0.4rem; flex-wrap: wrap; }
+
+/*
+ * #3150 — the unmistakable header "Open <App>" CTA. The founder flagged
+ * the launch button as missing/too-subtle TWICE, so this is a real,
+ * accent-filled primary button (NOT a chip, NOT a text link). Self-styled
+ * here because the shared .btn-primary rule lives in AppsPage's
+ * page-scoped <style> and never reaches this page — that was the root
+ * cause of the prior unstyled/subtle render.
+ */
+.hero-launch {
+  display: flex; align-items: center; gap: 0.7rem;
+  flex-wrap: wrap; margin: 0.55rem 0 0.7rem;
+}
+.hero-launch-btn {
+  display: inline-flex; align-items: center; gap: 0.4rem;
+  padding: 0.6rem 1.25rem;
+  font-size: 1.02rem; font-weight: 700; line-height: 1;
+  color: #fff;
+  background: var(--color-accent);
+  border: none; border-radius: 10px;
+  cursor: pointer;
+  box-shadow: 0 2px 10px color-mix(in srgb, var(--color-accent) 40%, transparent);
+  transition: filter 0.12s ease, transform 0.06s ease, box-shadow 0.12s ease;
+}
+.hero-launch-btn:hover {
+  filter: brightness(1.06);
+  box-shadow: 0 4px 16px color-mix(in srgb, var(--color-accent) 52%, transparent);
+}
+.hero-launch-btn:active { transform: translateY(1px); }
+.hero-launch-btn:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--color-accent) 55%, transparent);
+  outline-offset: 2px;
+}
+.hero-launch-btn:disabled { opacity: 0.7; cursor: progress; }
+.hero-launch-icon { font-size: 1.1em; line-height: 0; }
+.hero-launch-hint { font-size: 0.82rem; color: var(--color-text-dim); }
 
 .chip { display: inline-flex; align-items: center; gap: 0.3rem; padding: 0.18rem 0.55rem; border-radius: 999px; font-size: 0.7rem; font-weight: 600; white-space: nowrap; }
 .chip-cat { background: color-mix(in srgb, var(--color-border) 50%, transparent); color: var(--color-text-dim); text-transform: capitalize; }


### PR DESCRIPTION
## What

Make the silent-SSO launch button in the **AppDetail header** an unmistakable, app-named primary CTA. The founder flagged the launch button twice as missing/too-subtle and wanted "a proper Open button on the header section of the application card".

The hero button (added in #3167) carried `className="btn btn-primary"` — but that CSS rule lives only in `AppsPage`'s page-scoped `<style>` and never reaches `AppDetail`, so the button rendered effectively unstyled and subtle. That was the root cause.

## Changes

- `LaunchButton` gains a `hero` variant + an `appLabel` prop. The header CTA now reads **"↗ Open Grafana"** (concrete app title via `app.title`) and is a real accent-filled primary button with its own `.hero-launch-btn` CSS in `APP_DETAIL_CSS`: `1.02rem` / weight `700`, `0.6rem × 1.25rem` padding, accent background, drop shadow, hover/active/focus-visible states.
- The inline Overview-tab button keeps its compact style and plain "Open" label.
- Both buttons keep `data-testid="btn-launch-app"` and the working `launchAppViaSSO` / `launchKey` silent-SSO launch path — operator-confirmed on hw124 (UAT row A1, 2026-06-09: clicking Open on grafana lands already signed in, zero Keycloak UI).
- Unit tests scope the Overview-tab assertion to the overview panel (two `btn-launch-app` instances now render) and add a hero-CTA "Open" assertion.

## Verification

- `npx vitest run AppDetail.test.tsx` → 28/28 pass.
- `npx tsc --noEmit` → clean.
- Visual (header CTA prominence) needs the founder's eyes behind the PIN-email login wall.

Refs #3150
