### PR TITLE
fix(grafana): sidecar resource requests so Pod rolls under kyverno Enforce — unblocks #3374 zero-click

### DIFF
--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -110,7 +110,12 @@ spec:
       # 1.0.11 (#2745, 2026-06-12): loki/mimir/tempo re-homed into the
       # mgmt vCluster — datasource URLs re-pointed at the syncer-mangled
       # host-side Service names (<svc>-x-<ns>-x-mgmt-vcluster.mgmt.svc).
-      version: 1.0.12
+      # 1.0.13 (#3374, 2026-06-14): sidecar.resources requests/limits so the
+      # dashboard + datasource sidecars (containers[0]/[1]) pass the kyverno
+      # resource-requests Enforce policy — without them every grafana Pod
+      # roll is denied, so grafana can never restart to pick up the corrected
+      # GF_-shaped OIDC envFromSecret (the zero-click fix). Refs #3374.
+      version: 1.0.13
       sourceRef:
         kind: HelmRepository
         name: bp-grafana

--- a/platform/grafana/blueprint.yaml
+++ b/platform/grafana/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.0.12
+  version: 1.0.13
   card:
     title: Grafana
     family: insights

--- a/platform/grafana/chart/Chart.yaml
+++ b/platform/grafana/chart/Chart.yaml
@@ -56,8 +56,19 @@ type: application
 # to plain in-vCluster names when grafana itself promotes (audit
 # Phase-2). Lockstep with bootstrap-kit slots 22/23/24 + bp-catalyst-
 # platform 1.4.591 (CATALYST_MIMIR_URL + baseline CNP).
-version: 1.0.12
+version: 1.0.13
 appVersion: "12.3.1"
+# 1.0.13 (#3374, 2026-06-14): declare resources.requests/limits on the
+# dashboard + datasource sidecars (grafana.sidecar.resources). Those
+# sidecars are containers[0]/[1] of the grafana Pod and shipped with NO
+# requests, so on a kyverno-Enforce Sovereign the `resource-requests`
+# ClusterPolicy denies EVERY grafana Pod create (`rule requests-pod failed
+# at path /spec/containers/0/resources/requests/`). The original Pod
+# survives because it was admitted before enforcement, but any reschedule —
+# e.g. to pick up the corrected GF_-shaped OIDC envFromSecret — can never
+# create a new Pod, so grafana stays stuck on the stale spec and never lands
+# zero-click. Tiny footprint (10m/32Mi requests; the sidecars only watch
+# ConfigMaps + POST reload hooks). Refs #3374.
 # 1.0.4 (G91.grafana #2658, 2026-05-31): opt in to the bp-sso-bridge
 # (G91.1 #2652) SSO framework. Top-level `sso:` block (defaults
 # enabled=true). Adds templates/sso-oauth-source-externalsecret.yaml

--- a/platform/grafana/chart/values.yaml
+++ b/platform/grafana/chart/values.yaml
@@ -140,6 +140,27 @@ grafana:
     image:
       registry: harbor.openova.io
       repository: proxy-quay/kiwigrid/k8s-sidecar
+    # #3374 (2026-06-14) — the dashboard + datasource sidecars are
+    # `containers[0]`/`[1]` of the grafana Pod (the main grafana container
+    # is last). On a kyverno-Enforce Sovereign the `resource-requests`
+    # ClusterPolicy denies any Pod whose containers omit
+    # resources.requests.cpu/memory — and the upstream chart ships these
+    # sidecars with NO requests, so EVERY grafana Pod roll is blocked
+    # (`Pod ... blocked ... rule requests-pod failed at path
+    # /spec/containers/0/resources/requests/`). The original Pod survives
+    # only because it was admitted before kyverno started enforcing; once
+    # it must reschedule (e.g. to pick up a changed envFromSecret), the new
+    # Pod can never be created and grafana is stuck on the stale spec.
+    # Declaring sidecar.resources makes both sidecars kyverno-compliant so
+    # grafana can actually roll. Tiny footprint — the sidecars just watch
+    # ConfigMaps and POST reload hooks.
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 50m
+        memory: 64Mi
     datasources:
       enabled: true
       label: grafana_datasource


### PR DESCRIPTION
## Problem (blocks #3374 / #3517 verification on hw136)

After #3517 produced the correct GF_-shaped OIDC secret for grafana, the grafana Pod could not restart to consume it. The rollout is stuck — the new ReplicaSet's Pod is **denied by kyverno**:

```
Pod/grafana/grafana-749c4bb88f-knqbd was blocked due to resource-requests:
  rule requests-pod failed at path /spec/containers/0/resources/requests/
```

`containers[0]` is the **`grafana-sc-dashboard`** sidecar; `[1]` is `grafana-sc-datasources`. Both ship with **no resource requests** in the upstream chart. The originally-admitted grafana Pod (147m old) survives because it predates kyverno enforcement — but any reschedule (here, to pick up the corrected `envFromSecret`) can never create a new Pod. grafana stays pinned on the stale spec → never lands zero-click.

## Fix (chart-only)

Declare `grafana.sidecar.resources` (10m/32Mi requests, 50m/64Mi limits — the sidecars only watch ConfigMaps + POST reload hooks). Both sidecar containers now render requests; the main `grafana` container keeps its existing 100m/256Mi. Chart `1.0.12 → 1.0.13`; blueprint + slot 25 pin lockstep.

Verified rendered:
```
grafana-sc-dashboard   -> requests= {cpu: 10m, memory: 32Mi}
grafana-sc-datasources -> requests= {cpu: 10m, memory: 32Mi}
grafana                -> requests= {cpu: 100m, memory: 256Mi}
```

This is the third coordinated piece of the #3374 grafana zero-click fix (after #3515 targetNamespace + #3517 chart-ES/skipExternalSecret). With it, grafana can roll and consume the GF_-shaped secret. Live walk + UAT flip to follow.

Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)