### PR TITLE
fix(bp-powerdns-admin,bp-newapi): both SSO apps reliably land zero-click signed-in from t=0 — init-container OIDC gate + deterministic newapi redirect

### DIFF
--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -141,7 +141,13 @@ spec:
       # authorize_url` -> bare-URL 302 lands on PDA's own HTTP 500 (measured
       # live hw136). Reloader roll -> /oidc/login 302s to KC -> owner lands
       # on /dashboard/ signed-in.
-      version: 0.1.15
+      # 0.1.16 (#3374): the Reloader annotation proved UNRELIABLE on a fresh
+      # prov (measured live hw138: annotation present, Pod NEVER rolled, OIDC
+      # env empty 108min -> /oidc/login 500). Added a `wait-for-oidc`
+      # initContainer that blocks the main container until
+      # pda-sso-oidc-credentials is populated, so `envFrom` is never empty at
+      # first serve and /oidc/login deterministically 302s to KC from t=0.
+      version: 0.1.16
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns-admin

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -231,7 +231,16 @@ spec:
       # `rtz` namespace (where the synced `valkey-primary-x-valkey-x-rtz-
       # vcluster` Service lives) for the 6379 egress rule. This slot sets no
       # `networkPolicy.egress` override, so the chart default IS what renders.
-      version: 1.4.88
+      # 1.4.89 (#3374): zero-click bridge init page no longer DISCOVERS the
+      # authorize endpoint from /api/status (v0.13.2 omits
+      # custom_oauth_providers there → it fell through to /login → the SPA
+      # bounced to /setup). The chart injects NEWAPI_SSO_AUTHORIZE_URL /
+      # NEWAPI_SSO_CLIENT_ID / NEWAPI_SSO_SCOPES so the page redirects
+      # deterministically. NOTE: build-bp-newapi-sandbox-bridge.yaml
+      # auto-bumps this pin further (-> 1.4.90) when it rebuilds the bridge
+      # image on merge, so the slot carries BOTH the env vars AND the new
+      # sidecar binary that reads them.
+      version: 1.4.89
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.88
+  version: 1.4.89
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -576,7 +576,25 @@ name: bp-newapi
 # Add the bridge port to the CNP toPorts, gated on ssoInit + sandboxBridge.
 # Verified live on hw136: bare URL https://newapi.<fqdn>/ now serves the init
 # page -> silent KC broker -> lands signed-in in /console (zero-click).
-version: 1.4.88
+# 1.4.89 (#3374, 2026-06-15): the 1.4.85-1.4.88 zero-click landing was
+# UNRELIABLE on a fresh prov — the bridge init page DISCOVERED the authorize
+# endpoint + client_id at runtime from `pj.data.custom_oauth_providers` in GET
+# /api/status, but NewAPI v0.13.2's /api/status payload has NO
+# `custom_oauth_providers` field (proven live on hw138, dep 4b5ff7852e33fc15:
+# full key dump, field absent). So the discovery always returned [], the page
+# fell through to /login, and the SPA bounced the owner to the /setup wizard —
+# the exact symptom — EVEN THOUGH the DB was correctly seeded (setups row,
+# catalyst-root role=100, the `sovereign` custom_oauth_providers row enabled).
+# ROBUST FIX (sso_init.go 0.1.16): the bridge no longer discovers — the chart
+# injects NEWAPI_SSO_AUTHORIZE_URL / NEWAPI_SSO_CLIENT_ID / NEWAPI_SSO_SCOPES
+# (the IDENTICAL values the admin-sso-seed-job seeds) so the init page builds
+# the authorize redirect DIRECTLY. The only runtime call left is GET
+# /api/oauth/state (proven to mint state + set the session cookie live on
+# hw138), structurally required for NewAPI's callback CSRF. If the authorize
+# URL/client_id are unset the page degrades to the SPA /login link. The bridge
+# IMAGE TAG + a further chart patch bump are auto-committed by
+# build-bp-newapi-sandbox-bridge.yaml on merge (push to internal/handler/**).
+version: 1.4.89
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -346,6 +346,28 @@ spec:
             # custom_oauth_providers.slug. Default "sovereign".
             - name: NEWAPI_SSO_INIT_SLUG
               value: {{ (.Values.adminSeed | default dict).providerSlug | default "sovereign" | quote }}
