### PR TITLE
fix(bp-self-sovereign-cutover): bounded-poll the HelmRepository pivot in Step-08 before failing (0.1.58)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -442,7 +442,14 @@ spec:
       # 0.1.57 (#3379): chart default egressTest.enforceCIDRBlock now
       # true (validated on hw136 walk). The explicit overlay below stays
       # for clarity but is redundant-but-harmless — both agree.
-      version: 0.1.57
+      # 0.1.58 (#3526 Refs #3379): Step-08 (egress-block-test) now
+      # force-reconciles the GitRepository + bootstrap-kit Kustomization
+      # and BOUNDED-POLLS (~5 min) the HelmRepository pivot to convergence
+      # BEFORE asserting failure — robust to Step-06's async git-push
+      # window that fail-fast-FAILED the cutover at Step-08 on the hw136
+      # walk (59 HRs caught mid Flux-revert). RBAC gains kustomizations
+      # {update,patch}; egressBlockTestSeconds 900 → 1200 for poll headroom.
+      version: 0.1.58
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.57
+  version: 0.1.58
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,35 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.58 (#3526 Refs #3379, 2026-06-14): make Step-08 (egress-block-test)
+# pre-flight HelmRepository-pivot assertion ROBUST to Step-06's async
+# git-push window. Step-06 (helmrepository-patches) pivots the OCI
+# HelmRepository URLs two ways: (a) a live `kubectl patch` (immediate,
+# in-memory) that Flux's bootstrap-kit Kustomization reverts on its next
+# 5-min reconcile by re-applying the original ghcr.io manifests from
+# Gitea, and (b) a git-push of the sed-rewritten bootstrap-kit YAML to
+# local Gitea — the DURABLE rewrite, which only lands once the `openova`
+# GitRepository pulls the commit and the bootstrap-kit Kustomization
+# re-applies it. On the hw136 #3379 walk, Step-08 ran ~3 min after
+# Step-06 and asserted ONCE with no wait — it caught the transient
+# revert window (59 HRs back at ghcr.io) and FAIL-FAST'd (exit 1, ~74s)
+# BEFORE the 600s deny-egress hold ran, so the cutover-egress-block CCNP
+# was never applied and cutoverComplete stayed false.
+#
+# Fix (chart-only): before the assertion, Step-08 now FORCE-RECONCILES
+# the GitRepository `openova` + the bootstrap-kit Kustomization (annotate
+# reconcile.fluxcd.io/requestedAt) so Step-06's durable git commit is
+# pulled and re-applied immediately, then POLLS the external-HelmRepository
+# offender count to convergence with a bounded ~5-min timeout (re-poking
+# the reconcile + re-checking every 15s). It only FAILs if a ghcr.io URL
+# survives the full wait — by then the revert window has closed, so a
+# surviving offender is a genuinely un-pivoted HelmRepository, not the
+# Flux-revert race. RBAC ClusterRole gains kustomize.toolkit.fluxcd.io.
+# kustomizations {update,patch} (the reconcile-annotation needs patch;
+# it previously had get/list/watch only). stepTimeouts.egressBlockTest
+# Seconds bumped 900 → 1200 so the worst-case 300s-poll-then-600s-window
+# run keeps headroom under the Job activeDeadlineSeconds. No catalyst-api
+# / code change; no step count change (still 11 steps).
+#
 # 0.1.57 (#3379, 2026-06-14): default `egressTest.enforceCIDRBlock`
 # flipped false → true after the real 10-min deny-egress hold was
 # validated live on the hw136 cutover walk (Pillar-5 proof). All four
@@ -422,7 +452,7 @@ name: bp-self-sovereign-cutover
 # until the tofu-phase0-archive is sealed at handover; this Job treats
 # 425 as the EXPECTED benign pre-handover path (clear log, exit 0). The
 # cutover still auto-fires post-handover (founder rule #933 preserved).
-version: 0.1.57
+version: 0.1.58
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -95,20 +95,91 @@ data:
             # data-plane impact is null — the chart they point at is
             # already installed and isn't pulled again until next
             # cutover cycle, which would re-apply the patch first. The
-            # bulk of HelmRepositories (the 38 leaf-bp's) ARE patched
-            # durably because they live in 06a's HelmRelease values
-            # rather than separate slot files.
-            ext_offenders=$(kubectl get helmrepositories.source.toolkit.fluxcd.io -A \
-              -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}={.spec.url}{"\n"}{end}' \
-              | grep -E '=oci://ghcr\.io/openova-io' \
-              | grep -vE '/(bp-newapi|bp-self-sovereign-cutover)=' || true)
-            ext_count=$(echo "${ext_offenders}" | grep -c '=' || true)
+            # bulk of HelmRepositories ARE patched durably because
+            # Step-06 also git-pushes the rewritten bootstrap-kit YAML.
+            #
+            # #3526 — the pivot assertion MUST tolerate the async-git-push
+            # window. Step-06 (cutover-order 6) does TWO things to pivot
+            # the HelmRepository URLs:
+            #   (a) live `kubectl patch` of the listed HRs (immediate,
+            #       in-memory) — but Flux's bootstrap-kit Kustomization
+            #       re-applies the ORIGINAL ghcr.io manifests from Gitea
+            #       on its next 5-min reconcile, REVERTING those patches;
+            #   (b) a git-push of the sed-rewritten
+            #       clusters/_template/bootstrap-kit/*.yaml to local Gitea
+            #       — the DURABLE rewrite, which only takes effect once
+            #       the `openova` GitRepository pulls the new commit AND
+            #       the bootstrap-kit Kustomization re-applies it.
+            # Step-08 (cutover-order 8) runs ~3 min after Step-06, which
+            # on hw136 (#3379 walk) landed inside the revert window of (a)
+            # BEFORE (b) had reconciled — so a single-shot assertion saw
+            # 59 HRs back at ghcr.io and FAIL-FAST'd (exit 1, ~74s) before
+            # the 600s deny-egress hold ever ran (cutover-egress-block CCNP
+            # never applied, cutoverComplete stayed false).
+            #
+            # Fix: FORCE-RECONCILE the GitRepository + bootstrap-kit
+            # Kustomization so Step-06's durable git commit is pulled and
+            # re-applied NOW, then POLL the pivot to convergence with a
+            # bounded timeout. Only FAIL if the offenders persist after
+            # the full wait — by then the revert window has closed and a
+            # surviving ghcr.io URL is a real un-pivoted HelmRepository,
+            # not the transient Flux-revert race.
+            count_offenders() {
+              # Echoes the current external (non-slot-self-ref) ghcr.io
+              # HelmRepositories, one per line; caller derives the count.
+              kubectl get helmrepositories.source.toolkit.fluxcd.io -A \
+                -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}={.spec.url}{"\n"}{end}' \
+                | grep -E '=oci://ghcr\.io/openova-io' \
+                | grep -vE '/(bp-newapi|bp-self-sovereign-cutover)=' || true
+            }
+
+            echo "[egress-block-test] #3526: force-reconciling Step-06's durable git-push before asserting HelmRepository pivot"
+            now_ts=$(date +%s)
+            # GitRepository pull (SA has gitrepositories patch). This pulls
+            # Step-06 phase-2's local-Gitea commit immediately rather than
+            # waiting for the 1-min GitRepository interval.
+            kubectl annotate --overwrite gitrepository openova -n flux-system \
+              "reconcile.fluxcd.io/requestedAt=${now_ts}" >/dev/null 2>&1 \
+              && echo "  reconcile requested: gitrepository/openova" \
+              || echo "  WARN — could not annotate gitrepository/openova (continuing; the 1-min interval still converges)"
+            # bootstrap-kit Kustomization re-apply (SA has kustomizations
+            # patch as of chart 0.1.58 #3526). This re-applies the pulled
+            # commit's rewritten HelmRepository manifests immediately
+            # rather than waiting for the 5-min Kustomization interval —
+            # the long interval is exactly what made the revert window wide
+            # enough to catch Step-08 on hw136.
+            kubectl annotate --overwrite kustomization bootstrap-kit -n flux-system \
+              "reconcile.fluxcd.io/requestedAt=${now_ts}" >/dev/null 2>&1 \
+              && echo "  reconcile requested: kustomization/bootstrap-kit" \
+              || echo "  WARN — could not annotate kustomization/bootstrap-kit (continuing; the 5-min interval still converges)"
+
+            # Bounded poll to convergence. Up to ~5 min, re-checking every
+            # 15s, so a slow source-controller pull + helm/kustomize
+            # re-apply has time to land the durable local URLs before we
+            # judge. Re-annotate the GitRepository + Kustomization each
+            # cycle so a missed reconcile-request doesn't strand the poll.
+            pivot_deadline=$(( $(date +%s) + 300 ))
+            ext_offenders="$(count_offenders)"
+            ext_count=$(printf '%s' "${ext_offenders}" | grep -c '=' || true)
             echo "  external HelmRepositories still pointing at ghcr.io/openova-io (excluding slot-managed self-refs): ${ext_count}"
