### PR TITLE
fix(bp-gitea,bp-harbor): SHARED-PG consumers read the reflected connection Secret + shared engine (#3285)

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -114,7 +114,13 @@ spec:
       # RollingUpdate{maxUnavailable:0,maxSurge:100%}). RWO /data + LevelDB
       # lock wedge the surge-pod roll; Recreate releases the PVC + lock
       # before the new Pod starts so the 1.2.x roll completes clean.
-      version: 1.2.26
+      # 1.2.27 (#3285): SHARED-PG consumer wiring — database-secret-sync-job
+      # gated on postgres.cluster.enabled (skipped in SHARED mode, where no
+      # gitea-pg-app exists to poll). The DB password secret NAME flips via
+      # the SOVEREIGN_GITEA_PG_SECRET seam below (own-cluster gitea-pg-app →
+      # SHARED gitea-database-secret, the reflected Secret). own-cluster
+      # render byte-identical.
+      version: 1.2.27
       sourceRef:
         kind: HelmRepository
         name: bp-gitea
@@ -201,3 +207,25 @@ spec:
           # sharing, by gitea's own cluster otherwise) either way.
           database:
             HOST: ${SOVEREIGN_GITEA_PG_HOST:=gitea-pg-rw.gitea.svc.cluster.local}:5432
+        # ADR-0010 SHARED-PG consumer wiring (#3285). The upstream subchart
+        # reads GITEA__database__PASSWD from a single secretKeyRef whose
+        # NAME flips between modes (the `password` key is identical in both
+        # sources). Default `gitea-pg-app` = CNPG's own basic-auth Secret on
+        # gitea's OWN gitea-pg Cluster (byte-identical 1:1 path). Set
+        # SOVEREIGN_GITEA_PG_SECRET=gitea-database-secret in SHARED mode so
+        # gitea reads the reflected Secret bp-postgres-shared pushes into the
+        # gitea namespace from the shared engine's `shared-pg-gitea` role
+        # Secret (#3284 source-side reflector). This overrides the whole
+        # single-element list in platform/gitea/chart/values.yaml — the
+        # umbrella chart can NOT template a subchart value (upstream uses
+        # `toYaml`, not `tpl`), so the seam lives here. TWO-FLAG CONTRACT:
+        # to actually SHARE, pair this with SOVEREIGN_GITEA_PG_OWN_CLUSTER=
+        # false (skips gitea's own Cluster) + SOVEREIGN_GITEA_PG_HOST=
+        # shared-pg-rw.shared-data.svc.cluster.local (points DB host at the
+        # shared engine) + SOVEREIGN_ENABLE_SHARED_PG=true (slot 16a).
+        additionalConfigFromEnvs:
+          - name: GITEA__database__PASSWD
+            valueFrom:
+              secretKeyRef:
+                name: ${SOVEREIGN_GITEA_PG_SECRET:=gitea-pg-app}
+                key: password

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -152,6 +152,11 @@ spec:
   chart:
     spec:
       chart: bp-harbor
+      # 1.2.28: #3285 — SHARED-PG consumer wiring. database-secret-sync-job
+      # gated on postgres.cluster.enabled (skipped in SHARED mode, where no
+      # harbor-pg-app exists to poll). harbor's externalDatabase already
+      # reads harbor-database-secret (key password); the host flips via the
+      # SOVEREIGN_HARBOR_PG_HOST seam below. own-cluster render byte-identical.
       # 1.2.26: #3098 — guard the SSO ExternalSecret template with the
       # .Capabilities.APIVersions.Has "external-secrets.io/v1beta1" CRD-check
       # (gold standard, mirrors bp-external-dns + bp-sandbox). The dependsOn:
@@ -175,7 +180,7 @@ spec:
       # live on otech113 2026-05-05 (issue #935 Bug 1) — Step 02 was
       # in CreateContainerConfigError for 11+ retries, blocking
       # cutover indefinitely.
-      version: 1.2.27
+      version: 1.2.28
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.26
+  version: 1.2.27
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -97,7 +97,18 @@ name: bp-gitea
 # (old RS never scales down → HR Stalled → bp-catalyst-platform blocked).
 # Recreate terminates the old Pod first (releasing the PVC + lock) then
 # starts the new one. Single-replica gitea has no roll-time HA to lose.
-version: 1.2.26
+# 1.2.27 (#3285, 2026-06-11): SHARED-PG consumer wiring. The
+# database-secret-sync-job (which polls `gitea-pg-app` to mirror the
+# CNPG password into gitea-database-secret) is now gated on
+# `postgres.cluster.enabled != false` — the same gate cnpg-cluster.yaml +
+# database-secret.yaml already carry. In SHARED mode there is no
+# gitea-pg-app to poll; the populated gitea-database-secret is reflected
+# in by bp-postgres-shared (#3284), so the un-gated Job would time out
+# and FAIL the post-install hook. The DB password secret NAME flips via
+# the bootstrap-kit slot 10 `SOVEREIGN_GITEA_PG_SECRET` seam (own-cluster
+# default gitea-pg-app → SHARED gitea-database-secret). own-cluster render
+# byte-identical to 1.2.26.
+version: 1.2.27
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/database-secret-sync-job.yaml
+++ b/platform/gitea/chart/templates/database-secret-sync-job.yaml
@@ -41,7 +41,19 @@ returns Found before this Job populates it; some tooling assumes
 the Secret is named for the lifetime of the release). Reflector
 annotations are kept harmless — they just become a redundant
 no-op once this Job has populated the Secret.
