### PR TITLE
fix(bp-newapi,bp-kyverno-policies): un-block admin-promote CronJob — managed-by:flux + resource-requests CronJob path (#3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -101,7 +101,7 @@ spec:
       # pdns-auth-50 + dnsdist-19 images to raw docker.io because proxy-docker is
       # not bootstrap-pullable on a fresh prov (#3380-D's reroute wedged hw131 +
       # hw132). powerdns stays subject to every OTHER policy (scoped carve-out).
-      version: 1.0.33
+      version: 1.0.34
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -210,7 +210,7 @@ spec:
       # the upgrade's pre-upgrade gate (and post-upgrade seed/channel/db-sync)
       # aren't denied by kyverno flux-managed Enforce → 1.4.68 rolled back to
       # 1.4.66 on hw133, leaving NewAPI uninitialized. Same class as openbao #3434.
-      version: 1.4.70
+      version: 1.4.71
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.33
+  version: 1.0.34
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -170,7 +170,18 @@ type: application
 # while keeping proxy-cache for anonymous public registries.
 # Lockstep with bp-self-sovereign-cutover 0.1.43 (Step 03 Phase A
 # skopeo native-push + Step 07 REGISTRY drops /proxy-ghcr/ suffix).
-version: 1.0.33
+# 1.0.34 (#3374 admin-tier, 2026-06-14): fix the resource-requests Enforce
+# policy for CronJob. The single rule wrote `spec.template.spec.containers`
+# (the Pod-controller path) and relied on Kyverno autogen to rewrite it to
+# `spec.jobTemplate.spec.template.spec.containers` for CronJob — which did NOT
+# fire for a freshly-created helm hook CronJob: bp-newapi's admin-promote
+# CronJob (resources.requests PRESENT) was DENIED at `/spec/template/` and the
+# whole bp-newapi upgrade was blocked (#3455). Pin `autogen-controllers: none`
+# and split into explicit per-shape rules (Pod / template-bearing workload /
+# CronJob), each at its real container path — mirrors the harbor-proxy policy
+# (#2611) that solved the identical autogen-doesn't-expand class. No behavior
+# change for Deployment/StatefulSet/DaemonSet/Job (still gated). Refs #3374.
+version: 1.0.34
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/templates/baseline/05-resource-requests.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/05-resource-requests.yaml
@@ -21,6 +21,23 @@ metadata:
     catalyst.openova.io/policy-tier: compliance
     catalyst.openova.io/policy-domain: resilience
   annotations:
+    # Autogen is OFF and each workload PATH-SHAPE has its own explicit rule
+    # (#3374, 2026-06-14). ROOT CAUSE caught live on hw133: the prior SINGLE
+    # rule wrote the container path as `spec.template.spec.containers` (the
+    # Pod-controller path) and relied on Kyverno autogen to rewrite it to
+    # `spec.jobTemplate.spec.template.spec.containers` for CronJob. Autogen's
+    # CronJob expansion did NOT fire for a freshly-created helm hook CronJob:
+    # the `newapi-bp-newapi-admin-promote` CronJob (resources.requests PRESENT
+    # on its single container) was DENIED at path `/spec/template/` — the
+    # Pod-controller rule applied to a CronJob, which has no `spec.template`,
+    # so the pattern can never match → deny-everything for fresh CronJobs.
+    # (Live CronJobs created at bootstrap were merely grandfathered; kyverno
+    # validates on CREATE/UPDATE only.) This blocked bp-newapi's whole upgrade
+    # (#3455 / #3374). Same autogen-doesn't-expand-anyPattern/CronJob class as
+    # baseline/11-harbor-proxy.yaml (#2611), which already pins autogen off and
+    # writes one rule per shape. Fix mirrors it: Pod + template-bearing
+    # workload + CronJob rules, each at its real container path.
+    pod-policies.kyverno.io/autogen-controllers: none
     policies.kyverno.io/title: Containers must declare CPU and memory requests
     policies.kyverno.io/category: catalyst-compliance
     policies.kyverno.io/severity: high
@@ -33,7 +50,31 @@ spec:
   validationFailureAction: {{ include "bp-kyverno-policies.action" (dict "ctx" . "policy" .Values.compliancePolicies.resourceRequests.action) }}
   background: true
   rules:
-    - name: containers-must-declare-cpu-memory-requests
+    {{- $excludeNs := .Values.compliancePolicies.resourceRequests.excludeNamespaces }}
+    {{- $msg := "Every container must declare resources.requests.cpu and resources.requests.memory." }}
+    - name: requests-pod
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := $excludeNs }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: {{ $msg | quote }}
+        pattern:
+          spec:
+            containers:
+              - resources:
+                  requests:
+                    cpu: "?*"
+                    memory: "?*"
+    - name: requests-workload
       match:
         any:
           - resources:
@@ -42,19 +83,15 @@ spec:
                 - StatefulSet
                 - DaemonSet
                 - Job
-                - CronJob
       exclude:
         any:
           - resources:
               namespaces:
-                {{- range $ns := .Values.compliancePolicies.resourceRequests.excludeNamespaces }}
+                {{- range $ns := $excludeNs }}
                 - {{ $ns }}
                 {{- end }}
       validate:
