### PR TITLE
fix(cutover): enable the real 10-min deny-egress hold in slot-06a overlay (#3379)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -494,6 +494,30 @@ spec:
       # hw91. This is the missing lockstep half of #3012; mirror of
       # harbor/giteaPublicURL.
       consolePublicURL: https://console.${SOVEREIGN_FQDN}
+    # #3379 (2026-06-13): enable the REAL 10-minute deny-egress hold for
+    # Step-08 (egress-block-test). The chart default
+    # (egressTest.enforceCIDRBlock: false, values.yaml) ships the passive
+    # assertion-only fallback — it verifies the post-cutover architectural
+    # state (local Flux/Harbor URLs) + polls HR/Ks readiness, but it does
+    # NOT actually deny egress, so a HIDDEN runtime tether (a Go constant
+    # dialing harbor.openova.io, an image pull not routed through a
+    # HelmRepository) would pass silently. ADR-0002 + the founder rule are
+    # explicit: `cutoverComplete=true` is earned ONLY with the egress-block
+    # proof. With this set true, Step-08 resolves github.com / ghcr.io /
+    # harbor.openova.io / xpkg.upbound.io → public /32s and applies a
+    # cluster-wide CiliumClusterwideNetworkPolicy egressDeny for the
+    # survival window (private/loopback IPs are skipped, so intra-cluster
+    # traffic is never blocked), then asserts every HelmRelease +
+    # Kustomization stays Ready throughout. The Step-08 Job is fail-safe:
+    # any resolve/apply error falls back to assertion-only and NEVER wedges
+    # the cutover on a tooling failure (see 08-egress-block-test-job.yaml),
+    # and the deny policy is torn down on every pass/fail/abort path
+    # (inline delete + TERM/EXIT trap). The hold is reversible BY DESIGN
+    # (a timed CiliumClusterwideNetworkPolicy, removed at end-of-window) —
+    # safe to apply to a converged Sovereign because every blocked host is
+    # a tether the preceding steps 01-07 already pivoted off.
+    egressTest:
+      enforceCIDRBlock: true
     # Wave 5.110 (#2462): bastion mirror endpoint for harbor.openova.io,
     # substituted from cloudinit's flux-system/bastion-mirror Secret
     # (Huawei provider only; Hetzner leaves the var empty → chart skips

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -693,4 +693,28 @@ if grep -A20 'gitea-token-mint' "$TMP/render.yaml" | grep -q 'X DELETE.*tokens/'
 fi
 echo "  PASS (Step-09: validity probe short-circuits re-runs; unique mint name; no active-token DELETE)"
 
+echo "[cutover-contract] Case 25: slot-06a overlay enables the REAL deny-egress hold (#3379)"
+# The chart default (values.yaml egressTest.enforceCIDRBlock: false) ships
+# the passive assertion-only Step-08 — which verifies the post-cutover
+# architectural state but does NOT actually deny egress. ADR-0002 + the
+# founder rule require cutoverComplete=true to be earned through a REAL
+# 10-minute deny-egress hold against github.com/ghcr.io/harbor.openova.io.
+# The per-Sovereign overlay
+# (clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml)
+# is the lockstep half: it MUST set egressTest.enforceCIDRBlock: true so the
+# real CiliumClusterwideNetworkPolicy egressDeny is applied on every prov.
+# Guard against a silent revert to assertion-only. Located relative to the
+# repo root ($CHART_DIR/../../..); skipped only if the overlay is absent
+# (chart consumed standalone outside the monorepo).
+OVERLAY_06A="${CHART_DIR}/../../../clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml"
+if [ -f "$OVERLAY_06A" ]; then
+  if ! grep -Eq '^[[:space:]]*enforceCIDRBlock:[[:space:]]*true' "$OVERLAY_06A"; then
+    echo "FAIL: slot-06a overlay does not set egressTest.enforceCIDRBlock: true — the deny-egress hold would silently degrade to assertion-only (#3379)" >&2
+    exit 1
+  fi
+  echo "  PASS (slot-06a overlay enables the real deny-egress hold)"
+else
+  echo "  SKIP (slot-06a overlay not present — chart consumed standalone)"
+fi
+
 echo "[cutover-contract] All gates green."


### PR DESCRIPTION
## What

Sets `egressTest.enforceCIDRBlock: true` in the slot-06a per-Sovereign overlay (`clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml`) so the cutover Step-08 (egress-block-test) applies a **real 10-minute deny-egress hold** instead of the passive assertion-only fallback.

## Why

`bp-self-sovereign-cutover`'s Step-08 has two modes:

- **Chart default** (`egressTest.enforceCIDRBlock: false`): assertion-only — verifies the post-cutover architectural state (local Flux/Harbor URLs) and polls HR/Ks readiness, but **never denies egress**.
- **Enforce** (`true`): resolves `github.com` / `ghcr.io` / `harbor.openova.io` / `xpkg.upbound.io` → public `/32`s and applies a cluster-wide `CiliumClusterwideNetworkPolicy egressDeny` for the survival window, so any **hidden runtime tether** surfaces as NotReady.

ADR-0002 + the founder rule require `cutoverComplete=true` to be earned through the **real** deny-egress proof. The Step-08 Job already implements enforcement; the missing lockstep half was the per-Sovereign overlay — it never set `enforceCIDRBlock: true`, so every prov silently ran assertion-only. This was the same shape as the #3039 `consolePublicURL` overlay-lockstep gap.

## Measured current state (hw130, live)

- Cutover chart `bp-self-sovereign-cutover@0.1.56` installed dormant, HR Ready; status CM `cutoverComplete=false`, `cutoverStartedAt=""` (engine never ran — archive never landed, as expected).
- The live HR `.spec.values.egressTest` was **empty** → assertion-only would run.
- The 4 `sovereign.*` URL overlays are correctly present (#3039 lockstep intact).

## Safety

The hold is reversible by design (a timed CiliumClusterwideNetworkPolicy removed at end-of-window). The Step-08 Job is fail-safe: any resolve/apply error falls back to assertion-only and never wedges the cutover; the deny policy is torn down on every pass/fail/abort path (inline delete + TERM/EXIT trap). Every blocked host is a tether steps 01-07 already pivoted off.

## Drift-guard

Adds contract Case 25 (`platform/self-sovereign-cutover/chart/tests/cutover-contract.sh`) that FAILs if the overlay reverts to assertion-only. Red-proven locally: flip to `false` → FAIL, flip to `true` → PASS. All 25 contract gates green.

## Scope

- Chart templates/values **unchanged** → no chart version bump.
- Only the overlay value + the contract drift-guard.

Refs #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)