### PR TITLE
feat(catalyst-api): ClusterMesh-gated SOVEREIGN_ENABLE_CNPG_PAIR flip on the primary bootstrap-kit Kustomization

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -96,7 +96,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
@@ -158,6 +161,31 @@ const (
 	clusterMeshPeerCertValidity = 365 * 24 * time.Hour
 )
 
+// ClusterMesh-gated cnpg-pair enable (#3236) — names of the Flux
+// objects/keys the post-mesh gate flip touches. The bootstrap-kit
+// Kustomization is the one cloud-init applies on every control plane
+// (infra/providers/_shared/cloudinit-control-plane.tftpl,
+// flux-bootstrap.yaml writeup); its postBuild.substitute map threads
+// every Sovereign-shape value into clusters/_template/bootstrap-kit/*,
+// including slot 16b's `cnpgPair.enabled:
+// ${SOVEREIGN_ENABLE_CNPG_PAIR:-false}` gate.
+const (
+	bootstrapKitKustomizationName         = "bootstrap-kit"
+	fluxSystemNamespace                   = "flux-system"
+	clusterMeshCNPGPairSubstituteKey      = "SOVEREIGN_ENABLE_CNPG_PAIR"
+	clusterMeshPrimaryRegionSubstituteKey = "SOVEREIGN_PRIMARY_REGION"
+	clusterMeshReplicaRegionSubstituteKey = "SOVEREIGN_REPLICA_REGION"
+	fluxReconcileRequestedAtAnnotation    = "reconcile.fluxcd.io/requestedAt"
+)
+
+// fluxKustomizationGVR — kustomize.toolkit.fluxcd.io/v1 Kustomizations,
+// addressed via the dynamic client (no Flux Go types vendored here).
+var fluxKustomizationGVR = schema.GroupVersionResource{
+	Group:    "kustomize.toolkit.fluxcd.io",
+	Version:  "v1",
+	Resource: "kustomizations",
+}
+
 // clusterMeshDeploymentLabels — the upstream Cilium chart's
 // DaemonSet/Deployment names. Used by rollout-restart hints.
 var clusterMeshRolloutTargets = []struct {
@@ -177,6 +205,13 @@ var clusterMeshRolloutTargets = []struct {
 // Returning (nil, false) means "no override for this path, fall
 // through to production". Returning (client, true) injects the fake.
 var clusterMeshTestClientFactory func(kubeconfigPath string) (kubernetes.Interface, bool)
+
+// clusterMeshTestDynamicClientFactory — test-only hook mirroring
+// clusterMeshTestClientFactory for the DYNAMIC client the cnpg-pair
+// gate flip (#3236) uses to patch the bootstrap-kit Flux Kustomization.
+// Same contract: (nil, false) falls through to production; production
+// leaves this nil.
+var clusterMeshTestDynamicClientFactory func(kubeconfigPath string) (dynamic.Interface, bool)
 
 // clusterMeshTestOverrideLBTimeout / clusterMeshTestOverrideLBInterval
 // — test-only override knobs for the LB-discovery poll loop. Zero
@@ -523,7 +558,172 @@ func (h *Handler) AutoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 		"fullyMeshed", totalReady,
 	)
 
+	// ── ClusterMesh-gated cnpg-pair enable (#3236) ──────────────────
+	// 🛑 ANTI-PATTERN GUARD (hw124/#3196): slot 16b (bp-cnpg-pair)
+	// gates on its OWN substitute SOVEREIGN_ENABLE_CNPG_PAIR precisely
+	// because flipping on raw 2-region-ness (SOVEREIGN_ENABLE_HOT_
+	// STANDBY) rendered a replica that could never stream its
+	// basebackup when the mesh wasn't actually wired. The flip below
+	// therefore fires ONLY on the FULL-success path — every region's
+	// ReadyAt stamped, i.e. every peer pair Connected — never on
+	// partial success, never at bootstrap. Idempotent: re-running
+	// patches the same key to the same value and merely re-requests a
+	// reconcile.
+	if totalReady == len(statuses) && len(statuses) >= 2 {
+		h.enableCNPGPairAfterFullMesh(ctx, dep, primaryKubeconfigPath)
+	} else {
+		h.log.Info("clustermesh: mesh not fully established — SOVEREIGN_ENABLE_CNPG_PAIR left untouched (slot 16b stays gated OFF)",
+			"id", dep.ID,
+			"fullyMeshed", totalReady,
+			"regions", len(statuses),
+		)
+	}
+
 	return statuses, nil
+}
+
+// enableCNPGPairAfterFullMesh flips the slot-16b gate on the PRIMARY
+// region's bootstrap-kit Flux Kustomization (the one cloud-init applies
+// — infra/providers/_shared/cloudinit-control-plane.tftpl) by merging
+// `spec.postBuild.substitute.SOVEREIGN_ENABLE_CNPG_PAIR: "true"` and
+// stamping `reconcile.fluxcd.io/requestedAt` so Flux reconciles
+// immediately instead of waiting out the 5m interval. The cross-region
+// CNPG pair (clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml)
+// then deploys zero-touch, correctly gated on CONFIRMED mesh readiness.
+//
+// Defense (non-negotiable, per the chart's required-fail-fast): the
+// flip is REFUSED unless the substitute map already carries non-empty,
+// DISTINCT SOVEREIGN_PRIMARY_REGION / SOVEREIGN_REPLICA_REGION —
+// cloud-init stamps both on 2-region provs. With enabled=true and a
+// missing/equal region the bp-cnpg-pair chart render fails, and a
+// render failure inside the bootstrap-kit Kustomization fails the WHOLE
+// atomic apply → 0 HRs (the #2981/#2982 fresh-prov wedge shape). A
+// refused flip logs loudly and leaves the gate OFF (empty Ready
+// release — safe).
+//
+// Scope: ONLY SOVEREIGN_ENABLE_CNPG_PAIR. The shared-pg flags
+// (SOVEREIGN_ENABLE_SHARED_PG / *_PG_OWN_CLUSTER) are #3188 scope and
+// are deliberately not touched here. Only the PRIMARY's Kustomization
+// is patched — slot 16b is a primary-only HR (SECONDARY_HR_SUSPEND
+// suspends it on secondary control planes).
+//
+// Failure modes follow this file's convention: every failure is logged
+// + surfaced as a clustermesh-progress warn event, never an error —
+// the post-handover finalisation re-runs AutoEstablishClusterMesh and
+// the flip converges then.
+func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployment, primaryKubeconfigPath string) {
+	if primaryKubeconfigPath == "" {
+		// Unreachable from the full-success path (an empty path fails
+		// the primary slot, which blocks full success) — but this
+		// method must stay safe if ever called from another site.
+		h.log.Warn("clustermesh: cnpg-pair gate: primary kubeconfig path empty — cannot reach bootstrap-kit Kustomization",
+			"id", dep.ID)
+		return
+	}
+	dyn, err := h.clusterMeshDynamicClient(primaryKubeconfigPath)
+	if err != nil {
+		h.log.Warn("clustermesh: cnpg-pair gate: dynamic client build failed",
+			"id", dep.ID, "err", err)
+		h.emitClusterMeshProgress(dep, "warn",
+			fmt.Sprintf("ClusterMesh: cnpg-pair enable skipped — dynamic client build failed (%v); re-run converges", err))
+		return
+	}
+
+	getCtx, cancelGet := context.WithTimeout(ctx, clusterMeshCallTimeout)
+	ks, err := dyn.Resource(fluxKustomizationGVR).Namespace(fluxSystemNamespace).
+		Get(getCtx, bootstrapKitKustomizationName, metav1.GetOptions{})
+	cancelGet()
+	if err != nil {
+		h.log.Warn("clustermesh: cnpg-pair gate: Get bootstrap-kit Kustomization failed",
+			"id", dep.ID, "err", err)
+		h.emitClusterMeshProgress(dep, "warn",
+			fmt.Sprintf("ClusterMesh: cnpg-pair enable skipped — Get Kustomization %s/%s failed (%v); re-run converges",
+				fluxSystemNamespace, bootstrapKitKustomizationName, err))
+		return
+	}
+
+	substitute, found, err := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
+	if err != nil || !found {
+		h.log.Warn("clustermesh: refusing to flip SOVEREIGN_ENABLE_CNPG_PAIR — bootstrap-kit Kustomization has no readable spec.postBuild.substitute map",
+			"id", dep.ID, "found", found, "err", err)
+		h.emitClusterMeshProgress(dep, "warn",
+			"ClusterMesh: cnpg-pair enable refused — bootstrap-kit Kustomization carries no postBuild.substitute map")
+		return
+	}
+	primaryRegion := strings.TrimSpace(substitute[clusterMeshPrimaryRegionSubstituteKey])
+	replicaRegion := strings.TrimSpace(substitute[clusterMeshReplicaRegionSubstituteKey])
+	if primaryRegion == "" || replicaRegion == "" || primaryRegion == replicaRegion {
+		h.log.Warn("clustermesh: refusing to flip SOVEREIGN_ENABLE_CNPG_PAIR — substitute region precondition failed (bp-cnpg-pair `required`s distinct non-empty regions; a render failure would fail the whole atomic bootstrap-kit apply → 0 HRs)",
+			"id", dep.ID,
+			"primaryRegion", primaryRegion,
+			"replicaRegion", replicaRegion,
+		)
+		h.emitClusterMeshProgress(dep, "warn",
+			fmt.Sprintf("ClusterMesh: cnpg-pair enable REFUSED — SOVEREIGN_PRIMARY_REGION=%q / SOVEREIGN_REPLICA_REGION=%q must be non-empty and distinct in the bootstrap-kit substitute map",
+				primaryRegion, replicaRegion))
+		return
+	}
+
+	// JSON merge patch (RFC 7386) merges nested objects key-by-key, so
+	// sibling substitute keys + existing annotations are preserved —
+	// only the gate key and the reconcile-request stamp change.
+	stamp := time.Now().UTC().Format(time.RFC3339Nano)
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
+				fluxReconcileRequestedAtAnnotation: stamp,
+			},
+		},
+		"spec": map[string]any{
+			"postBuild": map[string]any{
+				"substitute": map[string]any{
+					clusterMeshCNPGPairSubstituteKey: "true",
+				},
+			},
+		},
+	}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		h.log.Warn("clustermesh: cnpg-pair gate: marshal merge patch failed",
+			"id", dep.ID, "err", err)
+		return
+	}
+	patchCtx, cancelPatch := context.WithTimeout(ctx, clusterMeshCallTimeout)
+	defer cancelPatch()
+	if _, err := dyn.Resource(fluxKustomizationGVR).Namespace(fluxSystemNamespace).
+		Patch(patchCtx, bootstrapKitKustomizationName, types.MergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
+		h.log.Warn("clustermesh: cnpg-pair gate: Patch bootstrap-kit Kustomization failed",
+			"id", dep.ID, "err", err)
+		h.emitClusterMeshProgress(dep, "warn",
+			fmt.Sprintf("ClusterMesh: cnpg-pair enable failed — Patch Kustomization %s/%s (%v); re-run converges",
+				fluxSystemNamespace, bootstrapKitKustomizationName, err))
+		return
+	}
+
+	h.log.Info("clustermesh: SOVEREIGN_ENABLE_CNPG_PAIR=true merged onto primary bootstrap-kit Kustomization + Flux reconcile requested",
+		"id", dep.ID,
+		"primaryRegion", primaryRegion,
+		"replicaRegion", replicaRegion,
+		"requestedAt", stamp,
+	)
+	h.emitClusterMeshProgress(dep, "info",
+		"ClusterMesh confirmed across all regions — enabled bp-cnpg-pair (slot 16b) via SOVEREIGN_ENABLE_CNPG_PAIR=true and requested Flux reconcile")
+}
+
+// clusterMeshDynamicClient builds a dynamic.Interface for the cluster
+// behind the given kubeconfig path, honouring the test-only factory
+// override the same way buildRegionSlots does for typed clients.
+func (h *Handler) clusterMeshDynamicClient(kubeconfigPath string) (dynamic.Interface, error) {
+	if clusterMeshTestDynamicClientFactory != nil {
+		if d, ok := clusterMeshTestDynamicClientFactory(kubeconfigPath); ok {
+			return d, nil
+		}
+	}
+	raw, err := os.ReadFile(kubeconfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("read kubeconfig %q: %w", kubeconfigPath, err)
+	}
+	return helmwatch.NewDynamicClientFromKubeconfig(string(raw))
 }
 
 // buildRegionSlots gathers per-region clients + identity. The primary

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -18,21 +18,29 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"log/slog"
 	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	kfake "k8s.io/client-go/kubernetes/fake"
 
