### PR TITLE
feat(continuum): production DR-contract seed ON — CRD pattern admits real cloud region codes (#3195 G6)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -986,7 +986,10 @@ spec:
       # 1.4.552 — #3188 (2026-06-10): catalog-seed gains the missing bp-postgres
       # Blueprint CR (the shareable PostgreSQL data-instance App card, ADR-0010)
       # — was the lone catalog-404 for the data-instance card on a fresh prov.
-      version: 1.4.580
+      # 1.4.581 (#3195 G6): continuum CRD region pattern relaxed to
+      # admit real cloud codes (kom4dc digits) — unblocks the
+      # production Continuum seed (slot 16b, cnpg-pair 0.2.3).
+      version: 1.4.581
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -190,7 +190,9 @@ spec:
       # Error" on hw126 despite the instance being 1/1 Running.
       # 0.2.2 (hw130): replication netpol also allows OWN-cluster 5432 —
       # it default-denied the primary's own instance-2 join (>1h wedge).
-      version: 0.2.2
+      # 0.2.3 (#3195 G6): production Continuum seed flipped ON (real
+      # region labels; CRD pattern relaxed in lockstep, catalyst chart).
+      version: 0.2.3
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair
@@ -270,6 +272,21 @@ spec:
         region: '${SOVEREIGN_PRIMARY_REGION:-}'
       replica:
         region: '${SOVEREIGN_REPLICA_REGION:-}'
+      # ── Continuum DR contract seed (#3195 G6, flipped 2026-06-12) ──
+      # Renders the production Continuum CR so continuum-controller has
+      # a real DR contract to reconcile (it was idle on every prov —
+      # `kubectl get continuum -A` empty, verified hw130). Gating: the
+      # chart renders this ONLY when cnpgPair.enabled is ALSO true, so
+      # single-region provs (gate OFF) stay byte-identical. The region
+      # labels carry the REAL canonical labels — the Continuum CRD
+      # pattern was relaxed in lockstep (products/catalyst/chart/crds/
+      # continuum.yaml) to admit digit-bearing codes; the prior
+      # letters-only pattern was Hetzner-era and unsatisfiable on
+      # kom4dc (me-east-215-*), which is what kept this seed OFF.
+      continuum:
+        enabled: true
+        primaryRegion: '${SOVEREIGN_PRIMARY_REGION:-}'
+        hotStandbyRegion: '${SOVEREIGN_REPLICA_REGION:-}'
       image:
         # harbor-proxy-pull compliant prefix (see header). Public CNPG
         # image; proxy-ghcr serves it cred-free pre-cutover.

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.2.2
+  version: 0.2.3
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cnpg-pair
-version: 0.2.2
+version: 0.2.3
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair

--- a/platform/cnpg-pair/chart/templates/continuum.yaml
+++ b/platform/cnpg-pair/chart/templates/continuum.yaml
@@ -33,7 +33,7 @@ live there too.
 */ -}}
 {{- if and .Values.cnpgPair.enabled .Values.cnpgPair.continuum.enabled (include "cnpg-pair.isPrimarySide" .) }}
 {{- include "cnpg-pair.validateRegions" . }}
-{{- $cprim := required "continuum.primaryRegion is REQUIRED when continuum.enabled=true — set the canonical 4-segment label (e.g. hz-fsn-rtz-prod) matching the Continuum CRD pattern ^[a-z]+-[a-z]+-[a-z]+-[a-z]+$" .Values.cnpgPair.continuum.primaryRegion -}}
+{{- $cprim := required "continuum.primaryRegion is REQUIRED when continuum.enabled=true — set the canonical 4-segment label (e.g. hz-fsn-rtz-prod) matching the Continuum CRD region pattern (canonical label, e.g. hw-me-east-215-a-rtz-prod)" .Values.cnpgPair.continuum.primaryRegion -}}
 {{- $cstby := required "continuum.hotStandbyRegion is REQUIRED when continuum.enabled=true — set the canonical 4-segment label (e.g. hz-hel-rtz-prod)" .Values.cnpgPair.continuum.hotStandbyRegion -}}
 apiVersion: dr.openova.io/v1
 kind: Continuum

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2628,7 +2628,13 @@ name: bp-catalyst-platform
 # flip admin.dns.<sov> → pdns-admin.<sov> (single-level, wildcard-cert-covered,
 # matches the KC client redirectUris) + bp-powerdns-admin 0.1.5 OIDC env-var
 # name fixes. Refs #3150.
-version: 1.4.580
+version: 1.4.581
+# 1.4.581 — #3195 G6 (2026-06-12): crds/continuum.yaml primaryRegion/
+#   hotStandbyRegions pattern relaxed to ^[a-z][a-z0-9]*(-[a-z0-9]+){3,}$
+#   — the letters-only 4-segment pattern was Hetzner-era and
+#   unsatisfiable on kom4dc (me-east-215-*), which kept the production
+#   Continuum seed unfireable. Backwards-compatible (all-letter labels
+#   still match). Flux CreateReplace flows it to live Sovereigns.
 appVersion: 1.4.494
 # 1.4.239 — Wave 3 / Issue #2140 (2026-05-23): Huawei provider
 # implementation lands behind the Wave 2 CloudProvider interface.

--- a/products/catalyst/chart/crds/continuum.yaml
+++ b/products/catalyst/chart/crds/continuum.yaml
@@ -83,7 +83,7 @@ spec:
                 primaryRegion:
                   type: string
                   description: Currently-primary host cluster name. Switched on failover.
-                  pattern: '^[a-z]+-[a-z]+-[a-z]+-[a-z]+$'
+                  pattern: '^[a-z][a-z0-9]*(-[a-z0-9]+){3,}$'
                 hotStandbyRegions:
                   type: array
                   minItems: 1
@@ -91,7 +91,7 @@ spec:
                   description: Host clusters running standby replicas. Promoted on failover.
                   items:
                     type: string
-                    pattern: '^[a-z]+-[a-z]+-[a-z]+-[a-z]+$'
+                    pattern: '^[a-z][a-z0-9]*(-[a-z0-9]+){3,}$'
                 leaseClient:
                   type: object
                   required: [kind]


### PR DESCRIPTION
G6's whole remaining scope in one lockstep: the CRD's Hetzner-era letters-only pattern relaxed (backwards-compatible, invalid samples hold) + the slot's seed flipped with real labels. Single-region byte-identical (double-gated). Live verification on hw130 after the pins flow. Refs #3195 #2922

🤖 Generated with [Claude Code](https://claude.com/claude-code)