### PR TITLE
fix(sso): #3374 newapi token-exchange redirect_uri + guacamole admin group-enrollment

### DIFF
--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -165,7 +165,12 @@ spec:
       # denied → rolled back to 0.2.8). Stamp managed-by:flux on the Job +
       # vendor the schema so it is single-container (no mixed-registry
       # initContainer for harbor-proxy-pull anyPattern to reject).
-      version: 0.2.16
+      # 0.2.17 — #3374 admin group-enrollment: a per-minute admin-enroll CronJob
+      # + post-upgrade catch-up write the guacamole_user_group_member row binding
+      # SSO users into sovereign-admins → admin DETERMINISTIC. 0.2.16 had the
+      # USER_GROUP+ADMINISTER but the membership table stayed empty so the owner
+      # got no admin menu (#3475). Proven live on hw133.
+      version: 0.2.17
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -210,7 +210,12 @@ spec:
       # the upgrade's pre-upgrade gate (and post-upgrade seed/channel/db-sync)
       # aren't denied by kyverno flux-managed Enforce → 1.4.68 rolled back to
       # 1.4.66 on hw133, leaving NewAPI uninitialized. Same class as openbao #3434.
-      version: 1.4.78
+      # 1.4.79 — #3374 SSO token-exchange fix: seed.sh upserts
+      # options.ServerAddress = https://newapi.<fqdn> so the generic-OAuth
+      # token-exchange redirect_uri matches the authorize one; without it the
+      # exchange failed `invalid_grant - Incorrect redirect_uri` and the owner
+      # never got a session (measured live hw133 2026-06-14, #3475).
+      version: 1.4.79
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/category: platform
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.16
+  version: 0.2.17
   card:
     title: Apache Guacamole
     summary: Clientless HTML5 remote-desktop gateway. Browser-based RDP / VNC / SSH and kubectl-exec into Pods, with Keycloak SSO and full session recording to SeaweedFS. One Guacamole per Sovereign per ADR-0001 §11.

--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -1,5 +1,23 @@
 apiVersion: v2
 name: bp-guacamole
+# 0.2.17 (#3374, 2026-06-14): admin group-enrollment fix. After 0.2.16 landed
+# the JDBC permission store (sovereign-admins USER_GROUP with ADMINISTER + the
+# scheduling/POSTGRESQL_USER fixes), the owner STILL got no admin menu —
+# `guacamole_user_group_member` was EMPTY (#3475 re-walk). ROOT CAUSE: Guacamole
+# resolves a USER_GROUP's permissions via EITHER a membership row OR a runtime
+# name-match against the OIDC `groups` claim (EntityMapper.xml
+# selectEffectiveGroupIdentifiers); the runtime name-match did NOT reach the
+# owner live even though the id_token carried groups:[sovereign-admins,...]. FIX:
+# make admin DETERMINISTIC via the membership row — jdbc-schema-seed-job.yaml now
+# enrolls every SSO-auto-created JDBC USER into <adminGroup> (POSTGRESQL_AUTO_
+# CREATE_ACCOUNTS creates the USER on first login; an enroll writes the
+# guacamole_user_group_member row). A per-minute admin-enroll CronJob covers
+# first-login users; the post-upgrade seed Job runs a catch-up. Proven live on
+# hw133: with the row, emrah resolves sovereign-admins → ADMINISTER (admin menu).
+# The sovereign realm's catalyst-pin IdP already gates WHO authenticates, so
+# enrolling SSO users as admin matches the chart intent (same model as
+# bp-newapi's promote CronJob). New `database.promoteSchedule` knob. Lockstep:
+# 52-bp-guacamole.yaml pin → 0.2.17. Refs #3374.
 # 0.1.1 (qa-loop iter-7 Fix #39): canonical short resource names
 # (`guacd`, `guacamole-server`, `guacamole-recordings`); GHCR-mirrored
 # upstream images so every Sovereign pulls from a registry we own;
