### PR TITLE
fix(catalyst-api): /apps grid projects bootstrap-HR shareable instances as Contexts cards (Refs #3370 #3537)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/sovereign.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign.go
@@ -630,6 +630,13 @@ func (h *Handler) HandleSovereignApps(w http.ResponseWriter, r *http.Request) {
 	// CR (spec.helmRelease) are suppressed so one running instance is
 	// exactly one card.
 	var appCRs []unstructured.Unstructured
+	// #3370 — the full HelmRelease list is retained so bootstrap-kit
+	// shareable instances (shared-pg / -b / -c on a zero-touch prov, which
+	// have NO companion Application CR) can ALSO project as instance cards
+	// below. Mirrors HandleListBlueprintInstances' bootstrapHRInstances
+	// fallback — without it, /apps shows zero instance cards on a converged
+	// prov even though /catalyst/v1/catalog/<bp>/instances renders them.
+	var hrItems []unstructured.Unstructured
 	instanceRows := []sovereignAppItem{}
 	adoptedHRs := map[string]bool{}
 	deps, depsErr := h.sovereignDepsFor()
@@ -637,6 +644,7 @@ func (h *Handler) HandleSovereignApps(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 		defer cancel()
 		if hrList, err := deps.dyn.Resource(helmReleaseGVR).Namespace("").List(ctx, metav1.ListOptions{}); err == nil {
+			hrItems = hrList.Items
 			for _, hr := range hrList.Items {
 				name := hr.GetName()
 				if helmReleaseReady(&hr) {
@@ -785,6 +793,87 @@ func (h *Handler) HandleSovereignApps(w http.ResponseWriter, r *http.Request) {
 				Topology:     topology,
 				ContextCount: contextCount,
 			})
+		}
+
+		// #3370 — project bootstrap-kit SHAREABLE HelmReleases as instance
+		// cards too. On a zero-touch converged prov the shared-pg / -b / -c
+		// instances exist ONLY as Flux HelmReleases (no companion
+		// Application CR yet — the self-registered CR materialises on the
+		// first post-bootstrap upgrade after the Application CRD lands), so
+		// the Application-CR pass above projects zero instance rows. Without
+		// this fallback /apps shows no shared-pg cards + no ⛓ Contexts badge
+		// even though /catalyst/v1/catalog/<bp>/instances already renders
+		// them (the bootstrapHRInstances fallback in HandleListBlueprintInstances).
+		// This is the GENERIC mechanism — any shareable Blueprint (postgres,
+		// valkey, kafka, seaweedfs) whose HR declares Contexts under its
+		// contextSchema valuesKey projects here with zero per-service code.
+		//
+		// Dedup: a shareable HR ADOPTED by a self-registered Application CR
+		// (adoptedHRs, keyed by spec.helmRelease.name) is already projected
+		// above — skip it so one running instance is exactly one card. We
+		// also skip when an Application-CR instance row already carries the
+		// HR's releaseName (the instance identity the self-registered CR is
+		// named after).
+		seenInstanceName := map[string]bool{}
+		for _, ir := range instanceRows {
+			seenInstanceName[strings.ToLower(ir.ID)] = true
+		}
+		for i := range hrItems {
+			hr := &hrItems[i]
+			hrName := hr.GetName()
+			if adoptedHRs[hrName] {
+				continue
+			}
+			chart, _, _ := unstructured.NestedString(hr.Object, "spec", "chart", "spec", "chart")
+			ctxSchema := h.contextSchemaFor(ctx, chart)
+			if ctxSchema == nil || ctxSchema.ValuesKey == "" {
+				// non-shareable chart → not an instance card (it stays a
+				// regular installed/bootstrap row below).
+				continue
+			}
+			// Instance identity = spec.releaseName (the Helm release IS the
+			// instance — shared-pg). Fall back to the HR name with bp-
+			// stripped (Flux default: release name = HR name).
+			instName, _, _ := unstructured.NestedString(hr.Object, "spec", "releaseName")
+			if instName == "" {
+				instName = strings.TrimPrefix(hrName, "bp-")
+			}
+			if seenInstanceName[strings.ToLower(instName)] {
+				continue
+			}
+			seenInstanceName[strings.ToLower(instName)] = true
+			bpFull := chart
+			if !strings.HasPrefix(bpFull, "bp-") {
+				bpFull = "bp-" + bpFull
+			}
+			slug := strings.TrimPrefix(bpFull, "bp-")
+			values, _, _ := unstructured.NestedMap(hr.Object, "spec", "values")
+			contextCount := 0
+			if entries, ok := values[ctxSchema.ValuesKey].([]interface{}); ok {
+				contextCount = len(entries)
+			}
+			status := "installing"
+			if helmReleaseReady(hr) {
+				status = "installed"
+			}
+			instanceRows = append(instanceRows, sovereignAppItem{
+				ID:           instName,
+				Slug:         slug,
+				Title:        instName,
+				Status:       status,
+				BootstrapKit: true,
+				Environment:  resolveAppEnvironment(envBySlug, instName),
+				ExternalURL:  urlByHRName[hrName],
+				Instance:     true,
+				Blueprint:    bpFull,
+				Topology:     readTopologyFromValues(values),
+				ContextCount: contextCount,
+			})
+			// Suppress the bootstrap SLOT row for this HR below — it is now
+			// represented by its instance card (one physical instance = one
+			// card). The slot row keys off the HR's catalog id (bp-<slug>),
+			// which is the HR name for bootstrap-kit installs.
+			adoptedHRs[hrName] = true
 		}
 	}
 

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_test.go
@@ -377,6 +377,95 @@ func TestSovereignApps_EnvironmentChipFromApplicationCR(t *testing.T) {
 	}
 }
 
+// makeShareableHR builds a bootstrap-kit HelmRelease for a SHAREABLE
+// blueprint (e.g. bp-postgres) with a spec.releaseName (the instance
+// identity) and spec.values.databases[] (the declared Contexts). Mirrors
+// the shape Flux installs on a zero-touch prov: the shared-pg / -b / -c
+// HRs that have NO companion Application CR. Used by
+// TestSovereignApps_BootstrapHRShareableInstanceCards (#3370 #3537).
+func makeShareableHR(hrName, releaseName string, ready string, dbs []map[string]interface{}) *unstructured.Unstructured {
+	u := makeHR(hrName, "flux-system", ready)
+	_ = unstructured.SetNestedField(u.Object, "bp-postgres", "spec", "chart", "spec", "chart")
+	_ = unstructured.SetNestedField(u.Object, releaseName, "spec", "releaseName")
+	dbAny := make([]interface{}, len(dbs))
+	for i, d := range dbs {
+		dbAny[i] = d
+	}
+	_ = unstructured.SetNestedSlice(u.Object, dbAny, "spec", "values", "databases")
+	return u
+}
+
+// TestSovereignApps_BootstrapHRShareableInstanceCards is the #3537
+// regression: on a zero-touch converged prov the shared-pg / -b / -c
+// instances exist ONLY as bootstrap Flux HelmReleases (0 Application
+// CRs). The /api/v1/sovereign/apps handler must still project them as
+// instance:true cards WITH the ⛓ Contexts count — the exact gap the
+// founder hit live on hw138 (instance rows = 0, contextCount = 0) while
+// /catalyst/v1/catalog/postgres/instances correctly rendered them.
+func TestSovereignApps_BootstrapHRShareableInstanceCards(t *testing.T) {
+	// THREE shareable HRs, ZERO Application CRs — the hw138 shape.
+	dynObjs := []runtime.Object{
+		makeShareableHR("bp-postgres-shared", "shared-pg", "True", []map[string]interface{}{
+			{"name": "registry", "owner": "harbor", "consumer": map[string]interface{}{"blueprint": "bp-harbor"}},
+			{"name": "gitea", "owner": "gitea", "consumer": map[string]interface{}{"blueprint": "bp-gitea"}},
+			{"name": "keycloak", "owner": "keycloak", "consumer": map[string]interface{}{"blueprint": "bp-keycloak"}},
+		}),
+		makeShareableHR("bp-postgres-shared-c", "shared-pg-c", "True", []map[string]interface{}{
+			{"name": "newapi", "owner": "newapi"},
+			{"name": "openova_flow", "owner": "openova-flow"},
+		}),
+		// A non-shareable bootstrap HR must NOT become an instance card.
+		makeHR("bp-cilium", "flux-system", "True"),
+	}
+	h := newSovereignHandler(t, nil, dynObjs)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereign/apps", nil)
+	w := httptest.NewRecorder()
+	h.HandleSovereignApps(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%s", w.Code, w.Body.String())
+	}
+	var got sovereignAppsResponse
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	byID := map[string]sovereignAppItem{}
+	for _, a := range got.Apps {
+		byID[a.ID] = a
+	}
+
+	// shared-pg → instance card with 3 Contexts.
+	sp, ok := byID["shared-pg"]
+	if !ok {
+		t.Fatalf("instance card for HR shared-pg missing — bootstrap shareable HR not projected (the #3537 gap)")
+	}
+	if !sp.Instance {
+		t.Errorf("shared-pg row should be marked instance=true")
+	}
+	if sp.ContextCount != 3 {
+		t.Errorf("shared-pg ContextCount = %d; want 3 (databases[])", sp.ContextCount)
+	}
+	if sp.Blueprint != "bp-postgres" {
+		t.Errorf("shared-pg Blueprint = %q; want bp-postgres", sp.Blueprint)
+	}
+	if sp.Status != "installed" {
+		t.Errorf("shared-pg Status = %q; want installed (HR Ready=True)", sp.Status)
+	}
+
+	// shared-pg-c → instance card with 2 Contexts.
+	spc, ok := byID["shared-pg-c"]
+	if !ok {
+		t.Fatalf("instance card for HR shared-pg-c missing")
+	}
+	if spc.ContextCount != 2 {
+		t.Errorf("shared-pg-c ContextCount = %d; want 2", spc.ContextCount)
+	}
+
+	// The non-shareable bp-cilium HR must NOT be an instance card.
+	if c, ok := byID["cilium"]; ok && c.Instance {
+		t.Errorf("non-shareable bp-cilium must not project an instance card")
+	}
+}
+
 // TestResolveAppEnvironment_FallbackOrder unit-tests the helper in
 // isolation so the fallback semantics are explicit.
 func TestResolveAppEnvironment_FallbackOrder(t *testing.T) {


### PR DESCRIPTION
## What

`HandleSovereignApps` (`GET /api/v1/sovereign/apps` — the `/apps` Deployments grid) projected `instance:true` cards ONLY from Application CRs. On a zero-touch converged prov the shared-pg / -b / -c instances exist ONLY as bootstrap Flux HelmReleases (no companion Application CR yet — the self-registered CR materialises on the first post-bootstrap upgrade after the Application CRD lands), so `/apps` showed zero shared-pg instance cards and zero Contexts badges even though `/catalyst/v1/catalog/<bp>/instances` rendered them via the `bootstrapHRInstances` fallback in `HandleListBlueprintInstances`.

This closes the founder's original "no multiple cards per pgsql database" catch on the `/apps` grid. The per-instance Contexts tabs + catalog instances already render correctly; this is the `/apps`-grid projection that was missing.

## How

Mirror `bootstrapHRInstances` into `HandleSovereignApps`: after the Application-CR pass, project every bootstrap HelmRelease whose chart is a SHAREABLE blueprint (declares a `contextSchema`) as an `instance:true` card, with `ContextCount` from the HR's `spec.values[valuesKey]` and the instance identity = `spec.releaseName`. Dedup against adopted HRs (self-registered Application CRs) and against Application-CR instance rows so one running instance is exactly one card; suppress the bootstrap slot row for a projected HR. Generic over the `contextSchema` declaration — any shareable Blueprint (postgres, valkey, kafka, seaweedfs) works with zero per-service code.

## Tests

Adds `TestSovereignApps_BootstrapHRShareableInstanceCards`: 3 shareable HRs + 0 Application CRs (the hw138 shape) → `shared-pg` / `shared-pg-c` project as `instance:true` cards with `ContextCount` 3 / 2; a non-shareable `bp-cilium` HR does not. Full handler suite green.

Cherry-picked from `5f0d89db0` (was based on stale main) onto fresh `origin/main`; clean cherry-pick, no conflicts.

Refs #3370 #3537

🤖 Generated with [Claude Code](https://claude.com/claude-code)