### PR TITLE
feat(bootstrap-kit): re-home loki/mimir/tempo into the mgmt vCluster (NS-1 #2745)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -990,7 +990,10 @@ spec:
       # admit real cloud codes (kom4dc digits) — unblocks the
       # production Continuum seed (slot 16b, cnpg-pair 0.2.3).
       # 1.4.587: cnpg list RBAC for the many-to-many instances endpoint (#3188).
-      version: 1.4.590
+      # 1.4.591 — #2745 (2026-06-12): loki/mimir/tempo → mgmt vCluster;
+      # CATALYST_MIMIR_URL re-pointed at the synced host Service + baseline
+      # CNP egress allowlist gains `mgmt`.
+      version: 1.4.591
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/22-loki.yaml
+++ b/clusters/_template/bootstrap-kit/22-loki.yaml
@@ -8,7 +8,38 @@
 # Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
 #                 bp-seaweedfs is Ready (Loki chunks/index live on S3).
 #
+# ── #2745 MGMT vCluster placement (NS-1 founder DoD) ─────────────────
+# "Each application must be in a vCluster (dmz/mgmt/rtz) unless there
+# is a very valid exceptional reason." The 18-app audit verdicted
+# loki/mimir/tempo PROMOTE-NOW: S3-backed umbrellas, zero CRD/
+# HTTPRoute/hostPath/valuesFrom coupling — none of the G105 #2697
+# revert traps (Gateway-API/ExternalSecret CRD admission, valuesFrom
+# Secret lookups in the HR's own ns) apply.
+#
+# The HR CR lives in host ns `mgmt` (where bp-mgmt-vcluster slot 58
+# exports the vc-mgmt kubeconfig Secret, exportKubeConfig.secret.name).
+# helm-controller resolves spec.kubeConfig.secretRef from the HR's own
+# namespace (Flux v2 SecretReference contract) and installs the chart
+# INSIDE the mgmt vCluster. targetNamespace/storageNamespace = the
+# inner `loki` namespace inside the vCluster (storageNamespace pinned
+# per the hw92 lesson — unpinned it defaults to the HR's own ns `mgmt`,
+# which createNamespace never creates inside the vCluster →
+# `namespaces "mgmt" not found` install failure; bp-coraza hit this).
+#
+# Host-side consumers re-point to the syncer-mangled Service name
+# `loki-x-loki-x-mgmt-vcluster.mgmt.svc.cluster.local:3100` (vCluster
+# sync.toHost.services; suffix = the vCluster instance name, i.e. the
+# slot-58 releaseName `mgmt-vcluster` — same convention as the
+# nats-jetstream/keycloak G92.2 entries in products/catalyst values).
+# In-vCluster consumers keep the plain `loki.loki.svc` name.
+# bp-grafana 1.0.11 datasources updated in lockstep (this PR); when
+# grafana itself promotes into mgmt (audit Phase-2) its datasources
+# revert to the plain names.
+#
 # dependsOn:
+#   - bp-mgmt-vcluster (slot 58) — the vc-mgmt Secret doesn't exist
+#     until that HR is Ready; the kubeConfig pivot dangles without it.
+#     Cross-ns dependsOn requires explicit `namespace:`.
 #   - bp-seaweedfs (slot 18) — Loki uses SeaweedFS S3 for chunks and
 #     index storage. Without SeaweedFS Ready, Loki cannot persist logs.
 #
@@ -18,13 +49,6 @@
 # Helm `--wait` would block waiting for the StatefulSet rollout, which
 # the HelmRelease cannot influence.
 
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: loki
-  labels:
-    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -42,16 +66,41 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-loki
-  namespace: flux-system
+  # #2745: HR lives in host ns `mgmt` (where bp-mgmt-vcluster exports
+  # the vc-mgmt Secret). helm-controller authenticates against the
+  # vCluster apiserver and installs the chart inside the vCluster.
+  namespace: mgmt
   labels:
     catalyst.openova.io/slot: "22"
+    catalyst.openova.io/vcluster: mgmt
 spec:
   interval: 15m
   timeout: 15m
   releaseName: loki
+  # targetNamespace = inner namespace INSIDE the mgmt vCluster. Kept at
+  # `loki` so in-vCluster consumers keep the canonical loki.loki.svc name.
   targetNamespace: loki
+  # hw92 lesson (bp-coraza): pin storageNamespace = targetNamespace,
+  # else helm-controller defaults it to the HR's own namespace (`mgmt`)
+  # and fails `namespaces "mgmt" not found` storing the release inside
+  # the vCluster (createNamespace only creates the target `loki`).
+  storageNamespace: loki
+  # vCluster pivot — helm-controller installs the chart inside the
+  # mgmt vCluster (Flux v2 HelmRelease v2 contract). #2745.
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   dependsOn:
+    # #2745: bp-mgmt-vcluster MUST be Ready before this HR tries to
+    # install — the vc-mgmt Secret doesn't exist until then. Cross-ns
+    # dependsOn requires explicit `namespace:`.
+    - name: bp-mgmt-vcluster
+      namespace: flux-system
+    # #2745: explicit namespace — a bare `name:` resolves in THIS HR's
+    # namespace (now `mgmt`) → dangling dep → wedge (#3191 shape).
     - name: bp-seaweedfs
+      namespace: flux-system
   chart:
     spec:
       chart: bp-loki
@@ -61,6 +110,10 @@ spec:
         name: bp-loki
         namespace: flux-system
   install:
+    # #2745: createNamespace=true so helm-controller provisions the
+    # inner `loki` namespace inside the mgmt vCluster on first install
+    # (the host-side Namespace YAML was dropped with this pivot).
+    createNamespace: true
     timeout: 15m
     disableWait: true
     remediation:

--- a/clusters/_template/bootstrap-kit/23-mimir.yaml
+++ b/clusters/_template/bootstrap-kit/23-mimir.yaml
@@ -6,7 +6,40 @@
 # Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
 #                 bp-seaweedfs is Ready (Mimir blocks live on S3).
 #
+# ── #2745 MGMT vCluster placement (NS-1 founder DoD) ─────────────────
+# "Each application must be in a vCluster (dmz/mgmt/rtz) unless there
+# is a very valid exceptional reason." The 18-app audit verdicted
+# loki/mimir/tempo PROMOTE-NOW: S3-backed umbrellas, zero CRD/
+# HTTPRoute/hostPath/valuesFrom coupling — none of the G105 #2697
+# revert traps (Gateway-API/ExternalSecret CRD admission, valuesFrom
+# Secret lookups in the HR's own ns) apply. The chart's webhook-gate
+# hook + rollout-operator register against the VCLUSTER apiserver —
+# self-contained, no host admission coupling.
+#
+# The HR CR lives in host ns `mgmt` (where bp-mgmt-vcluster slot 58
+# exports the vc-mgmt kubeconfig Secret, exportKubeConfig.secret.name).
+# helm-controller resolves spec.kubeConfig.secretRef from the HR's own
+# namespace (Flux v2 SecretReference contract) and installs the chart
+# INSIDE the mgmt vCluster. targetNamespace/storageNamespace = the
+# inner `mimir` namespace inside the vCluster (storageNamespace pinned
+# per the hw92 lesson — unpinned it defaults to the HR's own ns `mgmt`,
+# which createNamespace never creates inside the vCluster →
+# `namespaces "mgmt" not found` install failure; bp-coraza hit this).
+#
+# Host-side consumers re-point to the syncer-mangled Service names
+# (vCluster sync.toHost.services; suffix = the vCluster instance name,
+# i.e. the slot-58 releaseName `mgmt-vcluster`):
+#   query API:    mimir-nginx-x-mimir-x-mgmt-vcluster.mgmt.svc:80
+#   query-frontend: mimir-query-frontend-x-mimir-x-mgmt-vcluster.mgmt.svc:8080
+# Updated in lockstep in this PR: bp-grafana 1.0.11 prometheus
+# datasource + bp-catalyst-platform 1.4.591 CATALYST_MIMIR_URL +
+# baseline-catalyst-system CNP egress ns allowlist (+ `mgmt`).
+# In-vCluster consumers keep the plain `*.mimir.svc` names.
+#
 # dependsOn:
+#   - bp-mgmt-vcluster (slot 58) — the vc-mgmt Secret doesn't exist
+#     until that HR is Ready; the kubeConfig pivot dangles without it.
+#     Cross-ns dependsOn requires explicit `namespace:`.
 #   - bp-seaweedfs (slot 18) — Mimir blocks-storage uses SeaweedFS S3.
 #     Without SeaweedFS Ready, Mimir compactor/ingester StatefulSets
 #     cannot persist metric blocks.
@@ -18,13 +51,6 @@
 # Ready when manifests apply; runtime convergence is observed via
 # kubectl rollout status.
 
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: mimir
-  labels:
-    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -42,16 +68,41 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-mimir
-  namespace: flux-system
+  # #2745: HR lives in host ns `mgmt` (where bp-mgmt-vcluster exports
+  # the vc-mgmt Secret). helm-controller authenticates against the
+  # vCluster apiserver and installs the chart inside the vCluster.
+  namespace: mgmt
   labels:
     catalyst.openova.io/slot: "23"
+    catalyst.openova.io/vcluster: mgmt
 spec:
   interval: 15m
   timeout: 15m
   releaseName: mimir
+  # targetNamespace = inner namespace INSIDE the mgmt vCluster. Kept at
+  # `mimir` so in-vCluster consumers keep the canonical *.mimir.svc names.
   targetNamespace: mimir
+  # hw92 lesson (bp-coraza): pin storageNamespace = targetNamespace,
+  # else helm-controller defaults it to the HR's own namespace (`mgmt`)
+  # and fails `namespaces "mgmt" not found` storing the release inside
+  # the vCluster (createNamespace only creates the target `mimir`).
+  storageNamespace: mimir
+  # vCluster pivot — helm-controller installs the chart inside the
+  # mgmt vCluster (Flux v2 HelmRelease v2 contract). #2745.
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   dependsOn:
+    # #2745: bp-mgmt-vcluster MUST be Ready before this HR tries to
+    # install — the vc-mgmt Secret doesn't exist until then. Cross-ns
+    # dependsOn requires explicit `namespace:`.
+    - name: bp-mgmt-vcluster
+      namespace: flux-system
+    # #2745: explicit namespace — a bare `name:` resolves in THIS HR's
+    # namespace (now `mgmt`) → dangling dep → wedge (#3191 shape).
     - name: bp-seaweedfs
+      namespace: flux-system
   chart:
     spec:
       chart: bp-mimir
@@ -61,6 +112,10 @@ spec:
         name: bp-mimir
         namespace: flux-system
   install:
+    # #2745: createNamespace=true so helm-controller provisions the
+    # inner `mimir` namespace inside the mgmt vCluster on first install
+    # (the host-side Namespace YAML was dropped with this pivot).
+    createNamespace: true
     timeout: 15m
     disableWait: true
     remediation:

--- a/clusters/_template/bootstrap-kit/24-tempo.yaml
+++ b/clusters/_template/bootstrap-kit/24-tempo.yaml
@@ -7,7 +7,36 @@
 # Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
 #                 bp-seaweedfs is Ready (Tempo trace blocks live on S3).
 #
+# ── #2745 MGMT vCluster placement (NS-1 founder DoD) ─────────────────
+# "Each application must be in a vCluster (dmz/mgmt/rtz) unless there
+# is a very valid exceptional reason." The 18-app audit verdicted
+# loki/mimir/tempo PROMOTE-NOW: S3-backed umbrellas, zero CRD/
+# HTTPRoute/hostPath/valuesFrom coupling — none of the G105 #2697
+# revert traps (Gateway-API/ExternalSecret CRD admission, valuesFrom
+# Secret lookups in the HR's own ns) apply.
+#
+# The HR CR lives in host ns `mgmt` (where bp-mgmt-vcluster slot 58
+# exports the vc-mgmt kubeconfig Secret, exportKubeConfig.secret.name).
+# helm-controller resolves spec.kubeConfig.secretRef from the HR's own
+# namespace (Flux v2 SecretReference contract) and installs the chart
+# INSIDE the mgmt vCluster. targetNamespace/storageNamespace = the
+# inner `tempo` namespace inside the vCluster (storageNamespace pinned
+# per the hw92 lesson — unpinned it defaults to the HR's own ns `mgmt`,
+# which createNamespace never creates inside the vCluster →
+# `namespaces "mgmt" not found` install failure; bp-coraza hit this).
+#
+# Host-side consumers re-point to the syncer-mangled Service name
+# `tempo-x-tempo-x-mgmt-vcluster.mgmt.svc.cluster.local:3200` (vCluster
+# sync.toHost.services; suffix = the vCluster instance name, i.e. the
+# slot-58 releaseName `mgmt-vcluster`). In-vCluster consumers keep the
+# plain `tempo.tempo.svc` name. bp-grafana 1.0.11 datasources updated
+# in lockstep (this PR); when grafana itself promotes into mgmt (audit
+# Phase-2) its datasources revert to the plain names.
+#
 # dependsOn:
+#   - bp-mgmt-vcluster (slot 58) — the vc-mgmt Secret doesn't exist
+#     until that HR is Ready; the kubeConfig pivot dangles without it.
+#     Cross-ns dependsOn requires explicit `namespace:`.
 #   - bp-seaweedfs (slot 18) — Tempo blocks live on SeaweedFS S3.
 #     Without SeaweedFS Ready, Tempo cannot persist spans.
 #
@@ -16,13 +45,6 @@
 # bp-seaweedfs to be fully reconciled. Helm `--wait` would block on
 # the rollout, which the HelmRelease cannot influence.
 
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: tempo
-  labels:
-    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -40,16 +62,41 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-tempo
-  namespace: flux-system
+  # #2745: HR lives in host ns `mgmt` (where bp-mgmt-vcluster exports
+  # the vc-mgmt Secret). helm-controller authenticates against the
+  # vCluster apiserver and installs the chart inside the vCluster.
+  namespace: mgmt
   labels:
     catalyst.openova.io/slot: "24"
+    catalyst.openova.io/vcluster: mgmt
 spec:
   interval: 15m
   timeout: 15m
   releaseName: tempo
+  # targetNamespace = inner namespace INSIDE the mgmt vCluster. Kept at
+  # `tempo` so in-vCluster consumers keep the canonical tempo.tempo.svc name.
   targetNamespace: tempo
+  # hw92 lesson (bp-coraza): pin storageNamespace = targetNamespace,
+  # else helm-controller defaults it to the HR's own namespace (`mgmt`)
+  # and fails `namespaces "mgmt" not found` storing the release inside
+  # the vCluster (createNamespace only creates the target `tempo`).
+  storageNamespace: tempo
+  # vCluster pivot — helm-controller installs the chart inside the
+  # mgmt vCluster (Flux v2 HelmRelease v2 contract). #2745.
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   dependsOn:
+    # #2745: bp-mgmt-vcluster MUST be Ready before this HR tries to
+    # install — the vc-mgmt Secret doesn't exist until then. Cross-ns
+    # dependsOn requires explicit `namespace:`.
+    - name: bp-mgmt-vcluster
+      namespace: flux-system
+    # #2745: explicit namespace — a bare `name:` resolves in THIS HR's
+    # namespace (now `mgmt`) → dangling dep → wedge (#3191 shape).
     - name: bp-seaweedfs
+      namespace: flux-system
   chart:
     spec:
       chart: bp-tempo
@@ -59,6 +106,10 @@ spec:
         name: bp-tempo
         namespace: flux-system
   install:
+    # #2745: createNamespace=true so helm-controller provisions the
+    # inner `tempo` namespace inside the mgmt vCluster on first install
+    # (the host-side Namespace YAML was dropped with this pivot).
+    createNamespace: true
     timeout: 15m
     disableWait: true
     remediation:

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -55,9 +55,17 @@ spec:
   targetNamespace: grafana
   dependsOn:
     - name: bp-cnpg
+    # #2745 (2026-06-12): bp-loki/bp-mimir/bp-tempo HRs re-homed to host
+    # ns `mgmt` (mgmt vCluster placement). A bare `name:` resolves in
+    # THIS HR's namespace (flux-system) → dangling dep → grafana wedges
+    # forever (#3191 shape). Cross-ns dependsOn requires explicit
+    # `namespace:`.
     - name: bp-loki
+      namespace: mgmt
     - name: bp-mimir
+      namespace: mgmt
     - name: bp-tempo
+      namespace: mgmt
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template;
@@ -72,7 +80,10 @@ spec:
       # GrafanaAdmin (server admin) + allow_assign_grafana_admin=true, so
       # the owner — seeded into sovereign-admins by bp-keycloak 1.4.24 —
       # gets the full Administration nav, not org-Viewer.
-      version: 1.0.10
+      # 1.0.11 (#2745, 2026-06-12): loki/mimir/tempo re-homed into the
+      # mgmt vCluster — datasource URLs re-pointed at the syncer-mangled
+      # host-side Service names (<svc>-x-<ns>-x-mgmt-vcluster.mgmt.svc).
+      version: 1.0.11
       sourceRef:
         kind: HelmRepository
         name: bp-grafana

--- a/platform/grafana/blueprint.yaml
+++ b/platform/grafana/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.0.10
+  version: 1.0.11
   card:
     title: Grafana
     family: insights

--- a/platform/grafana/chart/Chart.yaml
+++ b/platform/grafana/chart/Chart.yaml
@@ -48,7 +48,15 @@ type: application
 # via the bp-keycloak 1.4.24 realm-import seed; the role re-evaluates from
 # the groups claim on every OAuth login. Render test
 # tests/sso-admin-role-mapping.sh.
-version: 1.0.10
+# 1.0.11 (#2745, 2026-06-12): bp-loki/bp-mimir/bp-tempo re-homed INSIDE
+# the mgmt vCluster (NS-1 founder DoD, audit PROMOTE-NOW). Grafana runs
+# host-side, so the three default datasource URLs re-point at the
+# host-visible syncer-mangled Service names
+# (<svc>-x-<inner-ns>-x-mgmt-vcluster.mgmt.svc.cluster.local). Reverts
+# to plain in-vCluster names when grafana itself promotes (audit
+# Phase-2). Lockstep with bootstrap-kit slots 22/23/24 + bp-catalyst-
+# platform 1.4.591 (CATALYST_MIMIR_URL + baseline CNP).
+version: 1.0.11
 appVersion: "12.3.1"
 # 1.0.4 (G91.grafana #2658, 2026-05-31): opt in to the bp-sso-bridge
 # (G91.1 #2652) SSO framework. Top-level `sso:` block (defaults

--- a/platform/grafana/chart/values.yaml
+++ b/platform/grafana/chart/values.yaml
@@ -288,6 +288,19 @@ gateway:
 # (releaseName + targetNamespace) in clusters/_template/bootstrap-kit/
 # 22-loki.yaml, 23-mimir.yaml, 24-tempo.yaml. Multi-cluster federation
 # overlays MAY point at a regional aggregator instead.
+#
+# #2745 (2026-06-12): bp-loki/bp-mimir/bp-tempo are re-homed INSIDE the
+# mgmt vCluster (NS-1 founder DoD). Grafana itself still runs host-side
+# (audit Phase-2 candidate), so these defaults point at the host-visible
+# syncer-mangled Service names the bp-mgmt-vcluster
+# sync.toHost.services reflector creates:
+#   <svc>-x-<inner-ns>-x-mgmt-vcluster.<host-ns mgmt>.svc.cluster.local
+# (suffix = the vCluster instance name = slot-58 releaseName
+# `mgmt-vcluster` — same convention as the nats-jetstream/keycloak
+# G92.2 entries in products/catalyst values). When grafana promotes
+# into the mgmt vCluster (audit Phase-2) these revert to the plain
+# in-vCluster names (loki.loki.svc / mimir-nginx.mimir.svc /
+# tempo.tempo.svc) via overlay or follow-up bump.
 observabilityStack:
   enabled: true
   # Custom sidecar discovery label override (mirrors
@@ -299,24 +312,27 @@ observabilityStack:
     prometheus:
       enabled: true
       # bp-mimir 1.0.5+ exposes its query frontend via the
-      # `<release>-mimir-nginx` Service on port 80 in the mimir
-      # namespace. The bootstrap-kit slot 23 wires releaseName=mimir,
-      # targetNamespace=mimir → mimir-nginx.mimir.svc:80.
-      url: "http://mimir-nginx.mimir.svc.cluster.local:80/prometheus"
+      # `<release>-mimir-nginx` Service on port 80 in the (inner) mimir
+      # namespace. #2745: bp-mimir lives inside the mgmt vCluster; the
+      # host-visible synced Service is
+      # mimir-nginx-x-mimir-x-mgmt-vcluster in host ns mgmt.
+      url: "http://mimir-nginx-x-mimir-x-mgmt-vcluster.mgmt.svc.cluster.local:80/prometheus"
       tenantId: anonymous
     loki:
       enabled: true
       # bp-loki 1.0.0 single-binary chart Service name is `<release>`
       # (no -gateway suffix on the simple-deployment values shipped by
-      # bp-loki today). Bootstrap-kit slot 22 wires releaseName=loki,
-      # targetNamespace=loki → loki.loki.svc:3100.
-      url: "http://loki.loki.svc.cluster.local:3100"
+      # bp-loki today). #2745: bp-loki lives inside the mgmt vCluster;
+      # the host-visible synced Service is loki-x-loki-x-mgmt-vcluster
+      # in host ns mgmt.
+      url: "http://loki-x-loki-x-mgmt-vcluster.mgmt.svc.cluster.local:3100"
       tenantId: anonymous
     tempo:
       enabled: true
       # bp-tempo 1.0.0 single-binary chart Service name is `<release>`.
-      # Bootstrap-kit slot 24 wires releaseName=tempo,
-      # targetNamespace=tempo → tempo.tempo.svc:3200 for the query API.
+      # #2745: bp-tempo lives inside the mgmt vCluster; the host-visible
+      # synced Service is tempo-x-tempo-x-mgmt-vcluster in host ns mgmt,
+      # port 3200 for the query API.
       #
       # Port 3200 is the upstream Tempo `http_listen_port` default
       # (grafana/helm-charts tempo-1.24.4 values.yaml `tempo.config`
@@ -326,7 +342,7 @@ observabilityStack:
       # port (also `:3100` in the Loki single-binary chart) and would
       # have produced `Tempo is not responding` in Grafana's datasource
       # health-check on a fresh-prov walk. G117.5a (Refs #2788).
-      url: "http://tempo.tempo.svc.cluster.local:3200"
+      url: "http://tempo-x-tempo-x-mgmt-vcluster.mgmt.svc.cluster.local:3200"
     alertmanager:
       # Default OFF — Mimir's bundled AM and standalone bp-alertmanager
       # are not yet wired in clusters/_template/. Per-Sovereign overlay

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2628,7 +2628,16 @@ name: bp-catalyst-platform
 # flip admin.dns.<sov> → pdns-admin.<sov> (single-level, wildcard-cert-covered,
 # matches the KC client redirectUris) + bp-powerdns-admin 0.1.5 OIDC env-var
 # name fixes. Refs #3150.
-version: 1.4.590
+# 1.4.591 — #2745 (2026-06-12) — loki/mimir/tempo re-homed INSIDE the mgmt
+# vCluster (NS-1 founder DoD, audit PROMOTE-NOW; bootstrap-kit slots
+# 22/23/24 carry the kubeConfig pivot). Two host-side consumer updates in
+# lockstep: (a) CATALYST_MIMIR_URL default in api-deployment{,-kustomize}
+# re-points at the syncer-mangled host Service
+# mimir-query-frontend-x-mimir-x-mgmt-vcluster.mgmt.svc:8080;
+# (b) baseline-catalyst-system CNP allowedPlatformNamespaces gains `mgmt`
+# so catalyst-api egress reaches the synced endpoints (Pods in host ns
+# mgmt). Paired with bp-grafana 1.0.11 datasource re-points. Refs #2745.
+version: 1.4.591
 # 1.4.587 — #3188: cutover-driver ClusterRole gains postgresql.cnpg.io
 #   clusters/databases + dr.openova.io read — the instances endpoint
 #   403'd cluster-wide (hw130: API 0 rows with 7 live clusters).

--- a/products/catalyst/chart/templates/api-deployment-kustomize.yaml
+++ b/products/catalyst/chart/templates/api-deployment-kustomize.yaml
@@ -1405,13 +1405,18 @@ spec:
             # 5-min / 5-second-step Pod sparkline via Prometheus
             # query_range. Empty value disables the mimir path and the
             # Pod metrics handler falls back to metrics-server's single
-            # point. The default literal matches the Service rendered
-            # by bp-mimir: name `mimir-query-frontend`, namespace
-            # `mimir`, port 8080. Per Inviolable Principle #4
-            # per-Sovereign overlays MAY override via `catalystApi.env`
-            # when bp-mimir ships in a different namespace.
+            # point. #2745 (2026-06-12): bp-mimir is re-homed INSIDE the
+            # mgmt vCluster; catalyst-api runs host-side, so the default
+            # is the host-visible syncer-mangled Service the
+            # bp-mgmt-vcluster sync.toHost.services reflector creates:
+            # `mimir-query-frontend-x-mimir-x-mgmt-vcluster` in host ns
+            # `mgmt`, port 8080 (suffix = vCluster instance name =
+            # slot-58 releaseName `mgmt-vcluster`, same convention as
+            # the nats-jetstream entry in values.yaml). Per Inviolable
+            # Principle #4 per-Sovereign overlays MAY override via
+            # `catalystApi.env` when bp-mimir ships elsewhere.
             - name: CATALYST_MIMIR_URL
-              value: "http://mimir-query-frontend.mimir.svc.cluster.local:8080"
+              value: "http://mimir-query-frontend-x-mimir-x-mgmt-vcluster.mgmt.svc.cluster.local:8080"
             # CATALYST_TEST_SESSION_ENABLED — gates POST /api/v1/auth/test-session
             # (qa-loop iter-11 Cluster-A). Default empty/false → endpoint
             # returns 404 to the public, indistinguishable from "this

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -1522,13 +1522,18 @@ spec:
             # 5-min / 5-second-step Pod sparkline via Prometheus
             # query_range. Empty value disables the mimir path and the
             # Pod metrics handler falls back to metrics-server's single
-            # point. The default literal matches the Service rendered
-            # by bp-mimir: name `mimir-query-frontend`, namespace
-            # `mimir`, port 8080. Per Inviolable Principle #4
-            # per-Sovereign overlays MAY override via `catalystApi.env`
-            # when bp-mimir ships in a different namespace.
+            # point. #2745 (2026-06-12): bp-mimir is re-homed INSIDE the
+            # mgmt vCluster; catalyst-api runs host-side, so the default
+            # is the host-visible syncer-mangled Service the
+            # bp-mgmt-vcluster sync.toHost.services reflector creates:
+            # `mimir-query-frontend-x-mimir-x-mgmt-vcluster` in host ns
+            # `mgmt`, port 8080 (suffix = vCluster instance name =
+            # slot-58 releaseName `mgmt-vcluster`, same convention as
+            # the nats-jetstream entry in values.yaml). Per Inviolable
+            # Principle #4 per-Sovereign overlays MAY override via
+            # `catalystApi.env` when bp-mimir ships elsewhere.
             - name: CATALYST_MIMIR_URL
-              value: "http://mimir-query-frontend.mimir.svc.cluster.local:8080"
+              value: "http://mimir-query-frontend-x-mimir-x-mgmt-vcluster.mgmt.svc.cluster.local:8080"
             # CATALYST_TEST_SESSION_ENABLED — gates POST /api/v1/auth/test-session
             # (qa-loop iter-11 Cluster-A). Default empty/false → endpoint
             # returns 404 to the public, indistinguishable from "this

--- a/products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml
+++ b/products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml
@@ -40,7 +40,10 @@ This template renders TWO CiliumNetworkPolicies:
          (Application gitops pulls), powerdns (DNS record CRUD),
          cnpg-system (smePostgres connection), openbao (secrets),
          harbor (registry pulls), nats-system (event bus),
-         observability (loki/mimir/tempo/alloy).
+         observability (loki/mimir/tempo/alloy), mgmt (#2745 —
+         loki/mimir/tempo run INSIDE the mgmt vCluster; their
+         host-side synced Service endpoints are Pods in host ns
+         `mgmt`, e.g. the CATALYST_MIMIR_URL query-frontend).
      Anything else is dropped. This is the "namespaced CNP only"
      posture the issue prescribed — no CiliumClusterwideNetworkPolicy.
 
@@ -70,7 +73,12 @@ unconditionally on every Sovereign and protects catalyst-system even
 when qaFixtures is disabled.
 */}}
 {{- if .Values.security.baselineCnp.enabled }}
