### PR TITLE
fix(kyverno-policies): three baseline Enforce patterns always-failed — never admitted a workload

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -63,7 +63,16 @@ spec:
       # Pending forever post-Phase-2b bootstrapMode flip → dashboard
       # vCluster grouping shows only "host" → Pillar 4 (Sandbox) silent
       # broken.
-      version: 1.0.28
+      # 1.0.29 (Refs #2737 #3236, 2026-06-11): FIX the three baseline Enforce
+      # policies (probes-present / harbor-proxy-pull / image-tag-pinned) whose
+      # validate patterns ALWAYS failed — they had never admitted a workload,
+      # so they gated the entire hw126 pipeline once a chart first reached
+      # admission. Empirically re-cut + two-directionally verified on a local
+      # kind + kyverno v1.18 harness. NOTE the G60 "validate.pattern + glob"
+      # claim above was the bug: autogen does NOT path-expand anyPattern, and
+      # `(image)`/`{"?{}":...}` anchors never validate; the fix uses explicit
+      # per-PATH-SHAPE rules + deny/foreach. See Chart.yaml for the full RCA.
+      version: 1.0.29
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.28
+  version: 1.0.29
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -1,5 +1,26 @@
 apiVersion: v2
 name: bp-kyverno-policies
+# 1.0.29 (Refs #2737 #3236, 2026-06-11): FIX three baseline Enforce policies
+# that had ALWAYS-FAIL validate patterns and had never admitted a single
+# workload (undetected until a gated chart first reached admission on hw126):
+#   - 04-probes: `{"?{}": "?*"}` required a probe SUB-KEY matching `?{}` (no
+#     real probe field can) — and `"?*"` matches scalars only, not the probe
+#     OBJECT. Switched to `validate.deny` with a JMESPath count (all
+#     containers must declare both probes; handler-type agnostic).
+#   - 11-harbor-proxy: the single `validate.anyPattern` rule wrote the Pod
+#     path `spec.containers`; Kyverno autogen does NOT path-expand anyPattern
+#     for workload controllers, so every Deployment was denied at the
+#     non-existent `/spec/containers/`. Split into per-PATH-SHAPE rules
+#     (Pod / template-bearing / CronJob) with `autogen-controllers: none`.
+#     The `*/proxy-*/*` glob itself was always correct (`*` spans `/`).
+#   - 12-image-tag-pinned: `(image): "!*:latest"` used a parenthesized
+#     CONDITIONAL anchor (not a validation) → denied compliant `:0.4.2`;
+#     also missed TAGLESS images. Switched to per-kind `validate.foreach`
+#     + regex `deny` requiring a `@sha256` digest OR a real `:tag` in the
+#     final path segment AND forbidding `:latest`.
+# All three verified two-directionally on a local kind + kyverno v1.18
+# harness (matches the bp-kyverno engine pin); 09-cilium-l7-mtls and
+# 10-flux-managed left untouched and re-verified for no regression.
 # 1.0.27 (G92.6 #2665, 2026-06-01): new K22 substrate-stays-on-host
 # ClusterPolicy. Per docs/DOD.md §A4 the substrate components (Cilium,
 # Flux, Kyverno, cert-manager, ESO, CNPG-operator, vCluster-syncers)
@@ -81,7 +102,7 @@ type: application
 # while keeping proxy-cache for anonymous public registries.
 # Lockstep with bp-self-sovereign-cutover 0.1.43 (Step 03 Phase A
 # skopeo native-push + Step 07 REGISTRY drops /proxy-ghcr/ suffix).
-version: 1.0.28
+version: 1.0.29
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/templates/baseline/04-probes.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/04-probes.yaml
@@ -56,13 +56,32 @@ spec:
           Every container in
           {{ `{{request.object.kind}}/{{request.object.metadata.name}}` }} must
           declare both livenessProbe and readinessProbe.
