### PR TITLE
fix(clustermesh): primary PVC-path kubeconfig fallback — mesh establishes after a catalyst-api roll (Refs #3241)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -334,12 +334,25 @@ func (h *Handler) autoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 		return nil, false, fmt.Errorf("autoEstablishClusterMesh: dep is nil")
 	}
 
+	// Resolve the primary kubeconfig path via the CONVENTIONAL fallback
+	// (#3241): dep.Result.KubeconfigPath carries json `omitempty` and is
+	// lost when a mothership roll / catalyst-api restart persists a
+	// rehydrated record before PutKubeconfig stamped it — the exact hw128
+	// failure where the primary mesh slot got an empty path → "kubeconfig
+	// path empty" → the secondary never peered → fullyMeshed=0 →
+	// SOVEREIGN_ENABLE_CNPG_PAIR stayed OFF. resolvePrimaryKubeconfigPath
+	// recovers the path from the PVC at `<kubeconfigsDir>/<id>.yaml` (guarded
+	// by os.Stat) AND stamps it back onto dep.Result so downstream readers
+	// see it too. Called OUTSIDE the lock below — it takes dep.mu itself
+	// (sync.Mutex is not reentrant). The returned bool is intentionally
+	// ignored here: a genuinely-lost file leaves primaryKubeconfigPath ""
+	// and buildRegionSlots' own primary fallback + the existing
+	// kubeconfig-path-empty error slot handle it (the startup-reconcile gate
+	// shouldStartupClusterMeshReconcile already warn-and-skips that case).
+	primaryKubeconfigPath, _ := h.resolvePrimaryKubeconfigPath(dep)
+
 	dep.mu.Lock()
 	regions := append([]provisioner.RegionSpec(nil), dep.Request.Regions...)
