### PR TITLE
docs(3375): live region-kill DR walk on hw139 — RTO 18.13s, RPO 0 (North Star #4)

### DIFF
--- a/docs/ledger/uat-walkthrough/3375-topology-dr.md
+++ b/docs/ledger/uat-walkthrough/3375-topology-dr.md
@@ -81,17 +81,37 @@ panel — the matrix owes them no DR contract. This is the honest negative case.
 
 ---
 
-## 2. Region-kill EXECUTION (live cross-region switchover) — deferred this pass
+## 2. Region-kill EXECUTION (live cross-region switchover) — EXECUTED LIVE on hw139
+
+Driven 2026-06-15 ~04:59Z on the live 2-region hw139 deployment `c89aa7059556b342`
+(region-a `me-east-215-a` primary + region-b `me-east-215-b` cross-region standby
+streaming async over ClusterMesh). This is the actual North-Star-4 failover EXECUTION —
+the kill→promote→survives walk runs end-to-end on `bp-cnpg-pair`. (A `kubectl`/`psql`
+ground-truth proof of the data layer, complementary to the §1 web-UI Switchover-dialog
+rows.)
 
 | Tested action | Expectation | Status |
 |---|---|---|
-| Trigger a live `bp-cnpg-pair` Switchover (rtz-A → rtz-B promote) and observe the Continuum record + replication-lag flip | promoted standby serves; switchover history row appears | ❌ **deferred** — no live Continuum CR yet; the DR machinery activates only once an app is placed active-hot-standby on a 2-region Sovereign with Continuum driving. This READ-ONLY pass does not drive a live switchover. |
-| Region-kill failover of the mgmt-tier (keycloak/gitea/harbor/grafana) | DNS-flip + standby promote, ~30s | ❌ **deferred** — same Continuum precondition. Tracked separately (the region-kill EXECUTION rows are driven outside this declaration walk). |
+| Drive a live `bp-cnpg-pair` region-kill (cordon region-a workers + force-delete the 3 primary pods) → promote region-b (the documented `spec.replica.enabled=false` switchover) → observe region-b accept writes | promoted standby serves writes; RTO measured | ✅ **EXECUTED** — region-b promoted to a writable primary; **full RTO kill→writable = 18.13s** (promotion latency patch→writable **0.90s**); region-b timeline incremented 1→2 (real promotion). |
+| Zero-data-loss: the pre-kill marker row survives the failover (RPO) | pre-kill row present on promoted region-b; post-kill write accepted | ✅ **EXECUTED** — pre-kill sentinel `id=2 'regionkill-hw139'` (written to region-a `04:58:23Z`, replicated to region-b pre-kill) **survived** on the promoted region-b primary; a NEW post-kill write (`id=35`) was accepted. **Data loss = 0 rows.** |
 
-The **declaration + enabled Switchover control** is verified live (§1); the **execution**
-of a real cross-region switchover is a separate, Continuum-driven walk and is honestly
-marked deferred here. hw128 holds the prior PASS pattern for the cnpg-pair region-kill
-(3s promote, zero data loss).
+**Ground reality recorded honestly (precondition repair):** the hw139 cnpg-pair was found
+in **Day-2 split-brain** from a PRIOR region-kill rehearsal (~2026-06-14 20:21Z) — region-a
+on timeline 1, region-b stuck on timeline 2 with its walreceiver FATAL-looping ~8h
+(`highest timeline 1 of the primary is behind recovery timeline 2`), the failover-readiness
+sidecar reporting `lag=999999s — NOT promotable`. The ClusterMesh datapath itself was
+healthy (region-b→region-a primary-mesh:5432 TCP OK) — a PG-level timeline divergence, not
+an infra break. A documented cnpg replica re-bootstrap (delete the diverged region-b PVCs →
+Flux/cnpg re-clone from region-a primary via `pg_basebackup` on timeline 1) restored
+**genuine live cross-region streaming** (verified: a probe row written to region-a propagated
+to the re-cloned region-b standby; region-a `pg_stat_replication` showed the region-b standby
+`10.43.3.106 streaming async`) BEFORE this kill. Full timeline + evidence under
+`docs/sessions/2026-06-15/evidence/3375-hw139-regionkill/`.
+
+The **declaration + enabled Switchover control** is verified live (§1); the **execution** of
+a real cross-region region-kill is now verified live here on hw139 (RTO 18.13s / RPO 0). This
+flushes any prior env's evidence — it is the hw139 result, measured fresh (the prior hw128
+PASS is not reused per the each-env-flushes-evidence rule).
 
 ---
 
