### PR TITLE
feat(catalyst-api): server-side zero-click OpenBao silent-SSO shim (#3226)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -77,7 +77,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.27
+      version: 1.2.28
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/core/controllers/blueprint/internal/validate/schemas/blueprint-topology.json
+++ b/core/controllers/blueprint/internal/validate/schemas/blueprint-topology.json
@@ -173,7 +173,9 @@
         "tls":        { "type": "boolean" },
         "visibility": { "type": "string", "enum": ["public", "private", "internal"] },
         "launchDefault": { "type": "boolean" },
-        "ssoEnabled":    { "type": "boolean" }
+        "ssoEnabled":    { "type": "boolean" },
+        "ssoInitPath":   { "type": "string", "maxLength": 512, "description": "#3150 — app-local OIDC-init path (e.g. Grafana /login/generic_oauth, Harbor /c/oidc/login). When set, the silent-SSO launch URL targets https://<host><ssoInitPath> instead of the app root." },
+        "ssoShim":       { "type": "boolean", "description": "#3226 — when true, the silent-SSO launch URL is the catalyst-api server-side shim (api.<fqdn>/catalyst/v1/apps/<id>/openbao-sso-init) rather than the app deep-link. For client-side-SPA apps (OpenBao) whose static ssoInitPath cannot auto-redirect; the shim asks Vault for the OIDC auth_url and 302s to Keycloak." }
       },
       "additionalProperties": false
     },

--- a/platform/_schemas/blueprint-topology.json
+++ b/platform/_schemas/blueprint-topology.json
@@ -173,7 +173,9 @@
         "tls":        { "type": "boolean" },
         "visibility": { "type": "string", "enum": ["public", "private", "internal"] },
         "launchDefault": { "type": "boolean" },
-        "ssoEnabled":    { "type": "boolean" }
+        "ssoEnabled":    { "type": "boolean" },
+        "ssoInitPath":   { "type": "string", "maxLength": 512, "description": "#3150 — app-local OIDC-init path (e.g. Grafana /login/generic_oauth, Harbor /c/oidc/login). When set, the silent-SSO launch URL targets https://<host><ssoInitPath> instead of the app root." },
+        "ssoShim":       { "type": "boolean", "description": "#3226 — when true, the silent-SSO launch URL is the catalyst-api server-side shim (api.<fqdn>/catalyst/v1/apps/<id>/openbao-sso-init) rather than the app deep-link. For client-side-SPA apps (OpenBao) whose static ssoInitPath cannot auto-redirect; the shim asks Vault for the OIDC auth_url and 302s to Keycloak." }
       },
       "additionalProperties": false
     },

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.27
+  version: 1.2.28
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.
@@ -84,6 +84,16 @@ spec:
       # `oidc` mount → it reverted to `?with=token` (manual Token form) and the
       # malformed mount path broke the callback round-trip. Emit `?with=oidc`.
       ssoInitPath: "/ui/vault/auth?with=oidc"