+            while [ "${ext_count}" -gt 0 ] && [ "$(date +%s)" -lt "${pivot_deadline}" ]; do
+              printf '%s\n' "${ext_offenders}" | sed 's/^/    not-yet-pivoted /'
+              echo "  [egress-block-test] #3526: ${ext_count} HelmRepository(ies) not yet pivoted at $(($(date +%s) - now_ts))s; re-poking reconcile, re-checking in 15s (bounded ${pivot_deadline}s)"
+              poke_ts=$(date +%s)
+              kubectl annotate --overwrite gitrepository openova -n flux-system \
+                "reconcile.fluxcd.io/requestedAt=${poke_ts}" >/dev/null 2>&1 || true
+              kubectl annotate --overwrite kustomization bootstrap-kit -n flux-system \
+                "reconcile.fluxcd.io/requestedAt=${poke_ts}" >/dev/null 2>&1 || true
+              sleep 15
+              ext_offenders="$(count_offenders)"
+              ext_count=$(printf '%s' "${ext_offenders}" | grep -c '=' || true)
+            done
             if [ "${ext_count}" -gt 0 ]; then
-              echo "${ext_offenders}" | sed 's/^/    OFFENDER /'
-              echo "  FAIL — at least one HelmRepository did not pivot"
+              printf '%s\n' "${ext_offenders}" | sed 's/^/    OFFENDER /'
+              echo "  FAIL — at least one HelmRepository did not pivot within the bounded reconcile wait (#3526)"
               exit 1
             fi
