### PR TITLE
fix(bootstrap-kit): list 11a-bp-powerdns-admin — forgotten kit slot (#3150)

### DIFF
--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -22,6 +22,10 @@ resources:
   - 09-keycloak.yaml
   - 10-gitea.yaml
   - 11-powerdns.yaml
+  # 11a was authored but never added to this list → Flux never created the
+  # bp-powerdns-admin HR (the exact forgotten-slot bug documented above for
+  # bp-sso-bridge on hw86). powerdns-admin is a G91 SSO opt-in. (#3150)
+  - 11a-bp-powerdns-admin.yaml
   - 12-external-dns.yaml
   - 13-bp-catalyst-platform.yaml
   # G91.1 #2652 — bp-sso-bridge framework. Reconciler that watches


### PR DESCRIPTION
## Problem
`clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml` exists but was **never added to `kustomization.yaml`'s resources list** — so Flux never creates the `bp-powerdns-admin` HelmRelease. powerdns-admin is therefore **absent on every prov**, which is why its console SSO row is un-walkable.

This is the **exact forgotten-slot bug** the kustomization's own comment documents (bp-sso-bridge on hw86: "slot file existed but kustomization.yaml didn't list it, so Flux never created the HR"). powerdns-admin is a declared **G91 SSO opt-in**.

## Evidence
- `kubectl -n flux-system get hr bp-powerdns-admin` → **NotFound** on hw124
- `bp-powerdns` (engine) + `bp-cert-manager-powerdns-webhook` → present/Ready
- resources list jumps `11-powerdns.yaml` → `12-external-dns.yaml`, skipping `11a`

## Fix
Add `- 11a-bp-powerdns-admin.yaml` after `11-powerdns.yaml`. The HR's `dependsOn` handles ordering. Once merged, hw124's bootstrap-kit kustomization (reconciles `./clusters/_template/bootstrap-kit`) deploys it, then its SSO `ssoInitPath` can be wired.

Refs #3150