### PR TITLE
fix(bp-postgres): mint per-binding role-password Secrets — CNPG never creates managed-role secrets

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -86,7 +86,11 @@ spec:
       # annotations — NOT in the consumer namespaces (gitea/harbor), which
       # don't exist when this HR installs. Breaks the bp-postgres-shared ⟲
       # bp-gitea/bp-harbor circular deadlock (live hw127).
-      version: 0.1.2
+      # 0.1.3 (#3285): the chart MINTS each per-binding role-password Secret
+      # (kubernetes.io/basic-auth, stable via lookup-keep) — CNPG never
+      # auto-creates managed-role secrets, so the hub reflects: pull had no
+      # source and consumers starved on hw130 (CreateContainerConfigError).
+      version: 0.1.3
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-4-1-data-services
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.1.2
+  version: 0.1.3
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-postgres
-version: 0.1.2
+version: 0.1.3
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable

--- a/platform/postgres/chart/templates/role-secrets.yaml
+++ b/platform/postgres/chart/templates/role-secrets.yaml
@@ -25,6 +25,7 @@ So the chart mints each role Secret itself:
   - resource-policy keep so a release replace never rotates passwords
     under a running consumer.
 */ -}}
+{{- if ne (toString .Values.enabled) "false" }}
 {{- range .Values.databases }}
 {{- $name := include "bp-postgres.roleSecretName" (dict "ctx" $ "db" .) }}
 {{- $existing := lookup "v1" "Secret" $.Release.Namespace $name }}
@@ -51,4 +52,5 @@ metadata:
 stringData:
   username: {{ .owner | quote }}
   password: {{ $password | quote }}
+{{- end }}
 {{- end }}

--- a/platform/postgres/chart/templates/role-secrets.yaml
+++ b/platform/postgres/chart/templates/role-secrets.yaml
@@ -1,0 +1,54 @@
+{{- /*
+Per-binding ROLE PASSWORD Secrets — the #3285 hw130 root-cause fix.
+
+CNPG only auto-generates credentials for the BOOTSTRAP owner
+(`<instance>-app`) and the superuser. `managed.roles[].passwordSecret`
+(cluster.yaml) is a Secret CNPG *consumes* to set the role's password —
+it never creates it. The prior design assumed CNPG would mint
+`<instance>-<owner>` per managed role; proven false live on hw130
+(first prov where consumers actually rendered SHARED): the role
+Secrets never appeared, the hub connection Secrets (which `reflects:`
+from them) stayed empty, reflector logged "Source shared-data/
+shared-pg-gitea could not be found", and gitea/harbor sat in
+CreateContainerConfigError on a missing reflected Secret.
+
+So the chart mints each role Secret itself:
+  - type kubernetes.io/basic-auth (CNPG's passwordSecret contract:
+    username + password keys).
+  - STABLE password across upgrades via the in-repo lookup-keep pattern
+    (gitea admin-secret shape): first render generates, later renders
+    re-use the live value. Safe here because the Secret is CHART-owned
+    (the connection-secret.yaml lookup warning concerns CNPG-owned
+    Secrets that appear after apply — different case).
+  - reflection-allowed so the hub Secret's `reflects:` pull (same
+    namespace) is permitted by bp-reflector.
+  - resource-policy keep so a release replace never rotates passwords
+    under a running consumer.
+*/ -}}
+{{- range .Values.databases }}
+{{- $name := include "bp-postgres.roleSecretName" (dict "ctx" $ "db" .) }}
+{{- $existing := lookup "v1" "Secret" $.Release.Namespace $name }}
+{{- $password := "" }}
+{{- if and $existing $existing.data $existing.data.password }}
+{{- $password = $existing.data.password | b64dec }}
+{{- else }}
+{{- $password = randAlphaNum 32 }}
+{{- end }}
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/basic-auth
+metadata:
+  name: {{ $name | quote }}
+  namespace: {{ $.Release.Namespace | quote }}
+  labels:
+    {{- include "bp-postgres.labels" $ | nindent 4 }}
+    catalyst.openova.io/binding: {{ .owner | quote }}
+  annotations:
+    helm.sh/resource-policy: keep
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: {{ $.Release.Namespace | quote }}
+stringData:
+  username: {{ .owner | quote }}
+  password: {{ $password | quote }}
+{{- end }}

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -169,6 +169,6 @@ on_db=$(grep -cE '^kind: Database$' "$TMP/on.yaml" || true)
 on_secret=$(grep -cE '^kind: Secret$' "$TMP/on.yaml" || true)
 [ "$on_cluster" -eq 1 ] || fail "enabled=true expected 1 Cluster, got $on_cluster"
 [ "$on_db" -eq 2 ]      || fail "enabled=true expected 2 Databases, got $on_db"
-[ "$on_secret" -eq 2 ]  || fail "enabled=true expected 2 Secrets, got $on_secret"
+[ "$on_secret" -eq 4 ]  || fail "enabled=true expected 4 Secrets (2 hub + 2 role), got $on_secret"
 
 echo "[render] PASS — bp-postgres render gate green (reuse proof: 1 Cluster, 2 Databases, 2 roles, 2 Secrets; master gate OFF → empty)"

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -70,7 +70,11 @@ role_count=$(grep -cE '^      - name: "(harbor|gitea)"$' "$TMP/shared.yaml" || t
 
 [ "$cluster_count" -eq 1 ] || fail "expected 1 Cluster, got $cluster_count"
 [ "$db_count" -eq 2 ]      || fail "expected 2 Databases, got $db_count"
-[ "$secret_count" -eq 2 ]  || fail "expected 2 reflected Secrets, got $secret_count"
+# 0.1.3 (#3285): 2 hub connection Secrets + 2 chart-minted role-password
+# Secrets (CNPG never creates managed-role secrets — proven live hw130).
+[ "$secret_count" -eq 4 ]  || fail "expected 4 Secrets (2 hub + 2 role-password), got $secret_count"
+basic_auth_count=$(grep -cE '^type: kubernetes.io/basic-auth$' "$TMP/shared.yaml" || true)
+[ "$basic_auth_count" -eq 2 ] || fail "expected 2 basic-auth role Secrets, got $basic_auth_count"
 [ "$role_count" -eq 2 ]    || fail "expected 2 managed roles, got $role_count"
 
 # ── Case 3: both Databases reference the SAME shared cluster ──────


### PR DESCRIPTION
hw130's first live SHARED-consumer render exposed the design's false assumption: CNPG doesn't generate managed-role password secrets, so the whole secret chain (role → hub → reflected copy) starved and consumers sat in CreateContainerConfigError. The chart now mints each role Secret (basic-auth, stable lookup-keep, reflection-allowed). Chart-only; self-heals live hw130 via pin-bump. Render+lint verified. Refs #3285 #3188

🤖 Generated with [Claude Code](https://claude.com/claude-code)