### PR TITLE
fix(bp-self-sovereign-cutover): wire Gitea pull-credential into GitRepository.spec.secretRef at step-05 — Pillar-5 cutover step-08 (Defect B, 0.1.60)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -455,7 +455,14 @@ spec:
       # → local Harbor openova-io stayed EMPTY → post-cutover catalyst-api
       # ImagePullBackOff at Step-07 → Step-08 deny-egress never ran. Fixed:
       # --insecure-policy + capture skopeo's true exit status.
-      version: 0.1.59
+      # 0.1.60 (#3536 Refs #3379): Step-05 (flux-gitrepository-patch) now
+      # wires a flux-system basic-auth secretRef (from the bootstrap-minted
+      # catalyst-gitea-token PAT) into GitRepository/openova BEFORE flipping
+      # the URL to the local Gitea — without it, REQUIRE_SIGNIN_VIEW=true
+      # 401'd every post-pivot clone, Step-06's rewrites never reconciled,
+      # and Step-08's pivot-wait never converged (hw138 keystone catch).
+      # RBAC gains secrets:create. (0.1.59 = PR #3535 Defect-A skopeo fix.)
+      version: 0.1.60
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.59
+  version: 0.1.60
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -458,7 +458,20 @@ name: bp-self-sovereign-cutover
 # code) → local Harbor openova-io stayed EMPTY → post-cutover
 # ImagePullBackOff → Step-08 deny-egress could never run. Fix: --insecure-policy
 # + capture skopeo's true exit status.
-version: 0.1.59
+# 0.1.60 (#3536, Refs #3379): Step-05 (flux-gitrepository-patch) flipped
+# GitRepository/openova to the authenticated local Gitea but with an EMPTY
+# secretRef (the bootstrap GitRepository cloned public github.com
+# anonymously; bp-gitea REQUIRE_SIGNIN_VIEW=true makes anonymous local
+# clone 401) → source-controller froze "authentication required" → step-06
+# HelmRepository rewrites never reconciled → step-08 pivot-wait never
+# converged → the 600s deny-egress hold never ran → cutoverComplete=false.
+# The Gitea PAT was only minted at step-09 (after step-08). Fix: step-05
+# now materialises a flux-system basic-auth Secret from the
+# `catalyst-gitea-token` PAT (minted at BOOTSTRAP by bp-catalyst-platform)
+# and wires it into GitRepository.spec.secretRef BEFORE the URL flip — same
+# credential + pattern as #3454's openova-sme-tenants GitRepository. Adds
+# `secrets: create` to the cutover-runner RBAC.
+version: 0.1.60
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/05-flux-gitrepository-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/05-flux-gitrepository-patch-job.yaml
@@ -2,8 +2,29 @@
 Step 05 — flux-gitrepository-patch.
 
 Patches `flux-system/<gitopsRepository.name>` GitRepository.spec.url
-to the local Sovereign Gitea URL. After this patch source-controller
-reconciles against the in-cluster Gitea Service.
+to the local Sovereign Gitea URL AND wires a basic-auth secretRef so
+source-controller can authenticate to the local Gitea. After this patch
+source-controller reconciles against the in-cluster Gitea Service.
+
+#3536 (Refs #3379) — secretRef wiring (load-bearing for step 08)
+────────────────────────────────────────────────────────────────
+The cloud-init bootstrap GitRepository pulls from public github.com with
+NO secretRef (anonymous clone). bp-gitea sets REQUIRE_SIGNIN_VIEW=true,
+so once we flip the URL to the local Gitea, an anonymous clone 401s
+("authentication required") even for a PUBLIC repo. source-controller
+then freezes on the stale pre-cutover artifact, step 06's HelmRepository
+URL rewrites never reconcile, and step 08's bounded pivot-wait can never
+converge → the 600s deny-egress hold never runs → cutoverComplete=false.
+
+Fix: BEFORE flipping the URL, materialise a Flux basic-auth Secret in the
+GitRepository's namespace carrying the `catalyst-gitea-token` PAT (minted
+at BOOTSTRAP by bp-catalyst-platform, in catalyst-system) in
+username/password shape, and set GitRepository.spec.secretRef.name to it.
+A Gitea PAT is accepted as the HTTP git password. This is the same
+credential + pattern issue #3454 used for the openova-sme-tenants
+GitRepository. Flux secretRef takes only a name (no namespace) and
+resolves it in the GitRepository's own namespace, so the Secret is
+created locally from the cross-namespace PAT here.
 
 Image phase: post.
 */ -}}
