### PR TITLE
fix(catalyst-api): openbao-sso-init shim must be public — bare-URL SSO 401'd behind RequireSession (#3374)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -986,6 +986,25 @@ func main() {
 	// what was hanging cutover on otech113 2026-05-05 (issue #935).
 	r.Post("/api/v1/internal/cutover/trigger", h.HandleCutoverInternalTrigger)
 
+	// #3374 — server-side zero-click silent-SSO shim for OpenBao.
+	// OpenBao's UI is a client-side SPA, so a static ssoInitPath can only
+	// pre-select the OIDC method (still one click). This shim asks Vault
+	// for the OIDC auth_url server-side and 302s the browser to Keycloak,
+	// giving grafana/harbor parity. The openbao HTTPRoute (bp-openbao)
+	// 302s the BARE URL (`/`, `/ui`, `/ui/`) straight here, so the very
+	// first request comes from a FRESH browser with NO catalyst_session
+	// cookie — therefore this route MUST live OUTSIDE RequireSession.
+	// Putting it inside (where it shipped through #3226) made the session
+	// middleware reject every bare-URL visit with 401 {"error":
+	// "unauthenticated"} before HandleOpenBaoSSOInit ever ran, so the
+	// founder-witnessed token form never got bypassed (caught live on
+	// hw133). The handler is self-contained and session-free: it resolves
+	// the blueprint from the catalog (empty session token tolerated), asks
+	// Vault for the auth_url, and 302s to Keycloak — falling back to the
+	// app deep-link on any error so it can NEVER 500, and 404ing only when
+	// no SSO-enabled openbao endpoint resolves.
+	r.Get("/catalyst/v1/apps/{id}/openbao-sso-init", h.HandleOpenBaoSSOInit)
+
 	// Auth-gated wizard endpoints — RequireSession validates the
 	// HMAC-signed catalyst_session cookie on every request. When
 	// cfg is nil (Sovereign clusters, CI without CATALYST_KC_ADDR)
@@ -1514,13 +1533,11 @@ func main() {
 		rg.Patch("/catalyst/v1/apps/{id}/endpoints/{name}", h.HandlePatchAppEndpoint)
 		rg.Delete("/catalyst/v1/apps/{id}/endpoints/{name}", h.HandleDeleteAppEndpoint)
 		rg.Get("/catalyst/v1/apps/{id}/launch-url", h.HandleGetLaunchURL)
-		// #3226 — server-side zero-click silent-SSO shim for OpenBao.
-		// OpenBao's UI is a client-side SPA, so a static ssoInitPath can
-		// only pre-select the OIDC method (still one click). This shim
-		// asks Vault for the OIDC auth_url server-side and 302s the
-		// browser to Keycloak, giving grafana/harbor parity. The openbao
-		// blueprint's ssoInitPath points the Open button at this route.
-		rg.Get("/catalyst/v1/apps/{id}/openbao-sso-init", h.HandleOpenBaoSSOInit)
+		// NOTE: the OpenBao silent-SSO shim (openbao-sso-init) is
+		// registered OUTSIDE this RequireSession group — see the public
+		// route above. A fresh browser hitting bao.<fqdn>/ has NO
+		// catalyst_session cookie, so RequireSession would 401 it before
+		// the shim ever ran (#3374 root cause).
 		rg.Post("/catalyst/v1/apps/instances", h.HandleCreateInstance)
 		rg.Get("/catalyst/v1/catalog/{blueprint}/instances", h.HandleListBlueprintInstances)
 

--- a/products/catalyst/bootstrap/api/internal/handler/openbao_sso_init_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/openbao_sso_init_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
 )
 
