### PR TITLE
feat(console): catalog/provisioning UX — Apps/Catalog nav split, placement-in-create, namespace-ensure, dropdowns (Refs #3601 #3599 #3598 #3600 #3597)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -261,6 +261,23 @@ type applicationStatusResponse struct {
 	// shape. Added qa-loop iter-7 Cluster-C (#1227).
 	Conditions     []map[string]interface{} `json:"conditions,omitempty"`
 	LastReconciled string                   `json:"lastReconciled,omitempty"`
+	// Spec surfaces the create-time placement so the AppDetail Topology
+	// tab reflects the placement chosen at install/create time WITHOUT
+	// waiting for the controller to populate status.placement (#3599,
+	// EPIC #3597). The FE TopologyTab reads `app.spec.placement` (the
+	// editor-posture mode string) + `app.spec.regions`.
+	Spec *applicationStatusSpec `json:"spec,omitempty"`
+}
+
+// applicationStatusSpec is the spec subset the Topology tab consumes.
+// Placement is normalised to the editor posture string
+// (single-region | active-active | active-hotstandby) regardless of
+// whether the CR stored the legacy string form or the #3373 object form.
+type applicationStatusSpec struct {
+	Placement      string                 `json:"placement,omitempty"`
+	Regions        []string               `json:"regions,omitempty"`
+	EnvironmentRef string                 `json:"environmentRef,omitempty"`
+	BlueprintRef   map[string]interface{} `json:"blueprintRef,omitempty"`
 }
 
 // ── HTTP handler — install ───────────────────────────────────────────
@@ -418,6 +435,24 @@ func (h *Handler) HandleApplicationInstall(w http.ResponseWriter, r *http.Reques
 	client, err := h.sovereignDynamicClient(dep)
 	if err != nil {
 		writeUserAccessUnavailable(w, err)
+		return
+	}
+
+	// #3598 (EPIC #3597) — ensure the Org/Environment namespace exists
+	// before creating the Application CR, so an install never fails with
+	// `namespaces "<org>" not found` when the organization controller's
+	// GitOps namespace reconcile hasn't landed yet. Idempotent.
+	if nsErr := ensureOrgNamespace(r.Context(), client, body.OrganizationRef); nsErr != nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"kind":       "Application",
+			"name":       body.Name,
+			"namespace":  body.OrganizationRef,
+			"error":      "namespace-ensure-failed",
+			"status":     "503",
+			"httpStatus": 503,
+			"applied":    false,
+			"detail":     fmt.Sprintf("could not ensure namespace %q: %v", body.OrganizationRef, nsErr),
+		})
 		return
 	}
 
@@ -606,7 +641,35 @@ func (h *Handler) HandleApplicationStatus(w http.ResponseWriter, r *http.Request
 	if resp.Conditions == nil {
 		resp.Conditions = []map[string]interface{}{}
 	}
+	// #3599 — surface the create-time placement from spec so the Topology
+	// tab reflects it immediately (no wait for status.placement).
+	resp.Spec = applicationStatusSpecFromCR(obj)
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// applicationStatusSpecFromCR projects the Application CR's spec subset
+// the Topology tab reads. Placement is normalised to the editor posture
+// string via placementForTopology so the editor's mode pre-select works
+// whether the CR stored the legacy string (`single-region`) or the
+// #3373 object form (`{mode: active-hotstandby, regions: [...]}`).
+func applicationStatusSpecFromCR(obj *unstructured.Unstructured) *applicationStatusSpec {
+	if obj == nil {
+		return nil
+	}
+	spec := &applicationStatusSpec{}
+	// Placement: readTopology already handles string + object(mode) +
+	// label fallback; map its result onto the editor posture enum.
+	spec.Placement = placementForTopology(readTopology(obj))
+	if regions, ok, _ := unstructured.NestedStringSlice(obj.Object, "spec", "regions"); ok {
+		spec.Regions = regions
+	}
+	if env, ok, _ := unstructured.NestedString(obj.Object, "spec", "environmentRef"); ok && env != "" {
+		spec.EnvironmentRef = env
+	}
+	if br, ok, _ := unstructured.NestedMap(obj.Object, "spec", "blueprintRef"); ok {
+		spec.BlueprintRef = br
+	}
+	return spec
 }
 
 // ── HTTP handler — SSE status stream ────────────────────────────────

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
@@ -856,6 +856,20 @@ func (h *Handler) HandleCreateInstance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// #3598 (EPIC #3597) — ensure the Org/Environment namespace exists
+	// BEFORE creating any Application CR. Without this the create races the
+	// organization controller's GitOps namespace reconcile and fails with
+	// `namespaces "<org>" not found` (the founder-reported "namespace not
+	// found"). Ensured here so BOTH the backing-service CRs below and the
+	// consumer CR land in a present namespace.
+	if nsErr := ensureOrgNamespace(r.Context(), client, body.Org); nsErr != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"code":    "namespace-ensure-failed",
+			"message": fmt.Sprintf("could not ensure namespace for Organization %q: %v", body.Org, nsErr),
+		})
+		return
+	}
+
 	// #3370 — backing-service journey. BEFORE creating the consumer:
 	// for each selection, either auto-create the backing service as its
 	// OWN instance-application (own card; default) or append a Context

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler_test.go
@@ -627,6 +627,55 @@ func TestCreateInstance_HappyPath(t *testing.T) {
 	}
 }
 
+// #3599 (EPIC #3597) — the create-from-catalog wizard writes the chosen
+// placement (mode + regions + vcluster) onto the Application CR so the
+// post-create Topology tab reflects it. Asserts the OBJECT form of
+// spec.placement + spec.regions land verbatim.
+func TestCreateInstance_PlacementStampedOnCR(t *testing.T) {
+	h, _, dyn := newTestHandlerWithEndpoint(t)
+	h.SetCatalogClient(fakeBlueprintInCatalog("wordpress",
+		[]map[string]interface{}{}, true, []string{"singleton", "active-hot-standby"}))
+	r := newTestRouter(h)
+
+	body := []byte(`{"blueprint":"wordpress","org":"acme","name":"wp-ha",` +
+		`"topology":"active-hot-standby",` +
+		`"placement":{"vcluster":"rtz","regions":["rgn-a","rgn-b"]}}`)
+	req := httptest.NewRequest("POST", "/catalyst/v1/apps/instances", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	got, err := dyn.Resource(ApplicationGVR()).Namespace("acme").Get(context.Background(), "wp-ha", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected CR landed; got %v", err)
+	}
+
+	// spec.placement is the OBJECT form: {mode, vcluster, regions}.
+	pl, ok, _ := unstructured.NestedMap(got.Object, "spec", "placement")
+	if !ok {
+		t.Fatalf("spec.placement not an object: %+v", got.Object["spec"])
+	}
+	if pl["mode"] != "active-hot-standby" {
+		t.Fatalf("spec.placement.mode = %v, want active-hot-standby", pl["mode"])
+	}
+	if pl["vcluster"] != "rtz" {
+		t.Fatalf("spec.placement.vcluster = %v, want rtz", pl["vcluster"])
+	}
+	plRegions, _, _ := unstructured.NestedStringSlice(got.Object, "spec", "placement", "regions")
+	if len(plRegions) != 2 || plRegions[0] != "rgn-a" || plRegions[1] != "rgn-b" {
+		t.Fatalf("spec.placement.regions = %v, want [rgn-a rgn-b]", plRegions)
+	}
+	// spec.regions mirrors the placement regions (what the Topology tab
+	// + the application-controller fan-out read).
+	regions, _, _ := unstructured.NestedStringSlice(got.Object, "spec", "regions")
+	if len(regions) != 2 || regions[0] != "rgn-a" || regions[1] != "rgn-b" {
+		t.Fatalf("spec.regions = %v, want [rgn-a rgn-b]", regions)
+	}
+}
+
 func TestCreateInstance_TopologyNotSupported(t *testing.T) {
 	h, _, _ := newTestHandlerWithEndpoint(t)
 	h.SetCatalogClient(fakeBlueprintInCatalog("wordpress",

--- a/products/catalyst/bootstrap/api/internal/handler/namespace_ensure.go
+++ b/products/catalyst/bootstrap/api/internal/handler/namespace_ensure.go
@@ -1,0 +1,96 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// namespacesGVR is the core/v1 Namespace resource. We address it through
+// the dynamic client (not a typed corev1 clientset) because every
+// Application-create path in this package already holds a
+// dynamic.Interface — mirroring the read idiom in
+// internal/infrastructure/topology_loader.go which lists namespaces via
+// the same GVR.
+func namespacesGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+}
+
+// ensureOrgNamespace creates the target Organization/Environment
+// namespace if it does not already exist, returning nil when the
+// namespace is present (created-or-verified).
+//
+// Why this exists (#3598, EPIC #3597): the create-from-catalog paths
+// (HandleCreateInstance + HandleApplicationInstall + the backing-service
+// auto-create) write the Application CR straight into the Org namespace
+// via `.Namespace(org).Create(...)`. That namespace is otherwise created
+// asynchronously by the organization controller's GitOps reconcile
+// (core/controllers/organization/internal/gitops/manifests.go renders a
+// `kind: Namespace`, committed to Gitea and applied by Flux). When an
+// operator installs an app into an Org whose GitOps namespace manifest
+// has not yet reconciled, the CR create fails with
+// `namespaces "<org>" not found` — the exact "namespace not found"
+// symptom the founder hit. Ensuring the namespace here closes that race
+// so the install never surfaces that error.
+//
+// Idempotent: an AlreadyExists on Create is treated as success (the
+// race-loser path + the steady-state path both return nil). The
+// namespace is labelled so it is recognisable as catalyst-managed and so
+// a later GitOps apply of the same namespace is a no-op rather than a
+// conflict.
+//
+// A blank namespace name is a programmer error (the caller validated the
+// Org slug upstream); we return an error rather than creating a
+// cluster-scoped object with an empty name.
+func ensureOrgNamespace(ctx context.Context, client dynamic.Interface, namespace string) error {
+	ns := strings.TrimSpace(namespace)
+	if ns == "" {
+		return fmt.Errorf("ensureOrgNamespace: empty namespace")
+	}
+
+	// Fast path: already present.
+	if _, err := client.Resource(namespacesGVR()).Get(ctx, ns, metav1.GetOptions{}); err == nil {
+		return nil
+	} else if !apierrors.IsNotFound(err) {
+		// A non-NotFound Get error (RBAC, apiserver down) is surfaced so
+		// the caller can return a clear 5xx instead of masking it as a
+		// create failure below.
+		return fmt.Errorf("ensureOrgNamespace: get namespace %q: %w", ns, err)
+	}
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata": map[string]interface{}{
+				"name": ns,
+				"labels": map[string]interface{}{
+					// Marks the namespace as created by catalyst-api's
+					// install path. The organization controller's GitOps
+					// namespace manifest carries its own labels; server-side
+					// apply / Flux treats this pre-created namespace as the
+					// existing object and reconciles labels onto it.
+					"app.kubernetes.io/managed-by":   "catalyst-api",
+					"catalyst.openova.io/org":         ns,
+					"catalyst.openova.io/provisioned": "install",
+				},
+			},
+		},
+	}
+
+	if _, err := client.Resource(namespacesGVR()).Create(ctx, obj, metav1.CreateOptions{}); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			// Race-loser: another caller (or the GitOps apply) created it
+			// between our Get and Create. That's success.
+			return nil
+		}
+		return fmt.Errorf("ensureOrgNamespace: create namespace %q: %w", ns, err)
+	}
+	return nil
+}

