### PR TITLE
fix(powerdns): revert #3405 proxy-docker image reroute — restored docker.io + powerdns ns exclude

### DIFF
--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -140,7 +140,13 @@ spec:
       # 1.2.13 (#3380-D): REST-API Ingress gated off on the Gateway path so
       # no orphaned powerdns-api-tls Certificate (Ready=False) is spawned;
       # dnsdist + pdns-auth images routed through Harbor proxy-docker.
-      version: 1.2.13
+      # 1.2.14 (2026-06-13): REVERT the #3380-D image reroute — dnsdist +
+      # pdns-auth go BACK to raw docker.io. proxy-docker is not
+      # bootstrap-pullable on a fresh prov, so #3380-D wedged hw131 + hw132
+      # (powerdns pods never started → no DNS → no wildcard TLS → console
+      # down). The kyverno-Enforce concern is handled by excluding the
+      # `powerdns` ns from harbor-proxy-pull (bp-kyverno-policies 1.0.33).
+      version: 1.2.14
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -95,7 +95,13 @@ spec:
       # images still need the per-chart 11-harbor-proxy fix (a cluster-wide image-
       # rewrite mutate can't know the per-Sovereign Harbor host without re-tethering
       # to the mothership → Pillar 5 violation). See Chart.yaml for the full RCA.
-      version: 1.0.32
+      # 1.0.33 (2026-06-13): EXCLUDE the `powerdns` namespace from the
+      # harbor-proxy-pull (11) Enforce policy (new per-policy
+      # harborProxyPull.extraExcludeNamespaces). bp-powerdns 1.2.14 reverted its
+      # pdns-auth-50 + dnsdist-19 images to raw docker.io because proxy-docker is
+      # not bootstrap-pullable on a fresh prov (#3380-D's reroute wedged hw131 +
+      # hw132). powerdns stays subject to every OTHER policy (scoped carve-out).
+      version: 1.0.33
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.32
+  version: 1.0.33
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -1,5 +1,21 @@
 apiVersion: v2
 name: bp-kyverno-policies
+# 1.0.33 (2026-06-13): EXCLUDE the `powerdns` namespace from the
+# harbor-proxy-pull (11) Enforce policy via a new per-policy
+# `harborProxyPull.extraExcludeNamespaces` carve-out (same shape as the
+# `flux-managed` extraExcludeNamespaces). bp-powerdns reverted its
+# pdns-auth-50 + dnsdist-19 images back to raw `docker.io/powerdns/...`
+# (bp-powerdns 1.2.14) because the `proxy-docker` Harbor project is NOT
+# bootstrap-pullable on a fresh prov — #3380-D's proxy-docker reroute
+# wedged EVERY fresh prov (hw131 + hw132: powerdns pods never started → no
+# DNS → no wildcard TLS → console down). powerdns is a trusted first-party
+# bootstrap component, so the docker.io images are exempt from the
+# image-source glob; powerdns stays subject to every OTHER policy (scoped
+# to THIS policy, NOT the shared complianceDefaultExcludes anchor). The
+# carve-out is applied to all three harbor-proxy rules (pod / workload /
+# cronjob). Re-doing #3380-D's proxy hardening correctly (proxy-docker
+# made bootstrap-pullable, cred-free like proxy-ghcr) is a separate
+# follow-up; once that lands the exclude can be dropped.
 # 1.0.31 (Refs #3268 #3263, 2026-06-11): SYSTEMIC inoculation — NEW MUTATE policy
 # `stamp-cilium-enforced-label` (templates/mutate/00-...) auto-stamps
 # `policy.cilium.io/enforced: "true"` on the Pod template of every always-on
@@ -154,7 +170,7 @@ type: application
 # while keeping proxy-cache for anonymous public registries.
 # Lockstep with bp-self-sovereign-cutover 0.1.43 (Step 03 Phase A
 # skopeo native-push + Step 07 REGISTRY drops /proxy-ghcr/ suffix).
