### PR TITLE
fix(cloud-init): IPv4-pin dual-stack bootstrap hosts — secondary-region CNI IPv6 killer

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -586,6 +586,22 @@ runcmd:
   ${indent(2, kubeconfig_put_block)}
 %{ endif ~}
 
+  # ── IPv4-pin dual-stack bootstrap hosts (#3232 — the intermittent multi-
+  # region CNI killer, root-caused on hw125). Huawei VPCs are IPv4-only;
+  # helm/kubectl (Go) can resolve these GitHub-Pages/GitHub hosts to AAAA
+  # and try IPv6 FIRST → "network is unreachable" with NO fallback →
+  # `helm repo add cilium` fails → no CNI → the region's nodes stay
+  # NotReady forever. region-A happened to get the A record, region-b got
+  # AAAA (hw125: region-b CNI-dead, ClusterMesh impossible, Pillar-3
+  # blocked). Pinning the resolved IPv4 in /etc/hosts BEFORE any pull is
+  # targeted + cloud-agnostic (every host below is IPv4-reachable from
+  # every cloud; on a dual-stack cloud the A record is still valid).
+  - |
+    for h in helm.cilium.io get.helm.sh raw.githubusercontent.com github.com objects.githubusercontent.com codeload.github.com; do
+      ip="$(getent ahostsv4 "$h" 2>/dev/null | awk 'NR==1{print $1}')"
+      [ -n "$ip" ] && printf '%s %s\n' "$ip" "$h" >> /etc/hosts || true
+    done
+
   # ── gateway-api CRDs: ONE official bundle apply (lean Hetzner pattern) ─
   # Flux's bp-gateway-api re-applies post-bootstrap; this single apply just
   # unblocks the Cilium operator's gateway-controller at its OWN boot.


### PR DESCRIPTION
## What

Pin the dual-stack bootstrap hosts (`helm.cilium.io`, `get.helm.sh`, `raw.githubusercontent.com`, `github.com`, `objects/codeload.githubusercontent.com`) to their resolved IPv4 in `/etc/hosts` before any cloud-init pull.

## Why (root-caused live on hw125)

`helm repo add cilium https://helm.cilium.io/` (helm is a Go binary; `helm.cilium.io` is dual-stack GitHub Pages) could resolve to the **IPv6** address and try IPv6 first. Huawei kom4dc VPCs are **IPv4-only** → `dial tcp [2606:50c0:8003::153]:443: connect: network is unreachable` with **no fallback to the A record** → `INSTALLATION FAILED: repo cilium not found` → no cilium DaemonSet → nodes `NotReady` ("cni plugin not initialized") → nothing schedules → **ClusterMesh A↔B never forms → Pillar-3 cross-region CNPG DR impossible.**

It is **intermittent per region** (region-A resolved the A record and was healthy; region-b got AAAA and was CNI-dead) — which is exactly why it has been an unpinnable, flaky multi-region failure across provs (hw124's "0 ReplicaClusters" was this same cause). Image pulls still succeed (containerd uses IPv4), so the env looks half-healthy.

## Verification

- Read live off region-b's host via a host-network + tolerate-all + hostPath pod (kom4dc blocks SSH), confirming the exact IPv6 error in `/var/log/cloud-init-output.log`.
- Salvaged region-b on hw125 by installing cilium via IPv4 from the bastion → all 4 nodes flipped to Ready in ~1 min, confirming IPv4 was the only failure-source.
- The change is dash-safe; the `dash -n` lint gate (#3230) covers it.

Refs #3232 #2737