### PR TITLE
feat(console): Organizations menu — directory + parent-first + redirect map (Refs #3378)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1667,6 +1667,14 @@ func main() {
 		rg.Put("/api/v1/sme/commerce/{kind}/{id}", h.HandleSMECommerceUpdate)
 		rg.Delete("/api/v1/sme/commerce/{kind}/{id}", h.HandleSMECommerceDelete)
 
+		// Organizations metering feed (issue #3378 B3) — per-org
+		// consumption aggregation, parent self-showback first. Lean
+		// kube-metrics aggregation (no new component): reuses the
+		// dashboard's per-namespace resource-request rows. The billing
+		// pages read this one GET; 100% attributes to the parent on a
+		// zero-sub-org estate (§5 day-one showback).
+		rg.Get("/api/v1/sme/consumption", h.HandleSovereignConsumption)
+
 		// EPIC-3 (#1098) — Sovereign-prefix RBAC access-matrix surface
 		// (TBD-F4 / C6-007). Chroot-friendly mirror of
 		// /api/v1/sovereigns/{id}/rbac/access-matrix; the id is resolved

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1675,6 +1675,14 @@ func main() {
 		// zero-sub-org estate (§5 day-one showback).
 		rg.Get("/api/v1/sme/consumption", h.HandleSovereignConsumption)
 
+		// Organizations Enter-org support session (issue #3378 B2) —
+		// mints the audited, time-boxed (≤60min) impersonation into a
+		// sub-org's OWN console as a support principal in the org's realm
+		// (never the owner's identity). Reuses the handover-redemption
+		// flow + the #3374/#3385 cookie fix. Writes the audit event;
+		// hidden on the parent row (and rejects entering the parent).
+		rg.Post("/api/v1/sme/organizations/{slug}/enter", h.HandleEnterOrg)
+
 		// EPIC-3 (#1098) — Sovereign-prefix RBAC access-matrix surface
 		// (TBD-F4 / C6-007). Chroot-friendly mirror of
 		// /api/v1/sovereigns/{id}/rbac/access-matrix; the id is resolved

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1655,6 +1655,18 @@ func main() {
 		// SME catalog service.
 		rg.Patch("/api/v1/sovereign/apps/{slug}/publish", h.HandleSovereignAppPublish)
 
+		// Organizations commerce editors (issue #3378 DoD 7/8) — the
+		// console's plans/addons/bundles/industries/apps editors proxy
+		// CRUD onto the EXISTING superadmin-JWT /catalog/admin/* endpoints
+		// on the in-cluster SME commerce catalog. NOT new business
+		// endpoints (§6) — the same mintSMEBridgeToken → smeCatalog proxy
+		// hop HandleSovereignAppPublish uses, generalized to full CRUD so
+		// console.<sovereign>/api/* can reach the admin paths. Reads use
+		// the existing public /catalog/{kind} list endpoints (SME gateway).
+		rg.Post("/api/v1/sme/commerce/{kind}", h.HandleSMECommerceCreate)
+		rg.Put("/api/v1/sme/commerce/{kind}/{id}", h.HandleSMECommerceUpdate)
+		rg.Delete("/api/v1/sme/commerce/{kind}/{id}", h.HandleSMECommerceDelete)
+
 		// EPIC-3 (#1098) — Sovereign-prefix RBAC access-matrix surface
 		// (TBD-F4 / C6-007). Chroot-friendly mirror of
 		// /api/v1/sovereigns/{id}/rbac/access-matrix; the id is resolved

--- a/products/catalyst/bootstrap/api/internal/handler/sme_catalog_client.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_catalog_client.go
@@ -15,9 +15,11 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -181,4 +183,62 @@ func (c *smeCatalogClient) SetPublished(ctx context.Context, slug string, publis
 	c.cachedAt = time.Time{}
 	c.mu.Unlock()
 	return resp.StatusCode, nil
+}
+
+// AdminProxy forwards an arbitrary method + sub-path + JSON body to the
+// SME commerce catalog (services/catalog) and returns (status, body,
+// contentType, error). It is the generic transport for the Organizations
+// commerce editors (issue #3378 DoD 7/8) — the editors ride the EXISTING
+// /catalog/admin/* endpoints (no new business endpoint, §6); this proxy
+// is the same thin transport SetPublished uses, generalized.
+//
+// `subPath` is appended to "<baseURL>/catalog/admin" (e.g.
+// "/plans", "/plans/{id}"). `body` is the verbatim request body bytes
+// (nil for DELETE). The bearer is the canonical SME bridge token minted
+// by the caller (mintSMEBridgeToken) — empty bearer ⇒ the upstream
+// JWTAuth returns 401 which we surface verbatim. Per
+// docs/INVIOLABLE-PRINCIPLES.md #10 the token is never logged.
+//
+// Caching: the SME catalog admin mutations invalidate the published
+// cache so a publish/unpublish or app edit reflects on the next read.
+func (c *smeCatalogClient) AdminProxy(
+	ctx context.Context,
+	method, subPath string,
+	body []byte,
+	bearer string,
+) (int, []byte, string, error) {
+	sub := "/" + strings.TrimLeft(strings.TrimSpace(subPath), "/")
+	url := c.baseURL + "/catalog/admin" + sub
+
+	var reader io.Reader
+	if len(body) > 0 {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, reader)
+	if err != nil {
+		return 0, nil, "", err
+	}
+	req.Header.Set("Accept", "application/json")
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if strings.TrimSpace(bearer) != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, nil, "", err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	ct := resp.Header.Get("Content-Type")
+
+	// A successful mutation invalidates the published cache.
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		c.mu.Lock()
+		c.cached = nil
+		c.cachedAt = time.Time{}
+		c.mu.Unlock()
+	}
+	return resp.StatusCode, respBody, ct, nil
 }

--- a/products/catalyst/bootstrap/api/internal/handler/sme_commerce.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_commerce.go
@@ -1,0 +1,133 @@
+// sme_commerce.go — the Organizations commerce editors' proxy hop
+// (issue #3378 DoD 7/8).
+//
+// The Sovereign console's Organizations menu surfaces editor UIs for the
+// commerce catalog (plans / add-ons / bundles / industries / apps). Those
+// editors ride the EXISTING superadmin-JWT /catalog/admin/* endpoints on
+// the SME commerce catalog (core/services/catalog/handlers/routes.go:
+// 19-38) — §6 of #3378: "Any new endpoint beyond B1-B3 = FAIL". This file
+// is therefore NOT a new business endpoint: it is the same thin proxy hop
+// HandleSovereignAppPublish already uses (mintSMEBridgeToken → smeCatalog
+// client → /catalog/admin/*), generalized to the full CRUD so the console
+// (served at console.<sovereign>, which proxies /api/* through catalyst-
+// api) can reach the admin endpoints that are otherwise only reachable
+// behind the catalog service's own gateway.
+//
+// Routes (registered in cmd/api/main.go), all session-gated like the rest
+// of /api/v1/* and forwarded with the canonical SME bridge token:
+//
+//   POST   /api/v1/sme/commerce/{kind}            → create
+//   PUT    /api/v1/sme/commerce/{kind}/{id}       → update
+//   DELETE /api/v1/sme/commerce/{kind}/{id}       → delete
+//
+// where {kind} ∈ {plans, addons, bundles, industries, apps}. Reads use
+// the existing public catalog list endpoints via the SME gateway — the
+// editors fetch those directly, so no read proxy is added here.
+
+package handler
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// commerceKinds is the closed set of /catalog/admin/* resource families
+// the editors manage. Anything outside this set is rejected with 404 so
+// the proxy can never be pointed at an arbitrary upstream sub-path.
+var commerceKinds = map[string]bool{
+	"plans":      true,
+	"addons":     true,
+	"bundles":    true,
+	"industries": true,
+	"apps":       true,
+}
+
+// HandleSMECommerceCreate — POST /api/v1/sme/commerce/{kind}.
+func (h *Handler) HandleSMECommerceCreate(w http.ResponseWriter, r *http.Request) {
+	h.proxyCommerce(w, r, http.MethodPost, "")
+}
+
+// HandleSMECommerceUpdate — PUT /api/v1/sme/commerce/{kind}/{id}.
+func (h *Handler) HandleSMECommerceUpdate(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimSpace(chi.URLParam(r, "id"))
+	if id == "" {
+		writeBadRequest(w, "missing-id", "id path parameter is required")
+		return
+	}
+	h.proxyCommerce(w, r, http.MethodPut, id)
+}
+
+// HandleSMECommerceDelete — DELETE /api/v1/sme/commerce/{kind}/{id}.
+func (h *Handler) HandleSMECommerceDelete(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimSpace(chi.URLParam(r, "id"))
+	if id == "" {
+		writeBadRequest(w, "missing-id", "id path parameter is required")
+		return
+	}
+	h.proxyCommerce(w, r, http.MethodDelete, id)
+}
+
+// proxyCommerce is the shared body: validate kind, mint the bridge
+// token, read the request body, forward to /catalog/admin/{kind}[/{id}],
+// and relay the upstream status + body verbatim so the editor sees the
+// real validation errors from the catalog service.
+func (h *Handler) proxyCommerce(w http.ResponseWriter, r *http.Request, method, id string) {
+	kind := strings.ToLower(strings.TrimSpace(chi.URLParam(r, "kind")))
+	if !commerceKinds[kind] {
+		writeJSON(w, http.StatusNotFound, map[string]string{
+			"error":  "unknown-commerce-kind",
+			"detail": "kind must be one of plans, addons, bundles, industries, apps",
+		})
+		return
+	}
+
+	bearer, status, errResp := h.mintSMEBridgeToken(r)
+	if errResp != nil {
+		writeJSON(w, status, errResp)
+		return
+	}
+
+	// Read the request body verbatim (create/update carry JSON; delete
+	// carries none). We forward raw bytes — the catalog service owns the
+	// schema, so its own decoder + validation is the single source of
+	// truth. readMutationBody returns (body, true) when a 4xx was already
+	// written (the inverted-boolean convention; see infrastructure.go).
+	var body []byte
+	if method != http.MethodDelete {
+		b, errd := readMutationBody(w, r)
+		if errd {
+			return
+		}
+		body = b
+	}
+
+	subPath := "/" + kind
+	if id != "" {
+		subPath += "/" + id
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), smeCatalogProbeBudget)
+	defer cancel()
+	upstreamStatus, respBody, ct, err := smeCatalog().AdminProxy(ctx, method, subPath, body, bearer)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "sme-catalog-unreachable",
+			"detail": err.Error(),
+		})
+		return
+	}
+	// Relay the upstream response verbatim — status + body — so the
+	// editor surfaces the catalog service's real result (created object,
+	// validation error, 404, etc.).
+	if ct == "" {
+		ct = "application/json"
+	}
+	w.Header().Set("Content-Type", ct)
+	w.WriteHeader(upstreamStatus)
+	if len(respBody) > 0 {
+		_, _ = w.Write(respBody)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sme_commerce_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_commerce_test.go
@@ -1,0 +1,107 @@
+// sme_commerce_test.go — coverage for the Organizations commerce proxy
+// transport (issue #3378 DoD 7/8). Locks: the commerceKinds allow-list,
+// and AdminProxy's URL composition + method + body + bearer forwarding +
+// verbatim status/body relay against an httptest upstream standing in for
+// the SME commerce catalog's /catalog/admin/* surface.
+package handler
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCommerceKindsAllowList(t *testing.T) {
+	for _, k := range []string{"plans", "addons", "bundles", "industries", "apps"} {
+		if !commerceKinds[k] {
+			t.Errorf("expected %q to be an allowed commerce kind", k)
+		}
+	}
+	for _, k := range []string{"", "users", "../secrets", "Plans", "deployments"} {
+		if commerceKinds[k] {
+			t.Errorf("expected %q to be REJECTED, but it was allowed", k)
+		}
+	}
+}
+
+func TestAdminProxy_ForwardsMethodPathBodyAndBearer(t *testing.T) {
+	var gotMethod, gotPath, gotAuth, gotBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"new-1"}`))
+	}))
+	defer upstream.Close()
+
+	c := &smeCatalogClient{baseURL: upstream.URL, http: upstream.Client()}
+
+	status, body, ct, err := c.AdminProxy(
+		context.Background(),
+		http.MethodPost,
+		"/plans",
+		[]byte(`{"slug":"test-w","price_omr":9}`),
+		"bridge-token",
+	)
+	if err != nil {
+		t.Fatalf("AdminProxy: %v", err)
+	}
+	if status != http.StatusCreated {
+		t.Errorf("status: got %d want 201", status)
+	}
+	if string(body) != `{"id":"new-1"}` {
+		t.Errorf("body relayed verbatim: got %q", body)
+	}
+	if ct != "application/json" {
+		t.Errorf("content-type relayed: got %q", ct)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("upstream method: got %q want POST", gotMethod)
+	}
+	if gotPath != "/catalog/admin/plans" {
+		t.Errorf("upstream path: got %q want /catalog/admin/plans", gotPath)
+	}
+	if gotAuth != "Bearer bridge-token" {
+		t.Errorf("bearer forwarded: got %q", gotAuth)
+	}
+	if gotBody != `{"slug":"test-w","price_omr":9}` {
+		t.Errorf("body forwarded: got %q", gotBody)
+	}
+}
+
+func TestAdminProxy_DeleteWithIDSubPathNoBody(t *testing.T) {
+	var gotMethod, gotPath string
+	hadBody := false
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		hadBody = len(b) > 0
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	c := &smeCatalogClient{baseURL: upstream.URL, http: upstream.Client()}
+	status, _, _, err := c.AdminProxy(context.Background(), http.MethodDelete, "/plans/p-1", nil, "tok")
+	if err != nil {
+		t.Fatalf("AdminProxy delete: %v", err)
+	}
+	if status != http.StatusNoContent {
+		t.Errorf("status: got %d want 204", status)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("method: got %q want DELETE", gotMethod)
+	}
+	if gotPath != "/catalog/admin/plans/p-1" {
+		t.Errorf("path: got %q want /catalog/admin/plans/p-1", gotPath)
+	}
+	if hadBody {
+		t.Errorf("delete must not forward a body")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sme_consumption.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_consumption.go
@@ -35,15 +35,15 @@ import (
 // orgConsumption is one org's consumption rollup. With zero sub-orgs the
 // only row is the parent (org="<parent>", isParent=true) carrying 100%.
 type orgConsumption struct {
-	Org      string                 `json:"org"`
-	IsParent bool                   `json:"isParent"`
+	Org      string `json:"org"`
+	IsParent bool   `json:"isParent"`
 	// CostUnits — the showback cost in abstract attribution units (the
 	// weighted CPU+memory+storage sum). Showback attributes consumption;
 	// it is not a billed currency amount.
-	CostUnits float64                `json:"costUnits"`
-	CPUMilli  float64                `json:"cpuMilli"`
-	MemoryGiB float64                `json:"memoryGiB"`
-	StorageGiB float64               `json:"storageGiB"`
+	CostUnits  float64 `json:"costUnits"`
+	CPUMilli   float64 `json:"cpuMilli"`
+	MemoryGiB  float64 `json:"memoryGiB"`
+	StorageGiB float64 `json:"storageGiB"`
 	// Apps — per-application breakdown within the org (DoD 3: "per-app
 	// cost attribution").
 	Apps []appConsumption `json:"apps"`
@@ -63,7 +63,7 @@ type appConsumption struct {
 // SovereignConsumptionResponse is the wire shape the billing pages read.
 type SovereignConsumptionResponse struct {
 	// TotalCostUnits — the Sovereign-wide showback total.
-	TotalCostUnits float64          `json:"totalCostUnits"`
+	TotalCostUnits float64 `json:"totalCostUnits"`
 	// Orgs — one rollup per org, parent first. Empty estate ⇒ a single
 	// parent row with zeros (never null — the page renders its chrome).
 	Orgs []orgConsumption `json:"orgs"`
@@ -77,10 +77,10 @@ type SovereignConsumptionResponse struct {
 // exact constants matter less than that the same weights apply to every
 // org so the per-app share (Percent) is meaningful (§2.6 showback).
 const (
-	weightCPUPerMilli   = 1.0      // per millicore of request
-	weightMemPerGiB     = 4.0      // per GiB of memory request
-	weightStoragePerGiB = 0.25     // per GiB of storage request
-	bytesPerGiB         = 1 << 30  // 1 GiB
+	weightCPUPerMilli   = 1.0     // per millicore of request
+	weightMemPerGiB     = 4.0     // per GiB of memory request
+	weightStoragePerGiB = 0.25    // per GiB of storage request
+	bytesPerGiB         = 1 << 30 // 1 GiB
 )
 
 // HandleSovereignConsumption — GET /api/v1/sme/consumption.

--- a/products/catalyst/bootstrap/api/internal/handler/sme_consumption.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_consumption.go
@@ -1,0 +1,242 @@
+// sme_consumption.go — the B3 metering feed (issue #3378 §6 B3).
+//
+// Per-org consumption aggregation, labeled by org, exposed via ONE GET
+// the Organizations billing pages read. The FIRST deliverable is parent
+// self-showback (testable with zero sub-orgs): on a Sovereign with no
+// sub-orgs, 100% of consumption attributes to the parent organization,
+// broken down per application / namespace (#3378 DoD 3 + §5).
+//
+// Meter source — the lean kube-metrics aggregation (the §6 B3 alternative,
+// "no new component"): this REUSES the existing per-namespace per-pod
+// resource-request rows the dashboard treemap already computes
+// (buildPodRows in dashboard.go), so no bp-openmeter kit slot, no new
+// Blueprint, no placement.yaml row. The cost model is transparent +
+// CPU/memory/storage-request weighted (showback = attributed
+// consumption, not a billed invoice).
+//
+// Route (registered in cmd/api/main.go), session-gated like the rest of
+// /api/v1/*:
+//
+//   GET /api/v1/sme/consumption  → SovereignConsumptionResponse
+//
+// This is NOT a marketplace funnel surface — it works day one on the
+// operator's own estate, which is the whole point of showback (§5).
+
+package handler
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// orgConsumption is one org's consumption rollup. With zero sub-orgs the
+// only row is the parent (org="<parent>", isParent=true) carrying 100%.
+type orgConsumption struct {
+	Org      string                 `json:"org"`
+	IsParent bool                   `json:"isParent"`
+	// CostUnits — the showback cost in abstract attribution units (the
+	// weighted CPU+memory+storage sum). Showback attributes consumption;
+	// it is not a billed currency amount.
+	CostUnits float64                `json:"costUnits"`
+	CPUMilli  float64                `json:"cpuMilli"`
+	MemoryGiB float64                `json:"memoryGiB"`
+	StorageGiB float64               `json:"storageGiB"`
+	// Apps — per-application breakdown within the org (DoD 3: "per-app
+	// cost attribution").
+	Apps []appConsumption `json:"apps"`
+}
+
+// appConsumption is one application's slice within an org.
+type appConsumption struct {
+	Application string  `json:"application"`
+	Namespace   string  `json:"namespace"`
+	CostUnits   float64 `json:"costUnits"`
+	CPUMilli    float64 `json:"cpuMilli"`
+	MemoryGiB   float64 `json:"memoryGiB"`
+	StorageGiB  float64 `json:"storageGiB"`
+	Percent     float64 `json:"percent"` // share of the org's total cost
+}
+
+// SovereignConsumptionResponse is the wire shape the billing pages read.
+type SovereignConsumptionResponse struct {
+	// TotalCostUnits — the Sovereign-wide showback total.
+	TotalCostUnits float64          `json:"totalCostUnits"`
+	// Orgs — one rollup per org, parent first. Empty estate ⇒ a single
+	// parent row with zeros (never null — the page renders its chrome).
+	Orgs []orgConsumption `json:"orgs"`
+	// Pending — true when the metrics cache wasn't available so the page
+	// can flag "metering warming up" instead of asserting a false zero.
+	Pending bool `json:"pending"`
+}
+
+// showback cost weights — transparent + stable. CPU is the scarcest
+// resource on these clusters, so a millicore weighs more than a MiB; the
+// exact constants matter less than that the same weights apply to every
+// org so the per-app share (Percent) is meaningful (§2.6 showback).
+const (
+	weightCPUPerMilli   = 1.0      // per millicore of request
+	weightMemPerGiB     = 4.0      // per GiB of memory request
+	weightStoragePerGiB = 0.25     // per GiB of storage request
+	bytesPerGiB         = 1 << 30  // 1 GiB
+)
+
+// HandleSovereignConsumption — GET /api/v1/sme/consumption.
+func (h *Handler) HandleSovereignConsumption(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	depID := strings.TrimSpace(q.Get("deployment_id"))
+	clusterID := depID
+	if h.k8sCache != nil {
+		clusterID = h.resolveChrootClusterID(clusterID)
+	}
+
+	// Resolve the parent org name = the Sovereign FQDN (the parent org IS
+	// the Sovereign, §2.2). Falls back to "sovereign" when unresolved.
+	parentOrg := h.consumptionParentOrg(depID)
+
+	// No cache ⇒ return the parent-only empty rollup flagged pending so
+	// the page renders showback chrome (never a hard error). This is the
+	// §5 "never blank" rule applied to the metering feed.
+	if clusterID == "" || h.k8sCache == nil || !h.k8sCacheHasCluster(clusterID) {
+		writeJSON(w, http.StatusOK, SovereignConsumptionResponse{
+			Orgs:    []orgConsumption{{Org: parentOrg, IsParent: true, Apps: []appConsumption{}}},
+			Pending: true,
+		})
+		return
+	}
+
+	pods, _, _ := h.k8sCache.List(clusterID, "pod", labels.Everything())
+	pvcs, _, _ := h.k8sCache.List(clusterID, "persistentvolumeclaim", labels.Everything())
+	podMetrics, _, _ := h.k8sCache.List(clusterID, "podmetrics", labels.Everything())
+	namespaces, _, _ := h.k8sCache.List(clusterID, "namespace", labels.Everything())
+	nodes, _, _ := h.k8sCache.List(clusterID, "node", labels.Everything())
+
+	rows := buildPodRows(pods, pvcs, podMetrics, namespaces, nodes, clusterID, "")
+
+	resp := aggregateConsumption(rows, parentOrg)
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// aggregateConsumption rolls podRows up into the per-org / per-app
+// showback shape. orgFor maps a namespace to its owning org; today every
+// namespace attributes to the parent (sub-org namespaces carry the
+// vcluster/org label that a later PR keys on — until then 100% → parent,
+// which is exactly the §5 day-one showback contract).
+func aggregateConsumption(rows []podRow, parentOrg string) SovereignConsumptionResponse {
+	// org → namespace+app key → app rollup.
+	type appKey struct{ org, ns, app string }
+	appAgg := map[appKey]*appConsumption{}
+	orgAgg := map[string]*orgConsumption{}
+
+	ensureOrg := func(org string) *orgConsumption {
+		oc, ok := orgAgg[org]
+		if !ok {
+			oc = &orgConsumption{Org: org, IsParent: org == parentOrg, Apps: []appConsumption{}}
+			orgAgg[org] = oc
+		}
+		return oc
+	}
+	// Always seed the parent so the estate is never blank (§5).
+	ensureOrg(parentOrg)
+
+	var total float64
+	for _, row := range rows {
+		org := orgForNamespace(row, parentOrg)
+		cpuMilli := row.cpuReq
+		memGiB := row.memReq / bytesPerGiB
+		storageGiB := row.storageLim / bytesPerGiB
+		cost := cpuMilli*weightCPUPerMilli + memGiB*weightMemPerGiB + storageGiB*weightStoragePerGiB
+
+		oc := ensureOrg(org)
+		oc.CostUnits += cost
+		oc.CPUMilli += cpuMilli
+		oc.MemoryGiB += memGiB
+		oc.StorageGiB += storageGiB
+		total += cost
+
+		app := row.application
+		if app == "" {
+			app = "(unlabeled)"
+		}
+		k := appKey{org: org, ns: row.namespace, app: app}
+		ac, ok := appAgg[k]
+		if !ok {
+			ac = &appConsumption{Application: app, Namespace: row.namespace}
+			appAgg[k] = ac
+		}
+		ac.CostUnits += cost
+		ac.CPUMilli += cpuMilli
+		ac.MemoryGiB += memGiB
+		ac.StorageGiB += storageGiB
+	}
+
+	// Attach apps to their org + compute per-app percent share.
+	for k, ac := range appAgg {
+		oc := orgAgg[k.org]
+		if oc == nil {
+			continue
+		}
+		if oc.CostUnits > 0 {
+			ac.Percent = roundPct(ac.CostUnits / oc.CostUnits * 100)
+		}
+		oc.Apps = append(oc.Apps, *ac)
+	}
+
+	// Stable ordering: parent first, then orgs by descending cost; apps
+	// within an org by descending cost.
+	orgs := make([]orgConsumption, 0, len(orgAgg))
+	for _, oc := range orgAgg {
+		sort.Slice(oc.Apps, func(i, j int) bool {
+			return oc.Apps[i].CostUnits > oc.Apps[j].CostUnits
+		})
+		oc.CostUnits = round2(oc.CostUnits)
+		oc.CPUMilli = round2(oc.CPUMilli)
+		oc.MemoryGiB = round2(oc.MemoryGiB)
+		oc.StorageGiB = round2(oc.StorageGiB)
+		orgs = append(orgs, *oc)
+	}
+	sort.Slice(orgs, func(i, j int) bool {
+		if orgs[i].IsParent != orgs[j].IsParent {
+			return orgs[i].IsParent // parent first
+		}
+		return orgs[i].CostUnits > orgs[j].CostUnits
+	})
+
+	return SovereignConsumptionResponse{
+		TotalCostUnits: round2(total),
+		Orgs:           orgs,
+	}
+}
+
+// orgForNamespace maps a pod's namespace to its owning org. Today every
+// namespace attributes to the parent (§5 day-one: 100% → parent). When a
+// sub-org's vCluster/namespace carries an org label, a later PR keys on
+// it here — the showback labels stay identical, so chargeback "becomes
+// meaningful automatically when the first sub-org splits out" (§5) with
+// no new mechanism.
+func orgForNamespace(_ podRow, parentOrg string) string {
+	return parentOrg
+}
+
+// consumptionParentOrg resolves the parent org name (the Sovereign FQDN).
+func (h *Handler) consumptionParentOrg(depID string) string {
+	if val, ok := h.deployments.Load(depID); ok {
+		if dep, ok := val.(*Deployment); ok {
+			dep.mu.Lock()
+			fqdn := dep.Request.SovereignFQDN
+			dep.mu.Unlock()
+			if strings.TrimSpace(fqdn) != "" {
+				return fqdn
+			}
+		}
+	}
+	return "sovereign"
+}
+
+func roundPct(v float64) float64 { return round2(v) }
+
+func round2(v float64) float64 {
+	return float64(int64(v*100+0.5)) / 100
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sme_consumption_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_consumption_test.go
@@ -1,0 +1,86 @@
+// sme_consumption_test.go — the B3 showback aggregation (issue #3378
+// DoD 3 + §5). Locks the day-one contract: with zero sub-orgs 100% of
+// consumption attributes to the parent, broken down per application, with
+// per-app percent shares that sum to ~100.
+package handler
+
+import (
+	"math"
+	"testing"
+)
+
+func TestAggregateConsumption_ParentSelfShowback(t *testing.T) {
+	const parent = "hw130.omantel.biz"
+	rows := []podRow{
+		// catalyst-api: 500m CPU, 1 GiB mem, no storage.
+		{namespace: "catalyst", application: "catalyst-api", cpuReq: 500, memReq: 1 << 30},
+		// grafana: 250m CPU, 0.5 GiB mem, 10 GiB storage.
+		{namespace: "monitoring", application: "grafana", cpuReq: 250, memReq: 512 << 20, storageLim: 10 << 30},
+		// a second grafana pod (same app/ns) — must fold into one app row.
+		{namespace: "monitoring", application: "grafana", cpuReq: 250, memReq: 512 << 20},
+	}
+
+	resp := aggregateConsumption(rows, parent)
+
+	// Exactly one org row — the parent — and it is flagged parent.
+	if len(resp.Orgs) != 1 {
+		t.Fatalf("expected exactly the parent org row, got %d orgs", len(resp.Orgs))
+	}
+	p := resp.Orgs[0]
+	if !p.IsParent || p.Org != parent {
+		t.Fatalf("first row must be the parent %q, got %q (isParent=%v)", parent, p.Org, p.IsParent)
+	}
+
+	// Two distinct apps within the parent.
+	if len(p.Apps) != 2 {
+		t.Fatalf("expected 2 app rows (catalyst-api + grafana), got %d", len(p.Apps))
+	}
+
+	// grafana folded its two pods: 500m CPU total, 1 GiB mem, 10 GiB storage.
+	var grafana *appConsumption
+	for i := range p.Apps {
+		if p.Apps[i].Application == "grafana" {
+			grafana = &p.Apps[i]
+		}
+	}
+	if grafana == nil {
+		t.Fatal("grafana app row missing")
+	}
+	if grafana.CPUMilli != 500 {
+		t.Errorf("grafana CPUMilli: got %v want 500 (two pods folded)", grafana.CPUMilli)
+	}
+	if math.Abs(grafana.StorageGiB-10) > 0.001 {
+		t.Errorf("grafana StorageGiB: got %v want 10", grafana.StorageGiB)
+	}
+
+	// Per-app percents sum to ~100 (the parent owns 100% of the estate).
+	var pct float64
+	for _, a := range p.Apps {
+		pct += a.Percent
+	}
+	if math.Abs(pct-100) > 0.5 {
+		t.Errorf("per-app percents should sum to ~100, got %v", pct)
+	}
+
+	// Cost is positive and equals the org total.
+	if p.CostUnits <= 0 {
+		t.Errorf("parent cost must be positive, got %v", p.CostUnits)
+	}
+	if math.Abs(p.CostUnits-resp.TotalCostUnits) > 0.01 {
+		t.Errorf("single-org estate: parent cost %v should equal total %v", p.CostUnits, resp.TotalCostUnits)
+	}
+}
+
+func TestAggregateConsumption_EmptyEstateNeverBlank(t *testing.T) {
+	// Zero rows ⇒ still exactly one parent row (the §5 never-blank rule).
+	resp := aggregateConsumption(nil, "sovereign")
+	if len(resp.Orgs) != 1 {
+		t.Fatalf("empty estate must still render the parent row, got %d orgs", len(resp.Orgs))
+	}
+	if !resp.Orgs[0].IsParent {
+		t.Errorf("the lone row must be the parent")
+	}
+	if resp.Orgs[0].Apps == nil {
+		t.Errorf("apps must be a non-nil slice so the page renders []")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sme_enter_org.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_enter_org.go
@@ -1,0 +1,230 @@
+// sme_enter_org.go — the B2 "Enter org" support session (issue #3378
+// §6 B2 + DoD 6).
+//
+// One endpoint mints the audited, time-boxed (≤60min) impersonation into
+// a sub-organization's OWN console as a SUPPORT PRINCIPAL in the org's
+// realm (never the owner's identity). This ABSORBS what OSS's SEE+SUPPORT
+// would have been (§2.4): the org's own limited-similar console IS the
+// view; there is no bespoke parent-side estate read.
+//
+// Recursion (§2.5): the SAME handover primitive that signs the operator
+// from mothership into a child Sovereign (auth_handover.go) signs the
+// sovereign-admin one level further down, into a sub-org's console. The
+// minted token reuses the EXISTING handover-redemption flow — the org's
+// catalyst-api redeems it at /auth/handover exactly as a Sovereign
+// redeems the mothership's token — and inherits the #3374/#3385 handover
+// cookie-domain fix (now on main) without duplicating it.
+//
+// Route (registered in cmd/api/main.go), session-gated + sovereign-admin:
+//
+//   POST /api/v1/sme/organizations/{slug}/enter
+//     → { "handoverURL": "...", "supportPrincipal": "...",
+//         "expiresAt": "...", "auditEventId": "..." }
+//
+// The caller (the Enter-org button) opens handoverURL in a new tab; the
+// org's console redeems it and lands the support principal logged in with
+// the in-console support banner. The audit event (who/when/org/duration)
+// is written before the URL is returned. The button is HIDDEN on the
+// parent row (§5: "you are already inside it") — the handler also rejects
+// an attempt to enter the parent as a guard.
+
+package handler
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+
+	auth "github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+)
+
+// enterOrgMaxTTL caps the support session at 60 minutes (§6 B2: "TTL ≤
+// 60min"). The session is deliberately short — support, not a standing
+// login.
+const enterOrgMaxTTL = 60 * time.Minute
+
+// EnterOrgResponse is the wire shape the Enter-org button consumes.
+type EnterOrgResponse struct {
+	// HandoverURL — the org-console URL the button opens; redeeming it
+	// lands the support principal logged into the org's console.
+	HandoverURL string `json:"handoverURL"`
+	// SupportPrincipal — the dedicated support identity in the org's
+	// realm (NEVER the owner's identity, §2.4).
+	SupportPrincipal string `json:"supportPrincipal"`
+	// Org — the entered org slug.
+	Org string `json:"org"`
+	// ExpiresAt — the session expiry (≤60min from now).
+	ExpiresAt time.Time `json:"expiresAt"`
+	// AuditEventID — the id of the audit event written for this entry.
+	AuditEventID string `json:"auditEventId"`
+}
+
+// HandleEnterOrg — POST /api/v1/sme/organizations/{slug}/enter.
+func (h *Handler) HandleEnterOrg(w http.ResponseWriter, r *http.Request) {
+	slug := strings.ToLower(strings.TrimSpace(chi.URLParam(r, "slug")))
+	if slug == "" {
+		writeBadRequest(w, "missing-slug", "org slug is required")
+		return
+	}
+
+	// Caller must be a sovereign-admin — the support session is a
+	// privileged operator action. ClaimsFromContext carries the authed
+	// session; an unauthenticated caller never reaches here (session
+	// gate), but we re-check the role explicitly.
+	claims := auth.ClaimsFromContext(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthenticated"})
+		return
+	}
+	if !enterOrgCallerIsAdmin(claims) {
+		writeJSON(w, http.StatusForbidden, map[string]string{
+			"error":  "insufficient-role",
+			"detail": "Enter-org requires a sovereign-admin session",
+		})
+		return
+	}
+
+	sovFQDN := h.sovereignFQDN()
+	if sovFQDN == "" {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "sovereign-fqdn-unconfigured",
+			"detail": "this catalyst-api Pod cannot resolve its Sovereign FQDN",
+		})
+		return
+	}
+
+	// Guard: the parent org IS the Sovereign — entering it is a no-op
+	// ("you are already inside it", §5). The button is hidden on the
+	// parent row; reject a forged attempt.
+	if strings.EqualFold(slug, sovFQDN) || slug == "sovereign" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":  "cannot-enter-parent",
+			"detail": "the parent organization is the Sovereign itself — you are already inside it",
+		})
+		return
+	}
+
+	if h.handoverSigner == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "handover-signer-unwired",
+			"detail": "this catalyst-api Pod has no handover signer; the support session cannot be minted",
+		})
+		return
+	}
+
+	// The org's own console host. Per-org consoles are served at
+	// console.<org>.<sovereign-domain> (the limited-similar UI, §2.4).
+	orgConsoleHost := "console." + slug + "." + sovFQDN
+	orgConsoleURL := "https://" + orgConsoleHost
+
+	// The support principal — a dedicated support identity in the org's
+	// realm, NEVER the owner's identity (§2.4). Derived from the
+	// operator's email so the audit trail ties the session to a real
+	// person while the principal that lands in the org is a support role.
+	supportPrincipal := "support+" + sanitizeEmailLocal(claims.Email) + "@" + slug + "." + sovFQDN
+
+	now := time.Now()
+	expiresAt := now.Add(enterOrgMaxTTL)
+	jti := uuid.NewString()
+
+	// Mint the handover token targeting the ORG's console (aud =
+	// console.<org>.<sov>). The org's catalyst-api redeems it at
+	// /auth/handover with the SAME validation the Sovereign uses for the
+	// mothership's token (iss=console.openova.io, role=sovereign-admin,
+	// email_verified). The support_session marker drives the in-console
+	// banner; impersonated_org records which org was entered.
+	tokenClaims := jwt.MapClaims{
+		"iss":             "https://console.openova.io",
+		"sub":             supportPrincipal,
+		"email":           supportPrincipal,
+		"email_verified":  true,
+		"role":            "sovereign-admin",
+		"sovereign_fqdn":  slug + "." + sovFQDN,
+		"deployment_id":   "",
+		"iat":             now.Unix(),
+		"exp":             expiresAt.Unix(),
+		"jti":             jti,
+		// Support-session markers (§6 B2): the org console renders the
+		// banner from support_session + records the auditing context.
+		"support_session":   true,
+		"support_principal": supportPrincipal,
+		"impersonated_org":  slug,
+		"initiated_by":      claims.Email,
+	}
+	token, err := h.handoverSigner.SignCustomClaims(tokenClaims)
+	if err != nil {
+		h.log.Error("enter-org: SignCustomClaims failed", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "mint-failed"})
+		return
+	}
+
+	auditID := "enter-org-" + slug + "-" + jti
+
+	// Write the audit event (who/when/org/duration) BEFORE returning the
+	// URL. Structured log line is the durable audit record; downstream
+	// log shipping persists it. (#3378 §6 B2: "writes the audit event".)
+	h.log.Info("enter-org: support session minted",
+		"audit", auditID,
+		"initiatedBy", claims.Email,
+		"org", slug,
+		"supportPrincipal", supportPrincipal,
+		"ttlSeconds", int(enterOrgMaxTTL.Seconds()),
+		"expiresAt", expiresAt.Format(time.RFC3339),
+	)
+
+	handoverURL := orgConsoleURL + "/auth/handover?token=" + token
+
+	writeJSON(w, http.StatusOK, EnterOrgResponse{
+		HandoverURL:      handoverURL,
+		SupportPrincipal: supportPrincipal,
+		Org:              slug,
+		ExpiresAt:        expiresAt,
+		AuditEventID:     auditID,
+	})
+}
+
+// enterOrgCallerIsAdmin reports whether the authed caller is a
+// sovereign-admin (or owner). Mirrors the role vocabulary the rest of the
+// Sovereign console authz uses.
+func enterOrgCallerIsAdmin(claims *auth.Claims) bool {
+	if claims == nil {
+		return false
+	}
+	if strings.EqualFold(claims.Tier, "owner") {
+		return true
+	}
+	for _, role := range claims.RealmAccess.Roles {
+		switch strings.ToLower(role) {
+		case "sovereign-admin", "sovereign-admins", "catalyst-admin", "catalyst-owner":
+			return true
+		}
+	}
+	return false
+}
+
+// sanitizeEmailLocal extracts a DNS/identity-safe local part from an
+// email so the support principal is a valid identifier.
+func sanitizeEmailLocal(email string) string {
+	local := email
+	if i := strings.IndexByte(email, '@'); i >= 0 {
+		local = email[:i]
+	}
+	var b strings.Builder
+	for _, c := range strings.ToLower(local) {
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9', c == '-', c == '.':
+			b.WriteRune(c)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	out := b.String()
+	if out == "" {
+		out = "operator"
+	}
+	return out
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sme_enter_org.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_enter_org.go
@@ -138,16 +138,16 @@ func (h *Handler) HandleEnterOrg(w http.ResponseWriter, r *http.Request) {
 	// email_verified). The support_session marker drives the in-console
 	// banner; impersonated_org records which org was entered.
 	tokenClaims := jwt.MapClaims{
-		"iss":             "https://console.openova.io",
-		"sub":             supportPrincipal,
-		"email":           supportPrincipal,
-		"email_verified":  true,
-		"role":            "sovereign-admin",
-		"sovereign_fqdn":  slug + "." + sovFQDN,
-		"deployment_id":   "",
-		"iat":             now.Unix(),
-		"exp":             expiresAt.Unix(),
-		"jti":             jti,
+		"iss":            "https://console.openova.io",
+		"sub":            supportPrincipal,
+		"email":          supportPrincipal,
+		"email_verified": true,
+		"role":           "sovereign-admin",
+		"sovereign_fqdn": slug + "." + sovFQDN,
+		"deployment_id":  "",
+		"iat":            now.Unix(),
+		"exp":            expiresAt.Unix(),
+		"jti":            jti,
 		// Support-session markers (§6 B2): the org console renders the
 		// banner from support_session + records the auditing context.
 		"support_session":   true,

--- a/products/catalyst/bootstrap/api/internal/handler/sme_enter_org_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_enter_org_test.go
@@ -1,0 +1,56 @@
+// sme_enter_org_test.go — coverage for the Enter-org support-session
+// helpers (issue #3378 B2 / DoD 6): the sovereign-admin authz gate, the
+// support-principal local-part sanitization, and the TTL cap invariant.
+package handler
+
+import (
+	"testing"
+	"time"
+
+	auth "github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+)
+
+func TestEnterOrgCallerIsAdmin(t *testing.T) {
+	tests := []struct {
+		name   string
+		claims *auth.Claims
+		want   bool
+	}{
+		{"nil claims rejected", nil, false},
+		{"owner tier admitted", &auth.Claims{Tier: "owner"}, true},
+		{"sovereign-admin role admitted", &auth.Claims{RealmAccess: auth.RealmAccess{Roles: []string{"sovereign-admin"}}}, true},
+		{"catalyst-owner role admitted", &auth.Claims{RealmAccess: auth.RealmAccess{Roles: []string{"catalyst-owner"}}}, true},
+		{"plain viewer rejected", &auth.Claims{Tier: "viewer", RealmAccess: auth.RealmAccess{Roles: []string{"catalyst-viewer"}}}, false},
+		{"no roles, no tier rejected", &auth.Claims{}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := enterOrgCallerIsAdmin(tc.claims); got != tc.want {
+				t.Errorf("enterOrgCallerIsAdmin = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeEmailLocal(t *testing.T) {
+	cases := map[string]string{
+		"emrah.baysal@openova.io": "emrah.baysal",
+		"Operator+Tag@x.com":      "operator-tag",
+		"weird name!@x.com":       "weird-name-",
+		"":                        "operator",
+		"@nolocal.com":            "operator",
+	}
+	for in, want := range cases {
+		if got := sanitizeEmailLocal(in); got != want {
+			t.Errorf("sanitizeEmailLocal(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestEnterOrgTTLCappedAt60Min(t *testing.T) {
+	// The support session must never exceed 60 minutes (§6 B2 "TTL ≤
+	// 60min"). This guards a future edit from widening the constant.
+	if enterOrgMaxTTL > 60*time.Minute {
+		t.Fatalf("enterOrgMaxTTL = %v, must be ≤ 60m", enterOrgMaxTTL)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sme_tenant.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_tenant.go
@@ -326,15 +326,15 @@ type smeTenantResponse struct {
 	ConsoleHost     string                        `json:"console_host"`
 	// Organizations model (issue #3378 B1) — surfaced so the directory
 	// can badge the org by kind/tier/billingMode/isolation.
-	Kind        string `json:"kind,omitempty"`
-	Tier        string `json:"tier,omitempty"`
-	BillingMode string `json:"billing_mode,omitempty"`
-	Isolation   string `json:"isolation,omitempty"`
-	CommitSHA   string `json:"commit_sha,omitempty"`
-	LastError       string                        `json:"last_error,omitempty"`
-	Steps           smeTenantSteps                `json:"steps"`
-	CreatedAt       time.Time                     `json:"created_at"`
-	UpdatedAt       time.Time                     `json:"updated_at"`
+	Kind        string         `json:"kind,omitempty"`
+	Tier        string         `json:"tier,omitempty"`
+	BillingMode string         `json:"billing_mode,omitempty"`
+	Isolation   string         `json:"isolation,omitempty"`
+	CommitSHA   string         `json:"commit_sha,omitempty"`
+	LastError   string         `json:"last_error,omitempty"`
+	Steps       smeTenantSteps `json:"steps"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
 }
 
 // smeTenantSteps surfaces the 7-state machine to the SPA so it can

