### PR TITLE
fix(catalyst-api): publish newapi + pdns-admin A records into the parent zone

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records.go
@@ -24,8 +24,8 @@
 //
 // What this writes:
 //   For every CanonicalSovereignSubdomain (console / auth / gitea /
-//   harbor / bao / grafana / hubble / pdns / openova-flow / marketplace
-//   / api / registry / guacamole) an A record
+//   harbor / bao / grafana / hubble / pdns / pdns-admin / openova-flow /
+//   marketplace / api / registry / guacamole / newapi / sandbox) an A record
 //     <sub>.<sovereign-fqdn>. → <primary-lb-ipv4>
 //   in the parent zone. PATCH REPLACE — idempotent re-runs are safe.
 
@@ -64,6 +64,25 @@ var CanonicalSovereignSubdomains = []string{
 	"marketplace",
 	"api",
 	"guacamole",
+	// newapi — public URL for the multi-tenant LLM marketplace gateway
+	// (bp-newapi, bootstrap-kit slot 80). The chart renders an HTTPRoute
+	// at newapi.<sov-fqdn> (platform/newapi/chart/templates/httproute.yaml,
+	// host newapi.${SOVEREIGN_FQDN} per clusters/_template/bootstrap-kit/
+	// 80-newapi.yaml) and Sandbox runtimes hit it via the controller-minted
+	// NEWAPI_BASE_URL=https://newapi.<sov-fqdn>/v1. Without this entry the
+	// parent zone returns NXDOMAIN — every Sandbox LLM call + the operator's
+	// newapi.<fqdn> browser walk fail even though the Gateway listener +
+	// HTTPRoute are Accepted (Refs #3263 #2737). Caught live on hw126:
+	// `dig newapi.hw126.omantel.biz` → empty while every sibling resolved.
+	"newapi",
+	// pdns-admin — public URL for the PowerDNS-Admin web UI (bp-powerdns-admin,
+	// bootstrap-kit slot 11a, host pdns-admin.${SOVEREIGN_FQDN} per
+	// clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml). The bare
+	// pdns.<fqdn> API host IS in this list; the human-facing UI host
+	// pdns-admin.<fqdn> was not, so operators hit NXDOMAIN on the UI even
+	// after #3227 redirected pdns.<fqdn>/ → pdns-admin.<fqdn>/ (the redirect
+	// target itself never resolved). Refs #3225 #3263.
+	"pdns-admin",
 	// sandbox — public URL for the Sandbox product's per-Sandbox
 	// pty-server StatefulSet (PR #1641 rendered the per-Sandbox
 	// HTTPRoute at sandbox.<sov-fqdn>/sessions/<owner-uid>/*; without

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records_test.go
@@ -1,0 +1,53 @@
+package handler
+
+import "testing"
+
+// TestCanonicalSovereignSubdomainsCoversBrowserFacingApps guards the parent-zone
+// A-record allowlist against the recurring class of bug where a Sovereign app
+// ships a Cilium Gateway HTTPRoute (Accepted=True) yet its public hostname
+// returns NXDOMAIN because catalyst-api never wrote the A record into the parent
+// pool zone.
+//
+// This is the discriminating attribute behind #3263 row 6 (newapi.<fqdn>
+// ERR_NAME_NOT_RESOLVED) and #3225 (pdns-admin.<fqdn> NXDOMAIN): on hw126 every
+// browser-facing HTTPRoute was Accepted by the cilium-gateway, but only the
+// subdomains present in CanonicalSovereignSubdomains resolved publicly. newapi
+// and pdns-admin were absent from the list, so only those two hosts 404'd at
+// DNS resolution.
+//
+// Every browser-facing bp-* host wired in clusters/_template/bootstrap-kit/*.yaml
+// (host: <prefix>.${SOVEREIGN_FQDN}) MUST appear here. Add a row when a new
+// public app HTTPRoute lands.
+func TestCanonicalSovereignSubdomainsCoversBrowserFacingApps(t *testing.T) {
+	have := make(map[string]struct{}, len(CanonicalSovereignSubdomains))
+	for _, s := range CanonicalSovereignSubdomains {
+		have[s] = struct{}{}
+	}
+
+	// The full set of browser-facing public subdomains a stock Sovereign
+	// exposes through its Cilium Gateway. Sourced from the bootstrap-kit slot
+	// overlays' HTTPRoute hostnames (host: <prefix>.${SOVEREIGN_FQDN}).
+	want := []string{
+		"console",      // bp-catalyst-platform (catalyst-ui)
+		"api",          // bp-catalyst-platform (catalyst-api)
+		"marketplace",  // bp-catalyst-platform (marketplace)
+		"guacamole",    // bp-guacamole
+		"auth",         // bp-keycloak
+		"gitea",        // bp-gitea
+		"registry",     // bp-harbor
+		"bao",          // bp-openbao
+		"grafana",      // bp-grafana
+		"hubble",       // cilium hubble-ui
+		"pdns",         // bp-powerdns (REST API host)
+		"pdns-admin",   // bp-powerdns-admin (UI host) — #3225
+		"openova-flow", // bp-openova-flow-server
+		"newapi",       // bp-newapi (LLM gateway) — #3263 row 6
+		"sandbox",      // bp-sandbox per-Sandbox pty-server
+	}
+
+	for _, sub := range want {
+		if _, ok := have[sub]; !ok {
+			t.Errorf("CanonicalSovereignSubdomains is missing %q — its HTTPRoute is Accepted but %s.<fqdn> will return NXDOMAIN (the #3263/#3225 gap class)", sub, sub)
+		}
+	}
+}


### PR DESCRIPTION
Refs #3263 #3225 #2737

## Symptom (live hw126)
- `newapi.hw126.omantel.biz` → ERR_NAME_NOT_RESOLVED (founder walk, #3263 row 6)
- `pdns-admin.hw126.omantel.biz` → NXDOMAIN (#3225)
- Every sibling host (console / auth / gitea / registry / grafana / bao / pdns / marketplace / guacamole / hubble / openova-flow / sandbox) resolved fine to the LB IP. external-dns logged "All records are already up to date".

## Root cause — the discriminating attribute
It is **not** an HTTPRoute chart annotation/label/namespace gap. I verified live on hw126 (deployment `c986326a77d391d4`):

- All 15 browser-facing HTTPRoutes — including `newapi` (15h old) and `pdns-admin` (5h old) — are `Accepted=True` + `ResolvedRefs=True` on the cilium-gateway, attached to the same `*.hw126.omantel.biz` listener, and byte-identical in shape to the working ones (same parentRefs, empty sectionName, no external-dns annotations anywhere).
- Pool-domain hostnames do **not** resolve via the Sovereign's local external-dns / HTTPRoutes. The Sovereign's local PowerDNS `omantel.biz` zone holds only SOA+NS (zero app A records), and its external-dns writes only there. The public authority for `omantel.biz` is `ns1/ns2.openova.io` — the **mothership** PowerDNS.
- The per-host A records on the mothership PowerDNS are written by catalyst-api's `upsertSovereignParentZoneRecords` (Phase-0) from a **hardcoded allowlist**, `CanonicalSovereignSubdomains` in `sovereign_dns_records.go`. That list held 14 prefixes but was **missing exactly `newapi` and `pdns-admin`** — which is precisely why those two, and only those two, returned NXDOMAIN.
- There is no working `*` wildcard A record (a random host under the zone also NXDOMAINs), so an explicit allowlist entry is the only way a host resolves. No `_externaldns.` TXT registry exists on the mothership zone, confirming these are bespoke catalyst-api writes, not external-dns output.

## Evidence (live, read-only)
- `kubectl get httproute -A` on hw126: 15 routes incl. newapi + pdns-admin, all Accepted.
- Mothership PowerDNS `omantel.biz` zone dump: 15 hw126 A records (api, auth, bao, console, gitea, grafana, guacamole, harbor→registry, hubble, apex, marketplace, openova-flow, pdns, registry, sandbox). `newapi` and `pdns-admin` absent.
- `dig newapi.hw126.omantel.biz / pdns-admin.hw126.omantel.biz @ns1.openova.io` → empty; all 14 listed siblings → `212.72.24.30`.

## Fix
- Add `newapi` and `pdns-admin` to `CanonicalSovereignSubdomains` so the Phase-0 parent-zone PATCH writes their A records alongside every other public host (idempotent REPLACE; re-runs are safe).
- Add a regression test (`sovereign_dns_records_test.go`) asserting every browser-facing bp-* host is in the allowlist, so this "NXDOMAIN despite Accepted HTTPRoute" class can't silently recur. Verified the guard fails when a host is removed and passes when present.

Wildcard TLS (`*.<fqdn>`, the cilium-gateway-cert SAN) already covers both hosts, so no cert/SAN change is needed. No chart version bumps: the HTTPRoute templates were never the gate — the central A-record allowlist was. I swept every `host: <prefix>.${SOVEREIGN_FQDN}` in the bootstrap-kit slots; the only remaining non-listed prefix is `admin`, which has no rendered HTTPRoute (`adminHost` was retired in #2412 — ops admin lives in the console BSS menu) and correctly stays out of the allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)