### PR TITLE
fix(bp-openbao): Continuum CR fails Helm install in secondary region — CRD-race, Capabilities-guard it (1.2.43)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -96,7 +96,15 @@ spec:
       # gitea hang → catalyst-platform ✗ → console 000 (hw144). $credNs now
       # defaults to the release ns (where the CronJob's secretKeyRef reads the
       # creds anyway). Default-OFF path unchanged; pin in lockstep.
-      version: 1.2.42
+      # 1.2.43 (#3612 #3568): Capabilities-guard the Continuum CR so `helm
+      # install bp-openbao` no longer FAILS in the SECONDARY region. The CR
+      # (dr.openova.io/v1) renders on role=secondary, but its CRD ships with
+      # bp-catalyst-platform (slot 13), which is primary-suspended in region-B
+      # → CRD absent → `no matches for kind "Continuum"` (hw145 region-b),
+      # cascading into sso-bridge/gitea/harbor/oidc-gate/newapi/powerdns-admin.
+      # Render now gated on .Capabilities.APIVersions.Has "dr.openova.io/v1"
+      # (gold-standard pattern). Single-region byte-identical; pin in lockstep.
+      version: 1.2.43
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.42
+  version: 1.2.43
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -85,7 +85,30 @@ name: bp-openbao
 # render is byte-identical; the only enabled-path change is the RBAC namespace.
 # tests/snapshot-replication-toggle.sh Case 2 gains a no-orphan-namespace +
 # Role-present assertion. No upstream subchart change.
-version: 1.2.42
+# 1.2.43 (#3612 / #3568, 2026-06-16): Capabilities-guard the Continuum CR so
+# `helm install bp-openbao` no longer FAILS in the SECONDARY region of a
+# 2-region prov. templates/continuum.yaml renders the `cont-openbao`
+# Continuum CR (dr.openova.io/v1) when continuum.enabled=true AND
+# snapshotReplication.role=secondary — i.e. ON the standby (region-B). But the
+# `continuums.dr.openova.io` CRD ships ONLY with bp-catalyst-platform
+# (products/catalyst/chart/crds/continuum.yaml, slot 13) — NOT with
+# bp-continuum (its crds/ is intentionally empty) — and slot 13 is
+# region-role=primary + SUSPENDED on every secondary CP (SECONDARY_HR_SUSPEND),
+# so the CRD is NEVER installed in region-B. Result on hw145 region-b: `helm
+# install bp-openbao` failed `no matches for kind "Continuum" in version
+# "dr.openova.io/v1"`, cascading into external-secrets-stores → sso-bridge /
+# gitea / harbor / oidc-gate / newapi / powerdns-admin. The render is now
+# gated on `.Capabilities.APIVersions.Has "dr.openova.io/v1"` (gold-standard
+# CRD-race pattern, cf bp-external-dns / #2988 / #3102): openbao installs
+# WITHOUT the CR when the CRD is absent; the CR is added on the next Flux
+# reconcile if/when the CRD lands. A `dependsOn bp-catalyst-platform` was NOT
+# used — that dep is deliberately suspended in region-B and would deadlock
+# region-B openbao forever; the Capabilities guard is the only correct fix.
+# Default + single-region render stays byte-identical (the gated keys still
+# render nothing). tests/continuum-render.sh Case 3 now passes
+# `--api-versions dr.openova.io/v1`; new Case 4 proves the guard skips the CR
+# (no install failure) when the CRD is absent. No upstream subchart change.
+version: 1.2.43
 # 1.2.37 (#3374, 2026-06-14): fix the sso-landing nginx ImagePullBackOff. The
 # image was `harbor.openova.io/proxy-docker/library/nginx` but the live Harbor
 # DockerHub proxy-cache project is `proxy-dockerhub` (proxy-docker does NOT