-version: 1.0.32
+version: 1.0.33
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/templates/baseline/11-harbor-proxy.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/11-harbor-proxy.yaml
@@ -68,6 +68,7 @@ spec:
     {{- $excludeNs := .Values.compliancePolicies.harborProxyPull.excludeNamespaces }}
     {{- $pats := .Values.compliancePolicies.harborProxyPull.allowedImagePatterns }}
     {{- $msg := "Container image does not match any allowed Harbor-source glob (proxy-cache `*/proxy-*/*` or native-push `*/openova-io/*`). Re-tag the image to pull through the Sovereign's local Harbor (e.g. registry.<sov-fqdn>/proxy-ghcr/... or registry.<sov-fqdn>/openova-io/openova/<svc>:<tag>)." }}
+    {{- $extraExcludeNs := .Values.compliancePolicies.harborProxyPull.extraExcludeNamespaces }}
     - name: image-from-harbor-proxy-pod
       match:
         any:
@@ -79,6 +80,18 @@ spec:
           - resources:
               namespaces:
                 {{- range $ns := $excludeNs }}
+                - {{ $ns }}
+                {{- end }}
+                {{- /*
+                  2026-06-13: per-policy extra excludes (NOT the shared anchor).
+                  bp-powerdns pulls pdns-auth-50 + dnsdist-19 from raw docker.io
+                  because the proxy-docker Harbor project is not bootstrap-pullable
+                  on a fresh prov (#3380-D's reroute wedged hw131 + hw132).
+                  powerdns is a trusted first-party bootstrap component; exempt it
+                  from the image-source glob HERE only — it stays subject to every
+                  other policy. Same shape as flux-managed.extraExcludeNamespaces.
+                */}}
+                {{- range $ns := $extraExcludeNs }}
                 - {{ $ns }}
                 {{- end }}
       validate:
@@ -110,6 +123,10 @@ spec:
                 {{- range $ns := $excludeNs }}
                 - {{ $ns }}
                 {{- end }}
+                {{- /* 2026-06-13: see image-from-harbor-proxy-pod rule above — powerdns docker.io carve-out. */}}
+                {{- range $ns := $extraExcludeNs }}
+                - {{ $ns }}
+                {{- end }}
       validate:
         message: {{ $msg | quote }}
         anyPattern:
@@ -133,6 +150,10 @@ spec:
           - resources:
               namespaces:
                 {{- range $ns := $excludeNs }}
+                - {{ $ns }}
+                {{- end }}
+                {{- /* 2026-06-13: see image-from-harbor-proxy-pod rule above — powerdns docker.io carve-out. */}}
+                {{- range $ns := $extraExcludeNs }}
                 - {{ $ns }}
                 {{- end }}
       validate:

--- a/platform/kyverno-policies/chart/values.yaml
+++ b/platform/kyverno-policies/chart/values.yaml
@@ -226,6 +226,24 @@ compliancePolicies:
     allowedImagePatterns:
       - "*/proxy-*/*"           # proxy-cache mode (cilium, cert-manager, postgres, etc.)
       - "*/openova-io/*"        # native-push mode (catalyst-api + all openova-io services post-cutover)
+    # 2026-06-13: EXCLUDE the `powerdns` namespace from harbor-proxy-pull.
+    # bp-powerdns's pdns-auth-50 + dnsdist-19 images pull from raw
+    # `docker.io/powerdns/...` (see platform/powerdns/chart/values.yaml).
+    # They CANNOT route through `harbor.openova.io/proxy-docker/...` because
+    # that Harbor project is not reliably pullable by a fresh-prov node at
+    # bootstrap — #3380-D's proxy-docker reroute wedged every fresh prov
+    # (hw131 + hw132: powerdns pods never started → no DNS → no wildcard TLS
+    # → console down). powerdns is a trusted first-party bootstrap component,
+    # so exempt it from the image-source glob here (matches hw130's effective
+    # state, where docker.io powerdns ran under kyverno without denial). This
+    # is scoped to THIS policy only (per-policy extraExcludeNamespaces, NOT
+    # the shared complianceDefaultExcludes anchor) — powerdns stays subject
+    # to every OTHER policy (probes / requests / image-tag-pinned / etc.).
+    # Same shape as the `flux-managed` extraExcludeNamespaces carve-out.
+    # Follow-up: making proxy-docker bootstrap-pullable (cred-free like
+    # proxy-ghcr) would let us drop this exclude and re-do #3380-D correctly.
+    extraExcludeNamespaces:
+      - powerdns
 
   imageTagPinned:
     enabled: true

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.13
+  version: 1.2.14
   card:
     title: PowerDNS
     summary: |

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -24,7 +24,19 @@ name: bp-powerdns
 # cache (were raw docker.io — Enforce-DENIED by harbor-proxy-pull on the
 # next roll, the `powerdns` ns is not excluded). Verified live hw130.
 # Contabo (gateway OFF, real Traefik) unaffected.
