### PR TITLE
fix(sso): OpenBao "Open" button lands signed-in via the /sso/landing top-level flow

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -104,7 +104,12 @@ spec:
       # cascading into sso-bridge/gitea/harbor/oidc-gate/newapi/powerdns-admin.
       # Render now gated on .Capabilities.APIVersions.Has "dr.openova.io/v1"
       # (gold-standard pattern). Single-region byte-identical; pin in lockstep.
-      version: 1.2.43
+      # 1.2.44 (#3626): repoint the console "Open" button's launch-url at the
+      # on-origin /sso/landing page (drop ssoShim + the /ui/vault/auth?with=oidc
+      # deep-link) so OpenBao lands signed-in instead of the popup-only Vault
+      # OIDC callback's window.opener=null error. blueprint.yaml/Chart.yaml
+      # lockstep; no chart-template change (landing page already shipped 1.2.35).
+      version: 1.2.44
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1027,7 +1027,8 @@ spec:
             # 1.4.621 — #3373 Batch A: SME valkey consumer + projector addr → rtz-vCluster syncer-mangled name (bp-valkey moved into rtz); valkey-cross-ns CNP disabled (rtz isolation netpol `sme` carve-out governs the wire).
             # 1.4.623 — #3373 Batch A: qa-fixtures CNPG barman backup endpoint default → rtz-vCluster synced seaweedfs-s3 name (seaweedfs moved into rtz; 1.4.622 was a content-free deploy-bot sweep).
             # 1.4.626 — #3492: Continuum CRD gains spec.switchover.{mechanism,raftTransition} (bp-openbao raft-transition DR contract); additive, slot-13 crds:CreateReplace propagates the schema. Render byte-unchanged.
-      version: 1.4.644
+            # 1.4.645 — #3626: catalog-seed repoints bp-openbao launch ssoInitPath → /sso/landing (was /ui/vault/auth?with=oidc) so the console "Open" button lands signed-in instead of the popup-only Vault OIDC callback's window.opener=null error. Lockstep with platform/openbao/blueprint.yaml; template-only, default render byte-unchanged.
+      version: 1.4.645
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.43
+  version: 1.2.44
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.
@@ -88,31 +88,32 @@ spec:
       visibility: private
       launchDefault: true
       ssoEnabled: true
-      # #3150 — silent-SSO OIDC-init path. OpenBao's UI is a SPA (Vault-UI
-      # fork): OIDC is started client-side, so there is no server GET route to
-      # land on. The deep-link pre-selects the `oidc` auth method in the UI so
-      # the operator's one click triggers the OIDC flow, which — with the
-      # realm-config IDR defaultProvider=catalyst-pin binding (bp-keycloak
-      # 1.4.9+, NOT an auth_url query param; see chart values.yaml comment) —
-      # re-uses the PIN silently. NOTE: requires the `oidc` auth method to be
-      # mounted by the sso-configure Deployment; when that job is unhealthy the
-      # UI falls back to ?with=token and silent SSO can't fire.
+      # #3626 — the console "Open" button's silent-SSO launch target. OpenBao's
+      # UI is a SPA (Vault-UI / Ember fork) whose OIDC login is POPUP-ONLY: the
+      # callback route `vault.cluster.oidc-callback` `afterModel` does an
+      # UNCONDITIONAL `window.opener.postMessage(...)` with no null-check and no
+      # in-page completion. The console Open button window.open()s this URL as a
+      # TOP-LEVEL tab, so any target that drives the Vault-UI OIDC flow directly
+      # (the old `/ui/vault/auth?with=oidc` deep-link, or the #3226 server-side
+      # shim that 302'd into `/ui/vault/auth/oidc/oidc/callback`) lands on a
+      # top-level callback where `window.opener` is null →
+      # "Cannot read properties of null (reading 'postMessage')" and the token
+      # form, never signed-in (measured live hw133 #3374 + hw146 #3626).
       #
