### PR TITLE
feat(placement): re-home bp-valkey INTO the rtz vCluster — #3373 Batch A (1/3)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1024,7 +1024,8 @@ spec:
             # 1.4.617 — #3454: repo-bootstrap hook PAT via secretKeyRef (no cross-ns RBAC race; 1.4.616 was a deploy-bot sweep of the old hook).
             # 1.4.618 — deploy-bot auto pin-bump (no chart-content change; Refs TBD-A6).
             # 1.4.619 — #3374: baseline-default-deny allows ingress from the oidc-gate host ns → oidc-gate auth-proxy can reach openova-flow-server in catalyst-system (was dropped → SSO OK but app 502'd on upstream timeout; same class as sme→NATS #3423).
-      version: 1.4.620
+            # 1.4.621 — #3373 Batch A: SME valkey consumer + projector addr → rtz-vCluster syncer-mangled name (bp-valkey moved into rtz); valkey-cross-ns CNP disabled (rtz isolation netpol `sme` carve-out governs the wire).
+      version: 1.4.621
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/17-valkey.yaml
+++ b/clusters/_template/bootstrap-kit/17-valkey.yaml
@@ -10,14 +10,30 @@
 # Wrapper chart: platform/valkey/chart/
 # Catalyst-curated values: platform/valkey/chart/values.yaml
 # Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# ── #3373 Batch A — RTZ vCluster placement (every instance in its
+#    vCluster by data) ────────────────────────────────────────────────
+# valkey is the clean pure-OSS migration (no HTTPRoute, no
+# ExternalSecret, no CNPG Cluster CR — none of the Free-tier
+# `customResources` toHost-sync coupling). Its wire is plain Service DNS,
+# which the OSS `services` toHost sync already mirrors (proven live by
+# nats-jetstream/loki/mimir/tempo). The HR CR lives in host ns `rtz`
+# (where bp-rtz-vcluster slot 59 exports the vc-rtz kubeconfig Secret);
+# helm-controller resolves spec.kubeConfig.secretRef from the HR's own
+# namespace and installs the chart INSIDE the rtz vCluster.
+# targetNamespace/storageNamespace = the inner `valkey` namespace inside
+# the vCluster (storageNamespace pinned per the hw92 lesson). The
+# host-side Namespace YAML is dropped — createNamespace:true provisions
+# the inner `valkey` ns inside the vCluster.
+#
+# Host-side consumer (the SME control-plane services in host ns `sme`,
+# still host-placed in Batch A) re-points to the syncer-mangled Service
+# name `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc.cluster.local:6379`
+# — rewired in products/catalyst values (smeServices.valkey.host +
+# projector.valkey.addr). The rtz isolation netpol gains a `sme` carve-out
+# (bp-rtz-vcluster allowedIngressNamespaces) so that wire is admitted
+# after the move (mirrors the #3423 sme→NATS carve-out).
 
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: valkey
-  labels:
-    catalyst.openova.io/sovereign: SOVEREIGN_FQDN_PLACEHOLDER
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -35,16 +51,28 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-valkey
-  namespace: flux-system
+  namespace: rtz  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
+    catalyst.openova.io/vcluster: rtz
     catalyst.openova.io/slot: "17"
 spec:
   interval: 15m
   releaseName: valkey
   targetNamespace: valkey
+  storageNamespace: valkey
+  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
+  kubeConfig:
+    secretRef:
+      name: vc-rtz
+      key: config
   # Valkey is a self-contained cache — only needs Flux Ready.
   dependsOn:
+    # bp-rtz-vcluster MUST be Ready first — the vc-rtz
+    # Secret doesn't exist until then. placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+    - name: bp-rtz-vcluster
+      namespace: flux-system
     - name: bp-flux
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   chart:
     spec:
       chart: bp-valkey
@@ -67,6 +95,7 @@ spec:
         namespace: flux-system
   # Event-driven install per docs/INVIOLABLE-PRINCIPLES.md #3.
   install:
+    createNamespace: true  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     timeout: 15m
     disableWait: true
     remediation:

--- a/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
@@ -67,7 +67,9 @@ spec:
       # 0.2.7 (#3373 fix (b)): toHost customResources sync gains HTTPRoute + ExternalSecret.
       # 0.2.8 (#3380-D): k8s distro control-plane images pinned off
       # registry.k8s.io onto Harbor proxy-k8s (harbor-proxy-pull Enforce).