@@ -103,13 +123,15 @@ marked deferred here. hw128 holds the prior PASS pattern for the cnpg-pair regio
 | 1b. Catalyst/mgmt-tier declaration matches matrix | 7 | **7/7 ✅** |
 | 1c. rtz vCluster + singleton declaration matches matrix | 4 | **4/4 ✅** |
 | **Topology-declaration acceptance (17 apps walked)** | 17 | **17/17 ✅** |
-| 2. Region-kill EXECUTION (live switchover) | 2 | **0/2 ❌ deferred (no live Continuum CR; separate walk)** |
+| 2. Region-kill EXECUTION (live switchover) on hw139 | 2 | **2/2 ✅ EXECUTED LIVE (RTO 18.13s / RPO 0)** |
 
 **TOPOLOGY/DR walk: 17/17 apps render the matrix-declared class + state backend +
 switchover mechanism + RTO/RPO + per-cluster placement; all 6 §6 HA apps show an enabled
 Switchover button + an honest DR panel; singletons (coraza/seaweedfs) correctly show no
-DR. Region-kill EXECUTION 0/2 — honestly deferred (no live Continuum CR on a read-only
-pass).**
+DR. Region-kill EXECUTION 2/2 ✅ — the `bp-cnpg-pair` cross-region failover was driven
+LIVE on hw139 (kill region-a → promote region-b → writable in 18.13s, pre-kill sentinel
+survived + post-kill write accepted = 0 data loss). This is the North-Star-4
+multi-region-failover proof on the current env.**
 
 ### Honest notes
 - Every Topology field is read off `docs/topology-matrix.md`, not invented; the live
@@ -117,7 +139,11 @@ pass).**
   RTO/RPO, per-cluster roles).
 - The DR panels are **honest**: they truthfully report "No live Continuum record yet"
   rather than faking a switched-over state. The enabled Switchover button is the
-  declared control surface; its **execution** is a separate Continuum-driven walk.
+  declared control surface; its **execution** is verified live in §2 on hw139
+  (`bp-cnpg-pair` region-kill → region-b promote → RTO 18.13s / RPO 0). Evidence:
+  `docs/sessions/2026-06-15/evidence/3375-hw139-regionkill/` (00-as-found-split-brain ·
+  00-timeline-rto · 01-pre-kill-replication · 02-kill-state · 03-promote-zero-data-loss ·
+  04-recover-split-brain).
 - CLASS-B mechanisms (loki/mimir/tempo s3-bucket-replication, nats raft, valkey sentinel)
   render their declared mechanism in the Topology tab even though the chart IaC is not yet
   wired (per matrix §4) — the declaration surface is complete.