@@ -168,10 +176,12 @@ users:
 // the package-private helper installClusterMeshClientFactory so we
 // don't have to plumb a real kubeconfig parser.
 type testFixture struct {
-	dir      string
-	clients  map[string]kubernetes.Interface // keyed by kubeconfig path
-	dep      *Deployment
-	handler  *Handler
+	dir                   string
+	clients               map[string]kubernetes.Interface // keyed by kubeconfig path
+	dynClients            map[string]dynamic.Interface    // keyed by kubeconfig path (primary only today)
+	primaryKubeconfigPath string
+	dep                   *Deployment
+	handler               *Handler
 }
 
 // installClusterMeshClientFactory replaces helmwatch's kubeconfig
@@ -257,8 +267,113 @@ func newTestFixture(t *testing.T, lbIPs []string) *testFixture {
 		dep.secondaryKubeconfigPaths[k] = filepath.Join(dir, depID+"-"+k+".yaml")
 	}
 
+	// Primary region's fake DYNAMIC client — carries the bootstrap-kit
+	// Flux Kustomization the cnpg-pair gate flip (#3236) patches. Seeded
+	// with the canonical 2-region substitute map cloud-init stamps
+	// (distinct non-empty SOVEREIGN_PRIMARY_REGION / SOVEREIGN_REPLICA_
+	// REGION). Tests that exercise the precondition guard replace this
+	// entry before installing the factories.
+	primaryKubeconfigPath := filepath.Join(dir, depID+".yaml")
+	dynClients := map[string]dynamic.Interface{
+		primaryKubeconfigPath: newFakeKustomizationDynClient(t,
+			buildBootstrapKitKustomization(defaultBootstrapKitSubstitute())),
+	}
+
 	h := &Handler{log: silentLogger(), kubeconfigsDir: dir}
