### PR TITLE
feat(placement): re-home bp-seaweedfs INTO the rtz vCluster — #3373 Batch A (2/3)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -77,7 +77,8 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.37
+      # 1.2.38 (#3373 Batch A): snapshot-replication s3 endpoint default → rtz-vCluster synced name (seaweedfs moved into rtz).
+      version: 1.2.38
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -131,7 +131,8 @@ spec:
       # + gateway /user/login -> OIDC entry redirect.
       # 1.2.30: explicit port 443 on the SSO redirect (the #3310 class).
       # 1.2.31: LANDING_PAGE=login — anon root funnels into OIDC.
-      version: 1.2.34
+      # 1.2.35 (#3373 Batch A): objectStorage S3+filer endpoint defaults → rtz-vCluster synced name (seaweedfs moved into rtz).
+      version: 1.2.35
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1025,7 +1025,8 @@ spec:
             # 1.4.618 — deploy-bot auto pin-bump (no chart-content change; Refs TBD-A6).
             # 1.4.619 — #3374: baseline-default-deny allows ingress from the oidc-gate host ns → oidc-gate auth-proxy can reach openova-flow-server in catalyst-system (was dropped → SSO OK but app 502'd on upstream timeout; same class as sme→NATS #3423).
             # 1.4.621 — #3373 Batch A: SME valkey consumer + projector addr → rtz-vCluster syncer-mangled name (bp-valkey moved into rtz); valkey-cross-ns CNP disabled (rtz isolation netpol `sme` carve-out governs the wire).
-      version: 1.4.622
+            # 1.4.623 — #3373 Batch A: qa-fixtures CNPG barman backup endpoint default → rtz-vCluster synced seaweedfs-s3 name (seaweedfs moved into rtz; 1.4.622 was a content-free deploy-bot sweep).
+      version: 1.4.623
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/18-seaweedfs.yaml
+++ b/clusters/_template/bootstrap-kit/18-seaweedfs.yaml
@@ -15,14 +15,37 @@
 # Wrapper chart: platform/seaweedfs/chart/
 # Catalyst-curated values: platform/seaweedfs/chart/values.yaml
 # Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# ── #3373 Batch A — RTZ vCluster placement (every instance in its
+#    vCluster by data) ────────────────────────────────────────────────
+# seaweedfs is a clean pure-OSS migration: no HTTPRoute, no
+# ExternalSecret, no CNPG Cluster CR — none of the Free-tier
+# `customResources` toHost-sync coupling. Its S3 wire is plain Service
+# DNS, which the OSS `services` toHost sync already mirrors. Critically,
+# EVERY seaweedfs S3 consumer is DEFAULT-OFF / overlay-injected on a
+# fresh prov: gitea objectStorage.enabled=false (blobs on local PVC),
+# harbor imageChartStorage.type=filesystem, loki/mimir/tempo default to
+# filesystem storage (S3 is per-Sovereign overlay), velero
+# provider/bucket/s3Url empty, openbao snapshot-replication off. So the
+# base render breaks no active wire — the move is byte-clean.
+#
+# The HR CR lives in host ns `rtz` (where bp-rtz-vcluster slot 59 exports
+# the vc-rtz kubeconfig Secret); helm-controller installs the chart INSIDE
+# the rtz vCluster. targetNamespace/storageNamespace = the inner
+# `seaweedfs` namespace (storageNamespace pinned per the hw92 lesson).
+# Host-side Namespace YAML dropped — createNamespace:true provisions the
+# inner ns. PVCs (master/volume/filer) sync host-side via the OSS
+# persistentVolumeClaims toHost sync (already enabled in rtz values).
+#
+# Consumer DEFAULT endpoint strings rewired to the syncer-mangled host
+# Service name `seaweedfs-s3-x-seaweedfs-x-rtz-vcluster.rtz.svc:8333`
+# (+ filer `seaweedfs-filer-x-seaweedfs-x-rtz-vcluster.rtz.svc:8888`) in
+# gitea + openbao + catalyst qa-fixtures, so an operator flipping those
+# consumers ON post-move points at the right place. The rtz isolation
+# netpol gains carve-outs (gitea, harbor, catalyst-system, mgmt, velero)
+# so those host consumers reach the synced Service after the move
+# (mirrors the #3423 sme→NATS carve-out).
 
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: seaweedfs
-  labels:
-    catalyst.openova.io/sovereign: SOVEREIGN_FQDN_PLACEHOLDER
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -40,20 +63,33 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-seaweedfs
-  namespace: flux-system
+  namespace: rtz  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
+    catalyst.openova.io/vcluster: rtz
     catalyst.openova.io/slot: "18"
 spec:
   interval: 15m
   releaseName: seaweedfs
   targetNamespace: seaweedfs