@@ -44,20 +65,100 @@ data:
           # "kustomization path not found".
           - name: SOVEREIGN_FQDN
             value: {{ .Values.sovereign.fqdn | quote }}
+          # #3536 — secretRef wiring inputs. The destination basic-auth
+          # Secret is created in the GitRepository's namespace; the source
+          # PAT (`catalyst-gitea-token`) is read from catalyst-system where
+          # bp-catalyst-platform's pre-install hook minted it at bootstrap.
+          - name: GIT_AUTH_SECRET_NAME
+            value: {{ .Values.gitRepositorySecretRef.destSecretName | quote }}
+          - name: PAT_SOURCE_NAMESPACE
+            value: {{ .Values.gitRepositorySecretRef.patSourceNamespace | quote }}
+          - name: PAT_SOURCE_SECRET_NAME
+            value: {{ .Values.gitRepositorySecretRef.patSourceSecretName | quote }}
+          - name: PAT_SOURCE_KEY
+            value: {{ .Values.gitRepositorySecretRef.patSourceKey | quote }}
+          - name: GIT_AUTH_USERNAME
+            value: {{ .Values.gitRepositorySecretRef.username | quote }}
         command: ["/bin/sh", "-c"]
         args:
           - |
             set -eu
             echo "[flux-gitrepository-patch] target=${GITREPO_NAMESPACE}/${GITREPO_NAME} -> ${LOCAL_GITEA_URL} (branch=${BRANCH})"
