### PR TITLE
fix(keycloak): federated user inherits ZERO required actions (#3150)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -136,7 +136,11 @@ spec:
       # so bp-sso-bridge ns mirrors it) so the new bp-sso-bridge 0.2.8
       # can mint a master-realm token for POST /admin/realms. Closes
       # 403-on-realm-create gap caught live during #2744 walk.
-      version: 1.4.20
+      # 1.4.21 (#3150, 2026-06-09): federated user inherits ZERO Keycloak
+      # required actions — UPDATE_PASSWORD.defaultAction false +
+      # catalyst-pin IdP updateProfileFirstLoginMode off. Live-proven on
+      # hw124 (fresh federation -> requiredActions=[]). Refs #3150.
+      version: 1.4.21
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.20
+  version: 1.4.21
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,5 +1,22 @@
 apiVersion: v2
 name: bp-keycloak
+# 1.4.21 (#3150, 2026-06-09): federated user must inherit ZERO Keycloak
+# required actions. Flip UPDATE_PASSWORD.defaultAction true -> false in the
+# sovereign realm-import requiredActions block, and pin the catalyst-pin
+# IdP's updateProfileFirstLoginMode to "off". The sovereign realm is
+# passwordless (every user authenticates only through the catalyst-pin OIDC
+# broker), but UPDATE_PASSWORD being a realm DEFAULT action meant Keycloak
+# stamped it onto every brand-new federated user created by the
+# `first broker login auto link` flow's idp-create-user-if-unique step —
+# so a first-time-via-SSO operator was bounced to
+# /login-actions/required-action?execution=UPDATE_PASSWORD, violating the
+# founder requirement "user will NEVER be asked by Keycloak for auth."
+# Live-proof on hw124: a fresh catalyst-pin federation created a user with
+# requiredActions=["UPDATE_PASSWORD"] and the OIDC chain terminated on the
+# password interrupt; post-fix the same federation yields requiredActions=[]
+# and the chain returns 302+code with no profile/password prompt. trustEmail
+# already suppresses VERIFY_EMAIL; the auto-link flow + updateProfileFirstLogin
+# Mode:off suppress VERIFY_PROFILE/UPDATE_PROFILE. Refs #3150.
 # 1.4.20 (#3150, 2026-06-09): enable `implicitFlowEnabled: true` on the
 # sovereign-realm `guacamole` Tier-2 client. Apache Guacamole's
 # guacamole-auth-sso-openid extension (1.5.5) implements ONLY the OIDC
@@ -174,7 +191,7 @@ name: bp-keycloak
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.4.20
+version: 1.4.21
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,22 +1,31 @@
 apiVersion: v2
 name: bp-keycloak
 # 1.4.21 (#3150, 2026-06-09): federated user must inherit ZERO Keycloak
-# required actions. Flip UPDATE_PASSWORD.defaultAction true -> false in the
-# sovereign realm-import requiredActions block, and pin the catalyst-pin
-# IdP's updateProfileFirstLoginMode to "off". The sovereign realm is
-# passwordless (every user authenticates only through the catalyst-pin OIDC
-# broker), but UPDATE_PASSWORD being a realm DEFAULT action meant Keycloak
-# stamped it onto every brand-new federated user created by the
-# `first broker login auto link` flow's idp-create-user-if-unique step —
-# so a first-time-via-SSO operator was bounced to
-# /login-actions/required-action?execution=UPDATE_PASSWORD, violating the
-# founder requirement "user will NEVER be asked by Keycloak for auth."
-# Live-proof on hw124: a fresh catalyst-pin federation created a user with
-# requiredActions=["UPDATE_PASSWORD"] and the OIDC chain terminated on the
-# password interrupt; post-fix the same federation yields requiredActions=[]
-# and the chain returns 302+code with no profile/password prompt. trustEmail
-# already suppresses VERIFY_EMAIL; the auto-link flow + updateProfileFirstLogin
-# Mode:off suppress VERIFY_PROFILE/UPDATE_PROFILE. Refs #3150.
+# required actions on EVERY path. The sovereign realm is passwordless (every
+# user authenticates only through the catalyst-pin OIDC broker) but a fresh
+# catalyst-pin federation was hitting two stacked prompts. Three coupled
+# realm-import fixes (all live-proven on hw124 2026-06-09):
+#   1. UPDATE_PASSWORD.defaultAction true -> false. Being a realm DEFAULT
+#      action, KC stamped it onto every brand-new federated user created by
+#      the `first broker login auto link` flow's idp-create-user-if-unique
+#      step, bouncing first-time-via-SSO operators to
+#      /login-actions/required-action?execution=UPDATE_PASSWORD.
+#   2. Declarative user-profile `components` block marking firstName +
+#      lastName OPTIONAL (email stays required). The catalyst-pin id_token
+#      carries no name claims; KC's DEFAULT profile requires names for role
+#      `user`, injecting a transient VERIFY_PROFILE interrupt that
+#      updateProfileFirstLoginMode does NOT suppress — only making the names
+#      optional does. (After fix 1, the live chain still terminated at
+#      VERIFY_PROFILE until this landed.)
+#   3. catalyst-pin IdP updateProfileFirstLoginMode pinned "off" — belt-and-
+#      suspenders against the legacy review-profile path.
+# trustEmail=true already suppresses VERIFY_EMAIL. Live-proof: pre-fix a
+# fresh federation created requiredActions=["UPDATE_PASSWORD"] then bounced
+# to VERIFY_PROFILE; post-fix the same federation yields requiredActions=[]
+# and the chain returns 302+authorization-code to the console callback with
+# ZERO profile/password prompts. New chart test
+# tests/sovereign-realm-federated-no-required-actions.sh locks all of it.
+# Refs #3150.
 # 1.4.20 (#3150, 2026-06-09): enable `implicitFlowEnabled: true` on the
 # sovereign-realm `guacamole` Tier-2 client. Apache Guacamole's
 # guacamole-auth-sso-openid extension (1.5.5) implements ONLY the OIDC

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -119,6 +119,55 @@ tenant emit; tenant takes precedence here.
        still holds: the URL is computed from .Release.Name + .Release.Namespace,
        both runtime-configurable via the bp-keycloak HelmRelease. */ -}}
 {{- $kcAddr := printf "http://%s.%s.svc.cluster.local" .Release.Name .Release.Namespace -}}
