### PR TITLE
fix(bp-newapi): wait-for-sql-dsn initContainer — stop the silent SQLite fallback (#3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -210,7 +210,7 @@ spec:
       # the upgrade's pre-upgrade gate (and post-upgrade seed/channel/db-sync)
       # aren't denied by kyverno flux-managed Enforce → 1.4.68 rolled back to
       # 1.4.66 on hw133, leaving NewAPI uninitialized. Same class as openbao #3434.
-      version: 1.4.74
+      version: 1.4.75
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.74
+  version: 1.4.75
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -479,7 +479,18 @@ name: bp-newapi
 # the full label set with managed-by=flux as a SINGLE key; the 4 hook Jobs +
 # the admin-promote CronJob + its jobTemplate use it instead of the
 # labels+duplicate pattern. Lockstep: 80-newapi.yaml pin → 1.4.73.
-version: 1.4.74
+# 1.4.75 (#3374 admin-tier, 2026-06-14): add the wait-for-sql-dsn initContainer
+# (databaseDsnGate). Live on hw133 the app booted on the placeholder EMPTY
+# SQL_DSN, silently fell back to an ephemeral SQLite DB, and never reconnected
+# to the correctly-seeded Postgres — so the bare URL stayed at the /setup
+# wizard (the SSO-seeded admin lives in PG, not the pod's SQLite). The original
+# design assumed an empty DSN would CrashLoop the pod until the
+# database-secret-sync-job PATCHed the real DSN, but NewAPI treats empty-DSN →
+# SQLite as a valid happy path, so the pod never restarts. The initContainer
+# blocks the main container until SQL_DSN is non-empty → NewAPI always
+# initialises against Postgres. Gated on cnpg.enabled. Lockstep: 80-newapi.yaml
+# pin → 1.4.75.
+version: 1.4.75
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -100,6 +100,75 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.newapi.securityContext | nindent 8 }}
+      {{- /*
+        #3374 (2026-06-14) — SQL_DSN readiness gate. The chart-emitted
+        DSN Secret renders SQL_DSN: "" as a placeholder; the
+        database-secret-sync-job PATCHes the real Postgres DSN into it
+        AFTER CNPG is ready (see cnpg-cluster.yaml). The original design
+        assumed the app Pod would CrashLoop on the empty DSN and recover on
+        the next kubelet restart once the DSN populated — but NewAPI does NOT
+        crash on an empty SQL_DSN: it silently FALLS BACK TO SQLITE
+        (`SQL_DSN not set, using SQLite as database`), a valid happy path, so
+        the Pod stays Running on an EPHEMERAL SQLite DB forever, disconnected
+        from the correctly-seeded Postgres (the live #3374 newapi gap on
+        hw133: bare URL stuck at the /setup wizard because the SSO-seeded
+        admin lives in PG, not the pod's SQLite). This initContainer blocks
+        the main container from EVER booting until SQL_DSN is non-empty, so
+        NewAPI always initialises against Postgres. Event-deterministic,
+        fresh-prov-safe, zero-touch. Gated on cnpg.enabled (operators wiring
+        an external DB via database.existingSecret populate it up-front, so
+        the gate passes immediately). databaseDsnGate.enabled=false opts out.
+      */}}
+      {{- $dsnGate := .Values.databaseDsnGate | default dict -}}
+      {{- if and (default true $dsnGate.enabled) .Values.cnpg.enabled }}
+      initContainers:
+        - name: wait-for-sql-dsn
+          image: {{ $dsnGate.image | default "harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1" | quote }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DSN_GATE_TIMEOUT_SECONDS
+              value: {{ $dsnGate.timeoutSeconds | default 300 | quote }}
+            - name: DSN_GATE_INTERVAL_SECONDS
+              value: {{ $dsnGate.intervalSeconds | default 5 | quote }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              # The DSN Secret is projected at /dsn/SQL_DSN. Wait until the
+              # database-secret-sync-job has PATCHed a NON-EMPTY value (the
+              # placeholder is ""). Kubernetes refreshes a mounted Secret in
+              # place within ~60s of the PATCH, so this initContainer sees the
+              # populated value without a Pod restart.
+              echo "[dsn-gate] waiting for a non-empty SQL_DSN at /dsn/SQL_DSN (budget ${DSN_GATE_TIMEOUT_SECONDS}s)"
+              deadline=$(( $(date +%s) + DSN_GATE_TIMEOUT_SECONDS ))
+              while [ "$(date +%s)" -lt "${deadline}" ]; do
+                if [ -s /dsn/SQL_DSN ]; then
+                  echo "[dsn-gate] SQL_DSN populated — NewAPI will initialise against Postgres"
+                  exit 0
+                fi
+                sleep "${DSN_GATE_INTERVAL_SECONDS}"
+              done
+              echo "[dsn-gate] FATAL: SQL_DSN still empty after ${DSN_GATE_TIMEOUT_SECONDS}s — the database-secret-sync-job did not populate it; refusing to boot on SQLite" >&2
+              exit 1
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 32Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: sql-dsn-gate
+              mountPath: /dsn
+              readOnly: true
+      {{- end }}
       containers:
         - name: newapi
           image: "{{ .Values.newapi.image.repository }}:{{ .Values.newapi.image.tag }}"
@@ -367,5 +436,15 @@ spec:
         - name: metering-spool
           emptyDir:
             sizeLimit: 64Mi
+        {{- end }}
+        {{- /* #3374: DSN Secret projected for the wait-for-sql-dsn initContainer. */ -}}
+        {{- $dsnGate := .Values.databaseDsnGate | default dict -}}
+        {{- if and (default true $dsnGate.enabled) .Values.cnpg.enabled }}
+        - name: sql-dsn-gate
+          secret:
+            secretName: {{ $effDbSecret }}
+            items:
+              - key: {{ $effDbKey }}
+                path: SQL_DSN
         {{- end }}
 {{- end }}

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -186,6 +186,24 @@ database:
   # (the contabo path historically did this via Crossplane).
   existingSecret: "" # operator-supplied (e.g. "newapi-db-dsn")
   existingSecretKey: "SQL_DSN"
+
+# ─── SQL_DSN readiness gate (#3374) ──────────────────────────────────────
+# An initContainer (wait-for-sql-dsn) that blocks the NewAPI container from
+# booting until the chart-emitted DSN Secret has a NON-EMPTY SQL_DSN. Without
+# it, the app boots on the placeholder empty DSN, silently falls back to an
+# EPHEMERAL SQLite DB (`SQL_DSN not set, using SQLite as database`), and never
+# reconnects to the correctly-seeded Postgres (the live #3374 newapi gap:
+# stuck at /setup because the SSO-seeded admin lives in PG, not the pod's
+# SQLite). Only renders when cnpg.enabled (operators wiring an external DB via
+# database.existingSecret populate the DSN up-front, so no gate is needed —
+# but it still passes immediately if they leave it on). Set enabled=false to
+# opt out entirely.
+databaseDsnGate:
+  enabled: true
+  image: "" # default harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1
+  timeoutSeconds: 300
+  intervalSeconds: 5
+
 # ─── CNPG-backed auto-provisioned Postgres (issue #943) ──────────────────
 # When enabled (DEFAULT true), the chart renders templates/cnpg-cluster.yaml:
 #   - postgresql.cnpg.io/v1.Cluster `<release>-newapi-pg`


### PR DESCRIPTION
## Problem (live on hw133, independent walk)
newapi's bare URL stays at the `/setup` 'System initialization' wizard even though HR 1.4.74 + the admin-seed are correct. The app booted with an **empty SQL_DSN** and silently fell back to an **ephemeral SQLite DB**:
```
[SYS] SQL_DSN not set, using SQLite as database
```
The chart-emitted DSN Secret renders `SQL_DSN: ""` as a placeholder; the `database-secret-sync-job` PATCHes the real Postgres DSN in AFTER CNPG is ready. The original design assumed an empty DSN would CrashLoop the pod until the DSN populated — but NewAPI treats **empty-DSN → SQLite as a valid happy path**, so the pod stays Running on SQLite forever, disconnected from the correctly-seeded Postgres (which has the setups row + the catalyst-root SSO user). Live proof: the DSN Secret is now populated, but the pod that started at 21:55:56 logged the SQLite fallback at 21:55:57 — it read the Secret before the sync-job patched it (env is fixed at container start).

## Fix
A `wait-for-sql-dsn` initContainer (new `databaseDsnGate` values) mounts the DSN Secret and blocks the main container until `SQL_DSN` is non-empty → NewAPI always initialises against Postgres. K8s refreshes the mounted Secret in place ~60s after the PATCH, so the gate clears without a manual restart. Gated on `cnpg.enabled` (operator external-DB via `database.existingSecret` populates up-front → gate passes immediately; **verified the initContainer is absent when cnpg.enabled=false**). 300s budget then fails loud rather than booting on SQLite.

## Validation
Strict-YAML render: no duplicate keys (won't trip the post-render); initContainer + secret volume + main SQL_DSN env all correct; gate correctly skipped for external DB. Chart **1.4.74 → 1.4.75** + blueprint.yaml + slot pin in lockstep.

## What the walker should see after reconcile
`newapi.hw133.omani.works` lands signed-in via SSO (no /setup wizard) — the app initialises against the seeded Postgres.

Refs #3374 #3455