### PR TITLE
ci: wire lint-cloudinit.sh as required POSIX-dash pre-merge gate (#3129-class guard)

### DIFF
--- a/.github/workflows/preflight-cloudinit-posix.yml
+++ b/.github/workflows/preflight-cloudinit-posix.yml
@@ -1,0 +1,124 @@
+name: preflight — cloud-init POSIX (dash) lint
+
+# REQUIRED pre-merge guard against the #3129-class regression: a cloud-init
+# `runcmd:` shell-syntax bug that ONLY the target VM's ancient `/bin/sh` (the
+# kom4dc image's dash) rejects. Such a bug aborts runcmd mid-stream, the
+# kubeconfig PUT-back never fires, and Phase-1 times out — costing a ~1-hour
+# live provision to discover. Refs #3145 (cloud-agnostic bootstrap EPIC);
+# motivating regression class #3129.
+#
+# This job renders the ONE shared cloud-agnostic control-plane cloud-init
+# template (infra/providers/_shared/cloudinit-control-plane.tftpl) per provider
+# via `scripts/lint-cloudinit.sh`, which:
+#   1. renders the template with a complete per-provider fixture (tofu
+#      templatefile() — no providers/network needed), then
+#   2. runs `dash -n` (POSIX parse-only) over every extracted runcmd item AND
+#      the concatenated script, and
+#   3. FAILS on any bash-ONLY construct in an item cloud-init runs under
+#      /bin/sh — `(( … ))` arithmetic-command, `[[ … ]]` test, `&>` redirect,
+#      `function` keyword — which `dash -n` parse-only does NOT catch and which
+#      the kom4dc /bin/sh REJECTS at runtime (that is the exact #3129 trap).
+#
+# It does NOT provision anything, touch the network, or modify the templates.
+#
+# Per CLAUDE.md "every workflow MUST be event-driven, NEVER scheduled": this is
+# push-on-merge + pull-request-on-touch; ad-hoc reruns go through
+# workflow_dispatch. There is no `schedule:` trigger.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/providers/_shared/**'
+      - 'infra/providers/hetzner/**'
+      - 'infra/providers/huawei/**'
+      - 'scripts/lint-cloudinit.sh'
+      - '.github/workflows/preflight-cloudinit-posix.yml'
+  pull_request:
+    paths:
+      - 'infra/providers/_shared/**'
+      - 'infra/providers/hetzner/**'
+      - 'infra/providers/huawei/**'
+      - 'scripts/lint-cloudinit.sh'
+      - '.github/workflows/preflight-cloudinit-posix.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  posix-lint:
+    name: dash -n cloud-init render (hetzner + huawei)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          # Lockstep with infra-hetzner-tofu.yaml / infra-huawei-tofu.yaml.
+          tofu_version: 1.8.5
+
+      - name: Pin runner deps (dash + busybox + python3 pyyaml)
+        run: |
+          set -eu
+          # dash IS the parse engine the script shells out to (DASH_BIN). It is
+          # preinstalled on ubuntu-latest, but pin it explicitly so a runner
+          # image change can never silently drop the gate's core dependency.
+          # busybox provides an additional ancient-/bin/sh reference if needed.
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends dash busybox
+          # PyYAML powers the script's runcmd extractor (it has a vendored
+          # fallback, but the real loader gives the accurate item split).
+          python3 -m pip install --quiet pyyaml || sudo apt-get install -y python3-yaml
+          echo "dash:    $(command -v dash)  ($(dash -c 'echo ok'))"
+          echo "busybox: $(command -v busybox)"
+          echo "python3: $(python3 --version)"
+          echo "tofu:    $(tofu version | head -1)"
+
+      - name: POSIX-lint rendered cloud-init (both providers)
+        run: |
+          set -eu
+          chmod +x scripts/lint-cloudinit.sh
+          # `both` lints hetzner + huawei and aggregates the exit status. A
+          # bash-ism that the kom4dc /bin/sh rejects exits NON-ZERO here and
+          # fails the required check — the merge is blocked before a ~1-hour
+          # live provision would have discovered it.
+          ./scripts/lint-cloudinit.sh both
+
+      - name: Self-test the gate (inject a bash-ism, prove it FAILS, then restore)
+        if: always()
+        run: |
+          set -eu
+          TPL=infra/providers/_shared/cloudinit-control-plane.tftpl
+          cp "$TPL" "${TPL}.orig"
+          # Inject a sh-run bash-ism the kom4dc /bin/sh rejects but `dash -n`
+          # parse-only passes — the exact #3129 trap — as a new runcmd item.
+          # `sed` is keyed on the first runcmd item (`- swapoff -a`).
+          grep -q "^  - swapoff -a$" "$TPL" || { echo "self-test anchor not found"; mv "${TPL}.orig" "$TPL"; exit 1; }
+          sed -i "0,/^  - swapoff -a$/s//  - 'if [[ -f \/tmp\/x ]]; then echo bashism; fi'\n  - swapoff -a/" "$TPL"
+          set +e
+          ./scripts/lint-cloudinit.sh hetzner >/tmp/selftest.log 2>&1
+          rc=$?
+          set -e
+          mv "${TPL}.orig" "$TPL"
+          echo "--- self-test lint output (bash-ism injected) ---"
+          cat /tmp/selftest.log
+          if [ "$rc" -eq 0 ]; then
+            echo "SELF-TEST FAILED: gate did NOT catch the injected bash-ism (exit 0)"
+            exit 1
+          fi
+          echo "SELF-TEST PASSED: gate caught the injected bash-ism (exit ${rc}); template restored"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo '## cloud-init POSIX (dash) lint'
+            echo ''
+            echo 'Rendered the shared control-plane cloud-init per provider and ran'
+            echo '`dash -n` + a bash-only-construct scan over every runcmd item.'
+            echo 'A bash-ism that the kom4dc `/bin/sh` rejects fails this required check.'
+          } >> "$GITHUB_STEP_SUMMARY" 2>&1 || true

