### PR TITLE
fix(catalyst): managed-by:flux on gitea repo-bootstrap hook Job so kyverno admits it (#3454)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1019,7 +1019,8 @@ spec:
       # catalog-seed shareable/contextSchema (bp-postgres, bp-valkey).
             # 1.4.598 — #3374: CATALYST_OPENBAO_ADDR onto catalyst-api (openbao bare-URL SSO shim).
             # 1.4.612 — #3454: pre-cutover local-Gitea openova/openova@sme-tenants repo bootstrap (SME gitops chain).
-      version: 1.4.612
+            # 1.4.613 — #3454: add managed-by:flux on the repo-bootstrap hook Job (kyverno flux-managed Enforce).
+      version: 1.4.613
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2652,7 +2652,13 @@ name: bp-catalyst-platform
 # bootstrap-job.yaml) seeds the org/repo/sme-tenants branch via the Gitea API so
 # the chain is live from first convergence; cutover Step 01 mirrors full content
 # later (idempotent). Gated on global.sovereignFQDN + ingress.marketplace.enabled.
-version: 1.4.612
+# 1.4.613 (#3454, 2026-06-14): the 1.4.612 hook Job was denied by the kyverno
+# `flux-managed` Enforce policy on converged Sovereigns (release ns catalyst-system
+# is NOT namespace-excluded). Add `app.kubernetes.io/managed-by: flux` to the Job +
+# SA + Role + RoleBinding (canonical idiom — gitea sso-configure-oauth-job, openbao
+# init-job). Verified via server-side dry-run against live hw133 (all kyverno
+# Enforce policies pass).
+version: 1.4.613
 # 1.4.597 — #3373 (2026-06-13) — coupling fix (a) placement-as-data:
 # templates/httproute.yaml backendRefs honor new
 # ingress.gateway.backendServiceApi / backendServiceUi overrides. When

--- a/products/catalyst/chart/templates/sme-services/gitea-tenants-repo-bootstrap-job.yaml
+++ b/products/catalyst/chart/templates/sme-services/gitea-tenants-repo-bootstrap-job.yaml
@@ -121,6 +121,13 @@ metadata:
   labels:
     catalyst.openova.io/blueprint: bp-catalyst-platform
     catalyst.openova.io/component: gitea-tenants-repo-bootstrap
+    # kyverno `flux-managed` Enforce policy (converged Sovereigns) blocks
+    # any Job NOT carrying this label or a HelmRelease ownerReference. Hook
+    # Jobs are created by Helm (not Flux-owned) so they MUST self-declare.
+    # Canonical idiom — see platform/gitea sso-configure-oauth-job.yaml,
+    # platform/openbao init-job.yaml. Release ns (catalyst-system) is NOT
+    # in the policy's namespace-exclude list, so this is load-bearing.
+    app.kubernetes.io/managed-by: flux
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     # Weight 12: AFTER the catalyst-gitea-token mint Job (weight 10) so the
@@ -137,6 +144,7 @@ metadata:
   namespace: gitea
   labels:
     catalyst.openova.io/blueprint: bp-catalyst-platform
+    app.kubernetes.io/managed-by: flux
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "12"
@@ -154,6 +162,7 @@ metadata:
   namespace: gitea
   labels:
     catalyst.openova.io/blueprint: bp-catalyst-platform
+    app.kubernetes.io/managed-by: flux
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "12"
@@ -175,6 +184,9 @@ metadata:
   labels:
     catalyst.openova.io/blueprint: bp-catalyst-platform
     catalyst.openova.io/component: gitea-tenants-repo-bootstrap
+    # Required by the kyverno `flux-managed` Enforce policy on converged
+    # Sovereigns (the release ns catalyst-system is NOT namespace-excluded).
+    app.kubernetes.io/managed-by: flux
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "12"


### PR DESCRIPTION
## Problem
Follow-up to #3457 (merged as `bp-catalyst-platform@1.4.612`). On converged hw133, the new pre-upgrade hook Job `gitea-tenants-repo-bootstrap` was **denied by the kyverno `flux-managed` Enforce policy**:
```
HelmRelease bp-catalyst-platform ... pre-upgrade hooks failed:
Hook pre-upgrade .../gitea-tenants-repo-bootstrap-job.yaml failed:
admission webhook "validate.kyverno.svc-fail" denied the request:
flux-managed: Job/catalyst-gitea-tenants-repo-bootstrap is not Flux-managed.
Add label `app.kubernetes.io/managed-by: flux` OR attach an ownerReference
to a HelmRelease / Kustomization.
```
The HR rolled back, so the repo-bootstrap never ran.

## Root cause
The `flux-managed` cluster policy matches `Job` (among others) and **excludes** a fixed namespace list (`catalyst`, `sme`, `gitea`, `flux-system`, ...) — but **NOT the release namespace `catalyst-system`**. Helm hook Jobs are created by Helm and carry no HelmRelease ownerReference, so on a converged Enforce env they must **self-declare** `app.kubernetes.io/managed-by: flux`. This is the established idiom on converged Sovereigns — `platform/gitea/chart/templates/sso-configure-oauth-job.yaml`, `platform/openbao/chart/templates/init-job.yaml`, `platform/harbor/chart/templates/database-secret-sync-job.yaml` all carry it.

## Fix
Add `app.kubernetes.io/managed-by: flux` to the repo-bootstrap **Job + ServiceAccount + Role + RoleBinding**. Pin bumped to `1.4.613` in lockstep.

## Validation
- `helm lint`: **0 charts failed**.
- **Server-side dry-run against live hw133** (`kubectl apply --dry-run=server`): the Job + Role + RoleBinding + SA all validate with **no kyverno denial** — i.e. they pass ALL Enforce policies (flux-managed, image-tag-pinned, harbor-proxy-pull, runasnonroot-readonlyrootfs, resource-limits, resource-requests, secret-not-in-env).
- `pin-sync-audit`: bootstrap-kit pin `13-bp-catalyst-platform.yaml` = `1.4.613` (verified PASS locally).

## Pipeline / acceptance
Chart-only -> CI publishes `1.4.613` -> hw133's `openova` GitRepository (tracking github main) picks up the new pin -> the `bp-catalyst-platform` HR upgrades, the pre-upgrade hook Job now runs (admitted by kyverno), seeds `openova/openova`@`sme-tenants`, and the `openova-sme-tenants` Flux GitRepository flips `Ready=True`.

Refs #3376
Refs #3378
Refs #3454

🤖 Generated with [Claude Code](https://claude.com/claude-code)
