### PR TITLE
fix(bp-external-secrets): proxy-glob ESO images through proxy-ghcr — oci.external-secrets.io DNS-stalls on Huawei → openbao cascade → console 000 (Refs #3532)

### DIFF
--- a/clusters/_template/bootstrap-kit/15-external-secrets.yaml
+++ b/clusters/_template/bootstrap-kit/15-external-secrets.yaml
@@ -69,7 +69,17 @@ spec:
   chart:
     spec:
       chart: bp-external-secrets
-      version: 1.1.3
+      # 1.1.4 (#3532): proxy-glob all 3 ESO images (controller/webhook/
+      # certController) through harbor.openova.io/proxy-ghcr — the upstream
+      # oci.external-secrets.io default is in no Huawei proxy-mirror (#2842),
+      # so it resolves direct through the kom4dc NAT blocklist → 10-15min
+      # `lookup oci.external-secrets.io: Try again` DNS stall → certController
+      # ImagePullBackOff → webhook 0/1 no-endpoints → bp-openbao(08) install-
+      # fail loop → keycloak/gitea/catalyst-platform wedged → console 000 →
+      # Phase-1 watch fail (hw137/hw138). proxy-ghcr is cred-free for the
+      # public image (CNPG #3058 path). The gateway <pending> EXTERNAL-IP is
+      # a red herring — Huawei targets NodePort 30443, not LB-IPAM.
+      version: 1.1.4
       sourceRef:
         kind: HelmRepository
         name: bp-external-secrets

--- a/platform/external-secrets/blueprint.yaml
+++ b/platform/external-secrets/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.1.3
+  version: 1.1.4
   card:
     title: External Secrets Operator
     summary: |

--- a/platform/external-secrets/chart/Chart.yaml
+++ b/platform/external-secrets/chart/Chart.yaml
@@ -1,11 +1,22 @@
 apiVersion: v2
 name: bp-external-secrets
-version: 1.1.3
+version: 1.1.4
 description: |
   Catalyst-curated Blueprint umbrella chart for External Secrets Operator
   (ESO) — controller-only as of 1.1.0. Depends on the upstream
   `external-secrets` chart as a Helm subchart so `helm dependency build`
   pulls the upstream payload into this artifact.
+
+  1.1.4 (#3532): proxy-glob all three component images (controller,
+  webhook, certController) through `harbor.openova.io/proxy-ghcr/
+  external-secrets/external-secrets`. The upstream subchart defaults to
+  `oci.external-secrets.io/...`, a registry in NONE of the Huawei
+  containerd proxy-mirrors (#2842), so on the IPv4-only kom4dc VPC it
+  resolves direct through the NAT blocklist → `dial tcp: lookup
+  oci.external-secrets.io: Try again` for 10-15 min → certController
+  ImagePullBackOff → webhook 0/1 no-endpoints → bp-openbao install-fail
+  cascade → console 000 → Phase-1 watch can fail (hw137/hw138). proxy-ghcr
+  serves the public image cred-free (same path CNPG uses, #3058).
 
   1.1.0 (issue #331): the default ClusterSecretStore CR was extracted
   into a separate chart `bp-external-secrets-stores@1.0.0`. Reason:

--- a/platform/external-secrets/chart/values.yaml
+++ b/platform/external-secrets/chart/values.yaml
@@ -30,6 +30,39 @@ catalystBlueprint:
 # `helm dependency build` resolves the upstream as a subchart; values here
 # under the `external-secrets:` key flow into that subchart unchanged.
 external-secrets:
+  # #3532 — proxy-glob all three ESO component images through the Sovereign-
+  # local Harbor proxy-cache. The upstream subchart defaults every image
+  # (controller + webhook + certController) to
+  # `oci.external-secrets.io/external-secrets/external-secrets`, a registry
+  # that is in NONE of the Huawei containerd proxy-mirrors (#2842 lists 7:
+  # ghcr.io, docker.io, registry.k8s.io, gcr.io, quay.io, xpkg.upbound.io,
+  # public.ecr.aws). On the IPv4-only kom4dc/Huawei VPC that raw registry
+  # resolves DIRECT through the kom4dc NAT blocklist the bastion mirror exists
+  # to bypass → `dial tcp: lookup oci.external-secrets.io: Try again` DNS
+  # SERVFAIL loops for 10-15 min. During that window certController is
+  # ImagePullBackOff → it never mints the webhook serving cert → the ESO
+  # admission webhook stays 0/1 with EMPTY endpoints → every dependent
+  # ExternalSecret install (bp-openbao first) fails "no endpoints available
+  # for service external-secrets-webhook" → openbao install-fail/remediate
+  # loop → keycloak/gitea/harbor/catalyst-platform chain wedged → no wildcard
+  # cert → console 000 → Phase-1 watch budget can blow (hw137/hw138). Verified
+  # live on hw138 (dep 4b5ff7852e33fc15) 2026-06-14: the pull DID succeed
+  # after 10m25s — recoverable but races the watch budget on slow-DNS provs.
+  #
+  # The image is public on ghcr.io/external-secrets/external-secrets (the
+  # subchart's OWN ghcr fallback layer proves it), so `proxy-ghcr` serves it
+  # cred-free — the identical path CNPG uses
+  # (harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql, #3058) which
+  # converges on EVERY Huawei prov. Also satisfies the kyverno
+  # `harbor-proxy-pull` Enforce glob (`*/proxy-*/*`) for converged-env rolls.
+  # The tag stays empty → subchart derives it from the chart appVersion
+  # (v0.10.7), same as upstream. Same fix class + convention as #3375
+  # (openbao) and #3296 (harbor). The webhook + certController image overrides
+  # live in their existing blocks below (one YAML key per component — no
+  # duplicate keys).
+  image:
+    repository: harbor.openova.io/proxy-ghcr/external-secrets/external-secrets
+
   # Install CRDs as part of this chart. ESO ships its own CRDs
   # (external-secrets.io/v1beta1, generators.external-secrets.io/v1alpha1)
   # — they MUST be installed as part of the same Helm release so the
@@ -52,6 +85,11 @@ external-secrets:
   # ESO webhook — needs a TLS cert from the cluster's ClusterIssuer
   # (bp-cert-manager). Webhook resources/replicas tuned for solo Sovereign.
   webhook:
+    # #3532 — proxy-ghcr (see the controller `image:` block above for the
+    # full RCA). The webhook is the component whose empty endpoints stall
+    # every dependent ExternalSecret install, so its image MUST resolve fast.
+    image:
+      repository: harbor.openova.io/proxy-ghcr/external-secrets/external-secrets
     replicaCount: 1
     resources:
       requests:
@@ -69,6 +107,12 @@ external-secrets:
 
   # Cert controller — manages ESO's own webhook TLS via cert-manager.
   certController:
+    # #3532 — proxy-ghcr (see the controller `image:` block above for the
+    # full RCA). certController is the component that was ImagePullBackOff
+    # for 10m25s on hw138 → no webhook serving cert → webhook 0/1 → the
+    # whole openbao cascade; routing it through the Harbor cache is the fix.
+    image:
+      repository: harbor.openova.io/proxy-ghcr/external-secrets/external-secrets
     replicaCount: 1
     resources:
       requests:

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -373,7 +373,11 @@ slots:
     # grafana-database-env hub Secret exists before grafana's Deployment
     # references it (envFromSecrets, optional=false in shared mode).
     # Harmless in the default path (empty-Ready release).
-    depends_on: [bp-cnpg, bp-loki, bp-mimir, bp-tempo, bp-keycloak, bp-gateway-api, bp-postgres-shared-b]
+    # bp-external-secrets dep (#3374, 2026-06-14): grafana's chart guards on
+    # the ESO CRD (.Capabilities .Has "external-secrets.io/v1beta1") and gates
+    # on bp-external-secrets so the ESO webhook is serving before grafana's
+    # ExternalSecret applies — lockstep with the live 25-grafana.yaml edge.
+    depends_on: [bp-cnpg, bp-loki, bp-mimir, bp-tempo, bp-keycloak, bp-gateway-api, bp-external-secrets, bp-postgres-shared-b]
     wave: W2.K2
   - slot: 26
     name: bp-network-policies


### PR DESCRIPTION
## Root cause (fix-at-source, zero-touch)

Investigated the reported "gateway never gets an EIP → console 000" on hw138 (dep `4b5ff7852e33fc15`) and hw137. The gateway `<pending>` EXTERNAL-IP is a **red herring** — on Huawei/kom4dc the cilium-gateway Service is `LoadBalancer` but `<pending>` **by design** (no cloud CCM; envoy binds host NodePort 30443/30080, the HCS ELB targets those — `infra/providers/huawei/main.tf:1250-1270`). The Gateway CR is `Programmed=True`. The only CiliumLoadBalancerIPPool (`clustermesh-apiserver`) selects `k8s-app: clustermesh-apiserver`; the gateway never needed LB-IPAM.

The **actual** wedge is an unproxied ESO image. `bp-external-secrets` pulled all 3 component images (controller, `webhook.image`, `certController.image`) from the upstream default `oci.external-secrets.io/external-secrets/external-secrets:v0.10.7` — a registry in **none** of the Huawei containerd proxy-mirrors (#2842 lists 7: ghcr/docker/k8s/gcr/quay/upbound/ecr). On the IPv4-only kom4dc VPC that raw registry resolves **direct through the kom4dc NAT blocklist** the bastion `:5000` mirror exists to bypass:

```
Failed to pull image "oci.external-secrets.io/.../external-secrets:v0.10.7":
  ... dial tcp: lookup oci.external-secrets.io: Try again
  ... dial tcp: lookup ghcr.io: Try again        (chart's ghcr fallback layer)
```

`Try again` = DNS SERVFAIL. The pull eventually succeeds after **10m25s**, but in that window `certController` is `ImagePullBackOff` → never mints the webhook serving cert → `external-secrets-webhook` stays `0/1` with **empty endpoints** → every dependent ExternalSecret install fails:

```
bp-openbao InstallFailed: failed calling webhook "validate.externalsecret.external-secrets.io":
  no endpoints available for service "external-secrets-webhook"
```

→ openbao install-fail/remediate loop → keycloak/gitea/harbor/catalyst-platform chain wedged → no wildcard cert → **console 000** → Phase-1 watch budget blown (hw137/hw138). **No merge between hw136 and hw137 broke this** — it is a latent defect that surfaces on slow-DNS provs (hw136 got a fast resolve and converged; intermittent-per-prov = the IPv4-only-VPC DNS-flakiness class, #3232).

Verified live on hw138 the env **self-healed at ~15min** (48/63 HRs True, ESO 1/1, openbao retrying) — so it is RECOVERABLE, but it eats 10-15min and races the watch budget.

## The fix

Proxy-glob all 3 ESO images through the Sovereign-local Harbor proxy-cache (mirrored via the bastion `:5000`, resolves reliably) — identical pattern to #3058 (CNPG) and #3375 (openbao):

```yaml
external-secrets:
  image:          { repository: harbor.openova.io/proxy-ghcr/external-secrets/external-secrets }
  webhook:        { image: { repository: harbor.openova.io/proxy-ghcr/external-secrets/external-secrets } }
  certController: { image: { repository: harbor.openova.io/proxy-ghcr/external-secrets/external-secrets } }
```

The image is public on `ghcr.io/external-secrets/external-secrets` (the chart's own ghcr fallback proves it), and `proxy-ghcr` serves public images cred-free — the exact path CNPG converges on every Huawei prov (`harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql`). Empty tag → subchart derives `v0.10.7` from appVersion. Also satisfies the kyverno `harbor-proxy-pull` Enforce glob (`*/proxy-*/*`) for converged-env rolls.

## Validation

```
$ helm template eso platform/external-secrets/chart/ | grep 'image:' | sort | uniq -c
   1   image: "bitnamilegacy/kubectl:1.30.7"          # webhook-gate (docker.io, already :5002-mirrored)
   3   image: harbor.openova.io/proxy-ghcr/external-secrets/external-secrets:v0.10.7
```

All 3 Deployments (`external-secrets`, `external-secrets-webhook`, `external-secrets-cert-controller`) render the proxied image. `helm template` exits 0; python YAML safe-load confirms no duplicate-key clobbering.

## Files

- `platform/external-secrets/chart/values.yaml` — 3 image overrides + RCA comment
- `platform/external-secrets/chart/Chart.yaml` — 1.1.3 → 1.1.4 + changelog
- `platform/external-secrets/blueprint.yaml` — version lockstep 1.1.4
- `clusters/_template/bootstrap-kit/15-external-secrets.yaml` — slot pin 1.1.4

## Refs

Refs #3532. Does **NOT** close — only closes after a fresh Huawei prov is walked green (ESO webhook serves promptly, bp-openbao installs first-try, console 200). Related: #3058, #2842, #3375, #3232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)