-	return &testFixture{dir: dir, clients: clients, dep: dep, handler: h}
+	return &testFixture{
+		dir:                   dir,
+		clients:               clients,
+		dynClients:            dynClients,
+		primaryKubeconfigPath: primaryKubeconfigPath,
+		dep:                   dep,
+		handler:               h,
+	}
+}
+
+// ── ClusterMesh-gated cnpg-pair enable (#3236) — test helpers ───────
+
+// Canonical region labels matching the shape cloud-init stamps into the
+// bootstrap-kit substitute map on a 2-region prov (tftpl
+// primary_region_canonical_label / replica_region_canonical_label).
+const (
+	testPrimaryRegionLabel = "hw-mea-rtz-prod"
+	testReplicaRegionLabel = "hw-meb-rtz-prod"
+)
+
+// buildBootstrapKitKustomization returns the flux-system/bootstrap-kit
+// Kustomization (kustomize.toolkit.fluxcd.io/v1) shaped like the one
+// cloud-init applies (infra/providers/_shared/cloudinit-control-plane
+// .tftpl flux-bootstrap.yaml), carrying the given postBuild.substitute
+// map.
+func buildBootstrapKitKustomization(substitute map[string]any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata": map[string]any{
+			"name":      bootstrapKitKustomizationName,
+			"namespace": fluxSystemNamespace,
+		},
+		"spec": map[string]any{
+			"interval": "5m",
+			"path":     "./clusters/_template/bootstrap-kit",
+			"postBuild": map[string]any{
+				"substitute": substitute,
+			},
+		},
+	}}
+}
+
+// defaultBootstrapKitSubstitute mirrors the substitute keys a 2-region
+// prov carries: distinct, non-empty primary/replica regions. The cnpg-
+// pair gate key is ABSENT (the provisioner never registers it — Flux's
+// inline `:-false` default keeps slot 16b off until the flip).
+func defaultBootstrapKitSubstitute() map[string]any {
+	return map[string]any{
+		"SOVEREIGN_FQDN":                      "tcm.example.io",
+		"SOVEREIGN_ENABLE_HOT_STANDBY":        "true",
+		clusterMeshPrimaryRegionSubstituteKey: testPrimaryRegionLabel,
+		clusterMeshReplicaRegionSubstituteKey: testReplicaRegionLabel,
+	}
+}
+
+// newFakeKustomizationDynClient builds a fake dynamic client that knows
+// the Flux Kustomization GVR, seeded with the given objects.
+func newFakeKustomizationDynClient(t *testing.T, objs ...runtime.Object) dynamic.Interface {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Kind: "Kustomization",
+	}, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Kind: "KustomizationList",
+	}, &unstructured.UnstructuredList{})
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{fluxKustomizationGVR: "KustomizationList"},
+		objs...)
+}
+
+// installClusterMeshDynamicClientFactory mirrors
+// installClusterMeshClientFactory for the dynamic-client path used by
+// the cnpg-pair gate flip. Returns a restore func.
+func installClusterMeshDynamicClientFactory(clients map[string]dynamic.Interface) func() {
+	prev := clusterMeshTestDynamicClientFactory
+	clusterMeshTestDynamicClientFactory = func(kcPath string) (dynamic.Interface, bool) {
+		c, ok := clients[kcPath]
+		return c, ok
+	}
+	return func() { clusterMeshTestDynamicClientFactory = prev }
+}
+
+// getBootstrapKitKustomization re-reads the Kustomization from the fake
+// dynamic client so assertions observe post-patch state.
+func getBootstrapKitKustomization(t *testing.T, dyn dynamic.Interface) *unstructured.Unstructured {
+	t.Helper()
+	ks, err := dyn.Resource(fluxKustomizationGVR).Namespace(fluxSystemNamespace).
+		Get(context.Background(), bootstrapKitKustomizationName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get bootstrap-kit Kustomization: %v", err)
+	}
+	return ks
 }
 
 // ── tests ───────────────────────────────────────────────────────────
