### PR TITLE
fix(continuum): ErrQuorumUnavailable distinct from ErrLeaseHeldByAnother — no more phantom-holder logs

### DIFF
--- a/core/controllers/continuum/internal/controller/continuum_controller.go
+++ b/core/controllers/continuum/internal/controller/continuum_controller.go
@@ -296,7 +296,15 @@ func (r *ContinuumReconciler) runPerCR(ctx context.Context, nn types.NamespacedN
 				if errors.Is(err, witness.ErrLeaseHeldByAnother) {
 					_ = r.publishLeaseCollision(ctx, nn, spec, err)
 				}
-				log.Info("lease lost; new holder in charge", "err", err)
+				// #3195 (hw130): quorum-unreachable is NOT a competing
+				// holder — log it as the wiring problem it is, so the
+				// operator fixes resolvers instead of hunting a phantom
+				// primary. Same safety posture (no promote) either way.
+				if errors.Is(err, witness.ErrQuorumUnavailable) {
+					log.Info("witness read-quorum unavailable — check leaseClient resolvers/wiring", "err", err)
+				} else {
+					log.Info("lease lost; new holder in charge", "err", err)
+				}
 				_ = r.patchStatusFromCR(ctx, cr, spec, witness.State{}, cnpg.Status{}, cnpg.Status{}, false, "")
 				continue
 			}

--- a/core/controllers/continuum/internal/witness/dnsquorum/client.go
+++ b/core/controllers/continuum/internal/witness/dnsquorum/client.go
@@ -265,8 +265,11 @@ func (c *DNSQuorumClient) Acquire(ctx context.Context, holder string, ttl time.D
 	}
 	cur, ok := c.readQuorum(ctx)
 	if !ok {
-		// Read quorum failed — defensive: treat as held by another.
-		return cur, witness.ErrLeaseHeldByAnother
+		// Read quorum failed — same SAFETY posture as held-by-another
+		// (never promote blind), but the DISTINCT sentinel so the
+		// operator sees "fix the witness wiring" instead of hunting a
+		// phantom competing holder (#3195 hw130).
+		return cur, witness.ErrQuorumUnavailable
 	}
 	// Truncate to second precision — matches RFC3339 wire format
 	// granularity (the wire round-trip would truncate anyway, so

--- a/core/controllers/continuum/internal/witness/dnsquorum/client_test.go
+++ b/core/controllers/continuum/internal/witness/dnsquorum/client_test.go
@@ -213,8 +213,11 @@ func TestDNSQuorum_BelowQuorum_AcquireFails(t *testing.T) {
 	c, _ := New(servers, "k", "lease.openova.io", "ns/cr", be, be)
 
 	_, err := c.Acquire(context.Background(), "fsn", 30*time.Second)
-	if !errors.Is(err, witness.ErrLeaseHeldByAnother) {
-		t.Fatalf("Acquire below-quorum: err = %v want ErrLeaseHeldByAnother (defensive)", err)
+	// #3195: below-quorum is the DISTINCT ErrQuorumUnavailable now —
+	// same no-promote safety, honest operator signal (was misreported
+	// as held-by-another, live on hw130).
+	if !errors.Is(err, witness.ErrQuorumUnavailable) {
+		t.Fatalf("Acquire below-quorum: err = %v want ErrQuorumUnavailable (defensive, distinct)", err)
 	}
 }
 
@@ -233,8 +236,8 @@ func TestDNSQuorum_SplitBrain_1_1_1_TreatedAsHeldByAnother(t *testing.T) {
 	be.setRaw("ns3", fqdn, fmt.Sprintf("ash|%s|5", time.Now().Add(time.Minute).UTC().Format(time.RFC3339)))
 
 	_, err := c.Acquire(context.Background(), "iad", 30*time.Second)
-	if !errors.Is(err, witness.ErrLeaseHeldByAnother) {
-		t.Fatalf("split-brain Acquire: err = %v want ErrLeaseHeldByAnother", err)
+	if !errors.Is(err, witness.ErrQuorumUnavailable) {
+		t.Fatalf("split-brain Acquire: err = %v want ErrQuorumUnavailable (1/1/1 disagreement = no readable quorum, distinct from a real holder)", err)
 	}
 }
 

--- a/core/controllers/continuum/internal/witness/witness.go
+++ b/core/controllers/continuum/internal/witness/witness.go
@@ -39,6 +39,19 @@ import (
 // NOT promote: another region is primary.
 var ErrLeaseHeldByAnother = errors.New("witness: lease held by another holder")
 
+// ErrQuorumUnavailable — Acquire could not reach a read quorum of the
+// witness backends at all (resolvers unreachable / misconfigured / a
+// majority down). Operationally DISTINCT from ErrLeaseHeldByAnother:
+// the safety behavior is the same (do NOT promote), but the operator
+// remediation is opposite — fix the witness wiring, don't look for a
+// competing holder. Born on hw130 (2026-06-12, #3195): placeholder
+// resolver IPs made the controller log "lease held by another holder"
+// every 10s with NO holder in existence, costing a forensic detour.
+// Callers MUST treat this like ErrLeaseHeldByAnother for promotion
+// decisions; errors.Is(err, ErrLeaseHeldByAnother) deliberately does
+// NOT match it so logs and conditions can tell the truth.
+var ErrQuorumUnavailable = errors.New("witness: read quorum unavailable (backends unreachable or misconfigured)")
+
 // ErrLeaseLost — Renew detected the witness no longer recognises this
 // holder. The lease has expired (TTL exceeded) or another holder
 // completed a CAS while we were not looking. The caller MUST treat


### PR DESCRIPTION
hw130's first production reconcile exposed the misclassification live: unreachable witness backends logged as 'lease held by another holder' with no holder in existence. Distinct sentinel, same no-promote safety, honest logs; tests updated. The quorum-topology design item stays open on #3195. Refs #3195

🤖 Generated with [Claude Code](https://claude.com/claude-code)