+  storageNamespace: seaweedfs
+  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
+  kubeConfig:
+    secretRef:
+      name: vc-rtz
+      key: config
   # SeaweedFS depends on:
   #   - bp-flux(03): standard GitOps prerequisite.
   #   - bp-cert-manager(02): the S3 Filer endpoint terminates TLS via a
   #     Certificate the chart requests from the cluster ClusterIssuer.
   dependsOn:
+    # bp-rtz-vcluster MUST be Ready first — the vc-rtz
+    # Secret doesn't exist until then. placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+    - name: bp-rtz-vcluster
+      namespace: flux-system
     - name: bp-flux
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-cert-manager
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   chart:
     spec:
       chart: bp-seaweedfs
@@ -69,6 +105,7 @@ spec:
         namespace: flux-system
   # Event-driven install per docs/INVIOLABLE-PRINCIPLES.md #3.
   install:
+    createNamespace: true  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     timeout: 15m
     disableWait: true
     remediation:

--- a/clusters/_template/bootstrap-kit/22-loki.yaml
+++ b/clusters/_template/bootstrap-kit/22-loki.yaml
@@ -100,7 +100,7 @@ spec:
     # #2745: explicit namespace — a bare `name:` resolves in THIS HR's
     # namespace (now `mgmt`) → dangling dep → wedge (#3191 shape).
     - name: bp-seaweedfs
-      namespace: flux-system
+      namespace: rtz
   chart:
     spec:
       chart: bp-loki

--- a/clusters/_template/bootstrap-kit/23-mimir.yaml
+++ b/clusters/_template/bootstrap-kit/23-mimir.yaml
@@ -102,7 +102,7 @@ spec:
     # #2745: explicit namespace — a bare `name:` resolves in THIS HR's
     # namespace (now `mgmt`) → dangling dep → wedge (#3191 shape).
     - name: bp-seaweedfs
-      namespace: flux-system
+      namespace: rtz
   chart:
     spec:
       chart: bp-mimir

--- a/clusters/_template/bootstrap-kit/24-tempo.yaml
+++ b/clusters/_template/bootstrap-kit/24-tempo.yaml
@@ -96,7 +96,7 @@ spec:
     # #2745: explicit namespace — a bare `name:` resolves in THIS HR's
     # namespace (now `mgmt`) → dangling dep → wedge (#3191 shape).
     - name: bp-seaweedfs
-      namespace: flux-system
+      namespace: rtz
   chart:
     spec:
       chart: bp-tempo

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -81,6 +81,7 @@ spec:
       namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-sealed-secrets
     - name: bp-seaweedfs
+      namespace: rtz  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-k8s-ws-proxy
     # #3374 — bp-guacamole now ships a CNPG Cluster CR for its JDBC
     # permission store (admin elevation). bp-cnpg (slot 16) registers the

--- a/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
@@ -69,7 +69,9 @@ spec:
       # registry.k8s.io onto Harbor proxy-k8s (harbor-proxy-pull Enforce).
       # 0.2.9 (#3373 Batch A): `sme` carve-out in allowedIngressNamespaces
       # so SME services reach the now-rtz-vCluster bp-valkey synced Service.
