### PR TITLE
fix(bp-openbao): default S3-creds RBAC namespace to release ns, not re-homed 'seaweedfs' — unwedges hw144 helm install (1.2.42)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -89,7 +89,14 @@ spec:
       # Adds crossRegion + cross-region mesh Service + ConfigMap; Continuum CR
       # promote step is OSS peers.json recovery. Default-OFF, single-region
       # byte-identical. Pin in lockstep.
-      version: 1.2.41
+      # 1.2.42 (#3562 #3373): unwedge the install — snapshot-replication.yaml
+      # defaulted the S3-creds Role/RoleBinding namespace to `seaweedfs`, which
+      # #3477 re-homed INTO the rtz vCluster (host ns gone), so `helm install`
+      # FAILED `namespaces "seaweedfs" not found` → openbao ✗ → sso-bridge ✗ →
+      # gitea hang → catalyst-platform ✗ → console 000 (hw144). $credNs now
+      # defaults to the release ns (where the CronJob's secretKeyRef reads the
+      # creds anyway). Default-OFF path unchanged; pin in lockstep.
+      version: 1.2.42
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.41
+  version: 1.2.42
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -69,7 +69,23 @@ name: bp-openbao
 # an OSS command; the design was unbuildable as written.)
 # Skip-render gated on continuum.enabled=true AND snapshotReplication.role=
 # secondary, so the default single-region render is byte-identical.
-version: 1.2.41
+# 1.2.42 (Refs #3562 #3373, 2026-06-15): FIX the install-wedging orphan
+# namespace. snapshot-replication.yaml defaulted the S3-creds Role/RoleBinding
+# namespace ($credNs) to `seaweedfs`, but #3373 Batch A (#3477) re-homed
+# bp-seaweedfs INTO the rtz vCluster, so the host `seaweedfs` namespace no
+# longer exists → `helm install bp-openbao` FAILED with `namespaces
+# "seaweedfs" not found` (×2), wedging the whole convergence chain
+# (openbao→sso-bridge→gitea→catalyst-platform→console 000) on hw144. The
+# CronJob already consumes the creds via secretKeyRef, which K8s resolves ONLY
+# in the Pod's OWN (release) namespace — so the Secret + its RBAC belong there,
+# never in seaweedfs. $credNs default flipped to .Release.Namespace
+# (values credentialsSecret.namespace: "" → release ns); the reflected/seeded
+# seaweedfs-s3-secret lands in the openbao ns (same bridge bp-gitea + catalyst
+# qa-fixtures use). snapshotReplication stays default-OFF so the single-region
+# render is byte-identical; the only enabled-path change is the RBAC namespace.
+# tests/snapshot-replication-toggle.sh Case 2 gains a no-orphan-namespace +
+# Role-present assertion. No upstream subchart change.
+version: 1.2.42
 # 1.2.37 (#3374, 2026-06-14): fix the sso-landing nginx ImagePullBackOff. The
 # image was `harbor.openova.io/proxy-docker/library/nginx` but the live Harbor
 # DockerHub proxy-cache project is `proxy-dockerhub` (proxy-docker does NOT

--- a/platform/openbao/chart/templates/snapshot-replication.yaml
+++ b/platform/openbao/chart/templates/snapshot-replication.yaml
@@ -73,7 +73,21 @@ objects). The primary vs secondary CronJob is selected by
 {{- $s3Region := $s3.region | default "us-east-1" -}}
 {{- $credSecret := $s3.credentialsSecret | default dict -}}
 {{- $credName := $credSecret.name | default "seaweedfs-s3-secret" -}}
-{{- $credNs := $credSecret.namespace | default "seaweedfs" -}}
+{{- /*
+  #3373 Batch A (#3477) re-homed bp-seaweedfs INTO the rtz vCluster, so the
+  host `seaweedfs` namespace NO LONGER EXISTS. The CronJob consumes the S3
+  admin creds via `secretKeyRef` (below), which K8s resolves ONLY in the Pod's
+  OWN namespace (.Release.Namespace) — a Pod can never read a Secret from
+  another namespace via secretKeyRef. So the credential Secret + its RBAC
+  belong in the release namespace, NOT in seaweedfs. Defaulting $credNs to the
+  stale `seaweedfs` value templated a Role/RoleBinding into a missing namespace
+  and FAILED the whole openbao helm install with `namespaces "seaweedfs" not
+  found` (#3562). Default now = .Release.Namespace; the reflected/seeded
+  seaweedfs-s3-secret lands here (same bridge pattern bp-gitea + the catalyst
+  qa-fixtures use to copy the source Secret out of the vCluster). Override
+  `s3.credentialsSecret.namespace` only for a host-placed seaweedfs.
+*/ -}}
+{{- $credNs := $credSecret.namespace | default .Release.Namespace -}}
 {{- $accessKeyKey := $credSecret.accessKeyKey | default "admin_access_key_id" -}}
 {{- $secretKeyKey := $credSecret.secretKeyKey | default "admin_secret_access_key" -}}
 {{- $staging := $sr.restoreStaging | default dict -}}