-        pattern:
-          spec:
-            template:
-              spec:
-                containers:
-                  - livenessProbe:
-                      "?{}": "?*"
-                    readinessProbe:
-                      "?{}": "?*"
+        # The prior `validate.pattern` form `livenessProbe: {"?{}": "?*"}`
+        # required a probe SUB-KEY literally matching the glob `?{}` — no real
+        # probe field (httpGet / exec / tcpSocket / initialDelaySeconds …) can
+        # ever match that, so the pattern denied EVERY workload (it never
+        # admitted one — undetected because no gated chart reached admission).
+        #
+        # `livenessProbe: "?*"` does NOT work either: the `?*` wildcard only
+        # matches NON-EMPTY SCALAR values, while `livenessProbe` is an OBJECT
+        # (httpGet / exec / …) — empirically verified in the kind+kyverno
+        # v1.18 harness that `"?*"` against an object field denies even a
+        # compliant container.
+        #
+        # The robust, probe-handler-agnostic check is `validate.deny` with a
+        # JMESPath count: "the number of containers that DECLARE the probe must
+        # equal the total container count" (i.e. ALL containers carry it).
+        # `containers[?livenessProbe]` filters to containers where the field is
+        # present/truthy. This works for any handler type and autogen-expands
+        # cleanly to `spec.template.spec.containers` for the matched workload
+        # kinds. Empirically green across both directions in the harness.
+        deny:
+          conditions:
+            any:
+              - key: "{{ `{{ request.object.spec.template.spec.containers[?livenessProbe] | length(@) }}` }}"
+                operator: NotEquals
+                value: "{{ `{{ request.object.spec.template.spec.containers | length(@) }}` }}"
+              - key: "{{ `{{ request.object.spec.template.spec.containers[?readinessProbe] | length(@) }}` }}"
+                operator: NotEquals
+                value: "{{ `{{ request.object.spec.template.spec.containers | length(@) }}` }}"
 {{- end -}}

--- a/platform/kyverno-policies/chart/templates/baseline/11-harbor-proxy.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/11-harbor-proxy.yaml
@@ -31,6 +31,12 @@ metadata:
     catalyst.openova.io/policy-tier: compliance
     catalyst.openova.io/policy-domain: governance
   annotations:
+    # Autogen is OFF because this policy uses validate.anyPattern, which
+    # Kyverno autogen does NOT path-expand for workload controllers (it
+    # would silently leave the rule at the non-existent Pod path on a
+    # Deployment → deny-everything). Each workload PATH-SHAPE is covered
+    # by its own explicit rule below instead.
+    pod-policies.kyverno.io/autogen-controllers: none
     policies.kyverno.io/title: Container images must pull through the Sovereign Harbor proxy
     policies.kyverno.io/category: catalyst-compliance
     policies.kyverno.io/severity: high
@@ -39,48 +45,108 @@ metadata:
       registry. Operator configures the allowed glob via
       .Values.compliancePolicies.harborProxyPull.allowedImagePattern.
 spec:
+  # Empirically-determined root cause (kind + kyverno v1.18 harness,
+  # 2026-06-11): the prior SINGLE rule wrote the container path as
+  # `spec.containers` (the Pod path) and relied on Kyverno's autogen to
+  # rewrite it to `spec.template.spec.containers` for Deployment /
+  # StatefulSet / DaemonSet. Kyverno autogen does NOT expand
+  # `validate.anyPattern` rules (only `validate.pattern` and a few other
+  # forms) — verified live: the autogen status produced ZERO template-path
+  # rules, so the policy was evaluated against `/spec/containers/` on a
+  # Deployment, that path does not exist, and EVERY workload was denied at
+  # `path /spec/containers/`. The glob `*/proxy-*/*` itself is correct (it
+  # matches a compliant Pod and a deep path like
+  # `harbor.x/proxy-ghcr/cloudnative-pg/postgresql:16.4-1` — `*` spans `/`).
+  #
+  # Fix: pin `autogen-controllers: none` and write one rule per workload
+  # PATH-SHAPE with the explicit container path (Pod / template-bearing /
+  # CronJob). Each rule's anyPattern lets an image pass if it matches ANY
+  # allowed glob (proxy-cache `*/proxy-*/*` OR native-push `*/openova-io/*`).
   validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.harborProxyPull.action) }}
   background: true
   rules:
-    - name: image-must-be-from-harbor-proxy
+    {{- $excludeNs := .Values.compliancePolicies.harborProxyPull.excludeNamespaces }}
+    {{- $pats := .Values.compliancePolicies.harborProxyPull.allowedImagePatterns }}
+    {{- $msg := "Container image does not match any allowed Harbor-source glob (proxy-cache `*/proxy-*/*` or native-push `*/openova-io/*`). Re-tag the image to pull through the Sovereign's local Harbor (e.g. registry.<sov-fqdn>/proxy-ghcr/... or registry.<sov-fqdn>/openova-io/openova/<svc>:<tag>)." }}
+    - name: image-from-harbor-proxy-pod
       match:
         any:
           - resources:
               kinds:
                 - Pod
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := $excludeNs }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: {{ $msg | quote }}
+        anyPattern:
+          {{- range $pat := $pats }}
+          # =(initContainers) is a conditional anchor — when the Pod has no
+          # initContainers the clause is a no-op; when present, every init
+          # image must match too.
+          - spec:
+              =(initContainers):
+                - image: {{ $pat | quote }}
+              containers:
+                - image: {{ $pat | quote }}
+          {{- end }}
+    - name: image-from-harbor-proxy-workload
+      match:
+        any:
+          - resources:
+              kinds:
                 - Deployment
                 - StatefulSet
                 - DaemonSet
                 - Job
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := $excludeNs }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: {{ $msg | quote }}
+        anyPattern:
+          {{- range $pat := $pats }}
+          - spec:
+              template:
+                spec:
+                  =(initContainers):
+                    - image: {{ $pat | quote }}
+                  containers:
+                    - image: {{ $pat | quote }}
+          {{- end }}
+    - name: image-from-harbor-proxy-cronjob
+      match:
+        any:
+          - resources:
+              kinds:
                 - CronJob
       exclude:
         any:
           - resources:
               namespaces:
-                {{- range $ns := .Values.compliancePolicies.harborProxyPull.excludeNamespaces }}
+                {{- range $ns := $excludeNs }}
                 - {{ $ns }}
                 {{- end }}
       validate:
-        message: >-
-          Container image does not match any allowed Harbor-source glob
-          (proxy-cache `*/proxy-*/*` or native-push `*/openova-io/*`).
-          Re-tag the image to pull through the Sovereign's local Harbor
-          (e.g. registry.<sov-fqdn>/proxy-ghcr/... or
-          registry.<sov-fqdn>/openova-io/openova/<svc>:<tag>).
-        # G66 (Refs #2615, 2026-05-31): anyPattern lets multiple globs
-        # validate independently — image passes if it matches ANY one.
-        # Required because openova-io application images are NATIVE-
-        # pushed (no /proxy-*/ segment) while upstream public images
-        # come via proxy-cache (have /proxy-*/ segment).
+        message: {{ $msg | quote }}
         anyPattern:
-          {{- range $pat := .Values.compliancePolicies.harborProxyPull.allowedImagePatterns }}
+          {{- range $pat := $pats }}
           - spec:
-              # =(initContainers): match-if-exists; if Pod has no
-              # initContainers, this clause is a no-op (Kyverno pattern
-              # anchor semantics — `=(<key>)` is "conditional-on-presence").
-              =(initContainers):
-                - image: {{ $pat | quote }}
-              containers:
-                - image: {{ $pat | quote }}
+              jobTemplate:
+                spec:
+                  template:
+                    spec:
+                      =(initContainers):
+                        - image: {{ $pat | quote }}
+                      containers:
+                        - image: {{ $pat | quote }}
           {{- end }}
 {{- end -}}

--- a/platform/kyverno-policies/chart/templates/baseline/12-image-tag-pinned.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/12-image-tag-pinned.yaml
@@ -31,6 +31,10 @@ metadata:
     catalyst.openova.io/policy-tier: compliance
     catalyst.openova.io/policy-domain: governance
   annotations:
+    # Autogen OFF: this policy uses `validate.foreach` + `deny.conditions`
+    # with explicit JMESPath container paths, which Kyverno autogen does not
+    # path-expand for workload controllers. Each PATH-SHAPE has its own rule.
+    pod-policies.kyverno.io/autogen-controllers: none
     policies.kyverno.io/title: Container images must be tag-pinned (no :latest)
     policies.kyverno.io/category: catalyst-compliance
     policies.kyverno.io/severity: high