-      version: 0.2.9
+      # 0.2.10 (#3373 Batch A): gitea/harbor/catalyst-system/mgmt/velero carve-outs
+      # in allowedIngressNamespaces so seaweedfs S3 consumers reach the now-rtz-vCluster synced Service.
+      version: 0.2.10
       sourceRef:
         kind: HelmRepository
         name: bp-rtz-vcluster

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -190,7 +190,7 @@ spec:
     - {file: 16c-bp-postgres-shared-b.yaml, hr: bp-postgres-shared-b, vcluster: host, target: rtz, namespace: shared-data}
     - {file: 16d-bp-postgres-shared-c.yaml, hr: bp-postgres-shared-c, vcluster: host, target: rtz, namespace: shared-data}
     - {file: 17-valkey.yaml, hr: bp-valkey, vcluster: rtz, target: rtz, namespace: valkey}   # Batch A (#3373) — PROMOTED: pure-OSS clean (no route/secret/CNPG); plain Service DNS via OSS services-sync
-    - {file: 18-seaweedfs.yaml, hr: bp-seaweedfs, vcluster: host, target: rtz, namespace: seaweedfs}
+    - {file: 18-seaweedfs.yaml, hr: bp-seaweedfs, vcluster: rtz, target: rtz, namespace: seaweedfs}   # Batch A (#3373) — PROMOTED: pure-OSS clean (no route/secret/CNPG); S3 wire is plain Service DNS via OSS services-sync; all consumers S3-default-OFF on a fresh prov
     - {file: 19-harbor.yaml, hr: bp-harbor, vcluster: host, target: mgmt, namespace: harbor}
     - {file: 25-grafana.yaml, hr: bp-grafana, vcluster: host, target: mgmt, namespace: grafana}
     - {file: 39-bp-vllm.yaml, hr: bp-vllm, vcluster: host, target: rtz, namespace: vllm}

--- a/platform/bp-rtz-vcluster/blueprint.yaml
+++ b/platform/bp-rtz-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.9
+  version: 0.2.10
   card:
     title: RTZ vCluster
     summary: |

--- a/platform/bp-rtz-vcluster/chart/Chart.yaml
+++ b/platform/bp-rtz-vcluster/chart/Chart.yaml
@@ -46,7 +46,13 @@ name: bp-rtz-vcluster
 # VALKEY_ADDR — without this carve-out they fail to reach the synced
 # Service. Additive; mirrors the #3423 sme→NATS carve-out on
 # bp-mgmt-vcluster.
-version: 0.2.9
+# 0.2.10 — Refs #3373 Batch A (2026-06-14): add gitea/harbor/catalyst-system/
+# mgmt/velero to networkPolicy.allowedIngressNamespaces. bp-seaweedfs moved
+# INTO this RTZ vCluster; its host-synced S3 Service now sits behind the
+# `-isolation` NetworkPolicy. These host namespaces run seaweedfs S3 consumers
+# (all default-OFF on a fresh prov; the carve-out admits the wire once an
+# operator enables S3 post-move). Additive; mirrors the #3423 carve-out.
+version: 0.2.10
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign RTZ

--- a/platform/bp-rtz-vcluster/chart/values.yaml
+++ b/platform/bp-rtz-vcluster/chart/values.yaml
@@ -83,6 +83,23 @@ rtzVcluster:
       # Endpoints are healthy; the policy is the wall. Mirrors the #3423
       # sme→NATS carve-out on bp-mgmt-vcluster.
       - sme
+      # REQUIRED (#3373 Batch A, 2026-06-14): bp-seaweedfs moved INTO this
+      # RTZ vCluster. Its host-synced S3 Service
+      # (seaweedfs-s3-x-seaweedfs-x-rtz-vcluster.rtz.svc:8333) now sits
+      # behind this isolation policy. These host namespaces run seaweedfs
+      # S3 consumers (all DEFAULT-OFF on a fresh prov; the carve-out admits
+      # the wire once an operator enables S3 post-move):
+      #   - gitea           → Git LFS/attachment blob storage (objectStorage)
+      #   - harbor          → registry image/chart blob storage (imageChartStorage s3)
+      #   - catalyst-system → guacamole session recordings; cnpg barman backups
+      #   - mgmt            → loki/mimir/tempo S3 chunk/block storage (already in mgmt vCluster)
+      #   - velero          → cluster backup target
+      # Mirrors the #3423 sme→NATS carve-out on bp-mgmt-vcluster.
+      - gitea
+      - harbor
+      - catalyst-system
+      - mgmt
+      - velero
     allowWorldIngress: false   # tenant pods never face world directly
 
 vcluster:

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.34
+  version: 1.2.35
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -108,7 +108,12 @@ name: bp-gitea
 # the bootstrap-kit slot 10 `SOVEREIGN_GITEA_PG_SECRET` seam (own-cluster
 # default gitea-pg-app → SHARED gitea-database-secret). own-cluster render
 # byte-identical to 1.2.26.