--- a/platform/openbao/chart/templates/continuum.yaml
+++ b/platform/openbao/chart/templates/continuum.yaml
@@ -20,21 +20,45 @@ case. THIS Continuum CR tells the engine HOW to promote bp-openbao (the
 mechanism) and WHERE (the standby Pod target + raft data dir).
 
 🛑 Skip-render (per #402 — never `{{ fail }}`): the CR renders ONLY when
-BOTH `.Values.continuum.enabled=true` AND
-`.Values.snapshotReplication.role=secondary`. The Continuum CR describes
-promotion of the STANDBY → primary, so it belongs on the standby (region-B)
-cluster; the active (region-A) cluster does not host it. A default `helm
-template` is byte-identical to origin/main (gated keys render nothing).
+ALL THREE hold — `.Values.continuum.enabled=true`,
+`.Values.snapshotReplication.role=secondary`, AND the `dr.openova.io/v1`
+CRD is registered in the target cluster (`.Capabilities.APIVersions.Has`).
+The Continuum CR describes promotion of the STANDBY → primary, so it belongs
+on the standby (region-B) cluster; the active (region-A) cluster does not
+host it. A default `helm template` is byte-identical to origin/main (gated
+keys render nothing).
+
+🛑 CRD-RACE GUARD (#3612 / #3568 — gold-standard pattern, cf bp-external-dns
+/ #2988 / #3102 harbor-ESO `.Capabilities` guard): the
+`continuums.dr.openova.io` CRD ships with bp-catalyst-platform
+(products/catalyst/chart/crds/continuum.yaml, slot 13) — NOT with
+bp-continuum (whose crds/ is intentionally empty). But slot 13 is
+region-role=primary and is SUSPENDED on every secondary control plane
+(`suspend: ${SECONDARY_HR_SUSPEND}`), so the Continuum CRD is NEVER
+installed in region-B. Yet THIS CR renders on the SECONDARY
+(role=secondary). Without the Capabilities guard, `helm install bp-openbao`
+in region-B FAILS with `no matches for kind "Continuum" in version
+"dr.openova.io/v1"` (verified live on hw145 region-b), cascading into
+external-secrets-stores → sso-bridge / gitea / harbor / oidc-gate / newapi
+/ powerdns-admin (all need openbao-backed secrets). The guard lets openbao
+install WITHOUT the CR when the CRD is absent; the CR is added on the next
+Flux reconcile if/when the CRD ever lands. NOTE: a `dependsOn
+bp-catalyst-platform` is NOT a viable alternative — that dep is deliberately
+suspended in region-B, so it would deadlock region-B openbao forever; the
+Capabilities guard is the only correct fix.
 
 The mechanism-agnostic lua-record / regions / hostnames blocks mirror the
 shape the bp-cnpg-pair Continuum CR uses (the working reference) so the
 flip-DNS step has a probe target + IP-set to write; per-Sovereign overlays
-fill the real region names + IPs.
+fill the real region names + IPs. (bp-cnpg-pair sidesteps this same race a
+different way — it renders its CR only on the PRIMARY side, where the CRD is
+present; openbao's DR contract genuinely belongs on the secondary, so it
+needs the Capabilities guard instead.)
 */}}
 {{- $c := .Values.continuum | default dict -}}
 {{- $sr := .Values.snapshotReplication | default dict -}}
 {{- $srRole := $sr.role | default "primary" -}}
-{{- if and $c.enabled (eq $srRole "secondary") -}}
+{{- if and $c.enabled (eq $srRole "secondary") (.Capabilities.APIVersions.Has "dr.openova.io/v1") -}}
 {{- $rt := $c.raftTransition | default dict -}}
 {{- $lease := $c.leaseClient | default dict -}}
 {{- $leaseCfg := $lease.config | default dict -}}

--- a/platform/openbao/chart/tests/continuum-render.sh
+++ b/platform/openbao/chart/tests/continuum-render.sh
@@ -53,8 +53,13 @@ if grep -qE "^kind: Continuum$" "$TMP/primary.yaml"; then
 fi
 echo "  PASS"
 
-echo "[continuum-render] Case 3: continuum.enabled=true + role=secondary emits the raft-transition Continuum CR"
+echo "[continuum-render] Case 3: continuum.enabled=true + role=secondary + CRD registered emits the raft-transition Continuum CR"
+# --api-versions dr.openova.io/v1 simulates the CRD being present in the
+# target cluster (#3612 Capabilities guard). On a real secondary CP the CRD
+# is ABSENT (bp-catalyst-platform is primary-suspended there) — Case 4 below
+# proves the guard then skips the CR so the install still succeeds.
 helm template smoke-bao . \
+  --api-versions dr.openova.io/v1 \
   --set continuum.enabled=true \
   --set snapshotReplication.enabled=true \
   --set snapshotReplication.role=secondary \