-{{- $allowedPlatform := .Values.security.baselineCnp.allowedPlatformNamespaces | default (list "keycloak" "gitea" "powerdns" "cnpg-system" "openbao" "harbor" "nats-system" "loki" "mimir" "tempo" "alloy" "opentelemetry" "external-secrets-system" "cert-manager" "sme" "newapi") }}
+{{- /* #2745: "mgmt" added — loki/mimir/tempo re-homed INSIDE the mgmt
+     vCluster; their synced host-side endpoints (the Pods backing
+     <svc>-x-<ns>-x-mgmt-vcluster Services) live in host ns `mgmt`.
+     The plain loki/mimir/tempo entries stay for Sovereigns that keep
+     the host-side placement via per-Sovereign overlay. */}}
+{{- $allowedPlatform := .Values.security.baselineCnp.allowedPlatformNamespaces | default (list "keycloak" "gitea" "powerdns" "cnpg-system" "openbao" "harbor" "nats-system" "loki" "mimir" "tempo" "alloy" "opentelemetry" "external-secrets-system" "cert-manager" "sme" "newapi" "mgmt") }}
 {{- $allowedIngressNs := .Values.security.baselineCnp.allowedIngressNamespaces | default (list "catalyst" "flux-system" "kube-system") }}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1774,9 +1774,17 @@ security:
       - openbao
       - harbor
       - nats-system