@@ -39,37 +43,146 @@ metadata:
       a @sha256: digest). Floating tags break SHA-pinned audit trails
       and reproducibility.
 spec:
+  # Empirically-determined root cause (kind + kyverno v1.18 harness,
+  # 2026-06-11): the prior `pattern` used a PARENTHESIZED key
+  # `(image): "!*:latest"`. In Kyverno, `(field)` is a CONDITIONAL anchor
+  # ("evaluate the sibling map only IF field matches"), NOT a value
+  # validation — with no sibling map it never denies, and when the engine
+  # treats the anchored value-glob it mis-evaluates, denying a provably
+  # compliant `...:0.4.2` image at `path /spec/containers/`. Two further
+  # bugs: (a) the Pod-path `spec.containers` was never autogen-expanded to
+  # the workload template path (same class as 11-harbor-proxy), and
+  # (b) `!*:latest` does not catch a TAGLESS image (`nginx`) which K8s
+  # silently resolves to `:latest`.
+  #
+  # Fix: `validate.foreach` over the container list at each explicit path,
+  # with a regex `deny` that requires a real pin — a `@sha256:<64-hex>`
+  # digest OR a `:<tag>` in the FINAL path segment (so a bare registry-port
+  # colon like `host:5000/img` does NOT count as a tag) — AND forbids
+  # `:latest`. Verified green both directions in the harness, including the
+  # registry-port edge cases the glob `*:*` got wrong.
   validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.imageTagPinned.action) }}
   background: true
   rules:
-    - name: image-must-not-be-latest
+    {{- $excludeNs := .Values.compliancePolicies.imageTagPinned.excludeNamespaces }}
+    {{- $msg := "One or more containers reference an unpinned image (`:latest`, or no tag/digest which K8s resolves to `:latest`). Pin to an explicit non-`:latest` tag or a @sha256 digest." }}
+    {{/*
+      $pinned: image carries a valid pin — a @sha256 digest, OR a :tag in
+      the final path segment (after the last `/`), OR a :tag on a
+      single-segment image. $islatest: image ends in `:latest`.
+      An image is UNPINNED (deny) when NOT $pinned OR $islatest.
+    */}}
+    {{- $pinnedExpr := "regex_match('^.*@sha256:[a-fA-F0-9]{64}$', element.image) || regex_match('^[^@]*/[^/:]+:[^/:]+$', element.image) || regex_match('^[^@/]+:[^/:]+$', element.image)" }}
+    {{- $latestExpr := "regex_match('^.*:latest$', element.image)" }}
+    - name: image-pinned-pod
       match:
         any:
           - resources:
               kinds:
                 - Pod
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := $excludeNs }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: {{ $msg | quote }}
+        foreach:
+          - list: "request.object.spec.containers"
+            deny:
+              conditions:
+                any:
+                  - key: {{ printf "{{ %s }}" $pinnedExpr | quote }}
+                    operator: Equals
+                    value: false
+                  - key: {{ printf "{{ %s }}" $latestExpr | quote }}
+                    operator: Equals
+                    value: true
+          - list: "request.object.spec.initContainers || `[]`"
+            deny:
+              conditions:
+                any:
+                  - key: {{ printf "{{ %s }}" $pinnedExpr | quote }}
+                    operator: Equals
+                    value: false
+                  - key: {{ printf "{{ %s }}" $latestExpr | quote }}
+                    operator: Equals
+                    value: true
+    - name: image-pinned-workload
+      match:
+        any:
+          - resources:
+              kinds:
                 - Deployment
                 - StatefulSet
                 - DaemonSet
                 - Job
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := $excludeNs }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: {{ $msg | quote }}
+        foreach:
+          - list: "request.object.spec.template.spec.containers"
+            deny:
+              conditions:
+                any:
+                  - key: {{ printf "{{ %s }}" $pinnedExpr | quote }}
+                    operator: Equals
+                    value: false
+                  - key: {{ printf "{{ %s }}" $latestExpr | quote }}
+                    operator: Equals
+                    value: true
+          - list: "request.object.spec.template.spec.initContainers || `[]`"
+            deny:
+              conditions:
+                any:
+                  - key: {{ printf "{{ %s }}" $pinnedExpr | quote }}
+                    operator: Equals
+                    value: false
+                  - key: {{ printf "{{ %s }}" $latestExpr | quote }}
+                    operator: Equals
+                    value: true
+    - name: image-pinned-cronjob
+      match:
+        any:
+          - resources:
+              kinds:
                 - CronJob
       exclude:
         any:
           - resources:
               namespaces:
