### PR TITLE
fix(bp-cilium): oidc-audience-mapper on hubble-ui client — oauth2-proxy callback 500 aud-mismatch (#3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -95,7 +95,11 @@ spec:
       # `catalyst.openova.io/hubble-ui-auth: oidc` annotation and flipped
       # default `catalystOverlay.hubbleUI.auth` from `oidc` → `none`
       # (no enforcement filter shipped yet). Refs #2744.
-      version: 1.4.2
+      # 1.4.3 (#3374 admin-tier): oidc-audience-mapper on the hubble-ui
+      # AppRegistration client — oauth2-proxy callback was 500ing on hw133
+      # (aud=[realm-management account], never hubble-ui). Same fix class as
+      # the bp-oidc-gate openova-flow audience-mapper (#3447).
+      version: 1.4.3
       sourceRef:
         kind: HelmRepository
         name: bp-cilium

--- a/platform/cilium/blueprint.yaml
+++ b/platform/cilium/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.4.2
+  version: 1.4.3
   card:
     title: Cilium
     summary: Unified CNI + Service Mesh (eBPF). mTLS via WireGuard, Hubble observability, Gateway API.

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -112,7 +112,22 @@ name: bp-cilium
 # Deployment's OAUTH2_PROXY_CLIENT_SECRET now reads that. cookie-secret
 # stays chart-managed. Set ssoBridgeSync.enabled=false to restore the old
 # (broken-by-design) standalone secret.
-version: 1.4.2
+# 1.4.3 (#3374 admin-tier, 2026-06-14): seed an oidc-audience-mapper on the
+# hubble-ui AppRegistration client so the bare URL lands signed-in. After
+# 1.4.2 the secret-convergence fix landed (oauth2-proxy 1/1, no more 503) but
+# the OIDC callback then returned HTTP 500 on hw133 (oauthproxy.go:888):
+#   audience from claim aud with value [realm-management account] does not
+#   match with any of allowed audiences map[hubble-ui:{}]
+# oauth2-proxy's keycloak-oidc provider VERIFIES the ID token's `aud` carries
+# its own --client-id; a vanilla confidential client only lists a client in
+# `aud` when the user holds a client role for it, and emrah.baysal holds none
+# on hubble-ui, so `aud` was [realm-management account] and never hubble-ui.
+# The client.json now seeds an oidc-audience-mapper (included.client.audience
+# =hubble-ui, id.token.claim=true because oauth2-proxy checks the ID token) —
+# the netbird realm-config idiom, identical to the bp-oidc-gate openova-flow
+# fix (#3447). bp-sso-bridge PUTs client.json template-wins every tick, so the
+# mapper lands on the live hubble-ui client zero-touch.
+version: 1.4.3
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`

--- a/platform/cilium/chart/templates/hubble-ui-sso-registration-configmap.yaml
+++ b/platform/cilium/chart/templates/hubble-ui-sso-registration-configmap.yaml
@@ -25,6 +25,20 @@ not clobbered.
 
 data.realm = "sovereign": the watcher only requires the realm to EXIST
 (GET /admin/realms/<realm> == 200); the sovereign realm always does.
+
+#3374 admin-tier (2026-06-14): client.json now seeds an oidc-audience-mapper.
+After the secret-convergence fix (1.4.2) the 503 cleared but the OIDC callback
+500'd on hw133 — oauth2-proxy's keycloak-oidc provider VERIFIES the ID token's
+`aud` contains its own --client-id, and a vanilla confidential client only puts
+a client into `aud` when the user holds a client role for it. emrah.baysal holds
+none on hubble-ui, so `aud` was [realm-management account] and never hubble-ui
+(oauthproxy.go:888 "audience ... does not match ... map[hubble-ui:{}]"). The
+oidc-audience-mapper injects hubble-ui into the ID-token aud (id.token.claim=true
+because oauth2-proxy checks the ID token) — the netbird realm-config idiom,
+identical to the bp-oidc-gate openova-flow fix (#3447). bp-sso-bridge PUTs
+client.json template-wins, so the mapper lands on the live hubble-ui client
+zero-touch (the hubble-ui realm-import client carries no protocolMappers, so the
+template array doesn't clobber anything).
 */ -}}
 {{- $ov := .Values.catalystOverlay.hubbleUI -}}
 {{- $hostname := $ov.hostname -}}
@@ -60,6 +74,18 @@ data:
         "https://{{ $hostname }}"
       ],
       "defaultClientScopes": ["web-origins", "acr", "profile", "roles", "email", "groups"],
+      "protocolMappers": [
+        {
+          "name": "audience-hubble-ui",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "hubble-ui",
+            "id.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ],
       "attributes": {
         "access.token.lifespan": "900"
       }


### PR DESCRIPTION
## Problem (live on hw133)
After bp-cilium **1.4.2** landed the secret-convergence fix, hubble no longer 503'd (oauth2-proxy 1/1, secret created) but the OIDC callback returns **HTTP 500** (oauthproxy.go:888):

```
audience from claim aud with value [realm-management account] does not match
with any of allowed audiences map[hubble-ui:{}]
```

oauth2-proxy's keycloak-oidc provider VERIFIES the ID token's `aud` carries its own `--client-id`. A vanilla confidential client only lists a client in `aud` when the user holds a client role for it; `emrah.baysal` holds none on `hubble-ui`, so `aud` was `[realm-management account]`, never `hubble-ui` → 500 → never reaches the service map. (grafana/harbor pass because they front their own OIDC and don't enforce `aud==client-id`.)

## Fix
The `hubble-ui` AppRegistration `client.json` now seeds an `oidc-audience-mapper` (`included.client.audience=hubble-ui`, `id.token.claim=true` because oauth2-proxy checks the ID token). **Identical fix class to bp-oidc-gate's openova-flow audience-mapper (#3447).** bp-sso-bridge PUTs `client.json` template-wins every tick → the mapper lands on the live `hubble-ui` client zero-touch. The realm-import `hubble-ui` client carries no protocolMappers, so the template array clobbers nothing.

Chart **1.4.2 → 1.4.3** + `blueprint.yaml` + `01-cilium.yaml` slot pin in lockstep.

## Validation
`helm template` renders `hubble-ui-sso-registration` ConfigMap; embedded `client.json` parses; `oidc-audience-mapper` present with `aud=hubble-ui`, `id.token.claim=true`; `externalSecret.json` preserved.

## What the walker should see after reconcile
`hubble.hw133.omani.works` → silent SSO → lands in the Hubble service map (no 500 callback page).

Refs #3374 #3455