### PR TITLE
fix(clustermesh): secondary mesh-name must strip every digit run, matching tofu — #3241 layer 5

### DIFF
--- a/products/catalyst/bootstrap/api/internal/provisioner/clustermesh_name_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/clustermesh_name_test.go
@@ -1,0 +1,43 @@
+package provisioner
+
+import "testing"
+
+// TestDeriveSecondaryClusterMeshName_MatchesTofuDigitStripping locks in
+// the #3241 layer-5 contract: the Go derivation must strip EVERY digit
+// run (tofu `replace(r.code, "/[0-9]+/", "")`), not just trailing runs.
+// Live on hw128 the divergence left region-a polling a cluster-config
+// key region-b never registered (`hw128-me-east-215-b` vs the real
+// `hw128-me-east--b`) — etcd connected, retrieved=false forever.
+func TestDeriveSecondaryClusterMeshName_MatchesTofuDigitStripping(t *testing.T) {
+	req := Request{
+		SovereignFQDN: "hw128.omani.works",
+		Regions: []RegionSpec{
+			{Provider: "huawei", CloudRegion: "me-east-215-a"},
+			{Provider: "huawei", CloudRegion: "me-east-215-b"},
+		},
+	}
+	cases := []struct {
+		cloudRegion string
+		want        string
+	}{
+		// kom4dc shape — interior digit run (the live hw128 bug).
+		{"me-east-215-b", "hw128-me-east--b"},
+		// Hetzner shapes — trailing run only; behaviour unchanged.
+		{"hel1", "hw128-hel"},
+		{"fsn1", "hw128-fsn"},
+		{"nbg1", "hw128-nbg"},
+		// No digits at all.
+		{"sin", "hw128-sin"},
+	}
+	for _, c := range cases {
+		got := DeriveSecondaryClusterMeshName(req, RegionSpec{Provider: "huawei", CloudRegion: c.cloudRegion})
+		if got != c.want {
+			t.Errorf("CloudRegion %q: got %q, want %q (must match tofu digit-run stripping)", c.cloudRegion, got, c.want)
+		}
+	}
+
+	// Explicit per-region override always wins.
+	if got := DeriveSecondaryClusterMeshName(req, RegionSpec{CloudRegion: "me-east-215-b", ClusterMeshName: "explicit-name"}); got != "explicit-name" {
+		t.Errorf("explicit ClusterMeshName override ignored: got %q", got)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -3297,22 +3297,34 @@ func DeriveSecondaryClusterMeshName(req Request, rs RegionSpec) string {
 	if stem == "" {
 		return ""
 	}
-	regionStem := stripTrailingDigits(rs.CloudRegion)
+	regionStem := stripDigitRuns(rs.CloudRegion)
 	if regionStem == "" {
 		return ""
 	}
 	return stem + "-" + regionStem
 }
 
-// stripTrailingDigits removes trailing digit runs from a region name —
-// `nbg1` → `nbg`, `hel1` → `hel`, `fsn1` → `fsn`, `sin` → `sin`.
-// Matches tofu's `replace(r.cloudRegion, "/[0-9]+/", "")`.
-func stripTrailingDigits(s string) string {
-	end := len(s)
-	for end > 0 && s[end-1] >= '0' && s[end-1] <= '9' {
-		end--
+// stripDigitRuns removes EVERY digit run from a region name — `nbg1` →
+// `nbg`, `hel1` → `hel`, `me-east-215-b` → `me-east--b`. This must
+// match tofu's `replace(r.code, "/[0-9]+/", "")` (infra/providers/*
+// secondary cluster.name derivation) EXACTLY: the predecessor
+// (stripTrailingDigits) only removed TRAILING runs, which agreed with
+// tofu on Hetzner regions (`fsn1`, `hel1` — digits at the end) but
+// diverged on kom4dc (`me-east-215-b` — interior run). Live on hw128
+// (#3241 layer 5) the orchestrator wrote peer entries / hostAliases /
+// etcd lookups under `hw128-me-east-215-b` while region-b's cilium
+// registered as `hw128-me-east--b` → region-a polled a cluster-config
+// key that never existed and sat at `remote configuration:
+// retrieved=false` forever, despite a healthy etcd session.
+func stripDigitRuns(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			b.WriteByte(s[i])
+		}
 	}
-	return s[:end]
+	return b.String()
 }
 
 // deriveClusterMeshID returns the canonical Cilium ClusterMesh peer ID


### PR DESCRIPTION
Layer 5 of #3241, found live on hw128 after layers 1-4 (merged #3290/#3299/#3303) brought the tunnel + two-stage flip up: region-a held a healthy etcd session to region-b but sat at `remote configuration: retrieved=false` forever. The Go secondary-name derivation (`stripTrailingDigits`) only strips trailing digit runs while tofu strips ALL runs — identical on Hetzner regions (`fsn1`/`hel1`), divergent on kom4dc (`me-east-215-b` → tofu `me-east--b`). Region-a was polling `cilium/cluster-config/hw128-me-east-215-b`; region-b registered as `hw128-me-east--b`. Cluster IDs agree (215/216) — name only.

Fix: `stripDigitRuns` matches the tofu semantics byte-for-byte; contract test covers kom4dc, Hetzner, no-digit, and explicit-override shapes. `go test -race ./...` green.

Self-applies to hw128 on the post-merge roll (changed secret bytes → the now change-gated restart fires → agents reconnect under the real name). Expected: region-a `1/1 remote clusters ready` → replica WAL stream completes → region-kill walk.

Refs #3241

🤖 Generated with [Claude Code](https://claude.com/claude-code)