--- a/docs/sessions/2026-06-15/evidence/3375-hw139-regionkill/00-as-found-split-brain.txt
+++ b/docs/sessions/2026-06-15/evidence/3375-hw139-regionkill/00-as-found-split-brain.txt
@@ -1,0 +1,41 @@
+# hw139 #3375 REGION-KILL — AS-FOUND STATE (before any action)
+# deployment c89aa7059556b342 / hw139.omani.works
+# 2-region: me-east-215-a (primary region) + me-east-215-b (standby region)
+# captured 2026-06-15T04:54:13Z
+
+## FINDING: the cnpg-pair was NOT cross-region streaming when found.
+## A PRIOR region-kill rehearsal (~2026-06-14 20:21-20:22Z, ~8h before this walk)
+## promoted region-b and left the pair in Day-2 SPLIT-BRAIN that never rejoined.
+
+### Evidence of the prior rehearsal — keystone_xregion table contents:
+# REGION-A primary (timeline 1, the original write):
+#   id=1 'pre-kill region-a hw139'  ts=2026-06-14 20:21:23+00
+# REGION-B replica (timeline 2 — was promoted in the prior rehearsal, took a post-kill write):
+#   id=1  'pre-kill region-a hw139'        ts=2026-06-14 20:21:23+00
+#   id=34 'post-kill region-b (promoted)'  ts=2026-06-14 20:22:17+00   <-- prior promotion artifact
+
+### Timeline divergence (the root cause the streams are dead):
+#   region-a primary-1 timeline_id = 1
+#   region-b replica-1  timeline_id = 2
+#   region-b walreceiver FATAL since 2026-06-14T20:35:24Z (~8.3h):
+#     "highest timeline 1 of the primary is behind recovery timeline 2"
+#   region-b pg_stat_wal_receiver = 0 rows (NOT streaming)
+#   region-a pg_replication_slots = only 2 in-region slots (primary_2, primary_3); NO cross-region slot
+
+### Platform's OWN promotability gate agrees it is broken:
+#   pod cnpg-pair-bp-cnpg-pair-failover-readiness = 0/1 NOT READY for ~9h
+#   log: "replica lag=999999s >= threshold=30s — NOT promotable"
+
+### Live connectivity probe (this walk, 2026-06-15T04:54:13Z):
+#   wrote regionkill_sentinel(id=1,'connectivity-probe-hw139') to region-a primary
+#   after 6s region-b still: relation "regionkill_sentinel" does not exist  -> NO replication
+
+### Infra/datapath is HEALTHY (this is a PG-level split-brain, not a mesh break):
+#   region-b -> region-a primary-mesh:5432 TCP = MESH-TCP-OK (ClusterMesh global svc works)
+#   both regions: 1 cp + 3 workers Ready (10h old); cnpg-pair-primary 3/3, cnpg-pair-replica 3/3 (locally healthy)
+
+## CONCLUSION (as-found): cross-region streaming is DEAD by timeline divergence from a
+## prior rehearsal. A kill-now would NOT prove RPO=0 (region-b data is a stale prior-promotion
+## copy, not a live replica of the current region-a primary). PRECONDITION: re-establish a
+## genuine live cross-region standby via the documented cnpg replica re-bootstrap, then run a
+## clean kill. The re-bootstrap is recorded transparently below (01-*).

--- a/docs/sessions/2026-06-15/evidence/3375-hw139-regionkill/00-timeline-rto.txt
+++ b/docs/sessions/2026-06-15/evidence/3375-hw139-regionkill/00-timeline-rto.txt
@@ -1,0 +1,18 @@
+# hw139 #3375 REGION-KILL — execution evidence (LIVE, North Star 4)
+# deployment c89aa7059556b342 / hw139.omani.works
+# 2-region me-east-215-a (primary) + me-east-215-b (standby), ClusterMesh cross-region streaming
+# captured 2026-06-15T05:00:22Z
+#
+# NOTE: the cnpg-pair was found in Day-2 split-brain from a PRIOR rehearsal (see 00-as-found-split-brain.txt);
+# a documented cnpg replica re-bootstrap restored GENUINE live cross-region streaming (region-b re-cloned
+# from region-a primary on timeline 1, streaming async, verified by a propagated probe row) BEFORE this kill.
+
+## Timeline
+T_KILL          (region-a primary cordon+delete) = 2026-06-15T04:59:00.486Z
+T_PROMOTE_PATCH (replica.enabled=false issued)    = 2026-06-15T04:59:17.707Z
+T_WRITABLE      (pg_is_in_recovery=f on region-b) = 2026-06-15T04:59:18.612Z
+
+FULL RTO (kill -> writable)            = 18.13s
+Promotion latency (patch -> writable)  = 0.90s
+(Operator reaction kill -> patch       = 17.22s)
+DATA LOSS = 0 rows (pre-kill sentinel id=2 'regionkill-hw139' survived on promoted region-b; post-kill write id=35 accepted)

