### PR TITLE
fix(placement): strip vCluster alias residue (slots 09/10/13) — auth/console route backends point at non-existent Services

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -237,8 +237,6 @@ spec:
     sovereignRealm:
       name: ${SOVEREIGN_REALM_NAME:=sovereign}
       ownerEmail: "${SOVEREIGN_OWNER_EMAIL}"
-    gateway:
-      backendService: keycloak-x-keycloak-x-mgmt-vcluster  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       host: auth.${SOVEREIGN_FQDN}
     # ── Shared-instance flip (#3188 three-instance model) ───────────────
     # Default OWN_CLUSTER=true → the bundled bitnami postgresql subchart

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -194,8 +194,6 @@ spec:
     # Upstream chart's own Ingress is disabled (gitea.ingress.enabled=false
     # in platform/gitea/chart/values.yaml) — Sovereigns ingress through
     # cilium-gateway from clusters/_template/bootstrap-kit/01-cilium.yaml.
-    gateway:
-      backendService: gitea-http-x-gitea-x-mgmt-vcluster  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       host: gitea.${SOVEREIGN_FQDN}
     # DoD D25 (t129 2026-05-16): override the chart's baked dev hostname
     # `gitea.catalyst.local` so the Gitea Web UI renders the LIVE

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1197,9 +1197,6 @@ spec:
       # MUST persist to local Gitea source-of-truth).
       imageRegistry: ''
     ingress:
-      gateway:
-        backendServiceUi: catalyst-ui-x-catalyst-system-x-mgmt-vcluster  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
-        backendServiceApi: catalyst-api-x-catalyst-system-x-mgmt-vcluster  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       hosts:
         console:
           host: console.${SOVEREIGN_FQDN}


### PR DESCRIPTION
hw130 live: HTTPRoute/keycloak `ResolvedRefs=False — Service keycloak-x-keycloak-x-mgmt-vcluster not found` → envoy 500 on every external auth request (KC 200 internally). The #3388 revert removed the placement rows' values maps but the regenerated slots KEPT the alias lines (renderer does not remove residue values). gitea (slot 10) and the console umbrella (slot 13) carry the same residue and break identically as they install. Stripped all three; gates green. Renderer residue-guard filed as a follow-up row on #3373.

Refs #3373

🤖 Generated with [Claude Code](https://claude.com/claude-code)