### PR TITLE
fix(clustermesh): mesh-reconcile loop must not converge before the cnpg-pair flip lands

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -309,9 +309,29 @@ var (
 //
 // Single-region provs (len(dep.Request.Regions) < 2) skip the whole
 // orchestrator — there is no peer to mesh with.
+//
+// This public wrapper preserves the (statuses, error) contract every
+// call site + test relies on. The reconcile loop calls the internal
+// autoEstablishClusterMesh directly so it can also observe whether the
+// #3236 cnpg-pair flip landed (the missing convergence signal that left
+// hw126 partially flipped — see runAutoEstablishClusterMesh).
 func (h *Handler) AutoEstablishClusterMesh(ctx context.Context, dep *Deployment) ([]ClusterMeshStatus, error) {
+	statuses, _, err := h.autoEstablishClusterMesh(ctx, dep)
+	return statuses, err
+}
+
+// autoEstablishClusterMesh is the worker behind AutoEstablishClusterMesh.
+// It returns the per-region statuses, an error, AND cnpgPairConverged —
+// true when the deployment is fully converged from the cnpg-pair flip's
+// point of view: single-region (no flip applicable), OR multi-region with
+// the mesh fully established AND the slot-16b flip fully landed. It is
+// false when the mesh is fully meshed but the flip refused/failed (e.g.
+// the primary postgres hasn't minted its replica-auth Secrets yet — the
+// exact hw126 state), so the reconcile loop keeps retrying instead of
+// declaring victory on mesh-only readiness.
+func (h *Handler) autoEstablishClusterMesh(ctx context.Context, dep *Deployment) ([]ClusterMeshStatus, bool, error) {
 	if dep == nil {
-		return nil, fmt.Errorf("autoEstablishClusterMesh: dep is nil")
+		return nil, false, fmt.Errorf("autoEstablishClusterMesh: dep is nil")
 	}
 
 	dep.mu.Lock()
@@ -331,7 +351,9 @@ func (h *Handler) AutoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 			"id", dep.ID,
 			"regionCount", len(regions),
 		)
-		return nil, nil
+		// Single-region: no peer mesh, no cnpg-pair flip — vacuously
+		// converged so the loop's single-region branch never blocks.
+		return nil, true, nil
 	}
 
 	slots := h.buildRegionSlots(dep, regions, primaryKubeconfigPath, secondaryPaths)
@@ -340,7 +362,11 @@ func (h *Handler) AutoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 			"id", dep.ID,
 			"reachableRegions", len(slots),
 		)
-		return nil, nil
+		// Multi-region request but <2 reachable regions — the mesh cannot
+		// be established, so this is NOT a converged state; the loop's
+		// len(statuses)>=2 guard also rejects it, but report false so the
+		// flip-convergence signal is never misread as success.
+		return nil, false, nil
 	}
 
 	h.emitClusterMeshProgress(dep, "info",
@@ -667,8 +693,15 @@ func (h *Handler) AutoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 	// partial success, never at bootstrap. Idempotent: re-running
 	// patches the same key to the same value and merely re-requests a
 	// reconcile.
+	// cnpgPairConverged is true only when the mesh is fully established
+	// AND the slot-16b flip lands on every region. When the mesh is meshed
+	// but the flip refuses (e.g. the primary postgres hasn't minted its
+	// replica-auth Secrets yet — the hw126 22:38 state), this stays false
+	// so the reconcile loop keeps retrying instead of stopping on
+	// mesh-only readiness.
+	cnpgPairConverged := false
 	if totalReady == len(statuses) && len(statuses) >= 2 {
-		h.enableCNPGPairAfterFullMesh(ctx, dep, slots)
+		cnpgPairConverged = h.enableCNPGPairAfterFullMesh(ctx, dep, slots)
 	} else {
 		h.log.Info("clustermesh: mesh not fully established — SOVEREIGN_ENABLE_CNPG_PAIR left untouched (slot 16b stays gated OFF)",
 			"id", dep.ID,
@@ -677,7 +710,7 @@ func (h *Handler) AutoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 		)
 	}
 
-	return statuses, nil
+	return statuses, cnpgPairConverged, nil
 }
 
 // enableCNPGPairAfterFullMesh flips the slot-16b gate on EVERY
@@ -726,11 +759,21 @@ func (h *Handler) AutoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 // the flip converges then. A patch failure AFTER the gather phase is
 // per-region (warn + continue): the merge patch is idempotent and the
 // re-run converges the missed region.
