### PR TITLE
fix(powerdns): redirect pdns.<fqdn> root to the pdns-admin UI (Refs #3225)

### DIFF
--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -129,7 +129,11 @@ spec:
       # occurred: * job powerdns-zone-bootstrap failed: BackoffLimitExceeded".
       # 1.2.10 (#3150): allow reflection of powerdns-api-credentials into the
       # powerdns-admin ns (slot 11a PDNS_API_KEY).
-      version: 1.2.10
+      # 1.2.11 (#3225): root catch-all on the API HTTPRoute 302-redirects a
+      # bare GET / on pdns.<fqdn> to the UI at pdns-admin.<fqdn> (set via
+      # values.api.uiRedirectHost below) so the browser lands on the UI
+      # instead of a 404; the /api forward rule is preserved.
+      version: 1.2.11
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns
@@ -174,6 +178,14 @@ spec:
         instances: ${SOVEREIGN_CNPG_INSTANCES:=1}
     api:
       host: pdns.${SOVEREIGN_FQDN}
+      # #3225: a bare GET / on the API host (pdns.<fqdn>) matches no rule and
+      # 404s in the founder's browser — the API host serves no UI. Redirect
+      # the catch-all root to the human PowerDNS-Admin UI at
+      # pdns-admin.<fqdn> (bp-powerdns-admin, slot 11a). The /api forward
+      # rule still wins by longest-prefix, so the REST API and in-cluster
+      # cert-manager DNS-01 / external-dns consumers (Service DNS, not this
+      # host) are untouched.
+      uiRedirectHost: pdns-admin.${SOVEREIGN_FQDN}
       gateway:
         enabled: true
     # DNS-01 wildcard cert: expose PowerDNS on NodePort 30053 so the

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.10
+  version: 1.2.11
   card:
     title: PowerDNS
     summary: |

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -7,7 +7,13 @@ name: bp-powerdns
 # 1.2.10 (#3150, 2026-06-10): permit reflection of powerdns-api-credentials
 # into the powerdns-admin ns so bp-powerdns-admin's PDNS_API_KEY resolves
 # (slot 11a first exercised by #3173 — see api-credentials-secret.yaml).
-version: 1.2.10
+# 1.2.11 (#3225, 2026-06-10): api-httproute.yaml gains a catch-all root
+# rule (gated on new api.uiRedirectHost) that 302-redirects a bare GET /
+# on pdns.<fqdn> to the powerdns-admin UI at pdns-admin.<fqdn>, so the
+# founder's browser lands on the UI instead of a 404. The /api forward
+# rule is preserved (Gateway-API longest-prefix). Default empty = no
+# redirect rule rendered (zero regression).
+version: 1.2.11
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/templates/api-httproute.yaml
+++ b/platform/powerdns/chart/templates/api-httproute.yaml
@@ -51,4 +51,32 @@ spec:
       backendRefs:
         - name: {{ .Values.api.gateway.backendService | default "powerdns" | quote }}
           port: {{ .Values.api.gateway.backendPort | default (.Values.powerdns.powerdns.webserver.bindPort | default 8081) }}
+    {{- /*
+      Root catch-all → UI redirect (#3225).
+
+      The PowerDNS REST API host serves no human UI: a bare GET / on
+      pdns.<fqdn> matches neither the /api forward rule above nor anything
+      else, so Cilium/Gateway-API returns a 404 in the founder's browser.
+      When api.uiRedirectHost is set, this SECOND rule matches the catch-all
+      PathPrefix / and 302-redirects to the powerdns-admin UI host
+      (pdns-admin.<fqdn>). Gateway API resolves overlapping PathPrefix
+      matches by longest-prefix, so /api keeps hitting the backend above
+      while everything else falls through to this redirect — the API
+      contract for cert-manager DNS-01 / external-dns (which hit the
+      in-cluster Service, not this host) is untouched.
+
+      Default empty → this rule is not rendered → zero behaviour change for
+      clusters that don't opt in.
+    */ -}}
+    {{- with .Values.api.uiRedirectHost }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/"
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            hostname: {{ . | quote }}
+            statusCode: 302
+    {{- end }}
 {{- end }}

--- a/platform/powerdns/chart/tests/httproute-ui-redirect.sh
+++ b/platform/powerdns/chart/tests/httproute-ui-redirect.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# bp-powerdns — HTTPRoute root-redirect render audit (#3225).
+#
+# A bare GET / on pdns.<fqdn> previously fell through unmatched (the only
+# rule matched PathPrefix /api → powerdns:8081) and returned a 404 in the
+# founder's browser. The PowerDNS API host serves no human UI; the UI lives
+# at pdns-admin.<fqdn> (bp-powerdns-admin). This test pins the path-scoped
+# root redirect that lands the browser on the UI instead of a 404.
+#
+# Cases:
+#   1. With api.uiRedirectHost set, the HTTPRoute carries a second rule that
+#      matches PathPrefix / and emits a RequestRedirect to that host (302).
+#   2. The existing PathPrefix /api → powerdns backend forward rule is
+#      PRESERVED (the redirect must not displace API routing — Gateway API
+#      picks the more-specific /api match over the catch-all /).
+#   3. Default-off: with api.uiRedirectHost unset/empty, NO RequestRedirect
+#      filter renders (zero regression for clusters that don't set it).
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+redirect_host="pdns-admin.example.com"
+
+overlay=(
+  --set api.gateway.enabled=true
+  --set api.host=pdns.example.com
+  --set api.uiRedirectHost="$redirect_host"
+)
+
+echo "[bp-powerdns] Case 1: root → UI RequestRedirect renders"
+out=$("$helm" template smoke "$chart_dir" "${overlay[@]}" 2>&1)
+route_block=$(echo "$out" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
+if [ -z "$route_block" ]; then
+  echo "FAIL: HTTPRoute did not render with api.gateway.enabled=true"
+  exit 1
+fi
+if ! echo "$route_block" | grep -q "type: RequestRedirect"; then
+  echo "FAIL: no RequestRedirect filter for root path"
+  exit 1
+fi
+if ! echo "$route_block" | grep -Eq "hostname: \"?$redirect_host\"?"; then
+  echo "FAIL: RequestRedirect hostname != $redirect_host"
+  exit 1
+fi
+if ! echo "$route_block" | grep -q "statusCode: 302"; then
+  echo "FAIL: RequestRedirect statusCode != 302"
+  exit 1
+fi
+# The redirect must match the catch-all root prefix.
+if ! echo "$route_block" | grep -Eq 'value: "?/"?'; then
+  echo "FAIL: redirect rule does not match PathPrefix /"
+  exit 1
+fi
+echo "[bp-powerdns] Case 1: PASS"
+
+echo "[bp-powerdns] Case 2: /api → powerdns backend forward rule PRESERVED"
+if ! echo "$route_block" | grep -Eq 'value: "?/api"?'; then
+  echo "FAIL: /api match value not present — API forward rule lost"
+  exit 1
+fi
+if ! echo "$route_block" | grep -q "name: powerdns"; then
+  echo "FAIL: powerdns backendRef lost — API no longer routed"
+  exit 1
+fi
+echo "[bp-powerdns] Case 2: PASS"
+
+echo "[bp-powerdns] Case 3: default-off — no RequestRedirect"
+out_default=$("$helm" template smoke "$chart_dir" \
+  --set api.gateway.enabled=true \
+  --set api.host=pdns.example.com 2>&1)
+default_route=$(echo "$out_default" | awk '/^---$/{f=0} /^kind: HTTPRoute$/{f=1} f')
+if echo "$default_route" | grep -q "type: RequestRedirect"; then
+  echo "FAIL: RequestRedirect rendered without api.uiRedirectHost set"
+  exit 1
+fi
+# The API forward rule must still be present in the default case.
+if ! echo "$default_route" | grep -q "name: powerdns"; then
+  echo "FAIL: powerdns backendRef missing in default render"
+  exit 1
+fi
+echo "[bp-powerdns] Case 3: PASS"
+
+echo "[bp-powerdns] All HTTPRoute UI-redirect cases PASS"

--- a/platform/powerdns/chart/values.yaml
+++ b/platform/powerdns/chart/values.yaml
@@ -383,6 +383,18 @@ api:
   host: pdns.openova.io
   path: /api
   pathType: Prefix
+  # #3225: redirect a bare GET / on the API host to the human UI.
+  # The PowerDNS REST API host (api.host) serves no UI — pdns.<fqdn>/ falls
+  # through unmatched and 404s in a browser. When set (the bootstrap-kit
+  # slot-11 overlay sets it to `pdns-admin.${SOVEREIGN_FQDN}`), the
+  # HTTPRoute gains a catch-all PathPrefix / rule with a 302
+  # RequestRedirect to this host. The /api forward rule wins by
+  # longest-prefix, so API routing (and in-cluster cert-manager DNS-01 /
+  # external-dns, which use the Service DNS not this host) is untouched.
+  # Empty default = no redirect rule rendered → zero behaviour change.
+  # Gateway API mode only (api.gateway.enabled=true); the legacy Ingress
+  # path ignores this key.
+  uiRedirectHost: ""
   ingressClassName: traefik
   tls:
     enabled: true


### PR DESCRIPTION
## Refs #3225

A bare `GET /` on the PowerDNS REST API host `pdns.<fqdn>` returned a 404 in the founder's browser. The chart's `api-httproute.yaml` HTTPRoute had a single rule matching `PathPrefix /api` → `powerdns:8081`; the root path matched nothing, so Cilium/Gateway-API 404'd it. The human UI lives at `pdns-admin.<fqdn>` (bp-powerdns-admin, slot 11a).

## Change

Add a second, path-scoped catch-all rule to `api-httproute.yaml`, gated on a new `api.uiRedirectHost` value:

- matches `PathPrefix /` with a `RequestRedirect` filter (`hostname: <api.uiRedirectHost>`, `statusCode: 302`).
- The existing `/api` → `powerdns` forward rule is preserved. Gateway-API resolves overlapping `PathPrefix` matches by longest-prefix, so `/api` keeps hitting the backend and everything else 302s to the UI host.
- Empty default → the rule is not rendered (no behaviour change for clusters that don't opt in).

`cert-manager` DNS-01 and `external-dns` reach PowerDNS via the in-cluster Service DNS, not via `pdns.<fqdn>`, so this path-scoped root redirect does not touch TLS issuance. The redirect is Gateway-API mode only; the legacy Ingress path ignores the key.

## Files

- `platform/powerdns/chart/templates/api-httproute.yaml` — second rule gated on `.Values.api.uiRedirectHost`.
- `platform/powerdns/chart/values.yaml` — `api.uiRedirectHost: ""` default.
- `clusters/_template/bootstrap-kit/11-powerdns.yaml` — `api.uiRedirectHost: pdns-admin.${SOVEREIGN_FQDN}`.
- Lockstep version bump `1.2.10` → `1.2.11`: `chart/Chart.yaml` + `blueprint.yaml` + slot-11 chart pin.

## Test (TDD)

`platform/powerdns/chart/tests/httproute-ui-redirect.sh`:

1. With `api.uiRedirectHost` set, the HTTPRoute carries a `RequestRedirect` to that host (302) on the root path.
2. The `/api` → `powerdns` forward rule is preserved.
3. Default-off: no `RequestRedirect` renders, API forward rule still present.

Verified red→green: fails on the pre-change template (`FAIL: no RequestRedirect filter for root path`, exit 1), passes after (exit 0). `helm lint` clean; rendered HTTPRoute is valid YAML with both rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