--- a/products/catalyst/bootstrap/api/internal/handler/sme_tenant.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_tenant.go
@@ -242,6 +242,73 @@ type smeTenantCreateRequest struct {
 	AdminEmail string `json:"admin_email"`
 	// CompanyName — branding metadata; optional.
 	CompanyName string `json:"company_name,omitempty"`
+
+	// ── Organizations internal door (issue #3378 B1) ──
+	//
+	// These map onto OrganizationSpec Kind/Tier/BillingMode + the
+	// derived Isolation. When omitted (the marketplace funnel = the
+	// customer door) the handler stamps the customer default shape so
+	// the funnel is byte-unchanged. kind="internal" (this menu's Create
+	// = the internal door) stamps the department shape (showback +
+	// namespace) and skips the voucher dependency — no voucher step for
+	// an internal org. The handler resolves billing_mode + isolation
+	// from kind when those two are omitted (the kind-derived default;
+	// the advanced-view override sends them explicitly).
+	Kind        string `json:"kind,omitempty"`
+	Tier        string `json:"tier,omitempty"`
+	BillingMode string `json:"billing_mode,omitempty"`
+	Isolation   string `json:"isolation,omitempty"`
+}
+
+// orgShape is the resolved Organizations-model shape (issue #3378 B1)
+// the create handler stamps onto the provision record.
+type orgShape struct {
+	Kind        string
+	Tier        string
+	BillingMode string
+	Isolation   string
+}
+
+// resolveOrgShape applies the §2.1/§2.3 model: kind defaults to
+// "customer" (the marketplace door); kind-derived billingMode +
+// isolation defaults (internal → showback + namespace; customer → real +
+// vcluster) fill in when the advanced override didn't send them; tier
+// defaults to "sme". Unknown enum values fall back to the kind default
+// so a malformed body can never stamp a nonsense shape.
+func resolveOrgShape(req smeTenantCreateRequest) orgShape {
+	kind := strings.ToLower(strings.TrimSpace(req.Kind))
+	if kind != "internal" && kind != "customer" {
+		kind = "customer"
+	}
+
+	// kind-derived defaults (§2.3).
+	defBilling, defIsolation := "real", "vcluster"
+	if kind == "internal" {
+		defBilling, defIsolation = "showback", "namespace"
+	}
+
+	billing := strings.ToLower(strings.TrimSpace(req.BillingMode))
+	switch billing {
+	case "real", "chargeback", "showback":
+	default:
+		billing = defBilling
+	}
+
+	isolation := strings.ToLower(strings.TrimSpace(req.Isolation))
+	switch isolation {
+	case "namespace", "vcluster":
+	default:
+		isolation = defIsolation
+	}
+
+	tier := strings.ToLower(strings.TrimSpace(req.Tier))
+	switch tier {
+	case "sme", "corporate":
+	default:
+		tier = "sme"
+	}
+
+	return orgShape{Kind: kind, Tier: tier, BillingMode: billing, Isolation: isolation}
 }
 
 type smeTenantResponse struct {
@@ -257,7 +324,13 @@ type smeTenantResponse struct {
 	VClusterName    string                        `json:"vcluster_name"`
 	TenantNamespace string                        `json:"tenant_namespace"`
 	ConsoleHost     string                        `json:"console_host"`
-	CommitSHA       string                        `json:"commit_sha,omitempty"`
+	// Organizations model (issue #3378 B1) — surfaced so the directory
+	// can badge the org by kind/tier/billingMode/isolation.
+	Kind        string `json:"kind,omitempty"`
+	Tier        string `json:"tier,omitempty"`
+	BillingMode string `json:"billing_mode,omitempty"`
+	Isolation   string `json:"isolation,omitempty"`
+	CommitSHA   string `json:"commit_sha,omitempty"`
 	LastError       string                        `json:"last_error,omitempty"`
 	Steps           smeTenantSteps                `json:"steps"`
 	CreatedAt       time.Time                     `json:"created_at"`
@@ -366,6 +439,10 @@ func smeTenantRecordToResponse(rec store.SMETenantProvisionRecord) smeTenantResp
 		VClusterName:    rec.VClusterName,
 		TenantNamespace: rec.TenantNamespace,
 		ConsoleHost:     deriveConsoleHost(rec),
+		Kind:            rec.Kind,
+		Tier:            rec.Tier,
+		BillingMode:     rec.BillingMode,
+		Isolation:       rec.Isolation,
 		CommitSHA:       rec.CommitSHA,
 		LastError:       rec.LastError,
 		Steps:           stepsForState(rec.State, rec.LastError),
@@ -462,6 +539,14 @@ func (h *Handler) HandleCreateSMETenant(w http.ResponseWriter, r *http.Request) 
 		writeBadRequest(w, "admin-email-invalid", "admin_email must be a valid email")
 		return
 	}
+
+	// Organizations model (issue #3378 B1): resolve the kind/tier/
+	// billingMode/isolation shape. kind defaults to "customer" (the
+	// marketplace funnel door) so the funnel is byte-unchanged; the
+	// internal door sends kind="internal" → showback + namespace, no
+	// voucher step. The resolved shape is stamped on the record below.
+	shape := resolveOrgShape(body)
+
 	if mode == "" {
 		mode = string(store.SMEDomainFreeSubdomain)
 	}
@@ -556,6 +641,15 @@ func (h *Handler) HandleCreateSMETenant(w http.ResponseWriter, r *http.Request) 
 		OTECHFQDN:       otech,
 		VClusterName:    "vc-" + subdomain,
 		TenantNamespace: "sme-" + smeTenantID,
+		// Organizations model (issue #3378 B1) — stamp the resolved
+		// kind/tier/billingMode/isolation so the directory badges the
+		// org correctly and the controller can later read the spec
+		// shape (namespace-mode reconcile is the placement/org-controller
+		// follow-on per #3378 §9; this records the desired-state fields).
+		Kind:        shape.Kind,
+		Tier:        shape.Tier,
+		BillingMode: shape.BillingMode,
+		Isolation:   shape.Isolation,
 	}
 	if err := deps.Store.Put(rec); err != nil {
 		h.log.Error("sme-tenant: persist pending failed", "err", err)

--- a/products/catalyst/bootstrap/api/internal/handler/sme_tenant_orgshape_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_tenant_orgshape_test.go
@@ -1,0 +1,67 @@
+// sme_tenant_orgshape_test.go — coverage for resolveOrgShape, the
+// Organizations internal-door defaulting (issue #3378 B1). Locks the
+// §2.1/§2.3 model: kind defaults to customer (the funnel door); kind-
+// derived billingMode + isolation defaults; the advanced override; and
+// the malformed-enum fallback that keeps a bad body from stamping a
+// nonsense shape.
+package handler
+
+import "testing"
+
+func TestResolveOrgShape(t *testing.T) {
+	tests := []struct {
+		name string
+		in   smeTenantCreateRequest
+		want orgShape
+	}{
+		{
+			name: "omitted kind defaults to the customer funnel shape (byte-unchanged)",
+			in:   smeTenantCreateRequest{},
+			want: orgShape{Kind: "customer", Tier: "sme", BillingMode: "real", Isolation: "vcluster"},
+		},
+		{
+			name: "internal door → showback + namespace (kind-derived defaults)",
+			in:   smeTenantCreateRequest{Kind: "internal"},
+			want: orgShape{Kind: "internal", Tier: "sme", BillingMode: "showback", Isolation: "namespace"},
+		},
+		{
+			name: "explicit customer → real + vcluster",
+			in:   smeTenantCreateRequest{Kind: "customer"},
+			want: orgShape{Kind: "customer", Tier: "sme", BillingMode: "real", Isolation: "vcluster"},
+		},
+		{
+			name: "advanced override: internal org forced onto chargeback + vcluster",
+			in:   smeTenantCreateRequest{Kind: "internal", BillingMode: "chargeback", Isolation: "vcluster"},
+			want: orgShape{Kind: "internal", Tier: "sme", BillingMode: "chargeback", Isolation: "vcluster"},
+		},
+		{
+			name: "corporate tier honored",
+			in:   smeTenantCreateRequest{Kind: "internal", Tier: "corporate"},
+			want: orgShape{Kind: "internal", Tier: "corporate", BillingMode: "showback", Isolation: "namespace"},
+		},
+		{
+			name: "case-insensitive enum normalization",
+			in:   smeTenantCreateRequest{Kind: "INTERNAL", Tier: "Corporate", BillingMode: "ShowBack", Isolation: "NameSpace"},
+			want: orgShape{Kind: "internal", Tier: "corporate", BillingMode: "showback", Isolation: "namespace"},
+		},
+		{
+			name: "malformed kind falls back to customer default shape",
+			in:   smeTenantCreateRequest{Kind: "garbage"},
+			want: orgShape{Kind: "customer", Tier: "sme", BillingMode: "real", Isolation: "vcluster"},
+		},
+		{
+			name: "malformed billingMode/isolation fall back to the kind-derived default",
+			in:   smeTenantCreateRequest{Kind: "internal", BillingMode: "bogus", Isolation: "bogus", Tier: "bogus"},
+			want: orgShape{Kind: "internal", Tier: "sme", BillingMode: "showback", Isolation: "namespace"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveOrgShape(tc.in)
+			if got != tc.want {
+				t.Fatalf("resolveOrgShape(%+v) = %+v, want %+v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/store/sme_tenant.go
+++ b/products/catalyst/bootstrap/api/internal/store/sme_tenant.go
@@ -166,7 +166,24 @@ type SMETenantProvisionRecord struct {
 	RetryCount int `json:"retry_count"`
 	// LastError — structured `<step>:<class>:<detail>` per ADR-0003
 	// §3.8. Truncated to 256 bytes.
-	LastError string    `json:"last_error,omitempty"`
+	LastError string `json:"last_error,omitempty"`
+
+	// ── Organizations model (issue #3378 B1 — the internal door) ──
+	//
+	// These four fields map onto OrganizationSpec
+	// (core/controllers/organization/internal/orgapi/types.go:54-79):
+	// Kind/Tier/BillingMode + the derived Isolation. The marketplace
+	// funnel (the customer door) omits them and the create handler
+	// stamps the customer default shape (kind=customer, tier=sme,
+	// billingMode=real, isolation=vcluster) so the funnel is byte-
+	// unchanged. The internal door (kind=internal) stamps the
+	// department shape (showback + namespace) and skips the voucher
+	// dependency. Empty (legacy records) reads as the customer default.
+	Kind        string `json:"kind,omitempty"`
+	Tier        string `json:"tier,omitempty"`
+	BillingMode string `json:"billing_mode,omitempty"`
+	Isolation   string `json:"isolation,omitempty"`
+
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/products/catalyst/bootstrap/ui/src/app/organizationsRedirects.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/organizationsRedirects.test.tsx
@@ -30,8 +30,8 @@ const ORGANIZATIONS_REDIRECTS: readonly { path: string; to: string }[] = [
   { path: '/bss/orders', to: '/organizations/billing/orders' },
   { path: '/bss/revenue', to: '/organizations/billing/revenue' },
   { path: '/bss/vouchers', to: '/organizations/billing/vouchers' },
-  { path: '/sme/users', to: '/organizations' },
-  { path: '/sme/roles', to: '/organizations' },
+  // /sme/users + /sme/roles keep live routes until the org-detail
+  // users/roles tabs land — intentionally NOT in the redirect map yet.
   { path: '/sme/tenants/new', to: '/organizations/new' },
   { path: '/parent-domains', to: '/organizations/domains' },
 ]

--- a/products/catalyst/bootstrap/ui/src/app/organizationsRedirects.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/organizationsRedirects.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * organizationsRedirects.test.tsx — the §4 redirect map (issue #3378):
+ * "old URLs never break". Every legacy BSS / SME-admin / parent-domains
+ * path must answer with a redirect to its new home under /organizations.
+ *
+ * The map under test mirrors ORGANIZATIONS_REDIRECTS in router.tsx
+ * verbatim — kept in lockstep so a drift fails the suite. Each case
+ * navigates to the legacy path and asserts the resolved location is the
+ * new home (the redirect fired). Uses the same beforeLoad-throw-redirect
+ * idiom as the production routes.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup, waitFor } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  redirect,
+  Outlet,
+} from '@tanstack/react-router'
+
+// Mirrors ORGANIZATIONS_REDIRECTS in router.tsx — keep in lockstep.
+const ORGANIZATIONS_REDIRECTS: readonly { path: string; to: string }[] = [
+  { path: '/bss', to: '/organizations' },
+  { path: '/bss/tenants', to: '/organizations' },
+  { path: '/bss/billing', to: '/organizations/billing/billing' },
+  { path: '/bss/orders', to: '/organizations/billing/orders' },
+  { path: '/bss/revenue', to: '/organizations/billing/revenue' },
+  { path: '/bss/vouchers', to: '/organizations/billing/vouchers' },
+  { path: '/sme/users', to: '/organizations' },
+  { path: '/sme/roles', to: '/organizations' },
+  { path: '/sme/tenants/new', to: '/organizations/new' },
+  { path: '/parent-domains', to: '/organizations/domains' },
+]
+
+// All new-home paths the redirects target — registered as leaf stubs so
+// the router can resolve the post-redirect location.
+const NEW_HOMES = [
+  '/organizations',
+  '/organizations/new',
+  '/organizations/billing/billing',
+  '/organizations/billing/orders',
+  '/organizations/billing/revenue',
+  '/organizations/billing/vouchers',
+  '/organizations/domains',
+]
+
+function buildRouter(initialPath: string) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const homeRoutes = NEW_HOMES.map((p) =>
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path: p,
+      component: () => <div data-testid={`home-${p}`}>{p}</div>,
+    }),
+  )
+  const redirectRoutes = ORGANIZATIONS_REDIRECTS.map((r) =>
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path: r.path,
+      component: () => null,
+      beforeLoad: () => {
+        throw redirect({ to: r.to as never, replace: true })
+      },
+    }),
+  )
+  const tree = rootRoute.addChildren([...homeRoutes, ...redirectRoutes])
+  return createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+  })
+}
+
+afterEach(() => cleanup())
+
+describe('Organizations redirect map (§4 — old URLs never break)', () => {
+  for (const { path, to } of ORGANIZATIONS_REDIRECTS) {
+    it(`${path} → ${to}`, async () => {
+      const router = buildRouter(path)
+      render(<RouterProvider router={router} />)
+      await waitFor(() => {
+        expect(router.state.location.pathname).toBe(to)
+      })
+    })
+  }
+})

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -107,9 +107,14 @@ import { NotificationsPage } from '@/pages/sovereign/NotificationsPage'
 // scrolling to the Marketplace anchor.
 import { DeploymentsList } from '@/pages/sovereign/DeploymentsList'
 // CreateTenantPage re-mounts as the Organizations internal door at
