### PR TITLE
fix(bp-kyverno-policies): exclude CNPG operator objects from flux-managed by label (#3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -101,7 +101,7 @@ spec:
       # pdns-auth-50 + dnsdist-19 images to raw docker.io because proxy-docker is
       # not bootstrap-pullable on a fresh prov (#3380-D's reroute wedged hw131 +
       # hw132). powerdns stays subject to every OTHER policy (scoped carve-out).
-      version: 1.0.34
+      version: 1.0.35
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.34
+  version: 1.0.35
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -181,7 +181,19 @@ type: application
 # CronJob), each at its real container path — mirrors the harbor-proxy policy
 # (#2611) that solved the identical autogen-doesn't-expand class. No behavior
 # change for Deployment/StatefulSet/DaemonSet/Job (still gated). Refs #3374.
-version: 1.0.34
+# 1.0.35 (#3374 admin-tier, 2026-06-14): exclude CNPG operator-created objects
+# from flux-managed by LABEL (app.kubernetes.io/managed-by: cloudnative-pg),
+# cluster-wide, instead of only by namespace. A FRESH guacamole-pg CNPG Cluster
+# (in shared catalyst-system) was wedged at "Unable to create required cluster
+# objects" on hw133 because its operator-created Service/guacamole-pg-r was
+# denied by flux-managed — the per-namespace exclude only covered dedicated
+# CNPG namespaces (cnpg/shared-data/powerdns-admin), and catalyst-system /
+# newapi host real Deployments that must stay gated. newapi-pg / openova-flow-pg
+# only passed because they were bootstrap-grandfathered (kyverno validates on
+# CREATE/UPDATE only) — a truly fresh prov hits the same wall. Excluding on the
+# operator label exempts ONLY CNPG operator-owned Services + utility Jobs in any
+# namespace; every Flux/Helm/kubectl workload stays gated. Refs #3374 #3248.
+version: 1.0.35
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/templates/baseline/10-flux-managed.yaml
+++ b/platform/kyverno-policies/chart/templates/baseline/10-flux-managed.yaml
@@ -73,6 +73,29 @@ spec:
                 {{- range $ns := .Values.compliancePolicies.fluxManaged.extraExcludeNamespaces }}
                 - {{ $ns }}
                 {{- end }}
+          {{- /*
+            #3374 (2026-06-14): exclude CNPG operator-created objects by LABEL,
+            cluster-wide, instead of by namespace. The per-namespace exclude
+            above only covers CNPG clusters in dedicated namespaces (cnpg /
+            shared-data / powerdns-admin). PER-APP CNPG clusters that land in a
+            SHARED namespace — guacamole-pg in catalyst-system, newapi-pg in
+            newapi, openova-flow-pg in catalyst-system — could not be excluded
+            that way without also exempting the real Deployments that share the
+            namespace. On hw133 a FRESH guacamole-pg Cluster was wedged at
+            "Unable to create required cluster objects" because its operator-
+            created Service/guacamole-pg-r was denied (the existing newapi-pg /
+            openova-flow-pg Services only passed because they were created at
+            bootstrap before Enforce engaged — grandfathered). Every CNPG
+            operator object carries `app.kubernetes.io/managed-by: cloudnative-pg`;
+            excluding on that label exempts ONLY operator-owned Services + utility
+            Jobs in ANY namespace, while every Flux/Helm/kubectl workload stays
+            gated. This is the definitional carve-out the namespace list was
+            approximating. Refs #3374 #3248.
+          */}}
+          - resources:
+              selector:
+                matchLabels:
+                  app.kubernetes.io/managed-by: cloudnative-pg
       validate:
         message: >-
           {{ `{{request.object.kind}}/{{request.object.metadata.name}}` }} is


### PR DESCRIPTION
## Problem (live on hw133)
A **fresh** `guacamole-pg` CNPG Cluster (created post-convergence, in shared `catalyst-system`) is wedged at `Unable to create required cluster objects`. The CNPG operator's reconcile is denied:
```
Service/catalyst-system/guacamole-pg-r blocked: flux-managed:
  Service/guacamole-pg-r is not Flux-managed ...
```
`flux-managed` is the only Enforce policy whose match-kinds include Service, and the CNPG operator creates `<cluster>-r/-ro/-rw` Services (+ utility Jobs) with NO flux labels/ownerRefs — operator-owned objects definitionally cannot be Flux-managed.

The existing carve-out is a per-**namespace** exclude (`cnpg`/`shared-data`/`powerdns-admin`). PER-APP CNPG clusters in a **shared** namespace can't use it: `guacamole-pg` (catalyst-system), `newapi-pg` (newapi), `openova-flow-pg` (catalyst-system) share their namespace with real Deployments that must stay gated. newapi-pg/openova-flow-pg only pass today because they were **bootstrap-grandfathered** (kyverno validates on CREATE/UPDATE only); a fresh prov hits the same wall.

## Fix
Exclude CNPG operator objects by **label** (`app.kubernetes.io/managed-by: cloudnative-pg`) cluster-wide, via an additional `exclude.any` selector. Every CNPG operator object carries that label → exempts ONLY operator-owned Services + utility Jobs in any namespace; every Flux/Helm/kubectl workload everywhere stays gated. The namespace excludes are kept (no removal).

This unblocks per-app CNPG clusters (guacamole, newapi, openova-flow) zero-touch on a fresh prov — directly enables the guacamole JDBC permission store (admin) to come up.

Chart **1.0.34 → 1.0.35** + blueprint.yaml + slot pin in lockstep.

## Validation
`helm template`: flux-managed rule has 2 excludes — the 18-namespace list + the `managed-by=cloudnative-pg` selector.

Refs #3374 #3455 #3248