### PR TITLE
fix(kyverno-policies): systemic mutate stamps cilium-enforced label cohort-wide (#3268)

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -82,7 +82,20 @@ spec:
       # Per-policy `extraExcludeNamespaces` (NOT the shared anchor): every other
       # policy stays enforced in those namespaces. Verified two-directionally on
       # the same kind + kyverno v1.18 harness. See Chart.yaml for the full RCA.
-      version: 1.0.30
+      # 1.0.31 (Refs #3268 #3263, 2026-06-11): SYSTEMIC inoculation — NEW MUTATE
+      # policy `stamp-cilium-enforced-label` auto-stamps
+      # `policy.cilium.io/enforced: "true"` on the Pod template of every always-on
+      # workload that lacks it, BEFORE 09-cilium-l7-mtls validates. The apiserver
+      # runs mutating webhooks before validating webhooks in one admission request,
+      # so the stamp lands → 09 admits — fixing 30 of the 34 charts in #3268 at the
+      # owning layer instead of 30 per-chart PRs. The label is INERT on the
+      # dataplane (Catalyst-internal marker; WireGuard does east-west mTLS
+      # unconditionally; SPIFFE mutual-auth OFF). Verified mutate-before-validate
+      # on the same kind + kyverno v1.18 harness. The 26 charts with non-proxy
+      # images still need the per-chart 11-harbor-proxy fix (a cluster-wide image-
+      # rewrite mutate can't know the per-Sovereign Harbor host without re-tethering
+      # to the mothership → Pillar 5 violation). See Chart.yaml for the full RCA.
+      version: 1.0.31
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.30
+  version: 1.0.31
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -1,5 +1,36 @@
 apiVersion: v2
 name: bp-kyverno-policies
+# 1.0.31 (Refs #3268 #3263, 2026-06-11): SYSTEMIC inoculation — NEW MUTATE policy
+# `stamp-cilium-enforced-label` (templates/mutate/00-...) auto-stamps
+# `policy.cilium.io/enforced: "true"` on the Pod template of every always-on
+# bootstrap-kit workload that lacks it, BEFORE the 09-cilium-l7-mtls VALIDATE
+# baseline evaluates the same admission request. The kube-apiserver runs MUTATING
+# webhooks before VALIDATING webhooks within one request, so the stamp lands and
+# 09 admits — fixing 30 of the 34 charts inventoried in #3268 at the owning layer
+# instead of 30 per-chart label PRs (and future Blueprints for free). VERIFIED on
+# a kind + kyverno v1.18 harness (matches the bp-kyverno engine pin): a Deployment
+# missing the label was DENIED by 09 with the mutate absent, and ADMITTED with the
+# label stamped on `spec.template.metadata.labels` once the mutate was present;
+# an already-compliant Deployment was admitted UNCHANGED (idempotent via the
+# `+(label)` add-when-missing anchor + a request.object precondition — the
+# precondition is also what makes kyverno v1.18 register the resource mutating
+# webhook at all). SAFETY: `policy.cilium.io/enforced` is a Catalyst-internal
+# marker for the not-yet-shipped catalyst-network-controller (EPIC-5 #1100);
+# Cilium upstream ignores it, WireGuard provides east-west mTLS unconditionally,
+# and SPIFFE mutual-auth is OFF (bp-spire deferred) — so the label is INERT on the
+# dataplane and safe to add broadly. A companion "Mutate B" (rewrite upstream
+# images to the Harbor proxy, to fix the 11-harbor-proxy-pull violations on 26
+# charts) was DESIGNED + proven idempotent on the SAME harness but DELIBERATELY
+# NOT shipped: a static cluster-wide mutate cannot know the per-Sovereign Harbor
+# host (`registry.<sov-fqdn>` post-cutover), and the only host it could hardcode
+# is the mothership `harbor.openova.io` — which would re-tether sovereign clusters
+# to the mothership and violate Pillar 5 / Principle #11 (the whole point of
+# bp-self-sovereign-cutover). The docker proxy-project name is also drifted
+# (`proxy-dockerhub` in 111 chart refs vs `proxy-docker`/`proxy-xpkg`/`proxy-ecr`
+# in the cutover config — live mothership Harbor only has proxy-dockerhub/ghcr/
+# gcr/k8s/quay), so a hardcoded rewrite would ImagePullBackOff some Sovereigns —
+# strictly worse than a visible kyverno deny. The 26 charts with non-proxy images
+# stay on the per-chart fix path; they are listed in the PR body.
 # 1.0.30 (Refs #2737 #3236 #3248, 2026-06-11): EXCLUDE the operator-managed
 # data-plane namespaces (`cnpg`, `shared-data`, `powerdns-admin`) from the
 # `flux-managed` (10) Enforce policy. The CNPG operator creates Services
@@ -123,7 +154,7 @@ type: application
 # while keeping proxy-cache for anonymous public registries.
 # Lockstep with bp-self-sovereign-cutover 0.1.43 (Step 03 Phase A
 # skopeo native-push + Step 07 REGISTRY drops /proxy-ghcr/ suffix).
-version: 1.0.30
+version: 1.0.31
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/templates/mutate/00-stamp-cilium-enforced-label.yaml
+++ b/platform/kyverno-policies/chart/templates/mutate/00-stamp-cilium-enforced-label.yaml
@@ -1,0 +1,126 @@
+{{/*
+SYSTEMIC FIX (Refs #3268 #3263, 2026-06-11) — auto-stamp
+`policy.cilium.io/enforced: "true"` on the Pod template of every always-on
+bootstrap-kit workload, BEFORE the 09-cilium-l7-mtls VALIDATE baseline runs.
+
+WHY A MUTATE INSTEAD OF 34 PER-CHART PRs
+  The 09-cilium-l7-mtls baseline (Enforce on hw126 post-handover) requires the
+  label `policy.cilium.io/enforced: "true"` on `spec.template.metadata.labels`
+  of every Deployment/StatefulSet/DaemonSet. 30 of the 34 always-on wrapper
+  charts inventoried in #3268 do NOT stamp it (only catalyst-platform, cnpg-pair,
+  powerdns-admin, sso-bridge do). Each one DENIES at admission on its next roll.
+
+  Within ONE admission request the kube-apiserver runs MUTATING webhooks BEFORE
+  VALIDATING webhooks (admission-controller phase order, K8s API reference). Both
+  Kyverno webhooks are registered on the same request. So a Kyverno `type: mutate`
+  ClusterPolicy that ADDS the missing label runs first; the `type: validate`
+  09 baseline then sees the already-mutated object and PASSES. One policy at the
+  owning layer fixes the whole cohort — including future Blueprints — with no
+  chart-side cooperation. (Mutate-before-validate ordering VERIFIED empirically
+  on a kind + kyverno v1.18 harness — a Deployment missing the label was ADMITTED
+  with the label stamped; see the PR body for the exact commands + outputs.)
+
+  AUTOGEN: this policy carries ONE explicit `Pod` rule. Kyverno autogen expands it
+  into controller variants matching Deployment/StatefulSet/DaemonSet/Job/ReplicaSet/
+  ReplicationController (patching `spec.template.metadata.labels`) and CronJob
+  (patching `spec.jobTemplate.spec.template.metadata.labels`) — VERIFIED in the
+  harness via `kubectl get cpol ... -o json` autogen rules + the live resource
+  mutating webhook covering all those kinds. No hand-written per-controller rule
+  is needed (and the autogen variants are what 09 actually sees on a Deployment).
+
+  PRECONDITION (required, not cosmetic): the `preconditions` clause that reads
+  `request.object.metadata.labels."policy.cilium.io/enforced"` is what makes
+  Kyverno v1.18 register the resource MUTATING webhook for this policy at all.
+  A pure `+(...)` conditional-anchor patch with no precondition was observed in
+  the harness to NOT register a mutating webhook (the patch was treated as
+  no-op-eligible) → the label never stamped → 09 denied. With the precondition
+  the webhook registers across all controller kinds and the mutate fires. The
+  precondition is also a natural idempotency guard (skip when already present).
+
+SAFETY — IS THE LABEL INERT ON THE DATAPLANE?
+  YES on every Sovereign shipped today. `policy.cilium.io/enforced` is a
+  Catalyst-INTERNAL marker consumed by the (future, not-yet-shipped)
+  catalyst-network-controller (EPIC-5 #1100), per the 09 policy's own comment.
+  Cilium upstream does NOTHING with this label. East-west encryption is provided
+  unconditionally by `encryption.type: wireguard` + `nodeEncryption: true`
+  (platform/cilium/chart/values.yaml) for ALL traffic regardless of any label,
+  and Cilium SPIFFE/SPIRE per-connection mutual auth (`authentication.mutual`)
+  is NOT enabled (bp-spire deferred — see cilium values.yaml comment). So adding
+  the label changes ZERO dataplane behavior; it only satisfies the Kyverno gate
+  and pre-stamps the label the future controller will look for. Safe to add
+  broadly. If a future Sovereign overlay turns on Cilium L7 mutual-auth, narrow
+  this policy's scope (it is fully `.Values`-gated + namespace-scoped).
+
+IDEMPOTENCY
+  `+(label)` adds only when MISSING; the precondition additionally short-circuits
+  when the label is already set. A chart that already stamps the label
+  (catalyst-platform etc.) is left untouched (VERIFIED: an already-compliant
+  Deployment was admitted with the label still exactly `"true"`, not doubled).
+  The `selector.matchLabels` of the workload is the IMMUTABLE field; this policy
+  patches ONLY the Pod-template labels (via autogen), never the selector, so it
+  cannot wedge an existing Deployment's immutable-field update.
+
+SCOPE
+  EXCLUDE the same namespace set the baseline policies exempt (the shared
+  `excludeNamespaces` anchor) so we never touch system / vCluster / sso-bridge /
+  control-plane namespaces. Gated by
+  `.Values.compliancePolicies.ciliumEnforcedLabelMutate.enabled`.
+*/}}
+{{- if and (hasKey .Values.compliancePolicies "ciliumEnforcedLabelMutate") .Values.compliancePolicies.ciliumEnforcedLabelMutate.enabled -}}
+{{- $excludeNs := .Values.compliancePolicies.ciliumEnforcedLabelMutate.excludeNamespaces -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: stamp-cilium-enforced-label
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: security
+  annotations:
+    policies.kyverno.io/title: Auto-stamp policy.cilium.io/enforced on Pod templates
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      MUTATE policy: stamp `policy.cilium.io/enforced: "true"` on the Pod
+      template of every always-on workload that lacks it (via Kyverno autogen
+      across Deploy/SS/DS/Job/CronJob), so the 09-cilium-l7-mtls VALIDATE
+      baseline admits it. Runs in the mutating-webhook phase BEFORE the
+      validate phase of the same admission request.
+spec:
+  # MUTATE on admission only (no background scan needed; nothing to mutate on
+  # already-admitted objects). Matches app-label-mutate (21).
+  background: false
+  rules:
+    # ONE Pod rule; Kyverno autogen expands it to every Pod-template-bearing
+    # controller (Deploy/SS/DS/Job/ReplicaSet/ReplicationController →
+    # spec.template.metadata.labels; CronJob → spec.jobTemplate.spec.template…).
+    - name: stamp-pod-label
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := $excludeNs }}
+                - {{ $ns }}
+                {{- end }}
+      preconditions:
+        all:
+          # Fire only when the label is ABSENT. Doubles as the registration
+          # trigger for the resource mutating webhook on kyverno v1.18 (a
+          # precondition-less +(...) patch does not register the webhook).
+          - key: {{ `"{{ request.object.metadata.labels.\"policy.cilium.io/enforced\" || '' }}"` }}
+            operator: Equals
+            value: ""
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            labels:
+              # `+(label)` only adds when absent — never overrides a chart-set
+              # or operator-set value.
+              +(policy.cilium.io/enforced): "true"
+{{- end -}}

--- a/platform/kyverno-policies/chart/tests/fixtures/README.md
+++ b/platform/kyverno-policies/chart/tests/fixtures/README.md
@@ -38,3 +38,31 @@ exactly one (per workload).
 
 The remaining 15 policies' fixtures are deferred — slice S1 ships the
 authoritative matrix.
+
+## MUTATE policy fixtures (Refs #3268)
+
+`stamp-cilium-enforced-label` is a MUTATE policy, so its fixtures are
+"needs-mutate" (the label is added) vs "already-stamped" (no-op / idempotent),
+rather than pass/fail validate cases.
+
+| Policy | Needs-mutate fixture | Idempotent fixture |
+|---|---|---|
+| stamp-cilium-enforced-label | `cilium-enforced-label-mutate/needs-mutate-deployment.yaml` | `cilium-enforced-label-mutate/already-stamped-deployment.yaml` |
+
+```bash
+helm template . --set compliancePolicies.bootstrapMode=false \
+  --set compliancePolicies.ciliumEnforcedLabelMutate.enabled=true \
+  --show-only templates/mutate/00-stamp-cilium-enforced-label.yaml > /tmp/mutate.yaml
+
+# needs-mutate → emits a patched resource with policy.cilium.io/enforced: "true"
+kyverno apply /tmp/mutate.yaml \
+  --resource tests/fixtures/cilium-enforced-label-mutate/needs-mutate-deployment.yaml
+# already-stamped → no mutation (resource unchanged)
+kyverno apply /tmp/mutate.yaml \
+  --resource tests/fixtures/cilium-enforced-label-mutate/already-stamped-deployment.yaml
+```
+
+The end-to-end mutate-before-validate proof (admission-time ordering against
+the REAL 09/11 Enforce baselines on a kind + kyverno v1.18 cluster) is captured
+in the PR body — `kyverno apply` exercises only the policy logic offline, not
+the apiserver's webhook phase ordering.

--- a/platform/kyverno-policies/chart/tests/fixtures/cilium-enforced-label-mutate/already-stamped-deployment.yaml
+++ b/platform/kyverno-policies/chart/tests/fixtures/cilium-enforced-label-mutate/already-stamped-deployment.yaml
@@ -1,0 +1,39 @@
+# IDEMPOTENCY fixture (Refs #3268) — a Deployment that ALREADY carries
+# `policy.cilium.io/enforced: "true"` on its Pod template. Under the
+# `stamp-cilium-enforced-label` mutate policy this resource is left UNCHANGED:
+# the rule precondition short-circuits (label already present) and the
+# `+(label)` add-when-missing anchor would not override it anyway. Charts that
+# already stamp the label (bp-catalyst-platform, bp-cnpg-pair, bp-powerdns-admin,
+# bp-sso-bridge) match this shape and must not be touched.
+#
+#   kyverno apply /tmp/mutate.yaml \
+#     --resource tests/fixtures/cilium-enforced-label-mutate/already-stamped-deployment.yaml
+#
+# Expect: no mutation (resource unchanged).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: already-stamped
+  namespace: harbor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: already-stamped
+  template:
+    metadata:
+      labels:
+        app: already-stamped
+        policy.cilium.io/enforced: "true"   # already present — must stay exactly this
+    spec:
+      containers:
+        - name: app
+          image: harbor.openova.io/proxy-ghcr/openova-io/openova/example:1.2.3
+          livenessProbe:
+            httpGet: { path: /healthz, port: 8080 }
+          readinessProbe:
+            httpGet: { path: /ready, port: 8080 }
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi

--- a/platform/kyverno-policies/chart/tests/fixtures/cilium-enforced-label-mutate/needs-mutate-deployment.yaml
+++ b/platform/kyverno-policies/chart/tests/fixtures/cilium-enforced-label-mutate/needs-mutate-deployment.yaml
@@ -1,0 +1,39 @@
+# MUTATE fixture (Refs #3268) — a Deployment that LACKS
+# `policy.cilium.io/enforced` on its Pod template. Under the
+# `stamp-cilium-enforced-label` mutate policy, `kyverno apply --cluster=false`
+# in mutate mode emits a patched resource whose
+# `spec.template.metadata.labels` now contains
+# `policy.cilium.io/enforced: "true"`. This is the workload shape that would
+# otherwise be DENIED by 09-cilium-l7-mtls on its next roll.
+#
+#   kyverno apply /tmp/mutate.yaml \
+#     --resource tests/fixtures/cilium-enforced-label-mutate/needs-mutate-deployment.yaml
+#
+# Expect: a mutation result that adds the enforced label.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: needs-enforced-label
+  namespace: harbor   # any non-excluded bootstrap-kit namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: needs-enforced-label
+  template:
+    metadata:
+      labels:
+        app: needs-enforced-label
+        # NOTE: policy.cilium.io/enforced is intentionally ABSENT here.
+    spec:
+      containers:
+        - name: app
+          image: harbor.openova.io/proxy-ghcr/openova-io/openova/example:1.2.3
+          livenessProbe:
+            httpGet: { path: /healthz, port: 8080 }
+          readinessProbe:
+            httpGet: { path: /ready, port: 8080 }
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi

--- a/platform/kyverno-policies/chart/values.yaml
+++ b/platform/kyverno-policies/chart/values.yaml
@@ -352,3 +352,29 @@ compliancePolicies:
   appLabelMutate:
     enabled: true
     excludeNamespaces: *complianceDefaultExcludes
+
+  # SYSTEMIC FIX (Refs #3268 #3263, 2026-06-11) — MUTATE policy that auto-stamps
+  # `policy.cilium.io/enforced: "true"` on the Pod template of every always-on
+  # workload that lacks it, BEFORE the 09-cilium-l7-mtls VALIDATE baseline runs.
+  #
+  # 30 of the 34 always-on bootstrap-kit charts inventoried in #3268 do NOT set
+  # this label — each one DENIES at admission on its next roll once the baseline
+  # enforces post-handover (proven live on keycloak hw126). The kube-apiserver
+  # runs MUTATING webhooks BEFORE VALIDATING webhooks in the SAME admission
+  # request, so this mutate stamps the missing label and the 09 validate then
+  # admits the (already-mutated) object. ONE policy fixes the whole cohort —
+  # including future Blueprints — instead of 30 per-chart label PRs.
+  # Mutate-before-validate verified on a kind + kyverno v1.18 harness (see
+  # template header + PR #3268-ref body).
+  #
+  # SAFETY: `policy.cilium.io/enforced` is a Catalyst-internal marker consumed by
+  # the (not-yet-shipped) catalyst-network-controller (EPIC-5 #1100). Cilium
+  # upstream does NOTHING with it; east-west mTLS is provided unconditionally by
+  # WireGuard (`encryption.type: wireguard`) and SPIFFE per-connection mutual auth
+  # is NOT enabled (bp-spire deferred). The label is therefore INERT on the
+  # dataplane today — adding it changes zero traffic behavior, only satisfies the
+  # Kyverno gate. Enabled by default (non-rejecting MUTATE cannot block any
+  # workload; the `+(label)` add-when-missing + precondition make it idempotent).
+  ciliumEnforcedLabelMutate:
+    enabled: true
+    excludeNamespaces: *complianceDefaultExcludes


### PR DESCRIPTION
## What

Inoculates the entire always-on bootstrap-kit chart cohort against the now-enforced `09-cilium-l7-mtls` baseline with **one** mutate `ClusterPolicy` at the owning (kyverno) layer, instead of 30 per-chart label PRs.

New `platform/kyverno-policies/chart/templates/mutate/00-stamp-cilium-enforced-label.yaml` — a `type: mutate` `ClusterPolicy` that stamps `policy.cilium.io/enforced: "true"` onto the Pod template of every always-on workload that lacks it.

## The mechanic

Within ONE admission request the kube-apiserver runs **MUTATING webhooks before VALIDATING webhooks**. Both Kyverno webhooks are registered on the same request, so the mutate adds the missing label first; the `09` validate baseline then sees the already-mutated object and admits it. Kyverno autogen expands the single `Pod` rule into controller variants (Deploy/SS/DS/Job/ReplicaSet/ReplicationController → `spec.template.metadata.labels`; CronJob → `spec.jobTemplate.spec.template…`), which is exactly what `09` evaluates on a Deployment. Fixes **30 of the 34** charts inventoried in #3268, plus future Blueprints, with no chart-side cooperation.

## Mutate-before-validate: VERIFIED on kind + kyverno v1.18

kind v0.24.0, kyverno helm chart `3.8.0` (image `reg.kyverno.io/kyverno/kyverno:v1.18.0` — matches the `bp-kyverno` engine pin `platform/kyverno/chart/Chart.yaml` appVersion `v1.18.0`). Applied the REAL rendered `09` + `11` baselines in **Enforce** (`--set compliancePolicies.bootstrapMode=false`) + the new mutate, into a non-excluded namespace `landmine-test`.

```
$ helm template kp . --set compliancePolicies.bootstrapMode=false \
    --show-only templates/baseline/09-cilium-l7-mtls.yaml \
    --show-only templates/baseline/11-harbor-proxy.yaml > baseline-09-11.yaml
$ grep validationFailureAction baseline-09-11.yaml
  validationFailureAction: Enforce
  validationFailureAction: Enforce

$ kubectl get cpol
NAME                          ADMISSION   BACKGROUND   READY
cilium-l7-mtls                true        true         True
harbor-proxy-pull             true        true         True
stamp-cilium-enforced-label   true        false        True

# resource mutating webhook registered by the mutate (covers all controllers):
$ kubectl get mutatingwebhookconfigurations kyverno-resource-mutating-webhook-cfg -o json | ...
mutate.kyverno.svc-fail -> ['cronjobs','daemonsets','deployments','jobs','pods',
                            'pods/ephemeralcontainers','replicasets',
                            'replicationcontrollers','statefulsets']
```

**PROOF 1 — Deployment missing the label + a compliant image → ADMITTED, label stamped:**
```
$ kubectl apply -f test1-missing-label.yaml          # template has NO policy.cilium.io/enforced
deployment.apps/t1-missing-label created
$ kubectl get deploy t1-missing-label -o jsonpath='{.spec.template.metadata.labels}'
{"app":"t1","policy.cilium.io/enforced":"true"}      # <-- mutate stamped it; 09 then admitted
```
With the mutate **absent**, the identical Deployment is DENIED:
```
admission webhook "validate.kyverno.svc-fail" denied the request:
cilium-l7-mtls: cilium-enforced-label: '... missing label
`policy.cilium.io/enforced: "true"` on spec.template.metadata.labels ...
failed at path /spec/template/metadata/labels/policy.cilium.io/enforced/'
```

**PROOF 2 — already-compliant Deployment → admitted UNCHANGED (idempotent):**
```
$ kubectl get deploy already-compliant -o jsonpath='enforced={.spec.template.metadata.labels.policy\.cilium\.io/enforced}'
enforced=true        # exactly "true", not doubled / not overridden
```

**PROOF 3 — the bare `docker.io/bitnamilegacy/keycloak` shape from the brief:** the label gets mutated, but the **non-proxy image is still DENIED by `11`** — confirming Mutate A fixes `09` only, and charts with non-proxy images still need the `11` fix:
```
$ kubectl apply -f test-keycloak.yaml   # StatefulSet, image docker.io/bitnamilegacy/keycloak:25.0.6
admission webhook denied: harbor-proxy-pull: ... Re-tag the image to pull through
the Sovereign's local Harbor ... failed at path /spec/template/spec/containers/0/image/
```

**`mutateBeforeValidateConfirmed: true`.**

A subtle kyverno v1.18 finding baked into the policy: a `patchStrategicMerge` with only a `+(...)` conditional anchor and **no** `preconditions` does NOT register a resource mutating webhook (the patch is treated as no-op-eligible) → the label never lands → `09` denies. Adding a `preconditions` clause that reads `request.object.metadata.labels."policy.cilium.io/enforced"` registers the webhook across all controller kinds. The precondition is also the idempotency guard.

## Safety — the label is INERT on the dataplane today

`policy.cilium.io/enforced` is a **Catalyst-internal marker** consumed by the (not-yet-shipped) catalyst-network-controller (EPIC-5 #1100), per the `09` policy's own comment. Cilium upstream does nothing with it. On every Sovereign shipped today:
- East-west mTLS is provided **unconditionally** by `encryption.type: wireguard` + `nodeEncryption: true` (`platform/cilium/chart/values.yaml`), for all traffic regardless of any label.
- SPIFFE/SPIRE per-connection mutual auth (`authentication.mutual`) is **NOT enabled** (`bp-spire` deferred — see the cilium values comment).

So adding the label changes **zero** dataplane behavior; it only satisfies the Kyverno gate (and pre-stamps the label the future controller will look for). `ciliumL7Active: false`. If a future Sovereign overlay turns on Cilium L7 mutual-auth, narrow the policy scope (it is fully `.Values`-gated + namespace-scoped). The mutate excludes the same namespace set the baseline policies exempt (the shared `complianceDefaultExcludes` anchor: system / vCluster `dmz`/`mgmt`/`rtz` / `sso-bridge` / control-plane).

## Mutate B (image rewrite) — designed, proven idempotent, DELIBERATELY NOT shipped

Mutate B (rewrite upstream images → Harbor proxy, to clear the `11-harbor-proxy-pull` violations) was built and proven on the **same harness**:
```
# per-registry foreach + regex_replace, idempotency-anchored on ^docker.io/ etc.
$ kubectl get pod bpod -o jsonpath='{range .spec.containers[*]}{.name}={.image}\n{end}'
dh=harbor.openova.io/proxy-dockerhub/bitnamilegacy/keycloak:25.0.6     # docker.io/... rewritten
gh=harbor.openova.io/proxy-ghcr/stakater/reloader:v1.0.0              # ghcr.io/... rewritten
already=harbor.openova.io/proxy-dockerhub/library/redis:7            # already-harbor → UNCHANGED (idempotent)
```
The mechanic works and is idempotent. But it **cannot be shipped safely as a static cluster-wide policy:**

1. **Per-Sovereign host is unknowable at admission time.** Post-cutover the Harbor host is `registry.<sov-fqdn>` (varies per Sovereign; `11` is host-agnostic `*/proxy-*/*` for exactly this reason). A mutate has no Helm templating / no FQDN. The only host it could hardcode is the mothership `harbor.openova.io` — which would **re-tether sovereign clusters to the mothership and violate Pillar 5 / Principle #11** (the whole point of `bp-self-sovereign-cutover`).
2. **The docker proxy-project name is drifted.** Charts use `proxy-dockerhub` (111 refs); the cutover config (`platform/self-sovereign-cutover/chart/values.yaml`) declares `proxy-docker` + `proxy-xpkg` + `proxy-ecr`. The **live mothership Harbor** (`GET https://harbor.openova.io/api/v2.0/projects`) actually has only: `proxy-dockerhub`, `proxy-ghcr`, `proxy-gcr`, `proxy-k8s`, `proxy-quay`. A hardcoded rewrite would `ImagePullBackOff` some Sovereigns — **strictly worse** than a visible kyverno deny (which is at least recoverable + diagnosable).

Per the brief's explicit instruction, Mutate B is excluded and these registries stay on the per-chart fix path.

### Charts still needing the per-chart `11-harbor-proxy-pull` fix (27)

`bp-openbao` (08), `bp-harbor` (19), `bp-gitea` (10), `bp-external-secrets` (15), `bp-powerdns` (11), `bp-external-dns` (12), `bp-valkey` (17 — also `12` `:latest`), `bp-nats-jetstream` (07), `bp-coraza` (35), `bp-velero` (34), `bp-grafana` (25), `bp-mimir` (23), `bp-loki` (22), `bp-tempo` (24), `bp-alloy` (21), `bp-opentelemetry` (20), `bp-opentelemetry-operator` (19c), `bp-seaweedfs` (18), `bp-trivy` (30), `bp-falco` (31), `bp-sigstore` (32), `bp-syft-grype` (33), `bp-reflector` (05a), `bp-reloader` (28), `bp-crossplane` (04), `bp-vpa` (29), `bp-cluster-autoscaler-hcloud` (50). (`bp-keycloak` is owned by another agent / #3267.)

## Lockstep

- `bp-kyverno-policies` Chart.yaml `1.0.30` → `1.0.31`
- `blueprint.yaml` `spec.version` `1.0.30` → `1.0.31`
- slot 27a pin (`clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml`) `1.0.30` → `1.0.31`
- new `compliancePolicies.ciliumEnforcedLabelMutate` value gate (default enabled)
- mutate fixtures (`needs-mutate` + idempotent `already-stamped`)

Render checks: `helm lint` passes; default render now has 21 ClusterPolicies (was 20); mutate gated off when `ciliumEnforcedLabelMutate.enabled=false`.

Refs #3268 #3263

🤖 Generated with [Claude Code](https://claude.com/claude-code)
