### PR TITLE
docs(uat): clickable live links in every UAT row

### DIFF
--- a/docs/ledger/UAT-WALKTHROUGH.md
+++ b/docs/ledger/UAT-WALKTHROUGH.md
@@ -2,7 +2,7 @@
 
 **Purpose.** This is the **end-user web-UI acceptance test** for every founder-approved ticket. **100% browser — no terminal, no kubectl, no git, no curl.** The end user never touches a shell; every step is **open a URL → click/type → see a screen**. Once the founder **agrees on this document**, the walk-execution agents run each section in a real browser and flip each `☐` to ✅ (witnessed on screen) or ❌ (failed on screen) with a screenshot.
 
-**Table format (mandated).** Each section is a 4-column table — **Tested page · Description · Status · Evidence**. Four narrow columns fit without horizontal scrolling (the developer `file:line` column is gone — it's irrelevant to a user). The walk agent fills **Status** (✅/❌) and pastes the screenshot link into **Evidence**.
+**Table format (mandated).** Each section is a 4-column table — **Tested page · Description · Status · Evidence**. Four narrow columns fit without horizontal scrolling (the developer `file:line` column is gone — it's irrelevant to a user). **Every "Tested page" cell is a clickable link** to the actual live page on the current env (**hw133.omani.works**) — click it and the page opens. On each wipe + re-walk the links flip to the new env. The walk agent fills **Status** (✅/❌) and pastes the screenshot link into **Evidence**.
 - **`GAP`** in a row = the feature has **no web-UI surface** — so a user cannot accept it. That is itself a finding (a feature with no UI is not user-acceptance-testable); it is **not** a reason to drop to a terminal check.
 - A **redirect that ends on a login screen is a fail** for SSO — only a rendered, signed-in screen counts.
 

--- a/docs/ledger/uat-walkthrough/3370-contexts.md
+++ b/docs/ledger/uat-walkthrough/3370-contexts.md
@@ -1,27 +1,27 @@
 # #3370 CONTEXTS — user acceptance walk (web UI)
 
-**Sign in:** open `https://console.<sovereign>/` → land on the **Dashboard** signed-in (no login form).
+**Sign in:** open [console.hw133.omani.works](https://console.hw133.omani.works/) → land on the **Dashboard** signed-in (no login form).
 
 | Tested page | Description | Status | Evidence |
 |---|---|---|---|
-| `/apps` → Catalog | Click the **PostgreSQL** card → it shows a **⛓ shareable** badge | ☐ | |
-| `/apps` → Catalog | The **Keycloak** card has **no** shareable badge | ☐ | |
-| `/catalog/bp-postgres` | Hero shows **⛓ shareable · db** | ☐ | |
-| `/apps` → Deployments | Three cards: **shared-pg**, **shared-pg-b**, **shared-pg-c** | ☐ | |
-| `/apps` → Deployments | Each of the three cards shows **⛓ 3 contexts** | ☐ | |
-| `/apps` → Deployments | No extra generic "bp-postgres" card (3 instances = 3 cards) | ☐ | |
-| `/app/shared-pg` → Contexts | Table rows: **db/gitea**, **db/registry**, **db/keycloak**, each **ready** | ☐ | |
-| `/app/shared-pg` → Contexts | Click the **gitea** consumer link → opens the Gitea app page | ☐ | |
-| `/app/bp-gitea` → Dependencies | A line reads **Depends on: shared-pg / db:gitea** | ☐ | |
-| `/catalog/bp-postgres` | **Supported topologies**: singleton (*default*) + active-hot-standby | ☐ | |
-| `/catalog/bp-postgres` | **Instances** section = exactly 3 rows + a **+ New instance** button | ☐ | |
-| `/catalog/bp-postgres` | ❌ **GAP** — no "Data instances" panel here, but it was never removed from the tenant console (deletion DoD unmet) | ☐ | |
-| `/catalog/bp-harbor` → New instance | Backing services shows a PostgreSQL selector, **Create new (default)** preselected | ☐ | |
-| `/apps` → Deployments | After "Create new" → **two** new cards: the Harbor instance + its own postgres | ☐ | |
-| `/catalog/bp-harbor` → New instance | Choose **Reuse existing** → pick a self-made postgres → Create → only **one** new card | ☐ | |
-| `/app/<reused-pg>` → Contexts | A **new row** appeared for the app that just reused it | ☐ | |
-| `/catalog/bp-harbor` → New instance | ❌ **GAP** — reusing **shared-pg/-b/-c** is rejected; must use a self-made instance | ☐ | |
-| `/catalog/bp-valkey` | Hero shows **⛓ shareable · keyspace** (not "db") | ☐ | |
-| `/app/<valkey>` → Contexts | Same table, rows named **keyspace/…** | ☐ | |
+| [Apps · Catalog](https://console.hw133.omani.works/apps) | Click the **PostgreSQL** card → it shows a **⛓ shareable** badge | ☐ | |
+| [Apps · Catalog](https://console.hw133.omani.works/apps) | The **Keycloak** card has **no** shareable badge | ☐ | |
+| [Catalog · PostgreSQL](https://console.hw133.omani.works/catalog/bp-postgres) | Hero shows **⛓ shareable · db** | ☐ | |
+| [Apps · Deployments](https://console.hw133.omani.works/apps) | Three cards: **shared-pg**, **shared-pg-b**, **shared-pg-c** | ☐ | |
+| [Apps · Deployments](https://console.hw133.omani.works/apps) | Each of the three cards shows **⛓ 3 contexts** | ☐ | |
+| [Apps · Deployments](https://console.hw133.omani.works/apps) | No extra generic "bp-postgres" card (3 instances = 3 cards) | ☐ | |
+| [shared-pg · Contexts](https://console.hw133.omani.works/app/shared-pg) | Table rows: **db/gitea**, **db/registry**, **db/keycloak**, each **ready** | ☐ | |
+| [shared-pg · Contexts](https://console.hw133.omani.works/app/shared-pg) | Click the **gitea** consumer link → opens the Gitea app page | ☐ | |
+| [bp-gitea · Dependencies](https://console.hw133.omani.works/app/bp-gitea) | A line reads **Depends on: shared-pg / db:gitea** | ☐ | |
+| [Catalog · PostgreSQL](https://console.hw133.omani.works/catalog/bp-postgres) | **Supported topologies**: singleton (*default*) + active-hot-standby | ☐ | |
+| [Catalog · PostgreSQL](https://console.hw133.omani.works/catalog/bp-postgres) | **Instances** section = exactly 3 rows + a **+ New instance** button | ☐ | |
+| [Catalog · PostgreSQL](https://console.hw133.omani.works/catalog/bp-postgres) | ❌ **GAP** — no "Data instances" panel here, but it was never removed from the tenant console (deletion DoD unmet) | ☐ | |
+| [Catalog · Harbor](https://console.hw133.omani.works/catalog/bp-harbor) | **+ New instance** → Backing services shows a PostgreSQL selector, **Create new (default)** preselected | ☐ | |
+| [Apps · Deployments](https://console.hw133.omani.works/apps) | After "Create new" → **two** new cards: the Harbor instance + its own postgres | ☐ | |
+| [Catalog · Harbor](https://console.hw133.omani.works/catalog/bp-harbor) | **Reuse existing** → pick a self-made postgres → Create → only **one** new card | ☐ | |
+| [shared-pg · Contexts](https://console.hw133.omani.works/app/shared-pg) | (on the reused instance) A **new row** appeared for the app that just reused it | ☐ | |
+| [Catalog · Harbor](https://console.hw133.omani.works/catalog/bp-harbor) | ❌ **GAP** — reusing **shared-pg/-b/-c** is rejected; must use a self-made instance | ☐ | |
+| [Catalog · Valkey](https://console.hw133.omani.works/catalog/bp-valkey) | Hero shows **⛓ shareable · keyspace** (not "db") | ☐ | |
+| [Apps · Deployments](https://console.hw133.omani.works/apps) | Open a Valkey instance → **Contexts** tab → same table, rows named **keyspace/…** | ☐ | |
 
 **Gaps:** Data-instances panel not deleted from the tenant console; the 3 bootstrap DBs can't be reused from the UI.

--- a/docs/ledger/uat-walkthrough/3373-placement.md
+++ b/docs/ledger/uat-walkthrough/3373-placement.md
@@ -1,14 +1,14 @@
 # #3373 PLACEMENT — user acceptance walk (web UI)
 
-**What the user should be able to do:** when provisioning or viewing an app, choose / see **which vCluster** it lives in — by data, in the UI, with the default needing no thought. **Sign in:** `https://console.<sovereign>/`.
+**What the user should be able to do:** when provisioning or viewing an app, choose / see **which vCluster** it lives in — by data, in the UI. **Sign in:** [console.hw133.omani.works](https://console.hw133.omani.works/).
 
 | Tested page | Description | Status | Evidence |
 |---|---|---|---|
-| App install (default flow) | The default path never asks about a vCluster — the app just installs | ☐ | |
-| App install → Advanced | ❌ **GAP** — there is **no** vCluster/region/cluster placement selector anywhere in the UI; the "Advanced" sections are backing-services + config only | ☐ | |
-| `/app/<any>` detail | ❌ **GAP** — the app page does **not** show which vCluster the app lives in (no placement field) | ☐ | |
-| `/app/<any>` (re-place) | ❌ **GAP** — no selector to change placement, no field to reflect a change | ☐ | |
-| `https://<app>.<sov>/` | A placed app's public URL **loads and renders** in the browser (it reaches the user through the gateway even though it runs in a vCluster) | ☐ | |
-| `https://<app>.<sov>/` | ❌ **LIMITATION** — on the open-source vCluster build, a route-bearing app may **not** serve from inside its vCluster (licensing limit); a failed load here is the known gap, not a regression | ☐ | |
+| [Apps](https://console.hw133.omani.works/apps) | App install (default flow) → never asks about a vCluster; the app just installs | ☐ | |
+| [Apps](https://console.hw133.omani.works/apps) | App install → **Advanced** → ❌ **GAP** — no vCluster/region/cluster placement selector anywhere (Advanced is backing-services + config only) | ☐ | |
+| [bp-keycloak](https://console.hw133.omani.works/app/bp-keycloak) | ❌ **GAP** — the app page does **not** show which vCluster the app lives in | ☐ | |
+| [bp-keycloak](https://console.hw133.omani.works/app/bp-keycloak) | ❌ **GAP** — no selector to change placement, no field to reflect a change | ☐ | |
+| [grafana.hw133.omani.works](https://grafana.hw133.omani.works/) | A placed app's public URL **loads and renders** (it reaches the user through the gateway even though it runs in a vCluster) | ☐ | |
+| [grafana.hw133.omani.works](https://grafana.hw133.omani.works/) | ❌ **LIMITATION** — on the open-source vCluster build a route-bearing app may **not** serve from inside its vCluster (licensing); a failed load here is the known gap, not a regression | ☐ | |
 
-**Verdict:** **largely not user-acceptance-testable today** — there is **no placement UI** (no selector, no display). A web-UI walk can only confirm a placed app still *serves*, not that the user can *choose or see* placement.
+**Verdict:** **largely not user-acceptance-testable today** — there is **no placement UI** (no selector, no display). A walk can only confirm a placed app still *serves*, not that the user can *choose or see* placement.

--- a/docs/ledger/uat-walkthrough/3374-sso.md
+++ b/docs/ledger/uat-walkthrough/3374-sso.md
@@ -1,30 +1,30 @@
 # #3374 SSO — user acceptance walk (web UI)
 
-**Contract:** in a **fresh incognito window**, type the bare URL → land **signed in** as the owner with **admin** rights. Zero clicks, no login / PIN / token form. A redirect that ends on a login screen is a **fail**. Two checks per app: (a) lands signed-in, (b) admin area reachable.
+**Contract:** in a **fresh incognito window**, click the link → land **signed in** as the owner with **admin** rights. Zero clicks, no login / PIN / token form. A redirect that ends on a login screen is a **fail**. Two checks per app: (a) lands signed-in, (b) admin area reachable.
 
 | Tested page | Description | Status | Evidence |
 |---|---|---|---|
-| `console.<sov>/` | Lands on the Dashboard signed-in as **emrah** (avatar top-right), no login form | ☐ | |
-| `console.<sov>/` | Operator/admin nav (Organizations, deployments) visible → admin | ☐ | |
-| `grafana.<sov>/` | Grafana home renders signed-in (no login, no "Sign in with Keycloak") | ☐ | |
-| `grafana.<sov>/admin/users` | **Server Admin → Users** page renders | ☐ | |
-| `gitea.<sov>/` | Gitea dashboard renders signed-in | ☐ | |
-| `gitea.<sov>/-/admin` | **Site Administration** panel renders | ☐ | |
-| `registry.<sov>/` | Harbor projects view renders signed-in | ☐ | |
-| `registry.<sov>/harbor/users` | **Administration → Users** page renders | ☐ | |
-| `bao.<sov>/ui/` | ❌ **BROKEN (hw133)** — should be the signed-in Vault UI; live = error page then bounced to the token/auth form | ☐ | |
-| `bao.<sov>/ui/vault/access` | Access/policies controls (blocked by the above) | ☐ | |
-| `pdns-admin.<sov>/` | ❌ **BROKEN (hw133)** — should be the dashboard signed-in; live = **HTTP 500** error page | ☐ | |
-| `guacamole.<sov>/` | Connections home renders signed-in (not a Tomcat 404) | ☐ | |
-| `guacamole.<sov>/` admin | ❌ **GAP** — no admin rights implemented (no permission store) | ☐ | |
-| `newapi.<sov>/` | Admin UI renders signed-in via SSO (not NewAPI's own login) | ☐ | |
-| `newapi.<sov>/` admin | ❌ **GAP** — no admin-group mapping configured | ☐ | |
-| `openova-flow.<sov>/` | Flow UI renders signed-in (no login button) | ☐ | |
-| `hubble.<sov>/` | Flow map renders **only after** a silent sign-in (must not serve to anonymous) | ☐ | |
-| `hubble.<sov>/` | ❌ **GAP** — no admin panel (read-only); on a bad overlay can fall back to no-auth | ☐ | |
-| `auth.<sov>/` | Lands on the **sovereign-realm** admin console (not the master local form) | ☐ | |
-| `auth.<sov>/admin/sovereign/console/` | Full realm-admin controls (Users/Clients/Realm settings) | ☐ | |
-| `marketplace.<sov>/` | Anonymous storefront renders; no spurious login form before checkout | ☐ | |
-| `console.<orgslug>.<domain>/` | ❌ **UNBUILT** — should land the org owner signed-in; per-org realm not yet built (gated on funnel) | ☐ | |
+| [console.hw133.omani.works](https://console.hw133.omani.works/) | Lands on the Dashboard signed-in as **emrah** (avatar top-right), no login form | ☐ | |
+| [console.hw133.omani.works](https://console.hw133.omani.works/organizations) | Operator/admin nav (Organizations, deployments) visible → admin | ☐ | |
+| [grafana.hw133.omani.works](https://grafana.hw133.omani.works/) | Grafana home renders signed-in (no login, no "Sign in with Keycloak") | ☐ | |
+| [grafana · admin](https://grafana.hw133.omani.works/admin/users) | **Server Admin → Users** page renders | ☐ | |
+| [gitea.hw133.omani.works](https://gitea.hw133.omani.works/) | Gitea dashboard renders signed-in | ☐ | |
+| [gitea · admin](https://gitea.hw133.omani.works/-/admin) | **Site Administration** panel renders | ☐ | |
+| [registry.hw133.omani.works](https://registry.hw133.omani.works/) | Harbor projects view renders signed-in | ☐ | |
+| [harbor · users](https://registry.hw133.omani.works/harbor/users) | **Administration → Users** page renders | ☐ | |
+| [bao.hw133.omani.works/ui/](https://bao.hw133.omani.works/ui/) | ❌ **BROKEN (hw133)** — should be the signed-in Vault UI; live = error page then bounced to the token/auth form | ☐ | |
+| [bao · access](https://bao.hw133.omani.works/ui/vault/access) | Access/policies controls (blocked by the above) | ☐ | |
+| [pdns-admin.hw133.omani.works](https://pdns-admin.hw133.omani.works/) | ❌ **BROKEN (hw133)** — should be the dashboard signed-in; live = **HTTP 500** error page | ☐ | |
+| [guacamole.hw133.omani.works](https://guacamole.hw133.omani.works/) | Connections home renders signed-in (not a Tomcat 404) | ☐ | |
+| [guacamole.hw133.omani.works](https://guacamole.hw133.omani.works/) | ❌ **GAP** — no admin rights implemented (no permission store) | ☐ | |
+| [newapi.hw133.omani.works](https://newapi.hw133.omani.works/) | Admin UI renders signed-in via SSO (not NewAPI's own login) | ☐ | |
+| [newapi.hw133.omani.works](https://newapi.hw133.omani.works/) | ❌ **GAP** — no admin-group mapping configured | ☐ | |
+| [openova-flow.hw133.omani.works](https://openova-flow.hw133.omani.works/) | Flow UI renders signed-in (no login button) | ☐ | |
+| [hubble.hw133.omani.works](https://hubble.hw133.omani.works/) | Flow map renders **only after** a silent sign-in (must not serve to anonymous) | ☐ | |
+| [hubble.hw133.omani.works](https://hubble.hw133.omani.works/) | ❌ **GAP** — no admin panel (read-only); on a bad overlay can fall back to no-auth | ☐ | |
+| [auth.hw133.omani.works](https://auth.hw133.omani.works/) | Lands on the **sovereign-realm** admin console (not the master local form) | ☐ | |
+| [keycloak · console](https://auth.hw133.omani.works/admin/sovereign/console/) | Full realm-admin controls (Users/Clients/Realm settings) | ☐ | |
+| [marketplace.hw133.omani.works](https://marketplace.hw133.omani.works/) | Anonymous storefront renders; no spurious login form before checkout | ☐ | |
+| _(per-org console)_ | ❌ **UNBUILT** — `console.<orgslug>.omani.homes` should land the org owner signed-in; per-org realm not yet built (gated on funnel) | ☐ | |
 
 **Evidence:** each passing app needs two screenshots (signed-in landing + admin area). **Live gaps:** OpenBao + PowerDNS-Admin broken; Guacamole/NewAPI/Hubble admin gaps; per-org realm unbuilt.

--- a/docs/ledger/uat-walkthrough/3375-topology-dr.md
+++ b/docs/ledger/uat-walkthrough/3375-topology-dr.md
@@ -1,19 +1,18 @@
 # #3375 TOPOLOGY/DR — user acceptance walk (web UI)
 
-**What the user does:** open a multi-region app, see its DR status, click **Switchover** to promote the other region, and confirm the app **keeps working with no data lost** — all from the console. **Precondition:** a real 2-region Sovereign with the app's multi-region option enabled.
+**What the user does:** open a multi-region app, see its DR status, click **Switchover** to promote the other region, confirm the app **keeps working with no data lost**. **Precondition:** a real 2-region Sovereign with the app's multi-region option enabled.
 
 | Tested page | Description | Status | Evidence |
 |---|---|---|---|
-| `/app/<db-app>` → Topology | DR section shows **Phase = Healthy**, Primary region, Replica region, replication lag (green) | ☐ | |
-| `/app/<db-app>` → Topology | ❌ **GAP** — the **Switchover** button is **disabled** ("Owner tier required"); an admin cannot run it in the live UI yet | ☐ | |
-| `https://<app>.<sov>/` | Use the app's UI to create a record you'll recognise later (e.g. a Gitea repo) | ☐ | |
-| `/app/<db-app>` → Topology | Click **Switchover…** → dialog lists the 7 steps + duration (<60s) → enter reason → **Confirm** | ☐ | |
-| `/app/<db-app>` → Topology | Watch the panel advance (validate → drain → flip DNS → promote → audit) → **other region is now primary**, last switchover **Success** | ☐ | |
-| `https://<app>.<sov>/` | Re-open the app → it loads and works (served from the promoted region) | ☐ | |
-| `https://<app>.<sov>/` | The record you created earlier is **still there** (zero data loss) | ☐ | |
-| `/app/<db-app>` → Topology | After the original region returns → panel shows **one** primary (the promoted region), old region a follower (no split-brain) | ☐ | |
-| `https://gitea.<sov>/` | After a gitea switchover: clone/push works again; a previously-pushed file is present | ☐ | |
-| `https://bao.<sov>/ui/` | During an openbao switchover: reading a stored secret in the Vault UI stays available throughout | ☐ | |
-| `/app/openbao` → Topology | ❌ **GAP** — the openbao *promotion* may not be wired to the console switchover; if it can't be driven from the UI, that half isn't walkable | ☐ | |
+| [bp-cnpg-pair · Topology](https://console.hw133.omani.works/app/bp-cnpg-pair) | DR section shows **Phase = Healthy**, Primary region, Replica region, replication lag (green) | ☐ | |
+| [bp-cnpg-pair · Topology](https://console.hw133.omani.works/app/bp-cnpg-pair) | ❌ **GAP** — the **Switchover** button is **disabled** ("Owner tier required"); an admin can't run it in the live UI yet | ☐ | |
+| [gitea.hw133.omani.works](https://gitea.hw133.omani.works/) | Use the app to create a record you'll recognise later (e.g. a Gitea repo) | ☐ | |
+| [bp-cnpg-pair · Topology](https://console.hw133.omani.works/app/bp-cnpg-pair) | Click **Switchover…** → dialog lists 7 steps + duration (<60s) → enter reason → **Confirm** | ☐ | |
+| [bp-cnpg-pair · Topology](https://console.hw133.omani.works/app/bp-cnpg-pair) | Watch the panel advance → **other region now primary**, last switchover **Success** | ☐ | |
+| [gitea.hw133.omani.works](https://gitea.hw133.omani.works/) | Re-open the app → it loads and works (served from the promoted region) | ☐ | |
+| [gitea.hw133.omani.works](https://gitea.hw133.omani.works/) | The record you created earlier is **still there** (zero data loss) | ☐ | |
+| [bp-cnpg-pair · Topology](https://console.hw133.omani.works/app/bp-cnpg-pair) | After the original region returns → **one** primary (the promoted region), old region a follower (no split-brain) | ☐ | |
+| [bao.hw133.omani.works/ui/](https://bao.hw133.omani.works/ui/) | During an openbao switchover: reading a stored secret in the Vault UI stays available throughout | ☐ | |
+| [bp-openbao · Topology](https://console.hw133.omani.works/app/bp-openbao) | ❌ **GAP** — the openbao *promotion* may not be wired to the console switchover | ☐ | |
 
 **Verdict:** the DR console UI exists, but two things block a clean walk today: the **Switchover button is disabled** (tier bug), and the cross-region machinery is **off unless explicitly enabled** on a genuine 2-region Sovereign.

--- a/docs/ledger/uat-walkthrough/3376-funnel.md
+++ b/docs/ledger/uat-walkthrough/3376-funnel.md
@@ -4,22 +4,22 @@
 
 | Tested page | Description | Status | Evidence |
 |---|---|---|---|
-| `console.<sov>/` → Organizations → Billing | Operator: **Vouchers** → strong code, 10 OMR, description → **Add/Update** → row shows **active, 0 used** | ☐ | |
-| same | A too-short code is rejected ("must be ≥16 characters") | ☐ | |
-| `marketplace.<sov>/redeem?code=<CODE>` | Stranger (fresh browser): a green **"Voucher valid — 10 OMR credit"** card renders | ☐ | |
-| same | Click **Sign up to redeem** → lands on **Plans** | ☐ | |
-| `marketplace.<sov>/plans` | Select a plan → **Continue to Stack** | ☐ | |
-| `/apps` | Add **WordPress** (toast "✓ added") → **Continue** | ☐ | |
-| `/addons` | Subdomain **walmart** + **.omani.homes** → "✓ available" → **Continue** | ☐ | |
-| `/bcp` | Choose a topology → **Review Order** | ☐ | |
-| `/review` | WordPress + plan + URL `walmart.omani.homes` listed → **Proceed to Checkout** | ☐ | |
-| `/checkout` | Type email → **Send sign-in code** → form switches to "code sent to …" | ☐ | |
-| `/checkout` | Enter the 6-digit code from the email → page flips to the signed-in launch panel | ☐ | |
-| `/checkout` launch | Tenant name set; subdomain **walmart.omani.homes**; voucher pre-filled; summary **"✓ Credit covers this order — Due now OMR 0"** | ☐ | |
-| `/checkout` launch | ❌ **GAP (hw133)** — voucher credit fails to load ("Couldn't load your voucher credit"); the billing service is down → **Launch can't complete** | ☐ | |
-| `/checkout` launch | Click **Launch my tenant** → provisioning progress (workspace → apps → TLS) | ☐ | |
-| `console.walmart.omani.homes/` | Browser is redirected here and renders **signed in as the owner** — no login | ☐ | |
-| `console.walmart.omani.homes/apps` | **WordPress** is listed as installed/running | ☐ | |
-| WordPress app URL | Click **Open** → the org's **WordPress site loads over HTTPS** — it actually serves | ☐ | |
+| [Organizations · Billing](https://console.hw133.omani.works/organizations/billing/vouchers) | Operator: **Vouchers** → strong code, 10 OMR, description → **Add/Update** → row shows **active, 0 used** | ☐ | |
+| [Organizations · Billing](https://console.hw133.omani.works/organizations/billing/vouchers) | A too-short code is rejected ("must be ≥16 characters") | ☐ | |
+| [marketplace · redeem](https://marketplace.hw133.omani.works/redeem?code=DEMO) | Stranger (fresh browser): a green **"Voucher valid — 10 OMR credit"** card renders | ☐ | |
+| [marketplace · redeem](https://marketplace.hw133.omani.works/redeem?code=DEMO) | Click **Sign up to redeem** → lands on **Plans** | ☐ | |
+| [marketplace · Plans](https://marketplace.hw133.omani.works/plans) | Select a plan → **Continue to Stack** | ☐ | |
+| [marketplace · Apps](https://marketplace.hw133.omani.works/apps) | Add **WordPress** (toast "✓ added") → **Continue** | ☐ | |
+| [marketplace · Add-ons](https://marketplace.hw133.omani.works/addons) | Subdomain **walmart** + **.omani.homes** → "✓ available" → **Continue** | ☐ | |
+| [marketplace · BCP](https://marketplace.hw133.omani.works/bcp) | Choose a topology → **Review Order** | ☐ | |
+| [marketplace · Review](https://marketplace.hw133.omani.works/review) | WordPress + plan + URL `walmart.omani.homes` listed → **Proceed to Checkout** | ☐ | |
+| [marketplace · Checkout](https://marketplace.hw133.omani.works/checkout) | Type email → **Send sign-in code** → form switches to "code sent to …" | ☐ | |
+| [marketplace · Checkout](https://marketplace.hw133.omani.works/checkout) | Enter the 6-digit code from the email → page flips to the signed-in launch panel | ☐ | |
+| [marketplace · Checkout](https://marketplace.hw133.omani.works/checkout) | Tenant name set; subdomain **walmart.omani.homes**; voucher pre-filled; summary **"✓ Credit covers this order — Due now OMR 0"** | ☐ | |
+| [marketplace · Checkout](https://marketplace.hw133.omani.works/checkout) | ❌ **GAP (hw133)** — voucher credit fails to load ("Couldn't load your voucher credit"); billing service is down → **Launch can't complete** | ☐ | |
+| [marketplace · Checkout](https://marketplace.hw133.omani.works/checkout) | Click **Launch my tenant** → provisioning progress (workspace → apps → TLS) | ☐ | |
+| [console.walmart.omani.homes](https://console.walmart.omani.homes/) | Browser is redirected here and renders **signed in as the owner** — no login | ☐ | |
+| [console.walmart.omani.homes/apps](https://console.walmart.omani.homes/apps) | **WordPress** is listed as installed/running | ☐ | |
+| [walmart.omani.homes](https://walmart.omani.homes/) | Click **Open** → the org's **WordPress site loads over HTTPS** — it actually serves | ☐ | |
 
 **The DoD is met only when the last two rows are witnessed.** **Live blocker (hw133):** voucher/billing step fails (SME stack crash-looping); the back half is unproven.

--- a/docs/ledger/uat-walkthrough/3378-organizations.md
+++ b/docs/ledger/uat-walkthrough/3378-organizations.md
@@ -1,23 +1,24 @@
 # #3378 ORGANIZATIONS — user acceptance walk (web UI)
 
-**What the user sees:** ONE **Organizations** menu (replacing BSS/OSS), with the Sovereign itself as the first row, sub-org creation, enter-org support, commerce, and per-app cost — all in the console. **Sign in:** `https://console.<sov>/`.
+**What the user sees:** ONE **Organizations** menu (replacing BSS/OSS), with the Sovereign itself as the first row, sub-org creation, enter-org support, commerce, and per-app cost. **Sign in:** [console.hw133.omani.works](https://console.hw133.omani.works/).
 
 | Tested page | Description | Status | Evidence |
 |---|---|---|---|
-| `/dashboard` | Sidebar: Dashboard, Cloud, Apps, Sandbox, Jobs, Compliance, Users, **Organizations**, Settings — and **no** "BSS" | ☐ | |
-| `/dashboard` | Click each other item → each opens its existing page unchanged | ☐ | |
-| `/organizations` | Intro: "The parent organization — the Sovereign itself — is the first row" | ☐ | |
-| `/organizations` | First row = the Sovereign with a **Parent** tag: internal · corporate · showback · vcluster · Active | ☐ | |
-| `/organizations` | **Showback** panel shows the parent's total + a per-app consumption table | ☐ | |
-| `/organizations/new` | Choose **Internal** → defaults change to showback + namespace; **no** voucher/payment step | ☐ | |
-| `/organizations/new` | **Advanced override** lets you change billing mode + isolation | ☐ | |
-| `/organizations/new` | Type slug **finance** → submit → success panel; **finance** appears in the directory | ☐ | |
-| `/organizations` | ❌ **GAP** — the new internal org is **mis-badged** as customer / real / vcluster | ☐ | |
-| `/organizations/billing/billing` | For the parent (showback): a showback notice + consumption panel, **no** payment actions | ☐ | |
-| `/organizations/finance` | An **Enter org** button is present (the parent has none) | ☐ | |
-| `/organizations/finance` | Click **Enter org** → new tab opens **finance's own console** signed in as a **support** identity; original tab shows "expires ≤60 min" | ☐ | |
-| `/organizations/commerce/plans` | **+ New Plan** → fill fields → **Create** → row appears in the table | ☐ | |
-| `marketplace.<sov>/plans` | The plan you just created appears in the storefront picker (no redeploy) | ☐ | |
-| `/bss`, `/bss/billing`, `/parent-domains` | Each redirects to its new **Organizations** home | ☐ | |
+| [Dashboard](https://console.hw133.omani.works/dashboard) | Sidebar: Dashboard, Cloud, Apps, Sandbox, Jobs, Compliance, Users, **Organizations**, Settings — and **no** "BSS" | ☐ | |
+| [Dashboard](https://console.hw133.omani.works/dashboard) | Click each other item → each opens its existing page unchanged | ☐ | |
+| [Organizations](https://console.hw133.omani.works/organizations) | Intro: "The parent organization — the Sovereign itself — is the first row" | ☐ | |
+| [Organizations](https://console.hw133.omani.works/organizations) | First row = the Sovereign with a **Parent** tag: internal · corporate · showback · vcluster · Active | ☐ | |
+| [Organizations](https://console.hw133.omani.works/organizations) | **Showback** panel shows the parent's total + a per-app consumption table | ☐ | |
+| [Create organization](https://console.hw133.omani.works/organizations/new) | Choose **Internal** → defaults change to showback + namespace; **no** voucher/payment step | ☐ | |
+| [Create organization](https://console.hw133.omani.works/organizations/new) | **Advanced override** lets you change billing mode + isolation | ☐ | |
+| [Create organization](https://console.hw133.omani.works/organizations/new) | Type slug **finance** → submit → success panel; **finance** appears in the directory | ☐ | |
+| [Organizations](https://console.hw133.omani.works/organizations) | ❌ **GAP** — the new internal org is **mis-badged** as customer / real / vcluster | ☐ | |
+| [Org · Billing](https://console.hw133.omani.works/organizations/billing/billing) | For the parent (showback): a showback notice + consumption panel, **no** payment actions | ☐ | |
+| [Org · finance](https://console.hw133.omani.works/organizations/finance) | An **Enter org** button is present (the parent has none) | ☐ | |
+| [Org · finance](https://console.hw133.omani.works/organizations/finance) | Click **Enter org** → new tab opens **finance's own console** signed in as a **support** identity; original tab shows "expires ≤60 min" | ☐ | |
+| [Commerce · Plans](https://console.hw133.omani.works/organizations/commerce/plans) | **+ New Plan** → fill fields → **Create** → row appears in the table | ☐ | |
+| [marketplace · Plans](https://marketplace.hw133.omani.works/plans) | The plan you just created appears in the storefront picker (no redeploy) | ☐ | |
+| [/bss](https://console.hw133.omani.works/bss) | Redirects to the new **Organizations** home | ☐ | |
+| [/parent-domains](https://console.hw133.omani.works/parent-domains) | Redirects to **Organizations · Domains** | ☐ | |
 
 **Gaps:** new sub-orgs mis-badged; org-detail Users/Roles tabs not built yet; Enter-org must actually land logged in (not just redirect).

--- a/docs/ledger/uat-walkthrough/3379-sovereignty.md
+++ b/docs/ledger/uat-walkthrough/3379-sovereignty.md
@@ -4,11 +4,11 @@
 
 | Tested page | Description | Status | Evidence |
 |---|---|---|---|
-| `console.<sov>/` | After cutover, the console still loads and you are signed in, as before | ☐ | |
-| `console.<sov>/` | Navigate Dashboard / Apps / Organizations → all render normally | ☐ | |
-| `grafana.<sov>/`, `gitea.<sov>/`, `registry.<sov>/` | Each app still loads signed-in, unchanged | ☐ | |
-| `https://<app>.<sov>/` | Use one app for real (push a repo, view a dashboard) → it works | ☐ | |
-| (any console page) | ❌ **GAP** — there is **no** UI page or badge that shows "this Sovereign is now independent / cutover complete" | ☐ | |
-| `/apps` | Install or update an app **after** cutover → it succeeds (pulls from the Sovereign's own local registry) | ☐ | |
+| [console.hw133.omani.works](https://console.hw133.omani.works/) | After cutover, the console still loads and you are signed in, as before | ☐ | |
+| [Apps](https://console.hw133.omani.works/apps) | Navigate Dashboard / Apps / Organizations → all render normally | ☐ | |
+| [grafana.hw133.omani.works](https://grafana.hw133.omani.works/) | App still loads signed-in, unchanged | ☐ | |
+| [gitea.hw133.omani.works](https://gitea.hw133.omani.works/) | Push a repo / use the app → it works (served from the Sovereign's own local services) | ☐ | |
+| [console.hw133.omani.works](https://console.hw133.omani.works/) | ❌ **GAP** — there is **no** UI page or badge that shows "this Sovereign is now independent / cutover complete" | ☐ | |
+| [Apps](https://console.hw133.omani.works/apps) | Install or update an app **after** cutover → it succeeds (pulls from the Sovereign's own local registry) | ☐ | |
 
 **Verdict:** **not an end-user-UI feature** — an operations process. The only valid web-UI acceptance is the **negative** one (after going independent, the user sees no change). Today the cutover has **never been run** on any handed-over environment, so even this is unexecuted.

--- a/docs/ledger/uat-walkthrough/3380-robustness.md
+++ b/docs/ledger/uat-walkthrough/3380-robustness.md
@@ -4,13 +4,13 @@
 
 | Tested page | Description | Status | Evidence |
 |---|---|---|---|
-| `console.<new-sov>/` | After a brand-new Sovereign is provisioned, the console loads and you are signed in (no manual fixing) | ☐ | |
-| `/apps` | The full app catalog shows everything **Installed** — none stuck failing | ☐ | |
-| `grafana.<sov>/`, `gitea.<sov>/`, `registry.<sov>/` | Each main app loads → the env is usable end-to-end | ☐ | |
-| `/apps` | Install a new app → it comes up; the rest of the console keeps working during the install | ☐ | |
-| `console.<sov>/` | Decommission/wipe a test environment → reported cleanly; the user's other environments are unaffected | ☐ | |
-| (internal) | The internal protections (image policy, network rules, retries, wipe cleanup) have **no UI** — validated only by the outcomes above | ☐ | |
+| [console.hw133.omani.works](https://console.hw133.omani.works/) | After a brand-new Sovereign is provisioned, the console loads and you are signed in (no manual fixing) | ☐ | |
+| [Apps](https://console.hw133.omani.works/apps) | The full app catalog shows everything **Installed** — none stuck failing | ☐ | |
+| [grafana.hw133.omani.works](https://grafana.hw133.omani.works/) | Each main app loads → the env is usable end-to-end | ☐ | |
+| [Apps](https://console.hw133.omani.works/apps) | Install a new app → it comes up; the rest of the console keeps working during the install | ☐ | |
+| [console.hw133.omani.works](https://console.hw133.omani.works/) | Decommission/wipe a test environment → reported cleanly; the user's other environments are unaffected | ☐ | |
+| _(internal — no UI)_ | The internal protections (image policy, network rules, retries, wipe cleanup) have **no UI** — validated only by the outcomes above | ☐ | |
 
-**Verdict:** **not an end-user-UI feature.** It passes only as the **outcome** of every other ticket's walk succeeding on a fresh, zero-touch environment — no standalone UI walk.
+**Verdict:** **not an end-user-UI feature.** It passes only as the **outcome** of every other ticket's walk succeeding on a fresh, zero-touch environment.
 
 **Live note (hw133):** the fresh-environment walk already surfaced a wound a user *would* feel — the SME/billing stack crash-looping (breaks the funnel) — so "comes up clean" currently **fails** for the funnel path.


### PR DESCRIPTION
Per founder UAT principle: every tested-page link must be clickable. Every Tested-page cell is now a real markdown link to the live env (hw133.omani.works) — click → page opens. Refs #3370 #3373 #3374 #3375 #3376 #3378 #3379 #3380