### PR TITLE
fix(bp-newapi): rewire newapi→valkey to rtz-vCluster synced name — #3373 Batch A bridge gap

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -215,7 +215,15 @@ spec:
       # token-exchange redirect_uri matches the authorize one; without it the
       # exchange failed `invalid_grant - Incorrect redirect_uri` and the owner
       # never got a session (measured live hw133 2026-06-14, #3475).
-      version: 1.4.80
+      # 1.4.81 — #3482 / Refs #3373 Batch A: newapi→valkey rewire. #3373 Batch A
+      # moved bp-valkey INTO the rtz vCluster but MISSED this default-ON
+      # consumer; newapi's valkey URL still pointed at the now-NXDOMAIN
+      # `valkey-primary.valkey.svc` → FATAL Redis-ping no-such-host →
+      # CrashLoopBackOff (live hw133, 10+ restarts). Chart default now targets
+      # the syncer-mangled `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc`
+      # (mirrors the SME VALKEY_ADDR rewire #3476). This slot's valkey block
+      # sets no `valkey.url` override, so the chart default IS what newapi uses.
+      version: 1.4.81
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -82,8 +82,8 @@ spec:
         properties:
           url:
             type: string
-            default: redis://valkey-primary.valkey.svc.cluster.local:6379
-            description: Valkey URL for session and rate-limit cache.
+            default: redis://valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc.cluster.local:6379
+            description: Valkey URL for session and rate-limit cache. #3373 Batch A — bp-valkey is in the rtz vCluster; the syncer mangles the host-synced Service name to `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc` (mirrors the SME VALKEY_ADDR rewire #3476).
       auth:
         type: object
         properties:

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -516,7 +516,17 @@ name: bp-newapi
 # class as bp-guacamole #3461). Default the gate image to the NewAPI image
 # itself (has /bin/sh; same openova-io glob as the main container). Lockstep:
 # 80-newapi.yaml pin → 1.4.77.
-version: 1.4.80
+# 1.4.81 (#3482 / Refs #3373 Batch A, 2026-06-14): rewire newapi→valkey to the
+# rtz-vCluster syncer-mangled Service name. #3373 Batch A moved bp-valkey INTO
+# the rtz vCluster but MISSED this consumer (the migration rewired SME, the
+# projector, gitea→seaweedfs, newapi→vLLM — but not newapi→valkey). newapi's
+# valkey default-ON URL still pointed at the OLD `valkey-primary.valkey.svc`
+# which is now NXDOMAIN → FATAL `Redis ping test failed: ... no such host` →
+# CrashLoopBackOff (observed live on hw133, 10+ restarts). values.yaml
+# `valkey.url` + blueprint.yaml configSchema default now point at
+# `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc.cluster.local:6379` (mirrors
+# the SME VALKEY_ADDR rewire #3476). Lockstep: 80-newapi.yaml pin → 1.4.81.
+version: 1.4.81
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -259,13 +259,25 @@ valkey:
   enabled: true
   # bp-valkey installs the upstream bitnami chart with
   # architecture=replication; the writeable Service is named
-  # `<release>-primary` (release = `valkey`), so the in-cluster DNS is
-  # `valkey-primary.valkey.svc.cluster.local`. There is NO plain `valkey`
+  # `<release>-primary` (release = `valkey`). There is NO plain `valkey`
   # Service — pointing at `valkey.valkey.svc.cluster.local` resolves to
   # NXDOMAIN and the NewAPI pod CrashLoops on the Redis ping probe (issue
   # #1944 — t34 newapi pod 31x CrashLoopBackOff with
   # `lookup valkey.valkey.svc.cluster.local: no such host`).
-  url: "redis://valkey-primary.valkey.svc.cluster.local:6379"
+  #
+  # #3373 Batch A (2026-06-14): bp-valkey moved INSIDE the rtz vCluster
+  # (placement.yaml: `bp-valkey → vcluster: rtz, namespace: valkey`). The
+  # bp-rtz-vcluster syncer reflects the in-vCluster `valkey-primary` Service
+  # to the HOST under the syncer-mangled name
+  # `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc`, so the host `valkey`
+  # namespace no longer carries a `valkey-primary` Service — the old
+  # `valkey-primary.valkey.svc` now resolves NXDOMAIN (same FATAL Redis-ping
+  # CrashLoop, observed live on hw133). newapi is host-placed in Batch A and
+  # this consumer is default-ON (`valkey.enabled: true`), so this default
+  # must point at the synced name. Mirrors the SME `VALKEY_ADDR` /
+  # projector `valkey.addr` rewire (#3476). Override `url` for a host-placed
+  # valkey.
+  url: "redis://valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc.cluster.local:6379"
   # If the operator's Valkey requires auth, supply via ExternalSecret.
   # Required key: REDIS_CONN_STRING (full URL with credentials).
   existingSecret: "" # e.g. "newapi-valkey-conn"


### PR DESCRIPTION
## The gap

`#3373` Batch A re-homed `bp-valkey` INTO the rtz vCluster (placement.yaml) and rewired most consumers — SME `VALKEY_ADDR`, catalyst projector `valkey.addr`, gitea→seaweedfs, newapi→vLLM. It **MISSED newapi→valkey**.

newapi's valkey consumer is **default-ON** (`valkey.enabled: true`) and slot 80 sets no `valkey.url` override, so the chart default IS what newapi uses. That default still pointed at the OLD `valkey-primary.valkey.svc.cluster.local`, now NXDOMAIN (the Service only exists in rtz under the syncer-mangled name).

### Confirmed LIVE on hw133
```
REDIS_CONN_STRING=redis://valkey-primary.valkey.svc.cluster.local:6379
[FATAL] Redis ping test failed: dial tcp: lookup valkey-primary.valkey.svc.cluster.local on 10.96.0.10:53: no such host
newapi-bp-newapi-...  2/3  CrashLoopBackOff  10 restarts
```
The synced Service exists as `valkey-primary-x-valkey-x-rtz-vcluster` in the `rtz` ns (ClusterIP 10.96.229.130, port 6379).

## The fix
- `platform/newapi/chart/values.yaml` `valkey.url` → `redis://valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc.cluster.local:6379`
- `platform/newapi/blueprint.yaml` configSchema default → same
- bp-newapi `1.4.80` → `1.4.81`; bootstrap-kit slot 80 pin → `1.4.81`

Mirrors the SME `VALKEY_ADDR` / projector `valkey.addr` rewire (#3476).

### Render proof
`helm template` (deploy-gate satisfied) emits:
```
- name: REDIS_CONN_STRING
  value: "redis://valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc.cluster.local:6379"
```
All 3 bp-newapi chart render tests PASS.

## Audit — was newapi→valkey the only active miss?
Grep of old service names (`valkey-primary.valkey.svc` / `seaweedfs-*.seaweedfs.svc` / `*.vllm.svc`) across all charts: **yes**. Remaining hits are non-issues:
- catalyst projector `valkey.addr`, SME `smeServices.valkey.host`, gitea `objectStorage.endpoint`, qa-fixtures CNPG barman endpoint, newapi `vllm.endpoint` — already synced in #3373.
- `sme-services/configmap.yaml` `VALKEY_ADDR` `default` — dead fallback; `.Values.smeServices.valkey.host` is set to the synced name.
- `platform/matrix` — not in placement.yaml / no bootstrap-kit slot → not deployed on a fresh prov.

After this, newapi can be re-walked for #3374.

Refs #3373
Refs #3482

🤖 Generated with [Claude Code](https://claude.com/claude-code)