### PR TITLE
feat(sso): silent-SSO per-app fan-out — harbor/openbao seed CRs + host fixes (Refs #3150)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -975,7 +975,11 @@ spec:
       # 1.4.532 — #3150 (2026-06-09): silent-SSO — launch-url resolves HR-backed
       # bootstrap apps (no Application CR) + per-endpoint ssoInitPath lands the
       # console "Open" on the app's OIDC-init route (grafana /login/generic_oauth).
-      version: 1.4.537
+      # 1.4.538 — #3150 (2026-06-09): silent-SSO per-app fan-out — catalog-seed
+      # gains in-cluster bp-harbor + bp-openbao Blueprint CRs (ssoInitPath
+      # /c/oidc/login, /ui/vault/auth?with=oidc%2F on the live registry.<sov> /
+      # bao.<sov> hosts) + fixes bp-guacamole seed host guac.<sov> → guacamole.<sov>.
+      version: 1.4.538
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -110,13 +110,25 @@ spec:
   # Audit row: harbor.<sov> (UI/API) + registry.<sov> (OCI pull/push).
   endpoints:
     - name: ui
-      hostnameTemplate: "harbor.{{.SovereignFQDN}}"
+      # Harbor's UI + API are served on the SAME host as the registry
+      # (registry.<sov>): clusters/_template/bootstrap-kit/19-harbor.yaml sets
+      # BOTH gateway.host AND externalURL to registry.${SOVEREIGN_FQDN}, and
+      # the Keycloak OIDC client redirect_uri is registry.<sov>/c/oidc/callback.
+      # The earlier harbor.<sov> value pointed at a host with NO HTTPRoute → the
+      # console launch-url would 404. Keep this aligned with the live externalURL.
+      hostnameTemplate: "registry.{{.SovereignFQDN}}"
       port: 443
       protocol: https
       tls: true
       visibility: public
       launchDefault: true
       ssoEnabled: true
+      # #3150 — silent-SSO OIDC-init path. Harbor core's OIDC onboarding route:
+      # a GET to /c/oidc/login with no code 302s straight to Keycloak
+      # (auth.<sov>/realms/sovereign/...?kc_idp_hint=catalyst-pin) → silent PIN
+      # re-use → operator lands inside Harbor with no login form. Verified live
+      # on hw124: GET /c/oidc/login → 302 auth.hw124.omani.works/realms/sovereign.
+      ssoInitPath: "/c/oidc/login"
     - name: registry
       hostnameTemplate: "registry.{{.SovereignFQDN}}"
       port: 443

--- a/platform/netbird/blueprint.yaml
+++ b/platform/netbird/blueprint.yaml
@@ -86,6 +86,15 @@ spec:
       visibility: public
       launchDefault: true
       ssoEnabled: true
+      # #3150 — silent-SSO OIDC-init path. The NetBird dashboard is a React SPA
+      # (oidc-client PKCE) that auto-starts the OIDC redirect on load when no
+      # session is present, so the init path is the SPA root "/" — the dashboard
+      # bounces straight to Keycloak (kc_idp_hint=catalyst-pin via the realm-config
+      # IDR default-provider binding) → silent PIN re-use. NetBird is default-OFF
+      # (configSchema.enabled=false) and NOT installed on hw124 — a witnessed
+      # Playwright landing is required when it is first enabled to confirm the
+      # SPA auto-starts (vs needing a deep-link query param).
+      ssoInitPath: "/"
   sso:
     realm: sovereign
     protocolMapper: oidc

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -58,13 +58,27 @@ spec:
   # no Coraza WAF); operator may publish via per-Sovereign overlay.
   endpoints:
     - name: api
-      hostnameTemplate: "vault.{{.SovereignFQDN}}"
+      # OpenBao is served at bao.<sov>: clusters/_template/bootstrap-kit/
+      # 08-openbao.yaml sets gateway.host to bao.${SOVEREIGN_FQDN}. The earlier
+      # vault.<sov> value pointed at a host with NO HTTPRoute → the console
+      # launch-url would 404. Keep this aligned with the live gateway.host.
+      hostnameTemplate: "bao.{{.SovereignFQDN}}"
       port: 8200
       protocol: https
       tls: true
       visibility: private
       launchDefault: true
       ssoEnabled: true
+      # #3150 — silent-SSO OIDC-init path. OpenBao's UI is a SPA (Vault-UI
+      # fork): OIDC is started client-side, so there is no server GET route to
+      # land on. The deep-link pre-selects the `oidc` auth method in the UI so
+      # the operator's one click triggers the OIDC flow, which — with the
+      # realm-config IDR defaultProvider=catalyst-pin binding (bp-keycloak
+      # 1.4.9+, NOT an auth_url query param; see chart values.yaml comment) —
+      # re-uses the PIN silently. NOTE: requires the `oidc` auth method to be
+      # mounted by the sso-configure Deployment; when that job is unhealthy the
+      # UI falls back to ?with=token and silent SSO can't fire.
+      ssoInitPath: "/ui/vault/auth?with=oidc%2F"
 
   # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
   # OpenBao OIDC auth method federated to sovereign realm (G91 manual

--- a/platform/powerdns-admin/blueprint.yaml
+++ b/platform/powerdns-admin/blueprint.yaml
@@ -57,6 +57,15 @@ spec:
       visibility: private
       launchDefault: true
       ssoEnabled: true
+      # #3150 — silent-SSO OIDC-init path. PowerDNS-Admin (ngoduykhanh) is a
+      # Flask/authlib app; the generic-OIDC provider registers its login view
+      # at /oidc/login, which redirects the browser to OIDC_OAUTH_AUTHORIZE_URL
+      # (already carries ?kc_idp_hint=catalyst-pin — see chart
+      # sso-oauth-source-externalsecret.yaml) → silent PIN re-use → operator
+      # lands inside PDA with no login form. NOT installed on hw124 (only the
+      # bp-powerdns DNS server is) — confirm the exact route against the running
+      # url_map when PDA is first provisioned.
+      ssoInitPath: "/oidc/login"
   sso:
     realm: sovereign
     protocolMapper: oidc

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,13 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.538 — #3150 (2026-06-09) — silent-SSO per-app fan-out. catalog-seed
+# blueprints.yaml: add in-cluster bp-harbor + bp-openbao Blueprint CRs (bare
+# HelmReleases with no Application CR; the catalyst-catalog returns items:[]
+# on a fresh Sovereign so the in-cluster CR is the ONLY launch-url resolution
+# path) with ssoInitPath (/c/oidc/login, /ui/vault/auth?with=oidc%2F) on the
+# correct live hosts (registry.<sov>, bao.<sov>); fix bp-guacamole seed host
+# guac.<sov> → guacamole.<sov> (the live HTTPRoute). No BE change — #3150's
+# handler resolves all of these generically. Refs #3150.
 # 1.4.517 — #3126 (2026-06-08) — provisioner resilience to transient github
 # failures at tofu-init: catalyst-api now sets CATALYST_TF_PLUGIN_CACHE_DIR
 # (=/var/lib/catalyst/tofu-plugin-cache, a sibling subdir of the existing
@@ -2598,7 +2606,7 @@ name: bp-catalyst-platform
 # OIDC-init route (grafana /login/generic_oauth) so the console "Open" button
 # lands the operator already-logged-in with no app login form. bp-grafana
 # catalog-seed CR gains ssoInitPath. Refs #3150.
-version: 1.4.537
+version: 1.4.538
 appVersion: 1.4.494
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -1586,7 +1586,20 @@ spec:
             mgmt-A: singleton
   endpoints:
   - name: ui
-    hostnameTemplate: guac.{{ "{{" }}.SovereignFQDN{{ "}}" }}
+    # #3150 — Guacamole is served at guacamole.<sov>:
+    # clusters/_template/bootstrap-kit/52-bp-guacamole.yaml sets the HTTPRoute
+    # hostname to guacamole.${SOVEREIGN_FQDN}. The earlier guac.<sov> value
+    # pointed at a host with NO HTTPRoute → the console launch-url landed on a
+    # dead host. Keep this aligned with the live HTTPRoute.
+    #
+    # ssoInitPath is intentionally OMITTED: Guacamole's UI is an Angular SPA
+    # and OIDC is driven by the OpenID extension, which auto-starts the redirect
+    # from the app root (POST /api/tokens) — there is no clean server GET route
+    # to land on. The legacy app-root launch is correct for it. (On hw124 the
+    # guacamole backend currently 404s /api/tokens and its OIDC env points at
+    # the stale realm `catalyst`/host `keycloak.*` rather than `sovereign`/
+    # `auth.*` — a separate config-drift defect, not a launch-url gap.)
+    hostnameTemplate: guacamole.{{ "{{" }}.SovereignFQDN{{ "}}" }}
     port: 443
     protocol: https
     tls: true
@@ -3062,6 +3075,203 @@ spec:
     ssoEnabled: true
   sso:
     realm: '{{ "{{" }}.OrgSlug{{ "}}" }}'
+    protocolMapper: oidc
+    groupsClaim: groups
+    rolesFromGroup:
+      sovereign-admins: admin
+    silentLogin: true
+---
+# #3150 — Harbor in-cluster Blueprint CR seed. Harbor installs as a bare
+# HelmRelease with NO companion Application CR, and on a fresh Sovereign the
+# catalyst-catalog returns items:[] (Gitea catalog Org not yet mirrored), so
+# the ONLY blueprint-resolution path the launch-url handler has is this
+# in-cluster CR (via catalog_client_cluster_fallback.go). Without this entry,
+# GET /apps/bp-harbor/launch-url 404s "Blueprint harbor has no endpoint".
+# Mirrors platform/harbor/blueprint.yaml.
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-harbor
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: platform
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+spec:
+  version: "1.2.26"
+  visibility: unlisted
+  card:
+    title: "Harbor"
+    category: platform
+    summary: "Per-Sovereign OCI registry. Keycloak SSO via OIDC. One Harbor per Catalyst control plane."
+    description: "Per-Sovereign OCI registry mirroring Catalyst Blueprint OCI artefacts + container images. Keycloak OIDC SSO; blobs in Object Storage, metadata in CNPG."
+    icon: "harbor.svg"
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: bp-harbor
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-harbor
+    version: "1.2.26"
+  topology:
+    supported:
+    - active-hot-standby
+    - singleton
+    defaults:
+      multi-region: active-hot-standby
+      single-region: singleton
+    perTopology:
+      active-hot-standby:
+        replication:
+          backend: cnpg-pair
+          mode: sync
+          lagSloSeconds: 0
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 30
+          rpoSeconds: 0
+        placement:
+          tier: mgmt
+          clusters:
+          - mgmt-A
+          - mgmt-B
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters:
+          - mgmt-A
+          roles:
+            mgmt-A: singleton
+  endpoints:
+  - name: ui
+    # Harbor UI + API + OIDC are served on the registry.<sov> host (the overlay
+    # sets BOTH gateway.host AND externalURL to registry.${SOVEREIGN_FQDN}); the
+    # KC OIDC redirect_uri is registry.<sov>/c/oidc/callback. The runtime token
+    # `{{ "{{" }}.SovereignFQDN{{ "}}" }}` is Helm-escaped so the rendered CR
+    # carries it verbatim for endpoint_handler.go to evaluate at request time.
+    hostnameTemplate: registry.{{ "{{" }}.SovereignFQDN{{ "}}" }}
+    port: 443
+    protocol: https
+    tls: true
+    visibility: public
+    launchDefault: true
+    ssoEnabled: true
+    # #3150 — silent-SSO OIDC-init path. GET /c/oidc/login (no code) 302s to
+    # Keycloak (auth.<sov>/realms/sovereign/...?kc_idp_hint=catalyst-pin) →
+    # silent PIN re-use → operator lands inside Harbor with no login form.
+    # Verified live on hw124: GET /c/oidc/login → 302 auth.hw124.omani.works.
+    ssoInitPath: "/c/oidc/login"
+  - name: registry
+    hostnameTemplate: registry.{{ "{{" }}.SovereignFQDN{{ "}}" }}
+    port: 443
+    protocol: https
+    tls: true
+    visibility: public
+    launchDefault: false
+    ssoEnabled: false
+  sso:
+    realm: sovereign
+    protocolMapper: oidc
+    groupsClaim: groups
+    rolesFromGroup:
+      sovereign-admins: admin
+    silentLogin: true
+---
+# #3150 — OpenBao in-cluster Blueprint CR seed (same rationale as bp-harbor
+# above: bare HelmRelease, no Application CR, empty catalyst-catalog on a fresh
+# Sovereign). Mirrors platform/openbao/blueprint.yaml.
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-openbao
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: platform
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+spec:
+  version: "1.2.25"
+  visibility: unlisted
+  card:
+    title: "OpenBao"
+    category: platform
+    summary: "Per-Sovereign secret backend. 3-node Raft per region. Keycloak OIDC SSO. MPL-2.0 Vault replacement."
+    description: "OpenBao secret backend (Raft per region, async perf-replication across regions). UI + CLI login via the Keycloak OIDC auth method."
+    icon: "openbao.svg"
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: bp-openbao
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-openbao
+    version: "1.2.25"
+  topology:
+    supported:
+    - active-passive
+    - singleton
+    defaults:
+      multi-region: active-passive
+      single-region: singleton
+    perTopology:
+      active-passive:
+        replication:
+          backend: openbao-perf-replication
+          mode: async
+          lagSloSeconds: 30
+        switchover:
+          mechanism: raft-transition
+          rtoSeconds: 30
+          rpoSeconds: 0
+        placement:
+          tier: mgmt
+          clusters:
+          - mgmt-A
+          - mgmt-B
+          roles:
+            mgmt-A: active
+            mgmt-B: passive
+      singleton:
+        placement:
+          tier: mgmt
+          clusters:
+          - mgmt-A
+          roles:
+            mgmt-A: singleton
+  endpoints:
+  - name: api
+    # OpenBao is served at bao.<sov> (overlay sets gateway.host to
+    # bao.${SOVEREIGN_FQDN}). Helm-escaped runtime token below.
+    hostnameTemplate: bao.{{ "{{" }}.SovereignFQDN{{ "}}" }}
+    port: 8200
+    protocol: https
+    tls: true
+    visibility: private
+    launchDefault: true
+    ssoEnabled: true
+    # #3150 — silent-SSO OIDC-init path. OpenBao's UI is a SPA; this deep-link
+    # pre-selects the `oidc` auth method so one click triggers the OIDC flow,
+    # which re-uses the PIN silently via the realm-config IDR
+    # defaultProvider=catalyst-pin binding (NOT an auth_url query param).
+    # Requires the `oidc` auth method to be mounted by the sso-configure
+    # Deployment.
+    ssoInitPath: "/ui/vault/auth?with=oidc%2F"
+  sso:
+    realm: sovereign
     protocolMapper: oidc
     groupsClaim: groups
     rolesFromGroup:


### PR DESCRIPTION
## What

Per-app silent-SSO fan-out following the grafana pathfinder (`docs/sessions/2026-06-09/sso-pathfinder-grafana.md`). Adds each remaining bootstrap-kit app's `ssoInitPath` so the console **Open** button lands the operator inside the app already logged in (no app login form).

## Key finding that shaped the change

On a fresh Sovereign (hw124) the **catalyst-catalog returns `items:[]`** (the Gitea catalog Org isn't mirrored yet), so the launch-url handler's ONLY working blueprint-resolution path is the **in-cluster Blueprint CR** seeded by `catalog-seed/blueprints.yaml`. harbor + openbao install as bare HelmReleases with **no Application CR and no seed CR** → `GET /apps/bp-{harbor,openbao}/launch-url` 404'd `"Blueprint X has no endpoint"`. So they each need an in-cluster CR, not just a `platform/<app>/blueprint.yaml` edit.

Several `ui` endpoint hostnames were also **stale** vs the live overlay HTTPRoute hosts (the launch-url builds the URL from `endpoint.hostnameTemplate`, so a wrong host = the launch lands on a dead 404 host).

## Changes

**`catalog-seed/blueprints.yaml`** (load-bearing at runtime):
- **Add** in-cluster `bp-harbor` CR — host `registry.<sov>` (overlay sets both `gateway.host` and `externalURL` to `registry.<sov>`; KC redirect_uri is `registry.<sov>/c/oidc/callback`), `ssoInitPath: /c/oidc/login`.
- **Add** in-cluster `bp-openbao` CR — host `bao.<sov>`, `ssoInitPath: /ui/vault/auth?with=oidc%2F`.
- **Fix** `bp-guacamole` seed host `guac.<sov>` → `guacamole.<sov>` (the live HTTPRoute).

**Canonical source `platform/<app>/blueprint.yaml`:**
- harbor: `ui` host `harbor.<sov>` → `registry.<sov>` + `ssoInitPath /c/oidc/login`.
- openbao: `api` host `vault.<sov>` → `bao.<sov>` + `ssoInitPath /ui/vault/auth?with=oidc%2F`.
- powerdns-admin: `ssoInitPath /oidc/login` (Flask/authlib).
- netbird: `ssoInitPath "/"` (React SPA auto-starts PKCE).

No backend change — #3150's handler resolves all of these generically. Bumps `bp-catalyst-platform` `1.4.536` → `1.4.537`.

## Verification (live on hw124)

- **harbor** — `GET https://registry.hw124.omani.works/c/oidc/login` → **302** `Location: https://auth.hw124.omani.works/realms/sovereign/protocol/openid-connect/auth?...&kc_idp_hint=catalyst-pin&redirect_uri=...%2Fc%2Foidc%2Fcallback`. Server-route, clean win — same shape as grafana.
- `helm template` renders all 37 seed CRs; YAML parses; the Helm-escaped `{{.SovereignFQDN}}` runtime token is preserved verbatim (not rendered empty).

## Per-app status (the honest matrix)

| App | Result |
|---|---|
| harbor | **shippable + verified** (302→Keycloak confirmed live) |
| guacamole | host fixed; **OIDC backend broken on hw124** (`/guacamole/api/tokens` 404, OIDC env points at stale realm `catalyst`/host `keycloak.*`) — separate config-drift defect, not a launch-url gap |
| openbao | seed + host + deep-link shipped; **`sso-configure` Deployment failing on hw124** (`wget: bad address openbao-openbao.openbao.svc...`) → `oidc` auth method never mounted → can't witness-land until that defect is fixed |
| powerdns-admin | source-only — **not installed on hw124** (only the `bp-powerdns` DNS server is) |
| netbird | source-only — **not installed on hw124** (default-OFF, no published chart/seed) |
| console | **no-op** — the console IS the IdP client the operator already holds |

The guacamole-backend and openbao-sso-configure defects are pre-existing and out of this change's scope; flagged on #3150 for separate follow-up.

Refs #3150

🤖 Generated with [Claude Code](https://claude.com/claude-code)
