### PR TITLE
fix(catalyst-api): deployment 'ready' hides secondary-region degradation — surface per-region HR health

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -933,6 +933,20 @@ func (d *Deployment) State() map[string]any {
 		if d.Result.HandoverFiredAt != nil {
 			out["handoverFiredAt"] = d.Result.HandoverFiredAt.UTC().Format(time.RFC3339)
 		}
+		// #3611 — per-region HelmRelease health, lifted to the top level
+		// so the operator-console deployments/jobs view can badge a
+		// degraded secondary on a "ready" deployment without unwrapping
+		// result. While the Phase-1 watchers are still attached (the
+		// pre-handover polling window) we RECOMPUTE the census live off
+		// the in-memory informer caches so the counts track convergence;
+		// once the watchers are torn down at handover we fall back to the
+		// snapshot markPhase1Done persisted onto Result.Regions. Both
+		// paths are surface-only — neither changes d.Status.
+		regions, secondaryDegraded := d.regionHealthForStateLocked()
+		if len(regions) > 0 {
+			out["regions"] = regions
+			out["secondaryDegraded"] = secondaryDegraded
+		}
 	}
 	// adoptedAt — handover-finalisation flag (issue #317) lifted to the
 	// top level so the UI's beforeLoad redirect (issue #319) reads it
