### PR TITLE
fix(jobs): secondary-region job rows converge on timeout terminals (#3277)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -845,6 +845,17 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		// sweep, and the policy flip stay ready-only — this rescues
 		// the TOPOLOGY, not the lifecycle.
 		go h.runAutoEstablishClusterMesh(dep)
+		// #3277 (founder, 2026-06-12): the secondary-region job rows
+		// freeze at their last-seen state forever on a timeout record
+		// (witnessed live: 9 "running" rows on hw130 with every
+		// component long Ready) because the C10-003 backfill ran only
+		// on OutcomeReady. The informer-cache reseed is read-only and
+		// converges each install-<region>:<chart> row to the CLUSTER-
+		// CURRENT state — exactly as valid at a timeout terminal as at
+		// ready. INLINE for the same reason as the ready path: the
+		// deferred stopSecondaries clears the watcher map the moment
+		// markPhase1Done returns.
+		h.runSecondaryBridgeBackfill(dep)
 	}
 }
 


### PR DESCRIPTION
The frozen region-b 'running' rows the founder reported: the backfill ran only on OutcomeReady. Now runs on the timeout terminal too — rows converge to cluster-current state. Refs #3277

🤖 Generated with [Claude Code](https://claude.com/claude-code)