### PR TITLE
fix: hw146 region-b cross-region data-wiring — shared-pg write host + openbao DR S3 cred + guacd PVC (Refs #3629)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -104,12 +104,15 @@ spec:
       # cascading into sso-bridge/gitea/harbor/oidc-gate/newapi/powerdns-admin.
       # Render now gated on .Capabilities.APIVersions.Has "dr.openova.io/v1"
       # (gold-standard pattern). Single-region byte-identical; pin in lockstep.
+      # 1.2.45 (#3626 + #3629): reconcile two concurrent 1.2.44 bumps — the
+      # #3626 console "Open" → /sso/landing repoint AND the #3629 snapshot-
+      # replication S3 seeder (independent files; pure version-line union).
       # 1.2.44 (#3626): repoint the console "Open" button's launch-url at the
       # on-origin /sso/landing page (drop ssoShim + the /ui/vault/auth?with=oidc
       # deep-link) so OpenBao lands signed-in instead of the popup-only Vault
       # OIDC callback's window.opener=null error. blueprint.yaml/Chart.yaml
       # lockstep; no chart-template change (landing page already shipped 1.2.35).
-      version: 1.2.44
+      version: 1.2.45
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -270,7 +270,18 @@ spec:
       postgresql:
         enabled: ${SOVEREIGN_KEYCLOAK_PG_OWN_CLUSTER:=true}
       externalDatabase:
-        host: shared-pg-rw.shared-data.svc.cluster.local
+        # #3629: host is a substitution var (the SAME pattern bp-gitea slot 10
+        # `${SOVEREIGN_GITEA_PG_HOST:=…}` + bp-harbor slot 19
+        # `${SOVEREIGN_HARBOR_PG_HOST:=…}` already use) instead of a hardcoded
+        # literal. Default `shared-pg-rw.shared-data…` keeps single-region
+        # byte-identical, but bitnami's externalDatabase.host is a scalar (no
+        # secretKeyRef), so the cross-region overlay must flip it to the
+        # ClusterMesh-global WRITE alias `shared-pg-mesh-rw.shared-data…` —
+        # the region-local `-rw` Service NXDOMAINs keycloak in the replica
+        # region (hw146: keycloak-0 JGroups JDBC `UnknownHostException
+        # shared-pg-rw`). bp-postgres 0.2.2 publishes the `-mesh-rw` alias on
+        # the primary + a replica stub so the value resolves in BOTH regions.
+        host: ${SOVEREIGN_KEYCLOAK_PG_HOST:=shared-pg-rw.shared-data.svc.cluster.local}
         port: 5432
         user: keycloak
         database: keycloak

--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -137,7 +137,7 @@ spec:
       # ingress rule (TCP 5432 from any in-cluster Pod) so the SHARED engine's
       # consumers reach it again; replication/own-cluster/operator carve-outs
       # unchanged; singleton stays byte-identical. Lockstep bump with 16c/16d.
-      version: 0.2.1
+      version: 0.2.2
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -82,7 +82,7 @@ spec:
       # primary NetworkPolicy default-denied every consumer's shared-pg-b-rw:5432
       # (grafana/powerdns hub on hw144). Adds TCP 5432 from any in-cluster Pod;
       # replication/own-cluster/operator carve-outs unchanged. Lockstep 16a/16d.
-      version: 0.2.1
+      version: 0.2.2
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -138,10 +138,16 @@ spec:
           namespaces: [grafana]
           extraData:
             GF_DATABASE_TYPE: postgres
-            GF_DATABASE_HOST: shared-pg-b-rw.shared-data.svc.cluster.local:5432
             GF_DATABASE_NAME: grafana
             GF_DATABASE_USER: grafana
             GF_DATABASE_SSL_MODE: disable
+          # GF_DATABASE_HOST carries host:port in one var (grafana's
+          # [database].host convention). #3629: declared as a hostPortKey so
+          # the chart renders the topology-aware $consumerHost
+          # (shared-pg-b-rw singleton, or the ClusterMesh-global
+          # shared-pg-b-mesh-rw write alias under active-hot-standby) instead
+          # of a region-local literal that NXDOMAIN'd grafana in region-B.
+          hostPortKeys: [GF_DATABASE_HOST]
           passwordAliases: [GF_DATABASE_PASSWORD]
       # pdns — READY-TO-ADOPT (schema-bootstrap follow-up, see header).
       - name: pdns

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -70,7 +70,7 @@ spec:
       # (SME mesh / newapi / openova-flow on hw144). Adds TCP 5432 from any
       # in-cluster Pod; replication/own-cluster/operator carve-outs unchanged.
       # Lockstep bump with 16a/16c.
-      version: 0.2.1
+      version: 0.2.2
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -171,7 +171,7 @@ spec:
       # SSO users into sovereign-admins → admin DETERMINISTIC. 0.2.16 had the
       # USER_GROUP+ADMINISTER but the membership table stayed empty so the owner
       # got no admin menu (#3475). Proven live on hw133.
-      version: 0.2.18
+      version: 0.2.19
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/category: platform
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.18
+  version: 0.2.19
   card:
     title: Apache Guacamole
     summary: Clientless HTML5 remote-desktop gateway. Browser-based RDP / VNC / SSH and kubectl-exec into Pods, with Keycloak SSO and full session recording to SeaweedFS. One Guacamole per Sovereign per ADR-0001 §11.

--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -171,7 +171,15 @@ name: bp-guacamole
 # connected → the permission store was unreachable → still no admin. Renamed to
 # the upstream-canonical POSTGRESQL_USER. Lockstep: 52-bp-guacamole.yaml pin →
 # 0.2.15. Refs #3374.
-version: 0.2.18
+# 0.2.19 (#3629, 2026-06-16): guacd PVC-mount fallback. #3374 made the WEBAPP
+# `recordings` volume an emptyDir when recordings.persistence=false (the
+# default) but MISSED guacd-deployment.yaml, whose volume block still
+# hard-referenced the gated-off `guacamole-recordings` PVC unconditionally.
+# guacd therefore FailedScheduling forever on the default path
+# (`persistentvolumeclaim "guacamole-recordings" not found`) — Pending in both
+# regions on hw146. Mirror the webapp's emptyDir/PVC `if` into guacd. Lockstep:
+# 52-bp-guacamole.yaml pin → 0.2.19. Refs #3629.
+version: 0.2.19
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/templates/guacd-deployment.yaml
+++ b/platform/guacamole/chart/templates/guacd-deployment.yaml
@@ -58,9 +58,23 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
       volumes:
+        # #3629: mirror the webapp's #3374 fallback — when
+        # recordings.persistence is false (the default), the `recordings`
+        # volume is an emptyDir, NOT the `guacamole-recordings` PVC. The
+        # guacd-deployment.yaml volume block previously hard-referenced the
+        # PVC unconditionally while seaweedfs-pvc.yaml only renders it under
+        # `persistence: true`, so guacd FailedScheduling
+        # (`persistentvolumeclaim "guacamole-recordings" not found`) forever
+        # on the default path. Operators who run real distributed SeaweedFS
+        # RWX flip recordings.persistence=true and both Pods bind the PVC.
         - name: recordings
+          {{- if .Values.guacamole.recordings.persistence }}
           persistentVolumeClaim:
             claimName: {{ include "bp-guacamole.recordingsName" . }}
+          {{- else }}
+          emptyDir:
+            sizeLimit: {{ .Values.guacamole.recordings.emptyDirSizeLimit | default "2Gi" | quote }}
+          {{- end }}
         - name: tmp
           emptyDir: {}
 {{- end }}

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.44
+  version: 1.2.45
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -108,7 +108,12 @@ name: bp-openbao
 # render nothing). tests/continuum-render.sh Case 3 now passes
 # `--api-versions dr.openova.io/v1`; new Case 4 proves the guard skips the CR
 # (no install failure) when the CRD is absent. No upstream subchart change.
-version: 1.2.44
+version: 1.2.45
+# 1.2.45 (#3626 + #3629, 2026-06-16): reconcile two concurrently-shipped 1.2.44
+# branches that both bumped bp-openbao. The changes live in independent files
+# (blueprint.yaml endpoint repoint vs snapshot-replication.yaml seeder), so this
+# is a pure version-line union — both #3626 and #3629 behaviour is present. The
+# two 1.2.44 changelog blocks below are kept as history.
 # 1.2.44 (#3626, 2026-06-16): make the console "Open" button land signed-in.
 # The Open button (AppDetail + AppsPage card) window.open()s catalyst-api's
 # launch-url as a TOP-LEVEL tab. blueprint.yaml's endpoint pointed that launch
@@ -125,6 +130,22 @@ version: 1.2.44
 # route + OIDC redirect-uri allowlist already exist); version bumped in
 # lockstep with blueprint.yaml + the bootstrap-kit slot pin so the new
 # blueprint OCI artifact (which carries the repointed endpoint) publishes.
+# 1.2.44 (#3629, 2026-06-16): snapshot-replication S3-credential SEEDER. The
+# snapshot save/fetch CronJobs read their S3 admin creds from `seaweedfs-s3-
+# secret` via secretKeyRef (resolves ONLY in the Pod's OWN ns), but
+# bp-seaweedfs creates that Secret INSIDE the rtz vCluster — the syncer mirrors
+# it to the HOST as `seaweedfs-s3-secret-x-seaweedfs-x-rtz-vcluster` in ns rtz,
+# NOT into the openbao ns. So on hw146 openbao-snapshot-save/fetch wedged
+# CreateContainerConfigError on the missing Secret. snapshot-replication.yaml
+# now ships a seeder Job (+ SA + cross-ns read ClusterRole + write Role) that
+# copies the admin access/secret keys from the host-synced source into the
+# openbao ns as `seaweedfs-s3-secret` — the SAME shape catalyst qa-fixtures'
+# `qa-cnpg-backup-s3-seed` Job uses, as a regular release resource (waits the
+# bootstrap-kit window, never a hook → no circular-dep wedge). Source location
+# is values-overridable (s3.credentialsSeeder.{sourceNamespace,sourceName}).
+# Renders ONLY under snapshotReplication.enabled (DoD-8 opt-in) so default +
+# single-region convergence is byte-identical. tests/snapshot-replication-
+# toggle.sh gains seeder assertions. No upstream subchart change.
 # 1.2.37 (#3374, 2026-06-14): fix the sso-landing nginx ImagePullBackOff. The
 # image was `harbor.openova.io/proxy-docker/library/nginx` but the live Harbor
 # DockerHub proxy-cache project is `proxy-dockerhub` (proxy-docker does NOT

--- a/platform/openbao/chart/templates/snapshot-replication.yaml
+++ b/platform/openbao/chart/templates/snapshot-replication.yaml
@@ -90,6 +90,13 @@ objects). The primary vs secondary CronJob is selected by
 {{- $credNs := $credSecret.namespace | default .Release.Namespace -}}
 {{- $accessKeyKey := $credSecret.accessKeyKey | default "admin_access_key_id" -}}
 {{- $secretKeyKey := $credSecret.secretKeyKey | default "admin_secret_access_key" -}}
