### PR TITLE
fix(grafana): raise sidecar memory limit 64Mi→192Mi — OOMKill regressed #3374 zero-click to 503 (Refs #3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -115,7 +115,11 @@ spec:
       # resource-requests Enforce policy — without them every grafana Pod
       # roll is denied, so grafana can never restart to pick up the corrected
       # GF_-shaped OIDC envFromSecret (the zero-click fix). Refs #3374.
-      version: 1.0.13
+      # 1.0.14 (#3374, 2026-06-14): raise sidecar memory limit 64Mi → 192Mi —
+      # 1.0.13's 64Mi OOMKilled the searchNamespace=ALL k8s-sidecar (exitCode
+      # 137 CrashLoopBackOff) → Pod stuck 1/3 NotReady → route 503 despite the
+      # main grafana container serving SSO. Refs #3374.
+      version: 1.0.14
       sourceRef:
         kind: HelmRepository
         name: bp-grafana

--- a/platform/grafana/blueprint.yaml
+++ b/platform/grafana/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.0.13
+  version: 1.0.14
   card:
     title: Grafana
     family: insights

--- a/platform/grafana/chart/Chart.yaml
+++ b/platform/grafana/chart/Chart.yaml
@@ -56,8 +56,15 @@ type: application
 # to plain in-vCluster names when grafana itself promotes (audit
 # Phase-2). Lockstep with bootstrap-kit slots 22/23/24 + bp-catalyst-
 # platform 1.4.591 (CATALYST_MIMIR_URL + baseline CNP).
-version: 1.0.13
+version: 1.0.14
 appVersion: "12.3.1"
+# 1.0.14 (#3374, 2026-06-14): raise the sidecar memory limit 64Mi → 192Mi
+# (request 32Mi → 64Mi). The 1.0.13 limit was too low for the
+# kiwigrid/k8s-sidecar running searchNamespace=ALL (cluster-wide ConfigMap +
+# Secret informer), so both grafana sidecars were OOMKilled (exitCode 137) in
+# a tight CrashLoopBackOff → grafana Pod stuck 1/3 NotReady → Service dropped
+# it → route flapped to 503 despite a healthy main grafana container serving
+# SSO. Refs #3374.
 # 1.0.13 (#3374, 2026-06-14): declare resources.requests/limits on the
 # dashboard + datasource sidecars (grafana.sidecar.resources). Those
 # sidecars are containers[0]/[1] of the grafana Pod and shipped with NO

--- a/platform/grafana/chart/values.yaml
+++ b/platform/grafana/chart/values.yaml
@@ -152,15 +152,24 @@ grafana:
     # it must reschedule (e.g. to pick up a changed envFromSecret), the new
     # Pod can never be created and grafana is stuck on the stale spec.
     # Declaring sidecar.resources makes both sidecars kyverno-compliant so
-    # grafana can actually roll. Tiny footprint — the sidecars just watch
-    # ConfigMaps and POST reload hooks.
+    # grafana can actually roll.
+    #
+    # 1.0.14 (#3374): the 1.0.13 memory limit of 64Mi was too low — the
+    # kiwigrid/k8s-sidecar runs with searchNamespace=ALL (it LISTs/WATCHes
+    # ConfigMaps + Secrets across EVERY namespace), and on hw136 both
+    # sidecars were OOMKilled (exitCode 137) in a tight CrashLoopBackOff,
+    # which kept the grafana Pod at 1/3 NotReady → the Service dropped it →
+    # the route flapped back to 503 even though the main grafana container
+    # was healthy and serving SSO. Bump to 64Mi request / 192Mi limit so the
+    # cluster-wide informer cache fits with headroom. Still a modest
+    # footprint for a Pod whose main container is 256Mi/512Mi.
     resources:
       requests:
         cpu: 10m
-        memory: 32Mi
-      limits:
-        cpu: 50m
         memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 192Mi
     datasources:
       enabled: true
       label: grafana_datasource


### PR DESCRIPTION
## Regression from #3520

#3520 added grafana sidecar resource requests (to pass kyverno `resource-requests` Enforce), but the **64Mi memory limit was too low**. The `kiwigrid/k8s-sidecar` runs with `searchNamespace=ALL` (cluster-wide ConfigMap + Secret informer), so both grafana sidecars were **OOMKilled (exitCode 137)** in a tight CrashLoopBackOff on hw136:

```
grafana-sc-dashboard:   OOMKilled exitCode 137  restarts=4  CrashLoopBackOff
grafana-sc-datasources: OOMKilled exitCode 137  restarts=4  CrashLoopBackOff
grafana (main):         ready=true restarts=0   ← healthy, serving SSO
```

That kept the Pod at **1/3 NotReady** → Service dropped it → route flapped back to **503**, even though the main grafana container was healthy and SSO was working (logs: `userId=2 emrah.baysal@openova.io` requests completing).

## Fix

Bump sidecar request `32Mi → 64Mi` and limit `64Mi → 192Mi` so the cluster-wide informer cache fits with headroom. Verified rendered (`grafana-sc-dashboard`/`grafana-sc-datasources` limits memory 192Mi). Chart `1.0.13 → 1.0.14`; blueprint + slot 25 pin lockstep.

This is the final piece of the #3374 grafana zero-click chain — the SSO config (#3515/#3517) + GF_-shaped secret was correct; this restores Pod stability so it actually stays 3/3.

Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)