### PR TITLE
fix(catalyst-ui): land app SSO in the target app, not console — same-Sovereign next allowlist (#3271)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/auth-gate.test.ts
+++ b/products/catalyst/bootstrap/ui/src/app/auth-gate.test.ts
@@ -5,6 +5,8 @@ import {
   hasCatalystSession,
   probeWhoamiAndCacheMarker,
   sanitizeNextParam,
+  sameSovereignHostFamily,
+  CANONICAL_SOVEREIGN_SUBDOMAINS,
   PUBLIC_PATH_PREFIXES,
 } from './auth-gate'
 
@@ -242,6 +244,139 @@ describe('sanitizeNextParam — open-redirect defense (CWE-601)', () => {
     expect(sanitizeNextParam('/dashboard ')).toBeUndefined()
     expect(sanitizeNextParam(' /dashboard')).toBeUndefined()
     expect(sanitizeNextParam('/dash\x00board')).toBeUndefined()
+  })
+})
+
+describe('sameSovereignHostFamily', () => {
+  it('derives {console,auth,api}.<fqdn> by stripping the first label', () => {
+    expect(sameSovereignHostFamily('console.t42.omani.works')).toEqual([
+      'console.t42.omani.works',
+      'auth.t42.omani.works',
+      'api.t42.omani.works',
+    ])
+    expect(sameSovereignHostFamily('api.t42.omani.works')).toEqual([
+      'console.t42.omani.works',
+      'auth.t42.omani.works',
+      'api.t42.omani.works',
+    ])
+  })
+
+  it('preserves a :port suffix on every family member', () => {
+    expect(sameSovereignHostFamily('console.t42.omani.works:8443')).toEqual([
+      'console.t42.omani.works:8443',
+      'auth.t42.omani.works:8443',
+      'api.t42.omani.works:8443',
+    ])
+  })
+
+  it('trusts nothing for bare hosts / single-label parents / localhost', () => {
+    expect(sameSovereignHostFamily('')).toEqual([])
+    expect(sameSovereignHostFamily('localhost')).toEqual([])
+    expect(sameSovereignHostFamily('localhost:5173')).toEqual([])
+    // A single-label parent like `console.local` → parent `local` is refused.
+    expect(sameSovereignHostFamily('console.local')).toEqual([])
+    expect(sameSovereignHostFamily('console.')).toEqual([])
+  })
+
+  it('CANONICAL_SOVEREIGN_SUBDOMAINS is the expected control-plane set', () => {
+    expect(CANONICAL_SOVEREIGN_SUBDOMAINS).toEqual(['console', 'auth', 'api'])
+  })
+})
+
+describe('sanitizeNextParam — same-Sovereign cross-host allowlist (#3271)', () => {
+  // After PIN-verify the OAuth `next` continuation is a legitimate
+  // cross-host URL on the SAME Sovereign:
+  //   https://api.<fqdn>/oidc/auth?...&redirect_uri=https://auth.<fqdn>/...
+  // sanitizeNextParam must ACCEPT it (so the app SSO lands the user in
+  // the target app, not the console /dashboard) while still rejecting
+  // every host outside the trusted {console,auth,api}.<fqdn> family.
+  const HOST = 'console.t42.omani.works'
+
+  it('accepts an absolute api.<fqdn> OAuth continuation (the #3271 walk)', () => {
+    const next =
+      'https://api.t42.omani.works/oidc/auth?client_id=catalyst-pin' +
+      '&redirect_uri=https://auth.t42.omani.works/realms/sovereign/broker/catalyst-pin/endpoint' +
+      '&state=abc&response_type=code'
+    expect(sanitizeNextParam(next, HOST)).toBe(next)
+  })
+
+  it('accepts absolute auth.<fqdn> and console.<fqdn> same-Sovereign URLs', () => {
+    expect(sanitizeNextParam('https://auth.t42.omani.works/realms/sovereign', HOST)).toBe(
+      'https://auth.t42.omani.works/realms/sovereign',
+    )
+    expect(sanitizeNextParam('https://console.t42.omani.works/dashboard', HOST)).toBe(
+      'https://console.t42.omani.works/dashboard',
+    )
+  })
+
+  it('still accepts same-origin relative paths', () => {
+    expect(sanitizeNextParam('/dashboard', HOST)).toBe('/dashboard')
+    expect(sanitizeNextParam('/provision/d-1/users', HOST)).toBe('/provision/d-1/users')
+  })
+
+  it('REJECTS an unrelated absolute host (open-redirect)', () => {
+    expect(sanitizeNextParam('https://evil.com/path', HOST)).toBeUndefined()
+    expect(sanitizeNextParam('http://evil.com', HOST)).toBeUndefined()
+  })
+
+  it('REJECTS protocol-relative //evil.com', () => {
+    expect(sanitizeNextParam('//evil.com', HOST)).toBeUndefined()
+    expect(sanitizeNextParam('//api.t42.omani.works/oidc/auth', HOST)).toBeUndefined()
+  })
+
+  it('REJECTS the look-alike suffix attack api.<fqdn>.evil.com (CWE-601)', () => {
+    // The registrable host is evil.com — NOT the Sovereign FQDN. A naive
+    // `next.includes("api.<fqdn>")` check would be fooled; the URL-parse +
+    // exact host membership test must reject this.
+    expect(
+      sanitizeNextParam('https://api.t42.omani.works.evil.com/oidc/auth', HOST),
+    ).toBeUndefined()
+    expect(
+      sanitizeNextParam('https://api.t42.omani.works@evil.com/oidc/auth', HOST),
+    ).toBeUndefined()
+    expect(
+      sanitizeNextParam('https://evil.com/api.t42.omani.works/oidc/auth', HOST),
+    ).toBeUndefined()
+  })
+
+  it('REJECTS a different Sovereign FQDN (cross-Sovereign redirect)', () => {
+    expect(
+      sanitizeNextParam('https://api.t99.omantel.biz/oidc/auth', HOST),
+    ).toBeUndefined()
+  })
+
+  it('REJECTS a same-host but wrong-subdomain (e.g. grafana.<fqdn>) absolute URL', () => {
+    // Only the control-plane family is trusted for a bare redirect target.
+    expect(
+      sanitizeNextParam('https://grafana.t42.omani.works/login', HOST),
+    ).toBeUndefined()
+  })
+
+  it('REJECTS javascript:/data: schemes regardless of host', () => {
+    expect(sanitizeNextParam('javascript:alert(1)', HOST)).toBeUndefined()
+    expect(sanitizeNextParam('data:text/html,<script>1</script>', HOST)).toBeUndefined()
+  })
+
+  it('falls back to paths-only when no trusted family can be derived', () => {
+    // On localhost (dev) there is no multi-label parent → absolute URLs
+    // are all rejected, relative paths still work.
+    expect(sanitizeNextParam('https://api.t42.omani.works/oidc/auth', 'localhost')).toBeUndefined()
+    expect(sanitizeNextParam('/dashboard', 'localhost')).toBe('/dashboard')
+  })
+
+  it('is port-exact: a mismatched port is rejected', () => {
+    // Current host has no port; an absolute next carrying :8443 is a
+    // different origin and must not be trusted.
+    expect(
+      sanitizeNextParam('https://api.t42.omani.works:8443/oidc/auth', HOST),
+    ).toBeUndefined()
+    // …but matches when the current host carries the same port.
+    expect(
+      sanitizeNextParam(
+        'https://api.t42.omani.works:8443/oidc/auth',
+        'console.t42.omani.works:8443',
+      ),
+    ).toBe('https://api.t42.omani.works:8443/oidc/auth')
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/app/auth-gate.ts
+++ b/products/catalyst/bootstrap/ui/src/app/auth-gate.ts
@@ -40,39 +40,120 @@ export function canonicalisePath(pathname: string): string {
 }
 
 /**
- * Sanitize a `next=` redirect target so it can NEVER point to an
- * external host (open-redirect class CWE-601).
+ * Derive the set of trusted same-Sovereign hostnames from a host that
+ * the UI is currently served on (e.g. `window.location.host`).
  *
- * Rules (strictly reject anything ambiguous — paths only):
+ * A Sovereign exposes three first-party control-plane hosts that all
+ * share the same parent FQDN: `console.<fqdn>` (this UI), `auth.<fqdn>`
+ * (Keycloak), and `api.<fqdn>` (catalyst-api). They are derived by
+ * stripping the first DNS label off the current host and re-prefixing
+ * each canonical label. So from `console.t42.omani.works` we derive
+ * `{console,auth,api}.t42.omani.works`.
+ *
+ * The host may carry a `:port` suffix (dev / non-default-port
+ * deployments). We split it off, derive the family from the bare
+ * hostname, and re-append the same port to every family member so a
+ * `https://api.<fqdn>:8443/...` next survives on a non-default port.
+ *
+ * Returns an empty array when the current host has no parent label to
+ * strip (bare hostname / IP / `localhost`) — in that degenerate case
+ * NO absolute host is trusted and `sanitizeNextParam` falls back to
+ * paths-only, which is the safe default.
+ */
+export const CANONICAL_SOVEREIGN_SUBDOMAINS = ['console', 'auth', 'api'] as const
+
+export function sameSovereignHostFamily(currentHost: string): string[] {
+  if (!currentHost) return []
+  const colon = currentHost.indexOf(':')
+  const hostname = colon === -1 ? currentHost : currentHost.slice(0, colon)
+  const port = colon === -1 ? '' : currentHost.slice(colon)
+  const firstDot = hostname.indexOf('.')
+  // No parent label to strip (bare host / IP / localhost) → trust nothing.
+  if (firstDot <= 0 || firstDot === hostname.length - 1) return []
+  const parentFqdn = hostname.slice(firstDot + 1)
+  // Guard against a parent that is itself a bare label with no dot
+  // (e.g. host `console.local` → parent `local`). A real Sovereign FQDN
+  // is multi-label; refuse to trust a single-label parent.
+  if (!parentFqdn.includes('.')) return []
+  return CANONICAL_SOVEREIGN_SUBDOMAINS.map((label) => `${label}.${parentFqdn}${port}`)
+}
+
+/**
+ * Sanitize a `next=` redirect target so it can NEVER point to an
+ * UNTRUSTED external host (open-redirect class CWE-601).
+ *
+ * Rules:
  *   - If the input is empty / non-string → return undefined.
  *   - Reject embedded NUL / control / whitespace characters.
- *   - Reject explicit URL schemes (`http:`, `https:`, `javascript:`,
- *     `data:`, `file:`, `vbscript:`, `mailto:`, etc).
  *   - Reject backslashes anywhere (some browsers normalize `\` to
  *     `/`, which would smuggle `\\evil.com` past a leading-slash
  *     check).
- *   - Reject anything that doesn't start with a single forward
- *     slash. In particular `//evil.com/foo` is rejected — the
- *     browser parses leading `//` as a protocol-relative authority
- *     reference (host = evil.com).
+ *   - Same-origin relative paths (`/dashboard`, `/provision/...`) pass
+ *     through unchanged, exactly as before. Leading `//` (protocol-
+ *     relative authority) is still rejected.
+ *   - Absolute `http(s)://` URLs are accepted ONLY when their host is
+ *     in the same-Sovereign trusted family (`console.<fqdn>` /
+ *     `auth.<fqdn>` / `api.<fqdn>`) derived from the current origin.
+ *     This is required for the cross-host OAuth `next` continuation
+ *     after PIN-verify: KC's identity broker bounces the operator to
+ *     `/login?next=https://api.<fqdn>/oidc/auth?...` (#3271). Without
+ *     this allowlist, that legitimate same-Sovereign continuation was
+ *     dropped and every app SSO landed the user on the console
+ *     `/dashboard` instead of the target app.
+ *   - Every OTHER absolute host is rejected — `https://evil.com`,
+ *     scheme-relative `//evil.com`, and crucially look-alike suffix
+ *     attacks like `https://api.<fqdn>.evil.com/` (the registrable
+ *     host is `evil.com`, NOT the Sovereign FQDN).
+ *   - Non-`http(s)` schemes (`javascript:`, `data:`, `file:`,
+ *     `vbscript:`, `mailto:`) are rejected outright.
  *
- * Returns the sanitized path, or `undefined` if the input is unsafe
- * — callers should fall back to the default landing page (e.g.
- * `/dashboard` or `/wizard`).
+ * Returns the sanitized target (relative path or trusted absolute
+ * URL), or `undefined` if the input is unsafe — callers fall back to
+ * the default landing page (e.g. `/dashboard` or `/wizard`).
+ *
+ * The current host is read from `window.location.host` by default but
+ * may be passed explicitly so the function stays pure + unit-testable
+ * without a DOM.
  *
  * qa-loop iter-4 cluster `users-page-null-map-and-open-redirect`
- * (TC-009 / 2026-05-09 routing matrix). The contract: post-login
- * navigation MUST land on the same origin under all circumstances.
+ * (TC-009 / 2026-05-09 routing matrix) + #3271 cross-host SSO
+ * continuation. The contract: post-login navigation MUST land on the
+ * same Sovereign under all circumstances — never off it.
  */
-export function sanitizeNextParam(raw: unknown): string | undefined {
+export function sanitizeNextParam(
+  raw: unknown,
+  currentHost: string | undefined = typeof window !== 'undefined'
+    ? window.location.host
+    : undefined,
+): string | undefined {
   if (typeof raw !== 'string' || raw.length === 0) return undefined
-  // Reject embedded NULs / control chars / any whitespace.
+  // Reject embedded NULs / control chars / any whitespace. The control
+  // range is intentional (we are screening for exactly those bytes).
+  // eslint-disable-next-line no-control-regex
   if (/[\x00-\x1f\s]/.test(raw)) return undefined
   // Reject backslashes anywhere — some browsers normalize `\` to `/`
   // before parsing, so `/\evil.com` and `\\evil.com` end up host
   // references at runtime.
   if (raw.indexOf('\\') !== -1) return undefined
-  // Reject schemes (http:, https:, javascript:, data:, file:, mailto:,
+
+  // Absolute http(s) URL → allow ONLY if the host is in the trusted
+  // same-Sovereign family. Any other absolute host is an open-redirect.
+  if (/^https?:\/\//i.test(raw)) {
+    let parsed: URL
+    try {
+      parsed = new URL(raw)
+    } catch {
+      return undefined
+    }
+    const family = sameSovereignHostFamily(currentHost ?? '')
+    // `parsed.host` includes the port if present — `family` members
+    // carry the same port suffix, so this comparison is port-exact and
+    // rejects look-alike suffix hosts (api.<fqdn>.evil.com → host is
+    // api.<fqdn>.evil.com which is not a family member).
+    if (family.includes(parsed.host)) return raw
+    return undefined
+  }
+  // Reject any other scheme (javascript:, data:, file:, mailto:,
   // vbscript:, etc.). A scheme is `<alpha>[<alpha>|<digit>|+|.|-]*:`.
   if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(raw)) return undefined
   // Require single-leading-slash absolute path. Reject leading `//`

--- a/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.test.tsx
@@ -77,6 +77,8 @@ beforeEach(() => {
     writable: true,
     value: {
       ...window.location,
+      host: 'console.t42.omani.works',
+      hostname: 'console.t42.omani.works',
       pathname: '/',
       href: 'http://test/login/verify',
       replace: replaceSpy,
@@ -147,5 +149,62 @@ describe('VerifyPinPage — post-PIN-verify default landing (BUG-015 / D23)', ()
       expect(replaceSpy).toHaveBeenCalledTimes(1)
     })
     expect(replaceSpy).toHaveBeenCalledWith('/apps')
+  })
+
+  it('navigates verbatim to a same-Sovereign absolute OAuth next (#3271 walk)', async () => {
+    // KC's identity-broker bounce after PIN-verify carries the OAuth
+    // continuation as an absolute cross-host URL on api.<fqdn>. The page
+    // must hard-navigate there verbatim — NOT drop the user on
+    // /dashboard (the original #3271 bug) and NOT mangle the URL with
+    // the relative-path basepath rewrite.
+    mockMode = 'sovereign'
+    const oauthNext =
+      'https://api.t42.omani.works/oidc/auth?client_id=catalyst-pin' +
+      '&redirect_uri=https://auth.t42.omani.works/realms/sovereign/broker/catalyst-pin/endpoint' +
+      '&state=xyz&response_type=code'
+    searchState.current = {
+      email: 'emrah.baysal@openova.io',
+      requestId: 'req-1',
+      next: oauthNext,
+    }
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { getByTestId } = render(<VerifyPinPage />)
+    fireEvent.click(getByTestId('pin-complete-stub'))
+
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenCalledTimes(1)
+    })
+    expect(replaceSpy).toHaveBeenCalledWith(oauthNext)
+  })
+
+  it('rejects an off-Sovereign absolute next and falls back to /dashboard', async () => {
+    // Open-redirect defense: an attacker-supplied https://evil.com next
+    // must be dropped — the operator lands on the Sovereign default.
+    mockMode = 'sovereign'
+    searchState.current = {
+      email: 'emrah.baysal@openova.io',
+      requestId: 'req-1',
+      next: 'https://evil.com/phish',
+    }
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { getByTestId } = render(<VerifyPinPage />)
+    fireEvent.click(getByTestId('pin-complete-stub'))
+
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenCalledTimes(1)
+    })
+    expect(replaceSpy).toHaveBeenCalledWith('/dashboard')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.tsx
@@ -137,6 +137,17 @@ export function VerifyPinPage() {
         const sovereignDefault =
           DETECTED_MODE.mode === 'sovereign' ? '/dashboard' : '/wizard'
         let target = sanitizeNextParam(next) ?? sovereignDefault
+        // #3271: an absolute same-Sovereign continuation (e.g.
+        // `https://api.<fqdn>/oidc/auth?...` from KC's identity-broker
+        // bounce) must be navigated to verbatim. The basepath-rewrite
+        // below is for relative `/...` paths on Catalyst-Zero only — it
+        // would corrupt an absolute URL. sanitizeNextParam has already
+        // proven the host is in the trusted {console,auth,api}.<fqdn>
+        // family, so this hard-navigation can never go off-Sovereign.
+        if (typeof window !== 'undefined' && /^https?:\/\//i.test(target)) {
+          window.location.replace(target)
+          return
+        }
         if (typeof window !== 'undefined') {
           // window.location.replace is a HARD navigation — it bypasses
           // the TanStack Router's basepath config. On contabo the SPA


### PR DESCRIPTION
## Problem

After a real PIN-verify, app SSO authenticates successfully (200 `{"ok":true}`, session cookie set) but the operator lands on console `/dashboard` instead of the target app (grafana/gitea/harbor/openbao). The cross-host OAuth `next` continuation is silently dropped at PIN-verify.

## Root cause

KC's identity-broker bounces the operator to a legitimate same-Sovereign cross-host URL:

```
/login?next=https://api.<fqdn>/oidc/auth?...&redirect_uri=https://auth.<fqdn>/realms/sovereign/broker/catalyst-pin/endpoint
```

`sanitizeNextParam` (`auth-gate.ts`) rejected **every** absolute URL (open-redirect defense), so the continuation returned `undefined` and `VerifyPinPage` fell back to the sovereign default `/dashboard`. The OAuth code-grant round-trip never completed, so the app never received an authorization code.

`oidcprovider/provider.go:415` even documents the expectation that `sanitizeNextParam` "already enforces" same-host `next` — but it did not. This change makes that comment true.

## Fix

`sanitizeNextParam` now ACCEPTS an absolute `http(s)://` next **iff its host is in the same-Sovereign trusted family** `{console,auth,api}.<fqdn>`, derived from the current origin by stripping the first DNS label. Every other absolute host is still rejected, preserving CWE-601 open-redirect protection.

Rejected (covered by tests):
- `https://evil.com`, `http://evil.com`
- look-alike suffix attack `https://api.<fqdn>.evil.com/` (registrable host is `evil.com`)
- userinfo smuggling `https://api.<fqdn>@evil.com/`
- cross-Sovereign FQDN `https://api.t99.omantel.biz/`
- non-control-plane subdomain `https://grafana.<fqdn>/`
- protocol-relative `//evil.com`, `javascript:`/`data:` schemes
- wrong-port (the check is port-exact)
- falls back to paths-only when no multi-label parent FQDN can be derived (localhost/dev)

`VerifyPinPage` hard-navigates to an absolute trusted target verbatim, bypassing the relative-path basepath rewrite (which is Catalyst-Zero-only and would corrupt an absolute URL).

### Server-side kcBrokerURL — intentionally NOT re-enabled

`buildKCBrokerURL` is dormant on purpose (`auth.go:797-821`): the `/broker/<alias>/login` pre-flight is rejected by Keycloak as `invalidRequestMessage` on direct invocation, and the realm session bootstraps naturally on the first per-app SSO redirect. Re-enabling it would reintroduce a known-broken flow. The client-side allowlist alone fixes the walk by routing the browser back through the working `/oidc/auth` continuation. No TS/Go `json:` tag was added, so the field-casing class of bug does not apply.

## Tests

- `sameSovereignHostFamily`: label-strip derivation, `:port` preservation, refuses single-label/bare/localhost parents.
- `sanitizeNextParam`: accepts `api.`/`auth.`/`console.<fqdn>` absolute + relative paths; rejects evil.com, suffix attack, userinfo, cross-Sovereign, non-control-plane subdomain, protocol-relative, schemes, wrong-port.
- `VerifyPinPage`: navigates verbatim to the absolute OAuth `next`; falls back to `/dashboard` for an off-Sovereign `next`.

All auth tests green (71 passed). `tsc -b --noEmit` clean. eslint clean on changed files.

The catalyst-ui image tag is auto-bumped by `catalyst-build.yaml` on merge (ui-deployment.yaml comment) — no manual chart/image pin bump required.

## Honest status

NOT verified on a live Sovereign. Needs a fresh-prov grafana SSO walk to confirm the operator lands logged-in *inside* the app (per the "wire-proof != lands-logged-in" rule).

Refs #3271 #3263