### PR TITLE
fix(topology): single-region-safe fixes (bp-sandbox enum, bp-continuum idle, powerdns-admin CNPG) + audit (#3189)

### DIFF
--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -79,7 +79,9 @@ spec:
       # 0.1.3 (#3150/#3173, 2026-06-10): image repoint
       # ngoduykhanh/powerdns-admin:0.4.2 (dead tag → ImagePullBackOff) →
       # powerdnsadmin/pda-legacy:0.4.2 + drop spurious ghcr-pull pullSecret.
-      version: 0.1.3
+      # 0.1.4 (#3189): wire SQLALCHEMY_DATABASE_URI from the CNPG `uri`
+      # secret key so pda-legacy uses pda-pg postgres, not baked-in SQLite.
+      version: 0.1.4
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns-admin

--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -193,7 +193,10 @@ spec:
       # helper), not bare `newapi`. Pre-fix every Sovereign's
       # sandbox-controller TokenMint POST returned `no such host`,
       # blocking the canonical Pillar-4 qwen-code customer journey.
-      version: 0.3.9
+      # 0.3.10 (#3189): topology source drift fix —
+      # switchover.mechanism leader-election → bp-continuum (valid CRD
+      # enum) + non-empty metrics hostnameTemplate; matches catalog-seed.
+      version: 0.3.10
       sourceRef:
         kind: HelmRepository
         name: bp-sandbox

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -147,7 +147,10 @@ spec:
       # implicit-flow id_token fragment landed on a Tomcat 404 ROOT page
       # and silent-SSO never reached the webapp). KC `guacamole` client's
       # `/*` redirectUris wildcard already accepts it.
-      version: 0.2.2
+      # 0.2.3: lockstep with chart bump d232af3f (upstream 1.5.5) — the
+      # deploy commit bumped Chart.yaml but the auto-bump pin hook didn't
+      # fire, leaving this pin drifted (broke the full lockstep sweep).
+      version: 0.2.3
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole

--- a/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+++ b/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
@@ -127,7 +127,9 @@ spec:
       # Principle #13 (chart-pin bumps must match a GHCR tag that
       # exists — verified post-merge via crane manifest before any
       # fresh-prov walk).
-      version: 0.1.3
+      # 0.1.4 (#3189): prerequisite-check initContainer no longer
+      # crashloops on single-region (no cnpg-pair) — exits 0 + idle-Ready.
+      version: 0.1.4
       sourceRef:
         kind: HelmRepository
         name: bp-continuum

--- a/docs/sessions/2026-06-10/pillar3-multiregion-design/DESIGN.md
+++ b/docs/sessions/2026-06-10/pillar3-multiregion-design/DESIGN.md
@@ -1,0 +1,112 @@
+# Pillar-3 Multi-Region (cnpg-pair + Continuum) — design + live gap analysis (#3189 Deliverable C)
+
+Date: 2026-06-10 · Sovereign: hw124 (`catalyst-hw124.omani.works`) · Author: hatiyildiz
+
+## 0. TL;DR
+
+hw124 was assumed single-region, but live state shows it is provisioned as **two
+regions of compute** (`me-east-215-a` cluster-id 168, `me-east-215-b` cluster-id
+169) — each running a **complete, fully-independent** Catalyst stack (own Flux,
+own 56-ish HRs, own standalone CNPG clusters). What it is **not** is a Pillar-3
+*active-hot-standby* topology: there is **no cross-region replication link**.
+
+The cross-region DR layer the 9 active-hot-standby Blueprints declare in their
+`topology.perTopology.active-hot-standby` block (`replication.backend: cnpg-pair`,
+`switchover.mechanism: bp-continuum`) is entirely **absent** at runtime. This doc
+specifies the target path and enumerates the concrete wiring gaps observed live.
+
+## 1. Target cross-region path (per the 9 active-hot-standby Blueprints)
+
+Each of the 9 cnpg-pair-backed apps (bp-catalyst-platform, bp-gitea, bp-grafana,
+bp-harbor, bp-keycloak, bp-guacamole, bp-netbird, bp-spire, + the bp-cnpg-pair
+primitive itself) replicates Postgres state region A → region B:
+
+```
+        Region A (primary)                         Region B (replica)
+   ┌──────────────────────────┐             ┌──────────────────────────┐
+   │ CNPG Cluster <app>-pg     │  WAL        │ CNPG ReplicaCluster       │
+   │   primary + 2 HA replicas │  stream     │   bootstrap.pg_basebackup │
+   │                           │ ──────────▶ │   externalClusters[]:     │
+   │ Service <app>-pg-primary  │  over       │     <app>-pg-primary-mesh │
+   │   -mesh                   │  Cilium     │   replica.enabled: true   │
+   │   annotation:             │  ClusterMesh│                           │
+   │   service.cilium.io/      │             │ promotable when WAL-lag   │
+   │   global: "true"          │             │   < walStreaming threshold│
+   └──────────────────────────┘             └──────────────────────────┘
+                │                                         ▲
+                │  Continuum CR (dr.openova.io/v1)        │
+                ▼                                         │
+   ┌──────────────────────────────────────────────────────────────────┐
+   │ continuum-controller — 7-step switchover on region-A-kill:        │
+   │  1 detect primary loss (lease witness: cloudflare-kv / dns-quorum) │
+   │  2 verify replica WAL-lag < threshold (RPO=0 gate)                 │
+   │  3 CNPG promote ReplicaCluster → primary (pg_ctl promote)          │
+   │  4 PDM lua-record DNS flip (A-record → region-B ingress)           │
+   │  5 drain region-A HTTPRoutes                                       │
+   │  6 post-switchover health probe (multi-vantage DNS resolve)        │
+   │  7 NATS audit publish (catalyst.audit)                             │
+   │  Target: RTO 30s · RPO 0 (sync WAL).                              │
+   └──────────────────────────────────────────────────────────────────┘
+```
+
+The mechanics already exist in code:
+- `platform/cnpg-pair/chart` renders primary Cluster + replica ReplicaCluster +
+  the `*-primary-mesh` global Service + the `*-audit-config` ConfigMap
+  (label `catalyst.openova.io/audit-config: "true"`).
+- `core/controllers/continuum` ships the full 7-step Sequencer, lease witnesses
+  (cloudflare-kv / dns-quorum), PDM lua-record client, and health probe.
+- `bp-continuum`'s `prerequisite-check` probes for the cnpg-pair audit ConfigMap
+  to decide active-vs-idle.
+
+## 2. Live gap analysis on hw124 (what's missing for Pillar-3)
+
+| # | Gap (observed live) | Evidence |
+|---|---------------------|----------|
+| G1 | **No `bp-cnpg-pair` installed.** Only `bp-cnpg` (the operator) is present. No primary/replica cluster-pair, no ReplicaCluster, no `*-primary-mesh` Service. | `kubectl get hr -A` → `bp-cnpg` only; `kubectl get cm -A -l catalyst.openova.io/audit-config=true` → none. |
+| G2 | **`bp-cnpg-pair` is not in the bootstrap-kit.** `clusters/_template/bootstrap-kit/` has `62-bp-continuum.yaml` but no cnpg-pair slot, so a fresh prov never installs it. The chart also defaults `cnpgPair.enabled: false`. | `ls clusters/_template/bootstrap-kit/ \| grep cnpg-pair` → empty. |
+| G3 | **Cilium ClusterMesh between A and B is not connected.** Region names/IDs differ (precondition met) but the `cilium-clustermesh` Secret is absent in region A, so cross-region pod/service routing — the transport cnpg-pair WAL streaming rides on — is down. | `kubectl -n kube-system get secret cilium-clustermesh` → NotFound; `cilium-config` cluster-name A=`hw124-mesh`/168, B=`hw124-me-east--b`/169. |
+| G4 | **No global services.** No Service carries `service.cilium.io/global: "true"`, so even with mesh up there is nothing for region B to consume. | Service annotation scan → 0 hits. |
+| G5 | **All CNPG clusters are standalone HA-within-region.** Both regions independently run `gitea-pg`, `harbor-pg`, etc. as 2-instance clusters — no `ReplicaCluster` kind anywhere. | `kubectl get clusters.postgresql.cnpg.io -A` in both regions → all standalone primaries. |
+| G6 | **No `Continuum` CR seeded.** continuum-controller has 0 CRs to reconcile (correctly idle once the crashloop guard is fixed — see #3189 A2). | `kubectl get continuum -A` → none. |
+
+## 3. Why a fresh 2-region prov was NOT fired
+
+Per the #3189 brief, autonomy was granted to provision a fresh 2-region Sovereign.
+A fresh prov was **deliberately not fired** because it would land in the *exact same
+state* observed above: the bootstrap-kit ships `bp-continuum` but neither
+`bp-cnpg-pair` (G2) nor a ClusterMesh-peering step (G3), so the cross-region DR
+layer would again be absent. Provisioning would burn HCS EIP/VPC quota
+(`feedback_hcs_quota_structural_blocker_pattern`) and reproduce, not close, the gap.
+
+The gap is in the **bootstrap-kit wiring + ClusterMesh peering**, not in any
+per-Blueprint topology declaration (those are clean — see #3189 Deliverable B).
+The single-region-safe code fixes (#3189 A1–A3) are the shippable, verified work
+this session; the Pillar-3 enablement below is the follow-up backlog.
+
+## 4. Follow-up backlog to enable Pillar-3 (ordered)
+
+1. **ClusterMesh peering as a bootstrap-kit step** (G3): after both regions' k3s
+   are up, exchange CA + apiserver endpoints and write the `cilium-clustermesh`
+   Secret on both sides (or `cilium clustermesh connect`). This is the transport
+   prerequisite for everything else.
+2. **Add `bp-cnpg-pair` to the bootstrap-kit** (G1/G2) gated on
+   `SOVEREIGN_ENABLE_HOT_STANDBY=true` + a 2nd region present, with
+   `cnpgPair.enabled: true`, `primary.region`/`replica.region` stamped from the
+   deployment's region list. One cnpg-pair per stateful app (or a shared
+   convention) so each `*-pg` primary in A gets a ReplicaCluster in B.
+3. **Seed one `Continuum` CR per active-hot-standby app** referencing its
+   cnpg-pair + lease witness, so continuum-controller leaves idle and starts
+   reconciling (the prerequisite-check then logs PASS, not the single-region
+   idle path from #3189 A2).
+4. **Region-kill failover walk**: drop region A, assert continuum promotes the B
+   ReplicaCluster + flips DNS within RTO 30s with 0 tx lost (RPO 0), capture
+   evidence per `docs/ledger/UAT.md`.
+
+## 5. Relationship to #3189 single-region fixes
+
+The #3189 A2 fix (continuum idle-no-op on single-region) is the **correct default**
+until items 1–4 land: with no cnpg-pair, continuum-controller MUST sit idle-Ready,
+not crashloop. Once the backlog wires cnpg-pair + a Continuum CR, the same probe
+logs PASS and the controller activates — no further code change to bp-continuum
+needed. The two are complementary: A2 makes the absence graceful; §4 makes the
+presence functional.

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/category: platform
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.2
+  version: 0.2.3
   card:
     title: Apache Guacamole
     summary: Clientless HTML5 remote-desktop gateway. Browser-based RDP / VNC / SSH and kubectl-exec into Pods, with Keycloak SSO and full session recording to SeaweedFS. One Guacamole per Sovereign per ADR-0001 §11.

--- a/platform/powerdns-admin/blueprint.yaml
+++ b/platform/powerdns-admin/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 0.1.3
+  version: 0.1.4
   card:
     title: powerdns-admin
     summary: |

--- a/platform/powerdns-admin/chart/Chart.yaml
+++ b/platform/powerdns-admin/chart/Chart.yaml
@@ -17,7 +17,7 @@ name: bp-powerdns-admin
 # to the maintained `powerdnsadmin/pda-legacy:0.4.2`. Drop the spurious
 # `ghcr-pull` imagePullSecret (proxy-dockerhub is anonymous; ghcr-pull is
 # the wrong cred and isn't reflected into this namespace). See values.yaml.
-version: 0.1.3
+version: 0.1.4
 description: |
   PowerDNS-Admin (ngoduykhanh/powerdns-admin) web UI Blueprint for
   per-Sovereign PowerDNS zone + record management. Drives the

--- a/platform/powerdns-admin/chart/templates/deployment.yaml
+++ b/platform/powerdns-admin/chart/templates/deployment.yaml
@@ -40,6 +40,29 @@ spec:
               protocol: TCP
           env:
             # ─── Database wiring ───────────────────────────────────────
+            # The `powerdnsadmin/pda-legacy` image (current upstream) does
+            # NOT honor the SQLA_DB_* split env vars — those were the old
+            # `ngoduykhanh/powerdns-admin` entrypoint convention, which
+            # assembled the SQLAlchemy URI from them at container start.
+            # pda-legacy's `create_app()` instead loads its baked-in
+            # `powerdnsadmin/docker_config.py` (which HARDCODES
+            # `SQLALCHEMY_DATABASE_URI = 'sqlite:////data/powerdns-admin.db'`)
+            # and then runs `AppSettings.load_environment()` LAST, which
+            # only overrides config keys whose UPPERCASED env var name
+            # matches a known setting — i.e. it reads `SQLALCHEMY_DATABASE_URI`
+            # verbatim, never the SQLA_DB_* parts. So to actually land on
+            # the provisioned CNPG `pda-pg` cluster (instead of silently
+            # falling back to on-disk SQLite) we MUST set the full
+            # `SQLALCHEMY_DATABASE_URI` from the CNPG-generated `uri` key.
+            # Refs #3189.
+            - name: SQLALCHEMY_DATABASE_URI
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.databaseSecret.name | default "pda-database-secret" }}
+                  key: {{ .Values.databaseSecret.uriKey | default "uri" }}
+            # The SQLA_DB_* vars below are retained for documentation +
+            # forward/backward compatibility with the older ngoduykhanh
+            # image; pda-legacy ignores them but they are harmless.
             - name: SQLA_DB_TYPE
               value: "postgres"
             - name: SQLA_DB_HOST

--- a/platform/powerdns-admin/chart/values.yaml
+++ b/platform/powerdns-admin/chart/values.yaml
@@ -123,6 +123,11 @@ databaseSecret:
   cnpgSecretName: pda-pg-app
   passwordKey: password
   usernameKey: username
+  # CNPG stamps a ready-to-use `uri` key (postgresql://user:pass@host:port/db)
+  # into its generated `<cluster>-app` Secret. pda-legacy's create_app()
+  # reads SQLALCHEMY_DATABASE_URI verbatim, so the deployment wires this
+  # key straight through — see deployment.yaml DB-wiring comment. Refs #3189.
+  uriKey: uri
 
 # ─── PowerDNS backend endpoint ───────────────────────────────────────────
 # Where the running PDA container reaches the authoritative server.

--- a/platform/sandbox/blueprint.yaml
+++ b/platform/sandbox/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-sandbox
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.3.9
+  version: 0.3.10
   card:
     title: Sandbox
     summary: |
@@ -63,12 +63,13 @@ spec:
   # durable state is the per-Sandbox manifests it writes to the per-Org
   # `catalyst-tenant` Gitea repo (which is the Gitea-replicated state,
   # not the controller's). active-hot-standby runs two controller
-  # replicas (one per RTZ region) sharing leader-election lease via the
-  # rtz-A CNPG-replicated leases CRD; switchover is leader-flip only
-  # (no data replication required on the controller plane). Each
-  # per-Sandbox session (D31 pair when SOVEREIGN_ENABLE_HOT_STANDBY=true)
-  # is replicated via the chart's own sandbox.cnpg.activeHotStandby
-  # block, not at the bp-sandbox-controller layer.
+  # replicas (one per RTZ region) sharing a leader-election lease via
+  # the rtz-A CNPG-replicated leases CRD; on region-kill the leader-flip
+  # is driven by bp-continuum (no data replication required on the
+  # controller plane). Each per-Sandbox session (D31 pair when
+  # SOVEREIGN_ENABLE_HOT_STANDBY=true) is replicated via the chart's own
+  # sandbox.cnpg.activeHotStandby block, not at the
+  # bp-sandbox-controller layer.
   topology:
     supported:
       - active-hot-standby
@@ -83,7 +84,17 @@ spec:
           mode: async
           lagSloSeconds: 0
         switchover:
-          mechanism: leader-election
+          # The CRD enum for switchover.mechanism does NOT include
+          # `leader-election` (valid: bp-continuum / manual /
+          # bp-velero-restore / lua-record / mm2-symmetric / ccr-promote /
+          # raft-transition / sentinel-failover / none — see
+          # core/pkg/apis/blueprint/v1alpha1/topology_types.go +
+          # products/catalyst/chart/crds/blueprint.yaml). The stateless
+          # controller's leader-flip is driven by bp-continuum on
+          # region-kill, same as every other active-hot-standby seed
+          # entry; this source value must match the catalog-seed copy
+          # (#3178/#3159) or the v1 CRD admission rejects the seeded CR.
+          mechanism: bp-continuum
           rtoSeconds: 30
           rpoSeconds: 0
         placement:
@@ -115,7 +126,13 @@ spec:
       launchDefault: true
       ssoEnabled: true
     - name: metrics
-      hostnameTemplate: ""        # ClusterIP only — controller-runtime metrics
+      # ClusterIP-only controller-runtime metrics — never publicly
+      # resolved. The v1 Blueprint CRD enforces hostnameTemplate
+      # minLength:1, so a non-routable cluster-internal name is used
+      # instead of "" (an empty value fails server-side admission —
+      # caught on hw124, same drift class as the switchover.mechanism
+      # fix above). Must match the catalog-seed copy. Refs #3159.
+      hostnameTemplate: "sandbox-metrics.sandbox.svc.cluster.local"
       port: 8080
       protocol: http
       tls: false

--- a/platform/sandbox/chart/Chart.yaml
+++ b/platform/sandbox/chart/Chart.yaml
@@ -119,7 +119,7 @@ annotations:
 # `helm template newapi platform/newapi/chart/ -s templates/service.yaml`
 # → metadata.name: newapi-bp-newapi. Walker on t38 (chart 1.4.216,
 # substrate be4f78bc872e2c56) caught the live regression.
-version: 0.3.9
+version: 0.3.10
 appVersion: "0.3.7"
 keywords:
   - catalyst

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -1533,7 +1533,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.2.2"
+  version: "0.2.3"
   visibility: listed
   card:
     title: "Apache Guacamole"

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -4526,7 +4526,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.3"
+  version: "0.1.4"
   visibility: unlisted
   card:
     title: "PowerDNS-Admin"
@@ -5042,7 +5042,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.1.3"
+  version: "0.1.4"
   visibility: unlisted
   card:
     title: "Continuum"
@@ -5396,7 +5396,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
 spec:
-  version: "0.3.9"
+  version: "0.3.10"
   visibility: unlisted
   card:
     title: "Sandbox"

--- a/products/continuum/chart/Chart.yaml
+++ b/products/continuum/chart/Chart.yaml
@@ -39,7 +39,7 @@ type: application
 # 0.1.0 sat in-tree without a bootstrap-kit slot to pin it, so the
 # blueprint-release workflow's `detect changed paths` step never had
 # reason to re-run and the chart was never pushed to GHCR.
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.1.0"
 home: https://openova.io
 sources:

--- a/products/continuum/chart/blueprint.yaml
+++ b/products/continuum/chart/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     openova.io/category: customer-facing-capability
 spec:
-  version: 0.1.3
+  version: 0.1.4
   card:
     title: Continuum
     summary: |

--- a/products/continuum/chart/templates/deployment.yaml
+++ b/products/continuum/chart/templates/deployment.yaml
@@ -36,8 +36,21 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       {{- if .Values.continuum.prerequisiteCheck.enabled }}
-      # #2922 PR-B prerequisite-guard initContainer — see values.yaml
-      # comment block on continuum.prerequisiteCheck for full rationale.
+      # #3189 prerequisite-check initContainer — see values.yaml comment
+      # block on continuum.prerequisiteCheck for full rationale.
+      #
+      # The probe detects whether a bp-cnpg-pair installation exists
+      # cluster-wide. On a single-region Sovereign there is no cnpg-pair,
+      # so bp-continuum has nothing to reconcile — it is a CORRECT idle
+      # state, not a failure (the controller-runtime Manager simply has
+      # 0 Continuum CRs to act on and reports Ready). The probe therefore
+      # exits 0 in that case and lets the main controller start idle.
+      #
+      # Earlier revisions did `sleep 300; exit 1` here, which forced the
+      # init container — and therefore the whole Pod — into
+      # Init:CrashLoopBackOff on every single-region prov (#3189). That
+      # presented a healthy single-region controller as perpetually
+      # broken. We keep the loud diagnostic log line but no longer crash.
       initContainers:
         - name: prerequisite-check
           image: {{ .Values.continuum.prerequisiteCheck.image | default "harbor.openova.io/proxy-dockerhub/alpine/k8s:1.30.0" | quote }}
@@ -50,14 +63,13 @@ spec:
               echo "[prerequisite-check] probing for bp-cnpg-pair audit ConfigMap cluster-wide..."
               pair_count="$(kubectl get cm -A -l catalyst.openova.io/audit-config=true --no-headers 2>/dev/null | wc -l)"
               if [ "$pair_count" -eq 0 ]; then
-                echo "[prerequisite-check] FAIL: no bp-cnpg-pair installation detected."
-                echo "[prerequisite-check] bp-continuum reconcile loop requires bp-cnpg-pair (Pillar-3 #2840 AC#1)."
-                echo "[prerequisite-check] Either install bp-cnpg-pair OR set continuum.enabled=false."
-                echo "[prerequisite-check] Sleeping 5 min before retry (operator can scale Deployment to 0 to silence)."
-                sleep 300
-                exit 1
+                echo "[prerequisite-check] no bp-cnpg-pair installation detected — single-region Sovereign."
+                echo "[prerequisite-check] bp-continuum has no CNPG cluster-pair to switch over (Pillar-3 multi-region only, #2840)."
+                echo "[prerequisite-check] Starting controller in IDLE mode: it will report Ready and reconcile nothing until a"
+                echo "[prerequisite-check] bp-cnpg-pair (2nd region) appears. This is a correct single-region no-op, NOT a failure."
+                exit 0
               fi
-              echo "[prerequisite-check] PASS: found $pair_count bp-cnpg-pair installation(s); main container will start."
+              echo "[prerequisite-check] PASS: found $pair_count bp-cnpg-pair installation(s); main container will start active."
           resources:
             {{- toYaml (.Values.continuum.prerequisiteCheck.resources | default (dict "requests" (dict "cpu" "10m" "memory" "32Mi") "limits" (dict "cpu" "100m" "memory" "64Mi"))) | nindent 12 }}
           securityContext:

--- a/products/continuum/chart/values.yaml
+++ b/products/continuum/chart/values.yaml
@@ -45,15 +45,21 @@ continuum:
   leaderElection:
     enabled: true
 
-  # G117.pillar-3-followup #2922 PR-B (2026-06-03): init container
-  # probe that asserts bp-cnpg-pair is installed BEFORE the main
-  # controller starts. Without bp-cnpg-pair the reconcile loop has no
-  # CNPG cluster pair to switch over → controller crash-loops on
-  # missing CRs. The probe sleeps + exits non-zero with a clear log
-  # line when prerequisites are missing, so `kubectl logs` surfaces
-  # the gap instead of a confusing controller stack trace. Operators
-  # CAN disable this guard via prerequisiteCheck.enabled=false (e.g.
-  # for chart unit tests or air-gapped offline reconcile evaluation).
+  # #3189 (2026-06-09): init container probe that DETECTS whether a
+  # bp-cnpg-pair installation exists cluster-wide before the main
+  # controller starts. On a single-region Sovereign there is no
+  # cnpg-pair, so bp-continuum has no CNPG cluster-pair to switch over —
+  # this is a CORRECT idle state (the controller-runtime Manager simply
+  # has 0 Continuum CRs to act on and reports Ready), NOT a failure.
+  #
+  # The probe logs a clear "single-region idle" diagnostic and exits 0,
+  # letting the main controller start and sit idle-Ready. Earlier
+  # revisions (#2922 PR-B) did `sleep 300; exit 1` here, which forced
+  # Init:CrashLoopBackOff on every single-region prov and presented a
+  # healthy controller as perpetually broken. We keep the loud log line
+  # but no longer crash. Operators CAN disable this guard entirely via
+  # prerequisiteCheck.enabled=false (e.g. for chart unit tests or
+  # air-gapped offline reconcile evaluation).
   prerequisiteCheck:
     enabled: true
     # Default image carries kubectl + sh — overridable for air-gapped


### PR DESCRIPTION
## Summary

Three single-region-safe topology fixes (Deliverable A of #3189), each **verified live on hw124** (single-region `me-east-215-a`), plus the topology alignment audit (Deliverable B = clean).

### A1 — bp-sandbox source topology drift vs catalog-seed
- `switchover.mechanism: leader-election` is **not** a valid Blueprint CRD enum (valid: `bp-continuum`/`manual`/`bp-velero-restore`/`lua-record`/`mm2-symmetric`/`ccr-promote`/`raft-transition`/`sentinel-failover`/`none`). Only the catalog-seed copy was patched (#3178/#3159); the `platform/sandbox` source still drifted → changed to `bp-continuum` to match.
- The metrics `endpoints[].hostnameTemplate: ""` also fails v1 CRD admission (`minLength:1`) → set to the same non-routable cluster-internal name the seed already uses.
- **Verified**: `kubectl apply --dry-run=server -f platform/sandbox/blueprint.yaml` → `bp-sandbox configured (server dry run)` (was rejected on the enum before).

### A2 — bp-continuum graceful single-region no-op
The `prerequisite-check` initContainer did `sleep 300; exit 1` when no `bp-cnpg-pair` exists → `Init:CrashLoopBackOff` on every single-region prov. But single-region (no cnpg-pair) is a **correct idle state**: the controller-runtime Manager has 0 `Continuum` CRs and reports Ready. The probe now logs the diagnostic and exits 0, letting the controller start idle-Ready.
- **Verified live**: patched the live init container with the exit-0 logic → `initContainerStatuses[0].state.terminated.exitCode=0, reason: Completed`. Crashloop gone. (The main-container image then hit a separate pre-existing overlay gap — see Findings.)

### A3 — powerdns-admin SQLite → CNPG
The `pda-legacy` image's baked-in `docker_config.py` hardcodes `SQLALCHEMY_DATABASE_URI = 'sqlite:////data/powerdns-admin.db'` and **ignores** the chart's `SQLA_DB_*` env (the old `ngoduykhanh` entrypoint convention). pda-legacy's `create_app()` → `AppSettings.load_environment()` honors **`SQLALCHEMY_DATABASE_URI`** verbatim (runs last, overrides the file). Wired it from the CNPG-generated `uri` secret key.
- **Verified live**: patched the live deployment with `SQLALCHEMY_DATABASE_URI` from `pda-database-secret.uri` → pod's effective `SQLALCHEMY_DATABASE_URI` scheme is `postgresql` (not sqlite); **16 PDA schema tables** (`account`, `apikey`, `domain`, `alembic_version`, …) created in the `pda-pg` CNPG postgres via `flask db upgrade`.

## Deliverable B — topology alignment audit
All **88** blueprint topology blocks audited against `platform/_schemas/blueprint-topology.json`: **CLEAN** — `supported`/`defaults`/`perTopology` cross-references valid, all switchover mechanisms valid CRD enums (after A1). The 9 cnpg-pair-backed active-hot-standby apps (catalyst-platform, gitea, guacamole, keycloak, netbird, spire, grafana, harbor + bp-cnpg-pair) all use `backend: cnpg-pair, mode: sync`; bp-sandbox correctly uses `backend: none` (state lives in Gitea). `catalog-seed` lockstep guard: **PASS** (67 checked, 0 fail).

## Findings (separate, pre-existing — not in scope for this PR)
- **bp-continuum image-pull on single-region**: once the init guard exits 0, the main controller image `ghcr.io/openova-io/openova/continuum-controller:dedba1c` fails to pull on hw124 — kyverno `harbor-proxy-pull` policy violation + ghcr 401. The chart's `continuum.image` helper supports a `global.imageRegistry` Harbor rewrite, but the live deployment was rendered with it empty. This is a per-Sovereign **deployment-overlay** gap (bp-continuum enabled without the Harbor registry rewrite every other chart gets), surfaced — not caused — by this fix. Tracked under #3189 for follow-up.

## Version lockstep (same commit, 3-way each)
| Blueprint | old → new |
|---|---|
| bp-sandbox | 0.3.9 → 0.3.10 |
| bp-continuum | 0.1.3 → 0.1.4 |
| bp-powerdns-admin | 0.1.3 → 0.1.4 |

Refs #3189

🤖 Generated with [Claude Code](https://claude.com/claude-code)
