### PR TITLE
feat(console+provisioning): placement step in catalog create flow + namespace-readiness guard (#3591)

### DIFF
--- a/core/console/src/components/CatalogPage.svelte
+++ b/core/console/src/components/CatalogPage.svelte
@@ -6,21 +6,44 @@
   import PortalShell from './PortalShell.svelte';
   import {
     getApps, getMyOrgs, installApp,
-    type User, type Org, type CatalogApp,
+    type User, type Org, type CatalogApp, type TopologyMode, type Placement,
   } from '../lib/api';
   import { path } from '../lib/config';
   import { getAppStateStore } from '../lib/stores/appState.svelte';
 
   const ACTIVE_ORG_KEY = 'sme-active-org';
 
+  // Canonical Sovereign region keys — mirrors the marketplace signup BCP
+  // picker (core/marketplace/src/components/BCPStep.svelte) and the values
+  // the provisioning gitops appconfigs path expects. Kept as a fixed list
+  // (no live regions endpoint yet); the catalog/regions endpoint is the
+  // right injection point when it exists.
+  const REGIONS: { key: string; label: string }[] = [
+    { key: 'hz-fsn-rtz-prod', label: 'Falkenstein (hz-fsn)' },
+    { key: 'hz-hel-rtz-prod', label: 'Helsinki (hz-hel)' },
+    { key: 'hz-nbg-rtz-prod', label: 'Nuremberg (hz-nbg)' },
+  ];
+
+  // Topology modes the create flow offers. We constrain the offered set to
+  // what the Blueprint declares it supports when that metadata is present
+  // (catalog topology field); otherwise all three are offered.
+  const TOPOLOGY_LABELS: Record<TopologyMode, string> = {
+    'single-region': 'Single-region (one region)',
+    'active-active': 'Active-active (two regions, both serving)',
+    'active-hotstandby': 'Active-hot-standby (primary + standby region)',
+  };
+  const ALL_TOPOLOGIES: TopologyMode[] = ['single-region', 'active-active', 'active-hotstandby'];
+
   let catalog = $state<CatalogApp[]>([]);
+  let orgs = $state<Org[]>([]);
   let loading = $state(true);
   let activeOrg = $state<Org | null>(null);
   let query = $state('');
   // Shared store — source of truth for tenant apps + app_states + jobs. #64
   let store = $state<ReturnType<typeof getAppStateStore> | null>(null);
 
-  // Add modal state.
+  // Add modal state. Placement (#3591) is captured here via SELECT inputs:
+  // target Organization, its vCluster, topology mode, and region(s).
   let modal = $state<null | {
     app: CatalogApp;
     mode: 'add' | 'capacity';
@@ -30,6 +53,11 @@
     // Advanced: per-dependency "dedicated" (new instance) vs "reuse" (existing instance slug/id).
     depChoices?: Record<string, 'dedicated' | string>;
     advancedOpen?: boolean;
+    // Placement selections.
+    orgId?: string;
+    topology?: TopologyMode;
+    primaryRegion?: string;
+    replicaRegion?: string;
   }>(null);
   let toasts = $state<Array<{ id: number; text: string; kind: 'ok' | 'info' | 'error' }>>([]);
   let toastId = 0;
@@ -48,6 +76,7 @@
 
   $effect(() => {
     getMyOrgs().then(list => {
+      orgs = list || [];
       const picked = pickActiveOrg(list || []);
       activeOrg = picked;
       if (picked) {
@@ -115,6 +144,22 @@
     setTimeout(() => { toasts = toasts.filter(t => t.id !== id); }, 3500);
   }
 
+  // The topology modes this app may be placed with. The SME catalog does
+  // not yet carry a per-app topology field (tracked by #3593), so today we
+  // offer the full set; once the catalog exposes supported_topologies this
+  // narrows to the app's real capability. Always includes single-region.
+  function supportedTopologies(_app: CatalogApp): TopologyMode[] {
+    return ALL_TOPOLOGIES;
+  }
+
+  // One vCluster per Organization in the SME model — the tenant's vCluster
+  // is addressed by the Org slug (host namespace tenant-<slug>). The SELECT
+  // is therefore a single, deterministic option keyed off the chosen Org.
+  function vclusterFor(orgId: string | undefined): string {
+    const o = orgs.find((x) => x.id === orgId);
+    return o ? o.slug : '';
+  }
+
   function requestAdd(app: CatalogApp) {
     // Default every dependency to a dedicated new instance; the user can flip
     // to "reuse" in the Advanced drawer if an existing shareable instance is
@@ -123,7 +168,25 @@
     for (const depSlug of app.dependencies ?? []) {
       depChoices[depSlug] = 'dedicated';
     }
-    modal = { mode: 'add', app, depChoices, advancedOpen: false };
+    // Seed placement defaults: active Org, its vCluster, single-region in the
+    // primary region. All editable via the SELECTs in the modal.
+    modal = {
+      mode: 'add', app, depChoices, advancedOpen: false,
+      orgId: activeOrg?.id,
+      topology: 'single-region',
+      primaryRegion: REGIONS[0].key,
+      replicaRegion: REGIONS[1].key,
+    };
+  }
+
+  // Placement is valid when: an Org is chosen, a primary region is chosen,
+  // and (for active-* modes) the replica region differs from the primary.
+  // Mirrors the gitops InvalidRegionPair guard so the user can't ship a
+  // config the provisioning generator would silently degrade.
+  function placementValid(m: NonNullable<typeof modal>): boolean {
+    if (!m.orgId || !m.primaryRegion) return false;
+    if (m.topology === 'single-region') return true;
+    return !!m.replicaRegion && m.replicaRegion !== m.primaryRegion;
   }
 
   // Only shareable deps are offered a reuse option. Non-shareable deps (none
@@ -146,10 +209,20 @@
   }
 
   async function confirmAdd() {
-    if (!modal || !activeOrg) return;
+    if (!modal) return;
+    const targetOrgId = modal.orgId ?? activeOrg?.id;
+    if (!targetOrgId || !placementValid(modal)) return;
     modal.pending = true;
+    const placement: Placement = {
+      topology: modal.topology ?? 'single-region',
+      primary_region: modal.primaryRegion ?? REGIONS[0].key,
+      vcluster: vclusterFor(targetOrgId),
+      ...(modal.topology && modal.topology !== 'single-region'
+        ? { replica_region: modal.replicaRegion }
+        : {}),
+    };
     try {
-      await installApp(activeOrg.id, modal.app.slug, modal.depChoices);
+      await installApp(targetOrgId, modal.app.slug, modal.depChoices, placement);
       showToast(`${modal.app.name} queued for install`, 'ok');
       modal = null;
       // Kick the shared store so this page and any sibling tab flip to
@@ -284,7 +357,61 @@
                 {/each}
               </p>
             {/if}
-            <p class="modal-body muted">Current tenant: {installedIds.length} apps installed on {org?.name ?? 'your plan'}.</p>
+            <p class="modal-body muted">Current tenant: {installedIds.length} apps installed.</p>
+
+            <!-- Placement step (#3591) — every input is a SELECT (no free-text). -->
+            <div class="placement">
+              <div class="place-field">
+                <label for="place-org">Organization</label>
+                <select id="place-org" bind:value={modal.orgId}>
+                  {#each orgs as o (o.id)}
+                    <option value={o.id}>{o.name}</option>
+                  {/each}
+                </select>
+              </div>
+
+              <div class="place-field">
+                <label for="place-vcluster">vCluster</label>
+                <select id="place-vcluster" disabled>
+                  <option value={vclusterFor(modal.orgId)}>{vclusterFor(modal.orgId) || '—'}</option>
+                </select>
+                <span class="place-hint">One vCluster per Organization — the app lands here.</span>
+              </div>
+
+              <div class="place-field">
+                <label for="place-topology">Topology</label>
+                <select id="place-topology" bind:value={modal.topology}>
+                  {#each supportedTopologies(modal.app) as t}
+                    <option value={t}>{TOPOLOGY_LABELS[t]}</option>
+                  {/each}
+                </select>
+              </div>
+
+              <div class="place-regions">
+                <div class="place-field">
+                  <label for="place-primary">{modal.topology === 'single-region' ? 'Region' : 'Primary region'}</label>
+                  <select id="place-primary" bind:value={modal.primaryRegion}>
+                    {#each REGIONS as r}
+                      <option value={r.key}>{r.label}</option>
+                    {/each}
+                  </select>
+                </div>
+                {#if modal.topology && modal.topology !== 'single-region'}
+                  <div class="place-field">
+                    <label for="place-replica">{modal.topology === 'active-active' ? 'Second region' : 'Standby region'}</label>
+                    <select id="place-replica" bind:value={modal.replicaRegion}>
+                      {#each REGIONS as r}
+                        <option value={r.key}>{r.label}</option>
+                      {/each}
+                    </select>
+                  </div>
+                {/if}
+              </div>
+
+              {#if modal.topology !== 'single-region' && modal.replicaRegion === modal.primaryRegion}
+                <p class="place-error" role="alert">Primary and {modal.topology === 'active-active' ? 'second' : 'standby'} regions must differ.</p>
+              {/if}
+            </div>
 
             {#if shareableDeps(modal.app).length > 0}
               <button
@@ -361,7 +488,7 @@
             {/if}
             <div class="modal-actions">
               <button class="btn btn-secondary" onclick={closeModal} disabled={modal.pending}>Cancel</button>
-              <button class="btn btn-primary" onclick={confirmAdd} disabled={modal.pending}>
+              <button class="btn btn-primary" onclick={confirmAdd} disabled={modal.pending || !placementValid(modal)}>
                 {modal.pending ? 'Installing…' : 'Install'}
               </button>
             </div>
@@ -581,6 +708,32 @@
     display: flex; gap: 0.5rem; justify-content: flex-end;
     margin-top: 1rem;
   }
+
+  /* Placement step (#3591) — SELECT-only inputs. */
+  .placement {
+    margin-top: 0.85rem;
+    display: flex; flex-direction: column; gap: 0.7rem;
+  }
+  .place-field { display: flex; flex-direction: column; gap: 0.25rem; }
+  .place-field label {
+    font-size: 0.78rem; font-weight: 600; color: var(--color-text-strong);
+  }
+  .place-field select {
+    width: 100%; padding: 0.45rem 0.6rem;
+    border: 1px solid var(--color-border); border-radius: 8px;
+    background: var(--color-bg, var(--color-surface)); color: var(--color-text);
+    font: inherit; font-size: 0.85rem; appearance: auto;
+  }
+  .place-field select:focus { outline: 2px solid var(--color-accent); border-color: transparent; }
+  .place-field select:disabled { opacity: 0.7; cursor: not-allowed; }
+  .place-hint { font-size: 0.72rem; color: var(--color-text-dim); }
+  .place-regions { display: grid; grid-template-columns: 1fr 1fr; gap: 0.7rem; }
+  @media (max-width: 480px) { .place-regions { grid-template-columns: 1fr; } }
+  .place-error {
+    margin: 0; color: var(--color-danger, #ef4444);
+    font-size: 0.78rem; font-weight: 500;
+  }
+
   .adv-toggle {
     margin-top: 0.75rem; padding: 0.35rem 0;
     background: none; border: none; color: var(--color-text-dim);

--- a/core/console/src/lib/api.ts
+++ b/core/console/src/lib/api.ts
@@ -250,12 +250,31 @@ export const getJobs = (tenantId: string) =>
 export const getUninstallPreview = (orgId: string, slug: string) =>
   request<UninstallPreview>(`/tenant/orgs/${orgId}/apps/${slug}/uninstall-preview`);
 
+// Placement captured by the catalog create flow (#3591). topology is the
+// BCP mode; region(s) and vcluster pin where the Application lands. All
+// fields come from SELECT/DROPDOWN inputs — no free-text (founder rule).
+//   - 'single-region'      → one region, no replica.
+//   - 'active-active'      → two regions, both serving.
+//   - 'active-hotstandby'  → primary + hot-standby replica region.
+// The backend translates this to the canonical app_configs.postgres
+// {active_hot_standby, primary_region, replica_region} contract the
+// provisioning gitops generator already consumes, and ensures the target
+// tenant namespace exists before the install lands.
+export type TopologyMode = 'single-region' | 'active-active' | 'active-hotstandby';
+export interface Placement {
+  topology: TopologyMode;
+  primary_region: string;
+  replica_region?: string;
+  vcluster: string;
+}
+
 // Day-2 app management (backend: task #134 — returns 501 until shipped)
 // dep_choices maps dependency slug -> 'dedicated' | existing instance slug/id.
 export const installApp = (
   orgId: string,
   slug: string,
   depChoices?: Record<string, string>,
+  placement?: Placement,
 ) =>
   request<{ status: string; message?: string; upgrade_suggestion?: string }>(
     `/tenant/orgs/${orgId}/apps`,
@@ -264,6 +283,7 @@ export const installApp = (
       body: JSON.stringify({
         slug,
         ...(depChoices && Object.keys(depChoices).length ? { dep_choices: depChoices } : {}),
+        ...(placement ? { placement } : {}),
       }),
     },
   );

--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -106,6 +106,13 @@ type appChangeData struct {
 	DeploySlugs    []string          `json:"deploy_slugs"`
 	DepChoices     map[string]string `json:"dep_choices"`
 	Apps           []string          `json:"apps"` // final tenant.Apps IDs after the change
+	// AppConfigs carries the create-flow placement (#3591) translated to the
+	// canonical configSchema contract keyed by app slug (e.g. {"postgres":
+	// {"active_hot_standby": true, "primary_region": "...", "replica_region":
+	// "..."}}). Threaded into the manifest generator so day-2 installs honour
+	// the chosen topology/regions. Nil/empty preserves the legacy
+	// single-region default.
+	AppConfigs map[string]map[string]any `json:"app_configs,omitempty"`
 }
 
 func (h *Handler) handleAppInstallRequested(ctx context.Context, event *events.Event) error {
@@ -420,7 +427,11 @@ func (h *Handler) applyTenantChange(ctx context.Context, data appChangeData, act
 			"tenant", data.TenantSlug, "action", action)
 	}
 
-	manifests := h.Generator.GenerateAllWithPassword(data.TenantSlug, planSlug, appSlugs, dbPassword)
+	// Thread the create-flow placement (#3591) into the generator via the
+	// canonical app_configs contract. Empty/nil preserves the legacy
+	// single-region default (GenerateAllWithAppConfigs treats absence as a
+	// no-op, identical to the old GenerateAllWithPassword path).
+	manifests := h.Generator.GenerateAllWithAppConfigs(data.TenantSlug, planSlug, appSlugs, dbPassword, data.AppConfigs)
 	if len(manifests) == 0 {
 		return fmt.Errorf("manifest generation produced no files")
 	}

--- a/core/services/tenant/handlers/apps.go
+++ b/core/services/tenant/handlers/apps.go
@@ -48,6 +48,11 @@ func (h *Handler) InstallApp(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Slug       string            `json:"slug"`
 		DepChoices map[string]string `json:"dep_choices"`
+		// Placement (#3591) — the catalog create flow's topology + region(s)
+		// + vCluster picks. All fixed-set SELECT values; no free-text. We
+		// translate it to the canonical app_configs.postgres contract the
+		// provisioning gitops generator already consumes.
+		Placement *installPlacement `json:"placement"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		respond.Error(w, http.StatusBadRequest, "invalid JSON body")
@@ -57,10 +62,37 @@ func (h *Handler) InstallApp(w http.ResponseWriter, r *http.Request) {
 		respond.Error(w, http.StatusBadRequest, "slug is required")
 		return
 	}
+	if perr := validatePlacement(body.Placement); perr != "" {
+		respond.Error(w, http.StatusBadRequest, perr)
+		return
+	}
 
 	tenant, err := h.Store.GetTenant(r.Context(), tenantID)
 	if err != nil || tenant == nil {
 		respond.Error(w, http.StatusNotFound, "organization not found")
+		return
+	}
+
+	// Namespace-readiness precondition (#3591). The Application install lands
+	// its HelmRelease in the tenant's namespace (tenant-<slug>). If the tenant
+	// hasn't finished provisioning, that namespace does not exist yet and the
+	// HR would fail with "namespace not found". Refuse with a clear message
+	// instead of dispatching an install that's doomed to land in a missing ns.
+	if tenant.Subdomain == "" {
+		respond.Error(w, http.StatusConflict,
+			"organization has no namespace yet — finish provisioning before installing apps")
+		return
+	}
+	switch tenant.Status {
+	case "active", "":
+		// ready — namespace exists (initial provision created tenant-<slug>).
+	case "provisioning":
+		respond.Error(w, http.StatusConflict,
+			"organization is still provisioning — its namespace is not ready yet, try again shortly")
+		return
+	default:
+		respond.Error(w, http.StatusConflict,
+			"organization is not active (status: "+tenant.Status+") — cannot install apps")
 		return
 	}
 
@@ -173,6 +205,19 @@ func (h *Handler) InstallApp(w http.ResponseWriter, r *http.Request) {
 			deploySlugs = append(deploySlugs, a.Slug)
 		}
 	}
+	// Translate the placement picks (#3591) into the canonical
+	// app_configs.postgres contract the provisioning gitops generator
+	// consumes (active_hot_standby + primary_region + replica_region). For
+	// single-region this leaves active_hot_standby=false (the legacy
+	// single-cluster path). Persist onto the tenant so a re-provision /
+	// regeneration keeps the same placement, and forward it on the payload.
+	appConfigs := placementToAppConfigs(body.Placement)
+	if len(appConfigs) > 0 {
+		if err := h.Store.MergeAppConfigs(r.Context(), tenantID, appConfigs); err != nil {
+			slog.Warn("install: persist app_configs failed (continuing)", "tenant_id", tenantID, "error", err)
+		}
+	}
+
 	// One idempotency key per user click, shared between HTTP + event so the
 	// provisioning service can dedup the two transports into a single run.
 	// See issue #71.
@@ -188,6 +233,9 @@ func (h *Handler) InstallApp(w http.ResponseWriter, r *http.Request) {
 		"deploy_slugs":    deploySlugs,
 		"dep_choices":     body.DepChoices,
 		"apps":            tenant.Apps,
+	}
+	if len(appConfigs) > 0 {
+		payload["app_configs"] = appConfigs
 	}
 	if err := h.callProvisioning(r.Context(), "/provisioning/apps/install", payload); err != nil {
 		slog.Error("install: provisioning HTTP call", "error", err, "tenant_id", tenantID)
@@ -501,4 +549,70 @@ func contains(haystack []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+// installPlacement is the create-flow placement payload (#3591). Every field
+// is a fixed-set SELECT value on the console (no free-text). topology is one
+// of single-region / active-active / active-hotstandby; regions are Sovereign
+// region keys; vcluster is the tenant's vCluster (one per Organization).
+type installPlacement struct {
+	Topology      string `json:"topology"`
+	PrimaryRegion string `json:"primary_region"`
+	ReplicaRegion string `json:"replica_region"`
+	VCluster      string `json:"vcluster"`
+}
+
+var validTopologyMode = map[string]bool{
+	"single-region":     true,
+	"active-active":     true,
+	"active-hotstandby": true,
+}
+
+// validatePlacement returns "" when the placement is valid (or absent), else a
+// user-facing error string. Mirrors the gitops InvalidRegionPair guard so the
+// console can't ship a config the provisioning generator would silently
+// degrade: active-* modes require two distinct regions.
+func validatePlacement(p *installPlacement) string {
+	if p == nil {
+		return "" // placement is optional — legacy single-region default applies.
+	}
+	if !validTopologyMode[p.Topology] {
+		return "invalid placement.topology: must be single-region, active-active, or active-hotstandby"
+	}
+	if p.PrimaryRegion == "" {
+		return "placement.primary_region is required"
+	}
+	if p.Topology != "single-region" {
+		if p.ReplicaRegion == "" {
+			return "placement.replica_region is required for active-active / active-hotstandby"
+		}
+		if p.ReplicaRegion == p.PrimaryRegion {
+			return "placement primary and replica regions must differ"
+		}
+	}
+	return ""
+}
+
+// placementToAppConfigs translates the placement into the canonical
+// app_configs.postgres contract the provisioning gitops generator consumes
+// (core/services/provisioning/gitops/gitops.go reads active_hot_standby +
+// primary_region + replica_region). single-region → active_hot_standby=false
+// (legacy single-cluster path). Returns nil when there's nothing to set.
+func placementToAppConfigs(p *installPlacement) map[string]map[string]any {
+	if p == nil || p.Topology == "" {
+		return nil
+	}
+	pg := map[string]any{}
+	if p.Topology == "single-region" {
+		pg["active_hot_standby"] = false
+	} else {
+		// active-active and active-hotstandby both pin two regions; the
+		// generator's cnpg-pair path keys off active_hot_standby + the
+		// region pair (active-active is rendered as the same two-region
+		// shape today — a follow-up can specialise it).
+		pg["active_hot_standby"] = true
+		pg["primary_region"] = p.PrimaryRegion
+		pg["replica_region"] = p.ReplicaRegion
+	}
+	return map[string]map[string]any{"postgres": pg}
 }

--- a/core/services/tenant/store/store.go
+++ b/core/services/tenant/store/store.go
@@ -158,6 +158,33 @@ func (s *Store) SetAppState(ctx context.Context, tenantID, appID, state string) 
 	return nil
 }
 
+// MergeAppConfigs merges per-app configSchema values into tenant.AppConfigs
+// without clobbering sibling apps or sibling fields. Used by the day-2
+// install path (#3591) to persist the placement picks (keyed by app slug,
+// e.g. "postgres") so a later regeneration keeps the same topology/regions.
+// Uses dotted $set keys (app_configs.<slug>.<field>) so concurrent writers
+// to different apps/fields don't overwrite each other.
+func (s *Store) MergeAppConfigs(ctx context.Context, tenantID string, cfgs map[string]map[string]any) error {
+	if tenantID == "" || len(cfgs) == 0 {
+		return nil
+	}
+	set := bson.D{{Key: "updated_at", Value: time.Now().UTC()}}
+	for slug, fields := range cfgs {
+		for k, v := range fields {
+			set = append(set, bson.E{Key: "app_configs." + slug + "." + k, Value: v})
+		}
+	}
+	update := bson.D{{Key: "$set", Value: set}}
+	res, err := s.tenants().UpdateOne(ctx, bson.D{{Key: "_id", Value: tenantID}}, update)
+	if err != nil {
+		return fmt.Errorf("store: merge app configs %s: %w", tenantID, err)
+	}
+	if res.MatchedCount == 0 {
+		return fmt.Errorf("store: tenant %s not found", tenantID)
+	}
+	return nil
+}
+
 // ClearAppState removes AppStates[appID] from the given tenant.
 func (s *Store) ClearAppState(ctx context.Context, tenantID, appID string) error {
 	if tenantID == "" || appID == "" {


### PR DESCRIPTION
## What

Adds the missing **placement step** to the catalog create flow and a **namespace-readiness guard** so installs can't land in a missing namespace.

Before: the create flow asked only for confirmation — it never collected placement (topology / region / vCluster) — and an install dispatched against a not-yet-provisioned Organization landed its HelmRelease in a missing `tenant-<slug>` namespace ("namespace not found").

## Console (CatalogPage add modal)
- New placement step. **ALL inputs are SELECT/DROPDOWN — no free-text** (founder rule): Organization, vCluster (one per Org), Topology (single-region / active-active / active-hotstandby), Region(s). Replica region appears for active-* modes; Install is gated until primary != replica.
- `installApp()` carries an optional `Placement`.

## Backend
- tenant `InstallApp` accepts `placement`, validates it (mirrors the gitops `InvalidRegionPair` guard), translates it to the canonical `app_configs.postgres` {active_hot_standby, primary_region, replica_region} contract the provisioning generator already consumes, persists it onto the tenant (`store.MergeAppConfigs`), and forwards it on the install payload.
- **Namespace-readiness precondition**: reject install with 409 + a clear message when the Organization has no subdomain or isn't active (still provisioning / suspended) — instead of landing an HR in a missing namespace.
- provisioning `appChangeData` gains `app_configs`; `applyTenantChange` threads it through `GenerateAllWithAppConfigs` so day-2 installs honour the chosen topology/regions. Empty/nil preserves the legacy single-region default.

## Verification
- `astro build` clean; `go build` + `go vet` clean (tenant + provisioning); `go test ./handlers/... ./store/... ./gitops/...` green in both modules.

## Note on base branch
The placement UI lives in `CatalogPage.svelte`, which is introduced by #3592. This PR is therefore **stacked on `issue-3592-nav-split-apps-catalog`** (its base). Review/merge #3594 (#3592) first, then re-target this to `main`. This is a catalyst-ui change — intentionally **not merged**; the orchestrator reviews first.

Refs #3591
