### PR TITLE
fix(catalyst-api): gate AppDetail Open button on a user-UI Blueprint endpoint

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -1213,7 +1213,12 @@ func (h *Handler) HandleApplicationGet(w http.ResponseWriter, r *http.Request) {
 	// joining the (targetNamespace, releaseName) against HTTPRoutes in
 	// the chroot k8sCache. Drives the "External URL" row on AppDetail
 	// Overview + the per-card "Open" button on the AppsPage list.
-	resp.ExternalURL = h.lookupExternalURL(r.Context(), depID, resp.TargetNamespace, resp.ReleaseName)
+	//
+	// #3224: gate the URL on the Blueprint declaring a user-UI endpoint so
+	// API/protocol-only apps (newapi, flow-server, keycloak, registry) do
+	// NOT get a dead "Open" button. resp.Blueprint here is the
+	// spec.blueprintRef.name (e.g. `bp-newapi` or `newapi`).
+	resp.ExternalURL = h.externalURLIfUserUI(r.Context(), depID, resp.Blueprint, resp.TargetNamespace, resp.ReleaseName)
 
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -1380,7 +1385,10 @@ func (h *Handler) synthesiseAppFromHelmRelease(ctx context.Context, depID, name 
 			}
 		}
 		resp.Phase = phase
-		resp.ExternalURL = h.lookupExternalURL(ctx, depID, resp.TargetNamespace, resp.ReleaseName)
+		// #3224: gate the URL on a user-UI endpoint. For HR-synth apps the
+		// blueprint name comes from spec.chart.spec.chart (e.g. `bp-grafana`,
+		// `bp-newapi`) — externalURLIfUserUI strips the `bp-` prefix.
+		resp.ExternalURL = h.externalURLIfUserUI(ctx, depID, resp.Blueprint, resp.TargetNamespace, resp.ReleaseName)
 		return resp, true
 	}
 	return applicationDetailResponse{}, false
@@ -1475,6 +1483,55 @@ func (h *Handler) lookupExternalURL(ctx context.Context, depID, targetNamespace,
 		}
 	}
 	return ""
+}
+
+// externalURLIfUserUI resolves the front-door URL for an installed
+// Application (via lookupExternalURL) and SUPPRESSES it when the app's
+// Blueprint declares no user-facing UI endpoint (#3224).
+//
+// The AppDetail "Open" button + "External URL" row render whenever the
+// returned URL is non-empty. lookupExternalURL alone matches an HTTPRoute
+// for ANY app that owns a front-door host — including API/protocol-only
+// apps (bp-newapi backend, bp-openova-flow-server, an OCI registry, the
+// keycloak admin realm). Those produced a DEAD "Open" button that lands the
+// operator on a bare login form or a 404.
+//
+// We gate on the SAME signal the silent-SSO launch-url endpoint uses
+// (blueprintHasUserUIEndpoint over the Blueprint's endpoints[]), so there is
+// ONE source of truth for "is this app launchable by a user".
+//
+// Fail-open policy: when the Blueprint can't be resolved at all (catalog
+// unwired on a chroot/CI, or a transient catalog error), keep the URL — we
+// must not regress grafana/harbor/openbao/guacamole/pdns-admin when the
+// blueprint metadata is merely unavailable. We suppress ONLY when the
+// Blueprint resolved successfully AND declares no user-UI endpoint.
+func (h *Handler) externalURLIfUserUI(ctx context.Context, depID, blueprint, targetNamespace, releaseName string) string {
+	u := h.lookupExternalURL(ctx, depID, targetNamespace, releaseName)
+	if u == "" {
+		return ""
+	}
+	bpName := strings.TrimPrefix(strings.TrimSpace(blueprint), "bp-")
+	if bpName == "" {
+		// No blueprint name to resolve — fail open (legacy behaviour).
+		return u
+	}
+	bp, err := h.resolveBlueprintMeta(ctx, bpName, "")
+	if err != nil || bp == nil {
+		// Could not resolve the Blueprint (catalog error / unwired) —
+		// fail open so a transient lookup failure never hides a real UI.
+		return u
+	}
+	if len(bp.Endpoints) == 0 {
+		// Catalog unwired or the Blueprint declares no endpoints at all —
+		// no UI signal available, fail open to preserve prior behaviour.
+		return u
+	}
+	if !blueprintHasUserUIEndpoint(bp) {
+		// Resolved, endpoints present, but none is a user UI (API/protocol
+		// only) → suppress the dead Open button.
+		return ""
+	}
+	return u
 }
 
 // ── HTTP handler — list (GET /sovereigns/{id}/applications) ──────────

