### PR TITLE
fix(bp-cnpg-pair): replication netpol must allow own-cluster 5432 — denied the primary's instance-2 join

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -188,7 +188,9 @@ spec:
       # Ingress-only policies default-denied the operator's status probe
       # and the Cluster phase stalled at "Instance Status Extraction
       # Error" on hw126 despite the instance being 1/1 Running.
-      version: 0.2.1
+      # 0.2.2 (hw130): replication netpol also allows OWN-cluster 5432 —
+      # it default-denied the primary's own instance-2 join (>1h wedge).
+      version: 0.2.2
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.2.1
+  version: 0.2.2
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cnpg-pair
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair

--- a/platform/cnpg-pair/chart/templates/networkpolicy.yaml
+++ b/platform/cnpg-pair/chart/templates/networkpolicy.yaml
@@ -62,6 +62,21 @@ spec:
       ports:
         - port: 5432
           protocol: TCP
+    # OWN-cluster pods (0.2.2, hw130 live find): this policy selects ALL
+    # primary-CR Pods, default-denying the cluster's OWN internal 5432 —
+    # instance-2's pg_basebackup join, instance-to-instance streaming,
+    # and any switchover rejoin. hw130 sat "Creating a new replica" >1h,
+    # the join pod's SYNs dropped (cilium monitor: "Policy denied …
+    # 5432 tcp SYN"). hw128's region-kill walk never caught it: those
+    # writes ran via kubectl exec (unix socket — never crossed the
+    # wire). Only a live multi-instance join exercises this path.
+    - from:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: {{ include "cnpg-pair.primaryName" . }}
+      ports:
+        - port: 5432
+          protocol: TCP
     # CNPG operator status + metrics probe — without this the operator
     # cannot extract the primary instance's status and the Cluster phase
     # stalls at "Instance Status Extraction Error".


### PR DESCRIPTION
hw130 live find via cilium monitor: the chart's own NetworkPolicy default-denied the primary cluster's internal replication (join pod SYN-dropped >1h). Own-cluster carve-out added; chart-only 0.2.2, self-heals hw130 via pin bump. Undetectable by render tests or exec-based walks — only a live multi-instance join hits this path. Refs #3241 #3195

🤖 Generated with [Claude Code](https://claude.com/claude-code)