@@ -95,10 +109,15 @@ metadata:
     catalyst.openova.io/component: openbao-snapshot-replication
     app.kubernetes.io/name: openbao-snapshot
 ---
-# Role: read the S3 credentials Secret (the only K8s object the CronJob
-# reads). Scoped to the single credential Secret name. Lives in the S3
-# creds Secret's namespace so the SA can read it cross-namespace via a
-# RoleBinding there.
+# Role/RoleBinding: a defence-in-depth `get` grant on the single S3
+# credential Secret, scoped to its name, in the namespace where that
+# Secret actually lives ($credNs — the release namespace by default, since
+# the CronJob reads the keys via secretKeyRef from its OWN namespace). The
+# Secret is consumed through secretKeyRef (a kubelet projection, no API
+# read), so this RBAC is not on the hot path; it exists so a future
+# explicit-API consumer in $credNs is least-privilege ready. $credNs MUST
+# be an existing namespace — defaulting it to the re-homed `seaweedfs` ns
+# is what broke the install (#3562).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/platform/openbao/chart/tests/snapshot-replication-toggle.sh
+++ b/platform/openbao/chart/tests/snapshot-replication-toggle.sh
@@ -97,6 +97,22 @@ if grep -qE "^  name: openbao-snapshot-restore-staging$" "$TMP/primary.yaml"; th
   echo "FAIL: primary render unexpectedly contains the restore-staging PVC." >&2
   exit 1
 fi
+# #3373/#3477 re-homed bp-seaweedfs INTO the rtz vCluster, so the host
+# `seaweedfs` namespace no longer exists; a Role/RoleBinding targeting it
+# fails the whole openbao helm install with `namespaces "seaweedfs" not
+# found` (#3562). The S3-creds RBAC must land in an EXISTING namespace
+# (the release ns), and NO rendered object may target a `seaweedfs` ns.
+if grep -qE '^[[:space:]]*namespace:[[:space:]]*"?seaweedfs"?[[:space:]]*$' "$TMP/primary.yaml"; then
+  echo "FAIL: primary render places a resource in the non-existent 'seaweedfs' namespace — openbao install would fail with 'namespaces \"seaweedfs\" not found'." >&2
+  grep -nE '^[[:space:]]*namespace:[[:space:]]*"?seaweedfs"?[[:space:]]*$' "$TMP/primary.yaml" >&2
+  exit 1
+fi
+# The S3-creds Role + RoleBinding must render in the release namespace
+# (helm template defaults .Release.Namespace to "default").
+if ! grep -qE "^  name: openbao-snapshot-s3-creds$" "$TMP/primary.yaml"; then
+  echo "FAIL: primary render missing the openbao-snapshot-s3-creds Role/RoleBinding." >&2
+  exit 1
+fi
 echo "  PASS"
 
 echo "[snapshot-replication-toggle] Case 3: enabled + role=secondary emits the snapshot-FETCH CronJob + restore PVC"

--- a/platform/openbao/chart/values.yaml
+++ b/platform/openbao/chart/values.yaml
@@ -375,12 +375,22 @@ snapshotReplication:
     bucket: openbao-snapshots
     # Region label (SeaweedFS ignores it but the AWS CLI requires one).
     region: us-east-1
-    # Secret holding the S3 admin access/secret keys. Default matches the
-    # bp-seaweedfs-generated cluster-wide Secret. Its keys:
+    # Secret holding the S3 admin access/secret keys. Keys:
     #   admin_access_key_id / admin_secret_access_key.
