### PR TITLE
fix(catalyst-api): level-triggered ClusterMesh reconcile + kill the silent per-region failure path

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -161,6 +161,28 @@ const (
 	clusterMeshPeerCertValidity = 365 * 24 * time.Hour
 )
 
+// Level-triggered ClusterMesh reconcile defaults (#3241). hw126
+// (c986326a77d391d4) proved the one-shot fan-out loses the race
+// against LB-IPAM: the primary's clustermesh-apiserver LB IP landed
+// seconds AFTER the single 3-second fan-out gave up, and nothing ever
+// re-ran the establish (next trigger = handover), so a healthy cluster
+// stayed partially meshed forever — and the #3236 cnpg-pair flip
+// correctly refused forever with it. The runAutoEstablishClusterMesh
+// wrapper therefore loops until fully meshed: exponential backoff from
+// the initial value, capped at the max, bounded by the total budget.
+// The Handler fields clusterMeshRetry* override these for tests; zero
+// falls back to the defaults below.
+const (
+	clusterMeshRetryInitialBackoffDefault = 1 * time.Minute
+	clusterMeshRetryMaxBackoffDefault     = 5 * time.Minute
+	clusterMeshRetryBudgetDefault         = 6 * time.Hour
+	// Per-attempt bound: the orchestrator's per-region LB lookup is
+	// the longest internal wait (5 min). Three regions x 5 min worst
+	// case is ~15 min; pad to 20 min for the per-peer cert mint +
+	// Patch stack.
+	clusterMeshAttemptTimeoutDefault = 20 * time.Minute
+)
+
 // ClusterMesh-gated cnpg-pair enable (#3236) — names of the Flux
 // objects/keys the post-mesh gate flip touches. The bootstrap-kit
 // Kustomization is the one cloud-init applies on every control plane
@@ -275,6 +297,32 @@ func (h *Handler) AutoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 	h.emitClusterMeshProgress(dep, "info",
 		fmt.Sprintf("ClusterMesh auto-establish: starting fan-out across %d regions", len(slots)))
 
+	// Surface slots that failed during buildRegionSlots (kubeconfig
+	// path empty / unreadable / client-build failure) BEFORE the
+	// fan-out. These slots enter Steps 1-3 with err pre-set and every
+	// step `continue`s past them before its first emit — on hw126
+	// (#3241) region-A failed exactly here and produced ZERO events
+	// (no "LB ready", no failure) while region-B reported "wired 0/1
+	// peers"; the operator had no way to tell the region's failure-
+	// source from the stream. G91 lesson: a call whose failure has
+	// domain meaning must never vanish into a server-side log only —
+	// every per-region failure emits a clustermesh-progress warn event
+	// carrying the region key + error string.
+	for i := range slots {
+		s := &slots[i]
+		if s.err == nil {
+			continue
+		}
+		h.log.Warn("clustermesh: region slot failed before fan-out",
+			"id", dep.ID,
+			"region", s.key,
+			"cluster", s.clusterName,
+			"err", s.err,
+		)
+		h.emitClusterMeshProgress(dep, "warn",
+			fmt.Sprintf("ClusterMesh: region %q (cluster %q) unreachable before fan-out (%v) — peers will be marked disconnected", s.key, s.clusterName, s.err))
+	}
+
 	// Step 1: per-region LB IP discovery (poll up to 5 min each).
 	for i := range slots {
 		s := &slots[i]
@@ -352,6 +400,12 @@ func (h *Handler) AutoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 				})
 			}
 			statuses = append(statuses, st)
+			// Terminal per-region event for the failed slot — the
+			// healthy regions get "wired N/M peers" below; without
+			// this emit a failed region ends the attempt with no
+			// terminal line at all (the hw126/#3241 silence shape).
+			h.emitClusterMeshProgress(dep, "warn",
+				fmt.Sprintf("ClusterMesh: region %q skipped — region unreachable (%v); wired 0/%d peers", a.key, a.err, len(slots)-1))
 			continue
 		}
 
@@ -543,12 +597,7 @@ func (h *Handler) AutoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 		return statuses[i].RegionKey < statuses[j].RegionKey
 	})
 
-	totalReady := 0
-	for _, st := range statuses {
-		if !st.ReadyAt.IsZero() {
-			totalReady++
-		}
-	}
+	totalReady := countFullyMeshedRegions(statuses)
 	h.emitClusterMeshProgress(dep, "info",
 		fmt.Sprintf("ClusterMesh auto-establish: completed (%d/%d regions fully meshed)", totalReady, len(statuses)))
 
@@ -1260,6 +1309,67 @@ func (h *Handler) rolloutRestartClusterMeshTargets(ctx context.Context, dep *Dep
 			)
 		}
 	}
