### PR TITLE
fix(cnpg): pin operator image to Harbor proxy so injected initContainer is proxied too

### DIFF
--- a/clusters/_template/bootstrap-kit/16-cnpg.yaml
+++ b/clusters/_template/bootstrap-kit/16-cnpg.yaml
@@ -63,7 +63,13 @@ spec:
       # CA written to MutatingWebhookConfiguration caBundle → x509
       # verify failed → all Cluster CR admissions denied. G53
       # webhook-gate remains as readiness signal.
-      version: 1.0.8
+      #
+      # 1.0.9 (Refs #3236 #2737): operator image pinned to the Harbor
+      # proxy-cache (proxy-ghcr/cloudnative-pg/cloudnative-pg:1.29.0) so the
+      # operator pod AND the bootstrap-controller initContainer it injects
+      # into every instance pod both pull harbor-proxied — bare ghcr.io ref
+      # flaky-DNS ImagePullBackOff'd the cnpg-pair replica on hw126 region-B.
+      version: 1.0.9
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg

--- a/platform/cnpg/blueprint.yaml
+++ b/platform/cnpg/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-4-1-data-services
 spec:
-  version: 1.0.8
+  version: 1.0.9
   card:
     title: CloudNativePG
     summary: |

--- a/platform/cnpg/chart/Chart.yaml
+++ b/platform/cnpg/chart/Chart.yaml
@@ -8,7 +8,17 @@ name: bp-cnpg
 # kind of certificate") → bp-catalyst-platform + bp-newapi Helm
 # install denied. Trust upstream operator's self-managed cert flow;
 # G53 webhook-gate Job remains as the readiness signal.
-version: 1.0.8
+#
+# 1.0.9 (Refs #3236 #2737): pin the cloudnative-pg operator image to the
+# Harbor proxy-cache (harbor.openova.io/proxy-ghcr/cloudnative-pg/
+# cloudnative-pg:1.29.0). The subchart renders both the operator pod's
+# image AND the OPERATOR_IMAGE_NAME env (which the operator injects as the
+# bootstrap-controller initContainer into every instance pod) from the same
+# image.repository:image.tag — so the override proxies both in lockstep. Bare
+# upstream ghcr.io ref violated the harbor-proxy baseline + flaky-ghcr-DNS
+# ImagePullBackOff killed the cnpg-pair replica basebackup on hw126 region-B.
+# webhookGate Job image proxied to proxy-dockerhub in the same pass.
+version: 1.0.9
 description: |
   Catalyst-curated Blueprint umbrella chart for CloudNativePG. Depends on
   the upstream `cloudnative-pg` chart as a Helm subchart so

--- a/platform/cnpg/chart/values.yaml
+++ b/platform/cnpg/chart/values.yaml
@@ -71,6 +71,33 @@ catalystBlueprint:
 # `helm dependency build` resolves the upstream as a subchart; values here
 # under the `cloudnative-pg:` key flow into that subchart unchanged.
 cloudnative-pg:
+  # 1.0.9 (Refs #3236 #2737): pin the operator image to the in-Sovereign
+  # Harbor proxy-cache instead of the bare upstream ref.
+  #
+  # The upstream subchart's deployment.yaml renders BOTH the operator pod's
+  # own `image:` AND the `OPERATOR_IMAGE_NAME` env var from this single
+  # `{{ .Values.image.repository }}:{{ .Values.image.tag | default
+  # .Chart.AppVersion }}` expression. CNPG's operator reads OPERATOR_IMAGE_NAME
+  # to decide which image to inject as the `bootstrap-controller`
+  # initContainer into EVERY instance pod it creates — so overriding
+  # repository+tag here proxies the operator pod AND every injected
+  # instance-bootstrap initContainer in lockstep. No separate knob exists.
+  #
+  # The bare upstream default (`ghcr.io/cloudnative-pg/cloudnative-pg` +
+  # subchart appVersion 1.29.0) violated the harbor-proxy-pull baseline and
+  # failed to pull on kom4dc nodes with flaky ghcr DNS
+  # ("dial tcp: lookup ghcr.io: Try again" → Init:ImagePullBackOff →
+  # cnpg-pair replica basebackup dead). Live on hw126 region-B.
+  #
+  # Tag pinned explicitly: upstream floats it to .Chart.AppVersion (1.29.0
+  # for subchart 0.28.0); pin so a subchart bump can't silently move the
+  # operator + every injected initContainer onto a different tag. Bump this
+  # tag in lockstep with the cloudnative-pg subchart version in Chart.yaml.
+  image:
+    repository: harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg
+    tag: "1.29.0"
+    pullPolicy: IfNotPresent
+
   # Install postgresql.cnpg.io CRDs as part of this chart. Required so
   # consumers of `postgresql.cnpg.io/v1.Cluster` (bp-powerdns,
   # bp-keycloak, bp-gitea, bp-langfuse, …) can gate themselves on bp-cnpg
