### PR TITLE
fix(bp-self-sovereign-cutover): step-03 harbor-prewarm FATALs on transient large-image copy resets — add skopeo --retry-times + per-image retry (0.1.68)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -537,7 +537,7 @@ spec:
       # Pending 22+ min, FailedScheduling Insufficient cpu — live hw145). It is
       # a skopeo image-copy Job (I/O-bound, not CPU-bound); right-sized the CPU
       # request 500m → 100m. Memory stays 512Mi. Chart-only.
-      version: 0.1.67
+      version: 0.1.68
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.67
+  version: 0.1.68
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -676,7 +676,26 @@ name: bp-self-sovereign-cutover
 # 03-harbor-prewarm-job.yaml): right-size requests.cpu 500m → 100m. Memory
 # stays 512Mi (skopeo needs the RAM for layer buffers) and the limits block is
 # unchanged. No step-count / RBAC / timeout change.
-version: 0.1.67
+# 0.1.68 (#TBD, Refs #3568 #3379, hw146 step-03 FATAL on transient large-image
+# copy resets 2026-06-16): Step-03 (harbor-prewarm) skopeo-copies every
+# ghcr.io/openova-io/* image into local Harbor. On hw146's cutover, 27/29 copies
+# succeeded but the two LARGE guacamole images (guacamole-server:1.5.5 +
+# guacd:1.5.5, ~50MB blobs) FAILED on TRANSIENT mid-blob connection resets over
+# the freshly-bootstrapped network — skopeo logged `Reading blob ... failed
+# (unexpected EOF), reconnecting ...` then `writing blob ... use of closed
+# network connection`. 2/29 failed -> push_fail>0 -> `FATAL: 2 openova-io
+# image(s) failed to push` -> cutover never reached step-04+. The single
+# `skopeo copy` per image carried only `--retry-times 3` (retries the blob fetch
+# INSIDE one copy) and FATALd if ANY image failed. FIX (chart-only, template
+# 03-harbor-prewarm-job.yaml): (1) bump `--retry-times 3` -> `--retry-times 5`
+# on the copy; (2) wrap each `skopeo copy` in an OUTER per-image retry loop
+# (PREWARM_COPY_ATTEMPTS, default 3) — if a full copy still fails after
+# `--retry-times`, the whole copy is re-attempted up to 3 times with a 5s
+# backoff before the image counts as push_fail; each attempt is logged. The
+# FATAL-on-failure contract is PRESERVED (Pillar 5 requires ALL openova-io
+# images local for the deny-egress hold) — the step only FATALs once BOTH retry
+# layers are exhausted. No step-count / RBAC / timeout change.
+version: 0.1.68
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -226,10 +226,30 @@ data:
             # no `wait -n`, so we cap concurrency by counting live background
             # PIDs and pausing the launch loop until one drains.
             #
-            # skopeo gains `--retry-times 3` so a single transient ghcr/Harbor
+            # skopeo gains `--retry-times 5` so a single transient ghcr/Harbor
             # 5xx or reset inside a copy self-heals (resumable layer fetch)
             # instead of failing the whole image — independent of the binary-
             # download retry above.
+            #
+            # #3608-followup (hw146 step-03 FATAL, 2026-06-16): even with
+            # `--retry-times`, the two LARGE guacamole images
+            # (guacamole-server:1.5.5 + guacd:1.5.5, ~50MB blobs) still FATAL'd
+            # the whole step on TRANSIENT mid-blob connection resets over a
+            # freshly-bootstrapped network — skopeo logged
+            # `Reading blob ... failed (unexpected EOF), reconnecting ...` then
+            # `writing blob ... use of closed network connection`, and 2/29
+            # copies failed -> push_fail>0 -> `FATAL: 2 openova-io image(s)
+            # failed to push` -> cutover never reached step-04+. `--retry-times`
+            # retries the individual blob fetch INSIDE one `skopeo copy`, but a
+            # Harbor-side reset that closes the dest connection can still abort
+            # the copy as a whole. So copy_one ALSO wraps the `skopeo copy` in an
+            # OUTER per-image retry loop (PREWARM_COPY_ATTEMPTS, default 3): if a
+            # full copy fails after exhausting `--retry-times`, the whole copy is
+            # re-attempted up to N times with a short backoff sleep before the
+            # image is counted as `push_fail`. The FATAL-on-failure contract is
+            # PRESERVED (Pillar 5 requires ALL openova-io images local for the
+            # deny-egress hold) — the step only FATALs once BOTH retry layers are
+            # exhausted for an image. Each outer attempt is logged.
             #
             # Two earlier #3379 keystone catches (hw138, 2026-06-14) stay in
             # force: (1) `--insecure-policy` so skopeo doesn't fatal on the
@@ -239,6 +259,7 @@ data:
             # always 0 under this `set -eu` (no pipefail) shell — the bug that
             # made every fatal copy miscount as success.
             : "${PREWARM_PARALLELISM:=6}"
+            : "${PREWARM_COPY_ATTEMPTS:=3}"
             cpdir="/tmp/prewarm-copies"
             rm -rf "${cpdir}"; mkdir -p "${cpdir}"
             echo "[harbor-prewarm] pushing ${count} image(s) with parallelism=${PREWARM_PARALLELISM}"
@@ -250,17 +271,44 @@ data:
               lref="${HARBOR_HOST}/${up#ghcr.io/}"
               # Slug for the per-image sentinel/log file names.
               slug=$(printf '%s' "${up}" | tr -c 'A-Za-z0-9._-' '_')