+      # #2745 (2026-06-12): loki/mimir/tempo run INSIDE the mgmt
+      # vCluster; their host-side synced Service endpoints
+      # (<svc>-x-<ns>-x-mgmt-vcluster) are Pods in host ns `mgmt` —
+      # the `mgmt` entry below carries that traffic (e.g. the
+      # CATALYST_MIMIR_URL query-frontend). The plain loki/mimir/tempo
+      # entries stay for Sovereigns that keep host-side placement via
+      # per-Sovereign overlay.
       - loki
       - mimir
       - tempo
+      - mgmt
       - alloy
       - opentelemetry
       - external-secrets-system

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -527,7 +527,7 @@ controllers:
       # (2026-06-02). enabled remains false until the bp-controller
       # surfaces are wired end-to-end; the pin matches the latest
       # successful push-on-main build per Inviolable Principle #4a.
-      tag: "100a213"
+      tag: "c809c11"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -618,7 +618,7 @@ controllers:
       # (#2745, 2026-06-03) — bumped from 8d01e2f (2026-05-31) to the
       # latest useraccess-controller main-HEAD push (2026-06-02).
       # #2851 closed the drift gap (auto-bump + sweep + freshness guard).
-      tag: "dcd2bb3"
+      tag: "82fd636"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -448,7 +448,7 @@ controllers:
       # 405 to the in-cluster SA). 72e3f08 = qa-loop iter-8 Fix #42
       # (#1252 + Containerfile fix-up #1253), fixed Bug 1 (UserAccess
       # Claim namespace).
