### PR TITLE
feat(dns): idempotent republish-dns endpoint for live Sovereigns

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1105,6 +1105,16 @@ func main() {
 		// PurgeReport summary. The wizard's failed-state banner renders the
 		// operator confirmation modal that POSTs here.
 		rg.Post("/api/v1/deployments/{id}/wipe", h.WipeDeployment)
+		// DNS re-publish endpoint (Refs #3265 #3263) — idempotent re-trigger
+		// that writes the CURRENT CanonicalSovereignSubdomains list into the
+		// parent PowerDNS zone for an EXISTING deployment.  Used when the
+		// canonical subdomain list grows after a Sovereign was provisioned (e.g.
+		// hw126 was provisioned before #3265 added "newapi" + "pdns-admin"), so
+		// operators can pick up the new A records WITHOUT a full re-provision.
+		// Inputs (FQDN, LB IP, parent zones) are reconstructed entirely from
+		// the persisted Deployment record — no external API calls.  The
+		// PowerDNS PATCH is REPLACE-idempotent; re-running is always safe.
+		rg.Post("/api/v1/deployments/{id}/republish-dns", h.HandleRepublishDNS)
 		// Handover JWT — issue #605 (minting) + issue #606 (consumption).
 		// MintHandoverToken: Catalyst-Zero operator finalises a deployment;
 		// wizard StepSuccess POSTs here to get a one-time RS256 JWT, then

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_republish.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_republish.go
@@ -1,0 +1,221 @@
+// sovereign_dns_republish.go — idempotent DNS re-publish for live Sovereigns.
+//
+// Why this file exists
+// ────────────────────
+// upsertSovereignParentZoneRecordsFromResult (sovereign_dns_records.go) is
+// called ONCE — at Phase-0 success — and writes the A records for every
+// CanonicalSovereignSubdomain into the parent zone.  When the canonical
+// subdomain list grows (e.g. #3265 added "newapi" and "pdns-admin"), Sovereigns
+// that were provisioned BEFORE the change stay with the old, shorter list.
+// hw126 (deployment id c986326a77d391d4) was provisioned with 14 subdomains;
+// #3265 raised it to 16.  The gap manifests as NXDOMAIN on newapi.<fqdn> and
+// pdns-admin.<fqdn> even though the Cilium Gateway HTTPRoute is Accepted and
+// the LB is healthy — the ONLY missing piece is the A record in the parent
+// PowerDNS zone.
+//
+// This endpoint provides an operator-callable re-trigger so the operator does
+// NOT need to re-provision (wipe + re-create) a live Sovereign just to pick up
+// the new subdomain list.
+//
+// Endpoint
+// ────────
+//   POST /internal/deployments/{id}/republish-dns
+//
+// Auth model
+// ──────────
+// Sits inside the RequireSession chi.Group (same as every other /internal/*
+// route).  No separate bearer token required — the signed-in mothership
+// operator calling this already owns the deployment.  checkOwnership is called
+// inside the handler per the pattern every other deployments/{id} endpoint
+// follows.
+//
+// Input reconstruction
+// ────────────────────
+// The handler reads dep.Result.SovereignFQDN and dep.Result.LoadBalancerIP
+// from the persisted Deployment record (on-disk store, survived Pod restarts)
+// and dep.Request.ParentDomains for the parent zone list.  No external API
+// calls are needed — every input survived in the deployment record exactly as
+// it was written by the original provision run.
+//
+// Idempotency
+// ──────────
+// PowerDNS PatchRRSets with ChangeType=REPLACE is unconditionally idempotent:
+// re-running the call with the same IP replaces the existing records byte-for-
+// byte; re-running after an IP change (LB reprovisioned) correctly overwrites
+// the stale record.  Safe to call multiple times.
+//
+// Response
+// ────────
+//   200 JSON:
+//     {
+//       "deploymentId": "c986326a77d391d4",
+//       "sovereignFQDN": "hw126.omantel.biz",
+//       "lbIP": "1.2.3.4",
+//       "parentZones": ["omantel.biz"],
+//       "published": ["console","auth",...,"newapi","pdns-admin"],
+//       "publishedCount": 16
+//     }
+//
+// Error responses follow the standard writeJSON shape (see handler.go).
+package handler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// dnsRepublishResponse is the JSON body returned on success.
+type dnsRepublishResponse struct {
+	DeploymentID   string   `json:"deploymentId"`
+	SovereignFQDN  string   `json:"sovereignFQDN"`
+	LBIP           string   `json:"lbIP"`
+	ParentZones    []string `json:"parentZones"`
+	Published      []string `json:"published"`
+	PublishedCount int      `json:"publishedCount"`
+}
+
+// HandleRepublishDNS handles
+//
+//	POST /internal/deployments/{id}/republish-dns
+//
+// It re-runs upsertSovereignParentZoneRecords against an EXISTING deployment's
+// persisted Result so any subdomains added to CanonicalSovereignSubdomains
+// after the original provision are written into the parent zone without
+// requiring a full re-provision.
+//
+// Inputs are sourced ENTIRELY from the persisted Deployment record:
+//   - dep.Result.SovereignFQDN  → sovereignFQDN for the upsert
+//   - dep.Result.LoadBalancerIP → lbIP for the A records
+//   - dep.Request.ParentDomains → parent zone list (with backstop derivation
+//     from FQDN if empty, matching the original prov-time logic exactly)
+//
+// The PowerDNS upsert is REPLACE-idempotent: re-running is safe.
+func (h *Handler) HandleRepublishDNS(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	val, ok := h.deployments.Load(id)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{
+			"error":  "deployment-not-found",
+			"detail": "no deployment with that id is loaded in-memory; restart catalyst-api to reload from disk if the deployment was persisted",
+		})
+		return
+	}
+	dep := val.(*Deployment)
+
+	// Ownership check — same gate every other /deployments/{id}* handler uses.
+	if !h.checkOwnership(w, r, dep) {
+		return
+	}
+
+	// Read inputs under the mutex — same pattern as upsertSovereignParentZoneRecordsFromResult.
+	dep.mu.Lock()
+	result := dep.Result
+	dep.mu.Unlock()
+
+	if result == nil {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+			"error":  "no-result",
+			"detail": "deployment has no Phase-0 result yet (still provisioning or failed before tofu completed); cannot republish DNS without an LB IP",
+		})
+		return
+	}
+	if result.SovereignFQDN == "" || result.LoadBalancerIP == "" {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+			"error":  "incomplete-result",
+			"detail": "deployment result is missing sovereignFQDN or loadBalancerIP; cannot reconstruct DNS inputs",
+		})
+		return
+	}
+
+	if h.powerdnsZoneClient == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "powerdns-not-wired",
+			"detail": "CATALYST_POWERDNS_API_KEY is unset on this catalyst-api Pod; DNS republish is only possible on a Sovereign-side Pod with PowerDNS wired",
+		})
+		return
+	}
+
+	// Collect parent zones — mirror the logic in upsertSovereignParentZoneRecordsFromResult
+	// verbatim so both paths agree on which zones are written.
+	dep.mu.Lock()
+	parents := make([]string, 0, len(dep.Request.ParentDomains))
+	for _, pd := range dep.Request.ParentDomains {
+		if pd.Name != "" {
+			parents = append(parents, pd.Name)
+		}
+	}
+	dep.mu.Unlock()
+
+	if len(parents) == 0 {
+		// Backstop: derive from FQDN tail labels (same as prov-time path).
+		parts := strings.SplitN(result.SovereignFQDN, ".", 2)
+		if len(parts) == 2 {
+			parents = []string{parts[1]}
+		}
+	}
+	if len(parents) == 0 {
+		// Single-label FQDN edge-case — use the FQDN itself as zone.
+		parents = []string{result.SovereignFQDN}
+	}
+
+	// Re-use the existing idempotent upsert.  The same 404-fallback logic that
+	// upsertSovereignParentZoneRecordsFromResult applies is reproduced here:
+	// when the synthesised ParentDomain equals the Sovereign FQDN itself, the
+	// first PATCH returns 404 because the authoritative zone is the FQDN's
+	// tail labels, not the FQDN itself.  We retry against the derived parent.
+	var errs []string
+	resolvedParents := make([]string, 0, len(parents))
+	for _, parent := range parents {
+		if err := h.upsertSovereignParentZoneRecords(r.Context(), result.SovereignFQDN, parent, result.LoadBalancerIP); err == nil {
+			resolvedParents = append(resolvedParents, parent)
+			continue
+		} else if strings.Contains(err.Error(), "status 404") && parent == result.SovereignFQDN {
+			if i := strings.Index(result.SovereignFQDN, "."); i > 0 {
+				derivedParent := result.SovereignFQDN[i+1:]
+				h.log.Info("republish-dns: parent zone 404 — retrying with derived parent",
+					"id", id,
+					"originalParent", parent,
+					"derivedParent", derivedParent,
+				)
+				if err2 := h.upsertSovereignParentZoneRecords(r.Context(), result.SovereignFQDN, derivedParent, result.LoadBalancerIP); err2 == nil {
+					resolvedParents = append(resolvedParents, derivedParent)
+					continue
+				} else {
+					errs = append(errs, "zone "+parent+": original="+err.Error()+"; derived-fallback="+err2.Error())
+					continue
+				}
+			}
+			errs = append(errs, "zone "+parent+": "+err.Error())
+		} else {
+			errs = append(errs, "zone "+parent+": "+err.Error())
+		}
+	}
+
+	if len(errs) > 0 {
+		h.log.Warn("republish-dns: one or more parent zone patches failed",
+			"id", id,
+			"errors", errs,
+		)
+		writeJSON(w, http.StatusBadGateway, map[string]any{
+			"error":         "partial-failure",
+			"detail":        "one or more parent zone patches failed; see errors field",
+			"errors":        errs,
+			"deploymentId":  id,
+			"sovereignFQDN": result.SovereignFQDN,
+		})
+		return
+	}
+
+	published := CanonicalSovereignSubdomains
+	writeJSON(w, http.StatusOK, dnsRepublishResponse{
+		DeploymentID:   id,
+		SovereignFQDN:  result.SovereignFQDN,
+		LBIP:           result.LoadBalancerIP,
+		ParentZones:    resolvedParents,
+		Published:      published,
+		PublishedCount: len(published),
+	})
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_republish_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_republish_test.go
@@ -1,0 +1,391 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/powerdns"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// stubPowerDNSClient is a minimal powerdnsZoneClient for republish-dns tests.
+// PatchRRSets records every call and optionally returns an error.
+type stubPowerDNSClient struct {
+	// patches accumulates every (zone, rrsets) call in order.
+	patches []stubPDNSPatch
+	// errForZone maps zone name → error to return; absent zone → nil.
+	errForZone map[string]error
+}
+
+type stubPDNSPatch struct {
+	Zone   string
+	RRSets []powerdns.RRSet
+}
+
+func (s *stubPowerDNSClient) CreateZone(_ context.Context, _ powerdns.ZoneSpec) error { return nil }
+func (s *stubPowerDNSClient) ZoneExists(_ context.Context, _ string) (bool, error)    { return true, nil }
+func (s *stubPowerDNSClient) PatchRRSets(_ context.Context, zone string, rrsets []powerdns.RRSet) error {
+	s.patches = append(s.patches, stubPDNSPatch{Zone: zone, RRSets: rrsets})
+	if s.errForZone != nil {
+		if err, ok := s.errForZone[zone]; ok {
+			return err
+		}
+	}
+	return nil
+}
+
+// makeDepForRepublish builds a ready Deployment whose Result contains the
+// given FQDN, LB IP, and (optionally) parent domains.
+func makeDepForRepublish(id, fqdn, lbIP string, parentDomains []string) *Deployment {
+	closedCh := make(chan provisioner.Event)
+	closedDone := make(chan struct{})
+	close(closedCh)
+	close(closedDone)
+
+	pds := make([]provisioner.ParentDomain, 0, len(parentDomains))
+	for _, pd := range parentDomains {
+		pds = append(pds, provisioner.ParentDomain{Name: pd})
+	}
+
+	return &Deployment{
+		ID:     id,
+		Status: "ready",
+		Request: provisioner.Request{
+			SovereignFQDN: fqdn,
+			ParentDomains: pds,
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN:  fqdn,
+			LoadBalancerIP: lbIP,
+		},
+		eventsCh: closedCh,
+		done:     closedDone,
+	}
+}
+
+// doRepublish fires HandleRepublishDNS via httptest with chi routing and
+// returns the response recorder.
+func doRepublish(h *Handler, depID string) *httptest.ResponseRecorder {
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/internal/deployments/"+depID+"/republish-dns", nil)
+
+	r := chi.NewRouter()
+	r.Post("/internal/deployments/{id}/republish-dns", h.HandleRepublishDNS)
+	r.ServeHTTP(rr, req)
+	return rr
+}
+
+// TestRepublishDNS_PublishesAllCanonicalSubdomains verifies that a successful
+// call writes exactly len(CanonicalSovereignSubdomains)+1 rrsets (subdomains +
+// apex) into the correct parent zone and returns them in the response body.
+func TestRepublishDNS_PublishesAllCanonicalSubdomains(t *testing.T) {
+	t.Parallel()
+
+	const (
+		depID = "c986326a77d391d4"
+		fqdn  = "hw126.omantel.biz"
+		lbIP  = "1.2.3.4"
+	)
+
+	stub := &stubPowerDNSClient{}
+	h := &Handler{log: slog.Default()}
+	h.deployments.Store(depID, makeDepForRepublish(depID, fqdn, lbIP, []string{"omantel.biz"}))
+	h.powerdnsZoneClient = stub
+
+	rr := doRepublish(h, depID)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d — body: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp dnsRepublishResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	// Verify the response carries all 16 canonical subdomains.
+	if resp.PublishedCount != len(CanonicalSovereignSubdomains) {
+		t.Errorf("publishedCount: want %d, got %d", len(CanonicalSovereignSubdomains), resp.PublishedCount)
+	}
+	if resp.DeploymentID != depID {
+		t.Errorf("deploymentId: want %q, got %q", depID, resp.DeploymentID)
+	}
+	if resp.LBIP != lbIP {
+		t.Errorf("lbIP: want %q, got %q", lbIP, resp.LBIP)
+	}
+	if len(resp.ParentZones) != 1 || resp.ParentZones[0] != "omantel.biz" {
+		t.Errorf("parentZones: want [omantel.biz], got %v", resp.ParentZones)
+	}
+
+	// Verify that PatchRRSets was called once (one parent zone) with
+	// len(CanonicalSovereignSubdomains)+1 rrsets (subdomains + apex).
+	if len(stub.patches) != 1 {
+		t.Fatalf("PatchRRSets call count: want 1, got %d", len(stub.patches))
+	}
+	wantRRSetCount := len(CanonicalSovereignSubdomains) + 1 // +1 for apex
+	if got := len(stub.patches[0].RRSets); got != wantRRSetCount {
+		t.Errorf("rrset count: want %d (subdomains+apex), got %d", wantRRSetCount, got)
+	}
+	if stub.patches[0].Zone != "omantel.biz" {
+		t.Errorf("zone patched: want %q, got %q", "omantel.biz", stub.patches[0].Zone)
+	}
+
+	// Verify that all CanonicalSovereignSubdomains appear in the published list.
+	publishedSet := make(map[string]struct{}, len(resp.Published))
+	for _, s := range resp.Published {
+		publishedSet[s] = struct{}{}
+	}
+	for _, sub := range CanonicalSovereignSubdomains {
+		if _, ok := publishedSet[sub]; !ok {
+			t.Errorf("subdomain %q missing from published list", sub)
+		}
+	}
+	// Spot-check the #3265 additions specifically.
+	for _, required := range []string{"newapi", "pdns-admin"} {
+		if _, ok := publishedSet[required]; !ok {
+			t.Errorf("#3265 subdomain %q missing from published list", required)
+		}
+	}
+}
+
+// TestRepublishDNS_404FallbackToParentOfFQDN verifies the 404-retry path: when
+// dep.Request.ParentDomains[0].Name equals the Sovereign FQDN itself (the
+// back-compat synthesis Validate performs when SovereignPoolDomain is absent),
+// the first PatchRRSets call targets the wrong "zone" (the FQDN itself, e.g.
+// "t126.omani.works") and PowerDNS returns 404 because the authoritative zone
+// is the tail-labels parent ("omani.works").  The handler retries against the
+// derived parent and succeeds.
+func TestRepublishDNS_404FallbackToParentOfFQDN(t *testing.T) {
+	t.Parallel()
+
+	const (
+		depID = "abc123"
+		fqdn  = "t126.omani.works"
+		lbIP  = "5.6.7.8"
+	)
+
+	// Explicitly set ParentDomains to the FQDN itself (the back-compat synthesis
+	// shape: dep.Request.ParentDomains[0].Name == fqdn).  The stub returns 404
+	// when asked to PATCH the zone named after the FQDN, triggering the fallback
+	// to "omani.works".
+	stub := &stubPowerDNSClient{
+		errForZone: map[string]error{
+			fqdn: fmt.Errorf("powerdns returned status 404"),
+		},
+	}
+	h := &Handler{log: slog.Default()}
+	// ParentDomains = [fqdn] — the back-compat synthesis shape.
+	h.deployments.Store(depID, makeDepForRepublish(depID, fqdn, lbIP, []string{fqdn}))
+	h.powerdnsZoneClient = stub
+
+	rr := doRepublish(h, depID)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d — body: %s", rr.Code, rr.Body.String())
+	}
+
+	// Two PatchRRSets calls expected: first attempt on "t126.omani.works" (fails
+	// 404), second on "omani.works" (succeeds).
+	if len(stub.patches) != 2 {
+		t.Fatalf("PatchRRSets call count: want 2 (original + fallback), got %d", len(stub.patches))
+	}
+	if stub.patches[0].Zone != fqdn {
+		t.Errorf("first patch zone: want %q, got %q", fqdn, stub.patches[0].Zone)
+	}
+	derivedParent := "omani.works"
+	if stub.patches[1].Zone != derivedParent {
+		t.Errorf("fallback patch zone: want %q, got %q", derivedParent, stub.patches[1].Zone)
+	}
+
+	var resp dnsRepublishResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.ParentZones) != 1 || resp.ParentZones[0] != derivedParent {
+		t.Errorf("parentZones in response: want [%q], got %v", derivedParent, resp.ParentZones)
+	}
+}
+
+// TestRepublishDNS_404NotFound verifies that a missing deployment id returns 404.
+func TestRepublishDNS_404NotFound(t *testing.T) {
+	t.Parallel()
+	h := &Handler{log: slog.Default()}
+	rr := doRepublish(h, "nonexistent-id")
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("want 404, got %d", rr.Code)
+	}
+}
+
+// TestRepublishDNS_NilResult verifies that a deployment whose Result is nil
+// returns 422 (no Phase-0 result yet).
+func TestRepublishDNS_NilResult(t *testing.T) {
+	t.Parallel()
+
+	closedCh := make(chan provisioner.Event)
+	closedDone := make(chan struct{})
+	close(closedCh)
+	close(closedDone)
+
+	dep := &Deployment{
+		ID:       "dep-nil-result",
+		Status:   "failed",
+		eventsCh: closedCh,
+		done:     closedDone,
+	}
+	h := &Handler{log: slog.Default()}
+	h.deployments.Store("dep-nil-result", dep)
+	h.powerdnsZoneClient = &stubPowerDNSClient{}
+
+	rr := doRepublish(h, "dep-nil-result")
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Errorf("want 422, got %d", rr.Code)
+	}
+}
+
+// TestRepublishDNS_PowerDNSNotWired verifies that when powerdnsZoneClient is
+// nil the handler returns 503.
+func TestRepublishDNS_PowerDNSNotWired(t *testing.T) {
+	t.Parallel()
+	h := &Handler{log: slog.Default()}
+	h.deployments.Store("dep-no-pdns",
+		makeDepForRepublish("dep-no-pdns", "t99.omani.works", "1.1.1.1", []string{"omani.works"}),
+	)
+	// h.powerdnsZoneClient intentionally left nil.
+
+	rr := doRepublish(h, "dep-no-pdns")
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("want 503, got %d", rr.Code)
+	}
+}
+
+// TestRepublishDNS_PatchError verifies that a PatchRRSets failure returns 502.
+func TestRepublishDNS_PatchError(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubPowerDNSClient{
+		errForZone: map[string]error{
+			"omani.works": fmt.Errorf("powerdns returned status 500"),
+		},
+	}
+	h := &Handler{log: slog.Default()}
+	h.deployments.Store("dep-patch-err",
+		makeDepForRepublish("dep-patch-err", "t100.omani.works", "2.2.2.2", []string{"omani.works"}),
+	)
+	h.powerdnsZoneClient = stub
+
+	rr := doRepublish(h, "dep-patch-err")
+	if rr.Code != http.StatusBadGateway {
+		t.Errorf("want 502, got %d", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "partial-failure") {
+		t.Errorf("want 'partial-failure' in response body, got: %s", body)
+	}
+}
+
+// TestRepublishDNS_ReconstructsInputsFromPersisted is the table test the spec
+// asks for: verifies that the handler correctly reconstructs sovereignFQDN,
+// lbIP, and parent zones from the persisted Deployment record for each shape.
+func TestRepublishDNS_ReconstructsInputsFromPersisted(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		fqdn          string
+		lbIP          string
+		parentDomains []string // what's in dep.Request.ParentDomains
+		wantZone      string   // the zone PatchRRSets should be called against
+		wantLBIP      string   // the IP all A records should point to
+		wantSubCount  int      // expected number of subdomains in the A records
+	}{
+		{
+			name:          "explicit-parent-domain",
+			fqdn:          "t111.omani.works",
+			lbIP:          "77.42.11.95",
+			parentDomains: []string{"omani.works"},
+			wantZone:      "omani.works",
+			wantLBIP:      "77.42.11.95",
+			wantSubCount:  len(CanonicalSovereignSubdomains),
+		},
+		{
+			name:          "no-parent-domains-derived-from-fqdn",
+			fqdn:          "t112.omani.works",
+			lbIP:          "88.53.22.96",
+			parentDomains: nil, // empty → backstop derives from FQDN
+			wantZone:      "omani.works",
+			wantLBIP:      "88.53.22.96",
+			wantSubCount:  len(CanonicalSovereignSubdomains),
+		},
+		{
+			name:          "multi-parent-domains",
+			fqdn:          "t113.omani.works",
+			lbIP:          "99.64.33.97",
+			parentDomains: []string{"omani.works", "omantel.biz"},
+			wantZone:      "omani.works", // first zone; test checks both below
+			wantLBIP:      "99.64.33.97",
+			wantSubCount:  len(CanonicalSovereignSubdomains),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			stub := &stubPowerDNSClient{}
+			h := &Handler{log: slog.Default()}
+			depID := "dep-" + tc.name
+			h.deployments.Store(depID, makeDepForRepublish(depID, tc.fqdn, tc.lbIP, tc.parentDomains))
+			h.powerdnsZoneClient = stub
+
+			rr := doRepublish(h, depID)
+			if rr.Code != http.StatusOK {
+				t.Fatalf("want 200, got %d — body: %s", rr.Code, rr.Body.String())
+			}
+
+			// Verify response body fields.
+			var resp dnsRepublishResponse
+			if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if resp.LBIP != tc.wantLBIP {
+				t.Errorf("lbIP: want %q, got %q", tc.wantLBIP, resp.LBIP)
+			}
+			if resp.PublishedCount != tc.wantSubCount {
+				t.Errorf("publishedCount: want %d, got %d", tc.wantSubCount, resp.PublishedCount)
+			}
+
+			// For multi-parent case ensure both zones are patched.
+			if len(tc.parentDomains) == 2 {
+				if len(stub.patches) != 2 {
+					t.Fatalf("multi-parent: want 2 PatchRRSets calls, got %d", len(stub.patches))
+				}
+				zones := map[string]bool{stub.patches[0].Zone: true, stub.patches[1].Zone: true}
+				for _, pd := range tc.parentDomains {
+					if !zones[pd] {
+						t.Errorf("parent zone %q not patched; got zones: %v", pd, stub.patches)
+					}
+				}
+			}
+
+			// Verify each patch uses the correct LB IP for all A records.
+			for _, patch := range stub.patches {
+				for _, rr := range patch.RRSets {
+					if rr.Type == "A" {
+						if len(rr.Records) != 1 || rr.Records[0].Content != tc.wantLBIP {
+							t.Errorf("rrset %q: want IP %q, got %v", rr.Name, tc.wantLBIP, rr.Records)
+						}
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`upsertSovereignParentZoneRecordsFromResult` runs once at Phase-0 success and writes the A records for every `CanonicalSovereignSubdomain`. When the list grows (e.g. #3265 added `newapi` + `pdns-admin`, raising 14 → 16), already-provisioned Sovereigns stay NXDOMAIN on the new subdomains even though the Cilium Gateway HTTPRoute is Accepted and the LB is healthy. hw126 (`c986326a77d391d4`) is the live example.

## Fix

New endpoint `POST /api/v1/deployments/{id}/republish-dns` (inside RequireSession group):

- Reconstructs inputs **entirely from the persisted `Deployment` record** — `dep.Result.SovereignFQDN`, `dep.Result.LoadBalancerIP`, `dep.Request.ParentDomains` — no external API calls
- Calls **existing** `upsertSovereignParentZoneRecords` (PowerDNS PATCH REPLACE — idempotent; re-running is always safe)
- Mirrors the 404-fallback from `upsertSovereignParentZoneRecordsFromResult`: when stored parent == FQDN (back-compat synthesis), retries with derived tail labels
- Returns `{deploymentId, sovereignFQDN, lbIP, parentZones, published, publishedCount}`

## Files changed

- `products/catalyst/bootstrap/api/internal/handler/sovereign_dns_republish.go` (new handler)
- `products/catalyst/bootstrap/api/internal/handler/sovereign_dns_republish_test.go` (9 tests, all pass)
- `products/catalyst/bootstrap/api/cmd/api/main.go` (route registration after `WipeDeployment`)

## How to invoke for hw126

```bash
curl -s -X POST \
  -b "session=<mothership-session-cookie>" \
  https://console.openova.io/api/v1/deployments/c986326a77d391d4/republish-dns \
  | jq '{publishedCount, published, parentZones}'
# expect: publishedCount=16, published includes "newapi" and "pdns-admin"
```

## Tests

```
go test ./internal/handler/... -run TestRepublish -v
# 9/9 PASS  (TestRepublishDNS_PublishesAllCanonicalSubdomains, 404FallbackToParentOfFQDN,
#             404NotFound, NilResult, PowerDNSNotWired, PatchError,
#             ReconstructsInputsFromPersisted/{explicit,no-parent-derived,multi-parent})
```

## Strategy-flip safety

`api-deployment.yaml` was **not touched**. No `{{ }}` added anywhere in resource names.

Refs #3265 #3263