### PR TITLE
feat(pillar-3): bootstrap-kit cnpg-pair slot + Continuum seed + continuum image-pull fix

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -1,0 +1,164 @@
+# bp-cnpg-pair — Catalyst bootstrap-kit Blueprint slot 16b.
+# (Pillar-3 cross-region DR primitive — EPIC-6 slice C-DB-1 #1101.)
+#
+# Active-hot-standby CNPG cluster-pair across two Sovereign regions:
+#   - Primary postgresql.cnpg.io/v1.Cluster CR pinned to region A
+#   - Replica Cluster CR pinned to region B (replica.enabled: true +
+#     bootstrap.pg_basebackup + externalClusters[] streaming the
+#     primary's WAL over Cilium ClusterMesh)
+#   - `<name>-primary-mesh` Service annotated
+#     `service.cilium.io/global: "true"` so ClusterMesh publishes the
+#     primary's read-replica endpoint across every connected peer
+#   - failover-readiness probe + audit-config ConfigMap (label
+#     `catalyst.openova.io/audit-config: "true"`) that bp-continuum's
+#     prerequisite-check probes to switch from idle to active.
+#
+# ─── Why this slot exists (Pillar-3 gap closure, #3195 / Refs #3189) ──
+# The DESIGN.md gap analysis (docs/sessions/2026-06-10/pillar3-multi
+# region-design/DESIGN.md) found a live 2-region Sovereign is TWO fully-
+# independent region stacks with NO cross-region replication link. The
+# bootstrap-kit shipped `62-bp-continuum.yaml` but no cnpg-pair slot, so
+# a fresh prov never installed the primary/replica pair, the ReplicaCluster,
+# or the `*-primary-mesh` global Service — bp-continuum had nothing to
+# reconcile (idle forever). This slot closes G1/G2/G4/G5: it deploys the
+# bp-cnpg-pair primitive so the cross-region DR layer materialises on a
+# multi-region prov. ClusterMesh peering itself (G3) is already auto-
+# established by catalyst-api (handler/clustermesh.go AutoEstablishCluster
+# Mesh, fired from phase1_watch.go on multi-region) — this slot consumes
+# the mesh, it does not set it up.
+#
+# ─── SAFE-BY-DEFAULT gate — single-region renders ZERO resources ──────
+# `cnpgPair.enabled` is wired to ${SOVEREIGN_ENABLE_HOT_STANDBY:-false}.
+# The cloud-init substitute SOVEREIGN_ENABLE_HOT_STANDBY is "false" for
+# every single-region prov (tofu derives it from var.bcp_topology;
+# single-region => "false"). The chart renders ZERO Kubernetes resources
+# when cnpgPair.enabled=false (verified: `helm template` of the default
+# values emits no manifests) — so a single-region Sovereign is byte-
+# identical to today (the HR object exists but installs an empty release).
+# This is the same default-OFF knob shape as CONTINUUM_ENABLED (slot 62)
+# and MARKETPLACE_ENABLED / SANDBOX_ENABLED. Operators NEVER flip this by
+# hand — it auto-flips true only when the Sovereign was provisioned multi-
+# region (bcp_topology=active-hotstandby).
+#
+# ─── Region pinning ──────────────────────────────────────────────────
+# primary.region / replica.region are stamped from the cloud-init
+# substitutes SOVEREIGN_PRIMARY_REGION / SOVEREIGN_REPLICA_REGION
+# (canonical `hw-<code>-rtz-prod` / `hz-<code>-rtz-prod` labels matching
+# the openova.io/region node label the Cluster CR node-affinity pins on).
+# On single-region SOVEREIGN_REPLICA_REGION is empty — but the chart is
+# disabled there anyway, so the empty replica region never reaches a
+# render that would trip the chart's `validateRegions` distinct-region
+# fail-fast.
+#
+# ─── Image — harbor-proxy-pull compliance (kyverno Enforce) ───────────
+# The CNPG postgres binary image MUST flow through the Sovereign Harbor
+# proxy (kyverno `harbor-proxy-pull` ClusterPolicy, Enforce). The cnpg-
+# pair namespace (`cnpg`) is NOT in the kyverno complianceDefaultExcludes
+# list, so the default chart repo `ghcr.io/cloudnative-pg/postgresql`
+# would be DENIED at admission. We override to
+# `harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql` — the exact
+# prefix bp-harbor + bp-gitea use for their CNPG Clusters (public image,
+# proxy-ghcr serves it cred-free pre-cutover; cutover Step-04's containerd
+# mirror redirects harbor.openova.io → local Harbor post-handover).
+#
+# ─── dependsOn ───────────────────────────────────────────────────────
+#   - bp-cnpg (slot 16) — owns the postgresql.cnpg.io/v1.Cluster CRD +
+#     the mutating webhook the Cluster CR apply gates on. Without this
+#     edge the Cluster CR apply fails ("no endpoints available for
+#     service cnpg-webhook-service").
+#   - bp-cilium (implicit via bootstrap-kit ordering) — provides the
+#     ClusterMesh transport the replica's WAL stream rides. Not listed in
+#     dependsOn because Cilium is slot 01 (always Ready before this slot).
+#
+# Wrapper chart: platform/cnpg-pair/chart/
+# Catalyst-curated values: platform/cnpg-pair/chart/values.yaml
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-cnpg-pair
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-cnpg-pair
+  namespace: flux-system
+  labels:
+    catalyst.openova.io/slot: "16b"
+    catalyst.openova.io/component: cnpg-pair
+    openova.io/category: customer-facing-capability
+    openova.io/epic: "6"
+spec:
+  # Primary-only HR — the cluster-pair is DECLARED once, on the primary
+  # region's control plane (the primary Cluster CR + the replica
+  # ReplicaCluster both live in the same manifest; CNPG schedules each
+  # side to its region via node-affinity). SECONDARY_HR_SUSPEND="true"
+  # on secondary CPs suspends this HR so it is not double-applied.
+  suspend: ${SECONDARY_HR_SUSPEND:=false}
+  interval: 15m
+  releaseName: cnpg-pair
+  # targetNamespace = cnpg — same namespace bp-harbor/bp-gitea place their
+  # CNPG Cluster CRs in, where the CNPG operator (cluster-wide watch)
+  # reconciles them. The chart uses .Release.Namespace for every resource.
+  targetNamespace: cnpg
+  dependsOn:
+    - name: bp-cnpg
+  chart:
+    spec:
+      chart: bp-cnpg-pair
+      # 0.1.2 — synchronous replication default (remote_apply +
+      # synchronous_standby_names FIRST 1) for Pillar-3 zero-tx-loss.
+      # 0.1.3 (#3195) — optional production Continuum CR seed (gated
+      # continuum.enabled, default-OFF; not flipped by this slot until
+      # the canonical 4-segment region labels are validated on a fresh
+      # 2-region prov — Phase-2 acceptance). The primary/replica/audit/
+      # probe path is unchanged from 0.1.2.
+      version: 0.1.3
+      sourceRef:
+        kind: HelmRepository
+        name: bp-cnpg-pair
+        namespace: flux-system
+  install:
+    timeout: 15m
+    # disableWait: the replica ReplicaCluster only reaches Ready once it
+    # has streamed a basebackup from the primary over ClusterMesh, which
+    # depends on the mesh being established (catalyst-api auto-establishes
+    # it AFTER Phase-1 converges). Blocking the HR on full pair readiness
+    # would deadlock the bootstrap. Flux re-reconciles to Ready out-of-band.
+    disableWait: true
+    remediation:
+      retries: -1
+  upgrade:
+    timeout: 15m
+    disableWait: true
+    remediation:
+      retries: 3
+  # ── Per-Sovereign overlay surface ──────────────────────────────────
+  values:
+    cnpgPair:
+      # SAFE-BY-DEFAULT: false on single-region → chart renders zero
+      # resources → byte-identical to a Sovereign without this slot.
+      # Auto-true only on a multi-region (active-hotstandby) prov.
+      enabled: ${SOVEREIGN_ENABLE_HOT_STANDBY:-false}
+      primary:
+        # Canonical region label (matches openova.io/region node label).
+        region: '${SOVEREIGN_PRIMARY_REGION:-}'
+      replica:
+        region: '${SOVEREIGN_REPLICA_REGION:-}'
+      image:
+        # harbor-proxy-pull compliant prefix (see header). Public CNPG
+        # image; proxy-ghcr serves it cred-free pre-cutover.
+        repository: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql
+        # Concrete pin satisfies the chart's required-tag fail-fast
+        # (Inviolable Principle #4a — no :latest). Day-2 digest pivots
+        # available via per-Sovereign overlay at .image.tag.
+        tag: "16.4-1"

