### PR TITLE
fix(powerdns-admin): full kyverno-Enforce compliance re-cut 0.1.8 + cold-install guard (Refs #2737)

### DIFF
--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -102,7 +102,16 @@ spec:
       # 0.1.7 (#2737, 2026-06-11): add `policy.cilium.io/enforced: "true"` to
       # the Pod template — kyverno cilium-l7-mtls Enforce denied the Deployment
       # on the hw126 fresh prov (first time it reached admission).
-      version: 0.1.7
+      # 0.1.8 (#2737, 2026-06-11): full kyverno-Enforce compliance re-cut.
+      # Whole-chart audit vs the live baseline policies confirms every
+      # container the chart ships already passes harbor-proxy-pull (proxy
+      # glob), image-tag-pinned (0.4.2 / postgresql:16), probes-present
+      # (both probes on the app container) and cilium-l7-mtls (enforced
+      # label, 0.1.7). Re-cut publishes the corrected chart so the FIX
+      # propagates past the stale pre-0.1.7 artifact hw126 first admitted.
+      # Adds the bp-gitea/bp-harbor Capabilities guard to the CNPG Cluster
+      # template so a cold install can't half-render before bp-cnpg's CRD.
+      version: 0.1.8
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns-admin

--- a/platform/powerdns-admin/blueprint.yaml
+++ b/platform/powerdns-admin/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 0.1.7
+  version: 0.1.8
   card:
     title: powerdns-admin
     summary: |

--- a/platform/powerdns-admin/chart/Chart.yaml
+++ b/platform/powerdns-admin/chart/Chart.yaml
@@ -44,7 +44,35 @@ name: bp-powerdns-admin
 # spec.template.metadata.labels, mirroring the bp-sso-bridge + catalyst chart
 # idiom. The container image already pulls through the Harbor proxy
 # (harbor.openova.io/proxy-dockerhub/…, #3150) so it satisfies harbor-proxy-pull.
-version: 0.1.7
+#
+# 0.1.8 (Refs #2737, 2026-06-11): full kyverno-Enforce compliance re-cut +
+# cold-install guard. Audited the WHOLE rendered chart against the live
+# baseline policies (platform/kyverno-policies/.../baseline/{04-probes,
+# 09-cilium-l7-mtls,11-harbor-proxy,12-image-tag-pinned}.yaml). Result:
+# every container the chart ships is already compliant —
+#   • Deployment/powerdns-admin container `powerdns-admin`:
+#       image harbor.openova.io/proxy-dockerhub/powerdnsadmin/pda-legacy:0.4.2
+#       → matches harbor-proxy glob `*/proxy-*/*`, tag `0.4.2` is pinned
+#       (not :latest), BOTH livenessProbe + readinessProbe (httpGet :http)
+#       present, Pod template carries `policy.cilium.io/enforced: "true"`
+#       (added 0.1.7/#3242).
+#   • CNPG Cluster `pda-pg`: imageName
+#       harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16 → proxy
+#       glob + pinned. (The `Cluster` CRD itself is not in any baseline
+#       policy `kinds:` match; the postgres Pod CNPG later creates inherits
+#       the pinned proxy image.)
+# The 0.1.6→0.1.7 denial the operator captured on hw126 traced to a
+# pre-0.1.7 OCI artifact still being served when admission was first
+# reached (0.1.2 shipped the dead non-Harbor `ngoduykhanh/powerdns-admin`
+# image → harbor-proxy-pull + image-tag-pinned DENY; the enforced label
+# arrived only at 0.1.7). This 0.1.8 re-cut publishes the already-correct
+# chart so the FIX actually lands.
+# ALSO add the bp-gitea/bp-harbor gold-standard `.Capabilities.APIVersions.
+# Has "postgresql.cnpg.io/v1"` guard to templates/cnpg-cluster.yaml so a
+# cold install can't half-render (apiserver rejecting the Cluster CR before
+# bp-cnpg registers the CRD) and wedge the chart BEFORE it reaches kyverno
+# admission at all.
+version: 0.1.8
 description: |
   PowerDNS-Admin (ngoduykhanh/powerdns-admin) web UI Blueprint for
   per-Sovereign PowerDNS zone + record management. Drives the

--- a/platform/powerdns-admin/chart/templates/cnpg-cluster.yaml
+++ b/platform/powerdns-admin/chart/templates/cnpg-cluster.yaml
@@ -6,7 +6,18 @@ CNPG operator generates a `<cluster>-app` Secret with the postgres-app
 user's password; reflector mirrors it into pda-database-secret (see
 templates/database-secret.yaml) so deployment.yaml can read the password
 via secretKeyRef without a cross-namespace reference.
