### PR TITLE
fix(bp-newapi): hookLabels helper — kill the duplicate managed-by key post-render failure (#3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -210,7 +210,7 @@ spec:
       # the upgrade's pre-upgrade gate (and post-upgrade seed/channel/db-sync)
       # aren't denied by kyverno flux-managed Enforce → 1.4.68 rolled back to
       # 1.4.66 on hw133, leaving NewAPI uninitialized. Same class as openbao #3434.
-      version: 1.4.72
+      version: 1.4.73
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.72
+  version: 1.4.73
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -468,7 +468,18 @@ name: bp-newapi
 # Enforce autogen bug (fixed in lockstep, bp-kyverno-policies 1.0.34). Stamping
 # the CronJob closes (a); the policy fix closes (b). Lockstep: 80-newapi.yaml
 # pin → 1.4.71.
-version: 1.4.72
+# 1.4.73 (#3374 admin-tier, 2026-06-14): fix the DUPLICATE-KEY post-render
+# failure 1.4.71/1.4.72 introduced. Appending `app.kubernetes.io/managed-by:
+# flux` AFTER `{{ include "bp-newapi.labels" . }}` (which already emits
+# managed-by=Helm) yielded TWO managed-by keys in one map. `helm template`
+# renders it last-wins, but bp-newapi's strict-YAML post-render rejected it:
+#   error while running post render ... mapping key
+#   "app.kubernetes.io/managed-by" already defined
+# → the whole upgrade FAILED on hw133. New `bp-newapi.hookLabels` helper emits
+# the full label set with managed-by=flux as a SINGLE key; the 4 hook Jobs +
+# the admin-promote CronJob + its jobTemplate use it instead of the
+# labels+duplicate pattern. Lockstep: 80-newapi.yaml pin → 1.4.73.
+version: 1.4.73
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/_helpers.tpl
+++ b/platform/newapi/chart/templates/_helpers.tpl
@@ -37,6 +37,29 @@ catalyst.openova.io/blueprint: bp-newapi
 {{- end }}
 
 {{/*
+Hook-resource labels (#3374). Identical to bp-newapi.labels EXCEPT
+`app.kubernetes.io/managed-by: flux` instead of Helm. Helm hook Jobs/CronJobs
+are created by the helm-controller with no HelmRelease ownerReference, so the
+kyverno `flux-managed` Enforce policy DENIES them unless they carry
+managed-by=flux. We can't simply append a second `managed-by` line after
+`bp-newapi.labels` — that yields a DUPLICATE map key that strict-YAML
+post-render (`error while running post render ... mapping key ... already
+defined`, caught live on hw133 with bp-newapi 1.4.71) rejects even though
+`helm template` renders it last-wins. This single-source helper emits the key
+ONCE with the flux value.
+*/}}
+{{- define "bp-newapi.hookLabels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/name: {{ include "bp-newapi.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: flux
+catalyst.openova.io/blueprint: bp-newapi
+{{- end }}
+
+{{/*
 Selector labels.
 */}}
 {{- define "bp-newapi.selectorLabels" -}}

--- a/platform/newapi/chart/templates/admin-sso-seed-job.yaml
+++ b/platform/newapi/chart/templates/admin-sso-seed-job.yaml
@@ -273,13 +273,12 @@ metadata:
   name: {{ $jobName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "bp-newapi.labels" . | nindent 4 }}
+    # hookLabels = bp-newapi.labels but managed-by=flux (single key, no dup):
+    # kyverno flux-managed Enforce DENIES a hook Job without managed-by=flux
+    # (helm-controller-created, no HR ownerReference). Without it this
+    # post-upgrade SSO admin seed fails → HR rolls back (#3374 / #3434).
+    {{- include "bp-newapi.hookLabels" . | nindent 4 }}
     catalyst.openova.io/component: admin-seed
-    # Override the helper's managed-by=Helm: kyverno `flux-managed` Enforce
-    # DENIES a hook Job without managed-by=flux (helm-controller-created, no
-    # HR ownerReference). Without it this post-upgrade SSO admin seed fails
-    # and the HR rolls back, so the admin map never lands (#3374 / #3434).
-    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "12"
@@ -354,14 +353,13 @@ metadata:
   name: {{ $cronName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "bp-newapi.labels" . | nindent 4 }}
+    # hookLabels = managed-by=flux (single key, no dup). kyverno flux-managed
+    # Enforce gates CronJob too (helm-controller hook CronJobs carry no HR
+    # ownerReference) → stamp it on the CronJob AND its spawned Jobs
+    # (jobTemplate below). Caught live on hw133 once the 4-Job managed-by fix
+    # let the upgrade reach the CronJob (#3374; openbao snapshot-replication #3434).
+    {{- include "bp-newapi.hookLabels" . | nindent 4 }}
     catalyst.openova.io/component: admin-promote
-    # kyverno `flux-managed` Enforce gates CronJob too (helm-controller hook
-    # CronJobs carry no HR ownerReference). Stamp managed-by=flux on the
-    # CronJob AND its spawned Jobs (jobTemplate below) or admission denies the
-    # CronJob — caught live on hw133 once the 4-Job managed-by fix let the
-    # upgrade reach the CronJob (#3374; openbao snapshot-replication #3434 class).
-    app.kubernetes.io/managed-by: flux
 spec:
   schedule: {{ $seed.promoteSchedule | default "* * * * *" | quote }}
   concurrencyPolicy: Forbid
@@ -371,10 +369,9 @@ spec:
   jobTemplate:
     metadata:
       labels:
-        {{- include "bp-newapi.labels" . | nindent 8 }}
+        # The CronJob-spawned Job is itself gated by flux-managed — managed-by=flux.
+        {{- include "bp-newapi.hookLabels" . | nindent 8 }}
         catalyst.openova.io/component: admin-promote
-        # The CronJob-spawned Job is itself gated by flux-managed — stamp it.
-        app.kubernetes.io/managed-by: flux
     spec:
       backoffLimit: 2
       activeDeadlineSeconds: 120

--- a/platform/newapi/chart/templates/channel-seed-job.yaml
+++ b/platform/newapi/chart/templates/channel-seed-job.yaml
@@ -203,13 +203,11 @@ metadata:
   name: {{ $jobName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "bp-newapi.labels" . | nindent 4 }}
+    # hookLabels = managed-by=flux (single key, no dup). kyverno flux-managed
+    # Enforce DENIES a hook Job without managed-by=flux → post-upgrade hook
+    # fails → HR rolls back (the landmine that stalled bp-newapi on hw133, #3374).
+    {{- include "bp-newapi.hookLabels" . | nindent 4 }}
     catalyst.openova.io/component: channel-seed
-    # Override the helper's managed-by=Helm: kyverno `flux-managed` Enforce
-    # DENIES a hook Job without managed-by=flux (helm-controller-created, no
-    # HR ownerReference). Without it this post-upgrade hook fails and the HR
-    # rolls back — the same landmine that stalled bp-newapi on hw133 (#3374).
-    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "10"

--- a/platform/newapi/chart/templates/database-secret-sync-job.yaml
+++ b/platform/newapi/chart/templates/database-secret-sync-job.yaml
@@ -62,13 +62,11 @@ metadata:
   name: {{ include "bp-newapi.fullname" . }}-db-dsn-sync
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "bp-newapi.labels" . | nindent 4 }}
+    # hookLabels = managed-by=flux (single key, no dup). kyverno flux-managed
+    # Enforce DENIES a hook Job without managed-by=flux → post-upgrade hook
+    # fails → HR rolls back (same landmine class as the rest, hw133 #3374).
+    {{- include "bp-newapi.hookLabels" . | nindent 4 }}
     catalyst.openova.io/component: newapi-db-dsn-sync
-    # Override the helper's managed-by=Helm: kyverno `flux-managed` Enforce
-    # DENIES a hook Job without managed-by=flux (helm-controller-created, no
-    # HR ownerReference). Without it this post-upgrade hook fails and the HR
-    # rolls back — same landmine class that stalled bp-newapi on hw133 (#3374).
-    app.kubernetes.io/managed-by: flux
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "5"


### PR DESCRIPTION
## Problem (live on hw133)
bp-newapi **1.4.71/1.4.72** fails:
```
Helm upgrade failed ... error while running post render ... yaml: unmarshal errors:
mapping key "app.kubernetes.io/managed-by" already defined at line 12
```
The managed-by:flux stamps (from #3458/#3465) were appended AFTER `{{ include "bp-newapi.labels" . }}` (which already emits managed-by=Helm) → TWO managed-by keys in one map. `helm template` renders last-wins (so earlier validation passed), but bp-newapi's strict-YAML **post-render** rejects the duplicate → the whole upgrade fails, SSO admin seed never lands. (bp-openbao/bp-guacamole don't post-render, so the same pattern works there — guacamole's seed Job runs live; this is bp-newapi-specific.)

## Fix
New `bp-newapi.hookLabels` helper emits the full label set with `managed-by=flux` as a **single key**. The 4 hook Jobs (eswebhook-gate / admin-seed / channel-seed / db-dsn-sync) + the admin-promote CronJob + its jobTemplate use it instead of the labels-plus-duplicate pattern.

## Validation
Strict duplicate-key YAML loader (simulates the post-render): 22 docs parse with **no duplicate keys**; all 4 hook Jobs + the CronJob carry `managed-by=flux` exactly once.

Chart **1.4.72 → 1.4.73** + blueprint.yaml + slot pin in lockstep.

## What the walker should see after reconcile
bp-newapi HR reaches `Ready=True` → `newapi.hw133.omani.works` lands signed-in via SSO, admin reachable.

Refs #3374 #3455