### PR TITLE
fix(bootstrap-kit): velero checksumAlgorithm in the operative slot BSL entry

### DIFF
--- a/clusters/_template/bootstrap-kit/34a-bp-velero-hcs.yaml
+++ b/clusters/_template/bootstrap-kit/34a-bp-velero-hcs.yaml
@@ -149,3 +149,11 @@ spec:
               key: cloud
             config:
               s3ForcePathStyle: "true"
+              # #2847 (hw130 acceptance walk): OBS rejects aws-sdk-v2
+              # flexible checksums (XAmzContentSHA256Mismatch on every
+              # PutObject). Empty string disables the request checksum.
+              # NOTE this must live HERE: this slot's values define the
+              # whole backupStorageLocation[0] entry, and Helm replaces
+              # LIST values wholesale — the chart-default config map
+              # (0.1.1) never survives the overlay.
+              checksumAlgorithm: ""


### PR DESCRIPTION
Helm list-replacement clobbered the 0.1.1 chart default — the key must live in slot 34a's own backupStorageLocation[0]. Refs #2847

🤖 Generated with [Claude Code](https://claude.com/claude-code)