+            echo "[egress-block-test] HelmRepository pivot converged — all external HelmRepositories on local Harbor"
             api_env=$(kubectl get deploy catalyst-api -n catalyst-system \
               -o jsonpath='{.spec.template.spec.containers[?(@.name=="catalyst-api")].env[?(@.name=="CATALYST_GITOPS_REPO_URL")].value}' || echo "")
             echo "  catalyst-api env CATALYST_GITOPS_REPO_URL=${api_env}"

--- a/platform/self-sovereign-cutover/chart/templates/rbac.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/rbac.yaml
@@ -20,8 +20,12 @@ The cutover runner needs cluster-scope reach because:
     Secret in `flux-system` so source-controller can pull from the
     per-Sovereign Harbor mirror without manual kubectl patch.
   - Step 07 patches Deployment in `catalyst-platform` namespace.
-  - Step 08 creates+deletes a CiliumNetworkPolicy cluster-wide and
-    queries HelmRelease/Kustomization status across all namespaces.
+  - Step 08 creates+deletes a CiliumNetworkPolicy cluster-wide, queries
+    HelmRelease/Kustomization status across all namespaces, AND (#3526)
+    force-reconciles the GitRepository + bootstrap-kit Kustomization so
+    Step-06's durable git-push lands before the HelmRepository-pivot
+    assertion — needs kustomizations {update,patch} for the reconcile
+    annotation.
   - Registry-pivot DaemonSet writes to /etc/rancher/k3s/registries.yaml
     on the host filesystem (hostPath, no K8s API needed beyond status
     update on the cutover-status ConfigMap).
@@ -115,6 +119,9 @@ rules:
   - apiGroups: ["helm.toolkit.fluxcd.io"]
     resources: ["helmreleases"]
     verbs: ["update", "patch"]   # step 06 phase-1.6 (catalog override) + step 10 vcluster-registry-pivot (TBD-V24 MISS-1)
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: ["kustomizations"]
+    verbs: ["update", "patch"]   # step 08 (#3526) force-reconciles the bootstrap-kit Kustomization so Step-06's durable git-push lands before the pivot assertion (the annotate reconcile.fluxcd.io/requestedAt patch)
   - apiGroups: ["pkg.crossplane.io"]
     resources: ["providers"]
     verbs: ["update", "patch"]   # step 11 crossplane-provider-pivot (TBD-V24 MISS-3)

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -514,7 +514,14 @@ stepTimeouts:
   fluxGitRepositoryPatchSeconds: 600
   helmRepositoryPatchesSeconds: 600
   catalystAPIEnvPatchSeconds: 600
-  egressBlockTestSeconds: 900   # 600 deny + buffer for assert sweep
+  # 600s deny survival window + up to 300s #3526 bounded pivot-poll
+  # (force-reconcile GitRepository + bootstrap-kit Kustomization and wait
+  # for Step-06's durable git-push to converge BEFORE the window opens)
+  # + buffer for the assert sweep / policy teardown. Was 900s before
+  # #3526 added the pivot-poll; bumped to 1200s so the worst-case
+  # 300s-poll-then-600s-window run still has headroom under the Job's
+  # activeDeadlineSeconds.
+  egressBlockTestSeconds: 1200
   # Step 09 (gitea-token-mint, TBD-C18) — short-lived: a single
   # Gitea API mint + validate + Secret patch + best-effort rollout.
   # 600s leaves generous headroom for the provisioning Deployment


### PR DESCRIPTION
Refs #3379 Refs #3526

## Problem (proven on the hw136 #3379 cutover walk)

Step-08 (`egress-block-test`) pre-flight asserted **once**, with no wait/retry, that every external HelmRepository had pivoted off `oci://ghcr.io/openova-io`. But Step-06 (`helmrepository-patches`) pivots them two ways:

1. a live `kubectl patch` (immediate, in-memory) — which Flux's `bootstrap-kit` Kustomization **reverts** on its next 5-min reconcile by re-applying the original `ghcr.io` manifests from Gitea;
2. an **async git-push** of the sed-rewritten `clusters/_template/bootstrap-kit/*.yaml` to local Gitea — the **durable** rewrite, which only lands once the `openova` GitRepository pulls the commit AND the `bootstrap-kit` Kustomization re-applies it.

On hw136, Step-08 ran ~3 min after Step-06 — inside the revert window of (1), before (2) had reconciled. It caught 59 HRs back at `ghcr.io` and **FAIL-FAST'd** (exit 1, ~74s) **before** the 600s deny-egress hold ran. So the `cutover-egress-block` CCNP was never applied and `cutoverComplete` stayed `false`. (The 39-vs-59 count gap also shows Step-06's kubectl-patch scope is narrower than the assertion enumeration; the git-push is what actually pivots all of them.)