-func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployment, slots []regionSlot) {
+//
+// Returns true ONLY when the flip fully landed (every region's
+// bootstrap-kit Kustomization patched ON). Any refusal/failure returns
+// false so the #3241 level-trigger keeps retrying: on hw126 the mesh was
+// fully established at 22:38 but the replica-auth Secrets had not been
+// minted yet, so this function correctly refused — yet the reconcile
+// loop treated "mesh meshed" as converged and STOPPED, leaving the flip
+// permanently unapplied until a manual catalyst-api restart. Threading
+// the outcome out lets runAutoEstablishClusterMesh keep the deployment
+// NOT-converged until the flip lands.
+func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployment, slots []regionSlot) bool {
 	if len(slots) == 0 {
 		h.log.Warn("clustermesh: cnpg-pair gate: no region slots — cannot reach any bootstrap-kit Kustomization",
 			"id", dep.ID)
-		return
+		return false
 	}
 
 	// ── Gather phase (all-or-nothing) ───────────────────────────────
@@ -754,7 +797,7 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 				"id", dep.ID, "region", regionLabel)
 			h.emitClusterMeshProgress(dep, "warn",
 				fmt.Sprintf("ClusterMesh: cnpg-pair enable skipped — region %q kubeconfig path empty; re-run converges", regionLabel))
-			return
+			return false
 		}
 		dyn, err := h.clusterMeshDynamicClient(s.kubeconfigPath)
 		if err != nil {
@@ -762,7 +805,7 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 				"id", dep.ID, "region", regionLabel, "err", err)
 			h.emitClusterMeshProgress(dep, "warn",
 				fmt.Sprintf("ClusterMesh: cnpg-pair enable skipped — region %q dynamic client build failed (%v); re-run converges", regionLabel, err))
-			return
+			return false
 		}
 
 		getCtx, cancelGet := context.WithTimeout(ctx, clusterMeshCallTimeout)
@@ -775,7 +818,7 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 			h.emitClusterMeshProgress(dep, "warn",
 				fmt.Sprintf("ClusterMesh: cnpg-pair enable skipped — region %q Get Kustomization %s/%s failed (%v); re-run converges",
 					regionLabel, fluxSystemNamespace, bootstrapKitKustomizationName, err))
-			return
+			return false
 		}
 
 		substitute, found, err := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
@@ -784,7 +827,7 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 				"id", dep.ID, "region", regionLabel, "found", found, "err", err)
 			h.emitClusterMeshProgress(dep, "warn",
 				fmt.Sprintf("ClusterMesh: cnpg-pair enable refused — region %q bootstrap-kit Kustomization carries no postBuild.substitute map", regionLabel))
-			return
+			return false
 		}
 		primaryRegion := strings.TrimSpace(substitute[clusterMeshPrimaryRegionSubstituteKey])
 		replicaRegion := strings.TrimSpace(substitute[clusterMeshReplicaRegionSubstituteKey])
@@ -798,7 +841,7 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 			h.emitClusterMeshProgress(dep, "warn",
 				fmt.Sprintf("ClusterMesh: cnpg-pair enable REFUSED — region %q SOVEREIGN_PRIMARY_REGION=%q / SOVEREIGN_REPLICA_REGION=%q must be non-empty and distinct in the bootstrap-kit substitute map",
 					regionLabel, primaryRegion, replicaRegion))
-			return
+			return false
 		}
 		targets = append(targets, flipTarget{regionKey: regionLabel, dyn: dyn})
 	}
@@ -817,7 +860,7 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 	// secret it cannot find. The #3241 level-trigger + post-handover
 	// re-runs converge once the primary's Secrets appear.
 	if !h.syncCNPGPairReplicaAuthSecrets(ctx, dep, slots) {
-		return
+		return false
 	}
 
 	// ── Patch phase ─────────────────────────────────────────────────
@@ -843,7 +886,7 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 	if err != nil {
 		h.log.Warn("clustermesh: cnpg-pair gate: marshal merge patch failed",
 			"id", dep.ID, "err", err)
-		return
+		return false
 	}
 	patched := 0
 	for _, t := range targets {
@@ -862,7 +905,7 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 		patched++
 	}
 	if patched == 0 {
-		return
+		return false
 	}
 
 	h.log.Info("clustermesh: SOVEREIGN_ENABLE_CNPG_PAIR=true merged onto bootstrap-kit Kustomizations + Flux reconcile requested (split-side: every region renders its own half of the pair)",
@@ -873,6 +916,13 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 	)
 	h.emitClusterMeshProgress(dep, "info",
 		fmt.Sprintf("ClusterMesh confirmed across all regions — enabled bp-cnpg-pair (slot 16b) via SOVEREIGN_ENABLE_CNPG_PAIR=true on %d/%d region Kustomizations and requested Flux reconcile", patched, len(targets)))
