### PR TITLE
fix(cnpg-pair): split-side topology — each cluster renders its own half of the pair (0.2.0)

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -1,17 +1,42 @@
 # bp-cnpg-pair — Catalyst bootstrap-kit Blueprint slot 16b.
 # (Pillar-3 cross-region DR primitive — EPIC-6 slice C-DB-1 #1101.)
 #
-# Active-hot-standby CNPG cluster-pair across two Sovereign regions:
+# Active-hot-standby CNPG cluster-pair across two Sovereign regions.
+#
+# ─── SPLIT-SIDE MODEL (chart 0.2.0) — each cluster renders ITS half ──
+# A 2-region Sovereign is TWO SEPARATE k3s clusters joined by Cilium
+# ClusterMesh (kom4dc mimics the regions with 2 VPCs) — NOT one
+# stretched cluster. So this HR is applied on BOTH control planes and
+# `cnpgPair.side` (stamped from the per-region SOVEREIGN_REGION_ROLE
+# substitute below) selects which half each cluster renders:
+#   side=primary (region-A cluster):
 #   - Primary postgresql.cnpg.io/v1.Cluster CR pinned to region A
-#   - Replica Cluster CR pinned to region B (replica.enabled: true +
-#     bootstrap.pg_basebackup + externalClusters[] streaming the
-#     primary's WAL over Cilium ClusterMesh)
 #   - `<name>-primary-mesh` Service annotated
 #     `service.cilium.io/global: "true"` so ClusterMesh publishes the
 #     primary's read-replica endpoint across every connected peer
-#   - failover-readiness probe + audit-config ConfigMap (label
+#   - audit-config ConfigMap (label
 #     `catalyst.openova.io/audit-config: "true"`) that bp-continuum's
-#     prerequisite-check probes to switch from idle to active.
+#     prerequisite-check probes to switch from idle to active
+#     (bp-continuum slot 62 runs on the primary cluster).
+#   side=replica (region-B cluster, SOVEREIGN_REGION_ROLE=secondary —
+#   the chart normalizes "secondary" → replica):
+#   - Replica Cluster CR pinned to region B (replica.enabled: true +
+#     bootstrap.pg_basebackup + externalClusters[] streaming the
+#     primary's WAL over Cilium ClusterMesh)
+#   - local `-primary-mesh` Service stub (Cilium merges global
+#     services by name+namespace across clusters; zero local backends
+#     → traffic crosses the mesh to the primary)
+#   - failover-readiness probe (its region-B node-affinity now matches
+#     the cluster it runs on).
+#
+# Chart ≤0.1.x declared the whole pair ONCE on the primary cluster
+# (this slot suspended on secondaries via SECONDARY_HR_SUSPEND) and
+# relied on node-affinity to "schedule each side to its region" — that
+# only works on a single stretched cluster. On hw126 the replica-side
+# workloads could NEVER schedule: FailedScheduling 0/4 nodes, affinity
+# requires openova.io/region=hw-me-east-215-b-rtz-prod while every
+# cluster-A node is ...-a-rtz-prod. 0.2.0 removes the suspend and
+# splits the render per side.
 #
 # ─── Why this slot exists (Pillar-3 gap closure, #3195 / Refs #3189) ──
 # The DESIGN.md gap analysis (docs/sessions/2026-06-10/pillar3-multi
@@ -119,12 +144,13 @@ metadata:
     openova.io/category: customer-facing-capability
     openova.io/epic: "6"
 spec:
-  # Primary-only HR — the cluster-pair is DECLARED once, on the primary
-  # region's control plane (the primary Cluster CR + the replica
-  # ReplicaCluster both live in the same manifest; CNPG schedules each
-  # side to its region via node-affinity). SECONDARY_HR_SUSPEND="true"
-  # on secondary CPs suspends this HR so it is not double-applied.
-  suspend: ${SECONDARY_HR_SUSPEND:=false}
+  # BOTH-clusters HR (chart 0.2.0 split-side) — every region's control
+  # plane applies this HR; `cnpgPair.side` (below) makes each cluster
+  # render exactly its own half of the pair. The former
+  # SECONDARY_HR_SUSPEND suspend is REMOVED: suspending on secondaries
+  # was the ≤0.1.x single-manifest model, under which the replica-side
+  # workloads (pinned to region-B node labels) could never schedule on
+  # the primary cluster (hw126 FailedScheduling — see header).
   interval: 15m
   releaseName: cnpg-pair
   # targetNamespace = cnpg — same namespace bp-harbor/bp-gitea place their
@@ -151,7 +177,12 @@ spec:
       # livenessProbe, and Harbor-proxies the default image. The default
       # image.repository now equals this slot's override, so the inline
       # override below is redundant but kept explicit for clarity.
-      version: 0.1.5
+      # 0.2.0 (Refs #3236 / #3195 / #2737) — split-side topology. New
+      # `cnpgPair.side` keyed off SOVEREIGN_REGION_ROLE; this HR now
+      # applies on BOTH control planes (suspend removed) and each
+      # cluster renders only its own half of the pair. See the slot
+      # header + the chart changelog for the full design note.
+      version: 0.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair
@@ -202,7 +233,24 @@ spec:
       # canonical "default-OFF until the dependency is truly wired" knob
       # shape — the cnpg-pair is a wire-it-when-the-mesh-is-confirmed
       # primitive, not an auto-fire-on-2-region one.
+      #
+      # 🛑 NOTE (split-side): because slot 16b now applies on EVERY
+      # region's control plane, the post-mesh flip (catalyst-api
+      # handler/clustermesh.go enableCNPGPairAfterFullMesh, #3236/#3238)
+      # patches SOVEREIGN_ENABLE_CNPG_PAIR=true onto the bootstrap-kit
+      # Kustomization of ALL regions — flipping only the primary would
+      # activate side=primary while cluster-B keeps rendering an empty
+      # release (no replica, no WAL stream).
       enabled: ${SOVEREIGN_ENABLE_CNPG_PAIR:-false}
+      # ── Side — WHICH HALF this cluster renders (chart 0.2.0) ───────
+      # SOVEREIGN_REGION_ROLE is the per-region cloud-init substitute
+      # (infra/providers/_shared/cloudinit-control-plane.tftpl; value
+      # domain primary|secondary from each provider's
+      # sovereign_region_role — hetzner main.tf stamps the literal,
+      # huawei derives it from the region index). The chart normalizes
+      # "secondary" → replica. Default "primary" keeps a single-region
+      # prov (where the gate is OFF anyway) byte-identical.
+      side: ${SOVEREIGN_REGION_ROLE:-primary}
       primary:
         # Canonical region label (matches openova.io/region node label).
         region: '${SOVEREIGN_PRIMARY_REGION:-}'

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -77,9 +77,16 @@ resources:
   # WAL streaming over Cilium ClusterMesh + `*-primary-mesh` global
   # Service + failover-readiness probe + audit-config ConfigMap (which
   # bp-continuum slot 62 prerequisite-checks to switch from idle to
-  # active). SAFE-BY-DEFAULT: gated ${SOVEREIGN_ENABLE_HOT_STANDBY:-false}
-  # → renders ZERO resources on a single-region prov (byte-identical to
-  # today). Auto-true only on a multi-region (active-hotstandby) prov.
+  # active). SPLIT-SIDE (chart 0.2.0): the HR applies on EVERY region's
+  # control plane and `cnpgPair.side` (from SOVEREIGN_REGION_ROLE) makes
+  # each cluster render only its own half — primary Cluster + mesh
+  # Service + audit-config on cluster-A; replica Cluster + failover-
+  # readiness probe on cluster-B (the regions are separate ClusterMesh-
+  # joined clusters, so region-pinned workloads must be APPLIED on
+  # their own cluster). SAFE-BY-DEFAULT: gated
+  # ${SOVEREIGN_ENABLE_CNPG_PAIR:-false} → renders ZERO resources until
+  # catalyst-api confirms full mesh and flips the substitute on ALL
+  # region Kustomizations (#3236/#3238).
   # Sequenced right after bp-cnpg (slot 16) which provides the CNPG
   # operator + postgresql.cnpg.io Cluster CRD + mutating webhook this
   # slot's Cluster CRs gate on. See 16b-bp-cnpg-pair.yaml header for the

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -421,6 +421,15 @@ write_files:
             SOVEREIGN_REPLICA_REGION: "${replica_region_canonical_label}"
             SOVEREIGN_ENABLE_HOT_STANDBY: "${enable_hot_standby}"
             SOVEREIGN_BCP_TOPOLOGY: "${bcp_topology}"
+            # SOVEREIGN_REGION_ROLE — this control plane's role in the
+            # multi-region topology (primary|secondary). Both providers
+            # pass sovereign_region_role (hetzner stamps the literal per
+            # CP, huawei derives it from the region index). Promoted out
+            # of the huawei-only block for the bp-cnpg-pair split-side
+            # model: slot 16b stamps `cnpgPair.side` from this so each
+            # cluster renders its own half of the CNPG pair (the chart
+            # normalizes "secondary" → replica).
+            SOVEREIGN_REGION_ROLE: "${sovereign_region_role}"
             SOVEREIGN_REGIONS_JSON: '${sovereign_regions_json}'
             SOVEREIGN_CONFIGURED_REGIONS_YAML: '${sovereign_configured_regions_yaml}'
 %{ if provider == "hetzner" ~}
@@ -448,7 +457,6 @@ write_files:
             SOVEREIGN_GATEWAY_HTTP_PORT: "30080"
             HARBOR_PROXY_MIRROR_ENDPOINT: "http://212.72.24.20:5000"
             PDNS_API_HOST: "${pdns_api_host}"
-            SOVEREIGN_REGION_ROLE: "${sovereign_region_role}"
 %{ endif ~}
       ---
       # sovereign-tls Kustomization — carries the cert-manager Certificate

