### PR TITLE
feat(catalyst-api): many-to-many Data-instances cards — one card per live CNPG Cluster with consumer bindings

### DIFF
--- a/docs/api/catalyst-api-openapi.yaml
+++ b/docs/api/catalyst-api-openapi.yaml
@@ -504,6 +504,23 @@ components:
         topology:  { $ref: '#/components/schemas/BcpTopology' }
         status:    { type: string, enum: [Pending, Reconciling, Ready, Degraded, Failed, Uninstalling] }
         createdAt: { type: string, format: date-time }
+        bindings:
+          type: array
+          description: |
+            Consumer bindings on a data-instance row (#3188 many-to-many
+            cards). Present only on postgres-engine-family instance rows
+            derived from live CNPG Cluster/Database CRs; omitted elsewhere.
+          items: { $ref: '#/components/schemas/InstanceBinding' }
+    InstanceBinding:
+      type: object
+      description: One consumer's binding to a data-instance (one Consumers-table row).
+      required: [database, role, mode, secret, consumer]
+      properties:
+        database: { type: string, description: Isolated database name on the instance }
+        role:     { type: string, description: Per-consumer login role (CNPG-managed owner) }
+        mode:     { type: string, enum: [shared, dedicated], description: shared = Database CR on a shared instance; dedicated = the instance's own app database }
+        secret:   { type: string, description: Reflected connection Secret name; empty when unknown }
+        consumer: { type: string, description: Consuming app/namespace; empty when not derivable }
     Application:
       allOf:
         - $ref: '#/components/schemas/ApplicationSummary'

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
@@ -125,6 +125,24 @@ type applicationSummary struct {
 	Topology  string `json:"topology"`
 	Status    string `json:"status"`
 	CreatedAt string `json:"createdAt,omitempty"`
+	// Bindings — #3188 many-to-many data-instance cards: the consumers
+	// bound to this instance (one row per database · role · mode ·
+	// secret · consumer). Populated only on the postgres-engine-family
+	// rows derived from live CNPG Cluster/Database CRs; omitted
+	// everywhere else so the UI keeps its honest empty state.
+	Bindings []instanceBinding `json:"bindings,omitempty"`
+}
+
+// instanceBinding is one consumer's binding to a data-instance — the
+// row the Data-instances panel's Consumers table renders. Field names
+// follow the Catalyst wire convention (lowercase camelCase json tags,
+// memory feedback_ts_field_casing_vs_go_json_tag).
+type instanceBinding struct {
+	Database string `json:"database"`
+	Role     string `json:"role"`
+	Mode     string `json:"mode"`
+	Secret   string `json:"secret"`
+	Consumer string `json:"consumer"`
 }
 
 // application mirrors `schema/Application` (Summary plus per-cluster
@@ -831,6 +849,26 @@ func (h *Handler) HandleListBlueprintInstances(w http.ResponseWriter, r *http.Re
 		})
 	}
 
+	// #3188 many-to-many cards: for the postgres engine family the live
+	// CNPG Cluster CRs are the per-instance ground truth — ONE card per
+	// running Postgres instance with its consumer bindings, not just
+	// the shared engine. On hw130 the HR projection below showed "1
+	// instance" (bp-postgres-shared) while 7 CNPG Clusters ran live
+	// (openova-flow-pg, newapi-pg, pdns-pg, pda-pg, shared-pg, sme-pg,
+	// cnpg-pair-primary). Enumerate the Clusters directly; each one is
+	// an instance row carrying its bindings (Database CRs → shared
+	// rows, none → one implicit dedicated row).
+	cnpgAuthoritative := false
+	if bp == "cnpg" || bp == "postgres" {
+		cnpgRows := h.cnpgClusterInstances(r.Context(), client, bp, orgFilter, out)
+		// When live Cluster CRs exist they supersede the engine-HR
+		// projection: the HR (bp-postgres-shared) is only the INSTALLER
+		// of the shared-pg Cluster, so projecting both would render one
+		// physical instance as two cards.
+		cnpgAuthoritative = len(cnpgRows) > 0
+		out = append(out, cnpgRows...)
+	}
+
 	// #3188 (hw129/hw130 round-1): bootstrap-kit installs of this
 	// blueprint ship as Flux HelmReleases with NO companion Application
 	// CR — the platform shared-PG engine (HR bp-postgres-shared, chart
