### PR TITLE
fix(catalyst): baseline-default-deny allows ingress from oidc-gate ns — openova-flow datapath (1.4.619)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1022,7 +1022,9 @@ spec:
             # 1.4.613 — #3454: add managed-by:flux on the repo-bootstrap hook Job (kyverno flux-managed Enforce).
             # 1.4.615 — #3454: secretRef on openova-sme-tenants GitRepo + authed probe (REQUIRE_SIGNIN_VIEW=true → anon clone 401).
             # 1.4.617 — #3454: repo-bootstrap hook PAT via secretKeyRef (no cross-ns RBAC race; 1.4.616 was a deploy-bot sweep of the old hook).
-      version: 1.4.618
+            # 1.4.618 — deploy-bot auto pin-bump (no chart-content change; Refs TBD-A6).
+            # 1.4.619 — #3374: baseline-default-deny allows ingress from the oidc-gate host ns → oidc-gate auth-proxy can reach openova-flow-server in catalyst-system (was dropped → SSO OK but app 502'd on upstream timeout; same class as sme→NATS #3423).
+      version: 1.4.619
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,19 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.619 — #3374 (2026-06-14) — baseline-default-deny: allow ingress
+# from the `oidc-gate` host namespace. The bp-oidc-gate auth-proxy (slot 13c)
+# reverse-proxies authenticated traffic to its upstream Service in
+# catalyst-system; openova-flow's gate dials
+# `openova-flow-server.catalyst-system.svc:80`. baseline-default-deny
+# (endpointSelector {} → every catalyst-system Pod, incl. flow-server) did NOT
+# list `oidc-gate` in allowedIngressNamespaces, so the proxied request was
+# dropped at flow-server's Cilium ingress hook — oidc-gate authenticated the
+# User (oauth2 callback succeeded) but openova-flow 502'd because the ClusterIP
+# Service AND the direct pod-IP both timed out from oidc-gate. Same isolation
+# class as the sme→NATS block (#3423). Added `oidc-gate` to both the values
+# default and the template fallback list. Diagnosed live on hw133 (both Pods
+# co-resident on cp1 → ruled out cross-node datapath; flow-server endpoint
+# ingress=Enabled while oidc-gate ns absent from the allow-list). Refs #3374.
 # 1.4.552 — #3188 (2026-06-10) — catalog-seed: add the missing bp-postgres
 # Blueprint CR. bp-postgres (the operator-facing, SHAREABLE PostgreSQL
 # data-instance card, ADR-0010) was the lone catalog-404 for the data-instance
@@ -2678,7 +2692,7 @@ name: bp-catalyst-platform
 # catalyst-gitea-token PAT as the GITEA_TOKEN env via secretKeyRef (same-ns,
 # kubelet-resolved at Pod start, no kubectl, no Role) and use token auth for
 # all Gitea calls. Drops the SA + gitea-ns Role/RoleBinding entirely.
-version: 1.4.618
+version: 1.4.619
 # 1.4.597 — #3373 (2026-06-13) — coupling fix (a) placement-as-data:
 # templates/httproute.yaml backendRefs honor new
 # ingress.gateway.backendServiceApi / backendServiceUi overrides. When

--- a/products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml
+++ b/products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml
@@ -79,7 +79,7 @@ when qaFixtures is disabled.
      The plain loki/mimir/tempo entries stay for Sovereigns that keep
      the host-side placement via per-Sovereign overlay. */}}
 {{- $allowedPlatform := .Values.security.baselineCnp.allowedPlatformNamespaces | default (list "keycloak" "gitea" "powerdns" "cnpg-system" "openbao" "harbor" "nats-system" "loki" "mimir" "tempo" "alloy" "opentelemetry" "external-secrets-system" "cert-manager" "sme" "newapi" "mgmt") }}
-{{- $allowedIngressNs := .Values.security.baselineCnp.allowedIngressNamespaces | default (list "catalyst" "flux-system" "kube-system") }}
+{{- $allowedIngressNs := .Values.security.baselineCnp.allowedIngressNamespaces | default (list "catalyst" "flux-system" "kube-system" "oidc-gate") }}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -154,6 +154,23 @@ spec:
     #        public traffic is also in kube-system but is matched by
     #        rule 1's `reserved.ingress: ""` selector — this rule
     #        covers the non-gateway kube-system Pods.