@@ -954,6 +968,48 @@ func (d *Deployment) State() map[string]any {
 	// running degrade gracefully (the bridge still renders).
 	out["openovaFlowEnabled"] = true
 	return out
+}
+
+// regionHealthForStateLocked returns the per-region HelmRelease health
+// census + the secondaryDegraded roll-up for State() (#3611). The CALLER
+// MUST hold d.mu.
+//
+// While the Phase-1 watchers are still attached (liveWatcher for the
+// primary, secondaryWatchers for the rest) it recomputes the census LIVE
+// off the in-memory informer caches so a poll during convergence tracks
+// the real counts. Once the watchers are torn down (handover, or a record
+// restored from disk where no watcher is attached) it returns the snapshot
+// markPhase1Done persisted onto Result.Regions. Both paths are surface-
+// only — this never touches d.Status.
+//
+// SnapshotComponents() on each watcher takes only that watcher's own lock,
+// never d.mu, so calling it under d.mu is safe.
+func (d *Deployment) regionHealthForStateLocked() (regions []provisioner.RegionHealth, secondaryDegraded bool) {
+	primaryAttached := d.liveWatcher != nil
+	secondariesAttached := len(d.secondaryWatchers) > 0
+	if !primaryAttached && !secondariesAttached {
+		// No live watchers — surface the persisted snapshot verbatim.
+		if d.Result == nil {
+			return nil, false
+		}
+		return d.Result.Regions, d.Result.SecondaryDegraded
+	}
+
+	// Primary states: prefer the live informer cache; fall back to the
+	// persisted terminal map when only secondaries are attached (a state
+	// that does not normally occur but keeps the census honest).
+	var primaryStates map[string]string
+	if primaryAttached {
+		primaryStates = make(map[string]string)
+		for _, cs := range d.liveWatcher.SnapshotComponents() {
+			primaryStates[cs.AppID] = cs.Status
+		}
+	} else if d.Result != nil {
+		primaryStates = d.Result.ComponentStates
+	}
+
+	primaryRegion := primaryRegionKey(&d.Request)
+	return provisioner.ComputeRegionHealth(primaryRegion, primaryStates, snapshotSecondaryStatesLocked(d))
 }
 
 func (h *Handler) CreateDeployment(w http.ResponseWriter, r *http.Request) {
@@ -1416,6 +1472,14 @@ func (h *Handler) ListDeployments(w http.ResponseWriter, r *http.Request) {
 		OwnerEmail    string  `json:"ownerEmail,omitempty"`
 		AdoptedAt     *string `json:"adoptedAt,omitempty"`
 		Error         string  `json:"error,omitempty"`
+		// SecondaryDegraded (#3611) — surface-only flag so the
+		// deployments list can badge a "ready" multi-region prov whose
+		// secondary region is significantly behind the primary, instead
+		// of a flat green pill. Omitted (false) for single-region and
+		// fully-converged provs. The per-region HR breakdown lives on the
+		// GET /deployments/{id} response (Result.Regions); the list keeps
+		// just the roll-up to stay lightweight.
+		SecondaryDegraded bool `json:"secondaryDegraded,omitempty"`
 	}
 
 	out := make([]listEntry, 0)
@@ -1433,6 +1497,10 @@ func (h *Handler) ListDeployments(w http.ResponseWriter, r *http.Request) {
 			OwnerEmail:    dep.OwnerEmail,
 			Error:         dep.Error,
 		}
+		// #3611 — roll-up the per-region census so the list can badge a
+		// degraded secondary on a "ready" deployment. Same live-or-
+		// persisted source as State(); surface-only.
+		_, entry.SecondaryDegraded = dep.regionHealthForStateLocked()
 		if !dep.StartedAt.IsZero() {
 			entry.StartedAt = dep.StartedAt.UTC().Format(time.RFC3339)
 		}

--- a/products/catalyst/bootstrap/api/internal/handler/deployments_region_health_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments_region_health_test.go
@@ -1,0 +1,133 @@
+package handler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// newReadyDeployment builds a minimal ready Deployment with no live
+// Phase-1 watchers attached, so State()/regionHealthForStateLocked take
+// the persisted-snapshot path (Result.Regions) — the post-handover shape.
+func newReadyDeployment(id string, result *provisioner.Result) *Deployment {
+	dep := &Deployment{
+		ID:        id,
+		Status:    "ready",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event),
+		done:      make(chan struct{}),
+		Request: provisioner.Request{
+			SovereignFQDN: "omantel.omani.works",
+		},
+		Result: result,
+	}
+	close(dep.eventsCh)
+	close(dep.done)
+	return dep
+}
+
+// TestState_SurfacesDegradedSecondary is the #3611 contract: a "ready"
+// multi-region deployment whose secondary region is degraded lifts the
+// per-region breakdown + secondaryDegraded=true to the top-level State()
+// shape, so the console stops rendering a flat green "ready". Mirrors the
+// hw145 evidence (region-a 60/63, region-b 48/63).
+func TestState_SurfacesDegradedSecondary(t *testing.T) {
+	dep := newReadyDeployment("test-degraded-secondary", &provisioner.Result{
+		Regions: []provisioner.RegionHealth{
+			{Region: "me-east-215-a", Primary: true, HRReady: 60, HRTotal: 63, Degraded: false},
+			{Region: "me-east-215-b", Primary: false, HRReady: 48, HRTotal: 63, Degraded: true},
+		},
+		SecondaryDegraded: true,
+	})
+
+	out := dep.State()
+
+	// status is intentionally still "ready" — surface, not gate.
+	if out["status"] != "ready" {
+		t.Fatalf("status = %v, want ready (surface-not-gate)", out["status"])
+	}
+
+	deg, ok := out["secondaryDegraded"].(bool)
+	if !ok || !deg {
+		t.Fatalf("secondaryDegraded = %v (ok=%v), want true at top level", out["secondaryDegraded"], ok)
+	}
+
+	regions, ok := out["regions"].([]provisioner.RegionHealth)
+	if !ok {
+		t.Fatalf("regions missing or wrong type at top level: %T %v", out["regions"], out["regions"])
+	}
+	if len(regions) != 2 {
+		t.Fatalf("want 2 regions, got %d: %+v", len(regions), regions)
+	}
+	if !regions[0].Primary || regions[0].Degraded {
+		t.Errorf("region[0] should be the non-degraded primary; got %+v", regions[0])
+	}
+	if regions[1].Primary || !regions[1].Degraded {
+		t.Errorf("region[1] should be the degraded secondary; got %+v", regions[1])
+	}
+	if regions[1].HRReady != 48 || regions[1].HRTotal != 63 {
+		t.Errorf("secondary census = %d/%d, want 48/63", regions[1].HRReady, regions[1].HRTotal)
+	}
+}
+
+// TestState_BothRegionsReady_NoBadge confirms a healthy 2-region prov
+// surfaces the per-region breakdown but secondaryDegraded=false (no badge).
+func TestState_BothRegionsReady_NoBadge(t *testing.T) {
+	dep := newReadyDeployment("test-both-ready", &provisioner.Result{
+		Regions: []provisioner.RegionHealth{
+			{Region: "me-east-215-a", Primary: true, HRReady: 63, HRTotal: 63, Degraded: false},
+			{Region: "me-east-215-b", Primary: false, HRReady: 63, HRTotal: 63, Degraded: false},
+		},
+		SecondaryDegraded: false,
+	})
+
+	out := dep.State()
+
+	deg, ok := out["secondaryDegraded"].(bool)
+	if !ok {
+		t.Fatalf("secondaryDegraded missing; want present=false")
+	}
+	if deg {
+		t.Errorf("secondaryDegraded = true, want false for a healthy 2-region prov")
+	}
+	if regions, ok := out["regions"].([]provisioner.RegionHealth); !ok || len(regions) != 2 {
+		t.Errorf("want 2 regions surfaced, got %T len=%d", out["regions"], len(regions))
+	}
+}
+
+// TestState_SingleRegion_NoRegionsKey confirms a single-region prov (no
+// Result.Regions persisted, no live watchers) does NOT emit a regions key
+// or a secondaryDegraded key — the badge is multi-region-only and a UI
+// client that pre-dates the field never sees a stray key.
+func TestState_SingleRegion_NoRegionsKey(t *testing.T) {
+	dep := newReadyDeployment("test-single-region", &provisioner.Result{
+		// No Regions populated (single-region prov), Phase-1 fields only.
+		ComponentStates: map[string]string{"bp-cilium": "installed"},
+	})
+
+	out := dep.State()
+
+	if _, ok := out["regions"]; ok {
+		t.Errorf("regions key should be absent for a single-region prov; got %v", out["regions"])
+	}
+	if _, ok := out["secondaryDegraded"]; ok {
+		t.Errorf("secondaryDegraded key should be absent for a single-region prov; got %v", out["secondaryDegraded"])
+	}
+}
+
+// TestState_NilResult_NoRegionHealth guards the nil-Result path (Phase 0
+// failed before a Result was attached): State() must not panic and must
+// not emit the region-health keys.
+func TestState_NilResult_NoRegionHealth(t *testing.T) {
+	dep := newReadyDeployment("test-nil-result", nil)
+
+	out := dep.State()
+
+	if _, ok := out["regions"]; ok {
+		t.Errorf("regions key should be absent when Result is nil; got %v", out["regions"])
+	}
+	if _, ok := out["secondaryDegraded"]; ok {
+		t.Errorf("secondaryDegraded key should be absent when Result is nil; got %v", out["secondaryDegraded"])
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -645,6 +645,24 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 	// Status pill alone once Phase1Substate is empty.
 	dep.Result.Phase1Substate = ""
 
+	// Per-region HelmRelease health (#3611). The primary region's terminal
+	// states are finalStates; the secondaries are snapshotted from their
+	// still-attached watchers (runPhase1Watch's deferred stopSecondaries
+	// has not run yet — markPhase1Done is called inline before it). We
+	// compute the census + the surface-only secondaryDegraded roll-up and
+	// stamp them onto Result so a multi-region "ready" stops hiding a
+	// degraded secondary. This does NOT change the Status decision below —
+	// it is surface-only by design (a slow secondary must never hang the
+	// prov). Computed under dep.mu so a racing State() reads a consistent
+	// snapshot. snapshotSecondaryStatesLocked calls SnapshotComponents()
+	// on each secondary watcher, which takes only the watcher's own lock
+	// (never dep.mu), so there is no lock-ordering hazard.
+	dep.Result.Regions, dep.Result.SecondaryDegraded = provisioner.ComputeRegionHealth(
+		primaryRegionKey(&dep.Request),
+		finalStates,
+		snapshotSecondaryStatesLocked(dep),
+	)
+
 	failed := 0
 	for _, s := range finalStates {
 		if s == helmwatch.StateFailed {
@@ -713,6 +731,10 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 	}
 
 	finalStatus := dep.Status
+	// Capture the #3611 region-health summary under the lock for the
+	// terminal log line + the secondary-degraded warn below.
+	regionHealth := dep.Result.Regions
+	secondaryDegraded := dep.Result.SecondaryDegraded
 	dep.mu.Unlock()
 
 	// Persist the deployment record after the status flip so a
@@ -733,7 +755,24 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		"failedCount", failed,
 		"finalStatus", finalStatus,
 		"phase1Outcome", outcome,
+		"regions", formatRegionHealth(regionHealth),
+		"secondaryDegraded", secondaryDegraded,
 	)
+
+	// #3611 — make a "ready" deployment HONEST about a degraded secondary.
+	// Status stays "ready" by design (surface-not-gate, so a slow secondary
+	// never hangs the prov), but a degraded secondary is overclaiming if it
+	// is invisible. Emit a loud warn so the condition is greppable in the
+	// catalyst-api logs even when the operator only ever sees the green
+	// "ready" pill. The per-region breakdown rides on Result.Regions for
+	// the console/jobs view.
+	if secondaryDegraded {
+		h.log.Warn("phase 1 ready but a SECONDARY region is degraded — surfaced via Result.Regions, status intentionally left ready (surface-not-gate, #3611)",
+			"id", dep.ID,
+			"finalStatus", finalStatus,
+			"regions", formatRegionHealth(regionHealth),
+		)
+	}
 
 	// Issues #764 + #768 — auto-fire the handover JWT mint immediately
 	// after Phase-1 reaches OutcomeReady. Until this landed, the
@@ -857,6 +896,74 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		// markPhase1Done returns.
 		h.runSecondaryBridgeBackfill(dep)
 	}
+}
+
+// primaryRegionKey returns the declared primary region's key for the
+// #3611 per-region health census — Regions[0].CloudRegion, falling back
+// to the legacy singular Request.Region. Empty when neither is set (a
+// pre-Regions hand-crafted payload); ComputeRegionHealth then labels the
+// primary entry "primary".
+func primaryRegionKey(req *provisioner.Request) string {
+	if req == nil {
+		return ""
+	}
+	if len(req.Regions) > 0 && req.Regions[0].CloudRegion != "" {
+		return req.Regions[0].CloudRegion
+	}
+	return req.Region
+}
+
+// snapshotSecondaryStatesLocked builds region-key → (component-id →
+// helmwatch state) for every currently-attached secondary watcher, by
+// calling SnapshotComponents() on each (#3611). The CALLER MUST hold
+// dep.mu — this reads dep.secondaryWatchers. SnapshotComponents itself
+// takes only the watcher's own lock, never dep.mu, so calling it under
+// dep.mu is safe (no inverse acquisition path exists).
+//
+// Returns nil for a single-region deployment (no secondary watchers),
+// which ComputeRegionHealth treats as "primary only".
+func snapshotSecondaryStatesLocked(dep *Deployment) map[string]map[string]string {
+	if len(dep.secondaryWatchers) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]string, len(dep.secondaryWatchers))
+	for region, w := range dep.secondaryWatchers {
+		if w == nil {
+			// Emit an empty map so the region still shows up as 0/0 in
+			// the census (its kubeconfig landed + a watcher slot was
+			// allocated, but the watcher object is gone) rather than
+			// silently vanishing from the breakdown.
+			out[region] = map[string]string{}
+			continue
+		}
+		states := make(map[string]string)
+		for _, cs := range w.SnapshotComponents() {
+			states[cs.AppID] = cs.Status
+		}
+		out[region] = states
+	}
+	return out
+}
+
+// formatRegionHealth renders the #3611 per-region census as a compact
+// log-friendly string, e.g. "me-east-215-a=60/63(primary)
+// me-east-215-b=48/63(DEGRADED)". Used only for structured-log values.
+func formatRegionHealth(regions []provisioner.RegionHealth) string {
+	if len(regions) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(regions))
+	for _, r := range regions {
+		tag := ""
+		switch {
+		case r.Primary:
+			tag = "(primary)"
+		case r.Degraded:
+			tag = "(DEGRADED)"
+		}
+		parts = append(parts, fmt.Sprintf("%s=%d/%d%s", r.Region, r.HRReady, r.HRTotal, tag))
+	}
+	return strings.Join(parts, " ")
 }
 
 // runSecondaryBridgeBackfill walks every secondary watcher attached to

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1165,6 +1165,35 @@ type Result struct {
 	// "Open Sovereign console" path (POST
 	// /deployments/{id}/mint-handover-token).
 	HandoverURL string `json:"handoverURL,omitempty"`
+
+	// Regions — per-region HelmRelease health census (#3611). For a
+	// multi-region deployment this is the ONLY honest read of how each
+	// region actually converged: the flat ComponentStates map above
+	// collapses every region together, and dep.Status="ready" is driven
+	// solely by the PRIMARY region's Phase-1 watch. A degraded secondary
+	// (hw145: region-a 60/63 HRs, region-b 48/63) would otherwise hide
+	// behind a bare green "ready" — this slice surfaces "region-b 48/63,
+	// degraded" instead. Computed at Phase-1 termination (a snapshot of
+	// the secondary watchers taken while they are still attached) and
+	// recomputed live in Deployment.State() while the watchers remain up,
+	// so the console/jobs view tracks convergence and then freezes on the
+	// handover picture. Empty for a single-region prov; for a multi-
+	// region prov the primary entry is emitted even before any secondary
+	// kubeconfig lands. Primary first, secondaries in sorted region-key
+	// order. See internal/provisioner/region_health.go for the gate.
+	Regions []RegionHealth `json:"regions,omitempty"`
+
+	// SecondaryDegraded — surface-only roll-up of Regions: true when ANY
+	// secondary region is significantly short of the primary's Ready-HR
+	// count (#3611). This is intentionally NOT a gate — markPhase1Done
+	// keeps flipping Status="ready" off the primary watcher alone so a
+	// legitimately-slow secondary never hangs the prov (Flux keeps
+	// reconciling long past the watch budget and the doctrine forbids
+	// wiping such envs). It exists so the operator console can badge a
+	// "ready" deployment as "secondary degraded" and so catalyst-api logs
+	// the condition at Phase-1 termination. Always false for a single-
+	// region prov.
+	SecondaryDegraded bool `json:"secondaryDegraded,omitempty"`
 }
 
 // PartialRegionMaterialisationError is returned by Provision when

