### PR TITLE
fix(bp-newapi): seed rollout-restarts NewAPI so the running pod loads the seeded SSO provider — 1.4.91 (Refs #3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -240,7 +240,11 @@ spec:
       # auto-bumps this pin further (-> 1.4.90) when it rebuilds the bridge
       # image on merge, so the slot carries BOTH the env vars AND the new
       # sidecar binary that reads them.
-      version: 1.4.90
+      # 1.4.91 (#3374, 2026-06-15): seed now rollout-restarts NewAPI after the
+      # custom-provider upsert so the running pod actually loads the provider
+      # (boot-only registry) — fixes the /api/oauth/sovereign "Unknown OAuth
+      # provider" callback failure that blocked zero-click SSO on fresh provs.
+      version: 1.4.91
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.90
+  version: 1.4.91
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,35 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.91 (#3374, 2026-06-15): newapi SSO callback REAL root-cause fix — the
+# running NewAPI pod never loaded the seeded custom OAuth provider. After
+# 1.4.79+ correctly seeded the `sovereign` custom_oauth_providers row (enabled,
+# client_id/secret/endpoints all present) AND the bare-URL zero-click init page
+# (sandbox-bridge 0.1.16) correctly redirected to Keycloak, the in-app callback
+# `/api/oauth/sovereign` STILL hard-failed `{"message":"Unknown OAuth provider"}`
+# → SSO never completed → owner bounced to /login → /setup (measured live hw139
+# dep c89aa7059556b342 2026-06-15). ROOT CAUSE: NewAPI loads custom OAuth
+# providers into its in-memory registry ONLY at boot (LoadCustomProviders /
+# oauth/registry.go); its 60s SYNC_FREQUENCY loop re-syncs ONLY `options` +
+# `channels`, NEVER `custom_oauth_providers` (pod log: "Loaded 0 custom OAuth
+# providers", then only "syncing options"/"syncing channels" forever). Because
+# admin-sso-seed-job runs as a Helm post-install/post-upgrade HOOK, it INSERTs
+# the provider row ~2s AFTER the NewAPI Deployment is already up (live: pod
+# started 18:51:56, row created 18:51:58, restartCount=0) → the process never
+# sees it. (The earlier `oidc_enabled=false` in /api/status is a RED HERRING —
+# that flag is NewAPI's BUILT-IN OIDC, which this Sovereign does not use; the
+# custom provider has no global enabled option, only its per-row `enabled`.)
+# FIX: admin-sso-seed-job.yaml seed.sh adds reload_newapi_provider() — after the
+# provider upsert it PATCHes the NewAPI Deployment's pod-template
+# `kubectl.kubernetes.io/restartedAt` (a rollout-restart, re-running
+# LoadCustomProviders → "Loaded 1 custom OAuth providers"). IDEMPOTENT: it
+# records a hash of the provider's material config in the Deployment annotation
+# `catalyst.openova.io/newapi-provider-reload-hash` and restarts ONLY when that
+# hash is absent/changed (no restart loop; the per-minute promote CronJob never
+# calls it). Mechanism: python3 (present in the postgres seed image) + the
+# mounted SA token; new RBAC grants get+patch on EXACTLY the NewAPI deployment.
+# Proven live on hw139: post-restart `/api/oauth/sovereign` reaches token-
+# exchange instead of "Unknown OAuth provider". Lockstep: 80-newapi.yaml pin →
+# 1.4.91. Refs #3374.
 # 1.4.79 (#3374, 2026-06-14): SSO token-exchange redirect_uri fix. After
 # 1.4.78 booted newapi on Postgres + loaded the sovereign OIDC provider, the
 # in-app "Continue with OpenOva SSO" round-tripped Keycloak but the back-channel
@@ -594,7 +624,7 @@ name: bp-newapi
 # URL/client_id are unset the page degrades to the SPA /login link. The bridge
 # IMAGE TAG + a further chart patch bump are auto-committed by
 # build-bp-newapi-sandbox-bridge.yaml on merge (push to internal/handler/**).
-version: 1.4.90
+version: 1.4.91
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/admin-sso-seed-job.yaml
+++ b/platform/newapi/chart/templates/admin-sso-seed-job.yaml
@@ -59,6 +59,12 @@ nothing.
 {{- $cnpgSecretName := printf "%s-app" $clusterName -}}
 {{- $jobName := include "bp-newapi.adminSeedJobName" . -}}
 {{- $cronName := include "bp-newapi.adminPromoteCronName" . -}}
+{{- /* #3374: the NewAPI Deployment the seed rollout-restarts so the running
+   pod reloads custom_oauth_providers from the DB (boot-only registry). */ -}}
+{{- $deployName := include "bp-newapi.fullname" . -}}
+{{- /* #3374: Deployment annotation recording the provider-config hash the
+   running NewAPI was last restarted for — makes the reload idempotent. */ -}}
+{{- $reloadHashAnno := "catalyst.openova.io/newapi-provider-reload-hash" -}}
 {{- $pgImage := .Values.cnpg.cluster.imageName | default "harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4" -}}
 {{- $fqdn := .Values.sovereignFQDN -}}
 {{- $clientId := .Values.auth.adminUI.keycloak.clientId | default "newapi-admin" -}}
@@ -112,6 +118,21 @@ rules:
       - {{ $cnpgSecretName | quote }}
       - {{ $oidcSecretName | quote }}
     verbs: ["get"]
+  # #3374 (2026-06-15) — provider-reload rollout-restart. After the seed INSERTs
+  # the custom_oauth_providers row, the running NewAPI pod must reload it: NewAPI
+  # loads custom OAuth providers into its in-memory registry ONLY at boot
+  # (LoadCustomProviders / GetEnabledCustomProviders); the 60s SYNC_FREQUENCY
+  # loop re-syncs ONLY options + channels, NEVER custom providers (proven live
+  # hw139, boot log "Loaded 0 custom OAuth providers" while the DB row was
+  # inserted 2s after the pod started → /api/oauth/sovereign returned "Unknown
+  # OAuth provider" → SSO callback dies → owner bounced to /login → /setup). The
+  # seed patches the NewAPI Deployment (standard kubectl.kubernetes.io/restartedAt
+  # annotation) to force a reload. Scoped get+patch on EXACTLY the NewAPI deploy.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames:
+      - {{ $deployName | quote }}
+    verbs: ["get", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -210,6 +231,58 @@ data:
               )
             RETURNING id;" | wc -l | tr -d ' ')"
       echo "[admin-seed] promoted ${n} SSO user(s) to root (oidc_id OR {{ $providerSlug }} binding)"
+    }
+    reload_newapi_provider() {
+      # #3374 (2026-06-15) — make the RUNNING NewAPI pod pick up the
+      # `{{ $providerSlug }}` custom_oauth_providers row this seed just wrote.
+      #
+      # ROOT CAUSE (measured live on hw139, dep c89aa7059556b342): NewAPI loads
+      # custom OAuth providers into an in-memory registry ONLY at boot
+      # (LoadCustomProviders; GetEnabledCustomProviders reads that map). The 60s
+      # SYNC_FREQUENCY loop re-syncs ONLY `options` + `channels` from the DB —
+      # NEVER `custom_oauth_providers` (confirmed in the pod log: repeated
+      # "syncing options"/"syncing channels", no custom-provider sync; upstream
+      # oauth/registry.go has no periodic reload). Because this seed runs as a
+      # Helm post-install/post-upgrade hook, it INSERTs the provider row AFTER
+      # the NewAPI Deployment is already up (live: pod started 18:51:56, row
+      # created 18:51:58, restartCount=0) — so the process boots with "Loaded 0
+      # custom OAuth providers", /api/oauth/{{ $providerSlug }} returns
+      # "Unknown OAuth provider", the SSO callback dies and the owner bounces to
+      # /login → /setup. A rollout-restart re-runs LoadCustomProviders → "Loaded
+      # 1 custom OAuth providers" and the callback works (proven live).
+      #
+      # We trigger the restart by patching the Deployment's pod-template
+      # `kubectl.kubernetes.io/restartedAt` (exactly what `kubectl rollout
+      # restart` does). IDEMPOTENT across reconciles: we record a hash of the
+      # provider's material config in the Deployment's top-level annotation
+      # `{{ $reloadHashAnno }}` and restart ONLY when that hash is absent or
+      # changed — so a re-run with no provider change is a no-op (no restart
+      # loop; the per-minute promote CronJob never calls this). All via the
+      # mounted ServiceAccount token (python3 is present in the postgres image;
+      # curl/wget are not, and an HTTP probe would fight the NetworkPolicy).
+      #
+      # Hash the live provider config (enabled+client_id+secret+endpoints). If
+      # the row is somehow absent (client_secret was not yet published when the
+      # provider INSERT was deferred), skip — the next reconcile reloads.
+      PROVIDER_HASH="$($PSQL -c "SELECT md5(string_agg(
+            coalesce(enabled::text,'')||'|'||coalesce(client_id,'')||'|'||
+            coalesce(client_secret,'')||'|'||coalesce(authorization_endpoint,'')||'|'||
+            coalesce(token_endpoint,'')||'|'||coalesce(user_info_endpoint,''), ''))
+          FROM custom_oauth_providers WHERE slug = '{{ $providerSlug }}';" 2>/dev/null | tr -d ' ')"
+      if [ -z "${PROVIDER_HASH}" ]; then
+        echo "[admin-seed] reload: provider {{ $providerSlug }} not present yet; skipping restart (next reconcile retries)"
+        return 0
+      fi
+      # Hand off to the dedicated reload script (its own ConfigMap key, mounted
+      # at /scripts/reload.py — kept a separate file so the Python lives in a
+      # clean block scalar, not nested in this shell heredoc). python3 ships in
+      # the postgres image; the mounted ServiceAccount token authenticates the
+      # k8s API call. Best-effort: a reload hiccup never fails the seed.
+      NEWAPI_DEPLOY_NAME='{{ $deployName }}' \
+      NEWAPI_RELOAD_ANNO='{{ $reloadHashAnno }}' \
+      NEWAPI_PROVIDER_HASH="${PROVIDER_HASH}" \
+        python3 /scripts/reload.py || \
+        echo "[admin-seed] reload: python step exited non-zero (best-effort; provider still seeded)"
     }
   seed.sh: |
     . /scripts/common.sh
@@ -312,11 +385,75 @@ data:
 
     # (d) promote anyone already signed in (re-run catch-up).
     promote_oidc_users
+
+    # (e) #3374 — reload the running NewAPI so it actually SEES the provider
+    #     row just written. NewAPI's custom-provider registry is boot-only and
+    #     the 60s sync loop never re-reads custom_oauth_providers, so a Helm
+    #     post-install/upgrade DB INSERT is invisible to the live pod until a
+    #     rollout-restart. Idempotent (hash-gated) — only restarts on a genuine
+    #     provider config change. Without this the bare URL completes the KC
+    #     authorize but the /api/oauth/{{ $providerSlug }} callback hard-fails
+    #     "Unknown OAuth provider" and the owner never lands signed-in.
+    reload_newapi_provider
     echo "[admin-seed] done."
   promote.sh: |
     . /scripts/common.sh
     wait_for_users_table
     promote_oidc_users
+  reload.py: |
+    # #3374 (2026-06-15) — rollout-restart NewAPI so the running pod reloads the
+    # seeded custom OAuth provider (boot-only registry; the 60s sync loop never
+    # re-reads custom_oauth_providers). Idempotent: records a hash of the
+    # provider config in the Deployment annotation and restarts ONLY when that
+    # hash is absent/changed. Uses only the stdlib + the mounted SA token.
+    import json, os, ssl, urllib.request, urllib.error, datetime
+    sa = "/var/run/secrets/kubernetes.io/serviceaccount"
+    tok = open(sa + "/token").read().strip()
+    ns = open(sa + "/namespace").read().strip()
+    ca = sa + "/ca.crt"
+    host = os.environ["KUBERNETES_SERVICE_HOST"]
+    port = os.environ.get("KUBERNETES_SERVICE_PORT_HTTPS") or os.environ.get("KUBERNETES_SERVICE_PORT") or "443"
+    name = os.environ["NEWAPI_DEPLOY_NAME"]
+    anno = os.environ["NEWAPI_RELOAD_ANNO"]
+    want = os.environ["NEWAPI_PROVIDER_HASH"]
+    base = "https://%s:%s/apis/apps/v1/namespaces/%s/deployments/%s" % (host, port, ns, name)
+    ctx = ssl.create_default_context(cafile=ca)
+
+
+    def call(method, url, body=None, ctype="application/json"):
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method, headers={
+            "Authorization": "Bearer " + tok,
+            "Accept": "application/json",
+            "Content-Type": ctype,
+        })
+        try:
+            with urllib.request.urlopen(req, timeout=20, context=ctx) as r:
+                return r.status, r.read().decode()
+        except urllib.error.HTTPError as e:
+            return e.code, e.read().decode()
+
+
+    st, body = call("GET", base)
+    if st != 200:
+        print("[admin-seed] reload: GET deployment failed (%s): %s" % (st, body[:200]))
+        raise SystemExit(0)
+    cur = (json.loads(body).get("metadata", {}).get("annotations", {}) or {}).get(anno)
+    if cur == want:
+        print("[admin-seed] reload: NewAPI already restarted for provider hash %s -- no-op" % want[:12])
+        raise SystemExit(0)
+    nowts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    patch = {
+        "metadata": {"annotations": {anno: want}},
+        "spec": {"template": {"metadata": {"annotations": {
+            "kubectl.kubernetes.io/restartedAt": nowts,
+        }}}},
+    }
+    st2, body2 = call("PATCH", base, patch, ctype="application/strategic-merge-patch+json")
+    if st2 == 200:
+        print("[admin-seed] reload: rollout-restart triggered for %s (provider hash %s -> %s)" % (name, (cur or "none")[:12], want[:12]))
+    else:
+        print("[admin-seed] reload: PATCH failed (%s): %s" % (st2, body2[:200]))
 ---
 apiVersion: batch/v1
 kind: Job


