### PR TITLE
feat(continuum): wire openbao raft-transition promotion into the switchover engine

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -82,7 +82,11 @@ spec:
       # gate, which #3477 left asserting the pre-move s3 endpoint), wedging
       # `chart pull error: not found` on hw133 + every fresh prov. Test fixed +
       # version bumped so the pinned artifact is fetchable on ghcr.
-      version: 1.2.39
+      # 1.2.40 (#3492): ship the openbao DR contract (Continuum CR,
+      # mechanism=raft-transition) so bp-continuum can promote bp-openbao
+      # on a region-kill. Default-OFF (continuum.enabled + role=secondary),
+      # so the single-region render is byte-identical. Pin in lockstep.
+      version: 1.2.40
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1026,7 +1026,8 @@ spec:
             # 1.4.619 — #3374: baseline-default-deny allows ingress from the oidc-gate host ns → oidc-gate auth-proxy can reach openova-flow-server in catalyst-system (was dropped → SSO OK but app 502'd on upstream timeout; same class as sme→NATS #3423).
             # 1.4.621 — #3373 Batch A: SME valkey consumer + projector addr → rtz-vCluster syncer-mangled name (bp-valkey moved into rtz); valkey-cross-ns CNP disabled (rtz isolation netpol `sme` carve-out governs the wire).
             # 1.4.623 — #3373 Batch A: qa-fixtures CNPG barman backup endpoint default → rtz-vCluster synced seaweedfs-s3 name (seaweedfs moved into rtz; 1.4.622 was a content-free deploy-bot sweep).
-      version: 1.4.625
+            # 1.4.626 — #3492: Continuum CRD gains spec.switchover.{mechanism,raftTransition} (bp-openbao raft-transition DR contract); additive, slot-13 crds:CreateReplace propagates the schema. Render byte-unchanged.
+      version: 1.4.626
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
+++ b/clusters/_template/bootstrap-kit/62-bp-continuum.yaml
@@ -131,7 +131,12 @@ spec:
       # fresh-prov walk).
       # 0.1.4 (#3189): prerequisite-check initContainer no longer
       # crashloops on single-region (no cnpg-pair) — exits 0 + idle-Ready.
-      version: 0.1.5
+      # 0.1.6 (#3492): switchover sequencer gains the per-mechanism
+      # Promoter seam — cnpg-pair (default) + raft-transition (bp-openbao
+      # `bao operator raft snapshot restore` + `transition-to-primary`
+      # via Pod exec on the surviving standby). RBAC adds pods +
+      # pods/exec. Pin moves in lockstep (Inviolable Principle #13).
+      version: 0.1.6
       sourceRef:
         kind: HelmRepository
         name: bp-continuum

--- a/core/controllers/continuum/cmd/main.go
+++ b/core/controllers/continuum/cmd/main.go
@@ -189,6 +189,24 @@ func main() {
 		}
 	}
 