-// /organizations/new (issue #3378). The SME UsersPage / RolesPage
-// imports were removed with their legacy routes — their people surfaces
-// fold into the org-detail page in a follow-on PR on the #3378 chain.
+// /organizations/new (issue #3378). The SME UsersPage / RolesPage keep
+// their /sme/users + /sme/roles routes for now — their people surfaces
+// fold into the org-detail page's users + roles tabs in a follow-on PR
+// on the #3378 chain, and only THEN do those two paths redirect (the
+// redirect destination must exist first). Until then they render live so
+// no SME-admin people surface regresses.
+import { UsersPage as SMEUsersPage } from '@/pages/sme/UsersPage'
+import { RolesPage as SMERolesPage } from '@/pages/sme/RolesPage'
 import { CreateTenantPage as SMECreateTenantPage } from '@/pages/sme/CreateTenantPage'
 import { SovereigntyPreviewPage } from '@/pages/sovereignty/SovereigntyPreviewPage'
 // qa-loop iter-6 Cluster-A `spa-target-state-routes-missing` —
@@ -1508,15 +1513,27 @@ const consoleInstallBlueprintRoute = createRoute({
  * keeps the bundle a single SPA per [Q-mine-1]/#795 and lets the
  * SME admin deep-link into either page from the welcome email.
  */
-// The legacy /sme/users, /sme/roles, /parent-domains, and
-// /sme/tenants/new route registrations moved to the Organizations menu
-// (issue #3378): their old paths now resolve via
-// consoleOrganizationsRedirectRoutes (→ /organizations + /organizations/
-// new + /organizations/domains), and the create form re-mounts as
-// CreateOrganizationPage at /organizations/new. The SMEUsersPage /
-// SMERolesPage people surfaces fold into the org-detail page's users +
-// roles tabs in a follow-on PR on this chain; until that lands the
-// legacy paths redirect to the directory so no deep-link 404s.
+// Organizations menu move (issue #3378): /parent-domains and
+// /sme/tenants/new now resolve via consoleOrganizationsRedirectRoutes
+// (→ /organizations/domains + /organizations/new), and the create form
+// re-mounts as CreateOrganizationPage at /organizations/new.
+//
+// /sme/users + /sme/roles keep their live routes below for now — their
+// people surfaces fold into the org-detail page's users + roles tabs in
+// a follow-on PR on this chain, and only THEN do those two paths
+// redirect (the destination must exist first). Until then they render
+// live so the SME-admin people surface (and the sme-demo walk) keeps
+// working.
+const consoleSMEUsersRoute = createRoute({
+  getParentRoute: () => consoleLayoutRoute,
+  path: '/sme/users',
+  component: SMEUsersPage,
+})
+const consoleSMERolesRoute = createRoute({
+  getParentRoute: () => consoleLayoutRoute,
+  path: '/sme/roles',
+  component: SMERolesPage,
+})
 
 /* ── Compliance dashboards — chroot Sovereign Console (slice U, #1096) ──
  *
@@ -1683,9 +1700,10 @@ const ORGANIZATIONS_REDIRECTS: readonly OrgRedirect[] = [
   { path: '/bss/orders', to: '/organizations/billing/orders' },
   { path: '/bss/revenue', to: '/organizations/billing/revenue' },
   { path: '/bss/vouchers', to: '/organizations/billing/vouchers' },
-  // SME-admin people surfaces → the org's own page owns its people.
-  { path: '/sme/users', to: '/organizations' },
-  { path: '/sme/roles', to: '/organizations' },
+  // /sme/users + /sme/roles intentionally NOT redirected yet — they keep
+  // live routes until the org-detail users/roles tabs land (the redirect
+  // destination must exist first; redirecting to a non-existent tab would
+  // break the SME-admin people surface + the sme-demo walk).
   { path: '/sme/tenants/new', to: '/organizations/new' },
   // Parent-domain pools → the Organizations Domains home.
   { path: '/parent-domains', to: '/organizations/domains' },
@@ -2225,6 +2243,10 @@ const routeTree = rootRoute.addChildren([
     consoleBlueprintsPublishRoute,
     consoleBlueprintsCurateRoute,
     consoleSettingsRoute,
+    // SME-admin people surfaces — live until the org-detail users/roles
+    // tabs land on the #3378 chain (then /sme/users + /sme/roles redirect).
+    consoleSMEUsersRoute,
+    consoleSMERolesRoute,
     // Compliance dashboards — chroot routes (slice U, #1096).
     consoleSREComplianceRoute,
     consoleSecComplianceRoute,

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -164,6 +164,9 @@ import { OrganizationsDirectoryPage } from '@/pages/sovereign/organizations/Orga
 // editor over the EXISTING /catalog/admin/* endpoints, mounted at
 // /organizations/commerce/{plans,addons,bundles,industries,apps}.
 import { CommerceEditorPage } from '@/pages/sovereign/organizations/CommerceEditorPage'
+// Org detail (issue #3378 §4) — identity card + consumption panel +
+// Enter-org button (sub-orgs only). Wires the dead data-href-todo.
+import { OrganizationDetailPage } from '@/pages/sovereign/organizations/OrganizationDetailPage'
 // B4 mode-aware billing (issue #3378 DoD 5) — wraps the moved billing
 // pages; payment flows render only in real mode, showback/chargeback get
 // the consumption view with zero payment actions.
@@ -1653,6 +1656,19 @@ const consoleOrganizationsNewRoute = createRoute({
   path: '/organizations/new',
   component: SMECreateTenantPage,
 })
+// /organizations/$org — the org detail page (identity card + consumption
+// panel + Enter-org button). The literal /organizations/{new,commerce,
+// billing,domains} routes are registered too; TanStack matches the most
+// specific literal segment before this $org param, so e.g.
+// /organizations/new resolves to the create form, not org slug "new".
+const consoleOrganizationDetailRoute = createRoute({
+  getParentRoute: () => consoleLayoutRoute,
+  path: '/organizations/$org',
+  component: () => {
+    const { org } = consoleOrganizationDetailRoute.useParams() as { org: string }
+    return <OrganizationDetailPage org={org} />
+  },
+})
 
 /* Moved pages — the SAME page components as the legacy BSS / parent-
  * domains routes, re-mounted under their /organizations home. Page
@@ -2282,6 +2298,7 @@ const routeTree = rootRoute.addChildren([
     // /parent-domains path keeps resolving).
     consoleOrganizationsRoute,
     consoleOrganizationsNewRoute,
+    consoleOrganizationDetailRoute,
     consoleOrgBillingRoute,
     consoleOrgOrdersRoute,
     consoleOrgRevenueRoute,

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -106,8 +106,10 @@ import { NotificationsPage } from '@/pages/sovereign/NotificationsPage'
 // resolve via the operator clicking Settings in the sidebar then
 // scrolling to the Marketplace anchor.
 import { DeploymentsList } from '@/pages/sovereign/DeploymentsList'
-import { UsersPage as SMEUsersPage } from '@/pages/sme/UsersPage'
-import { RolesPage as SMERolesPage } from '@/pages/sme/RolesPage'
+// CreateTenantPage re-mounts as the Organizations internal door at
+// /organizations/new (issue #3378). The SME UsersPage / RolesPage
+// imports were removed with their legacy routes — their people surfaces
+// fold into the org-detail page in a follow-on PR on the #3378 chain.
 import { CreateTenantPage as SMECreateTenantPage } from '@/pages/sme/CreateTenantPage'
 import { SovereigntyPreviewPage } from '@/pages/sovereignty/SovereigntyPreviewPage'
 // qa-loop iter-6 Cluster-A `spa-target-state-routes-missing` —
@@ -138,12 +140,21 @@ import { PodLogsPage } from '@/pages/sovereign/resources/PodLogsPage'
 // retired in favor of the sidebar's existing BSS group + the landing's
 // section-nav grid. Iframe content is preserved in the section pages
 // until Wave 6 PRs 2-6 native-port each one.
-import { BssLandingPage } from '@/pages/sovereign/bss/BssLandingPage'
+// BSS section pages re-mount under /organizations/billing/* (issue
+// #3378). BssLandingPage + TenantsPage are fully replaced by the
+// Organizations directory (the parent-first org table), so their imports
+// were removed with the legacy /bss + /bss/tenants routes.
 import { BillingPage as BssBillingPage } from '@/pages/sovereign/bss/BillingPage'
 import { OrdersPage as BssOrdersPage } from '@/pages/sovereign/bss/OrdersPage'
 import { RevenuePage as BssRevenuePage } from '@/pages/sovereign/bss/RevenuePage'
 import { VouchersPage as BssVouchersPage } from '@/pages/sovereign/bss/VouchersPage'
-import { TenantsPage as BssTenantsPage } from '@/pages/sovereign/bss/TenantsPage'
+// Organizations menu (issue #3378) — ONE menu replacing BSS+OSS. The
+// directory's parent org is the first citizen; CreateOrganizationPage is
+// the internal door (the same component as the SME create form, mounted
+// under the Organization-named route). Pages move WITH redirects (the old
+// /bss*, /sme/users, /sme/roles, /sme/tenants/new, /parent-domains URLs
+// keep resolving) — see consoleOrgRedirectRoutes below.
+import { OrganizationsDirectoryPage } from '@/pages/sovereign/organizations/OrganizationsDirectoryPage'
 // Wave 3 — Sandbox UI scaffold (branch: sandbox-wave3-ui-scaffold).
 // Per-Org agent-coding workspace mounted under /sandbox/* in the chroot
 // Sovereign Console. SandboxLanding is the 6-agent picker;
@@ -1497,47 +1508,15 @@ const consoleInstallBlueprintRoute = createRoute({
  * keeps the bundle a single SPA per [Q-mine-1]/#795 and lets the
  * SME admin deep-link into either page from the welcome email.
  */
-const consoleSMEUsersRoute = createRoute({
-  getParentRoute: () => consoleLayoutRoute,
-  path: '/sme/users',
-  component: SMEUsersPage,
-})
-
-const consoleSMERolesRoute = createRoute({
-  getParentRoute: () => consoleLayoutRoute,
-  path: '/sme/roles',
-  component: SMERolesPage,
-})
-
-/* ── Multi-domain Sovereign — Parent Domains admin (issue #829) ────────
- *
- * Operator-admin "Add another parent domain" surface + DNS propagation
- * status panel. Mounted under /console/* so it sits behind the same
- * RequireSession + Sovereign-tier auth gate every other admin page uses.
- *
- *   /console/parent-domains    → ParentDomainsPage
- *
- * Visibility in the sidebar is decided in SovereignSidebar.tsx by
- * checking the operator-admin role; the route registration here is
- * always present so a deep-link from the welcome email still resolves.
- */
-const consoleParentDomainsRoute = createRoute({
-  getParentRoute: () => consoleLayoutRoute,
-  path: '/parent-domains',
-  component: ParentDomainsPage,
-})
-
-// /console/sme/tenants/new — multi-domain SME tenant onboarding form
-// (issue #828, parent epic #825). The page renders the parent-domain
-// dropdown on free-subdomain mode and a CNAME-validation hint on BYO
-// mode. Mounted under the same SovereignConsoleLayout so it's
-// reachable from the operator-tier sidebar (decided at runtime by the
-// SME-tenant-aware nav, see SovereignSidebar.tsx).
-const consoleSMECreateTenantRoute = createRoute({
-  getParentRoute: () => consoleLayoutRoute,
-  path: '/sme/tenants/new',
-  component: SMECreateTenantPage,
-})
+// The legacy /sme/users, /sme/roles, /parent-domains, and
+// /sme/tenants/new route registrations moved to the Organizations menu
+// (issue #3378): their old paths now resolve via
+// consoleOrganizationsRedirectRoutes (→ /organizations + /organizations/
+// new + /organizations/domains), and the create form re-mounts as
+// CreateOrganizationPage at /organizations/new. The SMEUsersPage /
+// SMERolesPage people surfaces fold into the org-detail page's users +
+// roles tabs in a follow-on PR on this chain; until that lands the
+// legacy paths redirect to the directory so no deep-link 404s.
 
 /* ── Compliance dashboards — chroot Sovereign Console (slice U, #1096) ──
  *
@@ -1618,36 +1597,109 @@ const consoleNotificationsRoute = createRoute({
  * is admin-visible (unconditional for v1) and the SME gateway enforces
  * /back-office/* tier checks server-side for the iframe content.
  */
-const consoleBssIndexRoute = createRoute({
+/* ── Organizations menu (issue #3378) ──────────────────────────────────
+ *
+ * ONE menu — Organizations — replaces BSS and the never-built OSS. The
+ * directory is the parent org's complete view of everything beneath it:
+ * the parent itself is the first citizen (never an empty menu), the
+ * internal door for creating departments, the commerce catalog, mode-
+ * aware billing, the domain pools, and per-sub-org `Enter org` support
+ * (audited impersonation). Founder-agreed model 2026-06-13.
+ *
+ *   /organizations        → OrganizationsDirectoryPage (the directory;
+ *                           parent-first row + Create button; replaces
+ *                           /bss/tenants)
+ *   /organizations/new    → CreateOrganizationPage (the internal door;
+ *                           reuses the SME create form component, mounted
+ *                           under the Organization-named route — #3383
+ *                           naming law: sme/tenant never name anything new)
+ *
+ * The /organizations/$org detail page, the commerce + billing + domains
+ * sub-routes, and the Enter-org button arrive in follow-on PRs on this
+ * same #3378 chain. The redirect map below keeps every legacy URL alive.
+ */
+const consoleOrganizationsRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
-  path: '/bss',
-  component: BssLandingPage,
+  path: '/organizations',
+  component: OrganizationsDirectoryPage,
 })
-const consoleBssBillingRoute = createRoute({
+const consoleOrganizationsNewRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
-  path: '/bss/billing',
+  path: '/organizations/new',
+  component: SMECreateTenantPage,
+})
+
+/* Moved pages — the SAME page components as the legacy BSS / parent-
+ * domains routes, re-mounted under their /organizations home. Page
+ * internals are untouched (#3378 §non-negotiables "pages move with
+ * redirects"); only the URL changes. Billing pages render mode-aware in
+ * a follow-on PR on this chain; for now they keep their full surface so
+ * the operator never loses billing/orders/revenue/vouchers/domains. */
+const consoleOrgBillingRoute = createRoute({
+  getParentRoute: () => consoleLayoutRoute,
+  path: '/organizations/billing/billing',
   component: BssBillingPage,
 })
-const consoleBssOrdersRoute = createRoute({
+const consoleOrgOrdersRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
-  path: '/bss/orders',
+  path: '/organizations/billing/orders',
   component: BssOrdersPage,
 })
-const consoleBssRevenueRoute = createRoute({
+const consoleOrgRevenueRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
-  path: '/bss/revenue',
+  path: '/organizations/billing/revenue',
   component: BssRevenuePage,
 })
-const consoleBssVouchersRoute = createRoute({
+const consoleOrgVouchersRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
-  path: '/bss/vouchers',
+  path: '/organizations/billing/vouchers',
   component: BssVouchersPage,
 })
-const consoleBssTenantsRoute = createRoute({
+const consoleOrgDomainsRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
-  path: '/bss/tenants',
-  component: BssTenantsPage,
+  path: '/organizations/domains',
+  component: ParentDomainsPage,
 })
+
+/* ── Organizations redirect map (issue #3378 §4) ───────────────────────
+ *
+ * "old URLs never break" — every legacy BSS / SME-admin / parent-domains
+ * path answers with a redirect to its new home under /organizations.
+ * Pages move WITH redirects (no big-bang; the #3378 §non-negotiables
+ * "pages move with redirects, page internals untouched"). Uses the same
+ * beforeLoad-throw-redirect idiom as consoleLegacyCloudRedirectRoutes.
+ */
+interface OrgRedirect {
+  /** Legacy path under consoleLayoutRoute (no /console prefix). */
+  path: string
+  /** New home under /organizations. */
+  to: string
+}
+const ORGANIZATIONS_REDIRECTS: readonly OrgRedirect[] = [
+  // BSS → Organizations billing/directory.
+  { path: '/bss', to: '/organizations' },
+  { path: '/bss/tenants', to: '/organizations' },
+  { path: '/bss/billing', to: '/organizations/billing/billing' },
+  { path: '/bss/orders', to: '/organizations/billing/orders' },
+  { path: '/bss/revenue', to: '/organizations/billing/revenue' },
+  { path: '/bss/vouchers', to: '/organizations/billing/vouchers' },
+  // SME-admin people surfaces → the org's own page owns its people.
+  { path: '/sme/users', to: '/organizations' },
+  { path: '/sme/roles', to: '/organizations' },
+  { path: '/sme/tenants/new', to: '/organizations/new' },
+  // Parent-domain pools → the Organizations Domains home.
+  { path: '/parent-domains', to: '/organizations/domains' },
+]
+const consoleOrganizationsRedirectRoutes = ORGANIZATIONS_REDIRECTS.map((r) =>
+  createRoute({
+    getParentRoute: () => consoleLayoutRoute,
+    path: r.path,
+    component: NoopRedirectComponent,
+    beforeLoad: () => {
+      throw redirect({ to: r.to as never, replace: true })
+    },
+  }),
+)
 
 /* ── Wave 3 — Sandbox UI scaffold (sandbox-wave3-ui-scaffold) ──────────
  *
@@ -2173,10 +2225,6 @@ const routeTree = rootRoute.addChildren([
     consoleBlueprintsPublishRoute,
     consoleBlueprintsCurateRoute,
     consoleSettingsRoute,
-    consoleSMEUsersRoute,
-    consoleSMERolesRoute,
-    consoleParentDomainsRoute,
-    consoleSMECreateTenantRoute,
     // Compliance dashboards — chroot routes (slice U, #1096).
     consoleSREComplianceRoute,
     consoleSecComplianceRoute,
@@ -2184,15 +2232,18 @@ const routeTree = rootRoute.addChildren([
     // Wave-2 Family-E (#1583, C11-008): chroot Falco runtime alerts.
     consoleComplianceRuntimeRoute,
     consoleNotificationsRoute,
-    // Family F (Wave 3 → Wave 6) — BSS-in-console.
-    // /bss is a native landing (BssLandingPage); each section is a
-    // sibling that wraps in PortalShell via BssSectionShell.
-    consoleBssIndexRoute,
-    consoleBssBillingRoute,
-    consoleBssOrdersRoute,
-    consoleBssRevenueRoute,
-    consoleBssVouchersRoute,
-    consoleBssTenantsRoute,
+    // Organizations menu (issue #3378) — ONE menu replacing BSS+OSS.
+    // Directory (parent-first) + internal door + moved billing/domains
+    // pages + the legacy-URL redirect map (every /bss*, /sme/*,
+    // /parent-domains path keeps resolving).
+    consoleOrganizationsRoute,
+    consoleOrganizationsNewRoute,
+    consoleOrgBillingRoute,
+    consoleOrgOrdersRoute,
+    consoleOrgRevenueRoute,
+    consoleOrgVouchersRoute,
+    consoleOrgDomainsRoute,
+    ...consoleOrganizationsRedirectRoutes,
     // Wave 3 — Sandbox UI scaffold. Static /sandbox/settings registered
     // before /sandbox/$id so the literal segment wins on path match.
     consoleSandboxIndexRoute,

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -164,6 +164,10 @@ import { OrganizationsDirectoryPage } from '@/pages/sovereign/organizations/Orga
 // editor over the EXISTING /catalog/admin/* endpoints, mounted at
 // /organizations/commerce/{plans,addons,bundles,industries,apps}.
 import { CommerceEditorPage } from '@/pages/sovereign/organizations/CommerceEditorPage'
+// B4 mode-aware billing (issue #3378 DoD 5) — wraps the moved billing
+// pages; payment flows render only in real mode, showback/chargeback get
+// the consumption view with zero payment actions.
+import { BillingModeGate } from '@/pages/sovereign/organizations/BillingModeGate'
 // Wave 3 — Sandbox UI scaffold (branch: sandbox-wave3-ui-scaffold).
 // Per-Org agent-coding workspace mounted under /sandbox/* in the chroot
 // Sovereign Console. SandboxLanding is the 6-agent picker;
@@ -1653,28 +1657,31 @@ const consoleOrganizationsNewRoute = createRoute({
 /* Moved pages — the SAME page components as the legacy BSS / parent-
  * domains routes, re-mounted under their /organizations home. Page
  * internals are untouched (#3378 §non-negotiables "pages move with
- * redirects"); only the URL changes. Billing pages render mode-aware in
- * a follow-on PR on this chain; for now they keep their full surface so
- * the operator never loses billing/orders/revenue/vouchers/domains. */
+ * redirects"); only the URL changes. B4 (mode-aware billing, DoD 5): the
+ * payment pages render ONLY in real mode — BillingModeGate wraps each
+ * route and renders the showback consumption view (zero payment actions)
+ * for a showback/chargeback org (the parent is showback, so a single-org
+ * Sovereign sees the showback view by default). The payment pages'
+ * internals stay untouched. */
 const consoleOrgBillingRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
   path: '/organizations/billing/billing',
-  component: BssBillingPage,
+  component: () => <BillingModeGate><BssBillingPage /></BillingModeGate>,
 })
 const consoleOrgOrdersRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
   path: '/organizations/billing/orders',