-version: 1.2.13
+# 1.2.14 (2026-06-13): REVERT the #3380-D part-(2) image reroute — the
+# dnsdist + pdns-auth images go BACK to raw `docker.io/powerdns/...`. The
+# `proxy-docker` Harbor project is NOT bootstrap-pullable on a fresh prov
+# (unlike cred-free `proxy-ghcr`), so #3380-D wedged EVERY fresh prov
+# (hw131 + hw132: powerdns pods never started → REST API never up →
+# zone-bootstrap Job DeadlineExceeded → bp-powerdns never Ready →
+# cert-manager DNS01 can't issue the wildcard → no TLS → console down).
+# docker.io is hw130's proven-working source. The kyverno-Enforce concern
+# is now handled correctly by EXCLUDING the `powerdns` namespace from the
+# harbor-proxy-pull policy (bp-kyverno-policies 1.0.33,
+# harborProxyPull.extraExcludeNamespaces), NOT by rerouting the image.
+# The #3380-D part-(1) REST-API-Ingress gating is UNCHANGED.
+version: 1.2.14
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/values.yaml
+++ b/platform/powerdns/chart/values.yaml
@@ -76,19 +76,29 @@ powerdns:
   replicaCount: 3
 
   image:
-    # #3380-D (2026-06-13): route the PowerDNS Authoritative image through
-    # the Harbor `proxy-docker` cache instead of raw `docker.io`. The
-    # subchart default `docker.io/powerdns/pdns-auth-50` matches NEITHER
-    # harbor-proxy-pull glob (`*/proxy-*/*`, `*/openova-io/*`) — confirmed
-    # LIVE on hw130 (`powerdns-*` pods running `docker.io/powerdns/
-    # pdns-auth-50:5.0.3`, and the `powerdns` namespace is NOT in the
-    # policy excludeNamespaces list) — so the NEXT image roll would be
-    # Enforce-DENIED. `proxy-docker` proxies `registry-1.docker.io`, so
-    # `harbor.openova.io/proxy-docker/powerdns/pdns-auth-50` resolves the
-    # identical upstream digest. `harbor.openova.io` is the bootstrap
-    # default re-pointed by slot 11 / cutover Step-04 (same pattern as the
-    # CNPG/dnsdist images already proxied).
-    repository: harbor.openova.io/proxy-docker/powerdns/pdns-auth-50
+    # 2026-06-13: REVERTED #3380-D's `harbor.openova.io/proxy-docker/...`
+    # reroute back to raw `docker.io/powerdns/pdns-auth-50`. WHY: the
+    # `proxy-docker` Harbor project is NOT reliably pullable by a fresh-prov
+    # node at bootstrap (unlike `proxy-ghcr`, which serves PUBLIC images
+    # cred-free — see the postgres `imageName` below). #3380-D's reroute
+    # broke EVERY fresh prov (hw131 + hw132 both wedged here): the PowerDNS
+    # pods never started → the REST API never came up → the
+    # `powerdns-zone-bootstrap` hook Job hit DeadlineExceeded → bp-powerdns
+    # never went Ready → cert-manager DNS01 could not issue the wildcard →
+    # no TLS → console + everything stayed down. `docker.io` is hw130's
+    # proven-working source (provisioned BEFORE #3380-D — its `powerdns-*`
+    # pods ran `docker.io/powerdns/pdns-auth-50:5.0.3` healthy). The
+    # kyverno-Enforce `harbor-proxy-pull` concern that motivated #3380-D is
+    # now handled the RIGHT way — by EXCLUDING the `powerdns` namespace from
+    # that policy (platform/kyverno-policies/chart/values.yaml
+    # harborProxyPull.extraExcludeNamespaces) — NOT by rerouting the image
+    # (which is what broke bootstrap). powerdns is a trusted first-party
+    # bootstrap component; the namespace exclude matches hw130's effective
+    # state (it ran docker.io under kyverno without denial because the
+    # policy was still in Audit mode pre-handover there). Re-doing #3380-D's
+    # proxy hardening CORRECTLY (making proxy-docker bootstrap-pullable,
+    # cred-free like proxy-ghcr) is a separate follow-up.
+    repository: docker.io/powerdns/pdns-auth-50
     # tag: null → upstream chart falls back to .Chart.AppVersion (5.0.3).
     # Per INVIOLABLE-PRINCIPLES #4 we don't pin a literal tag here — the
     # chart's appVersion is the single source of truth and bumping the
