### PR TITLE
feat(sso): owner is admin-by-default across apps — sovereign-admins seeding + per-app mappings (founder NS-3)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -154,7 +154,14 @@ spec:
       # keycloak 0/1 → every SSO surface a bare login page. Repointed all
       # Bitnami images through the local Harbor proxy-cache + added the
       # policy.cilium.io/enforced label on both StatefulSets.
-      version: 1.4.23
+      # 1.4.24 (founder NS-3 #3263, 2026-06-12): owner is admin-by-default.
+      # Realm import seeds sovereignRealm.ownerEmail (threaded below from
+      # ${SOVEREIGN_OWNER_EMAIL}, i.e. the deployment's org_email) into
+      # /sovereign-admins + /sovereign-viewers at bootstrap, so grafana/
+      # gitea/harbor/openbao admin mappings (all keyed on sovereign-admins)
+      # elevate the owner on first SSO login. The catalyst-pin broker
+      # auto-links to the pre-seeded user by email (trustEmail=true flow).
+      version: 1.4.24
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak
@@ -214,7 +221,16 @@ spec:
   # overlays that haven't been migrated.
   values:
     sovereignFQDN: ${SOVEREIGN_FQDN}
+    # sovereignRealm.ownerEmail (founder NS-3 #3263): the deployment owner's
+    # email — cloud-init threads tofu's org_email into the bootstrap-kit
+    # Kustomization substitute map as SOVEREIGN_OWNER_EMAIL. The realm import
+    # seeds this user into /sovereign-admins so the owner is admin-by-default
+    # in every SSO-consuming app. On envs provisioned BEFORE the substitute
+    # var existed, Flux leaves the literal `${SOVEREIGN_OWNER_EMAIL}` in
+    # place — the chart's contains-"@" guard turns that into a no-op (no
+    # junk user) instead of a render failure.
     sovereignRealm:
       name: ${SOVEREIGN_REALM_NAME:=sovereign}
+      ownerEmail: "${SOVEREIGN_OWNER_EMAIL}"
     gateway:
       host: auth.${SOVEREIGN_FQDN}

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -68,7 +68,11 @@ spec:
       chart: bp-grafana
       # 1.0.9 (2026-06-12, founder): zero-click from the app ROOT —
       # oauth_auto_login + generic_oauth.auto_login flipped true.
-      version: 1.0.9
+      # 1.0.10 (founder NS-3 #3263, 2026-06-12): sovereign-admins →
+      # GrafanaAdmin (server admin) + allow_assign_grafana_admin=true, so
+      # the owner — seeded into sovereign-admins by bp-keycloak 1.4.24 —
+      # gets the full Administration nav, not org-Viewer.
+      version: 1.0.10
       sourceRef:
         kind: HelmRepository
         name: bp-grafana

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -401,6 +401,13 @@ write_files:
             SOVEREIGN_FQDN_DASHED: ${sovereign_fqdn_slug}
             PROVIDER: ${provider}
             SOVEREIGN_DEPLOYMENT_ID: ${deployment_id}
+            # SOVEREIGN_OWNER_EMAIL (founder NS-3 #3263) — the deployment
+            # owner's email (same org_email as sovereign.json's orgEmail).
+            # bp-keycloak slot 09 threads it into sovereignRealm.ownerEmail;
+            # the sovereign-realm import seeds that user into
+            # /sovereign-admins at bootstrap so the owner is admin-by-default
+            # across grafana/gitea/harbor/openbao on first SSO login.
+            SOVEREIGN_OWNER_EMAIL: "${org_email}"
             # SOVEREIGN_REGION_KEY — the bp-openova-flow-emitter REGION_KEY env
             # (slot 57). Provider-supplied: Hetzner passes the raw region key
             # (var.region / secondary each.key); Huawei passes the canonical

--- a/platform/grafana/blueprint.yaml
+++ b/platform/grafana/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.0.9
+  version: 1.0.10
   card:
     title: Grafana
     family: insights

