### PR TITLE
fix(ui): unbreak AppDetail.tsx CSS-template backticks blocking catalyst deploys (Refs #3150)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
@@ -1551,7 +1551,7 @@ const APP_DETAIL_CSS = `
 /*
  * #3150 — pinned to the RIGHT edge of the hero's top line (margin-left:
  * auto pushes it past the flex-1 .hero-body so the title + chips fill the
- * middle). Vertically centered via the .hero `align-items: center`. The
+ * middle). Vertically centered via the .hero 'align-items: center'. The
  * button + compact hint stack so the hint sits directly under the CTA
  * without stealing horizontal room from the title row. On narrow widths
  * the .hero flex-wrap drops this whole block to its own line below.


### PR DESCRIPTION
## What

Unbreak `AppDetail.tsx` — a syntax error from #3174 was failing the `build-ui` step of **Build & Deploy Catalyst** on every push to `main`, blocking ALL `bp-catalyst-platform` version bumps and deploys.

## Root cause

#3174 ("right-align AppDetail Open button") added a comment **inside** the `APP_DETAIL_CSS` template literal whose text contained two raw backticks:

```
* middle). Vertically centered via the .hero `align-items: center`. The
```

Inside a backtick template-literal, those characters prematurely terminate the string. `tsc` then parsed the remainder as JS and failed:

```
src/pages/sovereign/AppDetail.tsx(1554,48): error TS1005: ',' expected.
```

## Fix

Swap the two backticks for single quotes in the comment (cosmetic comment text only — no behavior change).

## Verification

`esbuild` reproduces and confirms:
- **pre-fix**: errors at `1554:47` — `Expected ";" but found "align"` (same location as the CI TS1005).
- **post-fix**: transforms cleanly (46kb output, exit 0).

Refs #3150

🤖 Generated with [Claude Code](https://claude.com/claude-code)
