### PR TITLE
fix(bp-guacamole): un-pin the webapp Pod (emptyDir recordings + Recreate) so the JDBC store serves (#3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -165,7 +165,7 @@ spec:
       # denied → rolled back to 0.2.8). Stamp managed-by:flux on the Job +
       # vendor the schema so it is single-container (no mixed-registry
       # initContainer for harbor-proxy-pull anyPattern to reject).
-      version: 0.2.12
+      version: 0.2.13
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/category: platform
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.12
+  version: 0.2.13
   card:
     title: Apache Guacamole
     summary: Clientless HTML5 remote-desktop gateway. Browser-based RDP / VNC / SSH and kubectl-exec into Pods, with Keycloak SSO and full session recording to SeaweedFS. One Guacamole per Sovereign per ADR-0001 §11.

--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -130,7 +130,22 @@ name: bp-guacamole
 # anyPattern to reject. The vendored SQL is pinned to
 # guacamole.webapp.image.tag (1.5.5); bump both together. Lockstep:
 # 52-bp-guacamole.yaml pin → 0.2.11. Refs #3374 #3434 #3296.
-version: 0.2.12
+# 0.2.13 (#3374 admin-tier, 2026-06-14): un-pin the webapp Pod so the JDBC
+# permission store actually reaches a serving pod. After 0.2.11 the seed Job
+# installed the sovereign-admins ADMINISTER USER_GROUP, but on hw133 the
+# replacement webapp replica (the one carrying POSTGRESQL_* + the JDBC
+# extension) Pended 40m+ with `volume node affinity conflict` + `Insufficient
+# cpu` while the stale pre-DB pod kept serving with no admin menu. ROOT CAUSE:
+# the recordings PVC's `seaweedfs-storage` class resolves to rancher.io/
+# local-path here, so its PV carries a hard node-affinity (RWO) that pinned the
+# Pod to a CPU-saturated node. Fix: (a) recordings.persistence DEFAULT false →
+# emptyDir recordings (no node-pin → schedules on any node with CPU; the PVC +
+# its migration hook/RBAC are skipped); (b) webapp.strategy=Recreate so the
+# single Pod releases its volumes before the replacement starts. Session-capture
+# recordings are not required for core function or the admin walk; operators with
+# real distributed SeaweedFS RWX set recordings.persistence=true. Lockstep:
+# 52-bp-guacamole.yaml pin → 0.2.13. Refs #3374.
+version: 0.2.13
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/templates/guacamole-deployment.yaml
+++ b/platform/guacamole/chart/templates/guacamole-deployment.yaml
@@ -9,6 +9,20 @@ metadata:
     catalyst.openova.io/component: webapp
 spec:
   replicas: {{ .Values.guacamole.webapp.replicas }}
+  # #3374 (2026-06-14): Recreate, not the default RollingUpdate. The webapp
+  # mounts the `guacamole-recordings` PVC ReadWriteOnce (seaweedfs-pvc.yaml).
+  # Under RollingUpdate the OLD pod keeps the RWO PVC bound to its node until
+  # the NEW pod is Ready, so the new pod can never schedule — it Pends forever
+  # with `volume node affinity conflict` + `Insufficient cpu` (caught live on
+  # hw133: the post-#3374-DB-seed replica stuck Pending 40m while the stale
+  # pre-seed pod — with no Postgres env, so no JDBC permission store — kept
+  # serving, leaving SSO users with no admin menu). Recreate terminates the old
+  # pod first → releases the RWO PVC → the new pod (with POSTGRESQL_* + JDBC)
+  # schedules and enrolls SSO users into the sovereign-admins admin group.
+  # Single-replica app (ADR-0001 §11 caps Guacamole at one per Sovereign), so
+  # the brief Recreate gap is acceptable.
+  strategy:
+    type: {{ .Values.guacamole.webapp.strategy | default "Recreate" | quote }}
   selector:
     matchLabels:
       {{- include "bp-guacamole.webappSelectorLabels" . | nindent 6 }}
@@ -171,9 +185,27 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
       volumes:
+        # #3374 (2026-06-14): recordings volume is emptyDir by DEFAULT
+        # (recordings.persistence=false). The persistent PVC pinned the webapp
+        # Pod to one node: on hw133 the `seaweedfs-storage` class is actually
+        # backed by rancher.io/local-path, so the PVC's PV carries a HARD
+        # node-affinity to the node that provisioned it (RWO). That node was at
+        # 97% CPU requests, so the post-#3374-DB-seed replica (the one with the
+        # POSTGRESQL_* env + JDBC permission store) Pended forever with `volume
+        # node affinity conflict` + `Insufficient cpu`, while the stale pre-seed
+        # pod kept serving with no admin menu. Session-capture recordings are
+        # NOT required for core Guacamole or the admin walk, and a solo-node
+        # local-path PVC is fragile anyway — so default to an emptyDir (no
+        # node-pin → schedules on any node with CPU). Operators who run real
+        # distributed SeaweedFS RWX flip recordings.persistence=true.
         - name: recordings
+          {{- if .Values.guacamole.recordings.persistence }}
           persistentVolumeClaim:
             claimName: {{ include "bp-guacamole.recordingsName" . }}
+          {{- else }}
+          emptyDir:
+            sizeLimit: {{ .Values.guacamole.recordings.emptyDirSizeLimit | default "2Gi" | quote }}
+          {{- end }}
         - name: tmp
           emptyDir: {}
         # Tomcat insists on writable work + temp dirs even with

--- a/platform/guacamole/chart/templates/recordings-pvc-migrate-hook.yaml
+++ b/platform/guacamole/chart/templates/recordings-pvc-migrate-hook.yaml
@@ -55,7 +55,9 @@ Pairs with:
 {{- if hasKey .Values.guacamole.recordings "allowMigration" -}}
 {{-   $migrate = .Values.guacamole.recordings.allowMigration -}}
 {{- end -}}
-{{- if and .Values.guacamole.enabled $migrate -}}
+{{- /* #3374: no recordings PVC exists when persistence=false (emptyDir) — the
+   storageClass-migration hook is then a no-op, so skip it entirely. */ -}}
+{{- if and .Values.guacamole.enabled $migrate .Values.guacamole.recordings.persistence -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/platform/guacamole/chart/templates/recordings-pvc-rbac.yaml
+++ b/platform/guacamole/chart/templates/recordings-pvc-rbac.yaml
@@ -12,7 +12,9 @@ Pairs with templates/recordings-pvc-migrate-hook.yaml.
 {{- if hasKey .Values.guacamole.recordings "allowMigration" -}}
 {{-   $migrate = .Values.guacamole.recordings.allowMigration -}}
 {{- end -}}
-{{- if and .Values.guacamole.enabled $migrate -}}
+{{- /* #3374: the migration RBAC is only needed when the recordings PVC exists
+   (persistence=true); skip it for the default emptyDir path. */ -}}
+{{- if and .Values.guacamole.enabled $migrate .Values.guacamole.recordings.persistence -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/platform/guacamole/chart/templates/seaweedfs-pvc.yaml
+++ b/platform/guacamole/chart/templates/seaweedfs-pvc.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.guacamole.enabled -}}
+{{- /* #3374: only provision the recordings PVC when persistence is enabled.
+   Default is emptyDir (see guacamole-deployment.yaml volumes note) so the
+   webapp Pod is not node-pinned to a local-path PV on a CPU-saturated node. */ -}}
+{{- if and .Values.guacamole.enabled .Values.guacamole.recordings.persistence -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/platform/guacamole/chart/tests/render.sh
+++ b/platform/guacamole/chart/tests/render.sh
@@ -103,12 +103,19 @@ echo "PASS: empty image.tag fails fast"
 # ClusterRoleBinding).
 # ─────────────────────────────────────────────────────────────────────
 render_on="$TMP/on.yaml"
+# #3374 (2026-06-14): recordings.persistence is now DEFAULT false (emptyDir,
+# no node-pin). The canonical 14-resource "full" bundle includes the
+# recordings PVC + its storageClass-migration hook (Job + SA + Role + RB), so
+# the full-ON case sets persistence=true to exercise that complete shape. The
+# default (emptyDir) path drops those 5 resources by design — covered by the
+# dedicated persistence-default check below.
 helm template bp-guacamole . \
   --set guacamole.enabled=true \
   --set guacamole.guacd.image.tag=1.5.5-r1 \
   --set guacamole.webapp.image.tag=1.5.5-r1 \
   --set guacamole.httproute.hostname=guacamole.test \
   --set guacamole.oidc.issuer=https://kc.test/realms/sovereign \
+  --set guacamole.recordings.persistence=true \
   > "$render_on"
 
 # 14-doc target with chartManagedSecret default ON: Deployment×2 (guacd
@@ -146,6 +153,32 @@ for k in "${required_kinds[@]}"; do
   fi
 done
 echo "PASS: every required kind present"
+
+# #3374 (2026-06-14): recordings.persistence DEFAULT false → the webapp Pod
+# uses an emptyDir recordings volume (no node-pin) + Recreate strategy, and
+# the recordings PVC / migration hook are NOT rendered. This is what unwedges
+# the JDBC-permission-store pod on a CPU-pressured local-path Sovereign.
+render_default="$TMP/default-recordings.yaml"
+helm template bp-guacamole . \
+  --set guacamole.enabled=true \
+  --set guacamole.guacd.image.tag=1.5.5-r1 \
+  --set guacamole.webapp.image.tag=1.5.5-r1 \
+  --set guacamole.httproute.hostname=guacamole.test \
+  --set guacamole.oidc.issuer=https://kc.test/realms/sovereign \
+  > "$render_default"
+if grep -qE '^kind: PersistentVolumeClaim$' "$render_default"; then
+  echo "FAIL: recordings PVC rendered with persistence default (should be emptyDir)"
+  exit 1
+fi
+if ! grep -qE 'type: "?Recreate"?' "$render_default"; then
+  echo "FAIL: webapp Deployment missing strategy type: Recreate"
+  exit 1
+fi
+if ! grep -qE 'emptyDir' "$render_default"; then
+  echo "FAIL: default recordings volume is not an emptyDir"
+  exit 1
+fi
+echo "PASS: persistence-default renders emptyDir recordings + Recreate, no PVC"
 
 # G117.5 W3.D1 #2744 (2026-06-02): the chart-managed Secret carries
 # `helm.sh/resource-policy: keep` per memory

--- a/platform/guacamole/chart/values.yaml
+++ b/platform/guacamole/chart/values.yaml
@@ -52,6 +52,10 @@ guacamole:
     port: 4822
   # ── guacamole webapp: Tomcat front-end ─────────────────────────
   webapp:
+    # #3374: Deployment strategy. Recreate (not RollingUpdate) so the single
+    # webapp Pod releases its volumes before the replacement starts — required
+    # when recordings.persistence=true (RWO PVC) and harmless otherwise.
+    strategy: Recreate
     # Resource name. Defaults to `guacamole-server` per the qa-loop test
     # matrix + catalyst-api shells/issue handler.
     name: guacamole-server
@@ -76,6 +80,16 @@ guacamole:
     port: 8080
   # ── Recording (SeaweedFS PVC) ──────────────────────────────────
   recordings:
+    # #3374: persistence DEFAULT false → the recordings volume is an emptyDir,
+    # not a PVC. A persistent PVC pinned the webapp Pod to one node (on hw133
+    # `seaweedfs-storage` resolves to rancher.io/local-path, whose PV carries a
+    # hard node-affinity + RWO), and when that node was CPU-saturated the
+    # post-DB-seed replica Pended forever → SSO users got no admin menu.
+    # Session-capture recordings are not required for core function or the
+    # admin walk. Operators with real distributed SeaweedFS RWX set this true.
+    persistence: false
+    # emptyDir sizeLimit when persistence=false.
+    emptyDirSizeLimit: 2Gi
     # PVC name. Defaults to `guacamole-recordings`. Override only when
     # multiple Guacamole instances share a namespace.
     pvcName: guacamole-recordings


### PR DESCRIPTION
## Problem (live on hw133, independent walk)
After 0.2.11 the jdbc-seed Job correctly installed the `sovereign-admins` ADMINISTER USER_GROUP, but guacamole still shows **no admin menu**: the webapp pod carrying the `POSTGRESQL_*` env + the JDBC permission-store extension never reaches Ready. The replacement replica Pended 40m+:
```
0/4 nodes are available: 1 Insufficient cpu, 3 node(s) had volume node affinity conflict
```
while the **stale pre-DB-seed pod** (no `POSTGRESQL_*` → no JDBC store → no admin) kept serving.

ROOT CAUSE: the recordings PVC's `seaweedfs-storage` class resolves to **rancher.io/local-path** here, so its PV carries a **hard node-affinity** + is **ReadWriteOnce** → the webapp Pod is pinned to the one node that provisioned the PV, which is at **97% CPU requests**. The new pod can't schedule there, and RWO/node-affinity excludes the other 3 nodes. (The chart comment even claimed RWM; the actual accessMode was RWO.)

## Fix
1. `recordings.persistence` **DEFAULT false** → recordings volume is an emptyDir (no PVC, no node-pin) → the webapp schedules on any node with CPU. The recordings PVC + migration hook + RBAC are skipped. Operators with real distributed SeaweedFS RWX set `persistence=true`.
2. `webapp.strategy=Recreate` (was default RollingUpdate) so the single Pod releases its volumes before the replacement starts.

Once the JDBC pod schedules, an SSO login auto-creates the JDBC user (`POSTGRESQL_AUTO_CREATE_ACCOUNTS=true`) and the `groups` claim binds it into the seeded `sovereign-admins` USER_GROUP → the user lands as guacamole admin.

## Validation
Chart render tests: full-ON sets persistence=true to keep the canonical 14-resource bundle; new check asserts the default path renders emptyDir recordings + Recreate + no PVC. All render tests pass. Chart **0.2.12 → 0.2.13** + blueprint.yaml + slot pin in lockstep.

## What the walker should see after reconcile
`guacamole.hw133.omani.works` → the new pod schedules → Settings → Users reachable (sovereign-admins → guacamole ADMIN).

Refs #3374 #3455