+
+	// Fully landed ONLY when EVERY region's Kustomization patched ON. A
+	// partial patch (some regions failed mid-loop) is a half-flipped
+	// split-side pair — exactly the broken topology the gather phase
+	// guards against — so report NOT-converged and let the level-trigger
+	// re-run finish the remaining regions (the merge patch is idempotent).
+	return patched == len(targets)
 }
 
 // syncCNPGPairReplicaAuthSecrets copies the primary cluster's CNPG

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -1554,15 +1554,26 @@ func TestAutoEstablishClusterMesh_ReplicaCopyFailureRefusesFlip(t *testing.T) {
 	}
 }
 
-// TestAutoEstablishClusterMesh_ReRunAfterSecretsAppearConverges — first
-// run with the source Secret absent refuses the flip; after the primary
-// produces it, a second run (the #3241 level-trigger shape) copies both
-// Secrets and flips both gates. Proves the refusal is recoverable, not
-// terminal, and that the copy is idempotent across runs.
+// TestAutoEstablishClusterMesh_ReRunAfterSecretsAppearConverges — the
+// hw126 22:38 state (#3241/#3236): the mesh is fully established on the
+// FIRST attempt (both LBs present) but the slot-16b flip REFUSES because
+// the primary postgres hasn't minted its replica-auth Secrets yet. The
+// prior loop treated "mesh meshed" as converged and STOPPED, so the flip
+// stayed unapplied until a manual catalyst-api restart.
+//
+// With the flip-convergence signal threaded out of
+// enableCNPGPairAfterFullMesh, the reconcile loop must now treat
+// "meshed but flip refused" as NOT-converged and keep retrying on its own
+// backoff. This test drives the LOOP (runAutoEstablishClusterMesh) ONCE
+// — no fresh kick — and proves it converges across two attempts: attempt
+// 1 meshes + refuses the flip; a goroutine then mints the source Secret
+// (the primary finishing initdb); attempt 2 copies both Secrets and flips
+// both gates; the loop stops with the final success event.
 func TestAutoEstablishClusterMesh_ReRunAfterSecretsAppearConverges(t *testing.T) {
 	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
 	primaryCS := fx.clients[fx.primaryKubeconfigPath]
-	// Run 1: one source Secret missing → flip refused.
+	// Source Secret missing at the start → attempt 1's flip refuses even
+	// though the mesh fully establishes (both LBs present from the start).
 	if err := primaryCS.CoreV1().Secrets(cnpgPairNamespace).Delete(context.Background(), cnpgPairReplicationCert, metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("delete source Secret: %v", err)
 	}
@@ -1571,33 +1582,66 @@ func TestAutoEstablishClusterMesh_ReRunAfterSecretsAppearConverges(t *testing.T)
 	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
 	defer restoreDyn()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	if _, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep); err != nil {
-		t.Fatalf("run 1: AutoEstablishClusterMesh error: %v", err)
-	}
-	assertGateNotFlipped(t, fx.dynClients[fx.primaryKubeconfigPath], "primary (run 1)")
-	assertGateNotFlipped(t, fx.dynClients[fx.secondaryKubeconfigPath], "secondary (run 1)")
+	// Fast retry knobs so the loop's two attempts complete in milliseconds.
+	fx.handler.clusterMeshRetryInitialBackoff = 20 * time.Millisecond
+	fx.handler.clusterMeshRetryMaxBackoff = 60 * time.Millisecond
+	fx.handler.clusterMeshRetryBudget = 20 * time.Second
+	fx.handler.clusterMeshAttemptTimeout = 5 * time.Second
 
