### PR TITLE
fix(bp-openbao): sso-landing nginx image proxy-dockerhub — fix ImagePullBackOff (#3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -77,7 +77,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.36
+      version: 1.2.37
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.36
+  version: 1.2.37
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -26,7 +26,15 @@ name: bp-openbao
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.2.36
+version: 1.2.37
+# 1.2.37 (#3374, 2026-06-14): fix the sso-landing nginx ImagePullBackOff. The
+# image was `harbor.openova.io/proxy-docker/library/nginx` but the live Harbor
+# DockerHub proxy-cache project is `proxy-dockerhub` (proxy-docker does NOT
+# exist → 401 Unauthorized on the manifest HEAD, landing pod ImagePullBackOff
+# — measured on hw133). Corrected to proxy-dockerhub/library/nginx (the same
+# convention the rest of the chart + every other bp-* uses; verified it pulls
+# live). The kyverno `*/proxy-*/*` glob accepted both, which is why the render
+# test passed — the project-existence is a runtime fact, not a glob fact.
 # 1.2.36 (#3374, 2026-06-14): the 1.2.35 Blueprint-Release publish FAILED at
 # the chart-integration-test step — tests/sso-landing-render.sh Case 4 piped
 # the whole helm render into `grep -q`, which exits early and SIGPIPEs the

--- a/platform/openbao/chart/templates/sso-landing.yaml
+++ b/platform/openbao/chart/templates/sso-landing.yaml
@@ -43,7 +43,7 @@ WHAT THIS PAGE DOES (gesture-free, popup-free, version-stable):
 {{- $mount := .Values.sso.bareURL.oidcMount | default "oidc" }}
 {{- $role := .Values.sso.bareURL.oidcRole | default "operator" }}
 {{- $landingPath := .Values.sso.bareURL.landingPath | default "/sso/landing" }}
-{{- $img := printf "%s/%s:%s" (.Values.ssoLanding.image.registry | default "harbor.openova.io") (.Values.ssoLanding.image.repository | default "proxy-docker/library/nginx") (.Values.ssoLanding.image.tag | default "1.27-alpine") }}
+{{- $img := printf "%s/%s:%s" (.Values.ssoLanding.image.registry | default "harbor.openova.io") (.Values.ssoLanding.image.repository | default "proxy-dockerhub/library/nginx") (.Values.ssoLanding.image.tag | default "1.27-alpine") }}
 ---
 # ── landing page content (HTML + JS) ──────────────────────────────────
 apiVersion: v1

--- a/platform/openbao/chart/values.yaml
+++ b/platform/openbao/chart/values.yaml
@@ -272,13 +272,16 @@ sso:
 
 # ─── SSO landing page (#3374) ────────────────────────────────────────────
 # The tiny nginx that serves the on-origin bare-URL landing page. Rendered
-# only when sso.bareURL.enabled. Image goes through the Harbor proxy mirror
-# (kyverno harbor-proxy-pull Enforce — `*/proxy-*/*`).
+# only when sso.bareURL.enabled. Image goes through the Harbor DockerHub
+# proxy-cache project (kyverno harbor-proxy-pull Enforce — `*/proxy-*/*`).
+# The project is `proxy-dockerhub` (the live convention — proxy-dockerhub/
+# library/alpine, .../hashicorp/vault-k8s all pull; the bare `proxy-docker`
+# project does NOT exist on Harbor and 401s the pull — measured on hw133).
 ssoLanding:
   replicas: 1
   image:
     registry: harbor.openova.io
-    repository: proxy-docker/library/nginx
+    repository: proxy-dockerhub/library/nginx
     tag: "1.27-alpine"
 
 # ─── Cross-cluster snapshot-replication (DR / #3375 DoD-8) ────────────────


### PR DESCRIPTION
## openbao-sso-landing pod ImagePullBackOff on hw133

After `bp-openbao:1.2.36` published and reconciled, the new `openbao-sso-landing` Deployment came up but the nginx pod went **ImagePullBackOff**:

```
Failed to pull "harbor.openova.io/proxy-docker/library/nginx:1.27-alpine":
401 Unauthorized (HEAD .../v2/proxy-docker/library/nginx/manifests/1.27-alpine)
```

The live Harbor DockerHub proxy-cache project is **`proxy-dockerhub`**, not `proxy-docker` (which does not exist → 401). Every other image on the cluster uses `proxy-dockerhub` (`proxy-dockerhub/library/alpine`, `.../hashicorp/vault-k8s`, …), and the rest of **this** chart already does too — the landing image was the lone typo.

## Fix
Corrected `values.yaml` + the `sso-landing.yaml` template default to `proxy-dockerhub/library/nginx`. **Verified it pulls live on hw133** (test pod Succeeded, "image already present"). The bare-URL HTTPRoute was already correct (confirmed live: `/sso/landing → openbao-sso-landing`, bare paths → 302 `/sso/landing`); only the landing pod's image blocked it.

The kyverno `*/proxy-*/*` harbor-proxy glob accepts `proxy-docker` (it matches the wildcard), which is why `kyverno-harbor-proxy-images.sh` passed — the proxy project's existence is a runtime fact the render test can't see.

Chart `1.2.36 → 1.2.37`; `blueprint.yaml` + slot `08` in lockstep. helm lint clean; all 3 openbao chart tests pass.

## After this lands
`bp-openbao:1.2.37` publishes → Flux reconciles → the `openbao-sso-landing` nginx starts → the bare URL `https://bao.hw133.omani.works/ui/` lands on the OpenBao admin Secrets-Engines screen signed in (no token form, no `postMessage` error).

Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)