### PR TITLE
docs(uat): complete the full-train walkthrough — openbao region-b, readiness surfacing, CRDs-in-vcluster + refine NS rows

### DIFF
--- a/docs/ledger/uat-walkthrough/train-2026-06-15.md
+++ b/docs/ledger/uat-walkthrough/train-2026-06-15.md
@@ -1,8 +1,13 @@
 # Catalog + Provisioning + North-Star train — fine-grained UAT walk (web UI)
 
 > **Scope:** the founder walks every feature of the catalog + provisioning + North-Star train on
-> the next fresh prov. **EPIC #3597** (catalog/provisioning UX) children **#3598 / #3599 / #3600 /
-> #3601 / #3602 / #3603**, plus the four standing North Stars **NS#1–NS#5**.
+> the next fresh prov (hw146). **EPIC #3597** (catalog/provisioning UX) children **#3598 / #3599 /
+> #3600 / #3601 / #3602 / #3603**, plus the four standing North Stars **NS#1–NS#5**, plus three
+> **fix-passengers** that merged after the original train and are now covered: **§9** openbao
+> region-b Continuum-CRD guard (PR #3613), **§10** per-region readiness surfacing (PR #3615), and
+> **§11** host CRDs registered inside vc-mgmt (PR #3403). §9/§11 verify infra (CRD reconcile,
+> region-b convergence) via `kubectl`/console — legitimate acceptance for those fixes — while every
+> other section is pure click-by-click UI; pure machine checks are demoted to the Appendix.
 >
 > **Format law (founder, 2026-06-03):** every row is **ONE UI action** — *Go to a URL → do one
 > click/type → see one screen/state.* Routes, button labels, and field names below are quoted
@@ -11,10 +16,11 @@
 > `grep` / `go test` / `kubectl` checks are demoted to the **Appendix — automated, NOT acceptance**.
 >
 > **Code provenance:** PR **#3604** (Apps/Catalog nav split · placement-in-create · namespace-ensure ·
-> dropdowns) is **merged to `main`** (commit `bdc6f2267`) — Sections 1, 2, 4 cite it. PR **#3605**
-> (editable catalog) is on branch **`feat/3602-3603-editable-catalog`** (commit `e206158f5`) — Section
-> 3 cites it; if #3605 is not yet merged at walk time, Section 3 is **pending merge** and is run on a
-> prov whose console image carries that branch.
+> dropdowns) **and** PR **#3605** (editable catalog, commit `b71c1d3eb`) are **both merged to `main`** —
+> Sections 1–4 all run on a fresh prov whose console image is at-or-past those commits. The fix-passenger
+> sections **§9 (#3613)**, **§10 (#3615)**, **§11 (#3403)** cover three fixes that merged *after* #3614
+> and are cited against the merged code. All `file:line` citations below were re-verified against the
+> current `main`-line console source on 2026-06-16.
 >
 > **Replace placeholders at walk time:** `<fqdn>` = the fresh prov's sovereign FQDN (e.g.
 > `hw146.omani.works`); `<JWT>` = the RS256 handover token (`iss=console.openova.io`,
@@ -38,34 +44,37 @@ install does **NOT** error *"namespace not found"* (the Org/Environment namespac
 server-side).
 
 > **Route facts.** Catalog page route = `/catalog` (`app/router.tsx:1330`, `consoleCatalogRoute`).
-> A catalog card is a `<Link>` to the class page `/catalog/$blueprintName` (`pages/sovereign/AppsPage.tsx:875`)
-> — there is **no** "Install/Create" button on the card itself; the create flow starts from the
-> class page's **+ New instance** button (`pages/sovereign/AppDetail/InstancesSection.tsx:114`).
+> A catalog card is a `<Link>` (`pages/sovereign/AppsPage.tsx:925`, `data-testid="sov-app-card-<id>"`
+> at `:928`) whose target is **computed** at `:919-923` — `const seg = isCatalog ? 'catalog' : 'app'`
+> → `/${seg}/${app.id}` (e.g. `/catalog/bp-postgres`). **There is NO "Install/Create" button on the
+> card** — the only card buttons are the admin **Edit** chip (`:1019`, §3) and a contexts deep-link
+> badge (`:976`). The create flow starts from the class page's **+ New instance** button
+> (`pages/sovereign/AppDetail/InstancesSection.tsx:100`).
 
 | Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
 |---|---|---|---|---|
-| 1.1 | `https://console.<fqdn>/catalog` | Read the left-nav + the page title | A grid of catalog cards; the page title reads **"Catalog"** (`CatalogPage.tsx:141`, `pageTitle="Catalog"`) | ☐ |
-| 1.2 | `https://console.<fqdn>/catalog` | Click the **PostgreSQL** card (title **"PostgreSQL"**, badge **⛓ shareable**) | The card is a link — you land on the class page **`/catalog/bp-postgres`** (the card `<Link>`, `AppsPage.tsx:875`) | ☐ |
-| 1.3 | `https://console.<fqdn>/catalog/bp-postgres` | Click the **`+ New instance`** button (top-right of the Instances table) | A dialog opens titled **"New instance of bp-postgres"** (`InstancesSection.tsx:650`, button `data-testid="btn-new-instance"` at `:114`) | ☐ |
-| 1.4 | (in the dialog) | Read **field 1**, labelled **"Instance name"**, and type `demo-pg-1` | A free-text input (`data-testid="input-instance-name"`, `InstancesSection.tsx:655,659`) — the comment at `:653` states it is **"the ONLY free-text field (#3600)"**; placeholder `my-instance` | ☐ |
-| 1.5 | (in the dialog) | Open **field 2**, labelled **"Organization"** | A **`<select>` dropdown** (`data-testid="select-instance-org"`, `InstancesSection.tsx:671,673`) whose options are live Orgs (`{displayName} ({slug})`), placeholder **"Select an organization…"** — **not free-text** | ☐ |
-| 1.6 | (in the dialog) | Pick the **`platform`** organization from the dropdown | A read-only line appears: **"Environment: platform-prod"** (`data-testid="instance-environment-derived"`, `InstancesSection.tsx:698-703`) — the namespace the install targets | ☐ |
-| 1.7 | (in the dialog) | Open **field 3**, labelled **"Topology mode"** | A **`<select>` dropdown** (`data-testid="select-instance-topology"`, `InstancesSection.tsx:709,714`) listing the Blueprint's supported modes, each `{mode} — {description}` from `ALL_MODES = ['single-region','active-active','active-hotstandby']` (`TopologyEditor.tsx:63`) | ☐ |
-| 1.8 | (in the dialog) | Select **`active-hotstandby — primary serves; standby ready for switchover`** | The mode is chosen (`TopologyEditor.tsx:348-349`); the Region(s) legend below flips to require multiple regions (next row) | ☐ |
-| 1.9 | (in the dialog) | Read **field 4**, the **"Region(s)"** fieldset | A **checkbox group** (`data-testid="instance-regions"`, `InstancesSection.tsx:726-727,751`), **not** a dropdown; with a multi-region mode the legend reads **"Region(s) — pick at least 2"** (`:736`); options are the live cluster regions `<region-a>` / `<region-b>` (`region-checkbox-<region>`, `:758-761`) | ☐ |
-| 1.10 | (in the dialog) | Tick **both** region checkboxes `<region-a>` and `<region-b>` | Both boxes check; **no** validation error. (If only one is ticked, the error **"active-hotstandby needs at least 2 regions."** shows at `data-testid="instance-regions-validation"`, `:768-774`) | ☐ |
-| 1.11 | (in the dialog) | Open **field 5**, labelled **"vCluster / zone"** | A **`<select>` dropdown** (`data-testid="select-instance-vcluster"`, `InstancesSection.tsx:780,784`) with options **Default (server picks)** + the fixed zone set **`host` / `mgmt` / `dmz` / `rtz`** (`VCLUSTER_OPTIONS`, `:39`) — **not free-text** | ☐ |
-| 1.12 | (in the dialog) | Select **`rtz`** from the vCluster dropdown | `rtz` is selected as the placement zone (the value the backend validates against `{host,mgmt,dmz,rtz}`, comment `:843`) | ☐ |
-| 1.13 | (in the dialog) | Click the submit button labelled **"Create instance"** | The button (`data-testid="btn-submit-instance"`, `InstancesSection.tsx:862,875`) shows **"Creating…"**, then the dialog **closes** (`onCreated` → `setDialogOpen(false)`, `:295`). **No** *"namespace not found"* error appears | ☐ |
-| 1.14 | `https://console.<fqdn>/catalog/bp-postgres` | Read the **Instances** table | A **new row `demo-pg-1`** appears in the instances table (`sov-instances-table`); its name links to **`/app/demo-pg-1`** (`InstancesSection.tsx:296` refetch) — the Application installed into the ensured `platform-prod` namespace | ☐ |
-| 1.15 | `https://console.<fqdn>/app/demo-pg-1` | Read the **Placement** row on the Overview | **"Placement"** reads `active-hotstandby` (`data-testid="app-detail-overview-placement"`, `AppDetail.tsx:1289-1292`) — the topology you chose persisted onto the Application CR | ☐ |
+| 1.1 | `https://console.<fqdn>/catalog` | Read the left-nav + the page title | A grid of catalog cards; the page title reads **"Catalog"** (`CatalogPage.tsx:194`, `pageTitle="Catalog"` on the `<PortalShell>`) | ☐ |
+| 1.2 | `https://console.<fqdn>/catalog` | Click the **PostgreSQL** card (title **"PostgreSQL"**, badge **⛓ shareable**) — note the card has **no** Install button, the whole card is the link | The card `<Link>` (`AppsPage.tsx:925`, target computed at `:919-923`) navigates you to the class page **`/catalog/bp-postgres`** | ☐ |
+| 1.3 | `https://console.<fqdn>/catalog/bp-postgres` | Click the **`+ New instance`** button (top-right of the Instances table) | A dialog opens titled **"New instance of postgres"** (the `bp-` prefix is stripped, `InstancesSection.tsx:500`; title at `:650`); button `data-testid="btn-new-instance"` at `:100`, label `+ New instance` at `:115` | ☐ |
+| 1.4 | (in the dialog) | Read **field 1**, labelled **"Instance name"**, and type `demo-pg-1` | A free-text input (`data-testid="input-instance-name"`, `InstancesSection.tsx:658`; placeholder `my-instance` at `:664`) — the comment at `:653` states it is **"the ONLY free-text field (#3600)"** | ☐ |
+| 1.5 | (in the dialog) | Open **field 2**, labelled **"Organization"** (label span at `:671`) | A **`<select>` dropdown** (`data-testid="select-instance-org"`, `InstancesSection.tsx:673`) whose options are live Orgs (`{displayName} ({slug})`), placeholder **"Select an organization…"** (`:680`) — **not free-text** | ☐ |
+| 1.6 | (in the dialog) | Pick the **`platform`** organization from the dropdown | A read-only line appears: **"Environment: platform-prod"** (`data-testid="instance-environment-derived"` at `InstancesSection.tsx:693`, rendered text at `:701`) — the namespace the install targets | ☐ |
+| 1.7 | (in the dialog) | Open **field 3**, labelled **"Topology mode"** (label span at `:709`) | A **`<select>` dropdown** (`data-testid="select-instance-topology"`, `InstancesSection.tsx:711`) listing the Blueprint's supported modes, each `{mode} — {description}` from `ALL_MODES = ['single-region','active-active','active-hotstandby']` (`TopologyEditor.tsx:63`) | ☐ |
+| 1.8 | (in the dialog) | Select **`active-hotstandby — primary serves; standby ready for switchover`** | The mode is chosen; the description text comes from `describeMode` (`TopologyEditor.tsx:348`, the `active-hotstandby` case → *"primary serves; standby ready for switchover"*); the Region(s) legend below flips to require multiple regions (next row) | ☐ |
+| 1.9 | (in the dialog) | Read **field 4**, the **"Region(s)"** fieldset | A **checkbox group** (`data-testid="instance-regions"`, `InstancesSection.tsx:727`), **not** a dropdown; with a multi-region mode the legend (`:735-737`) reads **"Region(s) — pick at least 2"**; options are the live cluster regions `<region-a>` / `<region-b>` (`region-checkbox-<region>`, `:760`) | ☐ |
+| 1.10 | (in the dialog) | Tick **both** region checkboxes `<region-a>` and `<region-b>` | Both boxes check; **no** validation error. (If only one is ticked, the error **"active-hotstandby needs at least 2 regions."** — rendered `{topology} needs at least 2 regions.` at `:772` — shows at `data-testid="instance-regions-validation"`, `:769`) | ☐ |
+| 1.11 | (in the dialog) | Open **field 5**, labelled **"vCluster / zone"** (label span at `:780`) | A **`<select>` dropdown** (`data-testid="select-instance-vcluster"`, `InstancesSection.tsx:782`) with options **Default (server picks)** (`:787`) + the fixed zone set **`host` / `mgmt` / `dmz` / `rtz`** (`VCLUSTER_OPTIONS`, `:39`) — **not free-text** | ☐ |
+| 1.12 | (in the dialog) | Select **`rtz`** from the vCluster dropdown | `rtz` is selected as the placement zone (the `<select>` block is `InstancesSection.tsx:781-800`; the value is validated server-side against `{host,mgmt,dmz,rtz}`) | ☐ |
+| 1.13 | (in the dialog) | Click the submit button labelled **"Create instance"** | The button (`data-testid="btn-submit-instance"`, `InstancesSection.tsx:862`; label `{submitting ? 'Creating…' : 'Create instance'}` at `:875`) shows **"Creating…"**, then the dialog **closes** (`onCreated` → `setDialogOpen(false)` at `:294`). **No** *"namespace not found"* error appears | ☐ |
+| 1.14 | `https://console.<fqdn>/catalog/bp-postgres` | Read the **Instances** table | A **new row `demo-pg-1`** appears (table refetched via `qc.invalidateQueries` at `InstancesSection.tsx:297`); its name links to **`/app/demo-pg-1`** — the Application installed into the ensured `platform-prod` namespace | ☐ |
+| 1.15 | `https://console.<fqdn>/app/demo-pg-1` | Read the **Placement** row on the Overview | **"Placement"** (`<dt>` at `AppDetail.tsx:1290`) reads `active-hotstandby` (`<dd data-testid="app-detail-overview-placement">` at `:1291`) — the topology you chose persisted onto the Application CR | ☐ |
 
 **Section 1 result: ___ / 15.** Every fixed-set input was a dropdown/checkbox (#3600); the wizard
 collected Organization + topology + regions + vCluster (#3599); the install did not error
 "namespace not found" (#3598).
 
 > **Honest note.** The catalog card itself carries **no** install button — you click the card to
-> reach the class page, then **+ New instance** (`InstancesSection.tsx:114`). That two-hop is the
+> reach the class page, then **+ New instance** (`InstancesSection.tsx:100`). That two-hop is the
 > shipped flow, not a missing button.
 
 ---
@@ -77,11 +86,11 @@ is gone) and **Catalog** is its own **left-nav entry** at `/catalog`.
 
 | Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
 |---|---|---|---|---|
-| 2.1 | `https://console.<fqdn>/dashboard` | Look at the left-nav rail for the **Apps** and **Catalog** items | Two **separate** nav entries: **"Apps"** (`SovereignSidebar.tsx:67-68`, `label:'Apps'` / `to:'/apps'`) and **"Catalog"** (`SovereignSidebar.tsx:80-81`, `label:'Catalog'` / `to:'/catalog'`) — the catalog is its OWN left-nav page now, no longer a tab on /apps | ☐ |
-| 2.2 | `https://console.<fqdn>/dashboard` | Click the **"Apps"** nav item | Navigates to **`/apps`**; the page title reads **"Applications"** (`AppsPage.tsx:504`, `pageTitle="Applications"`) | ☐ |
-| 2.3 | `https://console.<fqdn>/apps` | Look across the top of the Apps page for any tab strip | **No** "Deployments / Catalog" tabs render — only the installed-deployments grid (`AppsPage.tsx:7` header *"the page is TAB-LESS"*; inline `:593` *"Deployments/Catalog tabs removed"*) | ☐ |
-| 2.4 | `https://console.<fqdn>/apps` | If the grid is empty, find the empty-state link | The only catalog link here is the empty-state CTA **"Open catalog →"** → `/catalog` (`AppsPage.tsx:634`) — it is a link, **not** a tab | ☐ |
-| 2.5 | `https://console.<fqdn>/apps` | Click the **"Catalog"** nav item | Navigates to **`/catalog`** (a distinct route, `router.tsx:1330`); the page title reads **"Catalog"** (`CatalogPage.tsx:141`) | ☐ |
+| 2.1 | `https://console.<fqdn>/dashboard` | Look at the left-nav rail for the **Apps** and **Catalog** items | Two **separate** nav entries: **"Apps"** (`SovereignSidebar.tsx:68` `label:'Apps'` / `:69` `to:'/apps'`) and **"Catalog"** (`SovereignSidebar.tsx:80` `label:'Catalog'` / `:81` `to:'/catalog'`) — the catalog is its OWN left-nav page now, no longer a tab on /apps | ☐ |
+| 2.2 | `https://console.<fqdn>/dashboard` | Click the **"Apps"** nav item | Navigates to **`/apps`**; the page title reads **"Applications"** (`AppsPage.tsx:505`, `pageTitle="Applications"`) | ☐ |
+| 2.3 | `https://console.<fqdn>/apps` | Look across the top of the Apps page for any tab strip | **No** "Deployments / Catalog" tabs render — only the installed-deployments grid (`AppsPage.tsx:7` header *"the page is TAB-LESS"*; inline comment `:610-611` *"Deployments/Catalog tabs removed: /apps is the installed grid only"*) | ☐ |
+| 2.4 | `https://console.<fqdn>/apps` | If the grid is empty, find the empty-state link | The only catalog link here is the empty-state CTA **"Open catalog →"** → `/catalog` (`AppsPage.tsx:650-651`, `data-testid="sov-empty-open-catalog"`) — it is a link, **not** a tab | ☐ |
+| 2.5 | `https://console.<fqdn>/apps` | Click the **"Catalog"** nav item | Navigates to **`/catalog`** (a distinct route, `router.tsx:1330`); the page title reads **"Catalog"** (`CatalogPage.tsx:194`) | ☐ |
 | 2.6 | `https://console.<fqdn>/catalog` | Confirm the URL + that this is a standalone page (not `/apps?tab=...`) | The address bar reads exactly **`/catalog`**; the catalog grid renders as its own page (`consoleCatalogRoute`, `router.tsx:1328-1332`) | ☐ |
 
 **Section 2 result: ___ / 6.** `/apps` is tab-less (Applications), Catalog is a separate left-nav
@@ -95,26 +104,27 @@ page at `/catalog`.
 **supported topologies**, **light icon**, and **dark icon**; **Save** persists the change to the
 data-backed catalog overlay; the edit **survives a full page reload**.
 
-> **Provenance.** This section's code is on branch **`feat/3602-3603-editable-catalog`** (PR #3605,
-> `CatalogEditDialog.tsx`). Run it on a prov whose console image carries that branch. If #3605 is not
-> yet merged, mark this section **pending merge**.
+> **Provenance.** Editable-catalog (PR #3605, `CatalogEditDialog.tsx`) is **merged to `main`**
+> (commit `b71c1d3eb`, alongside #3604), so this section runs on any fresh prov whose console image
+> is at-or-past that commit. The dialog file is `pages/sovereign/CatalogEditDialog.tsx`.
 >
-> **Admin gate.** The per-card **Edit** button renders **only** when `isAdmin` is true
-> (`CatalogPage.tsx:259` passes `onEdit` only `isAdmin ? … : undefined`; absent ⇒ no button,
-> `AppsPage.tsx:1000`). `isAdmin` = the operator's tier is `admin` or `owner` (`useCatalogAdmin.ts:41-47`).
-> The handover identity `emrah.baysal@openova.io` (`role=sovereign-admin`) satisfies this.
+> **Admin gate.** The per-card **Edit** button renders **only** when `isAdmin` is true: `CatalogPage.tsx`
+> resolves `const isAdmin = useCatalogAdmin()` (`:143`) and passes `onEdit` only `isAdmin ? … : undefined`
+> (`:259`); on the card the chip is gated by `{onEdit ? (` (`AppsPage.tsx:1016`) — absent ⇒ no button.
+> `isAdmin` = the operator's tier is `admin` or `owner` (`useCatalogAdmin.ts:41-47`). The handover
+> identity `emrah.baysal@openova.io` (`role=sovereign-admin`) satisfies this.
 
 | Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
 |---|---|---|---|---|
-| 3.1 | `https://console.<fqdn>/catalog` | Hover the **Grafana** card and find the corner control | A **pencil-icon + "Edit"** chip in the card's status corner (`AppsPage.tsx:1027`, `.edit-chip`, `data-testid="sov-app-edit-<id>"`, `title="Edit Grafana catalog entry"`) | ☐ |
+| 3.1 | `https://console.<fqdn>/catalog` | Hover the **Grafana** card and find the corner control | A **pencil-icon + "Edit"** chip in the card's status corner (`AppsPage.tsx:1019-1022`, `.edit-chip`, `data-testid="sov-app-edit-<id>"`, `title="Edit Grafana catalog entry"`) | ☐ |
 | 3.2 | `https://console.<fqdn>/catalog` | Click the **Edit** chip on the Grafana card | A dialog opens titled **"Edit catalog entry"** (`CatalogEditDialog.tsx:115`, outer `role="dialog"` aria-label *"Edit catalog entry Grafana"* `:111`) | ☐ |
-| 3.3 | (in the dialog) | Read **field 1**, labelled **"Display name"**, and change it to `Grafana Observability` | A text input (`data-testid="catalog-edit-name"`, `CatalogEditDialog.tsx:122`, placeholder `WordPress`) | ☐ |
-| 3.4 | (in the dialog) | Read **field 2**, labelled **"Summary"** (optional one-liner) | A `<textarea>` (`data-testid="catalog-edit-summary"`, `CatalogEditDialog.tsx:133`, placeholder *"One-line description shown on the card"*) | ☐ |
-| 3.5 | (in the dialog) | Read **field 3**, labelled **"Supported topologies"** | A row of **checkboxes**, one per mode — **single-region**, **active-active**, **active-hotstandby** (`ALL_MODES`, `CatalogEditDialog.tsx:146-157`; each `data-testid="catalog-edit-topo-<mode>"`) | ☐ |
+| 3.3 | (in the dialog) | Read **field 1**, labelled **"Display name"** (label at `:122`), and change it to `Grafana Observability` | A text input (`data-testid="catalog-edit-name"`, `CatalogEditDialog.tsx:128`, placeholder `WordPress`) | ☐ |
+| 3.4 | (in the dialog) | Read **field 2**, labelled **"Summary"** (optional one-liner, label at `:133`) | A `<textarea>` (`data-testid="catalog-edit-summary"`, `CatalogEditDialog.tsx:139`, placeholder *"One-line description shown on the card"*) | ☐ |
+| 3.5 | (in the dialog) | Read **field 3**, labelled **"Supported topologies"** | A row of **checkboxes**, one per mode — **single-region**, **active-active**, **active-hotstandby** (mapped over `ALL_MODES`, `CatalogEditDialog.tsx:148-158`; each `data-testid="catalog-edit-topo-<mode>"` at `:154`) | ☐ |
 | 3.6 | (in the dialog) | Tick the **active-active** checkbox so it joins the supported set | The `active-active` box checks (`catalog-edit-topo-active-active`) — the supported-topologies set is now editable, not static | ☐ |
-| 3.7 | (in the dialog) | Read **field 4**, labelled **"Light-theme icon"**, and paste an image URL into its text box | A URL text input (`data-testid="catalog-edit-icon-light"`, `CatalogEditDialog.tsx:163`, placeholder *"https://… or upload"*) **plus** an **"Upload"** file picker (`catalog-edit-icon-light-upload-label`) | ☐ |
-| 3.8 | (in the dialog) | Read **field 5**, labelled **"Dark-theme icon"**, and paste an image URL into its text box | A URL text input (`data-testid="catalog-edit-icon-dark"`, `CatalogEditDialog.tsx:186`) plus an **"Upload"** file picker (`catalog-edit-icon-dark-upload-label`) | ☐ |
-| 3.9 | (in the dialog) | Click the **"Save"** button | The button (`data-testid="catalog-edit-save"`, `CatalogEditDialog.tsx:222`) shows **"Saving…"**, then the dialog **closes**; a `PUT /api/v1/sme/commerce/apps/{id}` persists the row (`commerce.api.ts:224`) | ☐ |
+| 3.7 | (in the dialog) | Read **field 4**, labelled **"Light-theme icon"** (label at `:163`), and paste an image URL into its text box | A URL text input (`data-testid="catalog-edit-icon-light"`, `CatalogEditDialog.tsx:170`, placeholder *"https://… or upload"*) **plus** an **"Upload"** file picker (`catalog-edit-icon-light-upload-label`) | ☐ |
+| 3.8 | (in the dialog) | Read **field 5**, labelled **"Dark-theme icon"** (label at `:186`), and paste an image URL into its text box | A URL text input (`data-testid="catalog-edit-icon-dark"`, `CatalogEditDialog.tsx:194`) plus an **"Upload"** file picker (`catalog-edit-icon-dark-upload-label`) | ☐ |
+| 3.9 | (in the dialog) | Click the **"Save"** button | The button (`data-testid="catalog-edit-save"`, `CatalogEditDialog.tsx:225`; label `{saving ? 'Saving…' : 'Save'}` at `:227`) shows **"Saving…"**, then the dialog **closes**; `saveCatalogEdit` (`commerce.api.ts:224`) issues `PUT /api/v1/sme/commerce/apps/{id}` (the path is built in `writeCommerce`, `commerce.api.ts:150`) to persist the row | ☐ |
 | 3.10 | `https://console.<fqdn>/catalog` | Read the Grafana card again (no reload yet) | The card now shows the new name **"Grafana Observability"** + the new icon (overlay applied live, `CatalogPage.tsx:233-239,257-258` after `editsQuery.refetch()`) | ☐ |
 | 3.11 | `https://console.<fqdn>/catalog` | **Hard-reload** the page (Ctrl/Cmd-Shift-R), then read the Grafana card | The edited name **"Grafana Observability"** + icon **persist** — the overlay is re-fetched on mount and merged server-side (`GET /api/v1/sme/commerce/apps`; `catalog_overlay.go` merges store rows onto the seed) — proving it is **data-backed, not in-memory** | ☐ |
 
@@ -145,7 +155,7 @@ surface** — the dashboard treemap grouped by vCluster, and the per-app **Place
 | 4.3 | `https://console.<fqdn>/dashboard` | Read the **`mgmt`** block tiles | The mgmt vCluster contains the mgmt-targeted apps (`loki`/`mimir`/`tempo`/`nats`) | ☐ |
 | 4.4 | `https://console.<fqdn>/dashboard` | Read the **`rtz`** + **`dmz`** block tiles | `rtz` contains rtz-targeted apps (`valkey`/`seaweedfs`/`vllm`); `dmz` contains `coraza` | ☐ |
 | 4.5 | `https://console.<fqdn>/dashboard` | Read the **`host`** block tiles | The route/secret apps (`keycloak`/`gitea`/`grafana`/`harbor`/`openbao`) render under `host` — held there by ratified #3373 design (sovereignty), **not** a defect | ☐ |
-| 4.6 | `https://console.<fqdn>/app/bp-coraza` | Read the **"Placement"** row on the Overview tab | **"Placement"** field renders the app's declared placement (`AppDetail.tsx:1289-1292`, `app-detail-overview-placement`) — the per-app confirmation that placement is a first-class field | ☐ |
+| 4.6 | `https://console.<fqdn>/app/bp-coraza` | Read the **"Placement"** row on the Overview tab | **"Placement"** field (`<dt>` at `AppDetail.tsx:1290`, `<dd data-testid="app-detail-overview-placement">` at `:1291`) renders the app's declared placement — the per-app confirmation that placement is a first-class field | ☐ |
 
 **Section 4 result: ___ / 6.** The treemap's LAYER1=vCluster grouping renders the four blocks and
 the app-detail Placement field corroborates per-app membership.
@@ -157,16 +167,18 @@ the app-detail Placement field corroborates per-app membership.
 **North Star #2 (founder, verbatim):** *"3 shared PG instances → 3 cards, 6-7 apps many-to-many."*
 The Contexts tab appears on each **⛓ shareable** instance's app-detail page.
 
-> Routes/labels carried from the established `3370-contexts.md` hw144 walk (same console build).
-> Exact context rows are env-specific; tick when the *shape* (3 cards · per-instance Contexts tab ·
-> distinct consumer sets) renders.
+> Routes/labels re-verified against current `main` console source 2026-06-16. Exact context rows are
+> env-specific; tick when the *shape* (3 cards · per-instance Contexts tab · distinct consumer sets)
+> renders. **Tab-label note:** the tab reads **"Contexts"** with a **separate numeric count badge**
+> (`AppDetail.tsx:669-677` renders `<TabButton id="contexts" label="Contexts" count={appContexts.length} …/>`,
+> shown only when the instance is `appShareable`) — it is not the literal string "Contexts N".
 
 | Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
 |---|---|---|---|---|
 | 5.1 | `https://console.<fqdn>/catalog/bp-postgres` | Read the hero badges + the **Instances** table | Hero shows **⛓ shareable**; the Instances table lists **3 rows** — `shared-pg`, `shared-pg-b`, `shared-pg-c` (org `platform`), each Ready with an **Open →** link | ☐ |
-| 5.2 | `https://console.<fqdn>/app/shared-pg` | Click the **"Contexts N"** tab | A table headed **`Context · Occupied by · Credential · Status`** with rows binding **harbor / gitea / keycloak** (3 distinct consumers) | ☐ |
-| 5.3 | `https://console.<fqdn>/app/shared-pg-b` | Click the **"Contexts N"** tab | A **distinct** consumer set — **grafana / powerdns / powerdns-admin** | ☐ |
-| 5.4 | `https://console.<fqdn>/app/shared-pg-c` | Click the **"Contexts N"** tab | A third consumer set — **catalyst-platform (sme_*) / newapi / openova-flow** | ☐ |
+| 5.2 | `https://console.<fqdn>/app/shared-pg` | Click the **"Contexts"** tab (with its count badge, `AppDetail.tsx:669-677`) | A table (`data-testid="sov-contexts-table"`, `ContextsTab.tsx:39`) headed **`Context · Occupied by · Credential · Status`** (`ContextsTab.tsx:50-53`) with rows binding **harbor / gitea / keycloak** (3 distinct consumers) | ☐ |
+| 5.3 | `https://console.<fqdn>/app/shared-pg-b` | Click the **"Contexts"** tab | A **distinct** consumer set — **grafana / powerdns / powerdns-admin** | ☐ |
+| 5.4 | `https://console.<fqdn>/app/shared-pg-c` | Click the **"Contexts"** tab | A third consumer set — **catalyst-platform (sme_*) / newapi / openova-flow** | ☐ |
 | 5.5 | (review) | Count the distinct consumer apps across the 3 instances | **6–7+ distinct apps** bind the 3 instances many-to-many — one engine, many consumers, isolated per-context credentials | ☐ |
 
 **Section 5 result: ___ / 5.** 3 shared-PG instance cards + per-instance Contexts tabs, genuinely
@@ -181,13 +193,17 @@ ADMIN; proof = surfing admin panels."* In a **fresh window**, a bare app URL lan
 the owner-admin — zero clicks, no PIN/login form. A redirect ending on a login screen or a 4xx/5xx is
 a **fail**.
 
-> Routes/labels carried from the established `3374-sso.md` hw144 walk (same console build).
+> Routes/labels re-verified against current `main` console source 2026-06-16. The left-rail nav order
+> is confirmed in `SovereignSidebar.tsx` `FLAT_NAV` (`:52-148`) + the pinned `SETTINGS_ITEM` (`:150`):
+> **Dashboard** (`:55`) · **Cloud** (`:62`) · **Apps** (`:68`) · **Catalog** (`:80`) · **Sandbox**
+> (`:96`) · **Jobs** (`:102`) · **Compliance** (`:118`) · **Users** (`:124`) · **Organizations**
+> (`:144`) · **Settings** (`:152`).
 
 | Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
 |---|---|---|---|---|
-| 6.1 | `https://console.<fqdn>/auth/handover?token=<JWT>` | Paste into a **fresh** tab, press Enter | 302 → `/dashboard`, **signed in, no login form**; left-rail nav (Dashboard, Cloud, Apps, Catalog, Sandbox, Jobs, Compliance, Users, Organizations, Settings); avatar **E** top-right | ☐ |
-| 6.2 | `https://console.<fqdn>/dashboard` | Click the avatar **E** (top-right, `data-testid="profile-menu-avatar"`) | A menu reading **"Signed in as emrah.baysal@openova.io"** + **Sign out** — the landed identity is the owner | ☐ |
-| 6.3 | `https://console.<fqdn>/app/bp-grafana` | Read the header, click the **Endpoints** tab | Header shows the **`↗ Open Grafana`** button + *"Single sign-in — no second login."*; Endpoints lists `grafana.<fqdn> · https · Ready · Open →` | ☐ |
+| 6.1 | `https://console.<fqdn>/auth/handover?token=<JWT>` | Paste into a **fresh** tab, press Enter | 302 → `/dashboard`, **signed in, no login form**; the 10-item left-rail nav (Dashboard, Cloud, Apps, Catalog, Sandbox, Jobs, Compliance, Users, Organizations, Settings) renders; avatar **E** top-right | ☐ |
+| 6.2 | `https://console.<fqdn>/dashboard` | Click the avatar (top-right; `data-testid="profile-menu-avatar"`, `widgets/auth/ProfileMenu.tsx:104`; the initial is `session.email[0]` so it shows **E**) | A menu reading **"Signed in as"** (`ProfileMenu.tsx:150`) followed by the live `session.email` (`data-testid="profile-menu-email"`, `:161`) — for the handover identity this is **`emrah.baysal@openova.io`** — plus a **Sign out** button (`:184`) | ☐ |
+| 6.3 | `https://console.<fqdn>/app/bp-grafana` | Read the header, click the **Endpoints** tab | Header shows the **`↗ Open Grafana`** launch button (`<LaunchButton variant="hero">` at `AppDetail.tsx:608`; label `Open ${appLabel}` at `:1194`, `↗` glyph + text rendered as two spans at `:1211/:1213`, `data-testid="btn-launch-app"` `:1199`) + the hint *"Single sign-in — no second login."* (`:614-616`); the **Endpoints** tab (`AppDetail.tsx:684`) lists `grafana.<fqdn> · https · Ready · Open →` | ☐ |
 | 6.4 | `https://grafana.<fqdn>` | Type the bare URL in a fresh tab, press Enter | Lands on **Grafana → Home/Dashboards**, **no login form**, avatar top-right (lands as ADMIN — `/api/user` `isGrafanaAdmin=true`) | ☐ |
 | 6.5 | `https://registry.<fqdn>` | Type the bare URL in a fresh tab, press Enter | Auto-redirects to **`/harbor/projects`**, **no login form**; `emrah.baysal@openova.io` top-right; **Administration** menu visible | ☐ |
 | 6.6 | `https://bao.<fqdn>` | Type the bare URL in a fresh tab, press Enter | OIDC round-trip completes → lands on **`/ui/vault/secrets`** (Secrets Engines), **no** `/ui/vault/auth` login form | ☐ |
@@ -206,12 +222,13 @@ walk** (the console treemap only *displays* region health), so rows 7.3–7.5 ru
 cluster kubeconfigs (region-a `/tmp/<fqdn>.kc`, region-b `/tmp/<fqdn>-b.kc`). It is included here so
 the founder sees the full North-Star set in one document.
 
-> Procedure carried from the established `3375-topology-dr.md` hw144 PASS (RTO ≈ 4s, RPO = 0).
+> Procedure carried from the established `3375-topology-dr.md` hw144 PASS (RTO ≈ 4s, RPO = 0); UI
+> citations re-verified against current `main` source 2026-06-16.
 
 | Step | Go to / run | Do | Expect | ☐ |
 |---|---|---|---|---|
-| 7.1 | `https://console.<fqdn>/cloud` | Read the Region / Cluster counters on the cloud graph | The cloud topology graph reports **Region 2/2** + **Cluster 2/2** (`/cloud` route, `router.tsx:1364`) | ☐ |
-| 7.2 | `https://console.<fqdn>/app/shared-pg` | Click the **Topology** tab; read the **Change placement** editor | A real editor — mode radios single-region / active-active / active-hotstandby; **Regions** checkboxes `<region-a>` + `<region-b>`; **Preview** + **Apply** (`AppDetail.tsx:678` Topology tab) — proving the picker is editable, not cosmetic | ☐ |
+| 7.1 | `https://console.<fqdn>/cloud` | Read the **Clusters** / **vClusters** infra tiles + the topology graph | The Cloud page (`/cloud` route, `router.tsx:1364`) shows the **"Clusters"** and **"vClusters"** tiles (`cloud-compute/CloudComputePage.tsx:7,12`, tagline *"k3s / k8s control planes — one per region"*) with a count of **2** clusters (one per region) plus the FlowCanvas topology graph (`FlowCanvasOrganic.tsx`) drawing both regions. *(There is no literal "Region 2/2" pill — read the per-region cluster count from the tiles + graph.)* | ☐ |
+| 7.2 | `https://console.<fqdn>/app/shared-pg` | Click the **Topology** tab; read the **Change placement** editor | The **Topology** tab (`<TabButton id="topology" label="Topology">` at `AppDetail.tsx:678`) opens the **"Change placement"** editor (`TopologyTab.tsx:307-309` heading; `<TopologyEditor>` mounted at `:317`): mode radios single-region / active-active / active-hotstandby (over `ALL_MODES`, `TopologyEditor.tsx:63,184`); **Regions** checkboxes `<region-a>` + `<region-b>`; **Preview** + **Apply** actions — proving the picker is editable, not cosmetic | ☐ |
 | 7.3 | **GATE** (region-b kc `/tmp/<fqdn>-b.kc`) | `psql -c "select pg_is_in_recovery()"` on `shared-pg-replica` + check `pg_stat_wal_receiver`; then query the **keycloak** DB for realms + users | Region-b replica is **streaming** (`pg_is_in_recovery = t`); keycloak DB present with realms **master + sovereign** and the baseline user set (record the count) | ☐ |
 | 7.4 | **KILL region-a** (region-a kc `/tmp/<fqdn>.kc`) | `kubectl cordon` the region-a workers, then `kubectl delete pod -l cnpg.io/cluster=shared-pg` | Region-a primary + workers gone — region-a is down | ☐ |
 | 7.5 | **PROMOTE region-b** (region-b kc) | `kubectl patch cluster shared-pg-replica --type merge -p '{"spec":{"replica":{"enabled":false}}}'`, then re-query keycloak realms + users | Replica promoted (`pg_is_in_recovery = f`, RTO ≈ a few seconds); realms **master + sovereign** and the user count are **identical to the 7.3 baseline → RPO = 0** (consumer data preserved) | ☐ |
@@ -235,28 +252,164 @@ drives it from the console; the acceptance is the **`Sovereign` badge** + **`cut
 > owner JWT → `tofuArchiveSubmitted: true`). The CTA below then drives the engine.
 >
 > The cutover UI is the **SovereigntyCard** on **Settings → Sovereignty** (`SettingsPage.tsx:110,424`
-> renders `<SovereigntyCard/>` at the `#sovereignty` anchor; `data-testid="settings-sovereignty"`).
+> renders `<SovereigntyCard/>` at the `#sovereignty` anchor; `data-testid="settings-sovereignty"` at
+> `:424`). The card component lives at
+> `products/catalyst/bootstrap/ui/src/widgets/sovereignty/SovereigntyCard.tsx` (the line cites below
+> are that file).
+>
+> **🛑 The 8-vs-11 nuance (read before row 8.5).** The card copy + the visible progress card are
+> hardcoded to **8 steps** (`SovereigntyCard.tsx:196` *"Runs the 8-step cutover"*; `:282` *"an 8-step
+> cutover"*; the modal `<ol>` lists exactly 8 at `:289-298`; the progress card is fixed at 8 rows,
+> `:215-220`). But the **engine runs 11**: the cutover Blueprint ships **11 ordered step Jobs**
+> (`platform/self-sovereign-cutover/chart/templates/01-…11-…`, each labelled
+> `bp.openova.io/cutover-order: "1"…"11"`) and the status ConfigMap **seeds `totalSteps: "11"`**
+> (`platform/self-sovereign-cutover/chart/templates/09-cutover-status-configmap.yaml:46`). The three
+> post-egress steps (gitea-token-mint = order 9, vcluster-registry-pivot = 10,
+> crossplane-provider-pivot = 11) run **after** the 8 the UI renders. **Acceptance is
+> `cutoverComplete=true` + the witnessed egress-block — never the visible row count.**
 
 | Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
 |---|---|---|---|---|
-| 8.1 | `https://console.<fqdn>/settings#sovereignty` | Scroll to the **Sovereignty** section | A card headed **"Cluster sovereignty"** with an amber **"Tethered"** badge (`SovereigntyCard.tsx:119,144`, `data-testid="sovereignty-card"` `data-cutover-state="tethered"`) | ☐ |
-| 8.2 | (Sovereignty card) | Read the primary CTA | A button **"Achieve True Sovereignty"** (`SovereigntyCard.tsx:193`, `data-testid="cutover-start-button"`) + helptext *"Runs the … cutover. ~10 minutes. Includes a 10-minute egress-block self-test against github.com + ghcr.io + harbor.openova.io."* (`:195-199`) | ☐ |
-| 8.3 | (Sovereignty card) | Click **"Achieve True Sovereignty"** | A confirm modal opens titled **"Achieve True Sovereignty"** (`SovereigntyCard.tsx:279`, `data-testid="cutover-confirm-modal"`) listing the cutover steps (mirror Gitea, Harbor proxy projects, pre-warm, containerd pivot, Flux GitRepository, HelmRepositories, catalyst-api env, egress-block self-test) (`:289-298`) | ☐ |
-| 8.4 | (confirm modal) | Click **"Start cutover"** | The button (`SovereigntyCard.tsx:339`, `data-testid="cutover-confirm-button"`) fires `POST /sovereign/cutover/start` (`useCutoverEvents.ts:64,284`); the modal closes and the **8-row progress card** mounts (`CutoverProgressCard`, `:216-220`) | ☐ |
-| 8.5 | `https://console.<fqdn>/settings#sovereignty` | Watch the progress card stream the steps | The engine advances through its **11 steps** (gitea-mirror, harbor-projects, harbor-prewarm, registry-pivot, flux-gitrepository-patch, helmrepository-patches, catalyst-api-env-patch, **egress-block-test**, gitea-token-mint, vcluster-registry-pivot, crossplane-provider-pivot); each row flips `running → done` | ☐ |
-| 8.6 | (during step-08, ~600s window) | Confirm the deny-egress hold is the **witnessed** kind (the one negative check this section needs) | `kubectl get ccnp cutover-egress-block` returns the policy **present** for the duration of the hold, denying egress to github.com / ghcr.io / harbor.openova.io while all Flux reconciles stay green — see Appendix A8 | ☐ |
-| 8.7 | `https://console.<fqdn>/settings#sovereignty` | After the hold completes, re-read the badge + stats | The badge flips to green **"Sovereign"** (`SovereigntyCard.tsx:139`, `data-cutover-state="sovereign"`); the stats panel shows **Mirrored commit**, **Harbor projects**, **Egress test = passed** (`:158-178`, `data-testid="sovereignty-stats"`) | ☐ |
+| 8.1 | `https://console.<fqdn>/settings#sovereignty` | Scroll to the **Sovereignty** section | A card headed **"Cluster sovereignty"** (`SovereigntyCard.tsx:119`) with an amber **"Tethered"** badge (`:144`; `data-testid="sovereignty-card"` `data-cutover-state="tethered"` at `:96-97`; `data-testid="sovereignty-badge"` at `:129`) | ☐ |
+| 8.2 | (Sovereignty card) | Read the primary CTA | A button **"Achieve True Sovereignty"** (`SovereigntyCard.tsx:193`; `data-testid="cutover-start-button"` at `:186`) + helptext *"Runs the 8-step cutover. ~10 minutes. Includes a 10-minute egress-block self-test against github.com + ghcr.io + harbor.openova.io."* (`:196-198`) — copy says **8**, engine runs **11** (see the nuance box) | ☐ |
+| 8.3 | (Sovereignty card) | Click **"Achieve True Sovereignty"** | A confirm modal opens titled **"Achieve True Sovereignty"** (`SovereigntyCard.tsx:279`; `data-testid="cutover-confirm-modal"` at `:273`) listing **8 visible** steps (mirror Gitea, 7 Harbor proxy projects, pre-warm, containerd pivot, Flux GitRepository, 38 HelmRepositories, catalyst-api env, egress-block self-test) (`:289-298`) | ☐ |
+| 8.4 | (confirm modal) | Click **"Start cutover"** | The button (`SovereigntyCard.tsx:339`; `data-testid="cutover-confirm-button"` at `:329`) fires `POST /sovereign/cutover/start` (via `widgets/sovereignty/useCutoverEvents.ts`); the modal closes and the progress card (fixed at **8 visible rows**, `CutoverProgressCard`, `:216-218`) mounts | ☐ |
+| 8.5 | `https://console.<fqdn>/settings#sovereignty` | Watch the progress card stream the steps | The 8 visible rows flip `running → done`; **server-side the engine runs all 11** (gitea-mirror, harbor-projects, harbor-prewarm, registry-pivot, flux-gitrepository-patch, helmrepository-patches, catalyst-api-env-patch, **egress-block-test** = order 8, then gitea-token-mint, vcluster-registry-pivot, crossplane-provider-pivot = orders 9–11). The post-egress 3 are not drawn but DO run (`totalSteps: "11"`, `09-cutover-status-configmap.yaml:46`) | ☐ |
+| 8.6 | (during step-08, ~600s window) | Confirm the deny-egress hold is the **witnessed** kind (the one negative check this section needs) | `kubectl get ccnp cutover-egress-block` returns the policy **present** for the full 600s hold, denying egress to github.com / ghcr.io / harbor.openova.io while all Flux reconciles stay green — see Appendix A8 | ☐ |
+| 8.7 | `https://console.<fqdn>/settings#sovereignty` | After the hold completes, re-read the badge + stats | The badge flips to green **"Sovereign"** (`SovereigntyCard.tsx:139`, `data-cutover-state="sovereign"`); the stats panel (`data-testid="sovereignty-stats"` at `:155`) shows **Mirrored commit** (`:159`), **Harbor projects** (`:165`), **Egress test = passed** (`:169-178`) | ☐ |
 | 8.8 | (negative acceptance) | Open `https://console.<fqdn>/apps`, `https://grafana.<fqdn>`, `https://gitea.<fqdn>` | Nothing the user touches is broken — console signed-in, Grafana SSO, Gitea served from the Sovereign's **own local** services (the post-independence negative contract) | ☐ |
 
-**Section 8 result: ___ / 8.** Handover → 11-step engine → green **Sovereign** badge +
+**Section 8 result: ___ / 8.** Handover → **11-step** engine (UI draws 8) → green **Sovereign** badge +
 `cutoverComplete=true` + **Egress test = passed**, with the `cutover-egress-block` CCNP witnessed
 during the 600s hold.
 
-> **Honest note.** The card copy says "8-step" / "8-row" (`SovereigntyCard.tsx:282`,
-> `CutoverProgressCard` is fixed at 8 visible rows) but the **engine runs 11 steps** server-side
-> (the post-egress steps gitea-token-mint, vcluster-registry-pivot, crossplane-provider-pivot run
-> after the visible block). Acceptance is `cutoverComplete=true` + the witnessed egress-block, not
-> the row count.
+> **Honest note.** The card copy says "8-step" / "8-row" (`SovereigntyCard.tsx:196,282`,
+> `CutoverProgressCard` fixed at 8 visible rows) but the **engine runs 11 steps** server-side — proven
+> by `totalSteps: "11"` in the status ConfigMap (`09-cutover-status-configmap.yaml:46`) and the 11
+> ordered step Jobs `01-…11-…` in `platform/self-sovereign-cutover/chart/templates/`. The post-egress
+> steps gitea-token-mint, vcluster-registry-pivot, crossplane-provider-pivot run after the visible
+> block. Acceptance is `cutoverComplete=true` + the witnessed egress-block, not the row count.
+
+---
+
+## Section 9 — Fix-passenger: openbao region-b Continuum-CRD guard (PR #3613 · closes #3612)
+
+**What this proves:** on a **fresh 2-region prov**, the secondary region's `bp-openbao` HelmRelease
+reaches **Ready** instead of failing `helm install` with `no matches for kind "Continuum" in version
+"dr.openova.io/v1"`, and the whole secrets cascade that depends on openbao recovers **in region-b**:
+`external-secrets-stores`, `sso-bridge`, `gitea`, `harbor`, `oidc-gate`, `newapi`, `powerdns-admin`.
+
+> **Why this is an infra-verification section, not pure clicks.** The fix is a Helm-render guard that
+> only manifests on a real **secondary** cluster, so acceptance is the operator confirming region-b
+> convergence — via the console deployment/jobs status **and** `kubectl` against the region-b
+> kubeconfig. This is legitimate acceptance for a CRD-race fix; the pure render check is in Appendix A9.
+>
+> **The fix (cite).** `platform/openbao/chart/templates/continuum.yaml` gates the `cont-openbao`
+> Continuum CR on the CRD being registered: the render condition is
+> `{{- if and $c.enabled (eq $srRole "secondary") (.Capabilities.APIVersions.Has "dr.openova.io/v1") -}}`
+> — the `.Capabilities.APIVersions.Has "dr.openova.io/v1"` clause is the new guard (gold-standard
+> CRD-race pattern, cf bp-external-dns / #2988 / #3102). The `continuums.dr.openova.io` CRD ships only
+> with bp-catalyst-platform (slot 13, region-role=primary, **suspended** on every secondary CP), so it
+> is never installed in region-b; without the guard the CR rendered there and broke the install. Chart
+> bumped **1.2.42 → 1.2.43**; bootstrap-kit slot pin `clusters/_template/bootstrap-kit/08-openbao.yaml:107`
+> (`version: 1.2.43`, changelog at `:99`).
+>
+> **Replace at walk time:** `<region-b-kc>` = the secondary cluster kubeconfig (e.g.
+> `/tmp/<fqdn>-b.kc`, the same one §7 uses); `<region-b>` = the secondary cloud-region code.
+
+| Step | Go to / run | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 9.1 | `https://console.<fqdn>/deployments` (mothership Catalyst-Zero console) | Find the fresh prov's row; read the status + any sub-badge | Status flips to **`ready`** and the row shows **no** "Secondary degraded" sub-badge (see §10) — i.e. region-b converged, not just region-a (`DeploymentsList.tsx:314-332`) | ☐ |
+| 9.2 | `GET https://console.openova.io/sovereign/api/v1/deployments/<deploymentId>` (owner JWT) | Read `regions[]` in the JSON | `regions[]` has two entries; the **secondary** entry (`primary:false`, `region:"<region-b>"`) reports `hrReady` ≈ `hrTotal` (e.g. 60/60-ish) and `degraded:false` — region-b's HRs converged (`region_health.go:50-76`) | ☐ |
+| 9.3 | **region-b** (`kubectl --kubeconfig <region-b-kc>`) | `kubectl -n flux-system get hr bp-openbao` | `bp-openbao` is **`Ready=True` / "Helm install succeeded"** — **not** `InstallFailed` with `no matches for kind "Continuum"` | ☐ |
+| 9.4 | **region-b** | `kubectl --kubeconfig <region-b-kc> get crd continuums.dr.openova.io` | The CRD is **absent** in region-b (`Error … NotFound`) — which is exactly why the guard is needed; openbao installed **without** the Continuum CR because the `.Capabilities` guard skipped it | ☐ |
+| 9.5 | **region-b** | `kubectl -n flux-system get hr external-secrets-stores sso-bridge gitea harbor` | All four are **`Ready=True`** — the first ring of the openbao-backed cascade recovered in region-b | ☐ |
+| 9.6 | **region-b** | `kubectl -n flux-system get hr oidc-gate newapi powerdns-admin` | All three are **`Ready=True`** — the rest of the cascade that the #3612 break took down is now green in region-b | ☐ |
+| 9.7 | **region-b** | `kubectl -n openbao get pods` (or the openbao release namespace) | The openbao Pod(s) are **Running/Ready** and unsealed in region-b — the secondary's secret store is actually live, not stuck Pending behind a failed install | ☐ |
+
+**Section 9 result: ___ / 7.** Region-b `bp-openbao` reaches Ready with the Continuum CRD absent (the
+guard skipped the CR), and the `external-secrets-stores → sso-bridge / gitea / harbor / oidc-gate /
+newapi / powerdns-admin` cascade is green in region-b.
+
+---
+
+## Section 10 — Fix-passenger: per-region readiness surfacing (PR #3615 · closes #3611)
+
+**What this proves:** the deployment status no longer hides a degraded secondary behind a flat green
+**"ready"**. The console + API now expose **per-region HelmRelease health** — each region's
+`hrReady / hrTotal` plus a **"Secondary degraded"** badge — so an operator sees region-a vs region-b
+convergence at a glance. (Surface-only: the existing `ready` gate is untouched, so a slow secondary
+can never hang the prov; #3615 only exposes the truth.)
+
+> **Why this is an infra-verification section.** The per-region census is computed server-side from the
+> live HelmRelease informer caches and lifted onto the deployment status; acceptance is the operator
+> reading the deployment status (console badge + API `regions[]`). The Go unit-table proof is in
+> Appendix A10.
+>
+> **The fix (cite).** API: `provisioner.RegionHealth` struct (`region_health.go:50-76`; JSON
+> `region` `:56` / `primary` `:61` / `hrReady` `:65` / `hrTotal` `:68` / `degraded` `:75`), computed by
+> `ComputeRegionHealth` (`region_health.go:135`); lifted onto the deployment status in `State()` as
+> `out["regions"]` + `out["secondaryDegraded"]` (`deployments.go:945-948`) and onto each list row as
+> `SecondaryDegraded json:"secondaryDegraded,omitempty"` (`deployments.go:1482`, set at `:1503`). UI
+> types: `RegionHealth` (`useDeploymentEvents.ts:76`; `hrReady` `:83` / `hrTotal` `:85` / `degraded`
+> `:87`), `DeploymentSnapshot.regions?` (`:176`) + `.secondaryDegraded?` (`:185`),
+> `DeploymentListEntry.secondaryDegraded?` (`useInflightDeployment.ts:63`). Render sites:
+> `AppsPage.tsx:528-534` (the in-flight/just-converged header pill,
+> `data-testid="sov-secondary-degraded-pill"`, label **"Secondary degraded"**) and
+> `DeploymentsList.tsx:314-332` (the fleet-list sub-badge,
+> `data-testid="deployments-list-secondary-degraded-<id>"`).
+
+| Step | Go to / run | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 10.1 | `https://console.<fqdn>/deployments` (Catalyst-Zero console) | Find the fresh prov's row; read the status column | The status pill shows **`ready`**; **if** region-b lagged the primary by the degraded threshold, an amber **"Secondary degraded"** sub-badge sits next to it (`DeploymentsList.tsx:314-332`). On a fully-converged 2-region prov the badge is **absent** — that is the PASS state | ☐ |
+| 10.2 | (per-Sovereign console, while the prov is still converging) `https://console.<fqdn>/apps` | Read the provisioning header (the just-completed banner) | When `streamStatus === 'completed'` the header renders the same amber **"Secondary degraded"** pill if the secondary lags (`AppsPage.tsx:528-534`, `data-testid="sov-secondary-degraded-pill"`), otherwise just **"View install history"** | ☐ |
+| 10.3 | `GET https://console.openova.io/sovereign/api/v1/deployments/<deploymentId>` (owner JWT) | Read the top-level `regions` array | `regions[]` has **one entry per region**; each carries `region`, `primary`, **`hrReady`**, **`hrTotal`**, `degraded` (`region_health.go:50-76` → `deployments.go:945-948`). Exactly one entry has `primary:true` | ☐ |
+| 10.4 | (same JSON) | Compare the **region-a** vs **region-b** counts | The primary entry shows its `hrReady/hrTotal`; the secondary entry shows **its own** `hrReady/hrTotal` — e.g. region-a `60/60`, region-b `60/60` (converged) or `48/63` (degraded). The counts are **distinct per region**, not a collapsed total | ☐ |
+| 10.5 | (same JSON) | Read the top-level `secondaryDegraded` boolean | `secondaryDegraded` is **`false`** on a fully-converged 2-region prov (it is the roll-up that drives the console badge; `deployments.go:948`). `true` only when a secondary is significantly behind (`regionDegraded`: ≥3-HR shortfall AND <90% of the primary's Ready count) | ☐ |
+| 10.6 | (degraded-path sanity, optional) catalyst-api logs | `kubectl -n catalyst logs deploy/catalyst-api` then grep for `secondary` | When a "ready" deployment has a degraded secondary, catalyst-api emits a loud **Warn** (greppable even though the operator only sees the green pill) — the surfacing is also wired into logs, not just the UI | ☐ |
+
+**Section 10 result: ___ / 6.** The deployment status exposes per-region `hrReady/hrTotal` + a
+`secondaryDegraded` roll-up; the console badges a degraded secondary instead of a bare green "ready".
+
+---
+
+## Section 11 — Fix-passenger: host CRDs registered INSIDE vc-mgmt (PR #3403 · #3373, `bp-mgmt-vcluster:0.2.10`)
+
+**What this proves:** an app **re-homed into the MGMT vCluster** that ships an **HTTPRoute**,
+**ExternalSecret**, or **CNPG `Cluster`** reconciles successfully — **no** `no matches for kind …` —
+because those host CRDs are registered **inside the vCluster apiserver** at control-plane startup via
+the OSS-native init-manifests deployer (the toHost custom-resource sync that would do this is vCluster
+Pro/Platform-gated and inert on the OSS build).
+
+> **Why this is an infra-verification section.** The fix registers CRDs inside a vCluster apiserver;
+> acceptance is `kubectl` against the vc-mgmt kubeconfig confirming the CRDs are registered **and** an
+> app's CR reconciles. The render-guard check is in Appendix A11.
+>
+> **The fix (cite).** `platform/bp-mgmt-vcluster/chart/values.yaml` adds
+> `experimental.deploy.vcluster.manifests` (`:369-372`) shipping three **structural** CRDs
+> (`x-kubernetes-preserve-unknown-fields`): **HTTPRoute** `httproutes.gateway.networking.k8s.io`
+> (`:373-402`), **ExternalSecret** `externalsecrets.external-secrets.io` (`:404-427`), and **CNPG**
+> `clusters.postgresql.cnpg.io` (`:428-452`). Chart **0.2.10**; bootstrap-kit slot pin
+> `clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml:84` (`version: 0.2.10`, #3373 changelog at
+> `:81-83`). The vc-mgmt kubeconfig is mirrored into `flux-system` as `mgmt-vcluster-kubeconfig`
+> (slot-58 chart `values.yaml:454-459`).
+>
+> **Replace at walk time:** `<vc-mgmt-kc>` = the MGMT-vCluster kubeconfig (extract from Secret
+> `mgmt-vcluster-kubeconfig` in `flux-system` on the primary cluster, or `vc-mgmt` in the `mgmt`
+> namespace). Live evidence of this exact path passing is in
+> `docs/sessions/2026-06-13/evidence/3373-LIVE-httproute-create-proof.txt`.
+
+| Step | Go to / run | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 11.1 | **host (primary CP)** `kubectl --kubeconfig <fqdn>.kc` | `kubectl -n flux-system get hr bp-mgmt-vcluster -o jsonpath='{.spec.chart.spec.version}'` | The pinned chart is **`0.2.10`** (the #3403 release that ships the init-manifests) and the HR is **`Ready=True`** | ☐ |
+| 11.2 | **host** | `kubectl -n flux-system get secret mgmt-vcluster-kubeconfig` (then extract it to `<vc-mgmt-kc>`) | The mirrored vc-mgmt kubeconfig Secret exists — the handle you use to talk to the MGMT vCluster apiserver | ☐ |
+| 11.3 | **vc-mgmt** `kubectl --kubeconfig <vc-mgmt-kc>` | `kubectl get crd httproutes.gateway.networking.k8s.io externalsecrets.external-secrets.io clusters.postgresql.cnpg.io` | **All three CRDs are registered** inside the vCluster (each annotated `catalyst.openova.io/managed-by: bp-mgmt-vcluster`) — proving the init-manifests applied at apiserver startup | ☐ |
+| 11.4 | **vc-mgmt** | Create a fully-specified test **HTTPRoute** inside the vCluster (e.g. `kubectl -n default apply -f -` with `spec.parentRefs:[{name: catalyst-gateway, namespace: gateway}]`, `spec.hostnames:[test.<fqdn>]`, one `backendRefs` rule) | The create **SUCCEEDS** (`httproute.gateway.networking.k8s.io/… created`) — **not** `error: no matches for kind "HTTPRoute" in version "gateway.networking.k8s.io/v1"` (the #3373 bug) | ☐ |
+| 11.5 | **vc-mgmt** | `kubectl get httproute -A` (read the object back) | The HTTPRoute is stored with its full spec round-tripped (hostnames / parentRefs / backendRefs preserved) — the structural CRD accepted the entire CR, host operators hold the authoritative schema | ☐ |
+| 11.6 | **vc-mgmt** | Verify a re-homed app that ships one of these kinds reconciles — e.g. an app owning an in-vcluster CNPG `Cluster`: `kubectl get cluster.postgresql.cnpg.io -A` | The app's CR is **present and reconciling** (no `no matches for kind "Cluster"`), confirming a real re-homed workload — not just a synthetic test object — works inside vc-mgmt | ☐ |
+
+**Section 11 result: ___ / 6.** vc-mgmt has HTTPRoute / ExternalSecret / CNPG `Cluster` CRDs
+registered inside its apiserver; an app's CR creates + reconciles with no `no matches for kind` error.
 
 ---
 
@@ -272,7 +425,10 @@ during the 600s hold.
 | 6 | NS#3 — zero-login SSO | 7 | ___ / 7 |
 | 7 | NS#4 — region-kill failover | 6 | ___ / 6 |
 | 8 | NS#5 — sovereignty cutover | 8 | ___ / 8 |
-| **Total** | | **64** | **___ / 64** |
+| 9 | openbao region-b Continuum-CRD guard (PR #3613) | 7 | ___ / 7 |
+| 10 | per-region readiness surfacing (PR #3615) | 6 | ___ / 6 |
+| 11 | CRDs inside vc-mgmt (PR #3403) | 6 | ___ / 6 |
+| **Total** | | **83** | **___ / 83** |
 
 ---
 
@@ -308,6 +464,21 @@ during the 600s hold.
   policy **present** for the full 600s hold; `GET /sovereign/cutover/status` →
   `cutoverComplete=true` + `egressTestPassed=true` after the hold. The CTA is operator-gated
   (`POST /api/v1/sovereign/cutover/start` behind `RequireSession`; in-cluster auto-trigger is
-  fail-closed, `cutover_internal.go`).
-</content>
-</invoke>
+  fail-closed, `cutover_internal.go`). The visible step list is 8 (`cutover.ts` `CUTOVER_STEPS`);
+  the engine's `totalSteps` is **11** (`09-cutover-status-configmap.yaml:46`).
+- **A9 (§9 openbao region-b).** Render proof: `helm template platform/openbao/chart` (default +
+  single-region) is byte-identical to origin/main; `tests/continuum-render.sh` Case 3 passes
+  `--api-versions dr.openova.io/v1` (CR renders) and Case 4 asserts the guard **skips** the CR when
+  the CRD is absent (no install failure). The guard line is `.Capabilities.APIVersions.Has
+  "dr.openova.io/v1"` in `platform/openbao/chart/templates/continuum.yaml`.
+- **A10 (§10 readiness surfacing).** Table-driven Go unit tests for `ComputeRegionHealth` /
+  `regionDegraded` / `countInstalled` (`region_health_test.go`: primary-only-ready, both-ready,
+  secondary-degraded, fully-installed-but-fewer-HRs, zero-observed, early 0/0, 3-region sort) +
+  `State()` surface tests (`deployments_region_health_test.go`). `secondaryDegraded` is surface-only
+  — the `status: "ready"` gate (`markPhase1Done`) is unchanged, so a slow secondary never hangs a prov.
+- **A11 (§11 CRDs in vc-mgmt).** Render guard: `platform/bp-mgmt-vcluster/chart/tests/render.sh`
+  asserts the three init-manifest CRDs (`httproutes.gateway.networking.k8s.io`,
+  `externalsecrets.external-secrets.io`, `clusters.postgresql.cnpg.io`) are present in the rendered
+  vc-config. Live evidence of the in-vcluster HTTPRoute create passing:
+  `docs/sessions/2026-06-13/evidence/3373-LIVE-httproute-create-proof.txt` (BEFORE: `no matches for
+  kind "HTTPRoute"`; AFTER: CRDs registered + a full HTTPRoute creates).


### PR DESCRIPTION
Completes the full-train UAT walkthrough `docs/ledger/uat-walkthrough/train-2026-06-15.md` (#3614) so the founder's hw146 walk is airtight: every row walkable by a non-engineer, every route/label/field cited to the current `main`-line console source (`file:line`), re-verified 2026-06-16.

## Three new fix-passenger sections (merged after #3614 — 19 new rows; total 64 → 83)
- **§9 (7 rows) — openbao region-b Continuum-CRD guard** (PR #3613 · issue #3612, `bp-openbao:1.2.43`). On a fresh 2-region prov, region-b `bp-openbao` reaches Ready (no `no matches for kind "Continuum"`) and the cascade recovers in region-b: `external-secrets-stores` → `sso-bridge` / `gitea` / `harbor` / `oidc-gate` / `newapi` / `powerdns-admin`. Cites the `.Capabilities.APIVersions.Has "dr.openova.io/v1"` guard in `platform/openbao/chart/templates/continuum.yaml` + the slot-08 pin. Verified via console `/deployments` + `kubectl` against the region-b kubeconfig.
- **§10 (6 rows) — per-region readiness surfacing** (PR #3615 · issue #3611). The deployment status now exposes `regions[].hrReady/hrTotal/degraded` + `secondaryDegraded` so a degraded secondary no longer hides behind a flat green "ready". Cites the API struct (`region_health.go:50-76`), `ComputeRegionHealth` (`:135`), `State()` surfacing (`deployments.go:945-948,1482,1503`), the UI types (`useDeploymentEvents.ts:76,176,185`), and the two render sites (`AppsPage.tsx:528-534`, `DeploymentsList.tsx:314-332`).
- **§11 (6 rows) — host CRDs registered inside vc-mgmt** (PR #3403 · #3373, `bp-mgmt-vcluster:0.2.10`). An app re-homed into `vc-mgmt` that ships an HTTPRoute / ExternalSecret / CNPG `Cluster` reconciles successfully because the host CRDs are registered inside the vCluster apiserver via OSS init-manifests. Cites the init-manifests in `platform/bp-mgmt-vcluster/chart/values.yaml:369-452` + the slot-58 pin.

§9/§11 verify infra (CRD reconcile, region-b convergence) via `kubectl`/console — legitimate acceptance for those remediations; pure render/unit checks are demoted to Appendix A9/A10/A11.

## Refined the existing sections
- Re-verified every route/label against the current `main` console source and corrected ~40 drifted `file:line` citations (the doc's numbers were ~30–50 lines stale in the big files; a few pointed at the wrong line entirely).
- Cleared the two documented nuances: (a) the catalog card has **no install button** — the flow is click card → class page → `+ New instance` → the placement wizard; (b) the cutover card copy says **8 steps** but the engine runs **11** (proven by `totalSteps: "11"` in `09-cutover-status-configmap.yaml:46` and the 11 ordered step Jobs `01-…11-…`), and the `SovereigntyCard` path moved to `widgets/sovereignty/`.
- Marked editable-catalog (PR #3605) as merged (was "on branch"); dropped two stray `</content></invoke>` tags left in the committed file; escaped a table-breaking pipe.

Docs-only change. No banned words.

Refs #3621
Refs #3597

🤖 Generated with [Claude Code](https://claude.com/claude-code)