### PR TITLE
feat(sso): root-URL zero-click for gitea + pdns-admin (gateway OIDC auto-entry)

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -126,7 +126,9 @@ spec:
       # hook); gitea image pulled via harbor.openova.io/proxy-dockerhub
       # (bare gitea/gitea ref denied by harbor-proxy-pull on any roll —
       # wedged live hw128 on the 1.2.27 upgrade).
-      version: 1.2.28
+      # 1.2.29 (2026-06-12, founder): root-URL zero-click — REQUIRE_SIGNIN_VIEW
+      # + gateway /user/login -> OIDC entry redirect.
+      version: 1.2.29
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -111,7 +111,8 @@ spec:
       # propagates past the stale pre-0.1.7 artifact hw126 first admitted.
       # Adds the bp-gitea/bp-harbor Capabilities guard to the CNPG Cluster
       # template so a cold install can't half-render before bp-cnpg's CRD.
-      version: 0.1.8
+      # 0.1.9 (2026-06-12, founder): root-URL zero-click — /login -> /oidc/login.
+      version: 0.1.9
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns-admin

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.28
+  version: 1.2.29
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -108,7 +108,7 @@ name: bp-gitea
 # the bootstrap-kit slot 10 `SOVEREIGN_GITEA_PG_SECRET` seam (own-cluster
 # default gitea-pg-app → SHARED gitea-database-secret). own-cluster render
 # byte-identical to 1.2.26.
-version: 1.2.28
+version: 1.2.29
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/httproute.yaml
+++ b/platform/gitea/chart/templates/httproute.yaml
@@ -33,6 +33,23 @@ spec:
   hostnames:
     - {{ .Values.gateway.host | quote }}
   rules:
+    # ROOT-URL zero-click SSO (founder mandate 2026-06-12): gitea has no
+    # native auto-redirect knob, so the gateway sends the login page
+    # itself into the OIDC entry. Logged-in users never hit /user/login
+    # (no loop); git/API clients never hit it either (token/basic auth).
+    # Paired with service.REQUIRE_SIGNIN_VIEW=true (values) so anonymous
+    # hits to ANY page funnel: / -> /user/login -> OIDC -> signed in.
+    - matches:
+        - path:
+            type: Exact
+            value: /user/login
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /user/oauth2/openova-sso
+            statusCode: 302
     - matches:
         - path:
             type: PathPrefix

--- a/platform/gitea/chart/values.yaml
+++ b/platform/gitea/chart/values.yaml
@@ -73,6 +73,13 @@ gitea:
       # G91.gitea (#2653) — global OAuth2-client toggles. Per-provider
       # config (clientId/secret/autoDiscoverUrl) lives under `gitea.oauth`
       # below; these are the global app.ini knobs.
+      # ROOT-URL zero-click SSO (founder mandate 2026-06-12): anonymous
+      # hits to ANY page must funnel into OIDC instead of the public
+      # landing/explore pages. REQUIRE_SIGNIN_VIEW sends anonymous ->
+      # /user/login, which the HTTPRoute redirects -> the OIDC entry ->
+      # signed in. Git/Flux/API clients are unaffected (token auth).
+      service:
+        REQUIRE_SIGNIN_VIEW: true
       oauth2_client:
         ENABLE_AUTO_REGISTRATION: true
         # Use email + username from claims; never email-only (avoids

--- a/platform/powerdns-admin/blueprint.yaml
+++ b/platform/powerdns-admin/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 0.1.8
+  version: 0.1.9
   card:
     title: powerdns-admin
     summary: |

--- a/platform/powerdns-admin/chart/Chart.yaml
+++ b/platform/powerdns-admin/chart/Chart.yaml
@@ -72,7 +72,7 @@ name: bp-powerdns-admin
 # cold install can't half-render (apiserver rejecting the Cluster CR before
 # bp-cnpg registers the CRD) and wedge the chart BEFORE it reaches kyverno
 # admission at all.
-version: 0.1.8
+version: 0.1.9
 description: |
   PowerDNS-Admin (ngoduykhanh/powerdns-admin) web UI Blueprint for
   per-Sovereign PowerDNS zone + record management. Drives the

--- a/platform/powerdns-admin/chart/templates/httproute.yaml
+++ b/platform/powerdns-admin/chart/templates/httproute.yaml
@@ -24,6 +24,20 @@ spec:
   hostnames:
     - {{ .Values.gateway.host | quote }}
   rules:
+    # ROOT-URL zero-click SSO (founder mandate 2026-06-12): PDA has no
+    # auto-redirect setting; the gateway sends its login page straight
+    # into the OIDC leg. Logged-in users never hit /login (no loop).
+    - matches:
+        - path:
+            type: Exact
+            value: /login
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /oidc/login
+            statusCode: 302
     - matches:
         - path:
             type: PathPrefix


### PR DESCRIPTION
Completes the founder root-URL standard for the two apps without upstream knobs: gitea REQUIRE_SIGNIN_VIEW + /user/login→OIDC redirect; pda /login→/oidc/login. No loops (logged-in users never hit login paths); token clients unaffected. Refs #3263

🤖 Generated with [Claude Code](https://claude.com/claude-code)