+
+Capabilities gate (0.1.8, Refs #2737): bp-cnpg ships the
+`postgresql.cnpg.io/v1` CRD. On a cold install — before bp-cnpg is
+reconciling — the apiserver rejects this Cluster CR and the whole
+HelmRelease render fails, wedging bp-powerdns-admin BEFORE it ever
+reaches kyverno admission. The Capabilities check skips this template
+until the CRD is registered, making the render self-healing on a partial
+reconcile. The bootstrap-kit slot 11a `dependsOn bp-cnpg` already orders
+this, but the guard mirrors the bp-gitea / bp-harbor gold-standard
+pattern so the chart never half-renders.
 */ -}}
+{{- if .Capabilities.APIVersions.Has "postgresql.cnpg.io/v1" }}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
@@ -48,3 +59,4 @@ spec:
       reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: {{ .Values.postgres.cluster.namespace | default .Release.Namespace | quote }}
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
       reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: {{ .Values.postgres.cluster.namespace | default .Release.Namespace | quote }}
+{{- end }}


### PR DESCRIPTION
## Round-2 — full chart audit vs the LIVE kyverno baseline policies

Round 1 (#3242) fixed the missing `policy.cilium.io/enforced` label working from a truncated denial. This round audits the **whole rendered chart** against the actual baseline policies in `platform/kyverno-policies/chart/templates/baseline/` (`04-probes.yaml`, `09-cilium-l7-mtls.yaml`, `11-harbor-proxy.yaml`, `12-image-tag-pinned.yaml`) — every Pod-bearing resource, every container.

### Per-container compliance table (render proof)

`helm template platform/powerdns-admin/chart --set gateway.host=pdns-admin.example.com --api-versions postgresql.cnpg.io/v1`

| Resource / container | harbor-proxy-pull | image-tag-pinned | probes-present | cilium-enforced-label |
|---|---|---|---|---|
| `Deployment/powerdns-admin` → `powerdns-admin`<br>`harbor.openova.io/proxy-dockerhub/powerdnsadmin/pda-legacy:0.4.2` | PASS (`*/proxy-*/*`) | PASS (`:0.4.2`) | PASS (liveness + readiness, httpGet `:http`/80) | PASS (label on Pod template) |
| `Cluster/pda-pg` (CNPG CRD)<br>`imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16` | n/a — `Cluster` kind not in any baseline policy `kinds:` match | n/a | n/a | n/a |

The `Cluster` CRD is operator-managed; the postgres Pod CNPG later creates inherits the **pinned proxy-ghcr** image above. The only Pod-bearing resource the chart directly emits — the Deployment — is fully compliant across all four Enforce rules (and also passes `resource-requests`, the fifth Enforce rule that targets workloads here).

### Why the operator still saw a denial on hw126

The probes have existed since chart inception (#2681); the Harbor image arrived at 0.1.3/#3150; the enforced label at 0.1.7/#3242. The chart **source** was already compliant. The captured denial traces to a **pre-0.1.7 OCI artifact** still being served when admission was first reached (0.1.2 shipped the dead non-Harbor `ngoduykhanh/powerdns-admin` image → `harbor-proxy-pull` + `image-tag-pinned` DENY; the enforced label only existed from 0.1.7). This 0.1.8 re-cut publishes the already-correct chart so the fix propagates.

### Substantive change: cold-install Capabilities guard

Added the bp-gitea / bp-harbor gold-standard `.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1"` guard to `templates/cnpg-cluster.yaml`. Without it, a cold install (Cluster CR applied before bp-cnpg registers the CRD) makes the apiserver reject the render and **wedges the chart before it ever reaches kyverno admission**. Verified gating is identical to bp-gitea:

```
# without the CRD api-version → Cluster SKIPPED (count 0)
helm template platform/powerdns-admin/chart ...                                  → 0
# with the CRD api-version    → Cluster RENDERS (count 1)
helm template platform/powerdns-admin/chart ... --api-versions postgresql.cnpg.io/v1 → 1
```

### Lockstep version bump 0.1.7 → 0.1.8

- `platform/powerdns-admin/chart/Chart.yaml`
- `platform/powerdns-admin/blueprint.yaml` (`  version:`)
- `clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml` (slot pin)

`helm lint` clean.

Refs #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)