### PR TITLE
fix(network-policies): apiserver-reachable allow (entity `all`) + gate default-deny off until validated (Refs #3188)

### DIFF
--- a/clusters/_template/bootstrap-kit/26-network-policies.yaml
+++ b/clusters/_template/bootstrap-kit/26-network-policies.yaml
@@ -70,11 +70,26 @@ spec:
       # mandatory-on; allowSystemNamespaces expanded to 45 control-
       # plane namespaces covering every bootstrap-kit targetNamespace
       # plus the 3 vCluster syncer namespaces.
-      version: 1.0.3
+      # 1.0.4 (Refs #3188, 2026-06-10): allow-system-namespaces now uses
+      # the reserved entity `all` (was a bare `{}` rule that didn't cover
+      # kube-apiserver/host/world) — fixes control-plane Pods losing the
+      # apiserver under default-deny. See the `enabled: false` gate below.
+      version: 1.0.4
       sourceRef:
         kind: HelmRepository
         name: bp-network-policies
         namespace: flux-system
+  # enabled: false — install the chart (so the HR/HelmChart resolves and
+  # the bootstrap-kit Kustomization reaches Ready) but render ZERO Cilium
+  # policies. Validated on live hw124 (2026-06-10): the 1.0.4 `all`-entity
+  # fix restores kyverno→apiserver under default-deny, BUT the default-deny
+  # still 403s the console ingress path — so the zero-trust posture is not
+  # yet safe to enforce cluster-wide. Re-enabling (enabled: true) is gated
+  # on a dedicated validation prov proving EVERY ingress/egress path
+  # (console, marketplace, SSO, tenant Orgs) survives default-deny. Until
+  # then this stays off so no fresh prov is severed. Refs #3188.
+  values:
+    enabled: false
   install:
     timeout: 5m
     disableWait: true

--- a/platform/network-policies/blueprint.yaml
+++ b/platform/network-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.0.3
+  version: 1.0.4
   card:
     title: Network Policies (zero-trust baseline)
     summary: |

--- a/platform/network-policies/chart/Chart.yaml
+++ b/platform/network-policies/chart/Chart.yaml
@@ -10,7 +10,7 @@ name: bp-network-policies
 # from boot. Per-Blueprint CNPs progressively tighten beyond this
 # coarse safety net.
 # 1.0.2 (initial — operator-opt-in).
-version: 1.0.3
+version: 1.0.4
 description: |
   Catalyst zero-trust default-deny CiliumClusterwideNetworkPolicy +
   allow-templates for control-plane namespaces, intra-namespace traffic,

--- a/platform/network-policies/chart/templates/allow-system-namespaces.yaml
+++ b/platform/network-policies/chart/templates/allow-system-namespaces.yaml
@@ -30,8 +30,23 @@ spec:
           {{- range .Values.allowSystemNamespaces }}
           - {{ . | quote }}
           {{- end }}
+  # 1.0.4 (Refs #3188, 2026-06-10): full reachability for control-plane
+  # namespaces must use the reserved entity `all`, NOT a bare `{}` rule.
+  # In Cilium a `{}` ingress/egress rule matches only Pod ENDPOINTS — it
+  # does NOT cover the reserved entities (`kube-apiserver`, `host`,
+  # `remote-node`, `world`). Under `00-default-deny`, that left every
+  # control-plane Pod (kyverno, flux, cert-manager, …) unable to reach the
+  # kube-apiserver ClusterIP (10.96.0.1 → identity `kube-apiserver`),
+  # the host, or external endpoints — kyverno's admission webhook lost its
+  # endpoints and its failurePolicy=Fail then blocked every Pod mutation
+  # cluster-wide. `all` = every endpoint + every reserved entity + world,
+  # which is the documented "full ingress/egress" intent for this coarse
+  # control-plane safety net. (The working bp-external-dns-apiserver CNP
+  # uses the same `toEntities` idiom for apiserver egress.)
   ingress:
-    - {}
+    - fromEntities:
+        - all
   egress:
-    - {}
+    - toEntities:
+        - all
 {{- end -}}


### PR DESCRIPTION
## Context
After #3200 made `bp-network-policies` pullable, its default-deny installed on live hw124 for the first time and **took the cluster down**: kyverno admission lost the kube-apiserver, its `failurePolicy=Fail` webhook then had no endpoints and rejected every Pod mutation cluster-wide; catalyst-api (Recreate strategy) couldn't be recreated → console 503. Recovered by deleting the 3 CCNPs.

## Root cause
`allow-system-namespaces.yaml` granted control-plane namespaces reachability with bare `ingress/egress: [{}]` rules. In Cilium a `{}` rule matches only Pod **endpoints** — it does **not** cover the reserved entities (`kube-apiserver`, `host`, `remote-node`, `world`). Under `00-default-deny`, every control-plane Pod (kyverno, flux, cert-manager, …) lost the apiserver ClusterIP `10.96.0.1` (Cilium identity `kube-apiserver`). The repo's working `bp-external-dns-apiserver` CNP already uses `toEntities: [kube-apiserver]`.

## Fix (two coupled changes)
1. **chart 1.0.4** — `allow-system-namespaces` now uses the Cilium catch-all entity `all` (`fromEntities/toEntities: [all]`) = every endpoint + every reserved entity + world. **Verified live on hw124**: with 1.0.4 applied under default-deny, both kyverno admission controllers stayed Ready with apiserver access (webhook endpoints populated), and Pod creation succeeded.
2. **slot-26 `values.enabled: false`** — even with fix (1), applying default-deny still **403'd the console ingress path** (verified: console 200 without policies, 403 with). So the zero-trust posture is not yet safe to enforce. Gating `enabled=false` keeps #3200's benefit (the chart is pulled → HelmRelease + bootstrap-kit Kustomization reach Ready, no health-wait wedge) while rendering **zero** policies, so no fresh prov is severed.

Re-enabling (`enabled: true`) is gated on a dedicated validation prov proving **every** ingress/egress path (console, marketplace, SSO, tenant Orgs) survives default-deny.

## Verify
- [ ] `helm template np platform/network-policies/chart --set enabled=true` renders `toEntities/fromEntities: [all]` in `10-allow-system-namespaces`
- [ ] Live (already done on hw124): default-deny + 1.0.4-allow → kyverno stays Ready, apiserver reachable
- [ ] Fresh prov with `enabled=false`: HR Ready, zero CCNPs, console/catalog/SSO unaffected

Refs #3188.