### PR TITLE
feat(bp-postgres): active-hot-standby = REAL cross-region cnpg-pair — shared-pg data tier no longer hollow (0.2.0)

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -121,7 +121,15 @@ spec:
       # bootstrap INSTALL, before the umbrella shipped the CRD).
       # 0.1.10 (#3375): role-Secret name RFC-1123 sanitization (lockstep
       # bump with 16c/16d — underscore-owner fix, see chart changelog).
-      version: 0.1.10
+      # 0.2.0 (#3571, Refs #3375 North-Star-4): active-hot-standby now renders
+      # the PROVEN bp-cnpg-pair SPLIT-SIDE cross-region shape (primary Cluster
+      # keeps the `shared-pg` name so the consumer host shared-pg-rw is
+      # unchanged + ClusterMesh-global shared-pg-mesh Service + native
+      # synchronous block; shared-pg-replica follower streams WAL on the
+      # secondary cluster) instead of the hw126 stretched-cluster antiAffinity.
+      # Gated by topology.crossRegion below (the SOVEREIGN_ENABLE_CNPG_PAIR
+      # post-mesh signal) so single-region provs stay byte-identical singletons.
+      version: 0.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -165,14 +173,37 @@ spec:
     instance:
       name: shared-pg
       namespace: shared-data
-      # Multi-region Sovereigns spread CNPG across regions; single-region
-      # falls back to 1. (Same envsubst seam as bp-gitea/bp-harbor.)
-      # Topology is singleton here for the Phase-2 reuse proof; flip to
-      # active-hot-standby for the Pillar-3 shape.
       storageSize: 10Gi
+    # ── Topology — cross-region active-hot-standby (#3571, Refs #3375) ───
+    # mode stays `singleton` so a single-region prov (or a 2-region prov
+    # BEFORE catalyst-api confirms the mesh) renders the byte-identical
+    # singleton shared-pg Cluster. crossRegion is wired to the SAME
+    # SOVEREIGN_ENABLE_CNPG_PAIR post-mesh-confirm substitute bp-cnpg-pair
+    # (slot 16b) rides — catalyst-api patches it true onto EVERY region's
+    # bootstrap-kit Kustomization (handler/clustermesh.go) only after
+    # ClusterMesh is established + the primary's replica-auth Secrets sync.
+    # When it flips true the chart renders the PROVEN bp-cnpg-pair split-side
+    # shape: side=primary (region-A) → the named `shared-pg` Cluster (so the
+    # keycloak/gitea/harbor host shared-pg-rw is unchanged) + the
+    # ClusterMesh-global shared-pg-mesh Service; side=secondary (region-B) →
+    # the shared-pg-replica follower streaming WAL over the mesh. side is
+    # stamped from the per-region SOVEREIGN_REGION_ROLE (primary|secondary).
+    # primary/replica.region carry the canonical openova.io/region node
+    # labels. A region-kill then preserves the consumers' data (keycloak
+    # realm survives a region-A kill) via bp-continuum's cnpg-pair switchover.
     topology:
       mode: singleton
+      crossRegion: ${SOVEREIGN_ENABLE_CNPG_PAIR:-false}
+      side: ${SOVEREIGN_REGION_ROLE:-primary}
+      # singleton instance count — UNCHANGED at 1 (byte-identical). The pair's
+      # per-side instance count is the SEPARATE chart default haInstances (3,
+      # the bp-cnpg-pair canonical), so flipping crossRegion never perturbs
+      # the singleton render's instances field.
       instances: 1
+      primary:
+        region: '${SOVEREIGN_PRIMARY_REGION:-}'
+      replica:
+        region: '${SOVEREIGN_REPLICA_REGION:-}'
     # The three bindings — the reuse proof. Three isolated databases +
     # three roles on ONE Cluster; each reflected into its consumer's
     # namespace.

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -72,7 +72,13 @@ spec:
       # finally renders on already-converged Sovereigns.
       # 0.1.10 (#3375): role-Secret name RFC-1123 sanitization (lockstep
       # bump with 16a/16d — underscore-owner fix, see chart changelog).
-      version: 0.1.10
+      # 0.2.0 (#3571, Refs #3375 North-Star-4): active-hot-standby = REAL
+      # bp-cnpg-pair split-side cross-region shape (shared-pg-b primary keeps
+      # its name so grafana/powerdns hosts are unchanged + shared-pg-b-mesh
+      # global Service + shared-pg-b-replica follower). Gated by
+      # topology.crossRegion below (SOVEREIGN_ENABLE_CNPG_PAIR). Single-region
+      # stays a byte-identical singleton. Lockstep bump with 16a/16d.
+      version: 0.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -98,9 +104,22 @@ spec:
       name: shared-pg-b
       namespace: shared-data
       storageSize: 10Gi
+    # Cross-region active-hot-standby (#3571) — see 16a for the full design.
+    # crossRegion rides SOVEREIGN_ENABLE_CNPG_PAIR (catalyst-api post-mesh
+    # flip); OFF/single-region renders a byte-identical singleton. side from
+    # SOVEREIGN_REGION_ROLE; regions from the canonical node labels. When ON:
+    # side=primary → named shared-pg-b Cluster (grafana/powerdns host
+    # shared-pg-b-rw unchanged) + shared-pg-b-mesh; side=secondary →
+    # shared-pg-b-replica follower streaming WAL over the mesh.
     topology:
       mode: singleton
+      crossRegion: ${SOVEREIGN_ENABLE_CNPG_PAIR:-false}
+      side: ${SOVEREIGN_REGION_ROLE:-primary}
       instances: 1
+      primary:
+        region: '${SOVEREIGN_PRIMARY_REGION:-}'
+      replica:
+        region: '${SOVEREIGN_REPLICA_REGION:-}'
     databases:
       # grafana — FLIPPED (see header). The extraData keys are grafana's
       # native GF_DATABASE_* env contract; GF_DATABASE_HOST carries

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -59,7 +59,13 @@ spec:
       # Context additions below.
       # 0.1.10 (#3375): role-Secret name RFC-1123 sanitization — fixes THIS
       # slot's Stalled upgrade (Secret "shared-pg-c-openova_flow" invalid).
-      version: 0.1.10
+      # 0.2.0 (#3571, Refs #3375 North-Star-4): active-hot-standby = REAL
+      # bp-cnpg-pair split-side cross-region shape (shared-pg-c primary keeps
+      # its name so the SME mesh / newapi / openova-flow hosts are unchanged +
+      # shared-pg-c-mesh global Service + shared-pg-c-replica follower). Gated
+      # by topology.crossRegion below (SOVEREIGN_ENABLE_CNPG_PAIR). Single-
+      # region stays a byte-identical singleton. Lockstep bump with 16a/16c.
+      version: 0.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -85,9 +91,22 @@ spec:
       name: shared-pg-c
       namespace: shared-data
       storageSize: 10Gi
+    # Cross-region active-hot-standby (#3571) — see 16a for the full design.
+    # crossRegion rides SOVEREIGN_ENABLE_CNPG_PAIR (catalyst-api post-mesh
+    # flip); OFF/single-region renders a byte-identical singleton. side from
+    # SOVEREIGN_REGION_ROLE; regions from the canonical node labels. When ON:
+    # side=primary → named shared-pg-c Cluster (SME mesh / newapi / openova-flow
+    # host shared-pg-c-rw unchanged) + shared-pg-c-mesh; side=secondary →
+    # shared-pg-c-replica follower streaming WAL over the mesh.
     topology:
       mode: singleton
+      crossRegion: ${SOVEREIGN_ENABLE_CNPG_PAIR:-false}
+      side: ${SOVEREIGN_REGION_ROLE:-primary}
       instances: 1
+      primary:
+        region: '${SOVEREIGN_PRIMARY_REGION:-}'
+      replica:
+        region: '${SOVEREIGN_REPLICA_REGION:-}'
     # The SME-mesh bindings: three isolated databases, ONE role `sme`
     # (chart 0.1.5 dedupes the role + password Secret across same-owner
     # bindings). Database names mirror smePostgres.cluster.database +

--- a/docs/topology-matrix.md
+++ b/docs/topology-matrix.md
@@ -196,10 +196,11 @@ adjudicates. No silent deviation.
 | (b) the two regions run as independent full stacks | tracked; ClusterMesh + cnpg-pair pair the stateful tiers (hw128 PASS) | #3241/#3307/#3322 |
 | (c) 0 Application CRs | **#3370** (creating them now) | #3370 |
 | (d) G115 — grafana ships no datasource/dashboard provisioning | **this ticket DoD-5** | #3375 |
+| (e) the SHARED-PG data tier (shared-pg/-b/-c) was a HOLLOW singleton — its consumers (keycloak/gitea/harbor ← shared-pg; grafana/powerdns ← -b; newapi/openova-flow/sme_* ← -c) declared active-hot-standby but lost data on a region-kill | **#3571 (this fix)**: bp-postgres 0.2.0 makes active-hot-standby render the PROVEN bp-cnpg-pair split-side shape (primary keeps `<instance>` so the `<instance>-rw` consumer host is unchanged + ClusterMesh-global `<instance>-mesh` Service + native synchronous block; `<instance>-replica` follower streams WAL on the secondary cluster). Gated on `topology.crossRegion`=`SOVEREIGN_ENABLE_CNPG_PAIR` (the post-mesh-confirm signal cnpg-pair rides); catalyst-api syncs the shared instances' `-replication`/`-ca` Secrets primary→replica (clustermesh.go #3254 extended to shared-data). bp-continuum drives the switchover (same cnpgPromoter as hw128). Single-region stays a byte-identical singleton. **Deferred validation**: region-kill must preserve a consumer's data (keycloak realm survives a region-A kill) on the next clean 2-region fresh prov | #3571 (Refs #3375) |
 
 ---
 
-_Refreshed by #3375. The agreement doc (2026-06-02) + `docs/ARCHITECTURE.md` §3/§8
+_Refreshed by #3375 / #3571. The agreement doc (2026-06-02) + `docs/ARCHITECTURE.md` §3/§8
 + `docs/DOD.md` Pillars 2-3 are the canon this matrix converges to._
 
 ---

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-4-1-data-services
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.1.10
+  version: 0.2.0
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,5 +1,19 @@
 apiVersion: v2
 name: bp-postgres
+# 0.2.0 — #3571 (Refs #3375 North-Star-4): active-hot-standby now renders the
+#   PROVEN bp-cnpg-pair SPLIT-SIDE cross-region shape (primary Cluster keeps the
+#   instance name so the consumer host `<instance>-rw` is unchanged + a
+#   ClusterMesh-global `<instance>-mesh` Service via managed.services.additional
+#   + the CNPG-native `synchronous` block; a `<instance>-replica` follower on
+#   side=replica streams WAL over the mesh) INSTEAD of the old single-Cluster
+#   region antiAffinity (the hw126 stretched-cluster fallacy that could never
+#   schedule region-B pods on cluster-A). This makes the 3 shared-pg engines'
+#   declared active-hot-standby REAL at the data layer — a region-kill preserves
+#   a consumer's data (e.g. keycloak realm survives a region-A kill) via
+#   bp-continuum's cnpg-pair switchover. singleton render is STRUCTURALLY
+#   byte-identical (proven: only per-render randAlphaNum passwords differ).
+#   New topology knobs: side/primary.region/replica.region/clusterMesh/
+#   networkPolicy — ALL active-hot-standby-only; singleton ignores them.
 # 0.1.10 — #3375: sanitize the per-OWNER role-Secret name (roleSecretName
 #   helper) so an owner with a legal-Postgres underscore (e.g. `openova_flow`)
 #   renders the valid k8s Secret name `<instance>-openova-flow` instead of the
@@ -23,7 +37,7 @@ name: bp-postgres
 #   regions so it admits under BOTH the pre-#3370 CRD (hard-required) and the
 #   #3370 CRD (CEL-waived) — breaks the live upgrade-rollback deadlock that
 #   blocked keycloak->gitea->catalyst-platform on hw130.
