### PR TITLE
fix(robustness): kyverno-Enforce image-tether guards + 3 live docker.io/registry.k8s.io wounds (#3380-D)

### DIFF
--- a/.github/workflows/check-kyverno-proxy-images.yaml
+++ b/.github/workflows/check-kyverno-proxy-images.yaml
@@ -1,0 +1,70 @@
+name: Kyverno admission drift-guard (proxy-images)
+
+# #3380-D admission-test CI gate.
+#
+# Renders the registry-sensitive bootstrap-kit charts and asserts every
+# container/initContainer image satisfies the live `harbor-proxy-pull`
+# Kyverno ClusterPolicy's allowed-image globs (read verbatim from
+# platform/kyverno-policies/chart/values.yaml). That policy runs
+# `validationFailureAction: Enforce` on every Sovereign, so an image that
+# matches none of its globs is DENIED at admission the moment its pod is
+# (re)scheduled.
+#
+# WHY THIS EXISTS
+#   Charts that wrap an upstream subchart routinely leak an upstream
+#   registry through a field the umbrella forgot to override (the loft-sh
+#   vcluster k8s-distro images defaulting to registry.k8s.io; the powerdns
+#   subchart defaulting to docker.io/powerdns/*). `helm lint` + smoke-render
+#   never catch this — the YAML is valid; only matching every image against
+#   the Enforce policy's own globs catches it. This gate moves the proof
+#   from "discovered live on a Sovereign after the next image roll" to
+#   "blocked at PR time" — the admission-test gate #3380-D asks for, in a
+#   fast (<1m) flake-free form (no kind cluster, no live kyverno).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'platform/bp-mgmt-vcluster/chart/**'
+      - 'platform/bp-dmz-vcluster/chart/**'
+      - 'platform/bp-rtz-vcluster/chart/**'
+      - 'platform/powerdns/chart/**'
+      - 'platform/kyverno-policies/chart/values.yaml'
+      - 'scripts/check-kyverno-proxy-images.sh'
+      - '.github/workflows/check-kyverno-proxy-images.yaml'
+  pull_request:
+    paths:
+      - 'platform/bp-mgmt-vcluster/chart/**'
+      - 'platform/bp-dmz-vcluster/chart/**'
+      - 'platform/bp-rtz-vcluster/chart/**'
+      - 'platform/powerdns/chart/**'
+      - 'platform/kyverno-policies/chart/values.yaml'
+      - 'scripts/check-kyverno-proxy-images.sh'
+      - '.github/workflows/check-kyverno-proxy-images.yaml'
+  workflow_dispatch:
+
+jobs:
+  proxy-images:
+    name: harbor-proxy-pull image conformance
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.0
+
+      - name: Add upstream subchart repos
+        # The vcluster + powerdns charts vendor their subchart .tgz under
+        # charts/ when present; on a clean CI checkout those are absent, so
+        # `helm dependency build` must resolve them from the upstream repos.
+        # The guard skips the build when a .tgz is already vendored.
+        run: |
+          helm repo add loft https://charts.loft.sh
+          helm repo add schich https://schich.tel/helm-charts
+          helm repo update
+
+      - name: Run proxy-images admission drift-guard
+        run: bash scripts/check-kyverno-proxy-images.sh

--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -137,7 +137,10 @@ spec:
       # Gateway-API default copied the cilium listener port (30443) into
       # the Location header, landing browsers on a port nothing serves
       # externally (proven live hw129).
-      version: 1.2.12
+      # 1.2.13 (#3380-D): REST-API Ingress gated off on the Gateway path so
+      # no orphaned powerdns-api-tls Certificate (Ready=False) is spawned;
+      # dnsdist + pdns-auth images routed through Harbor proxy-docker.
+      version: 1.2.13
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
@@ -66,7 +66,9 @@ spec:
       # 0.2.5 (#2940 Pillar 5): registry host driven by global.registryMirror
       # + the ${REGISTRY_MIRROR:=harbor.openova.io} subchart substitution below.
       # 0.2.6 (#3373 fix (b)): toHost customResources sync gains HTTPRoute + ExternalSecret.
-      version: 0.2.6
+      # 0.2.7 (#3380-D): k8s distro control-plane images pinned off
+      # registry.k8s.io onto Harbor proxy-k8s (harbor-proxy-pull Enforce).
+      version: 0.2.7
       sourceRef:
         kind: HelmRepository
         name: bp-dmz-vcluster

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -73,7 +73,9 @@ spec:
       # 0.2.6 (#2940 Pillar 5): registry host driven by global.registryMirror
       # + the ${REGISTRY_MIRROR:=harbor.openova.io} subchart substitution above.
       # 0.2.7 (#3373 fix (b)): toHost customResources sync gains HTTPRoute + ExternalSecret.
-      version: 0.2.7
+      # 0.2.8 (#3380-D): k8s distro control-plane images pinned off
+      # registry.k8s.io onto Harbor proxy-k8s (harbor-proxy-pull Enforce).
+      version: 0.2.8
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
@@ -65,7 +65,9 @@ spec:
       # 0.2.6 (#2940 Pillar 5): registry host driven by global.registryMirror
       # + the ${REGISTRY_MIRROR:=harbor.openova.io} subchart substitution below.
       # 0.2.7 (#3373 fix (b)): toHost customResources sync gains HTTPRoute + ExternalSecret.
-      version: 0.2.7
+      # 0.2.8 (#3380-D): k8s distro control-plane images pinned off
+      # registry.k8s.io onto Harbor proxy-k8s (harbor-proxy-pull Enforce).
+      version: 0.2.8
       sourceRef:
         kind: HelmRepository
         name: bp-rtz-vcluster

--- a/platform/bp-dmz-vcluster/blueprint.yaml
+++ b/platform/bp-dmz-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.6
+  version: 0.2.7
   card:
     title: DMZ vCluster
     summary: |

--- a/platform/bp-dmz-vcluster/chart/Chart.yaml
+++ b/platform/bp-dmz-vcluster/chart/Chart.yaml
@@ -33,7 +33,14 @@ name: bp-dmz-vcluster
 # customResources block before (no CNPG precedent here); added with
 # the two #3373 entries. Sibling to bp-mgmt-vcluster 0.2.7 +
 # bp-rtz-vcluster 0.2.7.
-version: 0.2.6
+# 0.2.7 — Refs #3380-D (2026-06-13): pin the k8s distro control-plane
+# images off upstream `registry.k8s.io` onto the Sovereign-local Harbor
+# `proxy-k8s` cache (lockstep with bp-mgmt-vcluster 0.2.8). The loft-sh
+# subchart otherwise defaults apiServer/controllerManager/scheduler to
+# `registry.k8s.io/kube-*` — which the `harbor-proxy-pull` Enforce
+# ClusterPolicy DENIES on the next image roll. Additive values only.
+# Sibling to bp-mgmt-vcluster 0.2.8 + bp-rtz-vcluster 0.2.8.
+version: 0.2.7
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign DMZ

--- a/platform/bp-dmz-vcluster/chart/values.yaml
+++ b/platform/bp-dmz-vcluster/chart/values.yaml
@@ -93,6 +93,29 @@ vcluster:
     distro:
       k8s:
         enabled: true
+        # #3380-D Pillar-5 anti-tether (2026-06-13): pin the k8s distro
+        # control-plane images off upstream `registry.k8s.io` and onto the
+        # Sovereign-local Harbor `proxy-k8s` cache (lockstep with
+        # bp-mgmt-vcluster). The loft-sh subchart otherwise defaults the
+        # apiServer/controllerManager/scheduler images to
+        # `registry.k8s.io/kube-*`, which the `harbor-proxy-pull` Enforce
+        # ClusterPolicy would DENY on the next image roll. `harbor.openova.io`
+        # is the bootstrap default (subchart values can't self-template
+        # `global.registryMirror`); slot 58/59 flips it via
+        # `${REGISTRY_MIRROR:=harbor.openova.io}` and cutover Step-04 pivots
+        # it post-handover. `tag` left to the subchart default.
+        apiServer:
+          image:
+            registry: harbor.openova.io
+            repository: proxy-k8s/kube-apiserver
+        controllerManager:
+          image:
+            registry: harbor.openova.io
+            repository: proxy-k8s/kube-controller-manager
+        scheduler:
+          image:
+            registry: harbor.openova.io
+            repository: proxy-k8s/kube-scheduler
     backingStore:
       database:
         embedded:

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.7
+  version: 0.2.8
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -51,7 +51,18 @@ name: bp-mgmt-vcluster
 # httproutes.gateway.networking.k8s.io +
 # externalsecrets.external-secrets.io (coupling fix (b) — re-homed
 # charts' routes/secrets mirror toHost).
-version: 0.2.7
+# 0.2.8 — Refs #3380-D (2026-06-13): pin the k8s distro control-plane
+# images (apiServer / controllerManager / scheduler) off upstream
+# `registry.k8s.io` onto the Sovereign-local Harbor `proxy-k8s` cache.
+# The loft-sh subchart defaulted all three to `registry.k8s.io/kube-*`
+# (confirmed LIVE on hw130 `mgmt-vcluster-0` initContainers) — which the
+# `harbor-proxy-pull` Enforce ClusterPolicy DENIES on the next image roll
+# (a self-inflicted wound the moment the vCluster reschedules). Additive
+# values only; `helm template` renders the proxy path. `harbor.openova.io`
+# kept as the bootstrap default (slot 58 `${REGISTRY_MIRROR}` + cutover
+# Step-04 re-point the host). Sibling to bp-dmz-vcluster 0.2.7 +
+# bp-rtz-vcluster 0.2.8.
+version: 0.2.8
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -153,6 +153,43 @@ vcluster:
     distro:
       k8s:
         enabled: true
+        # #3380-D Pillar-5 anti-tether (2026-06-13): pin the k8s distro
+        # control-plane images (apiServer / controllerManager / scheduler)
+        # off upstream `registry.k8s.io` and onto the Sovereign-local Harbor
+        # `proxy-k8s` cache. WITHOUT this, the loft-sh subchart defaults all
+        # three to `registry.k8s.io/kube-{apiserver,controller-manager,
+        # scheduler}` — confirmed LIVE on hw130 (`mgmt-vcluster-0`
+        # initContainers `registry.k8s.io/kube-apiserver:v1.31.4` +
+        # `registry.k8s.io/kube-controller-manager:v1.31.4`). Under the
+        # `harbor-proxy-pull` ClusterPolicy (Enforce — every image must match
+        # `*/proxy-*/*` or `*/openova-io/*`), the NEXT image roll of these
+        # control-plane pods would be DENIED at admission — a self-inflicted
+        # wound the moment the vCluster reschedules. `registry.k8s.io` is
+        # proxied by Harbor's `proxy-k8s` project (chart 0.1.x proxyProjects),
+        # so `harbor.openova.io/proxy-k8s/kube-apiserver:<tag>` resolves the
+        # identical upstream digest through the cache.
+        #
+        # The `harbor.openova.io` host is kept as the bootstrap default for
+        # the same reason as the syncer image below — subchart values can't
+        # self-template `global.registryMirror`; bootstrap-kit slot 58 flips
+        # the host via `${REGISTRY_MIRROR:=harbor.openova.io}` postBuild
+        # substitution and bp-self-sovereign-cutover Step-04 re-points it
+        # post-handover. `tag` is left to the subchart default (the upstream
+        # k8s version pin) so a vcluster subchart bump carries the matching
+        # control-plane version automatically. Default `helm template` renders
+        # the proxy path identically across all three distro components.
+        apiServer:
+          image:
+            registry: harbor.openova.io
+            repository: proxy-k8s/kube-apiserver
+        controllerManager:
+          image:
+            registry: harbor.openova.io
+            repository: proxy-k8s/kube-controller-manager
+        scheduler:
+          image:
+            registry: harbor.openova.io
+            repository: proxy-k8s/kube-scheduler
     backingStore:
       database:
         embedded:

--- a/platform/bp-rtz-vcluster/blueprint.yaml
+++ b/platform/bp-rtz-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.7
+  version: 0.2.8
   card:
     title: RTZ vCluster
     summary: |

--- a/platform/bp-rtz-vcluster/chart/Chart.yaml
+++ b/platform/bp-rtz-vcluster/chart/Chart.yaml
@@ -31,7 +31,14 @@ name: bp-rtz-vcluster
 # httproutes.gateway.networking.k8s.io +
 # externalsecrets.external-secrets.io (coupling fix (b) — re-homed
 # charts' routes/secrets mirror toHost).
-version: 0.2.7
+# 0.2.8 — Refs #3380-D (2026-06-13): pin the k8s distro control-plane
+# images off upstream `registry.k8s.io` onto the Sovereign-local Harbor
+# `proxy-k8s` cache (lockstep with bp-mgmt-vcluster 0.2.8). The loft-sh
+# subchart otherwise defaults apiServer/controllerManager/scheduler to
+# `registry.k8s.io/kube-*` — which the `harbor-proxy-pull` Enforce
+# ClusterPolicy DENIES on the next image roll. Additive values only.
+# Sibling to bp-mgmt-vcluster 0.2.8 + bp-dmz-vcluster 0.2.7.
+version: 0.2.8
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign RTZ

--- a/platform/bp-rtz-vcluster/chart/values.yaml
+++ b/platform/bp-rtz-vcluster/chart/values.yaml
@@ -80,6 +80,29 @@ vcluster:
     distro:
       k8s:
         enabled: true
+        # #3380-D Pillar-5 anti-tether (2026-06-13): pin the k8s distro
+        # control-plane images off upstream `registry.k8s.io` and onto the
+        # Sovereign-local Harbor `proxy-k8s` cache (lockstep with
+        # bp-mgmt-vcluster). The loft-sh subchart otherwise defaults the
+        # apiServer/controllerManager/scheduler images to
+        # `registry.k8s.io/kube-*`, which the `harbor-proxy-pull` Enforce
+        # ClusterPolicy would DENY on the next image roll. `harbor.openova.io`
+        # is the bootstrap default (subchart values can't self-template
+        # `global.registryMirror`); slot 58/59 flips it via
+        # `${REGISTRY_MIRROR:=harbor.openova.io}` and cutover Step-04 pivots
+        # it post-handover. `tag` left to the subchart default.
+        apiServer:
+          image:
+            registry: harbor.openova.io
+            repository: proxy-k8s/kube-apiserver
+        controllerManager:
+          image:
+            registry: harbor.openova.io
+            repository: proxy-k8s/kube-controller-manager
+        scheduler:
+          image:
+            registry: harbor.openova.io
+            repository: proxy-k8s/kube-scheduler
     backingStore:
       database:
         embedded:

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.12
+  version: 1.2.13
   card:
     title: PowerDNS
     summary: |

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -13,7 +13,18 @@ name: bp-powerdns
 # founder's browser lands on the UI instead of a 404. The /api forward
 # rule is preserved (Gateway-API longest-prefix). Default empty = no
 # redirect rule rendered (zero regression).
-version: 1.2.12
+# 1.2.13 (#3380-D, 2026-06-13): (1) the REST-API Ingress now renders ONLY
+# when the Gateway path is OFF (api.gateway.enabled=false). On a
+# Cilium-Gateway Sovereign the Ingress was redundant with the HTTPRoute AND
+# its cert-manager.io/cluster-issuer annotation spawned a standalone
+# `powerdns-api-tls` Certificate that sits Ready=False forever (chart
+# default issuer `letsencrypt-prod` names a ClusterIssuer absent on
+# Sovereigns; the cilium-gateway wildcard already serves pdns.<sov-fqdn>).
+# (2) the dnsdist + pdns-auth images route through the Harbor `proxy-docker`
+# cache (were raw docker.io — Enforce-DENIED by harbor-proxy-pull on the
+# next roll, the `powerdns` ns is not excluded). Verified live hw130.
+# Contabo (gateway OFF, real Traefik) unaffected.
+version: 1.2.13
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/templates/api-ingress.yaml
+++ b/platform/powerdns/chart/templates/api-ingress.yaml
@@ -10,8 +10,27 @@ NEVER lives in values.yaml or this chart.
 Per docs/INVIOLABLE-PRINCIPLES.md #10 (credentials never appear in source
 or commits) the basicAuth Secret is created out-of-band by the
 private-repo cluster manifest at clusters/contabo-mkt/apps/powerdns/.
