### PR TITLE
fix(bp-cnpg-pair): own-cluster carve-out on replica netpol — un-wedges the 24h replica join (#3322, 0.2.4)

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -192,7 +192,7 @@ spec:
       # it default-denied the primary's own instance-2 join (>1h wedge).
       # 0.2.3 (#3195 G6): production Continuum seed flipped ON (real
       # region labels; CRD pattern relaxed in lockstep, catalyst chart).
-      version: 0.2.3
+      version: 0.2.4
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.2.3
+  version: 0.2.4
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cnpg-pair
-version: 0.2.3
+version: 0.2.4
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair

--- a/platform/cnpg-pair/chart/templates/networkpolicy.yaml
+++ b/platform/cnpg-pair/chart/templates/networkpolicy.yaml
@@ -116,6 +116,20 @@ spec:
       ports:
         - port: 5432
           protocol: TCP
+    # #3322 OWN-CLUSTER carve-out: the replica Cluster's instance-2 joins
+    # instance-1 via the replica's -rw Service on 5432. This netpol selects
+    # the replica Pods, so without an explicit allow for the replica's OWN
+    # cnpg.io/cluster label it default-denies that join → instance-2 wedges
+    # at "Creating a new replica" (dial timeout to replica-rw:5432), exactly
+    # the primary side's own-cluster gap (lines above). hw130 caught this
+    # live (24h wedge). Mirror the primary carve-out.
+    - from:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: {{ include "cnpg-pair.replicaName" . }}
+      ports:
+        - port: 5432
+          protocol: TCP
     # CNPG operator status + metrics probe — the replica side selects its
     # own instance CR Pods, so it needs the same operator carve-out as the
     # primary or the replica Cluster phase stalls at "Instance Status


### PR DESCRIPTION
The cnpg-pair REPLICA cluster's instance-2 has been wedged 24h at 'Creating a new replica' — `dial timeout to cnpg-pair-...-replica-rw:5432`. Root cause: the `allow-probe-to-replica` NetworkPolicy selects the replica Pods and allowed only the failover-probe + operator, NOT the replica's OWN cnpg.io/cluster instance-to-instance 5432 path (the exact #3322 pattern the PRIMARY netpol already carves out, lines above it). Mirrored that carve-out. This un-blocks the #3375 region-kill DR walk (north star 4). 0.2.4, blueprint + pin lockstep; helm-lint + gates green.

Refs #3322 #3375 #3241

🤖 Generated with [Claude Code](https://claude.com/claude-code)