-      # The `?with=` value is the auth-method PATH with NO trailing slash.
-      # `oidc%2F` (encoded trailing slash) made the Ember UI fail to match the
-      # `oidc` mount → it reverted to `?with=token` (manual Token form) and the
-      # malformed mount path broke the callback round-trip. Emit `?with=oidc`.
-      ssoInitPath: "/ui/vault/auth?with=oidc"
-      # #3226 — zero-click silent-SSO parity with grafana/harbor. OpenBao's
-      # UI is a client-side SPA, so the ssoInitPath deep-link above can only
-      # PRE-SELECT the OIDC method — the operator still has to click "Sign in
-      # with OIDC". ssoShim:true makes catalyst-api's launch-url return its
-      # server-side shim (`api.<fqdn>/catalyst/v1/apps/openbao/openbao-sso-init`)
-      # instead. The shim asks Vault for the OIDC auth_url server-side and
-      # 302s the browser to Keycloak (silent PIN) → Vault callback → landed
-      # signed-in. If the auth_url POST fails, the shim falls back to the
-      # ssoInitPath deep-link above (the Open button never 500s).
-      ssoShim: true
+      # The fix (#3374): point the launch at the on-origin SSO landing page
+      # `/sso/landing` (chart templates/sso-landing.yaml), which runs the OIDC
+      # round-trip as a TOP-LEVEL window (auth_url → Keycloak silent → back to
+      # /sso/landing?code → GET oidc/callback → reconstruct the Vault-UI token in
+      # localStorage → /ui/vault/secrets). No popup, no window.opener, no
+      # catalyst-api dependency. The OIDC role already allow-lists
+      # https://bao.<fqdn>/sso/landing (sso-configure-deployment.yaml). This is
+      # the SAME flow the bare-URL HTTPRoute redirect (/, /ui, /ui/) uses, so
+      # the Open button and a bare-host visit now both land signed-in.
+      #
+      # Gated by sso.bareURL.enabled (default true); when disabled the landing
+      # page is not rendered and this path 404s — operators who disable bare-URL
+      # SSO must also re-point this endpoint.
+      ssoInitPath: "/sso/landing"
 
   # ── G117.4 + G117.5: SSO ───────────────────────────────────────────────
   # OpenBao OIDC auth method federated to sovereign realm (G91 manual

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -108,7 +108,23 @@ name: bp-openbao
 # render nothing). tests/continuum-render.sh Case 3 now passes
 # `--api-versions dr.openova.io/v1`; new Case 4 proves the guard skips the CR
 # (no install failure) when the CRD is absent. No upstream subchart change.
-version: 1.2.43
+version: 1.2.44
+# 1.2.44 (#3626, 2026-06-16): make the console "Open" button land signed-in.
+# The Open button (AppDetail + AppsPage card) window.open()s catalyst-api's
+# launch-url as a TOP-LEVEL tab. blueprint.yaml's endpoint pointed that launch
+# at the Vault-UI OIDC flow (ssoShim → the #3226 server-side shim 302'd into
+# /ui/vault/auth/oidc/oidc/callback; the non-shim ssoInitPath /ui/vault/auth
+# ?with=oidc auto-initiated the same flow) — but Vault-UI's OIDC callback is
+# POPUP-ONLY (unconditional window.opener.postMessage), so a top-level tab hit
+# window.opener=null → "Cannot read properties of null (reading 'postMessage')"
+# and the token form, never signed-in (measured live hw146). FIX: repoint the
+# endpoint ssoInitPath at the on-origin /sso/landing page (already shipped at
+# 1.2.35 for the bare-URL contract) + drop ssoShim, so launch-url returns
+# https://bao.<fqdn>/sso/landing — the SAME popup-free top-level flow the bare
+# `/` HTTPRoute redirect uses. No chart-TEMPLATE change (the landing page +
+# route + OIDC redirect-uri allowlist already exist); version bumped in
+# lockstep with blueprint.yaml + the bootstrap-kit slot pin so the new
+# blueprint OCI artifact (which carries the repointed endpoint) publishes.
 # 1.2.37 (#3374, 2026-06-14): fix the sso-landing nginx ImagePullBackOff. The
 # image was `harbor.openova.io/proxy-docker/library/nginx` but the live Harbor
 # DockerHub proxy-cache project is `proxy-dockerhub` (proxy-docker does NOT

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2712,7 +2712,18 @@ name: bp-catalyst-platform
 # (qaFixtures.cnpgBackupEndpointURL + cnpg-clusters-qa.yaml) to the
 # syncer-mangled host Service name. qa-fixtures only; Catalyst-Zero render
 # byte-unchanged. (1.4.622 was a content-free deploy-bot image sweep.)
