### PR TITLE
fix(bp-powerdns): redirect carries explicit port 443 — listener-port leak (#3225)

### DIFF
--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -133,7 +133,11 @@ spec:
       # bare GET / on pdns.<fqdn> to the UI at pdns-admin.<fqdn> (set via
       # values.api.uiRedirectHost below) so the browser lands on the UI
       # instead of a 404; the /api forward rule is preserved.
-      version: 1.2.11
+      # 1.2.12 (#3225): RequestRedirect carries explicit port 443 — the
+      # Gateway-API default copied the cilium listener port (30443) into
+      # the Location header, landing browsers on a port nothing serves
+      # externally (proven live hw129).
+      version: 1.2.12
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.11
+  version: 1.2.12
   card:
     title: PowerDNS
     summary: |

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -13,7 +13,7 @@ name: bp-powerdns
 # founder's browser lands on the UI instead of a 404. The /api forward
 # rule is preserved (Gateway-API longest-prefix). Default empty = no
 # redirect rule rendered (zero regression).
-version: 1.2.11
+version: 1.2.12
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/templates/api-httproute.yaml
+++ b/platform/powerdns/chart/templates/api-httproute.yaml
@@ -77,6 +77,13 @@ spec:
         - type: RequestRedirect
           requestRedirect:
             hostname: {{ . | quote }}
+            # Explicit 443: without it Gateway API copies the LISTENER
+            # port into the Location header — on Sovereigns the cilium
+            # gateway listens on 30443 behind the ELB, so the browser got
+            # `https://pdns-admin.<fqdn>:30443/` which nothing serves
+            # externally (proven live on hw129, 2026-06-12: redirect fired
+            # with :30443 → 000; same target on :443 → 302 /login).
+            port: 443
             statusCode: 302
     {{- end }}
 {{- end }}


### PR DESCRIPTION
The hw129 walk proved the #3225 redirect fires but lands on `:30443` (Gateway API copies the listener port) — dead externally. One-line fix: explicit `port: 443` in the RequestRedirect filter. Live evidence in the commit. Chart-only; lockstep 1.2.12. Refs #3225

🤖 Generated with [Claude Code](https://claude.com/claude-code)