### PR TITLE
feat(bp-postgres): three shared data instances — 3 cards, 7 consumers 3+3+1 (founder NS-2)

### DIFF
--- a/.github/workflows/blueprint-release.yaml
+++ b/.github/workflows/blueprint-release.yaml
@@ -646,51 +646,60 @@ jobs:
             exit 0
           fi
 
-          # Defensive: refuse to operate if multiple slots reference the
-          # same chart name — bootstrap-kit invariant is one slot per
-          # chart, and a violation would mean the schema changed under
-          # us and the hook would write wrong things.
-          slot_count=$(echo "$pin_file" | wc -l)
-          if [ "$slot_count" -ne 1 ]; then
-            echo "::error title=Multiple bootstrap-kit slots for ${CHART_NAME}::Expected exactly one slot file pinning chart '${CHART_NAME}', found ${slot_count}: $pin_file"
-            exit 1
-          fi
+          # Multiple slots MAY pin the same chart — the #3188 three-
+          # instance model installs bp-postgres at slots 16a/16c/16d
+          # (three data instances of one chart). The lockstep bump
+          # applies to EVERY slot file pinning the chart; the pin-sync
+          # audit (scripts/check-bootstrap-kit-pin-sync.sh) asserts the
+          # same all-pins contract.
+          bumped=false
+          bumped_files=""
+          prev_versions=""
+          for f in $pin_file; do
+            # Read current pin. The HelmRelease.spec.chart.spec.version
+            # is at exactly 6 spaces of indent in every slot (audited
+            # 2026-05-18 across all 51 files). If the shape ever changes
+            # we fail loudly rather than write the wrong line.
+            current=$(awk '/^      version:/{print $2; exit}' "$f" | tr -d '"')
+            if [ -z "$current" ]; then
+              echo "::error title=Unparseable bootstrap-kit pin::No '      version:' line at 6-space indent in $f. The HelmRelease.spec.chart.spec.version shape changed under TBD-A6's auto-bump hook; refusing to write."
+              exit 1
+            fi
 
-          # Read current pin. The HelmRelease.spec.chart.spec.version is
-          # at exactly 6 spaces of indent in every slot (audited 2026-
-          # 05-18 across all 51 files). If the shape ever changes we
-          # fail loudly rather than write the wrong line.
-          current=$(awk '/^      version:/{print $2; exit}' "$pin_file" | tr -d '"')
-          if [ -z "$current" ]; then
-            echo "::error title=Unparseable bootstrap-kit pin::No '      version:' line at 6-space indent in $pin_file. The HelmRelease.spec.chart.spec.version shape changed under TBD-A6's auto-bump hook; refusing to write."
-            exit 1
-          fi
+            if [ "$current" = "$CHART_VERSION" ]; then
+              echo "INFO: ${f} already pins ${CHART_NAME}=${CHART_VERSION} — no-op."
+              continue
+            fi
 
-          if [ "$current" = "$CHART_VERSION" ]; then
-            echo "INFO: ${pin_file} already pins ${CHART_NAME}=${CHART_VERSION} — no-op."
+            echo "Bumping ${f}: ${CHART_NAME} ${current} → ${CHART_VERSION}"
+            # sed targets the single 6-space `      version:` line at the
+            # chart-pin scope. There is exactly one such line per slot
+            # (audited 2026-05-18); the regex is anchored to start-of-line
+            # so a deeper-indented `version:` (e.g. inside .values.xxx)
+            # cannot accidentally match.
+            sed -i -E "s|^      version: .*\$|      version: ${CHART_VERSION}|" "$f"
+
+            # Verify the sed actually flipped the line — defence against
+            # a future indent change shipping silently.
+            new=$(awk '/^      version:/{print $2; exit}' "$f" | tr -d '"')
+            if [ "$new" != "$CHART_VERSION" ]; then
+              echo "::error title=sed failed::After rewrite, ${f} still pins '${new}', expected '${CHART_VERSION}'."
+              exit 1
+            fi
+
+            bumped=true
+            bumped_files="${bumped_files:+${bumped_files} }${f}"
+            prev_versions="${prev_versions:+${prev_versions} }${current}"
+          done
+
+          if [ "$bumped" != "true" ]; then
             echo "bumped=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "Bumping ${pin_file}: ${CHART_NAME} ${current} → ${CHART_VERSION}"
-          # sed targets the single 6-space `      version:` line at the
-          # chart-pin scope. There is exactly one such line per slot
-          # (audited 2026-05-18); the regex is anchored to start-of-line
-          # so a deeper-indented `version:` (e.g. inside .values.xxx)
-          # cannot accidentally match.
-          sed -i -E "s|^      version: .*\$|      version: ${CHART_VERSION}|" "$pin_file"
-
-          # Verify the sed actually flipped the line — defence against
-          # a future indent change shipping silently.
-          new=$(awk '/^      version:/{print $2; exit}' "$pin_file" | tr -d '"')
-          if [ "$new" != "$CHART_VERSION" ]; then
-            echo "::error title=sed failed::After rewrite, ${pin_file} still pins '${new}', expected '${CHART_VERSION}'."
-            exit 1
-          fi
-
           echo "bumped=true" >> "$GITHUB_OUTPUT"
-          echo "pin_file=${pin_file}" >> "$GITHUB_OUTPUT"
-          echo "prev_version=${current}" >> "$GITHUB_OUTPUT"
+          echo "pin_file=${bumped_files}" >> "$GITHUB_OUTPUT"
+          echo "prev_version=${prev_versions}" >> "$GITHUB_OUTPUT"
 
       # ──────────────────────────────────────────────────────────────
       # LOCKSTEP — platform/<bp>/blueprint.yaml `spec.version`

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -65,6 +65,15 @@ spec:
     # gateway.networking.k8s.io/v1 CRDs must be registered first.
     - name: bp-gateway-api
       namespace: flux-system
+    # bp-postgres-shared (#3188 three-instance model): when keycloak
+    # SHARES the shared-pg instance A (SOVEREIGN_KEYCLOAK_PG_OWN_CLUSTER
+    # =false), gate on it so the keycloak Database + role + reflected
+    # keycloak-database-secret exist first. Harmless in the default 1:1
+    # path — bp-postgres-shared is an empty Ready release within seconds
+    # of bp-cnpg + bp-reflector (the same unconditional-edge shape
+    # bp-gitea slot 10 + bp-harbor slot 19 already carry).
+    - name: bp-postgres-shared
+      namespace: flux-system
   chart:
     spec:
       chart: bp-keycloak
@@ -236,3 +245,35 @@ spec:
       ownerEmail: "${SOVEREIGN_OWNER_EMAIL}"
     gateway:
       host: auth.${SOVEREIGN_FQDN}
+    # ── Shared-instance flip (#3188 three-instance model) ───────────────
+    # Default OWN_CLUSTER=true → the bundled bitnami postgresql subchart
+    # renders exactly as today (the externalDatabase block is UNREAD when
+    # postgresql.enabled=true — default single-region render byte-
+    # identical, proven by the chart-render diff in the PR). Cloud-init
+    # computes OWN_CLUSTER=false from the same enable_shared_pg var that
+    # turns slot 16a ON (one-flag contract, #3285/#3309 gitea/harbor
+    # shape): the subchart StatefulSet is skipped and Keycloak runs in
+    # externalDatabase mode against the shared-pg `keycloak` database +
+    # role, reading credentials from the reflector-pushed hub Secret
+    # `keycloak-database-secret` (#3283 push pattern; the Pod sits in
+    # CreateContainerConfigError for the few seconds between namespace
+    # creation and the reflector push, then starts — kubelet retries).
+    # Keycloak's Liquibase owns the schema, so the empty database is the
+    # correct starting state. The bitnami subchart builds KC_DB_URL from
+    # the static host/port/database below; the password comes from the
+    # hub Secret via existingSecret/existingSecretPasswordKey. NOTE: do
+    # NOT set existingSecretUserKey — bitnami 25.2.0 consults it even
+    # when postgresql.enabled=true (KC_DB_USERNAME flips to a _FILE
+    # mount), which would break the default own-cluster render; the
+    # plain `user` value below carries the username instead (it matches
+    # the hub Secret's role by construction).
+    keycloak:
+      postgresql:
+        enabled: ${SOVEREIGN_KEYCLOAK_PG_OWN_CLUSTER:=true}
+      externalDatabase:
+        host: shared-pg-rw.shared-data.svc.cluster.local
+        port: 5432
+        user: keycloak
+        database: keycloak
+        existingSecret: keycloak-database-secret
+        existingSecretPasswordKey: password