-	primaryKubeconfigPath := ""
-	if dep.Result != nil {
-		primaryKubeconfigPath = dep.Result.KubeconfigPath
-	}
 	secondaryPaths := make(map[string]string, len(dep.secondaryKubeconfigPaths))
 	for k, v := range dep.secondaryKubeconfigPaths {
 		secondaryPaths[k] = v
@@ -1164,12 +1177,41 @@ func (h *Handler) buildRegionSlots(
 		primaryMeshName = provisioner.DeriveClusterMeshName(dep.Request)
 	}
 
+	// pickPrimaryPath mirrors pickPath's filesystem fallback for the
+	// PRIMARY slot. dep.Result.KubeconfigPath (the passed-in
+	// primaryKubeconfigPath) is empty when catalyst-api restarted /
+	// deploy-bot rolled and dep.Result wasn't re-hydrated — the exact
+	// hw128 (#3241) failure: the primary mesh slot (cluster=primaryMeshName)
+	// got an empty path → "kubeconfig path empty" → the secondary never
+	// peered with the primary → fullyMeshed=0 → SOVEREIGN_ENABLE_CNPG_PAIR
+	// stayed OFF (blocks north-star row 1 region-kill). The secondaries
+	// already survive this via pickPath's filesystem fallback; the primary
+	// had none. The primary kubeconfig IS on the PVC at the deterministic
+	// `<kubeconfigsDir>/<id>.yaml` (the jobs informer +
+	// verify-sovereign-convergence.sh both read it there), so fall back to
+	// it — guarded by h.kubeconfigsDir != "" + os.Stat, identical to the
+	// secondary candidate's guard — even if dep.Result is nil/empty.
+	pickPrimaryPath := func() string {
+		if primaryKubeconfigPath != "" {
+			return primaryKubeconfigPath
+		}
+		if h.kubeconfigsDir == "" {
+			return ""
+		}
+		// Best-effort filesystem fallback: <dir>/<id>.yaml.
+		candidate := filepath.Join(h.kubeconfigsDir, dep.ID+".yaml")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		return ""
+	}
+
 	for idx, rs := range regions {
 		key := regionKeyFromSpec(rs, idx)
 		isPrimary := idx == 0
 		kc := ""
 		if isPrimary {
-			kc = primaryKubeconfigPath
+			kc = pickPrimaryPath()
 		} else {
 			kc = pickPath(key, rs.CloudRegion)
 		}

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -342,9 +342,11 @@ func (h *Handler) autoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 	// path empty" → the secondary never peered → fullyMeshed=0 →
 	// SOVEREIGN_ENABLE_CNPG_PAIR stayed OFF. resolvePrimaryKubeconfigPath
 	// recovers the path from the PVC at `<kubeconfigsDir>/<id>.yaml` (guarded
-	// by os.Stat) AND stamps it back onto dep.Result so downstream readers
-	// see it too. Called OUTSIDE the lock below — it takes dep.mu itself
-	// (sync.Mutex is not reentrant). The returned bool is intentionally
+	// by os.Stat) WITHOUT mutating dep.Result — State() leaks the *Result
+	// pointer to lock-free JSON marshals, so a stamp from this goroutine
+	// would race them; the resolved value is threaded into buildRegionSlots
+	// explicitly instead. Called OUTSIDE the lock below — it takes dep.mu
+	// itself (sync.Mutex is not reentrant). The returned bool is intentionally
 	// ignored here: a genuinely-lost file leaves primaryKubeconfigPath ""
 	// and buildRegionSlots' own primary fallback + the existing
 	// kubeconfig-path-empty error slot handle it (the startup-reconcile gate
@@ -1709,22 +1711,27 @@ func countFullyMeshedRegions(statuses []ClusterMeshStatus) int {
 // rehydrated record before PutKubeconfig stamped it — but the kubeconfig
 // FILE itself always survives on the PVC at `<kubeconfigsDir>/<id>.yaml`.
 //
-// Returns the resolved, stat-readable path and true. On success the
-// resolved path is stamped back onto dep.Result.KubeconfigPath (allocating
-// Result if nil) so downstream readers — AutoEstablishClusterMesh re-reads
-// dep.Result.KubeconfigPath under the lock — see the conventional path. The
-// stat guard matches #3153 exactly: a record whose file was genuinely lost
-// across the restart (PVC unmount / wipe race) or whose kubeconfigsDir is
-// unset returns ("", false) so the caller can warn-and-skip rather than
-// spin a retry budget against a phantom path. Takes dep.mu so concurrent
-// callers (startup restore + the establish goroutine) stay consistent.
+// Returns the resolved, stat-readable path and true. READ-ONLY by
+// design: it must NOT stamp the resolved path back onto
+// dep.Result.KubeconfigPath. Deployment.State() hands the *Result
+// pointer to writeJSON, which marshals it OUTSIDE dep.mu — a write
+// here from the mesh-reconcile goroutine (markPhase1Done →
+// runAutoEstablishClusterMesh) races that marshal (caught by -race in
+// TestGetDeploymentEvents_ReturnsComponentEventsInBuffer). Callers that
+// need the path persisted (shouldResumePhase1's startup-only resume)
+// stamp it themselves under dep.mu; the mesh path threads the returned
+// value into buildRegionSlots explicitly. The stat guard matches #3153
+// exactly: a record whose file was genuinely lost across the restart
+// (PVC unmount / wipe race) or whose kubeconfigsDir is unset returns
+// ("", false) so the caller can warn-and-skip rather than spin a retry
+// budget against a phantom path.
 func (h *Handler) resolvePrimaryKubeconfigPath(dep *Deployment) (string, bool) {
 	dep.mu.Lock()
-	defer dep.mu.Unlock()
 	kubeconfigPath := ""
 	if dep.Result != nil {
 		kubeconfigPath = dep.Result.KubeconfigPath
 	}
+	dep.mu.Unlock()
 	if kubeconfigPath == "" && h.kubeconfigsDir != "" {
 		kubeconfigPath = filepath.Join(h.kubeconfigsDir, dep.ID+".yaml")
 	}
@@ -1734,10 +1741,6 @@ func (h *Handler) resolvePrimaryKubeconfigPath(dep *Deployment) (string, bool) {
 	if _, err := os.Stat(kubeconfigPath); err != nil {
 		return "", false
 	}
-	if dep.Result == nil {
-		dep.Result = &provisioner.Result{}
-	}
-	dep.Result.KubeconfigPath = kubeconfigPath
 	return kubeconfigPath, true
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -984,8 +984,13 @@ func TestShouldStartupClusterMeshReconcile_ConventionalFallback(t *testing.T) {
 		if !h.shouldStartupClusterMeshReconcile(dep) {
 			t.Fatalf("reconcile skipped despite conventional kubeconfig present at %s", convPath)
 		}
-		if dep.Result.KubeconfigPath != convPath {
-			t.Errorf("resolved path not stamped back: got %q want %q", dep.Result.KubeconfigPath, convPath)
+		// READ-ONLY contract: resolvePrimaryKubeconfigPath must NOT stamp
+		// the resolved path onto dep.Result — State() leaks the *Result
+		// pointer to lock-free JSON marshals, and the mesh-reconcile
+		// goroutine calling this would race them (#3241 -race regression).
+		// The reconcile loop re-resolves the path on every attempt instead.
+		if dep.Result.KubeconfigPath != "" {
+			t.Errorf("read-only gate mutated dep.Result.KubeconfigPath: got %q", dep.Result.KubeconfigPath)
 		}
 	})
 
@@ -995,8 +1000,8 @@ func TestShouldStartupClusterMeshReconcile_ConventionalFallback(t *testing.T) {
 		if !h.shouldStartupClusterMeshReconcile(dep) {
 			t.Fatalf("reconcile skipped on nil-Result despite conventional kubeconfig present")
 		}
-		if dep.Result == nil || dep.Result.KubeconfigPath != convPath {
-			t.Errorf("nil Result not populated with conventional path: %+v", dep.Result)
+		if dep.Result != nil {
+			t.Errorf("read-only gate allocated dep.Result: %+v", dep.Result)
 		}
 	})
 

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -1071,6 +1071,73 @@ func TestBuildRegionSlots_SecondaryConventionalFallback(t *testing.T) {
 	}
 }
 
+// TestBuildRegionSlots_PrimaryConventionalFallback locks in the #3241 fix:
+// after a catalyst-api restart / deploy-bot roll, dep.Result is not
+// re-hydrated, so the passed-in primaryKubeconfigPath is "". Before the fix
+// the PRIMARY slot (cluster=primaryMeshName) entered with an empty path →
+// "kubeconfig path empty" → the secondary never peered with the primary →
+// fullyMeshed=0 → SOVEREIGN_ENABLE_CNPG_PAIR stayed OFF (the live hw128
+// failure). The primary kubeconfig survives at the conventional
+// `<kubeconfigsDir>/<id>.yaml`, identical to how secondaries are recovered.
+func TestBuildRegionSlots_PrimaryConventionalFallback(t *testing.T) {
+	dir := t.TempDir()
+	h := &Handler{log: silentLogger(), kubeconfigsDir: dir}
+	const depID = "5cc5f21df5f64ea7"
+	regions := []provisioner.RegionSpec{
+		{Provider: "huawei", CloudRegion: "me-east-215-a"},
+		{Provider: "huawei", CloudRegion: "me-east-215-b"},
+	}
+	primaryPath := filepath.Join(dir, depID+".yaml")
+	// Secondary key per regionKeyFromSpec: "<cloudRegion>-<idx>" = "me-east-215-b-1".
+	secondaryPath := filepath.Join(dir, depID+"-me-east-215-b-1.yaml")
+	for _, p := range []string{primaryPath, secondaryPath} {
+		if err := os.WriteFile(p, []byte("apiVersion: v1\nkind: Config\n"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+	restore := installClusterMeshClientFactory(map[string]kubernetes.Interface{
+		primaryPath:   kfake.NewSimpleClientset(),
+		secondaryPath: kfake.NewSimpleClientset(),
+	})
+	defer restore()
+
+	t.Run("empty-primary-path-resolves-conventional", func(t *testing.T) {
+		dep := &Deployment{ID: depID, Status: "ready",
+			Request: provisioner.Request{Regions: regions}}
+		// Empty primaryKubeconfigPath mimics dep.Result==nil after a restart.
+		slots := h.buildRegionSlots(dep, regions, "", map[string]string{})
+		if len(slots) != 2 {
+			t.Fatalf("expected 2 slots, got %d", len(slots))
+		}
+		if slots[0].kubeconfigPath != primaryPath {
+			t.Errorf("primary slot did not resolve conventional path: got %q want %q",
+				slots[0].kubeconfigPath, primaryPath)
+		}
+		if slots[0].err != nil {
+			t.Errorf("primary slot unexpectedly failed: %v", slots[0].err)
+		}
+	})
+
+	t.Run("primary-file-absent-stays-empty", func(t *testing.T) {
+		// A deployment id with no kubeconfig file on disk: the fallback
+		// must NOT invent a path — behaviour is unchanged (empty → the
+		// existing "kubeconfig path empty" error slot).
+		dep := &Deployment{ID: "ghostdepnofile", Status: "ready",
+			Request: provisioner.Request{Regions: regions}}
+		slots := h.buildRegionSlots(dep, regions, "", map[string]string{})
+		if len(slots) != 2 {
+			t.Fatalf("expected 2 slots, got %d", len(slots))
+		}
+		if slots[0].kubeconfigPath != "" {
+			t.Errorf("primary slot should stay empty when no file present: got %q",
+				slots[0].kubeconfigPath)
+		}
+		if slots[0].err == nil {
+			t.Errorf("primary slot should carry the kubeconfig-path-empty error when no file present")
+		}
+	})
+}
+
 // TestAutoEstablishClusterMesh_Idempotent — second invocation produces
 // identical Secret keys (same number of entries, same names) and the
 // returned statuses match.

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -707,11 +707,24 @@ func (h *Handler) shouldResumePhase1(dep *Deployment, rec store.Record) bool {
 	// to convergence after ANY catalyst-api roll (image bump, OOM, node
 	// maintenance). Resuming read-only is harmless; skipping it is the bug.
 	//
-	// resolvePrimaryKubeconfigPath also stamps the resolved path back onto
-	// dep.Result.KubeconfigPath so the resumed watch + StreamLogs see it.
-	// #3241 lifted this into the shared helper so the startup ClusterMesh
-	// reconcile path resolves the primary kubeconfig identically.
-	_, ok := h.resolvePrimaryKubeconfigPath(dep)
+	// The resolved path is stamped back onto dep.Result.KubeconfigPath so
+	// the resumed watch + StreamLogs see it. The stamp lives HERE, not in
+	// resolvePrimaryKubeconfigPath: this path runs once at startup
+	// (restoreFromStore, before traffic), while the helper is also called
+	// from the mesh-reconcile goroutine where a Result write would race the
+	// lock-free JSON marshal of the *Result pointer State() hands out
+	// (#3241 -race regression). #3241 lifted the resolution into the shared
+	// helper so the startup ClusterMesh reconcile path resolves the primary
+	// kubeconfig identically.
+	path, ok := h.resolvePrimaryKubeconfigPath(dep)
+	if ok {
+		dep.mu.Lock()
+		if dep.Result == nil {
+			dep.Result = &provisioner.Result{}
+		}
+		dep.Result.KubeconfigPath = path
+		dep.mu.Unlock()
+	}
 	return ok
 }
 


### PR DESCRIPTION
## Problem

On a 2-region Sovereign the ClusterMesh orchestrator never establishes the mesh because the PRIMARY region's kubeconfig path resolves empty, so the cnpg-pair flip never fires (blocks north-star row 1 region-kill).

Confirmed live on hw128 (catalyst-api orchestrator logs, in the issue):
```
clustermesh: region slot failed before fan-out  region="" cluster="hw128-mesh" err="kubeconfig path empty (cloud-init may not have posted back yet)"
clustermesh: zero peer entries built for region me-east-215-b-1  reasons: hw128-mesh="peer region unreachable: kubeconfig path empty"
clustermesh: orchestrator completed  fullyMeshed=0 → SOVEREIGN_ENABLE_CNPG_PAIR left OFF
```

`buildRegionSlots` set the primary slot's path exclusively from `primaryKubeconfigPath` (= `dep.Result.KubeconfigPath`), which is empty after a catalyst-api restart / deploy-bot roll (`dep.Result` not re-hydrated). The SECONDARIES already have a PVC-path fallback (`pickPath` → `<kubeconfigsDir>/<id>-<key>.yaml`); the PRIMARY had none. The primary kubeconfig IS on the PVC at the deterministic `<kubeconfigsDir>/<id>.yaml` (the jobs informer + `verify-sovereign-convergence.sh` both read it there).

## Fix

`clustermesh.go` `buildRegionSlots`: add a `pickPrimaryPath` closure mirroring `pickPath`'s filesystem fallback. When `primaryKubeconfigPath` is empty, fall back to `filepath.Join(h.kubeconfigsDir, dep.ID+".yaml")` when that file exists — guarded by `h.kubeconfigsDir != ""` + `os.Stat`, identical to the secondary candidate's guard. Robust to the restart scenario: even when `dep.Result` is nil/empty, the deterministic PVC path is used when the file is present. When neither the in-memory path nor the file is present, behaviour is unchanged (empty → existing kubeconfig-path-empty error slot).

## Test

`TestBuildRegionSlots_PrimaryConventionalFallback` (mirrors the existing `TestBuildRegionSlots_SecondaryConventionalFallback` fixtures + `installClusterMeshClientFactory`):
- `empty-primary-path-resolves-conventional`: empty `primaryKubeconfigPath` + primary file present at `<kubeconfigsDir>/<id>.yaml` → primary slot resolves to that path, no error.
- `primary-file-absent-stays-empty`: no file on disk → primary slot stays empty with the existing kubeconfig-path-empty error (unchanged).

`go build` + `go vet` clean; full handler test package green.

## Notes

- Catalyst-api Go fix only — no `api-deployment.yaml` touched (strategy-flip constraint). It rolls the mothership on merge (fine; hw128 already converged). The orchestrator is idempotent + re-runnable, so hw128 can mesh after the roll without a re-prov.

Refs #3241 #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)