### PR TITLE
fix(catalyst-api): cross-region sync of shared-pg consumer HUB Secrets (grafana/powerdns-admin region-B DB host+password) [HOLD-merge]

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -335,6 +335,56 @@ var sharedPGReplicaAuthSecrets = func() []string {
 	return out
 }()
 
+// sharedPGConsumerHubSecrets — the per-consumer HUB CONNECTION Secret names
+// (bp-postgres role-secrets.yaml `reflect.secretName`, namespace shared-data)
+// that the cross-region CONSUMER apps read for their DB host + password
+// (#3629). Unlike the replica-auth TLS Secrets above, these carry CONSUMER
+// credentials, and they DIVERGE across regions: bp-postgres mints a fresh
+// random password per region during each region's pre-crossRegion-flip
+// SINGLETON phase (role-secrets.yaml is primary/singleton-side only) and
+// freezes it via `helm.sh/resource-policy: keep`. After the flip, region-B's
+// `<instance>-replica` follower streams region-A's catalog via pg_basebackup —
+// so the AUTHORITATIVE role password is region-A's — but region-B's consumer
+// namespaces still carry region-B's STALE, DIVERGENT hub Secret (its OWN random
+// password + the region-LOCAL `<instance>-rw` host that NXDOMAINs on the replica
+// cluster). Measured live on hw147 region-B: grafana + powerdns-admin
+// CrashLoopBackOff (`lookup shared-pg-b-rw…: no such host`), and even the host
+// aside the region-B password (`RXq1…`/`CmXM…`) did not match the region-A
+// catalog password (`E5WJ…`/`OB0h…`). The emberstack reflector copies a Secret
+// only WITHIN a cluster (never across the ClusterMesh), so the only fix is to
+// copy region-A's authoritative hub Secrets (correct password + the
+// topology-aware `<instance>-mesh-rw` host bp-postgres 0.2.2 renders on the
+// active-hot-standby primary) primary → replica into shared-data; region-B's
+// reflector then re-pushes the corrected Secret into each consumer namespace,
+// overwriting the divergent copy. Same names the slots 16a/16c/16d declare.
+//
+// Sourced from the slot `reflect.secretName` values — keep in lockstep with
+// clusters/_template/bootstrap-kit/16{a,c,d}-bp-postgres-shared*.yaml.
+var sharedPGConsumerHubSecrets = []string{
+	// instance A (shared-pg, slot 16a)
+	"harbor-database-secret",
+	"gitea-database-secret",
+	"keycloak-database-secret",
+	// instance B (shared-pg-b, slot 16c)
+	"grafana-database-env",
+	"pdns-database-secret",
+	"pda-shared-database-secret",
+	// instance C (shared-pg-c, slot 16d)
+	"sme-database-secret",
+	"newapi-database-secret",
+	"openova-flow-database-secret",
+}
+
+// sharedPGMeshRWHostMarker — the substring a hub Secret's `host` key carries
+// ONLY once bp-postgres has rendered the active-hot-standby topology-aware write
+// alias (`<instance>-mesh-rw`). The consumer-hub sync uses this as a readiness
+// gate: it propagates region-A's hub Secret to the replicas ONLY after region-A
+// has reconciled crossRegion=true (so its `host`/`uri` point at `-mesh-rw`), to
+// avoid ever pushing the region-LOCAL `-rw` host (which would NXDOMAIN on the
+// replica) during the brief window before region-A's own slot-16{a,c,d} upgrade
+// lands. Single-region / pre-flip hubs carry `-rw` and are correctly skipped.
+const sharedPGMeshRWHostMarker = "-mesh-rw."
+
 // fluxKustomizationGVR — kustomize.toolkit.fluxcd.io/v1 Kustomizations,
 // addressed via the dynamic client (no Flux Go types vendored here).
 var fluxKustomizationGVR = schema.GroupVersionResource{
@@ -1110,6 +1160,18 @@ func (h *Handler) enableCNPGPairAfterFullMesh(ctx context.Context, dep *Deployme
 				patched++
 			}
 		}
