### PR TITLE
fix(catalog): correct CRD-invalid seed values blocking the 1.4.540 catalyst-platform upgrade (Refs #3159)

### DIFF
--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -4996,7 +4996,17 @@ spec:
           backend: none
           mode: none
         switchover:
-          mechanism: leader-election
+          # CRD enum for switchover.mechanism does NOT include
+          # `leader-election` (valid: bp-continuum/manual/bp-velero-restore/
+          # lua-record/mm2-symmetric/ccr-promote/raft-transition/
+          # sentinel-failover/none). The stateless controller's leader-flip
+          # is driven by bp-continuum on region-kill, same as every other
+          # active-hot-standby seed entry — the platform/<x> source's
+          # informational `leader-election` value is v1alpha1-lax and fails
+          # the v1 CRD admission used by the in-cluster seed (caught live on
+          # hw124: the whole bp-catalyst-platform@1.4.540 upgrade aborted
+          # atomically on this one invalid CR). Refs #3159.
+          mechanism: bp-continuum
           rtoSeconds: 30
           rpoSeconds: 0
         placement:
@@ -5341,7 +5351,17 @@ spec:
           mode: async
           lagSloSeconds: 0
         switchover:
-          mechanism: leader-election
+          # CRD enum for switchover.mechanism does NOT include
+          # `leader-election` (valid: bp-continuum/manual/bp-velero-restore/
+          # lua-record/mm2-symmetric/ccr-promote/raft-transition/
+          # sentinel-failover/none). The stateless controller's leader-flip
+          # is driven by bp-continuum on region-kill, same as every other
+          # active-hot-standby seed entry — the platform/<x> source's
+          # informational `leader-election` value is v1alpha1-lax and fails
+          # the v1 CRD admission used by the in-cluster seed (caught live on
+          # hw124: the whole bp-catalyst-platform@1.4.540 upgrade aborted
+          # atomically on this one invalid CR). Refs #3159.
+          mechanism: bp-continuum
           rtoSeconds: 30
           rpoSeconds: 0
         placement:
@@ -5366,7 +5386,14 @@ spec:
       launchDefault: true
       ssoEnabled: true
     - name: metrics
-      hostnameTemplate: ""
+      # ClusterIP-only controller-runtime metrics — never publicly resolved.
+      # The platform/sandbox v1alpha1 source uses "" here, but the v1 CRD
+      # the in-cluster seed admits against enforces hostnameTemplate
+      # minLength:1, so a non-routable cluster-internal name is used instead
+      # of the empty string (caught by hw124 server-dry-run). The lockstep
+      # guard compares endpoints[].name/launchDefault, not hostnameTemplate,
+      # so this stays green. Refs #3159.
+      hostnameTemplate: "sandbox-metrics.sandbox.svc.cluster.local"
       port: 8080
       protocol: http
       tls: false


### PR DESCRIPTION
## What

Follow-up to #3176. The seed expansion shipped two CR field values valid under the `platform/<x>` v1alpha1 sources but **rejected by the v1 Blueprint CRD** that the in-cluster catalog-seed admits against. Helm applies the chart atomically, so ONE invalid CR aborted the entire `bp-catalyst-platform@1.4.540` upgrade on hw124 (`UpgradeFailed` → `RollbackFailed`) — meaning none of the 38 new catalog pages materialised.

## Root cause (caught live on hw124)

```
Helm upgrade failed ... chart bp-catalyst-platform@1.4.540: failed to create resource:
Blueprint.catalyst.openova.io "bp-continuum" is invalid:
spec.topology.perTopology.active-hot-standby.switchover.mechanism:
Unsupported value: "leader-election"
```

## Two fixes

1. **`bp-continuum` + `bp-sandbox` `switchover.mechanism`**: `leader-election` is not in the CRD enum (`bp-continuum`/`manual`/`bp-velero-restore`/`lua-record`/`mm2-symmetric`/`ccr-promote`/`raft-transition`/`sentinel-failover`/`none`). Both stateless controllers leader-flip via `bp-continuum` on region-kill — same as every other active-hot-standby seed entry.
2. **`bp-sandbox` `metrics` endpoint `hostnameTemplate: ''`** violated the v1 CRD `minLength: 1`. Set to a non-routable cluster-internal name. The lockstep guard compares `endpoints[].name`/`launchDefault`, not `hostnameTemplate`, so it stays green.

## Verification

- `helm template` → 76 CRs, exit 0; `helm lint` passes.
- `scripts/check-catalog-seed-lockstep.sh` → **PASS** (checked 66, fail 0).
- **`kubectl apply --dry-run=server -f <rendered>` against hw124's live CRD → 76 configured, 0 invalid** (the definitive atomic-apply validation).

Refs #3159

🤖 Generated with [Claude Code](https://claude.com/claude-code)
