### PR TITLE
fix(ci): GUARD-2 requires-overlay mode — 86/86 charts certifiable

### DIFF
--- a/platform/anthropic-adapter/chart/Chart.yaml
+++ b/platform/anthropic-adapter/chart/Chart.yaml
@@ -42,8 +42,6 @@ dependencies:
     repository: "https://sigstore.github.io/helm-charts"
 
 annotations:
-  # #2935 (2026-06-03): Blueprint-Release hollow-chart guard exemption.
-  # Chart legitimately renders zero resources with default values
-  # (default-off feature toggle or dependency-on-CRD pattern). Without
-  # this annotation Blueprint-Release rejects publish.
-  catalyst.openova.io/smoke-render-mode: "default-off"
+  # GUARD-2 contract: defaults fail-fast on required overlay values
+  # (SHA-pin / Sovereign FQDN) BY DESIGN — see scripts/check-chart-annotations.sh
+  catalyst.openova.io/smoke-render-mode: "requires-overlay"

--- a/platform/knative/chart/Chart.yaml
+++ b/platform/knative/chart/Chart.yaml
@@ -34,3 +34,7 @@ dependencies:
   - name: knative-operator
     version: "v1.21.1"
     repository: "https://knative.github.io/operator"
+annotations:
+  # GUARD-2 contract: defaults fail-fast on required overlay values
+  # (SHA-pin / Sovereign FQDN) BY DESIGN — see scripts/check-chart-annotations.sh
+  catalyst.openova.io/smoke-render-mode: "requires-overlay"

--- a/platform/librechat/chart/Chart.yaml
+++ b/platform/librechat/chart/Chart.yaml
@@ -39,3 +39,7 @@ dependencies:
   - name: common
     version: "0.1.3"
     repository: "https://sigstore.github.io/helm-charts"
+annotations:
+  # GUARD-2 contract: defaults fail-fast on required overlay values
+  # (SHA-pin / Sovereign FQDN) BY DESIGN — see scripts/check-chart-annotations.sh
+  catalyst.openova.io/smoke-render-mode: "requires-overlay"

--- a/scripts/check-chart-annotations.sh
+++ b/scripts/check-chart-annotations.sh
@@ -244,6 +244,18 @@ EOF
   if ! helm template "smoke-${chart_name}" "$chart_dir" \
         --namespace "smoke-${chart_name}" \
         > "$render_out" 2> "$render_err"; then
+    # requires-overlay (2026-06-12): some Catalyst-authored charts FAIL
+    # default-values render BY DESIGN — Inviolable-Principle-4-style
+    # `required` guards demanding the per-cluster overlay supply a
+    # SHA-pinned tag / the Sovereign FQDN (bp-anthropic-adapter,
+    # bp-knative, bp-librechat today). That fail-fast is the feature;
+    # GUARD 2 must not flag it. The annotation makes the intent
+    # explicit and keeps accidental render-breaks fatal for everyone
+    # else. (The empty-render sibling mode is `default-off` below.)
+    if [ "$smoke_mode" = "requires-overlay" ] && grep -qiE 'execution error|required' "$render_err"; then
+      echo "  ✓ $rel_path — GUARD 2: default-render fail-fast + smoke-render-mode:requires-overlay → OK (overlay-required by design)"
+      continue
+    fi
     render_failed=$((render_failed + 1))
     cat >&2 <<EOF
 


### PR DESCRIPTION
Three by-design fail-fast charts were permanently uncertifiable (the default-off escape only covers empty renders); new annotation mode accepted only for required-value failures, stale duplicate-key annotation removed. Full sweep green. Refs #3268

🤖 Generated with [Claude Code](https://claude.com/claude-code)