+
+ADR-0010 SHARING gate (#3285): when gitea SHARES a bp-postgres instance
+(`postgres.cluster.enabled=false`) there is NO `gitea-pg-app` Secret in
+the gitea namespace — the shared engine's `shared-pg-gitea` role Secret
+lives in shared-data and bp-postgres-shared already reflects the populated
+`gitea-database-secret` into the gitea namespace (the #3284 source-side
+push). This sync Job would poll a non-existent `gitea-pg-app` for 10 min,
+time out (exit 1), exhaust backoffLimit, and FAIL the post-install hook →
+Helm rolls the bp-gitea release back. So skip the whole Job (+ its SA /
+Role / RoleBinding) when the embedded cluster is disabled — the SAME gate
+the cnpg-cluster.yaml + database-secret.yaml templates already carry.
 */}}
+{{- if ne (toString .Values.postgres.cluster.enabled) "false" }}
 {{- $ns := .Values.postgres.cluster.namespace | default .Release.Namespace }}
 {{- $clusterName := .Values.postgres.cluster.name | default "gitea-pg" }}
 apiVersion: batch/v1
@@ -193,3 +205,4 @@ subjects:
   - kind: ServiceAccount
     name: gitea-database-secret-sync
     namespace: {{ $ns }}
+{{- end }}

