### PR TITLE
fix(clustermesh): two-stage cnpg-pair flip — kill the first-flip deadlock on fresh envs

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -87,6 +87,7 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -99,6 +100,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -214,7 +216,7 @@ const (
 	// `cnpgPair.side` off it; the two-stage flip (#3241 first-flip
 	// deadlock) keys the patch ordering off it.
 	clusterMeshRegionRoleSubstituteKey = "SOVEREIGN_REGION_ROLE"
-	fluxReconcileRequestedAtAnnotation    = "reconcile.fluxcd.io/requestedAt"
+	fluxReconcileRequestedAtAnnotation = "reconcile.fluxcd.io/requestedAt"
 )
 
 // Cross-cluster CNPG replica-auth Secret sync (#3254, the prerequisite
@@ -629,7 +631,8 @@ func (h *Handler) autoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 		// Stable order for the Secret update (so an idempotent re-run
 		// produces byte-identical Secret data and no rollout-restart
 		// thrash).
-		if err := h.applyClusterMeshSecret(ctx, a.clientset, peerEntries); err != nil {
+		secretChanged, err := h.applyClusterMeshSecret(ctx, a.clientset, peerEntries)
+		if err != nil {
 			h.log.Warn("clustermesh: Secret apply failed",
 				"id", dep.ID,
 				"region", a.key,
@@ -664,19 +667,33 @@ func (h *Handler) autoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 				peers = append(peers, hostAliasPeer{PeerName: b.clusterName, LBIP: b.lbIP})
 			}
 		}
-		if err := h.patchCiliumHostAliases(ctx, a.clientset, peers); err != nil {
+		aliasesChanged, aliasErr := h.patchCiliumHostAliases(ctx, a.clientset, peers)
+		if aliasErr != nil {
 			h.log.Warn("clustermesh: hostAliases patch failed (continuing)",
 				"id", dep.ID,
 				"region", a.key,
-				"err", err,
+				"err", aliasErr,
 			)
 		}
 
 		// Trigger rollout-restart on cilium + cilium-operator +
 		// clustermesh-apiserver in this region so they pick up the
-		// new peer entries + hostAliases deterministically. Best-effort:
-		// errors are logged, not fatal.
-		h.rolloutRestartClusterMeshTargets(ctx, dep, a)
+		// new peer entries + hostAliases deterministically — but ONLY
+		// when something actually changed (#3241 layer 4). The
+		// level-triggered reconcile re-runs this every ~2 min; an
+		// unconditional restart per pass crash-cycled the mesh
+		// components (apiserver Deployment generation 35 on hw128) and
+		// the agents never got a stable window to finish the
+		// remote-config sync — the loop kept resetting the very state
+		// it was waiting on. Best-effort: errors are logged, not fatal.
+		if secretChanged || aliasesChanged {
+			h.rolloutRestartClusterMeshTargets(ctx, dep, a)
+		} else {
+			h.log.Info("clustermesh: peer config unchanged — skipping rollout-restart (idempotent re-run)",
+				"id", dep.ID,
+				"region", a.key,
+			)
+		}
 
 		readyCount := 0
 		for _, p := range st.Peers {
@@ -1664,15 +1681,22 @@ func peerMeshHostname(peerClusterName string) string {
 // `entries` are overwritten with the freshly minted bytes (idempotent
 // re-runs converge byte-identically because mintPeerClientCert is the
 // only non-deterministic step and the new bytes always supersede).
-func (h *Handler) applyClusterMeshSecret(ctx context.Context, client kubernetes.Interface, entries map[string][]byte) error {
+// The returned bool reports whether the Secret actually CHANGED (created
+// or content updated) — the caller keys the rollout-restart on it
+// (#3241 layer 4): the level-triggered reconcile re-runs this every
+// ~2 min, and an unconditional restart per pass turned the loop into a
+// mesh-component crash-cycle (clustermesh-apiserver Deployment hit
+// generation 35 on hw128) that never left the agents a stable window to
+// finish the remote-config sync.
+func (h *Handler) applyClusterMeshSecret(ctx context.Context, client kubernetes.Interface, entries map[string][]byte) (bool, error) {
 	if len(entries) == 0 {
-		return nil
+		return false, nil
 	}
 	callCtx, cancel := context.WithTimeout(ctx, clusterMeshCallTimeout)
 	defer cancel()
 	existing, err := client.CoreV1().Secrets(clusterMeshNamespace).Get(callCtx, clusterMeshSecretName, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("Get Secret %s/%s: %w",
+		return false, fmt.Errorf("Get Secret %s/%s: %w",
 			clusterMeshNamespace, clusterMeshSecretName, err)
 	}
 	if apierrors.IsNotFound(err) {
@@ -1691,13 +1715,14 @@ func (h *Handler) applyClusterMeshSecret(ctx context.Context, client kubernetes.
 		}
 		if _, createErr := client.CoreV1().Secrets(clusterMeshNamespace).Create(callCtx, s, metav1.CreateOptions{}); createErr != nil {
 			if apierrors.IsAlreadyExists(createErr) {
-				// Race window — fall through to Update.
-				return h.updateClusterMeshSecret(ctx, client, entries)
+				// Race window — fall through to Update. Treat as changed:
+				// the racer's content is unknown.
+				return true, h.updateClusterMeshSecret(ctx, client, entries)
 			}
-			return fmt.Errorf("Create Secret %s/%s: %w",
+			return false, fmt.Errorf("Create Secret %s/%s: %w",
 				clusterMeshNamespace, clusterMeshSecretName, createErr)
 		}
-		return nil
+		return true, nil
 	}
 	// Merge: keep entries we don't manage, overwrite ones we do.
 	merged := make(map[string][]byte, len(existing.Data)+len(entries))
@@ -1707,12 +1732,25 @@ func (h *Handler) applyClusterMeshSecret(ctx context.Context, client kubernetes.
 	for k, v := range entries {
 		merged[k] = v
 	}
+	// Byte-identical content → no write, no restart (idempotent re-run).
+	if len(merged) == len(existing.Data) {
+		identical := true
+		for k, v := range merged {
+			if ev, ok := existing.Data[k]; !ok || !bytes.Equal(ev, v) {
+				identical = false
+				break
+			}
+		}
+		if identical {
+			return false, nil
+		}
+	}
 	patch := []byte(fmt.Sprintf(`{"data":%s}`, encodeSecretDataJSON(merged)))
 	if _, patchErr := client.CoreV1().Secrets(clusterMeshNamespace).Patch(callCtx, clusterMeshSecretName, types.MergePatchType, patch, metav1.PatchOptions{}); patchErr != nil {
-		return fmt.Errorf("Patch Secret %s/%s: %w",
+		return false, fmt.Errorf("Patch Secret %s/%s: %w",
 			clusterMeshNamespace, clusterMeshSecretName, patchErr)
 	}
-	return nil
+	return true, nil
 }
 
 // updateClusterMeshSecret is the race-window fallback when Create
@@ -1751,11 +1789,14 @@ func (h *Handler) updateClusterMeshSecret(ctx context.Context, client kubernetes
 // Caught on t128 (9680edbdce8fefe8, 2026-05-16): clustermesh agents
 // stayed `0/2 remote clusters ready` despite full peer entries
 // because TLS hostname verification failed at handshake time.
-func (h *Handler) patchCiliumHostAliases(ctx context.Context, client kubernetes.Interface, peers []hostAliasPeer) error {
+// The returned bool reports whether the DaemonSet pod template actually
+// changed — same restart-thrash rationale as applyClusterMeshSecret.
+func (h *Handler) patchCiliumHostAliases(ctx context.Context, client kubernetes.Interface, peers []hostAliasPeer) (bool, error) {
 	if len(peers) == 0 {
-		return nil
+		return false, nil
 	}
 	aliases := make([]map[string]any, 0, len(peers))
+	desired := make([]corev1.HostAlias, 0, len(peers))
 	for _, p := range peers {
 		if p.LBIP == "" || p.PeerName == "" {
 			continue
@@ -1764,9 +1805,19 @@ func (h *Handler) patchCiliumHostAliases(ctx context.Context, client kubernetes.
 			"ip":        p.LBIP,
 			"hostnames": []string{peerMeshHostname(p.PeerName)},
 		})
+		desired = append(desired, corev1.HostAlias{IP: p.LBIP, Hostnames: []string{peerMeshHostname(p.PeerName)}})
 	}
 	if len(aliases) == 0 {
-		return nil
+		return false, nil
+	}
+	// No-op guard: identical hostAliases already on the pod template →
+	// skip the patch (a strategic-merge write with identical content
+	// still bumps nothing, but skipping keeps intent explicit + cheap).
+	getCtx, cancelGet := context.WithTimeout(ctx, clusterMeshCallTimeout)
+	ds, getErr := client.AppsV1().DaemonSets(clusterMeshNamespace).Get(getCtx, "cilium", metav1.GetOptions{})
+	cancelGet()
+	if getErr == nil && reflect.DeepEqual(ds.Spec.Template.Spec.HostAliases, desired) {
+		return false, nil
 	}
 	patch := map[string]any{
 		"spec": map[string]any{
@@ -1779,14 +1830,14 @@ func (h *Handler) patchCiliumHostAliases(ctx context.Context, client kubernetes.
 	}
 	patchBytes, err := json.Marshal(patch)
 	if err != nil {
-		return fmt.Errorf("marshal hostAliases patch: %w", err)
+		return false, fmt.Errorf("marshal hostAliases patch: %w", err)
 	}
 	callCtx, cancel := context.WithTimeout(ctx, clusterMeshCallTimeout)
 	defer cancel()
 	if _, err := client.AppsV1().DaemonSets(clusterMeshNamespace).Patch(callCtx, "cilium", types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
-		return fmt.Errorf("patch cilium DaemonSet hostAliases: %w", err)
+		return false, fmt.Errorf("patch cilium DaemonSet hostAliases: %w", err)
 	}
-	return nil
+	return true, nil
 }
 
 // hostAliasPeer is a minimal projection used by patchCiliumHostAliases.

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -208,6 +208,12 @@ const (
 	clusterMeshCNPGPairSubstituteKey      = "SOVEREIGN_ENABLE_CNPG_PAIR"
 	clusterMeshPrimaryRegionSubstituteKey = "SOVEREIGN_PRIMARY_REGION"
 	clusterMeshReplicaRegionSubstituteKey = "SOVEREIGN_REPLICA_REGION"
+	// clusterMeshRegionRoleSubstituteKey is each region's OWN role in the
+	// pair ("primary" / "secondary"), stamped by cloud-init onto the
+	// region's bootstrap-kit Kustomization. bp-cnpg-pair keys
+	// `cnpgPair.side` off it; the two-stage flip (#3241 first-flip
+	// deadlock) keys the patch ordering off it.
+	clusterMeshRegionRoleSubstituteKey = "SOVEREIGN_REGION_ROLE"
 	fluxReconcileRequestedAtAnnotation    = "reconcile.fluxcd.io/requestedAt"
 )
 
@@ -769,10 +775,17 @@ func (h *Handler) autoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 // render fails, and a render failure inside the bootstrap-kit
 // Kustomization fails the WHOLE atomic apply → 0 HRs (the #2981/#2982
 // fresh-prov wedge shape). Likewise, if ANY region's Kustomization is
-// unreadable the whole flip is refused: a half-flipped pair (primary
-// active, replica gated OFF) is exactly the broken topology this
-// function exists to prevent. A refused flip logs loudly and leaves
-// the gate OFF everywhere (empty Ready releases — safe); the
+// unreadable the whole flip is refused — atomically, before ANY patch.
+//
+// Patch ordering is TWO-STAGE (#3241 first-flip deadlock): the primary
+// side flips unconditionally; the replica side flips only after the
+// primary's replica-auth Secrets exist + sync (#3254). primary-ON /
+// replica-pending is the INTENDED intermediate of a first flip — the
+// primary postgres must initdb before CNPG can mint the Secrets the
+// replica streams with. The pre-#3241 shape (sync gates ALL patches)
+// deadlocked the first flip on a fresh env: the Secrets could never
+// appear while the gate stayed OFF everywhere (hw128 live). A refusal
+// at either stage logs loudly and returns NOT-converged; the
 // level-triggered reconcile / post-handover finalisation re-runs and
 // converges.
 //
@@ -809,8 +822,9 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 	// patching anything. Any gap refuses the whole flip — a half-
 	// flipped split-side pair is the hw126 broken topology.
 	type flipTarget struct {
-		regionKey string
-		dyn       dynamic.Interface
+		regionKey   string
+		dyn         dynamic.Interface
+		primarySide bool
 	}
 	targets := make([]flipTarget, 0, len(slots))
 	for i := range slots {
@@ -870,27 +884,40 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 					regionLabel, primaryRegion, replicaRegion))
 			return false
 		}
-		targets = append(targets, flipTarget{regionKey: regionLabel, dyn: dyn})
+		// Classify the region's SIDE for the two-stage patch below. The
+		// region's own role substitute is authoritative (cloud-init stamps
+		// it; the chart's `cnpgPair.side` keys off the same value); when
+		// absent fall back to the deployment model invariant — slot 0 IS
+		// the primary region (mirrors the chart's `:-primary` default).
+		role := strings.TrimSpace(substitute[clusterMeshRegionRoleSubstituteKey])
+		if role == "" {
+			if i == 0 {
+				role = "primary"
+			} else {
+				role = "secondary"
+			}
+		}
+		targets = append(targets, flipTarget{regionKey: regionLabel, dyn: dyn, primarySide: role == "primary"})
 	}
 
-	// ── Cross-cluster replica-auth Secret sync (#3254) ──────────────
-	// Before flipping the gate ON, the replica-side Cluster CR's
-	// streaming auth (the primary's `-replication` client cert + `-ca`,
-	// both in namespace `cnpg`) must be present on EVERY replica
-	// cluster — those Secrets are created by CNPG only on the primary.
-	// Same all-or-nothing semantics as the gather phase above: if the
-	// source Secrets are absent (the primary postgres is still
-	// bootstrapping — CNPG mints these only after initdb) or any copy
-	// fails, REFUSE the whole flip and leave the gate OFF everywhere.
-	// A half state (gate flipped but the replica missing its auth
-	// Secrets) would render a replica Cluster that waits forever on a
-	// secret it cannot find. The #3241 level-trigger + post-handover
-	// re-runs converge once the primary's Secrets appear.
-	if !h.syncCNPGPairReplicaAuthSecrets(ctx, dep, slots) {
-		return false
-	}
-
-	// ── Patch phase ─────────────────────────────────────────────────
+	// ── Patch phase: TWO-STAGE (#3241 first-flip deadlock) ──────────
+	// The primary-side Cluster CR has NO dependency on the replica-auth
+	// Secrets — but the Secrets are minted by CNPG only AFTER the
+	// primary postgres initdb's, and the primary postgres only renders
+	// once its region's gate flips ON. Gating ALL patches on the Secret
+	// sync (the pre-#3241 shape) therefore DEADLOCKED the FIRST flip on
+	// a fresh env: hw128 sat with the level-trigger refusing forever
+	// ("source Secret unavailable on primary — refusing flip") while
+	// cnpg stayed empty in both regions. hw126 never hit this because
+	// its gate was already ON before the sync landed (#3254).
+	//
+	// Stage 1 flips every PRIMARY-side region unconditionally. Stage 2
+	// (replica-side regions) stays gated on the replica-auth sync — a
+	// half state there (gate flipped, auth Secrets missing) would
+	// render a replica Cluster waiting forever on a secret it cannot
+	// find. A Stage-2 refusal returns false so the level-trigger
+	// re-runs: the primary initdb proceeds meanwhile, the Secrets
+	// appear, the idempotent re-run syncs + flips the replicas.
 	// JSON merge patch (RFC 7386) merges nested objects key-by-key, so
 	// sibling substitute keys + existing annotations are preserved —
 	// only the gate key and the reconcile-request stamp change.
@@ -915,8 +942,7 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 			"id", dep.ID, "err", err)
 		return false
 	}
-	patched := 0
-	for _, t := range targets {
+	patchOne := func(t flipTarget) bool {
 		patchCtx, cancelPatch := context.WithTimeout(ctx, clusterMeshCallTimeout)
 		_, patchErr := t.dyn.Resource(fluxKustomizationGVR).Namespace(fluxSystemNamespace).
 			Patch(patchCtx, bootstrapKitKustomizationName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
@@ -927,9 +953,49 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 			h.emitClusterMeshProgress(dep, "warn",
 				fmt.Sprintf("ClusterMesh: cnpg-pair enable incomplete — region %q Patch Kustomization %s/%s (%v); re-run converges",
 					t.regionKey, fluxSystemNamespace, bootstrapKitKustomizationName, patchErr))
-			continue
+			return false
 		}
-		patched++
+		return true
+	}
+
+	primaryTotal, replicaTotal := 0, 0
+	for _, t := range targets {
+		if t.primarySide {
+			primaryTotal++
+		} else {
+			replicaTotal++
+		}
+	}
+
+	// Stage 1 — primary-side regions, unconditional.
+	patched := 0
+	for _, t := range targets {
+		if t.primarySide && patchOne(t) {
+			patched++
+		}
+	}
+	if patched < primaryTotal {
+		return false
+	}
+
+	// Stage 2 — replica-side regions, gated on the replica-auth sync
+	// (#3254). No replica-side regions → nothing to gate.
+	if replicaTotal > 0 {
+		if !h.syncCNPGPairReplicaAuthSecrets(ctx, dep, slots) {
+			h.log.Info("clustermesh: cnpg-pair two-stage flip — primary side ON, replica side awaiting the primary's replica-auth Secrets (initdb in progress); level-trigger re-run converges",
+				"id", dep.ID,
+				"primaryRegions", primaryTotal,
+				"replicaRegions", replicaTotal,
+			)
+			h.emitClusterMeshProgress(dep, "info",
+				fmt.Sprintf("ClusterMesh: cnpg-pair primary side enabled (%d region(s)); replica side waits for the primary postgres to mint its replication Secrets — re-run converges", primaryTotal))
+			return false
+		}
+		for _, t := range targets {
+			if !t.primarySide && patchOne(t) {
+				patched++
+			}
+		}
 	}
 	if patched == 0 {
 		return false

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -34,6 +34,7 @@ import (
 	"testing"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1874,5 +1875,56 @@ func TestEnableCNPGPair_TwoStageFirstFlip(t *testing.T) {
 	}
 	if g := gateOf(fx.secondaryKubeconfigPath); g != "true" {
 		t.Errorf("run 2: REPLICA region gate = %q, want \"true\"", g)
+	}
+}
+
+// TestAutoEstablishClusterMesh_IdempotentRerunSkipsRolloutRestart locks
+// in the #3241 layer-4 fix: the level-triggered reconcile re-runs the
+// orchestrator every ~2 min, and an UNCONDITIONAL rollout-restart per
+// pass crash-cycled the mesh components (clustermesh-apiserver
+// Deployment reached generation 35 live on hw128) — the agents never
+// got a stable window to finish the remote-config sync. Run 1 (Secret
+// created) must stamp restartedAt; run 2 (byte-identical peer config)
+// must NOT bump it.
+func TestAutoEstablishClusterMesh_IdempotentRerunSkipsRolloutRestart(t *testing.T) {
+	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
+	// Seed a minimal cilium DaemonSet on the primary so the
+	// rollout-restart patch has a real object to stamp (the fake
+	// otherwise swallows it as IsNotFound).
+	primaryCS := fx.clients[fx.primaryKubeconfigPath]
+	if _, err := primaryCS.AppsV1().DaemonSets(clusterMeshNamespace).Create(context.Background(),
+		&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "cilium", Namespace: clusterMeshNamespace}},
+		metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed cilium DaemonSet: %v", err)
+	}
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+
+	stampOf := func() string {
+		t.Helper()
+		ds, err := primaryCS.AppsV1().DaemonSets(clusterMeshNamespace).Get(context.Background(), "cilium", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("get cilium DaemonSet: %v", err)
+		}
+		return ds.Spec.Template.Annotations["catalyst.openova.io/restartedAt"]
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep); err != nil {
+		t.Fatalf("run 1: %v", err)
+	}
+	first := stampOf()
+	if first == "" {
+		t.Fatalf("run 1 did not stamp restartedAt despite creating the peer Secret")
+	}
+
+	if _, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep); err != nil {
+		t.Fatalf("run 2: %v", err)
+	}
+	if second := stampOf(); second != first {
+		t.Errorf("idempotent re-run bumped restartedAt %q -> %q — the #3241 layer-4 thrash", first, second)
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -1546,9 +1546,11 @@ func TestAutoEstablishClusterMesh_FullMeshSyncsReplicaAuthSecretsThenFlips(t *te
 // TestAutoEstablishClusterMesh_MissingSourceSecretRefusesFlip — when the
 // primary has NOT yet produced one of the CNPG replica-auth Secrets (its
 // postgres is still bootstrapping — CNPG mints `-replication`/`-ca` only
-// after initdb), the flip is REFUSED ENTIRELY: neither region's gate
-// flips and no Secret lands on the replica. The level-trigger re-run
-// converges once the primary's Secret appears.
+// after initdb), the TWO-STAGE flip (#3241 first-flip deadlock) flips
+// the PRIMARY side anyway (its Cluster has no dependency on those
+// Secrets — it is what MINTS them) but REFUSES the replica side: its
+// gate stays OFF and no Secret lands on the replica. The level-trigger
+// re-run converges once the primary's Secret appears.
 func TestAutoEstablishClusterMesh_MissingSourceSecretRefusesFlip(t *testing.T) {
 	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
 	// Remove ONE source Secret from the primary (simulates postgres
@@ -1572,8 +1574,9 @@ func TestAutoEstablishClusterMesh_MissingSourceSecretRefusesFlip(t *testing.T) {
 	}
 	requireFullyMeshed(t, statuses)
 
-	// All-or-nothing: NEITHER region's gate flips.
-	assertGateNotFlipped(t, fx.dynClients[fx.primaryKubeconfigPath], "primary")
+	// Two-stage: the primary side flips (stage 1, unconditional); the
+	// replica side is refused until its auth Secrets can be synced.
+	assertGateFlipped(t, fx.dynClients[fx.primaryKubeconfigPath], "primary")
 	assertGateNotFlipped(t, fx.dynClients[fx.secondaryKubeconfigPath], "secondary")
 	// The OTHER source Secret (the -ca) must NOT have been partially
 	// copied — the source read is all-or-nothing before any copy.
@@ -1588,9 +1591,10 @@ func TestAutoEstablishClusterMesh_MissingSourceSecretRefusesFlip(t *testing.T) {
 
 // TestAutoEstablishClusterMesh_ReplicaCopyFailureRefusesFlip — when the
 // copy to the replica cluster fails (here: a reactor rejects the Secret
-// write), the flip is REFUSED: neither region's gate flips. A
-// half-flipped pair (gate ON, replica auth Secret absent) is exactly the
-// broken topology this guard prevents.
+// write), the REPLICA side is refused: its gate stays OFF (a replica
+// gate ON without its auth Secrets is the broken topology this guard
+// prevents). The PRIMARY side flips regardless (stage 1 of the #3241
+// two-stage flip — it has no dependency on the replica copy).
 func TestAutoEstablishClusterMesh_ReplicaCopyFailureRefusesFlip(t *testing.T) {
 	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
 	// Make every Secret write into the replica's cnpg namespace fail.
@@ -1619,7 +1623,7 @@ func TestAutoEstablishClusterMesh_ReplicaCopyFailureRefusesFlip(t *testing.T) {
 	}
 	requireFullyMeshed(t, statuses)
 
-	assertGateNotFlipped(t, fx.dynClients[fx.primaryKubeconfigPath], "primary")
+	assertGateFlipped(t, fx.dynClients[fx.primaryKubeconfigPath], "primary")
 	assertGateNotFlipped(t, fx.dynClients[fx.secondaryKubeconfigPath], "secondary")
 	if !strings.Contains(logBuf.String(), "copy to replica failed") {
 		t.Errorf("expected a loud warning about the failed replica copy, got:\n%s", logBuf.String())
@@ -1798,5 +1802,77 @@ func TestBuildPeerConfigBlob_DialPort(t *testing.T) {
 	}
 	if strings.Contains(blob, ":2379") {
 		t.Errorf("blob still hardcodes 2379:\n%s", blob)
+	}
+}
+
+// TestEnableCNPGPair_TwoStageFirstFlip locks in the #3241 first-flip
+// fix: on a FRESH env the primary's replica-auth Secrets cannot exist
+// yet (CNPG mints them only after the primary postgres initdb's, and
+// that postgres only renders once the gate flips ON). Run 1 with the
+// Secrets ABSENT must flip the PRIMARY region's Kustomization, leave
+// the replica's OFF, and report NOT-converged. Run 2 with the Secrets
+// present (initdb finished) must flip the replica too and converge.
+// The pre-fix behaviour — sync gating ALL patches — left both regions
+// OFF forever (the hw128 live deadlock).
+func TestEnableCNPGPair_TwoStageFirstFlip(t *testing.T) {
+	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+
+	// Delete the fixture-seeded primary replica-auth Secrets — the
+	// fresh-env state where the primary postgres has not initdb'd.
+	primaryCS := fx.clients[fx.primaryKubeconfigPath]
+	for _, name := range cnpgPairReplicaAuthSecrets {
+		if err := primaryCS.CoreV1().Secrets(cnpgPairNamespace).Delete(
+			context.Background(), name, metav1.DeleteOptions{}); err != nil {
+			t.Fatalf("delete seeded secret %s: %v", name, err)
+		}
+	}
+
+	gateOf := func(kcPath string) string {
+		t.Helper()
+		ks, err := fx.dynClients[kcPath].Resource(fluxKustomizationGVR).
+			Namespace(fluxSystemNamespace).Get(context.Background(), bootstrapKitKustomizationName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("get Kustomization (%s): %v", kcPath, err)
+		}
+		sub, _, _ := unstructured.NestedStringMap(ks.Object, "spec", "postBuild", "substitute")
+		return sub[clusterMeshCNPGPairSubstituteKey]
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Run 1 — Secrets absent: primary flips ON, replica stays OFF,
+	// flip reports not-converged so the level-trigger re-runs.
+	_, converged, err := fx.handler.autoEstablishClusterMesh(ctx, fx.dep)
+	if err != nil {
+		t.Fatalf("run 1: %v", err)
+	}
+	if converged {
+		t.Fatalf("run 1 reported converged despite missing replica-auth Secrets")
+	}
+	if g := gateOf(fx.primaryKubeconfigPath); g != "true" {
+		t.Errorf("run 1: PRIMARY region gate = %q, want \"true\" (stage-1 unconditional)", g)
+	}
+	if g := gateOf(fx.secondaryKubeconfigPath); g == "true" {
+		t.Errorf("run 1: REPLICA region gate flipped ON before its auth Secrets exist")
+	}
+
+	// Primary postgres "finishes initdb": re-seed the Secrets.
+	seedCNPGPairSourceSecrets(t, primaryCS)
+
+	// Run 2 — idempotent re-run converges: replica flips too.
+	_, converged, err = fx.handler.autoEstablishClusterMesh(ctx, fx.dep)
+	if err != nil {
+		t.Fatalf("run 2: %v", err)
+	}
+	if !converged {
+		t.Fatalf("run 2 not converged despite Secrets present")
+	}
+	if g := gateOf(fx.secondaryKubeconfigPath); g != "true" {
+		t.Errorf("run 2: REPLICA region gate = %q, want \"true\"", g)
 	}
 }


### PR DESCRIPTION
Found live on hw128 right after #3299 brought the agent tunnel up: the reconcile loop refused the cnpg-pair flip every ~2 min ("source Secret unavailable on primary") while `cnpg` stayed empty in both regions — forever. Structural first-flip deadlock: the #3254 sync gated ALL patches on Secrets that only exist after the primary postgres runs, and that postgres only renders once the gate flips. hw126 predates #3254's gate, which is why it never showed this.

Fix: two-stage patch — primary-side regions flip unconditionally (the primary is what mints the Secrets); replica-side regions stay gated on the sync and converge on the level-trigger re-run once initdb finishes. Region side comes from the `SOVEREIGN_REGION_ROLE` substitute (fallback: slot 0 = primary, the chart's `:-primary` default). The original guard (replica gate ON without auth Secrets = broken topology) is preserved.

Tests: new `TestEnableCNPGPair_TwoStageFirstFlip` two-run contract; `MissingSourceSecret`/`ReplicaCopyFailure` updated to the two-stage semantics. `go test -race ./...` green.

Self-applies to live hw128 on the post-merge mothership roll (same mechanism as #3299) — expected sequence: primary gate ON → primary postgres initdb → Secrets minted → sync → replica gate ON → WAL streaming → region-kill walk.

Refs #3241

🤖 Generated with [Claude Code](https://claude.com/claude-code)