--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -1,28 +1,39 @@
-# bp-postgres (shared instance) — Catalyst bootstrap-kit Blueprint, slot 16a.
+# bp-postgres (shared instance A) — Catalyst bootstrap-kit Blueprint, slot 16a.
 #
-# ADR-0010 reuse proof: ONE shared CNPG Cluster (`shared-pg`) that BOTH
-# bp-harbor and bp-gitea run off, via two ISOLATED databases + two
-# per-consumer roles. This is the reusable, shareable backing-services
-# model proven live: 2 consumers, 1 engine.
+# ADR-0010 reuse proof: ONE shared CNPG Cluster (`shared-pg`) that
+# bp-gitea, bp-harbor AND bp-keycloak run off, via three ISOLATED
+# databases + three per-consumer roles. This is the reusable, shareable
+# backing-services model proven live (gitea+harbor, hw130) — keycloak
+# joins via the same #3283/#3285 hub-secret push pattern.
+#
+# THREE-INSTANCE MODEL (founder NS-2, Refs #3188): this slot is instance
+# A of three. Slots 16c (`shared-pg-b`: grafana + powerdns + powerdns-
+# admin) and 16d (`shared-pg-c`: the SME mesh) are two more installs of
+# the SAME bp-postgres chart, all gated on SOVEREIGN_ENABLE_SHARED_PG.
+# Three engines, 7 consumer applications, 3+3+1.
 #
 # The binding is pure declarative YAML — this HR's values.databases[]
 # renders (in platform/postgres/chart):
 #   - one CNPG Cluster `shared-pg`
-#   - two Database CRs (registry → harbor, gitea → gitea) on it
-#   - two managed.roles (harbor, gitea) on it
-#   - two hub connection Secrets (harbor-database-secret, gitea-database-
-#     secret) in THIS release's namespace (shared-data) carrying reflector
-#     auto-push annotations (#3283) so bp-reflector copies a same-named
-#     Secret into ns harbor / ns gitea once those namespaces appear — each
-#     consumer chart then runs in externalDatabase mode off its own Secret.
+#   - three Database CRs (registry → harbor, gitea → gitea,
+#     keycloak → keycloak) on it
+#   - three managed.roles (harbor, gitea, keycloak) on it
+#   - three hub connection Secrets (harbor-database-secret, gitea-
+#     database-secret, keycloak-database-secret) in THIS release's
+#     namespace (shared-data) carrying reflector auto-push annotations
+#     (#3283) so bp-reflector copies a same-named Secret into ns harbor /
+#     ns gitea / ns keycloak once those namespaces appear — each consumer
+#     chart then runs in externalDatabase mode off its own Secret.
 #     (The hub Secret lives in shared-data, NOT the consumer namespace,
 #     because those namespaces don't exist when this HR installs — creating
 #     the Secret there directly was the FATAL deadlock fixed in 0.1.2.)
 #
 # NO custom controller, NO Crossplane. The CNPG operator (bp-cnpg, slot
 # 16) + Flux reconcile everything. bp-harbor (19) and bp-gitea (10) set
-# postgres.cluster.enabled=false (their own embedded Cluster is skipped)
-# and dependsOn bp-postgres-shared.
+# postgres.cluster.enabled=false (their own embedded Cluster is skipped);
+# bp-keycloak (09) sets keycloak.postgresql.enabled=false (bundled
+# bitnami postgresql skipped, externalDatabase mode on). All three
+# dependsOn bp-postgres-shared.
 #
 # Slot ordering: after bp-cnpg (16, the operator + CRDs), before
 # bp-harbor (19). bp-gitea (10) gates on this via Flux dependsOn
@@ -95,7 +106,11 @@ spec:
       # reflects: pull was dead on two reflector limitations (no retry
       # for late sources; mirrors can't be push sources), proven live
       # hw130. Hub stays the #3283 push source for consumer namespaces.
-      version: 0.1.4
+      # 0.1.5 (#3188 three-instance model): same-owner binding dedupe +
+      # Database-CR-name underscore sanitize + hub `uri` key +
+      # reflect.extraData / reflect.passwordAliases (env-style hub for
+      # grafana). Enables slots 16c/16d as additional chart installs.
+      version: 0.1.5
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -120,10 +135,11 @@ spec:
     # today (the same default-OFF shape as slot 16b SOVEREIGN_ENABLE_HOT_
     # STANDBY / slot 62 CONTINUUM_ENABLED).
     #
-    # TWO-FLAG CONTRACT to actually share a real shared instance: flip
-    # BOTH SOVEREIGN_{GITEA,HARBOR}_PG_OWN_CLUSTER=false (consumer skips
-    # its own Cluster + points DB host at shared-pg) AND
-    # SOVEREIGN_ENABLE_SHARED_PG=true (this slot renders the engine).
+    # ONE-FLAG CONTRACT (#3285/#3309): cloud-init computes the per-
+    # consumer flips (SOVEREIGN_{GITEA,HARBOR,KEYCLOAK}_PG_OWN_CLUSTER=
+    # false → consumer skips its own Cluster + points at shared-pg) from
+    # the SAME enable_shared_pg tofu var that drives this gate, so
+    # SOVEREIGN_ENABLE_SHARED_PG=true is the single switch.
     enabled: ${SOVEREIGN_ENABLE_SHARED_PG:=false}
     instance:
       name: shared-pg
@@ -136,8 +152,9 @@ spec:
     topology:
       mode: singleton
       instances: 1
-    # The two bindings — the reuse proof. Two isolated databases + two
-    # roles on ONE Cluster; each reflected into its consumer's namespace.
+    # The three bindings — the reuse proof. Three isolated databases +
+    # three roles on ONE Cluster; each reflected into its consumer's
+    # namespace.
     databases:
       - name: registry          # harbor's coreDatabase
         owner: harbor
@@ -155,3 +172,18 @@ spec:
         reflect:
           secretName: gitea-database-secret
           namespaces: [gitea]