--- a/platform/gitea/chart/tests/shared-pg-consumer-wiring.sh
+++ b/platform/gitea/chart/tests/shared-pg-consumer-wiring.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# bp-gitea — ADR-0010 SHARED-PG consumer wiring gate (#3285, #3188).
+#
+# #3284 broke the bp-postgres-shared ⟲ bp-gitea/bp-harbor deadlock by
+# reflecting a populated `gitea-database-secret` into the gitea namespace.
+# #3285 is the remaining piece: in SHARED mode gitea must actually CONSUME
+# the shared engine — drop its bundled CNPG Cluster, skip the sync Job that
+# polls a non-existent `gitea-pg-app`, and read its DB password from the
+# reflected `gitea-database-secret` (key `password`) while its DB host
+# points at the shared engine's -rw Service.
+#
+# Two-flag contract (both default OFF → own-cluster, byte-identical):
+#   SOVEREIGN_GITEA_PG_OWN_CLUSTER=false → postgres.cluster.enabled=false
+#   + the slot-10 SOVEREIGN_GITEA_PG_SECRET / SOVEREIGN_GITEA_PG_HOST seams
+#     point the password secretKeyRef + DB host at the shared engine.
+#
+# Cases:
+#   1. own-cluster (default): bundled CNPG Cluster present; sync Job present;
+#      PASSWD env reads gitea-pg-app; DB host is gitea-pg-rw.gitea.
+#   2. SHARED (postgres.cluster.enabled=false + slot seams): NO bundled
+#      CNPG Cluster; NO sync Job; NO placeholder gitea-database-secret;
+#      PASSWD env reads the reflected gitea-database-secret; DB host is the
+#      shared engine's -rw Service.
+#
+# Usage: bash tests/shared-pg-consumer-wiring.sh [CHART_DIR]
+
+set -euo pipefail
+
+chart_dir="$(cd "${1:-$(dirname "$0")/..}" && pwd)"
+helm="${HELM_BIN:-helm}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# ── Case 1: own-cluster (default) ───────────────────────────────────────
+echo "[shared-pg] Case 1: own-cluster default → bundled CNPG + sync Job + gitea-pg-app"
+"$helm" template smoke "$chart_dir" --api-versions postgresql.cnpg.io/v1 \
+  > "$tmp/own.yaml" 2> "$tmp/own.err" || { cat "$tmp/own.err" >&2; fail "own-cluster render errored"; }
+
+[ "$(grep -cE '^kind: Cluster$' "$tmp/own.yaml")" -eq 1 ] \
+  || fail "own-cluster: expected 1 bundled CNPG Cluster"
+grep -q 'name: gitea-database-secret-sync$' "$tmp/own.yaml" \
+  || fail "own-cluster: sync Job missing"
+# PASSWD env reads gitea-pg-app
+grep -A4 'name: GITEA__database__PASSWD' "$tmp/own.yaml" | grep -q 'name: gitea-pg-app' \
+  || fail "own-cluster: PASSWD env must read gitea-pg-app"
+grep -q 'HOST=gitea-pg-rw.gitea.svc.cluster.local' "$tmp/own.yaml" \
+  || fail "own-cluster: DB host must be gitea-pg-rw.gitea"
+echo "  PASS"
+
+# ── Case 2: SHARED mode ─────────────────────────────────────────────────
+# Simulate the slot-10 envsubst seams: postgres.cluster.enabled=false +
+# the reflected secret name + the shared engine host.
+echo "[shared-pg] Case 2: SHARED → no bundled Cluster, no sync Job, reads reflected gitea-database-secret"
+"$helm" template smoke "$chart_dir" \
+  --set postgres.cluster.enabled=false \
+  --set 'gitea.gitea.config.database.HOST=shared-pg-rw.shared-data.svc.cluster.local:5432' \
+  --set 'gitea.gitea.additionalConfigFromEnvs[0].name=GITEA__database__PASSWD' \
+  --set 'gitea.gitea.additionalConfigFromEnvs[0].valueFrom.secretKeyRef.name=gitea-database-secret' \
+  --set 'gitea.gitea.additionalConfigFromEnvs[0].valueFrom.secretKeyRef.key=password' \
+  --api-versions postgresql.cnpg.io/v1 \
+  > "$tmp/shared.yaml" 2> "$tmp/shared.err" || { cat "$tmp/shared.err" >&2; fail "shared render errored"; }
+
+[ "$(grep -cE '^kind: Cluster$' "$tmp/shared.yaml")" -eq 0 ] \
+  || fail "SHARED: bundled CNPG Cluster must NOT render"
+grep -q 'name: gitea-database-secret-sync$' "$tmp/shared.yaml" \
+  && fail "SHARED: sync Job must NOT render (no gitea-pg-app to poll)" || true
+# placeholder gitea-database-secret Secret resource must NOT render in SHARED
+# (bp-postgres-shared owns the reflected copy). awk scopes to Secret docs.
+if awk '/^kind: Secret$/{k=1;next} k&&/^  name: gitea-database-secret$/{print "x"} /^---$/{k=0}' "$tmp/shared.yaml" | grep -q x; then
+  fail "SHARED: placeholder gitea-database-secret Secret must NOT render"
+fi
+# PASSWD env reads the reflected gitea-database-secret
+grep -A4 'name: GITEA__database__PASSWD' "$tmp/shared.yaml" | grep -q 'name: gitea-database-secret' \
+  || fail "SHARED: PASSWD env must read the reflected gitea-database-secret"
+grep -A4 'name: GITEA__database__PASSWD' "$tmp/shared.yaml" | grep -q 'key: password' \
+  || fail "SHARED: PASSWD env key must be 'password'"
+grep -q 'HOST=shared-pg-rw.shared-data.svc.cluster.local' "$tmp/shared.yaml" \
+  || fail "SHARED: DB host must point at the shared engine -rw Service"
+echo "  PASS"
+
+echo
+echo "[shared-pg-consumer-wiring] ALL CASES PASS"

