### PR TITLE
fix(bp-powerdns-admin): read CNPG pda-pg-app directly — retire racy reflects: pull-mirror that looped the embedded install (Refs #3486, #3380)

### DIFF
--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -129,7 +129,11 @@ spec:
       # postgres.cluster.enabled gate + databaseSecret.name flip so PDA
       # adopts the shared-pg-b `pda` Context (one-flag enable_shared_pg
       # contract, the gitea/harbor/keycloak shape).
-      version: 0.1.13
+      # 0.1.14 (#3486): embedded path reads the CNPG pda-pg-app Secret
+      # directly — retires the racy reflects: pull-mirror that left
+      # pda-database-secret empty and looped the install forever (wedged
+      # bootstrap-kit -> sovereign-tls -> wildcard cert -> console 000).
+      version: 0.1.14
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns-admin

--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -147,16 +147,21 @@ spec:
     sso:
       sovereignFqdn: "${SOVEREIGN_FQDN}"
     # ── Shared-instance flip (#3370 — the gitea/harbor/keycloak shape) ──
-    # Default OWN_CLUSTER=true → the bundled pda-pg Cluster + its
-    # pda-database-secret mirror render exactly as today (single-region
-    # render byte-identical; envs provisioned before these vars existed
-    # resolve the `:=` defaults). Cloud-init computes OWN_CLUSTER=false
-    # + the secret flip from the SAME enable_shared_pg var that turns
-    # slot 16c ON: PDA then reads username/password/uri straight from
-    # the reflector-PUSHED pda-shared-database-secret hub (shared-pg-b's
-    # `pda` Context) — no mirror hop, no reflects: pull.
+    # Default OWN_CLUSTER=true → the bundled pda-pg CNPG Cluster renders and
+    # PDA reads its generated `pda-pg-app` Secret DIRECTLY (same namespace,
+    # always present, carries uri/username/password). #3486: the default
+    # secret name is now `pda-pg-app`, NOT the retired empty
+    # `pda-database-secret` reflector mirror — that same-namespace
+    # `reflects:` pull was edge-triggered and raced the HR
+    # uninstall/reinstall remediation churn, leaving the mirror empty and
+    # looping the install forever (which wedged bootstrap-kit → sovereign-tls
+    # → the wildcard cert → console HTTP 000 on hw134). Cloud-init computes
+    # OWN_CLUSTER=false + the secret flip from the SAME enable_shared_pg var
+    # that turns slot 16c ON: PDA then reads username/password/uri straight
+    # from the reflector-PUSHED pda-shared-database-secret hub (shared-pg-b's
+    # `pda` Context) — also a direct read, no mirror hop, no reflects: pull.
     postgres:
       cluster:
         enabled: ${SOVEREIGN_PDA_PG_OWN_CLUSTER:=true}
     databaseSecret:
-      name: ${SOVEREIGN_PDA_PG_SECRET:=pda-database-secret}
+      name: ${SOVEREIGN_PDA_PG_SECRET:=pda-pg-app}

--- a/platform/powerdns-admin/blueprint.yaml
+++ b/platform/powerdns-admin/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 0.1.13
+  version: 0.1.14
   card:
     title: powerdns-admin
     summary: |

--- a/platform/powerdns-admin/chart/Chart.yaml
+++ b/platform/powerdns-admin/chart/Chart.yaml
@@ -90,7 +90,25 @@ name: bp-powerdns-admin
 # pda-shared-database-secret, reflector-PUSHED into this namespace)
 # via the slot-11a databaseSecret.name flip — same one-flag contract
 # as gitea/harbor/keycloak (enable_shared_pg).
-version: 0.1.13
+# 0.1.14 (#3486, 2026-06-14): RETIRE the racy same-namespace reflector
+# PULL-mirror that left `pda-database-secret` empty and looped the
+# embedded-cluster install forever on every fresh prov. The PDA Deployment
+# now reads the CNPG-generated `pda-pg-app` Secret DIRECTLY (default
+# databaseSecret.name flip in values.yaml + slot 11a) — same namespace,
+# always present, already carries uri/username/password. The old empty
+# Secret + its `reflects:` annotation was edge-triggered on the DESTINATION
+# only, so when CNPG regenerated `pda-pg-app` during the HR's
+# uninstall/reinstall remediation churn the mirror never re-ran → DATA=0 →
+# PDA Pod CreateContainerConfigError → 15m install timeout →
+# remediateLastFailure uninstall+retry → pda-pg re-bootstrap → infinite
+# loop. That HR-never-Ready wedged the bootstrap-kit Kustomization, which
+# blocked the sovereign-tls Kustomization (dependsOn bootstrap-kit) that
+# applies the `*.<fqdn>` wildcard Certificate → the Cilium Gateway :443
+# listener stayed `Invalid CertificateRef` → the console served HTTP 000
+# (traced live on hw134, dep 6a189d1b7d8cebc8). database-secret.yaml is
+# now skip-rendered (no consumer); the shared-pg-b path already read a
+# reflector-PUSHED hub directly so it is unchanged.
+version: 0.1.14
 description: |
   PowerDNS-Admin (ngoduykhanh/powerdns-admin) web UI Blueprint for
   per-Sovereign PowerDNS zone + record management. Drives the

--- a/platform/powerdns-admin/chart/templates/cnpg-cluster.yaml
+++ b/platform/powerdns-admin/chart/templates/cnpg-cluster.yaml
@@ -2,10 +2,13 @@
 CNPG Cluster for PowerDNS-Admin metadata (users, RBAC, audit log).
 Mirrors platform/gitea/chart/templates/cnpg-cluster.yaml.
 
-CNPG operator generates a `<cluster>-app` Secret with the postgres-app
-user's password; reflector mirrors it into pda-database-secret (see
-templates/database-secret.yaml) so deployment.yaml can read the password
-via secretKeyRef without a cross-namespace reference.
+CNPG operator generates a `<cluster>-app` Secret (`pda-pg-app`) carrying
+the postgres-app user's `uri`/`username`/`password`. 0.1.14 (#3486):
+deployment.yaml reads `pda-pg-app` DIRECTLY via secretKeyRef (same
+namespace, no cross-namespace ref) — the old empty `pda-database-secret`
+reflector pull-mirror (templates/database-secret.yaml) is retired because
+its same-namespace `reflects:` pull raced the HR remediation churn and
+never converged.
 
 Capabilities gate (0.1.8, Refs #2737): bp-cnpg ships the
 `postgresql.cnpg.io/v1` CRD. On a cold install — before bp-cnpg is
@@ -51,19 +54,21 @@ spec:
     {{- toYaml .Values.postgres.cluster.resources | nindent 4 }}
 
   # inheritedMetadata.annotations: CNPG propagates these onto every Secret
-  # it generates (pda-pg-app, pda-pg-superuser, …). The k8s-reflector
-  # (bp-reflector) requires the SOURCE Secret to carry
-  # `reflection-allowed: "true"` before it will copy data into the
-  # DESTINATION Secret (`pda-database-secret`, templates/database-secret.yaml).
-  # Setting these annotations on the Cluster CR's own metadata does NOT work
-  # — CNPG does not copy `metadata.annotations` onto generated Secrets; the
-  # `inheritedMetadata` stanza is the correct CNPG v1.24+ mechanism.
+  # it generates (pda-pg-app, pda-pg-superuser, …). The `inheritedMetadata`
+  # stanza is the correct CNPG v1.24+ mechanism (CNPG does not copy a
+  # Cluster CR's own `metadata.annotations` onto generated Secrets).
   #
-  # #3150: bp-powerdns-admin only first installed once #3173 listed slot 11a,
-  # which exposed that this block was MISSING — reflector logged
-  # "Source powerdns-admin/pda-pg-app does not permit it" so pda-database-secret
-  # stayed empty → the PDA Pod wedged in CreateContainerConfigError (no
-  # SQLA_DB_USER/PASSWORD). Mirrors the gitea/harbor gold-standard pattern.
+  # 0.1.14 (#3486): the PDA Deployment now reads `pda-pg-app` DIRECTLY
+  # (values.yaml databaseSecret.name), so these reflection-allowed
+  # annotations are no longer load-bearing for THIS chart — the racy
+  # same-namespace `reflects:` pull they enabled is retired (see
+  # templates/database-secret.yaml). They are kept (harmless) so that any
+  # cross-namespace consumer that opts into AUTO-reflection of pda-pg-app
+  # keeps working, mirroring the gitea/harbor gold-standard pattern.
+  #
+  # Historical (#3150): before this block existed, reflector logged
+  # "Source powerdns-admin/pda-pg-app does not permit it" and the old
+  # pda-database-secret mirror stayed empty → CreateContainerConfigError.
   inheritedMetadata:
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"

--- a/platform/powerdns-admin/chart/templates/database-secret.yaml
+++ b/platform/powerdns-admin/chart/templates/database-secret.yaml
@@ -1,17 +1,44 @@
 {{- /*
-Mirror of the CNPG-generated `pda-pg-app` Secret into the local
-namespace under the canonical name `pda-database-secret`. Reflector
-copies the `password` + `username` keys when the source Secret lands.
+0.1.14 (#3486): RETIRED — the racy same-namespace reflector PULL-mirror.
 
-The deployment.yaml secretKeyRefs use this name so we don't have to
-reference the CNPG-operator-generated name directly (which would couple
-deployment.yaml to a specific CNPG release naming convention).
-0.1.12 (#3370): gated on `postgres.cluster.enabled` — in shared mode
-(slot 16c Context) there is no pda-pg-app source to mirror; the
-deployment reads the reflector-PUSHED `pda-shared-database-secret` hub
-directly via the databaseSecret.name flip (the dead `reflects:` pull
-chain documented in bp-postgres role-secrets.yaml is avoided entirely).
+This template historically created an EMPTY Secret named
+`pda-database-secret` carrying a
+`reflector.v1.k8s.emberstack.com/reflects: <ns>/pda-pg-app` annotation,
+relying on bp-reflector to pull the `uri`/`username`/`password` keys out
+of the CNPG-generated `pda-pg-app` Secret.
+
+That pull is EDGE-TRIGGERED on the DESTINATION Secret's create/update —
+NOT on every change to the source. On a fresh prov the bp-powerdns-admin
+HelmRelease install routinely exceeds its 15m timeout while bp-cnpg
+cold-bootstraps the pda-pg Cluster, so `install.remediation.
+remediateLastFailure: true` UNINSTALLS the release (deleting the pda-pg
+Cluster and its CNPG Secrets) and reinstalls from scratch. Each time CNPG
+regenerates `pda-pg-app`, reflector's AUTO-reflection fires (push to other
+namespaces) but the same-namespace PULL-mirror does not re-run, so
+`pda-database-secret` stays empty (DATA=0). The PDA Pod then hangs in
+CreateContainerConfigError ("couldn't find key uri in Secret
+powerdns-admin/pda-database-secret"), the install times out again, and the
+loop repeats forever — wedging the bootstrap-kit Kustomization, which
+blocks the sovereign-tls Kustomization (dependsOn bootstrap-kit) that
+applies the `*.<fqdn>` wildcard Certificate, leaving the Cilium Gateway
+:443 listener `Invalid CertificateRef` and the console at HTTP 000. Traced
+live on hw134 (dep 6a189d1b7d8cebc8).
+
+The deployment now reads the CNPG-generated `pda-pg-app` Secret DIRECTLY
+(values.yaml `databaseSecret.name: pda-pg-app`) — same namespace, always
+present, already carries every key the Pod needs. The mirror is therefore
+DEAD and rendering it would only re-create an unused empty Secret that
+collides on the `pda-database-secret` name with no consumer. Render nothing.
+
+Kept (not deleted) so `git blame` / future revival keeps the historical
+shape; remove entirely once no Sovereign overlay pins
+`databaseSecret.name: pda-database-secret`.
+
+The shared-pg-b path (#3370, slot 11a) flips `databaseSecret.name` to the
+reflector-PUSHED `pda-shared-database-secret` hub — also a direct read, no
+`reflects:` pull — so neither path needs this mirror.
 */ -}}
+{{- if false }}
 {{- $clusterEnabled := true }}
 {{- if hasKey .Values.postgres.cluster "enabled" }}
 {{- $clusterEnabled = ne (toString .Values.postgres.cluster.enabled) "false" }}
@@ -28,4 +55,5 @@ metadata:
   annotations:
     reflector.v1.k8s.emberstack.com/reflects: "{{ .Release.Namespace }}/{{ .Values.databaseSecret.cnpgSecretName | default "pda-pg-app" }}"
 type: Opaque
+{{- end }}
 {{- end }}

--- a/platform/powerdns-admin/chart/values.yaml
+++ b/platform/powerdns-admin/chart/values.yaml
@@ -93,10 +93,10 @@ gateway:
 postgres:
   cluster:
     # 0.1.12 (#3370): embedded-cluster gate. false → the bundled pda-pg
-    # Cluster (and its pda-database-secret mirror) are skipped; PDA runs
-    # against the shared-pg-b instance's `pda` Context via the reflected
-    # pda-shared-database-secret hub (slot 11a flips databaseSecret.name
-    # in lockstep). Default true = byte-identical 1:1 embedded render.
+    # Cluster is skipped; PDA runs against the shared-pg-b instance's `pda`
+    # Context via the reflector-PUSHED pda-shared-database-secret hub (slot
+    # 11a flips databaseSecret.name in lockstep). true → PDA reads the
+    # bundled cluster's CNPG-generated pda-pg-app Secret directly (#3486).
     enabled: true
     name: pda-pg
     namespace: ""                  # defaults to .Release.Namespace
@@ -121,11 +121,35 @@ postgres:
         cpu: 500m
         memory: 512Mi
 
-# Reflector — mirrors the CNPG-generated `pda-pg-app` Secret into
-# `pda-database-secret` so the deployment.yaml secretKeyRef resolves
-# regardless of CNPG operator's own naming scheme.
+# Database credential Secret the deployment.yaml secretKeyRefs read
+# (uri/username/password).
+#
+# 0.1.14 (#3486): the embedded-cluster path reads the CNPG-generated
+# `pda-pg-app` Secret DIRECTLY (same namespace as the Deployment, always
+# present once bp-cnpg materialises the pda-pg Cluster, already carries
+# `uri`/`username`/`password`). The previous indirection — an empty
+# `pda-database-secret` carrying a `reflector .../reflects: pda-pg-app`
+# annotation that bp-reflector PULL-mirrored — wedged every fresh prov:
+# the same-namespace `reflects:` pull is edge-triggered on the DESTINATION,
+# so when CNPG regenerated `pda-pg-app` during the HR's
+# uninstall/reinstall remediation churn the mirror never re-ran →
+# `pda-database-secret` stayed empty (DATA=0) → the PDA Pod hung in
+# CreateContainerConfigError ("couldn't find key uri") → the 15m HR
+# install timed out → remediateLastFailure uninstalled + restarted → the
+# pda-pg Cluster re-bootstrapped → infinite loop. That HR-never-Ready
+# wedged the bootstrap-kit Kustomization's health-check loop, blocking the
+# `sovereign-tls` Kustomization (dependsOn bootstrap-kit) that applies the
+# `*.<fqdn>` wildcard Certificate → the Cilium Gateway :443 listener stayed
+# `Invalid CertificateRef` → the console served HTTP 000 (traced live on
+# hw134, dep 6a189d1b7d8cebc8). Reading the CNPG Secret directly removes
+# the empty-secret window entirely; the install converges first attempt.
+#
+# The shared-pg-b path (slot 11a flips this to `pda-shared-database-secret`,
+# #3370) already reads a reflector-PUSHED hub directly with the same key
+# contract — so deployment.yaml stays generic via `databaseSecret.name`.
 databaseSecret:
-  name: pda-database-secret
+  # cnpg cluster's generated `<cluster>-app` Secret (pda-pg → pda-pg-app).
+  name: pda-pg-app
   cnpgSecretName: pda-pg-app
   passwordKey: password
   usernameKey: username


### PR DESCRIPTION
## Problem
On the fresh prov **hw134** (standing-mission proof env, dep `6a189d1b7d8cebc8`) the operator console served **HTTP 000** (connection refused on :443) for 35+ min despite mothership status=ready and Flux 59/63 HRs Ready.

## Root cause (verified live on hw134, bottom-up)
```
console 000
└─ Cilium Gateway :443 listener condition "Invalid CertificateRef" / "InvalidCertificateRef"
   └─ Secret sovereign-wildcard-tls-hw134-omani-works never created (NO Certificate CR, NO Order, NO Challenge)
      └─ sovereign-tls Kustomization: "dependency 'flux-system/bootstrap-kit' is not ready"
         └─ bootstrap-kit Kustomization stuck 80+ min ("Reconciliation in progress", health-check loop)
            └─ bp-powerdns-admin HR never Ready (installFailures climbing, "context deadline exceeded")
               └─ PDA Pod CreateContainerConfigError: "couldn't find key uri in Secret powerdns-admin/pda-database-secret"
                  └─ pda-database-secret DATA=0 (empty)
```

`pda-database-secret` was an **empty** Secret carrying a `reflector.v1.k8s.emberstack.com/reflects: pda-pg-app` annotation that bp-reflector **PULL-mirrored** from the CNPG-generated `pda-pg-app`. That same-namespace pull is **edge-triggered on the DESTINATION** (create/update), not on every source change. While bp-cnpg cold-bootstraps `pda-pg`, the 15m HR install times out → `install.remediation.remediateLastFailure: true` **uninstalls** the release (deleting the `pda-pg` Cluster + its CNPG Secrets) and reinstalls. Each time CNPG regenerates `pda-pg-app`, reflector's *auto*-reflection fires (push to other namespaces) but the same-namespace *pull*-mirror does **not** re-run → `pda-database-secret` stays empty → the install loops forever. Reflector log confirms: `Could not update powerdns-admin/pda-database-secret - Source powerdns-admin/pda-pg-app could not be found.`

NOT an LE rate-limit: all ClusterIssuers Ready (ACME account registered), no Order ever attempted for the wildcard.

## Fix
Point the Deployment's 3 DB `secretKeyRef`s at the CNPG-generated **`pda-pg-app`** Secret **directly** — same namespace as the Deployment, always present once CNPG is up, already carries `uri`/`username`/`password` (verified live: `uri = postgresql://pda:***@pda-pg-rw.powerdns-admin:5432/pda`). Removes the empty-secret window entirely → install converges first attempt.

- `values.yaml`: `databaseSecret.name` default `pda-database-secret` → `pda-pg-app`
- `templates/database-secret.yaml`: skip-render the now-dead empty mirror (no consumer)
- `clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml`: `SOVEREIGN_PDA_PG_SECRET` default → `pda-pg-app`
- `templates/cnpg-cluster.yaml`: refresh now-stale mirror comments (`inheritedMetadata` kept — harmless)
- `Chart.yaml`: `0.1.13` → `0.1.14`

The shared-pg-b path (#3370, `postgres.cluster.enabled=false`) already read the reflector-**PUSHED** `pda-shared-database-secret` hub directly — no `reflects:` pull — so it is unchanged. Both paths stay generic via `databaseSecret.name`.

## Validation
- `helm template` (embedded default, `--api-versions postgresql.cnpg.io/v1`): the 3 DB env vars resolve to `pda-pg-app`/`uri`, `pda-pg-app`/`username`, `pda-pg-app`/`password`; **no** `pda-database-secret` Secret emitted; CNPG `Cluster pda-pg` still rendered.
- `helm template` (shared path, `enabled=false` + name flip): no `pda-pg` Cluster, secretKeyRefs → `pda-shared-database-secret`, no `pda-database-secret`.
- `helm lint`: 0 failed.

Applies on the next Flux reconcile (hw134 + all future provs).

Refs #3486
Refs #3380

🤖 Generated with [Claude Code](https://claude.com/claude-code)