-version: 1.2.34
+# 1.2.35 — Refs #3373 Batch A (2026-06-14): bp-seaweedfs moved INTO the rtz
+# vCluster; rewire the objectStorage S3 + filer endpoint DEFAULTS to the
+# syncer-mangled host Service name (seaweedfs-s3-x-seaweedfs-x-rtz-vcluster.rtz.svc).
+# objectStorage.enabled is default-OFF, so the single-region/Catalyst-Zero render
+# is byte-identical (the defaults apply only when an operator enables S3).
+version: 1.2.35
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/objectstorage-config.yaml
+++ b/platform/gitea/chart/templates/objectstorage-config.yaml
@@ -51,7 +51,7 @@ data:
   # credential entries as secretKeyRef against {{ $secret }}). Gitea reads
   # GITEA__storage__* at init and writes the [storage] app.ini section.
   GITEA__storage__STORAGE_TYPE: {{ $os.storageType | default "minio" | quote }}
-  GITEA__storage__MINIO_ENDPOINT: {{ $os.endpoint | default "seaweedfs-s3.seaweedfs.svc.cluster.local:8333" | quote }}
+  GITEA__storage__MINIO_ENDPOINT: {{ $os.endpoint | default "seaweedfs-s3-x-seaweedfs-x-rtz-vcluster.rtz.svc.cluster.local:8333" | quote }}
   GITEA__storage__MINIO_BUCKET: {{ $os.bucket | default "gitea-blobs" | quote }}
   GITEA__storage__MINIO_BASE_PATH: {{ $os.basePath | default "gitea" | quote }}
   GITEA__storage__MINIO_LOCATION: {{ $os.location | default "us-east-1" | quote }}

--- a/platform/gitea/chart/templates/objectstorage-mirror.yaml
+++ b/platform/gitea/chart/templates/objectstorage-mirror.yaml
@@ -110,7 +110,7 @@ spec:
             - name: REMOTE_ENDPOINT
               value: {{ .Values.objectStorage.mirror.remoteEndpoint | default "" | quote }}
             - name: FILER_ENDPOINT
-              value: {{ .Values.objectStorage.mirror.filerEndpoint | default "seaweedfs-filer.seaweedfs.svc.cluster.local:8888" | quote }}
+              value: {{ .Values.objectStorage.mirror.filerEndpoint | default "seaweedfs-filer-x-seaweedfs-x-rtz-vcluster.rtz.svc.cluster.local:8888" | quote }}
             - name: BUCKET
               value: {{ .Values.objectStorage.bucket | default "gitea-blobs" | quote }}
             - name: LOCATION

--- a/platform/gitea/chart/tests/objectstorage-dr-wiring.sh
+++ b/platform/gitea/chart/tests/objectstorage-dr-wiring.sh
@@ -19,7 +19,8 @@
 #   1. default: NO object-storage env, NO reflected Secret, NO config ConfigMap,
 #      NO mirror Deployment.
 #   2. enabled (objectStorage.enabled=true): config ConfigMap has
-#      STORAGE_TYPE=minio pointing at seaweedfs-s3.seaweedfs.svc:8333 +
+#      STORAGE_TYPE=minio pointing at the rtz-vCluster synced
+#      seaweedfs-s3-x-seaweedfs-x-rtz-vcluster.rtz.svc:8333 (#3373 Batch A) +
 #      reflected Secret renders; mirror still OFF (its own gate).
 #   3. enabled + mirror (primary side, remoteEndpoint set): mirror Deployment
 #      renders with weed filer.remote.sync.
