### PR TITLE
fix(catalyst): cutover step-07 re-run loop — derive runtime-config console URLs from sovereignFQDN (1.4.647)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1028,7 +1028,8 @@ spec:
             # 1.4.623 — #3373 Batch A: qa-fixtures CNPG barman backup endpoint default → rtz-vCluster synced seaweedfs-s3 name (seaweedfs moved into rtz; 1.4.622 was a content-free deploy-bot sweep).
             # 1.4.626 — #3492: Continuum CRD gains spec.switchover.{mechanism,raftTransition} (bp-openbao raft-transition DR contract); additive, slot-13 crds:CreateReplace propagates the schema. Render byte-unchanged.
             # 1.4.645 — #3626: catalog-seed repoints bp-openbao launch ssoInitPath → /sso/landing (was /ui/vault/auth?with=oidc) so the console "Open" button lands signed-in instead of the popup-only Vault OIDC callback's window.opener=null error. Lockstep with platform/openbao/blueprint.yaml; template-only, default render byte-unchanged.
-      version: 1.4.647
+            # 1.4.648 — #3638 (Refs #3379): catalyst-runtime-config ConfigMap DERIVES sovereign-console-url + sovereign-api-public-url from global.sovereignFQDN on a Sovereign (was always the mothership runtime.sovereignConsoleURL default, never overridden here) — so Flux render == bp-self-sovereign-cutover step-07 Phase-3a's patch → step-07 is idempotent (no revert → no FATAL re-run → no catalyst-api re-roll → cutover engine reaches step-08). Catalyst-Zero (empty FQDN) render byte-unchanged.
+      version: 1.4.648
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2712,7 +2712,25 @@ name: bp-catalyst-platform
 # (qaFixtures.cnpgBackupEndpointURL + cnpg-clusters-qa.yaml) to the
 # syncer-mangled host Service name. qa-fixtures only; Catalyst-Zero render
 # byte-unchanged. (1.4.622 was a content-free deploy-bot image sweep.)
-version: 1.4.647
+version: 1.4.648
+# 1.4.648 — #3638 (2026-06-16, Refs #3379; rebased over main's 1.4.647 deploy-bot bump) — fix the cutover step-07 re-run
+# loop at its source. templates/configmap-catalyst-runtime-config.yaml now
+# DERIVES sovereign-console-url + sovereign-api-public-url from
+# global.sovereignFQDN when set (every Sovereign), keeping the explicit
+# runtime.sovereignConsoleURL / sovereignAPIPublicURL mothership defaults
+# ONLY on Catalyst-Zero (empty FQDN). Before this, the chart always
+# re-rendered the mothership default (runtime.sovereignConsoleURL =
+# https://console.openova.io — never overridden in slot-13), so Flux
+# reverted bp-self-sovereign-cutover step-07 Phase-3a's live ConfigMap
+# patch back to the mothership URL every reconcile → step-07 Phase-3c
+# read-back assert FATAL'd ("still mothership/empty") + re-rolled
+# catalyst-api → the in-memory cutover engine restarted from step-01 →
+# infinite loop, step-08 (600s deny-egress hold) never ran. Now the chart
+# render == step-07's pivot target on a Sovereign → nothing to revert →
+# step-07 is idempotent → engine proceeds to step-08 + cutoverComplete.
+# Same `{{ if .Values.global.sovereignFQDN }}` idiom as sovereign-fqdn-
+# configmap.yaml. Catalyst-Zero (contabo-mkt) render byte-unchanged
+# (empty FQDN → else-branch keeps the runtime.* mothership defaults).
 # 1.4.645 — #3626 (2026-06-16) — catalog-seed: repoint bp-openbao's launch
 # endpoint ssoInitPath at the on-origin /sso/landing page (was
 # /ui/vault/auth?with=oidc). The console "Open" button window.open()s

--- a/products/catalyst/chart/templates/configmap-catalyst-runtime-config.yaml
+++ b/products/catalyst/chart/templates/configmap-catalyst-runtime-config.yaml
@@ -41,10 +41,53 @@ data:
   # catalyst-api as CORS_ORIGIN + CATALYST_SOVEREIGN_URL via
   # configMapKeyRef. Override via runtime.sovereignConsoleURL in
   # per-Sovereign overlay or bp-self-sovereign-cutover Step 7.
