### PR TITLE
fix(catalyst): secretRef on openova-sme-tenants GitRepo + authed probe (REQUIRE_SIGNIN_VIEW → anon clone 401) (#3454)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1020,7 +1020,8 @@ spec:
             # 1.4.598 — #3374: CATALYST_OPENBAO_ADDR onto catalyst-api (openbao bare-URL SSO shim).
             # 1.4.612 — #3454: pre-cutover local-Gitea openova/openova@sme-tenants repo bootstrap (SME gitops chain).
             # 1.4.613 — #3454: add managed-by:flux on the repo-bootstrap hook Job (kyverno flux-managed Enforce).
-      version: 1.4.614
+            # 1.4.615 — #3454: secretRef on openova-sme-tenants GitRepo + authed probe (REQUIRE_SIGNIN_VIEW=true → anon clone 401).
+      version: 1.4.615
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2658,7 +2658,17 @@ name: bp-catalyst-platform
 # SA + Role + RoleBinding (canonical idiom — gitea sso-configure-oauth-job, openbao
 # init-job). Verified via server-side dry-run against live hw133 (all kyverno
 # Enforce policies pass).
-version: 1.4.614
+# 1.4.615 (#3454, 2026-06-14): the DEEPER half of the SME-tenant gitops fix.
+# bp-gitea sets service.REQUIRE_SIGNIN_VIEW=true, so ANONYMOUS git clone of
+# even a PUBLIC repo returns 401 (proven live on hw133: a fresh public repo's
+# info/refs?service=git-upload-pack = 401 anon / 200 authed). The
+# openova-sme-tenants GitRepository had NO secretRef -> "authentication
+# required" forever, repo-present-or-not. Add a Flux basic-auth Secret
+# (sme-tenants-gitrepo-auth-secret.yaml, sourced from the catalyst-gitea-token
+# PAT) + wire smeTenants.gitRepository.secretRef. Also fix the repo-bootstrap
+# hook's /api/v1/version probe to authenticate (anon /version = 403 under
+# REQUIRE_SIGNIN_VIEW burned all 168 iterations on hw133).
+version: 1.4.615
 # 1.4.597 — #3373 (2026-06-13) — coupling fix (a) placement-as-data:
 # templates/httproute.yaml backendRefs honor new
 # ingress.gateway.backendServiceApi / backendServiceUi overrides. When

--- a/products/catalyst/chart/templates/sme-services/gitea-tenants-repo-bootstrap-job.yaml
+++ b/products/catalyst/chart/templates/sme-services/gitea-tenants-repo-bootstrap-job.yaml
@@ -226,19 +226,8 @@ spec:
               set -eu
               API="${GITEA_URL}/api/v1"
 
-              # Step 1: wait for the Gitea API to be reachable. Same budget
-              # knob the token-mint Job uses (default 168 x 5s = 14m) —
-              # covers the autoscaler-cold-start worst case on a fresh prov.
-              for i in $(seq 1 "$ITERATIONS"); do
-                if curl -sSf -o /dev/null --max-time 3 "${API}/version"; then
-                  echo "[repo-bootstrap] gitea api reachable"
-                  break
-                fi
-                echo "[repo-bootstrap] waiting for gitea api ($i/$ITERATIONS)"
-                sleep "$INTERVAL"
-              done
-
-              # Step 2: read admin creds from gitea/gitea-admin-secret.
+              # Step 1: read admin creds from gitea/gitea-admin-secret FIRST
+              # (the reachability probe below must authenticate — see Step 2).
               GU=$(kubectl -n gitea get secret gitea-admin-secret \
                 -o jsonpath='{.data.username}' | base64 -d)
               GP=$(kubectl -n gitea get secret gitea-admin-secret \
@@ -249,6 +238,28 @@ spec:
               fi
               # Basic auth header — never echo the password.
               AUTH=$(printf '%s:%s' "$GU" "$GP" | base64 -w0 2>/dev/null || printf '%s:%s' "$GU" "$GP" | base64 | tr -d '\n')
+
+              # Step 2: wait for the Gitea API to be reachable. Same budget
+              # knob the token-mint Job uses (default 168 x 5s = 14m) —
+              # covers the autoscaler-cold-start worst case on a fresh prov.
+              #
+              # #3454 — the probe MUST authenticate: bp-gitea sets
+              # service.REQUIRE_SIGNIN_VIEW=true (platform/gitea values.yaml),
+              # so the unauthenticated /api/v1/version returns 403, NOT 200.
+              # Probing anonymously burned all 168 iterations on hw133 before
+              # falling through. Send the admin Basic header so a healthy
+              # Gitea answers 200; treat 401/403 as "not ready yet" too (the
+              # Pod may still be initialising its admin user).
+              for i in $(seq 1 "$ITERATIONS"); do
+                code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 \
+                  -H "Authorization: Basic ${AUTH}" "${API}/version" || echo 000)
+                if [ "$code" = "200" ]; then
+                  echo "[repo-bootstrap] gitea api reachable (authed /version=200)"
+                  break
+                fi
+                echo "[repo-bootstrap] waiting for gitea api ($i/$ITERATIONS, /version=${code})"
+                sleep "$INTERVAL"
+              done
 
               # Step 3: ensure the org exists (idempotent).
               ORG_CODE=$(curl -sS -o /dev/null -w '%{http_code}' \

--- a/products/catalyst/chart/templates/sme-services/sme-tenants-gitrepo-auth-secret.yaml
+++ b/products/catalyst/chart/templates/sme-services/sme-tenants-gitrepo-auth-secret.yaml
@@ -1,0 +1,120 @@
+{{- /*
+Flux basic-auth Secret for the openova-sme-tenants GitRepository —
+issue #3454 (Refs #3376 / #3378 FUNNEL).
+
+WHY THIS FILE EXISTS
+====================
+The openova-sme-tenants GitRepository (sme-tenants-gitrepository.yaml)
+clones the Sovereign-local Gitea `openova/openova`@`sme-tenants`. The
+template only emits a secretRef when .Values.smeTenants.gitRepository
+.secretRef is set, and pre-#3454 it was unset — so source-controller
+attempted an ANONYMOUS clone.
+
+ROOT CAUSE (hw133, deployment 40c4e17667b600eb, 2026-06-14)
+===========================================================
+bp-gitea sets `service.REQUIRE_SIGNIN_VIEW=true`
+(platform/gitea/chart/values.yaml) — anonymous access is disabled
+cluster-wide. PROVEN live on hw133: a freshly-created PUBLIC repo
+(`private:false`) still returns HTTP 401 on
+`GET /<org>/<repo>/info/refs?service=git-upload-pack` anonymously, and
+200 only with credentials. So even though cutover Step 01 creates
+`openova/openova` as public, Flux CANNOT clone it without auth — the
+GitRepository reports "authentication required" regardless of whether the
+repo exists. The bp-gitea values comment states the intent explicitly:
+"Git/Flux/API clients are unaffected (token auth)" — i.e. Flux is
+EXPECTED to authenticate, not clone anonymously.
+
+This Secret + the secretRef wiring (values default below) is the missing
+half of the SME-tenant gitops fix: the repo-bootstrap hook
+(gitea-tenants-repo-bootstrap-job.yaml) creates the repo; THIS makes it
+clonable by Flux.
+
+CREDENTIAL SOURCE
+=================
+The `catalyst-gitea-token` Secret (key `token`) — the real Gitea PAT
+minted by this same chart's catalyst-gitea-token-secret.yaml pre-install
+hook (POST /api/v1/users/{admin}/tokens, scopes:["all"]). Proven 200 as
+gitea_admin against this Gitea on hw133. We emit it in the Flux
+basic-auth shape (keys `username` + `password`); source-controller embeds
+them in the clone URL. Username is the Gitea admin account
+(CATALYST_GITOPS_USER literal `gitea_admin`, matching api-deployment.yaml).
+
+The lookup-and-mirror pattern mirrors provisioning-github-token.yaml:
+read catalyst-gitea-token at render time and re-emit ONLY when the PAT is
+present + non-empty (the minter creates an empty `token` placeholder
+before its mint Job patches the real bytes — emitting an empty password
+would be useless, so we render nothing until the PAT exists and Flux's
+reconcile fills it once the minter completes).
+
+GATING
+======
+Rendered ONLY when BOTH .Values.global.sovereignFQDN non-empty (Sovereign,
+not the Catalyst-Zero mothership — which clones github.com over its own
+GitRepository) AND .Values.ingress.marketplace.enabled (the SME tenant
+pipeline is on). Same discriminator the openova-sme-tenants GitRepository
+itself uses.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #10: NO plaintext credentials in this
+template — the PAT lives only in catalyst-gitea-token and is read back via
+lookup; the bytes never appear in chart source or rendered manifests on
+disk. Per #4: the destination/source Secret names + key + the Gitea admin
+username flow through .Values with sensible defaults.
+
+References:
+  - Issue #3454 (this fix), Refs #3376 / #3378
+  - templates/sme-services/sme-tenants-gitrepository.yaml (the consumer of
+    .secretRef — already supports it, just needed wiring)
+  - templates/catalyst-gitea-token-secret.yaml (PAT source)
+  - platform/gitea/chart/values.yaml:93 (REQUIRE_SIGNIN_VIEW=true)
+*/}}
+{{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
+{{- if .Values.global.sovereignFQDN -}}
+{{- $gr := (.Values.smeTenants).gitRepository | default dict -}}
+{{- $sr := $gr.secretRef | default dict -}}
+{{- $secretName := $sr.name | default "openova-sme-tenants-git-auth" -}}
+{{- $secretNamespace := $gr.namespace | default "flux-system" -}}
+{{- $sourceNamespace := $sr.patSourceNamespace | default .Release.Namespace -}}
+{{- $sourceSecretName := $sr.patSourceSecretName | default "catalyst-gitea-token" -}}
+{{- $sourcePatKey := $sr.patSourceKey | default "token" -}}
+{{- $username := $sr.username | default "gitea_admin" -}}
+{{- $sourceSecret := lookup "v1" "Secret" $sourceNamespace $sourceSecretName -}}
+{{- $patB64 := "" -}}
+{{- if and $sourceSecret $sourceSecret.data (index $sourceSecret.data $sourcePatKey) -}}
+  {{- $candidate := index $sourceSecret.data $sourcePatKey -}}
+  {{- if not (empty ($candidate | b64dec)) -}}
+    {{- $patB64 = $candidate -}}
+  {{- end -}}
+{{- end -}}
+{{- if $patB64 -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $secretNamespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-platform
+    catalyst.openova.io/component: sme-tenants-git-auth
+    app.kubernetes.io/part-of: sme
+    # source-controller (flux-system) is the consumer; flux-system is
+    # excluded from the kyverno flux-managed Enforce namespace list, but
+    # we stamp managed-by:flux for consistency with the other hook-created
+    # resources and any future policy widening.
+    app.kubernetes.io/managed-by: flux
+  annotations:
+    catalyst.openova.io/mirrored-from: {{ printf "%s/%s" $sourceNamespace $sourceSecretName | quote }}
+    # Survive helm uninstall so a re-install keeps Flux authenticated
+    # without a clone-error window.
+    helm.sh/resource-policy: keep
+type: Opaque
+stringData:
+  # Flux GitRepository basic-auth contract: source-controller reads
+  # `username` + `password` and embeds them in the HTTP(S) clone URL.
+  # The PAT (catalyst-gitea-token) authenticates as the Gitea admin — a
+  # Gitea PAT is accepted as the HTTP password for git operations
+  # (REQUIRE_SIGNIN_VIEW=true makes anonymous clone 401; this makes it 200).
+  username: {{ $username | quote }}
+data:
+  password: {{ $patB64 | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1076,10 +1076,26 @@ smeTenants:
     org: openova
     repo: openova
     interval: 1m
-    # secretRef: name: gitea-credentials  # uncomment + populate if the
-    # in-cluster Gitea repo becomes private. For the public repo path
-    # source-controller does an unauthenticated clone, matching the
-    # bootstrap GitRepository's secret-less shape.
+    # #3454 — Flux MUST authenticate to clone the local Gitea even when
+    # openova/openova is PUBLIC, because bp-gitea sets
+    # service.REQUIRE_SIGNIN_VIEW=true (platform/gitea/chart/values.yaml)
+    # which makes ANONYMOUS git clone return 401 (proven live on hw133: a
+    # fresh public repo's info/refs?service=git-upload-pack = 401 anon, 200
+    # authed). The bp-gitea values comment confirms the intent: "Git/Flux/
+    # API clients are unaffected (token auth)". So the openova-sme-tenants
+    # GitRepository carries a secretRef to a Flux basic-auth Secret holding
+    # the catalyst-gitea-token PAT (rendered by sme-tenants-gitrepo-auth-
+    # secret.yaml). Without this the GitRepository sits "authentication
+    # required" forever and every sub-org hangs in Provisioning.
+    secretRef:
+      # Name of the Flux basic-auth Secret in this GitRepository's namespace
+      # (flux-system). Rendered by sme-tenants-gitrepo-auth-secret.yaml.
+      name: openova-sme-tenants-git-auth
+      # Gitea account the PAT belongs to (matches CATALYST_GITOPS_USER in
+      # api-deployment.yaml). The PAT is sourced from catalyst-gitea-token.
+      username: gitea_admin
+      patSourceSecretName: catalyst-gitea-token
+      patSourceKey: token
   # ─── Pre-cutover local-Gitea repo bootstrap (#3454, Refs #3376) ─────
   # The SME-tenant gitops chain (catalyst-api push target + the
   # openova-sme-tenants GitRepository above) targets the local Gitea


### PR DESCRIPTION
## Problem
The deeper half of the SME-tenant gitops fix (after #3457 / #3462 added the repo-bootstrap + kyverno label). On hw133 the `openova-sme-tenants` GitRepository stayed `Ready=False` with **"authentication required"** even though the repo-bootstrap was working.

## Root cause (proven live)
bp-gitea sets `service.REQUIRE_SIGNIN_VIEW=true` (`platform/gitea/chart/values.yaml`), which **disables anonymous access cluster-wide**. PROVEN on hw133: I created a fresh **public** repo (`private:false`) and tested its git endpoint:
```
anon   GET /<org>/<repo>/info/refs?service=git-upload-pack -> 401
authed GET /<org>/<repo>/info/refs?service=git-upload-pack -> 200
```
So even a **public** repo cannot be cloned anonymously. The `openova-sme-tenants` GitRepository had **no `secretRef`** -> it attempted an anonymous clone -> "authentication required", **repo-present-or-not**. The repo-bootstrap (1.4.612/613) is necessary but not sufficient. The bp-gitea values comment states the intent: *"Git/Flux/API clients are unaffected (token auth)"* — Flux is **expected** to authenticate.

Separately, the repo-bootstrap hook's `/api/v1/version` reachability probe was **anonymous**, so under `REQUIRE_SIGNIN_VIEW=true` it returned **403** and burned all 168 loop passes on hw133 before falling through.

## Fix
1. **New Flux basic-auth Secret** `openova-sme-tenants-git-auth` (`sme-tenants-gitrepo-auth-secret.yaml`), sourced via `lookup` from the `catalyst-gitea-token` PAT (proven 200 as `gitea_admin`), emitting the Flux GitRepository `username` + `password` contract. Carries `managed-by:flux` + the lookup-empty guard (same pattern as `provisioning-github-token.yaml`).
2. **Wire** `smeTenants.gitRepository.secretRef` in values so the existing GitRepository template (which already supports `secretRef`) emits it.
3. **Fix the repo-bootstrap hook probe** to authenticate (anon `/version` = 403 under `REQUIRE_SIGNIN_VIEW`).

## Validation
- `helm lint`: **0 charts failed**.
- **Server-side dry-run of the auth Secret against live hw133**: kyverno admits it (`created (server dry run)`).
- The `openova-sme-tenants` GitRepository now renders `secretRef: name: openova-sme-tenants-git-auth`.
- Repo-bootstrap hook script: `sh -n` and `dash -n` OK.
- `pin-sync-audit`: pin `13-bp-catalyst-platform.yaml` = `1.4.615` lockstep (verified PASS).

## Live convergence so far (hw133, zero-touch)
1.4.613 admitted the repo-bootstrap hook (kyverno fix landed — observed the Job `1/1 Running` on hw133). This PR (1.4.615) makes the GitRepository able to clone the repo the hook creates. Once published + reconciled, `openova-sme-tenants` should flip `Ready=True`.

Refs #3376
Refs #3378
Refs #3454

🤖 Generated with [Claude Code](https://claude.com/claude-code)