--- a/platform/grafana/chart/Chart.yaml
+++ b/platform/grafana/chart/Chart.yaml
@@ -40,7 +40,15 @@ type: application
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.0.9
+# 1.0.10 (founder NS-3, #3263, 2026-06-12): owner is admin-by-default.
+# role_attribute_path now maps `sovereign-admins` → 'GrafanaAdmin' (server
+# admin — full Administration nav) instead of org-level 'Admin', paired
+# with the REQUIRED allow_assign_grafana_admin=true (without it Grafana
+# degrades GrafanaAdmin to org Admin). The owner lands in sovereign-admins
+# via the bp-keycloak 1.4.24 realm-import seed; the role re-evaluates from
+# the groups claim on every OAuth login. Render test
+# tests/sso-admin-role-mapping.sh.
+version: 1.0.10
 appVersion: "12.3.1"
 # 1.0.4 (G91.grafana #2658, 2026-05-31): opt in to the bp-sso-bridge
 # (G91.1 #2652) SSO framework. Top-level `sso:` block (defaults

--- a/platform/grafana/chart/tests/sso-admin-role-mapping.sh
+++ b/platform/grafana/chart/tests/sso-admin-role-mapping.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# bp-grafana — founder NS-3 (#3263): `sovereign-admins` must map to Grafana
+# SERVER admin (GrafanaAdmin), not org-level Admin/Viewer.
+#
+# Root cause this guards against (hw130 live measurement, 2026-06-12): the
+# Sovereign owner landed in Grafana as Viewer. Two coupled halves fix it:
+#   (a) bp-keycloak 1.4.24 seeds the owner into `sovereign-admins` in the
+#       realm import (the groups claim now carries the group), and
+#   (b) THIS chart maps that group to 'GrafanaAdmin' via
+#       role_attribute_path AND sets allow_assign_grafana_admin=true —
+#       without the flag Grafana silently degrades GrafanaAdmin to org
+#       Admin and the Administration nav (users/orgs/plugins/settings)
+#       never appears.
+#
+# Cases:
+#   1. Rendered grafana.ini maps sovereign-admins → GrafanaAdmin in
+#      role_attribute_path (fallback stays Viewer).
+#   2. Rendered grafana.ini sets allow_assign_grafana_admin = true in the
+#      [auth.generic_oauth] block (the mapping is inert without it).
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+out=$("$helm" template smoke "$chart_dir" 2>/dev/null)
+
+# The upstream grafana subchart renders grafana.ini into a ConfigMap; pull
+# every rendered document's data and scan the [auth.generic_oauth] block.
+ini=$(echo "$out" | python3 -c "
+import yaml, sys
+for d in yaml.safe_load_all(sys.stdin):
+    if d and d.get('kind') == 'ConfigMap':
+        ini = (d.get('data') or {}).get('grafana.ini')
+        if ini and '[auth.generic_oauth]' in ini:
+            print(ini)
+            sys.exit(0)
+sys.exit(1)
+")
+
+if [ -z "${ini}" ]; then
+  echo "FAIL: no rendered ConfigMap carries a grafana.ini with [auth.generic_oauth]" >&2
+  exit 1
+fi
+
+oauth_block=$(echo "${ini}" | awk '/^\[auth\.generic_oauth\]/{f=1; next} /^\[/{f=0} f')
+
+# ── Case 1: role_attribute_path maps sovereign-admins → GrafanaAdmin ──────
+echo "[sso-admin-role-mapping] Case 1: sovereign-admins → GrafanaAdmin in role_attribute_path (#3263)"
+role_line=$(echo "${oauth_block}" | grep "role_attribute_path" || true)
+if [ -z "${role_line}" ]; then
+  echo "FAIL: role_attribute_path missing from [auth.generic_oauth]" >&2
+  exit 1
+fi
+if ! echo "${role_line}" | grep -q "sovereign-admins"; then
+  echo "FAIL: role_attribute_path no longer keys on sovereign-admins: ${role_line}" >&2
+  exit 1
+fi
+if ! echo "${role_line}" | grep -q "GrafanaAdmin"; then
+  echo "FAIL: role_attribute_path must grant 'GrafanaAdmin' (server admin), got: ${role_line}" >&2
+  echo "      Org-level 'Admin' leaves the owner without the Administration nav (hw130 founder NS-3 measurement)." >&2
+  exit 1
+fi
+if ! echo "${role_line}" | grep -q "Viewer"; then
+  echo "FAIL: role_attribute_path lost its non-admin 'Viewer' fallback: ${role_line}" >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 2: allow_assign_grafana_admin = true ─────────────────────────────
+echo "[sso-admin-role-mapping] Case 2: allow_assign_grafana_admin=true (GrafanaAdmin is inert without it) (#3263)"
+allow_line=$(echo "${oauth_block}" | grep "allow_assign_grafana_admin" || true)
+if [ -z "${allow_line}" ]; then
+  echo "FAIL: allow_assign_grafana_admin missing — Grafana degrades GrafanaAdmin to org Admin" >&2
+  exit 1
+fi
+if ! echo "${allow_line}" | grep -qiE "allow_assign_grafana_admin *= *true"; then
+  echo "FAIL: allow_assign_grafana_admin must be true, got: ${allow_line}" >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[bp-grafana #3263 sso-admin-role-mapping] All cases PASS"

--- a/platform/grafana/chart/values.yaml
+++ b/platform/grafana/chart/values.yaml
@@ -187,9 +187,21 @@ grafana:
       token_url: ""
       api_url: ""
       # JMESPath expression: any contains() over the realm `groups`
-      # claim that matches the adminGroup → Admin, else Viewer.
+      # claim that matches the adminGroup → GrafanaAdmin, else Viewer.
       # Operator overlays may broaden this to map additional groups.
-      role_attribute_path: "contains(groups[*], 'sovereign-admins') && 'Admin' || 'Viewer'"
+      #
+      # Founder NS-3 (#3263, 2026-06-12): 'GrafanaAdmin' (not 'Admin') so
+      # the Sovereign owner — seeded into `sovereign-admins` by the
+      # bp-keycloak realm import — lands as Grafana SERVER admin
+      # (Administration nav: users/orgs/plugins/settings), not merely
+      # org-level Admin. GrafanaAdmin assignment additionally requires
+      # allow_assign_grafana_admin=true below; without that flag Grafana
+      # degrades the mapping to org Admin. The role is re-evaluated from
+      # the groups claim on EVERY OAuth login (no skip_org_role_sync).
+      role_attribute_path: "contains(groups[*], 'sovereign-admins') && 'GrafanaAdmin' || 'Viewer'"
+      # Required for role_attribute_path to be allowed to grant the
+      # server-admin (GrafanaAdmin) flag via OAuth (founder NS-3, #3263).
+      allow_assign_grafana_admin: true
       # `email` claim provides the login identifier.
       login_attribute_path: "preferred_username"
       groups_attribute_path: "groups"
@@ -229,9 +241,10 @@ sso:
   refreshInterval: 1h
   # Realm group → Grafana role mapping (JMESPath expression evaluated
   # against the OIDC userinfo response by Grafana's
-  # role_attribute_path). The Sovereign operator is auto-added to
-  # `sovereign-admins` by the realm import; users in that group land
-  # as Grafana org-level Admins.
+  # role_attribute_path). The Sovereign owner (deployment orgEmail) is
+  # seeded into `sovereign-admins` by the bp-keycloak 1.4.24+ realm
+  # import (founder NS-3, #3263); users in that group land as Grafana
+  # SERVER admins (GrafanaAdmin via allow_assign_grafana_admin above).
   adminGroup: sovereign-admins
   # G117.5 #2744 — Identity Provider hint appended to the OIDC
   # authorize_url so KC's Identity Provider Redirector delegates to

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.23
+  version: 1.4.24
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -233,7 +233,24 @@ name: bp-keycloak
 # probes-present (Enforce), image-tag-pinned (Enforce), flux-managed (Enforce)
 # were already satisfied. Render-proven per-container, helm lint clean.
 # Refs #3263 #2737.
-version: 1.4.23
+#
+# 1.4.24 (founder NS-3, #3263, 2026-06-12): owner is admin-by-default. The
+# sovereign realm import seeds the deployment owner
+# (.Values.sovereignRealm.ownerEmail, threaded from tofu org_email via the
+# bootstrap-kit ${SOVEREIGN_OWNER_EMAIL} substitution) into
+# /sovereign-admins + /sovereign-viewers at bootstrap. Root cause of the
+# hw130 1/5-admin measurement: the catalyst-pin broker creates the owner
+# with ZERO groups on first SSO login, and every per-app admin mapping
+# (grafana role_attribute_path, gitea --admin-group, harbor
+# oidc_admin_group, openbao group alias) keys on sovereign-admins. The
+# broker's first-broker-login auto-link flow (idp-create-user-if-unique →
+# idp-auto-link, trustEmail=true) links the owner's first SSO login to the
+# pre-seeded user by email match — no prompt, no conflict. Guarded: user
+# renders only when ownerEmail contains "@" (skips empty AND unsubstituted
+# ${SOVEREIGN_OWNER_EMAIL} literals on pre-existing envs). defaultGroups
+# stays /sovereign-viewers only. Render test
+# tests/sovereign-realm-owner-admin-seed.sh.
+version: 1.4.24
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -988,7 +988,67 @@ data:
           }
         }
       ],
