### PR TITLE
fix(guacamole): JDBC permission store + sovereign-admins admin — SSO users land as admin (#3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -82,6 +82,12 @@ spec:
     - name: bp-sealed-secrets
     - name: bp-seaweedfs
     - name: bp-k8s-ws-proxy
+    # #3374 — bp-guacamole now ships a CNPG Cluster CR for its JDBC
+    # permission store (admin elevation). bp-cnpg (slot 16) registers the
+    # postgresql.cnpg.io/v1 CRD; without this edge the Cluster CR's
+    # Capabilities gate would skip on a fresh prov (guacamole installs before
+    # cnpg) → no DB → no admin. bp-cnpg before bp-guacamole closes that race.
+    - name: bp-cnpg
   chart:
     spec:
       chart: bp-guacamole
@@ -151,7 +157,11 @@ spec:
       # 0.2.3: lockstep with chart bump d232af3f (upstream 1.5.5) — the
       # deploy commit bumped Chart.yaml but the auto-bump pin hook didn't
       # fire, leaving this pin drifted (broke the full lockstep sweep).
-      version: 0.2.8
+      # 0.2.9 — #3374: JDBC permission store + sovereign-admins admin
+      # USER_GROUP. The openid extension authenticated SSO users but granted
+      # no admin; the new CNPG cluster + schema-seed Job + POSTGRESQL_* env
+      # make sovereign-admins members land as guacamole admin on SSO login.
+      version: 0.2.9
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/category: platform
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.8
+  version: 0.2.9
   card:
     title: Apache Guacamole
     summary: Clientless HTML5 remote-desktop gateway. Browser-based RDP / VNC / SSH and kubectl-exec into Pods, with Keycloak SSO and full session recording to SeaweedFS. One Guacamole per Sovereign per ADR-0001 §11.

--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -102,7 +102,20 @@ name: bp-guacamole
 # ships the openid extension only (no JDBC permission store), so
 # blueprint.yaml's `rolesFromGroup: sovereign-admins: admin` intent has no
 # implementation — tracked under #3374 DoD row 7.
-version: 0.2.8
+# 0.2.9 (#3374, 2026-06-14): CLOSES the admin-elevation gap the 0.2.5 note
+# flagged. The openid extension authenticates SSO users but carries no
+# permission store, so every SSO user landed with no connections and NO admin
+# (founder-witnessed). New templates wire the bundled JDBC (postgresql)
+# permission store: a dedicated CNPG cluster (cnpg-cluster.yaml), POSTGRESQL_*
+# env on the webapp (guacamole-deployment.yaml) with AUTO_CREATE_ACCOUNTS +
+# EXTENSION_PRIORITY="openid, postgresql", a schema-seed Job
+# (jdbc-schema-seed-job.yaml) that applies the image-bundled
+# 001-create-schema.sql once and seeds a `sovereign-admins` USER_GROUP holding
+# ADMINISTER, and a netpol egress to :5432. With OPENID_GROUPS_CLAIM_TYPE=groups
+# an SSO user in sovereign-admins auto-creates a JDBC record, binds into the
+# group, and lands as guacamole admin. New `guacamole.database.*` values.
+# Lockstep: 52-bp-guacamole.yaml pin → 0.2.9. Refs #3374.
+version: 0.2.9
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/templates/cnpg-cluster.yaml
+++ b/platform/guacamole/chart/templates/cnpg-cluster.yaml
@@ -1,0 +1,72 @@
+{{- /*
+#3374 (2026-06-14) — CNPG-managed Postgres cluster for the Guacamole JDBC
+permission store.
+
+The guacamole-auth-sso-openid extension authenticates SSO users but carries
+NO permission store on its own, so every SSO user landed with no connections
+and no admin (the founder-witnessed #3374 gap). This Cluster backs the bundled
+guacamole-auth-jdbc-postgresql extension: with POSTGRESQL_* env set, the
+guacamole entrypoint installs the JDBC extension, the schema-seed Job applies
+the bundled schema + a `<adminGroup>` USER_GROUP holding ADMINISTER, and
+POSTGRESQL_AUTO_CREATE_ACCOUNTS auto-provisions a JDBC record per SSO user on
+first login.
+
+Pattern mirrors bp-gitea / bp-harbor / bp-newapi cnpg-cluster.yaml. CNPG
+synthesises a `<name>-app` Secret (the rotating app password) that both the
+Deployment and the seed Job read. enableSuperuserAccess=true because the JDBC
+schema needs CREATE TYPE / TABLE which the seed Job runs as the superuser.
+
+Capabilities gate: bp-cnpg ships postgresql.cnpg.io/v1; the check skips this
+template until the CRD is registered (bootstrap order lands bp-cnpg first).
+*/ -}}
+{{- $db := .Values.guacamole.database | default dict -}}
+{{- $cl := $db.cluster | default dict -}}
+{{- if and .Values.guacamole.enabled (default true $db.enabled) (default true $cl.enabled) (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") }}
+{{- $name := $cl.name | default "guacamole-pg" -}}
+{{- $ns := $cl.namespace | default .Release.Namespace -}}
+{{- $owner := $cl.owner | default "guacamole" -}}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-guacamole.labels" . | nindent 4 }}
+    catalyst.openova.io/component: guacamole-db
+spec:
+  instances: {{ $cl.instances | default 1 }}
+  imageName: {{ $cl.imageName | default "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql" }}:{{ $cl.pgVersion | default "16" }}
+  {{- if ge (int ($cl.instances | default 1)) 2 }}
+  affinity:
+    topologyKey: {{ (default dict $cl.affinity).topologyKey | default "topology.kubernetes.io/region" | quote }}
+    podAntiAffinityType: {{ (default dict $cl.affinity).podAntiAffinityType | default "preferred" | quote }}
+  {{- end }}
+  bootstrap:
+    initdb:
+      database: {{ $cl.database | default "guacamole_db" | quote }}
+      owner: {{ $owner | quote }}
+  managed:
+    roles:
+      - name: {{ $owner | quote }}
+        ensure: present
+        login: true
+        passwordSecret:
+          name: {{ printf "%s-app" $name | quote }}
+  postgresql:
+    parameters:
+      max_connections: "100"
+      shared_buffers: "64MB"
+      effective_cache_size: "192MB"
+      work_mem: "4MB"
+      maintenance_work_mem: "64MB"
+      log_statement: "ddl"
+      log_min_duration_statement: "1000"
+  resources:
+    {{- toYaml ($cl.resources | default (dict "requests" (dict "cpu" "50m" "memory" "128Mi") "limits" (dict "memory" "512Mi"))) | nindent 4 }}
+  storage:
+    size: {{ $cl.storageSize | default "5Gi" }}
+    storageClass: {{ $cl.storageClass | default "local-path" | quote }}
+  enableSuperuserAccess: true
+  monitoring:
+    enablePodMonitor: false
+{{- end }}

--- a/platform/guacamole/chart/templates/guacamole-deployment.yaml
+++ b/platform/guacamole/chart/templates/guacamole-deployment.yaml
@@ -72,6 +72,44 @@ spec:
                   key: {{ .Values.guacamole.oidc.clientSecretRef.key }}
                   optional: false
 
+            {{- $db := .Values.guacamole.database | default dict }}
+            {{- if and (default true $db.enabled) ((default dict $db.cluster).enabled | default true) }}
+            # PostgreSQL JDBC permission store (#3374). The guacamole
+            # entrypoint installs the bundled guacamole-auth-jdbc-postgresql
+            # extension when POSTGRESQL_HOSTNAME is set; combined with the
+            # openid extension (above) it gives SSO users a real permission
+            # store. AUTO_CREATE_ACCOUNTS provisions a JDBC record per SSO
+            # principal on first login; the schema-seed Job's <adminGroup>
+            # USER_GROUP (ADMINISTER) + OPENID_GROUPS_CLAIM_TYPE=groups make
+            # sovereign-admins members land as admin.
+            {{- $cl := $db.cluster | default dict }}
+            {{- $clName := $cl.name | default "guacamole-pg" }}
+            {{- $clNs := $cl.namespace | default .Release.Namespace }}
+            - name: POSTGRESQL_HOSTNAME
+              value: {{ printf "%s-rw.%s.svc.cluster.local" $clName $clNs | quote }}
+            - name: POSTGRESQL_PORT
+              value: "5432"
+            - name: POSTGRESQL_DATABASE
+              value: {{ $cl.database | default "guacamole_db" | quote }}
+            - name: POSTGRESQL_USERNAME
+              value: {{ $cl.owner | default "guacamole" | quote }}
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $db.appSecretName | default (printf "%s-app" $clName) | quote }}
+                  key: password
+                  optional: false
+            - name: POSTGRESQL_SSL_MODE
+              value: {{ $db.sslMode | default "require" | quote }}
+            - name: POSTGRESQL_AUTO_CREATE_ACCOUNTS
+              value: {{ $db.autoCreateAccounts | default true | quote }}
+            # When multiple auth extensions are present, openid must run so
+            # the SSO identity is the authenticated principal and JDBC is the
+            # permission store (not a second login). Extension priority puts
+            # openid first; JDBC accounts are auto-created/looked-up for it.
+            - name: EXTENSION_PRIORITY
+              value: "openid, postgresql"
+            {{- end }}
             # Recording path — guacd writes here; the webapp ships
             # captures off to SeaweedFS via the shipper container below.
             - name: RECORDING_PATH

--- a/platform/guacamole/chart/templates/jdbc-schema-seed-job.yaml
+++ b/platform/guacamole/chart/templates/jdbc-schema-seed-job.yaml
@@ -1,0 +1,222 @@
+{{- /*
+#3374 (2026-06-14) — Guacamole JDBC schema-init + admin USER_GROUP seed.
+
+The guacamole-auth-sso-openid extension authenticates SSO users but has no
+permission store, so every SSO user lands with no connections and NO admin
+(the founder-witnessed #3374 gap; blueprint.yaml's `rolesFromGroup:
+sovereign-admins: admin` intent was unimplemented). This Job wires the
+bundled JDBC (postgresql) permission store:
+
+  1. An initContainer running the guacamole webapp image copies the bundled
+     JDBC schema (/opt/guacamole/postgresql/schema/*.sql) into a shared
+     emptyDir — the schema lives in the image, not this chart.
+  2. The main container (CNPG postgres image — has psql) connects to the
+     guacamole CNPG cluster and:
+       a. applies 001-create-schema.sql ONCE (idempotent guard: skip if the
+          `guacamole_entity` table already exists),
+       b. creates a `<adminGroup>` USER_GROUP entity holding the ADMINISTER
+          (+ CREATE_*) system permissions, so any SSO user whose `groups`
+          claim contains <adminGroup> inherits guacamole admin. We DELIBERATELY
+          do NOT seed the default guacadmin/guacadmin password account from
+          002-create-admin-user.sql — admin is group-driven via SSO only.
+
+Combined with the Deployment's POSTGRESQL_AUTO_CREATE_ACCOUNTS=true +
+OPENID_GROUPS_CLAIM_TYPE=groups, an `emrah.baysal`-in-sovereign-admins SSO
+login auto-creates the JDBC user, binds it into the USER_GROUP, and lands it
+as admin.
+
+DB-direct via the CNPG <cluster>-app Secret (host/port/dbname/user/password).
+enableSuperuserAccess on the Cluster is for the schema DDL; the app owner here
+owns the objects it creates, so the app credential suffices for the seed.
+
+Skip-render: guacamole.enabled=false, database.enabled=false, or the
+postgresql.cnpg.io CRD absent.
+*/ -}}
+{{- $db := .Values.guacamole.database | default dict -}}
+{{- $cl := $db.cluster | default dict -}}
+{{- if and .Values.guacamole.enabled (default true $db.enabled) (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") }}
+{{- $name := $cl.name | default "guacamole-pg" -}}
+{{- $appSecret := $db.appSecretName | default (printf "%s-app" $name) -}}
+{{- $adminGroup := $db.adminGroup | default "sovereign-admins" -}}
+{{- $pgImage := printf "%s:%s" ($cl.imageName | default "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql") ($cl.pgVersion | default "16") -}}
+{{- $guacImage := include "bp-guacamole.webappImage" . -}}
+{{- $sj := $db.seedJob | default dict -}}
+{{- $jobName := printf "%s-jdbc-seed" (include "bp-guacamole.fullname" .) | trunc 63 | trimSuffix "-" -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $jobName }}-scripts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-guacamole.labels" . | nindent 4 }}
+    catalyst.openova.io/component: jdbc-seed
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  seed.sh: |
+    set -eu
+    CRED=/cnpg
+    PGHOST="$(cat "${CRED}/host")"
+    PGPORT="$(cat "${CRED}/port" 2>/dev/null || echo 5432)"
+    PGDATABASE="$(cat "${CRED}/dbname")"
+    PGUSER="$(cat "${CRED}/user" 2>/dev/null || cat "${CRED}/username")"
+    PGPASSWORD="$(cat "${CRED}/password")"
+    export PGHOST PGPORT PGDATABASE PGUSER PGPASSWORD
+    PSQL="psql -v ON_ERROR_STOP=1 -qtA"
+    echo "[jdbc-seed] target=${PGHOST}:${PGPORT}/${PGDATABASE} user=${PGUSER}"
+
+    # Wait for the CNPG primary to accept connections.
+    i=0
+    until [ "$i" -ge 60 ]; do
+      if $PSQL -c "SELECT 1;" >/dev/null 2>&1; then echo "[jdbc-seed] db reachable"; break; fi
+      i=$((i+1)); echo "[jdbc-seed] waiting for postgres ($i/60)"; sleep 5
+    done
+    if [ "$i" -ge 60 ]; then echo "[jdbc-seed] FATAL: postgres unreachable after 5min" >&2; exit 1; fi
+
+    # (1) Apply the guacamole JDBC schema ONCE. The schema SQL (copied out of
+    #     the guacamole image by the initContainer) creates the enum TYPEs +
+    #     ~15 tables. Idempotency guard: skip when guacamole_entity exists.
+    if $PSQL -c "SELECT to_regclass('public.guacamole_entity');" | grep -q '^guacamole_entity$'; then
+      echo "[jdbc-seed] schema already present — skipping 001-create-schema.sql"
+    else
+      echo "[jdbc-seed] applying 001-create-schema.sql"
+      $PSQL -f /schema/001-create-schema.sql
+      echo "[jdbc-seed] schema applied"
+    fi
+
+    # (2) Seed the admin USER_GROUP (idempotent). Members inherit guacamole
+    #     admin (ADMINISTER) + the CREATE_* system permissions. The openid
+    #     extension binds an SSO user into this group when its `groups` claim
+    #     contains the name. NO password account is created — SSO-only admin.
+    ADMIN_GROUP="{{ $adminGroup }}"
+    $PSQL <<SQL
+    INSERT INTO guacamole_entity (name, type)
+    SELECT '${ADMIN_GROUP}', 'USER_GROUP'
+    WHERE NOT EXISTS (
+      SELECT 1 FROM guacamole_entity WHERE name = '${ADMIN_GROUP}' AND type = 'USER_GROUP'
+    );
+
+    INSERT INTO guacamole_user_group (entity_id)
+    SELECT entity_id FROM guacamole_entity
+    WHERE name = '${ADMIN_GROUP}' AND type = 'USER_GROUP'
+      AND entity_id NOT IN (SELECT entity_id FROM guacamole_user_group);
+
+    INSERT INTO guacamole_system_permission (entity_id, permission)
+    SELECT e.entity_id, p.permission::guacamole_system_permission_type
+    FROM (VALUES
+      ('CREATE_CONNECTION'),
+      ('CREATE_CONNECTION_GROUP'),
+      ('CREATE_SHARING_PROFILE'),
+      ('CREATE_USER'),
+      ('CREATE_USER_GROUP'),
+      ('ADMINISTER')
+    ) AS p(permission)
+    JOIN guacamole_entity e ON e.name = '${ADMIN_GROUP}' AND e.type = 'USER_GROUP'
+    WHERE NOT EXISTS (
+      SELECT 1 FROM guacamole_system_permission sp
+      WHERE sp.entity_id = e.entity_id
+        AND sp.permission = p.permission::guacamole_system_permission_type
+    );
+    SQL
+    echo "[jdbc-seed] admin USER_GROUP '${ADMIN_GROUP}' ensured with ADMINISTER"
+    echo "[jdbc-seed] done."
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $jobName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-guacamole.labels" . | nindent 4 }}
+    catalyst.openova.io/component: jdbc-seed
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: {{ $sj.backoffLimit | default 6 }}
+  activeDeadlineSeconds: {{ $sj.activeDeadlineSeconds | default 420 }}
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        {{- include "bp-guacamole.selectorLabels" . | nindent 8 }}
+        catalyst.openova.io/component: jdbc-seed
+    spec:
+      restartPolicy: OnFailure
+      {{- with .Values.guacamole.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 26
+        runAsGroup: 26
+        fsGroup: 26
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        # Copy the bundled JDBC schema out of the guacamole image so the
+        # postgres container can apply it. The schema is image-versioned —
+        # never hand-copied into this chart.
+        - name: copy-schema
+          image: {{ $guacImage | quote }}
+          imagePullPolicy: {{ .Values.guacamole.webapp.image.pullPolicy | default "IfNotPresent" }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              cp /opt/guacamole/postgresql/schema/001-create-schema.sql /schema/
+              echo "copied JDBC schema"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: schema
+              mountPath: /schema
+      containers:
+        - name: jdbc-seed
+          image: {{ $pgImage | quote }}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "/scripts/seed.sh"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+            - name: schema
+              mountPath: /schema
+            - name: cnpg
+              mountPath: /cnpg
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            {{- toYaml ($sj.resources | default (dict "requests" (dict "cpu" "10m" "memory" "64Mi") "limits" (dict "cpu" "200m" "memory" "128Mi"))) | nindent 12 }}
+      volumes:
+        - name: scripts
+          configMap:
+            name: {{ $jobName }}-scripts
+            defaultMode: 0555
+        - name: schema
+          emptyDir:
+            sizeLimit: 4Mi
+        - name: cnpg
+          secret:
+            secretName: {{ $appSecret | quote }}
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 8Mi
+{{- end }}

--- a/platform/guacamole/chart/templates/networkpolicy.yaml
+++ b/platform/guacamole/chart/templates/networkpolicy.yaml
@@ -93,4 +93,19 @@ spec:
       ports:
         - protocol: TCP
           port: 4222
+
+    {{- $db := .Values.guacamole.database | default dict }}
+    {{- if and (default true $db.enabled) ((default dict $db.cluster).enabled | default true) }}
+    # PostgreSQL JDBC permission store (#3374) — the webapp reads/writes the
+    # guacamole CNPG cluster for connection + permission state. The cluster
+    # is provisioned by templates/cnpg-cluster.yaml in this same namespace;
+    # CNPG labels its pods `cnpg.io/cluster: <name>`.
+    - to:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: {{ (default dict $db.cluster).name | default "guacamole-pg" | quote }}
+      ports:
+        - protocol: TCP
+          port: 5432
+    {{- end }}
 {{- end }}

--- a/platform/guacamole/chart/values.yaml
+++ b/platform/guacamole/chart/values.yaml
@@ -150,6 +150,70 @@ guacamole:
     # Optional groups claim from the IdP — Guacamole reads roles
     # from this claim and maps them to per-connection ACLs.
     groupsClaim: groups
+  # ── PostgreSQL JDBC permission store (#3374) ───────────────────
+  # The guacamole-auth-sso-openid extension AUTHENTICATES users but, alone,
+  # carries NO permission store — every SSO user lands with zero connections
+  # and NO admin (the #3374 DoD-7 gap; the image ships only the openid jar).
+  # Wiring the bundled JDBC (postgresql) extension gives guacamole a real
+  # permission store: POSTGRESQL_AUTO_CREATE_ACCOUNTS auto-provisions a JDBC
+  # record for each SSO user on first login, OPENID_GROUPS_CLAIM_TYPE maps the
+  # `groups` claim onto guacamole USER_GROUP entities, and the schema-seed Job
+  # creates a `<adminGroup>` USER_GROUP holding the ADMINISTER system
+  # permission — so every owner in `sovereign-admins` inherits guacamole admin
+  # the moment they sign in. The image (guacamole/guacamole:1.5.5) already
+  # bundles guacamole-auth-jdbc-postgresql + the driver + the schema SQL; the
+  # entrypoint installs the JDBC extension automatically when POSTGRESQL_* is
+  # set.
+  database:
+    # Master switch. Default ON: without it guacamole grants no admin, which
+    # is the founder-witnessed #3374 gap. Set false to keep openid-only.
+    enabled: true
+    # Dedicated CNPG cluster (mirrors bp-gitea / bp-harbor / bp-newapi). The
+    # JDBC schema needs CREATE TYPE/TABLE, so the seed Job applies it as the
+    # CNPG superuser (enableSuperuserAccess below). ADR-0010 SHARING is a
+    # follow-up — guacamole's schema-init is heavier than a single Database CR.
+    cluster:
+      enabled: true
+      name: guacamole-pg
+      namespace: "" # default .Release.Namespace
+      instances: 1
+      database: guacamole_db
+      owner: guacamole
+      imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql
+      pgVersion: "16"
+      storageSize: 5Gi
+      storageClass: local-path
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 512Mi
+    # The CNPG <cluster>-app Secret carries the rotating password; the
+    # Deployment + seed Job read it (key `password`).
+    appSecretName: "" # default "<cluster.name>-app"
+    sslMode: require
+    # Auto-provision a JDBC user record for each SSO-authenticated principal on
+    # first login (so openid users exist in the permission store).
+    autoCreateAccounts: true
+    # The IdP group whose members become guacamole admins. A USER_GROUP entity
+    # of this name is seeded with the ADMINISTER system permission; the openid
+    # `groups` claim binds the SSO user into it. Elevation keys on the group,
+    # never per-user (#3374 law §5).
+    adminGroup: sovereign-admins
+    # Image for the schema-seed Job's psql container (same CNPG postgres image
+    # as the cluster — has psql). The schema SQL itself is copied out of the
+    # guacamole webapp image by an initContainer.
+    seedJob:
+      backoffLimit: 6
+      activeDeadlineSeconds: 420
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          cpu: 200m
+          memory: 128Mi
   # ── HTTPRoute (Cilium Gateway) ─────────────────────────────────
   httproute:
     enabled: true

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -558,6 +558,11 @@ slots:
       - bp-sealed-secrets
       - bp-seaweedfs
       - bp-k8s-ws-proxy
+      # #3374 — bp-guacamole now ships a CNPG Cluster for its JDBC permission
+      # store (admin elevation). bp-cnpg (slot 16) must register the
+      # postgresql.cnpg.io/v1 CRD first or the Cluster CR's Capabilities gate
+      # skips on a fresh prov → no admin.
+      - bp-cnpg
     wave: present
 
   # ---- Slot 53 — bp-netbird WireGuard zero-trust mesh + remote-access overlay.


### PR DESCRIPTION
## Problem (measured live on hw133)

Guacamole **authenticates** SSO users (the openid extension works — bare-root 302 + `redirect_uri=/guacamole/` shipped in 0.2.5/0.2.8; live log: `emrah.baysal@openova.io successfully authenticated`) but grants **NO admin**: the chart ships the openid extension ONLY, with no permission store, so every SSO user lands with **zero connections and no admin** (founder-witnessed #3374 DoD-7 gap; blueprint.yaml's `rolesFromGroup: sovereign-admins: admin` was unimplemented).

## Root cause

`guacamole-auth-sso-openid` carries no permission backend. Admin / connection state lives in the bundled **JDBC (postgresql)** extension's schema, which was never wired. The image (`guacamole/guacamole:1.5.5`) already bundles `guacamole-auth-jdbc-postgresql` + driver + schema; the entrypoint installs JDBC when `POSTGRESQL_*` is set.

## Fix

- **`cnpg-cluster.yaml`** — dedicated `guacamole-pg` CNPG cluster (mirrors bp-gitea/bp-harbor/bp-newapi), `enableSuperuserAccess` for the schema DDL.
- **`guacamole-deployment.yaml`** — `POSTGRESQL_HOSTNAME/PORT/DATABASE/USERNAME/PASSWORD` (from the CNPG `<cluster>-app` Secret) + `POSTGRESQL_AUTO_CREATE_ACCOUNTS=true` + `EXTENSION_PRIORITY="openid, postgresql"` so openid is the authenticated principal and JDBC is the permission store (not a 2nd login).
- **`jdbc-schema-seed-job.yaml`** — post-install/post-upgrade Job. An initContainer (guacamole image) copies the bundled `001-create-schema.sql` out of the image; the postgres container applies it **once** (idempotent: skip if `guacamole_entity` exists) and seeds a **`sovereign-admins` USER_GROUP** holding `ADMINISTER` + `CREATE_*`. NO `guacadmin` password account — admin is **group-driven via SSO only**.
- **`networkpolicy.yaml`** — egress to the cnpg cluster on `:5432`.

With `OPENID_GROUPS_CLAIM_TYPE=groups` (already set), an SSO login whose `groups` claim contains `sovereign-admins` auto-creates the JDBC user, binds it into the USER_GROUP, and lands it as **guacamole admin**.

New `guacamole.database.*` values. Gated on `guacamole.enabled` + `database.enabled` + the `postgresql.cnpg.io` CRD. Slot-52 now `dependsOn bp-cnpg` (slot 16) — `expected-bootstrap-deps.yaml` updated to match (audit Drift 0). Chart + blueprint + slot pin lockstepped 0.2.8→0.2.9.

## Validation
- Chart renders 5 objects (Cluster/Deployment/Job/ConfigMap/NetworkPolicy) + valid YAML.
- The image-bundled **736-line `001-create-schema.sql`** + the admin-group seed SQL execute **cleanly against live shared-pg-c** inside a `BEGIN`/`pg_temp`/`ROLLBACK` → admin USER_GROUP=1, system perms=**6 (incl ADMINISTER)**; **live DB untouched** (zero-touch preserved).
- bootstrap-kit suite `ok`; `helm lint` 0 failed; **dependency-graph-audit PASSED (Drift 0)**.

## What the walker should see at the bare URL
`https://guacamole.hw133.omani.works/` → 302 `/guacamole/` → silent catalyst-pin SSO → lands in the Guacamole console signed in as `emrah.baysal`; the **admin gear/Settings menu is present** (Users / Connections / Settings) because the SSO user inherited `ADMINISTER` via the `sovereign-admins` USER_GROUP. (`guacamole-pg` CNPG cluster 1/1; `*-jdbc-seed` Job Completed.)

Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)