### PR TITLE
fix(catalyst): sync primary CNPG -replication/-ca Secrets cross-cluster before slot-16b flip

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -200,6 +200,55 @@ const (
 	fluxReconcileRequestedAtAnnotation    = "reconcile.fluxcd.io/requestedAt"
 )
 
+// Cross-cluster CNPG replica-auth Secret sync (#3254, the prerequisite
+// #3253's PR body flagged as unsolved). The bp-cnpg-pair replica Cluster
+// CR — rendered on the SECONDARY region's cluster since chart 0.2.0's
+// split-side topology (#3253) — streams its pg_basebackup/WAL from the
+// primary over Cilium ClusterMesh and authenticates as the
+// `streaming_replica` role with the PRIMARY cluster's CNPG-generated TLS
+// material. Those Secrets are created by CNPG ONLY on the primary
+// region's cluster (namespace `cnpg`); the replica chart's
+// `externalClusters[].sslKey`/`sslCert`/`sslRootCert`
+// (platform/cnpg-pair/chart/templates/replica-cluster.yaml ~L127-135)
+// reference them BY NAME, so the same-named Secrets must also exist on
+// the replica cluster. The chart comment claimed "ESO syncs this across
+// clusters in production" but nothing did — so the slot-16b flip copies
+// them here, primary → every replica, BEFORE enabling the gate.
+//
+// Names are DERIVED THE SAME WAY THE CHART DOES: the chart's
+// `cnpg-pair.fullname` helper resolves to <releaseName>-<chartName>
+// (releaseName `cnpg-pair` + chartName `bp-cnpg-pair`; the release name
+// does not contain the chart name, so they concatenate →
+// `cnpg-pair-bp-cnpg-pair`), and the externalClusters refs are
+// `<fullname>-primary-replication` / `<fullname>-primary-ca`. The HR
+// (clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml) pins
+// releaseName=cnpg-pair + targetNamespace=cnpg, both stable; if either
+// ever changes, these constants move in lockstep.
+//
+// 🛑 Cert ROTATION is NOT handled here: the copy is a point-in-time
+// snapshot. The #3241 level-trigger re-runs AutoEstablishClusterMesh
+// (and post-handover finalisation re-fires the flip), each of which
+// re-copies the then-current bytes, so a rotation eventually propagates
+// on a later establish run — but there is no dedicated watch/refresh. A
+// long-lived rotation story (an ESO ClusterExternalSecret / reflector
+// annotation that keeps the replica copy live) is follow-up
+// (#3249-class).
+const (
+	cnpgPairNamespace       = "cnpg"
+	cnpgPairReleaseFullname = "cnpg-pair-bp-cnpg-pair"
+	cnpgPairReplicationCert = cnpgPairReleaseFullname + "-primary-replication"
+	cnpgPairReplicationCA   = cnpgPairReleaseFullname + "-primary-ca"
+)
+
+// cnpgPairReplicaAuthSecrets — the exact Secret names the replica-side
+// chart's externalClusters block references (sslKey/sslCert →
+// `-primary-replication`, sslRootCert → `-primary-ca`). Copied primary →
+// every replica region before the flip.
+var cnpgPairReplicaAuthSecrets = []string{
+	cnpgPairReplicationCert,
+	cnpgPairReplicationCA,
+}
+
 // fluxKustomizationGVR — kustomize.toolkit.fluxcd.io/v1 Kustomizations,
 // addressed via the dynamic client (no Flux Go types vendored here).
 var fluxKustomizationGVR = schema.GroupVersionResource{
@@ -754,6 +803,23 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 		targets = append(targets, flipTarget{regionKey: regionLabel, dyn: dyn})
 	}
 
+	// ── Cross-cluster replica-auth Secret sync (#3254) ──────────────
+	// Before flipping the gate ON, the replica-side Cluster CR's
+	// streaming auth (the primary's `-replication` client cert + `-ca`,
+	// both in namespace `cnpg`) must be present on EVERY replica
+	// cluster — those Secrets are created by CNPG only on the primary.
+	// Same all-or-nothing semantics as the gather phase above: if the
+	// source Secrets are absent (the primary postgres is still
+	// bootstrapping — CNPG mints these only after initdb) or any copy
+	// fails, REFUSE the whole flip and leave the gate OFF everywhere.
+	// A half state (gate flipped but the replica missing its auth
+	// Secrets) would render a replica Cluster that waits forever on a
+	// secret it cannot find. The #3241 level-trigger + post-handover
+	// re-runs converge once the primary's Secrets appear.
+	if !h.syncCNPGPairReplicaAuthSecrets(ctx, dep, slots) {
+		return
+	}
+
 	// ── Patch phase ─────────────────────────────────────────────────
 	// JSON merge patch (RFC 7386) merges nested objects key-by-key, so
 	// sibling substitute keys + existing annotations are preserved —