-              if skopeo copy \
-                --insecure-policy \
-                --retry-times 3 \
-                --src-creds="${ghcr_user}:${ghcr_pat}" \
-                --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
-                --dest-tls-verify=true \
-                --src-tls-verify=true \
-                "docker://${up}" "docker://${lref}" >"${cpdir}/${slug}.log" 2>&1; then
+              # OUTER per-image retry loop: `--retry-times 5` self-heals a
+              # transient blob fetch inside ONE copy, but a Harbor-side reset
+              # that closes the dest connection can abort the whole copy (hw146
+              # large-image FATAL, see comment above). Re-attempt the full
+              # `skopeo copy` up to PREWARM_COPY_ATTEMPTS times before counting a
+              # push_fail. The per-attempt log is APPENDED so the final captured
+              # log shows every try.
+              attempt=1
+              rc=1
+              : >"${cpdir}/${slug}.log"
+              while [ "${attempt}" -le "${PREWARM_COPY_ATTEMPTS}" ]; do
+                echo "[harbor-prewarm] copy ${up} attempt ${attempt}/${PREWARM_COPY_ATTEMPTS}" >>"${cpdir}/${slug}.log"
+                if skopeo copy \
+                  --insecure-policy \
+                  --retry-times 5 \
+                  --src-creds="${ghcr_user}:${ghcr_pat}" \
+                  --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+                  --dest-tls-verify=true \
+                  --src-tls-verify=true \
+                  "docker://${up}" "docker://${lref}" >>"${cpdir}/${slug}.log" 2>&1; then
+                  rc=0
+                  break
+                else
+                  # Capture skopeo's REAL exit status INSIDE the else branch —
+                  # `rc=$?` placed AFTER the `fi` would read the if-construct's
+                  # status (0 when the condition is false with no else), the same
+                  # always-0 trap the #3379 hw138 real-exit-status fix called out.
+                  rc=$?
+                fi
+                echo "[harbor-prewarm] copy ${up} attempt ${attempt} failed (exit=${rc}); retrying after backoff" >>"${cpdir}/${slug}.log"
+                attempt=$((attempt+1))
+                # Short backoff lets a Harbor-side reset settle before the
+                # next full copy; skip the sleep after the final attempt.
+                [ "${attempt}" -le "${PREWARM_COPY_ATTEMPTS}" ] && sleep 5
+              done
+              if [ "${rc}" -eq 0 ]; then
                 printf '%s' "${up}" >"${cpdir}/${slug}.ok"
               else
-                rc=$?
                 printf '%s exit=%s' "${up}" "${rc}" >"${cpdir}/${slug}.fail"
               fi
             }


### PR DESCRIPTION
## Problem (verified live on hw146 cutover, 2026-06-16)

Cutover **step-03 harbor-prewarm** FATALs. It skopeo-copies every `ghcr.io/openova-io/*` image into local Harbor; **27 of 29 succeeded**, but 2 large images (`guacamole-server:1.5.5`, `guacd:1.5.5`, ~50 MB blobs) failed on **transient connection resets**:

```
Reading blob from ghcr.io … failed (unexpected EOF), reconnecting after 52428801 bytes…
writing blob: Patch https://registry.<fqdn>/… : use of closed network connection
[harbor-prewarm] FAIL ghcr.io/openova-io/openova/guacd:1.5.5 exit=1
[harbor-prewarm] FATAL: 2 openova-io image(s) failed to push
```

The step did a single `skopeo copy` per image with only `--retry-times 3` (retries the blob fetch *inside* one copy) and FATALs if ANY image fails. A Harbor-side reset that closes the dest connection aborts the whole copy → over a freshly-bootstrapped network the large-image copies reset intermittently → the cutover never reaches step-04+.

## Fix (chart-only, `templates/03-harbor-prewarm-job.yaml`)

1. Bump `--retry-times 3` → **`--retry-times 5`** on the `skopeo copy`.
2. Add a **per-image OUTER retry loop** (`PREWARM_COPY_ATTEMPTS`, default 3): if `skopeo copy` still fails after `--retry-times`, retry the whole copy up to 3 times with a 5s backoff before counting `push_fail`. Each attempt is logged (appended to the per-image captured log).
3. **FATAL-on-failure contract PRESERVED** — Pillar 5 requires ALL openova-io images local for the deny-egress hold, so the step still FATALs, but only once BOTH retry layers are exhausted for an image.

The `cutoverPhase: pre` image, the parallel fan-out, the per-worker `.ok`/`.fail` sentinel + log tally, `--insecure-policy`, and the real-exit-status branch are all unchanged.

## Proof

- `helm template platform/self-sovereign-cutover/chart` renders (exit 0); rendered step-03 ConfigMap script:
  ```
  --retry-times 5 \
  while [ "${attempt}" -le "${PREWARM_COPY_ATTEMPTS}" ]; do
    echo "[harbor-prewarm] copy ${up} attempt ${attempt}/${PREWARM_COPY_ATTEMPTS}" ...
    if skopeo copy --insecure-policy --retry-times 5 ... ; then rc=0; break; fi
    ...
  echo "[harbor-prewarm] FATAL: ${push_fail} openova-io image(s) failed to push ..."
  ```
- `helm lint` clean (0 failed).
- Rendered step-03 shell script passes `sh -n` **and** `dash -n` (POSIX-clean).
- `chart/tests/cutover-contract.sh` — all 25 cases green (step count still exactly 11).

Chart `0.1.67` → `0.1.68`; `blueprint.yaml` + `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` pin lockstep to 0.1.68.

Live 11-step → `cutoverComplete=true` validation is driven by the operator on the next clean fresh prov; this PR is the chart fix only.

Refs #3624 Refs #3568 Refs #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