--- a/platform/gitea/chart/values.yaml
+++ b/platform/gitea/chart/values.yaml
@@ -112,6 +112,23 @@ gitea:
     # entirely; gitea-database-secret + its sync Job remain for the
     # OTHER consumers documented in database-secret-sync-job.yaml
     # (harbor's env binding shape).
+    #
+    # ADR-0010 SHARING gate (#3285): the secretKeyRef NAME below is the
+    # ONLY thing that flips between modes (the `password` key is identical
+    # in both source Secrets):
+    #   - own-cluster (default): `gitea-pg-app` — CNPG's bundled basic-auth
+    #     Secret on gitea's OWN gitea-pg Cluster. Byte-identical hw91 path.
+    #   - SHARED (SOVEREIGN_GITEA_PG_OWN_CLUSTER=false): the reflected
+    #     `gitea-database-secret`, which bp-reflector pushes into the gitea
+    #     namespace from the shared engine's `shared-pg-gitea` role Secret
+    #     (CNPG synthesises it with a `password` key — same key, same
+    #     secretKeyRef shape, so only the Secret NAME changes).
+    # The upstream subchart consumes `additionalConfigFromEnvs` with a plain
+    # `toYaml` (not `tpl`), so the umbrella chart can NOT template this name.
+    # The bootstrap-kit slot 10 overlay overrides the whole single-element
+    # list via the `SOVEREIGN_GITEA_PG_SECRET` envsubst seam (default
+    # gitea-pg-app). This committed default keeps a standalone
+    # `helm template` (and every own-cluster prov) byte-identical.
     additionalConfigFromEnvs:
       - name: GITEA__database__PASSWD
         valueFrom:

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.27
+  version: 1.2.28
   card:
     title: Harbor
     family: foundation

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -62,7 +62,18 @@ type: application
 # never fired. Observed live on hw100. The slot-19 dependsOn: bp-external-secrets
 # gates HR-Ready but not webhook-serving; this Capabilities guard is its
 # complementary half — omit until the CRD exists, re-render on next reconcile.
-version: 1.2.27
+# 1.2.28 (#3285, 2026-06-11): SHARED-PG consumer wiring. The
+# database-secret-sync-job (which polls `harbor-pg-app` to mirror the CNPG
+# password into harbor-database-secret) is now gated on
+# `postgres.cluster.enabled != false` — the same gate cnpg-cluster.yaml +
+# database-secret.yaml already carry. In SHARED mode there is no
+# harbor-pg-app to poll; the populated harbor-database-secret is reflected
+# in by bp-postgres-shared (#3284), so the un-gated Job would time out and
+# FAIL the post-install hook. harbor's externalDatabase already reads
+# `harbor-database-secret` (key `password`) + its host flips via the
+# SOVEREIGN_HARBOR_PG_HOST slot seam, so no other consumer change is
+# needed. own-cluster render byte-identical to 1.2.27.
+version: 1.2.28
 appVersion: "2.14.3"
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now

