### PR TITLE
fix(bp-keycloak): allow /sso/landing redirect_uri on openbao client — bare-URL SSO (#3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -166,7 +166,7 @@ spec:
       # auto-links to the pre-seeded user by email (trustEmail=true flow).
       # 1.4.25: hook Job managed-by:flux (kyverno Enforce, #3297 class).
       # 1.4.26: config-cli right-sized 500m->100m (requests-wedge on hw130).
-      version: 1.4.27
+      version: 1.4.28
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.27
+  version: 1.4.28
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -261,7 +261,17 @@ name: bp-keycloak
 # authenticates silently via the sovereign realm's catalyst-pin IDR. The
 # master console remains reachable at its full path (break-glass untouched).
 # Gated on gateway.bareURLAdminRedirect.enabled (default true).
-version: 1.4.27
+# 1.4.28 (#3374, 2026-06-14): add https://bao.<fqdn>/sso/landing to the
+# `openbao` Tier-1 client redirectUris. The bp-openbao bare-URL zero-click
+# fix routes the bare paths to an on-origin landing page at /sso/landing
+# that runs the OIDC round-trip as a top-level window (kills the popup-only
+# postMessage error). Its auth_url call sets redirect_uri=<landing>, so
+# Keycloak must allow it — without this the authorize request 400s "Invalid
+# parameter: redirect_uri" (measured live hw133 2026-06-14). keycloak-config-
+# cli reconciles the realm on every post-upgrade Job, so this lands on both
+# fresh provs AND the existing live client. (The OpenBao OIDC role's
+# allowed_redirect_uris already carries it via bp-openbao 1.2.35+.)
+version: 1.4.28
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -673,6 +673,7 @@ data:
           "secret": {{ include "bp-keycloak.tier1ClientSecret" (dict "ctx" . "clientId" "openbao") | quote }},
           "redirectUris": [
             "https://bao.{{ .Values.sovereignFQDN }}/ui/vault/auth/oidc/oidc/callback",
+            "https://bao.{{ .Values.sovereignFQDN }}/sso/landing",
             "http://localhost:8250/oidc/callback"
           ],
           "webOrigins": [


### PR DESCRIPTION
## Keycloak rejected the openbao landing redirect_uri

The bp-openbao bare-URL zero-click fix (#3452/#3460) routes bare paths to an on-origin landing page at `https://bao.<fqdn>/sso/landing` that runs the OIDC round-trip as a **top-level window** (killing OpenBao's popup-only `postMessage` callback error). Verified live on hw133: bare `/ui/` → 302 `/sso/landing` → the page calls `auth_url` with `redirect_uri=<landing>` → Keycloak **400 "Invalid parameter: redirect_uri"**.

The openbao Tier-1 client's redirectUris (sovereign-realm import, `configmap-sovereign-realm.yaml`) only carried the Vault popup callback + the CLI loopback — not `/sso/landing`.

## Fix
Added `https://bao.<fqdn>/sso/landing` to the `openbao` client redirectUris in the realm import. `keycloak-config-cli` reconciles the realm **declaratively on every post-install/upgrade/rollback Job** (idempotent override), so this lands on **both** fresh provs AND the existing live openbao client when the chart rolls. The OpenBao OIDC role's `allowed_redirect_uris` already carries the landing URI (bp-openbao 1.2.35+) — this is the Keycloak-side half of the same allowlist.

## Validation
- Rendered openbao client redirectUris = `[vault-callback, /sso/landing, cli-loopback]`; realm JSON parses (10 clients).
- `g117-5-tier1-sso-clients.sh` PASS; helm lint clean.
- Chart `1.4.27 → 1.4.28`; `blueprint.yaml` + slot `09` lockstep.

## After this lands
Keycloak accepts the `/sso/landing` redirect → the landing page completes the OIDC exchange → bare `https://bao.<fqdn>/ui/` lands on the OpenBao admin Secrets-Engines screen signed in. This is the **5th and final** piece of the openbao bare-URL chain (#3452 landing page, #3456 test/publish unblock, #3460 nginx image, this = KC allowlist).

Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)