### PR TITLE
fix(cnpg-pair): NetworkPolicy must admit the CNPG operator status probe

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -182,7 +182,13 @@ spec:
       # applies on BOTH control planes (suspend removed) and each
       # cluster renders only its own half of the pair. See the slot
       # header + the chart changelog for the full design note.
-      version: 0.2.0
+      # 0.2.1 (Refs #3236 / #3195 / #2737) — both per-side ingress
+      # NetworkPolicies now allow the CNPG operator (cnpg-system) to the
+      # instance status (8000) + metrics (9187) ports. Without it the
+      # Ingress-only policies default-denied the operator's status probe
+      # and the Cluster phase stalled at "Instance Status Extraction
+      # Error" on hw126 despite the instance being 1/1 Running.
+      version: 0.2.1
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.2.0
+  version: 0.2.1
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-cnpg-pair
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.2.1
+appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair
   across two Sovereign regions. Companions the existing `bp-cnpg`
@@ -40,6 +40,25 @@ description: |
 
   Changelog
   ─────────
+  0.2.1 (2026-06-11, operator status-probe carve-out, Refs #3236 / #3195 / #2737)
+    - FIX: the per-side ingress NetworkPolicies (allow-replication-to-
+      primary on side=primary, allow-probe-to-replica on side=replica)
+      each select their cluster's CNPG instance Pods and declare
+      `policyTypes: [Ingress]` — which default-denies ALL other ingress
+      to those Pods, including the CNPG operator's status probe. On hw126
+      the primary instance was 1/1 Running yet the Cluster phase stalled
+      at "Instance Status Extraction Error" because the operator (in
+      cnpg-system) could not reach the instance status web server.
+      Both ingress policies now also allow namespaceSelector
+      kubernetes.io/metadata.name=<operatorNamespace> (default
+      cnpg-system) to the instance status port (default 8000) and the
+      Prometheus metrics port (default 9187). The replication 5432 rules
+      are untouched. New values knobs: networkPolicy.operatorNamespace /
+      operatorStatusPort / operatorMetricsPort.
+    - Default-OFF contract UNCHANGED: cnpgPair.enabled=false renders ZERO
+      resources on BOTH sides. Resource COUNTS are unchanged (rules added
+      to existing policies, no new objects).
+
   0.2.0 (2026-06-11, split-side topology, Refs #3236 / #3195 / #2737)
     - TOPOLOGY-DESIGN CHANGE: new `cnpgPair.side: primary|replica`
       knob (default `primary`; `secondary` accepted as an alias for

--- a/platform/cnpg-pair/chart/templates/networkpolicy.yaml
+++ b/platform/cnpg-pair/chart/templates/networkpolicy.yaml
@@ -9,6 +9,17 @@ the minimum required paths:
      cluster's `-r` Service on 5432 (cross-cluster via ClusterMesh).
   2. Probe: the failover-readiness probe Pod MAY reach the replica
      cluster's `-r` Service on 5432 (intra-cluster, in replica region).
+  3. Operator status: the CNPG operator (cloudnative-pg, in
+     `cnpgPair.networkPolicy.operatorNamespace` = cnpg-system) MAY reach
+     EACH instance Pod's status web server (operatorStatusPort = 8000)
+     and metrics exporter (operatorMetricsPort = 9187). A k8s
+     NetworkPolicy selecting the instance Pods default-denies all OTHER
+     ingress to them — including the operator's status probe — so without
+     this carve-out the Cluster phase stalls at "Instance Status
+     Extraction Error" (the hw126 symptom: primary 1/1 Running yet phase
+     = extraction error). Both the primary-side and the replica-side
+     ingress policies need it because each side selects its own instance
+     CR Pods.
 
 Everything else stays denied — no Egress to the public Internet, no
 Ingress except from the explicit selectors below.
@@ -51,6 +62,18 @@ spec:
       ports:
         - port: 5432
           protocol: TCP
+    # CNPG operator status + metrics probe — without this the operator
+    # cannot extract the primary instance's status and the Cluster phase
+    # stalls at "Instance Status Extraction Error".
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.cnpgPair.networkPolicy.operatorNamespace }}
+      ports:
+        - port: {{ .Values.cnpgPair.networkPolicy.operatorStatusPort }}
+          protocol: TCP
+        - port: {{ .Values.cnpgPair.networkPolicy.operatorMetricsPort }}
+          protocol: TCP
 {{- end }}
 {{- if (include "cnpg-pair.isReplicaSide" .) }}
 ---
