### PR TITLE
fix(bp-self-sovereign-cutover): right-size step-03 harbor-prewarm CPU 500m→100m — unschedulable on tight cluster (0.1.67)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -532,7 +532,12 @@ spec:
       # the severance — template 11 renders nothing, Principle 14) + the G75
       # block becomes idempotent/fast-path (skip the hold when no CronJob
       # exists). Chart-only.
-      version: 0.1.66
+      # 0.1.67 (#3608, Refs #3568): step-03 harbor-prewarm requested 500m CPU,
+      # unschedulable on a tight Sovereign (every node 89–99% CPU-requested →
+      # Pending 22+ min, FailedScheduling Insufficient cpu — live hw145). It is
+      # a skopeo image-copy Job (I/O-bound, not CPU-bound); right-sized the CPU
+      # request 500m → 100m. Memory stays 512Mi. Chart-only.
+      version: 0.1.67
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.66
+  version: 0.1.67
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -665,7 +665,18 @@ name: bp-self-sovereign-cutover
 #       preserved INSIDE the else branch for any rendered remnant (overlay
 #       opt-in). Step-01 no longer self-defeatingly patches the Flux-owned HR
 #       on the default path.
-version: 0.1.66
+# 0.1.67 (#3608, Refs #3568 #3379, hw145 step-03 unschedulable 2026-06-16):
+# Step-03 (harbor-prewarm) could not schedule. Its Pod requested 500m CPU
+# (G66, when the step gained skopeo image-copy work), but on a tight Sovereign
+# every node ran 89–99% CPU-requested (only ~424m free on the best node) → the
+# Pod sat Pending 22+ min with FailedScheduling "Insufficient cpu" and the
+# cutover stalled at step-03. harbor-prewarm is a skopeo image-copy Job —
+# I/O-bound (streaming image layers), NOT CPU-bound; every OTHER cutover step
+# Job requests only 25–100m CPU. FIX (chart-only, template
+# 03-harbor-prewarm-job.yaml): right-size requests.cpu 500m → 100m. Memory
+# stays 512Mi (skopeo needs the RAM for layer buffers) and the limits block is
+# unchanged. No step-count / RBAC / timeout change.
+version: 0.1.67
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -344,8 +344,15 @@ data:
               exit 1
             fi
         resources:
-          # G66: bump for skopeo image-copy work (downloads layers).
-          requests: { cpu: 500m, memory: 512Mi }
+          # G66: bump MEMORY for skopeo image-copy work (downloads layers).
+          # #3608 (Refs #3568): the 500m CPU request was unschedulable on a
+          # tight Sovereign (every node 89–99% CPU-requested → Pending 22+ min,
+          # FailedScheduling Insufficient cpu — live hw145). harbor-prewarm is a
+          # skopeo image-copy Job (I/O-bound, not CPU-bound); right-size the CPU
+          # request to 100m (in line with every other cutover step Job, which
+          # request 25–100m). Memory stays 512Mi — skopeo needs the RAM for
+          # layer buffers.
+          requests: { cpu: 100m, memory: 512Mi }
           limits:   { memory: 2Gi }
         securityContext:
           runAsNonRoot: true


### PR DESCRIPTION
Chart-only `bp-self-sovereign-cutover` fix. Verified live on hw145.

## Problem
Cutover **step-03 (harbor-prewarm)** cannot schedule. Its Pod requests **500m CPU**, but every node on the prov runs **89–99% CPU-requested** (only ~424m free on the best node), so the Pod sits **Pending 22+ min** with `FailedScheduling: Insufficient cpu` and the cutover stalls at step-03.

harbor-prewarm is a skopeo image-copy Job — **I/O-bound, not CPU-bound** (it streams image layers ghcr.io→local Harbor). The `requests.cpu: 500m` (set under G66 when the step gained skopeo copy work) is oversized for a tight Sovereign. Every other cutover step Job requests only 25–100m CPU. The CPU floor is the only problem — the 512Mi memory request is legitimate (skopeo needs the RAM for layer buffers).

## Fix
- `platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml`: `requests.cpu` **500m → 100m** (memory unchanged at 512Mi; `limits` block unchanged).
- Chart bumped **0.1.66 → 0.1.67** in lockstep across `Chart.yaml`, `blueprint.yaml` (`spec.version`), and `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` (chart pin).

No step-count / RBAC / timeout change.

## Validation
- `helm template platform/self-sovereign-cutover/chart` renders the step-03 harbor-prewarm Job with `requests: { cpu: 100m, memory: 512Mi }`; zero residual `cpu: 500m` in the rendered output.
- `helm lint` passes (0 failures).
- All three version-bearing files at `0.1.67` (CI drift gate satisfied).

## DoD
On the next fresh prov cutover walk, step-03 schedules (no `Insufficient cpu`) and runs to completion.

Refs #3608 Refs #3568 Refs #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)