--- a/products/catalyst/bootstrap/api/internal/handler/namespace_ensure_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/namespace_ensure_test.go
@@ -1,0 +1,98 @@
+// namespace_ensure_test.go — #3598 (EPIC #3597) contract coverage for
+// the create-into-Org-without-namespace path. The create-from-catalog
+// handlers must ENSURE the Org/Environment namespace before creating the
+// Application CR so an install never fails with `namespaces "<org>" not
+// found`.
+package handler
+
+import (
+	"context"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// fakeNamespaceClient builds a fake dynamic client that knows the
+// namespaces GVR list-kind (plus the Application GVR so the same client
+// can be reused by the create-path tests).
+func fakeNamespaceClient(seed ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		namespacesGVR():  "NamespaceList",
+		ApplicationGVR(): "ApplicationList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, seed...)
+}
+
+func nsObject(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata":   map[string]interface{}{"name": name},
+		},
+	}
+}
+
+func getNamespace(t *testing.T, client *dynamicfake.FakeDynamicClient, name string) (*unstructured.Unstructured, error) {
+	t.Helper()
+	return client.Resource(namespacesGVR()).Get(context.Background(), name, metav1.GetOptions{})
+}
+
+// The core #3598 contract: ensuring a namespace that does NOT exist
+// creates it (so the subsequent Application CR create won't hit
+// "namespace not found").
+func TestEnsureOrgNamespace_CreatesWhenAbsent(t *testing.T) {
+	client := fakeNamespaceClient()
+
+	// Pre-condition: the namespace is genuinely absent.
+	if _, err := getNamespace(t, client, "acme"); !apierrors.IsNotFound(err) {
+		t.Fatalf("precondition: expected acme namespace absent, got err=%v", err)
+	}
+
+	if err := ensureOrgNamespace(context.Background(), client, "acme"); err != nil {
+		t.Fatalf("ensureOrgNamespace returned error: %v", err)
+	}
+
+	got, err := getNamespace(t, client, "acme")
+	if err != nil {
+		t.Fatalf("namespace acme not present after ensure: %v", err)
+	}
+	if got.GetName() != "acme" {
+		t.Fatalf("created namespace name = %q, want acme", got.GetName())
+	}
+	// It should carry the catalyst-api managed-by marker.
+	labels := got.GetLabels()
+	if labels["app.kubernetes.io/managed-by"] != "catalyst-api" {
+		t.Fatalf("ensured namespace missing managed-by label, labels=%v", labels)
+	}
+}
+
+// Idempotency: ensuring an already-present namespace is a no-op success
+// (the steady-state + GitOps-already-created path).
+func TestEnsureOrgNamespace_IdempotentWhenPresent(t *testing.T) {
+	client := fakeNamespaceClient(nsObject("acme"))
+
+	if err := ensureOrgNamespace(context.Background(), client, "acme"); err != nil {
+		t.Fatalf("ensureOrgNamespace on existing namespace returned error: %v", err)
+	}
+
+	// Still exactly one namespace named acme (no duplicate / no error).
+	if _, err := getNamespace(t, client, "acme"); err != nil {
+		t.Fatalf("namespace acme missing after idempotent ensure: %v", err)
+	}
+}
+
+// A blank namespace is a programmer error and must be rejected rather
+// than creating a cluster-scoped object with an empty name.
+func TestEnsureOrgNamespace_RejectsEmpty(t *testing.T) {
+	client := fakeNamespaceClient()
+	if err := ensureOrgNamespace(context.Background(), client, "   "); err == nil {
+		t.Fatalf("ensureOrgNamespace(\"\") = nil, want error")
+	}
+}

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -62,6 +62,7 @@ import { MarketplaceFamilyPage } from '@/pages/marketplace/MarketplaceFamilyPage
 import { MarketplaceProductPage } from '@/pages/marketplace/MarketplaceProductPage'
 import { ProvisionPage } from '@/pages/provision/ProvisionPage'
 import { AppsPage } from '@/pages/sovereign/AppsPage'
+import { CatalogPage } from '@/pages/sovereign/CatalogPage'
 import { AppDetail } from '@/pages/sovereign/AppDetail'
 import { CatalogDetail } from '@/pages/sovereign/CatalogDetail'
 import { InstallPage } from '@/pages/sovereign/InstallPage'
@@ -708,11 +709,23 @@ const provisionAppRoute = createRoute({
   beforeLoad: provisionAuthGuard,
 })
 
+// #3601 (EPIC #3597) — Catalog page in the mothership provision tree.
+// Mirrors the chroot `/catalog`; renders the catalog grid as its own
+// surface. Registered (and added to the tree) BEFORE the dynamic
+// `/catalog/$blueprintName` so the static index wins on a bare
+// `/provision/$id/catalog` visit.
+const provisionCatalogRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/provision/$deploymentId/catalog',
+  component: CatalogPage,
+  beforeLoad: provisionAuthGuard,
+})
+
 // #3090 — CATALOG / class page in the mothership provision tree. Mirrors
 // provisionAppRoute but renders CatalogDetail (instances list + "+ New
-// instance"). AppsPage's Catalog-tab cards on the provision monitor
-// surface build `/provision/$deploymentId/catalog/$blueprintName`; the
-// chroot equivalent is consoleCatalogDetailRoute at `/catalog/$blueprintName`.
+// instance"). The Catalog page's cards on the provision monitor surface
+// build `/provision/$deploymentId/catalog/$blueprintName`; the chroot
+// equivalent is consoleCatalogDetailRoute at `/catalog/$blueprintName`.
 const provisionCatalogDetailRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/provision/$deploymentId/catalog/$blueprintName',
@@ -1306,6 +1319,16 @@ const consoleJobsRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
   path: '/jobs',
   component: JobsPage,
+})
+// #3601 (EPIC #3597) — Catalog as its OWN left-nav page (chroot Sovereign
+// Console). `/catalog` renders the catalog grid that used to be the
+// "Catalog" tab on /apps. Registered BEFORE the dynamic
+// `/catalog/$blueprintName` so the static index wins on a bare /catalog
+// visit (TanStack matches the literal segment ahead of the $param).
+const consoleCatalogRoute = createRoute({
+  getParentRoute: () => consoleLayoutRoute,
+  path: '/catalog',
+  component: CatalogPage,
 })
 // G117.2 #2741 — Catalog class drill-down (chroot Sovereign Console).
 // `/catalog/$blueprintName` renders the CLASS page: header + topology
