### PR TITLE
fix(infra/huawei): layer-7 ELB health checks — TCP checks masked dead envoy legs

### DIFF
--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -1233,12 +1233,27 @@ resource "huaweicloud_elb_member" "http" {
 }
 
 resource "huaweicloud_elb_monitor" "https" {
-  pool_id     = huaweicloud_elb_pool.https.id
-  protocol    = "TCP"
-  port        = 30443 # Wave 5.124 (hw29 fix-forward) — Gateway listener
-  interval    = 10
-  timeout     = 5
-  max_retries = 3
+  pool_id  = huaweicloud_elb_pool.https.id
+  # #3301 (hw130, 2026-06-12): TCP-only checks keep a member ONLINE even
+  # when its envoy ACCEPTS connections but fails every upstream HTTP
+  # request ("upstream connect error … connection timeout") — witnessed
+  # live as a strict 200/503 round-robin alternation on api.<fqdn> that
+  # survived an envoy DS restart, with all 4 members operating=ONLINE.
+  # An HTTP-layer check through the gateway listener ejects such a
+  # member from rotation, converting user-facing 1-in-N 503s to zero
+  # while the envoy-side root cause is chased. domain_name gives envoy
+  # its SNI/Host so the request traverses the real route; any HTTP
+  # status proves the member's envoy→backend path is alive (the console
+  # route serves 200/3xx; a dead upstream yields the 503 the check
+  # rejects).
+  protocol      = "HTTPS"
+  port          = 30443 # Wave 5.124 (hw29 fix-forward) — Gateway listener
+  domain_name   = "console.${var.sovereign_fqdn}"
+  url_path      = "/login"
+  status_code   = "200-399"
+  interval      = 10
+  timeout       = 5
+  max_retries   = 3
 }
 
 resource "huaweicloud_elb_monitor" "http" {


### PR DESCRIPTION
hw130's strict 200/503 alternation with all members ONLINE = the TCP monitor's blind spot. HTTPS check via the real listener (SNI console.<fqdn>, /login, 200-399) ejects dead-upstream members from rotation. tofu validate green; live hw130 patched via API in parallel. Refs #3301 #3323

🤖 Generated with [Claude Code](https://claude.com/claude-code)