@@ -54,7 +55,9 @@ grep -q 'name: gitea-objectstorage-mirror' "$tmp/default.yaml" \
 echo "  PASS"
 
 # ── Case 2: object storage ENABLED (mirror still off) ───────────────────
-echo "[objectstorage-dr] Case 2: enabled → STORAGE_TYPE=minio @ seaweedfs-s3:8333 + reflected Secret"
+# #3373 Batch A: seaweedfs moved INTO the rtz vCluster, so the canonical S3
+# endpoint is the syncer-mangled host Service name.
+echo "[objectstorage-dr] Case 2: enabled → STORAGE_TYPE=minio @ rtz-vCluster synced seaweedfs-s3:8333 + reflected Secret"
 "$helm" template smoke "$chart_dir" \
   --set objectStorage.enabled=true \
   --api-versions postgresql.cnpg.io/v1 \
@@ -63,8 +66,8 @@ echo "[objectstorage-dr] Case 2: enabled → STORAGE_TYPE=minio @ seaweedfs-s3:8
 # config ConfigMap: STORAGE_TYPE=minio pointing at the canonical S3 endpoint
 grep -q 'GITEA__storage__STORAGE_TYPE: "minio"' "$tmp/on.yaml" \
   || fail "enabled: STORAGE_TYPE must be minio"
-grep -q 'GITEA__storage__MINIO_ENDPOINT: "seaweedfs-s3.seaweedfs.svc.cluster.local:8333"' "$tmp/on.yaml" \
-  || fail "enabled: MINIO_ENDPOINT must be the canonical seaweedfs-s3:8333 Service"
+grep -q 'GITEA__storage__MINIO_ENDPOINT: "seaweedfs-s3-x-seaweedfs-x-rtz-vcluster.rtz.svc.cluster.local:8333"' "$tmp/on.yaml" \
+  || fail "enabled: MINIO_ENDPOINT must be the rtz-vCluster synced seaweedfs-s3:8333 Service (#3373 Batch A)"
 grep -q 'GITEA__storage__MINIO_BUCKET: "gitea-blobs"' "$tmp/on.yaml" \
   || fail "enabled: MINIO_BUCKET must be gitea-blobs"
 # reflected Secret bridges the cross-namespace seaweedfs-s3-secret

--- a/platform/gitea/chart/values.yaml
+++ b/platform/gitea/chart/values.yaml
@@ -401,9 +401,14 @@ objectStorage:
   storageType: minio
   # Canonical SeaweedFS S3 endpoint (host:port, NO scheme — Gitea's
   # MINIO_ENDPOINT expects host:port and toggles TLS via MINIO_USE_SSL).
-  # Matches platform/seaweedfs/chart/values.yaml s3 block (Service
-  # seaweedfs-s3, ClusterIP, port 8333) per docs/PLATFORM-TECH-STACK.md §3.5.
-  endpoint: seaweedfs-s3.seaweedfs.svc.cluster.local:8333
+  # #3373 Batch A (2026-06-14): bp-seaweedfs moved INSIDE the rtz vCluster
+  # (placement.yaml). The bp-rtz-vcluster syncer reflects the in-vCluster
+  # `seaweedfs-s3` Service to the HOST under the mangled name below, so the
+  # old `seaweedfs-s3.seaweedfs.svc` resolves NXDOMAIN. gitea is host-placed
+  # in Batch A and objectStorage is default-OFF — this default applies only
+  # when an operator flips objectStorage.enabled=true; align it to the synced
+  # name now. Override `endpoint` for a host-placed seaweedfs.
+  endpoint: seaweedfs-s3-x-seaweedfs-x-rtz-vcluster.rtz.svc.cluster.local:8333
   # Bucket that holds gitea's blob-class data. Created on first write by the
   # MinIO driver (Gitea auto-creates the bucket if MINIO_BUCKET is absent).
   bucket: gitea-blobs
@@ -475,7 +480,10 @@ objectStorage:
     remoteSecretAccessKeyKey: admin_secret_access_key
     # SeaweedFS filer the mirror sidecar talks to for the remote.configure /
     # remote.sync gRPC calls. Defaults to the in-cluster filer Service.