--- a/products/catalyst/bootstrap/api/internal/handler/applications_open_button_gate_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_open_button_gate_test.go
@@ -1,0 +1,203 @@
+// applications_open_button_gate_test.go — coverage for the AppDetail
+// "Open" button gate (#3224).
+//
+// Root cause (#3224): lookupExternalURL returns a front-door URL for ANY
+// HTTPRoute that matches an installed Application by name / backendRef /
+// hostname-leftmost-label. The SPA renders the "Open" button whenever
+// resp.ExternalURL is non-empty — so apps whose only endpoint is an
+// API/protocol surface (bp-newapi backend, bp-openova-flow-server,
+// keycloak's admin-only realm, an OCI registry endpoint, …) got a DEAD
+// "Open" button that lands the operator on a bare login form or a 404.
+//
+// The fix: gate ExternalURL on the SAME blueprint-endpoint signal the
+// silent-SSO launch-url endpoint uses (endpoint_handler.go) — an app only
+// qualifies for an "Open" button when its Blueprint declares a user-UI
+// endpoint: one with ssoEnabled:true OR launchDefault:true OR named "ui".
+// API/protocol-only endpoints (ssoEnabled:false, launchDefault:false,
+// non-"ui" name) must NOT qualify.
+//
+// This test exercises the pure predicate blueprintHasUserUIEndpoint so the
+// fail->pass cycle is hermetic (no k8sCache / catalog wiring needed).
+package handler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
+)
+
+func TestBlueprintHasUserUIEndpoint(t *testing.T) {
+	cases := []struct {
+		name string
+		bp   *blueprintMeta
+		want bool
+	}{
+		{
+			// bp-newapi: a single backend/protocol endpoint, no SSO UI.
+			// This is the regression case — must NOT show an Open button.
+			name: "api-only endpoint does not qualify",
+			bp: &blueprintMeta{Endpoints: []endpointDecl{
+				{Name: "api", Protocol: "https", SSOEnabled: false, LaunchDefault: false},
+			}},
+			want: false,
+		},
+		{
+			// bp-openova-flow-server: a backend endpoint reached by the
+			// console proxy, never opened directly by the operator.
+			name: "backend endpoint does not qualify",
+			bp: &blueprintMeta{Endpoints: []endpointDecl{
+				{Name: "backend", Protocol: "https", SSOEnabled: false, LaunchDefault: false},
+			}},
+			want: false,
+		},
+		{
+			// OCI registry / protocol surface — TLS but no UI.
+			name: "registry protocol endpoint does not qualify",
+			bp: &blueprintMeta{Endpoints: []endpointDecl{
+				{Name: "registry", Protocol: "https", TLS: boolPtr(true), SSOEnabled: false, LaunchDefault: false},
+			}},
+			want: false,
+		},
+		{
+			// grafana/harbor/openbao/guacamole/pdns-admin shape: a UI
+			// endpoint flagged launchDefault — MUST keep its Open button.
+			name: "launchDefault UI endpoint qualifies",
+			bp: &blueprintMeta{Endpoints: []endpointDecl{
+				{Name: "web", Protocol: "https", LaunchDefault: true, SSOEnabled: true},
+			}},
+			want: true,
+		},
+		{
+			// SSO-enabled but launchDefault omitted — still a user UI.
+			name: "ssoEnabled UI endpoint qualifies",
+			bp: &blueprintMeta{Endpoints: []endpointDecl{
+				{Name: "console", Protocol: "https", SSOEnabled: true, LaunchDefault: false},
+			}},
+			want: true,
+		},
+		{
+			// An endpoint literally named "ui" qualifies even without the
+			// SSO flags — the conventional UI-endpoint name.
+			name: "ui-named endpoint qualifies",
+			bp: &blueprintMeta{Endpoints: []endpointDecl{
+				{Name: "ui", Protocol: "https", SSOEnabled: false, LaunchDefault: false},
+			}},
+			want: true,
+		},
+		{
+			// Mixed: keycloak-shaped — an admin/protocol endpoint plus a
+			// genuine UI endpoint. The UI endpoint wins → qualifies.
+			name: "mixed api + ui endpoints qualifies",
+			bp: &blueprintMeta{Endpoints: []endpointDecl{
+				{Name: "admin", Protocol: "https", SSOEnabled: false, LaunchDefault: false},
+				{Name: "account", Protocol: "https", SSOEnabled: true, LaunchDefault: false},
+			}},
+			want: true,
+		},
+		{
+			// No endpoints declared at all — cannot prove a UI surface, so
+			// the predicate reports false (the caller treats a resolved-but-
+			// empty endpoint list as "no UI").
+			name: "no endpoints does not qualify",
+			bp:   &blueprintMeta{Endpoints: []endpointDecl{}},
+			want: false,
+		},
+		{
+			// nil metadata — the blueprint could not be resolved; predicate
+			// reports false and the caller decides the fail-open policy.
+			name: "nil blueprint does not qualify",
+			bp:   nil,
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := blueprintHasUserUIEndpoint(tc.bp)
+			if got != tc.want {
+				t.Fatalf("blueprintHasUserUIEndpoint(%+v) = %v, want %v", tc.bp, got, tc.want)
+			}
+		})
+	}
+}
+
+// catalogBPWithEndpoints builds a CatalogBlueprint whose
+// spec.endpoints[] carry the given endpoint declarations, so the gate
+// helper (externalURLIfUserUI → resolveBlueprintMeta) sees the same
+// blueprintMeta shape the live catalog returns.
+func catalogBPWithEndpoints(name string, eps []map[string]interface{}) *CatalogBlueprint {
+	rawEps := make([]interface{}, 0, len(eps))
+	for _, e := range eps {
+		rawEps = append(rawEps, e)
+	}
+	return &CatalogBlueprint{
+		Name:    name,
+		Version: "1.0.0",
+		Raw: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"endpoints": rawEps,
+			},
+		},
+	}
+}
+
+// TestExternalURLIfUserUI_GatesOnBlueprint exercises the full Open-button
+// gate: a live HTTPRoute resolves a front-door URL, but the Blueprint's
+// endpoint shape decides whether the URL survives (UI) or is suppressed
+// (API/protocol only). This is the #3224 acceptance: given an api/protocol-
+// only Blueprint the ExternalURL must be EMPTY; given a launchDefault/
+// ssoEnabled UI Blueprint it must be POPULATED.
+func TestExternalURLIfUserUI_GatesOnBlueprint(t *testing.T) {
+	// A live route exists for both apps (front door is serving) — the gate
+	// must decide purely on the Blueprint UI signal.
+	route := newHTTPRoute("catalyst-system", "newapi", "newapi.hw124.omani.works", "newapi")
+	uiRoute := newHTTPRoute("catalyst-system", "grafana", "grafana.hw124.omani.works", "grafana")
+
+	// The gate strips the `bp-` prefix before resolving (mirroring
+	// extractBlueprintFromApp), so the catalog resolves the stripped name —
+	// fixtures are keyed on `newapi` / `grafana`.
+	apiOnly := catalogBPWithEndpoints("newapi", []map[string]interface{}{
+		{"name": "api", "protocol": "https", "ssoEnabled": false, "launchDefault": false},
+	})
+	uiBP := catalogBPWithEndpoints("grafana", []map[string]interface{}{
+		{"name": "web", "protocol": "https", "ssoEnabled": true, "launchDefault": true},
+	})
+
+	t.Run("api-only blueprint suppresses URL", func(t *testing.T) {
+		f := newFactoryWithHTTPRoutes(t, route)
+		h := &Handler{log: quietLog()}
+		h.SetK8sCache(f, k8scache.NewSARCache(), "X-Forwarded-User")
+		h.SetCatalogClient(newFakeCatalog(apiOnly))
+		got := h.externalURLIfUserUI(context.Background(), "alpha", "bp-newapi", "catalyst-system", "newapi")
+		if got != "" {
+			t.Fatalf("api-only blueprint: got %q, want empty (no Open button)", got)
+		}
+	})
+
+	t.Run("ui blueprint preserves URL", func(t *testing.T) {
+		f := newFactoryWithHTTPRoutes(t, uiRoute)
+		h := &Handler{log: quietLog()}
+		h.SetK8sCache(f, k8scache.NewSARCache(), "X-Forwarded-User")
+		h.SetCatalogClient(newFakeCatalog(uiBP))
+		got := h.externalURLIfUserUI(context.Background(), "alpha", "bp-grafana", "catalyst-system", "grafana")
+		want := "https://grafana.hw124.omani.works"
+		if got != want {
+			t.Fatalf("ui blueprint: got %q, want %q (Open button must render)", got, want)
+		}
+	})
+
+	t.Run("catalog unwired fails open", func(t *testing.T) {
+		// No SetCatalogClient → resolveBlueprintMeta soft-fails with an
+		// empty (non-nil) meta. The gate must NOT suppress a real UI when
+		// blueprint metadata is merely unavailable (chroot / CI).
+		f := newFactoryWithHTTPRoutes(t, uiRoute)
+		h := &Handler{log: quietLog()}
+		h.SetK8sCache(f, k8scache.NewSARCache(), "X-Forwarded-User")
+		got := h.externalURLIfUserUI(context.Background(), "alpha", "bp-grafana", "catalyst-system", "grafana")
+		want := "https://grafana.hw124.omani.works"
+		if got != want {
+			t.Fatalf("catalog-unwired: got %q, want %q (fail open)", got, want)
+		}
+	})
+}

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
@@ -997,7 +997,24 @@ type topologyDefaults struct {
 // client. Returns nil + nil-error when the catalog is unwired AND the
 // blueprint has no on-cluster CR (so handlers don't 500 on a chroot
 // without catalog-svc).
+//
+// The caller-identity session token is lifted from the request so the
+// proxy hop to catalyst-catalog carries the same identity; the actual
+// resolution is shared with resolveBlueprintMeta (no-request callers
+// pass an empty token).
 func (h *Handler) fetchBlueprint(ctx context.Context, r *http.Request, name string) (*blueprintMeta, error) {
+	return h.resolveBlueprintMeta(ctx, name, applicationSessionToken(r))
+}
+
+// resolveBlueprintMeta is the request-free core of fetchBlueprint. It
+// resolves Blueprint.spec metadata for `name` via the wired catalog
+// client, carrying `sessionToken` for caller-identity passthrough (may be
+// empty for internal/no-request lookups such as the AppDetail Open-button
+// gate). Returns (&blueprintMeta{}, nil) — an empty, non-nil projection —
+// whenever the catalog is unwired or the blueprint is absent, so callers
+// can distinguish "resolved, no UI endpoint" from "could not resolve" by
+// checking the returned error.
+func (h *Handler) resolveBlueprintMeta(ctx context.Context, name, sessionToken string) (*blueprintMeta, error) {
 	if strings.TrimSpace(name) == "" {
 		return nil, errors.New("blueprint name empty")
 	}
@@ -1008,8 +1025,7 @@ func (h *Handler) fetchBlueprint(ctx context.Context, r *http.Request, name stri
 		// caller still sees an empty result.
 		return &blueprintMeta{}, nil
 	}
-	token := applicationSessionToken(r)
-	bp, err := h.catalogClient.Get(ctx, name, token)
+	bp, err := h.catalogClient.Get(ctx, name, sessionToken)
 	if err != nil {
 		if errors.Is(err, ErrBlueprintNotFound) {
 			return &blueprintMeta{}, nil
@@ -1030,6 +1046,37 @@ func (h *Handler) fetchBlueprint(ctx context.Context, r *http.Request, name stri
 	}
 	_ = json.Unmarshal(jsonBytes, &out)
 	return &out, nil
+}
+
+// blueprintHasUserUIEndpoint reports whether a Blueprint declares a
+// user-facing UI endpoint — the SAME signal the silent-SSO launch-url
+// endpoint (HandleGetLaunchURL) reads to decide an app is launchable.
+//
+// An endpoint qualifies as a user UI when ANY of:
+//
+//   - SSOEnabled == true   (the app fronts an OIDC login the operator uses), OR
+//   - LaunchDefault == true (the chart-tagged "open me" front door), OR
+//   - Name == "ui"          (the conventional UI-endpoint name).
+//
+// API/protocol-only endpoints — bp-newapi's backend, bp-openova-flow-server's
+// proxy target, an OCI registry endpoint, keycloak's admin-only realm — set
+// none of these and therefore do NOT qualify. The AppDetail "Open" button +
+// "External URL" row are gated on this so they never render for an app with
+// no user UI (#3224).
+//
+// Returns false for nil metadata or an empty endpoint list — the caller owns
+// the fail-open policy for the "could not resolve the blueprint" case.
+func blueprintHasUserUIEndpoint(bp *blueprintMeta) bool {
+	if bp == nil {
+		return false
+	}
+	for i := range bp.Endpoints {
+		ep := &bp.Endpoints[i]
+		if ep.SSOEnabled || ep.LaunchDefault || strings.EqualFold(ep.Name, "ui") {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveEndpoints joins Blueprint.spec.endpoints with per-instance


### PR DESCRIPTION
## Problem

`products/catalyst/bootstrap/api/internal/handler/applications.go` `lookupExternalURL()` returns a front-door URL for ANY HTTPRoute that matches an installed Application by name / backendRef / hostname-leftmost-label. So `resp.ExternalURL` was populated even for apps with no user UI — `bp-newapi` (backend), `bp-openova-flow-server`, `keycloak` (admin-only realm), and protocol/API-only endpoints (OCI registry). The SPA renders the "Open" button + "External URL" row whenever `ExternalURL` is non-empty, producing a dead button that lands the operator on a bare login form or a 404.

## Fix

Reuse the SAME signal the silent-SSO launch-url endpoint (`endpoint_handler.go` `HandleGetLaunchURL`) already reads to decide an app is launchable: a Blueprint endpoint qualifies as a user UI when `ssoEnabled:true` OR `launchDefault:true` OR named `ui`. API/protocol-only endpoints set none of these.

- New `blueprintHasUserUIEndpoint(*blueprintMeta)` predicate over `Blueprint.spec.endpoints[]`.
- New `resolveBlueprintMeta(ctx, name, sessionToken)` — the request-free core lifted out of `fetchBlueprint`, so `endpoint_handler.go` stays the single source of truth for blueprint-endpoint resolution. `fetchBlueprint` now delegates to it.
- New `externalURLIfUserUI(...)` wraps `lookupExternalURL` and suppresses the URL when the resolved Blueprint declares no user-UI endpoint. Both call sites — `HandleApplicationGet` and `synthesiseAppFromHelmRelease` (HR-synth bootstrap-kit apps) — route through it.

### Fail-open policy

When the Blueprint can't be resolved (catalog unwired on a chroot/CI, or a transient catalog error) or declares no endpoints at all, the URL is preserved so `grafana` / `harbor` / `openbao` / `guacamole` / `pdns-admin` never regress. Suppression fires ONLY when the Blueprint resolved successfully and declares endpoints, none of which is a user UI.

## TDD

`applications_open_button_gate_test.go`:
- `TestBlueprintHasUserUIEndpoint` — table test: api/protocol/backend/registry endpoints do NOT qualify; `launchDefault` / `ssoEnabled` / `ui`-named endpoints DO; mixed api+ui qualifies; nil/empty does not.
- `TestExternalURLIfUserUI_GatesOnBlueprint` — wires a live HTTPRoute + fake catalog and asserts an api-only Blueprint yields an EMPTY ExternalURL (no Open button), a `launchDefault`/`ssoEnabled` UI Blueprint yields the populated URL, and catalog-unwired fails open.

Written failing first (predicate undefined), then made to pass. `go build ./...`, `go test ./internal/handler/...`, and `go vet` all green.

Refs #3224

🤖 Generated with [Claude Code](https://claude.com/claude-code)