### PR TITLE
fix(bp-newapi): stamp managed-by:flux on all 4 hook Jobs — kyverno blocked the 1.4.68 upgrade (#3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -206,7 +206,11 @@ spec:
       # fresh Sovereign showed the "uninitialized" wizard with no admin. The new
       # DB-direct seed writes the setups row + SSO-only root user + sovereign
       # OIDC provider + promotes the owner to root on first login.
-      version: 1.4.68
+      # 1.4.69 — #3374 admin-tier: stamp managed-by:flux on all 4 hook Jobs so
+      # the upgrade's pre-upgrade gate (and post-upgrade seed/channel/db-sync)
+      # aren't denied by kyverno flux-managed Enforce → 1.4.68 rolled back to
+      # 1.4.66 on hw133, leaving NewAPI uninitialized. Same class as openbao #3434.
+      version: 1.4.69
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.68
+  version: 1.4.69
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -450,7 +450,18 @@ name: bp-newapi
 # bp-sso-bridge + an ExternalSecret (creationPolicy Merge) converges
 # OIDC_CLIENT_SECRET to the live KC value; companion slot fix points the
 # issuer at realms/sovereign.
-version: 1.4.68
+# 1.4.69 (#3374 admin-tier, 2026-06-14): stamp `app.kubernetes.io/managed-by:
+# flux` on ALL FOUR hook Jobs — the pre-upgrade `newapi-eswebhook-gate`
+# (000-external-secrets-webhook-readiness-job) PLUS the post-upgrade
+# admin-sso-seed / channel-seed / db-dsn-sync Jobs. On hw133 the 1.4.68
+# upgrade FAILED the pre-upgrade hook (kyverno `flux-managed` Enforce denies a
+# Job without managed-by=flux — helm-controller hook Jobs carry no HR
+# ownerReference) and the HR rolled back to 1.4.66, so the SSO admin seed
+# never reached the cluster (NewAPI stuck at /setup, uninitialized). All four
+# Jobs are stamped so the upgrade doesn't merely stall at the NEXT hook. Same
+# class as openbao #3434 + gitea/harbor #3296→#3297. Lockstep: 80-newapi.yaml
+# pin → 1.4.69.
+version: 1.4.69
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/000-external-secrets-webhook-readiness-job.yaml
+++ b/platform/newapi/chart/templates/000-external-secrets-webhook-readiness-job.yaml
@@ -113,6 +113,13 @@ metadata:
   labels:
     catalyst.openova.io/blueprint: bp-newapi
     catalyst.openova.io/component: external-secrets-webhook-gate
+    # kyverno `flux-managed` Enforce (baseline 10-flux-managed) DENIES any
+    # Job lacking this label. Helm hook Jobs are created by the
+    # helm-controller, not Flux directly, so it must be stamped explicitly
+    # or the FIRST chart roll on a converged kyverno-Enforce env fails this
+    # pre-upgrade hook and the whole HR rolls back (caught live on hw133,
+    # #3374; same class as openbao #3434 / gitea-harbor #3296→#3297).
+    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-weight": "-10"

--- a/platform/newapi/chart/templates/admin-sso-seed-job.yaml
+++ b/platform/newapi/chart/templates/admin-sso-seed-job.yaml
@@ -275,6 +275,11 @@ metadata:
   labels:
     {{- include "bp-newapi.labels" . | nindent 4 }}
     catalyst.openova.io/component: admin-seed
+    # Override the helper's managed-by=Helm: kyverno `flux-managed` Enforce
+    # DENIES a hook Job without managed-by=flux (helm-controller-created, no
+    # HR ownerReference). Without it this post-upgrade SSO admin seed fails
+    # and the HR rolls back, so the admin map never lands (#3374 / #3434).
+    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "12"

--- a/platform/newapi/chart/templates/channel-seed-job.yaml
+++ b/platform/newapi/chart/templates/channel-seed-job.yaml
@@ -205,6 +205,11 @@ metadata:
   labels:
     {{- include "bp-newapi.labels" . | nindent 4 }}
     catalyst.openova.io/component: channel-seed
+    # Override the helper's managed-by=Helm: kyverno `flux-managed` Enforce
+    # DENIES a hook Job without managed-by=flux (helm-controller-created, no
+    # HR ownerReference). Without it this post-upgrade hook fails and the HR
+    # rolls back — the same landmine that stalled bp-newapi on hw133 (#3374).
+    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "10"

--- a/platform/newapi/chart/templates/database-secret-sync-job.yaml
+++ b/platform/newapi/chart/templates/database-secret-sync-job.yaml
@@ -64,6 +64,11 @@ metadata:
   labels:
     {{- include "bp-newapi.labels" . | nindent 4 }}
     catalyst.openova.io/component: newapi-db-dsn-sync
+    # Override the helper's managed-by=Helm: kyverno `flux-managed` Enforce
+    # DENIES a hook Job without managed-by=flux (helm-controller-created, no
+    # HR ownerReference). Without it this post-upgrade hook fails and the HR
+    # rolls back — same landmine class that stalled bp-newapi on hw133 (#3374).
+    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "5"


### PR DESCRIPTION
## Problem (live on hw133)
bp-newapi **1.4.68** HR is kyverno-stalled (`Ready=False`, rolled back to **1.4.66**). The pre-upgrade hook `newapi-eswebhook-gate` is denied by the `flux-managed` Enforce policy:

```
Job/newapi-eswebhook-gate is not Flux-managed. Add label
app.kubernetes.io/managed-by: flux ...
```

Helm hook Jobs are created by the helm-controller (no HR ownerReference) and the chart's `bp-newapi.labels` helper sets `managed-by=Helm`. The whole upgrade rolls back → the 1.4.67 SSO admin-seed never reaches the cluster → NewAPI stays at its `/setup` System-initialization wizard, uninitialized with no SSO admin (the #3374 admin-tier failure on hw133).

## Fix
Stamp `app.kubernetes.io/managed-by: flux` on **all four** hook Jobs (so the upgrade doesn't merely stall at the next hook):
- `000-external-secrets-webhook-readiness-job` (pre-upgrade, -10)
- `admin-sso-seed-job` (post-upgrade, 12)
- `channel-seed-job` (post-upgrade, 10)
- `database-secret-sync-job` (post-upgrade, 5)

Images already comply (single registry per Job — no harbor-proxy anyPattern mismatch). Same class as openbao #3434, gitea/harbor #3296→#3297.

Chart **1.4.68 → 1.4.69** + `blueprint.yaml` + `80-newapi.yaml` slot pin in lockstep.

## Validation
`helm template` renders all hook Jobs with `managed-by=flux` (3 render by default + channel-seed under its gate; the pre-existing `helm lint` document-separator warning on `admin-sso-seed-job.yaml` is unchanged from main — `helm template` renders clean).

## What the walker should see after reconcile
`newapi.hw133.omani.works` lands signed-in via SSO (no `/setup` wizard), `/setting` reachable as admin.

Refs #3374 #3455