### PR TITLE
fix(clustermesh): steady-state self-heal so collaterally-deleted replica-auth Secrets re-copy (NS#4 region-kill, hw144)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -194,6 +194,19 @@ const (
 	// case is ~15 min; pad to 20 min for the per-peer cert mint +
 	// Patch stack.
 	clusterMeshAttemptTimeoutDefault = 20 * time.Minute
+
+	// Steady-state heal cadence (#3583). After the retry loop first
+	// converges (mesh fully established + #3236 cnpg-pair flip landed),
+	// runAutoEstablishClusterMesh does NOT exit — it keeps re-running the
+	// idempotent establish at this low frequency for as long as the
+	// deployment stays status=ready, so a replica-auth Secret that gets
+	// collaterally deleted from the replica's namespace (hw144: convergence
+	// churn's gitea/harbor uninstall-remediation loops wiped the freshly
+	// copied shared-pg `<name>-replication`/`-ca` Secrets out of shared-data,
+	// and nothing re-copied because the loop had already exited) is re-copied
+	// on the next pass. The Handler field clusterMeshSteadyStateInterval
+	// overrides this for tests; zero falls back to the default below.
+	clusterMeshSteadyStateIntervalDefault = 5 * time.Minute
 )
 
 // ClusterMesh-gated cnpg-pair enable (#3236) — names of the Flux