-                {{- range $ns := .Values.compliancePolicies.imageTagPinned.excludeNamespaces }}
+                {{- range $ns := $excludeNs }}
                 - {{ $ns }}
                 {{- end }}
       validate:
-        message: >-
-          One or more containers reference an unpinned image (`:latest`
-          or no tag/digest). Pin to an explicit tag or @sha256 digest.
-        pattern:
-          spec:
-            # X(<key>): "<glob>" enforces the value to match. Use
-            # negative wildcard "!*:latest" to deny :latest images.
-            =(initContainers):
-              - (image): "!*:latest"
-            containers:
-              - (image): "!*:latest"
+        message: {{ $msg | quote }}
+        foreach:
+          - list: "request.object.spec.jobTemplate.spec.template.spec.containers"
+            deny:
+              conditions:
+                any:
+                  - key: {{ printf "{{ %s }}" $pinnedExpr | quote }}
+                    operator: Equals
+                    value: false
+                  - key: {{ printf "{{ %s }}" $latestExpr | quote }}
+                    operator: Equals
+                    value: true
+          - list: "request.object.spec.jobTemplate.spec.template.spec.initContainers || `[]`"
+            deny:
+              conditions:
+                any:
+                  - key: {{ printf "{{ %s }}" $pinnedExpr | quote }}
+                    operator: Equals
+                    value: false
+                  - key: {{ printf "{{ %s }}" $latestExpr | quote }}
+                    operator: Equals
+                    value: true
 {{- end -}}


### PR DESCRIPTION
## Problem
Three kyverno baseline **Enforce** ClusterPolicies in `platform/kyverno-policies/chart/templates/baseline/` carried `validate` patterns that denied **every** workload — they had never admitted a single one. Undetected until a gated chart first reached admission on **hw126**, where they gate the whole pipeline (cnpg-pair, powerdns-admin, TLS, console). A provably-compliant powerdns-admin Deployment (`harbor.openova.io/proxy-dockerhub/powerdnsadmin/pda-legacy:0.4.2`, both probes, enforced label) was denied by all three.

`09-cilium-l7-mtls` and `10-flux-managed` are correct — left untouched and re-verified for no regression.

## Empirically-determined root causes (kind + kyverno v1.18 harness — not guessed)

| Policy | Bug | Fix |
|---|---|---|
| **04-probes** | `livenessProbe: {"?{}": "?*"}` required a probe SUB-KEY literally matching glob `?{}` — no real probe field (httpGet/exec/tcpSocket/…) does. (Also confirmed `"?*"` matches **scalars only**, never the probe OBJECT.) | `validate.deny` with a JMESPath count: count of containers declaring the probe must equal total container count → all containers carry both probes. Handler-type agnostic. |
| **11-harbor-proxy** | Single `validate.anyPattern` rule wrote the Pod path `spec.containers` and relied on autogen. **Kyverno autogen does NOT path-expand `anyPattern`** for workload controllers (verified: zero template-path rules generated) → every Deployment denied at the non-existent `/spec/containers/`. The `*/proxy-*/*` glob was always correct (`*` spans `/`). | Per-PATH-SHAPE rules (Pod / template-bearing / CronJob) with explicit container paths + `pod-policies.kyverno.io/autogen-controllers: none`. |
| **12-image-tag-pinned** | `(image): "!*:latest"` — parenthesized **conditional anchor** (gates sibling fields, never validates) → denied compliant `:0.4.2`. Also never caught TAGLESS images. | Per-kind `validate.foreach` + regex `deny`: require a `@sha256` digest OR a real `:tag` in the final path segment AND forbid `:latest`. Also fixes the registry-port-no-tag edge a `*:*` glob would mis-admit. |

