### PR TITLE
fix(catalyst-api): sweep stale 'running' bp-* jobs terminal at handover

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -796,6 +796,25 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		// adds ≤100ms before markPhase1Done's caller resumes.
 		h.runSecondaryBridgeBackfill(dep)
 
+		// Issue #3277 — sweep any still-reconciling bp-* install Job row
+		// terminal now that handover has succeeded. The helmwatch derives
+		// one Job row per HR from live state, but a row whose last-seen
+		// state was non-terminal (informer-dedup loss, a Pod restart that
+		// lost the in-memory cursor before the terminal edge, or a
+		// secondary watcher whose stream stalled) freezes at
+		// "running"/"pending" forever — the mother stops watching after
+		// handover, so nothing ever resolves it and the operator's
+		// bootstrap view reads "stuck running". The Sovereign is now
+		// self-managing every component, so the mother's view should read
+		// complete. This runs ONLY on OutcomeReady (a SUCCESSFUL handover)
+		// so a failed Phase-1 keeps its failure visible; the sweep itself
+		// leaves any already-Failed row untouched (never masks a real
+		// per-component failure as handed-over). Run INLINE for the same
+		// reason as runSecondaryBridgeBackfill above — in-memory store
+		// work, no network I/O, and `defer stopSecondaries()` tears down
+		// the watchers as soon as markPhase1Done returns.
+		h.runHandoverJobSweep(dep)
+
 		// Wave 5.90 phase 2b (#2441): post-handover flip of bp-kyverno-
 		// policies bootstrapMode from true (fresh-prov default — every
 		// ClusterPolicy renders Audit) → false (canonical per-policy
