### PR TITLE
docs(uat): fine-grained click-by-click test cases for the catalog+provisioning+NS1-5 train

### DIFF
--- a/docs/ledger/uat-walkthrough/train-2026-06-15.md
+++ b/docs/ledger/uat-walkthrough/train-2026-06-15.md
@@ -1,0 +1,313 @@
+# Catalog + Provisioning + North-Star train — fine-grained UAT walk (web UI)
+
+> **Scope:** the founder walks every feature of the catalog + provisioning + North-Star train on
+> the next fresh prov. **EPIC #3597** (catalog/provisioning UX) children **#3598 / #3599 / #3600 /
+> #3601 / #3602 / #3603**, plus the four standing North Stars **NS#1–NS#5**.
+>
+> **Format law (founder, 2026-06-03):** every row is **ONE UI action** — *Go to a URL → do one
+> click/type → see one screen/state.* Routes, button labels, and field names below are quoted
+> **verbatim from the deployed console source** `products/catalyst/bootstrap/ui/src/` (React/Vite/TSX)
+> with a `file:line` citation per surface, so a non-engineer can check each step without reading code.
+> `grep` / `go test` / `kubectl` checks are demoted to the **Appendix — automated, NOT acceptance**.
+>
+> **Code provenance:** PR **#3604** (Apps/Catalog nav split · placement-in-create · namespace-ensure ·
+> dropdowns) is **merged to `main`** (commit `bdc6f2267`) — Sections 1, 2, 4 cite it. PR **#3605**
+> (editable catalog) is on branch **`feat/3602-3603-editable-catalog`** (commit `e206158f5`) — Section
+> 3 cites it; if #3605 is not yet merged at walk time, Section 3 is **pending merge** and is run on a
+> prov whose console image carries that branch.
+>
+> **Replace placeholders at walk time:** `<fqdn>` = the fresh prov's sovereign FQDN (e.g.
+> `hw146.omani.works`); `<JWT>` = the RS256 handover token (`iss=console.openova.io`,
+> `sub=emrah.baysal@openova.io`, `role=sovereign-admin`); `<region-a>` / `<region-b>` = the two
+> cluster region codes (e.g. `me-east-215-a` / `me-east-215-b`). Tick **☑** a row that matches, **☒**
+> one that does not.
+
+**Sign-in (once, for the whole walk).** Open the handover URL
+`https://console.<fqdn>/auth/handover?token=<JWT>` in a fresh tab → it 302-redirects to `/dashboard`
+and you are **signed in with no login form** (avatar **E** top-right). This is the same zero-click
+entry every section below assumes; do not re-authenticate between sections.
+
+---
+
+## Section 1 — Provisioning an Application from the catalog (#3598 / #3599 / #3600)
+
+**What this proves:** an admin creates an Application **from a catalog entry**, and the create
+wizard collects **Organization, topology mode, region(s), and vCluster placement** — every fixed-set
+input is a **dropdown / checkbox, never free-text** (only the instance *name* is typed) — and the
+install does **NOT** error *"namespace not found"* (the Org/Environment namespace is ensured
+server-side).
+
+> **Route facts.** Catalog page route = `/catalog` (`app/router.tsx:1330`, `consoleCatalogRoute`).
+> A catalog card is a `<Link>` to the class page `/catalog/$blueprintName` (`pages/sovereign/AppsPage.tsx:875`)
+> — there is **no** "Install/Create" button on the card itself; the create flow starts from the
+> class page's **+ New instance** button (`pages/sovereign/AppDetail/InstancesSection.tsx:114`).
+
+| Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
+|---|---|---|---|---|
+| 1.1 | `https://console.<fqdn>/catalog` | Read the left-nav + the page title | A grid of catalog cards; the page title reads **"Catalog"** (`CatalogPage.tsx:141`, `pageTitle="Catalog"`) | ☐ |
+| 1.2 | `https://console.<fqdn>/catalog` | Click the **PostgreSQL** card (title **"PostgreSQL"**, badge **⛓ shareable**) | The card is a link — you land on the class page **`/catalog/bp-postgres`** (the card `<Link>`, `AppsPage.tsx:875`) | ☐ |
+| 1.3 | `https://console.<fqdn>/catalog/bp-postgres` | Click the **`+ New instance`** button (top-right of the Instances table) | A dialog opens titled **"New instance of bp-postgres"** (`InstancesSection.tsx:650`, button `data-testid="btn-new-instance"` at `:114`) | ☐ |
+| 1.4 | (in the dialog) | Read **field 1**, labelled **"Instance name"**, and type `demo-pg-1` | A free-text input (`data-testid="input-instance-name"`, `InstancesSection.tsx:655,659`) — the comment at `:653` states it is **"the ONLY free-text field (#3600)"**; placeholder `my-instance` | ☐ |
+| 1.5 | (in the dialog) | Open **field 2**, labelled **"Organization"** | A **`<select>` dropdown** (`data-testid="select-instance-org"`, `InstancesSection.tsx:671,673`) whose options are live Orgs (`{displayName} ({slug})`), placeholder **"Select an organization…"** — **not free-text** | ☐ |
+| 1.6 | (in the dialog) | Pick the **`platform`** organization from the dropdown | A read-only line appears: **"Environment: platform-prod"** (`data-testid="instance-environment-derived"`, `InstancesSection.tsx:698-703`) — the namespace the install targets | ☐ |
+| 1.7 | (in the dialog) | Open **field 3**, labelled **"Topology mode"** | A **`<select>` dropdown** (`data-testid="select-instance-topology"`, `InstancesSection.tsx:709,714`) listing the Blueprint's supported modes, each `{mode} — {description}` from `ALL_MODES = ['single-region','active-active','active-hotstandby']` (`TopologyEditor.tsx:63`) | ☐ |
+| 1.8 | (in the dialog) | Select **`active-hotstandby — primary serves; standby ready for switchover`** | The mode is chosen (`TopologyEditor.tsx:348-349`); the Region(s) legend below flips to require multiple regions (next row) | ☐ |
+| 1.9 | (in the dialog) | Read **field 4**, the **"Region(s)"** fieldset | A **checkbox group** (`data-testid="instance-regions"`, `InstancesSection.tsx:726-727,751`), **not** a dropdown; with a multi-region mode the legend reads **"Region(s) — pick at least 2"** (`:736`); options are the live cluster regions `<region-a>` / `<region-b>` (`region-checkbox-<region>`, `:758-761`) | ☐ |
+| 1.10 | (in the dialog) | Tick **both** region checkboxes `<region-a>` and `<region-b>` | Both boxes check; **no** validation error. (If only one is ticked, the error **"active-hotstandby needs at least 2 regions."** shows at `data-testid="instance-regions-validation"`, `:768-774`) | ☐ |
+| 1.11 | (in the dialog) | Open **field 5**, labelled **"vCluster / zone"** | A **`<select>` dropdown** (`data-testid="select-instance-vcluster"`, `InstancesSection.tsx:780,784`) with options **Default (server picks)** + the fixed zone set **`host` / `mgmt` / `dmz` / `rtz`** (`VCLUSTER_OPTIONS`, `:39`) — **not free-text** | ☐ |
+| 1.12 | (in the dialog) | Select **`rtz`** from the vCluster dropdown | `rtz` is selected as the placement zone (the value the backend validates against `{host,mgmt,dmz,rtz}`, comment `:843`) | ☐ |
+| 1.13 | (in the dialog) | Click the submit button labelled **"Create instance"** | The button (`data-testid="btn-submit-instance"`, `InstancesSection.tsx:862,875`) shows **"Creating…"**, then the dialog **closes** (`onCreated` → `setDialogOpen(false)`, `:295`). **No** *"namespace not found"* error appears | ☐ |
+| 1.14 | `https://console.<fqdn>/catalog/bp-postgres` | Read the **Instances** table | A **new row `demo-pg-1`** appears in the instances table (`sov-instances-table`); its name links to **`/app/demo-pg-1`** (`InstancesSection.tsx:296` refetch) — the Application installed into the ensured `platform-prod` namespace | ☐ |
+| 1.15 | `https://console.<fqdn>/app/demo-pg-1` | Read the **Placement** row on the Overview | **"Placement"** reads `active-hotstandby` (`data-testid="app-detail-overview-placement"`, `AppDetail.tsx:1289-1292`) — the topology you chose persisted onto the Application CR | ☐ |
+
+**Section 1 result: ___ / 15.** Every fixed-set input was a dropdown/checkbox (#3600); the wizard
+collected Organization + topology + regions + vCluster (#3599); the install did not error
+"namespace not found" (#3598).
+
+> **Honest note.** The catalog card itself carries **no** install button — you click the card to
+> reach the class page, then **+ New instance** (`InstancesSection.tsx:114`). That two-hop is the
+> shipped flow, not a missing button.
+
+---
+
+## Section 2 — Apps / Catalog navigation split (#3601)
+
+**What this proves:** `/apps` is a **tab-less Apps page** (the old "Deployments | Catalog" tab strip
+is gone) and **Catalog** is its own **left-nav entry** at `/catalog`.
+
+| Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
+|---|---|---|---|---|
+| 2.1 | `https://console.<fqdn>/dashboard` | Look at the left-nav rail for the **Apps** and **Catalog** items | Two **separate** nav entries: **"Apps"** (`SovereignSidebar.tsx:67-68`, `label:'Apps'` / `to:'/apps'`) and **"Catalog"** (`SovereignSidebar.tsx:80-81`, `label:'Catalog'` / `to:'/catalog'`) — the catalog is its OWN left-nav page now, no longer a tab on /apps | ☐ |
+| 2.2 | `https://console.<fqdn>/dashboard` | Click the **"Apps"** nav item | Navigates to **`/apps`**; the page title reads **"Applications"** (`AppsPage.tsx:504`, `pageTitle="Applications"`) | ☐ |
+| 2.3 | `https://console.<fqdn>/apps` | Look across the top of the Apps page for any tab strip | **No** "Deployments / Catalog" tabs render — only the installed-deployments grid (`AppsPage.tsx:7` header *"the page is TAB-LESS"*; inline `:593` *"Deployments/Catalog tabs removed"*) | ☐ |
+| 2.4 | `https://console.<fqdn>/apps` | If the grid is empty, find the empty-state link | The only catalog link here is the empty-state CTA **"Open catalog →"** → `/catalog` (`AppsPage.tsx:634`) — it is a link, **not** a tab | ☐ |
+| 2.5 | `https://console.<fqdn>/apps` | Click the **"Catalog"** nav item | Navigates to **`/catalog`** (a distinct route, `router.tsx:1330`); the page title reads **"Catalog"** (`CatalogPage.tsx:141`) | ☐ |
+| 2.6 | `https://console.<fqdn>/catalog` | Confirm the URL + that this is a standalone page (not `/apps?tab=...`) | The address bar reads exactly **`/catalog`**; the catalog grid renders as its own page (`consoleCatalogRoute`, `router.tsx:1328-1332`) | ☐ |
+
+**Section 2 result: ___ / 6.** `/apps` is tab-less (Applications), Catalog is a separate left-nav
+page at `/catalog`.
+
+---
+
+## Section 3 — Editable catalog (#3602 / #3603 · PR #3605)
+
+**What this proves:** an **admin** opens a catalog entry's **edit dialog** and changes its **name**,
+**supported topologies**, **light icon**, and **dark icon**; **Save** persists the change to the
+data-backed catalog overlay; the edit **survives a full page reload**.
+
+> **Provenance.** This section's code is on branch **`feat/3602-3603-editable-catalog`** (PR #3605,
+> `CatalogEditDialog.tsx`). Run it on a prov whose console image carries that branch. If #3605 is not
+> yet merged, mark this section **pending merge**.
+>
+> **Admin gate.** The per-card **Edit** button renders **only** when `isAdmin` is true
+> (`CatalogPage.tsx:259` passes `onEdit` only `isAdmin ? … : undefined`; absent ⇒ no button,
+> `AppsPage.tsx:1000`). `isAdmin` = the operator's tier is `admin` or `owner` (`useCatalogAdmin.ts:41-47`).
+> The handover identity `emrah.baysal@openova.io` (`role=sovereign-admin`) satisfies this.
+
+| Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
+|---|---|---|---|---|
+| 3.1 | `https://console.<fqdn>/catalog` | Hover the **Grafana** card and find the corner control | A **pencil-icon + "Edit"** chip in the card's status corner (`AppsPage.tsx:1027`, `.edit-chip`, `data-testid="sov-app-edit-<id>"`, `title="Edit Grafana catalog entry"`) | ☐ |
+| 3.2 | `https://console.<fqdn>/catalog` | Click the **Edit** chip on the Grafana card | A dialog opens titled **"Edit catalog entry"** (`CatalogEditDialog.tsx:115`, outer `role="dialog"` aria-label *"Edit catalog entry Grafana"* `:111`) | ☐ |
+| 3.3 | (in the dialog) | Read **field 1**, labelled **"Display name"**, and change it to `Grafana Observability` | A text input (`data-testid="catalog-edit-name"`, `CatalogEditDialog.tsx:122`, placeholder `WordPress`) | ☐ |
+| 3.4 | (in the dialog) | Read **field 2**, labelled **"Summary"** (optional one-liner) | A `<textarea>` (`data-testid="catalog-edit-summary"`, `CatalogEditDialog.tsx:133`, placeholder *"One-line description shown on the card"*) | ☐ |
+| 3.5 | (in the dialog) | Read **field 3**, labelled **"Supported topologies"** | A row of **checkboxes**, one per mode — **single-region**, **active-active**, **active-hotstandby** (`ALL_MODES`, `CatalogEditDialog.tsx:146-157`; each `data-testid="catalog-edit-topo-<mode>"`) | ☐ |
+| 3.6 | (in the dialog) | Tick the **active-active** checkbox so it joins the supported set | The `active-active` box checks (`catalog-edit-topo-active-active`) — the supported-topologies set is now editable, not static | ☐ |
+| 3.7 | (in the dialog) | Read **field 4**, labelled **"Light-theme icon"**, and paste an image URL into its text box | A URL text input (`data-testid="catalog-edit-icon-light"`, `CatalogEditDialog.tsx:163`, placeholder *"https://… or upload"*) **plus** an **"Upload"** file picker (`catalog-edit-icon-light-upload-label`) | ☐ |
+| 3.8 | (in the dialog) | Read **field 5**, labelled **"Dark-theme icon"**, and paste an image URL into its text box | A URL text input (`data-testid="catalog-edit-icon-dark"`, `CatalogEditDialog.tsx:186`) plus an **"Upload"** file picker (`catalog-edit-icon-dark-upload-label`) | ☐ |
+| 3.9 | (in the dialog) | Click the **"Save"** button | The button (`data-testid="catalog-edit-save"`, `CatalogEditDialog.tsx:222`) shows **"Saving…"**, then the dialog **closes**; a `PUT /api/v1/sme/commerce/apps/{id}` persists the row (`commerce.api.ts:224`) | ☐ |
+| 3.10 | `https://console.<fqdn>/catalog` | Read the Grafana card again (no reload yet) | The card now shows the new name **"Grafana Observability"** + the new icon (overlay applied live, `CatalogPage.tsx:233-239,257-258` after `editsQuery.refetch()`) | ☐ |
+| 3.11 | `https://console.<fqdn>/catalog` | **Hard-reload** the page (Ctrl/Cmd-Shift-R), then read the Grafana card | The edited name **"Grafana Observability"** + icon **persist** — the overlay is re-fetched on mount and merged server-side (`GET /api/v1/sme/commerce/apps`; `catalog_overlay.go` merges store rows onto the seed) — proving it is **data-backed, not in-memory** | ☐ |
+
+**Section 3 result: ___ / 11.** The admin edited name + supported topologies + light/dark icons, saved,
+and the change persisted across a hard reload.
+
+> **Honest note.** There is **no** success toast — acceptance is the dialog closing **and** the
+> reloaded card showing the new values (rows 3.10–3.11). The Save path writes to the SME commerce
+> catalog store (DB-backed), so the overlay survives reconcile.
+
+---
+
+## Section 4 — North Star #1: every app IN a vCluster (placement display)
+
+**North Star #1 (founder, verbatim):** *"every app IN a vCluster."* This section shows the **placement
+surface** — the dashboard treemap grouped by vCluster, and the per-app **Placement** field.
+
+> **Conformant-state caveat (carried from `3373-placement.md`).** The route/secret apps
+> (`keycloak`/`gitea`/`grafana`/`harbor`/`openbao`) stay on **`host`** by the ratified #3373 Batch-A
+> design (vcluster-izing them needs the loft.sh CRD-sync license, which breaks the Pillar-5 cutover
+> deny-egress hold). That is the **conformant** state, not a defect. The walk below confirms the
+> vCluster blocks render and apps sit in their declared zones.
+
+| Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
+|---|---|---|---|---|
+| 4.1 | `https://console.<fqdn>/dashboard` | Find the **"Layer 1"** dropdown above the treemap | A `<select>` labelled **"Layer 1"** (`TreemapLayerController.tsx:184`, `treemap-layer-0-select`) — default layers are `cluster` then `application` (`Dashboard.tsx:172-174`) | ☐ |
+| 4.2 | `https://console.<fqdn>/dashboard` | Set **Layer 1** → **`vCluster`** | The treemap regroups into top-level **vCluster blocks** — `host`, `mgmt`, `dmz`, `rtz` (option value `vcluster`, label **"vCluster"**, `TreemapLayerController.tsx:59`) | ☐ |
+| 4.3 | `https://console.<fqdn>/dashboard` | Read the **`mgmt`** block tiles | The mgmt vCluster contains the mgmt-targeted apps (`loki`/`mimir`/`tempo`/`nats`) | ☐ |
+| 4.4 | `https://console.<fqdn>/dashboard` | Read the **`rtz`** + **`dmz`** block tiles | `rtz` contains rtz-targeted apps (`valkey`/`seaweedfs`/`vllm`); `dmz` contains `coraza` | ☐ |
+| 4.5 | `https://console.<fqdn>/dashboard` | Read the **`host`** block tiles | The route/secret apps (`keycloak`/`gitea`/`grafana`/`harbor`/`openbao`) render under `host` — held there by ratified #3373 design (sovereignty), **not** a defect | ☐ |
+| 4.6 | `https://console.<fqdn>/app/bp-coraza` | Read the **"Placement"** row on the Overview tab | **"Placement"** field renders the app's declared placement (`AppDetail.tsx:1289-1292`, `app-detail-overview-placement`) — the per-app confirmation that placement is a first-class field | ☐ |
+
+**Section 4 result: ___ / 6.** The treemap's LAYER1=vCluster grouping renders the four blocks and
+the app-detail Placement field corroborates per-app membership.
+
+---
+
+## Section 5 — North Star #2: 3 shared-PG instances → 3 cards, many-to-many contexts
+
+**North Star #2 (founder, verbatim):** *"3 shared PG instances → 3 cards, 6-7 apps many-to-many."*
+The Contexts tab appears on each **⛓ shareable** instance's app-detail page.
+
+> Routes/labels carried from the established `3370-contexts.md` hw144 walk (same console build).
+> Exact context rows are env-specific; tick when the *shape* (3 cards · per-instance Contexts tab ·
+> distinct consumer sets) renders.
+
+| Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
+|---|---|---|---|---|
+| 5.1 | `https://console.<fqdn>/catalog/bp-postgres` | Read the hero badges + the **Instances** table | Hero shows **⛓ shareable**; the Instances table lists **3 rows** — `shared-pg`, `shared-pg-b`, `shared-pg-c` (org `platform`), each Ready with an **Open →** link | ☐ |
+| 5.2 | `https://console.<fqdn>/app/shared-pg` | Click the **"Contexts N"** tab | A table headed **`Context · Occupied by · Credential · Status`** with rows binding **harbor / gitea / keycloak** (3 distinct consumers) | ☐ |
+| 5.3 | `https://console.<fqdn>/app/shared-pg-b` | Click the **"Contexts N"** tab | A **distinct** consumer set — **grafana / powerdns / powerdns-admin** | ☐ |
+| 5.4 | `https://console.<fqdn>/app/shared-pg-c` | Click the **"Contexts N"** tab | A third consumer set — **catalyst-platform (sme_*) / newapi / openova-flow** | ☐ |
+| 5.5 | (review) | Count the distinct consumer apps across the 3 instances | **6–7+ distinct apps** bind the 3 instances many-to-many — one engine, many consumers, isolated per-context credentials | ☐ |
+
+**Section 5 result: ___ / 5.** 3 shared-PG instance cards + per-instance Contexts tabs, genuinely
+many-to-many.
+
+---
+
+## Section 6 — North Star #3: zero-login SSO (URL → signed in as admin)
+
+**North Star #3 (founder, verbatim):** *"NO login UI anywhere — URL → signed in as emrah.baysal as
+ADMIN; proof = surfing admin panels."* In a **fresh window**, a bare app URL lands **signed in** as
+the owner-admin — zero clicks, no PIN/login form. A redirect ending on a login screen or a 4xx/5xx is
+a **fail**.
+
+> Routes/labels carried from the established `3374-sso.md` hw144 walk (same console build).
+
+| Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
+|---|---|---|---|---|
+| 6.1 | `https://console.<fqdn>/auth/handover?token=<JWT>` | Paste into a **fresh** tab, press Enter | 302 → `/dashboard`, **signed in, no login form**; left-rail nav (Dashboard, Cloud, Apps, Catalog, Sandbox, Jobs, Compliance, Users, Organizations, Settings); avatar **E** top-right | ☐ |
+| 6.2 | `https://console.<fqdn>/dashboard` | Click the avatar **E** (top-right, `data-testid="profile-menu-avatar"`) | A menu reading **"Signed in as emrah.baysal@openova.io"** + **Sign out** — the landed identity is the owner | ☐ |
+| 6.3 | `https://console.<fqdn>/app/bp-grafana` | Read the header, click the **Endpoints** tab | Header shows the **`↗ Open Grafana`** button + *"Single sign-in — no second login."*; Endpoints lists `grafana.<fqdn> · https · Ready · Open →` | ☐ |
+| 6.4 | `https://grafana.<fqdn>` | Type the bare URL in a fresh tab, press Enter | Lands on **Grafana → Home/Dashboards**, **no login form**, avatar top-right (lands as ADMIN — `/api/user` `isGrafanaAdmin=true`) | ☐ |
+| 6.5 | `https://registry.<fqdn>` | Type the bare URL in a fresh tab, press Enter | Auto-redirects to **`/harbor/projects`**, **no login form**; `emrah.baysal@openova.io` top-right; **Administration** menu visible | ☐ |
+| 6.6 | `https://bao.<fqdn>` | Type the bare URL in a fresh tab, press Enter | OIDC round-trip completes → lands on **`/ui/vault/secrets`** (Secrets Engines), **no** `/ui/vault/auth` login form | ☐ |
+| 6.7 | `https://gitea.<fqdn>` | Type the bare URL in a fresh tab, press Enter | Title **"emrah.baysal — Dashboard — Catalyst Gitea"**, logged in | ☐ |
+
+**Section 6 result: ___ / 7.** Every URL lands signed-in as the owner-admin, zero clicks; per-app
+**Open** buttons present.
+
+---
+
+## Section 7 — North Star #4: region-kill failover (consumer data preserved)
+
+**North Star #4 (founder, verbatim):** agreed apps are actually multi-region — a primary-region kill
+is survived by the standby with **zero consumer data loss**. This is a **kubectl-driven datapath
+walk** (the console treemap only *displays* region health), so rows 7.3–7.5 run against the two
+cluster kubeconfigs (region-a `/tmp/<fqdn>.kc`, region-b `/tmp/<fqdn>-b.kc`). It is included here so
+the founder sees the full North-Star set in one document.
+
+> Procedure carried from the established `3375-topology-dr.md` hw144 PASS (RTO ≈ 4s, RPO = 0).
+
+| Step | Go to / run | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 7.1 | `https://console.<fqdn>/cloud` | Read the Region / Cluster counters on the cloud graph | The cloud topology graph reports **Region 2/2** + **Cluster 2/2** (`/cloud` route, `router.tsx:1364`) | ☐ |
+| 7.2 | `https://console.<fqdn>/app/shared-pg` | Click the **Topology** tab; read the **Change placement** editor | A real editor — mode radios single-region / active-active / active-hotstandby; **Regions** checkboxes `<region-a>` + `<region-b>`; **Preview** + **Apply** (`AppDetail.tsx:678` Topology tab) — proving the picker is editable, not cosmetic | ☐ |
+| 7.3 | **GATE** (region-b kc `/tmp/<fqdn>-b.kc`) | `psql -c "select pg_is_in_recovery()"` on `shared-pg-replica` + check `pg_stat_wal_receiver`; then query the **keycloak** DB for realms + users | Region-b replica is **streaming** (`pg_is_in_recovery = t`); keycloak DB present with realms **master + sovereign** and the baseline user set (record the count) | ☐ |
+| 7.4 | **KILL region-a** (region-a kc `/tmp/<fqdn>.kc`) | `kubectl cordon` the region-a workers, then `kubectl delete pod -l cnpg.io/cluster=shared-pg` | Region-a primary + workers gone — region-a is down | ☐ |
+| 7.5 | **PROMOTE region-b** (region-b kc) | `kubectl patch cluster shared-pg-replica --type merge -p '{"spec":{"replica":{"enabled":false}}}'`, then re-query keycloak realms + users | Replica promoted (`pg_is_in_recovery = f`, RTO ≈ a few seconds); realms **master + sovereign** and the user count are **identical to the 7.3 baseline → RPO = 0** (consumer data preserved) | ☐ |
+| 7.6 | **RESTORE** | `kubectl uncordon` the region-a nodes + revert region-b `replica.enabled = true` | Region-a schedulable again; region-b returns to replica role | ☐ |
+
+**Section 7 result: ___ / 6.** A region-a kill is survived by region-b; the consumer's keycloak realm
++ user rows are byte-identical after promote.
+
+---
+
+## Section 8 — North Star #5: sovereignty cutover (11 steps → cutoverComplete + 600s deny-egress)
+
+**North Star #5 (founder):** the Sovereign goes fully independent of the mothership. The operator
+drives it from the console; the acceptance is the **`Sovereign` badge** + **`cutoverComplete=true`**
+**and** the witnessed **`cutover-egress-block`** CiliumClusterwideNetworkPolicy present during the
+**600-second** deny-egress hold (ADR-0002 — no cutover claim without the egress-block proof).
+
+> **Precondition:** the cutover only fires **after handover** (the mother→child `tofu-archive` is
+> sealed; #3521). On a fresh prov, finalise handover first
+> (`POST https://console.openova.io/sovereign/api/v1/handover/finalise/<deploymentId>` with the
+> owner JWT → `tofuArchiveSubmitted: true`). The CTA below then drives the engine.
+>
+> The cutover UI is the **SovereigntyCard** on **Settings → Sovereignty** (`SettingsPage.tsx:110,424`
+> renders `<SovereigntyCard/>` at the `#sovereignty` anchor; `data-testid="settings-sovereignty"`).
+
+| Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
+|---|---|---|---|---|
+| 8.1 | `https://console.<fqdn>/settings#sovereignty` | Scroll to the **Sovereignty** section | A card headed **"Cluster sovereignty"** with an amber **"Tethered"** badge (`SovereigntyCard.tsx:119,144`, `data-testid="sovereignty-card"` `data-cutover-state="tethered"`) | ☐ |
+| 8.2 | (Sovereignty card) | Read the primary CTA | A button **"Achieve True Sovereignty"** (`SovereigntyCard.tsx:193`, `data-testid="cutover-start-button"`) + helptext *"Runs the … cutover. ~10 minutes. Includes a 10-minute egress-block self-test against github.com + ghcr.io + harbor.openova.io."* (`:195-199`) | ☐ |
+| 8.3 | (Sovereignty card) | Click **"Achieve True Sovereignty"** | A confirm modal opens titled **"Achieve True Sovereignty"** (`SovereigntyCard.tsx:279`, `data-testid="cutover-confirm-modal"`) listing the cutover steps (mirror Gitea, Harbor proxy projects, pre-warm, containerd pivot, Flux GitRepository, HelmRepositories, catalyst-api env, egress-block self-test) (`:289-298`) | ☐ |
+| 8.4 | (confirm modal) | Click **"Start cutover"** | The button (`SovereigntyCard.tsx:339`, `data-testid="cutover-confirm-button"`) fires `POST /sovereign/cutover/start` (`useCutoverEvents.ts:64,284`); the modal closes and the **8-row progress card** mounts (`CutoverProgressCard`, `:216-220`) | ☐ |
+| 8.5 | `https://console.<fqdn>/settings#sovereignty` | Watch the progress card stream the steps | The engine advances through its **11 steps** (gitea-mirror, harbor-projects, harbor-prewarm, registry-pivot, flux-gitrepository-patch, helmrepository-patches, catalyst-api-env-patch, **egress-block-test**, gitea-token-mint, vcluster-registry-pivot, crossplane-provider-pivot); each row flips `running → done` | ☐ |
+| 8.6 | (during step-08, ~600s window) | Confirm the deny-egress hold is the **witnessed** kind (the one negative check this section needs) | `kubectl get ccnp cutover-egress-block` returns the policy **present** for the duration of the hold, denying egress to github.com / ghcr.io / harbor.openova.io while all Flux reconciles stay green — see Appendix A8 | ☐ |
+| 8.7 | `https://console.<fqdn>/settings#sovereignty` | After the hold completes, re-read the badge + stats | The badge flips to green **"Sovereign"** (`SovereigntyCard.tsx:139`, `data-cutover-state="sovereign"`); the stats panel shows **Mirrored commit**, **Harbor projects**, **Egress test = passed** (`:158-178`, `data-testid="sovereignty-stats"`) | ☐ |
+| 8.8 | (negative acceptance) | Open `https://console.<fqdn>/apps`, `https://grafana.<fqdn>`, `https://gitea.<fqdn>` | Nothing the user touches is broken — console signed-in, Grafana SSO, Gitea served from the Sovereign's **own local** services (the post-independence negative contract) | ☐ |
+
+**Section 8 result: ___ / 8.** Handover → 11-step engine → green **Sovereign** badge +
+`cutoverComplete=true` + **Egress test = passed**, with the `cutover-egress-block` CCNP witnessed
+during the 600s hold.
+
+> **Honest note.** The card copy says "8-step" / "8-row" (`SovereigntyCard.tsx:282`,
+> `CutoverProgressCard` is fixed at 8 visible rows) but the **engine runs 11 steps** server-side
+> (the post-egress steps gitea-token-mint, vcluster-registry-pivot, crossplane-provider-pivot run
+> after the visible block). Acceptance is `cutoverComplete=true` + the witnessed egress-block, not
+> the row count.
+
+---
+
+## Summary scoreboard
+
+| Section | Feature | Rows | Result |
+|---|---|---|---|
+| 1 | Provisioning from catalog (#3598/#3599/#3600) | 15 | ___ / 15 |
+| 2 | Apps / Catalog nav split (#3601) | 6 | ___ / 6 |
+| 3 | Editable catalog (#3602/#3603 · PR #3605) | 11 | ___ / 11 |
+| 4 | NS#1 — every app in a vCluster | 6 | ___ / 6 |
+| 5 | NS#2 — 3 shared-PG cards, many-to-many | 5 | ___ / 5 |
+| 6 | NS#3 — zero-login SSO | 7 | ___ / 7 |
+| 7 | NS#4 — region-kill failover | 6 | ___ / 6 |
+| 8 | NS#5 — sovereignty cutover | 8 | ___ / 8 |
+| **Total** | | **64** | **___ / 64** |
+
+---
+
+## Appendix — automated checks (NOT acceptance)
+
+> Demoted per the founder's UAT format law. **Acceptance is the operator walking the clickable rows
+> above.** These are supporting machine cross-checks only.
+
+- **A1 (create-from-catalog).** The create dialog POSTs `createApplicationInstance(body)` →
+  `POST <fqdn>/catalyst/v1/apps/instances` (`catalog.api.ts:917,926`); the body carries
+  `org` / `name` / `blueprint` / `topology` / `placement` / `backing` (`catalog.api.ts:568-590`).
+  The namespace-ensure (#3598) is server-side in the catalyst-api handler
+  (`api/internal/handler/namespace_ensure.go`); the UI shows the derived `{org}-prod` read-only.
+- **A2 (nav split).** `consoleAppsRoute` `path:'/apps'` → `AppsPage`; `consoleCatalogRoute`
+  `path:'/catalog'` → `CatalogPage` (`app/router.tsx:1313-1317,1328-1332`). Frontend unit suites:
+  `AppsPage.test.tsx`, `CatalogPage.test.tsx` (PR #3604).
+- **A3 (editable catalog).** Save path `saveCatalogEdit(blueprintId, edit)` →
+  `PUT /api/v1/sme/commerce/apps/{id}` (existing row) or `POST /api/v1/sme/commerce/apps` (new)
+  (`commerce.api.ts:205,224,230`). Read-side overlay merge: `catalog_overlay.go` merges store rows
+  onto the seed on every `GET /api/v1/catalog`. Store = `core/services/catalog` (DB-backed). Suites:
+  `CatalogPage.edit.test.tsx`, `catalog_overlay_test.go` (PR #3605).
+- **A4 (NS#1 placement).** `scripts/audit-placement-conformance.py rendered` → exit 0
+  ("declared == actual"); treemap dimension `vcluster` (`TreemapLayerController.tsx:59`).
+- **A5 (NS#2 contexts).** The 3 instances are bootstrap-HR PostgreSQL `Cluster`s reflected as
+  first-class App cards; per-card context counts sum to the many-to-many total.
+- **A6 (NS#3 SSO).** `grafana.<fqdn>/api/user` → `isGrafanaAdmin=true`;
+  `registry.<fqdn>/api/v2.0/users/current` → `username=emrah.baysal@openova.io`; openbao OIDC
+  `client_id=openbao` → `/ui/vault/secrets`.
+- **A7 (NS#4 region-kill).** Raw capture written to
+  `docs/sessions/<date>/evidence/<fqdn>-ns4-region-kill-proof.txt`: `pg_is_in_recovery` flip +
+  keycloak realm/user counts pre/post (RPO = 0).
+- **A8 (NS#5 cutover).** During step-08, `kubectl get ccnp cutover-egress-block` must return the
+  policy **present** for the full 600s hold; `GET /sovereign/cutover/status` →
+  `cutoverComplete=true` + `egressTestPassed=true` after the hold. The CTA is operator-gated
+  (`POST /api/v1/sovereign/cutover/start` behind `RequireSession`; in-cluster auto-trigger is
+  fail-closed, `cutover_internal.go`).
+</content>
+</invoke>


### PR DESCRIPTION
Adds `docs/ledger/uat-walkthrough/train-2026-06-15.md` — **64 click-by-click UAT rows** (one UI action each) so the founder can walk every feature of the catalog + provisioning + North-Star train on the next fresh prov. Docs only; no product code.

## Coverage (8 sections, 64 rows)
| # | Feature | Tickets | Rows |
|---|---|---|---|
| 1 | Provisioning from catalog (Org + topology + region(s) + vCluster dropdowns; no "namespace not found") | #3598 #3599 #3600 | 15 |
| 2 | Apps/Catalog nav split (`/apps` tab-less; Catalog own left-nav) | #3601 | 6 |
| 3 | Editable catalog (admin edits name + topologies + light/dark icons; persists) | #3602 #3603 (PR #3605) | 11 |
| 4 | NS#1 — every app in a vCluster (treemap vCluster layer + app-detail Placement) | — | 6 |
| 5 | NS#2 — 3 shared-pg cards, many-to-many contexts | — | 5 |
| 6 | NS#3 — zero-login SSO (URL → signed in as admin) | — | 7 |
| 7 | NS#4 — region-kill failover (consumer data preserved) | — | 6 |
| 8 | NS#5 — sovereignty cutover (11 steps → cutoverComplete + 600s deny-egress) | — | 8 |

## Format discipline
Every row = **Go to URL → do one click/type → see one screen**. Routes/labels/field-names are quoted **verbatim from the deployed console source** `products/catalyst/bootstrap/ui/src/` (React/TSX) with a `file:line` citation per surface. `grep`/`go test`/`kubectl` checks are demoted to an **Appendix — NOT acceptance**.

Sections cite (file:line):
- **1** — `pages/sovereign/AppDetail/InstancesSection.tsx` (`+ New instance` :115, dialog :650, fields :655/:671/:693/:711/:782, `Create instance` :875) + `lib/catalog.api.ts` (POST `catalyst/v1/apps/instances`) — PR #3604 (merged `bdc6f2267`).
- **2** — `pages/sovereign/SovereignSidebar.tsx:67/80`, `AppsPage.tsx:7/504/634`, `CatalogPage.tsx:141`.
- **3** — `pages/sovereign/CatalogEditDialog.tsx:115/122/146/163/186/222`, `AppsPage.tsx:1027`, `CatalogPage.tsx:259`, `commerce.api.ts:224` — PR #3605 branch `feat/3602-3603-editable-catalog`.
- **4** — `components/TreemapLayerController.tsx:59/184`, `pages/sovereign/AppDetail.tsx:1289-1292/:678`.
- **5/6/7** — routes carried from the established hw144 walks (`3370-contexts.md`, `3374-sso.md`, `3375-topology-dr.md`).
- **8** — `widgets/sovereignty/SovereigntyCard.tsx:193/279/339`, `pages/sovereign/SettingsPage.tsx:110/424`, engine `cutover-egress-block` CCNP + 600s hold.

No banned terms. Acceptance remains the operator walking the rows on a fresh prov.

Refs #3610
Refs #3597

🤖 Generated with [Claude Code](https://claude.com/claude-code)