### PR TITLE
fix(console): #3378 org badge fidelity + enter-org gate + plans-table read

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1712,8 +1712,13 @@ func main() {
 		// on the in-cluster SME commerce catalog. NOT new business
 		// endpoints (§6) — the same mintSMEBridgeToken → smeCatalog proxy
 		// hop HandleSovereignAppPublish uses, generalized to full CRUD so
-		// console.<sovereign>/api/* can reach the admin paths. Reads use
-		// the existing public /catalog/{kind} list endpoints (SME gateway).
+		// console.<sovereign>/api/* can reach the admin paths. Reads proxy
+		// the EXISTING public /catalog/{kind} list endpoints through
+		// catalyst-api too (HandleSMECommerceList) — on the console host
+		// /api/catalog/* doesn't route to the catalog service the way the
+		// SME gateway does, so a bare GET /api/catalog/plans 404'd even
+		// though the plan existed (issue #3378 plans-table 404).
+		rg.Get("/api/v1/sme/commerce/{kind}", h.HandleSMECommerceList)
 		rg.Post("/api/v1/sme/commerce/{kind}", h.HandleSMECommerceCreate)
 		rg.Put("/api/v1/sme/commerce/{kind}/{id}", h.HandleSMECommerceUpdate)
 		rg.Delete("/api/v1/sme/commerce/{kind}/{id}", h.HandleSMECommerceDelete)

--- a/products/catalyst/bootstrap/api/internal/handler/sme_catalog_client.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_catalog_client.go
@@ -185,6 +185,44 @@ func (c *smeCatalogClient) SetPublished(ctx context.Context, slug string, publis
 	return resp.StatusCode, nil
 }
 
+// PublicProxy forwards a GET to the SME commerce catalog's PUBLIC list
+// endpoint ("<baseURL>/catalog/{sub}") and returns (status, body,
+// contentType, error). It is the read counterpart of AdminProxy for the
+// Organizations commerce editors (issue #3378 DoD 7/8): the editors read
+// the EXISTING public /catalog/{kind} list endpoints (no new business
+// endpoint, §6).
+//
+// On the Sovereign console (served at console.<sovereign>), /api/* proxies
+// through catalyst-api, which does NOT route /api/catalog/* to the catalog
+// service the way the SME/marketplace gateway does — so a bare
+// GET /api/catalog/plans 404s on the console host. Routing the console's
+// reads through catalyst-api (which CAN reach catalog.sme.svc) closes that
+// gap so the console plans/addons/bundles/industries/apps tables render the
+// same rows the marketplace storefront shows.
+//
+// The public list endpoints carry no auth (core/services/catalog/main.go
+// applies JWT only to /catalog/admin/*), so no bearer is sent.
+func (c *smeCatalogClient) PublicProxy(
+	ctx context.Context,
+	subPath string,
+) (int, []byte, string, error) {
+	sub := "/" + strings.TrimLeft(strings.TrimSpace(subPath), "/")
+	url := c.baseURL + "/catalog" + sub
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, nil, "", err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, nil, "", err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, respBody, resp.Header.Get("Content-Type"), nil
+}
+
 // AdminProxy forwards an arbitrary method + sub-path + JSON body to the
 // SME commerce catalog (services/catalog) and returns (status, body,
 // contentType, error). It is the generic transport for the Organizations

--- a/products/catalyst/bootstrap/api/internal/handler/sme_commerce.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_commerce.go
@@ -45,6 +45,46 @@ var commerceKinds = map[string]bool{
 	"apps":       true,
 }
 
+// HandleSMECommerceList — GET /api/v1/sme/commerce/{kind}.
+//
+// Reads the PUBLIC catalog list endpoint (/catalog/{kind}) through
+// catalyst-api so the Sovereign console's commerce tables render the rows
+// that exist in the catalog store. On the console host (console.<sovereign>)
+// /api/* proxies to catalyst-api, which — unlike the SME/marketplace
+// gateway — does not route /api/catalog/* to the catalog service, so the
+// console's old direct GET /api/catalog/plans 404'd even though the
+// storefront showed the plan. This read hop closes that gap (issue #3378
+// — the plans-table 404). No bearer: the catalog list endpoints are public.
+func (h *Handler) HandleSMECommerceList(w http.ResponseWriter, r *http.Request) {
+	kind := strings.ToLower(strings.TrimSpace(chi.URLParam(r, "kind")))
+	if !commerceKinds[kind] {
+		writeJSON(w, http.StatusNotFound, map[string]string{
+			"error":  "unknown-commerce-kind",
+			"detail": "kind must be one of plans, addons, bundles, industries, apps",
+		})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), smeCatalogProbeBudget)
+	defer cancel()
+	upstreamStatus, respBody, ct, err := smeCatalog().PublicProxy(ctx, "/"+kind)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "sme-catalog-unreachable",
+			"detail": err.Error(),
+		})
+		return
+	}
+	if ct == "" {
+		ct = "application/json"
+	}
+	w.Header().Set("Content-Type", ct)
+	w.WriteHeader(upstreamStatus)
+	if len(respBody) > 0 {
+		_, _ = w.Write(respBody)
+	}
+}
+
 // HandleSMECommerceCreate — POST /api/v1/sme/commerce/{kind}.
 func (h *Handler) HandleSMECommerceCreate(w http.ResponseWriter, r *http.Request) {
 	h.proxyCommerce(w, r, http.MethodPost, "")

--- a/products/catalyst/bootstrap/api/internal/handler/sme_commerce_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_commerce_test.go
@@ -75,6 +75,48 @@ func TestAdminProxy_ForwardsMethodPathBodyAndBearer(t *testing.T) {
 	}
 }
 