--- a/docs/sessions/2026-06-15/evidence/3375-hw139-regionkill/01-pre-kill-replication.txt
+++ b/docs/sessions/2026-06-15/evidence/3375-hw139-regionkill/01-pre-kill-replication.txt
@@ -1,0 +1,38 @@
+## PRE-KILL: live cross-region streaming + sentinel row written to region-a, replicated to region-b
+# captured 2026-06-15T04:58:23Z
+
+### region-a primary pg_stat_replication (10.43.x = region-b cross-region standby, async):
+ client_addr |   state   | sync_state |         application_name         
+-------------+-----------+------------+----------------------------------
+ 10.42.1.133 | streaming | potential  | cnpg-pair-bp-cnpg-pair-primary-3
+ 10.42.2.90  | streaming | sync       | cnpg-pair-bp-cnpg-pair-primary-2
+ 10.43.3.106 | streaming | async      | cnpg-pair-bp-cnpg-pair-replica
+(3 rows)
+
+
+### region-a is the writable primary (pg_is_in_recovery=f); region-b is read-only standby (=t):
+region-a pg_is_in_recovery = f
+region-b pg_is_in_recovery = t
+
+### write the PRE-KILL sentinel marker row to region-a primary:
+ id |      marker      |              ts               
+----+------------------+-------------------------------
+  2 | regionkill-hw139 | 2026-06-15 04:58:23.833267+00
+(1 row)
+
+INSERT 0 1
+### region-a current WAL LSN after sentinel write:
+0/D002418
+
+### PRE-KILL verify: sentinel row 'regionkill-hw139' (id=2) replicated to region-b standby BEFORE the kill:
+ id |          marker          |              ts               
+----+--------------------------+-------------------------------
+  1 | connectivity-probe-hw139 | 2026-06-15 04:51:59.0641+00
+  2 | regionkill-hw139         | 2026-06-15 04:58:23.833267+00
+(2 rows)
+
+### region-b replay LSN (caught up to region-a's sentinel write at 0/D002418):
+0/D002450|0/D002450
+### region-b is a true read-only standby pre-kill — write is REJECTED:
+ERROR:  cannot execute INSERT in a read-only transaction
+command terminated with exit code 1

--- a/docs/sessions/2026-06-15/evidence/3375-hw139-regionkill/02-kill-state.txt
+++ b/docs/sessions/2026-06-15/evidence/3375-hw139-regionkill/02-kill-state.txt
@@ -1,0 +1,14 @@
+## KILL: region-a primary down (3 workers cordoned + primary pods force-deleted)
+T_KILL = 2026-06-15T04:59:00.486Z
+
+### region-a nodes (workers SchedulingDisabled, cp1 untouched):
+NAME                                                           STATUS                     ROLES                       AGE   VERSION
+catalyst-hw139-omani-works-c89aa705-me-east-215-a-cp1-cedba1   Ready                      control-plane,etcd,master   10h   v1.31.4+k3s1
+catalyst-hw139-omani-works-c89aa705-me-east-215-a-w9b5077      Ready,SchedulingDisabled   <none>                      10h   v1.31.4+k3s1
+catalyst-hw139-omani-works-c89aa705-me-east-215-a-wb1b4e4      Ready,SchedulingDisabled   <none>                      10h   v1.31.4+k3s1
+catalyst-hw139-omani-works-c89aa705-me-east-215-a-wf4b21d      Ready,SchedulingDisabled   <none>                      10h   v1.31.4+k3s1
+
+### region-a primary cluster (pods can't reschedule — region is 'dead'):
+NAME                             AGE   INSTANCES   READY   STATUS                     PRIMARY
+cnpg-pair-bp-cnpg-pair-primary   9h    3                   Cluster in healthy state   cnpg-pair-bp-cnpg-pair-primary-1
+No resources found in cnpg namespace.

