### PR TITLE
fix(bootstrap-kit): publish bp-postgres + create cnpg ns + ClusterMesh-gate cnpg-pair (Refs #3188)

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -70,10 +70,31 @@
 #     ClusterMesh transport the replica's WAL stream rides. Not listed in
 #     dependsOn because Cilium is slot 01 (always Ready before this slot).
 #
+# ─── targetNamespace `cnpg` MUST be pre-created by this slot ───────────
+# The HR's targetNamespace is `cnpg` (below). Flux/Helm writes the release
+# storage Secret into that namespace on EVERY install — including a gated-
+# OFF, zero-resource (empty) release. If the namespace does not exist the
+# install fails with `namespaces "cnpg" not found` (caught live on hw124:
+# the slot installed but `cnpg` was never created — slot 16/bp-cnpg makes
+# `cnpg-system` for the OPERATOR, and every CNPG consumer (gitea/harbor/
+# powerdns/sme/newapi) places its Cluster CR in its OWN namespace, so
+# nothing ever created `cnpg`). Every sibling slot that targets a fresh
+# namespace (16-cnpg → cnpg-system, 16a → shared-data, 17-valkey → valkey)
+# declares it here. So this slot must create `cnpg` UNCONDITIONALLY —
+# independent of the cnpgPair.enabled gate, because even the empty release
+# needs the namespace to land its Helm release Secret.
+#
 # Wrapper chart: platform/cnpg-pair/chart/
 # Catalyst-curated values: platform/cnpg-pair/chart/values.yaml
 # Reconciled by: Flux on the new Sovereign's k3s control plane.
 
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cnpg
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -145,10 +166,35 @@ spec:
   # ── Per-Sovereign overlay surface ──────────────────────────────────
   values:
     cnpgPair:
-      # SAFE-BY-DEFAULT: false on single-region → chart renders zero
-      # resources → byte-identical to a Sovereign without this slot.
-      # Auto-true only on a multi-region (active-hotstandby) prov.
-      enabled: ${SOVEREIGN_ENABLE_HOT_STANDBY:-false}
+      # ── ClusterMesh-gated enable (NOT raw 2-region) ─────────────────
+      # SAFE-BY-DEFAULT: false → chart renders ZERO resources → byte-
+      # identical to a Sovereign without this slot.
+      #
+      # 🛑 This gate is DELIBERATELY DECOUPLED from ${SOVEREIGN_ENABLE_HOT_
+      # STANDBY}. A 2-region prov flips HOT_STANDBY=true purely because
+      # len(req.Regions) >= 2 (provisioner.go bcpTopologyEnableHotStandby),
+      # but the cross-region replica only reaches Ready once Cilium
+      # ClusterMesh is ACTUALLY established between the regions AND the
+      # `*-primary-mesh` global Service is published. On hw124 — a real
+      # 2-region prov where ClusterMesh was NOT wired — gating on raw
+      # HOT_STANDBY rendered the primary+replica pair, whose replica then
+      # could never stream a basebackup (no mesh) → the pair never
+      # converged. Worse, the pair tried to install into a `cnpg`
+      # namespace nothing created → `namespaces "cnpg" not found` ×7.
+      #
+      # So this slot gates on its OWN substitute SOVEREIGN_ENABLE_CNPG_
+      # PAIR, default-OFF. Unregistered in the provisioner substitute map
+      # (same as SOVEREIGN_ENABLE_SHARED_PG / CONTINUUM_ENABLED /
+      # NETBIRD_ENABLED) → Flux postBuild applies the inline `:-false`
+      # default → every prov (single OR multi-region) renders an empty,
+      # Ready release UNTIL an operator confirms ClusterMesh is up and
+      # flips SOVEREIGN_ENABLE_CNPG_PAIR=true on the per-Sovereign overlay
+      # (alongside SOVEREIGN_PRIMARY_REGION / SOVEREIGN_REPLICA_REGION,
+      # which the chart `required`s when enabled=true). This is the
+      # canonical "default-OFF until the dependency is truly wired" knob
+      # shape — the cnpg-pair is a wire-it-when-the-mesh-is-confirmed
+      # primitive, not an auto-fire-on-2-region one.
+      enabled: ${SOVEREIGN_ENABLE_CNPG_PAIR:-false}
       primary:
         # Canonical region label (matches openova.io/region node label).
         region: '${SOVEREIGN_PRIMARY_REGION:-}'

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -66,5 +66,18 @@ maintainers:
 # blueprint-release hollow-chart guard (#181) accepts the annotation.
 annotations:
   catalyst.openova.io/no-upstream: "true"
+  # Default-values render is intentionally short. Every template (the CNPG
+  # Cluster, the Database CRs, the reflected connection Secrets) is gated on
+  # `.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1"` — the CNPG CRD is
+  # NOT registered during the blueprint-release offline `helm template` smoke
+  # render, so the Cluster/Database never render there. The default
+  # `databases: []` also renders zero binding Secrets. The result is an empty
+  # render, which the smoke-render guard flags as "suspiciously short" unless
+  # this annotation declares the short render expected — the same pattern the
+  # directly-analogous bp-cnpg-pair (slot 16b) and 30+ sibling charts use. The
+  # enabled-render path (1 Cluster + N Databases + N roles + N Secrets, with
+  # `--api-versions postgresql.cnpg.io/v1`) is fully covered by the unit test
+  # chart/tests/postgres-render.sh, which CI runs via the `tests/*.sh` gate.
+  catalyst.openova.io/smoke-render-mode: "default-off"
   catalyst.openova.io/depends-on: "bp-cnpg,bp-reflector"
   catalyst.openova.io/issue: "3188"


### PR DESCRIPTION
## Why

Two merged PRs — #3197 (backing-services / bp-postgres) and #3196 (multi-region / bp-cnpg-pair) — regressed the live 2-region **hw124** HR chain. The cluster still serves (all front doors 200) but the HelmRelease chain is wedged. This makes the merged code actually work on a real prov and durably unwedges hw124. Refs #3188.

## Issue 1 — `bp-postgres:0.1.1` never published (the chain wedge)

Slot 16a pins `bp-postgres` **0.1.1**, but the package has **no published tag in GHCR** — so the HelmChart can't pull it → `bp-postgres-shared` Ready=False → `bp-gitea`/`bp-harbor` (dependsOn it) → `bp-catalyst-platform` + `bp-self-sovereign-cutover` all Ready=False.

**Root cause:** the Blueprint Release run for #3197's merge (commit `40e2ec39`, [run 27233373593](https://github.com/openova-io/openova/actions/runs/27233373593)) **failed at the 'Helm template smoke render (default values)' step**:
```
##[error]Rendered output is suspiciously short (1 lines). A working umbrella with an
upstream subchart should produce many more resources. (For charts that are intentionally
default-off, set annotations.catalyst.openova.io/smoke-render-mode: "default-off" ...)
```
Every bp-postgres template (`cluster.yaml`/`database.yaml`/`connection-secret.yaml`) is gated on `.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1"` — the CNPG CRD is **absent** during the offline `helm template` smoke render — and the default `databases: []` renders zero binding Secrets. So the default render is **legitimately empty** → the guard flags it → the publish job dies before pushing the OCI artifact.

**Fix:** add `catalyst.openova.io/smoke-render-mode: "default-off"` to `platform/postgres/chart/Chart.yaml` — the exact remediation the guard prints, and the pattern used by the directly-analogous **bp-cnpg-pair** (slot 16b) and 30+ sibling charts. The enabled-render path stays fully covered by `chart/tests/postgres-render.sh` (Cases 2–7, run by CI's `tests/*.sh` gate with `--api-versions postgresql.cnpg.io/v1`).

With the chart publishing, the HelmChart pulls `bp-postgres:0.1.1` → `bp-postgres-shared` installs **empty** (`SOVEREIGN_ENABLE_SHARED_PG=false` default → 0 resources) → Ready → gitea/harbor/catalyst-platform/cutover heal.

## Issue 2 — `bp-cnpg-pair` install failed on hw124 (`namespaces "cnpg" not found` ×7)

`cnpgPair.enabled` resolved **true** on hw124 because it was wired to `${SOVEREIGN_ENABLE_HOT_STANDBY}`, which flips true for **any** `len(regions) >= 2` prov (`provisioner.go bcpTopologyEnableHotStandby`). But hw124's cross-region ClusterMesh isn't wired, so the pair shouldn't be active — and the chart targets a `cnpg` namespace that **nothing creates** (slot 16/bp-cnpg makes `cnpg-system` for the operator; every CNPG consumer puts its Cluster in its own ns).

**Fix (slot 16b):**
1. Create the `cnpg` Namespace **unconditionally** (like every sibling slot that targets a fresh ns) — even an empty gated-off release needs the targetNamespace to land its Helm release Secret.
2. Re-gate `cnpgPair.enabled` to its **own** default-OFF substitute `${SOVEREIGN_ENABLE_CNPG_PAIR:-false}`, decoupled from raw 2-region. Same unregistered-default-OFF shape as `SOVEREIGN_ENABLE_SHARED_PG` / `CONTINUUM_ENABLED` → every prov renders an empty Ready release until an operator confirms ClusterMesh is up and flips it on (alongside `SOVEREIGN_PRIMARY_REGION`/`SOVEREIGN_REPLICA_REGION`, which the chart `required`s when enabled).

## Local verification

- `bp-postgres` default render = **1 line** (reproduces the CI failure; annotation now accepts it).
- `platform/postgres/chart/tests/postgres-render.sh` → **all 7 cases green** (incl. the 1-Cluster/2-Database/2-role/2-Secret reuse proof + master-gate OFF).
- `platform/cnpg-pair/chart/tests/cnpg-pair-render.sh` → **all 9 cases green**.
- `scripts/lint-cloudinit.sh both` → **PASS** (hetzner + huawei `dash -n`).
- Slot 16b YAML valid (3 docs: Namespace + HelmRepository + HelmRelease).

## Acceptance (post-merge, live hw124)

Once `bp-postgres:0.1.1` publishes and a bootstrap-kit reconcile fires, `kubectl -n flux-system get hr` should show `bp-postgres-shared`, `bp-gitea`, `bp-harbor`, `bp-catalyst-platform`, `bp-self-sovereign-cutover`, `bp-cnpg-pair` all Ready=True (or cleanly empty/disabled). Both fixes also make a **future fresh 2-region prov** clean.

Refs #3188

🤖 Generated with [Claude Code](https://claude.com/claude-code)