### PR TITLE
fix(bp-postgres): pin bump fires live upgrade → 3 shared-pg Application CRs render + shared-pg-c newapi/openova-flow Contexts (Refs #3370)

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -115,7 +115,11 @@ spec:
       # instance (canonical G117 representation; adoption-guarded,
       # Capabilities-gated) carrying the databases[] Context
       # declarations in spec.parameters.
-      version: 0.1.8
+      # 0.1.9 (#3370): pin bump — no template change; forces a
+      # helm-controller UPGRADE on already-converged Sovereigns so the
+      # Capabilities-gated Application CR renders (it was skipped at the
+      # bootstrap INSTALL, before the umbrella shipped the CRD).
+      version: 0.1.9
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -67,8 +67,10 @@ spec:
       # changelog. 0.1.5 ships the env-style hub (reflect.extraData +
       # passwordAliases) + the `uri` key this slot's bindings rely on.
       # 0.1.6 ships the #3370 bootstrapOwned Application-CR
-      # self-registration.
-      version: 0.1.8
+      # self-registration. 0.1.9 is the pin bump that fires the live
+      # helm-controller upgrade so the Capabilities-gated Application CR
+      # finally renders on already-converged Sovereigns.
+      version: 0.1.9
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -54,8 +54,10 @@ spec:
       # changelog. 0.1.5 ships the same-owner binding dedupe + the
       # underscore-sanitized Database CR names this slot relies on.
       # 0.1.6 ships the #3370 bootstrapOwned Application-CR
-      # self-registration.
-      version: 0.1.8
+      # self-registration. 0.1.9 is the pin bump that fires the live
+      # upgrade so the CR renders, plus this slot's newapi + openova-flow
+      # Context additions below.
+      version: 0.1.9
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -110,3 +112,32 @@ spec:
         consumer:
           blueprint: bp-catalyst-platform
           mode: shared
+      # newapi (#3370 §5 target shared-pg-c set): the bp-newapi consumer
+      # today embeds its own `newapi-bp-newapi-newapi-pg` Cluster
+      # (§4 violation). Declaring its Context here (isolated `newapi`
+      # database + `newapi` role + reflected secret into ns newapi) lets
+      # bp-newapi adopt shared-pg-c by flipping to externalDatabase mode
+      # off `newapi-database-secret` — same one-flag pattern as
+      # gitea/harbor/keycloak. READY-TO-ADOPT.
+      - name: newapi            # bp-newapi primary DB
+        owner: newapi
+        consumer:
+          blueprint: bp-newapi
+          mode: shared
+        reflect:
+          secretName: newapi-database-secret
+          namespaces: [newapi]
+      # openova-flow (#3370 §5 target shared-pg-c set): the
+      # catalyst-system openova-flow consumer today embeds its own
+      # `openova-flow-pg` Cluster (§4 violation). Its Context here
+      # (isolated `openova_flow` database + `openova_flow` role +
+      # reflected secret into ns catalyst-system) lets it adopt
+      # shared-pg-c. READY-TO-ADOPT.
+      - name: openova_flow      # openova-flow primary DB
+        owner: openova_flow
+        consumer:
+          blueprint: bp-openova-flow
+          mode: shared
+        reflect:
+          secretName: openova-flow-database-secret
+          namespaces: [catalyst-system]

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-4-1-data-services
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.1.8
+  version: 0.1.9
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,10 +1,20 @@
 apiVersion: v2
 name: bp-postgres
+# 0.1.9 — #3370: pin bump (no template change vs 0.1.8) so helm-controller
+#   performs a HelmRelease UPGRADE on already-converged Sovereigns. The
+#   application-cr.yaml self-registration is Capabilities-gated on
+#   apps.openova.io/v1; on hw133 the shared-pg{,-b,-c} HRs were INSTALLED at
+#   bootstrap (revision .v1) BEFORE the umbrella shipped that CRD, so the gate
+#   was false at install time and the Application CRs never rendered
+#   (`kubectl get applications -A` → 0 while 3 engines ran). helm-controller
+#   only re-renders chart templates on an upgrade, and an upgrade only fires on
+#   a new chart version — hence this lockstep bump. The CRD is now registered,
+#   so the upgrade renders the 3 bootstrap-owned Application CRs.
 # 0.1.7 — #3370 hotfix: bootstrap Application CR stamps environmentRef +
 #   regions so it admits under BOTH the pre-#3370 CRD (hard-required) and the
 #   #3370 CRD (CEL-waived) — breaks the live upgrade-rollback deadlock that
 #   blocked keycloak->gitea->catalyst-platform on hw130.
-version: 0.1.8
+version: 0.1.9
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable
@@ -34,6 +44,20 @@ description: |
 
   Changelog
   ─────────
+  0.1.9 (2026-06-14, Refs #3370 — pin bump to fire the live upgrade)
+    - No template change vs 0.1.8. The application-cr.yaml self-registration
+      (Capabilities-gated on apps.openova.io/v1) never materialized on
+      already-converged Sovereigns: the shared-pg{,-b,-c} HRs were INSTALLED
+      at bootstrap BEFORE the umbrella shipped that CRD (gate false → CR
+      skipped), and helm-controller does NOT re-render templates without a
+      HelmRelease UPGRADE, which only fires on a new chart version. This
+      lockstep version + slot-pin bump (16a/16c/16d) triggers that upgrade;
+      the CRD is now registered so the 3 bootstrap-owned Application CRs
+      render → 3 Deployment cards + the catalog Instances list populate.
+    - slot 16d (shared-pg-c) gains two more Context bindings — `newapi`
+      (consumer bp-newapi) + `openova-flow` (consumer bp-openova-flow) — so
+      shared-pg-c exposes the spec §5 target set (sme + newapi + openova-flow)
+      and the two embedded consumer Clusters can adopt it.
   0.1.6 (2026-06-12, Refs #3370 — Contexts + bootstrap self-registration)
     - templates/application-cr.yaml: when the slot opts in via
       bootstrapOwned.enabled, the chart self-registers the


### PR DESCRIPTION
## What

Refs #3370 (CONTEXTS). The live walk on hw133 found that the 3 shared-PG instances render **no Deployment cards** and the catalog Instances list does not populate them, even though `shared-pg{,-b,-c}` engines run healthy.

**Root cause (verified on hw133):** `kubectl get applications.apps.openova.io -A` → **0**. The chart's `application-cr.yaml` self-registration (added 0.1.6) is `.Capabilities.APIVersions.Has "apps.openova.io/v1"`-gated. The 3 bootstrap HRs were **INSTALLED** at bootstrap (revision `.v1`, 5h+ old) **before** the umbrella shipped that CRD → the gate was false at install → the Application CRs were skipped. helm-controller only re-renders chart templates on a HelmRelease **UPGRADE**, which only fires on a **new chart version** — and no pin bump has happened since install. So the CRs never materialized.

## Fix

- **Lockstep pin bump 0.1.8 → 0.1.9** (chart `Chart.yaml` + `blueprint.yaml` + slot pins 16a/16c/16d) — **no template change**. This forces helm-controller to upgrade the 3 live HRs; the CRD is now registered (created 2026-06-13 on hw133), so the upgrade renders the 3 bootstrap-owned Application CRs.
  - Result: the `/api/v1/sovereign/apps` projection (`sovereign.go:742`) emits 3 `instance:true` rows → 3 Deployment cards with `⛓ N contexts` badges, and `/catalog/bp-postgres` Instances list populates.
- **slot 16d (shared-pg-c) gains 2 Context bindings** — `newapi` (consumer `bp-newapi`) + `openova_flow` (consumer `bp-openova-flow`) — so shared-pg-c exposes the spec §5 target set (`sme + newapi + openova-flow`) and the two embedded consumer Clusters (`newapi/newapi-bp-newapi-newapi-pg`, `catalyst-system/openova-flow-pg`, §4 violations) can adopt it via externalDatabase mode. READY-TO-ADOPT.

## Verification

- `helm template` with `--api-versions apps.openova.io/v1 --api-versions postgresql.cnpg.io/v1` renders `kind: Application` (spec.bootstrap=true, blueprintRef.version 0.1.9, spec.parameters.databases carrying the Context decls) + Cluster + 5 Database CRs (sme-auth/billing/documents + newapi + openova-flow) on shared-pg-c.
- `chart/tests/postgres-render.sh` PASS (incl. Case 10 — #3370 bootstrapOwned Application-CR self-registration).
- `kubectl kustomize clusters/_template/bootstrap-kit/` green (159 resources).
- Live CRD on hw133 is the #3370-relaxed schema (only `blueprintRef` required; CEL waives environmentRef/regions when `bootstrap=true`; regions pattern accepts `platform-bootstrap-owned-host`) → the CR admits on upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)