-version: 1.4.644
+version: 1.4.645
+# 1.4.645 — #3626 (2026-06-16) — catalog-seed: repoint bp-openbao's launch
+# endpoint ssoInitPath at the on-origin /sso/landing page (was
+# /ui/vault/auth?with=oidc). The console "Open" button window.open()s
+# catalyst-api's launch-url as a top-level tab; the old target drove Vault-UI's
+# POPUP-ONLY OIDC callback (window.opener.postMessage) on a top-level tab →
+# window.opener=null → "Cannot read properties of null (reading 'postMessage')"
+# + the token form, never signed-in (live hw146). The catalog-seed CR is the
+# launch-url's in-cluster source-of-truth (catalog_client_cluster_fallback.go),
+# so it MUST match platform/openbao/blueprint.yaml's repointed endpoint
+# (check-catalog-seed-lockstep.sh). Template-only; default render otherwise
+# byte-identical. Refs #3626.
 # 1.4.597 — #3373 (2026-06-13) — coupling fix (a) placement-as-data:
 # templates/httproute.yaml backendRefs honor new
 # ingress.gateway.backendServiceApi / backendServiceUi overrides. When

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3281,20 +3281,20 @@ spec:
     visibility: private
     launchDefault: true
     ssoEnabled: true
-    # #3150 — silent-SSO OIDC-init path. OpenBao's UI is a SPA; this deep-link
-    # pre-selects the `oidc` auth method so one click triggers the OIDC flow,
-    # which re-uses the PIN silently via the realm-config IDR
-    # defaultProvider=catalyst-pin binding (NOT an auth_url query param).
-    # Requires the `oidc` auth method to be mounted by the sso-configure
-    # Deployment.
-    #
-    # The `?with=` value is the auth-method PATH with NO trailing slash. The
-    # prior `oidc%2F` (encoded trailing slash) made OpenBao's Ember UI fail to
-    # match the `oidc` mount → it normalised `?with=` back to `token` and
-    # showed the manual Token form (and the malformed mount path produced a
-    # callback whose state/redirect_uri did not round-trip → 400). Emit plain
-    # `?with=oidc`.
-    ssoInitPath: "/ui/vault/auth?with=oidc"
+    # #3626 — the console "Open" button window.open()s this launch target as a
+    # TOP-LEVEL tab. OpenBao's Vault-UI OIDC callback is POPUP-ONLY (its
+    # afterModel does an unconditional window.opener.postMessage), so any target
+    # that drives the Vault-UI OIDC flow directly (the old
+    # /ui/vault/auth?with=oidc deep-link, or the #3226 server-side shim) lands on
+    # a top-level callback with window.opener=null → "Cannot read properties of
+    # null (reading 'postMessage')" + the token form, never signed-in.
+    # Repointed (#3374 fix) at the on-origin /sso/landing page (chart
+    # templates/sso-landing.yaml) which runs the OIDC round-trip as a TOP-LEVEL
+    # window and lands /ui/vault/secrets signed-in — the SAME flow the bare-URL
+    # HTTPRoute redirect uses. The OIDC role allow-lists https://bao.<fqdn>/sso/
+    # landing (sso-configure-deployment.yaml). MUST stay in lockstep with
+    # platform/openbao/blueprint.yaml (check-catalog-seed-lockstep.sh).
+    ssoInitPath: "/sso/landing"
   sso:
     realm: sovereign
     protocolMapper: oidc


### PR DESCRIPTION
## What