@@ -840,8 +878,10 @@ func (h *Handler) HandleListBlueprintInstances(w http.ResponseWriter, r *http.Re
 	// consumers (gitea 110 tables + registry 49). Project those HRs as
 	// instance rows too — same fallback philosophy as the silent-SSO
 	// launch-url HR path above. Org-scoped filtering: bootstrap HRs are
-	// platform-owned, so any explicit ?org= filter excludes them.
-	if orgFilter == "" {
+	// platform-owned, so any explicit ?org= filter excludes them. When
+	// the CNPG Cluster enumeration above already produced rows, the HR
+	// path is skipped (it would double-count the shared engine).
+	if orgFilter == "" && !cnpgAuthoritative {
 		out = append(out, h.bootstrapHRInstances(r.Context(), client, bp, out)...)
 	}
 	writeJSON(w, http.StatusOK, listInstancesResponse{Items: out})
@@ -901,6 +941,134 @@ func (h *Handler) bootstrapHRInstances(ctx context.Context, client dynamic.Inter
 		})
 	}
 	return rows
+}
+
+// cnpgClusterGVR / cnpgDatabaseGVR — the CloudNativePG CRs the #3188
+// many-to-many Data-instances cards read. Declared locally like
+// helmReleaseGVR in sovereign.go.
+var cnpgClusterGVR = schema.GroupVersionResource{
+	Group:    "postgresql.cnpg.io",
+	Version:  "v1",
+	Resource: "clusters",
+}
+
+var cnpgDatabaseGVR = schema.GroupVersionResource{
+	Group:    "postgresql.cnpg.io",
+	Version:  "v1",
+	Resource: "databases",
+}
+
+// cnpgClusterInstances projects every live postgresql.cnpg.io/v1
+// Cluster CR into one instance row (#3188 many-to-many cards): name =
+// CR name, org = namespace, status from `.status.phase`, topology from
+// `.spec.replica.enabled` / `.spec.instances`, plus the consumer
+// bindings. A name already covered by an Application-CR row is not
+// duplicated — instead that existing row receives the bindings.
+// Best-effort: on a cluster without the CNPG CRD the List fails and
+// the Application-CR + HR rows stay authoritative.
+func (h *Handler) cnpgClusterInstances(ctx context.Context, client dynamic.Interface, bp, orgFilter string, existing []applicationSummary) []applicationSummary {
+	clusters, err := client.Resource(cnpgClusterGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil
+	}
+	bindingsByCluster := h.cnpgDatabaseBindings(ctx, client)
+	existingIdx := map[string]int{}
+	for i := range existing {
+		existingIdx[strings.ToLower(existing[i].Name)] = i
+	}
+	rows := []applicationSummary{}
+	for i := range clusters.Items {
+		cl := &clusters.Items[i]
+		ns := cl.GetNamespace()
+		if orgFilter != "" && !strings.EqualFold(ns, orgFilter) {
+			continue
+		}
+		bindings := bindingsByCluster[ns+"/"+cl.GetName()]
+		if len(bindings) == 0 {
+			// Per-app instance with no Database CRs: the Cluster's
+			// CNPG-bootstrapped `app` database serves exactly its own
+			// namespace — surface that as ONE implicit dedicated
+			// binding rather than an empty Consumers table.
+			bindings = []instanceBinding{{
+				Database: "app",
+				Role:     "app",
+				Mode:     "dedicated",
+				Consumer: ns,
+			}}
+		}
+		if idx, dup := existingIdx[strings.ToLower(cl.GetName())]; dup {
+			// An Application CR already covers this instance — keep
+			// that row authoritative, attach the live bindings to it.
+			if len(existing[idx].Bindings) == 0 {
+				existing[idx].Bindings = bindings
+			}
+			continue
+		}
+		status, _, _ := unstructured.NestedString(cl.Object, "status", "phase")
+		if status == "Cluster in healthy state" {
+			status = "Ready"
+		}
+		topology := "singleton"
+		if replicaEnabled, _, _ := unstructured.NestedBool(cl.Object, "spec", "replica", "enabled"); replicaEnabled {
+			topology = "replica"
+		} else if n, _, _ := unstructured.NestedInt64(cl.Object, "spec", "instances"); n > 1 {
+			topology = "ha"
+		}
+		rows = append(rows, applicationSummary{
+			ID:        string(cl.GetUID()),
+			Name:      cl.GetName(),
+			Blueprint: bp,
+			Org:       ns,
+			Topology:  topology,
+			Status:    status,
+			CreatedAt: cl.GetCreationTimestamp().UTC().Format(time.RFC3339),
+			Bindings:  bindings,
+		})
+	}
+	return rows
+}
+
+// cnpgDatabaseBindings lists every postgresql.cnpg.io/v1 Database CR
+// and groups them by owning Cluster (`<namespace>/<spec.cluster.name>`).
+// Each Database CR is one shared binding: database = .spec.name, role =
+// .spec.owner. The consumer is best-effort from the Database CR naming
+// convention `<cluster>-<consumer>` (shared-pg-gitea on cluster
+// shared-pg → gitea); when known, the reflected connection Secret
+// follows the `<consumer>-database-secret` convention.
+func (h *Handler) cnpgDatabaseBindings(ctx context.Context, client dynamic.Interface) map[string][]instanceBinding {
+	out := map[string][]instanceBinding{}
+	dbs, err := client.Resource(cnpgDatabaseGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		// Best-effort: a missing Database CRD only means no shared
+		// bindings to surface; the Cluster rows still render.
+		return out
+	}
+	for i := range dbs.Items {
+		db := &dbs.Items[i]
+		clusterName, _, _ := unstructured.NestedString(db.Object, "spec", "cluster", "name")
+		if clusterName == "" {
+			continue
+		}
+		dbName, _, _ := unstructured.NestedString(db.Object, "spec", "name")
+		owner, _, _ := unstructured.NestedString(db.Object, "spec", "owner")
+		consumer := ""
+		if rest := strings.TrimPrefix(db.GetName(), clusterName+"-"); rest != db.GetName() && rest != "" {
+			consumer = rest
+		}
+		secret := ""
+		if consumer != "" {
+			secret = consumer + "-database-secret"
+		}
+		key := db.GetNamespace() + "/" + clusterName
+		out[key] = append(out[key], instanceBinding{
+			Database: dbName,
+			Role:     owner,
+			Mode:     "shared",
+			Secret:   secret,
+			Consumer: consumer,
+		})
+	}
+	return out
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler_test.go
@@ -66,6 +66,10 @@ func fakeEndpointDynamic(seed ...runtime.Object) (func() (dynamic.Interface, err
 		// #3188: HandleListBlueprintInstances also projects bootstrap
 		// HelmReleases (no-org path) — the fake must know the list kind.
 		helmReleaseGVR: "HelmReleaseList",
+		// #3188 many-to-many cards: the postgres-family instances path
+		// also lists live CNPG Cluster + Database CRs.
+		cnpgClusterGVR:  "ClusterList",
+		cnpgDatabaseGVR: "DatabaseList",
 	}
 	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, seed...)
 	return func() (dynamic.Interface, error) {
@@ -701,6 +705,154 @@ func TestListBlueprintInstances_FilterByOrg(t *testing.T) {
 	}
 	if resp.Items[0].Name != "wp1" {
 		t.Fatalf("expected wp1, got %s", resp.Items[0].Name)
+	}
+}
+
+// seedCNPGCluster builds a postgresql.cnpg.io/v1 Cluster CR for the
+// #3188 many-to-many Data-instances tests.
+func seedCNPGCluster(uid, name, ns string, instances int64, phase string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "postgresql.cnpg.io/v1",
+		"kind":       "Cluster",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": ns,
+			"uid":       uid,
+		},
+		"spec":   map[string]interface{}{"instances": instances},
+		"status": map[string]interface{}{"phase": phase},
+	}}
+}
+
+// seedCNPGDatabase builds a postgresql.cnpg.io/v1 Database CR bound to
+// `cluster` declaring database `dbName` owned by `owner`.
+func seedCNPGDatabase(name, ns, cluster, dbName, owner string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "postgresql.cnpg.io/v1",
+		"kind":       "Database",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": ns,
+			"uid":       "uid-db-" + name,
+		},
+		"spec": map[string]interface{}{
+			"cluster": map[string]interface{}{"name": cluster},
+			"name":    dbName,
+			"owner":   owner,
+		},
+	}}
+}
+
+// seedEngineHR builds the bootstrap-kit shared-PG engine HelmRelease
+// (HR bp-postgres-shared, chart bp-postgres) — the row the pre-#3188
+// projection rendered as the ONLY instance.
+func seedEngineHR() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "helm.toolkit.fluxcd.io/v2",
+		"kind":       "HelmRelease",
+		"metadata": map[string]interface{}{
+			"name":      "bp-postgres-shared",
+			"namespace": "flux-system",
+			"uid":       "uid-hr-postgres-shared",
+		},
+		"spec": map[string]interface{}{
+			"chart": map[string]interface{}{"spec": map[string]interface{}{"chart": "bp-postgres"}},
+		},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "True"},
+			},
+		},
+	}}
+}
+
+// TestListBlueprintInstances_CNPGClustersWithBindings locks the #3188
+// many-to-many Data-instances shape: every live CNPG Cluster CR is one
+// instance row with its consumer bindings — a shared instance carries
+// the Database-CR rows (mode=shared), a bare per-app instance carries
+// ONE implicit dedicated binding. The engine HR (bp-postgres-shared)
+// must NOT add a duplicate card when Cluster rows exist (hw130 walked
+// "1 instance" while 7 Clusters ran live).
+func TestListBlueprintInstances_CNPGClustersWithBindings(t *testing.T) {
+	shared := seedCNPGCluster("uid-pg-shared", "shared-pg", "shared-data", 2, "Cluster in healthy state")
+	perApp := seedCNPGCluster("uid-pg-pdns", "pdns-pg", "powerdns", 1, "Setting up primary")
+	giteaDB := seedCNPGDatabase("shared-pg-gitea", "shared-data", "shared-pg", "gitea", "gitea")
+	h, _, _ := newTestHandlerWithEndpoint(t, shared, perApp, giteaDB, seedEngineHR())
+	h.SetCatalogClient(newFakeCatalog())
+	r := newTestRouter(h)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("GET", "/catalyst/v1/catalog/postgres/instances", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	var resp listInstancesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("expected 2 instance rows (one per Cluster CR; engine HR superseded), got %d: %+v", len(resp.Items), resp.Items)
+	}
+	byName := map[string]applicationSummary{}
+	for _, it := range resp.Items {
+		byName[it.Name] = it
+	}
+
+	sp, ok := byName["shared-pg"]
+	if !ok {
+		t.Fatalf("shared-pg row missing: %+v", resp.Items)
+	}
+	if sp.ID != "uid-pg-shared" || sp.Org != "shared-data" || sp.Status != "Ready" || sp.Topology != "ha" {
+		t.Fatalf("shared-pg row = %+v, want id=uid-pg-shared org=shared-data status=Ready topology=ha", sp)
+	}
+	if len(sp.Bindings) != 1 {
+		t.Fatalf("shared-pg bindings = %+v, want exactly the gitea Database-CR row", sp.Bindings)
+	}
+	want := instanceBinding{Database: "gitea", Role: "gitea", Mode: "shared", Secret: "gitea-database-secret", Consumer: "gitea"}
+	if sp.Bindings[0] != want {
+		t.Fatalf("shared-pg binding = %+v, want %+v", sp.Bindings[0], want)
+	}
+
+	pp, ok := byName["pdns-pg"]
+	if !ok {
+		t.Fatalf("pdns-pg row missing: %+v", resp.Items)
+	}
+	if pp.ID != "uid-pg-pdns" || pp.Org != "powerdns" || pp.Status != "Setting up primary" || pp.Topology != "singleton" {
+		t.Fatalf("pdns-pg row = %+v, want id=uid-pg-pdns org=powerdns status verbatim topology=singleton", pp)
+	}
+	if len(pp.Bindings) != 1 {
+		t.Fatalf("pdns-pg bindings = %+v, want ONE implicit dedicated row", pp.Bindings)
+	}
+	wantImplicit := instanceBinding{Database: "app", Role: "app", Mode: "dedicated", Secret: "", Consumer: "powerdns"}
+	if pp.Bindings[0] != wantImplicit {
+		t.Fatalf("pdns-pg binding = %+v, want %+v", pp.Bindings[0], wantImplicit)
+	}
+}
+
+// TestListBlueprintInstances_NoCNPGClusters_HRFallback keeps the
+// pre-existing engine-HR projection alive on an env with NO live CNPG
+// Cluster CRs (e.g. the CRD installed but nothing provisioned yet) —
+// the shared-engine card must still render rather than dropping to
+// zero instances.
+func TestListBlueprintInstances_NoCNPGClusters_HRFallback(t *testing.T) {
+	h, _, _ := newTestHandlerWithEndpoint(t, seedEngineHR())
+	h.SetCatalogClient(newFakeCatalog())
+	r := newTestRouter(h)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("GET", "/catalyst/v1/catalog/postgres/instances", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	var resp listInstancesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 1 || resp.Items[0].Name != "postgres-shared" {
+		t.Fatalf("expected the single engine-HR row, got %+v", resp.Items)
+	}
+	if len(resp.Items[0].Bindings) != 0 {
+		t.Fatalf("HR-projected row must carry no fabricated bindings, got %+v", resp.Items[0].Bindings)
 	}
 }
 

--- a/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
@@ -734,6 +734,30 @@ export interface ApplicationInstanceSummary {
   topology: string
   status: string
   createdAt?: string
+  /**
+   * Mirrors Go `Bindings []instanceBinding` (`bindings,omitempty`) —
+   * present only on postgres-engine-family rows derived from live CNPG
+   * Cluster + Database CRs (#3188 many-to-many Data-instances cards),
+   * absent on every other instance row.
+   */
+  bindings?: ApplicationInstanceBinding[]
+}
+
+/**
+ * Mirrors the Go `instanceBinding` (endpoint_handler.go) VERBATIM —
+ * lowercase camelCase per the `json:` tags (memory
+ * feedback_ts_field_casing_vs_go_json_tag). One consumer's binding row
+ * on a data-instance card: database · role · mode · secret · consumer.
+ */
+export interface ApplicationInstanceBinding {
+  database: string
+  role: string
+  /** "shared" (Database CR on a shared instance) or "dedicated" (the instance's own app database). */
+  mode: string
+  /** Reflected connection Secret name; empty when not derivable. */
+  secret: string
+  /** Consuming app/namespace; empty when not derivable. */
+  consumer: string
 }
 
 /** Mirrors `application` at endpoint_handler.go:130 (Summary + perCluster). */

--- a/products/catalyst/bootstrap/ui/src/lib/dataInstances.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/dataInstances.ts
@@ -10,10 +10,10 @@
  * SAME view in catalyst-ui (served at console.<fqdn>), where the founder
  * actually looks (#3188 row-3/4 walk complaint).
  *
- * The model (ADR-0010): a `bp-postgres` install = one CNPG Cluster = one
- * DATA-INSTANCE. The single PostgreSQL ENGINE CLASS (the `bp-cnpg`
- * operator) is shown ONCE; each data-instance is a first-class card.
- * Consumers SHARE an instance via isolated databases + per-consumer roles.
+ * The model (ADR-0010): ONE live CNPG Cluster = one DATA-INSTANCE. The
+ * single PostgreSQL ENGINE CLASS (the `bp-cnpg` operator) is shown ONCE;
+ * each data-instance is a first-class card. Consumers SHARE an instance
+ * via isolated databases + per-consumer roles (many-to-many).
  *
  * FEEDING ENDPOINT (verified, reused — NOT invented):
  *
@@ -23,46 +23,50 @@
  * registered at cmd/api/main.go without the /api/ prefix). Its row type
  * `ApplicationInstanceSummary` mirrors the Go `applicationSummary`
  * (endpoint_handler.go:119) VERBATIM — fields `id`, `name`, `blueprint`,
- * `org`, `topology`, `status`, `createdAt` (all lowercase camelCase per the
- * Go `json:` tags). This is the source of the engine-class card's instance
- * count and the per-instance cards.
+ * `org`, `topology`, `status`, `createdAt`, `bindings` (all lowercase
+ * camelCase per the Go `json:` tags). For the postgres engine family the
+ * endpoint enumerates the live `postgresql.cnpg.io/v1` Cluster CRs — one
+ * row per running instance — so the engine-class count and the per-instance
+ * cards reflect EVERY live Postgres, not just the shared engine install.
  *
- * HONEST GAP (do not fabricate): NO catalyst-api endpoint exposes the
- * per-consumer BINDING rows (database · role · mode · secret). Those live
- * only in each bp-postgres install HR's chart `values.databases[]`, which
- * no API surfaces today. So a data-instance's `bindings` is empty here and
- * the Consumers table renders the honest "bindings not yet surfaced by the
- * API" state — never a fabricated row. When the model is gated off (the
- * default on a stock prov, `SOVEREIGN_ENABLE_SHARED_PG=false`) the
- * instances list is empty and the panel renders "No PostgreSQL data
- * instances yet." Surfacing live bindings is a backend endpoint first
- * (a different PR) — see #3188.
+ * BINDINGS (#3188 many-to-many, now surfaced SERVER-SIDE): each row's
+ * `bindings[]` carries the consumer rows (database · role · mode ·
+ * secret · consumer) derived from the CNPG Database CRs (mode=shared) or
+ * the instance's own app database (mode=dedicated). When a row carries no
+ * `bindings` (older API, non-postgres blueprints) the Consumers table
+ * still renders the honest "not surfaced" state — never a fabricated row.
+ * When the instances list is empty the panel renders "No PostgreSQL data
+ * instances yet."
  */
 
 import type { ApplicationInstanceSummary } from '@/lib/catalog.api'
 
 /** One consumer's binding to a data-instance (one row in the table). */
 export interface Binding {
-  /** Consumer Blueprint / app id, e.g. "bp-harbor". */
+  /** Consumer app/namespace, e.g. "gitea". Empty when not derivable. */
   consumer: string
-  /** Isolated database name on the shared Cluster, e.g. "registry". */
+  /** Isolated database name on the Cluster, e.g. "registry". */
   database: string
   /** Per-consumer login role (CNPG-managed), e.g. "harbor". */
   role: string
-  /** Binding provenance — private (dedicated) or shared. */
-  mode: 'private' | 'shared'
+  /**
+   * Binding provenance — `shared` (Database CR on a shared instance),
+   * `dedicated` (the per-app instance's own app database), or `private`
+   * (legacy display fallback for unknown modes).
+   */
+  mode: 'shared' | 'dedicated' | 'private'
   /** Connection Secret reflected into the consumer namespace. */
   secret: string
 }
 
-/** A data-instance = one CNPG Cluster (one bp-postgres App card). */
+/** A data-instance = one CNPG Cluster (one card). */
 export interface DataInstance {
-  /** Instance name = Cluster name = App-card title, e.g. "shared-pg". */
+  /** Instance name = Cluster name = card title, e.g. "shared-pg". */
   name: string
   /** Engine class id (always bp-postgres here). */
   blueprint: string
   /** BCP topology of the instance (inherited by every consumer). */
-  topology: 'singleton' | 'active-hot-standby'
+  topology: 'singleton' | 'ha' | 'replica' | 'active-hot-standby'
   /** Live status of the instance (Ready/Failed/Provisioning/…). */
   status: string
   /** The consumers sharing this instance. */
@@ -103,13 +107,26 @@ export function isShared(instance: DataInstance): boolean {
 }
 
 /**
- * normalizeTopology maps any topology string to the two display states.
- * The instances endpoint returns the per-install topology string; only
- * `active-hot-standby` is the multi-region HA shape, everything else
- * (singleton / single-region / empty) renders as `singleton`.
+ * normalizeTopology maps the wire topology string to the display states.
+ * The instances endpoint emits `singleton`, `ha` (instances>1), `replica`
+ * (spec.replica.enabled — the hot-standby secondary), or the per-install
+ * `active-hot-standby`; anything else renders as `singleton`.
  */
 function normalizeTopology(topology: string | undefined): DataInstance['topology'] {
-  return topology === 'active-hot-standby' ? 'active-hot-standby' : 'singleton'
+  return topology === 'active-hot-standby' ||
+    topology === 'ha' ||
+    topology === 'replica'
+    ? topology
+    : 'singleton'
+}
+
+/**
+ * normalizeMode keeps the wire `mode` verbatim for the two values the API
+ * emits (`shared` / `dedicated`); anything unexpected renders with the
+ * neutral legacy `private` styling rather than an unstyled class.
+ */
+function normalizeMode(mode: string | undefined): Binding['mode'] {
+  return mode === 'shared' || mode === 'dedicated' ? mode : 'private'
 }
 
 /**
@@ -117,14 +134,16 @@ function normalizeTopology(topology: string | undefined): DataInstance['topology
  * the LIVE `GET /catalyst/v1/catalog/{blueprint}/instances` response rows
  * (the same `ApplicationInstanceSummary[]` the InstancesSection consumes).
  *
- * Each bp-postgres install = one data-instance card. The summary carries
- * NO binding data (the API doesn't expose the per-consumer database/role/
- * secret rows — see the module header), so `bindings` is always empty here;
- * the Consumers table renders the honest "not yet surfaced" state rather
- * than fabricating rows. The ENGINE CLASS card's count is `len(instances)`.
+ * Each row = one data-instance card. Rows from the postgres-family path
+ * carry `bindings[]` (surfaced server-side from CNPG Database CRs / the
+ * implicit per-app binding — see the module header); rows without it keep
+ * `bindings` empty so the Consumers table renders the honest "not
+ * surfaced" state rather than fabricating rows. The ENGINE CLASS card's
+ * count is `len(instances)`.
  *
  * CRITICAL (memory feedback_ts_field_casing_vs_go_json_tag): every field
- * read here (`name`, `topology`, `status`) matches the Go `json:` tag
+ * read here (`name`, `topology`, `status`, `bindings` + its `database` /
+ * `role` / `mode` / `secret` / `consumer`) matches the Go `json:` tag
  * VERBATIM. `res.json()` returns wire keys exactly — a casing mismatch
  * silently yields undefined (documented prior outage).
  */
@@ -137,7 +156,15 @@ export function fromInstanceSummaries(
       blueprint: 'bp-postgres',
       topology: normalizeTopology(r.topology),
       status: r.status ?? '',
-      bindings: [] as Binding[],
+      bindings: (r.bindings ?? []).map(
+        (b): Binding => ({
+          consumer: b.consumer,
+          database: b.database,
+          role: b.role,
+          mode: normalizeMode(b.mode),
+          secret: b.secret,
+        }),
+      ),
     }))
     .sort((a, b) => a.name.localeCompare(b.name))
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/DataInstances.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/DataInstances.test.tsx
@@ -113,13 +113,61 @@ describe('DataInstances — #3188 ADR-0010 panel (catalyst-ui)', () => {
     expect(text).toContain('Ready')
   })
 
