### PR TITLE
fix(bp-valkey): populate the Valkey instance Contexts tab with bp-newapi's keyspace (Refs #3370)

### DIFF
--- a/clusters/_template/bootstrap-kit/17-valkey.yaml
+++ b/clusters/_template/bootstrap-kit/17-valkey.yaml
@@ -81,13 +81,28 @@ spec:
     # The chart self-registers the Application CR for this valkey
     # instance (the canonical representation every console surface
     # reads), marked spec.bootstrap=true so the application-controller
-    # ADOPTS this HR's install instead of re-rendering it. Contexts
-    # (keyspaces[]) stay empty here — today's bootstrap consumers
-    # (bp-newapi, sme-services) connect to the default logical
-    # database directly; their keyspace adoption is enumerated on
-    # #3370's follow-up checklist.
+    # ADOPTS this HR's install instead of re-rendering it.
     bootstrapOwned:
       enabled: true
       helmRelease:
         name: bp-valkey
         namespace: flux-system
+    # ── Keyspace Contexts (#3370 generality proof on a non-DB blueprint) ─
+    # The SAME reuse mechanism as bp-postgres databases[], generalized by
+    # declaration only (kind=keyspace, valuesKey=keyspaces). bp-newapi is
+    # the canonical Valkey consumer (its REDIS_CONN_STRING) — declaring its
+    # keyspace here renders one keyspace/newapi Context (a dedicated logical
+    # DB index + a reflected newapi-keyspace-credential Secret pushed into
+    # ns newapi) so the instance's Contexts tab shows a populated
+    # keyspace/… row, proving the platform-wide mechanism on a cache, not a
+    # database. Auth is disabled on this Sovereign (slot changelog 1.0.2),
+    # so the reflected uri is redis://valkey:6379/1.
+    keyspaces:
+      - name: newapi          # bp-newapi's cache keyspace
+        index: 1              # dedicated logical DB index (0 = default)
+        consumer:
+          blueprint: bp-newapi
+          mode: shared
+        reflect:
+          secretName: newapi-keyspace-credential
+          namespaces: [newapi]


### PR DESCRIPTION
## What

Refs #3370 (CONTEXTS), DoD #7 (generality proof on a non-database blueprint). The live walk on hw133 found the Valkey instance's **Contexts tab empty** ("Contexts(0) — No Contexts declared on this instance yet").

**Root cause:** slot 17 self-registers the valkey Application CR (`bootstrapOwned`) but declared no `keyspaces[]`, so the generic Contexts projection read zero entries.

## Fix

Declare `bp-newapi`'s keyspace Context on the shared Valkey instance — `bp-newapi` is the canonical Valkey consumer (its `REDIS_CONN_STRING`). This renders via the **same declaration-driven machinery** as `bp-postgres` `databases[]` (zero blueprint-specific code — the spec DoD #7 generality proof on a cache, not a database):

- a reflected `newapi-keyspace-credential` Secret (`context-kind: keyspace`, `context-name: newapi`, index=1, host/port/uri) pushed into ns `newapi` via the reflector
- the keyspace in the instance's Application CR `spec.parameters.keyspaces[]`

so `/app/<valkey-instance>` → Contexts tab shows a populated `keyspace/newapi` row.

## Verification

- `chart/tests/contexts-render.sh` PASS (5 cases incl. keyspace Secret + bootstrap Application CR).
- Slot render verified: `newapi-keyspace-credential` Secret (`kind=keyspace`, index=1, `uri: redis://valkey-primary…:6379/1`) + Application CR `spec.parameters.keyspaces[newapi]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)