### PR TITLE
fix(bp-postgres,bp-valkey): bootstrap Application CR admits under the OLD CRD — un-deadlocks hw130

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -115,7 +115,7 @@ spec:
       # instance (canonical G117 representation; adoption-guarded,
       # Capabilities-gated) carrying the databases[] Context
       # declarations in spec.parameters.
-      version: 0.1.6
+      version: 0.1.7
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -68,7 +68,7 @@ spec:
       # passwordAliases) + the `uri` key this slot's bindings rely on.
       # 0.1.6 ships the #3370 bootstrapOwned Application-CR
       # self-registration.
-      version: 0.1.6
+      version: 0.1.7
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -55,7 +55,7 @@ spec:
       # underscore-sanitized Database CR names this slot relies on.
       # 0.1.6 ships the #3370 bootstrapOwned Application-CR
       # self-registration.
-      version: 0.1.6
+      version: 0.1.7
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/17-valkey.yaml
+++ b/clusters/_template/bootstrap-kit/17-valkey.yaml
@@ -60,7 +60,7 @@ spec:
       # (context-secrets.yaml) + bootstrapOwned Application-CR
       # self-registration — the generality proof of the platform-wide
       # reuse mechanism on a non-database blueprint.
-      version: 1.1.0
+      version: 1.1.1
       sourceRef:
         kind: HelmRepository
         name: bp-valkey

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-4-1-data-services
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.1.6
+  version: 0.1.7
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,6 +1,10 @@
 apiVersion: v2
 name: bp-postgres
-version: 0.1.6
+# 0.1.7 — #3370 hotfix: bootstrap Application CR stamps environmentRef +
+#   regions so it admits under BOTH the pre-#3370 CRD (hard-required) and the
+#   #3370 CRD (CEL-waived) — breaks the live upgrade-rollback deadlock that
+#   blocked keycloak->gitea->catalyst-platform on hw130.
+version: 0.1.7
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable

--- a/platform/postgres/chart/templates/application-cr.yaml
+++ b/platform/postgres/chart/templates/application-cr.yaml
@@ -55,6 +55,16 @@ metadata:
     catalyst.openova.io/organization: platform
 spec:
   bootstrap: true
+  {{- /* OLD-CRD compatibility (hw130 outage 2026-06-13): the pre-#3370
+       CRD hard-requires environmentRef + regions; the #3370 CRD CEL-
+       waives them for bootstrap-owned instances but still ACCEPTS them.
+       Without these two fields, the Capabilities gate above passes on a
+       CONVERGED env (the old CRD exists) and the CR is rejected ->
+       upgrade fails -> rollback loop -> the keycloak->gitea->umbrella
+       chain deadlocks BEFORE the umbrella can ship the new CRD. These
+       values are inert under both schemas. */}}
+  environmentRef: platform-bootstrap
+  regions: ["primary"]
   blueprintRef:
     name: bp-postgres
     version: {{ .Chart.Version | quote }}

--- a/platform/valkey/blueprint.yaml
+++ b/platform/valkey/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-4-1-data-services
 spec:
-  version: 1.1.0
+  version: 1.1.1
   card:
     title: Valkey
     summary: |

--- a/platform/valkey/chart/Chart.yaml
+++ b/platform/valkey/chart/Chart.yaml
@@ -30,7 +30,11 @@ name: bp-valkey
 # values.yaml under `valkey.auth` for the full rationale +
 # follow-up to re-enable auth once bp-newapi mirrors the
 # bp-valkey-generated password.
-version: 1.1.0
+# 1.1.1 — #3370 hotfix: bootstrap Application CR stamps environmentRef +
+#   regions so it admits under BOTH the pre-#3370 CRD (hard-required) and the
+#   #3370 CRD (CEL-waived) — breaks the live upgrade-rollback deadlock that
+#   blocked keycloak->gitea->catalyst-platform on hw130.
+version: 1.1.1
 description: |
   Catalyst-curated Blueprint umbrella chart for Valkey (Redis-compatible
   cache, BSD-3). Depends on the upstream `valkey` chart (Bitnami) as a

--- a/platform/valkey/chart/templates/application-cr.yaml
+++ b/platform/valkey/chart/templates/application-cr.yaml
@@ -25,6 +25,16 @@ metadata:
     catalyst.openova.io/organization: platform
 spec:
   bootstrap: true
+  {{- /* OLD-CRD compatibility (hw130 outage 2026-06-13): the pre-#3370
+       CRD hard-requires environmentRef + regions; the #3370 CRD CEL-
+       waives them for bootstrap-owned instances but still ACCEPTS them.
+       Without these two fields, the Capabilities gate above passes on a
+       CONVERGED env (the old CRD exists) and the CR is rejected ->
+       upgrade fails -> rollback loop -> the keycloak->gitea->umbrella
+       chain deadlocks BEFORE the umbrella can ship the new CRD. These
+       values are inert under both schemas. */}}
+  environmentRef: platform-bootstrap
+  regions: ["primary"]
   blueprintRef:
     name: bp-valkey
     version: {{ .Chart.Version | quote }}


### PR DESCRIPTION
Live outage fix (hw130, 2026-06-13): console/api/auth/gitea/marketplace 404.

**Chain**: bp-postgres 0.1.6's self-registration Application CR is rejected by the live PRE-#3370 CRD (`spec.environmentRef: Required, spec.regions: Required`) → upgrade-fails→rollback loop → `flux-system/bp-postgres-shared` never Ready → the #3373 conversion chain (keycloak→gitea→bp-catalyst-platform in vc-mgmt) waits on it → the umbrella that SHIPS the new CRD can never install → deadlock. The Capabilities gate checked CRD existence, not shape.

**Fix**: the CR stamps `environmentRef: platform-bootstrap` + `regions: [primary]` — hard-required by the old schema, CEL-waived-but-accepted by the new one, inert under both. postgres 0.1.7 + valkey 1.1.1 + slot pins lockstep. Render gates green (postgres ×10 incl. the self-registration case, valkey contexts ×5).

Refs #3370 #3373

🤖 Generated with [Claude Code](https://claude.com/claude-code)