### PR TITLE
fix(bp-postgres): shared-pg primary netpol must allow consumer 5432 ingress — SSO chain down on hw144 — 0.2.1

### DIFF
--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -129,7 +129,15 @@ spec:
       # secondary cluster) instead of the hw126 stretched-cluster antiAffinity.
       # Gated by topology.crossRegion below (the SOVEREIGN_ENABLE_CNPG_PAIR
       # post-mesh signal) so single-region provs stay byte-identical singletons.
-      version: 0.2.0
+      # 0.2.1 (#3577, Refs #3572 #3322): the 0.2.0 active-hot-standby primary
+      # NetworkPolicy (lifted from bp-cnpg-pair, a dedicated cluster) default-
+      # denied EVERY consumer's shared-pg-rw:5432 — on hw144 keycloak/gitea/
+      # harbor/grafana/catalyst-api all timed out (JDBC Acquisition timeout, the
+      # whole SSO chain down) the moment crossRegion flipped. Adds a consumer-
+      # ingress rule (TCP 5432 from any in-cluster Pod) so the SHARED engine's
+      # consumers reach it again; replication/own-cluster/operator carve-outs
+      # unchanged; singleton stays byte-identical. Lockstep bump with 16c/16d.
+      version: 0.2.1
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -78,7 +78,11 @@ spec:
       # global Service + shared-pg-b-replica follower). Gated by
       # topology.crossRegion below (SOVEREIGN_ENABLE_CNPG_PAIR). Single-region
       # stays a byte-identical singleton. Lockstep bump with 16a/16d.
-      version: 0.2.0
+      # 0.2.1 (#3577, Refs #3572 #3322): consumer-ingress carve-out — the 0.2.0
+      # primary NetworkPolicy default-denied every consumer's shared-pg-b-rw:5432
+      # (grafana/powerdns hub on hw144). Adds TCP 5432 from any in-cluster Pod;
+      # replication/own-cluster/operator carve-outs unchanged. Lockstep 16a/16d.
+      version: 0.2.1
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -65,7 +65,12 @@ spec:
       # shared-pg-c-mesh global Service + shared-pg-c-replica follower). Gated
       # by topology.crossRegion below (SOVEREIGN_ENABLE_CNPG_PAIR). Single-
       # region stays a byte-identical singleton. Lockstep bump with 16a/16c.
-      version: 0.2.0
+      # 0.2.1 (#3577, Refs #3572 #3322): consumer-ingress carve-out — the 0.2.0
+      # primary NetworkPolicy default-denied every consumer's shared-pg-c-rw:5432
+      # (SME mesh / newapi / openova-flow on hw144). Adds TCP 5432 from any
+      # in-cluster Pod; replication/own-cluster/operator carve-outs unchanged.
+      # Lockstep bump with 16a/16c.
+      version: 0.2.1
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-4-1-data-services
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.2.0
+  version: 0.2.1
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,5 +1,22 @@
 apiVersion: v2
 name: bp-postgres
+# 0.2.1 — #3577 (Refs #3572 #3322): the active-hot-standby PRIMARY-side
+#   NetworkPolicy (shared-pg-allow-replication-to-primary) was COPIED from
+#   bp-cnpg-pair, a DEDICATED cluster with no external consumers — so it never
+#   carried a consumer-ingress rule. But shared-pg is a SHARED data instance:
+#   its consumers (keycloak, gitea, harbor, grafana, powerdns, newapi,
+#   openova-flow, catalyst-api, …) live in MANY namespaces and all dial the
+#   primary's `<instance>-rw:5432`. A pod-selecting NetworkPolicy default-denies
+#   EVERY ingress it does not list, so on hw144 (the comprehensive prov) every
+#   consumer's 5432 connection timed out (keycloak JDBC Acquisition timeout, the
+#   handover EnsureUser 400, the entire SSO chain down) the instant crossRegion
+#   flipped on. The pre-0.2.0 singleton carried NO netpol → unrestricted
+#   consumer reach. FIX: add a consumer-ingress rule on the PRIMARY side
+#   allowing TCP 5432 from any in-cluster Pod (`namespaceSelector: {}`, the
+#   established repo idiom — harbor/guacamole/vpa) so no real consumer is missed.
+#   The replication + #3322 own-cluster + cross-region + CNPG-operator carve-outs
+#   stay intact; the replica side renders no consumer rule (consumers only hit
+#   the primary's `-rw`). singleton render stays byte-identical (still NO netpol).
 # 0.2.0 — #3571 (Refs #3375 North-Star-4): active-hot-standby now renders the
 #   PROVEN bp-cnpg-pair SPLIT-SIDE cross-region shape (primary Cluster keeps the
 #   instance name so the consumer host `<instance>-rw` is unchanged + a
