### PR TITLE
fix(kyverno-policies): exclude operator-managed data-plane namespaces from flux-managed Enforce

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -72,7 +72,17 @@ spec:
       # claim above was the bug: autogen does NOT path-expand anyPattern, and
       # `(image)`/`{"?{}":...}` anchors never validate; the fix uses explicit
       # per-PATH-SHAPE rules + deny/foreach. See Chart.yaml for the full RCA.
-      version: 1.0.29
+      # 1.0.30 (Refs #2737 #3236 #3248, 2026-06-11): EXCLUDE operator-managed
+      # data-plane namespaces (`cnpg`, `shared-data`, `powerdns-admin`) from the
+      # `flux-managed` (10) Enforce policy. The CNPG operator creates Services
+      # (`<cluster>-r`/`-ro`/`-rw`) + utility Jobs with no flux labels/ownerRefs
+      # — definitionally un-Flux-manageable — so flux-managed (the one Enforce
+      # policy matching Service) denied "Unable to create required cluster
+      # objects" the moment a gated CNPG Cluster reached admission on hw126.
+      # Per-policy `extraExcludeNamespaces` (NOT the shared anchor): every other
+      # policy stays enforced in those namespaces. Verified two-directionally on
+      # the same kind + kyverno v1.18 harness. See Chart.yaml for the full RCA.
+      version: 1.0.30
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.29
+  version: 1.0.30
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -1,5 +1,26 @@
 apiVersion: v2
 name: bp-kyverno-policies
+# 1.0.30 (Refs #2737 #3236 #3248, 2026-06-11): EXCLUDE the operator-managed
+# data-plane namespaces (`cnpg`, `shared-data`, `powerdns-admin`) from the
+# `flux-managed` (10) Enforce policy. The CNPG operator creates Services
+# (`<cluster>-r`/`-ro`/`-rw`) and utility Jobs with NO flux labels or
+# ownerReferences — operator-owned objects definitionally cannot be
+# Flux-managed, so flux-managed (the ONLY Enforce policy whose match-kinds
+# include Service) denied "Unable to create required cluster objects" the
+# moment a gated CNPG Cluster first reached admission on hw126. Those three
+# namespaces predate the data plane and were never in the shared
+# `complianceDefaultExcludes` anchor because no workload ran there until the
+# first gate-flips. Scoped via a new per-policy `extraExcludeNamespaces` key
+# (NOT the shared anchor): powerdns-admin also hosts a real `powerdns-admin`
+# Deployment that MUST stay subject to every other policy, and CNPG instance
+# Pods carry the harbor-proxied + pinned cluster image so they still PASS
+# 04/05/11/12 — only the flux-unmanageable operator Service/Job needs the
+# carve-out. Verified two-directionally on the same kind + kyverno v1.18
+# harness as #3250 (CNPG Service in cnpg/shared-data/powerdns-admin →
+# ADMITTED; identical no-flux Service in a non-excluded app namespace →
+# DENIED; CNPG-shaped Pod with the pinned proxied image in cnpg → ADMITTED;
+# CNPG-shaped Pod with a `:latest` image in cnpg → still DENIED, proving the
+# Pod-path supply-chain policy stays enforced there).
 # 1.0.29 (Refs #2737 #3236, 2026-06-11): FIX three baseline Enforce policies
 # that had ALWAYS-FAIL validate patterns and had never admitted a single
 # workload (undetected until a gated chart first reached admission on hw126):
@@ -102,7 +123,7 @@ type: application
 # while keeping proxy-cache for anonymous public registries.
 # Lockstep with bp-self-sovereign-cutover 0.1.43 (Step 03 Phase A
 # skopeo native-push + Step 07 REGISTRY drops /proxy-ghcr/ suffix).
-version: 1.0.29
+version: 1.0.30
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/templates/baseline/10-flux-managed.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/10-flux-managed.yaml
@@ -60,6 +60,19 @@ spec:
                 {{- range $ns := .Values.compliancePolicies.fluxManaged.excludeNamespaces }}
                 - {{ $ns }}
                 {{- end }}
