### PR TITLE
fix(bp-self-sovereign-cutover): step-08 egress-block-test bashism under busybox-ash /bin/sh — POSIX grep -vxF (0.1.70)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -537,7 +537,15 @@ spec:
       # Pending 22+ min, FailedScheduling Insufficient cpu — live hw145). It is
       # a skopeo image-copy Job (I/O-bound, not CPU-bound); right-sized the CPU
       # request 500m → 100m. Memory stays 512Mi. Chart-only.
-      version: 0.1.69
+      # 0.1.70 (#3634, Refs #3379): step-08 egress-block-test (the
+      # cutoverComplete gate) used bash process substitution
+      # `comm -13 <(echo ...)` under `/bin/sh` = busybox ash on alpine/k8s,
+      # which rejects `<(...)` as a parse-time syntax error → the whole step-08
+      # Job died before applying the deny-egress CCNP or running the 600s hold,
+      # so cutoverComplete never flipped. Fixed with POSIX `grep -vxF -f` on the
+      # writable /work emptyDir. Found auditing the never-run steps 08-11 to
+      # pre-empt hw147's cutover wedge. Chart-only.
+      version: 0.1.70
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.69
+  version: 0.1.70
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,37 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.70 (#3634 Refs #3379, step-08 bashism under busybox-ash /bin/sh,
+# 2026-06-16): the cutoverComplete gate (step-08 egress-block-test) would die
+# on a PARSE-time syntax error the FIRST time it is reached. Found auditing the
+# NEVER-RUN steps 08-11 (the saga has wedged at 01/03/05/06 every prior prov;
+# steps 04-11 have never executed) to pre-empt hw147's next cutover wedge.
+#
+# THE DEFECT — step-08's survival-window regression diff used bash PROCESS
+# SUBSTITUTION:
+#     new_hr=$(comm -13 <(echo "${baseline_hr}") <(echo "${hr_not_ready}"))
+# The container runs `command: ["/bin/sh", "-c"]` and on the alpine/k8s step
+# image `/bin/sh` is busybox ash, which does NOT support `<(...)`. busybox ash
+# parses the WHOLE script before executing, so `<(` is a parse-time
+# `syntax error: unexpected "("` → the container exits non-zero having run
+# NOTHING: no local-URL assertion, no cutover-egress-block CCNP applied, no
+# 600s survival window, no PASS → cutoverComplete stays false and the cutover
+# wedges at step-08. (busybox ash -n AND dash -n both REJECT `<(...)`; bash -n
+# accepts it — proving a bash-only construct, not a typo. The contract test only
+# `helm template`s; it never sh -n / dash -n-checks the rendered step scripts,
+# so this slipped through. Every OTHER cutover step script is dash -n clean —
+# step-08 was the sole offender, verified across all 11 in this audit.)
+#
+# THE FIX (chart-only, template 08-egress-block-test-job.yaml): `comm -13 A B`
+# (lines in B not in A) is exactly `grep -vxF -f A B`, which is POSIX (passes
+# dash -n AND busybox ash -n) and needs the baseline as a FILE. Persist the two
+# baseline sets to the existing writable /work emptyDir (added #3379 hw139) once
+# before the survival window, write the current sets there each poll, and diff
+# with `grep -vxF -f`. Byte-identical output to the old `comm -13` across every
+# case (empty baseline → all current items count as new; empty current → none),
+# verified. No step-count / RBAC / timeout / value change; contract test stays
+# green (11 steps). Live 11-step → cutoverComplete=true + 600s deny-egress
+# validation DEFERRED to the next clean fresh prov (operator drives the cutover;
+# this is the chart fix only).
 # 0.1.69 (#3627 Refs #3379, hw146 missing-chart-mirror + wrong-Ready gate,
 # 2026-06-16): TWO stacked defects that wedged the Pillar-5 cutover at
 # step-06, both root-caused live on hw146 (531e6908e606d11d).
@@ -747,7 +779,7 @@ name: bp-self-sovereign-cutover
 # FATAL-on-failure contract is PRESERVED (Pillar 5 requires ALL openova-io
 # images local for the deny-egress hold) — the step only FATALs once BOTH retry
 # layers are exhausted. No step-count / RBAC / timeout change.
-version: 0.1.69
+version: 0.1.70
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -276,6 +276,20 @@ data:
             else
               echo "[egress-block-test] baseline clean — no pre-existing NotReady items"
             fi
+            # #3634 — persist the baseline sets to files on the writable /work
+            # emptyDir for the POSIX regression diff in the survival loop below.
+            # The previous diff used `comm -13 <(echo "${baseline_hr}") <(echo
+            # "${hr_not_ready}")` — bash PROCESS SUBSTITUTION. This container
+            # runs `command: ["/bin/sh", ...]` and on the alpine/k8s image
+            # `/bin/sh` is busybox ash, which does NOT support `<(...)`: it is a
+            # PARSE-time syntax error (`syntax error: unexpected "("`) that
+            # aborted the WHOLE step-08 Job before it ran anything — no egress
+            # CCNP applied, no survival window, no PASS, so cutoverComplete
+            # never flipped true. `comm -13 A B` (lines in B not in A) is
+            # exactly `grep -vxF -f A B`, which is POSIX (passes dash -n AND
+            # busybox ash -n) and needs the baseline as a file.
+            printf '%s\n' "${baseline_hr}" > /work/baseline_hr.txt
+            printf '%s\n' "${baseline_ks}" > /work/baseline_ks.txt
             echo "[egress-block-test] entering ${DURATION_SECONDS}s survival window — only NEW NotReady regressions count as failure"
 
             start=$(date +%s)
@@ -292,8 +306,18 @@ data:
                 | grep -E '=False$' | sort -u || true)
 
               # Diff against baseline — only new entries count as a regression.