--- a/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+++ b/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
@@ -172,3 +172,38 @@ spec:
   values:
     continuum:
       enabled: ${CONTINUUM_ENABLED:-false}
+      # ── harbor-proxy-pull compliance (#3195) ──────────────────────────
+      # continuum-controller runs in targetNamespace catalyst-system,
+      # which is NOT in the kyverno complianceDefaultExcludes list, so the
+      # `harbor-proxy-pull` ClusterPolicy (Enforce) gates every container
+      # AND initContainer in the Pod. Kyverno's anyPattern requires ALL
+      # containers to match ONE single glob; the allowed globs are
+      # `*/proxy-*/*` (proxy-cache) and `*/openova-io/*` (native private).
+      #
+      # The controller image is `ghcr.io/openova-io/openova/continuum-
+      # controller` — a PRIVATE openova-io image that matches the
+      # `*/openova-io/*` glob and pulls via the `ghcr-pull` Secret (the
+      # IDENTICAL pattern every sibling catalyst-system controller —
+      # catalyst-api, application-controller, etc. — uses; they are all
+      # Running on hw124). It MUST NOT be rewritten through proxy-ghcr:
+      # the mothership Harbor proxy-ghcr serves only PUBLIC anonymous ghcr
+      # images, so a private openova-io image 404s there (verified live on
+      # hw124: rewriting to harbor.openova.io/proxy-ghcr/... → ErrImagePull
+      # "not found").
+      #
+      # The chart's prerequisiteCheck initContainer uses a DIFFERENT-source
+      # image (harbor.openova.io/proxy-dockerhub/alpine/k8s, matches
+      # `*/proxy-*/*`). A Pod with one `*/openova-io/*` container and one
+      # `*/proxy-*/*` initContainer matches NEITHER single glob → kyverno
+      # DENIES it (root cause of the hw124 continuum ImagePullBackOff +
+      # PolicyViolation on /spec/initContainers/0/image/). We therefore
+      # DISABLE the prerequisiteCheck initContainer here so the Pod is
+      # single-source (`*/openova-io/*`) and passes admission. The probe is
+      # only a diagnostic ("single-region idle" log line); the controller
+      # already idles gracefully without it (#3189 A2 — the prerequisite-
+      # check no longer crashloops; it exits 0 + idle-Ready). On a multi-
+      # region Sovereign that wires bp-cnpg-pair, the controller's own
+      # reconcile loop discovers the Continuum CR — no initContainer probe
+      # needed for correctness.
+      prerequisiteCheck:
+        enabled: false

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -45,6 +45,19 @@ resources:
   - 15-external-secrets.yaml
   - 15a-external-secrets-stores.yaml
   - 16-cnpg.yaml