@@ -163,5 +190,11 @@ webhookGate:
   validatingWebhookName: cnpg-validating-webhook-configuration
   timeoutSeconds: 300
   intervalSeconds: 2
-  image: "bitnamilegacy/kubectl:1.30.7"
+  # 1.0.9 (Refs #3236 #2737): pin to the in-Sovereign Harbor proxy-cache,
+  # matching webhookCertBootstrap.kubectlImage above and the bp-flux /
+  # bp-cert-manager / bp-guacamole convention. The bare `bitnamilegacy/
+  # kubectl` ref pulled straight from dockerhub — same harbor-proxy-pull
+  # baseline violation + ghcr/dockerhub DNS-flake exposure as the operator
+  # image, and the gate Job runs on every install (enabled: true).
+  image: "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7"
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Bug (live on hw126 region-B)

The CNPG operator injects **its own image** as the `bootstrap-controller`
initContainer into every instance pod it creates. `bp-cnpg` left the
operator image at the bare upstream default
`ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0`, so that bare ref was
injected into every instance pod:

- violates the harbor-proxy-pull baseline (flagged in audit on every instance pod), and
- fails to pull on kom4dc nodes with flaky ghcr DNS:
  `Init:ImagePullBackOff — dial tcp: lookup ghcr.io: Try again`
  → the cnpg-pair replica basebackup is dead.

## Mechanism (grounded in the rendered subchart)

The upstream `cloudnative-pg` subchart `deployment.yaml` renders BOTH the
operator pod's own `image:` AND the `OPERATOR_IMAGE_NAME` env var from the
**same** expression:

```
value: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
```

The operator reads `OPERATOR_IMAGE_NAME` to decide which image to inject as
the bootstrap-controller initContainer. So overriding
`cloudnative-pg.image.repository` + `cloudnative-pg.image.tag` proxies the
operator pod **and** every injected instance-bootstrap initContainer in
lockstep. There is no separate operator-image knob.

## Fix (`platform/cnpg/chart/`)

- `values.yaml`: set `cloudnative-pg.image.repository` to
  `harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg`, `tag` pinned
  explicitly to `1.29.0` (subchart 0.28.0 appVersion; pinned so a subchart
  bump can't silently float the operator + injected initContainer to a
  different tag).
- `values.yaml`: also proxy the `webhookGate` Job kubectl image (was bare
  `bitnamilegacy/kubectl:1.30.7`) to
  `harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7`, matching
  `webhookCertBootstrap.kubectlImage` and the bp-flux/bp-cert-manager
  convention; the gate runs on every install.
- Lockstep version bump `1.0.8 → 1.0.9`: `Chart.yaml` + `blueprint.yaml`
  (indented `spec.version`) + the slot-16 pin
  `clusters/_template/bootstrap-kit/16-cnpg.yaml`.
- Slot-16 has no image-related overrides — left consistent.

## Render proof

`helm lint` clean. Full `helm template` render — every concrete image ref:

```
image: "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7"
image: "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg:1.29.0"
- name: OPERATOR_IMAGE_NAME
  value: "harbor.openova.io/proxy-ghcr/cloudnative-pg/cloudnative-pg:1.29.0"
```

Policy scan (`not harbor.openova.io/proxy-* and not */openova-io/*`) returns
empty — all refs compliant, all with explicit tags. `OPERATOR_IMAGE_NAME`
follows the operator image, confirming the injected initContainer is proxied.

Refs #3236 #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)