### PR TITLE
fix(sso): explicit 443 on gitea/pda redirects — :30443 leak

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -128,7 +128,8 @@ spec:
       # wedged live hw128 on the 1.2.27 upgrade).
       # 1.2.29 (2026-06-12, founder): root-URL zero-click — REQUIRE_SIGNIN_VIEW
       # + gateway /user/login -> OIDC entry redirect.
-      version: 1.2.29
+      # 1.2.30: explicit port 443 on the SSO redirect (the #3310 class).
+      version: 1.2.30
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -112,7 +112,8 @@ spec:
       # Adds the bp-gitea/bp-harbor Capabilities guard to the CNPG Cluster
       # template so a cold install can't half-render before bp-cnpg's CRD.
       # 0.1.9 (2026-06-12, founder): root-URL zero-click — /login -> /oidc/login.
-      version: 0.1.9
+      # 0.1.10: explicit port 443 on the SSO redirect (the #3310 class).
+      version: 0.1.10
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns-admin

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.29
+  version: 1.2.30
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -108,7 +108,7 @@ name: bp-gitea
 # the bootstrap-kit slot 10 `SOVEREIGN_GITEA_PG_SECRET` seam (own-cluster
 # default gitea-pg-app → SHARED gitea-database-secret). own-cluster render
 # byte-identical to 1.2.26.
-version: 1.2.29
+version: 1.2.30
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/httproute.yaml
+++ b/platform/gitea/chart/templates/httproute.yaml
@@ -46,6 +46,11 @@ spec:
       filters:
         - type: RequestRedirect
           requestRedirect:
+            # Explicit 443 — Gateway API otherwise copies the cilium
+            # LISTENER port (30443) into Location, which nothing serves
+            # externally (the #3310 pdns lesson, repeated on first render
+            # and caught by the wire check).
+            port: 443
             path:
               type: ReplaceFullPath
               replaceFullPath: /user/oauth2/openova-sso

--- a/platform/powerdns-admin/blueprint.yaml
+++ b/platform/powerdns-admin/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 0.1.9
+  version: 0.1.10
   card:
     title: powerdns-admin
     summary: |

--- a/platform/powerdns-admin/chart/Chart.yaml
+++ b/platform/powerdns-admin/chart/Chart.yaml
@@ -72,7 +72,7 @@ name: bp-powerdns-admin
 # cold install can't half-render (apiserver rejecting the Cluster CR before
 # bp-cnpg registers the CRD) and wedge the chart BEFORE it reaches kyverno
 # admission at all.
-version: 0.1.9
+version: 0.1.10
 description: |
   PowerDNS-Admin (ngoduykhanh/powerdns-admin) web UI Blueprint for
   per-Sovereign PowerDNS zone + record management. Drives the

--- a/platform/powerdns-admin/chart/templates/httproute.yaml
+++ b/platform/powerdns-admin/chart/templates/httproute.yaml
@@ -34,6 +34,11 @@ spec:
       filters:
         - type: RequestRedirect
           requestRedirect:
+            # Explicit 443 — Gateway API otherwise copies the cilium
+            # LISTENER port (30443) into Location, which nothing serves
+            # externally (the #3310 pdns lesson, repeated on first render
+            # and caught by the wire check).
+            port: 443
             path:
               type: ReplaceFullPath
               replaceFullPath: /oidc/login


### PR DESCRIPTION
Wire check caught the listener-port leak — founder-DoD FAIL until pinned (the #3310 class). Refs #3263

🤖 Generated with [Claude Code](https://claude.com/claude-code)