-      tag: "c363dd1"
+      tag: "82fd636"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -488,7 +488,7 @@ controllers:
       # — adds EnsureBranch before PutFile so Gitea's branch-missing
       # 404 (mapped to ErrRepoNotFound by the client) no longer dead-
       # loops the env-controller.
-      tag: "32050f0"
+      tag: "82fd636"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -560,7 +560,7 @@ controllers:
       # — drops cross-namespace ownerRef on the host-side Flux CRs
       # (was being silently GC'd by the K8s collector because
       # Application lives in a different namespace from flux-system).
-      tag: "44dedf2"
+      tag: "82fd636"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -291,17 +291,22 @@ slots:
     name: bp-alloy
     depends_on: [bp-opentelemetry]
     wave: W2.K2
+  # #2745 (2026-06-12): loki/mimir/tempo re-homed INSIDE the mgmt
+  # vCluster (NS-1 founder DoD, audit PROMOTE-NOW). Each gains the
+  # bp-mgmt-vcluster edge so the install gates on the vc-mgmt
+  # kubeconfig Secret existing before helm-controller attempts the
+  # kubeConfig pivot (same shape as bp-coraza/bp-dmz-vcluster G92.4).
   - slot: 22
     name: bp-loki
-    depends_on: [bp-seaweedfs]
+    depends_on: [bp-mgmt-vcluster, bp-seaweedfs]
     wave: W2.K2
   - slot: 23
     name: bp-mimir