-        message: >-
-          Every container in
-          {{ `{{request.object.kind}}/{{request.object.metadata.name}}` }} must
-          declare resources.requests.cpu and resources.requests.memory.
+        message: {{ $msg | quote }}
         pattern:
           spec:
             template:
@@ -64,4 +101,30 @@ spec:
                       requests:
                         cpu: "?*"
                         memory: "?*"
+    - name: requests-cronjob
+      match:
+        any:
+          - resources:
+              kinds:
+                - CronJob
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := $excludeNs }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: {{ $msg | quote }}
+        pattern:
+          spec:
+            jobTemplate:
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - resources:
+                          requests:
+                            cpu: "?*"
+                            memory: "?*"
 {{- end -}}

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.70
+  version: 1.4.71
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -461,7 +461,14 @@ name: bp-newapi
 # Jobs are stamped so the upgrade doesn't merely stall at the NEXT hook. Same
 # class as openbao #3434 + gitea/harbor #3296→#3297. Lockstep: 80-newapi.yaml
 # pin → 1.4.69.
-version: 1.4.70
+# 1.4.71 (#3374 admin-tier, 2026-06-14): stamp managed-by:flux on the
+# admin-promote CronJob + its jobTemplate too. Once 1.4.69's 4-Job fix let the
+# upgrade get PAST flux-managed, the upgrade reached the admin-promote CronJob
+# which (a) also lacked managed-by:flux and (b) tripped the resource-requests
+# Enforce autogen bug (fixed in lockstep, bp-kyverno-policies 1.0.34). Stamping
+# the CronJob closes (a); the policy fix closes (b). Lockstep: 80-newapi.yaml
+# pin → 1.4.71.
+version: 1.4.71
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/admin-sso-seed-job.yaml
+++ b/platform/newapi/chart/templates/admin-sso-seed-job.yaml
@@ -356,6 +356,12 @@ metadata:
   labels:
     {{- include "bp-newapi.labels" . | nindent 4 }}
     catalyst.openova.io/component: admin-promote
+    # kyverno `flux-managed` Enforce gates CronJob too (helm-controller hook
+    # CronJobs carry no HR ownerReference). Stamp managed-by=flux on the
+    # CronJob AND its spawned Jobs (jobTemplate below) or admission denies the
+    # CronJob — caught live on hw133 once the 4-Job managed-by fix let the
+    # upgrade reach the CronJob (#3374; openbao snapshot-replication #3434 class).
+    app.kubernetes.io/managed-by: flux
 spec:
   schedule: {{ $seed.promoteSchedule | default "* * * * *" | quote }}
   concurrencyPolicy: Forbid
@@ -367,6 +373,8 @@ spec:
       labels:
         {{- include "bp-newapi.labels" . | nindent 8 }}
         catalyst.openova.io/component: admin-promote
+        # The CronJob-spawned Job is itself gated by flux-managed — stamp it.
+        app.kubernetes.io/managed-by: flux
     spec:
       backoffLimit: 2
       activeDeadlineSeconds: 120


### PR DESCRIPTION
## Problem (live on hw133, server-dry-run confirmed)
After #3458 (bp-newapi 1.4.69) stamped `managed-by:flux` on the 4 hook Jobs, the upgrade got PAST flux-managed and reached the **admin-promote CronJob**, which is then denied by TWO Enforce policies:
```
flux-managed: CronJob/newapi-bp-newapi-admin-promote is not Flux-managed ...
resource-requests: Every container ... must declare resources.requests ... failed at path /spec/template/
```
The bp-newapi HR stays `Ready=False`, rolled back to 1.4.66 → NewAPI uninitialized.

## Fixes
**(1) bp-newapi** — the admin-promote CronJob carried `managed-by=Helm`, not `flux`. Stamp `managed-by:flux` on the CronJob metadata AND its jobTemplate (the spawned Job is itself gated). Same shape as openbao snapshot-replication #3434.

**(2) bp-kyverno-policies** — `resource-requests` (Enforce) was a SINGLE rule at `spec.template.spec.containers` (Pod path) relying on Kyverno autogen to rewrite it for CronJob. Autogen did NOT expand it for a freshly-created hook CronJob: the admin-promote CronJob (**requests present**) was denied at `/spec/template/` — the Pod path applied to a CronJob (no `spec.template`). Live CronJobs were merely grandfathered (kyverno validates on CREATE/UPDATE only). **Same autogen-doesn't-expand class as `11-harbor-proxy.yaml` (#2611)**, which already pins autogen off + writes one rule per shape. Fix mirrors it: `autogen-controllers: none` + `requests-pod` / `requests-workload` / `requests-cronjob` (jobTemplate path). No behavior change for Deployment/StatefulSet/DaemonSet/Job; the cronjob path is byte-identical depth to harbor-proxy's proven-live cronjob rule.

bp-newapi **1.4.70→1.4.71** + bp-kyverno-policies **1.0.33→1.0.34**, each with blueprint.yaml + slot pin in lockstep.

## Validation
`helm template`: resource-requests has 3 explicit rules (pod / workload-template / cronjob-jobTemplate); newapi CronJob + jobTemplate carry `managed-by=flux` with requests present. Chart render tests green.

## What the walker should see after reconcile
bp-newapi HR reaches `Ready=True` on 1.4.71 → `newapi.hw133.omani.works` lands signed-in via SSO (no `/setup` wizard), admin reachable.

Refs #3374 #3455