+      # keycloak (#3188 three-instance model): the bitnami keycloak
+      # subchart flips to externalDatabase mode off this hub Secret —
+      # slot 09 gates its bundled keycloak-postgresql StatefulSet on
+      # SOVEREIGN_KEYCLOAK_PG_OWN_CLUSTER (computed from enable_shared_pg
+      # in cloud-init, same one-flag contract as gitea/harbor). Keycloak
+      # runs Liquibase on first boot, so an empty `keycloak` database is
+      # the correct starting state — no schema bootstrap needed here.
+      - name: keycloak          # keycloak's Liquibase-managed database
+        owner: keycloak
+        consumer:
+          blueprint: bp-keycloak
+          mode: shared
+        reflect:
+          secretName: keycloak-database-secret
+          namespaces: [keycloak]

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -1,0 +1,129 @@
+# bp-postgres (shared instance B) — Catalyst bootstrap-kit Blueprint, slot 16c.
+#
+# THREE-INSTANCE MODEL (founder NS-2, Refs #3188): instance B of three.
+# A second install of the SAME bp-postgres chart (slot 16a header has the
+# full model): CNPG Cluster `shared-pg-b` in shared-data carrying the
+# observability + DNS consumers:
+#
+#   - grafana (bp-grafana, slot 25) — FLIPPED zero-touch. The hub Secret
+#     `grafana-database-env` renders the upstream grafana chart's native
+#     env contract (GF_DATABASE_TYPE/HOST/NAME/USER + the minted
+#     GF_DATABASE_PASSWORD alias) via reflect.extraData/passwordAliases
+#     (chart 0.1.5); slot 25's grafana.envFromSecrets picks it up once
+#     reflector pushes it into ns grafana. Grafana migrates its own
+#     schema on first boot, so the empty database is the correct start.
+#   - pdns (bp-powerdns, slot 11) — READY-TO-ADOPT. Database + role +
+#     hub Secret (`pdns-database-secret`) are declared here, but the
+#     consumer flip is a per-app follow-up: bp-powerdns applies the
+#     gpgsql auth-5.0.3 schema via its own Cluster's initdb
+#     postInitApplicationSQL, and CNPG Database CRs have no schema hook —
+#     the flip needs a schema-bootstrap path in the bp-powerdns chart.
+#   - pda (bp-powerdns-admin, slot 11a) — READY-TO-ADOPT. Database +
+#     role + hub Secret (`pda-shared-database-secret` — the chart's own
+#     reflector mirror already owns the `pda-database-secret` name) are
+#     declared; the hub's `uri` key is the exact SQLALCHEMY_DATABASE_URI
+#     contract (#3189 A3), so the follow-up flip is a values-only
+#     databaseSecret.name swap once bp-powerdns-admin gates its bundled
+#     pda-pg Cluster.
+#
+# SAFE-BY-DEFAULT: same SOVEREIGN_ENABLE_SHARED_PG gate as 16a — OFF
+# renders ZERO resources (empty Ready release), so non-sharing provs are
+# byte-identical to today. The shared-data Namespace + the bp-postgres
+# HelmRepository are declared ONCE in 16a (kustomize build rejects
+# duplicates); this slot is the HelmRelease only.
+#
+# Wrapper chart: platform/postgres/chart/
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  # bp-postgres-shared-b is the instance-B data-instance HR. Consumers
+  # (bp-grafana today; bp-powerdns/bp-powerdns-admin post-adoption)
+  # dependsOn THIS, not bp-cnpg, per ADR-0010. releaseName matches
+  # instance.name so Cluster + Secrets are named consistently.
+  name: bp-postgres-shared-b
+  namespace: flux-system
+  labels:
+    catalyst.openova.io/slot: "16c"
+    catalyst.openova.io/data-instance: shared-pg-b
+spec:
+  interval: 15m
+  releaseName: shared-pg-b
+  targetNamespace: shared-data
+  # Same edges as 16a: the CNPG operator (CRDs + webhook) must be
+  # reconciling before the Cluster/Database CRs apply; bp-reflector
+  # pushes the hub Secrets into consumer namespaces as they appear.
+  dependsOn:
+    - name: bp-cnpg
+      namespace: flux-system
+    - name: bp-reflector
+      namespace: flux-system
+  chart:
+    spec:
+      chart: bp-postgres
+      # Pinned in lockstep with 16a/16d — see 16a for the chart
+      # changelog. 0.1.5 ships the env-style hub (reflect.extraData +
+      # passwordAliases) + the `uri` key this slot's bindings rely on.
+      version: 0.1.5
+      sourceRef:
+        kind: HelmRepository
+        name: bp-postgres
+        namespace: flux-system
+  install:
+    timeout: 15m
+    remediation:
+      retries: -1
+  upgrade:
+    timeout: 15m
+    remediation:
+      retries: 3
+  values:
+    # Same master gate as 16a — one switch for all three instances.
+    enabled: ${SOVEREIGN_ENABLE_SHARED_PG:=false}
+    instance:
+      name: shared-pg-b
+      namespace: shared-data
+      storageSize: 10Gi
+    topology:
+      mode: singleton
+      instances: 1
+    databases:
+      # grafana — FLIPPED (see header). The extraData keys are grafana's
+      # native GF_DATABASE_* env contract; GF_DATABASE_HOST carries
+      # host:port in one var per grafana's [database].host convention.
+      - name: grafana
+        owner: grafana
+        consumer:
+          blueprint: bp-grafana
+          mode: shared
+        reflect:
+          secretName: grafana-database-env
+          namespaces: [grafana]
+          extraData:
+            GF_DATABASE_TYPE: postgres
+            GF_DATABASE_HOST: shared-pg-b-rw.shared-data.svc.cluster.local:5432
+            GF_DATABASE_NAME: grafana
+            GF_DATABASE_USER: grafana
+            GF_DATABASE_SSL_MODE: disable
+          passwordAliases: [GF_DATABASE_PASSWORD]
+      # pdns — READY-TO-ADOPT (schema-bootstrap follow-up, see header).
+      - name: pdns
+        owner: pdns
+        consumer:
+          blueprint: bp-powerdns
+          mode: shared
+        reflect:
+          secretName: pdns-database-secret
+          namespaces: [powerdns]
+      # pda — READY-TO-ADOPT (values-only flip once the bundled pda-pg
+      # Cluster is gated; the `uri` key is the #3189 A3 contract).
+      - name: pda
+        owner: pda
+        consumer:
+          blueprint: bp-powerdns-admin
+          mode: shared
+        reflect:
+          secretName: pda-shared-database-secret
+          namespaces: [powerdns-admin]

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -1,0 +1,104 @@
+# bp-postgres (shared instance C) — Catalyst bootstrap-kit Blueprint, slot 16d.
+#
+# THREE-INSTANCE MODEL (founder NS-2, Refs #3188): instance C of three.
+# A third install of the SAME bp-postgres chart (slot 16a header has the
+# full model): CNPG Cluster `shared-pg-c` in shared-data carrying the
+# SME microservice mesh (bp-catalyst-platform, slot 13) — READY-TO-ADOPT.
+#
+# The SME mesh today bootstraps its own `sme-pg` Cluster (products/
+# catalyst/chart/templates/sme-services/cnpg-cluster.yaml) with the
+# primary sme_auth database plus sme_billing + sme_documents via initdb
+# postInitApplicationSQL, all owned by ONE role `sme` and gated on
+# marketplace.enabled. This slot declares the SAME shape on shared-pg-c
+# (three Database CRs, one deduped `sme` role — chart 0.1.5 same-owner
+# bindings) so the adoption flip is a per-app follow-up that points the
+# SME services' secret/host values at `sme-database-secret` /
+# shared-pg-c-rw without re-modelling anything. FerretDB (sme_documents)
+# rides the same role.
+#
+# SAFE-BY-DEFAULT: same SOVEREIGN_ENABLE_SHARED_PG gate as 16a/16c — OFF
+# renders ZERO resources (empty Ready release). The shared-data
+# Namespace + the bp-postgres HelmRepository are declared ONCE in 16a;
+# this slot is the HelmRelease only.
+#
+# Wrapper chart: platform/postgres/chart/
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  # bp-postgres-shared-c is the instance-C data-instance HR. The SME
+  # mesh (bp-catalyst-platform) dependsOn THIS post-adoption, per
+  # ADR-0010. releaseName matches instance.name so Cluster + Secrets
+  # are named consistently.
+  name: bp-postgres-shared-c
+  namespace: flux-system
+  labels:
+    catalyst.openova.io/slot: "16d"
+    catalyst.openova.io/data-instance: shared-pg-c
+spec:
+  interval: 15m
+  releaseName: shared-pg-c
+  targetNamespace: shared-data
+  # Same edges as 16a/16c.
+  dependsOn:
+    - name: bp-cnpg
+      namespace: flux-system
+    - name: bp-reflector
+      namespace: flux-system
+  chart:
+    spec:
+      chart: bp-postgres
+      # Pinned in lockstep with 16a/16c — see 16a for the chart
+      # changelog. 0.1.5 ships the same-owner binding dedupe + the
+      # underscore-sanitized Database CR names this slot relies on.
+      version: 0.1.5
+      sourceRef:
+        kind: HelmRepository
+        name: bp-postgres
+        namespace: flux-system
+  install:
+    timeout: 15m
+    remediation:
+      retries: -1
+  upgrade:
+    timeout: 15m
+    remediation:
+      retries: 3
+  values:
+    # Same master gate as 16a/16c — one switch for all three instances.
+    enabled: ${SOVEREIGN_ENABLE_SHARED_PG:=false}
+    instance:
+      name: shared-pg-c
+      namespace: shared-data
+      storageSize: 10Gi
+    topology:
+      mode: singleton
+      instances: 1
+    # The SME-mesh bindings: three isolated databases, ONE role `sme`
+    # (chart 0.1.5 dedupes the role + password Secret across same-owner
+    # bindings). Database names mirror smePostgres.cluster.database +
+    # additionalDatabases in products/catalyst/chart/values.yaml so the
+    # adoption flip is a host+secret swap, not a rename.
+    databases:
+      - name: sme_auth          # auth service primary DB
+        owner: sme
+        consumer:
+          blueprint: bp-catalyst-platform
+          mode: shared
+        # One hub Secret for the whole mesh — every SME service shares
+        # the `sme` credentials and derives its own database name.
+        reflect:
+          secretName: sme-database-secret
+          namespaces: [sme]
+      - name: sme_billing       # billing service primary DB
+        owner: sme
+        consumer:
+          blueprint: bp-catalyst-platform
+          mode: shared
+      - name: sme_documents     # FerretDB (MongoDB-wire) backing DB
+        owner: sme
+        consumer:
+          blueprint: bp-catalyst-platform
+          mode: shared

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -14,6 +14,7 @@
 #   - bp-mimir (slot 23)        — datasource for metrics.
 #   - bp-tempo (slot 24)        — datasource for traces.
 #   - bp-keycloak (slot 09)     — OIDC IdP for SSO.
