### PR TITLE
fix(catalog-seed): add the missing bp-postgres Blueprint CR (Refs #3188)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -983,7 +983,10 @@ spec:
       # bp-powerdns-admin Blueprint CR (was the lone catalog-404 on fresh prov).
       # 1.4.547 — #3150 (2026-06-10): catalog-seed bp-powerdns-admin endpoint
       # gains ssoEnabled+ssoInitPath for silent-SSO logged-in.
-      version: 1.4.551
+      # 1.4.552 — #3188 (2026-06-10): catalog-seed gains the missing bp-postgres
+      # Blueprint CR (the shareable PostgreSQL data-instance App card, ADR-0010)
+      # — was the lone catalog-404 for the data-instance card on a fresh prov.
+      version: 1.4.552
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,14 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.552 — #3188 (2026-06-10) — catalog-seed: add the missing bp-postgres
+# Blueprint CR. bp-postgres (the operator-facing, SHAREABLE PostgreSQL
+# data-instance card, ADR-0010) was the lone catalog-404 for the data-instance
+# App card on a fresh Sovereign — #3191 added it to blueprints.json but not the
+# in-cluster catalog-seed, which is the source GET /api/v1/catalog actually
+# serves, so GET /api/v1/catalog/bp-postgres returned 404 while bp-cnpg/
+# bp-cnpg-pair resolved. Seeded verbatim from platform/postgres/blueprint.yaml
+# (version 0.1.1, visibility listed, topology singleton+active-hot-standby, no
+# endpoints/no sso → lockstep-green). Refs #3188.
 # 1.4.542 — #3150 (2026-06-10) — catalog-seed: add the missing
 # bp-powerdns-admin Blueprint CR. bp-powerdns-admin (slot 11a) was the LONE
 # catalog-404 on a fresh Sovereign — the HR installed but no catalog-seed
@@ -2619,7 +2628,7 @@ name: bp-catalyst-platform
 # flip admin.dns.<sov> → pdns-admin.<sov> (single-level, wildcard-cert-covered,
 # matches the KC client redirectUris) + bp-powerdns-admin 0.1.5 OIDC env-var
 # name fixes. Refs #3150.
-version: 1.4.551
+version: 1.4.552
 appVersion: 1.4.494
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -5512,4 +5512,107 @@ spec:
     rolesFromGroup:
       sovereign-admins: admin
     silentLogin: true
+---
+# bp-postgres — the operator-facing, SHAREABLE PostgreSQL data-instance
+# App card (ADR-0010). Each install is ONE CNPG Cluster (the engine,
+# operated by bp-cnpg) exposed as a first-class App. Consumers SHARE it
+# via isolated databases + per-consumer roles, all pure declarative YAML
+# (a CNPG Database CR + a managed.roles entry + a reflected connection
+# Secret + a Flux dependsOn edge) — NO custom controller, NO Crossplane.
+#
+# Seeded verbatim from platform/postgres/blueprint.yaml (#3191/#3196).
+# Was the lone catalog-404 for the data-instance card on a fresh Sovereign
+# (GET /api/v1/catalog/bp-postgres returned 404 while bp-cnpg/bp-cnpg-pair
+# resolved) — #3191 added it to blueprints.json but not this in-cluster
+# seed, which is the source the catalog API actually serves. The engine
+# OPERATOR (bp-cnpg) stays unlisted; the N data-instances (gitea-pg,
+# harbor-pg, shared-pg, …) are bp-postgres App cards → visibility: listed.
+# No user-facing endpoint + no SSO on the source (connection is intra-
+# cluster via the reflected role Secret), so endpoints[] is empty and no
+# sso block — matching platform/postgres/blueprint.yaml keeps the lockstep
+# guard green. Refs #3188.
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-postgres
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: data
+    catalyst.openova.io/section: pts-4-1-data-services
+    catalyst.openova.io/companion: bp-cnpg
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+spec:
+  version: "0.1.1"
+  visibility: listed
+  card:
+    title: "PostgreSQL"
+    category: data
+    family: postgres
+    summary: "A reusable, shareable PostgreSQL data-instance. Each install is ONE CNPG Cluster — the engine — and a first-class App card. Consumers SHARE it via isolated databases + per-consumer roles (ADR-0010)."
+    description: "The binding is pure declarative YAML (a CNPG Database CR + a managed.roles entry + a reflected connection Secret + a Flux dependsOn edge) reconciled by Flux + the CNPG operator. NO custom controller and NO Crossplane. topology: active-hot-standby renders the Pillar-3 synchronous-replication shape (ADR-0004)."
+    icon: postgres.svg
+    license: "Apache-2.0"
+    tags: [database, postgres, sql, data, shareable, cnpg, adr-0010]
+    docs: "https://cloudnative-pg.io/documentation/"
+  placementSchema:
+    modes: [single-region, active-active]
+    default: single-region
+  manifests:
+    chart: bp-postgres
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-postgres
+    version: 0.1.1
+  # Seeded verbatim from platform/postgres/blueprint.yaml spec.topology.
+  # singleton = single-instance Cluster; active-hot-standby = sync
+  # replication across regions (ADR-0004 Pillar-3 zero-tx-loss) via the
+  # cnpg-pair backend, switchover by bp-continuum.
+  topology:
+    supported:
+      - singleton
+      - active-hot-standby
+    defaults:
+      multi-region: active-hot-standby
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: rtz
+          clusters:
+            - rtz-A
+          roles:
+            rtz-A: singleton
+      active-hot-standby:
+        replication:
+          backend: cnpg-pair
+          mode: sync
+          lagSloSeconds: 0
+        switchover:
+          mechanism: bp-continuum
+          rtoSeconds: 10
+          rpoSeconds: 0
+        placement:
+          tier: rtz
+          clusters:
+            - rtz-A
+            - rtz-B
+          roles:
+            rtz-A: active
+            rtz-B: passive
+  # No public endpoint — consumers connect intra-cluster via the
+  # CNPG-reflected role Secret. Empty endpoints[] + no sso block matches
+  # the platform/ source (keeps the lockstep guard green).
+  endpoints: []
+  # multiInstance — N distinct data-instances per Org (gitea-pg, harbor-pg,
+  # shared-pg, …). maxPerOrg 0 = unlimited. Mirrors the platform/ source.
+  multiInstance:
+    enabled: true
+    maxPerOrg: 0
+    namingTemplate: "{{ "{{" }}.AppName{{ "}}" }}-{{ "{{" }}.InstanceID{{ "}}" }}"
+    isolationLevel: namespace
 {{- end }}


### PR DESCRIPTION
## Problem

The **PostgreSQL App-card (`bp-postgres`) is NOT in the in-cluster catalog** on a fresh Sovereign:

```
GET /api/v1/catalog/bp-postgres → 404 blueprint_not_found   (all 77 siblings → 200)
```

#3191 added `bp-postgres` to `products/catalyst/bootstrap/api/internal/catalog/blueprints.json`, but **not** to `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` — the in-cluster Blueprint CRs the catalog API actually serves (the v1 GVR LIST fallback). So the founder's "PostgreSQL App-card visible in the catalog" requirement was unmet.

## Fix

1. **Seed the `bp-postgres` Blueprint CR** verbatim from `platform/postgres/blueprint.yaml`:
   - `version: 0.1.1`, `visibility: listed`
   - card: title **PostgreSQL** / category **data** / icon **postgres.svg**
   - `topology.supported: [singleton, active-hot-standby]` + full `perTopology` (singleton + active-hot-standby with cnpg-pair sync replication, bp-continuum switchover)
   - `multiInstance: enabled, maxPerOrg 0 (unlimited), isolationLevel namespace`
   - `endpoints: []` + no `sso` block — the source has neither (consumers connect intra-cluster via the CNPG-reflected role Secret). Matching the source keeps the lockstep guard green.
2. **`scripts/check-catalog-seed-lockstep.sh` PASS** — ran locally: `checked: 68   skipped: 11   fail: 0` (count rose 67→68; bp-postgres now matched against its `platform/` source).
3. **Checked sibling #3191/#3196 cards**: `bp-cnpg-pair` (#3196) and `bp-cnpg` are **already seeded** (`seeded=1`); the engine OPERATOR `bp-cnpg` stays unlisted by design. **`bp-postgres` was the only #3191/#3196 listed card absent from the seed.**
4. **3-way version lockstep** on the bp-catalyst-platform chart bump:
   - `products/catalyst/chart/Chart.yaml`: `1.4.551 → 1.4.552`
   - `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` pin: `1.4.551 → 1.4.552`
   - `platform/catalyst-platform/blueprint.yaml` `spec.version` is the `0.0.0` placeholder by design (the real pin lives in the bootstrap-kit slot, per its own inline comment).

## Verify (acceptance — live, post-merge)

After the deploy-bot publishes `bp-catalyst-platform:1.4.552` + the bootstrap-kit reconciles on hw124:

- mint a sovereign-realm token (Secret `catalyst-kc-sa-credentials` ns `catalyst-system`, client `catalyst-api-server`, client_credentials against `auth.hw124.omani.works/realms/sovereign`)
- confirm `GET https://console.hw124.omani.works/api/v1/catalog/bp-postgres → 200` (was 404)
- confirm `kubectl get blueprints.catalyst.openova.io bp-postgres -A` shows the CR

The PostgreSQL App-card now resolves a catalog page.

Refs #3188

🤖 Generated with [Claude Code](https://claude.com/claude-code)