### PR TITLE
feat(catalyst-api): export mothership job rows to the chroot at handover — /jobs shows BOTH regions

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -717,6 +717,19 @@ func main() {
 	// leave the chroot disk or enter logged structs (INVIOLABLE-PRINCIPLES #10).
 	r.Post("/api/v1/sovereign/secondary-kubeconfig", h.HandleSovereignSecondaryKubeconfig)
 
+	// /api/v1/internal/jobs/import — Sovereign-side receiver for the
+	// mother's handover jobs snapshot (Refs #3263 #3277). The chroot's
+	// jobs store is seeded only by its own bootstrap watch (region-a);
+	// the secondary regions' install rows live solely in the mothership
+	// store, so the chroot /jobs page showed half the regions until the
+	// mother started shipping its rows here at handover. Same auth model
+	// as /api/v1/internal/deployments/import — no operator session
+	// exists on the child at handover time; validation is by FQDN match
+	// against CATALYST_OTECH_FQDN + the safe-id regex on deploymentId.
+	// Idempotent: jobs.Store.ImportSnapshot never regresses a terminal
+	// row and preserves the chroot's own region-a rows.
+	r.Post("/api/v1/internal/jobs/import", h.HandleJobsImport)
+
 	// Wire the tenant registry — flat-file store at
 	// CATALYST_DEPLOYMENTS_DIR/-tenant-registry.json. Per ADR-0001 §6
 	// the catalyst-api is the host process for the unified-rbac slice

--- a/products/catalyst/bootstrap/api/internal/handler/deployment_handover_export.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployment_handover_export.go
@@ -54,6 +54,14 @@ func (h *Handler) exportDeploymentToChild(dep *Deployment, fqdn string) {
 	// — it must not be suppressed by an EOF on the deployment POST.
 	go h.exportSecondaryKubeconfigsToChild(dep, fqdn, depID)
 
+	// #3263 #3277: ship the deployment's Job rows (BOTH regions) to the
+	// chroot's jobs store. The chroot's own bootstrap watch seeds only
+	// region-a; the secondary regions' install rows exist solely in the
+	// mothership's store, so without this the chroot /jobs page shows
+	// half the regions. Independent of the record export for the same
+	// reason as the kubeconfig fan-out above.
+	go h.exportJobsToChild(depID, fqdn)
+
 	body, err := json.Marshal(rec)
 	if err != nil {
 		h.log.Error("deployment-export: marshal failed",

--- a/products/catalyst/bootstrap/api/internal/handler/handover_jwt.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handover_jwt.go
@@ -184,6 +184,14 @@ func (h *Handler) MintHandoverToken(w http.ResponseWriter, r *http.Request) {
 	// so unconditional re-fire is safe. Fire-and-forget like fireHandover.
 	go h.exportSecondaryKubeconfigsToChild(dep, fqdn, id)
 
+	// #3263 #3277 — re-fire the handover jobs export for the same
+	// recovery reason: an env whose handover predates the jobs wire
+	// (hw130) or whose handover-time export was lost to a catalyst-api
+	// roll receives its region-b job rows on the next operator re-mint.
+	// The chroot's import is idempotent (ImportSnapshot never regresses
+	// a terminal row), so unconditional re-fire is safe.
+	go h.exportJobsToChild(id, fqdn)
+
 	writeJSON(w, http.StatusOK, map[string]string{
 		"token":       tokenStr,
 		"redirectURL": redirectURL,

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_handover_export.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_handover_export.go
@@ -1,0 +1,200 @@
+// jobs_handover_export.go — mother-side handover jobs transfer
+// (Refs #3263 #3277).
+//
+// FOUNDER-DoD gap (hw126, re-verified hw130): the Sovereign console's
+// /jobs page "shows only half of the regions". Root cause: the chroot's
+// jobs store is seeded only by its OWN bootstrap watch (region-a); the
+// secondary regions' rows ("install-<region>:<chart>") are written
+// exclusively by the MOTHERSHIP's secondary helmwatch bridges and never
+// leave the mothership PVC. The Region column/filter (#3278 #3352) is
+// already shipped and auto-appears once 2+ region buckets exist — the
+// chroot just never gets the second bucket.
+//
+// The wire: at handover (exportDeploymentToChild) the mother POSTs a
+// bounded snapshot of the deployment's Job rows + each Job's latest
+// Execution summary (NO log lines) to
+//
+//	POST https://api.<sovereign-fqdn>/api/v1/internal/jobs/import
+//
+// The chroot upserts the rows idempotently (jobs.Store.ImportSnapshot —
+// never regresses a terminal row, preserves its own region-a rows), so
+// the local /jobs surface carries both regions exactly like the mother
+// view. Auth + retry follow exportDeploymentToChild verbatim: no
+// session exists on the child at handover time, the child validates by
+// FQDN match against CATALYST_OTECH_FQDN; transient EOF/refused during
+// the child's gateway programming window is absorbed by the 5s→60s
+// backoff with a 5-minute budget.
+//
+// Recovery path: the export ALSO re-fires from MintHandoverToken (the
+// operator's "Open Sovereign console" re-mint), mirroring the D16
+// secondary-kubeconfig re-fire — an env whose handover predates this
+// wire (hw130) receives its region-b rows on the next re-mint without
+// a re-prov.
+package handler
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+)
+
+// jobsImportPayload is the wire shape POSTed to the chroot's
+// /api/v1/internal/jobs/import endpoint. SovereignFQDN lets the child
+// apply the same cross-cluster poisoning guard HandleDeploymentImport
+// uses (match against CATALYST_OTECH_FQDN). Jobs come from the
+// mother's ListJobs derived view; Executions are filtered to each
+// Job's LatestExecutionID so the payload stays bounded — log lines are
+// intentionally NOT shipped.
+type jobsImportPayload struct {
+	DeploymentID  string           `json:"deploymentId"`
+	SovereignFQDN string           `json:"sovereignFqdn"`
+	Jobs          []jobs.Job       `json:"jobs"`
+	Executions    []jobs.Execution `json:"executions"`
+}
+
+// buildJobsExportPayload serialises the deployment's Job rows + latest
+// Execution summaries into the jobsImportPayload wire shape. Split out
+// of exportJobsToChild so the marshal shape is unit-testable without a
+// network half. Returns the marshalled body plus the job/execution
+// counts for logging.
+func (h *Handler) buildJobsExportPayload(depID, fqdn string) ([]byte, int, int, error) {
+	jobRows, err := h.jobs.ListJobs(depID)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+
+	// Bound the payload: ChildIDs is derived at read time on BOTH sides
+	// (the chroot's persistIndex strips it anyway) and each Job's
+	// latest Execution is the only attempt the operator's table view
+	// deep-links to — older retry attempts stay mother-side.
+	latest := make(map[string]bool, len(jobRows))
+	for i := range jobRows {
+		jobRows[i].ChildIDs = nil
+		if id := jobRows[i].LatestExecutionID; id != "" {
+			latest[id] = true
+		}
+	}
+	allExecs, err := h.jobs.ListExecutions(depID)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	execRows := make([]jobs.Execution, 0, len(latest))
+	for _, e := range allExecs {
+		if latest[e.ID] {
+			execRows = append(execRows, e)
+		}
+	}
+
+	body, err := json.Marshal(jobsImportPayload{
+		DeploymentID:  depID,
+		SovereignFQDN: fqdn,
+		Jobs:          jobRows,
+		Executions:    execRows,
+	})
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	return body, len(jobRows), len(execRows), nil
+}
+
+// exportJobsToChild ships the deployment's jobs snapshot to the
+// child's catalyst-api. Called as a goroutine from
+// exportDeploymentToChild (auto-handover + converged-late rescue, both
+// route through fireHandover) and from MintHandoverToken (operator
+// re-mint recovery). Fire-and-forget; failures are logged loudly per
+// docs/PRINCIPLES.md — the mother stays the source of truth and a
+// re-mint retries the export.
+func (h *Handler) exportJobsToChild(depID, fqdn string) {
+	if h.jobs == nil {
+		h.log.Warn("jobs-export: no jobs store; cannot export rows",
+			"id", depID,
+		)
+		return
+	}
+	body, nJobs, nExecs, err := h.buildJobsExportPayload(depID, fqdn)
+	if err != nil {
+		h.log.Error("jobs-export: build payload failed",
+			"id", depID, "err", err,
+		)
+		return
+	}
+	if nJobs == 0 {
+		h.log.Info("jobs-export: no job rows for deployment; nothing to ship",
+			"id", depID,
+		)
+		return
+	}
+
+	url := "https://api." + fqdn + "/api/v1/internal/jobs/import"
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // child's LE cert may be seconds behind handover, same rationale as exportDeploymentToChild
+		},
+	}
+	h.log.Info("jobs-export: shipping snapshot to child",
+		"id", depID, "url", url, "jobs", nJobs, "executions", nExecs,
+	)
+	h.postJobsExportWithRetry(client, url, body, depID)
+}
+
+// postJobsExportWithRetry POSTs body to url with the same retry shape
+// as exportDeploymentToChild: backoff doubles from 5s up to 60s, total
+// budget 5 min, 5xx retries, 4xx gives up. Split out so the network
+// half is unit-testable with an injected client.
+func (h *Handler) postJobsExportWithRetry(client *http.Client, url string, body []byte, depID string) {
+	backoff := 5 * time.Second
+	deadline := time.Now().Add(5 * time.Minute)
+	attempt := 0
+	for time.Now().Before(deadline) {
+		attempt++
+		req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			h.log.Error("jobs-export: NewRequest failed",
+				"id", depID, "url", url, "err", err,
+			)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		if err != nil {
+			h.log.Warn("jobs-export: POST failed (will retry)",
+				"id", depID, "url", url, "attempt", attempt, "err", err,
+			)
+			time.Sleep(backoff)
+			if backoff < 60*time.Second {
+				backoff *= 2
+			}
+			continue
+		}
+		status := resp.StatusCode
+		resp.Body.Close()
+		if status >= 500 {
+			h.log.Warn("jobs-export: child 5xx (will retry)",
+				"id", depID, "url", url, "attempt", attempt, "status", status,
+			)
+			time.Sleep(backoff)
+			if backoff < 60*time.Second {
+				backoff *= 2
+			}
+			continue
+		}
+		if status >= 400 {
+			h.log.Error("jobs-export: child 4xx (giving up)",
+				"id", depID, "url", url, "attempt", attempt, "status", status,
+			)
+			return
+		}
+		h.log.Info("jobs-export: snapshot shipped to child",
+			"id", depID, "url", url, "attempt", attempt,
+		)
+		return
+	}
+	h.log.Error("jobs-export: gave up after 5min retries",
+		"id", depID, "url", url, "attempts", attempt,
+	)
+}

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_handover_export_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_handover_export_test.go
@@ -1,0 +1,249 @@
+// Tests for the mother-side handover jobs export (Refs #3263 #3277).
+//
+// What this file proves:
+//
+//  1. buildJobsExportPayload serialises BOTH regions' Job rows with the
+//     wire keys the chroot's HandleJobsImport decodes (deploymentId,
+//     sovereignFqdn, jobs, executions), keeps the first-class region
+//     field on secondary-region rows, strips the derived childIds, and
+//     bounds the executions list to each Job's LATEST attempt — no log
+//     lines ride along.
+//  2. postJobsExportWithRetry delivers the payload to the chroot
+//     endpoint (success path) and gives up immediately on a 4xx — no
+//     retry storm against a child that rejected the import.
+package handler
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+)
+
+// seedTwoRegionJobsStore seeds the mother-side store shape: a primary
+// region row + a secondary region row (region-prefixed jobName per
+// snapshotsToSeedsForRegion's ":" convention) with two execution
+// attempts on the secondary row so the latest-only filter is provable.
+func seedTwoRegionJobsStore(t *testing.T, js *jobs.Store, depID string) (latestExecID string) {
+	t.Helper()
+	if err := js.UpsertJob(jobs.Job{
+		DeploymentID: depID,
+		JobName:      "install-cilium",
+		AppID:        "cilium",
+		Type:         jobs.JobTypeInstall,
+		ParentID:     jobs.JobID(depID, jobs.GroupBootstrapKit),
+		DependsOn:    []string{},
+		Status:       jobs.StatusPending,
+	}); err != nil {
+		t.Fatalf("UpsertJob region-a: %v", err)
+	}
+	if err := js.UpsertJob(jobs.Job{
+		DeploymentID: depID,
+		JobName:      "install-me-east-215-b-1:cilium",
+		AppID:        "me-east-215-b-1:cilium",
+		Region:       "me-east-215-b-1",
+		Type:         jobs.JobTypeInstall,
+		ParentID:     jobs.JobID(depID, jobs.GroupBootstrapKit),
+		DependsOn:    []string{},
+		Status:       jobs.StatusPending,
+	}); err != nil {
+		t.Fatalf("UpsertJob region-b: %v", err)
+	}
+
+	// Two attempts on the region-b job: only the SECOND (latest) may
+	// ride the export payload.
+	stale, err := js.StartExecution(depID, "install-me-east-215-b-1:cilium", time.Now().Add(-10*time.Minute))
+	if err != nil {
+		t.Fatalf("StartExecution stale: %v", err)
+	}
+	if err := js.FinishExecution(depID, stale.ID, jobs.StatusFailed, time.Now().Add(-9*time.Minute)); err != nil {
+		t.Fatalf("FinishExecution stale: %v", err)
+	}
+	latest, err := js.StartExecution(depID, "install-me-east-215-b-1:cilium", time.Now().Add(-5*time.Minute))
+	if err != nil {
+		t.Fatalf("StartExecution latest: %v", err)
+	}
+	if err := js.FinishExecution(depID, latest.ID, jobs.StatusSucceeded, time.Now().Add(-4*time.Minute)); err != nil {
+		t.Fatalf("FinishExecution latest: %v", err)
+	}
+	return latest.ID
+}
+
+func TestBuildJobsExportPayload_WireShape(t *testing.T) {
+	js, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("jobs.NewStore: %v", err)
+	}
+	depID := "hw130dep"
+	fqdn := "hw130.omani.works"
+	latestExecID := seedTwoRegionJobsStore(t, js, depID)
+
+	h := NewWithJobsStore(silentLogger(), js)
+	body, nJobs, nExecs, err := h.buildJobsExportPayload(depID, fqdn)
+	if err != nil {
+		t.Fatalf("buildJobsExportPayload: %v", err)
+	}
+	// 2 leaf rows + the synthesized bootstrap-kit group from
+	// ListJobs's derived view.
+	if nJobs != 3 {
+		t.Errorf("nJobs = %d, want 3 (2 leaves + synthesized group)", nJobs)
+	}
+	if nExecs != 1 {
+		t.Errorf("nExecs = %d, want 1 (latest attempt only — stale attempt stays mother-side)", nExecs)
+	}
+
+	// Decode as the typed wire shape the chroot's HandleJobsImport uses.
+	var typed jobsImportPayload
+	if err := json.Unmarshal(body, &typed); err != nil {
+		t.Fatalf("payload does not round-trip the import shape: %v", err)
+	}
+	if typed.DeploymentID != depID {
+		t.Errorf("deploymentId = %q, want %q", typed.DeploymentID, depID)
+	}
+	if typed.SovereignFQDN != fqdn {
+		t.Errorf("sovereignFqdn = %q, want %q (the chroot's poisoning guard keys off this)", typed.SovereignFQDN, fqdn)
+	}
+	var regionB *jobs.Job
+	for i := range typed.Jobs {
+		if typed.Jobs[i].JobName == "install-me-east-215-b-1:cilium" {
+			regionB = &typed.Jobs[i]
+		}
+	}
+	if regionB == nil {
+		t.Fatalf("region-b row missing from payload: %+v", typed.Jobs)
+	}
+	if regionB.Region != "me-east-215-b-1" {
+		t.Errorf("region-b row region = %q, want me-east-215-b-1 (the chroot Region column keys off this)", regionB.Region)
+	}
+	if len(typed.Executions) != 1 || typed.Executions[0].ID != latestExecID {
+		t.Errorf("executions = %+v, want exactly the latest attempt %q", typed.Executions, latestExecID)
+	}
+
+	// Raw-key assertions: childIds (derived) must be stripped from
+	// every job; no log-line content rides the payload.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatalf("raw unmarshal: %v", err)
+	}
+	for _, key := range []string{"deploymentId", "sovereignFqdn", "jobs", "executions"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("payload missing wire key %q", key)
+		}
+	}
+	var rawJobs []map[string]json.RawMessage
+	if err := json.Unmarshal(raw["jobs"], &rawJobs); err != nil {
+		t.Fatalf("raw jobs unmarshal: %v", err)
+	}
+	for _, rj := range rawJobs {
+		if _, ok := rj["childIds"]; ok {
+			t.Errorf("job carries derived childIds — must be stripped to bound the payload: %v", rj)
+		}
+	}
+	var rawExecs []map[string]json.RawMessage
+	if err := json.Unmarshal(raw["executions"], &rawExecs); err != nil {
+		t.Fatalf("raw executions unmarshal: %v", err)
+	}
+	for _, re := range rawExecs {
+		if _, ok := re["lines"]; ok {
+			t.Errorf("execution carries log lines — the export must skip them: %v", re)
+		}
+	}
+}
+
+// fakeJobsImportServer mimics the chroot's POST /api/v1/internal/jobs/
+// import endpoint, recording every payload.
+type fakeJobsImportServer struct {
+	mu       sync.Mutex
+	received []jobsImportPayload
+	hits     atomic.Int32
+	status   int
+}
+
+func (s *fakeJobsImportServer) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s.hits.Add(1)
+		var p jobsImportPayload
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &p)
+		s.mu.Lock()
+		s.received = append(s.received, p)
+		s.mu.Unlock()
+		code := s.status
+		if code == 0 {
+			code = http.StatusOK
+		}
+		w.WriteHeader(code)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}
+}
+
+func TestPostJobsExport_DeliversBothRegions(t *testing.T) {
+	js, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("jobs.NewStore: %v", err)
+	}
+	depID := "hw130dep"
+	fqdn := "hw130.omani.works"
+	seedTwoRegionJobsStore(t, js, depID)
+
+	chroot := &fakeJobsImportServer{}
+	srv := httptest.NewServer(chroot.handler())
+	defer srv.Close()
+
+	h := NewWithJobsStore(silentLogger(), js)
+	body, _, _, err := h.buildJobsExportPayload(depID, fqdn)
+	if err != nil {
+		t.Fatalf("buildJobsExportPayload: %v", err)
+	}
+	client := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: newRoundTripperToServer(srv),
+	}
+	url := "https://api." + fqdn + "/api/v1/internal/jobs/import"
+	h.postJobsExportWithRetry(client, url, body, depID)
+
+	if got := chroot.hits.Load(); got != 1 {
+		t.Fatalf("chroot hit count = %d, want 1", got)
+	}
+	chroot.mu.Lock()
+	p := chroot.received[0]
+	chroot.mu.Unlock()
+	regions := map[string]bool{}
+	for _, j := range p.Jobs {
+		regions[j.Region] = true
+	}
+	if !regions[""] || !regions["me-east-215-b-1"] {
+		t.Errorf("delivered payload region buckets = %v, want both primary (\"\") + me-east-215-b-1", regions)
+	}
+}
+
+func TestPostJobsExport_GivesUpOn4xx(t *testing.T) {
+	chroot := &fakeJobsImportServer{status: http.StatusForbidden}
+	srv := httptest.NewServer(chroot.handler())
+	defer srv.Close()
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	client := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: newRoundTripperToServer(srv),
+	}
+	done := make(chan struct{})
+	go func() {
+		h.postJobsExportWithRetry(client, "https://api.x.example/api/v1/internal/jobs/import", []byte(`{}`), "dep")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("postJobsExportWithRetry kept retrying a 4xx — must give up immediately")
+	}
+	if got := chroot.hits.Load(); got != 1 {
+		t.Errorf("chroot hit count = %d, want 1 (no retry on 4xx)", got)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_handover_import.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_handover_import.go
@@ -1,0 +1,108 @@
+// jobs_handover_import.go — POST /api/v1/internal/jobs/import
+// (Refs #3263 #3277).
+//
+// Sovereign-side endpoint that receives the mother's jobs snapshot at
+// handover time (see jobs_handover_export.go for the mother half). The
+// chroot's jobs store is seeded only by its OWN bootstrap watch
+// (primary region); the secondary regions' install rows live solely in
+// the mothership's store. This endpoint upserts those rows into the
+// local store so the chroot's /jobs surface renders BOTH regions and
+// the Region column/filter (#3278 #3352) auto-appears.
+//
+// Auth: NOT session-gated — cross-cluster ingress at handover happens
+// before any operator session exists on the child, exactly like
+// /api/v1/internal/deployments/import. Validation mirrors
+// HandleDeploymentImport: the payload's sovereignFqdn must match the
+// receiving cluster's CATALYST_OTECH_FQDN env (cross-cluster data
+// poisoning guard), and the deploymentId must pass the safe-id regex
+// the secondary-kubeconfig receiver uses.
+//
+// Idempotent: jobs.Store.ImportSnapshot merges under mergeJob
+// semantics — a re-POST of the same snapshot is a no-op, a terminal
+// local row is never regressed, and rows the chroot wrote itself
+// (region-a) are preserved/merged, never deleted.
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// HandleJobsImport receives the mother's jobs snapshot and upserts it
+// into this cluster's local jobs store.
+func (h *Handler) HandleJobsImport(w http.ResponseWriter, r *http.Request) {
+	if h.jobs == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "jobs-store-unavailable",
+			"detail": "catalyst-api has no jobs persistence layer; cannot import job rows",
+		})
+		return
+	}
+
+	var payload jobsImportPayload
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":  "bad-payload",
+			"detail": err.Error(),
+		})
+		return
+	}
+
+	// FQDN check — protect against cross-cluster data poisoning. Same
+	// guard as HandleDeploymentImport.
+	expectedFQDN := strings.TrimSpace(os.Getenv("CATALYST_OTECH_FQDN"))
+	if expectedFQDN == "" {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "not-a-sovereign",
+			"detail": "this catalyst-api is not running on a Sovereign cluster (CATALYST_OTECH_FQDN unset) — refusing to accept jobs import",
+		})
+		return
+	}
+	if !strings.EqualFold(strings.TrimSpace(payload.SovereignFQDN), expectedFQDN) {
+		writeJSON(w, http.StatusForbidden, map[string]string{
+			"error":  "fqdn-mismatch",
+			"detail": "jobs payload's sovereignFqdn does not match this cluster's CATALYST_OTECH_FQDN — refusing to import foreign job rows",
+		})
+		return
+	}
+
+	payload.DeploymentID = strings.TrimSpace(payload.DeploymentID)
+	if !safeIDPattern.MatchString(payload.DeploymentID) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":  "invalid-deploymentId",
+			"detail": "must match ^[a-z0-9][a-z0-9-]{0,62}$",
+		})
+		return
+	}
+
+	jobsApplied, execsApplied, err := h.jobs.ImportSnapshot(
+		payload.DeploymentID, payload.Jobs, payload.Executions,
+	)
+	if err != nil {
+		h.log.Error("jobs-import: ImportSnapshot failed",
+			"id", payload.DeploymentID,
+			"err", err,
+		)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":  "import-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+
+	h.log.Info("jobs-import: persisted",
+		"id", payload.DeploymentID,
+		"jobsReceived", len(payload.Jobs),
+		"jobsApplied", jobsApplied,
+		"executionsReceived", len(payload.Executions),
+		"executionsApplied", execsApplied,
+	)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":                true,
+		"deploymentId":      payload.DeploymentID,
+		"jobsApplied":       jobsApplied,
+		"executionsApplied": execsApplied,
+	})
+}

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_handover_import_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_handover_import_test.go
@@ -1,0 +1,307 @@
+// Tests for the chroot-side handover jobs receive endpoint
+// (Refs #3263 #3277) — POST /api/v1/internal/jobs/import.
+//
+// What this file proves:
+//
+//  1. A mother snapshot carrying both regions lands in the chroot's
+//     local jobs store: region-b rows materialise with their Region
+//     field intact, the chroot's own pre-existing region-a rows (and
+//     rows absent from the payload entirely) are preserved.
+//  2. Re-POSTing the same snapshot is idempotent — no duplicate rows.
+//  3. A terminal local row is never regressed through the endpoint.
+//  4. The cross-cluster poisoning guards hold: fqdn-mismatch → 403,
+//     CATALYST_OTECH_FQDN unset → 503, nil jobs store → 503, malformed
+//     deploymentId → 400.
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+)
+
+const jobsImportTestFQDN = "hw130.omani.works"
+
+// newJobsImportTestHandler wires a Handler with a t.TempDir-rooted
+// jobs store and stamps the Sovereign identity env the endpoint
+// validates against.
+func newJobsImportTestHandler(t *testing.T) (*Handler, *jobs.Store) {
+	t.Helper()
+	js, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("jobs.NewStore: %v", err)
+	}
+	t.Setenv("CATALYST_OTECH_FQDN", jobsImportTestFQDN)
+	return NewWithJobsStore(silentLogger(), js), js
+}
+
+func postJobsImport(t *testing.T, h *Handler, payload jobsImportPayload) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/internal/jobs/import", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.HandleJobsImport(rec, req)
+	return rec
+}
+
+func tsp(t *testing.T, s string) *time.Time {
+	t.Helper()
+	v, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	v = v.UTC()
+	return &v
+}
+
+// motherJobsPayload builds the wire payload the mother's
+// buildJobsExportPayload produces for a 2-region deployment.
+func motherJobsPayload(t *testing.T, depID string) jobsImportPayload {
+	t.Helper()
+	return jobsImportPayload{
+		DeploymentID:  depID,
+		SovereignFQDN: jobsImportTestFQDN,
+		Jobs: []jobs.Job{
+			{
+				DeploymentID: depID,
+				JobName:      "install-cilium",
+				AppID:        "cilium",
+				Type:         jobs.JobTypeInstall,
+				ParentID:     jobs.JobID(depID, jobs.GroupBootstrapKit),
+				DependsOn:    []string{},
+				Status:       jobs.StatusSucceeded,
+				StartedAt:    tsp(t, "2026-06-11T10:00:00Z"),
+				FinishedAt:   tsp(t, "2026-06-11T10:02:00Z"),
+			},
+			{
+				DeploymentID:      depID,
+				JobName:           "install-me-east-215-b-1:cilium",
+				AppID:             "me-east-215-b-1:cilium",
+				Region:            "me-east-215-b-1",
+				Type:              jobs.JobTypeInstall,
+				ParentID:          jobs.JobID(depID, jobs.GroupBootstrapKit),
+				DependsOn:         []string{},
+				Status:            jobs.StatusSucceeded,
+				StartedAt:         tsp(t, "2026-06-11T10:05:00Z"),
+				FinishedAt:        tsp(t, "2026-06-11T10:08:00Z"),
+				LatestExecutionID: "exec-b-cilium",
+			},
+		},
+		Executions: []jobs.Execution{
+			{
+				ID:           "exec-b-cilium",
+				JobID:        jobs.JobID(depID, "install-me-east-215-b-1:cilium"),
+				DeploymentID: depID,
+				Status:       jobs.StatusSucceeded,
+				StartedAt:    *tsp(t, "2026-06-11T10:05:00Z"),
+				FinishedAt:   tsp(t, "2026-06-11T10:08:00Z"),
+				LineCount:    12,
+			},
+		},
+	}
+}
+
+func jobByID(t *testing.T, js *jobs.Store, depID, id string) *jobs.Job {
+	t.Helper()
+	rows, err := js.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	for i := range rows {
+		if rows[i].ID == id {
+			return &rows[i]
+		}
+	}
+	return nil
+}
+
+func TestHandleJobsImport_UpsertsBothRegionsPreservesLocalRows(t *testing.T) {
+	h, js := newJobsImportTestHandler(t)
+	depID := "hw130dep"
+
+	// Chroot pre-state: its own bootstrap watch already recorded the
+	// region-a install AND a chroot-only row the mother knows nothing
+	// about (e.g. a Day-2 mutation fired locally post-handover).
+	if err := js.UpsertJob(jobs.Job{
+		DeploymentID: depID,
+		JobName:      "install-cilium",
+		AppID:        "cilium",
+		Type:         jobs.JobTypeInstall,
+		Status:       jobs.StatusSucceeded,
+		StartedAt:    tsp(t, "2026-06-11T10:00:00Z"),
+		FinishedAt:   tsp(t, "2026-06-11T10:02:00Z"),
+	}); err != nil {
+		t.Fatalf("seed region-a: %v", err)
+	}
+	if err := js.UpsertJob(jobs.Job{
+		DeploymentID: depID,
+		JobName:      "chroot-local-mutation",
+		Type:         jobs.JobTypeInstall,
+		Status:       jobs.StatusSucceeded,
+		StartedAt:    tsp(t, "2026-06-11T11:00:00Z"),
+		FinishedAt:   tsp(t, "2026-06-11T11:01:00Z"),
+	}); err != nil {
+		t.Fatalf("seed chroot-only row: %v", err)
+	}
+
+	rec := postJobsImport(t, h, motherJobsPayload(t, depID))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response decode: %v", err)
+	}
+	if resp["ok"] != true || resp["deploymentId"] != depID {
+		t.Errorf("response = %v, want ok=true + deploymentId=%q", resp, depID)
+	}
+	if resp["jobsApplied"] != float64(2) {
+		t.Errorf("jobsApplied = %v, want 2", resp["jobsApplied"])
+	}
+
+	// Region-b row materialised with its Region field — the chroot's
+	// /jobs Region column/filter (#3278 #3352) keys off 2+ buckets.
+	b := jobByID(t, js, depID, jobs.JobID(depID, "install-me-east-215-b-1:cilium"))
+	if b == nil {
+		t.Fatalf("region-b row missing after import")
+	}
+	if b.Region != "me-east-215-b-1" || b.Status != jobs.StatusSucceeded {
+		t.Errorf("region-b row = %+v, want region=me-east-215-b-1 succeeded", b)
+	}
+	// Pre-existing rows preserved.
+	if a := jobByID(t, js, depID, jobs.JobID(depID, "install-cilium")); a == nil || a.Status != jobs.StatusSucceeded {
+		t.Errorf("region-a row lost or regressed: %+v", a)
+	}
+	if local := jobByID(t, js, depID, jobs.JobID(depID, "chroot-local-mutation")); local == nil {
+		t.Errorf("chroot-only row deleted by import — import must only ADD information")
+	}
+	// Execution summary resolvable for the /logs deep-link.
+	if _, err := js.FindExecution(depID, "exec-b-cilium"); err != nil {
+		t.Errorf("imported execution not found: %v", err)
+	}
+}
+
+func TestHandleJobsImport_Idempotent(t *testing.T) {
+	h, js := newJobsImportTestHandler(t)
+	depID := "hw130dep"
+	payload := motherJobsPayload(t, depID)
+
+	if rec := postJobsImport(t, h, payload); rec.Code != http.StatusOK {
+		t.Fatalf("first POST status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	first, err := js.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	if rec := postJobsImport(t, h, payload); rec.Code != http.StatusOK {
+		t.Fatalf("second POST status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	second, err := js.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	if len(first) != len(second) {
+		t.Errorf("row count changed on re-POST: %d → %d", len(first), len(second))
+	}
+	execs, err := js.ListExecutions(depID)
+	if err != nil {
+		t.Fatalf("ListExecutions: %v", err)
+	}
+	if len(execs) != 1 {
+		t.Errorf("executions duplicated on re-POST: %d, want 1", len(execs))
+	}
+}
+
+func TestHandleJobsImport_NeverRegressesTerminalRow(t *testing.T) {
+	h, js := newJobsImportTestHandler(t)
+	depID := "hw130dep"
+
+	if err := js.UpsertJob(jobs.Job{
+		DeploymentID: depID,
+		JobName:      "install-cilium",
+		Type:         jobs.JobTypeInstall,
+		Status:       jobs.StatusSucceeded,
+		StartedAt:    tsp(t, "2026-06-11T10:00:00Z"),
+		FinishedAt:   tsp(t, "2026-06-11T10:02:00Z"),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	stale := jobsImportPayload{
+		DeploymentID:  depID,
+		SovereignFQDN: jobsImportTestFQDN,
+		Jobs: []jobs.Job{{
+			DeploymentID: depID,
+			JobName:      "install-cilium",
+			Type:         jobs.JobTypeInstall,
+			Status:       jobs.StatusRunning, // stale mother view
+			StartedAt:    tsp(t, "2026-06-11T10:00:00Z"),
+		}},
+	}
+	if rec := postJobsImport(t, h, stale); rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	a := jobByID(t, js, depID, jobs.JobID(depID, "install-cilium"))
+	if a == nil || a.Status != jobs.StatusSucceeded || a.FinishedAt == nil {
+		t.Errorf("terminal row regressed through the endpoint: %+v", a)
+	}
+}
+
+func TestHandleJobsImport_RejectsForeignFQDN(t *testing.T) {
+	h, js := newJobsImportTestHandler(t)
+	depID := "hw130dep"
+	payload := motherJobsPayload(t, depID)
+	payload.SovereignFQDN = "evil.example.com"
+
+	rec := postJobsImport(t, h, payload)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body: %s", rec.Code, rec.Body.String())
+	}
+	rows, err := js.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("foreign payload landed %d rows — poisoning guard failed", len(rows))
+	}
+}
+
+func TestHandleJobsImport_NotASovereign503(t *testing.T) {
+	h, _ := newJobsImportTestHandler(t)
+	t.Setenv("CATALYST_OTECH_FQDN", "")
+
+	rec := postJobsImport(t, h, motherJobsPayload(t, "hw130dep"))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 (mothership must refuse the import); body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleJobsImport_NilStore503(t *testing.T) {
+	t.Setenv("CATALYST_OTECH_FQDN", jobsImportTestFQDN)
+	h := NewWithPDM(silentLogger(), &fakePDM{}) // no jobs store wired
+
+	rec := postJobsImport(t, h, motherJobsPayload(t, "hw130dep"))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleJobsImport_RejectsMalformedDeploymentID(t *testing.T) {
+	h, _ := newJobsImportTestHandler(t)
+	payload := motherJobsPayload(t, "hw130dep")
+	payload.DeploymentID = "../../../etc/passwd"
+
+	rec := postJobsImport(t, h, payload)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/jobs/import.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/import.go
@@ -1,0 +1,162 @@
+// import.go — handover snapshot export/import support (#3263 #3277).
+//
+// The chroot's jobs store is seeded only by its OWN bootstrap watch,
+// which observes the primary region. The secondary regions' install
+// rows ("install-<region>:<chart>") are written exclusively by the
+// MOTHERSHIP's secondary helmwatch bridges, so a converged multi-region
+// Sovereign's /jobs page shows half the picture on the chroot — the
+// Region column/filter (#3278 #3352) never even appears because only
+// one region bucket exists locally.
+//
+// The mother closes the gap at handover by POSTing a bounded snapshot
+// of its Job + Execution rows (NO log lines) to the chroot's
+// /api/v1/internal/jobs/import endpoint. This file holds the two store
+// primitives that wire needs:
+//
+//   - ListExecutions — mother-side read used to build the snapshot.
+//   - ImportSnapshot — chroot-side idempotent upsert with
+//     no-terminal-regression merge semantics.
+package jobs
+
+import (
+	"errors"
+	"strings"
+)
+
+// ListExecutions returns a copy of every Execution row for the
+// deployment, in insertion order. The handover exporter filters this
+// down to each Job's LatestExecutionID so the wire payload stays
+// bounded (one summary per Job, no log lines).
+func (s *Store) ListExecutions(deploymentID string) ([]Execution, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	idx, err := s.loadIndex(deploymentID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Execution, len(idx.Executions))
+	copy(out, idx.Executions)
+	return out, nil
+}
+
+// ImportSnapshot upserts a batch of Job + Execution rows into the
+// deployment's index under ONE lock + ONE atomic persist. Designed for
+// the handover jobs import (chroot side); the merge rules make a
+// re-POST of the same snapshot a no-op:
+//
+//   - Jobs the store has never seen are inserted verbatim (IDs are
+//     re-stamped from deploymentID + JobName so a malformed payload
+//     can't plant a foreign-keyed row).
+//   - Jobs that already exist locally (the chroot's own region-a watch
+//     rows share IDs with the mother's region-a rows) are merged via
+//     mergeJob — monotonic timestamps, DependsOn + Region + latest
+//     execution-id preservation.
+//   - A TERMINAL local row is NEVER regressed by a non-terminal
+//     incoming row: the local row wins unchanged. Terminal→terminal
+//     overwrites are allowed (the mother is the source of truth for
+//     provisioning history, mirroring HandleDeploymentImport).
+//   - Executions are insert-or-fill-forward: unknown IDs append; a
+//     known non-terminal row may be completed by a terminal incoming
+//     row; a known terminal row is never altered.
+//   - Rows present locally but absent from the snapshot are untouched
+//     — the import only ever ADDS information.
+//
+// Derived fields (ChildIDs) and the legacy migration hook
+// (LegacyBatchID) are stripped on the way in; persistIndex would strip
+// them anyway, but clearing them here keeps the in-memory index
+// canonical too.
+//
+// Returns the number of Job rows and Execution rows accepted (inserted
+// or merged — skipped rows don't count).
+func (s *Store) ImportSnapshot(deploymentID string, jobsIn []Job, execsIn []Execution) (jobsApplied, execsApplied int, err error) {
+	if strings.TrimSpace(deploymentID) == "" {
+		return 0, 0, errors.New("jobs: ImportSnapshot: deploymentID is required")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	idx, err := s.loadIndex(deploymentID)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	byID := make(map[string]int, len(idx.Jobs))
+	for i := range idx.Jobs {
+		byID[idx.Jobs[i].ID] = i
+	}
+	for _, j := range jobsIn {
+		if strings.TrimSpace(j.JobName) == "" {
+			continue
+		}
+		j.DeploymentID = deploymentID
+		j.ID = JobID(deploymentID, j.JobName)
+		j.ChildIDs = nil
+		j.LegacyBatchID = ""
+		if j.DependsOn == nil {
+			j.DependsOn = []string{}
+		}
+		if j.Type == "" {
+			j.Type = JobTypeInstall
+		}
+		// Recompute DurationMs the same way mergeJob does so a first
+		// INSERT and a re-import MERGE converge on identical rows
+		// (idempotence) even when the payload's DurationMs drifted.
+		if j.StartedAt != nil && j.FinishedAt != nil {
+			j.DurationMs = j.FinishedAt.Sub(*j.StartedAt).Milliseconds()
+		}
+		if i, ok := byID[j.ID]; ok {
+			prev := idx.Jobs[i]
+			if IsTerminal(prev.Status) && !IsTerminal(j.Status) {
+				// Never regress a terminal row — the chroot's own
+				// watch already saw this job finish; a stale mother
+				// snapshot must not flip it back to running/pending.
+				continue
+			}
+			idx.Jobs[i] = mergeJob(prev, j)
+		} else {
+			byID[j.ID] = len(idx.Jobs)
+			idx.Jobs = append(idx.Jobs, j)
+		}
+		jobsApplied++
+	}
+
+	execByID := make(map[string]int, len(idx.Executions))
+	for i := range idx.Executions {
+		execByID[idx.Executions[i].ID] = i
+	}
+	for _, e := range execsIn {
+		if strings.TrimSpace(e.ID) == "" || strings.TrimSpace(e.JobID) == "" {
+			continue
+		}
+		e.DeploymentID = deploymentID
+		if i, ok := execByID[e.ID]; ok {
+			prev := idx.Executions[i]
+			// Never alter a terminal execution; only fill a local
+			// non-terminal row forward to a terminal incoming state.
+			if IsTerminal(prev.Status) || !IsTerminal(e.Status) {
+				continue
+			}
+			if e.StartedAt.IsZero() {
+				e.StartedAt = prev.StartedAt
+			}
+			if e.LineCount < prev.LineCount {
+				// The chroot may have appended more log lines locally
+				// than the mother's summary knows about — keep the
+				// higher ceiling so /logs pagination never truncates.
+				e.LineCount = prev.LineCount
+			}
+			idx.Executions[i] = e
+		} else {
+			execByID[e.ID] = len(idx.Executions)
+			idx.Executions = append(idx.Executions, e)
+		}
+		execsApplied++
+	}
+
+	if err := s.persistIndex(idx); err != nil {
+		return 0, 0, err
+	}
+	return jobsApplied, execsApplied, nil
+}

--- a/products/catalyst/bootstrap/api/internal/jobs/import_test.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/import_test.go
@@ -1,0 +1,296 @@
+// import_test.go — handover snapshot import merge semantics
+// (Refs #3263 #3277).
+//
+// What this file proves (chroot-side jobs.Store.ImportSnapshot):
+//
+//  1. A mother snapshot carrying BOTH regions' rows lands in an index
+//     that previously held only the chroot's own region-a rows — the
+//     region-b rows ("install-<region>:<chart>", Region stamped)
+//     materialise, the pre-existing region-a rows survive.
+//  2. Re-importing the same snapshot is a no-op (idempotence).
+//  3. A terminal local row is NEVER regressed by a non-terminal
+//     incoming row.
+//  4. Executions append/fill-forward but never alter a terminal row.
+package jobs
+
+import (
+	"testing"
+	"time"
+)
+
+func ts(s string) *time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	t = t.UTC()
+	return &t
+}
+
+// seedChrootRegionA writes the chroot-side pre-state: its own
+// bootstrap watch has already recorded a terminal region-a install.
+func seedChrootRegionA(t *testing.T, st *Store, depID string) {
+	t.Helper()
+	j := Job{
+		DeploymentID: depID,
+		JobName:      "install-cilium",
+		AppID:        "cilium",
+		Type:         JobTypeInstall,
+		ParentID:     JobID(depID, GroupBootstrapKit),
+		DependsOn:    []string{"install-flux"},
+		Status:       StatusSucceeded,
+		StartedAt:    ts("2026-06-11T10:00:00Z"),
+		FinishedAt:   ts("2026-06-11T10:02:00Z"),
+	}
+	if err := st.UpsertJob(j); err != nil {
+		t.Fatalf("seed UpsertJob: %v", err)
+	}
+}
+
+// motherSnapshot builds the mother-side payload shape: the same
+// region-a row PLUS a region-b row + its latest execution summary.
+func motherSnapshot(depID string) ([]Job, []Execution) {
+	jobsIn := []Job{
+		{
+			DeploymentID: depID,
+			JobName:      "install-cilium",
+			AppID:        "cilium",
+			Type:         JobTypeInstall,
+			ParentID:     JobID(depID, GroupBootstrapKit),
+			DependsOn:    []string{"install-flux"},
+			Status:       StatusSucceeded,
+			StartedAt:    ts("2026-06-11T10:00:00Z"),
+			FinishedAt:   ts("2026-06-11T10:02:00Z"),
+		},
+		{
+			DeploymentID:      depID,
+			JobName:           "install-me-east-215-b-1:cilium",
+			AppID:             "me-east-215-b-1:cilium",
+			Region:            "me-east-215-b-1",
+			Type:              JobTypeInstall,
+			ParentID:          JobID(depID, GroupBootstrapKit),
+			DependsOn:         []string{"install-me-east-215-b-1:flux"},
+			Status:            StatusSucceeded,
+			StartedAt:         ts("2026-06-11T10:05:00Z"),
+			FinishedAt:        ts("2026-06-11T10:08:00Z"),
+			LatestExecutionID: "exec-b-cilium",
+		},
+	}
+	execsIn := []Execution{
+		{
+			ID:           "exec-b-cilium",
+			JobID:        JobID(depID, "install-me-east-215-b-1:cilium"),
+			DeploymentID: depID,
+			Status:       StatusSucceeded,
+			StartedAt:    *ts("2026-06-11T10:05:00Z"),
+			FinishedAt:   ts("2026-06-11T10:08:00Z"),
+			LineCount:    12,
+		},
+	}
+	return jobsIn, execsIn
+}
+
+func findJob(jobsOut []Job, id string) *Job {
+	for i := range jobsOut {
+		if jobsOut[i].ID == id {
+			return &jobsOut[i]
+		}
+	}
+	return nil
+}
+
+func TestImportSnapshot_AddsRegionBPreservesRegionA(t *testing.T) {
+	st := newTestStore(t)
+	depID := "hw130dep"
+	seedChrootRegionA(t, st, depID)
+
+	jobsIn, execsIn := motherSnapshot(depID)
+	jApplied, eApplied, err := st.ImportSnapshot(depID, jobsIn, execsIn)
+	if err != nil {
+		t.Fatalf("ImportSnapshot: %v", err)
+	}
+	if jApplied != 2 {
+		t.Errorf("jobsApplied = %d, want 2 (region-a merge + region-b insert)", jApplied)
+	}
+	if eApplied != 1 {
+		t.Errorf("execsApplied = %d, want 1", eApplied)
+	}
+
+	got, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	a := findJob(got, JobID(depID, "install-cilium"))
+	if a == nil {
+		t.Fatalf("region-a row missing after import: %+v", got)
+	}
+	if a.Status != StatusSucceeded {
+		t.Errorf("region-a status = %q, want succeeded", a.Status)
+	}
+	b := findJob(got, JobID(depID, "install-me-east-215-b-1:cilium"))
+	if b == nil {
+		t.Fatalf("region-b row missing after import: %+v", got)
+	}
+	if b.Region != "me-east-215-b-1" {
+		t.Errorf("region-b Region = %q, want me-east-215-b-1 (the Region column keys off this)", b.Region)
+	}
+	if b.Status != StatusSucceeded {
+		t.Errorf("region-b status = %q, want succeeded", b.Status)
+	}
+
+	// The imported execution must be resolvable for the /logs deep-link.
+	exec, err := st.FindExecution(depID, "exec-b-cilium")
+	if err != nil {
+		t.Fatalf("FindExecution(exec-b-cilium): %v", err)
+	}
+	if exec.Status != StatusSucceeded || exec.LineCount != 12 {
+		t.Errorf("imported execution = %+v, want succeeded/12 lines", exec)
+	}
+}
+
+func TestImportSnapshot_Idempotent(t *testing.T) {
+	st := newTestStore(t)
+	depID := "hw130dep"
+	seedChrootRegionA(t, st, depID)
+
+	jobsIn, execsIn := motherSnapshot(depID)
+	if _, _, err := st.ImportSnapshot(depID, jobsIn, execsIn); err != nil {
+		t.Fatalf("first ImportSnapshot: %v", err)
+	}
+	first, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs after first import: %v", err)
+	}
+
+	// Re-import the SAME snapshot — counts may report merges but the
+	// resulting view must be unchanged.
+	if _, _, err := st.ImportSnapshot(depID, jobsIn, execsIn); err != nil {
+		t.Fatalf("second ImportSnapshot: %v", err)
+	}
+	second, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs after second import: %v", err)
+	}
+	if len(first) != len(second) {
+		t.Fatalf("job count changed on re-import: %d → %d", len(first), len(second))
+	}
+	for i := range first {
+		a, b := first[i], second[i]
+		if a.ID != b.ID || a.Status != b.Status || a.Region != b.Region ||
+			a.DurationMs != b.DurationMs || a.LatestExecutionID != b.LatestExecutionID {
+			t.Errorf("row %q changed on re-import: %+v → %+v", a.ID, a, b)
+		}
+	}
+	execs, err := st.ListExecutions(depID)
+	if err != nil {
+		t.Fatalf("ListExecutions: %v", err)
+	}
+	if len(execs) != 1 {
+		t.Errorf("executions duplicated on re-import: %d, want 1", len(execs))
+	}
+}
+
+func TestImportSnapshot_NeverRegressesTerminalRow(t *testing.T) {
+	st := newTestStore(t)
+	depID := "hw130dep"
+	seedChrootRegionA(t, st, depID) // terminal succeeded locally
+
+	stale := []Job{{
+		DeploymentID: depID,
+		JobName:      "install-cilium",
+		AppID:        "cilium",
+		Type:         JobTypeInstall,
+		ParentID:     JobID(depID, GroupBootstrapKit),
+		Status:       StatusRunning, // stale mother view: still running
+		StartedAt:    ts("2026-06-11T10:00:00Z"),
+	}}
+	jApplied, _, err := st.ImportSnapshot(depID, stale, nil)
+	if err != nil {
+		t.Fatalf("ImportSnapshot: %v", err)
+	}
+	if jApplied != 0 {
+		t.Errorf("jobsApplied = %d, want 0 (terminal row must be skipped)", jApplied)
+	}
+
+	got, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	a := findJob(got, JobID(depID, "install-cilium"))
+	if a == nil {
+		t.Fatalf("region-a row vanished: %+v", got)
+	}
+	if a.Status != StatusSucceeded {
+		t.Errorf("terminal row regressed: status = %q, want succeeded", a.Status)
+	}
+	if a.FinishedAt == nil {
+		t.Errorf("terminal row lost FinishedAt")
+	}
+}
+
+func TestImportSnapshot_ExecutionsNeverAlterTerminal(t *testing.T) {
+	st := newTestStore(t)
+	depID := "hw130dep"
+	_, execsIn := motherSnapshot(depID)
+
+	// First import lands the terminal execution.
+	if _, _, err := st.ImportSnapshot(depID, nil, execsIn); err != nil {
+		t.Fatalf("first ImportSnapshot: %v", err)
+	}
+	// A stale re-send claiming the execution is still running must not
+	// regress it.
+	stale := []Execution{{
+		ID:           "exec-b-cilium",
+		JobID:        JobID(depID, "install-me-east-215-b-1:cilium"),
+		DeploymentID: depID,
+		Status:       StatusRunning,
+		StartedAt:    *ts("2026-06-11T10:05:00Z"),
+		LineCount:    3,
+	}}
+	_, eApplied, err := st.ImportSnapshot(depID, nil, stale)
+	if err != nil {
+		t.Fatalf("second ImportSnapshot: %v", err)
+	}
+	if eApplied != 0 {
+		t.Errorf("execsApplied = %d, want 0 (terminal execution must be skipped)", eApplied)
+	}
+	exec, err := st.FindExecution(depID, "exec-b-cilium")
+	if err != nil {
+		t.Fatalf("FindExecution: %v", err)
+	}
+	if exec.Status != StatusSucceeded || exec.LineCount != 12 || exec.FinishedAt == nil {
+		t.Errorf("terminal execution altered: %+v", exec)
+	}
+}
+
+func TestImportSnapshot_ExecutionFillsForwardNonTerminal(t *testing.T) {
+	st := newTestStore(t)
+	depID := "hw130dep"
+
+	running := []Execution{{
+		ID:           "exec-b-cilium",
+		JobID:        JobID(depID, "install-me-east-215-b-1:cilium"),
+		DeploymentID: depID,
+		Status:       StatusRunning,
+		StartedAt:    *ts("2026-06-11T10:05:00Z"),
+		LineCount:    3,
+	}}
+	if _, _, err := st.ImportSnapshot(depID, nil, running); err != nil {
+		t.Fatalf("first ImportSnapshot: %v", err)
+	}
+	_, execsIn := motherSnapshot(depID) // terminal version of the same exec
+	_, eApplied, err := st.ImportSnapshot(depID, nil, execsIn)
+	if err != nil {
+		t.Fatalf("second ImportSnapshot: %v", err)
+	}
+	if eApplied != 1 {
+		t.Errorf("execsApplied = %d, want 1 (non-terminal → terminal fill-forward)", eApplied)
+	}
+	exec, err := st.FindExecution(depID, "exec-b-cilium")
+	if err != nil {
+		t.Fatalf("FindExecution: %v", err)
+	}
+	if exec.Status != StatusSucceeded || exec.FinishedAt == nil {
+		t.Errorf("execution not filled forward: %+v", exec)
+	}
+}


### PR DESCRIPTION
Refs #3263 #3277

## Problem (FOUNDER-DoD, hw126 report, re-verified live on hw130)

The Sovereign console's **/jobs page shows only half of the regions**. Root cause (proven live): the chroot's jobs store is seeded only by its OWN bootstrap watch (region-a); the 60 region-b rows (`install-me-east-215-b-1:*`) live solely in the MOTHERSHIP's store and never leave the mothership PVC. The Region column/filter is already shipped (#3278 + #3352) and auto-appears once 2+ region buckets exist — the chroot just never gets the second bucket.

## The wire

### Mother side — `exportJobsToChild` (`internal/handler/jobs_handover_export.go`)

Rides `exportDeploymentToChild` as its own goroutine (same independence rationale as the D16 secondary-kubeconfig fan-out: a record-export EOF must not suppress it), so it fires on **every** path that routes through `fireHandover`:

- Phase-1 auto-handover (`phase1_watch.go:1288` → `exportDeploymentToChild`)
- **converged-late rescue** (`phase1_converged_late.go:103` → `fireHandover` → same export) — covered automatically, no extra wiring needed
- plus a re-fire from `MintHandoverToken` (see retroactivity below)

Payload is bounded: `ListJobs(depID)` derived view + **only each job's latest Execution summary** (filtered by `LatestExecutionID`); log lines are NOT shipped; derived `childIds` stripped. Auth/retry follows `exportDeploymentToChild` verbatim — no session exists on the child at handover, TLS-insecure POST (child LE cert may be seconds behind), backoff 5s→60s, 5-minute budget, 5xx retries, 4xx gives up.

### Endpoint shapes

**POST** `https://api.<sovereign-fqdn>/api/v1/internal/jobs/import` (new, child side, registered next to `/api/v1/internal/deployments/import` outside RequireSession)

Request:
```json
{
  "deploymentId": "<depID>",
  "sovereignFqdn": "<fqdn>",          // poisoning guard, matched (EqualFold) vs CATALYST_OTECH_FQDN
  "jobs":       [ Job... ],           // wire-contract jobs.Job rows, both regions, childIds stripped
  "executions": [ Execution... ]      // latest attempt per job only; NO log lines
}
```

Responses: `200 {ok, deploymentId, jobsApplied, executionsApplied}` · `400` bad payload / malformed deploymentId (safe-id regex) · `403` fqdn-mismatch · `503` not-a-Sovereign (`CATALYST_OTECH_FQDN` unset) or jobs store unavailable · `500` persist failure.

### Child-side merge — `jobs.Store.ImportSnapshot` (`internal/jobs/import.go`)

One lock + one atomic persist for the whole batch. `mergeJob` semantics with two hard guarantees:

- **never regress a terminal row** — a terminal local row (the chroot's own watch already saw it finish) is skipped when the incoming row is non-terminal; executions likewise never altered once terminal (fill-forward only)
- **preserve existing region-a rows** — the import only ever ADDS information; rows absent from the snapshot are untouched, shared-ID region-a rows merge monotonically (timestamps, DependsOn/Region/latest-exec preservation)

Re-POSTing the same snapshot is a no-op (proven by test, including a DurationMs normalization wart the test caught).

## How hw130 gets its region-b rows retroactively

hw130's handover already fired, so the handover-time export never ran there. `MintHandoverToken` (the operator's "Open Sovereign console" re-mint) now re-fires `exportJobsToChild` exactly like the existing D16 secondary-kubeconfig re-fire at `handover_jwt.go:185` — the next re-mint against hw130's record ships the mothership's full two-region snapshot to the chroot, idempotently. No re-prov needed. (Any future converged-late rescue also carries the export, since it routes through `fireHandover` → `exportDeploymentToChild`.)

## Tests

- `internal/jobs/import_test.go` — region-b lands + region-a preserved; idempotence; terminal-row no-regression; executions never alter terminal / fill-forward non-terminal
- `internal/handler/jobs_handover_export_test.go` — marshal wire-shape (keys, region field, latest-exec-only, childIds stripped, no log lines); delivery of both region buckets through the retry helper; 4xx gives up after exactly 1 attempt
- `internal/handler/jobs_handover_import_test.go` — endpoint upserts both regions + preserves chroot-only rows; idempotent re-POST; terminal no-regression through the endpoint; 403 foreign-FQDN (store stays empty); 503 not-a-Sovereign; 503 nil store; 400 path-traversal deploymentId

`go test -race ./internal/...` — **all green** (handler 66s, jobs 3s, full sweep), re-verified on the exact pushed commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)