### PR TITLE
fix(funnel): SME NATS_URL → mgmt-vcluster synced service name — un-CrashLoop the SME chain (Refs #3376)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1018,7 +1018,7 @@ spec:
       # fields (spec.bootstrap/helmRelease/dependsOn + CEL waiver) +
       # catalog-seed shareable/contextSchema (bp-postgres, bp-valkey).
             # 1.4.598 — #3374: CATALYST_OPENBAO_ADDR onto catalyst-api (openbao bare-URL SSO shim).
-      version: 1.4.604
+      version: 1.4.605
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2643,7 +2643,7 @@ name: bp-catalyst-platform
 # deep-link (hw130, measured). Companion to bp-openbao 1.2.29 + the addr-only
 # client change in products/catalyst/bootstrap/api cmd/api/main.go.
 # 1.4.600 — sme/ferretdb image via harbor proxy-ghcr (kyverno rule 11; hw130 reinstall denial).
-version: 1.4.604
+version: 1.4.605
 # 1.4.597 — #3373 (2026-06-13) — coupling fix (a) placement-as-data:
 # templates/httproute.yaml backendRefs honor new
 # ingress.gateway.backendServiceApi / backendServiceUi overrides. When

--- a/products/catalyst/chart/templates/sme-services/configmap.yaml
+++ b/products/catalyst/chart/templates/sme-services/configmap.yaml
@@ -60,9 +60,24 @@ Redpanda default so contabo's existing SME consumers keep functioning.
   {{- /* Sovereign default: no Redpanda exists in cluster — leave empty
        so the SME services skip the legacy Kafka transport entirely. */ -}}
   {{- $defaultBrokers = "" -}}
-  {{- /* Sovereign default NATS URL. Correct namespace is `nats-system`
-       (see header comment §3). */ -}}
-  {{- $defaultNATS = "nats://nats-jetstream.nats-system.svc.cluster.local:4222" -}}
+  {{- /* Sovereign default NATS URL (#3376 funnel fix). #3373/#2697 moved
+       bp-nats-jetstream INSIDE the mgmt vCluster (placement.yaml:
+       `bp-nats-jetstream → vcluster: mgmt, namespace: nats-system`). The
+       bp-mgmt-vcluster syncer reflects the in-vCluster Service to the
+       HOST under the syncer-mangled name
+       `nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc`, so the
+       host `nats-system` namespace no longer carries a `nats-jetstream`
+       Service — the old default `nats-jetstream.nats-system.svc`
+       resolves NXDOMAIN and EVERY SME service (billing/tenant/
+       provisioning/domain/notification) CrashLoops on `nats connect:
+       no such host`, wedging the funnel (measured live hw130
+       2026-06-13: provisioning Init:0/1, billing/tenant/domain/
+       notification CrashLoopBackOff). The catalyst-api/continuum config
+       (values.yaml catalystApi.nats.url) was already updated to the
+       synced name in #2697; the SME default was missed in the move.
+       Align it here. Override via smeServices.eventBus.natsURL for a
+       host-placed NATS. */ -}}
+  {{- $defaultNATS = "nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222" -}}
 {{- end -}}
 {{- $brokers := default $defaultBrokers (index (default (dict) .Values.smeServices.eventBus) "brokers") -}}
 {{- $natsURL := default $defaultNATS (index (default (dict) .Values.smeServices.eventBus) "natsURL") -}}


### PR DESCRIPTION
## What this does

The funnel's SME-dependent steps (checkout, tenant creation, provisioning) need the SME microservices up. On hw130 (measured live 2026-06-13) `billing`/`tenant`/`provisioning`/`domain`/`notification` all **CrashLoop** on:

```
ERROR failed to connect to NATS url=nats://nats-jetstream.nats-system.svc.cluster.local:4222 error="nats connect: dial tcp: lookup nats-jetstream.nats-system.svc.cluster.local: no such host"
```

### Root cause
#3373/#2697 moved `bp-nats-jetstream` **inside the mgmt vCluster** (`placement.yaml`: `bp-nats-jetstream → vcluster: mgmt, namespace: nats-system`). The `bp-mgmt-vcluster` syncer reflects the in-vCluster Service to the **host** under the mangled name `nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local`, so the host `nats-system` namespace no longer carries a `nats-jetstream` Service.

The catalyst-api/continuum config (`catalystApi.nats.url` in `values.yaml`) was already updated to the synced name in #2697 — but the **SME services' `NATS_URL` default** (`templates/sme-services/configmap.yaml`) was missed and still pointed at the dead host name, so it resolves NXDOMAIN and CrashLoops.

### Fix
Align the SME Sovereign default to the same vcluster-synced service name the catalyst-api config already uses. Overridable via `smeServices.eventBus.natsURL` for a host-placed NATS. Catalyst-Zero (contabo, no `sovereignFQDN`) render is **byte-unchanged** (`NATS_URL: ""`).

This un-wedges the SME chain so the funnel's checkout/tenant/provisioning steps run on a fresh prov — the remaining item gating the #3376 live-walk after #3404 built the tofu-archive seal wire.

## Chart
`bp-catalyst-platform` 1.4.604 → 1.4.605 (+ kit pin).

## Verification
- Render with `--set global.sovereignFQDN=...` then `NATS_URL` resolves to the vcluster-synced service name.
- Render without it (Catalyst-Zero) then `NATS_URL: ""` (byte-unchanged).
- Live walk on a fresh prov: SME pods Ready, funnel checkout/tenant/provisioning complete.

Refs #3376 #3373