+
+#3380-D (2026-06-13): the Ingress is now rendered ONLY when the Gateway
+path is OFF. Previously this template rendered ALONGSIDE the HTTPRoute on
+Sovereigns ("+ Ingress, harmless on Sovereigns without Traefik") — but it
+is NOT harmless: the Ingress carries the cert-manager.io/cluster-issuer
+annotation, so cert-manager's Ingress-shim spawns a standalone
+`powerdns-api-tls` Certificate. On a Cilium-Gateway Sovereign that
+Certificate is BOTH redundant (the cilium-gateway https/apex-https
+listeners already serve `*.<sov-fqdn>` via `sovereign-wildcard-tls`, which
+covers `pdns.<sov-fqdn>` — verified live hw130) AND broken: the chart
+default `api.tls.issuer: letsencrypt-prod` names a ClusterIssuer that does
+NOT exist on Sovereigns (they issue via `wildcard-issuer`), so the
+CertificateRequest sits "Referenced ClusterIssuer not found" / Ready=False
+forever — a self-inflicted noise wound that pollutes `kubectl get
+certificate` and burns a pointless LE attempt. Gating the Ingress off when
+api.gateway.enabled=true removes the shim trigger at source; the HTTPRoute
++ Gateway wildcard fully serve `pdns.<sov-fqdn>` on Cilium Sovereigns.
+Contabo (api.gateway.enabled=false, real Traefik) is unaffected — it still
+gets the Ingress + its standalone cert.
 */}}
