### PR TITLE
fix(bp-postgres): strip committed merge markers — unblock the 0.1.4 publish

### DIFF
--- a/platform/postgres/chart/templates/role-secrets.yaml
+++ b/platform/postgres/chart/templates/role-secrets.yaml
@@ -1,5 +1,4 @@
 {{- /*
-<<<<<<< HEAD
 Per-binding ROLE PASSWORD Secret + HUB CONNECTION Secret — rendered
 TOGETHER in one scope so both carry the SAME password on every render
 including the very first (two separate templates each calling
@@ -47,50 +46,10 @@ consumer; resource-policy keep guards release replaces.
 ---
 # Role password Secret — CNPG managed.roles[].passwordSecret contract
 # (kubernetes.io/basic-auth: username + password).
-=======
-Per-binding ROLE PASSWORD Secrets — the #3285 hw130 root-cause fix.
-
-CNPG only auto-generates credentials for the BOOTSTRAP owner
-(`<instance>-app`) and the superuser. `managed.roles[].passwordSecret`
-(cluster.yaml) is a Secret CNPG *consumes* to set the role's password —
-it never creates it. The prior design assumed CNPG would mint
-`<instance>-<owner>` per managed role; proven false live on hw130
-(first prov where consumers actually rendered SHARED): the role
-Secrets never appeared, the hub connection Secrets (which `reflects:`
-from them) stayed empty, reflector logged "Source shared-data/
-shared-pg-gitea could not be found", and gitea/harbor sat in
-CreateContainerConfigError on a missing reflected Secret.
-
-So the chart mints each role Secret itself:
-  - type kubernetes.io/basic-auth (CNPG's passwordSecret contract:
-    username + password keys).
-  - STABLE password across upgrades via the in-repo lookup-keep pattern
-    (gitea admin-secret shape): first render generates, later renders
-    re-use the live value. Safe here because the Secret is CHART-owned
-    (the connection-secret.yaml lookup warning concerns CNPG-owned
-    Secrets that appear after apply — different case).
-  - reflection-allowed so the hub Secret's `reflects:` pull (same
-    namespace) is permitted by bp-reflector.
-  - resource-policy keep so a release replace never rotates passwords
-    under a running consumer.
-*/ -}}
-{{- if ne (toString .Values.enabled) "false" }}
-{{- range .Values.databases }}
-{{- $name := include "bp-postgres.roleSecretName" (dict "ctx" $ "db" .) }}
-{{- $existing := lookup "v1" "Secret" $.Release.Namespace $name }}
-{{- $password := "" }}
-{{- if and $existing $existing.data $existing.data.password }}
-{{- $password = $existing.data.password | b64dec }}
-{{- else }}
-{{- $password = randAlphaNum 32 }}
-{{- end }}
----
->>>>>>> origin/main
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/basic-auth
 metadata:
-<<<<<<< HEAD
   name: {{ $roleName | quote }}
   namespace: {{ $ns | quote }}
   labels:
@@ -129,19 +88,5 @@ stringData:
   host: "{{ $instance }}-rw.{{ $ns }}.svc.cluster.local"
   port: "5432"
 {{- end }}
-=======
-  name: {{ $name | quote }}
-  namespace: {{ $.Release.Namespace | quote }}
-  labels:
-    {{- include "bp-postgres.labels" $ | nindent 4 }}
-    catalyst.openova.io/binding: {{ .owner | quote }}
-  annotations:
-    helm.sh/resource-policy: keep
-    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: {{ $.Release.Namespace | quote }}
-stringData:
-  username: {{ .owner | quote }}
-  password: {{ $password | quote }}
->>>>>>> origin/main
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The #3314 background conflict resolution committed role-secrets.yaml with its markers; the Blueprint Release render gate correctly refused to publish (no broken chart shipped). Clean HEAD-side resolution; lint + packaged-tgz render + full suite PASS. Unblocks the hw130 self-heal chain. Refs #3285

🤖 Generated with [Claude Code](https://claude.com/claude-code)