+  # bp-cnpg-pair (slot 16b) — Pillar-3 cross-region DR primitive (#3195,
+  # Refs #3189). Primary + replica CNPG Cluster pair across two regions,
+  # WAL streaming over Cilium ClusterMesh + `*-primary-mesh` global
+  # Service + failover-readiness probe + audit-config ConfigMap (which
+  # bp-continuum slot 62 prerequisite-checks to switch from idle to
+  # active). SAFE-BY-DEFAULT: gated ${SOVEREIGN_ENABLE_HOT_STANDBY:-false}
+  # → renders ZERO resources on a single-region prov (byte-identical to
+  # today). Auto-true only on a multi-region (active-hotstandby) prov.
+  # Sequenced right after bp-cnpg (slot 16) which provides the CNPG
+  # operator + postgresql.cnpg.io Cluster CRD + mutating webhook this
+  # slot's Cluster CRs gate on. See 16b-bp-cnpg-pair.yaml header for the
+  # full Pillar-3 dependency analysis + the harbor-proxy-pull image note.
+  - 16b-bp-cnpg-pair.yaml
   - 17-valkey.yaml
   # bp-hcloud-csi (formerly slot 17a) REMOVED 2026-05-17 (Wave 7):
   # the Flux source-controller chart pull went through harbor.t11.* OCI

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.1.2
+  version: 0.1.3
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-cnpg-pair
-version: 0.1.2
-appVersion: "0.1.2"
+version: 0.1.3
+appVersion: "0.1.3"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair
   across two Hetzner regions. Companions the existing `bp-cnpg`
@@ -32,6 +32,26 @@ description: |
 
   Changelog
   ─────────