@@ -270,6 +385,8 @@ func TestAutoEstablishClusterMesh_HappyPath_TwoRegions(t *testing.T) {
 	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
 	restore := installClusterMeshClientFactory(fx.clients)
 	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -322,6 +439,8 @@ func TestAutoEstablishClusterMesh_LBAbsentInOneRegion(t *testing.T) {
 	fx := newTestFixture(t, []string{"203.0.113.10", ""})
 	restore := installClusterMeshClientFactory(fx.clients)
 	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
 	// Shrink the LB lookup timeout so the test isn't slow.
 	// (We reach into the package-level const indirectly via a test
 	// hook below.)
@@ -365,6 +484,8 @@ func TestAutoEstablishClusterMesh_Idempotent(t *testing.T) {
 	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
 	restore := installClusterMeshClientFactory(fx.clients)
 	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -433,5 +554,176 @@ func TestAutoEstablishClusterMesh_SingleRegionSkips(t *testing.T) {
 	}
 	if statuses != nil {
 		t.Errorf("statuses = %+v, want nil for single-region deployment", statuses)
+	}
+}
+
+// ── ClusterMesh-gated cnpg-pair enable (#3236) ──────────────────────
+
+// requireFullyMeshed asserts every region's ReadyAt is stamped — the
+// precondition the cnpg-pair flip tests rely on so a mesh regression
+// doesn't masquerade as a gate-flip regression.
+func requireFullyMeshed(t *testing.T, statuses []ClusterMeshStatus) {
+	t.Helper()
+	for _, st := range statuses {
+		if st.ReadyAt.IsZero() {
+			t.Fatalf("precondition: region %q not fully meshed (peers: %+v)", st.RegionKey, st.Peers)
+		}
+	}
+}
+
+// TestAutoEstablishClusterMesh_FullMeshFlipsCNPGPairGate — after a
+// CONFIRMED full-mesh establishment across both regions, the primary
+// region's flux-system/bootstrap-kit Kustomization must carry
+// postBuild.substitute.SOVEREIGN_ENABLE_CNPG_PAIR="true" plus the
+// reconcile.fluxcd.io/requestedAt annotation so slot 16b (bp-cnpg-pair)
+// deploys zero-touch on the next Flux reconcile. (#3236; the gate
+// itself exists because of hw124/#3196 — see the slot header in
+// clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml.)
+func TestAutoEstablishClusterMesh_FullMeshFlipsCNPGPairGate(t *testing.T) {
+	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	statuses, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep)
+	if err != nil {
+		t.Fatalf("AutoEstablishClusterMesh returned error: %v", err)
+	}
+	requireFullyMeshed(t, statuses)
+
+	ks := getBootstrapKitKustomization(t, fx.dynClients[fx.primaryKubeconfigPath])
+	substitute, found, err := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
+	if err != nil || !found {
+		t.Fatalf("read spec.postBuild.substitute: found=%v err=%v", found, err)
+	}
+	if got := substitute[clusterMeshCNPGPairSubstituteKey]; got != "true" {
+		t.Errorf("substitute[%s] = %q, want \"true\" after full mesh establishment",
+			clusterMeshCNPGPairSubstituteKey, got)
+	}
+	// The JSON merge patch must MERGE into the substitute map, never
+	// replace it — clobbering SOVEREIGN_PRIMARY_REGION/… would fail the
+	// chart's required-fail-fast and wedge the whole atomic apply.
+	if got := substitute[clusterMeshPrimaryRegionSubstituteKey]; got != testPrimaryRegionLabel {
+		t.Errorf("substitute[%s] = %q, want %q (patch clobbered sibling substitute keys)",
+			clusterMeshPrimaryRegionSubstituteKey, got, testPrimaryRegionLabel)
+	}
+	if got := substitute[clusterMeshReplicaRegionSubstituteKey]; got != testReplicaRegionLabel {
+		t.Errorf("substitute[%s] = %q, want %q (patch clobbered sibling substitute keys)",
+			clusterMeshReplicaRegionSubstituteKey, got, testReplicaRegionLabel)
+	}
+	stamp := ks.GetAnnotations()[fluxReconcileRequestedAtAnnotation]
+	if stamp == "" {
+		t.Fatalf("annotation %q absent — Flux reconcile never requested", fluxReconcileRequestedAtAnnotation)
+	}
+	if _, perr := time.Parse(time.RFC3339Nano, stamp); perr != nil {
+		t.Errorf("annotation %q = %q is not RFC3339Nano: %v", fluxReconcileRequestedAtAnnotation, stamp, perr)
+	}
+}
+
+// TestAutoEstablishClusterMesh_PartialMeshDoesNotFlipCNPGPairGate —
+// region B never gets a LoadBalancer IP, so the mesh is NOT fully
+// established. The gate flip must NOT happen (🛑 hw124/#3196 anti-
+// pattern guard: flipping on raw 2-region-ness — or on partial mesh —
+// renders a replica that can never stream its basebackup).
+func TestAutoEstablishClusterMesh_PartialMeshDoesNotFlipCNPGPairGate(t *testing.T) {
+	fx := newTestFixture(t, []string{"203.0.113.10", ""})
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+	prev := clusterMeshTestOverrideLBTimeout
+	clusterMeshTestOverrideLBTimeout = 200 * time.Millisecond
+	defer func() { clusterMeshTestOverrideLBTimeout = prev }()
+	prevInt := clusterMeshTestOverrideLBInterval
+	clusterMeshTestOverrideLBInterval = 25 * time.Millisecond
+	defer func() { clusterMeshTestOverrideLBInterval = prevInt }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if _, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep); err != nil {
+		t.Fatalf("AutoEstablishClusterMesh returned error: %v", err)
+	}
+
+	ks := getBootstrapKitKustomization(t, fx.dynClients[fx.primaryKubeconfigPath])
+	substitute, _, _ := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
+	if got, ok := substitute[clusterMeshCNPGPairSubstituteKey]; ok {
+		t.Errorf("substitute[%s] = %q — gate flipped on PARTIAL mesh (hw124/#3196 anti-pattern)",
+			clusterMeshCNPGPairSubstituteKey, got)
+	}
+	if stamp := ks.GetAnnotations()[fluxReconcileRequestedAtAnnotation]; stamp != "" {
+		t.Errorf("annotation %q = %q set despite partial mesh — reconcile must not be requested",
+			fluxReconcileRequestedAtAnnotation, stamp)
+	}
+}
+
+// TestAutoEstablishClusterMesh_SubstitutePreconditionBlocksCNPGPairFlip
+// — even on a fully-established mesh, the flip is refused when the
+// substitute map's SOVEREIGN_PRIMARY_REGION / SOVEREIGN_REPLICA_REGION
+// are absent, empty, or equal: the bp-cnpg-pair chart `required`s
+// distinct non-empty regions when enabled=true, and a render failure
+// inside the bootstrap-kit Kustomization fails the WHOLE atomic apply
+// (0 HRs). A loud warning must be logged so the gap is debuggable.
+func TestAutoEstablishClusterMesh_SubstitutePreconditionBlocksCNPGPairFlip(t *testing.T) {
+	cases := []struct {
+		name       string
+		substitute map[string]any
+	}{
+		{
+			name: "replica-region-missing",
+			substitute: map[string]any{
+				"SOVEREIGN_FQDN":                      "tcm.example.io",
+				clusterMeshPrimaryRegionSubstituteKey: testPrimaryRegionLabel,
+			},
+		},
+		{
+			name: "regions-equal",
+			substitute: map[string]any{
+				"SOVEREIGN_FQDN":                      "tcm.example.io",
+				clusterMeshPrimaryRegionSubstituteKey: testPrimaryRegionLabel,
+				clusterMeshReplicaRegionSubstituteKey: testPrimaryRegionLabel,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
+			fx.dynClients[fx.primaryKubeconfigPath] = newFakeKustomizationDynClient(t,
+				buildBootstrapKitKustomization(tc.substitute))
+			var logBuf bytes.Buffer
+			fx.handler.log = slog.New(slog.NewTextHandler(&logBuf, nil))
+			restore := installClusterMeshClientFactory(fx.clients)
+			defer restore()
+			restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+			defer restoreDyn()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			statuses, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep)
+			if err != nil {
+				t.Fatalf("AutoEstablishClusterMesh returned error: %v", err)
+			}
+			requireFullyMeshed(t, statuses)
+
+			ks := getBootstrapKitKustomization(t, fx.dynClients[fx.primaryKubeconfigPath])
+			substitute, _, _ := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
+			if got, ok := substitute[clusterMeshCNPGPairSubstituteKey]; ok {
+				t.Errorf("substitute[%s] = %q — gate flipped despite failed region precondition",
+					clusterMeshCNPGPairSubstituteKey, got)
+			}
+			if stamp := ks.GetAnnotations()[fluxReconcileRequestedAtAnnotation]; stamp != "" {
+				t.Errorf("annotation %q = %q set despite failed region precondition",
+					fluxReconcileRequestedAtAnnotation, stamp)
+			}
+			if !strings.Contains(logBuf.String(), "refusing to flip SOVEREIGN_ENABLE_CNPG_PAIR") {
+				t.Errorf("expected loud warning containing %q in log output, got:\n%s",
+					"refusing to flip SOVEREIGN_ENABLE_CNPG_PAIR", logBuf.String())
+			}
+		})
 	}
 }