+  #
+  # #3638 (2026-06-16): DERIVE from global.sovereignFQDN on a Sovereign.
+  # Root cause of the cutover step-07 re-run loop: step-07 Phase-3a
+  # (platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-
+  # patch-job.yaml) `kubectl patch`es this live ConfigMap's two keys to
+  # https://console.<fqdn>, then Phase-3c read-back-asserts no openova.io
+  # residue. But the chart USED to ALWAYS render the mothership default
+  # (runtime.sovereignConsoleURL = https://console.openova.io) — which is
+  # NEVER overridden in the slot-13 bootstrap-kit overlay (verified: no
+  # `runtime:` block in 13-bp-catalyst-platform.yaml, no overlay anywhere
+  # sets runtime.sovereignConsoleURL). So every Flux reconcile reverted
+  # step-07's live patch back to the mothership URL → Phase-3c FATAL'd on
+  # the next re-run ("still mothership/empty") + the env-patch re-rolled
+  # catalyst-api → the in-memory cutover engine restarted from step-01 →
+  # infinite loop; step-08 (the 600s deny-egress hold) never ran (#3638).
+  #
+  # global.sovereignFQDN IS set on every Sovereign (slot-13
+  # 13-bp-catalyst-platform.yaml `sovereignFQDN: ${SOVEREIGN_FQDN}`) and
+  # EMPTY on the mothership / Catalyst-Zero (contabo-mkt sets neither
+  # global.sovereignFQDN nor any runtime.* override). This is the SAME
+  # `if .Values.global.sovereignFQDN` Sovereign-vs-mothership idiom
+  # already used by sovereign-fqdn-configmap.yaml + api-deployment.yaml
+  # (gitea base-path / openbao addr). When the FQDN is set the chart now
+  # renders the SAME https://console.<fqdn> that step-07 pivots to → Flux
+  # render == step-07 patch → nothing to revert → step-07 Phase-3c passes
+  # on every reconcile → step-07 is idempotent (no re-patch, no re-roll,
+  # no engine restart) → the engine proceeds to step-08. The mothership
+  # (empty FQDN) keeps the explicit runtime.sovereignConsoleURL default
+  # unchanged — the branch only re-derives on a Sovereign.
+  {{- if .Values.global.sovereignFQDN }}
+  sovereign-console-url: {{ printf "https://console.%s" .Values.global.sovereignFQDN | quote }}
+  {{- else }}
   sovereign-console-url: {{ .Values.runtime.sovereignConsoleURL | quote }}
+  {{- end }}
   # #2940 (2026-06-03): public origin a provisioning Sovereign's
   # cloud-init PUTs its kubeconfig back to (CATALYST_API_PUBLIC_URL via
   # configMapKeyRef in api-deployment.yaml). Mothership URL is ONLY the
   # back-compat default; bp-self-sovereign-cutover Step 7 Phase 3
   # pivots it to the Sovereign's own console URL post-handover.
+  #
+  # #3638 (2026-06-16): DERIVE from global.sovereignFQDN on a Sovereign
+  # (same rationale + branch as sovereign-console-url above — this is the
+  # second key step-07 Phase-3a patches and Phase-3c asserts). The
+  # `/sovereign` suffix matches step-07's pivot target
+  # (`${CONSOLE_PUBLIC_URL}/sovereign`) and the chart default's suffix.
+  {{- if .Values.global.sovereignFQDN }}
+  sovereign-api-public-url: {{ printf "https://console.%s/sovereign" .Values.global.sovereignFQDN | quote }}
+  {{- else }}
   sovereign-api-public-url: {{ .Values.runtime.sovereignAPIPublicURL | quote }}
+  {{- end }}


### PR DESCRIPTION
## Problem (Refs #3638 #3379)

With #3630 merged, hw147's cutover reached the furthest point ever (steps 01-07 Complete, PAST step-06 where hw146 wedged) but then **loops at step-07** and never reaches step-08 (the 600s deny-egress hold) or `cutoverComplete`.

**Root cause (verified live on hw147 + in code):** the `bp-self-sovereign-cutover` **step-07 Phase-3a** (`platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml`) `kubectl patch`es the live `catalyst-runtime-config` ConfigMap keys `sovereign-console-url` + `sovereign-api-public-url` to `https://console.<fqdn>`, then **Phase-3c read-back-asserts** no `openova.io` residue (`exit 1` on failure).

