### PR TITLE
fix(bp-openbao): republish 1.2.39 — unwedge the never-published 1.2.38 OCI pin (snapshot-replication test lockstep miss in #3477)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -77,8 +77,12 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      # 1.2.38 (#3373 Batch A): snapshot-replication s3 endpoint default → rtz-vCluster synced name (seaweedfs moved into rtz).
-      version: 1.2.38
+      # 1.2.39 (#3374): republish — 1.2.38's OCI artifact NEVER landed (its
+      # Blueprint Release run failed at the snapshot-replication-toggle.sh test
+      # gate, which #3477 left asserting the pre-move s3 endpoint), wedging
+      # `chart pull error: not found` on hw133 + every fresh prov. Test fixed +
+      # version bumped so the pinned artifact is fetchable on ghcr.
+      version: 1.2.39
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.38
+  version: 1.2.39
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -26,11 +26,20 @@ name: bp-openbao
 # sectionName by default — multi-zone Sovereigns rename HTTPS listeners
 # to https-<sanitised-zone>, breaking NoMatchingListener with the prior
 # pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
+# 1.2.39 — Refs #3374 (2026-06-14): the 1.2.38 OCI publish NEVER landed on
+# ghcr — its Blueprint Release run (commit 3d8042122, PR #3477) FAILED at the
+# snapshot-replication-toggle.sh integration-test gate. #3477 rewired the s3
+# endpoint default to the rtz-vCluster synced Service name but did NOT update
+# the test's two endpoint assertions in lockstep, so Case 2 failed the render
+# check and the helm-push to GHCR never ran → bp-openbao:1.2.38 = "chart pull
+# error: not found" on every Sovereign + fresh prov. Test assertions corrected;
+# version bumped so CI publishes a passing artifact. No chart-behaviour change.
 # 1.2.38 — Refs #3373 Batch A (2026-06-14): bp-seaweedfs moved INTO the rtz
 # vCluster; rewire the snapshot-replication s3 endpoint DEFAULT to the
 # syncer-mangled host Service name. snapshotReplication is default-OFF, so the
 # single-region render is byte-identical (the default applies only when enabled).
-version: 1.2.38
+# NOTE: 1.2.38 was never published to ghcr (see 1.2.39 above).
+version: 1.2.39
 # 1.2.37 (#3374, 2026-06-14): fix the sso-landing nginx ImagePullBackOff. The
 # image was `harbor.openova.io/proxy-docker/library/nginx` but the live Harbor
 # DockerHub proxy-cache project is `proxy-dockerhub` (proxy-docker does NOT

--- a/platform/openbao/chart/tests/snapshot-replication-toggle.sh
+++ b/platform/openbao/chart/tests/snapshot-replication-toggle.sh
@@ -71,8 +71,10 @@ if ! grep -qE "sys/storage/raft/snapshot" "$TMP/primary.yaml"; then
   echo "FAIL: primary CronJob missing the raft snapshot save (sys/storage/raft/snapshot)." >&2
   exit 1
 fi
-# The S3 upload must point at the SeaweedFS S3 endpoint.
-if ! grep -qE "seaweedfs-s3\.seaweedfs\.svc\.cluster\.local:8333" "$TMP/primary.yaml"; then
+# The S3 upload must point at the SeaweedFS S3 endpoint. #3373 Batch A
+# (2026-06-14): bp-seaweedfs moved INTO the rtz vCluster, so the default
+# endpoint is now the syncer-mangled host Service name.
+if ! grep -qE "seaweedfs-s3-x-seaweedfs-x-rtz-vcluster\.rtz\.svc\.cluster\.local:8333" "$TMP/primary.yaml"; then
   echo "FAIL: primary CronJob missing the seaweedfs-s3 endpoint." >&2
   exit 1
 fi
@@ -120,7 +122,7 @@ if ! grep -qE "s3api list-objects-v2" "$TMP/secondary.yaml"; then
   echo "FAIL: secondary CronJob missing the S3 list-objects fetch." >&2
   exit 1
 fi
-if ! grep -qE "seaweedfs-s3\.seaweedfs\.svc\.cluster\.local:8333" "$TMP/secondary.yaml"; then
+if ! grep -qE "seaweedfs-s3-x-seaweedfs-x-rtz-vcluster\.rtz\.svc\.cluster\.local:8333" "$TMP/secondary.yaml"; then
   echo "FAIL: secondary CronJob missing the seaweedfs-s3 endpoint." >&2
   exit 1
 fi


### PR DESCRIPTION
## The keystone wedge

`clusters/_template/bootstrap-kit/08-openbao.yaml` pins `bp-openbao:1.2.38`, and `platform/openbao/chart/Chart.yaml` reads `version: 1.2.38` — but **`oci://ghcr.io/openova-io/bp-openbao:1.2.38` does not exist** (ghcr's highest published tag is 1.2.37). On hw133 and on **every fresh prov**, the slot-08 HelmRelease wedges with `chart pull error: ...1.2.38: not found`, and the chain behind it (`bp-sso-bridge`, `bp-oidc-gate`, `bp-newapi`, `bp-powerdns-admin`, `bp-external-secrets-stores`) stalls `False (dependency)`. newapi's published 1.4.81/82 valkey-fix can't reconcile because of this.

## Root cause — NOT a silent helm-push flake

The Blueprint Release run for the 1.2.38 bump (run [27482688235](https://github.com/openova-io/openova/actions/runs/27482688235), commit `3d8042122`, **PR #3477** "re-home bp-seaweedfs INTO the rtz vCluster") **FAILED** at the `Run chart integration tests (chart/tests/*.sh)` step in job `build (platform/openbao)`. That gate sits **before** `Helm push to GHCR`, so the push (and signing/SBOM/auto-bump) was skipped — the tag was packaged + smoke-rendered but never pushed.

#3477 rewired the snapshot-replication S3 endpoint **default** from `seaweedfs-s3.seaweedfs.svc.cluster.local:8333` to the rtz-vCluster syncer-mangled name `seaweedfs-s3-x-seaweedfs-x-rtz-vcluster.rtz.svc.cluster.local:8333` (in both `templates/snapshot-replication.yaml` and `values.yaml`), but did **not** update the two endpoint assertions in `chart/tests/snapshot-replication-toggle.sh` in lockstep. Case 2 (role=primary) then fails the render check → integration-test step exits 1 → no publish. Reproduced locally: `FAIL: primary CronJob missing the seaweedfs-s3 endpoint.`

## Fix

1. Correct both endpoint assertions in `snapshot-replication-toggle.sh` to the new synced Service name.
2. Bump `Chart.yaml` + `blueprint.yaml` + the slot-08 pin **1.2.38 → 1.2.39** so CI publishes a passing artifact. (1.2.38 can't be cleanly re-pushed — the version field already reads 1.2.38 with no fetchable artifact; a clean version bump with the fixed test is the deterministic path.)

No chart-behaviour change: `snapshotReplication` is default-OFF, so the single-region render is byte-identical; the new default applies only when an operator enables DR.

## Verification (local)

- All **7** openbao chart tests PASS (`snapshot-replication-toggle.sh` Cases 1–4 green).
- `check-bootstrap-kit-pin-sync.sh` PASS (pin == Chart.yaml version).
- `check-bootstrap-deps.sh` PASS (0 drift, 0 cycles).
- `check-catalog-seed-lockstep.sh` PASS (68 checked, 0 fail).
- No banned words in the diff.

## Full bootstrap-kit audit — only one gap

Audited all **64** bootstrap-kit HelmRelease pins (61 distinct OCI charts) against `ghcr.io/openova-io`. **`bp-openbao:1.2.38` is the ONLY missing artifact** — all 60 other distinct pins are PRESENT. No GitRepository-sourced HRs (nothing skipped). After this PR publishes 1.2.39, every bootstrap-kit pin is ghcr-published → fresh-prov-safe.

Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)