### PR DESCRIPTION
Refs #3236 #2737

## What

After catalyst-api's AutoEstablishClusterMesh reaches FULL success (every region's peer set Connected — ReadyAt stamped on ALL regions), it now patches the PRIMARY region's flux-system/bootstrap-kit Flux Kustomization (the object cloud-init applies from infra/providers/_shared/cloudinit-control-plane.tftpl):

1. JSON merge patch sets spec.postBuild.substitute SOVEREIGN_ENABLE_CNPG_PAIR="true" (merge semantics preserve every sibling substitute key — asserted in tests).
2. The same patch stamps reconcile.fluxcd.io/requestedAt with an RFC3339Nano timestamp so Flux reconciles immediately.

Result: the cross-region CNPG pair (slot 16b, clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml) deploys zero-touch, gated on ACTUAL mesh readiness.

## How the Kustomization is located + patched

- Name/namespace come from the cloud-init flux-bootstrap writeup: Kustomization bootstrap-kit in flux-system (kustomize.toolkit.fluxcd.io/v1).
- Addressed via the dynamic client (no Flux Go types vendored): production path reads the primary kubeconfig from disk and uses helmwatch.NewDynamicClientFromKubeconfig; tests inject a fake via a factory override mirroring the existing typed-client hook.
- Patch type is types.MergePatchType (RFC 7386) — custom resources do not support strategic merge, and merge patch merges nested objects key-by-key, so the substitute map and existing annotations are never clobbered.