+{{- /* #3629: credential-seeder source (host-synced rtz-vCluster Secret). */ -}}
+{{- $seeder := $s3.credentialsSeeder | default dict -}}
+{{- $seederImage := $seeder.image | default "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.29.3" -}}
+{{- if $registry }}{{- $seederImage = printf "%s/%s" $registry ($seeder.image | default "bitnamilegacy/kubectl:1.29.3") -}}{{- end -}}
+{{- $seederSrcNs := $seeder.sourceNamespace | default "rtz" -}}
+{{- $seederSrcName := $seeder.sourceName | default "seaweedfs-s3-secret-x-seaweedfs-x-rtz-vcluster" -}}
+{{- $seederWait := $seeder.waitIterations | default 900 -}}
 {{- $staging := $sr.restoreStaging | default dict -}}
 {{- $stagingPath := $staging.path | default "/snapshots/latest.snap" -}}
 {{- $stagingPvc := $staging.pvc | default dict -}}
@@ -149,6 +156,163 @@ subjects:
   - kind: ServiceAccount
     name: openbao-snapshot
     namespace: {{ .Release.Namespace | quote }}
+---
+# #3629: S3-credential SEEDER (both roles). bp-seaweedfs creates the source
+# `seaweedfs-s3-secret` INSIDE the rtz vCluster; the syncer mirrors it to the
+# HOST as $seederSrcName in ns $seederSrcNs. The snapshot CronJob reads its S3
+# creds via secretKeyRef, which K8s resolves ONLY in the Pod's own namespace —
+# so this Job copies the admin access/secret keys from the host-synced source
+# into the openbao ns as `$credName`. Same proven shape as the catalyst
+# qa-fixtures `qa-cnpg-backup-s3-seed` Job. Regular release resource (NOT a
+# Helm hook) so it can wait the full bootstrap-kit window for bp-seaweedfs
+# (a later slot) without wedging the openbao install (the qa-fixtures Fix #138
+# circular-dependency lesson). Renders only under snapshotReplication.enabled.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openbao-snapshot-s3-seeder
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao-snapshot-replication
+---
+# Cross-namespace READ of the single host-synced source Secret (cluster-scoped,
+# resourceNames-pinned so it is least-privilege — no broad Secret read).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Namespace }}-openbao-snapshot-s3-seeder-read
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao-snapshot-replication
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - {{ $seederSrcName | quote }}
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Namespace }}-openbao-snapshot-s3-seeder-read
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao-snapshot-replication
+subjects:
+  - kind: ServiceAccount
+    name: openbao-snapshot-s3-seeder
+    namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Namespace }}-openbao-snapshot-s3-seeder-read
+---
+# WRITE the seeded Secret in the openbao ($credNs) namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openbao-snapshot-s3-seeder-write
+  namespace: {{ $credNs | quote }}
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao-snapshot-replication
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openbao-snapshot-s3-seeder-write
+  namespace: {{ $credNs | quote }}
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao-snapshot-replication
+subjects:
+  - kind: ServiceAccount
+    name: openbao-snapshot-s3-seeder
+    namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openbao-snapshot-s3-seeder-write
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: openbao-snapshot-s3-seed
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao-snapshot-replication
+    # kyverno flux-managed Enforce gates Jobs in the openbao ns.
+    app.kubernetes.io/managed-by: flux
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 8
+  template:
+    metadata:
+      labels:
+        catalyst.openova.io/blueprint: bp-openbao
+        catalyst.openova.io/component: openbao-snapshot-replication
+        app.kubernetes.io/managed-by: flux
+    spec:
+      serviceAccountName: openbao-snapshot-s3-seeder
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+      containers:
+        - name: seed
+          image: {{ $seederImage | quote }}
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -eu
+              SRC_NS="{{ $seederSrcNs }}"
+              SRC_NAME="{{ $seederSrcName }}"
+              DST_NS="{{ $credNs }}"
+              DST_NAME="{{ $credName }}"
+              AK_KEY="{{ $accessKeyKey }}"
+              SK_KEY="{{ $secretKeyKey }}"
+              # bp-seaweedfs is a later bootstrap-kit slot — wait for the
+              # host-synced source Secret to materialise (default 900×2s=30m).
+              for _ in $(seq 1 {{ $seederWait }}); do
+                kubectl -n "$SRC_NS" get secret "$SRC_NAME" >/dev/null 2>&1 && break
+                sleep 2
+              done
+              AKID=$(kubectl -n "$SRC_NS" get secret "$SRC_NAME" -o jsonpath="{.data.$AK_KEY}")
+              SAKB=$(kubectl -n "$SRC_NS" get secret "$SRC_NAME" -o jsonpath="{.data.$SK_KEY}")
+              if [ -z "$AKID" ] || [ -z "$SAKB" ]; then
+                echo "FATAL: source S3 admin keys empty at $SRC_NS/$SRC_NAME — cannot seed openbao snapshot creds"
+                exit 1
+              fi
+              cat > /tmp/secret.json <<EOF
+              {"apiVersion":"v1","kind":"Secret","metadata":{"name":"$DST_NAME","namespace":"$DST_NS","labels":{"catalyst.openova.io/blueprint":"bp-openbao","app.kubernetes.io/managed-by":"flux"}},"type":"Opaque","data":{"$AK_KEY":"$AKID","$SK_KEY":"$SAKB"}}
+              EOF
+              if kubectl -n "$DST_NS" get secret "$DST_NAME" >/dev/null 2>&1; then
+                kubectl -n "$DST_NS" patch secret "$DST_NAME" --type=merge --patch-file=/tmp/secret.json
+              else
+                kubectl -n "$DST_NS" apply -f /tmp/secret.json
+              fi
+              echo "seeded $DST_NS/$DST_NAME from $SRC_NS/$SRC_NAME (keys $AK_KEY,$SK_KEY)"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: ["ALL"]
 {{- if eq $role "secondary" }}
 ---
 # Restore-staging PVC — only on the SECONDARY. The fetch CronJob writes the