@@ -2207,6 +2230,8 @@ const routeTree = rootRoute.addChildren([
   deploymentsListRoute,
   provisionRoute,
   provisionAppRoute,
+  // #3601 — static /catalog index BEFORE /catalog/$blueprintName.
+  provisionCatalogRoute,
   provisionCatalogDetailRoute,
   provisionInstallRoute,
   provisionInstallBlueprintRoute,
@@ -2257,6 +2282,9 @@ const routeTree = rootRoute.addChildren([
     consoleAppsRoute,
     consoleAppDetailRoute,
     consoleAppDetailTabRoute,
+    // #3601 — static /catalog index BEFORE /catalog/$blueprintName so the
+    // literal segment wins on a bare /catalog visit.
+    consoleCatalogRoute,
     consoleCatalogDetailRoute,
     consoleInstallRoute,
     consoleInstallBlueprintRoute,

--- a/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
@@ -206,6 +206,18 @@ export interface ApplicationStatusResponse {
   namespace: string
   phase?: string
   status?: Record<string, unknown>
+  /**
+   * #3599 — the create-time placement projected from the Application
+   * CR's spec so the Topology tab reflects it without waiting for the
+   * controller to populate status.placement. `placement` is the editor
+   * posture string (single-region | active-active | active-hotstandby).
+   */
+  spec?: {
+    placement?: string
+    regions?: string[]
+    environmentRef?: string
+    blueprintRef?: { name?: string; version?: string }
+  }
 }
 
 /**
@@ -824,10 +836,28 @@ export interface CreateApplicationInstanceRequest {
   isolationLevel?: 'namespace' | 'vcluster'
   values?: Record<string, unknown>
   /**
+   * #3373 / #3599 — instance placement (WHERE the instance runs). Maps to
+   * the OBJECT form of the Application CR's `spec.placement`. When set,
+   * the backend stamps `spec.placement = {mode: topology, vcluster,
+   * regions, clusters}` + `spec.regions = regions`, which the post-create
+   * Topology tab reads back. `vcluster` ∈ {host, mgmt, dmz, rtz}.
+   */
+  placement?: InstancePlacement
+  /**
    * #3370 — backing-service selections, one per required backing
    * service (the generic Create new / Reuse existing selector).
    */
   backing?: BackingSelection[]
+}
+
+/** Mirrors the Go `instances.InstancePlacementRequest` (#3373). */
+export interface InstancePlacement {
+  /** Target vCluster/zone: "" | host | mgmt | dmz | rtz. */
+  vcluster?: string
+  /** Catalyst region ids the instance runs in (spec.regions). */
+  regions?: string[]
+  /** Explicit cluster ids (advanced; usually derived from regions). */
+  clusters?: string[]
 }
 
 /** Mirrors `instances.BackingSelection` (#3370). */

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * InstancesSection.test.tsx — #3599 + #3600 (EPIC #3597) lock-in for the
+ * create-from-catalog wizard (NewInstanceDialog).
+ *
+ *   • Every fixed-set input is a dropdown / multiselect from LIVE data;
+ *     only the instance name is free-text (#3600):
+ *       - Organization → <select> populated from listOrganizations()
+ *       - Topology mode → <select> from the editor ALL_MODES set
+ *       - Region(s) → checkboxes from the live infrastructure topology
+ *       - vCluster → <select>
+ *   • Placement is written onto the create request (#3599): the POST body
+ *     carries placement {vcluster, regions} + topology.
+ *   • active-active / active-hotstandby require ≥2 regions; Create stays
+ *     disabled until satisfied (#3599 validation).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { InstancesSection } from './InstancesSection'
+
+// One blueprint with two supported topologies + no shareable backing deps.
+const WP_CATALOG = {
+  name: 'wordpress',
+  version: '2.0.0',
+  card: { title: 'WordPress' },
+  origin: 'upstream',
+  source: 'gitea',
+  raw: {
+    spec: {
+      multiInstance: { enabled: true },
+      topology: {
+        supported: ['single-region', 'active-hot-standby'],
+        defaults: { 'single-region': 'single-region', 'multi-region': 'active-hot-standby' },
+      },
+    },
+  },
+}
+
+// /sovereign/self parent-org payload (the directory's first row).
+const SELF = { deploymentId: 'd-1', sovereignFQDN: 't01.omani.works' }
+// /sme/tenants sub-org feed — RawTenant wire shape (snake_case). The
+// dialog's Org dropdown value is the subdomain slug.
+const TENANTS = {
+  items: [
+    { sme_tenant_id: 't-acme', subdomain: 'acme', company_name: 'Acme', tenant_namespace: 'acme', state: 'ready' },
+  ],
+}
+
+const TOPOLOGY = {
+  topology: {
+    pattern: 'multi-region',
+    regions: [
+      { id: 'r-a', name: 'rgn-a', provider: 'huawei', providerRegion: 'me-east-215-a', clusters: [
+        { id: 'c-a', name: 'cl-a', vclusters: [{ id: 'v1', name: 'acme-rtz', isolationMode: 'rtz', status: 'healthy' }] },
+      ] },
+      { id: 'r-b', name: 'rgn-b', provider: 'huawei', providerRegion: 'me-east-215-b', clusters: [] },
+    ],
+  },
+  cloud: [],
+  storage: { pvcs: [], buckets: [], volumes: [] },
+}
+
+// Captured create-instance POST bodies.
+let captured: Array<Record<string, unknown>> = []
+
+function installFetch() {
+  captured = []
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    // Create-instance POST.
+    if (url.includes('/catalyst/v1/apps/instances') && init?.method === 'POST') {
+      captured.push(JSON.parse(String(init.body)))
+      return json({ id: 'new-uid', name: 'wp-1', blueprint: 'wordpress', org: 'acme', topology: 'single-region', status: 'Pending' }, 201)
+    }
+    // Instances list (the section body).
+    if (url.includes('/instances')) return json({ items: [] })
+    // Org sources: /sovereign/self (parent) + /sme/tenants (sub-orgs).
+    if (url.includes('/sovereign/self')) return json(SELF)
+    if (url.includes('/sme/tenants')) return json(TENANTS)
+    // Infra topology (regions + vclusters).
+    if (url.includes('/infrastructure/topology')) return json(TOPOLOGY)
+    // Catalog item + version (topology supported list).
+    if (url.includes('/catalog/')) return json(WP_CATALOG)
+    return json({})
+  }) as typeof fetch
+}
+
+function json(body: unknown, status = 200) {
+  return Promise.resolve({ ok: status < 400, status, json: () => Promise.resolve(body) } as unknown as Response)
+}
+
+function renderSection() {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  // Mount under a deploymentId-bearing route so useResolvedDeploymentId
+  // resolves from the URL (no /sovereign/self round-trip needed for the id).
+  const route = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/catalog/$blueprintName',
+    component: () => <InstancesSection blueprint="bp-wordpress" />,
+  })
+  const appRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/app/$componentId',
+    component: () => <div data-testid="app-detail-target" />,
+  })
+  const tree = rootRoute.addChildren([route, appRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: ['/provision/d-1/catalog/bp-wordpress'] }),
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+async function openDialog() {
+  renderSection()
+  fireEvent.click(await screen.findByTestId('btn-new-instance'))
+  return screen.findByTestId('dialog-new-instance')
+}
+
+beforeEach(() => installFetch())
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('NewInstanceDialog — dropdowns (#3600)', () => {
+  it('Organization is a <select> populated from live orgs', async () => {
+    await openDialog()
+    const sel = (await screen.findByTestId('select-instance-org')) as HTMLSelectElement
+    expect(sel.tagName).toBe('SELECT')
+    // The Acme sub-org option resolves once listOrganizations settles.
+    await waitFor(() => {
+      expect(sel.querySelector('option[value="acme"]')).toBeTruthy()
+    })
+  })
+
+  it('Topology mode is a <select> from the editor mode set', async () => {
+    await openDialog()
+    const sel = (await screen.findByTestId('select-instance-topology')) as HTMLSelectElement
+    expect(sel.tagName).toBe('SELECT')
+    // Constrained to the blueprint's supported modes (single-region +
+    // active-hot-standby → active-hotstandby).
+    const values = Array.from(sel.querySelectorAll('option')).map((o) => o.getAttribute('value'))
+    expect(values).toContain('single-region')
+    expect(values).toContain('active-hotstandby')
+  })
+
+  it('vCluster is a <select>', async () => {
+    await openDialog()
+    expect(((await screen.findByTestId('select-instance-vcluster')) as HTMLSelectElement).tagName).toBe('SELECT')
+  })
+
+  it('Region(s) render as checkboxes from the live topology', async () => {
+    await openDialog()
+    expect(await screen.findByTestId('region-checkbox-rgn-a')).toBeTruthy()
+    expect(await screen.findByTestId('region-checkbox-rgn-b')).toBeTruthy()
+  })
+
+  it('the only free-text input is the instance name', async () => {
+    await openDialog()
+    const dialog = await screen.findByTestId('dialog-new-instance')
+    const textInputs = Array.from(dialog.querySelectorAll('input[type="text"]'))
+    expect(textInputs).toHaveLength(1)
+    expect((textInputs[0] as HTMLInputElement).getAttribute('data-testid')).toBe('input-instance-name')
+  })
+})
+
+describe('NewInstanceDialog — placement (#3599)', () => {
+  it('multi-region modes require ≥2 regions before Create enables', async () => {
+    await openDialog()
+    const name = await screen.findByTestId('input-instance-name')
+    fireEvent.change(name, { target: { value: 'wp-1' } })
+    fireEvent.change(await screen.findByTestId('select-instance-org'), { target: { value: 'acme' } })
+    fireEvent.change(await screen.findByTestId('select-instance-topology'), { target: { value: 'active-hotstandby' } })
+
+    const submit = (await screen.findByTestId('btn-submit-instance')) as HTMLButtonElement
+    // No regions yet → disabled + validation hint visible.
+    expect(submit.disabled).toBe(true)
+    expect(await screen.findByTestId('instance-regions-validation')).toBeTruthy()
+
+    // One region — still short of 2.
+    fireEvent.click(await screen.findByTestId('region-checkbox-rgn-a'))
+    expect(submit.disabled).toBe(true)
+
+    // Second region — now valid.
+    fireEvent.click(await screen.findByTestId('region-checkbox-rgn-b'))
+    await waitFor(() => expect(submit.disabled).toBe(false))
+  })
+
+  it('submit writes placement {vcluster, regions} + topology onto the request', async () => {
+    await openDialog()
+    fireEvent.change(await screen.findByTestId('input-instance-name'), { target: { value: 'wp-1' } })
+    fireEvent.change(await screen.findByTestId('select-instance-org'), { target: { value: 'acme' } })
+    fireEvent.change(await screen.findByTestId('select-instance-topology'), { target: { value: 'active-hotstandby' } })
+    fireEvent.click(await screen.findByTestId('region-checkbox-rgn-a'))
+    fireEvent.click(await screen.findByTestId('region-checkbox-rgn-b'))
+    fireEvent.change(await screen.findByTestId('select-instance-vcluster'), { target: { value: 'rtz' } })
+
+    fireEvent.click(await screen.findByTestId('btn-submit-instance'))
+
+    await waitFor(() => expect(captured.length).toBe(1))
+    const body = captured[0]
+    expect(body.blueprint).toBe('wordpress')
+    expect(body.org).toBe('acme')
+    expect(body.name).toBe('wp-1')
+    expect(body.topology).toBe('active-hotstandby')
+    expect(body.placement).toEqual({ vcluster: 'rtz', regions: ['rgn-a', 'rgn-b'] })
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
@@ -26,7 +26,20 @@ import {
   type BackingSelection,
   type CreateApplicationInstanceRequest,
 } from '@/lib/catalog.api'
+import { listOrganizations, type OrgRow } from '@/lib/organizations.api'
+import { getHierarchicalInfrastructure } from '@/lib/infrastructure.types'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+import { ALL_MODES, describeMode } from '@/widgets/topology/TopologyEditor'
 import { BLUEPRINT_BY_ID } from '@/shared/constants/catalog.generated'
+
+// #3599 / #3600 — the vCluster/zone options the catalyst-api backend
+// validates (`placement.vcluster ∈ {host, mgmt, dmz, rtz}`,
+// instances/create.go ValidateShape). Rendered as a dropdown (never
+// free-text) so an install can't be typo'd into an invalid zone.
+const VCLUSTER_OPTIONS = ['host', 'mgmt', 'dmz', 'rtz'] as const
+
+/** Modes that require ≥2 regions (the create-flow validation rule). */
+const MULTI_REGION_MODES = new Set(['active-active', 'active-hotstandby'])
 
 /**
  * InstancesSection — renders the per-Blueprint instances list (one row
@@ -386,22 +399,38 @@ export function PerClusterTable({
 }
 
 /**
- * NewInstanceDialog — G117.2 #2741 topology-picker dialog. Opens on
- * "+ New instance" click. Fields:
+ * NewInstanceDialog — the create-from-catalog wizard (#2741, extended by
+ * EPIC #3597 / #3599 / #3600). Opens on "+ New instance" click.
  *
- *  - name (string, lowercase k8s-name)
- *  - org (string, free-text; defaults to "" — operator types the Org
- *    slug they're installing into. TBD-followup: replace with a real
- *    Org picker once the OrgList endpoint is wired into the FE).
- *  - topology (radio: singleton / active-hot-standby / active-active /
- *    active-passive, gated by Blueprint.spec.topology.supported[] from
- *    getCatalogItemVersion). Defaults to the Blueprint's preferred
- *    default if exposed.
+ * Every fixed-set input is a dropdown / multiselect from LIVE data
+ * (#3600) — free-text remains ONLY for the instance name:
+ *
+ *  - name        — free-text (lowercase k8s-name; the only free field).
+ *  - org         — <select> from listOrganizations() (live Orgs).
+ *  - topology    — <select> from the canonical editor mode set
+ *                  (single-region / active-active / active-hotstandby),
+ *                  constrained to the Blueprint's supported modes when
+ *                  declared. REUSES the post-create Topology editor's
+ *                  ALL_MODES option set (#3599 — no divergent vocab).
+ *  - region(s)   — checkbox multiselect from the Sovereign's live cluster
+ *                  regions (getHierarchicalInfrastructure topology tree).
+ *  - vCluster    — <select> from {host, mgmt, dmz, rtz} (the backend's
+ *                  validated zone set), enriched with the live vcluster
+ *                  names when present.
+ *  - backing     — the #3370 Create new / Reuse existing selectors.
+ *
+ * Placement (#3599) is written onto the Application CR: the submit sends
+ * `topology` = the chosen mode + `placement = {vcluster, regions}`, which
+ * the backend stamps as `spec.placement = {mode, vcluster, regions}` +
+ * `spec.regions`. The post-create Topology tab reads those fields back, so
+ * it reflects the placement chosen here.
+ *
+ * Validation (#3599): active-active / active-hotstandby require ≥2
+ * regions; the Create button stays disabled until that holds.
  *
  * On submit POSTs to /catalyst/v1/apps/instances via
- * createApplicationInstance. On 4xx error message renders inline; on
- * 201 the dialog closes and the parent invalidates the instances
- * cache.
+ * createApplicationInstance. On 4xx the error renders inline; on 201 the
+ * dialog closes and the parent invalidates the instances cache.
  */
 export function NewInstanceDialog({
   blueprint,
@@ -415,27 +444,65 @@ export function NewInstanceDialog({
   const [name, setName] = useState('')
   const [org, setOrg] = useState('')
   const [topology, setTopology] = useState<string>('')
+  const [regions, setRegions] = useState<string[]>([])
+  const [vcluster, setVcluster] = useState<string>('')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   // #3370 — per-backing-service selection: "" = Create new (default),
   // any other value = the existing instance name to reuse.
   const [backingChoice, setBackingChoice] = useState<Record<string, string>>({})
 
+  const { deploymentId } = useResolvedDeploymentId()
+
+  // #3600 — live Organizations for the Org dropdown.
+  const orgsQuery = useQuery<OrgRow[]>({
+    queryKey: ['organizations-directory', deploymentId ?? ''],
+    queryFn: listOrganizations,
+    staleTime: 60_000,
+    retry: 1,
+  })
+  const orgs = orgsQuery.data ?? []
+
+  // #3599 / #3600 — live cluster regions + vclusters from the Sovereign's
+  // infrastructure topology (the SAME source the post-create Topology tab
+  // reads its available regions from). Regions use the catalyst id
+  // (RegionSpec.name), which is what Application.spec.regions stores.
+  const infraQuery = useQuery({
+    queryKey: ['infrastructure-topology', deploymentId ?? ''],
+    queryFn: () => getHierarchicalInfrastructure(deploymentId ?? ''),
+    enabled: !!deploymentId,
+    staleTime: 60_000,
+    retry: 1,
+  })
+  const availableRegions = useMemo<string[]>(() => {
+    const set = new Set<string>()
+    for (const r of infraQuery.data?.topology?.regions ?? []) {
+      if (r.name) set.add(r.name)
+    }
+    return Array.from(set).sort()
+  }, [infraQuery.data])
+  // Live vcluster names (enrich the fixed zone set so the operator can
+  // pick the actual vcluster when the topology reports them).
+  const liveVclusters = useMemo<string[]>(() => {
+    const set = new Set<string>()
+    for (const region of infraQuery.data?.topology?.regions ?? []) {
+      for (const cluster of region.clusters ?? []) {
+        for (const vc of cluster.vclusters ?? []) {
+          if (vc.name) set.add(vc.name)
+        }
+      }
+    }
+    return Array.from(set).sort()
+  }, [infraQuery.data])
+
   // Resolve the Blueprint's supported topologies via the catalog
-  // version endpoint. We don't have a fixed version pin from the
-  // AppDetail context, so call `getCatalogItem` first to read the
-  // latest version and then re-fetch with that version for the
-  // configSchema. For the dialog we only need `raw.spec.topology`, so
-  // a single getCatalogItemVersion call against the latest version is
-  // sufficient.
+  // version endpoint (latest pin → full raw spec).
   const bpName = blueprint.replace(/^bp-/, '')
   const bpQuery = useQuery({
     queryKey: ['catalog-item-latest', bpName],
     queryFn: async () => {
-      // First fetch — get the latest version pin.
       const { getCatalogItem } = await import('@/lib/catalog.api')
       const latest = await getCatalogItem(bpName)
-      // Second fetch — get the full raw spec (topology, configSchema).
       const full = await getCatalogItemVersion(bpName, latest.version)
       return full
     },
@@ -443,45 +510,58 @@ export function NewInstanceDialog({
     retry: 1,
   })
 
-  const supportedTopologies = useMemo<string[]>(() => {
+  // The blueprint's declared supported topologies, normalised to the
+  // editor mode vocab so they intersect with ALL_MODES. When the
+  // blueprint declares none, every editor mode is offered.
+  const supportedModes = useMemo<string[]>(() => {
     const raw = bpQuery.data?.raw as
-      | { spec?: { topology?: { supported?: string[]; defaults?: Record<string, string> } } }
+      | { spec?: { topology?: { supported?: string[] } } }
       | undefined
-    const list = raw?.spec?.topology?.supported ?? []
-    if (!Array.isArray(list)) return []
-    return list.filter((s) => typeof s === 'string')
+    const declared = (raw?.spec?.topology?.supported ?? [])
+      .filter((s): s is string => typeof s === 'string')
+      .map(canonicalEditorMode)
+    const allowed = declared.length > 0 ? new Set(declared) : null
+    return ALL_MODES.filter((m) => (allowed ? allowed.has(m) : true))
   }, [bpQuery.data])
 
-  const defaultTopology = useMemo<string>(() => {
+  const defaultMode = useMemo<string>(() => {
     const raw = bpQuery.data?.raw as
       | { spec?: { topology?: { defaults?: Record<string, string> } } }
       | undefined
     const defs = raw?.spec?.topology?.defaults
-    // Prefer multi-region default if set; else single-region; else
-    // first supported entry.
-    return defs?.['multi-region'] ?? defs?.['single-region'] ?? supportedTopologies[0] ?? ''
-  }, [bpQuery.data, supportedTopologies])
+    const declaredDefault = defs
+      ? canonicalEditorMode(defs['multi-region'] ?? defs['single-region'] ?? '')
+      : ''
+    if (declaredDefault && supportedModes.includes(declaredDefault)) return declaredDefault
+    return supportedModes.includes('single-region') ? 'single-region' : supportedModes[0] ?? 'single-region'
+  }, [bpQuery.data, supportedModes])
 
   useEffect(() => {
-    if (!topology && defaultTopology) {
-      setTopology(defaultTopology)
-    }
-  }, [defaultTopology, topology])
+    if (!topology && defaultMode) setTopology(defaultMode)
+  }, [defaultMode, topology])
 
-  // #3370 — required backing services: the blueprint's declared
-  // dependencies that are themselves SHAREABLE (declare a
-  // contextSchema). Each renders ONE generic selector: Create new
-  // (default) / Reuse existing — the same mechanism for every
-  // blueprint, driven purely by the declarations.
+  const requiresMultiRegion = MULTI_REGION_MODES.has(topology)
+
+  // #3370 — required backing services (declared depends[] that are
+  // themselves shareable). One generic selector each.
   const backingBlueprints = useMemo<string[]>(() => {
     const self = BLUEPRINT_BY_ID[`bp-${bpName}`]
     const depends = self?.depends ?? []
     return depends.filter((d) => BLUEPRINT_BY_ID[d]?.shareable === true)
   }, [bpName])
 
+  const toggleRegion = (region: string) =>
+    setRegions((prev) =>
+      prev.includes(region) ? prev.filter((r) => r !== region) : [...prev, region],
+    )
+
+  // #3599 validation — multi-region modes need ≥2 regions.
+  const placementValid = !requiresMultiRegion || regions.length >= 2
+  const canSubmit = !submitting && !!name && !!org && placementValid
+
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault()
-    if (submitting) return
+    if (!canSubmit) return
     setError(null)
     setSubmitting(true)
     try {
@@ -491,6 +571,15 @@ export function NewInstanceDialog({
         name: name.trim(),
       }
       if (topology) body.topology = topology
+      // #3599 — write the placement onto the Application CR. Only send
+      // fields the operator set, so a silent single-region install with
+      // no region/vcluster choice still falls back to the Blueprint
+      // defaults server-side.
+      if (regions.length > 0 || vcluster) {
+        body.placement = {}
+        if (vcluster) body.placement.vcluster = vcluster
+        if (regions.length > 0) body.placement.regions = regions
+      }
       if (backingBlueprints.length > 0) {
         body.backing = backingBlueprints.map((bp): BackingSelection => {
           const chosen = backingChoice[bp] ?? ''
@@ -508,6 +597,16 @@ export function NewInstanceDialog({
     } finally {
       setSubmitting(false)
     }
+  }
+
+  const fieldStyle: React.CSSProperties = {
+    width: '100%',
+    padding: '0.4rem 0.6rem',
+    background: 'var(--color-bg)',
+    color: 'var(--color-text)',
+    border: '1px solid var(--color-border)',
+    borderRadius: '4px',
+    fontSize: '0.85rem',
   }
 
   return (
@@ -537,8 +636,10 @@ export function NewInstanceDialog({
           border: '1px solid var(--color-border)',
           borderRadius: '8px',
           padding: '1.2rem',
-          minWidth: '420px',
-          maxWidth: '520px',
+          minWidth: '440px',
+          maxWidth: '560px',
+          maxHeight: '88vh',
+          overflowY: 'auto',
           boxShadow: '0 10px 40px rgba(0,0,0,0.3)',
         }}
       >
@@ -549,12 +650,9 @@ export function NewInstanceDialog({
           New instance of {bpName}
         </h3>
 
-        <label
-          style={{ display: 'block', marginBottom: '0.6rem', fontSize: '0.85rem' }}
-        >
-          <span style={{ display: 'block', marginBottom: '0.2rem' }}>
-            Instance name
-          </span>
+        {/* Instance name — the ONLY free-text field (#3600). */}
+        <label style={{ display: 'block', marginBottom: '0.6rem', fontSize: '0.85rem' }}>
+          <span style={{ display: 'block', marginBottom: '0.2rem' }}>Instance name</span>
           <input
             type="text"
             data-testid="input-instance-name"
@@ -564,44 +662,69 @@ export function NewInstanceDialog({
             pattern="^[a-z0-9][a-z0-9-]{0,40}[a-z0-9]$"
             title="Lowercase letters, digits, and dashes; 2-42 chars; no leading/trailing dash"
             placeholder="my-instance"
-            style={{
-              width: '100%',
-              padding: '0.4rem 0.6rem',
-              background: 'var(--color-bg)',
-              color: 'var(--color-text)',
-              border: '1px solid var(--color-border)',
-              borderRadius: '4px',
-              fontSize: '0.85rem',
-            }}
+            style={fieldStyle}
           />
         </label>
 
-        <label
-          style={{ display: 'block', marginBottom: '0.6rem', fontSize: '0.85rem' }}
-        >
-          <span style={{ display: 'block', marginBottom: '0.2rem' }}>
-            Organization
-          </span>
-          <input
-            type="text"
-            data-testid="input-instance-org"
+        {/* Organization — dropdown from live Orgs (#3600). */}
+        <label style={{ display: 'block', marginBottom: '0.6rem', fontSize: '0.85rem' }}>
+          <span style={{ display: 'block', marginBottom: '0.2rem' }}>Organization</span>
+          <select
+            data-testid="select-instance-org"
             value={org}
             onChange={(e) => setOrg(e.target.value)}
             required
-            placeholder="acme"
-            style={{
-              width: '100%',
-              padding: '0.4rem 0.6rem',
-              background: 'var(--color-bg)',
-              color: 'var(--color-text)',
-              border: '1px solid var(--color-border)',
-              borderRadius: '4px',
-              fontSize: '0.85rem',
-            }}
-          />
+            style={fieldStyle}
+          >
+            <option value="" disabled>
+              {orgsQuery.isPending ? 'Loading organizations…' : 'Select an organization…'}
+            </option>
+            {orgs.map((o) => (
+              <option key={o.id} value={o.slug}>
+                {o.displayName ? `${o.displayName} (${o.slug})` : o.slug}
+              </option>
+            ))}
+          </select>
+          {/* Environment is derived server-side as <org>-prod; surfaced
+              read-only so the operator sees WHERE it lands (#3599). No
+              free-text — there is no environments list to choose from. */}
+          {org ? (
+            <span
+              data-testid="instance-environment-derived"
+              style={{
+                display: 'block',
+                marginTop: '0.3rem',
+                fontSize: '0.74rem',
+                color: 'var(--color-text-dim)',
+              }}
+            >
+              Environment: <code>{org}-prod</code>
+            </span>
+          ) : null}
         </label>
 
+        {/* Topology mode — dropdown reusing the editor's ALL_MODES set,
+            constrained to the Blueprint's supported modes (#3599/#3600). */}
+        <label style={{ display: 'block', marginBottom: '0.6rem', fontSize: '0.85rem' }}>
+          <span style={{ display: 'block', marginBottom: '0.2rem' }}>Topology mode</span>
+          <select
+            data-testid="select-instance-topology"
+            value={topology}
+            onChange={(e) => setTopology(e.target.value)}
+            disabled={bpQuery.isPending}
+            style={fieldStyle}
+          >
+            {supportedModes.map((m) => (
+              <option key={m} value={m}>
+                {m} — {describeMode(m)}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {/* Region(s) — multiselect from live cluster regions (#3599/#3600). */}
         <fieldset
+          data-testid="instance-regions"
           style={{
             border: '1px solid var(--color-border)',
             borderRadius: '4px',
@@ -610,53 +733,78 @@ export function NewInstanceDialog({
           }}
         >
           <legend style={{ fontSize: '0.8rem', padding: '0 0.3rem' }}>
-            Topology
+            Region(s){requiresMultiRegion ? ' — pick at least 2' : ''}
           </legend>
-          {bpQuery.isPending ? (
+          {infraQuery.isPending ? (
             <p style={{ fontSize: '0.78rem', margin: 0, color: 'var(--color-text-dim)' }}>
-              Loading…
+              Loading regions…
             </p>
-          ) : supportedTopologies.length === 0 ? (
+          ) : availableRegions.length === 0 ? (
             <p
+              data-testid="instance-regions-empty"
               style={{ fontSize: '0.78rem', margin: 0, color: 'var(--color-text-dim)' }}
-              data-testid="topology-radio-empty"
             >
-              Blueprint does not declare supported topologies — server will
-              pick the default.
+              No cluster regions reported for this Sovereign — the server will
+              place the instance in its default region.
             </p>
           ) : (
-            supportedTopologies.map((t) => (
+            availableRegions.map((region) => (
               <label
-                key={t}
-                style={{
-                  display: 'block',
-                  fontSize: '0.82rem',
-                  padding: '0.15rem 0',
-                  cursor: 'pointer',
-                }}
+                key={region}
+                style={{ display: 'block', fontSize: '0.82rem', padding: '0.12rem 0', cursor: 'pointer' }}
               >
                 <input
-                  type="radio"
-                  name="topology"
-                  value={t}
-                  checked={topology === t}
-                  onChange={() => setTopology(t)}
-                  data-testid={`topology-radio-${t}`}
+                  type="checkbox"
+                  checked={regions.includes(region)}
+                  onChange={() => toggleRegion(region)}
+                  data-testid={`region-checkbox-${region}`}
                   style={{ marginRight: '0.4rem' }}
                 />
-                {t}
+                <code>{region}</code>
               </label>
             ))
           )}
+          {requiresMultiRegion && regions.length < 2 ? (
+            <p
+              data-testid="instance-regions-validation"
+              style={{ margin: '0.3rem 0 0', fontSize: '0.74rem', color: 'var(--color-danger)' }}
+            >
+              {topology} needs at least 2 regions.
+            </p>
+          ) : null}
         </fieldset>
+
+        {/* vCluster / zone — dropdown from the backend's validated zone
+            set, enriched with live vcluster names (#3599/#3600). */}
+        <label style={{ display: 'block', marginBottom: '0.6rem', fontSize: '0.85rem' }}>
+          <span style={{ display: 'block', marginBottom: '0.2rem' }}>vCluster / zone</span>
+          <select
+            data-testid="select-instance-vcluster"
+            value={vcluster}
+            onChange={(e) => setVcluster(e.target.value)}
+            style={fieldStyle}
+          >
+            <option value="">Default (server picks)</option>
+            {VCLUSTER_OPTIONS.map((z) => (
+              <option key={z} value={z}>
+                {z}
+              </option>
+            ))}
+            {liveVclusters
+              .filter((v) => !VCLUSTER_OPTIONS.includes(v as (typeof VCLUSTER_OPTIONS)[number]))
+              .map((v) => (
+                <option key={v} value={v}>
+                  {v}
+                </option>
+              ))}
+          </select>
+        </label>
 
         {/*
           #3370 — backing services. EVERY required backing service of
           this blueprint (declared depends[] whose target is shareable)
           renders ONE generic selector: Create new (default) / Reuse
-          existing. The dropdown lists existing instances of that
-          blueprint with topology + context count. No per-service UI —
-          the SAME selector for postgres, valkey, kafka, seaweedfs.
+          existing.
         */}
         {backingBlueprints.length > 0 ? (
           <fieldset
@@ -685,23 +833,13 @@ export function NewInstanceDialog({
         {error ? (
           <p
             data-testid="dialog-error"
-            style={{
-              color: 'var(--color-danger)',
-              fontSize: '0.8rem',
-              margin: '0 0 0.6rem',
-            }}
+            style={{ color: 'var(--color-danger)', fontSize: '0.8rem', margin: '0 0 0.6rem' }}
           >
             {error}
           </p>
         ) : null}
 
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'flex-end',
-            gap: '0.5rem',
-          }}
-        >
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
           <button
             type="button"
             data-testid="btn-cancel-instance"
@@ -722,7 +860,7 @@ export function NewInstanceDialog({
           <button
             type="submit"
             data-testid="btn-submit-instance"
-            disabled={submitting || !name || !org}
+            disabled={!canSubmit}
             style={{
               padding: '0.35rem 0.8rem',
               background: 'var(--color-accent)',
@@ -730,7 +868,7 @@ export function NewInstanceDialog({
               border: '0',
               borderRadius: '4px',
               fontSize: '0.82rem',
-              cursor: submitting ? 'not-allowed' : 'pointer',
+              cursor: canSubmit ? 'pointer' : 'not-allowed',
               fontWeight: 600,
             }}
           >
@@ -740,6 +878,37 @@ export function NewInstanceDialog({
       </form>
     </div>
   )
+}
+
+/**
+ * canonicalEditorMode — normalise a Blueprint topology token (which may
+ * use the hyphenated `active-hot-standby` / `singleton` / `multi-region`
+ * dialect) onto the editor mode vocabulary
+ * (single-region | active-active | active-hotstandby) so the create-flow
+ * dropdown intersects cleanly with ALL_MODES (#3599).
+ */
+function canonicalEditorMode(raw: string): string {
+  const s = (raw ?? '').trim().toLowerCase()
+  switch (s) {
+    case 'active-active':
+    case 'active_active':
+      return 'active-active'
+    case 'active-hot-standby':
+    case 'active-hotstandby':
+    case 'active_hot_standby':
+    case 'active-passive':
+    case 'active_passive':
+      return 'active-hotstandby'
+    case 'singleton':
+    case 'single-region':
+    case 'single_region':
+    case 'multi-region':
+    default:
+      // multi-region is a deployment posture, not an editor mode; map it
+      // (and anything unknown) to single-region so the dropdown still
+      // offers a valid editor option.
+      return 'single-region'
+  }
 }
 
 /**

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.test.tsx
@@ -1,14 +1,18 @@
 /**
- * AppsPage.test.tsx — pixel-port lock-in for the Sovereign Apps surface.
+ * AppsPage.test.tsx — lock-in for the Sovereign Apps surface.
  *
- *   • Page heading + tagline render
- *   • Both tabs render with counts pulled from the resolved catalog
- *     (Deployments + Catalog), the canonical .tab/.active class string
- *   • Card grid renders one .app-card per Application descriptor on
- *     first paint (waterfall — no spinner state)
- *   • Search filter narrows the visible cards by title / description /
- *     family
- *   • Sidebar nav surfaces are present (PortalShell wiring)
+ * #3601 (EPIC #3597): /apps is now TAB-LESS — it renders ONLY the
+ * installed-deployments grid. The catalog moved to its own left-nav page
+ * (/catalog → CatalogPage, covered by CatalogPage.test.tsx). This spec
+ * asserts:
+ *   • Page heading renders
+ *   • NO Deployments/Catalog tabs render
+ *   • Card grid renders one .app-card per INSTALLED descriptor on first
+ *     paint (bootstrap-kit apps always count as installed)
+ *   • Installed-tab cards link to the INSTANCE page /app/$id
+ *   • Search narrows the visible cards
+ *   • The empty-state "Open catalog" affordance links to /catalog
+ *   • PortalShell wiring (sidebar present)
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
@@ -45,11 +49,11 @@ function renderProvision(deploymentId: string) {
     path: '/provision/$deploymentId/app/$componentId',
     component: () => <div data-testid="app-detail-target" />,
   })
-  // #3090 — Catalog-tab cards must link to the CLASS page.
-  const catalogDetailRoute = createRoute({
+  // #3601 — the catalog is its own page now.
+  const catalogRoute = createRoute({
     getParentRoute: () => rootRoute,
-    path: '/provision/$deploymentId/catalog/$blueprintName',
-    component: () => <div data-testid="catalog-detail-target" />,
+    path: '/catalog',
+    component: () => <div data-testid="catalog-page-target" />,
   })
   const jobsRoute = createRoute({
     getParentRoute: () => rootRoute,
@@ -64,7 +68,7 @@ function renderProvision(deploymentId: string) {
   const tree = rootRoute.addChildren([
     provisionRoute,
     detailRoute,
-    catalogDetailRoute,
+    catalogRoute,
     jobsRoute,
     wizardRoute,
   ])
@@ -72,8 +76,6 @@ function renderProvision(deploymentId: string) {
     routeTree: tree,
     history: createMemoryHistory({ initialEntries: [`/provision/${deploymentId}`] }),
   })
-  // AppsPage's liveAppsQuery (useQuery, enabled on Sovereign mode) needs a
-  // QueryClient in context even when disabled — mirror AppsPage.handover.test.
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   })
@@ -86,8 +88,6 @@ function renderProvision(deploymentId: string) {
 
 beforeEach(() => {
   useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
-  // Stub fetch so useDeploymentEvents history-replay path resolves
-  // synchronously without making real network calls.
   globalThis.fetch = (() =>
     Promise.resolve({
       ok: true,
@@ -110,48 +110,20 @@ describe('AppsPage — header', () => {
   })
 })
 
-describe('AppsPage — tabs', () => {
-  it('renders Deployments + Catalog tabs', async () => {
+describe('AppsPage — tab-less (#3601)', () => {
+  it('renders NO Deployments/Catalog tabs', async () => {
     renderProvision('d-1')
-    const tabs = await screen.findByTestId('sov-tabs')
-    expect(within(tabs).getByTestId('sov-tab-installed')).toBeTruthy()
-    expect(within(tabs).getByTestId('sov-tab-catalog')).toBeTruthy()
-  })
-
-  it('Deployments tab is active by default', async () => {
-    renderProvision('d-1')
-    const installed = await screen.findByTestId('sov-tab-installed')
-    expect(installed.className).toContain('active')
-  })
-
-  it('clicking Catalog flips active to Catalog', async () => {
-    renderProvision('d-1')
-    const catalog = await screen.findByTestId('sov-tab-catalog')
-    fireEvent.click(catalog)
-    expect(catalog.className).toContain('active')
-    const installed = screen.getByTestId('sov-tab-installed')
-    expect(installed.className).not.toContain('active')
-  })
-
-  it('tabs render counts that mirror the catalog', async () => {
-    renderProvision('d-1')
-    const tabs = await screen.findByTestId('sov-tabs')
-    // Catalog count > 0 because BOOTSTRAP_KIT (11+) is always present.
-    const catalog = within(tabs).getByTestId('sov-tab-catalog')
-    const countSpan = catalog.querySelector('.tab-count')
-    expect(countSpan).toBeTruthy()
-    const n = Number((countSpan!.textContent ?? '').trim())
-    expect(n).toBeGreaterThan(0)
+    await screen.findByText('Applications')
+    expect(screen.queryByTestId('sov-tabs')).toBeNull()
+    expect(screen.queryByTestId('sov-tab-installed')).toBeNull()
+    expect(screen.queryByTestId('sov-tab-catalog')).toBeNull()
   })
 })
 
 describe('AppsPage — banner pollution gate (founder #475)', () => {
   it('renders no role="alert" or role="status" inside main on first paint', async () => {
     renderProvision('d-1')
-    // Wait for the page to settle.
     await screen.findByText('Applications')
-    // The Apps page main surface must be free of inline banners. Toasts
-    // (which would render inside the global tray, not main) are allowed.
     const main = document.querySelector('main')
     expect(main).toBeTruthy()
     expect(main!.querySelector('[role="alert"]')).toBeNull()
@@ -161,19 +133,16 @@ describe('AppsPage — banner pollution gate (founder #475)', () => {
   it('does not import or render the legacy FailureCard test ids', async () => {
     renderProvision('d-1')
     await screen.findByText('Applications')
-    // These test ids were the inline banner anchors. They must not paint
-    // anywhere on the Apps surface; the failure UX moves to global toasts.
     expect(screen.queryByTestId('sov-failure-card')).toBeNull()
     expect(screen.queryByTestId('sov-phase1-unavailable-banner')).toBeNull()
   })
 })
 
-describe('AppsPage — card grid', () => {
-  it('renders one .app-card per Application from first paint', async () => {
+describe('AppsPage — card grid (installed only)', () => {
+  it('renders one .app-card per INSTALLED Application from first paint', async () => {
     renderProvision('d-1')
-    // Deployments tab is active — bootstrap-kit cards are always
-    // counted as deployed, so the grid is non-empty.
-    fireEvent.click(await screen.findByTestId('sov-tab-catalog'))
+    // Bootstrap-kit apps always count as installed, so the grid is
+    // non-empty without flipping any tab.
     const grid = await screen.findByTestId('sov-apps-grid')
     const cards = within(grid).getAllByTestId(/^sov-app-card-bp-/)
     expect(cards.length).toBeGreaterThan(0)
@@ -181,52 +150,22 @@ describe('AppsPage — card grid', () => {
 
   it('grid uses the canonical .apps-grid class (auto-fit minmax 360px)', async () => {
     renderProvision('d-1')
-    fireEvent.click(await screen.findByTestId('sov-tab-catalog'))
     const grid = await screen.findByTestId('sov-apps-grid')
     expect(grid.className).toContain('apps-grid')
   })
 
   it('search filter narrows the visible cards', async () => {
     renderProvision('d-1')
-    fireEvent.click(await screen.findByTestId('sov-tab-catalog'))
     const before = within(await screen.findByTestId('sov-apps-grid')).getAllByTestId(/^sov-app-card-bp-/)
     fireEvent.change(screen.getByTestId('sov-search'), { target: { value: 'cilium' } })
     const after = within(await screen.findByTestId('sov-apps-grid')).getAllByTestId(/^sov-app-card-bp-/)
     expect(after.length).toBeLessThan(before.length)
-    // Still see Cilium.
     expect(after.some((c) => c.getAttribute('data-testid') === 'sov-app-card-bp-cilium')).toBe(true)
   })
-})
 
-describe('AppsPage — #3090 per-tab card link target (class vs instance)', () => {
-  it('Deployments-tab card links to the INSTANCE page /app/$id', async () => {
+  it('installed card links to the INSTANCE page /app/$id', async () => {
     renderProvision('d-1')
-    // Deployments tab is active by default; bootstrap-kit apps (cilium)
-    // always count as deployed so the card is present.
     const card = await screen.findByTestId('sov-app-card-bp-cilium')
     expect(card.getAttribute('href')).toBe('/provision/d-1/app/bp-cilium')
-  })
-
-  it('Catalog-tab card links to the CLASS page /catalog/$blueprint', async () => {
-    renderProvision('d-1')
-    fireEvent.click(await screen.findByTestId('sov-tab-catalog'))
-    const card = await screen.findByTestId('sov-app-card-bp-cilium')
-    expect(card.getAttribute('href')).toBe('/provision/d-1/catalog/bp-cilium')
-  })
-
-  it('the SAME blueprint card resolves to DIFFERENT targets per tab', async () => {
-    renderProvision('d-1')
-    // Deployments first.
-    const onDeployments = (
-      await screen.findByTestId('sov-app-card-bp-cilium')
-    ).getAttribute('href')
-    // Flip to Catalog.
-    fireEvent.click(screen.getByTestId('sov-tab-catalog'))
-    const onCatalog = (
-      await screen.findByTestId('sov-app-card-bp-cilium')
-    ).getAttribute('href')
-    expect(onDeployments).not.toBe(onCatalog)
-    expect(onDeployments).toContain('/app/bp-cilium')
-    expect(onCatalog).toContain('/catalog/bp-cilium')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
@@ -4,10 +4,11 @@
  * Layout (top-down, byte-identical to canonical class names):
  *   • Header row: <h1>Applications</h1> + tagline + (provisioning pill
  *     OR install-history link) right-aligned.
- *   • Tabs: "Deployments" | "Catalog" — same `.tabs / .tab / .tab-count`
- *     CSS the canonical surface uses, with the `.active` state on the
- *     selected tab. Counts read from `installedApps.length` /
- *     `catalogApps.length`.
+ *   • #3601 (EPIC #3597): the page is TAB-LESS. The old
+ *     "Deployments | Catalog" tab strip is gone — /apps shows only the
+ *     installed-deployments grid, and the catalog moved to its own
+ *     left-nav page (`/catalog` → CatalogPage). No Deployments/Catalog
+ *     tabs render here any more.
  *   • Search row: `.apps-toolbar > .search-wrap > .search-icon +
  *     .search-input` — visually identical to canonical AppsPage.
  *   • Card grid: `.apps-grid` (`grid-template-columns: repeat(auto-fit,
@@ -53,8 +54,6 @@ interface AppsPageProps {
   /** Test seam — disables the live SSE EventSource attach. */
   disableStream?: boolean
 }
-
-type TabId = 'installed' | 'catalog'
 
 export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
   const params = useResolvedDeploymentId() as {
@@ -453,10 +452,11 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
     }
   }, [isHandoverReady, sovereignFQDN])
 
-  // Catalog = every Application this deployment knows about (canonical
-  // calls this "every app in the org's catalog"; for the wizard surface
-  // it's the union of bootstrap-kit + transitive deps + selected). Same
-  // descriptor shape, so the card markup is shared between tabs.
+  // #3601 (EPIC #3597) — /apps is now TAB-LESS and shows ONLY installed
+  // deployments. The catalog grid moved to its own left-nav page
+  // (`/catalog` → CatalogPage). `catalogApps` is still the full
+  // `resolveApplications` union; here we only use it to derive the
+  // installed subset (it remains the source of truth CatalogPage renders).
   const catalogApps = applications
   // Deployments = every catalog entry that has at least one event
   // attributed to it OR was explicitly selected by the operator
@@ -478,13 +478,12 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
     [catalogApps, deployedIds],
   )
 
-  const [tab, setTab] = useState<TabId>('installed')
   const [query, setQuery] = useState<string>('')
 
+  // #3601 — the grid is the installed-deployments set only; no tab switch.
   const visibleApps = useMemo<ApplicationDescriptor[]>(() => {
-    const list = tab === 'installed' ? installedApps : catalogApps
     const filtered = query
-      ? list.filter((a) => {
+      ? installedApps.filter((a) => {
           const q = query.toLowerCase()
           return (
             a.title.toLowerCase().includes(q) ||
@@ -492,16 +491,9 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
             (a.familyName ?? '').toLowerCase().includes(q)
           )
         })
-      : list
-    return [...filtered].sort((a, b) => {
-      if (tab === 'catalog') {
-        const aIn = deployedIds.has(a.id) ? 0 : 1
-        const bIn = deployedIds.has(b.id) ? 0 : 1
-        if (aIn !== bIn) return aIn - bIn
-      }
-      return a.title.localeCompare(b.title)
-    })
-  }, [tab, installedApps, catalogApps, query, deployedIds])
+      : installedApps
+    return [...filtered].sort((a, b) => a.title.localeCompare(b.title))
+  }, [installedApps, query])
 
   const isProvisioning = streamStatus === 'connecting' || streamStatus === 'streaming'
 
@@ -598,29 +590,8 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
         </div>
       ) : null}
 
-      {/* Tabs */}
-      <div className="tabs" role="tablist" data-testid="sov-tabs">
-        <button
-          type="button"
-          className={`tab${tab === 'installed' ? ' active' : ''}`}
-          onClick={() => setTab('installed')}
-          role="tab"
-          aria-selected={tab === 'installed'}
-          data-testid="sov-tab-installed"
-        >
-          Deployments <span className="tab-count">{installedApps.length}</span>
-        </button>
-        <button
-          type="button"
-          className={`tab${tab === 'catalog' ? ' active' : ''}`}
-          onClick={() => setTab('catalog')}
-          role="tab"
-          aria-selected={tab === 'catalog'}
-          data-testid="sov-tab-catalog"
-        >
-          Catalog <span className="tab-count">{catalogApps.length}</span>
-        </button>
-      </div>
+      {/* #3601 — Deployments/Catalog tabs removed: /apps is the installed
+          grid only; the catalog lives at /catalog (left-nav CatalogPage). */}
 
       {/* Search + Environment filter */}
       <div className="apps-toolbar">
@@ -631,11 +602,7 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
           </svg>
           <input
             type="text"
-            placeholder={
-              tab === 'installed'
-                ? `Search your ${installedApps.length} apps…`
-                : `Search ${catalogApps.length} apps…`
-            }
+            placeholder={`Search your ${installedApps.length} apps…`}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             className="search-input"
@@ -659,13 +626,13 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
         </div>
       </div>
 
-      {tab === 'installed' && installedApps.length === 0 && liveInstances.length === 0 ? (
+      {installedApps.length === 0 && liveInstances.length === 0 ? (
         <div className="empty-state" data-testid="sov-empty-deployments">
           <p className="empty-title">No applications installed yet.</p>
           <p className="empty-sub">Provisioning has not produced any deployments — open the catalog to see what will install.</p>
-          <button type="button" className="btn btn-primary" onClick={() => setTab('catalog')}>
+          <Link to={'/catalog' as never} className="btn btn-primary" data-testid="sov-empty-open-catalog">
             Open catalog →
-          </button>
+          </Link>
         </div>
       ) : (
         <div className="apps-grid" data-testid="sov-apps-grid">
@@ -674,55 +641,52 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
             (Application CR). `shared-pg · PostgreSQL · singleton ·
             ● Ready · ⛓ 3 contexts`. The ⛓ badge deep-links to the
             instance's Contexts tab; the breakup never renders on
-            tiles. Deployments tab only — the Catalog tab is the
-            class view.
+            tiles. #3601 — /apps is installed-only, so these always
+            render (no tab gate).
           */}
-          {tab === 'installed'
-            ? liveInstances
-                .filter((inst) =>
-                  query
-                    ? inst.id.toLowerCase().includes(query.toLowerCase()) ||
-                      inst.slug.toLowerCase().includes(query.toLowerCase())
-                    : true,
-                )
-                .map((inst) => {
-                  const comp = findComponent(inst.slug)
-                  const descriptor: ApplicationDescriptor = {
-                    id: inst.id,
-                    bareId: inst.slug,
-                    title: inst.id,
-                    description: `${comp?.name ?? inst.slug} instance`,
-                    familyId: comp?.product ?? 'platform',
-                    familyName: comp?.name ?? inst.slug,
-                    tier: comp?.tier ?? 'mandatory',
-                    logoUrl: comp?.logoUrl ?? null,
-                    dependencies: [],
-                    bootstrapKit: inst.bootstrapKit,
-                  }
-                  return (
-                    <AppCard
-                      key={`instance-${inst.id}`}
-                      app={descriptor}
-                      isCatalog={false}
-                      environment={inst.environment}
-                      externalURL={inst.externalURL}
-                      status={inst.status}
-                      isService={false}
-                      marketplacePublished={null}
-                      slug={inst.slug}
-                      topology={inst.topology}
-                      contextCount={inst.contextCount}
-                    />
-                  )
-                })
-            : null}
+          {liveInstances
+            .filter((inst) =>
+              query
+                ? inst.id.toLowerCase().includes(query.toLowerCase()) ||
+                  inst.slug.toLowerCase().includes(query.toLowerCase())
+                : true,
+            )
+            .map((inst) => {
+              const comp = findComponent(inst.slug)
+              const descriptor: ApplicationDescriptor = {
+                id: inst.id,
+                bareId: inst.slug,
+                title: inst.id,
+                description: `${comp?.name ?? inst.slug} instance`,
+                familyId: comp?.product ?? 'platform',
+                familyName: comp?.name ?? inst.slug,
+                tier: comp?.tier ?? 'mandatory',
+                logoUrl: comp?.logoUrl ?? null,
+                dependencies: [],
+                bootstrapKit: inst.bootstrapKit,
+              }
+              return (
+                <AppCard
+                  key={`instance-${inst.id}`}
+                  app={descriptor}
+                  isCatalog={false}
+                  environment={inst.environment}
+                  externalURL={inst.externalURL}
+                  status={inst.status}
+                  isService={false}
+                  marketplacePublished={null}
+                  slug={inst.slug}
+                  topology={inst.topology}
+                  contextCount={inst.contextCount}
+                />
+              )
+            })}
           {visibleApps
             .filter(
               (app) =>
                 // #3370 — a blueprint whose instances render their own
                 // cards must not ALSO render a blueprint-level card on
-                // the Deployments tab (N instances ⇒ exactly N cards).
-                tab !== 'installed' ||
+                // the Deployments grid (N instances ⇒ exactly N cards).
                 !liveInstances.some((inst) => inst.blueprint === app.id),
             )
             .map((app) => {
@@ -736,7 +700,7 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
               <AppCard
                 key={app.id}
                 app={app}
-                isCatalog={tab === 'catalog'}
+                isCatalog={false}
                 environment={environment}
                 externalURL={externalURL}
                 status={(() => {
@@ -1180,46 +1144,6 @@ const APPS_PAGE_CSS = `
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
   gap: 0.65rem;
-}
-
-.tabs {
-  display: flex;
-  gap: 0.25rem;
-  margin: 1rem 0 0.5rem;
-  border-bottom: 1px solid var(--color-border);
-}
-.tab {
-  background: transparent;
-  border: none;
-  padding: 0.6rem 0.9rem;
-  color: var(--color-text-dim);
-  font: inherit;
-  font-size: 0.88rem;
-  font-weight: 500;
-  cursor: pointer;
-  border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-.tab:hover { color: var(--color-text); }
-.tab.active {
-  color: var(--color-text-strong);
-  border-bottom-color: var(--color-accent);
-  font-weight: 600;
-}
-.tab-count {
-  font-size: 0.7rem;
-  padding: 0.08rem 0.4rem;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--color-border) 60%, transparent);
-  color: var(--color-text-dim);
-  font-weight: 600;
-}
-.tab.active .tab-count {
-  background: color-mix(in srgb, var(--color-accent) 18%, transparent);
-  color: var(--color-accent);
 }
 
 .empty-state { margin-top: 3rem; text-align: center; color: var(--color-text-dim); }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogPage.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * CatalogPage.test.tsx — lock-in for the standalone Catalog page (#3601,
+ * EPIC #3597). The catalog grid that used to be the "Catalog" tab on
+ * /apps now lives at /catalog as its own surface.
+ *
+ *   • Renders the catalog grid (one .app-card per catalog descriptor)
+ *   • Cards link to the CLASS page /catalog/$blueprint (provision tree:
+ *     /provision/$id/catalog/$blueprint)
+ *   • Search narrows the visible cards
+ *   • Mounts inside PortalShell (sidebar present)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, within } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { CatalogPage } from './CatalogPage'
+import { useWizardStore } from '@/entities/deployment/store'
+import { INITIAL_WIZARD_STATE } from '@/entities/deployment/model'
+import { NotificationProvider } from '@/shared/ui/notifications'
+
+function renderCatalog(deploymentId: string) {
+  const rootRoute = createRootRoute({
+    component: () => (
+      <NotificationProvider>
+        <Outlet />
+      </NotificationProvider>
+    ),
+  })
+  const catalogRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/catalog',
+    component: () => <CatalogPage />,
+  })
+  const catalogDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/catalog/$blueprintName',
+    component: () => <div data-testid="catalog-detail-target" />,
+  })
+  const tree = rootRoute.addChildren([catalogRoute, catalogDetailRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: [`/provision/${deploymentId}/catalog`] }),
+  })
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
+  globalThis.fetch = (() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ apps: [] }),
+    } as unknown as Response)) as typeof fetch
+})
+
+afterEach(() => cleanup())
+
+describe('CatalogPage (#3601)', () => {
+  it('mounts inside the PortalShell (sidebar present)', async () => {
+    renderCatalog('d-1')
+    expect(await screen.findByTestId('sov-portal-shell')).toBeTruthy()
+    expect(screen.getByTestId('admin-sidebar')).toBeTruthy()
+  })
+
+  it('renders the catalog grid with one card per descriptor', async () => {
+    renderCatalog('d-1')
+    const grid = await screen.findByTestId('sov-catalog-grid')
+    const cards = within(grid).getAllByTestId(/^sov-app-card-bp-/)
+    // BOOTSTRAP_KIT (11+) is always present in the resolved catalog.
+    expect(cards.length).toBeGreaterThan(0)
+  })
+
+  it('catalog card links to the CLASS page /catalog/$blueprint', async () => {
+    renderCatalog('d-1')
+    const card = await screen.findByTestId('sov-app-card-bp-cilium')
+    expect(card.getAttribute('href')).toBe('/provision/d-1/catalog/bp-cilium')
+  })
+
+  it('search narrows the visible cards', async () => {
+    renderCatalog('d-1')
+    const before = within(await screen.findByTestId('sov-catalog-grid')).getAllByTestId(/^sov-app-card-bp-/)
+    fireEvent.change(screen.getByTestId('sov-catalog-search'), { target: { value: 'cilium' } })
+    const after = within(await screen.findByTestId('sov-catalog-grid')).getAllByTestId(/^sov-app-card-bp-/)
+    expect(after.length).toBeLessThan(before.length)
+    expect(after.some((c) => c.getAttribute('data-testid') === 'sov-app-card-bp-cilium')).toBe(true)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogPage.tsx
@@ -1,0 +1,412 @@
+/**
+ * CatalogPage — the Catalog as its OWN left-nav page (#3601, EPIC #3597).
+ *
+ * Founder point 2 (2026-06-15): `/apps` had two tabs (Deployments +
+ * Catalog) which was confusing. The split is:
+ *
+ *   • `/apps`    → AppsPage, tab-less, INSTALLED deployments only.
+ *   • `/catalog` → THIS page, the catalog grid as its own surface.
+ *
+ * This page owns the catalog grid that used to be the "Catalog" tab on
+ * AppsPage: the full `resolveApplications()` set (bootstrap-kit + selected
+ * + transitive deps), each rendered as the SAME `AppCard` AppsPage uses
+ * (so no markup drift), with the live publish/status overlay from
+ * `GET /api/v1/sovereign/apps`. Clicking a catalog card opens the CLASS
+ * page `/catalog/$blueprint` (CatalogDetail), exactly as the old tab did.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the catalog list
+ * is computed by `resolveApplications()` from the wizard store + bootstrap
+ * kit — there is no hand-maintained id list here.
+ */
+
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+import { DETECTED_MODE } from '@/shared/lib/detectMode'
+import { API_BASE } from '@/shared/config/urls'
+import { authedFetch } from '@/shared/lib/authedFetch'
+import { useWizardStore } from '@/entities/deployment/store'
+import { PortalShell } from './PortalShell'
+import { AppCard } from './AppsPage'
+import { resolveApplications, type ApplicationDescriptor } from './applicationCatalog'
+import type { ApplicationStatus } from './eventReducer'
+
+const DEFAULT_APP_ENVIRONMENT = 'dev'
+
+interface CatalogLiveData {
+  statusById: Record<string, ApplicationStatus>
+  publishedBySlug: Record<string, boolean>
+  environmentById: Record<string, string>
+  externalURLById: Record<string, string>
+}
+
+export function CatalogPage() {
+  const params = useResolvedDeploymentId() as { deploymentId: string | null }
+  const deploymentId = params.deploymentId ?? ''
+  const store = useWizardStore()
+  const isSovereignMode = DETECTED_MODE.mode === 'sovereign'
+
+  // Catalog = every Application this Sovereign knows about (the same
+  // `resolveApplications` union AppsPage's Catalog tab rendered).
+  const catalogApps = useMemo(
+    () => resolveApplications(store.selectedComponents),
+    [store.selectedComponents],
+  )
+
+  // Live publish/status overlay — identical projection to AppsPage's
+  // `sovereign-apps-live` query so a card's INSTALLED / AVAILABLE pill and
+  // its Publish toggle read the same ground truth on both surfaces. The
+  // queryKey is shared so the two pages hit one cache entry.
+  const liveQuery = useQuery<CatalogLiveData>({
+    queryKey: ['sovereign-apps-live'],
+    enabled: isSovereignMode,
+    refetchInterval: 5_000,
+    retry: false,
+    placeholderData: (prev) => prev,
+    queryFn: async () => {
+      const r = await authedFetch(`${API_BASE}/v1/sovereign/apps`, {
+        headers: { Accept: 'application/json' },
+      })
+      if (!r.ok) throw new Error(`live apps fetch ${r.status}`)
+      const body = (await r.json()) as {
+        apps?: Array<{
+          id: string
+          slug?: string
+          status?: string
+          marketplacePublished?: boolean
+          environment?: string
+          externalURL?: string
+          instance?: boolean
+        }>
+      }
+      const statusById: Record<string, ApplicationStatus> = {}
+      const publishedBySlug: Record<string, boolean> = {}
+      const environmentById: Record<string, string> = {}
+      const externalURLById: Record<string, string> = {}
+      for (const a of body.apps ?? []) {
+        if (!a.id) continue
+        // Instance rows belong on the Deployments grid, not the catalog
+        // (the catalog is the CLASS view).
+        if (a.instance === true) continue
+        if (typeof a.externalURL === 'string' && a.externalURL !== '') {
+          externalURLById[a.id] = a.externalURL
+        }
+        switch (a.status) {
+          case 'installed':
+          case 'bootstrap':
+            statusById[a.id] = 'installed'
+            break
+          case 'installing':
+            statusById[a.id] = 'installing'
+            break
+          case 'available':
+            statusById[a.id] = 'available'
+            break
+          default:
+            statusById[a.id] = 'pending'
+        }
+        if (a.slug && typeof a.marketplacePublished === 'boolean') {
+          publishedBySlug[a.slug] = a.marketplacePublished
+        }
+        if (typeof a.environment === 'string' && a.environment !== '') {
+          environmentById[a.id] = a.environment
+        }
+      }
+      return { statusById, publishedBySlug, environmentById, externalURLById }
+    },
+  })
+  const liveStatus = liveQuery.data?.statusById ?? {}
+  const publishedBySlug = liveQuery.data?.publishedBySlug ?? {}
+  const environmentById = liveQuery.data?.environmentById ?? {}
+  const externalURLById = liveQuery.data?.externalURLById ?? {}
+  const refetchLive = liveQuery.refetch
+
+  const [query, setQuery] = useState('')
+
+  const visibleApps = useMemo<ApplicationDescriptor[]>(() => {
+    const filtered = query
+      ? catalogApps.filter((a) => {
+          const q = query.toLowerCase()
+          return (
+            a.title.toLowerCase().includes(q) ||
+            (a.description ?? '').toLowerCase().includes(q) ||
+            (a.familyName ?? '').toLowerCase().includes(q)
+          )
+        })
+      : catalogApps
+    return [...filtered].sort((a, b) => a.title.localeCompare(b.title))
+  }, [catalogApps, query])
+
+  return (
+    <PortalShell deploymentId={deploymentId} pageTitle="Catalog">
+      <style>{CATALOG_PAGE_CSS}</style>
+
+      {/* Search */}
+      <div className="apps-toolbar">
+        <div className="search-wrap">
+          <svg className="search-icon" viewBox="0 0 24 24" width={16} height={16} fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+            <circle cx={11} cy={11} r={8} />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+          <input
+            type="text"
+            placeholder={`Search ${catalogApps.length} apps…`}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="search-input"
+            data-testid="sov-catalog-search"
+          />
+        </div>
+      </div>
+
+      {visibleApps.length === 0 ? (
+        <div className="empty-state" data-testid="sov-catalog-empty">
+          <p className="empty-title">No catalog entries match.</p>
+          <p className="empty-sub">Clear the search to see the full catalog.</p>
+        </div>
+      ) : (
+        <div className="apps-grid" data-testid="sov-catalog-grid">
+          {visibleApps.map((app) => {
+            const slug = app.id.replace(/^bp-/, '')
+            const published = Object.prototype.hasOwnProperty.call(publishedBySlug, slug)
+              ? publishedBySlug[slug]
+              : null
+            const environment = environmentById[app.id] ?? DEFAULT_APP_ENVIRONMENT
+            const externalURL = externalURLById[app.id] ?? ''
+            return (
+              <AppCard
+                key={app.id}
+                app={app}
+                isCatalog
+                environment={environment}
+                externalURL={externalURL}
+                status={(() => {
+                  const live = liveStatus[app.id]
+                  if (live) return live
+                  if (isSovereignMode && liveQuery.isSuccess) return 'available'
+                  return 'pending'
+                })()}
+                isService={false}
+                marketplacePublished={published}
+                slug={slug}
+                onPublishedChange={async (next) => {
+                  const r = await authedFetch(
+                    `${API_BASE}/v1/sovereign/apps/${encodeURIComponent(slug)}/publish`,
+                    {
+                      method: 'PATCH',
+                      headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                      },
+                      body: JSON.stringify({ published: next }),
+                    },
+                  )
+                  if (!r.ok) throw new Error(`publish toggle failed: ${r.status}`)
+                  await refetchLive()
+                }}
+              />
+            )
+          })}
+        </div>
+      )}
+    </PortalShell>
+  )
+}
+
+/**
+ * CSS — the catalog grid + search reuse AppsPage's class names verbatim
+ * (`.apps-toolbar`, `.search-*`, `.apps-grid`, `.empty-state`). The
+ * `.app-card` / `.chip` / `.status-chip` styles ride along with each
+ * `AppCard` from AppsPage (AppCard injects no styles itself — the cards
+ * render against the page-level rules here), so the catalog cards look
+ * byte-identical to the cards the old Catalog tab rendered.
+ */
+const CATALOG_PAGE_CSS = `
+.apps-toolbar { display: flex; gap: 0.75rem; align-items: center; margin: 1rem 0 0.75rem; }
+.search-wrap { position: relative; flex: 1; }
+.search-icon {
+  position: absolute; left: 12px; top: 50%; transform: translateY(-50%);
+  color: var(--color-text-dim); opacity: 0.6;
+}
+.search-input {
+  width: 100%;
+  padding: 0.6rem 0.85rem 0.6rem 2.2rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  color: var(--color-text);
+  font: inherit;
+  font-size: 0.88rem;
+}
+.search-input:focus { outline: 2px solid var(--color-accent); border-color: transparent; }
+
+.apps-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: 0.65rem;
+}
+
+.empty-state { margin-top: 3rem; text-align: center; color: var(--color-text-dim); }
+.empty-title { font-size: 1rem; color: var(--color-text-strong); margin: 0 0 0.3rem; font-weight: 600; }
+.empty-sub { font-size: 0.85rem; margin: 0 0 1.2rem; }
+
+.app-card {
+  position: relative;
+  background: var(--color-surface);
+  border: 1.5px solid var(--color-border);
+  border-radius: 12px;
+  padding: 0.6rem;
+  display: flex;
+  align-items: stretch;
+  gap: 0.75rem;
+  transition: transform 0.15s, border-color 0.15s, box-shadow 0.15s;
+  height: 108px;
+  overflow: hidden;
+  cursor: pointer;
+  color: inherit;
+  text-decoration: none;
+}
+.app-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--color-accent);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+}
+.app-card.state-installed { border-color: color-mix(in srgb, var(--color-success) 45%, var(--color-border)); }
+.app-card.state-installing { border-color: color-mix(in srgb, var(--color-accent) 55%, var(--color-border)); }
+.app-card.state-failed { border-color: color-mix(in srgb, var(--color-danger) 55%, var(--color-border)); }
+.app-card.is-service { border-style: dashed; opacity: 0.9; }
+.app-card.is-service:hover { opacity: 1; }
+
+.app-logo {
+  align-self: stretch;
+  aspect-ratio: 1 / 1;
+  height: auto;
+  border-radius: 10px;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+.app-icon {
+  align-self: stretch;
+  aspect-ratio: 1 / 1;
+  height: auto;
+  border-radius: 10px;
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0; color: #fff; font-size: 1.3rem; font-weight: 700;
+}
+
+.app-body {
+  flex: 1; min-width: 0;
+  display: flex; flex-direction: column; gap: 0.25rem;
+  padding-right: 4.5rem;
+  overflow: hidden;
+}
+.app-top { display: flex; align-items: baseline; gap: 0.5rem; }
+.app-name {
+  color: var(--color-text-strong); font-size: 0.92rem; font-weight: 600; line-height: 1.2;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  flex: 1 1 auto; min-width: 0;
+}
+.app-cat {
+  color: var(--color-text-dim); font-size: 0.68rem; text-transform: capitalize;
+  background: color-mix(in srgb, var(--color-border) 50%, transparent);
+  padding: 0.1rem 0.4rem; border-radius: 3px;
+}
+.app-desc {
+  margin: 0; color: var(--color-text); font-size: 0.78rem; line-height: 1.45;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+}
+.app-chips {
+  margin-top: 0.25rem;
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0.25rem;
+  overflow: hidden;
+  mask-image: linear-gradient(to right, #000 85%, transparent);
+  -webkit-mask-image: linear-gradient(to right, #000 85%, transparent);
+  min-height: 1.4rem;
+}
+.chip {
+  display: inline-flex; align-items: center; padding: 0.1rem 0.45rem;
+  border-radius: 999px; font-size: 0.65rem; font-weight: 600; line-height: 1.4; white-space: nowrap;
+}
+.chip-free { background: color-mix(in srgb, var(--color-success) 14%, transparent); color: var(--color-success); }
+.chip-dep { background: color-mix(in srgb, var(--color-accent) 12%, transparent); color: var(--color-accent); font-weight: 500; }
+.chip-env {
+  background: color-mix(in srgb, var(--color-text-strong) 12%, transparent);
+  color: var(--color-text-strong);
+  font-weight: 600;
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+}
+
+.status-corner { position: absolute; bottom: 0.5rem; right: 0.55rem; display: flex; gap: 0.4rem; align-items: center; }
+.open-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.18rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 1.4;
+  font-family: inherit;
+  cursor: pointer;
+  pointer-events: auto;
+  background: var(--color-accent);
+  color: #fff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.22);
+  transition: filter 120ms ease, transform 120ms ease;
+}
+.open-chip:hover { filter: brightness(0.92); transform: translateY(-1px); }
+.open-chip:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+.open-chip:disabled { opacity: 0.6; cursor: wait; }
+.open-chip svg { display: block; }
+.publish-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 0.65rem;
+  font-weight: 600;
+  line-height: 1.4;
+  font-family: inherit;
+  cursor: pointer;
+  pointer-events: auto;
+  transition: filter 120ms ease;
+}
+.publish-chip:hover { filter: brightness(1.15); }
+.publish-chip .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; display: inline-block; }
+.publish-chip.is-published {
+  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
+  color: var(--color-accent);
+  border-color: color-mix(in srgb, var(--color-accent) 35%, transparent);
+}
+.publish-chip.is-unpublished {
+  background: color-mix(in srgb, var(--color-text-dim) 14%, transparent);
+  color: var(--color-text-dim);
+  border-color: color-mix(in srgb, var(--color-text-dim) 30%, transparent);
+}
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+.status-chip .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; display: inline-block; }
+.status-chip .dot-spin { animation: sov-pulse 1.3s ease-in-out infinite; }
+.s-installed { background: color-mix(in srgb, var(--color-success) 16%, transparent); color: var(--color-success); }
+.s-installing { background: color-mix(in srgb, var(--color-accent) 16%, transparent); color: var(--color-accent); }
+.s-pending { background: color-mix(in srgb, var(--color-text-dim) 16%, transparent); color: var(--color-text-dim); }
+.s-available { background: color-mix(in srgb, var(--color-accent) 12%, transparent); color: var(--color-accent); border: 1px solid color-mix(in srgb, var(--color-accent) 40%, transparent); }
+.s-failed { background: color-mix(in srgb, var(--color-danger) 16%, transparent); color: var(--color-danger); }
+
+@keyframes sov-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+`

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx
@@ -48,10 +48,11 @@ interface SidebarProps {
 /* ── Top-level (flat) nav items ─────────────────────────────────── */
 
 interface FlatNavItem {
-  id: 'apps' | 'jobs' | 'dashboard' | 'cloud' | 'users' | 'settings'
+  id: 'apps' | 'catalog' | 'jobs' | 'dashboard' | 'cloud' | 'users' | 'settings'
   label: string
   to:
     | '/provision/$deploymentId'
+    | '/provision/$deploymentId/catalog'
     | '/provision/$deploymentId/jobs'
     | '/provision/$deploymentId/dashboard'
     | '/provision/$deploymentId/cloud'
@@ -77,6 +78,14 @@ const FLAT_NAV: FlatNavItem[] = [
     label: 'Apps',
     to: '/provision/$deploymentId',
     icon: 'M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z',
+  },
+  // Catalog (#3601) — the catalog grid as its own page in the provision
+  // tree (parity with the chroot SovereignSidebar Catalog entry).
+  {
+    id: 'catalog',
+    label: 'Catalog',
+    to: '/provision/$deploymentId/catalog',
+    icon: 'M4 7a2 2 0 012-2h8a2 2 0 012 2v10a2 2 0 01-2 2H6a2 2 0 01-2-2V7zm14 1a2 2 0 012 2v7a2 2 0 01-2 2M8 9h6M8 13h6',
   },
   {
     id: 'jobs',
@@ -114,7 +123,7 @@ const SETTINGS_ITEM: FlatNavItem = {
 
 /* ── Active-state derivation ────────────────────────────────────── */
 
-type ActiveSection = 'apps' | 'jobs' | 'dashboard' | 'cloud' | 'users' | 'settings'
+type ActiveSection = 'apps' | 'catalog' | 'jobs' | 'dashboard' | 'cloud' | 'users' | 'settings'
 
 // Cloud section is active when the path matches any of the
 // `/cloud[/...]` or legacy `/infrastructure[/...]` segments. We use a
@@ -126,6 +135,8 @@ const CLOUD_PATH_RE = /\/(cloud|infrastructure)(\/|$)/
 function deriveActiveSection(pathname: string): ActiveSection {
   if (CLOUD_PATH_RE.test(pathname)) return 'cloud'
   if (pathname.endsWith('/dashboard')) return 'dashboard'
+  // Catalog (#3601) — /catalog and /catalog/<blueprint> both count.
+  if (/\/catalog(\/|$)/.test(pathname)) return 'catalog'
   if (pathname.endsWith('/jobs')) return 'jobs'
   // Users surface — list, /new, and /<name> all count.
   if (/\/users(\/|$)/.test(pathname)) return 'users'

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
@@ -38,7 +38,7 @@ const CLOUD_ICON =
   'M6.657 18c-2.572 0 -4.657 -2.007 -4.657 -4.483c0 -2.475 2.085 -4.482 4.657 -4.482c.393 -1.762 1.794 -3.2 3.675 -3.773c1.88 -.572 3.956 -.193 5.444 1c1.488 1.19 2.162 3.007 1.77 4.769h.99c1.913 0 3.464 1.56 3.464 3.486c0 1.927 -1.551 3.487 -3.465 3.487h-11.878'
 
 interface FlatNavItem {
-  id: 'apps' | 'sandbox' | 'jobs' | 'compliance' | 'dashboard' | 'cloud' | 'users' | 'organizations' | 'settings'
+  id: 'apps' | 'catalog' | 'sandbox' | 'jobs' | 'compliance' | 'dashboard' | 'cloud' | 'users' | 'organizations' | 'settings'
   label: string
   to: string
   icon: string
@@ -67,6 +67,19 @@ const FLAT_NAV: FlatNavItem[] = [
     label: 'Apps',
     to: '/apps',
     icon: 'M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z',
+  },
+  // Catalog (#3601, EPIC #3597). Founder point 2 (2026-06-15): the
+  // catalog is its OWN left-nav page now, no longer a tab on /apps.
+  // `/catalog` → CatalogPage (the catalog grid). Sits right after Apps:
+  // Apps is "what's installed", Catalog is "what you can install".
+  //
+  // Icon: a stacked-cards / catalog glyph (single-stroke, matching the
+  // icon family used by the other entries).
+  {
+    id: 'catalog',
+    label: 'Catalog',
+    to: '/catalog',
+    icon: 'M4 7a2 2 0 012-2h8a2 2 0 012 2v10a2 2 0 01-2 2H6a2 2 0 01-2-2V7zm14 1a2 2 0 012 2v7a2 2 0 01-2 2M8 9h6M8 13h6',
   },
   // Sandbox (Wave 3, 2026-05-18 — issue: sandbox-wave3-ui-scaffold).
   // Per-Org agent-coding workspace — each session runs a chosen agent
@@ -172,13 +185,17 @@ const SETTINGS_SUB_NAV: SubNavItem[] = [
 
 // ── Active-state derivation ───────────────────────────────────────────────────
 
-type ActiveSection = 'apps' | 'sandbox' | 'jobs' | 'compliance' | 'dashboard' | 'cloud' | 'users' | 'organizations' | 'settings'
+type ActiveSection = 'apps' | 'catalog' | 'sandbox' | 'jobs' | 'compliance' | 'dashboard' | 'cloud' | 'users' | 'organizations' | 'settings'
 
 const CLOUD_PATH_RE = /^\/(cloud|infrastructure)(\/|$)/
 
 function deriveActiveSection(pathname: string): ActiveSection {
   if (CLOUD_PATH_RE.test(pathname)) return 'cloud'
   if (/^\/dashboard(\/|$)/.test(pathname)) return 'dashboard'
+  // /catalog(/*) → 'catalog' (#3601) so the Catalog nav item highlights
+  // for the catalog grid AND the per-Blueprint class page
+  // (/catalog/$blueprintName → CatalogDetail).
+  if (/^\/catalog(\/|$)/.test(pathname)) return 'catalog'
   // /sandbox(/*) → 'sandbox' so the nav highlight covers the landing,
   // /sandbox/$id, and /sandbox/settings (Wave 3).
   if (/^\/sandbox(\/|$)/.test(pathname)) return 'sandbox'

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.tsx
@@ -53,7 +53,16 @@ export interface TopologyEditorProps {
   disableNetwork?: boolean
 }
 
-const ALL_MODES = ['single-region', 'active-active', 'active-hotstandby'] as const
+/**
+ * ALL_MODES — the canonical topology-mode option set for the placement
+ * picker. Exported (#3599, EPIC #3597) so the create-from-catalog
+ * placement step reuses the SAME option set the post-create Topology
+ * editor offers, instead of reinventing it. Editor dialect:
+ * `single-region` / `active-active` / `active-hotstandby`.
+ */
+export const ALL_MODES = ['single-region', 'active-active', 'active-hotstandby'] as const
+
+export type TopologyMode = (typeof ALL_MODES)[number]
 
 export function TopologyEditor({
   sovereignId,
@@ -325,7 +334,12 @@ export function TopologyEditor({
   )
 }
 
-function describeMode(mode: string): string {
+/**
+ * describeMode — one-line human description per topology mode. Exported
+ * (#3599) so the create-flow placement step shows the same helper text
+ * the post-create editor shows for each mode.
+ */
+export function describeMode(mode: string): string {
   switch (mode) {
     case 'single-region':
       return 'one cluster; lowest cost; no failover'


### PR DESCRIPTION
## What

Implements **EPIC #3597** founder points 1-2 in the **DEPLOYED** Sovereign console — `products/catalyst/bootstrap/ui` (React/Vite/TSX) + `products/catalyst/bootstrap/api` (Go). **Not** `core/console` (Astro+Svelte, which is not deployed — a prior agent wrongly used it).

Four granular children, all walkable independently:

### #3601 — Apps/Catalog nav split
- `/apps` is now **tab-less** — installed deployments only (the Deployments/Catalog tab strip is gone).
- New **CatalogPage** owns the catalog grid (the old "Catalog" tab content), reusing AppsPage's exported `AppCard` so the cards are byte-identical.
- Routes added: `/catalog` (chroot) + `/provision/$id/catalog` (provision tree), each registered before the dynamic `/catalog/$blueprintName`.
- **Catalog** nav item added to both the chroot `SovereignSidebar` and the provision `Sidebar` (active-state highlights for `/catalog` + `/catalog/<bp>`).
- Deep links `/apps` and `/catalog` both load; no functionality lost (search, cards, create-flow entry).

### #3599 — placement in the create-from-catalog wizard
- `NewInstanceDialog` gains a **placement** step: topology **mode** + **region(s)** + **vCluster**, **reusing the post-create Topology editor's option set** (`ALL_MODES` + `describeMode` are now exported from `TopologyEditor` — no divergent vocab).
- Submit writes `placement {vcluster, regions}` onto the Application CR via the existing #3373 placement object (backend stamps `spec.placement = {mode, vcluster, regions}` + `spec.regions`).
- `HandleApplicationStatus` now surfaces a `spec` view (`placement`/`regions`/`environmentRef`), so the **post-create Topology tab reflects the create-time placement** immediately (no wait for `status.placement`).
- Validation: `active-active` / `active-hotstandby` require **≥2 regions**; Create stays disabled until satisfied. Blueprint default topology is pre-selected when declared, else `single-region`.

### #3598 — "namespace not found" fix
- New idempotent `ensureOrgNamespace` helper (dynamic client + namespaces GVR) called **before** the Application CR create in both `HandleCreateInstance` and `HandleApplicationInstall` (+ ahead of the backing-service auto-create).
- Closes the race against the organization controller's GitOps namespace reconcile that produced `namespaces "<org>" not found`. Graceful error path on genuine failure.

### #3600 — dropdowns, not free-text
- Organization → `<select>` (live `listOrganizations()`), topology mode → `<select>` (editor `ALL_MODES`, constrained by the blueprint's supported set), region(s) → checkbox multiselect (live infrastructure topology), vCluster → `<select>` (`{host, mgmt, dmz, rtz}` + live vclusters).
- **Free-text remains ONLY for the instance name.** The derived Environment (`<org>-prod`) is shown read-only (there is no environments-list endpoint to populate a dropdown from).

## Tests
- **Go**: `ensureOrgNamespace` (create / idempotent / empty-reject); `TestCreateInstance_PlacementStampedOnCR` (placement object + `spec.regions`); full catalyst-api handler suite green.
- **UI**: `CatalogPage.test.tsx` (grid + class-page links + search); `AppsPage.test.tsx` rewritten for the tab-less page; `InstancesSection.test.tsx` (dropdowns + placement-in-request + ≥2-region validation). Full production `npm run build` green.

## #3602 / #3603 (editable catalog) — re-validation only (NOT built here)
Findings posted to EPIC #3597. Summary: the `/catalog/admin/apps` admin CRUD exists (in the separate `core/services/catalog` service, proxied by catalyst-api as `/api/v1/sme/commerce/apps`) but supports POST/PUT/PATCH(publish)/DELETE only (no GET). The `store.App` schema **lacks** the fields #3603 needs: no supported-topologies field (topology lives on the Blueprint, not the catalog App) and only a single `Icon` (no light/dark variants). Those store-schema additions are the real prerequisite for #3602/#3603.

## Notes
- Smallest correct changes; reuses the existing Topology editor option-set + the existing #3373 placement object rather than reinventing.
- Do **not** merge — catalyst-ui rolls the mothership; orchestrator reviews.

Refs #3601 #3599 #3598 #3600 #3597

🤖 Generated with [Claude Code](https://claude.com/claude-code)