### PR TITLE
feat(catalog): editable catalog — data-backed overlay + admin-edit UI (Refs #3602 #3603 #3597)

### DIFF
--- a/core/services/catalog/store/store.go
+++ b/core/services/catalog/store/store.go
@@ -22,7 +22,27 @@ type App struct {
 	Category        string    `bson:"category" json:"category"`
 	Tags            []string  `bson:"tags" json:"tags"`
 	Icon            string    `bson:"icon" json:"icon"`
+	// IconLight / IconDark are theme-specific icon overrides (#3602,
+	// EPIC #3597). The console renders IconLight in the light theme and
+	// IconDark in the dark theme; each may be a URL or an inline data:
+	// URI (the admin-edit form supports both upload and URL). Both are
+	// optional and ADDITIVE over the legacy single `Icon`: an empty
+	// theme-icon falls back to `Icon`, so existing catalog rows that only
+	// carry `Icon` keep rendering unchanged. `Icon` stays the canonical
+	// default — these two are kept alongside it for back-compat.
+	IconLight       string    `bson:"icon_light,omitempty" json:"icon_light,omitempty"`
+	IconDark        string    `bson:"icon_dark,omitempty" json:"icon_dark,omitempty"`
 	IconBg          string    `bson:"icon_bg" json:"icon_bg"`
+	// SupportedTopologies is the admin-editable set of placement modes
+	// this catalog entry advertises (e.g. ["single-region",
+	// "active-active", "active-hotstandby"]) — #3602, EPIC #3597. The
+	// canonical topology declaration still lives on the Blueprint
+	// (spec.topology.supported); this field lets the sovereign-admin
+	// curate which of those modes the catalog surfaces per entry without
+	// editing the Blueprint. Empty = no admin override; the catalog read
+	// API keeps the Blueprint/seed's own placement set. Additive — never
+	// overwrites the seed when unset.
+	SupportedTopologies []string `bson:"supported_topologies,omitempty" json:"supported_topologies,omitempty"`
 	MinimumSize     string    `bson:"minimum_size" json:"minimum_size"`
 	RecommendedSize string    `bson:"recommended_size" json:"recommended_size"`
 	Website         string    `bson:"website" json:"website"`
@@ -278,6 +298,13 @@ func (s *Store) UpdateApp(ctx context.Context, id string, app *App) error {
 		{Key: "description", Value: app.Description},
 		{Key: "category", Value: app.Category},
 		{Key: "icon", Value: app.Icon},
+		// #3602 — theme icons + admin-curated topology set. Persisted on
+		// every UpdateApp so an admin edit survives a service restart
+		// (FerretDB is durable). Empty values are written too, so the
+		// admin can clear a theme-icon override and fall back to `Icon`.
+		{Key: "icon_light", Value: app.IconLight},
+		{Key: "icon_dark", Value: app.IconDark},
+		{Key: "supported_topologies", Value: app.SupportedTopologies},
 		{Key: "icon_bg", Value: app.IconBg},
 		{Key: "free", Value: app.Free},
 		{Key: "featured", Value: app.Featured},

--- a/core/services/catalog/store/store_test.go
+++ b/core/services/catalog/store/store_test.go
@@ -1,0 +1,88 @@
+// store_test.go — #3602 (EPIC #3597) coverage for the editable-catalog
+// fields added to store.App: SupportedTopologies, IconLight, IconDark.
+//
+// The store's mutations run against FerretDB (MongoDB wire protocol), so a
+// full UpdateApp round-trip needs a live database. What we CAN pin without
+// a DB — and what actually guards the persistence contract — is that the
+// new fields carry the right bson tags so they (a) serialise into the
+// document an InsertOne/UpdateOne writes and (b) decode back on the next
+// read. A missing/typo'd bson tag is exactly the failure that would make an
+// admin edit silently NOT survive a service restart; this round-trip test
+// fires on that.
+package store
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func TestApp_EditableFields_BSONRoundTrip(t *testing.T) {
+	in := App{
+		ID:                  "app-1",
+		Slug:                "grafana",
+		Name:                "Grafana (Edited)",
+		Icon:                "grafana.svg",
+		IconLight:           "https://cdn/grafana-light.svg",
+		IconDark:            "https://cdn/grafana-dark.svg",
+		SupportedTopologies: []string{"single-region", "active-active"},
+	}
+
+	raw, err := bson.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// The persisted document MUST carry the canonical snake_case keys the
+	// UpdateApp $set writes, so a future read decodes them. Assert the keys
+	// exist in the marshalled doc.
+	var doc bson.M
+	if err := bson.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal to map: %v", err)
+	}
+	for _, key := range []string{"icon_light", "icon_dark", "supported_topologies"} {
+		if _, ok := doc[key]; !ok {
+			t.Errorf("persisted document missing %q key — an edit to this field would not survive a restart", key)
+		}
+	}
+
+	// Round-trip back into App and confirm the values are intact.
+	var out App
+	if err := bson.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal to App: %v", err)
+	}
+	if out.IconLight != in.IconLight {
+		t.Errorf("IconLight round-trip: got %q want %q", out.IconLight, in.IconLight)
+	}
+	if out.IconDark != in.IconDark {
+		t.Errorf("IconDark round-trip: got %q want %q", out.IconDark, in.IconDark)
+	}
+	if len(out.SupportedTopologies) != 2 || out.SupportedTopologies[1] != "active-active" {
+		t.Errorf("SupportedTopologies round-trip: got %v want %v", out.SupportedTopologies, in.SupportedTopologies)
+	}
+	// Back-compat: the legacy single Icon survives alongside the new ones.
+	if out.Icon != "grafana.svg" {
+		t.Errorf("legacy Icon must be preserved alongside theme icons: got %q", out.Icon)
+	}
+}
+
+// TestApp_EditableFields_OmittedWhenEmpty pins the omitempty contract: a
+// catalog row that was never edited must NOT serialise empty theme-icon /
+// topology keys, so the overlay's hasOverlay() check (which treats their
+// presence as "edited") stays meaningful and pre-existing rows don't bloat.
+func TestApp_EditableFields_OmittedWhenEmpty(t *testing.T) {
+	in := App{ID: "app-2", Slug: "redis", Name: "Redis", Icon: "redis.svg"}
+	raw, err := bson.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var doc bson.M
+	if err := bson.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"icon_light", "icon_dark", "supported_topologies"} {
+		if _, ok := doc[key]; ok {
+			t.Errorf("empty %q must be omitted (omitempty) on an un-edited row", key)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_client.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_client.go
@@ -80,6 +80,14 @@ type CatalogBlueprint struct {
 	// walking the Versions array. Same value as Versions[0].ChartRef
 	// when populated.
 	ChartRef string `json:"chartRef,omitempty"`
+
+	// SupportedTopologies — #3602 (EPIC #3597) admin-curated placement
+	// modes for this catalog entry, surfaced by the editable-catalog
+	// overlay. Empty on a pure-seed entry (the console then falls back to
+	// PlacementSchema.Modes / the Blueprint's own spec.topology.supported);
+	// populated when a sovereign-admin edits the entry's supported set.
+	// Additive — only set when an admin edit carries it.
+	SupportedTopologies []string `json:"supportedTopologies,omitempty"`
 }
 
 // CatalogDefaultPlacement mirrors `spec.defaultPlacement` (#3373) —
@@ -149,6 +157,15 @@ type CatalogBlueprintCard struct {
 	Description string   `json:"description,omitempty"`
 	Tagline     string   `json:"tagline,omitempty"`
 	Icon        string   `json:"icon,omitempty"`
+	// IconLight / IconDark — #3602 (EPIC #3597) theme-specific icon
+	// overrides surfaced by the admin-editable catalog overlay. Empty on
+	// a pure-seed entry; populated when a sovereign-admin edits the entry
+	// and uploads/links per-theme icons. The console renders IconLight in
+	// the light theme and IconDark in the dark theme, falling back to the
+	// single `Icon` (then the build-time logo) when a theme icon is
+	// absent. Additive — never set unless an admin edit carries them.
+	IconLight   string   `json:"iconLight,omitempty"`
+	IconDark    string   `json:"iconDark,omitempty"`
 	Category    string   `json:"category,omitempty"`
 	Family      string   `json:"family,omitempty"`
 	Tags        []string `json:"tags,omitempty"`

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_overlay.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_overlay.go
@@ -1,0 +1,160 @@
+// Package handler — catalog_overlay.go: #3602 (EPIC #3597) editable-catalog
+// overlay.
+//
+// The Sovereign console's Catalog page (#3601 CatalogPage) reads
+// GET /api/v1/catalog, which catalyst-api serves by listing the seed —
+// the chart-shipped Blueprint CRs from
+// products/catalyst/chart/templates/catalog-seed/blueprints.yaml (via the
+// in-cluster CR fallback) plus any Gitea-mirrored catalog. That seed is
+// NOT admin-editable on its own.
+//
+// Founder point 3 (2026-06-15): "a real catalog where the admin can edit
+// each app's topology, name, light/dark icons". The persisted edits live
+// in the SME commerce catalog store (core/services/catalog, store.App),
+// which already exposes an admin CRUD (POST/PUT /catalog/admin/apps) that
+// the #3603 edit form drives, and a public read (GET /catalog/apps) that
+// returns every App row.
+//
+// This file is the read-side merge: it OVERLAYS the persisted store edits
+// onto the seed so an edit wins while an un-edited entry keeps the seed.
+// The overlay is strictly ADDITIVE — a store field is applied ONLY when it
+// carries a non-empty value (an actual edit), so:
+//
+//   - an entry the admin never edited (no matching store row, or a store
+//     row whose edit fields are empty) passes the seed through verbatim;
+//   - an entry the admin edited (non-empty name / summary / icon /
+//     iconLight / iconDark / supportedTopologies) shows the edit.
+//
+// Matching is by NORMALIZED name: the seed Blueprint CRs are `bp-`-prefixed
+// (`bp-grafana`) per docs/NAMING §Blueprint, while the store keys rows by a
+// bare slug (`grafana`). normalizeCatalogKey strips the `bp-` prefix on
+// both sides so the two line up.
+//
+// Graceful degradation (the existing smeCatalog() pattern): when the SME
+// commerce catalog is not deployed on this Sovereign (DNS NXDOMAIN, non-2xx,
+// undecodable body) fetchCatalogEdits returns an empty map and the seed is
+// served unchanged. The overlay never fails the catalog read.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+)
+
+// catalogEdit is the subset of the SME commerce catalog's store.App that
+// the editable-catalog overlay applies onto a seed entry. Field names
+// mirror the store's JSON tags VERBATIM (core/services/catalog/store.App)
+// so the bare-array GET /catalog/apps response decodes straight into it.
+type catalogEdit struct {
+	Slug                string   `json:"slug"`
+	Name                string   `json:"name"`
+	Tagline             string   `json:"tagline"`
+	Description         string   `json:"description"`
+	Icon                string   `json:"icon"`
+	IconLight           string   `json:"icon_light"`
+	IconDark            string   `json:"icon_dark"`
+	SupportedTopologies []string `json:"supported_topologies"`
+}
+
+// hasOverlay reports whether this store row carries at least one non-empty
+// edit field. A row with no overlay-relevant content (the common case for
+// the ~100 pre-seeded commerce rows that were never touched by the
+// editable-catalog feature) is skipped entirely so it can never shadow a
+// seed entry that happens to share its slug.
+func (e catalogEdit) hasOverlay() bool {
+	return strings.TrimSpace(e.Name) != "" ||
+		strings.TrimSpace(e.Tagline) != "" ||
+		strings.TrimSpace(e.Description) != "" ||
+		strings.TrimSpace(e.Icon) != "" ||
+		strings.TrimSpace(e.IconLight) != "" ||
+		strings.TrimSpace(e.IconDark) != "" ||
+		len(e.SupportedTopologies) > 0
+}
+
+// normalizeCatalogKey lower-cases and strips the canonical `bp-` Blueprint
+// prefix so a seed CR named `bp-grafana` matches a store row keyed
+// `grafana`.
+func normalizeCatalogKey(name string) string {
+	return strings.TrimPrefix(strings.ToLower(strings.TrimSpace(name)), "bp-")
+}
+
+// overlayCatalogEdits returns a NEW slice with the persisted store edits
+// merged onto the seed. Pure (no I/O) so it is unit-testable in isolation.
+//
+// Merge rules (additive — an edit wins, the seed survives otherwise):
+//   - Name        → Card.Title       (when the store Name is non-empty)
+//   - Tagline     → Card.Summary     (when the store Tagline is non-empty)
+//   - Description → Card.Description  (when the store Description is non-empty)
+//   - Icon        → Card.Icon         (when the store Icon is non-empty)
+//   - IconLight   → Card.IconLight    (when non-empty)
+//   - IconDark    → Card.IconDark     (when non-empty)
+//   - SupportedTopologies → top-level SupportedTopologies (when non-empty)
+//
+// Items with no matching edited store row are returned unchanged.
+func overlayCatalogEdits(items []CatalogBlueprint, edits map[string]catalogEdit) []CatalogBlueprint {
+	if len(edits) == 0 || len(items) == 0 {
+		return items
+	}
+	out := make([]CatalogBlueprint, len(items))
+	copy(out, items)
+	for i := range out {
+		e, ok := edits[normalizeCatalogKey(out[i].Name)]
+		if !ok || !e.hasOverlay() {
+			continue
+		}
+		if v := strings.TrimSpace(e.Name); v != "" {
+			out[i].Card.Title = e.Name
+		}
+		if v := strings.TrimSpace(e.Tagline); v != "" {
+			out[i].Card.Summary = e.Tagline
+		}
+		if v := strings.TrimSpace(e.Description); v != "" {
+			out[i].Card.Description = e.Description
+		}
+		if v := strings.TrimSpace(e.Icon); v != "" {
+			out[i].Card.Icon = e.Icon
+		}
+		if v := strings.TrimSpace(e.IconLight); v != "" {
+			out[i].Card.IconLight = e.IconLight
+		}
+		if v := strings.TrimSpace(e.IconDark); v != "" {
+			out[i].Card.IconDark = e.IconDark
+		}
+		if len(e.SupportedTopologies) > 0 {
+			out[i].SupportedTopologies = e.SupportedTopologies
+		}
+	}
+	return out
+}
+
+// fetchCatalogEdits pulls every App row from the SME commerce catalog's
+// PUBLIC list endpoint (GET /catalog/apps) and indexes the edited ones by
+// normalized slug. Returns an empty (non-nil) map on ANY failure — the SME
+// catalog being absent (the marketplace.enabled=false Sovereigns) or
+// unreachable is a normal state, not an error: the catalog read then serves
+// the seed unchanged. Per the existing smeCatalog() contract the public
+// list carries no auth, so no bearer is forwarded.
+func fetchCatalogEdits(ctx context.Context) map[string]catalogEdit {
+	edits := map[string]catalogEdit{}
+	status, body, _, err := smeCatalog().PublicProxy(ctx, "/apps")
+	if err != nil || status < 200 || status >= 300 || len(body) == 0 {
+		return edits
+	}
+	// GET /catalog/apps returns a BARE JSON array (respond.OK on a slice).
+	// Decode tolerantly: on a shape we don't recognise, return the empty
+	// map so the seed passes through rather than 500-ing the catalog read.
+	var rows []catalogEdit
+	if jerr := json.Unmarshal(body, &rows); jerr != nil {
+		return edits
+	}
+	for _, row := range rows {
+		key := normalizeCatalogKey(row.Slug)
+		if key == "" || !row.hasOverlay() {
+			continue
+		}
+		edits[key] = row
+	}
+	return edits
+}

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_overlay_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_overlay_test.go
@@ -1,0 +1,305 @@
+// catalog_overlay_test.go — #3602 (EPIC #3597) coverage for the
+// editable-catalog overlay merge.
+//
+// The DoD walk: "an edit persists + overlays the seed; an un-edited entry
+// returns the seed." These tests pin exactly that on the pure merge
+// (overlayCatalogEdits), on the store-row → edit decode (fetchCatalogEdits
+// against an httptest stand-in for GET /catalog/apps), and end-to-end
+// through HandleCatalogList with a fake SME catalog upstream.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// seedItem builds a minimal seed CatalogBlueprint as the in-cluster CR
+// fallback / catalyst-catalog would return it (the values the admin can
+// later override).
+func seedItem(name, title, summary, icon string) CatalogBlueprint {
+	return CatalogBlueprint{
+		Name:    name,
+		Version: "1.0.0",
+		Origin:  3,
+		Source:  "in-cluster",
+		Card: CatalogBlueprintCard{
+			Title:   title,
+			Summary: summary,
+			Icon:    icon,
+		},
+	}
+}
+
+func TestOverlayCatalogEdits_EditWinsUneditedKeepsSeed(t *testing.T) {
+	items := []CatalogBlueprint{
+		seedItem("bp-grafana", "Grafana", "Seed summary", "grafana.svg"),
+		seedItem("bp-keycloak", "Keycloak", "Identity", "keycloak.svg"),
+	}
+	// Only grafana is edited (store keys by bare slug).
+	edits := map[string]catalogEdit{
+		"grafana": {
+			Slug:                "grafana",
+			Name:                "Grafana (Edited)",
+			Tagline:             "Admin-curated summary",
+			Icon:                "custom-grafana.svg",
+			IconLight:           "https://cdn/light.svg",
+			IconDark:            "https://cdn/dark.svg",
+			SupportedTopologies: []string{"single-region", "active-active"},
+		},
+	}
+
+	out := overlayCatalogEdits(items, edits)
+
+	// grafana reflects the edit.
+	var g *CatalogBlueprint
+	var k *CatalogBlueprint
+	for i := range out {
+		switch out[i].Name {
+		case "bp-grafana":
+			g = &out[i]
+		case "bp-keycloak":
+			k = &out[i]
+		}
+	}
+	if g == nil || k == nil {
+		t.Fatalf("expected both entries in output, got %+v", out)
+	}
+	if g.Card.Title != "Grafana (Edited)" {
+		t.Errorf("edited title: got %q want %q", g.Card.Title, "Grafana (Edited)")
+	}
+	if g.Card.Summary != "Admin-curated summary" {
+		t.Errorf("edited summary: got %q", g.Card.Summary)
+	}
+	if g.Card.Icon != "custom-grafana.svg" {
+		t.Errorf("edited icon: got %q", g.Card.Icon)
+	}
+	if g.Card.IconLight != "https://cdn/light.svg" || g.Card.IconDark != "https://cdn/dark.svg" {
+		t.Errorf("edited theme icons: light=%q dark=%q", g.Card.IconLight, g.Card.IconDark)
+	}
+	if len(g.SupportedTopologies) != 2 || g.SupportedTopologies[0] != "single-region" {
+		t.Errorf("edited supportedTopologies: got %v", g.SupportedTopologies)
+	}
+
+	// keycloak is UNedited → seed unchanged.
+	if k.Card.Title != "Keycloak" || k.Card.Summary != "Identity" || k.Card.Icon != "keycloak.svg" {
+		t.Errorf("un-edited entry must keep the seed; got title=%q summary=%q icon=%q",
+			k.Card.Title, k.Card.Summary, k.Card.Icon)
+	}
+	if k.Card.IconLight != "" || k.Card.IconDark != "" || len(k.SupportedTopologies) != 0 {
+		t.Errorf("un-edited entry must NOT gain overlay fields; got light=%q dark=%q topo=%v",
+			k.Card.IconLight, k.Card.IconDark, k.SupportedTopologies)
+	}
+}
+
+func TestOverlayCatalogEdits_EmptyEditFieldsNeverClobberSeed(t *testing.T) {
+	items := []CatalogBlueprint{seedItem("bp-grafana", "Grafana", "Seed summary", "grafana.svg")}
+	// A store row that shares the slug but carries NO overlay content
+	// (the common pre-seeded commerce row). It must be skipped entirely so
+	// the seed survives.
+	edits := map[string]catalogEdit{
+		"grafana": {Slug: "grafana"}, // all edit fields empty
+	}
+	out := overlayCatalogEdits(items, edits)
+	if out[0].Card.Title != "Grafana" || out[0].Card.Summary != "Seed summary" || out[0].Card.Icon != "grafana.svg" {
+		t.Fatalf("empty store row clobbered the seed: %+v", out[0].Card)
+	}
+}
+
+func TestOverlayCatalogEdits_PartialEditOnlyTouchesProvidedFields(t *testing.T) {
+	items := []CatalogBlueprint{seedItem("bp-grafana", "Grafana", "Seed summary", "grafana.svg")}
+	// Admin renamed the entry but left summary + icon as-is.
+	edits := map[string]catalogEdit{
+		"grafana": {Slug: "grafana", Name: "Observability"},
+	}
+	out := overlayCatalogEdits(items, edits)
+	if out[0].Card.Title != "Observability" {
+		t.Errorf("name should be edited: got %q", out[0].Card.Title)
+	}
+	if out[0].Card.Summary != "Seed summary" {
+		t.Errorf("untouched summary must keep the seed: got %q", out[0].Card.Summary)
+	}
+	if out[0].Card.Icon != "grafana.svg" {
+		t.Errorf("untouched icon must keep the seed: got %q", out[0].Card.Icon)
+	}
+}
+
+func TestOverlayCatalogEdits_NoEditsIsNoop(t *testing.T) {
+	items := []CatalogBlueprint{seedItem("bp-grafana", "Grafana", "Seed summary", "grafana.svg")}
+	out := overlayCatalogEdits(items, map[string]catalogEdit{})
+	if len(out) != 1 || out[0].Card.Title != "Grafana" {
+		t.Fatalf("empty edits map must be a no-op; got %+v", out)
+	}
+}
+
+// TestFetchCatalogEdits_DecodesBareArrayFromStore points smeCatalog() at an
+// httptest server returning the BARE JSON array shape that
+// core/services/catalog GET /catalog/apps emits (respond.OK on a slice),
+// and checks the overlay map indexes only the EDITED rows by bare slug.
+func TestFetchCatalogEdits_DecodesBareArrayFromStore(t *testing.T) {
+	// GET /catalog/apps body: one edited row + one un-edited row.
+	body := `[
+		{"slug":"grafana","name":"Grafana (Edited)","icon_light":"l.svg","icon_dark":"d.svg","supported_topologies":["single-region"]},
+		{"slug":"keycloak","name":"","tagline":"","icon":""}
+	]`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/catalog/apps" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	restore := overrideSMECatalog(srv.URL)
+	defer restore()
+
+	edits := fetchCatalogEdits(context.Background())
+	if _, ok := edits["grafana"]; !ok {
+		t.Fatalf("edited row 'grafana' must be in the overlay map; got %v", editKeys(edits))
+	}
+	if _, ok := edits["keycloak"]; ok {
+		t.Errorf("un-edited row 'keycloak' (all-empty) must be skipped; got %v", editKeys(edits))
+	}
+	g := edits["grafana"]
+	if g.Name != "Grafana (Edited)" || g.IconLight != "l.svg" || g.IconDark != "d.svg" {
+		t.Errorf("decoded edit fields wrong: %+v", g)
+	}
+}
+
+// TestFetchCatalogEdits_GracefulWhenCatalogAbsent — when the SME catalog is
+// unreachable (the marketplace.enabled=false Sovereigns), fetchCatalogEdits
+// returns an empty map, NOT an error, so the catalog read serves the seed.
+func TestFetchCatalogEdits_GracefulWhenCatalogAbsent(t *testing.T) {
+	// Point at a closed port so the GET fails immediately.
+	restore := overrideSMECatalog("http://127.0.0.1:0")
+	defer restore()
+	edits := fetchCatalogEdits(context.Background())
+	if edits == nil {
+		t.Fatal("fetchCatalogEdits must return a non-nil empty map on failure")
+	}
+	if len(edits) != 0 {
+		t.Fatalf("expected empty map on unreachable catalog; got %v", editKeys(edits))
+	}
+}
+
+// TestHandleCatalogList_OverlaysStoreEdits is the end-to-end DoD walk: the
+// seed (fake catalyst-catalog) carries bp-wordpress; the SME store carries
+// an edit for it; GET /api/v1/catalog returns the edited name.
+func TestHandleCatalogList_OverlaysStoreEdits(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetCatalogClient(newFakeCatalog(sampleWordpressBlueprint()))
+
+	// SME store returns an edited wordpress row.
+	storeBody := `[{"slug":"wordpress","name":"WordPress (Renamed)","tagline":"My summary","icon_dark":"dark.svg","supported_topologies":["single-region","active-active"]}]`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(storeBody))
+	}))
+	defer srv.Close()
+	restore := overrideSMECatalog(srv.URL)
+	defer restore()
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/catalog", h.HandleCatalogList)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/catalog", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var env CatalogListResponseEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, rec.Body.String())
+	}
+	if len(env.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(env.Items))
+	}
+	got := env.Items[0]
+	// sampleWordpressBlueprint is named bp-wordpress with whatever seed
+	// title; the overlay must have replaced the title + summary + dark
+	// icon + supportedTopologies.
+	if got.Card.Title != "WordPress (Renamed)" {
+		t.Errorf("overlay title: got %q want %q", got.Card.Title, "WordPress (Renamed)")
+	}
+	if got.Card.Summary != "My summary" {
+		t.Errorf("overlay summary: got %q", got.Card.Summary)
+	}
+	if got.Card.IconDark != "dark.svg" {
+		t.Errorf("overlay dark icon: got %q", got.Card.IconDark)
+	}
+	if len(got.SupportedTopologies) != 2 {
+		t.Errorf("overlay supportedTopologies: got %v", got.SupportedTopologies)
+	}
+}
+
+// TestHandleCatalogList_SeedUnchangedWhenNoStoreEdit — when the SME store
+// has no matching edit, the seed entry passes through verbatim (the
+// "un-edited entry returns the seed" half of the DoD, at the handler).
+func TestHandleCatalogList_SeedUnchangedWhenNoStoreEdit(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetCatalogClient(newFakeCatalog(sampleWordpressBlueprint()))
+
+	// Store returns an edit for a DIFFERENT app, so wordpress is un-edited.
+	storeBody := `[{"slug":"some-other-app","name":"Other"}]`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(storeBody))
+	}))
+	defer srv.Close()
+	restore := overrideSMECatalog(srv.URL)
+	defer restore()
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/catalog", h.HandleCatalogList)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/catalog", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var env CatalogListResponseEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(env.Items) != 1 || env.Items[0].Name != "bp-wordpress" {
+		t.Fatalf("expected seed bp-wordpress, got %+v", env.Items)
+	}
+	// Seed title must be whatever the fake blueprint declared — NOT
+	// overwritten. We assert it's non-empty and carries no overlay-only
+	// fields.
+	if strings.TrimSpace(env.Items[0].Card.Title) == "" {
+		t.Errorf("seed title should be intact, got empty")
+	}
+	if env.Items[0].Card.IconDark != "" || len(env.Items[0].SupportedTopologies) != 0 {
+		t.Errorf("un-edited seed must not gain overlay fields: dark=%q topo=%v",
+			env.Items[0].Card.IconDark, env.Items[0].SupportedTopologies)
+	}
+}
+
+// overrideSMECatalog points smeCatalog() at the given baseURL for the
+// duration of a test and returns a restore func that clears the override.
+func overrideSMECatalog(baseURL string) func() {
+	prev := smeCatalogTestOverride
+	smeCatalogTestOverride = &smeCatalogClient{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		http:    &http.Client{Timeout: smeCatalogProbeBudget},
+	}
+	return func() { smeCatalogTestOverride = prev }
+}
+
+// keysOf is a tiny test helper for clearer failure messages.
+func editKeys(m map[string]catalogEdit) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_proxy.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_proxy.go
@@ -89,6 +89,13 @@ func (h *Handler) HandleCatalogList(w http.ResponseWriter, r *http.Request) {
 	for i := range items {
 		items[i].PopulateVersionsAlias()
 	}
+	// #3602 (EPIC #3597) — overlay the admin-editable catalog edits from
+	// the SME commerce catalog store onto the seed so an edited entry
+	// shows the admin's name / summary / icons / supported-topologies and
+	// an un-edited entry keeps the seed. Additive + best-effort: when the
+	// SME catalog isn't deployed or is unreachable, fetchCatalogEdits
+	// returns an empty map and items pass through unchanged.
+	items = overlayCatalogEdits(items, fetchCatalogEdits(r.Context()))
 	// `Origin` token presence (qa-loop iter-15 Fix #58, TC-058
 	// must_contain ['origin','bp-']). On a fresh chroot Sovereign the
 	// upstream may legitimately return zero blueprints (no fixtures
@@ -166,7 +173,12 @@ func (h *Handler) HandleCatalogGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	bp.PopulateVersionsAlias()
-	writeJSON(w, http.StatusOK, bp)
+	// #3602 (EPIC #3597) — overlay the admin edit for this single entry
+	// (same additive, best-effort merge as the list endpoint) so a
+	// renamed / re-iconed entry resolves with the edit on its detail page
+	// too. Reuses the slice merge with a one-element slice.
+	overlaid := overlayCatalogEdits([]CatalogBlueprint{*bp}, fetchCatalogEdits(r.Context()))
+	writeJSON(w, http.StatusOK, &overlaid[0])
 }
 
 // HandleCatalogGetVersion — proxies GET

