### PR TITLE
fix(keycloak): enable implicit flow on sovereign-realm guacamole client (#3150)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -136,7 +136,7 @@ spec:
       # so bp-sso-bridge ns mirrors it) so the new bp-sso-bridge 0.2.8
       # can mint a master-realm token for POST /admin/realms. Closes
       # 403-on-realm-create gap caught live during #2744 walk.
-      version: 1.4.19
+      version: 1.4.20
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.19
+  version: 1.4.20
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,5 +1,16 @@
 apiVersion: v2
 name: bp-keycloak
+# 1.4.20 (#3150, 2026-06-09): enable `implicitFlowEnabled: true` on the
+# sovereign-realm `guacamole` Tier-2 client. Apache Guacamole's
+# guacamole-auth-sso-openid extension (1.5.5) implements ONLY the OIDC
+# implicit flow (response_type=id_token token) — with implicit flow
+# disabled, KC returned `error=unauthorized_client … Implicit flow is
+# disabled for the client` and guacamole.<fqdn> silent-SSO 404'd at the
+# OIDC bounce. Verified live on hw124: post-fix the same auth request 303s
+# to the catalyst-pin broker login (no unauthorized_client). Only the
+# guacamole client gets implicit flow; all other Tier-1/Tier-2 clients
+# stay implicitFlowEnabled:false. tests/g117-5-tier2-sso-clients.sh Case 7
+# locks the invariant. Refs #3150.
 # 1.4.18 (G117.5-followup #2914, 2026-06-03): emit
 # catalyst-kc-master-admin-credentials Secret carrying the bitnami-
 # generated master-realm `admin` user creds (looked up from the
@@ -163,7 +174,7 @@ name: bp-keycloak
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.4.19
+version: 1.4.20
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -593,7 +593,26 @@ data:
           "publicClient": false,
           "standardFlowEnabled": true,
           "directAccessGrantsEnabled": false,
-          "implicitFlowEnabled": false,
+          {{- /*
+            #3150 — Apache Guacamole's `guacamole-auth-sso-openid` extension
+            (all versions through 1.5.x, shipped here as
+            guacamole-auth-sso-openid-1.5.5.jar) implements ONLY the OpenID
+            Connect *implicit* flow: it issues `response_type=id_token token`
+            and validates the returned id_token directly against the JWKS
+            endpoint — there is no token-endpoint code exchange and no
+            `openid-response-type` knob to switch it to authorization-code.
+            With `implicitFlowEnabled: false` Keycloak rejects guacamole's
+            auth request with `error=unauthorized_client … Implicit flow is
+            disabled for the client`, which surfaces as the silent-SSO 404 on
+            guacamole.<sovereign-fqdn>. This client is therefore the ONE
+            Tier-2 client that legitimately needs implicit flow enabled —
+            every other client in this realm-import stays
+            `implicitFlowEnabled: false`. The implicit-flow id_token still
+            routes through the catalyst-pin broker (`kc_idp_hint=catalyst-pin`
+            on the Guacamole auth-endpoint), so the PIN-delegation security
+            posture is preserved.
+          */ -}}
+          "implicitFlowEnabled": true,
           "serviceAccountsEnabled": false,
           "authorizationServicesEnabled": false,
           "secret": {{ include "bp-keycloak.tier2ClientSecret" (dict "ctx" . "clientId" "guacamole") | quote }},

--- a/platform/keycloak/chart/tests/g117-5-tier2-sso-clients.sh
+++ b/platform/keycloak/chart/tests/g117-5-tier2-sso-clients.sh
@@ -159,4 +159,34 @@ diff <(echo "${realm_json}" | python3 -c "import json,sys; d=json.load(sys.stdin
      >/dev/null || { echo "FAIL: Tier-2 client secrets DRIFTED between two renders" >&2; exit 1; }
 echo "  PASS"
 
+# Case 7: Flow-type invariant (#3150). Apache Guacamole's
+# guacamole-auth-sso-openid extension supports ONLY the OIDC implicit
+# flow (response_type=id_token token); with implicitFlowEnabled:false KC
+# rejects its auth request with `unauthorized_client … Implicit flow is
+# disabled` and guacamole.<fqdn> silent-SSO 404s. So the `guacamole`
+# client MUST have implicitFlowEnabled:true. Every OTHER client in the
+# realm-import (Tier-1 + the other Tier-2 clients, which use standard
+# authorization-code flow) MUST stay implicitFlowEnabled:false — implicit
+# flow is a weaker posture and must not leak to clients that don't need it.
+echo "[g117-5-tier2-sso-clients] Case 7: guacamole implicit flow ON, all others OFF (#3150)"
+flow_violations=$(echo "${realm_json}" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+bad = []
+for c in d.get('clients', []):
+    cid = c['clientId']
+    impl = c.get('implicitFlowEnabled', False)
+    if cid == 'guacamole' and impl is not True:
+        bad.append(f'guacamole expected implicitFlowEnabled=true got {impl}')
+    if cid != 'guacamole' and impl is True:
+        bad.append(f'{cid} unexpectedly has implicitFlowEnabled=true')
+print('\n'.join(bad))
+")
+if [ -n "$flow_violations" ]; then
+  echo "FAIL: implicit-flow invariant broken:" >&2
+  echo "$flow_violations" >&2
+  exit 1
+fi
+echo "  PASS"
+
 echo "[bp-keycloak G117.5 W3.D1 Tier-2 SSO clients] All cases PASS"


### PR DESCRIPTION
## Root cause

`guacamole.<sovereign-fqdn>` silent-SSO 404'd at the OIDC bounce with `error=unauthorized_client … Implicit flow is disabled for the client`.

Apache Guacamole's `guacamole-auth-sso-openid` extension (shipped here as `guacamole-auth-sso-openid-1.5.5.jar`) implements **only the OIDC implicit flow** — it issues `response_type=id_token token` and validates the returned id_token directly against the JWKS endpoint. There is no token-endpoint code exchange and **no `openid-response-type` configuration knob** to switch it to authorization-code (so the guacamole-side fix path (b) does not exist in this version). The sovereign-realm `guacamole` KC client had `implicitFlowEnabled: false`, so Keycloak rejected the request.

This is downstream of #3177 (which fixed the OIDC *issuer*/realm-host); this PR fixes the deeper **flow-type** break.

### Live evidence on hw124

Before (the exact request Guacamole's extension issues):
```
location: https://guacamole.hw124.omani.works/#error=unauthorized_client&error_description=Client+is+not+allowed+to+initiate+browser+login+with+given+response_type.+Implicit+flow+is+disabled+for+the+client.
```

After (`implicitFlowEnabled: true` on the guacamole client):
```
HTTP/1.1 303 See Other
location: https://auth.hw124.omani.works/realms/sovereign/broker/catalyst-pin/login?...&client_id=guacamole&client_data=<b64 {"ru":"https://guacamole.hw124.omani.works/","rt":"id_token token",...}>
```
Zero `unauthorized_client` occurrences. The OIDC chain reaches the sovereign realm and routes through the **catalyst-pin broker**, so PIN delegation is preserved.

## Fix

- `platform/keycloak/chart/templates/configmap-sovereign-realm.yaml`: set `implicitFlowEnabled: true` on the `guacamole` Tier-2 client **only**. All other Tier-1/Tier-2 clients (standard auth-code flow) stay `implicitFlowEnabled: false` — implicit flow is a weaker posture and must not leak to clients that don't need it.
- `platform/keycloak/chart/Chart.yaml`: bump `bp-keycloak` 1.4.19 → 1.4.20.
- `platform/keycloak/chart/tests/g117-5-tier2-sso-clients.sh`: add Case 7 locking the invariant (guacamole implicit ON, all others OFF). All 7 cases pass locally via `helm template`.

## Not in scope (separately tracked)

`guacamole.<fqdn>/` (bare `/`) returns 404 while `/guacamole/` returns 200. Unlike harbor (#3181, a wrong-backend bug), the guacamole HTTPRoute is `Accepted=True/ResolvedRefs=True` with the correct `guacamole-server:80` backend — the 404 is Tomcat's ROOT-context behavior (the WAR is served at the `/guacamole/` context path). This is the pre-existing TBD-G6 `/guacamole.html → /guacamole/` redirect gap noted in the deployment template, not the SSO break, and is left for a focused follow-up.

## Remaining for human verification

The PIN wall blocks the final logged-in screenshot — the strongest wire proof is the OIDC redirect chain above reaching the sovereign realm without `unauthorized_client`. The final step (clicking through the catalyst-pin broker PIN delegation → Guacamole home) needs a human-PIN click.

Refs #3150

🤖 Generated with [Claude Code](https://claude.com/claude-code)