+}
+
+// countFullyMeshedRegions returns how many regions in the status
+// summary reached the fully-meshed state (every peer Connected —
+// AutoEstablishClusterMesh stamps ReadyAt exactly then). The
+// runAutoEstablishClusterMesh reconcile loop uses this as its
+// level-trigger condition (#3241): retry until the count equals the
+// region total.
+func countFullyMeshedRegions(statuses []ClusterMeshStatus) int {
+	n := 0
+	for _, st := range statuses {
+		if !st.ReadyAt.IsZero() {
+			n++
+		}
+	}
+	return n
+}
+
+// shouldStartupClusterMeshReconcile reports whether a rehydrated
+// deployment needs the level-triggered ClusterMesh reconcile loop
+// kicked at catalyst-api startup (#3241): status=ready AND >1 region
+// AND the primary kubeconfig file still readable on the PVC. This is
+// what heals an hw126-shaped Sovereign zero-touch on the next
+// mothership roll — Phase 1 terminated long ago, so nothing else ever
+// re-fires the establish, and a partially-meshed cluster would
+// otherwise stay partial until handover.
+//
+// The kubeconfig guard is warn-and-skip, not fail: a ready record
+// whose kubeconfig file was lost across the restart (PVC unmount /
+// wipe race) would otherwise spin the whole retry budget against
+// "kubeconfig path empty". Fully-meshed deployments pass this check
+// too — the loop's first attempt is a cheap idempotent re-run that
+// confirms full mesh and exits.
+func (h *Handler) shouldStartupClusterMeshReconcile(dep *Deployment) bool {
+	dep.mu.Lock()
+	status := dep.Status
+	regionCount := len(dep.Request.Regions)
+	kubeconfigPath := ""
+	if dep.Result != nil {
+		kubeconfigPath = dep.Result.KubeconfigPath
+	}
+	dep.mu.Unlock()
+	if status != "ready" || regionCount < 2 {
+		return false
+	}
+	if kubeconfigPath == "" {
+		h.log.Warn("clustermesh: startup reconcile skipped — primary kubeconfig path empty on ready multi-region deployment",
+			"id", dep.ID,
+			"regions", regionCount,
+		)
+		return false
+	}
+	if _, err := os.Stat(kubeconfigPath); err != nil {
+		h.log.Warn("clustermesh: startup reconcile skipped — primary kubeconfig unreadable",
+			"id", dep.ID,
+			"path", kubeconfigPath,
+			"err", err,
+		)
+		return false
+	}
+	return true
 }
 
 // emitClusterMeshProgress pushes a typed SSE event onto the deployment

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -25,6 +25,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
 	"log/slog"
 	"math/big"
 	"os"
@@ -45,6 +46,7 @@ import (
 	kfake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
 )
 
 // ── test helpers ────────────────────────────────────────────────────
