### PR TITLE
feat(sso): zero-click from app root URLs — grafana auto_login + harbor primary_auth_mode

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -188,7 +188,9 @@ spec:
       # pulled via harbor.openova.io/proxy-dockerhub (bare refs denied by
       # harbor-proxy-pull on any roll — wedged live hw128 on the 1.2.28
       # upgrade, harbor-registry ReplicaSet FailedCreate).
-      version: 1.2.29
+      # 1.2.30 (2026-06-12, founder): primary_auth_mode=true — hitting
+      # registry.<fqdn>/ auto-initiates OIDC instead of showing the form.
+      version: 1.2.30
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -66,7 +66,9 @@ spec:
   chart:
     spec:
       chart: bp-grafana
-      version: 1.0.8
+      # 1.0.9 (2026-06-12, founder): zero-click from the app ROOT —
+      # oauth_auto_login + generic_oauth.auto_login flipped true.
+      version: 1.0.9
       sourceRef:
         kind: HelmRepository
         name: bp-grafana

--- a/platform/grafana/blueprint.yaml
+++ b/platform/grafana/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.0.8
+  version: 1.0.9
   card:
     title: Grafana
     family: insights

--- a/platform/grafana/chart/Chart.yaml
+++ b/platform/grafana/chart/Chart.yaml
@@ -40,7 +40,7 @@ type: application
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.0.8
+version: 1.0.9
 appVersion: "12.3.1"
 # 1.0.4 (G91.grafana #2658, 2026-05-31): opt in to the bp-sso-bridge
 # (G91.1 #2652) SSO framework. Top-level `sso:` block (defaults

--- a/platform/grafana/chart/values.yaml
+++ b/platform/grafana/chart/values.yaml
@@ -165,13 +165,18 @@ grafana:
       root_url: "https://%(domain)s/"
     auth:
       disable_login_form: false
-      oauth_auto_login: false
+      # Zero-click from the app ROOT URL (founder mandate, 2026-06-12):
+      # hitting grafana.<fqdn>/ must land signed-in via the sovereign
+      # realm — no grafana login form, no button. The login form stays
+      # enabled underneath (disable_login_form false) so admin/break-
+      # glass login at /login?disableAutoLogin remains possible.
+      oauth_auto_login: true
     "auth.generic_oauth":
       enabled: true
       name: "OpenOva SSO"
       icon: signin
       allow_sign_up: true
-      auto_login: false
+      auto_login: true
       client_id: "${GF_AUTH_GENERIC_OAUTH_CLIENT_ID}"
       client_secret: "${GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET}"
       scopes: "openid profile email groups"

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.29
+  version: 1.2.30
   card:
     title: Harbor
     family: foundation

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -73,7 +73,7 @@ type: application
 # `harbor-database-secret` (key `password`) + its host flips via the
 # SOVEREIGN_HARBOR_PG_HOST slot seam, so no other consumer change is
 # needed. own-cluster render byte-identical to 1.2.27.
-version: 1.2.29
+version: 1.2.30
 appVersion: "2.14.3"
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now

--- a/platform/harbor/chart/templates/sso-configure-oauth-job.yaml
+++ b/platform/harbor/chart/templates/sso-configure-oauth-job.yaml
@@ -217,6 +217,7 @@ spec:
               cat >/tmp/payload.json <<JSON
               {
                 "auth_mode": "oidc_auth",
+                "primary_auth_mode": true,
                 "oidc_name": "${OIDC_NAME}",
                 "oidc_endpoint": "${OIDC_ENDPOINT}",
                 "oidc_client_id": "${OIDC_CLIENT_ID}",


### PR DESCRIPTION
The app-root zero-click path was never built (auto_login:false since introduction) — every prior PASS was Launch-path only. Founder verified the gap live. Grafana+harbor flipped; gitea/pda/openbao lack upstream knobs (follow-up). Flows to hw130 on merge. Refs #3263

🤖 Generated with [Claude Code](https://claude.com/claude-code)