--- a/products/catalyst/bootstrap/api/internal/handler/sme_catalog_client.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_catalog_client.go
@@ -54,9 +54,19 @@ type smeCatalogClient struct {
 var smeCatalogSingleton *smeCatalogClient
 var smeCatalogOnce sync.Once
 
+// smeCatalogTestOverride lets tests point smeCatalog() at an httptest
+// server WITHOUT racing the sync.Once (which would otherwise pin the first
+// caller's baseURL for the rest of the process). nil in production — the
+// override is only ever set by the in-package test helper. Checked first in
+// smeCatalog() so a test can swap + restore deterministically.
+var smeCatalogTestOverride *smeCatalogClient
+
 // smeCatalog returns the package-level SME catalog client, lazily
 // constructed on first use.
 func smeCatalog() *smeCatalogClient {
+	if smeCatalogTestOverride != nil {
+		return smeCatalogTestOverride
+	}
 	smeCatalogOnce.Do(func() {
 		base := strings.TrimSpace(os.Getenv(smeCatalogURLEnv))
 		if base == "" {

--- a/products/catalyst/bootstrap/ui/src/lib/commerce.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/commerce.api.ts
@@ -89,6 +89,18 @@ export interface CommerceApp {
   tagline?: string
   category?: string
   published?: boolean
+  /**
+   * #3603 (EPIC #3597) — the admin-editable catalog fields. Mirror the
+   * store.App JSON tags VERBATIM (core/services/catalog/store.go): the
+   * legacy single `icon` plus the per-theme `icon_light` / `icon_dark`
+   * overrides and the admin-curated `supported_topologies` set. All
+   * optional + additive over the seed.
+   */
+  description?: string
+  icon?: string
+  icon_light?: string
+  icon_dark?: string
+  supported_topologies?: string[]
 }
 
 export type CommerceKind = 'plans' | 'addons' | 'bundles' | 'industries' | 'apps'
@@ -157,3 +169,68 @@ export const updateCommerce = <T>(kind: CommerceKind, id: string, body: T) =>
   writeCommerce<T>('PUT', kind, id, body)
 export const deleteCommerce = (kind: CommerceKind, id: string) =>
   writeCommerce<undefined>('DELETE', kind, id, undefined)
+
+/* ── #3603 (EPIC #3597) — catalog entry edit ───────────────────────── */
+
+/** The mutable subset of a catalog entry the #3603 edit form changes. */
+export interface CatalogEntryEdit {
+  name: string
+  tagline: string
+  supported_topologies: string[]
+  icon_light: string
+  icon_dark: string
+}
+
+/**
+ * saveCatalogEdit persists an admin's catalog-entry edit to the SME
+ * commerce catalog store.
+ *
+ * The store's UpdateApp does a FULL `$set` of every column from the decoded
+ * row, so a partial PUT would zero the untouched columns (deployable,
+ * published, helm_chart, …). To stay additive we therefore:
+ *
+ *   1. list every store App and find the row whose slug matches this
+ *      catalog entry (slugs are bare — the catalog id's `bp-` prefix is
+ *      stripped by the caller);
+ *   2. if it exists, MERGE the edited fields onto the FULL existing row
+ *      (the runtime object still carries every store column even though the
+ *      CommerceApp type only declares a few) and PUT it back by its `_id`,
+ *      so no column is lost;
+ *   3. if no row exists yet (a seed-only catalog entry the commerce store
+ *      never had), POST a new minimal row (slug + the edited fields) so the
+ *      edit still persists and overlays the seed on the next catalog read.
+ *
+ * Returns the slug it wrote, for the caller's optimistic cache update.
+ */
+export async function saveCatalogEdit(slug: string, edit: CatalogEntryEdit): Promise<string> {
+  const bare = slug.replace(/^bp-/, '')
+  const apps = await listApps()
+  const existing = apps.find((a) => (a.slug ?? '').replace(/^bp-/, '') === bare)
+
+  // The edited fields, with the legacy `icon` kept in sync to the light
+  // icon when the admin set one (so a single-icon consumer still updates).
+  const patch: Partial<CommerceApp> = {
+    name: edit.name,
+    tagline: edit.tagline,
+    supported_topologies: edit.supported_topologies,
+    icon_light: edit.icon_light,
+    icon_dark: edit.icon_dark,
+  }
+
+  if (existing && existing.id) {
+    // Merge onto the full runtime row so untouched columns survive the
+    // full-$set UpdateApp.
+    const merged = { ...existing, ...patch }
+    await updateCommerce('apps', existing.id, merged)
+    return bare
+  }
+
+  // No store row yet — create one carrying the edit. slug is required by
+  // the store; name falls back to the slug when the admin left it blank.
+  await createCommerce<CommerceApp>('apps', {
+    slug: bare,
+    name: edit.name || bare,
+    ...patch,
+  })
+  return bare
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
@@ -49,6 +49,7 @@ import type { ApplicationStatus } from './eventReducer'
 import { WipeDeploymentModal } from '@/components/CrudModals/WipeDeploymentModal'
 import { useNotifications } from '@/shared/ui/notifications'
 import { isDeploymentID } from '@/shared/types/deployment'
+import { useTheme } from '@/shared/lib/useTheme'
 
 interface AppsPageProps {
   /** Test seam — disables the live SSE EventSource attach. */
@@ -842,14 +843,41 @@ interface AppCardProps {
    */
   topology?: string
   contextCount?: number
+  /**
+   * #3603 (EPIC #3597) — admin-editable catalog icons. When set, the card
+   * renders the theme-correct override (iconLight in the light theme,
+   * iconDark in the dark theme) in place of the build-time logo, falling
+   * back: theme icon → the other theme's icon → app.logoUrl → initial.
+   * Empty on un-edited entries (the card keeps its build-time logo).
+   */
+  iconLight?: string
+  iconDark?: string
+  /**
+   * #3603 — admin Edit affordance. When provided, the card renders an
+   * "Edit" button in the status-corner (the Catalog page passes this only
+   * for sovereign-admins). Clicking opens the edit form; the button stops
+   * the card-link navigation. Absent ⇒ no Edit button (non-admins, the
+   * Deployments grid).
+   */
+  onEdit?: () => void
 }
 
 // Exported for the #3374 render test (AppsPage.open-button.test.tsx) — the
 // per-card Open button gate + silent-SSO click routing are leaf behaviour
 // best asserted directly on the card, without the live-apps query plumbing.
-export function AppCard({ app, status, isCatalog, isService, environment, marketplacePublished, slug, onPublishedChange, topology, contextCount, externalURL }: AppCardProps) {
+export function AppCard({ app, status, isCatalog, isService, environment, marketplacePublished, slug, onPublishedChange, topology, contextCount, externalURL, iconLight, iconDark, onEdit }: AppCardProps) {
   const stateClass = `state-${status}`
   const navigate = useNavigate()
+  // #3603 — render the theme-correct admin icon override when present:
+  // light icon in the light theme, dark icon in the dark theme. Fall back
+  // to the other theme's icon, then the build-time logo. Empty on
+  // un-edited entries → keeps app.logoUrl.
+  const { theme } = useTheme()
+  const themeIcon =
+    theme === 'light'
+      ? (iconLight || iconDark || '')
+      : (iconDark || iconLight || '')
+  const resolvedIcon = themeIcon || app.logoUrl || ''
   // #3374 — the per-card Open button resolves a silent-SSO launch via the
   // app's CR uid when known, else the bootstrap-kit blueprint/release name
   // (the BE launch-url resolver strips `bp-` and matches the HR). Mirrors
@@ -884,8 +912,15 @@ export function AppCard({ app, status, isCatalog, isService, environment, market
       data-testid={`sov-app-card-${app.id}`}
       data-status={status}
     >
-      {app.logoUrl ? (
-        <img src={app.logoUrl} alt={app.title} className="app-logo" loading="lazy" />
+      {resolvedIcon ? (
+        <img
+          src={resolvedIcon}
+          alt={app.title}
+          className="app-logo"
+          loading="lazy"
+          data-testid={`sov-app-icon-${app.id}`}
+          data-icon-theme={theme}
+        />
       ) : (
         <span className="app-icon" style={{ background: '#1f2937' }}>
           {app.title[0] ?? '?'}
@@ -957,6 +992,41 @@ export function AppCard({ app, status, isCatalog, isService, environment, market
       </div>
 
       <div className="status-corner">
+        {/* #3603 (EPIC #3597) — admin Edit affordance. Only rendered when
+         * onEdit is provided (the Catalog page passes it for
+         * sovereign-admins). The whole card is a Link, so the button stops
+         * the navigation and opens the edit form instead. Non-admins and
+         * the Deployments grid pass no onEdit ⇒ no button. */}
+        {onEdit ? (
+          <button
+            type="button"
+            className="edit-chip"
+            data-testid={`sov-app-edit-${app.id}`}
+            title={`Edit ${app.title} catalog entry`}
+            aria-label={`Edit ${app.title} catalog entry`}
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              onEdit()
+            }}
+          >
+            <svg
+              viewBox="0 0 24 24"
+              width={11}
+              height={11}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2.2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M12 20h9" />
+              <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+            </svg>
+            Edit
+          </button>
+        ) : null}
         {/* #3374 — per-card "Open" button RESTORED (founder flagged its
          * disappearance as "very important"). The #2743 "V4 verdict"
          * deleted it because it opened the RAW externalURL with no
@@ -1277,6 +1347,31 @@ const APPS_PAGE_CSS = `
 .open-chip:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
 .open-chip:disabled { opacity: 0.6; cursor: wait; }
 .open-chip svg { display: block; }
+/* #3603 — admin "Edit" pill (Catalog page, sovereign-admin only). Muted
+ * surface tone so it reads as a secondary affordance next to the accent
+ * Open button. pointer-events:auto so it stays clickable inside the card
+ * <a> Link. */
+.edit-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.18rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 1.4;
+  font-family: inherit;
+  cursor: pointer;
+  pointer-events: auto;
+  background: color-mix(in srgb, var(--color-text-strong) 8%, transparent);
+  color: var(--color-text-strong);
+  transition: filter 120ms ease, transform 120ms ease, border-color 120ms ease;
+}
+.edit-chip:hover { border-color: var(--color-accent); transform: translateY(-1px); }
+.edit-chip:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+.edit-chip svg { display: block; }
 .publish-chip {
   display: inline-flex;
   align-items: center;

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogEditDialog.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogEditDialog.tsx
@@ -1,0 +1,293 @@
+/**
+ * CatalogEditDialog — #3603 (EPIC #3597): the sovereign-admin edit form for
+ * a single catalog entry.
+ *
+ * Founder point 3 (2026-06-15): "a real catalog where the admin can edit
+ * each app's topology, name, light/dark icons." This dialog is the Edit
+ * affordance's form, opened from the Catalog page's per-card Edit button
+ * (admin-only). It changes:
+ *
+ *   • display name      (text)
+ *   • summary           (text)
+ *   • supported topologies (multiselect — reuses TopologyEditor's ALL_MODES
+ *     + describeMode so the vocabulary never diverges from the post-create
+ *     Topology editor)
+ *   • light icon        (URL or file upload → data: URI)
+ *   • dark icon         (URL or file upload → data: URI)
+ *
+ * Save persists via the #3602 API (saveCatalogEdit → PUT/POST
+ * /api/v1/sme/commerce/apps); the parent refreshes so the card reflects the
+ * new name + icon live, and the overlay makes the edit survive a reload.
+ */
+
+import { useState } from 'react'
+import { ALL_MODES, describeMode } from '@/widgets/topology/TopologyEditor'
+import { saveCatalogEdit, type CatalogEntryEdit } from '@/lib/commerce.api'
+
+export interface CatalogEditDialogProps {
+  /** Catalog entry id (may be `bp-`-prefixed) — keyed to the store slug. */
+  blueprintId: string
+  /** Initial form values from the current catalog card. */
+  initial: {
+    name: string
+    summary: string
+    supportedTopologies: string[]
+    iconLight: string
+    iconDark: string
+  }
+  onClose: () => void
+  /** Called with the edited fields after a successful save. */
+  onSaved: (edit: CatalogEntryEdit & { slug: string }) => void
+}
+
+/** Read a chosen file as a data: URI so an uploaded icon is self-contained. */
+function fileToDataURI(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result ?? ''))
+    reader.onerror = () => reject(reader.error ?? new Error('file read failed'))
+    reader.readAsDataURL(file)
+  })
+}
+
+export function CatalogEditDialog({ blueprintId, initial, onClose, onSaved }: CatalogEditDialogProps) {
+  const [name, setName] = useState(initial.name)
+  const [summary, setSummary] = useState(initial.summary)
+  const [topologies, setTopologies] = useState<string[]>(initial.supportedTopologies ?? [])
+  const [iconLight, setIconLight] = useState(initial.iconLight)
+  const [iconDark, setIconDark] = useState(initial.iconDark)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const toggleTopology = (mode: string) => {
+    setTopologies((prev) =>
+      prev.includes(mode) ? prev.filter((m) => m !== mode) : [...prev, mode],
+    )
+  }
+
+  const onPickIcon = async (which: 'light' | 'dark', file: File | undefined) => {
+    if (!file) return
+    try {
+      const uri = await fileToDataURI(file)
+      if (which === 'light') setIconLight(uri)
+      else setIconDark(uri)
+    } catch (e) {
+      setError(`icon upload failed: ${e instanceof Error ? e.message : String(e)}`)
+    }
+  }
+
+  const onSave = async () => {
+    setSaving(true)
+    setError(null)
+    const edit: CatalogEntryEdit = {
+      name: name.trim(),
+      tagline: summary.trim(),
+      supported_topologies: topologies,
+      icon_light: iconLight.trim(),
+      icon_dark: iconDark.trim(),
+    }
+    try {
+      const slug = await saveCatalogEdit(blueprintId, edit)
+      onSaved({ ...edit, slug })
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      className="catalog-edit-backdrop"
+      data-testid="catalog-edit-backdrop"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <style>{CATALOG_EDIT_CSS}</style>
+      <div
+        className="catalog-edit-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Edit catalog entry ${initial.name}`}
+        data-testid="catalog-edit-dialog"
+      >
+        <div className="ce-header">
+          <h2 className="ce-title">Edit catalog entry</h2>
+          <button type="button" className="ce-close" aria-label="Close" onClick={onClose}>
+            ×
+          </button>
+        </div>
+
+        <label className="ce-field">
+          <span className="ce-label">Display name</span>
+          <input
+            type="text"
+            className="ce-input"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            data-testid="catalog-edit-name"
+            placeholder="WordPress"
+          />
+        </label>
+
+        <label className="ce-field">
+          <span className="ce-label">Summary</span>
+          <textarea
+            className="ce-input ce-textarea"
+            value={summary}
+            onChange={(e) => setSummary(e.target.value)}
+            data-testid="catalog-edit-summary"
+            rows={2}
+            placeholder="One-line description shown on the card"
+          />
+        </label>
+
+        <div className="ce-field">
+          <span className="ce-label">Supported topologies</span>
+          <div className="ce-topos" data-testid="catalog-edit-topologies">
+            {ALL_MODES.map((mode) => (
+              <label key={mode} className="ce-topo" title={describeMode(mode)}>
+                <input
+                  type="checkbox"
+                  checked={topologies.includes(mode)}
+                  onChange={() => toggleTopology(mode)}
+                  data-testid={`catalog-edit-topo-${mode}`}
+                />
+                <span className="ce-topo-label">{mode}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="ce-field">
+          <span className="ce-label">Light-theme icon</span>
+          <div className="ce-icon-row">
+            <input
+              type="text"
+              className="ce-input"
+              value={iconLight}
+              onChange={(e) => setIconLight(e.target.value)}
+              data-testid="catalog-edit-icon-light"
+              placeholder="https://… or upload"
+            />
+            <label className="ce-upload" data-testid="catalog-edit-icon-light-upload-label">
+              Upload
+              <input
+                type="file"
+                accept="image/*"
+                className="ce-file"
+                data-testid="catalog-edit-icon-light-upload"
+                onChange={(e) => onPickIcon('light', e.target.files?.[0])}
+              />
+            </label>
+          </div>
+        </div>
+
+        <div className="ce-field">
+          <span className="ce-label">Dark-theme icon</span>
+          <div className="ce-icon-row">
+            <input
+              type="text"
+              className="ce-input"
+              value={iconDark}
+              onChange={(e) => setIconDark(e.target.value)}
+              data-testid="catalog-edit-icon-dark"
+              placeholder="https://… or upload"
+            />
+            <label className="ce-upload" data-testid="catalog-edit-icon-dark-upload-label">
+              Upload
+              <input
+                type="file"
+                accept="image/*"
+                className="ce-file"
+                data-testid="catalog-edit-icon-dark-upload"
+                onChange={(e) => onPickIcon('dark', e.target.files?.[0])}
+              />
+            </label>
+          </div>
+        </div>
+
+        {error ? (
+          <p className="ce-error" data-testid="catalog-edit-error" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        <div className="ce-actions">
+          <button type="button" className="ce-btn ce-btn-ghost" onClick={onClose} disabled={saving}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="ce-btn ce-btn-primary"
+            onClick={onSave}
+            disabled={saving}
+            data-testid="catalog-edit-save"
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const CATALOG_EDIT_CSS = `
+.catalog-edit-backdrop {
+  position: fixed; inset: 0; z-index: 1000;
+  background: rgba(0,0,0,0.55);
+  display: flex; align-items: center; justify-content: center;
+  padding: 1rem;
+}
+.catalog-edit-dialog {
+  width: min(540px, 100%);
+  max-height: 90vh; overflow-y: auto;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  padding: 1.25rem;
+  display: flex; flex-direction: column; gap: 0.85rem;
+  box-shadow: 0 12px 48px rgba(0,0,0,0.35);
+}
+.ce-header { display: flex; align-items: center; justify-content: space-between; }
+.ce-title { margin: 0; font-size: 1.05rem; font-weight: 700; color: var(--color-text-strong); }
+.ce-close {
+  background: transparent; border: none; cursor: pointer;
+  font-size: 1.4rem; line-height: 1; color: var(--color-text-dim);
+}
+.ce-close:hover { color: var(--color-text); }
+.ce-field { display: flex; flex-direction: column; gap: 0.3rem; }
+.ce-label { font-size: 0.78rem; font-weight: 600; color: var(--color-text-strong); }
+.ce-input {
+  width: 100%; padding: 0.5rem 0.7rem;
+  background: var(--color-bg, var(--color-surface));
+  border: 1px solid var(--color-border); border-radius: 8px;
+  color: var(--color-text); font: inherit; font-size: 0.85rem;
+}
+.ce-input:focus { outline: 2px solid var(--color-accent); border-color: transparent; }
+.ce-textarea { resize: vertical; }
+.ce-topos { display: flex; flex-wrap: wrap; gap: 0.6rem; }
+.ce-topo { display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.8rem; cursor: pointer; color: var(--color-text); }
+.ce-topo-label { text-transform: none; }
+.ce-icon-row { display: flex; gap: 0.5rem; align-items: center; }
+.ce-icon-row .ce-input { flex: 1; }
+.ce-upload {
+  position: relative; flex: 0 0 auto;
+  padding: 0.5rem 0.8rem; border-radius: 8px;
+  border: 1px solid var(--color-border); background: transparent;
+  color: var(--color-text); font-size: 0.8rem; cursor: pointer; white-space: nowrap;
+}
+.ce-upload:hover { border-color: var(--color-accent); }
+.ce-file { position: absolute; inset: 0; opacity: 0; cursor: pointer; }
+.ce-error { margin: 0; color: var(--color-danger); font-size: 0.8rem; }
+.ce-actions { display: flex; justify-content: flex-end; gap: 0.6rem; margin-top: 0.4rem; }
+.ce-btn {
+  padding: 0.5rem 1.1rem; border-radius: 8px; border: 1px solid transparent;
+  font: inherit; font-size: 0.85rem; font-weight: 600; cursor: pointer;
+}
+.ce-btn:disabled { opacity: 0.6; cursor: wait; }
+.ce-btn-ghost { background: transparent; border-color: var(--color-border); color: var(--color-text); }
+.ce-btn-ghost:hover:not(:disabled) { border-color: var(--color-accent); }
+.ce-btn-primary { background: var(--color-accent); color: #fff; }
+.ce-btn-primary:hover:not(:disabled) { filter: brightness(0.92); }
+`

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogPage.edit.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogPage.edit.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * CatalogPage.edit.test.tsx — #3603 (EPIC #3597) lock-in for the admin
+ * catalog-edit affordance on the Catalog page.
+ *
+ * Walk-through (the ticket's acceptance, exercised here in jsdom):
+ *   • the per-card Edit button renders for an admin, NOT for a non-admin
+ *   • clicking Edit opens the form (name / topologies / icons)
+ *   • Save calls the #3602 API and the card reflects the new name live
+ *   • the theme-correct icon renders (light icon in light theme; dark in
+ *     dark theme)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, within, waitFor } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useWizardStore } from '@/entities/deployment/store'
+import { INITIAL_WIZARD_STATE } from '@/entities/deployment/model'
+import { NotificationProvider } from '@/shared/ui/notifications'
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+// Admin gate — flipped per-test via the mutable holder below.
+const adminHolder = { value: true }
+vi.mock('@/shared/lib/useCatalogAdmin', () => ({
+  useCatalogAdmin: () => adminHolder.value,
+}))
+
+// Commerce API — capture saveCatalogEdit calls + drive the edits overlay.
+// The impl returns the bare slug (as the real saveCatalogEdit does) and
+// references both args so no-unused-vars stays happy.
+const saveSpy = vi.fn((slug: string, edit: Record<string, unknown>): Promise<string> => {
+  void edit
+  return Promise.resolve(slug.replace(/^bp-/, ''))
+})
+const listAppsHolder: { value: Array<Record<string, unknown>> } = { value: [] }
+vi.mock('@/lib/commerce.api', () => ({
+  listApps: async () => listAppsHolder.value,
+  saveCatalogEdit: (slug: string, edit: Record<string, unknown>) => saveSpy(slug, edit),
+}))
+
+// Theme — flipped per-test.
+const themeHolder = { value: 'light' as 'light' | 'dark' }
+vi.mock('@/shared/lib/useTheme', () => ({
+  useTheme: () => ({ theme: themeHolder.value, toggle: () => {} }),
+}))
+
+// Import AFTER mocks so CatalogPage + AppCard pick up the mocked modules.
+import { CatalogPage } from './CatalogPage'
+
+function renderCatalog() {
+  const rootRoute = createRootRoute({
+    component: () => (
+      <NotificationProvider>
+        <Outlet />
+      </NotificationProvider>
+    ),
+  })
+  const catalogRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/catalog',
+    component: () => <CatalogPage />,
+  })
+  const catalogDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/catalog/$blueprintName',
+    component: () => <div data-testid="catalog-detail-target" />,
+  })
+  const tree = rootRoute.addChildren([catalogRoute, catalogDetailRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: ['/provision/d-1/catalog'] }),
+  })
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
+  adminHolder.value = true
+  themeHolder.value = 'light'
+  listAppsHolder.value = []
+  saveSpy.mockClear()
+  globalThis.fetch = (() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ apps: [] }),
+    } as unknown as Response)) as typeof fetch
+})
+
+afterEach(() => cleanup())
+
+describe('CatalogPage admin edit (#3603)', () => {
+  it('renders the Edit button on each catalog card for an admin', async () => {
+    renderCatalog()
+    // cilium is a bootstrap-kit card always present in the resolved catalog.
+    expect(await screen.findByTestId('sov-app-edit-bp-cilium')).toBeTruthy()
+  })
+
+  it('does NOT render the Edit button for a non-admin', async () => {
+    adminHolder.value = false
+    renderCatalog()
+    // The card renders, but no Edit button.
+    await screen.findByTestId('sov-app-card-bp-cilium')
+    expect(screen.queryByTestId('sov-app-edit-bp-cilium')).toBeNull()
+  })
+
+  it('opens the edit form (name / topologies / icons) on Edit click', async () => {
+    renderCatalog()
+    fireEvent.click(await screen.findByTestId('sov-app-edit-bp-cilium'))
+    const dialog = await screen.findByTestId('catalog-edit-dialog')
+    expect(within(dialog).getByTestId('catalog-edit-name')).toBeTruthy()
+    expect(within(dialog).getByTestId('catalog-edit-topologies')).toBeTruthy()
+    expect(within(dialog).getByTestId('catalog-edit-icon-light')).toBeTruthy()
+    expect(within(dialog).getByTestId('catalog-edit-icon-dark')).toBeTruthy()
+    // Topology multiselect exposes the canonical ALL_MODES options.
+    expect(within(dialog).getByTestId('catalog-edit-topo-single-region')).toBeTruthy()
+    expect(within(dialog).getByTestId('catalog-edit-topo-active-active')).toBeTruthy()
+    expect(within(dialog).getByTestId('catalog-edit-topo-active-hotstandby')).toBeTruthy()
+  })
+
+  it('saves the edit via the #3602 API with the typed body', async () => {
+    renderCatalog()
+    fireEvent.click(await screen.findByTestId('sov-app-edit-bp-cilium'))
+    const dialog = await screen.findByTestId('catalog-edit-dialog')
+    fireEvent.change(within(dialog).getByTestId('catalog-edit-name'), {
+      target: { value: 'Cilium (Edited)' },
+    })
+    fireEvent.click(within(dialog).getByTestId('catalog-edit-topo-active-active'))
+    fireEvent.change(within(dialog).getByTestId('catalog-edit-icon-dark'), {
+      target: { value: 'https://cdn/cilium-dark.svg' },
+    })
+    fireEvent.click(within(dialog).getByTestId('catalog-edit-save'))
+
+    await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(1))
+    const [slugArg, editArg] = saveSpy.mock.calls[0]
+    expect(slugArg).toBe('bp-cilium')
+    expect(editArg).toMatchObject({
+      name: 'Cilium (Edited)',
+      icon_dark: 'https://cdn/cilium-dark.svg',
+    })
+    expect(editArg.supported_topologies).toContain('active-active')
+  })
+
+  it('reflects a saved name on the card after the edits refetch', async () => {
+    renderCatalog()
+    await screen.findByTestId('sov-app-card-bp-cilium')
+    // After a save the edits query refetches; simulate the store now
+    // carrying the renamed cilium row, then trigger the dialog save path.
+    listAppsHolder.value = [{ slug: 'cilium', name: 'Cilium (Renamed)' }]
+    fireEvent.click(screen.getByTestId('sov-app-edit-bp-cilium'))
+    fireEvent.click(await screen.findByTestId('catalog-edit-save'))
+    // editsQuery.refetch() re-reads listApps → the card title updates.
+    await waitFor(() => {
+      const card = screen.getByTestId('sov-app-card-bp-cilium')
+      expect(within(card).getByText('Cilium (Renamed)')).toBeTruthy()
+    })
+  })
+
+  it('renders the light icon in light theme and the dark icon in dark theme', async () => {
+    // Seed an edited cilium row carrying both theme icons.
+    listAppsHolder.value = [
+      {
+        slug: 'cilium',
+        name: 'Cilium',
+        icon_light: 'https://cdn/cilium-light.svg',
+        icon_dark: 'https://cdn/cilium-dark.svg',
+      },
+    ]
+
+    // Light theme → light icon.
+    themeHolder.value = 'light'
+    const { unmount } = renderCatalog()
+    await waitFor(() => {
+      const img = screen.getByTestId('sov-app-icon-bp-cilium') as HTMLImageElement
+      expect(img.getAttribute('src')).toBe('https://cdn/cilium-light.svg')
+    })
+    unmount()
+    cleanup()
+
+    // Dark theme → dark icon.
+    themeHolder.value = 'dark'
+    renderCatalog()
+    await waitFor(() => {
+      const img = screen.getByTestId('sov-app-icon-bp-cilium') as HTMLImageElement
+      expect(img.getAttribute('src')).toBe('https://cdn/cilium-dark.svg')
+    })
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogPage.tsx
@@ -28,10 +28,27 @@ import { authedFetch } from '@/shared/lib/authedFetch'
 import { useWizardStore } from '@/entities/deployment/store'
 import { PortalShell } from './PortalShell'
 import { AppCard } from './AppsPage'
+import { CatalogEditDialog } from './CatalogEditDialog'
 import { resolveApplications, type ApplicationDescriptor } from './applicationCatalog'
 import type { ApplicationStatus } from './eventReducer'
+import { useCatalogAdmin } from '@/shared/lib/useCatalogAdmin'
+import { listApps, type CommerceApp } from '@/lib/commerce.api'
 
 const DEFAULT_APP_ENVIRONMENT = 'dev'
+
+/**
+ * #3603 (EPIC #3597) — the admin-editable overlay for one catalog entry,
+ * read from the SME commerce store (the same rows the #3602 read API
+ * overlays onto the seed). Keyed by bare slug; drives the card's live name
+ * + theme icons and the edit form's initial values.
+ */
+interface CatalogEditOverlay {
+  name: string
+  summary: string
+  supportedTopologies: string[]
+  iconLight: string
+  iconDark: string
+}
 
 interface CatalogLiveData {
   statusById: Record<string, ApplicationStatus>
@@ -121,6 +138,42 @@ export function CatalogPage() {
   const externalURLById = liveQuery.data?.externalURLById ?? {}
   const refetchLive = liveQuery.refetch
 
+  // #3603 (EPIC #3597) — admin gate for the per-card Edit affordance. The
+  // write path is gated server-side too; this is the matching UI gate.
+  const isAdmin = useCatalogAdmin()
+
+  // #3603 — the admin-editable overlay (name / summary / topologies / theme
+  // icons) per bare slug, read from the SME commerce store. Drives the
+  // card's live name + icon and the edit form's initial values. Refetched
+  // after a save so the card updates without a full reload. Best-effort:
+  // when the SME catalog isn't deployed the list 404s/throws and the map is
+  // empty — cards then render their build-time logo + seed name.
+  const editsQuery = useQuery<Record<string, CatalogEditOverlay>>({
+    queryKey: ['catalog-admin-edits'],
+    retry: false,
+    staleTime: 30_000,
+    queryFn: async () => {
+      const apps = await listApps()
+      const bySlug: Record<string, CatalogEditOverlay> = {}
+      for (const a of apps as CommerceApp[]) {
+        const slug = (a.slug ?? '').replace(/^bp-/, '')
+        if (!slug) continue
+        bySlug[slug] = {
+          name: a.name ?? '',
+          summary: a.tagline ?? '',
+          supportedTopologies: a.supported_topologies ?? [],
+          iconLight: a.icon_light ?? '',
+          iconDark: a.icon_dark ?? '',
+        }
+      }
+      return bySlug
+    },
+  })
+  const editsBySlug = editsQuery.data ?? {}
+
+  // The catalog entry currently open in the edit dialog (null = closed).
+  const [editing, setEditing] = useState<ApplicationDescriptor | null>(null)
+
   const [query, setQuery] = useState('')
 
   const visibleApps = useMemo<ApplicationDescriptor[]>(() => {
@@ -173,10 +226,22 @@ export function CatalogPage() {
               : null
             const environment = environmentById[app.id] ?? DEFAULT_APP_ENVIRONMENT
             const externalURL = externalURLById[app.id] ?? ''
+            // #3603 — apply the admin edit (name + summary) onto the card
+            // descriptor so a saved rename shows live; the theme icons flow
+            // through the dedicated AppCard props below.
+            const edit = editsBySlug[slug]
+            const cardApp =
+              edit && (edit.name || edit.summary)
+                ? {
+                    ...app,
+                    title: edit.name || app.title,
+                    description: edit.summary || app.description,
+                  }
+                : app
             return (
               <AppCard
                 key={app.id}
-                app={app}
+                app={cardApp}
                 isCatalog
                 environment={environment}
                 externalURL={externalURL}
@@ -189,6 +254,9 @@ export function CatalogPage() {
                 isService={false}
                 marketplacePublished={published}
                 slug={slug}
+                iconLight={edit?.iconLight}
+                iconDark={edit?.iconDark}
+                onEdit={isAdmin ? () => setEditing(app) : undefined}
                 onPublishedChange={async (next) => {
                   const r = await authedFetch(
                     `${API_BASE}/v1/sovereign/apps/${encodeURIComponent(slug)}/publish`,
@@ -209,6 +277,31 @@ export function CatalogPage() {
           })}
         </div>
       )}
+
+      {/* #3603 — the admin edit form. Mounted only while an entry is being
+       * edited; saving persists via the #3602 API and refetches the edits
+       * map so the card reflects the new name + icon live. */}
+      {editing ? (
+        <CatalogEditDialog
+          blueprintId={editing.id}
+          initial={(() => {
+            const slug = editing.id.replace(/^bp-/, '')
+            const e = editsBySlug[slug]
+            return {
+              name: e?.name || editing.title,
+              summary: e?.summary || editing.description || '',
+              supportedTopologies: e?.supportedTopologies ?? [],
+              iconLight: e?.iconLight ?? '',
+              iconDark: e?.iconDark ?? '',
+            }
+          })()}
+          onClose={() => setEditing(null)}
+          onSaved={async () => {
+            setEditing(null)
+            await editsQuery.refetch()
+          }}
+        />
+      ) : null}
     </PortalShell>
   )
 }
@@ -363,6 +456,28 @@ const CATALOG_PAGE_CSS = `
 .open-chip:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
 .open-chip:disabled { opacity: 0.6; cursor: wait; }
 .open-chip svg { display: block; }
+/* #3603 — admin "Edit" pill on the catalog card (sovereign-admin only). */
+.edit-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.18rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 1.4;
+  font-family: inherit;
+  cursor: pointer;
+  pointer-events: auto;
+  background: color-mix(in srgb, var(--color-text-strong) 8%, transparent);
+  color: var(--color-text-strong);
+  transition: filter 120ms ease, transform 120ms ease, border-color 120ms ease;
+}
+.edit-chip:hover { border-color: var(--color-accent); transform: translateY(-1px); }
+.edit-chip:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+.edit-chip svg { display: block; }
 .publish-chip {
   display: inline-flex;
   align-items: center;

--- a/products/catalyst/bootstrap/ui/src/shared/lib/useCatalogAdmin.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/useCatalogAdmin.ts
@@ -1,0 +1,47 @@
+/**
+ * useCatalogAdmin — #3603 (EPIC #3597): is the current operator allowed to
+ * EDIT catalog entries?
+ *
+ * The catalog-edit write path (PUT/POST /api/v1/sme/commerce/apps → the SME
+ * commerce catalog's /catalog/admin/* CRUD) is gated SERVER-SIDE on
+ * superadmin OR sovereign-admin (core/services/catalog requireAdmin). This
+ * hook is the matching UI gate so a non-admin operator never sees the Edit
+ * affordance in the first place — it does NOT replace the server gate.
+ *
+ * The tier derivation mirrors AppDetail's #3375 `callerTier` verbatim
+ * (prefer the explicit `tier` claim, else map the catalyst-<tier> realm
+ * roles whoami returns) so "who is an admin" is computed identically
+ * everywhere. A sovereign-admin operator authenticates with tier `admin`
+ * or `owner` (the catalyst-owner / catalyst-admin realm roles).
+ */
+
+import { useMemo } from 'react'
+import { useSession } from './useSession'
+
+/**
+ * deriveCallerTier — the canonical tier resolution shared with AppDetail
+ * (#3375). Exported so a component that already holds a SessionState can
+ * reuse it without a second useSession call.
+ */
+export function deriveCallerTier(tier: string, roles: string[]): string {
+  if (tier) return tier
+  const lower = roles.map((r) => r.toLowerCase())
+  if (lower.includes('catalyst-owner')) return 'owner'
+  if (lower.includes('catalyst-admin')) return 'admin'
+  if (lower.includes('catalyst-operator')) return 'operator'
+  if (lower.includes('catalyst-developer')) return 'developer'
+  if (lower.includes('catalyst-viewer')) return 'viewer'
+  return ''
+}
+
+/**
+ * useCatalogAdmin returns true when the operator's tier is `admin` or
+ * `owner` — the sovereign-admin tier the catalog-edit write path requires.
+ */
+export function useCatalogAdmin(): boolean {
+  const session = useSession()
+  return useMemo(() => {
+    const tier = deriveCallerTier(session.tier, session.roles)
+    return tier === 'admin' || tier === 'owner'
+  }, [session.tier, session.roles])
+}


### PR DESCRIPTION
## What

Implements **EPIC #3597** founder point 3 — the **editable catalog** — in the **DEPLOYED** Sovereign console surfaces only: `core/services/catalog` (the store), `products/catalyst/bootstrap/api` (the read API overlay), and `products/catalyst/bootstrap/ui` (the admin-edit UI). Does **not** touch `core/console`.

Two granular children, both walkable:

### #3602 — data-backed, admin-editable catalog (overlay over the seed)
The Catalog page reads `GET /api/v1/catalog`, which catalyst-api serves from the chart **seed** (`templates/catalog-seed/blueprints.yaml` via the in-cluster Blueprint-CR fallback). That seed is now **overlaid by the persisted admin edits** from the SME commerce catalog store — an edit wins, an un-edited entry keeps the seed (additive, no data loss).

- **`store.App`** (`core/services/catalog`): adds `SupportedTopologies []string`, `IconLight`, `IconDark` (keeps the legacy single `Icon` for back-compat); persisted in `UpdateApp`'s full `$set` so an edit survives a service restart (FerretDB is durable).
- **catalyst-api** (`bootstrap/api/internal/handler`):
  - `catalog_overlay.go` — `overlayCatalogEdits` (pure, additive merge keyed by normalized `bp-`-stripped name) + `fetchCatalogEdits` (reads the store's public `GET /catalog/apps`, **best-effort**: empty map when the SME catalog isn't deployed → seed passes through unchanged).
  - `HandleCatalogList` + `HandleCatalogGet` apply the overlay; the wire shape gains `card.iconLight` / `card.iconDark` + top-level `supportedTopologies`.
  - `smeCatalogTestOverride` seam so the overlay is unit-testable without a live network.

### #3603 — admin edits name, topologies, light/dark icons
- The `/catalog` page (the #3604 `CatalogPage`) gains an **admin-only Edit** affordance per card → an edit form: **display name**, **summary**, **supported topologies** (multiselect, reusing `TopologyEditor`'s exported `ALL_MODES` + `describeMode` — no divergent vocab), **light icon** (URL or upload→`data:` URI), **dark icon** (same).
- **Save** persists via the #3602 API (`saveCatalogEdit` → merges onto the full store row and `PUT`s by `_id`, or `POST`s a new row — no column lost); the card reflects the new **name + icon live** and the edit **survives a reload** (overlay).
- Icons render **per console theme** — light icon in light theme, dark icon in dark (`AppCard` reads `useTheme`). Non-admins (and the Deployments grid) never see Edit.
- `useCatalogAdmin` gates the UI on tier `admin`/`owner` (mirrors AppDetail's #3375 `callerTier`); the write path is gated **server-side** too (`requireAdmin` → superadmin/sovereign-admin).

## Tests
- **Go (`core/services/catalog`)**: `store.App` bson round-trip for the new fields (+ omitempty contract).
- **Go (`bootstrap/api`)**: edit overlays the seed; un-edited entry returns the seed; empty store fields never clobber the seed; graceful when the catalog is absent; end-to-end through `HandleCatalogList`. Full handler suite green.
- **UI (`bootstrap/ui`)**: Edit renders for admin / not for non-admin; form opens (name/topologies/icons); save calls the API with the typed body; the card reflects the saved name; theme switch shows the right icon. Full production `npm run build` + typecheck green; existing `CatalogPage` / `AppsPage` tests still pass.

## Stacking
Branched on **#3604** (`worktree-agent-ab356cff7d9185372`) because #3603 builds the Edit affordance on the `CatalogPage` #3604 introduces. Review/merge #3604 first (or together). #3602 (store + API overlay) is independent of #3604.

## Notes
- Smallest correct, fully **additive** overlay — never breaks the static seed; reuses the existing `/api/v1/sme/commerce/apps` proxy + the TopologyEditor option-set rather than reinventing.
- Do **not** merge — catalyst-ui/api roll the mothership; orchestrator reviews.

Refs #3602 #3603 #3597

🤖 Generated with [Claude Code](https://claude.com/claude-code)