@@ -37,7 +54,7 @@ name: bp-postgres
 #   regions so it admits under BOTH the pre-#3370 CRD (hard-required) and the
 #   #3370 CRD (CEL-waived) — breaks the live upgrade-rollback deadlock that
 #   blocked keycloak->gitea->catalyst-platform on hw130.
-version: 0.2.0
+version: 0.2.1
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable
@@ -67,6 +84,25 @@ description: |
 
   Changelog
   ─────────
+  0.2.1 (2026-06-15, Refs #3572 #3322 — shared-pg consumer-ingress carve-out)
+    - networkpolicy.yaml PRIMARY side: add an ingress rule allowing TCP 5432
+      from any in-cluster Pod (`namespaceSelector: {}`). The 0.2.0 policy was
+      lifted from bp-cnpg-pair (a DEDICATED cluster — no external consumers) so
+      it only opened the replication + own-cluster + operator paths. shared-pg
+      is SHARED: keycloak/gitea/harbor/grafana/powerdns/newapi/openova-flow/
+      catalyst-api all dial the primary's `<instance>-rw:5432` from their own
+      namespaces, and a pod-selecting NetworkPolicy default-denies every ingress
+      it does not list — so on hw144 every consumer's 5432 connection timed out
+      (keycloak JDBC Acquisition timeout, the handover EnsureUser 400, the whole
+      SSO chain down) the moment crossRegion flipped on. The pre-0.2.0 singleton
+      had NO netpol → unrestricted consumer reach; this restores that reach
+      under the platform default-deny CCNP. `namespaceSelector: {}` is the
+      established repo idiom (harbor/guacamole/vpa) for broad in-cluster consumer
+      reachability — chosen so no real consumer is missed (the #3572 regression
+      was OVER-restriction). The replication + #3322 own-cluster + cross-region +
+      CNPG-operator carve-outs are unchanged; the replica side renders no
+      consumer rule (consumers only hit the primary's `-rw`). singleton render
+      stays byte-identical (still emits NO NetworkPolicy object).
   0.2.0 (2026-06-15, Refs #3375 / #3571 — active-hot-standby = REAL cnpg-pair)
     - topology.mode=active-hot-standby now renders the PROVEN bp-cnpg-pair
       SPLIT-SIDE cross-region shape, replacing the old single multi-instance

--- a/platform/postgres/chart/templates/networkpolicy.yaml
+++ b/platform/postgres/chart/templates/networkpolicy.yaml
@@ -18,11 +18,13 @@ to today (no NetworkPolicy object at all).
 {{- $isReplica := include "bp-postgres.renderReplicaHalf" . }}
 {{- if not $isReplica }}
 ---
-# PRIMARY side: allow the primary Cluster's Pods to accept replication
-# connections from the replica Cluster's Pods (delivered into this region by
-# ClusterMesh) AND from their OWN cluster (instance-to-instance streaming +
-# the multi-instance pg_basebackup join — the #3322 own-cluster gap that sat
-# >1h "Creating" on hw130) AND from the CNPG operator's status/metrics probe.
+# PRIMARY side: allow the primary Cluster's Pods to accept connections from
+# the cluster's SHARED-PG CONSUMERS (keycloak, gitea, harbor, grafana,
+# powerdns, newapi, openova-flow, catalyst-api … → <instance>-rw:5432) AND
+# the replica Cluster's Pods (delivered into this region by ClusterMesh) AND
+# their OWN cluster (instance-to-instance streaming + the multi-instance
+# pg_basebackup join — the #3322 own-cluster gap that sat >1h "Creating" on
+# hw130) AND the CNPG operator's status/metrics probe.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -37,6 +39,27 @@ spec:
       cnpg.io/cluster: {{ include "bp-postgres.instanceName" . }}
   policyTypes: [Ingress]
   ingress:
+    # SHARED-PG CONSUMERS (#3577): the data instance is SHARED — its consumers
+    # live in MANY namespaces (keycloak, gitea, harbor, grafana, powerdns,
+    # powerdns-admin, sme, newapi, catalyst-system, …) and every one dials the
+    # primary's `<instance>-rw` Service on 5432. This NetworkPolicy selects ALL
+    # primary-CR Pods, so it default-denies EVERY ingress it does not list —
+    # including all of those consumer connections (on hw144 keycloak-0 →
+    # shared-pg-rw timed out, JDBC Acquisition timeout, the whole SSO chain
+    # down). The pre-0.2.0 singleton shared-pg carried NO NetworkPolicy at all,
+    # so consumers reached 5432 unrestricted; this rule restores that reach
+    # under the platform default-deny CCNP. `namespaceSelector: {}` matches
+    # Pods in EVERY namespace (the established repo idiom — harbor/guacamole/vpa
+    # use it for the same broad in-cluster consumer reachability) so no real
+    # consumer is missed — the #3572 regression was OVER-restriction, not under.
+    # This is a data-tier engine (consumers only WRITE app SQL on 5432), so the
+    # broad allow is scoped to a single port; the replication / own-cluster /
+    # operator carve-outs below remain intact.
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - port: 5432
+          protocol: TCP
     # The replica Cluster's Pods (cross-cluster via ClusterMesh — the
     # selector matches by Pod label regardless of source cluster).
     - from:


### PR DESCRIPTION
## Bug (verified live on hw144 — the comprehensive 100% prov)

#3572's `platform/postgres/chart/templates/networkpolicy.yaml` renders `shared-pg-allow-replication-to-primary` — a **pod-selecting** NetworkPolicy (`podSelector: cnpg.io/cluster=shared-pg`). A pod-selecting NetworkPolicy **default-denies ALL ingress except what it explicitly allows**. The 0.2.0 policy was lifted from bp-cnpg-pair (a DEDICATED cluster with no external consumers), so it only opened the replication + own-cluster + CNPG-operator paths — **NOT the consumer connections**.

`shared-pg` is a **SHARED** data instance: its consumers (keycloak, gitea, harbor, grafana, powerdns, newapi, openova-flow, catalyst-api) live in MANY namespaces and all dial the primary's `shared-pg-rw:5432`. So the instant `crossRegion` flipped on hw144:
- `keycloak-0 → shared-pg-rw.shared-data:5432` = TCP timeout (exit 124)
- keycloak logs `JDBC Acquisition timeout`
- catalyst-api handover `EnsureUser` 400s
- **the entire SSO chain is down**

shared-pg itself stayed healthy (3/3, 9/100 conns). This is the documented "any pod-selecting NetworkPolicy default-denies the workload's OWN/consumer paths" trap (memory `feedback_netpol_carveouts_must_allow_own_cluster_paths` / #3322).

## Fix

Add a consumer-ingress rule on the **PRIMARY side** allowing TCP **5432** from any in-cluster Pod (`namespaceSelector: {}` — the established repo idiom; harbor/guacamole/vpa use it for the same broad in-cluster consumer reachability). This restores the unrestricted consumer reach the pre-0.2.0 singleton had (which carried NO netpol), now under the platform default-deny CCNP.

- Chosen broad-by-namespace so **no real consumer is missed** — the #3572 regression was OVER-restriction, not under. Consumers span keycloak/gitea/harbor/grafana/powerdns/powerdns-admin/sme/newapi/catalyst-system, with no single shared label to key off.
- Scoped to the single port 5432 (a data-tier engine — consumers only write app SQL).
- The replication + #3322 own-cluster + cross-region + CNPG-operator carve-outs are **unchanged**.
- The **replica side** renders no consumer rule — consumers only hit the primary's `-rw`; the replica takes WAL streaming + its own join only.

`networkpolicy.yaml` (primary side, new first ingress rule):
```yaml
  ingress:
    # SHARED-PG CONSUMERS (#3577): … the data instance is SHARED …
    - from:
        - namespaceSelector: {}
      ports:
        - port: 5432
          protocol: TCP
    # …replication / own-cluster / operator carve-outs unchanged…
```

## Verification (`helm template` + the chart render-test)

- **Active-hot-standby PRIMARY** render now carries `namespaceSelector: {}` on TCP 5432 as the first ingress entry (chart label `bp-postgres-0.2.1`).
- **Singleton (default)** render emits NO NetworkPolicy → byte-identical to pre-0.2.0 (`tests/postgres-render.sh` **Case 5** asserts "no NetworkPolicy"; `helm template --show-only` finds zero output).
- **Replica side** renders only `allow-replication-to-replica` (own-cluster `podSelector` + `cnpg-system` operator) — NO `namespaceSelector: {}` consumer rule.
- `tests/postgres-render.sh` → **PASS** (all 11 cases green, EXIT=0).
- `helm lint` → 0 failures.

## Rollout

Chart `0.2.0 → 0.2.1` + lockstep-bump the 3 shared-pg slot pins (16a/16c/16d) + `blueprint.yaml`. hw144's Flux tracks `main`, so the version + pin bump self-heals the live SSO chain on next reconcile.

Refs #3572 #3322 #3577

🤖 Generated with [Claude Code](https://claude.com/claude-code)