### PR TITLE
fix(clustermesh): rescue Phase-1-TIMEOUT records — orchestrator abandoned them forever

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -1956,8 +1956,17 @@ func (h *Handler) shouldStartupClusterMeshReconcile(dep *Deployment) bool {
 	dep.mu.Lock()
 	status := dep.Status
 	regionCount := len(dep.Request.Regions)
+	outcome := ""
+	if dep.Result != nil {
+		outcome = dep.Result.Phase1Outcome
+	}
 	dep.mu.Unlock()
-	if status != "ready" || regionCount < 2 {
+	// ready, OR failed-by-TIMEOUT (#3285/hw130): a timeout record's
+	// cluster keeps converging under Flux — abandoning its mesh forever
+	// contradicted the never-wipe-a-timeout doctrine. Hard failures
+	// (OutcomeFailed / flux-not-reconciling) stay excluded.
+	rescuableTimeout := status == "failed" && outcome == helmwatch.OutcomeTimeout
+	if (status != "ready" && !rescuableTimeout) || regionCount < 2 {
 		return false
 	}
 	if _, ok := h.resolvePrimaryKubeconfigPath(dep); !ok {

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -47,6 +47,7 @@ import (
 	kfake "k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
 
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
 )
@@ -1926,5 +1927,42 @@ func TestAutoEstablishClusterMesh_IdempotentRerunSkipsRolloutRestart(t *testing.
 	}
 	if second := stampOf(); second != first {
 		t.Errorf("idempotent re-run bumped restartedAt %q -> %q — the #3241 layer-4 thrash", first, second)
+	}
+}
+
+// TestShouldStartupClusterMeshReconcile_RescuesTimeoutRecords locks in
+// the #3285/hw130 doctrine gap: a Phase-1 TIMEOUT record ("components
+// observed, none hard-failed") keeps converging under Flux and must
+// NOT be abandoned by the mesh orchestrator — previously the gate's
+// status=="ready" check excluded it forever (hw130 sat fully converged
+// with 0/0 mesh). failed-by-TIMEOUT is rescuable; hard failures stay
+// excluded.
+func TestShouldStartupClusterMeshReconcile_RescuesTimeoutRecords(t *testing.T) {
+	dir := t.TempDir()
+	h := &Handler{log: silentLogger(), kubeconfigsDir: dir}
+	const depID = "hw130timeoutrescue"
+	if err := os.WriteFile(filepath.Join(dir, depID+".yaml"), []byte("apiVersion: v1\nkind: Config\n"), 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+	regions := []provisioner.RegionSpec{
+		{Provider: "huawei", CloudRegion: "me-east-215-a"},
+		{Provider: "huawei", CloudRegion: "me-east-215-b"},
+	}
+	mk := func(status, outcome string) *Deployment {
+		return &Deployment{ID: depID, Status: status,
+			Request: provisioner.Request{Regions: regions},
+			Result:  &provisioner.Result{Phase1Outcome: outcome}}
+	}
+	if !h.shouldStartupClusterMeshReconcile(mk("failed", helmwatch.OutcomeTimeout)) {
+		t.Errorf("failed+timeout record must be rescued (the hw130 abandonment)")
+	}
+	if h.shouldStartupClusterMeshReconcile(mk("failed", helmwatch.OutcomeFailed)) {
+		t.Errorf("failed+hard-failure record must stay excluded")
+	}
+	if h.shouldStartupClusterMeshReconcile(mk("failed", "flux-not-reconciling")) {
+		t.Errorf("flux-not-reconciling record must stay excluded")
+	}
+	if !h.shouldStartupClusterMeshReconcile(mk("ready", helmwatch.OutcomeReady)) {
+		t.Errorf("ready record must still pass")
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -764,6 +764,21 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		// per-region LB IP wait loops (each up to 5 min).
 		// docs/SOVEREIGN-MULTI-REGION-DOD.md gates D9-D12.
 		go h.runAutoEstablishClusterMesh(dep)
+	} else if outcome == helmwatch.OutcomeTimeout && len(dep.Request.Regions) >= 2 {
+		// #3285/hw130 (2026-06-12): a Phase-1 TIMEOUT is the
+		// recoverable classification ("components observed, none
+		// hard-failed, not all converged") — Flux keeps reconciling
+		// the cluster long after the watch budget expires, and the
+		// doctrine forbids wiping such envs. But the mesh orchestrator
+		// previously fired ONLY on OutcomeReady, so a timeout record
+		// was permanently abandoned: no mesh, no cnpg-pair flip, no
+		// Pillar-3 — witnessed live on hw130, fully converged at the
+		// cluster level with 0/0 mesh forever. Kick the level-trigger
+		// for timeouts too: its first attempts may fail while the
+		// cluster catches up (warn-and-retry is the loop's design) and
+		// it converges exactly when the env does. Handover stays
+		// ready-only — this rescues the TOPOLOGY, not the lifecycle.
+		go h.runAutoEstablishClusterMesh(dep)
 		// C10-003 (2026-05-17 t143): when Phase-1 reaches
 		// OutcomeReady, the PRIMARY's terminate path persists the
 		// final per-Job status from its own helmwatch state map.

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -764,21 +764,6 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		// per-region LB IP wait loops (each up to 5 min).
 		// docs/SOVEREIGN-MULTI-REGION-DOD.md gates D9-D12.
 		go h.runAutoEstablishClusterMesh(dep)
-	} else if outcome == helmwatch.OutcomeTimeout && len(dep.Request.Regions) >= 2 {
-		// #3285/hw130 (2026-06-12): a Phase-1 TIMEOUT is the
-		// recoverable classification ("components observed, none
-		// hard-failed, not all converged") — Flux keeps reconciling
-		// the cluster long after the watch budget expires, and the
-		// doctrine forbids wiping such envs. But the mesh orchestrator
-		// previously fired ONLY on OutcomeReady, so a timeout record
-		// was permanently abandoned: no mesh, no cnpg-pair flip, no
-		// Pillar-3 — witnessed live on hw130, fully converged at the
-		// cluster level with 0/0 mesh forever. Kick the level-trigger
-		// for timeouts too: its first attempts may fail while the
-		// cluster catches up (warn-and-retry is the loop's design) and
-		// it converges exactly when the env does. Handover stays
-		// ready-only — this rescues the TOPOLOGY, not the lifecycle.
-		go h.runAutoEstablishClusterMesh(dep)
 		// C10-003 (2026-05-17 t143): when Phase-1 reaches
 		// OutcomeReady, the PRIMARY's terminate path persists the
 		// final per-Job status from its own helmwatch state map.
@@ -844,6 +829,22 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		// manually patch per #2441 fallback). See post_handover_policy_
 		// enforce.go for the full helper.
 		go h.runPostHandoverPolicyEnforceFlip(dep)
+	} else if outcome == helmwatch.OutcomeTimeout && len(dep.Request.Regions) >= 2 {
+		// #3285/hw130 (2026-06-12): a Phase-1 TIMEOUT is the
+		// recoverable classification ("components observed, none
+		// hard-failed, not all converged") — Flux keeps reconciling
+		// the cluster long after the watch budget expires, and the
+		// doctrine forbids wiping such envs. But the mesh orchestrator
+		// previously fired ONLY on OutcomeReady, so a timeout record
+		// was permanently abandoned: no mesh, no cnpg-pair flip, no
+		// Pillar-3 — witnessed live on hw130, fully converged at the
+		// cluster level with 0/0 mesh forever. Kick the level-trigger
+		// for timeouts too: its first attempts may fail while the
+		// cluster catches up (warn-and-retry is the loop's design) and
+		// it converges exactly when the env does. Handover, the job
+		// sweep, and the policy flip stay ready-only — this rescues
+		// the TOPOLOGY, not the lifecycle.
+		go h.runAutoEstablishClusterMesh(dep)
 	}
 }
 


### PR DESCRIPTION
hw130 exposed the doctrine gap live: timeout records (recoverable by definition — Flux keeps reconciling) were permanently excluded from the mesh orchestrator at BOTH entry points, leaving a fully-converged cluster at 0/0 mesh with no rescue path. Both gates now accept failed+OutcomeTimeout (hard failures stay excluded); handover remains ready-only. Post-merge the mothership roll's restoreFromStore rescues hw130 directly. `go test -race ./...` green. Refs #3285 #3241

🤖 Generated with [Claude Code](https://claude.com/claude-code)