### PR TITLE
fix(external-secrets): webhook-gate poll window must stay under the HR Helm timeout

### DIFF
--- a/clusters/_template/bootstrap-kit/15-external-secrets.yaml
+++ b/clusters/_template/bootstrap-kit/15-external-secrets.yaml
@@ -69,7 +69,7 @@ spec:
   chart:
     spec:
       chart: bp-external-secrets
-      version: 1.1.2
+      version: 1.1.3
       sourceRef:
         kind: HelmRepository
         name: bp-external-secrets

--- a/platform/external-secrets/blueprint.yaml
+++ b/platform/external-secrets/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.1.2
+  version: 1.1.3
   card:
     title: External Secrets Operator
     summary: |

--- a/platform/external-secrets/chart/Chart.yaml
+++ b/platform/external-secrets/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-external-secrets
-version: 1.1.2
+version: 1.1.3
 description: |
   Catalyst-curated Blueprint umbrella chart for External Secrets Operator
   (ESO) — controller-only as of 1.1.0. Depends on the upstream

--- a/platform/external-secrets/chart/templates/webhook-gate-hook.yaml
+++ b/platform/external-secrets/chart/templates/webhook-gate-hook.yaml
@@ -43,7 +43,7 @@ DETECTOR, never a cluster-wedging fatal.
 {{- $svcName := (($gate.service).name) | default "external-secrets-webhook" -}}
 {{- $svcNs := (($gate.service).namespace) | default "external-secrets-system" -}}
 {{- $secretName := $gate.tlsSecretName | default "external-secrets-webhook" -}}
-{{- $timeout := $gate.timeoutSeconds | default 1200 -}}
+{{- $timeout := $gate.timeoutSeconds | default 600 -}}
 {{- $interval := $gate.intervalSeconds | default 2 -}}
 {{- $image := $gate.image | default "bitnamilegacy/kubectl:1.30.7" -}}
 {{- $pullPolicy := $gate.imagePullPolicy | default "IfNotPresent" -}}


### PR DESCRIPTION
## Root cause (diagnosed live on hw125)

The bp-external-secrets post-install/upgrade **webhook-gate Job** (added in #3205) defaults to `timeoutSeconds=1200` (20m), but the HR's install/upgrade Helm `timeout` is **15m**. On a cold prov the gate runs its full window, so Helm gives up waiting at 15m:

```
Helm upgrade failed ... post-upgrade hooks failed: timed out waiting for the condition
Stalled: missing target release for rollback: cannot remediate failed release
```

This single stall **cascades through the entire convergence graph**:
`bp-external-secrets` → `bp-external-secrets-stores` (dependsOn) → every ExternalSecret incl. `gitea-oauth-source-credentials` → `gitea-sso-configure` (`DeadlineExceeded` waiting for that secret) → `bp-gitea` → `bp-catalyst-platform` (the console) → continuum/sandbox/harbor/powerdns-admin. On hw125 it left the prov at 48/60 HRs.

## Fix

Drop the gate's default poll window to **600s (10m)**, comfortably under the 15m HR Helm timeout, so the gate always finishes (non-fatally, as designed) before Helm's hook-wait gives up. The gate's `tls.crt` + endpoints checks were verified sound on hw125 (secret has a 1716-byte `tls.crt`, endpoints ready) — only the window was wrong.

Lockstep version bump 1.1.2 → 1.1.3 across Chart.yaml + blueprint.yaml + the bootstrap-kit slot.

Refs #2737