--- a/platform/harbor/chart/templates/database-secret-sync-job.yaml
+++ b/platform/harbor/chart/templates/database-secret-sync-job.yaml
@@ -41,7 +41,19 @@ returns Found before this Job populates it; some tooling assumes
 the Secret is named for the lifetime of the release). Reflector
 annotations are kept harmless — they just become a redundant
 no-op once this Job has populated the Secret.
+
+ADR-0010 SHARING gate (#3285): when harbor SHARES a bp-postgres instance
+(`postgres.cluster.enabled=false`) there is NO `harbor-pg-app` Secret in
+the harbor namespace — the shared engine's `shared-pg-harbor` role Secret
+lives in shared-data and bp-postgres-shared already reflects the populated
+`harbor-database-secret` into the harbor namespace (the #3284 source-side
+push). This sync Job would poll a non-existent `harbor-pg-app` for 10 min,
+time out (exit 1), exhaust backoffLimit, and FAIL the post-install hook →
+Helm rolls the bp-harbor release back. So skip the whole Job (+ its SA /
+Role / RoleBinding) when the embedded cluster is disabled — the SAME gate
+the cnpg-cluster.yaml + database-secret.yaml templates already carry.
 */}}
+{{- if ne (toString .Values.postgres.cluster.enabled) "false" }}
 {{- $ns := .Values.postgres.cluster.namespace | default .Release.Namespace }}
 {{- $clusterName := .Values.postgres.cluster.name | default "harbor-pg" }}
 apiVersion: batch/v1
@@ -189,3 +201,4 @@ subjects:
   - kind: ServiceAccount
     name: harbor-database-secret-sync
     namespace: {{ $ns }}
+{{- end }}

