### PR TITLE
fix(infra-huawei): per-region pod + service CIDRs — stop the ClusterMesh PodCIDR collision blocking #3375 region-kill (Refs #3375)

### DIFF
--- a/infra/providers/huawei/main.tf
+++ b/infra/providers/huawei/main.tf
@@ -59,6 +59,36 @@ locals {
     r.code => format("10.%d.1.0/24", local.cidr_base + idx * 10)
   }
 
+  # #3504 (Refs #3375) — per-region k3s pod + service CIDRs.
+  #
+  # The k3s --cluster-cidr (pod CIDR) and --service-cidr MUST be
+  # non-overlapping across ClusterMesh peers (DoD gate D11). Previously
+  # both were hardcoded to 10.42.0.0/16 + 10.96.0.0/16 for EVERY region,
+  # so region-a cp1 and region-b cp1 both advertised 10.42.0.0/24. Across
+  # the mesh the region-a apiserver's pod-network source IP (10.42.0.x)
+  # then resolved AMBIGUOUSLY — a peer's ipcache mapped it to region-b's
+  # cp1 instead of region-a's — so every apiserver→webhook RESPONSE
+  # tunnelled to the wrong region and never returned (10s timeout). That
+  # mis-route broke the cp1 datapath (Cluster health 1/4 reachable),
+  # wedging the cnpg-pair initdb + cert-manager/kyverno webhooks → no
+  # region-b standby → #3375 region-kill impossible (root-caused on hw135).
+  #
+  # Mirror the Hetzner module (infra/providers/hetzner/main.tf
+  # region_cluster_cidr / region_service_cidr): offset each region's /16
+  # by its index. Pod CIDR 10.(42+idx).0.0/16, service CIDR
+  # 10.(96+idx).0.0/16 — primary=10.42/10.96, region-b=10.43/10.97, etc.
+  # These are the k3s overlay's INTERNAL pod/service ranges (independent
+  # of the per-prov region_vpc_cidr above, which addresses the nodes); the
+  # +42/+96 bases match Hetzner so both providers share the same D11 shape.
+  region_cluster_cidr = {
+    for idx, r in var.regions :
+    r.code => format("10.%d.0.0/16", 42 + idx)
+  }
+  region_service_cidr = {
+    for idx, r in var.regions :
+    r.code => format("10.%d.0.0/16", 96 + idx)
+  }
+
   # Effective per-region SKU — operator-supplied wins; module defaults
   # back-fill empty entries (s7n.large.4 / m7n.xlarge.8).
   effective_cp_flavor = {
@@ -377,13 +407,17 @@ resource "huaweicloud_networking_secgroup_rule" "ingress_cilium_health" {
 # any pod-to-pod traffic that escapes encap (e.g. host-gw / native routing
 # fallback) is also permitted. Defence-in-depth alongside source_dest_check=false.
 # HCS rejects "any" protocol — list specific protocols Cilium pod-to-pod uses.
+# #3504 (Refs #3375): the allowed prefix is the region's OWN pod CIDR
+# (was hardcoded 10.42.0.0/16; with per-region pod CIDRs region-b is now
+# 10.43.0.0/16, so a hardcoded 10.42 rule would drop region-b's own
+# pod-to-pod fallback traffic).
 resource "huaweicloud_networking_secgroup_rule" "ingress_pod_cidr_tcp" {
   for_each          = { for r in var.regions : r.code => r }
   security_group_id = huaweicloud_networking_secgroup.region[each.key].id
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
-  remote_ip_prefix  = "10.42.0.0/16"
+  remote_ip_prefix  = local.region_cluster_cidr[each.key]
   description       = "Pod CIDR TCP all-ports (Cilium pod-to-pod fallback path)"
 }
 resource "huaweicloud_networking_secgroup_rule" "ingress_pod_cidr_udp" {
@@ -392,7 +426,7 @@ resource "huaweicloud_networking_secgroup_rule" "ingress_pod_cidr_udp" {
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
-  remote_ip_prefix  = "10.42.0.0/16"
+  remote_ip_prefix  = local.region_cluster_cidr[each.key]
   description       = "Pod CIDR UDP all-ports (Cilium pod-to-pod fallback path)"
 }
 resource "huaweicloud_networking_secgroup_rule" "ingress_pod_cidr_icmp" {
@@ -401,7 +435,7 @@ resource "huaweicloud_networking_secgroup_rule" "ingress_pod_cidr_icmp" {
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "icmp"
-  remote_ip_prefix  = "10.42.0.0/16"
+  remote_ip_prefix  = local.region_cluster_cidr[each.key]
   description       = "Pod CIDR ICMP (Cilium pod-to-pod diagnostics)"
 }
 
@@ -806,8 +840,11 @@ locals {
       k3s_token             = sha256("${var.huawei_project_id}/${var.sovereign_fqdn}/k3s-bootstrap")
       # Per-CP region's own subnet first-IP.
       cp_private_ip = cidrhost(local.region_subnet_cidr[r.code], 2)
-      cluster_cidr  = "10.42.0.0/16"
-      service_cidr  = "10.96.0.0/16"
+      # #3504 (Refs #3375): per-region pod/service CIDRs (was hardcoded
+      # 10.42.0.0/16 + 10.96.0.0/16 for every region → ClusterMesh
+      # PodCIDR collision → cp1 datapath mis-route → region-kill blocked).
+      cluster_cidr = local.region_cluster_cidr[r.code]
+      service_cidr = local.region_service_cidr[r.code]
       # Canonical region labels (G84 #2631: `hw` prefix, NOT `hu`).
       region_canonical_label         = "hw-${r.code}-rtz-prod"
       primary_region_canonical_label = "hw-${var.regions[0].code}-rtz-prod"

--- a/infra/providers/huawei/tests/multi_region.tftest.hcl
+++ b/infra/providers/huawei/tests/multi_region.tftest.hcl
@@ -109,6 +109,28 @@ run "tier_b_two_regions_poc" {
     error_message = "Tier-B must create one security group per region (expected 2)."
   }
 
+  # #3504 (Refs #3375): per-region pod + service CIDRs must be DISTINCT
+  # across regions (DoD gate D11 — non-overlapping ClusterMesh pod CIDRs).
+  # Regression guard for the hardcoded 10.42.0.0/16 / 10.96.0.0/16 that
+  # made both regions' cp1 advertise 10.42.0.0/24 → ClusterMesh PodCIDR
+  # collision → cp1 datapath mis-route → region-kill blocked on hw135.
+  assert {
+    condition     = local.region_cluster_cidr["me-east-215-a"] == "10.42.0.0/16"
+    error_message = "Primary region pod CIDR must be 10.42.0.0/16."
+  }
+  assert {
+    condition     = local.region_cluster_cidr["me-east-215-b"] == "10.43.0.0/16"
+    error_message = "Secondary region pod CIDR must be 10.43.0.0/16 (offset by region index — must NOT collide with the primary's 10.42.0.0/16)."
+  }
+  assert {
+    condition     = local.region_cluster_cidr["me-east-215-a"] != local.region_cluster_cidr["me-east-215-b"]
+    error_message = "Per-region pod CIDRs MUST be distinct across ClusterMesh peers (D11) — a collision mis-routes the cp1 apiserver→webhook datapath."
+  }
+  assert {
+    condition     = local.region_service_cidr["me-east-215-a"] == "10.96.0.0/16" && local.region_service_cidr["me-east-215-b"] == "10.97.0.0/16"
+    error_message = "Per-region service CIDRs must be 10.96.0.0/16 (primary) and 10.97.0.0/16 (secondary) — offset by region index."
+  }
+
   # Wave 5.7: 2 EIPs (one per region) — was 6 (3 CP × 2 regions) in the
   # historical Hetzner-style fixed-3 design. The new per-region EIP keys
   # by region code (`cp["me-east-215-a"]`) rather than CP index.


### PR DESCRIPTION
## What

Fixes the **ClusterMesh PodCIDR collision** on multi-region Huawei/kom4dc Sovereigns — the operative datapath cause that stops the #3375 region-kill on hw135. Mirrors the Hetzner module's per-region CIDR allocation.

## Root cause (root-caused live on hw135, dep 368c2d9b74d0b71a)

`infra/providers/huawei/main.tf` hardcoded the k3s pod + service CIDR for **every** region:
```hcl
cluster_cidr  = "10.42.0.0/16"
service_cidr  = "10.96.0.0/16"
```
So a 2-region prov gave both regions' cp1 the same `10.42.0.0/24`:
```
hw135-me-east--b/...-b-cp1   10.159.1.251   10.42.0.0/24   clustermesh
hw135-mesh/...-a-cp1         10.149.1.33    10.42.0.0/24   custom-resource
```
The region-a apiserver's pod-network source `10.42.0.210` is then ambiguous across the mesh — a region-a worker's ipcache resolves it to **region-b's cp1 (`10.159.1.251`)** instead of local region-a (`10.149.1.33`). Every apiserver→webhook **response** tunnels to the wrong region → never returns → 10s timeout. cp1 `Cluster health: 1/4 reachable`; cp1 cannot reach any cross-node pod while worker-to-worker is fine. That mis-route wedges the cnpg-pair initdb + the cert-manager/kyverno webhooks → no region-b standby → region-kill cannot run.

This surfaced while verifying the #3499 admission-webhook fix on hw135: once the admission self-deadlock was cleared (cilium recovered 4/4), the cnpg-pair still could not initdb — because of this deeper PodCIDR collision.

## Fix

The Hetzner module already allocates per-region CIDRs correctly (`region_cluster_cidr` / `region_service_cidr`, offset by region index — DoD gate D11, with tofu tests). The Huawei module was never given the offset. This change mirrors it:

```hcl
region_cluster_cidr = { for idx, r in var.regions : r.code => format("10.%d.0.0/16", 42 + idx) }
region_service_cidr = { for idx, r in var.regions : r.code => format("10.%d.0.0/16", 96 + idx) }
```
→ primary `10.42/10.96`, region-b `10.43/10.97`. The k3s `--cluster-cidr` / `--service-cidr` now reference `local.region_cluster_cidr[r.code]` / `local.region_service_cidr[r.code]`.

The three intra-region pod-CIDR security-group rules (Wave 5.30 fallback path) also referenced the hardcoded `10.42.0.0/16`; they now use the region's **own** pod CIDR so region-b's `10.43` pod-to-pod fallback traffic isn't dropped. Cross-region pod traffic is VXLAN + WireGuard **encapsulated** (outer packet = node-IP), so no new cross-region SG rules are needed — the existing node-to-node (VPC-peering / EIP) rules already carry the tunnel.

## Verification

- `tofu fmt -check` clean.
- 4 assertions added to `tests/multi_region.tftest.hcl` guarding that the two regions get **distinct** pod + service CIDRs (regression guard for the hardcoded constants). The `infra-huawei-tofu.yaml` CI runs `tofu validate` + `tofu test`.
- On a fresh 2-region Huawei prov: region-a `10.42.0.0/16`, region-b `10.43.0.0/16` (no collision) → cp1's pod-network source IP is unambiguous → apiserver→webhook return-path routes correctly → cnpg-pair initdb's + region-b standby streams → region-kill possible. (Live walk tracked on #3504 / #3375.)

Refs #3504
Refs #3375

🤖 Generated with [Claude Code](https://claude.com/claude-code)
