### PR TITLE
fix(keycloak): kyverno-baseline-Enforce compliance for IdP StatefulSets + config-cli Job

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -146,7 +146,15 @@ spec:
       # the PUBLIC authorize endpoint — gitea (and every autodiscovery
       # consumer) no longer 307s the browser to the in-cluster
       # keycloak.keycloak.svc.cluster.local issuer (hw126 UAT FAIL).
-      version: 1.4.22
+      # 1.4.23 (#3263 #2737, 2026-06-11): kyverno-baseline-Enforce compliance
+      # for the keycloak + keycloak-postgresql StatefulSets and the config-cli
+      # Job (the IdP for ALL SSO). The #3264 roll recreated keycloak-0 after
+      # the baseline began enforcing → kyverno DENIED it (harbor-proxy-pull on
+      # bare docker.io/bitnamilegacy images + missing cilium-l7-mtls label) →
+      # keycloak 0/1 → every SSO surface a bare login page. Repointed all
+      # Bitnami images through the local Harbor proxy-cache + added the
+      # policy.cilium.io/enforced label on both StatefulSets.
+      version: 1.4.23
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.22
+  version: 1.4.23
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -210,7 +210,30 @@ name: bp-keycloak
 # fetch host → fixes EVERY autodiscovery consumer at the owning layer.
 # New templates/keycloak-frontend-env.yaml ConfigMap wired via
 # keycloak.extraEnvVarsCM.
-version: 1.4.22
+# 1.4.23 (#3263 #2737, 2026-06-11): kyverno-baseline-Enforce compliance for
+# the keycloak + keycloak-postgresql StatefulSets AND the keycloak-config-cli
+# Job — the IdP for ALL SSO. After the baseline policies began enforcing on
+# hw126, the #3264 roll recreated keycloak-0 and kyverno DENIED it (every SSO
+# surface fell back to a bare login page). Two Enforce drivers, now satisfied:
+#   - harbor-proxy-pull (Enforce): repoint EVERY Bitnami image off bare
+#     `docker.io/bitnamilegacy/…` to the Sovereign-local Harbor proxy-cache
+#     `harbor.openova.io/proxy-dockerhub/bitnamilegacy/…` (keycloak,
+#     keycloak-config-cli, postgresql, postgres-exporter, os-shell) so each
+#     image matches the allowed glob `*/proxy-*/*`. Requires
+#     global.security.allowInsecureImages=true (the umbrella chart hard-fails
+#     the render on a non-bitnami registry path; bytes are identical).
+#   - cilium-l7-mtls (Enforce): add pod-template label
+#     `policy.cilium.io/enforced: "true"` via keycloak.podLabels +
+#     keycloak.postgresql.primary.podLabels (selector-safe — bitnami
+#     common.labels.matchLabels picks only name/instance into the immutable
+#     selector). The config-cli Job is NOT matched by cilium-l7-mtls (Job is
+#     not in its match-kinds).
+# Also added a cpu limit on the keycloak container so the (Audit-mode)
+# resource-limits policy row stays clean. resource-requests (Enforce),
+# probes-present (Enforce), image-tag-pinned (Enforce), flux-managed (Enforce)
+# were already satisfied. Render-proven per-container, helm lint clean.
+# Refs #3263 #2737.
+version: 1.4.23
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -17,6 +17,16 @@ global:
   # `keycloak.postgresql.image.registry`, etc. for fine-grained override.
   # Per-Sovereign overlays wire those alongside this value. Tracked under #560.
   imageRegistry: ""
+  # #3263 (hw126 UAT 2026-06-11): the Bitnami umbrella chart hard-fails the
+  # render ("Original containers have been substituted for unrecognized ones")
+  # the moment any image is repointed off the `bitnami`/`bitnamilegacy` paths
+  # to the Sovereign-local Harbor proxy (`harbor.openova.io/proxy-dockerhub/
+  # bitnamilegacy/…`, required for the harbor-proxy-pull Enforce policy). The
+  # bytes are IDENTICAL — proxy-dockerhub is a read-through cache of the same
+  # bitnamilegacy archive — so skipping the registry-path verification is safe.
+  # Per Inviolable Principle #4 this stays operator-overridable.
+  security:
+    allowInsecureImages: true
 
 catalystBlueprint:
   upstream: { chart: keycloak, version: "25.2.0", repo: "https://charts.bitnami.com/bitnami" }
@@ -285,12 +295,39 @@ keycloak:
   # manifests. Verified existence with registry HEAD calls before pinning.
   # Tag stays the chart 25.2.0 default (`26.3.3-debian-12-r0`) — re-pin
   # when the chart bumps and we re-verify the new tag.