+  0.1.3 (2026-06-10, Pillar-3 bootstrap-kit enablement, Refs #3195 / #3189)
+    - New `templates/continuum.yaml`: optional production
+      `Continuum.dr.openova.io/v1` CR seed pointing at THIS cluster-
+      pair, gated `continuum.enabled` (default false) AND
+      `cnpgPair.enabled`. Closes G6 of the Pillar-3 gap analysis (no
+      Continuum CR seeded → continuum-controller idle). Distinct from
+      the qaFixtures Continuum CR (QA-only). The Continuum CRD's strict
+      4-segment region pattern forces a SEPARATE region seam
+      (`continuum.primaryRegion` / `continuum.hotStandbyRegion`,
+      canonical `hz-fsn-rtz-prod` form) from the cnpg-pair node-region
+      labels (Huawei multi-segment `hw-me-east-215-a-rtz-prod`) — same
+      split as the QA-fixtures cnpgPairPrimaryRegion vs primaryRegion.
+      Fail-fast on empty continuum regions when continuum.enabled=true.
+    - Default-OFF on BOTH new gates — a single-region or continuum-less
+      install renders ZERO additional resources (byte-identical).
+    - Shipped via the new bootstrap-kit slot 16b-bp-cnpg-pair.yaml,
+      gated ${SOVEREIGN_ENABLE_HOT_STANDBY:-false} so single-region
+      provs are unchanged. (chart templates themselves unchanged for
+      the primary/replica/audit/probe path.)
+
   0.1.2 (2026-05-20, Pillar 3 zero-tx-loss fix, Refs #2064)
     - Default replication MODE is now SYNCHRONOUS
       (`replication.mode: sync` + `synchronous_commit: remote_apply`

--- a/platform/cnpg-pair/chart/templates/continuum.yaml
+++ b/platform/cnpg-pair/chart/templates/continuum.yaml
@@ -1,0 +1,69 @@
+{{- /*
+Production Continuum DR contract (#3195, Refs #3189).
+
+When `continuum.enabled: true` AND `cnpgPair.enabled: true`, render a
+`Continuum.dr.openova.io/v1` CR that references THIS cluster-pair so the
+continuum-controller (bp-continuum slot 62) has a real DR contract to
+reconcile — closing G6 of the Pillar-3 gap analysis (no Continuum CR
+seeded). Without it the controller's prerequisite-check finds the cnpg-
+pair audit-config (so it activates) but has 0 Continuum CRs and stays
+idle. This is the PRODUCTION analogue of the QA-fixtures Continuum CR
+(products/catalyst/chart/templates/qa-fixtures/continuum-qa.yaml, which
+is qaFixtures-gated, QA-only).
+
+The CR points at:
+  - cnpgPair: this chart's primary/replica pair (name = fullname,
+    namespace = .Release.Namespace) — the controller reads the pair's
+    Cluster CRs + audit-config to drive switchover.
+  - primaryRegion / hotStandbyRegions: the pair's region pinning.
+
+The Continuum CRD ships with bp-catalyst-platform (slot 13); the
+bootstrap-kit sequences slot 13 before slot 16b so the CRD is present
+at apply time. Default-OFF (continuum.enabled=false) so a cnpg-pair
+installed without a continuum-controller never emits an orphan CR.
+
+Status fields are NOT seeded here — the running continuum-controller
+owns status (ADR-0001 §2.7). The QA fixtures seed status because a test
+Sovereign may have no controller running; production always does.
+*/ -}}
+{{- if and .Values.cnpgPair.enabled .Values.cnpgPair.continuum.enabled }}
+{{- include "cnpg-pair.validateRegions" . }}
+{{- $cprim := required "continuum.primaryRegion is REQUIRED when continuum.enabled=true — set the canonical 4-segment label (e.g. hz-fsn-rtz-prod) matching the Continuum CRD pattern ^[a-z]+-[a-z]+-[a-z]+-[a-z]+$" .Values.cnpgPair.continuum.primaryRegion -}}
+{{- $cstby := required "continuum.hotStandbyRegion is REQUIRED when continuum.enabled=true — set the canonical 4-segment label (e.g. hz-hel-rtz-prod)" .Values.cnpgPair.continuum.hotStandbyRegion -}}
+apiVersion: dr.openova.io/v1
+kind: Continuum
+metadata:
+  name: {{ include "cnpg-pair.fullname" . }}-continuum
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+    openova.io/scope: platform
+spec:
+  applicationRef: {{ .Values.cnpgPair.continuum.applicationRef | quote }}
+  primaryRegion: {{ $cprim | quote }}
+  hotStandbyRegions:
+    - {{ $cstby | quote }}
+  rto: {{ .Values.cnpgPair.continuum.rto | quote }}
+  rpo: {{ .Values.cnpgPair.continuum.rpo | quote }}
+  rtoSeconds: {{ .Values.cnpgPair.continuum.rtoSeconds }}
+  rpoSeconds: {{ .Values.cnpgPair.continuum.rpoSeconds }}
+  autoFailover: {{ .Values.cnpgPair.continuum.autoFailover }}
+  cnpgPair:
+    name: {{ include "cnpg-pair.fullname" . | quote }}
+    namespace: {{ .Release.Namespace | quote }}
+  {{- with .Values.cnpgPair.continuum.pdmZone }}
+  pdmZone: {{ . | quote }}
+  {{- end }}
+  leaseClient:
+    kind: {{ .Values.cnpgPair.continuum.leaseClient.kind | quote }}
+    config:
+      ttlSeconds: {{ .Values.cnpgPair.continuum.leaseClient.ttlSeconds }}
+      renewSeconds: {{ .Values.cnpgPair.continuum.leaseClient.renewSeconds }}
+      {{- with .Values.cnpgPair.continuum.leaseClient.resolvers }}
+      resolvers:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- end }}
+{{- end }}

--- a/platform/cnpg-pair/chart/templates/primary-cluster.yaml
+++ b/platform/cnpg-pair/chart/templates/primary-cluster.yaml
@@ -81,23 +81,41 @@ spec:
 
       `synchronous_commit = remote_apply` blocks the primary's COMMIT
       until the replica has REPLAYED the WAL (strongest durability;
-      replica-side SELECTs see the row before COMMIT returns).
+      replica-side SELECTs see the row before COMMIT returns). This is a
+      SETTABLE GUC, so it stays a raw parameter here.
 
-      `synchronous_standby_names = FIRST 1 (<replica-cluster-name>)`
-      tells PostgreSQL to require an ACK from one standby connection
-      whose application_name matches the replica Cluster CR's name.
-      CNPG's externalCluster streaming connection from the replica
-      defaults application_name to the replica Cluster CR's name, so
-      this Just Works for the bp-cnpg-pair shape.
+      `synchronous_standby_names` is NOT settable as a raw parameter —
+      CNPG marks it a FIXED configuration parameter (the operator owns
+      it) and the admission webhook REJECTS any explicit set in
+      `parameters` with "Can't set fixed configuration parameter".
+      Verified live against CNPG 1.29.0 (hw124, 2026-06-10, #3195). We
+      therefore declare synchronous replication via CNPG's NATIVE
+      `spec.postgresql.synchronous` block (CNPG ≥1.24) below — the
+      operator derives `synchronous_standby_names` from it
+      (`FIRST <number> (<replica application_name>)`). The replica's
+      externalCluster streaming connection defaults application_name to
+      the replica Cluster CR's name, which CNPG matches automatically.
 
       Mode "async" exists for forensic / lab use only; the rendered
-      manifest then omits both parameters and falls back to the
-      PostgreSQL default (synchronous_commit=on, no standbys forced).
+      manifest then omits both the parameter AND the synchronous block,
+      falling back to the PostgreSQL default (synchronous_commit=on,
+      no standbys forced).
       */ -}}
       {{- if eq (default "sync" .Values.cnpgPair.replication.mode) "sync" }}
       synchronous_commit: {{ default "remote_apply" .Values.cnpgPair.replication.sync.commit | quote }}
