### PR TITLE
fix(catalyst-api): derive conventional primary kubeconfig for startup ClusterMesh reconcile

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -1327,6 +1327,45 @@ func countFullyMeshedRegions(statuses []ClusterMeshStatus) int {
 	return n
 }
 
+// resolvePrimaryKubeconfigPath resolves a deployment's primary kubeconfig
+// path with the same CONVENTIONAL fallback #3153 added for the Phase-1
+// resume (shouldResumePhase1 in deployments.go): Result.KubeconfigPath
+// carries json `omitempty` and is lost when a mothership roll persists a
+// rehydrated record before PutKubeconfig stamped it — but the kubeconfig
+// FILE itself always survives on the PVC at `<kubeconfigsDir>/<id>.yaml`.
+//
+// Returns the resolved, stat-readable path and true. On success the
+// resolved path is stamped back onto dep.Result.KubeconfigPath (allocating
+// Result if nil) so downstream readers — AutoEstablishClusterMesh re-reads
+// dep.Result.KubeconfigPath under the lock — see the conventional path. The
+// stat guard matches #3153 exactly: a record whose file was genuinely lost
+// across the restart (PVC unmount / wipe race) or whose kubeconfigsDir is
+// unset returns ("", false) so the caller can warn-and-skip rather than
+// spin a retry budget against a phantom path. Takes dep.mu so concurrent
+// callers (startup restore + the establish goroutine) stay consistent.
+func (h *Handler) resolvePrimaryKubeconfigPath(dep *Deployment) (string, bool) {
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+	kubeconfigPath := ""
+	if dep.Result != nil {
+		kubeconfigPath = dep.Result.KubeconfigPath
+	}
+	if kubeconfigPath == "" && h.kubeconfigsDir != "" {
+		kubeconfigPath = filepath.Join(h.kubeconfigsDir, dep.ID+".yaml")
+	}
+	if kubeconfigPath == "" {
+		return "", false
+	}
+	if _, err := os.Stat(kubeconfigPath); err != nil {
+		return "", false
+	}
+	if dep.Result == nil {
+		dep.Result = &provisioner.Result{}
+	}
+	dep.Result.KubeconfigPath = kubeconfigPath
+	return kubeconfigPath, true
+}
+
 // shouldStartupClusterMeshReconcile reports whether a rehydrated
 // deployment needs the level-triggered ClusterMesh reconcile loop
 // kicked at catalyst-api startup (#3241): status=ready AND >1 region