@@ -474,6 +476,380 @@ func TestAutoEstablishClusterMesh_LBAbsentInOneRegion(t *testing.T) {
 	}
 	if connectedFalse == 0 {
 		t.Errorf("expected at least one Connected=false peer when one region has no LB IP; got none")
+	}
+
+	// #3241 — the LB-never-appeared failure must be visible in the
+	// clustermesh-progress event stream WITH the failing region's key,
+	// not only in server-side logs (G91 lesson).
+	regionKey := regionKeyFromSpec(fx.dep.Request.Regions[1], 1)
+	if !hasClusterMeshEvent(fx.dep, "warn", regionKey, "LB lookup failed") {
+		t.Errorf("expected a warn clustermesh-progress event carrying region key %q + %q; events:\n%s",
+			regionKey, "LB lookup failed", dumpClusterMeshEvents(fx.dep))
+	}
+}
+
+// ── Level-triggered reconcile + silent-path kill (#3241) ────────────
+
+// hasClusterMeshEvent reports whether the deployment's durable event
+// buffer carries a clustermesh-progress event at the given level whose
+// message contains EVERY substring.
+func hasClusterMeshEvent(dep *Deployment, level string, substrs ...string) bool {
+	for _, ev := range dep.snapshotEvents() {
+		if ev.Phase != clusterMeshPhase {
+			continue
+		}
+		if level != "" && ev.Level != level {
+			continue
+		}
+		all := true
+		for _, s := range substrs {
+			if !strings.Contains(ev.Message, s) {
+				all = false
+				break
+			}
+		}
+		if all {
+			return true
+		}
+	}
+	return false
+}
+
+// dumpClusterMeshEvents renders the clustermesh-progress events for
+// failure messages.
+func dumpClusterMeshEvents(dep *Deployment) string {
+	var sb strings.Builder
+	for _, ev := range dep.snapshotEvents() {
+		if ev.Phase != clusterMeshPhase {
+			continue
+		}
+		sb.WriteString(ev.Level)
+		sb.WriteString(": ")
+		sb.WriteString(ev.Message)
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+// waitForClusterMeshEvent polls the durable event buffer until an event
+// matching level+substrings appears or the timeout elapses.
+func waitForClusterMeshEvent(t *testing.T, dep *Deployment, timeout time.Duration, level string, substrs ...string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if hasClusterMeshEvent(dep, level, substrs...) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("no %s clustermesh-progress event containing %v within %s; events:\n%s",
+		level, substrs, timeout, dumpClusterMeshEvents(dep))
+}
+
+// TestAutoEstablishClusterMesh_RegionSlotFailureEmitsEventWithRegionKey
+// — the hw126 silence shape (#3241): a region whose slot fails during
+// buildRegionSlots (kubeconfig path empty / unreadable) used to enter
+// the fan-out with err pre-set and produce ZERO events — Steps 1-3 all
+// `continue` past failed slots before their first emit, so the region
+// simply vanished from the operator's stream while its peer reported
+// "wired 0/1 peers". Every per-region failure MUST emit a
+// clustermesh-progress warn event carrying the region key + the error
+// string.
+func TestAutoEstablishClusterMesh_RegionSlotFailureEmitsEventWithRegionKey(t *testing.T) {
+	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
+	// Break region B's kubeconfig resolution entirely: drop the
+	// explicit map entry AND the on-disk file so buildRegionSlots's
+	// filesystem fallback misses too — the slot enters the fan-out
+	// with err pre-set ("kubeconfig path empty ...").
+	regionKey := regionKeyFromSpec(fx.dep.Request.Regions[1], 1)
+	brokenPath := fx.dep.secondaryKubeconfigPaths[regionKey]
+	delete(fx.dep.secondaryKubeconfigPaths, regionKey)
+	if err := os.Remove(brokenPath); err != nil {
+		t.Fatalf("remove secondary kubeconfig: %v", err)
+	}
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	statuses, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep)
+	if err != nil {
+		t.Fatalf("AutoEstablishClusterMesh returned error: %v", err)
+	}
+	if got := countFullyMeshedRegions(statuses); got != 0 {
+		t.Errorf("fully meshed regions = %d, want 0 when one slot is broken", got)
+	}
+
+	// The pre-fan-out slot failure must surface with the region key +
+	// error string.
+	if !hasClusterMeshEvent(fx.dep, "warn", regionKey, "kubeconfig") {
+		t.Errorf("expected a warn clustermesh-progress event carrying region key %q + the kubeconfig error; events:\n%s",
+			regionKey, dumpClusterMeshEvents(fx.dep))
+	}
+	// And the failed region must get a terminal per-region line too —
+	// the healthy region gets "wired N/M peers"; the broken one must
+	// not end the attempt silently.
+	if !hasClusterMeshEvent(fx.dep, "warn", regionKey, "skipped") {
+		t.Errorf("expected a terminal warn event for skipped region %q; events:\n%s",
+			regionKey, dumpClusterMeshEvents(fx.dep))
+	}
+}
+
+// TestRunAutoEstablishClusterMesh_RetryConvergesAfterLBAppears — the
+// level-triggered reconcile (#3241). Attempt 1 sees region-A (primary)
+// WITHOUT a LoadBalancer IP (the hw126 LB-IPAM race) and ends
+// partially meshed; the test then stamps the LB IP onto the fake
+// Service (LB-IPAM "catching up") and the retry loop must converge to
+// fully meshed, land the #3236 cnpg-pair flip, emit per-attempt
+// progress events, and stop cleanly with a final success event.
+func TestRunAutoEstablishClusterMesh_RetryConvergesAfterLBAppears(t *testing.T) {
+	fx := newTestFixture(t, []string{"", "203.0.113.20"})
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+
+	// Fast knobs: sub-second LB poll + retry backoff so the loop
+	// converges in milliseconds.
+	prev := clusterMeshTestOverrideLBTimeout
+	clusterMeshTestOverrideLBTimeout = 150 * time.Millisecond
+	defer func() { clusterMeshTestOverrideLBTimeout = prev }()
+	prevInt := clusterMeshTestOverrideLBInterval
+	clusterMeshTestOverrideLBInterval = 25 * time.Millisecond
+	defer func() { clusterMeshTestOverrideLBInterval = prevInt }()
+	fx.handler.clusterMeshRetryInitialBackoff = 20 * time.Millisecond
+	fx.handler.clusterMeshRetryMaxBackoff = 60 * time.Millisecond
+	fx.handler.clusterMeshRetryBudget = 20 * time.Second
+	fx.handler.clusterMeshAttemptTimeout = 5 * time.Second
+
+	// Once attempt 1 reports partial mesh, stamp the missing LB IP —
+	// the level-trigger's whole point is that a later-arriving IP
+	// still converges without any external re-trigger.
+	flipDone := make(chan error, 1)
+	go func() {
+		deadline := time.Now().Add(15 * time.Second)
+		for time.Now().Before(deadline) {
+			if hasClusterMeshEvent(fx.dep, "warn", "retrying in") {
+				cs := fx.clients[fx.primaryKubeconfigPath]
+				svc, err := cs.CoreV1().Services(clusterMeshNamespace).Get(context.Background(), clusterMeshApiserverService, metav1.GetOptions{})
+				if err != nil {
+					flipDone <- err
+					return
+				}
+				svc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "203.0.113.10"}}
+				_, err = cs.CoreV1().Services(clusterMeshNamespace).Update(context.Background(), svc, metav1.UpdateOptions{})
+				flipDone <- err
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		flipDone <- fmt.Errorf("never observed a retry progress event")
+	}()
+
+	loopDone := make(chan struct{})
+	go func() {
+		fx.handler.runAutoEstablishClusterMesh(fx.dep)
+		close(loopDone)
+	}()
+	select {
+	case <-loopDone:
+	case <-time.After(25 * time.Second):
+		t.Fatalf("reconcile loop did not terminate; events:\n%s", dumpClusterMeshEvents(fx.dep))
+	}
+	if err := <-flipDone; err != nil {
+		t.Fatalf("LB flip goroutine: %v", err)
+	}
+
+	// Per-attempt progress event (attempt N, fullyMeshed X/Y).
+	if !hasClusterMeshEvent(fx.dep, "warn", "attempt 1 ended with", "regions fully meshed", "retrying in") {
+		t.Errorf("expected per-attempt retry progress event; events:\n%s", dumpClusterMeshEvents(fx.dep))
+	}
+	// Final success event — the loop stops cleanly once fully meshed.
+	if !hasClusterMeshEvent(fx.dep, "info", "fully meshed (2/2 regions)", "reconcile loop complete") {
+		t.Errorf("expected final success event after convergence; events:\n%s", dumpClusterMeshEvents(fx.dep))
+	}
+
+	// The mesh actually converged: both regions carry the 4 peer
+	// Secret entries.
+	for kcPath, client := range fx.clients {
+		secret, err := client.CoreV1().Secrets(clusterMeshNamespace).Get(context.Background(), clusterMeshSecretName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Get cilium-clustermesh in %q: %v", kcPath, err)
+		}
+		if len(secret.Data) != 4 {
+			t.Errorf("Secret in %q has %d entries, want 4 (keys %v)", kcPath, len(secret.Data), secretKeys(secret))
+		}
+	}
+
+	// And the #3236 cnpg-pair flip landed on the converged attempt.
+	ks := getBootstrapKitKustomization(t, fx.dynClients[fx.primaryKubeconfigPath])
+	substitute, found, err := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
+	if err != nil || !found {
+		t.Fatalf("read spec.postBuild.substitute: found=%v err=%v", found, err)
+	}
+	if got := substitute[clusterMeshCNPGPairSubstituteKey]; got != "true" {
+		t.Errorf("substitute[%s] = %q, want \"true\" after retry convergence",
+			clusterMeshCNPGPairSubstituteKey, got)
+	}
+}
+
+// TestRestoreFromStore_StartupKicksClusterMeshReconcile — #3241 part 2:
+// a stored status=ready multi-region deployment whose Phase-1 already
+// terminated gets the level-triggered reconcile loop kicked at
+// catalyst-api startup (this is what heals an hw126-shaped Sovereign
+// zero-touch on the next mothership roll — nothing else ever re-fires
+// the establish before handover).
+func TestRestoreFromStore_StartupKicksClusterMeshReconcile(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "") // mothership mode for chrootEnsureSMEPoolSeed
+	dir := t.TempDir()
+	caCert, caKey := genCAForTest(t, "test-mesh-ca")
+
+	depID := "depstartupmesh"
+	regions := []provisioner.RegionSpec{
+		{Provider: "hetzner", CloudRegion: "fsn1"},
+		{Provider: "hetzner", CloudRegion: "hel1"},
+	}
+	lbIPs := []string{"203.0.113.30", "203.0.113.40"}
+	clients := map[string]kubernetes.Interface{}
+	for i := range regions {
+		key := regionKeyFromSpec(regions[i], i)
+		kcPath := writeFakeKubeconfig(t, dir, depID, key)
+		clients[kcPath] = buildFakeClusterMeshCluster(t, lbIPs[i], caCert, caKey)
+	}
+	primaryKubeconfigPath := filepath.Join(dir, depID+".yaml")
+	dynClients := map[string]dynamic.Interface{
+		primaryKubeconfigPath: newFakeKustomizationDynClient(t,
+			buildBootstrapKitKustomization(defaultBootstrapKitSubstitute())),
+	}
+	restore := installClusterMeshClientFactory(clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(dynClients)
+	defer restoreDyn()
+
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	phase1Done := time.Now().Add(-1 * time.Hour).UTC()
+	rec := store.Record{
+		ID:     depID,
+		Status: "ready",
+		Request: store.Redact(provisioner.Request{
+			SovereignFQDN: "tsm.example.io",
+			Regions:       regions,
+		}),
+		Result: &provisioner.Result{
+			SovereignFQDN:    "tsm.example.io",
+			KubeconfigPath:   primaryKubeconfigPath,
+			Phase1FinishedAt: &phase1Done, // Phase-1 terminated → no watch resume; startup kick owns the re-establish
+		},
+		StartedAt:  time.Now().Add(-2 * time.Hour),
+		FinishedAt: time.Now().Add(-90 * time.Minute),
+	}
+	if err := st.Save(rec); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+
+	h := &Handler{log: silentLogger(), kubeconfigsDir: dir, store: st}
+	h.clusterMeshRetryInitialBackoff = 20 * time.Millisecond
+	h.clusterMeshRetryMaxBackoff = 60 * time.Millisecond
+	h.clusterMeshRetryBudget = 20 * time.Second
+	h.clusterMeshAttemptTimeout = 5 * time.Second
+
+	h.restoreFromStore()
+
+	val, ok := h.deployments.Load(depID)
+	if !ok {
+		t.Fatalf("deployment %q not restored", depID)
+	}
+	dep := val.(*Deployment)
+
+	// The startup-kicked loop must run the establish and converge —
+	// success event lands on the rehydrated record's durable buffer.
+	waitForClusterMeshEvent(t, dep, 10*time.Second, "info", "fully meshed (2/2 regions)", "reconcile loop complete")
+
+	// Establish was genuinely invoked: peer Secrets written in both
+	// fake regions + the #3236 flip landed.
+	for kcPath, client := range clients {
+		secret, err := client.CoreV1().Secrets(clusterMeshNamespace).Get(context.Background(), clusterMeshSecretName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Get cilium-clustermesh in %q: %v", kcPath, err)
+		}
+		if len(secret.Data) != 4 {
+			t.Errorf("Secret in %q has %d entries, want 4 (keys %v)", kcPath, len(secret.Data), secretKeys(secret))
+		}
+	}
+	ks := getBootstrapKitKustomization(t, dynClients[primaryKubeconfigPath])
+	substitute, _, _ := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
+	if got := substitute[clusterMeshCNPGPairSubstituteKey]; got != "true" {
+		t.Errorf("substitute[%s] = %q, want \"true\" after startup reconcile",
+			clusterMeshCNPGPairSubstituteKey, got)
+	}
+}
+
+// TestShouldStartupClusterMeshReconcile_Guards — warn-and-skip
+// per-deployment guards: single-region, non-ready, and
+// missing-kubeconfig deployments never get the loop kicked.
+func TestShouldStartupClusterMeshReconcile_Guards(t *testing.T) {
+	dir := t.TempDir()
+	h := &Handler{log: silentLogger(), kubeconfigsDir: dir}
+	kcPath := filepath.Join(dir, "depguard.yaml")
+	if err := os.WriteFile(kcPath, []byte("apiVersion: v1\nkind: Config\n"), 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+	twoRegions := []provisioner.RegionSpec{
+		{Provider: "hetzner", CloudRegion: "fsn1"},
+		{Provider: "hetzner", CloudRegion: "hel1"},
+	}
+	cases := []struct {
+		name string
+		dep  *Deployment
+		want bool
+	}{
+		{
+			name: "ready-two-region-kubeconfig-present",
+			dep: &Deployment{ID: "g1", Status: "ready",
+				Request: provisioner.Request{Regions: twoRegions},
+				Result:  &provisioner.Result{KubeconfigPath: kcPath}},
+			want: true,
+		},
+		{
+			name: "single-region-skipped",
+			dep: &Deployment{ID: "g2", Status: "ready",
+				Request: provisioner.Request{Regions: twoRegions[:1]},
+				Result:  &provisioner.Result{KubeconfigPath: kcPath}},
+			want: false,
+		},
+		{
+			name: "failed-status-skipped",
+			dep: &Deployment{ID: "g3", Status: "failed",
+				Request: provisioner.Request{Regions: twoRegions},
+				Result:  &provisioner.Result{KubeconfigPath: kcPath}},
+			want: false,
+		},
+		{
+			name: "kubeconfig-missing-warn-and-skip",
+			dep: &Deployment{ID: "g4", Status: "ready",
+				Request: provisioner.Request{Regions: twoRegions},
+				Result:  &provisioner.Result{KubeconfigPath: filepath.Join(dir, "absent.yaml")}},
+			want: false,
+		},
+		{
+			name: "result-nil-warn-and-skip",
+			dep: &Deployment{ID: "g5", Status: "ready",
+				Request: provisioner.Request{Regions: twoRegions}},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := h.shouldStartupClusterMeshReconcile(tc.dep); got != tc.want {
+				t.Errorf("shouldStartupClusterMeshReconcile = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -526,6 +526,7 @@ func (h *Handler) restoreFromStore() {
 	}
 
 	resumed := 0
+	meshReconciles := 0
 	for _, rec := range records {
 		dep := fromRecord(rec)
 		h.deployments.Store(dep.ID, dep)
@@ -583,6 +584,20 @@ func (h *Handler) restoreFromStore() {
 		if h.shouldResumePhase1(dep, rec) {
 			resumed++
 			h.resumePhase1Watch(dep)
+		} else if h.shouldStartupClusterMeshReconcile(dep) {
+			// #3241 — level-triggered ClusterMesh reconcile on startup.
+			// A ready multi-region deployment whose Phase-1 terminated
+			// on a previous Pod gets the same retry loop markPhase1Done
+			// fires, so a partially-meshed Sovereign (hw126 shape: the
+			// one-shot fan-out raced LB-IPAM and gave up forever) heals
+			// zero-touch on the next catalyst-api roll. Every establish
+			// step is idempotent, and the loop's first attempt on an
+			// already-fully-meshed Sovereign confirms + exits. Resumed
+			// Phase-1 watches are excluded — their markPhase1Done fires
+			// the loop itself on termination. Deployments with missing
+			// kubeconfigs are warn-and-skipped inside the should-helper.
+			meshReconciles++
+			go h.runAutoEstablishClusterMesh(dep)
 		}
 
 		// #1907 — bake-time top-up of the canonical .omani.X sme-pool.
@@ -598,6 +613,7 @@ func (h *Handler) restoreFromStore() {
 	h.log.Info("restored deployments from PVC",
 		"count", len(records),
 		"resumed", resumed,
+		"clusterMeshReconciles", meshReconciles,
 		"dir", h.store.Dir(),
 	)
 }

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -163,6 +163,20 @@ type Handler struct {
 	kubeconfigArrivalTimeout      time.Duration
 	kubeconfigArrivalPollInterval time.Duration
 
+	// ClusterMesh level-triggered reconcile knobs (#3241). The
+	// runAutoEstablishClusterMesh wrapper re-runs the idempotent
+	// AutoEstablishClusterMesh until every region is fully meshed:
+	// exponential backoff from InitialBackoff doubling to MaxBackoff,
+	// one attempt bounded by AttemptTimeout, the whole loop bounded by
+	// RetryBudget. Zero falls back to the clusterMeshRetry*Default
+	// constants in clustermesh.go. Tests inject sub-second values so
+	// the retry loop converges in milliseconds; production leaves all
+	// four at zero.
+	clusterMeshRetryInitialBackoff time.Duration
+	clusterMeshRetryMaxBackoff     time.Duration
+	clusterMeshRetryBudget         time.Duration
+	clusterMeshAttemptTimeout      time.Duration
+
 	// handoverCertWaitTimeout / handoverCertPollInterval — runtime knobs
 	// for the loop that waits for the sovereign-wildcard-tls Certificate
 	// Ready=True before the handover auto-fire mints the JWT. Zero falls

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -881,8 +881,31 @@ func (h *Handler) runSecondaryBridgeBackfill(dep *Deployment) {
 
 // runAutoEstablishClusterMesh is the goroutine wrapper around
 // AutoEstablishClusterMesh — used by markPhase1Done so the terminate
-// path returns immediately. Centralising the recover() + ctx bound +
-// log path here keeps markPhase1Done's hot path one line.
+// path returns immediately, and by restoreFromStore so a catalyst-api
+// roll re-converges a partially-meshed ready Sovereign zero-touch
+// (#3241). Centralising the recover() + ctx bound + retry loop here
+// keeps both call sites one line.
+//
+// Level-triggered, not edge-triggered. hw126 (c986326a77d391d4)
+// proved the prior one-shot shape loses the race against LB-IPAM: the
+// primary's clustermesh-apiserver LB IP landed seconds AFTER the
+// single 3-second fan-out gave up, nothing ever re-ran the establish
+// (next trigger = handover), so a healthy cluster stayed partially
+// meshed forever and the #3236 cnpg-pair flip correctly refused
+// forever with it. Every step inside AutoEstablishClusterMesh is
+// idempotent (Secret writes are get-then-merge, enable/connect
+// re-runs are no-ops, the #3236 flip is a same-value merge patch), so
+// re-running until fully meshed converges instead of thrashing.
+//
+// Loop shape: run the establish; when every region reports ReadyAt
+// (fully meshed) stop with a final success event. Otherwise sleep an
+// exponential backoff (clusterMeshRetryInitialBackoff doubling to
+// clusterMeshRetryMaxBackoff) and re-run, bounded by the
+// clusterMeshRetryBudget total and by the deployment staying
+// status=ready (a wipe mid-loop stops the retries — the kubeconfigs
+// are gone or going). Each retry emits a clustermesh-progress event
+// (attempt N, fullyMeshed X/Y) so the operator watches convergence,
+// not silence.
 func (h *Handler) runAutoEstablishClusterMesh(dep *Deployment) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -892,17 +915,110 @@ func (h *Handler) runAutoEstablishClusterMesh(dep *Deployment) {
 			)
 		}
 	}()
-	// Bounded budget: the orchestrator's per-region LB lookup is the
-	// longest internal wait (5 min). Three regions x 5 min worst case
-	// is ~15 min; pad to 20 min for the per-peer cert mint + Patch
-	// stack.
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+
+	attemptTimeout := h.clusterMeshAttemptTimeout
+	if attemptTimeout <= 0 {
+		attemptTimeout = clusterMeshAttemptTimeoutDefault
+	}
+
+	dep.mu.Lock()
+	regionCount := len(dep.Request.Regions)
+	dep.mu.Unlock()
+	if regionCount < 2 {
+		// Single-region: nothing to mesh with — preserve the one-shot
+		// shape (AutoEstablishClusterMesh logs the skip) and never
+		// retry.
+		ctx, cancel := context.WithTimeout(context.Background(), attemptTimeout)
+		defer cancel()
+		if _, err := h.AutoEstablishClusterMesh(ctx, dep); err != nil {
+			h.log.Warn("clustermesh: orchestrator returned error",
+				"id", dep.ID,
+				"err", err,
+			)
+		}
+		return
+	}
+
+	initialBackoff := h.clusterMeshRetryInitialBackoff
+	if initialBackoff <= 0 {
+		initialBackoff = clusterMeshRetryInitialBackoffDefault
+	}
+	maxBackoff := h.clusterMeshRetryMaxBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = clusterMeshRetryMaxBackoffDefault
+	}
+	budget := h.clusterMeshRetryBudget
+	if budget <= 0 {
+		budget = clusterMeshRetryBudgetDefault
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
 	defer cancel()
-	if _, err := h.AutoEstablishClusterMesh(ctx, dep); err != nil {
-		h.log.Warn("clustermesh: orchestrator returned error",
-			"id", dep.ID,
-			"err", err,
-		)
+
+	backoff := initialBackoff
+	for attempt := 1; ; attempt++ {
+		attemptCtx, cancelAttempt := context.WithTimeout(ctx, attemptTimeout)
+		statuses, err := h.AutoEstablishClusterMesh(attemptCtx, dep)
+		cancelAttempt()
+
+		fullyMeshed := countFullyMeshedRegions(statuses)
+		if err == nil && len(statuses) >= 2 && fullyMeshed == len(statuses) {
+			h.emitClusterMeshProgress(dep, "info",
+				fmt.Sprintf("ClusterMesh reconcile: fully meshed (%d/%d regions) on attempt %d — reconcile loop complete", fullyMeshed, len(statuses), attempt))
+			h.log.Info("clustermesh: reconcile loop converged",
+				"id", dep.ID,
+				"attempt", attempt,
+				"regions", len(statuses),
+			)
+			return
+		}
+		if err != nil {
+			h.log.Warn("clustermesh: orchestrator returned error",
+				"id", dep.ID,
+				"attempt", attempt,
+				"err", err,
+			)
+		}
+
+		// A deployment that left status=ready mid-loop (wipe, failure
+		// rewrite) must not keep getting establish attempts hurled at
+		// it for the rest of the budget.
+		dep.mu.Lock()
+		status := dep.Status
+		dep.mu.Unlock()
+		if status != "ready" {
+			h.log.Info("clustermesh: reconcile loop stopped — deployment no longer ready",
+				"id", dep.ID,
+				"status", status,
+				"attempt", attempt,
+			)
+			return
+		}
+
+		total := len(statuses)
+		if total == 0 {
+			// nil statuses (orchestrator error or no reachable
+			// regions) — report against the region count so the
+			// operator-facing X/Y stays meaningful.
+			total = regionCount
+		}
+		h.emitClusterMeshProgress(dep, "warn",
+			fmt.Sprintf("ClusterMesh reconcile: attempt %d ended with %d/%d regions fully meshed — retrying in %s", attempt, fullyMeshed, total, backoff))
+		if sleepErr := sleepCtx(ctx, backoff); sleepErr != nil {
+			h.emitClusterMeshProgress(dep, "warn",
+				fmt.Sprintf("ClusterMesh reconcile: retry budget exhausted after %d attempt(s) with %d/%d regions fully meshed — next trigger is a catalyst-api restart or the post-handover finalisation", attempt, fullyMeshed, total))
+			h.log.Warn("clustermesh: reconcile loop retry budget exhausted",
+				"id", dep.ID,
+				"attempts", attempt,
+				"fullyMeshed", fullyMeshed,
+				"err", sleepErr,
+			)
+			return
+		}
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
 	}
 }
 


### PR DESCRIPTION
Refs #3241 #3236 #2737

## Evidence (hw126 = c986326a77d391d4, first fully-converged 2-VPC prov)

The Phase-1 ClusterMesh auto-establish ran a THREE-SECOND one-shot fan-out and gave up forever:

```
13:52:25 ClusterMesh auto-establish: starting fan-out across 2 regions
13:52:25 ClusterMesh: region "me-east-215-b-1" apiserver LB ready at 212.72.24.37
13:52:27 ClusterMesh: region "me-east-215-b-1" wired 0/1 peers
13:52:28 ClusterMesh auto-establish: completed (0/2 regions fully meshed)
```

Region-A (primary) emitted NO event at all. Its clustermesh-apiserver Service has its LB-IPAM IP now (212.72.24.46) — the assignment raced Phase-1 completion. Nothing re-runs the establish before handover, so a healthy cluster stays partially meshed forever and the #3238 cnpg-pair flip correctly refuses forever with it. This was the last structural failure-source before Pillar-3 is walkable.

## Root cause of the region-A silence

`git log -L` proves the Step-1 (LB lookup) and Step-2 (cilium-ca) warn-event emits have existed since the original orchestrator (#1508) — so region-A never even entered Step 1. The only zero-event path is a slot whose `err` was pre-set inside `buildRegionSlots` (kubeconfig path empty / unreadable / client-build failure): those slots are appended with `err` set and **no log, no event**; Steps 1–2 `continue` past them before their first emit, and Step 3's unreachable-region branch appends statuses and `continue`s **before** the `wired N/M peers` emit. A 3-second total fan-out is incompatible with the 5-minute LB poll, confirming the immediate-return slot-failure path. Reproduced byte-for-byte in the red-proof run below.

## Changes (Go only, products/catalyst/bootstrap/api)

1. **Level-triggered retry** — `runAutoEstablishClusterMesh` (phase1_watch.go) now loops the idempotent `AutoEstablishClusterMesh` until every region stamps `ReadyAt`: exponential backoff 1m → 5m cap, 6h total budget, 20m per-attempt bound, early stop when the deployment leaves `status=ready` (wipe mid-loop). Emits a progress event per attempt (`attempt N ended with X/Y regions fully meshed — retrying in <backoff>`) and a final success event (`fully meshed (N/N regions) … reconcile loop complete`). Knobs are injectable Handler fields (`clusterMeshRetry*`), zero falls back to constants.
2. **Startup reconcile** — `restoreFromStore` (deployments.go) kicks the same loop in a goroutine for every restored deployment with `status=ready` AND >1 region (follows the existing `releaseOrphanedReservation` goroutine idiom). This heals hw126 zero-touch on the next mothership catalyst-api roll. Missing/unreadable kubeconfigs are warn-and-skipped per deployment (`shouldStartupClusterMeshReconcile`); resumed Phase-1 watches are excluded — their `markPhase1Done` fires the loop itself.
3. **Silent per-region failure path killed** — clustermesh.go now emits a `clustermesh-progress` warn event carrying the region key + error string for every slot that failed in `buildRegionSlots` (pre-fan-out emit pass) AND a terminal `region %q skipped … wired 0/N peers` line in Step 3's unreachable-region branch. G91 lesson: a call whose failure has domain meaning must never vanish into a server-side log only.

## TDD — red first, then green

Tests added to `internal/handler/clustermesh_test.go` (existing harness: `buildFakeClusterMeshCluster` / `installClusterMeshClientFactory` / the #3238 dynamicfake factory):

- `TestRunAutoEstablishClusterMesh_RetryConvergesAfterLBAppears` — attempt 1 sees the primary without an LB IP; after the first retry event the fake Service gains the IP; the loop converges fully meshed AND the #3238 `SOVEREIGN_ENABLE_CNPG_PAIR` flip lands. Millisecond injected backoff.
- `TestAutoEstablishClusterMesh_RegionSlotFailureEmitsEventWithRegionKey` — a missing-kubeconfig region must surface in the event stream with region key + error + terminal skip line.
- `TestRestoreFromStore_StartupKicksClusterMeshReconcile` — a stored ready 2-region record (`Phase1FinishedAt` set) gets the loop kicked at startup and converges on the fakes.
- `TestShouldStartupClusterMeshReconcile_Guards` — single-region / non-ready / missing-kubeconfig records are skipped.
- LB-absent test extended: the LB-timeout failure must appear in the event stream with the failing region's key.

**Red proofs run against the prior logic** (each then restored):

- Compile-red: stashing the four production files → tests cannot build (`undefined: countFullyMeshedRegions`, missing `clusterMeshRetry*` fields).
- Behavioral red 1 (emits discarded via shim): the emission test fails and the captured stream reproduces the hw126 shape verbatim — failing region emits nothing, healthy region reports `wired 0/1 peers`, `completed (0/2 regions fully meshed)`.
- Behavioral red 2 (origin/main one-shot wrapper): retry test fails — `never observed a retry progress event`.
- Behavioral red 3 (origin/main restoreFromStore): startup test fails — no clustermesh events at all.

## Verification

- `go build ./...` green
- `go vet ./...` green
- `go test ./internal/handler/...` green (full suite, 62s; all 12 ClusterMesh tests pass)
- `gofmt -l` clean on every touched file (the 64 pre-existing unformatted files in the package are untouched, present on origin/main too)

## Follow-up (no chart change in this PR)

None required for this fix — the establish path is entirely catalyst-api-side. If a future prov shows the LB-IPAM pool itself missing (not just slow), that is bp-cilium chart territory and should be handled as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
