### PR TITLE
docs(uat): UAT walk-through rewritten as 100% web-UI end-user acceptance

### DIFF
--- a/docs/ledger/UAT-WALKTHROUGH.md
+++ b/docs/ledger/UAT-WALKTHROUGH.md
@@ -1,14 +1,12 @@
 # UAT WALK-THROUGH — the agreement document (2026-06-14)
 
-**Purpose.** This is the click-by-click verification protocol for every founder-approved ticket. It is authored from the **real merged code** (every row cites `file:line`), NOT from claims. Once the founder **agrees on this document**, the walk-execution agents run each section on the live env and flip each `☐` to ✅ (witnessed) or ❌ (failed) with evidence. **No row may be marked done without the cited observation.**
+**Purpose.** This is the **end-user web-UI acceptance test** for every founder-approved ticket. **100% browser — no terminal, no kubectl, no git, no curl.** The end user never touches a shell; every step is **open a URL → click/type → see a screen**. Once the founder **agrees on this document**, the walk-execution agents run each section in a real browser and flip each `☐` to ✅ (witnessed on screen) or ❌ (failed on screen) with a screenshot.
 
-**How to read a row.** `| # | Go to (URL/route) | Do (exact click/type) | Expect (exact screen/text/state) | Source (file:line) | ☐ |`
-- **Source** cites the real code that makes the row true.
-- **`NO UI FOUND — gap`** = the DoD criterion has no operator-visible surface in the code today; it is a genuine gap, walked at the kubectl/Git layer and flagged for the founder.
-- **`AUTOMATED, NOT ACCEPTANCE`** = a CI/unit gate, demoted per the founder's rule ("this is only a unit test!!!"). Acceptance is the founder/agent walking the clickable + kubectl steps.
-- A **302-to-realm is never a pass** for SSO — only a rendered, logged-in screen counts.
+**How to read a step.** Each line is one browser action: `☐ open <URL> → click/type <X> → you should see <Y>`. The lines **wrap** (no tables) so the whole walk reads top-to-bottom with no horizontal scrolling.
+- **`GAP`** = the feature has **no web-UI surface** — so a user cannot accept it. That is itself a finding (a feature with no UI is not user-acceptance-testable); it is **not** a reason to drop to a terminal check.
+- A **redirect that ends on a login screen is a fail** for SSO — only a rendered, signed-in screen counts.
 
-**Acceptance bar.** Every walk runs on a **fresh, zero-touch, converged** Sovereign (no hand-patching). Evidence (screenshot + wire-capture + kubectl) lands under `docs/sessions/<date>/evidence/` and is linked from `docs/ledger/UAT.md`. PR-merge ≠ done; only a witnessed walk is done.
+**Acceptance bar.** Every walk runs in a browser against a **fresh, zero-touch, converged** Sovereign (no hand-patching). Evidence = **screenshots** under `docs/sessions/<date>/evidence/`, linked from `docs/ledger/UAT.md`. PR-merge ≠ done; only a witnessed on-screen walk is done.
 
 ---
 

--- a/docs/ledger/uat-walkthrough/3370-contexts.md
+++ b/docs/ledger/uat-walkthrough/3370-contexts.md
@@ -1,46 +1,40 @@
-## #3370 CONTEXTS
+# #3370 CONTEXTS — user acceptance walk (100% web UI)
 
-**What #3370 delivers:** ONE generic platform-wide mechanism for multi-application reusability. Every Blueprint declares `shareable: true|false` + a `contextSchema` (`platform/postgres/blueprint.yaml:38-53`, `platform/valkey/blueprint.yaml:30-45`); each shareable instance exposes its **Contexts** — the child entity a consumer occupies (postgres: a `db`; valkey: a `keyspace`). The catalog card renders a shareable badge, the `/apps` tile shows `⛓ N contexts`, the instance page gains a **Contexts** tab, consumers show `Depends on: <instance> / <kind>:<ctx>`. Three shared-postgres instances self-register a bootstrap-owned `Application` CR the controller ADOPTS status-only (zero duplicate HRs). **The walk targets the operator console at `products/catalyst/bootstrap/ui/` (React/TanStack Router), NOT the SME tenant console at `core/console/`.**
+**Sign in:** open `https://console.<sovereign>/` → you land on the **Dashboard** signed-in (no login form).
+_Each line = one browser step. `☐`/`✅`/`❌`. No terminal — everything is click/type/see._
 
