### PR TITLE
feat(openclaw): tier=rtz — placement sweep complete, zero unassigned apps

### DIFF
--- a/platform/openclaw/blueprint.yaml
+++ b/platform/openclaw/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-7-agentic-workspace
 spec:
-  version: 0.2.0
+  version: 0.2.1
   card:
     title: OpenClaw
     summary: |
@@ -105,6 +105,15 @@ spec:
   placementSchema:
     modes: [single-region]
     default: single-region
+  # Founder NS-1 placement mandate (2026-06-12): every app declares its
+  # vCluster zone. OpenClaw is a TENANT-FACING workspace controller +
+  # per-user runtime pods — production workload class, rtz per the
+  # ARCHITECTURE §4 zone model (the audit's one undeclared app).
+  topology:
+    perTopology:
+      single-region:
+        placement:
+          tier: rtz
   manifests:
     chart: ./chart
   depends:

--- a/platform/openclaw/chart/Chart.yaml
+++ b/platform/openclaw/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openclaw
-version: 0.2.0
+version: 0.2.1
 appVersion: "0.2.0"
 description: |
   Catalyst Blueprint chart for the OpenClaw workspace controller pattern


### PR DESCRIPTION
The audit's single undeclared app gets its zone; the founder's 'no application unassigned' sweep now holds repo-wide. Refs #2745

🤖 Generated with [Claude Code](https://claude.com/claude-code)