### PR TITLE
fix(keycloak): pin frontend URL to public auth.<fqdn> — OIDC discovery emits the public authorize endpoint

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -140,7 +140,13 @@ spec:
       # required actions — UPDATE_PASSWORD.defaultAction false +
       # catalyst-pin IdP updateProfileFirstLoginMode off. Live-proven on
       # hw124 (fresh federation -> requiredActions=[]). Refs #3150.
-      version: 1.4.21
+      # 1.4.22 (#3263 #3150 #2737, 2026-06-11): pin KC frontend URL to the
+      # public https://auth.${SOVEREIGN_FQDN} (KC_HOSTNAME +
+      # KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true) so the OIDC discovery doc emits
+      # the PUBLIC authorize endpoint — gitea (and every autodiscovery
+      # consumer) no longer 307s the browser to the in-cluster
+      # keycloak.keycloak.svc.cluster.local issuer (hw126 UAT FAIL).
+      version: 1.4.22
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.21
+  version: 1.4.22
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -200,7 +200,17 @@ name: bp-keycloak
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.4.21
+# 1.4.22 (#3263 #3150 #2737, 2026-06-11): pin KC frontend URL to the public
+# https://auth.<fqdn> via KC_HOSTNAME (+ KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true
+# so token/userinfo stay request-Host). KC was hostname-DYNAMIC, so an
+# in-cluster OIDC discovery fetch (gitea's openidConnect provider, hw126
+# UAT 2026-06-11) persisted http://keycloak.keycloak.svc.cluster.local/... as
+# the BROWSER authorize target → unresolvable (chrome-error). Now the
+# discovery doc emits the PUBLIC authorize endpoint + issuer regardless of
+# fetch host → fixes EVERY autodiscovery consumer at the owning layer.
+# New templates/keycloak-frontend-env.yaml ConfigMap wired via
+# keycloak.extraEnvVarsCM.
+version: 1.4.22
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/keycloak-frontend-env.yaml
+++ b/platform/keycloak/chart/templates/keycloak-frontend-env.yaml
@@ -1,0 +1,77 @@
+{{- /*
+Keycloak frontend-URL pin — bp-keycloak (#3263 #3150 #2737).
+
+WHY THIS EXISTS
+  Keycloak runs hostname-DYNAMIC on Sovereigns by default: with no
+  KC_HOSTNAME / frontendUrl, KC reflects the request Host header into
+  EVERY endpoint URL it emits — including the `authorization_endpoint`
+  and `issuer` in the `.well-known/openid-configuration` discovery doc.
+
+  That breaks every OIDC client that drives the browser-facing redirect
+  from the discovery doc. Concretely (operator UAT hw126, 2026-06-11):
+  gitea's `openidConnect` provider 307s the browser STRICTLY to the
+  `authorization_endpoint` in the discovery doc fetched at its persisted
+  --auto-discover-url. gitea (an in-cluster Pod) can only reliably reach
+  KC over the in-cluster Service `keycloak.keycloak.svc.cluster.local`
+  (the public `auth.<fqdn>` is not browser-reachable from inside the
+  cluster — split-horizon DNS / no LB hairpin), so the discovery doc it
+  fetches carries `authorization_endpoint:
+  http://keycloak.keycloak.svc.cluster.local/...` — which the operator's
+  BROWSER cannot resolve (chrome-error). bp-gitea 1.2.24 (#3194) tried a
+  public-first / in-cluster-fallback discovery fetch, but the public
+  fetch fails from inside the Pod for exactly the same reason, so it
+  falls back to and PERSISTS the internal URL every reconcile.
+
+THE FIX (owning layer = Keycloak)
+  Pin the FRONTEND base URL to the public `https://auth.<fqdn>` via
+  KC_HOSTNAME (Keycloak 26 hostname v2). With this set, the
+  browser-facing endpoints (authorize + the discovery doc's `issuer`)
+  are ALWAYS the public URL, regardless of which Host the discovery doc
+  was fetched over — so an in-cluster discovery fetch now yields the
+  PUBLIC authorize endpoint. This fixes EVERY autodiscovery consumer
+  (gitea, harbor, grafana, openbao, guacamole, …) in one place.
+
+  KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true keeps the BACKCHANNEL endpoints
+  (token / userinfo / jwks / introspection) request-Host-relative, so
+  in-cluster clients keep talking to KC over the internal Service with
+  no hairpin — backchannel stays internal-efficient. This is the exact
+  split the SSO rule requires: browser-facing → public, backchannel →
+  internal.
+
+  These two go via `keycloak.extraEnvVarsCM` (this ConfigMap). The
+  bitnami subchart renders extraEnvVars/extraEnvVarsCM as the container's
+  trailing `env:` / `envFrom:` entries, which take precedence over its
+  base env-vars ConfigMap (the base never sets KC_HOSTNAME when
+  ingress.enabled is false — verified), so these win cleanly. Rendered
+  only when `gateway.host` is set (the same per-Sovereign value that
+  drives the HTTPRoute) — non-Catalyst installs with no gateway.host keep
+  KC hostname-dynamic exactly as before.
+*/ -}}
+{{- /*
+This ConfigMap is ALWAYS rendered so the subchart's
+`keycloak.extraEnvVarsCM` reference (set in values.yaml) is always valid —
+a dangling configMapRef wedges the Pod with CreateContainerConfigError.
+When `gateway.host` is unset (non-Catalyst install) the ConfigMap is empty,
+so KC stays hostname-dynamic exactly as before; nothing is injected.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-kc-frontend-env
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-keycloak
+    catalyst.openova.io/component: keycloak-frontend-env
+{{- if and .Values.gateway .Values.gateway.host }}
+data:
+  # Public, browser-facing frontend base URL (authorize endpoint + issuer).
+  # `https://` because Cilium Gateway terminates TLS in front of KC and
+  # forwards X-Forwarded-Proto (keycloak.proxyHeaders: xforwarded).
+  KC_HOSTNAME: {{ printf "https://%s" .Values.gateway.host | quote }}
+  # Backchannel (token/userinfo/jwks/introspection) stays request-Host
+  # relative so in-cluster clients reach KC over the internal Service
+  # with no public-host hairpin.
+  KC_HOSTNAME_BACKCHANNEL_DYNAMIC: "true"
+{{- else }}
+data: {}
+{{- end }}

--- a/platform/keycloak/chart/tests/frontend-url-pin.sh
+++ b/platform/keycloak/chart/tests/frontend-url-pin.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# bp-keycloak — frontend-URL pin render audit (#3263 #3150 #2737).
+#
+# Guards the regression caught live on hw126 (operator UAT 2026-06-11):
+# gitea's OIDC client 307'd the browser to the in-cluster issuer
+# `http://keycloak.keycloak.svc.cluster.local/...` (unresolvable →
+# chrome-error) because KC ran hostname-DYNAMIC and an in-cluster OIDC
+# discovery fetch persisted INTERNAL endpoint URLs as the browser-redirect
+# target.
+#
+# The fix pins KC's FRONTEND base URL to the public https://auth.<fqdn> via
+# KC_HOSTNAME (+ KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true so backchannel stays
+# request-Host). The discovery doc then emits the PUBLIC authorize endpoint
+# + issuer regardless of which Host the doc was fetched over, which fixes
+# EVERY autodiscovery consumer (gitea, harbor, grafana, openbao, guacamole).
+#
+# Cases:
+#   1. gateway.host set → ConfigMap carries the PUBLIC https KC_HOSTNAME
+#   2. gateway.host set → KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true present
+#   3. gateway.host set → KC_HOSTNAME is NEVER the in-cluster svc DNS
+#   4. subchart StatefulSet wires the CM via envFrom configMapRef
+#   5. default-off path (no gateway.host) → ConfigMap renders EMPTY
+#      (KC stays hostname-dynamic for non-Catalyst standalone installs;
+#      the env ref is still valid so the Pod never CreateContainerConfigErrors)
+
+set -euo pipefail
+
+chart_dir="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+helm="${HELM_BIN:-helm}"
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+host="auth.smoke.omani.works"
+cm_name="keycloak-kc-frontend-env"
+
+# ── Render with gateway.host set (the per-Sovereign Catalyst path) ─────
+out=$("$helm" template keycloak "$chart_dir" \
+        --namespace keycloak \
+        --set gateway.host="$host" \
+        --set sovereignFQDN=smoke.omani.works 2>&1)
+
+cm_block=$(echo "$out" | awk -v n="$cm_name" '
+  /^---$/{inblock=0}
+  $0 ~ ("name: "n"$"){inblock=1}
+  inblock{print}
+')
+
+# ── Case 1: PUBLIC https KC_HOSTNAME present ──────────────────────────
+echo "[bp-keycloak] Case 1: ConfigMap carries the public https KC_HOSTNAME"
+if ! echo "$cm_block" | grep -q "KC_HOSTNAME: \"https://${host}\""; then
+  echo "FAIL: ${cm_name} did not carry KC_HOSTNAME=https://${host}"
+  echo "(without the public frontend pin, gitea 307s the browser to the"
+  echo " in-cluster keycloak.keycloak.svc.cluster.local issuer — hw126 FAIL)"
+  echo "$cm_block"
+  exit 1
+fi
+echo "[bp-keycloak] Case 1: PASS"
+
+# ── Case 2: backchannel stays request-Host dynamic ────────────────────
+echo "[bp-keycloak] Case 2: KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true present"
+if ! echo "$cm_block" | grep -q 'KC_HOSTNAME_BACKCHANNEL_DYNAMIC: "true"'; then
+  echo "FAIL: backchannel-dynamic not set true — token/userinfo would be"
+  echo "forced through the public host (no in-cluster hairpin support)"
+  echo "$cm_block"
+  exit 1
+fi
+echo "[bp-keycloak] Case 2: PASS"
+
+# ── Case 3: KC_HOSTNAME is never the in-cluster service DNS ───────────
+echo "[bp-keycloak] Case 3: KC_HOSTNAME never points at the in-cluster service"
+if echo "$cm_block" | grep -q "keycloak.keycloak.svc.cluster.local"; then
+  echo "FAIL: frontend KC_HOSTNAME leaked the in-cluster svc DNS — this is"
+  echo "the exact hw126 chrome-error symptom the pin exists to prevent"
+  echo "$cm_block"
+  exit 1
+fi
+echo "[bp-keycloak] Case 3: PASS"
+
+# ── Case 4: subchart STS wires the CM via envFrom ─────────────────────
+echo "[bp-keycloak] Case 4: keycloak StatefulSet envFrom references the CM"
+sts_block=$(echo "$out" | awk '
+  /^---$/{inblock=0}
+  /^kind: StatefulSet$/{inblock=1}
+  inblock{print}
+')
+if ! echo "$sts_block" | grep -q "name: ${cm_name}"; then
+  echo "FAIL: keycloak StatefulSet does not reference ${cm_name} (extraEnvVarsCM"
+  echo "not wired) — the frontend pin would never reach the KC container"
+  exit 1
+fi
+echo "[bp-keycloak] Case 4: PASS"
+
+# ── Case 5: default-off path renders an EMPTY ConfigMap ───────────────
+echo "[bp-keycloak] Case 5: no gateway.host → ConfigMap renders empty (dynamic)"
+out_default=$("$helm" template keycloak "$chart_dir" --namespace keycloak 2>&1)
+cm_default=$(echo "$out_default" | awk -v n="$cm_name" '
+  /^---$/{inblock=0}
+  $0 ~ ("name: "n"$"){inblock=1}
+  inblock{print}
+')
+if [ -z "$cm_default" ]; then
+  echo "FAIL: ${cm_name} must ALWAYS render (the subchart envFrom ref is"
+  echo "unconditional — a dangling configMapRef wedges the Pod with"
+  echo "CreateContainerConfigError)"
+  exit 1
+fi
+if echo "$cm_default" | grep -q "KC_HOSTNAME"; then
+  echo "FAIL: KC_HOSTNAME set with no gateway.host — must stay hostname-dynamic"
+  echo "for non-Catalyst standalone installs"
+  echo "$cm_default"
+  exit 1
+fi
+echo "[bp-keycloak] Case 5: PASS"
+
+echo "[bp-keycloak] All frontend-URL pin render cases PASS"

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -257,6 +257,22 @@ keycloak:
   # require `proxyHeaders` to be set so chart-level production-mode validation
   # passes without forcing in-pod TLS.
   proxyHeaders: "xforwarded"
+  # ─── Frontend-URL pin (#3263 #3150 #2737) ──────────────────────────────────
+  # Point the bitnami subchart at the parent-chart ConfigMap
+  # `templates/keycloak-frontend-env.yaml`, which injects:
+  #   KC_HOSTNAME=https://auth.<fqdn>          (frontend/browser-facing base)
+  #   KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true     (token/userinfo stay request-Host)
+  # so the `.well-known/openid-configuration` discovery doc emits the PUBLIC
+  # `authorization_endpoint` + `issuer` regardless of which Host the doc was
+  # fetched over. Without this, KC is hostname-DYNAMIC and an in-cluster
+  # discovery fetch (e.g. gitea's openidConnect provider) persists
+  # `http://keycloak.keycloak.svc.cluster.local/...` as the browser-redirect
+  # target → unresolvable from the operator's browser (chrome-error). Fixing
+  # it here fixes EVERY autodiscovery consumer (gitea, harbor, grafana,
+  # openbao, guacamole, …) in one place. The CM is rendered only when
+  # `gateway.host` is set; the subchart tpl-evaluates this name in its own
+  # context (.Release.Name = keycloak → `keycloak-kc-frontend-env`).
+  extraEnvVarsCM: '{{ .Release.Name }}-kc-frontend-env'
   # ─── Bitnami image-registry consolidation (issue #191) ──────────────────
   # Bitnami consolidated their tag scheme around 2025-09 (see
   # https://github.com/bitnami/charts/issues/30852). The original


### PR DESCRIPTION
## Symptom (founder walk, live hw126 — UAT.md §0c-ter, 2026-06-11)

Clicking **Open Gitea** in the console sent the BROWSER to the cluster-internal issuer:

```
http://keycloak.keycloak.svc.cluster.local/realms/sovereign/protocol/openid-connect/auth?client_id=gitea&redirect_uri=https%3A%2F%2Fgitea.hw126.omantel.biz%2F...
```

`keycloak.keycloak.svc.cluster.local` is unresolvable from a browser → `chrome-error`. It must be the public `https://auth.hw126.omantel.biz/realms/sovereign/...`.

## Owning layer: Keycloak (not gitea)

Keycloak ran **hostname-DYNAMIC** — no `KC_HOSTNAME` / frontendUrl, ever (verified across the chart's git history). So KC reflected the request `Host` into **every** endpoint URL it emits, including the `authorization_endpoint` + `issuer` in the `.well-known/openid-configuration` discovery doc.

gitea's `openidConnect` provider builds the browser-facing 307 **strictly** from that discovery doc, and (as an in-cluster Pod) can only reliably fetch KC over the internal Service `keycloak.keycloak.svc.cluster.local` — so it persisted the **internal** authorize endpoint as the browser-redirect target. `bp-gitea` 1.2.24 (#3194) tried a public-first / in-cluster-fallback discovery fetch, but the public fetch fails from inside the Pod for the same reason (split-horizon DNS / no LB hairpin), so it kept falling back to and persisting the internal URL on every reconcile. This is the **same** latent defect for every autodiscovery consumer (harbor, grafana, openbao, guacamole, …), not just gitea.

## Fix

Pin the **frontend** base URL to the public `https://auth.<fqdn>` via `KC_HOSTNAME` (Keycloak 26 hostname v2), with `KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true` so the **backchannel** endpoints (token / userinfo / jwks / introspection) stay request-Host relative — in-cluster clients keep talking to KC over the internal Service with no hairpin. This is the exact split the SSO rule requires: browser-facing → public, backchannel → internal.

Now the discovery doc emits the **public** authorize endpoint + issuer regardless of which Host fetched it, so an in-cluster discovery fetch yields the public authorize URL. gitea (and every consumer) converges with **no app-side change**.

### Wiring
- New `templates/keycloak-frontend-env.yaml` renders a ConfigMap from `.Values.gateway.host` (the same per-Sovereign value that drives the HTTPRoute).
- The bitnami subchart consumes it via `keycloak.extraEnvVarsCM`; the subchart's inline env/`envFrom` wins over its base env-vars ConfigMap (which never sets `KC_HOSTNAME` when `ingress.enabled: false`).
- The CM **always** renders (the `envFrom` ref is unconditional — a dangling `configMapRef` wedges the Pod with `CreateContainerConfigError`) but stays **empty** when `gateway.host` is unset, so non-Catalyst standalone installs keep KC hostname-dynamic exactly as before.

## Render proof (`gateway.host=auth.hw126.omantel.biz`)

```
# ConfigMap keycloak-kc-frontend-env
KC_HOSTNAME: "https://auth.hw126.omantel.biz"
KC_HOSTNAME_BACKCHANNEL_DYNAMIC: "true"

# keycloak StatefulSet env
envFrom:
  - configMapRef: { name: keycloak-env-vars }
  - configMapRef: { name: keycloak-kc-frontend-env }   # ← wins for KC_HOSTNAME
```

Default-off path (`helm template` with no `gateway.host`) renders `data: {}` → KC stays hostname-dynamic, no dangling ref.

## Version lockstep (3-way)
`Chart.yaml` == `blueprint.yaml` `spec.version` == bootstrap-kit slot-09 pin = **1.4.22**.

## Tests
- New `tests/frontend-url-pin.sh` (5 cases): public https `KC_HOSTNAME`, backchannel-dynamic true, never the in-cluster svc DNS, subchart `envFrom` wired, empty-CM default-off.
- `helm lint` clean (both gateway and bare modes).
- All **11** bp-keycloak chart tests pass.

## Verification still owed
This is a chart change — convergence proof = a fresh 2-region prov where the operator clicks **Open Gitea** and lands authenticated (browser hits `https://auth.<fqdn>/...`, no `chrome-error`). Not merged; CI captured below.

Refs #3263 #3150 #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)