### PR TITLE
fix(bp-self-sovereign-cutover): mirror-resync CronJob defaults enabled:false — IaC severance, not imperative HR patch (0.1.66) (#3606)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -523,7 +523,16 @@ spec:
       # seen_local_ready)` so the post-convergence 0/0 terminates-success while
       # a first-poll 0/0 (pivot never happened) still waits — preserving the
       # 0.1.63 strip-before-pivot half-pivot guard.
-      version: 0.1.65
+      # 0.1.66 (#3606): step-01 G75 wedged in a retry loop — its imperative
+      # `kubectl patch hr ... mirrorResync.enabled=false` was reverted by Flux
+      # every reconcile (the HR is git-owned, values default was `true`),
+      # re-rendering the gitea-mirror-resync CronJob → G75's 6-min post-verify
+      # FATAL'd on the reappeared CronJob → step-01 never advanced. Fix:
+      # mirrorResync.enabled default flips `true` → `false` (the IaC default IS
+      # the severance — template 11 renders nothing, Principle 14) + the G75
+      # block becomes idempotent/fast-path (skip the hold when no CronJob
+      # exists). Chart-only.
+      version: 0.1.66
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.65
+  version: 0.1.66
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -639,7 +639,33 @@ name: bp-self-sovereign-cutover
 # strip-before-pivot fix exists to prevent). A genuine half-pivot (HRs stuck
 # not-Ready, latch never set) still spins to the deadline and correctly REFUSES
 # the strip. Smallest correct fix; no step-count / RBAC / timeout change.
-version: 0.1.65
+# 0.1.66 (#3606, Refs #3568 #3379, hw144 step-01 loops-forever at G75 2026-06-16):
+# Cutover step-01 (gitea-mirror) wedged in a retry loop at sub-step G75 (sever
+# upstream git tether). The G75 finalize block ran an IMPERATIVE
+# `kubectl patch hr -n flux-system bp-self-sovereign-cutover ...
+# mirrorResync.enabled=false`. Flux OWNS that HelmRelease from git, where
+# values.yaml mirrorResync.enabled defaulted to `true`, so Flux REVERTED the
+# patch on its next reconcile (~4 min) and re-rendered the gitea-mirror-resync
+# CronJob (gated `{{- if .Values.mirrorResync.enabled }}` in template
+# 11-mirror-resync-cronjob.yaml). G75's 6-min post-verify hold then saw the
+# CronJob present again → "G75 FATAL: cronjob reappeared" → step-01 failed and
+# auto-retried forever; steps 02-11 never ran. A 5-min github re-clone CronJob
+# is ALSO fundamentally incompatible with Pillar 5 — it would breach the
+# step-08 600s deny-egress hold.
+# FIX (chart-only, no step-count / RBAC / timeout change):
+#   (1) values.yaml mirrorResync.enabled default flips `true` → `false`. The
+#       IaC default `false` IS the severance — template 11 renders nothing, so
+#       there is no CronJob for Flux to revert (Principle 14: severance lives
+#       in git, irreversible). A pre-cutover Sovereign that wants the
+#       upstream-resync loop opts IN via an operator overlay.
+#   (2) Step-01 G75 block (template 01-gitea-mirror-job.yaml) becomes
+#       idempotent/fast-path: if the gitea-mirror-resync CronJob does not
+#       exist it logs "already severed at IaC layer" and skips the wasteful
+#       6-min hold; the imperative patch + live-delete + post-verify dance is
+#       preserved INSIDE the else branch for any rendered remnant (overlay
+#       opt-in). Step-01 no longer self-defeatingly patches the Flux-owned HR
+#       on the default path.
+version: 0.1.66
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
@@ -278,27 +278,42 @@ data:
             # after live delete), THEN live delete, THEN post-verify
             # waits ≥1 mirror-resync interval to confirm the tether stays
             # severed.
-            echo "[gitea-mirror] G75: severing upstream git tether (delete mirror-resync CronJob)"
-            kubectl patch hr -n flux-system bp-self-sovereign-cutover \
-              --type=merge \
-              -p '{"spec":{"values":{"mirrorResync":{"enabled":false}}}}' 2>&1 || \
-              echo "[gitea-mirror] G75 WARN: HR patch failed (cronjob will recreate after delete unless chart conditional gates it)"
+            # G75 #3606 fast-path: with mirrorResync.enabled defaulting to
+            # false (values.yaml), template 11-mirror-resync-cronjob.yaml
+            # renders NOTHING — the gitea-mirror-resync CronJob never exists
+            # on a default Sovereign, so the tether is already severed at the
+            # IaC (git) layer. The old imperative `kubectl patch hr ...
+            # mirrorResync.enabled=false` was the #3606 bug: Flux owns this
+            # HR from git and REVERTED the patch every reconcile, re-rendering
+            # the CronJob → this 6-min post-verify FATAL'd → step-01 looped.
+            # We no longer patch the HR. We only DELETE + post-verify a
+            # rendered remnant when one actually exists (an operator overlay
+            # may have opted IN to mirrorResync pre-cutover).
+            if ! kubectl get cronjob -n {{ .Release.Namespace }} gitea-mirror-resync >/dev/null 2>&1; then
+              echo "[gitea-mirror] G75 OK: mirror-resync already severed at IaC layer (mirrorResync.enabled=false default) — skipping live-delete + post-verify hold"
+            else
+              echo "[gitea-mirror] G75: severing upstream git tether (delete mirror-resync CronJob)"
+              kubectl patch hr -n flux-system bp-self-sovereign-cutover \
+                --type=merge \
+                -p '{"spec":{"values":{"mirrorResync":{"enabled":false}}}}' 2>&1 || \
+                echo "[gitea-mirror] G75 WARN: HR patch failed (cronjob will recreate after delete unless chart conditional gates it)"
 
-            kubectl delete cronjob -n {{ .Release.Namespace }} gitea-mirror-resync --ignore-not-found=true 2>&1 || \
-              echo "[gitea-mirror] G75 WARN: cronjob delete failed (RBAC?)"
+              kubectl delete cronjob -n {{ .Release.Namespace }} gitea-mirror-resync --ignore-not-found=true 2>&1 || \
+                echo "[gitea-mirror] G75 WARN: cronjob delete failed (RBAC?)"
 
-            # Post-verify: wait 6min (>1 mirror-resync interval) + confirm
-            # CronJob still absent + confirm local Gitea HEAD unchanged.
-            CRONJOB_NS={{ .Release.Namespace }}
-            for i in $(seq 1 6); do
-              sleep 60
-              if kubectl get cronjob -n "${CRONJOB_NS}" gitea-mirror-resync >/dev/null 2>&1; then
-                echo "[gitea-mirror] G75 FATAL: cronjob reappeared at ${i}min — Flux re-reconciled despite HR patch (template not conditional?)"
-                exit 1
-              fi
-              echo "[gitea-mirror] G75 post-verify (${i}/6): cronjob still absent"
-            done
-            echo "[gitea-mirror] G75 OK: upstream git tether severed (cronjob deleted + HR patched + 6min hold confirmed no recreate)"
+              # Post-verify: wait 6min (>1 mirror-resync interval) + confirm
+              # CronJob still absent + confirm local Gitea HEAD unchanged.
+              CRONJOB_NS={{ .Release.Namespace }}
+              for i in $(seq 1 6); do
+                sleep 60
+                if kubectl get cronjob -n "${CRONJOB_NS}" gitea-mirror-resync >/dev/null 2>&1; then
+                  echo "[gitea-mirror] G75 FATAL: cronjob reappeared at ${i}min — Flux re-reconciled despite HR patch (template not conditional?)"
+                  exit 1
+                fi
+                echo "[gitea-mirror] G75 post-verify (${i}/6): cronjob still absent"
+              done
+              echo "[gitea-mirror] G75 OK: upstream git tether severed (cronjob deleted + HR patched + 6min hold confirmed no recreate)"
+            fi
 
             echo "[gitea-mirror] step complete"
         resources:

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -481,20 +481,27 @@ status:
 # are no-ops (the script detects the local repo is missing and exits
 # 0). Post-cutover fires close the upstream → local Gitea loop.
 mirrorResync:
-  # G75 #2622 (2026-05-31): MASTER SEVERANCE SWITCH. When `enabled:
-  # false`, the entire 11-mirror-resync-cronjob.yaml template renders
-  # to nothing — Flux won't recreate the CronJob after cutover Step 01
-  # deletes the live resource. This is the IaC half of the B' shape:
-  # IaC removal (this flag flips false via HR patch from Step 01) +
-  # live DELETE (Step 01) + post-verify hold (Step 01). Suspend is NOT
-  # equivalent per Principle 14 — a suspended cronjob is a future drift
-  # trap, severance must be irreversible at the IaC layer.
+  # G75 #2622 / #3606 (2026-06-16): MASTER SEVERANCE SWITCH. When
+  # `enabled: false`, the entire 11-mirror-resync-cronjob.yaml template
+  # renders to nothing — no `gitea-mirror-resync` CronJob ever exists on
+  # the Sovereign. THE IaC DEFAULT `false` IS THE SEVERANCE: per
+  # Principle 14 severance must live in git and be irreversible, and a
+  # CronJob that is never rendered cannot drift back. There is nothing
+  # for Flux to revert.
   #
-  # The chart default stays `true` because pre-cutover Sovereigns need
-  # the resync loop to pick up chart-bumps from upstream. Step 01 of
-  # bp-self-sovereign-cutover flips it to `false` via HR patch on the
-  # post-handover pivot.
-  enabled: true
+  # #3606 root-cause: the old default was `true` and cutover Step 01's
+  # G75 finalize block ran an IMPERATIVE `kubectl patch hr ... mirror
+  # Resync.enabled=false`. Flux OWNS this HelmRelease from git (where the
+  # value was `true`), so it REVERTED the patch on its very next
+  # reconcile (~4 min) and re-rendered the CronJob → Step 01's 6-min
+  # post-verify hold then saw the CronJob present again → G75 FATAL →
+  # step-01 looped forever and the cutover never advanced past step-01.
+  # A 5-min github re-clone CronJob is ALSO fundamentally incompatible
+  # with Pillar 5 — it would breach the Step-08 600s deny-egress hold.
+  # So the resync CronJob is now OFF by default; a pre-cutover Sovereign
+  # that wants the upstream-resync loop opts IN via an operator overlay
+  # (`mirrorResync.enabled: true`), and Step 01 no longer patches the HR.
+  enabled: false
   # Cron schedule. */5 = every 5 minutes. Short enough that chart-bump
   # → upstream-merge → Sovereign-reconcile completes in ~10 min end-
   # to-end (5 min for this CronJob to fire + the bp-* HelmRepository's


### PR DESCRIPTION
## Diagnosis (#3606)

Cutover **step-01 gitea-mirror** wedges in a retry loop at sub-step **G75 (sever upstream git tether)**. The G75 finalize block in `01-gitea-mirror-job.yaml` ran an **imperative** `kubectl patch hr -n flux-system bp-self-sovereign-cutover -p '{"spec":{"values":{"mirrorResync":{"enabled":false}}}}'`. Flux **owns** that HelmRelease from git — where `values.yaml` `mirrorResync.enabled` defaulted to `true` — so Flux **reverted** the patch on its next reconcile (~4 min) and re-rendered the `gitea-mirror-resync` CronJob (gated `{{- if .Values.mirrorResync.enabled }}` in `11-mirror-resync-cronjob.yaml`). G75's 6-min post-verify hold then saw the CronJob present again → `G75 FATAL: cronjob reappeared` → step-01 failed and auto-retried forever; steps 02-11 never ran.

A 5-min github re-clone CronJob is also fundamentally incompatible with Pillar 5 — it would breach the step-08 600s deny-egress hold.

## The fix (chart-only `bp-*`, no step-count / RBAC / timeout change)

1. **`chart/values.yaml`** — `mirrorResync.enabled` default flips `true` → `false`. The IaC default `false` **is** the severance: template `11-mirror-resync-cronjob.yaml` renders nothing, so no CronJob exists for Flux to revert (Principle 14 — severance lives in git, irreversible). A pre-cutover Sovereign that wants the upstream-resync loop opts IN via an operator overlay. Comment rewritten to the corrected rationale; `schedule` / `suspended` / `jobTimeoutSeconds` keys preserved.

2. **`chart/templates/01-gitea-mirror-job.yaml`** — the G75 block is now idempotent / fast-path. It checks `kubectl get cronjob gitea-mirror-resync` first: if absent it logs `G75 OK: mirror-resync already severed at IaC layer` and skips the wasteful 6-min hold. The original patch + live-delete + 6-min post-verify dance is preserved inside the `else` branch for any rendered remnant (overlay opt-in). The self-defeating HR patch no longer runs on the default path.

3. **`chart/Chart.yaml`** + **`blueprint.yaml`** — `version` bumped `0.1.65` → `0.1.66` (lockstep; both match, avoiding the Chart.yaml-vs-blueprint.yaml drift that bit #3589).

4. **`clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml`** — chart version pin bumped `0.1.65` → `0.1.66`.

## Proof

```
$ helm template ssc platform/self-sovereign-cutover/chart | grep -E '^kind: CronJob'
NONE (no kind: CronJob in render)
$ helm template ssc platform/self-sovereign-cutover/chart | grep -c '^kind:'
20
```

With default values the chart renders **zero** `kind: CronJob` — `gitea-mirror-resync` no longer renders. (The residual `gitea-mirror-resync` string matches are the step-01 Job's embedded shell comments + its fast-path `kubectl get cronjob` check + the RBAC delete verb, not a rendered resource.)

```
$ helm lint platform/self-sovereign-cutover/chart
1 chart(s) linted, 0 chart(s) failed
```

Refs #3606 Refs #3568 Refs #3379