+		// #3629 (best-effort, never blocks): once the flip has landed, region-A
+		// reconciles crossRegion=true and its bp-postgres hubs gain the
+		// topology-aware `-mesh-rw` host. Copy those hubs (correct password +
+		// host) primary → replica so the cross-region consumers (grafana,
+		// powerdns-admin, …) stop reading the divergent region-local hub each
+		// region minted in its singleton phase. The readiness gate inside the
+		// call defers any hub whose host is not yet `-mesh-rw`, so a first pass
+		// (before region-A's slot upgrade lands) is a harmless no-op and the
+		// #3241/#3583 level-trigger re-run converges it. NEVER gates the flip.
+		if sharedPGOn {
+			h.syncSharedPGConsumerHubSecrets(ctx, dep, slots)
+		}
 	}
 	if patched == 0 {
 		return false
@@ -1310,6 +1372,91 @@ func (h *Handler) syncSharedPGReplicaAuthSecrets(ctx context.Context, dep *Deplo
 		fmt.Sprintf("ClusterMesh: synced shared-pg replica-auth Secrets (%s) primary → %d replica region(s) for WAL-stream auth",
 			strings.Join(sharedPGReplicaAuthSecrets, ", "), len(slots)-1))
 	return true
+}
+
+// syncSharedPGConsumerHubSecrets copies the primary cluster's per-consumer HUB
+// CONNECTION Secrets (sharedPGConsumerHubSecrets, namespace shared-data) onto
+// every replica region's cluster so the cross-region consumer apps (grafana,
+// powerdns-admin, …) read the AUTHORITATIVE region-A password + the
+// topology-aware `<instance>-mesh-rw` write host instead of the divergent,
+// region-LOCAL hub Secret each region minted during its own singleton phase
+// (#3629 — see the sharedPGConsumerHubSecrets doc for the full divergence
+// analysis + the hw147 region-B evidence). Once copied into the replica's
+// shared-data, the replica's own emberstack reflector re-pushes the corrected
+// Secret into each consumer namespace (the source carries the reflection-auto
+// annotations), overwriting the stale copy.
+//
+// BEST-EFFORT — UNLIKE the replica-auth sync this NEVER blocks/refuses the
+// cnpg-pair flip: the hub Secrets are not needed for the WAL stream, only for
+// the consumers, so a missing/not-yet-`-mesh-rw` source or a per-replica copy
+// failure is logged and SKIPPED, and the #3241/#3583 level-trigger re-run
+// converges it on a later pass. It returns nothing (the caller ignores the
+// outcome) precisely so it can never wedge convergence.
+//
+// READINESS GATE: a hub Secret is propagated ONLY once its `host` key carries
+// the `-mesh-rw` marker — i.e. region-A has reconciled crossRegion=true and its
+// bp-postgres slot upgrade has rendered the topology-aware host. Before that the
+// source still carries the region-LOCAL `<instance>-rw` (which NXDOMAINs on the
+// replica), so pushing it would make things WORSE; skipping waits for the next
+// pass. Single-region (len(slots)<2) is a no-op.
+func (h *Handler) syncSharedPGConsumerHubSecrets(ctx context.Context, dep *Deployment, slots []regionSlot) {
+	if len(slots) < 2 {
+		return // single-region — no replica to sync to
+	}
+	primary := &slots[0]
+	if primary.clientset == nil {
+		h.log.Warn("clustermesh: shared-pg consumer-hub sync: primary clientset nil — skipping (best-effort, re-run converges)",
+			"id", dep.ID)
+		return
+	}
+
+	synced := make([]string, 0, len(sharedPGConsumerHubSecrets))
+	for _, name := range sharedPGConsumerHubSecrets {
+		getCtx, cancel := context.WithTimeout(ctx, clusterMeshCallTimeout)
+		src, err := primary.clientset.CoreV1().Secrets(sharedPGNamespace).Get(getCtx, name, metav1.GetOptions{})
+		cancel()
+		if err != nil {
+			// A consumer that isn't wired on this Sovereign (its slot binding
+			// is absent) simply has no hub Secret — skip quietly. Best-effort.
+			h.log.Info("clustermesh: shared-pg consumer-hub sync: source hub Secret not present on primary — skipping (consumer may be unconfigured; best-effort)",
+				"id", dep.ID, "namespace", sharedPGNamespace, "secret", name)
+			continue
+		}
+		// READINESS GATE: only propagate once region-A has rendered the
+		// `-mesh-rw` write host. A `-rw`-only host means region-A hasn't
+		// reconciled crossRegion yet — pushing it would NXDOMAIN on the
+		// replica, so wait for the next level-trigger pass.
+		if host := string(src.Data["host"]); !strings.Contains(host, sharedPGMeshRWHostMarker) {
+			h.log.Info("clustermesh: shared-pg consumer-hub sync: source host not yet topology-aware (-mesh-rw) — deferring (region-A crossRegion upgrade still landing; best-effort, re-run converges)",
+				"id", dep.ID, "secret", name, "host", host)
+			continue
+		}
+		copied := true
+		for i := 1; i < len(slots); i++ {
+			replica := &slots[i]
+			if replica.clientset == nil {
+				copied = false
+				continue
+			}
+			if err := h.copySecretAcrossClusters(ctx, src, replica.clientset, sharedPGNamespace); err != nil {
+				h.log.Warn("clustermesh: shared-pg consumer-hub sync: copy to replica failed — skipping this Secret/region (best-effort, re-run converges)",
+					"id", dep.ID, "region", replica.key, "namespace", sharedPGNamespace, "secret", name, "err", err)
+				copied = false
+				continue
+			}
+		}
+		if copied {
+			synced = append(synced, name)
+		}
+	}
+
+	if len(synced) > 0 {
+		h.log.Info("clustermesh: shared-pg consumer-hub Secrets synced primary → replica region(s) (#3629 cross-region consumer DB host/password)",
+			"id", dep.ID, "namespace", sharedPGNamespace, "secrets", synced, "replicaRegions", len(slots)-1)
+		h.emitClusterMeshProgress(dep, "info",
+			fmt.Sprintf("ClusterMesh: synced %d shared-pg consumer-hub Secret(s) (%s) primary → %d replica region(s) — cross-region consumer DB host/password (#3629)",
+				len(synced), strings.Join(synced, ", "), len(slots)-1))
+	}
 }
 
 // copySecretAcrossClusters create-or-updates a copy of src into the dst

