### PR TITLE
fix(bp-self-sovereign-cutover): step-06 helmrepository-patches Phase-3a wait loops forever at 0/0

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -512,7 +512,18 @@ spec:
       # local sha1 lookup that never touches the external OAuth2 source. Same
       # credential + pattern as step-05 #3536; image flips images.git →
       # images.kubectl (alpine/k8s has kubectl+curl+git). No RBAC change.
-      version: 0.1.64
+      # 0.1.65 (#3588, Refs #3568 #3379 #3526, hw144 step-06 loops-forever;
+      # rebased over 0.1.64's step-01 PAT fix #3584):
+      # 0.1.63's Phase-3a readiness wait used the success test `total>0 &&
+      # not_ready==0`. On hw144 the local-Harbor HR set converged then emptied
+      # (`61/61 → 1/1 → 0/0 not-Ready: <none>`) and the `total>0` guard meant
+      # `0/0` never succeeded — the loop spun out stripReadinessSeconds and then
+      # FATAL-refused the strip, wedging cutover at step-06. Fix: add a
+      # `seen_local_ready` latch + success test `not_ready==0 && (total>0 ||
+      # seen_local_ready)` so the post-convergence 0/0 terminates-success while
+      # a first-poll 0/0 (pivot never happened) still waits — preserving the
+      # 0.1.63 strip-before-pivot half-pivot guard.
+      version: 0.1.65
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.64
+  version: 0.1.65
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -620,7 +620,26 @@ name: bp-self-sovereign-cutover
 # and wires it into GitRepository.spec.secretRef BEFORE the URL flip — same
 # credential + pattern as #3454's openova-sme-tenants GitRepository. Adds
 # `secrets: create` to the cutover-runner RBAC.
-version: 0.1.64
+# 0.1.65 (#3588, Refs #3568 #3379 #3526, hw144 step-06 loops-forever 2026-06-15;
+# rebased over 0.1.64's step-01 PAT fix #3584):
+# Step-06 Phase-3a (the readiness-gated mothership-auth strip, 0.1.63) waited
+# FOREVER at `0/0` and FATAL-refused the strip → cutover wedged at step-06.
+# ROOT CAUSE: the Phase-3a success test was `total>0 && not_ready==0`. On hw144
+# the local-Harbor HelmRepository set converged `61/61 not-Ready → … → 1/1
+# (openova-catalog) → 0/0 not-Ready: <none>` and then looped forever: once the
+# tracked set emptied to total=0 (every pivoted HR Ready, then a Flux re-render
+# window transiently dropped the local-Harbor match count to zero) the `total>0`
+# guard could never be satisfied again, so the loop spun out the full
+# stripReadinessSeconds deadline and then exited non-zero (REFUSING the strip).
+# FIX: introduce a `seen_local_ready` latch (set the first poll in which a
+# non-empty local-Harbor set is fully Ready) and change the success test to
+# `not_ready==0 && (total>0 || seen_local_ready)`. This terminates-success on
+# the post-convergence 0/0 case while NEVER succeeding on a first-poll 0/0 where
+# the pivot never happened (which would reintroduce the 0.1.63 half-pivot the
+# strip-before-pivot fix exists to prevent). A genuine half-pivot (HRs stuck
+# not-Ready, latch never set) still spins to the deadline and correctly REFUSES
+# the strip. Smallest correct fix; no step-count / RBAC / timeout change.
+version: 0.1.65
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -739,6 +739,33 @@ data:
             strip_wait_deadline=$(( $(date +%s) + STRIP_READINESS_TIMEOUT_SECONDS ))
             echo "[helmrepository-patches] Phase-3a: waiting up to ${STRIP_READINESS_TIMEOUT_SECONDS}s for local-Harbor HelmRepositories to be Ready before stripping mothership auth"
             ready_ok="false"
+            # `seen_local_ready` latches TRUE the first poll in which every
+            # observed local-Harbor HR is Ready=True AND at least one local-
+            # Harbor HR was present (total>0). It is what lets the loop
+            # terminate-success in the `0/0` case WITHOUT reintroducing the
+            # strip-before-pivot half-pivot.
+            #
+            # WHY THE LATCH (the hw144 step-06 loops-forever bug, Refs #3568):
+            #   The original success test was `total>0 && not_ready==0`. On
+            #   hw144 the local-Harbor HR set converged `61/61 not-Ready → …
+            #   → 1/1 (openova-catalog) → 0/0 not-Ready: <none>` and then
+            #   LOOPED FOREVER at `0/0`: once the tracked set emptied to
+            #   total=0 (every pivoted HR Ready, then a Flux re-render /
+            #   churn window transiently dropped the local-Harbor match count
+            #   to zero) the `total>0` guard could never be satisfied again,
+            #   so the loop spun out the full deadline and then FATAL-refused
+            #   the strip → cutover wedged at step-06.
+            #
+            #   The fix is NOT "treat any 0/0 as done" — that would let the
+            #   VERY FIRST poll (before Flux has pivoted any HR to local
+            #   Harbor) strip ghcr.io with total=0, which is precisely the
+            #   half-pivot the #3379/#3526 strip-before-pivot fix prevents.
+            #   Instead we require that the pivot was OBSERVED CONVERGED at
+            #   least once: success is `not_ready==0` AND (`total>0` this poll
+            #   OR we have previously latched a fully-Ready local-Harbor set).
+            #   A genuine half-pivot (HRs stuck not-Ready, latch never set)
+            #   still spins to the deadline and correctly REFUSES the strip.
+            seen_local_ready="false"
             # Snapshot file (writable /tmp emptyDir) holding one line per HR:
             # "<ns> <name> <spec.url> <Ready-status>". Re-written each poll.
             # Using a file (not a heredoc) keeps the whole block correctly