+            {{- /*
+            #3374 0.1.16 (2026-06-15) — the landing page builds the authorize
+            redirect DIRECTLY from these values instead of discovering them at
+            runtime from GET /api/status. ROOT CAUSE (measured live hw138, dep
+            4b5ff7852e33fc15): NewAPI v0.13.2's /api/status payload has NO
+            `custom_oauth_providers` field, so the old discovery returned [] →
+            the page fell through to /login → the SPA bounced the owner to the
+            /setup wizard (even though the DB was correctly seeded). These are
+            the IDENTICAL values the admin-sso-seed-job seeds into
+            custom_oauth_providers (authorization_endpoint + client_id +
+            scopes). When sovereignFQDN is unset the seed/landing are no-ops
+            anyway (the page degrades to the SPA /login link). */}}
+            {{- $sk := .Values.adminSeed | default dict }}
+            {{- if .Values.sovereignFQDN }}
+            {{- $slug := $sk.providerSlug | default "sovereign" }}
+            - name: NEWAPI_SSO_AUTHORIZE_URL
+              value: {{ printf "https://auth.%s/realms/%s/protocol/openid-connect/auth?kc_idp_hint=catalyst-pin" .Values.sovereignFQDN $slug | quote }}
+            - name: NEWAPI_SSO_CLIENT_ID
+              value: {{ .Values.auth.adminUI.keycloak.clientId | default "newapi-admin" | quote }}
+            - name: NEWAPI_SSO_SCOPES
+              value: {{ $sk.scopes | default "openid profile email groups" | quote }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/platform/newapi/internal/handler/cmd/sandbox-bridge/main.go
+++ b/platform/newapi/internal/handler/cmd/sandbox-bridge/main.go
@@ -33,8 +33,20 @@
 //	                          #3374 landing page initiates (default
 //	                          "sovereign"). The bp-newapi admin-sso-seed-job
 //	                          seeds the provider under this slug.
+//	NEWAPI_SSO_AUTHORIZE_URL  optional — the Keycloak authorize endpoint the
+//	                          #3374 landing page redirects to (carries
+//	                          ?kc_idp_hint=catalyst-pin). 0.1.16: the page
+//	                          builds the redirect DIRECTLY from this instead of
+//	                          discovering it from /api/status (v0.13.2 does NOT
+//	                          expose custom_oauth_providers there). Empty ⇒ the
+//	                          page degrades to the SPA /login link.
+//	NEWAPI_SSO_CLIENT_ID      optional — the Keycloak client_id (default
+//	                          "newapi-admin"). Empty ⇒ degrade to /login.
+//	NEWAPI_SSO_SCOPES         optional — OAuth scope string (default
+//	                          "openid profile email groups").
 //
-// Refs #2303, Wave 5.57; #3374 (2026-06-14) zero-click SSO landing.
+// Refs #2303, Wave 5.57; #3374 (2026-06-14) zero-click SSO landing;
+// #3374 0.1.16 (2026-06-15) deterministic redirect (no /api/status discovery).
 package main
 
 import (
@@ -77,7 +89,10 @@ func main() {
 	// and OIDC callback keep flowing to NewAPI). SSOInitHandler itself 404s
 	// any path other than "/" as a belt-and-braces guard.
 	mux.HandleFunc("/", handler.SSOInitHandler(handler.SSOInitConfig{
-		Slug: os.Getenv("NEWAPI_SSO_INIT_SLUG"),
+		Slug:         os.Getenv("NEWAPI_SSO_INIT_SLUG"),
+		AuthorizeURL: os.Getenv("NEWAPI_SSO_AUTHORIZE_URL"),
+		ClientID:     os.Getenv("NEWAPI_SSO_CLIENT_ID"),
+		Scopes:       os.Getenv("NEWAPI_SSO_SCOPES"),
 	}))
 
 	srv := &http.Server{

--- a/platform/newapi/internal/handler/sso_init.go
+++ b/platform/newapi/internal/handler/sso_init.go
@@ -21,15 +21,37 @@
 // So the only mechanism that respects every constraint is a SAME-ORIGIN init
 // page that runs NewAPI's own init sequence: (1) fetch /api/oauth/state →
 // state + session cookie (same-origin, so the cookie lands on
-// newapi.<fqdn>), (2) read the custom OAuth provider from /api/status,
-// (3) redirect to the Keycloak authorize URL (which carries
+// newapi.<fqdn>), (2) redirect to the Keycloak authorize URL (which carries
 // kc_idp_hint=catalyst-pin → silent broker, no KC login form) with
 // redirect_uri=${origin}/oauth/<slug>&state=<state>. Keycloak returns to the
 // SPA callback /oauth/<slug>?code&state, the SPA posts /api/oauth/<slug>, the
 // session cookie is present → CSRF passes → NewAPI mints its session → the
-// owner lands in /console signed-in. The whole round-trip is proven live on
-// hw136. The bp-newapi admin-sso-seed-job's promote step (keyed on
-// user_oauth_bindings) elevates the owner to root.
+// owner lands in /console signed-in. The bp-newapi admin-sso-seed-job's
+// promote step (keyed on user_oauth_bindings) elevates the owner to root.
+//
+// ── #3374 0.1.16 (2026-06-15): why the prior page was UNRELIABLE ──────────
+// The original init page DISCOVERED the authorize endpoint + client_id at
+// runtime by reading `pj.data.custom_oauth_providers` out of GET /api/status.
+// Measured live on hw138 (dep 4b5ff7852e33fc15): NewAPI v0.13.2's /api/status
+// payload does NOT contain a `custom_oauth_providers` field AT ALL — it only
+// exposes the BUILT-IN provider flags (oidc_enabled / github_oauth / …, all
+// false on this Sovereign). So `provs` was ALWAYS [], the provider was never
+// found, the page fell through to /login, and the SPA bounced the
+// unauthenticated owner to the /setup wizard — exactly the symptom the bare
+// URL showed (even though the DB was correctly seeded: setups row present,
+// catalyst-root role=100, the `sovereign` custom_oauth_providers row enabled).
+// The runtime-discovery dependency was the whole defect.
+//
+// ROBUST FIX: stop discovering. The chart already KNOWS the authorize
+// endpoint, client_id and scopes (the bp-newapi admin-sso-seed-job seeds the
+// identical values into custom_oauth_providers). Pass them to this sidecar via
+// env (NEWAPI_SSO_AUTHORIZE_URL / NEWAPI_SSO_CLIENT_ID / NEWAPI_SSO_SCOPES) so
+// the page builds the authorize redirect DIRECTLY from data it controls. The
+// ONLY runtime call left is GET /api/oauth/state (proven to return
+// {"success":true,"data":...} + set the session cookie live on hw138), which
+// is structurally required for NewAPI's callback CSRF check and cannot be
+// elided. If the authorize URL / client_id are not configured (older overlay),
+// the page degrades to a graceful /login link instead of a broken redirect.
 //
 // This handler is mounted at `/` on the sandbox-bridge sidecar (already an
 // openova-io-globbed pod sidecar, so it satisfies kyverno harbor-proxy-pull
@@ -45,10 +67,14 @@ import (
 	"strings"
 )
 
-// ssoInitPage is the zero-click landing page. It runs NewAPI's own
-// onCustomOAuthClicked sequence for the configured provider slug. Kept
-// dependency-free (vanilla fetch + a <noscript> fallback link to the SPA
-// login) so it works in any browser and degrades safely.
+// ssoInitTemplate is the zero-click landing page. It mints NewAPI's CSRF
+// state via /api/oauth/state, then redirects to the chart-provided Keycloak
+// authorize URL — no runtime provider discovery. Kept dependency-free
+// (vanilla fetch + a <noscript> fallback link to the SPA login) so it works
+// in any browser and degrades safely. All operationally-meaningful values are
+// injected by the handler as JS string literals (html/template JS-context
+// escaped). When AuthorizeURL/ClientID are empty the script logs and falls
+// back to /login rather than building a broken redirect.
 var ssoInitTemplate = template.Must(template.New("sso-init").Parse(`<!doctype html>
 <html lang="en">
 <head>
@@ -76,35 +102,33 @@ var ssoInitTemplate = template.Must(template.New("sso-init").Parse(`<!doctype ht
 <script>
 (async function () {
   var SLUG = {{ .Slug }};
+  var AUTHORIZE_URL = {{ .AuthorizeURL }}; // KC authorize endpoint, carries ?kc_idp_hint=catalyst-pin
+  var CLIENT_ID = {{ .ClientID }};
+  var SCOPES = {{ .Scopes }};
   function fallback(){ window.location.replace("/login"); }
+  // The chart must inject the authorize URL + client_id (the bp-newapi
+  // admin-sso-seed-job seeds the identical values). Without them we cannot
+  // build a valid redirect — degrade to the SPA login rather than loop.
+  if (!AUTHORIZE_URL || !CLIENT_ID) return fallback();
   try {
     // 1. Mint the CSRF state (also sets the same-origin session cookie that
-    //    NewAPI's /api/oauth/<slug> callback checks).
+    //    NewAPI's /api/oauth/<slug> callback checks). This is the ONLY
+    //    runtime dependency and is structurally required.
     var sr = await fetch("/api/oauth/state", { credentials: "include" });
     if (!sr.ok) return fallback();
     var sj = await sr.json();
     if (!sj || !sj.success || !sj.data) return fallback();
     var state = sj.data;
-    // 2. Read the custom OAuth provider (authorize endpoint + client_id +
-    //    scopes) that the bp-newapi admin-sso-seed-job seeded.
-    var pr = await fetch("/api/status", { credentials: "include" });
-    if (!pr.ok) return fallback();
-    var pj = await pr.json();
-    var provs = (pj && pj.data && pj.data.custom_oauth_providers) || [];
-    var p = null;
-    for (var i = 0; i < provs.length; i++) {
-      if (provs[i].slug === SLUG) { p = provs[i]; break; }
-    }
-    if (!p && provs.length === 1) p = provs[0];
-    if (!p || !p.authorization_endpoint || !p.client_id) return fallback();
-    // 3. Build the authorize URL EXACTLY like the SPA does
-    //    (web/src/helpers/api.js onCustomOAuthClicked) and redirect.
-    var redirectUri = window.location.origin + "/oauth/" + p.slug;
-    var base = p.authorization_endpoint; // carries ?kc_idp_hint=catalyst-pin
-    var sep = base.indexOf("?") === -1 ? "?" : "&";
-    var scope = encodeURIComponent(p.scopes || "openid profile email");
-    var url = base + sep +
-      "client_id=" + encodeURIComponent(p.client_id) +
+    // 2. Build the authorize URL EXACTLY like the SPA does
+    //    (web/src/helpers/api.js onCustomOAuthClicked: redirect_uri =
+    //    window.location.origin + "/oauth/" + slug) and redirect. The
+    //    token-exchange redirect_uri (ServerAddress + "/oauth/" + slug, seeded
+    //    to the same origin) byte-matches this per RFC-6749 §4.1.3.
+    var redirectUri = window.location.origin + "/oauth/" + SLUG;
+    var sep = AUTHORIZE_URL.indexOf("?") === -1 ? "?" : "&";
+    var scope = encodeURIComponent(SCOPES || "openid profile email groups");
+    var url = AUTHORIZE_URL + sep +
+      "client_id=" + encodeURIComponent(CLIENT_ID) +
       "&redirect_uri=" + encodeURIComponent(redirectUri) +
       "&response_type=code" +
       "&scope=" + scope +
@@ -118,13 +142,30 @@ var ssoInitTemplate = template.Must(template.New("sso-init").Parse(`<!doctype ht
 </body>
 </html>`))
 
-// SSOInitConfig carries the one operationally-meaningful knob (the OIDC
-// provider slug) so nothing is hardcoded (Inviolable Principle #4).
+// SSOInitConfig carries the operationally-meaningful knobs so nothing is
+// hardcoded (Inviolable Principle #4). Slug selects the provider callback
+// path; AuthorizeURL/ClientID/Scopes drive the deterministic redirect.
 type SSOInitConfig struct {
 	// Slug is the custom_oauth_providers.slug the bp-newapi admin-sso-seed-job
-	// seeds (default "sovereign"). The init page selects this provider from
-	// /api/status; if absent and exactly one provider exists, it uses that.
+	// seeds (default "sovereign"). It forms the SPA callback redirect_uri
+	// ${origin}/oauth/<slug>.
 	Slug string
+	// AuthorizeURL is the Keycloak authorize endpoint the bp-newapi
+	// admin-sso-seed-job seeds into custom_oauth_providers.authorization_endpoint
+	// — e.g. https://auth.<fqdn>/realms/sovereign/protocol/openid-connect/auth?kc_idp_hint=catalyst-pin.
+	// When empty the page degrades to the SPA /login link.
+	AuthorizeURL string
+	// ClientID is the Keycloak client_id (default "newapi-admin"). When empty
+	// the page degrades to the SPA /login link.
+	ClientID string
+	// Scopes is the OAuth scope string (default "openid profile email groups").
+	Scopes string
+}
+
+// jsLiteral renders s as a safe quoted JS string literal for the html/template
+// JS context (so a value containing a quote cannot break out of the literal).
+func jsLiteral(s string) template.JS {
+	return template.JS("\"" + template.JSEscapeString(s) + "\"")
 }
 
 // SSOInitHandler returns an http.HandlerFunc that serves the zero-click
@@ -135,6 +176,12 @@ func SSOInitHandler(cfg SSOInitConfig) http.HandlerFunc {
 	slug := strings.TrimSpace(cfg.Slug)
 	if slug == "" {
 		slug = "sovereign"
+	}
+	authorizeURL := strings.TrimSpace(cfg.AuthorizeURL)
+	clientID := strings.TrimSpace(cfg.ClientID)
+	scopes := strings.TrimSpace(cfg.Scopes)
+	if scopes == "" {
+		scopes = "openid profile email groups"
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet && r.Method != http.MethodHead {
@@ -151,10 +198,18 @@ func SSOInitHandler(cfg SSOInitConfig) http.HandlerFunc {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
-		// template.JS-safe: Slug is rendered via html/template into a JS
-		// string context. Pass it as a quoted JS literal.
-		_ = ssoInitTemplate.Execute(w, struct{ Slug template.JS }{
-			Slug: template.JS("\"" + template.JSEscapeString(slug) + "\""),
+		// All values are rendered via html/template into a JS string context
+		// as quoted JS literals — break-out safe.
+		_ = ssoInitTemplate.Execute(w, struct {
+			Slug         template.JS
+			AuthorizeURL template.JS
+			ClientID     template.JS
+			Scopes       template.JS
+		}{
+			Slug:         jsLiteral(slug),
+			AuthorizeURL: jsLiteral(authorizeURL),
+			ClientID:     jsLiteral(clientID),
+			Scopes:       jsLiteral(scopes),
 		})
 	}
 }

--- a/platform/newapi/internal/handler/sso_init_test.go
+++ b/platform/newapi/internal/handler/sso_init_test.go
@@ -9,8 +9,19 @@ import (
 	"testing"
 )
 
+// fullConfig is the production shape: slug + authorize URL + client_id seeded
+// by the bp-newapi admin-sso-seed-job.
+func fullConfig() SSOInitConfig {
+	return SSOInitConfig{
+		Slug:         "sovereign",
+		AuthorizeURL: "https://auth.hw138.omani.works/realms/sovereign/protocol/openid-connect/auth?kc_idp_hint=catalyst-pin",
+		ClientID:     "newapi-admin",
+		Scopes:       "openid profile email groups",
+	}
+}
+
 func TestSSOInitHandler_ServesLandingAtRoot(t *testing.T) {
-	h := SSOInitHandler(SSOInitConfig{Slug: "sovereign"})
+	h := SSOInitHandler(fullConfig())
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	h(rec, req)
@@ -22,18 +33,32 @@ func TestSSOInitHandler_ServesLandingAtRoot(t *testing.T) {
 		t.Fatalf("Content-Type = %q, want text/html", ct)
 	}
 	body := rec.Body.String()
-	// The page must run NewAPI's own init sequence: mint state, read the
-	// provider, redirect to the authorize URL.
+	// 0.1.16: the page mints state, then redirects DIRECTLY to the
+	// chart-provided authorize URL — it must NOT read provider discovery from
+	// /api/status (v0.13.2 does not expose custom_oauth_providers there).
 	for _, want := range []string{
-		"/api/oauth/state",
-		"/api/status",
-		"custom_oauth_providers",
-		"/oauth/\" + p.slug", // redirect_uri construction
+		"/api/oauth/state",  // the only runtime dependency (CSRF state + cookie)
+		`"sovereign"`,       // the seeded provider slug, embedded as a JS literal
+		`/realms/sovereign`, // the injected authorize URL is present
+		// kc_idp_hint carried through. html/template JS-escapes `=` to the
+		// unicode escape `=` inside the JS string literal; the browser
+		// decodes it back at parse time, so the runtime URL is correct. Assert
+		// the param name + value (neither is escaped) to prove it's present.
+		`kc_idp_hint`,
+		`catalyst-pin`,
+		`"newapi-admin"`,   // the injected client_id is present
+		`"/oauth/" + SLUG`, // redirect_uri construction matches the SPA
 		"window.location.replace(url)",
-		`"sovereign"`, // the seeded provider slug, embedded as a JS literal
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("landing page missing %q", want)
+		}
+	}
+	// It must NOT depend on the non-existent /api/status custom_oauth_providers
+	// field — that dependency was the #3374 0.1.16 defect.
+	for _, banned := range []string{"/api/status", "custom_oauth_providers"} {
+		if strings.Contains(body, banned) {
+			t.Errorf("landing page still references %q — the unreliable runtime-discovery path", banned)
 		}
 	}
 	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
@@ -41,13 +66,39 @@ func TestSSOInitHandler_ServesLandingAtRoot(t *testing.T) {
 	}
 }
 
-func TestSSOInitHandler_DefaultsSlug(t *testing.T) {
-	// Empty slug must default to "sovereign".
-	h := SSOInitHandler(SSOInitConfig{Slug: ""})
+func TestSSOInitHandler_DefaultsSlugAndScopes(t *testing.T) {
+	// Empty slug must default to "sovereign"; empty scopes to the full set.
+	h := SSOInitHandler(SSOInitConfig{
+		Slug:         "",
+		AuthorizeURL: "https://auth.x/realms/sovereign/protocol/openid-connect/auth",
+		ClientID:     "newapi-admin",
+		Scopes:       "",
+	})
 	rec := httptest.NewRecorder()
 	h(rec, httptest.NewRequest(http.MethodGet, "/", nil))
-	if !strings.Contains(rec.Body.String(), `"sovereign"`) {
+	body := rec.Body.String()
+	if !strings.Contains(body, `"sovereign"`) {
 		t.Errorf("empty slug did not default to \"sovereign\"")
+	}
+	if !strings.Contains(body, `"openid profile email groups"`) {
+		t.Errorf("empty scopes did not default to the full scope set")
+	}
+}
+
+func TestSSOInitHandler_DegradesWhenAuthorizeURLMissing(t *testing.T) {
+	// Without an authorize URL / client_id the page must degrade to the SPA
+	// /login link, not build a broken redirect (graceful for older overlays).
+	h := SSOInitHandler(SSOInitConfig{Slug: "sovereign"})
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	body := rec.Body.String()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET / status = %d, want 200 (still serves the page)", rec.Code)
+	}
+	// The guard `if (!AUTHORIZE_URL || !CLIENT_ID) return fallback();` must be
+	// present so a missing config degrades gracefully.
+	if !strings.Contains(body, "!AUTHORIZE_URL || !CLIENT_ID") {
+		t.Errorf("missing the graceful-degrade guard for an unset authorize URL")
 	}
 }
 
@@ -55,7 +106,7 @@ func TestSSOInitHandler_404sNonRootPath(t *testing.T) {
 	// Belt-and-braces: even though the HTTPRoute only sends the bare root
 	// here, the handler must NOT serve the landing page for any other path
 	// (it would shadow the SPA / API if the route were ever misconfigured).
-	h := SSOInitHandler(SSOInitConfig{Slug: "sovereign"})
+	h := SSOInitHandler(fullConfig())
 	for _, p := range []string{"/console", "/api/status", "/oauth/sovereign", "/assets/x.js"} {
 		rec := httptest.NewRecorder()
 		h(rec, httptest.NewRequest(http.MethodGet, p, nil))
@@ -66,7 +117,7 @@ func TestSSOInitHandler_404sNonRootPath(t *testing.T) {
 }
 
 func TestSSOInitHandler_HeadOK_PostRejected(t *testing.T) {
-	h := SSOInitHandler(SSOInitConfig{Slug: "sovereign"})
+	h := SSOInitHandler(fullConfig())
 
 	recHead := httptest.NewRecorder()
 	h(recHead, httptest.NewRequest(http.MethodHead, "/", nil))
@@ -81,13 +132,21 @@ func TestSSOInitHandler_HeadOK_PostRejected(t *testing.T) {
 	}
 }
 
-func TestSSOInitHandler_SlugIsJSEscaped(t *testing.T) {
-	// A slug with a quote must not break out of the JS string literal.
-	h := SSOInitHandler(SSOInitConfig{Slug: `ev"il`})
+func TestSSOInitHandler_ValuesAreJSEscaped(t *testing.T) {
+	// A slug / client_id with a quote must not break out of the JS string
+	// literal (XSS / break-out risk).
+	h := SSOInitHandler(SSOInitConfig{
+		Slug:         `ev"il`,
+		AuthorizeURL: `https://auth.x/realms/sovereign/auth"`,
+		ClientID:     `cli"ent`,
+	})
 	rec := httptest.NewRecorder()
 	h(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 	body := rec.Body.String()
 	if strings.Contains(body, `var SLUG = "ev"il"`) {
 		t.Errorf("slug was not JS-escaped — XSS/break-out risk: %q", body)
+	}
+	if strings.Contains(body, `var CLIENT_ID = "cli"ent"`) {
+		t.Errorf("client_id was not JS-escaped — XSS/break-out risk")
 	}
 }

--- a/platform/powerdns-admin/blueprint.yaml
+++ b/platform/powerdns-admin/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 0.1.15
+  version: 0.1.16
   card:
     title: powerdns-admin
     summary: |

--- a/platform/powerdns-admin/chart/Chart.yaml
+++ b/platform/powerdns-admin/chart/Chart.yaml
@@ -123,7 +123,22 @@ name: bp-powerdns-admin
 # next Pod picks up the OIDC env and /oidc/login 302s to KC -> owner lands on
 # /dashboard/ signed-in (verified live hw136: full Administration sidebar incl.
 # Users, signed in as emrah.baysal@openova.io).
-version: 0.1.15
+# 0.1.16 (#3374, 2026-06-15): the 0.1.15 Reloader annotation proved UNRELIABLE
+# on a fresh prov — measured live on hw138 (dep 4b5ff7852e33fc15): the
+# `secret.reloader.stakater.com/reload` annotation WAS on the Deployment and
+# bp-reloader WAS Running, yet the PDA Pod was NEVER rolled (108min old, never
+# restarted; the running env had EMPTY OIDC_OAUTH_AUTHORIZE_URL while the
+# synced `pda-sso-oidc-credentials` Secret carried the real URL) -> every
+# bare-URL /oidc/login still 500'd ("Missing authorize_url"). Reloader's
+# annotation strategy is racy on the FIRST secret CREATION (vs a rotation).
+# ROBUST FIX: add a `wait-for-oidc` initContainer that blocks the main
+# container until `pda-sso-oidc-credentials` exists AND
+# OIDC_OAUTH_AUTHORIZE_URL is non-empty, so kubelet evaluates `envFrom` only
+# after the Secret is populated -> the OIDC env is NEVER empty at first serve
+# -> /oidc/login deterministically 302s to Keycloak from t=0. The Reloader
+# annotation is KEPT for live rotations. Event-deterministic, zero-touch,
+# fresh-prov-safe. Gated on sso.oidcReadinessGate.enabled (default true).
+version: 0.1.16
 description: |
   PowerDNS-Admin (ngoduykhanh/powerdns-admin) web UI Blueprint for
   per-Sovereign PowerDNS zone + record management. Drives the

--- a/platform/powerdns-admin/chart/templates/deployment.yaml
+++ b/platform/powerdns-admin/chart/templates/deployment.yaml
@@ -63,6 +63,91 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.sso.enabled }}
+      {{- $oidcGate := .Values.sso.oidcReadinessGate | default dict }}
+      {{- /* default-true gate that RESPECTS an explicit `false`: the Helm
+         `default true <bool>` idiom wrongly coerces an explicit false back to
+         true because false is the bool zero-value. Test key presence + value
+         directly (same idiom as the newapi httproute ssoInit gate). */}}
+      {{- $oidcGateOn := or (not (hasKey $oidcGate "enabled")) $oidcGate.enabled }}
+      {{- if $oidcGateOn }}
+      initContainers:
+        # #3374 (2026-06-14) — OIDC-readiness gate. THE ROBUST FIX for the
+        # fresh-prov HTTP 500. The OIDC env (OIDC_OAUTH_AUTHORIZE_URL/_TOKEN_URL/
+        # _KEY/_SECRET …) is injected into the main container via
+        # `envFrom.secretRef: pda-sso-oidc-credentials` (optional: true), and
+        # kubelet evaluates `envFrom` EXACTLY ONCE at container creation. On a
+        # fresh prov the PDA Pod starts ~3min BEFORE bp-sso-bridge mints the
+        # Keycloak client + projects that ExternalSecret (measured live: Pod
+        # created 15:38:44Z, Secret created 15:41:41Z on hw138), so the main
+        # container boots with EMPTY OIDC_OAUTH_AUTHORIZE_URL → PDA's
+        # Setting().get() returns '' → authlib raises `Missing "authorize_url"
+        # value` (routes/index.py oidc_login) → the bare-URL zero-click 302
+        # lands on PDA's own HTTP 500, never on Keycloak.
+        #
+        # The Stakater Reloader annotation (below, kept for ROTATIONS) was the
+        # prior-only mechanism and is NOT reliable for the FIRST secret
+        # CREATION on a fresh prov — measured live on hw138 the annotation was
+        # present yet Reloader never rolled the Pod (108min old, never
+        # restarted; zero reload activity in its log) → the env stayed empty
+        # and /oidc/login 500'd the whole 108min the env was up. An
+        # init-container is event-deterministic: the main container CANNOT
+        # start until the OIDC Secret exists AND OIDC_OAUTH_AUTHORIZE_URL is
+        # populated, so `envFrom` ALWAYS sees the real values at container
+        # creation and the env is NEVER empty at first serve. Kubernetes
+        # refreshes a mounted Secret in place within ~60s of the ExternalSecret
+        # sync, so this gate clears with NO Pod restart once bp-sso-bridge
+        # publishes. Fresh-prov-safe, zero-touch. Gated on sso.enabled (a
+        # non-SSO Sovereign emits no init-container) and individually opt-out
+        # via sso.oidcReadinessGate.enabled=false.
+        #
+        # Image = the PDA image itself: it has /bin/sh + /bin/cat, and matches
+        # the SAME kyverno harbor-proxy glob (*/proxy-*/*) as the main
+        # container, so kyverno harbor-proxy-pull's anyPattern (which requires
+        # ONE allowed glob to match BOTH initContainers AND containers) passes
+        # — a curl/dockerhub image would be DENIED (the bp-guacamole jdbc-seed
+        # + bp-newapi dsn-gate lesson). Operators override via
+        # sso.oidcReadinessGate.image with any image matching the glob.
+        - name: wait-for-oidc
+          image: {{ $oidcGate.image | default (printf "%s:%s" .Values.image.repository .Values.image.tag) | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              # The OIDC Secret is projected at /oidc/OIDC_OAUTH_AUTHORIZE_URL.
+              # Wait until bp-sso-bridge's ExternalSecret has materialised a
+              # NON-EMPTY authorize URL (the key that makes authlib's
+              # register() succeed). `-s` = exists AND non-zero size.
+              TIMEOUT={{ $oidcGate.timeoutSeconds | default 600 }}
+              INTERVAL={{ $oidcGate.intervalSeconds | default 5 }}
+              echo "[oidc-gate] waiting for a non-empty OIDC_OAUTH_AUTHORIZE_URL at /oidc (budget ${TIMEOUT}s)"
+              deadline=$(( $(date +%s) + TIMEOUT ))
+              while [ "$(date +%s)" -lt "${deadline}" ]; do
+                if [ -s /oidc/OIDC_OAUTH_AUTHORIZE_URL ]; then
+                  echo "[oidc-gate] OIDC_OAUTH_AUTHORIZE_URL populated — PDA will register the OIDC provider"
+                  exit 0
+                fi
+                sleep "${INTERVAL}"
+              done
+              echo "[oidc-gate] FATAL: OIDC_OAUTH_AUTHORIZE_URL still empty after ${TIMEOUT}s — bp-sso-bridge did not project pda-sso-oidc-credentials; refusing to boot into a guaranteed /oidc/login HTTP 500" >&2
+              exit 1
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          volumeMounts:
+            - name: oidc-credentials
+              mountPath: /oidc
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+      {{- end }}
+      {{- end }}
       containers:
         - name: powerdns-admin
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -222,3 +307,18 @@ spec:
         - name: app-upload
           emptyDir:
             sizeLimit: 64Mi
+        {{- if .Values.sso.enabled }}
+        {{- $oidcGate := .Values.sso.oidcReadinessGate | default dict }}
+        {{- $oidcGateOn := or (not (hasKey $oidcGate "enabled")) $oidcGate.enabled }}
+        {{- if $oidcGateOn }}
+        # #3374: the bp-sso-bridge OIDC ExternalSecret, projected so the
+        # wait-for-oidc initContainer can block until OIDC_OAUTH_AUTHORIZE_URL
+        # is populated. optional: true so a non-SSO / pre-sync render still
+        # mounts (the gate then polls until the key appears). Same Secret the
+        # main container reads via envFrom.
+        - name: oidc-credentials
+          secret:
+            secretName: pda-sso-oidc-credentials
+            optional: true
+        {{- end }}
+        {{- end }}

--- a/platform/powerdns-admin/chart/values.yaml
+++ b/platform/powerdns-admin/chart/values.yaml
@@ -224,6 +224,26 @@ sso:
   # exchange; see the loop forensics in templates/httproute.yaml).
   bareURL:
     enabled: true
+  # ── OIDC-readiness gate (#3374, 0.1.16) ────────────────────────────
+  # An initContainer that blocks the main PDA container from starting until
+  # the bp-sso-bridge `pda-sso-oidc-credentials` ExternalSecret exists AND
+  # OIDC_OAUTH_AUTHORIZE_URL is non-empty. This is the ROBUST replacement for
+  # relying on Stakater Reloader to roll the Pod after the Secret syncs:
+  # measured live on hw138 the Reloader annotation was present yet the Pod
+  # was never rolled (108min old), so the OIDC env stayed empty and
+  # /oidc/login HTTP-500'd the whole time. With the gate, `envFrom` always
+  # sees the populated Secret at container creation — the env is NEVER empty
+  # at first serve. See templates/deployment.yaml for the full forensics.
+  oidcReadinessGate:
+    enabled: true
+    # Defaults to the PDA image (has /bin/sh + matches the kyverno harbor
+    # proxy glob). Override only if a smaller glob-compliant image is wanted.
+    image: ""
+    # Phase-1 budget for bp-sso-bridge to project the OIDC Secret. The
+    # sso-bridge client-mint + ExternalSecret sync is a few minutes after the
+    # PDA Pod schedules on a fresh prov; 600s leaves generous headroom.
+    timeoutSeconds: 600
+    intervalSeconds: 5
 
 # Misc PDA settings.
 config:


### PR DESCRIPTION
Refs #3374

Two SSO apps failed zero-click sign-in on the **LIVE fresh prov hw138** even though prior "fixes" already shipped on main — proving those fixes were NOT reliable from t=0. Root-caused both LIVE with kubectl evidence; fixed at **SOURCE** (charts), no hand-patching the live env.

## Defect 1 — pdns-admin HTTP 500 (`bp-powerdns-admin` 0.1.15 → 0.1.16)

**Live root cause (the empty-OIDC-env proof, hw138 dep `4b5ff7852e33fc15`):**
- The running PDA Pod env had **EMPTY** `OIDC_OAUTH_AUTHORIZE_URL` while the synced `pda-sso-oidc-credentials` Secret carried the real URL (`.../realms/sovereign/protocol/openid-connect/auth?kc_idp_hint=catalyst-pin`).
- Timeline: Pod created `15:38:44Z`, Secret created `15:41:41Z` (~3min later). The OIDC env is injected via `envFrom.secretRef … optional:true`, which kubelet evaluates **only at container creation** → the Pod booted with no `authorize_url` → authlib raises `Missing "authorize_url"` → bare-URL `/oidc/login` 302 lands on PDA's own HTTP 500.
- The 0.1.15 **Stakater Reloader** annotation WAS present and `bp-reloader` WAS Running, yet the Pod was **NEVER rolled** (108min old, never restarted; zero reload activity in its log). Reloader's annotation strategy is racy on the FIRST secret *creation* (vs a rotation), so the env stayed empty the whole time.

**At-source fix:** a `wait-for-oidc` **initContainer** blocks the main container until `pda-sso-oidc-credentials` exists AND `OIDC_OAUTH_AUTHORIZE_URL` is non-empty → `envFrom` ALWAYS sees the populated Secret at container creation → the OIDC env is **never empty at first serve** and `/oidc/login` deterministically 302s to Keycloak from t=0. Event-deterministic, zero-touch, fresh-prov-safe. Reloader annotation KEPT for live rotations. Image = the PDA image itself (has `/bin/sh`, matches the SAME kyverno harbor-proxy glob `*/proxy-*/*` as the main container; identical securityContext to the known-passing main container). Gated `sso.oidcReadinessGate.enabled` (default true).

## Defect 2 — newapi `/setup` (`bp-newapi` 1.4.88 → 1.4.89 + `sso_init.go` 0.1.16)

**Live root cause (the unseeded-DB hypothesis was WRONG — the DB IS seeded):**
- `setups` row present → `/api/status` `setup:false`; `catalyst-root` `role=100`; the `sovereign` `custom_oauth_providers` row enabled with the exact authorize endpoint + `client_id=newapi-admin`; `ServerAddress` set.
- The defect is the zero-click bridge init page: it **discovered** the authorize endpoint + client_id at runtime from `pj.data.custom_oauth_providers` in `GET /api/status` — but **NewAPI v0.13.2's `/api/status` payload has NO `custom_oauth_providers` field at all** (proven via a full key dump). So `provs` was always `[]`, the page fell through to `/login`, and the SPA bounced the unauthenticated owner to the `/setup` wizard — the exact symptom. The runtime-discovery dependency was the whole defect; the prior "verified live" claim never exercised this path on a fresh prov.

**At-source fix:** stop discovering. The chart injects `NEWAPI_SSO_AUTHORIZE_URL` / `NEWAPI_SSO_CLIENT_ID` / `NEWAPI_SSO_SCOPES` (the **identical** values the `admin-sso-seed-job` seeds — confirmed byte-equal against the LIVE seeded row) so the init page builds the authorize redirect **directly**. The only runtime call left is `GET /api/oauth/state` (proven live to mint state + set the session cookie), structurally required for NewAPI's callback CSRF. The `redirect_uri` `${origin}/oauth/sovereign` matches the KC `newapi-admin` client's registered `redirectUris`. If the authorize URL/client_id are unset the page degrades to the SPA `/login` link.

## Confidence each lands zero-click signed-in admin on the NEXT fresh prov

- **pdns-admin — high.** The failure mode was purely an ordering race (empty `envFrom`). The initContainer removes the race deterministically: the main container provably cannot start with an empty `OIDC_OAUTH_AUTHORIZE_URL`. The prior fix was unreliable because Reloader's annotation strategy does not reliably trigger on the first secret *creation* (measured: annotation present, Pod never rolled).
- **newapi — high.** The injected authorize URL + client_id are byte-identical to the LIVE seeded provider row that already validates against Keycloak, and the only remaining runtime call (`/api/oauth/state`) is proven working live. The prior fix was unreliable because it read `/api/status.custom_oauth_providers`, a field v0.13.2 never emits → guaranteed fallback to `/login` → `/setup`.

## Versioning / release flow

- Lockstep-bumped **Chart.yaml + blueprint.yaml** for both Blueprints (the source-of-truth versions).
- newapi: the bridge **image tag** + a further chart patch bump are auto-committed by `build-bp-newapi-sandbox-bridge.yaml` on merge (push to `internal/handler/**`) — the slot would otherwise carry the new env vars but the OLD `7ae2285` sidecar binary.
- bootstrap-kit **slot pins** are auto-bumped by `blueprint-release.yaml` post-publish (a slot cannot pin to an unpublished OCI version without wedging Flux — this is the repo's established deploy-bot convention).

## Validation

- `helm template` + `helm lint` clean for both charts (gate on/off paths verified; YAML parses).
- Go handler unit tests pass, incl. a test asserting the page no longer references `/api/status` or `custom_oauth_providers`, plus a graceful-degrade test.
- `gofmt` clean; catalog-seed lockstep guard PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)