### PR TITLE
fix(bp-kyverno,bp-vpa): exempt the cilium CNI bootstrap from pod admission webhooks — break the cilium-roll self-deadlock (Refs #3375)

### DIFF
--- a/clusters/_template/bootstrap-kit/27-kyverno.yaml
+++ b/clusters/_template/bootstrap-kit/27-kyverno.yaml
@@ -68,7 +68,12 @@ spec:
       # closes META-AUDIT 1 sub-class 3 — kyverno admission webhook
       # registered before kyverno-svc Pod ready blocks own Secret CREATE
       # via failurePolicy: Fail. Verified deadlock on hw62 v14 06:11Z.
-      version: 1.3.6
+      # 1.3.7 (#3499, Refs #3375/#3380): config.webhooks.objectSelector excludes
+      # the cilium CNI stack from the Fail webhooks so a cilium DaemonSet roll
+      # can always recreate its own agent (the de-CNI'd apiserver node can't
+      # receive the webhook response otherwise → cnpg-pair initdb wedged on
+      # hw135 → no region-b standby → region-kill impossible).
+      version: 1.3.7
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/clusters/_template/bootstrap-kit/29-vpa.yaml
+++ b/clusters/_template/bootstrap-kit/29-vpa.yaml
@@ -50,7 +50,10 @@ spec:
   chart:
     spec:
       chart: bp-vpa
-      version: 1.0.1
+      # 1.0.2 (#3499, Refs #3375/#3380): VPA pod webhook excludes kube-system
+      # (--ignored-vpa-object-namespaces) so its 30s-timeout Ignore call can't
+      # stall the cilium CNI-bootstrap Pod creates during a cilium roll.
+      version: 1.0.2
       sourceRef:
         kind: HelmRepository
         name: bp-vpa

--- a/platform/kyverno/blueprint.yaml
+++ b/platform/kyverno/blueprint.yaml
@@ -9,7 +9,9 @@ spec:
   # + extraInitContainer that blocks main container until the secret is
   # populated. See platform/kyverno/chart/Chart.yaml for the full rationale.
   # 1.3.6 (#3149): webhook-gate non-fatal — no more fatal-hook→stuck-uninstall cascade.
-  version: 1.3.6
+  # 1.3.7 (#3499): config.webhooks.objectSelector excludes the cilium CNI stack so a
+  # cilium roll can always recreate its agent (breaks the apiserver-return-path deadlock).
+  version: 1.3.7
   card:
     title: Kyverno
     family: guardian

--- a/platform/kyverno/chart/Chart.yaml
+++ b/platform/kyverno/chart/Chart.yaml
@@ -24,7 +24,13 @@ type: application
 # gate stays a slow-warm DETECTOR (waits the full budget, logs loudly) but
 # never wedges the cluster; downstream admission-needers gate on their own
 # cert-wait + G50 retries. This is the "DEEPER FIX still owed" from the G54 header.
-version: 1.3.6
+# 1.3.7 (#3499, Refs #3375/#3380): config.webhooks.objectSelector excludes the
+# cilium CNI stack (app.kubernetes.io/part-of=cilium) from the Fail webhooks so
+# a cilium DaemonSet roll can always recreate its own agent — breaks the
+# self-deadlock where the de-CNI'd apiserver node can't receive the webhook
+# response (hw135: cnpg-pair initdb wedged → no region-b standby → region-kill
+# impossible). See chart/values.yaml config.webhooks for the full root cause.
+version: 1.3.7
 appVersion: "v1.18.0"
 keywords: [catalyst, blueprint, kyverno, policy, admission, security]
 maintainers:

--- a/platform/kyverno/chart/values.yaml
+++ b/platform/kyverno/chart/values.yaml
@@ -237,6 +237,57 @@ kyverno:
   # `config.webhooks.namespaceSelector` and per-controller `failurePolicy`
   # via the upstream chart's controller-scoped settings once 3-replica HA
   # is in place. See upstream `values.yaml` `config:` block for shape.
+  #
+  # #3499 (Refs #3375, #3380, 2026-06-14) — CNI-bootstrap admission exemption.
+  #
+  # ROOT CAUSE (root-caused live on hw135, dep 368c2d9b74d0b71a): kyverno's
+  # resource webhooks run failurePolicy=Fail and match `pods` + `batch/jobs`.
+  # When the cilium DaemonSet rolls (any spec change re-creates its agent
+  # pods), the rolling-update DELETES the old agent on the control-plane /
+  # apiserver node, then must CREATE the replacement — a Pod CREATE that
+  # passes through these very webhooks. With the apiserver node's cilium-agent
+  # momentarily gone, the apiserver->kyverno *request* still arrives but
+  # kyverno's *response* back to the apiserver's pod-network address times out
+  # (no BPF datapath on the de-CNI'd node):
+  #     ERR "read tcp <kyverno-pod>:9443-><apiserver-podIP>: i/o timeout"
+  #         url=/validate/fail?timeout=10s
+  # → admission hits the 10s deadline → "context deadline exceeded" → the
+  # replacement cilium-agent Pod is never admitted → the apiserver node stays
+  # CNI-less permanently → self-perpetuating deadlock that also wedges
+  # cilium-operator and every downstream Pod/Job create (incl. cnpg-pair
+  # initdb → no region-b standby → #3375 region-kill impossible).
+  #
+  # FIX: exempt the cilium CNI stack from the kyverno resource webhooks so a
+  # cilium roll can ALWAYS recreate its own agent and self-heal the datapath,
+  # regardless of admission/datapath state. All three cilium components
+  # (agent, operator, envoy) carry `app.kubernetes.io/part-of: cilium`, so a
+  # single objectSelector covers the whole CNI bootstrap. This does NOT weaken
+  # policy coverage for any tenant/app workload — only the cluster's own CNI
+  # pods bypass admission, and only on the create/update path. The upstream
+  # `kyverno.config.webhooks` helper preserves objectSelector verbatim and
+  # appends the kube-system + kyverno-namespace exclusions to namespaceSelector
+  # (see charts/kyverno/templates/config/_helpers.tpl). Setting config.webhooks
+  # here REPLACES the upstream default block, so the namespaceSelector below
+  # re-states the upstream kube-system exclusion (the helper still appends the
+  # kyverno namespace because excludeKyvernoNamespace stays true).
+  config:
+    webhooks:
+      # Exclude namespaces (re-states the upstream default — kube-system; the
+      # helper also appends the kyverno namespace via excludeKyvernoNamespace).
+      namespaceSelector:
+        matchExpressions:
+          - key: kubernetes.io/metadata.name
+            operator: NotIn
+            values:
+              - kube-system
+      # Exclude the cilium CNI stack (agent + operator + envoy) so a cilium
+      # DaemonSet roll never deadlocks against the Fail webhook return-path.
+      objectSelector:
+        matchExpressions:
+          - key: app.kubernetes.io/part-of
+            operator: NotIn
+            values:
+              - cilium
 
   # OpenReports CRDs — both flags must agree per upstream schema. Default
   # disabled (matches upstream); per-Sovereign overlays enable BOTH together

--- a/platform/vpa/blueprint.yaml
+++ b/platform/vpa/blueprint.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.1
+  # 1.0.2 (#3499): VPA pod webhook excludes kube-system so it can't stall the
+  # cilium CNI-bootstrap Pod creates during a cilium roll.
+  version: 1.0.2
   card:
     title: Vertical Pod Autoscaler
     family: guardian

--- a/platform/vpa/chart/Chart.yaml
+++ b/platform/vpa/chart/Chart.yaml
@@ -17,7 +17,12 @@ description: |
   (recommend only) — SREs opt individual workloads into `Auto` via
   VerticalPodAutoscaler CRs.
 type: application
-version: 1.0.1
+# 1.0.2 (#3499, Refs #3375/#3380): admissionController extraArgs
+# --ignored-vpa-object-namespaces=kube-system → the self-registered VPA pod
+# webhook excludes kube-system, so its 30s-timeout Ignore call can never stall
+# the cilium CNI-bootstrap Pod creates during a cilium DaemonSet roll (hw135
+# region-kill blocker). See chart/values.yaml admissionController.extraArgs.
+version: 1.0.2
 appVersion: "1.5.0"
 keywords: [catalyst, blueprint, vpa, autoscaling, vertical-pod-autoscaler, right-sizing]
 maintainers:

--- a/platform/vpa/chart/values.yaml
+++ b/platform/vpa/chart/values.yaml
@@ -91,6 +91,36 @@ vertical-pod-autoscaler:
       limits:
         cpu: 200m
         memory: 512Mi
+    # #3499 (Refs #3375, #3380, 2026-06-14) — exclude kube-system from the
+    # VPA pod-mutating webhook so it can never gate the CNI bootstrap.
+    #
+    # The VPA admission-controller SELF-REGISTERS a MutatingWebhookConfiguration
+    # (`vpa-webhook-config`) matching CREATE on `pods` in every namespace. Its
+    # backend Pod can be scheduled onto ANY node — including one whose
+    # cilium-agent a concurrent cilium DaemonSet roll has just deleted. When
+    # that happens the apiserver's call to the VPA webhook (failurePolicy=Ignore,
+    # timeout=30s) hangs against the de-CNI'd backend for the FULL 30s before
+    # being ignored — which exceeds the apiserver's Pod-create request deadline,
+    # so even the replacement cilium-agent Pod create returns "context deadline
+    # exceeded". That stalls CNI self-heal (root-caused live on hw135: VPA
+    # backend 10.42.4.209 sat on the de-CNI'd node, blocking cilium recreation
+    # for 30s/attempt; #3499). The companion bp-kyverno fix exempts cilium from
+    # the Fail webhook; this exempts it from the VPA webhook so the CNI bootstrap
+    # is gated by NO webhook at all.
+    #
+    # VPA 1.5.0 builds the webhook's namespaceSelector from
+    # `--ignored-vpa-object-namespaces` (comma-separated): the binary registers
+    # the webhook with `namespaceSelector: kubernetes.io/metadata.name NotIn
+    # [<here>]` AND skips VPA-object reconciliation in those namespaces (see
+    # autoscaler vertical-pod-autoscaler-1.5.0 pkg/admission-controller
+    # config.go selfRegistration + main.go). Because VPA RE-registers the
+    # webhook on every restart/roll, this exclusion survives — unlike a manual
+    # patch of the webhook config, which VPA would overwrite. kube-system holds
+    # the cilium DaemonSet + operator + envoy + all other CNI/control-plane
+    # bootstrap workloads; VPA never right-sizes those, so excluding it costs
+    # nothing.
+    extraArgs:
+      ignored-vpa-object-namespaces: kube-system
     # The admission controller serves a MutatingWebhookConfiguration over
     # TLS. The upstream chart bootstraps a self-signed CA + cert via an
     # init job, which is fine for Catalyst because the webhook is


### PR DESCRIPTION
## What

Breaks the **cilium DaemonSet rolling-update self-deadlock** that wedged the #3375 region-kill walk on the keystone fresh prov **hw135** (dep `368c2d9b74d0b71a`). Two source fixes, one per webhook leg.

## Root cause (root-caused live on hw135)

When the cilium DS rolls (any spec change re-creates its agent pods), the rolling-update **deletes** the old `cilium-agent` on the control-plane / apiserver node, then must **CREATE** the replacement — a Pod CREATE that passes through the cluster's admission webhooks. With the apiserver node's `cilium-agent` momentarily gone, the apiserver->webhook **request** still arrives, but the webhook's **response** back to the apiserver's pod-network address times out (no BPF datapath on the de-CNI'd node):

```
kyverno-admission-controller log:
ERR "read tcp 10.42.1.138:9443->10.42.0.210:43398: i/o timeout" url=/validate/fail?timeout=10s
ERR "read tcp 10.42.1.138:9443->10.42.0.210:45420: i/o timeout" url=/mutate/fail?timeout=10s
```

`10.42.0.210` is in the apiserver node's podCIDR (`10.42.0.0/24` = cp1). Admission hits the 10s deadline → `Timeout: request did not complete within requested timeout - context deadline exceeded`. Because the **replacement `cilium-agent` Pod is itself a Pod CREATE**, it can never be admitted → the apiserver node stays CNI-less permanently → `cilium-operator` wedges (`0/1`, `ProgressDeadlineExceeded`) → every downstream Pod/Job create times out — including the **`cnpg-pair` initdb Job** → no region-b standby → **#3375 region-kill cannot proceed**.

Evidence on hw135: cilium DS `DESIRED=4 READY=2` (cp1 + wdfac75 stuck, pods admission-rejected not crashed); `cnpg-pair-bp-cnpg-pair-primary` stuck `Setting up primary` 35m+ with `FailedCreate: Timeout ... context deadline exceeded`. Other cnpg clusters initdb'd fine because they were created **before** the cilium roll window; cnpg-pair caught the break. This is a **SOURCE** defect (reproduces on any fresh prov when the cilium DS rolls while a Fail-policy pods webhook is active), not a transient blip.

## The fix — exempt the CNI bootstrap from pod admission webhooks

A cilium roll must be able to recreate its own agent regardless of admission/datapath state. Two webhook legs gate the cilium agent Pod create; both are fixed at source:

**`bp-kyverno` 1.3.6 -> 1.3.7** — `config.webhooks.objectSelector` excludes `app.kubernetes.io/part-of=cilium` (covers agent + operator + envoy) from the **Fail** resource webhooks. The upstream `kyverno.config.webhooks` helper preserves `objectSelector` verbatim and still appends the `kube-system` + `kyverno` namespace exclusions. No policy coverage lost for any tenant/app workload — only the cluster's own CNI pods bypass admission, only on create/update.

**`bp-vpa` 1.0.1 -> 1.0.2** — admissionController `extraArgs: --ignored-vpa-object-namespaces=kube-system`. The VPA admission-controller self-registers a pod-mutating webhook (`Ignore`, **30s** timeout) whose backend can be scheduled onto a de-CNI'd node; on hw135 the VPA backend `10.42.4.209` sat on the broken node and stalled the cilium Pod create for the full 30s (exceeding the apiserver request deadline). VPA 1.5.0 builds the webhook's `namespaceSelector` from this flag and **re-registers on every restart/roll**, so the exclusion survives — unlike a manual webhook patch, which VPA would overwrite.

Both bootstrap-kit pins bumped in lockstep (`27-kyverno.yaml` -> 1.3.7, `29-vpa.yaml` -> 1.0.2).

## Verification

Rendered both charts:
- kyverno ConfigMap `webhooks` now = `{"namespaceSelector":{... kube-system, kyverno ...},"objectSelector":{"matchExpressions":[{"key":"app.kubernetes.io/part-of","operator":"NotIn","values":["cilium"]}]}}`
- vpa admission-controller args now include `--ignored-vpa-object-namespaces=kube-system`
- `helm lint` clean on both; pin-sync audit green.

Live-walk on hw135 (cilium DS -> 4/4, cilium-operator 1/1, cnpg-pair initdb + region-b standby streaming -> region-kill possible) tracked on #3499 / #3375.

## Notes / optional follow-up

The `opentelemetry-operator` `mpod.kb.io` webhook (`Ignore`, matches kube-system pods) is a *potential* third amplifier, but its backend is on a healthy node on hw135 and it is not the operative cause; excluding kube-system there needs an operator-flag/post-render change. Left as optional defense-in-depth on #3499 to avoid scope creep.

Refs #3375
Refs #3380
Refs #3499

🤖 Generated with [Claude Code](https://claude.com/claude-code)
