### PR TITLE
fix(bp-openbao): on-origin SSO landing kills bare-URL postMessage error — true zero-click (#3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -77,7 +77,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.34
+      version: 1.2.35
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.34
+  version: 1.2.35
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -26,7 +26,23 @@ name: bp-openbao
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.2.34
+version: 1.2.35
+# 1.2.35 (#3374, 2026-06-14): TRUE zero-click bare-URL — kill the popup-only
+# OIDC-callback postMessage error. OpenBao's Vault-UI OIDC login is POPUP-ONLY
+# (the callback route does an UNCONDITIONAL window.opener.postMessage with no
+# null-check + no in-page completion). The #3226 catalyst-api shim 302'd the
+# WHOLE browser tab into that callback → window.opener null → every bare-URL
+# visit rendered "Cannot read properties of null (reading 'postMessage')"
+# (measured live hw133 2026-06-14; the native popup login WORKED, proving the
+# wire/policy were fine). Replaced the shim redirect with an on-origin landing
+# page (templates/sso-landing.yaml): bare /, /ui, /ui/ now 302 to /sso/landing
+# (SAME host — no catalyst-api dependency, immune to a mothership roll-storm),
+# which runs the OIDC round-trip as a TOP-LEVEL window (auth_url → Keycloak
+# silent via catalyst-pin → back to /sso/landing?code → GET oidc/callback →
+# reconstruct the Vault-UI token in localStorage → /ui/vault/secrets). Added
+# the landing redirect_uri to the OIDC role allowed_redirect_uris (KC client
+# already allows it via `/*`). tests/sso-landing-render.sh pins the route +
+# the captured localStorage shape so a future UI bump cannot silently regress.
 # 1.2.34 (#3374, 2026-06-13): the openbao-sso-configure Deployment now rolls
 # when reconcile.sh changes. The reconcile loop lives in a ConfigMap, so a
 # SCRIPT change left the Pod template byte-identical → helm upgrade did NOT

--- a/platform/openbao/chart/templates/httproute.yaml
+++ b/platform/openbao/chart/templates/httproute.yaml
@@ -34,29 +34,50 @@ spec:
   hostnames:
     - {{ .Values.gateway.host | quote }}
   rules:
-{{- if and .Values.sso .Values.sso.bareURL .Values.sso.bareURL.enabled }}
+{{- if and .Values.sso .Values.sso.enabled .Values.sso.bareURL .Values.sso.bareURL.enabled }}
+{{- $landingPath := .Values.sso.bareURL.landingPath | default "/sso/landing" }}
 {{- /*
-BARE-URL zero-click SSO (#3374). The contract: typing bao.<fqdn>/ or
-bao.<fqdn>/ui/ in a fresh browser lands the operator signed in — no
-token form. OpenBao's Ember UI has no server-side auto-redirect knob
-(see sso.idpHint note in values.yaml), so the gateway sends the two
-bare entry paths into catalyst-api's openbao-sso-init shim (#3226,
-products/catalyst/bootstrap/api/internal/handler/openbao_sso_init.go),
-which asks Vault for the OIDC auth_url server-side and 302s to Keycloak
-(silent via catalyst-pin) -> Vault UI callback -> landed signed in.
+BARE-URL zero-click SSO (#3374, openbao-bare-url-landing). The contract:
+typing bao.<fqdn>/ or bao.<fqdn>/ui/ in a fresh browser lands the operator
+signed in — no token form.
+
+ROOT CAUSE the prior shim never escaped (measured live hw133 2026-06-14):
+OpenBao's Vault-UI (Ember) OIDC login is POPUP-ONLY — its callback route
+does an UNCONDITIONAL `window.opener.postMessage(...)` with no null-check
+and no in-page completion. The #3226 catalyst-api shim 302'd the WHOLE
+browser tab into that callback, so `window.opener` was null and the bare
+URL rendered the Ember error "Cannot read properties of null (reading
+'postMessage')". A server-side full-page redirect into a popup-only
+callback can NEVER land signed-in.
+
+THE FIX: the bare paths redirect to /sso/landing — a tiny static page
+served on THIS origin (templates/sso-landing.yaml) that runs the OIDC
+round-trip as a TOP-LEVEL window (auth_url -> Keycloak silent -> back to
+/sso/landing?code -> GET oidc/callback -> reconstruct the Vault-UI token in
+localStorage -> /ui/vault/secrets). No popup, no window.opener, no
+catalyst-api dependency (the redirect target is same-host, immune to a
+mothership/catalyst-api roll-storm).
 
 Loop-safety (the pdns-admin 0.1.11 lesson, #3353):
-  - ONLY Exact `/`, `/ui` and `/ui/` are intercepted.
-  - The shim's healthy 302 goes to auth.<fqdn> (different host).
-  - The shim's degraded fallback goes to /ui/vault/auth?with=oidc —
-    NOT matched (different path), so a broken shim degrades to the
-    one-click form, never a redirect loop.
-  - The OIDC callback /ui/vault/auth/oidc/oidc/callback and the
-    post-login landing /ui/vault/secrets are NOT matched.
-  - API clients use /v1/* — never matched.
+  - ONLY Exact `/`, `/ui`, `/ui/` are intercepted -> 302 to /sso/landing.
+  - /sso/landing is its OWN PathPrefix backend (the static page), NOT a
+    Vault UI route — never re-matched by the bare-path Exact rules.
+  - The landing page short-circuits to /ui/vault/secrets when a valid
+    token already exists (idempotent re-entry).
+  - The OIDC callback /ui/vault/auth/oidc/oidc/callback and the post-login
+    /ui/vault/secrets are NOT matched here (PathPrefix `/` backend serves
+    them straight to OpenBao).
+  - API clients use /v1/* — served by the `/` backend, never redirected.
 Port is explicit 443 (the #3310 listener-port-leak class).
 */}}
-{{- $apiHost := .Values.sso.bareURL.apiHost | default (printf "api.%s" (regexReplaceAll "^[^.]+\\." .Values.gateway.host "")) }}
+    # The landing page itself (served by the openbao-sso-landing nginx).
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ $landingPath | quote }}
+      backendRefs:
+        - name: openbao-sso-landing
+          port: 80
 {{- range $entry := list "/" "/ui" "/ui/" }}
     - matches:
         - path:
