### PR TITLE
feat(bootstrap-kit): pilot re-home bp-k8s-ws-proxy into the mgmt vCluster (#2745 pilot)

### DIFF
--- a/clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
+++ b/clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
@@ -1,3 +1,7 @@
+# #2745 pilot: first app re-homed per the founder vCluster mandate —
+# the coraza/sandbox G92.1 pattern applied; template for the remaining
+# mgmt-tier apps.
+#
 # bp-k8s-ws-proxy — Catalyst bootstrap-kit Blueprint slot 51 (exec
 # fan-out, post-W2.K4). Per-node WebSocket exec proxy that bridges
 # HMAC-signed
@@ -9,11 +13,38 @@
 # onto the local-node pod (zero cross-node hops, zero apiserver
 # round-trips through other nodes).
 #
+# ── #2745 MGMT vCluster placement (pilot) ────────────────────────────
+# The HR CR lives in host ns `mgmt` (where bp-mgmt-vcluster slot 58
+# exports the vc-mgmt kubeconfig Secret). helm-controller resolves
+# spec.kubeConfig.secretRef from the HR's own namespace (Flux v2
+# SecretReference contract) and installs the chart INSIDE the mgmt
+# vCluster. targetNamespace/storageNamespace = the inner
+# `catalyst-system` namespace inside the vCluster (storageNamespace
+# pinned per the hw92 lesson — helm-controller otherwise defaults it
+# to the HR's own ns `mgmt`, which createNamespace never creates
+# inside the vCluster → "namespaces not found" install failure;
+# same latent defect bp-coraza + bp-sandbox hit).
+#
+# Known couplings carried by this pivot (documented in PR #2745 pilot;
+# verify on a fresh prov before promoting the pattern):
+#   - The vc-mgmt-synced Service appears host-side as
+#     `k8s-ws-proxy-x-catalyst-system-x-mgmt` in host ns `mgmt`; host
+#     callers (Guacamole egress NetworkPolicy targets ns
+#     catalyst-system today) must re-point.
+#   - bp-mgmt-vcluster does NOT sync host nodes; the DaemonSet's
+#     one-pod-per-host-node + internalTrafficPolicy:Local contract is
+#     scoped to the vCluster's node view.
+#   - The in-cluster SA token binds the VCLUSTER apiserver — exec
+#     reach is mgmt-vCluster pods only.
+#
 # Wrapper chart: platform/k8s-ws-proxy/chart/
 # Catalyst-curated values: platform/k8s-ws-proxy/chart/values.yaml
 # Reconciled by: Flux on the new Sovereign's k3s control plane.
 #
 # dependsOn:
+#   - bp-mgmt-vcluster — vc-mgmt Secret doesn't exist until that HR is
+#     Ready; the kubeConfig pivot dangles without it. Cross-ns
+#     dependsOn requires explicit `namespace:` (#2745 pilot).
 #   - bp-cilium — DaemonSet pods need a working CNI before they bind
 #     the host-network listen port.
 #   - bp-sealed-secrets — the chart references a SealedSecret carrying
@@ -48,16 +79,42 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-k8s-ws-proxy
-  namespace: flux-system
+  # #2745 pilot: HR lives in host ns `mgmt` (where bp-mgmt-vcluster
+  # exports the vc-mgmt Secret). helm-controller authenticates against
+  # the vCluster apiserver and installs the chart inside the vCluster.
+  namespace: mgmt
   labels:
     catalyst.openova.io/slot: "51"
+    catalyst.openova.io/vcluster: mgmt
 spec:
   interval: 15m
   releaseName: k8s-ws-proxy
+  # targetNamespace = inner namespace INSIDE the mgmt vCluster. Kept
+  # at `catalyst-system` so in-vCluster callers keep the canonical
+  # short name k8s-ws-proxy.catalyst-system.svc.
   targetNamespace: catalyst-system
+  # hw92 lesson (bp-coraza/bp-sandbox): pin storageNamespace =
+  # targetNamespace, else helm-controller defaults it to the HR's own
+  # namespace (`mgmt`) and fails `namespaces "mgmt" not found` storing
+  # the release inside the vCluster (createNamespace only creates the
+  # target `catalyst-system`).
+  storageNamespace: catalyst-system
+  # vCluster pivot — helm-controller installs the chart inside the
+  # mgmt vCluster (Flux v2 HelmRelease v2 contract). #2745 pilot.
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   dependsOn:
+    # #2745 pilot: bp-mgmt-vcluster MUST be Ready before this HR tries
+    # to install — the vc-mgmt Secret doesn't exist until then.
+    # Cross-ns dependsOn requires explicit `namespace:`.
+    - name: bp-mgmt-vcluster
+      namespace: flux-system
     - name: bp-cilium
+      namespace: flux-system
     - name: bp-sealed-secrets
+      namespace: flux-system
   chart:
     spec:
       chart: bp-k8s-ws-proxy
@@ -88,6 +145,10 @@ spec:
         name: bp-k8s-ws-proxy
         namespace: flux-system
   install:
+    # #2745 pilot: createNamespace=true so helm-controller provisions
+    # the inner `catalyst-system` namespace inside the mgmt vCluster
+    # on first install (no host-side Namespace YAML needed).
+    createNamespace: true
     timeout: 15m
     disableWait: true
     remediation:

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -80,7 +80,12 @@ spec:
     - name: bp-keycloak
     - name: bp-sealed-secrets
     - name: bp-seaweedfs
+    # #2745 pilot: bp-k8s-ws-proxy HR re-homed to host ns `mgmt`
+    # (mgmt vCluster placement). A bare `name:` resolves in THIS HR's
+    # namespace (flux-system) → dangling dep → guacamole wedges
+    # (#3191 shape). Cross-ns dependsOn requires explicit `namespace:`.
     - name: bp-k8s-ws-proxy
+      namespace: mgmt
   chart:
     spec:
       chart: bp-guacamole

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -488,7 +488,12 @@ slots:
   #     (RWX recordings PVC) + bp-k8s-ws-proxy (apiserver tunnel).
   - slot: 51
     name: bp-k8s-ws-proxy
-    depends_on: [bp-cilium, bp-sealed-secrets]
+    # #2745 pilot (2026-06-12): MGMT vCluster placement adds
+    # bp-mgmt-vcluster as a new edge so the install gates on vc-mgmt
+    # existing before helm-controller attempts the pivot (same shape
+    # as bp-coraza/bp-dmz-vcluster G92.4 + bp-sandbox/bp-rtz-vcluster
+    # G92.5).
+    depends_on: [bp-mgmt-vcluster, bp-cilium, bp-sealed-secrets]
     wave: present
   - slot: 52
     name: bp-guacamole


### PR DESCRIPTION
Refs #2745

## What

Pilot re-homing of ONE low-risk mgmt-tier app — `bp-k8s-ws-proxy` (slot 51) — into the **mgmt vCluster**, applying the proven G92.x pattern (bp-coraza→dmz G92.4 #2663, bp-sandbox→rtz G92.5 #2664) per the founder DoD: *"Each application must be in a vCluster (dmz/mgmt/rtz) unless there is a very valid exceptional reason."*

This is the **pilot only** — 1 app re-homed, ~47 mgmt/dmz/rtz-tier apps remain on the host. The diff is the template for the rest.

## Mechanism (the reusable recipe)

- HR CR moves `flux-system` → host ns `mgmt`, where `bp-mgmt-vcluster` (slot 58) exports the `vc-mgmt` kubeconfig Secret (`exportKubeConfig.secret.name: vc-mgmt`, server `https://mgmt-vcluster.mgmt:443`, key `config`). Flux v2 resolves `spec.kubeConfig.secretRef` from the HR's own namespace.
- `targetNamespace: catalyst-system` + `storageNamespace: catalyst-system` — both pinned to the INNER namespace (hw92 lesson: unpinned storageNamespace defaults to the HR's own ns `mgmt`, which `createNamespace` never creates inside the vCluster → `namespaces "mgmt" not found`).
- `install.createNamespace: true` provisions the inner ns on first install.
- `dependsOn` gains `bp-mgmt-vcluster` (explicit `namespace: flux-system` — cross-ns edges require it); existing `bp-cilium`/`bp-sealed-secrets` edges made explicit-ns.
- **Lockstep 1** — slot 52 `bp-guacamole` depends on `bp-k8s-ws-proxy`; a bare `name:` resolves in the dependent's OWN ns (flux-system) → after the move it would dangle → guacamole wedges forever (the #3191 dangling-dep shape). Edge now carries `namespace: mgmt`.
- **Lockstep 2** — `scripts/expected-bootstrap-deps.yaml` slot 51 gains the `bp-mgmt-vcluster` edge. `bash scripts/check-bootstrap-deps.sh` → **drift 0, cycles 0, PASSED**.
- Host ns `mgmt` is already declared in slot 00 (`00-vcluster-host-namespaces.yaml`, #2982) so the HR CR applies atomically.
- Chart untouched (no version bump needed; `check-chart-annotations.sh` not applicable).
- `clusters/omantel.omani.works/bootstrap-kit/` is an already-divergent point-in-time copy (it carries slots the template dropped) — intentionally NOT touched; template is the canonical source.

## Why bp-k8s-ws-proxy is the right pilot mechanically

The bp-keycloak precedent (G92.2 #2661, **REVERTED** by G105-followup #2697) failed on two traps: the mgmt vCluster doesn't sync Gateway-API/ExternalSecret CRDs (HTTPRoute admission fails inside the vCluster) and Helm `valuesFrom` Secret lookups resolve in the HR's own ns. `bp-k8s-ws-proxy` ships **neither**: templates are DaemonSet + Service + RBAC + hmac-bootstrap Job only — no HTTPRoute, no ExternalSecret, no valuesFrom, no PG, no SSO callback. The slot transformation itself is clean and CI-verifiable.

## Why this opens as DRAFT — honest couplings that need a fresh-prov walk

No HTTPRoute coupling exists (the route-break caveat does not bite), but four same-class couplings do, and none can be cleanly wired from this slot file alone:

1. **Synced-service naming**: inside the vCluster the canonical short name `k8s-ws-proxy.catalyst-system.svc` keeps working; on the HOST the synced Service appears as `k8s-ws-proxy-x-catalyst-system-x-mgmt` in host ns `mgmt`. Host-side callers must re-point.
2. **Guacamole NetworkPolicy egress** (`platform/guacamole/chart/values.yaml:181-184`): targets ns `catalyst-system` + podSelector `app.kubernetes.io/name: bp-k8s-ws-proxy`. Post-move the proxy pods materialize host-side in ns `mgmt` with vCluster-translated metadata → the egress allow no longer matches → guacd/webapp traffic to the proxy is dropped by its own policy. Fix belongs in the guacamole chart (values + netpol), a separate lockstep PR with a chart bump.
3. **Node-view degradation**: `bp-mgmt-vcluster` intentionally does NOT sync host nodes ("Ingresses + nodes + PVs are intentionally NOT synced", chart values §sync). A DaemonSet inside the vCluster only schedules onto the vCluster's node view — the one-pod-per-HOST-node + `internalTrafficPolicy: Local` zero-cross-node-hop contract (the component's entire design point) degrades to vCluster-visible nodes.
4. **Exec scope + HMAC locality**: the in-cluster SA token binds the VCLUSTER apiserver — exec reach becomes mgmt-vCluster pods only (today's contract: bridge onto the LOCAL host kube-apiserver pods/exec; Guacamole's kubectl-exec sessions target host pods). The chart's hook Job will also mint a fresh `k8s-ws-proxy-hmac` Secret inside the vCluster; any host-side caller signing with the host `catalyst-system` key gets signature-rejected. (No in-repo Go caller hardcodes the host DNS today — verified by repo-wide grep — so both are latent, but they decide whether this app ultimately qualifies for the founder's "very valid exceptional reason" carve-out as a node-local host-infra component.)

## Validation done

- `bash scripts/check-bootstrap-deps.sh` → PASSED (drift 0, cycles 0).
- `kustomize build clusters/_template/bootstrap-kit` renders; the transformed HR shows `ns: mgmt`, `target/storage: catalyst-system`, `kubeConfig.secretRef: vc-mgmt/config`, 3 explicit-ns dependsOn edges; bp-guacamole renders the cross-ns edge.

## Founder-DoD statement

Pilot only: **1 of ~48** apps re-homed per the vCluster mandate. The remaining ~47 mgmt-tier apps follow this diff's shape, each needing the same coupling audit (HTTPRoute/ExternalSecret CRDs, valuesFrom, netpol selectors, host-caller DNS) before promotion. Not pillar work per se — it advances the topology track (vCluster containment) named in the founder deliverables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)