@@ -1336,36 +1375,29 @@ func countFullyMeshedRegions(statuses []ClusterMeshStatus) int {
 // re-fires the establish, and a partially-meshed cluster would
 // otherwise stay partial until handover.
 //
-// The kubeconfig guard is warn-and-skip, not fail: a ready record
-// whose kubeconfig file was lost across the restart (PVC unmount /
-// wipe race) would otherwise spin the whole retry budget against
-// "kubeconfig path empty". Fully-meshed deployments pass this check
-// too — the loop's first attempt is a cheap idempotent re-run that
-// confirms full mesh and exits.
+// The kubeconfig path is resolved with the #3153 conventional fallback
+// (resolvePrimaryKubeconfigPath): a record restored from the PVC loses
+// the `omitempty` Result.KubeconfigPath FIELD, but the kubeconfig FILE
+// survives at `<kubeconfigsDir>/<id>.yaml` — without this fallback an
+// hw126-shaped Sovereign would warn "primary kubeconfig path empty" and
+// skip the mesh reconcile forever. The guard stays warn-and-skip, not
+// fail: a record whose file was genuinely lost across the restart (PVC
+// unmount / wipe race) returns false rather than spinning the whole
+// retry budget. Fully-meshed deployments pass this check too — the
+// loop's first attempt is a cheap idempotent re-run that confirms full
+// mesh and exits.
 func (h *Handler) shouldStartupClusterMeshReconcile(dep *Deployment) bool {
 	dep.mu.Lock()
 	status := dep.Status
 	regionCount := len(dep.Request.Regions)
-	kubeconfigPath := ""
-	if dep.Result != nil {
-		kubeconfigPath = dep.Result.KubeconfigPath
-	}
 	dep.mu.Unlock()
 	if status != "ready" || regionCount < 2 {
 		return false
 	}
-	if kubeconfigPath == "" {
-		h.log.Warn("clustermesh: startup reconcile skipped — primary kubeconfig path empty on ready multi-region deployment",
+	if _, ok := h.resolvePrimaryKubeconfigPath(dep); !ok {
+		h.log.Warn("clustermesh: startup reconcile skipped — primary kubeconfig unresolved on ready multi-region deployment",
 			"id", dep.ID,
 			"regions", regionCount,
-		)
-		return false
-	}
-	if _, err := os.Stat(kubeconfigPath); err != nil {
-		h.log.Warn("clustermesh: startup reconcile skipped — primary kubeconfig unreadable",
-			"id", dep.ID,
-			"path", kubeconfigPath,
-			"err", err,
 		)
 		return false
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -853,6 +853,123 @@ func TestShouldStartupClusterMeshReconcile_Guards(t *testing.T) {
 	}
 }
 
+// TestShouldStartupClusterMeshReconcile_ConventionalFallback — the hw126
+// (#3241) regression: a deployment record restored from the PVC loses the
+// `omitempty` Result.KubeconfigPath FIELD, but the kubeconfig FILE always
+// survives at the conventional `<kubeconfigsDir>/<id>.yaml`. The reconcile
+// must derive that path (mirroring #3153's resume fallback) instead of
+// emitting "primary kubeconfig path empty" and skipping forever. It must
+// also stamp the resolved path back onto dep.Result so the downstream
+// AutoEstablishClusterMesh fan-out (which re-reads dep.Result.KubeconfigPath)
+// can reach the primary region.
+func TestShouldStartupClusterMeshReconcile_ConventionalFallback(t *testing.T) {
+	dir := t.TempDir()
+	h := &Handler{log: silentLogger(), kubeconfigsDir: dir}
+	twoRegions := []provisioner.RegionSpec{
+		{Provider: "huawei", CloudRegion: "me-east-215-a"},
+		{Provider: "huawei", CloudRegion: "me-east-215-b"},
+	}
+	const depID = "c986326a77d391d4"
+	// Conventional primary file present on the PVC; record field empty.
+	convPath := filepath.Join(dir, depID+".yaml")
+	if err := os.WriteFile(convPath, []byte("apiVersion: v1\nkind: Config\n"), 0o600); err != nil {
+		t.Fatalf("write conventional kubeconfig: %v", err)
+	}
+
+	t.Run("empty-field-result-present", func(t *testing.T) {
+		dep := &Deployment{ID: depID, Status: "ready",
+			Request: provisioner.Request{Regions: twoRegions},
+			Result:  &provisioner.Result{}} // KubeconfigPath == ""
+		if !h.shouldStartupClusterMeshReconcile(dep) {
+			t.Fatalf("reconcile skipped despite conventional kubeconfig present at %s", convPath)
+		}
+		if dep.Result.KubeconfigPath != convPath {
+			t.Errorf("resolved path not stamped back: got %q want %q", dep.Result.KubeconfigPath, convPath)
+		}
+	})
+
+	t.Run("nil-result-conventional-present", func(t *testing.T) {
+		dep := &Deployment{ID: depID, Status: "ready",
+			Request: provisioner.Request{Regions: twoRegions}} // Result == nil
+		if !h.shouldStartupClusterMeshReconcile(dep) {
+			t.Fatalf("reconcile skipped on nil-Result despite conventional kubeconfig present")
+		}
+		if dep.Result == nil || dep.Result.KubeconfigPath != convPath {
+			t.Errorf("nil Result not populated with conventional path: %+v", dep.Result)
+		}
+	})
+
+	t.Run("empty-field-no-file-still-skips", func(t *testing.T) {
+		// A different id whose conventional file does NOT exist must still
+		// warn-and-skip (no spinning the retry budget against a phantom).
+		dep := &Deployment{ID: "no-such-id", Status: "ready",
+			Request: provisioner.Request{Regions: twoRegions},
+			Result:  &provisioner.Result{}}
+		if h.shouldStartupClusterMeshReconcile(dep) {
+			t.Fatalf("reconcile should skip when neither field nor conventional file resolves")
+		}
+	})
+
+	t.Run("empty-kubeconfigsDir-skips", func(t *testing.T) {
+		// Without a configured kubeconfigsDir the conventional path can't
+		// be derived — the original warn-and-skip must still hold.
+		hNoDir := &Handler{log: silentLogger()}
+		dep := &Deployment{ID: depID, Status: "ready",
+			Request: provisioner.Request{Regions: twoRegions},
+			Result:  &provisioner.Result{}}
+		if hNoDir.shouldStartupClusterMeshReconcile(dep) {
+			t.Fatalf("reconcile should skip when kubeconfigsDir is empty")
+		}
+	})
+}
+
+// TestBuildRegionSlots_SecondaryConventionalFallback documents + locks in
+// the part-2 finding: secondary region kubeconfigs are resolved from the
+// conventional `<kubeconfigsDir>/<id>-<region>-<idx>.yaml` filesystem path
+// INDEPENDENTLY of the in-memory dep.secondaryKubeconfigPaths map (which is
+// also emptied on a PVC restore). No code change is needed for secondaries —
+// this test proves the existing pickPath fallback already derives them with
+// the same naming the PUT path (?region=<k>) writes.
+func TestBuildRegionSlots_SecondaryConventionalFallback(t *testing.T) {
+	dir := t.TempDir()
+	h := &Handler{log: silentLogger(), kubeconfigsDir: dir}
+	const depID = "c986326a77d391d4"
+	regions := []provisioner.RegionSpec{
+		{Provider: "huawei", CloudRegion: "me-east-215-a"},
+		{Provider: "huawei", CloudRegion: "me-east-215-b"},
+	}
+	primaryPath := filepath.Join(dir, depID+".yaml")
+	// Secondary key per regionKeyFromSpec: "<cloudRegion>-<idx>" = "me-east-215-b-1".
+	secondaryPath := filepath.Join(dir, depID+"-me-east-215-b-1.yaml")
+	for _, p := range []string{primaryPath, secondaryPath} {
+		if err := os.WriteFile(p, []byte("apiVersion: v1\nkind: Config\n"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+	// Route both resolved paths through fake clientsets so the slot build
+	// exercises path resolution without parsing a real kubeconfig.
+	restore := installClusterMeshClientFactory(map[string]kubernetes.Interface{
+		primaryPath:   kfake.NewSimpleClientset(),
+		secondaryPath: kfake.NewSimpleClientset(),
+	})
+	defer restore()
+	dep := &Deployment{ID: depID, Status: "ready",
+		Request: provisioner.Request{Regions: regions}}
+
+	// Empty secondaryPaths map mimics the post-restore state.
+	slots := h.buildRegionSlots(dep, regions, primaryPath, map[string]string{})
+	if len(slots) != 2 {
+		t.Fatalf("expected 2 slots, got %d", len(slots))
+	}
+	if slots[1].kubeconfigPath != secondaryPath {
+		t.Errorf("secondary slot did not resolve conventional path: got %q want %q",
+			slots[1].kubeconfigPath, secondaryPath)
+	}
+	if slots[1].err != nil {
+		t.Errorf("secondary slot unexpectedly failed: %v", slots[1].err)
+	}
+}
+
 // TestAutoEstablishClusterMesh_Idempotent — second invocation produces
 // identical Secret keys (same number of entries, same names) and the
 // returned statuses match.

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -28,7 +28,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -707,25 +706,13 @@ func (h *Handler) shouldResumePhase1(dep *Deployment, rec store.Record) bool {
 	// fallback the resume is skipped and the operator goes permanently blind
 	// to convergence after ANY catalyst-api roll (image bump, OOM, node
 	// maintenance). Resuming read-only is harmless; skipping it is the bug.
-	kubeconfigPath := ""
-	if dep.Result != nil {
-		kubeconfigPath = dep.Result.KubeconfigPath
-	}
-	if kubeconfigPath == "" && h.kubeconfigsDir != "" {
-		kubeconfigPath = filepath.Join(h.kubeconfigsDir, dep.ID+".yaml")
-	}
-	if kubeconfigPath == "" {
-		return false
-	}
-	if _, err := os.Stat(kubeconfigPath); err != nil {
-		return false
-	}
-	// Make sure the resumed watch + StreamLogs see the resolved path.
-	if dep.Result == nil {
-		dep.Result = &provisioner.Result{}
-	}
-	dep.Result.KubeconfigPath = kubeconfigPath
-	return true
+	//
+	// resolvePrimaryKubeconfigPath also stamps the resolved path back onto
+	// dep.Result.KubeconfigPath so the resumed watch + StreamLogs see it.
+	// #3241 lifted this into the shared helper so the startup ClusterMesh
+	// reconcile path resolves the primary kubeconfig identically.
+	_, ok := h.resolvePrimaryKubeconfigPath(dep)
+	return ok
 }
 
 // resumePhase1Watch re-attaches a Phase-1 helmwatch goroutine to a


### PR DESCRIPTION
## Problem (live, mothership ed9b9a9)

The #3243 startup ClusterMesh reconcile (#3241) skips a restored ready 2-region Sovereign forever:

```
WARN clustermesh: startup reconcile skipped — primary kubeconfig path empty on ready multi-region deployment  id=c986326a77d391d4 regions=2
```

A deployment record restored from the PVC drops the `omitempty` `Result.KubeconfigPath` FIELD, but the kubeconfig FILE always survives at the conventional `<kubeconfigsDir>/<id>.yaml`. `shouldStartupClusterMeshReconcile` read the field directly and warn-and-skipped — the partial mesh never heals.

This is the IDENTICAL failure #3153 (merged as #3154) fixed for the Phase-1 watch resume in `shouldResumePhase1`.

## Change

- Lift #3153's exact idiom into a shared `resolvePrimaryKubeconfigPath` helper: resolve `Result.KubeconfigPath` → conventional fallback `<kubeconfigsDir>/<id>.yaml` when empty and `kubeconfigsDir` set → `os.Stat` guard → stamp the resolved path back onto `dep.Result`. Both `shouldStartupClusterMeshReconcile` and `shouldResumePhase1` now call it, so the two restore paths resolve the primary kubeconfig identically.
- The write-back propagates to `AutoEstablishClusterMesh`, which re-reads `dep.Result.KubeconfigPath` under the lock to reach the primary region during the fan-out.
- Guard semantics preserved exactly: a record whose file was genuinely lost across the restart (PVC unmount / wipe race) or whose `kubeconfigsDir` is unset still returns `false` (warn-and-skip), so the retry budget is never spun against a phantom path.

## Secondary-region finding (no code change)

Secondary region kubeconfigs already resolve from the conventional `<kubeconfigsDir>/<id>-<region>-<idx>.yaml` filesystem path inside `buildRegionSlots`/`pickPath` (lines 803-811) — INDEPENDENTLY of the in-memory `dep.secondaryKubeconfigPaths` map that is also emptied on restore — using the same naming the PUT path (`?region=<k>`) writes (e.g. `c986326a77d391d4-me-east-215-b-1.yaml`). No change needed there; locked in with a regression test (`TestBuildRegionSlots_SecondaryConventionalFallback`).

## Tests

- `TestShouldStartupClusterMeshReconcile_ConventionalFallback` — restored ready 2-region deployment with EMPTY `KubeconfigPath` field but conventional file present kicks the reconcile and stamps the resolved path back; plus nil-`Result`, missing-file, and empty-`kubeconfigsDir` skip cases.
- `TestBuildRegionSlots_SecondaryConventionalFallback` — secondary slot resolves the conventional path from an empty `secondaryKubeconfigPaths` map.
- Pre-existing `TestShouldStartupClusterMeshReconcile_Guards` and the Phase-1 resume tests still pass.

`go build ./...`, `go test ./internal/handler/...` (full package), and `go vet ./internal/handler/` all green.

Refs #3241 #3153 #2737