--- a/scripts/lint-cloudinit.sh
+++ b/scripts/lint-cloudinit.sh
@@ -18,10 +18,15 @@
 #   scripts/lint-cloudinit.sh huawei
 #   scripts/lint-cloudinit.sh both      # lint both, aggregate exit status
 #
-# EXIT: 0 = all runcmd items parse under dash -n; non-zero = a syntax error was
-#       found (or the template failed to render). Non-POSIX constructs that the
-#       kom4dc /bin/sh chokes on (arithmetic `$((`, `[[`, `function`, `&>`) are
-#       reported as WARNINGS and do not by themselves fail the run.
+# EXIT: 0 = all runcmd items parse under dash -n AND no sh-run item uses a
+#       bash-only construct; non-zero = a `dash -n` syntax error OR a bash-only
+#       construct in an sh-run item (or the template failed to render).
+#       Bash-ONLY constructs that the kom4dc /bin/sh REJECTS at runtime — and
+#       which `dash -n` parse-only does NOT catch (the #3129 trap) — are a HARD
+#       FAIL when the item is run by /bin/sh: `(( … ))` arithmetic-command,
+#       `[[ … ]]` test, `&>` redirect, `function` keyword. (`$(( … ))`
+#       arithmetic EXPANSION is POSIX and is NOT flagged.) The same construct
+#       inside an explicit `bash -c "…"` body is a WARNING only (bash's domain).
 #
 # REQUIREMENTS: tofu (templatefile rendering — no providers needed), dash,
 #               python3 (+ pyyaml or a vendored fallback parser).
@@ -423,29 +428,36 @@ if not isinstance(runcmd, list):
     sys.stderr.write(f"[extract] runcmd is not a list (got {type(runcmd).__name__})\n")
     sys.exit(3)
 
