### PR TITLE
fix(cutover): step-03 harbor-prewarm DeadlineExceeded + resume re-runs a timed-out step (Refs #3379, Refs #3526)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -462,7 +462,15 @@ spec:
       # 401'd every post-pivot clone, Step-06's rewrites never reconciled,
       # and Step-08's pivot-wait never converged (hw138 keystone catch).
       # RBAC gains secrets:create. (0.1.59 = PR #3535 Defect-A skopeo fix.)
-      version: 0.1.60
+      # 0.1.61 (#3379 + #3526, hw139 step-03 wedge): Step-03 harbor-prewarm
+      # DeadlineExceeded — ~29 serial private-image skopeo copies over
+      # throttled egress blew 1800s with only 6/29 pushed. Fix: parallelize
+      # Phase-A (PREWARM_PARALLELISM=6 concurrent copies + --retry-times 3)
+      # and raise harborPrewarmSeconds 1800→5400. Paired catalyst-api change
+      # makes the Job/watch deadline honor THIS per-step value (was capped at
+      # the global 15m) AND re-runs a DeadlineExceeded step instead of
+      # wedging on it (transient-failure delete+re-run). No step-count change.
+      version: 0.1.61
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.60
+  version: 0.1.61
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,31 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.61 (#3379 + #3526, hw139 step-03 wedge, 2026-06-15): Step-03
+# harbor-prewarm DeadlineExceeded. The ~29 multi-layer PRIVATE openova-io
+# images are skopeo-native-pushed ghcr.io→local Harbor (the ONLY working
+# route — Harbor's anonymous proxy-cache 404s these private packages,
+# #3534). They ran STRICTLY SERIAL over kom4dc's throttled egress and blew
+# the deadline with only 6/29 pushed → incomplete local Harbor →
+# post-cutover ImagePullBackOff → Step-08 deny-egress proof never ran.
+# TWO fixes here (chart side) + a paired catalyst-api change:
+#   (1) PARALLELIZE Phase-A: the copy loop now fans out PREWARM_PARALLELISM
+#       (default 6) concurrent `skopeo copy` workers (each writes its own
+#       .ok/.fail sentinel + log; the parent waits + tallies), collapsing
+#       wall-clock ~6x. Each copy also gains `--retry-times 3` so a single
+#       transient ghcr/Harbor 5xx self-heals. POSIX-clean (dash/sh/busybox
+#       -n verified): live-PID counting throttle (no `wait -n`/arrays).
+#   (2) RAISE stepTimeouts.harborPrewarmSeconds 1800 → 5400 (90m) so a
+#       worst-case slow-egress run finishes inside budget. Event-driven
+#       watch means a fast run never waits out the ceiling.
+# The deadline bump only takes effect because catalyst-api now stamps the
+# Job/watch deadline from THIS per-step value (cutover.go cutoverStepDeadline
+# → createCutoverJob + watchJobToCompletion) instead of the old global 15m
+# cap that silently bounded every long step. And catalyst-api's resume/
+# re-fire path now treats a DeadlineExceeded Failed Job as TRANSIENT
+# (delete + re-run) rather than terminal — so a timed-out step-03 no longer
+# wedges the cutover forever. No step-count change (still 11 steps); the
+# two earlier #3379 hw138 catches (--insecure-policy + real-exit-status
+# branch) stay in force.
 # 0.1.58 (#3526 Refs #3379, 2026-06-14): make Step-08 (egress-block-test)
 # pre-flight HelmRepository-pivot assertion ROBUST to Step-06's async
 # git-push window. Step-06 (helmrepository-patches) pivots the OCI
@@ -471,7 +497,7 @@ name: bp-self-sovereign-cutover
 # and wires it into GitRepository.spec.secretRef BEFORE the URL flip — same
 # credential + pattern as #3454's openova-sme-tenants GitRepository. Adds
 # `secrets: create` to the cutover-runner RBAC.
-version: 0.1.60
+version: 0.1.61
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -207,51 +207,110 @@ data:
             count=$(printf '%s\n' "${openova_images}" | grep -c . || true)
             echo "[harbor-prewarm] found ${count} unique openova-io images to native-push"
 
-            # Native push each via skopeo copy.
-            push_ok=0
-            push_fail=0
-            for upstream in ${openova_images}; do
+            # Native push each via skopeo copy, run in PARALLEL with a
+            # bounded fan-out.
+            #
+            # #3379 step-03 DeadlineExceeded (hw139, 2026-06-15): these ~29
+            # multi-layer openova-io copies ran STRICTLY SERIAL over kom4dc's
+            # throttled ghcr→Harbor egress and blew the step deadline with
+            # only 6/29 pushed → local Harbor openova-io project incomplete →
+            # post-cutover ImagePullBackOff → Step-08 deny-egress proof never
+            # ran. The bytes themselves are unavoidable (the source images are
+            # PRIVATE on ghcr, so Harbor's anonymous proxy-cache 404s them —
+            # #3534 — this authenticated skopeo push is the only working
+            # route), but the WALL-CLOCK is collapsible: copies are
+            # independent, so we run PREWARM_PARALLELISM of them at once. Each
+            # worker writes its own result sentinel (`.ok`/`.fail`) + captured
+            # log under ${cpdir}; the parent `wait`s for all, then prints each
+            # log prefix-indented and tallies from the sentinels. POSIX sh has
+            # no `wait -n`, so we cap concurrency by counting live background
+            # PIDs and pausing the launch loop until one drains.
+            #
+            # skopeo gains `--retry-times 3` so a single transient ghcr/Harbor
+            # 5xx or reset inside a copy self-heals (resumable layer fetch)
+            # instead of failing the whole image — independent of the binary-
+            # download retry above.
+            #
+            # Two earlier #3379 keystone catches (hw138, 2026-06-14) stay in
+            # force: (1) `--insecure-policy` so skopeo doesn't fatal on the
+            # missing /etc/containers/policy.json that alpine/k8s + the lework
+            # static binary omit; (2) branch on skopeo's REAL exit status
+            # (captured per-worker) rather than a piped `sed` whose status is
+            # always 0 under this `set -eu` (no pipefail) shell — the bug that
+            # made every fatal copy miscount as success.
+            : "${PREWARM_PARALLELISM:=6}"
+            cpdir="/tmp/prewarm-copies"
+            rm -rf "${cpdir}"; mkdir -p "${cpdir}"
+            echo "[harbor-prewarm] pushing ${count} image(s) with parallelism=${PREWARM_PARALLELISM}"
+
+            copy_one() {
+              up="$1"
               # Convert ghcr.io/X/Y:tag → HARBOR_HOST/X/Y:tag
               # (drop ghcr.io/ prefix, keep rest identical)
-              local_ref="${HARBOR_HOST}/${upstream#ghcr.io/}"
-              echo "[harbor-prewarm] copy ${upstream} → ${local_ref}"
-              # #3379 keystone catch (hw138, 2026-06-14): this loop was a
-              # SILENT NO-OP — it reported push_ok=N / push_fail=0 while the
-              # local Harbor openova-io project stayed EMPTY (manifest 404),
-              # so post-cutover catalyst-api ImagePullBackOff'd and the
-              # deny-egress proof (Step 08) could never run. TWO defects:
-              #   (1) skopeo aborted with `level=fatal Error loading trust
-              #       policy: open /etc/containers/policy.json: no such file
-              #       or directory` — the alpine/k8s base image + the lework
-              #       static skopeo binary ship NO default signature-trust
-              #       policy, so EVERY copy died before transferring a byte.
-              #       Fix: pass --insecure-policy (skopeo's documented
-              #       no-policy flag). No source signatures are verified here
-              #       regardless; the source is our own authenticated
-              #       ghcr.io and Harbor enforces its own dest-side trust.
-              #   (2) `skopeo copy ... 2>&1 | sed` made the `if` evaluate the
-              #       exit status of `sed` (always 0 under this `set -eu`
-              #       shell, which has no `set -o pipefail`), NOT skopeo — so
-              #       every fatal copy was miscounted as push_ok. Fix:
-              #       capture skopeo's real exit status by writing its output
-              #       to a temp log, then prefix-print the log and branch on
-              #       the true status.
+              lref="${HARBOR_HOST}/${up#ghcr.io/}"
+              # Slug for the per-image sentinel/log file names.
+              slug=$(printf '%s' "${up}" | tr -c 'A-Za-z0-9._-' '_')
               if skopeo copy \
                 --insecure-policy \
+                --retry-times 3 \
                 --src-creds="${ghcr_user}:${ghcr_pat}" \
                 --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
                 --dest-tls-verify=true \
                 --src-tls-verify=true \
-                "docker://${upstream}" "docker://${local_ref}" >/tmp/skopeo.log 2>&1; then
-                sed 's/^/  /' /tmp/skopeo.log
-                push_ok=$((push_ok+1))
-                echo "[harbor-prewarm] OK ${upstream}"
+                "docker://${up}" "docker://${lref}" >"${cpdir}/${slug}.log" 2>&1; then
+                printf '%s' "${up}" >"${cpdir}/${slug}.ok"
               else
                 rc=$?
-                sed 's/^/  /' /tmp/skopeo.log
-                push_fail=$((push_fail+1))
-                echo "[harbor-prewarm] FAIL ${upstream} (skopeo exit ${rc})"
+                printf '%s exit=%s' "${up}" "${rc}" >"${cpdir}/${slug}.fail"
               fi
+            }
+
+            # Track live worker PIDs explicitly — POSIX sh's `jobs -p` is
+            # unreliable in a non-interactive shell, so we count by polling
+            # `kill -0 <pid>` against the PIDs we launched.
+            pids=""
+            for upstream in ${openova_images}; do
+              local_ref="${HARBOR_HOST}/${upstream#ghcr.io/}"
+              echo "[harbor-prewarm] queue ${upstream} → ${local_ref}"
+              copy_one "${upstream}" &
+              pids="${pids} $!"
+              # Throttle: block launching the next copy while
+              # PREWARM_PARALLELISM workers are still alive.
+              while : ; do
+                live=0
+                newpids=""
+                for p in ${pids}; do
+                  if kill -0 "${p}" 2>/dev/null; then
+                    live=$((live+1))
+                    newpids="${newpids} ${p}"
+                  fi
+                done
+                pids="${newpids}"
+                [ "${live}" -lt "${PREWARM_PARALLELISM}" ] && break
+                sleep 2
+              done
+            done
+            # Drain the final batch.
+            wait
+
+            # Tally + surface each copy's captured log.
+            push_ok=0
+            push_fail=0
+            for f in "${cpdir}"/*.ok; do
+              [ -e "${f}" ] || continue
+              up=$(cat "${f}")
+              slug=$(basename "${f}" .ok)
+              sed 's/^/  /' "${cpdir}/${slug}.log" 2>/dev/null || true
+              push_ok=$((push_ok+1))
+              echo "[harbor-prewarm] OK ${up}"
+            done
+            for f in "${cpdir}"/*.fail; do
+              [ -e "${f}" ] || continue
+              detail=$(cat "${f}")
+              slug=$(basename "${f}" .fail)
+              sed 's/^/  /' "${cpdir}/${slug}.log" 2>/dev/null || true
+              push_fail=$((push_fail+1))
+              echo "[harbor-prewarm] FAIL ${detail}"
             done
             echo "[harbor-prewarm] Phase A complete: push_ok=${push_ok} push_fail=${push_fail}"
             if [ "${push_fail}" -gt 0 ]; then

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -555,7 +555,22 @@ gateway:
 stepTimeouts:
   giteaMirrorSeconds: 1200
   harborProjectsSeconds: 600
-  harborPrewarmSeconds: 1800
+  # #3379 step-03 DeadlineExceeded (hw139, 2026-06-15): Step-03 skopeo-
+  # native-pushes ~29 multi-layer PRIVATE openova-io images ghcr.io→local
+  # Harbor (the ONLY working route — Harbor's anonymous proxy-cache 404s
+  # these private packages, #3534). On kom4dc's throttled egress the
+  # STRICTLY-SERIAL copies blew the old 1800s and pushed only 6/29 →
+  # incomplete Harbor → post-cutover ImagePullBackOff → Step-08 deny-egress
+  # proof never ran. The template now fans the copies out
+  # (PREWARM_PARALLELISM=6, ~6x wall-clock collapse) AND this ceiling is
+  # raised to 5400s (90m) so a worst-case slow-egress run still finishes
+  # inside budget rather than re-tripping the deadline. The Job stays
+  # event-driven (catalyst-api watches to completion), so a fast run does
+  # NOT wait out the ceiling. Honored end-to-end only because catalyst-api
+  # now stamps the Job/watch deadline from THIS per-step value (cutover.go
+  # createCutoverJob / watchJobToCompletion) rather than the old global
+  # 15m cap that silently bounded every long step.
+  harborPrewarmSeconds: 5400
   fluxGitRepositoryPatchSeconds: 600
   helmRepositoryPatchesSeconds: 600
   catalystAPIEnvPatchSeconds: 600

--- a/products/catalyst/bootstrap/api/internal/handler/cutover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover.go
@@ -340,6 +340,41 @@ func cutoverStepTimeout() time.Duration {
 	return defaultCutoverStepTimeout
 }
 
+// cutoverStepDeadline returns the wall-clock budget for a single step's
+// Job — the larger of the global default (cutoverStepTimeout) and the
+// step's OWN Pod-template activeDeadlineSeconds carried in its PodSpec
+// ConfigMap (the chart's stepTimeouts.<step>Seconds value).
+//
+// #3379 step-03 (hw139, 2026-06-15): the chart ships a deliberately
+// generous per-step deadline for the heavy steps (harbor-prewarm 5400s,
+// gitea-mirror 1200s, egress-block-test 1200s) by stamping
+// `activeDeadlineSeconds` INSIDE each step's embedded PodSpec. But
+// createCutoverJob / watchJobToCompletion previously used ONLY the global
+// 15-minute cutoverStepTimeout for the Job-level deadline + the watch
+// timeout — and the Job-level activeDeadlineSeconds is authoritative over
+// the Pod-template one, so when global (900s) < per-step (e.g. 5400s) the
+// Job was silently killed with reason=DeadlineExceeded at 15 minutes no
+// matter what the chart asked for. harbor-prewarm genuinely needs the
+// longer window (29 multi-layer private-image copies over throttled
+// egress); the latent gitea-mirror/egress-block-test mismatch survived
+// only because their real runtime happened to stay under 900s.
+//
+// Taking the MAX keeps the global default as a floor (a short step still
+// gets the generous 15-minute cap; an env override of
+// CATALYST_CUTOVER_STEP_TIMEOUT still raises every step) while letting a
+// step opt INTO a longer budget via its chart value. The Job stays
+// event-driven — watchJobToCompletion returns the instant the Job reaches
+// a terminal condition — so a fast run never waits out the ceiling.
+func cutoverStepDeadline(step cutoverStep) time.Duration {
+	base := cutoverStepTimeout()
+	if step.podSpec != nil && step.podSpec.ActiveDeadlineSeconds != nil {
+		if d := time.Duration(*step.podSpec.ActiveDeadlineSeconds) * time.Second; d > base {
+			return d
+		}
+	}
+	return base
+}
+
 func cutoverDaemonSetTimeout() time.Duration {
 	if v, _ := time.ParseDuration(os.Getenv(envCutoverDaemonSetWait)); v > 0 {
 		return v
@@ -847,7 +882,12 @@ func createCutoverJob(ctx context.Context, deps *cutoverDeps, step cutoverStep, 
 	// over the activeDeadlineSeconds window).
 	backoffLimit := int32(3)
 	ttl := int32(24 * 60 * 60) // 24h GC so the Job evidence stays around for audit.
-	activeDeadline := int64(cutoverStepTimeout().Seconds())
+	// #3379: honor the step's OWN chart deadline (stepTimeouts.<step>Seconds,
+	// carried on the PodSpec) when it exceeds the global default — otherwise
+	// the Job-level cap silently kills heavy steps (harbor-prewarm) at the
+	// 15-minute global before the chart's generous budget can apply. See
+	// cutoverStepDeadline.
+	activeDeadline := int64(cutoverStepDeadline(step).Seconds())
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -903,8 +943,10 @@ func createCutoverJob(ctx context.Context, deps *cutoverDeps, step cutoverStep, 
 // or an error on watch / context failure. Uses a single Watch call
 // against the Job by name so we get an event-driven completion signal
 // rather than polling.
-func watchJobToCompletion(ctx context.Context, deps *cutoverDeps, jobName string) (batchv1.JobConditionType, error) {
-	timeout := cutoverStepTimeout()
+func watchJobToCompletion(ctx context.Context, deps *cutoverDeps, jobName string, timeout time.Duration) (batchv1.JobConditionType, error) {
+	if timeout <= 0 {
+		timeout = cutoverStepTimeout()
+	}
 	wctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -967,6 +1009,75 @@ func terminalJobCondition(job *batchv1.Job) (batchv1.JobConditionType, bool) {
 		}
 	}
 	return "", false
+}
+
+// jobFailedTransiently reports whether a terminal-Failed Job failed for a
+// TRANSIENT reason that a retry can plausibly clear — specifically the
+// activeDeadlineSeconds timeout (reason "DeadlineExceeded"), as opposed to
+// a genuine non-zero application exit (reason "BackoffLimitExceeded",
+// "PodFailurePolicy", etc.) where re-running the same idempotent PodSpec
+// would just fail the same way and an operator must intervene.
+//
+// #3379 step-03 (hw139, 2026-06-15): Step-03 harbor-prewarm blew its
+// deadline mid-copy (DeadlineExceeded) → the engine recorded the step
+// result=failed → on every re-fire findExistingTerminalJobForStep
+// re-surfaced that Failed Job and runCutoverStep refused to re-create it
+// ("operator intervention required"), so the step NEVER re-executed and
+// the cutover was permanently wedged at 03. A DeadlineExceeded is exactly
+// the kind of failure a longer budget + parallel copies (this same PR)
+// fix on the next attempt — treat it as transient so the resume/re-fire
+// path deletes the timed-out Job and re-runs the step cleanly.
+//
+// We match on the Job's terminal JobFailed condition Reason, falling back
+// to a Message substring scan for older API servers that populate only the
+// message. Anything we don't positively recognise as transient is treated
+// as a genuine failure (fail-closed: we'd rather halt for an operator than
+// loop on a real error).
+func jobFailedTransiently(job *batchv1.Job) bool {
+	if job == nil {
+		return false
+	}
+	for _, c := range job.Status.Conditions {
+		if c.Type != batchv1.JobFailed || c.Status != corev1.ConditionTrue {
+			continue
+		}
+		if c.Reason == batchv1.JobReasonDeadlineExceeded {
+			return true
+		}
+		if strings.Contains(c.Message, "DeadlineExceeded") ||
+			strings.Contains(c.Message, "exceeded active deadline") ||
+			strings.Contains(c.Message, "activeDeadlineSeconds") {
+			return true
+		}
+	}
+	return false
+}
+
+// deleteCutoverJobsForStep removes every existing Job for a step (with
+// background propagation so the Pods go too) so the engine can re-create a
+// fresh Job for an idempotent re-run. Used when a prior Job failed
+// transiently (jobFailedTransiently) — a leftover DeadlineExceeded Job
+// would otherwise be re-discovered by findExistingTerminalJobForStep and
+// re-surfaced as terminal forever. Best-effort: a delete error is logged
+// by the caller but does not by itself abort the re-run attempt (the fresh
+// Create would only fail on a true name collision, which the create path
+// already tolerates via AlreadyExists).
+func deleteCutoverJobsForStep(ctx context.Context, deps *cutoverDeps, stepName string) error {
+	jobs, err := findExistingJobsForStep(ctx, deps, stepName)
+	if err != nil {
+		return err
+	}
+	propagation := metav1.DeletePropagationBackground
+	var firstErr error
+	for i := range jobs {
+		j := &jobs[i]
+		if delErr := deps.core.BatchV1().Jobs(deps.ns).Delete(ctx, j.Name, metav1.DeleteOptions{
+			PropagationPolicy: &propagation,
+		}); delErr != nil && !apierrors.IsNotFound(delErr) && firstErr == nil {
+			firstErr = fmt.Errorf("delete prior Job %s/%s: %w", deps.ns, j.Name, delErr)
+		}
+	}
+	return firstErr
 }
 
 // ── DaemonSet ready wait ────────────────────────────────────────────────────
@@ -1152,20 +1263,63 @@ func (h *Handler) runCutoverStep(ctx context.Context, deps *cutoverDeps, step cu
 				})
 				return nil
 			}
-			// cond == batchv1.JobFailed: surface as the step's terminal
-			// failure — the engine halts at this step, identical to a
-			// freshly-failed Job. We DO NOT re-create on Failed because
-			// the chart's PodSpec is idempotent state-ensure logic and
-			// a second attempt usually fails the same way; operator
-			// intervention is required.
-			if err := patchCutoverStatus(ctx, deps, map[string]string{
-				"step." + step.stepName + ".finishedAt": finishedAt.Format(time.RFC3339),
-				"step." + step.stepName + ".result":     "failed",
-				"step." + step.stepName + ".jobName":    job.Name,
-			}); err != nil {
-				return fmt.Errorf("status patch (resume-failed): %w", err)
+			// cond == batchv1.JobFailed.
+			//
+			// #3379 (hw139): a TRANSIENT failure — the Job hit its
+			// activeDeadlineSeconds (reason DeadlineExceeded) — is NOT an
+			// operator-intervention case. The prior run simply ran out of
+			// wall-clock (e.g. step-03 harbor-prewarm's image copies over
+			// throttled egress); a re-run with the now-larger budget +
+			// parallel copies can complete. Delete the timed-out Job (so
+			// findExistingTerminalJobForStep doesn't re-surface it on the
+			// next pass) and fall through to mint a fresh Job. The step's
+			// PodSpec is idempotent state-ensure logic, so re-running is
+			// safe (already-pushed images are no-op skopeo copies).
+			if jobFailedTransiently(job) {
+				h.publishCutoverEvent(bus, cutoverEvent{
+					Time:    time.Now().UTC().Format(time.RFC3339),
+					Phase:   cutoverPhaseStepStarted,
+					Level:   "info",
+					Step:    step.stepName,
+					JobName: job.Name,
+					Message: fmt.Sprintf("step %s prior Job %s failed transiently (deadline exceeded); deleting + re-running", step.stepName, job.Name),
+				})
+				if delErr := deleteCutoverJobsForStep(ctx, deps, step.stepName); delErr != nil {
+					// Non-fatal: log via event and proceed. createCutoverJob
+					// tolerates an AlreadyExists collision; a genuinely stuck
+					// delete surfaces as the fresh watch timing out, not a
+					// silent wedge.
+					h.log.Warn("cutover: failed to delete transiently-failed Job before re-run",
+						"step", step.stepName, "job", job.Name, "err", delErr)
+				}
+				// Clear the step's durable rows so the audit trail shows a
+				// clean re-attempt and the engine doesn't treat it as
+				// already-settled. Fall through to the normal create path.
+				if err := patchCutoverStatus(ctx, deps, map[string]string{
+					"step." + step.stepName + ".result":     "",
+					"step." + step.stepName + ".startedAt":  "",
+					"step." + step.stepName + ".finishedAt": "",
+					"step." + step.stepName + ".jobName":    "",
+				}); err != nil {
+					return fmt.Errorf("status patch (transient-failed reset): %w", err)
+				}
+				// Do not return — drop out of the idempotency block and
+				// create a fresh Job below.
+			} else {
+				// Genuine failure (non-zero application exit, backoff-limit
+				// exhausted, …): surface as the step's terminal failure —
+				// the engine halts at this step. We DO NOT re-create because
+				// a second attempt of an idempotent PodSpec usually fails the
+				// same way; operator intervention is required.
+				if err := patchCutoverStatus(ctx, deps, map[string]string{
+					"step." + step.stepName + ".finishedAt": finishedAt.Format(time.RFC3339),
+					"step." + step.stepName + ".result":     "failed",
+					"step." + step.stepName + ".jobName":    job.Name,
+				}); err != nil {
+					return fmt.Errorf("status patch (resume-failed): %w", err)
+				}
+				return fmt.Errorf("Job %s/%s reported Failed condition (carried over from prior cutover attempt)", deps.ns, job.Name)
 			}
-			return fmt.Errorf("Job %s/%s reported Failed condition (carried over from prior cutover attempt)", deps.ns, job.Name)
 		}
 	}
 
@@ -1216,7 +1370,7 @@ func (h *Handler) runCutoverStep(ctx context.Context, deps *cutoverDeps, step cu
 				return err
 			}
 		}
-		cond, err := watchJobToCompletion(ctx, deps, jobOrDS)
+		cond, err := watchJobToCompletion(ctx, deps, jobOrDS, cutoverStepDeadline(step))
 		if err != nil {
 			return err
 		}
@@ -1295,18 +1449,18 @@ func (h *Handler) publishCutoverEvent(bus *cutoverBroadcaster, ev cutoverEvent) 
 //
 // Otherwise — durable state shows a cutover was in progress when this
 // process started — we:
-//   1. Reset every step whose `.result == "running"` back to `""` so the
-//      engine re-runs that step from scratch (the corresponding Job from
-//      the previous attempt may have completed, failed, or still be
-//      running; we don't trust the orphan and create a fresh Job — the
-//      step's PodSpec must be idempotent, which it is by chart design —
-//      every step's PodSpec is "ensure target state X").
-//   2. List the cutover step ConfigMaps. If any are missing (chart
-//      uninstalled mid-flight) we log and bail.
-//   3. Claim the in-process running flag (always succeeds on a fresh Pod
-//      since the broadcaster is freshly constructed).
-//   4. Spawn runCutover with a background context so an init signal or
-//      brief HTTP server hiccup doesn't cancel a multi-step resume.
+//  1. Reset every step whose `.result == "running"` back to `""` so the
+//     engine re-runs that step from scratch (the corresponding Job from
+//     the previous attempt may have completed, failed, or still be
+//     running; we don't trust the orphan and create a fresh Job — the
+//     step's PodSpec must be idempotent, which it is by chart design —
+//     every step's PodSpec is "ensure target state X").
+//  2. List the cutover step ConfigMaps. If any are missing (chart
+//     uninstalled mid-flight) we log and bail.
+//  3. Claim the in-process running flag (always succeeds on a fresh Pod
+//     since the broadcaster is freshly constructed).
+//  4. Spawn runCutover with a background context so an init signal or
+//     brief HTTP server hiccup doesn't cancel a multi-step resume.
 //
 // Idempotency vs the auto-trigger Job
 // ───────────────────────────────────
@@ -1354,11 +1508,21 @@ func (h *Handler) ResumeInterruptedCutover(ctx context.Context) {
 	// In-flight detected: cutoverStartedAt != "" AND cutoverComplete != "true".
 	// If a previous attempt failed terminally (failedStep != ""), we still
 	// resume — the operator/auto-trigger will eventually re-POST anyway,
-	// and resuming after a terminal failure surfaces the same final state
-	// (the failed step re-runs; if it fails again the run terminates again
-	// with the same error; if it passes this time, the cutover proceeds).
-	// This matches the existing engine semantics where /start retries a
-	// failed cutover by re-running from the next not-success step.
+	// and resuming re-enters the failed step (runCutover skips only
+	// result=="success" rows). What happens there now depends on WHY the
+	// step failed (#3379, hw139):
+	//   - TRANSIENT failure (the prior Job hit its activeDeadlineSeconds,
+	//     reason DeadlineExceeded — e.g. step-03 harbor-prewarm running out
+	//     of wall-clock): runCutoverStep's idempotency block deletes the
+	//     timed-out Job and re-runs the step from scratch. With the larger
+	//     budget + parallel copies (same PR) the re-run can complete, so the
+	//     cutover proceeds instead of wedging at the failed step forever.
+	//   - GENUINE failure (non-zero application exit / backoff-limit
+	//     exhausted): runCutoverStep re-surfaces it as terminal and the run
+	//     halts again with the same error — operator intervention required.
+	// Either way the transient/genuine decision is centralized in
+	// runCutoverStep (via jobFailedTransiently), so both the startup-resume
+	// path and an explicit /start re-fire get identical behavior.
 	h.log.Info("cutover-resume: in-flight cutover detected on startup",
 		"currentStep", status["currentStep"],
 		"currentStepIndex", status["currentStepIndex"],

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_test.go
@@ -1414,3 +1414,219 @@ func TestIsApiserverNotReadyTransient_ClassifiesK3sWarmupCorrectly(t *testing.T)
 // reads naturally without sprinkling sync/atomic across the file.
 func atomicInc(p *int32) int32  { return atomic.AddInt32(p, 1) }
 func atomicLoad(p *int32) int32 { return atomic.LoadInt32(p) }
+
+// ── #3379 step-03: per-step deadline + transient-failure re-run ──────────────
+
+// podSpecYAMLWithDeadline mirrors minimalPodSpecYAML but stamps an
+// activeDeadlineSeconds inside the PodSpec — the way the chart's
+// stepTimeouts.<step>Seconds value lands on each step's ConfigMap.
+func podSpecYAMLWithDeadline(seconds int) string {
+	return fmt.Sprintf(`containers:
+- name: cutover-step
+  image: busybox:1.36
+  command: ["/bin/sh", "-c", "echo step done"]
+restartPolicy: Never
+activeDeadlineSeconds: %d
+`, seconds)
+}
+
+// makeTransientlyFailedJobForStep mirrors makeFailedJobForStep but stamps
+// the terminal Failed condition with reason DeadlineExceeded — the signal
+// that the prior Job ran out of its activeDeadlineSeconds budget rather
+// than exiting non-zero. jobFailedTransiently must classify this as
+// re-runnable.
+func makeTransientlyFailedJobForStep(stepName string) *batchv1.Job {
+	completedAt := metav1.NewTime(time.Now().UTC().Add(-30 * time.Second))
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("cutover-%s-deadline-%d", stepName, time.Now().Unix()),
+			Namespace: cutoverTestNS,
+			Labels: map[string]string{
+				cutoverStepPartOfLabel:    cutoverStepPartOfValue,
+				cutoverStepComponentLabel: "cutover-job",
+				cutoverStepLabelKey:       stepName,
+			},
+			CreationTimestamp: metav1.NewTime(completedAt.Time.Add(-30 * time.Minute)),
+		},
+		Status: batchv1.JobStatus{
+			Failed: 1,
+			Conditions: []batchv1.JobCondition{{
+				Type:               batchv1.JobFailed,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: completedAt,
+				Reason:             batchv1.JobReasonDeadlineExceeded,
+				Message:            "Job was active longer than specified deadline",
+			}},
+		},
+	}
+}
+
+// TestCutoverStepDeadline_HonorsPerStepPodSpecValue proves the Job/watch
+// budget is the MAX of the global default and the step's own PodSpec
+// activeDeadlineSeconds — so a chart bump of stepTimeouts.harborPrewarmSeconds
+// actually takes effect instead of being silently capped at the 15-minute
+// global (the #3379 step-03 DeadlineExceeded root cause).
+func TestCutoverStepDeadline_HonorsPerStepPodSpecValue(t *testing.T) {
+	global := cutoverStepTimeout()
+
+	// No PodSpec deadline → falls back to the global default.
+	bareSpec := &corev1.PodSpec{}
+	if got := cutoverStepDeadline(cutoverStep{podSpec: bareSpec}); got != global {
+		t.Errorf("no-deadline step = %v, want global default %v", got, global)
+	}
+
+	// Per-step deadline LARGER than the global (harbor-prewarm 5400s) →
+	// the larger value wins.
+	big := int64(5400)
+	bigSpec := &corev1.PodSpec{ActiveDeadlineSeconds: &big}
+	if got := cutoverStepDeadline(cutoverStep{podSpec: bigSpec}); got != time.Duration(big)*time.Second {
+		t.Errorf("large per-step deadline = %v, want %v", got, time.Duration(big)*time.Second)
+	}
+
+	// Per-step deadline SMALLER than the global → the global floor wins
+	// (a short step still gets the generous cap).
+	small := int64(30)
+	smallSpec := &corev1.PodSpec{ActiveDeadlineSeconds: &small}
+	if got := cutoverStepDeadline(cutoverStep{podSpec: smallSpec}); got != global {
+		t.Errorf("small per-step deadline = %v, want global floor %v", got, global)
+	}
+
+	// nil PodSpec is tolerated (defensive) → global default.
+	if got := cutoverStepDeadline(cutoverStep{}); got != global {
+		t.Errorf("nil-podSpec step = %v, want global default %v", got, global)
+	}
+}
+
+// TestJobFailedTransiently_ClassifiesDeadlineVsGenuine proves a
+// DeadlineExceeded Failed Job is treated as transient (re-runnable) while a
+// genuine non-zero exit (BackoffLimitExceeded) is NOT.
+func TestJobFailedTransiently_ClassifiesDeadlineVsGenuine(t *testing.T) {
+	if !jobFailedTransiently(makeTransientlyFailedJobForStep("harbor-prewarm")) {
+		t.Errorf("DeadlineExceeded Job classified non-transient; want transient")
+	}
+	if jobFailedTransiently(makeFailedJobForStep("gitea-mirror")) {
+		t.Errorf("BackoffLimitExceeded Job classified transient; want genuine (non-transient)")
+	}
+	// A completed Job has no Failed condition → not transient.
+	if jobFailedTransiently(makeCompletedJobForStep("harbor-prewarm", time.Minute)) {
+		t.Errorf("Complete Job classified transient; want false")
+	}
+	// Message-only DeadlineExceeded (older API servers) still matches.
+	msgOnly := makeFailedJobForStep("harbor-prewarm")
+	msgOnly.Status.Conditions[0].Reason = ""
+	msgOnly.Status.Conditions[0].Message = "Job was active longer than specified deadline"
+	if jobFailedTransiently(msgOnly) {
+		// "longer than specified deadline" is not one of our substrings;
+		// verify the exact substrings we DO match instead.
+		t.Logf("message %q not matched (expected — only explicit substrings match)", msgOnly.Status.Conditions[0].Message)
+	}
+	msgOnly.Status.Conditions[0].Message = "pod exceeded active deadline"
+	if !jobFailedTransiently(msgOnly) {
+		t.Errorf("message-substring %q not classified transient; want transient", msgOnly.Status.Conditions[0].Message)
+	}
+	if jobFailedTransiently(nil) {
+		t.Errorf("nil Job classified transient; want false")
+	}
+}
+
+// TestRunCutoverStep_RerunsTransientlyFailedJob is the #3379 keystone
+// regression: a prior Job that failed with DeadlineExceeded must be
+// DELETED and the step RE-RUN (not re-surfaced as a terminal failure that
+// wedges the cutover forever). On the re-run the step's Job completes and
+// the cutover advances to completion.
+func TestRunCutoverStep_RerunsTransientlyFailedJob(t *testing.T) {
+	preStatus := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cutoverStatusConfigMapName(),
+			Namespace: cutoverTestNS,
+		},
+		Data: map[string]string{
+			"cutoverComplete":               "false",
+			"cutoverStartedAt":              "2026-06-15T04:58:25Z",
+			"totalSteps":                    "1",
+			"step.harbor-prewarm.result":    "failed",
+			"step.harbor-prewarm.startedAt": "2026-06-15T04:58:30Z",
+			"failedStep":                    "harbor-prewarm",
+		},
+	}
+	priorJob := makeTransientlyFailedJobForStep("harbor-prewarm")
+	priorJobName := priorJob.Name
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-03-harbor-prewarm", "harbor-prewarm", 3, cutoverModeJob, minimalPodSpecYAML, ""),
+		preStatus,
+		priorJob,
+	}
+	h, client := fakeHandlerWithCutover(t, objs...)
+
+	// New Jobs created on the re-run auto-complete.
+	jobCreates := map[string]int{}
+	var muJobs sync.Mutex
+	client.PrependReactor("create", "jobs", func(action clienttesting.Action) (bool, k8sruntime.Object, error) {
+		ca, ok := action.(clienttesting.CreateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		job, ok := ca.GetObject().(*batchv1.Job)
+		if !ok {
+			return false, nil, nil
+		}
+		muJobs.Lock()
+		jobCreates[job.Labels[cutoverStepLabelKey]]++
+		muJobs.Unlock()
+		updated := job.DeepCopy()
+		updated.Status.Conditions = []batchv1.JobCondition{{
+			Type:   batchv1.JobComplete,
+			Status: corev1.ConditionTrue,
+			Reason: "Test",
+		}}
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			_, _ = client.BatchV1().Jobs(job.Namespace).UpdateStatus(
+				context.Background(), updated, metav1.UpdateOptions{},
+			)
+		}()
+		return false, nil, nil
+	})
+
+	h.ResumeInterruptedCutover(context.Background())
+
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		bus := h.cutoverBusFor()
+		bus.mu.Lock()
+		running := bus.running
+		bus.mu.Unlock()
+		if !running {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	cm, err := client.CoreV1().ConfigMaps(cutoverTestNS).Get(context.Background(),
+		cutoverStatusConfigMapName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get status ConfigMap: %v", err)
+	}
+	// The cutover must COMPLETE — the transiently-failed step re-ran and
+	// succeeded.
+	if cm.Data["cutoverComplete"] != "true" {
+		t.Errorf("cutoverComplete = %q, want true (transient DeadlineExceeded step must re-run + succeed)", cm.Data["cutoverComplete"])
+	}
+	if cm.Data["step.harbor-prewarm.result"] != "success" {
+		t.Errorf("step.harbor-prewarm.result = %q, want success", cm.Data["step.harbor-prewarm.result"])
+	}
+	// A fresh Job was created for the step (the re-run).
+	muJobs.Lock()
+	created := jobCreates["harbor-prewarm"]
+	muJobs.Unlock()
+	if created < 1 {
+		t.Errorf("harbor-prewarm Job creates = %d, want >=1 (transient failure must re-create)", created)
+	}
+	// The timed-out prior Job was deleted (so findExistingTerminalJobForStep
+	// won't re-surface it).
+	if _, gErr := client.BatchV1().Jobs(cutoverTestNS).Get(context.Background(), priorJobName, metav1.GetOptions{}); gErr == nil {
+		t.Errorf("prior DeadlineExceeded Job %s still exists; want deleted before re-run", priorJobName)
+	} else if !apierrors.IsNotFound(gErr) {
+		t.Errorf("unexpected error checking prior Job deletion: %v", gErr)
+	}
+}


### PR DESCRIPTION
## Why

Two stacked defects from the live **hw139 #3379 cutover wedge** — both block the Pillar-5 cutover from completing on a fresh prov. Develop-and-merge for the **NEXT** fresh prov; **validated-on-next-fresh-prov, NOT walked this session** (hw139 is being region-killed and fresh fires hit the kom4dc EIP wall).

## Defect 1 — Step-03 harbor-prewarm `DeadlineExceeded` (only 6/29 pushed)

The ~29 multi-layer **PRIVATE** `openova-io/*` images are skopeo-native-pushed `ghcr.io`→local Harbor (the **only** working route — Harbor's anonymous proxy-cache 404s these private packages, #3534). They ran **strictly serial** over kom4dc's throttled egress and tripped the step deadline mid-copy → local Harbor `openova-io` project incomplete → post-cutover `ImagePullBackOff` → Step-08 deny-egress proof never ran.

**Chosen approach (a) — parallelize + raise the ceiling — over (b) sourcing from the node's containerd cache (#3534 prepull):**
(b) is not reliably correct. The prewarm Pod is hardened (`runAsNonRoot`, `runAsUser 1000`, `readOnlyRootFilesystem`, `drop: [ALL]`), so reading the root-owned containerd socket needs a hostPath mount + privilege escalation (a security regression). The #3534 prepull only caches the `openova-io/openova` **subset**, runs as a detached background `nohup` that may not have finished, and runs **only on the control-plane node** while the prewarm Pod may schedule on a worker. (a) keeps the existing authenticated skopeo path and just removes the wall-clock bottleneck.

- **`03-harbor-prewarm-job.yaml`** — Phase-A copy loop fans out `PREWARM_PARALLELISM` (default 6) concurrent `skopeo copy` workers (each writes its own `.ok`/`.fail` sentinel + log; parent `wait`s + tallies), ~6× wall-clock collapse. Each copy gains `--retry-times 3`. POSIX-clean (`dash`/`sh`/`busybox -n` + a mock run under dash+busybox verified); live-PID-counting throttle (no `wait -n`/arrays). The two earlier #3379 hw138 catches stay in force (`--insecure-policy` + branch on skopeo's **real** per-worker exit status, not a piped `sed` whose status is always 0).
- **`values.yaml`** — `stepTimeouts.harborPrewarmSeconds` `1800`→`5400` (90m). Event-driven watch means a fast run never waits out the ceiling.
- **`cutover.go`** — NEW `cutoverStepDeadline()` makes `createCutoverJob` + `watchJobToCompletion` honor the step's **own** PodSpec `activeDeadlineSeconds` (the chart `stepTimeouts.<step>Seconds`) when it exceeds the global default. Without this the bump is **inert**: the Job-level `activeDeadlineSeconds` was always stamped from the global 15m `cutoverStepTimeout` (authoritative over the Pod-template one), silently killing every long step at 15m with reason `DeadlineExceeded`. Takes the **MAX** so the global stays a floor for short steps.

## Defect 2 — resume/re-fire never retried a Failed step

`cutover.go` resume reset only `result==running` rows, and `runCutoverStep`'s `findExistingTerminalJobForStep` refused to re-create a Job for a Failed step ("operator intervention required"). A `DeadlineExceeded` step-03 therefore re-failed on **every** re-fire and wedged the cutover forever.

- NEW `jobFailedTransiently()` classifies a `JobFailed` with reason `DeadlineExceeded` (or matching message) as **transient**; everything else (`BackoffLimitExceeded`, …) stays **genuine** (fail-closed). NEW `deleteCutoverJobsForStep()` removes the timed-out Job(s). `runCutoverStep`'s Failed branch now: **transient** → delete + clear the step rows + fall through to mint a fresh Job (idempotent re-run); **genuine** → halt exactly as before. Centralized in `runCutoverStep`, so startup-resume and explicit `/start` re-fire behave identically.

## Lockstep

- `bp-self-sovereign-cutover` chart **0.1.60 → 0.1.61** + `blueprint.yaml` **0.1.60 → 0.1.61**
- bootstrap-kit slot **06a** pin **0.1.60 → 0.1.61**
- catalyst-api image tag is **auto-stamped by `catalyst-build.yaml`** on merge-to-main (`bootstrap/api` is in its trigger paths) — not hand-pinned.

## Validation

- NEW Go tests: `TestCutoverStepDeadline_HonorsPerStepPodSpecValue`, `TestJobFailedTransiently_ClassifiesDeadlineVsGenuine`, `TestRunCutoverStep_RerunsTransientlyFailedJob` (re-runs + completes + deletes the prior `DeadlineExceeded` Job).
- Full `internal/handler` suite green (incl. the existing genuine-failure-halts test).
- chart `cutover-contract.sh` **25/25** gates green; bootstrap-kit `manifest-validation` green; `helm template` clean; `go build`/`vet`/`gofmt` clean.

**This is validated-on-next-fresh-prov — the live walk is deferred to when a clean prov can fire.**

Refs #3379
Refs #3526

🤖 Generated with [Claude Code](https://claude.com/claude-code)