### PR DESCRIPTION
## The real root cause (newapi SSO still failed on fresh prov hw139)

The prior bp-newapi 1.4.90 / sandbox-bridge 0.1.16 fix did NOT solve newapi SSO. Forensics on the live fresh prov **hw139.omani.works** (dep `c89aa7059556b342`):

- The bare URL `/` **already serves the zero-click SSO-init page** correctly (spinner + correct `AUTHORIZE_URL`/`CLIENT_ID`/`SLUG`). The 0.1.16 env-inject fix IS live.
- `/api/setup` → `{status:false, root_init:true}`; the DB is correctly seeded — `setups` row present, `catalyst-root` role=100, `custom_oauth_providers` slug=`sovereign` **enabled=t** with correct client_id/secret/endpoints.
- The `oidc_enabled=false` in `/api/status` is a **RED HERRING** — that flag is NewAPI's *built-in* OIDC (`oidc.enabled` option), which this Sovereign does NOT use. It uses a *custom* OAuth provider, which has **no global enabled option** (only its per-row `enabled`, which is true).
- **The actual defect:** `GET /api/oauth/sovereign` returned `{"message":"Unknown OAuth provider"}`. NewAPI boot log: `Loaded 0 custom OAuth providers`. NewAPI loads `custom_oauth_providers` into its in-memory registry **ONLY at boot** (`LoadCustomProviders` / `oauth/registry.go`); the 60s `SYNC_FREQUENCY` loop re-syncs **only** options + channels, **never** custom providers (confirmed live: repeated `syncing options`/`syncing channels`, no custom-provider sync). The `admin-sso-seed-job` runs as a Helm post-install/upgrade **hook**, so it INSERTs the provider row **~2s after** the NewAPI pod already started (pod started 18:51:56, row created 18:51:58, `restartCount=0`) → the running process never sees it → callback dies → owner bounced to `/login` → `/setup`.