@@ -807,6 +873,173 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 	)
 	h.emitClusterMeshProgress(dep, "info",
 		fmt.Sprintf("ClusterMesh confirmed across all regions — enabled bp-cnpg-pair (slot 16b) via SOVEREIGN_ENABLE_CNPG_PAIR=true on %d/%d region Kustomizations and requested Flux reconcile", patched, len(targets)))
+}
+
+// syncCNPGPairReplicaAuthSecrets copies the primary cluster's CNPG
+// replication-auth Secrets (cnpgPairReplicaAuthSecrets, namespace
+// cnpgPairNamespace) onto EVERY replica region's cluster, so the
+// replica-side bp-cnpg-pair Cluster CR can authenticate its
+// pg_basebackup/WAL stream against the primary (the chart references
+// these Secrets by name from `externalClusters[].sslKey`/`sslCert`/
+// `sslRootCert` — see #3254). Returns true when the whole pair-side is
+// satisfied (single-region — nothing to sync, vacuously true; OR every
+// replica got every Secret), false to REFUSE the flip.
+//
+// All-or-nothing, matching the gather phase: a missing SOURCE Secret on
+// the primary (the primary postgres is still bootstrapping — CNPG mints
+// `-replication`/`-ca` only after initdb) or ANY per-replica copy
+// failure refuses the entire flip and leaves the gate OFF everywhere
+// (safe: empty Ready releases). The #3241 level-trigger + post-handover
+// finalisation re-run AutoEstablishClusterMesh and converge once the
+// primary's Secrets exist. Every refusal logs loudly AND emits a
+// clustermesh-progress warn event, per this file's failure convention.
+//
+// slots[0] is the primary (regionKeyFromSpec returns "" for idx 0);
+// slots[1:] are the replica regions. Each slot's typed clientset was
+// built in buildRegionSlots; on the full-success path that gates this
+// flip, every slot is reachable.
+func (h *Handler) syncCNPGPairReplicaAuthSecrets(ctx context.Context, dep *Deployment, slots []regionSlot) bool {
+	if len(slots) < 2 {
+		// No replica region — nothing to sync. (AutoEstablishClusterMesh
+		// only calls the flip on len(statuses) >= 2, so this is a guard,
+		// not the live path.)
+		return true
+	}
+	primary := &slots[0]
+	if primary.clientset == nil {
+		h.log.Warn("clustermesh: cnpg-pair replica-auth sync: primary clientset nil — refusing flip",
+			"id", dep.ID)
+		h.emitClusterMeshProgress(dep, "warn",
+			"ClusterMesh: cnpg-pair enable refused — primary cluster client unavailable for replica-auth Secret sync; re-run converges")
+		return false
+	}
+
+	// Read the source Secrets from the primary ONCE. A missing source =
+	// the primary postgres has not initialised yet → refuse + converge
+	// on a later run.
+	sources := make([]*corev1.Secret, 0, len(cnpgPairReplicaAuthSecrets))
+	for _, name := range cnpgPairReplicaAuthSecrets {
+		getCtx, cancel := context.WithTimeout(ctx, clusterMeshCallTimeout)
+		src, err := primary.clientset.CoreV1().Secrets(cnpgPairNamespace).Get(getCtx, name, metav1.GetOptions{})
+		cancel()
+		if err != nil {
+			h.log.Warn("clustermesh: cnpg-pair replica-auth sync: source Secret unavailable on primary — refusing flip (primary postgres likely still bootstrapping)",
+				"id", dep.ID, "namespace", cnpgPairNamespace, "secret", name, "err", err)
+			h.emitClusterMeshProgress(dep, "warn",
+				fmt.Sprintf("ClusterMesh: cnpg-pair enable refused — primary Secret %s/%s not ready (%v); the replica needs it for WAL-stream auth — re-run converges once the primary postgres initialises",
+					cnpgPairNamespace, name, err))
+			return false
+		}
+		sources = append(sources, src)
+	}
+
+	// Copy every source Secret onto every replica region. Any failure
+	// refuses the whole flip (no partial state).
+	for i := 1; i < len(slots); i++ {
+		replica := &slots[i]
+		regionLabel := replica.key
+		if regionLabel == "" {
+			regionLabel = "secondary"
+		}
+		if replica.clientset == nil {
+			h.log.Warn("clustermesh: cnpg-pair replica-auth sync: replica clientset nil — refusing flip",
+				"id", dep.ID, "region", regionLabel)
+			h.emitClusterMeshProgress(dep, "warn",
+				fmt.Sprintf("ClusterMesh: cnpg-pair enable refused — replica region %q cluster client unavailable for replica-auth Secret sync; re-run converges", regionLabel))
+			return false
+		}
+		for _, src := range sources {
+			if err := h.copySecretAcrossClusters(ctx, src, replica.clientset, cnpgPairNamespace); err != nil {
+				h.log.Warn("clustermesh: cnpg-pair replica-auth sync: copy to replica failed — refusing flip",
+					"id", dep.ID, "region", regionLabel, "namespace", cnpgPairNamespace, "secret", src.Name, "err", err)
+				h.emitClusterMeshProgress(dep, "warn",
+					fmt.Sprintf("ClusterMesh: cnpg-pair enable refused — copying Secret %s/%s to replica region %q failed (%v); re-run converges",
+						cnpgPairNamespace, src.Name, regionLabel, err))
+				return false
+			}
+		}
+		h.log.Info("clustermesh: cnpg-pair replica-auth Secrets synced to replica region",
+			"id", dep.ID, "region", regionLabel, "namespace", cnpgPairNamespace, "secrets", cnpgPairReplicaAuthSecrets)
+	}
+
+	h.emitClusterMeshProgress(dep, "info",
+		fmt.Sprintf("ClusterMesh: synced cnpg-pair replica-auth Secrets (%s) primary → %d replica region(s) for WAL-stream auth",
+			strings.Join(cnpgPairReplicaAuthSecrets, ", "), len(slots)-1))
+	return true
+}
+
+// copySecretAcrossClusters create-or-updates a copy of src into the dst
+// cluster under the given namespace, keeping src's name. Server-side and
+// owner-scoped metadata (resourceVersion / UID / ownerReferences /
+// managedFields / creationTimestamp / generation / selfLink) are
+// stripped so the object is admissible on the destination; Data, Type,
+// Labels, and (non-Kustomize) Annotations carry over. Idempotent: a
+// re-run overwrites the destination's Data/Type with the current source
+// bytes (which is what makes the #3241 level-trigger re-run refresh the
+// copy). The destination namespace is assumed to exist (slot 16b ships
+// the `cnpg` Namespace unconditionally on every region).
+func (h *Handler) copySecretAcrossClusters(ctx context.Context, src *corev1.Secret, dst kubernetes.Interface, namespace string) error {
+	if src == nil {
+		return fmt.Errorf("source Secret is nil")
+	}
+	desired := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        src.Name,
+			Namespace:   namespace,
+			Labels:      src.Labels,
+			Annotations: src.Annotations,
+		},
+		Type:       src.Type,
+		Data:       src.Data,
+		StringData: src.StringData,
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, clusterMeshCallTimeout)
+	defer cancel()
+	existing, err := dst.CoreV1().Secrets(namespace).Get(callCtx, src.Name, metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("Get Secret %s/%s on replica: %w", namespace, src.Name, err)
+		}
+		if _, createErr := dst.CoreV1().Secrets(namespace).Create(callCtx, desired, metav1.CreateOptions{}); createErr != nil {
+			if apierrors.IsAlreadyExists(createErr) {
+				// Lost a race with another writer — fall through to update.
+				return h.updateCopiedSecret(callCtx, desired, dst, namespace)
+			}
+			return fmt.Errorf("Create Secret %s/%s on replica: %w", namespace, src.Name, createErr)
+		}
+		return nil
+	}
+	// Update in place — preserve the destination's resourceVersion so the
+	// Update is accepted, overwrite Data/Type/Labels/Annotations.
+	existing.Data = desired.Data
+	existing.StringData = desired.StringData
+	existing.Type = desired.Type
+	existing.Labels = desired.Labels
+	existing.Annotations = desired.Annotations
+	if _, updErr := dst.CoreV1().Secrets(namespace).Update(callCtx, existing, metav1.UpdateOptions{}); updErr != nil {
+		return fmt.Errorf("Update Secret %s/%s on replica: %w", namespace, src.Name, updErr)
+	}
+	return nil
+}
+
+// updateCopiedSecret is the create-raced-update fallback for
+// copySecretAcrossClusters: re-Get to pick up the live resourceVersion,
+// then Update with the desired Data/Type/Labels/Annotations.
+func (h *Handler) updateCopiedSecret(ctx context.Context, desired *corev1.Secret, dst kubernetes.Interface, namespace string) error {
+	existing, err := dst.CoreV1().Secrets(namespace).Get(ctx, desired.Name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("Get Secret %s/%s on replica (race fallback): %w", namespace, desired.Name, err)
+	}
+	existing.Data = desired.Data
+	existing.StringData = desired.StringData
+	existing.Type = desired.Type
+	existing.Labels = desired.Labels
+	existing.Annotations = desired.Annotations
+	if _, updErr := dst.CoreV1().Secrets(namespace).Update(ctx, existing, metav1.UpdateOptions{}); updErr != nil {
+		return fmt.Errorf("Update Secret %s/%s on replica (race fallback): %w", namespace, desired.Name, updErr)
+	}
+	return nil
 }
 
 // clusterMeshDynamicClient builds a dynamic.Interface for the cluster

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -44,6 +44,7 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	kfake "k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
@@ -132,6 +133,57 @@ func buildFakeClusterMeshCluster(t *testing.T, lbIP string, caCert, caKey []byte
 		t.Fatalf("create clustermesh-apiserver Service: %v", err)
 	}
 	return cs