@@ -162,6 +163,76 @@ func TestOpenBaoSSOInit_UnknownAppIs404(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for unknown app, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestOpenBaoSSOInit_ReachableWithoutSession — #3374 REGRESSION GUARD.
+//
+// The bare-URL contract (bp-openbao HTTPRoute 302s `/`, `/ui`, `/ui/`
+// straight to this shim) means the VERY FIRST request always comes from a
+// FRESH browser with NO `catalyst_session` cookie. The shim therefore MUST
+// be registered OUTSIDE the RequireSession middleware group. It originally
+// shipped (#3226) INSIDE that group, so on hw133 every bare-URL visit was
+// rejected by the session middleware with 401 {"error":"unauthenticated"}
+// before HandleOpenBaoSSOInit ever ran — the founder-witnessed token form
+// was never bypassed.
+//
+// This test reproduces production's two-group router shape (a public route
+// + a RequireSession-gated sibling) with a non-nil auth.Config (so the
+// middleware actually enforces) and asserts:
+//   - cookieless GET to the shim → 302 (the handler ran), NOT 401; and
+//   - cookieless GET to a RequireSession sibling → 401 (proving the
+//     middleware IS live in this harness, so the 302 above is meaningful).
+func TestOpenBaoSSOInit_ReachableWithoutSession(t *testing.T) {
+	vault := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"auth_url": "https://auth.t01.omani.works/realms/sovereign/protocol/openid-connect/auth?client_id=openbao",
+			},
+		})
+	}))
+	defer vault.Close()
+
+	h := newSSOInitHandler(t, vault.URL)
+	log := slog.New(slog.NewTextHandler(io_discard{}, nil))
+
+	// A non-nil Config with no cookie secret + no JWKS makes RequireSession
+	// enforce: ReadSessionToken returns "" for a cookieless request, so the
+	// middleware 401s before the handler. (A nil Config would be a
+	// transparent passthrough and would NOT catch the placement bug.)
+	cfg := &auth.Config{Realm: "sovereign", ClientID: "catalyst-zero-ui"}
+
+	r := chi.NewMux()
+	// Public group (mirrors main.go: shim lives here, OUTSIDE RequireSession).
+	r.Get("/catalyst/v1/apps/{id}/openbao-sso-init", h.HandleOpenBaoSSOInit)
+	// Session-gated group (mirrors main.go's r.Group(RequireSession)).
+	r.Group(func(rg chi.Router) {
+		rg.Use(auth.RequireSession(cfg, log))
+		rg.Get("/api/v1/whoami", h.HandleWhoami)
+	})
+
+	// 1) The shim must run WITHOUT a session cookie → 302, never 401.
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("GET", "/catalyst/v1/apps/openbao/openbao-sso-init", nil))
+	if rec.Code == http.StatusUnauthorized {
+		t.Fatalf("REGRESSION (#3374): cookieless bare-URL visit got 401 %s — "+
+			"the openbao-sso-init shim is behind RequireSession again; it MUST "+
+			"be registered in the PUBLIC route section of main.go", rec.Body.String())
+	}
+	if rec.Code != http.StatusFound {
+		t.Fatalf("expected the shim to 302 a cookieless browser to Keycloak, got %d (body=%s)",
+			rec.Code, rec.Body.String())
+	}
+
+	// 2) Sanity: the RequireSession middleware IS enforcing in this harness,
+	//    so the 302 above is a real "handler ran without a session", not a
+	//    passthrough artefact.
+	rec2 := httptest.NewRecorder()
+	r.ServeHTTP(rec2, httptest.NewRequest("GET", "/api/v1/whoami", nil))
+	if rec2.Code != http.StatusUnauthorized {
+		t.Fatalf("harness check: a RequireSession route should 401 without a "+
+			"cookie, got %d — the middleware is not enforcing, so this test "+
+			"cannot prove the shim is genuinely public", rec2.Code)
 	}
 }
 


### PR DESCRIPTION
## Problem (verified live on hw133)

The OpenBao bare-URL zero-click contract (#3374) wires `bp-openbao`'s HTTPRoute to 302 the bare paths (`/`, `/ui`, `/ui/`) straight to catalyst-api's `openbao-sso-init` shim, which asks Vault for the OIDC `auth_url` server-side and 302s the browser to Keycloak (grafana/harbor parity).

But the shim route shipped (#3226) **INSIDE** the `RequireSession` middleware group. The very first request always comes from a **fresh browser with no `catalyst_session` cookie**, so `auth.RequireSession` rejected every bare-URL visit with `401 {"error":"unauthenticated"}` *before* `HandleOpenBaoSSOInit` ever ran.

Live evidence on hw133:
```
$ curl -sk https://api.hw133.omani.works/catalyst/v1/apps/openbao/openbao-sso-init
HTTP 401
{"error":"unauthenticated"}
```
So `bao.hw133.omani.works/` → 302 → shim → **401**, the founder-witnessed token form was never bypassed.

(Confirmed `openova-flow` and `pdns-admin`, the other two LIVE FAILURES in the ticket, already 302 to the KC realm correctly on hw133 — flow via its `oidc-gate` oauth2-proxy, pdns-admin via its callback-aware `/` → `/oidc/login` HTTPRoute. The openbao shim was the remaining real breakage.)

## Fix

Move the `openbao-sso-init` route into the **public** section of `main.go`, alongside the handover receiver (`/auth/handover`), the kubeconfig PUT, and the cutover trigger — the other browser/in-cluster entry points that mint their own auth and must live outside `RequireSession` for exactly this reason.

The handler is self-contained and session-free: resolves the blueprint from the catalog (empty session token tolerated), asks Vault for the `auth_url`, 302s to Keycloak, **falls back to the app deep-link on any error (never 500s)**, and 404s only when no SSO-enabled openbao endpoint resolves.

## Regression guard

`TestOpenBaoSSOInit_ReachableWithoutSession` builds production's two-group router shape with an **enforcing** `auth.Config` and asserts:
- cookieless GET to the shim → **302** (handler ran), not 401;
- cookieless GET to a `RequireSession` sibling (`/api/v1/whoami`) → **401** (proving the middleware is live in the harness, so the 302 is meaningful).

A throwaway negative control confirmed the buggy placement (shim inside `RequireSession`) does 401.

## What the walker should see at the bare URL

`bao.hw133.omani.works/` (or `/ui/`) in a fresh incognito browser → 302 to the shim → 302 to `auth.<fqdn>` (silent `kc_idp_hint=catalyst-pin`) → Vault UI callback → **landed in the signed-in Vault UI, no token form**.

## Tests
- `go build ./...` — clean
- `go vet ./cmd/api/ ./internal/handler/` — clean
- `go test -race -run 'OpenBaoSSOInit|ComputeVaultUICallback' ./internal/handler/` — ok

Refs #3374 #3226

🤖 Generated with [Claude Code](https://claude.com/claude-code)