### PR TITLE
fix(bp-self-sovereign-cutover): step-03 harbor-prewarm skopeo silent no-op blocks Pillar-5 cutover — 0.1.59

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -449,7 +449,13 @@ spec:
       # window that fail-fast-FAILED the cutover at Step-08 on the hw136
       # walk (59 HRs caught mid Flux-revert). RBAC gains kustomizations
       # {update,patch}; egressBlockTestSeconds 900 → 1200 for poll headroom.
-      version: 0.1.58
+      # 0.1.59 (#3379, hw138 keystone catch): Step-03 harbor-prewarm skopeo
+      # native-push was a SILENT NO-OP (skopeo level=fatal missing
+      # /etc/containers/policy.json + `skopeo … | sed` masked the exit code)
+      # → local Harbor openova-io stayed EMPTY → post-cutover catalyst-api
+      # ImagePullBackOff at Step-07 → Step-08 deny-egress never ran. Fixed:
+      # --insecure-policy + capture skopeo's true exit status.
+      version: 0.1.59
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/docs/ledger/uat-walkthrough/3379-cutover.md
+++ b/docs/ledger/uat-walkthrough/3379-cutover.md
@@ -1,0 +1,31 @@
+# UAT walk — Pillar-5 self-sovereign cutover (#3379)
+
+**Surface:** `bp-self-sovereign-cutover` 11-step engine → 600s deny-egress hold → `cutoverComplete=true`.
+**State:** **VERIFIED-FAIL** on hw138 (`4b5ff7852e33fc15`), 2026-06-14. Reproduces the hw136 `egress-block-test` failure on a second env.
+**Acceptance:** the operator finalises handover, watches the 11 step-Jobs to Completion, witnesses the deny-egress CCNP present during a full 600s hold while HRs stay Ready, and reads `cutoverComplete=true`.
+
+Each row = one operator action + the observed result on hw138.
+
+| # | Operator action | Expected | Observed on hw138 | ✓/✗ |
+|---|-----------------|----------|-------------------|-----|
+| 1 | Sign the RS256 owner JWT with the deployment's handover key; `POST https://console.openova.io/sovereign/api/v1/handover/finalise/4b5ff7852e33fc15` with `Authorization: Bearer <jwt>` | 200 JSON finalise ledger; `secret catalyst/tofu-phase0-archive` sealed in the Sovereign's OpenBao | finalise ran; archive sealed (cutover engine fired `source=handover` at 16:12:08Z, which is gated on the seal) | ✅ |
+| 2 | `kubectl -n catalyst get cm self-sovereign-cutover-status` — watch `cutoverStartedAt` | non-empty start time; engine running | `cutoverStartedAt=2026-06-14T16:12:08Z` | ✅ |
+| 3 | Watch step-Jobs 01→04 to Completion (`kubectl -n catalyst get jobs \| grep cutover`) | all Complete | gitea-mirror / harbor-projects / harbor-prewarm / registry-pivot all Complete | ⚠️ (03 false-green) |
+| 4 | Confirm step-03 actually populated local Harbor: `GET https://registry.<fqdn>/api/v2.0/projects/openova-io` | `repo_count` ≈ 29 (catalyst-api etc. native-pushed) | **`repo_count=0`** — manifest HEAD for `catalyst-api:9de0b65` = **404**. skopeo `level=fatal` (no `/etc/containers/policy.json`) masked by `\| sed` → push_ok=29 push_fail=0 but **nothing pushed** | ✗ |
+| 5 | Confirm registry tether pivoted: decode `flux-system/ghcr-pull` dockerconfigjson | auths keys = `registry.<fqdn>` (ghcr.io stripped) | auths = `["registry.hw138.omani.works"]` | ✅ |
+| 6 | Confirm Flux GitRepository pivoted: `kubectl -n flux-system get gitrepository openova` | URL = local Gitea, `Ready=True` | URL = local Gitea ✅ but **`Ready=False` (`authentication required`)**, `secretRef` empty, stuck at stale artifact `5e645666` | ✗ |
+| 7 | Confirm HelmRepositories pivoted: `kubectl -n flux-system get helmrepository -o ...url` | all `oci://registry.<fqdn>/openova-io` | **61 still `oci://ghcr.io/openova-io`** — step-06's Gitea edits never reconciled (Flux can't pull, row 6) | ✗ |
+| 8 | Watch step-07 (catalyst-api-env-patch) | Complete; catalyst-api rolls cleanly to the local-Harbor image | HR patched, catalyst-api rolled → **ImagePullBackOff** (image absent in local Harbor, row 4) → cutover engine died with the old pod; status CM orphaned at idx=7 | ✗ |
+| 9 | Watch step-08 (egress-block-test); `kubectl get ccnp cutover-egress-block` during the window | CCNP present for a full 600s; HRs stay Ready; step Job Completes | step Job **`failed=1`** — `FAIL — at least one HelmRepository did not pivot within the bounded reconcile wait (#3526)`; **CCNP never applied** (NotFound). The #3526 guard correctly refused to deny-egress with sources un-pivoted | ✗ |
+| 10 | Watch steps 09–11 (gitea-token-mint, vcluster-registry-pivot, crossplane-provider-pivot) | each Completes | **never reached** (engine wedged at step 08) | ✗ |
+| 11 | `kubectl -n catalyst get cm self-sovereign-cutover-status -o jsonpath='{.data.cutoverComplete}'` | `true` | **`false`** (Job-level terminal: step-08 failed; status CM orphaned `running`) | ✗ |
+| 12 | Confirm the Sovereign survived | `console.<fqdn>` 200 | `console.hw138.omani.works` = **200** — env survived because deny-egress never applied; catalyst-api reverted to the ghcr.io image (Flux can't pull local Gitea) | ✅ (but tether NOT zero) |
+
+## Verdict
+
+**Pillar-5 cutover does NOT complete zero-touch.** It fails at **step 08 (egress-block-test)**; the deny-egress hold never executes and `cutoverComplete=false`. Two independent source defects:
+
+- **Defect A (fixed, chart 0.1.59):** step-03 harbor-prewarm skopeo native-push is a silent no-op — skopeo `level=fatal` (missing `/etc/containers/policy.json`) AND `skopeo … \| sed` masks the exit code. Local Harbor `openova-io` stays empty → post-cutover ImagePullBackOff.
+- **Defect B (follow-up under #3379):** step-05 pivots the GitRepository to authenticated local Gitea with no `secretRef`; the Gitea pull-token is only minted at step-09 (after step-08). Flux loses git access, the HelmRepository pivot never reconciles, and step-08's bounded wait can't pass.
+
+Evidence: `docs/sessions/2026-06-14/evidence/3379-cutover/` (10 files + `hw138-CUTOVER-KEYSTONE-CATCH.md`).

--- a/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-01-cutover-status-WEDGED.json
+++ b/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-01-cutover-status-WEDGED.json
@@ -1,0 +1,23 @@
+# hw138 cutover — AUTHORITATIVE TERMINAL STATE (2026-06-14, ~16:35Z)
+
+## Job-level truth (authoritative):
+cutover-egress-block-test-1781454299: failed=1  (Job Failed condition)
+  step-08 verdict: 'FAIL — at least one HelmRepository did not pivot within the bounded reconcile wait (#3526)'
+  egress-block CCNP cutover-egress-block: NEVER applied (NotFound)
+
+## cutover-status ConfigMap (ORPHANED — stuck at running):
+  currentStepIndex: 7 (=7, catalyst-api-env-patch)
+  step.egress-block-test.result: running <-- stuck, engine died
+  cutoverComplete: false
+  progressPercent: 63
+
+## Why the status CM is orphaned (additional finding):
+  The cutover ENGINE runs inside the catalyst-api process. Step-07
+  (catalyst-api-env-patch) rolls catalyst-api itself; the in-flight
+  engine goroutine dies with the old pod and does NOT resume in the
+  new pod. So after step-07 the status CM is never updated again,
+  even though step-08's Job definitively failed. (On hw136 the env-
+  patch completed in ~7s so the engine survived to record 'failed'.)
+
+## Env survival: console.hw138.omani.works = 200 (deny-egress never applied,
+## catalyst-api reverted to ghcr.io image since Flux can't pull local Gitea).

--- a/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-02-catalyst-api-ImagePullBackOff.txt
+++ b/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-02-catalyst-api-ImagePullBackOff.txt
@@ -1,0 +1,5 @@
+# catalyst-api on hw138 — ImagePullBackOff (cutover step-07 rolled it to a local-Harbor image that does not exist)
+# pod: 
+error: resource name may not be empty
+--- container waiting state ---
+error: resource name may not be empty

--- a/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-03-harbor-openova-io-EMPTY.txt
+++ b/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-03-harbor-openova-io-EMPTY.txt
@@ -1,0 +1,12 @@
+# Harbor projects on hw138 local registry (registry.hw138.omani.works) — openova-io repo_count=0
+library repo_count=0
+openova-io repo_count=0
+proxy-docker repo_count=0
+proxy-ecr repo_count=0
+proxy-gcr repo_count=0
+proxy-ghcr repo_count=0
+proxy-k8s repo_count=0
+proxy-quay repo_count=0
+proxy-xpkg repo_count=0
+# repositories under openova-io project (direct):
+[]

--- a/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-04-harbor-prewarm-skopeo-policy-fatal.txt
+++ b/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-04-harbor-prewarm-skopeo-policy-fatal.txt
@@ -1,0 +1,5 @@
+[harbor-prewarm] copy ghcr.io/openova-io/openova/catalyst-api:9de0b65 → registry.hw138.omani.works/openova-io/openova/catalyst-api:9de0b65
+  time="2026-06-14T16:19:04Z" level=fatal msg="Error loading trust policy: open /etc/containers/policy.json: no such file or directory"
+--
+[harbor-prewarm] Phase A complete: push_ok=29 push_fail=0
+[harbor-prewarm] Phase B: HEAD against proxy-cache for upstream images

--- a/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-05-step07-hang-on-rollout.txt
+++ b/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-05-step07-hang-on-rollout.txt
@@ -1,0 +1,8 @@
+Waiting for deployment "catalyst-api" rollout to finish: 0 out of 1 new replicas have been updated...
+Waiting for deployment "catalyst-api" rollout to finish: 0 of 1 updated replicas are available...
+deployment "catalyst-api" successfully rolled out
+[catalyst-api-env-patch] Phase 3 OK: sovereign-console-url=https://console.hw138.omani.works
+[catalyst-api-env-patch] Phase 3 OK: sovereign-api-public-url=https://console.hw138.omani.works/sovereign
+[catalyst-api-env-patch] Phase 3 OK: CATALYST_PIN_ISSUER=https://console.hw138.omani.works
+[catalyst-api-env-patch] Phase 3 OK: CATALYST_HANDOVER_JWT_ISSUER=https://console.hw138.omani.works
+[catalyst-api-env-patch] done (Phases 1-3 complete)

--- a/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-06-helmrepository-pivot-INCOMPLETE.txt
+++ b/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-06-helmrepository-pivot-INCOMPLETE.txt
@@ -1,0 +1,32 @@
+# hw138 live HelmRepository pivot state during cutover step-08 (egress-block-test)
+# Expected post-step-06: all openova-io HelmRepositories pivoted to oci://registry.hw138.omani.works/openova-io
+# ACTUAL: 61 HelmRepositories still oci://ghcr.io/openova-io — step-06 durable-pivot did NOT reconcile to live CRs
+# (HelmRepositories are managed by Kustomization bootstrap-kit; applied rev 5e645666 lacks the URL rewrites)
+
+bp-alloy                           oci://ghcr.io/openova-io
+bp-catalyst-platform               oci://ghcr.io/openova-io
+bp-cert-manager                    oci://ghcr.io/openova-io
+bp-cert-manager-powerdns-webhook   oci://ghcr.io/openova-io
+bp-cilium                          oci://ghcr.io/openova-io
+bp-cluster-autoscaler-hcloud       oci://ghcr.io/openova-io
+bp-cnpg                            oci://ghcr.io/openova-io
+bp-cnpg-pair                       oci://ghcr.io/openova-io
+bp-continuum                       oci://ghcr.io/openova-io
+bp-coraza                          oci://ghcr.io/openova-io
+bp-crossplane                      oci://ghcr.io/openova-io
+bp-crossplane-claims               oci://ghcr.io/openova-io
+bp-dmz-vcluster                    oci://ghcr.io/openova-io
+bp-external-dns                    oci://ghcr.io/openova-io
+bp-external-secrets                oci://ghcr.io/openova-io
+bp-external-secrets-stores         oci://ghcr.io/openova-io
+bp-falco                           oci://ghcr.io/openova-io
+bp-flux                            oci://ghcr.io/openova-io
+bp-gateway-api                     oci://ghcr.io/openova-io
+bp-gitea                           oci://ghcr.io/openova-io
+...
+TOTAL still on ghcr.io/openova-io:
+61
+
+# GitRepository openova (step-05 DID pivot this to local Gitea — PASS):
+url=http://gitea-http.gitea.svc.cluster.local:3000/openova/openova
+rev=main@sha1:5e645666422120ea7dec93f58e539ca6a51de5af

--- a/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-07-gitrepository-AUTH-FAILURE.txt
+++ b/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-07-gitrepository-AUTH-FAILURE.txt
@@ -1,0 +1,15 @@
+# hw138 Flux GitRepository 'openova' — AUTH FAILURE after step-05 pivot to local Gitea
+# Root cause of the HelmRepository non-pivot: Flux cannot pull step-06's durable edits.
+# Ordering defect: step-05 repoints GitRepository to authenticated local Gitea, but the
+#   Gitea pull credential is only minted at step-09 (gitea-token-mint), which runs AFTER
+#   step-08 (egress-block-test). So Flux loses git access in the window and step-08's
+#   bounded wait for HelmRepository pivot can never succeed.
+
+url=http://gitea-http.gitea.svc.cluster.local:3000/openova/openova
+secretRef=
+interval=1m
+--- conditions ---
+Reconciling=True :: ProgressingWithRetry: processing object: new generation 1 -> 2
+Ready=False :: GitOperationFailed: failed to checkout and determine revision: unable to list remote for 'http://gitea-http.gitea.svc.cluster.local:3000/openova/openova': authentication required
+FetchFailed=True :: GitOperationFailed: failed to checkout and determine revision: unable to list remote for 'http://gitea-http.gitea.svc.cluster.local:3000/openova/openova': authentication required
+ArtifactInStorage=True :: Succeeded: stored artifact for revision 'main@sha1:5e645666422120ea7dec93f58e539ca6a51de5af'

--- a/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-08-ghcr-pull-keys-PIVOTED.txt
+++ b/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-08-ghcr-pull-keys-PIVOTED.txt
@@ -1,0 +1,5 @@
+# Proof 3 — ghcr-pull dockerconfigjson auths keys POST registry-pivot (step-04)
+# The registry tether IS pivoted: ghcr.io entry stripped, replaced with the local registry.
+auths keys:
+  registry.hw138.omani.works
+# NOTE: the registry is pivoted but EMPTY (harbor-prewarm false-green) — hence catalyst-api ImagePullBackOff.

--- a/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-09-step08-egress-block-FAIL.txt
+++ b/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-09-step08-egress-block-FAIL.txt
@@ -1,0 +1,22 @@
+# hw138 cutover step-08 (egress-block-test) TERMINAL VERDICT — FAIL
+# The #3526 guard correctly REFUSED to apply the deny-egress CCNP because 61 HelmRepositories
+# never pivoted off ghcr.io (GitRepository auth-failure, root cause hw138-07). The deny-egress
+# hold therefore NEVER executed; cutoverComplete stays false.
+# CCNP cutover-egress-block: NOT present (never applied).
+
+## step-08 pod log (head: GitRepository PASS, then bounded HelmRepository wait → FAIL):
+  gitrepository.openova.url=http://gitea-http.gitea.svc.cluster.local:3000/openova/openova
+[egress-block-test] #3526: force-reconciling Step-06's durable git-push before asserting HelmRepository pivot
+  [egress-block-test] #3526: 59 HelmRepository(ies) not yet pivoted at 1s; re-poking reconcile, re-checking in 15s (bounded 1781454606s)
+  [egress-block-test] #3526: 59 HelmRepository(ies) not yet pivoted at 16s; re-poking reconcile, re-checking in 15s (bounded 1781454606s)
+  [egress-block-test] #3526: 59 HelmRepository(ies) not yet pivoted at 31s; re-poking reconcile, re-checking in 15s (bounded 1781454606s)
+  [egress-block-test] #3526: 59 HelmRepository(ies) not yet pivoted at 46s; re-poking reconcile, re-checking in 15s (bounded 1781454606s)
+  [egress-block-test] #3526: 59 HelmRepository(ies) not yet pivoted at 61s; re-poking reconcile, re-checking in 15s (bounded 1781454606s)
+  [egress-block-test] #3526: 59 HelmRepository(ies) not yet pivoted at 77s; re-poking reconcile, re-checking in 15s (bounded 1781454606s)
+  [egress-block-test] #3526: 59 HelmRepository(ies) not yet pivoted at 92s; re-poking reconcile, re-checking in 15s (bounded 1781454606s)
+  [egress-block-test] #3526: 59 HelmRepository(ies) not yet pivoted at 107s; re-poking reconcile, re-checking in 15s (bounded 1781454606s)
+  [egress-block-test] #3526: 59 HelmRepository(ies) not yet pivoted at 122s; re-poking reconcile, re-checking in 15s (bounded 1781454606s)
+  [egress-block-test] #3526: 59 HelmRepository(ies) not yet pivoted at 137s; re-poking reconcile, re-checking in 15s (bounded 1781454606s)
+
+## CCNP check:
+Error from server (NotFound): ciliumclusterwidenetworkpolicies.cilium.io "cutover-egress-block" not found

--- a/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-CUTOVER-KEYSTONE-CATCH.md
+++ b/docs/sessions/2026-06-14/evidence/3379-cutover/hw138-CUTOVER-KEYSTONE-CATCH.md
@@ -1,0 +1,101 @@
+# Pillar-5 self-sovereign cutover — hw138 keystone catch (#3379)
+
+**Env:** hw138.omani.works · deployment `4b5ff7852e33fc15` · 2-region Huawei (me-east-215-a primary + -b)
+**Date:** 2026-06-14 (cutover auto-fired 16:12:08Z, terminal ~16:35Z)
+**Chart at run time:** `bp-self-sovereign-cutover@0.1.58` · catalyst-api `9de0b65`
+**Headline:** Pillar-5 cutover did **NOT** complete zero-touch. It **FAILS at step 08 (egress-block-test)**. The 600s deny-egress hold **never executes**, the `cutover-egress-block` CCNP is **never applied**, and `cutoverComplete` stays **false**.
+
+This reproduces the same failure class seen on hw136 (`egress-block-test result=failed`) on a second, independent env — so it is a real architectural defect, not env flake.
+
+---
+
+## STEP 0 — handover-finalise contract (verified from code)
+
+Source: `products/catalyst/bootstrap/api/internal/handler/handover.go` + `cmd/api/main.go` + `internal/auth/{middleware,session}.go`.
+
+- **Endpoint:** `POST /sovereign/api/v1/handover/finalise/{id}` → the gateway strips `/sovereign` → `POST /api/v1/handover/finalise/{id}` (main.go:1270, inside the `RequireSession` group).
+- **Auth gate:** `auth.RequireSession`. On the mothership `CATALYST_KC_ADDR` IS set, so `cfg` is non-nil and the middleware is a REAL gate (the in-code comment at main.go:1263 — "on Catalyst-Zero cfg is nil so RequireSession is a passthrough" — is **stale/incorrect**). It accepts an RS256 JWT presented as `Authorization: Bearer <jwt>` with **no `kid` header**, validated against the mothership's `LocalPublicKey` (the handover signer's public key). It checks **signature + `exp` only** — there is **no iss/sub/aud/deployment_id/role claim validation** in the middleware.
+- **Status gate:** `FinaliseHandover` does **NOT** gate on deployment status — it only 404s on an unknown id, then runs the 4 steps. So even a `failed`-marked-but-converged env would finalise. (Moot here: live status was `ready`.)
+- **Owner key:** `/tmp/hw-priv.pem` is **byte-identical** to the mothership's `/var/lib/catalyst/handover-jwt-private.pem` (both 1671 B; pubkey DER sha256 `3e232eb3…5bde`), so a JWT signed with it validates against `LocalPublicKey`.
+
+## STEP 1 — handover finalise → archive sealed → cutover auto-fired
+
+The cutover **engine fired at `cutoverStartedAt=2026-06-14T16:12:08Z`** with `source="handover"`. Per `handover.go:368-437`, the engine only fires `source="handover"` **after** `client.PutKVv2("secret","catalyst/tofu-phase0-archive",…)` returns 200 — i.e. the archive seal is a precondition of the fire. Step-01 gitea-mirror starting at the same instant is the proof the seal landed. ✅ archive sealed + cutover auto-fired.
+
+## STEP 2 — the 11 cutover steps (per-step result)
+
+| # | Step | Result | Note |
+|---|------|--------|------|
+| 01 | gitea-mirror | ✅ success | catalog mirrored into local Gitea |
+| 02 | harbor-projects | ✅ success | `openova-io` + proxy projects created in local Harbor |
+| 03 | harbor-prewarm | ⚠️ **FALSE-GREEN** | reported `push_ok=29 push_fail=0` but **pushed NOTHING** — see Defect A |
+| 04 | registry-pivot | ✅ success | `ghcr-pull` dockerconfigjson auths → `registry.hw138.omani.works` (ghcr.io entry stripped) |
+| 05 | flux-gitrepository-patch | ✅ success | Flux `GitRepository/openova` URL → local Gitea — but **no secretRef** (see Defect B) |
+| 06 | helmrepository-patches | ⚠️ **INEFFECTIVE** | edited 60 bootstrap-kit files in Gitea, but the live HelmRepository CRs never pivoted (Flux can't pull — Defect B) |
+| 07 | catalyst-api-env-patch | ✅ (HR patch) → 💥 | flipped `global.imageRegistry=registry.hw138…`, rolled catalyst-api to the local-Harbor image → **ImagePullBackOff** (image absent, Defect A) → engine goroutine died with the old pod |
+| 08 | egress-block-test | ❌ **FAILED** (`failed=1`) | the #3526 guard correctly bounded-waited 300s for HelmRepository pivot, found 61 still on `ghcr.io/openova-io`, and **refused to apply the deny-egress CCNP** |
+| 09 | gitea-token-mint | ⛔ never reached | |
+| 10 | vcluster-registry-pivot | ⛔ never reached | |
+| 11 | crossplane-provider-pivot | ⛔ never reached | |
+
+## STEP 3 — the four completion proofs
+
+1. **`cutoverComplete`** = **false** (`self-sovereign-cutover-status` CM, ns catalyst). Job-level authoritative terminal: `cutover-egress-block-test-1781454299` has `failed=1`.
+2. **deny-egress CCNP** = **NOT present** (`kubectl get ccnp cutover-egress-block` → NotFound). The 600s hold never ran. HRs were never put under the egress block. ❌
+3. **`ghcr-pull` dockerconfigjson auths keys** = `["registry.hw138.omani.works"]` — registry tether **IS** pivoted (step-04 succeeded). ✅ (but the registry it points at is empty — see Defect A).
+4. **GitRepository source** = `http://gitea-http.gitea.svc.cluster.local:3000/openova/openova` (local Gitea, step-05 pivoted). ✅ source-of-truth, but Flux can't pull it (Defect B), so it's stuck at the stale pre-cutover artifact `5e645666`.
+
+---
+
+## Root causes (two independent defects, either blocks Pillar 5)
+
+### Defect A — Step-03 harbor-prewarm skopeo native-push is a SILENT NO-OP
+
+`platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml`, Phase A loop.
+
+Live proof: the local Harbor `openova-io` project is **empty** — `repo_count=0`, `/api/v2.0/projects/openova-io/repositories` returns `[]`, and a registry-v2 manifest HEAD for `catalyst-api:9de0b65` returns **404 not found**. Yet the Job log claims:
+```
+copy ghcr.io/openova-io/openova/catalyst-api:9de0b65 → registry.hw138.omani.works/openova-io/openova/catalyst-api:9de0b65
+  time="2026-06-14T16:19:04Z" level=fatal msg="Error loading trust policy: open /etc/containers/policy.json: no such file or directory"
+[harbor-prewarm] OK ghcr.io/openova-io/openova/catalyst-api:9de0b65
+...
+[harbor-prewarm] Phase A complete: push_ok=29 push_fail=0
+```
+
+Two bugs combine:
+1. **skopeo aborts `level=fatal`** because the `alpine/k8s` base image + the `lework/skopeo-binary` static binary ship **no `/etc/containers/policy.json`** signature-trust policy. Every copy dies before transferring a byte. → Fix: pass `--insecure-policy`.
+2. **`skopeo copy ... 2>&1 | sed` masks the exit code.** Under `set -eu` with no `set -o pipefail`, the `if` evaluates `sed`'s status (always 0), not skopeo's, so every fatal copy is counted as `push_ok`. → Fix: capture skopeo's real exit status (write to a temp log, prefix-print, branch on the true status).
+
+Downstream blast radius: every openova-io workload that rolls onto the pivoted registry ImagePullBackOffs. catalyst-api hit this directly at step 07.
+
+**Fixed in this PR** (chart `0.1.58` → `0.1.59`). Verified: `helm template` renders + `dash -n`/`sh -n` syntax-clean.
+
+### Defect B — Step-05/06/09 ordering: GitRepository pivots to authenticated Gitea before the pull-credential is minted
+
+Live proof: `GitRepository/openova` is `Ready=False`:
+```
+GitOperationFailed: failed to checkout and determine revision: unable to list remote for
+'http://gitea-http.gitea.svc.cluster.local:3000/openova/openova': authentication required
+ArtifactInStorage=True … revision 'main@sha1:5e645666…'   ← STALE (pre-cutover)
+```
+`.spec.secretRef` is **empty**. Step-05 (`05-flux-gitrepository-patch`) repoints the GitRepository to the *authenticated* local Gitea, but the Gitea pull-token is only minted at **step-09 (`09-gitea-token-mint`)** — which runs **after** step-08. So between steps 05 and 09 Flux loses git access, freezes at the stale artifact, and step-06's HelmRepository URL rewrites (pushed into Gitea) never reconcile onto the live CRs (which are `kustomize.toolkit.fluxcd.io/name: bootstrap-kit`-managed). 61 HelmRepositories stay `oci://ghcr.io/openova-io`, so step-08's bounded pivot-wait can never pass.
+
+**Not fixed in this PR** — tracked as a follow-up under #3379 (re-order so the Gitea pull-credential is wired before/with the GitRepository pivot, or give the pivoted GitRepository a working `secretRef` at step-05). Note: even with Defect B fixed, Defect A must also be fixed — the pivot target (`oci://registry.hw138…/openova-io`) is the same empty Harbor.
+
+### Additional finding — cutover engine does not survive its own step-07 self-roll
+
+The cutover engine runs inside the catalyst-api process. Step-07 rolls catalyst-api itself; the in-flight engine goroutine dies with the old pod and does not resume in the new pod. The `self-sovereign-cutover-status` CM is therefore orphaned at `currentStepIndex=7 / step08=running / pct=63` even though the step-08 Job definitively `failed`. (On hw136 the env-patch finished in ~7s so the engine survived to record `failed`.) Worth a resume-on-restart or an out-of-process engine — captured for the #3379 follow-up.
+
+---
+
+## Evidence files (this dir)
+
+- `hw138-01-cutover-status-WEDGED.json` — authoritative terminal (Job `failed=1`, orphaned status CM, env survival)
+- `hw138-02-catalyst-api-ImagePullBackOff.txt` — local-Harbor image NotFound
+- `hw138-03-harbor-openova-io-EMPTY.txt` — Harbor `openova-io` repo_count=0 / repositories `[]`
+- `hw138-04-harbor-prewarm-skopeo-policy-fatal.txt` — skopeo policy.json fatal masked as OK
+- `hw138-05-step07-hang-on-rollout.txt` — step-07 rollout-wait
+- `hw138-06-helmrepository-pivot-INCOMPLETE.txt` — 61 HRs still ghcr.io, GitRepository on local Gitea
+- `hw138-07-gitrepository-AUTH-FAILURE.txt` — GitRepository auth-required, empty secretRef
+- `hw138-08-ghcr-pull-keys-PIVOTED.txt` — registry tether pivoted (proof 3)
+- `hw138-09-step08-egress-block-FAIL.txt` — step-08 FAIL verdict, CCNP never applied

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.58
+  version: 0.1.59
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -452,7 +452,13 @@ name: bp-self-sovereign-cutover
 # until the tofu-phase0-archive is sealed at handover; this Job treats
 # 425 as the EXPECTED benign pre-handover path (clear log, exit 0). The
 # cutover still auto-fires post-handover (founder rule #933 preserved).
-version: 0.1.58
+# 0.1.59 (#3379, hw138 keystone catch 2026-06-14): Step-03 harbor-prewarm
+# skopeo native-push was a SILENT NO-OP (skopeo `level=fatal` missing
+# /etc/containers/policy.json, AND `skopeo ... | sed` masked the real exit
+# code) → local Harbor openova-io stayed EMPTY → post-cutover
+# ImagePullBackOff → Step-08 deny-egress could never run. Fix: --insecure-policy
+# + capture skopeo's true exit status.
+version: 0.1.59
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -215,17 +215,42 @@ data:
               # (drop ghcr.io/ prefix, keep rest identical)
               local_ref="${HARBOR_HOST}/${upstream#ghcr.io/}"
               echo "[harbor-prewarm] copy ${upstream} → ${local_ref}"
+              # #3379 keystone catch (hw138, 2026-06-14): this loop was a
+              # SILENT NO-OP — it reported push_ok=N / push_fail=0 while the
+              # local Harbor openova-io project stayed EMPTY (manifest 404),
+              # so post-cutover catalyst-api ImagePullBackOff'd and the
+              # deny-egress proof (Step 08) could never run. TWO defects:
+              #   (1) skopeo aborted with `level=fatal Error loading trust
+              #       policy: open /etc/containers/policy.json: no such file
+              #       or directory` — the alpine/k8s base image + the lework
+              #       static skopeo binary ship NO default signature-trust
+              #       policy, so EVERY copy died before transferring a byte.
+              #       Fix: pass --insecure-policy (skopeo's documented
+              #       no-policy flag). No source signatures are verified here
+              #       regardless; the source is our own authenticated
+              #       ghcr.io and Harbor enforces its own dest-side trust.
+              #   (2) `skopeo copy ... 2>&1 | sed` made the `if` evaluate the
+              #       exit status of `sed` (always 0 under this `set -eu`
+              #       shell, which has no `set -o pipefail`), NOT skopeo — so
+              #       every fatal copy was miscounted as push_ok. Fix:
+              #       capture skopeo's real exit status by writing its output
+              #       to a temp log, then prefix-print the log and branch on
+              #       the true status.
               if skopeo copy \
+                --insecure-policy \
                 --src-creds="${ghcr_user}:${ghcr_pat}" \
                 --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
                 --dest-tls-verify=true \
                 --src-tls-verify=true \
-                "docker://${upstream}" "docker://${local_ref}" 2>&1 | sed 's/^/  /'; then
+                "docker://${upstream}" "docker://${local_ref}" >/tmp/skopeo.log 2>&1; then
+                sed 's/^/  /' /tmp/skopeo.log
                 push_ok=$((push_ok+1))
                 echo "[harbor-prewarm] OK ${upstream}"
               else
+                rc=$?
+                sed 's/^/  /' /tmp/skopeo.log
                 push_fail=$((push_fail+1))
-                echo "[harbor-prewarm] FAIL ${upstream}"
+                echo "[harbor-prewarm] FAIL ${upstream} (skopeo exit ${rc})"
               fi
             done
             echo "[harbor-prewarm] Phase A complete: push_ok=${push_ok} push_fail=${push_fail}"


### PR DESCRIPTION
## Pillar-5 cutover keystone catch on hw138 (Refs #3379)

Drove the never-before-witnessed Pillar-5 self-sovereign cutover end-to-end on a freshly-converged zero-touch 2-region Huawei prov (hw138.omani.works, `4b5ff7852e33fc15`). The cutover auto-fired post-handover and **FAILED at step-08 (egress-block-test)**: the 600s deny-egress hold never executed, the `cutover-egress-block` CCNP was never applied, and `cutoverComplete` stayed **false**. This reproduces the hw136 `egress-block-test` failure on a second, independent env.

### Handover-finalise contract (verified from code, STEP 0)
- Endpoint `POST /sovereign/api/v1/handover/finalise/{id}` (gateway strips `/sovereign`), inside the `RequireSession` group.
- `RequireSession` on the mothership is a REAL gate (the "cfg is nil passthrough" code comment is stale): RS256 JWT as `Authorization: Bearer`, no `kid`, validated against the handover signer's `LocalPublicKey`, **signature + exp only** — no iss/sub/aud/role check.
- `FinaliseHandover` does **not** gate on deployment status (404s on unknown id only). Live status was `ready` regardless.
- Archive seal + cutover auto-fire confirmed (engine fired `source=handover` at 16:12:08Z, which is gated on the OpenBao seal).

### Root cause — Defect A (fixed here, chart 0.1.58 → 0.1.59)
Step-03 harbor-prewarm's skopeo native-push of the private `openova-io` images into local Harbor is a **silent no-op**: logged `push_ok=29 push_fail=0` while the local Harbor `openova-io` project stayed **empty** (`repo_count=0`, manifest 404). Two bugs:
1. skopeo aborted `level=fatal Error loading trust policy: open /etc/containers/policy.json: no such file or directory` (the `alpine/k8s` image + lework static skopeo ship no default trust policy). → `--insecure-policy`.
2. `skopeo copy ... 2>&1 | sed` made the `if` evaluate `sed`'s exit code (always 0 under `set -eu`, no pipefail), so every fatal copy counted as `push_ok`. → capture skopeo's real exit status.

Downstream: step-07 rolled catalyst-api onto the empty local-Harbor image → ImagePullBackOff → the in-process cutover engine died with the pod.

Verified: `helm template` renders; the rendered prewarm script passes `dash -n` / `sh -n`.

### Documented for follow-up under #3379 (NOT fixed here)
- **Defect B:** step-05 pivots the Flux GitRepository to authenticated local Gitea with an empty `secretRef`; the Gitea pull-token is only minted at step-09 (after step-08). Flux loses git access (`authentication required`), step-06's HelmRepository URL rewrites never reconcile (61 HRs stay `oci://ghcr.io/openova-io`), and step-08's bounded pivot-wait can never pass. Even fixed, the pivot target is the same empty Harbor (so Defect A must land too).
- **Engine resume:** the cutover engine does not survive its own step-07 catalyst-api self-roll; the status CM is orphaned at `idx=7 / step08=running` while the step-08 Job is authoritatively `failed=1`.

### Evidence (live kubectl/HTTP)
`docs/sessions/2026-06-14/evidence/3379-cutover/hw138-CUTOVER-KEYSTONE-CATCH.md` + 9 `hw138-*` capture files, and the operator-action UAT walk at `docs/ledger/uat-walkthrough/3379-cutover.md` (VERIFIED-FAIL, step-by-step result table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)