### PR TITLE
fix(harbor): repoint registry HTTPRoute backend harbor-core -> harbor (404)

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -228,6 +228,13 @@ spec:
   values:
     gateway:
       host: registry.${SOVEREIGN_FQDN}
+      # #3150 (2026-06-09): the chart's HTTPRoute backend defaults to
+      # `harbor-core`, but harbor-core is the API backend — it returns 404 for
+      # the portal SPA paths (`/`, `/account/sign-in`). registry.<sov>/ thus
+      # 404'd for every operator. The umbrella `harbor` Service (harbor-nginx
+      # front door) fans `/`→portal, `/api`,`/c`,`/service`→core, `/v2`→registry.
+      # Repoint the route at it. Verified live on hw124: `/`→200, `/v2/`→401.
+      backendService: harbor
     # G91.harbor (#2654) — wire bp-sso-bridge framework. The chart-side
     # post-install Job PUTs /api/v2.0/configurations with
     # auth_mode=oidc_auth + oidc_endpoint computed from sovereignFqdn.


### PR DESCRIPTION
## Problem
`registry.<sovereign-fqdn>/` returns **404 Page Not Found** for every operator (flagged live on hw124). Root-caused with evidence: the harbor HTTPRoute routes `/` to the `harbor-core` Service, but harbor-core is the **API backend** — it 404s the portal SPA paths (`/`, `/account/sign-in`). All 8 harbor pods are healthy; the route just points at the wrong Service.

## Fix
Set `gateway.backendService: harbor` in the bootstrap-kit harbor slot. The umbrella `harbor` Service (harbor-nginx front door) fans `/`→portal, `/api`,`/c`,`/service`→core, `/v2`→registry.

## Verified live on hw124 (route patched)
`registry.hw124.omani.works/` → **200**, `/account/sign-in` → **200**, `/v2/` → **401** (correct registry bearer-auth), `/c/oidc/login` → **302** to sovereign realm.

Refs #3150