### PR TITLE
fix(ui): jobs search crash on handover-imported rows (undefined toLowerCase)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.test.tsx
@@ -191,6 +191,24 @@ describe('JobsTable — matchJob (search filter)', () => {
   it('returns false when no field matches', () => {
     expect(matchJob(job, 'nothing-matches-this')).toBe(false)
   })
+
+  it('never throws on handover-imported rows that omit wire fields (#3367)', () => {
+    // Shape observed live on hw130 after the #3364 jobs import: the Job
+    // type promises strings, but imported rows carry only what the
+    // export stamped. Cast mirrors the runtime wire shape.
+    const imported = {
+      id: 'imp-1',
+      jobName: 'bp-grafana',
+      type: 'install',
+      status: 'succeeded',
+    } as unknown as Job
+    expect(() => matchJob(imported, 'graf')).not.toThrow()
+    expect(matchJob(imported, 'graf')).toBe(true)
+    expect(matchJob(imported, 'nothing-matches-this')).toBe(false)
+    const empty = { id: 'imp-2' } as unknown as Job
+    expect(() => matchJob(empty, 'x')).not.toThrow()
+    expect(matchJob(empty, 'x')).toBe(false)
+  })
 })
 
 describe('JobsTable — formatDuration', () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
@@ -192,17 +192,21 @@ export function regionUnionOfGroup(
  * Search predicate — matches across jobName / appId / dependsOn /
  * status / parentId. Case-insensitive substring match. Exported so
  * unit tests cover edge cases (empty query, query in deps, etc.).
+ *
+ * Every field access tolerates undefined/null: handover-imported rows
+ * (POST /api/v1/internal/jobs/import) carry only what the mothership
+ * export stamped, so the wire shape can omit any of these despite the
+ * Job type — TS types don't survive res.json().
  */
 export function matchJob(job: Job, query: string): boolean {
   if (!query.trim()) return true
   const q = query.toLowerCase()
-  if (job.jobName.toLowerCase().includes(q)) return true
-  if (job.displayName && job.displayName.toLowerCase().includes(q)) return true
-  if (job.appId.toLowerCase().includes(q)) return true
-  if (job.parentId.toLowerCase().includes(q)) return true
-  if (job.status.toLowerCase().includes(q)) return true
-  for (const d of job.dependsOn) {
-    if (d.toLowerCase().includes(q)) return true
+  const fields = [job.jobName, job.displayName, job.appId, job.parentId, job.status]
+  for (const f of fields) {
+    if (typeof f === 'string' && f.toLowerCase().includes(q)) return true
+  }
+  for (const d of job.dependsOn ?? []) {
+    if (typeof d === 'string' && d.toLowerCase().includes(q)) return true
   }
   return false
 }


### PR DESCRIPTION
Found live on hw130 minutes after the #3364 jobs import landed its 127 rows: typing into the /jobs search box hard-crashed the page — `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`.

**Root cause**: `matchJob` (JobsTable.tsx) lowercases `jobName`/`appId`/`parentId`/`status` unguarded and iterates `dependsOn` unguarded. The Job TS type promises strings, but TS types don't survive `res.json()` (the #2873 class) — handover-imported rows carry only what the mothership export stamped.

**Change**: every field access tolerates undefined/null (`typeof f === 'string'` guard; `dependsOn ?? []`). No behavior change for fully-populated rows.

**Validation**: vitest 51/51 (new test pins the imported-row shape + the all-fields-missing shape); `tsc --noEmit` clean.

**Live verification**: rides the next bp-catalyst-platform chart roll on hw130 — will type into /jobs search over the 127 imported rows, screenshot, and post the evidence on the issue before its lifecycle completes.

Refs #3367

🤖 Generated with [Claude Code](https://claude.com/claude-code)