### PR TITLE
fix(catalyst-api): Open-button gate fails CLOSED on missing UI evidence (#3224 hw130 regression)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -1512,19 +1512,28 @@ func (h *Handler) externalURLIfUserUI(ctx context.Context, depID, blueprint, tar
 	}
 	bpName := strings.TrimPrefix(strings.TrimSpace(blueprint), "bp-")
 	if bpName == "" {
-		// No blueprint name to resolve — fail open (legacy behaviour).
+		// No blueprint name — no UI signal can ever exist for this app.
+		// FAIL CLOSED (#3224 round-1 fix).
+		return ""
+	}
+	if h.catalogClient == nil {
+		// Catalog client not configured AT ALL (chroot config gap, CI) —
+		// the gate cannot distinguish any app from any other, so
+		// suppressing here would kill every WORKING Launch button
+		// fleet-wide. This is the single deliberate fail-OPEN branch.
 		return u
 	}
 	bp, err := h.resolveBlueprintMeta(ctx, bpName, "")
-	if err != nil || bp == nil {
-		// Could not resolve the Blueprint (catalog error / unwired) —
-		// fail open so a transient lookup failure never hides a real UI.
-		return u
-	}
-	if len(bp.Endpoints) == 0 {
-		// Catalog unwired or the Blueprint declares no endpoints at all —
-		// no UI signal available, fail open to preserve prior behaviour.
-		return u
+	if err != nil || bp == nil || len(bp.Endpoints) == 0 {
+		// FAIL CLOSED (#3224 round-1): transport error, blueprint
+		// NotFound in the catalog, malformed spec, or a genuine
+		// `endpoints: []` declaration (bp-newapi's shape) — in every
+		// case there is NO evidence of a user UI. The old fail-open
+		// here is exactly what rendered dead Open buttons on live
+		// hw130 (the catalog 404'd bp-newapi → button showed anyway).
+		// A suppressed button self-corrects on the next render if the
+		// catalog recovers; a dead button never does.
+		return ""
 	}
 	if !blueprintHasUserUIEndpoint(bp) {
 		// Resolved, endpoints present, but none is a user UI (API/protocol

--- a/products/catalyst/bootstrap/api/internal/handler/applications_open_button_gate_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_open_button_gate_test.go
@@ -201,3 +201,26 @@ func TestExternalURLIfUserUI_GatesOnBlueprint(t *testing.T) {
 		}
 	})
 }
+
+// TestExternalURLIfUserUI_NotFoundFailsClosed locks in the hw130
+// round-1 regression fix: the catalog is WIRED but 404s the blueprint
+// (NotFound → resolveBlueprintMeta returns empty meta). The old gate
+// failed OPEN here and rendered dead Open buttons for bp-newapi /
+// bp-openova-flow-server on live hw130 (evidence:
+// docs/sessions/2026-06-12/evidence/hw130-appdetail-*-open-regression.png).
+// With no evidence of a user UI the URL must be suppressed; only a
+// fully-unconfigured catalog client (the chroot config-gap case, the
+// test above) stays fail-open.
+func TestExternalURLIfUserUI_NotFoundFailsClosed(t *testing.T) {
+	route := newHTTPRoute("catalyst-system", "newapi", "newapi.hw130.omantel.biz", "newapi")
+	f := newFactoryWithHTTPRoutes(t, route)
+	h := &Handler{log: quietLog()}
+	h.SetK8sCache(f, k8scache.NewSARCache(), "X-Forwarded-User")
+	// Catalog wired but EMPTY — Get returns ErrBlueprintNotFound for
+	// every name, the exact hw130 shape (catalog 404 on bp-newapi).
+	h.SetCatalogClient(newFakeCatalog())
+	got := h.externalURLIfUserUI(context.Background(), "alpha", "bp-newapi", "catalyst-system", "newapi")
+	if got != "" {
+		t.Fatalf("NotFound blueprint: got %q, want empty — the gate must FAIL CLOSED (#3224)", got)
+	}
+}


### PR DESCRIPTION
Round-1's live walk caught the #3229 gate failing open on catalog NotFound — dead Open buttons on bp-newapi/bp-openova-flow-server. Evidence-or-no-button policy: all indeterminate branches fail closed; only catalogClient==nil (config gap) stays open so working Launches survive an unwired chroot. Regression test added. Refs #3224

🤖 Generated with [Claude Code](https://claude.com/claude-code)