--- a/infra/providers/hetzner/main.tf
+++ b/infra/providers/hetzner/main.tf
@@ -887,7 +887,10 @@ locals {
 
     # Huawei-branch substitute vars — passed empty/placeholder on Hetzner so
     # the shared template's `provider == "huawei"` block parses (tofu
-    # evaluates var refs even in non-taken directive branches). Inert here.
+    # evaluates var refs even in non-taken directive branches). Inert here,
+    # EXCEPT sovereign_region_role: it now feeds the SHARED
+    # SOVEREIGN_REGION_ROLE substitute (bp-cnpg-pair split-side, slot 16b
+    # `cnpgPair.side`), so the per-CP value is live on Hetzner too.
     pdns_api_host          = ""
     sovereign_region_role  = "primary"
     node_external_ip_value = ""
@@ -1316,7 +1319,9 @@ locals {
       catalyst_api_url           = var.catalyst_api_url
       load_balancer_ipv4         = hcloud_load_balancer.secondary[k].ipv4
 
-      # Huawei-branch substitute vars — inert on Hetzner (see primary call).
+      # Huawei-branch substitute vars — inert on Hetzner (see primary call),
+      # EXCEPT sovereign_region_role: live via the shared
+      # SOVEREIGN_REGION_ROLE substitute (bp-cnpg-pair split-side).
       pdns_api_host          = ""
       sovereign_region_role  = "secondary"
       node_external_ip_value = ""

--- a/platform/cnpg-pair/DESIGN.md
+++ b/platform/cnpg-pair/DESIGN.md
@@ -213,6 +213,47 @@ the strongest mode.
   promoted replica" (zero-tx-loss), no longer "within the
   configured async-lag tolerance."
 
+### 8. Split-side rendering — each cluster applies ITS half (chart 0.2.0)
+
+A 2-region Sovereign is two SEPARATE k3s clusters joined by Cilium
+ClusterMesh (kom4dc mimics the second region with a second VPC) —
+**not** one stretched cluster. Chart ≤0.1.x rendered both Cluster CRs
+in a single release on the primary cluster and relied on
+`openova.io/region` node-affinity to "schedule each side to its
+region". That only works on a stretched cluster: on separate clusters
+the replica Cluster CR + failover-readiness Deployment pinned to
+region-B labels can NEVER schedule on cluster-A (hw126:
+`FailedScheduling 0/4 nodes — affinity requires
+openova.io/region=hw-me-east-215-b-rtz-prod`).
+
+Chart 0.2.0 keys the render off `cnpgPair.side`
+(primary|replica; `secondary` aliases replica so the bootstrap-kit
+can substitute the per-region SOVEREIGN_REGION_ROLE verbatim):
+
+- `side=primary` (cluster-A): primary Cluster CR + the CNPG-managed
+  `-primary-mesh` global Service + audit-config ConfigMap (the
+  bp-continuum prerequisite probe reads it on the primary cluster) +
+  replication-ingress NetworkPolicy + the optional Continuum CR +
+  helm-test resources.
+- `side=replica` (cluster-B): replica Cluster CR (pg_basebackup +
+  externalClusters — the canonical CNPG separate-cluster replica
+  pattern, unchanged) + a local `-primary-mesh` Service stub (Cilium
+  merges global services BY NAME+NAMESPACE across clusters; without a
+  local Service object the externalCluster host is NXDOMAIN on
+  cluster-B; its selector matches zero local Pods so traffic crosses
+  the mesh) + failover-readiness Deployment + probe NetworkPolicies.
+
+Slot 16b applies the HR on BOTH control planes (the former
+SECONDARY_HR_SUSPEND suspend is removed) and the post-mesh #3238 flip
+patches SOVEREIGN_ENABLE_CNPG_PAIR onto ALL region Kustomizations —
+a primary-only flip would leave cluster-B rendering an empty release
+(no replica, no WAL stream).
+
+Cross-cluster prerequisite unchanged from 0.1.x but now explicit: the
+replica's streaming auth mounts the primary's `-replication` / `-ca`
+Secrets, which must be synced cluster-A → cluster-B (ESO/reflector
+per the per-Sovereign overlay).
+
 ---
 
 ## C-DB-3 acceptance test — implementer brief (HARNESS SHIPPED, awaits operator walk)

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -81,7 +81,7 @@ spec:
                   quantities (e.g. "100Gi", "1Ti").
               storageClass:
                 type: string
-                default: hcloud-volumes
+                default: ""
                 description: |
                   StorageClass for the primary's PVCs. H6's
                   bp-hcloud-csi provides `hcloud-volumes` on every
@@ -115,7 +115,7 @@ spec:
                 default: "100Gi"
               storageClass:
                 type: string
-                default: hcloud-volumes
+                default: ""
       walStreaming:
         type: object
         properties:

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -6,18 +6,22 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.1.5
+  version: 0.2.0
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |
-      Active-hotstandby CNPG cluster-pair across two Hetzner regions.
-      Primary postgresql.cnpg.io/v1.Cluster CR in region A; replica
-      Cluster CR in region B configured as a CNPG replica cluster
-      (replica.enabled=true + externalCluster) streaming WAL over a
-      Cilium ClusterMesh-shared Service. Failover-readiness probe Pod
-      flips Ready when WAL lag < threshold so Continuum K-Cont-2 can
-      promote on operator-triggered switchover. Per ADR-0001 §9 the
-      replication transport is ClusterMesh — never public TLS.
+      Active-hotstandby CNPG cluster-pair across two Sovereign regions
+      (two separate clusters joined by Cilium ClusterMesh). Each
+      cluster installs the chart with `side` selecting its half:
+      side=primary renders the primary postgresql.cnpg.io/v1.Cluster
+      CR + the ClusterMesh-global replication Service in region A;
+      side=replica renders the replica Cluster CR in region B
+      (replica.enabled=true + externalCluster, CNPG's separate-cluster
+      replica pattern) streaming WAL over the mesh Service, plus the
+      failover-readiness probe Pod that flips Ready when WAL lag <
+      threshold so Continuum K-Cont-2 can promote on operator-
+      triggered switchover. Per ADR-0001 §9 the replication transport
+      is ClusterMesh — never public TLS.
     icon: cnpg-pair.svg
     category: data
   visibility: listed
@@ -29,6 +33,20 @@ spec:
       - replica
       - image
     properties:
+      side:
+        type: string
+        enum: [primary, replica, secondary]
+        default: primary
+        description: |
+          WHICH HALF of the pair this install renders (chart 0.2.0
+          split-side topology). A 2-region Sovereign is two SEPARATE
+          clusters joined by Cilium ClusterMesh, so each cluster
+          applies the same chart and renders exactly its own half:
+          `primary` → primary Cluster CR + mesh Service + audit-config
+          (region A); `replica` → replica Cluster CR + failover-
+          readiness probe (region B). `secondary` is accepted as an
+          alias for `replica` so the bootstrap-kit slot can substitute
+          the per-region SOVEREIGN_REGION_ROLE value verbatim.
       primary:
         type: object
         required: [region]

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,23 +1,31 @@
 apiVersion: v2
 name: bp-cnpg-pair
-version: 0.1.5
-appVersion: "0.1.4"
+version: 0.2.0
+appVersion: "0.2.0"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair
-  across two Hetzner regions. Companions the existing `bp-cnpg`
-  (operator) Blueprint by shipping the per-Application data-plane:
+  across two Sovereign regions. Companions the existing `bp-cnpg`
+  (operator) Blueprint by shipping the per-Application data-plane.
+  SPLIT-SIDE TOPOLOGY (0.2.0): a 2-region Sovereign is two SEPARATE
+  clusters joined by Cilium ClusterMesh, so each cluster installs the
+  same chart with `cnpgPair.side` selecting WHICH HALF it renders:
+    side=primary (cluster-A):
     - Primary postgresql.cnpg.io/v1.Cluster CR pinned to region A
+    - Cilium ClusterMesh-global `-primary-mesh` Service so the replica
+      region streams WAL bytes over the private mesh, never public TLS
+    - audit-config ConfigMap declaring the NATS audit subjects this
+      Blueprint emits (consumed by Continuum K-Cont-2, which runs on
+      the primary cluster)
+    - replication-ingress NetworkPolicy (default-deny compatible —
+      see platform/network-policies)
+    side=replica (cluster-B):
     - Replica postgresql.cnpg.io/v1.Cluster CR pinned to region B,
       configured as a CNPG replica via `replica.enabled: true` +
       `externalCluster` referencing the primary's replication endpoint
-    - Cilium ClusterMesh-shared Service so the replica region streams
-      WAL bytes over the private mesh, never public TLS
+      (CNPG's canonical separate-cluster replica pattern)
     - Failover-readiness probe Pod that flips Ready when WAL lag falls
       below the configured threshold (replica becomes promotable)
-    - NetworkPolicy carve-out for the replication path (default-deny
-      compatible — see platform/network-policies)
-    - audit-config ConfigMap declaring the NATS audit subjects this
-      Blueprint emits (consumed by Continuum K-Cont-2)
+    - probe NetworkPolicies (ingress-to-replica + probe egress)
 
   This chart ships ZERO upstream Helm subchart bytes — every byte is
   Catalyst-authored, all on top of the CNPG CRDs that bp-cnpg installs.
@@ -32,6 +40,46 @@ description: |
 
   Changelog
   ─────────
+  0.2.0 (2026-06-11, split-side topology, Refs #3236 / #3195 / #2737)
+    - TOPOLOGY-DESIGN CHANGE: new `cnpgPair.side: primary|replica`
+      knob (default `primary`; `secondary` accepted as an alias for
+      `replica` so the bootstrap-kit can substitute the per-region
+      SOVEREIGN_REGION_ROLE verbatim). Chart ≤0.1.x rendered the
+      whole pair in ONE release on the primary cluster and claimed
+      "CNPG schedules each side to its region via node-affinity" —
+      that only holds on a single stretched cluster. A real 2-region
+      Sovereign is two SEPARATE k3s clusters joined by ClusterMesh,
+      so the replica Cluster CR + failover-readiness Deployment
+      pinned to region-B node labels could NEVER schedule on
+      cluster-A (hw126: FailedScheduling 0/4 nodes, affinity requires
+      openova.io/region=hw-me-east-215-b-rtz-prod — every cluster-A
+      node is ...-a-rtz-prod). 0.2.0 splits the render per side:
+        side=primary → primary Cluster CR + `-primary-mesh` global
+        Service + audit-config ConfigMap (bp-continuum's prerequisite
+        probe reads it on the primary cluster) + replication-ingress
+        NetworkPolicy + Continuum CR (when continuum.enabled) +
+        helm-test resources.
+        side=replica → replica Cluster CR (pg_basebackup +
+        externalClusters over the ClusterMesh-global Service — the
+        canonical CNPG separate-cluster replica pattern, unchanged) +
+        a local `-primary-mesh` Service stub (Cilium merges global
+        services BY NAME+NAMESPACE across clusters; without a local
+        Service object the host would be NXDOMAIN on cluster-B — its
+        selector matches zero local Pods so traffic crosses the mesh)
+        + failover-readiness Deployment + probe NetworkPolicies.
+      Slot 16b now applies the HR on BOTH control planes (the
+      SECONDARY_HR_SUSPEND suspend is removed) with
+      `side: ${SOVEREIGN_REGION_ROLE:-primary}`.
+    - Region validation now also runs on the replica-side render
+      (previously only the primary template called validateRegions).
+    - Default-OFF contract UNCHANGED: cnpgPair.enabled=false renders
+      ZERO resources on BOTH sides (byte-identical empty render).
+    - The replica side still mounts the primary's `-replication` /
+      `-ca` Secrets for streaming auth; on separate clusters those
+      Secrets must be synced cluster-A → cluster-B (ESO/reflector per
+      the per-Sovereign overlay) — contract unchanged from 0.1.x,
+      now explicit because the sides live on different clusters.
+
   0.1.4 (2026-06-11, kyverno-Enforce compliance re-cut, Refs #3236 / #2737)
     - The cnpgPair gate flipped TRUE for the first time on hw126 (#3238),
       so the chart's auxiliary workloads reached kyverno Enforce admission

--- a/platform/cnpg-pair/chart/templates/_helpers.tpl
+++ b/platform/cnpg-pair/chart/templates/_helpers.tpl
@@ -71,6 +71,39 @@ replica.region is degenerate). Triggered only when enabled=true.
 {{- end }}
 
 {{/*
+Side resolution — WHICH HALF of the pair this install renders
+(chart 0.2.0 split-side topology).
+
+A 2-region Sovereign is two SEPARATE clusters joined by Cilium
+ClusterMesh, so the pair's objects must be applied per-cluster:
+primary-side objects on cluster-A, replica-side objects on cluster-B.
+The bootstrap-kit slot 16b stamps `cnpgPair.side` from the per-region
+SOVEREIGN_REGION_ROLE cloud-init substitute, whose value domain is
+primary|secondary — normalize "secondary" to "replica" here so the
+slot substitutes the role verbatim. Empty/unset defaults to "primary"
+(standalone single-manifest installs keep the historical behaviour of
+rendering the primary half). Any other value fails the render.
+*/}}
+{{- define "cnpg-pair.side" -}}
+{{- $side := default "primary" .Values.cnpgPair.side -}}
+{{- if eq $side "secondary" -}}
+{{- $side = "replica" -}}
+{{- end -}}
+{{- if and (ne $side "primary") (ne $side "replica") -}}
+{{- fail (printf "cnpgPair.side must be one of primary|replica|secondary — got %q" .Values.cnpgPair.side) -}}
+{{- end -}}
+{{- $side -}}
+{{- end }}
+
+{{- define "cnpg-pair.isPrimarySide" -}}
+{{- if eq (include "cnpg-pair.side" .) "primary" -}}true{{- end -}}
+{{- end }}
+
+{{- define "cnpg-pair.isReplicaSide" -}}
+{{- if eq (include "cnpg-pair.side" .) "replica" -}}true{{- end -}}
+{{- end }}
+
+{{/*
 Canonical CR names — derived from fullname so Continuum + the
 ClusterMesh global Service can compute them deterministically.
 */}}

--- a/platform/cnpg-pair/chart/templates/audit-config.yaml
+++ b/platform/cnpg-pair/chart/templates/audit-config.yaml
@@ -21,8 +21,16 @@ audit-types, and let consumers discover them via label.
 This is a NEW seam — first time we co-locate a NATS audit-config
 with the Blueprint that emits the events. Logged in 01-canonical-
 seams.md "Platform" table.
+
+Side-gating (chart 0.2.0): renders ONLY on side=primary. bp-continuum
+(slot 62) runs on the PRIMARY cluster (its HR is suspended on
+secondary control planes) and its prerequisite-check initContainer
+probes `kubectl get cm -A -l catalyst.openova.io/audit-config=true`
+against ITS OWN cluster — so this ConfigMap must land on the primary
+side for the controller to flip from idle to active. That contract is
+unchanged by the side split.
 */ -}}
-{{- if .Values.cnpgPair.enabled }}
+{{- if and .Values.cnpgPair.enabled (include "cnpg-pair.isPrimarySide" .) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/platform/cnpg-pair/chart/templates/continuum.yaml
+++ b/platform/cnpg-pair/chart/templates/continuum.yaml
@@ -25,8 +25,13 @@ installed without a continuum-controller never emits an orphan CR.
 Status fields are NOT seeded here — the running continuum-controller
 owns status (ADR-0001 §2.7). The QA fixtures seed status because a test
 Sovereign may have no controller running; production always does.
+
+Side-gating (chart 0.2.0): renders ONLY on side=primary — the
+continuum-controller (slot 62) runs on the primary cluster (its HR is
+suspended on secondary control planes), so the CR it reconciles must
+live there too.
 */ -}}
-{{- if and .Values.cnpgPair.enabled .Values.cnpgPair.continuum.enabled }}
+{{- if and .Values.cnpgPair.enabled .Values.cnpgPair.continuum.enabled (include "cnpg-pair.isPrimarySide" .) }}
 {{- include "cnpg-pair.validateRegions" . }}
 {{- $cprim := required "continuum.primaryRegion is REQUIRED when continuum.enabled=true — set the canonical 4-segment label (e.g. hz-fsn-rtz-prod) matching the Continuum CRD pattern ^[a-z]+-[a-z]+-[a-z]+-[a-z]+$" .Values.cnpgPair.continuum.primaryRegion -}}
 {{- $cstby := required "continuum.hotStandbyRegion is REQUIRED when continuum.enabled=true — set the canonical 4-segment label (e.g. hz-hel-rtz-prod)" .Values.cnpgPair.continuum.hotStandbyRegion -}}

--- a/platform/cnpg-pair/chart/templates/failover-readiness.yaml
+++ b/platform/cnpg-pair/chart/templates/failover-readiness.yaml
@@ -16,8 +16,16 @@ applies here too.
 This Pod is the BLUEPRINT's contribution to promotability — it does
 NOT promote the replica itself (Continuum does), it just publishes
 the readiness signal Continuum reads.
+
+Side-gating (chart 0.2.0): renders ONLY on side=replica. The probe
+queries the REPLICA Cluster's local `-r` Service and its node-affinity
+pins the replica region — on the split-side topology it runs ON
+cluster-B, where both exist. Chart ≤0.1.x deployed it on the primary
+cluster where the region-B affinity could never schedule (hw126:
+FailedScheduling 0/4 nodes, affinity requires
+openova.io/region=hw-me-east-215-b-rtz-prod).
 */ -}}
-{{- if .Values.cnpgPair.enabled }}
+{{- if and .Values.cnpgPair.enabled (include "cnpg-pair.isReplicaSide" .) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/platform/cnpg-pair/chart/templates/networkpolicy.yaml
+++ b/platform/cnpg-pair/chart/templates/networkpolicy.yaml
@@ -17,8 +17,15 @@ This is a NamespacePolicy (NetworkPolicy in apps/v1 sense), NOT a
 CiliumClusterwideNetworkPolicy — the chart targets a single
 namespace, and the H8 platform CCNP already covers the cluster-
 scoped default-deny.
+
+Side-gating (chart 0.2.0): a NetworkPolicy must be applied on the
+cluster whose Pods it selects (podSelector is evaluated against LOCAL
+endpoints) — so the replication-ingress policy (selects primary CR
+Pods) renders on side=primary, and the probe policies (select replica
+CR Pods + the probe Pod) render on side=replica.
 */ -}}
 {{- if and .Values.cnpgPair.enabled .Values.cnpgPair.networkPolicy.enabled }}
+{{- if (include "cnpg-pair.isPrimarySide" .) }}
 ---
 # Allow primary CR Pods to accept replication connections from any
 # Pod with `cnpg.io/cluster=<replica>` label. ClusterMesh delivers
@@ -44,6 +51,8 @@ spec:
       ports:
         - port: 5432
           protocol: TCP
+{{- end }}
+{{- if (include "cnpg-pair.isReplicaSide" .) }}
 ---
 # Allow failover-readiness probe Pod to reach the replica's `-r`
 # Service on 5432 (Egress) AND allow the replica cluster's Pods to
@@ -107,4 +116,5 @@ spec:
       ports:
         - port: 5432
           protocol: TCP
+{{- end }}
 {{- end }}

--- a/platform/cnpg-pair/chart/templates/primary-cluster.yaml
+++ b/platform/cnpg-pair/chart/templates/primary-cluster.yaml
@@ -39,7 +39,9 @@ spec:
 
   storage:
     size: {{ .Values.cnpgPair.primary.storage.size | quote }}
-    storageClass: {{ .Values.cnpgPair.primary.storage.storageClass | quote }}
+    {{- with .Values.cnpgPair.primary.storage.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
 
   resources:
     {{- toYaml .Values.cnpgPair.primary.resources | nindent 4 }}

--- a/platform/cnpg-pair/chart/templates/primary-cluster.yaml
+++ b/platform/cnpg-pair/chart/templates/primary-cluster.yaml
@@ -11,8 +11,13 @@ to drive switchover.
 Region-pinning: the `openova.io/region` node-affinity term (paired
 with the matching label on this CR) ensures the operator schedules
 all instances inside the configured Hetzner region.
+
+Side-gating (chart 0.2.0): this CR renders ONLY on side=primary —
+the primary and replica halves of the pair live on SEPARATE clusters
+(ClusterMesh-joined), so cluster-B must never receive the primary
+Cluster CR (its region-A node-affinity could never schedule there).
 */ -}}
-{{- if .Values.cnpgPair.enabled }}
+{{- if and .Values.cnpgPair.enabled (include "cnpg-pair.isPrimarySide" .) }}
 {{- include "cnpg-pair.validateRegions" . }}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster

--- a/platform/cnpg-pair/chart/templates/replica-cluster.yaml
+++ b/platform/cnpg-pair/chart/templates/replica-cluster.yaml
@@ -24,8 +24,17 @@ template that pre-created the Service; CNPG refused to reconcile
 ("not owned by the cluster") and the primary Cluster phase stuck at
 "Unable to create required cluster objects". Phase-2 multi-region
 incident #3 (qa-loop-state/incidents.md, 2026-05-09).
+
+Side-gating (chart 0.2.0): this CR renders ONLY on side=replica — it
+must be APPLIED ON cluster-B (the replica region's own cluster), where
+its region-B node-affinity matches the local nodes. Chart ≤0.1.x
+rendered it on the primary cluster and the CR could never schedule
+(hw126: FailedScheduling 0/4 nodes). The pg_basebackup +
+externalClusters design below is precisely CNPG's separate-cluster
+replica pattern; only the apply TARGET was wrong.
 */ -}}
