### PR TITLE
fix(bp-postgres): sanitize per-owner role-Secret name (RFC 1123) — unblocks hw133 catalyst chain — 0.1.10 (Refs #3375)

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -119,7 +119,9 @@ spec:
       # helm-controller UPGRADE on already-converged Sovereigns so the
       # Capabilities-gated Application CR renders (it was skipped at the
       # bootstrap INSTALL, before the umbrella shipped the CRD).
-      version: 0.1.9
+      # 0.1.10 (#3375): role-Secret name RFC-1123 sanitization (lockstep
+      # bump with 16c/16d — underscore-owner fix, see chart changelog).
+      version: 0.1.10
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -70,7 +70,9 @@ spec:
       # self-registration. 0.1.9 is the pin bump that fires the live
       # helm-controller upgrade so the Capabilities-gated Application CR
       # finally renders on already-converged Sovereigns.
-      version: 0.1.9
+      # 0.1.10 (#3375): role-Secret name RFC-1123 sanitization (lockstep
+      # bump with 16a/16d — underscore-owner fix, see chart changelog).
+      version: 0.1.10
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -57,7 +57,9 @@ spec:
       # self-registration. 0.1.9 is the pin bump that fires the live
       # upgrade so the CR renders, plus this slot's newapi + openova-flow
       # Context additions below.
-      version: 0.1.9
+      # 0.1.10 (#3375): role-Secret name RFC-1123 sanitization — fixes THIS
+      # slot's Stalled upgrade (Secret "shared-pg-c-openova_flow" invalid).
+      version: 0.1.10
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-4-1-data-services
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.1.9
+  version: 0.1.10
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,5 +1,14 @@
 apiVersion: v2
 name: bp-postgres
+# 0.1.10 — #3375: sanitize the per-OWNER role-Secret name (roleSecretName
+#   helper) so an owner with a legal-Postgres underscore (e.g. `openova_flow`)
+#   renders the valid k8s Secret name `<instance>-openova-flow` instead of the
+#   RFC-1123-invalid `<instance>-openova_flow`. On hw133 the shared-pg-c HR was
+#   Stalled ("Secret \"shared-pg-c-openova_flow\" is invalid: metadata.name …")
+#   which blocked the WHOLE bp-catalyst-platform dependsOn chain from upgrading
+#   (catalyst-ui frozen on the old image). 0.1.5 already sanitized the Database
+#   CR names but missed the role-Secret name — this closes that gap. spec roles
+#   + username keep the real underscore'd identifier (Postgres allows it).
 # 0.1.9 — #3370: pin bump (no template change vs 0.1.8) so helm-controller
 #   performs a HelmRelease UPGRADE on already-converged Sovereigns. The
 #   application-cr.yaml self-registration is Capabilities-gated on
@@ -14,7 +23,7 @@ name: bp-postgres
 #   regions so it admits under BOTH the pre-#3370 CRD (hard-required) and the
 #   #3370 CRD (CEL-waived) — breaks the live upgrade-rollback deadlock that
 #   blocked keycloak->gitea->catalyst-platform on hw130.
-version: 0.1.9
+version: 0.1.10
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable
@@ -44,6 +53,17 @@ description: |
 
   Changelog
   ─────────
+  0.1.10 (2026-06-14, Refs #3375 — role-Secret name RFC-1123 sanitization)
+    - _helpers.tpl: new `bp-postgres.k8sName` sanitizer; `roleSecretName`
+      now sanitizes the owner segment so an owner like `openova_flow` yields
+      the valid `<instance>-openova-flow` Secret name (was the invalid
+      `<instance>-openova_flow`). cluster.yaml managed.roles[].passwordSecret
+      and role-secrets.yaml share the helper so the CNPG role reference and
+      the created Secret stay in lockstep. The PG role name + username keep
+      the verbatim underscore'd identifier. Unblocks hw133 shared-pg-c (was
+      Stalled on the invalid Secret name → blocked the bp-catalyst-platform
+      dependsOn chain). Completes the 0.1.5 Database-CR-name sanitization,
+      which had missed the role-Secret path.
   0.1.9 (2026-06-14, Refs #3370 — pin bump to fire the live upgrade)
     - No template change vs 0.1.8. The application-cr.yaml self-registration
       (Capabilities-gated on apps.openova.io/v1) never materialized on

--- a/platform/postgres/chart/templates/_helpers.tpl
+++ b/platform/postgres/chart/templates/_helpers.tpl
@@ -18,16 +18,33 @@ bp-postgres common helpers (ADR-0010, #3188).
 {{- end -}}
 
 {{/*
+Sanitise an arbitrary string into an RFC 1123 DNS-subdomain-safe name
+fragment so it can be used in a k8s resource name. PostgreSQL identifiers
+(role/database names) legally contain underscores (e.g. `openova_flow`),
+but k8s object names may NOT — a Secret named `shared-pg-c-openova_flow`
+is rejected with `metadata.name: Invalid value … must be lowercase RFC
+1123`. This lowercases and replaces every run of non-[a-z0-9-] with a
+single `-`, then trims leading/trailing `-`. (#3375 hw133 — bp-postgres-
+shared-c was Stalled on exactly this, which blocked the whole
+bp-catalyst-platform dependsOn chain.)
+*/}}
+{{- define "bp-postgres.k8sName" -}}
+{{- regexReplaceAll "[^a-z0-9-]+" (lower (toString .)) "-" | trimAll "-" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 The Secret name CNPG reconciles a managed role's password FROM. When a
 binding omits `passwordSecret`, default to `<instance>-<owner>` so a
 CNPG-bootstrapped role Secret (or a same-named consumer Secret) lines up.
+The owner segment is sanitised (k8sName) so an owner like `openova_flow`
+yields the valid `…-openova-flow` instead of an underscore'd invalid name.
 */}}
 {{- define "bp-postgres.roleSecretName" -}}
 {{- $instance := include "bp-postgres.instanceName" .ctx -}}
 {{- if .db.passwordSecret -}}
 {{- .db.passwordSecret -}}
 {{- else -}}
-{{- printf "%s-%s" $instance .db.owner -}}
+{{- printf "%s-%s" $instance (include "bp-postgres.k8sName" .db.owner) -}}
 {{- end -}}
 {{- end -}}
 

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -337,4 +337,48 @@ if grep -qE '^kind: Application$' "$TMP/appcr-off.yaml"; then
   fail "#3370: Application CR rendered with bootstrapOwned OFF (would duplicate the controller-created CR)"
 fi
 
-echo "[render] PASS — bp-postgres render gate green (reuse proof: 1 Cluster, 2 Databases, 2 roles, 2 Secrets; master gate OFF → empty; 3-instance shapes locked; #3370 Application-CR self-registration locked)"
+# ── Case 11: #3375 — underscore OWNER → sanitized role-Secret name ────
+# An owner with a legal-Postgres underscore (openova_flow) must render the
+# RFC-1123-valid role-Secret name `shared-pg-c-openova-flow` AND the CNPG
+# managed.roles[].passwordSecret.name must reference the SAME sanitized
+# name (cluster.yaml + role-secrets.yaml share the roleSecretName helper).
+# The PG role + username keep the verbatim underscore'd identifier. Locks
+# the hw133 shared-pg-c Stalled fix (Secret "…-openova_flow" was invalid).
+echo "[render] Case 11: underscore owner → sanitized role-Secret name (#3375)"
+cat > "$TMP/uscore.values.yaml" <<'YAML'
+instance:
+  name: shared-pg-c
+  namespace: shared-data
+topology:
+  mode: singleton
+  instances: 1
+databases:
+  - name: openova_flow
+    owner: openova_flow
+    consumer: { blueprint: bp-openova-flow, mode: shared }
+    reflect: { namespaces: [catalyst-system] }
+YAML
+helm template shared-pg-c . -f "$TMP/uscore.values.yaml" --namespace shared-data \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/uscore.yaml" 2> "$TMP/uscore.err" || {
+  cat "$TMP/uscore.err" >&2; fail "underscore-owner render errored"; }
+# The role-password Secret name (Secret metadata.name, 2-space indent) is sanitized.
+grep -qE '^  name: "?shared-pg-c-openova-flow"?$' "$TMP/uscore.yaml" \
+  || fail "#3375: role Secret name not sanitized (expected shared-pg-c-openova-flow)"
+# The CNPG managed role references the SAME sanitized Secret name (10-space
+# indent under managed.roles[].passwordSecret) — proves the cluster.yaml +
+# role-secrets.yaml lockstep via the shared roleSecretName helper.
+grep -qE '^          name: "?shared-pg-c-openova-flow"?$' "$TMP/uscore.yaml" \
+  || fail "#3375: managed.roles passwordSecret.name not sanitized / not in lockstep"
+# The Database CR's OWN metadata.name (2-space indent) is sanitized too
+# (0.1.5 contract); no k8s object name carries the underscore.
+if grep -qE '^  name: "?shared-pg-c-[a-z0-9-]*_' "$TMP/uscore.yaml"; then
+  fail "#3375: a k8s resource name leaked an underscore"
+fi
+# The PG role + username + Database spec.name keep the verbatim underscore'd
+# identifier (Postgres permits it; only the k8s OBJECT names are sanitized).
+grep -qE '^      - name: "openova_flow"$' "$TMP/uscore.yaml" \
+  || fail "#3375: managed role name should keep the verbatim openova_flow identifier"
+grep -q 'username: "openova_flow"' "$TMP/uscore.yaml" \
+  || fail "#3375: role Secret username should keep the verbatim openova_flow identifier"
+
+echo "[render] PASS — bp-postgres render gate green (reuse proof: 1 Cluster, 2 Databases, 2 roles, 2 Secrets; master gate OFF → empty; 3-instance shapes locked; #3370 Application-CR self-registration locked; #3375 underscore-owner role-Secret sanitization locked)"


### PR DESCRIPTION
## Unblocks the hw133 catalyst-platform upgrade chain (blocks #3375 verification)

On hw133 `bp-postgres-shared-c` is **Stalled**:
> Helm upgrade failed … Secret `"shared-pg-c-openova_flow"` is invalid: `metadata.name`: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters…

The slot declares a database/owner `openova_flow` (a legal Postgres identifier — underscores allowed). The `roleSecretName` helper built the per-owner role-Secret name as `<instance>-<owner>` = `shared-pg-c-openova_flow`, which k8s rejects. 0.1.5 already sanitized the **Database CR** names but missed the **role-Secret** path.

**Blast radius:** `bp-catalyst-platform` (and the umbrella) `dependsOn bp-postgres-shared-c`, so this Stalled HR froze the whole catalyst chain — the `catalyst-ui` pod could not upgrade (stuck on the old image), which is exactly what blocked the #3375 Topology read-back console code (PRs #3426 + #3430, already merged + published in chart 1.4.607+) from reaching hw133.

### Fix
- `_helpers.tpl`: new `bp-postgres.k8sName` sanitizer (lowercase, non-`[a-z0-9-]`→`-`, trim); `roleSecretName` sanitizes the owner segment → `shared-pg-c-openova-flow`. `cluster.yaml` `managed.roles[].passwordSecret.name` and `role-secrets.yaml` share the helper → CNPG role ref + created Secret stay in lockstep.
- PG role name + username + Database `spec.name` keep the verbatim underscore'd identifier (Postgres permits it; only k8s object names are sanitized).
- `chart/tests/postgres-render.sh` **Case 11** locks the underscore-owner shape.
- `Chart.yaml` + `blueprint.yaml` 0.1.9 → 0.1.10; slots **16a/16c/16d** pin bump in lockstep so the live HelmRelease UPGRADE fires.

### Verified
`bash platform/postgres/chart/tests/postgres-render.sh` → all **11** cases pass; `helm lint` clean; rendered against the **real hw133 shared-pg-c values** → 0 underscore resource names, `openova-flow` referenced consistently in both the Secret and the CNPG passwordSecret.

Refs #3375

🤖 Generated with [Claude Code](https://claude.com/claude-code)