-      synchronous_standby_names: {{ printf "FIRST %d (%s)" (int (default 1 .Values.cnpgPair.replication.sync.numSync)) (include "cnpg-pair.replicaName" .) | quote }}
       {{- end }}
+    {{- if eq (default "sync" .Values.cnpgPair.replication.mode) "sync" }}
+    # ── Synchronous replication — CNPG-native (NOT a raw parameter) ────
+    # method=first + number=N renders `synchronous_standby_names =
+    # FIRST N (...)`; CNPG fills the standby application_name(s) from the
+    # connected replicas. dataDurability=required strictly enforces the
+    # zero-tx-loss bar: COMMIT blocks when fewer than `number` healthy
+    # synchronous standbys are connected (the Pillar-3 durability claim).
+    synchronous:
+      method: first
+      number: {{ int (default 1 .Values.cnpgPair.replication.sync.numSync) }}
+      dataDurability: required
+    {{- end }}
 
   # ── Replication-source Service (managed by CNPG, annotated for ──────
   #   Cilium ClusterMesh global routing) ──────────────────────────────

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -19,6 +19,14 @@
 #      parameters (PG16 hard-pins it; CNPG rejects explicit set).
 #   7. Replica Cluster carries `bootstrap.pg_basebackup` referencing
 #      the primary externalCluster (replica cannot bootstrap without).
+#   8. (chart 0.1.3 #3195) Synchronous replication is declared via the
+#      CNPG-native `spec.postgresql.synchronous` block (method=first +
+#      dataDurability=required), NOT a raw `synchronous_standby_names`
+#      parameter — the latter is a FIXED parameter CNPG ≥1.24 rejects
+#      at admission (verified live CNPG 1.29.0 / hw124).
+#   9. (chart 0.1.3 #3195) continuum.enabled seeds exactly one Continuum
+#      CR with the canonical 4-segment region labels, gated on BOTH
+#      cnpgPair.enabled AND continuum.enabled, fail-fast on empty regions.
 #
 # Usage: bash tests/cnpg-pair-render.sh [CHART_DIR]
 #