## Anti-pattern guard enforcement (the reason this gate exists — hw124/#3196)

- The flip is invoked from exactly one site: the tail of AutoEstablishClusterMesh, behind totalReady == len(statuses) (every region fully meshed). Partial success and single-region paths leave the substitute untouched (test-asserted).
- Defense per the chart's required-fail-fast: before flipping, the substitute map must already carry non-empty, DISTINCT SOVEREIGN_PRIMARY_REGION / SOVEREIGN_REPLICA_REGION (cloud-init stamps both on 2-region provs). If absent/equal, the flip is REFUSED with a loud warning + a clustermesh-progress warn event — a render failure inside the bootstrap-kit Kustomization would fail the whole atomic apply (0 HRs).
- Scope guard: only SOVEREIGN_ENABLE_CNPG_PAIR is touched. SOVEREIGN_ENABLE_SHARED_PG and the *_PG_OWN_CLUSTER flags are #3188 scope and untouched.
- Idempotency: re-running merges the same key to the same value; the annotation just re-requests a reconcile.

## TDD (fail -> pass shown)

New tests in clustermesh_test.go (fake dynamic client seeded with the bootstrap-kit Kustomization, keyed by kubeconfig path like the existing typed harness):

- TestAutoEstablishClusterMesh_FullMeshFlipsCNPGPairGate — gate key = "true", sibling substitute keys preserved, reconcile annotation present + RFC3339Nano-parseable.
- TestAutoEstablishClusterMesh_PartialMeshDoesNotFlipCNPGPairGate — LB absent in region B: no flip, no annotation.
- TestAutoEstablishClusterMesh_SubstitutePreconditionBlocksCNPGPairFlip — replica-region-missing + regions-equal subcases: no flip, no annotation, loud warning captured from the slog output.

Red stage was run with declarations only (assertions failed exactly on the missing flip/warning), then the implementation turned all 7 clustermesh tests green. Full gate: go build ./... clean; go test ./internal/handler/... green (60s, full suite); go vet + gofmt clean.

## Follow-up (no chart change shipped here)

None required: slot 16b already gates on SOVEREIGN_ENABLE_CNPG_PAIR with an inline :-false default, so this PR is Go-only and no lockstep chart version bump is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