+      {{- /*
+      Owner is admin-by-default (founder NS-3, #3263).
+
+      Live measurement hw130 (2026-06-12): the deployment owner
+      (ownerEmail) lands 1/5 admin — grafana maps to Viewer, gitea /admin
+      Forbidden, harbor has no Administration nav — because the
+      catalyst-pin broker's `idp-create-user-if-unique` creates the owner
+      with ZERO group memberships on first SSO login. The handover-time
+      `EnsureUser(email, "sovereign-admins")` (auth_handover.go:244) only
+      fires at franchise handover, never on the normal pre-handover PIN
+      walk. Every per-app admin mapping already keys on `sovereign-admins`
+      (grafana role_attribute_path, gitea --admin-group, harbor
+      oidc_admin_group, openbao identity-group alias), so the ONE root
+      fix is seeding the owner into that group at bootstrap, here in the
+      realm import.
+
+      Why a pre-created user is safe with the broker:
+        The catalyst-pin IdP's `first broker login auto link` flow runs
+        idp-create-user-if-unique (sees the email already exists → not
+        unique) and falls through to idp-auto-link, which — with
+        trustEmail=true — links the federated identity to THIS user by
+        email match, no prompt, no SMTP. That is exactly the path the
+        realm already documents for catalyst-api EnsureUser-created
+        users (see the identityProviders comment below). syncMode FORCE
+        only re-syncs mapper-driven profile fields; the realm defines no
+        IdP group mappers, so the seeded memberships persist across
+        logins.
+
+      Why NOT realm defaultGroups: adding /sovereign-admins to
+      defaultGroups would make EVERY future federated user (any tenant
+      user authenticating into the sovereign realm) a full admin — the
+      default stays /sovereign-viewers only.
+
+      keycloak-config-cli reconciles a managed user's group list to
+      exactly the listed set on every import run, so /sovereign-viewers
+      is listed explicitly (defaultGroups only applies at creation;
+      without it here a later re-import would strip viewer membership).
+      Fields not listed (federatedIdentities, attributes) are left
+      untouched — the broker link survives re-imports.
+
+      Guards: skip when ownerEmail is empty (Catalyst-Zero installs) OR
+      lacks "@" — an env provisioned before the SOVEREIGN_OWNER_EMAIL
+      substitute-map var existed leaves the literal `${SOVEREIGN_OWNER_EMAIL}`
+      in the HR values; the "@" check makes that a no-op instead of a
+      junk user. Lowercased: KC stores usernames/emails lowercase and the
+      broker matches by lowercase email.
+      */ -}}
+      {{- $ownerEmail := lower (trim (default "" .Values.sovereignRealm.ownerEmail)) }}
       "users": [
+        {{- if and $ownerEmail (contains "@" $ownerEmail) }}
+        {
+          "username": {{ $ownerEmail | quote }},
+          "email": {{ $ownerEmail | quote }},
+          "enabled": true,
+          "emailVerified": true,
+          "groups": [
+            "/sovereign-admins",
+            "/sovereign-viewers"
+          ]
+        },
+        {{- end }}
         {
           "username": "service-account-catalyst-api-server",
           "enabled": true,

--- a/platform/keycloak/chart/tests/sovereign-realm-owner-admin-seed.sh
+++ b/platform/keycloak/chart/tests/sovereign-realm-owner-admin-seed.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# bp-keycloak — founder NS-3 (#3263): the deployment OWNER must land in the
+# admin groups at bootstrap, so every per-app mapping keyed on
+# `sovereign-admins` (grafana role_attribute_path → GrafanaAdmin, gitea
+# auth-source --admin-group, harbor oidc_admin_group, openbao identity-group
+# alias) elevates the owner on first SSO login.
+#
+# Root cause this guards against (hw130 live measurement, 2026-06-12):
+#   The catalyst-pin broker's `idp-create-user-if-unique` creates the owner
+#   with ZERO group memberships on first SSO login; the handover-time
+#   EnsureUser(email, "sovereign-admins") only fires at franchise handover.
+#   Result: owner = grafana Viewer, gitea /admin Forbidden, harbor without
+#   the Administration nav. The fix seeds the owner user (with groups) in
+#   the realm import itself — the broker then auto-links by email
+#   (first broker login auto link + trustEmail=true).
+#
+# Invariants locked here:
+#   1. ownerEmail set → realm import contains the owner user with BOTH
+#      /sovereign-admins and /sovereign-viewers groups, enabled +
+#      emailVerified, username == email (lowercased).
+#   2. ownerEmail unset (default) → NO owner user is seeded (only the
+#      catalyst-api-server service account user exists).
+#   3. ownerEmail left as the UNSUBSTITUTED Flux literal
+#      `${SOVEREIGN_OWNER_EMAIL}` (envs provisioned before the
+#      substitute-map var existed) → NO junk user is seeded.
+#   4. realm defaultGroups stays exactly ["/sovereign-viewers"] — making
+#      sovereign-admins a default group would grant admin to EVERY future
+#      federated user.
+#   5. Mixed-case ownerEmail is lowercased (KC stores usernames/emails
+#      lowercase; the broker links by lowercase email match).
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+SOV_FQDN="smoke.omani.works"
+
+extract_realm_json() {
+  python3 -c "
+import yaml, sys
+docs = list(yaml.safe_load_all(sys.stdin))
+for d in docs:
+    if d and d.get('kind') == 'ConfigMap' and 'sovereign-realm-config' in d.get('metadata', {}).get('name', ''):
+        print(d['data']['sovereign-realm.json'])
+        sys.exit(0)
+sys.exit(1)
+"
+}
+
+# ── Case 1: ownerEmail set → owner seeded with admin + viewer groups ──────
+echo "[sovereign-realm-owner-admin-seed] Case 1: ownerEmail set seeds owner into /sovereign-admins (#3263)"
+realm_json=$("$helm" template smoke "$chart_dir" \
+  --set sovereignFQDN="${SOV_FQDN}" \
+  --set sovereignRealm.ownerEmail="emrah.baysal@openova.io" 2>/dev/null | extract_realm_json)
+
+check=$(echo "${realm_json}" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+users = d.get('users', [])
+owner = next((u for u in users if u.get('username') == 'emrah.baysal@openova.io'), None)
+if owner is None:
+    print('OWNER-MISSING:' + ','.join(u.get('username','?') for u in users)); sys.exit(0)
+if owner.get('email') != 'emrah.baysal@openova.io':
+    print(f\"BAD-EMAIL:{owner.get('email')}\"); sys.exit(0)
+if owner.get('enabled') is not True:
+    print('NOT-ENABLED'); sys.exit(0)
+if owner.get('emailVerified') is not True:
+    print('NOT-EMAIL-VERIFIED'); sys.exit(0)
+groups = owner.get('groups', [])
+if '/sovereign-admins' not in groups:
+    print(f'MISSING-ADMINS-GROUP:{groups}'); sys.exit(0)
+if '/sovereign-viewers' not in groups:
+    print(f'MISSING-VIEWERS-GROUP:{groups}'); sys.exit(0)
+sa = next((u for u in users if u.get('username') == 'service-account-catalyst-api-server'), None)
+if sa is None:
+    print('SERVICE-ACCOUNT-USER-LOST'); sys.exit(0)
+print('OK')
+")
+if [ "$check" != "OK" ]; then
+  echo "FAIL: owner seed invariant broken: $check" >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 2: ownerEmail unset → no owner user ──────────────────────────────
+echo "[sovereign-realm-owner-admin-seed] Case 2: default (no ownerEmail) seeds no extra user"
+realm_json=$("$helm" template smoke "$chart_dir" \
+  --set sovereignFQDN="${SOV_FQDN}" 2>/dev/null | extract_realm_json)
+
+check=$(echo "${realm_json}" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+users = d.get('users', [])
+names = [u.get('username') for u in users]
+if names != ['service-account-catalyst-api-server']:
+    print(f'UNEXPECTED-USERS:{names}'); sys.exit(0)
+print('OK')
+")
+if [ "$check" != "OK" ]; then
+  echo "FAIL: default render must contain only the service-account user: $check" >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 3: unsubstituted Flux literal → no junk user ─────────────────────
+# A values file (not --set) so the ${...} literal reaches the chart verbatim
+# — exactly the bytes Flux leaves behind on an env provisioned before the
+# SOVEREIGN_OWNER_EMAIL substitute-map var existed.
+echo "[sovereign-realm-owner-admin-seed] Case 3: unsubstituted \${SOVEREIGN_OWNER_EMAIL} literal seeds no junk user"
+literal_values="$(mktemp)"
+trap 'rm -f "${literal_values}"' EXIT
+cat > "${literal_values}" <<'EOF'
+sovereignRealm:
+  ownerEmail: "${SOVEREIGN_OWNER_EMAIL}"
+EOF
+realm_json=$("$helm" template smoke "$chart_dir" \
+  --set sovereignFQDN="${SOV_FQDN}" \
+  --values "${literal_values}" 2>/dev/null | extract_realm_json)
+
+check=$(echo "${realm_json}" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+users = d.get('users', [])
+names = [u.get('username') for u in users]
+if names != ['service-account-catalyst-api-server']:
+    print(f'JUNK-USER-SEEDED:{names}'); sys.exit(0)
+print('OK')
+")
+if [ "$check" != "OK" ]; then
+  echo "FAIL: unsubstituted literal must not seed a user: $check" >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 4: defaultGroups stays viewers-only ──────────────────────────────
+echo "[sovereign-realm-owner-admin-seed] Case 4: defaultGroups stays [/sovereign-viewers] (never sovereign-admins)"
+realm_json=$("$helm" template smoke "$chart_dir" \
+  --set sovereignFQDN="${SOV_FQDN}" \
+  --set sovereignRealm.ownerEmail="emrah.baysal@openova.io" 2>/dev/null | extract_realm_json)
+
+check=$(echo "${realm_json}" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+dg = d.get('defaultGroups', [])
+if dg != ['/sovereign-viewers']:
+    print(f'DEFAULT-GROUPS-DRIFT:{dg}'); sys.exit(0)
+print('OK')
+")
+if [ "$check" != "OK" ]; then
+  echo "FAIL: defaultGroups drifted — every federated user would inherit it: $check" >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 5: mixed-case email is lowercased ────────────────────────────────
+echo "[sovereign-realm-owner-admin-seed] Case 5: mixed-case ownerEmail lowercased for broker email-match"
+realm_json=$("$helm" template smoke "$chart_dir" \
+  --set sovereignFQDN="${SOV_FQDN}" \
+  --set sovereignRealm.ownerEmail="Emrah.Baysal@OpenOva.io" 2>/dev/null | extract_realm_json)
+
+check=$(echo "${realm_json}" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+users = d.get('users', [])
+owner = next((u for u in users if '@' in (u.get('username') or '')), None)
+if owner is None:
+    print('OWNER-MISSING'); sys.exit(0)
+if owner.get('username') != 'emrah.baysal@openova.io' or owner.get('email') != 'emrah.baysal@openova.io':
+    print(f\"NOT-LOWERCASED:{owner.get('username')}/{owner.get('email')}\"); sys.exit(0)
+print('OK')
+")
+if [ "$check" != "OK" ]; then
+  echo "FAIL: mixed-case email must be lowercased: $check" >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[bp-keycloak #3263 owner-admin-seed] All cases PASS"

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -76,9 +76,29 @@ sso:
 # MUST set this to their tenant short-name. Matrix tests assert paths like
 # `/admin/realms/{name}/...` so the value must match the operator's tenant
 # convention.
+# sovereignRealm.ownerEmail: the deployment owner's email (the Sovereign's
+# `orgEmail`, e.g. emrah.baysal@openova.io). When set, the realm import seeds
+# this user into the `/sovereign-admins` + `/sovereign-viewers` groups so the
+# owner is admin-by-default across every SSO-consuming app (founder NS-3,
+# #3263): grafana (role_attribute_path → GrafanaAdmin), gitea (auth-source
+# --admin-group), harbor (oidc_admin_group), openbao (external identity-group
+# alias). The catalyst-pin broker's `first broker login auto link` flow
+# (idp-create-user-if-unique → idp-auto-link, trustEmail=true) auto-links the
+# owner's first SSO login to this pre-seeded user by email match — the SAME
+# linking path the post-handover catalyst-api EnsureUser-created users take,
+# so pre-seeding is provably safe by the realm's own design.
+#
+# Supplied per-Sovereign by the bootstrap-kit overlay via the
+# ${SOVEREIGN_OWNER_EMAIL} Flux substitution (cloud-init threads tofu's
+# org_email into the bootstrap-kit Kustomization substitute map). Empty
+# default = no user seeded (Catalyst-Zero / non-Sovereign installs).
+# The template additionally requires the value to contain "@" so an
+# UNSUBSTITUTED literal `${SOVEREIGN_OWNER_EMAIL}` (envs provisioned before
+# the substitute-map var existed) can never create a junk user.
 sovereignRealm:
   enabled: true
   name: "sovereign"
+  ownerEmail: ""
 
 # catalystApiServerClientSecret: the client secret for the catalyst-api-server
 # confidential client in the sovereign realm.


### PR DESCRIPTION
Refs #3263

## Founder-DoD (verbatim)

> "each external facing application is SSO logged in... emrah.baysal is able to administrate the apps by default — prove surfing in the admin panels."

Live measurement hw130 (2026-06-12): **1/5** — grafana maps the owner to Viewer, gitea authenticates but `/admin` is Forbidden, harbor shows no Administration nav, openbao ☑, pdns-admin untested-as-admin.

## Root cause (one root, investigated)

The owner user is created in the KC `sovereign` realm by the **catalyst-pin broker** on first SSO login via `idp-create-user-if-unique` — **with zero group memberships**. The only code path that puts anyone into `sovereign-admins` is `EnsureUser(email, "sovereign-admins")` at `products/catalyst/bootstrap/api/internal/handler/auth_handover.go:244` — and `/auth/handover` fires only at franchise handover, never on the normal pre-handover walk. Meanwhile every per-app admin mapping already keys on `sovereign-admins`:

- gitea: `gitea admin auth add-oauth/update-oauth --group-claim-name groups --admin-group sovereign-admins` (`platform/gitea/chart/templates/sso-configure-oauth-job.yaml`)
- harbor: `oidc_admin_group: sovereign-admins` via PUT `/api/v2.0/configurations` (`platform/harbor/chart/templates/sso-configure-oauth-job.yaml`)
- openbao: external identity-group alias `sovereign-admins → sso-operator-admin` (`platform/openbao/chart/templates/sso-configure-deployment.yaml`)
- grafana: `role_attribute_path` keyed on `sovereign-admins`

So the one-root fix is **seeding the owner into `sovereign-admins` at bootstrap, in the realm import itself**.

## What this PR ships

### 1. bp-keycloak `1.4.24` — owner seeded in the sovereign-realm import
`platform/keycloak/chart/templates/configmap-sovereign-realm.yaml` adds the owner user (`username`/`email` = lowercased `sovereignRealm.ownerEmail`, `enabled`, `emailVerified`) with groups `/sovereign-admins` + `/sovereign-viewers` to the keycloak-config-cli import.

**Why pre-creating the user before the broker link is provably safe here**: the catalyst-pin IdP's `first broker login auto link` flow is `idp-create-user-if-unique → idp-auto-link` with `trustEmail=true`. A pre-existing user with the same email makes create-if-unique fall through to **idp-auto-link**, which links the federated identity by email match with no prompt and no SMTP — this is the exact path the realm already documents for post-handover `EnsureUser`-created users. `syncMode: FORCE` only re-syncs mapper-driven profile fields and the realm defines no IdP group mappers, so the seeded memberships persist. The **default-group alternative was rejected**: putting `/sovereign-admins` in realm `defaultGroups` would grant admin to every future federated user (tenant users included). `defaultGroups` stays `["/sovereign-viewers"]` — locked by a render test.

`/sovereign-viewers` is listed explicitly because keycloak-config-cli reconciles a managed user's group list to exactly the listed set on re-import (defaultGroups only applies at creation).

### 2. Value plumbing — tofu `org_email` → Flux substitution → chart
- `infra/providers/_shared/cloudinit-control-plane.tftpl`: adds `SOVEREIGN_OWNER_EMAIL: "${org_email}"` to the bootstrap-kit Kustomization `postBuild.substitute` map (shared template — identical for both providers; `scripts/lint-cloudinit.sh both` PASS).
- `clusters/_template/bootstrap-kit/09-keycloak.yaml`: `sovereignRealm.ownerEmail: "${SOVEREIGN_OWNER_EMAIL}"` + pin `1.4.24`.
- **Guard**: the chart renders the user only when ownerEmail contains `@`. On an env provisioned before the substitute var existed, Flux leaves the literal `${SOVEREIGN_OWNER_EMAIL}` in the HR values — the guard turns that into a clean no-op instead of a junk user or render failure.

### 3. bp-grafana `1.0.10` — `sovereign-admins` ⇒ GrafanaAdmin
- `role_attribute_path: "contains(groups[*], 'sovereign-admins') && 'GrafanaAdmin' || 'Viewer'"`
- `allow_assign_grafana_admin: true` — required; without it Grafana degrades a `GrafanaAdmin` mapping result to org-level Admin and the Administration nav never appears. Role re-evaluates from the groups claim on every OAuth login (no `skip_org_role_sync`).

### 4. gitea + harbor + openbao — verified, no chart change needed
- **gitea** (chart `10.5.0` ships gitea 1.22.x): the supported mechanism is per-auth-source group-claim mapping — `--group-claim-name`, `--admin-group`, `--restricted-group` on `gitea admin auth add-oauth/update-oauth`, supported since gitea 1.19 (go-gitea/gitea#21342; gitea 1.22 docs: Administration → Command Line → `admin auth update-oauth`, and Usage → Authentication → OAuth2/OIDC group claims). The chart's sso-configure Job already passes `--admin-group sovereign-admins`; the admin flag syncs from the `groups` claim **on every login**. There is no `[oauth2_client] ENABLE_GROUP_MAPPING` ini knob — the per-source CLI flags are the mechanism. The realm's `groups` client scope is in gitea's `defaultClientScopes` with id_token + userinfo emission, so the claim is present.
- **harbor**: `oidc_admin_group=sovereign-admins` already PUT on every reconcile; group evaluated at OIDC login.
- **openbao**: identity-group alias on `sovereign-admins` already binds `sso-operator-admin` (hw130 measured ☑).

### 5. Lockstep + tests
- Chart bumps: bp-keycloak `1.4.23 → 1.4.24`, bp-grafana `1.0.9 → 1.0.10`; slot pins 09 + 25 updated; `blueprint.yaml` `spec.version` locksteps included. `scripts/check-bootstrap-kit-pin-sync.sh` PASS (60 pairs).
- New render tests: `platform/keycloak/chart/tests/sovereign-realm-owner-admin-seed.sh` (owner seeded with both groups; default render seeds nothing; unsubstituted literal seeds nothing; defaultGroups stays viewers-only; mixed-case lowercased) + `platform/grafana/chart/tests/sso-admin-role-mapping.sh` (GrafanaAdmin mapping + allow_assign_grafana_admin). All PASS.
- Existing realm render tests (federated-no-required-actions, tier1/tier2 SSO clients, oidc-kubectl-client) PASS; grafana httproute + g115 tests PASS; `helm lint` clean on both charts.

## Which apps elevate after rollout, and how

| App | Elevates? | What it takes |
|---|---|---|
| gitea | ✅ site admin | chart roll re-runs config-cli realm import (seeds group) → owner **re-logins** (admin flag syncs from groups claim at each login) |
| harbor | ✅ system admin (Administration nav) | re-login (oidc_admin_group evaluated at login); no config-job change needed |
| grafana | ✅ server admin (GrafanaAdmin) | bp-grafana 1.0.10 roll (grafana.ini change restarts pod) + re-login |
| openbao | ✅ already admin via group alias; group membership now actually present | re-login (fresh OIDC token carries the group) |
| pdns-admin | ⚠️ not elevated by this PR | see caveats |

## Honest caveats

1. **Existing envs (hw130 etc.) do not get the seed automatically.** The `SOVEREIGN_OWNER_EMAIL` substitute lives in the bootstrap-kit Kustomization rendered by cloud-init at prov time; on already-provisioned envs Flux keeps the old substitute map, the literal stays unsubstituted, and the chart guard no-ops. Full proof needs a **fresh prov** (or a one-line operator patch adding `SOVEREIGN_OWNER_EMAIL` to the live `bootstrap-kit` Kustomization's `spec.postBuild.substitute`, after which the next bp-keycloak reconcile seeds the owner — documented here, not hand-applied, per zero-touch).
2. **pdns-admin**: the chart carries `sso.adminGroup: sovereign-admins` but **no template consumes it** — PowerDNS-Admin's OIDC integration has no group→role mapping the chart wires today. Elevating the owner there needs a dedicated mechanism (e.g. an admin-API post-configure job); kept off this PR to hold the one-root scope.
3. **keycloak-config-cli reconciles the seeded user's group list** on every realm re-import: groups manually added to the owner outside the import would be reverted to the listed pair. Operators extending the owner's groups should do it via chart values/overlay.
4. The seed covers the **owner** (deployment `orgEmail`) only — additional admins still go through the console/UserAccess path; that path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)