The console **"Open"** button for the **OpenBao** card/detail does not land the operator authenticated (North Star #3 — every URL → signed in as admin). Grafana/Harbor land fine; OpenBao strands the user on the Vault token form with a JS error. This repoints OpenBao's launch target at the on-origin `/sso/landing` page so it lands signed-in.

## Root cause (confirmed in code)

Both Open buttons resolve a launch URL from catalyst-api and `window.open()` it as a **top-level tab**:
- `AppDetail.tsx:1143` / `AppsPage.tsx:776` (`launchAppViaSSO` → `getLaunchURL` → `GET /catalyst/v1/apps/{id}/launch-url`).

For OpenBao the launch endpoint pointed that top-level tab at the Vault-UI OIDC flow:
- `endpoint_handler.go:718-729` — `ssoShim:true` → the `#3226` server-side shim (`openbao_sso_init.go`) full-page-302s into `https://<host>/ui/vault/auth/<mount>/oidc/callback`; the non-shim `ssoInitPath: /ui/vault/auth?with=oidc` is auto-initiated by the Ember UI.

But Vault-UI's OIDC callback is **POPUP-ONLY**: `vault.cluster.oidc-callback` `afterModel` does an unconditional `window.opener.postMessage(...)` with no null-check and no in-page completion. On a top-level tab `window.opener === null` →

```
[ERROR] vault.cluster.oidc-callback  Cannot read properties of null (reading 'postMessage')
        TypeError … at e.afterModel (…/vault-<hash>.js)
```

— the operator never signs in (measured live hw146). Grafana/Harbor work because their OIDC is a plain server-side redirect (no popup, no `postMessage`).

The popup-free flow already ships (`#3374`): the on-origin `/sso/landing` page (`platform/openbao/chart/templates/sso-landing.yaml`) runs the OIDC round-trip as a **top-level window** and lands `/ui/vault/secrets` signed-in. The bare-URL HTTPRoute (`/`, `/ui`, `/ui/`) already 302s there and the OIDC role already allow-lists `https://bao.<fqdn>/sso/landing` (`sso-configure-deployment.yaml`) — only the console Open button never reached it.

## Change

Repoint OpenBao's launch endpoint `ssoInitPath` → `/sso/landing` and drop the dead `ssoShim`, in **both**:
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` — the launch-url's in-cluster source-of-truth (`catalog_client_cluster_fallback.go`).
- `platform/openbao/blueprint.yaml` — the Gitea-mirrored upstream the catalog serves.

Kept in lockstep by `check-catalog-seed-lockstep.sh`. `launch-url` now returns `https://bao.<fqdn>/sso/landing` — the **same** flow a bare-host visit uses — so both Open buttons land signed-in.

**Surface: chart-template-only.** No catalyst-ui change (the Open-button logic is unchanged; only the URL it receives changes). Version bumps so the new blueprint OCI artifacts publish + pin in lockstep:
- `bp-openbao` 1.2.43 → **1.2.44** (Chart.yaml + blueprint.yaml `spec.version` + slot 08)
- `bp-catalyst-platform` 1.4.644 → **1.4.645** (Chart.yaml + slot 13)

The `#3226` shim handler + its unit tests stay (harmless; `ssoShim` mechanism retained for any future SPA) — OpenBao simply no longer opts in.

## Validation (local — code + helm-template only; no live walk)

- `scripts/check-catalog-seed-lockstep.sh` → **PASS** (68 checked, 0 fail).
- `platform/openbao/chart/tests/sso-landing-render.sh` → **all 6 cases PASS** (landing page + bare-path redirect + OIDC redirect-uri allowlist intact).
- `helm template` both charts → **render OK**; catalog-seed `bp-openbao` endpoint renders `ssoInitPath: /sso/landing`.
- `go test ./internal/handler/` (catalyst-api) → **PASS** (incl. launch-url, ssoShim, OpenBaoSSOInit, and the live-blueprint compat tests).

## Acceptance (operator-walk — not run here, no browser)

On hw146 (tracks `main` pre-cutover, so the bp-openbao chart fix is Flux-pullable): console → OpenBao card/detail → **Open** → new tab lands on `/ui/vault/secrets` already authenticated (no Vault token form, no `postMessage` console error).

## Env-fixable vs next-train

- `platform/openbao/blueprint.yaml` + bp-openbao chart → **Flux-pullable on hw146** (the Sovereign's Gitea mirror serves it; Flux installs the bumped artifact). Live-validatable.
- `catalog-seed` ships in `bp-catalyst-platform` (mothership umbrella) — rolls with the next catalyst-platform reconcile. Both edits are required for a fully-correct fix regardless of which path serves a given request.

Refs #3626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