+
+            # ── #3536: wire a basic-auth secretRef BEFORE flipping the URL ──
+            #
+            # bp-gitea sets REQUIRE_SIGNIN_VIEW=true → an anonymous clone of
+            # the local Gitea 401s even for a public repo. The cloud-init
+            # bootstrap GitRepository has NO secretRef (it cloned public
+            # github.com anonymously). So we must give source-controller a
+            # credential, or every reconcile after the URL flip fails
+            # "authentication required" and step 08 can never converge.
+            #
+            # Credential = the `catalyst-gitea-token` PAT minted at BOOTSTRAP
+            # by bp-catalyst-platform (in ${PAT_SOURCE_NAMESPACE}). A Gitea
+            # PAT is accepted as the HTTP git password. Flux secretRef takes
+            # only a name resolved in the GitRepository's own namespace, so
+            # we read the cross-namespace PAT and write a basic-auth Secret
+            # (keys username/password) into ${GITREPO_NAMESPACE}.
+            #
+            # The PAT Secret exists from bootstrap, but its `token` byte may
+            # be momentarily empty if the minter Job is mid-flight; wait
+            # (bounded) for a non-empty value before proceeding — a cutover
+            # that wired an empty password would re-introduce the 401.
+            echo "[flux-gitrepository-patch] reading PAT ${PAT_SOURCE_NAMESPACE}/${PAT_SOURCE_SECRET_NAME}.${PAT_SOURCE_KEY}"
+            pat=""
+            for i in $(seq 1 30); do
+              pat=$(kubectl -n "${PAT_SOURCE_NAMESPACE}" get secret "${PAT_SOURCE_SECRET_NAME}" \
+                -o "jsonpath={.data.${PAT_SOURCE_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || true)
+              if [ -n "${pat}" ]; then
+                echo "[flux-gitrepository-patch] PAT present (attempt ${i})"
+                break
+              fi
+              echo "[flux-gitrepository-patch] PAT not yet populated in ${PAT_SOURCE_NAMESPACE}/${PAT_SOURCE_SECRET_NAME} (attempt ${i}/30) — sleeping 5s"
+              sleep 5
+            done
+            if [ -z "${pat}" ]; then
+              echo "[flux-gitrepository-patch] FATAL: ${PAT_SOURCE_NAMESPACE}/${PAT_SOURCE_SECRET_NAME}.${PAT_SOURCE_KEY} empty after 150s — bp-catalyst-platform PAT mint did not complete; refusing to pivot the GitRepository to an authenticated Gitea without a credential (would 401 on every reconcile)" >&2
+              exit 1
+            fi
+
+            # Create/update the basic-auth Secret in the GitRepository's
+            # namespace. Apply via stdin manifest so the PAT never lands in
+            # argv (visible to other namespaces' process listings). stringData
+            # lets the apiserver base64-encode for us.
+            echo "[flux-gitrepository-patch] materialising basic-auth Secret ${GITREPO_NAMESPACE}/${GIT_AUTH_SECRET_NAME}"
+            cat >/tmp/git-auth-secret.yaml <<EOF
+            apiVersion: v1
+            kind: Secret
+            metadata:
+              name: ${GIT_AUTH_SECRET_NAME}
+              namespace: ${GITREPO_NAMESPACE}
+              labels:
+                app.kubernetes.io/managed-by: self-sovereign-cutover
+                app.kubernetes.io/component: cutover-gitrepository-auth
+              annotations:
+                catalyst.openova.io/mirrored-from: ${PAT_SOURCE_NAMESPACE}/${PAT_SOURCE_SECRET_NAME}
+            type: Opaque
+            stringData:
+              username: ${GIT_AUTH_USERNAME}
+              password: ${pat}
+            EOF
+            kubectl apply -f /tmp/git-auth-secret.yaml
+            echo "[flux-gitrepository-patch] basic-auth Secret applied"
+
             # Issue #891 — apply the patch via a YAML strategic-merge file
             # so the multi-line ignore filter is shipped verbatim. JSON-
             # patching a multi-line string from sh is a rabbit-hole of
             # quoting; YAML lets us write it as a literal block.
+            # #3536 — the patch ALSO sets spec.secretRef.name so the
+            # post-flip GitRepository authenticates to the local Gitea.
             cat >/tmp/patch.yaml <<EOF
             spec:
               url: ${LOCAL_GITEA_URL}
               ref:
                 branch: ${BRANCH}
+              secretRef:
+                name: ${GIT_AUTH_SECRET_NAME}
               ignore: |
                 /*
                 !/clusters/_template
@@ -65,7 +166,7 @@ data:
                 !/platform
                 !/products
             EOF
-            echo "[flux-gitrepository-patch] applying patch (ignore widened to include clusters/${SOVEREIGN_FQDN}/)"
+            echo "[flux-gitrepository-patch] applying patch (URL -> local Gitea, secretRef -> ${GIT_AUTH_SECRET_NAME}, ignore widened to include clusters/${SOVEREIGN_FQDN}/)"
             kubectl patch gitrepository "${GITREPO_NAME}" \
               -n "${GITREPO_NAMESPACE}" \
               --type=merge --patch-file /tmp/patch.yaml

--- a/platform/self-sovereign-cutover/chart/templates/rbac.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/rbac.yaml
@@ -14,7 +14,10 @@ The cutover runner needs cluster-scope reach because:
   - Step 02 reads bp-harbor admin Secret in `harbor` namespace.
   - Step 02 reads ghcr-pull Secret in `flux-system` namespace.
   - Step 03 only writes to local Harbor over HTTP (no K8s API).
-  - Step 05 patches GitRepository in `flux-system` namespace.
+  - Step 05 reads the `catalyst-gitea-token` PAT in `catalyst-system`,
+    CREATES the basic-auth Secret `cutover-gitea-git-auth` in
+    `flux-system`, and patches GitRepository (URL + secretRef) in
+    `flux-system` so the post-pivot local-Gitea clone authenticates (#3536).
   - Step 06 patches HelmRepositories in `flux-system` namespace, AND
     (phase-0, #1184) merges harbor.<sov-fqdn> auth into the ghcr-pull
     Secret in `flux-system` so source-controller can pull from the
@@ -47,6 +50,9 @@ rules:
   # ───────────────────────────────────────────────────────────────
   - apiGroups: [""]
     resources: ["configmaps"]   # cutover-status ConfigMap is created+updated by every step
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]   # step 05 (#3536) creates the flux-system basic-auth Secret (cutover-gitea-git-auth) wired into GitRepository.spec.secretRef so the post-pivot local-Gitea clone authenticates
     verbs: ["create"]
   - apiGroups: ["cilium.io"]
     resources: ["ciliumnetworkpolicies", "ciliumclusterwidenetworkpolicies"]   # step 08 creates + tears down the cluster-wide egress-block policy (#2940)

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -104,6 +104,51 @@ gitea:
     usernameKey: "username"
     passwordKey: "password"
 
+# GitRepository pivot credential — step 05 (flux-gitrepository-patch). #3536.
+#
+# THE BUG (hw138/hw136 keystone catch, Refs #3379): step 05 repoints
+# GitRepository/openova from public github.com to the local Gitea, but the
+# cloud-init bootstrap GitRepository carries NO secretRef (public GitHub
+# clones anonymously). bp-gitea sets service.REQUIRE_SIGNIN_VIEW=true
+# (platform/gitea/chart/values.yaml) — anonymous clone of the local Gitea
+# 401s "authentication required" even for a PUBLIC repo (PROVEN live on
+# hw133, see products/catalyst/.../sme-tenants-gitrepo-auth-secret.yaml).
+# So after the pivot, source-controller can never fetch the local source →
+# step 06's HelmRepository URL rewrites never reconcile → step 08's bounded
+# pivot-wait can never converge → the 600s deny-egress hold never runs →
+# cutoverComplete=false. The Gitea PAT was only minted at step 09 (after
+# step 08), which is too late.
+#
+# THE FIX: step 05 wires a Flux basic-auth Secret into
+# GitRepository.spec.secretRef BEFORE flipping the URL, using the
+# `catalyst-gitea-token` PAT (key `token`) that bp-catalyst-platform's
+# pre-install hook already minted at BOOTSTRAP — long before cutover fires.
+# This is the identical credential + pattern issue #3454 used for the
+# openova-sme-tenants GitRepository. A Gitea PAT is accepted as the HTTP
+# git password (REQUIRE_SIGNIN_VIEW=true → anonymous 401, PAT → 200).
+#
+# Flux GitRepository.spec.secretRef accepts only `name` (no namespace) and
+# resolves it in the GitRepository's OWN namespace (flux-system). The PAT
+# Secret lives in catalyst-system, so step 05 reads it and materialises a
+# basic-auth Secret in flux-system (keys username/password) that the
+# GitRepository can reference.
+gitRepositorySecretRef:
+  # Destination basic-auth Secret name (created/updated by step 05 in the
+  # GitRepository's namespace = gitopsRepository.namespace). The
+  # GitRepository's spec.secretRef.name is patched to this.
+  destSecretName: "cutover-gitea-git-auth"
+  # Source PAT Secret minted at bootstrap by bp-catalyst-platform
+  # (templates/catalyst-gitea-token-secret.yaml). catalyst-platform's
+  # HelmRelease has targetNamespace: catalyst-system, so the Secret lands
+  # there with key `token`.
+  patSourceNamespace: "catalyst-system"
+  patSourceSecretName: "catalyst-gitea-token"
+  patSourceKey: "token"
+  # Git HTTP username for the basic-auth pair. Matches the Gitea admin
+  # account (CATALYST_GITOPS_USER literal `gitea_admin`, per
+  # api-deployment.yaml + sme-tenants-gitrepo-auth-secret.yaml).
+  username: "gitea_admin"
+
 # Local Harbor target — admin credentials + proxy_cache projects to create.
 harbor:
   # Shape of the admin secret materialised by bp-harbor's templates


### PR DESCRIPTION
## Defect B — cutover step-05 wires no Gitea credential into the GitRepository (Refs #3536, Refs #3379)

The never-before-completed Pillar-5 self-sovereign cutover FAILED at step-08 (egress-block-test) on hw138 (and hw136 before it): the 600s deny-egress hold never ran and `cutoverComplete` stayed false. Root-caused to a credential-ordering defect in step-05.

### The confirmed step-05 ↔ step-09 credential-ordering bug

- The cloud-init bootstrap `GitRepository/openova` (`flux-system`) pulls from public `github.com` with **no `secretRef`** — `infra/providers/_shared/cloudinit-control-plane.tftpl:376-393` writes it with `spec.url`/`ref` only (public GitHub clones anonymously).
- Cutover step-05 (`05-flux-gitrepository-patch-job.yaml`) flips `spec.url` to the local Gitea but leaves `secretRef` empty.
- `bp-gitea` sets `service.REQUIRE_SIGNIN_VIEW=true` (`platform/gitea/chart/values.yaml`) → an anonymous clone of the local Gitea returns **HTTP 401 "authentication required"** even for a PUBLIC repo (proven live on hw133; see `products/catalyst/chart/templates/sme-services/sme-tenants-gitrepo-auth-secret.yaml:13-25`).
- The Gitea PAT was only minted at **step-09** (`09-gitea-token-mint-job.yaml`, `cutover-order: "9"`), which runs **after** step-08.
- So source-controller froze on the stale pre-cutover artifact → step-06's HelmRepository URL rewrites never reconciled (61 HRs stayed `oci://ghcr.io/openova-io`) → step-08's bounded pivot-wait could never converge → the deny-egress hold never started.

### The fix

step-05 now, BEFORE flipping the URL:

1. Reads the `catalyst-gitea-token` PAT (key `token`) from `catalyst-system` — minted at **bootstrap** by `bp-catalyst-platform`'s pre-install hook (`catalyst-gitea-token-secret.yaml`), long before cutover fires (bounded wait for a non-empty value).
2. Materialises a Flux basic-auth Secret (`cutover-gitea-git-auth`, keys `username`/`password`) in the GitRepository's namespace (`flux-system`) — Flux `secretRef` accepts only a name resolved in the GitRepository's own namespace, and the PAT lives in `catalyst-system`.
3. Sets `GitRepository.spec.secretRef.name` to that Secret in the same patch that flips the URL.

A Gitea PAT is accepted as the HTTP git password (`REQUIRE_SIGNIN_VIEW=true` → anonymous 401, PAT → 200). This is the identical credential + pattern issue #3454 used for the `openova-sme-tenants` GitRepository. The cutover-runner RBAC gains `secrets: create`.

Step numbering is unchanged (the mint happens within step-05). The PAT mint at step-09 stays — it serves a different consumer (`sme/provisioning-github-token`).

### Validation (rendered, not asserted)

- `helm template platform/self-sovereign-cutover/chart` renders the populated wiring: `secretRef.name: cutover-gitea-git-auth`, PAT read from `catalyst-system/catalyst-gitea-token`.
- The rendered step-05 script passes `dash -n` and `sh -n`.
- All 11 cutover-order steps (01..11) intact.
- `tests/e2e/bootstrap-kit` static validation + `helm lint` green.

Lockstep chart bump 0.1.58 → 0.1.60 (`Chart.yaml` + `blueprint.yaml` + slot-06a pin). 0.1.59 is reserved for PR #3535's Defect-A skopeo prewarm fix; both must land for the cutover to reach the deny-egress hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