-    filerEndpoint: seaweedfs-filer.seaweedfs.svc.cluster.local:8888
+    # #3373 Batch A: seaweedfs moved into the rtz vCluster → the host-synced
+    # filer Service is the mangled name below. mirror.enabled is default-OFF;
+    # this applies only when the cross-region mirror is enabled post-move.
+    filerEndpoint: seaweedfs-filer-x-seaweedfs-x-rtz-vcluster.rtz.svc.cluster.local:8888
     # Container image for the `weed` CLI. Pulled through the Harbor
     # proxy-cache per CLAUDE.md inviolable rule (bare upstream refs are
     # denied by kyverno harbor-proxy-pull on a converged env).

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.37
+  version: 1.2.38
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -26,7 +26,11 @@ name: bp-openbao
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
-version: 1.2.37
+# 1.2.38 — Refs #3373 Batch A (2026-06-14): bp-seaweedfs moved INTO the rtz
+# vCluster; rewire the snapshot-replication s3 endpoint DEFAULT to the
+# syncer-mangled host Service name. snapshotReplication is default-OFF, so the
+# single-region render is byte-identical (the default applies only when enabled).
+version: 1.2.38
 # 1.2.37 (#3374, 2026-06-14): fix the sso-landing nginx ImagePullBackOff. The
 # image was `harbor.openova.io/proxy-docker/library/nginx` but the live Harbor
 # DockerHub proxy-cache project is `proxy-dockerhub` (proxy-docker does NOT

--- a/platform/openbao/chart/templates/snapshot-replication.yaml
+++ b/platform/openbao/chart/templates/snapshot-replication.yaml
@@ -64,7 +64,8 @@ objects). The primary vs secondary CronJob is selected by
 {{- $authMount := $kAuth.mountPath | default "kubernetes" -}}
 {{- $authRole := $kAuth.role | default "openbao-snapshot" -}}
 {{- $s3 := $sr.s3 | default dict -}}
-{{- $s3Endpoint := $s3.endpoint | default "http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333" -}}
+{{- /* #3373 Batch A: seaweedfs moved into the rtz vCluster → synced host Service name. */ -}}
+{{- $s3Endpoint := $s3.endpoint | default "http://seaweedfs-s3-x-seaweedfs-x-rtz-vcluster.rtz.svc.cluster.local:8333" -}}
 {{- $s3Bucket := $s3.bucket | default "openbao-snapshots" -}}
 {{- $s3Region := $s3.region | default "us-east-1" -}}
 {{- $credSecret := $s3.credentialsSecret | default dict -}}

--- a/platform/openbao/chart/values.yaml
+++ b/platform/openbao/chart/values.yaml
@@ -365,7 +365,11 @@ snapshotReplication:
   # access/secret keys), the same Secret bp-cnpg barman backups consume.
   s3:
     # S3 API endpoint. Default = canonical SeaweedFS S3 Service FQDN.
-    endpoint: "http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333"
+    # #3373 Batch A (2026-06-14): bp-seaweedfs moved INSIDE the rtz vCluster;
+    # the host-synced S3 Service carries the syncer-mangled name below.
+    # snapshot-replication is default-OFF — this applies only when an operator
+    # enables it post-move. Override `endpoint` for a host-placed seaweedfs.
+    endpoint: "http://seaweedfs-s3-x-seaweedfs-x-rtz-vcluster.rtz.svc.cluster.local:8333"
     # Bucket the snapshots live in. The primary uploads here; the secondary
     # fetches the latest object from here.
     bucket: openbao-snapshots

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2701,7 +2701,12 @@ name: bp-catalyst-platform
 # the bp-rtz-vcluster isolation netpol's `sme` carve-out). Mirrors the
 # #3376 SME NATS_URL→synced-name move. Catalyst-Zero (no sovereignFQDN)
 # render byte-unchanged.
