### PR TITLE
fix(bp-vllm): pull image through Harbor proxy so kyverno K1 admits the pod (#3380 row D)

### DIFF
--- a/clusters/_template/bootstrap-kit/39-bp-vllm.yaml
+++ b/clusters/_template/bootstrap-kit/39-bp-vllm.yaml
@@ -150,7 +150,7 @@ spec:
       # keeps this in sync with chart bumps; the
       # scripts/check-bootstrap-kit-pin-sync.sh CI gate fails the build
       # if drift is introduced.
-      version: 1.0.0
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-vllm
@@ -181,6 +181,19 @@ spec:
       # commercial relay. Operator overlays opt-IN with SOVEREIGN_VLLM_ENABLED=true.
       enabled: ${SOVEREIGN_VLLM_ENABLED:-false}
       replicas: 1
+      # Image host overlay (#3380 row D). The chart default already
+      # pins the Harbor-proxy path so kyverno K1 `harbor-proxy-pull`
+      # (ENFORCING — allowed globs `*/proxy-*/*` or `*/openova-io/*`)
+      # admits the pod; a bare `vllm/vllm-openai` docker.io ref would be
+      # DENIED at the first scale-up. `${REGISTRY_MIRROR:=harbor.openova.io}`
+      # keeps the bootstrap pull on the mothership proxy-cache and lets a
+      # per-Sovereign overlay (or the cutover registry pivot) rewrite the
+      # host to its local Harbor — identical idiom to slots 13b/13c/54/
+      # 58/59. The `/proxy-dockerhub/vllm/vllm-openai` suffix is
+      # invariant.
+      image:
+        repository: ${REGISTRY_MIRROR:=harbor.openova.io}/proxy-dockerhub/vllm/vllm-openai
+        tag: "v0.6.4"
       # Qwen2.5-Coder-1.5B-Instruct — public Apache-2.0 Coder-tuned
       # model, ~3 GB CPU footprint, ~5 min cold-load on cpx52. Sized
       # for the canonical cpx52 worker with no GPU. GPU Sovereigns

--- a/platform/vllm/blueprint.yaml
+++ b/platform/vllm/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-6-llm-serving
 spec:
-  version: 1.0.0
+  version: 1.0.1
   card:
     title: vLLM
     summary: High-throughput LLM inference engine with PagedAttention. OpenAI-compatible API. GPU-accelerated when nvidia.com/gpu is available; CPU fallback for non-GPU dev Sovereigns.

--- a/platform/vllm/chart/Chart.yaml
+++ b/platform/vllm/chart/Chart.yaml
@@ -18,7 +18,7 @@ description: |
   bp-llm-gateway (slot 40, multi-model fan-out), bp-nemo-guardrails
   (slot 43, prompt-injection rails), and bp-bge (slot 42, embeddings).
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "0.6.4"
 keywords: [catalyst, blueprint, vllm, llm, inference, openai-compatible, gpu, ai]
 maintainers:

--- a/platform/vllm/chart/values.yaml
+++ b/platform/vllm/chart/values.yaml
@@ -14,7 +14,8 @@ catalystBlueprint:
     version: ""
     repo: ""
     images:
-      vllm: "vllm/vllm-openai"
+      # Harbor-proxy path (kyverno K1 enforce) — see vllm.image below.
+      vllm: "harbor.openova.io/proxy-dockerhub/vllm/vllm-openai"
 
 # ─── vLLM inference server ───────────────────────────────────────────────
 vllm:
@@ -27,8 +28,17 @@ vllm:
   # Pinned upstream image tag. DO NOT use floating tags per
   # docs/INVIOLABLE-PRINCIPLES.md #4. vllm-openai 0.6.4 is the latest
   # GA release as of 2026-04 with stable Llama-3.1-8B support.
+  #
+  # Image MUST pull through the Sovereign's local Harbor proxy
+  # (kyverno K1 `harbor-proxy-pull` ENFORCING — allowed globs are
+  # `*/proxy-*/*` or `*/openova-io/*`; a bare `vllm/vllm-openai`
+  # docker.io ref is DENIED at admission on first scale-up, #3380
+  # row D). `harbor.openova.io/proxy-dockerhub/...` is the canonical
+  # default every chart uses (cnpg/flux/guacamole/openbao/...) and the
+  # bootstrap-kit slot overlays the host via `${REGISTRY_MIRROR}` so a
+  # post-cutover Sovereign rewrites it to its local Harbor.
   image:
-    repository: vllm/vllm-openai
+    repository: harbor.openova.io/proxy-dockerhub/vllm/vllm-openai
     tag: "v0.6.4"
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## What

`bp-vllm` defaulted to the bare docker.io ref `vllm/vllm-openai:v0.6.4`. kyverno **K1 `harbor-proxy-pull`** is **ENFORCING** (`platform/kyverno-policies/chart/templates/baseline/11-harbor-proxy.yaml`; allowed globs `*/proxy-*/*` or `*/openova-io/*`), so a bare ref is **DENIED at admission** the moment a vllm pod is scheduled.

The vllm namespace has **0 pods today** (slot 39 default-OFF), so this is a **latent** self-inflicted wedge — it bites the first scale-up or any `SOVEREIGN_VLLM_ENABLED=true` Sovereign. This is exactly the #3380 row-D "bp-vllm image proxy-glob" landmine.

## Fix

- Chart default `vllm.image.repository` → `harbor.openova.io/proxy-dockerhub/vllm/vllm-openai` (the canonical default every chart uses — cnpg/flux/guacamole/openbao/...).
- Slot 39 (`39-bp-vllm.yaml`) overlays the host via `${REGISTRY_MIRROR:=harbor.openova.io}/proxy-dockerhub/vllm/vllm-openai` so a post-cutover Sovereign rewrites it to its local Harbor — identical idiom to slots 13b/13c/54/58/59.
- `catalystBlueprint.upstream.images.vllm` reference updated to match.

## Lockstep bumps (helm-controller skips upgrades without a new version)

| file | old | new |
|---|---|---|
| `platform/vllm/chart/Chart.yaml` | 1.0.0 | 1.0.1 |
| `platform/vllm/blueprint.yaml` | 1.0.0 | 1.0.1 |
| `clusters/_template/bootstrap-kit/39-bp-vllm.yaml` pin | 1.0.0 | 1.0.1 |

`scripts/check-bootstrap-kit-pin-sync.sh` → **PASS** (`bp-vllm: chart=1.0.1 pin=1.0.1`).

## Verification — the required render-grep

```
$ helm template bp-vllm platform/vllm/chart --set vllm.enabled=true | grep -i 'image:'
          image: "harbor.openova.io/proxy-dockerhub/vllm/vllm-openai:v0.6.4"
```

The **only** image rendered is on the Harbor proxy path → matches the kyverno `*/proxy-*/*` glob → admitted under Enforce. The bare docker.io ref is gone.

Refs #3380

🤖 Generated with [Claude Code](https://claude.com/claude-code)