### PR TITLE
fix(marketplace): re-pin services-catalog 41e02c8 → c96f998 (5-plan filter regression)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -979,7 +979,10 @@ spec:
       # gains in-cluster bp-harbor + bp-openbao Blueprint CRs (ssoInitPath
       # /c/oidc/login, /ui/vault/auth?with=oidc%2F on the live registry.<sov> /
       # bao.<sov> hosts) + fixes bp-guacamole seed host guac.<sov> → guacamole.<sov>.
-      version: 1.4.539
+      # 1.4.540 — #3156 (2026-06-09): re-pin services-catalog smeTag 41e02c8 →
+      # c96f998 so the generic Org-provisioning plan picker shows the 5 generic
+      # tiers (filterPlansByProduct from #3157), not all 8 with the Sandbox dupes.
+      version: 1.4.540
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2606,7 +2606,10 @@ name: bp-catalyst-platform
 # OIDC-init route (grafana /login/generic_oauth) so the console "Open" button
 # lands the operator already-logged-in with no app login form. bp-grafana
 # catalog-seed CR gains ssoInitPath. Refs #3150.
-version: 1.4.539
+# 1.4.540 — fix(marketplace): re-pin services-catalog (smeTag) 41e02c8 → c96f998.
+# 41e02c8 predates the #3157 plans filter, so the generic Org-provisioning
+# picker showed all 8 plans (Sandbox dupes) instead of 5 on hw124. Refs #3156.
+version: 1.4.540
 appVersion: 1.4.494
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -311,7 +311,14 @@ images:
   admin:
     tag: "3c2f7e4"
   # All 10 SME microservices share one SHA tag (built from the same mono-repo commit).
-  smeTag: "41e02c8"
+  # 2026-06-09: bumped 41e02c8 → c96f998 (merge SHA of #3157). 41e02c8 (built
+  # 2026-06-05) PREDATES the #3157 marketplace-plans fix (merged 2026-06-09),
+  # so services-catalog:41e02c8 lacks filterPlansByProduct → the generic
+  # Org-provisioning picker rendered all 8 plans (5 generic + 3 Sandbox) on
+  # hw124 instead of 5. A later catalyst-platform roll re-pinned the stale
+  # 41e02c8, reverting the live filter. c96f998 carries the server-side filter
+  # and is published for all 8 services-* images (latest-tagged). Refs #3156.
+  smeTag: "c96f998"
 
 # ─── Runtime service coordinates (qa-loop iter-1, cluster
 # `catalyst-runtime-config-missing`) ────────────────────────────────────


### PR DESCRIPTION
## Marketplace plans regression — hw124 `/plans/` shows 8 instead of 5

### Symptom (verified live)
`GET https://marketplace.hw124.omani.works/api/catalog/plans?product=generic` returned **8 plans** — the 5 generic compute tiers (`s/m/l/xl/flexi`) plus the 3 Sandbox product tiers (`sandbox-free/pro/ent`), which visually duplicate the compute tiers in the Org-provisioning picker. It had verified at **5** earlier (#3156/#3157).

### Root cause
PR #3157 added the server-side `?product=generic` filter (`filterPlansByProduct` in `core/services/catalog/handlers/handlers.go`) and merged 2026-06-09 as `c96f998`. But the chart's SME bundle pin `images.smeTag` was `41e02c8` — built **2026-06-05**, which **predates** the #3157 merge. `services-catalog:41e02c8` has no filter, so `ListPlans` returned every plan. A later `bp-catalyst-platform` roll re-pinned the stale `41e02c8`, reverting the live filter.

The live `sme/catalog` deploy on hw124 was confirmed on `ghcr.io/openova-io/openova/services-catalog:41e02c8`.

### Fix
Re-pin `images.smeTag` `41e02c8` → `c96f998` (the merge SHA of #3157). `c96f998` is the full SME mono-repo bundle build, `latest`-tagged, and published for **all 8** `services-*` images, so bumping the shared tag is safe across the bundle. Chart `1.4.539` → `1.4.540`.

Helm render confirms the catalog image becomes `ghcr.io/openova-io/openova/services-catalog:c96f998`.

### Files
- `products/catalyst/chart/values.yaml` — `images.smeTag: 41e02c8 → c96f998`
- `products/catalyst/chart/Chart.yaml` — `version: 1.4.539 → 1.4.540`

### Verification plan (post-merge)
Roll `bp-catalyst-platform` to the cumulative-latest including this merge on hw124, then `GET .../api/catalog/plans?product=generic` → **5 plans** (`s/m/l/xl/flexi`, no sandbox).

Refs #3156

🤖 Generated with [Claude Code](https://claude.com/claude-code)