-      version: 0.2.8
+      # 0.2.9 (#3373 Batch A): `sme` carve-out in allowedIngressNamespaces
+      # so SME services reach the now-rtz-vCluster bp-valkey synced Service.
+      version: 0.2.9
       sourceRef:
         kind: HelmRepository
         name: bp-rtz-vcluster

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -189,7 +189,7 @@ spec:
     - {file: 16b-bp-cnpg-pair.yaml, hr: bp-cnpg-pair, vcluster: host, target: rtz, namespace: cnpg}
     - {file: 16c-bp-postgres-shared-b.yaml, hr: bp-postgres-shared-b, vcluster: host, target: rtz, namespace: shared-data}
     - {file: 16d-bp-postgres-shared-c.yaml, hr: bp-postgres-shared-c, vcluster: host, target: rtz, namespace: shared-data}
-    - {file: 17-valkey.yaml, hr: bp-valkey, vcluster: host, target: rtz, namespace: valkey}
+    - {file: 17-valkey.yaml, hr: bp-valkey, vcluster: rtz, target: rtz, namespace: valkey}   # Batch A (#3373) — PROMOTED: pure-OSS clean (no route/secret/CNPG); plain Service DNS via OSS services-sync
     - {file: 18-seaweedfs.yaml, hr: bp-seaweedfs, vcluster: host, target: rtz, namespace: seaweedfs}
     - {file: 19-harbor.yaml, hr: bp-harbor, vcluster: host, target: mgmt, namespace: harbor}
     - {file: 25-grafana.yaml, hr: bp-grafana, vcluster: host, target: mgmt, namespace: grafana}

--- a/platform/bp-rtz-vcluster/blueprint.yaml
+++ b/platform/bp-rtz-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.8
+  version: 0.2.9
   card:
     title: RTZ vCluster
     summary: |

--- a/platform/bp-rtz-vcluster/chart/Chart.yaml
+++ b/platform/bp-rtz-vcluster/chart/Chart.yaml
@@ -38,7 +38,15 @@ name: bp-rtz-vcluster
 # `registry.k8s.io/kube-*` — which the `harbor-proxy-pull` Enforce
 # ClusterPolicy DENIES on the next image roll. Additive values only.
 # Sibling to bp-mgmt-vcluster 0.2.8 + bp-dmz-vcluster 0.2.7.
-version: 0.2.8
+# 0.2.9 — Refs #3373 Batch A (2026-06-14): add `sme` to
+# networkPolicy.allowedIngressNamespaces. bp-valkey moved INTO this RTZ
+# vCluster; its host-synced Service now sits behind the `-isolation`
+# NetworkPolicy whose allow-list was {dmz, flux-system}. The host `sme`
+# namespace runs the BSS auth/gateway services that consume valkey via
+# VALKEY_ADDR — without this carve-out they fail to reach the synced
+# Service. Additive; mirrors the #3423 sme→NATS carve-out on
+# bp-mgmt-vcluster.
+version: 0.2.9
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign RTZ

--- a/platform/bp-rtz-vcluster/chart/values.yaml
+++ b/platform/bp-rtz-vcluster/chart/values.yaml
@@ -73,6 +73,16 @@ rtzVcluster:
       # …:443 i/o timeout") and never reconcile. flux-system is trusted
       # control-plane, so tenant isolation (world/other-tenants out) is intact. #3055
       - flux-system
+      # REQUIRED (#3373 Batch A, 2026-06-14): the host `sme` namespace runs
+      # the BSS control-plane services (auth/gateway via VALKEY_ADDR), which
+      # consume bp-valkey. #3373 placement moved bp-valkey INTO this RTZ
+      # vCluster, so its host-synced Service
+      # (valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc) now sits behind
+      # this isolation policy. Without this entry the SME auth/gateway
+      # services fail to reach valkey ("dial tcp …:6379 i/o timeout").
+      # Endpoints are healthy; the policy is the wall. Mirrors the #3423
+      # sme→NATS carve-out on bp-mgmt-vcluster.
+      - sme
     allowWorldIngress: false   # tenant pods never face world directly
 
 vcluster:

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2692,7 +2692,16 @@ name: bp-catalyst-platform
 # catalyst-gitea-token PAT as the GITEA_TOKEN env via secretKeyRef (same-ns,
 # kubelet-resolved at Pod start, no kubectl, no Role) and use token auth for
 # all Gitea calls. Drops the SA + gitea-ns Role/RoleBinding entirely.
-version: 1.4.620
+# 1.4.621 (#3373 Batch A, 2026-06-14): bp-valkey moved INSIDE the rtz
+# vCluster (placement.yaml). Rewire the SME valkey consumer + projector
+# addr to the syncer-mangled host Service name
+# `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc` (smeServices.valkey.host
+# + projector.valkey.addr); disable the now-moot valkey-cross-ns CNP (its
+# host `valkey` ns no longer carries the workload — the wire is governed by
+# the bp-rtz-vcluster isolation netpol's `sme` carve-out). Mirrors the
+# #3376 SME NATS_URL→synced-name move. Catalyst-Zero (no sovereignFQDN)
+# render byte-unchanged.
+version: 1.4.621
 # 1.4.597 — #3373 (2026-06-13) — coupling fix (a) placement-as-data:
 # templates/httproute.yaml backendRefs honor new
 # ingress.gateway.backendServiceApi / backendServiceUi overrides. When

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -785,7 +785,16 @@ services:
       stream: "catalyst.events"
       subject: "catalyst.events.>"
     valkey:
-      addr: "valkey-primary.valkey.svc.cluster.local:6379"
+      # #3373 Batch A (2026-06-14): bp-valkey moved INSIDE the rtz
+      # vCluster (placement.yaml: `bp-valkey → vcluster: rtz, namespace:
+      # valkey`). The bp-rtz-vcluster syncer reflects the in-vCluster
+      # `valkey-primary` Service to the HOST under the syncer-mangled
+      # name `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc`, so the host
+      # `valkey` namespace no longer carries a `valkey-primary` Service —
+      # the old `valkey-primary.valkey.svc` resolves NXDOMAIN. Align the
+      # projector addr to the synced name (lockstep with the nats.url move
+      # above). Override via this key for a host-placed valkey.
+      addr: "valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc.cluster.local:6379"
       username: ""
       # Optional Secret reference for the Valkey password.
       passwordSecret: {}
@@ -1374,15 +1383,25 @@ smeServices:
         cpu: 500m
         memory: 256Mi
   valkey:
-    # bp-valkey 1.0.0 (slot 17) deploys to namespace `valkey` with
-    # bitnami valkey 5.5.1 + architecture: replication. Service names:
-    #   - valkey-primary.valkey.svc.cluster.local (read/write)
-    #   - valkey-replicas.valkey.svc.cluster.local (read-only)
-    #   - valkey-headless.valkey.svc.cluster.local (StatefulSet headless)
-    # SME services pin to the primary by default so writes succeed; per-
-    # Sovereign overlays MAY split read traffic to -replicas via a
-    # second VALKEY_READ_ADDR (separate ticket).
-    host: valkey-primary.valkey.svc.cluster.local
+    # bp-valkey (slot 17) renders bitnami valkey 5.5.1 + architecture:
+    # replication. In-vCluster Service names (inner `valkey` ns):
+    #   - valkey-primary.valkey.svc (read/write)
+    #   - valkey-replicas.valkey.svc (read-only)
+    #   - valkey-headless.valkey.svc (StatefulSet headless)
+    #
+    # #3373 Batch A (2026-06-14): bp-valkey moved INSIDE the rtz vCluster
+    # (placement.yaml: `bp-valkey → vcluster: rtz, namespace: valkey`).
+    # The bp-rtz-vcluster syncer reflects the in-vCluster `valkey-primary`
+    # Service to the HOST under the syncer-mangled name
+    # `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc`, so the host
+    # `valkey` namespace no longer carries a `valkey-primary` Service. The
+    # SME control-plane services (host ns `sme`, still host-placed in
+    # Batch A) consume valkey across the vCluster boundary → pin to the
+    # synced name. SME services pin to the primary so writes succeed; per-
+    # Sovereign overlays MAY split read traffic to -replicas via a second
+    # VALKEY_READ_ADDR (separate ticket). Override `host` for a
+    # host-placed valkey.
+    host: valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc.cluster.local
     port: 6379
     namespace: valkey
     # ─── Cross-ns auth Secret mirror (issue #863) ──────────────────────
@@ -1402,11 +1421,18 @@ smeServices:
     crossNsPolicy:
       # Render templates/sme-services/valkey-cross-ns-policy.yaml — a
       # CiliumNetworkPolicy in the `valkey` namespace allowing ingress
-      # from the `sme` namespace on Valkey's port. Default true since
-      # the cross-ns wire is the canonical Sovereign topology. Disable
-      # via per-Sovereign overlay only when bp-valkey is repackaged
-      # into the `sme` namespace (rare).
-      enabled: true
+      # from the `sme` namespace on Valkey's port.
+      #
+      # #3373 Batch A (2026-06-14): DISABLED. bp-valkey moved INSIDE the
+      # rtz vCluster, so its pods are syncer-reflected into the HOST `rtz`
+      # namespace (the host `valkey` namespace no longer carries the
+      # workload). This CNP (endpointSelector in ns `valkey`) would select
+      # zero endpoints. The cross-ns wire is now governed by the
+      # bp-rtz-vcluster isolation NetworkPolicy, which carves out the `sme`
+      # namespace in allowedIngressNamespaces (mirrors the #3423 sme→NATS
+      # carve-out). Re-enable + override `namespace` only for a
+      # host-placed valkey.
+      enabled: false
       sourceNamespace: sme
   # ─── provisioning service GitHub token (issue #866) ──────────────────
   # The SME `provisioning` service Deployment references

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -275,7 +275,11 @@ slots:
     wave: W2.K1
   - slot: 17
     name: bp-valkey
