### PR TITLE
fix(powerdns-admin): pass kyverno Enforce admission on fresh prov (Refs #2737)

### DIFF
--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -99,7 +99,10 @@ spec:
       # 0.1.5 (#3150, 2026-06-10): silent-SSO logged-in — correct OIDC env-var
       # names (OIDC_OAUTH_USERNAME/_FIRSTNAME/_LAST_NAME/_EMAIL) + name claims
       # point at preferred_username (catalyst-pin carries no given_name).
-      version: 0.1.6
+      # 0.1.7 (#2737, 2026-06-11): add `policy.cilium.io/enforced: "true"` to
+      # the Pod template — kyverno cilium-l7-mtls Enforce denied the Deployment
+      # on the hw126 fresh prov (first time it reached admission).
+      version: 0.1.7
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns-admin

--- a/platform/powerdns-admin/blueprint.yaml
+++ b/platform/powerdns-admin/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 0.1.6
+  version: 0.1.7
   card:
     title: powerdns-admin
     summary: |

--- a/platform/powerdns-admin/chart/Chart.yaml
+++ b/platform/powerdns-admin/chart/Chart.yaml
@@ -36,7 +36,15 @@ name: bp-powerdns-admin
 #     live on hw124: console Open → pdns-admin.<fqdn>/oidc/login → KC silent →
 #     lands on the PDA Dashboard logged-in, no login form
 #     (docs/sessions/2026-06-10/evidence/hw124-powerdns-admin-loggedin.png).
-version: 0.1.6
+# 0.1.7 (Refs #2737, 2026-06-11): pass the kyverno Enforce admission on a
+# fresh Sovereign. bp-powerdns-admin reached kyverno admission for the FIRST
+# time on the hw126 fresh prov (prior provs wedged upstream) and was DENIED
+# by the baseline cilium-l7-mtls / cilium-enforced-label rule — the Pod
+# template was missing `policy.cilium.io/enforced: "true"`. Add the label to
+# spec.template.metadata.labels, mirroring the bp-sso-bridge + catalyst chart
+# idiom. The container image already pulls through the Harbor proxy
+# (harbor.openova.io/proxy-dockerhub/…, #3150) so it satisfies harbor-proxy-pull.
+version: 0.1.7
 description: |
   PowerDNS-Admin (ngoduykhanh/powerdns-admin) web UI Blueprint for
   per-Sovereign PowerDNS zone + record management. Drives the

--- a/platform/powerdns-admin/chart/templates/deployment.yaml
+++ b/platform/powerdns-admin/chart/templates/deployment.yaml
@@ -21,6 +21,13 @@ spec:
         app.kubernetes.io/name: bp-powerdns-admin
         app.kubernetes.io/instance: {{ .Release.Name }}
         catalyst.openova.io/blueprint: bp-powerdns-admin
+        # kyverno cilium-l7-mtls / cilium-enforced-label (baseline policy
+        # 09-cilium-l7-mtls): every Deployment/StatefulSet/DaemonSet Pod
+        # template must carry this label so the catalyst-network controller
+        # attaches the Pod to the L7 mTLS mesh. Without it the Enforce
+        # admission DENIES the Deployment — caught on the hw126 fresh prov,
+        # the first time bp-powerdns-admin ever reached kyverno admission.
+        policy.cilium.io/enforced: "true"
     spec:
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}


### PR DESCRIPTION
## What
`bp-powerdns-admin` reached kyverno admission for the first time on the hw126 fresh prov (prior provs wedged upstream) and the Enforce action DENIED `Deployment/powerdns-admin-bp-powerdns-admin`.

Two baseline ClusterPolicies were named in the deny:

1. **`cilium-l7-mtls` / rule `cilium-enforced-label`** (`platform/kyverno-policies/chart/templates/baseline/09-cilium-l7-mtls.yaml`) — the Pod template was missing the label `policy.cilium.io/enforced: "true"` on `spec.template.metadata.labels`.
2. **`harbor-proxy-pull` / rule `image-must-be-from-harbor-proxy`** (`platform/kyverno-policies/chart/templates/baseline/11-harbor-proxy.yaml`) — image must match `*/proxy-*/*` or `*/openova-io/*`.

## Fix
- `templates/deployment.yaml`: add `policy.cilium.io/enforced: "true"` to the Pod template labels (`spec.template.metadata.labels`), mirroring the established idiom in `platform/sso-bridge/chart` and `products/catalyst/chart`.
- The container image was already routed through the Harbor dockerhub proxy (`harbor.openova.io/proxy-dockerhub/powerdnsadmin/pda-legacy:0.4.2`) by #3150, and the CNPG postgres image through `harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16`. Both already match the `*/proxy-*/*` glob, so `image-must-be-from-harbor-proxy` was already satisfied on main; no image re-point was needed.
- The only Pod-bearing resource the two policies match (`Deployment`/`StatefulSet`/`DaemonSet`/`Job`/`CronJob`/`Pod`) in this chart is the `Deployment`. The CNPG `Cluster` CR is not in the match-kinds.
- Lockstep version bump `0.1.6` -> `0.1.7` in `Chart.yaml`, `blueprint.yaml`, and the bootstrap-kit slot pin `clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml`.

## Verify
```
$ helm template platform/powerdns-admin/chart --set gateway.host=pdns-admin.example.com 2>/dev/null | grep -E "image:|policy.cilium.io"
        policy.cilium.io/enforced: "true"
          image: "harbor.openova.io/proxy-dockerhub/powerdnsadmin/pda-legacy:0.4.2"

$ helm lint platform/powerdns-admin/chart
1 chart(s) linted, 0 chart(s) failed
```
Every rendered image starts with `harbor.openova.io/` and the Deployment Pod template carries the enforced label.

Refs #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)
