### PR TITLE
fix(marketplace): re-pin SME smeTag to c96f998 (5-plan filter regression)

### DIFF
--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -311,7 +311,15 @@ images:
   admin:
     tag: "3c2f7e4"
   # All 10 SME microservices share one SHA tag (built from the same mono-repo commit).
-  smeTag: "41e02c8"
+  # 2026-06-09: 41e02c8 → c96f998 (#3157 merge SHA). 41e02c8 (built 2026-06-05)
+  # predates the #3157 marketplace-plans fix, so services-catalog:41e02c8 lacks
+  # filterPlansByProduct → the generic Org-provisioning picker rendered all 8
+  # plans (5 generic + 3 Sandbox dupes) instead of 5. A later catalyst-platform
+  # roll had re-pinned the stale 41e02c8, reverting the live filter. c96f998
+  # carries the server-side filter and is published for every services-* image
+  # (verified: services-auth, unchanged by #3157, also has c96f998 → the SME
+  # build is all-services, not path-filtered). Refs #3156.
+  smeTag: "c96f998"
 
 # ─── Runtime service coordinates (qa-loop iter-1, cluster
 # `catalyst-runtime-config-missing`) ────────────────────────────────────


### PR DESCRIPTION
## Problem
The Org-provisioning plan picker at `marketplace.hw124.omani.works/plans/` shows **8 plans** (5 generic S/M/L/XL/Flexi + 3 Sandbox dupes) instead of **5**. #3157 added a server-side `filterPlansByProduct` to `services-catalog`, but hw124's `sme/catalog` runs `services-catalog:41e02c8` — built 2026-06-05, **predating** the #3157 filter. A later catalyst-platform roll re-pinned the stale tag, reverting the live fix.

## Fix
Re-pin the shared `images.smeTag` `41e02c8 → c96f998` (#3157 merge SHA). c96f998 carries the filter and is published for every `services-*` image (verified `services-auth` — unchanged by #3157 — also has c96f998, so the SME build is all-services, not path-filtered → no ImagePullBackOff risk).

No manual `Chart.yaml`/bootstrap-kit version bump — the deploy-bot owns that on merge (avoids the version collision that sank the prior attempt #3175).

Refs #3156