-	// The primary postgres finishes initdb → CNPG mints the Secret.
-	if _, err := primaryCS.CoreV1().Secrets(cnpgPairNamespace).Create(context.Background(), &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: cnpgPairReplicationCert, Namespace: cnpgPairNamespace},
-		Type:       corev1.SecretTypeTLS,
-		Data:       map[string][]byte{"tls.crt": []byte("REPL-CERT-2"), "tls.key": []byte("REPL-KEY-2")},
-	}, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("re-create source Secret: %v", err)
+	// Once attempt 1 reports "meshed but the cnpg-pair flip has not landed"
+	// (the new retry shape), the primary postgres finishes initdb → CNPG
+	// mints the Secret. The level-trigger's whole point: a later-appearing
+	// Secret still converges with NO external re-kick.
+	secretDone := make(chan error, 1)
+	go func() {
+		deadline := time.Now().Add(15 * time.Second)
+		for time.Now().Before(deadline) {
+			if hasClusterMeshEvent(fx.dep, "warn", "cnpg-pair flip has not landed", "retrying in") {
+				_, err := primaryCS.CoreV1().Secrets(cnpgPairNamespace).Create(context.Background(), &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: cnpgPairReplicationCert, Namespace: cnpgPairNamespace},
+					Type:       corev1.SecretTypeTLS,
+					Data:       map[string][]byte{"tls.crt": []byte("REPL-CERT-2"), "tls.key": []byte("REPL-KEY-2")},
+				}, metav1.CreateOptions{})
+				secretDone <- err
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		secretDone <- fmt.Errorf("never observed the meshed-but-flip-pending retry event")
+	}()
+
+	loopDone := make(chan struct{})
+	go func() {
+		fx.handler.runAutoEstablishClusterMesh(fx.dep)
+		close(loopDone)
+	}()
+	select {
+	case <-loopDone:
+	case <-time.After(25 * time.Second):
+		t.Fatalf("reconcile loop did not terminate; events:\n%s", dumpClusterMeshEvents(fx.dep))
+	}
+	if err := <-secretDone; err != nil {
+		t.Fatalf("source-Secret mint goroutine: %v", err)
 	}
 
