### PR TITLE
fix(bp-vpa): cap admission webhook timeout at 2s — defence-in-depth on the #3502 kube-system exemption

### DIFF
--- a/clusters/_template/bootstrap-kit/29-vpa.yaml
+++ b/clusters/_template/bootstrap-kit/29-vpa.yaml
@@ -53,7 +53,9 @@ spec:
       # 1.0.2 (#3499, Refs #3375/#3380): VPA pod webhook excludes kube-system
       # (--ignored-vpa-object-namespaces) so its 30s-timeout Ignore call can't
       # stall the cilium CNI-bootstrap Pod creates during a cilium roll.
-      version: 1.0.2
+      # 1.0.3 (Refs #3374/#3375): + --webhook-timeout-seconds=2 caps the hang
+      # in non-kube-system namespaces (cnpg initdb / keycloak / tenant vclusters).
+      version: 1.0.3
       sourceRef:
         kind: HelmRepository
         name: bp-vpa

--- a/platform/vpa/blueprint.yaml
+++ b/platform/vpa/blueprint.yaml
@@ -7,7 +7,9 @@ metadata:
 spec:
   # 1.0.2 (#3499): VPA pod webhook excludes kube-system so it can't stall the
   # cilium CNI-bootstrap Pod creates during a cilium roll.
-  version: 1.0.2
+  # 1.0.3 (Refs #3374/#3375): + --webhook-timeout-seconds=2 caps the same hang
+  # in non-kube-system namespaces (cnpg initdb / keycloak / tenant vclusters).
+  version: 1.0.3
   card:
     title: Vertical Pod Autoscaler
     family: guardian

--- a/platform/vpa/chart/Chart.yaml
+++ b/platform/vpa/chart/Chart.yaml
@@ -21,8 +21,12 @@ type: application
 # --ignored-vpa-object-namespaces=kube-system → the self-registered VPA pod
 # webhook excludes kube-system, so its 30s-timeout Ignore call can never stall
 # the cilium CNI-bootstrap Pod creates during a cilium DaemonSet roll (hw135
-# region-kill blocker). See chart/values.yaml admissionController.extraArgs.
-version: 1.0.2
+# region-kill wedge). See chart/values.yaml admissionController.extraArgs.
+# 1.0.3 (Refs #3374/#3375): + admissionController --webhook-timeout-seconds=2
+# defence-in-depth — bounds the same VPA-webhook hang in NON-kube-system
+# namespaces (cnpg initdb, keycloak, tenant vclusters) that the kube-system
+# exemption does not cover.
+version: 1.0.3
 appVersion: "1.5.0"
 keywords: [catalyst, blueprint, vpa, autoscaling, vertical-pod-autoscaler, right-sizing]
 maintainers:

--- a/platform/vpa/chart/values.yaml
+++ b/platform/vpa/chart/values.yaml
@@ -119,8 +119,27 @@ vertical-pod-autoscaler:
     # the cilium DaemonSet + operator + envoy + all other CNI/control-plane
     # bootstrap workloads; VPA never right-sizes those, so excluding it costs
     # nothing.
+    #
+    # ─── Webhook-timeout cap — defence-in-depth (Refs #3374, #3375) ──────
+    # `ignored-vpa-object-namespaces` above exempts ONLY kube-system, which
+    # protects the cilium CNI bootstrap. But the same VPA webhook still
+    # intercepts Pod CREATE in EVERY OTHER namespace (cnpg, keycloak, the
+    # tenant vclusters, …) with the upstream-default 30s timeout. If the
+    # single admission-controller replica is ever briefly unroutable while
+    # cilium is otherwise healthy (node reboot, replica reschedule), every
+    # Pod CREATE in those namespaces hangs up to 30s — long enough to time
+    # out a cnpg-pair initdb bootstrap Pod (root-caused live on hw135: the
+    # initdb Pod CREATE returned "context deadline exceeded", #3375). Since
+    # cilium is healthy in that scenario the mesh won't self-heal the way the
+    # kube-system exemption fixes the CNI case, so the exemption alone does
+    # not cover it. Capping the webhook timeout at 2s bounds that blast
+    # radius cluster-wide: failurePolicy=Ignore means the api-server simply
+    # falls through after 2s. 2s is ample for a cluster-internal mutation;
+    # steady state carries zero added CREATE latency. Per-Sovereign overlays
+    # MAY raise it.
     extraArgs:
       ignored-vpa-object-namespaces: kube-system
+      webhook-timeout-seconds: 2
     # The admission controller serves a MutatingWebhookConfiguration over
     # TLS. The upstream chart bootstraps a self-signed CA + cert via an
     # init job, which is fine for Catalyst because the webhook is


### PR DESCRIPTION
## Context — additive on the just-merged #3502

#3502 (merged) exempts **only kube-system** from the VPA admission-controller's self-registered pod-mutating webhook (`--ignored-vpa-object-namespaces=kube-system`). That correctly protects the **cilium CNI bootstrap** and breaks the cilium-roll self-deadlock.

This PR layers **defence-in-depth** on top of it: cap the webhook's timeout at **2s** so the same hang is bounded in **every other namespace** too.

## Why the kube-system exemption alone is not enough

The VPA webhook still intercepts Pod CREATE in **cnpg, keycloak, the tenant vclusters, …** with the upstream-default **30s** timeout. Root-caused live on hw135:

- With the pre-#3502 webhook, the cilium-agent on 2 of 4 primary nodes was deleted by a routine cilium roll. The single `vpa-admission` replica sat on one of those de-CNI'd nodes (Pod IP `10.42.4.209`), so **every** Pod CREATE hung the full 30s — `FailedCreate: context deadline exceeded`.
- #3502 fixes the **cilium (kube-system)** path.
- But `cnpg-pair-bp-cnpg-pair-primary-1-initdb` lives in the **`cnpg`** namespace, **not** kube-system. Its bootstrap Pod CREATE still returned `context deadline exceeded` (the **#3375** region-kill wedge — verified live: the initdb job was stuck `Running 0/1` for 65m with that exact event).
- In the non-kube-system scenario cilium is otherwise healthy, so the mesh won't self-heal the way the kube-system exemption fixes the CNI case. The exemption alone does not cover it.

## Fix

Add `webhook-timeout-seconds: 2` to `admissionController.extraArgs` (upstream documents this knob). `failurePolicy=Ignore`, so the api-server falls through after 2s instead of 30s. 2s is ample for a cluster-internal mutation; steady state carries zero added CREATE latency. Per-Sovereign overlays MAY raise it.

`helm template` confirms BOTH flags now render on the admission-controller container:
```
--ignored-vpa-object-namespaces=kube-system
--webhook-timeout-seconds=2
```

## Lockstep
- `platform/vpa/chart/values.yaml` — add `webhook-timeout-seconds: 2` (+ rationale)
- `platform/vpa/chart/Chart.yaml` — `1.0.2` to `1.0.3`
- `platform/vpa/blueprint.yaml` — `1.0.2` to `1.0.3`
- `clusters/_template/bootstrap-kit/29-vpa.yaml` — slot-29 pin `1.0.2` to `1.0.3`

Refs #3374 (SSO cross-node datapath). Refs #3375 (cnpg-pair initdb / region-kill — same single root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