--- a/docs/sessions/2026-06-15/evidence/3375-hw139-regionkill/03-promote-zero-data-loss.txt
+++ b/docs/sessions/2026-06-15/evidence/3375-hw139-regionkill/03-promote-zero-data-loss.txt
@@ -1,0 +1,46 @@
+## PROMOTE + ZERO-DATA-LOSS (region-b, newly promoted primary)
+# captured 2026-06-15T04:59:34Z
+
+### region-b cluster after promote:
+NAME                             AGE     INSTANCES   READY   STATUS                                       PRIMARY
+cnpg-pair-bp-cnpg-pair-replica   2m40s   3           2       Waiting for the instances to become active   cnpg-pair-bp-cnpg-pair-replica-1
+
+### region-b is now WRITABLE (pg_is_in_recovery = f):
+f
+
+### RPO PROOF — the PRE-KILL sentinel row 'regionkill-hw139' (id=2) SURVIVED the failover:
+ id |          marker          |              ts               
+----+--------------------------+-------------------------------
+  1 | connectivity-probe-hw139 | 2026-06-15 04:51:59.0641+00
+  2 | regionkill-hw139         | 2026-06-15 04:58:23.833267+00
+(2 rows)
+
+
+### region-b accepts a NEW post-promotion write (proves it is a live writable primary):
+ id |               marker                |              ts               
+----+-------------------------------------+-------------------------------
+ 35 | post-kill region-b (promoted) hw139 | 2026-06-15 04:59:35.419567+00
+(1 row)
+
+INSERT 0 1
+
+### final table on promoted region-b (pre-kill rows + post-kill write):
+ id |               marker                |              ts               
+----+-------------------------------------+-------------------------------
+  1 | connectivity-probe-hw139            | 2026-06-15 04:51:59.0641+00
+  2 | regionkill-hw139                    | 2026-06-15 04:58:23.833267+00
+ 35 | post-kill region-b (promoted) hw139 | 2026-06-15 04:59:35.419567+00
+(3 rows)
+
+### region-b new-primary standbys streaming (post-promotion, rebuilt):
+ client_addr |   state   | sync_state 
+-------------+-----------+------------
+ 10.43.1.71  | streaming | async
+ 10.43.2.152 | streaming | async
+(2 rows)
+
+### region-b cluster final (promoted primary, healthy):
+NAME                             AGE     INSTANCES   READY   STATUS                     PRIMARY
+cnpg-pair-bp-cnpg-pair-replica   3m27s   3           3       Cluster in healthy state   cnpg-pair-bp-cnpg-pair-replica-1
+### region-b timeline after promotion (incremented to 2 = real promotion):
+2

--- a/docs/sessions/2026-06-15/evidence/3375-hw139-regionkill/04-recover-split-brain.txt
+++ b/docs/sessions/2026-06-15/evidence/3375-hw139-regionkill/04-recover-split-brain.txt
@@ -1,0 +1,29 @@
+## RECOVER + Day-2 split-brain caveat
+# captured 2026-06-15T05:00:47Z
+
+### region-a nodes uncordoned (all Ready, env non-terminal):
+NAME                                                           STATUS   ROLES                       AGE   VERSION
+catalyst-hw139-omani-works-c89aa705-me-east-215-a-cp1-cedba1   Ready    control-plane,etcd,master   10h   v1.31.4+k3s1
+catalyst-hw139-omani-works-c89aa705-me-east-215-a-w9b5077      Ready    <none>                      10h   v1.31.4+k3s1
+catalyst-hw139-omani-works-c89aa705-me-east-215-a-wb1b4e4      Ready    <none>                      10h   v1.31.4+k3s1
+catalyst-hw139-omani-works-c89aa705-me-east-215-a-wf4b21d      Ready    <none>                      10h   v1.31.4+k3s1
+
+### critical region-a control-plane apps stayed healthy THROUGHOUT (cordon does not evict running pods):
+keycloak-0   1/1     Running   1 (10h ago)   10h
+
+### region-b remains the authoritative writable primary (pg_is_in_recovery=f):
+f
+
+### Day-2 split-brain caveat (per hw128/hw136 runbook):
+  After uncordon, region-a's cnpg-pair-primary pods reschedule and the cluster re-bootstraps as its
+  OWN writable primary from local data on timeline 1, while region-b is the promoted authoritative
+  primary on timeline 2 -> classic post-failover split-brain. Rebuilding region-a as a standby of the
+  promoted region-b is a Day-2 reconciliation action (operator / continuum-controller), NOT part of the
+  failover proof. The failover proof (kill -> promote -> zero-data-loss, RTO 18.13s / RPO 0) is COMPLETE.
+  The env is left non-terminal with all control-plane apps healthy for downstream walks.
+
+### (correction) full control-plane app health on region-a — all 1/1 Running through the kill (ages predate T_KILL=04:59, 0 restarts):
+catalyst-api-97c9dccc6-924wp                         1/1     Running            0             6h29m
+catalyst-ui-65889f6f7b-4m7nn                         1/1     Running            0             7h27m
+console-d6478b77c-sphjz         1/1     Running            0                6h33m
+keycloak-0   1/1     Running   1 (10h ago)   10h


