### PR TITLE
fix(bp-openbao): managed-by:flux on hook+cron Jobs — kyverno blocked 1.2.32, HR rolled back (#3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -77,7 +77,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.32
+      version: 1.2.33
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.32
+  version: 1.2.33
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -26,7 +26,17 @@ name: bp-openbao
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.2.32
+version: 1.2.33
+# 1.2.33 (#3374, 2026-06-13): the three openbao Job/CronJob templates
+# (init-job, auth-bootstrap-job post-upgrade hooks + the snapshot-replication
+# CronJob) now carry `app.kubernetes.io/managed-by: flux`. The kyverno
+# `flux-managed` Enforce policy (baseline 10-flux-managed) gates Job + CronJob
+# in the openbao namespace (NOT on its exclude list) and DENIES any without
+# that label. Helm hook Jobs are created by the helm-controller, not Flux, so
+# the FIRST chart roll on a converged Enforce env (hw133) failed the
+# post-upgrade init-job hook → the HR rolled the 1.2.32 upgrade back to 1.2.31
+# every attempt → the sso-configure idempotency fix never reached the cluster.
+# Same landmine class as the gitea/harbor hook Jobs (#3296→#3297).
 # 1.2.32 (#3374, 2026-06-13): sso-configure external identity-group mapping
 # is now FULLY idempotent. The reconciler created each sovereign-admins /
 # sovereign-ops → sso-operator-admin alias via POST identity/group-alias,

--- a/platform/openbao/chart/templates/auth-bootstrap-job.yaml
+++ b/platform/openbao/chart/templates/auth-bootstrap-job.yaml
@@ -67,6 +67,11 @@ metadata:
   labels:
     catalyst.openova.io/blueprint: bp-openbao
     catalyst.openova.io/component: openbao-auth-bootstrap
+    # kyverno `flux-managed` Enforce DENIES a Job without this label. Helm
+    # hook Jobs are created by the helm-controller, not Flux, so stamp it
+    # explicitly or the FIRST chart roll on a converged Enforce env fails
+    # the post-upgrade hook and the HR rolls back (#3374 / #3296 class).
+    app.kubernetes.io/managed-by: flux
 spec:
   activeDeadlineSeconds: {{ $deadline }}
   backoffLimit: {{ $backoff }}

--- a/platform/openbao/chart/templates/init-job.yaml
+++ b/platform/openbao/chart/templates/init-job.yaml
@@ -66,6 +66,14 @@ metadata:
   labels:
     catalyst.openova.io/blueprint: bp-openbao
     catalyst.openova.io/component: openbao-init
+    # kyverno `flux-managed` Enforce (baseline policy
+    # workload-must-be-flux-managed) DENIES any Job lacking this label.
+    # Helm hook Jobs are created by the helm-controller, not Flux directly,
+    # so they need it stamped explicitly — without it the FIRST chart roll
+    # on a converged kyverno-Enforce env fails the post-upgrade hook and
+    # the HR rolls back (caught live on hw133, #3374; same class as the
+    # gitea/harbor sso-configure hook landmine #3296→#3297).
+    app.kubernetes.io/managed-by: flux
 spec:
   activeDeadlineSeconds: {{ $deadline }}
   backoffLimit: {{ $backoff }}

--- a/platform/openbao/chart/templates/snapshot-replication.yaml
+++ b/platform/openbao/chart/templates/snapshot-replication.yaml
@@ -163,6 +163,11 @@ metadata:
     catalyst.openova.io/blueprint: bp-openbao
     catalyst.openova.io/component: openbao-snapshot-replication
     catalyst.openova.io/snapshot-role: {{ $role | quote }}
+    # kyverno `flux-managed` Enforce gates CronJob + Job in the openbao ns
+    # (not on its exclude list). Helm stamps managed-by=Helm, not flux, so
+    # the CronJob AND its spawned Jobs (jobTemplate below) need this label
+    # explicitly or admission denies them when DoD-8 enables replication.
+    app.kubernetes.io/managed-by: flux
 spec:
   schedule: {{ $schedule | quote }}
   # Async, periodic — matches the row's "async perf-replication". Never run
@@ -176,6 +181,9 @@ spec:
       labels:
         catalyst.openova.io/blueprint: bp-openbao
         catalyst.openova.io/component: openbao-snapshot-replication
+        # The CronJob-spawned Job is itself gated by the flux-managed
+        # policy — stamp managed-by=flux on the jobTemplate too.
+        app.kubernetes.io/managed-by: flux
     spec:
       activeDeadlineSeconds: {{ $deadline }}
       backoffLimit: {{ $backoff }}


### PR DESCRIPTION
## Problem (verified live on hw133)

The previous bp-openbao bump (1.2.32, the sso-configure idempotency fix) **failed to upgrade and rolled back to 1.2.31 on every attempt**:

```
Released=False reason=UpgradeFailed: post-upgrade hooks failed:
  Hook post-upgrade bp-openbao/templates/init-job.yaml failed:
  admission webhook "validate.kyverno.svc-fail" denied:
  Job/openbao-init is not Flux-managed. Add label `app.kubernetes.io/managed-by: flux`
Ready=False reason=RollbackSucceeded: Helm rollback to bp-openbao@1.2.31 succeeded
Stalled=True reason=RetriesExceeded: Failed to upgrade after 4 attempt(s)
```

The kyverno `flux-managed` Enforce policy (baseline `10-flux-managed`) gates **Job AND CronJob**, and its namespace exclude-list does **not** include `openbao`. The openbao post-install/post-upgrade hook Jobs (`openbao-init` weight 5, `openbao-auth-bootstrap` weight 10) are created by the **helm-controller, not Flux**, so they carried no `managed-by: flux` label → admission denied → the whole upgrade rolled back → the 1.2.32 sso-configure fix never reached the cluster.

This is the **first roll of bp-openbao on a converged kyverno-Enforce env**, which is exactly when this landmine fires (same class as the gitea/harbor database-secret hook Jobs, #3296→#3297).

## Fix

Stamp `app.kubernetes.io/managed-by: flux` on all three Job/CronJob templates:
- `init-job.yaml` + `auth-bootstrap-job.yaml` — the post-upgrade hooks that trip on the first roll;
- `snapshot-replication.yaml` — CronJob + jobTemplate (DoD-8; gated the same way once enabled).

## Verification

Live policy scope confirmed:
```
clusterpolicy/flux-managed → workload-must-be-flux-managed:
  kinds=[Deployment, StatefulSet, DaemonSet, Job, CronJob, Service, Ingress]
  exclude namespaces: …  (no `openbao`)
```
- Chart `1.2.32` → `1.2.33` + `blueprint.yaml` + bootstrap-kit slot pin in lockstep.
- `tests/e2e/bootstrap-kit` lockstep + template-parse tests green.
- `reconcile.sh` unchanged (carries the 1.2.32 idempotency fix).

## Effect once reconciled on hw133

The 1.2.33 upgrade passes admission → the sso-configure reconciler with the idempotent alias mapping lands → the per-tick `WARN: mapping external group … failed` stops and logs `mapped`. Combined with the catalyst-api shim-route fix (#3429), `bao.<fqdn>/ui/` lands the operator signed-in with admin policy.

Refs #3374 #3296

🤖 Generated with [Claude Code](https://claude.com/claude-code)