--- a/platform/openbao/chart/tests/snapshot-replication-toggle.sh
+++ b/platform/openbao/chart/tests/snapshot-replication-toggle.sh
@@ -46,6 +46,11 @@ if grep -qE "name: openbao-snapshot-restore-staging$" "$TMP/default.yaml"; then
   echo "FAIL: default render contains the restore-staging PVC — skip-render is broken." >&2
   exit 1
 fi
+# #3629: the S3-credential seeder is also gated OFF by default.
+if grep -qE "name: openbao-snapshot-s3-seed$" "$TMP/default.yaml"; then
+  echo "FAIL: default render contains the S3-credential seeder Job — skip-render is broken (#3629)." >&2
+  exit 1
+fi
 echo "  PASS"
 
 echo "[snapshot-replication-toggle] Case 2: enabled + role=primary emits the snapshot-SAVE CronJob + S3 upload + auth login"
@@ -111,6 +116,31 @@ fi
 # (helm template defaults .Release.Namespace to "default").
 if ! grep -qE "^  name: openbao-snapshot-s3-creds$" "$TMP/primary.yaml"; then
   echo "FAIL: primary render missing the openbao-snapshot-s3-creds Role/RoleBinding." >&2
+  exit 1
+fi
+# #3629: the S3-credential SEEDER Job + RBAC must render so seaweedfs-s3-secret
+# lands in the openbao ns (the source lives in the rtz vCluster, the syncer
+# mirrors it host-side as seaweedfs-s3-secret-x-seaweedfs-x-rtz-vcluster). The
+# snapshot CronJob's secretKeyRef resolves ONLY in its own ns, so the seeder is
+# what makes the save/fetch Jobs schedulable (hw146 CreateContainerConfigError).
+if ! grep -qE "^  name: openbao-snapshot-s3-seed$" "$TMP/primary.yaml"; then
+  echo "FAIL: primary render missing the openbao-snapshot-s3-seed seeder Job (#3629)." >&2
+  exit 1
+fi
+if ! grep -qE "^  name: openbao-snapshot-s3-seeder$" "$TMP/primary.yaml"; then
+  echo "FAIL: primary render missing the seeder ServiceAccount (#3629)." >&2
+  exit 1
+fi
+# The seeder reads the HOST-synced rtz-vCluster source Secret (NOT a bare
+# `seaweedfs-s3-secret` in a non-existent ns) and writes the openbao-ns copy.
+if ! grep -q "seaweedfs-s3-secret-x-seaweedfs-x-rtz-vcluster" "$TMP/primary.yaml"; then
+  echo "FAIL: seeder does not source from the rtz-vCluster-synced Secret (#3629)." >&2
+  exit 1
+fi
+# The seeder's cross-ns read ClusterRole must be resourceNames-pinned (least
+# privilege — no broad cluster-wide Secret read).
+if ! grep -qE "^  name: default-openbao-snapshot-s3-seeder-read$" "$TMP/primary.yaml"; then
+  echo "FAIL: primary render missing the seeder cross-ns read ClusterRole (#3629)." >&2
   exit 1
 fi
 echo "  PASS"