@@ -65,11 +86,11 @@ Port is explicit 443 (the #3310 listener-port-leak class).
       filters:
         - type: RequestRedirect
           requestRedirect:
-            hostname: {{ $apiHost | quote }}
+            hostname: {{ $.Values.gateway.host | quote }}
             port: 443
             path:
               type: ReplaceFullPath
-              replaceFullPath: {{ $.Values.sso.bareURL.shimPath | default "/catalyst/v1/apps/openbao/openbao-sso-init" | quote }}
+              replaceFullPath: {{ $landingPath | quote }}
             statusCode: 302
 {{- end }}
 {{- end }}

--- a/platform/openbao/chart/templates/sso-configure-deployment.yaml
+++ b/platform/openbao/chart/templates/sso-configure-deployment.yaml
@@ -403,8 +403,16 @@ spec:
             # (https://bao.<fqdn>/ui/vault/auth/oidc/oidc/callback). With the
             # wrong host the OIDC callback's redirect_uri failed openbao's
             # allowed_redirect_uris check → silent SSO never completed. (#3150)
+            #
+            # The THIRD URI is the bare-URL landing page (#3374,
+            # templates/sso-landing.yaml): the landing JS calls
+            # auth/oidc/oidc/auth_url with redirect_uri=<this landing>, so the
+            # OIDC role must allow it (OpenBao's allowed_redirect_uris is a
+            # strict allowlist, no wildcard). The Keycloak `openbao` client
+            # already accepts it via its `/*` redirectUri (bp-sso-bridge). The
+            # value MUST match $landingPath in httproute.yaml / sso-landing.yaml.
             - name: OIDC_ALLOWED_REDIRECT_URIS
-              value: {{ printf "https://bao.%s/ui/vault/auth/oidc/oidc/callback http://localhost:8250/oidc/callback" (.Values.sso.sovereignFqdn | default "openbao.local") | quote }}
+              value: {{ printf "https://bao.%s/ui/vault/auth/oidc/oidc/callback https://bao.%s%s http://localhost:8250/oidc/callback" (.Values.sso.sovereignFqdn | default "openbao.local") (.Values.sso.sovereignFqdn | default "openbao.local") (.Values.sso.bareURL.landingPath | default "/sso/landing") | quote }}
             - name: INTERVAL_SECONDS
               value: "60"
           resources:

--- a/platform/openbao/chart/templates/sso-landing.yaml
+++ b/platform/openbao/chart/templates/sso-landing.yaml
@@ -1,0 +1,326 @@
+{{- /*
+bp-openbao SSO landing — TRUE zero-click bare-URL entry (#3374).
+
+WHY THIS EXISTS (root cause, measured live on hw133 2026-06-14):
+  OpenBao's Vault-UI (Ember) OIDC login is POPUP-ONLY. The callback route
+  `vault/cluster/oidc-callback` `afterModel` does an UNCONDITIONAL
+  `window.opener.postMessage(payload, origin)` — there is NO null-check and
+  NO in-page completion path (verified against openbao v2.3.1 UI source).
+  The #3226 catalyst-api shim drove a server-side FULL-PAGE 302 straight
+  into that callback, so `window.opener` was null and every bare-URL visit
+  rendered the Ember error page:
+    "Error: Cannot read properties of null (reading 'postMessage')"
+  (oidc-callback afterModel, vault bundle). Wire-proof 302 ≠ landed-in.
+
+WHAT THIS PAGE DOES (gesture-free, popup-free, version-stable):
+  A tiny static page served on the OpenBao origin itself. It IS the OIDC
+  redirect_uri (added to the role's allowed_redirect_uris + matched by the
+  KC client's `/*`), so it completes the round-trip as a TOP-LEVEL window:
+    1. No `code` in URL  -> POST auth/<mount>/oidc/auth_url
+       {role, redirect_uri:<this page>} (unauthenticated endpoint), then
+       top-window `location.replace(auth_url)` -> Keycloak (silent via the
+       realm IDP defaultProvider=catalyst-pin) -> back HERE with code+state.
+    2. `code`+`state` in URL -> GET auth/<mount>/oidc/callback?state=&code=
+       (the exact exchange the Ember adapter does) -> returns the auth block
+       {client_token, policies, entity_id, lease_duration, renewable}. We
+       reconstruct the Vault-UI localStorage entry `vault-token<DELIM>1`
+       (+ selectedAuth) — the ground-truth shape captured from a live
+       working OIDC session on this OpenBao version — and redirect to
+       /ui/vault/secrets. The UI boots already-authenticated. No popup, no
+       window.opener, no token form.
+
+  All dynamic auth values come from the live API response; only the static
+  `token`-backend descriptor + the `<DELIM>1` cluster key are structural
+  constants (asserted by tests/sso-landing-localstorage-shape.sh so a future
+  OpenBao UI bump that changes the shape fails CI, per #3374 law §2.3).
+
+  Loop-safety: this page lives at /sso/landing — NOT a Vault UI route, NOT
+  the OIDC callback. The bare-path HTTPRoute (/, /ui, /ui/) redirects HERE;
+  a re-entry that already holds a valid token short-circuits to
+  /ui/vault/secrets (idempotent). API clients use /v1/* — never touched.
+*/ -}}
+{{- if and .Values.gateway .Values.gateway.enabled .Values.gateway.host .Values.sso .Values.sso.enabled .Values.sso.bareURL .Values.sso.bareURL.enabled }}
+{{- $mount := .Values.sso.bareURL.oidcMount | default "oidc" }}
+{{- $role := .Values.sso.bareURL.oidcRole | default "operator" }}
+{{- $landingPath := .Values.sso.bareURL.landingPath | default "/sso/landing" }}
+{{- $img := printf "%s/%s:%s" (.Values.ssoLanding.image.registry | default "harbor.openova.io") (.Values.ssoLanding.image.repository | default "proxy-docker/library/nginx") (.Values.ssoLanding.image.tag | default "1.27-alpine") }}
+---
+# ── landing page content (HTML + JS) ──────────────────────────────────
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openbao-sso-landing
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao-sso-landing
+data:
+  index.html: |
+    <!doctype html>
+    <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <meta name="robots" content="noindex,nofollow">
+      <title>Signing in… — OpenBao</title>
+      <style>
+        html,body{height:100%;margin:0}
+        body{display:flex;align-items:center;justify-content:center;
+          font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+          background:#1c1c28;color:#e3e3e8}
+        .box{text-align:center;max-width:30rem;padding:2rem}
+        .spin{width:2.5rem;height:2.5rem;margin:0 auto 1.25rem;border:3px solid #3a3a4d;
+          border-top-color:#ffd814;border-radius:50%;animation:r .8s linear infinite}
+        @keyframes r{to{transform:rotate(360deg)}}
+        h1{font-size:1.15rem;font-weight:600;margin:.25rem 0}
+        p{font-size:.9rem;color:#9a9aad;margin:.4rem 0 0}
+        a{color:#ffd814}
+        .err{display:none;color:#ff8a8a}
+      </style>
+    </head>
+    <body>
+      <div class="box">
+        <div class="spin" id="spin"></div>
+        <h1 id="msg">Signing you in to OpenBao…</h1>
+        <p id="sub">One moment — completing single sign-on.</p>
+        <p class="err" id="err"></p>
+      </div>
+      <script>
+      (function () {
+        // Injected at render time by Helm (Inviolable Principle #4 — no
+        // hard-coded host/mount; everything derives from chart values).
+        var MOUNT = {{ $mount | quote }};
+        var ROLE  = {{ $role | quote }};
+        var LANDING_PATH = {{ $landingPath | quote }};
+        var ORIGIN = window.location.origin;
+        var REDIRECT_URI = ORIGIN + LANDING_PATH;
+        var API = ORIGIN + "/v1/auth/" + MOUNT;
+        var POST_LOGIN = "/ui/vault/secrets";
+
+        function fail(m) {
+          var s = document.getElementById("spin"); if (s) s.style.display = "none";
+          document.getElementById("msg").textContent = "Sign-in could not complete";
+          document.getElementById("sub").style.display = "none";
+          var e = document.getElementById("err");
+          e.style.display = "block";
+          e.innerHTML = (m || "Unexpected error.") +
+            '<br><br><a href="/ui/vault/auth?with=' + encodeURIComponent(MOUNT + "/") +
+            '">Continue to the sign-in page</a>';
+        }
+
+        function qs(name) {
+          return new URLSearchParams(window.location.search).get(name);
+        }
+
+        // Vault-UI localStorage skeleton (ground-truth shape, openbao 2.3.x).
+        // The `token` auth backend descriptor is what the UI persists after
+        // ANY login (OIDC included); dynamic fields come from the live auth
+        // response. tests/sso-landing-localstorage-shape.sh pins this.
+        function persist(authResp, displayName) {
+          var a = authResp || {};
+          var ttl = a.lease_duration || 0;
+          var data = {
+            userRootNamespace: "",
+            displayName: displayName || (a.metadata && a.metadata.role ? ("oidc-" + a.metadata.role) : "oidc"),
+            backend: {
+              type: "token",
+              typeDisplay: "Token",
+              description: "Token authentication.",
+              tokenPath: "id",
+              displayNamePath: "display_name",
+              formAttributes: ["token"]
+            },
+            token: a.client_token,
+            policies: a.policies || [],
+            renewable: !!a.renewable,
+            entity_id: a.entity_id || "",
+            ttl: ttl,
+            tokenExpirationEpoch: Date.now() + (ttl * 1000)
+          };
+          // Ember store assigns cluster id "1" to the single Vault cluster;
+          // the key delimiter is U+2603 (snowman), per Vault-UI token-store.
+          var DELIM = "☃";
+          window.localStorage.setItem("vault-token" + DELIM + "1", JSON.stringify(data));
+          window.localStorage.setItem("selectedAuth", MOUNT + "/");
+        }
+
+        function exchange(state, code) {
+          document.getElementById("sub").textContent = "Finalising your session…";
+          var url = API + "/oidc/callback?state=" + encodeURIComponent(state) +
+                    "&code=" + encodeURIComponent(code);
+          fetch(url, { credentials: "omit", headers: { "Accept": "application/json" } })
+            .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+            .then(function (res) {
+              var a = res.j && res.j.auth;
+              if (!res.ok || !a || !a.client_token) {
+                fail("The identity provider returned no session token.");
+                return;
+              }
+              // Cosmetic display name from a token self-lookup (best-effort;
+              // never blocks the landing on failure).
+              fetch(ORIGIN + "/v1/auth/token/lookup-self", {
+                credentials: "omit",
+                headers: { "X-Vault-Token": a.client_token, "Accept": "application/json" }
+              }).then(function (r) { return r.ok ? r.json() : null; })
+                .catch(function () { return null; })
+                .then(function (look) {
+                  var dn = look && look.data && look.data.display_name ? look.data.display_name : null;
+                  try { persist(a, dn); } catch (e) { fail("Could not store the session locally."); return; }
+                  window.location.replace(POST_LOGIN);
+                });
+            })
+            .catch(function () { fail("Network error completing sign-in."); });
+        }
+
+        function begin() {
+          fetch(API + "/oidc/auth_url", {
+            method: "POST",
+            credentials: "omit",
+            headers: { "Content-Type": "application/json", "Accept": "application/json" },
+            body: JSON.stringify({ role: ROLE, redirect_uri: REDIRECT_URI })
+          })
+            .then(function (r) { return r.json(); })
+            .then(function (j) {
+              var au = j && j.data && j.data.auth_url;
+              if (!au) { fail("Could not start single sign-on (no authorization URL)."); return; }
+              window.location.replace(au);
+            })
+            .catch(function () { fail("Network error starting sign-in."); });
+        }
+
+        // Already signed in? (re-entry / idempotent) — straight through.
+        try {
+          var DELIM = "☃";
+          var existing = window.localStorage.getItem("vault-token" + DELIM + "1");
+          if (existing) {
+            var ex = JSON.parse(existing);
+            if (ex && ex.token && ex.tokenExpirationEpoch && ex.tokenExpirationEpoch > Date.now() + 30000) {
+              window.location.replace(POST_LOGIN);
+              return;
+            }
+          }
+        } catch (e) { /* fall through to a fresh login */ }
+
+        var code = qs("code");
+        var state = qs("state");
+        if (code && state) { exchange(state, code); } else { begin(); }
+      })();
+      </script>
+    </body>
+    </html>
+  nginx.conf: |
+    worker_processes 1;
+    events { worker_connections 64; }
+    http {
+      types { text/html html; }
+      default_type text/html;
+      access_log off;
+      server {
+        listen 8080;
+        # Never let the landing page be cached — it carries the live OIDC
+        # state machine; a stale copy would replay an expired code/state.
+        add_header Cache-Control "no-store, no-cache, must-revalidate, max-age=0" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        location = /healthz { return 200 "ok\n"; }
+        location / {
+          root /usr/share/nginx/html;
+          try_files /index.html =404;
+        }
+      }
+    }
+---
+# ── nginx Deployment serving the landing page ─────────────────────────
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openbao-sso-landing
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao-sso-landing
+spec:
+  replicas: {{ .Values.ssoLanding.replicas | default 1 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bp-openbao
+      catalyst.openova.io/component: openbao-sso-landing
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-openbao
+        catalyst.openova.io/component: openbao-sso-landing
+      annotations:
+        # Roll the Deployment whenever the page/nginx config changes so the
+        # served content tracks the chart (silent-ConfigMap-edit trap).
+        checksum/config: {{ .Files.Get "templates/sso-landing.yaml" | sha256sum | trunc 16 | quote }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: nginx
+          image: {{ $img | quote }}
+          imagePullPolicy: IfNotPresent
+          command: ["nginx", "-c", "/etc/nginx/nginx.conf", "-g", "daemon off;"]
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet: { path: /healthz, port: 8080 }
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /healthz, port: 8080 }
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - { name: html, mountPath: /usr/share/nginx/html/index.html, subPath: index.html, readOnly: true }
+            - { name: conf, mountPath: /etc/nginx/nginx.conf, subPath: nginx.conf, readOnly: true }
+            - { name: cache, mountPath: /var/cache/nginx }
+            - { name: run, mountPath: /var/run }
+          resources:
+            requests: { cpu: 5m, memory: 16Mi }
+            limits: { cpu: 50m, memory: 32Mi }
+      volumes:
+        - name: html
+          configMap:
+            name: openbao-sso-landing
+            items: [{ key: index.html, path: index.html }]
+        - name: conf
+          configMap:
+            name: openbao-sso-landing
+            items: [{ key: nginx.conf, path: nginx.conf }]
+        - name: cache
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
+---
+# ── Service ────────────────────────────────────────────────────────────
+apiVersion: v1
+kind: Service
+metadata:
+  name: openbao-sso-landing
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao-sso-landing
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: bp-openbao
+    catalyst.openova.io/component: openbao-sso-landing
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP
+{{- end }}

--- a/platform/openbao/chart/tests/sso-landing-render.sh
+++ b/platform/openbao/chart/tests/sso-landing-render.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# bp-openbao — SSO bare-URL landing render + localStorage-shape guard (#3374).
+#
+# WHY: OpenBao's Vault-UI OIDC login is POPUP-ONLY (the callback route does an
+# unconditional window.opener.postMessage with no null-check). The #3226
+# catalyst-api shim full-page-redirected into that callback and ALWAYS rendered
+# the Ember error "Cannot read properties of null (reading 'postMessage')"
+# (measured live hw133 2026-06-14). The fix is an on-origin landing page
+# (templates/sso-landing.yaml) that runs the OIDC round-trip as a TOP-LEVEL
+# window and reconstructs the Vault-UI token in localStorage.
+#
+# This guard pins the contract so a future chart/template edit cannot silently
+# regress it (the #3374 law §2.3 — regression-proofing is part of the feature):
+#   1. The bare paths (/, /ui, /ui/) 302 to /sso/landing on the SAME host —
+#      NOT to the catalyst-api shim (a mothership roll must not break bare-URL).
+#   2. /sso/landing is its own backend (the openbao-sso-landing Service).
+#   3. The landing Deployment + ConfigMap + Service all render.
+#   4. The localStorage skeleton constants are intact — the snowman-delimited
+#      key `vault-token` + "☃" + "1", `selectedAuth`, and the token-backend
+#      descriptor. If a future OpenBao UI bump changes the stored shape, the
+#      operator MUST update the page AND this guard together (CI red here is
+#      the tripwire).
+#   5. OIDC_ALLOWED_REDIRECT_URIS includes the landing URI (else OpenBao
+#      rejects the auth_url with an empty result and the page dead-ends).
+#   6. Default-off: nothing renders when sso.bareURL.enabled is false.
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+FQDN="hw133.omani.works"
+HOST="bao.${FQDN}"
+
+render() {
+  "$helm" template smoke "$chart_dir" \
+    --set gateway.enabled=true \
+    --set "gateway.host=${HOST}" \
+    --set "sso.sovereignFqdn=${FQDN}" \
+    "$@" 2>&1
+}
+
+out="$(render)"
+
+# ── Case 1: bare paths redirect to /sso/landing on the SAME host ──────────
+echo "[bp-openbao] Case 1: bare paths 302 -> /sso/landing (same host, not the shim)"
+route_block="$(echo "$out" | awk '/^kind: HTTPRoute$/{f=1} f && /^---$/{exit} f')"
+# Helm quotes the string value; match quote-agnostically.
+if ! echo "$route_block" | grep -qE 'replaceFullPath: "?/sso/landing"?'; then
+  echo "FAIL: bare-path redirect does not target /sso/landing"
+  echo "$route_block"; exit 1
+fi
+if echo "$route_block" | grep -qiE "openbao-sso-init|catalyst/v1/apps/openbao"; then
+  echo "FAIL: bare paths still redirect to the catalyst-api shim (the popup-callback bug)"
+  exit 1
+fi
+# the redirect hostname must be the openbao host itself (no catalyst-api dependency)
+if echo "$route_block" | grep -E "hostname:" | grep -qiE "api\."; then
+  echo "FAIL: bare-path redirect points at an api.* host (catalyst-api dependency)"
+  exit 1
+fi
+echo "[bp-openbao] Case 1: PASS"
+
+# ── Case 2: /sso/landing routes to the landing Service ────────────────────
+echo "[bp-openbao] Case 2: /sso/landing -> openbao-sso-landing backend"
+if ! echo "$route_block" | grep -qE 'value: "?/sso/landing"?'; then
+  echo "FAIL: no /sso/landing PathPrefix rule"; exit 1
+fi
+if ! echo "$route_block" | grep -q "name: openbao-sso-landing"; then
+  echo "FAIL: /sso/landing does not backendRef the openbao-sso-landing Service"; exit 1
+fi
+echo "[bp-openbao] Case 2: PASS"
+
+# ── Case 3: landing Deployment + ConfigMap + Service render ───────────────
+echo "[bp-openbao] Case 3: landing Deployment/ConfigMap/Service present"
+for k in "kind: ConfigMap" "kind: Deployment" "kind: Service"; do
+  if ! echo "$out" | awk -v want="$k" '
+      /^---/{blk=""} {blk=blk"\n"$0}
+      /name: openbao-sso-landing/{ if (blk ~ want) found=1 }
+      END{ exit (found?0:1) }'; then
+    echo "FAIL: no openbao-sso-landing resource of '${k}'"
+    exit 1
+  fi
+done
+echo "[bp-openbao] Case 3: PASS"
+
+# ── Case 4: localStorage skeleton constants intact ────────────────────────
+echo "[bp-openbao] Case 4: Vault-UI localStorage shape constants pinned"
+# The landing HTML is embedded in the openbao-sso-landing ConfigMap; the
+# markers below are unique to it, so assert against the whole render (robust
+# to literal-block indentation drift).
+html="$out"
+# 4a. snowman-delimited token key
+if ! printf '%s' "$html" | grep -q 'vault-token'; then
+  echo "FAIL: landing page missing the 'vault-token' localStorage key"; exit 1
+fi
+if ! printf '%s' "$html" | grep -q '☃'; then
+  echo "FAIL: landing page missing the U+2603 snowman key delimiter (Vault-UI token-store contract)"
+  exit 1
+fi
+# 4b. selectedAuth + post-login destination
+printf '%s' "$html" | grep -q 'selectedAuth'        || { echo "FAIL: missing selectedAuth write"; exit 1; }
+printf '%s' "$html" | grep -q '/ui/vault/secrets'   || { echo "FAIL: missing /ui/vault/secrets landing"; exit 1; }
+# 4c. the token-backend descriptor fields the UI requires (JS object source
+#     form — keys are unquoted JS, JSON.stringify quotes them at runtime to
+#     the captured ground-truth shape {"type":"token",...}).
+for f in 'type: "token"' 'tokenPath: "id"' 'displayNamePath: "display_name"'; do
+  if ! printf '%s' "$html" | grep -qF "$f"; then
+    echo "FAIL: localStorage token-backend descriptor missing field: $f"
+    exit 1
+  fi
+done
+# 4d. the two OIDC API calls the flow depends on
+printf '%s' "$html" | grep -q 'oidc/auth_url'  || { echo "FAIL: missing auth_url call"; exit 1; }
+printf '%s' "$html" | grep -q 'oidc/callback'  || { echo "FAIL: missing callback exchange call"; exit 1; }
+echo "[bp-openbao] Case 4: PASS"
+
+# ── Case 5: OIDC_ALLOWED_REDIRECT_URIS includes the landing URI ───────────
+echo "[bp-openbao] Case 5: OIDC role allowlists the landing redirect_uri"
+if ! echo "$out" | grep -E 'OIDC_ALLOWED_REDIRECT_URIS' -A1 | grep -q "https://${HOST}/sso/landing"; then
+  echo "FAIL: OIDC_ALLOWED_REDIRECT_URIS does not include https://${HOST}/sso/landing"
+  echo "(OpenBao auth_url returns an empty URL for a non-allowlisted redirect_uri -> the page dead-ends)"
+  exit 1
+fi
+echo "[bp-openbao] Case 5: PASS"
+
+# ── Case 6: default-off — nothing renders when bareURL disabled ───────────
+echo "[bp-openbao] Case 6: sso.bareURL.enabled=false -> no landing resources, no bare-path redirect"
+out_off="$(render --set sso.bareURL.enabled=false)"
+if echo "$out_off" | grep -q "openbao-sso-landing"; then
+  echo "FAIL: landing resources rendered while sso.bareURL.enabled=false"; exit 1
+fi
+if echo "$out_off" | grep -q "replaceFullPath: /sso/landing"; then
+  echo "FAIL: bare-path redirect rendered while sso.bareURL.enabled=false"; exit 1
+fi
+echo "[bp-openbao] Case 6: PASS"
+
+echo "[bp-openbao] All SSO landing render cases PASS"

--- a/platform/openbao/chart/values.yaml
+++ b/platform/openbao/chart/values.yaml
@@ -240,18 +240,46 @@ sso:
   # documentation; it is not consumed by the configure-deployment.
   idpHint: catalyst-pin
   # ── Bare-URL zero-click entry (#3374) ────────────────────────────────
-  # Gateway-level interception of the bare entry paths (/, /ui, /ui/)
-  # into catalyst-api's openbao-sso-init shim (#3226). See the loop-safety
-  # analysis in templates/httproute.yaml. Disable to fall back to the
-  # token form on bare entry (the founder-witnessed #3374 failure).
+  # Gateway-level interception of the bare entry paths (/, /ui, /ui/) ->
+  # 302 to the on-origin SSO landing page (templates/sso-landing.yaml),
+  # which completes the OIDC round-trip as a TOP-LEVEL window and lands the
+  # operator in /ui/vault/secrets signed in. See the loop-safety + root-
+  # cause analysis in templates/httproute.yaml + sso-landing.yaml. Disable
+  # to fall back to the token form on bare entry (the founder-witnessed
+  # #3374 failure).
+  #
+  # NOTE: the prior design 302'd the bare paths to catalyst-api's
+  # openbao-sso-init shim (#3226). That shim full-page-redirected into
+  # OpenBao's POPUP-ONLY OIDC callback (window.opener postMessage, no
+  # null-check) and ALWAYS rendered the Ember "Cannot read properties of
+  # null (reading 'postMessage')" error — measured live on hw133
+  # 2026-06-14. The landing page replaces it; apiHost/shimPath are retained
+  # only for reference and are no longer consumed by the HTTPRoute.
   bareURL:
     enabled: true
-    # Hostname of the catalyst-api HTTPRoute. When empty, derived from
-    # gateway.host by replacing the first DNS label with "api."
-    # (bao.hw130.omantel.biz -> api.hw130.omantel.biz).
+    # Path of the on-origin SSO landing page (served by the
+    # openbao-sso-landing nginx Deployment). MUST stay in sync across
+    # httproute.yaml, sso-landing.yaml, and OIDC_ALLOWED_REDIRECT_URIS.
+    landingPath: /sso/landing
+    # Vault OIDC auth-method mount + role the landing page drives. Match
+    # the sso-configure Deployment (auth/oidc enable + role/operator).
+    oidcMount: oidc
+    oidcRole: operator
+    # (Legacy, unused by the HTTPRoute since the landing-page fix — kept for
+    # reference / external tooling that still reads them.)
     apiHost: ""
-    # Path of the server-side SSO-init shim on the catalyst-api host.
     shimPath: /catalyst/v1/apps/openbao/openbao-sso-init
+
+# ─── SSO landing page (#3374) ────────────────────────────────────────────
+# The tiny nginx that serves the on-origin bare-URL landing page. Rendered
+# only when sso.bareURL.enabled. Image goes through the Harbor proxy mirror
+# (kyverno harbor-proxy-pull Enforce — `*/proxy-*/*`).
+ssoLanding:
+  replicas: 1
+  image:
+    registry: harbor.openova.io
+    repository: proxy-docker/library/nginx
+    tag: "1.27-alpine"
 
 # ─── Cross-cluster snapshot-replication (DR / #3375 DoD-8) ────────────────
 # Implements the bp-openbao state-preservation row from


### PR DESCRIPTION
## openbao bare URL rendered the Ember `postMessage` error, never landed signed-in

Re-reproduced live on hw133 (deployment `40c4e17667b600eb`) with headless Playwright. The bare URL `bao.hw133.omani.works/ui/` → catalyst-api shim → Keycloak (silent, no PIN form) → back to `/ui/vault/auth/oidc/oidc/callback?code=…` → the Vault UI rendered a full "**Error: Cannot read properties of null (reading 'postMessage')**" page (oidc-callback `afterModel`).

### Real root cause (deeper than #3429/#3431/#3434/#3436)

Those fixes corrected the shim/302-chain + group-mapping, but the **bare-URL landing still failed** because the disease is architectural:

OpenBao's Vault-UI (Ember) OIDC login is **POPUP-ONLY**. The callback route `vault/cluster/oidc-callback` `afterModel` does an **unconditional** `window.opener.postMessage(payload, origin)` — no `window.opener` null-check, no in-page completion path (verified against openbao **v2.3.1** UI source: `routes/vault/cluster/oidc-callback.js` + `components/auth-jwt.js` — login starts via `window.open` only, the main window waits for the popup's postMessage). The #3226 catalyst-api shim 302'd the **whole browser tab** into that callback, so `window.opener` is null → every bare-URL visit throws.

**Proof the wire + policy were already correct:** clicking the native "Sign in with OIDC Provider" button (the real popup flow) lands on the admin **Secrets Engines** page. OIDC config, bound_claims (all 3 realm groups), the `sso-operator-admin` identity-group alias, and the KC client are all fine. The failure was 100% the bare-URL entry path.

### The fix — on-origin landing page (no popup, no catalyst-api dependency)

`templates/sso-landing.yaml` (a tiny nginx-served static page):
- bare `/`, `/ui`, `/ui/` now **302 to `/sso/landing` on the SAME host** — immune to a mothership/catalyst-api roll-storm (the prior shim 503'd during rolls). The catalyst-api shim redirect is removed from `httproute.yaml`.
- `/sso/landing` runs the OIDC round-trip as a **top-level window**: `POST oidc/auth_url {role, redirect_uri:<landing>}` → `location.replace(auth_url)` → Keycloak (silent via the realm IDP `defaultProvider=catalyst-pin`) → back to `/sso/landing?code` → `GET oidc/callback?state=&code=` (the exact exchange the Ember adapter does) → reconstruct the Vault-UI token in localStorage → `/ui/vault/secrets`. UI boots **already-authenticated**.
- the landing `redirect_uri` is added to the OIDC role `allowed_redirect_uris` (OpenBao's allowlist is strict, no wildcard); the Keycloak `openbao` client already accepts it via its `/*` redirectUri (bp-sso-bridge).

### Validated live on hw133 before writing the chart
- `auth_url` returns **empty** for a non-allowlisted `redirect_uri`, **populated** for the landing path — confirms the allowlist addition is required + sufficient.
- `GET /v1/auth/oidc/oidc/callback?state=&code=` returns `client_token` + `policies:[default, sso-operator-admin, sso-operator-read]` + `entity_id` + `lease_duration:2764800` — **admin**, exactly what the landing page persists.
- The reconstructed localStorage shape (`vault-token`+U+2603+`1`, `selectedAuth=oidc/`, token-backend descriptor) is the **ground truth** dumped from a live working OIDC session on this OpenBao version — not guessed. Only the skeleton is hardcoded; all dynamic fields come from the live callback response.

### Regression-proofing (#3374 law §2.3)
`tests/sso-landing-render.sh` (6 cases) pins: bare-path redirect target (NOT the old shim, same host not `api.*`), the `/sso/landing` backend, the Deployment/ConfigMap/Service set, the localStorage shape constants (snowman key + token-backend descriptor + the two OIDC calls), and the `redirect_uri` allowlist. A future OpenBao UI bump that changes the stored shape, or an edit re-pointing the bare paths at the shim, **fails CI**.

### Lockstep + validation
- Chart `1.2.34 → 1.2.35`; `blueprint.yaml` + bootstrap-kit slot `08` pin bumped together.
- `helm lint` clean; all 3 chart tests pass; nginx image goes through the Harbor proxy mirror (kyverno-compliant, verified by the existing `kyverno-harbor-proxy-images.sh`).

### What the walker should now see
After CI publishes `bp-openbao:1.2.35` and Flux reconciles (slot 08) + the sso-configure tick adds the landing URI to the role: the bare URL `https://bao.hw133.omani.works/ui/` shows a brief "Signing you in…" then lands on the **OpenBao Secrets Engines** admin screen, signed in as emrah.baysal — no token form, no `postMessage` error, no login button.

Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)