+{{- /* ── Declarative user-profile config (#3150) ───────────────────────────
+     Keycloak 24+ has the declarative user profile ALWAYS ON. Its default
+     config marks `firstName` and `lastName` as required for the `user`
+     role. The catalyst-pin OIDC id_token carries only email (+ groups) —
+     NO given/family name — so when the broker creates a brand-new
+     federated user, Keycloak's first-broker-login evaluates the user
+     profile, finds firstName/lastName missing, and injects a TRANSIENT
+     VERIFY_PROFILE interrupt (this is NOT a stored required action and is
+     NOT suppressed by updateProfileFirstLoginMode — it is a profile-
+     completeness gate). Live-proven on hw124 2026-06-09: after fixing
+     UPDATE_PASSWORD the chain still terminated at
+     /login-actions/required-action?execution=VERIFY_PROFILE.
+
+     Fix: ship a declarative-user-profile component in the realm import
+     that drops `required` from firstName + lastName (email stays
+     required). With the names optional the profile is "complete" for a
+     name-less federated user, so no VERIFY_PROFILE fires — the broker
+     returns the authorization code with zero prompts. keycloak-config-cli
+     imports realm `components` reliably; the `kc.user.profile.config`
+     value MUST be a single-element array whose element is a JSON STRING
+     (Keycloak stores the profile as serialized JSON), so we build the
+     map with Go templating then `toJson`-encode it twice: once for the
+     inner profile document, once (implicitly, via the realm being valid
+     JSON) for the surrounding string. */ -}}
+{{- $userProfileDoc := dict
+    "attributes" (list
+      (dict "name" "username" "displayName" "${username}"
+        "validations" (dict "length" (dict "min" 3 "max" 255) "username-prohibited-characters" (dict) "up-username-not-idn-homograph" (dict))
+        "permissions" (dict "view" (list "admin" "user") "edit" (list "admin" "user"))
+        "multivalued" false)
+      (dict "name" "email" "displayName" "${email}"
+        "validations" (dict "email" (dict) "length" (dict "max" 255))
+        "required" (dict "roles" (list "user"))
+        "permissions" (dict "view" (list "admin" "user") "edit" (list "admin" "user"))
+        "multivalued" false)
+      (dict "name" "firstName" "displayName" "${firstName}"
+        "validations" (dict "length" (dict "max" 255) "person-name-prohibited-characters" (dict))
+        "permissions" (dict "view" (list "admin" "user") "edit" (list "admin" "user"))
+        "multivalued" false)
+      (dict "name" "lastName" "displayName" "${lastName}"
+        "validations" (dict "length" (dict "max" 255) "person-name-prohibited-characters" (dict))
+        "permissions" (dict "view" (list "admin" "user") "edit" (list "admin" "user"))
+        "multivalued" false)
+    )
+    "groups" (list
+      (dict "name" "user-metadata" "displayHeader" "User metadata" "displayDescription" "Attributes, which refer to user metadata")
+    )
+-}}
+{{- $userProfileConfigJSON := toJson $userProfileDoc -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -173,6 +222,28 @@ data:
         { "name": "sovereign-viewers" }
       ],
       {{- /*
+      #3150 (2026-06-09): declarative user-profile with firstName/lastName
+      OPTIONAL. The catalyst-pin id_token has no name claims; with the KC
+      default profile (names required for role `user`) a fresh federated
+      user is bounced to VERIFY_PROFILE. Dropping `required` from firstName
+      + lastName makes the name-less federated profile "complete" so no
+      profile prompt fires. See the $userProfileDoc builder near the top of
+      this template for the rationale. The value is a single-element array
+      whose element is the serialized profile JSON string.
+      */ -}}
+      "components": {
+        "org.keycloak.userprofile.UserProfileProvider": [
+          {
+            "providerId": "declarative-user-profile",
+            "config": {
+              "kc.user.profile.config": [
+                {{ $userProfileConfigJSON | toJson }}
+              ]
+            }
+          }
+        ]
+      },
+      {{- /*
       #3150 (2026-06-09): UPDATE_PASSWORD `defaultAction` MUST be false.
 
       Every user on this realm authenticates EXCLUSIVELY through the
@@ -199,11 +270,20 @@ data:
 
       The action stays `enabled:true` (still available for the rare
       self-service password-set case) but is no longer auto-applied to
-      every new user. trustEmail=true on the catalyst-pin IdP already
-      suppresses VERIFY_EMAIL, and the auto-link flow (no review-profile
-      execution) + updateProfileFirstLoginMode:off (set on the IdP below)
-      suppress VERIFY_PROFILE / UPDATE_PROFILE. With all three the
-      federated user inherits ZERO required actions.
+      every new user. This is ONE of three coupled #3150 fixes that
+      together yield an empty requiredActions list on every path:
+        1. UPDATE_PASSWORD.defaultAction=false (here) — no password prompt.
+        2. declarative user-profile with firstName/lastName OPTIONAL (the
+           `components` block above) — no VERIFY_PROFILE prompt. (The
+           catalyst-pin id_token carries no name claims; KC's DEFAULT
+           profile requires names for role `user`, which injects a
+           transient VERIFY_PROFILE interrupt that updateProfileFirstLogin
+           Mode does NOT suppress — only making the names optional does.)
+        3. trustEmail=true on the catalyst-pin IdP — no VERIFY_EMAIL.
+      updateProfileFirstLoginMode:off (set on the IdP below) is a fourth,
+      belt-and-suspenders guard against the legacy review-profile path.
+      Live-proven on hw124 2026-06-09: with all of these a fresh
+      federation returns 302+code with ZERO prompts.
       */ -}}
       "requiredActions": [
         {

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -172,13 +172,46 @@ data:
         { "name": "sovereign-ops" },
         { "name": "sovereign-viewers" }
       ],
+      {{- /*
+      #3150 (2026-06-09): UPDATE_PASSWORD `defaultAction` MUST be false.
+
+      Every user on this realm authenticates EXCLUSIVELY through the
+      catalyst-pin OIDC broker (PIN -> catalyst-api session -> federated
+      identity) — there are NO local passwords. When the broker creates
+      a brand-new federated user via the `first broker login auto link`
+      flow's `idp-create-user-if-unique` step, Keycloak stamps the realm's
+      DEFAULT required actions onto that fresh user. With
+      `UPDATE_PASSWORD.defaultAction=true` the new operator was immediately
+      bounced to /login-actions/required-action?execution=UPDATE_PASSWORD —
+      a password-set prompt that makes no sense for a passwordless
+      broker-only realm and directly violates the founder requirement
+      "user will NEVER be asked by Keycloak for auth."
+
+      Live-proof on hw124 (2026-06-09): a fresh catalyst-pin federation
+      created user newop-...@hw124.omani.works with
+      requiredActions=["UPDATE_PASSWORD"], and the OIDC chain terminated
+      on the UPDATE_PASSWORD required-action interrupt instead of
+      returning the authorization `code`. Flipping defaultAction->false
+      removes UPDATE_PASSWORD from the default set so federated users are
+      created with an EMPTY requiredActions list and the chain returns
+      302+code with no profile/password prompt on every path — including
+      a first-time-via-SSO operator who never PIN-logged-in before.
+
+      The action stays `enabled:true` (still available for the rare
+      self-service password-set case) but is no longer auto-applied to
+      every new user. trustEmail=true on the catalyst-pin IdP already
+      suppresses VERIFY_EMAIL, and the auto-link flow (no review-profile
+      execution) + updateProfileFirstLoginMode:off (set on the IdP below)
+      suppress VERIFY_PROFILE / UPDATE_PROFILE. With all three the
+      federated user inherits ZERO required actions.
+      */ -}}
       "requiredActions": [
         {
           "alias": "UPDATE_PASSWORD",
           "name": "Update Password",
           "providerId": "UPDATE_PASSWORD",
           "enabled": true,
-          "defaultAction": true,
+          "defaultAction": false,
           "priority": 30,
           "config": {}
         },
@@ -826,6 +859,18 @@ data:
 
         trustEmail=true skips KC's email-verify required-action since
         we already verified email via the PIN delivery.
+
+        updateProfileFirstLoginMode=off (#3150): Keycloak's per-IdP
+        default for this knob is "on", which arms the review-profile /
+        VERIFY_PROFILE prompt on first broker login. The custom
+        `first broker login auto link` flow above has no review-profile
+        execution so this is already bypassed today, but pinning it to
+        "off" here is the explicit, durable guard so a future declarative
+        user-profile change or a flow edit can never re-surface a profile
+        prompt. Combined with trustEmail=true (no VERIFY_EMAIL) and
+        UPDATE_PASSWORD.defaultAction=false (no password prompt — see the
+        requiredActions block above) the federated user is created with an
+        EMPTY requiredActions list on EVERY path.
         */ -}}
         {
           "alias": "catalyst-pin",
@@ -833,6 +878,7 @@ data:
           "providerId": "oidc",
           "enabled": true,
           "trustEmail": true,
+          "updateProfileFirstLoginMode": "off",
           "storeToken": false,
           "addReadTokenRoleOnCreate": false,
           "authenticateByDefault": false,

--- a/platform/keycloak/chart/tests/sovereign-realm-federated-no-required-actions.sh
+++ b/platform/keycloak/chart/tests/sovereign-realm-federated-no-required-actions.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# bp-keycloak — #3150: a catalyst-pin-federated user must inherit ZERO
+# Keycloak required actions on EVERY path (incl. a first-time-via-SSO
+# operator who never PIN-logged-in before).
+#
+# Founder hard requirement: "user will NEVER be asked by Keycloak for auth."
+#
+# Root cause this guards against:
+#   The sovereign realm is passwordless — every user authenticates only
+#   through the catalyst-pin OIDC broker. When the broker creates a
+#   brand-new federated user via the `first broker login auto link` flow's
+#   `idp-create-user-if-unique` step, Keycloak stamps the realm's DEFAULT
+#   required actions onto that fresh user. So if UPDATE_PASSWORD (or any
+#   other action) carries defaultAction=true, the new operator is bounced
+#   to /login-actions/required-action?execution=UPDATE_PASSWORD — a
+#   password-set prompt that makes no sense for a broker-only realm.
+#   Live-proven on hw124 2026-06-09: a fresh federation created a user with
+#   requiredActions=["UPDATE_PASSWORD"] and the OIDC chain terminated on the
+#   password interrupt. Post-fix the same federation yields requiredActions=[].
+#
+# Invariants locked here (any future drift fails this render test BEFORE
+# it reaches a fresh-prov operator walk):
+#   1. NO requiredAction in the sovereign realm import has defaultAction=true.
+#   2. UPDATE_PASSWORD specifically is enabled but NOT a default action.
+#   3. The catalyst-pin IdP has trustEmail=true (no VERIFY_EMAIL).
+#   4. The catalyst-pin IdP has updateProfileFirstLoginMode="off"
+#      (no review-profile / VERIFY_PROFILE / UPDATE_PROFILE prompt).
+#   5. The catalyst-pin IdP's firstBrokerLoginFlowAlias points at the
+#      custom no-prompt auto-link flow, and that flow contains
+#      idp-create-user-if-unique + idp-auto-link and NO review-profile
+#      execution.
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+SOV_FQDN="smoke.omani.works"
+out=$("$helm" template smoke "$chart_dir" --set sovereignFQDN="${SOV_FQDN}" 2>/dev/null)
+
+realm_json=$(echo "$out" | python3 -c "
+import yaml, sys
+docs = list(yaml.safe_load_all(sys.stdin))
+for d in docs:
+    if d and d.get('kind') == 'ConfigMap' and 'sovereign-realm-config' in d.get('metadata', {}).get('name', ''):
+        print(d['data']['sovereign-realm.json'])
+        sys.exit(0)
+sys.exit(1)
+")
+
+if [ -z "${realm_json}" ]; then
+  echo "FAIL: sovereign-realm-config ConfigMap did not render (chart misconfigured)" >&2
+  exit 1
+fi
+
+# Case 1: NO required action is a default action.
+echo "[sovereign-realm-federated-no-required-actions] Case 1: no defaultAction=true required actions (#3150)"
+default_actions=$(echo "${realm_json}" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+bad = [a.get('alias', a.get('providerId','?')) for a in d.get('requiredActions', []) if a.get('defaultAction') is True]
+print(' '.join(bad))
+")
+if [ -n "$default_actions" ]; then
+  echo "FAIL: realm has default required actions that get stamped onto every federated user: $default_actions" >&2
+  echo "      A brand-new catalyst-pin federated user would be prompted for these — violates 'user will NEVER be asked by Keycloak for auth'." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# Case 2: UPDATE_PASSWORD present, enabled, but NOT a default action.
+echo "[sovereign-realm-federated-no-required-actions] Case 2: UPDATE_PASSWORD enabled but not default (#3150)"
+upw=$(echo "${realm_json}" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for a in d.get('requiredActions', []):
+    if a.get('alias') == 'UPDATE_PASSWORD' or a.get('providerId') == 'UPDATE_PASSWORD':
+        print(f\"enabled={a.get('enabled')} default={a.get('defaultAction')}\")
+        break
+else:
+    print('MISSING')
+")
+case "$upw" in
+  "enabled=True default=False") echo "  PASS ($upw)" ;;
+  *) echo "FAIL: UPDATE_PASSWORD must be enabled=True default=False, got: $upw" >&2; exit 1 ;;
+esac
+
+# Case 3: catalyst-pin IdP trustEmail=true.
+echo "[sovereign-realm-federated-no-required-actions] Case 3: catalyst-pin trustEmail=true (no VERIFY_EMAIL)"
+trust=$(echo "${realm_json}" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for idp in d.get('identityProviders', []):
+    if idp.get('alias') == 'catalyst-pin':
+        print(idp.get('trustEmail'))
+        break
+else:
+    print('MISSING')
+")
+if [ "$trust" != "True" ]; then
+  echo "FAIL: catalyst-pin IdP trustEmail must be true (got: $trust)" >&2
+  exit 1
+fi
+echo "  PASS"
+
+# Case 4: catalyst-pin IdP updateProfileFirstLoginMode=off.
+echo "[sovereign-realm-federated-no-required-actions] Case 4: catalyst-pin updateProfileFirstLoginMode=off (no VERIFY_PROFILE) (#3150)"
+upmode=$(echo "${realm_json}" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for idp in d.get('identityProviders', []):
+    if idp.get('alias') == 'catalyst-pin':
+        print(idp.get('updateProfileFirstLoginMode','MISSING'))
+        break
+else:
+    print('IDP-MISSING')
+")
+if [ "$upmode" != "off" ]; then
+  echo "FAIL: catalyst-pin IdP updateProfileFirstLoginMode must be 'off' (got: $upmode)" >&2
+  echo "      Default 'on' arms the review-profile/VERIFY_PROFILE prompt on first broker login." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# Case 5: firstBrokerLoginFlowAlias points at the no-prompt auto-link flow,
+# and that flow has create-user + auto-link and NO review-profile step.
+echo "[sovereign-realm-federated-no-required-actions] Case 5: auto-link first-broker-login flow, no review-profile step (#3150)"
+flow_check=$(echo "${realm_json}" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+idp = next((i for i in d.get('identityProviders', []) if i.get('alias') == 'catalyst-pin'), None)
+if not idp:
+    print('IDP-MISSING'); sys.exit(0)
+alias = idp.get('firstBrokerLoginFlowAlias')
+if not alias:
+    print('FLOW-ALIAS-MISSING'); sys.exit(0)
+flow = next((f for f in d.get('authenticationFlows', []) if f.get('alias') == alias), None)
+if not flow:
+    print(f'FLOW-NOT-DEFINED:{alias}'); sys.exit(0)
+provs = [e.get('authenticator') for e in flow.get('authenticationExecutions', [])]
+if 'idp-create-user-if-unique' not in provs:
+    print(f'MISSING-CREATE-USER:{provs}'); sys.exit(0)
+if 'idp-auto-link' not in provs:
+    print(f'MISSING-AUTO-LINK:{provs}'); sys.exit(0)
+# review-profile is the prompting step we must NOT have
+if any('review-profile' in (p or '') or 'review profile' in (p or '') for p in provs):
+    print(f'HAS-REVIEW-PROFILE:{provs}'); sys.exit(0)
+print('OK')
+")
+if [ "$flow_check" != "OK" ]; then
+  echo "FAIL: first-broker-login flow invariant broken: $flow_check" >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[bp-keycloak #3150 federated-no-required-actions] All cases PASS"

--- a/platform/keycloak/chart/tests/sovereign-realm-federated-no-required-actions.sh
+++ b/platform/keycloak/chart/tests/sovereign-realm-federated-no-required-actions.sh
@@ -155,4 +155,37 @@ if [ "$flow_check" != "OK" ]; then
 fi
 echo "  PASS"
 
+# Case 6: declarative user-profile makes firstName + lastName OPTIONAL
+# (email stays required). KC's default profile requires names for the
+# `user` role; the catalyst-pin id_token carries no name claims, so the
+# default would inject a transient VERIFY_PROFILE prompt on first broker
+# login. The realm import MUST ship a declarative-user-profile component
+# that drops `required` from firstName + lastName.
+echo "[sovereign-realm-federated-no-required-actions] Case 6: user-profile firstName/lastName optional, email required (#3150)"
+profile_check=$(echo "${realm_json}" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+comps = d.get('components', {}).get('org.keycloak.userprofile.UserProfileProvider', [])
+if not comps:
+    print('NO-USERPROFILE-COMPONENT'); sys.exit(0)
+cfg = comps[0].get('config', {}).get('kc.user.profile.config', [])
+if not cfg:
+    print('NO-PROFILE-CONFIG'); sys.exit(0)
+prof = json.loads(cfg[0])
+req = {a['name']: a.get('required') for a in prof.get('attributes', [])}
+if req.get('firstName') is not None:
+    print(f\"firstName-still-required:{req.get('firstName')}\"); sys.exit(0)
+if req.get('lastName') is not None:
+    print(f\"lastName-still-required:{req.get('lastName')}\"); sys.exit(0)
+if req.get('email') is None:
+    print('email-not-required (should stay required)'); sys.exit(0)
+print('OK')
+")
+if [ "$profile_check" != "OK" ]; then
+  echo "FAIL: user-profile invariant broken: $profile_check" >&2
+  echo "      A name-less catalyst-pin federated user would hit VERIFY_PROFILE." >&2
+  exit 1
+fi
+echo "  PASS"
+
 echo "[bp-keycloak #3150 federated-no-required-actions] All cases PASS"


### PR DESCRIPTION
## Problem

A catalyst-pin-federated user — created on first SSO federation via the
`first broker login auto link` flow's `idp-create-user-if-unique` step —
was prompted by Keycloak on first login. This violates the founder hard
requirement: **"user will NEVER be asked by Keycloak for auth."**

## Root cause (live-proven on hw124, two stacked prompts)

The sovereign realm is **passwordless** — every user authenticates only
through the catalyst-pin OIDC broker. A fresh federation hit **two**
distinct interrupts, discovered by driving a real OIDC federation chain
on hw124 with a brand-new email:

1. **`UPDATE_PASSWORD`** — `UPDATE_PASSWORD` carried `defaultAction: true`
   in the realm-import `requiredActions` block. Keycloak stamps the realm's
   **default** required actions onto every brand-new user created by
   `idp-create-user-if-unique`. First evidence: the redirect chain ended at
   `/login-actions/required-action?execution=UPDATE_PASSWORD` and the admin
   API showed the new user with `requiredActions: ["UPDATE_PASSWORD"]`.

2. **`VERIFY_PROFILE`** — after fixing #1, the live chain *still* terminated
   at `/login-actions/required-action?execution=VERIFY_PROFILE`. Keycloak's
   declarative user profile (always-on in 24+) marks `firstName` + `lastName`
   as **required** for role `user`. The catalyst-pin id_token carries **no
   name claims**, so the broker creates a name-less user; first-broker-login
   evaluates the profile, finds the required names missing, and injects a
   **transient** `VERIFY_PROFILE` interrupt. This is NOT a stored required
   action and is NOT suppressed by `updateProfileFirstLoginMode` — only
   making the names optional removes it.

## Fix (three coupled realm-import changes)

1. `UPDATE_PASSWORD.defaultAction` `true` → `false` (stays `enabled: true`
   for the rare self-service path; just no longer auto-stamped).
2. Ship a **declarative-user-profile `components` block** that drops
   `required` from `firstName` + `lastName` (email stays required). Built
   via a Helm `dict` + `toJson` so the serialized profile JSON is correctly
   escaped as the `kc.user.profile.config` string value.
3. catalyst-pin IdP `updateProfileFirstLoginMode` pinned to `"off"` — belt-
   and-suspenders against the legacy review-profile path.

`trustEmail: true` already suppresses `VERIFY_EMAIL`.

## Live verification on hw124

Drove a fresh catalyst-pin federation end-to-end (test-session-minted owner
cookie → KC broker → catalyst-api `/oidc/auth` → broker code exchange →
first-broker-login auto-link). **Post-fix** the chain terminates at:

```
console.hw124.omani.works/auth/callback?state=…&session_state=…&code=…
```

— the authorization **code** returned to the console callback with **ZERO**
required-action interrupts. The newly-created KC user
(`newop4-…@hw124.omani.works`, federated via `catalyst-pin`) has
`requiredActions: []`, `emailVerified: true`. hw124 was left as found
(test-session env reverted by Flux reconcile; HR resumed).

## Tests

New `tests/sovereign-realm-federated-no-required-actions.sh` (6 cases): no
`defaultAction=true` actions; `UPDATE_PASSWORD` enabled-not-default;
`trustEmail=true`; `updateProfileFirstLoginMode=off`; auto-link flow with no
review-profile step; user-profile `firstName`/`lastName` optional + email
required. All 10 keycloak chart tests pass; `helm lint` clean.

3-way version lockstep bumped `1.4.20` → `1.4.21` (Chart.yaml ==
blueprint.yaml `spec.version` == bootstrap-kit pin).

Refs #3150

🤖 Generated with [Claude Code](https://claude.com/claude-code)