@@ -1305,9 +1318,12 @@ func (h *Handler) syncSharedPGReplicaAuthSecrets(ctx context.Context, dep *Deplo
 // managedFields / creationTimestamp / generation / selfLink) are
 // stripped so the object is admissible on the destination; Data, Type,
 // Labels, and (non-Kustomize) Annotations carry over. Idempotent: a
-// re-run overwrites the destination's Data/Type with the current source
-// bytes (which is what makes the #3241 level-trigger re-run refresh the
-// copy). The destination namespace is assumed to exist (slot 16b ships
+// re-run refreshes the destination's Data/Type from the current source
+// bytes (which is what makes the #3241 level-trigger / #3583 steady-state
+// re-run heal the copy). When the destination already matches the source
+// (the common steady-state pass — nothing drifted) the Update is SKIPPED
+// (#3583), so a heal pass is a cheap Get+compare that writes only on
+// drift. The destination namespace is assumed to exist (slot 16b ships
 // the `cnpg` Namespace unconditionally on every region).
 func (h *Handler) copySecretAcrossClusters(ctx context.Context, src *corev1.Secret, dst kubernetes.Interface, namespace string) error {
 	if src == nil {
@@ -1341,6 +1357,14 @@ func (h *Handler) copySecretAcrossClusters(ctx context.Context, src *corev1.Secr
 		}
 		return nil
 	}
+	// #3583: the destination already exists. On the common steady-state pass
+	// the bytes match (nothing drifted) — skip the Update entirely so the
+	// heal phase stays a cheap Get+compare and only writes when it is
+	// genuinely re-healing. An Update on every pass would churn
+	// resourceVersions for no reason and add needless apiserver load.
+	if secretContentMatches(existing, desired) {
+		return nil
+	}
 	// Update in place — preserve the destination's resourceVersion so the
 	// Update is accepted, overwrite Data/Type/Labels/Annotations.
 	existing.Data = desired.Data
@@ -1354,6 +1378,41 @@ func (h *Handler) copySecretAcrossClusters(ctx context.Context, src *corev1.Secr
 	return nil
 }
 
+// secretContentMatches reports whether the destination Secret already
+// carries the desired content, so copySecretAcrossClusters /
+// updateCopiedSecret can skip a redundant Update on a steady-state heal
+// pass (#3583). It compares Type and the EFFECTIVE data — Data overlaid
+// with StringData — because the apiserver folds StringData into Data on
+// write, so a destination that was created from `desired` reports the
+// merged bytes under .Data with .StringData cleared. Labels/Annotations
+// are intentionally NOT part of the match: the replica-auth Secrets this
+// path copies carry no meaningful labels, and the heal contract is about
+// the WAL-stream auth material (Data/Type), not cosmetic metadata.
+func secretContentMatches(existing, desired *corev1.Secret) bool {
+	if existing == nil || desired == nil {
+		return false
+	}
+	if existing.Type != desired.Type {
+		return false
+	}
+	return reflect.DeepEqual(effectiveSecretData(existing), effectiveSecretData(desired))
+}
+
+// effectiveSecretData returns Data overlaid with StringData (StringData
+// wins, matching apiserver semantics), as a fresh map so callers never
+// mutate the Secret. Empty values normalise to a non-nil empty map so a
+// nil-Data and empty-Data Secret compare equal.
+func effectiveSecretData(s *corev1.Secret) map[string][]byte {
+	out := make(map[string][]byte, len(s.Data)+len(s.StringData))
+	for k, v := range s.Data {
+		out[k] = v
+	}
+	for k, v := range s.StringData {
+		out[k] = []byte(v)
+	}
+	return out
+}
+
 // updateCopiedSecret is the create-raced-update fallback for
 // copySecretAcrossClusters: re-Get to pick up the live resourceVersion,
 // then Update with the desired Data/Type/Labels/Annotations.
@@ -1361,6 +1420,11 @@ func (h *Handler) updateCopiedSecret(ctx context.Context, desired *corev1.Secret
 	existing, err := dst.CoreV1().Secrets(namespace).Get(ctx, desired.Name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("Get Secret %s/%s on replica (race fallback): %w", namespace, desired.Name, err)
+	}
+	// #3583: the racing creator may have already written the desired bytes —
+	// skip the redundant Update if so.
+	if secretContentMatches(existing, desired) {
+		return nil
 	}
 	existing.Data = desired.Data
 	existing.StringData = desired.StringData

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -692,6 +692,40 @@ func waitForClusterMeshEvent(t *testing.T, dep *Deployment, timeout time.Duratio
 		level, substrs, timeout, dumpClusterMeshEvents(dep))
 }
 
+// watchAndStopSteadyStateOnConverged spawns a background watcher that, the
+// moment the reconcile loop emits its final "reconcile loop complete"
+// success event, flips the deployment out of "ready". #3583 changed
+// runAutoEstablishClusterMesh so first-convergence hands off to the
+// (blocking) steady-state heal phase instead of returning; tests that
+// assert the bounded CONVERGENCE path (not the steady-state heal) use this
+// to release the heal goroutine so runAutoEstablishClusterMesh returns.
+// Returns a stop func that ends the watcher. The status flip happens AFTER
+// convergence (the success event fires only once the retry loop converged),
+// so it never short-circuits the convergence the test is exercising.
+func watchAndStopSteadyStateOnConverged(fx *testFixture) func() {
+	stop := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(5 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				if hasClusterMeshEvent(fx.dep, "info", "reconcile loop complete") {
+					fx.dep.mu.Lock()
+					if fx.dep.Status == "ready" {
+						fx.dep.Status = "wiped"
+					}
+					fx.dep.mu.Unlock()
+					return
+				}
+			}
+		}
+	}()
+	return func() { close(stop) }
+}
+
 // TestAutoEstablishClusterMesh_RegionSlotFailureEmitsEventWithRegionKey
 // — the hw126 silence shape (#3241): a region whose slot fails during
 // buildRegionSlots (kubeconfig path empty / unreadable) used to enter
@@ -770,6 +804,17 @@ func TestRunAutoEstablishClusterMesh_RetryConvergesAfterLBAppears(t *testing.T) 
 	fx.handler.clusterMeshRetryMaxBackoff = 60 * time.Millisecond
 	fx.handler.clusterMeshRetryBudget = 20 * time.Second
 	fx.handler.clusterMeshAttemptTimeout = 5 * time.Second
+	// #3583: convergence now hands off to the steady-state heal phase rather
+	// than returning. Fast interval so the heal goroutine notices the
+	// post-convergence status flip (below) and releases runAutoEstablish.
+	fx.handler.clusterMeshSteadyStateInterval = 20 * time.Millisecond
+
+	// #3583: once the loop reaches convergence (final success event) flip the
+	// deployment out of "ready" so the steady-state heal phase exits and
+	// runAutoEstablishClusterMesh returns — this test asserts the convergence
+	// path, not the (separately-tested) steady-state heal.
+	stopSteady := watchAndStopSteadyStateOnConverged(fx)
+	defer stopSteady()
 
 	// Once attempt 1 reports partial mesh, stamp the missing LB IP —
 	// the level-trigger's whole point is that a later-arriving IP
