### PR TITLE
fix(bp-gitea): flux-managed label on sso-configure hook Job (kyverno Enforce, 1.2.33)

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -131,7 +131,7 @@ spec:
       # + gateway /user/login -> OIDC entry redirect.
       # 1.2.30: explicit port 443 on the SSO redirect (the #3310 class).
       # 1.2.31: LANDING_PAGE=login — anon root funnels into OIDC.
-      version: 1.2.32
+      version: 1.2.33
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.32
+  version: 1.2.33
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -108,7 +108,7 @@ name: bp-gitea
 # the bootstrap-kit slot 10 `SOVEREIGN_GITEA_PG_SECRET` seam (own-cluster
 # default gitea-pg-app → SHARED gitea-database-secret). own-cluster render
 # byte-identical to 1.2.26.
-version: 1.2.32
+version: 1.2.33
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/sso-configure-oauth-job.yaml
+++ b/platform/gitea/chart/templates/sso-configure-oauth-job.yaml
@@ -35,6 +35,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     catalyst.openova.io/blueprint: bp-gitea
+    # kyverno flux-managed (Enforce): hook Jobs have no HelmRelease
+    # ownerReference — the label is the sanctioned pass (#3297 class).
+    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
@@ -47,6 +50,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     catalyst.openova.io/blueprint: bp-gitea
+    # kyverno flux-managed (Enforce): hook Jobs have no HelmRelease
+    # ownerReference — the label is the sanctioned pass (#3297 class).
+    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
@@ -70,6 +76,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     catalyst.openova.io/blueprint: bp-gitea
+    # kyverno flux-managed (Enforce): hook Jobs have no HelmRelease
+    # ownerReference — the label is the sanctioned pass (#3297 class).
+    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
@@ -90,6 +99,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     catalyst.openova.io/blueprint: bp-gitea
+    # kyverno flux-managed (Enforce): hook Jobs have no HelmRelease
+    # ownerReference — the label is the sanctioned pass (#3297 class).
+    app.kubernetes.io/managed-by: flux
     catalyst.openova.io/component: sso-configure
   annotations:
     "helm.sh/hook": post-install,post-upgrade


### PR DESCRIPTION
hw130 live denial verbatim: `Job/gitea-sso-configure is not Flux-managed` — the #3297 keycloak-class hook-Job landmine, gitea edition, detonating on tonight's first reinstall under Enforce. One label per the sanctioned pass; 1.2.33 with blueprint + pin lockstep.

Refs #3373 #3380

🤖 Generated with [Claude Code](https://claude.com/claude-code)