--- a/platform/openbao/chart/values.yaml
+++ b/platform/openbao/chart/values.yaml
@@ -393,6 +393,27 @@ snapshotReplication:
       namespace: ""
       accessKeyKey: admin_access_key_id
       secretKeyKey: admin_secret_access_key
+    # #3629: the credentialsSecret above does NOT exist in the openbao ns by
+    # itself — bp-seaweedfs creates `seaweedfs-s3-secret` INSIDE the rtz
+    # vCluster (a Helm pre-install hook), and the vCluster syncer mirrors it
+    # to the HOST as `seaweedfs-s3-secret-x-seaweedfs-x-rtz-vcluster` in ns
+    # `rtz`. The snapshot CronJob's secretKeyRef resolves ONLY in its own ns,
+    # so without a bridge the save/fetch Jobs CreateContainerConfigError
+    # (hw146: openbao-snapshot-save/fetch wedged on the missing Secret). This
+    # seeder Job copies the admin S3 keys from the host-synced source into the
+    # openbao ns as `seaweedfs-s3-secret` — the SAME pattern the catalyst
+    # qa-fixtures `qa-cnpg-backup-s3-seed` Job uses. Renders only when
+    # snapshotReplication.enabled=true (DoD-8 opt-in), so the default
+    # convergence is untouched.
+    credentialsSeeder:
+      # Image with kubectl — proxied through Harbor (kyverno image-origin rule).
+      image: harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.29.3
+      # Source: the host-synced rtz-vCluster Secret (post-#3477 re-home).
+      sourceNamespace: rtz
+      sourceName: seaweedfs-s3-secret-x-seaweedfs-x-rtz-vcluster
+      # Wait window for the source to materialise (bp-seaweedfs is a later
+      # bootstrap-kit slot): default 900 × 2s = 30 min, matching qa-fixtures.
+      waitIterations: 900
   # Restore-staging PVC on the secondary — where the FETCH CronJob writes
   # the latest snapshot so bp-continuum's promotion step finds it.
   restoreStaging:

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-4-1-data-services
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.2.1
+  version: 0.2.2
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,5 +1,23 @@
 apiVersion: v2
 name: bp-postgres