@@ -99,6 +104,26 @@ if ! echo "$cr_block" | grep -q "applicationRef: openbao"; then
 fi
 if ! echo "$cr_block" | grep -q "hz-fsn-rtz-prod"; then
   echo "FAIL: Continuum CR did not wire the primaryRegion." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[continuum-render] Case 4 (#3612 CRD-race guard): role=secondary but the dr.openova.io/v1 CRD ABSENT emits NO CR (install must not fail)"
+# This is the live hw145-region-b condition: bp-openbao installs on a
+# secondary CP where bp-catalyst-platform (the Continuum CRD owner, slot 13)
+# is primary-suspended, so the CRD is not registered. WITHOUT --api-versions,
+# helm's default capabilities do NOT include dr.openova.io/v1 — the
+# Capabilities guard MUST skip the CR so `helm install` renders clean and
+# succeeds (the CR is added on the next reconcile once/if the CRD lands).
+helm template smoke-bao . \
+  --set continuum.enabled=true \
+  --set snapshotReplication.enabled=true \
+  --set snapshotReplication.role=secondary \
+  --set continuum.primaryRegion=hz-fsn-rtz-prod \
+  --set continuum.standbyRegion=hz-hel-rtz-prod \
+  --set continuum.pdmZone=t99.omani.works > "$TMP/secondary-no-crd.yaml"
+if grep -qE "^kind: Continuum$" "$TMP/secondary-no-crd.yaml"; then
+  echo "FAIL: role=secondary rendered a Continuum CR even though the dr.openova.io/v1 CRD is absent — the install would fail with 'no matches for kind Continuum' (the #3612 region-b regression)." >&2
   exit 1
 fi
 echo "  PASS"


### PR DESCRIPTION
## Problem (verified live on hw145 region-b `me-east-215-b-1`)

In every 2-region prov, `helm install bp-openbao` FAILS in the **secondary** region:

```
chart bp-openbao@1.2.42: resource mapping not found for name "cont-openbao" namespace "openbao":
no matches for kind "Continuum" in version "dr.openova.io/v1" — ensure CRDs are installed first
```

Cascade: external-secrets-stores → sso-bridge / gitea / harbor / oidc-gate / newapi / powerdns-admin all fail (they need openbao-backed secrets). Region-a openbao is healthy. So region-b of every 2-region prov degrades.

## Root cause (both halves)

- **CR-producer (bp-openbao):** `platform/openbao/chart/templates/continuum.yaml` renders the `cont-openbao` Continuum CR (`dr.openova.io/v1`) when `continuum.enabled=true AND snapshotReplication.role=secondary`. On a 2-region prov, slot-08's overlay resolves both true in region-b (`continuum.enabled=${SOVEREIGN_ENABLE_HOT_STANDBY}`, `snapshotReplication.role=${SOVEREIGN_REGION_ROLE}`=`secondary`). So the CR renders **on the standby (region-B)** — by design (the CR describes promotion of the standby).
- **CRD-owner is NOT bp-continuum:** the `continuums.dr.openova.io` CRD lives ONLY in `products/catalyst/chart/crds/continuum.yaml` — the **bp-catalyst-platform umbrella** (slot 13). `products/continuum/chart/crds/` is intentionally empty (README only). And slot 13 is `region-role: primary` and **SUSPENDS on every secondary CP** (`suspend: ${SECONDARY_HR_SUSPEND}`). So the Continuum CRD is **never installed in region-B**, yet the CR renders there → install fails.

`bp-cnpg-pair`'s analogous `continuum.yaml` never hits this because it renders its CR **only on the primary side** (`isPrimarySide`). openbao genuinely needs its CR on the secondary, so it needs the Capabilities guard instead.

## Fix

Gate the CR render on `.Capabilities.APIVersions.Has "dr.openova.io/v1"` (gold-standard CRD-race pattern, cf bp-external-dns / #2988 / #3102 harbor-ESO). openbao installs WITHOUT the CR when the CRD is absent; the CR is added on the next Flux reconcile if/when the CRD lands. Breaks the region-b cascade immediately.

**No `dependsOn` added** — and one would be wrong here: the CRD owner (catalyst-platform slot 13) is *deliberately suspended* in region-B, so `dependsOn bp-catalyst-platform` would deadlock region-B openbao forever. The Capabilities guard is the only correct fix.

## helm-template proofs (run locally, all pass)

| render args | Continuum CR |
|---|---|
| (default) | 0 — byte-identical to origin/main |
| `--set continuum.enabled=true --set snapshotReplication.role=secondary` (no `--api-versions`) | **0 — install renders clean (the fix)** |
| `--api-versions dr.openova.io/v1` + same flags | 1 — CR present once the CRD lands |
| `--api-versions dr.openova.io/v1 --set ...role=primary` | 0 — CR belongs only on the secondary |

`helm lint platform/openbao/chart` → 0 failed. `tests/continuum-render.sh` (4 cases) + `tests/cross-region-render.sh` (3 cases) → all green. The CI blueprint-release integration-test gate runs `tests/*.sh` before the GHCR push, so the guard is enforced.

## Changes

- `platform/openbao/chart/templates/continuum.yaml` — Capabilities guard + doc.
- `platform/openbao/chart/tests/continuum-render.sh` — Case 3 now passes `--api-versions dr.openova.io/v1`; new Case 4 proves the guard skips the CR when the CRD is absent (the region-b condition).
- Chart 1.2.42 → 1.2.43; `blueprint.yaml` + bootstrap-kit slot-08 pin in lockstep.

Refs #3612 #3568
