### PR TITLE
fix(bp-sso-bridge): per-app OIDC ExternalSecret into HR targetNamespace — grafana zero-click 503 (Refs #3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -128,7 +128,15 @@ spec:
       # the hubble oauth2-proxy CreateContainerConfigError (slot-01 install-
       # time .Capabilities snapshot permanently omits the chart's own ES).
       # Lockstep: bp-cilium 1.4.2 ships the hubble-ui declaration. Refs #3374.
-      version: 0.2.16
+      # 0.2.17 (#3374, 2026-06-14): emit the per-app OIDC ExternalSecret into
+      # the HR's targetNamespace (where the app Pod runs) instead of the HR's
+      # own namespace (flux-system). Fixes grafana's 2/3
+      # CreateContainerConfigError → 503: the chart-side grafana ES is omitted
+      # by the install-time .Capabilities ESO-CRD-race guard, so the bp-sso-
+      # bridge ES was the only one — and it landed in flux-system, invisible to
+      # the grafana Pod's envFromSecret. Default (in-place HR) render
+      # byte-identical. Refs #3374.
+      version: 0.2.17
       sourceRef:
         kind: HelmRepository
         name: bp-sso-bridge

--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.16
+  version: 0.2.17
   card:
     title: sso-bridge
     summary: |

--- a/platform/sso-bridge/chart/Chart.yaml
+++ b/platform/sso-bridge/chart/Chart.yaml
@@ -1,6 +1,22 @@
 apiVersion: v2
 name: bp-sso-bridge
-version: 0.2.16
+version: 0.2.17
+# 0.2.17 (#3374, 2026-06-14): emit the per-app OIDC ExternalSecret into the
+# HR's `targetNamespace` (the namespace where the app POD actually runs),
+# falling back to the HR's own namespace only when targetNamespace is unset.
+# Every Tier-1 SSO slot installs its HR in flux-system but targets the app's
+# own namespace (bp-grafana→grafana, bp-harbor→harbor, bp-openbao→openbao,
+# bp-gitea→gitea, bp-powerdns-admin→powerdns-admin); the pre-fix code wrote
+# the ES into the HR namespace (flux-system), so the projected
+# `<cid>-sso-oidc-credentials` Secret landed in flux-system — invisible to
+# the app Pod's `envFromSecret`. harbor/openbao/gitea were masked because
+# their chart ALSO ships an ES rendering into the targetNamespace; grafana's
+# chart ES is omitted by the install-time `.Capabilities` ESO-CRD-race guard,
+# so grafana had NO ES in its own namespace → Pod stuck 2/3
+# CreateContainerConfigError → grafana route 503 "no healthy upstream". This
+# makes bp-sso-bridge deliver the OIDC secret to the correct namespace for
+# every app regardless of whether the chart-side ES rendered. The default
+# (in-place HR with no targetNamespace) render is byte-identical. Refs #3374.
 # 0.2.16 (#3374, 2026-06-14): the AppRegistration watcher (upsert_per_org_
 # client) now applies an OPTIONAL chart-declared ExternalSecret when the
 # AppRegistration ConfigMap carries a `data["externalSecret.json"]` block

--- a/platform/sso-bridge/chart/templates/configmap-reconciler.yaml
+++ b/platform/sso-bridge/chart/templates/configmap-reconciler.yaml
@@ -490,7 +490,26 @@ data:
       local hr="$1" op_email="$2" fqdn="$3"
       local name ns
       name="$(printf '%s' "${hr}" | jq -r '.metadata.name')"
-      ns="$(printf '%s' "${hr}" | jq -r '.metadata.namespace')"
+      # #3374 (2026-06-14) — the ExternalSecret MUST land in the namespace
+      # where the app POD actually runs, which is the HR's `targetNamespace`
+      # when set (every Tier-1 SSO slot installs the HR in `flux-system` but
+      # targets the app's own ns: bp-grafana → grafana, bp-harbor → harbor,
+      # bp-openbao → openbao, bp-gitea → gitea, bp-powerdns-admin →
+      # powerdns-admin). The pre-fix code wrote the ES into the HR's OWN
+      # namespace (.metadata.namespace = flux-system), so the projected
+      # `<cid>-sso-oidc-credentials` Secret materialised in flux-system —
+      # invisible to the app Pod's `envFromSecret`. harbor/openbao/gitea were
+      # masked because their CHART also ships an ES that renders into the
+      # targetNamespace; grafana's chart ES is omitted at install time by the
+      # `.Capabilities` ESO-CRD-race guard (helm-controller never re-evaluates
+      # the install-time capability snapshot on drift), so the ONLY grafana ES
+      # was this one in flux-system → grafana Pod stuck 2/3
+      # CreateContainerConfigError → route 503 "no healthy upstream". Targeting
+      # the runtime namespace fixes grafana directly and makes the projection
+      # correct for every app regardless of whether its chart-side ES rendered.
+      # Falls back to .metadata.namespace when targetNamespace is unset
+      # (byte-identical to the old behaviour for an in-place HR).
+      ns="$(printf '%s' "${hr}" | jq -r '.spec.targetNamespace // .metadata.namespace')"
 
       # The clientId is the HR name (strip a leading "bp-" prefix if present
       # — bp-gitea is the HR, but the natural OIDC clientId is `gitea`).

--- a/platform/sso-bridge/chart/tests/3374-externalsecret-target-namespace.sh
+++ b/platform/sso-bridge/chart/tests/3374-externalsecret-target-namespace.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# bp-sso-bridge — #3374 ExternalSecret target-namespace regression guard.
+#
+# The per-app OIDC ExternalSecret that bp-sso-bridge emits MUST land in the
+# namespace where the app POD actually runs — the HelmRelease's
+# `targetNamespace` when set, NOT the HR's own namespace.
+#
+# Every Tier-1 SSO slot installs its HR in `flux-system` but targets the
+# app's own namespace (bp-grafana→grafana, bp-harbor→harbor,
+# bp-openbao→openbao, bp-gitea→gitea, bp-powerdns-admin→powerdns-admin).
+# Before #3374 the reconciler computed the ES namespace from
+# `.metadata.namespace` (= flux-system), so the projected
+# `<cid>-sso-oidc-credentials` Secret materialised in flux-system —
+# invisible to the app Pod's `envFromSecret`. grafana broke wholesale (its
+# chart-side ES is omitted by the install-time `.Capabilities` ESO-CRD-race
+# guard, so the bp-sso-bridge ES was the ONLY grafana ES) → grafana Pod 2/3
+# CreateContainerConfigError → route 503 "no healthy upstream".
+#
+# This is a shape-only test: it renders the reconcile.sh ConfigMap and
+# asserts the HR-namespace resolution falls through `.spec.targetNamespace`
+# FIRST. Actual end-to-end is verified on a live Sovereign (the #3374 walk).
+#
+# Asserts:
+#   1. The `ns` resolution in reconcile_one prefers `.spec.targetNamespace`
+#      with `.metadata.namespace` only as the fallback.
+#   2. emit_external_secret stamps `namespace: ${hrns}` (the resolved value),
+#      i.e. it does NOT hardcode flux-system or re-read .metadata.namespace.
+#   3. bash -n syntax-clean.
+#
+# Usage: bash tests/3374-externalsecret-target-namespace.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="$(cd "${1:-$(dirname "$0")/..}" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+helm="${HELM_BIN:-helm}"
+
+"$helm" template smoke "$CHART_DIR" --show-only templates/configmap-reconciler.yaml \
+  2>/dev/null > "$TMP/cm.yaml"
+
+# Extract the embedded reconcile.sh out of the ConfigMap literal block.
+python3 - "$TMP/cm.yaml" "$TMP/reconcile.sh" <<'PY'
+import sys, yaml
+doc = yaml.safe_load(open(sys.argv[1]))
+open(sys.argv[2], "w").write(doc["data"]["reconcile.sh"])
+PY
+
+SCRIPT="$TMP/reconcile.sh"
+
+# ── Case 1: ns resolution prefers targetNamespace ────────────────────────
+# The canonical line is:
+#   ns="$(printf '%s' "${hr}" | jq -r '.spec.targetNamespace // .metadata.namespace')"
+if ! grep -Eq '\.spec\.targetNamespace[[:space:]]*//[[:space:]]*\.metadata\.namespace' "$SCRIPT"; then
+  echo "FAIL: reconcile_one no longer resolves the ExternalSecret namespace via" >&2
+  echo "      '.spec.targetNamespace // .metadata.namespace'." >&2
+  echo "      The per-app OIDC ExternalSecret MUST target the app's runtime" >&2
+  echo "      namespace (HR targetNamespace), else it lands in flux-system and" >&2
+  echo "      the app Pod's envFromSecret can't see it (#3374 grafana 503)." >&2
+  exit 1
+fi
+
+# Negative guard: there must be NO bare `.metadata.namespace`-only resolution
+# feeding the ES namespace (that was the pre-#3374 bug).
+if grep -Eq "ns=\"\\\$\(printf '%s' \"\\\$\{hr\}\" \| jq -r '\.metadata\.namespace'\)\"" "$SCRIPT"; then
+  echo "FAIL: reconcile_one resolves ns from .metadata.namespace ALONE — that is" >&2
+  echo "      the pre-#3374 regression (ES lands in flux-system, not the app ns)." >&2
+  exit 1
+fi
+
+# ── Case 2: emit_external_secret stamps the resolved namespace ────────────
+# The emitter signature is `emit_external_secret <cid> <hrns>` and the body
+# prints `namespace: ${hrns}`. Guard that it still uses the passed value and
+# does not hardcode a namespace.
+if ! grep -q '"  namespace: ${hrns}"' "$SCRIPT"; then
+  echo "FAIL: emit_external_secret no longer stamps 'namespace: \${hrns}' for the" >&2
+  echo "      ExternalSecret — the resolved target namespace must flow through." >&2
+  exit 1
+fi
+if grep -Eq '"  namespace: flux-system"' "$SCRIPT"; then
+  echo "FAIL: emit_external_secret hardcodes 'namespace: flux-system' for the ES." >&2
+  exit 1
+fi
+
+# ── Case 3: bash -n ──────────────────────────────────────────────────────
+if ! bash -n "$SCRIPT"; then
+  echo "FAIL: rendered reconcile.sh is not bash -n clean" >&2
+  exit 1
+fi
+
+echo "PASS: bp-sso-bridge emits the per-app OIDC ExternalSecret into the HR" \
+     "targetNamespace (app runtime ns), fixing the #3374 grafana 503."


### PR DESCRIPTION
## Problem (live on hw136, deployment `3a2ee904b1d0366a`)

`grafana.hw136.omani.works/` serves **503 "no healthy upstream"** — no zero-click sign-in. The grafana Pod is **2/3 CreateContainerConfigError**:

```
grafana-78759dd5b6-4vrkd   2/3   CreateContainerConfigError
  envFrom: grafana-sso-oidc-credentials  Optional: false   # missing in `grafana` ns
```

The secret `grafana-sso-oidc-credentials` exists only in **`flux-system`**, never in **`grafana`**:

```
flux-system/grafana-sso-oidc-credentials   Opaque   7   (SecretSynced=True)
grafana ns:  <none>
```

## Root cause

`bp-sso-bridge`'s reconciler (`reconcile_one` → `emit_external_secret`) resolved the ExternalSecret namespace from the HelmRelease's **own** namespace (`.metadata.namespace`). But every Tier-1 SSO slot installs its HR in `flux-system` while targeting the app's namespace via `targetNamespace`:

| App | HR ns | targetNamespace |
|---|---|---|
| bp-grafana | flux-system | grafana |
| bp-harbor | flux-system | harbor |
| bp-openbao | flux-system | openbao |
| bp-gitea | flux-system | gitea |
| bp-powerdns-admin | flux-system | powerdns-admin |

So the projected `<cid>-sso-oidc-credentials` Secret landed in `flux-system` — invisible to the app Pod's `envFromSecret`.

harbor/openbao/gitea/powerdns are **masked** because their chart ALSO ships an ExternalSecret rendering into the targetNamespace (`harbor/harbor-sso-oidc-credentials` is present, `blueprint=bp-harbor`). grafana's chart-side ES is **omitted at install time** by the `.Capabilities.APIVersions.Has "external-secrets.io/v1beta1"` ESO-CRD-race guard — and helm-controller never re-evaluates the install-time capability snapshot on drift — so the bp-sso-bridge ES was grafana's **only** ES, sitting in the wrong namespace.

## Fix

Resolve the ExternalSecret namespace as `.spec.targetNamespace // .metadata.namespace` so the OIDC secret is projected into the namespace where the app Pod runs. Matches the chart's documented contract ("emits an ExternalSecret CR in the app's namespace") and hardens every app regardless of whether its chart-side ES rendered. Default (in-place HR, no targetNamespace) render is byte-identical.

- `platform/sso-bridge/chart/templates/configmap-reconciler.yaml` — `reconcile_one` resolves ns targetNamespace-first.
- `chart/tests/3374-externalsecret-target-namespace.sh` — shape-only regression guard (passes; existing tests still pass).
- Chart.yaml `0.2.16 → 0.2.17`; blueprint.yaml + slot 13b pin lockstep.

Chart-only; no catalyst-api.

## Verification

Live walk on hw136 after merge + Flux reconcile: grafana Pod 3/3 Running, `grafana-sso-oidc-credentials` present in `grafana` ns, `https://grafana.hw136.omani.works/` lands zero-click signed-in as admin. Evidence + UAT row flip to follow.

Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)