### PR TITLE
fix(bp-openbao): secondary snapshot-FETCH CronJob drops its unused OpenBao login (1.2.46)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -104,6 +104,12 @@ spec:
       # cascading into sso-bridge/gitea/harbor/oidc-gate/newapi/powerdns-admin.
       # Render now gated on .Capabilities.APIVersions.Has "dr.openova.io/v1"
       # (gold-standard pattern). Single-region byte-identical; pin in lockstep.
+      # 1.2.46 (#3629): the SECONDARY (fetch) snapshot CronJob drops its OpenBao
+      # k8s-auth login — the fetch is pure S3 I/O and never reads BAO_TOKEN, but
+      # the unconditional login crashlooped it on hw147 region-B (`Could not
+      # resolve host openbao-openbao…` → `bao login returned no client_token`)
+      # while openbao-0 was Running. Login now PRIMARY/save-only. Single-region
+      # byte-identical (snapshotReplication default-OFF); pin in lockstep.
       # 1.2.45 (#3626 + #3629): reconcile two concurrent 1.2.44 bumps — the
       # #3626 console "Open" → /sso/landing repoint AND the #3629 snapshot-
       # replication S3 seeder (independent files; pure version-line union).
@@ -112,7 +118,7 @@ spec:
       # deep-link) so OpenBao lands signed-in instead of the popup-only Vault
       # OIDC callback's window.opener=null error. blueprint.yaml/Chart.yaml
       # lockstep; no chart-template change (landing page already shipped 1.2.35).
-      version: 1.2.45
+      version: 1.2.46
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.45
+  version: 1.2.46
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -108,7 +108,21 @@ name: bp-openbao
 # render nothing). tests/continuum-render.sh Case 3 now passes
 # `--api-versions dr.openova.io/v1`; new Case 4 proves the guard skips the CR
 # (no install failure) when the CRD is absent. No upstream subchart change.
-version: 1.2.45
+version: 1.2.46
+# 1.2.46 (#3629, 2026-06-16): the SECONDARY (fetch) snapshot CronJob no longer
+# performs an OpenBao k8s-auth login. The fetch path is PURE S3 I/O
+# (list-objects-v2 + `s3 cp` to the restore-staging PVC) and NEVER reads
+# BAO_TOKEN — but the login ran UNCONDITIONALLY before the role branch, so on
+# hw147 region-B the fetch crashlooped `curl: (6) Could not resolve host
+# openbao-openbao.openbao.svc.cluster.local` → `FATAL: bao login returned no
+# client_token` (every CronJob tick Error) while openbao-0 itself was Running —
+# the openbao DR-snapshot floor (region-kill-relevant) was dead. The login is
+# now ONLY on the PRIMARY/save branch (it genuinely needs BAO_TOKEN for
+# `GET sys/storage/raft/snapshot`); the fetch goes straight to the S3 staging.
+# snapshot-replication stays default-OFF (DoD-8 opt-in) so default + single-
+# region render is byte-identical; tests/snapshot-replication-toggle.sh Case 2
+# asserts the save KEEPS the login + Case 3 asserts the fetch DROPS it. No
+# upstream subchart change.
 # 1.2.45 (#3626 + #3629, 2026-06-16): reconcile two concurrently-shipped 1.2.44
 # branches that both bumped bp-openbao. The changes live in independent files
 # (blueprint.yaml endpoint repoint vs snapshot-replication.yaml seeder), so this

--- a/platform/openbao/chart/templates/snapshot-replication.yaml
+++ b/platform/openbao/chart/templates/snapshot-replication.yaml
@@ -429,25 +429,20 @@ spec:
                 - |
                   set -eu
                   log() { printf '%s | %s\n' "$(date -u +%FT%TZ)" "$*"; }
-
-                  # ─── K8s-auth login to OpenBao ─────────────────────────
-                  # SAME pattern as sso-configure-deployment.yaml:113 and
-                  # ESO: present the projected SA token to
-                  # auth/<path>/login, extract client_token. The init-time
-                  # root token was revoked by auth-bootstrap, so this is the
-                  # only valid ongoing auth path.
-                  SA_TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
-                  BAO_TOKEN="$(curl -sS -k \
-                    -H 'Content-Type: application/json' \
-                    --data "{\"role\":\"${BAO_K8S_AUTH_ROLE}\",\"jwt\":\"${SA_TOKEN}\"}" \
-                    "${BAO_ADDR%/}/v1/auth/${BAO_K8S_AUTH_PATH}/login" \
-                    | sed -n 's/.*"client_token":"\([^"]*\)".*/\1/p')"
-                  if [ -z "${BAO_TOKEN}" ]; then
-                    log "FATAL: bao login returned no client_token — the ${BAO_K8S_AUTH_ROLE} role may not yet be bound by auth-bootstrap"
-                    exit 1
-                  fi
-                  log "authenticated to OpenBao via k8s auth role ${BAO_K8S_AUTH_ROLE}"
 {{- if eq $role "secondary" }}
