### PR TITLE
fix(catalyst-api): default EnableSharedPostgres=true so the #3370 instance-cards + Contexts surface renders on every fresh prov

### DIFF
--- a/infra/providers/hetzner/variables.tf
+++ b/infra/providers/hetzner/variables.tf
@@ -112,8 +112,8 @@ variable "enable_hot_standby" {
 # the reuse model was unreachable even on a fresh prov.
 variable "enable_shared_pg" {
   type        = string
-  description = "When 'true', bootstrap-kit slot 16a renders the shared CNPG engine (ADR-0010 #3188 reusable backing-services). Opt-in; default 'false' keeps slot 16a an empty-but-Ready release. Set from catalyst-api Request.EnableSharedPostgres."
-  default     = "false"
+  description = "When 'true' (the default, Refs #3370), bootstrap-kit slots 16a/16c/16d render the shared CNPG engines (ADR-0010 #3188 reusable backing-services) plus each instance's self-registered Application CR — the founder North-Star-2 target and the only path that makes the #3370 instance-cards + Contexts surface render on a fresh prov. Set 'false' for the byte-identical dedicated-cluster path. Set from catalyst-api Request.EnableSharedPostgres."
+  default     = "true"
   validation {
     condition     = contains(["true", "false"], var.enable_shared_pg)
     error_message = "enable_shared_pg must be the string 'true' or 'false'."

--- a/infra/providers/huawei/variables.tf
+++ b/infra/providers/huawei/variables.tf
@@ -446,8 +446,8 @@ variable "enable_hot_standby" {
 # substitute key, so the chart's envsubst fallback `false` always won.
 variable "enable_shared_pg" {
   type        = string
-  description = "When 'true', bootstrap-kit slot 16a renders the shared CNPG engine (ADR-0010 #3188 reusable backing-services). Opt-in; default 'false' keeps slot 16a an empty-but-Ready release. Set from catalyst-api Request.EnableSharedPostgres."
-  default     = "false"
+  description = "When 'true' (the default, Refs #3370), bootstrap-kit slots 16a/16c/16d render the shared CNPG engines (ADR-0010 #3188 reusable backing-services) plus each instance's self-registered Application CR — the founder North-Star-2 target and the only path that makes the #3370 instance-cards + Contexts surface render on a fresh prov. Set 'false' for the byte-identical dedicated-cluster path. Set from catalyst-api Request.EnableSharedPostgres."
+  default     = "true"
   validation {
     condition     = contains(["true", "false"], var.enable_shared_pg)
     error_message = "enable_shared_pg must be the string 'true' or 'false'."

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -967,7 +967,22 @@ func (h *Handler) CreateDeployment(w http.ResponseWriter, r *http.Request) {
 	// bool fields without changing the struct shape). Paired with the
 	// chart-side `${MARKETPLACE_ENABLED:-true}` slot fallback (PR #1967)
 	// and the matching variables.tf default flip.
-	req := provisioner.Request{MarketplaceEnabled: true}
+	//
+	// EnableSharedPostgres=true (Refs #3370) — same default-true idiom:
+	// the ADR-0010 reusable shared-Postgres model (bootstrap-kit slot
+	// 16a/16c/16d) is the founder North-Star-2 target state ('3 shared
+	// PG instances → 3 cards, 6-7 apps many-to-many'). It is ALSO the
+	// only path that lands an Application CR per shared-pg instance on a
+	// fresh prov (the bp-postgres chart self-registers it ONLY when
+	// `enabled != "false"`, the master gate fed by SOVEREIGN_ENABLE_
+	// SHARED_PG); without it `/api/v1/sovereign/apps` projects ZERO
+	// instance cards + ZERO Contexts (the #3370 surface is unreachable).
+	// Leaving the default OFF made #3370 invisible on every fresh prov
+	// (hw138). The deadlock that historically blocked SHARED_PG=true
+	// (#3283) is closed; the chart is at 0.1.10. An explicit
+	// `"enableSharedPostgres": false` in the body still wins for the
+	// byte-identical dedicated-cluster path.
+	req := provisioner.Request{MarketplaceEnabled: true, EnableSharedPostgres: true}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
 		return

--- a/products/catalyst/bootstrap/api/internal/handler/deployments_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments_test.go
@@ -284,6 +284,80 @@ func TestCreateDeployment_MarketplaceEnabledDefaultsTrue(t *testing.T) {
 	}
 }
 
+// Refs #3370 — a deployment POST that OMITS `enableSharedPostgres` MUST
+// land with Request.EnableSharedPostgres=true, the founder North-Star-2
+// target state. CreateDeployment pre-initialises the Request before
+// json.Decode (the same default-true bool idiom as MarketplaceEnabled), so
+// the "absent key leaves field untouched" semantics fall through to the
+// pre-init value. This is the only path that fires the bp-postgres chart's
+// shared-pg engines + their self-registered Application CRs on a fresh
+// prov; without the default ON, `/api/v1/sovereign/apps` projected ZERO
+// instance cards + ZERO Contexts (the #3370 surface was invisible on
+// hw138). Asserts the canonical "field omitted → true" case AND the
+// "explicit false → byte-identical dedicated-cluster path survives the
+// decode" case.
+func TestCreateDeployment_EnableSharedPostgresDefaultsTrue(t *testing.T) {
+	t.Setenv("DYNADOT_MANAGED_DOMAINS", "omani.works")
+	t.Setenv("CATALYST_GHCR_PULL_TOKEN", "ghp_TEST_PLACEHOLDER_NOT_REAL")
+	t.Setenv("CATALYST_HARBOR_ROBOT_TOKEN", "harbor_TEST_PLACEHOLDER")
+
+	cases := []struct {
+		name      string
+		sharedKey bool // include enableSharedPostgres in the body
+		sharedVal bool // value when included
+		want      bool // expected dep.Request.EnableSharedPostgres
+	}{
+		{name: "omitted-defaults-true", sharedKey: false, want: true},
+		{name: "explicit-true-passes-through", sharedKey: true, sharedVal: true, want: true},
+		{name: "explicit-false-dedicated-cluster-survives", sharedKey: true, sharedVal: false, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pdm.ResetManagedDomains()
+			fake := &fakePDM{}
+			h := NewWithPDM(slog.Default(), fake)
+
+			body := map[string]any{
+				"sovereignFQDN":          "k8s.acme.io",
+				"sovereignDomainMode":    "byo",
+				"sovereignSubdomain":     "k8s",
+				"hetznerToken":           "tok",
+				"hetznerProjectID":       "proj",
+				"region":                 "fsn1",
+				"orgName":                "Acme",
+				"orgEmail":               "ops@acme.io",
+				"sshPublicKey":           "ssh-ed25519 AAAA test",
+				"objectStorageRegion":    "fsn1",
+				"objectStorageAccessKey": "TESTACCESSKEY1234567",
+				"objectStorageSecretKey": "TESTSECRETKEY1234567890123456789012345678",
+			}
+			if tc.sharedKey {
+				body["enableSharedPostgres"] = tc.sharedVal
+			}
+			raw, _ := json.Marshal(body)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPost, "/api/v1/deployments", bytes.NewReader(raw))
+			h.CreateDeployment(w, r)
+			if w.Code != http.StatusCreated {
+				t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+			}
+			var resp struct {
+				ID string `json:"id"`
+			}
+			_ = json.Unmarshal(w.Body.Bytes(), &resp)
+			val, ok := h.deployments.Load(resp.ID)
+			if !ok {
+				t.Fatalf("deployment %s missing from sync.Map", resp.ID)
+			}
+			dep := val.(*Deployment)
+			if dep.Request.EnableSharedPostgres != tc.want {
+				t.Fatalf("EnableSharedPostgres = %v, want %v (#3370 default-flip semantics)", dep.Request.EnableSharedPostgres, tc.want)
+			}
+		})
+	}
+}
+
 // Issue #748 — orgEmail must match the authenticated session. A signed-in
 // operator who tries to POST a deployment whose req.OrgEmail belongs to
 // some OTHER identity must receive 403, NEVER 201. The session header

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner_shared_pg_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner_shared_pg_test.go
@@ -65,12 +65,19 @@ func TestWriteTfvars_EnableSharedPostgres_OptInResolvesTrue(t *testing.T) {
 // 2. Absent (the default) keeps the gate OFF — safe-by-default preserved.
 func TestWriteTfvars_EnableSharedPostgres_DefaultResolvesFalse(t *testing.T) {
 	req := tfvarsRequest(t)
-	// EnableSharedPostgres left at its zero value (false) — exactly the
-	// shape every non-opt-in fire-body has today.
+	// EnableSharedPostgres left at its zero value (false) — this is now the
+	// EXPLICIT opt-out shape (an operator who sets `"enableSharedPostgres":
+	// false` in the body for the byte-identical dedicated-cluster path).
+	// As of #3370 the CreateDeployment handler pre-seeds the field to TRUE
+	// before json.Decode, so an OMITTED body provisions shared-pg by
+	// default (covered by handler test TestCreateDeployment_
+	// EnableSharedPostgresDefaultsTrue). This provisioner-layer test pins
+	// that a zero-value Request still stringifies to "false" so the opt-out
+	// path keeps slot 16a an empty-but-Ready release.
 
 	out := writeTfvarsSharedPG(t, req)
 
 	if got := out["enable_shared_pg"]; got != "false" {
-		t.Errorf("enable_shared_pg = %v, want %q (default OFF → slot 16a is an empty-but-Ready release)", got, "false")
+		t.Errorf("enable_shared_pg = %v, want %q (explicit opt-out → slot 16a is an empty-but-Ready release)", got, "false")
 	}
 }


### PR DESCRIPTION
## Problem

On a fresh converged Huawei prov (**hw138.omani.works**, dep `4b5ff7852e33fc15`, console=200, 49 apps render) the **#3370 surface is MISSING**: `/apps` shows no per-database PostgreSQL instance cards (shared-pg / -b / -c) and no Contexts tabs. Live API proof — `GET /api/v1/sovereign/apps` returns the bare blueprint schema with **no `contexts`/`instance`/`blueprint`/`topology`/`contextCount` field on any app**.

## Definitive root cause — NOT pin-stale

The pinned catalyst-api/ui image `9de0b65` **already contains the full #3370 code**: the entire feature landed in commit `708dbfb24` (PR #3382), which is an **ancestor of `9de0b65`** (`git merge-base --is-ancestor 708dbfb24 9de0b65` → YES). So the image is correct.

The `/api/v1/sovereign/apps` handler (`sovereign.go` `HandleSovereignApps`) builds instance cards + `contextCount` **exclusively from Application CRs** (`instanceRows` from `List(applicationGVR)`). **hw138 has 0 Application CRs.**

The `bp-postgres` chart self-registers one Application CR per instance via `templates/application-cr.yaml`, gated on:
```
(ne .Values.enabled "false") AND .Values.bootstrapOwned.enabled AND Capabilities.Has "apps.openova.io/v1"
```
Live on hw138: the CRD **is** registered (serving `v1`) and `bootstrapOwned=true`, but the **master gate `enabled=false`** because hw138 was provisioned with `SOVEREIGN_ENABLE_SHARED_PG=false` (the default `req.EnableSharedPostgres=false`). All three `bp-postgres-shared{,-b,-c}` HRs are therefore **empty-but-Ready** (no `shared-pg` Cluster — every CNPG cluster on hw138 is a dedicated per-app one — and no Application CR) → zero instance cards → zero `contexts`.

**Honest verdict on the prior #3370 walk:** the #3370 surface on a fresh Sovereign is **conditional on `enableSharedPostgres=true` at provision time** — it does NOT render on a default-flag prov. Any walk that presented #3370 as "renders on any fresh converged prov" overstated it; the shared-pg three-instance model must be switched on at provision.

## Fix

Default the ADR-0010 shared-Postgres model **ON** for fresh provs — the founder North-Star-2 target ("3 shared PG instances → 3 cards, 6-7 apps many-to-many") and the only path that lands an Application CR per shared-pg instance on a fresh prov. The `#3283` deadlock that historically blocked `SHARED_PG=true` is **closed**; the chart is at `0.1.10`. `enable_shared_pg` and `enable_hot_standby`/`cnpg-pair` are orthogonal gates — both can be on; no multi-region conflict.

- **`handler/deployments.go`** — `CreateDeployment` pre-seeds `Request{EnableSharedPostgres: true}` before `json.Decode` (the same default-true bool idiom already used for `MarketplaceEnabled`); an explicit `"enableSharedPostgres": false` in the body still wins for the byte-identical dedicated-cluster path.
- **`infra/providers/{hetzner,huawei}/variables.tf`** — `enable_shared_pg` default `"false"` → `"true"` for direct-tofu callers; validation constraint unchanged.
- **`deployments_test.go`** — `TestCreateDeployment_EnableSharedPostgresDefaultsTrue` pins omitted→true / explicit-true→true / explicit-false→false.
- **`provisioner_shared_pg_test.go`** — clarify the zero-value test is now the explicit opt-out shape; provisioner-layer stringification unchanged.

## Validation

`go build ./...` + `go vet` + `go test` (handler `CreateDeployment` + provisioner shared-pg) all **PASS**.

## Live-env note (important)

hw138's `SOVEREIGN_ENABLE_SHARED_PG` value is **cloud-init-injected into the live Flux Kustomization at provision time (NOT stored in git)** — the live `bootstrap-kit` Kustomization carries it in `postBuild.substitute`. Therefore **this merge cannot retroactively flip it on hw138**; hw138 needs a **refire** with the new default to render the #3370 surface. Every future fresh prov renders it zero-touch.

Refs #3370

🤖 Generated with [Claude Code](https://claude.com/claude-code)