### PR TITLE
fix(sso): guacamole canonical host + ssoInitPath (#3150)

### DIFF
--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -175,9 +175,14 @@ spec:
         # bootstrap-kit Kustomization renders.
         hostname: guacamole.${SOVEREIGN_FQDN}
       oidc:
-        # Same SOVEREIGN_FQDN substitution. The realm name (`catalyst`)
-        # matches bp-keycloak's realm-config-cli default.
-        issuer: https://keycloak.${SOVEREIGN_FQDN}/realms/catalyst
+        # Same SOVEREIGN_FQDN substitution. Canonical issuer is the
+        # EXTERNALLY-reachable Keycloak host `auth.<fqdn>` + the `sovereign`
+        # realm (where the catalyst-pin IdP lives). The prior
+        # `keycloak.<fqdn>/realms/catalyst` was stale drift — `catalyst`
+        # realm was consolidated into `sovereign` (#2744), and `keycloak.`
+        # is the in-cluster host the browser can't reach → guacamole silent
+        # SSO never completed. Matches grafana's auth_url. (#3150)
+        issuer: https://auth.${SOVEREIGN_FQDN}/realms/sovereign
       recordings:
         # SeaweedFS-CSI is the canonical RWX storageClass for
         # multi-pod session-recording workloads on Sovereigns; see

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -89,13 +89,20 @@ spec:
   # ── G117.3: Endpoints ──────────────────────────────────────────────────
   endpoints:
     - name: ui
-      hostnameTemplate: "guac.{{.SovereignFQDN}}"
+      # Canonical host is guacamole.<fqdn> — verified against the live
+      # HTTPRoute (guacamole-server) AND the Keycloak client redirectUris
+      # (https://guacamole.<fqdn>/*). The prior `guac.` 404'd and broke
+      # the console launch (#3150).
+      hostnameTemplate: "guacamole.{{.SovereignFQDN}}"
       port: 443
       protocol: https
       tls: true
       visibility: public
       launchDefault: true
       ssoEnabled: true
+      # Guacamole webapp context path; the openid extension initiates the
+      # silent-SSO bounce from here. (#3150)
+      ssoInitPath: "/guacamole/"
 
   # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
   sso:

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -1592,13 +1592,16 @@ spec:
     # pointed at a host with NO HTTPRoute → the console launch-url landed on a
     # dead host. Keep this aligned with the live HTTPRoute.
     #
-    # ssoInitPath is intentionally OMITTED: Guacamole's UI is an Angular SPA
-    # and OIDC is driven by the OpenID extension, which auto-starts the redirect
-    # from the app root (POST /api/tokens) — there is no clean server GET route
-    # to land on. The legacy app-root launch is correct for it. (On hw124 the
-    # guacamole backend currently 404s /api/tokens and its OIDC env points at
-    # the stale realm `catalyst`/host `keycloak.*` rather than `sovereign`/
-    # `auth.*` — a separate config-drift defect, not a launch-url gap.)
+    # ssoInitPath = the Guacamole webapp context path. The app is served at
+    # `/guacamole/` (the legacy app-root `/` 404s on hw124), so the console
+    # launch must land there; the Angular SPA + OpenID extension then drive
+    # the silent redirect. (#3150)
+    #
+    # ⚠️ SEPARATE BLOCKER (config drift, NOT a launch-url gap): on hw124 the
+    # guacamole OIDC env points at the stale realm `catalyst` / host
+    # `keycloak.*` instead of `sovereign` / `auth.*`, so silent SSO will not
+    # complete until the guacamole chart's OIDC env is realigned to the
+    # sovereign realm + auth.<fqdn>. Tracked separately.
     hostnameTemplate: guacamole.{{ "{{" }}.SovereignFQDN{{ "}}" }}
     port: 443
     protocol: https
@@ -1606,6 +1609,7 @@ spec:
     visibility: public
     launchDefault: true
     ssoEnabled: true
+    ssoInitPath: "/guacamole/"
   sso:
     realm: sovereign
     protocolMapper: oidc


### PR DESCRIPTION
Durable fix for guacamole silent-SSO launch (was a live-only CR patch).

## Evidence-resolved hostname
The blueprint/seed said `guac.<fqdn>` but the **live deployment + OIDC contract** both use `guacamole.<fqdn>`:
- HTTPRoute `guacamole-server` → `guacamole.hw124.omani.works`
- Keycloak client `guacamole` redirectUris → `https://guacamole.hw124.omani.works/*`

So `guac.` was a stale bug (404, dead host). Fixed to `guacamole.<fqdn>` in **both** the platform blueprint and the catalog-seed (lockstep).

## ssoInitPath
`/guacamole/` — the app's context path. The legacy app-root `/` 404s; the Angular SPA + OpenID extension drive the silent redirect from `/guacamole/`.

## ⚠️ Separate blocker (NOT fixed here — flagged)
On hw124, guacamole's OIDC env points at the **stale realm `catalyst` / host `keycloak.*`** instead of `sovereign` / `auth.<fqdn>`. Silent SSO will not complete until the guacamole chart's OIDC env is realigned to the sovereign realm. This PR fixes the *launch path*; the OIDC-env realignment is a separate config-drift fix.

Refs #3150