### PR TITLE
fix(placement): revert the 3 PROMOTE-NOW conversions to STAGED — restore hw130 console/auth/gitea

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -83,7 +83,7 @@ spec:
     # ordering puts cutover after these two come up.
     # G92.3 #2662 (2026-06-01): both HRs moved to host ns `mgmt`.
     - name: bp-gitea
-      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-harbor
     # NB on issue #1871 (TBD-A24 cutover↔gateway circular deadlock):
     # PR #1875 initially added `- name: sovereign-tls` to this list.

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -39,7 +39,7 @@ metadata:
   # longer needs to colocate with vc-mgmt. Reverting also restores
   # the Helm valuesFrom lookup of secrets like 'object-storage'
   # (cloud-init seeds it in flux-system; lookup is in HR's own ns).
-  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+  namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
     catalyst.openova.io/slot: "09"
     catalyst.openova.io/vcluster: mgmt
@@ -47,23 +47,7 @@ spec:
   interval: 15m
   releaseName: keycloak
   targetNamespace: keycloak
-  storageNamespace: keycloak
   # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
-  kubeConfig:
-    secretRef:
-      name: vc-mgmt
-      key: config
-  # G105-followup #2697 (2026-06-01) — G92.2 #2661 placement REVERTED.
-  # bp-keycloak was moved INSIDE the mgmt vCluster, but the vCluster
-  # doesn't yet sync Gateway API CRDs / ExternalSecret CRDs / mgmt ns
-  # back to host, so the chart's HTTPRoute + ExternalSecret resources
-  # fail admission inside the vCluster with `no matches for kind
-  # "HTTPRoute" in version "gateway.networking.k8s.io/v1"`. The
-  # application-controller G92.1 #2674 pivot at the Blueprint layer
-  # STAYS — only this slot's hard-coded kubeConfig.secretRef is removed
-  # so the chart installs on HOST until vCluster CRD sync ships.
-  # Caught live on hw86 2026-06-01: founder PIN-sign-in fails → cascade →
-  # grafana shows local login → no SSO.
   dependsOn:
     # bp-mgmt-vcluster MUST be Ready first — the vc-mgmt
     # Secret doesn't exist until then. placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -40,7 +40,7 @@ metadata:
   # longer needs to colocate with vc-mgmt. Reverting also restores
   # the Helm valuesFrom lookup of secrets like 'object-storage'
   # (cloud-init seeds it in flux-system; lookup is in HR's own ns).
-  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+  namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
     catalyst.openova.io/slot: "10"
     catalyst.openova.io/vcluster: mgmt
@@ -48,17 +48,7 @@ spec:
   interval: 15m
   releaseName: gitea
   targetNamespace: gitea
-  storageNamespace: gitea
   # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
-  kubeConfig:
-    secretRef:
-      name: vc-mgmt
-      key: config
-  # G105-followup #2697 (2026-06-01) — G92.3 #2662 placement REVERTED.
-  # vCluster lacks Gateway API + ExternalSecret CRDs and the mgmt
-  # namespace inside itself. App installs on HOST until vCluster CRD
-  # sync ships. Application-controller G92.1 Blueprint-layer pivot
-  # stays; only slot-level forcing removed.
   dependsOn:
     # bp-mgmt-vcluster MUST be Ready first — the vc-mgmt
     # Secret doesn't exist until then. placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
@@ -66,7 +56,7 @@ spec:
       namespace: flux-system
     # bp-keycloak now lives in flux-system (G105-followup #2697).
     - name: bp-keycloak
-      namespace: mgmt
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template;
     # gateway.networking.k8s.io/v1 CRDs must be registered first.
     - name: bp-gateway-api

--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -85,7 +85,7 @@ spec:
       namespace: flux-system
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
-      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-sso-bridge
       namespace: flux-system
     - name: bp-external-secrets-stores

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -33,7 +33,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-catalyst-platform
-  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+  namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
     catalyst.openova.io/vcluster: mgmt
     # slot encodes bootstrap-kit install order; component=catalyst-platform
@@ -56,12 +56,7 @@ spec:
   interval: 15m
   releaseName: catalyst-platform
   targetNamespace: catalyst-system
-  storageNamespace: catalyst-system
   # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
-  kubeConfig:
-    secretRef:
-      name: vc-mgmt
-      key: config
   dependsOn:
     # bp-mgmt-vcluster MUST be Ready first — the vc-mgmt
     # Secret doesn't exist until then. placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
@@ -69,7 +64,7 @@ spec:
       namespace: flux-system
     # G92.3 #2662 (2026-06-01): bp-gitea HR moved to host ns `mgmt`.
     - name: bp-gitea
-      namespace: mgmt
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     # bp-gateway-api (issue #503): umbrella chart ships catalyst-ui +
     # catalyst-api HTTPRoute templates; gateway.networking.k8s.io/v1
     # CRDs must be registered first.
@@ -86,7 +81,7 @@ spec:
     # the umbrella install, eliminating the race.
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
-      namespace: mgmt
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-cnpg
       namespace: flux-system
     # bp-crossplane-claims (chart-roll-rca iter-15, 2026-05-10): owns the