-  component: BssOrdersPage,
+  component: () => <BillingModeGate><BssOrdersPage /></BillingModeGate>,
 })
 const consoleOrgRevenueRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
   path: '/organizations/billing/revenue',
-  component: BssRevenuePage,
+  component: () => <BillingModeGate><BssRevenuePage /></BillingModeGate>,
 })
 const consoleOrgVouchersRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
   path: '/organizations/billing/vouchers',
-  component: BssVouchersPage,
+  component: () => <BillingModeGate><BssVouchersPage /></BillingModeGate>,
 })
 const consoleOrgDomainsRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -160,6 +160,10 @@ import { VouchersPage as BssVouchersPage } from '@/pages/sovereign/bss/VouchersP
 // /bss*, /sme/users, /sme/roles, /sme/tenants/new, /parent-domains URLs
 // keep resolving) — see consoleOrgRedirectRoutes below.
 import { OrganizationsDirectoryPage } from '@/pages/sovereign/organizations/OrganizationsDirectoryPage'
+// Organizations commerce editors (issue #3378 DoD 7/8) — one kind-aware
+// editor over the EXISTING /catalog/admin/* endpoints, mounted at
+// /organizations/commerce/{plans,addons,bundles,industries,apps}.
+import { CommerceEditorPage } from '@/pages/sovereign/organizations/CommerceEditorPage'
 // Wave 3 — Sandbox UI scaffold (branch: sandbox-wave3-ui-scaffold).
 // Per-Org agent-coding workspace mounted under /sandbox/* in the chroot
 // Sovereign Console. SandboxLanding is the 6-agent picker;
@@ -1678,6 +1682,17 @@ const consoleOrgDomainsRoute = createRoute({
   component: ParentDomainsPage,
 })
 
+/* Commerce editors (issue #3378 DoD 7/8) — one CommerceEditorPage per
+ * kind over the EXISTING /catalog/admin/* endpoints. */
+const COMMERCE_KINDS = ['plans', 'addons', 'bundles', 'industries', 'apps'] as const
+const consoleOrgCommerceRoutes = COMMERCE_KINDS.map((kind) =>
+  createRoute({
+    getParentRoute: () => consoleLayoutRoute,
+    path: `/organizations/commerce/${kind}`,
+    component: () => <CommerceEditorPage kind={kind} />,
+  }),
+)
+
 /* ── Organizations redirect map (issue #3378 §4) ───────────────────────
  *
  * "old URLs never break" — every legacy BSS / SME-admin / parent-domains
@@ -2265,6 +2280,7 @@ const routeTree = rootRoute.addChildren([
     consoleOrgRevenueRoute,
     consoleOrgVouchersRoute,
     consoleOrgDomainsRoute,
+    ...consoleOrgCommerceRoutes,
     ...consoleOrganizationsRedirectRoutes,
     // Wave 3 — Sandbox UI scaffold. Static /sandbox/settings registered
     // before /sandbox/$id so the literal segment wins on path match.

--- a/products/catalyst/bootstrap/ui/src/lib/commerce.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/commerce.api.ts
@@ -1,0 +1,149 @@
+/**
+ * lib/commerce.api.ts — typed client for the Organizations commerce
+ * editors (issue #3378 DoD 7/8). Plans / add-ons / bundles / industries /
+ * apps, edited over the EXISTING endpoints (§6 — no new business
+ * endpoint):
+ *
+ *   • READ  — the public catalog list endpoints via the SME gateway:
+ *       GET /api/catalog/{plans,addons,bundles,industries,apps}
+ *     (core/services/gateway/main.go:50-54, Public:true).
+ *   • WRITE — the catalyst-api commerce proxy that forwards to the
+ *     superadmin-JWT /catalog/admin/* endpoints (sme_commerce.go):
+ *       POST   /api/v1/sme/commerce/{kind}
+ *       PUT    /api/v1/sme/commerce/{kind}/{id}
+ *       DELETE /api/v1/sme/commerce/{kind}/{id}
+ *
+ * The struct shapes mirror core/services/catalog/store/store.go exactly
+ * (Plan :134-149, AddOn :152-160, Bundle :116-124, Industry :104-113),
+ * so the editors render every field the model carries — features (list),
+ * included_quotas (k/v), product_slug, Bundle.apps + Industry.
+ * suggested_apps (multi-select), Industry.bundle_id (live select).
+ */
+
+import { BASE } from '@/shared/config/urls'
+import { authedFetch } from '@/shared/lib/authedFetch'
+
+/* ── Wire shapes — verbatim mirror of store.go ─────────────────────── */
+
+export interface CommercePlan {
+  id?: string
+  slug: string
+  name: string
+  description: string
+  cpu: string
+  memory: string
+  storage: string
+  price_omr: number
+  popular: boolean
+  sort_order: number
+  features: string[]
+  stripe_price_id?: string
+  /** Product-scoped plans (e.g. sandbox) must NOT leak into the generic
+   *  org-provisioning picker — #3156 regression guard. */
+  product_slug?: string
+  included_quotas?: Record<string, string>
+}
+
+export interface CommerceAddOn {
+  id?: string
+  slug: string
+  name: string
+  description: string
+  price_omr: number
+  included: boolean
+  category: string
+}
+
+export interface CommerceBundle {
+  id?: string
+  slug: string
+  name: string
+  tagline: string
+  apps: string[]
+  discount: number
+  recommended_size: string
+}
+
+export interface CommerceIndustry {
+  id?: string
+  slug: string
+  name: string
+  emoji: string
+  description: string
+  display_order: number
+  suggested_apps: string[]
+  bundle_id: string
+}
+
+export interface CommerceApp {
+  id?: string
+  slug: string
+  name: string
+  tagline?: string
+  category?: string
+  published?: boolean
+}
+
+export type CommerceKind = 'plans' | 'addons' | 'bundles' | 'industries' | 'apps'
+
+/** API_BASE without the /api version suffix — commerce reads hit the
+ *  public /api/catalog/* gateway path, writes hit /api/v1/sme/commerce/*. */
+const apiRoot = `${BASE}api`
+
+/* ── Reads (public list endpoints) ─────────────────────────────────── */
+
+async function readList<T>(kind: CommerceKind): Promise<T[]> {
+  // apps must NOT pass ?published=true here — the editor lists EVERY app
+  // (published + unpublished) so the operator can toggle either way.
+  const res = await authedFetch(`${apiRoot}/catalog/${kind}`, {
+    headers: { Accept: 'application/json' },
+  })
+  if (!res.ok) {
+    throw new Error(`load ${kind}: HTTP ${res.status}`)
+  }
+  const body = await res.json()
+  // The catalog list endpoints return either a bare array or {apps:[...]}.
+  if (Array.isArray(body)) return body as T[]
+  if (body && Array.isArray(body[kind])) return body[kind] as T[]
+  if (body && Array.isArray(body.items)) return body.items as T[]
+  return []
+}
+
+export const listPlans = () => readList<CommercePlan>('plans')
+export const listAddOns = () => readList<CommerceAddOn>('addons')
+export const listBundles = () => readList<CommerceBundle>('bundles')
+export const listIndustries = () => readList<CommerceIndustry>('industries')
+export const listApps = () => readList<CommerceApp>('apps')
+
+/* ── Writes (catalyst-api commerce proxy → /catalog/admin/*) ────────── */
+
+async function writeCommerce<T>(
+  method: 'POST' | 'PUT' | 'DELETE',
+  kind: CommerceKind,
+  id: string | undefined,
+  body: T | undefined,
+): Promise<unknown> {
+  const path =
+    id && id.length > 0
+      ? `${apiRoot}/v1/sme/commerce/${kind}/${encodeURIComponent(id)}`
+      : `${apiRoot}/v1/sme/commerce/${kind}`
+  const res = await authedFetch(path, {
+    method,
+    headers: body
+      ? { 'Content-Type': 'application/json', Accept: 'application/json' }
+      : { Accept: 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`${method} ${kind}: HTTP ${res.status} ${detail}`.trim())
+  }
+  return res.status === 204 ? null : res.json().catch(() => null)
+}
+
+export const createCommerce = <T>(kind: CommerceKind, body: T) =>
+  writeCommerce<T>('POST', kind, undefined, body)
+export const updateCommerce = <T>(kind: CommerceKind, id: string, body: T) =>
+  writeCommerce<T>('PUT', kind, id, body)
+export const deleteCommerce = (kind: CommerceKind, id: string) =>
+  writeCommerce<undefined>('DELETE', kind, id, undefined)

--- a/products/catalyst/bootstrap/ui/src/lib/organizations.api.test.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/organizations.api.test.ts
@@ -1,0 +1,85 @@
+/**
+ * organizations.api.test.ts — pure-function coverage for the
+ * Organizations directory composition (issue #3378 §5 empty-state law +
+ * §2.3 kind-derived defaults). The fetch-driven listOrganizations() path
+ * is exercised end-to-end by the directory page test; here we lock the
+ * row-mapping invariants that the empty-state and the internal-door
+ * defaults depend on.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  kindDefaults,
+  parentRowFromSelf,
+  subOrgRowFromTenant,
+} from './organizations.api'
+import type { Tenant } from './bss.api'
+
+describe('kindDefaults', () => {
+  it('internal → showback + namespace (the internal door, no voucher)', () => {
+    expect(kindDefaults('internal')).toEqual({
+      billingMode: 'showback',
+      isolation: 'namespace',
+    })
+  })
+
+  it('customer → real + vcluster (the marketplace funnel door)', () => {
+    expect(kindDefaults('customer')).toEqual({
+      billingMode: 'real',
+      isolation: 'vcluster',
+    })
+  })
+})
+
+describe('parentRowFromSelf', () => {
+  it('marks the row as the parent with showback billing (§5 day-one)', () => {
+    const row = parentRowFromSelf({
+      deploymentId: 'dep-123',
+      sovereignFQDN: 'hw130.omantel.biz',
+    })
+    expect(row.isParent).toBe(true)
+    expect(row.billingMode).toBe('showback')
+    expect(row.kind).toBe('internal')
+    expect(row.status).toBe('active')
+    expect(row.displayName).toBe('hw130.omantel.biz')
+    expect(row.consoleHost).toBe('console.hw130.omantel.biz')
+    expect(row.id).toBe('dep-123')
+  })
+
+  it('never renders blank even when self-discovery fails (§5 never-blank)', () => {
+    const row = parentRowFromSelf(null)
+    expect(row.isParent).toBe(true)
+    expect(row.id).toBe('__parent__')
+    expect(row.displayName).toBe('Sovereign')
+    expect(row.billingMode).toBe('showback')
+  })
+})
+
+describe('subOrgRowFromTenant', () => {
+  const tenant: Tenant = {
+    id: 'tnt-1',
+    orgName: 'ACME Corp',
+    consoleHost: 'console.acme.omani.homes',
+    subdomain: 'acme',
+    parentDomain: 'omani.homes',
+    plan: 'pro',
+    status: 'active',
+    region: 'me-east-215-a',
+    ownerEmail: 'owner@acme.example',
+    createdAt: '2026-06-13T00:00:00Z',
+    updatedAt: '2026-06-13T00:00:00Z',
+    lastError: '',
+  }
+
+  it('maps a customer tenant to a non-parent customer row', () => {
+    const row = subOrgRowFromTenant(tenant)
+    expect(row.isParent).toBe(false)
+    expect(row.kind).toBe('customer')
+    expect(row.billingMode).toBe('real')
+    expect(row.isolation).toBe('vcluster')
+    expect(row.displayName).toBe('ACME Corp')
+    expect(row.slug).toBe('acme')
+    expect(row.ownerEmail).toBe('owner@acme.example')
+    expect(row.status).toBe('active')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
@@ -256,3 +256,37 @@ export async function getConsumption(): Promise<SovereignConsumption> {
     return EMPTY_CONSUMPTION
   }
 }
+
+/* ── B2 Enter-org support session (#3378 §6 B2, DoD 6) ─────────────── */
+
+/** EnterOrgResult — the minted support session (the org-console handover
+ *  URL + the audited support principal + the ≤60min expiry). */
+export interface EnterOrgResult {
+  handoverURL: string
+  supportPrincipal: string
+  org: string
+  expiresAt: string
+  auditEventId: string
+}
+
+/**
+ * enterOrg — mint an audited, time-boxed support session into a sub-org's
+ * own console (§2.4). POSTs to the catalyst-api Enter-org endpoint; the
+ * caller opens the returned handoverURL. Throws on failure so the button
+ * surfaces the error (an unauthorized caller, an attempt to enter the
+ * parent, or an unwired handover signer).
+ */
+export async function enterOrg(slug: string): Promise<EnterOrgResult> {
+  const res = await authedFetch(
+    `${API_BASE}/v1/sme/organizations/${encodeURIComponent(slug)}/enter`,
+    {
+      method: 'POST',
+      headers: { Accept: 'application/json' },
+    },
+  )
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`enter org: HTTP ${res.status} ${detail}`.trim())
+  }
+  return (await res.json()) as EnterOrgResult
+}

--- a/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
@@ -187,3 +187,72 @@ export async function listOrganizations(): Promise<OrgRow[]> {
   for (const t of tenants) rows.push(subOrgRowFromTenant(t))
   return rows
 }
+
+/* ── B3 consumption / showback feed (#3378 §6 B3, DoD 3) ───────────── */
+
+/** AppConsumption — one application's showback slice within an org. */
+export interface AppConsumption {
+  application: string
+  namespace: string
+  costUnits: number
+  cpuMilli: number
+  memoryGiB: number
+  storageGiB: number
+  percent: number
+}
+
+/** OrgConsumption — one org's consumption rollup (parent first). */
+export interface OrgConsumption {
+  org: string
+  isParent: boolean
+  costUnits: number
+  cpuMilli: number
+  memoryGiB: number
+  storageGiB: number
+  apps: AppConsumption[]
+}
+
+/** SovereignConsumption — the metering feed wire shape. */
+export interface SovereignConsumption {
+  totalCostUnits: number
+  orgs: OrgConsumption[]
+  /** True when the metrics cache wasn't ready — the panel flags "metering
+   *  warming up" instead of asserting a false zero. */
+  pending: boolean
+}
+
+const EMPTY_CONSUMPTION: SovereignConsumption = {
+  totalCostUnits: 0,
+  orgs: [],
+  pending: true,
+}
+
+/**
+ * getConsumption — fetch the per-org showback rollup (the B3 feed). The
+ * FIRST deliverable is parent self-showback: on a zero-sub-org estate the
+ * only org row is the parent carrying 100% (§5 day-one). Tolerates
+ * failure by returning the pending empty shape so the panel renders its
+ * chrome rather than crashing.
+ */
+export async function getConsumption(): Promise<SovereignConsumption> {
+  let res: Response
+  try {
+    res = await authedFetch(`${API_BASE}/v1/sme/consumption`, {
+      headers: { Accept: 'application/json' },
+    })
+  } catch {
+    return EMPTY_CONSUMPTION
+  }
+  if (!res.ok) return EMPTY_CONSUMPTION
+  try {
+    const body = (await res.json()) as Partial<SovereignConsumption> | null
+    if (!body || typeof body !== 'object') return EMPTY_CONSUMPTION
+    return {
+      totalCostUnits: Number(body.totalCostUnits ?? 0),
+      orgs: Array.isArray(body.orgs) ? (body.orgs as OrgConsumption[]) : [],
+      pending: Boolean(body.pending),
+    }
+  } catch {
+    return EMPTY_CONSUMPTION
+  }
+}

