### PR TITLE
docs(uat): #3376 funnel walked to signed-in tenant form (billing/balance 502 is the gap)

### DIFF
--- a/docs/ledger/UAT.md
+++ b/docs/ledger/UAT.md
@@ -46,7 +46,7 @@ postMessage) and pdns-admin (500) remain broken — these are the two hard apps 
 
 | Item | State on hw133 | Pending |
 |---|---|---|
-| #3376 FUNNEL (voucher→tenant→signed-in) | **front-half walked** — storefront "Build your cloud tenant" → 6-step wizard → [Plans](../sessions/2026-06-13/evidence/hw133-walk/hw133-09-funnel-plans.png) → [Checkout sign-in prompt](../sessions/2026-06-13/evidence/hw133-walk/hw133-10-funnel-checkout-signin.png) all render | back-half: email magic-code → voucher → tenant provision → land-signed-in (NOT yet walked) |
+| #3376 FUNNEL (voucher→tenant→signed-in) | **walked to the signed-in tenant-creation form** — storefront → wizard → [Plans](../sessions/2026-06-13/evidence/hw133-walk/hw133-09-funnel-plans.png) → [checkout sign-in](../sessions/2026-06-13/evidence/hw133-walk/hw133-10-funnel-checkout-signin.png) → **magic-code emailed + verified → signed-in as the customer** → tenant name + `.omani.rest` subdomain form + order summary [signed-in checkout](../sessions/2026-06-13/evidence/hw133-walk/hw133-11-funnel-signed-in-voucher-502.png). `api/auth/magic-link`+`verify`+`me`+`catalog` all 200. | ❌ **`GET /api/billing/balance` → 502 Bad Gateway** blocks the voucher-credit load + Purchase → the "stranger *with a voucher*" can't complete to a provisioned tenant. Billing-service bug (sme ns). |
 | #3375 region-kill DR | cnpg-pair primary present, #3307 peering at boot | continuum-driven kill + promote walk |
 | #3379 cutover | dormant at slot-06a | post-handover 8-tether pivot + 10-min egress hold |
 | #3373 vCluster re-home | mgmt/dmz/rtz vclusters live | founder decision: OSS Pro-gating (license / host-bridge / host-side) |


### PR DESCRIPTION
Corrects the funnel row to the actual deeper walk: magic-code emailed + verified → signed-in as the customer → tenant-creation form; only `GET /api/billing/balance` 502s (billing service, sme ns), blocking the voucher + Purchase. Refs #3376