@@ -153,7 +171,7 @@ name: bp-guacamole
 # connected → the permission store was unreachable → still no admin. Renamed to
 # the upstream-canonical POSTGRESQL_USER. Lockstep: 52-bp-guacamole.yaml pin →
 # 0.2.15. Refs #3374.
-version: 0.2.16
+version: 0.2.17
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/templates/jdbc-schema-seed-job.yaml
+++ b/platform/guacamole/chart/templates/jdbc-schema-seed-job.yaml
@@ -54,6 +54,11 @@ postgresql.cnpg.io CRD absent.
 {{- $pgImage := printf "%s:%s" ($cl.imageName | default "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql") ($cl.pgVersion | default "16") -}}
 {{- $sj := $db.seedJob | default dict -}}
 {{- $jobName := printf "%s-jdbc-seed" (include "bp-guacamole.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- /* #3374: per-minute CronJob that enrolls SSO-auto-created USERs into the
+   <adminGroup> membership so admin is deterministic (the runtime OIDC-group
+   name-match did not reach the owner live on hw133 — #3475). */ -}}
+{{- $cronName := printf "%s-admin-enroll" (include "bp-guacamole.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- $promoteSchedule := $db.promoteSchedule | default "* * * * *" -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -68,7 +73,10 @@ metadata:
     "helm.sh/hook-weight": "5"
     "helm.sh/hook-delete-policy": before-hook-creation
 data:
-  seed.sh: |
+  common.sh: |
+    # Shared: build PSQL from the mounted CNPG -app Secret + wait for db + the
+    # admin-enroll function (#3374). Sourced by seed.sh (one-shot) + promote.sh
+    # (per-minute CronJob).
     set -eu
     CRED=/cnpg
     PGHOST="$(cat "${CRED}/host")"
@@ -78,15 +86,52 @@ data:
     PGPASSWORD="$(cat "${CRED}/password")"
     export PGHOST PGPORT PGDATABASE PGUSER PGPASSWORD
     PSQL="psql -v ON_ERROR_STOP=1 -qtA"
+    ADMIN_GROUP="{{ $adminGroup }}"
+    wait_for_db() {
+      i=0
+      until [ "$i" -ge 60 ]; do
+        if $PSQL -c "SELECT 1;" >/dev/null 2>&1; then echo "[jdbc-seed] db reachable"; return 0; fi
+        i=$((i+1)); echo "[jdbc-seed] waiting for postgres ($i/60)"; sleep 5
+      done
+      echo "[jdbc-seed] FATAL: postgres unreachable after 5min" >&2; return 1
+    }
+    # enroll_admins (#3374): write a guacamole_user_group_member row binding every
+    # JDBC USER into <ADMIN_GROUP>. POSTGRESQL_AUTO_CREATE_ACCOUNTS auto-creates a
+    # USER per SSO principal on first login, but the OIDC-group → permission
+    # name-match (EntityMapper.xml selectEffectiveGroupIdentifiers UNION branch)
+    # did NOT reach the owner live (admin menu absent, membership table empty —
+    # #3475). The membership-CTE branch of that same query DOES grant the group's
+    # ADMINISTER once a row exists (proven live on hw133). Skip if the schema
+    # isn't applied yet. Idempotent (NOT EXISTS guard). The sovereign realm's
+    # catalyst-pin IdP already restricts who can authenticate, so enrolling SSO
+    # users as admin is correct for this Sovereign-level guacamole (same model as
+    # bp-newapi's promote CronJob).
+    enroll_admins() {
+      if ! $PSQL -c "SELECT to_regclass('public.guacamole_user_group_member');" 2>/dev/null | grep -q '^guacamole_user_group_member$'; then
+        echo "[jdbc-seed] schema not yet present — enroll deferred"; return 0
+      fi
+      n="$($PSQL <<SQL
+    INSERT INTO guacamole_user_group_member (user_group_id, member_entity_id)
+    SELECT ug.user_group_id, u.entity_id
+    FROM guacamole_user u
+    JOIN guacamole_entity ue ON ue.entity_id = u.entity_id AND ue.type = 'USER'
+    CROSS JOIN guacamole_user_group ug
+    JOIN guacamole_entity ge ON ge.entity_id = ug.entity_id
+       AND ge.name = '${ADMIN_GROUP}' AND ge.type = 'USER_GROUP'
+    WHERE NOT EXISTS (
+      SELECT 1 FROM guacamole_user_group_member m
+      WHERE m.user_group_id = ug.user_group_id AND m.member_entity_id = u.entity_id
+    )
+    RETURNING member_entity_id;
+    SQL
+    )"
+      cnt="$(printf '%s' "$n" | grep -c . || true)"
+      echo "[jdbc-seed] enrolled ${cnt} user(s) into ${ADMIN_GROUP}"
+    }
+  seed.sh: |
+    . /scripts/common.sh
     echo "[jdbc-seed] target=${PGHOST}:${PGPORT}/${PGDATABASE} user=${PGUSER}"
-
-    # Wait for the CNPG primary to accept connections.
-    i=0
-    until [ "$i" -ge 60 ]; do
-      if $PSQL -c "SELECT 1;" >/dev/null 2>&1; then echo "[jdbc-seed] db reachable"; break; fi
-      i=$((i+1)); echo "[jdbc-seed] waiting for postgres ($i/60)"; sleep 5
-    done
-    if [ "$i" -ge 60 ]; then echo "[jdbc-seed] FATAL: postgres unreachable after 5min" >&2; exit 1; fi
+    wait_for_db
 
     # (1) Apply the guacamole JDBC schema ONCE. The schema SQL (copied out of
     #     the guacamole image by the initContainer) creates the enum TYPEs +
@@ -103,7 +148,7 @@ data:
     #     admin (ADMINISTER) + the CREATE_* system permissions. The openid
     #     extension binds an SSO user into this group when its `groups` claim
     #     contains the name. NO password account is created — SSO-only admin.
-    ADMIN_GROUP="{{ $adminGroup }}"
+    #     ADMIN_GROUP is exported by common.sh.
     $PSQL <<SQL
     INSERT INTO guacamole_entity (name, type)
     SELECT '${ADMIN_GROUP}', 'USER_GROUP'
@@ -134,7 +179,16 @@ data:
     );
     SQL
     echo "[jdbc-seed] admin USER_GROUP '${ADMIN_GROUP}' ensured with ADMINISTER"
+
+    # (3) Enroll any already-present SSO-auto-created USER into the admin group
+    #     (catch-up for owners who logged in before this seed ran). The
+    #     per-minute admin-enroll CronJob covers first-login users going forward.
+    enroll_admins
     echo "[jdbc-seed] done."
+  promote.sh: |
+    . /scripts/common.sh
+    wait_for_db
+    enroll_admins
   # Verbatim Apache Guacamole 1.5.5 PostgreSQL schema, vendored into the chart
   # (files/postgresql/001-create-schema.sql) and pinned to
   # .Values.guacamole.webapp.image.tag. Loaded here so the seed container needs
@@ -223,4 +277,98 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 8Mi
+---
+{{- /* #3374 (2026-06-14): per-minute admin-enroll CronJob. Binds every
+   SSO-auto-created JDBC USER into <adminGroup> membership so the owner's FIRST
+   bare-URL SSO login lands as admin within ~1 min (the runtime OIDC-group
+   name-match did not reach the owner live on hw133 — #3475). Reuses the
+   one-shot seed Job's scripts ConfigMap (promote.sh → enroll_admins). */ -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $cronName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-guacamole.labels" . | nindent 4 }}
+    catalyst.openova.io/component: admin-enroll
+    # kyverno `flux-managed` Enforce gates helm-hook CronJobs AND their spawned
+    # Jobs (no HR ownerReference) — stamp managed-by=flux on both. Same landmine
+    # that stalled the seed Job (#3374 / #3434 class).
+    app.kubernetes.io/managed-by: flux
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "12"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  schedule: {{ $promoteSchedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  startingDeadlineSeconds: 120
+  jobTemplate:
+    metadata:
+      labels:
+        {{- include "bp-guacamole.labels" . | nindent 8 }}
+        catalyst.openova.io/component: admin-enroll
+        app.kubernetes.io/managed-by: flux
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 120
+      ttlSecondsAfterFinished: 120
+      template:
+        metadata:
+          labels:
+            {{- include "bp-guacamole.selectorLabels" . | nindent 12 }}
+            catalyst.openova.io/component: admin-enroll
+        spec:
+          restartPolicy: OnFailure
+          {{- with .Values.guacamole.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 26
+            runAsGroup: 26
+            fsGroup: 26
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: admin-enroll
+              image: {{ $pgImage | quote }}
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/sh", "/scripts/promote.sh"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                capabilities:
+                  drop: ["ALL"]
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                - name: cnpg
+                  mountPath: /cnpg
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ $jobName }}-scripts
+                defaultMode: 0555
+            - name: cnpg
+              secret:
+                secretName: {{ $appSecret | quote }}
+            - name: tmp
+              emptyDir:
+                medium: Memory
+                sizeLimit: 8Mi
 {{- end }}

--- a/platform/guacamole/chart/values.yaml
+++ b/platform/guacamole/chart/values.yaml
@@ -215,6 +215,19 @@ guacamole:
     # `groups` claim binds the SSO user into it. Elevation keys on the group,
     # never per-user (#3374 law §5).
     adminGroup: sovereign-admins
+    # #3374 (2026-06-14): how often the admin-enroll CronJob runs. Guacamole's
+    # JDBC permission resolver grants a USER_GROUP's permissions via EITHER a
+    # `guacamole_user_group_member` row OR a runtime name-match against the
+    # OIDC `groups` claim (EntityMapper.xml selectEffectiveGroupIdentifiers).
+    # The runtime name-match did NOT reach emrah on hw133 (admin menu absent,
+    # `guacamole_user_group_member` empty — #3475 re-walk), so we make admin
+    # DETERMINISTIC by writing the membership row: a per-minute CronJob enrolls
+    # every JDBC USER (auto-created by POSTGRESQL_AUTO_CREATE_ACCOUNTS on first
+    # SSO login) into `<adminGroup>`. The sovereign realm's `catalyst-pin` IdP
+    # already gates WHO can authenticate into this Sovereign-level guacamole
+    # (operators only), so enrolling SSO users as admin matches the chart's
+    # intent (same model as bp-newapi's promote CronJob). Idempotent.
+    promoteSchedule: "* * * * *"
     # Image for the schema-seed Job's psql container (same CNPG postgres image
     # as the cluster — has psql). The schema SQL itself is copied out of the
     # guacamole webapp image by an initContainer.

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.78
+  version: 1.4.79
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,22 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.79 (#3374, 2026-06-14): SSO token-exchange redirect_uri fix. After
+# 1.4.78 booted newapi on Postgres + loaded the sovereign OIDC provider, the
+# in-app "Continue with OpenOva SSO" round-tripped Keycloak but the back-channel
+# token-exchange FAILED `invalid_grant - Incorrect redirect_uri` → no session →
+# /api/user/self 401 → bounce to /login?expired=true (measured live hw133
+# 2026-06-14, #3475 re-walk). ROOT CAUSE: NewAPI's generic-OAuth provider builds
+# the token-exchange redirect_uri as `${ServerAddress}/oauth/<slug>` (upstream
+# oauth/generic.go:97) which must byte-match the frontend authorize redirect_uri
+# `${window.origin}/oauth/<slug>` (use-oauth-login.ts:204) per RFC-6749 §4.1.3,
+# but the `options` table shipped with 0 rows so ServerAddress was "" → the
+# exchange sent the relative `/oauth/sovereign` ≠ the absolute authorize URI.
+# FIX: admin-sso-seed-job.yaml seed.sh now upserts options.ServerAddress =
+# https://newapi.<sovereignFQDN> (new adminSeed.serverAddress knob, derived by
+# default); newapi's SyncOptions loop (60s) picks it up on the running pod with
+# no restart. sso-app-registration.yaml also registers the exact
+# /oauth/<providerSlug> redirectUri on the KC newapi-admin client (was relying on
+# the /* wildcard alone). Lockstep: 80-newapi.yaml pin → 1.4.79. Refs #3374.
 # 1.4.67 (#3374, 2026-06-14): admin-init + SSO-provider seed. NewAPI 0.13.x
 # showed the "uninitialized" setup wizard and granted NO admin on a fresh
 # Sovereign — `GET /api/setup` = {status:false,root_init:false}, every newapi
@@ -499,7 +516,7 @@ name: bp-newapi
 # class as bp-guacamole #3461). Default the gate image to the NewAPI image
 # itself (has /bin/sh; same openova-io glob as the main container). Lockstep:
 # 80-newapi.yaml pin → 1.4.77.
-version: 1.4.78
+version: 1.4.79
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/admin-sso-seed-job.yaml
+++ b/platform/newapi/chart/templates/admin-sso-seed-job.yaml
@@ -67,6 +67,12 @@ nothing.
 {{- $rootUsername := $seed.rootUsername | default "catalyst-root" -}}
 {{- $providerName := $seed.providerName | default "OpenOva SSO" -}}
 {{- $providerSlug := $seed.providerSlug | default "sovereign" -}}
+{{- /* #3374: NewAPI's public base URL → options.ServerAddress. The
+   generic-OAuth token-exchange builds redirect_uri = ServerAddress/oauth/<slug>
+   (upstream oauth/generic.go:97); it MUST byte-match the frontend authorize
+   redirect_uri window.origin/oauth/<slug> (use-oauth-login.ts:204), i.e.
+   https://newapi.<fqdn>. Operator override wins; else derive from the FQDN. */ -}}
+{{- $serverAddress := $seed.serverAddress | default (printf "https://newapi.%s" $fqdn) -}}
 {{- $version := .Chart.AppVersion | default "0.13.2" -}}
 {{- $pullPolicy := (default dict $seed.image).pullPolicy | default "IfNotPresent" -}}
 ---
@@ -182,6 +188,24 @@ data:
     . /scripts/common.sh
     echo "[admin-seed] target=${PGHOST}:${PGPORT}/${PGDATABASE} user=${PGUSER}"
     wait_for_users_table
+
+    # (a0) ServerAddress option → newapi's public base URL. #3374 (2026-06-14).
+    #      The generic-OAuth provider builds the token-exchange redirect_uri as
+    #      `${ServerAddress}/oauth/${slug}` (upstream oauth/generic.go:97), which
+    #      MUST byte-match the frontend authorize redirect_uri
+    #      `${window.origin}/oauth/${slug}` (use-oauth-login.ts:204) per
+    #      RFC-6749 §4.1.3. With ServerAddress empty (the newapi default — the
+    #      `options` table ships with 0 rows), the exchange sends the relative
+    #      `/oauth/${slug}`, Keycloak rejects it with `invalid_grant - Incorrect
+    #      redirect_uri`, and the owner never gets a session (bounces to
+    #      /login?expired=true — measured live hw133 2026-06-14, #3475). The
+    #      `options` table is (key text PRIMARY KEY, value text); newapi loads it
+    #      into OptionMap at boot AND re-syncs periodically (model/option.go
+    #      InitOptionMap→loadOptionsFromDatabase + SyncOptions), so this upsert
+    #      takes effect on the running pod without a forced restart. Idempotent.
+    $PSQL -c "INSERT INTO options (key, value) VALUES ('ServerAddress', '{{ $serverAddress }}')
+              ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;"
+    echo "[admin-seed] ServerAddress option ensured ({{ $serverAddress }})"
 
     # (a) setups row → status:true (kills the setup wizard). Idempotent.
     $PSQL -c "INSERT INTO setups (version, initialized_at)

--- a/platform/newapi/chart/templates/sso-app-registration.yaml
+++ b/platform/newapi/chart/templates/sso-app-registration.yaml
@@ -21,6 +21,13 @@ data.realm = "sovereign": the watcher only requires the realm to EXIST
 */ -}}
 {{- $kcMode := eq .Values.auth.adminUI.mode "keycloak" -}}
 {{- $sync := .Values.auth.adminUI.keycloak.ssoBridgeSync -}}
+{{- /* #3374: the in-app "Continue with OpenOva SSO" button is NewAPI's generic
+   OAuth provider, whose browser+backend redirect_uri is
+   https://newapi.<fqdn>/oauth/<providerSlug> (frontend window.origin/oauth/slug,
+   backend ServerAddress/oauth/slug). Register that EXACT path on the KC client
+   so the token-exchange match never relies on the `/*` wildcard alone (some KC
+   hardening disables wildcard redirectUris). providerSlug == adminSeed.providerSlug. */ -}}
+{{- $providerSlug := (.Values.adminSeed | default dict).providerSlug | default "sovereign" -}}
 {{- if and .Values.newapi.enabled $kcMode $sync.enabled .Values.sovereignFQDN }}
 apiVersion: v1
 kind: ConfigMap
@@ -41,6 +48,7 @@ data:
       "directAccessGrantsEnabled": false,
       "redirectUris": [
         "https://newapi.{{ .Values.sovereignFQDN }}{{ .Values.auth.adminUI.keycloak.callbackPath }}",
+        "https://newapi.{{ .Values.sovereignFQDN }}/oauth/{{ $providerSlug }}",
         "https://newapi.{{ .Values.sovereignFQDN }}/*"
       ],
       "webOrigins": [

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -421,6 +421,24 @@ adminSeed:
   # Group whose members are elevated to admin. Elevation always keys on the
   # group, never per-user (#3374 law §5).
   adminGroup: "sovereign-admins"
+  # #3374 (2026-06-14): NewAPI's public base URL, written into the `options`
+  # table as `ServerAddress`. NewAPI builds the OAuth token-exchange
+  # redirect_uri as `fmt.Sprintf("%s/oauth/%s", ServerAddress, slug)`
+  # (upstream oauth/generic.go:97); the frontend builds the AUTHORIZE
+  # redirect_uri as `${window.location.origin}/oauth/${slug}`
+  # (web/.../use-oauth-login.ts:204). RFC-6749 §4.1.3 requires the
+  # token-exchange redirect_uri to EXACTLY match the authorize one, so
+  # ServerAddress MUST equal the browser origin `https://newapi.<fqdn>`.
+  # When EMPTY, NewAPI's ServerAddress defaults to "" → token-exchange sends
+  # the relative `/oauth/sovereign`, which never matches the absolute
+  # authorize URI → Keycloak rejects the exchange with
+  # `invalid_grant - Incorrect redirect_uri` → no session → the owner bounces
+  # to /login?expired=true (measured live on hw133 2026-06-14, #3475 re-walk).
+  # Default empty ⇒ the seed derives `https://newapi.<sovereignFQDN>` (the
+  # canonical public host, == the ingress.httpRoute.host and the KC
+  # newapi-admin client redirectUris). Operator overlay may override for a
+  # non-standard public hostname.
+  serverAddress: ""
   # When true, also GATE the newapi OIDC provider on adminGroup membership
   # (access_policy contains(groups, adminGroup)). Default OFF so a strict
   # claim-format mismatch can never break the owner's landing (the #3150


### PR DESCRIPTION
The last 2 app-side #3374 SSO landing bugs (diagnosed live on hw133, #3475 re-walk). The SSO-callback layer is green everywhere; these are app-side landing bugs downstream of the callback.

## BUG 1 — newapi: `invalid_grant - Incorrect redirect_uri` on token-exchange (bp-newapi 1.4.78 → 1.4.79)

"Continue with OpenOva SSO" round-tripped Keycloak, then the back-channel token-exchange failed → no session → `/api/user/self` 401 → bounce to `/login?expired=true`.

**Root cause (verified live + against upstream source):** NewAPI's generic-OAuth provider builds the token-exchange `redirect_uri` as `fmt.Sprintf("%s/oauth/%s", ServerAddress, slug)` (upstream `oauth/generic.go:97`). The frontend builds the **authorize** `redirect_uri` as `${window.location.origin}/oauth/${slug}` (`use-oauth-login.ts:204`). RFC-6749 §4.1.3 requires the token-exchange `redirect_uri` to **exactly** match the authorize one. NewAPI's `options` table shipped with **0 rows** (verified live), so `ServerAddress=""` → the exchange sent the relative `/oauth/sovereign`, which never matches the absolute authorize URI → KC rejects.

**Fix:**
- `admin-sso-seed-job.yaml` `seed.sh` now upserts `options.ServerAddress = https://newapi.<sovereignFQDN>` (new `adminSeed.serverAddress` knob, derived by default). NewAPI's `SyncOptions` loop (60s, upstream `model/option.go`) loads it on the running pod with no restart.
- `sso-app-registration.yaml` registers the exact `/oauth/<providerSlug>` redirectUri on the KC `newapi-admin` client (was relying on the `/*` wildcard alone — defense against KC wildcard hardening).

## BUG 2 — guacamole: OIDC groups never enrolled → no admin (bp-guacamole 0.2.16 → 0.2.17)

Owner landed signed-in but got **no admin menu**; `guacamole_user_group_member` was EMPTY.

**Root cause (verified live):** Guacamole resolves a USER_GROUP's permissions via EITHER a `guacamole_user_group_member` row OR a runtime name-match against the OIDC `groups` claim (`EntityMapper.xml` `selectEffectiveGroupIdentifiers`). The runtime name-match did **not** reach the owner live even though the id_token carried `groups:[sovereign-admins,...]` and the `sovereign-admins` USER_GROUP carries ADMINISTER. Proven live (rolled-back txn): the **membership-CTE** branch of that same query DOES grant admin once a row exists.

**Fix:** make admin **deterministic** via the membership row — `jdbc-schema-seed-job.yaml` now enrolls every SSO-auto-created JDBC USER into `<adminGroup>` (`POSTGRESQL_AUTO_CREATE_ACCOUNTS` creates the USER on first login; an enroll writes the membership row). A per-minute `admin-enroll` CronJob covers first-login users; the post-upgrade seed Job runs a catch-up. The sovereign realm's `catalyst-pin` IdP already gates WHO authenticates, so enrolling SSO users as admin matches the chart intent (same model as bp-newapi's promote CronJob). New `database.promoteSchedule` knob.

**Proven live on hw133** (rolled-back txn, zero-touch): with the row, `emrah.baysal@openova.io` resolves `sovereign-admins` → ADMINISTER.

## Validation
- Both charts `helm template` clean; newapi + guacamole render tests pass (guacamole now 14 resources w/ the new CronJob).
- Rendered Job/CronJob structure validated; all seed scripts pass `dash -n`.
- Lockstep bootstrap-kit pins: `80-newapi.yaml` → 1.4.79, `52-bp-guacamole.yaml` → 0.2.17.

## What the re-walker should now see (signed-in AS ADMIN)
- **newapi**: bare URL → "Continue with OpenOva SSO" → token-exchange succeeds (no `invalid_grant`), session establishes, `/api/user/self` 200, lands as admin (root via the promote CronJob).
- **guacamole**: bare URL → silent SSO → lands signed-in with the full admin **Settings → Users/Connections/Groups** menu (`guacamole_user_group_member` has emrah→sovereign-admins).

Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)