-    depends_on: [bp-seaweedfs]
+    depends_on: [bp-mgmt-vcluster, bp-seaweedfs]
     wave: W2.K2
   - slot: 24
     name: bp-tempo
-    depends_on: [bp-seaweedfs]
+    depends_on: [bp-mgmt-vcluster, bp-seaweedfs]
     wave: W2.K2
   - slot: 25
     name: bp-grafana


### PR DESCRIPTION
Refs #2745

## What

Re-homes **bp-loki (slot 22), bp-mimir (slot 23), bp-tempo (slot 24)** into the **mgmt vCluster**, per the founder DoD (NS-1 verbatim): *"Each application must be in a vCluster (dmz/mgmt/rtz) unless there is a very valid exceptional reason."* The 18-app audit verdicted all three **PROMOTE-NOW**: S3-backed umbrellas, zero CRD/HTTPRoute/hostPath/valuesFrom coupling — none of the G105 #2697 revert traps (Gateway-API/ExternalSecret CRD admission inside the vCluster, `valuesFrom` Secret lookups in the HR's own ns) apply. Verified by repo grep: none of the three charts ship HTTPRoute / ExternalSecret / SealedSecret / hostPath / valuesFrom.

## Mechanism (the proven G92.4 recipe, PR #3350 shape)