--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh_test.go
@@ -2432,3 +2432,143 @@ func TestRunClusterMeshSteadyStateHeal_StopsImmediatelyWhenNotReady(t *testing.T
 		t.Fatalf("steady-state heal did not return immediately when status != ready at entry")
 	}
 }
+
+// ── #3629: cross-region consumer HUB Secret sync ────────────────────────
+
+// getSharedDataSecret reads a Secret from the shared-data namespace of a fake
+// clientset, returning (nil, false) when absent.
+func getSharedDataSecret(t *testing.T, cs kubernetes.Interface, name string) (*corev1.Secret, bool) {
+	t.Helper()
+	s, err := cs.CoreV1().Secrets(sharedPGNamespace).Get(context.Background(), name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, false
+	}
+	if err != nil {
+		t.Fatalf("get Secret %s/%s: %v", sharedPGNamespace, name, err)
+	}
+	return s, true
+}
+
+// seedHubSecret creates a consumer hub Secret in shared-data on the given
+// clientset with the supplied host + password (mirrors what bp-postgres
+// role-secrets.yaml renders). Carries the reflector-auto annotations so the
+// copy is byte-identical to production.
+func seedHubSecret(t *testing.T, cs kubernetes.Interface, name, host, password string) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := cs.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: sharedPGNamespace},
+	}, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create shared-data namespace: %v", err)
+	}
+	if _, err := cs.CoreV1().Secrets(sharedPGNamespace).Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: sharedPGNamespace,
+			Annotations: map[string]string{
+				"reflector.v1.k8s.emberstack.com/reflection-allowed":      "true",
+				"reflector.v1.k8s.emberstack.com/reflection-auto-enabled": "true",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"host":     []byte(host),
+			"password": []byte(password),
+			"uri":      []byte("postgresql://owner:" + password + "@" + host + ":5432/db"),
+		},
+	}, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create hub Secret %s: %v", name, err)
+	}
+}
+
+// TestSyncSharedPGConsumerHubSecrets covers the #3629 best-effort cross-region
+// consumer-hub Secret sync: (1) a `-mesh-rw` source propagates to the replica
+// (correct host + password, overwriting the replica's divergent copy); (2) a
+// region-local `-rw` source is DEFERRED (not pushed — it would NXDOMAIN on the
+// replica); (3) a missing source is skipped (consumer unconfigured); (4)
+// single-region is a no-op.
+func TestSyncSharedPGConsumerHubSecrets(t *testing.T) {
+	h := &Handler{log: silentLogger()}
+	dep := &Deployment{ID: "dep-3629"}
+
+	t.Run("mesh-rw-source-propagates-to-replica", func(t *testing.T) {
+		primaryCS := kfake.NewSimpleClientset()
+		replicaCS := kfake.NewSimpleClientset()
+		// Primary hub carries the topology-aware -mesh-rw host + the
+		// AUTHORITATIVE region-A password.
+		seedHubSecret(t, primaryCS, "grafana-database-env",
+			"shared-pg-b-mesh-rw.shared-data.svc.cluster.local", "E5WJ-region-A-pw")
+		// Replica starts with the DIVERGENT singleton-phase copy (region-local
+		// host + its OWN random password) — the exact hw147 region-B defect.
+		seedHubSecret(t, replicaCS, "grafana-database-env",
+			"shared-pg-b-rw.shared-data.svc.cluster.local", "RXq1-region-B-pw")
+
+		slots := []regionSlot{
+			{key: "", clientset: primaryCS},
+			{key: "secondary", clientset: replicaCS},
+		}
+		h.syncSharedPGConsumerHubSecrets(context.Background(), dep, slots)
+
+		got, ok := getSharedDataSecret(t, replicaCS, "grafana-database-env")
+		if !ok {
+			t.Fatalf("replica hub Secret missing after sync")
+		}
+		if h := string(got.Data["host"]); h != "shared-pg-b-mesh-rw.shared-data.svc.cluster.local" {
+			t.Errorf("replica host = %q, want the -mesh-rw host (region-local -rw would NXDOMAIN)", h)
+		}
+		if p := string(got.Data["password"]); p != "E5WJ-region-A-pw" {
+			t.Errorf("replica password = %q, want the authoritative region-A password (the replica's catalog has region-A's role pw)", p)
+		}
+		// The reflector-auto annotations carry over so the replica's reflector
+		// re-pushes the corrected Secret into the consumer namespace.
+		if got.Annotations["reflector.v1.k8s.emberstack.com/reflection-auto-enabled"] != "true" {
+			t.Errorf("replica hub Secret lost the reflection-auto annotation — consumer ns would not get the corrected copy")
+		}
+	})
+
+	t.Run("region-local-rw-source-is-deferred", func(t *testing.T) {
+		primaryCS := kfake.NewSimpleClientset()
+		replicaCS := kfake.NewSimpleClientset()
+		// Primary hub still carries the SINGLETON -rw host (region-A has not
+		// reconciled crossRegion=true yet) — must NOT be pushed.
+		seedHubSecret(t, primaryCS, "grafana-database-env",
+			"shared-pg-b-rw.shared-data.svc.cluster.local", "pw-A")
+		// Replica has its own divergent copy; it must be left UNTOUCHED.
+		seedHubSecret(t, replicaCS, "grafana-database-env",
+			"shared-pg-b-rw.shared-data.svc.cluster.local", "pw-B-stale")
+
+		slots := []regionSlot{
+			{key: "", clientset: primaryCS},
+			{key: "secondary", clientset: replicaCS},
+		}
+		h.syncSharedPGConsumerHubSecrets(context.Background(), dep, slots)
+
+		got, _ := getSharedDataSecret(t, replicaCS, "grafana-database-env")
+		if p := string(got.Data["password"]); p != "pw-B-stale" {
+			t.Errorf("replica password = %q, want it UNCHANGED (pw-B-stale) — a -rw source must be deferred, not pushed", p)
+		}
+	})
+
+	t.Run("missing-source-is-skipped", func(t *testing.T) {
+		primaryCS := kfake.NewSimpleClientset() // no hub Secrets at all
+		replicaCS := kfake.NewSimpleClientset()
+		slots := []regionSlot{
+			{key: "", clientset: primaryCS},
+			{key: "secondary", clientset: replicaCS},
+		}
+		// Must not panic / error — best-effort skip of every unconfigured
+		// consumer.
+		h.syncSharedPGConsumerHubSecrets(context.Background(), dep, slots)
+		if _, ok := getSharedDataSecret(t, replicaCS, "grafana-database-env"); ok {
+			t.Errorf("replica unexpectedly gained a hub Secret from an empty primary")
+		}
+	})
+
+	t.Run("single-region-is-noop", func(t *testing.T) {
+		primaryCS := kfake.NewSimpleClientset()
+		seedHubSecret(t, primaryCS, "grafana-database-env",
+			"shared-pg-b-rw.shared-data.svc.cluster.local", "pw")
+		// len(slots) == 1 → no replica → must return immediately, no panic.
+		h.syncSharedPGConsumerHubSecrets(context.Background(), dep, []regionSlot{{key: "", clientset: primaryCS}})
+	})
+}


