### PR TITLE
fix(bootstrap-kit): ghcr-pull secretRef on bp-network-policies HelmRepository (Refs #3188)

### DIFF
--- a/clusters/_template/bootstrap-kit/26-network-policies.yaml
+++ b/clusters/_template/bootstrap-kit/26-network-policies.yaml
@@ -42,6 +42,13 @@ spec:
   type: oci
   interval: 15m
   url: oci://ghcr.io/openova-io
+  # ghcr-pull authenticates the OCI pull — bp-network-policies is a PRIVATE
+  # ghcr package (like every other bp-* chart). Without this secretRef Flux
+  # falls back to anonymous auth → 401 Unauthorized → the chart never pulls →
+  # the bootstrap-kit Kustomization wedges its health-wait on this one HR and
+  # never advances to newer revisions. Mirrors slots 13/16b. Refs #3188.
+  secretRef:
+    name: ghcr-pull
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
## Problem
On live hw124 the bootstrap-kit Kustomization was stuck `READY=Unknown` ("Reconciliation in progress"), health-waiting on a single wedged HR:

```
flux-system/bp-network-policies :: 1.0.3 :: HelmChart ... chart pull error:
failed to download chart ... 'oci://ghcr.io/openova-io/bp-network-policies:1.0.3':
failed to authorize: failed to fetch anonymous token: ... 401 Unauthorized
```

Root cause: slot-26's `bp-network-policies` HelmRepository (`type: oci`) was **missing `secretRef: {name: ghcr-pull}`** — the auth secret every other `bp-*` HelmRepository carries (slots 13/16a/16b). `bp-network-policies` is a **private** ghcr package, so Flux fell back to anonymous auth, hitting `401`. The chart never resolved.

Because the Kustomization runs `wait: true`, its health-check wedged on this one HR and **never advanced to newer git revisions** — preventing the catalog-seed `bp-postgres` CR (#3199) and any other downstream change from reconciling.

This also wedges every fresh prov: slot-26 lives in the cluster scaffold, so a new Sovereign fails on `bp-network-policies` identically.

## Fix
Add `secretRef: {name: ghcr-pull}` to the `bp-network-policies` HelmRepository — byte-for-byte the pattern on slots 13 (`bp-catalyst-platform`) and 16b (`bp-cnpg-pair`).

## Verify
- [ ] Live hw124: `kubectl -n flux-system get helmrepository bp-network-policies -o jsonpath='{.spec.secretRef.name}'` returns `ghcr-pull`
- [ ] `kubectl get hr -n flux-system bp-network-policies` reaches Ready=True (chart pulls)
- [ ] bootstrap-kit Kustomization advances past the health-wait, applies the bp-postgres catalog-seed, and `GET /api/v1/catalog/bp-postgres` returns 200

Refs #3188.