--- a/products/catalyst/bootstrap/api/internal/provisioner/region_health.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/region_health.go
@@ -1,0 +1,185 @@
+package provisioner
+
+// Per-region HelmRelease health breakdown (#3611).
+//
+// A 2-region deployment flips to status="ready" the instant the PRIMARY
+// region's Phase-1 watch reaches OutcomeReady and the secondary kubeconfig
+// has landed — markPhase1Done never consults the secondary regions'
+// per-component state. So a degraded secondary (hw145: region-a 60/63 HRs
+// Ready, region-b 48/63 after an openbao cascade) hides behind a bare green
+// "ready" pill and the operator never sees it.
+//
+// The fix is to SURFACE the truth, not hard-gate it. Hard-gating "ready" on
+// secondary convergence risks hanging provs when a secondary is legitimately
+// slow (Flux keeps reconciling long past the watch budget and the doctrine
+// forbids wiping such envs). Instead we compute a per-region Ready/total HR
+// breakdown + a `degraded` flag and expose it on the deployment status; the
+// existing `ready` gate is untouched. The console/jobs view can then render
+// "region-b 48/63, degraded" instead of a flat "ready".
+
+// hrStateInstalled is the helmwatch terminal state string for a fully
+// reconciled HelmRelease (helmwatch.StateInstalled == "installed").
+//
+// Duplicated as a local literal rather than imported because internal/
+// helmwatch imports this package (for provisioner.Event) — taking the
+// reverse dependency would form an import cycle. ComputeRegionHealth
+// operates on the already-derived state-string maps, so it never needs the
+// helmwatch package, only this one constant.
+const hrStateInstalled = "installed"
+
+// regionDegradedAbsoluteFloor — minimum Ready-HR shortfall (primary minus
+// secondary) below which a secondary is NOT flagged degraded even if it is a
+// few HRs behind. A secondary that is ~1-2 HRs behind the primary is almost
+// always mid-reconcile, not stuck; flagging it would make the badge flap on
+// every poll during normal convergence. hw145's region-b was 12 HRs behind
+// (48 vs 60) — comfortably past this floor.
+const regionDegradedAbsoluteFloor = 3
+
+// regionDegradedRatioNumerator / regionDegradedRatioDenominator express the
+// "significantly short of the primary" ratio gate: a secondary is degraded
+// when its Ready count is below this fraction of the primary's Ready count.
+// 9/10 (90%) mirrors the convergedLateMinReady ratio idiom already used in
+// phase1_converged_late.go. hw145 region-b: 48 < (9/10)*60 == 54 → degraded.
+const (
+	regionDegradedRatioNumerator   = 9
+	regionDegradedRatioDenominator = 10
+)
+
+// RegionHealth is the per-region HelmRelease census surfaced on the
+// deployment status so "ready" stops hiding a degraded secondary (#3611).
+type RegionHealth struct {
+	// Region is the region key. For the primary it is the declared
+	// Regions[0].CloudRegion (falling back to "primary" when unknown);
+	// for secondaries it is the cloud-init ?region= key the secondary
+	// control-plane PUT its kubeconfig under (e.g. "hel1-2",
+	// "me-east-215-b-1").
+	Region string `json:"region"`
+
+	// Primary marks the region whose Phase-1 watch drives the
+	// deployment-level "ready" classification. Exactly one entry is
+	// Primary=true.
+	Primary bool `json:"primary"`
+
+	// HRReady is the count of bp-* HelmReleases observed in the
+	// terminal "installed" state in this region.
+	HRReady int `json:"hrReady"`
+
+	// HRTotal is the count of bp-* HelmReleases observed in this region.
+	HRTotal int `json:"hrTotal"`
+
+	// Degraded is true when this region is a SECONDARY that falls
+	// significantly short of the primary's Ready-HR count (see
+	// regionDegraded). The primary is never Degraded — it IS the
+	// convergence baseline, and its own failure is already surfaced via
+	// dep.Status/Phase1Outcome.
+	Degraded bool `json:"degraded"`
+}
+
+// countInstalled returns (ready, total) for a component-state map keyed by
+// component id → helmwatch state string. Ready == state "installed".
+func countInstalled(states map[string]string) (ready, total int) {
+	for _, s := range states {
+		total++
+		if s == hrStateInstalled {
+			ready++
+		}
+	}
+	return ready, total
+}
+
+// regionDegraded decides whether a SECONDARY region with secReady/secTotal
+// installed HRs is degraded relative to a primary with priReady installed
+// HRs. A secondary is degraded when it is not fully installed AND it is
+// significantly behind the primary — significant meaning BOTH past the
+// absolute shortfall floor AND below the ratio gate. Requiring both keeps a
+// nearly-caught-up secondary (1-2 HRs behind, transient) from flapping the
+// badge while still catching a real cascade like hw145's 48/63-vs-60/63.
+//
+// A secondary that has observed ZERO HRs (secTotal == 0) is treated as
+// degraded only when the primary has a meaningful population — a 0/0
+// secondary whose watcher just attached (no list yet) must not register as
+// degraded against a 0/0 primary during early convergence.
+func regionDegraded(priReady, secReady, secTotal int) bool {
+	if secTotal > 0 && secReady == secTotal {
+		// Secondary fully installed — never degraded regardless of how
+		// the primary's count compares (a secondary can legitimately run
+		// fewer HRs than the primary, e.g. a region that does not host
+		// the marketplace).
+		return false
+	}
+	shortfall := priReady - secReady
+	if shortfall < regionDegradedAbsoluteFloor {
+		return false
+	}
+	// secReady < (num/den) * priReady, written without floats.
+	belowRatio := secReady*regionDegradedRatioDenominator < priReady*regionDegradedRatioNumerator
+	return belowRatio
+}
+
+// ComputeRegionHealth builds the per-region HelmRelease census + the
+// secondaryDegraded roll-up (#3611). It is a pure function over the
+// already-derived per-region state maps so it is fully table-testable
+// without a live cluster.
+//
+//   - primaryRegion: the declared primary region key (Regions[0].CloudRegion);
+//     "" falls back to the label "primary".
+//   - primaryStates: the primary watcher's terminal component-state map
+//     (dep.Result.ComponentStates).
+//   - secondaryStates: region key → that secondary watcher's component-state
+//     map (snapshotted from dep.secondaryWatchers).
+//
+// Returns the per-region breakdown (primary first, secondaries in sorted key
+// order for deterministic output) and secondaryDegraded = true when ANY
+// secondary is flagged degraded. secondaryDegraded is surface-only — callers
+// log it and expose it but MUST NOT gate "ready" on it.
+func ComputeRegionHealth(primaryRegion string, primaryStates map[string]string, secondaryStates map[string]map[string]string) (regions []RegionHealth, secondaryDegraded bool) {
+	priReady, priTotal := countInstalled(primaryStates)
+	primaryLabel := primaryRegion
+	if primaryLabel == "" {
+		primaryLabel = "primary"
+	}
+	regions = append(regions, RegionHealth{
+		Region:   primaryLabel,
+		Primary:  true,
+		HRReady:  priReady,
+		HRTotal:  priTotal,
+		Degraded: false,
+	})
+
+	// Deterministic secondary ordering — sort the region keys so the
+	// emitted slice (and any JSON the API serialises from it) is stable
+	// across polls and across test runs.
+	keys := make([]string, 0, len(secondaryStates))
+	for k := range secondaryStates {
+		keys = append(keys, k)
+	}
+	sortStrings(keys)
+
+	for _, region := range keys {
+		secReady, secTotal := countInstalled(secondaryStates[region])
+		degraded := regionDegraded(priReady, secReady, secTotal)
+		if degraded {
+			secondaryDegraded = true
+		}
+		regions = append(regions, RegionHealth{
+			Region:   region,
+			Primary:  false,
+			HRReady:  secReady,
+			HRTotal:  secTotal,
+			Degraded: degraded,
+		})
+	}
+	return regions, secondaryDegraded
+}
+
+// sortStrings is a tiny in-package insertion sort so region_health.go does
+// not pull "sort" just for one deterministic ordering. The secondary-region
+// count is tiny (1-3 regions in every real prov), so the O(n^2) cost is
+// irrelevant.
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/provisioner/region_health_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/region_health_test.go
@@ -1,0 +1,250 @@
+package provisioner
+
+import (
+	"reflect"
+	"testing"
+)
+
+// installedN returns a component-state map with `installed` entries named
+// c0..c(installed-1) and `installing` entries filling up to total — a compact
+// way to build a region census of "installed/total" for the table tests.
+func installedN(installed, total int) map[string]string {
+	if installed > total {
+		installed = total
+	}
+	m := make(map[string]string, total)
+	for i := 0; i < total; i++ {
+		state := "installing"
+		if i < installed {
+			state = "installed"
+		}
+		m[componentName(i)] = state
+	}
+	return m
+}
+
+func componentName(i int) string {
+	// stable distinct keys; the exact name is irrelevant to counting.
+	return "bp-component-" + string(rune('a'+i%26)) + "-" + itoa(i)
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}
+
+func TestComputeRegionHealth(t *testing.T) {
+	tests := []struct {
+		name             string
+		primaryRegion    string
+		primaryStates    map[string]string
+		secondaryStates  map[string]map[string]string
+		wantRegions      []RegionHealth
+		wantSecondaryDeg bool
+	}{
+		{
+			name:          "single-region primary only ready — no secondaries, not degraded",
+			primaryRegion: "me-east-215-a",
+			primaryStates: installedN(63, 63),
+			wantRegions: []RegionHealth{
+				{Region: "me-east-215-a", Primary: true, HRReady: 63, HRTotal: 63, Degraded: false},
+			},
+			wantSecondaryDeg: false,
+		},
+		{
+			name:          "both regions fully ready — secondary not degraded",
+			primaryRegion: "me-east-215-a",
+			primaryStates: installedN(63, 63),
+			secondaryStates: map[string]map[string]string{
+				"me-east-215-b": installedN(63, 63),
+			},
+			wantRegions: []RegionHealth{
+				{Region: "me-east-215-a", Primary: true, HRReady: 63, HRTotal: 63, Degraded: false},
+				{Region: "me-east-215-b", Primary: false, HRReady: 63, HRTotal: 63, Degraded: false},
+			},
+			wantSecondaryDeg: false,
+		},
+		{
+			name:          "secondary degraded — the hw145 case (region-a 60/63, region-b 48/63)",
+			primaryRegion: "me-east-215-a",
+			primaryStates: installedN(60, 63),
+			secondaryStates: map[string]map[string]string{
+				"me-east-215-b": installedN(48, 63),
+			},
+			wantRegions: []RegionHealth{
+				{Region: "me-east-215-a", Primary: true, HRReady: 60, HRTotal: 63, Degraded: false},
+				{Region: "me-east-215-b", Primary: false, HRReady: 48, HRTotal: 63, Degraded: true},
+			},
+			wantSecondaryDeg: true,
+		},
+		{
+			name:          "secondary one HR behind primary — NOT degraded (below absolute floor)",
+			primaryRegion: "reg-a",
+			primaryStates: installedN(63, 63),
+			secondaryStates: map[string]map[string]string{
+				"reg-b": installedN(62, 63),
+			},
+			wantRegions: []RegionHealth{
+				{Region: "reg-a", Primary: true, HRReady: 63, HRTotal: 63, Degraded: false},
+				{Region: "reg-b", Primary: false, HRReady: 62, HRTotal: 63, Degraded: false},
+			},
+			wantSecondaryDeg: false,
+		},
+		{
+			name:          "secondary fully installed but fewer total HRs than primary — NOT degraded",
+			primaryRegion: "reg-a",
+			primaryStates: installedN(63, 63),
+			secondaryStates: map[string]map[string]string{
+				// e.g. a region that does not host the marketplace: 55/55
+				// installed. shortfall 8 > floor and 55 < 0.9*63=56.7, but
+				// the secondary is FULLY installed so it must not be flagged.
+				"reg-b": installedN(55, 55),
+			},
+			wantRegions: []RegionHealth{
+				{Region: "reg-a", Primary: true, HRReady: 63, HRTotal: 63, Degraded: false},
+				{Region: "reg-b", Primary: false, HRReady: 55, HRTotal: 55, Degraded: false},
+			},
+			wantSecondaryDeg: false,
+		},
+		{
+			name:          "secondary watcher attached but zero HRs observed yet vs converged primary — degraded",
+			primaryRegion: "reg-a",
+			primaryStates: installedN(60, 63),
+			secondaryStates: map[string]map[string]string{
+				"reg-b": {},
+			},
+			wantRegions: []RegionHealth{
+				{Region: "reg-a", Primary: true, HRReady: 60, HRTotal: 63, Degraded: false},
+				{Region: "reg-b", Primary: false, HRReady: 0, HRTotal: 0, Degraded: true},
+			},
+			wantSecondaryDeg: true,
+		},
+		{
+			name:          "early convergence — both 0/0 — secondary NOT degraded (no meaningful primary baseline)",
+			primaryRegion: "reg-a",
+			primaryStates: map[string]string{},
+			secondaryStates: map[string]map[string]string{
+				"reg-b": {},
+			},
+			wantRegions: []RegionHealth{
+				{Region: "reg-a", Primary: true, HRReady: 0, HRTotal: 0, Degraded: false},
+				{Region: "reg-b", Primary: false, HRReady: 0, HRTotal: 0, Degraded: false},
+			},
+			wantSecondaryDeg: false,
+		},
+		{
+			name:          "empty primary region key falls back to 'primary' label",
+			primaryRegion: "",
+			primaryStates: installedN(10, 10),
+			wantRegions: []RegionHealth{
+				{Region: "primary", Primary: true, HRReady: 10, HRTotal: 10, Degraded: false},
+			},
+			wantSecondaryDeg: false,
+		},
+		{
+			name:          "three regions — one healthy secondary, one degraded; sorted deterministically; roll-up true",
+			primaryRegion: "reg-a",
+			primaryStates: installedN(60, 63),
+			secondaryStates: map[string]map[string]string{
+				// intentionally inserted out of sorted order to prove the
+				// output is sorted by region key.
+				"reg-c": installedN(40, 63), // degraded
+				"reg-b": installedN(60, 63), // healthy
+			},
+			wantRegions: []RegionHealth{
+				{Region: "reg-a", Primary: true, HRReady: 60, HRTotal: 63, Degraded: false},
+				{Region: "reg-b", Primary: false, HRReady: 60, HRTotal: 63, Degraded: false},
+				{Region: "reg-c", Primary: false, HRReady: 40, HRTotal: 63, Degraded: true},
+			},
+			wantSecondaryDeg: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotRegions, gotDeg := ComputeRegionHealth(tc.primaryRegion, tc.primaryStates, tc.secondaryStates)
+			if gotDeg != tc.wantSecondaryDeg {
+				t.Errorf("secondaryDegraded = %v, want %v", gotDeg, tc.wantSecondaryDeg)
+			}
+			if !reflect.DeepEqual(gotRegions, tc.wantRegions) {
+				t.Errorf("regions mismatch:\n got = %#v\nwant = %#v", gotRegions, tc.wantRegions)
+			}
+		})
+	}
+}
+
+func TestComputeRegionHealth_PrimaryAlwaysFirstAndNeverDegraded(t *testing.T) {
+	// Even when the primary is itself behind (it failed some HRs), the
+	// primary entry is never flagged Degraded — its own health is conveyed
+	// via dep.Status / Phase1Outcome, and Degraded is a secondary-only
+	// signal in this census.
+	regions, deg := ComputeRegionHealth("reg-a", installedN(10, 63), map[string]map[string]string{
+		"reg-b": installedN(63, 63),
+	})
+	if len(regions) != 2 {
+		t.Fatalf("want 2 regions, got %d", len(regions))
+	}
+	if !regions[0].Primary {
+		t.Errorf("first region must be the primary; got %+v", regions[0])
+	}
+	if regions[0].Degraded {
+		t.Errorf("primary must never be flagged degraded; got %+v", regions[0])
+	}
+	// secondary is fully installed → roll-up false even though the primary
+	// is the weak one.
+	if deg {
+		t.Errorf("secondaryDegraded must be false when the only secondary is fully installed; got true")
+	}
+}
+
+func TestRegionDegraded_Gate(t *testing.T) {
+	tests := []struct {
+		name                       string
+		priReady, secReady, secTot int
+		want                       bool
+	}{
+		{"secondary fully installed never degraded", 63, 55, 55, false},
+		{"one behind under floor", 63, 62, 63, false},
+		{"two behind under floor", 63, 61, 63, false},
+		{"three behind but still >=90% not degraded", 30, 27, 63, false}, // shortfall 3 >= floor, 27 >= 0.9*30=27 → not below ratio
+		{"hw145 12 behind and <90% degraded", 60, 48, 63, true},
+		{"exactly at 90% ratio not degraded", 100, 90, 120, false}, // 90 < 90? no
+		{"just below 90% ratio degraded", 100, 89, 120, true},      // 89 < 90 and shortfall 11
+		{"zero observed vs strong primary degraded", 60, 0, 0, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := regionDegraded(tc.priReady, tc.secReady, tc.secTot); got != tc.want {
+				t.Errorf("regionDegraded(%d,%d,%d) = %v, want %v", tc.priReady, tc.secReady, tc.secTot, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCountInstalled(t *testing.T) {
+	ready, total := countInstalled(map[string]string{
+		"a": "installed",
+		"b": "installed",
+		"c": "installing",
+		"d": "failed",
+		"e": "degraded",
+		"f": "pending",
+	})
+	if ready != 2 {
+		t.Errorf("ready = %d, want 2 (only 'installed' counts)", ready)
+	}
+	if total != 6 {
+		t.Errorf("total = %d, want 6", total)
+	}
+	// nil map → 0/0
+	if r, tot := countInstalled(nil); r != 0 || tot != 0 {
+		t.Errorf("countInstalled(nil) = %d/%d, want 0/0", r, tot)
+	}
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
@@ -519,12 +519,28 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
             </Link>
           </div>
         ) : streamStatus === 'completed' ? (
-          <Link
-            to={`/jobs` as never}
-            className="text-[11px] text-[var(--color-text-dim)] hover:text-[var(--color-text)] no-underline"
-          >
-            View install history
-          </Link>
+          <div className="flex items-center gap-2">
+            {/* #3611 — a ready multi-region Sovereign whose secondary
+                region is degraded surfaces an amber badge here instead of
+                only the bare "View install history" link, so the operator
+                sees the secondary lag at the deployment level. Surface-
+                only: the Sovereign IS ready (the primary converged). */}
+            {snapshot?.secondaryDegraded ? (
+              <span
+                data-testid="sov-secondary-degraded-pill"
+                title="Secondary region is significantly behind the primary in HelmRelease convergence"
+                className="rounded-lg border border-[#F59E0B]/40 bg-[#F59E0B]/10 px-2 py-1 text-[11px] font-semibold text-[#F59E0B]"
+              >
+                Secondary degraded
+              </span>
+            ) : null}
+            <Link
+              to={`/jobs` as never}
+              className="text-[11px] text-[var(--color-text-dim)] hover:text-[var(--color-text)] no-underline"
+            >
+              View install history
+            </Link>
+          </div>
         ) : null
       }
     >

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/DeploymentsList.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/DeploymentsList.tsx
@@ -305,6 +305,33 @@ export function DeploymentsList() {
                     >
                       {d.status}
                     </span>
+                    {/* #3611 — a "ready" multi-region prov whose secondary
+                        region is degraded gets an amber sub-badge so the
+                        status column stops claiming a flat green "ready".
+                        Surface-only: the deployment is still operationally
+                        ready (the primary converged); this flags that the
+                        secondary lags. */}
+                    {d.secondaryDegraded ? (
+                      <span
+                        data-testid={`deployments-list-secondary-degraded-${d.id}`}
+                        title="Secondary region is significantly behind the primary in HelmRelease convergence"
+                        style={{
+                          display: 'inline-block',
+                          marginLeft: 6,
+                          padding: '2px 8px',
+                          borderRadius: 999,
+                          background: 'rgba(245,158,11,0.10)',
+                          border: '1px solid rgba(245,158,11,0.35)',
+                          color: '#F59E0B',
+                          fontWeight: 600,
+                          fontSize: 11,
+                          textTransform: 'uppercase',
+                          letterSpacing: 0.4,
+                        }}
+                      >
+                        Secondary degraded
+                      </span>
+                    ) : null}
                   </td>
                   <td style={{ padding: '10px 12px', borderBottom: '1px solid var(--wiz-border)' }}>
                     {formatDate(d.startedAt)}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/useDeploymentEvents.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/useDeploymentEvents.ts
@@ -68,6 +68,25 @@ const IN_FLIGHT_STATUSES: ReadonlySet<string> = new Set([
   'phase1-watching',
 ])
 
+/**
+ * #3611 — per-region HelmRelease health, mirroring the Go `RegionHealth`
+ * struct in api/internal/provisioner/region_health.go. One entry per
+ * region observed in a multi-region deployment.
+ */
+export interface RegionHealth {
+  /** Region key — declared primary region (e.g. "me-east-215-a") or the
+   * cloud-init ?region= key a secondary control-plane PUT under. */
+  region: string
+  /** Exactly one entry is the primary (drives the deployment "ready"). */
+  primary: boolean
+  /** bp-* HelmReleases observed in the terminal "installed" state. */
+  hrReady: number
+  /** bp-* HelmReleases observed in this region. */
+  hrTotal: number
+  /** Secondary-only: significantly short of the primary's Ready count. */
+  degraded: boolean
+}
+
 export interface DeploymentSnapshot {
   id?: string
   status?: 'pending' | 'provisioning' | 'ready' | 'failed' | string
@@ -142,6 +161,28 @@ export interface DeploymentSnapshot {
    * poll-after-SSE-reconnect.
    */
   handoverFiredAt?: string
+  /**
+   * #3611 — per-region HelmRelease health census. For a multi-region
+   * deployment this is the only honest read of how each region actually
+   * converged: `componentStates` above collapses every region together,
+   * and `status: "ready"` is driven solely by the PRIMARY region's
+   * Phase-1 watch. A degraded secondary (hw145: region-a 60/63 HRs,
+   * region-b 48/63) would otherwise hide behind a bare green "ready" —
+   * this array surfaces "region-b 48/63, degraded" instead. Primary
+   * first, secondaries sorted by region key. Absent for single-region
+   * provs. Lifted to the top level by deployments.go (mirror of the Go
+   * `RegionHealth` struct in api/internal/provisioner/region_health.go).
+   */
+  regions?: RegionHealth[]
+  /**
+   * #3611 — surface-only roll-up of `regions`: true when any secondary
+   * region is significantly behind the primary's Ready-HR count. NOT a
+   * gate (catalyst-api keeps flipping `status: "ready"` off the primary
+   * watcher alone so a slow secondary never hangs the prov); it exists so
+   * the console can badge a "ready" deployment as "secondary degraded".
+   * Absent/false for single-region and fully-converged provs.
+   */
+  secondaryDegraded?: boolean
   result?: {
     sovereignFQDN: string
     controlPlaneIP: string

--- a/products/catalyst/bootstrap/ui/src/shared/lib/useInflightDeployment.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/useInflightDeployment.ts
@@ -53,6 +53,14 @@ export interface DeploymentListEntry {
   ownerEmail?: string
   adoptedAt?: string | null
   error?: string
+  /**
+   * #3611 — surface-only flag: true when a "ready" multi-region prov's
+   * secondary region is significantly behind the primary. Lets the
+   * deployments list badge it "secondary degraded" instead of a flat
+   * green pill. The full per-region breakdown lives on the detail
+   * response (GET /deployments/{id}); the list carries just this roll-up.
+   */
+  secondaryDegraded?: boolean
 }
 
 interface ListDeploymentsResponse {


### PR DESCRIPTION
## Problem

A 2-region deployment flips `status: ready` the instant the **primary** region's Phase-1 watch reaches `OutcomeReady` and the secondary kubeconfig lands. `markPhase1Done` (`internal/handler/phase1_watch.go`) never consults the secondary regions' per-component state — they are watched by `spawnSecondaryRegionWatchers` but never participate in the readiness classification.

**Live evidence (hw145):** region-a 60/63 HRs Ready, region-b **48/63** (openbao cascade), yet `status=ready`. A degraded secondary hid behind a flat green pill — overclaiming.

## Approach — surface, NOT hard-gate

Safety-critical scoping decision. A hard secondary-convergence gate risks **hanging provs** when a secondary is legitimately slow (Flux keeps reconciling long past the watch budget, and the doctrine forbids wiping such envs). So the existing `ready` gate is **untouched** — instead the degradation is made **visible**:

- `provisioner.RegionHealth` + `Result.Regions []RegionHealth` + `Result.SecondaryDegraded` (surface-only roll-up).
- `ComputeRegionHealth` (new `internal/provisioner/region_health.go`) is a **pure, table-tested** helper. Ready = HRs in the terminal `installed` state. A secondary is `degraded` when it is significantly short of the primary — **≥3-HR absolute shortfall AND <90% of the primary's Ready count** (mirrors the `convergedLateMinReady` 90% idiom; matches hw145's 48-vs-60). A secondary that is fully installed but simply runs fewer HRs than the primary is never flagged.
- `markPhase1Done` computes the census from the primary's `finalStates` + the still-attached secondary watchers' `SnapshotComponents()`, stamps it on `Result`, and logs a loud **Warn** when a `ready` deployment has a degraded secondary (greppable even when the operator only sees the green pill). **Status stays `ready` by design.**
- `Deployment.State()` lifts `regions` + `secondaryDegraded` to the top level and **recomputes live** off the in-memory informer caches while the watchers are attached (tracks convergence), falling back to the persisted snapshot after handover. `ListDeployments` adds `secondaryDegraded` to each row.

### UI (`products/catalyst/bootstrap/ui`)

`RegionHealth` + the two fields added to `DeploymentSnapshot` (`useDeploymentEvents.ts`) and `DeploymentListEntry` (`useInflightDeployment.ts`). An amber **"Secondary degraded"** sub-badge renders next to the status pill in `DeploymentsList.tsx` and in the Sovereign Admin header (`AppsPage.tsx`), reusing the existing degraded tone.

## Why surface-only (the scoping rationale)

`ready` gates the operator-facing handover surface. Blocking it on secondary convergence would re-introduce the exact prov-hang class the doctrine forbids (a slow-but-healthy secondary). Surfacing keeps the lifecycle unchanged while ending the overclaim. The `secondaryConverged`-style signal is delivered as the `secondaryDegraded` boolean — **logged + exposed, not gating**.

## Tests

- Table-driven Go unit tests for `ComputeRegionHealth` / `regionDegraded` / `countInstalled`: primary-only-ready, both-ready, **secondary-degraded (the hw145 case)**, fully-installed-but-fewer-HRs, zero-observed-vs-converged, early 0/0, 3-region deterministic sort.
- Handler `State()` surface tests: degraded secondary lifted to top level, healthy 2-region no badge, single-region no key, nil-Result no panic.
- `go build ./...` + `go test ./internal/{provisioner,handler}` green. UI `tsc -b --noEmit` green; touched UI test files (`DeploymentsList`, `AppsPage*`) all pass.

Refs #3611
Refs #3568

🤖 Generated with [Claude Code](https://claude.com/claude-code)
