### PR TITLE
docs(uat): add newapi SSO #3563 zero-click re-login row to §6 walkthrough (6/6 apps)

### DIFF
--- a/docs/ledger/uat-walkthrough/hw147-2026-06-16.md
+++ b/docs/ledger/uat-walkthrough/hw147-2026-06-16.md
@@ -192,7 +192,7 @@ tab appears on each **⛓ shareable** instance's app-detail page and lists the c
 
 ---
 
-## Section 6 — North Star #3: zero-login SSO (URL → signed in as admin), 5/5 apps
+## Section 6 — North Star #3: zero-login SSO (URL → signed in as admin), 6/6 apps
 
 **North Star #3 (founder, verbatim): *"NO login UI anywhere — URL → signed in as emrah.baysal as
 ADMIN; proof = surfing admin panels."*** In a **fresh tab**, a bare app URL or the catalog **Open**
@@ -221,9 +221,10 @@ login screen or a 4xx/5xx is a **fail**. hw146 passed **4/5 (Gitea/Grafana/Harbo
 | 6.5 | `https://console.<fqdn>/catalog` | On the **Keycloak** card, click the **Open** chip | A new tab lands on **`auth.<fqdn>/admin/sovereign/console/`** — the Keycloak **admin console** with the realm nav, no login form | ☐ |
 | 6.6 | `https://console.<fqdn>/catalog` | On the **OpenBao** card, click the **Open** chip **(#3628 re-check — the one that failed on hw146)** | A new tab routes through **`bao.<fqdn>/sso/landing`** → silent OIDC → lands on the **Vault UI signed-in (Secrets Engines list, `/ui/vault/secrets`)**. You must **NOT** see the *"Sign in to OpenBao"* token form **nor** a `Cannot read properties of null (reading 'postMessage')` console error | ☐ |
 | 6.7 | `https://bao.<fqdn>` | (negative cross-check) Type the **bare** host in a fresh tab, press Enter | The bare path **302s to `/sso/landing`** then lands on **`/ui/vault/secrets`** signed-in — the SAME flow as the Open button, proving both front doors land authenticated | ☐ |
+| 6.8 | `https://console.<fqdn>/catalog` → newapi **Open** chip, then `https://newapi.<fqdn>/` a **2nd** time | Click newapi's **Open** chip (lands signed-in, no login form); then type the **bare** `newapi.<fqdn>` host again in a fresh tab and press Enter | The 2nd bare-URL visit is **zero-click** — it lands **straight back signed-in** (newapi UI, no login form) with NO re-login / OIDC-bind prompt. This is the **#3563** regression check: a 2nd bare-URL visit must NOT hit the bind | ☐ |
 
-**Section 6 result: ___ / 7.** Five apps (Grafana, Harbor, Gitea, Keycloak, OpenBao) each land
-signed-in as the owner-admin, zero clicks — including the **OpenBao /sso/landing** fix.
+**Section 6 result: ___ / 8.** Six apps (Grafana, Harbor, Gitea, Keycloak, OpenBao, newapi) each land
+signed-in as the owner-admin, zero clicks — including the **OpenBao /sso/landing** fix and the **newapi #3563 zero-click re-login**.
 
 ---
 


### PR DESCRIPTION
Adds the missing **newapi** row (6.8) to the §6 zero-login SSO matrix: newapi's Open chip lands signed-in, then a 2nd bare-URL visit must be **zero-click** (no re-login / OIDC-bind) — the **#3563** regression check. Tally 5/5->6/6. Rows stay ☐ (walked live per the env-flushes-evidence rule). Refs #3563.