### PR TITLE
fix(bp-mgmt-vcluster): allow sme→NATS ingress through vCluster isolation netpol (0.2.9)

### DIFF
--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -75,7 +75,10 @@ spec:
       # 0.2.7 (#3373 fix (b)): toHost customResources sync gains HTTPRoute + ExternalSecret.
       # 0.2.8 (#3380-D): k8s distro control-plane images pinned off
       # registry.k8s.io onto Harbor proxy-k8s (harbor-proxy-pull Enforce).
-      version: 0.2.8
+      # 0.2.9 (#3376): add `sme` to the isolation netpol ingress allow-list
+      # — #3373 moved NATS into this vCluster, walling off the host SME/BSS
+      # services that use it as their event bus (funnel back-half was dead).
+      version: 0.2.9
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -62,7 +62,17 @@ name: bp-mgmt-vcluster
 # kept as the bootstrap default (slot 58 `${REGISTRY_MIRROR}` + cutover
 # Step-04 re-point the host). Sibling to bp-dmz-vcluster 0.2.7 +
 # bp-rtz-vcluster 0.2.8.
-version: 0.2.8
+# 0.2.9 — Refs #3376: add `sme` to networkPolicy.allowedIngressNamespaces.
+# #3373 placement moved nats-jetstream INTO this MGMT vCluster; its
+# host-synced Service now sits behind the `-isolation` NetworkPolicy whose
+# ingress allow-list was {dmz, flux-system} only. The BSS control-plane
+# services in the host `sme` namespace (billing/tenant/domain/notification/
+# provisioning/marketplace) use NATS as their event bus → every one
+# CrashLooped on "failed to connect to NATS … i/o timeout" (confirmed LIVE
+# on hw133: all 4 SME pods, endpoints healthy, policy is the wall) → the
+# voucher/billing funnel back-half (#3376) was dead. Additive allow-list
+# entry only; no other behaviour changes.
+version: 0.2.9
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -141,6 +141,16 @@ mgmtVcluster:
       # tcp …:443 i/o timeout") on their next reconcile — they only appear
       # healthy until Cilium starts enforcing the netpol. #3055
       - flux-system
+      # REQUIRED: the host `sme` namespace runs the BSS control-plane
+      # services (billing/tenant/domain/notification/provisioning/
+      # marketplace) whose event bus is NATS. #3373 placement moved
+      # nats-jetstream INTO this MGMT vCluster, so its host-synced
+      # Service (nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc)
+      # now sits behind this isolation policy. Without this entry every
+      # SME service CrashLoops on "failed to connect to NATS … i/o
+      # timeout" → the voucher/billing funnel back-half (#3376) is dead.
+      # Endpoints are healthy; the policy is the wall. #3376
+      - sme
 
 # ─── Upstream chart values (subchart key: vcluster) ────────────────
 # `helm dependency build` resolves the upstream loft-sh/vcluster


### PR DESCRIPTION
## Root cause (confirmed LIVE on hw133, deployment `40c4e17667b600eb`)

The voucher/billing funnel back-half (#3376) is dead at billing. Live diagnosis:

- `sme/billing`, `sme/domain`, `sme/tenant`, `sme/notification` all **CrashLoopBackOff** on the identical error:
  `failed to connect to NATS url=nats://nats-jetstream-x-nats-system-x-mgmt-vcluster.mgmt.svc.cluster.local:4222 error="dial tcp 10.96.26.27:4222: i/o timeout"`
- The synced NATS Service in `mgmt` has **healthy endpoints** (the 3 real NATS pods). It is not a wiring problem — it is a **policy wall**.
- `mgmt/mgmt-vcluster-bp-mgmt-vcluster-isolation` NetworkPolicy (`podSelector: {}` = every pod in mgmt, including the vCluster-synced NATS pods) allows ingress only from **dmz**, **flux-system**, and same-namespace.
- #3373 placement moved `nats-jetstream` **into** the MGMT vCluster. The host `sme` namespace runs the BSS services that use NATS as their event bus, and `sme` was never in the allow-list → every SME service times out → funnel dead.

## Fix

Add `sme` to `mgmtVcluster.networkPolicy.allowedIngressNamespaces` (additive — no other behaviour changes). Chart 0.2.8 → 0.2.9; slot-58 pin bumped to match.

Scope was verified against the **whole class**: alloy / opentelemetry / grafana (the other host→mgmt consumers) show **no** errors live (otel uses a debug exporter; alloy logs clean), so they are deliberately **not** added — only the proven-broken consumer namespace is.

## Acceptance (will be witnessed, not asserted)

After merge + Flux reconcile on a live env: the 4 SME pods reach Ready, and the marketplace voucher-redeem funnel back-half is re-walked in a browser to ✅ with a screenshot in the #3376 UAT section. PR-merge ≠ done.

Refs #3376