### PR TITLE
fix(bp-velero-hcs): disable request checksums — OBS rejected every backup write (XAmzContentSHA256Mismatch)

### DIFF
--- a/clusters/_template/bootstrap-kit/34a-bp-velero-hcs.yaml
+++ b/clusters/_template/bootstrap-kit/34a-bp-velero-hcs.yaml
@@ -81,7 +81,9 @@ spec:
   chart:
     spec:
       chart: bp-velero-hcs
-      version: 0.1.0
+      # 0.1.1 (#2847): checksumAlgorithm "" — OBS rejects aws-sdk-v2
+      # flexible checksums (XAmzContentSHA256Mismatch on every write).
+      version: 0.1.1
       sourceRef:
         kind: HelmRepository
         name: bp-velero-hcs

--- a/platform/velero-hcs/blueprint.yaml
+++ b/platform/velero-hcs/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-observability
 spec:
-  version: 0.1.0
+  version: 0.1.1
   card:
     title: Velero (HCS)
     family: insights

--- a/platform/velero-hcs/chart/Chart.yaml
+++ b/platform/velero-hcs/chart/Chart.yaml
@@ -33,7 +33,7 @@ description: |
   bp-velero on HCS) → closes the resulting backup-engine gap on
   every HCS Sovereign. Refs #2847.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.18.0"
 keywords: [catalyst, blueprint, velero, backup, disaster-recovery, huawei, hcs, obs]
 maintainers:

--- a/platform/velero-hcs/chart/values.yaml
+++ b/platform/velero-hcs/chart/values.yaml
@@ -131,6 +131,16 @@ velero:
           region: ""
           s3ForcePathStyle: "true"
           s3Url: ""
+          # #2847 acceptance walk (hw130, 2026-06-12): every PutObject
+          # failed with XAmzContentSHA256Mismatch — aws-sdk-go-v2's
+          # flexible-checksum default (CRC32 trailing checksums /
+          # signed streaming payloads) is not honored by Huawei OBS's
+          # S3 compatibility, so the BSL validated "Available" (read
+          # path) while EVERY backup write failed. Empty string
+          # disables the request checksum algorithm in
+          # velero-plugin-for-aws (>=1.10), restoring plain SigV4
+          # bodies that OBS accepts.
+          checksumAlgorithm: ""
     volumeSnapshotLocation:
       - name:
         provider: ""


### PR DESCRIPTION
The #2847 acceptance walk ran a real backup and found the write path broken under a deceptively-Available BSL (read-only validation). One-line BSL config fix (checksumAlgorithm ""); re-verification on live hw130 after the pin lands. Refs #2847

🤖 Generated with [Claude Code](https://claude.com/claude-code)