+      # #3226 — zero-click silent-SSO parity with grafana/harbor. OpenBao's
+      # UI is a client-side SPA, so the ssoInitPath deep-link above can only
+      # PRE-SELECT the OIDC method — the operator still has to click "Sign in
+      # with OIDC". ssoShim:true makes catalyst-api's launch-url return its
+      # server-side shim (`api.<fqdn>/catalyst/v1/apps/openbao/openbao-sso-init`)
+      # instead. The shim asks Vault for the OIDC auth_url server-side and
+      # 302s the browser to Keycloak (silent PIN) → Vault callback → landed
+      # signed-in. If the auth_url POST fails, the shim falls back to the
+      # ssoInitPath deep-link above (the Open button never 500s).
+      ssoShim: true
 
   # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
   # OpenBao OIDC auth method federated to sovereign realm (G91 manual

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -26,7 +26,14 @@ name: bp-openbao
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.2.27
+version: 1.2.28
+# 1.2.28 (#3226, 2026-06-10): zero-click silent-SSO parity with grafana/harbor.
+# blueprint.yaml endpoint declares ssoShim:true so catalyst-api's launch-url
+# returns the server-side OpenBao SSO-init shim URL instead of the SPA
+# deep-link. The shim asks Vault for the OIDC auth_url server-side and 302s the
+# browser to Keycloak (silent PIN) → Vault callback → landed signed-in. No
+# chart-template change; version bumped in lockstep with blueprint.yaml + the
+# bootstrap-kit slot pin so the new blueprint OCI artifact publishes.
 # 1.2.27 (#3150, 2026-06-10): OIDC callback now LANDS the operator logged-in.
 # sso-configure reconciler: (1) bound_claims.groups widened to sovereign-admins
 # + sovereign-ops + sovereign-viewers (the realm stamps defaultGroups

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1427,6 +1427,13 @@ func main() {
 		rg.Patch("/catalyst/v1/apps/{id}/endpoints/{name}", h.HandlePatchAppEndpoint)
 		rg.Delete("/catalyst/v1/apps/{id}/endpoints/{name}", h.HandleDeleteAppEndpoint)
 		rg.Get("/catalyst/v1/apps/{id}/launch-url", h.HandleGetLaunchURL)
+		// #3226 — server-side zero-click silent-SSO shim for OpenBao.
+		// OpenBao's UI is a client-side SPA, so a static ssoInitPath can
+		// only pre-select the OIDC method (still one click). This shim
+		// asks Vault for the OIDC auth_url server-side and 302s the
+		// browser to Keycloak, giving grafana/harbor parity. The openbao
+		// blueprint's ssoInitPath points the Open button at this route.
+		rg.Get("/catalyst/v1/apps/{id}/openbao-sso-init", h.HandleOpenBaoSSOInit)
 		rg.Post("/catalyst/v1/apps/instances", h.HandleCreateInstance)
 		rg.Get("/catalyst/v1/catalog/{blueprint}/instances", h.HandleListBlueprintInstances)
 

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
@@ -87,9 +87,9 @@ type endpointMutationRequest struct {
 
 // endpointPRResponse mirrors `schema/EndpointPR`.
 type endpointPRResponse struct {
-	PRURL           string                   `json:"prURL"`
-	Status          string                   `json:"status"`
-	PreCheckResults endpointPreCheckResults  `json:"preCheckResults"`
+	PRURL           string                  `json:"prURL"`
+	Status          string                  `json:"status"`
+	PreCheckResults endpointPreCheckResults `json:"preCheckResults"`
 }
 
 type endpointPreCheckResults struct {
@@ -110,6 +110,7 @@ type resolvedEndpoint struct {
 	LaunchDefault     bool   `json:"launchDefault,omitempty"`
 	SSOEnabled        bool   `json:"ssoEnabled,omitempty"`
 	SSOInitPath       string `json:"ssoInitPath,omitempty"`
+	SSOShim           bool   `json:"ssoShim,omitempty"`
 	Status            string `json:"status"`
 	CertificateStatus string `json:"certificateStatus,omitempty"`
 	LaunchURL         string `json:"launchURL,omitempty"`
@@ -609,7 +610,18 @@ func (h *Handler) HandleGetLaunchURL(w http.ResponseWriter, r *http.Request) {
 	if ep.TLS != nil {
 		tls = *ep.TLS
 	}
-	urlStr := buildLaunchURL(hostname, tls, ep.SSOInitPath)
+	var urlStr string
+	if shim := buildSSOShimURL(h.endpointSovereignFQDN(), uid); ep.SSOShim && shim != "" {
+		// #3226 — return the server-side shim URL (catalyst-api origin)
+		// instead of the app deep-link. window.open() follows the shim's
+		// 302 to Keycloak for zero-click parity. The {id} we echo is the
+		// same one the FE addressed us with so the shim resolves the same
+		// blueprint. When the fqdn is unknown (shim=="") we fall through to
+		// the app deep-link so the URL is never host-less.
+		urlStr = shim
+	} else {
+		urlStr = buildLaunchURL(hostname, tls, ep.SSOInitPath)
+	}
 	expiresAt := time.Now().Add(60 * time.Second).UTC().Format(time.RFC3339)
 
 	writeJSON(w, http.StatusOK, launchURLResponse{
@@ -890,10 +902,10 @@ func (h *Handler) buildEndpointManifest(m precheck.Mutation) []byte {
 			"name":      m.Name,
 			"namespace": m.Org,
 			"labels": map[string]interface{}{
-				"app.kubernetes.io/instance":             m.App,
-				"app.kubernetes.io/managed-by":           "catalyst-api",
-				"catalyst.openova.io/organization":       m.Org,
-				"catalyst.openova.io/endpoint-name":      m.Name,
+				"app.kubernetes.io/instance":        m.App,
+				"app.kubernetes.io/managed-by":      "catalyst-api",
+				"catalyst.openova.io/organization":  m.Org,
+				"catalyst.openova.io/endpoint-name": m.Name,
 			},
 		},
 		"spec": map[string]interface{}{
@@ -971,11 +983,22 @@ type endpointDecl struct {
 	// (synced via the app's *-sso-oidc-credentials ExternalSecret). Empty
 	// → legacy behaviour (app root + prompt=none&kc_idp_hint query).
 	SSOInitPath string `yaml:"ssoInitPath,omitempty" json:"ssoInitPath,omitempty"`
+
+	// SSOShim — #3226. When true, the silent-SSO launch URL is NOT the
+	// app's own host/ssoInitPath but the catalyst-api server-side shim
+	// (`https://api.<fqdn>/catalyst/v1/apps/<id>/openbao-sso-init`). The
+	// shim asks Vault for the OIDC auth_url and 302s the browser to
+	// Keycloak — the zero-click parity OpenBao's client-side SPA can't
+	// achieve via a static ssoInitPath alone. ssoInitPath stays declared
+	// because the shim uses it as its own deep-link fallback when the
+	// auth_url POST fails (Vault sealed / oidc not mounted). Empty/false
+	// → the ssoInitPath behaviour above applies unchanged.
+	SSOShim bool `yaml:"ssoShim,omitempty" json:"ssoShim,omitempty"`
 }
 
 type ssoDecl struct {
-	Realm        string `yaml:"realm,omitempty" json:"realm,omitempty"`
-	SilentLogin  *bool  `yaml:"silentLogin,omitempty" json:"silentLogin,omitempty"`
+	Realm       string `yaml:"realm,omitempty" json:"realm,omitempty"`
+	SilentLogin *bool  `yaml:"silentLogin,omitempty" json:"silentLogin,omitempty"`
 }
 
 type multiInstanceDecl struct {
@@ -984,8 +1007,8 @@ type multiInstanceDecl struct {
 }
 
 type topologyDecl struct {
-	Supported []string                 `yaml:"supported" json:"supported"`
-	Defaults  topologyDefaults         `yaml:"defaults" json:"defaults"`
+	Supported []string         `yaml:"supported" json:"supported"`
+	Defaults  topologyDefaults `yaml:"defaults" json:"defaults"`
 }
 
 type topologyDefaults struct {
@@ -1062,10 +1085,18 @@ func (h *Handler) resolveEndpoints(app *unstructured.Unstructured, bp *blueprint
 			LaunchDefault:    ep.LaunchDefault,
 			SSOEnabled:       ep.SSOEnabled,
 			SSOInitPath:      ep.SSOInitPath,
+			SSOShim:          ep.SSOShim,
 			Status:           "Ready",
 		}
 		if ep.SSOEnabled {
-			re.LaunchURL = buildLaunchURL(hostname, tls, ep.SSOInitPath)
+			// #3226 — prefer the server-side shim URL when the endpoint
+			// declares ssoShim (zero-click parity for SPA apps); else the
+			// app deep-link / legacy silent-SSO shape.
+			if shim := buildSSOShimURL(fqdn, appName); ep.SSOShim && shim != "" {
+				re.LaunchURL = shim
+			} else {
+				re.LaunchURL = buildLaunchURL(hostname, tls, ep.SSOInitPath)
+			}
 		}
 		out = append(out, re)
 	}
@@ -1170,6 +1201,22 @@ func buildLaunchURL(hostname string, tls bool, ssoInitPath string) string {
 	q.Set("prompt", "none")
 	q.Set("kc_idp_hint", "catalyst-pin")
 	return fmt.Sprintf("%s://%s/?%s", scheme, hostname, q.Encode())
+}
+
+// buildSSOShimURL constructs the absolute URL of the catalyst-api
+// server-side silent-SSO shim (#3226) for the given app id. The shim lives
+// on the API origin (`api.<fqdn>`, the same canonical pattern used by the
+// handover export + tofu-archive POST targets) at
+// `/catalyst/v1/apps/<id>/openbao-sso-init`. Returns "" when fqdn is empty
+// so the caller falls back to the deep-link rather than emitting a
+// host-less URL.
+func buildSSOShimURL(fqdn, id string) string {
+	fqdn = strings.TrimSpace(fqdn)
+	id = strings.TrimSpace(id)
+	if fqdn == "" || id == "" {
+		return ""
+	}
+	return fmt.Sprintf("https://api.%s/catalyst/v1/apps/%s/openbao-sso-init", fqdn, url.PathEscape(id))
 }
 
 // chooseTopology selects the active topology for a createInstance call.
@@ -1434,12 +1481,12 @@ func readTopology(u *unstructured.Unstructured) string {
 //     Org-B's IaC repo (per the W3.D4 #2765 integration test).
 //
 //  2. Fallback to the global `CATALYST_GITEA_TOKEN` env var when:
-//       (a) the Handler has no openbao client wired (test mode /
-//           single-Org bootstrap Sovereign before openbao is up); OR
-//       (b) the per-Org secret returns ErrSecretNotFound (the Org's
-//           token hasn't been seeded yet — typical for the FIRST
-//           reconcile after bootstrap-org-iac-repo.sh provisions the
-//           Gitea side but before the OpenBao seed lands).
+//     (a) the Handler has no openbao client wired (test mode /
+//     single-Org bootstrap Sovereign before openbao is up); OR
+//     (b) the per-Org secret returns ErrSecretNotFound (the Org's
+//     token hasn't been seeded yet — typical for the FIRST
+//     reconcile after bootstrap-org-iac-repo.sh provisions the
+//     Gitea side but before the OpenBao seed lands).
 //
 //  3. Transport errors from OpenBao (NOT not-found) are surfaced as
 //     errors — we do NOT silently fall back through a transient

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler_test.go
@@ -91,8 +91,8 @@ func fakeBlueprintInCatalogWithCap(name string, endpoints []map[string]interface
 		Version: "1.0.0",
 		Raw: map[string]interface{}{
 			"spec": map[string]interface{}{
-				"version":       "1.0.0",
-				"endpoints":     endpoints,
+				"version":   "1.0.0",
+				"endpoints": endpoints,
 				"sso": map[string]interface{}{
 					"realm":       "sovereign",
 					"silentLogin": true,
@@ -114,12 +114,12 @@ func fakeBlueprintInCatalogWithCap(name string, endpoints []map[string]interface
 // fakeIaCAndStatus builds a fake gitea client + status checker that
 // scripts all-pass — sufficient for happy-path tests.
 type fakeIaCWriter struct {
-	mu        sync.Mutex
-	branches  map[string]bool
-	files     map[string][]byte
-	prs       map[string]gitea.PullRequest
-	prSeq     int64
-	merged    map[int64]bool
+	mu       sync.Mutex
+	branches map[string]bool
+	files    map[string][]byte
+	prs      map[string]gitea.PullRequest
+	prSeq    int64
+	merged   map[int64]bool
 }
 
 func newFakeIaCWriter() *fakeIaCWriter {
@@ -562,6 +562,33 @@ func TestGetLaunchURL_HRBacked_NoInitPathFallsBackLegacy(t *testing.T) {
 	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
 	if !strings.Contains(resp.URL, "prompt=none") || !strings.Contains(resp.URL, "kc_idp_hint=catalyst-pin") {
 		t.Fatalf("no-initPath HR app must use legacy silent-SSO shape: %s", resp.URL)
+	}
+}
+
+// #3226 — when an endpoint declares ssoShim:true (OpenBao's SPA can't
+// auto-redirect via a static ssoInitPath), the launch-url returns the
+// server-side shim URL on the catalyst-api origin instead of the deep-link.
+// window.open() on that URL follows the shim's 302 to Keycloak, giving
+// grafana/harbor zero-click parity.
+func TestGetLaunchURL_SSOShimReturnsShimURL(t *testing.T) {
+	h, _, _ := newTestHandlerWithEndpoint(t)
+	h.SetCatalogClient(fakeBlueprintInCatalog("openbao",
+		[]map[string]interface{}{
+			{"name": "api", "hostnameTemplate": "bao.{SovereignFQDN}", "tls": true,
+				"ssoEnabled": true, "launchDefault": true,
+				"ssoInitPath": "/ui/vault/auth?with=oidc", "ssoShim": true},
+		}, false, []string{"singleton"}))
+	r := newTestRouter(h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("GET", "/catalyst/v1/apps/openbao/launch-url", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	var resp launchURLResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	want := "https://api.t01.omani.works/catalyst/v1/apps/openbao/openbao-sso-init"
+	if resp.URL != want {
+		t.Fatalf("ssoShim launch URL mismatch:\n got %q\nwant %q", resp.URL, want)
 	}
 }
 
@@ -1103,9 +1130,9 @@ func TestCreateAppEndpoint_DenyCrossOrgWhenCallerNotMember(t *testing.T) {
 	req := httptest.NewRequest("POST", "/catalyst/v1/apps/uid-201/endpoints", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req = withTestClaims(req, &testClaimsSpec{
-		Tier:        "admin",
-		Org:         "beta", // ← different Org
-		RealmRoles:  []string{"catalyst-admin-beta"},
+		Tier:       "admin",
+		Org:        "beta", // ← different Org
+		RealmRoles: []string{"catalyst-admin-beta"},
 	})
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
@@ -1236,4 +1263,3 @@ func TestCallerInOrg_AcceptsOrgMembershipCallback(t *testing.T) {
 		t.Fatal("expected callback to reject non-member")
 	}
 }
-

--- a/products/catalyst/bootstrap/api/internal/handler/openbao_sso_init.go
+++ b/products/catalyst/bootstrap/api/internal/handler/openbao_sso_init.go
@@ -1,0 +1,160 @@
+// openbao_sso_init.go — #3226 server-side zero-click silent-SSO shim that
+// gives OpenBao grafana/harbor parity.
+//
+// Why a server-side shim is required (PROVEN in #3150 + the issue):
+//
+//   - Grafana `/login/generic_oauth` and Harbor `/c/oidc/login` are
+//     SERVER-side GET routes that 302 to Keycloak's authorize endpoint.
+//     A static ssoInitPath pointing at those routes auto-redirects, so the
+//     console Open button lands the operator already signed-in.
+//
+//   - OpenBao's UI is a client-side SPA (Vault-UI / Ember fork). OIDC is
+//     started in JavaScript, so there is no server GET route to land on.
+//     The best a static ssoInitPath (`/ui/vault/auth?with=oidc`) can do is
+//     PRE-SELECT the OIDC method in the UI — the operator STILL has to click
+//     "Sign in with OIDC". That is the one-click gap #3226 closes.
+//
+// What this shim does, replicating server-side what those apps do natively:
+//
+//  1. server-side POST to the Vault OIDC auth_url API
+//     (`POST <vaultAddr>/v1/auth/<mount>/oidc/auth_url` with
+//     {role, redirect_uri:<the Vault UI callback>}) using the in-cluster
+//     Vault address (the openbao client already wired for the handover
+//     receiver);
+//  2. read the returned `auth_url` (the Keycloak authorize URL — already
+//     carries kc_idp_hint=catalyst-pin via the realm IDP defaultProvider
+//     binding, NOT appended here);
+//  3. 302-redirect the browser to that auth_url.
+//
+// So: console Open → this shim → Keycloak silent PIN → Vault callback →
+// landed signed-in. The openbao blueprint's ssoInitPath is pointed at this
+// shim (relative path on the console origin) so the Open button calls it.
+//
+// Failure path (Inviolable: the Open button must NEVER 500): if the
+// auth_url POST fails for any reason (Vault sealed, oidc method not mounted
+// yet, openbao client unwired on Catalyst-Zero), the shim 302-redirects to
+// the app's deep-link (`https://<host>/ui/vault/auth?with=oidc`) so the
+// operator at least lands on the pre-selected OIDC method — the legacy
+// one-click behaviour — instead of an error page.
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// HandleOpenBaoSSOInit — GET /catalyst/v1/apps/{id}/openbao-sso-init
+//
+// Resolves the openbao endpoint (the same HR-backed blueprint resolution
+// the launch-url handler uses — openbao installs as a HelmRelease with no
+// Application CR), computes the Vault UI OIDC callback, asks Vault for the
+// auth_url, and 302s the browser there. Falls back to the app deep-link on
+// any error; 404s only when no SSO-enabled openbao endpoint resolves.
+func (h *Handler) HandleOpenBaoSSOInit(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	// Resolve the blueprint the same way launch-url does: openbao ships as
+	// an HR with no Application CR, so treat {id} as the blueprint name
+	// ("openbao" or "bp-openbao").
+	bp := strings.TrimPrefix(strings.TrimSpace(id), "bp-")
+	bpDoc, bpErr := h.fetchBlueprint(r.Context(), r, bp)
+	if bpErr != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"code":    "blueprint-unavailable",
+			"message": bpErr.Error(),
+		})
+		return
+	}
+
+	ep := pickEndpoint(bpDoc, "")
+	if ep == nil || !ep.SSOEnabled {
+		writeJSON(w, http.StatusNotFound, map[string]string{
+			"code":    "endpoint-not-found",
+			"message": fmt.Sprintf("Blueprint %q has no SSO-enabled endpoint for the OpenBao SSO-init shim", bp),
+		})
+		return
+	}
+
+	tls := true
+	if ep.TLS != nil {
+		tls = *ep.TLS
+	}
+	scheme := "https"
+	if !tls {
+		scheme = "http"
+	}
+	hostname := evaluateHostnameTemplate(ep.HostnameTemplate, h.endpointSovereignFQDN(), "", bp)
+
+	// The deep-link fallback is the blueprint's own ssoInitPath rendered
+	// against the resolved host. This is exactly what the legacy launch-url
+	// produced — pre-selects the OIDC method, one click.
+	deepLink := buildLaunchURL(hostname, tls, ep.SSOInitPath)
+	if deepLink == "" {
+		// No ssoInitPath declared → fall back to the app root with the
+		// legacy silent-SSO query (buildLaunchURL handles empty path).
+		deepLink = fmt.Sprintf("%s://%s/", scheme, hostname)
+	}
+
+	// No Vault client (Catalyst-Zero / not a handover target) → deep-link.
+	bao := h.openbao
+	if bao == nil {
+		http.Redirect(w, r, deepLink, http.StatusFound)
+		return
+	}
+
+	mount := openbaoOIDCMount()
+	role := openbaoOIDCRole()
+	callback := computeVaultUICallback(scheme, hostname, mount)
+
+	authURL, err := bao.OIDCAuthURL(r.Context(), mount, role, callback)
+	if err != nil {
+		// Vault sealed / oidc method not mounted / transport error — the
+		// Open button must never 500. Fall back to the deep-link.
+		h.log.Warn("openbao-sso-init: auth_url failed, falling back to deep-link",
+			"app", bp, "error", err.Error())
+		http.Redirect(w, r, deepLink, http.StatusFound)
+		return
+	}
+
+	http.Redirect(w, r, authURL, http.StatusFound)
+}
+
+// computeVaultUICallback builds the Vault-UI OIDC callback redirect_uri.
+// The Vault web UI completes the OIDC round-trip at
+// `https://<host>/ui/vault/auth/<mount>/oidc/callback` — sending the
+// browser back into the SPA which then exchanges the code. This must match
+// the redirect_uri allow-listed on the Vault OIDC role + the Keycloak
+// client, otherwise Keycloak rejects the authorize request.
+func computeVaultUICallback(scheme, host, mount string) string {
+	mount = strings.Trim(strings.TrimSpace(mount), "/")
+	if mount == "" {
+		mount = "oidc"
+	}
+	return fmt.Sprintf("%s://%s/ui/vault/auth/%s/oidc/callback", scheme, host, mount)
+}
+
+// openbaoOIDCMount reads the Vault OIDC auth-method mount path from env
+// (Inviolable Principle #4 — env-driven, no hardcoded value), defaulting
+// to the canonical "oidc" mount the sso-configure Deployment enables.
+func openbaoOIDCMount() string {
+	if v := strings.TrimSpace(os.Getenv("CATALYST_OPENBAO_OIDC_MOUNT")); v != "" {
+		return v
+	}
+	return "oidc"
+}
+
+// openbaoOIDCRole reads the Vault OIDC role name from env, defaulting to
+// "operator" — the role the openbao sso-configure Deployment creates
+// (`auth/oidc/role/operator`, default_role=operator). The OIDC auth_url
+// API requires an existing role; "operator" is the only one the bootstrap
+// kit provisions.
+func openbaoOIDCRole() string {
+	if v := strings.TrimSpace(os.Getenv("CATALYST_OPENBAO_OIDC_ROLE")); v != "" {
+		return v
+	}
+	return "operator"
+}

--- a/products/catalyst/bootstrap/api/internal/handler/openbao_sso_init_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/openbao_sso_init_test.go
@@ -1,0 +1,180 @@
+// openbao_sso_init_test.go — unit coverage for the #3226 server-side
+// zero-click silent-SSO shim that gives OpenBao grafana/harbor parity.
+//
+// OpenBao's UI is a client-side SPA, so a static ssoInitPath cannot
+// auto-redirect — it can only pre-select the OIDC method and still needs
+// a click. The shim replicates server-side what grafana / harbor do
+// natively: it asks Vault for the OIDC auth_url (the Keycloak authorize
+// URL, already carrying kc_idp_hint=catalyst-pin via the realm IDP
+// binding) and 302-redirects the browser straight to it.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
+)
+
+// ssoInitRouter mounts only the shim route so the tests are isolated.
+func ssoInitRouter(h *Handler) *chi.Mux {
+	r := chi.NewMux()
+	r.Get("/catalyst/v1/apps/{id}/openbao-sso-init", h.HandleOpenBaoSSOInit)
+	return r
+}
+
+// newSSOInitHandler builds a Handler with the openbao endpoint wired into
+// a fake catalog plus the given Vault address. The blueprint mirrors the
+// live platform/openbao/blueprint.yaml shape (bao.<fqdn> host, ssoEnabled,
+// the ?with=oidc deep-link fallback).
+func newSSOInitHandler(t *testing.T, vaultAddr string) *Handler {
+	t.Helper()
+	h := NewWithPDM(slog.New(slog.NewTextHandler(io_discard{}, nil)), nil)
+	h.SetEndpointPrecheckDeps(EndpointPrecheckDeps{
+		SovereignFQDN: "t01.omani.works",
+	})
+	h.SetCatalogClient(fakeBlueprintInCatalog("openbao",
+		[]map[string]interface{}{
+			{
+				"name":             "api",
+				"hostnameTemplate": "bao.{SovereignFQDN}",
+				"tls":              true,
+				"ssoEnabled":       true,
+				"launchDefault":    true,
+				"ssoInitPath":      "/ui/vault/auth?with=oidc",
+			},
+		}, false, []string{"singleton"}))
+	if vaultAddr != "" {
+		h.SetOpenBao(openbao.New(vaultAddr, "shim-token"))
+	}
+	return h
+}
+
+// TestOpenBaoSSOInit_RedirectsToVaultAuthURL — the happy path: with a
+// reachable Vault that returns an auth_url, the shim 302-redirects the
+// browser to that EXACT auth_url (this is what gives zero-click parity).
+func TestOpenBaoSSOInit_RedirectsToVaultAuthURL(t *testing.T) {
+	const authURL = "https://auth.t01.omani.works/realms/sovereign/protocol/openid-connect/auth" +
+		"?client_id=openbao&kc_idp_hint=catalyst-pin&redirect_uri=https%3A%2F%2Fbao.t01.omani.works" +
+		"%2Fui%2Fvault%2Fauth%2Foidc%2Foidc%2Fcallback&response_type=code&scope=openid&state=st&nonce=nc"
+
+	var gotReq struct {
+		Path   string
+		Role   string
+		RdrURI string
+	}
+	vault := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotReq.Path = r.URL.Path
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotReq.Role, _ = body["role"].(string)
+		gotReq.RdrURI, _ = body["redirect_uri"].(string)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"auth_url": authURL},
+		})
+	}))
+	defer vault.Close()
+
+	h := newSSOInitHandler(t, vault.URL)
+	r := ssoInitRouter(h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("GET", "/catalyst/v1/apps/openbao/openbao-sso-init", nil))
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	if loc := rec.Header().Get("Location"); loc != authURL {
+		t.Fatalf("Location must be the Vault auth_url verbatim:\n got %q\nwant %q", loc, authURL)
+	}
+	// The shim must hit the Vault OIDC auth_url API with the Vault UI
+	// callback as redirect_uri (Vault appends /oidc/oidc/callback).
+	if gotReq.Path != "/v1/auth/oidc/oidc/auth_url" {
+		t.Errorf("wrong Vault path; got %q", gotReq.Path)
+	}
+	if gotReq.Role != "operator" {
+		t.Errorf("expected role=operator (the bootstrap-kit OIDC role); got %q", gotReq.Role)
+	}
+	if !strings.HasPrefix(gotReq.RdrURI, "https://bao.t01.omani.works/ui/vault/auth/oidc/oidc/callback") {
+		t.Errorf("redirect_uri must target the Vault UI callback; got %q", gotReq.RdrURI)
+	}
+}
+
+// TestOpenBaoSSOInit_FallsBackToDeepLinkOnVaultError — when the auth_url
+// POST fails (Vault sealed / oidc method not mounted / 500), the shim
+// must NOT 500 the Open button. It 302-redirects to the app's deep-link
+// (ssoInitPath) so the operator at least lands on the pre-selected OIDC
+// method instead of an error page.
+func TestOpenBaoSSOInit_FallsBackToDeepLinkOnVaultError(t *testing.T) {
+	vault := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"errors":["vault is sealed"]}`))
+	}))
+	defer vault.Close()
+
+	h := newSSOInitHandler(t, vault.URL)
+	r := ssoInitRouter(h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("GET", "/catalyst/v1/apps/openbao/openbao-sso-init", nil))
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("expected 302 fallback (never 500), got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	want := "https://bao.t01.omani.works/ui/vault/auth?with=oidc"
+	if loc := rec.Header().Get("Location"); loc != want {
+		t.Fatalf("fallback Location must be the deep-link:\n got %q\nwant %q", loc, want)
+	}
+}
+
+// TestOpenBaoSSOInit_FallsBackWhenOpenBaoUnwired — Catalyst-Zero (or any
+// catalyst-api without CATALYST_OPENBAO_ADDR) has no Vault client. The
+// shim must still 302 to the deep-link, never 500.
+func TestOpenBaoSSOInit_FallsBackWhenOpenBaoUnwired(t *testing.T) {
+	h := newSSOInitHandler(t, "") // no openbao client wired
+	r := ssoInitRouter(h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("GET", "/catalyst/v1/apps/openbao/openbao-sso-init", nil))
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("expected 302 fallback when openbao unwired, got %d", rec.Code)
+	}
+	want := "https://bao.t01.omani.works/ui/vault/auth?with=oidc"
+	if loc := rec.Header().Get("Location"); loc != want {
+		t.Fatalf("fallback Location must be the deep-link; got %q", loc)
+	}
+}
+
+// TestOpenBaoSSOInit_UnknownAppIs404 — addressing an id with no resolvable
+// SSO-enabled endpoint must 404, not silently redirect somewhere bogus.
+func TestOpenBaoSSOInit_UnknownAppIs404(t *testing.T) {
+	h := NewWithPDM(slog.New(slog.NewTextHandler(io_discard{}, nil)), nil)
+	h.SetEndpointPrecheckDeps(EndpointPrecheckDeps{SovereignFQDN: "t01.omani.works"})
+	h.SetCatalogClient(newFakeCatalog()) // empty catalog
+	r := ssoInitRouter(h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("GET", "/catalyst/v1/apps/nope/openbao-sso-init", nil))
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown app, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestComputeVaultUICallback — the redirect_uri the shim sends to Vault is
+// the Vault-UI OIDC callback. Vault's web UI uses
+// https://<host>/ui/vault/auth/<mount>/oidc/callback. We mirror that here
+// so the round-trip lands back in the UI.
+func TestComputeVaultUICallback(t *testing.T) {
+	got := computeVaultUICallback("https", "bao.t01.omani.works", "oidc")
+	want := "https://bao.t01.omani.works/ui/vault/auth/oidc/oidc/callback"
+	if got != want {
+		t.Fatalf("callback mismatch:\n got %q\nwant %q", got, want)
+	}
+}
+
+var _ = context.Background

--- a/products/catalyst/bootstrap/api/internal/openbao/client.go
+++ b/products/catalyst/bootstrap/api/internal/openbao/client.go
@@ -224,3 +224,99 @@ func (c *Client) GetKVv2(ctx context.Context, mountPath, secretPath string) (map
 // so callers can distinguish "no per-Org token yet" from transport
 // errors. errors.Is(err, ErrSecretNotFound) is the canonical check.
 var ErrSecretNotFound = fmt.Errorf("openbao: secret not found")
+
+// OIDCAuthURL drives the Vault OIDC login start handshake server-side and
+// returns the Keycloak authorize URL the browser must be sent to. It POSTs:
+//
+//	POST <addr>/v1/auth/<mount>/oidc/auth_url
+//	body: {"role": <role>, "redirect_uri": <vault-ui-callback>}
+//
+// and reads `data.auth_url` from the response:
+//
+//	{"data": {"auth_url": "https://auth.<fqdn>/realms/<realm>/.../auth?..."}}
+//
+// The returned auth_url already carries `kc_idp_hint=catalyst-pin` because
+// the sovereign realm's OIDC client / IDP defaultProvider binding bakes the
+// hint into the issuer's authorize redirect — catalyst-api does NOT append
+// it here (Inviolable Principle #4: env-driven, no hardcoded query rewrite).
+//
+// This is the server-side replication of what Grafana's
+// `/login/generic_oauth` and Harbor's `/c/oidc/login` GET routes do
+// natively — but OpenBao's SPA cannot, which is why #3226 needs this shim.
+//
+// `mount` defaults to "oidc" (the standard Vault OIDC auth-method mount).
+// Returns a wrapped error on any non-200 / empty auth_url so the caller's
+// fallback path (the deep-link) can fire — the Open button must never 500.
+func (c *Client) OIDCAuthURL(ctx context.Context, mount, role, redirectURI string) (string, error) {
+	if c == nil {
+		return "", fmt.Errorf("openbao: client is nil")
+	}
+	if strings.TrimSpace(c.Addr) == "" {
+		return "", fmt.Errorf("openbao: address is required")
+	}
+	if strings.TrimSpace(c.Token) == "" {
+		return "", fmt.Errorf("openbao: token is required")
+	}
+	role = strings.TrimSpace(role)
+	if role == "" {
+		return "", fmt.Errorf("openbao: role is required")
+	}
+	redirectURI = strings.TrimSpace(redirectURI)
+	if redirectURI == "" {
+		return "", fmt.Errorf("openbao: redirect_uri is required")
+	}
+	mount = strings.Trim(strings.TrimSpace(mount), "/")
+	if mount == "" {
+		mount = "oidc"
+	}
+
+	reqBody, err := json.Marshal(map[string]any{
+		"role":         role,
+		"redirect_uri": redirectURI,
+	})
+	if err != nil {
+		return "", fmt.Errorf("openbao: marshal auth_url body: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/v1/auth/%s/oidc/auth_url",
+		strings.TrimRight(c.Addr, "/"),
+		mount,
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
+	if err != nil {
+		return "", fmt.Errorf("openbao: build auth_url request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Vault-Token", c.Token)
+
+	httpc := c.HTTP
+	if httpc == nil {
+		httpc = http.DefaultClient
+	}
+	resp, err := httpc.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("openbao: auth_url request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<14))
+		return "", fmt.Errorf("openbao: auth_url %s/oidc/auth_url: status %d: %s",
+			mount, resp.StatusCode, strings.TrimSpace(string(respBody)),
+		)
+	}
+
+	var envelope struct {
+		Data struct {
+			AuthURL string `json:"auth_url"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&envelope); err != nil {
+		return "", fmt.Errorf("openbao: decode auth_url body: %w", err)
+	}
+	if strings.TrimSpace(envelope.Data.AuthURL) == "" {
+		return "", fmt.Errorf("openbao: auth_url response carried no data.auth_url")
+	}
+	return envelope.Data.AuthURL, nil
+}

--- a/products/catalyst/bootstrap/api/internal/openbao/client_test.go
+++ b/products/catalyst/bootstrap/api/internal/openbao/client_test.go
@@ -223,3 +223,133 @@ func TestGetKVv2_RequiredFields(t *testing.T) {
 		})
 	}
 }
+
+// ── OIDCAuthURL coverage (#3226 — server-side zero-click SSO shim) ────
+
+// TestOIDCAuthURL_OK — happy path: POST /v1/auth/{mount}/oidc/auth_url
+// with {role, redirect_uri} returns the inner data.auth_url verbatim.
+func TestOIDCAuthURL_OK(t *testing.T) {
+	const wantAuthURL = "https://auth.t01.omani.works/realms/sovereign/protocol/openid-connect/auth?client_id=openbao&redirect_uri=https%3A%2F%2Fbao.t01.omani.works%2Fui%2Fvault%2Fauth%2Foidc%2Foidc%2Fcallback&response_type=code&scope=openid&state=st&nonce=nc"
+	var (
+		gotPath string
+		gotTok  string
+		gotBody map[string]any
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		gotPath = r.URL.Path
+		gotTok = r.Header.Get("X-Vault-Token")
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"auth_url": wantAuthURL},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-token")
+	got, err := c.OIDCAuthURL(context.Background(), "oidc", "default",
+		"https://bao.t01.omani.works/ui/vault/auth/oidc/oidc/callback")
+	if err != nil {
+		t.Fatalf("OIDCAuthURL returned error: %v", err)
+	}
+	if got != wantAuthURL {
+		t.Fatalf("auth_url mismatch:\n got %q\nwant %q", got, wantAuthURL)
+	}
+	if gotPath != "/v1/auth/oidc/oidc/auth_url" {
+		t.Errorf("wrong path; got %q want /v1/auth/oidc/oidc/auth_url", gotPath)
+	}
+	if gotTok != "test-token" {
+		t.Errorf("wrong token header; got %q", gotTok)
+	}
+	if gotBody["role"] != "default" {
+		t.Errorf("role not forwarded; got %v", gotBody["role"])
+	}
+	if gotBody["redirect_uri"] != "https://bao.t01.omani.works/ui/vault/auth/oidc/oidc/callback" {
+		t.Errorf("redirect_uri not forwarded; got %v", gotBody["redirect_uri"])
+	}
+}
+
+// TestOIDCAuthURL_DefaultMount — empty mount falls back to "oidc".
+func TestOIDCAuthURL_DefaultMount(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"auth_url": "https://x/auth"},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tk")
+	if _, err := c.OIDCAuthURL(context.Background(), "", "default", "https://h/cb"); err != nil {
+		t.Fatalf("OIDCAuthURL: %v", err)
+	}
+	if gotPath != "/v1/auth/oidc/oidc/auth_url" {
+		t.Errorf("empty mount must default to 'oidc'; got %q", gotPath)
+	}
+}
+
+// TestOIDCAuthURL_EmptyAuthURLErrors — a 200 with no auth_url is a
+// failure (the shim must fall back to the deep-link, not 302 to "").
+func TestOIDCAuthURL_EmptyAuthURLErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{}})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tk")
+	_, err := c.OIDCAuthURL(context.Background(), "oidc", "default", "https://h/cb")
+	if err == nil {
+		t.Fatal("expected error on empty auth_url; got nil")
+	}
+}
+
+// TestOIDCAuthURL_StatusErrorWraps — non-200 surfaces the status code.
+func TestOIDCAuthURL_StatusErrorWraps(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"errors":["role default not found"]}`)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "tk")
+	_, err := c.OIDCAuthURL(context.Background(), "oidc", "default", "https://h/cb")
+	if err == nil {
+		t.Fatal("expected error on 400; got nil")
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("error should include status; got %v", err)
+	}
+}
+
+// TestOIDCAuthURL_RequiredFields — pre-flight validation mirrors the
+// other client methods.
+func TestOIDCAuthURL_RequiredFields(t *testing.T) {
+	cases := []struct {
+		name  string
+		c     *Client
+		role  string
+		rdr   string
+		match string
+	}{
+		{"nil-client", (*Client)(nil), "default", "https://h/cb", "client is nil"},
+		{"missing-addr", &Client{Token: "tk"}, "default", "https://h/cb", "address is required"},
+		{"missing-token", &Client{Addr: "http://x"}, "default", "https://h/cb", "token is required"},
+		{"missing-role", &Client{Addr: "http://x", Token: "tk"}, "", "https://h/cb", "role is required"},
+		{"missing-redirect", &Client{Addr: "http://x", Token: "tk"}, "default", "", "redirect_uri is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.c.OIDCAuthURL(context.Background(), "oidc", tc.role, tc.rdr)
+			if err == nil {
+				t.Fatal("expected error; got nil")
+			}
+			if !strings.Contains(err.Error(), tc.match) {
+				t.Errorf("error message mismatch; got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds a server-side shim in catalyst-api that gives OpenBao the same zero-click silent-SSO behaviour Grafana and Harbor already have.

OpenBao's UI is a client-side SPA (Vault-UI / Ember fork). OIDC is started in JavaScript, so there is no server GET route to land on — the best a static `ssoInitPath` (`/ui/vault/auth?with=oidc`) can do is pre-select the OIDC method, and the operator STILL has to click "Sign in with OIDC". Grafana `/login/generic_oauth` and Harbor `/c/oidc/login` are server-side GETs that 302 to Keycloak natively. This shim replicates that server-side for OpenBao.

## How

- `openbao.Client.OIDCAuthURL` — server-side `POST {vaultAddr}/v1/auth/{mount}/oidc/auth_url` with `{role, redirect_uri:<Vault UI callback>}`, returns the Keycloak authorize URL (`data.auth_url`). The auth_url already carries `kc_idp_hint=catalyst-pin` via the realm IDP `defaultProvider` binding — not appended here (Principle #4, env-driven).
- `HandleOpenBaoSSOInit` — `GET /catalyst/v1/apps/{id}/openbao-sso-init`: resolves the openbao endpoint (HR-backed blueprint resolution, same as launch-url), computes the Vault UI callback `https://bao.<fqdn>/ui/vault/auth/oidc/oidc/callback`, asks Vault for the auth_url, and 302-redirects the browser to Keycloak.
- Failure path: if the auth_url POST fails (Vault sealed, oidc method not mounted yet, openbao client unwired on Catalyst-Zero), the shim 302s to the app deep-link instead — the Open button never 500s.
- `launch-url` returns the shim URL (`https://api.<fqdn>/catalyst/v1/apps/openbao/openbao-sso-init`) when the endpoint declares `ssoShim:true`; `bp-openbao` now sets `ssoShim:true`. The console Open button calls launch-url and `window.open`s the result, which follows the shim's 302.
- mount/role are env-driven (`CATALYST_OPENBAO_OIDC_MOUNT` / `CATALYST_OPENBAO_OIDC_ROLE`), defaulting to `oidc` / `operator` — matching the mount + role the openbao `sso-configure` Deployment creates (`auth/oidc/role/operator`, `default_role=operator`).

So: console Open -> shim -> Keycloak silent PIN -> Vault callback -> landed signed-in.

## Tests (TDD-first)

Written failing first, then made to pass:

- `internal/openbao/client_test.go` — `OIDCAuthURL` happy path (asserts the exact `/v1/auth/oidc/oidc/auth_url` path, role + redirect_uri forwarded, returned auth_url verbatim), default mount, empty-auth_url errors, non-200 status-wrap, required-field validation.
- `internal/handler/openbao_sso_init_test.go` — 302 to the EXACT Vault auth_url (Location header); deep-link fallback on Vault error; deep-link fallback when the openbao client is unwired; 404 on unknown app; Vault UI callback shape.
- `internal/handler/endpoint_handler_test.go` — launch-url returns the shim URL when `ssoShim:true`.

The full browser no-login-form DOM walk rides the next prov.

## Lockstep

bp-openbao `1.2.27` -> `1.2.28` across Chart.yaml + blueprint.yaml + the bootstrap-kit slot 08 pin (pin-sync check passes). No chart-template change.

Refs #3226 #3150