-def body_from_item(item):
-    """Return the shell-script body to lint for a runcmd item.
-    - str               -> the string itself (cloud-init runs it via sh -c)
-    - [..., '-c', body] -> the -c body (argv form, e.g. ['bash','-c', body])
-    - other list        -> join argv with spaces (best-effort; still a command
-                           line the shell must parse)
+def body_and_mode_from_item(item):
+    """Return (body, mode) for a runcmd item.
+    body = the shell-script body to lint.
+    mode = the interpreter cloud-init runs THE ITEM under:
+      - "sh"   -> cloud-init runs the string via /bin/sh (= dash on kom4dc).
+                  A non-POSIX construct here is a HARD bug (#3129 class).
+      - "bash" -> the item is an explicit ['bash','-c',...] argv form, so the
+                  body is bash's own concern; non-POSIX constructs are fine.
+    Forms:
+    - str               -> the string itself, run via /bin/sh         -> mode sh
+    - [iface,'-c',body] -> the -c body; mode = iface basename (bash|sh|...)
+    - other list        -> argv joined; run via /bin/sh by cloud-init  -> mode sh
     """
     if isinstance(item, str):
-        return item
+        return item, "sh"
     if isinstance(item, list):
-        # find a '-c' followed by a body
         for k in range(len(item) - 1):
             if item[k] == "-c":
-                return str(item[k + 1])
-        # no -c: join the argv tokens as a single command line
-        return " ".join(str(x) for x in item)
-    return str(item)
+                iface = os.path.basename(str(item[0])) if item else "sh"
+                mode = "bash" if iface.endswith("bash") else "sh"
+                return str(item[k + 1]), mode
+        # no -c: join the argv tokens as a single command line (run via sh)
+        return " ".join(str(x) for x in item), "sh"
+    return str(item), "sh"
 
 items_tsv = io.StringIO()
 all_bodies = []
 count = 0
 for idx, item in enumerate(runcmd):
-    body = body_from_item(item)
+    body, mode = body_and_mode_from_item(item)
     count += 1
     fn = os.path.join(out_dir, f"item-{idx:03d}.sh")
     with open(fn, "w") as f:
@@ -453,10 +465,14 @@ for idx, item in enumerate(runcmd):
         f.write(body)
         if not body.endswith("\n"):
             f.write("\n")
+    # Record the interpreter mode alongside the item, so the construct scan
+    # can FAIL sh-run items but spare explicit `bash -c` bodies.
+    with open(os.path.join(out_dir, f"item-{idx:03d}.mode"), "w") as mf:
+        mf.write(mode)
     preview = body.strip().splitlines()[0] if body.strip() else "(empty)"
     if len(preview) > 100:
         preview = preview[:97] + "..."
-    items_tsv.write(f"{idx:03d}\t{preview}\n")
+    items_tsv.write(f"{idx:03d}\t{mode}\t{preview}\n")
     all_bodies.append(body)
 
 with open(os.path.join(out_dir, "all.sh"), "w") as f:
@@ -487,7 +503,7 @@ posix_lint() {
   for f in "${items_dir}"/item-*.sh; do
     [ -e "${f}" ] || continue
     idx="$(basename "${f}" .sh | sed 's/^item-//')"
-    preview="$(grep -E "^${idx}	" "${items_dir}/items.tsv" 2>/dev/null | cut -f2-)"
+    preview="$(grep -E "^${idx}	" "${items_dir}/items.tsv" 2>/dev/null | cut -f3-)"
     derr="$("${DASH_BIN}" -n "${f}" 2>&1)"
     if [ -n "${derr}" ]; then
       LINT_FAILS=$((LINT_FAILS + 1))
@@ -504,25 +520,40 @@ posix_lint() {
     printf '%s\n' "${derr_all}" | sed 's/^/        /' >&2
   fi
 
-  # Non-POSIX construct warnings (kom4dc /bin/sh = dash; these break it).
-  #   $((   arithmetic expansion
-  #   [[    bash test keyword
-  #   &>    bash redirect-both
+  # Non-POSIX construct scan (kom4dc /bin/sh = dash; these break it AT RUNTIME,
+  # which `dash -n` parse-only does NOT catch — that is the exact #3129 trap).
+  # Genuinely bash-ONLY constructs (dash rejects them at runtime, NOT parse):
+  #   (( … ))   arithmetic COMMAND (note: `$(( … ))` arithmetic EXPANSION is
+  #             POSIX and dash supports it — do NOT flag it)
+  #   [[ … ]]   bash test keyword
+  #   &>        bash redirect-both
   #   function  bash function keyword
+  # For items cloud-init runs under /bin/sh (mode=sh) any of these is a HARD
+  # FAIL — the rendered runcmd would abort mid-stream on the target's dash.
+  # For explicit `bash -c "..."` items (mode=bash) the body is bash's own
+  # concern, so the same construct is informational only (WARN).
   for f in "${items_dir}"/item-*.sh; do
     [ -e "${f}" ] || continue
     idx="$(basename "${f}" .sh | sed 's/^item-//')"
-    preview="$(grep -E "^${idx}	" "${items_dir}/items.tsv" 2>/dev/null | cut -f2-)"
-    # Strip the shebang line before scanning.
-    body="$(sed '1d' "${f}")"
+    preview="$(grep -E "^${idx}	" "${items_dir}/items.tsv" 2>/dev/null | cut -f3-)"
+    mode="$(cat "${items_dir}/item-${idx}.mode" 2>/dev/null || echo sh)"
+    # Strip the shebang line before scanning. Mask any `bash -c "…"`/`bash -c
+    # '…'` quoted sub-body: arithmetic-commands etc. inside an explicit bash
+    # invocation are bash's domain even when the OUTER item is sh-run.
+    body="$(sed '1d' "${f}" | sed -E "s/bash -c \"[^\"]*\"//g; s/bash -c '[^']*'//g")"
     hits=""
-    printf '%s' "${body}" | grep -q '\$((' && hits="${hits} \$(( arithmetic-expansion"
+    printf '%s' "${body}" | grep -Eq '(^|[^$])\(\([[:space:]]*[A-Za-z_]' && hits="${hits} (( arithmetic-command"
     printf '%s' "${body}" | grep -Eq '\[\[' && hits="${hits} [[ bash-test"
     printf '%s' "${body}" | grep -Eq '(^|[^0-9>])&>' && hits="${hits} &> bash-redirect"
     printf '%s' "${body}" | grep -Eq '(^|[[:space:]])function[[:space:]]+[A-Za-z_]' && hits="${hits} function-keyword"
     if [ -n "${hits}" ]; then
-      LINT_WARNS=$((LINT_WARNS + 1))
-      warn "runcmd[${idx}] non-POSIX construct(s):${hits}  — item: ${preview}"
+      if [ "${mode}" = "sh" ]; then
+        LINT_FAILS=$((LINT_FAILS + 1))
+        err "runcmd[${idx}] (sh-run) non-POSIX construct(s) — kom4dc /bin/sh REJECTS:${hits}  — item: ${preview}"
+      else
+        LINT_WARNS=$((LINT_WARNS + 1))
+        warn "runcmd[${idx}] (bash -c) non-POSIX construct(s) [bash body, informational]:${hits}  — item: ${preview}"
+      fi
     fi
   done
 }


### PR DESCRIPTION
## What

Wires the existing `scripts/lint-cloudinit.sh` harness as a pre-merge CI gate, and fixes the harness so it actually FAILS on the #3129-class bug it was built to catch.

`grep -rl lint-cloudinit .github/workflows` returned nothing before this change — the single highest-leverage guard against a cloud-init `runcmd:` shell-syntax bug that ONLY the target VM's ancient `/bin/sh` (the kom4dc image's dash) rejects existed as a harness with no gate. Such a bug aborts runcmd mid-stream, the kubeconfig PUT-back never fires, and Phase-1 times out — a ~1-hour live provision to discover (5 prior PRs: #3130 #3135 #3136 #3141 #3144).

## Changes

- **`.github/workflows/preflight-cloudinit-posix.yml`** (new) — triggers on `pull_request` + `push` touching `infra/providers/_shared/**`, `infra/providers/hetzner/**`, `infra/providers/huawei/**`, `scripts/lint-cloudinit.sh`, or the workflow itself. Pins tofu 1.8.5 (lockstep with `infra-hetzner-tofu.yaml`) + dash + busybox + python3-pyyaml, then runs `scripts/lint-cloudinit.sh both`. A self-test step injects a bash-ism, proves the gate FAILS, and restores the template byte-identical.
- **`scripts/lint-cloudinit.sh`** — a bash-only construct (`[[ ]]`, `(( ))` arithmetic-command, `&>`, `function`) in an item cloud-init runs under `/bin/sh` is now a HARD FAIL, not a WARN. `dash -n` parse-only cannot catch these (they fail at runtime, not parse) — that is the exact #3129 trap. The same construct inside an explicit `bash -c "..."` body stays informational (bash's domain; the extractor now tags each item with its interpreter mode and masks `bash -c "..."`/`bash -c '...'` quoted sub-bodies). Also stops flagging POSIX `$(( ))` arithmetic-expansion (dash supports it).

## TDD — gate proven to work

The cloud-init template is NOT modified by this PR (byte-identical to `main`). The proof injects a sh-run bash-ism into the rendered path, shows non-zero exit, then removes it.

### Step 1 — bash-ism injected → FAILS (exit 1)

```
[lint-cloudinit] === provider: hetzner ===
  PASS hetzner: rendered OK (32809 bytes of #cloud-config)
[lint-cloudinit] hetzner: extracted 46 runcmd item(s)
  FAIL runcmd[000] (sh-run) non-POSIX construct(s) — kom4dc /bin/sh REJECTS: [[ bash-test  — item: if [[ -f /tmp/x ]]; then echo bashism; fi
  FAIL hetzner: dash -n FOUND 1 syntax failure(s)
[lint-cloudinit] RESULT: at least one target FAILED dash -n (see above)
ACTUAL_EXIT=1
```

(injection used: `- 'if [[ -f /tmp/x ]]; then echo bashism; fi'` as a runcmd item)

### Step 2 — injection removed → PASSES (exit 0)

```
[lint-cloudinit] === provider: hetzner ===
  PASS hetzner: rendered OK (32761 bytes of #cloud-config)
[lint-cloudinit] hetzner: extracted 45 runcmd item(s)
  PASS hetzner: dash -n PASSED for all 45 runcmd items + concatenated script
[lint-cloudinit] === provider: huawei ===
  PASS huawei: rendered OK (31332 bytes of #cloud-config)
[lint-cloudinit] huawei: extracted 42 runcmd item(s)
  PASS huawei: dash -n PASSED for all 42 runcmd items + concatenated script
[lint-cloudinit] RESULT: all targets passed dash -n
ACTUAL_EXIT=0
```

The workflow's self-test step reproduces exactly this inject/fail/restore cycle inside CI on every run.

## Notes

- No chart/blueprint touched → no lockstep version bumps.
- The harness self-test confirmed the `$(( ))` arithmetic-expansion the clean template legitimately uses (e.g. `nohup bash -c "deadline=$((SECONDS+1800)); ..."` and POSIX `n=$((n+1))`) no longer trips the gate.

Refs #3228. Refs #3145. Motivating regression class: #3129.