### The harbor root cause, precisely
The glob is fine. On a raw **Pod**, the compliant image is ADMITTED; on a **Deployment** the identical image is DENIED at `path /spec/containers/`. Kyverno's autogen — which path-expands `validate.pattern` rules to `spec.template.spec.containers` — silently does **not** expand `validate.anyPattern` rules (the policy `.status.autogen` was empty; zero template rules produced). So the anyPattern stayed at the Pod path, which doesn't exist on a Deployment, and the missing path fails the pattern → deny-everything.

## Method
Local **kind** cluster (`kindest/node:v1.30.6`, the CI idiom) + **kyverno chart 3.8.0 / appVersion v1.18.0** (matches the `bp-kyverno` engine pin). Policies installed at **Enforce** (`bootstrapMode: false`). Every case applied with real admission (server-side dry-run hits the full webhook chain). Filename suffix `__ADMIT`/`__DENY` is the expected verdict.

## Matrix proof (real `kubectl apply` admission)

**Baseline (broken policies, origin/main) — RED:**
```
PASS=7 FAIL=7   (every ADMIT case denied)
  harbor__proxy-dockerhub__ADMIT      expect=ADMIT got=DENY  FAIL
  harbor__openova-io__ADMIT           expect=ADMIT got=DENY  FAIL
  harbor__proxy-ghcr-deep__ADMIT      expect=ADMIT got=DENY  FAIL
  probes__both__ADMIT                 expect=ADMIT got=DENY  FAIL
  tag__semver__ADMIT                  expect=ADMIT got=DENY  FAIL
  tag__digest__ADMIT                  expect=ADMIT got=DENY  FAIL
  harbor__init-proxy-ok__ADMIT        expect=ADMIT got=DENY  FAIL
  (all DENY cases passed)
```

**Fixed policies — GREEN (14/14):**
```
CASE                                   EXPECT   ACTUAL   RESULT
harbor__dockerhub-direct__DENY         DENY     DENY     PASS
harbor__init-bad__DENY                 DENY     DENY     PASS
harbor__init-proxy-ok__ADMIT           ADMIT    ADMIT    PASS
harbor__openova-io__ADMIT              ADMIT    ADMIT    PASS
harbor__proxy-dockerhub__ADMIT         ADMIT    ADMIT    PASS
harbor__proxy-ghcr-deep__ADMIT         ADMIT    ADMIT    PASS
probes__both__ADMIT                    ADMIT    ADMIT    PASS
probes__neither__DENY                  DENY     DENY     PASS
probes__no-liveness__DENY              DENY     DENY     PASS
probes__no-readiness__DENY             DENY     DENY     PASS
tag__digest__ADMIT                     ADMIT    ADMIT    PASS
tag__latest__DENY                      DENY     DENY     PASS
tag__semver__ADMIT                     ADMIT    ADMIT    PASS
tag__tagless__DENY                     DENY     DENY     PASS
PASS=14 FAIL=0  → MATRIX GREEN
```

**Extra checks:**
- The exact compliant powerdns-admin Deployment from the report → **ADMITTED**.
- `09-cilium-l7-mtls` still denies a workload missing `policy.cilium.io/enforced` and admits a compliant one → **no regression**.
- `10-flux-managed` still denies a workload missing `app.kubernetes.io/managed-by: flux` → **no regression**.
- image-tag registry-port edges on the installed policy: `myreg.local:5000/app` (port, no tag → `:latest`) **DENY**; `myreg.local:5000/app:1.2.3` (port + tag) **passes tag check** — the precise behavior the `*:*` glob got wrong.
- All three policies validate against the real kyverno v1.18 CRD schema (`kubectl apply --dry-run=server`).

## Lockstep
Chart `1.0.28 → 1.0.29`: `chart/Chart.yaml` + `blueprint.yaml` + bootstrap-kit slot `27a-kyverno-policies.yaml` pin. `helm lint` clean.

Refs #2737 #3236