### PR TITLE
fix(kyverno-policies): exclude ns sme from harbor-proxy-pull — operator provisioning plane (1.0.32)

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -95,7 +95,7 @@ spec:
       # images still need the per-chart 11-harbor-proxy fix (a cluster-wide image-
       # rewrite mutate can't know the per-Sovereign Harbor host without re-tethering
       # to the mothership → Pillar 5 violation). See Chart.yaml for the full RCA.
-      version: 1.0.31
+      version: 1.0.32
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.31
+  version: 1.0.32
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -154,7 +154,7 @@ type: application
 # while keeping proxy-cache for anonymous public registries.
 # Lockstep with bp-self-sovereign-cutover 0.1.43 (Step 03 Phase A
 # skopeo native-push + Step 07 REGISTRY drops /proxy-ghcr/ suffix).
-version: 1.0.31
+version: 1.0.32
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/values.yaml
+++ b/platform/kyverno-policies/chart/values.yaml
@@ -77,6 +77,16 @@ compliancePolicies:
       - cert-manager
       - openova-system
       - catalyst
+      # 2026-06-13: ns `sme` is the operator's tenant-provisioning control
+      # plane (provisioning/ferretdb/billing/marketplace/catalog) — same
+      # operator-trust tier as `catalyst`/`mgmt`/`rtz`/`sso-bridge` already
+      # excluded. Its Deployments legitimately MIX a proxied util init
+      # (alpine/k8s) with native openova-io main images; harbor-proxy-pull's
+      # anyPattern requires per-pod homogeneity, so the mix is denied on
+      # reinstall under Enforce (hw130 umbrella install blocked live). It is
+      # NOT tenant workload — it provisions tenants. catalyst-system carries
+      # the same shape (catalyst-api + util inits).
+      - sme
       - kyverno
       - monitoring
       - ingress


### PR DESCRIPTION
Final umbrella admission gate on hw130. The `harbor-proxy-pull` rule uses `anyPattern` = every container in a pod must share ONE source prefix (all `*/proxy-*/*` OR all `*/openova-io/*`). sme-services pods mix a proxied alpine/k8s init with native openova-io main images → neither pattern matches → denied on reinstall under Enforce. ns `sme` is operator provisioning infrastructure (same trust tier as the already-excluded catalyst/mgmt/rtz/dmz/sso-bridge), NOT tenant workload. Post-cutover image-source stays enforced by the Step-04 containerd mirror. 1.0.32, blueprint + pin lockstep.

Refs #3380 #3268

🤖 Generated with [Claude Code](https://claude.com/claude-code)