### PR TITLE
fix(bp-openbao): roll sso-configure on reconcile.sh change — ConfigMap edits were silent (#3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -77,7 +77,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.33
+      version: 1.2.34
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.33
+  version: 1.2.34
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -26,7 +26,16 @@ name: bp-openbao
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.2.33
+version: 1.2.34
+# 1.2.34 (#3374, 2026-06-13): the openbao-sso-configure Deployment now rolls
+# when reconcile.sh changes. The reconcile loop lives in a ConfigMap, so a
+# SCRIPT change left the Pod template byte-identical → helm upgrade did NOT
+# restart the pod → the running reconciler kept the STALE mounted ConfigMap
+# (the 1.2.32/1.2.33 idempotency fix landed in the ConfigMap but the live
+# pod never picked it up, so the false per-tick WARN persisted on hw133).
+# Added a `checksum/reconcile-script: sha256(.Chart.Version)` Pod annotation —
+# every chart bump (and the script-lockstep rule means a script change always
+# bumps the chart) now forces the Deployment to roll onto the new script.
 # 1.2.33 (#3374, 2026-06-13): the three openbao Job/CronJob templates
 # (init-job, auth-bootstrap-job post-upgrade hooks + the snapshot-replication
 # CronJob) now carry `app.kubernetes.io/managed-by: flux`. The kyverno

--- a/platform/openbao/chart/templates/sso-configure-deployment.yaml
+++ b/platform/openbao/chart/templates/sso-configure-deployment.yaml
@@ -349,6 +349,16 @@ spec:
       annotations:
         # Force re-roll when sso.sovereignFqdn or admin group change.
         checksum/sso-config: {{ printf "%s:%s:%s:%s:%s" (.Values.sso.sovereignFqdn | default "") (.Values.sso.adminGroup | default "") (.Values.sso.opsGroup | default "") (.Values.sso.viewerGroup | default "") (.Values.sso.clientId | default "openbao") | sha256sum }}
+        # #3374 — the reconcile loop lives in the openbao-sso-configure
+        # ConfigMap (reconcile.sh). A change to that SCRIPT does not alter
+        # this Pod template, so without a revision marker the helm upgrade
+        # leaves the OLD pod running the OLD script with the stale mounted
+        # ConfigMap (caught live on hw133: the 1.2.32/1.2.33 idempotency
+        # fix landed in the ConfigMap but the running reconciler kept
+        # logging the false WARN because its pod never rolled). Hashing the
+        # chart version forces a roll on every chart bump — and the
+        # script-lockstep rule means a script change always bumps the chart.
+        checksum/reconcile-script: {{ .Chart.Version | sha256sum }}
     spec:
       serviceAccountName: openbao-sso-configure
       securityContext:


### PR DESCRIPTION
## Problem (verified live on hw133)

The `openbao-sso-configure` reconcile loop lives in a ConfigMap (`reconcile.sh`). The Deployment's only re-roll trigger was `checksum/sso-config`, which hashes ONLY the SSO value inputs (`sovereignFqdn` / admin group / `clientId`) — **not** the script. So a SCRIPT change left the Pod template byte-identical → the helm upgrade did not restart the pod → the running reconciler kept its **stale mounted ConfigMap**.

This made the previous two openbao fixes ineffective on the live env: the 1.2.32 + 1.2.33 idempotent-alias fix landed in the ConfigMap (`helm upgrade to bp-openbao@1.2.33 succeeded`, release `openbao.v10`), but the pod was still the original:
```
openbao-sso-configure-9cb68667c-rdj4j  created=13:16  (pre-fix)
… 19:19:56 | WARN: mapping external group sovereign-admins failed; retrying next tick
```
i.e. the OLD script was still running.

## Fix

Add a `checksum/reconcile-script: sha256(.Chart.Version)` Pod annotation. Every chart bump rolls the Deployment onto the new ConfigMap, and the script-lockstep rule (a script change always bumps the chart) makes this a reliable trigger for ANY `reconcile.sh` edit.

## Validation
- Chart `1.2.33` → `1.2.34` + `blueprint.yaml` + slot pin in lockstep.
- `tests/e2e/bootstrap-kit` lockstep + template-parse tests green.
- `reconcile.sh` `dash -n` clean (unchanged).

## Effect on hw133

Once 1.2.34 reconciles, the sso-configure pod rolls onto the idempotent reconcile.sh → the per-tick `WARN` stops and the loop logs `external group … → sso-operator-admin mapped`. The admin grant was already live (the alias bound at the first-ever tick), so this is correctness + truthful-narration + a real fix to the silent-ConfigMap-edit class.

Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)