But the `bp-catalyst-platform` chart **always re-rendered those keys from the mothership default** — `runtime.sovereignConsoleURL = https://console.openova.io` — which is **never overridden in the slot-13 bootstrap-kit overlay** (verified: no `runtime:` block in `13-bp-catalyst-platform.yaml`; no overlay anywhere sets `runtime.sovereignConsoleURL`). So **every Flux reconcile reverted step-07's live patch back to the mothership URL** → Phase-3c FATAL'd `runtime-config sovereign-console-url='https://console.openova.io' still mothership/empty` on the next re-run → the env-patch re-rolled catalyst-api → the cutover engine re-entered the failed step → **infinite loop**.

## Fix (chart-only — `bp-catalyst-platform`)

`templates/configmap-catalyst-runtime-config.yaml` now **DERIVES** both keys from `global.sovereignFQDN`:

```yaml
{{- if .Values.global.sovereignFQDN }}
sovereign-console-url: {{ printf "https://console.%s" .Values.global.sovereignFQDN | quote }}
{{- else }}
sovereign-console-url: {{ .Values.runtime.sovereignConsoleURL | quote }}
{{- end }}
```

- **Every Sovereign sets `global.sovereignFQDN`** via slot-13 `sovereignFQDN: ${SOVEREIGN_FQDN}` → the chart now renders the **same `https://console.<fqdn>` that step-07 pivots to** → Flux has nothing to revert → step-07 Phase-3c passes on every reconcile → **step-07 is idempotent** (no re-patch, no re-roll) → the engine advances to step-08.
- **Catalyst-Zero / mothership (empty FQDN)** keeps the explicit `runtime.sovereignConsoleURL` mothership default — **byte-unchanged**.
- Same `if .Values.global.sovereignFQDN` Sovereign-vs-mothership idiom already used by `sovereign-fqdn-configmap.yaml` + `api-deployment.yaml`.

## Why fix A alone is sufficient (no catalyst-api change)

The brief flagged a possible secondary defect B ("engine progress is in-memory → restart re-runs from step-01"). **This is not the case** — the cutover engine already:
- **persists** step progress to the durable `self-sovereign-cutover-status` ConfigMap (`cutover.go` `patchCutoverStatus`), and
- **resumes** correctly on a Pod restart via `ResumeInterruptedCutover` (cutover.go:1513) + the skip-`success`-only loop (cutover.go:1173) + the terminal-Job idempotency seam (cutover.go:1242, advances completed steps **without re-running** their workloads).

The loop was purely fix A: step-07 never reached `result=success` because Phase-3c FATAL'd every time on the reverted ConfigMap. Once the chart render matches the pivot, step-07 → `success` and the engine proceeds. The fresh job ages observed on hw147 are step-07's own correct re-runs of the only failed step (steps 01-06 are re-confirmed, not re-executed).

The issuer envs (`CATALYST_PIN_ISSUER` / `CATALYST_HANDOVER_JWT_ISSUER`) are **not chart-rendered**, so Helm 3-way merge already preserved step-07 Phase-3b's `kubectl set env` values (the brief's log confirmed `CATALYST_HANDOVER_JWT_ISSUER` succeeded on retry). Only the explicitly-rendered ConfigMap reverted — which is what this PR fixes.

## Verification

- `helm template` (Sovereign, `global.sovereignFQDN=hw147.omani.works`): `sovereign-console-url: "https://console.hw147.omani.works"` + `sovereign-api-public-url: "https://console.hw147.omani.works/sovereign"` — **identical to step-07's pivot target**.
- `helm template` (mothership, no FQDN): `https://console.openova.io` + `https://console.openova.io/sovereign` — unchanged.
- Full-chart mothership render **byte-identical to base** (excluding per-render random secrets in unrelated Secret templates).
- `helm lint` clean (0 failures).

## Lockstep

- `products/catalyst/chart/Chart.yaml` `version: 1.4.646 → 1.4.647`
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` pin `1.4.646 → 1.4.647`

The 11-step → `cutoverComplete` + 600s deny-egress walk is the operator's on the next fresh prov.

🤖 Generated with [Claude Code](https://claude.com/claude-code)