+// TestPublicProxy_ForwardsGetToPublicCatalogPath locks the read hop the
+// Sovereign console uses for its commerce tables (issue #3378 plans-table
+// 404): GET → "<base>/catalog/{kind}", no bearer, verbatim status+body
+// relay. This is the path that makes the console plans table render the
+// rows the storefront shows.
+func TestPublicProxy_ForwardsGetToPublicCatalogPath(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"id":"p-1","slug":"starter"}]`))
+	}))
+	defer upstream.Close()
+
+	c := &smeCatalogClient{baseURL: upstream.URL, http: upstream.Client()}
+	status, body, ct, err := c.PublicProxy(context.Background(), "/plans")
+	if err != nil {
+		t.Fatalf("PublicProxy: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Errorf("status: got %d want 200", status)
+	}
+	if string(body) != `[{"id":"p-1","slug":"starter"}]` {
+		t.Errorf("body relayed verbatim: got %q", body)
+	}
+	if ct != "application/json" {
+		t.Errorf("content-type relayed: got %q", ct)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("upstream method: got %q want GET", gotMethod)
+	}
+	if gotPath != "/catalog/plans" {
+		t.Errorf("upstream path: got %q want /catalog/plans", gotPath)
+	}
+	if gotAuth != "" {
+		t.Errorf("public read must not forward an Authorization header, got %q", gotAuth)
+	}
+}
+
 func TestAdminProxy_DeleteWithIDSubPathNoBody(t *testing.T) {
 	var gotMethod, gotPath string
 	hadBody := false

--- a/products/catalyst/bootstrap/ui/src/lib/bss.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/bss.api.ts
@@ -631,6 +631,18 @@ export interface Tenant {
   parentDomain: string
   /** Plan tier (free|pro|enterprise|...) — null until BE wires it. */
   plan: string | null
+  /**
+   * Organizations-model spec fields (issue #3378 B1). The orchestrator
+   * stamps these on the SMETenantProvisionRecord and the tenants feed
+   * surfaces them as kind / tier / billing_mode / isolation. Empty string
+   * when the record predates the B1 fields (older provisioning runs) — the
+   * Organizations directory then falls back to kind-derived defaults so a
+   * legacy row still badges sensibly rather than rendering blanks.
+   */
+  kind: string
+  tier: string
+  billingMode: string
+  isolation: string
   /** Lifecycle status normalized to the UI vocabulary. */
   status: TenantStatus
   /** Hetzner region key (fsn1 / hel1 / ...) — null until BE wires it. */
@@ -694,6 +706,13 @@ interface RawTenant {
   console_host?: string
   plan?: string
   region?: string
+  // Organizations-model spec fields (issue #3378 B1) — already emitted by
+  // smeTenantResponse (products/catalyst/bootstrap/api/internal/handler/
+  // sme_tenant.go:329-332). Optional so older payloads still parse.
+  kind?: string
+  tier?: string
+  billing_mode?: string
+  isolation?: string
   last_error?: string
   created_at?: string
   updated_at?: string
@@ -711,6 +730,10 @@ function mapTenant(raw: RawTenant): Tenant {
     subdomain,
     parentDomain,
     plan: raw.plan && raw.plan !== '' ? String(raw.plan) : null,
+    kind: String(raw.kind ?? '').trim(),
+    tier: String(raw.tier ?? '').trim(),
+    billingMode: String(raw.billing_mode ?? '').trim(),
+    isolation: String(raw.isolation ?? '').trim(),
     status: mapStateToStatus(String(raw.state ?? '')),
     region: raw.region && raw.region !== '' ? String(raw.region) : null,
     ownerEmail: String(raw.admin_email ?? ''),

--- a/products/catalyst/bootstrap/ui/src/lib/commerce.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/commerce.api.ts
@@ -4,9 +4,16 @@
  * apps, edited over the EXISTING endpoints (§6 — no new business
  * endpoint):
  *
- *   • READ  — the public catalog list endpoints via the SME gateway:
- *       GET /api/catalog/{plans,addons,bundles,industries,apps}
- *     (core/services/gateway/main.go:50-54, Public:true).
+ *   • READ  — the catalyst-api commerce read-proxy that forwards to the
+ *     public catalog list endpoints (sme_commerce.go HandleSMECommerceList
+ *     → /catalog/{kind}):
+ *       GET /api/v1/sme/commerce/{plans,addons,bundles,industries,apps}
+ *     Reads go through catalyst-api (not a bare /api/catalog/*) because the
+ *     Sovereign console host (console.<sovereign>) proxies /api/* to
+ *     catalyst-api, which — unlike the SME/marketplace gateway — does NOT
+ *     route /api/catalog/* to the catalog service. A bare GET
+ *     /api/catalog/plans therefore 404'd on the console even though the
+ *     storefront showed the plan (issue #3378 plans-table 404).
  *   • WRITE — the catalyst-api commerce proxy that forwards to the
  *     superadmin-JWT /catalog/admin/* endpoints (sme_commerce.go):
  *       POST   /api/v1/sme/commerce/{kind}
@@ -86,16 +93,19 @@ export interface CommerceApp {
 
 export type CommerceKind = 'plans' | 'addons' | 'bundles' | 'industries' | 'apps'
 
-/** API_BASE without the /api version suffix — commerce reads hit the
- *  public /api/catalog/* gateway path, writes hit /api/v1/sme/commerce/*. */
+/** API_BASE root — both commerce reads AND writes hit catalyst-api under
+ *  /api/v1/sme/commerce/*. Reads proxy the public /catalog/{kind} list;
+ *  writes proxy the superadmin-JWT /catalog/admin/* endpoints. (See the
+ *  file header for why reads must NOT use a bare /api/catalog/* path on the
+ *  Sovereign console host — issue #3378 plans-table 404.) */
 const apiRoot = `${BASE}api`
 
-/* ── Reads (public list endpoints) ─────────────────────────────────── */
+/* ── Reads (catalyst-api commerce read-proxy → public catalog list) ─── */
 
 async function readList<T>(kind: CommerceKind): Promise<T[]> {
   // apps must NOT pass ?published=true here — the editor lists EVERY app
   // (published + unpublished) so the operator can toggle either way.
-  const res = await authedFetch(`${apiRoot}/catalog/${kind}`, {
+  const res = await authedFetch(`${apiRoot}/v1/sme/commerce/${kind}`, {
     headers: { Accept: 'application/json' },
   })
   if (!res.ok) {

--- a/products/catalyst/bootstrap/ui/src/lib/organizations.api.test.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/organizations.api.test.ts
@@ -63,6 +63,10 @@ describe('subOrgRowFromTenant', () => {
     subdomain: 'acme',
     parentDomain: 'omani.homes',
     plan: 'pro',
+    kind: 'customer',
+    tier: 'sme',
+    billingMode: 'real',
+    isolation: 'vcluster',
     status: 'active',
     region: 'me-east-215-a',
     ownerEmail: 'owner@acme.example',
@@ -75,11 +79,61 @@ describe('subOrgRowFromTenant', () => {
     const row = subOrgRowFromTenant(tenant)
     expect(row.isParent).toBe(false)
     expect(row.kind).toBe('customer')
+    expect(row.tier).toBe('sme')
     expect(row.billingMode).toBe('real')
     expect(row.isolation).toBe('vcluster')
     expect(row.displayName).toBe('ACME Corp')
     expect(row.slug).toBe('acme')
     expect(row.ownerEmail).toBe('owner@acme.example')
     expect(row.status).toBe('active')
+  })
+
+  // #3378 badge-fidelity regression: an Internal org must badge Internal
+  // (showback + namespace), NOT the old hardcoded customer/real/vcluster.
+  it('maps an internal tenant to an internal/showback/namespace row', () => {
+    const row = subOrgRowFromTenant({
+      ...tenant,
+      id: 'tnt-internal',
+      orgName: 'Finance',
+      subdomain: 'finance',
+      kind: 'internal',
+      tier: 'corporate',
+      billingMode: 'showback',
+      isolation: 'namespace',
+    })
+    expect(row.kind).toBe('internal')
+    expect(row.tier).toBe('corporate')
+    expect(row.billingMode).toBe('showback')
+    expect(row.isolation).toBe('namespace')
+  })
+
+  // An internal org with a chargeback override round-trips that override
+  // (the advanced-view billing-mode pick), not the kind default.
+  it('honors an explicit billingMode override on an internal org', () => {
+    const row = subOrgRowFromTenant({
+      ...tenant,
+      kind: 'internal',
+      billingMode: 'chargeback',
+      isolation: 'namespace',
+    })
+    expect(row.kind).toBe('internal')
+    expect(row.billingMode).toBe('chargeback')
+  })
+
+  // Legacy rows that predate the B1 spec fields (empty kind/tier/billing/
+  // isolation) fall back to the kind-derived customer defaults so they
+  // still badge sensibly rather than rendering blanks.
+  it('falls back to customer defaults when spec fields are empty (legacy row)', () => {
+    const row = subOrgRowFromTenant({
+      ...tenant,
+      kind: '',
+      tier: '',
+      billingMode: '',
+      isolation: '',
+    })
+    expect(row.kind).toBe('customer')
+    expect(row.tier).toBe('sme')
+    expect(row.billingMode).toBe('real')
+    expect(row.isolation).toBe('vcluster')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/organizations.api.ts
@@ -147,23 +147,64 @@ export function parentRowFromSelf(self: SovereignSelf | null): OrgRow {
 }
 
 /**
+ * normalizeKind — coerce the tenants-feed `kind` string onto the OrgKind
+ * union. Anything that isn't the literal 'internal' (incl. empty/legacy
+ * rows) reads as 'customer' — the marketplace external door is the safe
+ * default for a row whose spec predates the B1 fields.
+ */
+function normalizeKind(raw: string | undefined): OrgKind {
+  return String(raw ?? '').trim().toLowerCase() === 'internal' ? 'internal' : 'customer'
+}
+
+/**
+ * normalizeTier — coerce the tenants-feed `tier` onto OrgTier. 'corporate'
+ * is honored verbatim; everything else (incl. empty) reads as 'sme'.
+ */
+function normalizeTier(raw: string | undefined): OrgTier {
+  return String(raw ?? '').trim().toLowerCase() === 'corporate' ? 'corporate' : 'sme'
+}
+
+/**
+ * normalizeBillingMode — coerce the tenants-feed `billing_mode` onto the
+ * OrgBillingMode union, falling back to the kind-derived default when the
+ * field is empty or unrecognized (legacy rows that predate B1).
+ */
+function normalizeBillingMode(raw: string | undefined, kind: OrgKind): OrgBillingMode {
+  const v = String(raw ?? '').trim().toLowerCase()
+  if (v === 'real' || v === 'chargeback' || v === 'showback') return v
+  return kindDefaults(kind).billingMode
+}
+
+/**
+ * normalizeIsolation — coerce the tenants-feed `isolation` onto the
+ * OrgIsolation union, falling back to the kind-derived default when empty
+ * or unrecognized.
+ */
+function normalizeIsolation(raw: string | undefined, kind: OrgKind): OrgIsolation {
+  const v = String(raw ?? '').trim().toLowerCase()
+  if (v === 'namespace' || v === 'vcluster') return v
+  return kindDefaults(kind).isolation
+}
+
+/**
  * subOrgRowFromTenant — map an existing Tenant (one Organization CR) to a
- * directory row. The tenants feed today is the customer path, so kind
- * defaults to 'customer' with the customer-derived isolation/billing
- * unless the feed later surfaces the real spec fields. tier defaults to
- * 'sme' (the customer tier).
+ * directory row. The tenants feed surfaces the real spec fields the
+ * orchestrator stamps (kind / tier / billing_mode / isolation, issue
+ * #3378 B1), so an Internal org badges Internal · showback · namespace —
+ * NOT the old hardcoded customer/real/vcluster. Rows whose spec predates
+ * the B1 fields (empty kind/tier/billing/isolation) fall back to the
+ * kind-derived defaults so a legacy customer row still badges sensibly.
  */
 export function subOrgRowFromTenant(t: Tenant): OrgRow {
-  const kind: OrgKind = 'customer'
-  const def = kindDefaults(kind)
+  const kind = normalizeKind(t.kind)
   return {
     id: t.id,
     slug: t.subdomain || t.orgName || t.id,
     displayName: t.orgName || t.subdomain || t.id,
     kind,
-    tier: 'sme',
-    billingMode: def.billingMode,
-    isolation: def.isolation,
+    tier: normalizeTier(t.tier),
+    billingMode: normalizeBillingMode(t.billingMode, kind),
+    isolation: normalizeIsolation(t.isolation, kind),
     status: t.status,
     isParent: false,
     ownerEmail: t.ownerEmail,

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/EnterOrgButton.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/EnterOrgButton.test.tsx
@@ -60,4 +60,19 @@ describe('EnterOrgButton — B2 support session (DoD 6)', () => {
     expect(await screen.findByTestId('enter-org-error')).toBeTruthy()
     expect(screen.getByTestId('enter-org-error').textContent).toContain('insufficient-role')
   })
+
+  // #3378 enter-org gap: a still-provisioning sub-org has no live console,
+  // so the button must be disabled (no blank-tab handover) with a clear
+  // "not live yet" state, NOT open a blank tab.
+  it('disables the button + explains when the org console is not live yet', () => {
+    const provisioning = { ...SUB, status: 'provisioning' as const }
+    const open = vi.fn()
+    render(<EnterOrgButton org={provisioning} onEnterOverride={vi.fn()} openOverride={open} />)
+    const btn = screen.getByTestId('enter-org-button') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+    expect(screen.getByTestId('enter-org-not-live').textContent).toContain('Console not live yet')
+    // clicking a disabled button must not mint/open anything
+    fireEvent.click(btn)
+    expect(open).not.toHaveBeenCalled()
+  })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/EnterOrgButton.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/organizations/EnterOrgButton.tsx
@@ -33,6 +33,35 @@ export function EnterOrgButton({ org, onEnterOverride, openOverride }: EnterOrgB
   // Defensive: never offer the support session for the parent (§5).
   if (org.isParent) return null
 
+  // The support session lands in the org's OWN console. That console only
+  // exists once the org's deployment is live — until then a handover URL
+  // would open a blank tab (the sub-org console isn't serving yet, the
+  // documented #3378 enter-org gap). Gate the button on a live org so the
+  // operator gets a clear "not live yet" state instead of a blank tab.
+  const live = org.status === 'active'
+  if (!live) {
+    return (
+      <div className="flex flex-col items-end gap-1" data-testid="enter-org-not-live">
+        <button
+          type="button"
+          data-testid="enter-org-button"
+          disabled
+          aria-disabled="true"
+          title="The org console isn’t live until provisioning finishes."
+          className="inline-flex items-center gap-1.5 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-dim)] opacity-60"
+        >
+          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M11 16l-4-4m0 0l4-4m-4 4h14M3 4v16" />
+          </svg>
+          Enter org
+        </button>
+        <span className="text-[10px] text-[var(--color-text-dim)]">
+          Console not live yet — {org.status}. Available once provisioning completes.
+        </span>
+      </div>
+    )
+  }
+
   async function onClick() {
     setBusy(true)
     setError(null)


### PR DESCRIPTION
## #3378 ORGANIZATIONS — three live failures from the hw133 walk (was 13 ✅ / 3 ❌)

### 1. Badge fidelity (the documented GAP)
`subOrgRowFromTenant` hardcoded **every** sub-org to `customer / sme / real / vcluster`, so a created **Internal** org mis-badged. The wire already surfaces the truth — `smeTenantResponse` emits `kind/tier/billing_mode/isolation` (`sme_tenant.go:329-332`), stamped by `resolveOrgShape` at create — but the FE list path dropped them.

- Thread `kind/tier/billingMode/isolation` through `RawTenant` → `Tenant` → `mapTenant` (`bss.api.ts`).
- `subOrgRowFromTenant` reads them, with kind-derived fallbacks **only** for legacy rows whose spec predates the B1 fields.
- An Internal org now badges **internal · showback · namespace**, an explicit override round-trips, and a legacy (empty-spec) row still badges sensibly.

### 2. Enter-org blank tab
The support session lands in the sub-org's **own** console, which only serves once the org deployment is live. For a still-provisioning sub-org the handover opened a **blank** tab. The button is now gated on `status === 'active'`: a not-yet-live org shows a disabled button + "Console not live yet — `<status>`" instead of opening a blank tab.

### 3. Plans-table 404
The console read hit a bare `/api/catalog/plans`, which on the console host (`console.<sovereign>`, where `/api/*` proxies to **catalyst-api**) does **not** route to the catalog service the way the SME/marketplace gateway does — so it 404'd even though the storefront showed the plan. Added a catalyst-api read-proxy `GET /api/v1/sme/commerce/{kind}` → public `/catalog/{kind}` (`HandleSMECommerceList` + `PublicProxy`, no bearer) and pointed `commerce.api.ts readList` at it. The console plans table now renders the same rows the storefront shows.

## Tests
- New `subOrgRowFromTenant` cases: internal badge, explicit override, legacy fallback.
- New `EnterOrgButton` not-live gate test (disabled + no open on click).
- New `PublicProxy` Go test (GET → `/catalog/{kind}`, no Authorization header).
- UI 143 passing · Go handler suite green · typecheck + eslint + go vet clean.

## What the walker should now see
- **Badge**: create an **Internal** org → it persists/displays **internal · corporate (or sme) · showback · namespace**, not customer/real/vcluster.
- **Enter-org**: a still-provisioning sub-org shows a disabled "Enter org" + "Console not live yet" (no blank tab); once the org is live the button mints the session and opens the handover.
- **Plans**: the console `Commerce · Plans` table lists the created plan(s) instead of `load plans: HTTP 404 / No plans yet`.

Refs #3378

🤖 Generated with [Claude Code](https://claude.com/claude-code)