### PR TITLE
fix(external-secrets): post-install webhook-readiness gate (Refs #3155)

### DIFF
--- a/clusters/_template/bootstrap-kit/15-external-secrets.yaml
+++ b/clusters/_template/bootstrap-kit/15-external-secrets.yaml
@@ -69,7 +69,7 @@ spec:
   chart:
     spec:
       chart: bp-external-secrets
-      version: 1.1.1
+      version: 1.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-external-secrets

--- a/platform/external-secrets/blueprint.yaml
+++ b/platform/external-secrets/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.1.1
+  version: 1.1.2
   card:
     title: External Secrets Operator
     summary: |

--- a/platform/external-secrets/chart/Chart.yaml
+++ b/platform/external-secrets/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-external-secrets
-version: 1.1.1
+version: 1.1.2
 description: |
   Catalyst-curated Blueprint umbrella chart for External Secrets Operator
   (ESO) — controller-only as of 1.1.0. Depends on the upstream

--- a/platform/external-secrets/chart/templates/webhook-gate-hook.yaml
+++ b/platform/external-secrets/chart/templates/webhook-gate-hook.yaml
@@ -1,0 +1,140 @@
+{{- /*
+#3155 (2026-06-10): bp-external-secrets post-install webhook readiness gate.
+
+The race
+========
+bp-external-secrets ships the ESO controller + the validating/mutating
+admission webhooks (`validate.externalsecret.external-secrets.io`,
+failurePolicy: Fail). On a cold/throttled prov the upstream webhook image
+(`oci.external-secrets.io/.../external-secrets`) can take ~2 min to pull, and
+the webhook Pod fails its readiness probe until TLS is mounted — so the
+`external-secrets-webhook` Service has NO ready endpoints for a window.
+
+But the bp-external-secrets HR reports `Ready=True / InstallSucceeded` as soon
+as Helm finishes (webhook-Pod readiness is NOT part of Helm's release health).
+So `dependsOn: bp-external-secrets` is satisfied PREMATURELY: a consumer like
+bp-harbor installs an ExternalSecret, the apiserver calls the not-yet-serving
+webhook → `no endpoints available for service "external-secrets-webhook"` →
+harbor Helm install FAILS, and Flux did NOT self-heal (hw124 #3155: harbor
+False ~50 min, bootstrap-kit HealthCheckFailed, sovereign-tls DependencyNotReady,
+serves 000).
+
+The fix — same producer-side gate as kyverno (#2605) / cert-manager
+========================================================================
+This post-install Job holds the Helm hook phase (and therefore HR Ready) until
+the webhook is actually SERVING:
+  (a) Endpoints `external-secrets-webhook` has ≥1 ready address, AND
+  (b) Secret `external-secrets-webhook` carries a non-empty `tls.crt`.
+Then `dependsOn` consumers wait for a serving webhook, not just a finished Helm
+release.
+
+NON-FATAL on timeout (#3149): a fatal hook → Flux install-remediation →
+uninstall, which the admission webhook (failurePolicy: Fail) can then block →
+HR stuck StateError, a cascade strictly WORSE than letting ESO finish warming
+while consumers' own retries absorb the gap. The gate stays a loud slow-warm
+DETECTOR, never a cluster-wedging fatal.
+*/}}
+{{- $gate := .Values.webhookGate | default dict -}}
+{{- $enabled := true -}}
+{{- if hasKey $gate "enabled" -}}
+{{-   $enabled = $gate.enabled -}}
+{{- end -}}
+{{- if $enabled }}
+{{- $svcName := (($gate.service).name) | default "external-secrets-webhook" -}}
+{{- $svcNs := (($gate.service).namespace) | default "external-secrets-system" -}}
+{{- $secretName := $gate.tlsSecretName | default "external-secrets-webhook" -}}
+{{- $timeout := $gate.timeoutSeconds | default 1200 -}}
+{{- $interval := $gate.intervalSeconds | default 2 -}}
+{{- $image := $gate.image | default "bitnamilegacy/kubectl:1.30.7" -}}
+{{- $pullPolicy := $gate.imagePullPolicy | default "IfNotPresent" -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-webhook-gate
+  namespace: {{ $svcNs | quote }}
+  labels:
+    app.kubernetes.io/name: bp-external-secrets
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/component: webhook-gate
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-external-secrets
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        catalyst.openova.io/component: webhook-gate
+    spec:
+      serviceAccountName: {{ .Release.Name }}-webhook-gate
+      restartPolicy: Never
+      containers:
+        - name: gate
+          image: {{ $image | quote }}
+          imagePullPolicy: {{ $pullPolicy | quote }}
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "32Mi"
+            limits:
+              cpu: "100m"
+              memory: "128Mi"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: WEBHOOK_SVC
+              value: {{ $svcName | quote }}
+            - name: WEBHOOK_NS
+              value: {{ $svcNs | quote }}
+            - name: TLS_SECRET
+              value: {{ $secretName | quote }}
+            - name: TIMEOUT_SECONDS
+              value: {{ $timeout | quote }}
+            - name: INTERVAL_SECONDS
+              value: {{ $interval | quote }}
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -euo pipefail
+              echo "external-secrets webhook gate: poll (a) endpoints/${WEBHOOK_NS}/${WEBHOOK_SVC} >=1 ready, (b) secret/${WEBHOOK_NS}/${TLS_SECRET} has non-empty tls.crt (budget=${TIMEOUT_SECONDS}s, interval=${INTERVAL_SECONDS}s)"
+              deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+              attempt=0
+              while [ "$(date +%s)" -lt "${deadline}" ]; do
+                attempt=$(( attempt + 1 ))
+                ep_count="$(kubectl get endpoints "${WEBHOOK_SVC}" \
+                  -n "${WEBHOOK_NS}" \
+                  --ignore-not-found \
+                  -o jsonpath='{range .subsets[*]}{.addresses[*].ip}{"\n"}{end}' 2>/dev/null \
+                  | tr ' ' '\n' | grep -c . || true)"
+                tls_len="$(kubectl get secret "${TLS_SECRET}" \
+                  -n "${WEBHOOK_NS}" \
+                  --ignore-not-found \
+                  -o jsonpath='{.data.tls\.crt}' 2>/dev/null \
+                  | wc -c | tr -d ' ')"
+                if [ "${ep_count}" -ge 1 ] && [ "${tls_len}" -gt 100 ]; then
+                  echo "Both conditions cleared after ${attempt} attempt(s); endpoints=${ep_count} tls_crt_len=${tls_len}."
+                  exit 0
+                fi
+                echo "Attempt ${attempt}: endpoints=${ep_count} tls_crt_len=${tls_len}; sleeping ${INTERVAL_SECONDS}s."
+                sleep "${INTERVAL_SECONDS}"
+              done
+              echo "WARNING: external-secrets webhook gate did not clear within ${TIMEOUT_SECONDS}s — proceeding NON-FATALLY (#3149/#3155)." >&2
+              echo "Rationale: a fatal exit makes Helm mark post-install/upgrade FAILED -> Flux install-remediation uninstalls -> the ESO admission webhook (failurePolicy: Fail) can then block deletion of ExternalSecret-related resources -> HR stuck StateError, a cascade strictly WORSE than letting ESO finish warming while dependsOn consumers' own retries absorb the gap." >&2
+              echo "Diagnose with:" >&2
+              echo "  kubectl -n ${WEBHOOK_NS} get pods -l app.kubernetes.io/name=external-secrets-webhook" >&2
+              echo "  kubectl -n ${WEBHOOK_NS} get endpoints ${WEBHOOK_SVC}" >&2
+              echo "  kubectl -n ${WEBHOOK_NS} get secret ${TLS_SECRET}" >&2
+              exit 0
+{{- end }}

--- a/platform/external-secrets/chart/templates/webhook-gate-rbac.yaml
+++ b/platform/external-secrets/chart/templates/webhook-gate-rbac.yaml
@@ -1,0 +1,68 @@
+{{- /*
+#3155 (2026-06-10): RBAC for the bp-external-secrets webhook-gate Job.
+Same producer-side gate pattern as kyverno #2605 / cert-manager.
+
+Scoped to the webhook namespace (external-secrets-system):
+- GET/LIST Endpoints (verify external-secrets-webhook Service has >=1 ready addr)
+- GET/LIST Secrets   (verify external-secrets-webhook TLS secret has tls.crt)
+
+Both are namespace-scoped -> Role + RoleBinding only, no cluster-scope grant.
+*/}}
+{{- $gate := .Values.webhookGate | default dict -}}
+{{- $enabled := true -}}
+{{- if hasKey $gate "enabled" -}}
+{{-   $enabled = $gate.enabled -}}
+{{- end -}}
+{{- if $enabled }}
+{{- $svcNs := (($gate.service).namespace) | default "external-secrets-system" -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-webhook-gate
+  namespace: {{ $svcNs | quote }}
+  labels:
+    app.kubernetes.io/name: bp-external-secrets
+    catalyst.openova.io/component: webhook-gate
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-webhook-gate
+  namespace: {{ $svcNs | quote }}
+  labels:
+    app.kubernetes.io/name: bp-external-secrets
+    catalyst.openova.io/component: webhook-gate
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints", "secrets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-webhook-gate
+  namespace: {{ $svcNs | quote }}
+  labels:
+    app.kubernetes.io/name: bp-external-secrets
+    catalyst.openova.io/component: webhook-gate
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-webhook-gate
+    namespace: {{ $svcNs | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-webhook-gate
+{{- end }}

--- a/platform/external-secrets/chart/values.yaml
+++ b/platform/external-secrets/chart/values.yaml
@@ -105,3 +105,19 @@ external-secrets:
 # resolve a CRD-ordering deadlock. Set
 # `platform/external-secrets-stores/chart/values.yaml::clusterSecretStore.*`
 # instead — the same key path; only the chart owning the CR changed.
+
+# #3155 (2026-06-10): post-install webhook-readiness gate. Holds the bp-external-
+# secrets HR Ready until the ESO admission webhook is actually SERVING (endpoints
+# ready + tls.crt present), so dependsOn consumers (bp-harbor, any ExternalSecret)
+# don't install into a not-yet-serving webhook and fail. Same producer-side gate
+# as kyverno #2605. NON-FATAL on timeout (#3149). Set enabled:false to skip.
+webhookGate:
+  enabled: true
+  service:
+    name: external-secrets-webhook
+    namespace: external-secrets-system
+  tlsSecretName: external-secrets-webhook
+  timeoutSeconds: 1200
+  intervalSeconds: 2
+  image: bitnamilegacy/kubectl:1.30.7
+  imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Problem (hw124 #3155, zero-touch)
`bp-external-secrets` HR reports `Ready=True / InstallSucceeded` the moment Helm finishes — but the ESO admission webhook (`validate.externalsecret.external-secrets.io`, failurePolicy: Fail) may not be **serving** yet on a cold/throttled prov (upstream webhook image ~2 min to pull + readiness probe). So `dependsOn: bp-external-secrets` is satisfied **prematurely**: bp-harbor installs an ExternalSecret → apiserver calls the not-yet-serving webhook → `no endpoints available for service "external-secrets-webhook"` → harbor Helm install **fails**, and Flux did not self-heal (harbor False ~50 min, bootstrap-kit HealthCheckFailed, sovereign-tls DependencyNotReady, serves 000).

## Fix — same producer-side gate as kyverno #2605 / cert-manager
A post-install/upgrade Job holds the Helm hook phase (and therefore HR Ready) until the webhook is actually serving:
- (a) `endpoints/external-secrets-system/external-secrets-webhook` has ≥1 ready address, **and**
- (b) `secret/external-secrets-webhook` carries a non-empty `tls.crt`.

Then `dependsOn` consumers wait for a **serving** webhook, not just a finished Helm release.

**NON-FATAL on timeout (#3149):** a fatal hook → Flux uninstall → the ESO webhook (failurePolicy: Fail) can block the deletion → HR stuck StateError — a cascade strictly worse than letting ESO warm while consumers' own retries absorb the gap. The gate stays a loud slow-warm detector.

## Files
- `templates/webhook-gate-hook.yaml` (Job) + `templates/webhook-gate-rbac.yaml` (SA + namespace-scoped Role/RoleBinding for get/list endpoints+secrets) — adapted byte-for-byte from the proven `platform/kyverno/chart` gate.
- `values.yaml` — `webhookGate` defaults (opt-out via `enabled: false`).
- chart `1.1.1 → 1.1.2` (Chart.yaml + blueprint.yaml + slot-15 pin in lockstep).

## Verify
- [x] `helm template` (deps built) renders the gate Job + RBAC with correct `external-secrets-webhook` svc/secret + `external-secrets-system` ns.
- [ ] Fresh prov: bp-harbor no longer races the webhook (installs cleanly first pass).

Refs #3155.