+}
+
+// seedCNPGPairSourceSecrets pre-creates the namespace `cnpg` and the two
+// primary-side CNPG replication-auth Secrets the slot-16b flip copies to
+// every replica (#3254). Called on the PRIMARY fake clientset so the
+// happy-path flip succeeds; tests that exercise the missing-source guard
+// delete one before invoking the orchestrator.
+func seedCNPGPairSourceSecrets(t *testing.T, cs kubernetes.Interface) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := cs.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: cnpgPairNamespace},
+	}, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create cnpg namespace: %v", err)
+	}
+	secrets := map[string]map[string][]byte{
+		cnpgPairReplicationCert: {"tls.crt": []byte("REPL-CERT"), "tls.key": []byte("REPL-KEY")},
+		cnpgPairReplicationCA:   {"ca.crt": []byte("REPL-CA")},
+	}
+	for name, data := range secrets {
+		typ := corev1.SecretTypeTLS
+		if name == cnpgPairReplicationCA {
+			typ = corev1.SecretTypeOpaque
+		}
+		if _, err := cs.CoreV1().Secrets(cnpgPairNamespace).Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: cnpgPairNamespace,
+				Labels:    map[string]string{"cnpg.io/cluster": cnpgPairReleaseFullname + "-primary"},
+			},
+			Type: typ,
+			Data: data,
+		}, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("create source Secret %s: %v", name, err)
+		}
+	}
+}
+
+// seedCNPGPairReplicaNamespace pre-creates the `cnpg` namespace on a
+// replica fake clientset, matching production where slot 16b ships the
+// Namespace unconditionally on every region. Without it the copy's
+// Create would fail "namespaces \"cnpg\" not found" — but in the
+// fake clientset Create into a missing namespace succeeds, so this is
+// here for parity/clarity rather than strict necessity.
+func seedCNPGPairReplicaNamespace(t *testing.T, cs kubernetes.Interface) {
+	t.Helper()
+	if _, err := cs.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: cnpgPairNamespace},
+	}, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create cnpg namespace on replica: %v", err)
+	}
 }
 
 // writeFakeKubeconfig drops a stub kubeconfig YAML into the directory
