### PR TITLE
fix(bootstrap-kit): register slot 16a + safe-by-default bp-postgres gate + unregistered-slot CI guard (Refs #3188)

### DIFF
--- a/.github/workflows/test-bootstrap-kit.yaml
+++ b/.github/workflows/test-bootstrap-kit.yaml
@@ -52,6 +52,15 @@ jobs:
           sudo chmod +x /usr/local/bin/yq
           yq --version
 
+      - name: Install kustomize
+        # Phase-2.5b of check-bootstrap-deps.sh runs a `kustomize build` of
+        # the bootstrap-kit so duplicate-resource / merge errors (a slot
+        # registered but colliding with another, e.g. the same Namespace
+        # declared twice) are caught at PR time, not at fresh-prov reconcile.
+        # The script warn-skips if kustomize is absent; install it so the
+        # check is enforcing in CI.
+        uses: imranismail/setup-kustomize@v2
+
       - name: Run bootstrap-kit dependency audit
         run: bash scripts/check-bootstrap-deps.sh
 

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -73,13 +73,25 @@ spec:
     # values.yaml).
     - name: bp-cnpg
       namespace: flux-system
-    # ADR-0010 reuse proof: when gitea SHARES the bp-postgres `shared-pg`
-    # instance (SOVEREIGN_GITEA_PG_OWN_CLUSTER=false), gate on the shared
-    # data-instance HR so its `gitea` Database + role + reflected
-    # gitea-database-secret exist before gitea's pod starts. Harmless when
-    # gitea owns its cluster (the HR exists either way; the dependency just
-    # waits for shared-pg to be Ready). bp-postgres-shared itself dependsOn
-    # bp-cnpg, so the operator/CRDs are still ordered first.
+    # ADR-0010 reuse proof: gitea dependsOn bp-postgres-shared (slot 16a)
+    # UNCONDITIONALLY. This edge is ALWAYS safe because slot 16a installs
+    # an EMPTY (but Ready) release by default (SOVEREIGN_ENABLE_SHARED_PG=
+    # false) — so the dependency just waits for that empty HR to be Ready
+    # whether or not gitea is actually sharing. (#3191 regression: slot
+    # 16a was authored but never registered in kustomization.yaml → the HR
+    # was never created → THIS edge dangled forever → bp-gitea Ready=False
+    # → bp-catalyst-platform wedged. Fixed by registering 16a; this guard
+    # comment documents WHY the edge is unconditional + how the empty-Ready
+    # default keeps it safe.)
+    #
+    # TWO-FLAG CONTRACT to actually SHARE: flip BOTH
+    # SOVEREIGN_GITEA_PG_OWN_CLUSTER=false (gitea skips its OWN gitea-pg
+    # Cluster + points its DB host at shared-pg's -rw Service) AND
+    # SOVEREIGN_ENABLE_SHARED_PG=true (slot 16a renders the shared engine +
+    # provisions gitea's Database + role + reflected gitea-database-secret).
+    # Flipping only ONE is a misconfig: own-cluster=false + shared-pg=false
+    # leaves gitea with no DB at all. The defaults (own-cluster=true,
+    # shared-pg=false) are the byte-identical 1:1 legacy path.
     - name: bp-postgres-shared
       namespace: flux-system
   chart:
@@ -98,7 +110,11 @@ spec:
       # SHARING gate (SOVEREIGN_GITEA_PG_OWN_CLUSTER) so gitea can SHARE
       # the bp-postgres `shared-pg` data-instance instead of owning its
       # gitea-pg Cluster. Default true → byte-identical 1:1 legacy path.
-      version: 1.2.25
+      # 1.2.26 (#3188): Deployment strategy Recreate (was upstream default
+      # RollingUpdate{maxUnavailable:0,maxSurge:100%}). RWO /data + LevelDB
+      # lock wedge the surge-pod roll; Recreate releases the PVC + lock
+      # before the new Pod starts so the 1.2.x roll completes clean.
+      version: 1.2.26
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -73,7 +73,10 @@ spec:
   chart:
     spec:
       chart: bp-postgres
-      version: 0.1.0
+      # 0.1.1 (#3188): master gate `enabled` (default true) → OFF renders
+      # ZERO resources so this HR is an empty Ready release when sharing is
+      # disabled (SOVEREIGN_ENABLE_SHARED_PG=false, the safe default).
+      version: 0.1.1
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -89,6 +92,20 @@ spec:
     remediation:
       retries: 3
   values:
+    # ── SAFE-BY-DEFAULT master gate ─────────────────────────────────────
+    # OFF → the chart renders ZERO resources → this HR installs an EMPTY
+    # (but Ready) release. bp-gitea (slot 10) + bp-harbor (slot 19)
+    # dependsOn bp-postgres-shared UNCONDITIONALLY, so this empty-Ready
+    # release satisfies the edge WITHOUT deploying an unused shared-pg
+    # Cluster. Single-region / non-sharing provs are byte-identical to
+    # today (the same default-OFF shape as slot 16b SOVEREIGN_ENABLE_HOT_
+    # STANDBY / slot 62 CONTINUUM_ENABLED).
+    #
+    # TWO-FLAG CONTRACT to actually share a real shared instance: flip
+    # BOTH SOVEREIGN_{GITEA,HARBOR}_PG_OWN_CLUSTER=false (consumer skips
+    # its own Cluster + points DB host at shared-pg) AND
+    # SOVEREIGN_ENABLE_SHARED_PG=true (this slot renders the engine).
+    enabled: ${SOVEREIGN_ENABLE_SHARED_PG:=false}
     instance:
       name: shared-pg
       namespace: shared-data

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -132,13 +132,21 @@ spec:
     # wait for the webhook to be Ready before it creates the ExternalSecret.
     - name: bp-external-secrets
       namespace: flux-system
-    # ADR-0010 reuse proof: when harbor SHARES the bp-postgres `shared-pg`
-    # instance (SOVEREIGN_HARBOR_PG_OWN_CLUSTER=false), gate on the shared
-    # data-instance HR so its `registry` Database + role + reflected
-    # harbor-database-secret exist before harbor's core pod starts.
-    # Harmless when harbor owns its cluster (the dependency just waits for
-    # shared-pg Ready). bp-postgres-shared dependsOn bp-cnpg, so the
-    # operator/CRDs are still ordered first.
+    # ADR-0010 reuse proof: harbor dependsOn bp-postgres-shared (slot 16a)
+    # UNCONDITIONALLY. Always safe because slot 16a installs an EMPTY (but
+    # Ready) release by default (SOVEREIGN_ENABLE_SHARED_PG=false) — the
+    # edge just waits for that empty HR to be Ready whether or not harbor
+    # is sharing. (#3191 regression: slot 16a authored but never registered
+    # in kustomization.yaml → HR never created → this edge dangled → harbor
+    # Ready=False. Fixed by registering 16a.)
+    #
+    # TWO-FLAG CONTRACT to actually SHARE: flip BOTH
+    # SOVEREIGN_HARBOR_PG_OWN_CLUSTER=false (harbor skips its OWN harbor-pg
+    # Cluster + points its DB host at shared-pg's -rw Service) AND
+    # SOVEREIGN_ENABLE_SHARED_PG=true (slot 16a renders the shared engine +
+    # provisions harbor's `registry` Database + role + reflected
+    # harbor-database-secret). The defaults (own-cluster=true, shared-pg=
+    # false) are the byte-identical 1:1 legacy path.
     - name: bp-postgres-shared
       namespace: flux-system
   chart:

--- a/clusters/_template/bootstrap-kit/26-network-policies.yaml
+++ b/clusters/_template/bootstrap-kit/26-network-policies.yaml
@@ -24,13 +24,14 @@
 # Wrapper chart: platform/network-policies/chart/ (pure overlay; no
 # upstream subchart — CRDs come from bp-cilium's upstream Cilium chart).
 
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: catalyst-system
-  labels:
-    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+# NOTE: the `catalyst-system` Namespace is declared ONCE by slot 13
+# (13-bp-catalyst-platform.yaml) — NOT re-declared here. When this slot was
+# first registered in kustomization.yaml (#3188), a duplicate Namespace doc
+# here failed the kustomize build ("may not add resource with an already
+# registered id: Namespace/catalyst-system"). Slot 13 runs before slot 26,
+# so the namespace already exists by the time this HR's targetNamespace is
+# resolved. Removing the duplicate is the canonical de-dup (kustomize owns
+# resource-id uniqueness across the merged set).
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -45,6 +45,33 @@ resources:
   - 15-external-secrets.yaml
   - 15a-external-secrets-stores.yaml
   - 16-cnpg.yaml
+  # bp-postgres-shared (slot 16a) — ADR-0010 reusable/shareable backing-
+  # services model (#3191, Refs #3188). ONE shared CNPG Cluster that BOTH
+  # bp-gitea (slot 10) and bp-harbor (slot 19) can run off, via two
+  # ISOLATED databases + two per-consumer roles + two reflected Secrets.
+  # Both consumers dependsOn bp-postgres-shared UNCONDITIONALLY, so this
+  # slot MUST be registered or the whole gitea→catalyst-platform chain
+  # wedges (the #3191 regression: slot file authored but never listed
+  # here → HR never created → dangling dependsOn — caught live on hw124).
+  #
+  # SAFE-BY-DEFAULT: the chart's master gate `enabled` is wired to
+  # ${SOVEREIGN_ENABLE_SHARED_PG:=false} below. OFF → the chart renders
+  # ZERO resources → the HR is an EMPTY Ready release that satisfies the
+  # consumers' dependsOn WITHOUT deploying an unused shared-pg Cluster.
+  # This is the SAME default-OFF knob shape as slot 16b's
+  # SOVEREIGN_ENABLE_HOT_STANDBY and slot 62's CONTINUUM_ENABLED. A
+  # single-region prov that is NOT sharing Postgres is byte-identical to
+  # today (gitea + harbor still own their own embedded Clusters via
+  # SOVEREIGN_{GITEA,HARBOR}_PG_OWN_CLUSTER:=true).
+  #
+  # Two-flag contract to actually SHARE a real shared instance: the
+  # operator flips BOTH SOVEREIGN_{GITEA,HARBOR}_PG_OWN_CLUSTER=false (so
+  # the consumer skips its own Cluster + points at shared-pg) AND
+  # SOVEREIGN_ENABLE_SHARED_PG=true (so this slot renders the engine).
+  #
+  # Slot ordering: after bp-cnpg (16, operator + CRDs), before bp-cnpg-
+  # pair (16b). Flux dependsOn pins the real install order regardless.
+  - 16a-bp-postgres-shared.yaml
   # bp-cnpg-pair (slot 16b) — Pillar-3 cross-region DR primitive (#3195,
   # Refs #3189). Primary + replica CNPG Cluster pair across two regions,
   # WAL streaming over Cilium ClusterMesh + `*-primary-mesh` global
@@ -119,6 +146,16 @@ resources:
   - 23-mimir.yaml
   - 24-tempo.yaml
   - 25-grafana.yaml
+  # bp-network-policies (slot 26) — G101 zero-trust default-deny baseline
+  # (Refs #2650). The chart + slot file were authored to fix the hw86
+  # finding (ZERO zero-trust enforcement on every fresh prov) but the slot
+  # was NEVER listed here → the HR was never created → the G101 fix has
+  # been INERT on every prov since (the SAME unregistered-slot class as the
+  # #3191 / hw124 wedge — surfaced by the new check-bootstrap-deps.sh
+  # Phase-2.5 slot-registration guard). Registering it installs the
+  # CiliumClusterwideNetworkPolicy default-deny + DNS-egress + system-ns
+  # allow set on boot. dependsOn bp-cilium (slot 01) for the cilium.io CRDs.
+  - 26-network-policies.yaml
   - 27-kyverno.yaml
   - 27a-kyverno-policies.yaml
   - 28-reloader.yaml

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.25
+  version: 1.2.26
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -89,7 +89,15 @@ name: bp-gitea
 # skipped and the shared instance (slot 16a) owns the `gitea` Database +
 # role + reflected gitea-database-secret. gitea's DB HOST then points at
 # the shared cluster's -rw Service via SOVEREIGN_GITEA_PG_HOST.
-version: 1.2.25
+# 1.2.26 (#3188, 2026-06-10): Deployment rollout strategy override
+# `gitea.strategy.type: Recreate` (was the upstream default RollingUpdate
+# {maxUnavailable:0,maxSurge:100%}). Gitea's /data is a ReadWriteOnce PVC
+# with an exclusive LevelDB file lock — under maxUnavailable:0 the surge
+# Pod can never mount the RWO volume the old Pod holds, so the roll wedges
+# (old RS never scales down → HR Stalled → bp-catalyst-platform blocked).
+# Recreate terminates the old Pod first (releasing the PVC + lock) then
+# starts the new one. Single-replica gitea has no roll-time HA to lose.
+version: 1.2.26
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/values.yaml
+++ b/platform/gitea/chart/values.yaml
@@ -145,6 +145,22 @@ gitea:
   persistence:
     enabled: true
     size: 20Gi
+  # Deployment rollout strategy — override the upstream default of
+  # RollingUpdate{maxUnavailable:0,maxSurge:100%} to Recreate (#3188).
+  # Gitea's `/data` is a ReadWriteOnce PVC (persistence.accessModes default
+  # [ReadWriteOnce] upstream). With maxUnavailable:0 the rollout MUST bring
+  # a NEW (surge) Pod to Ready BEFORE terminating the old one — but the new
+  # Pod can never mount the RWO volume the old Pod still holds, and even if
+  # it could, gitea's embedded LevelDB queue takes an exclusive file lock on
+  # /data, so the surge Pod CrashLoops on "resource temporarily unavailable"
+  # and the rollout WEDGES (old ReplicaSet never scales down → chart upgrade
+  # never reaches Ready → bp-gitea Stalled → bp-catalyst-platform blocked).
+  # Recreate tears the old Pod down FIRST, releasing the PVC + the LevelDB
+  # lock, then starts the new one — the correct strategy for any single-
+  # replica RWO-backed stateful Deployment. Single-replica gitea already has
+  # no HA during a roll, so Recreate costs nothing it didn't already lack.
+  strategy:
+    type: Recreate
   # Upstream chart Ingress — DISABLED. Catalyst routes via Cilium Gateway
   # API (see top-level `gateway:` block below). Issue #387.
   ingress:

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-4-1-data-services
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.1.0
+  version: 0.1.1
   card:
     title: PostgreSQL
     summary: |
@@ -29,6 +29,15 @@ spec:
   configSchema:
     type: object
     properties:
+      enabled:
+        type: boolean
+        default: true
+        description: |
+          Master gate. false → the install renders ZERO resources (an
+          empty Ready release). The bootstrap-kit slot 16a wires this to
+          ${SOVEREIGN_ENABLE_SHARED_PG:=false} so a non-sharing Sovereign
+          gets a Ready bp-postgres-shared HR without deploying an unused
+          shared-pg Cluster.
       instance:
         type: object
         description: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-postgres
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "0.1.1"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable
   PostgreSQL engine. Each install of bp-postgres = ONE
@@ -30,6 +30,15 @@ description: |
 
   Changelog
   ─────────
+  0.1.1 (2026-06-10, Refs #3188)
+    - Master gate `.Values.enabled` (default true). OFF → the chart
+      renders ZERO Kubernetes resources (empty Ready release). The
+      bootstrap-kit slot 16a wires it to ${SOVEREIGN_ENABLE_SHARED_PG:=
+      false} so a non-sharing Sovereign still gets a Ready bp-postgres-
+      shared HR (satisfying the unconditional bp-gitea / bp-harbor
+      dependsOn) WITHOUT deploying an unused shared-pg Cluster. Sprig-safe
+      `ne (toString .Values.enabled) "false"` idiom. No change to the
+      default reuse-proof render shape.
   0.1.0 (2026-06-10, ADR-0010, Refs #3188)
     - Initial chart: one CNPG Cluster + per-consumer Database CRs +
       managed.roles + reflected connection Secrets, all driven by

--- a/platform/postgres/chart/templates/cluster.yaml
+++ b/platform/postgres/chart/templates/cluster.yaml
@@ -10,8 +10,14 @@ ships the postgresql.cnpg.io/v1 CRD. On a cold install before bp-cnpg is
 reconciling, the apiserver rejects this Cluster. The gate skips the
 template until the CRD is registered. The Flux dependsOn edge
 (bp-postgres-<name> dependsOn bp-cnpg) makes this a no-op in practice.
+
+Master gate (.Values.enabled, default true): when the slot disables sharing
+(${SOVEREIGN_ENABLE_SHARED_PG:=false}) the chart renders ZERO resources so
+the HR is an empty Ready release. Sprig-safe `ne (toString …) "false"` —
+a literal `false` is not "empty", so a plain `if` would misfire (memory
+feedback_sprig_default_bool_unsafe).
 */ -}}
-{{- if .Capabilities.APIVersions.Has "postgresql.cnpg.io/v1" }}
+{{- if and (ne (toString .Values.enabled) "false") (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") }}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/platform/postgres/chart/templates/connection-secret.yaml
+++ b/platform/postgres/chart/templates/connection-secret.yaml
@@ -17,7 +17,11 @@ plaintext lands in this committed template — reflector copies live bytes.
 Helm `lookup` is intentionally NOT used: on a fresh Sovereign CNPG
 bootstraps the role Secret AFTER this HelmRelease applies, so a lookup
 would render empty. Reflector is event-driven and updates within seconds.
+
+Master gate (.Values.enabled, default true): OFF → render ZERO resources
+so the slot 16a HR is an empty Ready release when sharing is disabled.
 */ -}}
+{{- if ne (toString .Values.enabled) "false" }}
 {{- $ctx := . }}
 {{- range $db := .Values.databases }}
 {{- if $db.reflect }}
@@ -48,6 +52,7 @@ type: Opaque
 # (missing key) during the initial consumer render.
 data:
   password: ""
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/platform/postgres/chart/templates/database.yaml
+++ b/platform/postgres/chart/templates/database.yaml
@@ -15,8 +15,11 @@ declarative primitive (Inviolable Principle #2).
 Capabilities gate: skip until the Database CRD is registered (it ships
 with the CNPG operator). The instance HR's dependsOn bp-cnpg makes this
 a no-op in practice.
+
+Master gate (.Values.enabled, default true): OFF → render ZERO resources
+so the slot 16a HR is an empty Ready release when sharing is disabled.
 */ -}}
-{{- if .Capabilities.APIVersions.Has "postgresql.cnpg.io/v1" }}
+{{- if and (ne (toString .Values.enabled) "false") (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") }}
 {{- $ctx := . }}
 {{- range .Values.databases }}
 ---

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -101,4 +101,33 @@ if grep -q 'synchronous_commit' "$TMP/shared.yaml"; then
   fail "singleton render leaked synchronous_commit"
 fi
 
-echo "[render] PASS — bp-postgres render gate green (reuse proof: 1 Cluster, 2 Databases, 2 roles, 2 Secrets)"
+# ── Case 6: master gate OFF → ZERO resources (#3188 safe-by-default) ──
+# `enabled=false` must render an EMPTY release even with the CNPG CRD
+# present and bindings declared — so the bootstrap-kit slot 16a HR is a
+# Ready (but empty) release that satisfies the bp-gitea / bp-harbor
+# dependsOn WITHOUT deploying an unused shared-pg Cluster. This is the
+# regression-lock for the #3191 / hw124 wedge fix.
+echo "[render] Case 6: enabled=false → ZERO resources (master gate, even with CRD + bindings)"
+helm template shared-pg . -f "$TMP/shared.values.yaml" --set enabled=false \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/off.yaml" 2> "$TMP/off.err" || {
+  cat "$TMP/off.err" >&2; fail "gated-off render errored"; }
+if grep -qE '^kind:' "$TMP/off.yaml"; then
+  fail "enabled=false render emitted resources (expected an empty release)"
+fi
+
+# ── Case 7: enabled=true explicit → identical to the default render ──
+# Guards against a `toString` regression where the gate misfires on the
+# truthy path (Sprig default-bool trap, memory feedback_sprig_default_
+# bool_unsafe).
+echo "[render] Case 7: enabled=true explicit → full reuse-proof render (1 Cluster + 2 Databases + 2 Secrets)"
+helm template shared-pg . -f "$TMP/shared.values.yaml" --set enabled=true \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/on.yaml" 2> "$TMP/on.err" || {
+  cat "$TMP/on.err" >&2; fail "gated-on render errored"; }
+on_cluster=$(grep -cE '^kind: Cluster$' "$TMP/on.yaml" || true)
+on_db=$(grep -cE '^kind: Database$' "$TMP/on.yaml" || true)
+on_secret=$(grep -cE '^kind: Secret$' "$TMP/on.yaml" || true)
+[ "$on_cluster" -eq 1 ] || fail "enabled=true expected 1 Cluster, got $on_cluster"
+[ "$on_db" -eq 2 ]      || fail "enabled=true expected 2 Databases, got $on_db"
+[ "$on_secret" -eq 2 ]  || fail "enabled=true expected 2 Secrets, got $on_secret"
+
+echo "[render] PASS — bp-postgres render gate green (reuse proof: 1 Cluster, 2 Databases, 2 roles, 2 Secrets; master gate OFF → empty)"

--- a/platform/postgres/chart/values.yaml
+++ b/platform/postgres/chart/values.yaml
@@ -11,6 +11,21 @@
 # hardcode). The catalyst-layer generator (ADR-0010) writes these values
 # into the instance HR when a consumer declares `spec.backingServices`.
 
+# ── Master gate (safe-by-default) ───────────────────────────────────────
+# When false the chart renders ZERO Kubernetes resources — the install is
+# an empty (but Ready) release. The bootstrap-kit slot 16a wires this to
+# ${SOVEREIGN_ENABLE_SHARED_PG:=false} so a Sovereign that is NOT sharing a
+# Postgres engine still gets a Ready bp-postgres-shared HR (satisfying the
+# unconditional bp-gitea / bp-harbor dependsOn edge) WITHOUT deploying an
+# unused shared-pg Cluster. Default is `true` here so a DIRECT chart
+# consumer (and the render gate) keeps the full reuse-proof render shape —
+# the OFF state is opt-in via the slot's envsubst seam, the same pattern as
+# slot 16b's cnpgPair.enabled / slot 62's CONTINUUM_ENABLED. The `toString`
+# comparison is the Sprig-safe boolean idiom (a literal `false` is not
+# "empty", so a plain `if .Values.enabled` would misfire — see memory
+# feedback_sprig_default_bool_unsafe).
+enabled: true
+
 # ── The data instance (one CNPG Cluster) ────────────────────────────────
 instance:
   # Cluster name = the data-instance identity. Surfaces as the App-card

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -597,7 +597,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-cnpg",

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -644,7 +644,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "section": "pts-4-1-data-services",
     "depends": [
       "bp-cnpg",

--- a/scripts/check-bootstrap-deps.sh
+++ b/scripts/check-bootstrap-deps.sh
@@ -238,6 +238,89 @@ fi
 echo "  Parsed ${#ACTUAL_NAMES[@]} HelmRelease(s) across ${#HR_FILES[@]} file(s)"
 
 # ---------------------------------------------------------------------------
+# Phase 2.5 — Slot-registration audit (kustomization.yaml completeness)
+# ---------------------------------------------------------------------------
+#
+# Every NN-*.yaml slot file that carries a HelmRelease MUST be listed in
+# kustomization.yaml's resources[]. An unregistered slot file is INERT:
+# `kubectl apply -k` (the production reconcile path) only applies resources
+# named in resources[], so the slot's HR is NEVER created on the cluster —
+# any consumer that dependsOn that HR dangles forever. This is the #3191
+# regression class (slot 16a-bp-postgres-shared.yaml authored but never
+# registered → bp-gitea's dependsOn dangled → bp-catalyst-platform wedged
+# on hw124). The same shape previously bit bp-sso-bridge (hw86) and
+# bp-powerdns-admin (#3150) — a forgotten-slot bug CI never caught.
+#
+# This guard fails the audit when a slot file with an HR is missing from
+# resources[]. (Files with no HelmRelease — e.g. 00-vcluster-host-
+# namespaces.yaml — are exempt: they still SHOULD be listed, but their
+# absence does not dangle a dependsOn edge, so we only hard-fail on HR-
+# bearing files. The drift workflow surfaces the rest.)
+
+_banner "Phase 2.5: slot-registration audit (kustomization.yaml)"
+
+KUSTOMIZATION_FILE="${KIT_DIR}/kustomization.yaml"
+if [[ ! -f "${KUSTOMIZATION_FILE}" ]]; then
+  _err "kustomization.yaml not found in ${KIT_DIR#"${REPO_ROOT}/"} — cannot audit slot registration."
+  exit 3
+fi
+
+# The set of basenames listed in resources[]. yq extracts them directly so
+# commented-out lines (the documented-but-disabled case) are NOT counted as
+# registered — exactly the bug we are guarding against.
+declare -A REGISTERED=()
+while IFS= read -r res; do
+  [[ -z "${res}" ]] && continue
+  REGISTERED["${res}"]=1
+done < <(yq -r '.resources[]' "${KUSTOMIZATION_FILE}" 2>/dev/null || true)
+
+UNREGISTERED_COUNT=0
+for f in "${HR_FILES[@]}"; do
+  base="$(basename "$f")"
+  # Only HR-bearing files dangle a dependsOn edge when unregistered.
+  has_hr="$(yq -r 'select(.kind == "HelmRelease") | .metadata.name' "$f" 2>/dev/null | head -n1 || true)"
+  [[ -z "${has_hr}" ]] && continue
+  if [[ -z "${REGISTERED[${base}]+x}" ]]; then
+    _err "slot file '${base}' carries a HelmRelease ('${has_hr}') but is NOT listed in ${KUSTOMIZATION_FILE#"${REPO_ROOT}/"} resources[]. An unregistered slot is inert (kubectl apply -k skips it) → any consumer dependsOn '${has_hr}' dangles forever (the #3191 / hw124 wedge). Add '- ${base}' to resources[]."
+    UNREGISTERED_COUNT=$((UNREGISTERED_COUNT + 1))
+  fi
+done
+
+if [[ ${UNREGISTERED_COUNT} -gt 0 ]]; then
+  echo "" >&2
+  _err "${UNREGISTERED_COUNT} HR-bearing slot file(s) missing from kustomization.yaml resources[]. Register each and re-run."
+  exit 1
+fi
+
+_ok "every HR-bearing slot file is registered in kustomization.yaml resources[]"
+
+# Phase 2.5b — kustomize build sanity. Registration alone is necessary but
+# not sufficient: a newly-registered slot can still break the merged set
+# (e.g. a duplicate resource id — two slots declaring the same Namespace,
+# which is how 26-network-policies.yaml + 13-bp-catalyst-platform.yaml
+# collided on catalyst-system when 26 was first registered in #3188). A
+# `kustomize build` of the kit catches that whole class. Best-effort: if no
+# kustomize binary is available we warn-skip rather than fail the audit, so
+# the guard never blocks an environment lacking kustomize/kubectl.
+_KUSTOMIZE=""
+if command -v kustomize >/dev/null 2>&1; then
+  _KUSTOMIZE="kustomize build"
+elif command -v kubectl >/dev/null 2>&1; then
+  _KUSTOMIZE="kubectl kustomize"
+fi
+if [[ -n "${_KUSTOMIZE}" ]]; then
+  if _kustomize_err="$(${_KUSTOMIZE} "${KIT_DIR}" 2>&1 >/dev/null)"; then
+    _ok "kustomize build of ${KIT_DIR#"${REPO_ROOT}/"} succeeds (no duplicate/merge errors)"
+  else
+    _err "kustomize build of ${KIT_DIR#"${REPO_ROOT}/"} FAILED — the registered resource set does not merge cleanly:"
+    echo "${_kustomize_err}" | sed 's/^/         /' >&2
+    exit 1
+  fi
+else
+  _warn "kustomize/kubectl not found — skipping the kustomize-build sanity check (registration check still ran)"
+fi
+
+# ---------------------------------------------------------------------------
 # Phase 3 — Compare actual vs expected (drift detection)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Regression (verified live on hw124)

#3191 created `clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml` and made `bp-gitea` + `bp-harbor` `dependsOn: bp-postgres-shared` **unconditionally**, but **never registered slot 16a in `kustomization.yaml`**. An unregistered slot is inert (`kubectl apply -k` / Flux kustomize-controller only apply resources listed in `resources[]`), so the `bp-postgres-shared` HR was never created → the consumers' `dependsOn` dangled forever → `bp-postgres-shared → bp-gitea → bp-catalyst-platform` wedged (1.4.550 could not roll).

## Fix (safe-by-default preserved — single-region prov stays byte-identical)

1. **Register `- 16a-bp-postgres-shared.yaml`** in `kustomization.yaml` (immediately before `16b-bp-cnpg-pair.yaml`).
2. **bp-postgres chart `0.1.0 → 0.1.1`** — new master gate `.Values.enabled` (default `true`, Sprig-safe `ne (toString .) "false"`). OFF → renders **ZERO** resources → the HR is an **empty Ready** release that satisfies the unconditional `bp-gitea`/`bp-harbor` `dependsOn` **without** deploying an unused `shared-pg` Cluster. Slot 16a wires it to `${SOVEREIGN_ENABLE_SHARED_PG:=false}`. Render gate gains Case 6 (gate-off → empty) + Case 7 (gate-on → full reuse proof). The **two-flag share contract** (own-cluster=false AND shared-pg=true) is documented on slots 16a/10/19.
3. **CI-gap guard** — `check-bootstrap-deps.sh` Phase 2.5 now **fails** when any HR-bearing slot file is missing from `kustomization.yaml` `resources[]` (the #3191 class), plus Phase 2.5b runs a `kustomize build` of the kit to catch duplicate-resource/merge errors. `kustomize` wired into the `dependency-graph-audit` CI job.
   - The guard **immediately surfaced a second inert slot**: `26-network-policies.yaml` (G101 zero-trust default-deny, #2650) was authored but **never registered** → zero-trust default-deny was **NOT installed on any fresh prov**. Registered it, and removed its duplicate `catalyst-system` Namespace (owned by slot 13) so the kustomize build merges cleanly.
4. **bp-gitea chart `1.2.25 → 1.2.26`** — Deployment `strategy: Recreate` (was the upstream default `RollingUpdate{maxUnavailable:0,maxSurge:100%}`). Gitea's `/data` is an RWO PVC with an exclusive LevelDB lock; the surge Pod can never mount it → the roll wedges. Recreate releases the PVC + lock before the new Pod starts.

3-way version lockstep on both chart bumps (Chart.yaml == blueprint.yaml == bootstrap-kit pin); bp-postgres catalog snapshot updated to 0.1.1.

## Local gates (all green)

- `check-bootstrap-deps.sh` — registration ✅ + kustomize-build ✅ + zero drift + zero cycles
- `check-bootstrap-kit-pin-sync.sh --changed-only` — `bp-gitea 1.2.26`, `bp-postgres 0.1.1` both in sync
- `check-catalog-seed-lockstep.sh` — PASS (67 checked)
- `platform/postgres/chart/tests/postgres-render.sh` — 7 cases PASS (incl. gate-off → empty)
- `kubectl kustomize clusters/_template/bootstrap-kit/` — 60 HelmReleases, builds clean
- `helm template platform/gitea/chart` — Deployment renders `strategy: type: Recreate`

## On-cluster verification owed (hw124, after merge)

After merge + a forced bootstrap-kit reconcile: confirm `bp-postgres-shared` HR is **Ready** (empty), `bp-gitea` Ready=True, `bp-catalyst-platform` rolls to latest Ready=True.

Refs #3188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)