### PR TITLE
fix(cnpg-pair): full kyverno-Enforce compliance re-cut for failover-readiness (Refs #3236 #2737)

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -143,7 +143,15 @@ spec:
       # the canonical 4-segment region labels are validated on a fresh
       # 2-region prov — Phase-2 acceptance). The primary/replica/audit/
       # probe path is unchanged from 0.1.2.
-      version: 0.1.3
+      # 0.1.4 (Refs #3236 / #2737) — kyverno-Enforce compliance re-cut.
+      # The cnpgPair gate flipped TRUE on hw126 (#3238), so the failover-
+      # readiness Deployment hit kyverno Enforce admission for the first
+      # time and was DENIED on cilium-l7-mtls / probes-present / harbor-
+      # proxy-pull / image-tag-pinned. 0.1.4 adds the enforced label, a
+      # livenessProbe, and Harbor-proxies the default image. The default
+      # image.repository now equals this slot's override, so the inline
+      # override below is redundant but kept explicit for clarity.
+      version: 0.1.4
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.1.3
+  version: 0.1.4
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-cnpg-pair
-version: 0.1.3
-appVersion: "0.1.3"
+version: 0.1.4
+appVersion: "0.1.4"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair
   across two Hetzner regions. Companions the existing `bp-cnpg`
@@ -32,6 +32,34 @@ description: |
 
   Changelog
   ─────────
+  0.1.4 (2026-06-11, kyverno-Enforce compliance re-cut, Refs #3236 / #2737)
+    - The cnpgPair gate flipped TRUE for the first time on hw126 (#3238),
+      so the chart's auxiliary workloads reached kyverno Enforce admission
+      for the first time in history. The `failover-readiness` Deployment
+      was DENIED on four baseline policies; this re-cut makes every
+      rendered container compliant:
+        • cilium-l7-mtls: added `policy.cilium.io/enforced: "true"` to the
+          failover-readiness Pod template labels.
+        • probes-present: the probe container now declares BOTH a
+          livenessProbe (heartbeat /tmp/alive freshness — proves the poll
+          loop is not wedged) AND the existing readinessProbe (/tmp/ready
+          — promotability). The two probes answer different questions, so
+          a lagging-but-healthy replica no longer kills the probe Pod.
+        • harbor-proxy-pull + image-tag-pinned: the default
+          `cnpgPair.image.repository` is now
+          `harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql`
+          (matching the slot-16b override and every sibling CNPG chart);
+          the required-tag fail-fast already bars `:latest`.
+      Also re-tagged the helm-test `test-replication` Pod image to the same
+      Harbor proxy prefix (helm-test Pods are NOT Flux-reconciled, but the
+      prefix is fixed for consistency + manual-`helm test` admission).
+    - The CNPG primary/replica `Cluster` CRs are NOT kyverno-matched (the
+      `Cluster` kind is absent from every baseline policy `kinds:` list),
+      so their `imageName` is left to the shared `cnpgPair.imageRef` helper
+      — which now resolves to the Harbor proxy prefix anyway.
+    - Default-OFF contract UNCHANGED: a disabled (single-region) install
+      still renders ZERO resources, byte-identical to 0.1.3.
+
   0.1.3 (2026-06-10, Pillar-3 bootstrap-kit enablement, Refs #3195 / #3189)
     - New `templates/continuum.yaml`: optional production
       `Continuum.dr.openova.io/v1` CR seed pointing at THIS cluster-

--- a/platform/cnpg-pair/chart/templates/failover-readiness.yaml
+++ b/platform/cnpg-pair/chart/templates/failover-readiness.yaml
@@ -40,6 +40,12 @@ spec:
         {{- include "cnpg-pair.selectorLabels" . | nindent 8 }}
         catalyst.openova.io/role: failover-readiness-probe
         catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+        # kyverno cilium-l7-mtls (Enforce): the catalyst-network
+        # controller routes this Pod under the zero-trust mesh via this
+        # label. Required on spec.template.metadata.labels — without it
+        # the Deployment is DENIED at admission (first reached when the
+        # cnpgPair gate flipped true on hw126, #3238).
+        policy.cilium.io/enforced: "true"
     spec:
       # Probe runs in the replica region — when the replica region
       # is the one promoting, Continuum reads this Pod's Ready
@@ -78,6 +84,12 @@ spec:
               REPLICA_HOST="{{ include "cnpg-pair.replicaName" . }}-r"
               THRESHOLD={{ .Values.cnpgPair.walStreaming.targetLagSeconds }}
               while true; do
+                # Heartbeat first — the livenessProbe reads /tmp/alive's
+                # mtime to detect a WEDGED loop (a hung psql or a stalled
+                # shell never refreshes it). The readinessProbe's /tmp/ready
+                # is a SEPARATE signal (promotability), so the two probes
+                # answer different questions: alive vs promotable.
+                : > /tmp/alive
                 LAG=$(psql "host=${REPLICA_HOST} port=5432 user=postgres dbname=postgres sslmode=require" \
                        -tAXc "SELECT EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))::int" 2>/dev/null \
                        || echo "999999")
@@ -92,6 +104,24 @@ spec:
           env:
             - name: PGCONNECT_TIMEOUT
               value: "5"
+          # livenessProbe — DISTINCT from readiness. Readiness ("/tmp/ready
+          # exists") flips with replica promotability and is EXPECTED to be
+          # false whenever WAL lag exceeds the threshold; gating liveness on
+          # it would kill a perfectly-healthy probe that is simply reporting a
+          # lagging replica. Liveness instead asserts the poll LOOP itself is
+          # making progress: every pass touches /tmp/alive, so a heartbeat
+          # younger than 60s proves the shell loop is not wedged. kyverno
+          # probes-present (Enforce) requires BOTH probes on every container.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "test -f /tmp/alive && test -z \"$(find /tmp/alive -mmin +1)\""
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
           readinessProbe:
             exec:
               command: ["test", "-f", "/tmp/ready"]

--- a/platform/cnpg-pair/chart/templates/tests/test-replication.yaml
+++ b/platform/cnpg-pair/chart/templates/tests/test-replication.yaml
@@ -33,7 +33,13 @@ spec:
   serviceAccountName: {{ include "cnpg-pair.fullname" . }}-test
   containers:
     - name: probe
-      image: ghcr.io/cloudnative-pg/postgresql:16.4-1
+      # harbor-proxy-pull compliant prefix (kyverno harbor-proxy-pull glob
+      # `*/proxy-*/*`). helm-test Pods carry `helm.sh/hook: test` so Flux
+      # never reconciles them (they run only under `helm test`), but the
+      # image is pinned to the Sovereign Harbor proxy for consistency with
+      # the rest of the chart and so a manual `helm test` run on a hardened
+      # cluster is not denied at admission.
+      image: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4-1
       command: [/bin/bash, -c]
       args:
         - |

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -162,7 +162,16 @@ cnpgPair:
   # SHA digest (not a floating tag); a versioned tag is acceptable
   # in pre-prod but cluster overlays should pin to digest.
   image:
-    repository: ghcr.io/cloudnative-pg/postgresql
+    # harbor-proxy-pull compliant default (kyverno harbor-proxy-pull
+    # ClusterPolicy, Enforce). The failover-readiness Deployment reaches
+    # kyverno admission and is DENIED unless its image matches the
+    # Sovereign-Harbor proxy glob `*/proxy-*/*`. This is the exact prefix
+    # bp-gitea / bp-harbor / bp-powerdns / bp-postgres use for their CNPG
+    # Clusters — a public image proxy-ghcr serves cred-free pre-cutover,
+    # redirected to the local Harbor by cutover Step-04 post-handover.
+    # The bootstrap-kit slot 16b already pins this same repository; the
+    # default now matches so the standalone chart renders compliant too.
+    repository: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql
     # REQUIRED — empty fails the render. Example pin:
     #   tag: "16.3-23"
     tag: ""


### PR DESCRIPTION
## Why

The `cnpgPair` gate flipped TRUE for the **first time in history** on hw126 tonight (via #3238 — the gate was always OFF before). That pushed `bp-cnpg-pair@0.1.3`'s auxiliary workloads through kyverno **Enforce** admission for the first time, and the `failover-readiness` Deployment was a **complete denial** on four baseline policies → Helm rolled back (4 attempts) → HR Stalled:

```
Deployment/cnpg/cnpg-pair-bp-cnpg-pair-failover-readiness blocked:
  cilium-l7-mtls/cilium-enforced-label: missing label policy.cilium.io/enforced: "true"
  harbor-proxy-pull/image-must-be-from-harbor-proxy: image not */proxy-*/* or */openova-io/*
  image-tag-pinned/image-must-not-be-latest: container unpinned
  probes-present/containers-must-have-liveness-and-readiness: containers[0] missing livenessProbe+readinessProbe
```

Same recipe as the just-merged #3246 (powerdns-admin).

## What changed (0.1.3 -> 0.1.4)

- **cilium-l7-mtls** — added `policy.cilium.io/enforced: "true"` to the failover-readiness **Pod template** labels (`spec.template.metadata.labels`).
- **probes-present** — the probe container now declares **BOTH** a `livenessProbe` and the existing `readinessProbe`. They answer different questions: the poll loop touches `/tmp/alive` on every pass; liveness asserts that heartbeat is < 60s old (poll loop not wedged), while readiness (`/tmp/ready`) reflects replica **promotability** (expected-false when WAL lag > threshold). Gating liveness on readiness would kill a healthy probe that is merely reporting a lagging replica.
- **harbor-proxy-pull + image-tag-pinned** — default `cnpgPair.image.repository` is now `harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql` (matches the slot-16b override + every sibling CNPG chart). The chart's existing `required`-tag fail-fast already bars `:latest`.
- helm-test `test-replication` Pod image re-tagged to the same Harbor proxy prefix (helm-test Pods are **not** Flux-reconciled — fixed for consistency + manual-`helm test` admission).
- **CNPG `Cluster` CRs are NOT kyverno-matched** (the `Cluster` kind is absent from every baseline policy `kinds:` list — verified against `platform/kyverno-policies/.../baseline/{04-probes,09-cilium-l7-mtls,11-harbor-proxy,12-image-tag-pinned}.yaml`). Their `imageName` is left to the shared `cnpgPair.imageRef` helper, which now resolves to the Harbor proxy prefix anyway.
- **Lockstep version bump** -> `0.1.4`: `chart/Chart.yaml` (+ `appVersion`), `blueprint.yaml`, and the slot pin in `clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml`.

## Per-container compliance proof (ENABLED render)

Rendered via:
```
helm template platform/cnpg-pair/chart --set cnpgPair.enabled=true \
  --set cnpgPair.primary.region=hw-me-east-215-a-rtz-prod \
  --set cnpgPair.replica.region=hw-me-east-215-b-rtz-prod \
  --set cnpgPair.image.tag=16.4-1
```

| Resource (kyverno-matched?) | Container | Image | Tag pinned | liveness + readiness | cilium enforced label |
|---|---|---|---|---|---|
| Deployment `failover-readiness` (**yes**) | `probe` | `harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql` | `16.4-1` yes | both yes | yes (Pod template) |
| Cluster `…-primary` (**no** — CRD kind) | (CNPG-owned StatefulSet) | `harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql` | `16.4-1` yes | n/a (CNPG owns Pods) | n/a (CR) |
| Cluster `…-replica` (**no** — CRD kind) | (CNPG-owned StatefulSet) | `harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql` | `16.4-1` yes | n/a | n/a |
| Pod `test-replication` (helm-test hook, **not Flux-reconciled**) | `probe` | `harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql` | `16.4-1` yes | n/a (helm-test Pod) | n/a (hook) |

The only Flux-reconciled, kyverno-matched Pod-bearing resource the chart ships is the `failover-readiness` Deployment — now fully compliant on all four denied policies.

## Safe-by-default contract

The **DISABLED** (single-region) render still emits **ZERO resources** — verified **byte-for-byte identical** to `origin/main`:
```
diff <(helm template origin/main:.../chart) <(helm template ./chart)  -> IDENTICAL
```

## Validation
- `helm lint platform/cnpg-pair/chart` -> clean (only the informational `icon is recommended`).
- `bash platform/cnpg-pair/chart/tests/cnpg-pair-render.sh` -> **9/9 cases green** (incl. disabled-empty, enabled 7-resource count, fail-fast cases).

honestStatus: code-complete-walk-pending (kyverno admission proven via render audit against the live baseline policies; a fresh 2-region prov with `SOVEREIGN_ENABLE_CNPG_PAIR=true` is the acceptance walk).

Refs #3236 #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)