@@ -875,6 +894,57 @@ func (h *Handler) runSecondaryBridgeBackfill(dep *Deployment) {
 			"snapshotCount", len(snap),
 			"jobsWritten", jobsCount,
 			"executionsSeeded", execsSeeded,
+		)
+	}
+}
+
+// runHandoverJobSweep stamps every still-reconciling bp-* install Job
+// row terminal at a successful Phase-1 handover (issue #3277). Delegates
+// to Bridge.SweepHandoverInstallJobs, which leaves already-Failed rows
+// untouched (a real per-component failure is never masked) and stamps
+// each non-terminal install row Succeeded with an honest hand-over
+// LogLine.
+//
+// Called ONLY from markPhase1Done's OutcomeReady branch, so it can only
+// ever run on a SUCCESSFUL handover — a failed Phase-1 keeps its failure
+// visible. Best-effort: a store error is logged at warn but never
+// derails the handover (the row staying "running" is a cosmetic
+// regression on a healthy cluster, not a correctness failure).
+//
+// Resolves the per-deployment Bridge the same way the rest of the
+// handler does (bridgeFor get-or-create) so the sweep runs against the
+// same jobs.Store the helmwatch feed already wrote to. A nil h.jobs
+// (CI without persistence) makes bridgeFor hand back a no-op in-memory
+// bridge whose ListJobs is empty — the sweep is a harmless zero-row
+// walk there.
+func (h *Handler) runHandoverJobSweep(dep *Deployment) {
+	defer func() {
+		if r := recover(); r != nil {
+			h.log.Error("handover job sweep: panic recovered",
+				"id", dep.ID,
+				"panic", r,
+			)
+		}
+	}()
+	if h.jobs == nil {
+		return
+	}
+	bridge := h.bridgeFor(dep)
+	if bridge == nil {
+		return
+	}
+	swept, err := bridge.SweepHandoverInstallJobs(time.Now().UTC())
+	if err != nil {
+		h.log.Warn("handover job sweep: failed",
+			"id", dep.ID,
+			"err", err,
+		)
+		return
+	}
+	if swept > 0 {
+		h.log.Info("handover job sweep: stamped still-reconciling install rows terminal",
+			"id", dep.ID,
+			"sweptRows", swept,
 		)
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch_handover_sweep_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch_handover_sweep_test.go
@@ -1,0 +1,138 @@
+// phase1_watch_handover_sweep_test.go — issue #3277: at a SUCCESSFUL
+// Phase-1 handover, markPhase1Done sweeps every still-reconciling bp-*
+// install Job row terminal so the mother's bootstrap view never shows a
+// row "stuck running" after the Sovereign self-manages it. A FAILED
+// Phase-1 must NOT sweep — its failure stays visible.
+package handler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// seedRunningInstallRow wires a jobs.Bridge onto dep (backed by h.jobs)
+// and records one install-<chart> row stuck in the running state — the
+// frozen "running forever" row #3277 describes.
+func seedRunningInstallRow(t *testing.T, h *Handler, dep *Deployment, chart string) {
+	t.Helper()
+	bridge := jobs.NewBridge(h.jobs, dep.ID)
+	dep.jobsBridge = bridge
+	if err := bridge.OnHelmReleaseEvent(chart, jobs.HelmStateInstalling, "info", "Helm install in progress", time.Now().UTC(), nil); err != nil {
+		t.Fatalf("seed running install row: %v", err)
+	}
+	got, err := h.jobs.ListJobs(dep.ID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	for _, j := range got {
+		if j.JobName == jobs.JobNamePrefix+chart && j.Status != jobs.StatusRunning {
+			t.Fatalf("pre-condition: install-%s = %q, want %q", chart, j.Status, jobs.StatusRunning)
+		}
+	}
+}
+
+func installRowStatus(t *testing.T, h *Handler, depID, chart string) string {
+	t.Helper()
+	got, err := h.jobs.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	for _, j := range got {
+		if j.JobName == jobs.JobNamePrefix+chart {
+			return j.Status
+		}
+	}
+	t.Fatalf("install-%s row not found in %+v", chart, got)
+	return ""
+}
+
+// TestMarkPhase1Done_SweepsStaleRunningRowsOnReady — the core #3277
+// assertion at the handler level: a successful handover (OutcomeReady)
+// stamps a still-running install row terminal so it no longer reads
+// "running" on the mother.
+func TestMarkPhase1Done_SweepsStaleRunningRowsOnReady(t *testing.T) {
+	st, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("jobs.NewStore: %v", err)
+	}
+	h := NewWithJobsStore(silentLogger(), st)
+
+	dep := &Deployment{
+		ID:        "phase1-sweep-ready",
+		Status:    "phase1-watching",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event, 256),
+		done:      make(chan struct{}),
+		Request: provisioner.Request{
+			SovereignFQDN: "otech-sweep.example.com",
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN: "otech-sweep.example.com",
+		},
+		OwnerEmail: "operator@sweep.example.com",
+	}
+	h.deployments.Store(dep.ID, dep)
+	seedRunningInstallRow(t, h, dep, "gitea")
+
+	finalStates := map[string]string{
+		"cilium": helmwatch.StateInstalled,
+		"gitea":  helmwatch.StateInstalling, // still converging at handover
+	}
+	h.markPhase1Done(dep, finalStates, helmwatch.OutcomeReady)
+
+	if got := installRowStatus(t, h, dep.ID, "gitea"); got != jobs.StatusSucceeded {
+		t.Fatalf("post-handover install-gitea = %q, want %q (#3277 sweep)", got, jobs.StatusSucceeded)
+	}
+}
+
+// TestMarkPhase1Done_PreservesRunningRowsOnFailure — a FAILED Phase-1
+// must never be masked. The sweep is gated on OutcomeReady, so a
+// running install row on a failed deployment stays running (the watch
+// failed; the mother keeps its honest state) — it is NOT stamped
+// succeeded.
+func TestMarkPhase1Done_PreservesRunningRowsOnFailure(t *testing.T) {
+	st, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("jobs.NewStore: %v", err)
+	}
+	h := NewWithJobsStore(silentLogger(), st)
+
+	dep := &Deployment{
+		ID:        "phase1-sweep-failed",
+		Status:    "phase1-watching",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event, 256),
+		done:      make(chan struct{}),
+		Request: provisioner.Request{
+			SovereignFQDN: "otech-failsweep.example.com",
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN: "otech-failsweep.example.com",
+		},
+		OwnerEmail: "operator@failsweep.example.com",
+	}
+	h.deployments.Store(dep.ID, dep)
+	seedRunningInstallRow(t, h, dep, "gitea")
+
+	finalStates := map[string]string{
+		"cilium":            helmwatch.StateInstalled,
+		"catalyst-platform": helmwatch.StateFailed,
+		"gitea":             helmwatch.StateInstalling,
+	}
+	h.markPhase1Done(dep, finalStates, helmwatch.OutcomeFailed)
+
+	if dep.Status != "failed" {
+		t.Fatalf("Status = %q, want %q", dep.Status, "failed")
+	}
+	// The running row is NOT swept on a failed Phase-1 — the mother keeps
+	// its honest, non-handed-over state. (deriveTreeView may propagate
+	// the catalyst-platform failure to dependents, but gitea has no dep
+	// on it here, so it stays running — never fabricated to succeeded.)
+	if got := installRowStatus(t, h, dep.ID, "gitea"); got == jobs.StatusSucceeded {
+		t.Fatalf("install-gitea = %q on FAILED Phase-1 — sweep must not run on failure", got)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
@@ -898,6 +898,115 @@ func (b *Bridge) MarkProvisionerFailed(message string, t time.Time) error {
 	return nil
 }
 
+// SweepHandoverInstallJobs stamps every still-reconciling bp-* install
+// Job row terminal at a SUCCESSFUL Phase-1 handover (issue #3277).
+//
+// Why this exists: the mother's Phase-1 helmwatch derives one Job row
+// per HelmRelease from live HR state, but at watch-end nothing swept
+// the rows whose last-observed state was non-terminal. When the watch
+// terminates by OutcomeReady, an individual install-* row can still be
+// frozen at "running"/"pending" in the snapshot — informer-dedup loss
+// (the seed observed the HR already at its terminal state, so no
+// distinct transition event fired), a Pod restart that wiped the
+// in-memory cursor before the terminal edge, or a secondary-region
+// watcher whose stream stalled. The mother stops watching after
+// handover, so that row's "running" never resolves and the operator's
+// bootstrap view reads "stuck running forever".
+//
+// At a successful handover the Sovereign is now self-managing every
+// component, so the mother's bootstrap view should read complete — not
+// stuck running. This sweep walks every leaf install Job (Type ==
+// JobTypeInstall named "install-<chart>") and stamps each NON-TERMINAL
+// row Succeeded, finishing any open Execution and appending an honest
+// hand-over LogLine so the record never claims silent install-success
+// without explaining that the mother has handed the component off.
+//
+// Correctness guards:
+//   - ONLY call this on a SUCCESSFUL handover (the caller gates on
+//     helmwatch.OutcomeReady). A FAILED Phase-1 must keep its failed
+//     rows visible — never call this for a failure.
+//   - Rows already Failed are LEFT UNTOUCHED — a real per-component
+//     failure is never masked as handed-over, even at OutcomeReady
+//     (OutcomeReady is all-installed by definition, but the guard makes
+//     the invariant explicit and defends a future caller).
+//   - Rows already Succeeded are a no-op (IsTerminal short-circuit).
+//   - Group rows derive their status from descendants at read time, so
+//     they're skipped — sweeping the leaves is sufficient.
+//
+// The Job model exposes only pending|running|succeeded|failed; there is
+// no distinct "handed-over" terminal value, and the FE JobStatus union
+// is the same four buckets — so the truth about hand-over lives in the
+// final LogLine, not a fabricated fifth status. Mirrors
+// markLifecyclePhaseTerminalLocked's locking + FinishExecution pattern.
+func (b *Bridge) SweepHandoverInstallJobs(t time.Time) (swept int, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	all, listErr := b.store.ListJobs(b.deploymentID)
+	if listErr != nil {
+		return 0, listErr
+	}
+	t = t.UTC()
+	const handoverNote = "[handed-over] Phase-1 handover complete — the Sovereign is now self-managing this component. The mother is no longer tracking its state; see the Sovereign console for live status."
+	for _, j := range all {
+		// Leaf install rows only. Group rows derive status from
+		// descendants at read time; lifecycle (Phase-0) rows are already
+		// stamped terminal by MarkProvisionerComplete before Phase-1.
+		if j.Type != JobTypeInstall {
+			continue
+		}
+		if !strings.HasPrefix(j.JobName, JobNamePrefix) {
+			continue
+		}
+		// Never touch a terminal row: an already-Succeeded row is done,
+		// and an already-Failed row must keep surfacing its failure — a
+		// real per-component failure is never masked as handed-over.
+		if IsTerminal(j.Status) {
+			continue
+		}
+
+		// Finish any open Execution on this Job so the GitLab-CI viewer
+		// shows the row terminal too. Reuse the persisted
+		// LatestExecutionID; allocate one retroactively if the row never
+		// started an Execution (a row stuck "pending" with no attempt),
+		// matching markLifecyclePhaseTerminalLocked so the JobsTable
+		// never renders an em-dash duration cell.
+		execID := j.LatestExecutionID
+		if execID == "" {
+			exec, startErr := b.store.StartExecution(b.deploymentID, j.JobName, t)
+			if startErr != nil {
+				return swept, startErr
+			}
+			execID = exec.ID
+		}
+		if appendErr := b.store.AppendLogLines(b.deploymentID, execID, []LogLine{{
+			Timestamp: t,
+			Level:     LevelInfo,
+			Message:   handoverNote,
+		}}); appendErr != nil {
+			return swept, appendErr
+		}
+		// FinishExecution is idempotent on an already-terminal Execution's
+		// status and is the canonical terminal transition — it stamps the
+		// Execution AND the Job (Status + FinishedAt + DurationMs) in one
+		// call, converging a Job row left non-terminal even when its
+		// Execution already finished.
+		if finishErr := b.store.FinishExecution(b.deploymentID, execID, StatusSucceeded, t); finishErr != nil {
+			return swept, finishErr
+		}
+		// Clear any live cursor so a late raw-log line doesn't re-open
+		// the Execution. comp is the AppID (bare chart) the cursor keys
+		// off; fall back to stripping the install- prefix.
+		comp := j.AppID
+		if comp == "" {
+			comp = strings.TrimPrefix(j.JobName, JobNamePrefix)
+		}
+		delete(b.activeExecID, comp)
+		swept++
+	}
+	return swept, nil
+}
+
 // ensureLifecycleJobLocked idempotently materialises the durable Job
 // row for a single Phase-0 lifecycle phase. Used by paths that may
 // run before SeedProvisionerJobs (e.g. a fast emit, a test that

--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge_handover_sweep_test.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge_handover_sweep_test.go
@@ -1,0 +1,204 @@
+// helmwatch_bridge_handover_sweep_test.go — lock-in for issue #3277:
+// at a SUCCESSFUL Phase-1 handover the mother must sweep every
+// still-reconciling bp-* install Job row terminal, while NEVER masking
+// a real per-component failure as handed-over.
+package jobs
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// statusByName returns the status of the leaf install Job with the
+// given JobName, or fails the test.
+func statusByName(t *testing.T, in []Job, name string) string {
+	t.Helper()
+	for _, j := range in {
+		if j.JobName == name {
+			return j.Status
+		}
+	}
+	t.Fatalf("leaf %q not found in %+v", name, in)
+	return ""
+}
+
+// TestBridge_SweepHandoverInstallJobs_StampsNonTerminalRows asserts the
+// core #3277 fix: given a finalStates set with some HRs non-terminal at
+// a successful handover, the sweep stamps every install row terminal so
+// no row is left "running"/"pending", AND a row that genuinely FAILED is
+// preserved as failed (never masked as handed-over).
+func TestBridge_SweepHandoverInstallJobs_StampsNonTerminalRows(t *testing.T) {
+	st, br, depID := newBridgeFixture(t)
+	t0 := time.Date(2026, 6, 11, 9, 0, 0, 0, time.UTC)
+
+	// cilium — reached Installed (terminal succeeded) before handover.
+	if err := br.OnHelmReleaseEvent("cilium", HelmStateInstalled, "info", "Ready=True", t0, nil); err != nil {
+		t.Fatalf("OnHelmReleaseEvent cilium: %v", err)
+	}
+	// gitea — stuck Installing (running) at handover: this is the frozen
+	// "running forever" row #3277 describes.
+	if err := br.OnHelmReleaseEvent("gitea", HelmStateInstalling, "info", "Helm install in progress", t0, nil); err != nil {
+		t.Fatalf("OnHelmReleaseEvent gitea: %v", err)
+	}
+	// harbor — never started reconciling: a pending Job-only row with no
+	// Execution allocated yet.
+	if err := br.OnHelmReleaseEvent("harbor", HelmStatePending, "info", "DependencyNotReady", t0, nil); err != nil {
+		t.Fatalf("OnHelmReleaseEvent harbor: %v", err)
+	}
+	// crossplane — genuinely FAILED before handover. Must stay failed.
+	if err := br.OnHelmReleaseEvent("crossplane", HelmStateInstalling, "info", "first reconcile", t0, nil); err != nil {
+		t.Fatalf("OnHelmReleaseEvent crossplane installing: %v", err)
+	}
+	if err := br.OnHelmReleaseEvent("crossplane", HelmStateFailed, "error", "InstallFailed: timed out", t0.Add(time.Second), nil); err != nil {
+		t.Fatalf("OnHelmReleaseEvent crossplane failed: %v", err)
+	}
+
+	// Pre-sweep sanity: gitea running, harbor pending, crossplane failed.
+	pre := mustList(t, st, depID)
+	if got := statusByName(t, pre, "install-gitea"); got != StatusRunning {
+		t.Fatalf("pre-sweep install-gitea = %q, want %q", got, StatusRunning)
+	}
+	if got := statusByName(t, pre, "install-harbor"); got != StatusPending {
+		t.Fatalf("pre-sweep install-harbor = %q, want %q", got, StatusPending)
+	}
+	if got := statusByName(t, pre, "install-crossplane"); got != StatusFailed {
+		t.Fatalf("pre-sweep install-crossplane = %q, want %q", got, StatusFailed)
+	}
+
+	swept, err := br.SweepHandoverInstallJobs(t0.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("SweepHandoverInstallJobs: %v", err)
+	}
+	// gitea (running) + harbor (pending) swept = 2. cilium already
+	// succeeded, crossplane already failed → both skipped.
+	if swept != 2 {
+		t.Fatalf("swept = %d, want 2 (gitea + harbor)", swept)
+	}
+
+	post := mustList(t, st, depID)
+	// No leaf install row may be left non-terminal after the sweep.
+	for _, j := range leafJobs(post) {
+		if !strings.HasPrefix(j.JobName, JobNamePrefix) {
+			continue
+		}
+		if !IsTerminal(j.Status) {
+			t.Fatalf("install row %q left non-terminal after sweep: %q", j.JobName, j.Status)
+		}
+	}
+	// The frozen rows are now Succeeded (handed over).
+	if got := statusByName(t, post, "install-gitea"); got != StatusSucceeded {
+		t.Fatalf("post-sweep install-gitea = %q, want %q", got, StatusSucceeded)
+	}
+	if got := statusByName(t, post, "install-harbor"); got != StatusSucceeded {
+		t.Fatalf("post-sweep install-harbor = %q, want %q", got, StatusSucceeded)
+	}
+	// cilium stays succeeded (untouched), crossplane stays FAILED (a real
+	// failure is never masked as handed-over).
+	if got := statusByName(t, post, "install-cilium"); got != StatusSucceeded {
+		t.Fatalf("post-sweep install-cilium = %q, want %q", got, StatusSucceeded)
+	}
+	if got := statusByName(t, post, "install-crossplane"); got != StatusFailed {
+		t.Fatalf("post-sweep install-crossplane = %q, want %q (failure must be preserved)", got, StatusFailed)
+	}
+
+	// The swept rows carry an honest hand-over LogLine on their
+	// Execution — not a silent fabricated success.
+	gitea, execs, err := st.GetJob(depID, JobID(depID, "install-gitea"))
+	if err != nil {
+		t.Fatalf("GetJob install-gitea: %v", err)
+	}
+	if gitea.FinishedAt == nil {
+		t.Fatal("post-sweep install-gitea has nil FinishedAt — terminal rows must stamp FinishedAt")
+	}
+	if len(execs) == 0 {
+		t.Fatal("post-sweep install-gitea has no Execution")
+	}
+	page, err := st.PageLogs(depID, gitea.LatestExecutionID, 1, 100)
+	if err != nil {
+		t.Fatalf("PageLogs install-gitea: %v", err)
+	}
+	foundNote := false
+	for _, ll := range page.Lines {
+		if strings.Contains(ll.Message, "handed-over") {
+			foundNote = true
+			break
+		}
+	}
+	if !foundNote {
+		t.Fatalf("post-sweep install-gitea log has no hand-over note: %+v", page.Lines)
+	}
+
+	// A row stuck pending with NO Execution gets one allocated
+	// retroactively so the JobsTable never renders an em-dash duration.
+	harbor, harborExecs, err := st.GetJob(depID, JobID(depID, "install-harbor"))
+	if err != nil {
+		t.Fatalf("GetJob install-harbor: %v", err)
+	}
+	if harbor.FinishedAt == nil {
+		t.Fatal("post-sweep install-harbor has nil FinishedAt")
+	}
+	if len(harborExecs) == 0 {
+		t.Fatal("post-sweep install-harbor: expected a retroactively-allocated Execution")
+	}
+}
+
+// TestBridge_SweepHandoverInstallJobs_Idempotent asserts a second sweep
+// is a no-op (every row is already terminal), so a re-attached watch /
+// re-fired handover does not churn the store.
+func TestBridge_SweepHandoverInstallJobs_Idempotent(t *testing.T) {
+	_, br, _ := newBridgeFixture(t)
+	t0 := time.Date(2026, 6, 11, 9, 0, 0, 0, time.UTC)
+	if err := br.OnHelmReleaseEvent("gitea", HelmStateInstalling, "info", "in progress", t0, nil); err != nil {
+		t.Fatalf("OnHelmReleaseEvent: %v", err)
+	}
+
+	first, err := br.SweepHandoverInstallJobs(t0.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("first SweepHandoverInstallJobs: %v", err)
+	}
+	if first != 1 {
+		t.Fatalf("first sweep = %d, want 1", first)
+	}
+	second, err := br.SweepHandoverInstallJobs(t0.Add(2 * time.Minute))
+	if err != nil {
+		t.Fatalf("second SweepHandoverInstallJobs: %v", err)
+	}
+	if second != 0 {
+		t.Fatalf("second sweep = %d, want 0 (idempotent)", second)
+	}
+}
+
+// TestBridge_SweepHandoverInstallJobs_SkipsGroupsAndLifecycle asserts the
+// sweep only touches leaf install rows: the synthesised bootstrap-kit
+// group and the Phase-0 lifecycle Jobs (tofu-*, cluster-bootstrap) are
+// not swept.
+func TestBridge_SweepHandoverInstallJobs_SkipsGroupsAndLifecycle(t *testing.T) {
+	st, br, depID := newBridgeFixture(t)
+	t0 := time.Date(2026, 6, 11, 9, 0, 0, 0, time.UTC)
+
+	// Phase-0 lifecycle Jobs in a pending state (not install-* rows).
+	if err := br.SeedProvisionerJobs(); err != nil {
+		t.Fatalf("SeedProvisionerJobs: %v", err)
+	}
+	// One running install row.
+	if err := br.OnHelmReleaseEvent("gitea", HelmStateInstalling, "info", "in progress", t0, nil); err != nil {
+		t.Fatalf("OnHelmReleaseEvent: %v", err)
+	}
+
+	swept, err := br.SweepHandoverInstallJobs(t0.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("SweepHandoverInstallJobs: %v", err)
+	}
+	// Only install-gitea is swept — the 5 lifecycle Jobs (which are
+	// JobType install but NOT prefixed "install-") are left alone.
+	if swept != 1 {
+		t.Fatalf("swept = %d, want 1 (only the install-* leaf)", swept)
+	}
+
+	post := mustList(t, st, depID)
+	// The lifecycle phase Jobs (e.g. tofu-init) are untouched / pending.
+	if got := statusByName(t, post, PhaseTofuInit); got != StatusPending {
+		t.Fatalf("lifecycle %q = %q after sweep, want %q (must not be swept)", PhaseTofuInit, got, StatusPending)
+	}
+}


### PR DESCRIPTION
Refs #3277 #3263

## Problem
After a Sovereign hands over, the mothership's view of that deployment still shows bp-* install jobs stuck "running" forever.

The mother's Phase-1 helmwatch (`phase1_watch.go`, primary + `spawnSecondaryRegionWatchers`) derives one job row per HelmRelease from live HR state. At watch-end `markPhase1Done` stamps only the tofu LIFECYCLE phases terminal via `markLifecyclePhaseTerminalLocked` — nothing sweeps the still-reconciling bp-* HELMWATCH rows. A row whose last-seen state was non-terminal at handover (informer-dedup loss, a Pod restart that lost the in-memory cursor before the terminal edge, or a secondary-region watcher whose stream stalled) freezes at "running"/"pending" in the snapshot. The mother stops watching post-handover, so it never resolves and the operator's bootstrap view reads "stuck running".

## Fix
- `jobs.Bridge.SweepHandoverInstallJobs(t)` — walks every non-terminal leaf `install-<chart>` row and stamps it `Succeeded`, finishing any open Execution and appending an honest hand-over LogLine. Mirrors `markLifecyclePhaseTerminalLocked`'s locking (`b.mu`) + `FinishExecution` pattern (stamps Execution AND Job in one call).
- `Handler.runHandoverJobSweep(dep)` — called INLINE from `markPhase1Done`'s `OutcomeReady` branch (same placement + reasoning as `runSecondaryBridgeBackfill`), resolving the per-deployment bridge via `bridgeFor`.

## Honesty / correctness
- Runs ONLY on a **successful** handover (`OutcomeReady`), so a failed Phase-1 keeps its failure visible.
- The sweep leaves any **already-Failed** row untouched — a real per-component failure is never masked as handed-over.
- The Job model (and the FE `JobStatus` union) expose only `pending|running|succeeded|failed` — there is no distinct "handed-over" terminal value, and adding a fifth status would ripple across the FE rendering/timeline/flow-adapter and their tests. So the truth about hand-over lives in a final LogLine ("[handed-over] … the mother is no longer tracking this; see the Sovereign console"), not a fabricated status. `Succeeded` is used only for a Ready HR or a row the mother has now handed off; a not-yet-Ready row carries the explanatory LogLine.

## Tests
- `helmwatch_bridge_handover_sweep_test.go` — successful handover with non-terminal HRs sweeps every install row terminal (none left running) while a genuinely failed HR is preserved; idempotency; group + Phase-0 lifecycle rows skipped.
- `phase1_watch_handover_sweep_test.go` — `markPhase1Done(OutcomeReady)` sweeps a stale running row to succeeded; `markPhase1Done(OutcomeFailed)` preserves it (sweep not invoked on failure).

Local: `go build ./...`, `go vet`, full `internal/jobs` + `internal/handler` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)