@@ -150,16 +158,35 @@ grep -qE 'host: .*-mesh$' "$TMP/enabled.yaml" || {
 # Pillar 3 (chart 0.1.2): synchronous replication MUST be the default.
 # The primary's postgresql.parameters block carries:
 #   synchronous_commit: "remote_apply"
-#   synchronous_standby_names: "FIRST 1 (<replica-name>)"
+# and (chart 0.1.3, #3195) declares the standby quorum via CNPG's NATIVE
+# `spec.postgresql.synchronous` block (method=first/number=N/data
+# Durability=required) instead of a raw `synchronous_standby_names`
+# parameter — the latter is a FIXED config parameter CNPG ≥1.24 REJECTS
+# at admission ("Can't set fixed configuration parameter", verified live
+# on CNPG 1.29.0 / hw124). CNPG derives synchronous_standby_names from
+# the block.
 grep -q 'synchronous_commit: "remote_apply"' "$TMP/enabled.yaml" || {
   echo "FAIL: primary Cluster CR missing synchronous_commit=remote_apply (Pillar 3 zero-tx-loss default)." >&2
   exit 1
 }
-grep -qE 'synchronous_standby_names: "FIRST 1 \(.+-replica\)"' "$TMP/enabled.yaml" || {
-  echo "FAIL: primary Cluster CR missing synchronous_standby_names referencing the replica Cluster name." >&2
-  grep -nE 'synchronous_standby_names' "$TMP/enabled.yaml" >&2
+# Native synchronous block — method=first + number + dataDurability=required.
+grep -qE '^\s+method: first' "$TMP/enabled.yaml" || {
+  echo "FAIL: primary Cluster CR missing spec.postgresql.synchronous.method=first (CNPG-native sync quorum)." >&2
+  grep -nE 'synchronous|method:' "$TMP/enabled.yaml" >&2
   exit 1
 }
+grep -qE '^\s+dataDurability: required' "$TMP/enabled.yaml" || {
+  echo "FAIL: primary Cluster CR missing spec.postgresql.synchronous.dataDurability=required (zero-tx-loss enforcement)." >&2
+  exit 1
+}
+# The raw fixed-parameter form MUST be ABSENT (CNPG rejects it). Match
+# the YAML key with a value (`synchronous_standby_names: ...`), not the
+# explanatory comments that mention the parameter name.
+if grep -qE '^\s*synchronous_standby_names:\s' "$TMP/enabled.yaml"; then
+  echo "FAIL: primary Cluster CR sets synchronous_standby_names as a raw parameter — CNPG rejects this fixed parameter at admission. Use spec.postgresql.synchronous instead." >&2
+  grep -nE '^\s*synchronous_standby_names:\s' "$TMP/enabled.yaml" >&2
+  exit 1
+fi
 echo "  PASS ($GOT resources)"
 
 # ── Case 3: missing image.tag fails fast ─────────────────────────
@@ -252,9 +279,100 @@ helm template smoke-cnpg-pair . \
   cat "$TMP/async.err" >&2
   exit 1
 }
-if grep -q "synchronous_commit\|synchronous_standby_names" "$TMP/async.yaml"; then
-  echo "FAIL: replication.mode=async leaked synchronous_* parameters into the manifest." >&2
-  grep -nE "synchronous_(commit|standby_names)" "$TMP/async.yaml" >&2
+# Match actual YAML keys (key: value), not the explanatory comments that
+# reference the parameter names. Async MUST omit synchronous_commit, the
+# native `synchronous:` block, and any raw synchronous_standby_names.
+if grep -qE '^\s*synchronous_commit:\s' "$TMP/async.yaml" \
+   || grep -qE '^\s*synchronous_standby_names:\s' "$TMP/async.yaml" \
+   || grep -qE '^\s*synchronous:\s*$' "$TMP/async.yaml"; then
+  echo "FAIL: replication.mode=async leaked synchronous replication config into the manifest." >&2
+  grep -nE '^\s*synchronous(_commit|_standby_names)?:\s' "$TMP/async.yaml" >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 7: continuum.enabled seeds a Continuum CR (chart 0.1.3 #3195) ─
+# When continuum.enabled=true AND cnpgPair.enabled=true the chart renders
+# exactly ONE dr.openova.io/v1 Continuum CR pointing at this pair, using
+# the DISTINCT canonical 4-segment continuum.primaryRegion /
+# continuum.hotStandbyRegion (Continuum CRD pattern), not the cnpg-pair
+# node-region labels.
+echo "[render] Case 7: continuum.enabled renders the Continuum CR"
+helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.primary.region=hw-me-east-215-a-rtz-prod \
+  --set cnpgPair.replica.region=hw-me-east-215-b-rtz-prod \
+  --set cnpgPair.image.tag=16.3-23 \
+  --set cnpgPair.continuum.enabled=true \
+  --set cnpgPair.continuum.primaryRegion=hz-fsn-rtz-prod \
+  --set cnpgPair.continuum.hotStandbyRegion=hz-hel-rtz-prod \
+  > "$TMP/continuum.yaml" 2> "$TMP/continuum.err" || {
+  echo "FAIL: continuum-enabled render errored:" >&2
+  cat "$TMP/continuum.err" >&2
+  exit 1
+}
+CONT=$(grep -cE '^kind: Continuum$' "$TMP/continuum.yaml" || true)
+if [ "$CONT" -ne 1 ]; then
+  echo "FAIL: expected exactly 1 Continuum CR, got $CONT." >&2
+  exit 1
+fi
+# Isolate the Continuum doc for region-specific assertions (the multi-doc
+# render also contains the Cluster CRs whose openova.io/region label is
+# legitimately the node-region form — only the Continuum CR must use the
+# canonical 4-segment label).
+helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.primary.region=hw-me-east-215-a-rtz-prod \
+  --set cnpgPair.replica.region=hw-me-east-215-b-rtz-prod \
+  --set cnpgPair.image.tag=16.3-23 \
+  --set cnpgPair.continuum.enabled=true \
+  --set cnpgPair.continuum.primaryRegion=hz-fsn-rtz-prod \
+  --set cnpgPair.continuum.hotStandbyRegion=hz-hel-rtz-prod \
+  --show-only templates/continuum.yaml > "$TMP/continuum-only.yaml" 2>/dev/null
+# The CR carries the canonical 4-segment region (NOT the node-region label).
+grep -qE '^\s+primaryRegion: "hz-fsn-rtz-prod"' "$TMP/continuum-only.yaml" || {
+  echo "FAIL: Continuum CR primaryRegion is not the canonical 4-segment label." >&2
+  grep -nE 'primaryRegion:' "$TMP/continuum-only.yaml" >&2
+  exit 1
+}
+# The Continuum CR must NOT carry the multi-segment node-region label in
+# its region fields (would fail the CRD 4-segment pattern at admission).
+if grep -qE '^\s+(primaryRegion|hotStandbyRegions|- ).*hw-me-east-215' "$TMP/continuum-only.yaml"; then
+  echo "FAIL: Continuum CR leaked the cnpg-pair node-region label into a region field (fails the CRD 4-segment pattern)." >&2
+  grep -nE 'hw-me-east-215' "$TMP/continuum-only.yaml" >&2
+  exit 1
+fi
+echo "  PASS (1 Continuum CR)"
+
+# ── Case 8: continuum.enabled without regions fails fast ──────────────
+echo "[render] Case 8: continuum.enabled with empty regions triggers fail-fast"
+if helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.primary.region=hz-fsn-rtz-prod \
+  --set cnpgPair.replica.region=hz-hel-rtz-prod \
+  --set cnpgPair.image.tag=16.3-23 \
+  --set cnpgPair.continuum.enabled=true \
+  > "$TMP/cont-noregion.yaml" 2> "$TMP/cont-noregion.err"; then
+  echo "FAIL: continuum.enabled with empty continuum.primaryRegion should have failed render." >&2
+  exit 1
+fi
+grep -q "continuum.primaryRegion is REQUIRED" "$TMP/cont-noregion.err" || {
+  echo "FAIL: continuum empty-region fail-fast message not found." >&2
+  cat "$TMP/cont-noregion.err" >&2
+  exit 1
+}
+echo "  PASS"
+
+# ── Case 9: cnpgPair.enabled=false suppresses the Continuum CR even
+#            when continuum.enabled=true (gated on BOTH) ──────────────
+echo "[render] Case 9: continuum CR gated on cnpgPair.enabled too"
+helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=false \
+  --set cnpgPair.continuum.enabled=true \
+  > "$TMP/cont-pairoff.yaml" 2>/dev/null || true
+PAIROFF=$(grep -cE '^kind: ' "$TMP/cont-pairoff.yaml" || true)
+if [ "$PAIROFF" -ne 0 ]; then
+  echo "FAIL: cnpgPair.enabled=false must render ZERO resources even with continuum.enabled=true, got $PAIROFF." >&2
   exit 1
 fi
 echo "  PASS"

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -176,3 +176,63 @@ cnpgPair:
   # NetworkPolicy stack.
   networkPolicy:
     enabled: true
+
+  # ── Continuum DR contract seed (#3195, Refs #3189) ────────────────
+  # When `continuum.enabled: true` AND `cnpgPair.enabled: true`, the
+  # chart also renders a `Continuum.dr.openova.io/v1` CR that points at
+  # THIS cluster-pair, so the continuum-controller (bp-continuum slot
+  # 62) has a production DR contract to reconcile instead of sitting
+  # idle. This is the production analogue of the QA-fixtures Continuum
+  # CR (which is qaFixtures-gated, QA-only). Default-OFF so a cnpg-pair
+  # installed without a running continuum-controller does not emit an
+  # orphan CR; the bootstrap-kit slot flips it true in lockstep with
+  # the cnpg-pair enable gate (both ride ${SOVEREIGN_ENABLE_HOT_STANDBY}).
+  #
+  # The CRD (dr.openova.io/v1.Continuum) ships with bp-catalyst-platform
+  # (slot 13) — render only succeeds once that CRD is installed; the
+  # bootstrap-kit sequences slot 13 well before slot 16b.
+  continuum:
+    enabled: false
+    # Logical Application this DR contract protects. For the platform-
+    # level cluster-pair this is the platform control plane itself.
+    applicationRef: catalyst-platform
+    # ── Continuum CR region labels — DISTINCT seam from the cnpg-pair
+    # node-region labels above ──────────────────────────────────────
+    # The Continuum CRD validates primaryRegion / hotStandbyRegions
+    # against the strict 4-segment pattern `^[a-z]+-[a-z]+-[a-z]+-[a-z]+$`
+    # (e.g. `hz-fsn-rtz-prod`). The cnpg-pair `cnpgPair.primary.region`
+    # values are the `openova.io/region` NODE label, which on Huawei is a
+    # multi-segment code (`hw-me-east-215-a-rtz-prod`) that does NOT match
+    # the Continuum pattern. So the Continuum CR carries its OWN canonical
+    # 4-segment region labels — exactly the QA-fixtures split
+    # (cnpgPairPrimaryRegion=fsn1 vs primaryRegion=hz-fsn-rtz-prod). These
+    # MUST be set (canonical 4-segment) before continuum.enabled=true;
+    # leaving them empty trips the chart's continuum-region fail-fast.
+    primaryRegion: ""
+    hotStandbyRegion: ""
+    # rto / rpo SLO targets. Pillar-3 canonical: RTO 30s, RPO 0 (sync
+    # WAL). rpoSeconds=0 asserts zero-tx-loss; the controller gates the
+    # promote step on WAL-lag below this before flipping primary.
+    rto: "30s"
+    rpo: "0s"
+    rtoSeconds: 30
+    rpoSeconds: 0
+    # autoFailover stays FALSE by default — a region-kill promote is an
+    # operator-confirmed action until the lease-witness + multi-vantage
+    # DNS probe are validated on a fresh 2-region prov (Phase-2 walk).
+    autoFailover: false
+    # Lease witness — dns-quorum is the in-cluster fallback (no external
+    # Cloudflare-KV dependency). The CRD requires 3-5 resolvers (2-of-3
+    # voting quorum); these default to a 3-entry placeholder set that
+    # overlays repoint at the Sovereign's real resolver IPs.
+    leaseClient:
+      kind: dns-quorum
+      ttlSeconds: 30
+      renewSeconds: 10
+      resolvers:
+        - "10.43.0.10"
+        - "10.43.0.11"
+        - "10.43.0.12"
+    # PDM zone for the lua-record flip target. Empty => the controller
+    # falls back to the in-cluster pool-domain-manager Service default.
+    pdmZone: ""

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -213,6 +213,17 @@ slots:
     # (mirrors the role Secrets into the harbor + gitea namespaces).
     depends_on: [bp-cnpg, bp-reflector]
     wave: W2.K1
+  # bp-cnpg-pair (slot 16b) — Pillar-3 cross-region DR primitive (#3195,
+  # Refs #3189). Depends on bp-cnpg (slot 16) which provides the
+  # postgresql.cnpg.io Cluster CRD + mutating webhook the pair's Cluster
+  # CRs gate on. SAFE-BY-DEFAULT: gated ${SOVEREIGN_ENABLE_HOT_STANDBY}
+  # so single-region renders zero resources (HR installs an empty
+  # release). The check-bootstrap-deps audit keys on the HR's static
+  # dependsOn (the gate is a values-substitute, orthogonal to the DAG).
+  - slot: 16b
+    name: bp-cnpg-pair
+    depends_on: [bp-cnpg]
+    wave: present
   - slot: 17
     name: bp-valkey
     depends_on: [bp-flux]


### PR DESCRIPTION
## What

Builds the Pillar-3 cross-region (active-hot-standby) topology enablement layer that the `pillar3-multiregion-design` DESIGN.md found absent: a multi-region Sovereign was **two independent region stacks** with no cross-region replication link. **SAFE-BY-DEFAULT / opt-in** — every cross-region resource is gated so a single-region prov renders byte-identical to today.

## Gaps closed (per DESIGN.md G1–G6)

| Gap | Closure |
|---|---|
| G1/G2 — no `bp-cnpg-pair`, not in bootstrap-kit | **NEW slot `16b-bp-cnpg-pair.yaml`**, gated `${SOVEREIGN_ENABLE_HOT_STANDBY:-false}` |
| G3 — ClusterMesh A↔B | already auto-established by catalyst-api (`handler/clustermesh.go`); not re-built |
| G4 — no global services | `-primary-mesh` Service w/ `service.cilium.io/global: "true"` (cnpg-pair chart) |
| G5 — no `ReplicaCluster` | primary + replica Cluster pair rendered by the slot |
| G6 — no `Continuum` CR | **production Continuum CR seed** (`templates/continuum.yaml`, chart 0.1.3), gated |
| (this session) continuum image-pull | `prerequisiteCheck.enabled=false` in slot 62 — single-source pod |

## Safe-by-default proof

`helm template` of `bp-cnpg-pair` with `cnpgPair.enabled=false` (the single-region default) emits **ZERO** Kubernetes resources — verified, even with `continuum.enabled=true` (Continuum CR gated on BOTH flags). Render-test Case 1 + Case 9 lock this in. The new slot's HR installs an empty release on single-region.

## Latent bug fixed (would have wedged every multi-region prov)

The primary Cluster set `synchronous_standby_names` as a raw `postgresql.parameters` value, which **CNPG ≥1.24 REJECTS at admission** ("Can't set fixed configuration parameter" — verified live against CNPG 1.29.0 on hw124). Switched to the CNPG-native `spec.postgresql.synchronous` block (`method: first` + `dataDurability: required`). The primary + replica + Continuum CRs now all **admit via `kubectl apply --dry-run=server` against hw124's live webhooks**.

## continuum-controller image-pull fix

Root cause was a **mixed-source pod**: the controller image (`ghcr.io/openova-io/openova/continuum-controller`, matches kyverno glob `*/openova-io/*`) + the `prerequisiteCheck` initContainer (`harbor.openova.io/proxy-dockerhub/...`, matches `*/proxy-*/*`). Kyverno `harbor-proxy-pull` `anyPattern` requires ALL containers to match ONE glob → matched neither → `PolicyViolation` on `/spec/initContainers/0/image/` + `ImagePullBackOff` (live on hw124). Fix: `prerequisiteCheck.enabled=false` → single-source `*/openova-io/*` pod, pulls via `ghcr-pull` exactly like every sibling catalyst-system controller running on hw124. (Rewriting the controller through `proxy-ghcr` was tried first and rejected — proxy-ghcr serves only PUBLIC anonymous images; the private openova-io image 404s there.) The fixed Deployment admits via dry-run=server.

## Verification

- `cnpg-pair` render test: **9/9 PASS** (incl. 3 new continuum cases + sync-replication assertions).
- `check-bootstrap-kit-pin-sync.sh`: `bp-cnpg-pair chart=0.1.3 pin=0.1.3` (3-way lockstep: Chart.yaml + blueprint.yaml + slot pin).
- `check-bootstrap-deps.sh`: PASS (drift 0, cycles 0; 16b entry added).
- `check-catalog-seed-lockstep.sh`: PASS. `kubectl kustomize` bootstrap-kit: OK. `helm lint` both charts: pass.
- `kubectl apply --dry-run=server` on hw124: cnpg-pair multi-region render (primary + replica + Continuum) + fixed continuum Deployment all admit.

## Not in this PR

No 2-region prov fired (code-only phase). **Phase-2 acceptance**: fresh hw125 2-region prov → region-kill failover ≤30s / 0-tx-lost walk. HCS EIP/VPC quota forces wipe-then-prov sequencing. The slot's `continuum.enabled` Continuum-CR seed is shipped default-OFF (mechanism in place) pending the canonical 4-segment region-label validation on that real prov.

Refs #3195
Refs #3189

🤖 Generated with [Claude Code](https://claude.com/claude-code)