@@ -328,13 +338,14 @@ dnsdist:
     # line (matches Authoritative 5.0.x release cadence). Pin a concrete
     # tag here — the dnsdist Deployment template defaults to the value
     # below when image.tag is unset.
-    # #3380-D (2026-06-13): routed through the Harbor `proxy-docker` cache
-    # (was raw `docker.io/powerdns/dnsdist-19`). The raw docker.io ref
-    # matches no harbor-proxy-pull glob and would be Enforce-DENIED on the
-    # next image roll — confirmed LIVE on hw130 (`dnsdist-*` pod running
-    # `docker.io/powerdns/dnsdist-19:1.9.14`, `powerdns` ns not excluded).
-    # proxy-docker proxies registry-1.docker.io → identical digest.
-    repository: harbor.openova.io/proxy-docker/powerdns/dnsdist-19
+    # 2026-06-13: REVERTED #3380-D's `proxy-docker` reroute back to raw
+    # `docker.io/powerdns/dnsdist-19` — same root cause + fix as the
+    # pdns-auth-50 image above. `proxy-docker` is not bootstrap-pullable on
+    # a fresh prov, so the reroute wedged hw131 + hw132; docker.io is
+    # hw130's proven-working source. The kyverno-Enforce concern is handled
+    # by excluding the `powerdns` namespace from the harbor-proxy-pull
+    # policy (NOT by rerouting the image).
+    repository: docker.io/powerdns/dnsdist-19
     tag: "1.9.14"
     pullPolicy: IfNotPresent
   replicaCount: 1                   # scale alongside Sovereign expansion; single instance fronts one region

--- a/scripts/check-kyverno-proxy-images.sh
+++ b/scripts/check-kyverno-proxy-images.sh
@@ -88,11 +88,21 @@ ALLOWLIST_REGEX='(\{\{)|(\$\{)|(alpine/k8s)|(alpine/git)|(curlimages/curl)|(libr
 #   Format: "<chart-path>|<helm --set args>". These are the registry-sensitive
 #   subchart-wrapping bootstrap charts most prone to an upstream-registry leak.
 #   Extend this list when a new subchart-wrapping bp-* lands.
