### PR TITLE
fix(bp-guacamole): POSTGRESQL_USER env name (was POSTGRESQL_USERNAME) — JDBC pod crash-loop (#3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -165,7 +165,7 @@ spec:
       # denied → rolled back to 0.2.8). Stamp managed-by:flux on the Job +
       # vendor the schema so it is single-container (no mixed-registry
       # initContainer for harbor-proxy-pull anyPattern to reject).
-      version: 0.2.14
+      version: 0.2.15
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/category: platform
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.14
+  version: 0.2.15
   card:
     title: Apache Guacamole
     summary: Clientless HTML5 remote-desktop gateway. Browser-based RDP / VNC / SSH and kubectl-exec into Pods, with Keycloak SSO and full session recording to SeaweedFS. One Guacamole per Sovereign per ADR-0001 §11.

--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -145,7 +145,15 @@ name: bp-guacamole
 # recordings are not required for core function or the admin walk; operators with
 # real distributed SeaweedFS RWX set recordings.persistence=true. Lockstep:
 # 52-bp-guacamole.yaml pin → 0.2.13. Refs #3374.
-version: 0.2.14
+# 0.2.15 (#3374 admin-tier, 2026-06-14): fix the POSTGRESQL_USER env name. Once
+# 0.2.13 let the JDBC-enabled webapp pod schedule, it CRASH-LOOPED on hw133 with
+# `FATAL: Missing required environment variables ... POSTGRESQL_USER` — the
+# chart set POSTGRESQL_USERNAME, but the Apache Guacamole image entrypoint
+# requires POSTGRESQL_USER. With the wrong name the bundled JDBC extension never
+# connected → the permission store was unreachable → still no admin. Renamed to
+# the upstream-canonical POSTGRESQL_USER. Lockstep: 52-bp-guacamole.yaml pin →
+# 0.2.15. Refs #3374.
+version: 0.2.15
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/templates/guacamole-deployment.yaml
+++ b/platform/guacamole/chart/templates/guacamole-deployment.yaml
@@ -105,7 +105,16 @@ spec:
               value: "5432"
             - name: POSTGRESQL_DATABASE
               value: {{ $cl.database | default "guacamole_db" | quote }}
-            - name: POSTGRESQL_USERNAME
+            # #3374 (2026-06-14): the env var is POSTGRESQL_USER, NOT
+            # POSTGRESQL_USERNAME. The Apache Guacamole image entrypoint
+            # (guacamole-docker .../bin/start.sh) requires POSTGRESQL_USER and
+            # FATALs `Missing required environment variables ... POSTGRESQL_USER`
+            # otherwise — which is exactly how the JDBC-enabled webapp pod
+            # crash-looped the moment it finally scheduled on hw133 (the
+            # POSTGRESQL_USERNAME name never matched, so the bundled JDBC
+            # extension never connected and the permission store was unreachable
+            # → no admin). Fixed to the upstream-canonical POSTGRESQL_USER.
+            - name: POSTGRESQL_USER
               value: {{ $cl.owner | default "guacamole" | quote }}
             - name: POSTGRESQL_PASSWORD
               valueFrom:


### PR DESCRIPTION
## Problem (live on hw133)
Once #3472 (0.2.13) let the JDBC-enabled webapp pod actually **schedule**, it crash-looped (Error, 3 restarts):
```
FATAL: Missing required environment variables ... POSTGRESQL_USER
```
The chart set `POSTGRESQL_USERNAME`, but the Apache Guacamole image entrypoint requires **`POSTGRESQL_USER`**. With the wrong name the bundled `guacamole-auth-jdbc-postgresql` extension never connected → the permission store (sovereign-admins USER_GROUP + ADMINISTER, seeded by #3461) was unreachable → SSO users still got no admin menu. The bug was **latent** until now: the pre-0.2.13 serving pod predated the DB wiring entirely (no POSTGRESQL_* env), so the wrong name was never exercised.

## Fix
Rename to upstream-canonical `POSTGRESQL_USER`. The other POSTGRESQL_* vars already match the image's expected names.

## Validation
`helm template` confirms `POSTGRESQL_USER` renders; chart render tests green. Chart **0.2.14 → 0.2.15** + blueprint.yaml + slot pin in lockstep.

## What the walker should see after reconcile
The webapp pod stays Running (no crash); SSO login auto-creates the JDBC user and binds it into sovereign-admins → guacamole Settings → Users reachable as admin.

Refs #3374 #3455