--- a/platform/harbor/chart/tests/shared-pg-consumer-wiring.sh
+++ b/platform/harbor/chart/tests/shared-pg-consumer-wiring.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# bp-harbor — ADR-0010 SHARED-PG consumer wiring gate (#3285, #3188).
+#
+# #3284 broke the bp-postgres-shared ⟲ bp-gitea/bp-harbor deadlock by
+# reflecting a populated `harbor-database-secret` into the harbor namespace.
+# #3285 is the remaining piece: in SHARED mode harbor must actually CONSUME
+# the shared engine — drop its bundled CNPG Cluster, skip the sync Job that
+# polls a non-existent `harbor-pg-app`, and read its DB password from the
+# reflected `harbor-database-secret` (key `password`, via the upstream
+# chart's database.external.existingSecret) while its DB host points at the
+# shared engine's -rw Service.
+#
+# harbor's externalDatabase already reads `harbor-database-secret` in BOTH
+# modes (the umbrella default), so the consumer-side delta is small:
+#   - skip the bundled CNPG Cluster (postgres.cluster.enabled gate, already
+#     on cnpg-cluster.yaml + database-secret.yaml)
+#   - skip the un-gated sync Job (the #3285 change)
+#   - flip the DB host via the slot-19 SOVEREIGN_HARBOR_PG_HOST seam.
+#
+# Cases:
+#   1. own-cluster (default): bundled CNPG Cluster present; sync Job present;
+#      POSTGRESQL_PASSWORD reads harbor-database-secret; host harbor-pg-rw.harbor.
+#   2. SHARED (postgres.cluster.enabled=false + slot host seam): NO bundled
+#      CNPG Cluster; NO sync Job; NO placeholder harbor-database-secret;
+#      POSTGRESQL_PASSWORD reads harbor-database-secret; host shared-pg-rw.shared-data.
+#
+# Usage: bash tests/shared-pg-consumer-wiring.sh [CHART_DIR]
+
+set -euo pipefail
+
+chart_dir="$(cd "${1:-$(dirname "$0")/..}" && pwd)"
+helm="${HELM_BIN:-helm}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# ── Case 1: own-cluster (default) ───────────────────────────────────────
+echo "[shared-pg] Case 1: own-cluster default → bundled CNPG + sync Job + harbor-pg-rw host"
+"$helm" template smoke "$chart_dir" --api-versions postgresql.cnpg.io/v1 \
+  > "$tmp/own.yaml" 2> "$tmp/own.err" || { cat "$tmp/own.err" >&2; fail "own-cluster render errored"; }
+
+[ "$(grep -cE '^kind: Cluster$' "$tmp/own.yaml")" -eq 1 ] \
+  || fail "own-cluster: expected 1 bundled CNPG Cluster"
+grep -q 'name: harbor-database-secret-sync$' "$tmp/own.yaml" \
+  || fail "own-cluster: sync Job missing"
+grep -A4 'name: POSTGRESQL_PASSWORD' "$tmp/own.yaml" | grep -q 'name: harbor-database-secret' \
+  || fail "own-cluster: POSTGRESQL_PASSWORD must read harbor-database-secret"
+grep -q 'POSTGRESQL_HOST: "harbor-pg-rw.harbor.svc.cluster.local"' "$tmp/own.yaml" \
+  || fail "own-cluster: DB host must be harbor-pg-rw.harbor"
+echo "  PASS"
+
+# ── Case 2: SHARED mode ─────────────────────────────────────────────────
+echo "[shared-pg] Case 2: SHARED → no bundled Cluster, no sync Job, reads reflected harbor-database-secret"
+"$helm" template smoke "$chart_dir" \
+  --set postgres.cluster.enabled=false \
+  --set 'harbor.database.external.host=shared-pg-rw.shared-data.svc.cluster.local' \
+  --api-versions postgresql.cnpg.io/v1 \
+  > "$tmp/shared.yaml" 2> "$tmp/shared.err" || { cat "$tmp/shared.err" >&2; fail "shared render errored"; }
+
+[ "$(grep -cE '^kind: Cluster$' "$tmp/shared.yaml")" -eq 0 ] \
+  || fail "SHARED: bundled CNPG Cluster must NOT render"
+grep -q 'name: harbor-database-secret-sync$' "$tmp/shared.yaml" \
+  && fail "SHARED: sync Job must NOT render (no harbor-pg-app to poll)" || true
+# placeholder harbor-database-secret Secret resource must NOT render in SHARED.
+if awk '/^kind: Secret$/{k=1;next} k&&/^  name: harbor-database-secret$/{print "x"} /^---$/{k=0}' "$tmp/shared.yaml" | grep -q x; then
+  fail "SHARED: placeholder harbor-database-secret Secret must NOT render"
+fi
+grep -A4 'name: POSTGRESQL_PASSWORD' "$tmp/shared.yaml" | grep -q 'name: harbor-database-secret' \
+  || fail "SHARED: POSTGRESQL_PASSWORD must read the reflected harbor-database-secret"
+grep -A4 'name: POSTGRESQL_PASSWORD' "$tmp/shared.yaml" | grep -q 'key: password' \
+  || fail "SHARED: POSTGRESQL_PASSWORD key must be 'password'"
+grep -q 'POSTGRESQL_HOST: "shared-pg-rw.shared-data.svc.cluster.local"' "$tmp/shared.yaml" \
+  || fail "SHARED: DB host must point at the shared engine -rw Service"
+echo "  PASS"
+
+echo
+echo "[shared-pg-consumer-wiring] ALL CASES PASS"


### PR DESCRIPTION
## What