-version: 1.4.622
+# 1.4.623 (#3373 Batch A, 2026-06-14): bp-seaweedfs moved INSIDE the rtz
+# vCluster. Rewire the qa-fixtures CNPG barman backup endpoint default
+# (qaFixtures.cnpgBackupEndpointURL + cnpg-clusters-qa.yaml) to the
+# syncer-mangled host Service name. qa-fixtures only; Catalyst-Zero render
+# byte-unchanged. (1.4.622 was a content-free deploy-bot image sweep.)
+version: 1.4.623
 # 1.4.597 — #3373 (2026-06-13) — coupling fix (a) placement-as-data:
 # templates/httproute.yaml backendRefs honor new
 # ingress.gateway.backendServiceApi / backendServiceUi overrides. When

--- a/products/catalyst/chart/templates/qa-fixtures/cnpg-clusters-qa.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/cnpg-clusters-qa.yaml
@@ -266,7 +266,7 @@ spec:
   backup:
     barmanObjectStore:
       destinationPath: {{ printf "s3://%s/cluster-primary" (.Values.qaFixtures.cnpgBackupBucket | default "qa-fixtures") | quote }}
-      endpointURL: {{ .Values.qaFixtures.cnpgBackupEndpointURL | default "http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333" | quote }}
+      endpointURL: {{ .Values.qaFixtures.cnpgBackupEndpointURL | default "http://seaweedfs-s3-x-seaweedfs-x-rtz-vcluster.rtz.svc.cluster.local:8333" | quote }}
       s3Credentials:
         accessKeyId:
           name: {{ .Values.qaFixtures.cnpgBackupS3SecretName | default "qa-cnpg-backup-s3" | quote }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1812,7 +1812,10 @@ qaFixtures:
   # qa-omantel namespace so cluster-primary's spec.backup resolves.
   # Override these for off-cluster S3 (R2 / B2 / native AWS).
   cnpgBackupBucket: qa-fixtures
-  cnpgBackupEndpointURL: http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333
+  # #3373 Batch A (2026-06-14): bp-seaweedfs moved INSIDE the rtz vCluster →
+  # the host-synced S3 Service carries the syncer-mangled name below (qa-fixtures
+  # only; override for off-cluster S3).
+  cnpgBackupEndpointURL: http://seaweedfs-s3-x-seaweedfs-x-rtz-vcluster.rtz.svc.cluster.local:8333
   cnpgBackupS3SecretName: qa-cnpg-backup-s3
   cnpgBackupSourceSecretNamespace: seaweedfs
   cnpgBackupSourceSecretName: seaweedfs-s3-secret

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -283,7 +283,11 @@ slots:
     wave: W2.K1
   - slot: 18
     name: bp-seaweedfs
-    depends_on: [bp-flux, bp-cert-manager]
+    # #3373 Batch A (2026-06-14): bp-seaweedfs moved INTO the rtz vCluster
+    # (placement.yaml) — the generator adds the bp-rtz-vcluster runtime edge
+    # (the vc-rtz Secret doesn't exist until that HR is Ready). Same pattern as
+    # loki/mimir/tempo declaring bp-mgmt-vcluster.
+    depends_on: [bp-flux, bp-cert-manager, bp-rtz-vcluster]
     wave: W2.K1
   - slot: 19
     name: bp-harbor


### PR DESCRIPTION
## What

**Batch A (2/3)** of the #3373 placement migration — *every instance in its vCluster by DATA*. Re-homes **bp-seaweedfs → rtz**. Per `docs/sessions/2026-06-14/3373-migration-plan.md` §0/§5/§8.

seaweedfs is a clean pure-OSS case: **no HTTPRoute, no ExternalSecret, no CNPG Cluster CR** — none of the vCluster `customResources` toHost-sync that loft.sh gates behind the **Free-tier platform tether** (§0). Its S3 wire is plain Service DNS (OSS `services` toHost sync); PVCs sync via the OSS `persistentVolumeClaims` toHost sync (already enabled in rtz values).

### Why the move is byte-clean: every S3 consumer is DEFAULT-OFF on a fresh prov

| Consumer | Default on a fresh prov |
|---|---|
| gitea | `objectStorage.enabled=false` (blobs on local PVC) |
| harbor | `imageChartStorage.type=filesystem` |
| loki/mimir/tempo | filesystem storage (S3 is per-Sovereign overlay) |
| velero | `provider/bucket/s3Url` empty |
| openbao | snapshot-replication off |

So nothing active breaks. The S3 wire only resolves once an operator opts a consumer in — and those default endpoints now point at the post-move name.

## Mechanism — placement is DATA

Flip the seaweedfs row in `placement.yaml` `vcluster: host → rtz` + `render-slot-placement.py fix`. The generator stamps the HR `namespace: rtz`, the vcluster label, `targetNamespace`/`storageNamespace: seaweedfs`, `kubeConfig.secretRef → vc-rtz`, the `bp-rtz-vcluster` dependsOn runtime edge, and `install.createNamespace`. Host-side Namespace YAML dropped.

The generator's **`fix_dependents` pass** also re-stamps the `bp-seaweedfs` dependsOn edge in **loki/mimir/tempo/guacamole** from `namespace: flux-system → rtz` (their consumers must point at seaweedfs's new home — the #3191 dangling-dep guard). `expected-bootstrap-deps.yaml` slot-18 gains the `bp-rtz-vcluster` edge (same as loki/mimir/tempo declaring `bp-mgmt-vcluster`).

## Consumer DEFAULT endpoint rewire (mirrors the proven #3376 SME NATS_URL→synced-name move)

Rewire the default endpoint strings to the syncer-mangled host name `seaweedfs-s3-x-seaweedfs-x-rtz-vcluster.rtz.svc:8333` (+ filer `…8888`) in:
- **gitea** — objectStorage s3 + mirror filer endpoints + the `objectstorage-dr-wiring` test assertion.
- **openbao** — snapshot-replication s3 endpoint.
- **catalyst qa-fixtures** — CNPG barman backup endpoint.

## Netpol carve-outs (mirror the #3423 sme→NATS carve-out)

Add `gitea, harbor, catalyst-system, mgmt, velero` to `bp-rtz-vcluster` `allowedIngressNamespaces` (was `{dmz, flux-system}`) so those host consumers reach the synced Service through the `-isolation` NetworkPolicy.

## Chart bumps + kit pins (lockstep)

| Chart | bump | kit slot |
|---|---|---|
| `bp-rtz-vcluster` | 0.2.8 → 0.2.9 | 59 |
| `bp-gitea` | 1.2.34 → 1.2.35 | 10 |
| `bp-openbao` | 1.2.37 → 1.2.38 | 08 |
| `bp-catalyst-platform` | 1.4.620 → 1.4.621 | 13 |

`bp-seaweedfs` chart unchanged (placement move only; pin stays 1.2.1).

## Verification (local — independent walker validates on the keystone fresh-prov)

- `render-slot-placement.py check` **PASSED** — 7 in vClusters (seaweedfs joined), 19 staged.
- `check-bootstrap-kit-pin-sync.sh` **PASS**.
- `check-bootstrap-deps.sh` **PASS** — 0 drift, 0 cycles (the re-stamped loki/mimir/tempo/guacamole edges + slot-18 bp-rtz-vcluster edge reconcile).
- `gitea/chart/tests/objectstorage-dr-wiring.sh` **ALL CASES PASS** (synced endpoint).
- rtz `-isolation` NetworkPolicy renders all 7 carve-outs.
- gitea S3-enabled + openbao snapshot-replication-enabled render the synced endpoint.
- gitea default render + Catalyst-Zero render **byte-unchanged** (only `randAlphaNum` secrets differ).
- `helm lint` clean (exit 0) on all 4 charts; `TestBootstrapKit_TemplateClusterParses` **ok**.

Live expectation after Flux reconcile on hw133: seaweedfs pods (master/volume/filer) appear as `*-x-seaweedfs-x-rtz-vcluster` in the **rtz** host namespace; PVCs sync host-side.

> **Merge ordering note:** this branch + #3476 (valkey) both bump `bp-rtz-vcluster` (`allowedIngressNamespaces`) and `bp-catalyst-platform` to the SAME versions (0.2.9 / 1.4.621). After the first of the two merges, the second needs a rebase on origin/main to reconcile the chart-version + values carve-out blocks (both carve-outs are additive and coexist).

Refs #3373

🤖 Generated with [Claude Code](https://claude.com/claude-code)