+                  # ─── SECONDARY (fetch): NO OpenBao login ───────────────
+                  # #3629: the fetch path does PURE S3 I/O (list-objects-v2 +
+                  # s3 cp to the staging PVC) and NEVER touches an OpenBao API
+                  # — it does not read BAO_TOKEN at all. The earlier
+                  # unconditional `bao login` made the fetch FATAL on its OWN
+                  # region's OpenBao auth being reachable + the openbao-snapshot
+                  # role being bound by auth-bootstrap, even though the token is
+                  # unused: on hw147 region-B the fetch crashlooped on
+                  # `curl: (6) Could not resolve host openbao-openbao…` →
+                  # `bao login returned no client_token` while openbao-0 itself
+                  # was Running. The save (primary) genuinely needs the token
+                  # (GET sys/storage/raft/snapshot), so the login stays on that
+                  # branch only.
                   # ─── SECONDARY: fetch latest snapshot to staging PVC ────
                   # Pull the most recent snapshot object from S3 to the
                   # restore-staging path. This does NOT touch any OpenBao
@@ -468,6 +463,26 @@ spec:
                     "s3://${S3_BUCKET}/${LATEST}" "${STAGING_PATH}"
                   log "staged ${LATEST} -> ${STAGING_PATH} (restore-ready for bp-continuum promotion)"
 {{- else }}
+                  # ─── K8s-auth login to OpenBao (PRIMARY/save only) ─────
+                  # SAME pattern as sso-configure-deployment.yaml:113 and
+                  # ESO: present the projected SA token to
+                  # auth/<path>/login, extract client_token. The init-time
+                  # root token was revoked by auth-bootstrap, so this is the
+                  # only valid ongoing auth path. The save genuinely needs this
+                  # token (GET sys/storage/raft/snapshot below); the fetch
+                  # (secondary) does not, so the login lives ONLY on this branch
+                  # (#3629 — the fetch crashloop fix).
+                  SA_TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+                  BAO_TOKEN="$(curl -sS -k \
+                    -H 'Content-Type: application/json' \
+                    --data "{\"role\":\"${BAO_K8S_AUTH_ROLE}\",\"jwt\":\"${SA_TOKEN}\"}" \
+                    "${BAO_ADDR%/}/v1/auth/${BAO_K8S_AUTH_PATH}/login" \
+                    | sed -n 's/.*"client_token":"\([^"]*\)".*/\1/p')"
+                  if [ -z "${BAO_TOKEN}" ]; then
+                    log "FATAL: bao login returned no client_token — the ${BAO_K8S_AUTH_ROLE} role may not yet be bound by auth-bootstrap"
+                    exit 1
+                  fi
+                  log "authenticated to OpenBao via k8s auth role ${BAO_K8S_AUTH_ROLE}"
                   # ─── PRIMARY: snapshot save + ship to S3 ────────────────
                   # GET /v1/sys/storage/raft/snapshot is the HTTP form of
                   # `bao operator raft snapshot save` — a READ on the Raft

--- a/platform/openbao/chart/tests/snapshot-replication-toggle.sh
+++ b/platform/openbao/chart/tests/snapshot-replication-toggle.sh
@@ -87,9 +87,14 @@ if ! grep -qE "aws --endpoint-url .* s3 cp .* \"s3://" "$TMP/primary.yaml"; then
   echo "FAIL: primary CronJob missing the 'aws s3 cp' upload to the bucket." >&2
   exit 1
 fi