+                {{- /*
+                  #3248 follow-up (Refs #2737 #3236, first proven hw126): the
+                  CNPG operator creates Services (`<cluster>-r/-ro/-rw`) and
+                  utility Jobs with NO flux labels / ownerRefs — by design,
+                  operator-owned objects can NEVER be Flux-managed. flux-managed
+                  is the ONE Enforce policy whose denial is definitionally
+                  impossible for these. Namespace-scoped per-policy extra
+                  excludes (NOT the shared anchor — powerdns-admin also hosts a
+                  real Deployment that must stay subject to every other policy).
+                */}}
+                {{- range $ns := .Values.compliancePolicies.fluxManaged.extraExcludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
       validate:
         message: >-
           {{ `{{request.object.kind}}/{{request.object.metadata.name}}` }} is

--- a/platform/kyverno-policies/chart/values.yaml
+++ b/platform/kyverno-policies/chart/values.yaml
@@ -159,6 +159,26 @@ compliancePolicies:
     # the audit trail. Enforce by default.
     action: Enforce
     excludeNamespaces: *complianceDefaultExcludes
+    # #3248 follow-up (Refs #2737 #3236, first proven hw126): operator-managed
+    # data-plane namespaces. The CNPG operator creates Services
+    # (`<cluster>-r`/`-ro`/`-rw`) and utility Jobs with NO flux labels or
+    # ownerReferences — operator-owned objects definitionally cannot be
+    # Flux-managed, so flux-managed (the ONLY Enforce policy whose match-kinds
+    # include Service) denies "Unable to create required cluster objects" the
+    # moment a gated CNPG Cluster first reaches admission. These namespaces
+    # predate the data plane and were never in complianceDefaultExcludes
+    # because no workload ran there until the hw126 gate-flips.
+    #
+    # Scoped to THIS policy only (not the shared anchor): powerdns-admin also
+    # hosts a real `powerdns-admin` Deployment that MUST stay subject to every
+    # other policy (probes / requests / image-pin). CNPG instance Pods carry
+    # the cluster's harbor-proxied + pinned image and inherited resource
+    # requests, so they still PASS 04/05/11/12 — only the operator-created
+    # Service/Job (flux-unmanageable) needs this carve-out.
+    extraExcludeNamespaces:
+      - cnpg            # bp-cnpg-pair primary/replica Clusters → operator Services + Jobs
+      - shared-data     # bp-postgres-shared (shared-pg) Cluster → operator Services + Jobs
+      - powerdns-admin  # bp-powerdns-admin CNPG Cluster → operator Services + Jobs
 
   harborProxyPull:
     enabled: true


### PR DESCRIPTION
## Problem (proven live on hw126)
The `flux-managed` (10) **Enforce** ClusterPolicy denies **CNPG-operator-created Services** (`<cluster>-r`/`-ro`/`-rw`, no flux labels/ownerRefs by design), so every new CNPG Cluster fails with "Unable to create required cluster objects":

```
resource Service/cnpg/cnpg-pair-bp-cnpg-pair-primary-r was blocked ... flux-managed
```

`flux-managed` is the **only** Enforce policy whose match-kinds include `Service`. Its `excludeNamespaces` (the shared `complianceDefaultExcludes` anchor: kube-system, flux-system, cilium, cilium-gateway, cert-manager, openova-system, catalyst, kyverno, monitoring, ingress, dmz, mgmt, rtz, sso-bridge) predates the data plane: `cnpg`, `powerdns-admin`, `shared-data` host **operator-created** resources (CNPG instance Pods, Services, PVCs, utility Jobs) and were never added because no workload ran there until the first gate-flips. All pre-existing CNPG databases were admitted before kyverno enforced.

## Fix (minimum-set, per-policy)
Added a per-policy `extraExcludeNamespaces` key to `fluxManaged` and excluded the three operator-managed data-plane namespaces there — **not** the shared anchor.

- Scoped to **`flux-managed` only**: operator-owned objects definitionally cannot carry `app.kubernetes.io/managed-by: flux` or a Flux ownerReference, so this is the one policy whose denial is structurally impossible for them.
- **Not** the shared anchor: `powerdns-admin` also hosts a real `powerdns-admin` Deployment that MUST stay subject to every other policy (probes/requests/image-pin).

## Pod-path policies verdict — do CNPG Pods pass 04/05/11/12?
**Yes — left enforced (not excluded).**
- `04-probes` and `05-resource-requests` match only `Deployment/StatefulSet/DaemonSet` (+Job for 05) — they do **not** match the raw **Pods** the CNPG operator creates for instances, so they never gate CNPG Pods.
- `11-harbor-proxy` and `12-image-tag-pinned` match `Pod` — CNPG instance Pods carry the cluster's `imageName` (`harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4-1`, harbor-proxied + pinned) and inherited resource requests, so they **PASS**.

Proof they stay enforced: a CNPG-shaped Pod with a `:latest` image in `cnpg` is still **DENIED** by `image-tag-pinned`:
```
resource Pod/cnpg/cnpg-bad-1 was blocked due to the following policies
image-tag-pinned: ... Pin to an explicit non-`:latest` tag or a @sha256 digest.
```

## Matrix proof (real server-side-dry-run admission)
kind `kindest/node:v1.30.6` + kyverno chart **3.8.0 / appVersion v1.18.0** (matches the `bp-kyverno` engine pin). All 20 ClusterPolicies installed at **Enforce** (`bootstrapMode=false`). Filename suffix `__ADMIT`/`__DENY` is the expected verdict.

```
CASE                                EXPECT  ACTUAL  RESULT
pod__cnpg-instance__cnpg            ADMIT   ADMIT   PASS   # CNPG Pod (both probes, proxied+pinned image)
pod__cnpg-latest__cnpg             DENY    DENY    PASS   # image-tag-pinned STILL enforces in cnpg
svc__cnpg-r__cnpg                   ADMIT   ADMIT   PASS   # the proven hw126 denial — now admitted
svc__shared-rw__shared-data        ADMIT   ADMIT   PASS
svc__pda-ro__powerdns-admin        ADMIT   ADMIT   PASS
svc__noflux__appns                 DENY    DENY    PASS   # flux-managed STILL works (no over-broad exclude)
svc__fluxlabelled__appns           ADMIT   ADMIT   PASS   # control: real flux-labelled svc passes
PASS=7 FAIL=0  ->  MATRIX GREEN
```

- The proven denial case (CNPG Service in `cnpg`/`shared-data`/`powerdns-admin`) → **ADMITTED**.
- Identical no-flux Service in a non-excluded app namespace → **DENIED** by `flux-managed` (the exact hw126 message: `Service/some-r is not Flux-managed`) — the policy still works.
- CNPG-shaped Pod with the pinned proxied image in `cnpg` → **ADMITTED**.

## Lockstep
Chart `1.0.29 -> 1.0.30`: `chart/Chart.yaml` + `blueprint.yaml` + bootstrap-kit slot `27a-kyverno-policies.yaml` pin. `helm lint` clean.

## Files
- `platform/kyverno-policies/chart/templates/baseline/10-flux-managed.yaml` — range the new `extraExcludeNamespaces`
- `platform/kyverno-policies/chart/values.yaml` — `fluxManaged.extraExcludeNamespaces: [cnpg, shared-data, powerdns-admin]`
- `platform/kyverno-policies/chart/Chart.yaml` — 1.0.30 + RCA
- `platform/kyverno-policies/blueprint.yaml` — 1.0.30
- `clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml` — pin 1.0.30

Refs #2737 #3236 #3248