### PR TITLE
fix(ui): null-deref crash in provision dashboard when treemap items is null (#3281)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.test.tsx
@@ -179,6 +179,38 @@ describe('Dashboard — toolbar + empty state', () => {
   })
 })
 
+describe('Dashboard — null-items provisioning guard (issue #3281)', () => {
+  /**
+   * Regression tests for the null-deref crash introduced by the backend
+   * emitting `{"items": null}` (not `[]`) while a Sovereign is still
+   * provisioning. Both shapes must render the empty state without
+   * throwing «Cannot read properties of null (reading 'length')».
+   *
+   * The fix path: isEmpty = !query.isLoading && !treemapData?.items?.length
+   * and visibleItems useMemo guards: if (!treemapData?.items) return []
+   */
+  it('renders empty state without crashing when items is null', async () => {
+    // Cast needed: the TypeScript type says items: TreemapItem[] (non-null)
+    // but the live API returns items: null during provisioning — that is
+    // the exact lie that caused the crash in #3281.
+    renderDashboard('d-1', { items: null as unknown as never[], total_count: 0 })
+    expect(await screen.findByTestId('dashboard-empty')).toBeTruthy()
+    expect(screen.queryByTestId('dashboard-error')).toBeNull()
+  })
+
+  it('renders empty state without crashing when items is []', async () => {
+    renderDashboard('d-1', { items: [], total_count: 0 })
+    expect(await screen.findByTestId('dashboard-empty')).toBeTruthy()
+    expect(screen.queryByTestId('dashboard-error')).toBeNull()
+  })
+
+  it('does NOT render the treemap surface when items is null', async () => {
+    renderDashboard('d-1', { items: null as unknown as never[], total_count: 0 })
+    await screen.findByTestId('dashboard-empty')
+    expect(screen.queryByTestId('dashboard-treemap-surface')).toBeNull()
+  })
+})
+
 describe('Dashboard — 12-cell flat fixture', () => {
   it('renders the treemap container surface', async () => {
     const { container } = renderDashboard('d-1', TWELVE_CELL_FIXTURE)

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
@@ -223,9 +223,13 @@ export function Dashboard({
   const treemapData: TreemapData | undefined = initialDataOverride ?? query.data
   const totalCount = treemapData?.total_count ?? 0
 
-  /* Visible items at the current drill depth. */
+  /* Visible items at the current drill depth.
+   * treemapData.items may be null (not just undefined) when the cluster
+   * has not yet reported back — the backend emits `"items": null` during
+   * provisioning. Guard with ?. so the null-items path falls through to
+   * the empty-state render instead of throwing. */
   const visibleItems = useMemo<TreemapItem[]>(() => {
-    if (!treemapData) return []
+    if (!treemapData?.items) return []
     return walkDrillPath(treemapData.items, drillPath)
   }, [treemapData, drillPath])
 
@@ -332,7 +336,7 @@ export function Dashboard({
     }
   }, [])
 
-  const isEmpty = !query.isLoading && (!treemapData || treemapData.items.length === 0)
+  const isEmpty = !query.isLoading && !treemapData?.items?.length
   const isNested = layers.length > 1 && drillPath.length === 0
 
   function popDrillTo(idx: number) {


### PR DESCRIPTION
## Summary

- During provisioning the treemap API returns `{"items": null}` (not `[]`), causing `Cannot read properties of null (reading 'length')` at `Dashboard.tsx:335`
- Two dereferences assumed `items` was always a non-null array — both guarded with optional chaining (`?.`)
- Existing empty state text ("Once the Sovereign cluster reports back…") is already honest for the provisioning case — no UI copy change needed

## Dereferences guarded

| Location | Before | After |
|---|---|---|
| `Dashboard.tsx:229` | `walkDrillPath(treemapData.items, drillPath)` | `if (!treemapData?.items) return []` guard before call |
| `Dashboard.tsx:335` | `!treemapData \|\| treemapData.items.length === 0` | `!treemapData?.items?.length` |

## Test plan

- [ ] `npm run test "Dashboard.test"` — 3 new regression tests pass: `items=null` renders empty state without crash, `items=[]` renders empty state, `items=null` does not render treemap surface
- [ ] Pre-existing test count: 8 passing (1 pre-existing failure on `Cluster→Application leaf click` — unrelated to this fix, already failing on main)
- [ ] Navigate to `/sovereign/provision/<id>/dashboard` while hw127 is still provisioning — should show empty state instead of SPA crash

Refs #3281 #3263

🤖 Generated with [Claude Code](https://claude.com/claude-code)