-# The K8s-auth login (same pattern as sso-configure / ESO).
-if ! grep -qE "/v1/auth/.*/login" "$TMP/primary.yaml"; then
-  echo "FAIL: primary CronJob missing the OpenBao K8s-auth login." >&2
+# The K8s-auth login (same pattern as sso-configure / ESO). #3629: assert the
+# SNAPSHOT-SAVE login specifically (its payload `"jwt":"${SA_TOKEN}"` with
+# uppercase SA_TOKEN — distinct from the lowercase sso-configure login) so the
+# test locks the per-role split: the save KEEPS the login (it reads BAO_TOKEN
+# for GET sys/storage/raft/snapshot), the fetch DROPS it (Case 3).
+if ! grep -qF '"jwt\":\"${SA_TOKEN}' "$TMP/primary.yaml" \
+   && ! grep -qF '"jwt":"${SA_TOKEN}' "$TMP/primary.yaml"; then
+  echo "FAIL (#3629): primary SAVE CronJob missing the OpenBao K8s-auth login (SA_TOKEN payload) — the save needs BAO_TOKEN for the raft snapshot." >&2
   exit 1
 fi
 # S3 creds sourced from the cluster-wide seaweedfs-s3-secret.
@@ -175,6 +180,18 @@ fi
 # Secondary must NOT emit the save CronJob.
 if grep -qE "^  name: openbao-snapshot-save$" "$TMP/secondary.yaml"; then
   echo "FAIL: secondary render unexpectedly contains the snapshot-save CronJob." >&2
+  exit 1
+fi
+# #3629: the secondary FETCH must NOT perform an OpenBao k8s-auth login — it
+# does pure S3 I/O and never reads BAO_TOKEN. The earlier unconditional login
+# crashlooped the fetch (`Could not resolve host openbao-openbao` →
+# `bao login returned no client_token`) on hw147 region-B while openbao-0 was
+# Running. The snapshot-save login payload is `"jwt":"${SA_TOKEN}"` (uppercase
+# SA_TOKEN, distinct from the lowercase sso-configure login); assert it is
+# absent from the secondary render.
+if grep -qF '"jwt\":\"${SA_TOKEN}' "$TMP/secondary.yaml" \
+   || grep -qF '"jwt":"${SA_TOKEN}' "$TMP/secondary.yaml"; then
+  echo "FAIL (#3629): secondary FETCH CronJob still performs an OpenBao login (snapshot-save SA_TOKEN payload present) — the fetch must do pure S3 I/O." >&2
   exit 1
 fi
 echo "  PASS"


### PR DESCRIPTION
## Problem (verified live on hw147 region-B)

The secondary (fetch) `openbao-snapshot-fetch` CronJob crashlooped every tick:

```
curl: (6) Could not resolve host: openbao-openbao.openbao.svc.cluster.local
FATAL: bao login returned no client_token — the openbao-snapshot role may not yet be bound by auth-bootstrap
```

…while `openbao-0` itself was **Running 1/1**. The openbao DR-snapshot floor (region-kill-relevant) was dead on the standby region.

## Root cause

`snapshot-replication.yaml`'s CronJob script ran an OpenBao k8s-auth login **unconditionally**, before the primary/secondary role branch. But the **secondary (fetch) path is PURE S3 I/O** (`s3api list-objects-v2` + `s3 cp` to the restore-staging PVC) and **never reads `BAO_TOKEN`**. So the fetch FATAL'd on an auth step it does not use — gated on its own region's OpenBao auth being reachable + the `openbao-snapshot` role being bound by auth-bootstrap, neither of which the fetch needs.

The S3 credential seeder + `seaweedfs-s3-secret` (the #3585/#3629 seeder) were confirmed present and correct — this was **not** a missing-secret defect.

## Fix

Move the `bao login` to the **PRIMARY/save branch only** (the save genuinely needs `BAO_TOKEN` for `GET sys/storage/raft/snapshot`). The secondary fetch now goes straight to S3 staging.

## Safety / tests

- `snapshotReplication` stays **default-OFF** (DoD-8 opt-in) → default + single-region render is byte-identical.
- `tests/snapshot-replication-toggle.sh`: Case 2 now asserts the **save KEEPS** the login (`"jwt":"${SA_TOKEN}"` payload); Case 3 asserts the **fetch DROPS** it.
- All embedded scripts pass `dash -n`. All 9 bp-openbao chart test gates green (incl. kyverno-harbor-proxy-images).
- Lockstep: `Chart.yaml` + `blueprint.yaml` + slot-08 pin `1.2.45 -> 1.2.46`.

**Chart-only** — safe to merge (no catalyst-api change).

Refs #3629

🤖 Generated with [Claude Code](https://claude.com/claude-code)