-{{- if .Values.cnpgPair.enabled }}
+{{- if and .Values.cnpgPair.enabled (include "cnpg-pair.isReplicaSide" .) }}
+{{- include "cnpg-pair.validateRegions" . }}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/platform/cnpg-pair/chart/templates/replica-cluster.yaml
+++ b/platform/cnpg-pair/chart/templates/replica-cluster.yaml
@@ -54,7 +54,9 @@ spec:
 
   storage:
     size: {{ .Values.cnpgPair.replica.storage.size | quote }}
-    storageClass: {{ .Values.cnpgPair.replica.storage.storageClass | quote }}
+    {{- with .Values.cnpgPair.replica.storage.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
 
   resources:
     {{- toYaml .Values.cnpgPair.replica.resources | nindent 4 }}

--- a/platform/cnpg-pair/chart/templates/replica-mesh-service.yaml
+++ b/platform/cnpg-pair/chart/templates/replica-mesh-service.yaml
@@ -1,0 +1,59 @@
+{{- /*
+Replica-side ClusterMesh global Service stub (chart 0.2.0).
+
+Cilium ClusterMesh global services are merged BY NAME+NAMESPACE: a
+Service participates in the mesh only if a Service object with the
+same name + namespace exists in EVERY consuming cluster, each
+annotated `service.cilium.io/global: "true"` (upstream Cilium
+ClusterMesh contract). On the split-side topology the primary side's
+`-primary-mesh` Service is CNPG-managed on cluster-A (via the primary
+Cluster CR's `spec.managed.services.additional[]`) — but cluster-B
+has no primary Cluster CR, so nothing creates the local Service the
+replica's `externalClusters.connectionParameters.host` resolves:
+without this stub, DNS for `<fullname>-primary-mesh` is NXDOMAIN on
+cluster-B and the replica can never open its streaming connection.
+
+This stub:
+  - carries the SAME name (`<fullname>-primary-mesh`), port (5432),
+    and global/affinity annotations as the primary side's managed
+    Service, so Cilium merges the two into one global service;
+  - uses the primary Cluster's `-r`-equivalent selector
+    (`cnpg.io/cluster: <fullname>-primary`), which matches ZERO Pods
+    on cluster-B — so every connection routes across the mesh to the
+    primary region's backends (the `affinity: local` hint falls
+    through to remote when no local backend exists);
+  - does NOT collide with CNPG ownership: the local CNPG operator on
+    cluster-B manages only the replica Cluster's Services
+    (`<fullname>-replica-r/-ro/-rw`), never this name. (The 0.1.0
+    "refusing to reconcile service" incident was a SAME-cluster
+    collision with the primary CR's auto-created `-r` — not possible
+    here, the primary CR lives on the other cluster.)
+*/ -}}
+{{- if and .Values.cnpgPair.enabled .Values.cnpgPair.clusterMesh.enabled (include "cnpg-pair.isReplicaSide" .) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cnpg-pair.replicationServiceName" . }}
+  labels:
+    {{- include "cnpg-pair.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
+    catalyst.openova.io/role: replication-source
+  annotations:
+    # Cilium ClusterMesh — same annotations as the primary side's
+    # CNPG-managed Service so the mesh merges both into one global
+    # service. Zero local backends here → traffic crosses the mesh.
+    service.cilium.io/global: "true"
+    service.cilium.io/affinity: {{ .Values.cnpgPair.clusterMesh.affinity | quote }}
+    catalyst.openova.io/blueprint: bp-cnpg-pair
+spec:
+  type: ClusterIP
+  selector:
+    # CNPG `-r` selector shape for the PRIMARY Cluster — matches zero
+    # Pods on the replica cluster by construction.
+    cnpg.io/cluster: {{ include "cnpg-pair.primaryName" . }}
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+      protocol: TCP
+{{- end }}

--- a/platform/cnpg-pair/chart/templates/tests/test-replication.yaml
+++ b/platform/cnpg-pair/chart/templates/tests/test-replication.yaml
@@ -16,8 +16,13 @@ assertion is run by the qa-loop test executor on the replica cluster
 Per BLUEPRINT-AUTHORING.md §11, helm-test Pods carry the
 `helm.sh/hook: test` annotation so `helm test` discovers them; they are
 NOT installed by default reconciliation.
+
+Side-gating (chart 0.2.0): renders ONLY on side=primary — every
+assertion below (primary Cluster Ready, `-mesh` Service, pg_isready
+against `-rw`) targets primary-side objects, which on the split-side
+topology exist only on cluster-A.
 */ -}}
-{{- if .Values.cnpgPair.enabled }}
+{{- if and .Values.cnpgPair.enabled (include "cnpg-pair.isPrimarySide" .) }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -1,32 +1,48 @@
 #!/usr/bin/env bash
-# bp-cnpg-pair render gate (slice C-DB-1, #1101; chart 0.1.1).
+# bp-cnpg-pair render gate (slice C-DB-1, #1101; chart 0.2.0 split-side).
 #
 # Asserts the chart's load-bearing rules:
-#   1. Default render (cnpgPair.enabled=false) → ZERO resources.
-#   2. Enabled render with full values → 7 resources (primary +
-#      replica + probe Deployment + 3 NetworkPolicies +
-#      audit-config ConfigMap). The replication Service is no
-#      longer hand-rendered — it is declared via the primary
-#      Cluster's `spec.managed.services.additional[]` so CNPG owns
-#      it (chart 0.1.1, fix for Phase-2 multi-region incident #3).
-#   3. Enabled with empty image.tag → fails with documented error.
-#   4. Enabled with same primary/replica region → fails with
-#      documented error.
-#   5. ClusterMesh disabled → primary Cluster carries no
-#      `managed.services.additional` block (no global Service
-#      published across the mesh).
-#   6. `hot_standby` is NOT set in either Cluster CR's postgresql
+#   1. Default render (cnpgPair.enabled=false) → ZERO resources, on
+#      BOTH sides (side=primary and side=replica) — byte-identical
+#      empty renders.
+#   2. Enabled side=primary render → 3 non-test resources (primary
+#      Cluster CR + audit-config ConfigMap + replication-ingress
+#      NetworkPolicy) + 4 helm-test resources. NO replica Cluster, NO
+#      failover-readiness Deployment (those live on cluster-B — chart
+#      0.2.0: a 2-region Sovereign is two SEPARATE clusters joined by
+#      ClusterMesh; region-B-pinned workloads can never schedule on
+#      cluster-A, hw126 FailedScheduling).
+#   3. Enabled side=replica render → 5 non-test resources (replica
+#      Cluster CR + `-primary-mesh` global Service stub + failover-
+#      readiness Deployment + 2 probe NetworkPolicies) + 0 helm-test.
+#      NO primary Cluster, NO audit-config (bp-continuum's prerequisite
+#      probe reads it on the primary cluster).
+#   4. `side: secondary` is accepted as an alias for replica (the
+#      bootstrap-kit substitutes SOVEREIGN_REGION_ROLE verbatim, whose
+#      domain is primary|secondary); any other value fails the render.
+#   5. Enabled with empty image.tag → fails with documented error
+#      (both sides).
+#   6. Enabled with same primary/replica region → fails with
+#      documented error (both sides — validateRegions runs on each).
+#   7. ClusterMesh disabled → primary side carries no
+#      `managed.services.additional` block; replica side renders no
+#      Service stub (no global Service published across the mesh).
+#   8. `hot_standby` is NOT set in either Cluster CR's postgresql
 #      parameters (PG16 hard-pins it; CNPG rejects explicit set).
-#   7. Replica Cluster carries `bootstrap.pg_basebackup` referencing
-#      the primary externalCluster (replica cannot bootstrap without).
-#   8. (chart 0.1.3 #3195) Synchronous replication is declared via the
+#   9. Replica Cluster carries `bootstrap.pg_basebackup` referencing
+#      the primary externalCluster (replica cannot bootstrap without),
+#      and its externalCluster.host targets the `-primary-mesh` global
+#      Service the local stub + ClusterMesh resolve.
+#  10. (chart 0.1.3 #3195) Synchronous replication is declared via the
 #      CNPG-native `spec.postgresql.synchronous` block (method=first +
 #      dataDurability=required), NOT a raw `synchronous_standby_names`
 #      parameter — the latter is a FIXED parameter CNPG ≥1.24 rejects
 #      at admission (verified live CNPG 1.29.0 / hw124).
-#   9. (chart 0.1.3 #3195) continuum.enabled seeds exactly one Continuum
+#  11. (chart 0.1.3 #3195) continuum.enabled seeds exactly one Continuum
 #      CR with the canonical 4-segment region labels, gated on BOTH
-#      cnpgPair.enabled AND continuum.enabled, fail-fast on empty regions.
+#      cnpgPair.enabled AND continuum.enabled, fail-fast on empty
+#      regions — and (0.2.0) ONLY on side=primary, where the continuum-
+#      controller runs.
 #
 # Usage: bash tests/cnpg-pair-render.sh [CHART_DIR]
 #
@@ -40,47 +56,49 @@ trap 'rm -rf "$TMP"' EXIT
 
 cd "$CHART_DIR"
 
-# ── Case 1: default render (disabled) ────────────────────────────
-echo "[render] Case 1: default render (cnpgPair.enabled=false) emits ZERO resources"
-helm template smoke-cnpg-pair . > "$TMP/disabled.yaml" 2> "$TMP/disabled.err" || {
-  echo "FAIL: default-disabled render errored:" >&2
-  cat "$TMP/disabled.err" >&2
+# ── Case 1: default render (disabled) — both sides ───────────────
+echo "[render] Case 1: default render (cnpgPair.enabled=false) emits ZERO resources on BOTH sides"
+helm template smoke-cnpg-pair . > "$TMP/disabled-primary.yaml" 2> "$TMP/disabled-primary.err" || {
+  echo "FAIL: default-disabled (side=primary) render errored:" >&2
+  cat "$TMP/disabled-primary.err" >&2
   exit 1
 }
-# A YAML doc with only template comments + zero `kind:` lines is
-# correct for a fully-disabled render.
-KINDS=$(grep -cE "^kind: " "$TMP/disabled.yaml" || true)
-if [ "$KINDS" -ne 0 ]; then
-  echo "FAIL: default render produced $KINDS resource(s); expected 0." >&2
-  grep -E "^kind: " "$TMP/disabled.yaml" >&2
+helm template smoke-cnpg-pair . --set cnpgPair.side=replica \
+  > "$TMP/disabled-replica.yaml" 2> "$TMP/disabled-replica.err" || {
+  echo "FAIL: default-disabled (side=replica) render errored:" >&2
+  cat "$TMP/disabled-replica.err" >&2
   exit 1
-fi
+}
+for f in disabled-primary disabled-replica; do
+  KINDS=$(grep -cE "^kind: " "$TMP/$f.yaml" || true)
+  if [ "$KINDS" -ne 0 ]; then
+    echo "FAIL: $f render produced $KINDS resource(s); expected 0." >&2
+    grep -E "^kind: " "$TMP/$f.yaml" >&2
+    exit 1
+  fi
+done
 echo "  PASS"
 
-# ── Case 2: full-on render ───────────────────────────────────────
-echo "[render] Case 2: enabled render emits all expected resources"
+# ── Case 2: side=primary enabled render ──────────────────────────
+echo "[render] Case 2: enabled side=primary render emits the primary half only"
 helm template smoke-cnpg-pair . \
   --set cnpgPair.enabled=true \
   --set cnpgPair.primary.region=hz-fsn-rtz-prod \
   --set cnpgPair.replica.region=hz-hel-rtz-prod \
   --set cnpgPair.image.tag=16.3-23 \
-  > "$TMP/enabled.yaml" 2> "$TMP/enabled.err" || {
-  echo "FAIL: enabled render errored:" >&2
-  cat "$TMP/enabled.err" >&2
+  > "$TMP/primary.yaml" 2> "$TMP/primary.err" || {
+  echo "FAIL: side=primary render errored:" >&2
+  cat "$TMP/primary.err" >&2
   exit 1
 }
 
-# Expect 1×Cluster (primary) + 1×Cluster (replica) + 1×Deployment
-# (probe) + 3×NetworkPolicy + 1×ConfigMap = 7 non-test kinds. The
-# replication Service is now CNPG-managed via the primary Cluster's
-# spec.managed.services.additional, so it is NOT a kind in the
-# rendered manifest. Helm-test resources (Pod + ServiceAccount + Role
-# + RoleBinding under templates/tests/) ARE rendered by `helm template`
-# but are filtered at install time by Helm's hook semantics; we
-# count them separately.
-EXPECTED_NONTEST=7
-EXPECTED_TEST=4
-if ! python3 - "$TMP/enabled.yaml" > "$TMP/render-counts" <<'PYEOF'
+# Expect 1×Cluster (primary) + 1×ConfigMap (audit) + 1×NetworkPolicy
+# (replication ingress) = 3 non-test kinds; helm-test Pod + SA + Role
+# + RoleBinding = 4 test kinds. The replication Service is CNPG-
+# managed via the primary Cluster's spec.managed.services.additional,
+# so it is NOT a kind in the rendered manifest.
+count_resources() {
+  python3 - "$1" <<'PYEOF'
 import sys, yaml
 docs = list(yaml.safe_load_all(open(sys.argv[1])))
 docs = [d for d in docs if d]
@@ -89,185 +107,271 @@ nontest = [d for d in docs if d not in test]
 print(f"NONTEST={len(nontest)}")
 print(f"TEST={len(test)}")
 PYEOF
-then
-  echo "FAIL: helm template output failed to parse as YAML" >&2
+}
+count_resources "$TMP/primary.yaml" > "$TMP/primary-counts" || {
+  echo "FAIL: side=primary output failed to parse as YAML" >&2
+  exit 1
+}
+NONTEST=$(grep -E '^NONTEST=' "$TMP/primary-counts" | cut -d= -f2)
+TEST=$(grep -E '^TEST=' "$TMP/primary-counts" | cut -d= -f2)
+if [ "$NONTEST" -ne 3 ] || [ "$TEST" -ne 4 ]; then
+  echo "FAIL: side=primary expected 3 non-test + 4 test resources, got $NONTEST + $TEST." >&2
+  grep -E "^kind: " "$TMP/primary.yaml" >&2
   exit 1
 fi
-NONTEST=$(grep -E '^NONTEST=' "$TMP/render-counts" | cut -d= -f2)
-TEST=$(grep -E '^TEST=' "$TMP/render-counts" | cut -d= -f2)
-if [ "$NONTEST" -ne "$EXPECTED_NONTEST" ]; then
-  echo "FAIL: expected $EXPECTED_NONTEST non-test resources, got $NONTEST." >&2
-  grep -E "^kind: " "$TMP/enabled.yaml" >&2
-  exit 1
-fi
-if [ "$TEST" -ne "$EXPECTED_TEST" ]; then
-  echo "FAIL: expected $EXPECTED_TEST helm-test resources, got $TEST." >&2
-  exit 1
-fi
-GOT="$NONTEST non-test + $TEST test"
 
-# Spot-check a few load-bearing assertions:
-grep -q "kind: Cluster" "$TMP/enabled.yaml" || {
-  echo "FAIL: no CNPG Cluster CR rendered." >&2
-  exit 1
-}
-# The Cilium global annotation is now nested INSIDE the primary
-# Cluster's spec.managed.services.additional[*].serviceTemplate
-# rather than on a standalone Service. Either way it must show up.
-grep -q 'service.cilium.io/global: "true"' "$TMP/enabled.yaml" || {
-  echo "FAIL: primary Cluster CR missing managed.services.additional service.cilium.io/global=true annotation." >&2
-  exit 1
-}
-grep -q "openova.io/cnpg-role: primary" "$TMP/enabled.yaml" || {
+grep -q "openova.io/cnpg-role: primary" "$TMP/primary.yaml" || {
   echo "FAIL: primary Cluster CR missing openova.io/cnpg-role=primary label." >&2
   exit 1
 }
-grep -q "openova.io/cnpg-role: replica" "$TMP/enabled.yaml" || {
-  echo "FAIL: replica Cluster CR missing openova.io/cnpg-role=replica label." >&2
+if grep -q "openova.io/cnpg-role: replica" "$TMP/primary.yaml"; then
+  echo "FAIL: side=primary rendered the replica Cluster CR — it must apply on cluster-B only (split-side 0.2.0)." >&2
+  exit 1
+fi
+if grep -q "^kind: Deployment" "$TMP/primary.yaml"; then
+  echo "FAIL: side=primary rendered the failover-readiness Deployment — its region-B affinity can never schedule on cluster-A (hw126)." >&2
+  exit 1
+fi
+# The Cilium global annotation is nested INSIDE the primary Cluster's
+# spec.managed.services.additional[*].serviceTemplate.
+grep -q 'service.cilium.io/global: "true"' "$TMP/primary.yaml" || {
+  echo "FAIL: primary Cluster CR missing managed.services.additional service.cilium.io/global=true annotation." >&2
   exit 1
 }
-grep -q "kind: ConfigMap" "$TMP/enabled.yaml" || {
-  echo "FAIL: audit-config ConfigMap not rendered." >&2
+grep -q "kind: ConfigMap" "$TMP/primary.yaml" || {
+  echo "FAIL: audit-config ConfigMap not rendered on side=primary (bp-continuum prerequisite probe reads it there)." >&2
   exit 1
 }
-grep -q "audit.subject:" "$TMP/enabled.yaml" || {
+grep -q "audit.subject:" "$TMP/primary.yaml" || {
   echo "FAIL: audit-config ConfigMap missing audit.subject key." >&2
   exit 1
 }
 # Bug-fix #3 from Phase-2 incidents: hot_standby MUST NOT be present
-# in either Cluster CR's postgresql.parameters block (PG16 fixed-param,
-# CNPG rejects).
-if grep -q 'hot_standby:' "$TMP/enabled.yaml"; then
-  echo "FAIL: hot_standby parameter present in rendered manifest — PG16 fixed-param, CNPG rejects." >&2
-  grep -nE 'hot_standby:' "$TMP/enabled.yaml" >&2
+# (PG16 fixed-param, CNPG rejects).
+if grep -q 'hot_standby:' "$TMP/primary.yaml"; then
+  echo "FAIL: hot_standby parameter present in side=primary manifest — PG16 fixed-param, CNPG rejects." >&2
   exit 1
 fi
-# Bug-fix #2: replica Cluster MUST carry bootstrap.pg_basebackup
-# (otherwise the replica phase sticks at "Setting up primary").
-grep -q 'pg_basebackup:' "$TMP/enabled.yaml" || {
-  echo "FAIL: replica Cluster CR missing bootstrap.pg_basebackup stanza." >&2
-  exit 1
-}
-# Bug-fix #3: replica Cluster's externalCluster.host points at the
-# CNPG-managed `-mesh` Service (NOT the conflicting `-r`).
-grep -qE 'host: .*-mesh$' "$TMP/enabled.yaml" || {
-  echo "FAIL: replica externalCluster does not reference the CNPG-managed -mesh Service." >&2
-  grep -nE 'host:' "$TMP/enabled.yaml" >&2
-  exit 1
-}
 # Pillar 3 (chart 0.1.2): synchronous replication MUST be the default.
-# The primary's postgresql.parameters block carries:
-#   synchronous_commit: "remote_apply"
-# and (chart 0.1.3, #3195) declares the standby quorum via CNPG's NATIVE
-# `spec.postgresql.synchronous` block (method=first/number=N/data
-# Durability=required) instead of a raw `synchronous_standby_names`
-# parameter — the latter is a FIXED config parameter CNPG ≥1.24 REJECTS
-# at admission ("Can't set fixed configuration parameter", verified live
-# on CNPG 1.29.0 / hw124). CNPG derives synchronous_standby_names from
-# the block.
-grep -q 'synchronous_commit: "remote_apply"' "$TMP/enabled.yaml" || {
+grep -q 'synchronous_commit: "remote_apply"' "$TMP/primary.yaml" || {
   echo "FAIL: primary Cluster CR missing synchronous_commit=remote_apply (Pillar 3 zero-tx-loss default)." >&2
   exit 1
 }
-# Native synchronous block — method=first + number + dataDurability=required.
-grep -qE '^\s+method: first' "$TMP/enabled.yaml" || {
+# Native synchronous block — method=first + number + dataDurability=required
+# (raw synchronous_standby_names is a FIXED parameter CNPG rejects).
+grep -qE '^\s+method: first' "$TMP/primary.yaml" || {
   echo "FAIL: primary Cluster CR missing spec.postgresql.synchronous.method=first (CNPG-native sync quorum)." >&2
-  grep -nE 'synchronous|method:' "$TMP/enabled.yaml" >&2
   exit 1
 }
-grep -qE '^\s+dataDurability: required' "$TMP/enabled.yaml" || {
+grep -qE '^\s+dataDurability: required' "$TMP/primary.yaml" || {
   echo "FAIL: primary Cluster CR missing spec.postgresql.synchronous.dataDurability=required (zero-tx-loss enforcement)." >&2
   exit 1
 }
-# The raw fixed-parameter form MUST be ABSENT (CNPG rejects it). Match
-# the YAML key with a value (`synchronous_standby_names: ...`), not the
-# explanatory comments that mention the parameter name.
-if grep -qE '^\s*synchronous_standby_names:\s' "$TMP/enabled.yaml"; then
-  echo "FAIL: primary Cluster CR sets synchronous_standby_names as a raw parameter — CNPG rejects this fixed parameter at admission. Use spec.postgresql.synchronous instead." >&2
-  grep -nE '^\s*synchronous_standby_names:\s' "$TMP/enabled.yaml" >&2
+if grep -qE '^\s*synchronous_standby_names:\s' "$TMP/primary.yaml"; then
+  echo "FAIL: primary Cluster CR sets synchronous_standby_names as a raw parameter — CNPG rejects this fixed parameter at admission." >&2
   exit 1
 fi
-echo "  PASS ($GOT resources)"
+echo "  PASS (3 non-test + 4 test resources)"
 
-# ── Case 3: missing image.tag fails fast ─────────────────────────
-echo "[render] Case 3: empty image.tag triggers fail-fast"
+# ── Case 3: side=replica enabled render ──────────────────────────
+echo "[render] Case 3: enabled side=replica render emits the replica half only"
+helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.side=replica \
+  --set cnpgPair.primary.region=hz-fsn-rtz-prod \
+  --set cnpgPair.replica.region=hz-hel-rtz-prod \
+  --set cnpgPair.image.tag=16.3-23 \
+  > "$TMP/replica.yaml" 2> "$TMP/replica.err" || {
+  echo "FAIL: side=replica render errored:" >&2
+  cat "$TMP/replica.err" >&2
+  exit 1
+}
+count_resources "$TMP/replica.yaml" > "$TMP/replica-counts" || {
+  echo "FAIL: side=replica output failed to parse as YAML" >&2
+  exit 1
+}
+NONTEST=$(grep -E '^NONTEST=' "$TMP/replica-counts" | cut -d= -f2)
+TEST=$(grep -E '^TEST=' "$TMP/replica-counts" | cut -d= -f2)
+# 1×Cluster (replica) + 1×Service (mesh stub) + 1×Deployment (probe)
+# + 2×NetworkPolicy = 5 non-test; helm-test renders on primary only.
+if [ "$NONTEST" -ne 5 ] || [ "$TEST" -ne 0 ]; then
+  echo "FAIL: side=replica expected 5 non-test + 0 test resources, got $NONTEST + $TEST." >&2
+  grep -E "^kind: " "$TMP/replica.yaml" >&2
+  exit 1
+fi
+grep -q "openova.io/cnpg-role: replica" "$TMP/replica.yaml" || {
+  echo "FAIL: replica Cluster CR missing openova.io/cnpg-role=replica label." >&2
+  exit 1
+}
+if grep -q "openova.io/cnpg-role: primary" "$TMP/replica.yaml"; then
+  echo "FAIL: side=replica rendered the primary Cluster CR — it must apply on cluster-A only (split-side 0.2.0)." >&2
+  exit 1
+fi
+grep -q "^kind: Deployment" "$TMP/replica.yaml" || {
+  echo "FAIL: side=replica missing the failover-readiness Deployment — it runs ON cluster-B where its region-B affinity matches." >&2
+  exit 1
+}
+# The probe Deployment pins the REPLICA region (it now schedules,
+# because cluster-B's nodes carry that label).
+grep -q 'values: \["hz-hel-rtz-prod"\]' "$TMP/replica.yaml" || {
+  echo "FAIL: side=replica workloads do not pin the replica region label." >&2
+  exit 1
+}
+# Bug-fix #2: replica Cluster MUST carry bootstrap.pg_basebackup
+# (otherwise the replica phase sticks at "Setting up primary").
+grep -q 'pg_basebackup:' "$TMP/replica.yaml" || {
+  echo "FAIL: replica Cluster CR missing bootstrap.pg_basebackup stanza." >&2
+  exit 1
+}
+# Replica's externalCluster.host points at the `-primary-mesh` global
+# Service; the local stub Service of the SAME NAME must be rendered
+# (Cilium merges global services by name+namespace — without the local
+# object the host is NXDOMAIN on cluster-B).
+grep -qE 'host: .*-primary-mesh$' "$TMP/replica.yaml" || {
+  echo "FAIL: replica externalCluster does not reference the -primary-mesh global Service." >&2
+  grep -nE 'host:' "$TMP/replica.yaml" >&2
+  exit 1
+}
+grep -q "^kind: Service" "$TMP/replica.yaml" || {
+  echo "FAIL: side=replica missing the -primary-mesh Service stub (ClusterMesh global-service name+namespace merge)." >&2
+  exit 1
+}
+grep -q 'service.cilium.io/global: "true"' "$TMP/replica.yaml" || {
+  echo "FAIL: replica-side mesh Service stub missing service.cilium.io/global=true annotation." >&2
+  exit 1
+}
+if grep -q "kind: ConfigMap" "$TMP/replica.yaml"; then
+  echo "FAIL: side=replica rendered the audit-config ConfigMap — bp-continuum probes it on the PRIMARY cluster." >&2
+  exit 1
+fi
+if grep -q 'hot_standby:' "$TMP/replica.yaml"; then
+  echo "FAIL: hot_standby parameter present in side=replica manifest — PG16 fixed-param, CNPG rejects." >&2
+  exit 1
+fi
+echo "  PASS (5 non-test resources)"
+
+# ── Case 4: side normalization + invalid side fail-fast ──────────
+echo "[render] Case 4: side=secondary aliases replica; invalid side fails fast"
+helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.side=secondary \
+  --set cnpgPair.primary.region=hz-fsn-rtz-prod \
+  --set cnpgPair.replica.region=hz-hel-rtz-prod \
+  --set cnpgPair.image.tag=16.3-23 \
+  > "$TMP/secondary.yaml" 2> "$TMP/secondary.err" || {
+  echo "FAIL: side=secondary render errored (must alias replica):" >&2
+  cat "$TMP/secondary.err" >&2
+  exit 1
+}
+if ! diff -q "$TMP/secondary.yaml" "$TMP/replica.yaml" >/dev/null; then
+  echo "FAIL: side=secondary render differs from side=replica — the alias must be byte-identical." >&2
+  exit 1
+fi
 if helm template smoke-cnpg-pair . \
      --set cnpgPair.enabled=true \
+     --set cnpgPair.side=bogus \
      --set cnpgPair.primary.region=hz-fsn-rtz-prod \
      --set cnpgPair.replica.region=hz-hel-rtz-prod \
-     > "$TMP/notag.yaml" 2> "$TMP/notag.err"; then
-  echo "FAIL: render succeeded with empty cnpgPair.image.tag — should have failed fast." >&2
-  exit 1
-fi
-if ! grep -q "cnpgPair.image.tag is REQUIRED" "$TMP/notag.err"; then
-  echo "FAIL: expected fail-fast error mentioning cnpgPair.image.tag is REQUIRED:" >&2
-  cat "$TMP/notag.err" >&2
-  exit 1
-fi
-echo "  PASS"
-
-# ── Case 4: same primary/replica region fails fast ───────────────
-echo "[render] Case 4: same primary/replica region triggers fail-fast"
-if helm template smoke-cnpg-pair . \
-     --set cnpgPair.enabled=true \
-     --set cnpgPair.primary.region=hz-fsn-rtz-prod \
-     --set cnpgPair.replica.region=hz-fsn-rtz-prod \
      --set cnpgPair.image.tag=16.3-23 \
-     > "$TMP/sameregion.yaml" 2> "$TMP/sameregion.err"; then
-  echo "FAIL: render succeeded with primary.region == replica.region — should have failed fast." >&2
+     > /dev/null 2> "$TMP/badside.err"; then
+  echo "FAIL: render succeeded with cnpgPair.side=bogus — should have failed fast." >&2
   exit 1
 fi
-if ! grep -q "MUST NOT equal" "$TMP/sameregion.err"; then
-  echo "FAIL: expected fail-fast error mentioning regions MUST NOT equal:" >&2
-  cat "$TMP/sameregion.err" >&2
+grep -q "cnpgPair.side must be one of" "$TMP/badside.err" || {
+  echo "FAIL: expected fail-fast error mentioning cnpgPair.side:" >&2
+  cat "$TMP/badside.err" >&2
   exit 1
-fi
+}
 echo "  PASS"
 
-# ── Case 5: ClusterMesh disabled → no managed-service block ──────
-# Chart 0.1.1: the replication Service is no longer a standalone kind;
-# it lives inside the primary Cluster's spec.managed.services.additional.
-# When ClusterMesh is disabled, that block must not be present so no
-# global Service annotation leaks out.
-echo "[render] Case 5: clusterMesh.enabled=false omits managed.services.additional"
+# ── Case 5: missing image.tag fails fast (both sides) ────────────
+echo "[render] Case 5: empty image.tag triggers fail-fast on both sides"
+for side in primary replica; do
+  if helm template smoke-cnpg-pair . \
+       --set cnpgPair.enabled=true \
+       --set cnpgPair.side="$side" \
+       --set cnpgPair.primary.region=hz-fsn-rtz-prod \
+       --set cnpgPair.replica.region=hz-hel-rtz-prod \
+       > "$TMP/notag-$side.yaml" 2> "$TMP/notag-$side.err"; then
+    echo "FAIL: side=$side render succeeded with empty cnpgPair.image.tag — should have failed fast." >&2
+    exit 1
+  fi
+  grep -q "cnpgPair.image.tag is REQUIRED" "$TMP/notag-$side.err" || {
+    echo "FAIL: side=$side expected fail-fast error mentioning cnpgPair.image.tag is REQUIRED:" >&2
+    cat "$TMP/notag-$side.err" >&2
+    exit 1
+  }
+done
+echo "  PASS"
+
+# ── Case 6: same primary/replica region fails fast (both sides) ──
+echo "[render] Case 6: same primary/replica region triggers fail-fast on both sides"
+for side in primary replica; do
+  if helm template smoke-cnpg-pair . \
+       --set cnpgPair.enabled=true \
+       --set cnpgPair.side="$side" \
+       --set cnpgPair.primary.region=hz-fsn-rtz-prod \
+       --set cnpgPair.replica.region=hz-fsn-rtz-prod \
+       --set cnpgPair.image.tag=16.3-23 \
+       > "$TMP/sameregion-$side.yaml" 2> "$TMP/sameregion-$side.err"; then
+    echo "FAIL: side=$side render succeeded with primary.region == replica.region — should have failed fast." >&2
+    exit 1
+  fi
+  grep -q "MUST NOT equal" "$TMP/sameregion-$side.err" || {
+    echo "FAIL: side=$side expected fail-fast error mentioning regions MUST NOT equal:" >&2
+    cat "$TMP/sameregion-$side.err" >&2
+    exit 1
+  }
+done
+echo "  PASS"
+
+# ── Case 7: ClusterMesh disabled — no global Service either side ─
+echo "[render] Case 7: clusterMesh.enabled=false omits the global Service on both sides"
 helm template smoke-cnpg-pair . \
   --set cnpgPair.enabled=true \
   --set cnpgPair.primary.region=hz-fsn-rtz-prod \
   --set cnpgPair.replica.region=hz-hel-rtz-prod \
   --set cnpgPair.image.tag=16.3-23 \
   --set cnpgPair.clusterMesh.enabled=false \
-  > "$TMP/nomesh.yaml" 2> "$TMP/nomesh.err" || {
-  echo "FAIL: nomesh render errored:" >&2
-  cat "$TMP/nomesh.err" >&2
+  > "$TMP/nomesh-primary.yaml" 2>&1 || {
+  echo "FAIL: nomesh side=primary render errored:" >&2
+  cat "$TMP/nomesh-primary.yaml" >&2
   exit 1
 }
-SERVICES=$(awk '/^kind: Service$/{print}' "$TMP/nomesh.yaml" | grep -c . || true)
-if [ "$SERVICES" -ne 0 ]; then
-  echo "FAIL: clusterMesh disabled but standalone Service still rendered." >&2
-  exit 1
-fi
 # Strip comment lines + helm-test resources before checking for the
 # annotation; the helm-test Pod's command body contains the literal
-# string "service.cilium.io/global" as part of an assertion message,
-# which would otherwise false-positive.
-python3 - "$TMP/nomesh.yaml" > "$TMP/nomesh-nontest.yaml" <<'PYEOF'
+# string "service.cilium.io/global" as part of an assertion message.
+python3 - "$TMP/nomesh-primary.yaml" > "$TMP/nomesh-primary-nontest.yaml" <<'PYEOF'
 import sys, yaml
 docs = list(yaml.safe_load_all(open(sys.argv[1])))
 nontest = [d for d in docs if d and 'helm.sh/hook' not in (d.get('metadata',{}).get('annotations') or {})]
 print(yaml.safe_dump_all(nontest))
 PYEOF
-if sed 's/#.*//' "$TMP/nomesh-nontest.yaml" | grep -q 'service\.cilium\.io/global'; then
-  echo "FAIL: clusterMesh disabled but service.cilium.io/global annotation still rendered." >&2
+if sed 's/#.*//' "$TMP/nomesh-primary-nontest.yaml" | grep -q 'service\.cilium\.io/global'; then
+  echo "FAIL: clusterMesh disabled but side=primary still renders service.cilium.io/global." >&2
+  exit 1
+fi
+helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.side=replica \
+  --set cnpgPair.primary.region=hz-fsn-rtz-prod \
+  --set cnpgPair.replica.region=hz-hel-rtz-prod \
+  --set cnpgPair.image.tag=16.3-23 \
+  --set cnpgPair.clusterMesh.enabled=false \
+  > "$TMP/nomesh-replica.yaml" 2>&1 || {
+  echo "FAIL: nomesh side=replica render errored:" >&2
+  cat "$TMP/nomesh-replica.yaml" >&2
+  exit 1
+}
+SERVICES=$(grep -cE '^kind: Service$' "$TMP/nomesh-replica.yaml" || true)
+if [ "$SERVICES" -ne 0 ]; then
+  echo "FAIL: clusterMesh disabled but side=replica still renders the mesh Service stub." >&2
   exit 1
 fi
 echo "  PASS"
 
-# ── Case 6: replication.mode=async omits synchronous_* parameters ─
-# Chart 0.1.2: the synchronous block exists ONLY when mode=sync.
-# Forensic / lab overlays opting into async MUST get a primary
-# Cluster CR with no synchronous_commit / synchronous_standby_names
-# entries (PG falls back to defaults).
-echo "[render] Case 6: replication.mode=async omits synchronous_* parameters"
+# ── Case 8: replication.mode=async omits synchronous_* parameters ─
+echo "[render] Case 8: replication.mode=async omits synchronous_* parameters"
 helm template smoke-cnpg-pair . \
   --set cnpgPair.enabled=true \
   --set cnpgPair.primary.region=hz-fsn-rtz-prod \
@@ -279,9 +383,6 @@ helm template smoke-cnpg-pair . \
   cat "$TMP/async.err" >&2
   exit 1
 }
-# Match actual YAML keys (key: value), not the explanatory comments that
-# reference the parameter names. Async MUST omit synchronous_commit, the
-# native `synchronous:` block, and any raw synchronous_standby_names.
 if grep -qE '^\s*synchronous_commit:\s' "$TMP/async.yaml" \
    || grep -qE '^\s*synchronous_standby_names:\s' "$TMP/async.yaml" \
    || grep -qE '^\s*synchronous:\s*$' "$TMP/async.yaml"; then
@@ -291,13 +392,8 @@ if grep -qE '^\s*synchronous_commit:\s' "$TMP/async.yaml" \
 fi
 echo "  PASS"
 
-# ── Case 7: continuum.enabled seeds a Continuum CR (chart 0.1.3 #3195) ─
-# When continuum.enabled=true AND cnpgPair.enabled=true the chart renders
-# exactly ONE dr.openova.io/v1 Continuum CR pointing at this pair, using
-# the DISTINCT canonical 4-segment continuum.primaryRegion /
-# continuum.hotStandbyRegion (Continuum CRD pattern), not the cnpg-pair
-# node-region labels.
-echo "[render] Case 7: continuum.enabled renders the Continuum CR"
+# ── Case 9: continuum.enabled seeds a Continuum CR on side=primary ─
+echo "[render] Case 9: continuum.enabled renders the Continuum CR (primary side only)"
 helm template smoke-cnpg-pair . \
   --set cnpgPair.enabled=true \
   --set cnpgPair.primary.region=hw-me-east-215-a-rtz-prod \
@@ -313,13 +409,10 @@ helm template smoke-cnpg-pair . \
 }
 CONT=$(grep -cE '^kind: Continuum$' "$TMP/continuum.yaml" || true)
 if [ "$CONT" -ne 1 ]; then
-  echo "FAIL: expected exactly 1 Continuum CR, got $CONT." >&2
+  echo "FAIL: expected exactly 1 Continuum CR on side=primary, got $CONT." >&2
   exit 1
 fi
-# Isolate the Continuum doc for region-specific assertions (the multi-doc
-# render also contains the Cluster CRs whose openova.io/region label is
-# legitimately the node-region form — only the Continuum CR must use the
-# canonical 4-segment label).
+# Isolate the Continuum doc for region-specific assertions.
 helm template smoke-cnpg-pair . \
   --set cnpgPair.enabled=true \
   --set cnpgPair.primary.region=hw-me-east-215-a-rtz-prod \
@@ -329,23 +422,39 @@ helm template smoke-cnpg-pair . \
   --set cnpgPair.continuum.primaryRegion=hz-fsn-rtz-prod \
   --set cnpgPair.continuum.hotStandbyRegion=hz-hel-rtz-prod \
   --show-only templates/continuum.yaml > "$TMP/continuum-only.yaml" 2>/dev/null
-# The CR carries the canonical 4-segment region (NOT the node-region label).
 grep -qE '^\s+primaryRegion: "hz-fsn-rtz-prod"' "$TMP/continuum-only.yaml" || {
   echo "FAIL: Continuum CR primaryRegion is not the canonical 4-segment label." >&2
   grep -nE 'primaryRegion:' "$TMP/continuum-only.yaml" >&2
   exit 1
 }
-# The Continuum CR must NOT carry the multi-segment node-region label in
-# its region fields (would fail the CRD 4-segment pattern at admission).
 if grep -qE '^\s+(primaryRegion|hotStandbyRegions|- ).*hw-me-east-215' "$TMP/continuum-only.yaml"; then
   echo "FAIL: Continuum CR leaked the cnpg-pair node-region label into a region field (fails the CRD 4-segment pattern)." >&2
-  grep -nE 'hw-me-east-215' "$TMP/continuum-only.yaml" >&2
   exit 1
 fi
-echo "  PASS (1 Continuum CR)"
+# Side gate: the replica cluster must NOT receive the Continuum CR
+# (the continuum-controller runs on the primary cluster only).
+helm template smoke-cnpg-pair . \
+  --set cnpgPair.enabled=true \
+  --set cnpgPair.side=replica \
+  --set cnpgPair.primary.region=hw-me-east-215-a-rtz-prod \
+  --set cnpgPair.replica.region=hw-me-east-215-b-rtz-prod \
+  --set cnpgPair.image.tag=16.3-23 \
+  --set cnpgPair.continuum.enabled=true \
+  --set cnpgPair.continuum.primaryRegion=hz-fsn-rtz-prod \
+  --set cnpgPair.continuum.hotStandbyRegion=hz-hel-rtz-prod \
+  > "$TMP/continuum-replica.yaml" 2>/dev/null || {
+  echo "FAIL: continuum-enabled side=replica render errored." >&2
+  exit 1
+}
+CONT_R=$(grep -cE '^kind: Continuum$' "$TMP/continuum-replica.yaml" || true)
+if [ "$CONT_R" -ne 0 ]; then
+  echo "FAIL: side=replica rendered $CONT_R Continuum CR(s); expected 0 (controller runs on primary)." >&2
+  exit 1
+fi
+echo "  PASS (1 Continuum CR, primary side only)"
 
-# ── Case 8: continuum.enabled without regions fails fast ──────────────
-echo "[render] Case 8: continuum.enabled with empty regions triggers fail-fast"
+# ── Case 10: continuum.enabled without regions fails fast ────────
+echo "[render] Case 10: continuum.enabled with empty regions triggers fail-fast"
 if helm template smoke-cnpg-pair . \
   --set cnpgPair.enabled=true \
   --set cnpgPair.primary.region=hz-fsn-rtz-prod \
@@ -363,9 +472,9 @@ grep -q "continuum.primaryRegion is REQUIRED" "$TMP/cont-noregion.err" || {
 }
 echo "  PASS"
 
-# ── Case 9: cnpgPair.enabled=false suppresses the Continuum CR even
-#            when continuum.enabled=true (gated on BOTH) ──────────────
-echo "[render] Case 9: continuum CR gated on cnpgPair.enabled too"
+# ── Case 11: cnpgPair.enabled=false suppresses the Continuum CR even
+#             when continuum.enabled=true (gated on BOTH) ─────────
+echo "[render] Case 11: continuum CR gated on cnpgPair.enabled too"
 helm template smoke-cnpg-pair . \
   --set cnpgPair.enabled=false \
   --set cnpgPair.continuum.enabled=true \

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -15,6 +15,37 @@ cnpgPair:
   # disabled so platform overlays can include it without side effects.
   enabled: false
 
+  # ── Side — WHICH HALF of the pair this install renders (chart 0.2.0) ──
+  # A 2-region Sovereign is TWO SEPARATE k8s clusters linked by Cilium
+  # ClusterMesh (kom4dc mimics this with 2 VPCs) — NOT one stretched
+  # cluster. Chart ≤0.1.x rendered BOTH Cluster CRs in one release and
+  # relied on node-affinity to "schedule each side to its region", which
+  # only works on a stretched cluster: on separate clusters the replica
+  # Cluster + failover-readiness probe pinned to region-B labels can
+  # NEVER schedule on cluster-A (hw126: FailedScheduling 0/4 nodes,
+  # affinity requires openova.io/region=hw-me-east-215-b-rtz-prod).
+  #
+  # side=primary renders the region-A half ONLY:
+  #   primary Cluster CR + `*-primary-mesh` global Service (via
+  #   managed.services.additional) + audit-config ConfigMap (bp-continuum
+  #   slot 62 runs on the primary cluster and prerequisite-probes this
+  #   ConfigMap) + the replication-ingress NetworkPolicy + the optional
+  #   Continuum CR + the helm-test resources.
+  # side=replica renders the region-B half ONLY:
+  #   replica Cluster CR (pg_basebackup + externalClusters streaming the
+  #   primary's WAL over the ClusterMesh-global `-mesh` Service) +
+  #   failover-readiness probe Deployment (its region-B affinity now
+  #   matches the nodes it runs on) + the probe NetworkPolicies.
+  #
+  # The bootstrap-kit slot 16b stamps this from the per-region
+  # SOVEREIGN_REGION_ROLE substitute (cloud-init), whose value domain is
+  # primary|secondary (infra/providers/*/main.tf sovereign_region_role)
+  # — the chart normalizes "secondary" to the replica side so the slot
+  # can substitute the role verbatim. Accepted values:
+  # primary | replica | secondary (≡ replica); anything else fails the
+  # render.
+  side: primary
+
   # ── Primary region ────────────────────────────────────────────────
   primary:
     # Hetzner region key (matches openova.io/region label on nodes per

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -57,9 +57,12 @@ cnpgPair:
     storage:
       size: 100Gi
       # H6 (bp-hcloud-csi) provides this StorageClass. Per the seam
-      # map (`platform/hcloud-csi/`) the canonical name is
-      # `hcloud-volumes`. Cluster overlays may override.
-      storageClass: hcloud-volumes
+      # Cloud-agnostic (#3253 hw126 RCA): empty = the cluster's DEFAULT
+      # StorageClass (local-path on k3s/Huawei). `hcloud-volumes` only
+      # exists where bp-hcloud-csi runs — hardcoding it wedged every
+      # non-Hetzner prov with "storageclass not found" (PVC Pending
+      # forever). Hetzner overlays set it via the slot substitute.
+      storageClass: ""
     resources:
       requests:
         cpu: 500m
@@ -86,7 +89,7 @@ cnpgPair:
     instances: 3
     storage:
       size: 100Gi
-      storageClass: hcloud-volumes
+      storageClass: ""
     resources:
       requests:
         cpu: 500m

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -619,7 +619,7 @@ func (h *Handler) AutoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 	// patches the same key to the same value and merely re-requests a
 	// reconcile.
 	if totalReady == len(statuses) && len(statuses) >= 2 {
-		h.enableCNPGPairAfterFullMesh(ctx, dep, primaryKubeconfigPath)
+		h.enableCNPGPairAfterFullMesh(ctx, dep, slots)
 	} else {
 		h.log.Info("clustermesh: mesh not fully established — SOVEREIGN_ENABLE_CNPG_PAIR left untouched (slot 16b stays gated OFF)",
 			"id", dep.ID,
@@ -631,7 +631,7 @@ func (h *Handler) AutoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 	return statuses, nil
 }
 
-// enableCNPGPairAfterFullMesh flips the slot-16b gate on the PRIMARY
+// enableCNPGPairAfterFullMesh flips the slot-16b gate on EVERY
 // region's bootstrap-kit Flux Kustomization (the one cloud-init applies
 // — infra/providers/_shared/cloudinit-control-plane.tftpl) by merging
 // `spec.postBuild.substitute.SOVEREIGN_ENABLE_CNPG_PAIR: "true"` and
@@ -640,79 +640,121 @@ func (h *Handler) AutoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 // CNPG pair (clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml)
 // then deploys zero-touch, correctly gated on CONFIRMED mesh readiness.
 //
+// ALL-REGIONS scope (chart 0.2.0 split-side topology): slot 16b is no
+// longer a primary-only HR — it applies on every control plane with
+// `cnpgPair.side: ${SOVEREIGN_REGION_ROLE:-primary}`, so side=primary
+// renders the primary Cluster + mesh Service on cluster-A and
+// side=replica renders the replica Cluster + failover-readiness probe
+// on cluster-B. Flipping only the primary's Kustomization (the pre-
+// split behaviour) would activate the primary half while the secondary
+// keeps rendering an empty release — no replica, no WAL stream. The
+// regionSlots passed in carry each region's kubeconfig path (on the
+// full-success path that triggers this flip, every slot is reachable).
+//
 // Defense (non-negotiable, per the chart's required-fail-fast): the
-// flip is REFUSED unless the substitute map already carries non-empty,
-// DISTINCT SOVEREIGN_PRIMARY_REGION / SOVEREIGN_REPLICA_REGION —
-// cloud-init stamps both on 2-region provs. With enabled=true and a
-// missing/equal region the bp-cnpg-pair chart render fails, and a
-// render failure inside the bootstrap-kit Kustomization fails the WHOLE
-// atomic apply → 0 HRs (the #2981/#2982 fresh-prov wedge shape). A
-// refused flip logs loudly and leaves the gate OFF (empty Ready
-// release — safe).
+// flip is REFUSED — for ALL regions, atomically — unless every
+// region's substitute map carries non-empty, DISTINCT
+// SOVEREIGN_PRIMARY_REGION / SOVEREIGN_REPLICA_REGION (cloud-init
+// stamps both on every control plane of a 2-region prov). With
+// enabled=true and a missing/equal region the bp-cnpg-pair chart
+// render fails, and a render failure inside the bootstrap-kit
+// Kustomization fails the WHOLE atomic apply → 0 HRs (the #2981/#2982
+// fresh-prov wedge shape). Likewise, if ANY region's Kustomization is
+// unreadable the whole flip is refused: a half-flipped pair (primary
+// active, replica gated OFF) is exactly the broken topology this
+// function exists to prevent. A refused flip logs loudly and leaves
+// the gate OFF everywhere (empty Ready releases — safe); the
+// level-triggered reconcile / post-handover finalisation re-runs and
+// converges.
 //
 // Scope: ONLY SOVEREIGN_ENABLE_CNPG_PAIR. The shared-pg flags
 // (SOVEREIGN_ENABLE_SHARED_PG / *_PG_OWN_CLUSTER) are #3188 scope and
-// are deliberately not touched here. Only the PRIMARY's Kustomization
-// is patched — slot 16b is a primary-only HR (SECONDARY_HR_SUSPEND
-// suspends it on secondary control planes).
+// are deliberately not touched here.
 //
 // Failure modes follow this file's convention: every failure is logged
 // + surfaced as a clustermesh-progress warn event, never an error —
 // the post-handover finalisation re-runs AutoEstablishClusterMesh and
-// the flip converges then.
-func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployment, primaryKubeconfigPath string) {
-	if primaryKubeconfigPath == "" {
-		// Unreachable from the full-success path (an empty path fails
-		// the primary slot, which blocks full success) — but this
-		// method must stay safe if ever called from another site.
-		h.log.Warn("clustermesh: cnpg-pair gate: primary kubeconfig path empty — cannot reach bootstrap-kit Kustomization",
+// the flip converges then. A patch failure AFTER the gather phase is
+// per-region (warn + continue): the merge patch is idempotent and the
+// re-run converges the missed region.
+func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployment, slots []regionSlot) {
+	if len(slots) == 0 {
+		h.log.Warn("clustermesh: cnpg-pair gate: no region slots — cannot reach any bootstrap-kit Kustomization",
 			"id", dep.ID)
 		return
 	}
-	dyn, err := h.clusterMeshDynamicClient(primaryKubeconfigPath)
-	if err != nil {
-		h.log.Warn("clustermesh: cnpg-pair gate: dynamic client build failed",
-			"id", dep.ID, "err", err)
-		h.emitClusterMeshProgress(dep, "warn",
-			fmt.Sprintf("ClusterMesh: cnpg-pair enable skipped — dynamic client build failed (%v); re-run converges", err))
-		return
+
+	// ── Gather phase (all-or-nothing) ───────────────────────────────
+	// Build a dynamic client + read the bootstrap-kit Kustomization in
+	// EVERY region and verify the region-substitute precondition before
+	// patching anything. Any gap refuses the whole flip — a half-
+	// flipped split-side pair is the hw126 broken topology.
+	type flipTarget struct {
+		regionKey string
+		dyn       dynamic.Interface
+	}
+	targets := make([]flipTarget, 0, len(slots))
+	for i := range slots {
+		s := &slots[i]
+		regionLabel := s.key
+		if regionLabel == "" {
+			regionLabel = "primary"
+		}
+		if s.kubeconfigPath == "" {
+			h.log.Warn("clustermesh: cnpg-pair gate: region kubeconfig path empty — cannot reach its bootstrap-kit Kustomization",
+				"id", dep.ID, "region", regionLabel)
+			h.emitClusterMeshProgress(dep, "warn",
+				fmt.Sprintf("ClusterMesh: cnpg-pair enable skipped — region %q kubeconfig path empty; re-run converges", regionLabel))
+			return
+		}
+		dyn, err := h.clusterMeshDynamicClient(s.kubeconfigPath)
+		if err != nil {
+			h.log.Warn("clustermesh: cnpg-pair gate: dynamic client build failed",
+				"id", dep.ID, "region", regionLabel, "err", err)
+			h.emitClusterMeshProgress(dep, "warn",
+				fmt.Sprintf("ClusterMesh: cnpg-pair enable skipped — region %q dynamic client build failed (%v); re-run converges", regionLabel, err))
+			return
+		}
+
+		getCtx, cancelGet := context.WithTimeout(ctx, clusterMeshCallTimeout)
+		ks, err := dyn.Resource(fluxKustomizationGVR).Namespace(fluxSystemNamespace).
+			Get(getCtx, bootstrapKitKustomizationName, metav1.GetOptions{})
+		cancelGet()
+		if err != nil {
+			h.log.Warn("clustermesh: cnpg-pair gate: Get bootstrap-kit Kustomization failed",
+				"id", dep.ID, "region", regionLabel, "err", err)
+			h.emitClusterMeshProgress(dep, "warn",
+				fmt.Sprintf("ClusterMesh: cnpg-pair enable skipped — region %q Get Kustomization %s/%s failed (%v); re-run converges",
+					regionLabel, fluxSystemNamespace, bootstrapKitKustomizationName, err))
+			return
+		}
+
+		substitute, found, err := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
+		if err != nil || !found {
+			h.log.Warn("clustermesh: refusing to flip SOVEREIGN_ENABLE_CNPG_PAIR — bootstrap-kit Kustomization has no readable spec.postBuild.substitute map",
+				"id", dep.ID, "region", regionLabel, "found", found, "err", err)
+			h.emitClusterMeshProgress(dep, "warn",
+				fmt.Sprintf("ClusterMesh: cnpg-pair enable refused — region %q bootstrap-kit Kustomization carries no postBuild.substitute map", regionLabel))
+			return
+		}
+		primaryRegion := strings.TrimSpace(substitute[clusterMeshPrimaryRegionSubstituteKey])
+		replicaRegion := strings.TrimSpace(substitute[clusterMeshReplicaRegionSubstituteKey])
+		if primaryRegion == "" || replicaRegion == "" || primaryRegion == replicaRegion {
+			h.log.Warn("clustermesh: refusing to flip SOVEREIGN_ENABLE_CNPG_PAIR — substitute region precondition failed (bp-cnpg-pair `required`s distinct non-empty regions; a render failure would fail the whole atomic bootstrap-kit apply → 0 HRs)",
+				"id", dep.ID,
+				"region", regionLabel,
+				"primaryRegion", primaryRegion,
+				"replicaRegion", replicaRegion,
+			)
+			h.emitClusterMeshProgress(dep, "warn",
+				fmt.Sprintf("ClusterMesh: cnpg-pair enable REFUSED — region %q SOVEREIGN_PRIMARY_REGION=%q / SOVEREIGN_REPLICA_REGION=%q must be non-empty and distinct in the bootstrap-kit substitute map",
+					regionLabel, primaryRegion, replicaRegion))
+			return
+		}
+		targets = append(targets, flipTarget{regionKey: regionLabel, dyn: dyn})
 	}
 
-	getCtx, cancelGet := context.WithTimeout(ctx, clusterMeshCallTimeout)
-	ks, err := dyn.Resource(fluxKustomizationGVR).Namespace(fluxSystemNamespace).
-		Get(getCtx, bootstrapKitKustomizationName, metav1.GetOptions{})
-	cancelGet()
-	if err != nil {
-		h.log.Warn("clustermesh: cnpg-pair gate: Get bootstrap-kit Kustomization failed",
-			"id", dep.ID, "err", err)
-		h.emitClusterMeshProgress(dep, "warn",
-			fmt.Sprintf("ClusterMesh: cnpg-pair enable skipped — Get Kustomization %s/%s failed (%v); re-run converges",
-				fluxSystemNamespace, bootstrapKitKustomizationName, err))
-		return
-	}
-
-	substitute, found, err := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
-	if err != nil || !found {
-		h.log.Warn("clustermesh: refusing to flip SOVEREIGN_ENABLE_CNPG_PAIR — bootstrap-kit Kustomization has no readable spec.postBuild.substitute map",
-			"id", dep.ID, "found", found, "err", err)
-		h.emitClusterMeshProgress(dep, "warn",
-			"ClusterMesh: cnpg-pair enable refused — bootstrap-kit Kustomization carries no postBuild.substitute map")
-		return
-	}
-	primaryRegion := strings.TrimSpace(substitute[clusterMeshPrimaryRegionSubstituteKey])
-	replicaRegion := strings.TrimSpace(substitute[clusterMeshReplicaRegionSubstituteKey])
-	if primaryRegion == "" || replicaRegion == "" || primaryRegion == replicaRegion {
-		h.log.Warn("clustermesh: refusing to flip SOVEREIGN_ENABLE_CNPG_PAIR — substitute region precondition failed (bp-cnpg-pair `required`s distinct non-empty regions; a render failure would fail the whole atomic bootstrap-kit apply → 0 HRs)",
-			"id", dep.ID,
-			"primaryRegion", primaryRegion,
-			"replicaRegion", replicaRegion,
-		)
-		h.emitClusterMeshProgress(dep, "warn",
-			fmt.Sprintf("ClusterMesh: cnpg-pair enable REFUSED — SOVEREIGN_PRIMARY_REGION=%q / SOVEREIGN_REPLICA_REGION=%q must be non-empty and distinct in the bootstrap-kit substitute map",
-				primaryRegion, replicaRegion))
-		return
-	}
-
+	// ── Patch phase ─────────────────────────────────────────────────
 	// JSON merge patch (RFC 7386) merges nested objects key-by-key, so
 	// sibling substitute keys + existing annotations are preserved —
 	// only the gate key and the reconcile-request stamp change.
@@ -737,26 +779,34 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 			"id", dep.ID, "err", err)
 		return
 	}
-	patchCtx, cancelPatch := context.WithTimeout(ctx, clusterMeshCallTimeout)
-	defer cancelPatch()
-	if _, err := dyn.Resource(fluxKustomizationGVR).Namespace(fluxSystemNamespace).
-		Patch(patchCtx, bootstrapKitKustomizationName, types.MergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
-		h.log.Warn("clustermesh: cnpg-pair gate: Patch bootstrap-kit Kustomization failed",
-			"id", dep.ID, "err", err)
-		h.emitClusterMeshProgress(dep, "warn",
-			fmt.Sprintf("ClusterMesh: cnpg-pair enable failed — Patch Kustomization %s/%s (%v); re-run converges",
-				fluxSystemNamespace, bootstrapKitKustomizationName, err))
+	patched := 0
+	for _, t := range targets {
+		patchCtx, cancelPatch := context.WithTimeout(ctx, clusterMeshCallTimeout)
+		_, patchErr := t.dyn.Resource(fluxKustomizationGVR).Namespace(fluxSystemNamespace).
+			Patch(patchCtx, bootstrapKitKustomizationName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+		cancelPatch()
+		if patchErr != nil {
+			h.log.Warn("clustermesh: cnpg-pair gate: Patch bootstrap-kit Kustomization failed",
+				"id", dep.ID, "region", t.regionKey, "err", patchErr)
+			h.emitClusterMeshProgress(dep, "warn",
+				fmt.Sprintf("ClusterMesh: cnpg-pair enable incomplete — region %q Patch Kustomization %s/%s (%v); re-run converges",
+					t.regionKey, fluxSystemNamespace, bootstrapKitKustomizationName, patchErr))
+			continue
+		}
+		patched++
+	}
+	if patched == 0 {
 		return
 	}
 
-	h.log.Info("clustermesh: SOVEREIGN_ENABLE_CNPG_PAIR=true merged onto primary bootstrap-kit Kustomization + Flux reconcile requested",
+	h.log.Info("clustermesh: SOVEREIGN_ENABLE_CNPG_PAIR=true merged onto bootstrap-kit Kustomizations + Flux reconcile requested (split-side: every region renders its own half of the pair)",
 		"id", dep.ID,
-		"primaryRegion", primaryRegion,
-		"replicaRegion", replicaRegion,
+		"regionsPatched", patched,
+		"regionsTotal", len(targets),
 		"requestedAt", stamp,
 	)
 	h.emitClusterMeshProgress(dep, "info",
-		"ClusterMesh confirmed across all regions — enabled bp-cnpg-pair (slot 16b) via SOVEREIGN_ENABLE_CNPG_PAIR=true and requested Flux reconcile")
+		fmt.Sprintf("ClusterMesh confirmed across all regions — enabled bp-cnpg-pair (slot 16b) via SOVEREIGN_ENABLE_CNPG_PAIR=true on %d/%d region Kustomizations and requested Flux reconcile", patched, len(targets)))
 }
 
 // clusterMeshDynamicClient builds a dynamic.Interface for the cluster

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -178,12 +178,13 @@ users:
 // the package-private helper installClusterMeshClientFactory so we
 // don't have to plumb a real kubeconfig parser.
 type testFixture struct {
-	dir                   string
-	clients               map[string]kubernetes.Interface // keyed by kubeconfig path
-	dynClients            map[string]dynamic.Interface    // keyed by kubeconfig path (primary only today)
-	primaryKubeconfigPath string
-	dep                   *Deployment
-	handler               *Handler
+	dir                     string
+	clients                 map[string]kubernetes.Interface // keyed by kubeconfig path
+	dynClients              map[string]dynamic.Interface    // keyed by kubeconfig path (EVERY region — split-side flip patches all)
+	primaryKubeconfigPath   string
+	secondaryKubeconfigPath string // first secondary region's path ("" when single-region)
+	dep                     *Deployment
+	handler                 *Handler
 }
 
 // installClusterMeshClientFactory replaces helmwatch's kubeconfig
@@ -269,26 +270,41 @@ func newTestFixture(t *testing.T, lbIPs []string) *testFixture {
 		dep.secondaryKubeconfigPaths[k] = filepath.Join(dir, depID+"-"+k+".yaml")
 	}
 
-	// Primary region's fake DYNAMIC client — carries the bootstrap-kit
-	// Flux Kustomization the cnpg-pair gate flip (#3236) patches. Seeded
-	// with the canonical 2-region substitute map cloud-init stamps
-	// (distinct non-empty SOVEREIGN_PRIMARY_REGION / SOVEREIGN_REPLICA_
-	// REGION). Tests that exercise the precondition guard replace this
-	// entry before installing the factories.
+	// Per-region fake DYNAMIC clients — each carries the bootstrap-kit
+	// Flux Kustomization the cnpg-pair gate flip (#3236) patches. Since
+	// the chart-0.2.0 split-side topology, the flip lands on EVERY
+	// region's Kustomization (each cluster renders its own half of the
+	// pair), so every region gets its own seeded fake. Seeded with the
+	// canonical 2-region substitute map cloud-init stamps on every
+	// control plane (distinct non-empty SOVEREIGN_PRIMARY_REGION /
+	// SOVEREIGN_REPLICA_REGION — the tftpl stamps both keys in the
+	// shared block). Tests that exercise the precondition guard replace
+	// entries before installing the factories.
 	primaryKubeconfigPath := filepath.Join(dir, depID+".yaml")
-	dynClients := map[string]dynamic.Interface{
-		primaryKubeconfigPath: newFakeKustomizationDynClient(t,
-			buildBootstrapKitKustomization(defaultBootstrapKitSubstitute())),
+	dynClients := map[string]dynamic.Interface{}
+	secondaryKubeconfigPath := ""
+	for i := range regions {
+		key := regionKeyFromSpec(regions[i], i)
+		kcPath := primaryKubeconfigPath
+		if i > 0 {
+			kcPath = filepath.Join(dir, depID+"-"+key+".yaml")
+			if secondaryKubeconfigPath == "" {
+				secondaryKubeconfigPath = kcPath
+			}
+		}
+		dynClients[kcPath] = newFakeKustomizationDynClient(t,
+			buildBootstrapKitKustomization(defaultBootstrapKitSubstitute()))
 	}
 
 	h := &Handler{log: silentLogger(), kubeconfigsDir: dir}
 	return &testFixture{
-		dir:                   dir,
-		clients:               clients,
-		dynClients:            dynClients,
-		primaryKubeconfigPath: primaryKubeconfigPath,
-		dep:                   dep,
-		handler:               h,
+		dir:                     dir,
+		clients:                 clients,
+		dynClients:              dynClients,
+		primaryKubeconfigPath:   primaryKubeconfigPath,
+		secondaryKubeconfigPath: secondaryKubeconfigPath,
+		dep:                     dep,
+		handler:                 h,
 	}
 }
 
@@ -684,15 +700,18 @@ func TestRunAutoEstablishClusterMesh_RetryConvergesAfterLBAppears(t *testing.T) 
 		}
 	}
 
-	// And the #3236 cnpg-pair flip landed on the converged attempt.
-	ks := getBootstrapKitKustomization(t, fx.dynClients[fx.primaryKubeconfigPath])
-	substitute, found, err := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
-	if err != nil || !found {
-		t.Fatalf("read spec.postBuild.substitute: found=%v err=%v", found, err)
-	}
-	if got := substitute[clusterMeshCNPGPairSubstituteKey]; got != "true" {
-		t.Errorf("substitute[%s] = %q, want \"true\" after retry convergence",
-			clusterMeshCNPGPairSubstituteKey, got)
+	// And the #3236 cnpg-pair flip landed on the converged attempt —
+	// on BOTH regions' Kustomizations (split-side topology).
+	for _, kcPath := range []string{fx.primaryKubeconfigPath, fx.secondaryKubeconfigPath} {
+		ks := getBootstrapKitKustomization(t, fx.dynClients[kcPath])
+		substitute, found, err := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
+		if err != nil || !found {
+			t.Fatalf("region %q: read spec.postBuild.substitute: found=%v err=%v", kcPath, found, err)
+		}
+		if got := substitute[clusterMeshCNPGPairSubstituteKey]; got != "true" {
+			t.Errorf("region %q: substitute[%s] = %q, want \"true\" after retry convergence",
+				kcPath, clusterMeshCNPGPairSubstituteKey, got)
+		}
 	}
 }
 
@@ -720,9 +739,17 @@ func TestRestoreFromStore_StartupKicksClusterMeshReconcile(t *testing.T) {
 		clients[kcPath] = buildFakeClusterMeshCluster(t, lbIPs[i], caCert, caKey)
 	}
 	primaryKubeconfigPath := filepath.Join(dir, depID+".yaml")
-	dynClients := map[string]dynamic.Interface{
-		primaryKubeconfigPath: newFakeKustomizationDynClient(t,
-			buildBootstrapKitKustomization(defaultBootstrapKitSubstitute())),
+	// EVERY region's Kustomization gets the split-side flip, so each
+	// region needs its own seeded fake dynamic client.
+	dynClients := map[string]dynamic.Interface{}
+	for i := range regions {
+		key := regionKeyFromSpec(regions[i], i)
+		kcPath := primaryKubeconfigPath
+		if i > 0 {
+			kcPath = filepath.Join(dir, depID+"-"+key+".yaml")
+		}
+		dynClients[kcPath] = newFakeKustomizationDynClient(t,
+			buildBootstrapKitKustomization(defaultBootstrapKitSubstitute()))
 	}
 	restore := installClusterMeshClientFactory(clients)
 	defer restore()
@@ -782,11 +809,13 @@ func TestRestoreFromStore_StartupKicksClusterMeshReconcile(t *testing.T) {
 			t.Errorf("Secret in %q has %d entries, want 4 (keys %v)", kcPath, len(secret.Data), secretKeys(secret))
 		}
 	}
-	ks := getBootstrapKitKustomization(t, dynClients[primaryKubeconfigPath])
-	substitute, _, _ := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
-	if got := substitute[clusterMeshCNPGPairSubstituteKey]; got != "true" {
-		t.Errorf("substitute[%s] = %q, want \"true\" after startup reconcile",
-			clusterMeshCNPGPairSubstituteKey, got)
+	for kcPath, dyn := range dynClients {
+		ks := getBootstrapKitKustomization(t, dyn)
+		substitute, _, _ := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
+		if got := substitute[clusterMeshCNPGPairSubstituteKey]; got != "true" {
+			t.Errorf("region %q: substitute[%s] = %q, want \"true\" after startup reconcile (split-side: BOTH regions flip)",
+				kcPath, clusterMeshCNPGPairSubstituteKey, got)
+		}
 	}
 }
 
@@ -1065,13 +1094,17 @@ func requireFullyMeshed(t *testing.T, statuses []ClusterMeshStatus) {
 }
 
 // TestAutoEstablishClusterMesh_FullMeshFlipsCNPGPairGate — after a
-// CONFIRMED full-mesh establishment across both regions, the primary
+// CONFIRMED full-mesh establishment across both regions, EVERY
 // region's flux-system/bootstrap-kit Kustomization must carry
 // postBuild.substitute.SOVEREIGN_ENABLE_CNPG_PAIR="true" plus the
 // reconcile.fluxcd.io/requestedAt annotation so slot 16b (bp-cnpg-pair)
 // deploys zero-touch on the next Flux reconcile. (#3236; the gate
 // itself exists because of hw124/#3196 — see the slot header in
-// clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml.)
+// clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml.) The
+// all-regions scope is the chart-0.2.0 split-side topology: each
+// cluster renders its own half of the pair, so a primary-only flip
+// would leave the secondary rendering an empty release — no replica,
+// no WAL stream.
 func TestAutoEstablishClusterMesh_FullMeshFlipsCNPGPairGate(t *testing.T) {
 	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
 	restore := installClusterMeshClientFactory(fx.clients)
@@ -1088,32 +1121,71 @@ func TestAutoEstablishClusterMesh_FullMeshFlipsCNPGPairGate(t *testing.T) {
 	}
 	requireFullyMeshed(t, statuses)
 
-	ks := getBootstrapKitKustomization(t, fx.dynClients[fx.primaryKubeconfigPath])
-	substitute, found, err := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
-	if err != nil || !found {
-		t.Fatalf("read spec.postBuild.substitute: found=%v err=%v", found, err)
+	for _, kcPath := range []string{fx.primaryKubeconfigPath, fx.secondaryKubeconfigPath} {
+		ks := getBootstrapKitKustomization(t, fx.dynClients[kcPath])
+		substitute, found, err := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
+		if err != nil || !found {
+			t.Fatalf("region %q: read spec.postBuild.substitute: found=%v err=%v", kcPath, found, err)
+		}
+		if got := substitute[clusterMeshCNPGPairSubstituteKey]; got != "true" {
+			t.Errorf("region %q: substitute[%s] = %q, want \"true\" after full mesh establishment (split-side: BOTH regions must flip)",
+				kcPath, clusterMeshCNPGPairSubstituteKey, got)
+		}
+		// The JSON merge patch must MERGE into the substitute map, never
+		// replace it — clobbering SOVEREIGN_PRIMARY_REGION/… would fail the
+		// chart's required-fail-fast and wedge the whole atomic apply.
+		if got := substitute[clusterMeshPrimaryRegionSubstituteKey]; got != testPrimaryRegionLabel {
+			t.Errorf("region %q: substitute[%s] = %q, want %q (patch clobbered sibling substitute keys)",
+				kcPath, clusterMeshPrimaryRegionSubstituteKey, got, testPrimaryRegionLabel)
+		}
+		if got := substitute[clusterMeshReplicaRegionSubstituteKey]; got != testReplicaRegionLabel {
+			t.Errorf("region %q: substitute[%s] = %q, want %q (patch clobbered sibling substitute keys)",
+				kcPath, clusterMeshReplicaRegionSubstituteKey, got, testReplicaRegionLabel)
+		}
+		stamp := ks.GetAnnotations()[fluxReconcileRequestedAtAnnotation]
+		if stamp == "" {
+			t.Fatalf("region %q: annotation %q absent — Flux reconcile never requested", kcPath, fluxReconcileRequestedAtAnnotation)
+		}
+		if _, perr := time.Parse(time.RFC3339Nano, stamp); perr != nil {
+			t.Errorf("region %q: annotation %q = %q is not RFC3339Nano: %v", kcPath, fluxReconcileRequestedAtAnnotation, stamp, perr)
+		}
 	}
-	if got := substitute[clusterMeshCNPGPairSubstituteKey]; got != "true" {
-		t.Errorf("substitute[%s] = %q, want \"true\" after full mesh establishment",
+}
+
+// TestAutoEstablishClusterMesh_SecondaryKustomizationMissingBlocksFlip
+// — the split-side flip is ALL-OR-NOTHING: when the secondary region's
+// bootstrap-kit Kustomization is unreadable, the flip must be refused
+// on the PRIMARY too. A half-flipped pair (primary half active,
+// secondary gated OFF) is exactly the broken hw126 topology — primary
+// Cluster waiting forever for a replica the secondary never renders.
+func TestAutoEstablishClusterMesh_SecondaryKustomizationMissingBlocksFlip(t *testing.T) {
+	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
+	// Secondary dyn client exists but has NO bootstrap-kit Kustomization
+	// → the gather phase's Get fails for the secondary region.
+	fx.dynClients[fx.secondaryKubeconfigPath] = newFakeKustomizationDynClient(t)
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	statuses, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep)
+	if err != nil {
+		t.Fatalf("AutoEstablishClusterMesh returned error: %v", err)
+	}
+	requireFullyMeshed(t, statuses)
+
+	ks := getBootstrapKitKustomization(t, fx.dynClients[fx.primaryKubeconfigPath])
+	substitute, _, _ := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
+	if got, ok := substitute[clusterMeshCNPGPairSubstituteKey]; ok {
+		t.Errorf("substitute[%s] = %q on the PRIMARY — flip must be all-or-nothing when the secondary Kustomization is unreadable",
 			clusterMeshCNPGPairSubstituteKey, got)
 	}
-	// The JSON merge patch must MERGE into the substitute map, never
-	// replace it — clobbering SOVEREIGN_PRIMARY_REGION/… would fail the
-	// chart's required-fail-fast and wedge the whole atomic apply.
-	if got := substitute[clusterMeshPrimaryRegionSubstituteKey]; got != testPrimaryRegionLabel {
-		t.Errorf("substitute[%s] = %q, want %q (patch clobbered sibling substitute keys)",
-			clusterMeshPrimaryRegionSubstituteKey, got, testPrimaryRegionLabel)
-	}
-	if got := substitute[clusterMeshReplicaRegionSubstituteKey]; got != testReplicaRegionLabel {
-		t.Errorf("substitute[%s] = %q, want %q (patch clobbered sibling substitute keys)",
-			clusterMeshReplicaRegionSubstituteKey, got, testReplicaRegionLabel)
-	}
-	stamp := ks.GetAnnotations()[fluxReconcileRequestedAtAnnotation]
-	if stamp == "" {
-		t.Fatalf("annotation %q absent — Flux reconcile never requested", fluxReconcileRequestedAtAnnotation)
-	}
-	if _, perr := time.Parse(time.RFC3339Nano, stamp); perr != nil {
-		t.Errorf("annotation %q = %q is not RFC3339Nano: %v", fluxReconcileRequestedAtAnnotation, stamp, perr)
+	if stamp := ks.GetAnnotations()[fluxReconcileRequestedAtAnnotation]; stamp != "" {
+		t.Errorf("annotation %q = %q set on the PRIMARY despite secondary gather failure",
+			fluxReconcileRequestedAtAnnotation, stamp)
 	}
 }
 
@@ -1203,15 +1275,21 @@ func TestAutoEstablishClusterMesh_SubstitutePreconditionBlocksCNPGPairFlip(t *te
 			}
 			requireFullyMeshed(t, statuses)
 
-			ks := getBootstrapKitKustomization(t, fx.dynClients[fx.primaryKubeconfigPath])
-			substitute, _, _ := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
-			if got, ok := substitute[clusterMeshCNPGPairSubstituteKey]; ok {
-				t.Errorf("substitute[%s] = %q — gate flipped despite failed region precondition",
-					clusterMeshCNPGPairSubstituteKey, got)
-			}
-			if stamp := ks.GetAnnotations()[fluxReconcileRequestedAtAnnotation]; stamp != "" {
-				t.Errorf("annotation %q = %q set despite failed region precondition",
-					fluxReconcileRequestedAtAnnotation, stamp)
+			// All-or-nothing: the PRIMARY's failed precondition must
+			// block the flip on the SECONDARY too (whose own substitute
+			// map is healthy) — a half-flipped split-side pair is the
+			// hw126 broken topology.
+			for _, kcPath := range []string{fx.primaryKubeconfigPath, fx.secondaryKubeconfigPath} {
+				ks := getBootstrapKitKustomization(t, fx.dynClients[kcPath])
+				substitute, _, _ := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
+				if got, ok := substitute[clusterMeshCNPGPairSubstituteKey]; ok {
+					t.Errorf("region %q: substitute[%s] = %q — gate flipped despite failed region precondition",
+						kcPath, clusterMeshCNPGPairSubstituteKey, got)
+				}
+				if stamp := ks.GetAnnotations()[fluxReconcileRequestedAtAnnotation]; stamp != "" {
+					t.Errorf("region %q: annotation %q = %q set despite failed region precondition",
+						kcPath, fluxReconcileRequestedAtAnnotation, stamp)
+				}
 			}
 			if !strings.Contains(logBuf.String(), "refusing to flip SOVEREIGN_ENABLE_CNPG_PAIR") {
 				t.Errorf("expected loud warning containing %q in log output, got:\n%s",


### PR DESCRIPTION
## Pillar-3 core topology fix

A 2-region Sovereign is **two SEPARATE k3s clusters** joined by Cilium ClusterMesh (kom4dc mimics region 2 with a second VPC) — not one stretched cluster. bp-cnpg-pair ≤0.1.x declared the whole pair in ONE release on the primary cluster (slot 16b suspended on secondaries) and relied on node-affinity to "schedule each side to its region". That only works on a stretched cluster.

**Live evidence (hw126):**
```
failover-readiness pod: FailedScheduling 0/4 nodes — affinity requires openova.io/region=hw-me-east-215-b-rtz-prod
(cluster-A's 4 nodes are ALL hw-me-east-215-a-rtz-prod)
```
The replica Cluster CR + failover-readiness Deployment pinned to region-B labels can NEVER schedule on cluster-A. The replica's own design (pg_basebackup + externalClusters streaming WAL over the `*-primary-mesh` global Service) is precisely CNPG's separate-cluster replica pattern — the objects just need to be applied ON cluster-B.

## What changed

### Chart 0.1.5 → 0.2.0 (`platform/cnpg-pair/`)
- New **`cnpgPair.side: primary|replica`** (default `primary`). `secondary` is accepted as an alias for `replica` — the per-region cloud-init substitute `SOVEREIGN_REGION_ROLE` has value domain `primary|secondary` (infra/providers/*/main.tf `sovereign_region_role`), so the slot substitutes it verbatim and the chart normalizes. Invalid values fail the render.
- **side=primary** renders: primary Cluster CR + CNPG-managed `-primary-mesh` global Service + audit-config ConfigMap (bp-continuum slot 62 runs on the primary cluster and its prerequisite probe `kubectl get cm -A -l catalyst.openova.io/audit-config=true` reads its OWN cluster — contract preserved) + replication-ingress NetworkPolicy + optional Continuum CR + helm-test resources.
- **side=replica** renders: replica Cluster CR (unchanged pg_basebackup + externalClusters design) + **a local `-primary-mesh` Service stub** + failover-readiness Deployment (#3247 kyverno-compliance preserved; its region-B affinity now matches the cluster it runs on) + the 2 probe NetworkPolicies.
  - Why the Service stub: Cilium ClusterMesh merges global services **by name+namespace across clusters** — a Service object must exist in the consuming cluster too, annotated `service.cilium.io/global`. Without it the replica's `externalClusters.host` (`<fullname>-primary-mesh`) is NXDOMAIN on cluster-B. The stub's selector (`cnpg.io/cluster: <fullname>-primary`) matches zero local Pods, so every connection crosses the mesh to the primary's backends. No CNPG ownership collision (the 0.1.0 incident was a same-cluster `-r` collision; the primary CR doesn't exist on cluster-B).
- `validateRegions` now also runs on the replica-side render.
- **SAFE-BY-DEFAULT preserved:** `cnpgPair.enabled=false` → ZERO resources on BOTH sides (byte-identical empty renders, asserted by the render gate).
- Version lockstep: Chart.yaml 0.2.0 + blueprint.yaml 0.2.0 + slot 16b pin 0.2.0 (`check-bootstrap-kit-pin-sync.sh` green).

### Slot 16b (`clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml`)
- `suspend: ${SECONDARY_HR_SUSPEND:=false}` **removed** — both control planes apply the HR; `side: ${SOVEREIGN_REGION_ROLE:-primary}` selects the half.
- Header + kustomization.yaml comment rewritten to the split-side model so the single-cluster affinity claim cannot be reintroduced.

### Cloud-init (`infra/providers/_shared/cloudinit-control-plane.tftpl`)
- `SOVEREIGN_REGION_ROLE: "${sovereign_region_role}"` **promoted from the huawei-only block to the SHARED substitute map** (it already existed at the old ~line 451; both providers pass the var — hetzner main.tf stamps `primary`/`secondary` per CP at lines 892/1321, huawei derives it from the region index). Dash-safe: `scripts/lint-cloudinit.sh both` green (46+43 runcmd items pass `dash -n`); `tofu validate` green for both providers.

### catalyst-api flip — BOTH regions (`products/catalyst/bootstrap/api/internal/handler/clustermesh.go`)
The #3238 flip previously patched only the PRIMARY cluster's bootstrap-kit Kustomization. Under split-side that would activate side=primary while cluster-B keeps rendering an empty release (no replica, no WAL stream). `enableCNPGPairAfterFullMesh` now:
- takes the full `regionSlots` (each carries its region's kubeconfig path — on the full-success path that triggers the flip, every slot is reachable) and patches `SOVEREIGN_ENABLE_CNPG_PAIR=true` + `reconcile.fluxcd.io/requestedAt` onto **every region's** Kustomization;
- gather phase is **all-or-nothing**: any unreadable Kustomization or failed region-substitute precondition refuses the whole flip (a half-flipped pair is exactly the hw126 broken topology); the level-triggered reconcile (#3241) / post-handover re-run converges;
- patch phase is per-region best-effort after a clean gather (idempotent merge patch; re-run converges a transiently missed region).

## Validation
- `chart/tests/cnpg-pair-render.sh` rewritten for the side split — **11 cases green**: disabled byte-identical-empty both sides; side=primary = 3 non-test + 4 helm-test resources; side=replica = 5 non-test + 0 test; `secondary` alias render byte-identical to `replica`; empty-tag + same-region fail-fasts on both sides; invalid-side fail-fast; clusterMesh-off omits the global Service on both sides; async omits sync params; Continuum CR exactly 1 on side=primary and 0 on side=replica; continuum fail-fasts unchanged.
- `go build ./...` + `go vet` + full handler test package green (64s). Extended dynamicfake harness (#3243/#3245 idiom): fixture seeds per-region dyn clients; full-mesh flip asserted on BOTH regions; new `TestAutoEstablishClusterMesh_SecondaryKustomizationMissingBlocksFlip` covers the all-or-nothing refusal; the precondition test now asserts the healthy secondary also stays unflipped; retry-convergence + startup-restore tests assert both regions.
- `check-bootstrap-kit-pin-sync.sh`, `check-bootstrap-deps.sh` (dependsOn unchanged), `check-tofu-flux-envsubst.sh`, `check-no-banned-words.sh` — all green locally.

## Honest limits
- Cross-cluster WAL streaming, the replica basebackup over the mesh, and the replica-side Secret sync (`-replication`/`-ca` must be reflected cluster-A → cluster-B, the pre-existing 0.1.x contract now made explicit) are **only provable on a live 2-region prov** — static renders + unit tests cannot cover them. The next fresh 2-region prov walk is the acceptance gate.
- `kubectl get hr -A` must be re-checked on the live env after merge per the #3188-wave rule (CI-green ≠ prov-green).

Refs #3236 #3195 #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)
