### PR TITLE
fix(rbac): cnpg list for the many-to-many instances endpoint (#3188 hw130 403)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -989,7 +989,8 @@ spec:
       # 1.4.581 (#3195 G6): continuum CRD region pattern relaxed to
       # admit real cloud codes (kom4dc digits) — unblocks the
       # production Continuum seed (slot 16b, cnpg-pair 0.2.3).
-      version: 1.4.586
+      # 1.4.587: cnpg list RBAC for the many-to-many instances endpoint (#3188).
+      version: 1.4.587
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2628,7 +2628,10 @@ name: bp-catalyst-platform
 # flip admin.dns.<sov> → pdns-admin.<sov> (single-level, wildcard-cert-covered,
 # matches the KC client redirectUris) + bp-powerdns-admin 0.1.5 OIDC env-var
 # name fixes. Refs #3150.
-version: 1.4.586
+version: 1.4.587
+# 1.4.587 — #3188: cutover-driver ClusterRole gains postgresql.cnpg.io
+#   clusters/databases + dr.openova.io read — the instances endpoint
+#   403'd cluster-wide (hw130: API 0 rows with 7 live clusters).
 # 1.4.581 — #3195 G6 (2026-06-12): crds/continuum.yaml primaryRegion/
 #   hotStandbyRegions pattern relaxed to ^[a-z][a-z0-9]*(-[a-z0-9]+){3,}$
 #   — the letters-only 4-segment pattern was Hetzner-era and

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -453,3 +453,14 @@ rules:
   - apiGroups: ["sandbox.openova.io"]
     resources: ["sandboxes"]
     verbs: ["get", "list", "watch", "delete"]
+  # #3188 many-to-many Data-instances (PR #3348): the instances endpoint
+  # enumerates live CNPG Clusters + Databases cluster-wide; without
+  # these the list 403s and the card renders empty (caught live on
+  # hw130 — API 0 rows with 7 clusters running). dr.openova.io
+  # cnpgpairs quiets the topology informer's forbidden spam.
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters", "databases"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["dr.openova.io"]
+    resources: ["cnpgpairs", "continuums"]
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
The 7-card view's missing piece: the chroot SA couldn't list CNPG clusters — API 0 rows with 7 live. Read-only rules + lockstep. Refs #3188

🤖 Generated with [Claude Code](https://claude.com/claude-code)