### PR TITLE
fix(cutover): strip ghcr.io auth AFTER the HelmRepository pivot is Ready, not before — kill the half-pivot wedge (bp-self-sovereign-cutover 0.1.63)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -486,7 +486,21 @@ spec:
       # deletes+re-runs a GENUINELY-failed step (the zero-touch re-trigger the
       # timeouts-only auto-resume #3558 won't drive); auto-resume stays
       # fail-closed. No step-count change.
-      version: 0.1.62
+      # 0.1.63 (Refs #3379 #3526, hw139 strip-before-pivot half-pivot): the
+      # ROOT-CAUSE fix for the half-pivot that froze 8 HRs on hw139 for 10h.
+      # Step-06 used to STRIP ghcr.io/harbor.openova.io auth from ghcr-pull in
+      # Phase-0 — BEFORE the Phase-1 HelmRepository URL pivot. Any later-step
+      # wedge then left ghcr.io creds gone while HR sources still pointed at
+      # ghcr.io → every reconcile failed "no auth config for 'ghcr.io'",
+      # unrecoverable zero-touch. FIX: Phase-0 is now purely ADDITIVE (merge
+      # Harbor auth, keep ghcr.io fallback); the destructive strip moved to a
+      # NEW Phase 3 at the END of Step-06, gated behind a bounded wait that
+      # proves every local-Harbor HelmRepository is Ready=True FIRST. If the
+      # pivot doesn't converge, the strip is REFUSED (Job exits non-zero,
+      # ghcr.io auth intact, recoverable). Invariant: ghcr.io creds never
+      # stripped until every HR pulls Ready from registry.<fqdn>.
+      # helmRepositoryPatchesSeconds 600→2400 + new stripReadinessSeconds 600.
+      version: 0.1.63
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.62
+  version: 0.1.63
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,56 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.63 (Refs #3379 #3526, hw139 strip-before-pivot half-pivot, 2026-06-15):
+# THE ROOT-CAUSE FIX for the cutover half-pivot that froze 8 HRs on the live
+# hw139 for 10h (and blocked the unrelated merged bp-newapi #3564 from
+# rolling). Verified live: every namespace's `ghcr-pull` Secret held ONLY
+# `registry.hw139.omani.works` (the `ghcr.io` key was stripped) while the
+# HelmRepository sources still resolved to `ghcr.io` — so 8 HRs
+# (bp-catalyst-platform, bp-openbao, bp-self-sovereign-cutover itself,
+# bp-continuum, bp-external-secrets-stores, bp-newapi, bp-sso-bridge,
+# bp-sandbox) wedged on `failed to configure login options: no auth config
+# for 'ghcr.io' in the docker-registry Secret 'ghcr-pull'`.
+#
+# ROOT CAUSE: Step-06 (helmrepository-patches) ran the DESTRUCTIVE
+# `ghcr.io` / `harbor.openova.io` auth STRIP in Phase-0 — which executes
+# BEFORE Phase-1's live HelmRepository URL pivot and Phase-2's durable Gitea
+# push. The instant Phase-0 stripped the creds, the cluster entered a lethal
+# intermediate state (ghcr.io creds GONE, HR sources still ghcr.io). If ANY
+# later cutover step wedged (step-05/08/10 have all wedged at points across
+# the #3379 saga), the half-pivot was permanent and unrecoverable zero-touch:
+# every reconcile failed for lack of ghcr.io auth, and because the strip + add
+# were one jq pass the engine re-stripped on every re-run.
+#
+# THE FIX (chart 06-helmrepository-patches-job.yaml):
+#   (1) Phase-0 is now PURELY ADDITIVE — it MERGES the local Harbor auth into
+#       ghcr-pull and nothing else. The ghcr.io fallback stays intact through
+#       the whole pivot.
+#   (2) The destructive strip MOVED to a NEW Phase 3 at the END of Step-06,
+#       AFTER Phase-1 (live URL pivot) + Phase-2 (durable Gitea push). The two
+#       former "nothing to push" early `exit 0`s now FALL THROUGH to Phase 3
+#       (the live pivot may have happened even with no Gitea edit).
+#   (3) Phase 3 is GATED: Phase-3a bounded-waits (stripReadinessSeconds, 600s)
+#       for EVERY HelmRepository now pointing at local Harbor to report
+#       Ready=True (source-controller fetched + verified the OCI artifact —
+#       proving registry.<fqdn> serves the chart AND the Phase-0 Harbor auth
+#       works). Only THEN does Phase-3b run the `del(.auths[ghcr.io,...])`
+#       strip. If the pivot does NOT converge, Phase-3a EXITS NON-ZERO with the
+#       mothership auth INTACT — the cluster keeps pulling from ghcr.io and the
+#       step is recoverable on the next engine re-run.
+# INVARIANT: ghcr.io creds are never stripped until every HR is already
+# pulling Ready from registry.<fqdn>. A strip-before-pivot wedge is now
+# structurally impossible.
+#
+# Lockstep: stepTimeouts.helmRepositoryPatchesSeconds raised 600 → 2400 (40m)
+# so the Job-level deadline covers the SUM of the in-Job waits (Phase -1
+# gateway-wait up to 1800s + Phase-3a strip-readiness up to 600s + buffer) —
+# catalyst-api honors this per-step value (cutover.go cutoverStepDeadline). New
+# stepTimeouts.stripReadinessSeconds (600s) + STRIP_READINESS_TIMEOUT_SECONDS
+# env. Contract test Case 17 renamed (merge→ADD) + new Case 17b locks the
+# strip into Phase 3 (readiness-gated, fail-closed, after the pivot). No
+# catalyst-api code change, no step-count change (still 11 steps). Live
+# 11-step→cutoverComplete=true validation DEFERRED to the next clean fresh prov
+# (kom4dc infra-gated; hw139 is already half-pivoted + must NOT be hand-patched).
 # 0.1.62 (#3379, hw139 step-08 + step-10 catches, 2026-06-15): the cutover
 # reached 9/11 on hw139 (registry + git tethers pivoted) and stalled on TWO
 # residual catches that this version fixes at source:
@@ -534,7 +585,7 @@ name: bp-self-sovereign-cutover
 # and wires it into GitRepository.spec.secretRef BEFORE the URL flip — same
 # credential + pattern as #3454's openova-sme-tenants GitRepository. Adds
 # `secrets: create` to the cutover-runner RBAC.
-version: 0.1.62
+version: 0.1.63
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -134,6 +134,15 @@ data:
             value: {{ .Values.gateway.name | quote }}
           - name: GATEWAY_WAIT_TIMEOUT_SECONDS
             value: {{ .Values.gateway.waitTimeoutSeconds | quote }}
+          # Phase-3 strip-before-pivot fix (Refs #3379 #3526). The
+          # mothership-auth strip (ghcr.io / harbor.openova.io) waits up to
+          # this long for every local-Harbor HelmRepository to reach
+          # Ready=True before removing the ghcr.io fallback. If the pivot
+          # never converges, the strip is SKIPPED (Job exits non-zero with
+          # ghcr.io auth intact → recoverable). See
+          # .Values.stepTimeouts.stripReadinessSeconds.
+          - name: STRIP_READINESS_TIMEOUT_SECONDS
+            value: {{ .Values.stepTimeouts.stripReadinessSeconds | quote }}
         volumeMounts:
           - name: helmrepository-list
             mountPath: /work
@@ -219,7 +228,7 @@ data:
               exit 1
             fi
 
-            # ---- Phase 0: merge harbor.<sov-fqdn> auth into ghcr-pull (#1184) ----
+            # ---- Phase 0: ADD harbor.<sov-fqdn> auth to ghcr-pull (#1184) ----
             #
             # source-controller pulls Helm OCI charts from
             # oci://harbor.<sov-fqdn>/openova-io using the imagePullSecret
@@ -229,6 +238,25 @@ data:
             # harbor.openova.io auth only — it has NO entry for
             # harbor.<sov-fqdn>. Once Phase-1 below pivots HelmRepository
             # URLs, every reconcile against the local Harbor 401s.
+            #
+            # ── STRIP-BEFORE-PIVOT FIX (Refs #3379 #3526, hw139 half-pivot) ──
+            # Phase-0 is now PURELY ADDITIVE — it merges the local Harbor
+            # auth and NOTHING ELSE. The DESTRUCTIVE removal of the
+            # mothership-side ghcr.io / harbor.openova.io auth entries
+            # (TBD-V24 MISS-2 credential hygiene) was MOVED to the new
+            # Phase 3 at the END of this Job — see that block for the full
+            # rationale. The invariant the move enforces: NEVER strip
+            # ghcr.io creds until every HelmRepository is already pivoted to
+            # local Harbor AND reconciling Ready from it. On hw139 the strip
+            # ran in Phase-0 (BEFORE the Phase-1 URL pivot); a later step
+            # wedged, leaving ghcr.io creds gone while the on-disk Gitea
+            # YAML / live HR sources still pointed at ghcr.io → every
+            # reconcile failed "no auth config for 'ghcr.io' in the
+            # docker-registry Secret 'ghcr-pull'" and the half-pivot was
+            # permanent + unrecoverable zero-touch (8 HRs wedged 10h,
+            # blocking the unrelated bp-newapi #3564 roll). Adding Harbor
+            # auth early is safe (purely additive, idempotent); removing
+            # ghcr.io auth is the irreversible act that MUST come last.
             #
             # Manual fix done on omantel 2026-05-10 (session 5c468708):
             #   HARBOR_AUTH=$(echo -n "admin:${HADMIN_PW}" | base64 -w0)
@@ -299,113 +327,42 @@ data:
 
             existing_json=$(printf '%s' "${existing_b64}" | base64 -d)
 
-            # Idempotency guard: a re-run is a no-op when BOTH conditions
-            # hold simultaneously —
-            #   (a) harbor.<sov-fqdn> already maps to the expected auth
-            #   (b) every entry listed in MOTHERSHIP_AUTHS_TO_STRIP is
-            #       already absent from .auths
-            # Re-runs of step-06 (catalyst-api may retry) MUST NOT churn
-            # the Secret resourceVersion when there's nothing to do —
-            # that triggers a noisy reflector cascade.
+            # Idempotency guard: the ADD is a no-op when harbor.<sov-fqdn>
+            # already maps to the expected auth. Re-runs of step-06
+            # (catalyst-api may retry / the engine may re-fire) MUST NOT
+            # churn the Secret resourceVersion when there's nothing to add
+            # — that triggers a noisy reflector cascade.
+            #
+            # NOTE (Refs #3379 #3526): Phase-0 NO LONGER strips the
+            # mothership ghcr.io / harbor.openova.io auth — that is deferred
+            # to Phase 3 (end of Job, gated on the pivot being Ready). So
+            # the idempotency check here is the simple "is the Harbor auth
+            # already present" test; the strip's own idempotency lives in
+            # Phase 3.
             already=$(printf '%s' "${existing_json}" | jq -r --arg h "${harbor_host}" \
               '.auths[$h].auth // empty')
             harbor_auth=$(printf '%s:%s' "${HARBOR_USERNAME}" "${HARBOR_PASSWORD}" | base64 -w0)
 
-            # Check whether any of the strip targets is still present.
-            # `MOTHERSHIP_AUTHS_TO_STRIP` is a comma-separated list rendered
-            # from .Values.harbor.mothershipAuthsToStrip — see the chart's
-            # values.yaml for the canonical hosts and rationale (TBD-V24
-            # MISS-2). Empty list → strip_remaining is empty → behaviour is
-            # identical to chart < 0.1.35.
-            strip_remaining=""
-            if [ -n "${MOTHERSHIP_AUTHS_TO_STRIP:-}" ]; then
-              # IFS-split on comma; iterate; collect hosts that still
-              # have an auth entry in existing_json.
-              old_ifs="$IFS"
-              IFS=','
-              for strip_host in ${MOTHERSHIP_AUTHS_TO_STRIP}; do
-                # Strip whitespace defensively (operator-edited overlays
-                # sometimes carry trailing spaces around commas).
-                strip_host=$(printf '%s' "${strip_host}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                [ -z "${strip_host}" ] && continue
-                # Skip the local harbor host even if an operator
-                # accidentally listed it — stripping the entry we just
-                # merged in would deadlock Phase 1.
-                if [ "${strip_host}" = "${harbor_host}" ]; then
-                  echo "[helmrepository-patches] Phase-0 WARN: refusing to strip ${strip_host} (matches local harbor host); check .Values.harbor.mothershipAuthsToStrip overlay"
-                  continue
-                fi
-                present=$(printf '%s' "${existing_json}" | jq -r --arg h "${strip_host}" \
-                  '.auths | has($h)')
-                if [ "${present}" = "true" ]; then
-                  strip_remaining="${strip_remaining}${strip_host} "
-                fi
-              done
-              IFS="$old_ifs"
-            fi
-
-            if [ -n "${already}" ] && [ "${already}" = "${harbor_auth}" ] && [ -z "${strip_remaining}" ]; then
-              echo "[helmrepository-patches] Phase-0 skip: ghcr-pull already carries auth for ${harbor_host} and mothership entries already stripped"
+            if [ -n "${already}" ] && [ "${already}" = "${harbor_auth}" ]; then
+              echo "[helmrepository-patches] Phase-0 skip: ghcr-pull already carries auth for ${harbor_host} (strip deferred to Phase 3)"
             else
-              # Single jq pipeline: ADD harbor.<sov-fqdn> auth AND
-              # DELETE every host in MOTHERSHIP_AUTHS_TO_STRIP. Both
-              # mutations happen in one pass so the Secret takes a
-              # single resourceVersion bump regardless of which side
-              # was stale. Per CLAUDE.md §3 Principle #11 the post-
-              # cutover cluster MUST NOT carry standing auth for any
-              # `openova-io`-rooted registry — leaving the ghcr.io or
-              # harbor.openova.io entries in place would let a
-              # regression silently re-authenticate against upstream
-              # (the credential-hygiene gap flagged by TBD-V24 MISS-2).
-              #
-              # `del(.auths[$h])` is idempotent — deleting a missing
-              # key is a no-op in jq, so re-runs after the initial
-              # strip just no-op the strip arms.
-              # Build the jq invocation as a single argv-shell-quoted
-              # string so we can use POSIX-sh `set --` semantics without
-              # bash-only arrays. Each entry in MOTHERSHIP_AUTHS_TO_STRIP
-              # contributes one `--arg s<N> <host>` pair + one
-              # ` | del(.auths[$s<N>])` filter stage.
+              # Single jq pass: ADD harbor.<sov-fqdn> auth. This is the
+              # PURELY ADDITIVE half of the old combined pipeline — the
+              # destructive `del(.auths[...])` arms were moved to Phase 3
+              # (see the strip-before-pivot fix). Adding Harbor auth early
+              # is the precondition that lets Phase-1's pivoted
+              # HelmRepositories pull from local Harbor; it leaves the
+              # ghcr.io fallback intact so a wedge before Phase 3 is
+              # recoverable.
               #
               # `--arg` ALWAYS treats its value as a string (no shell
-              # interpolation), so even a maliciously crafted host like
-              # `"; rm -rf /` would land verbatim as a JSON-string
-              # operand to `del()` — never executed.
-              jq_filter='.auths[$h] = {"username":$user,"auth":$auth}'
-              strip_idx=0
-              # Reset positional params so `set --` below builds a clean
-              # `--arg s<N> <host>` list. The Job's args[] passes only the
-              # script body to `sh -c`, so $@ is normally empty — this is
-              # belt-and-braces against future operator overlays adding
-              # extra args.
-              set --
-              if [ -n "${MOTHERSHIP_AUTHS_TO_STRIP:-}" ]; then
-                # POSIX-safe comma-iteration via parameter expansion.
-                rem="${MOTHERSHIP_AUTHS_TO_STRIP},"
-                while [ -n "${rem}" ] && [ "${rem}" != "," ]; do
-                  strip_host="${rem%%,*}"
-                  rem="${rem#*,}"
-                  strip_host=$(printf '%s' "${strip_host}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                  [ -z "${strip_host}" ] && continue
-                  # Defence-in-depth: never delete the local harbor
-                  # entry even if listed (matches the earlier idempotency
-                  # check that also skips it).
-                  if [ "${strip_host}" = "${harbor_host}" ]; then
-                    continue
-                  fi
-                  jq_filter="${jq_filter} | del(.auths[\$s${strip_idx}])"
-                  # Append `--arg s<N> <host>` to the positional params
-                  # so we can invoke jq with "$@" below.
-                  set -- "$@" --arg "s${strip_idx}" "${strip_host}"
-                  strip_idx=$((strip_idx+1))
-                done
-              fi
+              # interpolation), so the Harbor password is never re-parsed
+              # by the shell.
               new_json=$(printf '%s' "${existing_json}" | jq \
                 --arg h "${harbor_host}" \
                 --arg user "${HARBOR_USERNAME}" \
                 --arg auth "${harbor_auth}" \
-                "$@" \
-                "${jq_filter}")
+                '.auths[$h] = {"username":$user,"auth":$auth}')
               new_b64=$(printf '%s' "${new_json}" | base64 -w0)
               # Merge-patch the data field. Quoting note: ${GHCR_PULL_SECRET_KEY}
               # is `.dockerconfigjson` which is a literal key (the leading
@@ -415,7 +372,7 @@ data:
               if kubectl patch secret "${GHCR_PULL_SECRET_NAME}" \
                   -n "${GHCR_PULL_SECRET_NAMESPACE}" \
                   --type=merge --patch "${patch_payload}" >/dev/null; then
-                echo "[helmrepository-patches] Phase-0 OK: merged ${harbor_host} auth into ${GHCR_PULL_SECRET_NAMESPACE}/${GHCR_PULL_SECRET_NAME}"
+                echo "[helmrepository-patches] Phase-0 OK: added ${harbor_host} auth to ${GHCR_PULL_SECRET_NAMESPACE}/${GHCR_PULL_SECRET_NAME} (ghcr.io fallback retained until Phase 3)"
               else
                 echo "[helmrepository-patches] FATAL: kubectl patch ${GHCR_PULL_SECRET_NAME} failed" >&2
                 exit 1
@@ -689,35 +646,210 @@ data:
               echo "[helmrepository-patches] Phase-2.5 SKIP: ${catalyst_yaml} not present in local mirror"
             fi
 
+            # NOTE (Refs #3379 #3526): the two "nothing to push" paths below
+            # must FALL THROUGH to Phase 3 (the readiness-gated strip), NOT
+            # `exit 0` early — even when there is no Gitea edit to commit,
+            # the live HelmRepository pivot (Phase-1) may have happened and
+            # the ghcr.io strip still has to run AFTER the pivot is Ready. So
+            # they only skip the commit/push, then continue.
             if [ "${edited}" -eq 0 ]; then
-              echo "[helmrepository-patches] no edits — already pivoted in Gitea or upstream prefix not present"
-              # Don't fail; phase-1 already succeeded.
+              echo "[helmrepository-patches] no edits — already pivoted in Gitea or upstream prefix not present (continuing to Phase 3)"
+            else
+              git add "${target_dir}"
+              if git diff --staged --quiet; then
+                echo "[helmrepository-patches] git diff empty after sed — nothing to commit (continuing to Phase 3)"
+              else
+                git commit -m "cutover: pivot ${edited} HelmRepository URLs to local Harbor" >/dev/null
+                push_err=$(git push origin main 2>&1) || {
+                  echo "[helmrepository-patches] FATAL: git push failed" >&2
+                  # Surface the actual git stderr so operators can diagnose
+                  # auth / branch-protection / hook rejections without re-
+                  # running the Job. The output is git's own stderr — does
+                  # NOT contain the embedded credential (those live in the
+                  # remote URL only and git redacts them in error messages).
+                  printf '%s\n' "$push_err" >&2
+                  exit 1
+                }
+                echo "[helmrepository-patches] pushed to ${redacted} (commit will reconcile via bootstrap-kit Kustomization)"
+
+                # Trigger an immediate Flux reconciliation so the new YAML
+                # lands without waiting for the polling interval.
+                kubectl annotate --overwrite gitrepository openova \
+                  -n flux-system \
+                  "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null || true
+              fi
+            fi
+
+            # ====================================================================
+            # Phase 3 — readiness-gated mothership-auth STRIP (Refs #3379 #3526)
+            # ====================================================================
+            #
+            # THE STRIP-BEFORE-PIVOT FIX. This block performs the destructive
+            # credential-hygiene removal (TBD-V24 MISS-2) that USED to live in
+            # Phase-0. It is the LAST thing Step-06 does, and it runs ONLY
+            # after a bounded wait that PROVES every pivoted HelmRepository
+            # actually reconciles Ready from local Harbor.
+            #
+            # WHY THE MOVE (hw139 half-pivot, 8 HRs wedged 10h):
+            #   Phase-0 ran the strip BEFORE the Phase-1 URL pivot. Between
+            #   those two acts — and any time a LATER cutover step wedged
+            #   (step-05/08/10 have all wedged at various points; see Chart.yaml
+            #   changelog) — the cluster was in the lethal intermediate state:
+            #   ghcr.io creds GONE, but the live HR sources + the on-disk Gitea
+            #   YAML still `oci://ghcr.io/openova-io`. Every reconcile then
+            #   failed `no auth config for 'ghcr.io' in the docker-registry
+            #   Secret 'ghcr-pull'`, the half-pivot was permanent, and the
+            #   cutover engine (which strips again on every re-run because the
+            #   ADD+strip were one jq pass) could never recover zero-touch.
+            #
+            # THE INVARIANT THIS ENFORCES:
+            #   ghcr.io / harbor.openova.io auth is removed from ghcr-pull ONLY
+            #   when every HelmRepository this Job pivoted is already Ready=True
+            #   pulling from registry.<sov-fqdn>. If readiness does not converge
+            #   within the budget, this block EXITS NON-ZERO with the mothership
+            #   auth STILL INTACT — so the HRs keep pulling from ghcr.io and the
+            #   step is cleanly recoverable (the engine deletes the timed-out /
+            #   failed Job and re-runs; Phase-0's ADD + Phase-1's pivot are
+            #   idempotent, and this Phase-3 strip is idempotent too).
+            #
+            # Idempotency: if every strip target is already absent, the block
+            # is a pure no-op (no Secret churn). A re-run after a partial strip
+            # (jq del of a missing key is a no-op) re-converges cleanly.
+            if [ -z "${MOTHERSHIP_AUTHS_TO_STRIP:-}" ]; then
+              echo "[helmrepository-patches] Phase-3 skip: MOTHERSHIP_AUTHS_TO_STRIP empty — nothing to strip"
+              echo "[helmrepository-patches] step complete"
               exit 0
             fi
 
-            git add "${target_dir}"
-            if git diff --staged --quiet; then
-              echo "[helmrepository-patches] git diff empty after sed — nothing to commit"
-              exit 0
-            fi
-            git commit -m "cutover: pivot ${edited} HelmRepository URLs to local Harbor" >/dev/null
-            push_err=$(git push origin main 2>&1) || {
-              echo "[helmrepository-patches] FATAL: git push failed" >&2
-              # Surface the actual git stderr so operators can diagnose
-              # auth / branch-protection / hook rejections without re-
-              # running the Job. The output is git's own stderr — does
-              # NOT contain the embedded credential (those live in the
-              # remote URL only and git redacts them in error messages).
-              printf '%s\n' "$push_err" >&2
+            # ---- Phase 3a: bounded wait for the pivoted HRs to be Ready ----
+            #
+            # We only gate on the HelmRepositories whose URL now points at the
+            # LOCAL Harbor host (harbor_host) — i.e. the ones this cutover
+            # pivoted. An HR still on ghcr.io is either intentionally external
+            # or not-yet-reverted-by-Flux; gating on it would deadlock. A
+            # local-Harbor HR that is Ready=True PROVES (a) registry.<fqdn>
+            # serves the chart and (b) the Phase-0 Harbor auth works — exactly
+            # the precondition for safely dropping ghcr.io.
+            #
+            # Ready is read from the Flux source-controller condition
+            # (.status.conditions[type==Ready].status). source-controller sets
+            # Ready=True once it has FETCHED + verified the OCI artifact, which
+            # for an OCI HelmRepository means a successful authenticated pull —
+            # the very operation that 401s if Harbor auth is wrong.
+            strip_wait_deadline=$(( $(date +%s) + STRIP_READINESS_TIMEOUT_SECONDS ))
+            echo "[helmrepository-patches] Phase-3a: waiting up to ${STRIP_READINESS_TIMEOUT_SECONDS}s for local-Harbor HelmRepositories to be Ready before stripping mothership auth"
+            ready_ok="false"
+            # Snapshot file (writable /tmp emptyDir) holding one line per HR:
+            # "<ns> <name> <spec.url> <Ready-status>". Re-written each poll.
+            # Using a file (not a heredoc) keeps the whole block correctly
+            # indented inside the YAML block scalar.
+            hr_snapshot=/tmp/.hr-readiness.txt
+            while [ "$(date +%s)" -lt "${strip_wait_deadline}" ]; do
+              # Re-poke a reconcile so we don't wait out the 15m interval.
+              now_ts=$(date +%s)
+              total=0
+              not_ready=0
+              not_ready_names=""
+              kubectl get helmrepositories -A \
+                -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{" "}{.spec.url}{" "}{range .status.conditions[?(@.type=="Ready")]}{.status}{end}{"\n"}{end}' \
+                2>/dev/null > "${hr_snapshot}" || : > "${hr_snapshot}"
+              # Enumerate every HelmRepository cluster-wide; select those whose
+              # spec.url host is the local Harbor host.
+              while read -r ns name url ready; do
+                [ -z "${ns}" ] && continue
+                case "${url}" in
+                  *"//${harbor_host}/"*|*"//${harbor_host}") : ;;  # local-Harbor HR — gate on it
+                  *) continue ;;                                    # not pivoted to local Harbor — skip
+                esac
+                total=$((total+1))
+                if [ "${ready}" != "True" ]; then
+                  not_ready=$((not_ready+1))
+                  not_ready_names="${not_ready_names}${ns}/${name}(${ready:-<none>}) "
+                  kubectl annotate --overwrite -n "${ns}" "helmrepository/${name}" \
+                    "reconcile.fluxcd.io/requestedAt=${now_ts}" >/dev/null 2>&1 || true
+                fi
+              done < "${hr_snapshot}"
+              if [ "${total}" -gt 0 ] && [ "${not_ready}" -eq 0 ]; then
+                ready_ok="true"
+                echo "[helmrepository-patches] Phase-3a OK: all ${total} local-Harbor HelmRepository(ies) Ready=True"
+                break
+              fi
+              echo "[helmrepository-patches] Phase-3a: ${not_ready}/${total} local-Harbor HelmRepository(ies) not yet Ready: ${not_ready_names:-<none>}; retrying in 15s"
+              sleep 15
+            done
+
+            if [ "${ready_ok}" != "true" ]; then
+              echo "[helmrepository-patches] FATAL: local-Harbor HelmRepositories did not all reach Ready=True within ${STRIP_READINESS_TIMEOUT_SECONDS}s — REFUSING to strip ghcr.io / harbor.openova.io auth (leaving mothership auth intact so the cluster keeps pulling from ghcr.io and this step is recoverable on re-run)" >&2
+              kubectl get helmrepositories -A 2>&1 >&2 || true
               exit 1
-            }
-            echo "[helmrepository-patches] pushed to ${redacted} (commit will reconcile via bootstrap-kit Kustomization)"
+            fi
 