-  it('renders the honest "bindings not yet surfaced" state per instance (never fabricates rows)', async () => {
+  it('renders the honest "bindings not surfaced" state per bindings-less instance (never fabricates rows)', async () => {
     renderPanel()
     const empties = await screen.findAllByTestId('data-instance-no-bindings')
     expect(empties.length).toBe(2)
     // No consumers table is fabricated when the API exposes no binding rows.
     expect(screen.queryByTestId('consumers-table')).toBeNull()
     expect(screen.queryByTestId('binding-row')).toBeNull()
+  })
+
+  it('renders the Consumers table from the wire `bindings[]` rows (#3188 many-to-many)', async () => {
+    // Wire body with server-side bindings: shared-pg carries two shared
+    // Database-CR rows, pdns-pg carries the implicit dedicated row. Field
+    // names are the Go `instanceBinding` json tags VERBATIM.
+    installFetch({
+      items: [
+        {
+          id: 'aaaaaaaa-1111',
+          name: 'shared-pg',
+          blueprint: 'postgres',
+          org: 'shared-data',
+          topology: 'ha',
+          status: 'Ready',
+          bindings: [
+            { database: 'gitea', role: 'gitea', mode: 'shared', secret: 'gitea-database-secret', consumer: 'gitea' },
+            { database: 'registry', role: 'harbor', mode: 'shared', secret: 'harbor-database-secret', consumer: 'harbor' },
+          ],
+        },
+        {
+          id: 'bbbbbbbb-2222',
+          name: 'pdns-pg',
+          blueprint: 'postgres',
+          org: 'powerdns',
+          topology: 'singleton',
+          status: 'Ready',
+          bindings: [
+            { database: 'app', role: 'app', mode: 'dedicated', secret: '', consumer: 'powerdns' },
+          ],
+        },
+      ],
+    })
+    renderPanel()
+    const tables = await screen.findAllByTestId('consumers-table')
+    expect(tables.length).toBe(2)
+    const rows = screen.getAllByTestId('binding-row')
+    expect(rows.length).toBe(3)
+    const text = rows.map((r) => r.textContent).join(' ')
+    // database · role · mode · secret · consumer, casing per the Go tags.
+    expect(text).toContain('gitea-database-secret')
+    expect(text).toContain('registry')
+    expect(text).toContain('harbor')
+    expect(text).toContain('shared')
+    expect(text).toContain('dedicated')
+    expect(text).toContain('powerdns')
+    // shared-pg has 2 consumers → SHARED pill; no honest-gap line remains.
+    expect(screen.queryByTestId('data-instance-no-bindings')).toBeNull()
   })
 
   it('renders the honest empty state on [] (model gated off)', async () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/DataInstances.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/DataInstances.tsx
@@ -7,17 +7,20 @@
  * Renders the three ADR-0010 surfaces:
  *   1. ONE PostgreSQL ENGINE-CLASS card (the `bp-cnpg` engine, shown once),
  *      with the live data-instance count.
- *   2. The N DATA-INSTANCE cards (bp-postgres installs), each with a
- *      Consumers (bindings) table: app · database · role · mode · secret.
- *   3. The honest empty states — "No PostgreSQL data instances yet" when the
- *      model is gated off, and per-instance "bindings not yet surfaced by the
- *      API" because no catalyst-api endpoint exposes the binding rows today.
+ *   2. The N DATA-INSTANCE cards — one per live CNPG Cluster (#3188
+ *      many-to-many) — each with a Consumers (bindings) table:
+ *      app · database · role · mode · secret.
+ *   3. The honest empty states — "No PostgreSQL data instances yet" when
+ *      nothing runs, and the per-instance "bindings not surfaced" line for
+ *      rows the API returns without a `bindings[]` field.
  *
  * Fed by the LIVE, REUSED endpoint
  *   GET /catalyst/v1/catalog/bp-postgres/instances
- * via `getApplicationInstances` (the same call InstancesSection uses). NO new
- * API was invented; the per-consumer binding rows are NOT exposed by any
- * endpoint (see dataInstances.ts header) so they are never fabricated.
+ * via `getApplicationInstances` (the same call InstancesSection uses). The
+ * per-consumer binding rows are now surfaced SERVER-SIDE on that endpoint
+ * (#3188: CNPG Cluster CRs → instance rows, Database CRs → shared bindings,
+ * bare per-app Clusters → one implicit dedicated binding); rows without
+ * `bindings` still render the honest empty state — never a fabricated row.
  */
 
 import { useQuery } from '@tanstack/react-query'
@@ -127,15 +130,15 @@ export function DataInstances({
               <div className="di-consumers">
                 <div className="di-consumers-head">Consumers (bindings)</div>
                 {inst.bindings.length === 0 ? (
-                  // Honest gap: no catalyst-api endpoint exposes the
-                  // per-consumer binding rows yet (they live in the install
-                  // HR's chart values.databases[]). Never fabricate rows.
+                  // Honest empty state: this row arrived WITHOUT a
+                  // `bindings[]` field (non-postgres blueprint or an older
+                  // catalyst-api). Never fabricate rows client-side.
                   <div
                     className="di-no-consumers"
                     data-testid="data-instance-no-bindings"
                   >
-                    Bindings (database · role · mode · secret) are not yet
-                    surfaced by the API.
+                    Bindings (database · role · mode · secret) are not
+                    surfaced for this instance.
                   </div>
                 ) : (
                   <table
@@ -296,7 +299,8 @@ table.di-bindings code {
   background: color-mix(in srgb, var(--color-success) 16%, transparent);
   color: var(--color-success);
 }
-.di-mode-private {
+.di-mode-private,
+.di-mode-dedicated {
   background: color-mix(in srgb, var(--color-text-dim) 14%, transparent);
   color: var(--color-text-dim);
 }


### PR DESCRIPTION
## Problem

The Data-instances panel showed **"1 instance"** on hw130 while **7 CNPG Clusters** ran live (`catalyst-system/openova-flow-pg`, `newapi/newapi-bp-newapi-newapi-pg`, `powerdns/pdns-pg`, `powerdns-admin/pda-pg`, `shared-data/shared-pg`, `sme/sme-pg`, `cnpg/cnpg-pair-bp-cnpg-pair-primary`). `GET /catalyst/v1/catalog/{blueprint}/instances` only projected Application CRs plus the `bp-postgres-shared` engine HelmRelease — the founder-ordered shape is ONE card per live Postgres instance with its consumer bindings (many-to-many), not just the shared engine.

## Change

**catalyst-api** (`endpoint_handler.go`):
- For the postgres engine family (`cnpg` / `postgres`), `HandleListBlueprintInstances` now enumerates live `postgresql.cnpg.io/v1` **Cluster** CRs cluster-wide: one row per Cluster — `id` = CR uid, `org` = namespace, `status` from `.status.phase` ("Cluster in healthy state" → `Ready`, else verbatim), `topology` = `singleton` / `ha` (instances>1) / `replica` (`spec.replica.enabled`).
- New `bindings[]` field (`instanceBinding`: `database · role · mode · secret · consumer`, lowercase camelCase wire tags): **Database** CRs matched on `.spec.cluster.name` → `mode=shared` rows (consumer best-effort from the `<cluster>-<consumer>` CR name, secret `<consumer>-database-secret`); Clusters with no Database CRs → ONE implicit `mode=dedicated` binding (`app`/`app`, consumer = namespace).
- When live Cluster rows exist they supersede the engine-HR projection (the HR is only the installer of the `shared-pg` Cluster — projecting both would render one physical instance as two cards). The HR fallback stays for envs with no live Clusters; rows are deduped by lowercase name against Application-CR rows, which then receive the live bindings.

**UI** (`dataInstances.ts` / `DataInstances.tsx` / `catalog.api.ts`):
- Consumes the wire `bindings[]` — the Consumers table renders the rows; the honest "bindings not surfaced" state is kept for rows without the field. TS mirrors the Go `json:` tags verbatim; topology display extended with `ha`/`replica`; `dedicated` mode pill styled.

**Contract** (`docs/api/catalyst-api-openapi.yaml`): `ApplicationSummary.bindings` + `InstanceBinding` schema.

## hw130 expected wire shape (7 rows)

`shared-pg` (org `shared-data`, Ready, with its Database-CR shared bindings) + `openova-flow-pg`, `newapi-bp-newapi-newapi-pg`, `pdns-pg`, `pda-pg`, `sme-pg`, `cnpg-pair-bp-cnpg-pair-primary` each with one implicit dedicated binding (consumer = their namespace). No duplicate `postgres-shared` engine-HR card.

## Tests

- `go test -race ./internal/handler/` — **green** (full package, 65s): new `TestListBlueprintInstances_CNPGClustersWithBindings` (2 Cluster CRs + `shared-pg-gitea` Database CR + engine HR → exactly 2 rows with correct shared/dedicated bindings, HR superseded) and `TestListBlueprintInstances_NoCNPGClusters_HRFallback` (engine-HR card still renders with no fabricated bindings); fake dynamic client registers `ClusterList`/`DatabaseList` list kinds.
- `npx vitest run DataInstances.test.tsx` — **5/5 green** including the new Consumers-table rendering case; `npm run build` (tsc -b + vite) — green.

## Caveats (honest)

- `consumer`/`secret` on shared bindings are best-effort derivations from the `<cluster>-<consumer>` Database-CR naming convention; a Database CR named outside that convention renders with empty consumer/secret rather than a fabricated value.
- The implicit dedicated binding reflects CNPG's bootstrap `app` database; it carries no secret name on the wire.
- Verified by unit/wire tests only — the hw130 live walk (screenshot of 7 cards) is the acceptance step and has not been run from this PR.

Refs #3188

🤖 Generated with [Claude Code](https://claude.com/claude-code)