### PR DESCRIPTION
## 🛑 HOLD-merge — catalyst-api change

A cutover is currently running on hw147 and the mothership prov path is sensitive; merging catalyst-api/ui PRs triggers a deploy-bot roll that can abandon an in-flight prov. Hold until the operator clears the window.

## Problem (verified live on hw147, BOTH regions)

Region-B consumers of the shared-pg engines crashloop:

| App (region-B) | symptom |
|---|---|
| grafana | `dial tcp: lookup shared-pg-b-rw.shared-data…: no such host` |
| powerdns-admin | `could not translate host name "shared-pg-b-rw.shared-data…": Name does not resolve` |

`#3631` (bp-postgres 0.2.2) already created the `<instance>-mesh-rw` global ClusterMesh Services (they exist in region-B) and fixed **keycloak**, but grafana + powerdns-admin still failed.

## Root cause

1. **bp-postgres `role-secrets.yaml` is primary/singleton-side only.** Each region renders it **independently** during its pre-crossRegion-flip **singleton phase**, minting a **different** random password per region (frozen via `helm.sh/resource-policy: keep`):

   | consumer | region-A pw | region-B pw |
   |---|---|---|
   | grafana | `E5WJ…` | `RXq1…` |
   | pda | `OB0h…` | `CmXM…` |

