### PR TITLE
fix(kit): restore gateway.host for keycloak + gitea slots — HTTPRoutes render again

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -238,6 +238,12 @@ spec:
       name: ${SOVEREIGN_REALM_NAME:=sovereign}
       ownerEmail: "${SOVEREIGN_OWNER_EMAIL}"
       host: auth.${SOVEREIGN_FQDN}
+    # Restored 2026-06-13: the #3373 slot regeneration replaced gateway.host
+    # with the vCluster backendService alias; the #3391 residue strip then
+    # removed the whole block — chart renders NO HTTPRoute without
+    # gateway.host (auth.<fqdn> 404'd live).
+    gateway:
+      host: auth.${SOVEREIGN_FQDN}
     # ── Shared-instance flip (#3188 three-instance model) ───────────────
     # Default OWN_CLUSTER=true → the bundled bitnami postgresql subchart
     # renders exactly as today (the externalDatabase block is UNREAD when

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -195,6 +195,9 @@ spec:
     # in platform/gitea/chart/values.yaml) — Sovereigns ingress through
     # cilium-gateway from clusters/_template/bootstrap-kit/01-cilium.yaml.
       host: gitea.${SOVEREIGN_FQDN}
+    # Restored 2026-06-13 (same #3373/#3391 shape as slot 09).
+    gateway:
+      host: gitea.${SOVEREIGN_FQDN}
     # DoD D25 (t129 2026-05-16): override the chart's baked dev hostname
     # `gitea.catalyst.local` so the Gitea Web UI renders the LIVE
     # Sovereign FQDN in pageData.appUrl, clone URLs, and internal links.


### PR DESCRIPTION
Live: ns keycloak has ZERO HTTPRoutes (auth 404) because the chart renders the route only when `gateway.host` is set — the #3373 regeneration had swapped host→vCluster-alias and the #3391 strip removed the block. Key-level diff vs pre-conversion confirms slots 09/10 lost exactly the gateway block; slot 13 intact. Restored verbatim with ${SOVEREIGN_FQDN} substitution. Gates green.

Refs #3373

🤖 Generated with [Claude Code](https://claude.com/claude-code)