### PR TITLE
fix(cutover): default egressTest.enforceCIDRBlock true — real deny-egress hold validated on hw136 (Refs #3379)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -439,7 +439,10 @@ spec:
       # 0.1.54 (#3052): auto-trigger Job handles catalyst-api's new HTTP
       # 425 handover-completion gate — the cutover no longer half-pivots
       # the registry at bootstrap on a fresh, un-handed-over prov.
-      version: 0.1.56
+      # 0.1.57 (#3379): chart default egressTest.enforceCIDRBlock now
+      # true (validated on hw136 walk). The explicit overlay below stays
+      # for clarity but is redundant-but-harmless — both agree.
+      version: 0.1.57
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.56
+  version: 0.1.57
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,13 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.57 (#3379, 2026-06-14): default `egressTest.enforceCIDRBlock`
+# flipped false → true after the real 10-min deny-egress hold was
+# validated live on the hw136 cutover walk (Pillar-5 proof). All four
+# blockedDomains resolve to PUBLIC IPs that never overlap a Sovereign's
+# pod/service CIDRs; Step-08 skips private/loopback IPs and is fail-safe.
+# The egress-block proof is now the default for every Sovereign, not just
+# those whose 06a overlay opts in. See values.yaml egressTest comment.
+#
 # 0.1.50 (#2951 / #2940 ATTACK#9, 2026-06-03): Step 10 (vcluster-registry-
 # pivot) now ALSO pivots the bp-sso-bridge HelmRelease's
 # `image.repository` HOST from `harbor.openova.io/proxy-dockerhub/alpine/
@@ -414,7 +422,7 @@ name: bp-self-sovereign-cutover
 # until the tofu-phase0-archive is sealed at handover; this Job treats
 # 425 as the EXPECTED benign pre-handover path (clear log, exit 0). The
 # cutover still auto-fires post-handover (founder rule #933 preserved).
-version: 0.1.56
+version: 0.1.57
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -382,7 +382,21 @@ egressTest:
   # blockedDomains → public IPs and applies a scoped CiliumNetworkPolicy
   # egressDeny toCIDR for the survival window, catching hidden runtime
   # tethers the declarative assertion can't see.
-  enforceCIDRBlock: false
+  #
+  # 0.1.57 (#3379, 2026-06-14): default flipped false → true. The real
+  # 10-min deny-egress hold was validated live on the hw136 cutover walk
+  # (Pillar-5 proof): all four blockedDomains (github.com, ghcr.io,
+  # harbor.openova.io, xpkg.upbound.io) resolve to PUBLIC IPs that never
+  # overlap a Sovereign's pod (10.42/43.x) or service (10.96/97.x) CIDR,
+  # and the Step-08 Job skips private/loopback IPs + is fail-safe (any
+  # resolve/apply error falls back to assertion-only, the egressDeny
+  # policy is torn down on every pass/fail/abort path). So the egress-
+  # block proof — `cutoverComplete=true` earned ONLY with a real deny-
+  # egress hold, per ADR-0002 — is now the default for every Sovereign,
+  # not just those whose 06a overlay opts in. The 06a slot overlay's
+  # explicit `egressTest.enforceCIDRBlock: true` is now redundant-but-
+  # harmless (overlay still wins; both agree).
+  enforceCIDRBlock: true
   blockedDomains:
     - "github.com"
     - "ghcr.io"


### PR DESCRIPTION
## What

Flip the chart default `egressTest.enforceCIDRBlock` from `false` → `true` in `platform/self-sovereign-cutover`, so the **real 10-minute deny-egress hold** (Step-08) is the default for every Sovereign cutover — not just those whose `06a` overlay opts in.

Lockstep version bump 0.1.56 → 0.1.57 across:
- `platform/self-sovereign-cutover/chart/values.yaml` (the flip + changelog)
- `platform/self-sovereign-cutover/chart/Chart.yaml`
- `platform/self-sovereign-cutover/blueprint.yaml`
- `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` (slot pin)

## Why safe (verified live on hw136, deployment 3a2ee904b1d0366a)

The opt-in default existed because a mis-resolved upstream CIDR overlapping a live in-cluster dependency would FAIL Step-08 → cutover engine aborts → half-pivoted unrecoverable prov. That risk is now ruled out by live evidence:

- hw136 pod CIDR: `10.42.0.0/24` … `10.42.3.0/24`; service CIDR `10.96.0.1`.
- All four `blockedDomains` resolve to PUBLIC IPs with **zero** overlap:
  - `github.com → 20.233.83.145`
  - `ghcr.io → 20.233.83.147`
  - `harbor.openova.io → 45.151.123.50`
  - `xpkg.upbound.io → 34.111.161.63`
- Step-08 Job skips private/loopback IPs and is fail-safe: any resolve/apply error falls back to assertion-only, and the `egressDeny` CiliumClusterwideNetworkPolicy is torn down on every pass/fail/abort path (inline delete + TERM/EXIT trap).

This makes the egress-block proof — `cutoverComplete=true` earned ONLY with a real deny-egress hold, per ADR-0002 / Principle #11 — the default everywhere. The `06a` overlay's explicit `egressTest.enforceCIDRBlock: true` (added in #3401) is now redundant-but-harmless; the overlay still wins and both agree.

`helm template` smoke-renders clean (exit 0); `ENFORCE_CIDR_BLOCK` renders `value: "true"` in the Step-08 PodSpec ConfigMap.

Refs #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)