### PR TITLE
feat(console): suppress Switchover for active-active/none DR variants (Refs #3375)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -273,6 +273,16 @@ export function TopologyTab({
   }, [liveClass, declaredClass])
   const showDR = isDRCapableClass(effectiveDRClass)
 
+  // Whether this variant carries an operator-initiated switchover. active-active
+  // apps that declare `switchover: none` (e.g. clickhouse/iceberg/vllm — both
+  // regions serve, no promotion) get the replication/DR info but NO Switchover
+  // button (there's nothing to promote). hot-standby / active-passive always do.
+  const switchoverMechanism = declaredVariant?.switchover?.mechanism ?? null
+  const hasSwitchover =
+    effectiveDRClass === 'active-hot-standby' ||
+    effectiveDRClass === 'active-passive' ||
+    (!!switchoverMechanism && switchoverMechanism.toLowerCase() !== 'none')
+
   useEffect(() => {
     // When initialApp updates, just trigger no-op so consumers re-derive.
   }, [initialApp])
@@ -395,7 +405,8 @@ export function TopologyTab({
           namespace={namespace}
           callerTier={callerTier}
           declaredClass={effectiveDRClass}
-          switchoverMechanism={declaredVariant?.switchover?.mechanism ?? null}
+          switchoverMechanism={switchoverMechanism}
+          hasSwitchover={hasSwitchover}
           disableNetwork={disableNetwork}
         />
       ) : null}

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/DRSection.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/DRSection.tsx
@@ -63,6 +63,13 @@ export interface DRSectionProps {
    * raft-transition) surfaced in the contract line when no live CR exists.
    */
   switchoverMechanism?: string | null
+  /**
+   * #3375 — whether this variant carries an operator-initiated switchover.
+   * false for active-active apps that declare `switchover: none` (both
+   * regions serve, no promotion) — the panel then shows the replication
+   * posture but no Switchover button. Defaults true for back-compat.
+   */
+  hasSwitchover?: boolean
   /** Test seam — pre-fill the Continuum CR + audit list, skip network. */
   initialContinuum?: ContinuumGetResponse
   /** Test seam — bypass the audit fetch + network calls. */
@@ -77,6 +84,7 @@ export function DRSection({
   callerTier,
   declaredClass,
   switchoverMechanism,
+  hasSwitchover = true,
   initialContinuum,
   disableNetwork = false,
 }: DRSectionProps) {
@@ -151,8 +159,9 @@ export function DRSection({
   // switchover — the catalyst-api handler defaults the target to the first
   // hot-standby region server-side, so we pass an empty target and let the
   // dialog/handler resolve it. This is what makes the control walkable
-  // rather than permanently absent.
-  const canSwitchover = isOwner && (!!failoverTarget || crMissing)
+  // rather than permanently absent. Suppressed entirely when the variant
+  // declares no switchover (active-active / none).
+  const canSwitchover = hasSwitchover && isOwner && (!!failoverTarget || crMissing)
 
   return (
     <section
@@ -163,7 +172,14 @@ export function DRSection({
         <h3 className="text-sm font-semibold text-[var(--color-text-strong)]">
           {heading}
         </h3>
-        {canSwitchover ? (
+        {!hasSwitchover ? (
+          <span
+            data-testid="continuum-dr-no-switchover"
+            className="text-xs text-[var(--color-text-dim)]"
+          >
+            Both regions serve — no switchover
+          </span>
+        ) : canSwitchover ? (
           <button
             type="button"
             data-testid="continuum-dr-switchover-btn"


### PR DESCRIPTION
Refinement on top of #3426 (the #3375 Topology read-back + DR panel).

`active-active` apps that declare `switchover: none` (clickhouse, iceberg, vllm, livekit, knative, …) — both regions serve live traffic, no promotion — now show the replication posture but **no Switchover button**, with an explicit "Both regions serve — no switchover" note. hot-standby + active-passive (and any active-active declaring a real mechanism like `mm2-symmetric` / `ccr-promote`) keep the working Switchover control. Prevents a misleading promote action on apps the matrix declares `switchover: none`.

`TopologyTab` computes `hasSwitchover` from the declared variant's switchover mechanism and threads it into `DRSection`; the button + "Owner tier required" states are gated behind it.

Verified: UI `tsc -b` clean (0 errors on current main); all 10 continuum + AppDetail test files (77 tests) pass.

Refs #3375

🤖 Generated with [Claude Code](https://claude.com/claude-code)