+#   bp-powerdns is INTENTIONALLY NOT in this list as of 2026-06-13: its
+#   pdns-auth-50 + dnsdist-19 images pull from raw `docker.io/powerdns/...`
+#   because the Harbor `proxy-docker` project is not bootstrap-pullable on a
+#   fresh prov (#3380-D's proxy-docker reroute wedged hw131 + hw132 — powerdns
+#   pods never started → no DNS → no wildcard TLS → console down). The
+#   harbor-proxy-pull policy EXCLUDES the `powerdns` namespace
+#   (platform/kyverno-policies/chart/values.yaml
+#   harborProxyPull.extraExcludeNamespaces: [powerdns]), so those docker.io
+#   images are NOT Enforce-denied at admission — there is nothing for this
+#   render-time guard to assert. Re-add powerdns here only if proxy-docker is
+#   made bootstrap-pullable and the namespace exclude is dropped.
 CHARTS=(
   "platform/bp-mgmt-vcluster/chart|--set mgmtVcluster.enabled=true"
   "platform/bp-dmz-vcluster/chart|--set dmzVcluster.enabled=true"
   "platform/bp-rtz-vcluster/chart|--set rtzVcluster.enabled=true"
-  "platform/powerdns/chart|--set api.enabled=true --set api.gateway.enabled=true"
 )
 
 matches_any_glob() {


### PR DESCRIPTION
## The regression

PR #3405 (commit `35025a7af`, "#3380-D") rerouted the PowerDNS `pdns-auth-50` + `dnsdist-19` images from raw `docker.io/powerdns/...` to `harbor.openova.io/proxy-docker/powerdns/...` to satisfy the kyverno `harbor-proxy-pull` Enforce policy.

But the `proxy-docker` Harbor project is **not reliably pullable by a fresh-prov node at bootstrap** (unlike `proxy-ghcr`, which the chart notes serves PUBLIC images cred-free). So:

- PowerDNS pods never start →
- the PowerDNS REST API never comes up →
- the `powerdns-zone-bootstrap` hook Job hits `DeadlineExceeded` →
- bp-powerdns never goes Ready →
- cert-manager DNS01 can't issue the wildcard →
- no TLS → console + everything stays down.

**Proven reproducible**: two fresh 2-region provs (hw131, hw132) both wedged here. hw130 (provisioned BEFORE #3405, docker.io images) had PowerDNS UP. Restoring the docker.io images = restoring hw130's known-working bootstrap.

## The fix

1. **`platform/powerdns/chart/values.yaml`** — revert both image repos back to `docker.io/powerdns/pdns-auth-50` + `docker.io/powerdns/dnsdist-19` (hw130's proven-working source).
2. **`platform/kyverno-policies/chart`** — handle the kyverno-Enforce concern the right way: exclude the `powerdns` namespace from the `harbor-proxy-pull` policy via a new per-policy `harborProxyPull.extraExcludeNamespaces` carve-out (same shape as the existing `flux-managed` carve-out). Applied to all three harbor-proxy rules (pod / workload / cronjob). powerdns is a trusted first-party bootstrap component; this matches hw130's effective state where powerdns ran docker.io under kyverno without denial. powerdns stays subject to every other policy.
3. **Lockstep version bumps** — bp-powerdns `1.2.13 → 1.2.14`, bp-kyverno-policies `1.0.32 → 1.0.33` (Chart.yaml + blueprint.yaml + bootstrap-kit slot pins 11 + 27a).
4. **`scripts/check-kyverno-proxy-images.sh`** — drop powerdns from the render-checked chart list (it is now namespace-excluded, so there is nothing for the render-time guard to assert).

The #3380-D part-(1) REST-API-Ingress gating is **unchanged** — only the image reroute is reverted.

## Gates run locally (all green)

- `check-bootstrap-kit-pin-sync.sh --changed-only` → PASS (1.2.14 / 1.0.33 in lockstep)
- `check-kyverno-proxy-images.sh` → PASS
- `check-bootstrap-deps.sh` → PASS (0 drift, 0 cycles)
- `helm lint` both charts → PASS
- `helm template` both charts → valid YAML; powerdns renders `docker.io/powerdns/pdns-auth-50:5.0.3` + `docker.io/powerdns/dnsdist-19:1.9.14`; harbor-proxy policy excludes `powerdns` in all 3 rules

## Follow-up (separate, NOT in this PR)

Re-doing #3405's `proxy-docker` hardening **correctly** — i.e. making `proxy-docker` bootstrap-pullable, cred-free the same way `proxy-ghcr` is — is a separate follow-up. Once that lands, the namespace exclude can be dropped and the images can route through the proxy again. This PR deliberately does not attempt that; it restores fresh-prov convergence first.

Refs #3380
Refs #3408

🤖 Generated with [Claude Code](https://claude.com/claude-code)