+	// #3492 — raft-transition promotion backend (bp-openbao). The
+	// RaftExecPromoter execs `bao operator raft snapshot restore` +
+	// `transition-to-primary` into the surviving openbao standby Pod via
+	// SPDY exec; the PodLister resolves a podSelector to a Ready Pod.
+	// cnpg-pair CRs never touch this path. A nil executor (clientset
+	// init failure) leaves raft-transition CRs failing at step-2 with a
+	// clear "no RaftPromoter wired" error rather than crashing the
+	// controller — cnpg-pair DR is unaffected.
+	var raftPromoter switchover.Promoter
+	if execBackend, err := newSPDYPodExecutor(ctrl.GetConfigOrDie()); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: raft-transition exec backend init failed (%v); raft-transition switchovers will error until fixed (cnpg-pair unaffected)\n", err)
+	} else {
+		raftPromoter = &switchover.RaftExecPromoter{
+			Exec:   execBackend,
+			Lister: newDynamicPodLister(dyn),
+		}
+	}
+
 	r := &controller.ContinuumReconciler{
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
@@ -198,6 +216,7 @@ func main() {
 		PDMClient:       pdmClient,
 		Audit:           audit,
 		Drainer:         switchover.NewDynamicHTTPRouteDrainer(dyn),
+		RaftPromoter:    raftPromoter,
 		HealthDelay:     healthDelay,
 		HealthOpts: switchover.HealthOptions{
 			// Production: 8.8.8.8 / 1.1.1.1 / 9.9.9.9 multi-vantage

--- a/core/controllers/continuum/cmd/raftexec.go
+++ b/core/controllers/continuum/cmd/raftexec.go
@@ -1,0 +1,146 @@
+// Production Pod-exec backend for the raft-transition promotion (#3492).
+//
+// This is the kube-client implementation of switchover.PodExecutor +
+// switchover.PodLister the controller wires into the RaftExecPromoter so
+// bp-continuum can run `bao operator raft snapshot restore` +
+// `transition-to-primary` inside the surviving-region openbao standby Pod
+// on a region-kill.
+//
+// The exec uses client-go remotecommand SPDY against the kube-apiserver —
+// the same mechanism core/cmd/k8s-ws-proxy/internal/proxy/exec.go uses.
+// It lives in the cmd package (not internal/switchover) so the switchover
+// package keeps a minimal interface seam and does not grow a hard
+// dependency on the remotecommand SDK (which keeps its unit tests
+// SDK-free).
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	remotecommand "k8s.io/client-go/tools/remotecommand"
+)
+
+// podGVR — core/v1 Pods, for the PodLister.
+var podGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+
+// spdyPodExecutor implements switchover.PodExecutor via remotecommand SPDY.
+type spdyPodExecutor struct {
+	cfg       *rest.Config
+	clientset kubernetes.Interface
+}
+
+// newSPDYPodExecutor builds the executor from the in-cluster REST config.
+func newSPDYPodExecutor(cfg *rest.Config) (*spdyPodExecutor, error) {
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("raftexec: clientset: %w", err)
+	}
+	return &spdyPodExecutor{cfg: cfg, clientset: cs}, nil
+}
+
+// Exec runs `command` in (namespace/pod/container) and returns combined
+// stdout+stderr. A non-zero exit surfaces as a non-nil error (the SDK
+// returns a CodeExitError) — the caller's wrapper includes the output so
+// the operator sees exactly what the bao binary rejected.
+func (e *spdyPodExecutor) Exec(ctx context.Context, namespace, pod, container string, command []string) (string, error) {
+	req := e.clientset.CoreV1().RESTClient().
+		Post().
+		Resource("pods").
+		Namespace(namespace).
+		Name(pod).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: container,
+			Command:   command,
+			Stdin:     false,
+			Stdout:    true,
+			Stderr:    true,
+			TTY:       false,
+		}, kubescheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(e.cfg, "POST", req.URL())
+	if err != nil {
+		return "", fmt.Errorf("raftexec: NewSPDYExecutor: %w", err)
+	}
+	var stdout, stderr bytes.Buffer
+	streamErr := exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+	out := joinExecOutput(&stdout, &stderr)
+	if streamErr != nil {
+		return out, streamErr
+	}
+	return out, nil
+}
+
+// dynamicPodLister implements switchover.PodLister via the dynamic client.
+type dynamicPodLister struct {
+	dyn dynamic.Interface
+}
+
+// newDynamicPodLister builds the lister from the dynamic client.
+func newDynamicPodLister(dyn dynamic.Interface) *dynamicPodLister {
+	return &dynamicPodLister{dyn: dyn}
+}
+
+// ReadyPods returns the names of Ready Pods in `namespace` matching
+// `selector`, lexically sorted so promotion is deterministic.
+func (l *dynamicPodLister) ReadyPods(ctx context.Context, namespace, selector string) ([]string, error) {
+	list, err := l.dyn.Resource(podGVR).Namespace(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: selector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("raftexec: list pods (%s/%s): %w", namespace, selector, err)
+	}
+	var ready []string
+	for i := range list.Items {
+		pod := &corev1.Pod{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(list.Items[i].Object, pod); err != nil {
+			continue
+		}
+		if isPodReady(pod) {
+			ready = append(ready, pod.Name)
+		}
+	}
+	sort.Strings(ready)
+	return ready, nil
+}
+
+// isPodReady reports whether the Pod has condition Ready=True.
+func isPodReady(pod *corev1.Pod) bool {
+	for _, c := range pod.Status.Conditions {
+		if c.Type == corev1.PodReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// joinExecOutput merges stdout+stderr (stderr after stdout, newline-joined).
+func joinExecOutput(stdout, stderr *bytes.Buffer) string {
+	var b bytes.Buffer
+	if stdout != nil {
+		b.Write(stdout.Bytes())
+	}
+	if stderr != nil && stderr.Len() > 0 {
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.Write(stderr.Bytes())
+	}
+	return b.String()
+}

--- a/core/controllers/continuum/internal/controller/continuum_controller.go
+++ b/core/controllers/continuum/internal/controller/continuum_controller.go
@@ -117,6 +117,14 @@ type ContinuumReconciler struct {
 	// Drainer — HTTPRoute weight flipper. Shared across CRs.
 	Drainer switchover.HTTPRouteDrainer
 
+	// RaftPromoter serves the `raft-transition` switchover mechanism
+	// (bp-openbao): restore the staged snapshot + `bao operator raft
+	// transition-to-primary` via Pod exec on the surviving standby.
+	// Wired in cmd/main.go from a pod-exec backend. Nil = raft-transition
+	// CRs fail at step-2 with a clear error (cnpg-pair CRs unaffected).
+	// (#3492)
+	RaftPromoter switchover.Promoter
+
 	// HealthOpts carries the F-3 post-switchover health-check
 	// dependencies (DNS resolver fanout + audit-tail). Fields nil =
 	// the corresponding check is recorded as deferred.
@@ -363,8 +371,10 @@ func (r *ContinuumReconciler) runSwitchover(
 		ApplicationName:    spec.ApplicationRef,
 		FromRegion:         spec.PrimaryRegion,
 		ToRegion:           toRegion,
+		Mechanism:          spec.Mechanism,
 		CNPGPair:           spec.CNPGPair,
 		CNPGNamespace:      spec.CNPGNamespace,
+		RaftTransition:     spec.RaftTransition,
 		HTTPRouteName:      spec.HTTPRouteName,
 		HTTPRouteNamespace: spec.HTTPRouteNamespace,
 		PDMZone:            spec.PDMZone,
@@ -383,8 +393,9 @@ func (r *ContinuumReconciler) runSwitchover(
 
 	zone := plan.PDMZone
 	seq := &switchover.Sequencer{
-		CNPG:    r.cnpgReader(),
-		Witness: w,
+		CNPG:         r.cnpgReader(),
+		RaftPromoter: r.RaftPromoter,
+		Witness:      w,
 		PDMCommit: func(ctx context.Context, records []dns.Record) error {
 			if r.PDMClient == nil {
 				return errors.New("PDMClient not configured")
@@ -999,7 +1010,7 @@ func (r *ContinuumReconciler) publishLeaseCollision(ctx context.Context, nn type
 // the same as switchover.planFingerprint — that one's input is a
 // SwitchoverPlan, this one's input is a ContinuumSpec.
 func switchoverSpecFingerprint(spec ContinuumSpec) string {
-	return fmt.Sprintf("primary=%s|hot=%v|kind=%s|ttl=%d|renew=%d|rto=%d|auto=%t|pair=%s/%s|hr=%s/%s|zone=%s",
+	return fmt.Sprintf("primary=%s|hot=%v|kind=%s|ttl=%d|renew=%d|rto=%d|auto=%t|mech=%s|pair=%s/%s|raft=%s/%s/%s|hr=%s/%s|zone=%s",
 		spec.PrimaryRegion,
 		spec.HotStandbyRegions,
 		spec.LeaseClientKind,
@@ -1007,7 +1018,9 @@ func switchoverSpecFingerprint(spec ContinuumSpec) string {
 		spec.RenewSeconds,
 		spec.RTOSeconds,
 		spec.AutoFailover,
+		spec.Mechanism,
 		spec.CNPGNamespace, spec.CNPGPair,
+		spec.RaftTransition.Namespace, spec.RaftTransition.Pod, spec.RaftTransition.PodSelector,
 		spec.HTTPRouteNamespace, spec.HTTPRouteName,
 		spec.PDMZone,
 	)

--- a/core/controllers/continuum/internal/controller/continuum_controller_test.go
+++ b/core/controllers/continuum/internal/controller/continuum_controller_test.go
@@ -454,6 +454,52 @@ func TestParseSpec_RequiredFields(t *testing.T) {
 	}
 }
 
+// #3492 — mechanism defaults to empty (=cnpg-pair) when not declared, and
+// the raft-transition block is read when present.
+func TestParseSpec_SwitchoverMechanism(t *testing.T) {
+	t.Parallel()
+
+	// Default: no switchover.mechanism → empty Mechanism (cnpg-pair).
+	cr := newTestContinuumCR("ns", "cr1", "fsn", []string{"hel"}, "in-memory")
+	spec, err := parseSpec(cr)
+	if err != nil {
+		t.Fatalf("parseSpec: %v", err)
+	}
+	if spec.Mechanism != "" {
+		t.Errorf("default Mechanism = %q, want empty (cnpg-pair default)", spec.Mechanism)
+	}
+	if spec.RaftTransition.Namespace != "" {
+		t.Errorf("default RaftTransition should be empty, got namespace=%q", spec.RaftTransition.Namespace)
+	}
+
+	// raft-transition declared, with target.
+	cr = newTestContinuumCR("openbao", "cont-openbao", "me-east-215-a-1", []string{"me-east-215-b-1"}, "dns-quorum")
+	_ = unstructured.SetNestedField(cr.Object, "raft-transition", "spec", "switchover", "mechanism")
+	_ = unstructured.SetNestedMap(cr.Object, map[string]interface{}{
+		"namespace":    "openbao",
+		"podSelector":  "app.kubernetes.io/name=openbao",
+		"container":    "openbao",
+		"snapshotPath": "/snapshots/latest.snap",
+	}, "spec", "switchover", "raftTransition")
+
+	spec, err = parseSpec(cr)
+	if err != nil {
+		t.Fatalf("parseSpec (raft): %v", err)
+	}
+	if string(spec.Mechanism) != "raft-transition" {
+		t.Errorf("Mechanism = %q, want raft-transition", spec.Mechanism)
+	}
+	if spec.RaftTransition.Namespace != "openbao" {
+		t.Errorf("RaftTransition.Namespace = %q", spec.RaftTransition.Namespace)
+	}
+	if spec.RaftTransition.PodSelector != "app.kubernetes.io/name=openbao" {
+		t.Errorf("RaftTransition.PodSelector = %q", spec.RaftTransition.PodSelector)
+	}
+	if spec.RaftTransition.SnapshotPath != "/snapshots/latest.snap" {
+		t.Errorf("RaftTransition.SnapshotPath = %q", spec.RaftTransition.SnapshotPath)
+	}
+}
+
 func TestParseSpec_ErrorPaths(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/core/controllers/continuum/internal/controller/sequencer_provider.go
+++ b/core/controllers/continuum/internal/controller/sequencer_provider.go
@@ -77,8 +77,9 @@ func (r *ContinuumReconciler) SequencerFor(ns, name string) (*switchover.Sequenc
 
 	zone := spec.PDMZone
 	seq := &switchover.Sequencer{
-		CNPG:    r.cnpgReader(),
-		Witness: w,
+		CNPG:         r.cnpgReader(),
+		RaftPromoter: r.RaftPromoter,
+		Witness:      w,
 		PDMCommit: func(ctx context.Context, records []dns.Record) error {
 			if r.PDMClient == nil {
 				return errors.New("PDMClient not configured")
@@ -99,8 +100,10 @@ func (r *ContinuumReconciler) SequencerFor(ns, name string) (*switchover.Sequenc
 		ContinuumName:      types.NamespacedName{Namespace: ns, Name: name}.String(),
 		ApplicationName:    spec.ApplicationRef,
 		FromRegion:         spec.PrimaryRegion,
+		Mechanism:          spec.Mechanism,
 		CNPGPair:           spec.CNPGPair,
 		CNPGNamespace:      spec.CNPGNamespace,
+		RaftTransition:     spec.RaftTransition,
 		HTTPRouteName:      spec.HTTPRouteName,
 		HTTPRouteNamespace: spec.HTTPRouteNamespace,
 		PDMZone:            spec.PDMZone,

--- a/core/controllers/continuum/internal/controller/spec.go
+++ b/core/controllers/continuum/internal/controller/spec.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/openova-io/openova/core/controllers/continuum/internal/dns"
+	"github.com/openova-io/openova/core/controllers/continuum/internal/switchover"
 )
 
 // ContinuumSpec is the parsed view of Continuum.spec used by the
@@ -57,12 +58,25 @@ type ContinuumSpec struct {
 	// operator.
 	AutoFailover bool
 
+	// Mechanism — the switchover state-promotion mechanism
+	// (`cnpg-pair` default | `raft-transition`). Read from
+	// spec.switchover.mechanism; mirrors the Blueprint topology
+	// declaration's switchover.mechanism column. Empty keeps the
+	// cnpg-pair default (#3492).
+	Mechanism switchover.Mechanism
+
 	// CNPGPair + CNPGNamespace — name + namespace of the
 	// bp-cnpg-pair Cluster CR pair this Continuum operates on.
 	// Resolved from the Continuum CR's spec.cnpgPair field (or via
-	// the Application — TBD with C-DB-1's wiring).
+	// the Application — TBD with C-DB-1's wiring). Used by the
+	// cnpg-pair mechanism.
 	CNPGPair      string
 	CNPGNamespace string
+
+	// RaftTransition — the openbao standby target for the
+	// `raft-transition` mechanism. Read from
+	// spec.switchover.raftTransition. Empty for cnpg-pair (#3492).
+	RaftTransition switchover.RaftTransitionTarget
 
 	// HTTPRouteName + HTTPRouteNamespace — Gateway-API HTTPRoute the
 	// drain step targets. Empty = no drain.
@@ -145,6 +159,14 @@ func parseSpec(cr *unstructured.Unstructured) (ContinuumSpec, error) {
 		out.CNPGNamespace = cr.GetNamespace()
 	}
 
+	// #3492 — switchover mechanism + raft-transition target. Empty
+	// mechanism keeps the cnpg-pair default so existing CRs are
+	// unchanged.
+	if m, _, _ := unstructured.NestedString(cr.Object, "spec", "switchover", "mechanism"); m != "" {
+		out.Mechanism = switchover.Mechanism(m)
+	}
+	out.RaftTransition = parseRaftTransition(cr)
+
 	out.HTTPRouteName, _, _ = unstructured.NestedString(cr.Object, "spec", "httpRoute", "name")
 	out.HTTPRouteNamespace, _, _ = unstructured.NestedString(cr.Object, "spec", "httpRoute", "namespace")
 	if out.HTTPRouteNamespace == "" && out.HTTPRouteName != "" {
@@ -194,6 +216,21 @@ func parseSynthParams(cr *unstructured.Unstructured) dns.SynthParams {
 	hns, _, _ := unstructured.NestedStringSlice(cr.Object, "spec", "luaRecord", "hostnames")
 	sp.Hostnames = hns
 	return sp
+}
+
+// parseRaftTransition reads the openbao raft-transition target off the CR
+// (spec.switchover.raftTransition). All fields optional at parse time; the
+// SwitchoverPlan.Validate gate enforces namespace + (pod|podSelector) when
+// the mechanism is actually raft-transition (#3492).
+func parseRaftTransition(cr *unstructured.Unstructured) switchover.RaftTransitionTarget {
+	t := switchover.RaftTransitionTarget{}
+	t.Namespace, _, _ = unstructured.NestedString(cr.Object, "spec", "switchover", "raftTransition", "namespace")
+	t.Pod, _, _ = unstructured.NestedString(cr.Object, "spec", "switchover", "raftTransition", "pod")
+	t.PodSelector, _, _ = unstructured.NestedString(cr.Object, "spec", "switchover", "raftTransition", "podSelector")
+	t.Container, _, _ = unstructured.NestedString(cr.Object, "spec", "switchover", "raftTransition", "container")
+	t.SnapshotPath, _, _ = unstructured.NestedString(cr.Object, "spec", "switchover", "raftTransition", "snapshotPath")
+	t.BaoBinary, _, _ = unstructured.NestedString(cr.Object, "spec", "switchover", "raftTransition", "baoBinary")
+	return t
 }
 
 // parseDurationSeconds parses a `[0-9]+(s|m|h)` duration into

--- a/core/controllers/continuum/internal/switchover/health.go
+++ b/core/controllers/continuum/internal/switchover/health.go
@@ -229,6 +229,20 @@ func (s *Sequencer) PostSwitchoverHealth(ctx context.Context, plan SwitchoverPla
 
 func (s *Sequencer) healthReplicas(ctx context.Context, plan SwitchoverPlan) HealthCheck {
 	c := HealthCheck{Name: CheckReplicasHealthy}
+	// The replicas-healthy check inspects a CNPG cluster-pair, which only
+	// the cnpg-pair mechanism has. For raft-transition (bp-openbao) there
+	// is no Cluster-CR pair — the meaningful post-promotion signal is the
+	// DNS-probe check (traffic lands on the promoted region) — so record
+	// this check as deferred rather than spuriously failing (#3492).
+	mech := plan.Mechanism
+	if mech == "" {
+		mech = DefaultMechanism
+	}
+	if mech != MechanismCNPGPair {
+		c.Deferred = true
+		c.Detail = fmt.Sprintf("deferred: replicas-healthy is cnpg-pair-specific; mechanism=%q has no Cluster-CR pair (DNS-probe check is the post-promotion health signal)", mech)
+		return c
+	}
 	if s.CNPG == nil {
 		c.Detail = "CNPG reader not configured"
 		return c

--- a/core/controllers/continuum/internal/switchover/promoter.go
+++ b/core/controllers/continuum/internal/switchover/promoter.go
@@ -1,0 +1,175 @@
+// Promotion-mechanism seam — slice for #3492 (the openbao-raft promotion
+// half of #3375, "TOPOLOGY/DR ... continuum executes it").
+//
+// The 7-step Sequencer (sequence.go) is mechanism-agnostic for five of
+// its steps — validate-lease (1), drain-http (3), flip-dns (4),
+// swap-lease (5), audit (7). Only the two STATE-STORE-PROMOTION steps
+// differ per blueprint:
+//
+//	step-2  cordon old primary's writes
+//	step-6  promote the standby to primary (and demote the old primary)
+//
+// For the cnpg-pair mechanism (bp-cnpg-pair, the working reference) those
+// steps are: annotate `cnpg.io/cluster.primary` on the primary Cluster CR
+// (cordon) and flip `spec.replica.enabled` on the two cluster-pair halves
+// (promote). For the raft-transition mechanism (bp-openbao, per
+// docs/topology-matrix.md) the promotion is instead a `bao operator raft
+// snapshot restore` of the staged snapshot followed by `bao operator raft
+// transition-to-primary` on the surviving-region standby pod — with NO
+// CNPG cluster-pair involved at all.
+//
+// The Promoter interface is the seam. The sequencer selects the active
+// Promoter by `SwitchoverPlan.Mechanism`; cnpgPromoter is the default so
+// the cnpg-pair path is byte-identical to before this seam existed.
+
+package switchover
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/openova-io/openova/core/controllers/continuum/internal/cnpg"
+)
+
+// Mechanism is the canonical switchover-mechanism discriminator, mirroring
+// the Blueprint topology declaration's `switchover.mechanism` field
+// (core/controllers/pkg/apis/blueprint/v1alpha1/topology_types.go
+// SwitchoverSpec.Mechanism) and the `docs/topology-matrix.md` row column.
+//
+// Only the mechanisms bp-continuum can itself EXECUTE are enumerated here.
+// Other rows (`manual`, `bp-velero-restore`, s3/mirrormaker CLASS-B) are
+// not driven by this engine and never reach the Sequencer.
+type Mechanism string
+
+const (
+	// MechanismCNPGPair — the bp-cnpg-pair active-hot-standby /
+	// active-passive promotion: cordon annotation + `replica.enabled`
+	// flip on the two Cluster CR halves. The default and the long-running
+	// reference (hw128 region-kill PASS).
+	MechanismCNPGPair Mechanism = "cnpg-pair"
+
+	// MechanismRaftTransition — the bp-openbao active-passive promotion:
+	// restore the staged Raft snapshot + `bao operator raft
+	// transition-to-primary` on the surviving-region standby pod. KV reads
+	// continue uninterrupted on the replica throughout (the row invariant).
+	MechanismRaftTransition Mechanism = "raft-transition"
+)
+
+// DefaultMechanism is applied when SwitchoverPlan.Mechanism is empty. The
+// cnpg-pair path is the historical default — an unset mechanism on an
+// existing Continuum CR keeps its prior behavior exactly.
+const DefaultMechanism = MechanismCNPGPair
+
+// IsValid reports whether m is a mechanism this engine can execute.
+func (m Mechanism) IsValid() bool {
+	switch m {
+	case MechanismCNPGPair, MechanismRaftTransition:
+		return true
+	}
+	return false
+}
+
+// Promoter abstracts the two state-store-promotion steps of the
+// switchover sequence (the only mechanism-specific steps). One Promoter
+// implementation exists per Mechanism. Both methods return an optional
+// rollback hook (registered on success, invoked when a LATER step fails),
+// mirroring the stepFunc contract in sequence.go.
+//
+// Cordon is step-2 (stop accepting writes on the old primary). Promote is
+// step-6 (the standby becomes primary; the old primary becomes the
+// follower). The two are split — rather than one Promote call — so the
+// sequence's drain-http + flip-dns + swap-lease steps run BETWEEN cordon
+// and promote exactly as the cnpg-pair reference does (cordon early so no
+// writes land on the doomed primary while DNS still points at it; promote
+// late once traffic + lease have moved).
+type Promoter interface {
+	// Cordon stops the old primary from accepting writes. Returns a
+	// rollback hook that un-cordons it (best-effort).
+	Cordon(ctx context.Context, plan SwitchoverPlan) (rollback func(ctx context.Context) error, err error)
+
+	// Promote makes the standby (plan.ToRegion) the new primary and
+	// demotes the old primary (plan.FromRegion) to follower. Returns a
+	// rollback hook that reverses the promotion (best-effort).
+	Promote(ctx context.Context, plan SwitchoverPlan) (rollback func(ctx context.Context) error, err error)
+}
+
+// promoterFor returns the Promoter for the plan's mechanism. cnpg-pair is
+// served by the sequencer's own cnpg.Reader (the default, wired on the
+// Sequencer struct); raft-transition is served by s.RaftPromoter, which
+// the controller wires from a pod-exec backend. A raft-transition plan
+// with no RaftPromoter wired is a configuration error surfaced at step-2.
+func (s *Sequencer) promoterFor(plan SwitchoverPlan) (Promoter, error) {
+	m := plan.Mechanism
+	if m == "" {
+		m = DefaultMechanism
+	}
+	switch m {
+	case MechanismCNPGPair:
+		if s.CNPG == nil {
+			return nil, errors.New("cnpg-pair mechanism: CNPG reader is required")
+		}
+		return &cnpgPromoter{r: s.CNPG}, nil
+	case MechanismRaftTransition:
+		if s.RaftPromoter == nil {
+			return nil, errors.New("raft-transition mechanism: no RaftPromoter wired (controller must set Sequencer.RaftPromoter)")
+		}
+		return s.RaftPromoter, nil
+	default:
+		return nil, fmt.Errorf("unknown switchover mechanism %q (want one of cnpg-pair, raft-transition)", m)
+	}
+}
+
+// cnpgPromoter is the default Promoter — it reproduces, byte-for-byte, the
+// cnpg-pair cordon (step-2) and replica.enabled flip (step-6) the
+// Sequencer performed inline before the Promoter seam was extracted. It
+// wraps the same *cnpg.Reader the Sequencer already holds.
+type cnpgPromoter struct {
+	r *cnpg.Reader
+}
+
+// Cordon — step-2 for cnpg-pair: annotate the primary Cluster CR with
+// "switchover-pending" so the CNPG operator stops accepting writes. Same
+// behavior as the pre-seam inline step.
+func (p *cnpgPromoter) Cordon(ctx context.Context, plan SwitchoverPlan) (func(ctx context.Context) error, error) {
+	if p == nil || p.r == nil {
+		return nil, errors.New("cnpgPromoter: nil reader")
+	}
+	primary, _, err := p.r.FindPair(ctx, plan.CNPGNamespace, plan.CNPGPair)
+	if err != nil {
+		return nil, fmt.Errorf("find pair: %w", err)
+	}
+	if err := p.r.SetPrimaryAnnotation(ctx, plan.CNPGNamespace, primary.GetName(), "switchover-pending"); err != nil {
+		return nil, err
+	}
+	return func(ctx context.Context) error {
+		return p.r.ClearPrimaryAnnotation(ctx, plan.CNPGNamespace, primary.GetName())
+	}, nil
+}
+
+// Promote — step-6 for cnpg-pair: clear the cordon on the old primary,
+// then flip spec.replica.enabled so the old primary follows and the new
+// primary leads. Same behavior as the pre-seam inline step.
+func (p *cnpgPromoter) Promote(ctx context.Context, plan SwitchoverPlan) (func(ctx context.Context) error, error) {
+	if p == nil || p.r == nil {
+		return nil, errors.New("cnpgPromoter: nil reader")
+	}
+	primary, replica, err := p.r.FindPair(ctx, plan.CNPGNamespace, plan.CNPGPair)
+	if err != nil {
+		return nil, fmt.Errorf("find pair (uncordon): %w", err)
+	}
+	if err := p.r.ClearPrimaryAnnotation(ctx, plan.CNPGNamespace, primary.GetName()); err != nil {
+		return nil, err
+	}
+	if err := p.r.SetReplicaEnabled(ctx, plan.CNPGNamespace, primary.GetName(), true); err != nil {
+		return nil, err
+	}
+	if err := p.r.SetReplicaEnabled(ctx, plan.CNPGNamespace, replica.GetName(), false); err != nil {
+		return nil, err
+	}
+	return func(ctx context.Context) error {
+		_ = p.r.SetReplicaEnabled(ctx, plan.CNPGNamespace, replica.GetName(), true)
+		_ = p.r.SetReplicaEnabled(ctx, plan.CNPGNamespace, primary.GetName(), false)
+		return nil
+	}, nil
+}

--- a/core/controllers/continuum/internal/switchover/raft.go
+++ b/core/controllers/continuum/internal/switchover/raft.go
@@ -1,0 +1,214 @@
+// Raft-transition promotion — the bp-openbao half of #3375 (#3492).
+//
+// bp-openbao is active-passive with DR mechanism `raft-transition`
+// (docs/topology-matrix.md, platform/openbao/blueprint.yaml
+// spec.topology.perTopology.active-passive.switchover.mechanism). On a
+// region-kill the surviving-region openbao — a Raft standby that has been
+// fed periodic snapshots by the bp-openbao snapshot-replication CronJob
+// (platform/openbao/chart/templates/snapshot-replication.yaml: the
+// secondary fetches `latest.snap` to a restore-staging PVC) — is promoted
+// by:
+//
+//	1. `bao operator raft snapshot restore <staged-snapshot>`  (load the
+//	   point-in-time copy of region-A's KV store), then
+//	2. `bao operator raft transition-to-primary`               (make this
+//	   standby the cluster's write leader).
+//
+// The bp-openbao chart's snapshot-replication template stages the data and
+// states verbatim: "The actual restore + `transition-to-primary` is a
+// bp-continuum switchover step (CLASS-B controller follow-on), NOT
+// performed here." THIS file is that step.
+//
+// KV reads continue uninterrupted on the standby throughout — the restore
+// is the row's only mutating call and it runs on a Pod that was already
+// serving reads as a replica. (The walk runbook's DoD-8 step 8.5 asserts
+// the read loop is uninterrupted across the kill.)
+//
+// Promotion is effected via a Pod exec against the standby's openbao
+// container — the same mechanism a sovereign-admin would use by hand
+// (`kubectl exec <pod> -- bao operator raft ...`). bp-continuum holds the
+// in-cluster ServiceAccount + RBAC (pods/exec) to do this without a human.
+
+package switchover
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// PodExecutor runs a command inside a container and returns its combined
+// output. The production implementation (RaftExecPromoter's, wired in
+// cmd/main.go) uses client-go remotecommand SPDY exec against the
+// kube-apiserver; tests inject a fake. Kept minimal so the switchover
+// package doesn't grow a hard dependency on the remotecommand SDK — the
+// concrete SPDY executor lives in the cmd package alongside the rest of
+// the kube wiring.
+type PodExecutor interface {
+	// Exec runs `command` in (namespace/pod/container) and returns the
+	// merged stdout+stderr. A non-nil error means the exec stream itself
+	// failed OR the command exited non-zero (the SDK surfaces a non-zero
+	// exit as a CodeExitError).
+	Exec(ctx context.Context, namespace, pod, container string, command []string) (output string, err error)
+}
+
+// RaftTransitionTarget identifies the surviving-region openbao standby Pod
+// the promotion execs into, plus the snapshot path the bp-openbao chart
+// staged. Populated by the controller from the Continuum CR's
+// spec.switchover.raftTransition block (parseSpec), which the bp-openbao
+// bootstrap-kit slot fills from the topology declaration.
+type RaftTransitionTarget struct {
+	// Namespace is the openbao release namespace on the standby cluster
+	// (e.g. "openbao").
+	Namespace string
+
+	// Pod is the standby Raft member Pod to promote (e.g.
+	// "openbao-0"). When empty, PodSelector is used to discover it.
+	Pod string
+
+	// PodSelector is a label selector used to find the standby Pod when
+	// Pod is empty (e.g. "app.kubernetes.io/name=openbao"). The promoter
+	// picks the lexically-first Ready Pod matching it. Either Pod or
+	// PodSelector must be set.
+	PodSelector string
+
+	// Container is the openbao container name inside the Pod (default
+	// "openbao").
+	Container string
+
+	// SnapshotPath is the on-Pod path the secondary's snapshot-fetch
+	// CronJob staged `latest.snap` to (the chart default is
+	// /snapshots/latest.snap on the openbao-snapshot-restore-staging
+	// PVC). Empty disables the restore and promotes from whatever state
+	// the standby already has (degraded — last-snapshot-on-disk only).
+	SnapshotPath string
+
+	// BaoBinary is the openbao CLI name in the container image (default
+	// "bao"; some images ship the legacy "vault" name).
+	BaoBinary string
+}
+
+// withDefaults fills empty fields with the chart-default conventions.
+func (t RaftTransitionTarget) withDefaults() RaftTransitionTarget {
+	out := t
+	if out.Container == "" {
+		out.Container = "openbao"
+	}
+	if out.BaoBinary == "" {
+		out.BaoBinary = "bao"
+	}
+	return out
+}
+
+// PodLister discovers the standby Pod when only a label selector is given.
+// Implemented by the controller's dynamic client; tests inject a fake.
+// Returns Ready Pod names so the promoter never execs into a NotReady
+// member.
+type PodLister interface {
+	// ReadyPods returns the names of Ready Pods in `namespace` matching
+	// `selector`, in lexical order (so promotion is deterministic).
+	ReadyPods(ctx context.Context, namespace, selector string) ([]string, error)
+}
+
+// RaftExecPromoter implements Promoter for the raft-transition mechanism.
+// It runs the openbao snapshot-restore + transition-to-primary via Pod
+// exec on the surviving-region standby. Wired by the controller (the
+// Exec/Lister backends are the real kube clients); the per-CR target comes
+// from the SwitchoverPlan.
+type RaftExecPromoter struct {
+	// Exec runs commands in the standby openbao container.
+	Exec PodExecutor
+
+	// Lister resolves a PodSelector to a concrete Ready Pod. Optional
+	// when every plan supplies an explicit Pod.
+	Lister PodLister
+}
+
+// resolveTarget reads the raft-transition target off the plan and fills in
+// the standby Pod (via the Lister when only a selector was given).
+func (p *RaftExecPromoter) resolveTarget(ctx context.Context, plan SwitchoverPlan) (RaftTransitionTarget, error) {
+	t := plan.RaftTransition.withDefaults()
+	if t.Namespace == "" {
+		return t, errors.New("raft-transition: spec.switchover.raftTransition.namespace is required")
+	}
+	if t.Pod == "" {
+		if t.PodSelector == "" {
+			return t, errors.New("raft-transition: one of raftTransition.pod or raftTransition.podSelector is required")
+		}
+		if p.Lister == nil {
+			return t, errors.New("raft-transition: podSelector set but no PodLister wired")
+		}
+		pods, err := p.Lister.ReadyPods(ctx, t.Namespace, t.PodSelector)
+		if err != nil {
+			return t, fmt.Errorf("raft-transition: list standby pods (%s/%s): %w", t.Namespace, t.PodSelector, err)
+		}
+		if len(pods) == 0 {
+			return t, fmt.Errorf("raft-transition: no Ready openbao pod matches %q in %s", t.PodSelector, t.Namespace)
+		}
+		t.Pod = pods[0]
+	}
+	return t, nil
+}
+
+// Cordon — step-2 for raft-transition. Unlike cnpg-pair there is NOTHING
+// to cordon on the standby: the OLD primary lives in the killed region and
+// is unreachable (a region-kill is the trigger), so there is no write path
+// to fence here. The standby keeps serving KV READS uninterrupted (the row
+// invariant) and accepts no writes until promoted in step-6. Cordon is
+// therefore a deliberate no-op with no rollback — but it still validates
+// the target resolves, so a misconfigured CR fails early (at step-2)
+// rather than after traffic + lease have already moved.
+func (p *RaftExecPromoter) Cordon(ctx context.Context, plan SwitchoverPlan) (func(ctx context.Context) error, error) {
+	if p == nil || p.Exec == nil {
+		return nil, errors.New("RaftExecPromoter: nil executor")
+	}
+	if _, err := p.resolveTarget(ctx, plan); err != nil {
+		return nil, err
+	}
+	// No write to fence on the survivor; promotion is the operative step.
+	return nil, nil
+}
+
+// Promote — step-6 for raft-transition. Restores the staged snapshot (when
+// configured) then runs `bao operator raft transition-to-primary` on the
+// standby, making it the write leader. The rollback hook is a no-op: a
+// region-kill promotion is one-directional — the killed region's data is
+// gone, so "un-promoting" would lose the writes the survivor accepted
+// after promotion. Re-pairing the recovered region is the documented Day-2
+// rejoin (DoD-9), not a switchover rollback.
+func (p *RaftExecPromoter) Promote(ctx context.Context, plan SwitchoverPlan) (func(ctx context.Context) error, error) {
+	if p == nil || p.Exec == nil {
+		return nil, errors.New("RaftExecPromoter: nil executor")
+	}
+	t, err := p.resolveTarget(ctx, plan)
+	if err != nil {
+		return nil, err
+	}
+
+	// 1. Restore the staged snapshot (point-in-time copy of the killed
+	//    region's KV). Skipped when no SnapshotPath is configured — then
+	//    the standby promotes from its own on-disk Raft state.
+	if t.SnapshotPath != "" {
+		restoreCmd := []string{
+			t.BaoBinary, "operator", "raft", "snapshot", "restore", t.SnapshotPath,
+		}
+		if out, err := p.Exec.Exec(ctx, t.Namespace, t.Pod, t.Container, restoreCmd); err != nil {
+			return nil, fmt.Errorf("raft snapshot restore on %s/%s: %w (output: %s)", t.Namespace, t.Pod, err, strings.TrimSpace(out))
+		}
+	}
+
+	// 2. Transition this standby to the Raft primary (write leader).
+	transitionCmd := []string{
+		t.BaoBinary, "operator", "raft", "transition-to-primary",
+	}
+	if out, err := p.Exec.Exec(ctx, t.Namespace, t.Pod, t.Container, transitionCmd); err != nil {
+		// Some openbao/vault builds name the verb differently across
+		// versions; surface the raw output so the operator sees exactly
+		// what the binary rejected rather than a bare exit code.
+		return nil, fmt.Errorf("raft transition-to-primary on %s/%s: %w (output: %s)", t.Namespace, t.Pod, err, strings.TrimSpace(out))
+	}
+
+	// One-directional: no rollback (see doc comment).
+	return nil, nil
+}

--- a/core/controllers/continuum/internal/switchover/raft_test.go
+++ b/core/controllers/continuum/internal/switchover/raft_test.go
@@ -1,0 +1,334 @@
+package switchover
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/core/controllers/continuum/internal/cnpg"
+	"github.com/openova-io/openova/core/controllers/continuum/internal/dns"
+	"github.com/openova-io/openova/core/controllers/continuum/internal/events"
+	"github.com/openova-io/openova/core/controllers/continuum/internal/witness"
+)
+
+// fakeExec records every Exec call so tests can assert the exact bao
+// commands the raft promotion ran.
+type fakeExec struct {
+	mu    sync.Mutex
+	calls [][]string // command vector per call
+	// failOn, when non-empty, makes Exec fail for the first command whose
+	// joined string contains failOn (simulates a bao non-zero exit).
+	failOn string
+}
+
+func (f *fakeExec) Exec(ctx context.Context, ns, pod, container string, command []string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, command)
+	joined := strings.Join(command, " ")
+	if f.failOn != "" && strings.Contains(joined, f.failOn) {
+		return "boom: " + f.failOn, errors.New("command exited 1")
+	}
+	return "ok: " + joined, nil
+}
+
+func (f *fakeExec) callStrings() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.calls))
+	for _, c := range f.calls {
+		out = append(out, strings.Join(c, " "))
+	}
+	return out
+}
+
+// fakeLister returns a fixed Ready-pod set.
+type fakeLister struct {
+	pods []string
+	err  error
+}
+
+func (l *fakeLister) ReadyPods(ctx context.Context, ns, selector string) ([]string, error) {
+	return l.pods, l.err
+}
+
+// raftPlan returns a valid raft-transition SwitchoverPlan.
+func raftPlan() SwitchoverPlan {
+	return SwitchoverPlan{
+		ContinuumName:   "openbao/cont-openbao",
+		ApplicationName: "openbao/openbao",
+		FromRegion:      "me-east-215-a-1",
+		ToRegion:        "me-east-215-b-1",
+		Mechanism:       MechanismRaftTransition,
+		RaftTransition: RaftTransitionTarget{
+			Namespace:    "openbao",
+			Pod:          "openbao-0",
+			SnapshotPath: "/snapshots/latest.snap",
+		},
+		PDMZone: "t99.omani.works",
+		SynthParams: dns.SynthParams{
+			Hostnames: []string{"bao.t99.omani.works"},
+			RegionToIPs: map[string][]string{
+				"me-east-215-a-1": {"203.0.113.1"},
+				"me-east-215-b-1": {"203.0.113.9"},
+			},
+			HealthCheckURL: "https://bao.t99.omani.works/v1/sys/health",
+		},
+	}
+}
+
+// raftSequencer builds a Sequencer wired with a raft promoter + the
+// mechanism-agnostic deps (witness/PDM/audit). CNPG is intentionally nil
+// to prove the raft path never touches it.
+func raftSequencer(t *testing.T, exec PodExecutor, lister PodLister) (*Sequencer, *events.Recorder) {
+	t.Helper()
+	store := witness.NewInMemoryStore()
+	w := store.Client("openbao/cont-openbao")
+	if _, err := w.Acquire(context.Background(), "me-east-215-a-1", time.Hour); err != nil {
+		t.Fatalf("seed lease: %v", err)
+	}
+	rec := events.NewRecorder()
+	seq := &Sequencer{
+		// CNPG deliberately nil — raft-transition must not use it.
+		RaftPromoter: &RaftExecPromoter{Exec: exec, Lister: lister},
+		Witness:      w,
+		Audit:        rec,
+		Sleep:        func(time.Duration) {},
+		PDMCommit:    func(ctx context.Context, records []dns.Record) error { return nil },
+	}
+	return seq, rec
+}
+
+func TestRaftTransition_FullSequence_RestoreThenTransition(t *testing.T) {
+	t.Parallel()
+	exec := &fakeExec{}
+	seq, rec := raftSequencer(t, exec, nil)
+
+	res := seq.Execute(context.Background(), raftPlan())
+	if res.Err != nil {
+		t.Fatalf("raft-transition sequence failed: %v (failedAt=%d)", res.Err, res.FailedAtStep)
+	}
+	if len(res.StepsCompleted) != 7 {
+		t.Fatalf("want 7 steps completed, got %d (%v)", len(res.StepsCompleted), res.StepsCompleted)
+	}
+
+	calls := exec.callStrings()
+	// Exactly two execs: restore then transition-to-primary, in order.
+	if len(calls) != 2 {
+		t.Fatalf("want 2 exec calls (restore, transition), got %d: %v", len(calls), calls)
+	}
+	if !strings.Contains(calls[0], "raft snapshot restore /snapshots/latest.snap") {
+		t.Errorf("first exec should be the snapshot restore, got %q", calls[0])
+	}
+	if !strings.Contains(calls[1], "raft transition-to-primary") {
+		t.Errorf("second exec should be transition-to-primary, got %q", calls[1])
+	}
+	// Restore MUST precede transition.
+	if strings.Contains(calls[0], "transition-to-primary") {
+		t.Errorf("transition ran before restore: %v", calls)
+	}
+
+	// The audit switchover event fired with the right from/to.
+	sw := rec.EventsByType(events.TypeSwitchover)
+	if len(sw) != 1 {
+		t.Fatalf("want 1 switchover audit, got %d", len(sw))
+	}
+	if sw[0].FromPrimary != "me-east-215-a-1" || sw[0].ToPrimary != "me-east-215-b-1" {
+		t.Errorf("audit from/to wrong: from=%s to=%s", sw[0].FromPrimary, sw[0].ToPrimary)
+	}
+}
+
+func TestRaftTransition_PodSelectorResolution(t *testing.T) {
+	t.Parallel()
+	exec := &fakeExec{}
+	// Two Ready pods; lister returns them lexically — promoter picks [0].
+	lister := &fakeLister{pods: []string{"openbao-0", "openbao-1"}}
+	seq, _ := raftSequencer(t, exec, lister)
+
+	plan := raftPlan()
+	plan.RaftTransition.Pod = "" // force selector resolution
+	plan.RaftTransition.PodSelector = "app.kubernetes.io/name=openbao"
+
+	res := seq.Execute(context.Background(), plan)
+	if res.Err != nil {
+		t.Fatalf("sequence failed: %v", res.Err)
+	}
+	if len(exec.calls) != 2 {
+		t.Fatalf("want 2 execs, got %d", len(exec.calls))
+	}
+	// (Pod name isn't echoed by the fake, but resolution succeeding +
+	// execs firing proves the selector path ran.)
+}
+
+func TestRaftTransition_NoSnapshotPath_SkipsRestore(t *testing.T) {
+	t.Parallel()
+	exec := &fakeExec{}
+	seq, _ := raftSequencer(t, exec, nil)
+
+	plan := raftPlan()
+	plan.RaftTransition.SnapshotPath = "" // no staged snapshot → restore skipped
+
+	res := seq.Execute(context.Background(), plan)
+	if res.Err != nil {
+		t.Fatalf("sequence failed: %v", res.Err)
+	}
+	calls := exec.callStrings()
+	if len(calls) != 1 {
+		t.Fatalf("want 1 exec (transition only), got %d: %v", len(calls), calls)
+	}
+	if !strings.Contains(calls[0], "transition-to-primary") {
+		t.Errorf("the single exec should be transition-to-primary, got %q", calls[0])
+	}
+}
+
+func TestRaftTransition_RestoreFailure_FailsSwitchover(t *testing.T) {
+	t.Parallel()
+	exec := &fakeExec{failOn: "snapshot restore"}
+	seq, _ := raftSequencer(t, exec, nil)
+
+	res := seq.Execute(context.Background(), raftPlan())
+	if res.Err == nil {
+		t.Fatalf("expected switchover to fail when restore errors")
+	}
+	if res.FailedAtStep != 6 {
+		t.Errorf("restore failure should fail at step 6 (promote), got %d", res.FailedAtStep)
+	}
+	// transition-to-primary must NOT have run after a failed restore.
+	for _, c := range exec.callStrings() {
+		if strings.Contains(c, "transition-to-primary") {
+			t.Errorf("transition ran despite restore failure: %v", exec.callStrings())
+		}
+	}
+}
+
+func TestRaftTransition_NoPromoterWired_FailsCleanly(t *testing.T) {
+	t.Parallel()
+	store := witness.NewInMemoryStore()
+	w := store.Client("openbao/cont-openbao")
+	_, _ = w.Acquire(context.Background(), "me-east-215-a-1", time.Hour)
+	seq := &Sequencer{
+		// No RaftPromoter wired.
+		Witness:   w,
+		Audit:     events.NewRecorder(),
+		Sleep:     func(time.Duration) {},
+		PDMCommit: func(ctx context.Context, r []dns.Record) error { return nil },
+	}
+	res := seq.Execute(context.Background(), raftPlan())
+	if res.Err == nil {
+		t.Fatalf("expected failure when no RaftPromoter is wired")
+	}
+	if !strings.Contains(res.Err.Error(), "RaftPromoter") {
+		t.Errorf("error should name the missing RaftPromoter, got: %v", res.Err)
+	}
+	// It should fail at the cordon step (step 2), before any traffic/DNS move.
+	if res.FailedAtStep != 2 {
+		t.Errorf("want failure at step 2 (cordon), got %d", res.FailedAtStep)
+	}
+}
+
+func TestRaftTransition_Validate(t *testing.T) {
+	t.Parallel()
+	// Missing namespace.
+	p := raftPlan()
+	p.RaftTransition.Namespace = ""
+	if err := p.Validate(); err == nil {
+		t.Errorf("expected validate error for missing raftTransition.namespace")
+	}
+	// Missing both pod + selector.
+	p = raftPlan()
+	p.RaftTransition.Pod = ""
+	p.RaftTransition.PodSelector = ""
+	if err := p.Validate(); err == nil {
+		t.Errorf("expected validate error for missing pod/podSelector")
+	}
+	// raft-transition does NOT require CNPGPair.
+	p = raftPlan()
+	p.CNPGPair = ""
+	p.CNPGNamespace = ""
+	if err := p.Validate(); err != nil {
+		t.Errorf("raft-transition should not require CNPGPair: %v", err)
+	}
+}
+
+// TestCNPGPair_StillDefaultMechanism guards the byte-identical default:
+// an empty Mechanism resolves to cnpg-pair and runs the cnpg promotion
+// (cordon + replica flip) against the Cluster-CR pair, NEVER the raft path.
+func TestCNPGPair_StillDefaultMechanism(t *testing.T) {
+	t.Parallel()
+	store := witness.NewInMemoryStore()
+	w := store.Client("ns/cr")
+	if _, err := w.Acquire(context.Background(), "fsn", time.Hour); err != nil {
+		t.Fatalf("seed lease: %v", err)
+	}
+	rec := events.NewRecorder()
+	scheme := runtime.NewScheme()
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{cnpg.ClusterGVR: "ClusterList"},
+		newClusterPair("ns", "demo")...)
+	cnpgR := cnpg.NewReader(dyn)
+
+	// RaftPromoter is wired but must NOT be used for an empty-mechanism plan.
+	raftCalled := false
+	seq := &Sequencer{
+		CNPG:         cnpgR,
+		RaftPromoter: &recordingPromoter{onCall: func() { raftCalled = true }},
+		Witness:      w,
+		Audit:        rec,
+		Sleep:        func(time.Duration) {},
+		PDMCommit:    func(ctx context.Context, r []dns.Record) error { return nil },
+	}
+	plan := SwitchoverPlan{
+		ContinuumName: "ns/cr",
+		FromRegion:    "fsn",
+		ToRegion:      "hel",
+		// Mechanism deliberately empty → must default to cnpg-pair.
+		CNPGPair:      "demo",
+		CNPGNamespace: "ns",
+		SynthParams: dns.SynthParams{
+			Hostnames: []string{"x.example"},
+			RegionToIPs: map[string][]string{
+				"fsn": {"5.1.2.3"},
+				"hel": {"5.5.6.7"},
+			},
+			HealthCheckURL: "https://probe.example/healthz",
+		},
+	}
+	res := seq.Execute(context.Background(), plan)
+	if res.Err != nil {
+		t.Fatalf("default-mechanism (cnpg-pair) sequence failed: %v", res.Err)
+	}
+	if raftCalled {
+		t.Errorf("raft promoter was invoked for an empty-mechanism (cnpg-pair) plan")
+	}
+	// The cnpg pair's replica half should now be the primary (enabled=false).
+	replica, _, err := cnpgR.Get(context.Background(), "ns", "demo-replica")
+	if err != nil {
+		t.Fatalf("get replica: %v", err)
+	}
+	if replica.IsReplicaCluster {
+		t.Errorf("after cnpg-pair switchover the replica half should be promoted (replica.enabled=false)")
+	}
+}
+
+// recordingPromoter is a Promoter that records whether it was called.
+type recordingPromoter struct{ onCall func() }
+
+func (p *recordingPromoter) Cordon(ctx context.Context, plan SwitchoverPlan) (func(ctx context.Context) error, error) {
+	if p.onCall != nil {
+		p.onCall()
+	}
+	return nil, nil
+}
+func (p *recordingPromoter) Promote(ctx context.Context, plan SwitchoverPlan) (func(ctx context.Context) error, error) {
+	if p.onCall != nil {
+		p.onCall()
+	}
+	return nil, nil
+}

--- a/core/controllers/continuum/internal/switchover/sequence.go
+++ b/core/controllers/continuum/internal/switchover/sequence.go
@@ -4,12 +4,20 @@
 // `from` (old primary) to `to` (new primary) goes through:
 //
 //	step-1  validate-lease     — confirm the lease holder is `from` (or that we hold quorum to take it)
-//	step-2  cordon-old         — annotate old CNPG primary so the operator stops accepting writes
+//	step-2  cordon-old         — stop the old primary accepting writes (mechanism-specific)
 //	step-3  drain-traffic      — flip Cilium HTTPRoute weight=0 toward old primary; sleep 10s
 //	step-4  flip-dns           — write the lua-record body via PDM /v1/lua/commit; the new primary's IPs come first
 //	step-5  swap-lease         — release the old lease, acquire the new lease against the witness
-//	step-6  uncordon-new       — clear cordon on old primary's CR; flip CNPG replica.enabled flags
+//	step-6  promote-new        — promote the standby to primary (mechanism-specific)
 //	step-7  audit              — emit `continuum-switchover` on NATS catalyst.audit
+//
+// Steps 2 + 6 are the only MECHANISM-SPECIFIC steps — they dispatch
+// through a per-mechanism Promoter (promoter.go). For the default
+// `cnpg-pair` mechanism they cordon via a `cnpg.io/cluster.primary`
+// annotation + flip `spec.replica.enabled` on the two Cluster CR halves;
+// for `raft-transition` (bp-openbao) they restore the staged Raft snapshot
+// + run `bao operator raft transition-to-primary` on the surviving standby
+// Pod (#3492). The other five steps are mechanism-agnostic.
 //
 // Each step is atomic and registers a rollback hook. On step-N
 // failure, steps {N-1 .. 1} are rolled back in reverse order. Steps
@@ -58,14 +66,28 @@ type SwitchoverPlan struct {
 	// ToRegion is the host-cluster name being promoted to primary.
 	ToRegion string
 
+	// Mechanism selects the state-store-promotion strategy for steps 2 +
+	// 6 (the only mechanism-specific steps). Empty defaults to
+	// `cnpg-pair` so existing Continuum CRs keep their prior behavior.
+	// `raft-transition` drives the bp-openbao promotion instead (#3492).
+	// Mirrors the Blueprint topology declaration's
+	// switchover.mechanism column (docs/topology-matrix.md).
+	Mechanism Mechanism
+
 	// CNPGPair is the pair name (label
 	// catalyst.openova.io/cnpg-pair) Continuum operates on. The
 	// sequencer's CNPG steps look up the (primary, replica) Cluster
-	// CRs by this label.
+	// CRs by this label. Required only for the cnpg-pair mechanism.
 	CNPGPair string
 
 	// CNPGNamespace is the K8s namespace the cluster-pair lives in.
 	CNPGNamespace string
+
+	// RaftTransition carries the openbao standby target for the
+	// `raft-transition` mechanism (namespace / pod / staged snapshot
+	// path). Ignored for cnpg-pair. Filled by the controller from the
+	// Continuum CR's spec.switchover.raftTransition block.
+	RaftTransition RaftTransitionTarget
 
 	// HTTPRouteName + HTTPRouteNamespace are the Gateway-API
 	// HTTPRoute resource the sequencer drains. Empty values make
@@ -151,8 +173,26 @@ func (p SwitchoverPlan) Validate() error {
 	if p.FromRegion == p.ToRegion {
 		return errors.New("plan: FromRegion == ToRegion (no-op)")
 	}
-	if p.CNPGPair == "" || p.CNPGNamespace == "" {
-		return errors.New("plan: CNPGPair + CNPGNamespace are required")
+	// Mechanism-specific required fields. Empty mechanism = cnpg-pair
+	// (the historical default).
+	mech := p.Mechanism
+	if mech == "" {
+		mech = DefaultMechanism
+	}
+	switch mech {
+	case MechanismCNPGPair:
+		if p.CNPGPair == "" || p.CNPGNamespace == "" {
+			return errors.New("plan: CNPGPair + CNPGNamespace are required for cnpg-pair mechanism")
+		}
+	case MechanismRaftTransition:
+		if p.RaftTransition.Namespace == "" {
+			return errors.New("plan: RaftTransition.Namespace is required for raft-transition mechanism")
+		}
+		if p.RaftTransition.Pod == "" && p.RaftTransition.PodSelector == "" {
+			return errors.New("plan: RaftTransition needs pod or podSelector for raft-transition mechanism")
+		}
+	default:
+		return fmt.Errorf("plan: unknown switchover mechanism %q", mech)
 	}
 	return nil
 }
@@ -171,8 +211,15 @@ type Result struct {
 // Sequencer executes a SwitchoverPlan.
 type Sequencer struct {
 	// CNPG is the cluster-CR reader/writer (primary annotation +
-	// replica.enabled flips).
+	// replica.enabled flips). Serves the default cnpg-pair promotion
+	// mechanism (steps 2 + 6).
 	CNPG *cnpg.Reader
+
+	// RaftPromoter serves the `raft-transition` promotion mechanism
+	// (bp-openbao). Nil unless the controller wires a pod-exec backend;
+	// a raft-transition plan with no RaftPromoter fails at step-2 with a
+	// clear "no RaftPromoter wired" error (#3492).
+	RaftPromoter Promoter
 
 	// Witness is the lease backend (in-memory for tests, CF-KV /
 	// dns-quorum in K-Cont-3).
@@ -318,30 +365,19 @@ func (s *Sequencer) steps(plan SwitchoverPlan) []stepFunc {
 			},
 		},
 
-		// Step 2 — cordon old primary writes by annotating its
-		// CNPG Cluster CR.
+		// Step 2 — cordon the old primary's writes. Mechanism-specific:
+		// cnpg-pair annotates the primary Cluster CR; raft-transition is
+		// a no-op (the old primary is in the killed region, nothing to
+		// fence — the survivor keeps serving reads). Dispatched through
+		// the per-mechanism Promoter (#3492).
 		{
 			name: "cordon-old-primary",
 			run: func(ctx context.Context) (func(ctx context.Context) error, error) {
-				if s.CNPG == nil {
-					return nil, errors.New("CNPG reader is required")
-				}
-				primary, _, err := s.CNPG.FindPair(ctx, plan.CNPGNamespace, plan.CNPGPair)
+				promoter, err := s.promoterFor(plan)
 				if err != nil {
-					return nil, fmt.Errorf("find pair: %w", err)
-				}
-				// Annotate primary CR with a marker pointing at the
-				// new target Pod = "<replica-pod-1>". For our purposes
-				// any non-empty string flags the operator that a
-				// switchover is requested. Real deployments coordinate
-				// the value with CNPG's per-instance naming; here we
-				// stamp "switchover-pending".
-				if err := s.CNPG.SetPrimaryAnnotation(ctx, plan.CNPGNamespace, primary.GetName(), "switchover-pending"); err != nil {
 					return nil, err
 				}
-				return func(ctx context.Context) error {
-					return s.CNPG.ClearPrimaryAnnotation(ctx, plan.CNPGNamespace, primary.GetName())
-				}, nil
+				return promoter.Cordon(ctx, plan)
 			},
 		},
 
@@ -420,32 +456,20 @@ func (s *Sequencer) steps(plan SwitchoverPlan) []stepFunc {
 			},
 		},
 
-		// Step 6 — uncordon new primary writes; flip CNPG replica
-		// flags so the new primary stops following WAL and the old
-		// primary starts following.
+		// Step 6 — promote the standby to primary. Mechanism-specific:
+		// cnpg-pair clears the cordon + flips replica.enabled on both
+		// Cluster CR halves; raft-transition restores the staged snapshot
+		// + runs `bao operator raft transition-to-primary` on the
+		// surviving openbao standby. Dispatched through the per-mechanism
+		// Promoter (#3492).
 		{
-			name: "uncordon-new-primary",
+			name: "promote-new-primary",
 			run: func(ctx context.Context) (func(ctx context.Context) error, error) {
-				primary, replica, err := s.CNPG.FindPair(ctx, plan.CNPGNamespace, plan.CNPGPair)
+				promoter, err := s.promoterFor(plan)
 				if err != nil {
-					return nil, fmt.Errorf("find pair (uncordon): %w", err)
-				}
-				// Clear the cordon annotation on what WAS primary
-				// (now replica) and flip replica.enabled on both.
-				if err := s.CNPG.ClearPrimaryAnnotation(ctx, plan.CNPGNamespace, primary.GetName()); err != nil {
 					return nil, err
 				}
-				if err := s.CNPG.SetReplicaEnabled(ctx, plan.CNPGNamespace, primary.GetName(), true); err != nil {
-					return nil, err
-				}
-				if err := s.CNPG.SetReplicaEnabled(ctx, plan.CNPGNamespace, replica.GetName(), false); err != nil {
-					return nil, err
-				}
-				return func(ctx context.Context) error {
-					_ = s.CNPG.SetReplicaEnabled(ctx, plan.CNPGNamespace, replica.GetName(), true)
-					_ = s.CNPG.SetReplicaEnabled(ctx, plan.CNPGNamespace, primary.GetName(), false)
-					return nil
-				}, nil
+				return promoter.Promote(ctx, plan)
 			},
 		},
 

--- a/core/controllers/go.mod
+++ b/core/controllers/go.mod
@@ -37,14 +37,17 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.2 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/moby/spdystream v0.4.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/nats-io/nkeys v0.4.7 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/core/controllers/go.sum
+++ b/core/controllers/go.sum
@@ -1,3 +1,5 @@
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -48,6 +50,8 @@ github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af h1:kmjWCqn2qkEml422C2
 github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -67,6 +71,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/moby/spdystream v0.4.0 h1:Vy79D6mHeJJjiPdFEL2yku1kl0chZpJfZcPpb16BRl8=
+github.com/moby/spdystream v0.4.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -74,6 +80,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/nats-io/nats.go v1.37.0 h1:07rauXbVnnJvv1gfIyghFEo6lUcYRY0WXc3x7x0vUxE=
 github.com/nats-io/nats.go v1.37.0/go.mod h1:Ubdu4Nh9exXdSz0RVWRFBbRfrbSxOYd26oF0wkWclB8=
 github.com/nats-io/nkeys v0.4.7 h1:RwNJbbIdYCoClSDNY7QVKZlyb/wfT6ugvFCiKy6vDvI=

--- a/docs/topology-matrix.md
+++ b/docs/topology-matrix.md
@@ -58,7 +58,7 @@ fields sourced from the agreement row + chart citations (never invented):
 |---|---|---|:---:|---|:---:|
 | bp-catalyst-platform | active-hot-standby: mgmt-A,mgmt-B | matches-row | implements-row(cited:cnpg-pair) | cnpg-pair sync (hw128 PASS pattern) | pending |
 | bp-keycloak | active-hot-standby: mgmt-A,mgmt-B | matches-row | implements-row(cited:cnpg-pair) | cnpg-pair sync (hw128 PASS pattern) | pending |
-| bp-openbao | active-passive: mgmt-A,mgmt-B | matches-row | implements-row(this-ticket) | PRIORITY §6 — openbao-perf-replication | pending |
+| bp-openbao | active-passive: mgmt-A,mgmt-B | matches-row | implements-row(this-ticket) | snapshot-replication (state) + bp-continuum raft-transition promotion (engine, #3492) both wired | pending |
 | bp-gitea | active-hot-standby: mgmt-A,mgmt-B | matches-row | implements-row(this-ticket) | PRIORITY §6 — cnpg-pair | pending |
 | bp-harbor | active-hot-standby: mgmt-A,mgmt-B | matches-row + orphan-placementSchema→remove | implements-row(cited:cnpg-pair) | cnpg-pair sync (hw128 PASS pattern) | pending |
 | bp-grafana | active-hot-standby: mgmt-A,mgmt-B | matches-row | implements-row(cited:cnpg-pair) | cnpg-pair sync (hw128 PASS pattern) | pending |

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -39,7 +39,13 @@ name: bp-openbao
 # syncer-mangled host Service name. snapshotReplication is default-OFF, so the
 # single-region render is byte-identical (the default applies only when enabled).
 # NOTE: 1.2.38 was never published to ghcr (see 1.2.39 above).
-version: 1.2.39
+# 1.2.40 (#3492, 2026-06-14): ship the openbao DR contract — a Continuum CR
+# (templates/continuum.yaml) declaring switchover.mechanism=raft-transition +
+# the standby Pod target so the bp-continuum engine can promote bp-openbao on
+# a region-kill (`bao operator raft snapshot restore` + `transition-to-primary`).
+# Skip-render gated on continuum.enabled=true AND snapshotReplication.role=
+# secondary, so the default single-region render is byte-identical.
+version: 1.2.40
 # 1.2.37 (#3374, 2026-06-14): fix the sso-landing nginx ImagePullBackOff. The
 # image was `harbor.openova.io/proxy-docker/library/nginx` but the live Harbor
 # DockerHub proxy-cache project is `proxy-dockerhub` (proxy-docker does NOT

--- a/platform/openbao/chart/templates/continuum.yaml
+++ b/platform/openbao/chart/templates/continuum.yaml
@@ -1,0 +1,95 @@
+{{- /*
+Catalyst DR contract for bp-openbao — the Continuum CR (#3492, the
+openbao half of #3375).
+
+Per docs/topology-matrix.md, bp-openbao = active-passive / switchover
+mechanism `raft-transition`. The bp-continuum engine
+(core/controllers/continuum) drives the region-kill promotion: on a kill
+it runs the mechanism-agnostic steps (lease / drain-HTTP / flip-DNS /
+audit) PLUS the raft-transition promote step — `bao operator raft snapshot
+restore <staged>` + `bao operator raft transition-to-primary` via Pod exec
+on the surviving openbao standby (sequence.go step-6 dispatched through the
+RaftExecPromoter). The snapshot-replication.yaml block stages the snapshot;
+THIS Continuum CR tells the engine HOW to promote bp-openbao (the
+mechanism) and WHERE (the standby Pod target).
+
+🛑 Skip-render (per #402 — never `{{ fail }}`): the CR renders ONLY when
+BOTH `.Values.continuum.enabled=true` AND
+`.Values.snapshotReplication.role=secondary`. The Continuum CR describes
+promotion of the STANDBY → primary, so it belongs on the standby (region-B)
+cluster; the active (region-A) cluster does not host it. A default `helm
+template` is byte-identical to origin/main (gated keys render nothing).
+
+The mechanism-agnostic lua-record / regions / hostnames blocks mirror the
+shape the bp-cnpg-pair Continuum CR uses (the working reference) so the
+flip-DNS step has a probe target + IP-set to write; per-Sovereign overlays
+fill the real region names + IPs.
+*/}}
+{{- $c := .Values.continuum | default dict -}}
+{{- $sr := .Values.snapshotReplication | default dict -}}
+{{- $srRole := $sr.role | default "primary" -}}
+{{- if and $c.enabled (eq $srRole "secondary") -}}
+{{- $rt := $c.raftTransition | default dict -}}
+{{- $lease := $c.leaseClient | default dict -}}
+{{- $leaseCfg := $lease.config | default dict -}}
+{{- $appHost := printf "bao.%s" ($c.pdmZone | default "") -}}
+apiVersion: dr.openova.io/v1
+kind: Continuum
+metadata:
+  name: {{ $c.name | default "cont-openbao" | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao-dr-continuum
+    openova.io/application: openbao
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  applicationRef: openbao
+  # primaryRegion = the ACTIVE region (dies in the kill); hotStandbyRegions =
+  # this surviving region (promoted to primary by the raft-transition).
+  primaryRegion: {{ $c.primaryRegion | quote }}
+  hotStandbyRegions:
+    - {{ $c.standbyRegion | quote }}
+  rto: {{ printf "%ds" (int ($c.rtoSeconds | default 60)) | quote }}
+  rpo: {{ printf "%ds" (int ($c.rpoSeconds | default 30)) | quote }}
+  rtoSeconds: {{ int ($c.rtoSeconds | default 60) }}
+  rpoSeconds: {{ int ($c.rpoSeconds | default 30) }}
+  autoFailover: {{ $c.autoFailover | default false }}
+  # ── #3492: raft-transition switchover mechanism ──────────────────────────
+  # The engine dispatches the cordon + promote steps through the
+  # RaftExecPromoter instead of the cnpg-pair cordon/replica-flip.
+  switchover:
+    mechanism: raft-transition
+    raftTransition:
+      namespace: {{ .Release.Namespace | quote }}
+      {{- if $rt.pod }}
+      pod: {{ $rt.pod | quote }}
+      {{- end }}
+      podSelector: {{ $rt.podSelector | default "app.kubernetes.io/name=openbao" | quote }}
+      container: {{ $rt.container | default "openbao" | quote }}
+      snapshotPath: {{ $rt.snapshotPath | default "/snapshots/latest.snap" | quote }}
+      baoBinary: {{ $rt.baoBinary | default "bao" | quote }}
+  pdmZone: {{ $c.pdmZone | quote }}
+  leaseClient:
+    kind: {{ $lease.kind | default "dns-quorum" | quote }}
+    config:
+      ttlSeconds: {{ int ($leaseCfg.ttlSeconds | default 30) }}
+      renewSeconds: {{ int ($leaseCfg.renewSeconds | default 10) }}
+      {{- with $leaseCfg.resolvers }}
+      resolvers:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- end }}
+  luaRecord:
+    selector: ifurlup
+    healthCheck:
+      # OpenBao's unauthenticated health endpoint — a good liveness probe
+      # target for the lua-record ifurlup selector.
+      url: {{ printf "https://%s/v1/sys/health" $appHost | quote }}
+      intervalSeconds: 5
+      timeoutSeconds: 2
+    hostnames:
+      - {{ $appHost | quote }}
+{{- end }}

--- a/platform/openbao/chart/tests/continuum-render.sh
+++ b/platform/openbao/chart/tests/continuum-render.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# bp-openbao continuum-render test (DR / #3375 DoD-8, #3492).
+#
+# Verifies the openbao DR contract (templates/continuum.yaml) — the
+# Continuum CR that tells the bp-continuum engine to promote bp-openbao via
+# `raft-transition` (`bao operator raft snapshot restore` +
+# `transition-to-primary` on the surviving standby) on a region-kill.
+#
+#   Case 1 — default render: NO Continuum CR (skip-render, never `{{ fail }}`
+#            per #402). The default single-region render is byte-identical.
+#   Case 2 — continuum.enabled=true but role=primary: STILL no CR. The CR
+#            describes promotion of the STANDBY, so it belongs only on the
+#            secondary (region-B) cluster.
+#   Case 3 — continuum.enabled=true + role=secondary: the Continuum CR
+#            renders with switchover.mechanism=raft-transition + the
+#            raftTransition target (namespace / podSelector / snapshotPath).
+#
+# Usage: bash tests/continuum-render.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+echo "[continuum-render] Case 1: default render produces NO Continuum CR"
+helm template smoke-bao . > "$TMP/default.yaml"
+if grep -qE "^kind: Continuum$" "$TMP/default.yaml"; then
+  echo "FAIL: default render contains a Continuum CR — skip-render is broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[continuum-render] Case 2: continuum.enabled=true + role=primary still emits NO CR (CR belongs on the secondary)"
+helm template smoke-bao . \
+  --set continuum.enabled=true \
+  --set snapshotReplication.role=primary \
+  --set continuum.primaryRegion=hz-fsn-rtz-prod \
+  --set continuum.standbyRegion=hz-hel-rtz-prod \
+  --set continuum.pdmZone=t99.omani.works > "$TMP/primary.yaml"
+if grep -qE "^kind: Continuum$" "$TMP/primary.yaml"; then
+  echo "FAIL: continuum.enabled + role=primary rendered a Continuum CR — it must only render on the secondary." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[continuum-render] Case 3: continuum.enabled=true + role=secondary emits the raft-transition Continuum CR"
+helm template smoke-bao . \
+  --set continuum.enabled=true \
+  --set snapshotReplication.enabled=true \
+  --set snapshotReplication.role=secondary \
+  --set continuum.primaryRegion=hz-fsn-rtz-prod \
+  --set continuum.standbyRegion=hz-hel-rtz-prod \
+  --set continuum.pdmZone=t99.omani.works > "$TMP/secondary.yaml"
+
+cr_block="$(awk '/^---$/{f=0} /^kind: Continuum$/{f=1} f' "$TMP/secondary.yaml")"
+if [ -z "$cr_block" ]; then
+  echo "FAIL: role=secondary did not render the Continuum CR." >&2
+  exit 1
+fi
+# The mechanism MUST be raft-transition (NOT the cnpg-pair default).
+if ! echo "$cr_block" | grep -q "mechanism: raft-transition"; then
+  echo "FAIL: Continuum CR is missing switchover.mechanism=raft-transition." >&2
+  echo "$cr_block" >&2
+  exit 1
+fi
+# The raftTransition target must carry the standby Pod selector + snapshot path.
+if ! echo "$cr_block" | grep -q 'podSelector: "app.kubernetes.io/name=openbao"'; then
+  echo "FAIL: Continuum CR raftTransition.podSelector is wrong/missing." >&2
+  exit 1
+fi
+if ! echo "$cr_block" | grep -q 'snapshotPath: "/snapshots/latest.snap"'; then
+  echo "FAIL: Continuum CR raftTransition.snapshotPath is wrong/missing (must match the snapshot-replication restore-staging path)." >&2
+  exit 1
+fi
+# applicationRef must be openbao, and the regions wired through.
+if ! echo "$cr_block" | grep -q "applicationRef: openbao"; then
+  echo "FAIL: Continuum CR applicationRef is not openbao." >&2
+  exit 1
+fi
+if ! echo "$cr_block" | grep -q "hz-fsn-rtz-prod"; then
+  echo "FAIL: Continuum CR did not wire the primaryRegion." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[continuum-render] All bp-openbao continuum-render gates green."

--- a/platform/openbao/chart/values.yaml
+++ b/platform/openbao/chart/values.yaml
@@ -397,3 +397,64 @@ snapshotReplication:
   # stuck OpenBao or S3 endpoint never leaves a Job pending forever.
   activeDeadlineSeconds: 600
   backoffLimit: 3
+
+# ── #3492: openbao DR contract (Continuum CR, raft-transition) ──────────────
+# The bp-continuum engine drives bp-openbao's region-kill promotion. Per
+# docs/topology-matrix.md bp-openbao = active-passive / mechanism
+# `raft-transition`: on a region-kill the surviving standby runs
+# `bao operator raft snapshot restore <staged-snapshot>` +
+# `bao operator raft transition-to-primary`. The snapshot-replication block
+# above stages the snapshot; THIS block ships the Continuum CR that declares
+# the raft-transition mechanism + target so the engine knows HOW to promote
+# this Application.
+#
+# Skip-render (per #402 — never `{{ fail }}`): the Continuum CR renders ONLY
+# when continuum.enabled=true AND snapshotReplication.role=secondary (the CR
+# describes promotion of the STANDBY → primary, so it belongs on the standby
+# cluster). A default `helm template` is byte-identical to origin/main.
+continuum:
+  # Master switch for the openbao Continuum CR. Default-OFF; a per-Sovereign
+  # multi-region overlay flips this true alongside snapshotReplication.enabled
+  # once bp-continuum is installed + the lease witness is configured.
+  enabled: false
+  # Name + namespace of the Continuum CR. Defaults colocate with the openbao
+  # release namespace so bp-continuum's RBAC (pods/exec in the target ns)
+  # covers it.
+  name: cont-openbao
+  # primaryRegion = the ACTIVE region's host-cluster name (the one that dies
+  # in the kill); hotStandbyRegions = the surviving region promoted to primary.
+  # Per-Sovereign overlay sets both to the real cluster names.
+  primaryRegion: ""
+  standbyRegion: ""
+  # RTO/RPO mirror the topology declaration's switchover block
+  # (rtoSeconds: 60, rpoSeconds: 30 — async snapshot interval).
+  rtoSeconds: 60
+  rpoSeconds: 30
+  # autoFailover stays false for openbao: a region-kill promotion restores a
+  # snapshot (potential RPO loss within the async interval) + is
+  # one-directional, so it is an operator-confirmed action (DoD-8 step 8.6),
+  # not an automatic lag-breach flip.
+  autoFailover: false
+  # Lease witness — dns-quorum by default (the same fallback bp-cnpg-pair
+  # uses). Per-Sovereign overlay may switch to cloudflare-kv.
+  leaseClient:
+    kind: dns-quorum
+    config:
+      ttlSeconds: 30
+      renewSeconds: 10
+      resolvers:
+        - "10.43.0.10"
+        - "10.43.0.11"
+        - "10.43.0.12"
+  # PowerDNS zone the lua-record probe target is flipped in (the Sovereign
+  # FQDN). Per-Sovereign overlay sets it.
+  pdmZone: ""
+  # raftTransition target — the surviving standby Pod the promotion execs
+  # into. podSelector discovers the Ready Pod by label; snapshotPath is the
+  # staged-snapshot path the secondary fetch CronJob wrote (matches
+  # snapshotReplication.restoreStaging.path).
+  raftTransition:
+    podSelector: "app.kubernetes.io/name=openbao"
+    container: openbao
+    snapshotPath: /snapshots/latest.snap
+    baoBinary: bao

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2701,12 +2701,18 @@ name: bp-catalyst-platform
 # the bp-rtz-vcluster isolation netpol's `sme` carve-out). Mirrors the
 # #3376 SME NATS_URL→synced-name move. Catalyst-Zero (no sovereignFQDN)
 # render byte-unchanged.
+# 1.4.626 (#3492, 2026-06-14): the Continuum CRD (crds/continuum.yaml)
+# gains spec.switchover.{mechanism,raftTransition} so the bp-openbao
+# raft-transition DR contract validates structurally. Additive +
+# preserve-unknown-fields, so existing CRs are unaffected; slot-13
+# crds:CreateReplace propagates the schema to live Sovereigns. Render
+# byte-unchanged (CRD-only).
 # 1.4.623 (#3373 Batch A, 2026-06-14): bp-seaweedfs moved INSIDE the rtz
 # vCluster. Rewire the qa-fixtures CNPG barman backup endpoint default
 # (qaFixtures.cnpgBackupEndpointURL + cnpg-clusters-qa.yaml) to the
 # syncer-mangled host Service name. qa-fixtures only; Catalyst-Zero render
 # byte-unchanged. (1.4.622 was a content-free deploy-bot image sweep.)
-version: 1.4.625
+version: 1.4.626
 # 1.4.597 — #3373 (2026-06-13) — coupling fix (a) placement-as-data:
 # templates/httproute.yaml backendRefs honor new
 # ingress.gateway.backendServiceApi / backendServiceUi overrides. When

--- a/products/catalyst/chart/crds/continuum.yaml
+++ b/products/catalyst/chart/crds/continuum.yaml
@@ -192,6 +192,71 @@ spec:
                     quorum confirms primary unreachable. If false,
                     controller surfaces alarm only and waits for manual
                     switchover via the Application page (UI in #1101).
+                switchover:
+                  type: object
+                  description: |
+                    Switchover orchestration knobs. `mechanism` selects the
+                    state-store-promotion strategy for the two
+                    mechanism-specific steps of the switchover sequence
+                    (cordon + promote); the other five steps (lease /
+                    drain-HTTP / flip-DNS / audit) are mechanism-agnostic.
+                    Mirrors the Blueprint topology declaration's
+                    switchover.mechanism column (docs/topology-matrix.md).
+                    Also carries the operator-initiated switchover request
+                    flags (requested / targetRegion / requestedBy / reason)
+                    patched by catalyst-api's POST .../switchover.
+                  properties:
+                    mechanism:
+                      type: string
+                      enum: [cnpg-pair, raft-transition]
+                      default: cnpg-pair
+                      description: |
+                        cnpg-pair (default) = bp-cnpg-pair promotion
+                        (cordon annotation + replica.enabled flip on the two
+                        Cluster CR halves). raft-transition = bp-openbao
+                        promotion (`bao operator raft snapshot restore` of
+                        the staged snapshot + `transition-to-primary` via
+                        Pod exec on the surviving standby; #3492).
+                    raftTransition:
+                      type: object
+                      description: |
+                        Openbao standby target for the raft-transition
+                        mechanism. Filled by the bp-openbao bootstrap-kit
+                        slot from the topology declaration. Ignored for
+                        cnpg-pair.
+                      properties:
+                        namespace:
+                          type: string
+                          description: openbao release namespace on the standby cluster.
+                        pod:
+                          type: string
+                          description: |
+                            Explicit standby Raft member Pod to promote
+                            (e.g. openbao-0). When empty, podSelector is
+                            used to discover the Ready Pod.
+                        podSelector:
+                          type: string
+                          description: |
+                            Label selector to find the standby Pod when pod
+                            is empty (e.g. app.kubernetes.io/name=openbao).
+                            The lexically-first Ready match is promoted.
+                        container:
+                          type: string
+                          default: openbao
+                          description: openbao container name inside the Pod.
+                        snapshotPath:
+                          type: string
+                          description: |
+                            On-Pod path the secondary snapshot-fetch CronJob
+                            staged latest.snap to (chart default
+                            /snapshots/latest.snap). Empty promotes from the
+                            standby's own on-disk Raft state (degraded).
+                        baoBinary:
+                          type: string
+                          default: bao
+                          description: openbao CLI name in the image (bao | vault).
+                      x-kubernetes-preserve-unknown-fields: true
+                  x-kubernetes-preserve-unknown-fields: true
               x-kubernetes-preserve-unknown-fields: true
             status:
               type: object

--- a/products/catalyst/chart/crds/tests/continuum-sample-valid.yaml
+++ b/products/catalyst/chart/crds/tests/continuum-sample-valid.yaml
@@ -59,3 +59,42 @@ spec:
   rto: 5m
   rpo: 1m
   autoFailover: false
+---
+# #3492 — openbao raft-transition sample. active-passive secret backend;
+# switchover.mechanism=raft-transition drives `bao operator raft snapshot
+# restore` + `transition-to-primary` on the surviving standby Pod. No
+# cnpgPair (raft-transition needs no CNPG cluster-pair).
+apiVersion: dr.openova.io/v1
+kind: Continuum
+metadata:
+  name: cont-openbao
+  namespace: openbao
+spec:
+  applicationRef: openbao
+  primaryRegion: hz-fsn-rtz-prod
+  hotStandbyRegions:
+    - hz-hel-rtz-prod
+  switchover:
+    mechanism: raft-transition
+    raftTransition:
+      namespace: openbao
+      podSelector: app.kubernetes.io/name=openbao
+      container: openbao
+      snapshotPath: /snapshots/latest.snap
+      baoBinary: bao
+  leaseClient:
+    kind: dns-quorum
+    config:
+      resolvers:
+        - 10.43.0.10
+        - 10.43.0.11
+        - 10.43.0.12
+      ttlSeconds: 30
+      renewSeconds: 10
+  luaRecord:
+    selector: ifurlup
+    healthCheck:
+      url: https://bao.t99.omani.works/v1/sys/health
+  rto: 60s
+  rpo: 30s
+  autoFailover: false

--- a/products/continuum/chart/Chart.yaml
+++ b/products/continuum/chart/Chart.yaml
@@ -39,7 +39,13 @@ type: application
 # 0.1.0 sat in-tree without a bootstrap-kit slot to pin it, so the
 # blueprint-release workflow's `detect changed paths` step never had
 # reason to re-run and the chart was never pushed to GHCR.
-version: 0.1.5
+# 0.1.6 (#3492, 2026-06-14): the switchover sequencer gains a
+# per-mechanism Promoter seam — cnpg-pair (default, byte-identical) +
+# raft-transition (bp-openbao: `bao operator raft snapshot restore` +
+# `transition-to-primary` via Pod exec on the surviving standby). RBAC
+# adds pods + pods/exec for the raft promotion. Slot-62 pin moves to
+# 0.1.6 in lockstep (Inviolable Principle #13).
+version: 0.1.6
 appVersion: "0.1.0"
 home: https://openova.io
 sources:

--- a/products/continuum/chart/templates/rbac.yaml
+++ b/products/continuum/chart/templates/rbac.yaml
@@ -53,6 +53,19 @@ rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  # #3492 — raft-transition mechanism (bp-openbao). The switchover
+  # sequence's promote step execs `bao operator raft snapshot restore` +
+  # `transition-to-primary` inside the surviving openbao standby Pod, and
+  # resolves a podSelector to a Ready Pod. cnpg-pair switchovers never use
+  # these; the grant ships up-front per Inviolable Principle #1
+  # (target-state shape). pods/exec is the create-verb subresource the
+  # SPDY exec stream requires.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
## What

bp-continuum already drove **cnpg-pair** switchover (the working reference); its 7-step Sequencer hardwired the CNPG cordon (step-2) + `replica.enabled` flip (step-6). Per `docs/topology-matrix.md`, **bp-openbao** is active-passive with DR mechanism **`raft-transition`** — on a region-kill the surviving standby runs `bao operator raft snapshot restore` (of the snapshot the bp-openbao snapshot-replication CronJob staged) + `bao operator raft transition-to-primary`. That promotion half **lived in bp-continuum and was not wired** — the #3375 topology builder's explicit gap (*"the openbao-raft promotion half lives in bp-continuum and was NOT re-wired in this pass"*). This PR wires it.

## Engine (`core/controllers/continuum`)

- **Per-mechanism `Promoter` seam** (`promoter.go`): the two state-store-promotion steps (2 + 6) — the *only* mechanism-specific steps — dispatch by `SwitchoverPlan.Mechanism`. `cnpgPromoter` reproduces the cnpg-pair cordon + replica-flip **byte-for-byte**; an empty mechanism defaults to `cnpg-pair`, so existing Continuum CRs are unchanged. The five mechanism-agnostic steps (lease / drain-HTTP / flip-DNS / swap-lease / audit) are shared.
- **`RaftExecPromoter`** (`raft.go`): restores the staged snapshot (when configured) then runs `transition-to-primary` via Pod exec on the surviving standby (resolved by explicit `pod` or a Ready-pod `podSelector`). One-directional — no rollback (a region-kill promotion is not reversible; rejoin is the documented Day-2 path). KV reads stay uninterrupted (restore is the only mutating call, on a Pod already serving as a replica).
- **Production exec backend** (`cmd/raftexec.go`): client-go `remotecommand` SPDY exec + dynamic-client Ready-pod lister, wired onto the reconciler in `main.go`. A nil backend leaves raft-transition CRs failing cleanly at step-2 (cnpg-pair unaffected).
- Controller reads `spec.switchover.mechanism` + `spec.switchover.raftTransition`; `PostSwitchoverHealth`'s cnpg-only replicas check is recorded **deferred** for non-cnpg mechanisms (DNS-probe check is the post-promotion signal).

## Charts / wiring

- **bp-continuum** RBAC: `pods` + `pods/exec` for the raft promotion; chart `0.1.5`→`0.1.6` + slot-62 pin in lockstep.
- **bp-openbao**: ship the openbao Continuum CR (`templates/continuum.yaml`) declaring `mechanism: raft-transition` + the standby target. Skip-render gated on `continuum.enabled=true` AND `snapshotReplication.role=secondary` (the CR belongs on the standby) — **default render byte-identical** to main (proven). chart `1.2.39`→`1.2.40` + slot-08 pin; new `tests/continuum-render.sh` gates the render.
- **Continuum CRD**: `spec.switchover.{mechanism,raftTransition}` schema (additive + preserve-unknown-fields); bp-catalyst-platform `1.4.625`→`1.4.626` + slot-13 pin (`crds:CreateReplace` propagates the schema to live Sovereigns).

## Tests

- 7 new switchover unit tests: full raft sequence (restore→transition **order**), podSelector resolution, no-snapshot skip-restore, restore-failure stops **before** transition, no-promoter clean failure, validate, and a guard that an **empty mechanism still runs cnpg-pair** (raft promoter never invoked).
- parseSpec test for `mechanism` + `raftTransition`.
- `tests/continuum-render.sh`: default = 0 CRs, `role=primary` = 0 CRs, `role=secondary` = the raft-transition CR.
- Full `core/controllers` suite green (`-race`); all 7 bp-openbao chart tests green (incl. the publish-gating `snapshot-replication-toggle.sh` and the SSO tests — SSO config untouched).

## Validation

Validates at the **Wave-3 region-kill operation** (DoD-8): the engine can now promote the surviving openbao standby on a region-A kill (restore staged snapshot + `transition-to-primary`), so region B serves the region-A-written secret read-write.

Refs #3375
Refs #3492

🤖 Generated with [Claude Code](https://claude.com/claude-code)