### PR TITLE
fix(powerdns-admin): point PDNS_API_URL at the real powerdns Service (Refs #3189)

### DIFF
--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -99,7 +99,7 @@ spec:
       # 0.1.5 (#3150, 2026-06-10): silent-SSO logged-in — correct OIDC env-var
       # names (OIDC_OAUTH_USERNAME/_FIRSTNAME/_LAST_NAME/_EMAIL) + name claims
       # point at preferred_username (catalyst-pin carries no given_name).
-      version: 0.1.5
+      version: 0.1.6
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns-admin

--- a/platform/powerdns-admin/blueprint.yaml
+++ b/platform/powerdns-admin/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 0.1.5
+  version: 0.1.6
   card:
     title: powerdns-admin
     summary: |

--- a/platform/powerdns-admin/chart/Chart.yaml
+++ b/platform/powerdns-admin/chart/Chart.yaml
@@ -36,7 +36,7 @@ name: bp-powerdns-admin
 #     live on hw124: console Open → pdns-admin.<fqdn>/oidc/login → KC silent →
 #     lands on the PDA Dashboard logged-in, no login form
 #     (docs/sessions/2026-06-10/evidence/hw124-powerdns-admin-loggedin.png).
-version: 0.1.5
+version: 0.1.6
 description: |
   PowerDNS-Admin (ngoduykhanh/powerdns-admin) web UI Blueprint for
   per-Sovereign PowerDNS zone + record management. Drives the

--- a/platform/powerdns-admin/chart/values.yaml
+++ b/platform/powerdns-admin/chart/values.yaml
@@ -131,11 +131,15 @@ databaseSecret:
 
 # ─── PowerDNS backend endpoint ───────────────────────────────────────────
 # Where the running PDA container reaches the authoritative server.
-# Per-Sovereign overlay sets these or accepts the in-cluster default
-# (matches platform/powerdns/chart/templates/dnsdist.yaml api Service
-# name + port).
+# Per-Sovereign overlay sets these or accepts the in-cluster default.
+# 0.1.6 (#3189, 2026-06-10): the API/webserver (port 8081) is exposed by
+# the bp-powerdns chart's `powerdns` Service (live: `powerdns` svc port
+# `webserver:8081`; the chart's own zone-bootstrap-job curls
+# `http://powerdns:8081`). The previous `bp-powerdns-api` host does NOT
+# exist as a Service → NXDOMAIN → PowerDNS-Admin could not reach the API
+# → empty Zones table (its core function dead). Point at the real svc.
 pdns:
-  apiUrl: "http://bp-powerdns-api.powerdns.svc.cluster.local:8081"
+  apiUrl: "http://powerdns.powerdns.svc.cluster.local:8081"
   # The API key the PDA container POSTs via X-API-Key. bp-powerdns chart
   # ships templates/api-credentials-secret.yaml; the same Secret is
   # reflected into this namespace via the reflector chain so we read


### PR DESCRIPTION
## Problem
PowerDNS-Admin dialed `PDNS_API_URL=http://bp-powerdns-api.powerdns.svc.cluster.local:8081` — but **no `bp-powerdns-api` Service exists**. The PowerDNS API/webserver (port 8081) is exposed by the bp-powerdns chart's **`powerdns`** Service (live: `powerdns` svc port `webserver:8081`; the chart's own zone-bootstrap-job curls `http://powerdns:8081`). So the host was **NXDOMAIN** → PowerDNS-Admin could never reach the API → **empty Zones table** (its core DNS-management function dead; the Pod was erroring on the failed connection).

## Fix
`pdns.apiUrl → http://powerdns.powerdns.svc.cluster.local:8081`. SSO into PowerDNS-Admin already worked (UAT §2.2) — this fixes the actual function behind the login. chart `0.1.5 → 0.1.6` (Chart.yaml + blueprint.yaml + slot-11a pin lockstep).

## Verify
- [x] `helm template` renders `PDNS_API_URL: http://powerdns.powerdns.svc.cluster.local:8081`
- [ ] Live after roll: powerdns-admin Pod stops erroring; Zones table reachable (API 200)

Refs #3189.