This is the documented kubectl-patch-then-Flux-reverts race class.

## Fix (chart-only, `platform/self-sovereign-cutover/chart/`)

- **`08-egress-block-test-job.yaml`** — before the assertion, FORCE-RECONCILE the GitRepository `openova` + the `bootstrap-kit` Kustomization (annotate `reconcile.fluxcd.io/requestedAt`) so Step-06's durable commit is pulled and re-applied immediately, then **bounded-poll** the external-HelmRepository offender count to convergence (~5 min, re-poke + re-check every 15s). FAIL only if a `ghcr.io` URL survives the full wait — by then the revert window has closed, so a survivor is a genuinely un-pivoted HelmRepository, not the Flux-revert race.
- **`rbac.yaml`** — ClusterRole gains `kustomize.toolkit.fluxcd.io.kustomizations {update,patch}` (it had `get/list/watch` only; the reconcile annotation needs `patch`).
- **`values.yaml`** — `stepTimeouts.egressBlockTestSeconds` 900 → 1200 so the worst-case 300s-poll-then-600s-window run keeps headroom under the Job `activeDeadlineSeconds`.
- Lockstep version bump **0.1.57 → 0.1.58**: `Chart.yaml`, `blueprint.yaml`, and the `bootstrap-kit` slot 06a pin.

No catalyst-api / code change; no step count change (still 11 steps).

## Validation

- `helm template` renders clean (exit 0, no stderr, 21 docs parse as YAML; the step-08 podSpec parses as YAML).
- The new pre-flight block passes strict POSIX `sh -n` in isolation; the full script passes `bash -n` (the Job image `alpine/k8s` runs busybox `ash`, which already runs the pre-existing `comm -13 <(...)` survival-window code).

This is what lets a fresh prov's cutover pass Step-08 → reach Step-09 (mints the funnel token) → `cutoverComplete=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)