+    # The CronJob reads these via secretKeyRef, which K8s resolves ONLY in the
+    # Pod's own (release) namespace — a Pod cannot read a Secret from another
+    # namespace this way. #3373 Batch A (#3477) re-homed bp-seaweedfs INTO the
+    # rtz vCluster, dropping the host `seaweedfs` namespace; this Secret +
+    # its RBAC must therefore live in the release namespace (empty namespace =
+    # .Release.Namespace), where bp-reflector/a seeder Job copies the source
+    # seaweedfs-s3-secret out of the vCluster (same bridge bp-gitea +
+    # catalyst qa-fixtures use). Setting namespace to the (missing) `seaweedfs`
+    # ns failed the openbao install with `namespaces "seaweedfs" not found`
+    # (#3562). Override only for a host-placed seaweedfs.
     credentialsSecret:
       name: seaweedfs-s3-secret
-      namespace: seaweedfs
+      # Empty → templates resolve to .Release.Namespace (the openbao ns).
+      namespace: ""
       accessKeyKey: admin_access_key_id
       secretKeyKey: admin_secret_access_key
   # Restore-staging PVC on the secondary — where the FETCH CronJob writes


### PR DESCRIPTION
## Problem (verified live on hw144 — the 100% validation run)

`bp-openbao` (1.2.41) helm install FAILS with `namespaces "seaweedfs" not found` (×2), `ProgressingWithRetry`. This wedges the ENTIRE convergence chain:

```
openbao ✗ → bp-sso-bridge ✗ → gitea gitea-sso-configure hook can't get
gitea-oauth-source-credentials → gitea install hangs (30m timeout) →
bp-catalyst-platform ✗ → console 000 → cutover unreachable
```

## Root cause

`platform/openbao/chart/templates/snapshot-replication.yaml` defaulted the S3-creds `Role` + `RoleBinding` namespace (`$credNs`, line ~76) to **`seaweedfs`**. #3373 Batch A (#3477, commit `3d8042122`) re-homed `bp-seaweedfs` **INTO the rtz vCluster**, so the host `seaweedfs` namespace no longer exists. Helm cannot apply a namespaced object into a missing namespace, so the whole install fails.

#3477 already rewired the S3 *endpoint* default to the rtz-synced host Service (line ~71), but the credential-secret **namespace** default was left as the stale `seaweedfs`.

## Fix

The CronJob consumes the S3 creds via `secretKeyRef` (lines ~232-241), which K8s resolves **ONLY in the Pod's own (release) namespace** — a Pod can never read a Secret from another namespace via `secretKeyRef`. So the Secret + its RBAC belong in the release namespace, never `seaweedfs`. The `Role`/`RoleBinding` were the **only** two resources landing in `$credNs`, and they were already vestigial (no code path does a cross-namespace API `get`).

- `$credNs` default flipped `seaweedfs` → `.Release.Namespace` (`platform/openbao/chart/templates/snapshot-replication.yaml:76`).
- `values.yaml` `snapshotReplication.s3.credentialsSecret.namespace: seaweedfs` → `""` (empty → release ns).
- Same bridge pattern `bp-gitea` (`objectstorage-secret.yaml`) + the catalyst `qa-fixtures` (`cnpg-clusters-qa.yaml`) already use to copy the source secret out of the vCluster into the consumer's own namespace.

## Proof (helm template, dependency built)

| Scenario | Result |
|---|---|
| default single-region render | byte-clean — zero `openbao-snapshot`/`seaweedfs` resources (skip-render intact) |
| `enabled, role=primary` | **NO** `namespace: seaweedfs` anywhere; `openbao-snapshot-s3-creds` Role/RoleBinding land in the release ns |
| `enabled, role=secondary` | **NO** `namespace: seaweedfs` anywhere |
| `-n openbao` install ns | Role/RoleBinding + RB subject land in `openbao` |
| explicit `credentialsSecret.namespace=custom-ns` override | still honored (host-placed seaweedfs escape hatch) |
| `secretKeyRef` secret name | unchanged `seaweedfs-s3-secret` (consumed same-namespace) |

`tests/snapshot-replication-toggle.sh` all 4 cases green, with a new no-orphan-namespace + Role-present regression assertion added to Case 2.

## Lockstep version bumps

- Chart `1.2.41` → `1.2.42`
- `blueprint.yaml` `spec.version` → `1.2.42`
- slot-08 pin (`clusters/_template/bootstrap-kit/08-openbao.yaml`) → `1.2.42`

`snapshotReplication` stays default-OFF, so the single-region render is byte-identical — the only enabled-path change is the RBAC namespace. Rolls into live hw144 via Flux on merge.

Refs #3562 #3373 #3574

🤖 Generated with [Claude Code](https://claude.com/claude-code)