### PR TITLE
fix(bp-guacamole): un-stall jdbc-seed Job — managed-by:flux + vendor schema single-container (#3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -161,7 +161,11 @@ spec:
       # USER_GROUP. The openid extension authenticated SSO users but granted
       # no admin; the new CNPG cluster + schema-seed Job + POSTGRESQL_* env
       # make sovereign-admins members land as guacamole admin on SSO login.
-      version: 0.2.10
+      # 0.2.11 — #3374 admin-tier: un-stall the seed Job (0.2.10 was kyverno-
+      # denied → rolled back to 0.2.8). Stamp managed-by:flux on the Job +
+      # vendor the schema so it is single-container (no mixed-registry
+      # initContainer for harbor-proxy-pull anyPattern to reject).
+      version: 0.2.11
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/category: platform
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.10
+  version: 0.2.11
   card:
     title: Apache Guacamole
     summary: Clientless HTML5 remote-desktop gateway. Browser-based RDP / VNC / SSH and kubectl-exec into Pods, with Keycloak SSO and full session recording to SeaweedFS. One Guacamole per Sovereign per ADR-0001 §11.

--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -115,7 +115,22 @@ name: bp-guacamole
 # an SSO user in sovereign-admins auto-creates a JDBC record, binds into the
 # group, and lands as guacamole admin. New `guacamole.database.*` values.
 # Lockstep: 52-bp-guacamole.yaml pin → 0.2.9. Refs #3374.
-version: 0.2.10
+# 0.2.11 (#3374 admin-tier, 2026-06-14): un-stall the seed Job on hw133. The
+# 0.2.10 jdbc-schema-seed Job was DENIED on every reconcile (HR rolled back to
+# 0.2.8) by TWO kyverno Enforce policies: (1) flux-managed — the hook Job
+# carried managed-by=Helm (the helper) not flux; (2) harbor-proxy-pull — its
+# anyPattern needs ONE allowed glob to match BOTH the initContainers AND the
+# containers, but the guacamole-webapp initContainer was ghcr.io/openova-io/...
+# (native-push glob) while the psql container was proxy-ghcr/cnpg... (proxy
+# glob), and no single glob matched both. Fix: (a) stamp managed-by:flux on the
+# Job; (b) VENDOR the Apache Guacamole 1.5.5 schema into the chart
+# (files/postgresql/001-create-schema.sql, loaded into the scripts ConfigMap
+# via .Files.Get) and drop the webapp initContainer, so the Job is
+# single-container (CNPG psql, proxy glob) — no second registry for the
+# anyPattern to reject. The vendored SQL is pinned to
+# guacamole.webapp.image.tag (1.5.5); bump both together. Lockstep:
+# 52-bp-guacamole.yaml pin → 0.2.11. Refs #3374 #3434 #3296.
+version: 0.2.11
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/files/postgresql/001-create-schema.sql
+++ b/platform/guacamole/chart/files/postgresql/001-create-schema.sql
@@ -1,0 +1,736 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+--
+-- Connection group types
+--
+
+CREATE TYPE guacamole_connection_group_type AS ENUM(
+    'ORGANIZATIONAL',
+    'BALANCING'
+);
+
+--
+-- Entity types
+--
+
+CREATE TYPE guacamole_entity_type AS ENUM(
+    'USER',
+    'USER_GROUP'
+);
+
+--
+-- Object permission types
+--
+
+CREATE TYPE guacamole_object_permission_type AS ENUM(
+    'READ',
+    'UPDATE',
+    'DELETE',
+    'ADMINISTER'
+);
+
+--
+-- System permission types
+--
+
+CREATE TYPE guacamole_system_permission_type AS ENUM(
+    'CREATE_CONNECTION',
+    'CREATE_CONNECTION_GROUP',
+    'CREATE_SHARING_PROFILE',
+    'CREATE_USER',
+    'CREATE_USER_GROUP',
+    'ADMINISTER'
+);
+
+--
+-- Guacamole proxy (guacd) encryption methods
+--
+
+CREATE TYPE guacamole_proxy_encryption_method AS ENUM(
+    'NONE',
+    'SSL'
+);
+
+--
+-- Table of connection groups. Each connection group has a name.
+--
+
+CREATE TABLE guacamole_connection_group (
+
+  connection_group_id   serial       NOT NULL,
+  parent_id             integer,
+  connection_group_name varchar(128) NOT NULL,
+  type                  guacamole_connection_group_type
+                        NOT NULL DEFAULT 'ORGANIZATIONAL',
+
+  -- Concurrency limits
+  max_connections          integer,
+  max_connections_per_user integer,
+  enable_session_affinity  boolean NOT NULL DEFAULT FALSE,
+
+  PRIMARY KEY (connection_group_id),
+
+  CONSTRAINT connection_group_name_parent
+    UNIQUE (connection_group_name, parent_id),
+
+  CONSTRAINT guacamole_connection_group_ibfk_1
+    FOREIGN KEY (parent_id)
+    REFERENCES guacamole_connection_group (connection_group_id)
+    ON DELETE CASCADE
+
+);
+
+CREATE INDEX guacamole_connection_group_parent_id
+    ON guacamole_connection_group(parent_id);
+
+--
+-- Table of connections. Each connection has a name, protocol, and
+-- associated set of parameters.
+-- A connection may belong to a connection group.
+--
+
+CREATE TABLE guacamole_connection (
+
+  connection_id       serial       NOT NULL,
+  connection_name     varchar(128) NOT NULL,
+  parent_id           integer,
+  protocol            varchar(32)  NOT NULL,
+  
+  -- Concurrency limits
+  max_connections          integer,
+  max_connections_per_user integer,
+
+  -- Connection Weight
+  connection_weight        integer,
+  failover_only            boolean NOT NULL DEFAULT FALSE,
+
+  -- Guacamole proxy (guacd) overrides
+  proxy_port              integer,
+  proxy_hostname          varchar(512),
+  proxy_encryption_method guacamole_proxy_encryption_method,
+
+  PRIMARY KEY (connection_id),
+
+  CONSTRAINT connection_name_parent
+    UNIQUE (connection_name, parent_id),
+
+  CONSTRAINT guacamole_connection_ibfk_1
+    FOREIGN KEY (parent_id)
+    REFERENCES guacamole_connection_group (connection_group_id)
+    ON DELETE CASCADE
+
+);
+
+CREATE INDEX guacamole_connection_parent_id
+    ON guacamole_connection(parent_id);
+
+--
+-- Table of base entities which may each be either a user or user group. Other
+-- tables which represent qualities shared by both users and groups will point
+-- to guacamole_entity, while tables which represent qualities specific to
+-- users or groups will point to guacamole_user or guacamole_user_group.
+--
+
+CREATE TABLE guacamole_entity (
+
+  entity_id     serial                  NOT NULL,
+  name          varchar(128)            NOT NULL,
+  type          guacamole_entity_type   NOT NULL,
+
+  PRIMARY KEY (entity_id),
+
+  CONSTRAINT guacamole_entity_name_scope
+    UNIQUE (type, name)
+
+);
+
+--
+-- Table of users. Each user has a unique username and a hashed password
+-- with corresponding salt. Although the authentication system will always set
+-- salted passwords, other systems may set unsalted passwords by simply not
+-- providing the salt.
+--
+
+CREATE TABLE guacamole_user (
+
+  user_id       serial       NOT NULL,
+  entity_id     integer      NOT NULL,
+
+  -- Optionally-salted password
+  password_hash bytea        NOT NULL,
+  password_salt bytea,
+  password_date timestamptz  NOT NULL,
+
+  -- Account disabled/expired status
+  disabled      boolean      NOT NULL DEFAULT FALSE,
+  expired       boolean      NOT NULL DEFAULT FALSE,
+
+  -- Time-based access restriction
+  access_window_start    time,
+  access_window_end      time,
+
+  -- Date-based access restriction
+  valid_from  date,
+  valid_until date,
+
+  -- Timezone used for all date/time comparisons and interpretation
+  timezone varchar(64),
+
+  -- Profile information
+  full_name           varchar(256),
+  email_address       varchar(256),
+  organization        varchar(256),
+  organizational_role varchar(256),
+
+  PRIMARY KEY (user_id),
+
+  CONSTRAINT guacamole_user_single_entity
+    UNIQUE (entity_id),
+
+  CONSTRAINT guacamole_user_entity
+    FOREIGN KEY (entity_id)
+    REFERENCES guacamole_entity (entity_id)
+    ON DELETE CASCADE
+
+);
+
+--
+-- Table of user groups. Each user group may have an arbitrary set of member
+-- users and member groups, with those members inheriting the permissions
+-- granted to that group.
+--
+
+CREATE TABLE guacamole_user_group (
+
+  user_group_id serial      NOT NULL,
+  entity_id     integer     NOT NULL,
+
+  -- Group disabled status
+  disabled      boolean     NOT NULL DEFAULT FALSE,
+
+  PRIMARY KEY (user_group_id),
+
+  CONSTRAINT guacamole_user_group_single_entity
+    UNIQUE (entity_id),
+
+  CONSTRAINT guacamole_user_group_entity
+    FOREIGN KEY (entity_id)
+    REFERENCES guacamole_entity (entity_id)
+    ON DELETE CASCADE
+
+);
+
+--
+-- Table of users which are members of given user groups.
+--
+
+CREATE TABLE guacamole_user_group_member (
+
+  user_group_id    integer       NOT NULL,
+  member_entity_id integer       NOT NULL,
+
+  PRIMARY KEY (user_group_id, member_entity_id),
+
+  -- Parent must be a user group
+  CONSTRAINT guacamole_user_group_member_parent
+    FOREIGN KEY (user_group_id)
+    REFERENCES guacamole_user_group (user_group_id) ON DELETE CASCADE,
+
+  -- Member may be either a user or a user group (any entity)
+  CONSTRAINT guacamole_user_group_member_entity
+    FOREIGN KEY (member_entity_id)
+    REFERENCES guacamole_entity (entity_id) ON DELETE CASCADE
+
+);
+
+--
+-- Table of sharing profiles. Each sharing profile has a name, associated set
+-- of parameters, and a primary connection. The primary connection is the
+-- connection that the sharing profile shares, and the parameters dictate the
+-- restrictions/features which apply to the user joining the connection via the
+-- sharing profile.
+--
+
+CREATE TABLE guacamole_sharing_profile (
+
+  sharing_profile_id    serial       NOT NULL,
+  sharing_profile_name  varchar(128) NOT NULL,
+  primary_connection_id integer      NOT NULL,
+
+  PRIMARY KEY (sharing_profile_id),
+
+  CONSTRAINT sharing_profile_name_primary
+    UNIQUE (sharing_profile_name, primary_connection_id),
+
+  CONSTRAINT guacamole_sharing_profile_ibfk_1
+    FOREIGN KEY (primary_connection_id)
+    REFERENCES guacamole_connection (connection_id)
+    ON DELETE CASCADE
+
+);
+
+CREATE INDEX guacamole_sharing_profile_primary_connection_id
+    ON guacamole_sharing_profile(primary_connection_id);
+
+--
+-- Table of connection parameters. Each parameter is simply a name/value pair
+-- associated with a connection.
+--
+
+CREATE TABLE guacamole_connection_parameter (
+
+  connection_id   integer       NOT NULL,
+  parameter_name  varchar(128)  NOT NULL,
+  parameter_value varchar(4096) NOT NULL,
+
+  PRIMARY KEY (connection_id,parameter_name),
+
+  CONSTRAINT guacamole_connection_parameter_ibfk_1
+    FOREIGN KEY (connection_id)
+    REFERENCES guacamole_connection (connection_id) ON DELETE CASCADE
+
+);
+
+CREATE INDEX guacamole_connection_parameter_connection_id
+    ON guacamole_connection_parameter(connection_id);
+
+--
+-- Table of sharing profile parameters. Each parameter is simply
+-- name/value pair associated with a sharing profile. These parameters dictate
+-- the restrictions/features which apply to the user joining the associated
+-- connection via the sharing profile.
+--
+
+CREATE TABLE guacamole_sharing_profile_parameter (
+
+  sharing_profile_id integer       NOT NULL,
+  parameter_name     varchar(128)  NOT NULL,
+  parameter_value    varchar(4096) NOT NULL,
+
+  PRIMARY KEY (sharing_profile_id, parameter_name),
+
+  CONSTRAINT guacamole_sharing_profile_parameter_ibfk_1
+    FOREIGN KEY (sharing_profile_id)
+    REFERENCES guacamole_sharing_profile (sharing_profile_id) ON DELETE CASCADE
+
+);
+
+CREATE INDEX guacamole_sharing_profile_parameter_sharing_profile_id
+    ON guacamole_sharing_profile_parameter(sharing_profile_id);
+
+--
+-- Table of arbitrary user attributes. Each attribute is simply a name/value
+-- pair associated with a user. Arbitrary attributes are defined by other
+-- extensions. Attributes defined by this extension will be mapped to
+-- properly-typed columns of a specific table.
+--
+
+CREATE TABLE guacamole_user_attribute (
+
+  user_id         integer       NOT NULL,
+  attribute_name  varchar(128)  NOT NULL,
+  attribute_value varchar(4096) NOT NULL,
+
+  PRIMARY KEY (user_id, attribute_name),
+
+  CONSTRAINT guacamole_user_attribute_ibfk_1
+    FOREIGN KEY (user_id)
+    REFERENCES guacamole_user (user_id) ON DELETE CASCADE
+
+);
+
+CREATE INDEX guacamole_user_attribute_user_id
+    ON guacamole_user_attribute(user_id);
+
+--
+-- Table of arbitrary user group attributes. Each attribute is simply a
+-- name/value pair associated with a user group. Arbitrary attributes are
+-- defined by other extensions. Attributes defined by this extension will be
+-- mapped to properly-typed columns of a specific table.
+--
+
+CREATE TABLE guacamole_user_group_attribute (
+
+  user_group_id   integer       NOT NULL,
+  attribute_name  varchar(128)  NOT NULL,
+  attribute_value varchar(4096) NOT NULL,
+
+  PRIMARY KEY (user_group_id, attribute_name),
+
+  CONSTRAINT guacamole_user_group_attribute_ibfk_1
+    FOREIGN KEY (user_group_id)
+    REFERENCES guacamole_user_group (user_group_id) ON DELETE CASCADE
+
+);
+
+CREATE INDEX guacamole_user_group_attribute_user_group_id
+    ON guacamole_user_group_attribute(user_group_id);
+
+--
+-- Table of arbitrary connection attributes. Each attribute is simply a
+-- name/value pair associated with a connection. Arbitrary attributes are
+-- defined by other extensions. Attributes defined by this extension will be
+-- mapped to properly-typed columns of a specific table.
+--
+
+CREATE TABLE guacamole_connection_attribute (
+
+  connection_id   integer       NOT NULL,
+  attribute_name  varchar(128)  NOT NULL,
+  attribute_value varchar(4096) NOT NULL,
+
+  PRIMARY KEY (connection_id, attribute_name),
+
+  CONSTRAINT guacamole_connection_attribute_ibfk_1
+    FOREIGN KEY (connection_id)
+    REFERENCES guacamole_connection (connection_id) ON DELETE CASCADE
+
+);
+
+CREATE INDEX guacamole_connection_attribute_connection_id
+    ON guacamole_connection_attribute(connection_id);
+
+--
+-- Table of arbitrary connection group attributes. Each attribute is simply a
+-- name/value pair associated with a connection group. Arbitrary attributes are
+-- defined by other extensions. Attributes defined by this extension will be
+-- mapped to properly-typed columns of a specific table.
+--
+
+CREATE TABLE guacamole_connection_group_attribute (
+
+  connection_group_id integer       NOT NULL,
+  attribute_name      varchar(128)  NOT NULL,
+  attribute_value     varchar(4096) NOT NULL,
+
+  PRIMARY KEY (connection_group_id, attribute_name),
+
+  CONSTRAINT guacamole_connection_group_attribute_ibfk_1
+    FOREIGN KEY (connection_group_id)
+    REFERENCES guacamole_connection_group (connection_group_id) ON DELETE CASCADE
+
+);
+
+CREATE INDEX guacamole_connection_group_attribute_connection_group_id
+    ON guacamole_connection_group_attribute(connection_group_id);
+
+--
+-- Table of arbitrary sharing profile attributes. Each attribute is simply a
+-- name/value pair associated with a sharing profile. Arbitrary attributes are
+-- defined by other extensions. Attributes defined by this extension will be
+-- mapped to properly-typed columns of a specific table.
+--
+
+CREATE TABLE guacamole_sharing_profile_attribute (
+
+  sharing_profile_id integer       NOT NULL,
+  attribute_name     varchar(128)  NOT NULL,
+  attribute_value    varchar(4096) NOT NULL,
+
+  PRIMARY KEY (sharing_profile_id, attribute_name),
+
+  CONSTRAINT guacamole_sharing_profile_attribute_ibfk_1
+    FOREIGN KEY (sharing_profile_id)
+    REFERENCES guacamole_sharing_profile (sharing_profile_id) ON DELETE CASCADE
+
+);
+
+CREATE INDEX guacamole_sharing_profile_attribute_sharing_profile_id
+    ON guacamole_sharing_profile_attribute(sharing_profile_id);
+
+--
+-- Table of connection permissions. Each connection permission grants a user or
+-- user group specific access to a connection.
+--
+
+CREATE TABLE guacamole_connection_permission (
+
+  entity_id     integer NOT NULL,
+  connection_id integer NOT NULL,
+  permission    guacamole_object_permission_type NOT NULL,
+
+  PRIMARY KEY (entity_id, connection_id, permission),
+
+  CONSTRAINT guacamole_connection_permission_ibfk_1
+    FOREIGN KEY (connection_id)
+    REFERENCES guacamole_connection (connection_id) ON DELETE CASCADE,
+
+  CONSTRAINT guacamole_connection_permission_entity
+    FOREIGN KEY (entity_id)
+    REFERENCES guacamole_entity (entity_id) ON DELETE CASCADE
+
+);
+
+CREATE INDEX guacamole_connection_permission_connection_id
+    ON guacamole_connection_permission(connection_id);
+
+CREATE INDEX guacamole_connection_permission_entity_id
+    ON guacamole_connection_permission(entity_id);
+
+--
+-- Table of connection group permissions. Each group permission grants a user
+-- or user group specific access to a connection group.
+--
+
+CREATE TABLE guacamole_connection_group_permission (
+
+  entity_id           integer NOT NULL,
+  connection_group_id integer NOT NULL,
+  permission          guacamole_object_permission_type NOT NULL,
+
+  PRIMARY KEY (entity_id, connection_group_id, permission),
+
+  CONSTRAINT guacamole_connection_group_permission_ibfk_1
+    FOREIGN KEY (connection_group_id)
+    REFERENCES guacamole_connection_group (connection_group_id) ON DELETE CASCADE,
+
+  CONSTRAINT guacamole_connection_group_permission_entity
+    FOREIGN KEY (entity_id)
+    REFERENCES guacamole_entity (entity_id) ON DELETE CASCADE
+
+);
+
+CREATE INDEX guacamole_connection_group_permission_connection_group_id
+    ON guacamole_connection_group_permission(connection_group_id);
+
+CREATE INDEX guacamole_connection_group_permission_entity_id
+    ON guacamole_connection_group_permission(entity_id);
+
+--
+-- Table of sharing profile permissions. Each sharing profile permission grants
+-- a user or user group specific access to a sharing profile.
+--
+
+CREATE TABLE guacamole_sharing_profile_permission (
+
+  entity_id          integer NOT NULL,
+  sharing_profile_id integer NOT NULL,
+  permission         guacamole_object_permission_type NOT NULL,
+
+  PRIMARY KEY (entity_id, sharing_profile_id, permission),
+
+  CONSTRAINT guacamole_sharing_profile_permission_ibfk_1
+    FOREIGN KEY (sharing_profile_id)
+    REFERENCES guacamole_sharing_profile (sharing_profile_id) ON DELETE CASCADE,
+
+  CONSTRAINT guacamole_sharing_profile_permission_entity
+    FOREIGN KEY (entity_id)
+    REFERENCES guacamole_entity (entity_id) ON DELETE CASCADE
+
+);
+
+CREATE INDEX guacamole_sharing_profile_permission_sharing_profile_id
+    ON guacamole_sharing_profile_permission(sharing_profile_id);
+
+CREATE INDEX guacamole_sharing_profile_permission_entity_id
+    ON guacamole_sharing_profile_permission(entity_id);
+
+--
+-- Table of system permissions. Each system permission grants a user or user
+-- group a system-level privilege of some kind.
+--
+
+CREATE TABLE guacamole_system_permission (
+
+  entity_id  integer NOT NULL,
+  permission guacamole_system_permission_type NOT NULL,
+
+  PRIMARY KEY (entity_id, permission),
+
+  CONSTRAINT guacamole_system_permission_entity
+    FOREIGN KEY (entity_id)
+    REFERENCES guacamole_entity (entity_id) ON DELETE CASCADE
+
+);
+
+CREATE INDEX guacamole_system_permission_entity_id
+    ON guacamole_system_permission(entity_id);
+
+--
+-- Table of user permissions. Each user permission grants a user or user group
+-- access to another user (the "affected" user) for a specific type of
+-- operation.
+--
+
+CREATE TABLE guacamole_user_permission (
+
+  entity_id        integer NOT NULL,
+  affected_user_id integer NOT NULL,
+  permission       guacamole_object_permission_type NOT NULL,
+
+  PRIMARY KEY (entity_id, affected_user_id, permission),
+
+  CONSTRAINT guacamole_user_permission_ibfk_1
+    FOREIGN KEY (affected_user_id)
+    REFERENCES guacamole_user (user_id) ON DELETE CASCADE,
+
+  CONSTRAINT guacamole_user_permission_entity
+    FOREIGN KEY (entity_id)
+    REFERENCES guacamole_entity (entity_id) ON DELETE CASCADE
+
+);
+
+CREATE INDEX guacamole_user_permission_affected_user_id
+    ON guacamole_user_permission(affected_user_id);
+
+CREATE INDEX guacamole_user_permission_entity_id
+    ON guacamole_user_permission(entity_id);
+
+--
+-- Table of user group permissions. Each user group permission grants a user
+-- or user group access to a another user group (the "affected" user group) for
+-- a specific type of operation.
+--
+
+CREATE TABLE guacamole_user_group_permission (
+
+  entity_id              integer NOT NULL,
+  affected_user_group_id integer NOT NULL,
+  permission             guacamole_object_permission_type NOT NULL,
+
+  PRIMARY KEY (entity_id, affected_user_group_id, permission),
+
+  CONSTRAINT guacamole_user_group_permission_affected_user_group
+    FOREIGN KEY (affected_user_group_id)
+    REFERENCES guacamole_user_group (user_group_id) ON DELETE CASCADE,
+
+  CONSTRAINT guacamole_user_group_permission_entity
+    FOREIGN KEY (entity_id)
+    REFERENCES guacamole_entity (entity_id) ON DELETE CASCADE
+
+);
+
+CREATE INDEX guacamole_user_group_permission_affected_user_group_id
+    ON guacamole_user_group_permission(affected_user_group_id);
+
+CREATE INDEX guacamole_user_group_permission_entity_id
+    ON guacamole_user_group_permission(entity_id);
+
+--
+-- Table of connection history records. Each record defines a specific user's
+-- session, including the connection used, the start time, and the end time
+-- (if any).
+--
+
+CREATE TABLE guacamole_connection_history (
+
+  history_id           serial       NOT NULL,
+  user_id              integer      DEFAULT NULL,
+  username             varchar(128) NOT NULL,
+  remote_host          varchar(256) DEFAULT NULL,
+  connection_id        integer      DEFAULT NULL,
+  connection_name      varchar(128) NOT NULL,
+  sharing_profile_id   integer      DEFAULT NULL,
+  sharing_profile_name varchar(128) DEFAULT NULL,
+  start_date           timestamptz  NOT NULL,
+  end_date             timestamptz  DEFAULT NULL,
+
+  PRIMARY KEY (history_id),
+
+  CONSTRAINT guacamole_connection_history_ibfk_1
+    FOREIGN KEY (user_id)
+    REFERENCES guacamole_user (user_id) ON DELETE SET NULL,
+
+  CONSTRAINT guacamole_connection_history_ibfk_2
+    FOREIGN KEY (connection_id)
+    REFERENCES guacamole_connection (connection_id) ON DELETE SET NULL,
+
+  CONSTRAINT guacamole_connection_history_ibfk_3
+    FOREIGN KEY (sharing_profile_id)
+    REFERENCES guacamole_sharing_profile (sharing_profile_id) ON DELETE SET NULL
+
+);
+
+CREATE INDEX guacamole_connection_history_user_id
+    ON guacamole_connection_history(user_id);
+
+CREATE INDEX guacamole_connection_history_connection_id
+    ON guacamole_connection_history(connection_id);
+
+CREATE INDEX guacamole_connection_history_sharing_profile_id
+    ON guacamole_connection_history(sharing_profile_id);
+
+CREATE INDEX guacamole_connection_history_start_date
+    ON guacamole_connection_history(start_date);
+
+CREATE INDEX guacamole_connection_history_end_date
+    ON guacamole_connection_history(end_date);
+
+CREATE INDEX guacamole_connection_history_connection_id_start_date
+    ON guacamole_connection_history(connection_id, start_date);
+
+--
+-- User login/logout history
+--
+
+CREATE TABLE guacamole_user_history (
+
+  history_id           serial       NOT NULL,
+  user_id              integer      DEFAULT NULL,
+  username             varchar(128) NOT NULL,
+  remote_host          varchar(256) DEFAULT NULL,
+  start_date           timestamptz  NOT NULL,
+  end_date             timestamptz  DEFAULT NULL,
+
+  PRIMARY KEY (history_id),
+
+  CONSTRAINT guacamole_user_history_ibfk_1
+    FOREIGN KEY (user_id)
+    REFERENCES guacamole_user (user_id) ON DELETE SET NULL
+
+);
+
+CREATE INDEX guacamole_user_history_user_id
+    ON guacamole_user_history(user_id);
+
+CREATE INDEX guacamole_user_history_start_date
+    ON guacamole_user_history(start_date);
+
+CREATE INDEX guacamole_user_history_end_date
+    ON guacamole_user_history(end_date);
+
+CREATE INDEX guacamole_user_history_user_id_start_date
+    ON guacamole_user_history(user_id, start_date);
+
+--
+-- User password history
+--
+
+CREATE TABLE guacamole_user_password_history (
+
+  password_history_id serial  NOT NULL,
+  user_id             integer NOT NULL,
+
+  -- Salted password
+  password_hash bytea        NOT NULL,
+  password_salt bytea,
+  password_date timestamptz  NOT NULL,
+
+  PRIMARY KEY (password_history_id),
+
+  CONSTRAINT guacamole_user_password_history_ibfk_1
+    FOREIGN KEY (user_id)
+    REFERENCES guacamole_user (user_id) ON DELETE CASCADE
+
+);
+
+CREATE INDEX guacamole_user_password_history_user_id
+    ON guacamole_user_password_history(user_id);
+

--- a/platform/guacamole/chart/templates/jdbc-schema-seed-job.yaml
+++ b/platform/guacamole/chart/templates/jdbc-schema-seed-job.yaml
@@ -5,20 +5,33 @@ The guacamole-auth-sso-openid extension authenticates SSO users but has no
 permission store, so every SSO user lands with no connections and NO admin
 (the founder-witnessed #3374 gap; blueprint.yaml's `rolesFromGroup:
 sovereign-admins: admin` intent was unimplemented). This Job wires the
-bundled JDBC (postgresql) permission store:
+bundled JDBC (postgresql) permission store with a SINGLE container (CNPG
+postgres image — has psql) that:
+  a. applies 001-create-schema.sql ONCE (idempotent guard: skip if the
+     `guacamole_entity` table already exists),
+  b. creates a `<adminGroup>` USER_GROUP entity holding the ADMINISTER
+     (+ CREATE_*) system permissions, so any SSO user whose `groups`
+     claim contains <adminGroup> inherits guacamole admin. We DELIBERATELY
+     do NOT seed the default guacadmin/guacadmin password account from
+     002-create-admin-user.sql — admin is group-driven via SSO only.
 
-  1. An initContainer running the guacamole webapp image copies the bundled
-     JDBC schema (/opt/guacamole/postgresql/schema/*.sql) into a shared
-     emptyDir — the schema lives in the image, not this chart.
-  2. The main container (CNPG postgres image — has psql) connects to the
-     guacamole CNPG cluster and:
-       a. applies 001-create-schema.sql ONCE (idempotent guard: skip if the
-          `guacamole_entity` table already exists),
-       b. creates a `<adminGroup>` USER_GROUP entity holding the ADMINISTER
-          (+ CREATE_*) system permissions, so any SSO user whose `groups`
-          claim contains <adminGroup> inherits guacamole admin. We DELIBERATELY
-          do NOT seed the default guacadmin/guacadmin password account from
-          002-create-admin-user.sql — admin is group-driven via SSO only.
+#3374 admin-tier (2026-06-14) — the schema SQL is now VENDORED into the chart
+(files/postgresql/001-create-schema.sql, the verbatim Apache Guacamole 1.5.5
+schema, loaded into the scripts ConfigMap via .Files.Get) instead of being
+copied at runtime from the guacamole webapp image by an initContainer. WHY:
+the kyverno `harbor-proxy-pull` Enforce policy uses an `anyPattern` that
+requires ONE allowed glob to match BOTH the initContainers AND the containers
+of a Job. The guacamole webapp image is `ghcr.io/openova-io/...` (matches the
+native-push glob `STAR/openova-io/STAR` only; the private image 404s through
+the Harbor proxy-ghcr cache — verified live on hw133) while the CNPG psql
+image is `harbor.openova.io/proxy-ghcr/...` (matches the proxy glob
+`STAR/proxy-STAR/STAR` only). No single glob matches both, so the
+mixed-registry initContainer+container Job was DENIED (rolled bp-guacamole
+0.2.10 back to 0.2.8 on hw133, so the permission store never installed and SSO
+users had no admin Settings menu). Vendoring the static, version-pinned schema
+removes the second registry entirely so the Job is single-container (proxy
+glob) and passes. The vendored SQL is pinned to
+`.Values.guacamole.webapp.image.tag` (1.5.5); bump both together on upgrade.
 
 Combined with the Deployment's POSTGRESQL_AUTO_CREATE_ACCOUNTS=true +
 OPENID_GROUPS_CLAIM_TYPE=groups, an `emrah.baysal`-in-sovereign-admins SSO
@@ -39,7 +52,6 @@ postgresql.cnpg.io CRD absent.
 {{- $appSecret := $db.appSecretName | default (printf "%s-app" $name) -}}
 {{- $adminGroup := $db.adminGroup | default "sovereign-admins" -}}
 {{- $pgImage := printf "%s:%s" ($cl.imageName | default "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql") ($cl.pgVersion | default "16") -}}
-{{- $guacImage := include "bp-guacamole.webappImage" . -}}
 {{- $sj := $db.seedJob | default dict -}}
 {{- $jobName := printf "%s-jdbc-seed" (include "bp-guacamole.fullname" .) | trunc 63 | trimSuffix "-" -}}
 ---
@@ -123,6 +135,13 @@ data:
     SQL
     echo "[jdbc-seed] admin USER_GROUP '${ADMIN_GROUP}' ensured with ADMINISTER"
     echo "[jdbc-seed] done."
+  # Verbatim Apache Guacamole 1.5.5 PostgreSQL schema, vendored into the chart
+  # (files/postgresql/001-create-schema.sql) and pinned to
+  # .Values.guacamole.webapp.image.tag. Loaded here so the seed container needs
+  # ONLY the CNPG postgres image (no mixed-registry initContainer → kyverno
+  # harbor-proxy-pull anyPattern passes; see the header note).
+  001-create-schema.sql: |
+{{ .Files.Get "files/postgresql/001-create-schema.sql" | indent 4 }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -132,6 +151,11 @@ metadata:
   labels:
     {{- include "bp-guacamole.labels" . | nindent 4 }}
     catalyst.openova.io/component: jdbc-seed
+    # kyverno `flux-managed` Enforce DENIES a Job without this label (helm
+    # hook Jobs are helm-controller-created, no HR ownerReference). Without it
+    # the post-upgrade seed fails and the HR rolls back — the exact landmine
+    # that stalled bp-guacamole 0.2.10 on hw133 (#3374; #3434/#3296 class).
+    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "10"
@@ -158,30 +182,11 @@ spec:
         fsGroup: 26
         seccompProfile:
           type: RuntimeDefault
-      initContainers:
-        # Copy the bundled JDBC schema out of the guacamole image so the
-        # postgres container can apply it. The schema is image-versioned —
-        # never hand-copied into this chart.
-        - name: copy-schema
-          image: {{ $guacImage | quote }}
-          imagePullPolicy: {{ .Values.guacamole.webapp.image.pullPolicy | default "IfNotPresent" }}
-          command:
-            - /bin/sh
-            - -c
-            - |
-              set -eu
-              cp /opt/guacamole/postgresql/schema/001-create-schema.sql /schema/
-              echo "copied JDBC schema"
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            capabilities:
-              drop: ["ALL"]
-          volumeMounts:
-            - name: schema
-              mountPath: /schema
       containers:
+        # SINGLE container (CNPG postgres image — has psql). The schema SQL is
+        # vendored into the scripts ConfigMap (.Files.Get) and mounted at
+        # /schema, so there is no second-registry initContainer for kyverno's
+        # harbor-proxy-pull anyPattern to reject (see the header note).
         - name: jdbc-seed
           image: {{ $pgImage | quote }}
           imagePullPolicy: IfNotPresent
@@ -195,7 +200,9 @@ spec:
           volumeMounts:
             - name: scripts
               mountPath: /scripts
-            - name: schema
+            # Same ConfigMap re-mounted read-only at /schema — seed.sh reads
+            # /schema/001-create-schema.sql (the vendored schema key).
+            - name: scripts
               mountPath: /schema
             - name: cnpg
               mountPath: /cnpg
@@ -209,9 +216,6 @@ spec:
           configMap:
             name: {{ $jobName }}-scripts
             defaultMode: 0555
-        - name: schema
-          emptyDir:
-            sizeLimit: 4Mi
         - name: cnpg
           secret:
             secretName: {{ $appSecret | quote }}


### PR DESCRIPTION
## Problem (live on hw133)
bp-guacamole **0.2.10** HR is kyverno-stalled (rolled back to **0.2.8**), so the JDBC permission store never installs and SSO users have no admin Settings menu. The post-upgrade `jdbc-schema-seed` Job is denied by TWO Enforce policies:
- `flux-managed` — the hook Job carried `managed-by=Helm` (the helper), not `flux`.
- `harbor-proxy-pull` — its `anyPattern` needs ONE glob to match BOTH the initContainers AND containers. The schema-copy initContainer is `ghcr.io/openova-io/...` (native-push glob only; the **private** image 404s through Harbor proxy-ghcr — verified live) while the psql container is `proxy-ghcr/cnpg...` (proxy glob only). No single glob matches both → denied.

## Fix
1. Stamp `app.kubernetes.io/managed-by: flux` on the Job (same class as openbao #3434, gitea/harbor #3296→#3297).
2. **Vendor** the Apache Guacamole 1.5.5 schema into the chart (`files/postgresql/001-create-schema.sql`, verbatim from the live 1.5.5 image, sha `ae5ca0f3…`) loaded via `.Files.Get`, and **drop the webapp-image initContainer** → the Job is **single-container** (CNPG psql, proxy glob), no second registry for the anyPattern to reject. The vendored SQL is pinned to `guacamole.webapp.image.tag` (1.5.5).

Seed logic unchanged (idempotent schema apply + `sovereign-admins` USER_GROUP holding ADMINISTER). Chart **0.2.10 → 0.2.11** + `blueprint.yaml` + `52-bp-guacamole.yaml` slot pin in lockstep.

## Validation
`helm template` → Job has 0 initContainers, 1 container (`harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16`), `managed-by=flux`; ConfigMap carries the 736-line schema with `guacamole_entity`; all chart render tests pass.

## What the walker should see after reconcile
`guacamole.hw133.omani.works` user dropdown shows **Settings → Users** (admin); `#/settings/users` renders (sovereign-admins → guacamole ADMIN).

Refs #3374 #3455