### PR TITLE
fix(handover): tofu-archive receiver MUST be outside RequireSession — cutover never fired on a real Sovereign (Refs #3379)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -986,6 +986,30 @@ func main() {
 	// what was hanging cutover on otech113 2026-05-05 (issue #935).
 	r.Post("/api/v1/internal/cutover/trigger", h.HandleCutoverInternalTrigger)
 
+	// Sovereign-side handover ARCHIVE RECEIVER (issue #317 / #933,
+	// fix #3379). Catalyst-Zero's postTofuArchive POSTs the sealed
+	// OpenTofu state here (https://api.<sov-fqdn>/api/v1/handover/
+	// tofu-archive) so the new Sovereign writes it to OpenBao
+	// `secret/catalyst/tofu-phase0-archive` and auto-fires the cutover
+	// engine (ReceiveTofuArchive). The mother→child POST carries ONLY
+	// `Content-Type: application/json` — there is NO catalyst_session
+	// cookie (it is a server-to-server call, no browser). Therefore this
+	// route MUST live OUTSIDE RequireSession, exactly like the kubeconfig
+	// PUT (#183/#634), the cloud-init-log PUT (#3132), AuthHandover
+	// (#606), the cutover trigger (#935) and the openbao SSO shim (#3374)
+	// above. It shipped INSIDE RequireSession (#317) and stayed unnoticed
+	// because Catalyst-Zero's RequireSession is a nil-cfg passthrough — but
+	// on a REAL Sovereign (CATALYST_KC_ADDR set) the active middleware
+	// rejected every handover archive POST with 401 {"error":
+	// "unauthenticated"} before ReceiveTofuArchive ever ran, so the
+	// tofu-phase0-archive marker never sealed → the cutover never fired →
+	// `cutoverComplete` stayed false forever (caught live on the hw136
+	// cutover walk, #3379). The handler's own auth is content-based
+	// (deploymentId + sovereignFqdn validation) + the OpenBao-configured
+	// gate (503 on Catalyst-Zero), the same defence pattern as
+	// PutKubeconfig's SHA-compare — no session cookie required.
+	r.Post("/api/v1/handover/tofu-archive", h.ReceiveTofuArchive)
+
 	// #3374 — server-side zero-click silent-SSO shim for OpenBao.
 	// OpenBao's UI is a client-side SPA, so a static ssoInitPath can only
 	// pre-select the OIDC method (still one click). This shim asks Vault
@@ -1231,16 +1255,19 @@ func main() {
 		// path for live cloud cleanup. Refuses on in-flight deployments
 		// (409), wiped deployments (410), or adopted Sovereigns (422).
 		rg.Delete("/api/v1/deployments/{id}/release-subdomain", h.ReleaseSubdomain)
-		// Handover finalisation (issue #317). Catalyst-Zero side: stops the
-		// helmwatch informer, ships the OpenTofu state to the new Sovereign's
-		// catalyst-api, and purges every local trace once the new side
-		// confirms the archive is sealed in its OpenBao. Sovereign side:
-		// receives the archive on /handover/tofu-archive and writes it to
-		// `secret/catalyst/tofu-phase0-archive`. The two endpoints live on
-		// the same binary; Catalyst-Zero leaves CATALYST_OPENBAO_ADDR unset,
-		// so a misrouted archive POST hits 503 instead of 200.
+		// Handover finalisation (issue #317). Catalyst-Zero side ONLY:
+		// stops the helmwatch informer, ships the OpenTofu state to the new
+		// Sovereign's catalyst-api, and purges every local trace once the
+		// new side confirms the archive is sealed in its OpenBao. This route
+		// stays INSIDE RequireSession because it is the operator-driven
+		// wizard finalise — on Catalyst-Zero `cfg` is nil so RequireSession
+		// is a transparent passthrough, and on a Sovereign this route is
+		// never legitimately called (the Sovereign is the RECEIVER, not the
+		// sender). The receiver half (`/handover/tofu-archive`) is registered
+		// OUTSIDE RequireSession above (next to the cutover trigger), because
+		// the inbound POST from Catalyst-Zero's postTofuArchive carries NO
+		// session cookie — see the #3379 comment there.
 		rg.Post("/api/v1/handover/finalise/{id}", h.FinaliseHandover)
-		rg.Post("/api/v1/handover/tofu-archive", h.ReceiveTofuArchive)
 		// Jobs/Executions REST surface — the canvas + per-job detail
 		// pages read this in parallel to the existing SSE events feed.
 		// All endpoints are read-only; every mutation flows through the

--- a/products/catalyst/bootstrap/api/internal/handler/handover_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handover_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
@@ -325,6 +326,75 @@ func TestReceiveTofuArchive_NoOpenBaoReturns503(t *testing.T) {
 	h.ReceiveTofuArchive(rec, req)
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503 when openbao client absent; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestReceiveTofuArchive_IsOutsideRequireSession (#3379) — the handover
+// archive receiver MUST be reachable WITHOUT a catalyst_session cookie.
+//
+// Catalyst-Zero's postTofuArchive POSTs the sealed OpenTofu state to
+// https://api.<sov-fqdn>/api/v1/handover/tofu-archive with ONLY a
+// Content-Type header — it is a server-to-server call, no browser, no
+// cookie. On Catalyst-Zero this slipped through because RequireSession is
+// a nil-cfg passthrough; but on a REAL Sovereign (CATALYST_KC_ADDR set)
+// the active middleware rejected every archive POST with 401
+// {"error":"unauthenticated"} BEFORE ReceiveTofuArchive ever ran — so the
+// tofu-phase0-archive marker never sealed → the cutover engine never fired
+// → cutoverComplete stayed false forever (caught live on the hw136 cutover
+// walk). This test wires an ACTIVE RequireSession and asserts a cookieless
+// archive POST reaches the handler (503 for no-OpenBao, the handler's own
+// content-based gate) rather than being 401'd by the middleware.
+func TestReceiveTofuArchive_IsOutsideRequireSession(t *testing.T) {
+	h := newTestHandler(t) // no OpenBao client → handler's own gate returns 503
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// A non-nil Config (no cookie secret / no JWKS) makes RequireSession
+	// ENFORCE: ReadSessionToken returns "" for a cookieless request, so the
+	// middleware 401s before any wrapped handler. A nil Config would be a
+	// transparent passthrough and would NOT catch the placement bug.
+	cfg := &auth.Config{Realm: "sovereign", ClientID: "catalyst-zero-ui"}
+
+	r := chi.NewMux()
+	// PUBLIC group — mirrors main.go: the archive receiver lives here,
+	// OUTSIDE RequireSession (next to the kubeconfig PUT + cutover trigger).
+	r.Post("/api/v1/handover/tofu-archive", h.ReceiveTofuArchive)
+	// SESSION-GATED group — mirrors main.go's r.Group(RequireSession). The
+	// finalise route + whoami live here.
+	r.Group(func(rg chi.Router) {
+		rg.Use(auth.RequireSession(cfg, log))
+		rg.Get("/api/v1/whoami", h.HandleWhoami)
+	})
+
+	body, _ := json.Marshal(tofuArchiveRequest{
+		DeploymentID:  "dep-x",
+		SovereignFQDN: "x.example",
+		Files:         map[string]string{"terraform.tfstate": "e30="},
+	})
+
+	// 1) The archive POST must reach the handler WITHOUT a cookie → 503
+	//    (handler's no-OpenBao gate), NEVER 401 (middleware block).
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/v1/handover/tofu-archive", bytes.NewReader(body)))
+	if rec.Code == http.StatusUnauthorized {
+		t.Fatalf("REGRESSION (#3379): cookieless tofu-archive POST got 401 %s — "+
+			"the handover archive receiver is behind RequireSession again; it MUST "+
+			"be registered in the PUBLIC route section of main.go (the mother→child "+
+			"call carries no session cookie, so a 401 here means the cutover can "+
+			"NEVER fire)", rec.Body.String())
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected the receiver to reach the handler (503 for no-OpenBao) "+
+			"on a cookieless POST, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	// 2) Harness sanity: the RequireSession middleware IS enforcing here, so
+	//    the 503 above is a real "handler ran cookieless", not a passthrough.
+	rec2 := httptest.NewRecorder()
+	r.ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, "/api/v1/whoami", nil))
+	if rec2.Code != http.StatusUnauthorized {
+		t.Fatalf("harness check: a RequireSession route should 401 without a "+
+			"cookie, got %d — the middleware is not enforcing, so this test "+
+			"cannot prove the receiver is genuinely public", rec2.Code)
 	}
 }
 


### PR DESCRIPTION
## The bug (caught live on the hw136 #3379 cutover walk)

`ReceiveTofuArchive` (`POST /api/v1/handover/tofu-archive`) was registered **inside** the `RequireSession` route group (since issue #317, `main.go`). On **Catalyst-Zero** that slipped through because `RequireSession(nil, …)` is a transparent passthrough — but on a **real Sovereign** (`CATALYST_KC_ADDR` set, middleware active) it rejected the mother→child archive POST with **`401 {"error":"unauthenticated"}` before the handler ever ran**.

`postTofuArchive` (Catalyst-Zero side) sends the archive with **only** `Content-Type: application/json` — it is a server-to-server call, no browser, no `catalyst_session` cookie. So on hw136:

```
POST /sovereign/api/v1/handover/finalise/3a2ee904b1d0366a → 200 OK, but:
  "steps": { "tofuArchiveSubmitted": false, ... }
  "errors": ["submit tofu archive: status 401: {\"error\":\"unauthenticated\"}"]
```

→ `secret/catalyst/tofu-phase0-archive` never sealed → the cutover engine never auto-fired → `cutoverComplete` stayed `false` forever. Pillar-5 (#3379) is unreachable until this is fixed.

**No half-pivot**: the archive simply never sealed. hw136 stayed fully intact — `ghcr-pull` still keyed `ghcr.io`, GitRepository `openova` still `github.com`, no cutover Jobs stamped, console 200.

## The fix

Move `ReceiveTofuArchive` to the **public** route section of `main.go`, next to the other cookieless inbound receivers. This is the identical bug class already fixed for:
- kubeconfig PUT (#183/#634)
- cloud-init-log PUT (#3132)
- AuthHandover (#606)
- cutover internal trigger (#935)
- openbao SSO shim (#3374)

Every cookieless inbound receiver must live outside `RequireSession`. `ReceiveTofuArchive` was the one that got missed. Its own auth is content-based (`deploymentId` + `sovereignFqdn` validation) plus the OpenBao-configured gate (503 on Catalyst-Zero) — the same defence pattern as `PutKubeconfig`'s SHA-compare, no session cookie required.

`FinaliseHandover` (the operator-driven wizard finalise) correctly **stays** inside `RequireSession` — on Catalyst-Zero it's a passthrough; on a Sovereign it's never legitimately called (the Sovereign is the receiver, not the sender).

## Test

Adds `TestReceiveTofuArchive_IsOutsideRequireSession`: wires an **active** `RequireSession` and asserts a cookieless archive POST reaches the handler (`503` for no-OpenBao) rather than being `401`'d by the middleware, with a harness check that `/whoami` still `401`s without a cookie. Same regression-guard shape as the #3374 `openbao-sso-init` test. Full handler suite green.

Refs #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)