-            # Trigger an immediate Flux reconciliation so the new YAML
-            # lands without waiting for the polling interval.
-            kubectl annotate --overwrite gitrepository openova \
-              -n flux-system \
-              "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null || true
+            # ---- Phase 3b: strip the mothership auth (now safe) ----
+            #
+            # Re-read the Secret fresh (Phase-0's ADD + reflector may have
+            # bumped its resourceVersion) and del() every strip target. The
+            # local harbor host is NEVER stripped (defence-in-depth, even if an
+            # operator overlay erroneously lists it). `--arg` keeps every host
+            # a verbatim JSON string (no shell interpolation / injection).
+            strip_b64=$(read_secret_key "${target_ns}")
+            if [ -z "${strip_b64}" ]; then
+              echo "[helmrepository-patches] FATAL: Phase-3b cannot re-read ${target_ns}/${GHCR_PULL_SECRET_NAME} ${GHCR_PULL_SECRET_KEY}" >&2
+              exit 1
+            fi
+            strip_json=$(printf '%s' "${strip_b64}" | base64 -d)
+
+            # Determine which targets are still present (no-op if none).
+            strip_remaining=""
+            rem="${MOTHERSHIP_AUTHS_TO_STRIP},"
+            while [ -n "${rem}" ] && [ "${rem}" != "," ]; do
+              strip_host="${rem%%,*}"
+              rem="${rem#*,}"
+              strip_host=$(printf '%s' "${strip_host}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+              [ -z "${strip_host}" ] && continue
+              if [ "${strip_host}" = "${harbor_host}" ]; then
+                echo "[helmrepository-patches] Phase-3b WARN: refusing to strip ${strip_host} (matches local harbor host); check .Values.harbor.mothershipAuthsToStrip overlay"
+                continue
+              fi
+              present=$(printf '%s' "${strip_json}" | jq -r --arg h "${strip_host}" '.auths | has($h)')
+              [ "${present}" = "true" ] && strip_remaining="${strip_remaining}${strip_host} "
+            done
+
+            if [ -z "${strip_remaining}" ]; then
+              echo "[helmrepository-patches] Phase-3b skip: mothership auth entries already absent from ghcr-pull"
+              echo "[helmrepository-patches] step complete"
+              exit 0
+            fi
+
+            # Build the `del(.auths[$sN])` jq filter + matching --arg list via
+            # POSIX positional params (no bash arrays).
+            jq_filter='.'
+            strip_idx=0
+            set --
+            rem="${MOTHERSHIP_AUTHS_TO_STRIP},"
+            while [ -n "${rem}" ] && [ "${rem}" != "," ]; do
+              strip_host="${rem%%,*}"
+              rem="${rem#*,}"
+              strip_host=$(printf '%s' "${strip_host}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+              [ -z "${strip_host}" ] && continue
+              if [ "${strip_host}" = "${harbor_host}" ]; then
+                continue
+              fi
+              jq_filter="${jq_filter} | del(.auths[\$s${strip_idx}])"
+              set -- "$@" --arg "s${strip_idx}" "${strip_host}"
+              strip_idx=$((strip_idx+1))
+            done
+
+            stripped_json=$(printf '%s' "${strip_json}" | jq "$@" "${jq_filter}")
+            stripped_b64=$(printf '%s' "${stripped_json}" | base64 -w0)
+            strip_patch=$(printf '{"data":{"%s":"%s"}}' "${GHCR_PULL_SECRET_KEY}" "${stripped_b64}")
+            if kubectl patch secret "${GHCR_PULL_SECRET_NAME}" \
+                -n "${GHCR_PULL_SECRET_NAMESPACE}" \
+                --type=merge --patch "${strip_patch}" >/dev/null; then
+              echo "[helmrepository-patches] Phase-3b OK: stripped mothership auth (${strip_remaining}) from ${GHCR_PULL_SECRET_NAMESPACE}/${GHCR_PULL_SECRET_NAME} — Sovereign now pulls EXCLUSIVELY from ${harbor_host}"
+            else
+              echo "[helmrepository-patches] FATAL: Phase-3b kubectl patch ${GHCR_PULL_SECRET_NAME} (strip) failed" >&2
+              exit 1
+            fi
 
             echo "[helmrepository-patches] step complete"
         resources:

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -279,13 +279,19 @@ if ! grep -q 'gitea_host=' "$TMP/render.yaml"; then
 fi
 echo "  PASS (Step-01 has DNS readiness probe)"
 
-echo "[cutover-contract] Case 17: Step-06 phase-0 merges harbor.<sov-fqdn> auth into ghcr-pull (#1184)"
+echo "[cutover-contract] Case 17: Step-06 phase-0 ADDS harbor.<sov-fqdn> auth to ghcr-pull (#1184)"
 # 0.1.23 only patched HelmRepository URLs; the pivoted URLs 401 on
 # first reconcile because ghcr-pull lacks auth for harbor.<sov-fqdn>.
 # 0.1.24 adds Phase-0 to Step-06 that merges admin:<password> into the
 # Secret. Guard against future regressions that drop the merge.
-if ! grep -q 'Phase 0: merge harbor' "$TMP/render.yaml"; then
-  echo "FAIL: Step-06 missing Phase 0 (harbor.<sov-fqdn> auth merge into ghcr-pull) (#1184)" >&2
+#
+# Strip-before-pivot fix (Refs #3379 #3526): Phase-0 is now PURELY
+# ADDITIVE ("Phase 0: ADD harbor...") — the destructive mothership-auth
+# strip moved to Phase 3 (see Case 17b). The harbor-auth ADD itself MUST
+# still be wired here (it's the precondition for the pivot to pull from
+# local Harbor).
+if ! grep -q 'Phase 0: ADD harbor' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 missing Phase 0 (harbor.<sov-fqdn> auth ADD into ghcr-pull) (#1184)" >&2
   exit 1
 fi
 if ! grep -q 'GHCR_PULL_SECRET_NAME' "$TMP/render.yaml"; then
@@ -307,6 +313,59 @@ if ! awk '/^kind: ClusterRole$/,/^---$/' "$TMP/render.yaml" \
   exit 1
 fi
 echo "  PASS (Step-06 Phase-0 ghcr-pull merge wired)"
+
+echo "[cutover-contract] Case 17b: Step-06 strips mothership auth in Phase 3 (AFTER pivot+readiness), NOT in Phase-0 (strip-before-pivot fix, Refs #3379 #3526)"
+# THE STRIP-BEFORE-PIVOT GUARD. hw139: Phase-0 stripped ghcr.io/harbor.
+# openova.io BEFORE the Phase-1 URL pivot; a later step wedged → ghcr.io
+# creds gone while HR sources still pointed at ghcr.io → 8 HRs wedged on
+# "no auth config for 'ghcr.io'", unrecoverable zero-touch. The fix moves
+# the destructive `del(.auths[...])` strip to a NEW Phase 3 at the END of
+# Step-06, gated behind a bounded wait that proves every local-Harbor
+# HelmRepository is Ready=True FIRST. This case locks that ordering in.
+#
+# (a) The strip must exist and be labelled Phase-3 (not Phase-0).
+if ! grep -q 'Phase 3 — readiness-gated mothership-auth STRIP' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 missing the Phase-3 readiness-gated strip block (strip-before-pivot fix, Refs #3379 #3526)" >&2
+  exit 1
+fi
+# (b) A readiness wait MUST gate the strip: the strip-readiness timeout
+#     env + the Ready=True wait loop + the fail-closed REFUSE message.
+if ! grep -q 'STRIP_READINESS_TIMEOUT_SECONDS' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 missing STRIP_READINESS_TIMEOUT_SECONDS env — the strip is not readiness-gated (Refs #3379 #3526)" >&2
+  exit 1
+fi
+if ! grep -q 'REFUSING to strip ghcr.io' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 strip is not fail-closed — must REFUSE the strip (exit non-zero, ghcr.io auth intact) when the pivot does not reach Ready (Refs #3379 #3526)" >&2
+  exit 1
+fi
+# (c) The strip env timeout MUST be backed by a chart value (the test
+#     runs from CHART_DIR, so values.yaml is CWD-relative). Belt-and-
+#     braces with (b): the rendered env carrying a non-empty value below
+#     already proves it flows, but assert the source knob exists too.
+if ! grep -q 'stripReadinessSeconds' values.yaml; then
+  echo "FAIL: chart values.yaml missing stepTimeouts.stripReadinessSeconds (backs STRIP_READINESS_TIMEOUT_SECONDS) (Refs #3379 #3526)" >&2
+  exit 1
+fi
+# The rendered env MUST carry a concrete positive integer (not empty).
+if ! grep -A1 'name: STRIP_READINESS_TIMEOUT_SECONDS' "$TMP/render.yaml" | grep -Eq 'value: "[0-9]+"'; then
+  echo "FAIL: STRIP_READINESS_TIMEOUT_SECONDS rendered with no/empty value (Refs #3379 #3526)" >&2
+  exit 1
+fi
+# (d) Phase-0 MUST NOT carry the destructive del() — verify the ONLY
+#     non-comment `del(.auths[` occurrence sits AFTER the Phase-3 header.
+#     (Comment lines mentioning del() are fine; the executable jq filter
+#     line `jq_filter="... | del(.auths[$s...` is the one that matters.)
+phase3_line=$(grep -n 'Phase 3 — readiness-gated mothership-auth STRIP' "$TMP/render.yaml" | head -1 | cut -d: -f1)
+del_exec_line=$(grep -n 'jq_filter=.*del(.auths\[' "$TMP/render.yaml" | head -1 | cut -d: -f1)
+if [ -z "${del_exec_line}" ]; then
+  echo "FAIL: Step-06 has no executable del(.auths[...]) jq filter — the strip was dropped entirely (Refs #3379 #3526)" >&2
+  exit 1
+fi
+if [ -z "${phase3_line}" ] || [ "${del_exec_line}" -lt "${phase3_line}" ]; then
+  echo "FAIL: Step-06 executable strip del(.auths[...]) at line ${del_exec_line} runs BEFORE the Phase-3 header at line ${phase3_line:-<none>} — strip-before-pivot regression (Refs #3379 #3526)" >&2
+  exit 1
+fi
+echo "  PASS (strip is in Phase 3, readiness-gated + fail-closed, after the pivot)"
 
 echo "[cutover-contract] Case 16: Step-06 helmrepository-patches pushes YAML edit to local Gitea (#970)"
 # 0.1.19 Step-06 only ran kubectl patch against live HelmRepository

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -572,7 +572,40 @@ stepTimeouts:
   # 15m cap that silently bounded every long step.
   harborPrewarmSeconds: 5400
   fluxGitRepositoryPatchSeconds: 600
-  helmRepositoryPatchesSeconds: 600
+  # Step 06 (helmrepository-patches) activeDeadlineSeconds. This step now
+  # has FOUR potentially-slow waits inside one Job and the deadline must
+  # cover their SUM in the worst case:
+  #   Phase -1  gateway-wait        up to gateway.waitTimeoutSeconds (1800s/30m)
+  #   Phase 0/1/2  auth-add + URL pivot + Gitea push   (seconds)
+  #   Phase 3a  strip-readiness wait up to stripReadinessSeconds (600s/10m)
+  # Raised 600 → 2400 (40m) by the strip-before-pivot fix (Refs #3379
+  # #3526) so the new Phase-3 readiness gate can run to convergence
+  # without the Job-level deadline killing it mid-wait (which would be a
+  # DeadlineExceeded = transient, so the engine re-runs — but a clean
+  # 40m ceiling avoids needless churn). Honored end-to-end because
+  # catalyst-api stamps the Job/watch deadline from this per-step value
+  # (cutover.go cutoverStepDeadline → createCutoverJob /
+  # watchJobToCompletion), taking the MAX of it and the global default.
+  # Event-driven: a fast run (gateway already Programmed, HRs reconcile
+  # in seconds) returns immediately and never waits out the ceiling.
+  helmRepositoryPatchesSeconds: 2400
+  # Step 06 Phase-3a (strip-before-pivot fix, Refs #3379 #3526). After the
+  # Phase-1 URL pivot + Phase-2 durable Gitea push, Step-06 waits up to
+  # this long for EVERY HelmRepository now pointing at local Harbor to
+  # report Ready=True (source-controller fetched + verified the OCI
+  # artifact — proving registry.<fqdn> serves the chart AND the Phase-0
+  # Harbor auth works) BEFORE it strips the ghcr.io / harbor.openova.io
+  # fallback from ghcr-pull. If the pivot does not converge within this
+  # budget the strip is REFUSED and the Job exits non-zero with the
+  # mothership auth INTACT — the cluster keeps pulling from ghcr.io and
+  # the step is recoverable on the next engine re-run (the prior fail is a
+  # genuine exit, so an operator /cutover/start re-fire re-drives it; a
+  # DeadlineExceeded variant re-runs automatically). 600s (10m) is
+  # generous: the charts were skopeo-prewarmed into local Harbor at
+  # Step-03, so a pivoted HR's first authenticated pull is typically
+  # seconds. The re-poke-reconcile inside the loop means a fast converge
+  # returns well under the ceiling.
+  stripReadinessSeconds: 600
   catalystAPIEnvPatchSeconds: 600
   # 600s deny survival window + up to 300s #3526 bounded pivot-poll
   # (force-reconcile GitRepository + bootstrap-kit Kustomization and wait


### PR DESCRIPTION
## The wedge (verified live on hw139)

`kubectl get hr -A` on hw139 showed **8 HelmReleases frozen for 10h** on:

```
failed to configure login options: no auth config for 'ghcr.io' in the docker-registry Secret 'ghcr-pull'
```

— 3 direct (`bp-catalyst-platform`, `bp-openbao`, `bp-self-sovereign-cutover` — the engine wedged ITSELF) + 5 transitive (`bp-continuum`, `bp-external-secrets-stores`, `bp-newapi`, `bp-sso-bridge`, `bp-sandbox`). This also blocked the unrelated merged `bp-newapi` #3564 from rolling.

Every namespace's `ghcr-pull` Secret held **only** `registry.hw139.omani.works` (the `ghcr.io` key was stripped) while the `HelmRepository(type:oci)` sources still resolved to `oci://ghcr.io/openova-io`.

## Root cause — strip BEFORE pivot

Step-06 (`helmrepository-patches`) ran the **destructive `ghcr.io` / `harbor.openova.io` auth STRIP in Phase-0** — which executes **before** Phase-1's live HelmRepository URL pivot and Phase-2's durable Gitea push (the strip + the Harbor-auth add were a single jq pass). The instant Phase-0 stripped the creds, the cluster sat in the lethal intermediate state: **ghcr.io creds gone, HR sources still ghcr.io.** If any later cutover step wedged (step-05/08/10 have all wedged across the #3379 saga), the half-pivot was permanent and unrecoverable zero-touch — and because the strip re-ran on every engine re-fire, recovery was impossible.

## The fix

`platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml`:

1. **Phase-0 is now purely ADDITIVE** — merges the local Harbor auth into `ghcr-pull` and nothing else. The `ghcr.io` fallback stays intact through the entire pivot.
2. **The destructive strip MOVED to a new Phase 3** at the END of Step-06, after Phase-1 (live URL pivot) + Phase-2 (durable Gitea push). The two former "nothing to push" early `exit 0`s now **fall through** to Phase 3 (the live pivot may have happened even with no Gitea edit).
3. **Phase 3 is GATED.** Phase-3a bounded-waits (`stripReadinessSeconds`, 600s) for **every** HelmRepository now pointing at local Harbor to report `Ready=True` — i.e. source-controller fetched + verified the OCI artifact, which proves `registry.<fqdn>` serves the chart AND the Phase-0 Harbor auth works. Only **then** does Phase-3b run `del(.auths[ghcr.io,...])`. If the pivot does **not** converge (or nothing pivoted), Phase-3a **exits non-zero with the mothership auth INTACT** → the cluster keeps pulling from ghcr.io → the step is recoverable on the next engine re-run.

**Invariant:** ghcr.io creds are never stripped until every HR is already pulling `Ready` from `registry.<fqdn>`. A strip-before-pivot wedge is now structurally impossible.

**Resume coherence preserved:** still 11 steps; Step-06 stays Step-06. A genuine Phase-3a timeout surfaces as a terminal step failure (auto-resume fail-closed, ghcr.io intact → recoverable) that an operator `POST /cutover/start` re-fire (`operatorRetry=true`, already in `cutover.go`) re-drives cleanly — Phase-0 ADD skips (idempotent), Phase-1 pivot SKIPs (already pivoted), Phase-3 strips once HRs are Ready. A `DeadlineExceeded` variant auto-re-runs via `jobFailedTransiently`.

## Lockstep

- `stepTimeouts.helmRepositoryPatchesSeconds` 600 → **2400** (40m) so the Job-level `activeDeadlineSeconds` covers the SUM of the in-Job waits (Phase -1 gateway-wait up to 1800s + Phase-3a strip-readiness up to 600s + buffer); honored end-to-end via `cutover.go` `cutoverStepDeadline`.
- new `stepTimeouts.stripReadinessSeconds` (600s) + `STRIP_READINESS_TIMEOUT_SECONDS` env.
- contract test Case 17 renamed (merge→ADD) + **new Case 17b** locks the strip into Phase 3 (readiness-gated, fail-closed, after the pivot).
- chart `0.1.62` → **`0.1.63`**; `06a` slot pin + `blueprint.yaml` bumped in lockstep.

No catalyst-api Go change.

## Validation

- `helm lint` clean.
- All 25 cutover contract cases green (incl. new Case 17b).
- Rendered Step-06 shell passes `dash -n` (the strict POSIX `/bin/sh` that kom4dc ships).
- `go test ./internal/handler -run Cutover` green (no engine change).

**Live 11-step → `cutoverComplete=true` walk is DEFERRED to the next clean fresh prov** — kom4dc is infra-gated (fresh provs fail at the API-conflict layer) and hw139 is already half-pivoted and must NOT be hand-patched. This is a build-and-merge fix so the next clean prov's cutover completes instead of wedging.

Refs #3379 #3526

🤖 Generated with [Claude Code](https://claude.com/claude-code)