### PR TITLE
fix(bootstrap-kit): drift detection on bp-cnpg-pair HR — pair resources self-heal

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -187,6 +187,12 @@ spec:
         kind: HelmRepository
         name: bp-cnpg-pair
         namespace: flux-system
+  # Drift detection (hw126 lesson): helm does not re-apply deleted/mutated
+  # resources on reconcile, so a removed Cluster CR stays gone until the next
+  # chart bump. With drift correction the HR self-heals its rendered set —
+  # the zero-touch contract for the DR-critical pair.
+  driftDetection:
+    mode: enabled
   install:
     timeout: 15m
     # disableWait: the replica ReplicaCluster only reaches Ready once it


### PR DESCRIPTION
hw126 lesson: a deleted Cluster CR stays gone until the next chart bump because helm-controller does not drift-correct by default. The DR-critical pair must self-heal its rendered set. Slot-only change, syncs via the Kustomization directly. Refs #3236 #2737