@@ -769,12 +796,24 @@ data:
                     "reconcile.fluxcd.io/requestedAt=${now_ts}" >/dev/null 2>&1 || true
                 fi
               done < "${hr_snapshot}"
+              # Latch: at least one local-Harbor HR present this poll AND all
+              # of them Ready — the proof that registry.<fqdn> + Phase-0 auth
+              # work. Once latched it stays latched, so a later poll that finds
+              # the tracked set emptied (total=0) still counts as converged.
               if [ "${total}" -gt 0 ] && [ "${not_ready}" -eq 0 ]; then
+                seen_local_ready="true"
+              fi
+              # Success when NOTHING is not-ready AND we have ever observed the
+              # pivot fully converged. Covers both the steady all-Ready case
+              # (total>0, not_ready=0) and the post-convergence 0/0 case (the
+              # tracked set emptied after a clean pass) — without ever
+              # succeeding on a first-poll 0/0 where the pivot never happened.
+              if [ "${not_ready}" -eq 0 ] && { [ "${total}" -gt 0 ] || [ "${seen_local_ready}" = "true" ]; }; then
                 ready_ok="true"
-                echo "[helmrepository-patches] Phase-3a OK: all ${total} local-Harbor HelmRepository(ies) Ready=True"
+                echo "[helmrepository-patches] Phase-3a OK: local-Harbor HelmRepository pivot converged Ready=True (this poll total=${total}, seen_local_ready=${seen_local_ready})"
                 break
               fi
-              echo "[helmrepository-patches] Phase-3a: ${not_ready}/${total} local-Harbor HelmRepository(ies) not yet Ready: ${not_ready_names:-<none>}; retrying in 15s"
+              echo "[helmrepository-patches] Phase-3a: ${not_ready}/${total} local-Harbor HelmRepository(ies) not yet Ready: ${not_ready_names:-<none>} (seen_local_ready=${seen_local_ready}); retrying in 15s"
               sleep 15
             done
 


### PR DESCRIPTION
## Defect (verified live on hw144)

The cutover reached **step-06** then wedged. The step-06 Job `cutover-helmrepository-patches` Phase-3a (the readiness-gated mothership-auth strip, chart 0.1.63, Refs #3379 #3526) waits for the local-Harbor HelmRepositories to become Ready before stripping ghcr.io / harbor.openova.io auth from `ghcr-pull`.

Its log shows them converging `61/61 not yet Ready → 1/1 (openova-catalog) → 0/0 not yet Ready: <none>` and then it **loops forever** (~17+ min), eventually FATAL-refusing the strip:

```
[helmrepository-patches] Phase-3a: 0/0 local-Harbor HelmRepository(ies) not yet Ready: <none>; retrying in 15s
```

## Root cause

`platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml:772` — the Phase-3a success condition:

```sh
if [ "${total}" -gt 0 ] && [ "${not_ready}" -eq 0 ]; then
  ready_ok="true"; break
fi
```

The `total > 0` guard means: once the tracked local-Harbor HR set converges to **empty** (`total=0`, after every pivoted HR went Ready and a Flux re-render / churn window transiently dropped the local-Harbor match count to zero — the `<none>` in the log) the success branch can never be taken again. The loop spins out the full `stripReadinessSeconds` deadline, then exits non-zero refusing the strip → cutover wedges at step-06.

## Fix

Introduce a `seen_local_ready` latch (set the first poll in which a **non-empty** local-Harbor set is fully Ready) and change the success test to:

```sh
if [ "${not_ready}" -eq 0 ] && { [ "${total}" -gt 0 ] || [ "${seen_local_ready}" = "true" ]; }; then
```

This terminates-success on the post-convergence `0/0` case while **never** succeeding on a first-poll `0/0` where the pivot never happened — which would reintroduce the 0.1.63 strip-before-pivot half-pivot. A genuine half-pivot (HRs stuck not-Ready, latch never set) still spins to the deadline and correctly REFUSES the strip (`ghcr.io` auth intact, recoverable).

### Behaviour matrix (simulated)

| not_ready | total | seen_local_ready | verdict |
|---|---|---|---|
| 0 | 0 | false | **WAIT** (first-poll, pivot never happened — half-pivot guard) |
| 0 | 61 | true | SUCCEED (steady all-Ready) |
| 0 | 0 | true | **SUCCEED** (post-convergence 0/0 — the hw144 wedge) |
| 5 | 61 | false | WAIT (genuine half-pivot → deadline refuses strip) |
| 2 | 61 | false | WAIT (mid-convergence partial) |

## Validation

- `tests/cutover-contract.sh` — **25/25 green**, incl. Case 17b (strip is in Phase 3, readiness-gated + fail-closed, after the pivot).
- Rendered step-06 script passes `dash -n` (POSIX / BusyBox-sh syntax check).
- chart `0.1.63 → 0.1.64`; `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` pin bumped to `0.1.64`.

## Scope + honest forward note

Smallest correct fix — no step-count, RBAC, or timeout change. This lands on GitHub for **future provs** via the catalog mirror; it does NOT unwedge the running hw144 (its Flux is already on local Gitea).

This is the cutover saga — each attempt reveals the next defect (genuine forward progress). Step-07 (catalyst-api-env-patch) and step-08 (the 600s deny-egress hold) have **never been reached on a fresh prov** and may reveal further defects when this fix lets the cutover advance past step-06.

Refs #3568 #3379 #3526

🤖 Generated with [Claude Code](https://claude.com/claude-code)