### PR TITLE
feat(console): Region column + filter on /jobs — derive from jobName (founder hw126 report)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.test.tsx
@@ -34,6 +34,8 @@ import {
   formatDuration,
   matchJob,
   regionFromJob,
+  regionOf,
+  regionUnionOfGroup,
 } from './JobsTable'
 import { FIXTURE_JOBS } from '@/test/fixtures/jobs.fixture'
 import type { Job } from '@/lib/jobs.types'
@@ -262,12 +264,20 @@ describe('JobsTable — render', () => {
     expect(headers).toEqual(['name', 'app', 'deps', 'parent', 'status', 'started', 'duration'])
   })
 
-  it('row link points at the clean /jobs/$jobId path (post-#976 root URLs)', async () => {
+  it('row link stays scoped under /provision/$deploymentId on the mother surface (prov #59)', async () => {
     renderTable({ jobs: FIXTURE_JOBS })
     await screen.findByTestId('jobs-table')
     const link = screen.getByTestId('jobs-row-link-job-install-cilium') as HTMLAnchorElement
     expect(link.tagName.toLowerCase()).toBe('a')
-    expect(link.getAttribute('href')).toBe('/jobs/job-install-cilium')
+    // useJobLinkBuilder contract: on the mother's monitoring surface
+    // (non-sovereign hostname + $deploymentId in the route — exactly
+    // this harness, mounted at /provision/d-1/jobs) every link MUST
+    // stay scoped under /provision/$deploymentId; the clean
+    // /jobs/$jobId form is reserved for the Sovereign chroot console
+    // where the deployment is implicit from the hostname. The previous
+    // expectation here (clean root URLs, post-#976) predated the
+    // prov #59 chroot-scoping fix (2026-05-13) and failed ever since.
+    expect(link.getAttribute('href')).toBe('/provision/d-1/jobs/job-install-cilium')
   })
 
   // Issue #232 verbatim: "simulates 0 reducer-derived jobs + 5
@@ -362,6 +372,141 @@ describe('regionFromJob (C8-005)', () => {
     expect(
       regionFromJob({ jobName: 'install-fsn1:bp-cilium', appId: 'fsn1:bp-cilium', region: undefined }),
     ).toBe('fsn1')
+  })
+})
+
+// ── founder hw126 report: region must be derivable from jobName alone ─
+describe('regionOf — jobName-only region derivation (founder hw126)', () => {
+  it('extracts the region from a secondary-region install row', () => {
+    // The exact shape the founder saw missing a region label on hw126.
+    expect(regionOf('install-me-east-215-b-1:harbor')).toBe('me-east-215-b-1')
+  })
+
+  it('returns "" (primary) for a plain install row', () => {
+    expect(regionOf('install-harbor')).toBe('')
+  })
+
+  it('returns "" (primary) for lifecycle rows (provision-*)', () => {
+    expect(regionOf('provision-tofu-apply')).toBe('')
+    expect(regionOf('provision-network')).toBe('')
+  })
+
+  it('never misreads a ":" qualifier in a lifecycle row as a region', () => {
+    expect(regionOf('provision-tofu:apply')).toBe('')
+  })
+
+  it('handles the bare componentID form <region>:<chart>', () => {
+    expect(regionOf('hel1-2:cilium')).toBe('hel1-2')
+  })
+
+  it('returns "" for group slugs and empty names', () => {
+    expect(regionOf('applications')).toBe('')
+    expect(regionOf('day-2-mutations')).toBe('')
+    expect(regionOf('')).toBe('')
+  })
+})
+
+describe('regionUnionOfGroup — parent/group rows surface the child-region union', () => {
+  const child = (over: Partial<Job>): Pick<Job, 'jobName' | 'appId' | 'region' | 'parentId' | 'type'> => ({
+    jobName: over.jobName ?? 'install-cilium',
+    appId: over.appId ?? '',
+    region: over.region,
+    parentId: over.parentId ?? 'applications',
+    type: over.type ?? 'install',
+  })
+
+  it('unions distinct child regions, lexically sorted', () => {
+    const jobs = [
+      child({ jobName: 'install-hel1-2:cilium' }),
+      child({ jobName: 'install-fsn1:cilium' }),
+      child({ jobName: 'install-fsn1:flux' }), // duplicate region — deduped
+      child({ jobName: 'install-cert-manager' }), // primary — excluded from the union
+    ]
+    expect(regionUnionOfGroup(jobs, 'applications')).toEqual(['fsn1', 'hel1-2'])
+  })
+
+  it('returns [] when every child is primary (cell renders "—")', () => {
+    const jobs = [
+      child({ jobName: 'install-cilium' }),
+      child({ jobName: 'install-flux' }),
+    ]
+    expect(regionUnionOfGroup(jobs, 'applications')).toEqual([])
+  })
+
+  it('only counts direct children of the requested group', () => {
+    const jobs = [
+      child({ jobName: 'install-fsn1:cilium', parentId: 'applications' }),
+      child({ jobName: 'install-hel1-2:cilium', parentId: 'bootstrap-kit' }),
+      // Nested group rows never contribute themselves.
+      child({ jobName: 'nbg1-1:subgroup', parentId: 'applications', type: 'group' }),
+    ]
+    expect(regionUnionOfGroup(jobs, 'applications')).toEqual(['fsn1'])
+  })
+
+  it('prefers the first-class region field on children', () => {
+    const jobs = [
+      child({ jobName: 'install-harbor', region: 'me-east-215-b-1' }),
+    ]
+    expect(regionUnionOfGroup(jobs, 'applications')).toEqual(['me-east-215-b-1'])
+  })
+})
+
+describe('Parent chip hover title carries the group region union (multi-region)', () => {
+  const baseLeaf = {
+    type: 'install' as const,
+    parentId: 'applications',
+    childIds: [],
+    dependsOn: [],
+    status: 'succeeded' as const,
+    startedAt: '2026-06-11T10:00:00Z',
+    finishedAt: '2026-06-11T10:01:00Z',
+    durationMs: 60_000,
+  }
+  const group: Job = {
+    id: 'applications',
+    jobName: 'applications',
+    displayName: 'Applications',
+    type: 'group',
+    appId: '',
+    parentId: '',
+    dependsOn: [],
+    childIds: ['bp-cilium', 'me-east-215-b-1:bp-harbor'],
+    status: 'succeeded',
+    startedAt: '2026-06-11T10:00:00Z',
+    finishedAt: '2026-06-11T10:01:00Z',
+    durationMs: 60_000,
+  }
+
+  it('appends the union to the Parent chip title on a multi-region set', async () => {
+    const jobs: Job[] = [
+      group,
+      { ...baseLeaf, id: 'bp-cilium', jobName: 'install-cilium', appId: 'bp-cilium' },
+      {
+        ...baseLeaf,
+        id: 'me-east-215-b-1:bp-harbor',
+        jobName: 'install-me-east-215-b-1:harbor',
+        appId: 'me-east-215-b-1:bp-harbor',
+        region: 'me-east-215-b-1',
+      },
+    ]
+    renderTable({ jobs })
+    await screen.findByTestId('jobs-table')
+    const chip = screen.getByTestId('jobs-cell-parent-bp-cilium')
+    expect(chip.getAttribute('title')).toBe('Applications — regions: me-east-215-b-1')
+    // The visible chip label stays the plain parent label.
+    expect(chip.textContent).toBe('Applications')
+  })
+
+  it('keeps the plain parent label as title on a single-region set', async () => {
+    const jobs: Job[] = [
+      group,
+      { ...baseLeaf, id: 'bp-cilium', jobName: 'install-cilium', appId: 'bp-cilium' },
+      { ...baseLeaf, id: 'bp-flux', jobName: 'install-flux', appId: 'bp-flux' },
+    ]
+    renderTable({ jobs })
+    await screen.findByTestId('jobs-table')
+    const chip = screen.getByTestId('jobs-cell-parent-bp-cilium')
+    expect(chip.getAttribute('title')).toBe('Applications')
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
@@ -5,10 +5,14 @@
  *   • Toolbar:
  *       - search input that filters across jobName / appId / dependsOn /
  *         status / parent
- *       - filter dropdowns per column for status / app / parent
+ *       - filter dropdowns per column for status / app / parent, plus
+ *         region on a multi-region Sovereign (2+ region buckets in the
+ *         job set, primary counted as its own bucket)
  *   • <table data-testid="jobs-table"> with columns:
- *       name (with child-count badge on parents), app, deps, parent,
- *       status, started, duration
+ *       name (with child-count badge on parents), app, region (multi-
+ *       region only — derived from the backend-stamped region field or
+ *       the install-<region>:<chart> jobName), deps, parent, status,
+ *       started, duration
  *
  * Rows are CLICKABLE LINKS, not expandable accordions. Clicking a
  * leaf navigates to its own JobDetail page; clicking a parent
@@ -77,6 +81,48 @@ export function compareJobs(a: Job, b: Job): number {
 }
 
 /**
+ * Canonical jobName prefixes (mirror the backend's JobNamePrefix in
+ * products/catalyst/bootstrap/api/internal/jobs — per Principle #4 the
+ * literals live here once, never inline in the parser).
+ */
+const INSTALL_JOB_PREFIX = 'install-'
+const LIFECYCLE_JOB_PREFIX = 'provision-'
+
+/**
+ * regionOf — derive the region key from a bare jobName (founder hw126
+ * report: the /jobs table must show + filter region per row, and the
+ * region is derivable from the row name alone).
+ *
+ * Canonical jobName shapes (see helmwatch_bridge.go RegionFromComponent
+ * and the dependsOn canonicalisation table at its line ~544):
+ *   • "install-<region>:<chart>"  — secondary-region install row
+ *     (e.g. "install-me-east-215-b-1:harbor")        → "<region>"
+ *   • "<region>:<chart>"          — bare componentID form → "<region>"
+ *   • "install-<chart>"           — primary-region install → ""
+ *   • "provision-*"               — lifecycle rows (tofu plan/apply,
+ *     network, …) always run from the primary control plane and are
+ *     never region-encoded → "" (the UI labels "" as "primary")
+ *
+ * Returns "" (primary) when no region key is encoded, so the region
+ * filter's "All"/primary semantics match regionFromJob's contract.
+ * Exported so the unit test in JobsTable.test.tsx can lock in the
+ * secondary / primary / lifecycle shapes.
+ */
+export function regionOf(jobName: string): string {
+  if (!jobName) return ''
+  // Lifecycle rows are never region-encoded — even a ":" in their name
+  // (a step qualifier) must not be misread as a region separator.
+  if (jobName.startsWith(LIFECYCLE_JOB_PREFIX)) return ''
+  // Strip the canonical `install-` prefix, then check for the region
+  // separator. Anything before `:` is the region.
+  const stripped = jobName.startsWith(INSTALL_JOB_PREFIX)
+    ? jobName.slice(INSTALL_JOB_PREFIX.length)
+    : jobName
+  const sep = stripped.indexOf(':')
+  return sep > 0 ? stripped.substring(0, sep) : ''
+}
+
+/**
  * regionFromJob — extract the cloud region key from a Job.
  *
  * Preference order:
@@ -85,9 +131,9 @@ export function compareJobs(a: Job, b: Job): number {
  *      of truth — set only for secondary-region rows, empty for primary.
  *   2. Fallback to the `<region>:<chart>` prefix encoded in `appId`
  *      (the backend's canonical componentID for secondaries), then the
- *      `install-<region>:<chart>` `jobName`. The fallback keeps older
- *      payloads (and group rows) rendering correctly while the wire
- *      shape rolls forward.
+ *      `install-<region>:<chart>` `jobName` via {@link regionOf}. The
+ *      fallback keeps older payloads (and group rows) rendering
+ *      correctly while the wire shape rolls forward.
  *
  * The encoding is documented in
  * products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
@@ -114,16 +160,32 @@ export function regionFromJob(job: Pick<Job, 'jobName' | 'appId' | 'region'>): s
   }
   // Fallback: parse the jobName when AppID is empty (group rows /
   // pre-bridge legacy rows).
-  if (job.jobName) {
-    // Strip the canonical `install-` prefix, then check for the
-    // region separator. Anything before `:` is the region.
-    const stripped = job.jobName.startsWith('install-')
-      ? job.jobName.slice('install-'.length)
-      : job.jobName
-    const sep = stripped.indexOf(':')
-    if (sep > 0) return stripped.substring(0, sep)
+  return regionOf(job.jobName)
+}
+
+/**
+ * regionUnionOfGroup — distinct, lexically-sorted region keys across a
+ * group's direct children (matched by parentId). A parent/group row
+ * carries no region of its own, so its Region cell shows the union of
+ * its children's regions — or "—" when every child is primary (the
+ * union is empty). Nested group rows are skipped: their own children
+ * contribute through their own union, never through the grandparent's.
+ *
+ * Exported so the unit test in JobsTable.test.tsx can lock in the
+ * union / all-primary / other-parent cases.
+ */
+export function regionUnionOfGroup(
+  jobs: readonly Pick<Job, 'jobName' | 'appId' | 'region' | 'parentId' | 'type'>[],
+  groupId: string,
+): string[] {
+  const set = new Set<string>()
+  for (const j of jobs) {
+    if (j.parentId !== groupId) continue
+    if (j.type === 'group') continue
+    const r = regionFromJob(j)
+    if (r) set.add(r)
   }
-  return ''
+  return [...set].sort((a, b) => a.localeCompare(b))
 }
 
 /**
@@ -228,6 +290,18 @@ export function JobsTable({ jobs, appIdFilter, initialParentFilter }: JobsTableP
       if (j.type === 'group') {
         m.set(j.id, j.displayName ?? j.jobName)
       }
+    }
+    return m
+  }, [jobs])
+
+  // Region union per group id — a parent/group row has no region of its
+  // own, so its Region cell (and the Parent chip's hover title on a
+  // multi-region Sovereign) surfaces the union of its children's
+  // regions, never a bogus "primary" label (founder hw126 report).
+  const regionUnionByGroupId = useMemo<Map<string, string[]>>(() => {
+    const m = new Map<string, string[]>()
+    for (const j of jobs) {
+      if (j.type === 'group') m.set(j.id, regionUnionOfGroup(jobs, j.id))
     }
     return m
   }, [jobs])
@@ -455,6 +529,7 @@ export function JobsTable({ jobs, appIdFilter, initialParentFilter }: JobsTableP
                   job={j}
                   parentLabel={parentLabelById.get(j.parentId) ?? j.parentId}
                   showRegion={showRegion}
+                  regionUnionByGroupId={regionUnionByGroupId}
                 />
               ))
             )}
@@ -471,6 +546,10 @@ interface JobRowProps {
   /** Render the Region cell — true only on a multi-region Sovereign so
       a single-region table keeps its original column set. */
   showRegion: boolean
+  /** Distinct region keys per group id (regionUnionOfGroup output) —
+      drives the group-row Region cell union and the Parent chip's
+      hover title on a multi-region Sovereign. */
+  regionUnionByGroupId: Map<string, string[]>
 }
 
 /**
@@ -521,10 +600,21 @@ function useJobLinkBuilder(): (jobId: string) => string {
   }
 }
 
-function JobRow({ job, parentLabel, showRegion }: JobRowProps) {
+function JobRow({ job, parentLabel, showRegion, regionUnionByGroupId }: JobRowProps) {
   const started = formatRelative(job.startedAt)
   const jobLink = useJobLinkBuilder()
   const region = regionFromJob(job)
+  // Union of the row's OWN children's regions (group rows) + union of
+  // the row's PARENT group's children (drives the Parent chip title).
+  const ownGroupRegions = regionUnionByGroupId.get(job.id) ?? []
+  const parentGroupRegions = regionUnionByGroupId.get(job.parentId) ?? []
+  // On a multi-region Sovereign the Parent chip's hover title carries
+  // the group's region union so the operator can see at a glance which
+  // regions a parent group spans without opening it.
+  const parentTitle =
+    showRegion && parentGroupRegions.length > 0
+      ? `${parentLabel} — regions: ${parentGroupRegions.join(', ')}`
+      : parentLabel
   return (
     <tr
       className="jobs-row"
@@ -549,7 +639,21 @@ function JobRow({ job, parentLabel, showRegion }: JobRowProps) {
       </td>
       {showRegion ? (
         <td className="jobs-cell jobs-cell-region">
-          {region ? (
+          {job.type === 'group' ? (
+            // Parent/group rows have no region of their own — show the
+            // union of their children's regions, or "—" when every
+            // child is primary. Never label a group "primary": a group
+            // spanning region-b children is not a primary-region row.
+            ownGroupRegions.length > 0 ? (
+              <div className="jobs-chip-row">
+                {ownGroupRegions.map((r) => (
+                  <Chip key={r} text={r} testid={`jobs-cell-region-${job.id}-${r}`} kind="app" />
+                ))}
+              </div>
+            ) : (
+              <span className="jobs-empty-cell" data-testid={`jobs-cell-region-empty-${job.id}`}>—</span>
+            )
+          ) : region ? (
             <Chip text={region} testid={`jobs-cell-region-${job.id}`} kind="app" />
           ) : (
             // Primary-region rows have no region key — label them
@@ -581,7 +685,7 @@ function JobRow({ job, parentLabel, showRegion }: JobRowProps) {
             to={jobLink(job.parentId) as never}
             className="jobs-chip jobs-chip-parent jobs-chip-link"
             data-testid={`jobs-cell-parent-${job.id}`}
-            title={parentLabel}
+            title={parentTitle}
           >
             {parentLabel}
           </Link>


### PR DESCRIPTION
## Founder report (hw126 + hw130)

The Sovereign console /jobs page "shows only half of the regions" with no Region column/filter. The column + dropdown landed in #3278 (first-class `region` field + `regionFromJob`), but three gaps remained against the founder DoD:

1. **Region was not derivable from the row name alone, tested.** Pre-#3349 payloads, group rows, and legacy rows carry no `region` field and often no region-prefixed `appId` — the jobName (`install-me-east-215-b-1:harbor`) is the only signal. That parsing was inlined and had no coverage for lifecycle shapes.
2. **Lifecycle rows (`provision-*`)** could mis-parse: a `:` step qualifier would have been read as a region key.
3. **Parent/group rows had no region rule** — an empty region falls through to the "primary" label, which is wrong for a group spanning region-b children.

## What this ships

- **`regionOf(jobName)`** — exported canonical jobName→region parser (`JobsTable.tsx`). Shapes: `install-<region>:<chart>` → region; `install-<chart>` → primary; `provision-*` → always primary; bare `<region>:<chart>` componentID form → region. `regionFromJob` delegates its jobName fallback to it; the precedence (first-class `region` field → `appId` prefix → jobName) is unchanged, so #3278 behavior is preserved byte-for-byte for wire rows.
- **`regionUnionOfGroup(jobs, groupId)`** — distinct, sorted region keys across a group's direct children. Group rows render the union as compact pills, or "—" when every child is primary — never a bogus "primary". The **Parent chip hover title** now carries the union on a multi-region Sovereign (`Applications — regions: me-east-215-b-1`), visible today from every leaf row.
- **12 new unit tests** — secondary / primary / lifecycle jobName shapes (including the verbatim hw126 row `install-me-east-215-b-1:harbor`), union dedupe + sorting + direct-children scoping + first-class-field preference, and Parent-chip title rendering on multi- vs single-region sets.
- **One stale test aligned with the shipped contract**: `row link points at the clean /jobs/$jobId path (post-#976)` asserted the pre-prov-#59 clean-root form and failed on main ever since the chroot-scoping fix (mother-surface links stay under `/provision/$deploymentId` — see the `useJobLinkBuilder` docstring). Updated to assert the documented scoped form.

## Test results

- `npx vitest run src/pages/sovereign/JobsTable.test.tsx` — **50/50 green** (was 37 passed / 1 pre-existing fail on main).
- Adjacent Jobs-surface files (`JobsPage*`, `AppDetail`, `useLiveJobsBackfill`, `jobsAdapter`, `JobDetail.hang.regression`, `handoverStageOverride`): 4 failures, **identical on pristine main** (verified via stash A/B) — zero new failures from this change.
- `npm run build` — green (generated catalog artifacts reverted, not part of this PR).

## How region-b rows render once #3349's fan-out lands

Post-converged-late-handover, region-b rows arrive named `install-me-east-215-b-1:harbor` (backend stamps `region` first-class via `RegionFromComponent`; jobName parsing is the belt-and-braces fallback). The moment the job set spans 2+ region buckets (primary counts as its own bucket), `showRegion` flips on: the table grows a **Region** column — `me-east-215-b-1` pill on region-b rows, "primary" on region-a rows, child-union pills on any group row — and the toolbar grows a **Region** dropdown (`All`, `me-east-215-b-1`, …) listing exactly the distinct keys present. A single-region Sovereign keeps its original 7-column table — no dropdown, no column.

Refs #3263

🤖 Generated with [Claude Code](https://claude.com/claude-code)