+# 0.2.2 — #3629 (Refs #3571 #3572 North-Star-4): cross-region CONSUMER write
+#   host. 0.2.0 promised "the consumer host `<instance>-rw` is unchanged across
+#   regions", but never delivered it: CNPG's `<instance>-rw` Service is
+#   region-LOCAL (it exists only where the named primary Cluster runs), and the
+#   only ClusterMesh-global Service (`<instance>-mesh`) is `selectorType: r`
+#   (READ-only). So an agreed-multi-region consumer scheduled in the REPLICA
+#   region (grafana, powerdns-admin, keycloak — all on the #3572 active-hot-
+#   standby list) dialed `<instance>-rw.shared-data` and got NXDOMAIN
+#   (hw146 region-B: grafana/powerdns-admin CrashLoopBackOff + keycloak-0
+#   JGroups `UnknownHostException shared-pg-rw`). FIX: a SECOND managed Service
+#   `<instance>-mesh-rw` (`selectorType: rw` → the current primary instance,
+#   `service.cilium.io/global: "true"`) on the primary + a same-named replica
+#   stub (replica-mesh-service.yaml), so the write host resolves in BOTH regions
+#   and routes WRITES to whichever region is primary (follows bp-continuum
+#   promotion). The hub Secret's `host`/`uri` keys + a new reflect.hostKeys/
+#   hostPortKeys mechanism (grafana's GF_DATABASE_HOST) render this topology-
+#   aware `$consumerHost`. singleton render stays byte-identical (still
+#   `<instance>-rw`, no `-mesh-rw` Service — gated on activeHotStandby).
 # 0.2.1 — #3577 (Refs #3572 #3322): the active-hot-standby PRIMARY-side
 #   NetworkPolicy (shared-pg-allow-replication-to-primary) was COPIED from
 #   bp-cnpg-pair, a DEDICATED cluster with no external consumers — so it never
@@ -54,7 +72,7 @@ name: bp-postgres
 #   regions so it admits under BOTH the pre-#3370 CRD (hard-required) and the
 #   #3370 CRD (CEL-waived) — breaks the live upgrade-rollback deadlock that
 #   blocked keycloak->gitea->catalyst-platform on hw130.
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable

--- a/platform/postgres/chart/templates/_helpers.tpl
+++ b/platform/postgres/chart/templates/_helpers.tpl
@@ -109,6 +109,34 @@ into one global service so the host resolves and traffic crosses the mesh.
 {{- end -}}
 
 {{/*
+ClusterMesh-global WRITE Service alias the cross-region CONSUMER apps
+(grafana/keycloak/powerdns-admin) dial so their DB host resolves identically
+in BOTH regions and always routes to the CURRENT primary's write endpoint.
+
+The design's repeated promise — "the consumer host `<instance>-rw` is
+unchanged across regions" (16a/16c headers, cluster.yaml) — was never met:
+CNPG's auto-created `<instance>-rw` Service is region-LOCAL (it exists only
+where the named primary Cluster runs), and the existing `<instance>-mesh`
+global Service is `selectorType: r` (READ-only), so a consumer in the replica
+region that points at `<instance>-rw` gets NXDOMAIN (#3629: grafana/keycloak/
+powerdns-admin crashlooped on `shared-pg-*-rw.shared-data` in region-B).
+
+Named `<instance>-mesh-rw` (NOT `<instance>-rw`, which collides with CNPG's
+auto-created `-rw` Service — the bp-cnpg-pair "refusing to reconcile service,
+not owned by the cluster" incident). On the primary side it is declared via
+the primary Cluster CR's `spec.managed.services.additional[]` with
+`selectorType: rw` (CNPG ≥1.22), annotated `service.cilium.io/global: "true"`;
+on the replica side a same-named stub (zero local backends) lets Cilium merge
+the two into one global service so the host resolves and WRITES cross the mesh
+to the primary's primary instance. Promotion (bp-continuum flips the CR sides)
+re-homes the `rw` selector to whichever region is primary, so the consumer
+host needs no change on failover.
+*/}}
+{{- define "bp-postgres.writeServiceName" -}}
+{{- printf "%s-mesh-rw" (include "bp-postgres.instanceName" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Sanitise an arbitrary string into an RFC 1123 DNS-subdomain-safe name
 fragment so it can be used in a k8s resource name. PostgreSQL identifiers
 (role/database names) legally contain underscores (e.g. `openova_flow`),

--- a/platform/postgres/chart/templates/cluster.yaml
+++ b/platform/postgres/chart/templates/cluster.yaml
@@ -142,6 +142,34 @@ spec:
                   port: 5432
                   targetPort: 5432
                   protocol: TCP
+        # ClusterMesh-global WRITE alias (#3629). selectorType: rw → the
+        # PRIMARY instance only, so the cross-region CONSUMER apps
+        # (grafana/keycloak/powerdns-admin) get a host that resolves in BOTH
+        # regions and always routes WRITES to the current primary. The
+        # replica region has zero local backends matching this selector, so
+        # Cilium's affinity routing falls through to this primary region; a
+        # same-named stub (replica-mesh-service.yaml) keeps the host from
+        # NXDOMAIN-ing on the replica cluster. (The `<instance>-rw` name is
+        # reserved by CNPG, hence the `-mesh-rw` alias.)
+        - selectorType: rw
+          serviceTemplate:
+            metadata:
+              name: {{ include "bp-postgres.writeServiceName" . }}
+              labels:
+                {{- include "bp-postgres.labels" . | nindent 16 }}
+                catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+                catalyst.openova.io/role: write-endpoint
+              annotations:
+                service.cilium.io/global: "true"
+                service.cilium.io/affinity: {{ .Values.topology.clusterMesh.affinity | quote }}
+                catalyst.openova.io/blueprint: bp-postgres
+            spec:
+              type: ClusterIP
+              ports:
+                - name: postgres
+                  port: 5432
+                  targetPort: 5432
+                  protocol: TCP
     {{- end }}
   {{- end }}
   # inheritedMetadata: CNPG propagates these onto every Secret it generates

--- a/platform/postgres/chart/templates/replica-mesh-service.yaml
+++ b/platform/postgres/chart/templates/replica-mesh-service.yaml
@@ -59,4 +59,40 @@ spec:
       port: 5432
       targetPort: 5432
       protocol: TCP
+---
+{{- /*
+Replica-side stub for the ClusterMesh-global WRITE alias `<instance>-mesh-rw`
+(#3629). The primary side declares it `selectorType: rw` via the primary
+Cluster CR's managed.services (cluster.yaml); this same-named stub (zero local
+backends) lets Cilium merge the two into one global service so the cross-region
+CONSUMER apps' write host resolves on cluster-B and routes across the mesh to
+the primary region's primary instance. Selector adds the CNPG primary-role
+label so a same-cluster match would only ever be the local primary (none on the
+replica side) — identical merge semantics to the `-mesh` read stub above.
+*/ -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bp-postgres.writeServiceName" . }}
+  namespace: {{ include "bp-postgres.namespace" . }}
+  labels:
+    {{- include "bp-postgres.labels" . | nindent 4 }}
+    catalyst.openova.io/cnpg-pair: {{ include "bp-postgres.instanceName" . | quote }}
+    catalyst.openova.io/role: write-endpoint
+  annotations:
+    service.cilium.io/global: "true"
+    service.cilium.io/affinity: {{ .Values.topology.clusterMesh.affinity | quote }}
+    catalyst.openova.io/blueprint: bp-postgres
+spec:
+  type: ClusterIP
+  selector:
+    # CNPG `-rw` selector shape (primary instance of the PRIMARY Cluster) —
+    # matches zero Pods on the replica cluster by construction.
+    cnpg.io/cluster: {{ include "bp-postgres.instanceName" . }}
+    cnpg.io/instanceRole: primary
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+      protocol: TCP
 {{- end }}

--- a/platform/postgres/chart/templates/role-secrets.yaml
+++ b/platform/postgres/chart/templates/role-secrets.yaml
@@ -103,6 +103,19 @@ stringData:
 {{- end }}
 {{- /* Pass 3 — hub connection Secrets, one per binding declaring
 `reflect`, each carrying its owner's (deduped) password. */ -}}
+{{- /* Consumer-facing DB host (#3629). In active-hot-standby the consumer
+apps may run in EITHER region, and the named primary Cluster's `<instance>-rw`
+Service is region-LOCAL (it exists only where the primary runs), so a consumer
+in the replica region that dials `<instance>-rw` gets NXDOMAIN. Point the hub
+`host`/`uri` at the ClusterMesh-global WRITE alias `<instance>-mesh-rw` (a
+`selectorType: rw` managed Service on the primary + a replica-side stub) so the
+host resolves in BOTH regions and routes WRITES to the current primary. Single-
+region (singleton, no mesh) keeps `<instance>-rw` so the render stays byte-
+identical to pre-0.2.2. */ -}}
+{{- $consumerHost := printf "%s-rw.%s.svc.cluster.local" $instance $ns }}
+{{- if eq (include "bp-postgres.activeHotStandby" $ctx) "true" }}
+{{- $consumerHost = printf "%s.%s.svc.cluster.local" (include "bp-postgres.writeServiceName" $ctx) $ns }}
+{{- end }}
 {{- range .Values.databases }}
 {{- $db := . }}
 {{- if and $db.reflect $db.reflect.secretName }}
@@ -131,14 +144,30 @@ stringData:
   user: {{ $db.owner | quote }}
   password: {{ $password | quote }}
   dbname: {{ $db.name | quote }}
-  host: "{{ $instance }}-rw.{{ $ns }}.svc.cluster.local"
+  # $consumerHost = `<instance>-rw` (singleton) or the ClusterMesh-global
+  # `<instance>-mesh-rw` write alias (active-hot-standby) so the host
+  # resolves in BOTH regions — see the $consumerHost note above (#3629).
+  host: {{ $consumerHost | quote }}
   port: "5432"
   # CNPG-app-Secret-parity connection string (0.1.5) — URI-style
   # consumers (powerdns-admin SQLALCHEMY_DATABASE_URI) read this key
   # verbatim. Password is chart-minted randAlphaNum (URL-safe).
-  uri: "postgresql://{{ $db.owner }}:{{ $password }}@{{ $instance }}-rw.{{ $ns }}.svc.cluster.local:5432/{{ $db.name }}"
+  uri: "postgresql://{{ $db.owner }}:{{ $password }}@{{ $consumerHost }}:5432/{{ $db.name }}"
 {{- range $k, $v := $db.reflect.extraData }}
   {{ $k }}: {{ $v | quote }}
+{{- end }}
+{{- /* Topology-aware host injection (#3629). An env-style consumer often
+needs the DB host under its OWN variable name (grafana's GF_DATABASE_HOST),
+which previously meant a STATIC `<instance>-rw` literal in reflect.extraData
+— region-local, so it broke that consumer in the replica region. Declaring
+the key under reflect.hostKeys (host only) / reflect.hostPortKeys (host:5432)
+renders the topology-aware $consumerHost instead, so the consumer follows the
+singleton vs active-hot-standby switch automatically. */ -}}
+{{- range $hk := $db.reflect.hostKeys }}
+  {{ $hk }}: {{ $consumerHost | quote }}
+{{- end }}
+{{- range $hpk := $db.reflect.hostPortKeys }}
+  {{ $hpk }}: {{ printf "%s:5432" $consumerHost | quote }}
 {{- end }}
 {{- range $alias := $db.reflect.passwordAliases }}
   {{ $alias }}: {{ $password | quote }}

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -175,6 +175,18 @@ grep -q 'dataDurability: required' "$TMP/ahs.yaml" || fail "ahs primary synchron
 grep -q 'name: shared-pg-mesh' "$TMP/ahs.yaml" || fail "ahs primary missing -mesh global Service"
 grep -q 'service.cilium.io/global: "true"' "$TMP/ahs.yaml" || fail "ahs primary -mesh Service missing global annotation"
 grep -qE '^      additional:$' "$TMP/ahs.yaml" || fail "ahs primary mesh Service not under managed.services.additional"
+# #3629: the ClusterMesh-global WRITE alias -mesh-rw (selectorType: rw) so the
+# cross-region consumer host resolves in BOTH regions + routes writes to the
+# current primary. Must sit alongside the read -mesh service.
+grep -q 'name: shared-pg-mesh-rw' "$TMP/ahs.yaml" || fail "#3629: ahs primary missing -mesh-rw global WRITE Service"
+grep -qE '^        - selectorType: rw$' "$TMP/ahs.yaml" || fail "#3629: ahs primary -mesh-rw not selectorType rw"
+grep -q 'role: write-endpoint' "$TMP/ahs.yaml" || fail "#3629: ahs primary -mesh-rw missing write-endpoint role label"
+# #3629: the consumer hub host/uri must point at the -mesh-rw alias (NOT the
+# region-local -rw) under active-hot-standby so the replica region resolves it.
+grep -q 'host: "shared-pg-mesh-rw.shared-data.svc.cluster.local"' "$TMP/ahs.yaml" \
+  || fail "#3629: ahs primary hub Secret host != shared-pg-mesh-rw (region-local -rw would NXDOMAIN in region-B)"
+grep -q '@shared-pg-mesh-rw.shared-data.svc.cluster.local:5432/' "$TMP/ahs.yaml" \
+  || fail "#3629: ahs primary hub Secret uri not on the -mesh-rw write alias"
 # Region node-affinity (NOT the old topologyKey antiAffinity).
 grep -q 'key: openova.io/region' "$TMP/ahs.yaml" || fail "ahs primary missing region node-affinity"
 if grep -q 'topologyKey: topology.kubernetes.io/region' "$TMP/ahs.yaml"; then
@@ -210,6 +222,11 @@ grep -q 'name: shared-pg-ca' "$TMP/ahs-replica.yaml" || fail "ahs replica missin
 # The -mesh Service STUB renders on the replica side (same name, NXDOMAIN guard).
 grep -qE '^kind: Service$' "$TMP/ahs-replica.yaml" || fail "ahs replica missing -mesh Service stub"
 grep -q 'name: shared-pg-mesh' "$TMP/ahs-replica.yaml" || fail "ahs replica -mesh stub name mismatch"
+# #3629: the -mesh-rw WRITE stub also renders on the replica side so the
+# cross-region consumer write host resolves on cluster-B (zero local backends →
+# traffic crosses the mesh to the primary).
+grep -q 'name: shared-pg-mesh-rw' "$TMP/ahs-replica.yaml" || fail "#3629: ahs replica missing -mesh-rw WRITE stub"
+grep -q 'cnpg.io/instanceRole: primary' "$TMP/ahs-replica.yaml" || fail "#3629: ahs replica -mesh-rw stub missing primary-role selector"
 # NO Database CRs / role-password / hub Secrets on the replica side.
 if grep -qE '^kind: Database$' "$TMP/ahs-replica.yaml"; then
   fail "ahs replica side leaked a Database CR (primary-side only)"
@@ -264,6 +281,14 @@ fi
 if grep -qE '^  name: [a-z0-9-]+-mesh$|^        host: [a-z0-9-]+-mesh$' "$TMP/shared.yaml"; then
   fail "singleton render leaked a -mesh ClusterMesh Service (active-hot-standby only)"
 fi
+# #3629: the -mesh-rw WRITE alias is ALSO active-hot-standby-only; singleton
+# must not leak it, and the singleton consumer host must stay the region-local
+# -rw (byte-identical to pre-0.2.2).
+if grep -qE '^  name: [a-z0-9-]+-mesh-rw$' "$TMP/shared.yaml"; then
+  fail "#3629: singleton render leaked the -mesh-rw WRITE Service (active-hot-standby only)"
+fi
+grep -q 'host: "shared-pg-rw.shared-data.svc.cluster.local"' "$TMP/shared.yaml" \
+  || fail "#3629: singleton consumer host changed away from shared-pg-rw (must stay byte-identical)"
 if grep -q 'service.cilium.io/global' "$TMP/shared.yaml"; then
   fail "singleton render leaked the ClusterMesh global annotation (active-hot-standby only)"
 fi
@@ -331,10 +356,12 @@ databases:
       namespaces: [grafana]
       extraData:
         GF_DATABASE_TYPE: postgres
-        GF_DATABASE_HOST: shared-pg-b-rw.shared-data.svc.cluster.local:5432
         GF_DATABASE_NAME: grafana
         GF_DATABASE_USER: grafana
         GF_DATABASE_SSL_MODE: disable
+      # #3629: GF_DATABASE_HOST is now a hostPortKey (topology-aware host:port)
+      # not a static extraData literal — mirrors the real slot 16c.
+      hostPortKeys: [GF_DATABASE_HOST]
       passwordAliases: [GF_DATABASE_PASSWORD]
   - name: pdns
     owner: pdns
@@ -356,8 +383,11 @@ b_secret=$(grep -cE '^kind: Secret$' "$TMP/shared-b.yaml" || true)
 [ "$b_secret" -eq 6 ]  || fail "instance-B expected 6 Secrets (3 role + 3 hub), got $b_secret"
 grep -q 'GF_DATABASE_TYPE: "postgres"' "$TMP/shared-b.yaml" \
   || fail "instance-B grafana hub missing GF_DATABASE_TYPE extraData"
+# #3629: GF_DATABASE_HOST now comes from hostPortKeys (host:port). In singleton
+# it renders the region-local shared-pg-b-rw — byte-identical to the old
+# extraData literal. Under active-hot-standby it would render shared-pg-b-mesh-rw.
 grep -q 'GF_DATABASE_HOST: "shared-pg-b-rw.shared-data.svc.cluster.local:5432"' "$TMP/shared-b.yaml" \
-  || fail "instance-B grafana hub missing GF_DATABASE_HOST extraData"
+  || fail "instance-B grafana hub missing GF_DATABASE_HOST hostPortKey (singleton host:port)"
 grep -qE '^  GF_DATABASE_PASSWORD: ' "$TMP/shared-b.yaml" \
   || fail "instance-B grafana hub missing GF_DATABASE_PASSWORD alias"
 # The alias must carry the SAME password as the grafana role Secret.


### PR DESCRIPTION
Fixes the three real cross-region data-wiring defects surfaced by the hw146 region-b app-health sweep (deployment `531e6908e606d11d`, 2-region kom4dc 2-VPC mimic). All verified live read-only; fixes are chart/IaC source only and ride the next fresh prov (zero-touch — hw146 was NOT hand-patched).

Refs #3629 #3571 #3572 #3375

## Defect 1 — cross-region consumer WRITE host (bp-postgres 0.2.2)

`grafana`/`powerdns-admin`/`keycloak` (all on the #3572 active-hot-standby consumer list, founder-confirmed agreed-multi-region) crashlooped in region-B on `shared-pg-*-rw.shared-data` NXDOMAIN. **Verdict: DB WIRING, not placement** — these apps ARE meant to run multi-region; the bug is the missing write-capable cross-region host.

0.2.0 promised "the consumer host `<instance>-rw` is unchanged across regions" but never delivered it: CNPG's `<instance>-rw` Service is region-LOCAL, and the only ClusterMesh-global Service (`<instance>-mesh`) is `selectorType: r` (read-only). Fix: a SECOND managed Service `<instance>-mesh-rw` (`selectorType: rw`, `service.cilium.io/global`) on the primary + a same-named replica stub, so the write host resolves in BOTH regions and routes writes to the current primary (follows bp-continuum promotion). The hub Secret `host`/`uri` + a new `reflect.hostKeys`/`hostPortKeys` mechanism (grafana `GF_DATABASE_HOST`) render the topology-aware host. keycloak slot 09 host → substitution var (the bp-gitea/bp-harbor pattern) so the cross-region overlay flips it to `shared-pg-mesh-rw`.

- `cluster.yaml` +`selectorType: rw` global Service; `replica-mesh-service.yaml` +`-mesh-rw` stub; `_helpers.tpl` +`writeServiceName`; `role-secrets.yaml` topology-aware `$consumerHost` + `hostKeys`/`hostPortKeys`; slots 16c (grafana) + 09 (keycloak).
- **singleton render byte-identical** (gated on `activeHotStandby`). `postgres-render.sh` +assertions; all 11 cases green.

## Defect 2 — openbao raft DR snapshot S3 creds (bp-openbao 1.2.44)

`openbao-snapshot-save` (region-a) + `openbao-snapshot-fetch` (region-b) Jobs `CreateContainerConfigError`. **Verdict: real defect** — the snapshot CronJobs read S3 creds from `seaweedfs-s3-secret` via secretKeyRef (resolves only in the Pod's own ns), but bp-seaweedfs creates that Secret INSIDE the rtz vCluster; the syncer mirrors it host-side as `seaweedfs-s3-secret-x-seaweedfs-x-rtz-vcluster` in ns `rtz`, never into ns openbao. The chart already documented the expectation that a bridge seeds it — but none was wired.

Fix: a seeder Job (+ SA + cross-ns read ClusterRole resourceNames-pinned + write Role) copies the admin access/secret keys from the host-synced source into ns openbao as `seaweedfs-s3-secret` — the same shape catalyst qa-fixtures' `qa-cnpg-backup-s3-seed` Job uses. Regular release resource (never a hook → no circular-dep wedge). Renders only under `snapshotReplication.enabled` (= `SOVEREIGN_ENABLE_HOT_STANDBY`, the SAME gate the snapshot Jobs ride). Embedded scripts pass `sh -n` + `dash -n`. `snapshot-replication-toggle.sh` +seeder assertions.

## Defect 3a — guacd PVC mount (bp-guacamole 0.2.19)

`guacd` Pending in BOTH regions: `persistentvolumeclaim "guacamole-recordings" not found`. **Verdict: real chart defect** — #3374 made the WEBAPP `recordings` volume an emptyDir when `recordings.persistence=false` (default) but MISSED `guacd-deployment.yaml`, which still hard-referenced the gated-off PVC. Mirror the webapp's emptyDir/PVC `if` into guacd.

## Defect 3b — cnpg-pair replica-3 Pending — NO FIX (expected)

`cnpg-pair-bp-cnpg-pair-replica-3-join` Pending: `1 node(s) didn't match pod anti-affinity rules, 3 Insufficient cpu`. **Verdict: kom4dc resource ceiling, NOT a chart defect.** 3 replica instances (`podAntiAffinityType: preferred`, soft) across only 3 region-b workers already at 37-41 pods each; replica-1/-2 Ready = the working HA floor, replica-3 best-effort. No anti-affinity/resource change warranted.

## Validation
- `helm lint` clean on all 3 charts; blueprint.yaml ↔ Chart.yaml version parity OK; `kubectl kustomize` of the bootstrap-kit builds.
- Chart render tests green (bp-postgres 11 cases incl. singleton byte-identical + new `-mesh-rw`; bp-openbao 4 cases incl. seeder; bp-guacamole render verified default=emptyDir / persistence=true=PVC for guacd+webapp).
- All version bumps lockstep (Chart.yaml + blueprint.yaml + bootstrap-kit slot pins: bp-postgres 16a/16c/16d, bp-openbao 08, bp-guacamole 52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)