+    #
+    #      - `oidc-gate` (the bp-oidc-gate auth-proxy host namespace,
+    #        placement.yaml slot 13c, #3374) — the per-app oauth2-proxy
+    #        Pods front the host-Gateway routes for zero-click SSO and
+    #        reverse-proxy authenticated traffic to their upstream
+    #        Service. openova-flow's gate
+    #        (`--upstream=http://openova-flow-server.catalyst-system.
+    #        svc.cluster.local:80`) lives in `oidc-gate` and dials
+    #        flow-server in catalyst-system. Without this allow the
+    #        ingress hook on every catalyst-system upstream drops the
+    #        proxied request → oidc-gate authenticates the User but
+    #        every page 502s (upstream timeout). Regression caught on
+    #        hw133 (#813, fresh prov 2026-06-14): SSO callback
+    #        succeeded but openova-flow never served because the
+    #        ClusterIP Service AND the direct pod-IP both timed out
+    #        from oidc-gate — same isolation class as the sme→NATS
+    #        block (#3423).
     #
     #    Operators may extend or shrink this list via
     #    `.Values.security.baselineCnp.allowedIngressNamespaces`.

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1897,10 +1897,20 @@ security:
     #     do cluster introspection calls into catalyst-system. The
     #     reserved.ingress gateway endpoint also in kube-system is
     #     matched by a separate rule via reserved.ingress: "" label.
+    #   - oidc-gate — the bp-oidc-gate auth-proxy host namespace
+    #     (placement.yaml slot 13c, #3374). The per-app oauth2-proxy
+    #     reverse-proxies authenticated traffic to its upstream Service
+    #     in catalyst-system (openova-flow's gate dials
+    #     `openova-flow-server.catalyst-system.svc:80`). Without this
+    #     allow the baseline-default-deny ingress hook drops the
+    #     proxied request — oidc-gate authenticates the User but the
+    #     app 502s on upstream timeout (hw133 #813, fresh prov
+    #     2026-06-14; same isolation class as the sme→NATS #3423 block).
     allowedIngressNamespaces:
       - catalyst
       - flux-system
       - kube-system
+      - oidc-gate
 
 # ── Migrations (post-install / post-upgrade Helm-hook Jobs) ──────────────
 # Per PR #2795 (G117.2 multi-instance Application CRD): backfill spec.instanceId


### PR DESCRIPTION
## Root cause — NetworkPolicy deny (NOT a cross-node datapath issue)

openova-flow's SSO works (oauth2-proxy callback succeeds) but the app 502s because **oidc-gate (oauth2-proxy) cannot reach its upstream `openova-flow-server` cross-pod** — both the ClusterIP Service AND the direct pod-IP time out.

Diagnosed live on **hw133**:

- Both Pods are **co-resident on node cp1** (`oidc-gate` pod 10.42.0.121, `openova-flow-server` pod 10.42.0.97) → a cross-node Cilium datapath issue is ruled out.
- `openova-flow-server` Service + endpoints are healthy (`10.42.0.97:8080`, Ready).
- The `baseline-default-deny` **CiliumNetworkPolicy** in `catalyst-system` (`endpointSelector: {}` → every catalyst-system Pod, incl. flow-server) has an ingress allow-list of `[catalyst, flux-system, kube-system]` + same-namespace + gateway + host entities. **`oidc-gate` is absent.**
- `cilium-dbg endpoint list` on cp1 confirms flow-server (endpoint **3384**) has **ingress=Enabled** (policy enforced), while oidc-gate sits in a namespace not in the allow-list → the proxied request is dropped at flow-server's ingress hook.
- oidc-gate's upstream is exactly `--upstream=http://openova-flow-server.catalyst-system.svc.cluster.local:80`.

This is the **same isolation class as the sme→NATS block (#3423)** — a consumer namespace not allow-listed into a default-deny.

## Fix (at source, zero-touch)

Add `oidc-gate` to `security.baselineCnp.allowedIngressNamespaces` in both:
- `products/catalyst/chart/values.yaml` (the default), and
- `products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml` (the template fallback `| default (list ...)`), with an explanatory comment.

Bump chart **1.4.618 → 1.4.619** (1.4.618 was a content-free deploy-bot pin sweep on a different SHA — keeping 1.4.618 would collide with the already-published OCI artifact that lacks this fix) + bootstrap-kit pin.

## Render proof

```
$ helm template ... --show-only .../baseline-catalyst-system.yaml | (ingress values)
                - "catalyst"
                - "flux-system"
                - "kube-system"
                - "oidc-gate"   <-- added
```

## Live verification

After this reconciles on hw133, oidc-gate → flow-server is reachable (Service + pod-IP no longer time out) and openova-flow serves end-to-end through SSO. (Walk evidence to follow on the issue.)

Scope: ONLY the openova-flow datapath / baseline CNP ingress allow-list. No SSO app charts or console touched.

Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)