## Why the prior fix missed it

The 0.1.16 sidecar fix correctly makes the bare URL redirect to Keycloak (and that part works). But the **callback** dies *inside* NewAPI because the provider isn't in the running process's memory — a layer the env-var/init-page fix never touched.

## The at-source fix (this PR)

`admin-sso-seed-job.yaml` `seed.sh` adds `reload_newapi_provider()`: after the provider upsert, it PATCHes the NewAPI Deployment's pod-template `kubectl.kubernetes.io/restartedAt` (a rollout-restart → re-runs `LoadCustomProviders` → `Loaded 1 custom OAuth providers`).

- **Idempotent / no restart loop:** records a hash of the provider's material config (enabled+client_id+secret+endpoints) in the Deployment annotation `catalyst.openova.io/newapi-provider-reload-hash`; restarts ONLY when that hash is absent/changed. The per-minute promote CronJob never calls it.
- **Mechanism:** `python3` (present in the postgres seed image) + the mounted ServiceAccount token. No new image, no extra container, no HTTP probe (avoids NetworkPolicy fragility). New RBAC grants `get`+`patch` on EXACTLY the NewAPI deployment by name.
- `reload.py` lives in its own ConfigMap key (clean block scalar).

## Live verification on hw139

- `reload.py` run 1 → `rollout-restart triggered for newapi-bp-newapi (provider hash none -> e81551230060)` (deployment gen 2→3, hash annotation set); run 2 → `NewAPI already restarted for provider hash e81551230060 -- no-op` (idempotent).
- Post-restart boot log: `Loaded custom OAuth provider: OpenOva SSO (sovereign)` → `Loaded 1 custom OAuth providers`; `/api/oauth/sovereign` now reaches token-exchange instead of `Unknown OAuth provider`.
- **End-to-end browser walk:** bare `https://newapi.hw139.omani.works/` → landed signed-in at `/console/token` as the owner (`sovereign_2`), full authenticated admin sidebar, no `/setup`, no `/login`, zero clicks. The promote CronJob then elevated the owner to **role=100 (admin)** in the DB.

## Lockstep

Chart `1.4.90` → `1.4.91`; `clusters/_template/bootstrap-kit/80-newapi.yaml` pin → `1.4.91`; `blueprint.yaml` → `1.4.91`.

Since hw139's Flux tracks `main`, merging auto-rolls 1.4.91 onto hw139 and the seed's reload step fires on the upgrade hook.

Refs #3374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)