### PR TITLE
fix(bp-oidc-gate): oidc-audience-mapper kills openova-flow bare-URL callback 500 (#3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
+++ b/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
@@ -60,7 +60,7 @@ spec:
   chart:
     spec:
       chart: bp-oidc-gate
-      version: 0.1.0
+      version: 0.1.1
       sourceRef:
         kind: HelmRepository
         name: bp-oidc-gate

--- a/platform/oidc-gate/blueprint.yaml
+++ b/platform/oidc-gate/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.0
+  version: 0.1.1
   card:
     title: oidc-gate
     summary: |

--- a/platform/oidc-gate/chart/Chart.yaml
+++ b/platform/oidc-gate/chart/Chart.yaml
@@ -14,7 +14,15 @@ name: bp-oidc-gate
 # (G117.5 #2744). Machine paths: per-instance skipAuthRoutes (regex,
 # METHOD=^path form) + --skip-jwt-bearer-tokens so token-bearing
 # service-to-service callers pass without a browser session.
-version: 0.1.0
+#
+# 0.1.1 (#3374, 2026-06-14): FIX the openova-flow bare-URL 500. The
+# minted KC client emitted `aud: [realm-management account]` with no
+# self-clientId, so oauth2-proxy's ID-token audience verification
+# rejected every callback (oauthproxy.go:888) — the bare URL never landed
+# signed-in. client.json now seeds an oidc-audience-mapper injecting the
+# clientId into the ID-token aud; bp-sso-bridge PUT (template-wins) lands
+# it on the live pre-existing client zero-touch.
+version: 0.1.1
 appVersion: "7.6.0"
 description: |
   Catalyst generic OIDC gate — a per-app oauth2-proxy instance set that

--- a/platform/oidc-gate/chart/templates/instances.yaml
+++ b/platform/oidc-gate/chart/templates/instances.yaml
@@ -14,6 +14,19 @@ Loop-safety per the pdns-admin 0.1.11 lesson: the gate's own callback
 (/oauth2/callback) is SERVED by oauth2-proxy itself, never redirected;
 already-authenticated sessions pass straight to the upstream
 (idempotent); skipAuthRoutes lets machine paths through untouched.
+
+Audience contract (0.1.1, #3374): oauth2-proxy's keycloak-oidc provider
+VERIFIES the ID token's `aud` claim contains its own --client-id during
+the callback code exchange. A vanilla Keycloak confidential client emits
+`aud: [realm-management account]` (the user's default role audiences) and
+NEVER its own clientId unless the user holds a client role — so the gate
+500'd every callback ("audience from claim aud with value
+[realm-management account] does not match ... map[openova-flow:{}]",
+oauthproxy.go:888). The client.json below therefore seeds an
+oidc-audience-mapper that injects <clientId> into the ID token aud (the
+netbird realm-config idiom). bp-sso-bridge POSTs client.json verbatim and
+shallow-merges template-wins on PUT, so the mapper reaches both freshly
+minted and pre-existing clients on the next reconcile tick — zero-touch.
 */ -}}
 {{- $root := . -}}
 {{- range $inst := .Values.instances }}
@@ -71,6 +84,18 @@ data:
         "https://{{ $hostname }}"
       ],
       "defaultClientScopes": ["web-origins", "acr", "profile", "roles", "email", "groups"],
+      "protocolMappers": [
+        {
+          "name": {{ printf "audience-%s" $cid | quote }},
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": {{ $cid | quote }},
+            "id.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ],
       "attributes": {
         "access.token.lifespan": "900"
       }


### PR DESCRIPTION
## openova-flow bare-URL was 500ing on the OAuth2 callback

The walker re-walk (#3441) saw the openova-flow bare URL reach Keycloak (silent, via catalyst-pin — no PIN form, good) but die on `/oauth2/callback` with **HTTP 500**, never landing signed-in. Re-reproduced live on hw133 (deployment `40c4e17667b600eb`) with headless Playwright.

### Real root cause (deeper than the first pass)

oauth2-proxy log at callback time (`oidc-gate-openova-flow`, oauthproxy.go:888):

```
Error creating session during OAuth2 callback: audience from claim aud
with value [realm-management account] does not match with any of allowed
audiences map[openova-flow:{}]
```

oauth2-proxy's `keycloak-oidc` provider **verifies the ID token's `aud` claim contains its own `--client-id`** during the code exchange. A vanilla Keycloak **confidential** client only ever lands a client in `aud` when the user holds a **client role** for it. `emrah.baysal` holds none on `openova-flow`, so the ID token's `aud` was `[realm-management account]` (default account/realm-management role audiences) and **never `openova-flow`** → verification fails → 500. Verified the live KC client: secret matches the oidc-gate ExternalSecret, redirectUris correct, but **zero protocol mappers** and no audience mapper.

grafana + harbor pass the same bare-URL walk because they front their **own** OIDC and don't strictly enforce `aud == client-id`.

### The fix (at source, generic, zero-touch)

The AppRegistration `client.json` that `bp-sso-bridge` POSTs/PUTs to Keycloak now seeds an `oidc-audience-mapper` injecting the gate's `clientId` into the **ID-token** `aud` (`id.token.claim: "true"` — oauth2-proxy checks the ID token). This follows the existing `platform/netbird/chart` realm-config idiom.

`bp-sso-bridge`'s reconciler PUTs `client.json` **template-wins on every tick** (`jq '.[1] * .[0]'`, configmap-reconciler.yaml:842), so the mapper reaches both freshly-minted AND the **live pre-existing** `openova-flow` client on the next reconcile — no `kubectl patch`. Generic: applies to **every** oidc-gate instance, never a per-app hack (the #3374 §5 law).

### Lockstep + validation
- `bp-oidc-gate` chart `0.1.0 → 0.1.1`; bootstrap-kit slot `13c` pin bumped together.
- `helm template` renders clean; embedded `client.json` parses as valid JSON; mapper-field assertions pass (`protocolMapper=oidc-audience-mapper`, `included.client.audience=openova-flow`, `id.token.claim=true`).

### What the walker should now see
After CI publishes `bp-oidc-gate:0.1.1` and Flux reconciles (slot 13c) + the sso-bridge ticks the client PUT: the bare URL `https://openova-flow.hw133.omani.works/` lands on the Flow UI **signed in** as emrah.baysal — no 500, no login button. The `/oauth2/callback` returns 302→upstream instead of 500.

Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)