### PR TITLE
fix(bp-openbao): sso-configure identity-group alias mapping idempotent — kill false per-tick WARN (#3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -77,7 +77,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.31
+      version: 1.2.32
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.31
+  version: 1.2.32
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -26,7 +26,19 @@ name: bp-openbao
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.2.31
+version: 1.2.32
+# 1.2.32 (#3374, 2026-06-13): sso-configure external identity-group mapping
+# is now FULLY idempotent. The reconciler created each sovereign-admins /
+# sovereign-ops → sso-operator-admin alias via POST identity/group-alias,
+# which Vault 400s ("alias already exists") on EVERY tick after the first —
+# so the loop logged "WARN: mapping external group … failed" forever even
+# though tick-1 had bound it (verified live on hw133). Two fixes: (a) parse
+# the canonical group id from data.canonical_id (not a greedy "id" match
+# that could grab the alias sub-object's id and corrupt the binding); (b) on
+# subsequent ticks UPDATE the existing alias via
+# identity/group-alias/id/<alias_id> instead of re-creating it. The admin
+# uplift was already live (tick-1 succeeded), but the false per-tick WARN
+# masked genuine failures and the greedy id parse was a latent rebind hazard.
 # 1.2.29 (#3374, 2026-06-13): BARE-URL zero-click SSO. The #3226 shim only
 # fired from the console Open button; typing bao.<fqdn>/ui/ still showed the
 # token form (founder-witnessed). The HTTPRoute now 302s the bare entry paths

--- a/platform/openbao/chart/templates/sso-configure-deployment.yaml
+++ b/platform/openbao/chart/templates/sso-configure-deployment.yaml
@@ -264,21 +264,55 @@ data:
       if [ -z "${OIDC_ACCESSOR}" ]; then
         log "WARN: could not resolve oidc auth mount accessor; admin-group mapping deferred to next tick"
       else
+        # group_field pulls the FIRST "<key>":"<value>" out of a
+        # `bao_get identity/group/name/<name>` body (one comma-joined line).
+        # The body nests an `alias` sub-object that ALSO carries `id` +
+        # `canonical_id`, so a greedy `.*"id":"…"` over the whole line is
+        # ambiguous. We split on commas first (tr , \n) and take head -1,
+        # which deterministically returns the EARLIEST key occurrence:
+        #   - `canonical_id` appears once (inside the alias) and its value
+        #     IS the canonical group id we must bind the alias to → _gid;
+        #   - `id` appears first as the alias's own id → _aid (the alias to
+        #     UPDATE on re-runs). $1=json body, $2=key name.
+        group_field() {
+          printf '%s' "$1" | tr ',' '\n' | sed -n "s/.*\"$2\":\"\([^\"]*\)\".*/\1/p" | head -1
+        }
         map_admin_group() {
-          # $1 = realm group name (claim value)
+          # $1 = realm group name (claim value). Fully idempotent: creates
+          # the external group + alias on first tick, and UPDATES both on
+          # every subsequent tick. Vault rejects a DUPLICATE
+          # `identity/group-alias` create with 400 ("alias already exists"),
+          # so re-creating an existing alias every tick logged a false
+          # "mapping failed" forever (#3374, hw133) even though tick-1 had
+          # already bound it. The update path targets the existing alias by
+          # id via identity/group-alias/id/<alias_id>.
           _grp="$1"
-          # Idempotent create/update of the external group with the admin policy.
           _gjson="$(bao_get "identity/group/name/${_grp}")"
-          _gid="$(printf '%s' "${_gjson}" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')"
+          # The canonical group id == the alias.canonical_id in the body.
+          _gid="$(group_field "${_gjson}" canonical_id)"
+          # The existing group-alias id (absent until the first alias write).
+          _aid="$(group_field "${_gjson}" id)"
           if [ -z "${_gid}" ]; then
+            # Group does not exist yet — create it, then re-read its id.
             bao_write "identity/group" "$(printf '{"name":"%s","type":"external","policies":["sso-operator-admin"]}' "${_grp}")" || return 1
-            _gid="$(bao_get "identity/group/name/${_grp}" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')"
+            _gjson="$(bao_get "identity/group/name/${_grp}")"
+            _gid="$(group_field "${_gjson}" canonical_id)"
+            _aid="$(group_field "${_gjson}" id)"
           else
+            # Group exists — keep its policy current (last-write-wins).
             bao_write "identity/group/name/${_grp}" '{"type":"external","policies":["sso-operator-admin"]}' || return 1
           fi
           [ -z "${_gid}" ] && return 1
-          # Idempotent alias: name == claim value, bound to this oidc mount.
-          bao_write "identity/group-alias" "$(printf '{"name":"%s","mount_accessor":"%s","canonical_id":"%s"}' "${_grp}" "${OIDC_ACCESSOR}" "${_gid}")"
+          # Bind (or rebind) the alias: name == the realm group claim value,
+          # mounted on this oidc accessor, pointing at the canonical group.
+          if [ -n "${_aid}" ]; then
+            # Alias already exists → UPDATE by id (POST to the same path on
+            # an existing alias 400s with "alias already exists").
+            bao_write "identity/group-alias/id/${_aid}" "$(printf '{"name":"%s","mount_accessor":"%s","canonical_id":"%s"}' "${_grp}" "${OIDC_ACCESSOR}" "${_gid}")"
+          else
+            # No alias yet → CREATE it.
+            bao_write "identity/group-alias" "$(printf '{"name":"%s","mount_accessor":"%s","canonical_id":"%s"}' "${_grp}" "${OIDC_ACCESSOR}" "${_gid}")"
+          fi
         }
         for g in "${OIDC_ADMIN_GROUP}" "${OIDC_OPS_GROUP}"; do
           if map_admin_group "${g}"; then


### PR DESCRIPTION
## Problem (verified live on hw133)

The openbao `sso-configure` reconciler maps the realm groups `sovereign-admins` / `sovereign-ops` → the `sso-operator-admin` Vault policy via an external identity group + group-alias. It created the alias with `POST identity/group-alias`, which Vault **400s** with `alias already exists` on **every tick after the first**. So `map_admin_group` returned non-zero and the loop logged:

```
WARN: mapping external group sovereign-admins failed; retrying next tick
WARN: mapping external group sovereign-ops failed; retrying next tick
```

…every 60s. On hw133 it had been doing this for 5h. The admin grant (bound at tick-1) was actually intact, but the false failure signal violates phase-narrate-truthfully and masks genuine future failures (e.g. if the alias ever needs recreating), and the greedy id parse was a latent rebind hazard.

## Root cause (isolated live via the sso-configure SA token)

```
group-alias exit=1          # POST identity/group-alias  → HTTP 400 "alias already exists"
```
The reconcile reads the group body, which nests an `alias` sub-object carrying BOTH `id` and `canonical_id`, then re-POSTs a create on an alias that already exists.

## Fix (at source)

- `group_field()` parses `data.canonical_id` as the canonical group id (split-on-comma + `head -1`) instead of a greedy `."id".":"` match that could grab the alias sub-object's id and bind the alias to the wrong canonical id.
- On subsequent ticks the alias is **UPDATED** via `identity/group-alias/id/<alias_id>` instead of re-created → genuinely idempotent, logs `mapped`.

## Live verification (hw133, against the running openbao)

```
canonical_id(_gid) = [6a03ee63-4b8c-a652-3d8b-e36e0e107457]
id(_aid)           = [31a2a27f-6ac6-ce47-765b-405465fc22c9]
alias UPDATE by id exit=0          # was 400
```
Both `sovereign-admins` and `sovereign-ops` already carry `policies:["sso-operator-admin"]` with a valid alias on `mount_accessor: auth_oidc_8f978fe6`, so an operator in `sovereign-admins` lands with **full admin policy**. This fix removes the false failure signal and hardens the binding.

## Validation
- `reconcile.sh` passes `dash -n` (POSIX-strict, matches the kom4dc `/bin/sh`) and `sh -n` — zero leaked Helm directives.
- Chart `1.2.31` → `1.2.32`; bootstrap-kit slot `08-openbao.yaml` pin bumped in lockstep.

## What the walker should see at the bare URL

Combined with the catalyst-api shim-route fix (#3429, merged): `bao.<fqdn>/ui/` in a fresh incognito → silent KC PIN → Vault UI callback → **signed-in Vault UI with admin (superuser) policy**, no token form, no read-only downgrade.

Refs #3374 #3150

🤖 Generated with [Claude Code](https://claude.com/claude-code)