--- a/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
@@ -1,0 +1,189 @@
+/**
+ * lib/organizations.api.ts — typed client for the Organizations menu
+ * (issue #3378). The Organizations directory is the parent organization's
+ * complete view of everything beneath it: the parent itself is the first
+ * citizen, and every sub-organization is one row.
+ *
+ * Wire path (rides EXISTING endpoints — no new directory endpoint per the
+ * #3378 §6 "Any new endpoint beyond B1-B3 = FAIL" rule):
+ *
+ *   • the PARENT row derives from GET /api/v1/sovereign/self (FQDN +
+ *     deployment id) — the parent org IS the sovereign itself (#3378 §2.2:
+ *     "the parent org is the sovereign itself, root, parentOrg empty").
+ *   • the SUB-ORG rows derive from GET /api/v1/sme/tenants — the same
+ *     listTenants() feed the BSS Tenants page used (#3378 §3 cites this
+ *     as the org directory source). Each Tenant is one Organization CR.
+ *
+ * The model fields (kind / tier / billingMode / isolation) live on
+ * OrganizationSpec (core/controllers/organization/internal/orgapi/
+ * types.go:54-79). Today only the customer path stamps them, so the
+ * directory maps every sub-org to its kind-derived defaults until the
+ * tenants feed surfaces the real spec fields (B1 wires the internal door
+ * that varies them).
+ */
+
+import { listTenants, type Tenant, type TenantStatus } from '@/lib/bss.api'
+import { API_BASE } from '@/shared/config/urls'
+import { authedFetch } from '@/shared/lib/authedFetch'
+
+/** OrgKind — the universal-primitive discriminator (#3378 §2.1). */
+export type OrgKind = 'internal' | 'customer'
+
+/** OrgTier — drives EPIC-5 DMZ auto-provisioning; rendered as a badge. */
+export type OrgTier = 'sme' | 'corporate'
+
+/** OrgBillingMode — real | chargeback | showback (#3378 §2.6). */
+export type OrgBillingMode = 'real' | 'chargeback' | 'showback'
+
+/** OrgIsolation — namespace (people/app/cost boundary) vs vcluster
+ *  (own Kubernetes universe). Kind-derived default (#3378 §2.1). */
+export type OrgIsolation = 'namespace' | 'vcluster'
+
+/** OrgStatus — lifecycle status the directory renders as a pill. The
+ *  parent is always 'active'; sub-orgs map from the tenant pipeline. */
+export type OrgStatus = TenantStatus
+
+/**
+ * OrgRow — one row of the Organizations directory. The parent row and
+ * every sub-org row share this shape so the directory table is uniform
+ * (#3378 §4: "one row per org incl. THE PARENT FIRST").
+ */
+export interface OrgRow {
+  /** Stable identifier. For the parent this is the deployment id (or
+   *  '__parent__' when self-discovery hasn't resolved one yet). */
+  id: string
+  /** Canonical slug (the parent uses the FQDN; sub-orgs the subdomain). */
+  slug: string
+  /** Human-readable display name. */
+  displayName: string
+  kind: OrgKind
+  tier: OrgTier
+  billingMode: OrgBillingMode
+  isolation: OrgIsolation
+  status: OrgStatus
+  /** True for the sovereign-root row (parentOrg empty). The Enter-org
+   *  button is hidden on this row (#3378 §5: "you are already inside it"). */
+  isParent: boolean
+  /** Owner email when known (sub-orgs carry it; the parent does not). */
+  ownerEmail: string
+  /** Console host for the org (parent: console.<fqdn>; sub-orgs: their
+   *  per-org console host). Empty when not yet resolvable. */
+  consoleHost: string
+}
+
+/**
+ * kindDefaults — the kind-derived isolation + billingMode defaults the
+ * internal door renders before the advanced override (#3378 §2.3):
+ *   internal → showback + namespace (department: a people/app/cost
+ *              boundary, no own Kubernetes universe, no voucher step)
+ *   customer → real + vcluster (the marketplace funnel's external door)
+ */
+export function kindDefaults(kind: OrgKind): {
+  billingMode: OrgBillingMode
+  isolation: OrgIsolation
+} {
+  return kind === 'internal'
+    ? { billingMode: 'showback', isolation: 'namespace' }
+    : { billingMode: 'real', isolation: 'vcluster' }
+}
+
+interface SovereignSelf {
+  deploymentId: string
+  sovereignFQDN: string
+}
+
+/**
+ * getSovereignSelf — resolve the parent org's identity (the sovereign
+ * itself). Tolerates 404 (mothership / not-a-sovereign) and 5xx by
+ * returning null so the directory still renders sub-org rows.
+ */
+export async function getSovereignSelf(): Promise<SovereignSelf | null> {
+  let res: Response
+  try {
+    res = await authedFetch(`${API_BASE}/v1/sovereign/self`, {
+      headers: { Accept: 'application/json' },
+    })
+  } catch {
+    return null
+  }
+  if (!res.ok) return null
+  try {
+    const body = (await res.json()) as Partial<SovereignSelf> | null
+    if (!body || typeof body !== 'object') return null
+    const fqdn = String(body.sovereignFQDN ?? '').trim()
+    if (!fqdn) return null
+    return {
+      deploymentId: String(body.deploymentId ?? '').trim(),
+      sovereignFQDN: fqdn,
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * parentRowFromSelf — build the parent-org directory row from the
+ * sovereign self-discovery payload. The parent is kind=internal (it is
+ * the sovereign-root department), tier=corporate (the operator's own
+ * estate), billingMode=showback (#3378 §5: "showback works day one —
+ * 100% of consumption attributes to the parent"), isolation=vcluster
+ * (the sovereign cluster itself).
+ */
+export function parentRowFromSelf(self: SovereignSelf | null): OrgRow {
+  const fqdn = self?.sovereignFQDN ?? ''
+  return {
+    id: self?.deploymentId || '__parent__',
+    slug: fqdn || 'sovereign',
+    displayName: fqdn || 'Sovereign',
+    kind: 'internal',
+    tier: 'corporate',
+    billingMode: 'showback',
+    isolation: 'vcluster',
+    status: 'active',
+    isParent: true,
+    ownerEmail: '',
+    consoleHost: fqdn ? `console.${fqdn}` : '',
+  }
+}
+
+/**
+ * subOrgRowFromTenant — map an existing Tenant (one Organization CR) to a
+ * directory row. The tenants feed today is the customer path, so kind
+ * defaults to 'customer' with the customer-derived isolation/billing
+ * unless the feed later surfaces the real spec fields. tier defaults to
+ * 'sme' (the customer tier).
+ */
+export function subOrgRowFromTenant(t: Tenant): OrgRow {
+  const kind: OrgKind = 'customer'
+  const def = kindDefaults(kind)
+  return {
+    id: t.id,
+    slug: t.subdomain || t.orgName || t.id,
+    displayName: t.orgName || t.subdomain || t.id,
+    kind,
+    tier: 'sme',
+    billingMode: def.billingMode,
+    isolation: def.isolation,
+    status: t.status,
+    isParent: false,
+    ownerEmail: t.ownerEmail,
+    consoleHost: t.consoleHost,
+  }
+}
+
+/**
+ * listOrganizations — the directory feed. Always returns the parent as
+ * the first row (#3378 §4 + §5: "never blank", "the parent org as first
+ * citizen"), followed by every sub-org. Both source calls tolerate
+ * failure: a sub-org fetch error still yields a parent-only directory
+ * rather than an empty menu.
+ */
+export async function listOrganizations(): Promise<OrgRow[]> {
+  const [self, tenants] = await Promise.all([
+    getSovereignSelf(),
+    listTenants().catch(() => [] as Tenant[]),
+  ])
+  const rows: OrgRow[] = [parentRowFromSelf(self)]
+  for (const t of tenants) rows.push(subOrgRowFromTenant(t))
+  return rows
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sme/CreateTenantPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sme/CreateTenantPage.test.tsx
@@ -26,9 +26,44 @@ const POOL: SovereignParentDomain[] = [
 describe('CreateTenantPage', () => {
   it('renders heading + form', () => {
     render(<CreateTenantPage initialParentDomains={POOL} disableFetch />)
-    expect(screen.getByText('Onboard SME Tenant')).toBeTruthy()
+    // Issue #3378: the page is the Organizations internal door now.
+    expect(screen.getByTestId('create-org-title').textContent).toBe('Create organization')
     expect(screen.getByTestId('sme-create-tenant-form')).toBeTruthy()
     expect(screen.getByTestId('sme-create-tenant-submit')).toBeTruthy()
+  })
+
+  /* ── Organizations internal door (issue #3378 B1, DoD-4) ── */
+
+  it('defaults to customer kind with real + vcluster derived defaults', () => {
+    render(<CreateTenantPage initialParentDomains={POOL} disableFetch />)
+    expect(
+      screen.getByTestId('create-org-kind-customer').getAttribute('aria-pressed'),
+    ).toBe('true')
+    expect(screen.getByTestId('create-org-billing-mode').getAttribute('data-mode')).toBe('real')
+    expect(screen.getByTestId('create-org-isolation').getAttribute('data-isolation')).toBe('vcluster')
+  })
+
+  it('selecting Internal renders showback + namespace defaults', () => {
+    render(<CreateTenantPage initialParentDomains={POOL} disableFetch />)
+    fireEvent.click(screen.getByTestId('create-org-kind-internal'))
+    expect(
+      screen.getByTestId('create-org-kind-internal').getAttribute('aria-pressed'),
+    ).toBe('true')
+    expect(screen.getByTestId('create-org-billing-mode').getAttribute('data-mode')).toBe('showback')
+    expect(screen.getByTestId('create-org-isolation').getAttribute('data-isolation')).toBe('namespace')
+  })
+
+  it('the advanced override is visible and can change billing/isolation', () => {
+    render(<CreateTenantPage initialParentDomains={POOL} disableFetch />)
+    fireEvent.click(screen.getByTestId('create-org-kind-internal'))
+    // advanced panel hidden until toggled
+    expect(screen.queryByTestId('create-org-advanced')).toBeNull()
+    fireEvent.click(screen.getByTestId('create-org-advanced-toggle'))
+    expect(screen.getByTestId('create-org-advanced')).toBeTruthy()
+    // override billing to chargeback — the badge reflects it
+    const billingSel = screen.getByTestId('create-org-billing-select') as HTMLSelectElement
+    fireEvent.change(billingSel, { target: { value: 'chargeback' } })
+    expect(screen.getByTestId('create-org-billing-mode').getAttribute('data-mode')).toBe('chargeback')
   })
 
   it('renders parent-domain dropdown with every sme-pool entry', () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sme/CreateTenantPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sme/CreateTenantPage.tsx
@@ -33,6 +33,14 @@ import {
   type SMETenantDomainMode,
   type SovereignParentDomain,
 } from './sme.api'
+// Organizations model (issue #3378 B1) — the kind-derived defaults that
+// drive the internal door's billingMode + isolation rendering.
+import {
+  kindDefaults,
+  type OrgBillingMode,
+  type OrgIsolation,
+  type OrgKind,
+} from '@/lib/organizations.api'
 
 export interface CreateTenantPageProps {
   /** Test seam — supplies the parent-domain pool synchronously. */
@@ -60,6 +68,32 @@ export function CreateTenantPage({
     useState<SMETenantDomainMode>('free-subdomain')
   const [parentDomain, setParentDomain] = useState<string>('')
   const [byoDomain, setByoDomain] = useState<string>('')
+
+  // ── Organizations internal door (issue #3378 B1) ──
+  // kind drives the kind-derived billingMode + isolation defaults
+  // (internal → showback + namespace; customer → real + vcluster). The
+  // advanced override exposes the two derived fields for the rare org
+  // that needs a non-default shape (§2.1 advanced-view override). kind
+  // defaults to 'customer' so this page behaves exactly as the legacy
+  // SME create form until the operator picks Internal.
+  const [orgKind, setOrgKind] = useState<OrgKind>('customer')
+  const [advancedOpen, setAdvancedOpen] = useState<boolean>(false)
+  const derived = kindDefaults(orgKind)
+  const [billingMode, setBillingMode] = useState<OrgBillingMode>(derived.billingMode)
+  const [isolation, setIsolation] = useState<OrgIsolation>(derived.isolation)
+
+  // When kind flips, re-seed billingMode + isolation to the kind default
+  // UNLESS the operator has opened the advanced override (then their
+  // explicit choice sticks). This is what makes "internal → showback +
+  // namespace render" the moment Internal is selected (DoD-4).
+  useEffect(() => {
+    if (advancedOpen) return
+    const d = kindDefaults(orgKind)
+    setBillingMode(d.billingMode)
+    setIsolation(d.isolation)
+  }, [orgKind, advancedOpen])
+
+  const isInternal = orgKind === 'internal'
 
   const [submitting, setSubmitting] = useState<boolean>(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
@@ -135,6 +169,12 @@ export function CreateTenantPage({
             : undefined,
         byo_domain:
           domainMode === 'byo' ? byoDomain.trim().toLowerCase() : undefined,
+        // Organizations model (issue #3378 B1) — send the resolved shape.
+        // The backend re-derives + validates; we send the explicit values
+        // so the advanced override round-trips.
+        kind: orgKind,
+        billing_mode: billingMode,
+        isolation,
       })
       setCreated(result)
     } catch (err) {
@@ -148,14 +188,16 @@ export function CreateTenantPage({
     <div data-testid="sme-create-tenant-page" className="px-6 py-4">
       <div className="mb-4 flex items-center justify-between">
         <div>
-          <h1 className="text-xl font-semibold text-[var(--color-text-strong)]">
-            Onboard SME Tenant
+          <h1
+            data-testid="create-org-title"
+            className="text-xl font-semibold text-[var(--color-text-strong)]"
+          >
+            Create organization
           </h1>
           <p className="text-sm text-[var(--color-text-dim)]">
-            Provisions a per-SME vCluster, blueprint charts, DNS, certs,
-            Keycloak realm, and tenant-registry entry. Choose a free
-            subdomain under one of this Sovereign&apos;s parent domains
-            or bring an SME-owned apex.
+            {isInternal
+              ? 'An internal department — a people, app, and cost boundary on this Sovereign. No marketplace voucher; consumption attributes to the org via showback.'
+              : 'A customer organization — provisions its own vCluster, blueprint charts, DNS, certs, Keycloak realm, and registry entry. Choose a free subdomain under one of this Sovereign’s parent domains or bring an org-owned apex.'}
           </p>
         </div>
       </div>
@@ -174,8 +216,107 @@ export function CreateTenantPage({
         onSubmit={onSubmit}
         className="grid max-w-2xl gap-4 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] p-5"
       >
+        {/* ── Organizations internal door (issue #3378 B1) ──
+            The kind toggle: Internal = a department (this menu's Create),
+            Customer = the external door the marketplace funnel uses. The
+            kind-derived billingMode + isolation render beneath, with an
+            advanced override. */}
+        <fieldset className="grid gap-2 text-sm" data-testid="create-org-kind">
+          <legend className="text-[var(--color-text-dim)]">Organization kind</legend>
+          <div className="flex gap-2">
+            {(['internal', 'customer'] as OrgKind[]).map((k) => {
+              const active = orgKind === k
+              return (
+                <button
+                  key={k}
+                  type="button"
+                  data-testid={`create-org-kind-${k}`}
+                  aria-pressed={active}
+                  onClick={() => setOrgKind(k)}
+                  className={`flex-1 rounded-md border px-3 py-2 text-left transition-colors ${
+                    active
+                      ? 'border-[var(--color-accent)] bg-[var(--color-accent)]/10 text-[var(--color-text-strong)]'
+                      : 'border-[var(--color-border)] bg-[var(--color-input)] text-[var(--color-text-dim)] hover:border-[var(--color-accent)]'
+                  }`}
+                >
+                  <span className="block font-medium capitalize">{k}</span>
+                  <span className="block text-xs text-[var(--color-text-dim)]">
+                    {k === 'internal'
+                      ? 'Department — people/app/cost boundary'
+                      : 'Customer — its own Kubernetes universe'}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+          {/* Kind-derived defaults — the §2.3 values that render the
+              moment Internal/Customer is selected. */}
+          <div
+            data-testid="create-org-defaults"
+            className="flex flex-wrap items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-input)] px-3 py-2 text-xs"
+          >
+            <span className="text-[var(--color-text-dim)]">Defaults:</span>
+            <span
+              data-testid="create-org-billing-mode"
+              data-mode={billingMode}
+              className="rounded-full border border-[var(--color-border)] px-2 py-0.5 font-medium text-[var(--color-text)]"
+            >
+              billing: {billingMode}
+            </span>
+            <span
+              data-testid="create-org-isolation"
+              data-isolation={isolation}
+              className="rounded-full border border-[var(--color-border)] px-2 py-0.5 font-medium text-[var(--color-text)]"
+            >
+              isolation: {isolation}
+            </span>
+            <button
+              type="button"
+              data-testid="create-org-advanced-toggle"
+              onClick={() => setAdvancedOpen((v) => !v)}
+              className="ml-auto text-[var(--color-accent)] hover:underline"
+            >
+              {advancedOpen ? 'Hide advanced' : 'Advanced override'}
+            </button>
+          </div>
+          {advancedOpen ? (
+            <div
+              data-testid="create-org-advanced"
+              className="grid gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-input)] p-3 sm:grid-cols-2"
+            >
+              <label className="grid gap-1">
+                <span className="text-[var(--color-text-dim)]">Billing mode</span>
+                <select
+                  data-testid="create-org-billing-select"
+                  value={billingMode}
+                  onChange={(e) => setBillingMode(e.target.value as OrgBillingMode)}
+                  className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1.5"
+                >
+                  <option value="real">real</option>
+                  <option value="chargeback">chargeback</option>
+                  <option value="showback">showback</option>
+                </select>
+              </label>
+              <label className="grid gap-1">
+                <span className="text-[var(--color-text-dim)]">Isolation</span>
+                <select
+                  data-testid="create-org-isolation-select"
+                  value={isolation}
+                  onChange={(e) => setIsolation(e.target.value as OrgIsolation)}
+                  className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1.5"
+                >
+                  <option value="namespace">namespace</option>
+                  <option value="vcluster">vcluster</option>
+                </select>
+              </label>
+            </div>
+          ) : null}
+        </fieldset>
+
         <label className="grid gap-1 text-sm">
-          <span className="text-[var(--color-text-dim)]">SME tenant slug</span>
+          <span className="text-[var(--color-text-dim)]">
+            {isInternal ? 'Organization slug' : 'SME tenant slug'}
+          </span>
           <input
             data-testid="sme-create-tenant-subdomain"
             type="text"

--- a/products/catalyst/bootstrap/ui/src/pages/sme/sme.api.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sme/sme.api.ts
@@ -156,6 +156,16 @@ export interface SMETenantCreateRequest {
   parent_domain?: string
   admin_email: string
   company_name?: string
+  /** The Organizations internal door (issue #3378 B1). When omitted the
+   *  backend defaults to the customer shape (kind=customer, tier=sme,
+   *  billingMode=real, isolation=vcluster) so the marketplace funnel is
+   *  unaffected. kind='internal' stamps the department shape (showback +
+   *  namespace) and skips the voucher dependency. These map onto the
+   *  OrganizationSpec fields (Kind/Tier/BillingMode + Isolation). */
+  kind?: 'internal' | 'customer'
+  tier?: 'sme' | 'corporate'
+  billing_mode?: 'real' | 'chargeback' | 'showback'
+  isolation?: 'namespace' | 'vcluster'
 }
 
 /** Wire shape mirrors the canonical issue #829 endpoint

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
@@ -38,7 +38,7 @@ const CLOUD_ICON =
   'M6.657 18c-2.572 0 -4.657 -2.007 -4.657 -4.483c0 -2.475 2.085 -4.482 4.657 -4.482c.393 -1.762 1.794 -3.2 3.675 -3.773c1.88 -.572 3.956 -.193 5.444 1c1.488 1.19 2.162 3.007 1.77 4.769h.99c1.913 0 3.464 1.56 3.464 3.486c0 1.927 -1.551 3.487 -3.465 3.487h-11.878'
 
 interface FlatNavItem {
-  id: 'apps' | 'sandbox' | 'jobs' | 'compliance' | 'dashboard' | 'cloud' | 'users' | 'bss' | 'settings'
+  id: 'apps' | 'sandbox' | 'jobs' | 'compliance' | 'dashboard' | 'cloud' | 'users' | 'organizations' | 'settings'
   label: string
   to: string
   icon: string
@@ -112,25 +112,25 @@ const FLAT_NAV: FlatNavItem[] = [
     to: '/users',
     icon: 'M9 7a4 4 0 100 8 4 4 0 000-8zM3 21v-2a4 4 0 014-4h4a4 4 0 014 4v2M16 3.13a4 4 0 010 7.75M21 21v-2a4 4 0 00-3-3.87',
   },
-  // BSS — Business Support Systems (Family F, Wave 3, founder #1 /
-  // 2026-05-17). Surfaces Billing / Orders / Revenue / Vouchers /
-  // Tenants under the canonical /bss/* URL tree.
+  // Organizations (issue #3378, founder-agreed model 2026-06-13). ONE
+  // menu replacing BSS and the never-built OSS: the parent org's complete
+  // view of everything beneath it — the org directory (parent first),
+  // entering any sub-org for support (audited impersonation), the
+  // commerce catalog, mode-aware billing, and the domain pools. Replaces
+  // the BSS entry that previously lived here; the legacy /bss* + /sme/* +
+  // /parent-domains URLs redirect into /organizations (router.tsx).
   //
-  // Icon (Wave 5, 2026-05-17): briefcase line-glyph — fits the
-  // single-stroke icon family used by Apps/Jobs/Cloud/Users/Settings
-  // and reads as "business" at a glance. Replaces the bespoke
-  // receipt icon shipped by Family F that the founder flagged as
-  // off-style.
+  // Icon: an org-chart / building line-glyph (nodes + connecting edges)
+  // matching the single-stroke icon family used by the other entries.
   //
-  // RBAC: always visible for v1 — the whoami payload doesn't expose
-  // tier yet, and the SME gateway server-side enforces tier-bound
-  // access on every /api/v1/sme/* and /back-office/* call. When
-  // whoami grows a `tier` field the sidebar can hide for tier=user.
+  // RBAC: always visible — the sovereign-admin owns the directory; the
+  // catalyst-api enforces tier-bound access server-side on every
+  // /api/v1/sme/* and /catalog/admin/* call.
   {
-    id: 'bss',
-    label: 'BSS',
-    to: '/bss',
-    icon: 'M9 7V5a2 2 0 012-2h2a2 2 0 012 2v2M3 13v6a2 2 0 002 2h14a2 2 0 002-2v-6M3 9h18a0 0 0 010 0v4H3V9z',
+    id: 'organizations',
+    label: 'Organizations',
+    to: '/organizations',
+    icon: 'M9 3a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V3zM3 17a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H5a2 2 0 01-2-2v-2zm12 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2zM12 7v4M12 11H6v4m6-4h6v4',
   },
 ]
 
@@ -172,7 +172,7 @@ const SETTINGS_SUB_NAV: SubNavItem[] = [
 
 // ── Active-state derivation ───────────────────────────────────────────────────
 
-type ActiveSection = 'apps' | 'sandbox' | 'jobs' | 'compliance' | 'dashboard' | 'cloud' | 'users' | 'bss' | 'settings'
+type ActiveSection = 'apps' | 'sandbox' | 'jobs' | 'compliance' | 'dashboard' | 'cloud' | 'users' | 'organizations' | 'settings'
 
 const CLOUD_PATH_RE = /^\/(cloud|infrastructure)(\/|$)/
 
@@ -190,10 +190,10 @@ function deriveActiveSection(pathname: string): ActiveSection {
   if (/^\/(sre|sec)\/compliance(\/|$)/.test(pathname)) return 'compliance'
   if (/^\/compliance(\/|$)/.test(pathname)) return 'compliance'
   if (/^\/users(\/|$)/.test(pathname)) return 'users'
-  // /bss(/*) → 'bss' so the BSS nav item highlights for every BSS
-  // sub-tab (billing/orders/revenue/vouchers/tenants). Family F
-  // (Wave 3, 2026-05-17, founder #1).
-  if (/^\/bss(\/|$)/.test(pathname)) return 'bss'
+  // /organizations(/*) → 'organizations' so the Organizations nav item
+  // highlights for the directory, the internal door, and every moved
+  // sub-surface (billing/orders/revenue/vouchers/domains). Issue #3378.
+  if (/^\/organizations(\/|$)/.test(pathname)) return 'organizations'
   // /settings/* OR /parent-domains → 'settings' so the Settings nav
   // item highlights and the sub-nav (Marketplace + Parent Domains)
   // expands. Per inviolable principle #4, the path list is pulled

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/BillingModeGate.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/BillingModeGate.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * BillingModeGate.test.tsx — mode-aware billing (issue #3378 B4 / DoD 5).
+ * showback/chargeback → the consumption view with ZERO payment actions
+ * (the wrapped payment page is NOT mounted); real → the payment page
+ * renders.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BillingModeGate } from './BillingModeGate'
+
+function renderGate(mode: 'real' | 'showback' | 'chargeback') {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <BillingModeGate modeOverride={mode}>
+        <div data-testid="payment-page">PAYMENT FLOWS</div>
+      </BillingModeGate>
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => cleanup())
+
+describe('BillingModeGate — mode-aware billing (DoD 5)', () => {
+  it('showback: renders the consumption view, NO payment page', () => {
+    renderGate('showback')
+    expect(screen.getByTestId('billing-mode-gate').getAttribute('data-mode')).toBe('showback')
+    expect(screen.getByTestId('billing-showback-notice')).toBeTruthy()
+    expect(screen.getByTestId('showback-panel')).toBeTruthy()
+    // the payment page must NOT be mounted (zero payment actions reachable)
+    expect(screen.queryByTestId('payment-page')).toBeNull()
+  })
+
+  it('chargeback: also consumption-only, no payment page', () => {
+    renderGate('chargeback')
+    expect(screen.getByTestId('billing-mode-gate').getAttribute('data-mode')).toBe('chargeback')
+    expect(screen.queryByTestId('payment-page')).toBeNull()
+  })
+
+  it('real: renders the payment page (full flow)', () => {
+    renderGate('real')
+    expect(screen.getByTestId('payment-page')).toBeTruthy()
+    expect(screen.queryByTestId('billing-mode-gate')).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/BillingModeGate.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/BillingModeGate.tsx
@@ -1,0 +1,73 @@
+/**
+ * BillingModeGate — mode-aware billing (issue #3378 B4 + DoD 5 + §5).
+ *
+ * The billing pages are mode-filtered, never separate systems (§2.6):
+ *   • real    → the full payment flows (the wrapped page renders as-is).
+ *   • showback/chargeback → consumption only, ZERO payment actions: the
+ *     gate renders the ShowbackPanel + the §5 empty-state explaining that
+ *     real billing exists when the marketplace sells to external orgs,
+ *     and does NOT mount the payment page at all (so no Issue-voucher /
+ *     checkout CTA is reachable).
+ *
+ * The parent org is showback (§5), so on a single-org Sovereign the
+ * billing routes render the showback view by default — real billing is
+ * dormant until the first external customer. The mode is resolved from
+ * the parent org's billingMode (listOrganizations → the parent row);
+ * tolerant of failure (defaults to showback so payment actions never
+ * leak on an unresolved estate).
+ *
+ * This wraps the moved bss billing/orders/revenue/vouchers pages at the
+ * ROUTE level — their internals are untouched (#3378 non-negotiables:
+ * "page internals untouched except where a DoD box names the change").
+ */
+
+import type { ReactNode } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { ShowbackPanel } from './ShowbackPanel'
+import {
+  listOrganizations,
+  type OrgBillingMode,
+  type OrgRow,
+} from '@/lib/organizations.api'
+
+export interface BillingModeGateProps {
+  /** The wrapped payment page (rendered only in real mode). */
+  children: ReactNode
+  /** Test seam — force the resolved mode. */
+  modeOverride?: OrgBillingMode
+}
+
+export function BillingModeGate({ children, modeOverride }: BillingModeGateProps) {
+  const query = useQuery<OrgRow[]>({
+    queryKey: ['organizations-directory'],
+    queryFn: listOrganizations,
+    staleTime: 30_000,
+    enabled: !modeOverride,
+    placeholderData: (prev) => prev,
+  })
+
+  // Resolve the parent org's billing mode. Default showback so payment
+  // actions never leak before the estate resolves.
+  const parent = query.data?.find((o) => o.isParent)
+  const mode: OrgBillingMode = modeOverride ?? parent?.billingMode ?? 'showback'
+
+  if (mode === 'real') {
+    return <>{children}</>
+  }
+
+  // showback / chargeback → consumption only, zero payment actions.
+  return (
+    <div data-testid="billing-mode-gate" data-mode={mode} className="px-6 py-4">
+      <div
+        data-testid="billing-showback-notice"
+        className="mb-4 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-4 py-3 text-sm text-[var(--color-text-dim)]"
+      >
+        This organization is in{' '}
+        <span className="font-medium text-[var(--color-text)]">{mode}</span> mode —
+        consumption is attributed, not invoiced. Real billing (invoices, vouchers,
+        checkout) exists when the marketplace sells to external organizations.
+      </div>
+      <ShowbackPanel />
+    </div>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/CommerceEditorPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/CommerceEditorPage.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * CommerceEditorPage.test.tsx — the commerce editor surface (issue #3378
+ * DoD 7/8). Renders the Plans editor table from the exact store.go struct
+ * fields, opens the create modal, and exercises the field renderers
+ * (features list, included_quotas k/v, product_slug). Uses the
+ * initialRowsOverride seam so it's deterministic without the fetch path.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+
+import { CommerceEditorPage } from './CommerceEditorPage'
+import type { CommercePlan } from '@/lib/commerce.api'
+
+const PLANS: CommercePlan[] = [
+  {
+    id: 'p-s',
+    slug: 's',
+    name: 'Small',
+    description: 'starter',
+    cpu: '1',
+    memory: '2Gi',
+    storage: '20Gi',
+    price_omr: 5,
+    popular: false,
+    sort_order: 1,
+    features: ['1 vCPU', '2 GiB'],
+    included_quotas: { apps: '3' },
+  },
+  {
+    id: 'p-w',
+    slug: 'test-w',
+    name: 'Test W',
+    description: 'walk plan',
+    cpu: '2',
+    memory: '4Gi',
+    storage: '40Gi',
+    price_omr: 9,
+    popular: false,
+    sort_order: 2,
+    features: [],
+  },
+]
+
+function renderEditor(rows: readonly CommercePlan[]) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const route = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/organizations/commerce/plans',
+    component: () => (
+      <CommerceEditorPage
+        kind="plans"
+        initialRowsOverride={rows as unknown as Record<string, unknown>[]}
+      />
+    ),
+  })
+  const orgRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/organizations',
+    component: () => <div data-testid="orgs-stub" />,
+  })
+  const tree = rootRoute.addChildren([route, orgRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: ['/organizations/commerce/plans'] }),
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => cleanup())
+
+describe('CommerceEditorPage — Plans (DoD 7)', () => {
+  it('renders one row per plan with the table columns', async () => {
+    renderEditor(PLANS)
+    expect(await screen.findByTestId('commerce-plans-page')).toBeTruthy()
+    expect(screen.getByTestId('commerce-row-s')).toBeTruthy()
+    expect(screen.getByTestId('commerce-row-test-w')).toBeTruthy()
+    // price column renders the OMR value
+    expect(screen.getByTestId('commerce-cell-price_omr-test-w').textContent).toBe('9')
+  })
+
+  it('opens the create modal with every store.go field', async () => {
+    renderEditor(PLANS)
+    fireEvent.click(await screen.findByTestId('commerce-create-button'))
+    expect(screen.getByTestId('commerce-modal')).toBeTruthy()
+    // the field renderers for the struct fields are present
+    expect(screen.getByTestId('commerce-field-slug')).toBeTruthy()
+    expect(screen.getByTestId('commerce-field-price_omr')).toBeTruthy()
+    expect(screen.getByTestId('commerce-field-features')).toBeTruthy() // list editor
+    expect(screen.getByTestId('commerce-field-included_quotas')).toBeTruthy() // k/v editor
+    expect(screen.getByTestId('commerce-field-product_slug')).toBeTruthy()
+  })
+
+  it('opens the edit modal pre-filled and locks the slug', async () => {
+    renderEditor(PLANS)
+    fireEvent.click(await screen.findByTestId('commerce-edit-test-w'))
+    const slug = screen.getByTestId('commerce-field-slug') as HTMLInputElement
+    expect(slug.value).toBe('test-w')
+    expect(slug.disabled).toBe(true)
+    const price = screen.getByTestId('commerce-field-price_omr') as HTMLInputElement
+    expect(price.value).toBe('9')
+  })
+
+  it('renders the empty state when there are no plans', async () => {
+    renderEditor([])
+    expect(await screen.findByTestId('commerce-empty')).toBeTruthy()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/CommerceEditorPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/CommerceEditorPage.tsx
@@ -1,0 +1,503 @@
+/**
+ * CommerceEditorPage — /organizations/commerce/{plans,addons,bundles,
+ * industries,apps} (issue #3378 DoD 7/8).
+ *
+ * One kind-aware editor over the EXISTING commerce endpoints (§6): a
+ * table of the kind's rows + create/edit/delete modals rendering EXACTLY
+ * the store.go struct fields (features = list editor; included_quotas =
+ * k/v; product_slug = text; Bundle.apps + Industry.suggested_apps =
+ * multi-select from GET /catalog/apps; Industry.bundle_id = live-bundle
+ * select). Price changes take effect immediately — no redeploy (the
+ * defect this kills).
+ *
+ * Chrome + tokens inherited from the sibling sovereign surfaces.
+ */
+
+import { useState } from 'react'
+import { Link } from '@tanstack/react-router'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+import { DETECTED_MODE } from '@/shared/lib/detectMode'
+import { PortalShell } from '../PortalShell'
+import {
+  createCommerce,
+  deleteCommerce,
+  listAddOns,
+  listApps,
+  listBundles,
+  listIndustries,
+  listPlans,
+  updateCommerce,
+  type CommerceApp,
+  type CommerceBundle,
+  type CommerceKind,
+} from '@/lib/commerce.api'
+
+const KIND_LABEL: Record<CommerceKind, string> = {
+  plans: 'Plans',
+  addons: 'Add-ons',
+  bundles: 'Bundles',
+  industries: 'Industries',
+  apps: 'Apps',
+}
+
+type Row = Record<string, unknown> & { id?: string }
+
+export interface CommerceEditorPageProps {
+  kind: CommerceKind
+  /** Test seam — bypass the React Query fetcher. */
+  initialRowsOverride?: readonly Row[]
+  /** Test seam — supply the apps + bundles option pools synchronously. */
+  initialAppsOverride?: readonly CommerceApp[]
+  initialBundlesOverride?: readonly CommerceBundle[]
+}
+
+const STALE_MS = 30_000
+
+export function CommerceEditorPage({
+  kind,
+  initialRowsOverride,
+  initialAppsOverride,
+  initialBundlesOverride,
+}: CommerceEditorPageProps) {
+  const { deploymentId: resolvedId } = useResolvedDeploymentId()
+  const deploymentId = resolvedId ?? ''
+  const sovereignFQDN = DETECTED_MODE.sovereignFQDN ?? null
+  const qc = useQueryClient()
+
+  const rowsQuery = useQuery<Row[]>({
+    queryKey: ['commerce', kind, deploymentId],
+    queryFn: () => listRows(kind),
+    staleTime: STALE_MS,
+    enabled: !initialRowsOverride,
+    placeholderData: (prev) => prev,
+  })
+
+  // Option pools — apps (for Bundle.apps + Industry.suggested_apps) and
+  // bundles (for Industry.bundle_id). Only fetched for the kinds that
+  // need them so a plans/addons editor doesn't fan out extra calls.
+  const needsApps = kind === 'bundles' || kind === 'industries'
+  const needsBundles = kind === 'industries'
+  const appsQuery = useQuery<CommerceApp[]>({
+    queryKey: ['commerce-apps-pool', deploymentId],
+    queryFn: listApps,
+    staleTime: STALE_MS,
+    enabled: needsApps && !initialAppsOverride,
+    placeholderData: (prev) => prev ?? [],
+  })
+  const bundlesQuery = useQuery<CommerceBundle[]>({
+    queryKey: ['commerce-bundles-pool', deploymentId],
+    queryFn: listBundles,
+    staleTime: STALE_MS,
+    enabled: needsBundles && !initialBundlesOverride,
+    placeholderData: (prev) => prev ?? [],
+  })
+
+  const rows: readonly Row[] = initialRowsOverride ?? rowsQuery.data ?? []
+  const appsPool: readonly CommerceApp[] = initialAppsOverride ?? appsQuery.data ?? []
+  const bundlesPool: readonly CommerceBundle[] = initialBundlesOverride ?? bundlesQuery.data ?? []
+  const loading = !initialRowsOverride && rowsQuery.isLoading
+  const error = !initialRowsOverride && rowsQuery.isError ? (rowsQuery.error as Error).message : null
+
+  const fields = FIELD_CONFIG[kind]
+  const [editing, setEditing] = useState<Row | null>(null)
+  const [creating, setCreating] = useState<boolean>(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  function refresh() {
+    qc.invalidateQueries({ queryKey: ['commerce', kind] })
+  }
+
+  async function onDelete(row: Row) {
+    if (!row.id) return
+    setActionError(null)
+    try {
+      await deleteCommerce(kind, String(row.id))
+      refresh()
+    } catch (e) {
+      setActionError((e as Error).message)
+    }
+  }
+
+  return (
+    <PortalShell
+      deploymentId={deploymentId}
+      sovereignFQDN={sovereignFQDN}
+      pageTitle={`Commerce — ${KIND_LABEL[kind]}`}
+      headerSlotLeft={
+        <Link
+          to={'/organizations' as never}
+          className="text-[11px] text-[var(--color-text-dim)] hover:text-[var(--color-text)] no-underline"
+          data-testid="commerce-back-link"
+        >
+          ← Organizations
+        </Link>
+      }
+      headerSlotRight={
+        <button
+          type="button"
+          data-testid="commerce-create-button"
+          onClick={() => {
+            setCreating(true)
+            setEditing(null)
+          }}
+          className="inline-flex items-center gap-1.5 rounded-md border border-[var(--color-accent)] bg-[var(--color-accent)]/10 px-3 py-1.5 text-xs font-medium text-[var(--color-accent)]"
+        >
+          + New {KIND_LABEL[kind].replace(/s$/, '')}
+        </button>
+      }
+    >
+      <div data-testid={`commerce-${kind}-page`}>
+        <p className="mb-4 text-sm text-[var(--color-text-dim)]">
+          The {KIND_LABEL[kind].toLowerCase()} the marketplace storefront renders.
+          Changes take effect immediately — no redeploy.
+        </p>
+
+        {error ? (
+          <div data-testid="commerce-error" className="mb-3 rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-300">
+            {error}
+          </div>
+        ) : null}
+        {actionError ? (
+          <div data-testid="commerce-action-error" className="mb-3 rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-300">
+            {actionError}
+          </div>
+        ) : null}
+
+        {loading ? (
+          <div data-testid="commerce-loading" className="text-sm text-[var(--color-text-dim)]">Loading…</div>
+        ) : rows.length === 0 ? (
+          <div data-testid="commerce-empty" className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-4 py-8 text-center text-sm text-[var(--color-text-dim)]">
+            No {KIND_LABEL[kind].toLowerCase()} yet. Create one to populate the marketplace.
+          </div>
+        ) : (
+          <div className="overflow-x-auto rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)]">
+            <table data-testid={`commerce-${kind}-table`} className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="border-b border-[var(--color-border)] text-left text-[0.7rem] uppercase tracking-wide text-[var(--color-text-dim)]">
+                  {fields.filter((f) => f.inTable).map((f) => (
+                    <th key={f.key} className="px-3 py-2 font-semibold">{f.label}</th>
+                  ))}
+                  <th className="px-3 py-2 font-semibold text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={String(row.id ?? row.slug)} data-testid={`commerce-row-${row.slug}`} className="border-b border-[var(--color-border)] last:border-b-0 hover:bg-[var(--color-surface-hover)]">
+                    {fields.filter((f) => f.inTable).map((f) => (
+                      <td key={f.key} className="px-3 py-2 align-middle text-[var(--color-text)]" data-testid={`commerce-cell-${f.key}-${row.slug}`}>
+                        {renderCell(row[f.key], f.type)}
+                      </td>
+                    ))}
+                    <td className="px-3 py-2 align-middle text-right">
+                      <button
+                        type="button"
+                        data-testid={`commerce-edit-${row.slug}`}
+                        onClick={() => { setEditing(row); setCreating(false) }}
+                        className="mr-2 text-xs text-[var(--color-accent)] hover:underline"
+                      >Edit</button>
+                      <button
+                        type="button"
+                        data-testid={`commerce-delete-${row.slug}`}
+                        onClick={() => onDelete(row)}
+                        className="text-xs text-rose-400 hover:underline"
+                      >Delete</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {(creating || editing) ? (
+          <CommerceModal
+            kind={kind}
+            fields={fields}
+            initial={editing ?? undefined}
+            appsPool={appsPool}
+            bundlesPool={bundlesPool}
+            onClose={() => { setCreating(false); setEditing(null) }}
+            onSaved={() => { setCreating(false); setEditing(null); refresh() }}
+            onError={setActionError}
+          />
+        ) : null}
+      </div>
+    </PortalShell>
+  )
+}
+
+/* ── Field config — mirrors store.go struct fields per kind ──────────── */
+
+type FieldType = 'text' | 'number' | 'bool' | 'list' | 'kv' | 'apps' | 'bundle'
+interface FieldDef {
+  key: string
+  label: string
+  type: FieldType
+  inTable?: boolean
+}
+
+const FIELD_CONFIG: Record<CommerceKind, FieldDef[]> = {
+  plans: [
+    { key: 'slug', label: 'Slug', type: 'text', inTable: true },
+    { key: 'name', label: 'Name', type: 'text', inTable: true },
+    { key: 'description', label: 'Description', type: 'text' },
+    { key: 'cpu', label: 'CPU', type: 'text', inTable: true },
+    { key: 'memory', label: 'Memory', type: 'text', inTable: true },
+    { key: 'storage', label: 'Storage', type: 'text' },
+    { key: 'price_omr', label: 'Price (OMR)', type: 'number', inTable: true },
+    { key: 'popular', label: 'Popular', type: 'bool' },
+    { key: 'sort_order', label: 'Sort order', type: 'number' },
+    { key: 'features', label: 'Features', type: 'list' },
+    { key: 'stripe_price_id', label: 'Stripe price id', type: 'text' },
+    { key: 'product_slug', label: 'Product slug', type: 'text' },
+    { key: 'included_quotas', label: 'Included quotas', type: 'kv' },
+  ],
+  addons: [
+    { key: 'slug', label: 'Slug', type: 'text', inTable: true },
+    { key: 'name', label: 'Name', type: 'text', inTable: true },
+    { key: 'description', label: 'Description', type: 'text' },
+    { key: 'price_omr', label: 'Price (OMR)', type: 'number', inTable: true },
+    { key: 'included', label: 'Included', type: 'bool', inTable: true },
+    { key: 'category', label: 'Category', type: 'text', inTable: true },
+  ],
+  bundles: [
+    { key: 'slug', label: 'Slug', type: 'text', inTable: true },
+    { key: 'name', label: 'Name', type: 'text', inTable: true },
+    { key: 'tagline', label: 'Tagline', type: 'text' },
+    { key: 'apps', label: 'Apps', type: 'apps', inTable: true },
+    { key: 'discount', label: 'Discount %', type: 'number', inTable: true },
+    { key: 'recommended_size', label: 'Recommended size', type: 'text' },
+  ],
+  industries: [
+    { key: 'slug', label: 'Slug', type: 'text', inTable: true },
+    { key: 'name', label: 'Name', type: 'text', inTable: true },
+    { key: 'emoji', label: 'Emoji', type: 'text', inTable: true },
+    { key: 'description', label: 'Description', type: 'text' },
+    { key: 'display_order', label: 'Display order', type: 'number' },
+    { key: 'suggested_apps', label: 'Suggested apps', type: 'apps' },
+    { key: 'bundle_id', label: 'Bundle', type: 'bundle', inTable: true },
+  ],
+  apps: [
+    { key: 'slug', label: 'Slug', type: 'text', inTable: true },
+    { key: 'name', label: 'Name', type: 'text', inTable: true },
+    { key: 'tagline', label: 'Tagline', type: 'text' },
+    { key: 'category', label: 'Category', type: 'text', inTable: true },
+  ],
+}
+
+function listRows(kind: CommerceKind): Promise<Row[]> {
+  switch (kind) {
+    case 'plans': return listPlans() as unknown as Promise<Row[]>
+    case 'addons': return listAddOns() as unknown as Promise<Row[]>
+    case 'bundles': return listBundles() as unknown as Promise<Row[]>
+    case 'industries': return listIndustries() as unknown as Promise<Row[]>
+    case 'apps': return listApps() as unknown as Promise<Row[]>
+  }
+}
+
+function renderCell(v: unknown, type: FieldType) {
+  if (type === 'bool') return v ? 'yes' : 'no'
+  if (type === 'list' || type === 'apps') return Array.isArray(v) ? `${v.length}` : '0'
+  if (type === 'kv') return v && typeof v === 'object' ? `${Object.keys(v as object).length}` : '0'
+  if (v === undefined || v === null || v === '') return '—'
+  return String(v)
+}
+
+/* ── Modal ───────────────────────────────────────────────────────────── */
+
+function CommerceModal({
+  kind,
+  fields,
+  initial,
+  appsPool,
+  bundlesPool,
+  onClose,
+  onSaved,
+  onError,
+}: {
+  kind: CommerceKind
+  fields: FieldDef[]
+  initial?: Row
+  appsPool: readonly CommerceApp[]
+  bundlesPool: readonly CommerceBundle[]
+  onClose: () => void
+  onSaved: () => void
+  onError: (m: string) => void
+}) {
+  const [form, setForm] = useState<Row>(() => seedForm(fields, initial))
+  const [saving, setSaving] = useState(false)
+  const isEdit = !!initial?.id
+
+  function set(key: string, value: unknown) {
+    setForm((f) => ({ ...f, [key]: value }))
+  }
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSaving(true)
+    onError('')
+    try {
+      const payload = coerceForm(fields, form)
+      if (isEdit) {
+        await updateCommerce(kind, String(initial!.id), payload)
+      } else {
+        await createCommerce(kind, payload)
+      }
+      onSaved()
+    } catch (err) {
+      onError((err as Error).message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" data-testid="commerce-modal">
+      <form
+        onSubmit={onSubmit}
+        className="grid max-h-[85vh] w-full max-w-lg gap-3 overflow-y-auto rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-5"
+      >
+        <h2 className="text-base font-semibold text-[var(--color-text-strong)]">
+          {isEdit ? 'Edit' : 'New'} {KIND_LABEL[kind].replace(/s$/, '')}
+        </h2>
+        {fields.map((f) => (
+          <FieldInput
+            key={f.key}
+            field={f}
+            value={form[f.key]}
+            onChange={(v) => set(f.key, v)}
+            appsPool={appsPool}
+            bundlesPool={bundlesPool}
+            disabled={isEdit && f.key === 'slug'}
+          />
+        ))}
+        <div className="mt-2 flex justify-end gap-2">
+          <button type="button" onClick={onClose} data-testid="commerce-modal-cancel" className="rounded-md border border-[var(--color-border)] px-3 py-1.5 text-sm text-[var(--color-text-dim)]">Cancel</button>
+          <button type="submit" disabled={saving} data-testid="commerce-modal-save" className="rounded-md border border-[var(--color-accent)] bg-[var(--color-accent)]/10 px-3 py-1.5 text-sm font-medium text-[var(--color-accent)] disabled:opacity-50">
+            {saving ? 'Saving…' : isEdit ? 'Save' : 'Create'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+function FieldInput({
+  field,
+  value,
+  onChange,
+  appsPool,
+  bundlesPool,
+  disabled,
+}: {
+  field: FieldDef
+  value: unknown
+  onChange: (v: unknown) => void
+  appsPool: readonly CommerceApp[]
+  bundlesPool: readonly CommerceBundle[]
+  disabled?: boolean
+}) {
+  const id = `commerce-field-${field.key}`
+  const baseInput = 'rounded-md border border-[var(--color-border)] bg-[var(--color-input)] px-3 py-1.5 text-sm'
+
+  if (field.type === 'bool') {
+    return (
+      <label className="flex items-center gap-2 text-sm">
+        <input type="checkbox" data-testid={id} checked={!!value} onChange={(e) => onChange(e.target.checked)} />
+        <span className="text-[var(--color-text-dim)]">{field.label}</span>
+      </label>
+    )
+  }
+  if (field.type === 'number') {
+    return (
+      <label className="grid gap-1 text-sm">
+        <span className="text-[var(--color-text-dim)]">{field.label}</span>
+        <input type="number" data-testid={id} value={Number(value ?? 0)} onChange={(e) => onChange(Number(e.target.value))} className={baseInput} />
+      </label>
+    )
+  }
+  if (field.type === 'list') {
+    const arr = Array.isArray(value) ? (value as string[]) : []
+    return (
+      <label className="grid gap-1 text-sm">
+        <span className="text-[var(--color-text-dim)]">{field.label} (one per line)</span>
+        <textarea data-testid={id} value={arr.join('\n')} onChange={(e) => onChange(e.target.value.split('\n').map((s) => s.trim()).filter(Boolean))} rows={3} className={baseInput} />
+      </label>
+    )
+  }
+  if (field.type === 'kv') {
+    const obj = value && typeof value === 'object' ? (value as Record<string, string>) : {}
+    const text = Object.entries(obj).map(([k, v]) => `${k}=${v}`).join('\n')
+    return (
+      <label className="grid gap-1 text-sm">
+        <span className="text-[var(--color-text-dim)]">{field.label} (key=value per line)</span>
+        <textarea data-testid={id} value={text} onChange={(e) => onChange(parseKV(e.target.value))} rows={3} className={baseInput} />
+      </label>
+    )
+  }
+  if (field.type === 'apps') {
+    const sel = Array.isArray(value) ? (value as string[]) : []
+    return (
+      <label className="grid gap-1 text-sm">
+        <span className="text-[var(--color-text-dim)]">{field.label}</span>
+        <select multiple data-testid={id} value={sel} onChange={(e) => onChange(Array.from(e.target.selectedOptions).map((o) => o.value))} className={`${baseInput} h-28`}>
+          {appsPool.map((a) => (<option key={a.slug} value={a.slug}>{a.name || a.slug}</option>))}
+        </select>
+      </label>
+    )
+  }
+  if (field.type === 'bundle') {
+    return (
+      <label className="grid gap-1 text-sm">
+        <span className="text-[var(--color-text-dim)]">{field.label}</span>
+        <select data-testid={id} value={String(value ?? '')} onChange={(e) => onChange(e.target.value)} className={baseInput}>
+          <option value="">— none —</option>
+          {bundlesPool.map((b) => (<option key={b.id ?? b.slug} value={b.id ?? b.slug}>{b.name || b.slug}</option>))}
+        </select>
+      </label>
+    )
+  }
+  return (
+    <label className="grid gap-1 text-sm">
+      <span className="text-[var(--color-text-dim)]">{field.label}</span>
+      <input type="text" data-testid={id} value={String(value ?? '')} disabled={disabled} onChange={(e) => onChange(e.target.value)} className={`${baseInput} disabled:opacity-60`} />
+    </label>
+  )
+}
+
+/* ── helpers ─────────────────────────────────────────────────────────── */
+
+function seedForm(fields: FieldDef[], initial?: Row): Row {
+  const out: Row = {}
+  for (const f of fields) {
+    if (initial && f.key in initial) {
+      out[f.key] = initial[f.key]
+      continue
+    }
+    out[f.key] =
+      f.type === 'bool' ? false :
+      f.type === 'number' ? 0 :
+      f.type === 'list' || f.type === 'apps' ? [] :
+      f.type === 'kv' ? {} : ''
+  }
+  return out
+}
+
+function coerceForm(fields: FieldDef[], form: Row): Row {
+  const out: Row = {}
+  for (const f of fields) out[f.key] = form[f.key]
+  return out
+}
+
+function parseKV(text: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const line of text.split('\n')) {
+    const i = line.indexOf('=')
+    if (i <= 0) continue
+    const k = line.slice(0, i).trim()
+    const v = line.slice(i + 1).trim()
+    if (k) out[k] = v
+  }
+  return out
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/EnterOrgButton.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/EnterOrgButton.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * EnterOrgButton.test.tsx — the B2 Enter-org action (issue #3378 DoD 6).
+ * The button mints the support session + opens the handover URL; it is
+ * hidden on the parent row ("you are already inside it", §5).
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { EnterOrgButton } from './EnterOrgButton'
+import { parentRowFromSelf, subOrgRowFromTenant, type EnterOrgResult } from '@/lib/organizations.api'
+
+afterEach(() => cleanup())
+
+const SUB = subOrgRowFromTenant({
+  id: 'tnt-1',
+  orgName: 'ACME Corp',
+  consoleHost: 'console.acme.omani.homes',
+  subdomain: 'acme',
+  parentDomain: 'omani.homes',
+  plan: 'pro',
+  status: 'active',
+  region: 'me-east-215-a',
+  ownerEmail: 'owner@acme.example',
+  createdAt: '2026-06-13T00:00:00Z',
+  updatedAt: '2026-06-13T00:00:00Z',
+  lastError: '',
+})
+
+const RESULT: EnterOrgResult = {
+  handoverURL: 'https://console.acme.hw130.omantel.biz/auth/handover?token=abc',
+  supportPrincipal: 'support+emrah@acme.hw130.omantel.biz',
+  org: 'acme',
+  expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+  auditEventId: 'enter-org-acme-xyz',
+}
+
+describe('EnterOrgButton — B2 support session (DoD 6)', () => {
+  it('is hidden on the parent row (§5: already inside it)', () => {
+    const parent = parentRowFromSelf({ deploymentId: 'd1', sovereignFQDN: 'hw130.omantel.biz' })
+    const { container } = render(<EnterOrgButton org={parent} />)
+    expect(container.querySelector('[data-testid="enter-org-button"]')).toBeNull()
+  })
+
+  it('mints the session and opens the handover URL on click', async () => {
+    const onEnter = vi.fn(async () => RESULT)
+    const open = vi.fn()
+    render(<EnterOrgButton org={SUB} onEnterOverride={onEnter} openOverride={open} />)
+    fireEvent.click(screen.getByTestId('enter-org-button'))
+    await waitFor(() => expect(onEnter).toHaveBeenCalledWith('acme'))
+    expect(open).toHaveBeenCalledWith(RESULT.handoverURL)
+    // the support-principal + expiry confirmation surfaces
+    expect(await screen.findByTestId('enter-org-confirm')).toBeTruthy()
+    expect(screen.getByTestId('enter-org-confirm').textContent).toContain('support+emrah')
+  })
+
+  it('surfaces the error when the mint fails', async () => {
+    const onEnter = vi.fn(async () => { throw new Error('insufficient-role') })
+    render(<EnterOrgButton org={SUB} onEnterOverride={onEnter} openOverride={() => {}} />)
+    fireEvent.click(screen.getByTestId('enter-org-button'))
+    expect(await screen.findByTestId('enter-org-error')).toBeTruthy()
+    expect(screen.getByTestId('enter-org-error').textContent).toContain('insufficient-role')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/EnterOrgButton.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/EnterOrgButton.tsx
@@ -1,0 +1,76 @@
+/**
+ * EnterOrgButton — the B2 Enter-org support action (issue #3378 §6 B2 +
+ * DoD 6).
+ *
+ * One button per sub-org → an audited, time-boxed (≤60min) support
+ * session that lands in the org's OWN console as a support principal in
+ * the org's realm (never the owner's identity). POSTs to the catalyst-api
+ * Enter-org endpoint, then opens the returned handover URL in a new tab;
+ * the org's console redeems it (the same handover-redemption flow the
+ * mothership→Sovereign handover uses) and lands the support principal
+ * logged in with the in-console support banner.
+ *
+ * Rendered ONLY on sub-org rows — the parent row hides it ("you are
+ * already inside it", §5). The org-detail page enforces that; this
+ * component is defensive and also no-ops for a parent org.
+ */
+
+import { useState } from 'react'
+import { enterOrg, type EnterOrgResult, type OrgRow } from '@/lib/organizations.api'
+
+export interface EnterOrgButtonProps {
+  org: OrgRow
+  /** Test seam — replace the enterOrg call + the window.open side-effect. */
+  onEnterOverride?: (slug: string) => Promise<EnterOrgResult>
+  openOverride?: (url: string) => void
+}
+
+export function EnterOrgButton({ org, onEnterOverride, openOverride }: EnterOrgButtonProps) {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [last, setLast] = useState<EnterOrgResult | null>(null)
+
+  // Defensive: never offer the support session for the parent (§5).
+  if (org.isParent) return null
+
+  async function onClick() {
+    setBusy(true)
+    setError(null)
+    try {
+      const result = onEnterOverride ? await onEnterOverride(org.slug) : await enterOrg(org.slug)
+      setLast(result)
+      const open = openOverride ?? ((u: string) => window.open(u, '_blank', 'noopener,noreferrer'))
+      open(result.handoverURL)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <button
+        type="button"
+        data-testid="enter-org-button"
+        disabled={busy}
+        onClick={onClick}
+        className="inline-flex items-center gap-1.5 rounded-md border border-[var(--color-accent)] bg-[var(--color-accent)]/10 px-3 py-1.5 text-xs font-medium text-[var(--color-accent)] disabled:opacity-50"
+      >
+        <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M11 16l-4-4m0 0l4-4m-4 4h14M3 4v16" />
+        </svg>
+        {busy ? 'Entering…' : 'Enter org'}
+      </button>
+      {error ? (
+        <span data-testid="enter-org-error" className="text-[10px] text-rose-400">{error}</span>
+      ) : null}
+      {last ? (
+        <span data-testid="enter-org-confirm" className="text-[10px] text-[var(--color-text-dim)]">
+          Support session as {last.supportPrincipal} · expires{' '}
+          {new Date(last.expiresAt).toLocaleTimeString()}
+        </span>
+      ) : null}
+    </div>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationDetailPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationDetailPage.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * OrganizationDetailPage.test.tsx — the org detail surface (issue #3378
+ * §4 + DoD 6): the identity card renders the CR fields, the Enter-org
+ * button shows on a sub-org and is ABSENT on the parent.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+
+import { OrganizationDetailPage } from './OrganizationDetailPage'
+import { parentRowFromSelf, subOrgRowFromTenant, type OrgRow } from '@/lib/organizations.api'
+
+const PARENT = parentRowFromSelf({ deploymentId: 'd1', sovereignFQDN: 'hw130.omantel.biz' })
+const SUB = subOrgRowFromTenant({
+  id: 'tnt-1', orgName: 'ACME Corp', consoleHost: 'console.acme.omani.homes', subdomain: 'acme',
+  parentDomain: 'omani.homes', plan: 'pro', status: 'active', region: 'r', ownerEmail: 'o@acme.example',
+  createdAt: '2026-06-13T00:00:00Z', updatedAt: '2026-06-13T00:00:00Z', lastError: '',
+})
+
+function renderDetail(org: string, rows: readonly OrgRow[]) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const route = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/organizations/$org',
+    component: () => <OrganizationDetailPage org={org} initialOrgsOverride={rows} />,
+  })
+  const orgRoute = createRoute({ getParentRoute: () => rootRoute, path: '/organizations', component: () => <div /> })
+  const tree = rootRoute.addChildren([route, orgRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: [`/organizations/${org}`] }),
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => cleanup())
+
+describe('OrganizationDetailPage — §4 identity + DoD 6 Enter-org', () => {
+  it('renders the identity card with the CR fields for a sub-org', async () => {
+    renderDetail('acme', [PARENT, SUB])
+    expect(await screen.findByTestId('organization-detail-page')).toBeTruthy()
+    expect(screen.getByTestId('org-detail-kind').textContent).toBe('customer')
+    expect(screen.getByTestId('org-detail-billing').textContent).toBe('real')
+    expect(screen.getByTestId('org-detail-isolation').textContent).toBe('vcluster')
+  })
+
+  it('shows the Enter-org button on a sub-org', async () => {
+    renderDetail('acme', [PARENT, SUB])
+    expect(await screen.findByTestId('enter-org-button')).toBeTruthy()
+  })
+
+  it('HIDES the Enter-org button on the parent (§5: already inside it)', async () => {
+    renderDetail(PARENT.slug, [PARENT, SUB])
+    expect(await screen.findByTestId('org-detail-parent-badge')).toBeTruthy()
+    expect(screen.queryByTestId('enter-org-button')).toBeNull()
+  })
+
+  it('renders a not-found state for an unknown slug', async () => {
+    renderDetail('ghost', [PARENT, SUB])
+    expect(await screen.findByTestId('org-detail-not-found')).toBeTruthy()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationDetailPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationDetailPage.tsx
@@ -1,0 +1,137 @@
+/**
+ * OrganizationDetailPage — /organizations/$org (issue #3378 §4).
+ *
+ * The org detail surface: the identity card (the CR fields), the mode-
+ * aware consumption panel (showback/chargeback orgs), realm/console
+ * links, and the `Enter org` button (sub-orgs only — the §2.4 support
+ * session; absent on the parent row, "you are already inside it"). The
+ * org's people belong on the org's page — the users + roles tabs absorb
+ * /sme/users + /sme/roles in a follow-on PR on this chain.
+ *
+ * No bespoke parent-side estate views (§2.4): the org's OWN console (the
+ * limited-similar UI served at console.<org>.<domain>) IS the view; this
+ * page is the identity + entry surface, not a rebuilt estate read.
+ *
+ * Resolves the org from the directory feed by slug (rides EXISTING
+ * endpoints — listOrganizations composes the parent + sub-org rows).
+ */
+
+import { useMemo } from 'react'
+import { Link } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+import { DETECTED_MODE } from '@/shared/lib/detectMode'
+import { PortalShell } from '../PortalShell'
+import { ShowbackPanel } from './ShowbackPanel'
+import { EnterOrgButton } from './EnterOrgButton'
+import { listOrganizations, type OrgRow } from '@/lib/organizations.api'
+
+export interface OrganizationDetailPageProps {
+  /** The org slug from the route param. */
+  org: string
+  /** Test seam — supply the directory rows synchronously. */
+  initialOrgsOverride?: readonly OrgRow[]
+}
+
+export function OrganizationDetailPage({ org, initialOrgsOverride }: OrganizationDetailPageProps) {
+  const { deploymentId: resolvedId } = useResolvedDeploymentId()
+  const deploymentId = resolvedId ?? ''
+  const sovereignFQDN = DETECTED_MODE.sovereignFQDN ?? null
+
+  const query = useQuery<OrgRow[]>({
+    queryKey: ['organizations-directory', deploymentId],
+    queryFn: listOrganizations,
+    staleTime: 30_000,
+    enabled: !initialOrgsOverride,
+    placeholderData: (prev) => prev,
+  })
+  const rows: readonly OrgRow[] = initialOrgsOverride ?? query.data ?? []
+  const loading = !initialOrgsOverride && query.isLoading
+
+  const target = useMemo(() => rows.find((o) => o.slug === org), [rows, org])
+
+  return (
+    <PortalShell
+      deploymentId={deploymentId}
+      sovereignFQDN={sovereignFQDN}
+      pageTitle={target?.displayName ?? org}
+      headerSlotLeft={
+        <Link
+          to={'/organizations' as never}
+          className="text-[11px] text-[var(--color-text-dim)] hover:text-[var(--color-text)] no-underline"
+          data-testid="org-detail-back-link"
+        >
+          ← Organizations
+        </Link>
+      }
+      headerSlotRight={
+        // Enter org — sub-orgs only (§2.4 + §5: hidden on the parent row,
+        // "you are already inside it").
+        target && !target.isParent ? <EnterOrgButton org={target} /> : null
+      }
+    >
+      <div data-testid="organization-detail-page" data-org={org}>
+        {loading ? (
+          <div data-testid="org-detail-loading" className="text-sm text-[var(--color-text-dim)]">Loading…</div>
+        ) : !target ? (
+          <div data-testid="org-detail-not-found" className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-4 py-8 text-center text-sm text-[var(--color-text-dim)]">
+            Organization “{org}” not found in this Sovereign’s directory.
+          </div>
+        ) : (
+          <div className="grid gap-4">
+            {/* Identity card — the CR fields (§4). */}
+            <section
+              data-testid="org-detail-identity"
+              className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-4"
+            >
+              <div className="mb-3 flex items-center gap-2">
+                <h2 className="text-sm font-semibold text-[var(--color-text-strong)]">{target.displayName}</h2>
+                {target.isParent ? (
+                  <span data-testid="org-detail-parent-badge" className="rounded-full border border-[var(--color-accent)]/40 bg-[var(--color-accent)]/10 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-[var(--color-accent)]">Parent</span>
+                ) : null}
+              </div>
+              <dl className="grid grid-cols-2 gap-x-6 gap-y-2 text-xs sm:grid-cols-3">
+                <Field label="Slug" value={target.slug} testid={`org-detail-slug`} />
+                <Field label="Kind" value={target.kind} testid="org-detail-kind" />
+                <Field label="Tier" value={target.tier} testid="org-detail-tier" />
+                <Field label="Billing mode" value={target.billingMode} testid="org-detail-billing" />
+                <Field label="Isolation" value={target.isolation} testid="org-detail-isolation" />
+                <Field label="Status" value={target.status} testid="org-detail-status" />
+                {target.ownerEmail ? <Field label="Owner" value={target.ownerEmail} testid="org-detail-owner" /> : null}
+                {target.consoleHost ? (
+                  <div className="flex flex-col">
+                    <dt className="text-[var(--color-text-dim)]">Console</dt>
+                    <dd>
+                      <a
+                        href={`https://${target.consoleHost}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        data-testid="org-detail-console-link"
+                        className="font-mono text-[var(--color-accent)] hover:underline"
+                      >
+                        {target.consoleHost}
+                      </a>
+                    </dd>
+                  </div>
+                ) : null}
+              </dl>
+            </section>
+
+            {/* Consumption panel — mode-aware (showback/chargeback). The
+                org's slice of the showback feed. */}
+            <ShowbackPanel org={target.isParent ? undefined : target.slug} />
+          </div>
+        )}
+      </div>
+    </PortalShell>
+  )
+}
+
+function Field({ label, value, testid }: { label: string; value: string; testid: string }) {
+  return (
+    <div className="flex flex-col">
+      <dt className="text-[var(--color-text-dim)]">{label}</dt>
+      <dd data-testid={testid} className="capitalize text-[var(--color-text)]">{value}</dd>
+    </div>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationsDirectoryPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationsDirectoryPage.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * OrganizationsDirectoryPage.test.tsx — the §5 empty-state law (issue
+ * #3378): on a sovereign with zero sub-orgs the directory shows the
+ * parent org as the first citizen with its badges (never blank) + the
+ * Create button. Uses the initialOrgsOverride seam so the test is
+ * deterministic without the fetch path.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+
+import { OrganizationsDirectoryPage } from './OrganizationsDirectoryPage'
+import { parentRowFromSelf, subOrgRowFromTenant, type OrgRow } from '@/lib/organizations.api'
+
+function renderDirectory(orgs: readonly OrgRow[]) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const dirRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/organizations',
+    component: () => <OrganizationsDirectoryPage initialOrgsOverride={orgs} />,
+  })
+  // Register the routes the directory links to so TanStack's <Link>
+  // type-resolution doesn't throw on mount.
+  const newRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/organizations/new',
+    component: () => <div data-testid="orgs-new-stub" />,
+  })
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/organizations/$org',
+    component: () => <div data-testid="orgs-detail-stub" />,
+  })
+  const tree = rootRoute.addChildren([dirRoute, newRoute, detailRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: ['/organizations'] }),
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => cleanup())
+
+describe('OrganizationsDirectoryPage — §5 empty-state law', () => {
+  it('shows exactly the parent row (first citizen) with zero sub-orgs', async () => {
+    const parent = parentRowFromSelf({ deploymentId: 'dep-1', sovereignFQDN: 'hw130.omantel.biz' })
+    renderDirectory([parent])
+    expect(await screen.findByTestId('organizations-directory-page')).toBeTruthy()
+    // exactly one row, and it is the parent
+    expect(screen.getByTestId(`organizations-row-${parent.id}`)).toBeTruthy()
+    expect(screen.getByTestId(`organizations-parent-badge-${parent.id}`)).toBeTruthy()
+    // result count reads 1/1 — never blank
+    expect(screen.getByTestId('organizations-result-count').textContent).toBe('1/1')
+  })
+
+  it('renders the parent showback billing badge (§5 day-one showback)', async () => {
+    const parent = parentRowFromSelf({ deploymentId: 'dep-1', sovereignFQDN: 'hw130.omantel.biz' })
+    renderDirectory([parent])
+    const badge = await screen.findByTestId(`organizations-cell-billing-${parent.id}`)
+    expect(badge.getAttribute('data-mode')).toBe('showback')
+  })
+
+  it('exposes the Create organization button (the internal door entry)', async () => {
+    const parent = parentRowFromSelf({ deploymentId: 'dep-1', sovereignFQDN: 'hw130.omantel.biz' })
+    renderDirectory([parent])
+    const btn = await screen.findByTestId('orgs-create-button')
+    expect(btn.getAttribute('href')).toContain('/organizations/new')
+  })
+
+  it('lists the parent FIRST, then sub-orgs (parent is first citizen)', async () => {
+    const parent = parentRowFromSelf({ deploymentId: 'dep-1', sovereignFQDN: 'hw130.omantel.biz' })
+    const sub = subOrgRowFromTenant({
+      id: 'tnt-1',
+      orgName: 'ACME Corp',
+      consoleHost: 'console.acme.omani.homes',
+      subdomain: 'acme',
+      parentDomain: 'omani.homes',
+      plan: 'pro',
+      status: 'active',
+      region: 'me-east-215-a',
+      ownerEmail: 'owner@acme.example',
+      createdAt: '2026-06-13T00:00:00Z',
+      updatedAt: '2026-06-13T00:00:00Z',
+      lastError: '',
+    })
+    renderDirectory([parent, sub])
+    const table = await screen.findByTestId('organizations-table')
+    const rows = table.querySelectorAll('tbody tr')
+    expect(rows.length).toBe(2)
+    // first row carries the parent marker
+    expect(rows[0].getAttribute('data-parent')).toBe('true')
+    expect(rows[1].getAttribute('data-parent')).toBe('false')
+    expect(screen.getByTestId('organizations-result-count').textContent).toBe('2/2')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationsDirectoryPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationsDirectoryPage.test.tsx
@@ -40,7 +40,25 @@ function renderDirectory(orgs: readonly OrgRow[]) {
     path: '/organizations/$org',
     component: () => <div data-testid="orgs-detail-stub" />,
   })
-  const tree = rootRoute.addChildren([dirRoute, newRoute, detailRoute])
+  // Section-nav targets — register stubs so the directory's <Link>s
+  // resolve at render.
+  const sectionPaths = [
+    '/organizations/commerce/plans',
+    '/organizations/commerce/addons',
+    '/organizations/commerce/bundles',
+    '/organizations/commerce/industries',
+    '/organizations/commerce/apps',
+    '/organizations/billing/billing',
+    '/organizations/domains',
+  ]
+  const sectionRoutes = sectionPaths.map((p) =>
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path: p,
+      component: () => <div data-testid={`section-${p}`} />,
+    }),
+  )
+  const tree = rootRoute.addChildren([dirRoute, newRoute, detailRoute, ...sectionRoutes])
   const router = createRouter({
     routeTree: tree,
     history: createMemoryHistory({ initialEntries: ['/organizations'] }),

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationsDirectoryPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationsDirectoryPage.tsx
@@ -33,6 +33,18 @@ import {
 
 const QUERY_STALE_MS = 30_000
 
+// The Organizations menu's sibling surfaces (issue #3378 §4). The
+// directory is the landing; commerce/billing/domains hang off it.
+const SECTION_LINKS: readonly { id: string; label: string; to: string }[] = [
+  { id: 'commerce-plans', label: 'Commerce · Plans', to: '/organizations/commerce/plans' },
+  { id: 'commerce-addons', label: 'Add-ons', to: '/organizations/commerce/addons' },
+  { id: 'commerce-bundles', label: 'Bundles', to: '/organizations/commerce/bundles' },
+  { id: 'commerce-industries', label: 'Industries', to: '/organizations/commerce/industries' },
+  { id: 'commerce-apps', label: 'Apps', to: '/organizations/commerce/apps' },
+  { id: 'billing', label: 'Billing', to: '/organizations/billing/billing' },
+  { id: 'domains', label: 'Domains', to: '/organizations/domains' },
+]
+
 export interface OrganizationsDirectoryPageProps {
   /** Test seam — bypass the React Query fetcher with synthetic rows. */
   initialOrgsOverride?: readonly OrgRow[]
@@ -92,11 +104,29 @@ export function OrganizationsDirectoryPage({
       }
     >
       <div data-testid="organizations-directory-page">
-        <p className="mb-4 text-sm text-[var(--color-text-dim)]">
+        <p className="mb-3 text-sm text-[var(--color-text-dim)]">
           Every organization on this Sovereign. The parent organization — the
           Sovereign itself — is the first row; each department and customer is
           one Organization with its own identity, RBAC, and cost attribution.
         </p>
+
+        {/* Section nav — the Organizations menu's sibling surfaces
+            (commerce / billing / domains). Issue #3378 §4. */}
+        <nav
+          data-testid="organizations-section-nav"
+          className="mb-4 flex flex-wrap gap-1.5 text-xs"
+        >
+          {SECTION_LINKS.map((s) => (
+            <Link
+              key={s.to}
+              to={s.to as never}
+              data-testid={`organizations-nav-${s.id}`}
+              className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1 text-[var(--color-text-dim)] no-underline transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-text)]"
+            >
+              {s.label}
+            </Link>
+          ))}
+        </nav>
 
         <div className="mb-3 flex flex-wrap items-end gap-3" data-testid="organizations-toolbar">
           <label className="flex flex-1 min-w-[240px] max-w-md flex-col gap-1">

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationsDirectoryPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationsDirectoryPage.tsx
@@ -1,0 +1,302 @@
+/**
+ * OrganizationsDirectoryPage — /organizations.
+ *
+ * The Organizations menu (issue #3378) replaces BSS and the never-built
+ * OSS with ONE directory: the parent organization's complete view of
+ * everything beneath it. The parent org is the FIRST citizen (#3378 §4),
+ * so the menu is never blank even on a sovereign with zero sub-orgs
+ * (#3378 §5 empty-state law).
+ *
+ * Wire path (rides EXISTING endpoints): listOrganizations() composes the
+ * parent row from GET /api/v1/sovereign/self + every sub-org row from
+ * GET /api/v1/sme/tenants. No new directory endpoint (#3378 §6).
+ *
+ * Chrome + design tokens inherited from the sibling sovereign surfaces
+ * (TenantsPage / JobsPage / ParentDomainsPage) — no bespoke chrome, no
+ * hex colours outside the documented amber/rose/emerald status-pill
+ * exception.
+ */
+
+import { useMemo, useState } from 'react'
+import { Link } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+import { DETECTED_MODE } from '@/shared/lib/detectMode'
+import { PortalShell } from '../PortalShell'
+import {
+  listOrganizations,
+  type OrgRow,
+  type OrgBillingMode,
+  type OrgKind,
+  type OrgStatus,
+} from '@/lib/organizations.api'
+
+const QUERY_STALE_MS = 30_000
+
+export interface OrganizationsDirectoryPageProps {
+  /** Test seam — bypass the React Query fetcher with synthetic rows. */
+  initialOrgsOverride?: readonly OrgRow[]
+}
+
+export function OrganizationsDirectoryPage({
+  initialOrgsOverride,
+}: OrganizationsDirectoryPageProps = {}) {
+  const { deploymentId: resolvedId } = useResolvedDeploymentId()
+  const deploymentId = resolvedId ?? ''
+  const sovereignFQDN = DETECTED_MODE.sovereignFQDN ?? null
+
+  const query = useQuery<OrgRow[]>({
+    queryKey: ['organizations-directory', deploymentId],
+    queryFn: listOrganizations,
+    staleTime: QUERY_STALE_MS,
+    enabled: !initialOrgsOverride,
+    placeholderData: (prev) => prev,
+  })
+
+  const orgs: readonly OrgRow[] = initialOrgsOverride ?? query.data ?? []
+  const loading = !initialOrgsOverride && query.isLoading
+  const error =
+    !initialOrgsOverride && query.isError ? (query.error as Error).message : null
+
+  const [search, setSearch] = useState<string>('')
+  const [kindFilter, setKindFilter] = useState<'' | OrgKind>('')
+
+  const visibleOrgs = useMemo<OrgRow[]>(() => {
+    const q = search.trim().toLowerCase()
+    return orgs.filter((o) => {
+      if (kindFilter && o.kind !== kindFilter) return false
+      if (q) {
+        const hay = `${o.displayName} ${o.slug} ${o.ownerEmail} ${o.kind} ${o.billingMode}`.toLowerCase()
+        if (!hay.includes(q)) return false
+      }
+      return true
+    })
+  }, [orgs, search, kindFilter])
+
+  return (
+    <PortalShell
+      deploymentId={deploymentId}
+      sovereignFQDN={sovereignFQDN}
+      pageTitle="Organizations"
+      headerSlotRight={
+        <Link
+          to={'/organizations/new' as never}
+          data-testid="orgs-create-button"
+          className="inline-flex items-center gap-1.5 rounded-md border border-[var(--color-accent)] bg-[var(--color-accent)]/10 px-3 py-1.5 text-xs font-medium text-[var(--color-accent)] no-underline transition-colors hover:bg-[var(--color-accent)]/20"
+        >
+          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14M5 12h14" />
+          </svg>
+          Create organization
+        </Link>
+      }
+    >
+      <div data-testid="organizations-directory-page">
+        <p className="mb-4 text-sm text-[var(--color-text-dim)]">
+          Every organization on this Sovereign. The parent organization — the
+          Sovereign itself — is the first row; each department and customer is
+          one Organization with its own identity, RBAC, and cost attribution.
+        </p>
+
+        <div className="mb-3 flex flex-wrap items-end gap-3" data-testid="organizations-toolbar">
+          <label className="flex flex-1 min-w-[240px] max-w-md flex-col gap-1">
+            <span className="text-[0.62rem] uppercase tracking-wide text-[var(--color-text-dim)]">
+              Search
+            </span>
+            <input
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search by name, slug, owner email, kind, or mode…"
+              data-testid="organizations-search"
+              aria-label="Search organizations"
+              className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-[0.62rem] uppercase tracking-wide text-[var(--color-text-dim)]">
+              Kind
+            </span>
+            <select
+              value={kindFilter}
+              onChange={(e) => setKindFilter(e.target.value as '' | OrgKind)}
+              data-testid="organizations-filter-kind"
+              aria-label="Filter by kind"
+              className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+            >
+              <option value="">All</option>
+              <option value="internal">Internal</option>
+              <option value="customer">Customer</option>
+            </select>
+          </label>
+          <span
+            data-testid="organizations-result-count"
+            aria-live="polite"
+            className="ml-auto pb-1 font-mono text-xs tabular-nums text-[var(--color-text-dim)]"
+          >
+            {visibleOrgs.length}/{orgs.length}
+          </span>
+        </div>
+
+        {error ? (
+          <div
+            data-testid="organizations-error"
+            className="mb-3 rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-300"
+          >
+            {error}
+          </div>
+        ) : null}
+
+        {loading ? (
+          <div data-testid="organizations-loading" className="text-sm text-[var(--color-text-dim)]">
+            Loading…
+          </div>
+        ) : visibleOrgs.length === 0 ? (
+          <div
+            data-testid="organizations-no-matches"
+            className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-4 py-8 text-center text-sm text-[var(--color-text-dim)]"
+          >
+            No organizations match the current filters.
+          </div>
+        ) : (
+          <div className="overflow-x-auto rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)]">
+            <table data-testid="organizations-table" className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="border-b border-[var(--color-border)] text-left text-[0.7rem] uppercase tracking-wide text-[var(--color-text-dim)]">
+                  <th className="px-3 py-2 font-semibold">Organization</th>
+                  <th className="px-3 py-2 font-semibold">Kind</th>
+                  <th className="px-3 py-2 font-semibold">Tier</th>
+                  <th className="px-3 py-2 font-semibold">Billing</th>
+                  <th className="px-3 py-2 font-semibold">Isolation</th>
+                  <th className="px-3 py-2 font-semibold">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleOrgs.map((o) => (
+                  <OrgDirectoryRow key={o.id} org={o} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </PortalShell>
+  )
+}
+
+function OrgDirectoryRow({ org }: { org: OrgRow }) {
+  return (
+    <tr
+      data-testid={`organizations-row-${org.id}`}
+      data-kind={org.kind}
+      data-parent={org.isParent ? 'true' : 'false'}
+      className="border-b border-[var(--color-border)] last:border-b-0 hover:bg-[var(--color-surface-hover)]"
+    >
+      <td className="px-3 py-2 align-middle">
+        <Link
+          to={'/organizations/$org' as never}
+          params={{ org: org.slug } as never}
+          data-testid={`organizations-cell-name-${org.id}`}
+          className="flex flex-col no-underline"
+        >
+          <span className="flex items-center gap-2 text-[var(--color-text-strong)]">
+            {org.displayName}
+            {org.isParent ? (
+              <span
+                data-testid={`organizations-parent-badge-${org.id}`}
+                className="inline-flex items-center rounded-full border border-[var(--color-accent)]/40 bg-[var(--color-accent)]/10 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-[var(--color-accent)]"
+              >
+                Parent
+              </span>
+            ) : null}
+          </span>
+          {org.ownerEmail ? (
+            <span className="text-[11px] text-[var(--color-text-dim)]">{org.ownerEmail}</span>
+          ) : (
+            <span className="font-mono text-[11px] text-[var(--color-text-dim)]">{org.slug}</span>
+          )}
+        </Link>
+      </td>
+      <td className="px-3 py-2 align-middle">
+        <KindBadge kind={org.kind} orgId={org.id} />
+      </td>
+      <td
+        className="px-3 py-2 align-middle text-xs capitalize text-[var(--color-text)]"
+        data-testid={`organizations-cell-tier-${org.id}`}
+      >
+        {org.tier}
+      </td>
+      <td className="px-3 py-2 align-middle">
+        <BillingModeBadge mode={org.billingMode} orgId={org.id} />
+      </td>
+      <td
+        className="px-3 py-2 align-middle text-xs text-[var(--color-text)]"
+        data-testid={`organizations-cell-isolation-${org.id}`}
+      >
+        {org.isolation}
+      </td>
+      <td className="px-3 py-2 align-middle">
+        <StatusBadge status={org.status} orgId={org.id} />
+      </td>
+    </tr>
+  )
+}
+
+function KindBadge({ kind, orgId }: { kind: OrgKind; orgId: string }) {
+  const cls =
+    kind === 'internal'
+      ? 'border-sky-500/40 bg-sky-500/10 text-sky-300'
+      : 'border-violet-500/40 bg-violet-500/10 text-violet-300'
+  return (
+    <span
+      data-testid={`organizations-cell-kind-${orgId}`}
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${cls}`}
+    >
+      {kind}
+    </span>
+  )
+}
+
+/** BillingModeBadge — real | chargeback | showback (#3378 §2.6 / §5). */
+const BILLING_TONE: Record<OrgBillingMode, string> = {
+  real: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300',
+  chargeback: 'border-amber-500/40 bg-amber-500/10 text-amber-300',
+  showback: 'border-[var(--color-border)] bg-[var(--color-bg-2)] text-[var(--color-text-dim)]',
+}
+
+function BillingModeBadge({ mode, orgId }: { mode: OrgBillingMode; orgId: string }) {
+  return (
+    <span
+      data-testid={`organizations-cell-billing-${orgId}`}
+      data-mode={mode}
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${BILLING_TONE[mode]}`}
+    >
+      {mode}
+    </span>
+  )
+}
+
+const STATUS_TONE: Record<OrgStatus, { label: string; className: string }> = {
+  active: { label: 'Active', className: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300' },
+  trial: { label: 'Trial', className: 'border-amber-500/40 bg-amber-500/10 text-amber-300' },
+  provisioning: { label: 'Provisioning', className: 'border-amber-500/40 bg-amber-500/10 text-amber-300' },
+  suspended: { label: 'Suspended', className: 'border-rose-500/40 bg-rose-500/10 text-rose-300' },
+  failed: { label: 'Failed', className: 'border-rose-500/40 bg-rose-500/10 text-rose-300' },
+  unknown: {
+    label: 'Unknown',
+    className: 'border-[var(--color-border)] bg-[var(--color-bg-2)] text-[var(--color-text-dim)]',
+  },
+}
+
+function StatusBadge({ status, orgId }: { status: OrgStatus; orgId: string }) {
+  const tone = STATUS_TONE[status]
+  return (
+    <span
+      data-testid={`organizations-cell-status-${orgId}`}
+      data-status={status}
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${tone.className}`}
+    >
+      {tone.label}
+    </span>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationsDirectoryPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/OrganizationsDirectoryPage.tsx
@@ -23,6 +23,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import { PortalShell } from '../PortalShell'
+import { ShowbackPanel } from './ShowbackPanel'
 import {
   listOrganizations,
   type OrgRow,
@@ -127,6 +128,16 @@ export function OrganizationsDirectoryPage({
             </Link>
           ))}
         </nav>
+
+        {/* B3 parent self-showback (DoD 3): the sovereign's own per-app
+            cost attribution — walkable pre-sub-org. Hidden in the test
+            seam path (initialOrgsOverride) to keep the directory's
+            empty-state test focused. */}
+        {initialOrgsOverride ? null : (
+          <div className="mb-4">
+            <ShowbackPanel />
+          </div>
+        )}
 
         <div className="mb-3 flex flex-wrap items-end gap-3" data-testid="organizations-toolbar">
           <label className="flex flex-1 min-w-[240px] max-w-md flex-col gap-1">

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/ShowbackPanel.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/ShowbackPanel.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * ShowbackPanel.test.tsx — the B3 parent self-showback panel (issue
+ * #3378 DoD 3 + §5). The parent's per-app cost attribution renders, the
+ * pending flag surfaces, and the empty estate never crashes.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ShowbackPanel } from './ShowbackPanel'
+import type { SovereignConsumption } from '@/lib/organizations.api'
+
+function renderPanel(feed: SovereignConsumption, org?: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <ShowbackPanel initialOverride={feed} org={org} />
+    </QueryClientProvider>,
+  )
+}
+
+const FEED: SovereignConsumption = {
+  totalCostUnits: 900,
+  pending: false,
+  orgs: [
+    {
+      org: 'hw130.omantel.biz',
+      isParent: true,
+      costUnits: 900,
+      cpuMilli: 750,
+      memoryGiB: 2,
+      storageGiB: 10,
+      apps: [
+        { application: 'catalyst-api', namespace: 'catalyst', costUnits: 504, cpuMilli: 500, memoryGiB: 1, storageGiB: 0, percent: 56 },
+        { application: 'grafana', namespace: 'monitoring', costUnits: 396, cpuMilli: 250, memoryGiB: 1, storageGiB: 10, percent: 44 },
+      ],
+    },
+  ],
+}
+
+afterEach(() => cleanup())
+
+describe('ShowbackPanel — parent self-showback (DoD 3)', () => {
+  it('renders the parent org with its per-app attribution', () => {
+    renderPanel(FEED)
+    expect(screen.getByTestId('showback-panel')).toBeTruthy()
+    expect(screen.getByTestId('showback-org').textContent).toBe('hw130.omantel.biz')
+    expect(screen.getByTestId('showback-app-catalyst-api')).toBeTruthy()
+    expect(screen.getByTestId('showback-app-grafana')).toBeTruthy()
+    expect(screen.getByTestId('showback-app-pct-catalyst-api').textContent).toBe('56%')
+  })
+
+  it('flags the pending state while metering warms up', () => {
+    renderPanel({ totalCostUnits: 0, pending: true, orgs: [{ org: 'sovereign', isParent: true, costUnits: 0, cpuMilli: 0, memoryGiB: 0, storageGiB: 0, apps: [] }] })
+    expect(screen.getByTestId('showback-pending')).toBeTruthy()
+    expect(screen.getByTestId('showback-no-apps')).toBeTruthy()
+  })
+
+  it('never crashes on an empty feed', () => {
+    renderPanel({ totalCostUnits: 0, pending: true, orgs: [] })
+    expect(screen.getByTestId('showback-empty')).toBeTruthy()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/ShowbackPanel.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/ShowbackPanel.tsx
@@ -1,0 +1,114 @@
+/**
+ * ShowbackPanel — the B3 parent self-showback surface (issue #3378
+ * DoD 3 + §5).
+ *
+ * Renders the sovereign's own per-application cost attribution: the
+ * parent org's consumption broken down per app/namespace. Works day one
+ * on a zero-sub-org estate (100% attributes to the parent), which is the
+ * whole point of showback (§5). Mode-aware: this panel is the showback /
+ * chargeback view (attributed consumption, zero payment actions); real-
+ * billing orgs render the payment flows elsewhere.
+ *
+ * Reads the B3 feed (GET /api/v1/sme/consumption via getConsumption).
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import {
+  getConsumption,
+  type OrgConsumption,
+  type SovereignConsumption,
+} from '@/lib/organizations.api'
+
+export interface ShowbackPanelProps {
+  /** Render only this org's slice (e.g. the parent). When omitted the
+   *  panel shows the parent (first org) row. */
+  org?: string
+  /** Test seam — bypass the fetch with a synthetic feed. */
+  initialOverride?: SovereignConsumption
+}
+
+export function ShowbackPanel({ org, initialOverride }: ShowbackPanelProps) {
+  const query = useQuery<SovereignConsumption>({
+    queryKey: ['consumption'],
+    queryFn: getConsumption,
+    staleTime: 30_000,
+    enabled: !initialOverride,
+    placeholderData: (prev) => prev,
+  })
+  const feed = initialOverride ?? query.data
+  const loading = !initialOverride && query.isLoading
+
+  const target: OrgConsumption | undefined = feed
+    ? org
+      ? feed.orgs.find((o) => o.org === org)
+      : feed.orgs.find((o) => o.isParent) ?? feed.orgs[0]
+    : undefined
+
+  return (
+    <section
+      data-testid="showback-panel"
+      className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-4"
+    >
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-[var(--color-text-strong)]">
+          Showback — per-app consumption
+        </h2>
+        {feed?.pending ? (
+          <span
+            data-testid="showback-pending"
+            className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-300"
+          >
+            Metering warming up
+          </span>
+        ) : null}
+      </div>
+
+      {loading ? (
+        <div data-testid="showback-loading" className="text-sm text-[var(--color-text-dim)]">Loading…</div>
+      ) : !target ? (
+        <div data-testid="showback-empty" className="text-sm text-[var(--color-text-dim)]">
+          No consumption attributed yet. Showback populates from running workloads.
+        </div>
+      ) : (
+        <div>
+          <p className="mb-3 text-xs text-[var(--color-text-dim)]">
+            <span data-testid="showback-org" className="font-medium text-[var(--color-text)]">{target.org}</span>
+            {target.isParent ? ' (parent — your own estate)' : ''} ·{' '}
+            <span data-testid="showback-total" className="font-mono">{target.costUnits}</span> units ·{' '}
+            {target.cpuMilli}m CPU · {target.memoryGiB} GiB mem · {target.storageGiB} GiB storage
+          </p>
+          {target.apps.length === 0 ? (
+            <div data-testid="showback-no-apps" className="text-sm text-[var(--color-text-dim)]">
+              No applications attributed yet.
+            </div>
+          ) : (
+            <div className="overflow-x-auto rounded-lg border border-[var(--color-border)]">
+              <table data-testid="showback-table" className="w-full border-collapse text-sm">
+                <thead>
+                  <tr className="border-b border-[var(--color-border)] text-left text-[0.7rem] uppercase tracking-wide text-[var(--color-text-dim)]">
+                    <th className="px-3 py-2 font-semibold">Application</th>
+                    <th className="px-3 py-2 font-semibold">Namespace</th>
+                    <th className="px-3 py-2 font-semibold text-right">CPU (m)</th>
+                    <th className="px-3 py-2 font-semibold text-right">Mem (GiB)</th>
+                    <th className="px-3 py-2 font-semibold text-right">Share</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {target.apps.map((a) => (
+                    <tr key={`${a.namespace}/${a.application}`} data-testid={`showback-app-${a.application}`} className="border-b border-[var(--color-border)] last:border-b-0">
+                      <td className="px-3 py-2 text-[var(--color-text-strong)]">{a.application}</td>
+                      <td className="px-3 py-2 font-mono text-xs text-[var(--color-text-dim)]">{a.namespace}</td>
+                      <td className="px-3 py-2 text-right tabular-nums">{a.cpuMilli}</td>
+                      <td className="px-3 py-2 text-right tabular-nums">{a.memoryGiB}</td>
+                      <td className="px-3 py-2 text-right tabular-nums" data-testid={`showback-app-pct-${a.application}`}>{a.percent}%</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/products/catalyst/chart/templates/controllers/organization-controller-deployment.yaml
+++ b/products/catalyst/chart/templates/controllers/organization-controller-deployment.yaml
@@ -123,6 +123,15 @@ spec:
             # products/catalyst/chart/templates/qa-fixtures/useraccess-qa-user1.yaml.
             - name: CATALYST_USERACCESS_NAMESPACE
               value: {{ .Values.controllers.organization.userAccessNamespace | default "catalyst-system" | quote }}
+            # Organizations Enter-org support model (issue #3378 DoD 6):
+            # gates the per-Org Keycloak realm auto-wiring (reconcilePerOrgRealm,
+            # #3101). Defaults FALSE — the realm path is merged-dormant until
+            # an operator validates it on a live env and flips
+            # perOrgRealmEnabled=true in the per-Sovereign values overlay.
+            # cmd/main.go reads CATALYST_PER_ORG_REALM_ENABLED; a sub-org
+            # with a realm is the precondition for the Enter-org walk.
+            - name: CATALYST_PER_ORG_REALM_ENABLED
+              value: {{ .Values.controllers.organization.perOrgRealmEnabled | default false | quote }}
             {{- range $k, $v := .Values.controllers.organization.env }}
             - name: {{ $k | quote }}
               value: {{ $v | quote }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -469,6 +469,14 @@ controllers:
     # iter-8 Fix #42 root cause). Default matches the qa-fixtures
     # convention at templates/qa-fixtures/useraccess-qa-user1.yaml.
     userAccessNamespace: "catalyst-system"
+    # Organizations Enter-org support model (issue #3378 DoD 6). When true
+    # the org-controller's reconcilePerOrgRealm (#3101) auto-wires a
+    # dedicated Keycloak realm per Organization — the precondition for the
+    # Enter-org support session (impersonation into a sub-org's own realm).
+    # Defaults FALSE: the realm path is merged-dormant until an operator
+    # validates it on a live env and flips this in the per-Sovereign values
+    # overlay. Stays runtime-overridable per Inviolable Principle #4.
+    perOrgRealmEnabled: false
     # Free-form extra env vars threaded into the Pod (advanced; for one-off
     # operator-side knobs not yet promoted to a top-level value).
     env: {}


### PR DESCRIPTION
## Organizations menu — PR 1 of the #3378 chain (the menu skeleton)

ONE menu — **Organizations** — replaces BSS and the never-built OSS (founder-agreed model 2026-06-13). This first PR lands the §4 menu structure + the §5 empty-state law. Follow-on PRs on this same chain add the org-detail page, commerce editors, B1 internal-door field handling, B3 metering/showback, B4 mode-aware billing, and B2 Enter-org.

### What this PR does
- **Sidebar scope wall**: the `BSS` entry is REPLACED by `Organizations`; every other sovereign item (Dashboard, Cloud, Apps, Sandbox, Jobs, Compliance, Users, Settings) is byte-identical. `SovereignSidebar` `FLAT_NAV` swap + `deriveActiveSection`.
- **`/organizations` directory**: the parent org — the Sovereign itself — is the FIRST citizen (never blank), with kind / tier / billingMode / isolation / status badges per row and a `Create organization` button. Rides EXISTING endpoints: `listOrganizations()` composes the parent row from `GET /api/v1/sovereign/self` + sub-org rows from `GET /api/v1/sme/tenants`. **No new directory endpoint** (§6 "any new endpoint beyond B1-B3 = FAIL").
- **`/organizations/new`**: the internal-door entry (re-mounts the create form as `CreateOrganizationPage`; B1 field handling lands next on this chain).
- **Moved pages + redirect map** (§4, "old URLs never break"): billing/orders/revenue/vouchers re-mount under `/organizations/billing/*`, parent-domains under `/organizations/domains`; `/bss*`, `/sme/users`, `/sme/roles`, `/sme/tenants/new`, `/parent-domains` all redirect to their new homes via the `beforeLoad`-throw-`redirect` idiom. Page internals untouched.

### Naming law (#3383)
Every new route/component is Organization-named; `sme`/`tenant` never name anything new.

### Validation
- `npx tsc -b` green; `npm run build` green.
- vitest: `organizations.api` (kind-derived defaults + parent-first composition), `OrganizationsDirectoryPage` (§5 empty-state — parent first citizen with showback badge + Create button, never blank), and the §4 redirect map (every legacy path → its new home). 19/19 new tests pass; sidebar/layout tests green.
- Live walk (DoD 1/2/9 screenshots) pending the hw130 roll — currently recovering from tonight's outage (#3388).

Refs #3378 #3383