### PR TITLE
fix(sso): gitea LANDING_PAGE=login — root funnels anon into OIDC

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -129,7 +129,8 @@ spec:
       # 1.2.29 (2026-06-12, founder): root-URL zero-click — REQUIRE_SIGNIN_VIEW
       # + gateway /user/login -> OIDC entry redirect.
       # 1.2.30: explicit port 443 on the SSO redirect (the #3310 class).
-      version: 1.2.30
+      # 1.2.31: LANDING_PAGE=login — anon root funnels into OIDC.
+      version: 1.2.31
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.30
+  version: 1.2.31
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -108,7 +108,7 @@ name: bp-gitea
 # the bootstrap-kit slot 10 `SOVEREIGN_GITEA_PG_SECRET` seam (own-cluster
 # default gitea-pg-app → SHARED gitea-database-secret). own-cluster render
 # byte-identical to 1.2.26.
-version: 1.2.30
+version: 1.2.31
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/values.yaml
+++ b/platform/gitea/chart/values.yaml
@@ -80,6 +80,13 @@ gitea:
       # signed in. Git/Flux/API clients are unaffected (token auth).
       service:
         REQUIRE_SIGNIN_VIEW: true
+      # LANDING_PAGE=login: gitea EXEMPTS its home page from
+      # REQUIRE_SIGNIN_VIEW (verified in-pod: anon / = 200), so anonymous
+      # visitors must be steered to /user/login (-> the gateway OIDC
+      # redirect -> signed in). Signed-in users at / get their dashboard
+      # (session checked first) — no loop.
+      server:
+        LANDING_PAGE: login
       oauth2_client:
         ENABLE_AUTO_REGISTRATION: true
         # Use email + username from claims; never email-only (avoids


### PR DESCRIPTION
gitea exempts its home page from REQUIRE_SIGNIN_VIEW (in-pod verified); LANDING_PAGE=login closes the founder root-URL standard. Refs #3263

🤖 Generated with [Claude Code](https://claude.com/claude-code)