@@ -77,6 +100,19 @@ spec:
               catalyst.openova.io/cnpg-pair: {{ include "cnpg-pair.fullname" . | quote }}
       ports:
         - port: 5432
+          protocol: TCP
+    # CNPG operator status + metrics probe — the replica side selects its
+    # own instance CR Pods, so it needs the same operator carve-out as the
+    # primary or the replica Cluster phase stalls at "Instance Status
+    # Extraction Error" too.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.cnpgPair.networkPolicy.operatorNamespace }}
+      ports:
+        - port: {{ .Values.cnpgPair.networkPolicy.operatorStatusPort }}
+          protocol: TCP
+        - port: {{ .Values.cnpgPair.networkPolicy.operatorMetricsPort }}
           protocol: TCP
 ---
 # Egress carve-out for the probe Pod — must resolve DNS and reach

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -171,6 +171,22 @@ if grep -qE '^\s*synchronous_standby_names:\s' "$TMP/primary.yaml"; then
   echo "FAIL: primary Cluster CR sets synchronous_standby_names as a raw parameter — CNPG rejects this fixed parameter at admission." >&2
   exit 1
 fi
+# 0.2.1 (#3236): the Ingress-only allow-replication-to-primary policy must
+# also admit the CNPG operator (cnpg-system) to the instance status (8000)
+# + metrics (9187) ports, or the operator's status probe is default-denied
+# and the Cluster phase stalls at "Instance Status Extraction Error" (hw126).
+grep -q 'kubernetes.io/metadata.name: cnpg-system' "$TMP/primary.yaml" || {
+  echo "FAIL: primary-side NetworkPolicy missing the cnpg-system operator carve-out — operator status probe will be default-denied." >&2
+  exit 1
+}
+grep -qE '^\s+- port: 8000' "$TMP/primary.yaml" || {
+  echo "FAIL: primary-side NetworkPolicy missing the operator status port (8000)." >&2
+  exit 1
+}
+grep -qE '^\s+- port: 9187' "$TMP/primary.yaml" || {
+  echo "FAIL: primary-side NetworkPolicy missing the operator metrics port (9187)." >&2
+  exit 1
+}
 echo "  PASS (3 non-test + 4 test resources)"
 
 # ── Case 3: side=replica enabled render ──────────────────────────
@@ -248,6 +264,22 @@ if grep -q 'hot_standby:' "$TMP/replica.yaml"; then
   echo "FAIL: hot_standby parameter present in side=replica manifest — PG16 fixed-param, CNPG rejects." >&2
   exit 1
 fi
+# 0.2.1 (#3236): the replica side selects its own instance CR Pods in its
+# Ingress-only allow-probe-to-replica policy, so it needs the same operator
+# (cnpg-system) status (8000) + metrics (9187) carve-out or the replica
+# Cluster phase stalls at "Instance Status Extraction Error" too.
+grep -q 'kubernetes.io/metadata.name: cnpg-system' "$TMP/replica.yaml" || {
+  echo "FAIL: replica-side NetworkPolicy missing the cnpg-system operator carve-out — operator status probe will be default-denied." >&2
+  exit 1
+}
+grep -qE '^\s+- port: 8000' "$TMP/replica.yaml" || {
+  echo "FAIL: replica-side NetworkPolicy missing the operator status port (8000)." >&2
+  exit 1
+}
+grep -qE '^\s+- port: 9187' "$TMP/replica.yaml" || {
+  echo "FAIL: replica-side NetworkPolicy missing the operator metrics port (9187)." >&2
+  exit 1
+}
 echo "  PASS (5 non-test resources)"
 
 # ── Case 4: side normalization + invalid side fail-fast ──────────