### PR DESCRIPTION
## What

Executed the **genuine cross-region region-kill failover** for `bp-cnpg-pair` on the **live 2-region hw139** deployment `c89aa7059556b342` (region-a `me-east-215-a` primary + region-b `me-east-215-b` cross-region standby streaming async over ClusterMesh). This is the North-Star-4 ("agreed apps actually multi-region") proof, measured fresh on the current env. It replaces the "region-kill deferred on hw139" note in the topology-DR walkthrough.

## Ground reality (recorded honestly)

The hw139 cnpg-pair was found in **Day-2 split-brain** from a PRIOR region-kill rehearsal (~2026-06-14 20:21Z): region-a on timeline 1, region-b stuck on **timeline 2** with its walreceiver **FATAL-looping ~8h** (`highest timeline 1 of the primary is behind recovery timeline 2`), and the platform's own `failover-readiness` sidecar reporting `lag=999999s — NOT promotable`. The ClusterMesh datapath itself was healthy (region-b→region-a `primary-mesh:5432` TCP OK) — a PG-level timeline divergence, not an infra break.

A **documented cnpg replica re-bootstrap** (delete the diverged region-b PVCs → Flux/cnpg re-clone from region-a primary via `pg_basebackup` on timeline 1) restored **genuine live cross-region streaming**, verified by a probe row written to region-a propagating to the re-cloned region-b standby (region-a `pg_stat_replication` showed `10.43.3.106 streaming async`), BEFORE the kill.

## Result — measured LIVE on hw139

| Marker | Value |
|---|---|
| T_KILL (region-a cordon + primary pods deleted) | 04:59:00.486Z |
| T_PROMOTE_PATCH (`spec.replica.enabled=false`) | 04:59:17.707Z |
| T_WRITABLE (`pg_is_in_recovery=f` on region-b) | 04:59:18.612Z |
| **Full RTO (kill→writable)** | **18.13s** |
| Promotion latency (patch→writable) | 0.90s |
| region-b timeline after promotion | 1 → **2** (real promotion) |
| **RPO / data loss** | **0 rows** |

- Pre-kill sentinel `id=2 'regionkill-hw139'` (written to region-a 04:58:23Z, replicated to region-b pre-kill) **SURVIVED** on the promoted region-b primary.
- region-b accepted a NEW post-kill write (`id=35`).
- region-a uncordoned post-walk; control-plane apps (catalyst-api/ui, console, keycloak) stayed `1/1 Running` throughout. The Day-2 split-brain rejoin is a separate reconciliation action, not part of the failover proof.

## Evidence

`docs/sessions/2026-06-15/evidence/3375-hw139-regionkill/` — 00-as-found-split-brain · 00-timeline-rto · 01-pre-kill-replication · 02-kill-state · 03-promote-zero-data-loss · 04-recover-split-brain.

This is a documented operator DR action (not a hand-patch fix); the precondition re-bootstrap is recorded transparently. Per the each-env-flushes-evidence rule, the prior hw128 PASS is not reused — this is the hw139 result.

Refs #3375

🤖 Generated with [Claude Code](https://claude.com/claude-code)