-version: 0.1.10
+version: 0.2.0
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable
@@ -53,6 +67,48 @@ description: |
 
   Changelog
   ─────────
+  0.2.0 (2026-06-15, Refs #3375 / #3571 — active-hot-standby = REAL cnpg-pair)
+    - topology.mode=active-hot-standby now renders the PROVEN bp-cnpg-pair
+      SPLIT-SIDE cross-region shape, replacing the old single multi-instance
+      Cluster + `topology.kubernetes.io/region` antiAffinity (the hw126
+      stretched-cluster fallacy: a 2-region Sovereign is two SEPARATE
+      ClusterMesh-joined clusters, so one Cluster CR's region-B pods can NEVER
+      schedule on cluster-A). Each region's control plane applies the same HR;
+      `topology.side` (primary|replica|secondary, from SOVEREIGN_REGION_ROLE)
+      selects which half it renders:
+        side=primary (cluster.yaml): a Cluster that KEEPS the instance name —
+          so the consumer host `<instance>-rw.<ns>.svc.cluster.local` is
+          UNCHANGED (keycloak/gitea/harbor/grafana/... bind it as today) —
+          with region node-affinity + primaryUpdateMethod:switchover + the
+          CNPG-native `spec.postgresql.synchronous` block (method=first,
+          dataDurability=required — NOT a raw synchronous_standby_names
+          parameter, which the CNPG webhook rejects as fixed, the #3195 trap)
+          + a ClusterMesh-global `<instance>-mesh` Service via
+          `managed.services.additional`. The Database CRs + managed roles +
+          hub Secrets + the Application card render here only.
+        side=replica (replica-cluster.yaml + replica-mesh-service.yaml): a
+          `<instance>-replica` follower Cluster (replica.enabled +
+          pg_basebackup + externalClusters streaming the primary's WAL over
+          the `-mesh` global Service) + a same-named local `-mesh` Service
+          stub (Cilium merges global services by name+namespace; zero local
+          backends → traffic crosses the mesh) + the #3322 own-cluster +
+          hw126 operator-status NetworkPolicy carve-outs. NO Database CRs /
+          roles / hub Secrets (the replica inherits the catalog via WAL).
+    - bp-continuum drives the cross-region switchover (its cnpgPromoter flips
+      `spec.replica.enabled` on the `<instance>` + `<instance>-replica` CR
+      halves — the SAME mechanism the hw128 region-kill walk PASSED, RTO 18s /
+      RPO 0). catalyst-api copies the primary's `<instance>-replication` /
+      `<instance>-ca` TLS Secrets primary→replica before the cnpg-pair flip
+      (handler/clustermesh.go, the #3254 sync extended to shared-data).
+    - New topology knobs (ALL active-hot-standby-only; singleton ignores them):
+      side, primary.region, replica.region, clusterMesh.{enabled,affinity},
+      networkPolicy.{enabled,operatorNamespace,operatorStatusPort,
+      operatorMetricsPort}.
+    - SAFE-BY-DEFAULT: singleton (the default) render is STRUCTURALLY
+      byte-identical to 0.1.10 (proven by the chart-render diff: only the
+      per-render randAlphaNum passwords differ). active-hot-standby is gated
+      by the bootstrap-kit slots on SOVEREIGN_ENABLE_CNPG_PAIR (the post-mesh
+      confirm signal bp-cnpg-pair uses) so single-region provs are unchanged.
   0.1.10 (2026-06-14, Refs #3375 — role-Secret name RFC-1123 sanitization)
     - _helpers.tpl: new `bp-postgres.k8sName` sanitizer; `roleSecretName`
       now sanitizes the owner segment so an owner like `openova_flow` yields
@@ -174,5 +230,9 @@ annotations:
   # `--api-versions postgresql.cnpg.io/v1`) is fully covered by the unit test
   # chart/tests/postgres-render.sh, which CI runs via the `tests/*.sh` gate.
   catalyst.openova.io/smoke-render-mode: "default-off"
-  catalyst.openova.io/depends-on: "bp-cnpg,bp-reflector"
+  # bp-cilium is added for the active-hot-standby split-side path: the
+  # replica's WAL stream rides Cilium ClusterMesh (the `-mesh` global Service).
+  # Implicit via bootstrap-kit ordering (cilium is slot 01, always Ready first)
+  # — listed here for the dependency graph. singleton needs neither.
+  catalyst.openova.io/depends-on: "bp-cnpg,bp-reflector,bp-cilium"
   catalyst.openova.io/issue: "3188"

--- a/platform/postgres/chart/templates/_helpers.tpl
+++ b/platform/postgres/chart/templates/_helpers.tpl
@@ -18,6 +18,97 @@ bp-postgres common helpers (ADR-0010, #3188).
 {{- end -}}
 
 {{/*
+active-hot-standby cross-region split-side resolution (#3375 / #3571).
+
+A 2-region Sovereign is two SEPARATE k3s clusters joined by Cilium
+ClusterMesh — NOT one stretched cluster. In `active-hot-standby` mode the
+data instance therefore renders the bp-cnpg-pair split-side shape: the
+PRIMARY half lands on region-A's control plane, the REPLICA half on
+region-B's. Each cluster applies the SAME HelmRelease and `topology.side`
+(stamped from the per-region SOVEREIGN_REGION_ROLE substitute) selects
+which half it renders.
+
+`topology.side` value domain: primary|replica|secondary (secondary aliases
+replica so the bootstrap-kit substitutes the cloud-init role verbatim).
+Empty/unset → primary, so a singleton install (where the split never
+applies) keeps the historical single-cluster behaviour. Any other value
+fails the render. Mirrors bp-cnpg-pair's `cnpg-pair.side` helper exactly.
+*/}}
+{{- define "bp-postgres.side" -}}
+{{- $side := default "primary" .Values.topology.side -}}
+{{- if eq $side "secondary" -}}
+{{- $side = "replica" -}}
+{{- end -}}
+{{- if and (ne $side "primary") (ne $side "replica") -}}
+{{- fail (printf "topology.side must be one of primary|replica|secondary — got %q" .Values.topology.side) -}}
+{{- end -}}
+{{- $side -}}
+{{- end -}}
+
+{{- define "bp-postgres.isReplicaSide" -}}
+{{- if eq (include "bp-postgres.side" .) "replica" -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Whether this install renders the active-hot-standby (cnpg-pair) shape.
+
+TRUE when EITHER `topology.mode` is the literal `active-hot-standby` OR the
+boolean `topology.crossRegion` is set — the bootstrap-kit slots wire
+`topology.crossRegion` to ${SOVEREIGN_ENABLE_CNPG_PAIR:-false}, the SAME
+post-mesh-confirm signal bp-cnpg-pair's `cnpgPair.enabled` rides (catalyst-api
+patches it onto every region's Kustomization only after ClusterMesh is
+established + the primary's replica-auth Secrets sync). This boolean seam lets
+the slots flip the shared instances into the pair shape WITHOUT a second
+catalyst-api flip-key (envsubst can substitute a plain true/false, but can't
+turn the boolean into the `active-hot-standby` mode STRING — that needs tofu
+template logic only available in cloud-init, and the cnpg-pair signal is a
+RUNTIME catalyst-api patch, not a cloud-init substitute). Sprig-safe
+`ne (toString …) "false"` so a literal `false` is honoured. Default false →
+singleton, byte-identical to pre-0.2.0.
+*/}}
+{{- define "bp-postgres.activeHotStandby" -}}
+{{- if or (eq .Values.topology.mode "active-hot-standby") (and (hasKey .Values.topology "crossRegion") (ne (toString .Values.topology.crossRegion) "false")) -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+True ONLY when this install is an active-hot-standby REPLICA half — the
+single condition under which the data instance renders a follower Cluster
+instead of the primary/singleton Cluster + its Database/role/Secret
+machinery. Used to gate every primary-only template (the Database CRs,
+the managed roles, the hub Secrets, the Application CR placement) so the
+replica side renders ONLY the follower Cluster + its mesh stub + netpol.
+*/}}
+{{- define "bp-postgres.renderReplicaHalf" -}}
+{{- if and (include "bp-postgres.activeHotStandby" .) (eq (include "bp-postgres.side" .) "replica") -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+The follower Cluster CR name on the replica side. Distinct from the
+primary instance name (which the consumer host `<instance>-rw` resolves
+to) so the two Cluster CRs never collide and bp-continuum's switchover
+sequencer can find each side. Mirrors bp-cnpg-pair's `<fullname>-replica`.
+*/}}
+{{- define "bp-postgres.replicaName" -}}
+{{- printf "%s-replica" (include "bp-postgres.instanceName" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+ClusterMesh-global replication Service alias the replica's externalCluster
+dials to reach the primary's read endpoint over Cilium ClusterMesh.
+
+Named `<instance>-mesh` (NOT `<instance>-r`, which would collide with the
+CNPG-auto-created `-r` Service — the bp-cnpg-pair 0.1.0 "refusing to
+reconcile service" incident). On the primary side it is declared via the
+primary Cluster CR's `spec.managed.services.additional[]` (CNPG owns it,
+annotated `service.cilium.io/global: "true"`); on the replica side a
+same-named stub Service (zero local backends) lets Cilium merge the two
+into one global service so the host resolves and traffic crosses the mesh.
+*/}}
+{{- define "bp-postgres.replicationServiceName" -}}
+{{- printf "%s-mesh" (include "bp-postgres.instanceName" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Sanitise an arbitrary string into an RFC 1123 DNS-subdomain-safe name
 fragment so it can be used in a k8s resource name. PostgreSQL identifiers
 (role/database names) legally contain underscores (e.g. `openova_flow`),

--- a/platform/postgres/chart/templates/application-cr.yaml
+++ b/platform/postgres/chart/templates/application-cr.yaml
@@ -42,8 +42,16 @@ Contexts: `spec.parameters.databases` carries this instance's Context
 declarations (blueprint contextSchema: kind=db, valuesKey=databases)
 verbatim from the slot's Git-committed values — the generic console
 Contexts projection reads them from there.
+
+Split-side (#3375 / #3571): the Application CR is the data instance's ONE
+card — render it on the PRIMARY side only. In active-hot-standby the same HR
+applies on both control planes; rendering the CR on the replica side too
+would create a duplicate card on cluster-B (violating "N instances ⇒ exactly
+N cards") and a status-only adoption CR with no consumer Contexts. The
+renderReplicaHalf gate keeps the card primary-side; its placement reflects
+active-hotstandby so the console shows the cross-region topology.
 */ -}}
-{{- if and (ne (toString .Values.enabled) "false") .Values.bootstrapOwned.enabled (.Capabilities.APIVersions.Has "apps.openova.io/v1") }}
+{{- if and (ne (toString .Values.enabled) "false") .Values.bootstrapOwned.enabled (.Capabilities.APIVersions.Has "apps.openova.io/v1") (not (include "bp-postgres.renderReplicaHalf" .)) }}
 apiVersion: apps.openova.io/v1
 kind: Application
 metadata:
@@ -71,8 +79,10 @@ spec:
   blueprintRef:
     name: bp-postgres
     version: {{ .Chart.Version | quote }}
-  {{- /* placement = the canonical topology surface (G117). */}}
-  {{- if eq (.Values.topology.mode | default "singleton") "active-hot-standby" }}
+  {{- /* placement = the canonical topology surface (G117). Reflects the
+       EFFECTIVE mode so the card shows active-hotstandby once the slot's
+       crossRegion flag (SOVEREIGN_ENABLE_CNPG_PAIR) flips the pair on. */}}
+  {{- if eq (include "bp-postgres.activeHotStandby" .) "true" }}
   placement: active-hotstandby
   {{- else }}
   placement: single-region
@@ -91,7 +101,7 @@ spec:
   releaseName: {{ .Release.Name }}
   parameters:
     topology:
-      mode: {{ .Values.topology.mode | default "singleton" | quote }}
+      mode: {{ if eq (include "bp-postgres.activeHotStandby" .) "true" }}{{ "active-hot-standby" | quote }}{{ else }}{{ "singleton" | quote }}{{ end }}
     {{- with .Values.databases }}
     databases:
       {{- toYaml . | nindent 6 }}

--- a/platform/postgres/chart/templates/cluster.yaml
+++ b/platform/postgres/chart/templates/cluster.yaml
@@ -16,8 +16,19 @@ Master gate (.Values.enabled, default true): when the slot disables sharing
 the HR is an empty Ready release. Sprig-safe `ne (toString …) "false"` —
 a literal `false` is not "empty", so a plain `if` would misfire (memory
 feedback_sprig_default_bool_unsafe).
+
+active-hot-standby split-side (#3375 / #3571): a 2-region Sovereign is two
+SEPARATE ClusterMesh-joined clusters, so the data instance renders the
+proven bp-cnpg-pair split-side shape rather than a single stretched Cluster
+(the hw126 fallacy: one Cluster CR's region-B pods can never schedule on
+cluster-A). This file renders the PRIMARY half — the Cluster KEEPS the
+instance name (so the consumer host `<instance>-rw` is unchanged) plus the
+ClusterMesh-global `-mesh` Service. The REPLICA half is replica-cluster.yaml
+(gated to side=replica), which this template skips entirely.
 */ -}}
-{{- if and (ne (toString .Values.enabled) "false") (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") }}
+{{- if and (ne (toString .Values.enabled) "false") (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") (not (include "bp-postgres.renderReplicaHalf" .)) }}
+{{- $ahs := eq (include "bp-postgres.activeHotStandby" .) "true" }}
+{{- $sync := and $ahs (eq (default "sync" .Values.topology.replication.mode) "sync") }}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
@@ -25,20 +36,38 @@ metadata:
   namespace: {{ include "bp-postgres.namespace" . }}
   labels:
     {{- include "bp-postgres.labels" . | nindent 4 }}
+    {{- if $ahs }}
+    # bp-continuum's switchover sequencer + the Catalyst projector locate
+    # the pair via these labels (mirrors bp-cnpg-pair's primary CR). The
+    # `-rw` Service of THIS named Cluster is the consumer-facing write
+    # endpoint; the cnpg-pair label ties it to the replica half for DR.
+    openova.io/cnpg-role: primary
+    openova.io/region: {{ .Values.topology.primary.region | quote }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+    {{- end }}
 spec:
+  {{- if $ahs }}
+  {{- /* active-hot-standby PRIMARY half — the cnpg-pair primary shape.
+       instances = haInstances (the pair canonical 3, decoupled from the
+       singleton `instances` so a crossRegion flip never perturbs singleton).
+       Region-pinning via node-affinity (the operator's idiomatic region
+       seam) — NOT the old `affinity.topologyKey` antiAffinity, which only
+       spread within ONE stretched cluster (the hw126 fallacy). */}}
+  instances: {{ .Values.topology.haInstances | default 3 }}
+  primaryUpdateMethod: switchover
+  imageName: {{ include "bp-postgres.imageRef" . | quote }}
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: openova.io/region
+                operator: In
+                values: [{{ .Values.topology.primary.region | quote }}]
+    podAntiAffinityType: preferred
+  {{- else }}
   instances: {{ .Values.topology.instances | default 1 }}
   imageName: {{ include "bp-postgres.imageRef" . | quote }}
-
-  {{- /*
-  active-hot-standby with instances >= 2: default affinity.topologyKey
-  to topology.kubernetes.io/region so the CNPG operator spreads replicas
-  across regions on Cilium ClusterMesh peers (Pillar 3 zero-tx-loss),
-  mirroring the G93.3 #2668 rationale in the legacy consumer charts.
-  */ -}}
-  {{- if and (eq .Values.topology.mode "active-hot-standby") (ge (int (.Values.topology.instances | default 1)) 2) }}
-  affinity:
-    topologyKey: topology.kubernetes.io/region
-    podAntiAffinityType: preferred
   {{- end }}
 
   bootstrap:
@@ -62,9 +91,21 @@ spec:
   (the SME mesh's sme_auth/sme_billing/sme_documents all owned by `sme`),
   which is N Database CRs on ONE role. The passwordSecret is taken from
   the FIRST binding declaring the owner, matching role-secrets.yaml.
+
+  managed.services (active-hot-standby only): the ClusterMesh-global
+  `-mesh` Service the replica region streams WAL from. Declared via CNPG's
+  `spec.managed.services.additional[]` (CNPG ≥1.22) so CNPG owns the
+  Service and applies the `service.cilium.io/global` annotation to the
+  right object (the bp-cnpg-pair 0.1.1 fix for "refusing to reconcile
+  service: <name>-r, not owned by the cluster"). selectorType: r =
+  read-replica endpoint; the replica region has zero local backends
+  matching it, so Cilium's local-affinity routing falls through to this
+  primary region.
   */ -}}
-  {{- if .Values.databases }}
+  {{- $meshSvc := and $ahs .Values.topology.clusterMesh.enabled }}
+  {{- if or .Values.databases $meshSvc }}
   managed:
+    {{- if .Values.databases }}
     roles:
       {{- $seenOwners := dict }}
       {{- range .Values.databases }}
@@ -77,6 +118,31 @@ spec:
           name: {{ include "bp-postgres.roleSecretName" (dict "ctx" $ "db" .) | quote }}
       {{- end }}
       {{- end }}
+    {{- end }}
+    {{- if $meshSvc }}
+    services:
+      additional:
+        - selectorType: r
+          serviceTemplate:
+            metadata:
+              name: {{ include "bp-postgres.replicationServiceName" . }}
+              labels:
+                {{- include "bp-postgres.labels" . | nindent 16 }}
+                catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+                catalyst.openova.io/role: replication-source
+              annotations:
+                # Cilium ClusterMesh — publish this Service across every peer.
+                service.cilium.io/global: "true"
+                service.cilium.io/affinity: {{ .Values.topology.clusterMesh.affinity | quote }}
+                catalyst.openova.io/blueprint: bp-postgres
+            spec:
+              type: ClusterIP
+              ports:
+                - name: postgres
+                  port: 5432
+                  targetPort: 5432
+                  protocol: TCP
+    {{- end }}
   {{- end }}
   # inheritedMetadata: CNPG propagates these onto every Secret it generates
   # (<instance>-app, <instance>-<role>, <instance>-superuser). bp-reflector
@@ -96,18 +162,42 @@ spec:
       {{- end }}
       {{- /*
       active-hot-standby + sync: append the synchronous-replication GUCs
-      (ADR-0004). remote_apply blocks COMMIT until the replica replays the
-      WAL — the Pillar-3 zero-tx-loss bar. async mode omits them.
+      (ADR-0004). The replica region's externalCluster connects via the
+      `streaming_replica` user CNPG provisions automatically.
+      `synchronous_commit = remote_apply` blocks COMMIT until the replica
+      has REPLAYED the WAL — the Pillar-3 zero-tx-loss bar. It is a
+      SETTABLE GUC so it stays a raw parameter.
+
+      `synchronous_standby_names` is NOT settable as a raw parameter — CNPG
+      marks it a FIXED configuration parameter and the admission webhook
+      REJECTS any explicit set ("Can't set fixed configuration parameter",
+      verified live CNPG 1.29.0 hw124 #3195). We therefore declare it via
+      CNPG's NATIVE `spec.postgresql.synchronous` block below (CNPG ≥1.24);
+      the operator derives `synchronous_standby_names` from it, matching the
+      replica Cluster CR's name as the standby application_name. This is the
+      exact bp-cnpg-pair primary shape (the old raw-parameter form was the
+      pre-#3195 trap that wedged hw124).
       */ -}}
-      {{- if eq .Values.topology.mode "active-hot-standby" }}
+      {{- if $ahs }}
       max_wal_senders: "10"
       max_replication_slots: "10"
       wal_level: "logical"
-      {{- if eq (default "sync" .Values.topology.replication.mode) "sync" }}
+      {{- if $sync }}
       synchronous_commit: {{ default "remote_apply" .Values.topology.replication.sync.commit | quote }}
-      synchronous_standby_names: {{ printf "FIRST %d (%s-r)" (int (default 1 .Values.topology.replication.sync.numSync)) (include "bp-postgres.instanceName" .) | quote }}
       {{- end }}
       {{- end }}
+    {{- if $sync }}
+    # ── Synchronous replication — CNPG-native (NOT a raw parameter) ────
+    # method=first + number=N renders `synchronous_standby_names =
+    # FIRST N (...)`; CNPG fills the standby application_name from the
+    # connected replica Cluster (<instance>-replica). dataDurability=required
+    # strictly enforces the zero-tx-loss bar: COMMIT blocks when fewer than
+    # `number` healthy synchronous standbys are connected (Pillar-3).
+    synchronous:
+      method: first
+      number: {{ int (default 1 .Values.topology.replication.sync.numSync) }}
+      dataDurability: required
+    {{- end }}
 
   resources:
     {{- toYaml .Values.instance.resources | nindent 4 }}

--- a/platform/postgres/chart/templates/database.yaml
+++ b/platform/postgres/chart/templates/database.yaml
@@ -18,8 +18,14 @@ a no-op in practice.
 
 Master gate (.Values.enabled, default true): OFF → render ZERO resources
 so the slot 16a HR is an empty Ready release when sharing is disabled.
+
+Split-side (#3375 / #3571): the Database CRs are PRIMARY-side only. In
+active-hot-standby the replica half is a streaming follower that inherits
+every database via the WAL stream (CNPG forbids writes there until promoted),
+so a Database CR on the replica cluster would be rejected / meaningless. The
+renderReplicaHalf gate skips this whole template on side=replica.
 */ -}}
-{{- if and (ne (toString .Values.enabled) "false") (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") }}
+{{- if and (ne (toString .Values.enabled) "false") (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") (not (include "bp-postgres.renderReplicaHalf" .)) }}
 {{- $ctx := . }}
 {{- range .Values.databases }}
 ---

--- a/platform/postgres/chart/templates/networkpolicy.yaml
+++ b/platform/postgres/chart/templates/networkpolicy.yaml
@@ -1,0 +1,115 @@
+{{- /*
+NetworkPolicy carve-out for active-hot-standby cross-region replication
+(#3375 / #3571).
+
+The platform default-deny CCNP (bp-network-policies) denies all pod-to-pod
+traffic by default. In active-hot-standby mode this NetworkPolicy opens the
+minimum required paths so the cnpg-pair shape can stream WAL + the CNPG
+operator can extract instance status. It is the bp-cnpg-pair networkpolicy.yaml
+shape, keyed off this data instance's Cluster names, side-gated per the
+split-side topology (a podSelector is evaluated against LOCAL endpoints, so
+each side renders only the policies selecting its own Cluster's Pods).
+
+Singleton mode renders NOTHING here — single-region instances have no
+cross-region replication path to open, so the default render is byte-identical
+to today (no NetworkPolicy object at all).
+*/ -}}
+{{- if and (ne (toString .Values.enabled) "false") (include "bp-postgres.activeHotStandby" .) .Values.topology.networkPolicy.enabled }}
+{{- $isReplica := include "bp-postgres.renderReplicaHalf" . }}
+{{- if not $isReplica }}
+---
+# PRIMARY side: allow the primary Cluster's Pods to accept replication
+# connections from the replica Cluster's Pods (delivered into this region by
+# ClusterMesh) AND from their OWN cluster (instance-to-instance streaming +
+# the multi-instance pg_basebackup join — the #3322 own-cluster gap that sat
+# >1h "Creating" on hw130) AND from the CNPG operator's status/metrics probe.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-allow-replication-to-primary
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: {{ include "bp-postgres.instanceName" . }}
+  policyTypes: [Ingress]
+  ingress:
+    # The replica Cluster's Pods (cross-cluster via ClusterMesh — the
+    # selector matches by Pod label regardless of source cluster).
+    - from:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: {{ include "bp-postgres.replicaName" . }}
+      ports:
+        - port: 5432
+          protocol: TCP
+    # OWN-cluster pods (#3322 carve-out): this policy selects ALL primary-CR
+    # Pods, default-denying the cluster's OWN internal 5432 (instance-2's
+    # pg_basebackup join, instance-to-instance streaming, switchover rejoin).
+    - from:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: {{ include "bp-postgres.instanceName" . }}
+      ports:
+        - port: 5432
+          protocol: TCP
+    # CNPG operator status + metrics probe — without this the operator cannot
+    # extract instance status and the Cluster phase stalls at "Instance Status
+    # Extraction Error" (hw126 symptom).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.topology.networkPolicy.operatorNamespace }}
+      ports:
+        - port: {{ .Values.topology.networkPolicy.operatorStatusPort }}
+          protocol: TCP
+        - port: {{ .Values.topology.networkPolicy.operatorMetricsPort }}
+          protocol: TCP
+{{- end }}
+{{- if $isReplica }}
+---
+# REPLICA side: allow the replica Cluster's Pods to accept connections from
+# their OWN cluster (instance-2 joins instance-1 via the replica's -rw
+# Service on 5432 — the #3322 own-cluster gap) AND from the CNPG operator's
+# status/metrics probe.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "bp-postgres.instanceName" . }}-allow-replication-to-replica
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: {{ include "bp-postgres.replicaName" . }}
+  policyTypes: [Ingress]
+  ingress:
+    # OWN-cluster pods (#3322 carve-out): the replica Cluster's instance-2
+    # joins instance-1 via the replica's -rw Service on 5432; without an
+    # explicit allow for the replica's OWN cnpg.io/cluster label it
+    # default-denies that join (hw130 24h wedge).
+    - from:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: {{ include "bp-postgres.replicaName" . }}
+      ports:
+        - port: 5432
+          protocol: TCP
+    # CNPG operator status + metrics probe — the replica side selects its own
+    # instance CR Pods, so it needs the same operator carve-out as the primary.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.topology.networkPolicy.operatorNamespace }}
+      ports:
+        - port: {{ .Values.topology.networkPolicy.operatorStatusPort }}
+          protocol: TCP
+        - port: {{ .Values.topology.networkPolicy.operatorMetricsPort }}
+          protocol: TCP
+{{- end }}
+{{- end }}

--- a/platform/postgres/chart/templates/replica-cluster.yaml
+++ b/platform/postgres/chart/templates/replica-cluster.yaml
@@ -1,0 +1,137 @@
+{{- /*
+Replica CNPG Cluster CR — the active-hot-standby cross-region follower
+half of the data instance (#3375 / #3571).
+
+CNPG's "replica cluster" pattern (`replica.enabled: true` +
+`bootstrap.pg_basebackup` + `externalClusters[]`) lets this Cluster CR
+follow the primary instance's WAL stream while staying a regular CNPG
+Cluster locally. It cannot be written to until promoted; promotion is
+driven by bp-continuum's switchover sequencer (it flips
+`spec.replica.enabled` on this CR and the primary CR atomically) — NOT
+by CNPG itself. This is the EXACT bp-cnpg-pair replica shape, with the
+streaming source pointed at THIS data instance's primary Cluster
+(`<instance>`, which keeps the instance name so the consumer host
+`<instance>-rw` is unchanged) rather than bp-cnpg-pair's `<fullname>-primary`.
+
+Replication source-discovery: the replica resolves the primary via the
+Cilium ClusterMesh-global `<instance>-mesh` Service the primary Cluster CR
+exposes through `spec.managed.services.additional[]` (cluster.yaml). The
+`service.cilium.io/global: "true"` annotation makes it visible across every
+mesh peer; ClusterMesh's local-affinity routing falls through to the remote
+(primary) region because the replica region has zero local backends matching
+the selector. (A local same-named stub Service — replica-mesh-service.yaml —
+prevents NXDOMAIN on this cluster.)
+
+Side-gating: renders ONLY on the active-hot-standby REPLICA half. It must
+be APPLIED ON the region-B cluster (where its region-B node-affinity matches
+the local nodes). The primary/singleton Cluster (cluster.yaml) is skipped on
+this side; this follower is skipped on the primary side. The two halves live
+on SEPARATE ClusterMesh-joined clusters — the hw126 split-side lesson.
+
+Cross-cluster auth (#3254 analogue): the replica's externalCluster mounts
+the PRIMARY Cluster's CNPG-generated `<instance>-replication` /
+`<instance>-ca` TLS Secrets, which CNPG mints only on the primary cluster.
+catalyst-api copies them primary → replica in namespace `<release-ns>` before
+flipping SOVEREIGN_ENABLE_CNPG_PAIR on (handler/clustermesh.go), exactly as
+it does for the bp-cnpg-pair `-primary-replication` / `-primary-ca` Secrets.
+*/ -}}
+{{- if and (ne (toString .Values.enabled) "false") (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") (include "bp-postgres.renderReplicaHalf" .) }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ include "bp-postgres.replicaName" . }}
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    openova.io/cnpg-role: replica
+    openova.io/region: {{ .Values.topology.replica.region | quote }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+spec:
+  instances: {{ .Values.topology.haInstances | default 3 }}
+  imageName: {{ include "bp-postgres.imageRef" . | quote }}
+
+  storage:
+    size: {{ .Values.instance.storageSize | default "5Gi" }}
+    storageClass: {{ .Values.instance.storageClass | default "local-path" | quote }}
+
+  resources:
+    {{- toYaml .Values.instance.resources | nindent 4 }}
+
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: openova.io/region
+                operator: In
+                values: [{{ .Values.topology.replica.region | quote }}]
+    podAntiAffinityType: preferred
+
+  # ── Replica-cluster mode ─────────────────────────────────────────
+  # `replica.enabled: true` configures this Cluster as a CNPG replica
+  # cluster: instances bootstrap via streaming replication from the named
+  # externalCluster source. bp-continuum's switchover path patches
+  # `replica.enabled: false` here (and flips the primary CR to the inverse)
+  # to promote/demote atomically.
+  replica:
+    enabled: true
+    source: {{ include "bp-postgres.instanceName" . }}
+
+  # ── Bootstrap from primary ──────────────────────────────────────
+  # CNPG REQUIRES an explicit bootstrap stanza on a replica Cluster:
+  # `replica.enabled: true` alone leaves the phase stuck at "Setting up
+  # primary" (bp-cnpg-pair caught this live). pg_basebackup pulls the
+  # initial heap from the named externalCluster (resolved via the
+  # ClusterMesh-global `-mesh` Service), then the replica streams WAL
+  # continuously over the same connection. database+owner MUST match the
+  # primary's bootstrap.initdb (the FIRST binding, or neutral `app`).
+  {{- $first := first .Values.databases }}
+  {{- $bootDb := (default (dict) $first).name | default "app" }}
+  {{- $bootOwner := (default (dict) $first).owner | default "app" }}
+  bootstrap:
+    pg_basebackup:
+      source: {{ include "bp-postgres.instanceName" . }}
+      database: {{ $bootDb | quote }}
+      owner:    {{ $bootOwner | quote }}
+
+  externalClusters:
+    - name: {{ include "bp-postgres.instanceName" . }}
+      connectionParameters:
+        # Cilium ClusterMesh-global Service alias — managed by CNPG via the
+        # primary Cluster's `spec.managed.services.additional` entry
+        # (selectorType: r, name: <instance>-mesh, annotated
+        # service.cilium.io/global: "true"). Resolves locally; ClusterMesh's
+        # affinity routing reaches the primary region's read endpoint over
+        # the private mesh (zero local backends on this cluster).
+        host: {{ include "bp-postgres.replicationServiceName" . }}
+        port: "5432"
+        user: streaming_replica
+        sslmode: require
+        dbname: {{ $bootDb | quote }}
+      # streaming_replica auth: CNPG provisions a TLS client cert for the
+      # streaming_replica role on every Cluster CR; the replica mounts it
+      # from the primary's `-replication` Secret. catalyst-api copies these
+      # Secrets primary → replica cluster before the cnpg-pair flip (#3254
+      # analogue) since they live on separate clusters.
+      sslKey:
+        name: {{ include "bp-postgres.instanceName" . }}-replication
+        key: tls.key
+      sslCert:
+        name: {{ include "bp-postgres.instanceName" . }}-replication
+        key: tls.crt
+      sslRootCert:
+        name: {{ include "bp-postgres.instanceName" . }}-ca
+        key: ca.crt
+
+  # `hot_standby` is intentionally OMITTED — PostgreSQL 16 hard-pins it to
+  # `on` for any Cluster running with `replica.enabled: true`, and CNPG
+  # rejects the explicit set with phase "Unable to create required cluster
+  # objects" (bp-cnpg-pair caught this live on omantel-hel 2026-05-09).
+  postgresql:
+    parameters:
+      max_wal_senders: "10"
+      max_replication_slots: "10"
+      wal_level: "logical"
+
+  enableSuperuserAccess: {{ .Values.instance.enableSuperuserAccess | default false }}
+{{- end }}

--- a/platform/postgres/chart/templates/replica-mesh-service.yaml
+++ b/platform/postgres/chart/templates/replica-mesh-service.yaml
@@ -1,0 +1,62 @@
+{{- /*
+Replica-side ClusterMesh global Service stub (#3375 / #3571).
+
+Cilium ClusterMesh global services are merged BY NAME+NAMESPACE: a Service
+participates in the mesh only if a same-named + same-namespace Service exists
+in EVERY consuming cluster, each annotated `service.cilium.io/global: "true"`
+(upstream Cilium ClusterMesh contract). On the split-side topology the
+primary side's `<instance>-mesh` Service is CNPG-managed on cluster-A (via
+the primary Cluster CR's `spec.managed.services.additional[]`) — but
+cluster-B has no primary Cluster CR, so nothing creates the local Service the
+replica's `externalClusters.connectionParameters.host` resolves: without this
+stub, DNS for `<instance>-mesh` is NXDOMAIN on cluster-B and the replica can
+never open its streaming connection.
+
+This stub:
+  - carries the SAME name (`<instance>-mesh`), port (5432), and
+    global/affinity annotations as the primary side's managed Service, so
+    Cilium merges the two into one global service;
+  - uses the primary Cluster's `-r`-equivalent selector
+    (`cnpg.io/cluster: <instance>`), which matches ZERO Pods on cluster-B —
+    so every connection routes across the mesh to the primary region's
+    backends (the `affinity: local` hint falls through to remote when no
+    local backend exists);
+  - does NOT collide with CNPG ownership: the local CNPG operator on
+    cluster-B manages only the replica Cluster's Services
+    (`<instance>-replica-r/-ro/-rw`), never this name. (The bp-cnpg-pair
+    0.1.0 "refusing to reconcile service" incident was a SAME-cluster
+    collision with the primary CR's auto-created `-r` — not possible here,
+    the primary CR lives on the other cluster.)
+
+This is the bp-cnpg-pair replica-mesh-service.yaml shape, with the names
+keyed off the data instance (`<instance>`) instead of `<fullname>-primary`.
+*/ -}}
+{{- if and (ne (toString .Values.enabled) "false") .Values.topology.clusterMesh.enabled (include "bp-postgres.renderReplicaHalf" .) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bp-postgres.replicationServiceName" . }}
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+    catalyst.openova.io/role: replication-source
+  annotations:
+    # Cilium ClusterMesh — same annotations as the primary side's
+    # CNPG-managed Service so the mesh merges both into one global service.
+    # Zero local backends here → traffic crosses the mesh.
+    service.cilium.io/global: "true"
+    service.cilium.io/affinity: {{ .Values.topology.clusterMesh.affinity | quote }}
+    catalyst.openova.io/blueprint: bp-postgres
+spec:
+  type: ClusterIP
+  selector:
+    # CNPG `-r` selector shape for the PRIMARY Cluster — matches zero Pods
+    # on the replica cluster by construction.
+    cnpg.io/cluster: {{ include "bp-postgres.instanceName" . }}
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+      protocol: TCP
+{{- end }}

--- a/platform/postgres/chart/templates/role-secrets.yaml
+++ b/platform/postgres/chart/templates/role-secrets.yaml
@@ -39,8 +39,16 @@ CRs but ONE role + ONE password. The hub Secret also gains:
 Stability: password = lookup(live role Secret) || lookup(live hub
 Secret) || randAlphaNum — upgrades never rotate under a running
 consumer; resource-policy keep guards release replaces.
+
+Split-side (#3375 / #3571): the role-password + hub connection Secrets are
+PRIMARY-side only. CNPG's managed.roles[].passwordSecret is consumed by the
+PRIMARY Cluster; the replica follower has no managed roles of its own (it
+streams the primary's catalog), and the consumer-facing hub Secrets reflect
+out of the primary region's shared-data. The renderReplicaHalf gate skips
+this whole template on side=replica so the replica cluster never mints a
+second, divergent password set.
 */ -}}
-{{- if ne (toString .Values.enabled) "false" }}
+{{- if and (ne (toString .Values.enabled) "false") (not (include "bp-postgres.renderReplicaHalf" .)) }}
 {{- $ctx := . }}
 {{- $ns := .Release.Namespace }}
 {{- $instance := include "bp-postgres.instanceName" . }}

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -125,28 +125,158 @@ hub_pw_count=$(grep -cE '^  password: ' "$TMP/shared.yaml" || true)
 hub_host_count=$(grep -cE '^  host: "shared-pg-rw.shared-data.svc.cluster.local"$' "$TMP/shared.yaml" || true)
 [ "$hub_host_count" -eq 2 ] || fail "#3285: expected 2 hub Secrets with the shared-pg-rw host, got $hub_host_count"
 
-# ── Case 4: active-hot-standby + sync → sync GUCs present ─────────
-echo "[render] Case 4: active-hot-standby + sync → synchronous-replication GUCs"
+# ── Case 4: active-hot-standby PRIMARY side → cnpg-pair primary shape ─────
+# (#3375/#3571) active-hot-standby renders the bp-cnpg-pair SPLIT-SIDE shape,
+# NOT a single multi-instance Cluster with region antiAffinity (the hw126
+# fallacy). The PRIMARY half: a Cluster that KEEPS the instance name (so the
+# consumer host `<instance>-rw` is unchanged) + region node-affinity + the
+# CNPG-NATIVE `synchronous` block (NOT a raw synchronous_standby_names
+# parameter — the CNPG webhook rejects that as a fixed param, the #3195 trap)
+# + the ClusterMesh-global `<instance>-mesh` Service via
+# managed.services.additional. The Database CRs/roles still render here.
+echo "[render] Case 4: active-hot-standby PRIMARY → named primary Cluster + native sync block + -mesh global Service"
 cat > "$TMP/ahs.values.yaml" <<'YAML'
-instance: { name: harbor-pg }
+instance: { name: shared-pg }
 topology:
   mode: active-hot-standby
-  instances: 2
+  side: primary
+  instances: 3
+  primary: { region: hz-fsn-rtz-prod }
+  replica: { region: hz-hel-rtz-prod }
   replication: { mode: sync, sync: { commit: remote_apply, numSync: 1 } }
 databases:
-  - { name: registry, owner: harbor }
+  - name: registry
+    owner: harbor
+    reflect: { secretName: harbor-database-secret, namespaces: [harbor] }
 YAML
-helm template harbor-pg . -f "$TMP/ahs.values.yaml" \
-  --api-versions postgresql.cnpg.io/v1 > "$TMP/ahs.yaml" 2>&1 || fail "ahs render errored"
+helm template shared-pg . -f "$TMP/ahs.values.yaml" --namespace shared-data \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/ahs.yaml" 2>&1 || fail "ahs primary render errored"
+# The named primary Cluster (consumer host <instance>-rw resolves to it).
+grep -qE '^  name: shared-pg$' "$TMP/ahs.yaml" || fail "ahs primary: named primary Cluster shared-pg missing"
+# No replica follower on the primary side (it lives on cluster-B).
+if grep -qE '^  name: shared-pg-replica$' "$TMP/ahs.yaml"; then
+  fail "ahs primary side leaked the replica Cluster (must be replica-side only)"
+fi
+# synchronous_commit raw GUC (settable) present; synchronous_standby_names
+# MUST NOT be a raw parameter (CNPG-fixed → webhook reject).
 grep -q 'synchronous_commit: "remote_apply"' "$TMP/ahs.yaml" \
-  || fail "active-hot-standby missing synchronous_commit"
-grep -q 'synchronous_standby_names: "FIRST 1 (harbor-pg-r)"' "$TMP/ahs.yaml" \
-  || fail "active-hot-standby missing synchronous_standby_names"
+  || fail "ahs primary missing synchronous_commit"
+# synchronous_standby_names must NOT be a rendered raw PARAMETER (CNPG-fixed →
+# webhook reject). Match only an actual GUC line (key: value), not the `#` doc
+# comment that names the field while explaining the native-block rationale.
+if grep -qE '^      synchronous_standby_names:' "$TMP/ahs.yaml"; then
+  fail "ahs primary leaked synchronous_standby_names as a raw parameter (#3195 fixed-param trap)"
+fi
+# CNPG-native synchronous block (the operator derives standby_names from it).
+grep -qE '^    synchronous:$' "$TMP/ahs.yaml" || fail "ahs primary missing native spec.postgresql.synchronous block"
+grep -q 'method: first' "$TMP/ahs.yaml" || fail "ahs primary synchronous.method != first"
+grep -q 'dataDurability: required' "$TMP/ahs.yaml" || fail "ahs primary synchronous.dataDurability != required"
+# ClusterMesh-global -mesh Service via managed.services.additional.
+grep -q 'name: shared-pg-mesh' "$TMP/ahs.yaml" || fail "ahs primary missing -mesh global Service"
+grep -q 'service.cilium.io/global: "true"' "$TMP/ahs.yaml" || fail "ahs primary -mesh Service missing global annotation"
+grep -qE '^      additional:$' "$TMP/ahs.yaml" || fail "ahs primary mesh Service not under managed.services.additional"
+# Region node-affinity (NOT the old topologyKey antiAffinity).
+grep -q 'key: openova.io/region' "$TMP/ahs.yaml" || fail "ahs primary missing region node-affinity"
+if grep -q 'topologyKey: topology.kubernetes.io/region' "$TMP/ahs.yaml"; then
+  fail "ahs primary leaked the old stretched-cluster topologyKey antiAffinity (hw126 fallacy)"
+fi
+# Database CR + role still render on the primary side.
+grep -cE '^kind: Database$' "$TMP/ahs.yaml" | grep -q '^1$' || fail "ahs primary expected 1 Database CR"
+# NetworkPolicy carve-out renders (replication path + own-cluster + operator).
+grep -q 'allow-replication-to-primary' "$TMP/ahs.yaml" || fail "ahs primary missing replication NetworkPolicy"
 
-# ── Case 5: singleton → NO sync GUCs ─────────────────────────────
-echo "[render] Case 5: singleton → no synchronous-replication GUCs"
+# ── Case 4b: active-hot-standby REPLICA side → follower Cluster + mesh stub ──
+# The REPLICA half (side=replica): a `<instance>-replica` follower Cluster
+# (replica.enabled + pg_basebackup + externalClusters streaming from the
+# named primary over the -mesh Service) + the local -mesh Service stub. NO
+# Database CRs / roles / hub Secrets (the replica inherits the catalog via WAL).
+echo "[render] Case 4b: active-hot-standby REPLICA → follower Cluster + -mesh stub, NO Database/role Secrets"
+helm template shared-pg . -f "$TMP/ahs.values.yaml" --namespace shared-data \
+  --set topology.side=secondary \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/ahs-replica.yaml" 2>&1 || fail "ahs replica render errored"
+grep -qE '^  name: shared-pg-replica$' "$TMP/ahs-replica.yaml" || fail "ahs replica: follower Cluster shared-pg-replica missing"
+# The primary/singleton Cluster MUST NOT render on the replica side.
+if grep -qE '^kind: Cluster$' "$TMP/ahs-replica.yaml" && grep -qE '^  name: shared-pg$' "$TMP/ahs-replica.yaml"; then
+  fail "ahs replica side leaked the primary Cluster shared-pg (must be primary-side only)"
+fi
+replica_clusters=$(grep -cE '^kind: Cluster$' "$TMP/ahs-replica.yaml" || true)
+[ "$replica_clusters" -eq 1 ] || fail "ahs replica expected EXACTLY 1 (follower) Cluster, got $replica_clusters"
+grep -q 'replica:' "$TMP/ahs-replica.yaml" || fail "ahs replica missing spec.replica block"
+grep -q 'pg_basebackup:' "$TMP/ahs-replica.yaml" || fail "ahs replica missing bootstrap.pg_basebackup"
+grep -q 'user: streaming_replica' "$TMP/ahs-replica.yaml" || fail "ahs replica missing streaming_replica externalCluster"
+grep -q 'host: shared-pg-mesh' "$TMP/ahs-replica.yaml" || fail "ahs replica externalCluster host != shared-pg-mesh"
+grep -q 'name: shared-pg-replication' "$TMP/ahs-replica.yaml" || fail "ahs replica missing primary -replication TLS ref"
+grep -q 'name: shared-pg-ca' "$TMP/ahs-replica.yaml" || fail "ahs replica missing primary -ca TLS ref"
+# The -mesh Service STUB renders on the replica side (same name, NXDOMAIN guard).
+grep -qE '^kind: Service$' "$TMP/ahs-replica.yaml" || fail "ahs replica missing -mesh Service stub"
+grep -q 'name: shared-pg-mesh' "$TMP/ahs-replica.yaml" || fail "ahs replica -mesh stub name mismatch"
+# NO Database CRs / role-password / hub Secrets on the replica side.
+if grep -qE '^kind: Database$' "$TMP/ahs-replica.yaml"; then
+  fail "ahs replica side leaked a Database CR (primary-side only)"
+fi
+if grep -qE '^type: kubernetes.io/basic-auth$' "$TMP/ahs-replica.yaml"; then
+  fail "ahs replica side leaked a role-password Secret (primary-side only)"
+fi
+# Replica-side NetworkPolicy carve-out (own-cluster join + operator).
+grep -q 'allow-replication-to-replica' "$TMP/ahs-replica.yaml" || fail "ahs replica missing replication NetworkPolicy"
+
+# ── Case 4c: crossRegion boolean (the SLOT wiring) → same pair shape ──────
+# The bootstrap-kit slots leave mode=singleton and flip topology.crossRegion to
+# ${SOVEREIGN_ENABLE_CNPG_PAIR}. Prove the boolean alone (mode still singleton)
+# renders the cnpg-pair PRIMARY shape — same as mode=active-hot-standby — so the
+# slot does NOT need to turn the bool into the mode STRING (impossible in
+# envsubst). And prove side=secondary + crossRegion=true renders the follower.
+echo "[render] Case 4c: topology.crossRegion=true (slot signal) → cnpg-pair shape with mode=singleton"
+cat > "$TMP/xr.values.yaml" <<'YAML'
+instance: { name: shared-pg }
+topology:
+  mode: singleton
+  crossRegion: true
+  side: primary
+  instances: 3
+  primary: { region: hz-fsn-rtz-prod }
+  replica: { region: hz-hel-rtz-prod }
+  replication: { mode: sync, sync: { commit: remote_apply, numSync: 1 } }
+databases:
+  - { name: registry, owner: harbor, reflect: { secretName: harbor-database-secret, namespaces: [harbor] } }
+YAML
+helm template shared-pg . -f "$TMP/xr.values.yaml" --namespace shared-data \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/xr.yaml" 2>&1 || fail "crossRegion primary render errored"
+grep -qE '^    synchronous:$' "$TMP/xr.yaml" || fail "crossRegion=true (mode singleton) did NOT activate the synchronous block"
+grep -q 'name: shared-pg-mesh' "$TMP/xr.yaml" || fail "crossRegion=true did NOT render the -mesh Service"
+grep -q 'key: openova.io/region' "$TMP/xr.yaml" || fail "crossRegion=true did NOT render region node-affinity"
+# Replica half via crossRegion + side=secondary.
+helm template shared-pg . -f "$TMP/xr.values.yaml" --namespace shared-data \
+  --set topology.side=secondary \
+  --api-versions postgresql.cnpg.io/v1 > "$TMP/xr-replica.yaml" 2>&1 || fail "crossRegion replica render errored"
+grep -qE '^  name: shared-pg-replica$' "$TMP/xr-replica.yaml" || fail "crossRegion=true + side=secondary did NOT render the follower Cluster"
+
+# ── Case 5: singleton → byte-identical (NO sync, NO mesh, NO netpol) ──────
+echo "[render] Case 5: singleton → no synchronous block, no -mesh Service, no NetworkPolicy"
 if grep -q 'synchronous_commit' "$TMP/shared.yaml"; then
   fail "singleton render leaked synchronous_commit"
+fi
+if grep -qE '^    synchronous:$' "$TMP/shared.yaml"; then
+  fail "singleton render leaked the native synchronous block"
+fi
+# Match an actual -mesh Service object (metadata.name / service host), not the
+# prose comments (singleton render emits neither).
+if grep -qE '^  name: [a-z0-9-]+-mesh$|^        host: [a-z0-9-]+-mesh$' "$TMP/shared.yaml"; then
+  fail "singleton render leaked a -mesh ClusterMesh Service (active-hot-standby only)"
+fi
+if grep -q 'service.cilium.io/global' "$TMP/shared.yaml"; then
+  fail "singleton render leaked the ClusterMesh global annotation (active-hot-standby only)"
+fi
+if grep -qE '^kind: NetworkPolicy$' "$TMP/shared.yaml"; then
+  fail "singleton render leaked a NetworkPolicy (active-hot-standby only)"
+fi
+if grep -qE '^kind: Cluster$' "$TMP/shared.yaml" && grep -qE '^  name: shared-pg-replica$' "$TMP/shared.yaml"; then
+  fail "singleton render leaked a replica follower Cluster"
+fi
+# The singleton Cluster is single-instance (instances: 1), no node-affinity.
+grep -qE '^  instances: 1$' "$TMP/shared.yaml" || fail "singleton expected instances: 1"
+if grep -q 'key: openova.io/region' "$TMP/shared.yaml"; then
+  fail "singleton render leaked region node-affinity (active-hot-standby only)"
 fi
 
 # ── Case 6: master gate OFF → ZERO resources (#3188 safe-by-default) ──

--- a/platform/postgres/chart/values.yaml
+++ b/platform/postgres/chart/values.yaml
@@ -75,21 +75,81 @@ instance:
 
 # ── Topology (multi-region BCP) ─────────────────────────────────────────
 # singleton          → one single-instance Cluster (no cross-region HA).
-# active-hot-standby → multi-instance Cluster with synchronous replication
-#                      across regions (ADR-0004 Pillar-3 zero-tx-loss). The
-#                      operator spreads instances via topology.kubernetes.io/
-#                      region antiAffinity when instances >= 2.
+# active-hot-standby → the bp-cnpg-pair SPLIT-SIDE cross-region shape
+#                      (#3375 / #3571). A 2-region Sovereign is two SEPARATE
+#                      ClusterMesh-joined clusters, so the data instance
+#                      renders a PRIMARY Cluster (keeps the instance name so
+#                      the consumer host `<instance>-rw` is unchanged) on
+#                      region A and a REPLICA follower Cluster on region B
+#                      streaming WAL over the ClusterMesh-global `-mesh`
+#                      Service with synchronous_commit=remote_apply (ADR-0004
+#                      Pillar-3 zero-tx-loss). bp-continuum drives switchover.
+#                      This is the PROVEN mechanism (hw128 region-kill PASS,
+#                      RTO 18s / RPO 0) — NOT the old single-Cluster region
+#                      antiAffinity, which only spread within ONE stretched
+#                      cluster (the hw126 fallacy that could never schedule
+#                      region-B pods on cluster-A).
 topology:
   mode: singleton
-  # Instance count. singleton ignores >1; active-hot-standby uses it to
-  # spread Pods across regions (canonical 2 for a single-replica pair).
+  # crossRegion (boolean, default false) — the bootstrap-kit slots wire this to
+  # ${SOVEREIGN_ENABLE_CNPG_PAIR:-false}, the SAME post-mesh-confirm signal
+  # bp-cnpg-pair's cnpgPair.enabled rides (catalyst-api patches it onto every
+  # region's Kustomization ONLY after ClusterMesh is established + the primary's
+  # replica-auth Secrets sync). When true it renders the active-hot-standby
+  # (cnpg-pair split-side) shape EVEN with mode left at singleton — the boolean
+  # seam exists because envsubst can substitute a plain true/false but cannot
+  # turn it into the `active-hot-standby` mode STRING (that needs tofu template
+  # logic, unavailable for a RUNTIME catalyst-api substitute patch). Either
+  # `mode: active-hot-standby` OR `crossRegion: true` activates the pair.
+  # Default false → singleton, byte-identical to pre-0.2.0.
+  crossRegion: false
+  # Instance count for the SINGLETON Cluster. Default 1 keeps the singleton
+  # render unchanged. (active-hot-standby uses haInstances instead, so a slot
+  # can flip crossRegion without ever touching this singleton field.)
   instances: 1
+  # Per-side instance count for the active-hot-standby pair (primary half AND
+  # replica half each get this many). Canonical 3 per bp-cnpg-pair. Decoupled
+  # from `instances` so the singleton render's instance count is never
+  # perturbed by the crossRegion flip.
+  haInstances: 3
+  # ── Split-side — WHICH HALF of the cross-region pair this install renders.
+  # primary|replica|secondary (secondary aliases replica so the bootstrap-kit
+  # substitutes the per-region SOVEREIGN_REGION_ROLE verbatim). Empty/unset →
+  # primary, so a singleton install (where the split never applies) is
+  # unchanged. ONLY consulted in active-hot-standby mode.
+  side: primary
+  # ── Region pinning (active-hot-standby only). Canonical openova.io/region
+  # node labels the primary / replica Cluster CRs pin on. Stamped from the
+  # cloud-init SOVEREIGN_PRIMARY_REGION / SOVEREIGN_REPLICA_REGION substitutes.
+  primary:
+    region: ""
+  replica:
+    region: ""
   # Synchronous replication knobs (only consulted in active-hot-standby).
   replication:
     mode: sync           # sync (Pillar-3 default) | async (forensic/lab)
     sync:
       commit: remote_apply  # on | remote_write | remote_apply
       numSync: 1
+  # ── Cilium ClusterMesh — the canonical inter-region replication transport
+  # (ADR-0001 §9). The primary's `-mesh` global Service publishes its read
+  # endpoint across the mesh; the replica's externalCluster dials it. OFF
+  # would force an out-of-band public endpoint, which is NOT supported.
+  # Only consulted in active-hot-standby.
+  clusterMesh:
+    enabled: true
+    # affinity: local → primary region keeps reads local; the replica region
+    # (zero local backends with cnpg-role=primary) falls through to remote.
+    affinity: local
+  # ── NetworkPolicy carve-out (active-hot-standby only). The platform
+  # default-deny CCNP (bp-network-policies) covers shared-data; these knobs
+  # open the cross-region + own-cluster replication path + the CNPG operator
+  # status probe (the #3322 + hw126 carve-outs bp-cnpg-pair proved).
+  networkPolicy:
+    enabled: true
+    operatorNamespace: cnpg-system
+    operatorStatusPort: 8000
+    operatorMetricsPort: 9187
 
 # ── Bindings (the shareable part) ───────────────────────────────────────
 # Each entry binds ONE consumer to this instance. The chart renders a

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -268,6 +268,60 @@ var cnpgPairReplicaAuthSecrets = []string{
 	cnpgPairReplicationCA,
 }
 
+// Cross-cluster CNPG replica-auth Secret sync for the SHARED-PG instances
+// (#3571, Refs #3375 North-Star-4). bp-postgres 0.2.0 makes the 3 shared
+// data instances (shared-pg / -b / -c) render the SAME bp-cnpg-pair
+// split-side shape when topology.crossRegion flips on — and crossRegion is
+// wired to the SAME SOVEREIGN_ENABLE_CNPG_PAIR substitute this flip patches.
+// So when the gate flips, each shared instance's REPLICA half (rendered on
+// the secondary cluster) streams WAL from its primary and authenticates with
+// the primary's CNPG-generated `<instance>-replication` / `<instance>-ca`
+// TLS Secrets — created by CNPG only on the PRIMARY cluster, in namespace
+// `shared-data`. Exactly like the bp-cnpg-pair pair, those Secrets must also
+// exist on the replica cluster (the replica chart references them by name
+// from externalClusters.sslKey/sslCert/sslRootCert), so this flip copies
+// them primary → every replica BEFORE enabling the gate.
+//
+// Names are DERIVED THE SAME WAY THE CHART DOES: a CNPG Cluster named
+// `<instance>` generates `<instance>-replication` (streaming_replica client
+// cert) + `<instance>-ca` (the cluster CA). The instance names are the slot
+// releaseNames (16a→shared-pg, 16c→shared-pg-b, 16d→shared-pg-c) and the
+// namespace is shared-data (the shared-pg slots' targetNamespace) — all
+// stable; if any ever changes, these constants move in lockstep.
+//
+// CONDITIONAL: the shared-pg instances exist only when shared-pg is enabled
+// (SOVEREIGN_ENABLE_SHARED_PG=true). When it is OFF the slots render empty
+// releases, CNPG never mints these Secrets, and the sync SKIPS the whole
+// group (so a non-shared-pg Sovereign's cnpg-pair flip is never blocked by
+// absent shared-pg Secrets). Detected from the substitute map already
+// gathered for the region precondition (clusterMeshSharedPGSubstituteKey).
+const (
+	clusterMeshSharedPGSubstituteKey = "SOVEREIGN_ENABLE_SHARED_PG"
+	sharedPGNamespace                = "shared-data"
+)
+
+// sharedPGInstanceNames — the 3 shared data-instance Cluster names (= the
+// slot releaseNames). Each contributes a `<name>-replication` + `<name>-ca`
+// Secret pair to copy primary → every replica when crossRegion flips on.
+var sharedPGInstanceNames = []string{
+	"shared-pg",   // slot 16a — gitea / harbor / keycloak
+	"shared-pg-b", // slot 16c — grafana / powerdns / powerdns-admin
+	"shared-pg-c", // slot 16d — the SME mesh / newapi / openova-flow
+}
+
+// sharedPGReplicaAuthSecrets — the per-instance `-replication` + `-ca` Secret
+// names the bp-postgres replica-cluster.yaml externalClusters block
+// references (sslKey/sslCert → `<instance>-replication`, sslRootCert →
+// `<instance>-ca`). Built from sharedPGInstanceNames so the set stays in
+// lockstep with the slot releaseNames.
+var sharedPGReplicaAuthSecrets = func() []string {
+	out := make([]string, 0, len(sharedPGInstanceNames)*2)
+	for _, n := range sharedPGInstanceNames {
+		out = append(out, n+"-replication", n+"-ca")
+	}
+	return out
+}()
+
 // fluxKustomizationGVR — kustomize.toolkit.fluxcd.io/v1 Kustomizations,
 // addressed via the dynamic client (no Flux Go types vendored here).
 var fluxKustomizationGVR = schema.GroupVersionResource{
@@ -842,6 +896,12 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 		regionKey   string
 		dyn         dynamic.Interface
 		primarySide bool
+		// sharedPGEnabled — the region's SOVEREIGN_ENABLE_SHARED_PG
+		// substitute (#3571). When true the bp-postgres shared instances
+		// (shared-pg/-b/-c) ALSO render the cnpg-pair split-side shape on
+		// this crossRegion flip, so their `<instance>-replication`/`-ca`
+		// Secrets must be synced primary → replica alongside bp-cnpg-pair's.
+		sharedPGEnabled bool
 	}
 	targets := make([]flipTarget, 0, len(slots))
 	for i := range slots {
@@ -914,7 +974,8 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 				role = "secondary"
 			}
 		}
-		targets = append(targets, flipTarget{regionKey: regionLabel, dyn: dyn, primarySide: role == "primary"})
+		sharedPGEnabled := strings.EqualFold(strings.TrimSpace(substitute[clusterMeshSharedPGSubstituteKey]), "true")
+		targets = append(targets, flipTarget{regionKey: regionLabel, dyn: dyn, primarySide: role == "primary", sharedPGEnabled: sharedPGEnabled})
 	}
 
 	// ── Patch phase: TWO-STAGE (#3241 first-flip deadlock) ──────────
@@ -1006,6 +1067,29 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 			)
 			h.emitClusterMeshProgress(dep, "info",
 				fmt.Sprintf("ClusterMesh: cnpg-pair primary side enabled (%d region(s)); replica side waits for the primary postgres to mint its replication Secrets — re-run converges", primaryTotal))
+			return false
+		}
+		// #3571: the bp-postgres SHARED instances (shared-pg/-b/-c) ride the
+		// SAME crossRegion flip, so their replicas also need the primary's
+		// `<instance>-replication`/`-ca` Secrets on the replica cluster. Sync
+		// them too — but ONLY when shared-pg is enabled (else those Secrets
+		// never exist and would falsely block the cnpg-pair flip). The
+		// primary region's substitute is authoritative for the gate.
+		sharedPGOn := false
+		for _, t := range targets {
+			if t.primarySide && t.sharedPGEnabled {
+				sharedPGOn = true
+				break
+			}
+		}
+		if sharedPGOn && !h.syncSharedPGReplicaAuthSecrets(ctx, dep, slots) {
+			h.log.Info("clustermesh: shared-pg two-stage flip — cnpg-pair replica-auth synced, shared-pg instances awaiting their primary replica-auth Secrets (initdb in progress); level-trigger re-run converges",
+				"id", dep.ID,
+				"primaryRegions", primaryTotal,
+				"replicaRegions", replicaTotal,
+			)
+			h.emitClusterMeshProgress(dep, "info",
+				fmt.Sprintf("ClusterMesh: shared-pg cross-region replicas wait for the shared engines' primary postgres to mint their replication Secrets (%d instance(s)) — re-run converges", len(sharedPGInstanceNames)))
 			return false
 		}
 		for _, t := range targets {
@@ -1125,6 +1209,93 @@ func (h *Handler) syncCNPGPairReplicaAuthSecrets(ctx context.Context, dep *Deplo
 	h.emitClusterMeshProgress(dep, "info",
 		fmt.Sprintf("ClusterMesh: synced cnpg-pair replica-auth Secrets (%s) primary → %d replica region(s) for WAL-stream auth",
 			strings.Join(cnpgPairReplicaAuthSecrets, ", "), len(slots)-1))
+	return true
+}
+
+// syncSharedPGReplicaAuthSecrets copies the primary cluster's CNPG
+// replication-auth Secrets for the 3 SHARED data instances
+// (sharedPGReplicaAuthSecrets, namespace sharedPGNamespace=shared-data) onto
+// EVERY replica region's cluster, so each shared instance's replica-side
+// Cluster CR (bp-postgres 0.2.0 split-side, #3571) can authenticate its
+// pg_basebackup/WAL stream against its primary. Same contract +
+// all-or-nothing semantics as syncCNPGPairReplicaAuthSecrets (the bp-cnpg-pair
+// analogue), only the namespace + Secret-name set differ.
+//
+// Called ONLY when shared-pg is enabled (the caller gates on the primary
+// region's SOVEREIGN_ENABLE_SHARED_PG substitute) — when OFF the shared
+// instances render empty releases, CNPG never mints these Secrets, and this
+// function is never reached, so a non-shared-pg Sovereign's cnpg-pair flip is
+// never blocked by absent shared-pg Secrets.
+//
+// A missing SOURCE Secret on the primary (the shared engine's postgres is
+// still bootstrapping — CNPG mints `<instance>-replication`/`-ca` only after
+// initdb) or ANY per-replica copy failure refuses the whole flip and leaves
+// the gate OFF everywhere (safe: empty Ready releases). The #3241
+// level-trigger + post-handover finalisation re-run AutoEstablishClusterMesh
+// and converge once the primaries' Secrets exist.
+func (h *Handler) syncSharedPGReplicaAuthSecrets(ctx context.Context, dep *Deployment, slots []regionSlot) bool {
+	if len(slots) < 2 {
+		return true // no replica region — nothing to sync (guard, not live path)
+	}
+	primary := &slots[0]
+	if primary.clientset == nil {
+		h.log.Warn("clustermesh: shared-pg replica-auth sync: primary clientset nil — refusing flip",
+			"id", dep.ID)
+		h.emitClusterMeshProgress(dep, "warn",
+			"ClusterMesh: shared-pg cross-region enable refused — primary cluster client unavailable for replica-auth Secret sync; re-run converges")
+		return false
+	}
+
+	// Read the source Secrets from the primary ONCE. A missing source = the
+	// shared engine's postgres has not initialised yet → refuse + converge.
+	sources := make([]*corev1.Secret, 0, len(sharedPGReplicaAuthSecrets))
+	for _, name := range sharedPGReplicaAuthSecrets {
+		getCtx, cancel := context.WithTimeout(ctx, clusterMeshCallTimeout)
+		src, err := primary.clientset.CoreV1().Secrets(sharedPGNamespace).Get(getCtx, name, metav1.GetOptions{})
+		cancel()
+		if err != nil {
+			h.log.Warn("clustermesh: shared-pg replica-auth sync: source Secret unavailable on primary — refusing flip (shared engine postgres likely still bootstrapping)",
+				"id", dep.ID, "namespace", sharedPGNamespace, "secret", name, "err", err)
+			h.emitClusterMeshProgress(dep, "warn",
+				fmt.Sprintf("ClusterMesh: shared-pg cross-region enable refused — primary Secret %s/%s not ready (%v); the replica needs it for WAL-stream auth — re-run converges once the shared engine postgres initialises",
+					sharedPGNamespace, name, err))
+			return false
+		}
+		sources = append(sources, src)
+	}
+
+	// Copy every source Secret onto every replica region. Any failure refuses
+	// the whole flip (no partial state).
+	for i := 1; i < len(slots); i++ {
+		replica := &slots[i]
+		regionLabel := replica.key
+		if regionLabel == "" {
+			regionLabel = "secondary"
+		}
+		if replica.clientset == nil {
+			h.log.Warn("clustermesh: shared-pg replica-auth sync: replica clientset nil — refusing flip",
+				"id", dep.ID, "region", regionLabel)
+			h.emitClusterMeshProgress(dep, "warn",
+				fmt.Sprintf("ClusterMesh: shared-pg cross-region enable refused — replica region %q cluster client unavailable for replica-auth Secret sync; re-run converges", regionLabel))
+			return false
+		}
+		for _, src := range sources {
+			if err := h.copySecretAcrossClusters(ctx, src, replica.clientset, sharedPGNamespace); err != nil {
+				h.log.Warn("clustermesh: shared-pg replica-auth sync: copy to replica failed — refusing flip",
+					"id", dep.ID, "region", regionLabel, "namespace", sharedPGNamespace, "secret", src.Name, "err", err)
+				h.emitClusterMeshProgress(dep, "warn",
+					fmt.Sprintf("ClusterMesh: shared-pg cross-region enable refused — copying Secret %s/%s to replica region %q failed (%v); re-run converges",
+						sharedPGNamespace, src.Name, regionLabel, err))
+				return false
+			}
+		}
+		h.log.Info("clustermesh: shared-pg replica-auth Secrets synced to replica region",
+			"id", dep.ID, "region", regionLabel, "namespace", sharedPGNamespace, "secrets", sharedPGReplicaAuthSecrets)
+	}
+
+	h.emitClusterMeshProgress(dep, "info",
+		fmt.Sprintf("ClusterMesh: synced shared-pg replica-auth Secrets (%s) primary → %d replica region(s) for WAL-stream auth",
+			strings.Join(sharedPGReplicaAuthSecrets, ", "), len(slots)-1))
 	return true
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -188,6 +188,71 @@ func seedCNPGPairReplicaNamespace(t *testing.T, cs kubernetes.Interface) {
 	}
 }
 
+// seedSharedPGSourceSecrets seeds the 3 shared data instances'
+// `<instance>-replication` + `<instance>-ca` Secrets on the PRIMARY (#3571)
+// in the shared-data namespace, so the crossRegion flip's cross-cluster copy
+// succeeds. Mirrors what CNPG mints once each shared engine's postgres
+// initdb's.
+func seedSharedPGSourceSecrets(t *testing.T, cs kubernetes.Interface) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := cs.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: sharedPGNamespace},
+	}, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create shared-data namespace: %v", err)
+	}
+	for _, name := range sharedPGReplicaAuthSecrets {
+		typ := corev1.SecretTypeTLS
+		data := map[string][]byte{"tls.crt": []byte("SPG-" + name + "-CRT"), "tls.key": []byte("SPG-" + name + "-KEY")}
+		if strings.HasSuffix(name, "-ca") {
+			typ = corev1.SecretTypeOpaque
+			data = map[string][]byte{"ca.crt": []byte("SPG-" + name + "-CA")}
+		}
+		if _, err := cs.CoreV1().Secrets(sharedPGNamespace).Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: sharedPGNamespace},
+			Type:       typ,
+			Data:       data,
+		}, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("create shared-pg source Secret %s: %v", name, err)
+		}
+	}
+}
+
+// seedSharedPGReplicaNamespace pre-creates `shared-data` on a replica fake
+// clientset (slot 16a ships the Namespace unconditionally on every region).
+func seedSharedPGReplicaNamespace(t *testing.T, cs kubernetes.Interface) {
+	t.Helper()
+	if _, err := cs.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: sharedPGNamespace},
+	}, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create shared-data namespace on replica: %v", err)
+	}
+}
+
+// enableSharedPGInFixture flips SOVEREIGN_ENABLE_SHARED_PG=true on every
+// region's bootstrap-kit Kustomization substitute AND seeds the shared-pg
+// source Secrets on the primary + the shared-data namespace on each replica,
+// so the #3571 shared-pg replica-auth sync runs on the crossRegion flip.
+func enableSharedPGInFixture(t *testing.T, fx *testFixture) {
+	t.Helper()
+	// Re-seed each region's dynamic client with a substitute map that adds
+	// the shared-pg flag.
+	for kcPath := range fx.dynClients {
+		sub := defaultBootstrapKitSubstitute()
+		sub[clusterMeshSharedPGSubstituteKey] = "true"
+		fx.dynClients[kcPath] = newFakeKustomizationDynClient(t, buildBootstrapKitKustomization(sub))
+	}
+	// Seed the shared-pg source Secrets on the primary, the namespace on
+	// replicas.
+	primaryCS := fx.clients[fx.primaryKubeconfigPath]
+	seedSharedPGSourceSecrets(t, primaryCS)
+	for kcPath, cs := range fx.clients {
+		if kcPath != fx.primaryKubeconfigPath {
+			seedSharedPGReplicaNamespace(t, cs)
+		}
+	}
+}
+
 // writeFakeKubeconfig drops a stub kubeconfig YAML into the directory
 // at the path AutoEstablishClusterMesh expects. The content is parsed
 // by helmwatch.NewKubernetesClientFromKubeconfig — but our test path
@@ -1543,6 +1608,126 @@ func TestAutoEstablishClusterMesh_FullMeshSyncsReplicaAuthSecretsThenFlips(t *te
 	// AND the gate flipped on BOTH regions.
 	assertGateFlipped(t, fx.dynClients[fx.primaryKubeconfigPath], "primary")
 	assertGateFlipped(t, fx.dynClients[fx.secondaryKubeconfigPath], "secondary")
+}
+
+// TestAutoEstablishClusterMesh_SharedPGEnabled_SyncsSharedReplicaAuthThenFlips
+// (#3571) — when SOVEREIGN_ENABLE_SHARED_PG=true the bp-postgres shared
+// instances (shared-pg/-b/-c) ride the SAME crossRegion flip, so their
+// `<instance>-replication`/`-ca` Secrets (namespace shared-data) must also be
+// copied primary → replica before the gate flips. Assert all 6 land on the
+// replica byte-identical AND the gate flips on both regions.
+func TestAutoEstablishClusterMesh_SharedPGEnabled_SyncsSharedReplicaAuthThenFlips(t *testing.T) {
+	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
+	enableSharedPGInFixture(t, fx)
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+
+	// Sanity: the replica starts WITHOUT the shared-pg source Secrets.
+	replicaCS := fx.clients[fx.secondaryKubeconfigPath]
+	for _, name := range sharedPGReplicaAuthSecrets {
+		if _, err := replicaCS.CoreV1().Secrets(sharedPGNamespace).Get(context.Background(), name, metav1.GetOptions{}); err == nil {
+			t.Fatalf("precondition: replica unexpectedly already has shared-pg Secret %s", name)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	statuses, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep)
+	if err != nil {
+		t.Fatalf("AutoEstablishClusterMesh returned error: %v", err)
+	}
+	requireFullyMeshed(t, statuses)
+
+	// All 6 shared-pg source Secrets must now exist on the replica, byte-identical.
+	primaryCS := fx.clients[fx.primaryKubeconfigPath]
+	for _, name := range sharedPGReplicaAuthSecrets {
+		got, err := replicaCS.CoreV1().Secrets(sharedPGNamespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("replica missing copied shared-pg Secret %s — replica WAL-stream auth would dangle: %v", name, err)
+		}
+		src, _ := primaryCS.CoreV1().Secrets(sharedPGNamespace).Get(ctx, name, metav1.GetOptions{})
+		for k, v := range src.Data {
+			if string(got.Data[k]) != string(v) {
+				t.Errorf("shared-pg Secret %s key %q: replica=%q want %q (copy not byte-identical)", name, k, got.Data[k], v)
+			}
+		}
+	}
+
+	// AND the gate flipped on BOTH regions (so the shared-pg replica halves render).
+	assertGateFlipped(t, fx.dynClients[fx.primaryKubeconfigPath], "primary")
+	assertGateFlipped(t, fx.dynClients[fx.secondaryKubeconfigPath], "secondary")
+}
+
+// TestAutoEstablishClusterMesh_SharedPGEnabled_MissingSourceRefusesReplicaFlip
+// (#3571) — shared-pg ON but one shared engine's source Secret not yet minted
+// (its postgres mid-bootstrap) → the replica side is refused (its gate stays
+// OFF) while the primary side flips (stage 1). Mirrors the cnpg-pair
+// missing-source guard, extended to the shared-pg secret set.
+func TestAutoEstablishClusterMesh_SharedPGEnabled_MissingSourceRefusesReplicaFlip(t *testing.T) {
+	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
+	enableSharedPGInFixture(t, fx)
+	// Remove ONE shared-pg source Secret from the primary.
+	primaryCS := fx.clients[fx.primaryKubeconfigPath]
+	if err := primaryCS.CoreV1().Secrets(sharedPGNamespace).Delete(context.Background(), "shared-pg-b-replication", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete shared-pg source Secret: %v", err)
+	}
+	var logBuf bytes.Buffer
+	fx.handler.log = slog.New(slog.NewTextHandler(&logBuf, nil))
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	statuses, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep)
+	if err != nil {
+		t.Fatalf("AutoEstablishClusterMesh returned error: %v", err)
+	}
+	requireFullyMeshed(t, statuses)
+
+	// Two-stage: primary flips, replica refused until the shared-pg auth lands.
+	assertGateFlipped(t, fx.dynClients[fx.primaryKubeconfigPath], "primary")
+	assertGateNotFlipped(t, fx.dynClients[fx.secondaryKubeconfigPath], "secondary")
+	if !strings.Contains(logBuf.String(), "shared-pg replica-auth sync: source Secret unavailable on primary") {
+		t.Errorf("expected a loud warning about the missing shared-pg source Secret, got:\n%s", logBuf.String())
+	}
+}
+
+// TestAutoEstablishClusterMesh_SharedPGDisabled_DoesNotBlockFlip (#3571) —
+// when SOVEREIGN_ENABLE_SHARED_PG is absent/false the shared instances render
+// empty releases, CNPG never mints their Secrets, and the shared-pg sync must
+// be SKIPPED entirely — the cnpg-pair flip proceeds even with NO shared-pg
+// source Secrets present. This is the default-shape regression-lock.
+func TestAutoEstablishClusterMesh_SharedPGDisabled_DoesNotBlockFlip(t *testing.T) {
+	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
+	// Deliberately do NOT enable shared-pg and do NOT seed any shared-pg
+	// Secret (the default fixture). The cnpg-pair sync still has its own
+	// secrets seeded by newTestFixture.
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	statuses, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep)
+	if err != nil {
+		t.Fatalf("AutoEstablishClusterMesh returned error: %v", err)
+	}
+	requireFullyMeshed(t, statuses)
+
+	// The gate flips on BOTH regions despite ZERO shared-pg Secrets present —
+	// the shared-pg sync was skipped (flag off), not refused.
+	assertGateFlipped(t, fx.dynClients[fx.primaryKubeconfigPath], "primary")
+	assertGateFlipped(t, fx.dynClients[fx.secondaryKubeconfigPath], "secondary")
+	// And no shared-pg Secret was conjured onto the replica.
+	replicaCS := fx.clients[fx.secondaryKubeconfigPath]
+	if _, err := replicaCS.CoreV1().Secrets(sharedPGNamespace).Get(ctx, "shared-pg-replication", metav1.GetOptions{}); err == nil {
+		t.Errorf("shared-pg Secret appeared on the replica despite shared-pg being disabled")
+	}
 }
 
 // TestAutoEstablishClusterMesh_MissingSourceSecretRefusesFlip — when the


### PR DESCRIPTION
## The gap (founder-confirmed live on hw139, North Star #4)

`shared-pg`/`-b`/`-c` (`bp-postgres@0.1.10`) deployed as **singleton** cnpg Clusters — the Topology tab literally said *"declares no topology contract → single instance, no cross-region failover."* Yet their consumers declare `active-hot-standby`:

- shared-pg ← keycloak / gitea / harbor
- shared-pg-b ← grafana / powerdns
- shared-pg-c ← newapi / openova-flow / sme_*

So those apps' DR was **hollow at the data layer** — kill shared-pg's region and they lose data despite their cards claiming multi-region. The region-kill walk proved the `bp-cnpg-pair` MECHANISM (RTO 18s / RPO 0, hw128), but the agreed apps didn't sit on it. The `blueprint.yaml` already declared `perTopology.active-hot-standby.replication.backend: cnpg-pair` — but the CHART rendered a single multi-instance Cluster with `topology.kubernetes.io/region` antiAffinity, the **hw126 stretched-cluster fallacy** (a 2-region Sovereign is two SEPARATE ClusterMesh-joined clusters; one Cluster CR's region-B pods can never schedule on cluster-A).

## The fix

`bp-postgres` 0.2.0 makes `active-hot-standby` render the **PROVEN bp-cnpg-pair split-side shape**:

- **side=primary**: a Cluster that KEEPS the instance name (so the consumer host `<instance>-rw.<ns>.svc.cluster.local` is **UNCHANGED**) + region node-affinity + the CNPG-native `spec.postgresql.synchronous` block (`method=first`, `dataDurability=required` — NOT a raw `synchronous_standby_names` parameter, which the CNPG webhook rejects as fixed, the #3195 trap) + a ClusterMesh-global `<instance>-mesh` Service via `managed.services.additional`. Database CRs + roles + hub Secrets + the Application card render here only.
- **side=replica**: a `<instance>-replica` follower Cluster (`replica.enabled` + `pg_basebackup` + `externalClusters` streaming WAL over the `-mesh` Service) + a same-named `-mesh` Service stub + the #3322 own-cluster + hw126 operator-status NetworkPolicy carve-outs. No Database CRs / roles / Secrets (the replica inherits the catalog via the WAL stream).

`bp-continuum` drives the cross-region switchover — its `cnpgPromoter` flips `spec.replica.enabled` on the `<instance>` + `<instance>-replica` halves, the **SAME mechanism the hw128 region-kill walk PASSED**.

## How it gates (single-region byte-safe)

The 3 slots wire `topology.crossRegion` to the SAME `SOVEREIGN_ENABLE_CNPG_PAIR` post-mesh-confirm substitute bp-cnpg-pair rides (catalyst-api patches it onto every region's Kustomization **only after** ClusterMesh is established + the primary's replica-auth Secrets sync). A boolean seam (`crossRegion`) is used because envsubst can substitute a plain `true`/`false` but can't turn it into the `active-hot-standby` mode STRING (that needs tofu logic, unavailable for a RUNTIME catalyst-api patch). catalyst-api's cross-cluster replica-auth Secret sync (#3254) is **extended** to also copy the shared instances' `<instance>-replication`/`-ca` Secrets primary→replica in namespace `shared-data` — conditional on shared-pg being enabled, so a non-shared-pg Sovereign's cnpg-pair flip is never blocked.

## Single-region byte-safety proof

The singleton render (default, and any 2-region prov before the mesh confirms) is **STRUCTURALLY byte-identical** to 0.1.10 — proven by a chart-render diff of all 3 slot shapes against the committed chart (the only deltas are the per-render `randAlphaNum` passwords). New topology knobs (`side`/`crossRegion`/`haInstances`/`primary.region`/`replica.region`/`clusterMesh`/`networkPolicy`) are **ALL active-hot-standby-only**.

## What's in this PR

| File | Change |
|---|---|
| `platform/postgres/chart/templates/cluster.yaml` | primary/singleton — active-hot-standby renders the cnpg-pair primary shape (named Cluster + node-affinity + native synchronous + `-mesh` global Service) |
| `…/replica-cluster.yaml` (new) | `<instance>-replica` follower (replica.enabled + pg_basebackup + externalClusters over the mesh) |
| `…/replica-mesh-service.yaml` (new) | the replica-side `-mesh` Service stub (NXDOMAIN guard, Cilium merges by name) |
| `…/networkpolicy.yaml` (new) | the cross-region + #3322 own-cluster + hw126 operator-status carve-outs |
| `…/_helpers.tpl` | `side` / `activeHotStandby` / `renderReplicaHalf` / `replicaName` / `replicationServiceName` helpers |
| `…/database.yaml`, `role-secrets.yaml`, `application-cr.yaml` | gated to the PRIMARY side only |
| `…/values.yaml`, `Chart.yaml` (0.2.0), `blueprint.yaml` (0.2.0) | new topology knobs + changelog |
| `…/tests/postgres-render.sh` | +5 cases (ahs primary + replica + crossRegion-boolean slot path + singleton no-leak) |
| slots 16a/16c/16d | `topology.crossRegion`/`side`/region pins; pin → 0.2.0 |
| `core`-side `clustermesh.go` + `clustermesh_test.go` | extend the cross-cluster replica-auth Secret sync to the 3 shared instances (shared-data); +3 tests |
| `docs/topology-matrix.md` | machinery-convergence row (e) — shared-pg tier now on the real cnpg-pair |

## Validation

- `helm template`-validated BOTH single-region (byte-identical singleton) and 2-region (primary + replica halves) renders, both parse as valid YAML / structurally-sound CNPG Cluster CRs.
- `chart/tests/postgres-render.sh`: 13 cases green. `helm lint`: clean.
- catalyst-api: `go build`/`go vet` clean; `internal/handler` + `internal/provisioner` test suites green (incl. 3 new shared-pg sync tests). `check-bootstrap-kit-pin-sync.sh`, `check-bootstrap-deps.sh` (0 drift, 0 cycles), `check-tofu-flux-envsubst.sh` all PASS.

**Deferred validation** (kom4dc-infra-gated, hw139 half-pivoted, no hand-patch): build-and-merge for the next clean 2-region fresh prov, where a region-kill must preserve a **consumer's** data (e.g. keycloak realm survives a region-A kill).

Refs #3375
Refs #3571

🤖 Generated with [Claude Code](https://claude.com/claude-code)