--- a/platform/cnpg-pair/chart/values.yaml
+++ b/platform/cnpg-pair/chart/values.yaml
@@ -219,6 +219,24 @@ cnpgPair:
   # NetworkPolicy stack.
   networkPolicy:
     enabled: true
+    # The CNPG operator (cloudnative-pg) runs in this namespace and
+    # polls EACH instance Pod's status web server to extract instance
+    # status. A k8s NetworkPolicy selecting the instance Pods
+    # default-denies all other ingress to them, so without an explicit
+    # carve-out the operator's status probe is blocked and the Cluster
+    # phase stalls at "Instance Status Extraction Error" (caught live on
+    # hw126: primary 1/1 Running, phase = extraction error). These knobs
+    # open the operator → instance status/metrics paths.
+    operatorNamespace: cnpg-system
+    # Instance manager status web server — the port the operator polls
+    # for instance status/health (cloudnative-pg 1.29.0). NOT the
+    # postgres 5432 port and NOT the metrics port.
+    operatorStatusPort: 8000
+    # Prometheus metrics exporter on each instance Pod. Opened from the
+    # operator namespace too so a PodMonitor/serviceMonitor scraping from
+    # cnpg-system (or the operator's own metrics collection) is not
+    # default-denied once the gate flips ON.
+    operatorMetricsPort: 9187
 
   # ── Continuum DR contract seed (#3195, Refs #3189) ────────────────
   # When `continuum.enabled: true` AND `cnpgPair.enabled: true`, the


### PR DESCRIPTION
## What

On hw126 the primary CNPG instance was **1/1 Running** but the Cluster phase stalled at **"Instance Status Extraction Error"**. Root cause: the per-side ingress NetworkPolicies each select their cluster's CNPG instance Pods and declare `policyTypes: [Ingress]`. As a k8s NetworkPolicy that default-denies **all other ingress** to the selected Pods — including the CNPG operator's status probe. The operator runs in `cnpg-system` and polls each instance Pod's status web server (port 8000 on cloudnative-pg 1.29.0) to extract instance status; that traffic was silently dropped.

## Change

`platform/cnpg-pair/chart/templates/networkpolicy.yaml` — both ingress policies now carry an additional `from` rule:

- **primary side** (`allow-replication-to-primary`)
- **replica side** (`allow-probe-to-replica`)

each allowing `namespaceSelector kubernetes.io/metadata.name=<operatorNamespace>` (default `cnpg-system`) to:
- the instance **status port** (default **8000**) — the port the operator polls for instance status, and
- the Prometheus **metrics port** (default **9187**) — so a PodMonitor/serviceMonitor scraping from the operator namespace is not default-denied once the gate flips ON.

The replication **5432** rules are untouched. New values knobs: `networkPolicy.operatorNamespace` / `operatorStatusPort` / `operatorMetricsPort`.

## Status port grounding

cloudnative-pg **1.29.0** (chart `cnpg/cloudnative-pg` 0.28.0, pinned in `platform/cnpg/chart/Chart.yaml`). The instance manager serves the operator's status/management endpoint on **8000** and the Prometheus exporter on **9187**; the operator namespace is `cnpg-system` (confirmed across `platform/cnpg/chart/templates/*`). The "Instance Status Extraction Error" phase is exactly the operator failing to reach the instance status server on 8000.

## Verify

- Both sides rendered; the `port: 8000` + `port: 9187` + `cnpg-system` carve-out present on each.
- Render gate (`chart/tests/cnpg-pair-render.sh`) extended to assert the carve-out on both sides — all 11 cases green.
- `helm lint` clean.

## Lockstep

`0.2.0 → 0.2.1`: `Chart.yaml` (version + appVersion + changelog), `blueprint.yaml` indented `spec.version`, slot `16b-bp-cnpg-pair.yaml` HR pin.

Refs #3236 #3195 #2737