### PR TITLE
fix(bp-newapi): NetworkPolicy valkey egress → rtz namespace (newapi→valkey datapath, Refs #3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -223,7 +223,15 @@ spec:
       # the syncer-mangled `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc`
       # (mirrors the SME VALKEY_ADDR rewire #3476). This slot's valkey block
       # sets no `valkey.url` override, so the chart default IS what newapi uses.
-      version: 1.4.82
+      # 1.4.83 — Refs #3374: NetworkPolicy valkey-egress selector rewire. #3483
+      # rewired the connection string to the rtz-synced valkey but LEFT the
+      # egress NetworkPolicy rule selecting the now-dead `valkey` namespace, so
+      # newapi's egress to valkey:6379 was DENIED → CrashLoop `Redis ping test
+      # failed` (keystone #3374 walk, live hw135). The chart now selects the
+      # `rtz` namespace (where the synced `valkey-primary-x-valkey-x-rtz-
+      # vcluster` Service lives) for the 6379 egress rule. This slot sets no
+      # `networkPolicy.egress` override, so the chart default IS what renders.
+      version: 1.4.83
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.82
+  version: 1.4.83
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -526,7 +526,19 @@ name: bp-newapi
 # `valkey.url` + blueprint.yaml configSchema default now point at
 # `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc.cluster.local:6379` (mirrors
 # the SME VALKEY_ADDR rewire #3476). Lockstep: 80-newapi.yaml pin → 1.4.81.
-version: 1.4.82
+# 1.4.83 (Refs #3374, 2026-06-14): rewire the NetworkPolicy valkey egress
+# selector to match the #3483 connection-string rewire. #3483 repointed
+# `valkey.url` at the rtz-vCluster syncer-mangled
+# `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc` but LEFT the egress
+# NetworkPolicy rule (`networkPolicy.egress[bp-valkey]`) selecting the now-
+# dead `valkey` namespace (`namespaceSelector: kubernetes.io/metadata.name:
+# valkey`). #3373 Batch A re-homed bp-valkey to the rtz vCluster, so the
+# synced Service lives in the HOST `rtz` namespace — egress to valkey:6379
+# was DENIED → newapi CrashLoop `Redis ping test failed` (keystone #3374
+# walk, live hw135). Flips `networkPolicy.egress[bp-valkey].namespaceLabel`
+# `valkey` → `rtz` so the rendered egress namespaceSelector permits the
+# datapath to the rtz-synced valkey. Lockstep: 80-newapi.yaml pin → 1.4.83.
+version: 1.4.83
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -882,9 +882,10 @@ gateway:
   backendService: ""
 # ─── NetworkPolicy ───────────────────────────────────────────────────────
 # Default-allow ingress from the platform's gateway namespace; egress
-# to Postgres, Valkey, Keycloak, in-cluster vLLM, DNS, and the operator-
-# configured commercial-provider endpoints (egress for those is
-# enforced by the cluster's egress gateway, not this NetworkPolicy).
+# to Postgres, Valkey (now in the rtz host namespace — #3373 Batch A),
+# Keycloak, in-cluster vLLM, DNS, and the operator-configured
+# commercial-provider endpoints (egress for those is enforced by the
+# cluster's egress gateway, not this NetworkPolicy).
 networkPolicy:
   enabled: true
   ingress:
@@ -912,8 +913,17 @@ networkPolicy:
     # actual Postgres Pods reconcile into `.Release.Namespace` (this
     # blueprint's namespace), which `cnpg-system` namespaceSelector
     # could never reach.
-    # bp-valkey
-    - namespaceLabel: valkey
+    # bp-valkey — #3373 Batch A (2026-06-14) moved bp-valkey INTO the rtz
+    # vCluster (placement.yaml: `bp-valkey → vcluster: rtz, namespace:
+    # valkey`). The bp-rtz-vcluster syncer reflects the in-vCluster
+    # `valkey-primary` Service to the HOST `rtz` namespace under the
+    # syncer-mangled name `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc`
+    # — matching the rewired REDIS_CONN_STRING (#3483). The `valkey` host
+    # namespace no longer exists, so this egress rule MUST select the `rtz`
+    # namespace where the synced Service actually lives; otherwise newapi's
+    # egress to valkey:6379 is denied and the Pod CrashLoops on the Redis
+    # ping probe (`Redis ping test failed`, measured live hw135 #3374).
+    - namespaceLabel: rtz
       port: 6379
     # bp-keycloak (OIDC discovery + token)
     - namespaceLabel: keycloak


### PR DESCRIPTION
## Problem

The keystone **#3374** walk found `newapi-bp-newapi` CrashLooping `Redis ping test failed` on hw135.

PR #3483 (Refs #3373 Batch A) rewired newapi's `REDIS_CONN_STRING` to the rtz-vCluster syncer-mangled `valkey-primary-x-valkey-x-rtz-vcluster.rtz.svc.cluster.local:6379` — because #3373 Batch A re-homed **bp-valkey INTO the rtz vCluster**. But #3483 LEFT the NetworkPolicy egress rule for port 6379 selecting the now-**dead `valkey` namespace**:

```yaml
- namespaceSelector:
    matchLabels:
      kubernetes.io/metadata.name: valkey   # ← namespace no longer exists
  ports:
    - port: 6379
```

The synced valkey Service now lives in the HOST `rtz` namespace (`valkey-primary-x-valkey-x-rtz-vcluster`), so newapi's egress to valkey:6379 was **DENIED** → Redis ping fails → CrashLoopBackOff. This is the netpol-selector half of the newapi→valkey break; the cross-node Cilium WireGuard mesh half is fixed separately (a2ad9263). Both are needed.

## Fix (at source, in the bp-newapi chart)

Flip `networkPolicy.egress[bp-valkey].namespaceLabel` from `valkey` → `rtz` in `platform/newapi/chart/values.yaml`. The `templates/networkpolicy.yaml` template renders this list into `namespaceSelector: { matchLabels: kubernetes.io/metadata.name: <namespaceLabel> }`, so the rendered egress now permits the datapath to the rtz-synced valkey — exactly matching the #3483 connection-string rewire target namespace.

**Selector change (old → new):**
```diff
-    - namespaceLabel: valkey
+    - namespaceLabel: rtz
       port: 6379
```

## Files

- `platform/newapi/chart/values.yaml` — egress selector `valkey` → `rtz` (+ comment)
- `platform/newapi/chart/Chart.yaml` — version `1.4.82` → `1.4.83` (+ changelog)
- `platform/newapi/blueprint.yaml` — `spec.version` lockstep → `1.4.83`
- `clusters/_template/bootstrap-kit/80-newapi.yaml` — slot 80 pin → `1.4.83` (+ changelog)

## Verification

`helm template newapi platform/newapi/chart` — the rendered NetworkPolicy 6379 egress rule now reads:

```yaml
    - to:
        - namespaceSelector:
            matchLabels:
              kubernetes.io/metadata.name: rtz
      ports:
        - port: 6379
          protocol: TCP
```

`kubernetes.io/metadata.name` is the apiserver-applied immutable namespace label (GA since k8s 1.22), so this matches the `rtz` host namespace where the synced valkey Service lives. newapi → rtz valkey:6379 egress is now allowed.

Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)