### PR TITLE
fix(sso): revert pda /login redirect — broke the OIDC callback (regression)

### DIFF
--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -113,7 +113,9 @@ spec:
       # template so a cold install can't half-render before bp-cnpg's CRD.
       # 0.1.9 (2026-06-12, founder): root-URL zero-click — /login -> /oidc/login.
       # 0.1.10: explicit port 443 on the SSO redirect (the #3310 class).
-      version: 0.1.10
+      # 0.1.11: REVERT the /login redirect — it intercepted the OIDC
+      # post-callback bounce (ERR_TOO_MANY_REDIRECTS -> 500, admin walk).
+      version: 0.1.11
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns-admin

--- a/platform/powerdns-admin/blueprint.yaml
+++ b/platform/powerdns-admin/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 0.1.10
+  version: 0.1.11
   card:
     title: powerdns-admin
     summary: |

--- a/platform/powerdns-admin/chart/Chart.yaml
+++ b/platform/powerdns-admin/chart/Chart.yaml
@@ -72,7 +72,7 @@ name: bp-powerdns-admin
 # cold install can't half-render (apiserver rejecting the Cluster CR before
 # bp-cnpg registers the CRD) and wedge the chart BEFORE it reaches kyverno
 # admission at all.
-version: 0.1.10
+version: 0.1.11
 description: |
   PowerDNS-Admin (ngoduykhanh/powerdns-admin) web UI Blueprint for
   per-Sovereign PowerDNS zone + record management. Drives the

--- a/platform/powerdns-admin/chart/templates/httproute.yaml
+++ b/platform/powerdns-admin/chart/templates/httproute.yaml
@@ -24,25 +24,6 @@ spec:
   hostnames:
     - {{ .Values.gateway.host | quote }}
   rules:
-    # ROOT-URL zero-click SSO (founder mandate 2026-06-12): PDA has no
-    # auto-redirect setting; the gateway sends its login page straight
-    # into the OIDC leg. Logged-in users never hit /login (no loop).
-    - matches:
-        - path:
-            type: Exact
-            value: /login
-      filters:
-        - type: RequestRedirect
-          requestRedirect:
-            # Explicit 443 — Gateway API otherwise copies the cilium
-            # LISTENER port (30443) into Location, which nothing serves
-            # externally (the #3310 pdns lesson, repeated on first render
-            # and caught by the wire check).
-            port: 443
-            path:
-              type: ReplaceFullPath
-              replaceFullPath: /oidc/login
-            statusCode: 302
     - matches:
         - path:
             type: PathPrefix


### PR DESCRIPTION
Self-caught by the admin proof walk: the redirect loops PDA's post-callback bounce → 500. Restores the working 1-click flow. Refs #3263

🤖 Generated with [Claude Code](https://claude.com/claude-code)