### PR TITLE
fix(cutover): mirror helm charts to local Harbor + verify pullability before ghcr strip (step-03/step-06)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -537,7 +537,7 @@ spec:
       # Pending 22+ min, FailedScheduling Insufficient cpu — live hw145). It is
       # a skopeo image-copy Job (I/O-bound, not CPU-bound); right-sized the CPU
       # request 500m → 100m. Memory stays 512Mi. Chart-only.
-      version: 0.1.68
+      version: 0.1.69
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.68
+  version: 0.1.69
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,57 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.69 (#3627 Refs #3379, hw146 missing-chart-mirror + wrong-Ready gate,
+# 2026-06-16): TWO stacked defects that wedged the Pillar-5 cutover at
+# step-06, both root-caused live on hw146 (531e6908e606d11d).
+#
+#   DEFECT A — no step ever mirrored the openova-io helm CHART OCI artifacts
+#   into local Harbor. Step-06 Phase-1 repoints every HelmRepository to
+#   oci://registry.<sov-fqdn>/openova-io and Phase-3 strips the ghcr.io
+#   fallback, but step-03 (harbor-prewarm) only skopeo-pushed the CONTAINER
+#   images enumerated from running Pods — NOT the charts. On hw146 the local
+#   Harbor openova-io project held 29 container repos and ZERO chart repos;
+#   the HelmReleases survived only because they were installed from ghcr.io
+#   at bootstrap and the strip had not yet run. The moment Phase-3 strips
+#   ghcr.io, any HR needing a (re)pull 404s. FIX: step-03 gains Phase A2 —
+#   it reads (chart,version,sourceRef) off every HelmRelease whose
+#   sourceRef.kind=HelmRepository and whose sourceRef.name is in the cutover
+#   pivot set (.Values.helmRepositories.names), then skopeo-copies each chart
+#   OCI artifact ghcr.io/openova-io/<chart>:<ver> → local Harbor BEFORE
+#   egress is cut. Same retry discipline as Phase A (--insecure-policy +
+#   --retry-times 3 + captured real exit status + parallel fan-out). The
+#   chart name+version come from the consuming HelmRelease's
+#   spec.chart.spec, NOT the HelmRepository (whose spec.url is only the
+#   project pointer). Template 03-harbor-prewarm-job.yaml.
+#
+#   DEFECT B — step-06 Phase-3a gated the strip on each pivoted
+#   HelmRepository reporting .status.conditions[Ready]==True. But for
+#   spec.type=oci HelmRepositories Flux source-controller does NOT reconcile
+#   them and sets NO conditions at all (they are static pointers consumed
+#   lazily by HelmReleases; no HelmChart/OCIRepository is ever created). On
+#   hw146 (source-controller v1.4.1) all 61 pivoted HRs were type=oci with
+#   EMPTY conditions (Ready=<none>), so the gate's Ready could never become
+#   True → it FATAL-refused the strip every run → cutover wedged at step-06
+#   forever (also the hw144 "loops at 0/0" shape, #3588 — same wrong-object
+#   read; this supersedes #3568's seen_local_ready latch). FIX: Phase-3a now
+#   performs a DIRECT authenticated `helm pull` of a representative sample of
+#   the pivoted charts from registry.<fqdn> (helm 3.16.3 ships in
+#   alpine/k8s:1.31.4; HOME + HELM_*_HOME point at the writable /tmp
+#   emptyDir). A successful pull proves Harbor serves the chart AND the
+#   Phase-0 auth works — the exact precondition for stripping ghcr.io. The
+#   strip-before-pivot INVARIANT is preserved: if the probe does not succeed
+#   within STRIP_READINESS_TIMEOUT_SECONDS the strip is REFUSED and the Job
+#   exits non-zero with mothership auth INTACT (recoverable). Phase-3b strip
+#   + idempotency unchanged. New value helmReadinessProbe.sampleSize (5) +
+#   HELM_PROBE_SAMPLE_SIZE env. Template 06-helmrepository-patches-job.yaml.
+#
+# No catalyst-api change, no step-count change (still 11 steps — step-03 is
+# extended, step-06's gate is replaced). Contract test Case 17b stays green
+# (the strip remains in Phase 3, fail-closed, after the pivot) + is extended
+# to assert the helm-pull probe replaces the .status.Ready read. New Case 26
+# locks the step-03 chart-mirror. Live 11-step→cutoverComplete=true + 600s
+# deny-egress validation DEFERRED to the next clean fresh prov (hw146 is
+# post-step-05 + pulls this chart from its own local Harbor OCI, so it cannot
+# receive a GitHub-main fix).
 # 0.1.64 (#3584 Refs #3379, hw144 step-01 gitea-mirror 401, 2026-06-15):
 # Step-01 (gitea-mirror) authenticated to the Gitea REST API with the admin
 # username+password as BasicAuth (`Authorization: Basic base64(user:pwd)`).
@@ -695,7 +747,7 @@ name: bp-self-sovereign-cutover
 # FATAL-on-failure contract is PRESERVED (Pillar 5 requires ALL openova-io
 # images local for the deny-egress hold) — the step only FATALs once BOTH retry
 # layers are exhausted. No step-count / RBAC / timeout change.
-version: 0.1.68
+version: 0.1.69
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -46,6 +46,15 @@ data:
     {{- range .Values.prewarm.images }}
     {{ . }}
     {{- end }}
+  # Phase A2 (Refs #3627): the openova-io HelmRepository pivot set — the
+  # SAME list step-06 repoints to local Harbor. Phase A2 mirrors the helm
+  # CHART OCI artifact (not just the container images) for every HelmRelease
+  # whose sourceRef.name is one of these, so the charts are present + pullable
+  # in local Harbor BEFORE step-06 strips the ghcr.io fallback.
+  chart-mirror-names.txt: |
+    {{- range .Values.helmRepositories.names }}
+    {{ . }}
+    {{- end }}
   podSpec: |
     serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
     restartPolicy: Never
@@ -86,9 +95,25 @@ data:
                 key: {{ .Values.harbor.ghcrSecretRef.dockerConfigKey }}
           - name: GHCR_DOCKERCONFIG_NAMESPACE
             value: {{ .Values.harbor.ghcrSecretRef.namespace | quote }}
+          # Phase A2 (Refs #3627 #3379): the cutover pivot set — the
+          # namespace holding the Flux HelmRepositories that step-06 repoints
+          # to local Harbor, and the names of those openova-io HelmRepositories.
+          # Phase A2 reads the chart+version off every HelmRelease whose
+          # sourceRef.kind=HelmRepository and whose sourceRef.name is in this
+          # set, then skopeo-mirrors the chart OCI artifact into local Harbor
+          # so the charts are PULLABLE post-cutover (without this, step-06
+          # only pivots the URL — the chart artifacts themselves never reach
+          # local Harbor, so the first post-strip (re)pull 404s).
+          - name: HELMREPO_NAMESPACE
+            value: {{ .Values.helmRepositories.namespace | quote }}
+          - name: UPSTREAM_PREFIX
+            value: {{ .Values.helmRepositories.upstreamPrefix | quote }}
         volumeMounts:
           - name: prewarm
             mountPath: /work
+            readOnly: true
+          - name: chart-mirror-names
+            mountPath: /chart-mirror
             readOnly: true
           - name: tmp
             mountPath: /tmp
@@ -366,6 +391,163 @@ data:
               exit 1
             fi
 
+            # ─── Phase A2: skopeo native push of openova-io HELM CHARTS ────────
+            #
+            # #3627 (Refs #3379, root-caused live on hw146): Phase A above
+            # mirrors the openova-io CONTAINER images, but NO cutover step ever
+            # mirrors the helm CHART OCI artifacts. Step-06 Phase-1 repoints
+            # every Flux HelmRepository from oci://ghcr.io/openova-io/<chart>
+            # to oci://registry.<sov-fqdn>/openova-io/<chart>, and step-06
+            # Phase-3 then strips the ghcr.io fallback from ghcr-pull. If the
+            # chart artifacts are NOT in local Harbor at that point, the first
+            # post-strip (re)pull 404s and the HelmRelease wedges. The
+            # HelmReleases survive on hw146 ONLY because they were installed
+            # from ghcr.io at bootstrap and the strip has not yet run; local
+            # Harbor's openova-io project held 29 container repos and ZERO
+            # chart repos. A true sovereignty cutover MUST carry every
+            # openova-io chart in local Harbor BEFORE egress is cut.
+            #
+            # The chart NAME + VERSION are NOT on the HelmRepository (its
+            # spec.url is only the project pointer oci://ghcr.io/openova-io);
+            # they live on each consuming HelmRelease's
+            # spec.chart.spec.{chart,version,sourceRef.{kind,name}}. We
+            # enumerate those tuples, select the ones whose sourceRef.kind is
+            # HelmRepository and whose sourceRef.name is in the cutover pivot
+            # set (.Values.helmRepositories.names, mounted at /chart-mirror),
+            # dedupe by chart:version, then skopeo-copy each chart OCI artifact
+            # ghcr.io/openova-io/<chart>:<version> → ${HARBOR_HOST}/openova-io/
+            # <chart>:<version>. Helm OCI charts are plain OCI artifacts, so
+            # `skopeo copy` handles them regardless of media type. Same retry
+            # discipline as Phase A (--insecure-policy + --retry-times 3 +
+            # captured real exit status + parallel fan-out via sentinels).
+            #
+            # `openova-catalog` is in the pivot set but is a project POINTER
+            # for per-Application HelmReleases (rendered by bp-catalyst-platform
+            # from .Values.catalog.helmRepository.url), not a single bootstrap
+            # chart artifact — it has no HelmRelease of its own to read a
+            # chart:version off, so the sourceRef-driven enumeration below
+            # naturally excludes it (no bootstrap HR sources from it). Any
+            # per-Application charts an operator later installs are mirrored by
+            # the ongoing gitea-mirror-resync + Harbor's own pull-through, not
+            # by this one-shot cutover prewarm.
+            echo "[harbor-prewarm] Phase A2: mirror openova-io helm charts into local Harbor"
+
+            # Build the pivot-set lookup (one HR name per line, mounted RO).
+            pivot_set_file=/tmp/.chart-pivot-set.txt
+            : > "${pivot_set_file}"
+            while IFS= read -r pl; do
+              pn=$(printf '%s' "${pl}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+              [ -z "${pn}" ] && continue
+              printf '%s\n' "${pn}" >> "${pivot_set_file}"
+            done < /chart-mirror/chart-mirror-names.txt
+
+            in_pivot_set() {
+              # $1 = HelmRepository name; 0 if present in the pivot set.
+              grep -Fxq "$1" "${pivot_set_file}"
+            }
+
+            # Enumerate (chart, version, sourceRef.kind, sourceRef.name) from
+            # every HelmRelease cluster-wide. Tab-separated; a HR with no
+            # explicit chart.spec is skipped (empty fields).
+            chart_tuples=$(kubectl get helmreleases -A -o json | \
+              jq -r '.items[].spec.chart.spec
+                | select(.chart != null and .sourceRef != null)
+                | [ .chart, (.version // ""), (.sourceRef.kind // ""), (.sourceRef.name // "") ]
+                | @tsv' 2>/dev/null | sort -u || true)
+
+            # Resolve the UPSTREAM chart-OCI host/project prefix from the same
+            # value step-06 pivots FROM (oci://ghcr.io/openova-io → host
+            # ghcr.io, project path openova-io). Strip the oci:// scheme.
+            up_chart_prefix=$(printf '%s' "${UPSTREAM_PREFIX}" | sed -e 's,^oci://,,' -e 's,/$,,')
+
+            # Dedupe the work list to chart:version pairs we actually mirror.
+            chart_work=/tmp/.chart-work.txt
+            : > "${chart_work}"
+            printf '%s\n' "${chart_tuples}" | while IFS="$(printf '\t')" read -r c_chart c_ver c_kind c_name; do
+              [ -z "${c_chart}" ] && continue
+              [ "${c_kind}" = "HelmRepository" ] || continue
+              in_pivot_set "${c_name}" || continue
+              if [ -z "${c_ver}" ]; then
+                echo "[harbor-prewarm] Phase A2 WARN: HelmRelease chart ${c_chart} (source ${c_name}) has no pinned version — skipping (cannot mirror a floating tag deterministically)"
+                continue
+              fi
+              printf '%s\t%s\n' "${c_chart}" "${c_ver}" >> "${chart_work}"
+            done
+            sort -u "${chart_work}" -o "${chart_work}"
+            chart_count=$(grep -c . "${chart_work}" || true)
+            echo "[harbor-prewarm] Phase A2: ${chart_count} unique openova-io chart(s) to mirror"
+
+            # Per-chart copy worker — same sentinel pattern as copy_one.
+            chart_cpdir=/tmp/chart-mirror-copies
+            rm -rf "${chart_cpdir}"; mkdir -p "${chart_cpdir}"
+            copy_chart() {
+              cchart="$1"; cver="$2"
+              csrc="docker://${up_chart_prefix}/${cchart}:${cver}"
+              cdst="docker://${HARBOR_HOST}/openova-io/${cchart}:${cver}"
+              cslug=$(printf '%s_%s' "${cchart}" "${cver}" | tr -c 'A-Za-z0-9._-' '_')
+              if skopeo copy \
+                --insecure-policy \
+                --retry-times 3 \
+                --src-creds="${ghcr_user}:${ghcr_pat}" \
+                --dest-creds="${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+                --dest-tls-verify=true \
+                --src-tls-verify=true \
+                "${csrc}" "${cdst}" >"${chart_cpdir}/${cslug}.log" 2>&1; then
+                printf '%s:%s' "${cchart}" "${cver}" >"${chart_cpdir}/${cslug}.ok"
+              else
+                crc=$?
+                printf '%s:%s exit=%s' "${cchart}" "${cver}" "${crc}" >"${chart_cpdir}/${cslug}.fail"
+              fi
+            }
+
+            chart_pids=""
+            while IFS="$(printf '\t')" read -r w_chart w_ver; do
+              [ -z "${w_chart}" ] && continue
+              echo "[harbor-prewarm] queue chart ${up_chart_prefix}/${w_chart}:${w_ver} → ${HARBOR_HOST}/openova-io/${w_chart}:${w_ver}"
+              copy_chart "${w_chart}" "${w_ver}" &
+              chart_pids="${chart_pids} $!"
+              # Throttle to PREWARM_PARALLELISM live workers (POSIX sh, no wait -n).
+              while : ; do
+                clive=0
+                cnewpids=""
+                for cp in ${chart_pids}; do
+                  if kill -0 "${cp}" 2>/dev/null; then
+                    clive=$((clive+1))
+                    cnewpids="${cnewpids} ${cp}"
+                  fi
+                done
+                chart_pids="${cnewpids}"
+                [ "${clive}" -lt "${PREWARM_PARALLELISM}" ] && break
+                sleep 2
+              done
+            done < "${chart_work}"
+            # Drain.
+            wait
+
+            chart_ok=0
+            chart_fail=0
+            for f in "${chart_cpdir}"/*.ok; do
+              [ -e "${f}" ] || continue
+              cup=$(cat "${f}")
+              cslug=$(basename "${f}" .ok)
+              sed 's/^/  /' "${chart_cpdir}/${cslug}.log" 2>/dev/null || true
+              chart_ok=$((chart_ok+1))
+              echo "[harbor-prewarm] OK chart ${cup}"
+            done
+            for f in "${chart_cpdir}"/*.fail; do
+              [ -e "${f}" ] || continue
+              cdetail=$(cat "${f}")
+              cslug=$(basename "${f}" .fail)
+              sed 's/^/  /' "${chart_cpdir}/${cslug}.log" 2>/dev/null || true
+              chart_fail=$((chart_fail+1))
+              echo "[harbor-prewarm] FAIL chart ${cdetail}"
+            done
+            echo "[harbor-prewarm] Phase A2 complete: chart_ok=${chart_ok} chart_fail=${chart_fail}"
+            if [ "${chart_fail}" -gt 0 ]; then
+              echo "[harbor-prewarm] FATAL: ${chart_fail} openova-io chart(s) failed to mirror — step-06 cannot strip ghcr.io safely (post-cutover chart (re)pulls would 404)"
+              exit 1
+            fi
+
             # ─── Phase B (legacy): HEAD against proxy-cache for non-openova-io ─
             echo "[harbor-prewarm] Phase B: HEAD against proxy-cache for upstream images"
             base="${HARBOR_INTERNAL_URL}/v2"
@@ -418,5 +600,11 @@ data:
           items:
             - key: prewarm.list
               path: prewarm.list
+      - name: chart-mirror-names
+        configMap:
+          name: cutover-step-03-harbor-prewarm
+          items:
+            - key: chart-mirror-names.txt
+              path: chart-mirror-names.txt
       - name: tmp
         emptyDir: {}

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -143,6 +143,14 @@ data:
           # .Values.stepTimeouts.stripReadinessSeconds.
           - name: STRIP_READINESS_TIMEOUT_SECONDS
             value: {{ .Values.stepTimeouts.stripReadinessSeconds | quote }}
+          # Phase-3a pull-probe sample size (Refs #3627). The strip is gated on
+          # a successful authenticated `helm pull` of a representative sample of
+          # the pivoted local-Harbor charts (NOT on a non-existent
+          # HelmRepository .status.Ready). bp-catalyst-platform is always probed
+          # when present; this caps the rest of the sample so the gate stays
+          # fast while still proving Harbor serves charts + auth works.
+          - name: HELM_PROBE_SAMPLE_SIZE
+            value: {{ .Values.helmReadinessProbe.sampleSize | quote }}
         volumeMounts:
           - name: helmrepository-list
             mountPath: /work
@@ -721,99 +729,165 @@ data:
               exit 0
             fi
 
-            # ---- Phase 3a: bounded wait for the pivoted HRs to be Ready ----
+            # ---- Phase 3a: prove pivoted charts are PULLABLE from local Harbor ----
             #
-            # We only gate on the HelmRepositories whose URL now points at the
-            # LOCAL Harbor host (harbor_host) — i.e. the ones this cutover
-            # pivoted. An HR still on ghcr.io is either intentionally external
-            # or not-yet-reverted-by-Flux; gating on it would deadlock. A
-            # local-Harbor HR that is Ready=True PROVES (a) registry.<fqdn>
-            # serves the chart and (b) the Phase-0 Harbor auth works — exactly
-            # the precondition for safely dropping ghcr.io.
+            # We gate the strip on the HelmRepositories whose URL now points at
+            # the LOCAL Harbor host (harbor_host) — the ones this cutover
+            # pivoted. The proof that it is SAFE to drop the ghcr.io fallback is
+            # a successful AUTHENTICATED OCI PULL of a representative set of the
+            # pivoted charts from registry.<fqdn>: that proves (a) Harbor serves
+            # the chart artifact (Phase A2 of step-03 mirrored it) and (b) the
+            # Phase-0 Harbor auth works — exactly the precondition for stripping
+            # ghcr.io. If the probe does NOT succeed within the budget, this
+            # block leaves ready_ok=false → the FATAL/REFUSE path below exits
+            # non-zero with mothership auth INTACT (recoverable on re-run).
             #
-            # Ready is read from the Flux source-controller condition
-            # (.status.conditions[type==Ready].status). source-controller sets
-            # Ready=True once it has FETCHED + verified the OCI artifact, which
-            # for an OCI HelmRepository means a successful authenticated pull —
-            # the very operation that 401s if Harbor auth is wrong.
+            # WHY NOT read the HelmRepository .status Ready condition (the
+            # PREVIOUS gate, Refs #3568): for spec.type=oci HelmRepositories
+            # Flux source-controller does NOT reconcile them and sets NO
+            # .status.conditions AT ALL — they are static pointers consumed
+            # lazily by the consuming HelmReleases (no HelmChart / OCIRepository
+            # object is ever created for them). On hw146 (source-controller
+            # v1.4.1) all 61 pivoted HelmRepositories were type=oci with EMPTY
+            # .status.conditions (Ready=<none>), so the old gate's Ready could
+            # NEVER become True → it FATAL-refused the strip every run and the
+            # cutover wedged at step-06 forever (also the hw144 "loops at 0/0"
+            # shape, Refs #3588 — the same wrong-object read). The real proof is
+            # an actual authenticated pull, NOT a non-existent status field.
+            #
+            # The probe runs from the writable /tmp emptyDir (the Pod is
+            # readOnlyRootFilesystem:true) by pointing HOME + the HELM_*_HOME
+            # vars there before `helm registry login` / `helm pull`.
             strip_wait_deadline=$(( $(date +%s) + STRIP_READINESS_TIMEOUT_SECONDS ))
-            echo "[helmrepository-patches] Phase-3a: waiting up to ${STRIP_READINESS_TIMEOUT_SECONDS}s for local-Harbor HelmRepositories to be Ready before stripping mothership auth"
+            echo "[helmrepository-patches] Phase-3a: proving pivoted charts are pullable from ${harbor_host} (up to ${STRIP_READINESS_TIMEOUT_SECONDS}s) before stripping mothership auth"
             ready_ok="false"
-            # `seen_local_ready` latches TRUE the first poll in which every
-            # observed local-Harbor HR is Ready=True AND at least one local-
-            # Harbor HR was present (total>0). It is what lets the loop
-            # terminate-success in the `0/0` case WITHOUT reintroducing the
-            # strip-before-pivot half-pivot.
-            #
-            # WHY THE LATCH (the hw144 step-06 loops-forever bug, Refs #3568):
-            #   The original success test was `total>0 && not_ready==0`. On
-            #   hw144 the local-Harbor HR set converged `61/61 not-Ready → …
-            #   → 1/1 (openova-catalog) → 0/0 not-Ready: <none>` and then
-            #   LOOPED FOREVER at `0/0`: once the tracked set emptied to
-            #   total=0 (every pivoted HR Ready, then a Flux re-render /
-            #   churn window transiently dropped the local-Harbor match count
-            #   to zero) the `total>0` guard could never be satisfied again,
-            #   so the loop spun out the full deadline and then FATAL-refused
-            #   the strip → cutover wedged at step-06.
-            #
-            #   The fix is NOT "treat any 0/0 as done" — that would let the
-            #   VERY FIRST poll (before Flux has pivoted any HR to local
-            #   Harbor) strip ghcr.io with total=0, which is precisely the
-            #   half-pivot the #3379/#3526 strip-before-pivot fix prevents.
-            #   Instead we require that the pivot was OBSERVED CONVERGED at
-            #   least once: success is `not_ready==0` AND (`total>0` this poll
-            #   OR we have previously latched a fully-Ready local-Harbor set).
-            #   A genuine half-pivot (HRs stuck not-Ready, latch never set)
-            #   still spins to the deadline and correctly REFUSES the strip.
-            seen_local_ready="false"
-            # Snapshot file (writable /tmp emptyDir) holding one line per HR:
-            # "<ns> <name> <spec.url> <Ready-status>". Re-written each poll.
-            # Using a file (not a heredoc) keeps the whole block correctly
-            # indented inside the YAML block scalar.
-            hr_snapshot=/tmp/.hr-readiness.txt
-            while [ "$(date +%s)" -lt "${strip_wait_deadline}" ]; do
-              # Re-poke a reconcile so we don't wait out the 15m interval.
-              now_ts=$(date +%s)
-              total=0
-              not_ready=0
-              not_ready_names=""
-              kubectl get helmrepositories -A \
-                -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{" "}{.spec.url}{" "}{range .status.conditions[?(@.type=="Ready")]}{.status}{end}{"\n"}{end}' \
-                2>/dev/null > "${hr_snapshot}" || : > "${hr_snapshot}"
-              # Enumerate every HelmRepository cluster-wide; select those whose
-              # spec.url host is the local Harbor host.
-              while read -r ns name url ready; do
-                [ -z "${ns}" ] && continue
-                case "${url}" in
-                  *"//${harbor_host}/"*|*"//${harbor_host}") : ;;  # local-Harbor HR — gate on it
-                  *) continue ;;                                    # not pivoted to local Harbor — skip
+
+            # Writable helm home (root FS is read-only).
+            export HOME=/tmp/helm-home
+            export HELM_CACHE_HOME=/tmp/helm-home/cache
+            export HELM_CONFIG_HOME=/tmp/helm-home/config
+            export HELM_DATA_HOME=/tmp/helm-home/data
+            export HELM_REGISTRY_CONFIG=/tmp/helm-home/config/registry.json
+            mkdir -p "${HELM_CACHE_HOME}" "${HELM_CONFIG_HOME}" "${HELM_DATA_HOME}" /tmp/helm-pull
+
+            if ! command -v helm >/dev/null 2>&1; then
+              echo "[helmrepository-patches] FATAL: helm not found on PATH — cannot prove local-Harbor pullability (alpine/k8s is expected to ship helm 3.x)" >&2
+              exit 1
+            fi
+            echo "[helmrepository-patches] Phase-3a: helm $(helm version --short 2>/dev/null || echo '?')"
+
+            # Build the probe list: (chart, version) for every HelmRelease whose
+            # sourceRef.kind=HelmRepository and whose referenced HelmRepository's
+            # LIVE spec.url host is harbor_host (i.e. already pivoted to local
+            # Harbor). This mirrors step-03 Phase A2's enumeration (the charts it
+            # mirrored) and the old gate's "only local-Harbor HRs" selection.
+            local_hr_file=/tmp/.local-harbor-hrs.txt
+            kubectl get helmrepositories -A \
+              -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.url}{"\n"}{end}' \
+              2>/dev/null | while read -r hrname hrurl; do
+                [ -z "${hrname}" ] && continue
+                case "${hrurl}" in
+                  *"//${harbor_host}/"*|*"//${harbor_host}") printf '%s\n' "${hrname}" ;;
+                  *) : ;;
                 esac
-                total=$((total+1))
-                if [ "${ready}" != "True" ]; then
-                  not_ready=$((not_ready+1))
-                  not_ready_names="${not_ready_names}${ns}/${name}(${ready:-<none>}) "
-                  kubectl annotate --overwrite -n "${ns}" "helmrepository/${name}" \
-                    "reconcile.fluxcd.io/requestedAt=${now_ts}" >/dev/null 2>&1 || true
-                fi
-              done < "${hr_snapshot}"
-              # Latch: at least one local-Harbor HR present this poll AND all
-              # of them Ready — the proof that registry.<fqdn> + Phase-0 auth
-              # work. Once latched it stays latched, so a later poll that finds
-              # the tracked set emptied (total=0) still counts as converged.
-              if [ "${total}" -gt 0 ] && [ "${not_ready}" -eq 0 ]; then
-                seen_local_ready="true"
+              done | sort -u > "${local_hr_file}" || : > "${local_hr_file}"
+
+            probe_file=/tmp/.chart-probe.txt
+            kubectl get helmreleases -A -o json 2>/dev/null | \
+              jq -r '.items[].spec.chart.spec
+                | select(.chart != null and .sourceRef != null and (.sourceRef.kind // "") == "HelmRepository")
+                | [ (.sourceRef.name // ""), .chart, (.version // "") ]
+                | @tsv' 2>/dev/null | \
+              while IFS="$(printf '\t')" read -r src chart ver; do
+                [ -z "${chart}" ] && continue
+                [ -z "${ver}" ] && continue
+                grep -Fxq "${src}" "${local_hr_file}" || continue
+                printf '%s\t%s\n' "${chart}" "${ver}"
+              done | sort -u > "${probe_file}" || : > "${probe_file}"
+
+            probe_total=$(grep -c . "${probe_file}" || true)
+            # Probe a REPRESENTATIVE sample (cap to keep the gate fast) — a
+            # successful pull of any pivoted chart proves Harbor serves charts
+            # + the auth works; always include bp-catalyst-platform (the
+            # keystone HR) when present so the probe is never trivially small.
+            sample_file=/tmp/.chart-probe-sample.txt
+            : > "${sample_file}"
+            grep -E '^bp-catalyst-platform[[:space:]]' "${probe_file}" >> "${sample_file}" 2>/dev/null || true
+            grep -vE '^bp-catalyst-platform[[:space:]]' "${probe_file}" 2>/dev/null \
+              | head -n "${HELM_PROBE_SAMPLE_SIZE}" >> "${sample_file}" || true
+            sort -u "${sample_file}" -o "${sample_file}"
+            sample_total=$(grep -c . "${sample_file}" || true)
+            echo "[helmrepository-patches] Phase-3a: ${probe_total} pivoted chart(s) on ${harbor_host}; probing a sample of ${sample_total}"
+
+            helm registry login "${harbor_host}" \
+              -u "${HARBOR_USERNAME:-admin}" -p "${HARBOR_PASSWORD}" >/dev/null 2>&1 \
+              && echo "[helmrepository-patches] Phase-3a: helm registry login ${harbor_host} OK" \
+              || echo "[helmrepository-patches] Phase-3a WARN: helm registry login ${harbor_host} returned non-zero (will retry inside the pull loop)"
+
+            while [ "$(date +%s)" -lt "${strip_wait_deadline}" ]; do
+              if [ "${sample_total}" -eq 0 ]; then
+                # No pivoted-chart HelmRelease found yet — Phase-1's URL pivot
+                # may not have rendered onto the consuming HRs. Re-poke the HR
+                # reconciles + re-derive the sample; never strip on an empty
+                # sample (that is the half-pivot guard).
+                echo "[helmrepository-patches] Phase-3a: no pivoted-chart HelmRelease observed yet; re-poking reconciles + retrying in 15s"
+                kubectl get helmrepositories -A \
+                  -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+                  | while read -r rns rname; do
+                      [ -z "${rns}" ] && continue
+                      kubectl annotate --overwrite -n "${rns}" "helmrepository/${rname}" \
+                        "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null 2>&1 || true
+                    done || true
+                # Re-derive on the next loop (cheap): recompute local HRs + sample.
+                kubectl get helmrepositories -A \
+                  -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.url}{"\n"}{end}' 2>/dev/null \
+                  | while read -r hrname hrurl; do
+                      [ -z "${hrname}" ] && continue
+                      case "${hrurl}" in
+                        *"//${harbor_host}/"*|*"//${harbor_host}") printf '%s\n' "${hrname}" ;;
+                        *) : ;;
+                      esac
+                    done | sort -u > "${local_hr_file}" || : > "${local_hr_file}"
+                kubectl get helmreleases -A -o json 2>/dev/null | \
+                  jq -r '.items[].spec.chart.spec
+                    | select(.chart != null and .sourceRef != null and (.sourceRef.kind // "") == "HelmRepository")
+                    | [ (.sourceRef.name // ""), .chart, (.version // "") ]
+                    | @tsv' 2>/dev/null | \
+                  while IFS="$(printf '\t')" read -r src chart ver; do
+                    [ -z "${chart}" ] && continue
+                    [ -z "${ver}" ] && continue
+                    grep -Fxq "${src}" "${local_hr_file}" || continue
+                    printf '%s\t%s\n' "${chart}" "${ver}"
+                  done | sort -u > "${probe_file}" || : > "${probe_file}"
+                : > "${sample_file}"
+                grep -E '^bp-catalyst-platform[[:space:]]' "${probe_file}" >> "${sample_file}" 2>/dev/null || true
+                grep -vE '^bp-catalyst-platform[[:space:]]' "${probe_file}" 2>/dev/null \
+                  | head -n "${HELM_PROBE_SAMPLE_SIZE}" >> "${sample_file}" || true
+                sort -u "${sample_file}" -o "${sample_file}"
+                sample_total=$(grep -c . "${sample_file}" || true)
+                sleep 15
+                continue
               fi
-              # Success when NOTHING is not-ready AND we have ever observed the
-              # pivot fully converged. Covers both the steady all-Ready case
-              # (total>0, not_ready=0) and the post-convergence 0/0 case (the
-              # tracked set emptied after a clean pass) — without ever
-              # succeeding on a first-poll 0/0 where the pivot never happened.
-              if [ "${not_ready}" -eq 0 ] && { [ "${total}" -gt 0 ] || [ "${seen_local_ready}" = "true" ]; }; then
+              pull_ok=0
+              pull_fail=0
+              pull_fail_names=""
+              while IFS="$(printf '\t')" read -r p_chart p_ver; do
+                [ -z "${p_chart}" ] && continue
+                if helm pull "oci://${harbor_host}/openova-io/${p_chart}" \
+                     --version "${p_ver}" -d /tmp/helm-pull >/tmp/.helm-pull.log 2>&1; then
+                  pull_ok=$((pull_ok+1))
+                else
+                  pull_fail=$((pull_fail+1))
+                  pull_fail_names="${pull_fail_names}${p_chart}:${p_ver} "
+                fi
+              done < "${sample_file}"
+              if [ "${pull_ok}" -gt 0 ] && [ "${pull_fail}" -eq 0 ]; then
                 ready_ok="true"
-                echo "[helmrepository-patches] Phase-3a OK: local-Harbor HelmRepository pivot converged Ready=True (this poll total=${total}, seen_local_ready=${seen_local_ready})"
+                echo "[helmrepository-patches] Phase-3a OK: all ${pull_ok} sampled chart(s) pulled from ${harbor_host}/openova-io — local Harbor serves the charts + auth works"
                 break
               fi
-              echo "[helmrepository-patches] Phase-3a: ${not_ready}/${total} local-Harbor HelmRepository(ies) not yet Ready: ${not_ready_names:-<none>} (seen_local_ready=${seen_local_ready}); retrying in 15s"
+              echo "[helmrepository-patches] Phase-3a: ${pull_fail}/${sample_total} sampled chart(s) not yet pullable from ${harbor_host}: ${pull_fail_names:-<none>} (last error below); retrying in 15s"
+              sed 's/^/    /' /tmp/.helm-pull.log 2>/dev/null | tail -5 || true
               sleep 15
             done
 

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -365,7 +365,40 @@ if [ -z "${phase3_line}" ] || [ "${del_exec_line}" -lt "${phase3_line}" ]; then
   echo "FAIL: Step-06 executable strip del(.auths[...]) at line ${del_exec_line} runs BEFORE the Phase-3 header at line ${phase3_line:-<none>} — strip-before-pivot regression (Refs #3379 #3526)" >&2
   exit 1
 fi
-echo "  PASS (strip is in Phase 3, readiness-gated + fail-closed, after the pivot)"
+# (e) The Phase-3a readiness signal MUST be a DIRECT authenticated `helm pull`
+#     of the pivoted charts from local Harbor, NOT a read of the pivoted
+#     HelmRepository's .status.conditions[Ready] (Refs #3627). For
+#     spec.type=oci HelmRepositories Flux source-controller sets NO conditions
+#     at all (static pointers consumed lazily by HelmReleases), so the old
+#     Ready read could never become True → the strip was FATAL-refused every
+#     run and the cutover wedged at step-06 (hw146; also the hw144 0/0 shape,
+#     #3588). Guard against a regression back to the status-Ready read.
+if ! grep -Eq 'helm pull "oci://\$\{harbor_host\}/openova-io/' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase-3a does not prove pullability via 'helm pull oci://\${harbor_host}/openova-io/<chart>' — the strip readiness gate is not a real authenticated pull (Refs #3627)" >&2
+  exit 1
+fi
+if ! grep -q 'helm registry login' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase-3a does not 'helm registry login' the local Harbor before the pull probe (Refs #3627)" >&2
+  exit 1
+fi
+# The probe MUST run from a writable helm home (the Pod is
+# readOnlyRootFilesystem:true) — assert the HELM_*_HOME redirect to /tmp.
+if ! grep -q 'HELM_CACHE_HOME=/tmp' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase-3a does not point HELM_CACHE_HOME at the writable /tmp emptyDir — helm pull would fail on the read-only root FS (Refs #3627)" >&2
+  exit 1
+fi
+# And the gate MUST NOT have regressed to gating on the HelmRepository Ready
+# condition (the wrong-object read this fix removed).
+if grep -q 'local-Harbor HelmRepository(ies) not yet Ready' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase-3a still reads HelmRepository .status.conditions[Ready] — type:oci HRs carry no status; regression to the wrong-object gate (Refs #3627)" >&2
+  exit 1
+fi
+# HELM_PROBE_SAMPLE_SIZE env MUST render with a concrete positive integer.
+if ! grep -A1 'name: HELM_PROBE_SAMPLE_SIZE' "$TMP/render.yaml" | grep -Eq 'value: "[0-9]+"'; then
+  echo "FAIL: HELM_PROBE_SAMPLE_SIZE rendered with no/empty value — the Phase-3a probe sample size is unset (Refs #3627)" >&2
+  exit 1
+fi
+echo "  PASS (strip is in Phase 3, fail-closed; readiness proven via authenticated helm pull, not a non-existent HelmRepository Ready)"
 
 echo "[cutover-contract] Case 16: Step-06 helmrepository-patches pushes YAML edit to local Gitea (#970)"
 # 0.1.19 Step-06 only ran kubectl patch against live HelmRepository
@@ -775,5 +808,42 @@ if [ -f "$OVERLAY_06A" ]; then
 else
   echo "  SKIP (slot-06a overlay not present — chart consumed standalone)"
 fi
+
+echo "[cutover-contract] Case 26: Step-03 harbor-prewarm mirrors openova-io helm CHARTS into local Harbor (Refs #3627)"
+# hw146: step-03 Phase A skopeo-pushed only the CONTAINER images enumerated
+# from running Pods; NO step ever mirrored the helm CHART OCI artifacts. So
+# local Harbor's openova-io project held 0 chart repos and the moment step-06
+# Phase-3 stripped ghcr.io any HelmRelease (re)pull 404'd. Phase A2 reads
+# (chart,version) off every HelmRelease whose sourceRef.kind=HelmRepository +
+# sourceRef.name is in the pivot set, then skopeo-copies the chart OCI
+# artifact into local Harbor BEFORE egress is cut. Guard the wiring.
+if ! grep -q 'Phase A2: mirror openova-io helm charts into local Harbor' "$TMP/render.yaml"; then
+  echo "FAIL: Step-03 missing the Phase A2 helm-chart mirror — the charts never reach local Harbor; step-06's ghcr.io strip would 404 every (re)pull (Refs #3627)" >&2
+  exit 1
+fi
+# The chart name+version MUST be read off the consuming HelmRelease's
+# spec.chart.spec (NOT the HelmRepository, whose spec.url is only the pointer).
+if ! grep -q '.items\[\].spec.chart.spec' "$TMP/render.yaml"; then
+  echo "FAIL: Step-03 Phase A2 does not enumerate chart+version from HelmRelease spec.chart.spec (Refs #3627)" >&2
+  exit 1
+fi
+# It MUST select only sourceRef.kind=HelmRepository entries (skip OCIRepository/
+# GitRepository sources) so it mirrors exactly the charts step-06 pivots.
+if ! grep -q '"HelmRepository"' "$TMP/render.yaml"; then
+  echo "FAIL: Step-03 Phase A2 does not gate on sourceRef.kind==HelmRepository (Refs #3627)" >&2
+  exit 1
+fi
+# And it MUST skopeo-copy into the openova-io project of local Harbor.
+if ! grep -q 'docker://${HARBOR_HOST}/openova-io/' "$TMP/render.yaml"; then
+  echo "FAIL: Step-03 Phase A2 does not skopeo-copy charts into \${HARBOR_HOST}/openova-io/ (Refs #3627)" >&2
+  exit 1
+fi
+# The chart-mirror pivot-set MUST be projected as a ConfigMap data key driven
+# off the same .Values.helmRepositories.names step-06 uses.
+if ! grep -q 'chart-mirror-names.txt' "$TMP/render.yaml"; then
+  echo "FAIL: Step-03 missing the chart-mirror-names.txt projection (the pivot-set the chart mirror iterates) (Refs #3627)" >&2
+  exit 1
+fi
+echo "  PASS (Step-03 Phase A2 mirrors openova-io helm charts into local Harbor before egress is cut)"
 
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -557,6 +557,29 @@ gateway:
   # answer.
   waitTimeoutSeconds: 1800
 
+# Step-06 Phase-3a chart-pullability probe (Refs #3627 #3379, root-caused
+# live on hw146). The strip-before-pivot fix (#3568) gates the destructive
+# ghcr.io / harbor.openova.io auth strip behind a proof that the pivoted
+# charts reconcile from local Harbor. The ORIGINAL gate read each pivoted
+# HelmRepository's `.status.conditions[Ready]` — but for spec.type=oci
+# HelmRepositories Flux source-controller sets NO conditions at all (they are
+# static pointers consumed lazily by HelmReleases; no HelmChart/OCIRepository
+# is ever created). On hw146 all 61 pivoted HRs were type=oci with EMPTY
+# conditions, so the gate's Ready could never become True and the strip was
+# FATAL-refused on every run → cutover wedged at step-06. The corrected gate
+# performs a DIRECT authenticated `helm pull` of a representative sample of
+# the pivoted charts from registry.<fqdn>; success proves Harbor serves the
+# chart artifact (step-03 Phase A2 mirrored it) AND the Phase-0 Harbor auth
+# works. The charts are skopeo-prewarmed into local Harbor at step-03, so a
+# pull is typically seconds.
+helmReadinessProbe:
+  # Number of pivoted charts (besides bp-catalyst-platform, which is always
+  # probed when present) to pull in the Phase-3a proof. A successful pull of
+  # any pivoted chart already proves Harbor + auth; a small sample keeps the
+  # gate fast while remaining a genuine end-to-end pull. Operators may raise
+  # this to probe more charts.
+  sampleSize: 5
+
 # Per-step Job-stamp tuning. Each value lands inside the corresponding
 # PodSpec ConfigMap; catalyst-api copies it onto the stamped Job.
 stepTimeouts:


### PR DESCRIPTION
## Summary

Two stacked defects wedged the Pillar-5 sovereignty cutover at **step-06**, both root-caused **live on hw146** (`531e6908e606d11d`). North Star #5 (cutover → `cutoverComplete=true` + the 600s deny-egress hold) has never completed. This fixes both in the cutover chart (`bp-self-sovereign-cutover` 0.1.68 → 0.1.69).

### Defect A — no step mirrors the helm CHART OCI artifacts into local Harbor (`step-03`)

step-06 Phase-1 repoints every `HelmRepository` to `oci://registry.<sov-fqdn>/openova-io` and Phase-3 strips the `ghcr.io` fallback, but step-03 (harbor-prewarm) only skopeo-pushed the CONTAINER images enumerated from running Pods — not the charts. On hw146 the local Harbor `openova-io` project held 29 container repos and ZERO chart repos; the HelmReleases survived only because they were installed from `ghcr.io` at bootstrap and the strip had not yet run. The moment Phase-3 strips `ghcr.io`, any HR (re)pull 404s.

**Fix** (`templates/03-harbor-prewarm-job.yaml`, new Phase A2): reads `(chart, version, sourceRef)` off every HelmRelease whose `sourceRef.kind=HelmRepository` and whose `sourceRef.name` is in the cutover pivot set (`.Values.helmRepositories.names`), then `skopeo copy docker://ghcr.io/openova-io/<chart>:<ver> → docker://<harbor>/openova-io/<chart>:<ver>` BEFORE egress is cut. The chart name+version come from the consuming HelmRelease's `spec.chart.spec`, **not** the HelmRepository (whose `spec.url` is only the project pointer). Same retry discipline as the existing image-mirror phase (`--insecure-policy` + `--retry-times 3` + captured real exit status + parallel fan-out via sentinels). `openova-catalog` is correctly excluded (it is a project pointer for per-Application HRs, with no bootstrap HelmRelease of its own).

### Defect B — step-06 Phase-3a gate reads a non-existent Ready condition (`step-06`)

Phase-3a gated the destructive strip on each pivoted `HelmRepository` reporting `.status.conditions[Ready]==True`. For `spec.type=oci` HelmRepositories Flux source-controller does NOT reconcile them and sets NO conditions at all (static pointers consumed lazily by HelmReleases; no `HelmChart`/`OCIRepository` is ever created). On hw146 (source-controller v1.4.1) all 61 pivoted HRs were `type=oci` with EMPTY conditions (`Ready=<none>`), so the gate's Ready could never become True → it FATAL-refused the strip every run → cutover wedged at step-06. (Also the hw144 "loops at 0/0" shape, #3588 — same wrong-object read; supersedes #3568's `seen_local_ready` latch.)

**Fix** (`templates/06-helmrepository-patches-job.yaml`, Phase-3a rewrite): performs a DIRECT authenticated `helm pull` of a representative sample of the pivoted charts from `registry.<fqdn>` (helm 3.16.3 ships in `alpine/k8s:1.31.4`; `HOME` + `HELM_*_HOME` point at the writable `/tmp` emptyDir under `readOnlyRootFilesystem:true`). A successful pull proves Harbor serves the chart AND the Phase-0 auth works — the precondition for stripping `ghcr.io`. The strip-before-pivot invariant is preserved: if the probe does not succeed within `STRIP_READINESS_TIMEOUT_SECONDS`, the strip is REFUSED and the Job exits non-zero with mothership auth INTACT (recoverable). Phase-3b strip + idempotency unchanged.

## Validation

- `helm template` exit 0 (4698 lines) + `helm lint` clean.
- Rendered step-03 AND step-06 scripts pass BOTH `sh -n` and `dash -n` (POSIX sh, no bashisms — kom4dc is ancient dash).
- `tests/cutover-contract.sh` all green; **step count stays 11** (step-03 extended, step-06's gate replaced — NOT a new step). Case 17b extended to assert the `helm pull` probe replaces the `.status.Ready` read; new Case 26 locks the step-03 chart-mirror.
- Lockstep: `Chart.yaml` + `blueprint.yaml` + `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` all 0.1.68 → 0.1.69.

## Forward note

This rides the **next** fresh prov. hw146 is post-step-05 and pulls the cutover chart from its own local Harbor OCI, so it cannot receive a GitHub-main fix. The live 11-step → `cutoverComplete=true` + 600s deny-egress walk is operator-driven on that next prov. No "cutover works" claim is made here — evidence is code + helm-template + lint + contract-test only.

Refs #3627 #3379 #3588

🤖 Generated with [Claude Code](https://claude.com/claude-code)