-| # | Go to (URL/route) | Do (click/type — EXACT label) | Expect (EXACT screen/text/count) | Source (file:line) | ☐ |
-|---|---|---|---|---|---|
-| **DoD #1 — shareable badge on catalog cards** | | | | | |
-| 1 | `/apps` | Click the **Catalog** tab (testid `sov-tab-catalog`) | Card grid, one card per Blueprint CLASS | `AppsPage.tsx:612-621` | ☐ |
-| 2 | `/apps` Catalog | Locate **PostgreSQL** card | Card carries `⛓ shareable` chip (`sov-catalog-shareable-bp-postgres`) | `AppsPage.tsx:940-948,859` | ☐ |
-| 3 | `/apps` Catalog | Locate **Keycloak/Gitea** card | NO `⛓ shareable` chip | `AppsPage.tsx:859,940` | ☐ |
-| 4 | `/catalog/bp-postgres` | Observe hero meta-chips | Green chip `⛓ shareable · db` (`badge-shareable`) | `CatalogDetail.tsx:229-237,155-159` | ☐ |
-| 6 | terminal | `kubectl get blueprint bp-postgres -o jsonpath='{.spec.shareable}{" "}{.spec.contextSchema.kind}'` | `true db` | `platform/postgres/blueprint.yaml:38,40-46` | ☐ |
-| **DoD #2 — one Application CR per instance; zero duplicate installs (adoption)** | | | | | |
-| 7 | terminal | `kubectl get applications.apps.openova.io -A` | ≥3 rows: `shared-pg{,-b,-c}` in `shared-data` (was 0 pre-#3370) | `platform/postgres/chart/templates/application-cr.yaml:46-99` | ☐ |
-| 8 | terminal | `kubectl get application shared-pg -n shared-data -o jsonpath='{.spec.bootstrap}{" "}{.metadata.labels.apps\.openova\.io/bootstrap-owned}'` | `true true` | `application-cr.yaml:54,57` | ☐ |
-| 10 | terminal BEFORE→AFTER | Count `kubectl get hr -A`, reconcile the 3 bootstrap CRs, re-count | HR count UNCHANGED — adoption renders NO new HR | adoption guard `application_controller.go:611-613,1922-1925,1933-2011` | ☐ |
-| 11 | terminal | `kubectl get application shared-pg -n shared-data -o jsonpath='{.status.phase}{" "}{.status.conditions[?(@.reason=="BootstrapAdopted")].reason}'` | `Ready BootstrapAdopted` | `application_controller.go:1970-1994,189` | ☐ |
-| **DoD #3 — /apps shows 3 postgres instance cards with ⛓ N contexts** | | | | | |
-| 13 | `/apps` Deployments | Locate **shared-pg** card | Topology chip + `⛓ 3 contexts` badge (`sov-app-contexts-shared-pg`) | `AppsPage.tsx:679-716,913-939` | ☐ |
-| 14 | `/apps` Deployments | Locate **shared-pg-b**, **shared-pg-c** | Each with topology chip + `⛓ 3 contexts` | `AppsPage.tsx:679-716` | ☐ |
-| 15 | `/apps` Deployments | Confirm no blueprint-level `bp-postgres` card | N instances ⇒ exactly N cards | `AppsPage.tsx:718-726` | ☐ |
-| 16 | backend | `curl .../api/v1/sovereign/apps \| jq '.apps[] \| select(.instance==true)'` | 3 objects, each `contextCount: 3` | `sovereign.go:585,742-788,755-759` | ☐ |
-| **DoD #4 — /catalog/bp-postgres: topologies + New instance + 3 instance lines; panel GONE** | | | | | |
-| 18 | `/catalog/bp-postgres` | **Supported topologies** | `singleton` + `active-hot-standby`; singleton `default` chip | `CatalogDetail.tsx:370-404`; `blueprint.yaml:162-168` | ☐ |
-| 19 | `/catalog/bp-postgres` | **Instances** header | `+ New instance` button (`btn-new-instance`) | `InstancesSection.tsx:84-104` | ☐ |
-| 20 | `/catalog/bp-postgres` | Instances table (`sov-instances-table`) | EXACTLY 3 rows: shared-pg{,-b,-c} | `InstancesSection.tsx:154-235`; `endpoint_handler.go:1094-1161` | ☐ |
-| 22 | `/catalog/bp-postgres` | Confirm NO "Data instances" panel | **GAP — DataInstances.svelte NOT deleted; only the SME console (`core/console`) carries it (`AppsPage.svelte:9,443-445`). Row FAILS strict DoD §2.8.** | operator console renders none | ☐ |
-| **DoD #5 — /app/shared-pg Contexts tab + consumer Depends-on** | | | | | |
-| 24 | `/app/shared-pg` | Observe tab strip | **Contexts** tab, count `3` (gated on shareable) | `AppDetail.tsx:650-658,222-231` | ☐ |
-| 25 | `/app/shared-pg` | Click **Contexts** | Table `sov-contexts-table`: Context \| Occupied by \| Credential \| Status | `AppDetail.tsx:709-712`; `ContextsTab.tsx:42-55` | ☐ |
-| 26 | `/app/shared-pg` Contexts | Read rows | `db/gitea·gitea→·gitea-database-secret·ready`; `db/registry·harbor→`; `db/keycloak·keycloak→` | `ContextsTab.tsx:57-104`; `16a-bp-postgres-shared.yaml:173-204` | ☐ |
-| 29 | `/app/bp-gitea` Dependencies tab | Read line | `Depends on: shared-pg / db:gitea` (`sov-app-dependson-shared-pg`) | `AppDetail.tsx:783-799`; `applications.go:1280-1293` | ☐ |
-| **DoD #6 — provisioning walk: DEFAULT auto-creates backing; ADVANCED reuse ⇒ new Context** | | | | | |
-| 35 | New-instance dialog (DEFAULT) | Leave **Create new (default)**; **Create instance** | POST `backing:[{mode:'create'}]`; new consumer + new backing card both appear | `InstancesSection.tsx:482-511`; `endpoint_handler.go:976-1020` | ☐ |
-| 38-39 | New-instance dialog (REUSE) | **Reuse existing** → pick a console-created pg → Create | Only ONE new card; a new Context row appears on the reused instance | `endpoint_handler.go:1022-1066`; `ContextsTab.tsx:57-104` | ☐ |
-| 41 | safety | Attempt reuse of a **bootstrap-owned** instance via API | Rejected `backing-bootstrap-owned`. **GAP — reuse of shared-pg/-b/-c blocked in-console; demo must use a console-created instance.** | `endpoint_handler.go:1031-1037` | ☐ |
-| **DoD #7 — generality: SAME mechanism on valkey (non-DB)** | | | | | |
-| 42-44 | terminal + `/catalog/bp-valkey` | `kubectl get blueprint bp-valkey ...`; open Contexts on a valkey instance | `true keyspace`; SAME table, rows `keyspace/<name>` | `valkey/blueprint.yaml:30,33`; `ContextsTab.tsx:64-66` | ☐ |
-| 46 | git diff review | ContextsTab / AppCard / NewInstanceDialog | NO `if blueprint==='postgres'` branching — declaration-driven | `endpoint_handler.go:1269-1284` (generic) | ☐ |
-| **DoD #8 — ≥2 embedded DBs eliminated; remaining enumerated** | | | | | |
-| 47-49 | terminal | pda → shared-pg-b, sme → shared-pg-c dependsOn edges | Both present (2 eliminations meet the bar) | `11a-bp-powerdns-admin.yaml:84-85`; `13-bp-catalyst-platform.yaml:105` | ☐ |
-| 50-51 | terminal | Remaining embedded Clusters + shared-pg-c mapping | **GAP — pdns-pg (no gate), openova-flow-pg, newapi-pg remain; shared-pg-c declares only `sme_*`, NOT newapi/openova-flow.** | `powerdns/chart/templates/cnpg-cluster.yaml:33-37`; `16d-...-c.yaml:92-113` | ☐ |
-| **DoD #9 — evidence** | | | | | |
-| 52 | repo | Each box → screenshot under `docs/sessions/<date>/evidence/` + UAT.md row | All linked | DoD §10-11 | ☐ |
+### Shareable apps are marked in the catalog
+- [ ] Sidebar **Apps** → **Catalog** tab → the **PostgreSQL** card shows a **⛓ shareable** badge.
+- [ ] Same grid → the **Keycloak** (or **Gitea**) card has **no** shareable badge.
+- [ ] Click the **PostgreSQL** card → its detail page hero shows **⛓ shareable · db**.
 
-**Gaps:** (1) DataInstances.svelte+lib not deleted from SME console; (2) reuse of the 3 bootstrap instances blocked in-console; (3) shared-pg-c maps only sme, not newapi/openova-flow; (4) pdns-pg/openova-flow-pg/newapi-pg embedded DBs remain; (5) version skew bp-postgres 0.1.6 (UI seed) vs 0.1.8 (slot).
+### The three shared databases each render as one card with their Contexts
+- [ ] **Apps** → **Deployments** tab → you see three cards: **shared-pg**, **shared-pg-b**, **shared-pg-c**.
+- [ ] Each of those three cards shows a **⛓ 3 contexts** badge.
+- [ ] There is **no** separate generic "bp-postgres" card (three instances = three cards, nothing extra).
+
+### Opening a shared database shows who occupies it
+- [ ] Click the **shared-pg** card → click the **Contexts** tab.
+- [ ] The Contexts table shows three rows — **db/gitea**, **db/registry**, **db/keycloak** — each with a consuming app and a **ready** status.
+- [ ] Click the **gitea** consumer link in that table → it opens the **Gitea** app page.
+
+### The consumer shows what it depends on
+- [ ] Open the **Gitea** app page → **Dependencies** tab → a line reads **Depends on: shared-pg / db:gitea**.
+
+### Catalog detail: topologies, instances, and the old panel is gone
+- [ ] Open **Catalog → PostgreSQL** → a **Supported topologies** section lists **singleton** (marked *default*) + **active-hot-standby**.
+- [ ] Same page → an **Instances** section lists **exactly three** rows (shared-pg, -b, -c) with a **+ New instance** button.
+- [ ] ❌ **GAP** — the page should have **no** old "Data instances" panel. It is gone here, but the same panel was **never removed** from the separate tenant console (still visible there) — strictly, the deletion DoD is unmet.
+
+### Creating an app: default makes its own DB; reuse adds a Context
+- [ ] **Catalog → Harbor → + New instance** → in the dialog, the **Backing services** section shows a PostgreSQL selector with **Create new (default)** preselected.
+- [ ] Leave **Create new** → **Create instance** → on **Deployments** you now see **two** new cards: the Harbor instance **and** its own auto-created postgres card.
+- [ ] Open **+ New instance** again → choose **Reuse existing** → pick a postgres instance you created earlier → **Create instance** → only **one** new card appears (no second DB).
+- [ ] Open that reused postgres instance → **Contexts** tab → a **new row** has appeared for the app that just reused it.
+- [ ] ❌ **GAP** — try **Reuse existing** and pick **shared-pg/-b/-c** → it is rejected (the three bootstrap databases can't be reused from the UI); the reuse demo must use a self-created instance.
+
+### Generality: the same Contexts UI works for a non-database (valkey)
+- [ ] **Catalog → Valkey** → hero shows **⛓ shareable · keyspace** (not "db").
+- [ ] Open a Valkey instance → **Contexts** tab → the **same** table, with rows named **keyspace/…** instead of db.
+
+**Gaps surfaced:** old Data-instances panel not deleted from the tenant console; the 3 bootstrap DBs can't be reused from the UI; (and behind the scenes shared-pg-c only carries the `sme` apps, not newapi/openova-flow — not visible as a UI difference but noted for completeness).

--- a/docs/ledger/uat-walkthrough/3373-placement.md
+++ b/docs/ledger/uat-walkthrough/3373-placement.md
@@ -1,51 +1,26 @@
-## #3373 PLACEMENT
+# #3373 PLACEMENT — user acceptance walk (100% web UI)
 
-**Law:** placement is INSTANCE data (`Application.spec.placement`), set by DATA not a hand-coded slot; ONE render mechanism = the Flux `spec.kubeConfig.secretRef` pivot; host = absolute minimum; Git is the truth (a direct Git edit of `spec.placement` is as valid as a console write); the advanced selector is generic (rendered from the blueprint declaration). **Live re-home of a running stateful instance is excluded (ticket §8); the Git-field semantics are in scope (DoD-7).**
+**What the user should be able to do:** when provisioning or viewing an app, choose / see **which vCluster** it lives in — by data, in the UI, with the default needing no thought. **Sign in:** open `https://console.<sovereign>/`.
 
-### DoD-1 — Schema + CR field + controller honor placement
-| # | Action | Do | Expect | Source | ☐ |
-|---|---|---|---|---|---|
-| 1.1 | shell | inspect `spec.placement` in the CRD | dual-form field (string DR-posture OR `{vcluster,regions,clusters,mode}`); `x-kubernetes-preserve-unknown-fields` | `products/catalyst/chart/crds/application.yaml:121-159` | ☐ |
-| 1.3 | shell | inspect `status.placement` | object `vcluster` enum `[host,mgmt,dmz,rtz]` + `source` (`instance\|blueprint-default\|...`) | `application.yaml:426-451` | ☐ |
-| 1.4-1.5 | shell | controller resolution + validation | order instance>blueprint-default>legacy; vcluster ∉ allowedPlacements → `markFailed(ReasonInvalid,...)` | `application_controller.go:706-729` | ☐ |
-| 1.7 | shell | renderer pivot | stamps `spec.kubeConfig.secretRef {name,key:config}` (the ONE mechanism) | `fanout.go:269-293` | ☐ |
-| 1.8 | **AUTOMATED** | `go test ./controllers/application/... -run Placement -race` | green | `fanout_test.go` | ☐ |
+_Each line = one browser step. `☐`/`✅`/`❌`. No terminal._
 
-### DoD-2 — Provisioning advanced view: vCluster/regions/clusters selectors
-| # | Action | Do | Expect | Source | ☐ |
-|---|---|---|---|---|---|
-| 2.4 | console + marketplace | search for a generic placement selector bound to `allowedPlacements` | **NO UI FOUND — gap. Zero rows. The default-vs-advanced screenshots DoD-2 demands are unsatisfiable today.** | (none in `core/console/src`, `core/marketplace/src`) | ☐ |
-| 2.5 | API | `GET /catalog/{bp}` | carries `defaultPlacement`+`allowedPlacements[]` — the data a selector NEEDS exists server-side; only the UI is missing | `catalyst-catalog/internal/source/source.go:148-154,212-231` | ☐ |
+### Default provisioning hides the vCluster detail
+- [ ] Start provisioning an app (the install/new-instance flow). In the **default** path you are **not** asked about a vCluster — the app just installs. ✅ if the default flow never shows a placement choice.
 
-### DoD-3 — Live walk: spawn an instance with NON-default placement → lands in chosen vCluster
-| # | Action | Do | Expect | Source | ☐ |
-|---|---|---|---|---|---|
-| 3.1 | Git (no UI exists) | author an Application CR, set `spec.placement.vcluster` to a non-default allowed tier, commit | Flux reconciles, no admission reject | `platform/openbao/blueprint.yaml:21-23` | ☐ |
-| 3.3 | shell | `kubectl get hr <inst-hr> -n <hostNs> -o jsonpath='{.spec.kubeConfig.secretRef.name}'` | `vc-<tier>` | `fanout.go:269-293`; `placement.yaml:57-72` | ☐ |
-| 3.4 | shell | resources land INSIDE the vCluster inner namespace | Deploy/STS in vCluster, not host | `22-loki.yaml:80-130` | ☐ |
-| 3.5 | console app detail | look for "vCluster: <tier>" placement field | **NO UI FOUND — gap. AppDetail.svelte has no `status.placement` renderer (its "vCluster" copy is tenant boilerplate).** | `AppDetail.svelte:330,353` | ☐ |
+### Advanced provisioning lets the user choose the vCluster
+- [ ] In the install flow, open **Advanced** → look for a **vCluster / region / cluster** placement selector.
+- [ ] ❌ **GAP** — there is **no** placement selector anywhere in the web UI. The "Advanced" sections that exist are for **backing services** and **config fields**, not placement. The default-vs-advanced placement screenshots the DoD asks for **cannot be produced** — the feature has no UI.
 
-### DoD-4 — §4 table executed; conformance audit asserts actual==declared, zero undeclared host workloads
-| # | Action | Do | Expect | Source | ☐ |
-|---|---|---|---|---|---|
-| 4.1 | shell | `cat clusters/_template/bootstrap-kit/placement.yaml` | single source-of-truth table (vclusters map + slots with target+justification) | `placement.yaml:47-203` | ☐ |
-| 4.2 | **AUTOMATED** | `python3 scripts/audit-placement-conformance.py rendered` | exit 0 | `audit-placement-conformance.py:68-94` | ☐ |
-| 4.3 | shell | `...py live --kubeconfig <kc>` | per-HR ✓ + `zero undeclared host workloads` | `audit-placement-conformance.py:107-163` | ☐ |
-| 4.4 | shell | each §4 target row in its vCluster | each `vc-<target-tier>`. **GAP — several still `vcluster: host` (keycloak REVERTED post-outage); audit migration-gap list names them.** | `placement.yaml:153-203` | ☐ |
-| 4.6 | shell | `...py rendered --strict-target` | **FAILS by design until active==target for every slot.** | `audit-placement-conformance.py:91-93` | ☐ |
+### An app's page shows which vCluster it lives in
+- [ ] Open any app's detail page → look for a **vCluster: <mgmt/dmz/rtz/host>** field.
+- [ ] ❌ **GAP** — the app detail page does **not** display the instance's vCluster placement. (Its only "vCluster" text is generic tenant wording.) The user cannot see where an app is placed.
 
-### DoD-5 — 3 coupling fixes, proven on one re-homed app (gitea/harbor with working HTTPRoute + secrets)
-| # | Action | Do | Expect | Source | ☐ |
-|---|---|---|---|---|---|
-| 5.2 | shell | vCluster CRD-sync set | `sync.fromHost.customResourceDefinitions` registers httproutes + externalsecrets inside the vCluster | `bp-mgmt-vcluster/chart/values.yaml:299-313` | ☐ |
-| 5.5 | browser | open the re-homed app's public URL | serves via host Gateway → backendRef alias → in-vCluster pod | `bp-mgmt-vcluster/chart/values.yaml:299-307` | ☐ |
-| 5.6 | shell | **OSS Pro-gating limitation row** | OSS syncer only (no loft-sh Pro integrated networking); a route-serving failure here = the known Pro gap, recorded not regressed | `bp-mgmt-vcluster/chart/values.yaml:299-313` | ☐ |
+### Re-placing an app and seeing it reflected
+- [ ] (If a placement selector existed) change an app's vCluster in the UI → the app page should show the new vCluster.
+- [ ] ❌ **GAP** — not walkable: no selector to change it, no field to show it.
 
-### DoD-6/7 — zero hand-coded placement; Git-is-truth
-| # | Action | Do | Expect | Source | ☐ |
-|---|---|---|---|---|---|
-| 6.1 | shell | `python3 scripts/render-slot-placement.py check` | PASSED; a hand-edited placement field FAILS (placement is DATA) | `render-slot-placement.py:100-200,466-484` | ☐ |
-| 7.1-7.3 | Gitea repo | edit `spec.placement.vcluster` directly in Git, commit, `flux reconcile` | instance re-homes to the new tier, `source: instance`; works with Catalyst shut down | `application_controller.go:706-723`; `fanout.go:269-293` | ☐ |
-| 7.5 | console | console reflects the new placement | **NO UI FOUND — gap. Only the kubectl half of Git-is-truth is walkable.** | (none) | ☐ |
+### What the user CAN observe (the user-visible outcome of placement)
+- [ ] Open an app that is supposed to live inside a vCluster (e.g. a re-homed app) and **open its public URL in the browser** → the app **serves and renders** (proving it reaches the user through the gateway even though it runs inside a vCluster). ✅ if the page loads.
+- [ ] ❌ **LIMITATION** — on the open-source vCluster build, route-bearing apps may **not** serve from inside their vCluster (a licensing limitation). If the app's URL fails to load for that reason, record it as the known Pro-gating gap, not a regression.
 
-**Gaps:** (1) NO placement selector UI (DoD-2); (2) NO console placement display (DoD-3); (3) NO console-reflects-new-placement (DoD-7); (4) §4 not fully executed (keycloak host); (5) OSS Pro-gating limits route-bearing re-home.
+**Verdict:** #3373 is **largely not user-acceptance-testable today** — the model exists underneath, but there is **no placement UI** (no selector, no display), so a web-UI walk can only confirm that placed apps still *serve*, not that the user can *choose or see* placement. This is the honest gap.

--- a/docs/ledger/uat-walkthrough/3374-sso.md
+++ b/docs/ledger/uat-walkthrough/3374-sso.md
@@ -1,36 +1,55 @@
-## #3374 SSO
+# #3374 SSO — user acceptance walk (100% web UI)
 
-**Contract (founder law):** typing the **bare root URL** of any external app in a **fresh incognito browser** lands the user signed-in as owner (`emrah.baysal`, in `sovereign-admins`) with admin rights — zero clicks, no login/PIN/token form. **A 302-to-realm is NOT a pass** (openbao + guacamole passed the wire and failed the walk, #3150). Each app needs TWO shots: (1) signed-in landing, (2) admin panel. **Nothing is banked** — every row UNVERIFIED at acceptance, walked fresh in one session.
+**Contract:** in a **fresh incognito window**, type the bare URL of any app → you land **signed in** as the owner with **admin** rights. Zero clicks, no login / PIN / token form. A redirect that ends on a login screen is a **fail**. Two checks per app: (a) lands signed-in, (b) the admin area is reachable.
 
-### Tier 1 — Operator apps (sovereign realm)
-| # | Go to (bare URL) | Do | Expect (lands signed-in / which admin panel) | Source | ☐ |
-|---|---|---|---|---|---|
-| 1a/1b | `console.<FQDN>/` | nothing | dashboard signed-in as emrah; `whoami` role `sovereign-admin` tier `owner` | `SovereignConsoleLayout.tsx:129-198`; `auth_handover.go:273-313` | ☐ |
-| 2a | `grafana.<FQDN>/` | nothing | Grafana home signed-in, no login form (`auto_login`) | `grafana/chart/values.yaml:193,199` | ☐ |
-| 2b | `grafana.<FQDN>/admin/users` | nothing | **Server Admin** panel (GrafanaAdmin role) | `values.yaml:221,224` | ☐ |
-| 3a/3b | `gitea.<FQDN>/` ; `/-/admin` | nothing | Gitea dashboard signed-in; **Site Administration** panel | `gitea/chart/values.yaml:93,100,347`; `httproute.yaml:42-57` | ☐ |
-| 4a/4b | `registry.<FQDN>/` ; `/harbor/users` | nothing | Harbor projects signed-in; **Administration → Users** | `harbor sso-configure-oauth-job.yaml:219-231,227,156` | ☐ |
-| 5a/5b | `bao.<FQDN>/ui/` ; `/ui/vault/access` | nothing | **signed-in Vault UI, no token form**; Access/policies with full controls | `openbao httproute.yaml:60-74`; shim `openbao_sso_init.go:50-124`; `sso-configure-deployment.yaml:256,342`. **THIS SESSION (hw133): postMessage error on doubled `/oidc/oidc/callback` → bounced to auth form — BROKEN.** | ☐ |
-| 6a/6c | `pdns-admin.<FQDN>/` ; Administration menu | nothing | dashboard signed-in (no "Sign in with OIDC" click); Administrator menu | `pdns httproute.yaml:51-62`; `powerdns-admin/chart/values.yaml:192`. **THIS SESSION (hw133): `/oidc/login` HTTP 500 — BROKEN.** | ☐ |
-| 7a/7b | `guacamole.<FQDN>/` ; `/guacamole/#/settings/users` | nothing | connections home signed-in (not Tomcat 404); Settings→Users. **GAP — admin-elevation unimplemented (openid extension only, NO JDBC permission store; Chart comment 103-104).** | `guacamole-httproute.yaml:30-39`; `_helpers.tpl:148-154` | ☐ |
-| 8a/8b | `newapi.<FQDN>/` | nothing | admin UI signed-in via native OIDC. **GAP — no explicit `sovereign-admins`→admin mapping in chart values (only client registration).** | `newapi configmap.yaml:16-27`; `80-newapi.yaml:282-293` | ☐ |
-| 9a/9b | `openova-flow.<FQDN>/` | nothing | bp-oidc-gate oauth2-proxy → UI signed-in, no login button. No native role model (admin = authenticated sovereign-admins member) | `13c-bp-oidc-gate.yaml:88-103` | ☐ |
-| 10a/10b | `hubble.<FQDN>/` | nothing | flow-map only after oauth2-proxy auth; **GAP — no admin panel (read-only); raw-chart default `auth: none` = security gap if overlay's `oidc` missing.** | `01-cilium.yaml:356`; `cilium/chart/values.yaml:340` | ☐ |
-| 11a/11b | `auth.<FQDN>/` ; `/admin/sovereign/console/` | nothing | **sovereign-realm admin console** signed-in (NOT master local form); full realm-admin controls | `keycloak httproute.yaml:56-67`; `configmap-sovereign-realm.yaml:235-242` | ☐ |
-| 12 | `marketplace.<FQDN>/` | nothing | anonymous storefront (by design); confirm NO spurious login UI | DoD §3 row 12 | ☐ |
+_Each line = one browser step. `☐`/`✅`/`❌`._
 
-### Tier 2 — Per-Org realm (gated on FUNNEL #3376)
-**UNBUILT.** `CATALYST_PER_ORG_REALM_ENABLED` defaults FALSE; `EnsureRealm` creates only a bare realm (`realm`,`displayName`,`enabled`) — **NO owner-seeding, NO catalyst-pin IdP, NO per-app client, NO group setup**.
-| # | Action | Expect | Source | ☐ |
-|---|---|---|---|---|
-| T2 | KC realm `<org-slug>` → Users | org owner seeded into admin group | **GAP — owner-seed NOT implemented in EnsureRealm** (`keycloak.go:261-294`) | ☐ |
-| T3/T4 | `console.<org-slug>.<tenant-domain>/` ; org app bare URL | lands signed-in as org owner | **UNBUILT — gated on FUNNEL; per-Org app-client registration NO config FOUND** | ☐ |
+### Console
+- [ ] Open `https://console.<sov>/` → lands on the Dashboard signed-in as **emrah** (avatar top-right), no login form.
+- [ ] The operator/admin navigation (Organizations, deployments) is visible → you are admin.
 
-### Regression probe (DoD-6)
-| # | Action | Expect | Source | ☐ |
-|---|---|---|---|---|
-| P1-P3 | shipped per-app probe (fresh session → root → assert authenticated, no login-form selector); negative test; CI on every SSO-chain roll | all rows green; reds for a broken client; mechanical UNVERIFIED flip on roll | **GAP — locate/verify the shipped probe component** | ☐ |
+### Grafana
+- [ ] Open `https://grafana.<sov>/` → Grafana home renders signed-in (no Grafana login, no "Sign in with Keycloak" button).
+- [ ] Open `https://grafana.<sov>/admin/users` → the **Server Admin → Users** page renders.
 
-**Evidence:** every Tier-1 row needs TWO screenshots (landing + admin), committed + linked, flipped UNVERIFIED on any SSO-chain roll.
+### Gitea
+- [ ] Open `https://gitea.<sov>/` → Gitea dashboard renders signed-in.
+- [ ] Open `https://gitea.<sov>/-/admin` → the **Site Administration** panel renders.
 
-**Gaps:** openbao + pdns-admin BROKEN live (hw133); guacamole no JDBC admin store; newapi no admin-group map; hubble no admin panel + raw auth:none; per-Org realm UNBUILT; regression probe to verify.
+### Harbor
+- [ ] Open `https://registry.<sov>/` → Harbor projects view renders signed-in.
+- [ ] Open `https://registry.<sov>/harbor/users` → the **Administration → Users** page renders.
+
+### OpenBao  ❌ BROKEN (hw133)
+- [ ] Open `https://bao.<sov>/ui/` → should be the signed-in Vault UI with no token form. **Live result: an error page ("Cannot read properties of null") then bounced to the auth form — does NOT land signed-in.**
+- [ ] Open `https://bao.<sov>/ui/vault/access` → should show Access/policies. (Blocked by the above.)
+
+### PowerDNS-Admin  ❌ BROKEN (hw133)
+- [ ] Open `https://pdns-admin.<sov>/` → should be the dashboard signed-in. **Live result: HTTP 500 error page — does NOT load.**
+
+### Guacamole
+- [ ] Open `https://guacamole.<sov>/` → should land on the connections home signed-in (not a Tomcat 404).
+- [ ] ❌ **GAP** — admin rights are not implemented for Guacamole (no permission store), so the "admin by default" half cannot pass.
+
+### NewAPI
+- [ ] Open `https://newapi.<sov>/` → admin UI renders signed-in via SSO (not NewAPI's own login form).
+- [ ] ❌ **GAP** — there is no configured admin-group mapping, so admin elevation isn't guaranteed.
+
+### OpenOva Flow
+- [ ] Open `https://openova-flow.<sov>/` → the Flow UI renders signed-in (no login button). (No separate admin area — admin = authenticated owner.)
+
+### Hubble
+- [ ] Open `https://hubble.<sov>/` → the flow map renders **only after** a silent SSO sign-in (it must **not** show flows to an anonymous visitor).
+- [ ] ❌ **GAP** — Hubble has no admin panel (read-only), and on a misconfigured overlay it can fall back to no-auth (a security gap to check).
+
+### Keycloak admin
+- [ ] Open `https://auth.<sov>/` → lands on the **sovereign-realm admin console** signed-in (not the master-realm username/password form).
+- [ ] Browse Realm settings / Users / Clients → full realm-admin controls render.
+
+### Marketplace (by design)
+- [ ] Open `https://marketplace.<sov>/` → the anonymous storefront renders; confirm **no** spurious login form appears before checkout.
+
+### Tenant org SSO (gated on the funnel)
+- [ ] ❌ **UNBUILT** — open a customer org's console `https://console.<orgslug>.<domain>/` → should land the org owner signed-in. The per-org realm is not yet built (bare realm, no owner seeding) — not walkable until the funnel ships.
+
+**Evidence:** for each app that passes, capture two screenshots — the signed-in landing and the admin area. **Live gaps:** OpenBao + PowerDNS-Admin broken; Guacamole/NewAPI/Hubble admin gaps; per-org realm unbuilt.

--- a/docs/ledger/uat-walkthrough/3375-topology-dr.md
+++ b/docs/ledger/uat-walkthrough/3375-topology-dr.md
@@ -1,40 +1,31 @@
-## #3375 TOPOLOGY/DR
+# #3375 TOPOLOGY/DR — user acceptance walk (100% web UI)
 
-**Law:** every blueprint defines its DR perfectly, continuum executes it, agreed apps proven by region-kill. Source of truth = `docs/sessions/2026-06-02-per-blueprint-topology-audit.md` (promoted to `docs/topology-matrix.md`). Acceptance = a witnessed continuum-driven promote with zero data loss + DNS flip + lands-working on a **fresh 2-region zero-touch prov** — never kubectl surgery, never a wire-proof. **Precondition: the prov is genuinely 2-region AND the §6 cross-region machinery is overlay-ENABLED (all flags default-OFF; a single-region prov renders NONE of it = the PR #1599 anti-pattern).**
+**What the user does:** open a multi-region app, see its disaster-recovery status, click **Switchover** to promote the other region, and confirm the app **keeps working with no data lost** — all from the console. **Precondition:** the Sovereign is a real 2-region deployment with the app's multi-region option enabled (a single-region app has no DR to test).
 
-### Block A — Registry & schema convergence (DoD-1/2/3/4 + G115)
-| # | Action | Do | Expect | Source | ☐ |
-|---|---|---|---|---|---|
-| A1-A4 | shell | `docs/topology-matrix.md` | ~90 rows, no blank class; 14 CLASS-B rows; 4 ROW-AMENDMENTS for founder | `docs/topology-matrix.md:57-187` | ☐ |
-| A6 | shell | `go test ./core/controllers/internal/clusterregistry/...` | `CanonicalIDStrings()`=6 IDs; `Parse("mgmt-B")`→{mgmt,B} | `clusterregistry/registry.go:129-183` | ☐ |
-| A7-A9 | shell | `KubeConfigSecretFor` wired + live resolve | seam populated by `clusterResolver().SecretFor`; same-region HR → real `vc-*` secret; cross-region split-side = no kubeConfig (IaC-pure) | `application_controller.go:842,925`; `registry.go:255-269` | ☐ |
-| A10-A11 | console | App Detail → Topology tab | DR section renders for active-hotstandby. **GAP — `callerTier` not threaded `AppDetail.tsx:715-719`→TopologyTab→DRSection; live Switchover button shows disabled "Owner tier required".** | `TopologyTab.tsx:252`; `DRSection.tsx:118,130` | ☐ |
-| A12 | browser | `grafana.<sov>` datasources + dashboards (G115) | non-empty (not the empty hw86 state) | `grafana/chart/templates/datasource-configmaps.yaml` | ☐ |
+_Each line = one browser step. `☐`/`✅`/`❌`. No terminal._
 
-### Block B — cnpg-pair region-kill, CONTINUUM-DRIVEN (the §6.1 proven row)
-| # | Action | Do | Expect (RTO/RPO) | Source | ☐ |
-|---|---|---|---|---|---|
-| B2 | shell | `kubectl get cluster <pair>-primary -o jsonpath='{.spec.postgresql.synchronous}'` | sync `remote_apply` (zero-tx-loss) | `primary-cluster.yaml:111-125` | ☐ |
-| B4 | shell | `psql -c "SELECT sync_state FROM pg_stat_replication"` | one row `sync` BEFORE the kill | `primary-cluster.yaml:81-125` | ☐ |
-| B8 | shell | seed canary table + write loop on `db.<org>.<sov>` | replicated to region-B; loop running | — | ☐ |
-| B9-B10 | console | DR section → **Switchover…** → confirm dialog (7 steps) | POST `/continuums/{name}/switchover` (NOT kubectl); CR patched | `SwitchoverDialog.tsx:108-212`; `continuum.go:292,462-469` | ☐ |
-| B11-B14 | console | watch StatusPanel steps 1-7 | validate-lease → cordon → drain-http → **flip-dns** (lua-record, region-B first) → swap-lease → uncordon (promote) → audit | `sequence.go:301-476`; `dns/lua.go:133-318` | ☐ |
-| B15 | shell | MEASURE RTO (confirm→FailedOver+writes) | **<60s promote, <5s write disruption** (hw128 baseline 3s) | `ARCHITECTURE.md:874` | ☐ |
-| B16 | shell | MEASURE RPO on new primary `SELECT count(*) FROM dr_canary` | **RPO=0 — every committed write present** | sync proof B2 | ☐ |
-| B18 | client | write + read against `db.<org>.<sov>` post-flip | connects region-B, works (not just wire-proven) | acceptance bar | ☐ |
+### See the DR status of a multi-region app
+- [ ] Sign in at `https://console.<sov>/` → open the multi-region database app's detail page → click the **Topology** tab.
+- [ ] The DR section shows: **Phase = Healthy**, **Primary region**, **Replica region**, and a **replication lag** indicator (green / small).
+- [ ] ❌ **GAP** — the **Switchover** button is present but **disabled** ("Owner tier required"), because the page doesn't pass the caller's tier through. Today an admin cannot actually click it in the live UI — this must be fixed before the walk can proceed via the button.
 
-### Block C — rejoin without split-brain (DoD-9)
-| C2-C3 | shell | bring region-A back; `psql -c "SELECT pg_is_in_recovery()"` | `t` (follower, not 2nd primary); exactly ONE lease holder | `sequence.go:404-441` | ☐ |
+### Create some data first (so "no data loss" is provable in the UI)
+- [ ] Use the app through its own web UI to create a record you'll recognise later — e.g. open the **Gitea** app and create a repo, or add a row via the app — and remember it.
 
-### Block D/E — gitea + openbao region-kill (DoD-7/8)
-| # | Action | Expect | Source | ☐ |
-|---|---|---|---|---|
-| D2/D4 | shell | gitea blob mirror running (`weed filer.remote.sync`); blob present in BOTH regions before the kill | `objectstorage-mirror.yaml:39-108` | ☐ |
-| D6 | git | post-kill: clone returns repo+blob, new push succeeds within RTO | DoD-7 | ☐ |
-| E2/E5 | shell | openbao snapshot CronJobs (save/fetch to S3); **KV reads UNINTERRUPTED on replica during kill** | `snapshot-replication.yaml:135-299` | ☐ |
-| E4 | shell | promote: `vault operator raft transition-to-primary` | **GAP candidate — promotion delegated to bp-continuum; if no wiring AND no runbook → NO MECHANISM FOUND.** | `snapshot-replication.yaml:26-28` | ☐ |
+### Trigger the switchover from the console
+- [ ] App detail → **Topology** tab → click **Switchover…** → a dialog lists the 7 steps and an estimated duration (<60s, <5s write disruption) → enter a reason → **Confirm Switchover**.
+- [ ] Watch the status panel advance through the steps (validate → drain → flip DNS → promote → audit) until it shows the **other region is now primary** and **last switchover = Success**.
 
-### Block F — console truth + evidence
-| F1 | console | Topology tab post-walk shows converged declaration (active=region-B, Phase=FailedOver) | `StatusPanel.tsx:72,152-163` | ☐ |
+### Confirm the app still works and the data survived
+- [ ] Re-open the app's own URL in the browser → it loads and works (now served from the promoted region).
+- [ ] Find the record you created earlier → it is **still there** (zero data loss), via the app's web UI.
 
-**Gaps:** (1) console callerTier not threaded (Switchover disabled); (2) openbao promotion half possibly unwired; (3) switchover authz HTTP 200 not 403; (4) all cross-region machinery default-OFF — needs a genuine 2-region overlay-enabled prov.
+### Rejoin (no split-brain)
+- [ ] Back on the **Topology** tab, after the original region returns → the panel shows exactly **one** primary (the promoted region) and the old region as a follower — not two primaries.
+
+### Other agreed apps (same shape, via each app's UI)
+- [ ] **Gitea**: after a switchover, clone/push works again from the browser-shown repo within the stated time, and a previously-pushed file is present.
+- [ ] **OpenBao**: during the switchover, reading a stored secret in the Vault UI stays available the whole time.
+- [ ] ❌ **GAP** — the OpenBao *promotion* step may not be wired to the console switchover; if the DR panel can't drive it, that half isn't user-walkable yet.
+
+**Verdict:** the DR **console UI exists** (status + switchover dialog + step panel), but two things block a clean web-UI walk today: the **Switchover button is disabled** (tier not threaded), and the cross-region machinery is **off unless explicitly enabled** on a genuine 2-region Sovereign. Both must be true before this walks.

--- a/docs/ledger/uat-walkthrough/3376-funnel.md
+++ b/docs/ledger/uat-walkthrough/3376-funnel.md
@@ -1,38 +1,40 @@
-## #3376 FUNNEL
+# #3376 FUNNEL — user acceptance walk (100% web UI)
 
-**End goal:** a stranger holding a voucher ends **signed in inside their own org's console with the purchased app RUNNING.** Terminal evidence = WordPress serving inside `console.<orgslug>.omani.homes`, reached zero-click as the org owner. Org-created / provisioning-started / handover-minted are NOT the finish line.
+**The story:** a stranger with a voucher ends up **signed into their own org's console with the purchased app running** — entirely in the browser, no terminal. Two actors: the **operator** (mints the voucher in the admin console) and the **stranger** (the customer, in a fresh browser).
 
-### Phase A — Operator mints the voucher (BSS, DoD-6)
-| # | Go to | Do | Expect | Source | ☐ |
-|---|---|---|---|---|---|
-| 1-3 | operator `/billing` | "Vouchers" → enter ≥16-char code, 10 OMR, Add/Update | weak code (`<16`) REJECTED 400; valid row "10 OMR · active" | `BillingPage.svelte:236-326`; entropy gate `vouchers.go:98-108` | ☐ |
-| 4b | wire | burst checkout/redeem >5× | HTTP 429 rate-limit (DoD-7) | `handlers.go:42-77` | ☐ |
+_Each line = one browser step. `☐`/`✅`/`❌`._
 
-### Phase B — Stranger redeems the link
-| 5-7 | `marketplace.<sov>/redeem?code=...` | auto-validate → "Voucher valid", "10 OMR credit" → "Sign up to redeem" | green card, code stashed in localStorage → `/plans` | `redeem.astro:88-177`; `vouchers.go:328-372` | ☐ |
+### Operator mints a voucher
+- [ ] Operator signs in at `https://console.<sov>/` → **Organizations → Billing** → **Vouchers** section.
+- [ ] Type a strong code, **10 OMR** credit, a description → **Add / Update** → the voucher appears in the table as **active, 0 used**.
+- [ ] (Try a too-short code → it is rejected with a "must be ≥16 characters" message.)
 
-### Phase C — 6-step wizard
-| 8-22 | `/plans`→`/apps`→`/addons`→`/bcp`→`/review`→`/checkout` | pick S plan → add **WordPress** → subdomain `walkmart` + `.omani.homes` → topology → Review → Checkout | each step advances; "✓ walkmart.omani.homes available"; BCP single/active-hot-standby choice | `PlanStep/AppsStep/AddonsStep/BCPStep/ReviewStep.svelte` | ☐ |
+### Stranger opens the voucher link
+- [ ] In a **fresh browser**, open `https://marketplace.<sov>/redeem?code=<CODE>` → a green **"Voucher valid — 10 OMR credit"** card renders.
+- [ ] Click **Sign up to redeem** → lands on the **Plans** page.
 
-### Phase D — Magic-link sign-in
-| 23-27 | `/checkout` | type email → "Send sign-in code" → enter 6-digit code from inbox | code emailed (crypto/rand); verify → signed-in as customer | `CheckoutStep.svelte:513-596`; `auth/handlers.go:142-267` | ☐ |
+### Stranger builds their tenant (the 6-step wizard)
+- [ ] **Plans** → click **Select** on a plan → **Continue to Stack**.
+- [ ] **Apps** → add **WordPress** (toast "✓ WordPress added") → **Continue**.
+- [ ] **Add-ons** → type subdomain **walmart** + choose **.omani.homes** → it shows "✓ walmart.omani.homes is available" → **Continue**.
+- [ ] **Business continuity** → choose a topology → **Review Order**.
+- [ ] **Review** → the WordPress app + plan + URL `walmart.omani.homes` are listed → **Proceed to Checkout**.
 
-### Phase E — Tenant naming + voucher applied + purchase
-| 28-31b | `/checkout` launch panel | tenant name, confirm subdomain, voucher pre-filled | "−OMR 10 credit" → **"✓ Credit covers this order — Due now OMR 0"**, CTA "Launch my tenant" | `CheckoutStep.svelte:602-795` | ☐ |
-| 32-34b | click **Launch my tenant** | createTenant → checkout → voucher consumed | 201 `{slug,status:provisioning}`; voucher "Used" 0→1; `paid_by_credit:true` | `tenant/handlers.go:200-271`; `billing/handlers.go:263-332` | ☐ |
+### Stranger signs in by email code
+- [ ] **Checkout** → type the customer's email → **Send sign-in code** → the form switches to "A 6-digit code was sent to …".
+- [ ] Open the email, copy the code, type it → the page flips to the signed-in launch panel (the customer's email shown).
 
-### Phase F — Tenant Org PROVISIONS (the measured-broken wire)
-| # | Action | Do | Expect | Source | ☐ |
-|---|---|---|---|---|---|
-| 35 | wire | `POST /provisioning/start` | 2xx (NOT 502). **THIS SESSION (hw133): `GET /api/billing/balance` → 502; billing SME service CrashLoops on NATS i/o timeout — SME→NATS cross-node datapath broken → the funnel cannot complete.** | `provisioning/handlers.go:135-159` | ☐ |
-| 36 | kubectl | `kubectl -n catalyst get secret tofu-phase0-archive` | EXISTS (mother→child push wire alive; cutover 425-gated without it) | issue §4 | ☐ |
-| 37 | kubectl | `sme/provisioning` pod | Ready (the 21h `Init:0/1` dies). **THIS SESSION (hw133): provisioning `Init:0/1`; billing/domain/notification/tenant CrashLoopBackOff.** | issue §3 | ☐ |
-| 38-39 | console `/jobs` + dig | steps advance to READY; `dig walmart.omani.homes` | vCluster + WordPress HR Ready; resolves to the Sovereign LB (not stale `49.12.16.160`) | `provisioning/handlers.go:392-591`; `pool-domain-manager` | ☐ |
+### Voucher covers the cost, then launch
+- [ ] In the launch panel → type a tenant name; the subdomain shows **walmart.omani.homes**; the voucher is pre-filled.
+- [ ] The order summary shows **"✓ Credit covers this order — Due now OMR 0.000"** and the button reads **Launch my tenant**.
+- [ ] ❌ **GAP (live, hw133)** — the voucher credit fails to load ("Couldn't load your voucher credit") because the billing service is down; **Launch** cannot complete. Root cause behind the scenes: the SME services can't reach their message bus. This blocks everything below until fixed.
+- [ ] Click **Launch my tenant** → it shows provisioning progress (creating workspace → installing apps → issuing TLS).
 
-### Phase G/H — Lands signed-in in OWN org console + app RUNNING (the finish line)
-| # | Go to | Expect | Source | ☐ |
-|---|---|---|---|---|
-| 40-41 | redirect → `console.walmart.omani.homes` | org console renders signed-in as owner, zero-click, no login UI | `config.ts:93-175`. **GAP — per-Org zero-click SSO landing lives in the SSO ticket; verify it lands signed-in or it's an SSO gap blocking DoD-5.** | ☐ |
-| 42-45 | `console.walmart.omani.homes/apps` → WordPress → Open → the org URL | **WordPress SERVING** over valid TLS, `curl -I` 200 (the TERMINAL screenshot) | DoD-5 | ☐ |
+### Lands in the OWN org console, signed in
+- [ ] The browser is redirected to **`https://console.walmart.omani.homes/`** and renders **signed in as the owner** — no login screen.
 
-**The DoD is NOT met until Rows 42-45 are witnessed.** **Gaps (this session, live):** billing/balance 502 (SME→NATS cross-node datapath); the whole back-half (provision → app running) unproven; per-Org SSO landing to verify; the tofu-archive wire gates everything.
+### The purchased app is RUNNING (the finish line)
+- [ ] In the org console → **Apps** → **WordPress** is listed as installed/running.
+- [ ] Click **Open** → a new tab loads the org's **WordPress site over valid HTTPS** — it actually serves.
+
+**The DoD is met only when the last two steps are witnessed.** **Live blocker (hw133):** the voucher/billing step fails because the SME stack is crash-looping; the back half (provision → app running) is unproven.

--- a/docs/ledger/uat-walkthrough/3378-organizations.md
+++ b/docs/ledger/uat-walkthrough/3378-organizations.md
@@ -1,43 +1,42 @@
-## #3378 ORGANIZATIONS
+# #3378 ORGANIZATIONS — user acceptance walk (100% web UI)
 
-**Model:** ONE `Organizations` menu replacing BSS + the never-built OSS — parent-first directory, the internal door, audited Enter-org impersonation, commerce catalog, mode-aware billing (real/chargeback/showback), parent self-showback day one, domain pools, redirect map — while the scope wall (Dashboard/Cloud/Apps/Sandbox/Jobs/Compliance/Users/Settings) stays byte-identical.
+**What the user sees:** ONE **Organizations** menu (replacing the old BSS/OSS), with the Sovereign itself as the first row, the ability to create sub-orgs, enter an org for support, run commerce, and see per-app cost — all in the console. **Sign in:** `https://console.<sov>/`.
 
-### A. Scope wall
-| A1-A5 | `console.<sov>/dashboard` | sidebar = Dashboard,Cloud,Apps,Sandbox,Jobs,Compliance,Users,**Organizations**,Settings; NO `BSS`; the 8 others byte-identical; click Organizations → `/organizations` | `SovereignSidebar.tsx:52-142,193-196` | ☐ |
+_Each line = one browser step. `☐`/`✅`/`❌`._
 
-### B. Directory — parent first citizen
-| # | Go to | Expect | Source | ☐ |
-|---|---|---|---|---|
-| B1-B4 | `/organizations` | title + intro "The parent organization — the Sovereign itself — is the first row"; table cols Organization\|Kind\|Tier\|Billing\|Isolation\|Status; FIRST row = parent (FQDN + `Parent` pill): `internal·corporate·showback·vcluster·Active` | `OrganizationsDirectoryPage.tsx:93-251`; `organizations.api.ts:132-147` | ☐ |
-| B5 | `/organizations` | directory NEVER blank (parent seeded even if sub-org fetch fails) | `organizations.api.ts:181-189` | ☐ |
-| B7 | `/organizations` | section nav: Commerce·Plans, Add-ons, Bundles, Industries, Apps, Billing, Domains | `OrganizationsDirectoryPage.tsx:116-130` | ☐ |
+### The single menu (scope wall intact)
+- [ ] The left sidebar shows: Dashboard, Cloud, Apps, Sandbox, Jobs, Compliance, Users, **Organizations**, Settings — and **no** "BSS" entry.
+- [ ] Click each of the other 8 items in turn → each opens its existing page unchanged.
+- [ ] Click **Organizations** → the Organizations directory opens.
 
-### C. Parent self-showback (B3 feed)
-| C1-C4 | `/organizations` showback panel | heading "Showback — per-app consumption"; org line "(parent — your own estate) · units · CPU · mem · storage"; per-app table (Application\|Namespace\|CPU\|Mem\|Share); ~100% to parent | `ShowbackPanel.tsx:48-104`; `sme_consumption.go:122-221` | ☐ |
+### The directory, parent first
+- [ ] The directory intro reads "The parent organization — the Sovereign itself — is the first row".
+- [ ] The first row is the Sovereign (its domain) with a **Parent** tag, and columns: Kind **internal**, Tier **corporate**, Billing **showback**, Isolation **vcluster**, Status **Active**.
+- [ ] A **Create organization** button is present, plus a sub-nav: Commerce · Plans, Add-ons, Bundles, Industries, Apps, Billing, Domains.
 
-### D. Internal door
-| # | Go to | Do | Expect | Source | ☐ |
-|---|---|---|---|---|---|
-| D1-D7 | `/organizations/new` | choose **internal** | defaults flip `showback`+`namespace`; NO voucher step; Advanced override = billing/isolation selects; slug `finance` → submit | `CreateTenantPage.tsx:224-359`; `organizations.api.ts:81-88` | ☐ |
-| D9 | `/organizations` | the `finance` row badges | **GAP (PARTIAL) — `subOrgRowFromTenant` hardcodes every sub-org to `customer/real/vcluster` (`organizations.api.ts:156-172`); an internal org mis-badges until the tenants feed surfaces spec fields.** | ☐ |
+### Showback works on day one
+- [ ] On the Organizations page, a **Showback — per-app consumption** panel shows the parent org's total (units · CPU · memory · storage) and a per-app table with each app's share.
 
-### E. Mode-aware billing
-| E1-E5 | `/organizations/billing/billing` | BillingModeGate → showback notice + panel, NO payment actions; real-mode half rides FUNNEL #3376 (don't fabricate); fallback defaults to showback | `BillingModeGate.tsx:40-72` | ☐ |
+### Create a sub-organization (internal department)
+- [ ] **Create organization** → choose **Internal** → the defaults change to **showback** billing + **namespace** isolation, and **no voucher/payment step** appears.
+- [ ] Open **Advanced override** → you can change billing mode and isolation.
+- [ ] Type a slug (e.g. **finance**) → submit → a success panel renders, and **finance** appears in the directory.
+- [ ] ❌ **GAP** — the new internal org is **mis-badged** in the directory as customer / real / vcluster (the directory hardcodes those), instead of internal / showback / namespace.
 
-### F. Enter org — audited impersonation
-| # | Go to | Do | Expect | Source | ☐ |
-|---|---|---|---|---|---|
-| F1-F2 | `/organizations/$org` | parent has NO Enter-org button; sub-org HAS it | `OrganizationDetailPage.tsx:67-71`; `EnterOrgButton.tsx:51-64` | ☐ |
-| F4-F6 | click **Enter org** | POST `/organizations/finance/enter` → opens handover URL → **org's own console lands logged in as `support+<op>@finance...`** (NOT a wire-302); confirm line "expires <≤60min>" | `sme_enter_org.go:119-179`; `EnterOrgButton.tsx:36-73` | ☐ |
-| F8-F9 | catalyst-api logs | audit line "enter-org: support session minted" with initiatedBy/org/ttl; ≤60min | `sme_enter_org.go:45-177` | ☐ |
-| F10-F12 | negative | enter-parent → 400; non-admin → 403; signer unwired → 503 | `sme_enter_org.go:83-117` | ☐ |
+### Mode-aware billing
+- [ ] **Organizations → Billing** → for the parent (showback) it shows a **showback notice + the consumption panel** with **no** payment actions (payment never leaks for a showback org).
 
-### G/H. Commerce CRUD (+ #3156 regression)
-| G1-G8 | `/organizations/commerce/plans` | create/edit/delete a plan; it surfaces in the storefront `?product=generic`; **a `product_slug:sandbox` plan does NOT appear in the generic picker** | `CommerceEditorPage.tsx`; `catalog/handlers.go:265-280` | ☐ |
-| H1-H5 | addons/bundles/industries/apps | full CRUD; bundles/industries multi-select from `/catalog/apps`,`/catalog/bundles` | `CommerceEditorPage.tsx:256-286` | ☐ |
+### Enter an org for support (audited, time-boxed)
+- [ ] Click into the **finance** org's detail page → an **Enter org** button is present (the parent has none).
+- [ ] Click **Enter org** → a new tab opens **finance's own console**, signed in as a **support** identity (not the owner), and the original tab shows "Support session … expires <≤60 min>".
+- [ ] ❌ acceptance note — the new tab must actually **land logged in** (not just redirect); verify it shows the org console, not a login page.
 
-### I. Redirect map + Domains
-| I1-I8 | `/bss*`,`/sme/tenants/new`,`/parent-domains` | each redirects to its `/organizations/*` home | `router.tsx:1733-1758` | ☐ |
-| I10 | `/sme/users`,`/sme/roles` | **NOT redirected (by design)** — org-detail users/roles tabs not built yet; confirm they still render | `router.tsx:1538-1546,1741-1744` | ☐ |
+### Commerce editing reflects in the storefront
+- [ ] **Organizations → Commerce → Plans** → **+ New Plan** → fill the fields → **Create** → the plan appears in the table.
+- [ ] Open the marketplace storefront's plan picker → the plan you just created appears there (no redeploy).
+- [ ] Edit its price → it updates in both the table and the storefront.
 
-**Gaps:** (1) directory badge fidelity PARTIAL (sub-orgs hardcoded customer/real/vcluster); (2) `/sme/users`+`/roles` un-redirected, org-detail tabs not built (deferred); (3) Enter-org acceptance = lands-logged-in, depends on the org-side handover redemption + cookie-domain fix.
+### Redirects from old paths
+- [ ] Open `/bss`, `/bss/billing`, `/parent-domains` → each redirects to its new `Organizations` home.
+
+**Gaps:** new sub-orgs mis-badged in the directory; the org-detail Users/Roles tabs aren't built yet (old `/sme/users` still in place); Enter-org acceptance depends on the org-side handover landing logged in.

--- a/docs/ledger/uat-walkthrough/3379-sovereignty.md
+++ b/docs/ledger/uat-walkthrough/3379-sovereignty.md
@@ -1,45 +1,21 @@
-## #3379 SOVEREIGNTY
+# #3379 SOVEREIGNTY — user acceptance walk (100% web UI)
 
-**Acceptance:** on a freshly **handed-over** Sovereign, the cutover engine auto-fires, all steps reach SUCCEEDED, the **10-minute deny-egress hold holds green**, `cutoverComplete=true` is stamped, and a fresh pod pulls from local Harbor while egress is still denied.
+**Honest framing:** the cutover (cutting the Sovereign's cord to the mothership) is a **behind-the-scenes process** that the end user never drives. So there is **almost no end-user UI** for it. The only thing a user can *accept* in the browser is: **after** the Sovereign becomes independent, **everything keeps working exactly as before** — nothing the user touches breaks.
 
-> **⚠ Three load-bearing realities:**
-> 1. **11 steps, not the ADR's 8** (status ConfigMap hard-codes `totalSteps:"11"`, `09-cutover-status-configmap.yaml:46`).
-> 2. **The "deny-egress NetworkPolicy" is a CIDR block, not FQDN** (Cilium 1.16 can't FQDN-egressDeny). Step 08 resolves github.com/ghcr.io/harbor.openova.io/xpkg.upbound.io → /32s + applies `CiliumClusterwideNetworkPolicy egressDeny: toCIDRSet` — ONLY when `egressTest.enforceCIDRBlock: true` (the overlay sets it; **chart default false = denies nothing = invalid proof**).
-> 3. **`cutoverComplete=true` is set ONLY after all 11 steps succeed** (`cutover.go:1085-1092`; failure returns at `:1064-1082`).
+_Each line = one browser step. `☐`/`✅`/`❌`._
 
-### A. Pre-cutover dormant + 425 gate
-| A1-A7 | kubectl/API | HR Ready (disableWait), 11 step ConfigMaps, status seeded `cutoverComplete:false`; registries v1 (mothership); Flux source still GitHub; **bootstrap auto-trigger gets HTTP 425 `handover-incomplete`** (archive not sealed); marker absent | `06a-...yaml:21-23`; `cutover_internal.go:442-453,166-178` | ☐ |
+### After cutover, the console still works
+- [ ] Open `https://console.<sov>/` → it loads and you are signed in, exactly as before cutover.
+- [ ] Navigate Dashboard / Apps / Organizations → all render normally.
 
-### B. Handover → engine auto-fires (gate skipped)
-| B1-B3 | API | mother POSTs phase-0 archive → child seals `secret/catalyst/tofu-phase0-archive` → `fireCutoverEngine(...,"handover")` skips 425 → `cutoverStartedAt` set | `handover.go:368,406,425`; `cutover.go:1015-1019` | ☐ |
+### After cutover, the apps still work
+- [ ] Open each main app's URL (`grafana.<sov>`, `gitea.<sov>`, `registry.<sov>`, …) → each loads signed-in, unchanged.
+- [ ] Use one app for real (e.g. push to a Gitea repo, view a Grafana dashboard) → it works — the Sovereign is serving everything from its own local services now.
 
-### C. The 11 tether-pivot steps (engine sorts by cutover-order)
-| step | TETHER | Expect `step.<name>.result=success` | Source | ☐ |
-|---|---|---|---|---|
-| 01 gitea-mirror | git github→local Gitea | push OK + mirror-resync SEVERED (CronJob deleted, stays gone) | `01-...yaml:32,195-253` | ☐ |
-| 02-03 harbor | local Harbor proxy projects + prewarm | projects exist on `harbor-core.harbor` | `02/03-...yaml` | ☐ |
-| 04 registry-pivot | containerd mothership→local Harbor on every node | `registries.yaml`=v2 all nodes | `04-...daemonset.yaml:13-272` | ☐ |
-| 05 flux-gitrepository | GitRepository → local Gitea | `gitrepository.openova.url`=local | `05-...yaml:21,56-71` | ☐ |
-| 06 helmrepository-patches | 38 OCI HRs ghcr→local; **STRIPS ghcr.io/harbor.openova.io/xpkg auth from ghcr-pull** | all HR URLs local; `ghcr-pull` keys `registry.<fqdn>` only | `06-...yaml:228-296,356-464` | ☐ |
-| 07 catalyst-api-env | gitops repo + PIN/JWT issuers → local; FATAL if `consolePublicURL`=example.local | no example.local residue (guards #3039 half-pivot) | `07-...yaml:225-270` | ☐ |
-| 08 egress-block-test | **the 10-min hold** (see D) | — | `08-...yaml` | ☐ |
-| 09 gitea-token-mint | local Gitea API token for SME | success | `values.yaml:585-608` | ☐ |
-| 10 vcluster-registry | vcluster+sso-bridge image hosts → harbor.<fqdn>; asserts zero residual | success | `10-...yaml:316-347` | ☐ |
-| 11 crossplane-provider | Provider packages xpkg→harbor.<fqdn>/proxy-xpkg | success | `11-...yaml:205,292-294` | ☐ |
+### Is there any user-visible "independent" indicator?
+- [ ] ❌ **GAP** — there is **no** console page or badge that shows the user "this Sovereign is now independent / cutover complete". The sovereignty state is internal only; a user cannot see or confirm it in the UI.
 
-### D. THE PROOF — step 08 hold + cutoverComplete + independence
-| # | Action | Expect | Source | ☐ |
-|---|---|---|---|---|
-| D1 | `kubectl get hr ... -o jsonpath='{.spec.values.egressTest.enforceCIDRBlock}'` | `true` (else step 08 denies nothing = invalid proof) | `06a-...yaml:497-520` | ☐ |
-| D3 | `kubectl get ccnp cutover-egress-block` DURING the window | live policy `egressDeny: toCIDRSet` of the /32s | `08-...yaml:119-178` | ☐ |
-| D5 | watch the 600s window | `no new regressions during 600s window — sovereignty proof PASSED` | `08-...yaml:226-238` | ☐ |
-| D6 | `kubectl get secret ghcr-pull ... \| jq .auths` | keys ONLY `registry.<fqdn>` (no ghcr.io/harbor.openova.io) — no half-pivot | DoD-2 | ☐ |
-| D7 | `kubectl get cm ...status -o jsonpath='{.data.cutoverComplete}'` | `true`, `progressPercent:100` (only after all 11) | `cutover.go:1085-1092` | ☐ |
-| D8 | sweep all Flux sources | ZERO external refs (github.com/ghcr.io/harbor.openova.io/xpkg) | DoD-3 | ☐ |
-| D9 | re-deny egress, `kubectl run probe --image=registry.<fqdn>/...` | Pod Running — pulled from local Harbor with mothership egress black-holed | DoD-5 | ☐ |
+### Installing/updating an app still works while disconnected
+- [ ] Install or update any app from the console **after** cutover → it succeeds (pulling from the Sovereign's own local registry, not the mothership). ✅ if the install completes and the app comes up.
 
-### E. Post-cutover + F. failure-shape gates
-| E1/E3 | `flux reconcile`; PIN silent-SSO | pulls local; JWT `iss`=`console.<fqdn>` (landed-logged-in, not a 302) | ADR-0002 §4.2; `07-...yaml:246-270` | ☐ |
-| F1-F3 | assert ABSENT | step-07 FATAL (#3039); mirror-resync revert (hw86); enforce-mode silent fallback | — | ☐ |
-
-**Status:** cutover has **never fired** (no env handed over) — the entire walk is unexecuted. **Divergences:** 11 steps not 8; CIDR-deny not FQDN; enforce must be true.
+**Verdict:** #3379 is **not really an end-user-UI feature** — it is an operations process. The only valid web-UI acceptance is the **negative** one: after the Sovereign goes independent, the user notices **no change** (console + every app + installs keep working). There is no UI to "see cutover" — and today the cutover has **never been run** on any handed-over environment, so even this negative walk is unexecuted.

--- a/docs/ledger/uat-walkthrough/3380-robustness.md
+++ b/docs/ledger/uat-walkthrough/3380-robustness.md
@@ -1,39 +1,21 @@
-## #3380 ROBUSTNESS
+# #3380 ROBUSTNESS — user acceptance walk (100% web UI)
 
-**Goal:** the platform must not wound itself during provisioning, image rolls, wipes. 5 measured defects (A-E) + 3 new session findings (F-H), each with a **binary** verification event (PASS/FAIL, no interpretation). A section is done only when its event passes, never when its PR merges.
+**Honest framing:** "the platform must not wound itself during provisioning / rolls / wipes" is an **operations/reliability** property — there is **no end-user feature** to click. The user never sees a kyverno policy or a network rule. The only thing a user can *accept* in the browser is the **outcome**: a freshly created environment **comes up cleanly and stays up**, and creating/deleting environments doesn't break anything they can see.
 
-### A — Wipe must fail fast + report truthfully (#3140)
-| A1-A5 | wipe a real env | `TofuDestroyed` honest (false → Errors[] + ProviderPurge is primary); `ProviderPurge["vpc_peerings"]` populated; peerings purged BEFORE VPC cascade (#3315); ≤6-pass loop → `ResidualOrphans==0`; **next wipe flips `wiped` AND AK/SK sweep returns 0 catalyst-* VPC/EIP/NAT/ECS (bastion excluded)** | `huawei/provider.go:292-352,923-933,1941-1996` | ☐ |
+_Each line = one browser step. `☐`/`✅`/`❌`._
 
-### B — Thin cloud-init: Flux owns everything after k3s (#3145, open)
-| # | Event | Expect | Source | ☐ |
-|---|---|---|---|---|
-| B1 | `grep 'helm repo add cilium' cloudinit-control-plane.tftpl` | **GAP — imperative cilium/gw-CRD prelude STILL PRESENT (`:687`); fix removes it (Flux slot/dependsOn).** | — | ☐ |
-| B2-B3 | PUT-kubeconfig early + IPv4-pin loop intact | 15-min budget respected; #3232 IPv4-pin survives any refactor | `phase1_watch.go:117-119`; `tftpl:663-687` | ☐ |
-| B5 | fresh prov | cloud-init = k3s+PUT+flux-bootstrap only; cilium+gw-CRDs installed DECLARATIVELY by Flux | — | ☐ |
+### A fresh environment comes up clean (the user-visible proof of robustness)
+- [ ] After a brand-new Sovereign is provisioned, open `https://console.<new-sov>/` → it loads and you are signed in. ✅ if the console comes up with no manual fixing.
+- [ ] Open **Apps** → the full app catalog shows everything **Installed** (none stuck failing). ✅ if all core apps are healthy.
+- [ ] Open each main app URL (grafana / gitea / harbor / …) → each loads. ✅ if the env is genuinely usable end-to-end.
 
-### C — Phase-1 watch + jobs survive mothership rolls (#3153)
-| C1/C5 | roll catalyst-api mid-prov | `shouldResumePhase1` treats file-on-PVC as resumable; log `resuming phase 1 watch after pod restart`; jobs keep streaming (NOT hw124 "0 events at 40/56"); hw130 frozen rows flip terminal | `deployments.go:698-766` | ☐ |
+### Creating and removing things doesn't visibly break the platform
+- [ ] Install a new app from the console → it comes up; the rest of the console keeps working during the install (no blank screens, no errors).
+- [ ] (Operator) decommission / wipe a test environment → the console reports it cleanly and the user's other environments are unaffected.
 
-### D — Kyverno-Enforce landmine inventory (#3268)
-| # | Event | Expect | Source | ☐ |
-|---|---|---|---|---|
-| D1-D2 | `bash scripts/check-kyverno-proxy-images.sh` | exit 0; no raw `registry.k8s.io`/`docker.io` in bp-{mgmt,dmz,rtz}-vcluster | `check-kyverno-proxy-images.sh:102-228` | ☐ |
-| D3 | bp-vllm images | **GAP — bp-vllm NOT in the render matrix; add to CHARTS** | `:102-106` | ☐ |
-| D4 | hook Jobs carry `managed-by: flux` | sanctioned pass | `gitea sso-configure-oauth-job.yaml:38-79` | ☐ |
-| D5 | sovereign-tls dependsOn scope | **GAP — no drift guard; manual diff (hw130 shared-PG stall delayed ALL TLS ~75min)** | `check-bootstrap-deps.sh` | ☐ |
-| D7 | `kubectl get certificate powerdns-api-tls -n powerdns` | **GAP — Ready=False, diagnosis OPEN** | `11-powerdns.yaml` | ☐ |
-| D8 | re-roll a previously-denied image | Scheduled/Running, no kyverno deny event | `kyverno-policies/chart/values.yaml:193-228` | ☐ |
+### Where robustness is INVISIBLE to the user (noted, not walked)
+- [ ] The internal protections (image-source policy, network rules, fetch retries, wipe cleanup, watch-resume after a restart) have **no UI** — a user cannot and should not see them. They are validated only by the above outcomes holding true.
 
-### E — cilium-envoy xDS dead-leg on catalyst-api rolls (#3301)
-| E2-E3 | stale-xDS detector + roll healthz | **GAP — NO detector found in-repo (Build item open); only the manual cp1 restart runbook exists.** Event: roll → 0 post-Ready 503, OR detector auto-heals <60s | DoD §E | ☐ |
+**Verdict:** #3380 is **not an end-user-UI feature**. Its only valid web-UI acceptance is the **outcome** — a fresh environment provisions cleanly and stays usable, and lifecycle actions don't visibly break the platform. In effect, **#3380 passes when every *other* ticket's walk succeeds on a fresh, zero-touch environment**; it has no standalone UI walk of its own.
 
-### New session findings (folded in per DoD §5)
-| # | Finding | Event | Expect | Source | ☐ |
-|---|---|---|---|---|---|
-| F | bp-cnpg slow-ghcr fetch wedge (#3409 area) | inspect cnpg/shared-PG slot retries | HR `timeout:15m` + install `retries:-1`/upgrade `retries:3` so a slow ghcr fetch retries not wedges | `16-cnpg.yaml:95-101`; `16a-...yaml:126-132` | ☐ |
-| F3 | slot-drift guard | every `NN-*.yaml` in `kustomization.yaml` | `scripts/check-bootstrap-deps.sh` green | `kustomization.yaml:87` | ☐ |
-| G | cloud-init kubeconfig-capture API false-negative | `GET /cloudinit-log` 404 truthfulness | **GAP — THIS SESSION: the kubeconfig WAS on the PVC (`/var/lib/catalyst/kubeconfigs/<id>.yaml`) but the API reported "not captured"/404, blinding the operator. The 404 must mean genuinely-absent, not a path false-negative.** | `cloudinit_log.go:152-160`; `kubeconfig` endpoint 409 | ☐ |
-| H | SME→NATS cross-node datapath crashloop | publisher + NATS on different nodes | **GAP — THIS SESSION (hw133 root cause of the #3376 502): billing/domain/notification/tenant CrashLoop because `cp1 → worker:4222` times out (NATS healthy, NO netpol). The `platform/nats-jetstream/chart/templates/` dir has NO NetworkPolicy at all — add a cross-node client carve-out + verify the cross-node Cilium datapath.** | `platform/nats-jetstream/chart/templates/` (no netpol); graceful-degrade `sandbox_sessions_nats_test.go:149-156` | ☐ |
-
-**Open Build items:** thin cloud-init (B1); bp-vllm proxy matrix (D3); sovereign-tls dependsOn guard (D5); powerdns-api-tls diagnosis (D7); envoy xDS detector (E2); cloud-init capture false-negative (G); NATS cross-node datapath/netpol (H).
+**Live note (hw133):** the fresh-environment walk already surfaced real wounds that a user *would* feel — the SME/billing stack crash-looping (breaks the funnel) — so the "comes up clean" check currently **fails** for the funnel path.


### PR DESCRIPTION
Per founder: UAT is the END USER's web acceptance test — no terminal, no kubectl. Every step is open-URL → click/type → see. Tables replaced with wrapping checklist lines (no horizontal scroll). Features with no UI surface are marked GAP (a feature with no UI can't be user-accepted), not dropped to a shell check. Refs #3370 #3373 #3374 #3375 #3376 #3378 #3379 #3380