### PR TITLE
feat(catalyst-ui): surface ADR-0010 Data instances view in the deployed console

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/dataInstances.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/dataInstances.ts
@@ -1,0 +1,143 @@
+/**
+ * dataInstances.ts — the ADR-0010 "Data instances" model, ported into the
+ * DEPLOYED React operator console (catalyst-ui).
+ *
+ * Background: the ADR-0010 reusable/shareable backing-services view first
+ * shipped in the Svelte console (`core/console/src/lib/dataInstances.ts` +
+ * `DataInstances.svelte`), but that console is built as the `console`
+ * image and deployed UNROUTED in the `sme` namespace — the founder can't
+ * reach it. This module + the companion `DataInstances.tsx` surface the
+ * SAME view in catalyst-ui (served at console.<fqdn>), where the founder
+ * actually looks (#3188 row-3/4 walk complaint).
+ *
+ * The model (ADR-0010): a `bp-postgres` install = one CNPG Cluster = one
+ * DATA-INSTANCE. The single PostgreSQL ENGINE CLASS (the `bp-cnpg`
+ * operator) is shown ONCE; each data-instance is a first-class card.
+ * Consumers SHARE an instance via isolated databases + per-consumer roles.
+ *
+ * FEEDING ENDPOINT (verified, reused — NOT invented):
+ *
+ *   GET /catalyst/v1/catalog/{blueprint}/instances → ListBlueprintInstancesResponse
+ *
+ * served by catalyst-api (`endpoint_handler.go` HandleListBlueprintInstances,
+ * registered at cmd/api/main.go without the /api/ prefix). Its row type
+ * `ApplicationInstanceSummary` mirrors the Go `applicationSummary`
+ * (endpoint_handler.go:119) VERBATIM — fields `id`, `name`, `blueprint`,
+ * `org`, `topology`, `status`, `createdAt` (all lowercase camelCase per the
+ * Go `json:` tags). This is the source of the engine-class card's instance
+ * count and the per-instance cards.
+ *
+ * HONEST GAP (do not fabricate): NO catalyst-api endpoint exposes the
+ * per-consumer BINDING rows (database · role · mode · secret). Those live
+ * only in each bp-postgres install HR's chart `values.databases[]`, which
+ * no API surfaces today. So a data-instance's `bindings` is empty here and
+ * the Consumers table renders the honest "bindings not yet surfaced by the
+ * API" state — never a fabricated row. When the model is gated off (the
+ * default on a stock prov, `SOVEREIGN_ENABLE_SHARED_PG=false`) the
+ * instances list is empty and the panel renders "No PostgreSQL data
+ * instances yet." Surfacing live bindings is a backend endpoint first
+ * (a different PR) — see #3188.
+ */
+
+import type { ApplicationInstanceSummary } from '@/lib/catalog.api'
+
+/** One consumer's binding to a data-instance (one row in the table). */
+export interface Binding {
+  /** Consumer Blueprint / app id, e.g. "bp-harbor". */
+  consumer: string
+  /** Isolated database name on the shared Cluster, e.g. "registry". */
+  database: string
+  /** Per-consumer login role (CNPG-managed), e.g. "harbor". */
+  role: string
+  /** Binding provenance — private (dedicated) or shared. */
+  mode: 'private' | 'shared'
+  /** Connection Secret reflected into the consumer namespace. */
+  secret: string
+}
+
+/** A data-instance = one CNPG Cluster (one bp-postgres App card). */
+export interface DataInstance {
+  /** Instance name = Cluster name = App-card title, e.g. "shared-pg". */
+  name: string
+  /** Engine class id (always bp-postgres here). */
+  blueprint: string
+  /** BCP topology of the instance (inherited by every consumer). */
+  topology: 'singleton' | 'active-hot-standby'
+  /** Live status of the instance (Ready/Failed/Provisioning/…). */
+  status: string
+  /** The consumers sharing this instance. */
+  bindings: Binding[]
+}
+
+/** The engine CLASS card (the operator, shown once under Platform/engines). */
+export interface EngineClass {
+  /** Engine class id, e.g. "bp-cnpg". */
+  blueprint: string
+  /** Display title, e.g. "PostgreSQL". */
+  title: string
+  /** How many data-instances run this engine. */
+  instanceCount: number
+}
+
+/**
+ * postgresClass derives the single PostgreSQL engine-class card from the
+ * set of data-instances. The engine (bp-cnpg operator) is shown ONCE; the
+ * count is the number of data-instances using it. Mirrors the Svelte
+ * `postgresClass` verbatim.
+ */
+export function postgresClass(instances: DataInstance[]): EngineClass {
+  return {
+    blueprint: 'bp-cnpg',
+    title: 'PostgreSQL',
+    instanceCount: instances.length,
+  }
+}
+
+/**
+ * isShared reports whether a data-instance is shared by >1 consumer (the
+ * reuse case). Drives the "SHARED" pill on the data-instance card. Mirrors
+ * the Svelte `isShared` verbatim.
+ */
+export function isShared(instance: DataInstance): boolean {
+  return instance.bindings.length > 1
+}
+
+/**
+ * normalizeTopology maps any topology string to the two display states.
+ * The instances endpoint returns the per-install topology string; only
+ * `active-hot-standby` is the multi-region HA shape, everything else
+ * (singleton / single-region / empty) renders as `singleton`.
+ */
+function normalizeTopology(topology: string | undefined): DataInstance['topology'] {
+  return topology === 'active-hot-standby' ? 'active-hot-standby' : 'singleton'
+}
+
+/**
+ * fromInstanceSummaries builds the DataInstance[] the console renders from
+ * the LIVE `GET /catalyst/v1/catalog/{blueprint}/instances` response rows
+ * (the same `ApplicationInstanceSummary[]` the InstancesSection consumes).
+ *
+ * Each bp-postgres install = one data-instance card. The summary carries
+ * NO binding data (the API doesn't expose the per-consumer database/role/
+ * secret rows — see the module header), so `bindings` is always empty here;
+ * the Consumers table renders the honest "not yet surfaced" state rather
+ * than fabricating rows. The ENGINE CLASS card's count is `len(instances)`.
+ *
+ * CRITICAL (memory feedback_ts_field_casing_vs_go_json_tag): every field
+ * read here (`name`, `topology`, `status`) matches the Go `json:` tag
+ * VERBATIM. `res.json()` returns wire keys exactly — a casing mismatch
+ * silently yields undefined (documented prior outage).
+ */
+export function fromInstanceSummaries(
+  rows: ApplicationInstanceSummary[],
+): DataInstance[] {
+  return rows
+    .map((r) => ({
+      name: r.name,
+      blueprint: 'bp-postgres',
+      topology: normalizeTopology(r.topology),
+      status: r.status ?? '',
+      bindings: [] as Binding[],
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.test.tsx
@@ -282,4 +282,51 @@ describe('CatalogDetail — #3090 class page', () => {
     expect(screen.queryByTestId('sov-instances-table')).toBeNull()
     expect(screen.queryByTestId('btn-new-instance')).toBeNull()
   })
+
+  // ── #3188 / ADR-0010 — the "Data instances" panel on data-engine pages ──
+
+  it('renders the Data instances panel on the bp-postgres class page', async () => {
+    const POSTGRES_CATALOG = {
+      name: 'postgres',
+      version: '0.1.1',
+      card: { title: 'PostgreSQL', category: 'data' },
+      origin: 'upstream',
+      source: 'gitea',
+      raw: { spec: { multiInstance: { enabled: true } } },
+    }
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      // bp-postgres instances feed the data-instances panel (engine count).
+      if (url.includes('/catalog/postgres/instances')) {
+        return jsonRes({
+          items: [
+            {
+              id: 'pg-1',
+              name: 'shared-pg',
+              blueprint: 'postgres',
+              org: 'sovereign',
+              topology: 'singleton',
+              status: 'Ready',
+            },
+          ],
+        })
+      }
+      if (url.includes('/instances')) return jsonRes({ items: [] })
+      if (url.includes('/catalog/')) return jsonRes(POSTGRES_CATALOG)
+      return jsonRes({})
+    }) as typeof fetch
+
+    renderCatalog('postgres')
+    // The ADR-0010 panel + the PostgreSQL engine-class card render here.
+    expect(await screen.findByTestId('data-instances-panel')).toBeTruthy()
+    expect(await screen.findByTestId('engine-class-card')).toBeTruthy()
+    // The one bp-postgres install surfaces as a data-instance card.
+    expect(await screen.findByTestId('data-instance-card')).toBeTruthy()
+  })
+
+  it('does NOT render the Data instances panel on a non-data Blueprint (grafana)', async () => {
+    renderCatalog('grafana')
+    await screen.findByTestId('catalog-title')
+    expect(screen.queryByTestId('data-instances-panel')).toBeNull()
+  })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
@@ -6,6 +6,7 @@ import { findComponent } from '@/pages/wizard/steps/componentGroups'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import { InstancesSection } from './AppDetail/InstancesSection'
+import { DataInstances } from './DataInstances'
 
 /**
  * CatalogDetail — the per-Blueprint CLASS page.
@@ -144,6 +145,15 @@ export function CatalogDetail() {
   const deps = readDependencies(cat)
   const tags = Array.isArray(card.tags) ? card.tags : []
 
+  // ADR-0010 / #3188 — surface the "Data instances" panel on the data-engine
+  // class pages (the bp-postgres data-instance Blueprint + the bp-cnpg engine
+  // operator). This is the reusable/shareable backing-services view the
+  // founder's row-3/4 walk asked for — the PostgreSQL engine class card + each
+  // data-instance card + its Consumers (bindings) table — ported here from the
+  // unrouted Svelte console into the DEPLOYED catalyst-ui. `name` is the bare
+  // blueprint id (the `bp-` prefix is stripped above).
+  const isPostgresDataEngine = name === 'postgres' || name === 'cnpg'
+
   // Icon: reuse the same resolution as AppDetail / AppsPage — the
   // component-catalog `logoUrl` (a real public/ asset URL) keyed by the
   // bare blueprint id. `card.icon` from the API is only a bare SVG
@@ -277,6 +287,16 @@ export function CatalogDetail() {
           </p>
         </section>
       ) : null}
+
+      {/*
+        Data instances (ADR-0010 / #3188) — the reusable/shareable
+        backing-services view, rendered only on the data-engine class pages
+        (bp-postgres / bp-cnpg). PostgreSQL engine-class card (shown once) +
+        each bp-postgres data-instance card with its Consumers (bindings)
+        table. Fed by the live GET /catalyst/v1/catalog/bp-postgres/instances
+        endpoint; honest empty state when the model is gated off.
+      */}
+      {isPostgresDataEngine ? <DataInstances blueprint="bp-postgres" /> : null}
 
       {/*
         Instances — the page BODY (centerpiece). For multi-instance and

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/DataInstances.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/DataInstances.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * DataInstances.test.tsx — #3188 lock-in for the ADR-0010 "Data instances"
+ * panel ported into the DEPLOYED React console (catalyst-ui).
+ *
+ * The panel renders:
+ *   • ONE PostgreSQL engine-class card (shown once) with the live count.
+ *   • One data-instance card per bp-postgres install, with its status/topology
+ *     pills.
+ *   • The honest "No PostgreSQL data instances yet" empty state on [].
+ *   • The honest per-instance "bindings not yet surfaced by the API" state
+ *     (no catalyst-api endpoint exposes the binding rows today — never
+ *     fabricated).
+ *
+ * This is a fetch round-trip test (the established convention in this tree,
+ * functionally the MSW round-trip the brief asks for): the stubbed
+ * `fetch().json()` returns a body whose field names match the Go `json:` tags
+ * of `applicationSummary` (endpoint_handler.go:119) VERBATIM — `name`,
+ * `topology`, `status`, `blueprint`, `org`, `id` (lowercase camelCase). A
+ * casing mismatch would silently yield undefined fields (documented prior
+ * outage, memory feedback_ts_field_casing_vs_go_json_tag); the assertions
+ * below would then fail, which is exactly the regression guard we want.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { DataInstances } from './DataInstances'
+
+/**
+ * Wire body for GET /catalyst/v1/catalog/bp-postgres/instances. Field names
+ * are the Go `json:` tags VERBATIM (lowercase camelCase) — the casing the
+ * backend actually emits.
+ */
+const TWO_INSTANCES = {
+  items: [
+    {
+      id: 'aaaaaaaa-1111',
+      name: 'shared-pg',
+      blueprint: 'postgres',
+      org: 'sovereign',
+      topology: 'singleton',
+      status: 'Ready',
+    },
+    {
+      id: 'bbbbbbbb-2222',
+      name: 'gitea-pg',
+      blueprint: 'postgres',
+      org: 'sovereign',
+      topology: 'active-hot-standby',
+      status: 'Ready',
+    },
+  ],
+}
+
+function jsonRes(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response)
+}
+
+function installFetch(body: unknown, status = 200) {
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (url.includes('/instances')) return jsonRes(body, status)
+    return jsonRes({})
+  }) as typeof fetch
+}
+
+function renderPanel() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <DataInstances blueprint="bp-postgres" />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('DataInstances — #3188 ADR-0010 panel (catalyst-ui)', () => {
+  beforeEach(() => {
+    installFetch(TWO_INSTANCES)
+  })
+
+  it('renders the PostgreSQL engine-class card once, with the live instance count', async () => {
+    renderPanel()
+    const card = await screen.findByTestId('engine-class-card')
+    expect(card.textContent).toContain('PostgreSQL')
+    expect(card.textContent).toContain('bp-cnpg')
+    // Two data-instances in the mocked response → "2 instances".
+    await waitFor(() =>
+      expect(screen.getByTestId('engine-instance-count').textContent).toContain(
+        '2 instances',
+      ),
+    )
+  })
+
+  it('renders one data-instance card per bp-postgres install (correct field casing)', async () => {
+    renderPanel()
+    const cards = await screen.findAllByTestId('data-instance-card')
+    expect(cards.length).toBe(2)
+    // Names/topology/status read from the wire body via the camelCase Go
+    // json tags — a casing mismatch would render undefined and fail these.
+    const text = cards.map((c) => c.textContent).join(' ')
+    expect(text).toContain('shared-pg')
+    expect(text).toContain('gitea-pg')
+    expect(text).toContain('active-hot-standby')
+    expect(text).toContain('Ready')
+  })
+
+  it('renders the honest "bindings not yet surfaced" state per instance (never fabricates rows)', async () => {
+    renderPanel()
+    const empties = await screen.findAllByTestId('data-instance-no-bindings')
+    expect(empties.length).toBe(2)
+    // No consumers table is fabricated when the API exposes no binding rows.
+    expect(screen.queryByTestId('consumers-table')).toBeNull()
+    expect(screen.queryByTestId('binding-row')).toBeNull()
+  })
+
+  it('renders the honest empty state on [] (model gated off)', async () => {
+    installFetch({ items: [] })
+    renderPanel()
+    const empty = await screen.findByTestId('data-instances-empty')
+    expect(empty.textContent).toContain('No PostgreSQL data instances yet')
+    // Engine card still shows, with a zero count.
+    expect(screen.getByTestId('engine-instance-count').textContent).toContain(
+      '0 instances',
+    )
+    expect(screen.queryByTestId('data-instance-card')).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/DataInstances.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/DataInstances.tsx
@@ -1,0 +1,303 @@
+/**
+ * DataInstances.tsx — the ADR-0010 "Data instances" panel, ported from the
+ * unrouted Svelte console (`core/console/src/components/DataInstances.svelte`)
+ * into the DEPLOYED React operator console (catalyst-ui), where the founder
+ * actually looks (#3188 row-3/4 walk).
+ *
+ * Renders the three ADR-0010 surfaces:
+ *   1. ONE PostgreSQL ENGINE-CLASS card (the `bp-cnpg` engine, shown once),
+ *      with the live data-instance count.
+ *   2. The N DATA-INSTANCE cards (bp-postgres installs), each with a
+ *      Consumers (bindings) table: app · database · role · mode · secret.
+ *   3. The honest empty states — "No PostgreSQL data instances yet" when the
+ *      model is gated off, and per-instance "bindings not yet surfaced by the
+ *      API" because no catalyst-api endpoint exposes the binding rows today.
+ *
+ * Fed by the LIVE, REUSED endpoint
+ *   GET /catalyst/v1/catalog/bp-postgres/instances
+ * via `getApplicationInstances` (the same call InstancesSection uses). NO new
+ * API was invented; the per-consumer binding rows are NOT exposed by any
+ * endpoint (see dataInstances.ts header) so they are never fabricated.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+
+import { getApplicationInstances } from '@/lib/catalog.api'
+import {
+  type DataInstance,
+  fromInstanceSummaries,
+  postgresClass,
+  isShared,
+} from '@/lib/dataInstances'
+
+/**
+ * DataInstances — the panel. `blueprint` defaults to `bp-postgres` (the
+ * data-instance Blueprint); callers on the bp-postgres / bp-cnpg catalog
+ * detail page render it without props.
+ */
+export function DataInstances({
+  blueprint = 'bp-postgres',
+}: {
+  blueprint?: string
+}) {
+  const instancesQuery = useQuery({
+    queryKey: ['data-instances', blueprint],
+    queryFn: () => getApplicationInstances(blueprint),
+    staleTime: 15_000,
+    refetchInterval: 15_000,
+    retry: 1,
+  })
+
+  const instances: DataInstance[] = fromInstanceSummaries(
+    instancesQuery.data?.items ?? [],
+  )
+  const engine = postgresClass(instances)
+
+  return (
+    <section className="section data-instances" data-testid="data-instances-panel">
+      <style>{DATA_INSTANCES_CSS}</style>
+      <h2>Data instances</h2>
+      <p className="section-hint di-sub">
+        Shareable PostgreSQL engines. Each instance is one CNPG cluster; apps
+        share an instance via isolated databases + per-app roles. Pure
+        Flux-applied YAML — no controller, no Crossplane.
+      </p>
+
+      {/* 1. Engine CLASS card (shown once) */}
+      <div className="di-engines">
+        <div className="di-engine-card" data-testid="engine-class-card">
+          <span className="di-engine-icon">🐘</span>
+          <div className="di-engine-body">
+            <span className="di-engine-title">{engine.title}</span>
+            <span className="di-engine-sub">Engine · {engine.blueprint}</span>
+          </div>
+          <span
+            className="di-engine-count"
+            data-testid="engine-instance-count"
+            title="data-instances running this engine"
+          >
+            {engine.instanceCount} instance{engine.instanceCount === 1 ? '' : 's'}
+          </span>
+        </div>
+      </div>
+
+      {instancesQuery.isPending ? (
+        <p className="section-hint" data-testid="data-instances-loading">
+          Loading data instances…
+        </p>
+      ) : instancesQuery.isError ? (
+        <p
+          className="section-hint di-error"
+          data-testid="data-instances-error"
+        >
+          Failed to load data instances:{' '}
+          {(instancesQuery.error as Error)?.message ?? 'unknown error'}
+        </p>
+      ) : instances.length === 0 ? (
+        <div className="di-empty" data-testid="data-instances-empty">
+          No PostgreSQL data instances yet.
+        </div>
+      ) : (
+        // 2. Data-instance cards, each with a Consumers (bindings) table.
+        <div className="di-instances">
+          {instances.map((inst) => (
+            <div
+              key={inst.name}
+              className="di-instance-card"
+              data-testid="data-instance-card"
+              data-instance={inst.name}
+            >
+              <div className="di-instance-head">
+                <span className="di-instance-name">{inst.name}</span>
+                <span className="di-pill di-pill-bp">{inst.blueprint}</span>
+                <span className="di-pill di-pill-topo">{inst.topology}</span>
+                {inst.status ? (
+                  <span className="di-pill di-pill-status">{inst.status}</span>
+                ) : null}
+                {isShared(inst) ? (
+                  <span
+                    className="di-pill di-pill-shared"
+                    title="Shared by more than one app"
+                  >
+                    SHARED
+                  </span>
+                ) : null}
+              </div>
+
+              <div className="di-consumers">
+                <div className="di-consumers-head">Consumers (bindings)</div>
+                {inst.bindings.length === 0 ? (
+                  // Honest gap: no catalyst-api endpoint exposes the
+                  // per-consumer binding rows yet (they live in the install
+                  // HR's chart values.databases[]). Never fabricate rows.
+                  <div
+                    className="di-no-consumers"
+                    data-testid="data-instance-no-bindings"
+                  >
+                    Bindings (database · role · mode · secret) are not yet
+                    surfaced by the API.
+                  </div>
+                ) : (
+                  <table
+                    className="di-bindings"
+                    data-testid="consumers-table"
+                  >
+                    <thead>
+                      <tr>
+                        <th>App</th>
+                        <th>Database</th>
+                        <th>Role</th>
+                        <th>Mode</th>
+                        <th>Secret</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {inst.bindings.map((b) => (
+                        <tr
+                          key={`${b.consumer}/${b.database}`}
+                          data-testid="binding-row"
+                        >
+                          <td>{b.consumer}</td>
+                          <td>
+                            <code>{b.database}</code>
+                          </td>
+                          <td>
+                            <code>{b.role}</code>
+                          </td>
+                          <td>
+                            <span className={`di-mode di-mode-${b.mode}`}>
+                              {b.mode}
+                            </span>
+                          </td>
+                          <td>
+                            <code className="di-secret">{b.secret}</code>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+/* ─── CSS — mirrors DataInstances.svelte's styles, adapted to the
+ *      catalyst-ui `.section` / `--color-*` token language. ──────────── */
+const DATA_INSTANCES_CSS = `
+.data-instances .di-sub { max-width: 52rem; }
+
+.di-engines { margin: 0.4rem 0 1rem; }
+.di-engine-card {
+  display: flex; align-items: center; gap: 0.75rem;
+  background: var(--color-surface);
+  border: 1.5px dashed var(--color-border);
+  border-radius: 12px;
+  padding: 0.6rem 0.9rem;
+  max-width: 28rem;
+}
+.di-engine-icon { font-size: 1.4rem; }
+.di-engine-body { display: flex; flex-direction: column; min-width: 0; }
+.di-engine-title { font-size: 0.92rem; font-weight: 600; color: var(--color-text-strong); }
+.di-engine-sub {
+  font-size: 0.7rem; color: var(--color-text-dim);
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
+.di-engine-count {
+  margin-left: auto;
+  font-size: 0.72rem; color: var(--color-text-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+.di-empty {
+  padding: 0.8rem 1rem;
+  background: var(--color-surface);
+  border: 1px dashed var(--color-border);
+  border-radius: 10px;
+  color: var(--color-text-dim);
+  font-size: 0.82rem;
+}
+.di-error { color: var(--color-danger); }
+
+.di-instances {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));
+  gap: 0.9rem;
+}
+.di-instance-card {
+  background: var(--color-surface);
+  border: 1.5px solid var(--color-border);
+  border-radius: 12px;
+  padding: 0.75rem 0.9rem;
+}
+.di-instance-head {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem;
+  margin-bottom: 0.6rem;
+}
+.di-instance-name {
+  font-size: 0.95rem; font-weight: 600; color: var(--color-text-strong);
+}
+.di-pill {
+  padding: 0.05rem 0.45rem; border-radius: 4px; font-size: 0.62rem;
+  font-weight: 600; letter-spacing: 0.03em; text-transform: uppercase;
+}
+.di-pill-bp {
+  background: color-mix(in srgb, var(--color-border) 50%, transparent);
+  color: var(--color-text-dim);
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
+.di-pill-topo {
+  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
+  color: var(--color-accent);
+}
+.di-pill-status {
+  background: color-mix(in srgb, var(--color-border) 40%, transparent);
+  color: var(--color-text-dim);
+}
+.di-pill-shared {
+  background: color-mix(in srgb, var(--color-success) 16%, transparent);
+  color: var(--color-success);
+}
+
+.di-consumers-head {
+  font-size: 0.72rem; font-weight: 600; letter-spacing: 0.02em;
+  color: var(--color-text-dim); text-transform: uppercase;
+  margin-bottom: 0.35rem;
+}
+.di-no-consumers { font-size: 0.8rem; color: var(--color-text-dim); }
+
+table.di-bindings {
+  width: 100%; border-collapse: collapse; font-size: 0.78rem;
+}
+table.di-bindings th {
+  text-align: left; font-weight: 600; color: var(--color-text-dim);
+  padding: 0.25rem 0.5rem 0.25rem 0;
+  border-bottom: 1px solid var(--color-border);
+}
+table.di-bindings td {
+  padding: 0.3rem 0.5rem 0.3rem 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 40%, transparent);
+  color: var(--color-text-strong);
+}
+table.di-bindings code {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.72rem;
+}
+.di-secret { color: var(--color-text-dim); }
+.di-mode {
+  padding: 0.04rem 0.4rem; border-radius: 4px; font-size: 0.62rem;
+  font-weight: 600; text-transform: uppercase;
+}
+.di-mode-shared {
+  background: color-mix(in srgb, var(--color-success) 16%, transparent);
+  color: var(--color-success);
+}
+.di-mode-private {
+  background: color-mix(in srgb, var(--color-text-dim) 14%, transparent);
+  color: var(--color-text-dim);
+}
+`


### PR DESCRIPTION
## What

Surfaces the ADR-0010 reusable/shareable backing-services **"Data instances"** view in the **deployed** operator console (`catalyst-ui`, React, served at `console.<fqdn>`), where the founder actually looks — instead of the Svelte `core/console/`, which ships as the `console` image deployed **unrouted** in the `sme` namespace and is unreachable.

This is the founder's row-3/4 walk complaint verbatim (ADR-0010 problem statement): the console showed "depends on bp-cnpg" (the operator) instead of WHICH Postgres data-instance an app is bound to, and never showed "this engine has N consumers".

## How

- **`src/lib/dataInstances.ts`** — the model (`DataInstance` / `Binding` / `EngineClass`, `postgresClass`, `isShared`) mirroring the Svelte lib, plus `fromInstanceSummaries()` fed by the **live, REUSED** endpoint:

  ```
  GET /catalyst/v1/catalog/{blueprint}/instances → ListBlueprintInstancesResponse
  ```

  served by catalyst-api (`endpoint_handler.go` `HandleListBlueprintInstances`) — the **same** call `InstancesSection` already uses. **No new API invented.**

- **`src/pages/sovereign/DataInstances.tsx`** — the panel: ONE PostgreSQL **engine-class** card (shown once, `bp-cnpg`) with the live instance count + each `bp-postgres` **data-instance** card with its topology/status pills. Honest empty states:
  - `No PostgreSQL data instances yet.` on `[]` (the model is gated off by default — `SOVEREIGN_ENABLE_SHARED_PG=false`).
  - per-instance `Bindings … are not yet surfaced by the API.` — the per-consumer binding rows (database · role · mode · secret) are **NOT** exposed by any catalyst-api endpoint today (they live only in each install HR's chart `values.databases[]`). They are **never fabricated**. Surfacing live bindings is a backend endpoint first — a different PR.

- Wired into **`CatalogDetail.tsx`** for the data engines (`bp-postgres` / `bp-cnpg`) only; non-data Blueprints don't render it.

## Field casing

Every TS interface reading the wire JSON (`name` / `topology` / `status`) matches the Go `applicationSummary` `json:` tags **verbatim** (lowercase camelCase) per memory `feedback_ts_field_casing_vs_go_json_tag` — a casing mismatch silently returns `undefined` (documented prior outage).

## Tests

Vitest round-trip (the established fetch-stub convention in this tree, MSW-equivalent):
- engine-class card + data-instance cards render from a **casing-correct** mocked `/instances` response;
- the honest **empty state** renders on `[]` with a 0 count;
- the **no-fabricated-bindings** state renders per instance;
- `CatalogDetail` renders the panel on `bp-postgres` and **not** on a non-data Blueprint.

`tsc --noEmit` clean, `eslint` clean, `no-hardcoded-api` guardrail green. (Pre-existing unrelated UI test failures in PinInput6/ProvisionPage/JobsPage/SettingsPage fail identically on the clean base.)

## Versioning

`catalyst-ui` image + `bp-catalyst-platform` chart auto-bump via `catalyst-build.yaml` on merge — no manual bump.

## Honesty

NOT live-verified — needs a catalyst-ui roll + a prov with the shared-pg gate enabled to render real instances. On a stock prov the panel correctly renders the empty state.

Refs #3188 #2741 #3263

🤖 Generated with [Claude Code](https://claude.com/claude-code)