### PR TITLE
chore(cnpg-pair): re-cut 0.1.5 — re-admit past the exhausted-retries stall

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -151,7 +151,7 @@ spec:
       # livenessProbe, and Harbor-proxies the default image. The default
       # image.repository now equals this slot's override, so the inline
       # override below is redundant but kept explicit for clarity.
-      version: 0.1.4
+      version: 0.1.5
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.1.4
+  version: 0.1.5
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cnpg-pair
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.1.4"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair


### PR DESCRIPTION
The 0.1.4 retries exhausted against the broken baseline policies just before #3250 fixed them; Stalled HRs don't re-attempt without a spec/chart change. Version-only re-cut so the retry flows from git (env stays zero-touch). Refs #3236 #2737