Per slot (22/23/24 identically):

- HR CR moves `flux-system` → host ns `mgmt`, where `bp-mgmt-vcluster` (slot 58) exports the **`vc-mgmt`** kubeconfig Secret (`exportKubeConfig.secret.name: vc-mgmt`, server `https://mgmt-vcluster.mgmt:443`, key `config` — verified in `platform/bp-mgmt-vcluster/chart/values.yaml`). helm-controller resolves `spec.kubeConfig.secretRef` from the HR's own namespace (Flux v2 SecretReference contract).
- `targetNamespace` + `storageNamespace` pinned to the app's inner ns (`loki`/`mimir`/`tempo`) — hw92 lesson: unpinned storageNamespace defaults to the HR's own ns `mgmt`, which `createNamespace` never creates inside the vCluster → `namespaces "mgmt" not found`.
- `install.createNamespace: true`; host-side Namespace YAMLs **dropped** (the inner ns is the vCluster's view).
- `dependsOn` gains `bp-mgmt-vcluster` (`namespace: flux-system`) and the existing `bp-seaweedfs` edge becomes explicit-ns (a bare `name:` would now resolve in ns `mgmt` → dangling dep → the #3191 wedge shape).
- Labels gain `catalyst.openova.io/vcluster: mgmt`.
- vCluster prerequisites verified in `bp-mgmt-vcluster` chart values: `sync.toHost.{services,persistentVolumeClaims,configMaps,secrets}: enabled` — StatefulSet PVCs land on the host provisioner; Services reflect back host-side.

## The consumer map (who references loki/mimir/tempo Service DNS)

Synced-name convention: `<svc>-x-<inner-ns>-x-mgmt-vcluster.mgmt.svc.cluster.local` — suffix is the vCluster **instance** name = slot-58 `releaseName: mgmt-vcluster`, the same convention already used by the nats-jetstream and keycloak G92.2 entries in `products/catalyst/chart/values.yaml` (`nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc...`). All names ≤ 63 chars (longest: `mimir-query-frontend-x-mimir-x-mgmt-vcluster` = 44).

**Changed in this PR (host-side consumers, plain name would break):**

| Consumer | Was | Now |
|---|---|---|
| `platform/grafana/chart/values.yaml` prometheus datasource | `mimir-nginx.mimir.svc:80/prometheus` | `mimir-nginx-x-mimir-x-mgmt-vcluster.mgmt.svc:80/prometheus` |
| same, loki datasource | `loki.loki.svc:3100` | `loki-x-loki-x-mgmt-vcluster.mgmt.svc:3100` |
| same, tempo datasource | `tempo.tempo.svc:3200` | `tempo-x-tempo-x-mgmt-vcluster.mgmt.svc:3200` |
| `products/catalyst` api-deployment{,-kustomize}.yaml `CATALYST_MIMIR_URL` (Pod sparkline query_range) | `mimir-query-frontend.mimir.svc:8080` | `mimir-query-frontend-x-mimir-x-mgmt-vcluster.mgmt.svc:8080` |
| `products/catalyst` baseline-catalyst-system CNP `allowedPlatformNamespaces` (template default AND values.yaml explicit list) | no `mgmt` | gains `mgmt` — the synced Services' backing Pods live in host ns `mgmt`; without it catalyst-api→mimir egress is dropped by its own baseline policy (the #3322 own-paths class) |

Grafana is itself slated for the mgmt vCluster (audit Phase-2) — when it promotes, its datasources revert to the **plain** in-vCluster names (`loki.loki.svc` etc.); comments at each URL say exactly that.

**Audited, intentionally NOT changed (with reasons):**

- `platform/mimir/chart/templates/webhook-gate-hook.yaml` (`mimir-rollout-operator.mimir.svc:443`) — in-vCluster self-reference; plain name stays correct inside the vCluster; the webhook registers against the VCLUSTER apiserver (self-contained).
- `platform/alloy` — `alloy.configMap.content` is **empty by default** (no forwarder shipped); host-side per-Sovereign overlays that populate it must use the synced names; in-vCluster overlays (if alloy later promotes) use plain names.
- `platform/opentelemetry` — exporters bundled but no default LGTM endpoints configured in our wrapper; same overlay rule as alloy.
- `platform/vpa` — `extraArgs: {}` default; mimir mention is comment-only.
- `platform/network-policies` (slot 26, **gated `enabled: false`** per #3201) — its system-ns allowlist contains `loki`/`mimir`/`tempo` entries that become inert (host namespaces no longer exist). Untouched to avoid bumping a gated chart; flagged for the dedicated validation prov that re-enables slot 26.
- `infra/providers/_shared/cloudinit-control-plane.tftpl` reflector allow/auto-namespace annotations — `loki,mimir,tempo` entries become inert; `mgmt` is already present; cloud-init untouched (Phase-1 budget risk for zero functional gain).
- `products/catalyst` qa-fixtures `cilium-network-policies.yaml` — qa-omantel matrix bundle; LGTM ns entries become inert; revisit when the QA matrix is re-walked.
- `products/catalyst/bootstrap/api/cmd/api/main.go:399` Go fallback default — dead in production (the chart always sets `CATALYST_MIMIR_URL`); left unchanged so this stays a chart-only PR with no catalyst-api image rebuild.
- `products/sandbox` `sandbox_storage.go` — references the `loki-data` S3 **bucket** name on SeaweedFS (host-side), not Service DNS; unaffected.
- catalog-seed `blueprints.yaml`, `core/services/catalog/handlers/seed.go`, console UI `.ts` constants, Chart descriptions — cosmetic text/tags, no Service DNS (verified by `svc.cluster.local` grep).
- `clusters/omantel.omani.works/bootstrap-kit/` — already-divergent point-in-time copy, intentionally not touched (template is canonical; same call as PR #3350).

## Validation

- `bash scripts/check-bootstrap-deps.sh` → **drift 0, cycles 0, PASSED** (slots 22/23/24 gain the `bp-mgmt-vcluster` edge in `scripts/expected-bootstrap-deps.yaml`, lockstep).
- `kubectl kustomize clusters/_template/bootstrap-kit` renders; the three HRs show `ns: mgmt`, `target/storage: <inner-ns>`, `kubeConfig.secretRef: vc-mgmt/config`, both dependsOn edges explicit-ns; bp-grafana renders the three cross-ns edges; **no host Namespace** loki/mimir/tempo remains in the render.
- `helm lint` bp-grafana + bp-catalyst-platform: 0 failed.
- `helm template` proof: grafana datasource ConfigMap renders the three synced URLs; catalyst renders `CATALYST_MIMIR_URL` synced value and `"mgmt"` in the baseline CNP allowlist.
- `bash scripts/check-bootstrap-kit-pin-sync.sh` → PASS (bp-grafana 1.0.11 = pin 1.0.11; bp-catalyst-platform 1.4.591 = pin 1.4.591; LGTM charts untouched at 1.0.0/1.0.5/1.0.0).
- `bash scripts/check-chart-annotations.sh` scoped to both touched charts → 0 violations.

## Merge-timing + live-env caveats (do not merge blind)

- Merging bumps **bp-catalyst-platform** → deploy-bot rolls mothership catalyst-api. Per the standing rule, do NOT merge while a prov is in flight (a roll mid-apply abandons the deployment).
- On a LIVE env this migration prunes the old flux-system HRs → helm uninstalls host-side loki/mimir/tempo (host PVC telemetry is dropped — ephemeral observability data) → reinstalls inside the vCluster. Acceptance is a **fresh-prov walk**: LGTM pods Running in host ns `mgmt` (vCluster-synced), grafana datasource health-checks green against the synced URLs, console Pod sparkline (mimir query path) alive.
- Mimir's multi-component anti-affinity operates on the vCluster's node view (bp-mgmt-vcluster does not sync host nodes) — spread quality on multi-node Sovereigns is a fresh-prov observation point, not a correctness break (synced Pods are scheduled by the host scheduler).

## Founder-DoD statement

With the #3350 pilot (bp-k8s-ws-proxy, draft) counted, this PR brings vCluster-homed apps to **4 of ~48** (loki, mimir, tempo here + the pilot; bp-coraza/dmz and the vCluster slots themselves are infrastructure, not apps). ~44 apps remain on the host, each needing the same coupling audit before promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)