### PR TITLE
fix(bp-newapi): DSN-gate initContainer image must share the openova-io glob (#3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -210,7 +210,7 @@ spec:
       # the upgrade's pre-upgrade gate (and post-upgrade seed/channel/db-sync)
       # aren't denied by kyverno flux-managed Enforce → 1.4.68 rolled back to
       # 1.4.66 on hw133, leaving NewAPI uninitialized. Same class as openbao #3434.
-      version: 1.4.76
+      version: 1.4.77
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.76
+  version: 1.4.77
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -490,7 +490,16 @@ name: bp-newapi
 # blocks the main container until SQL_DSN is non-empty → NewAPI always
 # initialises against Postgres. Gated on cnpg.enabled. Lockstep: 80-newapi.yaml
 # pin → 1.4.75.
-version: 1.4.76
+# 1.4.77 (#3374 admin-tier, 2026-06-14): fix the kyverno denial 1.4.75's
+# DSN-gate introduced. The wait-for-sql-dsn initContainer used a
+# proxy-dockerhub/curl image while the main container is ghcr.io/openova-io/*;
+# the harbor-proxy-pull anyPattern needs ONE glob to match BOTH init + main, so
+# the mixed registries were DENIED (`/spec/template/spec/containers/0/image/` +
+# `initContainers/0/image/`) → bp-newapi 1.4.75 stuck Ready=False on hw133 (same
+# class as bp-guacamole #3461). Default the gate image to the NewAPI image
+# itself (has /bin/sh; same openova-io glob as the main container). Lockstep:
+# 80-newapi.yaml pin → 1.4.77.
+version: 1.4.77
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -122,9 +122,19 @@ spec:
       {{- $dsnGate := .Values.databaseDsnGate | default dict -}}
       {{- if and (default true $dsnGate.enabled) .Values.cnpg.enabled }}
       initContainers:
+        # Image defaults to the NewAPI image itself (same ghcr.io/openova-io/*
+        # glob as the main container). kyverno harbor-proxy-pull uses an
+        # anyPattern that requires ONE allowed glob to match BOTH the
+        # initContainers AND the containers of a workload — a curl image
+        # (proxy-dockerhub) mixed with the openova-io main image matches no
+        # single glob and is DENIED (the bp-guacamole jdbc-seed lesson, #3461;
+        # caught live on hw133 with bp-newapi 1.4.75). The NewAPI image has
+        # /bin/sh, so it runs the trivial file-poll gate. Operators override via
+        # databaseDsnGate.image with any image that also matches the glob +
+        # carries the ghcr-pull secret.
         - name: wait-for-sql-dsn
-          image: {{ $dsnGate.image | default "harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1" | quote }}
-          imagePullPolicy: IfNotPresent
+          image: {{ $dsnGate.image | default (printf "%s:%s" .Values.newapi.image.repository .Values.newapi.image.tag) | quote }}
+          imagePullPolicy: {{ .Values.newapi.image.pullPolicy | default "IfNotPresent" }}
           env:
             - name: DSN_GATE_TIMEOUT_SECONDS
               value: {{ $dsnGate.timeoutSeconds | default 300 | quote }}

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -199,7 +199,12 @@ database:
 # opt out entirely.
 databaseDsnGate:
   enabled: true
-  image: "" # default harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1
+  # Default: the NewAPI image itself (same ghcr.io/openova-io/* glob as the main
+  # container, so kyverno harbor-proxy-pull's anyPattern — which needs ONE glob
+  # to match BOTH init + main containers — passes; a curl/proxy-dockerhub image
+  # mixed with the openova-io main image matches no single glob and is denied,
+  # #3461). The image has /bin/sh, which is all the file-poll gate needs.
+  image: "" # default "<newapi.image.repository>:<newapi.image.tag>"
   timeoutSeconds: 300
   intervalSeconds: 5
 # ─── CNPG-backed auto-provisioned Postgres (issue #943) ──────────────────


### PR DESCRIPTION
## Problem (live on hw133)
bp-newapi **1.4.75** (the wait-for-sql-dsn DSN-gate from #3471) is DENIED, HR stuck Ready=False:
```
Deployment/newapi-bp-newapi blocked: harbor-proxy-pull:
... failed at path /spec/template/spec/containers/0/image/ ... initContainers/0/image/
```
The kyverno harbor-proxy-pull `anyPattern` needs ONE glob to match BOTH init + main containers. The DSN-gate initContainer used `proxy-dockerhub/curlimages/curl` (matches `*/proxy-*/*`) while the main NewAPI container is `ghcr.io/openova-io/...` (matches `*/openova-io/*`) — no single glob matches both → denied. **Exact class as the bp-guacamole jdbc-seed mix (#3461)**; the DSN-gate fix re-introduced it on a different chart.

## Fix
Default the gate image to the **NewAPI image itself** so both init + main share the `*/openova-io/*` glob. The NewAPI image has `/bin/sh` (all the file-poll gate needs). Operators override `databaseDsnGate.image` with any glob-matching image.

## Validation
`helm template`: init + main resolve to the same `ghcr.io/openova-io/openova/newapi-mirror` image (shared glob); strict-YAML render has no duplicate keys. Chart **1.4.76 → 1.4.77** + blueprint.yaml + slot pin in lockstep.

## What the walker should see after reconcile
bp-newapi HR reaches Ready; the new pod's wait-for-sql-dsn initContainer blocks until the PG DSN populates → NewAPI initialises on Postgres → bare URL lands signed-in (no /setup).

Refs #3374 #3455