+#   - bp-postgres-shared-b (16c) — shared-instance hub Secret (#3188).
 #
 # disableWait: Grafana waits for its CNPG-managed `grafana-app` Secret
 # (synthesised by bp-cnpg via the chart's Cluster CR), and for upstream
@@ -71,6 +72,14 @@ spec:
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template;
     # gateway.networking.k8s.io/v1 CRDs must be registered first.
     - name: bp-gateway-api
+    # bp-postgres-shared-b (#3188 three-instance model): when grafana
+    # SHARES the shared-pg-b instance, gate on it so the grafana Database
+    # + role + reflector-pushed `grafana-database-env` hub Secret exist
+    # before grafana's Deployment references them. Harmless in the
+    # default path — bp-postgres-shared-b is an empty Ready release
+    # within seconds of bp-cnpg + bp-reflector (same unconditional-edge
+    # shape as bp-gitea/bp-harbor → bp-postgres-shared).
+    - name: bp-postgres-shared-b
   chart:
     spec:
       chart: bp-grafana
@@ -113,3 +122,29 @@ spec:
     # fresh Sovereign.
     sso:
       sovereignFqdn: ${SOVEREIGN_FQDN}
+    # ── Shared-instance flip (#3188 three-instance model) ───────────────
+    # The upstream grafana subchart appends this envFrom secretRef to the
+    # Deployment. The hub Secret `grafana-database-env` (slot 16c, chart
+    # bp-postgres 0.1.5) carries grafana's NATIVE env contract —
+    # GF_DATABASE_TYPE/HOST/NAME/USER (reflect.extraData) + the minted
+    # GF_DATABASE_PASSWORD (passwordAliases) — and per grafana's config
+    # precedence env vars override grafana.ini, so injecting it flips
+    # grafana from its sqlite default to the shared-pg-b `grafana`
+    # database with ZERO grafana.ini churn. Grafana migrates its own
+    # schema on first boot.
+    #
+    # The `optional` seam is the safety: cloud-init computes it from the
+    # SAME enable_shared_pg var as the 16a/16c/16d gates (one-flag
+    # contract). Default optional=true → the Secret never exists on a
+    # non-sharing prov and the stanza is provably inert (a secretRef
+    # marked optional on an absent Secret injects nothing). Shared mode
+    # optional=false → kubelet hard-gates the Pod (CreateContainer-
+    # ConfigError, auto-retried) until reflector pushes the Secret, so
+    # grafana can NEVER silently start on sqlite while the binding is
+    # live — the race documented in feedback_netpol_carveouts / #3283 is
+    # closed by construction. envFromSecrets (plural) is used because
+    # envFromSecret (singular) already carries the SSO credentials.
+    grafana:
+      envFromSecrets:
+        - name: grafana-database-env
+          optional: ${SOVEREIGN_GRAFANA_DB_SECRET_OPTIONAL:=true}

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -71,6 +71,16 @@ resources:
   #
   # Slot ordering: after bp-cnpg (16, operator + CRDs), before bp-cnpg-
   # pair (16b). Flux dependsOn pins the real install order regardless.
+  #
+  # THREE-INSTANCE MODEL (founder NS-2, Refs #3188): slots 16a + 16c +
+  # 16d are THREE installs of the same bp-postgres chart — engines
+  # shared-pg (gitea + harbor + keycloak), shared-pg-b (grafana +
+  # powerdns + powerdns-admin) and shared-pg-c (the SME mesh) — all
+  # riding the ONE SOVEREIGN_ENABLE_SHARED_PG gate. All three MUST be
+  # registered here: bp-keycloak (09) / bp-gitea (10) / bp-harbor (19)
+  # dependsOn bp-postgres-shared and bp-grafana (25) dependsOn
+  # bp-postgres-shared-b UNCONDITIONALLY, so an authored-but-unlisted
+  # slot file is the #3191 dangling-dependsOn wedge.
   - 16a-bp-postgres-shared.yaml
   # bp-cnpg-pair (slot 16b) — Pillar-3 cross-region DR primitive (#3195,
   # Refs #3189). Primary + replica CNPG Cluster pair across two regions,
@@ -92,6 +102,12 @@ resources:
   # slot's Cluster CRs gate on. See 16b-bp-cnpg-pair.yaml header for the
   # full Pillar-3 dependency analysis + the harbor-proxy-pull image note.
   - 16b-bp-cnpg-pair.yaml
+  # Instances B + C of the three-instance model (see the 16a block
+  # comment above) — HR-only slot files (Namespace + HelmRepository live
+  # in 16a). Same SOVEREIGN_ENABLE_SHARED_PG gate, same empty-Ready
+  # default-OFF shape.
+  - 16c-bp-postgres-shared-b.yaml
+  - 16d-bp-postgres-shared-c.yaml
   - 17-valkey.yaml
   # bp-hcloud-csi (formerly slot 17a) REMOVED 2026-05-17 (Wave 7):
   # the Flux source-controller chart pull went through harbor.t11.* OCI

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -449,6 +449,17 @@ write_files:
             SOVEREIGN_GITEA_PG_HOST: "${enable_shared_pg == "true" ? "shared-pg-rw.shared-data.svc.cluster.local" : "gitea-pg-rw.gitea.svc.cluster.local"}"
             SOVEREIGN_GITEA_PG_SECRET: "${enable_shared_pg == "true" ? "gitea-database-secret" : "gitea-pg-app"}"
             SOVEREIGN_HARBOR_PG_HOST: "${enable_shared_pg == "true" ? "shared-pg-rw.shared-data.svc.cluster.local" : "harbor-pg-rw.harbor.svc.cluster.local"}"
+            # #3188 three-instance model: the SAME one-flag contract
+            # extends to instance A's third consumer (keycloak — slot 09
+            # skips its bundled bitnami postgresql + flips to
+            # externalDatabase mode off the keycloak-database-secret hub)
+            # and instance B's grafana (slot 25 envFromSecrets
+            # `grafana-database-env`; optional=false hard-gates the Pod on
+            # the reflector push so grafana can never silently start on
+            # sqlite while sharing is live). Slots 16c/16d (shared-pg-b /
+            # shared-pg-c) ride the SOVEREIGN_ENABLE_SHARED_PG gate above.
+            SOVEREIGN_KEYCLOAK_PG_OWN_CLUSTER: "${enable_shared_pg == "true" ? "false" : "true"}"
+            SOVEREIGN_GRAFANA_DB_SECRET_OPTIONAL: "${enable_shared_pg == "true" ? "false" : "true"}"
             SOVEREIGN_BCP_TOPOLOGY: "${bcp_topology}"
             # SOVEREIGN_REGION_ROLE — this control plane's role in the
             # multi-region topology (primary|secondary). Both providers

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-4-1-data-services
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.1.4
+  version: 0.1.5
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-postgres
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable
@@ -30,6 +30,25 @@ description: |
 
   Changelog
   ─────────