--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -72,7 +72,7 @@ spec:
     # reconcile once catalyst-api is up. So sso-bridge runs early, writes
     # sso/<app>, and gitea/catalyst-platform install behind it.
     - name: bp-keycloak
-      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-openbao
   chart:
     spec:

--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -90,7 +90,7 @@ spec:
     - name: bp-vcluster-helmrepo
       namespace: flux-system
     - name: bp-catalyst-platform
-      namespace: mgmt
+      namespace: flux-system
     # bp-harbor (slot 19, Wave 11 convergence fix 2026-05-18) — sandbox's
     # chart pull goes through harbor.<sov-fqdn> after the post-handover
     # cutover Step-06 phase-1 HelmRepository URL rewrite. Without this

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -69,7 +69,7 @@ spec:
       namespace: mgmt
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
-      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template;
     # gateway.networking.k8s.io/v1 CRDs must be registered first.
     - name: bp-gateway-api

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -78,7 +78,7 @@ spec:
     - name: bp-cert-manager
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
-      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-sealed-secrets
     - name: bp-seaweedfs
     - name: bp-k8s-ws-proxy

--- a/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+++ b/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
@@ -104,7 +104,7 @@ spec:
   targetNamespace: catalyst-system
   dependsOn:
     - name: bp-catalyst-platform
-      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     # G92.2 #2661 (2026-06-01): bp-nats-jetstream HR moved to host ns `mgmt`.
     - name: bp-nats-jetstream
       namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -68,7 +68,7 @@ spec:
     # host ns `mgmt`.
     - name: bp-openbao
     - name: bp-keycloak
-      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-cnpg
   chart:
     spec:

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -156,20 +156,19 @@ spec:
     # coupling-fix proof app (gitea).
     - {file: 07-nats-jetstream.yaml, hr: bp-nats-jetstream, vcluster: mgmt, target: mgmt,
        namespace: nats-system}
-    - {file: 09-keycloak.yaml, hr: bp-keycloak, vcluster: mgmt, target: mgmt,
-       namespace: keycloak,
-       values: {gateway.backendService: keycloak-x-keycloak-x-mgmt-vcluster}}
+    # REVERTED TO STAGED (2026-06-13 hw130 outage): the PROMOTE-NOW conversion
+    # assumed the syncer copies HTTPRoute/ExternalSecret/CNPG CRDs into the
+    # vCluster — measured FALSE on live vc-mgmt (0 sync-set CRDs; keycloak
+    # install: "no matches for kind HTTPRoute"). Stays staged until the
+    # in-vCluster CRD mechanism is implemented + proven on a non-critical app.
+    - {file: 09-keycloak.yaml, hr: bp-keycloak, vcluster: host, target: mgmt, namespace: keycloak}
     # extraNamespaces: the umbrella renders the SME service set into ns
     # `sme` and cutover artifacts into ns `catalyst` alongside its own
     # catalyst-system — declared so the live conformance audit can
     # attribute those workloads (multi-namespace chart, not undeclared).
-    - {file: 13-bp-catalyst-platform.yaml, hr: bp-catalyst-platform, vcluster: mgmt, target: mgmt,
-       namespace: catalyst-system, extraNamespaces: [sme, catalyst],
-       values: {ingress.gateway.backendServiceApi: catalyst-api-x-catalyst-system-x-mgmt-vcluster,
-                ingress.gateway.backendServiceUi: catalyst-ui-x-catalyst-system-x-mgmt-vcluster}}
-    - {file: 10-gitea.yaml, hr: bp-gitea, vcluster: mgmt, target: mgmt,
-       namespace: gitea,
-       values: {gateway.backendService: gitea-http-x-gitea-x-mgmt-vcluster}}
+    - {file: 13-bp-catalyst-platform.yaml, hr: bp-catalyst-platform, vcluster: host, target: mgmt,
+       namespace: catalyst-system, extraNamespaces: [sme, catalyst]}
+    - {file: 10-gitea.yaml, hr: bp-gitea, vcluster: host, target: mgmt, namespace: gitea}
 
     # Already inside their vClusters (proven recipe slots).
     - {file: 22-loki.yaml, hr: bp-loki, vcluster: mgmt, target: mgmt, namespace: loki}


### PR DESCRIPTION
Service restore. Measured on live vc-mgmt: ZERO sync-set CRDs despite the 0.2.7 syncer config + restart — `sync.toHost.customResources` does NOT copy CRDs into the vCluster (the #3373 coupling-fix assumption). keycloak's in-vCluster install fails (`no matches for kind HTTPRoute`) → gitea → umbrella → console/api/auth/marketplace 404.

Placement is data (the model working as designed): keycloak/gitea/catalyst-platform flip back to `vcluster: host, target: mgmt` — STAGED, intent preserved. Slots regenerated, placement/deps/pin gates green. The in-vCluster CRD mechanism becomes a prerequisite row on #3373's staged table, proven on a non-critical app before any re-promotion. nats/loki/mimir/tempo/coraza/sandbox stay converted (Ready, unaffected).

Refs #3373

🤖 Generated with [Claude Code](https://claude.com/claude-code)