### PR TITLE
fix(bp-newapi): zero-click bare-URL SSO — auto-redirect on load + promote the custom-provider SSO owner to admin (Refs #3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -231,7 +231,7 @@ spec:
       # `rtz` namespace (where the synced `valkey-primary-x-valkey-x-rtz-
       # vcluster` Service lives) for the 6379 egress rule. This slot sets no
       # `networkPolicy.egress` override, so the chart default IS what renders.
-      version: 1.4.84
+      version: 1.4.85
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.84
+  version: 1.4.85
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -538,7 +538,36 @@ name: bp-newapi
 # walk, live hw135). Flips `networkPolicy.egress[bp-valkey].namespaceLabel`
 # `valkey` → `rtz` so the rendered egress namespaceSelector permits the
 # datapath to the rtz-synced valkey. Lockstep: 80-newapi.yaml pin → 1.4.83.
-version: 1.4.84
+# 1.4.85 (#3374, 2026-06-14): zero-click bare-URL SSO — auto-redirect on
+# load + custom-provider admin promote. TWO fixes, both root-caused live on
+# hw136 (dep 3a2ee904b1d0366a):
+#   (1) AUTO-REDIRECT. NewAPI's embedded React SPA (pinned mirror, not a fork)
+#       serves a marketing/login homepage at `/` and only fires OIDC on a
+#       "Sign in" CLICK → the zero-click contract was unmet (bare URL showed
+#       the marketing page). oauth2-proxy is the WRONG tool (NewAPI auths only
+#       via its own session cookie + ignores proxy headers — middleware/auth.go)
+#       and a static gateway 302 fails NewAPI's callback CSRF check (the `state`
+#       must be minted same-origin by GET /api/oauth/state first). FIX: the
+#       sandbox-bridge sidecar now serves a SAME-ORIGIN init page at the bare
+#       root (handler/sso_init.go) that runs NewAPI's own onCustomOAuthClicked
+#       sequence (state → /api/status provider → authorize redirect with
+#       kc_idp_hint=catalyst-pin); the HTTPRoute steers ONLY the bare root
+#       (Exact `/`) to the bridge, everything else to NewAPI. The full OIDC
+#       round-trip lands the owner signed-in (proven live on hw136).
+#   (2) ADMIN PROMOTE. NewAPI's CUSTOM (generic) OAuth provider persists the
+#       SSO subject in the `user_oauth_bindings` table, NOT the legacy
+#       `users.oidc_id` column (the comment at model/custom_oauth_provider.go:126
+#       is explicit; oidc_id is only written by the BUILT-IN oidc provider we do
+#       NOT use). The admin-sso-seed-job promote keyed on `oidc_id <> ''`, so
+#       the SSO owner (oidc_id='') was NEVER promoted → stayed role=1 → every
+#       admin route 302'd to /forbidden (live hw136: user `sovereign_2` had a
+#       user_oauth_bindings row but oidc_id=''). FIX: promote on EITHER a
+#       non-empty oidc_id OR a binding to the sovereign custom provider —
+#       verified live, /console/setting now reachable post-SSO.
+# Bridge image rebuilds via build-bp-newapi-sandbox-bridge.yaml (push to
+# internal/handler/**); the Exact `/` route serves the landing once the new
+# bridge image rolls.
+version: 1.4.85
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/admin-sso-seed-job.yaml
+++ b/platform/newapi/chart/templates/admin-sso-seed-job.yaml
@@ -180,9 +180,36 @@ data:
     promote_oidc_users() {
       # Any SSO-authenticated, active user that is not yet root → root (100).
       # access_policy on the provider gates login to the admin group, so only
-      # authorised owners ever own an oidc_id row.
-      n="$($PSQL -c "UPDATE users SET role=100 WHERE oidc_id IS NOT NULL AND oidc_id <> '' AND role < 100 AND status = 1 RETURNING id;" | wc -l | tr -d ' ')"
-      echo "[admin-seed] promoted ${n} OIDC user(s) to root"
+      # authorised owners ever own an SSO identity row.
+      #
+      # #3374 (2026-06-14) — CUSTOM-PROVIDER identity lives in
+      # `user_oauth_bindings`, NOT `users.oidc_id`. NewAPI's generic
+      # (custom) OAuth provider persists the SSO subject in the
+      # `user_oauth_bindings` table (controller/oauth.go findOrCreateOAuthUser
+      # → model.UpdateUserOAuthBinding; the comment at
+      # model/custom_oauth_provider.go:126 is explicit: "Custom provider: use
+      # user_oauth_bindings table"). The legacy `users.oidc_id` column is only
+      # written by the BUILT-IN `oidc` provider, which this Sovereign does NOT
+      # use (we seed a custom provider, slug `{{ $providerSlug }}`). So an
+      # SSO user created through the sovereign provider has oidc_id='' and the
+      # old `oidc_id <> ''` predicate NEVER matched it → the owner signed in
+      # via SSO but stayed role=1 (common) forever and every admin route
+      # 302'd to /forbidden (measured live on hw136: user `sovereign_2` had a
+      # `user_oauth_bindings` row but oidc_id='' → never promoted). Promote on
+      # EITHER signal: a non-empty legacy oidc_id (built-in provider, kept for
+      # back-compat) OR a binding to the sovereign custom provider.
+      n="$($PSQL -c "UPDATE users SET role=100
+            WHERE status = 1 AND role < 100
+              AND (
+                (oidc_id IS NOT NULL AND oidc_id <> '')
+                OR id IN (
+                  SELECT b.user_id FROM user_oauth_bindings b
+                  JOIN custom_oauth_providers p ON p.id = b.provider_id
+                  WHERE p.slug = '{{ $providerSlug }}'
+                )
+              )
+            RETURNING id;" | wc -l | tr -d ' ')"
+      echo "[admin-seed] promoted ${n} SSO user(s) to root (oidc_id OR {{ $providerSlug }} binding)"
     }
   seed.sh: |
     . /scripts/common.sh

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -340,6 +340,12 @@ spec:
                 secretKeyRef:
                   name: {{ $effTokenSigningKeySecret }}
                   key: ADMIN_SECRET
+            # #3374 — the OIDC provider slug the zero-click bare-URL landing
+            # page (served by this sidecar at `/`, routed by the HTTPRoute's
+            # Exact `/` rule) initiates. Matches the admin-sso-seed-job's
+            # custom_oauth_providers.slug. Default "sovereign".
+            - name: NEWAPI_SSO_INIT_SLUG
+              value: {{ (.Values.adminSeed | default dict).providerSlug | default "sovereign" | quote }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/platform/newapi/chart/templates/httproute.yaml
+++ b/platform/newapi/chart/templates/httproute.yaml
@@ -61,6 +61,36 @@ spec:
   hostnames:
     - {{ $host | quote }}
   rules:
+{{- /*
+#3374 (2026-06-14) — zero-click bare-URL SSO. NewAPI's embedded React SPA
+(consumed as a pinned mirror, not a fork) serves a marketing/login homepage at
+`/` and only fires the OIDC flow on a "Sign in with <provider>" CLICK, which
+breaks the zero-click contract. oauth2-proxy is the WRONG tool (NewAPI auths
+only via its own session cookie + ignores proxy headers — middleware/auth.go),
+and a static gateway 302 to Keycloak fails NewAPI's callback CSRF check (the
+`state` must first be minted by GET /api/oauth/state, which sets the session
+cookie). So the sandbox-bridge sidecar serves a SAME-ORIGIN init page at the
+bare root that runs NewAPI's own onCustomOAuthClicked sequence (state → status
+→ authorize redirect carrying kc_idp_hint=catalyst-pin). An `Exact /` match
+wins over the `PathPrefix /` rule below (Gateway API prefers the most specific
+match), so ONLY the bare root is intercepted; the SPA, /assets, /api and the
+/oauth/<slug> callback all keep flowing to NewAPI. The full OIDC round-trip
+lands the owner signed-in (verified live on hw136). Gated + overrideable.
+*/}}
+{{- /* default-true gate that respects an explicit `false` (the Helm `default
+   true <bool>` idiom wrongly coerces an explicit false back to true because
+   false is the bool zero-value, so test the key presence + value directly). */ -}}
+{{- $ssoInit := .Values.ssoInit | default dict -}}
+{{- $ssoInitOn := or (not (hasKey $ssoInit "enabled")) $ssoInit.enabled -}}
+{{- if and $ssoInitOn .Values.sandboxBridge.enabled }}
+    - matches:
+        - path:
+            type: Exact
+            value: "/"
+      backendRefs:
+        - name: {{ .Values.gateway.backendService | default (include "bp-newapi.fullname" .) }}
+          port: {{ .Values.sandboxBridge.port }}
+{{- end }}
     - matches:
         - path:
             type: PathPrefix

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -981,6 +981,24 @@ hpa:
 # response: invalid character '<'" failure mode observed on hw01
 # 2026-05-24). Built by .github/workflows/build-bp-newapi-sandbox-
 # bridge.yaml from platform/newapi/internal/handler.
+# ─── Zero-click bare-URL SSO landing (#3374) ─────────────────────────────
+# NewAPI's embedded React SPA (pinned mirror, not a fork) serves a
+# marketing/login homepage at `/` and only fires the OIDC flow on a click.
+# To honour the #3374 zero-click contract, the sandbox-bridge sidecar serves
+# a SAME-ORIGIN init page at the bare root that runs NewAPI's own
+# onCustomOAuthClicked sequence (GET /api/oauth/state → /api/status → redirect
+# to the Keycloak authorize URL with kc_idp_hint=catalyst-pin). The HTTPRoute
+# routes ONLY the bare root (Exact `/`) to the bridge; everything else flows
+# to NewAPI. oauth2-proxy is NOT used here — NewAPI authenticates only via its
+# own DB-backed session cookie and ignores proxy-auth headers, so a front-door
+# proxy would not log the user into NewAPI; and a static gateway 302 fails
+# NewAPI's callback CSRF check (the `state` must be minted same-origin first).
+#
+# Requires sandboxBridge.enabled (the bridge sidecar serves the page). The
+# provider slug is taken from adminSeed.providerSlug (default "sovereign").
+# Set enabled=false to serve NewAPI's own homepage at `/` instead.
+ssoInit:
+  enabled: true
 sandboxBridge:
   enabled: true
   image:

--- a/platform/newapi/internal/handler/cmd/sandbox-bridge/main.go
+++ b/platform/newapi/internal/handler/cmd/sandbox-bridge/main.go
@@ -15,6 +15,12 @@
 //	:8080  POST /admin/tokens/sandbox  → handler.Handler.SandboxToken
 //	:8080  GET  /metrics               → promhttp.Handler (scrape target)
 //	:8080  GET  /healthz               → 200 OK (kubelet probe)
+//	:8080  GET  /                      → handler.SSOInitHandler (#3374
+//	                                     zero-click bare-URL SSO landing page).
+//	                                     The bp-newapi HTTPRoute sends ONLY the
+//	                                     bare root (Exact `/`) here; every other
+//	                                     path goes to NewAPI, so this never
+//	                                     shadows the SPA / API / OIDC callback.
 //
 // Env contract
 //
@@ -23,8 +29,12 @@
 //	NEWAPI_ADMIN_SECRET       required — bearer the sandbox-controller
 //	                          presents. Same Secret, `ADMIN_SECRET` key.
 //	BRIDGE_LISTEN             optional — listen address, default ":8080".
+//	NEWAPI_SSO_INIT_SLUG      optional — custom_oauth_providers.slug the
+//	                          #3374 landing page initiates (default
+//	                          "sovereign"). The bp-newapi admin-sso-seed-job
+//	                          seeds the provider under this slug.
 //
-// Refs #2303, Wave 5.57.
+// Refs #2303, Wave 5.57; #3374 (2026-06-14) zero-click SSO landing.
 package main
 
 import (
@@ -61,6 +71,14 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
+	// #3374 zero-click bare-URL SSO landing page. Registered LAST and on the
+	// most-specific bare-root path; the bp-newapi HTTPRoute Exact `/` rule is
+	// what actually steers only the bare root to this sidecar (the SPA, API,
+	// and OIDC callback keep flowing to NewAPI). SSOInitHandler itself 404s
+	// any path other than "/" as a belt-and-braces guard.
+	mux.HandleFunc("/", handler.SSOInitHandler(handler.SSOInitConfig{
+		Slug: os.Getenv("NEWAPI_SSO_INIT_SLUG"),
+	}))
 
 	srv := &http.Server{
 		Addr:              addr,

--- a/platform/newapi/internal/handler/sso_init.go
+++ b/platform/newapi/internal/handler/sso_init.go
@@ -1,0 +1,160 @@
+// sso_init.go — #3374 zero-click bare-URL SSO landing page.
+//
+// NewAPI (Calcium-Ion/new-api) is consumed as a PINNED MIRROR, not a fork —
+// its embedded React SPA serves a marketing/login homepage at `/` and only
+// fires the OIDC flow when the operator CLICKS "Sign in with <provider>"
+// (web/src/helpers/api.js onCustomOAuthClicked → /api/oauth/state then
+// window.location.assign to the Keycloak authorize URL). That click breaks
+// the #3374 zero-click contract: a bare URL must land the owner signed-in
+// with NO click.
+//
+// We cannot patch the embedded SPA (mirror, not fork) and oauth2-proxy is the
+// WRONG tool here — NewAPI authenticates ONLY via its own DB-backed session
+// cookie set by its /api/oauth/<slug> callback and IGNORES proxy-auth headers
+// (middleware/auth.go reads session.Get("id") only), so a front-door proxy
+// would gate the user but NewAPI would still show its own login page. The
+// authorize redirect also CANNOT be a static gateway 302, because NewAPI's
+// callback hard-403s on a CSRF `state` that must first be minted by
+// GET /api/oauth/state (which sets the session cookie) — verified live on
+// hw136 (a bare GET to /api/oauth/sovereign returns 403 MsgOAuthStateInvalid).
+//
+// So the only mechanism that respects every constraint is a SAME-ORIGIN init
+// page that runs NewAPI's own init sequence: (1) fetch /api/oauth/state →
+// state + session cookie (same-origin, so the cookie lands on
+// newapi.<fqdn>), (2) read the custom OAuth provider from /api/status,
+// (3) redirect to the Keycloak authorize URL (which carries
+// kc_idp_hint=catalyst-pin → silent broker, no KC login form) with
+// redirect_uri=${origin}/oauth/<slug>&state=<state>. Keycloak returns to the
+// SPA callback /oauth/<slug>?code&state, the SPA posts /api/oauth/<slug>, the
+// session cookie is present → CSRF passes → NewAPI mints its session → the
+// owner lands in /console signed-in. The whole round-trip is proven live on
+// hw136. The bp-newapi admin-sso-seed-job's promote step (keyed on
+// user_oauth_bindings) elevates the owner to root.
+//
+// This handler is mounted at `/` on the sandbox-bridge sidecar (already an
+// openova-io-globbed pod sidecar, so it satisfies kyverno harbor-proxy-pull
+// without a new image). The bp-newapi HTTPRoute routes ONLY the bare root
+// (Exact `/`) to the bridge; every other path (the SPA, /assets, /api,
+// /oauth/<slug> callback, /console) continues to NewAPI, so this page never
+// shadows the app. Refs #3374.
+package handler
+
+import (
+	"html/template"
+	"net/http"
+	"strings"
+)
+
+// ssoInitPage is the zero-click landing page. It runs NewAPI's own
+// onCustomOAuthClicked sequence for the configured provider slug. Kept
+// dependency-free (vanilla fetch + a <noscript> fallback link to the SPA
+// login) so it works in any browser and degrades safely.
+var ssoInitTemplate = template.Must(template.New("sso-init").Parse(`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Signing you in…</title>
+<style>
+  html,body{height:100%;margin:0}
+  body{display:flex;align-items:center;justify-content:center;
+       font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+       color:#334155;background:#f8fafc}
+  .box{text-align:center}
+  .spinner{width:34px;height:34px;margin:0 auto 14px;border:3px solid #cbd5e1;
+           border-top-color:#2563eb;border-radius:50%;animation:spin .8s linear infinite}
+  @keyframes spin{to{transform:rotate(360deg)}}
+  a{color:#2563eb}
+</style>
+</head>
+<body>
+<div class="box">
+  <div class="spinner"></div>
+  <div>Signing you in…</div>
+  <noscript><p>JavaScript is required. <a href="/login">Continue to sign in</a>.</p></noscript>
+</div>
+<script>
+(async function () {
+  var SLUG = {{ .Slug }};
+  function fallback(){ window.location.replace("/login"); }
+  try {
+    // 1. Mint the CSRF state (also sets the same-origin session cookie that
+    //    NewAPI's /api/oauth/<slug> callback checks).
+    var sr = await fetch("/api/oauth/state", { credentials: "include" });
+    if (!sr.ok) return fallback();
+    var sj = await sr.json();
+    if (!sj || !sj.success || !sj.data) return fallback();
+    var state = sj.data;
+    // 2. Read the custom OAuth provider (authorize endpoint + client_id +
+    //    scopes) that the bp-newapi admin-sso-seed-job seeded.
+    var pr = await fetch("/api/status", { credentials: "include" });
+    if (!pr.ok) return fallback();
+    var pj = await pr.json();
+    var provs = (pj && pj.data && pj.data.custom_oauth_providers) || [];
+    var p = null;
+    for (var i = 0; i < provs.length; i++) {
+      if (provs[i].slug === SLUG) { p = provs[i]; break; }
+    }
+    if (!p && provs.length === 1) p = provs[0];
+    if (!p || !p.authorization_endpoint || !p.client_id) return fallback();
+    // 3. Build the authorize URL EXACTLY like the SPA does
+    //    (web/src/helpers/api.js onCustomOAuthClicked) and redirect.
+    var redirectUri = window.location.origin + "/oauth/" + p.slug;
+    var base = p.authorization_endpoint; // carries ?kc_idp_hint=catalyst-pin
+    var sep = base.indexOf("?") === -1 ? "?" : "&";
+    var scope = encodeURIComponent(p.scopes || "openid profile email");
+    var url = base + sep +
+      "client_id=" + encodeURIComponent(p.client_id) +
+      "&redirect_uri=" + encodeURIComponent(redirectUri) +
+      "&response_type=code" +
+      "&scope=" + scope +
+      "&state=" + encodeURIComponent(state);
+    window.location.replace(url);
+  } catch (e) {
+    fallback();
+  }
+})();
+</script>
+</body>
+</html>`))
+
+// SSOInitConfig carries the one operationally-meaningful knob (the OIDC
+// provider slug) so nothing is hardcoded (Inviolable Principle #4).
+type SSOInitConfig struct {
+	// Slug is the custom_oauth_providers.slug the bp-newapi admin-sso-seed-job
+	// seeds (default "sovereign"). The init page selects this provider from
+	// /api/status; if absent and exactly one provider exists, it uses that.
+	Slug string
+}
+
+// SSOInitHandler returns an http.HandlerFunc that serves the zero-click
+// landing page for EXACTLY the bare root path. It 404s any other path so a
+// misconfigured route (sending more than `/` here) fails loud instead of
+// shadowing the SPA. Method is GET/HEAD only.
+func SSOInitHandler(cfg SSOInitConfig) http.HandlerFunc {
+	slug := strings.TrimSpace(cfg.Slug)
+	if slug == "" {
+		slug = "sovereign"
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-store")
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		// template.JS-safe: Slug is rendered via html/template into a JS
+		// string context. Pass it as a quoted JS literal.
+		_ = ssoInitTemplate.Execute(w, struct{ Slug template.JS }{
+			Slug: template.JS("\"" + template.JSEscapeString(slug) + "\""),
+		})
+	}
+}

--- a/platform/newapi/internal/handler/sso_init_test.go
+++ b/platform/newapi/internal/handler/sso_init_test.go
@@ -1,0 +1,93 @@
+// sso_init_test.go — unit tests for the #3374 zero-click bare-URL SSO
+// landing page handler.
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSSOInitHandler_ServesLandingAtRoot(t *testing.T) {
+	h := SSOInitHandler(SSOInitConfig{Slug: "sovereign"})
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET / status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("Content-Type = %q, want text/html", ct)
+	}
+	body := rec.Body.String()
+	// The page must run NewAPI's own init sequence: mint state, read the
+	// provider, redirect to the authorize URL.
+	for _, want := range []string{
+		"/api/oauth/state",
+		"/api/status",
+		"custom_oauth_providers",
+		"/oauth/\" + p.slug", // redirect_uri construction
+		"window.location.replace(url)",
+		`"sovereign"`, // the seeded provider slug, embedded as a JS literal
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("landing page missing %q", want)
+		}
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store", got)
+	}
+}
+
+func TestSSOInitHandler_DefaultsSlug(t *testing.T) {
+	// Empty slug must default to "sovereign".
+	h := SSOInitHandler(SSOInitConfig{Slug: ""})
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if !strings.Contains(rec.Body.String(), `"sovereign"`) {
+		t.Errorf("empty slug did not default to \"sovereign\"")
+	}
+}
+
+func TestSSOInitHandler_404sNonRootPath(t *testing.T) {
+	// Belt-and-braces: even though the HTTPRoute only sends the bare root
+	// here, the handler must NOT serve the landing page for any other path
+	// (it would shadow the SPA / API if the route were ever misconfigured).
+	h := SSOInitHandler(SSOInitConfig{Slug: "sovereign"})
+	for _, p := range []string{"/console", "/api/status", "/oauth/sovereign", "/assets/x.js"} {
+		rec := httptest.NewRecorder()
+		h(rec, httptest.NewRequest(http.MethodGet, p, nil))
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("GET %s status = %d, want 404", p, rec.Code)
+		}
+	}
+}
+
+func TestSSOInitHandler_HeadOK_PostRejected(t *testing.T) {
+	h := SSOInitHandler(SSOInitConfig{Slug: "sovereign"})
+
+	recHead := httptest.NewRecorder()
+	h(recHead, httptest.NewRequest(http.MethodHead, "/", nil))
+	if recHead.Code != http.StatusOK {
+		t.Errorf("HEAD / status = %d, want 200", recHead.Code)
+	}
+
+	recPost := httptest.NewRecorder()
+	h(recPost, httptest.NewRequest(http.MethodPost, "/", nil))
+	if recPost.Code != http.StatusMethodNotAllowed {
+		t.Errorf("POST / status = %d, want 405", recPost.Code)
+	}
+}
+
+func TestSSOInitHandler_SlugIsJSEscaped(t *testing.T) {
+	// A slug with a quote must not break out of the JS string literal.
+	h := SSOInitHandler(SSOInitConfig{Slug: `ev"il`})
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	body := rec.Body.String()
+	if strings.Contains(body, `var SLUG = "ev"il"`) {
+		t.Errorf("slug was not JS-escaped — XSS/break-out risk: %q", body)
+	}
+}


### PR DESCRIPTION
## What

Two #3374 zero-click SSO defects in **bp-newapi**, both root-caused **live on hw136** (deployment `3a2ee904b1d0366a`, FQDN `hw136.omani.works`).

> Note: the companion **bp-powerdns-admin** defect (DEFECT 1: bare-URL `/oidc/login` → app-side HTTP 500 because the Pod boots before the OIDC ExternalSecret and `envFrom` is start-time-only) was root-caused + fixed independently and **already landed on `main`** (the `secret.reloader.stakater.com/reload` annotation, bp-powerdns-admin 0.1.15). Verified live on hw136: the bare URL `https://pdns-admin.hw136.omani.works/` lands on `/dashboard/` signed-in as `emrah.baysal@openova.io` with the full Administration sidebar. This PR carries only the newapi fixes.

### DEFECT 2 — newapi (rows r14/r15)

**(1) AUTO-REDIRECT.** NewAPI's embedded React SPA (a **pinned mirror, not a fork**) serves a marketing/login homepage at `/` and only fires the OIDC flow on a "Sign in" CLICK → the bare URL never auto-signed-in.
- **oauth2-proxy is the WRONG tool**: NewAPI authenticates ONLY via its own DB-backed session cookie and ignores proxy-auth headers (`middleware/auth.go` reads `session.Get("id")` only), so a front-door proxy would gate the user but NewAPI would still show its login page. The platform deliberately did NOT add newapi to `bp-oidc-gate`.
- **A static gateway 302 to Keycloak also fails**: NewAPI's callback hard-403s on a CSRF `state` that must first be minted by `GET /api/oauth/state` (which sets the session cookie).
- **FIX**: the **sandbox-bridge sidecar** (already an `ghcr.io/openova-io/*`-globbed pod sidecar, so kyverno harbor-proxy-pull passes with no new image) serves a **same-origin init page at the bare root** (`handler/sso_init.go`) that runs NewAPI's own `onCustomOAuthClicked` sequence — mint state, read the provider from `/api/status`, redirect to the Keycloak authorize URL carrying `kc_idp_hint=catalyst-pin`. The HTTPRoute steers **only** the bare root (`Exact /`) to the bridge; the SPA, `/assets`, `/api` and the `/oauth/<slug>` callback keep flowing to NewAPI. The full OIDC round-trip lands the owner signed-in (proven live on hw136 by running the init sequence in-browser → lands on `/console`).

**(2) ADMIN PROMOTE.** NewAPI's **custom** (generic) OAuth provider persists the SSO subject in the `user_oauth_bindings` table, NOT the legacy `users.oidc_id` column (upstream `model/custom_oauth_provider.go:126` is explicit; `oidc_id` is written only by the BUILT-IN `oidc` provider, which this Sovereign does not use). The `admin-sso-seed-job` promote keyed on `oidc_id <> ''`, so the SSO owner (`oidc_id=''`) was **never promoted** → stayed `role=1` → every admin route 302'd to `/forbidden`.
- Live on hw136: user `sovereign_2` had a `user_oauth_bindings` row but `oidc_id=''` → never promoted.
- **FIX**: promote on EITHER a non-empty `oidc_id` OR a binding to the sovereign custom provider. **Verified live**: after the corrected promote, `/console/setting` renders signed-in as admin (was `/forbidden`).

## Verified live on hw136

| Row | Surface | Result |
|---|---|---|
| r15 | newapi admin Settings (`/console/setting`) reachable post-SSO | ✅ renders (was `/forbidden`) — promote fix |
| r14 | bare URL → signed-in console via SSO | OIDC round-trip lands signed-in (`sovereign_2`); the bare-URL auto-fire serves once the rebuilt sandbox-bridge image rolls |

## Notes

- The bridge image rebuilds via `.github/workflows/build-bp-newapi-sandbox-bridge.yaml` on this push to `internal/handler/**`; the `Exact /` landing serves once the new bridge image rolls (a follow-up auto-PR bumps `sandboxBridge.image.tag`).
- Go handler unit-tested (`handler/sso_init_test.go`, 5 cases: serves at `/`, 404s other paths, HEAD/POST methods, default slug, JS-escape).
- chart 1.4.84→1.4.85, blueprint + slot 80 pin lockstep. Gated + overrideable (`ssoInit.enabled`, default true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)