+  # ─── Harbor proxy-cache pull (#3263 #2737, hw126 UAT 2026-06-11) ─────────
+  # Pull every Bitnami image THROUGH the Sovereign-local Harbor proxy-cache
+  # (`harbor.openova.io/proxy-dockerhub/…`) per CLAUDE.md inviolable + kyverno
+  # baseline policy `harbor-proxy-pull` (Enforce). A bare
+  # `docker.io/bitnamilegacy/…` ref matches NEITHER allowed glob
+  # (`*/proxy-*/*` proxy-cache, `*/openova-io/*` native-push), so on hw126 the
+  # #3264 roll recreated keycloak-0, harbor-proxy-pull DENIED admission, and
+  # keycloak + keycloak-postgresql went 0/1 → every SSO surface (the IdP for
+  # ALL clients) fell back to a bare login page. The bitnamilegacy/* path is
+  # the read-only historic archive (issue #191); proxy-dockerhub serves PUBLIC
+  # images cred-free pre-cutover and the local Harbor takes over post-cutover.
+  # registry+repository split keeps the subchart's per-image override seam.
   image:
-    registry: docker.io
-    repository: bitnamilegacy/keycloak
+    registry: harbor.openova.io
+    repository: proxy-dockerhub/bitnamilegacy/keycloak
     tag: 26.3.3-debian-12-r0
+  # Pod-template label so the keycloak StatefulSet satisfies kyverno baseline
+  # `cilium-l7-mtls` (Enforce) — the catalyst-network controller attaches the
+  # Pod to the L7 mTLS mesh via this label. `common.labels.matchLabels` PICKS
+  # only app.kubernetes.io/{name,instance} into the immutable STS selector, so
+  # this custom label lands ONLY on spec.template.metadata.labels (where the
+  # policy checks) and never pollutes the selector → upgrade-safe.
+  podLabels:
+    policy.cilium.io/enforced: "true"
   postgresql:
     enabled: true
+    # Pod-template label for the keycloak-postgresql StatefulSet — same
+    # cilium-l7-mtls (Enforce) requirement as the keycloak Pod above. Lands on
+    # spec.template.metadata.labels via the postgresql subchart's primary
+    # pod-label merge; selector-safe (matchLabels picks name/instance only).
+    primary:
+      podLabels:
+        policy.cilium.io/enforced: "true"
     auth:
       username: keycloak
       database: keycloak
@@ -306,25 +343,32 @@ keycloak:
       # Caught live on hw86 2026-06-01 blocking the entire bp-* cascade
       # (memory feedback_sso_manual_recovery_procedure.md).
       existingSecret: "keycloak-postgresql"
+    # All postgresql-subchart images via Harbor proxy-cache (#3263) — same
+    # harbor-proxy-pull (Enforce) requirement as the keycloak image above.
     image:
-      registry: docker.io
-      repository: bitnamilegacy/postgresql
+      registry: harbor.openova.io
+      repository: proxy-dockerhub/bitnamilegacy/postgresql
       tag: 17.6.0-debian-12-r0
     metrics:
       image:
-        registry: docker.io
-        repository: bitnamilegacy/postgres-exporter
+        registry: harbor.openova.io
+        repository: proxy-dockerhub/bitnamilegacy/postgres-exporter
         tag: 0.17.1-debian-12-r15
     volumePermissions:
       image:
-        registry: docker.io
-        repository: bitnamilegacy/os-shell
+        registry: harbor.openova.io
+        repository: proxy-dockerhub/bitnamilegacy/os-shell
         tag: 12-debian-12-r50
   ingress:
     enabled: false  # Catalyst uses Cilium Gateway API (see `gateway:` block below), not the upstream chart ingress
   resources:
     requests: { cpu: 250m, memory: 512Mi }
-    limits: { memory: 2Gi }
+    # cpu limit added #3263 so the keycloak container also satisfies the
+    # resource-limits baseline policy (Audit, not the outage cause but kept
+    # clean). Set generously (2 cores) — Keycloak's JVM + Liquibase migrations
+    # are CPU-bursty at startup and an over-tight cpu limit throttles them,
+    # so this is a ceiling well above steady-state, not a steady-state cap.
+    limits: { cpu: "2", memory: 2Gi }
   # ─── Probes — issue #146 (decouple slow Liquibase from livenessProbe) ─────
   #
   # Diagnostic finding (prov #21 + #22): the Keycloak StatefulSet's Service
@@ -399,9 +443,15 @@ keycloak:
     # post-upgrade,post-rollback with weight 5). The realm is provisioned
     # exactly once per fresh release; re-run on upgrade is idempotent
     # (config-cli reconciles the realm to spec).
