### PR TITLE
fix(cloudinit): embedded SOVEREIGN_PDA_PG_SECRET -> pda-pg-app — the var that overrode the #3487 chart default (Refs #3486, #3380)

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -481,8 +481,18 @@ write_files:
             # sme-pg Cluster; every SME service + FerretDB dials
             # shared-pg-c-rw with credentials from the sme-database-
             # secret hub — one `sme` role across the three databases).
+            #
+            # #3486 — the EMBEDDED path (enable_shared_pg=false) now reads the
+            # CNPG-generated `pda-pg-app` Secret DIRECTLY (same namespace,
+            # always present, carries uri/username/password). The retired
+            # `pda-database-secret` reflector PULL-mirror was edge-triggered on
+            # the destination and raced the HR uninstall/reinstall remediation
+            # churn → stayed empty → PDA CreateContainerConfigError → 15m
+            # install timeout → loop forever → wedged bootstrap-kit →
+            # sovereign-tls → the wildcard cert → console HTTP 000 (hw134). The
+            # shared path still reads the reflector-PUSHED hub directly.
             SOVEREIGN_PDA_PG_OWN_CLUSTER: "${enable_shared_pg == "true" ? "false" : "true"}"
-            SOVEREIGN_PDA_PG_SECRET: "${enable_shared_pg == "true" ? "pda-shared-database-secret" : "pda-database-secret"}"
+            SOVEREIGN_PDA_PG_SECRET: "${enable_shared_pg == "true" ? "pda-shared-database-secret" : "pda-pg-app"}"
             SOVEREIGN_SME_PG_OWN_CLUSTER: "${enable_shared_pg == "true" ? "false" : "true"}"
             SOVEREIGN_SME_PG_HOST: "${enable_shared_pg == "true" ? "shared-pg-c-rw.shared-data.svc.cluster.local" : ""}"
             SOVEREIGN_SME_PG_SECRET: "${enable_shared_pg == "true" ? "sme-database-secret" : ""}"


### PR DESCRIPTION
## Why this is needed (companion to #3487)
#3487 made the PDA Deployment read the CNPG-generated `pda-pg-app` Secret directly (chart default `databaseSecret.name: pda-pg-app`). But on a live Sovereign that default is **overridden** by the HelmRelease value the `bootstrap-kit` Flux Kustomization substitutes from this cloud-init template's `postBuild` map.

For the embedded path (`enable_shared_pg=false` — the default, and hw134) line 485 hardcoded:
```
SOVEREIGN_PDA_PG_SECRET: "...false ? ... : "pda-database-secret""
```
So every prov's live `postBuild.substitute.SOVEREIGN_PDA_PG_SECRET` = `pda-database-secret` → the HR kept `databaseSecret.name: pda-database-secret` → the empty-mirror install loop persisted regardless of the chart default. Verified live on hw134: the HR `.spec.values.databaseSecret.name` was `pda-database-secret` even after the 0.1.14 chart landed.

## Fix
Flip the embedded-path value to **`pda-pg-app`** (the CNPG Secret the chart now reads directly). The shared path (`enable_shared_pg=true`) still resolves `pda-shared-database-secret` (the reflector-PUSHED hub).

```
SOVEREIGN_PDA_PG_SECRET: "${enable_shared_pg == "true" ? "pda-shared-database-secret" : "pda-pg-app"}"
```

## Validation
- `scripts/lint-cloudinit.sh both` → PASS (hetzner 46 runcmd + huawei 43 runcmd, `dash -n` clean).
- Embedded-path render now emits `SOVEREIGN_PDA_PG_SECRET: pda-pg-app`.

Applies on the next fresh prov (cloud-init bakes the substitute map at bootstrap). For the already-provisioned hw134 the live `postBuild.substitute` var was patched to `pda-pg-app` directly to validate the convergence.

Refs #3486
Refs #3380

🤖 Generated with [Claude Code](https://claude.com/claude-code)