@@ -240,7 +292,18 @@ func newTestFixture(t *testing.T, lbIPs []string) *testFixture {
 		key := regionKeyFromSpec(regions[i], i)
 		_ = regionKey
 		kcPath := writeFakeKubeconfig(t, dir, depID, key)
-		clients[kcPath] = buildFakeClusterMeshCluster(t, lbIP, caCert, caKey)
+		cs := buildFakeClusterMeshCluster(t, lbIP, caCert, caKey)
+		// #3254: seed the cnpg-pair replica-auth Secrets on the PRIMARY
+		// (idx 0) so the slot-16b flip's cross-cluster copy succeeds; seed
+		// the `cnpg` namespace on each replica (matches slot 16b shipping
+		// the Namespace unconditionally on every region). Tests exercising
+		// the missing-source guard delete a source Secret afterwards.
+		if i == 0 {
+			seedCNPGPairSourceSecrets(t, cs)
+		} else {
+			seedCNPGPairReplicaNamespace(t, cs)
+		}
+		clients[kcPath] = cs
 	}
 
 	dep := &Deployment{
@@ -736,7 +799,16 @@ func TestRestoreFromStore_StartupKicksClusterMeshReconcile(t *testing.T) {
 	for i := range regions {
 		key := regionKeyFromSpec(regions[i], i)
 		kcPath := writeFakeKubeconfig(t, dir, depID, key)
-		clients[kcPath] = buildFakeClusterMeshCluster(t, lbIPs[i], caCert, caKey)
+		cs := buildFakeClusterMeshCluster(t, lbIPs[i], caCert, caKey)
+		// #3254: seed the cnpg-pair replica-auth source Secrets on the
+		// primary (idx 0) + the cnpg namespace on the replica, so the
+		// slot-16b flip's cross-cluster copy succeeds and the gate flips.
+		if i == 0 {
+			seedCNPGPairSourceSecrets(t, cs)
+		} else {
+			seedCNPGPairReplicaNamespace(t, cs)
+		}
+		clients[kcPath] = cs
 	}
 	primaryKubeconfigPath := filepath.Join(dir, depID+".yaml")
 	// EVERY region's Kustomization gets the split-side flip, so each
@@ -1297,4 +1369,235 @@ func TestAutoEstablishClusterMesh_SubstitutePreconditionBlocksCNPGPairFlip(t *te
 			}
 		})
 	}