-{{- if .Values.api.enabled }}
+{{- if and .Values.api.enabled (not (and .Values.api.gateway .Values.api.gateway.enabled)) }}
 {{- /*
 Capabilities gate (issue #190): the `traefik.io/v1alpha1` Middleware CRD
 ships with the Traefik ingress controller. k3s ships Traefik by default

--- a/platform/powerdns/chart/values.yaml
+++ b/platform/powerdns/chart/values.yaml
@@ -76,6 +76,19 @@ powerdns:
   replicaCount: 3
 
   image:
+    # #3380-D (2026-06-13): route the PowerDNS Authoritative image through
+    # the Harbor `proxy-docker` cache instead of raw `docker.io`. The
+    # subchart default `docker.io/powerdns/pdns-auth-50` matches NEITHER
+    # harbor-proxy-pull glob (`*/proxy-*/*`, `*/openova-io/*`) — confirmed
+    # LIVE on hw130 (`powerdns-*` pods running `docker.io/powerdns/
+    # pdns-auth-50:5.0.3`, and the `powerdns` namespace is NOT in the
+    # policy excludeNamespaces list) — so the NEXT image roll would be
+    # Enforce-DENIED. `proxy-docker` proxies `registry-1.docker.io`, so
+    # `harbor.openova.io/proxy-docker/powerdns/pdns-auth-50` resolves the
+    # identical upstream digest. `harbor.openova.io` is the bootstrap
+    # default re-pointed by slot 11 / cutover Step-04 (same pattern as the
+    # CNPG/dnsdist images already proxied).
+    repository: harbor.openova.io/proxy-docker/powerdns/pdns-auth-50
     # tag: null → upstream chart falls back to .Chart.AppVersion (5.0.3).
     # Per INVIOLABLE-PRINCIPLES #4 we don't pin a literal tag here — the
     # chart's appVersion is the single source of truth and bumping the
@@ -315,7 +328,13 @@ dnsdist:
     # line (matches Authoritative 5.0.x release cadence). Pin a concrete
     # tag here — the dnsdist Deployment template defaults to the value
     # below when image.tag is unset.
-    repository: docker.io/powerdns/dnsdist-19
+    # #3380-D (2026-06-13): routed through the Harbor `proxy-docker` cache
+    # (was raw `docker.io/powerdns/dnsdist-19`). The raw docker.io ref
+    # matches no harbor-proxy-pull glob and would be Enforce-DENIED on the
+    # next image roll — confirmed LIVE on hw130 (`dnsdist-*` pod running
+    # `docker.io/powerdns/dnsdist-19:1.9.14`, `powerdns` ns not excluded).
+    # proxy-docker proxies registry-1.docker.io → identical digest.
+    repository: harbor.openova.io/proxy-docker/powerdns/dnsdist-19
     tag: "1.9.14"
     pullPolicy: IfNotPresent
   replicaCount: 1                   # scale alongside Sovereign expansion; single instance fronts one region

--- a/scripts/check-kyverno-proxy-images.sh
+++ b/scripts/check-kyverno-proxy-images.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# check-kyverno-proxy-images.sh — #3380-D admission-test drift-guard.
+#
+# WHAT
+#   Renders the registry-sensitive bootstrap-kit charts in their Sovereign
+#   configuration and asserts every container/initContainer image satisfies
+#   the live `harbor-proxy-pull` Kyverno ClusterPolicy's allowed-image globs
+#   (platform/kyverno-policies/chart/values.yaml → harborProxyPull.
+#   allowedImagePatterns). That policy runs `validationFailureAction:
+#   Enforce` on every Sovereign, so an image that does NOT match one of its
+#   globs is DENIED at admission the moment the pod is (re)scheduled.
+#
+# WHY (the wound this guards against)
+#   Charts that wrap an upstream subchart routinely leak an upstream
+#   registry through a field the umbrella forgot to override. The canonical
+#   live case (#3380-D): the loft-sh/vcluster subchart defaulted its k8s
+#   distro control-plane images to `registry.k8s.io/kube-*`, which sat
+#   un-denied only because the ns had no pod churn — the NEXT image roll
+#   would have been Enforce-DENIED. `helm lint` + smoke-render never catch
+#   this because the rendered YAML is valid; only matching every image
+#   against the Enforce policy's own globs catches it. This is the CI half
+#   of the kyverno-policies admission-test gate the ticket asks for — it
+#   moves the proof from "discovered live on hw130" to "blocked at PR time".
+#
+# DESIGN
+#   Pure `helm template` + glob match — no kind cluster, no live kyverno,
+#   so it is fast (<30s) and flake-free. The two allowed globs are read
+#   VERBATIM from the policy values so this guard can never drift from the
+#   policy it enforces. A small, explicit allowlist covers the genuinely
+#   legitimate non-proxy images (the cutover steps 01-04 that run BEFORE
+#   the local Harbor proxy exists, and Helm templated `{{...}}` placeholders
+#   that are not real refs).
+#
+# EXIT
+#   0  — every image in every rendered chart matches an allowed glob (or the
+#        allowlist).
+#   1  — at least one image would be Enforce-DENIED by harbor-proxy-pull.
+#   2  — tooling error (helm/yq missing, chart render failed).
+#
+# Usage: bash scripts/check-kyverno-proxy-images.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "FATAL: helm not on PATH" >&2
+  exit 2
+fi
+
+# ── Allowed globs — read verbatim from the policy so the guard can't drift.
+POLICY_VALUES="platform/kyverno-policies/chart/values.yaml"
+# Extract the harborProxyPull.allowedImagePatterns list entries. The block is
+# small + stable; a focused grep beats a yq dependency on minimal runners.
+mapfile -t ALLOWED_GLOBS < <(
+  awk '
+    /^  harborProxyPull:/ { in_block=1 }
+    in_block && /^    allowedImagePatterns:/ { in_list=1; next }
+    in_list && /^      - / {
+      line=$0
+      sub(/^      - /, "", line)
+      sub(/[[:space:]]*#.*$/, "", line)            # strip trailing comment
+      gsub(/"/, "", line)
+      gsub(/[[:space:]]/, "", line)
+      print line
+      next
+    }
+    in_list && !/^      - / { in_list=0; in_block=0 }
+  ' "$POLICY_VALUES"
+)
+
+if [ "${#ALLOWED_GLOBS[@]}" -eq 0 ]; then
+  echo "FATAL: could not parse harborProxyPull.allowedImagePatterns from $POLICY_VALUES" >&2
+  exit 2
+fi
+echo "[proxy-images] allowed globs (from $POLICY_VALUES): ${ALLOWED_GLOBS[*]}"
+
+# ── Explicit allowlist for legitimate non-proxy images.
+#   - The cutover steps 01-04 use upstream-public images BY DESIGN (they run
+#     BEFORE the local Harbor proxy + containerd registries.yaml v2 exist).
+#     Those step PodSpecs live in ConfigMaps and are stamped post-handover;
+#     the harbor-proxy-pull policy excludes the `catalyst` cutover namespace.
+#   - `{{...}}` and `${...}` are Helm/envsubst placeholders, not real refs.
+ALLOWLIST_REGEX='(\{\{)|(\$\{)|(alpine/k8s)|(alpine/git)|(curlimages/curl)|(library/alpine)|(library/busybox)'
+
+# ── Charts to render, with the value that flips their top-level gate on.
+#   Format: "<chart-path>|<helm --set args>". These are the registry-sensitive
+#   subchart-wrapping bootstrap charts most prone to an upstream-registry leak.
+#   Extend this list when a new subchart-wrapping bp-* lands.
+CHARTS=(
+  "platform/bp-mgmt-vcluster/chart|--set mgmtVcluster.enabled=true"
+  "platform/bp-dmz-vcluster/chart|--set dmzVcluster.enabled=true"
+  "platform/bp-rtz-vcluster/chart|--set rtzVcluster.enabled=true"
+  "platform/powerdns/chart|--set api.enabled=true --set api.gateway.enabled=true"
+)
+
+matches_any_glob() {
+  local img="$1"
+  local g
+  for g in "${ALLOWED_GLOBS[@]}"; do
+    # shellcheck disable=SC2053  # intentional glob match (==, not =~)
+    case "$img" in
+      $g) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+rc=0
+for entry in "${CHARTS[@]}"; do
+  chart="${entry%%|*}"
+  setargs="${entry#*|}"
+  if [ ! -d "$chart" ]; then
+    echo "[proxy-images] WARN: chart dir $chart absent — skipping" >&2
+    continue
+  fi
+  # Build subchart deps if a Chart.yaml dependencies block is present AND the
+  # subchart .tgz is not already vendored in charts/. CI checks out a clean
+  # tree (empty charts/) so the build runs there; locally the .tgz may
+  # already be present (and the upstream repo may not be `helm repo add`-ed),
+  # in which case we reuse the vendored copy rather than re-fetching.
+  if grep -q '^dependencies:' "$chart/Chart.yaml" 2>/dev/null; then
+    if ! ls "$chart"/charts/*.tgz >/dev/null 2>&1; then
+      ( cd "$chart" && helm dependency build >/dev/null 2>&1 ) || {
+        echo "FATAL: helm dependency build failed for $chart (add the subchart repo via 'helm repo add' or vendor the .tgz under charts/)" >&2
+        exit 2
+      }
+    fi
+  fi
+  rendered="$( (cd "$chart" && helm template guard . $setargs 2>/dev/null) )" || {
+    echo "FATAL: helm template failed for $chart $setargs" >&2
+    exit 2
+  }
+  # Pull every `image:` value (containers + initContainers render the same key).
+  while IFS= read -r img; do
+    [ -n "$img" ] || continue
+    if printf '%s' "$img" | grep -Eq "$ALLOWLIST_REGEX"; then
+      continue
+    fi
+    if ! matches_any_glob "$img"; then
+      echo "DENY: $chart renders image '$img' — matches NO harbor-proxy-pull glob (${ALLOWED_GLOBS[*]}). It would be Enforce-DENIED at admission. Route it through the Harbor proxy-cache (e.g. harbor.openova.io/proxy-<upstream>/...)." >&2
+      rc=1
+    fi
+  done < <(
+    printf '%s\n' "$rendered" \
+      | grep -oE '^[[:space:]]*-?[[:space:]]*image:[[:space:]]*"?[^"]+' \
+      | sed -E 's/^[[:space:]]*-?[[:space:]]*image:[[:space:]]*"?//' \
+      | sort -u
+  )
+done
+
+if [ "$rc" -eq 0 ]; then
+  echo "[proxy-images] PASS — every rendered image satisfies harbor-proxy-pull."
+else
+  echo "[proxy-images] FAIL — at least one image would be Enforce-DENIED by harbor-proxy-pull (#3380-D)." >&2
+fi
+exit "$rc"


### PR DESCRIPTION
## What

Closes the #3380-D kyverno-Enforce landmine class at source + ships the admission-test CI drift-guard the ticket asks for. Three self-inflicted-wound images confirmed **live on hw130**, all fixed; a CI guard added so the class can't recur.

## The wounds (all live-confirmed on hw130)

| # | Chart | Live image | Why it wounds |
|---|---|---|---|
| 1 | bp-{mgmt,dmz,rtz}-vcluster | `registry.k8s.io/kube-apiserver:v1.31.4`, `…/kube-controller-manager:v1.31.4` (initContainers) | loft-sh subchart defaults the k8s distro control-plane images to `registry.k8s.io`. `harbor-proxy-pull` (Enforce) DENIES on the next image roll. |
| 2 | powerdns | orphaned `powerdns-api-tls` Certificate `Ready=False` 36h | the REST-API Ingress's `cert-manager.io/cluster-issuer` annotation spawns a standalone cert on Cilium-Gateway Sovereigns where it's redundant (wildcard already serves `pdns.<fqdn>`) AND broken (`letsencrypt-prod` ClusterIssuer absent → "Referenced ClusterIssuer not found"). |
| 3 | powerdns | `docker.io/powerdns/dnsdist-19:1.9.14`, `docker.io/powerdns/pdns-auth-50:5.0.3` (running pods) | raw docker.io; `powerdns` ns is NOT in the policy excludeNamespaces → next roll Enforce-DENIED. **Caught by the new guard, not by hand.** |

## The fixes

1. **vcluster k8s distro** — pinned apiServer/controllerManager/scheduler onto `harbor.openova.io/proxy-k8s/kube-*` across all 3 charts (harbor.openova.io kept as bootstrap default the way the syncer image already is; slot 58/54/59 `${REGISTRY_MIRROR}` + cutover Step-04 re-point the host). Render-verified zero `registry.k8s.io`. Charts 0.2.7/0.2.6/0.2.7; slot pins bumped in lockstep (pin-sync green).
2. **powerdns cert** — Ingress now renders ONLY when `api.gateway.enabled=false`, so cert-manager's Ingress-shim no longer spawns the orphaned cert on Sovereigns. Contabo (gateway OFF, real Traefik) unchanged. Render-verified both modes. Chart 1.2.10; slot 11 pin bumped.
3. **powerdns images** — dnsdist + pdns-auth routed through `harbor.openova.io/proxy-docker/powerdns/*`.

## The drift-guard (the asked-for admission-test gate)

`scripts/check-kyverno-proxy-images.sh` + `.github/workflows/check-kyverno-proxy-images.yaml`: renders the registry-sensitive charts and asserts every image matches the `harbor-proxy-pull` allowed globs (`*/proxy-*/*`, `*/openova-io/*`), read **verbatim** from the policy values so it can't drift. Pure `helm template` + glob — fast (<1m), no kind cluster, no live kyverno. Red-proven: revert a fix → DENY/FAIL, restore → PASS. It already earned its keep by catching wound #3.

## Status of the other #3380 rows

- **A (wipe)** — deferred to the wipe phase per the ticket (verified by the hw130 wipe event later).
- **B (thin cloud-init / IPv6 helm-repo #3232)** — already fixed at source (`infra/providers/_shared/cloudinit-control-plane.tftpl:663-687` IPv4-pin hosts). The imperative-prelude removal is a larger ordering change deferred to avoid a cloud-init refactor (highest-risk surface).
- **C (phase1 resume)** — the resume gate is already fixed (#3153: `resolvePrimaryKubeconfigPath` file-on-PVC fallback at `clustermesh.go:1916`). The frozen-rows backfill specimen lives on the mothership record store (out of hw130 walk scope); no clean existing sweep hook — deferred to avoid inventing one.
- **D (kyverno)** — vcluster + powerdns + admission-test gate shipped here. The `sovereign-tls dependsOn bootstrap-kit` narrowing is structurally constrained (Flux Kustomization→Kustomization only) and a proper fix needs a cert-manager Kustomization split — deferred to avoid a bootstrap-ordering refactor.
- **E (cilium-envoy xDS)** — root-cause + detector is a live-repro investigation, not a source diff; deferred.

Zero-touch — no live env hand-patched. All fixes prove themselves through `helm template` + the guard.

Refs #3380

🤖 Generated with [Claude Code](https://claude.com/claude-code)