### PR TITLE
fix(bp-self-sovereign-cutover): step-09 gitea-token-mint bounds+retries BasicAuth mint (#3584 hang) (0.1.72)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -545,7 +545,7 @@ spec:
       # so cutoverComplete never flipped. Fixed with POSIX `grep -vxF -f` on the
       # writable /work emptyDir. Found auditing the never-run steps 08-11 to
       # pre-empt hw147's cutover wedge. Chart-only.
-      version: 0.1.71
+      version: 0.1.72
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.71
+  version: 0.1.72
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,5 +1,19 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
+# 0.1.72 (#3643 Refs #3584 #3379, step-09 gitea-token-mint BasicAuth resilience
+# 2026-06-16): step-09 (gitea-token-mint) is the FIRST never-run step after the
+# #3640 step-08 fix lets the engine reach it. It mints the provisioning token via
+# POST /api/v1/users/gitea_admin/tokens. Gitea MANDATES BasicAuth for token
+# creation (a token cannot mint a token), so the #3584 PAT remedy can't apply —
+# but Gitea's apiAuth consults the openova-sso OAuth2 source on BasicAuth password
+# validation, which BLOCKS ~130s then 401s while Keycloak is still re-converging
+# in the cutover window (step-07 just rolled catalyst-api + pivoted the issuer).
+# The bare `curl -fsS -u` mint (no --max-time, no retry, FATAL on fail) would
+# wedge step-09. FIX (template 09-gitea-token-mint-job.yaml): wrap the mint in a
+# 6-attempt retry loop with --max-time 40 (under the ~130s hang) + 15s backoff
+# (~5.5min, within the 600s giteaTokenMintSeconds deadline) so it survives the
+# transient slowness until the OAuth2 lookup is fast. Idempotent existing-token
+# probe + validation unchanged. No step-count / RBAC / deadline change.
 # 0.1.71 (#3640 Refs #3379, hw148 step-08 egress-block CCNP cluster-wide
 # default-deny 2026-06-16): the cutover reached step-08 (egress-block-test) for
 # the FIRST time on hw148 (27b443cca00a0fab) — furthest in the #3379 saga (hw146
@@ -807,7 +821,7 @@ name: bp-self-sovereign-cutover
 # FATAL-on-failure contract is PRESERVED (Pillar 5 requires ALL openova-io
 # images local for the deny-egress hold) — the step only FATALs once BOTH retry
 # layers are exhausted. No step-count / RBAC / timeout change.
-version: 0.1.71
+version: 0.1.72
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/09-gitea-token-mint-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/09-gitea-token-mint-job.yaml
@@ -208,17 +208,35 @@ data:
             mint_body=$(printf '{"name":"%s","scopes":%s}' "${TOKEN_NAME}" "${scope_json_array}")
             echo "[gitea-token-mint] minting token (scopes=${TOKEN_SCOPES})"
 
-            mint_response=$(curl -fsS -u "${GITEA_USERNAME}:${GITEA_PASSWORD}" \
-              -X POST \
-              -H "Content-Type: application/json" \
-              -H "Accept: application/json" \
-              -d "${mint_body}" \
-              "${api_url}/users/${GITEA_USERNAME}/tokens" 2>&1) || {
-              echo "[gitea-token-mint] FATAL: mint POST failed" >&2
+            # #3643 (Refs #3584): Gitea MANDATES BasicAuth for token creation (a
+            # token cannot mint a token — see the header note), so the #3584 PAT
+            # remedy cannot apply here. But Gitea's apiAuth consults the
+            # openova-sso OAuth2 source when validating a BasicAuth PASSWORD, which
+            # BLOCKS ~130s then 401s while Keycloak is still re-converging in the
+            # cutover window (step-07 just rolled catalyst-api + pivoted the
+            # issuer). Bound each attempt (--max-time 40, under the ~130s hang) and
+            # retry with backoff so the mint survives the transient slowness until
+            # the OAuth2 lookup is fast — ~6 attempts x (40s + 15s) ~= 5.5min.
+            mint_response=""; mint_ok=""
+            for mint_attempt in 1 2 3 4 5 6; do
+              if mint_response=$(curl -fsS --max-time 40 -u "${GITEA_USERNAME}:${GITEA_PASSWORD}" \
+                -X POST \
+                -H "Content-Type: application/json" \
+                -H "Accept: application/json" \
+                -d "${mint_body}" \
+                "${api_url}/users/${GITEA_USERNAME}/tokens" 2>&1); then
+                mint_ok=yes
+                break
+              fi
+              echo "[gitea-token-mint] mint attempt ${mint_attempt}/6 failed (Gitea BasicAuth OAuth2-lookup slow/401 in the cutover window — #3584); retrying in 15s"
+              sleep 15
+            done
+            if [ -z "${mint_ok}" ]; then
+              echo "[gitea-token-mint] FATAL: mint POST failed after 6 attempts (~5.5min)" >&2
               # Redact credential before surfacing the body.
               printf '%s\n' "${mint_response}" | sed -E "s,${GITEA_PASSWORD}+,REDACTED,g" >&2
               exit 1
-            }
+            fi
 
             # Extract the sha1 field WITHOUT printing it. Use grep
             # because alpine/k8s has no jq guaranteed.


### PR DESCRIPTION
## Summary
step-09 gitea-token-mint (#3643): the mandatory-BasicAuth token mint had no timeout/retry — it would wedge the cutover at step-09 on the #3584 Gitea-OAuth2 hang.

## Root cause
step-09 is the FIRST never-run step the #3640 step-08 fix lets the engine reach. Gitea **requires BasicAuth for token creation** (a token can't mint a token), so the #3584 PAT remedy can't apply — and #3584 proved Gitea BasicAuth **hangs ~130s→401** while Keycloak re-converges post-step-07. The bare `curl -fsS -u` (no `--max-time`, no retry, FATAL) wedges step-09.

## Fix
6-attempt retry loop, `--max-time 40` + 15s backoff (~5.5min, within the 600s `giteaTokenMintSeconds` deadline). Idempotent probe + validation unchanged. No step-count/RBAC/deadline change.

Refs #3643 #3584 #3379. Validates when a fresh prov drives the cutover past step-08 to step-09.