-	// Run 2: now converges — both Secrets copied, both gates flipped.
-	if _, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep); err != nil {
-		t.Fatalf("run 2: AutoEstablishClusterMesh error: %v", err)
+	// Attempt 1 emitted the meshed-but-flip-pending retry event (proves the
+	// loop did NOT stop on mesh-only readiness — the hw126 regression).
+	if !hasClusterMeshEvent(fx.dep, "warn", "cnpg-pair flip has not landed", "retrying in") {
+		t.Errorf("expected a meshed-but-flip-pending retry event; events:\n%s", dumpClusterMeshEvents(fx.dep))
 	}
+	// Final success event — the loop stops cleanly only once the flip lands.
+	if !hasClusterMeshEvent(fx.dep, "info", "fully meshed (2/2 regions)", "cnpg-pair flip landed", "reconcile loop complete") {
+		t.Errorf("expected final success event after flip converged; events:\n%s", dumpClusterMeshEvents(fx.dep))
+	}
+
+	// The convergence happened: both replica-auth Secrets copied + both
+	// gates flipped — within ONE loop invocation, no fresh kick.
 	replicaCS := fx.clients[fx.secondaryKubeconfigPath]
 	for _, name := range cnpgPairReplicaAuthSecrets {
 		if _, ok := getCNPGSecret(t, replicaCS, name); !ok {
-			t.Errorf("run 2: replica still missing Secret %s after source appeared", name)
+			t.Errorf("replica still missing Secret %s after source appeared", name)
 		}
 	}
-	assertGateFlipped(t, fx.dynClients[fx.primaryKubeconfigPath], "primary (run 2)")
-	assertGateFlipped(t, fx.dynClients[fx.secondaryKubeconfigPath], "secondary (run 2)")
+	assertGateFlipped(t, fx.dynClients[fx.primaryKubeconfigPath], "primary")
+	assertGateFlipped(t, fx.dynClients[fx.secondaryKubeconfigPath], "secondary")
 }

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -958,13 +958,24 @@ func (h *Handler) runAutoEstablishClusterMesh(dep *Deployment) {
 	backoff := initialBackoff
 	for attempt := 1; ; attempt++ {
 		attemptCtx, cancelAttempt := context.WithTimeout(ctx, attemptTimeout)
-		statuses, err := h.AutoEstablishClusterMesh(attemptCtx, dep)
+		statuses, cnpgPairConverged, err := h.autoEstablishClusterMesh(attemptCtx, dep)
 		cancelAttempt()
 
 		fullyMeshed := countFullyMeshedRegions(statuses)
-		if err == nil && len(statuses) >= 2 && fullyMeshed == len(statuses) {
+		meshConverged := len(statuses) >= 2 && fullyMeshed == len(statuses)
+		// Convergence for a multi-region deployment requires BOTH the mesh
+		// fully established AND the #3236 cnpg-pair flip landed. hw126 at
+		// 22:38 was mesh-fully-established (2/2) yet the flip correctly
+		// REFUSED because the primary's replica-auth Secrets weren't minted
+		// for another 10 minutes — the prior `fullyMeshed == regions` exit
+		// declared victory anyway and STOPPED, so nothing ever re-ran the
+		// copy+flip and a manual catalyst-api restart was needed. Treating
+		// "meshed but flip not landed" as NOT-converged keeps the loop
+		// retrying on the existing backoff until the flip lands (or the
+		// budget exhausts).
+		if err == nil && meshConverged && cnpgPairConverged {
 			h.emitClusterMeshProgress(dep, "info",
-				fmt.Sprintf("ClusterMesh reconcile: fully meshed (%d/%d regions) on attempt %d — reconcile loop complete", fullyMeshed, len(statuses), attempt))
+				fmt.Sprintf("ClusterMesh reconcile: fully meshed (%d/%d regions) + cnpg-pair flip landed on attempt %d — reconcile loop complete", fullyMeshed, len(statuses), attempt))
 			h.log.Info("clustermesh: reconcile loop converged",
 				"id", dep.ID,
 				"attempt", attempt,
@@ -1002,15 +1013,23 @@ func (h *Handler) runAutoEstablishClusterMesh(dep *Deployment) {
 			// operator-facing X/Y stays meaningful.
 			total = regionCount
 		}
+		// Distinguish the two not-yet-converged shapes so the operator
+		// watches the right thing: a partial mesh vs a fully-meshed
+		// cluster still waiting on the cnpg-pair flip (the hw126 state).
+		progress := fmt.Sprintf("%d/%d regions fully meshed", fullyMeshed, total)
+		if meshConverged && !cnpgPairConverged {
+			progress = fmt.Sprintf("%d/%d regions fully meshed but the cnpg-pair flip has not landed (primary replica-auth Secrets likely still pending)", fullyMeshed, total)
+		}
 		h.emitClusterMeshProgress(dep, "warn",
-			fmt.Sprintf("ClusterMesh reconcile: attempt %d ended with %d/%d regions fully meshed — retrying in %s", attempt, fullyMeshed, total, backoff))
+			fmt.Sprintf("ClusterMesh reconcile: attempt %d ended with %s — retrying in %s", attempt, progress, backoff))
 		if sleepErr := sleepCtx(ctx, backoff); sleepErr != nil {
 			h.emitClusterMeshProgress(dep, "warn",
-				fmt.Sprintf("ClusterMesh reconcile: retry budget exhausted after %d attempt(s) with %d/%d regions fully meshed — next trigger is a catalyst-api restart or the post-handover finalisation", attempt, fullyMeshed, total))
+				fmt.Sprintf("ClusterMesh reconcile: retry budget exhausted after %d attempt(s) with %s — next trigger is a catalyst-api restart or the post-handover finalisation", attempt, progress))
 			h.log.Warn("clustermesh: reconcile loop retry budget exhausted",
 				"id", dep.ID,
 				"attempts", attempt,
 				"fullyMeshed", fullyMeshed,
+				"cnpgPairConverged", cnpgPairConverged,
 				"err", sleepErr,
 			)
 			return


### PR DESCRIPTION
## What

On hw126 at 22:38 the startup reconcile ran, the mesh fully established (2/2), but the slot-16b cnpg-pair flip correctly **refused** — the primary postgres had not yet minted its replica-auth Secrets (they appeared ~10 minutes later). The loop logged `reconcile loop converged, attempt:1` and **stopped**, because its exit condition was `fullyMeshed == regions` only. Nothing ever retried the copy+flip; a manual catalyst-api restart was needed.

## Change

- `enableCNPGPairAfterFullMesh` now returns `bool` — `true` only when every region's bootstrap-kit Kustomization patched ON; any refusal/failure returns `false`.
- `AutoEstablishClusterMesh` keeps its public `([]ClusterMeshStatus, error)` contract via a thin wrapper over a new internal `autoEstablishClusterMesh` that also returns `cnpgPairConverged`.
- `runAutoEstablishClusterMesh` (the #3241 level-trigger loop) now treats **"mesh fully established BUT cnpg flip refused/failed"** as NOT-converged for multi-region deployments, and keeps retrying on the existing backoff/budget until the flip lands (or the budget exhausts). Single-region (no flip applicable) converges as today.
- The retry-progress event distinguishes a partial mesh from a fully-meshed cluster still waiting on the flip, so the operator watches the right thing.

## Test

`TestAutoEstablishClusterMesh_ReRunAfterSecretsAppearConverges` now drives the **loop** (`runAutoEstablishClusterMesh`) once and converges **within one loop invocation across two attempts** with no fresh kick: attempt 1 meshes + refuses the flip; a goroutine mints the source Secret once the meshed-but-flip-pending retry event appears; attempt 2 copies both Secrets and flips both gates; the loop stops with the final success event.

`go build`/`go vet`/`go test ./internal/handler/` all green.

Refs #3241 #3236 #2737