### PR TITLE
docs(placement): §4 exception for the 17 route/CNPG host-staying apps — #3373

### DIFF
--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -179,8 +179,73 @@ spec:
     - {file: 35-coraza.yaml, hr: bp-coraza, vcluster: dmz, target: dmz, namespace: coraza}
     - {file: 19a-bp-sandbox.yaml, hr: bp-sandbox, vcluster: rtz, target: rtz, namespace: catalyst-system}
 
-    # NEEDS-REWORK / staged backlog (§4 targets; active=host until each
-    # wave's coupling audit completes — a promote is a one-field flip).
+    # ── §4 PLACEMENT EXCEPTION — host-staying on the pure-OSS Sovereign
+    #    stack (a SOVEREIGNTY decision, NOT an unfinished task) ──────────
+    #
+    # The 17 rows below carry `target != host` (founder §4 wants them in a
+    # vCluster), yet their ACTIVE placement stays `host` on the pure-OSS
+    # Sovereign build. This is NOT migration debt that a future one-field
+    # flip clears — it is a documented exception forced by a hard
+    # upstream-licensing fact + the Pillar-5 sovereignty mandate. (Decision
+    # ratified with #3373 Batch A, 2026-06-14. Source of truth:
+    # docs/sessions/2026-06-14/3373-migration-plan.md §0/§4/§6.)
+    #
+    # THE GOVERNING CONSTRAINT — vCluster CRD-sync is loft.sh Free-tier,
+    # NOT pure-OSS:
+    #   Re-homing a chart that ships an HTTPRoute, an ExternalSecret, or a
+    #   CNPG `Cluster` CR requires the vCluster syncer to register those
+    #   CRDs inside the vCluster apiserver and mirror the CRs toHost (so
+    #   the host Cilium Gateway / external-secrets-operator / cnpg-operator
+    #   — all host-minimum substrate — can reconcile them). That
+    #   `sync.toHost.customResources` mechanism is a vCluster **Free-tier**
+    #   feature that requires an ONGOING connection to the loft.sh platform
+    #   for license validation. It is NOT part of the pure-OSS
+    #   (Apache-2.0) build hw133's vClusters run. The block is accepted by
+    #   Helm but the OSS syncer never registers the CRDs → 0 sync-set CRDs
+    #   → the chart fails to install inside the vCluster (measured live on
+    #   vc-mgmt 2026-06-13: keycloak `no matches for kind HTTPRoute`; the
+    #   #2697 revert). The rtz/mgmt values DO declare the `customResources`
+    #   block (coupling fix (b)) — it is accepted but silently no-ops on
+    #   the pure-OSS syncer.
+    #
+    # WHY NOT just license it (path L)? Two sub-paths, both rejected by
+    # Pillar 5 (a Sovereign owns its whole stack, no mothership/vendor
+    # tether — Principle #11 + ADR-0002):
+    #   - Free-tier platform connection = a PERMANENT outbound tether to
+    #     admin.loft.sh for license validation. A franchised/air-gapped
+    #     Sovereign cannot carry that and still pass the
+    #     bp-self-sovereign-cutover deny-egress hold.
+    #   - Air-gapped offline-license-key mode is an ENTERPRISE-only add-on
+    #     (Dev/Prod/Scale tiers, contact sales@loft.sh) — NOT available on
+    #     the Free tier, and a paid per-Sovereign Enterprise license is
+    #     itself a vendor tether + recurring cost the model forbids.
+    #   (Verified against vCluster docs 2026-06-14: oss-vs-free +
+    #   platform/install/air-gapped. The Free-tier CRD-sync feature has NO
+    #   offline activation path that is sovereignty-safe.)
+    #
+    # CONSEQUENCE — the §4 target for every route/secret/CNPG app below is
+    # ASPIRATIONAL on the pure-OSS stack: it materialises ONLY if a future
+    # OSS-native in-vCluster CRD-sync (or a host-bridge that renders the
+    # route+secret host-side while re-homing just the pod) ships. Until
+    # then these stay `host` BY DESIGN. The 3 clean apps (valkey,
+    # seaweedfs, vllm — plain Service DNS, no route/secret/CNPG) DID
+    # migrate to rtz in Batch A above; they are the ONLY pure-OSS-clean
+    # set. The 17 below are the documented exception, grouped by blocker:
+    #
+    #   ROUTE + ExternalSecret (Free-tier CRD-sync blocked) — 10:
+    #     openbao, keycloak, gitea, harbor, grafana, powerdns-admin,
+    #     newapi, openova-flow-server, guacamole, catalyst-platform.
+    #   CNPG `Cluster` CR (host cnpg-operator can't see an un-reflected
+    #   in-vCluster CR — same Free-tier mechanism) — 4:
+    #     postgres-shared (×3: 16a/16c/16d) + cnpg-pair (16b).
+    #   Host-adjacent reconcilers / DaemonSet (re-home case-by-case, fold
+    #   in with their route-bearing peers) — 3:
+    #     sso-bridge, openova-flow-emitter, k8s-ws-proxy (k8s-ws-proxy is
+    #     a per-node-host-reach DaemonSet → strongest keep-host case).
+    #
+    # NEEDS-REWORK / staged backlog (§4 targets are ASPIRATIONAL per the
+    # exception above; active=host BY DESIGN on pure-OSS — NOT a one-field
+    # flip until OSS-native CRD-sync or a host-bridge lands).
     - {file: 08-openbao.yaml, hr: bp-openbao, vcluster: host, target: mgmt, namespace: openbao}
     - {file: 11a-bp-powerdns-admin.yaml, hr: bp-powerdns-admin, vcluster: host, target: mgmt,
        namespace: powerdns-admin}   # §4: UI not substrate — DEFAULT mgmt, listed for founder veto