@@ -1850,6 +1895,11 @@ func TestAutoEstablishClusterMesh_ReRunAfterSecretsAppearConverges(t *testing.T)
 	fx.handler.clusterMeshRetryMaxBackoff = 60 * time.Millisecond
 	fx.handler.clusterMeshRetryBudget = 20 * time.Second
 	fx.handler.clusterMeshAttemptTimeout = 5 * time.Second
+	// #3583: release the post-convergence steady-state heal phase so the loop
+	// returns (this test asserts the convergence path).
+	fx.handler.clusterMeshSteadyStateInterval = 20 * time.Millisecond
+	stopSteady := watchAndStopSteadyStateOnConverged(fx)
+	defer stopSteady()
 
 	// Once attempt 1 reports "meshed but the cnpg-pair flip has not landed"
 	// (the new retry shape), the primary postgres finishes initdb → CNPG
@@ -2149,5 +2199,236 @@ func TestShouldStartupClusterMeshReconcile_RescuesTimeoutRecords(t *testing.T) {
 	}
 	if !h.shouldStartupClusterMeshReconcile(mk("ready", helmwatch.OutcomeReady)) {
 		t.Errorf("ready record must still pass")
+	}
+}
+
+// ── #3583 steady-state self-heal + copy-skip-on-match ───────────────────
+
+// TestCopySecretAcrossClusters_SkipsUpdateWhenUnchanged locks in the
+// #3583 write-elision: copying a Secret that already matches the source on
+// the destination must NOT issue an Update (so a steady-state heal pass
+// stays a cheap Get+compare). A fake-clientset "update" reactor counts the
+// Update calls: zero across an unchanged re-copy proves the write was
+// elided; one more after the source drifts proves the heal write still
+// fires.
+func TestCopySecretAcrossClusters_SkipsUpdateWhenUnchanged(t *testing.T) {
+	h := &Handler{log: silentLogger()}
+	dst := kfake.NewSimpleClientset()
+	var updates int
+	dst.PrependReactor("update", "secrets", func(action ktesting.Action) (bool, runtime.Object, error) {
+		updates++
+		return false, nil, nil // fall through to the default tracker
+	})
+	ctx := context.Background()
+	if _, err := dst.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: sharedPGNamespace},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create namespace: %v", err)
+	}
+
+	src := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-pg-replication", Namespace: sharedPGNamespace},
+		Type:       corev1.SecretTypeTLS,
+		Data:       map[string][]byte{"tls.crt": []byte("CRT-1"), "tls.key": []byte("KEY-1")},
+	}
+
+	// First copy creates the Secret (a Create, not an Update).
+	if err := h.copySecretAcrossClusters(ctx, src, dst, sharedPGNamespace); err != nil {
+		t.Fatalf("first copy (create): %v", err)
+	}
+	if updates != 0 {
+		t.Fatalf("create path issued %d Update(s), want 0", updates)
+	}
+
+	// Second copy with an IDENTICAL source must be a no-op — no Update.
+	if err := h.copySecretAcrossClusters(ctx, src, dst, sharedPGNamespace); err != nil {
+		t.Fatalf("second copy (unchanged): %v", err)
+	}
+	if updates != 0 {
+		t.Errorf("unchanged re-copy issued %d Update(s), want 0 — write-elision regressed (a heal pass would churn the apiserver every interval)", updates)
+	}
+
+	// Now drift the source — the next copy MUST write (exactly one Update)
+	// so a genuine heal still lands.
+	drifted := src.DeepCopy()
+	drifted.Data["tls.crt"] = []byte("CRT-2-HEALED")
+	if err := h.copySecretAcrossClusters(ctx, drifted, dst, sharedPGNamespace); err != nil {
+		t.Fatalf("third copy (drifted): %v", err)
+	}
+	if updates != 1 {
+		t.Errorf("drifted re-copy issued %d Update(s), want exactly 1 — the heal Update never fired", updates)
+	}
+	afterHeal, err := dst.CoreV1().Secrets(sharedPGNamespace).Get(ctx, src.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get after heal copy: %v", err)
+	}
+	if string(afterHeal.Data["tls.crt"]) != "CRT-2-HEALED" {
+		t.Errorf("drifted re-copy left stale bytes %q, want %q", afterHeal.Data["tls.crt"], "CRT-2-HEALED")
+	}
+}
+
+// TestSecretContentMatches covers the StringData/Type-aware comparison the
+// write-elision relies on, including the apiserver's StringData→Data fold.
+func TestSecretContentMatches(t *testing.T) {
+	base := func() *corev1.Secret {
+		return &corev1.Secret{
+			Type: corev1.SecretTypeTLS,
+			Data: map[string][]byte{"tls.crt": []byte("A"), "tls.key": []byte("B")},
+		}
+	}
+	if !secretContentMatches(base(), base()) {
+		t.Errorf("identical Secrets must match")
+	}
+	// Type drift → no match.
+	a, b := base(), base()
+	b.Type = corev1.SecretTypeOpaque
+	if secretContentMatches(a, b) {
+		t.Errorf("Type drift must NOT match")
+	}
+	// Data drift → no match.
+	a, b = base(), base()
+	b.Data["tls.crt"] = []byte("Z")
+	if secretContentMatches(a, b) {
+		t.Errorf("Data drift must NOT match")
+	}
+	// StringData on the desired side folds into the effective data and must
+	// compare equal to a destination that already carries it under .Data.
+	desired := &corev1.Secret{Type: corev1.SecretTypeOpaque, StringData: map[string]string{"k": "v"}}
+	existing := &corev1.Secret{Type: corev1.SecretTypeOpaque, Data: map[string][]byte{"k": []byte("v")}}
+	if !secretContentMatches(existing, desired) {
+		t.Errorf("StringData(desired) vs folded Data(existing) must match (apiserver fold semantics)")
+	}
+	// nil guard.
+	if secretContentMatches(nil, base()) || secretContentMatches(base(), nil) {
+		t.Errorf("nil operand must never match")
+	}
+}
+
+// TestRunClusterMeshSteadyStateHeal_ReCopiesDeletedReplicaSecret is the
+// heart of #3583: after first convergence the steady-state heal phase
+// keeps re-running the idempotent establish, so a replica-auth Secret that
+// gets collaterally deleted out of the replica's namespace (the hw144
+// shared-pg case, and the cnpg-pair case) is re-copied on the next pass —
+// no catalyst-api restart required. Drives runClusterMeshSteadyStateHeal
+// directly with a sub-second interval; deletes BOTH a shared-pg and a
+// cnpg-pair replica Secret; asserts both reappear; then flips status away
+// from "ready" to terminate the goroutine (the wipe path).
+func TestRunClusterMeshSteadyStateHeal_ReCopiesDeletedReplicaSecret(t *testing.T) {
+	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
+	enableSharedPGInFixture(t, fx)
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+
+	// Land first convergence: one establish copies every replica-auth Secret
+	// and flips the gate. (This is the state the retry loop reaches right
+	// before it hands off to the steady-state heal phase.)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := fx.handler.AutoEstablishClusterMesh(ctx, fx.dep); err != nil {
+		t.Fatalf("initial establish: %v", err)
+	}
+	replicaCS := fx.clients[fx.secondaryKubeconfigPath]
+	// Sanity: both a shared-pg and a cnpg-pair replica Secret are present.
+	sharedVictim := sharedPGReplicaAuthSecrets[0]
+	cnpgVictim := cnpgPairReplicaAuthSecrets[0]
+	if _, err := replicaCS.CoreV1().Secrets(sharedPGNamespace).Get(ctx, sharedVictim, metav1.GetOptions{}); err != nil {
+		t.Fatalf("precondition: shared-pg replica Secret %s should exist after first establish: %v", sharedVictim, err)
+	}
+	if _, ok := getCNPGSecret(t, replicaCS, cnpgVictim); !ok {
+		t.Fatalf("precondition: cnpg-pair replica Secret %s should exist after first establish", cnpgVictim)
+	}
+
+	// hw144 shape: convergence churn collaterally deletes the replica-auth
+	// Secrets out of the replica's namespaces.
+	if err := replicaCS.CoreV1().Secrets(sharedPGNamespace).Delete(ctx, sharedVictim, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete shared-pg replica Secret: %v", err)
+	}
+	if err := replicaCS.CoreV1().Secrets(cnpgPairNamespace).Delete(ctx, cnpgVictim, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete cnpg-pair replica Secret: %v", err)
+	}
+
+	// Sub-second heal cadence so the next pass fires in milliseconds.
+	fx.handler.clusterMeshSteadyStateInterval = 20 * time.Millisecond
+	fx.handler.clusterMeshAttemptTimeout = 5 * time.Second
+
+	healDone := make(chan struct{})
+	go func() {
+		fx.handler.runClusterMeshSteadyStateHeal(fx.dep)
+		close(healDone)
+	}()
+
+	// Poll for both Secrets to reappear — the steady-state pass self-heals.
+	deadline := time.Now().Add(10 * time.Second)
+	healed := false
+	for time.Now().Before(deadline) {
+		_, sErr := replicaCS.CoreV1().Secrets(sharedPGNamespace).Get(context.Background(), sharedVictim, metav1.GetOptions{})
+		_, cOK := getCNPGSecret(t, replicaCS, cnpgVictim)
+		if sErr == nil && cOK {
+			healed = true
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !healed {
+		t.Fatalf("steady-state heal did not re-copy the deleted replica Secrets;\nevents:\n%s", dumpClusterMeshEvents(fx.dep))
+	}
+
+	// The re-copied Secrets must be byte-identical to the primary source —
+	// a hollow placeholder would not authenticate the WAL stream.
+	primaryCS := fx.clients[fx.primaryKubeconfigPath]
+	srcShared, err := primaryCS.CoreV1().Secrets(sharedPGNamespace).Get(context.Background(), sharedVictim, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get primary shared-pg source %s: %v", sharedVictim, err)
+	}
+	gotShared, err := replicaCS.CoreV1().Secrets(sharedPGNamespace).Get(context.Background(), sharedVictim, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get re-healed shared-pg replica %s: %v", sharedVictim, err)
+	}
+	for k, v := range srcShared.Data {
+		if string(gotShared.Data[k]) != string(v) {
+			t.Errorf("re-healed shared-pg Secret %s key %q: replica=%q want %q (heal copy not byte-identical)", sharedVictim, k, gotShared.Data[k], v)
+		}
+	}
+
+	// Flip status away from ready (the wipe path) — the heal goroutine must
+	// observe it and terminate promptly.
+	fx.dep.mu.Lock()
+	fx.dep.Status = "wiped"
+	fx.dep.mu.Unlock()
+	select {
+	case <-healDone:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("steady-state heal goroutine did not stop after status left ready")
+	}
+}
+
+// TestRunClusterMeshSteadyStateHeal_StopsImmediatelyWhenNotReady proves the
+// heal goroutine exits at once if the deployment already left status=ready
+// before the first pass (a wipe that lands in the convergence→steady-state
+// handoff window) — it must never hurl an establish at a tearing-down
+// cluster.
+func TestRunClusterMeshSteadyStateHeal_StopsImmediatelyWhenNotReady(t *testing.T) {
+	fx := newTestFixture(t, []string{"203.0.113.10", "203.0.113.20"})
+	restore := installClusterMeshClientFactory(fx.clients)
+	defer restore()
+	restoreDyn := installClusterMeshDynamicClientFactory(fx.dynClients)
+	defer restoreDyn()
+
+	fx.dep.mu.Lock()
+	fx.dep.Status = "wiping"
+	fx.dep.mu.Unlock()
+	fx.handler.clusterMeshSteadyStateInterval = 1 * time.Hour // would block forever if entered
+
+	done := make(chan struct{})
+	go func() {
+		fx.handler.runClusterMeshSteadyStateHeal(fx.dep)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("steady-state heal did not return immediately when status != ready at entry")
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -177,6 +177,17 @@ type Handler struct {
 	clusterMeshRetryBudget         time.Duration
 	clusterMeshAttemptTimeout      time.Duration
 
+	// clusterMeshSteadyStateInterval (#3583) — cadence of the
+	// post-convergence steady-state heal phase. Once the retry loop
+	// converges, runAutoEstablishClusterMesh re-runs the idempotent
+	// establish at this interval (on a long-lived ctx, bounded only by the
+	// deployment staying status=ready) so a collaterally-deleted
+	// replica-auth Secret self-heals. Zero falls back to
+	// clusterMeshSteadyStateIntervalDefault. Tests inject a sub-second
+	// value so the steady-state pass is exercised in milliseconds;
+	// production leaves it at zero.
+	clusterMeshSteadyStateInterval time.Duration
+
 	// handoverCertWaitTimeout / handoverCertPollInterval — runtime knobs
 	// for the loop that waits for the sovereign-wildcard-tls Certificate
 	// Ready=True before the handover auto-fire mints the JWT. Zero falls

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -995,14 +995,34 @@ func (h *Handler) runHandoverJobSweep(dep *Deployment) {
 // re-running until fully meshed converges instead of thrashing.
 //
 // Loop shape: run the establish; when every region reports ReadyAt
-// (fully meshed) stop with a final success event. Otherwise sleep an
-// exponential backoff (clusterMeshRetryInitialBackoff doubling to
-// clusterMeshRetryMaxBackoff) and re-run, bounded by the
-// clusterMeshRetryBudget total and by the deployment staying
-// status=ready (a wipe mid-loop stops the retries — the kubeconfigs
-// are gone or going). Each retry emits a clustermesh-progress event
-// (attempt N, fullyMeshed X/Y) so the operator watches convergence,
-// not silence.
+// (fully meshed) AND the #3236 cnpg-pair flip has landed, emit the final
+// success event ONCE and transition into the steady-state heal phase
+// (below) — it does NOT exit. Otherwise sleep an exponential backoff
+// (clusterMeshRetryInitialBackoff doubling to clusterMeshRetryMaxBackoff)
+// and re-run, bounded by the clusterMeshRetryBudget total and by the
+// deployment staying status=ready (a wipe mid-loop stops the retries —
+// the kubeconfigs are gone or going). Each retry emits a
+// clustermesh-progress event (attempt N, fullyMeshed X/Y) so the operator
+// watches convergence, not silence.
+//
+// Steady-state heal phase (#3583): after first convergence the goroutine
+// keeps re-running the SAME idempotent establish at the much slower
+// clusterMeshSteadyStateInterval, bounded ONLY by the deployment staying
+// status=ready (its own context.Background()-derived ctx, NOT the retry
+// budget — the budget only governs the bounded convergence phase). hw144
+// proved why a permanent exit was wrong: the 6 shared-pg replica-auth
+// `<name>-replication`/`-ca` Secrets were copied primary→replica at
+// convergence, the loop converged + exited, then convergence churn
+// (gitea/harbor uninstall-remediation loops) collaterally DELETED them
+// from the replica's shared-data namespace and NOTHING re-copied (the loop
+// was gone, the next trigger is a catalyst-api restart) → the shared-pg
+// replicas could never pg_basebackup → cross-region DR went hollow. Every
+// step inside AutoEstablishClusterMesh is idempotent and the
+// copySecretAcrossClusters write is now skipped when the destination
+// already matches (#3583), so a steady-state pass is a cheap Get+compare
+// that writes ONLY when it is actually healing a drift. The first-
+// convergence success event still fires exactly once (operator signal);
+// the status!=ready check ends the goroutine on wipe.
 func (h *Handler) runAutoEstablishClusterMesh(dep *Deployment) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -1078,6 +1098,13 @@ func (h *Handler) runAutoEstablishClusterMesh(dep *Deployment) {
 				"attempt", attempt,
 				"regions", len(statuses),
 			)
+			// #3583: do NOT exit on first convergence — transition into the
+			// steady-state heal phase so a collaterally-deleted replica-auth
+			// Secret is re-copied on the next pass (hw144). The success event
+			// above fires exactly once (the operator's "converged" signal);
+			// the heal phase runs on its own long-lived ctx (not the retry
+			// budget) and ends only when the deployment leaves status=ready.
+			h.runClusterMeshSteadyStateHeal(dep)
 			return
 		}
 		if err != nil {
@@ -1135,6 +1162,127 @@ func (h *Handler) runAutoEstablishClusterMesh(dep *Deployment) {
 		if backoff > maxBackoff {
 			backoff = maxBackoff
 		}
+	}
+}
+
+// runClusterMeshSteadyStateHeal is the post-convergence phase of
+// runAutoEstablishClusterMesh (#3583). Once the bounded retry loop has
+// reached full convergence (mesh established + #3236 cnpg-pair flip
+// landed) it does NOT exit; it re-runs the idempotent
+// autoEstablishClusterMesh at the slow clusterMeshSteadyStateInterval for
+// as long as the deployment stays status=ready, so a replica-auth Secret
+// that gets collaterally deleted out of the replica's namespace (hw144:
+// the shared-pg `<name>-replication`/`-ca` Secrets, deleted by convergence
+// churn's gitea/harbor uninstall-remediation loops) is re-copied on the
+// next pass instead of dangling until the next catalyst-api restart.
+//
+// Lifecycle contract (do NOT widen):
+//   - Its own ctx is derived from context.Background(), NOT the retry
+//     budget — the budget bounds only the convergence phase; steady-state
+//     is unbounded in time and ends solely on status != "ready".
+//   - status is re-checked before AND after every pass (a wipe that lands
+//     mid-sleep or mid-pass exits the goroutine promptly — the kubeconfigs
+//     are gone or going, same rationale as the convergence loop's check).
+//   - Each pass is bounded by clusterMeshAttemptTimeout, mirroring the
+//     convergence loop's per-attempt bound.
+//   - Reads dep.Status / dep.Request under dep.mu only; writes NOTHING to
+//     dep.Result (the package's -race rule: dep.Result is stamped at
+//     startup only). The success event already fired exactly once in the
+//     caller; steady-state stays quiet (debug-level log) on the common
+//     no-drift pass and only emits a clustermesh-progress event when a
+//     pass actually re-heals or regresses.
+func (h *Handler) runClusterMeshSteadyStateHeal(dep *Deployment) {
+	interval := h.clusterMeshSteadyStateInterval
+	if interval <= 0 {
+		interval = clusterMeshSteadyStateIntervalDefault
+	}
+	attemptTimeout := h.clusterMeshAttemptTimeout
+	if attemptTimeout <= 0 {
+		attemptTimeout = clusterMeshAttemptTimeoutDefault
+	}
+
+	// Long-lived ctx: lives until the deployment leaves status=ready (the
+	// status check below cancels the work), independent of the convergence
+	// budget that bounded the caller's retry loop.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h.log.Info("clustermesh: steady-state heal phase started — re-reconciling on interval until the deployment leaves status=ready",
+		"id", dep.ID,
+		"interval", interval,
+	)
+
+	for {
+		dep.mu.Lock()
+		status := dep.Status
+		dep.mu.Unlock()
+		if status != "ready" {
+			h.log.Info("clustermesh: steady-state heal phase stopped — deployment no longer ready",
+				"id", dep.ID,
+				"status", status,
+			)
+			return
+		}
+
+		if sleepErr := sleepCtx(ctx, interval); sleepErr != nil {
+			// ctx cancelled (process shutdown) — stop quietly.
+			h.log.Info("clustermesh: steady-state heal phase stopped — context cancelled",
+				"id", dep.ID,
+				"err", sleepErr,
+			)
+			return
+		}
+
+		// Re-check after the sleep: a wipe that landed during the interval
+		// must not get an establish attempt hurled at a tearing-down cluster.
+		dep.mu.Lock()
+		status = dep.Status
+		dep.mu.Unlock()
+		if status != "ready" {
+			h.log.Info("clustermesh: steady-state heal phase stopped — deployment no longer ready",
+				"id", dep.ID,
+				"status", status,
+			)
+			return
+		}
+
+		attemptCtx, cancelAttempt := context.WithTimeout(ctx, attemptTimeout)
+		statuses, cnpgPairConverged, err := h.autoEstablishClusterMesh(attemptCtx, dep)
+		cancelAttempt()
+
+		fullyMeshed := countFullyMeshedRegions(statuses)
+		meshConverged := len(statuses) >= 2 && fullyMeshed == len(statuses)
+		if err != nil {
+			// A transient error on a steady-state pass is not fatal — the
+			// next pass retries. Surface it so a persistent drift is visible.
+			h.emitClusterMeshProgress(dep, "warn",
+				fmt.Sprintf("ClusterMesh steady-state heal: reconcile pass returned an error (%v) — retrying on the next %s interval", err, interval))
+			h.log.Warn("clustermesh: steady-state heal pass returned error",
+				"id", dep.ID,
+				"err", err,
+			)
+			continue
+		}
+		if meshConverged && cnpgPairConverged {
+			// Common case: still fully converged, the copy was a no-op
+			// (destination already matched). Stay quiet — debug-level only.
+			h.log.Debug("clustermesh: steady-state heal pass — still fully converged, no drift",
+				"id", dep.ID,
+				"regions", len(statuses),
+			)
+			continue
+		}
+		// A drift was found and (idempotently) re-healed by this pass — the
+		// copy re-created the deleted Secret(s) / the flip was re-applied.
+		// Surface it so the operator sees the self-heal fire (hw144 shape).
+		h.emitClusterMeshProgress(dep, "info",
+			fmt.Sprintf("ClusterMesh steady-state heal: re-reconciled a drift (%d/%d regions meshed, cnpg-pair flip landed=%t) — replica-auth Secrets / gate re-applied", fullyMeshed, len(statuses), cnpgPairConverged))
+		h.log.Info("clustermesh: steady-state heal pass re-reconciled a drift",
+			"id", dep.ID,
+			"fullyMeshed", fullyMeshed,
+			"regions", len(statuses),
+			"cnpgPairConverged", cnpgPairConverged,
+		)
 	}
 }
 


### PR DESCRIPTION
## What

`runAutoEstablishClusterMesh`'s level-triggered retry loop reached convergence (`meshConverged && cnpgPairConverged`) and then **RETURNED** (`phase1_watch.go`). After exit nothing re-ran the cross-region replica-auth Secret sync until the next trigger (catalyst-api restart → `restoreFromStore` → `shouldStartupClusterMeshReconcile`).

On a real 2-region prov (hw144) the 6 shared-pg `<name>-replication`/`-ca` Secrets were copied primary → replica at convergence (logged "shared-pg replica-auth Secrets synced…"), the loop converged + exited, then convergence churn (gitea/harbor uninstall-remediation loops) collaterally **DELETED** them from the replica region's `shared-data` namespace, and nothing re-copied (the loop was already gone) → shared-pg replicas could never `pg_basebackup` (`secret shared-pg-replication not found`) → cross-region DR went hollow → North Star #4 (region-kill preserves keycloak data) not demonstrable. cnpg-pair survived only because its Secrets sit in the quieter `cnpg` namespace. `copySecretAcrossClusters` never deletes; the gap was purely the missing post-convergence re-reconcile.

## Fix (smallest safe, self-healing)

Turn the post-convergence lifecycle from **exit → steady-state heal**:

- **`phase1_watch.go`** — on first convergence, fire the existing success event **exactly once** (operator signal preserved), then call the new `runClusterMeshSteadyStateHeal(dep)`. It re-runs the idempotent `autoEstablishClusterMesh` at `clusterMeshSteadyStateInterval` (default **5m**) on its **own `context.Background()`-derived ctx (NOT the retry budget)**, bounded **only** by the deployment staying `status=ready`. A deleted replica-auth Secret self-heals on the next pass. The single-region early branch, the `recover()` guard, the `meshConverged`/`cnpgPairConverged` detection and the backoff math are **untouched**. The cnpg-pair replica-auth Secrets share the exit path and re-reconcile via the same loop automatically.
- **`handler.go`** — new `clusterMeshSteadyStateInterval` tunable (zero → default; tests inject sub-second).
- **`clustermesh.go`** — `clusterMeshSteadyStateIntervalDefault` const beside the existing `clusterMeshRetry*Default` consts; and `copySecretAcrossClusters` / `updateCopiedSecret` now **skip the `Update` when the destination already content-matches the source** (Type + effective Data via `secretContentMatches`), so a steady-state pass is a cheap Get+compare that writes **only on drift**. Create-on-missing intact.

Race-clean: the heal goroutine reads `dep.Status`/`dep.Request` under `dep.mu` and writes **nothing** to `dep.Result` (the package's `-race` rule). All three production call sites already invoke `go h.runAutoEstablishClusterMesh(dep)` (fire-and-forget), so the blocking steady-state phase is a correct deployment-lifetime background heal; it ends when the deployment is wiped (status flips).

## Tests (`clustermesh_test.go`)

- write-elision: reactor-counted Updates — **0** on an unchanged re-copy, **1** after the source drifts (heal write still lands byte-identical).
- `secretContentMatches`: Type drift / Data drift / StringData→Data fold / nil guard.
- steady-state pass re-copies a deleted **shared-pg AND cnpg-pair** replica Secret, byte-identical, with no catalyst-api restart; then exits when status leaves `ready`.
- immediate exit when `status != ready` at entry (wipe in the convergence→steady-state handoff window).
- the two existing convergence tests release the now-background steady-state goroutine on the success event (assert the bounded convergence path, not the heal).

```
go build ./...            # exit 0 (whole module)
go vet ./...              # exit 0
go test ./... -race       # 36 pkgs ok, no failures, no data races
```

Refs #3583
Refs #3571
Refs #3375

🤖 Generated with [Claude Code](https://claude.com/claude-code)
