### PR TITLE
fix(continuum): add ghcr-pull imagePullSecrets to continuum-controller (Refs #3189)

### DIFF
--- a/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+++ b/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
@@ -129,7 +129,7 @@ spec:
       # fresh-prov walk).
       # 0.1.4 (#3189): prerequisite-check initContainer no longer
       # crashloops on single-region (no cnpg-pair) — exits 0 + idle-Ready.
-      version: 0.1.4
+      version: 0.1.5
       sourceRef:
         kind: HelmRepository
         name: bp-continuum

--- a/products/continuum/chart/Chart.yaml
+++ b/products/continuum/chart/Chart.yaml
@@ -39,7 +39,7 @@ type: application
 # 0.1.0 sat in-tree without a bootstrap-kit slot to pin it, so the
 # blueprint-release workflow's `detect changed paths` step never had
 # reason to re-run and the chart was never pushed to GHCR.
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.1.0"
 home: https://openova.io
 sources:

--- a/products/continuum/chart/blueprint.yaml
+++ b/products/continuum/chart/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     openova.io/category: customer-facing-capability
 spec:
-  version: 0.1.4
+  version: 0.1.5
   card:
     title: Continuum
     summary: |

--- a/products/continuum/chart/templates/deployment.yaml
+++ b/products/continuum/chart/templates/deployment.yaml
@@ -29,6 +29,15 @@ spec:
     spec:
       serviceAccountName: {{ include "continuum.fullname" . }}
       automountServiceAccountToken: true
+      # GHCR image (ghcr.io/openova-io/openova/continuum-controller) is a
+      # PRIVATE package — same pattern as catalyst-api / application-controller.
+      # Without this, the deploy-bot's controller-image sweep rolls the Pod onto
+      # a new tag it can't pull → ImagePullBackOff (anonymous 401), which left
+      # continuum-controller down on hw124 and blocked the #3189 single-region
+      # idle-Ready verification. The ghcr-pull Secret lives in the same
+      # targetNamespace (catalyst-system) as the other control-plane controllers.
+      imagePullSecrets:
+        - name: ghcr-pull
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534


### PR DESCRIPTION
## Problem
On live hw124 `continuum-controller` has been **ImagePullBackOff** — its Deployment carried **no `imagePullSecrets`**, but it pulls a **private** ghcr image (`ghcr.io/openova-io/openova/continuum-controller`). Every sibling control-plane controller (catalyst-api, application-controller, environment-controller) sets `imagePullSecrets: [ghcr-pull]`; continuum was the odd one out. When the deploy-bot's controller-image sweep rolled it onto a new tag (`dedba1c`), the kubelet got anonymous `401` → the Pod never started.

## Impact
- Blocks verification of **#3189** A2 (continuum single-region idle-Ready) — the prerequisite-check no-op fix is already in the chart, but the Pod never starts to demonstrate it.
- continuum is the **Pillar-3 switchover mechanism**; this would break it on any fresh prov whenever its image tag advances.

## Fix
Add `imagePullSecrets: [- name: ghcr-pull]` to the continuum Deployment pod spec — byte-identical to the sibling controllers. `ghcr-pull` already lives in continuum's targetNamespace (`catalyst-system`). chart `0.1.4 → 0.1.5` (Chart.yaml + blueprint.yaml + slot-62 pin in lockstep).

## Verify
- [ ] `helm template … --set continuum.enabled=true` renders `imagePullSecrets: [ghcr-pull]` (done locally)
- [ ] Live hw124 after roll: `continuum-controller` Pod pulls `dedba1c` → Running/Ready (idle-Ready single-region), no ImagePullBackOff

Refs #3189.