### PR DESCRIPTION
## What

**Part 2** of #3373 Batch A. The 17 staged-backlog rows in `placement.yaml` carry `target != host` (founder §4 wants them in a vCluster) but stay `host` on the pure-OSS Sovereign build. Without an explicit note, that `vcluster != target` gap reads as **unfinished migration debt** — a silent gap. It is NOT: it is a documented **sovereignty exception**.

This PR adds a `§4 PLACEMENT EXCEPTION` block to the staged-backlog header of `placement.yaml`.

## The exception, recorded

1. **THE GOVERNING CONSTRAINT** — re-homing a chart that ships an HTTPRoute, ExternalSecret, or CNPG `Cluster` CR needs the vCluster syncer to register those CRDs inside the vCluster apiserver and mirror them toHost (so the host Cilium Gateway / external-secrets-operator / cnpg-operator can reconcile). That `sync.toHost.customResources` mechanism is a vCluster **Free-tier** feature requiring an **ongoing loft.sh platform connection** — NOT part of the pure-OSS (Apache-2.0) build. It silently no-ops on the OSS syncer (measured live vc-mgmt 2026-06-13: keycloak `no matches for kind HTTPRoute`; the #2697 revert).

2. **WHY NOT LICENSE IT (path L)** — both sub-paths violate Pillar 5:
   - The Free-tier platform connection is a **permanent admin.loft.sh tether** (fails the `bp-self-sovereign-cutover` deny-egress hold).
   - Air-gapped offline-license mode is an **Enterprise-only paid add-on** (a vendor tether + recurring cost).
   - *Verified against vCluster docs 2026-06-14 ([oss-vs-free](https://www.vcluster.com/docs/vcluster/introduction/oss-vs-free) + [platform/install/air-gapped](https://vcluster.com/docs/platform/install/advanced/air-gapped)): the Free-tier CRD-sync feature has NO sovereignty-safe offline activation path.*

3. **CONSEQUENCE + GROUPING** — the §4 target for route/secret/CNPG apps is **aspirational** on pure-OSS; it materialises only if OSS-native in-vCluster CRD-sync (or a host-bridge rendering route+secret host-side) ships. Until then these 17 stay host **by design**:
   - **10 route + ExternalSecret:** openbao, keycloak, gitea, harbor, grafana, powerdns-admin, newapi, openova-flow-server, guacamole, catalyst-platform.
   - **4 CNPG `Cluster` CR:** postgres-shared (×3) + cnpg-pair.
   - **3 host-adjacent reconcilers/DaemonSet:** sso-bridge, openova-flow-emitter, k8s-ws-proxy (the per-node DaemonSet → strongest keep-host case).
   - The 3 clean apps (valkey/seaweedfs/vllm — plain Service DNS) DID migrate to rtz in Batch A (#3476/#3477/#3478).

## Verification

Comment-only change to `placement.yaml` — **no slot data row touched**; `render-slot-placement.py check` PASSES; zero rendered-manifest change.

Refs #3373

🤖 Generated with [Claude Code](https://claude.com/claude-code)