+}
+
+// ── #3254: cross-cluster CNPG replica-auth Secret sync ──────────────
+
+// getCNPGSecret reads a Secret from the cnpg namespace of a fake
+// clientset, returning (nil, false) when absent.
+func getCNPGSecret(t *testing.T, cs kubernetes.Interface, name string) (*corev1.Secret, bool) {
+	t.Helper()
+	s, err := cs.CoreV1().Secrets(cnpgPairNamespace).Get(context.Background(), name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, false
+	}
+	if err != nil {
+		t.Fatalf("get Secret %s/%s: %v", cnpgPairNamespace, name, err)
+	}
+	return s, true
+}
+
+// assertGateFlipped/assertGateNotFlipped assert the SOVEREIGN_ENABLE_
+// CNPG_PAIR substitute + reconcile annotation state on a region's
+// bootstrap-kit Kustomization.
+func assertGateFlipped(t *testing.T, dyn dynamic.Interface, region string) {
+	t.Helper()
+	ks := getBootstrapKitKustomization(t, dyn)
+	substitute, _, _ := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
+	if got := substitute[clusterMeshCNPGPairSubstituteKey]; got != "true" {
+		t.Errorf("region %q: substitute[%s] = %q, want \"true\"", region, clusterMeshCNPGPairSubstituteKey, got)
+	}
+	if stamp := ks.GetAnnotations()[fluxReconcileRequestedAtAnnotation]; stamp == "" {
+		t.Errorf("region %q: reconcile annotation absent — Flux reconcile never requested", region)
+	}
+}
+
+func assertGateNotFlipped(t *testing.T, dyn dynamic.Interface, region string) {
+	t.Helper()
+	ks := getBootstrapKitKustomization(t, dyn)
+	substitute, _, _ := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
+	if got, ok := substitute[clusterMeshCNPGPairSubstituteKey]; ok {
+		t.Errorf("region %q: substitute[%s] = %q — gate flipped when it must stay OFF", region, clusterMeshCNPGPairSubstituteKey, got)
+	}
+	if stamp := ks.GetAnnotations()[fluxReconcileRequestedAtAnnotation]; stamp != "" {
+		t.Errorf("region %q: reconcile annotation = %q set when the flip must be refused", region, stamp)
+	}
+}
+
+// TestAutoEstablishClusterMesh_FullMeshSyncsReplicaAuthSecretsThenFlips
+// — happy path: a fully-meshed 2-region prov copies BOTH primary CNPG
+// replica-auth Secrets (the `-replication` client cert + the `-ca`) onto
+// the replica cluster's `cnpg` namespace AND THEN flips both regions'
+// SOVEREIGN_ENABLE_CNPG_PAIR gates. Without the copy the replica Cluster
+// CR's externalClusters sslKey/sslCert/sslRootCert refs would dangle and
+// the WAL stream could never authenticate (#3254).
+func TestAutoEstablishClusterMesh_FullMeshSyncsReplicaAuthSecretsThenFlips(t *testing.T) {
+	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+
+	// Sanity: the replica starts WITHOUT the source Secrets.
+	replicaCS := fx.clients[fx.secondaryKubeconfigPath]
+	for _, name := range cnpgPairReplicaAuthSecrets {
+		if _, ok := getCNPGSecret(t, replicaCS, name); ok {
+			t.Fatalf("precondition: replica unexpectedly already has Secret %s", name)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	statuses, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep)
+	if err != nil {
+		t.Fatalf("AutoEstablishClusterMesh returned error: %v", err)
+	}
+	requireFullyMeshed(t, statuses)
+
+	// Both source Secrets must now exist on the replica, byte-identical.
+	primaryCS := fx.clients[fx.primaryKubeconfigPath]
+	for _, name := range cnpgPairReplicaAuthSecrets {
+		got, ok := getCNPGSecret(t, replicaCS, name)
+		if !ok {
+			t.Fatalf("replica missing copied Secret %s — replica WAL-stream auth would dangle", name)
+		}
+		src, _ := getCNPGSecret(t, primaryCS, name)
+		for k, v := range src.Data {
+			if string(got.Data[k]) != string(v) {
+				t.Errorf("Secret %s key %q: replica=%q want %q (copy not byte-identical)", name, k, got.Data[k], v)
+			}
+		}
+		if got.Type != src.Type {
+			t.Errorf("Secret %s: replica Type=%q want %q", name, got.Type, src.Type)
+		}
+		// Server-side metadata must be stripped (no inherited UID).
+		if got.UID == src.UID && src.UID != "" {
+			t.Errorf("Secret %s: replica inherited the primary's UID %q — server-side metadata not stripped", name, got.UID)
+		}
+	}
+
+	// AND the gate flipped on BOTH regions.
+	assertGateFlipped(t, fx.dynClients[fx.primaryKubeconfigPath], "primary")
+	assertGateFlipped(t, fx.dynClients[fx.secondaryKubeconfigPath], "secondary")
+}
+
+// TestAutoEstablishClusterMesh_MissingSourceSecretRefusesFlip — when the
+// primary has NOT yet produced one of the CNPG replica-auth Secrets (its
+// postgres is still bootstrapping — CNPG mints `-replication`/`-ca` only
+// after initdb), the flip is REFUSED ENTIRELY: neither region's gate
+// flips and no Secret lands on the replica. The level-trigger re-run
+// converges once the primary's Secret appears.
+func TestAutoEstablishClusterMesh_MissingSourceSecretRefusesFlip(t *testing.T) {
+	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
+	// Remove ONE source Secret from the primary (simulates postgres
+	// mid-bootstrap).
+	primaryCS := fx.clients[fx.primaryKubeconfigPath]
+	if err := primaryCS.CoreV1().Secrets(cnpgPairNamespace).Delete(context.Background(), cnpgPairReplicationCert, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete source Secret: %v", err)
+	}
+	var logBuf bytes.Buffer
+	fx.handler.log = slog.New(slog.NewTextHandler(&logBuf, nil))
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	statuses, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep)
+	if err != nil {
+		t.Fatalf("AutoEstablishClusterMesh returned error: %v", err)
+	}
+	requireFullyMeshed(t, statuses)
+
+	// All-or-nothing: NEITHER region's gate flips.
+	assertGateNotFlipped(t, fx.dynClients[fx.primaryKubeconfigPath], "primary")
+	assertGateNotFlipped(t, fx.dynClients[fx.secondaryKubeconfigPath], "secondary")
+	// The OTHER source Secret (the -ca) must NOT have been partially
+	// copied — the source read is all-or-nothing before any copy.
+	replicaCS := fx.clients[fx.secondaryKubeconfigPath]
+	if _, ok := getCNPGSecret(t, replicaCS, cnpgPairReplicationCA); ok {
+		t.Errorf("replica got %s despite missing sibling source Secret — copy must be all-or-nothing", cnpgPairReplicationCA)
+	}
+	if !strings.Contains(logBuf.String(), "source Secret unavailable on primary") {
+		t.Errorf("expected a loud warning about the missing source Secret, got:\n%s", logBuf.String())
+	}
+}
+
+// TestAutoEstablishClusterMesh_ReplicaCopyFailureRefusesFlip — when the
+// copy to the replica cluster fails (here: a reactor rejects the Secret
+// write), the flip is REFUSED: neither region's gate flips. A
+// half-flipped pair (gate ON, replica auth Secret absent) is exactly the
+// broken topology this guard prevents.
+func TestAutoEstablishClusterMesh_ReplicaCopyFailureRefusesFlip(t *testing.T) {
+	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
+	// Make every Secret write into the replica's cnpg namespace fail.
+	replicaCS := fx.clients[fx.secondaryKubeconfigPath].(*kfake.Clientset)
+	failWrite := func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetNamespace() == cnpgPairNamespace {
+			return true, nil, fmt.Errorf("injected replica Secret write failure")
+		}
+		return false, nil, nil
+	}
+	replicaCS.PrependReactor("create", "secrets", failWrite)
+	replicaCS.PrependReactor("update", "secrets", failWrite)
+
+	var logBuf bytes.Buffer
+	fx.handler.log = slog.New(slog.NewTextHandler(&logBuf, nil))
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	statuses, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep)
+	if err != nil {
+		t.Fatalf("AutoEstablishClusterMesh returned error: %v", err)
+	}
+	requireFullyMeshed(t, statuses)
+
+	assertGateNotFlipped(t, fx.dynClients[fx.primaryKubeconfigPath], "primary")
+	assertGateNotFlipped(t, fx.dynClients[fx.secondaryKubeconfigPath], "secondary")
+	if !strings.Contains(logBuf.String(), "copy to replica failed") {
+		t.Errorf("expected a loud warning about the failed replica copy, got:\n%s", logBuf.String())
+	}
+}
+
+// TestAutoEstablishClusterMesh_ReRunAfterSecretsAppearConverges — first
+// run with the source Secret absent refuses the flip; after the primary
+// produces it, a second run (the #3241 level-trigger shape) copies both
+// Secrets and flips both gates. Proves the refusal is recoverable, not
+// terminal, and that the copy is idempotent across runs.
+func TestAutoEstablishClusterMesh_ReRunAfterSecretsAppearConverges(t *testing.T) {
+	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
+	primaryCS := fx.clients[fx.primaryKubeconfigPath]
+	// Run 1: one source Secret missing → flip refused.
+	if err := primaryCS.CoreV1().Secrets(cnpgPairNamespace).Delete(context.Background(), cnpgPairReplicationCert, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete source Secret: %v", err)
+	}
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep); err != nil {
+		t.Fatalf("run 1: AutoEstablishClusterMesh error: %v", err)
+	}
+	assertGateNotFlipped(t, fx.dynClients[fx.primaryKubeconfigPath], "primary (run 1)")
+	assertGateNotFlipped(t, fx.dynClients[fx.secondaryKubeconfigPath], "secondary (run 1)")
+
+	// The primary postgres finishes initdb → CNPG mints the Secret.
+	if _, err := primaryCS.CoreV1().Secrets(cnpgPairNamespace).Create(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: cnpgPairReplicationCert, Namespace: cnpgPairNamespace},
+		Type:       corev1.SecretTypeTLS,
+		Data:       map[string][]byte{"tls.crt": []byte("REPL-CERT-2"), "tls.key": []byte("REPL-KEY-2")},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("re-create source Secret: %v", err)
+	}
+
+	// Run 2: now converges — both Secrets copied, both gates flipped.
+	if _, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep); err != nil {
+		t.Fatalf("run 2: AutoEstablishClusterMesh error: %v", err)
+	}
+	replicaCS := fx.clients[fx.secondaryKubeconfigPath]
+	for _, name := range cnpgPairReplicaAuthSecrets {
+		if _, ok := getCNPGSecret(t, replicaCS, name); !ok {
+			t.Errorf("run 2: replica still missing Secret %s after source appeared", name)
+		}
+	}
+	assertGateFlipped(t, fx.dynClients[fx.primaryKubeconfigPath], "primary (run 2)")
+	assertGateFlipped(t, fx.dynClients[fx.secondaryKubeconfigPath], "secondary (run 2)")
 }