-    depends_on: [bp-flux]
+    # #3373 Batch A (2026-06-14): bp-valkey moved INTO the rtz vCluster
+    # (placement.yaml) — the generator adds the bp-rtz-vcluster runtime edge
+    # (the vc-rtz Secret doesn't exist until that HR is Ready). Same pattern as
+    # loki/mimir/tempo declaring bp-mgmt-vcluster.
+    depends_on: [bp-flux, bp-rtz-vcluster]
     wave: W2.K1
   - slot: 18
     name: bp-seaweedfs


### PR DESCRIPTION
## What

**Batch A (1/3)** of the #3373 placement migration — *every instance in its vCluster by DATA*. Re-homes **bp-valkey → rtz** (the clean pure-OSS case). Per `docs/sessions/2026-06-14/3373-migration-plan.md` §0/§5/§8.

valkey is the migration with zero coupling: **no HTTPRoute, no ExternalSecret, no CNPG Cluster CR** — none of the vCluster `customResources` toHost-sync that loft.sh gates behind the **Free-tier platform tether** (the governing §0 constraint). valkey's wire is plain Service DNS, which the pure-OSS `services` toHost sync already mirrors (proven live by nats-jetstream/loki/mimir/tempo).

## Mechanism — placement is DATA, never code

1. Flip the valkey row in `clusters/_template/bootstrap-kit/placement.yaml`: `vcluster: host → rtz`.
2. `python3 scripts/render-slot-placement.py fix` — the generator stamps the slot's HR `namespace: rtz`, the `catalyst.openova.io/vcluster: rtz` label, `targetNamespace`/`storageNamespace: valkey` (inner ns), `spec.kubeConfig.secretRef → vc-rtz` (the **one** render pivot, G92.1), the `bp-rtz-vcluster` dependsOn runtime edge, and `install.createNamespace: true`.
3. Host-side Namespace YAML dropped (createNamespace provisions the inner ns inside the vCluster — same as loki).

**No hand-coded slot YAML** — every placement field is a pure function of placement.yaml.

## Consumer rewire (mirrors the proven #3376 SME NATS_URL→synced-name move, `27e57b3af`)

The SME control-plane services (host ns `sme`, still host-placed in Batch A) consume valkey **across the vCluster boundary**. After the move, the syncer reflects the in-vCluster `valkey-primary` Service to the host under the syncer-mangled name `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc`, so the old `valkey-primary.valkey.svc` resolves NXDOMAIN.

- `smeServices.valkey.host` + `projector.valkey.addr` → the synced name.
- `valkey-cross-ns` CNP **disabled** (its host `valkey` ns no longer carries the workload; the wire is now governed by the rtz isolation netpol's `sme` carve-out).

## Netpol carve-out (mirrors the #3423 sme→NATS carve-out)

Add `sme` to `bp-rtz-vcluster` `networkPolicy.allowedIngressNamespaces` (was `{dmz, flux-system}`) so the SME auth/gateway services are admitted to the synced Service through the `-isolation` NetworkPolicy.

## Chart bumps + kit pins (lockstep)

| Chart | bump | kit slot |
|---|---|---|
| `bp-rtz-vcluster` | 0.2.8 → 0.2.9 | 59 |
| `bp-catalyst-platform` | 1.4.620 → 1.4.621 | 13 |

`bp-valkey` chart unchanged (placement move only; pin stays 1.1.2).

## Verification (local — independent walker validates on the keystone fresh-prov)

- `render-slot-placement.py check` **PASSED** — 7 in vClusters (valkey joined), 19 staged.
- `check-bootstrap-kit-pin-sync.sh` **PASS** — all pins in sync.
- rtz `-isolation` NetworkPolicy renders the `sme` carve-out (alongside dmz, flux-system).
- Under a sovereignFQDN, `VALKEY_ADDR` resolves to `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc.cluster.local:6379`.
- valkey-cross-ns CNP **absent** from the render.
- **Catalyst-Zero render byte-unchanged** (only `randAlphaNum` secret values differ between invocations — expected).
- `TestBootstrapKit_TemplateClusterParses` **ok**.

Live expectation after Flux reconcile on hw133: valkey pods appear as `*-x-valkey-x-rtz-vcluster` in the **rtz** host namespace; SME `sme`-ns consumers still reach valkey.

Refs #3373

🤖 Generated with [Claude Code](https://claude.com/claude-code)