### PR TITLE
feat(console): Topology tab declared-class + DR read-back for every app; enable Switchover for owner tier (Refs #3375)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,6 +1,58 @@
 {
-  "generatedAt": "2026-06-12T17:40:39.542Z",
+  "generatedAt": "2026-06-13T18:40:48.549Z",
   "blueprints": [
+    {
+      "id": "bp-alloy",
+      "slug": "alloy",
+      "title": "Alloy",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.1",
+      "section": "pts-3-observability",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "none",
+              "mode": "none",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
     {
       "id": "bp-anthropic-adapter",
       "slug": "anthropic-adapter",
@@ -17,7 +69,53 @@
         "bp-external-secrets"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-active",
+          "singleton"
+        ],
+        "multiRegion": "active-active",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-active": {
+            "replication": {
+              "backend": "none",
+              "mode": "none",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "none",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "active"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-bge",
@@ -35,7 +133,53 @@
         "bp-cnpg"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-active",
+          "singleton"
+        ],
+        "multiRegion": "active-active",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-active": {
+            "replication": {
+              "backend": "none",
+              "mode": "none",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "none",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "active"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-catalyst-platform",
@@ -57,7 +201,53 @@
         "bp-crossplane-claims"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-hot-standby",
+          "singleton"
+        ],
+        "multiRegion": "active-hot-standby",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-hot-standby": {
+            "replication": {
+              "backend": "cnpg-pair",
+              "mode": "sync",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 30,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B"
+              ],
+              "roles": {
+                "mgmt-A": "active",
+                "mgmt-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-cert-manager",
@@ -73,7 +263,43 @@
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "openbao-perf-replication",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-cert-manager-dynadot-webhook",
@@ -91,7 +317,39 @@
         "bp-cert-manager"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-cert-manager-powerdns-webhook",
@@ -109,7 +367,39 @@
         "bp-cert-manager"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-cilium",
@@ -121,11 +411,43 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-cilium-policies",
@@ -141,7 +463,43 @@
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "flux-git",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-clickhouse",
@@ -157,7 +515,101 @@
       "section": "pts-4-application-tier",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-active",
+          "singleton"
+        ],
+        "multiRegion": "active-active",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-active": {
+            "replication": {
+              "backend": "none",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "none",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "active"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-cluster-autoscaler-hcloud",
+      "slug": "cluster-autoscaler-hcloud",
+      "title": "Cluster Autoscaler (Hetzner)",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.3.0",
+      "section": "pts-3-2-scaling-and-resilience",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-cnpg",
@@ -175,7 +627,39 @@
         "bp-flux"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-cnpg-pair",
@@ -187,7 +671,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "section": "pts-9-disaster-recovery",
       "depends": [
         "bp-cnpg",
@@ -195,7 +679,91 @@
         "bp-cilium"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-hot-standby"
+        ],
+        "multiRegion": "active-hot-standby",
+        "singleRegion": "active-hot-standby",
+        "perTopology": {
+          "active-hot-standby": {
+            "replication": {
+              "backend": "cnpg-pair",
+              "mode": "sync",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 10,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "passive"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-coraza",
+      "slug": "coraza",
+      "title": "Coraza WAF (SPOA)",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.0",
+      "section": "pts-3-3-security-and-policy",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "flux-git",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-crossplane",
@@ -211,7 +779,43 @@
       "section": "pts-3-2-gitops-and-iac",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "flux-git",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-crossplane-claims",
@@ -229,7 +833,43 @@
         "bp-crossplane"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "flux-git",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-debezium",
@@ -245,7 +885,53 @@
       "section": "pts-4-application-tier",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "mirrormaker2",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-dmz-vcluster",
@@ -257,14 +943,42 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.2.5",
+      "version": "0.2.7",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [
         "bp-cilium",
         "bp-cert-manager"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "velero",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "dmz",
+              "clusters": [
+                "dmz-A",
+                "dmz-B"
+              ],
+              "roles": {
+                "dmz-A": "singleton",
+                "dmz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-external-dns",
@@ -280,7 +994,43 @@
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "none",
+              "mode": "none",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-external-secrets",
@@ -299,7 +1049,43 @@
         "bp-cert-manager"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "openbao-perf-replication",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-external-secrets-stores",
@@ -315,7 +1101,91 @@
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "flux-git",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-falco",
+      "slug": "falco",
+      "title": "Falco",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.1",
+      "section": "pts-3-3-security-and-policy",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-ferretdb",
@@ -331,7 +1201,53 @@
       "section": "pts-4-application-tier",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "cnpg-pair",
+              "mode": "sync",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 60,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-flink",
@@ -347,7 +1263,53 @@
       "section": "pts-4-application-tier",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "s3-bucket-replication",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-flux",
@@ -363,7 +1325,43 @@
       "section": "pts-3-2-gitops-and-iac",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "flux-git",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-gateway-api",
@@ -379,7 +1377,43 @@
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "flux-git",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-gitea",
@@ -391,11 +1425,119 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.31",
+      "version": "1.2.34",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-hot-standby",
+          "singleton"
+        ],
+        "multiRegion": "active-hot-standby",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-hot-standby": {
+            "replication": {
+              "backend": "cnpg-pair",
+              "mode": "sync",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 30,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B"
+              ],
+              "roles": {
+                "mgmt-A": "active",
+                "mgmt-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-grafana",
+      "slug": "grafana",
+      "title": "Grafana",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.12",
+      "section": "pts-3-observability",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-hot-standby",
+          "singleton"
+        ],
+        "multiRegion": "active-hot-standby",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-hot-standby": {
+            "replication": {
+              "backend": "cnpg-pair",
+              "mode": "sync",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 30,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B"
+              ],
+              "roles": {
+                "mgmt-A": "active",
+                "mgmt-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-guacamole",
@@ -407,7 +1549,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.4",
+      "version": "0.2.8",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [
         "bp-keycloak",
@@ -417,7 +1559,166 @@
         "bp-k8s-ws-proxy"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-hot-standby",
+          "singleton"
+        ],
+        "multiRegion": "active-hot-standby",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-hot-standby": {
+            "replication": {
+              "backend": "cnpg-pair",
+              "mode": "sync",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 30,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B"
+              ],
+              "roles": {
+                "mgmt-A": "active",
+                "mgmt-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-harbor",
+      "slug": "harbor",
+      "title": "Harbor",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.2.30",
+      "section": "pts-3-5-storage-and-data",
+      "depends": [
+        "bp-cnpg",
+        "bp-cert-manager"
+      ],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-hot-standby",
+          "singleton"
+        ],
+        "multiRegion": "active-hot-standby",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-hot-standby": {
+            "replication": {
+              "backend": "cnpg-pair",
+              "mode": "sync",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 30,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B"
+              ],
+              "roles": {
+                "mgmt-A": "active",
+                "mgmt-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-hcloud-ccm",
+      "slug": "hcloud-ccm",
+      "title": "Hetzner Cloud Controller Manager",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.0",
+      "section": "pts-3-1-cloud-integration",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-hcloud-csi",
@@ -433,7 +1734,39 @@
       "section": "pts-3-5-storage-and-data",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-iceberg",
@@ -449,7 +1782,53 @@
       "section": "pts-4-application-tier",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-active",
+          "singleton"
+        ],
+        "multiRegion": "active-active",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-active": {
+            "replication": {
+              "backend": "s3-bucket-replication",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "none",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "active"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-k8s-ws-proxy",
@@ -467,7 +1846,53 @@
         "bp-sealed-secrets"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "none",
+              "mode": "none",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 5,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B"
+              ],
+              "roles": {
+                "mgmt-A": "active",
+                "mgmt-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-keycloak",
@@ -479,11 +1904,57 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.4.26",
+      "version": "1.4.27",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-hot-standby",
+          "singleton"
+        ],
+        "multiRegion": "active-hot-standby",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-hot-standby": {
+            "replication": {
+              "backend": "cnpg-pair",
+              "mode": "sync",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 30,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B"
+              ],
+              "roles": {
+                "mgmt-A": "active",
+                "mgmt-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-knative",
@@ -502,7 +1973,53 @@
         "bp-cert-manager"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-active",
+          "singleton"
+        ],
+        "multiRegion": "active-active",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-active": {
+            "replication": {
+              "backend": "none",
+              "mode": "none",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "none",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "active"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-kserve",
@@ -522,7 +2039,219 @@
         "bp-knative"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-active",
+          "singleton"
+        ],
+        "multiRegion": "active-active",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-active": {
+            "replication": {
+              "backend": "none",
+              "mode": "none",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "none",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "active"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-kyverno",
+      "slug": "kyverno",
+      "title": "Kyverno",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.3.6",
+      "section": "pts-3-3-security-and-policy",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "flux-git",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-kyverno-policies",
+      "slug": "kyverno-policies",
+      "title": "Kyverno Policy Library",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.33",
+      "section": "pts-3-3-security-and-policy",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "flux-git",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-langfuse",
+      "slug": "langfuse",
+      "title": "Langfuse",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.1.0",
+      "section": "pts-3-observability",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "cnpg-pair",
+              "mode": "sync",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 60,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-librechat",
@@ -543,7 +2272,93 @@
         "bp-keycloak"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-active",
+          "singleton"
+        ],
+        "multiRegion": "active-active",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-active": {
+            "replication": {
+              "backend": "none",
+              "mode": "none",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "none",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "active"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-litmus",
+      "slug": "litmus",
+      "title": "LitmusChaos",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.0",
+      "section": "pts-3-3-security-and-policy",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-livekit",
@@ -563,7 +2378,53 @@
         "bp-valkey"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-active",
+          "singleton"
+        ],
+        "multiRegion": "active-active",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-active": {
+            "replication": {
+              "backend": "none",
+              "mode": "none",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "none",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "active"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-llm-gateway",
@@ -583,7 +2444,115 @@
         "bp-external-secrets"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-active",
+          "singleton"
+        ],
+        "multiRegion": "active-active",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-active": {
+            "replication": {
+              "backend": "none",
+              "mode": "none",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "none",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "active"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-loki",
+      "slug": "loki",
+      "title": "Loki",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.0",
+      "section": "pts-3-observability",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "s3-bucket-replication",
+              "mode": "async",
+              "lagSloSeconds": 60
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 60,
+              "rpoSeconds": 60
+            },
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B"
+              ],
+              "roles": {
+                "mgmt-A": "active",
+                "mgmt-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-matrix",
@@ -603,7 +2572,53 @@
         "bp-cert-manager"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "cnpg-pair",
+              "mode": "sync",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 60,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-mgmt-vcluster",
@@ -615,14 +2630,42 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.2.6",
+      "version": "0.2.8",
       "section": "pts-3-2-control-plane-isolation",
       "depends": [
         "bp-cilium",
         "bp-cert-manager"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "velero",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-milvus",
@@ -638,7 +2681,115 @@
       "section": "pts-4-application-tier",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "s3-bucket-replication",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-mimir",
+      "slug": "mimir",
+      "title": "Mimir",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.5",
+      "section": "pts-3-observability",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "s3-bucket-replication",
+              "mode": "async",
+              "lagSloSeconds": 60
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 60,
+              "rpoSeconds": 60
+            },
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B"
+              ],
+              "roles": {
+                "mgmt-A": "active",
+                "mgmt-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-nats-jetstream",
@@ -654,7 +2805,53 @@
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "raft",
+              "mode": "sync",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 30,
+              "rpoSeconds": 60
+            },
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B"
+              ],
+              "roles": {
+                "mgmt-A": "active",
+                "mgmt-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-nemo-guardrails",
@@ -672,7 +2869,53 @@
         "bp-vllm"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-active",
+          "singleton"
+        ],
+        "multiRegion": "active-active",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-active": {
+            "replication": {
+              "backend": "flux-git",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "none",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "active"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-neo4j",
@@ -688,7 +2931,53 @@
       "section": "pts-4-application-tier",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "velero",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "bp-velero-restore",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-netbird",
@@ -700,7 +2989,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [
         "bp-keycloak",
@@ -708,7 +2997,53 @@
         "bp-sealed-secrets"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-hot-standby",
+          "singleton"
+        ],
+        "multiRegion": "active-hot-standby",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-hot-standby": {
+            "replication": {
+              "backend": "cnpg-pair",
+              "mode": "sync",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 30,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B"
+              ],
+              "roles": {
+                "mgmt-A": "active",
+                "mgmt-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-network-policies",
@@ -726,7 +3061,43 @@
         "bp-cilium"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "flux-git",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-newapi",
@@ -738,7 +3109,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "1.4.63",
+      "version": "1.4.66",
       "section": "pts-4-6-llm-serving",
       "depends": [
         "bp-cnpg",
@@ -748,7 +3119,119 @@
         "bp-vllm"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "cnpg-pair",
+              "mode": "sync",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 30,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B"
+              ],
+              "roles": {
+                "mgmt-A": "active",
+                "mgmt-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-oidc-gate",
+      "slug": "oidc-gate",
+      "title": "oidc-gate",
+      "summary": "|",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "0.1.0",
+      "section": "pts-2-3-per-sovereign-supporting-services",
+      "depends": [
+        "bp-cilium",
+        "bp-keycloak",
+        "bp-external-secrets-stores"
+      ],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "none",
+              "mode": "none",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 30,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B"
+              ],
+              "roles": {
+                "mgmt-A": "active",
+                "mgmt-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-openbao",
@@ -760,11 +3243,57 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.28",
+      "version": "1.2.31",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "openbao-perf-replication",
+              "mode": "async",
+              "lagSloSeconds": 30
+            },
+            "switchover": {
+              "mechanism": "raft-transition",
+              "rtoSeconds": 60,
+              "rpoSeconds": 30
+            },
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B"
+              ],
+              "roles": {
+                "mgmt-A": "active",
+                "mgmt-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-openclaw",
@@ -784,7 +3313,29 @@
         "bp-cert-manager"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-openmeter",
@@ -804,7 +3355,53 @@
         "bp-cert-manager"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "cnpg-pair",
+              "mode": "sync",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 60,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-opensearch",
@@ -820,7 +3417,125 @@
       "section": "pts-4-application-tier",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-active",
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-active",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-active": {
+            "replication": {
+              "backend": "ccr",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "ccr-promote",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "active"
+              }
+            }
+          },
+          "active-passive": {
+            "replication": {
+              "backend": "ccr",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "ccr-promote",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-opentelemetry",
+      "slug": "opentelemetry",
+      "title": "OpenTelemetry Collector",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.2.1",
+      "section": "pts-3-observability",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-opentelemetry-operator",
@@ -839,7 +3554,39 @@
         "bp-cert-manager"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-postgres",
@@ -851,7 +3598,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-cnpg",
@@ -868,6 +3615,52 @@
         "produces": [
           "credentialSecret"
         ]
+      },
+      "topology": {
+        "supported": [
+          "singleton",
+          "active-hot-standby"
+        ],
+        "multiRegion": "active-hot-standby",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          },
+          "active-hot-standby": {
+            "replication": {
+              "backend": "cnpg-pair",
+              "mode": "sync",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 10,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "passive"
+              }
+            }
+          }
+        }
       }
     },
     {
@@ -880,13 +3673,45 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.12",
+      "version": "1.2.14",
       "section": "pts-3-2-gitops-and-iac",
       "depends": [
         "bp-cert-manager"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-powerdns-admin",
@@ -898,7 +3723,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-powerdns",
@@ -910,7 +3735,39 @@
         "bp-gateway-api"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-qa-app",
@@ -926,7 +3783,31 @@
       "section": "pts-qa",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-reflector",
@@ -942,7 +3823,91 @@
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "none",
+              "mode": "none",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-reloader",
+      "slug": "reloader",
+      "title": "Reloader",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.0",
+      "section": "pts-3-3-security-and-policy",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-rtz-vcluster",
@@ -954,14 +3919,42 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.2.6",
+      "version": "0.2.8",
       "section": "pts-3-2-control-plane-isolation",
       "depends": [
         "bp-cilium",
         "bp-cert-manager"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "velero",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-sandbox",
@@ -982,7 +3975,53 @@
         "bp-harbor"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-hot-standby",
+          "singleton"
+        ],
+        "multiRegion": "active-hot-standby",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-hot-standby": {
+            "replication": {
+              "backend": "none",
+              "mode": "async",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 30,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-sealed-secrets",
@@ -998,7 +4037,93 @@
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-seaweedfs",
+      "slug": "seaweedfs",
+      "title": "SeaweedFS",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.2.1",
+      "section": "pts-3-5-storage-and-data",
+      "depends": [
+        "bp-cert-manager"
+      ],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "filer-remote-storage",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-self-sovereign-cutover",
@@ -1017,7 +4142,81 @@
         "bp-harbor"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "none",
+              "mode": "none",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-sigstore",
+      "slug": "sigstore",
+      "title": "Sigstore Policy Controller",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.0",
+      "section": "pts-3-3-security-and-policy",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-spire",
@@ -1033,7 +4232,53 @@
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-hot-standby",
+          "singleton"
+        ],
+        "multiRegion": "active-hot-standby",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-hot-standby": {
+            "replication": {
+              "backend": "cnpg-pair",
+              "mode": "sync",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 30,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B"
+              ],
+              "roles": {
+                "mgmt-A": "active",
+                "mgmt-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-sso-bridge",
@@ -1053,7 +4298,53 @@
         "bp-external-secrets-stores"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "none",
+              "mode": "none",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 30,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B"
+              ],
+              "roles": {
+                "mgmt-A": "active",
+                "mgmt-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-stalwart-sovereign",
@@ -1073,7 +4364,25 @@
         "bp-powerdns"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [],
+              "roles": {}
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-stalwart-tenant",
@@ -1094,7 +4403,53 @@
         "bp-powerdns"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "cnpg-pair",
+              "mode": "sync",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 60,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-strimzi",
@@ -1110,7 +4465,77 @@
       "section": "pts-4-application-tier",
       "depends": [],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-active",
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-active",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-active": {
+            "replication": {
+              "backend": "mirrormaker2",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "mm2-symmetric",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "active"
+              }
+            }
+          },
+          "active-passive": {
+            "replication": {
+              "backend": "mirrormaker2",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "mm2-symmetric",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-stunner",
@@ -1129,7 +4554,163 @@
         "bp-cert-manager"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-active",
+          "singleton"
+        ],
+        "multiRegion": "active-active",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-active": {
+            "replication": {
+              "backend": "none",
+              "mode": "none",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "none",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "active"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-syft-grype",
+      "slug": "syft-grype",
+      "title": "Syft + Grype",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.0",
+      "section": "pts-3-3-security-and-policy",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-tempo",
+      "slug": "tempo",
+      "title": "Tempo",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.0",
+      "section": "pts-3-observability",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "s3-bucket-replication",
+              "mode": "async",
+              "lagSloSeconds": 60
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 60,
+              "rpoSeconds": 60
+            },
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B"
+              ],
+              "roles": {
+                "mgmt-A": "active",
+                "mgmt-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "mgmt",
+              "clusters": [
+                "mgmt-A"
+              ],
+              "roles": {
+                "mgmt-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-temporal",
@@ -1148,7 +4729,101 @@
         "bp-cert-manager"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "cnpg-pair",
+              "mode": "sync",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 60,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-trivy",
+      "slug": "trivy",
+      "title": "Trivy",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.3",
+      "section": "pts-3-3-security-and-policy",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-valkey",
@@ -1160,7 +4835,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-flux"
@@ -1176,6 +4851,52 @@
         "produces": [
           "credentialSecret"
         ]
+      },
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "sentinel",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "sentinel-failover",
+              "rtoSeconds": 30,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
       }
     },
     {
@@ -1194,7 +4915,143 @@
         "bp-flux"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-velero",
+      "slug": "velero",
+      "title": "Velero",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.2.2",
+      "section": "pts-3-observability",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "s3-bucket-replication",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-velero-hcs",
+      "slug": "velero-hcs",
+      "title": "Velero (HCS)",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "0.1.1",
+      "section": "pts-3-observability",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "s3-bucket-replication",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-vllm",
@@ -1212,7 +5069,101 @@
         "bp-kserve"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-active",
+          "singleton"
+        ],
+        "multiRegion": "active-active",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-active": {
+            "replication": {
+              "backend": "none",
+              "mode": "none",
+              "lagSloSeconds": null
+            },
+            "switchover": {
+              "mechanism": "none",
+              "rtoSeconds": null,
+              "rpoSeconds": null
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "active"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "bp-vpa",
+      "slug": "vpa",
+      "title": "Vertical Pod Autoscaler",
+      "summary": "",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.1",
+      "section": "pts-3-3-security-and-policy",
+      "depends": [],
+      "shareable": false,
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      }
     },
     {
       "id": "bp-wordpress-tenant",
@@ -1234,7 +5185,53 @@
         "bp-cert-manager"
       ],
       "shareable": false,
-      "contextSchema": null
+      "contextSchema": null,
+      "topology": {
+        "supported": [
+          "active-passive",
+          "singleton"
+        ],
+        "multiRegion": "active-passive",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "active-passive": {
+            "replication": {
+              "backend": "cnpg-pair",
+              "mode": "sync",
+              "lagSloSeconds": 0
+            },
+            "switchover": {
+              "mechanism": "bp-continuum",
+              "rtoSeconds": 60,
+              "rpoSeconds": 0
+            },
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "rtz-A": "active",
+                "rtz-B": "passive"
+              }
+            }
+          },
+          "singleton": {
+            "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "rtz",
+              "clusters": [
+                "rtz-A"
+              ],
+              "roles": {
+                "rtz-A": "singleton"
+              }
+            }
+          }
+        }
+      }
     }
   ],
   "bootstrapKit": [

--- a/products/catalyst/bootstrap/api/internal/catalog/catalog.go
+++ b/products/catalyst/bootstrap/api/internal/catalog/catalog.go
@@ -81,6 +81,51 @@ type Blueprint struct {
 	// Blueprints (nil otherwise). Every generic console surface
 	// (catalog badge, Contexts tab, reuse selector) renders from this.
 	ContextSchema *ContextSchema `json:"contextSchema"`
+
+	// Topology (#3375) — the declared topology + DR contract lifted from
+	// the Blueprint's spec.topology (the source docs/topology-matrix.md
+	// promotes). nil when the Blueprint ships no topology block. The
+	// console reads this back per-app on the Topology tab; the catalyst-api
+	// can surface it on the application-status endpoint so the read-back
+	// works for chroot-installed apps with no wizard-store entry.
+	Topology *Topology `json:"topology,omitempty"`
+}
+
+// Topology (#3375) is the per-Blueprint topology declaration. Mirrors the
+// BlueprintTopology TS shape emitted by build-catalog.mjs verbatim.
+type Topology struct {
+	Supported    []string                   `json:"supported"`
+	MultiRegion  *string                    `json:"multiRegion"`
+	SingleRegion *string                    `json:"singleRegion"`
+	PerTopology  map[string]TopologyVariant `json:"perTopology"`
+}
+
+// TopologyVariant is the DR contract for one declared variant.
+type TopologyVariant struct {
+	Replication *TopologyReplication `json:"replication"`
+	Switchover  *TopologySwitchover  `json:"switchover"`
+	Placement   *TopologyPlacement   `json:"placement"`
+}
+
+// TopologyReplication is the state-preservation backend for a variant.
+type TopologyReplication struct {
+	Backend       *string `json:"backend"`
+	Mode          *string `json:"mode"`
+	LagSloSeconds *int    `json:"lagSloSeconds"`
+}
+
+// TopologySwitchover is the promotion mechanism + RTO/RPO for a variant.
+type TopologySwitchover struct {
+	Mechanism  *string `json:"mechanism"`
+	RtoSeconds *int    `json:"rtoSeconds"`
+	RpoSeconds *int    `json:"rpoSeconds"`
+}
+
+// TopologyPlacement is the tier + per-cluster role map for a variant.
+type TopologyPlacement struct {
+	Tier     *string           `json:"tier"`
+	Clusters []string          `json:"clusters"`
+	Roles    map[string]string `json:"roles"`
 }
 
 // ContextSchema (#3370) describes what a Context is for a shareable

--- a/products/catalyst/bootstrap/ui/scripts/build-catalog.mjs
+++ b/products/catalyst/bootstrap/ui/scripts/build-catalog.mjs
@@ -25,7 +25,7 @@
 // §3 Phase 3) reuses the same card surface across products.
 
 import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
+import { basename, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -204,6 +204,99 @@ function parseScalar(s) {
   return s
 }
 
+/**
+ * #3375 — Topology declaration extraction.
+ *
+ * Every blueprint.yaml carries `spec.topology` (the G117 shape promoted
+ * into docs/topology-matrix.md — the agreement is the law). The tiny YAML
+ * reader above parses the nested objects, but inline flow arrays
+ * (`clusters: [mgmt-A, mgmt-B]`) come through `parseScalar` as the raw
+ * bracketed string. `parseInlineArray` normalises those.
+ *
+ * The console's AppDetail Topology tab READS BACK this declaration for
+ * EVERY installed app (the §1 acceptance of #3375): topology class, DR
+ * mechanism (replication backend/mode + switchover mechanism + RTO/RPO),
+ * and per-cluster placement roles (mgmt-A active / mgmt-B passive, …).
+ * Sourced here so the read-back has the SAME source the matrix promotes
+ * — never invented, never hardcoded (INVIOLABLE-PRINCIPLES.md #4).
+ */
+function parseInlineArray(v) {
+  if (Array.isArray(v)) return v.filter((x) => x != null && x !== '')
+  if (typeof v !== 'string') return []
+  const s = v.trim()
+  if (s.startsWith('[') && s.endsWith(']')) {
+    const inner = s.slice(1, -1).trim()
+    if (inner === '') return []
+    return inner
+      .split(',')
+      .map((p) => parseScalar(p.trim()))
+      .filter((x) => x != null && x !== '')
+  }
+  // A lone scalar promotes to a single-element list.
+  return [parseScalar(s)]
+}
+
+/**
+ * extractTopology turns the parsed `spec.topology` object into the typed
+ * shape the console reads back. Returns null when the Blueprint declares
+ * no topology block (older scaffolds), so the consumer can fall back to a
+ * neutral "singleton" render rather than asserting a class it never declared.
+ */
+function extractTopology(topoRaw) {
+  if (!topoRaw || typeof topoRaw !== 'object' || Array.isArray(topoRaw)) return null
+
+  const supported = parseInlineArray(topoRaw.supported).map(String)
+  const defaults = topoRaw.defaults && typeof topoRaw.defaults === 'object' ? topoRaw.defaults : {}
+  const multiRegion =
+    typeof defaults['multi-region'] === 'string' ? defaults['multi-region'] : null
+  const singleRegion =
+    typeof defaults['single-region'] === 'string' ? defaults['single-region'] : null
+
+  // perTopology: { <variant>: { replication{backend,mode,lagSloSeconds},
+  //   switchover{mechanism,rtoSeconds,rpoSeconds}, placement{tier,clusters[],roles{}} } }
+  const perTopologyRaw =
+    topoRaw.perTopology && typeof topoRaw.perTopology === 'object' && !Array.isArray(topoRaw.perTopology)
+      ? topoRaw.perTopology
+      : {}
+  const perTopology = {}
+  for (const [variant, vRaw] of Object.entries(perTopologyRaw)) {
+    if (!vRaw || typeof vRaw !== 'object') continue
+    const repl = vRaw.replication && typeof vRaw.replication === 'object' ? vRaw.replication : null
+    const sw = vRaw.switchover && typeof vRaw.switchover === 'object' ? vRaw.switchover : null
+    const pl = vRaw.placement && typeof vRaw.placement === 'object' ? vRaw.placement : null
+    const roles =
+      pl && pl.roles && typeof pl.roles === 'object' && !Array.isArray(pl.roles)
+        ? Object.fromEntries(Object.entries(pl.roles).map(([k, v]) => [k, String(v)]))
+        : {}
+    perTopology[variant] = {
+      replication: repl
+        ? {
+            backend: typeof repl.backend === 'string' ? repl.backend : null,
+            mode: typeof repl.mode === 'string' ? repl.mode : null,
+            lagSloSeconds: typeof repl.lagSloSeconds === 'number' ? repl.lagSloSeconds : null,
+          }
+        : null,
+      switchover: sw
+        ? {
+            mechanism: typeof sw.mechanism === 'string' ? sw.mechanism : null,
+            rtoSeconds: typeof sw.rtoSeconds === 'number' ? sw.rtoSeconds : null,
+            rpoSeconds: typeof sw.rpoSeconds === 'number' ? sw.rpoSeconds : null,
+          }
+        : null,
+      placement: pl
+        ? {
+            tier: typeof pl.tier === 'string' ? pl.tier : null,
+            clusters: parseInlineArray(pl.clusters).map(String),
+            roles,
+          }
+        : null,
+    }
+  }
+
+  if (supported.length === 0 && Object.keys(perTopology).length === 0) return null
+  return { supported, multiRegion, singleRegion, perTopology }
+}
+
 function listBlueprintFiles(dir) {
   if (!existsSync(dir)) return []
   const out = []
@@ -234,11 +327,28 @@ function buildCatalog() {
     const meta = parsed?.metadata ?? {}
     const spec = parsed?.spec ?? {}
     const card = spec?.card ?? {}
-    const name = meta?.name
+    const rawName = meta?.name
     const visibility = spec?.visibility ?? 'unlisted'
 
-    if (!name || typeof name !== 'string' || !name.startsWith('bp-')) {
-      skipped.push({ file, reason: `missing or invalid metadata.name (must be bp-<name>): ${name}` })
+    // #3375 — canonical id derivation. The contract is `bp-<folder>`. Many
+    // bootstrap blueprints (harbor, grafana, loki, tempo, trivy, velero, …)
+    // declare `metadata.name: <folder>` WITHOUT the `bp-` prefix — they
+    // install fine (the HR name is `bp-<folder>`) but the old hard
+    // `startsWith('bp-')` gate dropped them from the catalog ENTIRELY, so
+    // their AppDetail page never had a catalog entry and their Topology tab
+    // could not read back a declared class. The folder name IS the canonical
+    // slug (it matches the bootstrap-kit NN-<name>.yaml derivation), so when
+    // metadata.name is present but un-prefixed we derive `bp-<folder>` and
+    // keep going. Genuinely-missing / non-string names are still skipped.
+    const folderSlug = basename(dirname(file)).replace(/^bp-/, '')
+    let name
+    if (typeof rawName === 'string' && rawName.startsWith('bp-')) {
+      name = rawName
+    } else if (typeof rawName === 'string' && rawName.trim() !== '' && rawName.replace(/^bp-/, '') === folderSlug) {
+      // Un-prefixed name that matches the folder — derive the canonical id.
+      name = `bp-${folderSlug}`
+    } else {
+      skipped.push({ file, reason: `missing or invalid metadata.name (must be bp-<name> or match folder): ${rawName}` })
       continue
     }
 
@@ -280,6 +390,10 @@ function buildCatalog() {
         : [],
       shareable: spec.shareable === true,
       contextSchema,
+      // #3375 — declared topology + DR contract (read back by the
+      // AppDetail Topology tab for EVERY app). null when the Blueprint
+      // ships no `spec.topology` block.
+      topology: extractTopology(spec.topology),
     })
   }
 
@@ -389,6 +503,15 @@ export interface BlueprintCardEntry {
   shareable: boolean
   /** #3370 — the Context declaration (null when not shareable). */
   contextSchema: BlueprintContextSchema | null
+  /**
+   * #3375 — declared topology + DR contract, lifted verbatim from the
+   * Blueprint's \`spec.topology\` (the same source docs/topology-matrix.md
+   * promotes). Read back by the AppDetail Topology tab for every app so
+   * the operator sees the app's real declared class + DR mechanism +
+   * per-cluster placement — not a blank editor. null when the Blueprint
+   * ships no topology block.
+   */
+  topology: BlueprintTopology | null
 }
 
 /**
@@ -403,6 +526,39 @@ export interface BlueprintContextSchema {
   valuesKey: string
   needs: string[]
   produces: string[]
+}
+
+/**
+ * #3375 — the per-Blueprint topology declaration the console reads back.
+ *
+ *   supported       — declared topology variants (e.g. [active-hot-standby, singleton])
+ *   multiRegion     — defaults.multi-region (the class a 2-region Sovereign picks)
+ *   singleRegion    — defaults.single-region (the class a 1-region Sovereign picks)
+ *   perTopology     — DR contract per variant (replication + switchover + placement roles)
+ */
+export interface BlueprintTopology {
+  supported: string[]
+  multiRegion: string | null
+  singleRegion: string | null
+  perTopology: Record<string, BlueprintTopologyVariant>
+}
+
+export interface BlueprintTopologyVariant {
+  replication: {
+    backend: string | null
+    mode: string | null
+    lagSloSeconds: number | null
+  } | null
+  switchover: {
+    mechanism: string | null
+    rtoSeconds: number | null
+    rpoSeconds: number | null
+  } | null
+  placement: {
+    tier: string | null
+    clusters: string[]
+    roles: Record<string, string>
+  } | null
 }
 
 /**
@@ -425,6 +581,19 @@ export const LISTED_CATEGORIES: readonly string[] = Array.from(
 /** Lookup: id → entry. */
 export const BLUEPRINT_BY_ID: Readonly<Record<string, BlueprintCardEntry>> = Object.fromEntries(
   ALL_BLUEPRINTS.map(b => [b.id, b])
+)
+
+/**
+ * #3375 — Lookup: blueprint id → declared topology (null when the
+ * Blueprint ships no topology block). The AppDetail Topology tab resolves
+ * an app's matrix-declared class + DR mechanism + per-cluster roles from
+ * here, keyed on either the \`bp-<name>\` id or the bare slug.
+ */
+export const TOPOLOGY_BY_ID: Readonly<Record<string, BlueprintTopology>> = Object.fromEntries(
+  ALL_BLUEPRINTS.filter(b => b.topology != null).flatMap(b => {
+    const t = b.topology as BlueprintTopology
+    return [[b.id, t], [b.slug, t]]
+  })
 )
 
 /** Source files this catalog was built from (for diagnostics / CI logs). */

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
@@ -50,6 +50,7 @@ import { deriveJobs } from './jobs'
 import { adaptDerivedJobsToFlat } from './jobsAdapter'
 import { findComponent } from '@/pages/wizard/steps/componentGroups'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+import { useSession } from '@/shared/lib/useSession'
 import { API_BASE } from '@/shared/config/urls'
 import type { ApplicationStatus } from './eventReducer'
 import {
@@ -117,6 +118,24 @@ export function AppDetail({ disableStream = false }: AppDetailProps = {}) {
   const componentId = params.componentId ?? ''
   const urlTab = params.tab
   const store = useWizardStore()
+
+  // #3375 — the operator's Catalyst tier, used to enable the DR Switchover
+  // control on the Topology tab for the owner/admin tier (the prior bug:
+  // callerTier was never threaded → the button was permanently disabled
+  // "Owner tier required"). Prefer the explicit `tier` claim; fall back to
+  // deriving it from the catalyst-<tier> realm roles whoami also returns —
+  // so a session that carries only realm roles still resolves correctly.
+  const session = useSession()
+  const callerTier = useMemo(() => {
+    if (session.tier) return session.tier
+    const roles = session.roles.map((r) => r.toLowerCase())
+    if (roles.includes('catalyst-owner')) return 'owner'
+    if (roles.includes('catalyst-admin')) return 'admin'
+    if (roles.includes('catalyst-operator')) return 'operator'
+    if (roles.includes('catalyst-developer')) return 'developer'
+    if (roles.includes('catalyst-viewer')) return 'viewer'
+    return ''
+  }, [session.tier, session.roles])
 
   const applications = useMemo(
     () => resolveApplications(store.selectedComponents),
@@ -716,6 +735,7 @@ export function AppDetail({ disableStream = false }: AppDetailProps = {}) {
               sovereignId={deploymentId}
               applicationName={componentId}
               namespace={appNamespace}
+              callerTier={callerTier}
             />
           </div>
         ) : appTab === 'resources' ? (

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -30,6 +30,63 @@ import {
 import { getHierarchicalInfrastructure } from '@/lib/infrastructure.types'
 import { TopologyEditor } from '@/widgets/topology/TopologyEditor'
 import { DRSection } from '@/widgets/continuum/DRSection'
+import {
+  TOPOLOGY_BY_ID,
+  type BlueprintTopology,
+  type BlueprintTopologyVariant,
+} from '@/shared/constants/catalog.generated'
+
+/**
+ * #3375 — topology-class vocabulary normaliser.
+ *
+ * The matrix / blueprint.yaml declare classes with hyphens
+ * (`active-hot-standby`); the placement EDITOR + the live Application CR
+ * carry the editor vocab (`active-hotstandby`, `single-region`). Map both
+ * dialects onto one canonical token so the read-back, the editor's
+ * current-mode highlight, and the DR-section gate all agree.
+ */
+function canonicalTopologyClass(raw: string | null | undefined): string {
+  const s = (raw ?? '').trim().toLowerCase()
+  switch (s) {
+    case 'active-hot-standby':
+    case 'active-hotstandby':
+    case 'active_hot_standby':
+      return 'active-hot-standby'
+    case 'active-passive':
+    case 'active_passive':
+      return 'active-passive'
+    case 'active-active':
+    case 'active_active':
+      return 'active-active'
+    case 'singleton':
+    case 'single-region':
+    case 'single_region':
+      return 'singleton'
+    default:
+      return s || 'singleton'
+  }
+}
+
+/** Human one-liner per canonical class. */
+function describeTopologyClass(klass: string): string {
+  switch (klass) {
+    case 'active-hot-standby':
+      return 'Primary serves; a synchronous hot standby in the second region is ready for near-zero-RTO switchover.'
+    case 'active-passive':
+      return 'Primary serves; a warm standby in the second region promotes on failure (some replication lag).'
+    case 'active-active':
+      return 'Both regions serve live traffic; data syncs between them.'
+    case 'singleton':
+      return 'One instance in one region; no cross-region failover (cluster-local or stateless).'
+    default:
+      return ''
+  }
+}
+
+/** Whether a declared class carries a cross-region DR contract. */
+function isDRCapableClass(klass: string): boolean {
+  return klass === 'active-hot-standby' || klass === 'active-passive' || klass === 'active-active'
+}
 
 export interface TopologyTabProps {
   /** Sovereign id (deploymentId on chroot, mother). */
@@ -157,12 +214,89 @@ export function TopologyTab({
     return Array.from(set).sort()
   }, [currentRegions, infraQ.data])
 
+  // Is the Sovereign genuinely multi-region? On a 2-region prov the
+  // cross-region default class applies; on a single-region prov every app
+  // falls back to its single-region default. Counts distinct *physical*
+  // regions from the infra topology (the kom4dc 2-VPC mimic still surfaces
+  // two region nodes), and treats the app's own region set as a floor.
+  const sovereignRegionCount = useMemo(() => {
+    const fromInfra = infraQ.data?.topology?.regions?.length ?? 0
+    return Math.max(fromInfra, currentRegions.length)
+  }, [infraQ.data, currentRegions])
+  const isMultiRegion = sovereignRegionCount > 1
+
+  // #3375 — the app's DECLARED topology, lifted from its blueprint.yaml
+  // spec.topology (the same source docs/topology-matrix.md promotes). Keyed
+  // on either the `bp-<name>` id or the bare slug — applicationName is the
+  // componentId, which is one of those on every route.
+  const declaredTopology: BlueprintTopology | undefined = useMemo(() => {
+    const key = (applicationName ?? '').trim()
+    if (!key) return undefined
+    return TOPOLOGY_BY_ID[key] ?? TOPOLOGY_BY_ID[key.replace(/^bp-/, '')] ?? TOPOLOGY_BY_ID[`bp-${key}`]
+  }, [applicationName])
+
+  // The class this Sovereign WILL run the app as: the multi-region default
+  // on a 2-region prov, else the single-region default — exactly the choice
+  // the TopologyPicker + the fan-out controller make. Canonicalised so it
+  // matches both dialects.
+  const declaredClass = useMemo(() => {
+    if (!declaredTopology) return 'singleton'
+    const pick = isMultiRegion
+      ? declaredTopology.multiRegion ?? declaredTopology.singleRegion ?? declaredTopology.supported[0]
+      : declaredTopology.singleRegion ?? declaredTopology.supported[0]
+    return canonicalTopologyClass(pick)
+  }, [declaredTopology, isMultiRegion])
+
+  // The DR contract variant for the declared class (perTopology entry).
+  // perTopology keys use the hyphenated dialect; match canonically.
+  const declaredVariant: BlueprintTopologyVariant | undefined = useMemo(() => {
+    if (!declaredTopology) return undefined
+    for (const [variant, contract] of Object.entries(declaredTopology.perTopology)) {
+      if (canonicalTopologyClass(variant) === declaredClass) return contract
+    }
+    return undefined
+  }, [declaredTopology, declaredClass])
+
+  // The live placement the Application CR / status reports (editor dialect).
+  const liveClass = useMemo(() => canonicalTopologyClass(currentMode), [currentMode])
+
+  // The class the DR section + region-kill walk operate on. Prefer the live
+  // CR placement when it reports a DR-capable class (the CR is the running
+  // truth); otherwise fall back to the DECLARED class so bootstrap-kit apps
+  // with no Application CR (gitea/harbor/openbao/grafana/keycloak install as
+  // bare HelmReleases — getApplicationStatus returns nothing) still surface
+  // the DR panel that the matrix asserts. Never invents a class the app
+  // doesn't declare.
+  const effectiveDRClass = useMemo(() => {
+    if (isDRCapableClass(liveClass)) return liveClass
+    return declaredClass
+  }, [liveClass, declaredClass])
+  const showDR = isDRCapableClass(effectiveDRClass)
+
   useEffect(() => {
     // When initialApp updates, just trigger no-op so consumers re-derive.
   }, [initialApp])
 
   return (
     <div className="topology-tab" data-testid="app-topology-tabpanel">
+      {/* #3375 — DECLARED topology read-back. The §1 acceptance: every app
+          shows its real declared class + DR mechanism + per-cluster
+          placement (from blueprint.yaml spec.topology), not a blank editor.
+          Rendered first, above the editor, so the operator reads the
+          ground-truth before touching the placement controls. */}
+      <DeclaredTopologyPanel
+        applicationName={applicationName}
+        declaredTopology={declaredTopology}
+        declaredClass={declaredClass}
+        declaredVariant={declaredVariant}
+        liveClass={liveClass}
+        isMultiRegion={isMultiRegion}
+        sovereignRegionCount={sovereignRegionCount}
+      />
+
+      <h3 className="mt-6 mb-2 text-sm font-medium text-[var(--color-text-strong)]">
+        Change placement
+      </h3>
       <p className="mb-3 text-xs text-[var(--color-text-dim)]">
         Edit the placement mode and region set for{' '}
         <code className="font-mono text-[var(--color-text)]">{applicationName}</code>. Apply
@@ -234,7 +368,7 @@ export function TopologyTab({
         <div className="mt-3 grid grid-cols-2 gap-3 text-xs text-[var(--color-text-dim)]">
           <div data-testid="topology-tab-replication-lag">
             <strong className="text-[var(--color-text)]">Replication lag</strong>:{' '}
-            {currentMode === 'active-hotstandby' ? '—' : 'n/a (mode)'}
+            {effectiveDRClass === 'active-hot-standby' ? '—' : 'n/a (mode)'}
           </div>
           <div data-testid="topology-tab-last-switchover">
             <strong className="text-[var(--color-text)]">Last switchover</strong>:{' '}
@@ -245,20 +379,228 @@ export function TopologyTab({
         </div>
       </div>
 
-      {/* EPIC-6 Slice U-DR-1 (#1101) — DR section. Visible only when
-          the Application's placement is active-hotstandby. Composes the
-          live Continuum status, switchover button, failback panel, and
-          switchover history. */}
-      {currentMode === 'active-hotstandby' ? (
+      {/* EPIC-6 Slice U-DR-1 (#1101) + #3375 — DR section. Renders whenever
+          the app's EFFECTIVE class is DR-capable (active-hot-standby /
+          active-passive / active-active) — taken from the live Application
+          CR when it reports one, else from the DECLARED class so bootstrap-
+          kit apps (gitea/harbor/openbao/grafana/keycloak — bare HelmReleases
+          with no Application CR) still surface the Switchover control the
+          matrix asserts. Composes the live Continuum status, switchover
+          button, failback panel, and switchover history. */}
+      {showDR ? (
         <DRSection
           sovereignId={sovereignId}
           continuumName={continuumName ?? `dr-${applicationName}`}
           applicationName={applicationName}
           namespace={namespace}
           callerTier={callerTier}
+          declaredClass={effectiveDRClass}
+          switchoverMechanism={declaredVariant?.switchover?.mechanism ?? null}
           disableNetwork={disableNetwork}
         />
       ) : null}
     </div>
+  )
+}
+
+/* ─── Declared-topology read-back panel (#3375) ──────────────────────── */
+
+interface DeclaredTopologyPanelProps {
+  applicationName: string
+  declaredTopology: BlueprintTopology | undefined
+  declaredClass: string
+  declaredVariant: BlueprintTopologyVariant | undefined
+  liveClass: string
+  isMultiRegion: boolean
+  sovereignRegionCount: number
+}
+
+/**
+ * DeclaredTopologyPanel — the §1 acceptance surface for #3375.
+ *
+ * Reads back, for THIS app, the declared topology class + DR mechanism +
+ * per-cluster placement straight from its blueprint.yaml `spec.topology`
+ * (the same source docs/topology-matrix.md promotes). Always rendered — so
+ * every app's Topology tab states its real declared posture rather than the
+ * generic editor alone. Honest about the live-vs-declared split: when the
+ * Sovereign is single-region the cross-region machinery is OFF and the
+ * single-region default applies.
+ */
+function DeclaredTopologyPanel({
+  applicationName,
+  declaredTopology,
+  declaredClass,
+  declaredVariant,
+  liveClass,
+  isMultiRegion,
+  sovereignRegionCount,
+}: DeclaredTopologyPanelProps) {
+  const placement = declaredVariant?.placement
+  const replication = declaredVariant?.replication
+  const switchover = declaredVariant?.switchover
+  const clusters = placement?.clusters ?? []
+  const roles = placement?.roles ?? {}
+
+  const classLabel = (k: string): string => {
+    switch (k) {
+      case 'active-hot-standby':
+        return 'active-hot-standby'
+      case 'active-passive':
+        return 'active-passive'
+      case 'active-active':
+        return 'active-active'
+      default:
+        return 'singleton'
+    }
+  }
+
+  // A "live differs from declared" hint when the running CR reports a class
+  // other than what the Sovereign topology implies (e.g. the app was
+  // installed single-region on a 2-region prov, or vice-versa).
+  const liveDiffers =
+    isDRCapableClass(liveClass) && liveClass !== declaredClass
+
+  return (
+    <section
+      className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-4"
+      data-testid="topology-tab-declared-panel"
+    >
+      <div className="mb-2 flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold text-[var(--color-text-strong)]">
+          Declared topology
+        </h3>
+        <span
+          className={`inline-flex items-center rounded-md px-2.5 py-0.5 text-xs font-semibold ${
+            declaredClass === 'singleton'
+              ? 'bg-[var(--color-border)]/40 text-[var(--color-text-dim)]'
+              : 'bg-[var(--color-accent)]/15 text-[var(--color-accent)]'
+          }`}
+          data-testid="topology-tab-declared-class"
+        >
+          {classLabel(declaredClass)}
+        </span>
+      </div>
+
+      {!declaredTopology ? (
+        <p className="text-xs text-[var(--color-text-dim)]" data-testid="topology-tab-declared-none">
+          <code className="font-mono">{applicationName}</code> declares no topology contract
+          in its Blueprint — it runs as a single instance with no cross-region failover.
+        </p>
+      ) : (
+        <>
+          <p className="mb-3 text-xs text-[var(--color-text-dim)]" data-testid="topology-tab-declared-desc">
+            {describeTopologyClass(declaredClass)}
+          </p>
+
+          <dl className="grid grid-cols-1 gap-x-6 gap-y-1.5 text-xs sm:grid-cols-2">
+            <div className="flex justify-between gap-3 sm:block">
+              <dt className="text-[var(--color-text-dim)]">Effective class</dt>
+              <dd
+                className="font-mono text-[var(--color-text)]"
+                data-testid="topology-tab-declared-effective"
+              >
+                {classLabel(declaredClass)}{' '}
+                <span className="text-[var(--color-text-dim)]">
+                  ({isMultiRegion ? `multi-region · ${sovereignRegionCount} regions` : 'single-region default'})
+                </span>
+              </dd>
+            </div>
+            <div className="flex justify-between gap-3 sm:block">
+              <dt className="text-[var(--color-text-dim)]">Supported</dt>
+              <dd className="font-mono text-[var(--color-text)]" data-testid="topology-tab-declared-supported">
+                {declaredTopology.supported.map(classLabel).join(' · ') || '—'}
+              </dd>
+            </div>
+            {placement?.tier ? (
+              <div className="flex justify-between gap-3 sm:block">
+                <dt className="text-[var(--color-text-dim)]">Tier</dt>
+                <dd className="font-mono text-[var(--color-text)]" data-testid="topology-tab-declared-tier">
+                  {placement.tier}
+                </dd>
+              </div>
+            ) : null}
+            {replication?.backend ? (
+              <div className="flex justify-between gap-3 sm:block">
+                <dt className="text-[var(--color-text-dim)]">State preservation</dt>
+                <dd className="font-mono text-[var(--color-text)]" data-testid="topology-tab-declared-replication">
+                  {replication.backend}
+                  {replication.mode ? ` · ${replication.mode}` : ''}
+                </dd>
+              </div>
+            ) : null}
+            {switchover?.mechanism ? (
+              <div className="flex justify-between gap-3 sm:block">
+                <dt className="text-[var(--color-text-dim)]">Switchover</dt>
+                <dd className="font-mono text-[var(--color-text)]" data-testid="topology-tab-declared-switchover">
+                  {switchover.mechanism}
+                </dd>
+              </div>
+            ) : null}
+            {switchover && (switchover.rtoSeconds != null || switchover.rpoSeconds != null) ? (
+              <div className="flex justify-between gap-3 sm:block">
+                <dt className="text-[var(--color-text-dim)]">RTO / RPO</dt>
+                <dd className="font-mono text-[var(--color-text)]" data-testid="topology-tab-declared-rto-rpo">
+                  {switchover.rtoSeconds != null ? `${switchover.rtoSeconds}s` : '—'} /{' '}
+                  {switchover.rpoSeconds != null ? `${switchover.rpoSeconds}s` : '—'}
+                </dd>
+              </div>
+            ) : null}
+          </dl>
+
+          {clusters.length > 0 ? (
+            <div className="mt-3">
+              <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-wide text-[var(--color-text-dim)]">
+                Per-cluster placement
+              </p>
+              <ul className="flex flex-wrap gap-1.5" data-testid="topology-tab-declared-clusters">
+                {clusters.map((c) => {
+                  const role = roles[c] ?? 'active'
+                  return (
+                    <li
+                      key={c}
+                      data-testid={`topology-tab-declared-cluster-${c}`}
+                      className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-xs ${
+                        role === 'active'
+                          ? 'border-green-500/40 bg-green-500/10 text-green-400'
+                          : role === 'passive' || role === 'standby'
+                            ? 'border-yellow-500/40 bg-yellow-500/10 text-yellow-400'
+                            : 'border-[var(--color-border)] text-[var(--color-text-dim)]'
+                      }`}
+                    >
+                      <code className="font-mono">{c}</code>
+                      <span className="uppercase text-[10px] font-semibold">{role}</span>
+                    </li>
+                  )
+                })}
+              </ul>
+            </div>
+          ) : null}
+
+          {!isMultiRegion && isDRCapableClass(canonicalTopologyClass(declaredTopology.multiRegion)) ? (
+            <p
+              className="mt-3 rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-[11px] text-[var(--color-text-dim)]"
+              data-testid="topology-tab-declared-singleregion-note"
+            >
+              This Sovereign is single-region, so the cross-region DR machinery is dormant. On a
+              2-region Sovereign this app runs as{' '}
+              <strong className="text-[var(--color-text)]">
+                {classLabel(canonicalTopologyClass(declaredTopology.multiRegion))}
+              </strong>{' '}
+              and the Switchover panel below activates.
+            </p>
+          ) : null}
+
+          {liveDiffers ? (
+            <p
+              className="mt-2 text-[11px] text-yellow-400"
+              data-testid="topology-tab-declared-live-differs"
+            >
+              Live placement on the running instance is{' '}
+              <strong>{classLabel(liveClass)}</strong> (differs from the declared default).
+            </p>
+          ) : null}
+        </>
+      )}
+    </section>
   )
 }

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -42,6 +42,15 @@ export interface BlueprintCardEntry {
   shareable: boolean
   /** #3370 — the Context declaration (null when not shareable). */
   contextSchema: BlueprintContextSchema | null
+  /**
+   * #3375 — declared topology + DR contract, lifted verbatim from the
+   * Blueprint's `spec.topology` (the same source docs/topology-matrix.md
+   * promotes). Read back by the AppDetail Topology tab for every app so
+   * the operator sees the app's real declared class + DR mechanism +
+   * per-cluster placement — not a blank editor. null when the Blueprint
+   * ships no topology block.
+   */
+  topology: BlueprintTopology | null
 }
 
 /**
@@ -59,6 +68,39 @@ export interface BlueprintContextSchema {
 }
 
 /**
+ * #3375 — the per-Blueprint topology declaration the console reads back.
+ *
+ *   supported       — declared topology variants (e.g. [active-hot-standby, singleton])
+ *   multiRegion     — defaults.multi-region (the class a 2-region Sovereign picks)
+ *   singleRegion    — defaults.single-region (the class a 1-region Sovereign picks)
+ *   perTopology     — DR contract per variant (replication + switchover + placement roles)
+ */
+export interface BlueprintTopology {
+  supported: string[]
+  multiRegion: string | null
+  singleRegion: string | null
+  perTopology: Record<string, BlueprintTopologyVariant>
+}
+
+export interface BlueprintTopologyVariant {
+  replication: {
+    backend: string | null
+    mode: string | null
+    lagSloSeconds: number | null
+  } | null
+  switchover: {
+    mechanism: string | null
+    rtoSeconds: number | null
+    rpoSeconds: number | null
+  } | null
+  placement: {
+    tier: string | null
+    clusters: string[]
+    roles: Record<string, string>
+  } | null
+}
+
+/**
  * Every Blueprint discovered at build time. Order is stable (sorted by id).
  *
  * StepComponents filters this with `visibility === 'listed'` to render the
@@ -66,6 +108,58 @@ export interface BlueprintContextSchema {
  * bootstrap-kit phases when the SSE backend emits Flux Kustomization events.
  */
 export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
+  {
+    "id": "bp-alloy",
+    "slug": "alloy",
+    "title": "Alloy",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.0.1",
+    "section": "pts-3-observability",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "none",
+            "mode": "none",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
   {
     "id": "bp-anthropic-adapter",
     "slug": "anthropic-adapter",
@@ -82,7 +176,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-external-secrets"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-active",
+        "singleton"
+      ],
+      "multiRegion": "active-active",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-active": {
+          "replication": {
+            "backend": "none",
+            "mode": "none",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "none",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "active"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-bge",
@@ -100,7 +240,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-cnpg"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-active",
+        "singleton"
+      ],
+      "multiRegion": "active-active",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-active": {
+          "replication": {
+            "backend": "none",
+            "mode": "none",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "none",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "active"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-catalyst-platform",
@@ -122,7 +308,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-crossplane-claims"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-hot-standby",
+        "singleton"
+      ],
+      "multiRegion": "active-hot-standby",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-hot-standby": {
+          "replication": {
+            "backend": "cnpg-pair",
+            "mode": "sync",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 30,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B"
+            ],
+            "roles": {
+              "mgmt-A": "active",
+              "mgmt-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-cert-manager",
@@ -138,7 +370,43 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-3-3-security-and-policy",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "openbao-perf-replication",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-cert-manager-dynadot-webhook",
@@ -156,7 +424,39 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-cert-manager"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-cert-manager-powerdns-webhook",
@@ -174,7 +474,39 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-cert-manager"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-cilium",
@@ -186,11 +518,43 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-cilium-policies",
@@ -206,7 +570,43 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "flux-git",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-clickhouse",
@@ -222,7 +622,101 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-4-application-tier",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-active",
+        "singleton"
+      ],
+      "multiRegion": "active-active",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-active": {
+          "replication": {
+            "backend": "none",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "none",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "active"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-cluster-autoscaler-hcloud",
+    "slug": "cluster-autoscaler-hcloud",
+    "title": "Cluster Autoscaler (Hetzner)",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.3.0",
+    "section": "pts-3-2-scaling-and-resilience",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-cnpg",
@@ -240,7 +734,39 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-flux"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-cnpg-pair",
@@ -252,7 +778,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "section": "pts-9-disaster-recovery",
     "depends": [
       "bp-cnpg",
@@ -260,7 +786,91 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-cilium"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-hot-standby"
+      ],
+      "multiRegion": "active-hot-standby",
+      "singleRegion": "active-hot-standby",
+      "perTopology": {
+        "active-hot-standby": {
+          "replication": {
+            "backend": "cnpg-pair",
+            "mode": "sync",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 10,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "passive"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-coraza",
+    "slug": "coraza",
+    "title": "Coraza WAF (SPOA)",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.0.0",
+    "section": "pts-3-3-security-and-policy",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "flux-git",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-crossplane",
@@ -276,7 +886,43 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-3-2-gitops-and-iac",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "flux-git",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-crossplane-claims",
@@ -294,7 +940,43 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-crossplane"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "flux-git",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-debezium",
@@ -310,7 +992,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-4-application-tier",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "mirrormaker2",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-dmz-vcluster",
@@ -322,14 +1050,42 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.2.5",
+    "version": "0.2.7",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [
       "bp-cilium",
       "bp-cert-manager"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "velero",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "dmz",
+            "clusters": [
+              "dmz-A",
+              "dmz-B"
+            ],
+            "roles": {
+              "dmz-A": "singleton",
+              "dmz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-external-dns",
@@ -345,7 +1101,43 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "none",
+            "mode": "none",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-external-secrets",
@@ -364,7 +1156,43 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-cert-manager"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "openbao-perf-replication",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-external-secrets-stores",
@@ -380,7 +1208,91 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-3-3-security-and-policy",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "flux-git",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-falco",
+    "slug": "falco",
+    "title": "Falco",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.0.1",
+    "section": "pts-3-3-security-and-policy",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-ferretdb",
@@ -396,7 +1308,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-4-application-tier",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "cnpg-pair",
+            "mode": "sync",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 60,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-flink",
@@ -412,7 +1370,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-4-application-tier",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "s3-bucket-replication",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-flux",
@@ -428,7 +1432,43 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-3-2-gitops-and-iac",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "flux-git",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-gateway-api",
@@ -444,7 +1484,43 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "flux-git",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-gitea",
@@ -456,11 +1532,119 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.31",
+    "version": "1.2.34",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-hot-standby",
+        "singleton"
+      ],
+      "multiRegion": "active-hot-standby",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-hot-standby": {
+          "replication": {
+            "backend": "cnpg-pair",
+            "mode": "sync",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 30,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B"
+            ],
+            "roles": {
+              "mgmt-A": "active",
+              "mgmt-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-grafana",
+    "slug": "grafana",
+    "title": "Grafana",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.0.12",
+    "section": "pts-3-observability",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-hot-standby",
+        "singleton"
+      ],
+      "multiRegion": "active-hot-standby",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-hot-standby": {
+          "replication": {
+            "backend": "cnpg-pair",
+            "mode": "sync",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 30,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B"
+            ],
+            "roles": {
+              "mgmt-A": "active",
+              "mgmt-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-guacamole",
@@ -472,7 +1656,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.4",
+    "version": "0.2.8",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [
       "bp-keycloak",
@@ -482,7 +1666,166 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-k8s-ws-proxy"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-hot-standby",
+        "singleton"
+      ],
+      "multiRegion": "active-hot-standby",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-hot-standby": {
+          "replication": {
+            "backend": "cnpg-pair",
+            "mode": "sync",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 30,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B"
+            ],
+            "roles": {
+              "mgmt-A": "active",
+              "mgmt-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-harbor",
+    "slug": "harbor",
+    "title": "Harbor",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.2.30",
+    "section": "pts-3-5-storage-and-data",
+    "depends": [
+      "bp-cnpg",
+      "bp-cert-manager"
+    ],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-hot-standby",
+        "singleton"
+      ],
+      "multiRegion": "active-hot-standby",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-hot-standby": {
+          "replication": {
+            "backend": "cnpg-pair",
+            "mode": "sync",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 30,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B"
+            ],
+            "roles": {
+              "mgmt-A": "active",
+              "mgmt-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-hcloud-ccm",
+    "slug": "hcloud-ccm",
+    "title": "Hetzner Cloud Controller Manager",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.0.0",
+    "section": "pts-3-1-cloud-integration",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-hcloud-csi",
@@ -498,7 +1841,39 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-3-5-storage-and-data",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-iceberg",
@@ -514,7 +1889,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-4-application-tier",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-active",
+        "singleton"
+      ],
+      "multiRegion": "active-active",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-active": {
+          "replication": {
+            "backend": "s3-bucket-replication",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "none",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "active"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-k8s-ws-proxy",
@@ -532,7 +1953,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-sealed-secrets"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "none",
+            "mode": "none",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 5,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B"
+            ],
+            "roles": {
+              "mgmt-A": "active",
+              "mgmt-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-keycloak",
@@ -544,11 +2011,57 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.4.26",
+    "version": "1.4.27",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-hot-standby",
+        "singleton"
+      ],
+      "multiRegion": "active-hot-standby",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-hot-standby": {
+          "replication": {
+            "backend": "cnpg-pair",
+            "mode": "sync",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 30,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B"
+            ],
+            "roles": {
+              "mgmt-A": "active",
+              "mgmt-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-knative",
@@ -567,7 +2080,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-cert-manager"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-active",
+        "singleton"
+      ],
+      "multiRegion": "active-active",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-active": {
+          "replication": {
+            "backend": "none",
+            "mode": "none",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "none",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "active"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-kserve",
@@ -587,7 +2146,219 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-knative"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-active",
+        "singleton"
+      ],
+      "multiRegion": "active-active",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-active": {
+          "replication": {
+            "backend": "none",
+            "mode": "none",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "none",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "active"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-kyverno",
+    "slug": "kyverno",
+    "title": "Kyverno",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.3.6",
+    "section": "pts-3-3-security-and-policy",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "flux-git",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-kyverno-policies",
+    "slug": "kyverno-policies",
+    "title": "Kyverno Policy Library",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.0.33",
+    "section": "pts-3-3-security-and-policy",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "flux-git",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-langfuse",
+    "slug": "langfuse",
+    "title": "Langfuse",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.1.0",
+    "section": "pts-3-observability",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "cnpg-pair",
+            "mode": "sync",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 60,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-librechat",
@@ -608,7 +2379,93 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-keycloak"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-active",
+        "singleton"
+      ],
+      "multiRegion": "active-active",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-active": {
+          "replication": {
+            "backend": "none",
+            "mode": "none",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "none",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "active"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-litmus",
+    "slug": "litmus",
+    "title": "LitmusChaos",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.0.0",
+    "section": "pts-3-3-security-and-policy",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-livekit",
@@ -628,7 +2485,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-valkey"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-active",
+        "singleton"
+      ],
+      "multiRegion": "active-active",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-active": {
+          "replication": {
+            "backend": "none",
+            "mode": "none",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "none",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "active"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-llm-gateway",
@@ -648,7 +2551,115 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-external-secrets"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-active",
+        "singleton"
+      ],
+      "multiRegion": "active-active",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-active": {
+          "replication": {
+            "backend": "none",
+            "mode": "none",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "none",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "active"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-loki",
+    "slug": "loki",
+    "title": "Loki",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.0.0",
+    "section": "pts-3-observability",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "s3-bucket-replication",
+            "mode": "async",
+            "lagSloSeconds": 60
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 60,
+            "rpoSeconds": 60
+          },
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B"
+            ],
+            "roles": {
+              "mgmt-A": "active",
+              "mgmt-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-matrix",
@@ -668,7 +2679,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-cert-manager"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "cnpg-pair",
+            "mode": "sync",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 60,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-mgmt-vcluster",
@@ -680,14 +2737,42 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.2.6",
+    "version": "0.2.8",
     "section": "pts-3-2-control-plane-isolation",
     "depends": [
       "bp-cilium",
       "bp-cert-manager"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "velero",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-milvus",
@@ -703,7 +2788,115 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-4-application-tier",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "s3-bucket-replication",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-mimir",
+    "slug": "mimir",
+    "title": "Mimir",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.0.5",
+    "section": "pts-3-observability",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "s3-bucket-replication",
+            "mode": "async",
+            "lagSloSeconds": 60
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 60,
+            "rpoSeconds": 60
+          },
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B"
+            ],
+            "roles": {
+              "mgmt-A": "active",
+              "mgmt-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-nats-jetstream",
@@ -719,7 +2912,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "raft",
+            "mode": "sync",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 30,
+            "rpoSeconds": 60
+          },
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B"
+            ],
+            "roles": {
+              "mgmt-A": "active",
+              "mgmt-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-nemo-guardrails",
@@ -737,7 +2976,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-vllm"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-active",
+        "singleton"
+      ],
+      "multiRegion": "active-active",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-active": {
+          "replication": {
+            "backend": "flux-git",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "none",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "active"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-neo4j",
@@ -753,7 +3038,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-4-application-tier",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "velero",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "bp-velero-restore",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-netbird",
@@ -765,7 +3096,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [
       "bp-keycloak",
@@ -773,7 +3104,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-sealed-secrets"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-hot-standby",
+        "singleton"
+      ],
+      "multiRegion": "active-hot-standby",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-hot-standby": {
+          "replication": {
+            "backend": "cnpg-pair",
+            "mode": "sync",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 30,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B"
+            ],
+            "roles": {
+              "mgmt-A": "active",
+              "mgmt-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-network-policies",
@@ -791,7 +3168,43 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-cilium"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "flux-git",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-newapi",
@@ -803,7 +3216,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "1.4.63",
+    "version": "1.4.66",
     "section": "pts-4-6-llm-serving",
     "depends": [
       "bp-cnpg",
@@ -813,7 +3226,119 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-vllm"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "cnpg-pair",
+            "mode": "sync",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 30,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B"
+            ],
+            "roles": {
+              "mgmt-A": "active",
+              "mgmt-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-oidc-gate",
+    "slug": "oidc-gate",
+    "title": "oidc-gate",
+    "summary": "|",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "0.1.0",
+    "section": "pts-2-3-per-sovereign-supporting-services",
+    "depends": [
+      "bp-cilium",
+      "bp-keycloak",
+      "bp-external-secrets-stores"
+    ],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "none",
+            "mode": "none",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 30,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B"
+            ],
+            "roles": {
+              "mgmt-A": "active",
+              "mgmt-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-openbao",
@@ -825,11 +3350,57 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.28",
+    "version": "1.2.31",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "openbao-perf-replication",
+            "mode": "async",
+            "lagSloSeconds": 30
+          },
+          "switchover": {
+            "mechanism": "raft-transition",
+            "rtoSeconds": 60,
+            "rpoSeconds": 30
+          },
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B"
+            ],
+            "roles": {
+              "mgmt-A": "active",
+              "mgmt-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-openclaw",
@@ -849,7 +3420,29 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-cert-manager"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-openmeter",
@@ -869,7 +3462,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-cert-manager"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "cnpg-pair",
+            "mode": "sync",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 60,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-opensearch",
@@ -885,7 +3524,125 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-4-application-tier",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-active",
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-active",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-active": {
+          "replication": {
+            "backend": "ccr",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "ccr-promote",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "active"
+            }
+          }
+        },
+        "active-passive": {
+          "replication": {
+            "backend": "ccr",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "ccr-promote",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-opentelemetry",
+    "slug": "opentelemetry",
+    "title": "OpenTelemetry Collector",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.2.1",
+    "section": "pts-3-observability",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-opentelemetry-operator",
@@ -904,7 +3661,39 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-cert-manager"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-postgres",
@@ -916,7 +3705,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.1.6",
+    "version": "0.1.8",
     "section": "pts-4-1-data-services",
     "depends": [
       "bp-cnpg",
@@ -933,6 +3722,52 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "produces": [
         "credentialSecret"
       ]
+    },
+    "topology": {
+      "supported": [
+        "singleton",
+        "active-hot-standby"
+      ],
+      "multiRegion": "active-hot-standby",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        },
+        "active-hot-standby": {
+          "replication": {
+            "backend": "cnpg-pair",
+            "mode": "sync",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 10,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "passive"
+            }
+          }
+        }
+      }
     }
   },
   {
@@ -945,13 +3780,45 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.12",
+    "version": "1.2.14",
     "section": "pts-3-2-gitops-and-iac",
     "depends": [
       "bp-cert-manager"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-powerdns-admin",
@@ -963,7 +3830,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.12",
+    "version": "0.1.13",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-powerdns",
@@ -975,7 +3842,39 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-gateway-api"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-qa-app",
@@ -991,7 +3890,31 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-qa",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-reflector",
@@ -1007,7 +3930,91 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-3-3-security-and-policy",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "none",
+            "mode": "none",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-reloader",
+    "slug": "reloader",
+    "title": "Reloader",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.0.0",
+    "section": "pts-3-3-security-and-policy",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-rtz-vcluster",
@@ -1019,14 +4026,42 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.2.6",
+    "version": "0.2.8",
     "section": "pts-3-2-control-plane-isolation",
     "depends": [
       "bp-cilium",
       "bp-cert-manager"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "velero",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-sandbox",
@@ -1047,7 +4082,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-harbor"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-hot-standby",
+        "singleton"
+      ],
+      "multiRegion": "active-hot-standby",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-hot-standby": {
+          "replication": {
+            "backend": "none",
+            "mode": "async",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 30,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-sealed-secrets",
@@ -1063,7 +4144,93 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-3-3-security-and-policy",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-seaweedfs",
+    "slug": "seaweedfs",
+    "title": "SeaweedFS",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.2.1",
+    "section": "pts-3-5-storage-and-data",
+    "depends": [
+      "bp-cert-manager"
+    ],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "filer-remote-storage",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-self-sovereign-cutover",
@@ -1082,7 +4249,81 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-harbor"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "none",
+            "mode": "none",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-sigstore",
+    "slug": "sigstore",
+    "title": "Sigstore Policy Controller",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.0.0",
+    "section": "pts-3-3-security-and-policy",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-spire",
@@ -1098,7 +4339,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-hot-standby",
+        "singleton"
+      ],
+      "multiRegion": "active-hot-standby",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-hot-standby": {
+          "replication": {
+            "backend": "cnpg-pair",
+            "mode": "sync",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 30,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B"
+            ],
+            "roles": {
+              "mgmt-A": "active",
+              "mgmt-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-sso-bridge",
@@ -1118,7 +4405,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-external-secrets-stores"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "none",
+            "mode": "none",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 30,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B"
+            ],
+            "roles": {
+              "mgmt-A": "active",
+              "mgmt-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-stalwart-sovereign",
@@ -1138,7 +4471,25 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-powerdns"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [],
+            "roles": {}
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-stalwart-tenant",
@@ -1159,7 +4510,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-powerdns"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "cnpg-pair",
+            "mode": "sync",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 60,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-strimzi",
@@ -1175,7 +4572,77 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "section": "pts-4-application-tier",
     "depends": [],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-active",
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-active",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-active": {
+          "replication": {
+            "backend": "mirrormaker2",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "mm2-symmetric",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "active"
+            }
+          }
+        },
+        "active-passive": {
+          "replication": {
+            "backend": "mirrormaker2",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "mm2-symmetric",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-stunner",
@@ -1194,7 +4661,163 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-cert-manager"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-active",
+        "singleton"
+      ],
+      "multiRegion": "active-active",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-active": {
+          "replication": {
+            "backend": "none",
+            "mode": "none",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "none",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "active"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-syft-grype",
+    "slug": "syft-grype",
+    "title": "Syft + Grype",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.0.0",
+    "section": "pts-3-3-security-and-policy",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-tempo",
+    "slug": "tempo",
+    "title": "Tempo",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.0.0",
+    "section": "pts-3-observability",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "s3-bucket-replication",
+            "mode": "async",
+            "lagSloSeconds": 60
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 60,
+            "rpoSeconds": 60
+          },
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B"
+            ],
+            "roles": {
+              "mgmt-A": "active",
+              "mgmt-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "mgmt",
+            "clusters": [
+              "mgmt-A"
+            ],
+            "roles": {
+              "mgmt-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-temporal",
@@ -1213,7 +4836,101 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-cert-manager"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "cnpg-pair",
+            "mode": "sync",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 60,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-trivy",
+    "slug": "trivy",
+    "title": "Trivy",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.0.3",
+    "section": "pts-3-3-security-and-policy",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-valkey",
@@ -1225,7 +4942,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.1.0",
+    "version": "1.1.2",
     "section": "pts-4-1-data-services",
     "depends": [
       "bp-flux"
@@ -1241,6 +4958,52 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "produces": [
         "credentialSecret"
       ]
+    },
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "sentinel",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "sentinel-failover",
+            "rtoSeconds": 30,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
     }
   },
   {
@@ -1259,7 +5022,143 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-flux"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-velero",
+    "slug": "velero",
+    "title": "Velero",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.2.2",
+    "section": "pts-3-observability",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "s3-bucket-replication",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-velero-hcs",
+    "slug": "velero-hcs",
+    "title": "Velero (HCS)",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "0.1.1",
+    "section": "pts-3-observability",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "s3-bucket-replication",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-vllm",
@@ -1277,7 +5176,101 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-kserve"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-active",
+        "singleton"
+      ],
+      "multiRegion": "active-active",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-active": {
+          "replication": {
+            "backend": "none",
+            "mode": "none",
+            "lagSloSeconds": null
+          },
+          "switchover": {
+            "mechanism": "none",
+            "rtoSeconds": null,
+            "rpoSeconds": null
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "active"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "bp-vpa",
+    "slug": "vpa",
+    "title": "Vertical Pod Autoscaler",
+    "summary": "",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.0.1",
+    "section": "pts-3-3-security-and-policy",
+    "depends": [],
+    "shareable": false,
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    }
   },
   {
     "id": "bp-wordpress-tenant",
@@ -1299,7 +5292,53 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "bp-cert-manager"
     ],
     "shareable": false,
-    "contextSchema": null
+    "contextSchema": null,
+    "topology": {
+      "supported": [
+        "active-passive",
+        "singleton"
+      ],
+      "multiRegion": "active-passive",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "active-passive": {
+          "replication": {
+            "backend": "cnpg-pair",
+            "mode": "sync",
+            "lagSloSeconds": 0
+          },
+          "switchover": {
+            "mechanism": "bp-continuum",
+            "rtoSeconds": 60,
+            "rpoSeconds": 0
+          },
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "rtz-A": "active",
+              "rtz-B": "passive"
+            }
+          }
+        },
+        "singleton": {
+          "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "rtz",
+            "clusters": [
+              "rtz-A"
+            ],
+            "roles": {
+              "rtz-A": "singleton"
+            }
+          }
+        }
+      }
+    }
   }
 ] as const
 
@@ -1316,8 +5355,22 @@ export const BLUEPRINT_BY_ID: Readonly<Record<string, BlueprintCardEntry>> = Obj
   ALL_BLUEPRINTS.map(b => [b.id, b])
 )
 
+/**
+ * #3375 — Lookup: blueprint id → declared topology (null when the
+ * Blueprint ships no topology block). The AppDetail Topology tab resolves
+ * an app's matrix-declared class + DR mechanism + per-cluster roles from
+ * here, keyed on either the `bp-<name>` id or the bare slug.
+ */
+export const TOPOLOGY_BY_ID: Readonly<Record<string, BlueprintTopology>> = Object.fromEntries(
+  ALL_BLUEPRINTS.filter(b => b.topology != null).flatMap(b => {
+    const t = b.topology as BlueprintTopology
+    return [[b.id, t], [b.slug, t]]
+  })
+)
+
 /** Source files this catalog was built from (for diagnostics / CI logs). */
 export const PLATFORM_BLUEPRINT_FILES: readonly string[] = [
+  "platform/alloy/blueprint.yaml",
   "platform/anthropic-adapter/blueprint.yaml",
   "platform/bge/blueprint.yaml",
   "platform/catalyst-platform/blueprint.yaml",
@@ -1327,8 +5380,10 @@ export const PLATFORM_BLUEPRINT_FILES: readonly string[] = [
   "platform/cilium-policies/blueprint.yaml",
   "platform/cilium/blueprint.yaml",
   "platform/clickhouse/blueprint.yaml",
+  "platform/cluster-autoscaler-hcloud/blueprint.yaml",
   "platform/cnpg-pair/blueprint.yaml",
   "platform/cnpg/blueprint.yaml",
+  "platform/coraza/blueprint.yaml",
   "platform/crossplane-claims/blueprint.yaml",
   "platform/crossplane/blueprint.yaml",
   "platform/debezium/blueprint.yaml",
@@ -1336,54 +5391,75 @@ export const PLATFORM_BLUEPRINT_FILES: readonly string[] = [
   "platform/external-dns/blueprint.yaml",
   "platform/external-secrets-stores/blueprint.yaml",
   "platform/external-secrets/blueprint.yaml",
+  "platform/falco/blueprint.yaml",
   "platform/ferretdb/blueprint.yaml",
   "platform/flink/blueprint.yaml",
   "platform/flux/blueprint.yaml",
   "platform/gateway-api/blueprint.yaml",
   "platform/gitea/blueprint.yaml",
+  "platform/grafana/blueprint.yaml",
   "platform/guacamole/blueprint.yaml",
+  "platform/harbor/blueprint.yaml",
+  "platform/hcloud-ccm/blueprint.yaml",
   "platform/hcloud-csi/blueprint.yaml",
   "platform/iceberg/blueprint.yaml",
   "platform/k8s-ws-proxy/blueprint.yaml",
   "platform/keycloak/blueprint.yaml",
   "platform/knative/blueprint.yaml",
   "platform/kserve/blueprint.yaml",
+  "platform/kyverno-policies/blueprint.yaml",
+  "platform/kyverno/blueprint.yaml",
+  "platform/langfuse/blueprint.yaml",
   "platform/librechat/blueprint.yaml",
+  "platform/litmus/blueprint.yaml",
   "platform/livekit/blueprint.yaml",
   "platform/llm-gateway/blueprint.yaml",
+  "platform/loki/blueprint.yaml",
   "platform/matrix/blueprint.yaml",
   "platform/mgmt-vcluster/blueprint.yaml",
   "platform/milvus/blueprint.yaml",
+  "platform/mimir/blueprint.yaml",
   "platform/nats-jetstream/blueprint.yaml",
   "platform/nemo-guardrails/blueprint.yaml",
   "platform/neo4j/blueprint.yaml",
   "platform/netbird/blueprint.yaml",
   "platform/network-policies/blueprint.yaml",
   "platform/newapi/blueprint.yaml",
+  "platform/oidc-gate/blueprint.yaml",
   "platform/openbao/blueprint.yaml",
   "platform/openclaw/blueprint.yaml",
   "platform/openmeter/blueprint.yaml",
   "platform/opensearch/blueprint.yaml",
   "platform/opentelemetry-operator/blueprint.yaml",
+  "platform/opentelemetry/blueprint.yaml",
   "platform/postgres/blueprint.yaml",
   "platform/powerdns-admin/blueprint.yaml",
   "platform/powerdns/blueprint.yaml",
   "platform/qa-app/blueprint.yaml",
   "platform/reflector/blueprint.yaml",
+  "platform/reloader/blueprint.yaml",
   "platform/rtz-vcluster/blueprint.yaml",
   "platform/sandbox/blueprint.yaml",
   "platform/sealed-secrets/blueprint.yaml",
+  "platform/seaweedfs/blueprint.yaml",
   "platform/self-sovereign-cutover/blueprint.yaml",
+  "platform/sigstore/blueprint.yaml",
   "platform/spire/blueprint.yaml",
   "platform/sso-bridge/blueprint.yaml",
   "platform/stalwart-sovereign/blueprint.yaml",
   "platform/stalwart-tenant/blueprint.yaml",
   "platform/strimzi/blueprint.yaml",
   "platform/stunner/blueprint.yaml",
+  "platform/syft-grype/blueprint.yaml",
+  "platform/tempo/blueprint.yaml",
   "platform/temporal/blueprint.yaml",
+  "platform/trivy/blueprint.yaml",
   "platform/valkey/blueprint.yaml",
   "platform/vcluster-helmrepo/blueprint.yaml",
+  "platform/velero-hcs/blueprint.yaml",
+  "platform/velero/blueprint.yaml",
   "platform/vllm/blueprint.yaml",
+  "platform/vpa/blueprint.yaml",
   "platform/wordpress-tenant/blueprint.yaml"
 ] as const
 

--- a/products/catalyst/bootstrap/ui/src/shared/lib/useSession.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/useSession.ts
@@ -29,6 +29,16 @@ export interface SessionState {
   signedIn: boolean
   email: string | null
   sub: string | null
+  /**
+   * #3375 — the operator's Catalyst tier (viewer < developer < operator <
+   * admin < owner), lower-cased, from GET /whoami. Empty string when the
+   * session carries no tier claim. Threaded into the AppDetail Topology tab
+   * so the DR Switchover control enables for the owner/admin tier instead of
+   * rendering permanently disabled "Owner tier required".
+   */
+  tier: string
+  /** #3375 — Keycloak realm-access roles (e.g. catalyst-owner) from /whoami. */
+  roles: string[]
   loading: boolean
   refetch: () => void
   signOut: () => Promise<void>
@@ -38,6 +48,10 @@ interface WhoamiResponse {
   email: string
   sub: string
   verified: boolean
+  /** Catalyst tier (#3375) — present on PIN-derived + chroot sessions. */
+  tier?: string
+  /** Keycloak realm-access claim (#3375). */
+  realm_access?: { roles?: string[] }
 }
 
 const SESSION_QUERY_KEY = ['catalyst', 'session', 'whoami'] as const
@@ -135,6 +149,11 @@ export function useSession(): SessionState {
     signedIn: data !== null,
     email: data?.email ?? null,
     sub: data?.sub ?? null,
+    // #3375 — expose tier + realm roles so the DR Switchover control can
+    // enable for the owner/admin tier. The whoami handler already returns
+    // both (auth.go HandleWhoami: Tier + realm_access.roles).
+    tier: (data?.tier ?? '').toLowerCase(),
+    roles: data?.realm_access?.roles ?? [],
     loading: q.isLoading,
     refetch,
     signOut,

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/DRSection.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/DRSection.tsx
@@ -52,6 +52,17 @@ export interface DRSectionProps {
   namespace?: string
   /** Caller's tier — controls render of switchover/failback/approve buttons. */
   callerTier?: string
+  /**
+   * #3375 — the app's effective DR class (active-hot-standby / active-passive
+   * / active-active), from the live CR or the declared blueprint topology.
+   * Drives the heading + the honest "no live Continuum CR" copy.
+   */
+  declaredClass?: string
+  /**
+   * #3375 — the declared switchover mechanism (e.g. bp-continuum,
+   * raft-transition) surfaced in the contract line when no live CR exists.
+   */
+  switchoverMechanism?: string | null
   /** Test seam — pre-fill the Continuum CR + audit list, skip network. */
   initialContinuum?: ContinuumGetResponse
   /** Test seam — bypass the audit fetch + network calls. */
@@ -64,6 +75,8 @@ export function DRSection({
   applicationName,
   namespace,
   callerTier,
+  declaredClass,
+  switchoverMechanism,
   initialContinuum,
   disableNetwork = false,
 }: DRSectionProps) {
@@ -118,6 +131,29 @@ export function DRSection({
   const isOwner = tier === 'owner' || tier === 'admin'
   const isSovereignAdmin = tier === 'admin' || tier === 'owner'
 
+  // #3375 — the live Continuum query resolves to "loaded but not found"
+  // (404) for apps that have no Continuum CR yet (bootstrap-kit apps, or a
+  // single-region prov). Distinguish that from "still loading" so the panel
+  // never spins forever — the matrix asserts a real DR surface, not a
+  // permanent "Loading Continuum status…".
+  const crLoading = !initialContinuum && !disableNetwork && continuumQ.isLoading
+  const crMissing = !cr && !crLoading
+  const heading =
+    declaredClass === 'active-passive'
+      ? 'Disaster Recovery (active-passive)'
+      : declaredClass === 'active-active'
+        ? 'Disaster Recovery (active-active)'
+        : 'Disaster Recovery (active-hot-standby)'
+
+  // The Switchover button is enabled for the owner tier whenever there is a
+  // failover target. When a live CR is present we use its hot-standby set;
+  // when none exists yet (no Continuum CR) the owner can still INITIATE the
+  // switchover — the catalyst-api handler defaults the target to the first
+  // hot-standby region server-side, so we pass an empty target and let the
+  // dialog/handler resolve it. This is what makes the control walkable
+  // rather than permanently absent.
+  const canSwitchover = isOwner && (!!failoverTarget || crMissing)
+
   return (
     <section
       className="continuum-dr-section mt-6 rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] p-4"
@@ -125,9 +161,9 @@ export function DRSection({
     >
       <div className="mb-3 flex items-baseline justify-between">
         <h3 className="text-sm font-semibold text-[var(--color-text-strong)]">
-          Disaster Recovery (active-hotstandby)
+          {heading}
         </h3>
-        {isOwner && failoverTarget ? (
+        {canSwitchover ? (
           <button
             type="button"
             data-testid="continuum-dr-switchover-btn"
@@ -153,13 +189,38 @@ export function DRSection({
         )}
       </div>
 
-      {!cr ? (
+      {crLoading ? (
         <p
           data-testid="continuum-dr-loading"
           className="text-xs text-[var(--color-text-dim)]"
         >
           Loading Continuum status…
         </p>
+      ) : crMissing ? (
+        <div data-testid="continuum-dr-no-cr" className="text-xs text-[var(--color-text-dim)]">
+          <p>
+            No live Continuum record for{' '}
+            <code className="font-mono text-[var(--color-text)]">{applicationName}</code> yet —
+            the cross-region DR machinery activates once the app is placed{' '}
+            <strong className="text-[var(--color-text)]">{declaredClass ?? 'active-hot-standby'}</strong>{' '}
+            on a 2-region Sovereign.
+          </p>
+          {switchoverMechanism ? (
+            <p className="mt-1.5" data-testid="continuum-dr-declared-mechanism">
+              Declared switchover mechanism:{' '}
+              <code className="font-mono text-[var(--color-text)]">{switchoverMechanism}</code>.
+            </p>
+          ) : null}
+          <div className="mt-4">
+            <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--color-text-dim)]">
+              Switchover history
+            </h4>
+            <SwitchoverHistory
+              events={auditQ.data?.items ?? []}
+              applicationName={applicationName}
+            />
+          </div>
+        </div>
       ) : (
         <>
           <StatusPanel
@@ -203,12 +264,17 @@ export function DRSection({
         </>
       )}
 
-      {showSwitchover && failoverTarget ? (
+      {showSwitchover ? (
         <SwitchoverDialog
           sovereignId={sovereignId}
           continuumName={continuumName}
           namespace={namespace}
           fromRegion={primaryRegion}
+          // May be empty when no live CR exists — the catalyst-api switchover
+          // handler then resolves the target to the first declared hot-standby
+          // region server-side (continuum.go HandleContinuumSwitchoverRequest).
+          // The dialog renders a "the standby region" placeholder for the
+          // empty case but submits the empty string verbatim.
           toRegion={failoverTarget}
           applicationName={applicationName}
           disableNetwork={disableNetwork}

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/SwitchoverDialog.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/SwitchoverDialog.tsx
@@ -129,10 +129,20 @@ export function SwitchoverDialog({
         >
           <p className="font-medium text-[var(--color-text)]">
             Primary will move{' '}
-            <code className="font-mono text-[var(--color-accent)]">{fromRegion}</code>
+            <code className="font-mono text-[var(--color-accent)]">
+              {fromRegion || 'the current primary'}
+            </code>
             {' → '}
-            <code className="font-mono text-[var(--color-accent)]">{toRegion}</code>
+            <code className="font-mono text-[var(--color-accent)]">
+              {toRegion || 'the standby region'}
+            </code>
           </p>
+          {!toRegion ? (
+            <p className="mt-1 text-xs text-[var(--color-text-dim)]">
+              The standby region is resolved automatically from the declared
+              hot-standby placement.
+            </p>
+          ) : null}
         </div>
 
         <div className="mb-4">


### PR DESCRIPTION
## #3375 TOPOLOGY/DR — make the Topology tab a declaration + DR acceptance surface

**Live failure (hw133, walked this session): 0 / 87.** The AppDetail "Topology" tab was a generic placement EDITOR — identical for every app. It never read back any app's declared topology, offered no `active-passive`/`singleton`, and showed no DR/Switchover panel. `callerTier` was never threaded, so even where a DR panel could appear the Switchover button rendered permanently disabled ("Owner tier required").

### What this delivers (the 3 scope items)

**1. Declared-topology READ-BACK for EVERY app (§1 acceptance).**
`build-catalog.mjs` now lifts each `blueprint.yaml` `spec.topology` (the same source `docs/topology-matrix.md` promotes) into the generated catalog + a `TOPOLOGY_BY_ID` lookup. A new **Declared topology** panel on the tab shows, per app, the real class (active-hot-standby / active-passive / active-active / singleton), state backend + mode, switchover mechanism + RTO/RPO, and **per-cluster placement roles** (`mgmt-A active` / `mgmt-B passive`, …). Verified data resolution:
- gitea/grafana/harbor/keycloak → active-hot-standby · cnpg-pair/sync · bp-continuum · mgmt-A active / mgmt-B passive
- openbao → active-passive · openbao-perf-replication/async · raft-transition
- valkey → active-passive · sentinel/async · rtz-A/rtz-B
- cnpg-pair → active-hot-standby · rtz-A/rtz-B · cilium → singleton (all 6 tiers)

**2. Working Switchover/Failover for the owner tier.**
`useSession` now surfaces the operator's `tier` (the `whoami` handler already returns it) + realm roles; `AppDetail` threads `callerTier` into `TopologyTab → DRSection`, so the Switchover button **enables** for owner/admin and opens the real dialog (`POST .../switchover` patches the Continuum CR; the K-Cont-2 reconciler runs the 7-step sequence).

**3. DR panel for declared-HA apps, honest about live state.**
The DR section renders on the **effective class** (live CR class when present, else the declared class) so bootstrap-kit apps (gitea/harbor/openbao/grafana/keycloak — bare HelmReleases, no Application CR) surface the Switchover control. When no live Continuum CR exists yet it shows the declared mechanism + an honest "activates on a 2-region Sovereign" state instead of spinning on "Loading Continuum status…" forever — **never fakes a promotion**.

`build-catalog` also derives `bp-<folder>` for blueprints whose `metadata.name` lacks the `bp-` prefix (harbor, grafana, loki, …) so all **91** blueprints now emit with topology (was 68). The 24 added are all `unlisted` infra → **listed marketplace set byte-identical**.

### Pipeline to hw133
Console code → `catalyst-ui` image (built from `products/catalyst/bootstrap/ui/Containerfile`) → chart `images.catalystUi.tag`. The topology field on the Go catalog rides the `catalyst-api` image → `images.catalystApi.tag`. After merge, CI builds both; if the deploy-bot does not auto-bump, the tags get stamped to the squash-merge SHA.

### Verification (local)
- UI `tsc -b --noEmit` ✅ · full `vite build` ✅ (10186 modules)
- 10 continuum + AppDetail test files (77 tests) ✅
- catalyst-api `go build ./...` ✅ (new `Topology` field parses clean) · continuum/whoami handler tests ✅
- Pre-existing Dashboard/JobsPage/SettingsPage/ResourceDetail test failures + the 2 eslint `set-state-in-effect` errors are **identical on clean HEAD** (untouched by this change).

An independent walker validates the browser acceptance + flips the UAT rows.

Refs #3375

🤖 Generated with [Claude Code](https://claude.com/claude-code)