### PR TITLE
fix(infra/huawei): pairwise VPC peering + routes — mesh pod datapath was unroutable across the 2-VPC mimic

### DIFF
--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -123,6 +123,63 @@ resource "huaweicloud_vpc" "region" {
   }
 }
 
+# ── Cross-VPC peering for the multi-region mesh datapath ─────────────────
+#
+# kom4dc is ONE physical region; "multi-region" is mimicked via one VPC
+# per RegionSpec. ClusterMesh CONTROL traffic dials public
+# nodeEIP:NodePort (works without peering), but the POD DATAPATH —
+# global-service backends, cnpg-pair WAL streaming — routes to peer NODE
+# INTERNAL IPs, which are unroutable across unpeered VPCs. Verified live
+# on hw128 (#3241 layer 6, 2026-06-11): with both regions 1/1 meshed the
+# replica's pg_basebackup timed out against the primary-mesh global
+# service for an hour; creating this exact peering + the two routes via
+# the Huawei API unblocked it within one retry (and the region-kill walk
+# then PASSED with a 3s promote). Intra-region VPC peering is free and
+# consumes no EIP quota.
+#
+# Pairwise full mesh over the region list (kom4dc reality is 2 VPCs =
+# one pair). Peering requester/accepter live in the same tenant, so the
+# connection auto-activates — no accepter resource needed.
+locals {
+  vpc_peering_pairs = {
+    for pair in flatten([
+      for i, a in var.regions : [
+        for j, b in var.regions : {
+          key = "${a.code}--${b.code}"
+          a   = a.code
+          b   = b.code
+        } if j > i
+      ]
+    ]) : pair.key => pair
+  }
+}
+
+resource "huaweicloud_vpc_peering_connection" "mesh" {
+  for_each = local.vpc_peering_pairs
+
+  name        = "${local.name_prefix}-${each.key}-peering"
+  vpc_id      = huaweicloud_vpc.region[each.value.a].id
+  peer_vpc_id = huaweicloud_vpc.region[each.value.b].id
+}
+
+resource "huaweicloud_vpc_route" "mesh_a_to_b" {
+  for_each = local.vpc_peering_pairs
+
+  vpc_id      = huaweicloud_vpc.region[each.value.a].id
+  destination = local.region_vpc_cidr[each.value.b]
+  type        = "peering"
+  nexthop     = huaweicloud_vpc_peering_connection.mesh[each.key].id
+}
+
+resource "huaweicloud_vpc_route" "mesh_b_to_a" {
+  for_each = local.vpc_peering_pairs
+
+  vpc_id      = huaweicloud_vpc.region[each.value.b].id
+  destination = local.region_vpc_cidr[each.value.a]
+  type        = "peering"
+  nexthop     = huaweicloud_vpc_peering_connection.mesh[each.key].id
+}
+
 resource "huaweicloud_vpc_subnet" "region" {
   for_each = { for r in var.regions : r.code => r }
 

--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -157,7 +157,10 @@ locals {
 resource "huaweicloud_vpc_peering_connection" "mesh" {
   for_each = local.vpc_peering_pairs
 
-  name        = "${local.name_prefix}-${each.key}-peering"
+  # Name capped at 64 chars (HCS limit): the raw region-pair key
+  # overflows on long region codes (me-east-215-a--me-east-215-b), so
+  # use a stable 8-hex digest of the pair key instead.
+  name        = "${local.name_prefix}-peer-${substr(sha256(each.key), 0, 8)}"
   vpc_id      = huaweicloud_vpc.region[each.value.a].id
   peer_vpc_id = huaweicloud_vpc.region[each.value.b].id
 }


### PR DESCRIPTION
Source fix for #3241 layer 6, proven live on hw128 today: with both regions fully meshed at the control plane, the pod datapath (global services, cnpg-pair WAL) was structurally unroutable — separate VPCs, no peering, workers without EIPs. The API-created equivalent of this exact peering+routes unblocked the replica within one basebackup retry, enabling the region-kill walk PASS (3s promote). This makes the next prov zero-touch. `tofu validate` clean.

Refs #3241

🤖 Generated with [Claude Code](https://claude.com/claude-code)