### PR TITLE
feat(provisioner): wire SOVEREIGN_ENABLE_SHARED_PG to a fire-body opt-in

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -420,6 +420,8 @@ write_files:
             SOVEREIGN_PRIMARY_REGION: "${primary_region_canonical_label}"
             SOVEREIGN_REPLICA_REGION: "${replica_region_canonical_label}"
             SOVEREIGN_ENABLE_HOT_STANDBY: "${enable_hot_standby}"
+            # ADR-0010 #3188 master gate for bootstrap-kit slot 16a shared-pg.
+            SOVEREIGN_ENABLE_SHARED_PG: "${enable_shared_pg}"
             SOVEREIGN_BCP_TOPOLOGY: "${bcp_topology}"
             # SOVEREIGN_REGION_ROLE — this control plane's role in the
             # multi-region topology (primary|secondary). Both providers

--- a/infra/providers/hetzner/main.tf
+++ b/infra/providers/hetzner/main.tf
@@ -856,6 +856,7 @@ locals {
     wildcard_cert_issuer     = local.wildcard_cert_issuer
     bcp_topology             = var.bcp_topology
     enable_hot_standby       = var.enable_hot_standby
+    enable_shared_pg         = var.enable_shared_pg
     sovereign_cnpg_instances = length(var.regions) > 1 ? "2" : "1"
     continuum_enabled        = length(var.regions) > 1 ? "true" : "false"
     parent_domains_yaml = coalesce(
@@ -1290,6 +1291,7 @@ locals {
       wildcard_cert_issuer     = local.wildcard_cert_issuer
       bcp_topology             = var.bcp_topology
       enable_hot_standby       = var.enable_hot_standby
+      enable_shared_pg         = var.enable_shared_pg
       sovereign_cnpg_instances = length(var.regions) > 1 ? "2" : "1"
       continuum_enabled        = length(var.regions) > 1 ? "true" : "false"
       parent_domains_yaml = coalesce(

--- a/infra/providers/hetzner/variables.tf
+++ b/infra/providers/hetzner/variables.tf
@@ -96,6 +96,30 @@ variable "enable_hot_standby" {
   }
 }
 
+# enable_shared_pg — opt-in master gate for the ADR-0010 reusable,
+# shareable backing-services model (#3188). Mirrors enable_hot_standby's
+# seam exactly: catalyst-api's provisioner.Request.EnableSharedPostgres
+# stringifies to this var, the cloud-init template interpolates it
+# verbatim into the bootstrap-kit Kustomization postBuild.substitute as
+# SOVEREIGN_ENABLE_SHARED_PG, and bootstrap-kit slot 16a
+# (16a-bp-postgres-shared.yaml) reads `${SOVEREIGN_ENABLE_SHARED_PG:=false}`
+# as the chart-side master gate. Default 'false' keeps the shared engine
+# DORMANT — slot 16a installs an empty-but-Ready release that satisfies the
+# unconditional bp-gitea/bp-harbor dependsOn edge without deploying an
+# unused shared-pg Cluster (single-region / non-sharing provs stay
+# byte-identical to today). Before this var existed NOTHING set the
+# substitute key, so the chart's envsubst fallback `false` always won and
+# the reuse model was unreachable even on a fresh prov.
+variable "enable_shared_pg" {
+  type        = string
+  description = "When 'true', bootstrap-kit slot 16a renders the shared CNPG engine (ADR-0010 #3188 reusable backing-services). Opt-in; default 'false' keeps slot 16a an empty-but-Ready release. Set from catalyst-api Request.EnableSharedPostgres."
+  default     = "false"
+  validation {
+    condition     = contains(["true", "false"], var.enable_shared_pg)
+    error_message = "enable_shared_pg must be the string 'true' or 'false'."
+  }
+}
+
 # ── QA fixtures auto-enable (Fix #73 — qa-loop bounded-cycle iter-16) ──
 # When set, bp-catalyst-platform's qaFixtures stack (qa-<sov> namespace +
 # qa-wp Application + Continuum CR + CNPGPair + PDM CRs + ScheduledBackup

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -776,6 +776,7 @@ locals {
       ])
       bcp_topology             = var.bcp_topology
       enable_hot_standby       = var.enable_hot_standby
+      enable_shared_pg         = var.enable_shared_pg
       sovereign_cnpg_instances = length(var.regions) > 1 ? "2" : "1"
       continuum_enabled        = length(var.regions) > 1 ? "true" : "false"
       marketplace_enabled      = var.marketplace_enabled

--- a/infra/providers/huawei/variables.tf
+++ b/infra/providers/huawei/variables.tf
@@ -431,6 +431,29 @@ variable "enable_hot_standby" {
   }
 }
 
+# enable_shared_pg — opt-in master gate for the ADR-0010 reusable,
+# shareable backing-services model (#3188). Companion to the Hetzner
+# port's `enable_shared_pg`; mirrors enable_hot_standby's seam exactly.
+# catalyst-api's provisioner.Request.EnableSharedPostgres stringifies to
+# this var, the shared cloud-init template interpolates it verbatim into
+# the bootstrap-kit Kustomization postBuild.substitute as
+# SOVEREIGN_ENABLE_SHARED_PG, and bootstrap-kit slot 16a
+# (16a-bp-postgres-shared.yaml) reads `${SOVEREIGN_ENABLE_SHARED_PG:=false}`
+# as the chart-side master gate. Default 'false' keeps the shared engine
+# DORMANT — slot 16a installs an empty-but-Ready release that satisfies the
+# unconditional bp-gitea/bp-harbor dependsOn edge without deploying an
+# unused shared-pg Cluster. Before this var existed NOTHING set the
+# substitute key, so the chart's envsubst fallback `false` always won.
+variable "enable_shared_pg" {
+  type        = string
+  description = "When 'true', bootstrap-kit slot 16a renders the shared CNPG engine (ADR-0010 #3188 reusable backing-services). Opt-in; default 'false' keeps slot 16a an empty-but-Ready release. Set from catalyst-api Request.EnableSharedPostgres."
+  default     = "false"
+  validation {
+    condition     = contains(["true", "false"], var.enable_shared_pg)
+    error_message = "enable_shared_pg must be the string 'true' or 'false'."
+  }
+}
+
 variable "wildcard_cert_use_staging" {
   type        = string
   default     = "false"

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -423,6 +423,32 @@ type Request struct {
 	// checkbox.
 	MarketplaceEnabled bool `json:"marketplaceEnabled"`
 
+	// EnableSharedPostgres — opt-in switch for the ADR-0010 reusable,
+	// shareable backing-services model (#3188). When true, bootstrap-kit
+	// slot 16a (16a-bp-postgres-shared.yaml) renders the shared `shared-pg`
+	// CNPG engine + the per-consumer Database CRs/roles/reflected Secrets;
+	// when false (the safe default) slot 16a installs an EMPTY-but-Ready
+	// release that satisfies the unconditional bp-gitea/bp-harbor
+	// `dependsOn` edge WITHOUT deploying an unused engine. Single-region /
+	// non-sharing provs stay byte-identical to today.
+	//
+	// Threaded through the EXACT same seam as BcpTopology →
+	// SOVEREIGN_ENABLE_HOT_STANDBY: catalyst-api Request → tofu var
+	// `enable_shared_pg` (string "true"/"false") → cloud-init Flux
+	// Kustomization postBuild.substitute as SOVEREIGN_ENABLE_SHARED_PG →
+	// slot 16a reads `${SOVEREIGN_ENABLE_SHARED_PG:=false}`. Before this
+	// field NOTHING set the substitute var, so the chart's envsubst
+	// fallback `false` always won and the #3188 model was dormant +
+	// unreachable even on a fresh prov.
+	//
+	// Default false (the master gate stays OFF). This is the OPT-IN seam —
+	// the default is unchanged. NOTE: to actually run two consumers off the
+	// shared engine the operator ALSO flips the per-consumer
+	// SOVEREIGN_{GITEA,HARBOR}_PG_OWN_CLUSTER=false overlays (the two-flag
+	// contract documented in slot 16a); this field controls ONLY whether
+	// slot 16a renders the engine at all.
+	EnableSharedPostgres bool `json:"enableSharedPostgres"`
+
 	// QATestEnabled — when true, bp-catalyst-platform's qaFixtures stack
 	// (qa-<sov> namespace + qa-wp Application + Continuum CR + CNPGPair
 	// + PDM CRs + ScheduledBackup + status-seeder Jobs + tier-bound
@@ -2286,6 +2312,20 @@ func writeTfvars(deployDir string, req Request) error {
 		// status surfaces use this same value to render the BSS-menu DR
 		// posture chip and the Settings page Continuity Plan row.
 		"bcp_topology": deriveBcpTopology(req),
+
+		// Shared-Postgres opt-in threading (ADR-0010 / #3188). Mirrors the
+		// enable_hot_standby seam exactly: the boolean Request field maps
+		// to a stringified "true"/"false" tofu var the cloud-init template
+		// interpolates verbatim into the bootstrap-kit Kustomization
+		// postBuild.substitute as SOVEREIGN_ENABLE_SHARED_PG. slot 16a
+		// (16a-bp-postgres-shared.yaml) reads `${SOVEREIGN_ENABLE_SHARED_PG
+		// :=false}` as its master gate — OFF (the safe default) renders an
+		// empty-but-Ready release. Before this var NOTHING set the
+		// substitute, so the chart fallback `false` always won and the
+		// reuse model was dormant + unreachable even on a fresh prov.
+		// infra/providers/{hetzner,huawei}/variables.tf carry the matching
+		// `["true","false"]` validation so a typo fails at `tofu plan`.
+		"enable_shared_pg": map[bool]string{true: "true", false: "false"}[req.EnableSharedPostgres],
 
 		// QA namespace + Organization names — derived from the Sovereign
 		// FQDN's first label at provision time per principle #4 (never

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner_shared_pg_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner_shared_pg_test.go
@@ -1,0 +1,76 @@
+// provisioner_shared_pg_test.go — #3188 / ADR-0010 coverage for the
+// shared-Postgres opt-in seam.
+//
+// bootstrap-kit slot 16a (16a-bp-postgres-shared.yaml) gates the shared
+// CNPG engine on the chart-side `${SOVEREIGN_ENABLE_SHARED_PG:=false}`
+// envsubst. Before this seam NOTHING set the substitute var, so the
+// fallback `false` always won and the reusable-shared-Postgres model was
+// dormant + unreachable even on a fresh prov. These tests pin the wire:
+// the boolean Request.EnableSharedPostgres field stringifies to the
+// `enable_shared_pg` tofu var (which the cloud-init template interpolates
+// verbatim into the Kustomization postBuild.substitute as
+// SOVEREIGN_ENABLE_SHARED_PG).
+//
+//  1. opt-in set  → enable_shared_pg = "true"  (the model is reachable).
+//  2. opt-in absent (default) → enable_shared_pg = "false" (safe default
+//     preserved — single-region / non-sharing provs byte-identical).
+package provisioner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeTfvarsSharedPG is a small helper that validates + writes the tfvars
+// for the given Request into a temp dir and returns the decoded map.
+func writeTfvarsSharedPG(t *testing.T, req Request) map[string]any {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "writeTfvars-sharedpg-*")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	if err := req.Validate(); err != nil {
+		t.Fatalf("Validate(): %v", err)
+	}
+	if err := writeTfvars(dir, req); err != nil {
+		t.Fatalf("writeTfvars: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "tofu.auto.tfvars.json"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, raw)
+	}
+	return out
+}
+
+// 1. The fire-body opt-in flips the substitution var to "true".
+func TestWriteTfvars_EnableSharedPostgres_OptInResolvesTrue(t *testing.T) {
+	req := tfvarsRequest(t)
+	req.EnableSharedPostgres = true
+
+	out := writeTfvarsSharedPG(t, req)
+
+	if got := out["enable_shared_pg"]; got != "true" {
+		t.Errorf("enable_shared_pg = %v, want %q (opt-in set → slot 16a renders the shared engine)", got, "true")
+	}
+}
+
+// 2. Absent (the default) keeps the gate OFF — safe-by-default preserved.
+func TestWriteTfvars_EnableSharedPostgres_DefaultResolvesFalse(t *testing.T) {
+	req := tfvarsRequest(t)
+	// EnableSharedPostgres left at its zero value (false) — exactly the
+	// shape every non-opt-in fire-body has today.
+
+	out := writeTfvarsSharedPG(t, req)
+
+	if got := out["enable_shared_pg"]; got != "false" {
+		t.Errorf("enable_shared_pg = %v, want %q (default OFF → slot 16a is an empty-but-Ready release)", got, "false")
+	}
+}

--- a/scripts/lint-cloudinit.sh
+++ b/scripts/lint-cloudinit.sh
@@ -111,6 +111,7 @@ fixture_common() {
     continuum_enabled                 = "false"
     bcp_topology                      = "single-region"
     enable_hot_standby                = "false"
+    enable_shared_pg                  = "false"
     sovereign_cnpg_instances          = "1"
     wildcard_cert_issuer              = "letsencrypt-dns01-prod-powerdns"
     parent_domains_yaml               = "[{name: \"t99.omani.works\", role: \"primary\"}]"


### PR DESCRIPTION
## What

bootstrap-kit slot 16a (`16a-bp-postgres-shared.yaml:108`) gates the ADR-0010 reusable-shared-Postgres engine on the chart-side `${SOVEREIGN_ENABLE_SHARED_PG:=false}` envsubst — but **nothing set that substitute var**, so the fallback `false` always won and the reuse model was **dormant + unreachable even on a fresh prov**.

This wires the gate to a controllable fire-body input through the **exact same seam** as `SOVEREIGN_ENABLE_HOT_STANDBY` (slot 16b cnpg-pair) — no new mechanism invented.

## How (mirrors `enable_hot_standby` end-to-end)

| Layer | enable_hot_standby (existing) | enable_shared_pg (this PR) |
|---|---|---|
| Fire-body field | `Request.BcpTopology` → derived | `Request.EnableSharedPostgres` (`json:"enableSharedPostgres"`) |
| tfvars emit | `enable_hot_standby` map[bool]string | `enable_shared_pg` map[bool]string |
| variables.tf | both providers, `["true","false"]` | both providers, `["true","false"]` |
| templatefile pass | 2 hetzner + 1 huawei | 2 hetzner + 1 huawei |
| cloud-init substitute | `SOVEREIGN_ENABLE_HOT_STANDBY` | `SOVEREIGN_ENABLE_SHARED_PG` |
| chart gate | `${SOVEREIGN_ENABLE_HOT_STANDBY:-}` | `${SOVEREIGN_ENABLE_SHARED_PG:=false}` (already authored) |

## Constraints honored

- **Default stays `false`** — safe-by-default preserved; this is purely an OPT-IN path. Single-region / non-sharing provs are byte-identical to today.
- **TS/Go casing** — Go tag `json:"enableSharedPostgres"` is lowercase camelCase per convention; no existing TS interface references shared-pg, so no casing conflict. UI wiring (a wizard checkbox like `StepMarketplace`) is a separate workstream.
- **strategy-flip** — `api-deployment.yaml` is NOT touched (constraint trivially satisfied).
- **Two-flag contract** — to actually share, the operator also flips `SOVEREIGN_{GITEA,HARBOR}_PG_OWN_CLUSTER=false` per slot 16a/19/10 docs. This var controls ONLY whether slot 16a renders the engine.

## How to enable on fire

Set in the `POST /sovereign/api/v1/deployments` body:

```json
{ "enableSharedPostgres": true }
```

## Test

New `provisioner_shared_pg_test.go`: fire-body opt-in → `enable_shared_pg="true"`; absent (default) → `"false"`. Both pass; full provisioner suite + `go vet` + `tofu fmt -check` green locally.

Refs #3188 #3263