### PR TITLE
fix(bp-postgres): source-side reflector for shared-PG connection Secrets — break the bp-postgres-shared deadlock (#3283)

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -10,9 +10,14 @@
 #   - one CNPG Cluster `shared-pg`
 #   - two Database CRs (registry → harbor, gitea → gitea) on it
 #   - two managed.roles (harbor, gitea) on it
-#   - two reflected connection Secrets (harbor-database-secret into ns
-#     harbor; gitea-database-secret into ns gitea) so each consumer chart
-#     runs in externalDatabase mode off its own Secret.
+#   - two hub connection Secrets (harbor-database-secret, gitea-database-
+#     secret) in THIS release's namespace (shared-data) carrying reflector
+#     auto-push annotations (#3283) so bp-reflector copies a same-named
+#     Secret into ns harbor / ns gitea once those namespaces appear — each
+#     consumer chart then runs in externalDatabase mode off its own Secret.
+#     (The hub Secret lives in shared-data, NOT the consumer namespace,
+#     because those namespaces don't exist when this HR installs — creating
+#     the Secret there directly was the FATAL deadlock fixed in 0.1.2.)
 #
 # NO custom controller, NO Crossplane. The CNPG operator (bp-cnpg, slot
 # 16) + Flux reconcile everything. bp-harbor (19) and bp-gitea (10) set
@@ -76,7 +81,12 @@ spec:
       # 0.1.1 (#3188): master gate `enabled` (default true) → OFF renders
       # ZERO resources so this HR is an empty Ready release when sharing is
       # disabled (SOVEREIGN_ENABLE_SHARED_PG=false, the safe default).
-      version: 0.1.1
+      # 0.1.2 (#3283): the reflected connection Secrets are now created in
+      # shared-data (this HR's own targetNamespace) with reflector auto-push
+      # annotations — NOT in the consumer namespaces (gitea/harbor), which
+      # don't exist when this HR installs. Breaks the bp-postgres-shared ⟲
+      # bp-gitea/bp-harbor circular deadlock (live hw127).
+      version: 0.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-4-1-data-services
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.1.1
+  version: 0.1.2
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-postgres
-version: 0.1.1
-appVersion: "0.1.1"
+version: 0.1.2
+appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable
   PostgreSQL engine. Each install of bp-postgres = ONE
@@ -30,6 +30,19 @@ description: |
 
   Changelog
   ─────────
+  0.1.2 (2026-06-11, Refs #3283)
+    - FATAL deadlock fix: connection-secret.yaml now creates each reflected
+      connection Secret in the RELEASE namespace (shared-data, which always
+      exists) instead of the consumer namespace (gitea/harbor, which is
+      created by the consumer Blueprints that dependsOn THIS HR). The hub
+      Secret PULLS from the CNPG role Secret (reflects) AND is a reflection
+      SOURCE (reflection-allowed + reflection-auto-enabled + reflection-
+      auto-namespaces) so bp-reflector push-copies a same-named copy into
+      each consumer namespace once it appears. Breaks the bp-postgres-shared
+      ⟲ bp-gitea/bp-harbor circular deadlock (`namespaces "gitea" not
+      found`) that wedged any SHARED_PG=true prov (confirmed live hw127).
+      The four annotation keys mirror bp-gitea/bp-harbor cnpg-cluster.yaml
+      inheritedMetadata. No dependsOn edge change.
   0.1.1 (2026-06-10, Refs #3188)
     - Master gate `.Values.enabled` (default true). OFF → the chart
       renders ZERO Kubernetes resources (empty Ready release). The

--- a/platform/postgres/chart/templates/connection-secret.yaml
+++ b/platform/postgres/chart/templates/connection-secret.yaml
@@ -14,6 +14,47 @@ Secret is annotated reflection-allowed via the Cluster's inheritedMetadata
 (cluster.yaml). Per Inviolable Principle #10 (credential hygiene) no
 plaintext lands in this committed template — reflector copies live bytes.
 
+🛑 #3283 — SOURCE-side reflector pattern (the deadlock fix).
+
+  The earlier shape created this connection Secret DIRECTLY in each
+  consumer namespace (`namespace: $ns` where $ns = gitea / harbor). But
+  those namespaces are created by bp-gitea (slot 10) / bp-harbor (slot 19),
+  which **dependsOn bp-postgres-shared** (slot 16a). So at the moment this
+  HR installs, the consumer namespaces do NOT yet exist → the apiserver
+  rejects the Secret with `namespaces "gitea" not found` → bp-postgres-
+  shared never goes Ready → bp-gitea / bp-harbor never run → their
+  namespaces are never created → DEADLOCK (confirmed LIVE on hw127). The
+  cycle cascades to bp-catalyst-platform (console down) and every
+  downstream consumer.
+
+  The fix is the SOURCE-side push: this chart creates ONE hub Secret per
+  binding in its OWN release namespace (`shared-data`, which always
+  exists — it is the bp-postgres-shared targetNamespace). The hub Secret:
+
+    1. PULLS the live bytes from the CNPG-generated role Secret
+       (`<instance>-<owner>`) in this same namespace via the
+       `reflector…/reflects` annotation — exactly as bp-gitea / bp-harbor
+       database-secret.yaml do today, just colocated in shared-data; AND
+
+    2. is itself a reflection SOURCE — it carries reflection-allowed +
+       reflection-auto-enabled + reflection-auto-namespaces so bp-reflector
+       AUTO-PUSHES a same-named copy into each consumer namespace AS SOON
+       AS that namespace appears. (Reflector preserves the source name on
+       auto-push — see platform/powerdns-admin pdns-api-credentials-mirror
+       comment — so the hub Secret is named `reflect.secretName`, the exact
+       name the consumer chart's externalDatabase env binding reads. The
+       push copy lands as `<consumer-ns>/<reflect.secretName>`.)
+
+  Result: bp-postgres-shared install only ever touches shared-data → it
+  goes Ready cleanly → unblocks bp-gitea / bp-harbor → they create their
+  namespaces → reflector copies the hub Secret in within a reconcile
+  interval (~5s) → the consumer Pod reads its DB password. No deadlock.
+
+  The four annotation keys are the exact ones bp-gitea / bp-harbor
+  cnpg-cluster.yaml inheritedMetadata already rely on for their 1:1 path
+  (reflection-allowed / reflection-allowed-namespaces / reflection-auto-
+  enabled / reflection-auto-namespaces), mirrored verbatim.
+
 Helm `lookup` is intentionally NOT used: on a fresh Sovereign CNPG
 bootstraps the role Secret AFTER this HelmRelease applies, so a lookup
 would render empty. Reflector is event-driven and updates within seconds.
@@ -28,21 +69,34 @@ so the slot 16a HR is an empty Ready release when sharing is disabled.
 {{- $sourceSecret := include "bp-postgres.roleSecretName" (dict "ctx" $ctx "db" $db) }}
 {{- $sourceNs := include "bp-postgres.namespace" $ctx }}
 {{- $secretName := $db.reflect.secretName | default (printf "%s-database-secret" $db.name) }}
-{{- range $ns := $db.reflect.namespaces }}
+{{- $targetNamespaces := join "," $db.reflect.namespaces }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
+  # The hub Secret lives in the RELEASE namespace (shared-data), which
+  # always exists. Reflector AUTO-PUSHES a same-named copy into each
+  # consumer namespace once it appears — the source-side pattern that
+  # breaks the bp-postgres-shared ⟲ bp-gitea/bp-harbor deadlock (#3283).
   name: {{ $secretName }}
-  namespace: {{ $ns }}
+  namespace: {{ $sourceNs }}
   labels:
     {{- include "bp-postgres.labels" $ctx | nindent 4 }}
     catalyst.openova.io/binding-secret: {{ $db.name | quote }}
   annotations:
-    # bp-reflector mirrors all keys from the CNPG-generated role Secret
-    # into this Secret. The consumer reads `password` / `username` / the
-    # connection keys CNPG emits (`host`, `port`, `dbname`, `uri`, …).
+    # Hop 1 — PULL: copy all keys from the CNPG-generated role Secret
+    # (in this same shared-data namespace) into this hub Secret. The
+    # consumer reads `password` / `username` / the connection keys CNPG
+    # emits (`host`, `port`, `dbname`, `uri`, …).
     reflector.v1.k8s.emberstack.com/reflects: "{{ $sourceNs }}/{{ $sourceSecret }}"
+    # Hop 2 — PUSH (source-side): mark this hub Secret reflection-allowed
+    # and auto-push a same-named copy into each consumer namespace AS SOON
+    # AS that namespace exists. These are the EXACT four keys bp-gitea /
+    # bp-harbor cnpg-cluster.yaml inheritedMetadata use for their 1:1 path.
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: {{ $targetNamespaces | quote }}
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: {{ $targetNamespaces | quote }}
     # Keep on helm uninstall — reflector independently manages it after
     # first creation.
     helm.sh/resource-policy: keep
@@ -52,7 +106,6 @@ type: Opaque
 # (missing key) during the initial consumer render.
 data:
   password: ""
-{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -10,6 +10,11 @@
 #      single Cluster. This is the reuse proof: 2 consumers, 1 engine.
 #   3. The Database CRs each carry the binding owner + the shared cluster
 #      name, proving logical isolation on one engine.
+#   3b. (#3283 deadlock fix) Every reflected connection Secret lands in the
+#      RELEASE namespace (shared-data) — NONE targets gitea/harbor directly
+#      (those namespaces don't exist when bp-postgres-shared installs). Each
+#      hub Secret carries reflection-auto-namespaces naming the consumer ns
+#      so bp-reflector push-copies it in once the namespace appears.
 #   4. active-hot-standby + sync → the Cluster carries
 #      synchronous_commit + synchronous_standby_names (ADR-0004 Pillar-3).
 #   5. singleton → the Cluster carries NEITHER sync GUC.
@@ -76,6 +81,38 @@ shared_refs=$(grep -cE '^    name: shared-pg$' "$TMP/shared.yaml" || true)
 [ "$shared_refs" -ge 2 ] || fail "expected both Database CRs to point at shared-pg (got $shared_refs)"
 grep -q 'owner: "harbor"' "$TMP/shared.yaml" || fail "harbor owner missing"
 grep -q 'owner: "gitea"'  "$TMP/shared.yaml" || fail "gitea owner missing"
+
+# ── Case 3b: #3283 — connection Secrets land in shared-data, NOT the ──
+# consumer namespaces (which don't exist when bp-postgres-shared installs).
+# This is the deadlock regression-lock: the SOURCE-side reflector pattern.
+echo "[render] Case 3b: #3283 — every reflected Secret in shared-data (push-source), none in gitea/harbor"
+# Extract the namespace of every Secret. The shared.values namespace is
+# shared-data; assert all reflected connection Secrets carry it.
+secret_ns_in_shared=$(awk '/^kind: Secret$/{s=1} s&&/^  namespace: shared-data$/{c++} /^---$/{s=0} END{print c+0}' "$TMP/shared.yaml")
+[ "$secret_ns_in_shared" -eq 2 ] || fail "#3283: expected 2 connection Secrets in shared-data, got $secret_ns_in_shared"
+# NO Secret may target the consumer namespaces directly — that is the bug.
+if grep -E '^  namespace: (gitea|harbor)$' "$TMP/shared.yaml" | grep -q .; then
+  fail "#3283 REGRESSION: a Secret targets a consumer namespace (gitea/harbor) directly — re-introduces the deadlock"
+fi
+# Each hub Secret must carry the push-source annotations naming its
+# consumer namespace so reflector auto-copies it once the ns appears.
+grep -q 'reflector.v1.k8s.emberstack.com/reflection-allowed: "true"' "$TMP/shared.yaml" \
+  || fail "#3283: hub Secret missing reflection-allowed"
+grep -q 'reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"' "$TMP/shared.yaml" \
+  || fail "#3283: hub Secret missing reflection-auto-enabled"
+grep -q 'reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "harbor"' "$TMP/shared.yaml" \
+  || fail "#3283: harbor hub Secret missing reflection-auto-namespaces: harbor"
+grep -q 'reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "gitea"' "$TMP/shared.yaml" \
+  || fail "#3283: gitea hub Secret missing reflection-auto-namespaces: gitea"
+grep -q 'reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "harbor"' "$TMP/shared.yaml" \
+  || fail "#3283: harbor hub Secret missing reflection-allowed-namespaces: harbor"
+grep -q 'reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "gitea"' "$TMP/shared.yaml" \
+  || fail "#3283: gitea hub Secret missing reflection-allowed-namespaces: gitea"
+# And each still PULLS from the CNPG role Secret in shared-data (hop 1).
+grep -q 'reflector.v1.k8s.emberstack.com/reflects: "shared-data/shared-pg-harbor"' "$TMP/shared.yaml" \
+  || fail "#3283: harbor hub Secret missing reflects from shared-data/shared-pg-harbor"
+grep -q 'reflector.v1.k8s.emberstack.com/reflects: "shared-data/shared-pg-gitea"' "$TMP/shared.yaml" \
+  || fail "#3283: gitea hub Secret missing reflects from shared-data/shared-pg-gitea"
 
 # ── Case 4: active-hot-standby + sync → sync GUCs present ─────────
 echo "[render] Case 4: active-hot-standby + sync → synchronous-replication GUCs"


### PR DESCRIPTION
## What

Fixes the FATAL circular deadlock that wedges any `SHARED_PG=true` prov (confirmed live on hw127, #3283).

`platform/postgres/chart/templates/connection-secret.yaml` created each reflected connection Secret **directly in the consumer namespace** (`namespace: {{ $ns }}` where `$ns` = gitea / harbor). But those namespaces are created by bp-gitea (slot 10) / bp-harbor (slot 19), which **dependsOn bp-postgres-shared** (slot 16a). At install time the consumer namespaces do not yet exist → the apiserver rejects the Secret with `namespaces "gitea" not found` → bp-postgres-shared never goes Ready → the consumers never run → their namespaces are never created → **circular deadlock** → cascades to bp-catalyst-platform (console down) and every downstream consumer.

## Fix — source-side reflector (the ADR-0010 pattern the template's own docs describe)

The chart now creates **one hub Secret per binding in its OWN release namespace** (`shared-data`, which always exists — it is the bp-postgres-shared `targetNamespace`). The hub Secret:

1. **Hop 1 (PULL)** — copies the live bytes from the CNPG-generated role Secret (`shared-pg-<owner>`) in the same `shared-data` namespace via the `reflector…/reflects` annotation (exactly as bp-gitea/bp-harbor `database-secret.yaml` do today, just colocated in shared-data).
2. **Hop 2 (PUSH, source-side)** — carries `reflection-allowed` + `reflection-allowed-namespaces` + `reflection-auto-enabled` + `reflection-auto-namespaces` so bp-reflector **auto-pushes a same-named copy** into each consumer namespace as soon as it appears. (Reflector preserves the source name on auto-push, so the hub Secret is named `reflect.secretName` — the exact name the consumer reads — and the push copy lands as `<consumer-ns>/<reflect.secretName>`.)

bp-postgres-shared install now only ever touches `shared-data` → goes Ready cleanly → unblocks bp-gitea/bp-harbor → they create their namespaces → reflector copies the hub Secret in (~5s). No deadlock.

The four annotation keys mirror bp-gitea/bp-harbor `cnpg-cluster.yaml` `inheritedMetadata` **verbatim** (the working 1:1 reflector idiom).

## dependsOn graph

**Unchanged** — `bp-postgres-shared` → `[bp-cnpg, bp-reflector]`; gitea/harbor → `bp-postgres-shared`. The fix makes the existing edges **satisfiable** (bp-postgres-shared no longer needs the consumer namespaces). `scripts/expected-bootstrap-deps.yaml` needs no update.

## PROOF — rendered Secret metadata (helm template, 2 consumers gitea+harbor)

Every reflected Secret now has `namespace: shared-data` and carries the reflection annotations naming its consumer namespace. NONE targets gitea/harbor directly.

```yaml
kind: Secret
metadata:
  name: harbor-database-secret
  namespace: shared-data
  ...
  annotations:
    reflector.v1.k8s.emberstack.com/reflects: "shared-data/shared-pg-harbor"
    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "harbor"
    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "harbor"
    helm.sh/resource-policy: keep
type: Opaque
---
kind: Secret
metadata:
  name: gitea-database-secret
  namespace: shared-data
  ...
  annotations:
    reflector.v1.k8s.emberstack.com/reflects: "shared-data/shared-pg-gitea"
    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "gitea"
    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "gitea"
    helm.sh/resource-policy: keep
type: Opaque
```

`tests/postgres-render.sh` gains **Case 3b** asserting: 2 Secrets in `shared-data`, 0 in gitea/harbor, each carries `reflection-auto-namespaces` naming its consumer ns + `reflects` from the right CNPG role Secret. All 7 cases pass; `helm lint` clean.

## Lockstep

- `platform/postgres/chart/Chart.yaml` 0.1.1 → **0.1.2** (+ changelog)
- `platform/postgres/blueprint.yaml` `spec.version` 0.1.1 → **0.1.2**
- `clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml` chart pin → **0.1.2**

## Honest follow-up (NOT this PR — does not affect the deadlock fix)

The gitea Pod reads its DB password directly from `gitea-pg-app` via `additionalConfigFromEnvs` secretKeyRef (`platform/gitea/chart/values.yaml`), not from `gitea-database-secret`. In SHARED mode the CNPG role Secret is `shared-pg-gitea` in `shared-data`, so the reflected `gitea-database-secret` name does not match gitea's env binding. That is a separate SHARED-PG consumer-wiring gap behind the OFF-by-default two-flag contract (`SOVEREIGN_GITEA_PG_OWN_CLUSTER=false` + `SOVEREIGN_ENABLE_SHARED_PG=true`) and is irrelevant to the FATAL deadlock this PR fixes (bp-postgres-shared can now install at all). Tracked for the actual SHARED-PG walk.

Refs #3283 #3188

🤖 Generated with [Claude Code](https://claude.com/claude-code)