+  0.1.5 (2026-06-12, Refs #3188 — founder NS-2 three-instance model)
+    - Same-owner bindings: managed.roles + the role-password Secret are
+      deduped per UNIQUE owner, so one role can own N isolated databases
+      (the SME-mesh shape: sme_auth + sme_billing + sme_documents all
+      owned by role `sme`). One password per owner, stable across the
+      dedupe (lookup role Secret -> lookup any hub of that owner -> mint).
+    - Database CR k8s names sanitized (`replace "_" "-"`) so databases
+      with legal-Postgres underscores render valid RFC-1123 CR names;
+      spec.name keeps the real database name verbatim.
+    - Hub connection Secret gains `uri` (CNPG-app-Secret-parity
+      postgresql:// connection string, the powerdns-admin #3189 A3
+      adoption contract) + optional per-binding `reflect.extraData`
+      (static keys, e.g. grafana's GF_DATABASE_TYPE/HOST/NAME/USER) +
+      `reflect.passwordAliases` (extra key names carrying the minted
+      password, e.g. GF_DATABASE_PASSWORD) so env-style consumers bind
+      via upstream envFromSecrets with zero consumer-chart templates.
+    - Enables the 3-instance bootstrap-kit shape: slots 16a (shared-pg) +
+      16c (shared-pg-b) + 16d (shared-pg-c) are three installs of THIS
+      chart, all gated on SOVEREIGN_ENABLE_SHARED_PG.
   0.1.2 (2026-06-11, Refs #3283)
     - FATAL deadlock fix: connection-secret.yaml now creates each reflected
       connection Secret in the RELEASE namespace (shared-data, which always

--- a/platform/postgres/chart/templates/cluster.yaml
+++ b/platform/postgres/chart/templates/cluster.yaml
@@ -58,16 +58,24 @@ spec:
   CNPG reconciles CREATE/ALTER ROLE + password from the named Secret on
   every reconcile, so a Secret rotation or initdb-vs-Secret drift is
   ALTER USER'd away (the bp-gitea Wave-5.35 #2211 lesson, generalised).
+  0.1.5 (#3188): deduped per UNIQUE owner — bindings may share one owner
+  (the SME mesh's sme_auth/sme_billing/sme_documents all owned by `sme`),
+  which is N Database CRs on ONE role. The passwordSecret is taken from
+  the FIRST binding declaring the owner, matching role-secrets.yaml.
   */ -}}
   {{- if .Values.databases }}
   managed:
     roles:
+      {{- $seenOwners := dict }}
       {{- range .Values.databases }}
+      {{- if not (hasKey $seenOwners .owner) }}
+      {{- $_ := set $seenOwners .owner true }}
       - name: {{ .owner | quote }}
         ensure: present
         login: true
         passwordSecret:
           name: {{ include "bp-postgres.roleSecretName" (dict "ctx" $ "db" .) | quote }}
+      {{- end }}
       {{- end }}
   {{- end }}
   # inheritedMetadata: CNPG propagates these onto every Secret it generates

--- a/platform/postgres/chart/templates/database.yaml
+++ b/platform/postgres/chart/templates/database.yaml
@@ -26,7 +26,11 @@ so the slot 16a HR is an empty Ready release when sharing is disabled.
 apiVersion: postgresql.cnpg.io/v1
 kind: Database
 metadata:
-  name: {{ printf "%s-%s" (include "bp-postgres.instanceName" $ctx) .name | trunc 63 | trimSuffix "-" }}
+  # `replace "_" "-"` (0.1.5, #3188): Postgres database names legally
+  # carry underscores (sme_auth, sme_billing) but Kubernetes resource
+  # names are RFC-1123 — sanitize the CR name; spec.name keeps the real
+  # database name verbatim.
+  name: {{ printf "%s-%s" (include "bp-postgres.instanceName" $ctx) .name | replace "_" "-" | trunc 63 | trimSuffix "-" }}
   namespace: {{ include "bp-postgres.namespace" $ctx }}
   labels:
     {{- include "bp-postgres.labels" $ctx | nindent 4 }}

--- a/platform/postgres/chart/templates/role-secrets.yaml
+++ b/platform/postgres/chart/templates/role-secrets.yaml
@@ -1,8 +1,9 @@
 {{- /*
-Per-binding ROLE PASSWORD Secret + HUB CONNECTION Secret — rendered
-TOGETHER in one scope so both carry the SAME password on every render
-including the very first (two separate templates each calling
-randAlphaNum would mint two different values on a fresh install).
+Per-OWNER role password Secret + per-binding HUB CONNECTION Secret —
+rendered TOGETHER in one scope so every Secret carrying a given owner's
+password carries the SAME password on every render including the very
+first (two separate templates each calling randAlphaNum would mint two
+different values on a fresh install).
 
 Why the chart mints the password (0.1.3, #3285 hw130 layer 1): CNPG only
 auto-generates the bootstrap owner's credentials; managed.roles[].
@@ -19,6 +20,22 @@ password chart-owned there is nothing to pull: the hub renders the full
 connection contract below and stays a clean PUSH source (#3283
 source-side pattern) for the consumer namespaces.
 
+0.1.5 (#3188 three-instance model): bindings may now SHARE one owner
+(e.g. the SME mesh's sme_auth + sme_billing + sme_documents databases
+all owned by role `sme`). The role-password Secret + the managed.roles
+entry are deduped per UNIQUE owner — N same-owner bindings = N Database
+CRs but ONE role + ONE password. The hub Secret also gains:
+  - `uri` — the CNPG-app-Secret-parity connection string
+    (postgresql://owner:password@host:port/dbname) so URI-style
+    consumers (powerdns-admin's SQLALCHEMY_DATABASE_URI, #3189 A3
+    pattern) adopt the instance with a values-only secretKeyRef swap.
+  - `reflect.extraData` — optional STATIC keys rendered verbatim, so an
+    env-style consumer (grafana's upstream envFromSecrets) reads its
+    native variable names (GF_DATABASE_TYPE, GF_DATABASE_HOST, ...).
+  - `reflect.passwordAliases` — optional extra key names carrying the
+    chart-minted password (GF_DATABASE_PASSWORD), kept in the same
+    render scope so aliases NEVER drift from the role password.
+
 Stability: password = lookup(live role Secret) || lookup(live hub
 Secret) || randAlphaNum — upgrades never rotate under a running
 consumer; resource-policy keep guards release replaces.
@@ -27,40 +44,61 @@ consumer; resource-policy keep guards release replaces.
 {{- $ctx := . }}
 {{- $ns := .Release.Namespace }}
 {{- $instance := include "bp-postgres.instanceName" . }}
+{{- /* Pass 1 — resolve ONE stable password per UNIQUE owner. The role
+Secret name is taken from the FIRST binding declaring that owner (per-
+binding passwordSecret overrides therefore apply owner-wide). */ -}}
+{{- $owners := dict }}
 {{- range .Values.databases }}
 {{- $db := . }}
+{{- if not (hasKey $owners $db.owner) }}
 {{- $roleName := include "bp-postgres.roleSecretName" (dict "ctx" $ctx "db" $db) }}
 {{- $password := "" }}
 {{- $liveRole := lookup "v1" "Secret" $ns $roleName }}
 {{- if and $liveRole $liveRole.data $liveRole.data.password }}
 {{- $password = $liveRole.data.password | b64dec }}
-{{- else if and $db.reflect $db.reflect.secretName }}
+{{- end }}
+{{- $_ := set $owners $db.owner (dict "roleName" $roleName "password" $password) }}
+{{- end }}
+{{- /* Hub fallback: any reflect-bearing binding of this owner whose live
+hub Secret still holds the password (release-replace recovery). */ -}}
+{{- $rec := get $owners $db.owner }}
+{{- if and (not $rec.password) $db.reflect $db.reflect.secretName }}
 {{- $liveHub := lookup "v1" "Secret" $ns $db.reflect.secretName }}
 {{- if and $liveHub $liveHub.data $liveHub.data.password }}
-{{- $password = $liveHub.data.password | b64dec }}
+{{- $_ := set $rec "password" ($liveHub.data.password | b64dec) }}
 {{- end }}
 {{- end }}
-{{- if not $password }}
-{{- $password = randAlphaNum 32 }}
+{{- end }}
+{{- /* Pass 2 — mint where nothing live exists, then emit ONE role
+Secret per unique owner (sorted-key iteration = deterministic order). */ -}}
+{{- range $owner, $rec := $owners }}
+{{- if not $rec.password }}
+{{- $_ := set $rec "password" (randAlphaNum 32) }}
 {{- end }}
 ---
 # Role password Secret — CNPG managed.roles[].passwordSecret contract
-# (kubernetes.io/basic-auth: username + password).
+# (kubernetes.io/basic-auth: username + password). ONE per unique owner.
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/basic-auth
 metadata:
-  name: {{ $roleName | quote }}
+  name: {{ $rec.roleName | quote }}
   namespace: {{ $ns | quote }}
   labels:
     {{- include "bp-postgres.labels" $ctx | nindent 4 }}
-    catalyst.openova.io/binding: {{ $db.owner | quote }}
+    catalyst.openova.io/binding: {{ $owner | quote }}
   annotations:
     helm.sh/resource-policy: keep
 stringData:
-  username: {{ $db.owner | quote }}
-  password: {{ $password | quote }}
+  username: {{ $owner | quote }}
+  password: {{ $rec.password | quote }}
+{{- end }}
+{{- /* Pass 3 — hub connection Secrets, one per binding declaring
+`reflect`, each carrying its owner's (deduped) password. */ -}}
+{{- range .Values.databases }}
+{{- $db := . }}
 {{- if and $db.reflect $db.reflect.secretName }}
+{{- $password := (get $owners $db.owner).password }}
 ---
 # Hub connection Secret — lives in the release namespace (always exists;
 # the #3283 anti-deadlock source-side pattern) and auto-pushes a
@@ -87,6 +125,16 @@ stringData:
   dbname: {{ $db.name | quote }}
   host: "{{ $instance }}-rw.{{ $ns }}.svc.cluster.local"
   port: "5432"
+  # CNPG-app-Secret-parity connection string (0.1.5) — URI-style
+  # consumers (powerdns-admin SQLALCHEMY_DATABASE_URI) read this key
+  # verbatim. Password is chart-minted randAlphaNum (URL-safe).
+  uri: "postgresql://{{ $db.owner }}:{{ $password }}@{{ $instance }}-rw.{{ $ns }}.svc.cluster.local:5432/{{ $db.name }}"
+{{- range $k, $v := $db.reflect.extraData }}
+  {{ $k }}: {{ $v | quote }}
+{{- end }}
+{{- range $alias := $db.reflect.passwordAliases }}
+  {{ $alias }}: {{ $password | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -178,4 +178,111 @@ on_secret=$(grep -cE '^kind: Secret$' "$TMP/on.yaml" || true)
 [ "$on_db" -eq 2 ]      || fail "enabled=true expected 2 Databases, got $on_db"
 [ "$on_secret" -eq 4 ]  || fail "enabled=true expected 4 Secrets (2 hub + 2 role), got $on_secret"
 
-echo "[render] PASS — bp-postgres render gate green (reuse proof: 1 Cluster, 2 Databases, 2 roles, 2 Secrets; master gate OFF → empty)"
+# ── Case 8: instance-B shape (#3188 three-instance model) ────────────
+# grafana binding with extraData (static GF_DATABASE_* env keys) +
+# passwordAliases (GF_DATABASE_PASSWORD) + ready-to-adopt pdns + pda
+# bindings. Locks: the env-style hub contract, the `uri` key
+# (powerdns-admin #3189 A3 adoption contract), 3 Databases on ONE
+# shared-pg-b Cluster.
+echo "[render] Case 8: instance-B shape → grafana env-style hub + uri key + 3 Databases on shared-pg-b"
+cat > "$TMP/shared-b.values.yaml" <<'YAML'
+instance:
+  name: shared-pg-b
+  namespace: shared-data
+topology:
+  mode: singleton
+  instances: 1
+databases:
+  - name: grafana
+    owner: grafana
+    consumer: { blueprint: bp-grafana, mode: shared }
+    reflect:
+      secretName: grafana-database-env
+      namespaces: [grafana]
+      extraData:
+        GF_DATABASE_TYPE: postgres
+        GF_DATABASE_HOST: shared-pg-b-rw.shared-data.svc.cluster.local:5432
+        GF_DATABASE_NAME: grafana
+        GF_DATABASE_USER: grafana
+        GF_DATABASE_SSL_MODE: disable
+      passwordAliases: [GF_DATABASE_PASSWORD]
+  - name: pdns
+    owner: pdns
+    consumer: { blueprint: bp-powerdns, mode: shared }
+    reflect: { secretName: pdns-database-secret, namespaces: [powerdns] }
+  - name: pda
+    owner: pda
+    consumer: { blueprint: bp-powerdns-admin, mode: shared }
+    reflect: { secretName: pda-shared-database-secret, namespaces: [powerdns-admin] }
+YAML
+helm template shared-pg-b . -f "$TMP/shared-b.values.yaml" --namespace shared-data \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/shared-b.yaml" 2> "$TMP/shared-b.err" || {
+  cat "$TMP/shared-b.err" >&2; fail "instance-B render errored"; }
+b_cluster=$(grep -cE '^kind: Cluster$' "$TMP/shared-b.yaml" || true)
+b_db=$(grep -cE '^kind: Database$' "$TMP/shared-b.yaml" || true)
+b_secret=$(grep -cE '^kind: Secret$' "$TMP/shared-b.yaml" || true)
+[ "$b_cluster" -eq 1 ] || fail "instance-B expected 1 Cluster, got $b_cluster"
+[ "$b_db" -eq 3 ]      || fail "instance-B expected 3 Databases, got $b_db"
+[ "$b_secret" -eq 6 ]  || fail "instance-B expected 6 Secrets (3 role + 3 hub), got $b_secret"
+grep -q 'GF_DATABASE_TYPE: "postgres"' "$TMP/shared-b.yaml" \
+  || fail "instance-B grafana hub missing GF_DATABASE_TYPE extraData"
+grep -q 'GF_DATABASE_HOST: "shared-pg-b-rw.shared-data.svc.cluster.local:5432"' "$TMP/shared-b.yaml" \
+  || fail "instance-B grafana hub missing GF_DATABASE_HOST extraData"
+grep -qE '^  GF_DATABASE_PASSWORD: ' "$TMP/shared-b.yaml" \
+  || fail "instance-B grafana hub missing GF_DATABASE_PASSWORD alias"
+# The alias must carry the SAME password as the grafana role Secret.
+grafana_role_pw=$(awk '/name: "shared-pg-b-grafana"/{s=1} s&&/^  password: /{print $2; exit}' "$TMP/shared-b.yaml")
+grafana_alias_pw=$(awk '/^  GF_DATABASE_PASSWORD: /{print $2; exit}' "$TMP/shared-b.yaml")
+[ -n "$grafana_role_pw" ] && [ "$grafana_role_pw" = "$grafana_alias_pw" ] \
+  || fail "instance-B GF_DATABASE_PASSWORD alias drifted from the grafana role password"
+uri_count=$(grep -cE '^  uri: "postgresql://' "$TMP/shared-b.yaml" || true)
+[ "$uri_count" -eq 3 ] || fail "instance-B expected 3 hub uri keys (#3189 A3 contract), got $uri_count"
+grep -q 'uri: "postgresql://pda:' "$TMP/shared-b.yaml" \
+  || fail "instance-B pda hub uri missing/owner-mismatched"
+
+# ── Case 9: instance-C shape — same-owner bindings (SME mesh) ─────────
+# THREE databases (sme_auth, sme_billing, sme_documents) owned by ONE
+# role `sme`. Locks the 0.1.5 dedupe (1 managed role, 1 role Secret)
+# and the underscore sanitize on Database CR k8s names.
+echo "[render] Case 9: instance-C shape → 3 same-owner Databases, 1 role, sanitized CR names"
+cat > "$TMP/shared-c.values.yaml" <<'YAML'
+instance:
+  name: shared-pg-c
+  namespace: shared-data
+topology:
+  mode: singleton
+  instances: 1
+databases:
+  - name: sme_auth
+    owner: sme
+    consumer: { blueprint: bp-catalyst-platform, mode: shared }
+    reflect: { secretName: sme-database-secret, namespaces: [sme] }
+  - name: sme_billing
+    owner: sme
+    consumer: { blueprint: bp-catalyst-platform, mode: shared }
+  - name: sme_documents
+    owner: sme
+    consumer: { blueprint: bp-catalyst-platform, mode: shared }
+YAML
+helm template shared-pg-c . -f "$TMP/shared-c.values.yaml" --namespace shared-data \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/shared-c.yaml" 2> "$TMP/shared-c.err" || {
+  cat "$TMP/shared-c.err" >&2; fail "instance-C render errored"; }
+c_db=$(grep -cE '^kind: Database$' "$TMP/shared-c.yaml" || true)
+c_role=$(grep -cE '^      - name: "sme"$' "$TMP/shared-c.yaml" || true)
+c_basic=$(grep -cE '^type: kubernetes.io/basic-auth$' "$TMP/shared-c.yaml" || true)
+c_secret=$(grep -cE '^kind: Secret$' "$TMP/shared-c.yaml" || true)
+[ "$c_db" -eq 3 ]    || fail "instance-C expected 3 Databases, got $c_db"
+[ "$c_role" -eq 1 ]  || fail "instance-C expected EXACTLY 1 managed role sme (dedupe), got $c_role"
+[ "$c_basic" -eq 1 ] || fail "instance-C expected EXACTLY 1 role-password Secret (dedupe), got $c_basic"
+[ "$c_secret" -eq 2 ] || fail "instance-C expected 2 Secrets (1 role + 1 hub), got $c_secret"
+# Sanitized k8s names; verbatim Postgres names.
+grep -q 'name: shared-pg-c-sme-auth' "$TMP/shared-c.yaml" \
+  || fail "instance-C Database CR name not underscore-sanitized"
+if grep -qE '^  name: shared-pg-c-sme_' "$TMP/shared-c.yaml"; then
+  fail "instance-C Database CR k8s name leaked an underscore"
+fi
+grep -q 'name: "sme_auth"' "$TMP/shared-c.yaml" || fail "instance-C spec.name sme_auth missing"
+grep -q 'name: "sme_billing"' "$TMP/shared-c.yaml" || fail "instance-C spec.name sme_billing missing"
+grep -q 'name: "sme_documents"' "$TMP/shared-c.yaml" || fail "instance-C spec.name sme_documents missing"
+
+echo "[render] PASS — bp-postgres render gate green (reuse proof: 1 Cluster, 2 Databases, 2 roles, 2 Secrets; master gate OFF → empty; 3-instance shapes locked)"

--- a/platform/postgres/chart/values.yaml
+++ b/platform/postgres/chart/values.yaml
@@ -97,6 +97,12 @@ topology:
 # Secret. Two entries = two consumers SHARING this one Cluster (two
 # isolated databases + two roles).
 #
+# 0.1.5 (#3188): bindings may SHARE one owner (N databases, ONE role +
+# ONE password — the SME-mesh shape). The role Secret + managed.roles
+# entry are deduped per unique owner; database names with underscores
+# are legal (the Database CR's k8s name is sanitized, spec.name keeps
+# the real Postgres name).
+#
 # databases:
 #   - name: registry        # the isolated database name
 #     owner: harbor         # the per-consumer login role (CNPG manages it)
@@ -114,4 +120,13 @@ topology:
 #     reflect:
 #       secretName: harbor-database-secret  # name in the consumer ns
 #       namespaces: [harbor]                # target namespace(s)
+#       # Optional STATIC keys rendered verbatim into the hub Secret —
+#       # lets an env-style consumer (grafana envFromSecrets) read its
+#       # native variable names. NEVER put credentials here (Principle
+#       # #10) — use passwordAliases for the minted password.
+#       extraData: {}
+#       # Optional extra key names carrying the chart-minted password
+#       # (e.g. [GF_DATABASE_PASSWORD]) — same render scope as the role
+#       # Secret so aliases never drift.
+#       passwordAliases: []
 databases: []

--- a/scripts/check-bootstrap-kit-pin-sync.sh
+++ b/scripts/check-bootstrap-kit-pin-sync.sh
@@ -241,38 +241,38 @@ for chart_yaml in "${CHART_YAMLS[@]}"; do
     continue
   fi
 
-  slot_count=$(echo "${pin_files}" | wc -l)
-  if [ "${slot_count}" -gt 1 ]; then
-    echo "error: multiple bootstrap-kit slots pin chart '${name}':" >&2
-    echo "${pin_files}" >&2
-    echo "       (bootstrap-kit invariant: one slot per chart name)" >&2
-    exit 2
-  fi
+  # Multiple slots MAY pin the same chart — the #3188 three-instance
+  # model installs bp-postgres at slots 16a/16c/16d (three data
+  # instances of one chart). The lockstep contract simply applies to
+  # EVERY pin: each slot file's `      version:` must equal the source
+  # Chart.yaml version. (The former one-slot-per-chart invariant was a
+  # schema assumption, not a convergence requirement; the auto-bump
+  # hook in blueprint-release.yaml bumps every matching slot file.)
+  for pin_file in ${pin_files}; do
+    pinned_version=$(awk '/^      version:/{print $2; exit}' "${pin_file}" | tr -d '"')
 
-  pin_file="${pin_files}"
-  pinned_version=$(awk '/^      version:/{print $2; exit}' "${pin_file}" | tr -d '"')
+    if [ -z "${pinned_version}" ]; then
+      echo "error: ${pin_file} has no '      version:' line at 6-space indent" >&2
+      exit 2
+    fi
 
-  if [ -z "${pinned_version}" ]; then
-    echo "error: ${pin_file} has no '      version:' line at 6-space indent" >&2
-    exit 2
-  fi
+    checked=$((checked + 1))
 
-  checked=$((checked + 1))
+    if [ "${pinned_version}" = "${version}" ]; then
+      echo "  OK   ${name}: chart=${version} pin=${pinned_version} (${pin_file#${REPO_ROOT}/})"
+    else
+      echo "  DRIFT ${name}: chart=${version} pin=${pinned_version} (file: ${pin_file#${REPO_ROOT}/})"
+      drift=$((drift + 1))
+    fi
 
-  if [ "${pinned_version}" = "${version}" ]; then
-    echo "  OK   ${name}: chart=${version} pin=${pinned_version}"
-  else
-    echo "  DRIFT ${name}: chart=${version} pin=${pinned_version} (file: ${pin_file#${REPO_ROOT}/})"
-    drift=$((drift + 1))
-  fi
-
-  # Collect the pin tuple for the optional --check-ghcr phase. We
-  # check the PIN version (not the chart version) — the contract is
-  # that whatever the kit installs must exist on GHCR. If drift is
-  # also flagged, both errors are reported.
-  GHCR_NAMES+=("${name}")
-  GHCR_VERSIONS+=("${pinned_version}")
-  GHCR_PINS+=("${pin_file#${REPO_ROOT}/}")
+    # Collect the pin tuple for the optional --check-ghcr phase. We
+    # check the PIN version (not the chart version) — the contract is
+    # that whatever the kit installs must exist on GHCR. If drift is
+    # also flagged, both errors are reported.
+    GHCR_NAMES+=("${name}")
+    GHCR_VERSIONS+=("${pinned_version}")
+    GHCR_PINS+=("${pin_file#${REPO_ROOT}/}")
+  done
 done
 
 echo

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -100,7 +100,14 @@ slots:
     # bp-gateway-api dep (issue #503): chart ships an HTTPRoute template.
     # G92.2 #2661 (2026-06-01): MGMT vCluster placement added
     # bp-mgmt-vcluster — REVERTED by G105-followup (see slot 8 note).
-    depends_on: [bp-cert-manager, bp-gateway-api]
+    # bp-postgres-shared dep (#3188 three-instance model): when keycloak
+    # SHARES the shared-pg instance A (SOVEREIGN_KEYCLOAK_PG_OWN_CLUSTER=
+    # false), gate on it so the keycloak Database + role + reflected
+    # keycloak-database-secret exist first. Harmless in the default 1:1
+    # path (empty-Ready release) — same shape as slots 10/19. No cycle:
+    # bp-postgres-shared ← {bp-cnpg ← bp-flux, bp-reflector ←
+    # bp-cert-manager}; none of those reaches bp-keycloak.
+    depends_on: [bp-cert-manager, bp-gateway-api, bp-postgres-shared]
     wave: present
   - slot: 10
     name: bp-gitea
@@ -224,6 +231,21 @@ slots:
     name: bp-cnpg-pair
     depends_on: [bp-cnpg]
     wave: present
+  # bp-postgres-shared-b (slot 16c) + bp-postgres-shared-c (slot 16d) —
+  # instances B + C of the #3188 three-instance model (founder NS-2):
+  # three installs of the SAME bp-postgres chart, all gated
+  # ${SOVEREIGN_ENABLE_SHARED_PG}. B (shared-pg-b) carries grafana
+  # (flipped, slot 25) + powerdns/powerdns-admin (ready-to-adopt); C
+  # (shared-pg-c) carries the SME mesh (ready-to-adopt). Same edges as
+  # 16a: bp-cnpg (operator + CRDs), bp-reflector (hub-Secret push).
+  - slot: 16c
+    name: bp-postgres-shared-b
+    depends_on: [bp-cnpg, bp-reflector]
+    wave: W2.K1
+  - slot: 16d
+    name: bp-postgres-shared-c
+    depends_on: [bp-cnpg, bp-reflector]
+    wave: W2.K1
   - slot: 17
     name: bp-valkey
     depends_on: [bp-flux]
@@ -311,7 +333,12 @@ slots:
   - slot: 25
     name: bp-grafana
     # bp-gateway-api dep (issue #503): chart ships an HTTPRoute template.
-    depends_on: [bp-cnpg, bp-loki, bp-mimir, bp-tempo, bp-keycloak, bp-gateway-api]
+    # bp-postgres-shared-b dep (#3188 three-instance model): when grafana
+    # SHARES the shared-pg-b instance, gate on it so the reflector-pushed
+    # grafana-database-env hub Secret exists before grafana's Deployment
+    # references it (envFromSecrets, optional=false in shared mode).
+    # Harmless in the default path (empty-Ready release).
+    depends_on: [bp-cnpg, bp-loki, bp-mimir, bp-tempo, bp-keycloak, bp-gateway-api, bp-postgres-shared-b]
     wave: W2.K2
   - slot: 26
     name: bp-network-policies


### PR DESCRIPTION
## Founder NS-2 — three independent pgsql instances, 6-7 applications reused 3+2+1

> "The cnpg provisioning in this cycle should provision **3 independent pgsql instances** so represented with 3 independent cards and catalog instance shows 3 instances. These 3 instances are used by 6-7 applications reused **3+2+1** or similar ways."

This PR ships the 3-instance model as **three installs of the ONE `bp-postgres` chart** — slots 16a/16c/16d, all riding the existing `SOVEREIGN_ENABLE_SHARED_PG` gate. The #3348 projection layer already renders one card per live instance with bindings, so the three cards follow from these three engines with zero UI work.

### The 3-instance consumer matrix (7 applications, 3+3+1)

| Instance (card) | Slot / HR | Consumer | State |
|---|---|---|---|
| `shared-pg` (A) | 16a `bp-postgres-shared` | gitea | **FLIPPED** (live hw130, #3309) |
| | | harbor (`registry`) | **FLIPPED** (live hw130, #3309) |
| | | keycloak | **FLIPPED zero-touch (NEW)** — bitnami `externalDatabase` + `SOVEREIGN_KEYCLOAK_PG_OWN_CLUSTER` seam |
| `shared-pg-b` (B) | 16c `bp-postgres-shared-b` | grafana | **FLIPPED zero-touch (NEW)** — upstream `envFromSecrets` + native `GF_DATABASE_*` hub Secret |
| | | powerdns (`pdns`) | READY-TO-ADOPT — Database CR + role + hub Secret declared; flip is a per-app follow-up (pdns applies its gpgsql auth-5.0.3 schema via its own Cluster's initdb; CNPG Database CRs have no schema hook) |
| | | powerdns-admin (`pda`) | READY-TO-ADOPT — hub Secret carries the `uri` key (the exact #3189 A3 `SQLALCHEMY_DATABASE_URI` contract), so the follow-up flip is a values-only `databaseSecret.name` swap once the bundled `pda-pg` Cluster is gated |
| `shared-pg-c` (C) | 16d `bp-postgres-shared-c` | SME mesh (`sme_auth` + `sme_billing` + `sme_documents`, ONE role `sme`) | READY-TO-ADOPT — mirrors `smePostgres` values exactly so adoption is a host+secret swap, not a re-model |

### Honest founder-DoD statement

With `SOVEREIGN_ENABLE_SHARED_PG=true` a fresh prov gets **3 independent CNPG instances → 3 cards**, with **4 of the 7 applications actually running on them zero-touch** (gitea, harbor, keycloak, grafana) and **3 declared ready-to-adopt** (pdns, pda, SME) — their Database CRs, roles and connection Secrets exist on the right instance and appear as bindings on the cards, but the apps still run on their own bundled clusters until the per-app flips land. Flipping pdns/pda/SME off their current databases is a data migration on live envs; their charts do not yet support skipping their bundled Clusters via values, so per the constraint-honesty rule those flips are follow-ups, not silently claimed here.

### What changed

**`bp-postgres` 0.1.5** (`platform/postgres/chart`)
- Same-owner binding dedupe: `managed.roles` + role-password Secret render once per UNIQUE owner (the SME shape: 3 databases, 1 role, 1 password).
- Database CR k8s names underscore-sanitized (`sme_auth` → CR `shared-pg-c-sme-auth`, `spec.name` verbatim).
- Hub Secret gains `uri` (CNPG-app-Secret parity) + per-binding `reflect.extraData` (static keys, e.g. `GF_DATABASE_TYPE`) + `reflect.passwordAliases` (minted password under consumer-native key names, e.g. `GF_DATABASE_PASSWORD`) — env-style consumers bind via upstream `envFromSecrets` with zero consumer-chart templates.
- Render tests extended: Case 8 (instance-B shape: env-style hub + `uri`) + Case 9 (instance-C shape: same-owner dedupe + sanitize). **All 9 cases green.**

**Bootstrap-kit**
- 16a: pin 0.1.5 + the keycloak binding (third consumer on instance A).
- NEW 16c (`shared-pg-b`) + 16d (`shared-pg-c`): HR-only slots (Namespace + HelmRepository stay in 16a — kustomize rejects duplicates), same `dependsOn [bp-cnpg, bp-reflector]`, same gate. Registered in `kustomization.yaml` (#3191 dangling-dependsOn lesson).
- 09-keycloak: `dependsOn bp-postgres-shared` + `keycloak.postgresql.enabled: ${SOVEREIGN_KEYCLOAK_PG_OWN_CLUSTER:=true}` + static `externalDatabase` block. **No DAG cycle**: `bp-postgres-shared ← {bp-cnpg ← bp-flux, bp-reflector ← bp-cert-manager}`.
- 25-grafana: `dependsOn bp-postgres-shared-b` + `grafana.envFromSecrets: [{name: grafana-database-env, optional: ${SOVEREIGN_GRAFANA_DB_SECRET_OPTIONAL:=true}}]`. In shared mode `optional=false` hard-gates the Pod on the reflector push, so grafana can never silently start on sqlite while the binding is live.

**Cloud-init** (`infra/providers/_shared/cloudinit-control-plane.tftpl`)
- Two new one-flag seams computed from the same `enable_shared_pg` var: `SOVEREIGN_KEYCLOAK_PG_OWN_CLUSTER`, `SOVEREIGN_GRAFANA_DB_SECRET_OPTIONAL` (the #3285/#3309 gitea/harbor contract extended).

**Guards updated for the multi-slot reality**
- `scripts/check-bootstrap-kit-pin-sync.sh` + the blueprint-release auto-bump hook: multiple slots may pin one chart; the lockstep contract now applies to EVERY pin (16a/16c/16d bump together).
- `scripts/expected-bootstrap-deps.yaml`: keycloak/grafana edges + the two new HRs (lockstep with the slot files).

### Fresh-prov safety — render proofs

- **Default OFF (single-region)**: all three HRs install empty Ready releases (chart Case 6 regression-locked). `bp-keycloak` default render is **structurally byte-identical** with the `externalDatabase` block present — bitnami reads it only when `postgresql.enabled=false`. (`existingSecretUserKey` is deliberately NOT set: bitnami 25.2.0 consults it even in own-cluster mode, flipping `KC_DB_USERNAME` to a `_FILE` mount — caught by the render diff, would have broken default provs.)
- **`bp-grafana` default render** differs by exactly ONE inert stanza — an `optional: true` secretRef on a Secret that never exists when sharing is off (injects nothing, provably). Stated here rather than claimed identical.
- **Shared mode render proofs**: keycloak → `KC_DB_URL: jdbc:postgresql://shared-pg-rw.shared-data...:5432/keycloak`, password file from `keycloak-database-secret`, bundled postgresql StatefulSet skipped (2 STS → 1).

### Validation (all green)

- `platform/postgres/chart/tests/postgres-render.sh` — 9/9 cases
- `scripts/check-bootstrap-deps.sh` — 0 drift, 0 cycles
- `scripts/check-bootstrap-kit-pin-sync.sh` — all 3 bp-postgres pins in lockstep
- `kubectl kustomize clusters/_template/bootstrap-kit` — builds
- `scripts/lint-cloudinit.sh both` — dash -n green both providers
- `scripts/check-tofu-flux-envsubst.sh` — seams correctly escaped
- `scripts/check-no-banned-words.sh` — clean

### Notes for the next live walk

- First SHARED_PG=true prov after this merge walks: 3 cards in the catalog, keycloak SSO end-to-end off shared-pg, grafana dashboards persisted in shared-pg-b (`SELECT count(*) FROM dashboard` beats a wire-proof).
- When slot 26 network-policies re-enables (#3201), the keycloak/grafana → shared-data:5432 paths need the same carve-outs gitea/harbor already exercise (memory: netpol must allow the workload's own cluster paths).
- HOLD the merge if a prov is in flight (memory: never merge right before firing — though this is chart+kit only, the workflow file change rolls CI, not catalyst-api).

Refs #3188

🤖 Generated with [Claude Code](https://claude.com/claude-code)