+    # keycloak-config-cli image via Harbor proxy-cache (#3263) — the realm-
+    # import Job's Pod is subject to harbor-proxy-pull (Enforce) + resource-
+    # requests (Enforce) like every other gated workload. A bare
+    # docker.io/bitnamilegacy ref would be DENIED on Job-pod create, so the
+    # realm-import would never run and downstream bp-gitea / catalyst-api
+    # (which depend on the realm existing) would wedge.
     image:
-      registry: docker.io
-      repository: bitnamilegacy/keycloak-config-cli
+      registry: harbor.openova.io
+      repository: proxy-dockerhub/bitnamilegacy/keycloak-config-cli
       tag: 6.4.0-debian-12-r11
     # ─── Hook timing — issue #129 (install) + #140 (post-upgrade) ───────────
     #


### PR DESCRIPTION
## Why

On live **hw126** the `bp-keycloak` StatefulSet pods are DENIED by kyverno on (re)create → `keycloak` 0/1, `keycloak-postgresql` 0/1 → **every SSO surface shows a bare login page** (this is the IdP for ALL SSO). The pods were admitted at bootstrap BEFORE baseline enforcement worked; the #3264 roll recreated `keycloak-0` and kyverno now DENIES it.

## Root cause — two Enforce-policy drivers

Verified against the live baseline sources in `platform/kyverno-policies/chart/templates/baseline/*.yaml`. The `keycloak` namespace is NOT in `complianceDefaultExcludes`, so the workloads must comply. Enforce policies that match a StatefulSet/Job: **04 probes-present, 05 resource-requests, 09 cilium-l7-mtls, 10 flux-managed, 11 harbor-proxy-pull, 12 image-tag-pinned**.

1. **harbor-proxy-pull (Enforce)** — images were `docker.io/bitnamilegacy/...`, matching NEITHER allowed glob (`*/proxy-*/*` proxy-cache, `*/openova-io/*` native-push). → repointed every Bitnami image to `harbor.openova.io/proxy-dockerhub/bitnamilegacy/...` (the canonical idiom from bp-cnpg/bp-flux/bp-harbor). Requires `global.security.allowInsecureImages=true` — the Bitnami umbrella chart hard-fails the render on a non-`bitnami` registry path; bytes are identical (read-through cache of the same `bitnamilegacy` archive).
2. **cilium-l7-mtls (Enforce)** — pod templates lacked `policy.cilium.io/enforced: "true"`. → added via `keycloak.podLabels` + `keycloak.postgresql.primary.podLabels`. **Selector-safe**: bitnami `common.labels.matchLabels` picks only `app.kubernetes.io/{name,instance}` into the immutable STS selector, so the custom label lands only on `spec.template.metadata.labels` (where the policy checks) → upgrade-safe.

`04 probes-present` / `05 resource-requests` / `12 image-tag-pinned` / `10 flux-managed` were already satisfied. Added a cpu limit on the `keycloak` container so the Audit-mode `resource-limits` row stays clean too. The `keycloak-config-cli` **Job** is not matched by `cilium-l7-mtls` (Job not in its match-kinds), so needs no label.

## Render-proof — per-container, every Enforce cell compliant

`helm template keycloak . --set gateway.host=auth.hw126.omani.works` (as a live prov renders):

| Workload | Container | tag-pinned (12) | proxied (11) | cilium-lbl (09) | req cpu+mem (05) | lim cpu+mem (06,audit) | liveness/readiness (04) |
|---|---|---|---|---|---|---|---|
| StatefulSet/keycloak-postgresql | postgresql | YES | YES | YES | YES | YES | YES / YES |
| StatefulSet/keycloak | init `prepare-write-dirs` | YES | YES | YES (pod-lvl) | YES | YES | n/a (init) |
| StatefulSet/keycloak | keycloak | YES | YES | YES | YES | YES | YES / YES |
| Job/keycloak-config-cli | keycloak-config-cli | YES | YES | n/a (Job) | YES | YES | n/a (Job) |

Images after repoint:
- `harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak:26.3.3-debian-12-r0`
- `harbor.openova.io/proxy-dockerhub/bitnamilegacy/postgresql:17.6.0-debian-12-r0`
- `harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak-config-cli:6.4.0-debian-12-r11`
- (+ postgres-exporter, os-shell on the same proxy path)

Confirmed `policy.cilium.io/enforced` is on the pod template of both StatefulSets but **NOT** in either immutable selector. `helm lint` clean.

## Lockstep version bump

`1.4.22 → 1.4.23` in: `platform/keycloak/chart/Chart.yaml` (version + changelog), `platform/keycloak/blueprint.yaml` (indented `spec.version`), `clusters/_template/bootstrap-kit/09-keycloak.yaml` (slot pin).

Refs #3263 #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)