Wires the remaining piece of the SHARED-PG model (the #3188 reuse proof): in SHARED mode the consumers (gitea, harbor) now connect to the SHARED engine via the reflected connection Secret, instead of their OWN bundled CNPG.

#3284 broke the `bp-postgres-shared ⟲ bp-gitea/bp-harbor` convergence deadlock by reflecting a populated `<consumer>-database-secret` into each consumer namespace from the shared engine's role Secret. This PR makes the consumers actually CONSUME it.

## Changes

**bp-gitea** (`platform/gitea/`)
- `database-secret-sync-job.yaml`: gated on `postgres.cluster.enabled != false` (same gate `cnpg-cluster.yaml` + `database-secret.yaml` already carry). In SHARED mode there is no `gitea-pg-app` to poll — the un-gated Job would time out after 10 min, exhaust `backoffLimit`, and FAIL the post-install hook → release rollback.
- `values.yaml`: documents the two-mode `additionalConfigFromEnvs` secret-name seam.
- bootstrap-kit slot 10: new `SOVEREIGN_GITEA_PG_SECRET` envsubst seam overrides the single-element `additionalConfigFromEnvs` so the `GITEA__database__PASSWD` secretKeyRef flips from `gitea-pg-app` (own) → reflected `gitea-database-secret` (shared). The umbrella chart can't template a subchart value (upstream uses `toYaml`, not `tpl`), so the seam lives in the slot — same pattern as the existing `SOVEREIGN_GITEA_PG_HOST` host seam.

**bp-harbor** (`platform/harbor/`)
- `database-secret-sync-job.yaml`: same gate. harbor's externalDatabase ALREADY reads `harbor-database-secret` (key `password`) in both modes + its host flips via the existing `SOVEREIGN_HARBOR_PG_HOST` slot seam, so the un-gated sync Job was the only gap.

## Render proof (both charts)

**own-cluster (default)** — byte-identical to the prior pin (only the non-deterministic `randAlphaNum` admin password + its derived pod-template checksums differ):
- bundled CNPG `Cluster` present, sync Job present
- gitea: `GITEA__database__PASSWD` → `gitea-pg-app` key `password`; `HOST=gitea-pg-rw.gitea.svc.cluster.local`
- harbor: `POSTGRESQL_PASSWORD` → `harbor-database-secret` key `password`; `POSTGRESQL_HOST: harbor-pg-rw.harbor.svc.cluster.local`

**SHARED (`postgres.cluster.enabled=false` + slot seams)**:
- NO bundled CNPG `Cluster`, NO sync Job, NO placeholder `<consumer>-database-secret`
- gitea: `GITEA__database__PASSWD` → reflected `gitea-database-secret` key `password`; `HOST=shared-pg-rw.shared-data.svc.cluster.local:5432`
- harbor: `POSTGRESQL_PASSWORD` → `harbor-database-secret` key `password`; `POSTGRESQL_HOST: shared-pg-rw.shared-data.svc.cluster.local`

The reflected-secret keys map correctly: CNPG synthesises the role Secret with a `password` key, so only the Secret NAME flips between modes — the `key: password` secretKeyRef shape is identical.

New regression gates: `tests/shared-pg-consumer-wiring.sh` in both charts lock the two-mode contract. `helm lint` clean; all existing chart tests green.

## Lockstep
- bp-gitea `1.2.26 → 1.2.27` (Chart.yaml + blueprint.yaml + slot 10 pin)
- bp-harbor `1.2.27 → 1.2.28` (Chart.yaml + blueprint.yaml + slot 19 pin)

## Honest status
NOT live-verified — needs the dedicated SHARED_PG prov walk (`SOVEREIGN_ENABLE_SHARED_PG=true` + both `*_PG_OWN_CLUSTER=false`) to confirm the shared engine's `shared-pg-<owner>` role Secrets populate + reflect end-to-end.

Refs #3285 #3188

🤖 Generated with [Claude Code](https://claude.com/claude-code)
