### PR TITLE
feat(catalyst-api): Data-instances card projects bootstrap-HR engines (#3188 headline count)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
@@ -830,7 +830,77 @@ func (h *Handler) HandleListBlueprintInstances(w http.ResponseWriter, r *http.Re
 			CreatedAt: item.GetCreationTimestamp().UTC().Format(time.RFC3339),
 		})
 	}
+
+	// #3188 (hw129/hw130 round-1): bootstrap-kit installs of this
+	// blueprint ship as Flux HelmReleases with NO companion Application
+	// CR — the platform shared-PG engine (HR bp-postgres-shared, chart
+	// bp-postgres, release in shared-data) being the founder-headline
+	// case. Counting only Application CRs rendered the Data-instances
+	// card as "0 instances" on an env whose engine was live with two
+	// consumers (gitea 110 tables + registry 49). Project those HRs as
+	// instance rows too — same fallback philosophy as the silent-SSO
+	// launch-url HR path above. Org-scoped filtering: bootstrap HRs are
+	// platform-owned, so any explicit ?org= filter excludes them.
+	if orgFilter == "" {
+		out = append(out, h.bootstrapHRInstances(r.Context(), client, bp, out)...)
+	}
 	writeJSON(w, http.StatusOK, listInstancesResponse{Items: out})
+}
+
+// bootstrapHRInstances projects Flux HelmReleases whose chart is
+// bp-<blueprint> into applicationSummary rows — the bootstrap-kit
+// (platform-owned) installs that have no Application CR. `existing`
+// suppresses duplicates when a future Application CR adopts a release
+// (matched by release/instance name).
+func (h *Handler) bootstrapHRInstances(ctx context.Context, client dynamic.Interface, bp string, existing []applicationSummary) []applicationSummary {
+	hrs, err := client.Resource(helmReleaseGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		// Best-effort projection: the Application-CR rows already in
+		// `existing` stay authoritative; an HR list failure must not
+		// fail the endpoint.
+		return nil
+	}
+	seen := map[string]struct{}{}
+	for _, e := range existing {
+		seen[strings.ToLower(e.Name)] = struct{}{}
+	}
+	rows := []applicationSummary{}
+	for i := range hrs.Items {
+		hr := &hrs.Items[i]
+		chart, _, _ := unstructured.NestedString(hr.Object, "spec", "chart", "spec", "chart")
+		if chart != "bp-"+bp {
+			continue
+		}
+		// Instance display name: the release name (HR name with the
+		// bp- prefix stripped reads naturally — bp-postgres-shared →
+		// postgres-shared), targetNamespace as the locality hint.
+		name := strings.TrimPrefix(hr.GetName(), "bp-")
+		if _, dup := seen[strings.ToLower(name)]; dup {
+			continue
+		}
+		status := "NotReady"
+		conds, _, _ := unstructured.NestedSlice(hr.Object, "status", "conditions")
+		for _, c := range conds {
+			cm, ok := c.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if cm["type"] == "Ready" && cm["status"] == "True" {
+				status = "Ready"
+				break
+			}
+		}
+		rows = append(rows, applicationSummary{
+			ID:        string(hr.GetUID()),
+			Name:      name,
+			Blueprint: bp,
+			Org:       "platform",
+			Topology:  "singleton",
+			Status:    status,
+			CreatedAt: hr.GetCreationTimestamp().UTC().Format(time.RFC3339),
+		})
+	}
+	return rows
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler_instances_hr_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler_instances_hr_test.go
@@ -1,0 +1,57 @@
+package handler
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynfake "k8s.io/client-go/dynamic/fake"
+)
+
+// TestBootstrapHRInstances_ProjectsEngineHRs locks the #3188 card fix:
+// a bootstrap-kit HelmRelease whose chart is bp-<blueprint> (the
+// shared-PG engine shape: HR bp-postgres-shared, chart bp-postgres,
+// release in shared-data, NO Application CR) must appear as ONE
+// instance row — round-1 walked the card reading "0 instances" while
+// the live engine served two consumers. Also: a non-matching chart is
+// excluded, and a name already covered by an Application-CR row is not
+// duplicated.
+func TestBootstrapHRInstances_ProjectsEngineHRs(t *testing.T) {
+	mk := func(name, chart, ready string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "helm.toolkit.fluxcd.io/v2",
+			"kind":       "HelmRelease",
+			"metadata":   map[string]interface{}{"name": name, "namespace": "flux-system", "uid": "uid-" + name},
+			"spec": map[string]interface{}{
+				"chart": map[string]interface{}{"spec": map[string]interface{}{"chart": chart}},
+			},
+			"status": map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{"type": "Ready", "status": ready},
+				},
+			},
+		}}
+	}
+	scheme := runtime.NewScheme()
+	c := dynfake.NewSimpleDynamicClient(scheme,
+		mk("bp-postgres-shared", "bp-postgres", "True"),
+		mk("bp-gitea", "bp-gitea", "True"),
+		mk("bp-postgres-covered", "bp-postgres", "False"),
+	)
+	h := &Handler{log: quietLog()}
+	rows := h.bootstrapHRInstances(context.Background(), c, "postgres",
+		[]applicationSummary{{Name: "postgres-covered"}})
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1 (engine HR only; gitea chart excluded, covered name deduped): %+v", len(rows), rows)
+	}
+	r := rows[0]
+	if r.Name != "postgres-shared" || r.Org != "platform" || r.Status != "Ready" || r.Blueprint != "postgres" {
+		t.Fatalf("row = %+v, want name=postgres-shared org=platform status=Ready blueprint=postgres", r)
+	}
+	if r.ID != "uid-bp-postgres-shared" {
+		t.Fatalf("ID = %q, want the HR UID", r.ID)
+	}
+	_ = metav1.ListOptions{}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler_test.go
@@ -63,6 +63,9 @@ func fakeEndpointDynamic(seed ...runtime.Object) (func() (dynamic.Interface, err
 	scheme := runtime.NewScheme()
 	listKinds := map[schema.GroupVersionResource]string{
 		ApplicationGVR(): "ApplicationList",
+		// #3188: HandleListBlueprintInstances also projects bootstrap
+		// HelmReleases (no-org path) — the fake must know the list kind.
+		helmReleaseGVR: "HelmReleaseList",
 	}
 	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, seed...)
 	return func() (dynamic.Interface, error) {


### PR DESCRIPTION
Round-1's card walk read '0 instances' while the live shared engine served two consumers — the endpoint counted Application CRs only. Bootstrap HRs whose chart matches the blueprint now project as platform-owned instance rows (deduped, best-effort, org-filter-excluded). Bindings remain the documented follow-up. Closes the card's count on the next console roll; round-2 re-walk verdicts it. Refs #3188

🤖 Generated with [Claude Code](https://claude.com/claude-code)