2. After the flip, region-B's `<instance>-replica` follower streams **region-A's** catalog via `pg_basebackup` → the **authoritative** role password is region-A's. But region-B's consumer namespaces still carry region-B's **stale, divergent** hub Secret (its own password + the region-local `<instance>-rw` host, which has no Service on the replica cluster → NXDOMAIN).

3. The emberstack **reflector copies Secrets only within a cluster, never across the ClusterMesh**, so region-A's correct hub never reaches region-B.

**Why keycloak worked but grafana/pda didn't:** keycloak/gitea/harbor read their DB host from a **cloud-init scalar seam** (`SOVEREIGN_KEYCLOAK_PG_HOST`, overlay-flippable to `-mesh-rw`). grafana reads `GF_DATABASE_HOST` and pda reads the full `SQLALCHEMY_DATABASE_URI` **straight from the reflected hub Secret** — host **and** password baked in — so neither can be fixed by a host scalar alone, and the divergent password would fail auth even if the host were corrected.

## Fix

Extend the existing #3254/#3571 cross-cluster sync — which already copies the `<instance>-replication`/`-ca` TLS Secrets primary→replica — to **also copy the 9 consumer HUB connection Secrets** (the slot 16a/16c/16d `reflect.secretName` set: `grafana-database-env`, `pda-shared-database-secret`, `keycloak-database-secret`, `gitea-database-secret`, `harbor-database-secret`, `pdns-database-secret`, `sme-database-secret`, `newapi-database-secret`, `openova-flow-database-secret`) into `shared-data`. Region-B's own reflector then re-pushes the corrected Secret (authoritative region-A password + the topology-aware `<instance>-mesh-rw` host) into each consumer namespace, overwriting the divergent copy.

- **BEST-EFFORT — never gates the cnpg-pair flip** (hub Secrets are consumer creds, not WAL-stream auth). A readiness gate propagates a hub **only once its `host` carries `-mesh-rw`** (region-A reconciled crossRegion=true), so a `-rw` host is never pushed (it would NXDOMAIN on the replica). A missing/failed source is skipped.
- Rides the **#3583 steady-state heal loop** (5-min re-run while `status=ready`), so it converges a few passes after the flip.
- **Single-region is a no-op; region-A render unchanged.**

## Tests

- New `TestSyncSharedPGConsumerHubSecrets`: propagate-on-`-mesh-rw` / defer-on-`-rw` / skip-missing-source / single-region-no-op.
- Full handler suite + clustermesh suite green with `-race`.

## Companion

Paired with the chart-only #3636 (bp-openbao secondary-fetch login fix) for the openbao DR-snapshot leg of #3629.

Refs #3629

🤖 Generated with [Claude Code](https://claude.com/claude-code)