### PR DESCRIPTION
## Gap (flagged by #3253's PR body as a known prerequisite, unsolved)

The replica-side CNPG `Cluster` CR — rendered on the SECONDARY region's cluster since chart 0.2.0's split-side topology (#3253) — authenticates its `pg_basebackup`/WAL streaming against the primary using the primary cluster's CNPG-generated Secrets:

- `cnpg-pair-bp-cnpg-pair-primary-replication` (`tls.key` + `tls.crt` — the `streaming_replica` client cert; the replica chart's `externalClusters[].sslKey`/`sslCert`)
- `cnpg-pair-bp-cnpg-pair-primary-ca` (`ca.crt` — `externalClusters[].sslRootCert`)

Both exist ONLY on the PRIMARY region's cluster (namespace `cnpg`). The replica chart comment claimed "ESO syncs this across clusters in production" — nothing actually did. Without them the replica bootstrap waits forever.

## Change (Go-only)

`enableCNPGPairAfterFullMesh` in `products/catalyst/bootstrap/api/internal/handler/clustermesh.go` (which post-#3253 takes all `regionSlots`) now copies the two Secrets primary → every replica BEFORE patching the Kustomizations:

- **Names derived the same way the chart does.** `cnpg-pair.fullname` = `<releaseName>-<chartName>` = `cnpg-pair-bp-cnpg-pair` (HR pins `releaseName: cnpg-pair`, `targetNamespace: cnpg`); refs `<fullname>-primary-replication` / `<fullname>-primary-ca`, namespace `cnpg`. Grounded against `helm template` of `platform/cnpg-pair/chart` (`externalClusters` ssl refs).
- **Copy semantics:** read via the primary slot's typed client; create-or-update via each replica slot's typed client into the same namespace/name; strips `resourceVersion`/`UID`/`ownerReferences`/`managedFields`/`creationTimestamp`; idempotent. The `cnpg` Namespace already exists on both sides (slot 16b ships it unconditionally).
- **All-or-nothing, matching the gather phase:** a missing source Secret (the primary postgres is still bootstrapping — CNPG mints these only after initdb) or any copy failure REFUSES the whole flip with the established warn-and-return + `clustermesh-progress` warn event. No half state. The #3241 level-trigger and post-handover re-runs retry and converge.
- Cert **rotation** is not handled here (the level-trigger re-runs refresh on each establish run; a long-lived rotation story is follow-up #3249-class). Noted in a code comment.

## Tests (TDD, per-region fake-client harness)

Added to `clustermesh_test.go`:

- `..._FullMeshSyncsReplicaAuthSecretsThenFlips` — copies both Secrets byte-identically (server-side metadata stripped) THEN flips both Kustomizations.
- `..._MissingSourceSecretRefusesFlip` — one source Secret absent → neither gate flips, no partial copy, loud warning.
- `..._ReplicaCopyFailureRefusesFlip` — reactor rejects the replica write → neither gate flips, loud warning.
- `..._ReRunAfterSecretsAppearConverges` — run 1 (source missing) refuses; after the primary produces it, run 2 copies + flips both.

The existing flip fixtures (`newTestFixture` + `TestRestoreFromStore_StartupKicksClusterMeshReconcile`) now seed the primary's source Secrets so their flips still occur.

`go build ./... ` + `go vet ./...` + `go test ./internal/handler/ -count=1` all green.

## Notes

- Go-only. If a follow-up wants the replica copy kept live across cert rotation, that is a chart/ESO change (ClusterExternalSecret / reflector) tracked at #3249-class — out of this change's surface.

Refs #3236 #3195 #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)