-              new_hr=$(comm -13 <(echo "${baseline_hr}") <(echo "${hr_not_ready}"))
-              new_ks=$(comm -13 <(echo "${baseline_ks}") <(echo "${ks_not_ready}"))
+              # POSIX-safe (#3634): `grep -vxF -f BASELINE CURRENT` emits the
+              # CURRENT lines absent from BASELINE — byte-identical to the old
+              # `comm -13 <(echo BASELINE) <(echo CURRENT)` but with no bash
+              # process substitution (busybox ash /bin/sh rejects `<(...)`).
+              # `-x` whole-line, `-F` fixed-string so `/` and `=` in the
+              # ns/name=False rows are literal. An empty baseline file makes
+              # grep match no patterns → `-v` returns ALL current lines (every
+              # not-ready item is new) — same as `comm -13` with an empty A.
+              printf '%s\n' "${hr_not_ready}" > /work/hr_not_ready.txt
+              printf '%s\n' "${ks_not_ready}" > /work/ks_not_ready.txt
+              new_hr=$(grep -vxF -f /work/baseline_hr.txt /work/hr_not_ready.txt || true)
+              new_ks=$(grep -vxF -f /work/baseline_ks.txt /work/ks_not_ready.txt || true)
 
               if [ -n "${new_hr}${new_ks}" ]; then
                 echo "[egress-block-test] NEW NotReady at $(($(date +%s) - start))s (regression):"


### PR DESCRIPTION
## Summary

Auditing the **NEVER-RUN cutover steps 08-11** (to pre-empt hw147's next cutover wedge) found ONE real defect: step-08 (`egress-block-test`, the `cutoverComplete` gate) would die on a **parse-time syntax error** the first time it is reached. Steps 09/10/11 audited clean.

## The defect

`platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml` survival-window regression diff used **bash process substitution**:

```sh
new_hr=$(comm -13 <(echo "${baseline_hr}") <(echo "${hr_not_ready}"))
new_ks=$(comm -13 <(echo "${baseline_ks}") <(echo "${ks_not_ready}"))
```

The container runs `command: ["/bin/sh", "-c"]`. On the step image (`alpine/k8s`) `/bin/sh` is **busybox ash**, which does **not** support `<(...)`. busybox ash parses the whole script before executing, so `<(` is a parse-time `syntax error: unexpected "("` — the container exits non-zero having executed **nothing**: no local-URL assertion, no `cutover-egress-block` CCNP applied, no 600s survival window, no PASS. catalyst-api sees a Failed Job and the cutover **wedges at step-08**; `cutoverComplete` stays `false`.

## Why it surfaces on hw147 specifically

Per memory `feedback_cutover_reveals_earlier_defect_each_attempt`, **steps 04-11 have NEVER executed** — the cutover has wedged at steps 01/03/05/06 every prior prov. With #3630 (step-03 chart-mirror + step-06 helm-pull gate) merged and the step-07 06a overlay verified, hw147's cutover reaches step-08 for the **first time** — and hits this parse error. This is the next-earlier defect the saga pattern predicts.

## Verification

| shell | `<(...)` |
|---|---|
| busybox ash `-n` | `syntax error: unexpected "("` — **REJECTED** |
| dash `-n` (POSIX) | `Syntax error: "(" unexpected` — **REJECTED** |
| bash `-n` | **ACCEPTED** (proves a bash-only construct, not a typo) |

All 11 cutover step scripts + the auto-trigger Job were extracted from the rendered chart and checked with **both** `dash -n` and `busybox ash -n`. Before this PR: step-08 FAILED. After: all 11 + auto-trigger pass both. The contract test only `helm template`s — it never `sh -n`/`dash -n`-checks the rendered step scripts, which is why this slipped through.

## Fix (chart-only, smallest correct)

`comm -13 A B` (lines in B not in A) is exactly `grep -vxF -f A B`, which is POSIX (passes `dash -n` AND `busybox ash -n`) and needs the baseline as a file. Persist the two baseline sets to the existing writable `/work` emptyDir (added in #3379 hw139) once before the survival window, write the current sets there each poll, and diff with `grep -vxF -f`. `grep` is guaranteed present (the script already uses `grep -E`); this also sidesteps any `comm` availability question.

Output is **byte-identical** to the old `comm -13` across every case (byte-verified):
- empty baseline → all current not-ready items count as new (regression detected)
- empty current (cluster healthy, the PASS case) → no regression
- `$()` strips the trailing blank, so the `[ -n ... ]` guard sees a genuinely empty `new_hr`/`new_ks` when healthy.

No step-count / RBAC / timeout / value change. Contract test stays **green** (all 26 cases, 11 steps).

## Lockstep

- `chart/Chart.yaml` 0.1.69 → 0.1.70 (+ changelog header)
- `blueprint.yaml` 0.1.69 → 0.1.70
- `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` pin 0.1.69 → 0.1.70 (+ changelog)

## Acceptance (deferred)

Live 11-step → `cutoverComplete=true` + the 600s deny-egress hold validation is DEFERRED to the next clean fresh prov (the operator drives the cutover; this is the chart fix only). This PR makes step-08 *reachable* — it is necessary, not sufficient, for the Pillar-5 walk.

Refs #3634
Refs #3379

🤖 Generated with [Claude Code](https://claude.com/claude-code)