### PR TITLE
fix(catalyst-api): canonicalise topology override — UI placement dialect resolves against canonical SupportedTopologies (#3648)

### DIFF
--- a/docs/ledger/uat-walkthrough/3646-flux-activities.md
+++ b/docs/ledger/uat-walkthrough/3646-flux-activities.md
@@ -1,0 +1,36 @@
+# 3646 — Every activity is a Flux/CR reconciliation on one honest canvas — UAT walk
+
+> **Ticket:** [#3646](https://github.com/openova-io/openova/issues/3646) · **Car:** T3 · **PR:** #3652 · **Train:** `train/hw150`
+>
+> **What this proves:** the `/jobs` canvas shows **every** platform activity as a projection of a Flux
+> object / CR reconciliation — HelmRelease installs, the 11-step cutover, a DR switchover — each with its
+> `dependsOn` edges, and **never** showing a mid-flight activity as falsely "Succeeded". "Flux first"
+> (founder #5).
+>
+> **Format law:** pure UI rows on `/jobs`. Replace `<fqdn>`/`<JWT>`. Tick **☑**/**☒**.
+
+**Sign-in (once).** `https://console.<fqdn>/auth/handover?token=<JWT>` → signed in, no login form.
+
+## Section 1 — The cutover EXECUTION is visible with its 11 steps + edges (the #3646 catch)
+
+| Step | Go to (URL) | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 1.1 | `/jobs` (during a live cutover) | open the activity view | a `Cutover` group with its **11 step rows** + `dependsOn` edges — not a single opaque "install" row | ☐ |
+| 1.2 | `/jobs` (mid-flight) | read the group state while `cutoverComplete=false` | the group/steps show **running**, NEVER a premature "Succeeded" (the dormant-install confusion is gone) | ☐ |
+| 1.3 | `/jobs` (after completion) | re-read | the group flips to Succeeded only when `cutoverComplete=true` | ☐ |
+
+## Section 2 — A DR switchover appears via the SAME bridge (generality)
+
+| Step | Go to | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 2.1 | `/jobs` (after triggering a T5 switchover) | watch | the switchover appears as an activity group with its steps + edges — same model as the cutover | ☐ |
+
+## Section 3 — HelmRelease activities read as Flux alongside the others
+
+| Step | Go to | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 3.1 | `/jobs` | open any app-install row | it reads as a Flux HelmRelease reconciliation — confirming the helm-fed jobs ARE flux, now beside the raw-Job activities | ☐ |
+
+## Appendix — automated (NOT acceptance)
+- `go test ./products/catalyst/bootstrap/api/internal/jobs ./.../internal/handler` green incl `-race`.
+- `activity_bridge_test.go` (group+steps+edges, failed-step→group-failed) + `cutover_activity_bridge_test.go` (durable replay shows mid-flight as running, never Succeeded — the #3646 guarantee).

--- a/docs/ledger/uat-walkthrough/3647-cutover-bulletproof.md
+++ b/docs/ledger/uat-walkthrough/3647-cutover-bulletproof.md
@@ -1,0 +1,40 @@
+# 3647 — Cutover bulletproof: zero external deps, proven — UAT walk (web UI + operator)
+
+> **Ticket:** [#3647](https://github.com/openova-io/openova/issues/3647) · **Car:** T1 · **PR:** #3650 · **Train:** `train/hw150`
+>
+> **What this proves:** after handover + cutover the Sovereign has **no external dependency** — and the
+> cutover gate PROVES it by force-rolling a pod under the deny-egress hold and requiring a fresh pull
+> from the **local Harbor** (`registry.<fqdn>`). Holds for host AND vcluster apps. `cutoverComplete=true`
+> is set ONLY when that fresh pull succeeds.
+>
+> **Format law (founder, 2026-06-03):** UI rows where the surface exists; the genuinely-infra checks
+> (a pod pulling an image) are operator actions, clearly marked — NOT demoted, because the pull IS the
+> acceptance. Replace `<fqdn>` = hw150 FQDN; `<JWT>` = handover token. Tick **☑** pass, **☒** fail.
+
+**Sign-in (once).** `https://console.<fqdn>/auth/handover?token=<JWT>` → signed in as emrah.baysal, no login form.
+
+## Section 1 — The gate sets `cutoverComplete` only after a fresh pull under deny-egress (founder #0/#3)
+
+| Step | Go to (URL) / action | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 1.1 | `/jobs` (after handover fires the cutover) | watch the `Cutover` activity (visible via T3) | step-08 **egress-block** runs the fresh-pull proof, then reaches **Succeeded** | ☐ |
+| 1.2 | `/jobs` → the Cutover group | read the group state at completion | the group is `Succeeded` ONLY after step-08; `cutoverComplete=true` | ☐ |
+
+## Section 2 — A pod rolled AFTER cutover pulls from local Harbor, not ghcr (the #3647 fix, live)
+
+| Step | Action (operator) | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 2.1 | host app (e.g. grafana) | `kubectl rollout restart deploy/grafana-bp-grafana -n <ns>` | new pod schedules | ☐ |
+| 2.2 | `kubectl describe pod <new grafana pod>` | read the Events / image source | image pulled from `registry.<fqdn>` (local Harbor); **no** `ghcr.io ... 401`, no `ImagePullBackOff` | ☐ |
+| 2.3 | a **vcluster** app (generality) | roll one of its pods | pulls from local Harbor too — proves it is not a host-only fix | ☐ |
+
+## Section 3 — Egress to the outside is blocked while the cluster stays alive
+
+| Step | Action | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 3.1 | during the 600s deny-egress hold | `kubectl exec <a pod> -- curl -m5 https://ghcr.io` | times out / connection refused (external egress denied) | ☐ |
+| 3.2 | same window | `kubectl get nodes` + console still loads | apiserver / DNS / intra-cluster reachable (`enableDefaultDeny.egress:false` preserved, #3640) | ☐ |
+
+## Appendix — automated (NOT acceptance)
+- `helm template platform/self-sovereign-cutover/chart` renders clean; both embedded scripts `dash -n` clean.
+- `04-registry-pivot-daemonset.yaml` writes containerd `certs.d/<host>/hosts.toml`; `08-egress-block-test-job.yaml` `run_fresh_pull_proof()` force-deletes a pod + fails the gate on `ImagePullBackOff`.

--- a/docs/ledger/uat-walkthrough/3648-topology-vocabulary.md
+++ b/docs/ledger/uat-walkthrough/3648-topology-vocabulary.md
@@ -1,0 +1,65 @@
+# 3648 — Topology is ONE canonical vocabulary, every app — UAT walk (web UI)
+
+> **Ticket:** [#3648](https://github.com/openova-io/openova/issues/3648) · **Car:** T0 · **PR:** #3649 · **Train:** `train/hw150`
+>
+> **What this proves:** a Blueprint's `SupportedTopologies` is the single source of truth, offered
+> identically in the **create wizard** AND the **AppDetail placement strip**, for **every** app — no
+> dialect divergence, no header/strip contradiction, no `invalid-topology` error. Proven on three
+> different Blueprints, not postgres alone.
+>
+> **Format law (founder, 2026-06-03):** every row is ONE UI action — *go to a URL → one click/type →
+> one screen/state.* Routes/labels are quoted from the deployed console source
+> (`products/catalyst/bootstrap/ui/src/`) with `file:line`. `grep`/`go test` are the Appendix, NOT
+> acceptance.
+>
+> **Replace at walk time:** `<fqdn>` = hw150 FQDN (e.g. `hw150.omani.works`); `<JWT>` = the RS256
+> handover token; `<region-a>`/`<region-b>` = the two region codes. Tick **☑** pass, **☒** fail.
+
+**Sign-in (once).** Open `https://console.<fqdn>/auth/handover?token=<JWT>` → 302 to `/dashboard`,
+signed in as **emrah.baysal** with NO login form (avatar **E** top-right).
+
+---
+
+## Section 1 — Create at a supported topology, for THREE different Blueprints (founder item #3)
+
+**Proves:** the create flow canonicalises the editor dialect (`active-hotstandby → active-hot-standby`)
+before validating against `SupportedTopologies`, so the selection is accepted for **every** stateful
+app — the failure was platform-wide, not a postgres quirk. Route: catalog card → class page → **+ New
+instance** (`AppDetail/InstancesSection.tsx:100`); the wizard topology `<select>` posts the canonical
+value (`endpoint_handler.go` `chooseTopology`/`canonicalizeTopology`, #3649).
+
+| Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
+|---|---|---|---|---|
+| 1.1 | `/catalog/bp-postgres` | **+ New instance** → Topology **active-hot-standby** → Org → ☑ `<region-a>` ☑ `<region-b>` → **Create** | install starts; **NO** `topology "active-hotstandby" not in supported [singleton active-hot-standby] (invalid-topology)` | ☐ |
+| 1.2 | `/catalog/bp-grafana` | same (active-hot-standby, 2 regions) | install starts; no invalid-topology error | ☐ |
+| 1.3 | `/catalog/bp-gitea` | same | install starts; no invalid-topology error | ☐ |
+| 1.4 | `/catalog/bp-openbao` | **+ New instance** → Topology **active-passive** (its declared mode) → Create | accepted; openbao does NOT offer active-hot-standby (not in its `SupportedTopologies`) | ☐ |
+
+## Section 2 — The AppDetail placement strip offers ONLY supported modes (founder item #2, raised 3×)
+
+**Proves:** the strip (`widgets/topology/TopologyEditor.tsx`) is constrained to the Blueprint's declared
+topologies (`supportedCanonical`, `:129-138`) which `AppDetail/TopologyTab.tsx:232-258` feeds in, so it
+can never present a mode the header says is unsupported.
+
+| Step | Go to (URL) | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 2.1 | `/app/<a postgres instance>` → **Topology & DR** tab | read the header (`DeclaredTopologyPanel`) | header shows `Effective active-hot-standby · Supported active-hot-standby · singleton` | ☐ |
+| 2.2 | (same tab) | inspect the **Change placement** strip below | it offers **only** `singleton` + `active-hot-standby`; **active-active is disabled/absent** — strip agrees with header (the 3×-reported contradiction is gone) | ☐ |
+| 2.3 | `/app/<an openbao instance>` → Topology & DR | inspect the strip | offers only `singleton` + `active-passive`; no active-hot-standby/active-active | ☐ |
+
+## Section 3 — Generality proof (the law holds with ZERO per-app code)
+
+**Proves:** the behaviour is declaration-driven, not whittled per app.
+
+| Step | Go to (URL) | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 3.1 | `/catalog/<a Blueprint that declares active-active>` → New instance | open the topology select | **active-active is offered** (because declared) | ☐ |
+| 3.2 | `/catalog/<a singleton-only Blueprint>` → New instance | open the topology select | only `singleton` is offered; the 2-region picker stays hidden | ☐ |
+| 3.3 | repo (operator/reviewer) | `git grep -nE '"postgres"|active-hotstandby|single-region' core/ products/catalyst/bootstrap/api` on the create+validate path | no raw-dialect post, no app-name branch — every value flows through the canonicaliser | ☐ |
+
+## Appendix — automated checks (NOT acceptance)
+
+- `npx vitest run src/widgets/topology` → `TopologyEditor.test.tsx:56` "constrains the picker to the Blueprint supported topologies (#3648)" green (59 tests).
+- `npx vitest run src/pages/sovereign/AppDetail` → `InstancesSection` create-flow tests green.
+- backend: `endpoint_handler_test.go` `TestChooseTopology_CanonicalisesEditorDialect` green.
+- `git grep` audit (DoD §9.7): every topology POST site routes through `canonicalizeTopology`/`canonicalizeMode`.

--- a/docs/ledger/uat-walkthrough/3654-de-hardcode.md
+++ b/docs/ledger/uat-walkthrough/3654-de-hardcode.md
@@ -1,0 +1,39 @@
+# 3654 — The engine is standard: every capability Blueprint-declared, zero per-app code — UAT walk
+
+> **Ticket:** [#3654](https://github.com/openova-io/openova/issues/3654) · **Car:** T2 · **PR:** #3655 · **Train:** `train/hw150`
+>
+> **What this proves:** the "operator produces instances" and "SSO admin bootstrap" capabilities are
+> **declared in the Blueprint** and the engine acts on the declaration identically for every app — a
+> NON-postgres operator gets the same treatment by declaring `producesInstances`, with **zero** postgres-
+> specific code. "All the concepts are applicable for all" (founder #4).
+>
+> **Format law:** UI rows + a code-grep generality proof (the only honest way to prove "no per-app code").
+> Replace `<fqdn>`/`<JWT>`. Tick **☑**/**☒**.
+
+**Sign-in (once).** `https://console.<fqdn>/auth/handover?token=<JWT>` → signed in, no login form.
+
+## Section 1 — A NON-postgres operator gets the engine treatment, by declaration
+
+| Step | Go to (URL) | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 1.1 | `/catalog/bp-valkey` (or another operator declaring `producesInstances`) | open the class page | it shows the **engine-card / "+ New instance"** treatment — the same as postgres | ☐ |
+| 1.2 | (same) | **+ New instance** → name → Create | an instance is produced via the generic `ProducerRegistry` path — no postgres-specific branch | ☐ |
+
+## Section 2 — The apps that had the capability still work (behaviour preserved)
+
+| Step | Go to | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 2.1 | `/catalog/bp-postgres` | + New instance | still produces instances (the generalization preserved it) | ☐ |
+| 2.2 | a `bp-newapi` instance | open it after install | its first admin is seeded via the **standard** `sso.bootstrap` path (not a newapi-specific Job) | ☐ |
+
+## Section 3 — Generality proof: ZERO app-name in the generalized path
+
+| Step | Action (operator / reviewer) | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 3.1 | repo | `git grep -nE '== "postgres"' core/controllers/pkg/backingservice` | **0 matches** on the produces-instances path | ☐ |
+| 3.2 | repo | `git grep -n 'newapi' platform/newapi/chart/templates/admin-sso-seed-job.yaml` | no app-name **equality branch** — values resolve from `.Values.sso` | ☐ |
+| 3.3 | the new operator's `blueprint.yaml` | read it | the ONLY thing added vs postgres is the `producesInstances` declaration — `git diff` shows no engine code per-app | ☐ |
+
+## Appendix — automated (NOT acceptance)
+- `go test ./core/controllers/pkg/backingservice` green (postgres preserved; redis/mongodb fail loudly via the registry).
+- `helm template` bp-cnpg + bp-newapi clean; standard `sso.adminGroup`/`bootstrap` drive the rendered seed, legacy fallback works.

--- a/docs/ledger/uat-walkthrough/3656-ui-faithfulness.md
+++ b/docs/ledger/uat-walkthrough/3656-ui-faithfulness.md
@@ -1,0 +1,48 @@
+# 3656 — The UI is a faithful view: no flash, no stale, no pop-in — UAT walk (web UI)
+
+> **Ticket:** [#3656](https://github.com/openova-io/openova/issues/3656) · **Car:** T4 · **PR:** #3649 (part) · **Train:** `train/hw150`
+>
+> **What this proves:** the console renders **nothing definitive until the source resolves** and never
+> offers an action it then retracts — no flashing buttons, no stale status, no late pop-in. The UI
+> corollary of IaC-first (founder #6).
+>
+> **Format law:** pure UI rows, observed **on open** (the loading window is the test). Replace
+> `<fqdn>`/`<JWT>`. Tick **☑**/**☒**.
+
+**Sign-in (once).** `https://console.<fqdn>/auth/handover?token=<JWT>` → signed in, no login form.
+
+## Section 1 — No "+ New instance" flash (DONE, #3649)
+
+| Step | Go to (URL) | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 1.1 | `/catalog/bp-grafana` (multi-instance) | open cold, watch the header | the **+ New instance** button does NOT flash before the list loads; it appears once, after the list resolves | ☐ |
+
+## Section 2 — A full singleton never offers "+ New instance"
+
+| Step | Go to | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 2.1 | `/catalog/<a singleton app that already has its 1 instance>` | open the page | **no** "+ New instance" button at all — it never appears-then-disappears | ☐ |
+| 2.2 | `/catalog/<a singleton app with 0 instances>` | open | the button IS shown (the first is creatable) | ☐ |
+
+## Section 3 — The Open button shows immediately for front-door apps, never on headless
+
+| Step | Go to | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 3.1 | the apps grid → harbor / gitea card | open the grid cold | the **Open** affordance is present immediately (disabled "Open…" placeholder → enabled), not a late pop-in | ☐ |
+| 3.2 | a headless app card (a controller / openova-flow) | open | NO transient Open chip flashes (placeholder shows only for declared-UI apps — depends on T2 `hasUserUIEndpoint`) | ☐ |
+
+## Section 4 — Jobs show their true terminal state on open
+
+| Step | Go to | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 4.1 | `/jobs` (with jobs that completed long ago) | open the page | completed jobs show **Succeeded** immediately (or an explicit "confirming…"), never Pending/Running then a late flip to Succeeded | ☐ |
+
+## Section 5 — Generality
+
+| Step | Go to | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 5.1 | a fourth async surface chosen at walk time (e.g. the org/environment list) | open cold | a skeleton/loading state, never a wrong-then-corrected value | ☐ |
+
+## Appendix — automated (NOT acceptance)
+- `InstancesSection.test.tsx` "+ New instance gating (#3648, founder #6)": singleton+instance → hidden; multi → shown after load; singleton+empty → shown.
+- Open-button + jobs-stale root cause + fix direction recorded in `docs/sessions/2026-06-16/train-iac-first-hw150.md` §T4 (needs T2 `hasUserUIEndpoint` + T3 live model; walked on hw150).

--- a/docs/ledger/uat-walkthrough/3657-catalog-edit-iac.md
+++ b/docs/ledger/uat-walkthrough/3657-catalog-edit-iac.md
@@ -1,0 +1,43 @@
+# 3657 — The catalog edit is an IaC commit, edited in place — UAT walk (web UI + git)
+
+> **Ticket:** [#3657](https://github.com/openova-io/openova/issues/3657) · **Car:** T6 · **PR:** #3649 (inline UI) + #3651 (git write) · **Train:** `train/hw150`
+>
+> **What this proves:** a catalog entry is edited **in place on its own page** (no chip + popup), the
+> edit lands as a **git commit** to the local catalog repo, and an out-of-band git edit round-trips to
+> the UI — the catalog is genuinely IaC (founder #1 + #8).
+>
+> **Format law:** UI rows + a git-side verification (the commit IS the acceptance). Replace
+> `<fqdn>`/`<JWT>`. Tick **☑**/**☒**.
+
+**Sign-in (once).** `https://console.<fqdn>/auth/handover?token=<JWT>` → signed in as emrah.baysal (admin).
+
+## Section 1 — Edit in place on the detail page; no popup, no grid chip-modal (founder #1)
+
+| Step | Go to (URL) | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 1.1 | `/catalog/bp-alloy` | click the admin **Edit** button in the hero (`catalog-detail-edit`) | the edit form opens **inline on the page** (name / summary / topologies / icons) — no modal | ☐ |
+| 1.2 | `/catalog` (grid) | click a card's **Edit** chip | it NAVIGATES to that card's detail page — no popup opens on the grid | ☐ |
+
+## Section 2 — The edit lands as a git commit (founder #8)
+
+| Step | Go to / action | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 2.1 | `/catalog/bp-alloy` → Edit → change the summary → **Save** | save | the page refreshes in place with the new summary | ☐ |
+| 2.2 | local Gitea `catalog-sovereign/bp-alloy/blueprint.yaml` | view the repo history | a **commit** carrying the edited summary (not just an overlay-store row) — `git log` shows it | ☐ |
+
+## Section 3 — Out-of-band git edit round-trips to the UI
+
+| Step | Go to / action | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 3.1 | local Gitea: edit `catalog-sovereign/bp-alloy/blueprint.yaml` directly (change the name) → commit | wait for the projector read | — | ☐ |
+| 3.2 | reload `/catalog/bp-alloy` | observe | the UI shows the git-side name (git-first read; the UI holds no truth of its own) | ☐ |
+
+## Section 4 — Generality
+
+| Step | Go to | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 4.1 | a **second** Blueprint, a **different** field (the light/dark icon) | edit → Save → check git | the same edit→commit→read works — not bp-alloy-specific | ☐ |
+
+## Appendix — automated (NOT acceptance)
+- `CatalogPage.edit.test.tsx`: Edit chip navigates to the detail page, no popup mounts.
+- `catalog_edit_git_test.go` (7 cases): YAML merge, write→commit→read-back, git-wins-over-store, commerce-body decode+commit, no-op when unwired.

--- a/docs/ledger/uat-walkthrough/train-iac-first-hw150.md
+++ b/docs/ledger/uat-walkthrough/train-iac-first-hw150.md
@@ -1,0 +1,137 @@
+# IaC-first train — hw150 final UAT walk (web UI)
+
+> **Scope:** the founder walks every **car** of the *IaC-first standard-engine train* on the next
+> fresh prov (**hw150**). Cars: **T0** (#3649 — topology dialect + inline catalog edit, items 1/2/3),
+> **T1** (#3650 — cutover bulletproof, #0/#3/#3647), **T2** (de-hardcode, #4), **T3** (unified Flux
+> activities, #5/#3646), **T4** (UI faithfulness, #6), **T5** (Continuum/DR switchover, #7/#3492),
+> **T6** (catalog-edit→git, #8). Train plan: [`docs/sessions/2026-06-16/train-iac-first-hw150.md`](../../sessions/2026-06-16/train-iac-first-hw150.md).
+>
+> **Format law (founder, 2026-06-03):** every row is **ONE UI action** — *Go to a URL → do one
+> click/type → see one screen/state.* Routes/labels are quoted from the deployed console source
+> (`products/catalyst/bootstrap/ui/src/`) with a `file:line` citation where the surface already
+> exists on `main`. Surfaces still landing with their car carry **`(route TBD — fill at merge)`** and
+> are finalised when that car's PR merges. `grep`/`go test`/`kubectl` are the **Appendix — automated,
+> NOT acceptance.**
+>
+> **The spine being proven (all 7 cars are one principle):** IaC in git is the single source of
+> truth; the engine is standard (no per-app code); the UI is a thin two-way skin (renders IaC, edit =
+> commit, reconcile = Flux); every activity is a reconciliation. Each section is one corollary made
+> walkable.
+>
+> **Replace at walk time:** `<fqdn>` = hw150 sovereign FQDN (e.g. `hw150.omani.works`); `<JWT>` = the
+> RS256 handover token (`iss=console.openova.io`, `sub=emrah.baysal@openova.io`, `role=sovereign-admin`);
+> `<region-a>`/`<region-b>` = the two region codes (e.g. `me-east-215-a`/`-b`). Tick **☑** pass, **☒** fail.
+
+**Sign-in (once, whole walk).** Open `https://console.<fqdn>/auth/handover?token=<JWT>` → it 302s to
+`/dashboard` and you are **signed in with NO login form** (avatar **E** top-right). Zero-click entry;
+do not re-authenticate between sections.
+
+---
+
+## T0 — Topology dialect + inline catalog edit (#3649 · founder items 1/2/3)
+
+**Proves:** (#3) a postgres instance creates at any *supported* topology without the
+`active-hotstandby not in supported` error; (#2) the AppDetail placement strip never offers an
+unsupported mode (no contradiction with the declared header); (#1) the catalog entry is editable
+**in place on its own page** — no separate chip + popup.
+
+| Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
+|---|---|---|---|---|
+| 0.1 | `/catalog/bp-postgres` | **+ New instance** → topology **active-hot-standby** → pick `<region-a>`+`<region-b>` → **Create** | install starts; **NO** `topology "active-hotstandby" not in supported [singleton active-hot-standby]` error (#3) | ☐ |
+| 0.2 | `/app/<a postgres instance>` → **Topology & DR** tab | inspect the *Change placement* picker | it offers **only** the Blueprint's declared modes; active-active is **greyed/absent** for a singleton·active-hot-standby Blueprint — matches the declared header (#2) | ☐ |
+| 0.3 | `/catalog/bp-alloy` | click the admin **Edit** button in the hero (`CatalogDetail.tsx` `catalog-detail-edit`) | the edit form opens **inline on the page** (name / summary / supported topologies / light+dark icon) — **no modal, no separate chip** (#1) | ☐ |
+| 0.4 | (same page) | change the display name → **Save** | the page refreshes in place with the new name; reload still shows it | ☐ |
+| 0.5 | `/catalog` (as admin) | click the **Edit** chip on a card | it **navigates** to that card's detail page — **no popup** opens on the grid (#1) | ☐ |
+
+## T1 — Cutover bulletproof: zero external deps, proven (#3650 · founder #0/#3, #3647)
+
+**Proves:** after handover+cutover the Sovereign has **no external dependency**, and the gate proves
+it by **rolling a pod under deny-egress** and requiring a fresh pull from the **local Harbor**.
+
+| Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
+|---|---|---|---|---|
+| 1.1 | `/jobs` (after handover fires the cutover) | watch the cutover activity (see T3 — it is now visible) | all 11 cutover steps reach **Succeeded**, including **step-08 egress-block** | ☐ |
+| 1.2 | cutover status surface `(route TBD — fill at merge)` | read `cutoverComplete` | **`cutoverComplete = true`** — set ONLY because a pod was force-rolled under deny-egress and pulled from local Harbor (the fresh-pull proof) | ☐ |
+| 1.3 | `/catalog/bp-grafana` → open Grafana, then (operator) delete a Grafana pod | watch it reschedule | the new pod reaches **Running** by pulling from `registry.<fqdn>` (local Harbor) — **not** ghcr.io; no `ImagePullBackOff` (this is the #3647 fix, live) | ☐ |
+
+> Appendix check (NOT acceptance): under the 600s deny-egress hold, `egress to github.com/ghcr.io/harbor.openova.io` is blocked while apiserver/DNS/intra-cluster stay reachable (`enableDefaultDeny.egress:false` preserved, #3640).
+
+## T2 — De-hardcode: the engine is standard, not per-app (founder #4)
+
+**Proves:** the "operator produces instances" concept and the SSO admin-seed are **Blueprint-declared
+capabilities**, applying uniformly — no `postgres`/`newapi` literals in the engine.
+
+| Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
+|---|---|---|---|---|
+| 2.1 | `/catalog` | find a **non-postgres** operator Blueprint that declares it produces instances | it shows the **engine-card / + New instance** treatment — the same as postgres, with **no postgres-specific** code path `(route TBD — fill at merge)` | ☐ |
+| 2.2 | a Blueprint declaring the standard `sso-bootstrap` contract | open it after install | its first admin is seeded via the Sovereign SSO by the **standard** mechanism (not a newapi-specific Job) `(route TBD — fill at merge)` | ☐ |
+| 2.3 | `/catalog/bp-postgres` and `/catalog/bp-newapi` | confirm both still work | postgres still produces instances; newapi still seeds its admin — behaviour preserved through the generalisation | ☐ |
+
+## T3 — Unified Flux activities: every activity is a job on the canvas (founder #5 · #3646)
+
+**Proves:** every platform activity — HelmRelease installs, the cutover steps, a DR switchover — is a
+projection of a Flux object / CR reconciliation, shown on one activity canvas with dependency edges.
+
+| Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
+|---|---|---|---|---|
+| 3.1 | `/jobs` | open the activity view during/after cutover | the **11 cutover steps** appear as job rows **with their dependsOn edges** — previously invisible (#3646) | ☐ |
+| 3.2 | `/jobs` | trigger a DR switchover (T5) and watch | the **switchover** appears as a job/activity with its dependencies — "DR switchover is a flux/reconcile job" (founder #5) `(route TBD — fill at merge)` | ☐ |
+| 3.3 | `/jobs` | inspect any HelmRelease-backed row | it reads as a Flux reconciliation — confirming the helm-fed jobs ARE flux, now alongside the others | ☐ |
+
+## T4 — UI faithfulness: never assert-then-retract (founder #6)
+
+**Proves:** the UI renders nothing definitive until its source resolves — no flash, no stale state.
+
+| Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
+|---|---|---|---|---|
+| 4.1 | `/catalog/bp-grafana` (multi-instance) | open the page cold | the **+ New instance** button does **not** flash before the list loads; it appears once, after the list resolves (#3648) | ☐ |
+| 4.2 | `/catalog/<a singleton app with 1 instance>` | open the page | **no** "+ New instance" button (a singleton that's already full can't create a second) — it never appears-then-disappears | ☐ |
+| 4.3 | `/catalog/bp-harbor` then **Open** | open an app card | the **Open** button is present as soon as the URL is known — no late pop-in `(Open-button-late — fill at merge)` | ☐ |
+| 4.4 | `/jobs` | open after some jobs completed | completed jobs show **Succeeded** immediately — **not** Pending/Running then a late flip `(jobs-stale — fill at merge)` | ☐ |
+
+## T5 — Standard Continuum/DR switchover (founder #7 · #3492/#3375)
+
+**Proves:** for any app placed active-hot-standby on a 2-region Sovereign, the DR panel shows a
+**live Continuum record** and the **Switchover** action actually promotes the replica — generic, not
+per-app.
+
+| Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
+|---|---|---|---|---|
+| 5.1 | `/app/<an active-hot-standby app>` → **Disaster Recovery** | read the panel | a **live Continuum record** (primary `<region-a>`, replica `<region-b>`, healthy) — **not** "No live Continuum record yet" (#7) | ☐ |
+| 5.2 | (same) | click **Switchover…** → confirm | the replica is promoted (primary flips to `<region-b>`); `lastSwitchover` updates; the app stays writable | ☐ |
+| 5.3 | `/app/<a different active-hot-standby app>` | repeat 5.1 | a live record there too — proving it's **generic** (grafana, gitea, postgres — same machinery, no per-app code) | ☐ |
+
+## T6 — Catalog edit → git (founder #8)
+
+**Proves:** the catalog edit is an **IaC change** (a commit to the local catalog git), and an
+out-of-band git edit round-trips to the UI — IaC is the single source of truth.
+
+| Step | Go to (URL) | Do (click / type) | Expect (screen / state) | ☐ |
+|---|---|---|---|---|
+| 6.1 | `/catalog/bp-alloy` → **Edit** → change summary → **Save** | then open the local Gitea catalog repo | the edit landed as a **git commit** to the catalog entry's source (not just an overlay row) `(repo path TBD — fill at merge)` | ☐ |
+| 6.2 | local Gitea: edit the same entry's metadata directly (out-of-band) → wait for reconcile | reload `/catalog/bp-alloy` | the UI **shows the git-side change** — the UI holds no truth of its own (#8) | ☐ |
+
+---
+
+## Acceptance roll-up
+
+A car is **shipped** only when its section above is walked green on hw150 with a screenshot, per the
+5-pillar contract (PR-merge ≠ shipped). The train merges as one batch; this walk is the gate. When a
+car merges, replace its `(... TBD — fill at merge)` placeholders with the verbatim route/label +
+`file:line` from the merged console/api source.
+
+| Car | PR | Section | Walked on hw150 |
+|---|---|---|---|
+| T0 | #3649 | T0 | ☐ |
+| T1 | #3650 | T1 | ☐ |
+| T2 | _(de-hardcode)_ | T2 | ☐ |
+| T3 | _(unified activities)_ | T3 | ☐ |
+| T4 | #3649-line (UI) | T4 | ☐ |
+| T5 | _(Continuum/DR)_ | T5 | ☐ |
+| T6 | _(catalog→git)_ | T6 | ☐ |
+
+## Appendix — automated checks (NOT acceptance)
+
+- T1: `helm template` of `platform/self-sovereign-cutover/chart` renders clean; the egress CCNP keeps `enableDefaultDeny.egress:false`; the fresh-pull proof job force-rolls a pod and fails the gate on `ImagePullBackOff`.
+- T2/T3/T5/T6: `go test ./...` green in the changed packages (per-PR).
+- T0/T4: `npx vitest run src/pages/sovereign` + `npx tsc --noEmit` green (per PR #3649).

--- a/docs/sessions/2026-06-16/train-iac-first-hw150.md
+++ b/docs/sessions/2026-06-16/train-iac-first-hw150.md
@@ -1,0 +1,48 @@
+# Train: "IaC-first standard engine" → walked on hw150
+
+**Founder directive (2026-06-16):** treat the 8 review points holistically, build them as
+parallel PRs that merge as **one coordinated train**, test what's live-testable on hw149
+before it's wiped, update/extend the UAT walkthroughs so the **final walk runs on hw150**,
+and assign subagents to the parallel work.
+
+## The spine (why these are one thing)
+
+IaC in git is the single source of truth. The platform is a standard reconciliation engine.
+The UI is a thin, bidirectional skin: it **renders** declared+live state and turns "edit"
+into **a write back to the same IaC** (commit → Flux reconciles). Nothing is keyed on an app
+name; every activity is a reconciliation of declared state. Each point below is a corollary,
+and the train is that spine landed.
+
+## The train cars (PRs) — each a subagent
+
+| Car | Points | Scope | Surface | Subagent |
+|----|--------|-------|---------|----------|
+| **T0** | 1,2,3 | topology picker ← SupportedTopologies; create canonicalise; inline catalog edit (popup gone) | catalyst-api + UI | ✅ **shipped — PR #3649** |
+| **T1 — cutover bulletproof** | 0,3 | registry-pivot reloads k3s so post-cutover image pulls hit local Harbor (#3647); egress-block gate FORCES a pod roll under deny-egress (proves zero external deps) | cutover chart | go/infra agent |
+| **T2 — de-hardcode** | 4 | engine-class generic (`producesInstances:<kind>`, not `postgresClass`); newapi admin-seed → a STANDARD `sso-bootstrap` Blueprint contract any app declares | core + charts + UI | go agent |
+| **T3 — unified Flux activities** | 5 | one activity canvas: install / DB-provision / cutover / DR-switchover all projected from Flux objects + CRs via per-source bridges (absorbs #3646) | catalyst-api + UI | fullstack agent |
+| **T4 — UI faithfulness** | 6 | skeletons + tight invalidation — never assert-then-retract: new-instance flash (singleton gate), Open-button-late, jobs stale-pending | UI | ts agent |
+| **T5 — standard Continuum/DR** | 7 | the Continuum CR/controller produces live DR records + drives switchover (the unbuilt layer; #3492/#3375) — generic, not per-app | core controller | go agent |
+| **T6 — catalog-edit → git** | 8 | catalog edit COMMITS to the local catalog git (not the commerce overlay); the UI re-reads from IaC, so an advanced user's git edit shows automatically | catalyst-api | go agent |
+
+## Merge discipline (the "same train")
+
+- Tracking epic issue **`train/iac-first-hw150`** lists every car + a shared label `train/hw150`.
+- Every car branches off **origin/main**, opens a PR labelled `train/hw150`, `Refs` the epic.
+- The train merges as one batch after all cars are green; **then** a single fresh prov (hw150)
+  walks the whole thing. PR-merge ≠ shipped — the hw150 walk is the gate.
+
+## Test-before-wipe (hw149, capture while alive)
+
+Already captured live: NS#5 cutoverComplete + 4 proofs; NS#4 region-kill (stream→promote→
+preserve→writable); #3647 (new-pod ghcr 401). Still to capture before wipe: the #6 UI repros
+(new-instance flash, jobs stale-pending, Open-late) and the #7 "no live Continuum record" for
+grafana/gitea — as evidence rows the UAT doc references.
+
+## UAT walkthrough for hw150
+
+Amend `docs/ledger/uat-walkthrough/` into a single **hw150** walk whose sections map 1:1 to the
+acceptance of every car: topology create + placement (T0); pod-roll-under-deny-egress (T1);
+"no app-name in code" spot-checks (T2); one activity feed incl. a switchover job (T3); zero
+flash/stale (T4); a real DR switchover with a live Continuum record (T5); a catalog edit that
+lands as a git commit + an out-of-band git edit that shows in the UI (T6).

--- a/docs/sessions/2026-06-16/train-iac-first-hw150.md
+++ b/docs/sessions/2026-06-16/train-iac-first-hw150.md
@@ -46,3 +46,24 @@ acceptance of every car: topology create + placement (T0); pod-roll-under-deny-e
 "no app-name in code" spot-checks (T2); one activity feed incl. a switchover job (T3); zero
 flash/stale (T4); a real DR switchover with a live Continuum record (T5); a catalog edit that
 lands as a git commit + an out-of-band git edit that shows in the UI (T6).
+
+## T4 (UI faithfulness) — implementation status
+
+- **new-instance flash → DONE** (commit `839a0844c`, in #3649): `InstancesSection`'s "+ New instance"
+  renders only once the list resolves AND another instance is creatable
+  (`!isPending && (multiInstance !== false || items.length === 0)`); 3 tests lock the singleton case.
+- **Open-button-late → root-caused; needs a static user-UI signal.** `AppsPage.tsx:1059` renders the
+  Open chip only when `externalURL` is non-empty, and `externalURL` arrives async via `liveAppsQuery`,
+  so a real front-door app (harbor/gitea) shows nothing then pops in. A blanket placeholder is NOT the
+  fix — the BE projects `externalURL` ONLY for UI apps (`:1054-1058`), so it would flash a transient
+  chip on headless apps (the same assert-then-retract). The faithful fix exposes the Blueprint's
+  `hasUserUIEndpoint` to the UI (generated constant / BE field) so the card shows a confident disabled
+  placeholder for UI apps only. Folds into **T2** (Blueprint-declared capabilities) or a focused
+  follow-up; **validate on hw150**.
+- **jobs-stale → root-caused; needs live validation with T3.** JobsPage merges reducer-derived rows
+  with the live-jobs query (`useLiveJobsBackfill`, 5s poll, `placeholderData: prev`); on open, stale
+  reducer rows (pending/running) show until the live fetch (which wins on conflict) lands — the
+  "succeeded after a while". refetch-on-mount/focus are already RQ defaults, so the real fix is to
+  **not render reducer-derived status as definitive** (a "confirming…" state until the live source
+  confirms). This sits on top of **T3's** new activity model (#3652) → fix + walk on the live hw150
+  jobs canvas, not blind.

--- a/docs/sessions/2026-06-16/train-status-7of7.md
+++ b/docs/sessions/2026-06-16/train-status-7of7.md
@@ -1,0 +1,57 @@
+# IaC-first train — 7/7 status (durable record, 2026-06-16)
+
+The train = the founder's 2026-06-16 step-by-step review (8 points #0–#8) built as **7 coordinated
+cars**, merged as one batch and walked on a fresh **hw150**. All seven are CI-green + mergeable.
+
+## 7 cars — CI-green + mergeable
+
+| Car | PR | head SHA | CI | Ticket (at #3370 bar) | Walkthrough |
+|---|---|---|---|---|---|
+| T0 | [#3649](https://github.com/openova-io/openova/pull/3649) | `ef80a505f` | ✅ | #3648 | `3648-topology-vocabulary.md` |
+| T1 | [#3650](https://github.com/openova-io/openova/pull/3650) | `3b87092da` | ✅ | #3647 | `3647-cutover-bulletproof.md` |
+| T2 | [#3655](https://github.com/openova-io/openova/pull/3655) | `ee7ab9dc1` | ✅ | #3654 | `3654-de-hardcode.md` |
+| T3 | [#3652](https://github.com/openova-io/openova/pull/3652) | `558fef995` | ✅ | #3646 | `3646-flux-activities.md` |
+| T4 | [#3658](https://github.com/openova-io/openova/pull/3658) | `80455cf82` | ✅ | #3656 | `3656-ui-faithfulness.md` |
+| T5 | [#3653](https://github.com/openova-io/openova/pull/3653) | `b4d477b99` | ✅ | #3375/#3492 | `3375-topology-dr.md` |
+| T6 | [#3651](https://github.com/openova-io/openova/pull/3651) | `355d0f4b2` | ✅ | #3657 | `3657-catalog-edit-iac.md` |
+
+## Founder review item → car (one line each)
+
+| Item | What | Car | PR |
+|---|---|---|---|
+| #0 | zero external deps after cutover (gate proves it) | T1 | #3650 |
+| #1 | catalog editable in place, no chip+popup | T6 (+T0 inline UI) | #3651 / #3649 |
+| #2 | AppDetail topology strip contradiction | T0 | #3649 |
+| #3 | postgres create + bulletproof gate | T0 (create) + T1 (gate) | #3649 / #3650 |
+| #4 | no per-app hardcoding (capability-declared engine) | T2 | #3655 |
+| #5 | flux-first: every activity a job + DR-as-job | T3 | #3652 |
+| #6 | UI faithfulness (new-instance flash / Open / jobs-stale) | T4 | #3658 |
+| #7 | DR switchover live record, generic | T5 | #3653 |
+| #8 | IaC single source / catalog-edit→git | T6 | #3651 |
+
+> **On the older "Q1/Q2/Q6" framing:** those are the prior North-Star deliverables
+> (every-app-in-a-vCluster, shared-PG many-to-many cards, per-app Open buttons), already shipped on
+> hw144/hw146 — NOT part of this 8-point train. Q6's Open-button concern is subsumed by T4 / #6.
+
+## Cleared-or-boarding
+**BOARDING** — 7/7 CI-green + mergeable, ready to merge as one batch. Acceptance is the hw150 walk,
+not the merge (PR-merge ≠ shipped).
+
+## Cache-cleanup declaration
+- The `/opt/registry-*` caches (~20 GB) are **REQUIRED** — the mothership's pull-through mirrors
+  (dockerhub/ghcr/quay/kyverno/xpkg + the main `harbor-cache`) for the live `vmi3116389` control plane;
+  the ghcr mirror holds the openova-io images.
+- **NOT removed; RELOCATED** to `/home/registry-cache/…` via symlink; all 6 containers serve `/v2/` 200;
+  mothership unaffected; persists across reboot (symlink + `restart=always`).
+- Result: `/` **99% → 40%** (23 GB free); `/home` 51%. **CLEARED.**
+- Plus the safe sweep (journal/apt/logs) and the registry relocation; no service touched beyond the
+  per-registry brief restart.
+
+## hw149 vs hw150
+hw149 is cutover-complete → frozen + #3647-blocked from new images → **no car deploys there**. One fresh
+hw150 walks all: pre-cutover phase (T0/T2/T4/T5/T6) + cutover phase (T1/T3).
+
+## Next
+Coordinated merge (#3655 → #3658 → #3649 → rest; resolve the CRD `blueprint.yaml` / `catalog.generated`
+/ UI overlaps as they stack) → mothership roll settles (0 builds in-flight, pod-age > 5 min) → wipe
+hw149 → fire hw150 → walk all seven walkthroughs.

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
@@ -1852,6 +1852,13 @@ func buildSSOShimURL(fqdn, id string) string {
 // per-call decision is now computed by Handler.detectMultiRegion and
 // passed in here so this helper stays pure + table-test-friendly.
 func chooseTopology(bp *blueprintMeta, override string, multiRegion bool) (string, error) {
+	// #3648 — the catalyst-ui posts the placement-editor dialect
+	// (single-region / active-active / active-hotstandby); Blueprint
+	// SupportedTopologies use the canonical vocabulary (singleton /
+	// active-active / active-hot-standby / active-passive). Canonicalise the
+	// operator override so either spelling resolves against Supported. Empty
+	// stays empty (the default-selection path below).
+	override = canonicalizeTopology(override)
 	if bp == nil || bp.Topology == nil || len(bp.Topology.Supported) == 0 {
 		// Permissive fallback — no topology declared → singleton.
 		if override != "" && override != "singleton" && override != "active-hot-standby" &&
@@ -1878,6 +1885,29 @@ func chooseTopology(bp *blueprintMeta, override string, multiRegion bool) (strin
 		return bp.Topology.Defaults.SingleRegion, nil
 	}
 	return bp.Topology.Supported[0], nil
+}
+
+// canonicalizeTopology maps the catalyst-ui placement-editor dialect
+// (single-region / active-active / active-hotstandby) onto the canonical
+// Blueprint topology vocabulary (singleton / active-active /
+// active-hot-standby / active-passive) so a create or placement-change
+// posted with either spelling resolves against bp.Topology.Supported
+// (#3648). Empty input returns empty (preserves the default-selection
+// path); an unknown non-empty value is returned trimmed so the caller
+// still rejects it as unsupported with its original spelling.
+func canonicalizeTopology(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "active-hot-standby", "active-hotstandby", "active_hot_standby":
+		return "active-hot-standby"
+	case "active-passive", "active_passive":
+		return "active-passive"
+	case "active-active", "active_active":
+		return "active-active"
+	case "singleton", "single-region", "single_region":
+		return "singleton"
+	default:
+		return strings.TrimSpace(raw)
+	}
 }
 
 // detectMultiRegion computes whether the active Sovereign is

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler_test.go
@@ -1179,6 +1179,35 @@ func TestChooseTopology_OverrideRejectedWhenUnsupported(t *testing.T) {
 	}
 }
 
+// TestChooseTopology_CanonicalisesEditorDialect (#3648) — the catalyst-ui
+// posts the placement-editor dialect (single-region / active-hotstandby)
+// while the Blueprint declares the canonical vocabulary (singleton /
+// active-hot-standby). chooseTopology must canonicalise the override so the
+// create / placement-change resolves instead of failing "not in supported"
+// (the founder's live postgres-create failure).
+func TestChooseTopology_CanonicalisesEditorDialect(t *testing.T) {
+	bp := &blueprintMeta{Topology: &topologyDecl{Supported: []string{"singleton", "active-hot-standby"}}}
+	cases := []struct {
+		override string
+		want     string
+	}{
+		{"active-hotstandby", "active-hot-standby"},  // the founder's failing case
+		{"active-hot-standby", "active-hot-standby"}, // already canonical
+		{"single-region", "singleton"},               // editor dialect → singleton
+		{"singleton", "singleton"},                   // already canonical
+	}
+	for _, c := range cases {
+		got, err := chooseTopology(bp, c.override, true)
+		if err != nil || got != c.want {
+			t.Fatalf("override %q: expected %q, got %q err=%v", c.override, c.want, got, err)
+		}
+	}
+	// An unknown value is still rejected against Supported.
+	if _, err := chooseTopology(bp, "active-active", true); err == nil {
+		t.Fatal("expected error: active-active not in [singleton active-hot-standby]")
+	}
+}
+
 // ── G117 W2.C2 — multi-instance admission gate integration tests ───
 
 // TestCreateInstance_MultiInstanceEnabled_3Instances exercises the

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.test.tsx
@@ -221,3 +221,50 @@ describe('NewInstanceDialog — placement (#3599)', () => {
     expect(body.placement).toEqual({ vcluster: 'rtz', regions: ['rgn-a', 'rgn-b'] })
   })
 })
+
+// #3648 (founder #6) — the "+ New instance" button must never flash before the
+// instances list resolves, and must not offer a second instance for a
+// singleton-per-Org Blueprint that already has its one instance.
+describe('"+ New instance" gating (#3648, founder #6)', () => {
+  function renderWith(multiInstance: boolean, items: Array<Record<string, unknown>>) {
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('/instances')) return json({ items })
+      if (url.includes('/catalog/')) return json(WP_CATALOG)
+      return json({})
+    }) as typeof fetch
+    const rootRoute = createRootRoute({ component: () => <Outlet /> })
+    const route = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/provision/$deploymentId/catalog/$blueprintName',
+      component: () => <InstancesSection blueprint="bp-wordpress" multiInstance={multiInstance} />,
+    })
+    const tree = rootRoute.addChildren([route])
+    const router = createRouter({
+      routeTree: tree,
+      history: createMemoryHistory({ initialEntries: ['/provision/d-1/catalog/bp-wordpress'] }),
+    })
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    return render(
+      <QueryClientProvider client={qc}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    )
+  }
+
+  it('hides the button for a singleton that already has an instance', async () => {
+    renderWith(false, [{ id: 'i-1', name: 'wp-only', org: 'acme', topology: 'single-region', status: 'Ready' }])
+    await screen.findByTestId('sov-instance-row-wp-only')
+    expect(screen.queryByTestId('btn-new-instance')).toBeNull()
+  })
+
+  it('shows the button for a multi-instance Blueprint once the list resolves', async () => {
+    renderWith(true, [])
+    expect(await screen.findByTestId('btn-new-instance')).toBeTruthy()
+  })
+
+  it('keeps the button for a singleton with no instance yet (the first is creatable)', async () => {
+    renderWith(false, [])
+    expect(await screen.findByTestId('btn-new-instance')).toBeTruthy()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
@@ -61,10 +61,18 @@ export function InstancesSection({
   blueprint,
   appUID,
   perCluster,
+  multiInstance,
 }: {
   blueprint: string
   appUID?: string
   perCluster?: Array<Record<string, unknown>>
+  /**
+   * #3648 (founder #6) — whether this Blueprint allows >1 instance per Org.
+   * When false (singleton-per-Org) and an instance already exists, the
+   * "+ New instance" button is hidden — you can't create a second. Undefined
+   * is treated as multi-instance (button shows once the list resolves).
+   */
+  multiInstance?: boolean
 }) {
   const [dialogOpen, setDialogOpen] = useState(false)
   const qc = useQueryClient()
@@ -95,25 +103,31 @@ export function InstancesSection({
         }}
       >
         <h2 style={{ margin: 0 }}>Instances</h2>
-        <button
-          type="button"
-          data-testid="btn-new-instance"
-          onClick={() => setDialogOpen(true)}
-          className="btn btn-primary"
-          style={{
-            padding: '0.3rem 0.8rem',
-            fontSize: '0.82rem',
-            background: 'var(--color-accent)',
-            color: 'white',
-            border: '0',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            fontWeight: 600,
-          }}
-          aria-label="Create a new instance of this Blueprint"
-        >
-          + New instance
-        </button>
+        {/* #3648 (founder #6) — never flash a definitive action before the
+            data resolves, and never offer "New instance" for a singleton that
+            already has its one instance. Show only once the list has loaded
+            AND another instance is actually creatable. */}
+        {!instancesQuery.isPending && (multiInstance !== false || items.length === 0) ? (
+          <button
+            type="button"
+            data-testid="btn-new-instance"
+            onClick={() => setDialogOpen(true)}
+            className="btn btn-primary"
+            style={{
+              padding: '0.3rem 0.8rem',
+              fontSize: '0.82rem',
+              background: 'var(--color-accent)',
+              color: 'white',
+              border: '0',
+              borderRadius: '6px',
+              cursor: 'pointer',
+              fontWeight: 600,
+            }}
+            aria-label="Create a new instance of this Blueprint"
+          >
+            + New instance
+          </button>
+        ) : null}
       </div>
 
       {instancesQuery.isPending ? (

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -322,6 +322,7 @@ export function TopologyTab({
         availableRegions={availableRegions}
         namespace={namespace}
         blueprint={blueprint}
+        supportedCanonical={declaredTopology?.supported}
         disableNetwork={disableNetwork}
         onApplied={() => {
           setRefreshTick((t) => t + 1)

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
@@ -1,5 +1,6 @@
+import { useState } from 'react'
 import { useParams, Link } from '@tanstack/react-router'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { getCatalogItem, getApplication, type CatalogItem } from '@/lib/catalog.api'
 import { findComponent } from '@/pages/wizard/steps/componentGroups'
@@ -7,6 +8,8 @@ import { BLUEPRINT_BY_ID } from '@/shared/constants/catalog.generated'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import { InstancesSection } from './AppDetail/InstancesSection'
+import { useCatalogAdmin } from '@/shared/lib/useCatalogAdmin'
+import { CatalogEditForm } from './CatalogEditForm'
 
 /**
  * CatalogDetail — the per-Blueprint CLASS page.
@@ -57,6 +60,11 @@ export function CatalogDetail() {
   }
   const name = (params.blueprintName ?? '').replace(/^bp-/, '')
   const { deploymentId } = useResolvedDeploymentId()
+  const isAdmin = useCatalogAdmin()
+  const qc = useQueryClient()
+  // #3648 (founder item #1) — inline edit-in-place on the detail page,
+  // replacing the separate edit chip + modal on the catalog grid.
+  const [editing, setEditing] = useState(false)
 
   // Chroot-aware "back to Catalog" target. On the mothership provision
   // monitor (`/provision/$deploymentId/...`) the apps grid is at
@@ -198,6 +206,28 @@ export function CatalogDetail() {
           <h1>
             <span data-testid="catalog-title">{title}</span>
           </h1>
+          {isAdmin && !editing ? (
+            <button
+              type="button"
+              data-testid="catalog-detail-edit"
+              onClick={() => setEditing(true)}
+              title="Edit this catalog entry"
+              style={{
+                alignSelf: 'flex-start',
+                marginTop: '0.15rem',
+                padding: '0.3rem 0.8rem',
+                borderRadius: '8px',
+                border: '1px solid var(--color-border)',
+                background: 'transparent',
+                color: 'var(--color-text)',
+                fontSize: '0.8rem',
+                fontWeight: 600,
+                cursor: 'pointer',
+              }}
+            >
+              Edit
+            </button>
+          ) : null}
           {card.tagline || card.summary ? (
             <p className="hero-tagline">{card.tagline || card.summary}</p>
           ) : null}
@@ -290,6 +320,30 @@ export function CatalogDetail() {
           ) : null}
         </div>
       </div>
+
+      {/* #3648 (founder item #1) — inline edit-in-place panel. Replaces the
+          separate edit chip + modal on the catalog grid: the operator edits
+          the entry on its own page, where it is already shown. */}
+      {editing ? (
+        <section className="section" data-testid="catalog-edit-section">
+          <h2>Edit catalog entry</h2>
+          <CatalogEditForm
+            blueprintId={`bp-${name}`}
+            initial={{
+              name: title,
+              summary: card.tagline || card.summary || '',
+              supportedTopologies: topologies.map(toEditorMode),
+              iconLight: logoUrl ?? '',
+              iconDark: '',
+            }}
+            onSaved={() => {
+              setEditing(false)
+              void qc.invalidateQueries({ queryKey: ['catalog-item', name] })
+            }}
+            onCancel={() => setEditing(false)}
+          />
+        </section>
+      ) : null}
 
       {/* About */}
       {card.description ? (
@@ -431,6 +485,21 @@ function readMultiInstance(cat: CatalogItem): boolean {
   const spec = (raw?.spec as Record<string, unknown> | undefined) ?? undefined
   const mi = spec?.multiInstance as { enabled?: boolean } | undefined
   return !!mi?.enabled
+}
+
+// #3648 — map BOTH the canonical matrix vocabulary (singleton /
+// active-hot-standby) AND the editor dialect onto the editor dialect
+// (single-region / active-hotstandby / active-active) the inline edit form's
+// topology checkboxes use, so a Blueprint's declared topologies pre-check
+// correctly regardless of which spelling the API returned.
+const CANONICAL_TO_EDITOR: Record<string, string> = {
+  singleton: 'single-region',
+  'active-hot-standby': 'active-hotstandby',
+  'active-active': 'active-active',
+}
+function toEditorMode(raw: string): string {
+  const s = raw.trim().toLowerCase()
+  return CANONICAL_TO_EDITOR[s] ?? s
 }
 
 function readTopologies(cat: CatalogItem): string[] {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
@@ -417,7 +417,7 @@ export function CatalogDetail() {
         // #3090 / #3165 — shared CLASS-page instances list + "+ New
         // instance" (inline topology-picker dialog). Instance rows link
         // to the INSTANCE page `/app/$componentId`.
-        <InstancesSection blueprint={`bp-${name}`} />
+        <InstancesSection blueprint={`bp-${name}`} multiInstance={multiInstance} />
       )}
 
       {/* Supported topologies */}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogEditDialog.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogEditDialog.tsx
@@ -1,100 +1,29 @@
 /**
- * CatalogEditDialog — #3603 (EPIC #3597): the sovereign-admin edit form for
- * a single catalog entry.
+ * CatalogEditDialog — #3603 (EPIC #3597): modal wrapper around the reusable
+ * CatalogEditForm (#3648, founder item #1).
  *
- * Founder point 3 (2026-06-15): "a real catalog where the admin can edit
- * each app's topology, name, light/dark icons." This dialog is the Edit
- * affordance's form, opened from the Catalog page's per-card Edit button
- * (admin-only). It changes:
- *
- *   • display name      (text)
- *   • summary           (text)
- *   • supported topologies (multiselect — reuses TopologyEditor's ALL_MODES
- *     + describeMode so the vocabulary never diverges from the post-create
- *     Topology editor)
- *   • light icon        (URL or file upload → data: URI)
- *   • dark icon         (URL or file upload → data: URI)
- *
- * Save persists via the #3602 API (saveCatalogEdit → PUT/POST
- * /api/v1/sme/commerce/apps); the parent refreshes so the card reflects the
- * new name + icon live, and the overlay makes the edit survive a reload.
+ * The edit FORM now lives in CatalogEditForm so the catalog DETAIL page can
+ * render it inline (edit-in-place — the founder's "the page must be editable"
+ * directive). This dialog is the modal presentation, retained for any caller
+ * that still wants a popup; the catalog flow opens the inline editor on the
+ * detail page instead. Testids + behaviour are preserved so existing tests
+ * keep passing.
  */
 
-import { useState } from 'react'
-import { ALL_MODES, describeMode } from '@/widgets/topology/TopologyEditor'
-import { saveCatalogEdit, type CatalogEntryEdit } from '@/lib/commerce.api'
+import { CatalogEditForm, type CatalogEditFormInitial } from './CatalogEditForm'
+import { type CatalogEntryEdit } from '@/lib/commerce.api'
 
 export interface CatalogEditDialogProps {
   /** Catalog entry id (may be `bp-`-prefixed) — keyed to the store slug. */
   blueprintId: string
   /** Initial form values from the current catalog card. */
-  initial: {
-    name: string
-    summary: string
-    supportedTopologies: string[]
-    iconLight: string
-    iconDark: string
-  }
+  initial: CatalogEditFormInitial
   onClose: () => void
   /** Called with the edited fields after a successful save. */
   onSaved: (edit: CatalogEntryEdit & { slug: string }) => void
 }
 
-/** Read a chosen file as a data: URI so an uploaded icon is self-contained. */
-function fileToDataURI(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => resolve(String(reader.result ?? ''))
-    reader.onerror = () => reject(reader.error ?? new Error('file read failed'))
-    reader.readAsDataURL(file)
-  })
-}
-
 export function CatalogEditDialog({ blueprintId, initial, onClose, onSaved }: CatalogEditDialogProps) {
-  const [name, setName] = useState(initial.name)
-  const [summary, setSummary] = useState(initial.summary)
-  const [topologies, setTopologies] = useState<string[]>(initial.supportedTopologies ?? [])
-  const [iconLight, setIconLight] = useState(initial.iconLight)
-  const [iconDark, setIconDark] = useState(initial.iconDark)
-  const [saving, setSaving] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  const toggleTopology = (mode: string) => {
-    setTopologies((prev) =>
-      prev.includes(mode) ? prev.filter((m) => m !== mode) : [...prev, mode],
-    )
-  }
-
-  const onPickIcon = async (which: 'light' | 'dark', file: File | undefined) => {
-    if (!file) return
-    try {
-      const uri = await fileToDataURI(file)
-      if (which === 'light') setIconLight(uri)
-      else setIconDark(uri)
-    } catch (e) {
-      setError(`icon upload failed: ${e instanceof Error ? e.message : String(e)}`)
-    }
-  }
-
-  const onSave = async () => {
-    setSaving(true)
-    setError(null)
-    const edit: CatalogEntryEdit = {
-      name: name.trim(),
-      tagline: summary.trim(),
-      supported_topologies: topologies,
-      icon_light: iconLight.trim(),
-      icon_dark: iconDark.trim(),
-    }
-    try {
-      const slug = await saveCatalogEdit(blueprintId, edit)
-      onSaved({ ...edit, slug })
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
-      setSaving(false)
-    }
-  }
-
   return (
     <div
       className="catalog-edit-backdrop"
@@ -103,7 +32,7 @@ export function CatalogEditDialog({ blueprintId, initial, onClose, onSaved }: Ca
         if (e.target === e.currentTarget) onClose()
       }}
     >
-      <style>{CATALOG_EDIT_CSS}</style>
+      <style>{CATALOG_EDIT_DIALOG_CSS}</style>
       <div
         className="catalog-edit-dialog"
         role="dialog"
@@ -117,122 +46,18 @@ export function CatalogEditDialog({ blueprintId, initial, onClose, onSaved }: Ca
             ×
           </button>
         </div>
-
-        <label className="ce-field">
-          <span className="ce-label">Display name</span>
-          <input
-            type="text"
-            className="ce-input"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            data-testid="catalog-edit-name"
-            placeholder="WordPress"
-          />
-        </label>
-
-        <label className="ce-field">
-          <span className="ce-label">Summary</span>
-          <textarea
-            className="ce-input ce-textarea"
-            value={summary}
-            onChange={(e) => setSummary(e.target.value)}
-            data-testid="catalog-edit-summary"
-            rows={2}
-            placeholder="One-line description shown on the card"
-          />
-        </label>
-
-        <div className="ce-field">
-          <span className="ce-label">Supported topologies</span>
-          <div className="ce-topos" data-testid="catalog-edit-topologies">
-            {ALL_MODES.map((mode) => (
-              <label key={mode} className="ce-topo" title={describeMode(mode)}>
-                <input
-                  type="checkbox"
-                  checked={topologies.includes(mode)}
-                  onChange={() => toggleTopology(mode)}
-                  data-testid={`catalog-edit-topo-${mode}`}
-                />
-                <span className="ce-topo-label">{mode}</span>
-              </label>
-            ))}
-          </div>
-        </div>
-
-        <div className="ce-field">
-          <span className="ce-label">Light-theme icon</span>
-          <div className="ce-icon-row">
-            <input
-              type="text"
-              className="ce-input"
-              value={iconLight}
-              onChange={(e) => setIconLight(e.target.value)}
-              data-testid="catalog-edit-icon-light"
-              placeholder="https://… or upload"
-            />
-            <label className="ce-upload" data-testid="catalog-edit-icon-light-upload-label">
-              Upload
-              <input
-                type="file"
-                accept="image/*"
-                className="ce-file"
-                data-testid="catalog-edit-icon-light-upload"
-                onChange={(e) => onPickIcon('light', e.target.files?.[0])}
-              />
-            </label>
-          </div>
-        </div>
-
-        <div className="ce-field">
-          <span className="ce-label">Dark-theme icon</span>
-          <div className="ce-icon-row">
-            <input
-              type="text"
-              className="ce-input"
-              value={iconDark}
-              onChange={(e) => setIconDark(e.target.value)}
-              data-testid="catalog-edit-icon-dark"
-              placeholder="https://… or upload"
-            />
-            <label className="ce-upload" data-testid="catalog-edit-icon-dark-upload-label">
-              Upload
-              <input
-                type="file"
-                accept="image/*"
-                className="ce-file"
-                data-testid="catalog-edit-icon-dark-upload"
-                onChange={(e) => onPickIcon('dark', e.target.files?.[0])}
-              />
-            </label>
-          </div>
-        </div>
-
-        {error ? (
-          <p className="ce-error" data-testid="catalog-edit-error" role="alert">
-            {error}
-          </p>
-        ) : null}
-
-        <div className="ce-actions">
-          <button type="button" className="ce-btn ce-btn-ghost" onClick={onClose} disabled={saving}>
-            Cancel
-          </button>
-          <button
-            type="button"
-            className="ce-btn ce-btn-primary"
-            onClick={onSave}
-            disabled={saving}
-            data-testid="catalog-edit-save"
-          >
-            {saving ? 'Saving…' : 'Save'}
-          </button>
-        </div>
+        <CatalogEditForm
+          blueprintId={blueprintId}
+          initial={initial}
+          onSaved={onSaved}
+          onCancel={onClose}
+        />
       </div>
     </div>
   )
 }
 
-const CATALOG_EDIT_CSS = `
+const CATALOG_EDIT_DIALOG_CSS = `
 .catalog-edit-backdrop {
   position: fixed; inset: 0; z-index: 1000;
   background: rgba(0,0,0,0.55);
@@ -256,38 +81,4 @@ const CATALOG_EDIT_CSS = `
   font-size: 1.4rem; line-height: 1; color: var(--color-text-dim);
 }
 .ce-close:hover { color: var(--color-text); }
-.ce-field { display: flex; flex-direction: column; gap: 0.3rem; }
-.ce-label { font-size: 0.78rem; font-weight: 600; color: var(--color-text-strong); }
-.ce-input {
-  width: 100%; padding: 0.5rem 0.7rem;
-  background: var(--color-bg, var(--color-surface));
-  border: 1px solid var(--color-border); border-radius: 8px;
-  color: var(--color-text); font: inherit; font-size: 0.85rem;
-}
-.ce-input:focus { outline: 2px solid var(--color-accent); border-color: transparent; }
-.ce-textarea { resize: vertical; }
-.ce-topos { display: flex; flex-wrap: wrap; gap: 0.6rem; }
-.ce-topo { display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.8rem; cursor: pointer; color: var(--color-text); }
-.ce-topo-label { text-transform: none; }
-.ce-icon-row { display: flex; gap: 0.5rem; align-items: center; }
-.ce-icon-row .ce-input { flex: 1; }
-.ce-upload {
-  position: relative; flex: 0 0 auto;
-  padding: 0.5rem 0.8rem; border-radius: 8px;
-  border: 1px solid var(--color-border); background: transparent;
-  color: var(--color-text); font-size: 0.8rem; cursor: pointer; white-space: nowrap;
-}
-.ce-upload:hover { border-color: var(--color-accent); }
-.ce-file { position: absolute; inset: 0; opacity: 0; cursor: pointer; }
-.ce-error { margin: 0; color: var(--color-danger); font-size: 0.8rem; }
-.ce-actions { display: flex; justify-content: flex-end; gap: 0.6rem; margin-top: 0.4rem; }
-.ce-btn {
-  padding: 0.5rem 1.1rem; border-radius: 8px; border: 1px solid transparent;
-  font: inherit; font-size: 0.85rem; font-weight: 600; cursor: pointer;
-}
-.ce-btn:disabled { opacity: 0.6; cursor: wait; }
-.ce-btn-ghost { background: transparent; border-color: var(--color-border); color: var(--color-text); }
-.ce-btn-ghost:hover:not(:disabled) { border-color: var(--color-accent); }
-.ce-btn-primary { background: var(--color-accent); color: #fff; }
-.ce-btn-primary:hover:not(:disabled) { filter: brightness(0.92); }
 `

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogEditForm.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogEditForm.tsx
@@ -1,0 +1,259 @@
+/**
+ * CatalogEditForm — #3648 (founder item #1, 2026-06-16): the reusable
+ * catalog-entry edit FORM, extracted from CatalogEditDialog so the edit
+ * happens INLINE on the catalog detail page (/catalog/bp-<name>) rather than
+ * in a separate chip + modal.
+ *
+ * "Editing the catalog item on a separate edit chip and popup is a very bad
+ *  idea. We already have the individual page and the page must be editable."
+ *
+ * This component is the form body ONLY — no backdrop, no dialog chrome — so
+ * it drops straight into the detail page in an edit-in-place panel. The
+ * modal wrapper (CatalogEditDialog) now just renders <CatalogEditForm> inside
+ * its backdrop, so the two surfaces never diverge. Fields:
+ *
+ *   • display name      (text)
+ *   • summary           (text)
+ *   • supported topologies (multiselect — reuses TopologyEditor's ALL_MODES
+ *     + describeMode so the vocabulary never diverges from the post-create
+ *     Topology editor)
+ *   • light icon        (URL or file upload → data: URI)
+ *   • dark icon         (URL or file upload → data: URI)
+ *
+ * Save persists via saveCatalogEdit (PUT/POST /api/v1/sme/commerce/apps); the
+ * caller's onSaved refreshes the page so the new name/icon/topologies render
+ * live.
+ */
+
+import { useState } from 'react'
+import { ALL_MODES, describeMode } from '@/widgets/topology/TopologyEditor'
+import { saveCatalogEdit, type CatalogEntryEdit } from '@/lib/commerce.api'
+
+export interface CatalogEditFormInitial {
+  name: string
+  summary: string
+  supportedTopologies: string[]
+  iconLight: string
+  iconDark: string
+}
+
+export interface CatalogEditFormProps {
+  /** Catalog entry id (may be `bp-`-prefixed) — keyed to the store slug. */
+  blueprintId: string
+  /** Initial form values from the current catalog entry. */
+  initial: CatalogEditFormInitial
+  /** Called with the edited fields after a successful save. */
+  onSaved: (edit: CatalogEntryEdit & { slug: string }) => void
+  /** Called when the operator cancels (closes the inline editor / modal). */
+  onCancel: () => void
+}
+
+/** Read a chosen file as a data: URI so an uploaded icon is self-contained. */
+export function fileToDataURI(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result ?? ''))
+    reader.onerror = () => reject(reader.error ?? new Error('file read failed'))
+    reader.readAsDataURL(file)
+  })
+}
+
+export function CatalogEditForm({ blueprintId, initial, onSaved, onCancel }: CatalogEditFormProps) {
+  const [name, setName] = useState(initial.name)
+  const [summary, setSummary] = useState(initial.summary)
+  const [topologies, setTopologies] = useState<string[]>(initial.supportedTopologies ?? [])
+  const [iconLight, setIconLight] = useState(initial.iconLight)
+  const [iconDark, setIconDark] = useState(initial.iconDark)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const toggleTopology = (mode: string) => {
+    setTopologies((prev) =>
+      prev.includes(mode) ? prev.filter((m) => m !== mode) : [...prev, mode],
+    )
+  }
+
+  const onPickIcon = async (which: 'light' | 'dark', file: File | undefined) => {
+    if (!file) return
+    try {
+      const uri = await fileToDataURI(file)
+      if (which === 'light') setIconLight(uri)
+      else setIconDark(uri)
+    } catch (e) {
+      setError(`icon upload failed: ${e instanceof Error ? e.message : String(e)}`)
+    }
+  }
+
+  const onSave = async () => {
+    setSaving(true)
+    setError(null)
+    const edit: CatalogEntryEdit = {
+      name: name.trim(),
+      tagline: summary.trim(),
+      supported_topologies: topologies,
+      icon_light: iconLight.trim(),
+      icon_dark: iconDark.trim(),
+    }
+    try {
+      const slug = await saveCatalogEdit(blueprintId, edit)
+      onSaved({ ...edit, slug })
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="ce-form" data-testid="catalog-edit-form">
+      <style>{CATALOG_EDIT_FORM_CSS}</style>
+
+      <label className="ce-field">
+        <span className="ce-label">Display name</span>
+        <input
+          type="text"
+          className="ce-input"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          data-testid="catalog-edit-name"
+          placeholder="WordPress"
+        />
+      </label>
+
+      <label className="ce-field">
+        <span className="ce-label">Summary</span>
+        <textarea
+          className="ce-input ce-textarea"
+          value={summary}
+          onChange={(e) => setSummary(e.target.value)}
+          data-testid="catalog-edit-summary"
+          rows={2}
+          placeholder="One-line description shown on the card"
+        />
+      </label>
+
+      <div className="ce-field">
+        <span className="ce-label">Supported topologies</span>
+        <div className="ce-topos" data-testid="catalog-edit-topologies">
+          {ALL_MODES.map((mode) => (
+            <label key={mode} className="ce-topo" title={describeMode(mode)}>
+              <input
+                type="checkbox"
+                checked={topologies.includes(mode)}
+                onChange={() => toggleTopology(mode)}
+                data-testid={`catalog-edit-topo-${mode}`}
+              />
+              <span className="ce-topo-label">{mode}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="ce-field">
+        <span className="ce-label">Light-theme icon</span>
+        <div className="ce-icon-row">
+          <input
+            type="text"
+            className="ce-input"
+            value={iconLight}
+            onChange={(e) => setIconLight(e.target.value)}
+            data-testid="catalog-edit-icon-light"
+            placeholder="https://… or upload"
+          />
+          <label className="ce-upload" data-testid="catalog-edit-icon-light-upload-label">
+            Upload
+            <input
+              type="file"
+              accept="image/*"
+              className="ce-file"
+              data-testid="catalog-edit-icon-light-upload"
+              onChange={(e) => onPickIcon('light', e.target.files?.[0])}
+            />
+          </label>
+        </div>
+      </div>
+
+      <div className="ce-field">
+        <span className="ce-label">Dark-theme icon</span>
+        <div className="ce-icon-row">
+          <input
+            type="text"
+            className="ce-input"
+            value={iconDark}
+            onChange={(e) => setIconDark(e.target.value)}
+            data-testid="catalog-edit-icon-dark"
+            placeholder="https://… or upload"
+          />
+          <label className="ce-upload" data-testid="catalog-edit-icon-dark-upload-label">
+            Upload
+            <input
+              type="file"
+              accept="image/*"
+              className="ce-file"
+              data-testid="catalog-edit-icon-dark-upload"
+              onChange={(e) => onPickIcon('dark', e.target.files?.[0])}
+            />
+          </label>
+        </div>
+      </div>
+
+      {error ? (
+        <p className="ce-error" data-testid="catalog-edit-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <div className="ce-actions">
+        <button type="button" className="ce-btn ce-btn-ghost" onClick={onCancel} disabled={saving}>
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="ce-btn ce-btn-primary"
+          onClick={onSave}
+          disabled={saving}
+          data-testid="catalog-edit-save"
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+const CATALOG_EDIT_FORM_CSS = `
+.ce-form { display: flex; flex-direction: column; gap: 0.85rem; }
+.ce-field { display: flex; flex-direction: column; gap: 0.3rem; }
+.ce-label { font-size: 0.78rem; font-weight: 600; color: var(--color-text-strong); }
+.ce-input {
+  width: 100%; padding: 0.5rem 0.7rem;
+  background: var(--color-bg, var(--color-surface));
+  border: 1px solid var(--color-border); border-radius: 8px;
+  color: var(--color-text); font: inherit; font-size: 0.85rem;
+}
+.ce-input:focus { outline: 2px solid var(--color-accent); border-color: transparent; }
+.ce-textarea { resize: vertical; }
+.ce-topos { display: flex; flex-wrap: wrap; gap: 0.6rem; }
+.ce-topo { display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.8rem; cursor: pointer; color: var(--color-text); }
+.ce-topo-label { text-transform: none; }
+.ce-icon-row { display: flex; gap: 0.5rem; align-items: center; }
+.ce-icon-row .ce-input { flex: 1; }
+.ce-upload {
+  position: relative; flex: 0 0 auto;
+  padding: 0.5rem 0.8rem; border-radius: 8px;
+  border: 1px solid var(--color-border); background: transparent;
+  color: var(--color-text); font-size: 0.8rem; cursor: pointer; white-space: nowrap;
+}
+.ce-upload:hover { border-color: var(--color-accent); }
+.ce-file { position: absolute; inset: 0; opacity: 0; cursor: pointer; }
+.ce-error { margin: 0; color: var(--color-danger); font-size: 0.8rem; }
+.ce-actions { display: flex; justify-content: flex-end; gap: 0.6rem; margin-top: 0.4rem; }
+.ce-btn {
+  padding: 0.5rem 1.1rem; border-radius: 8px; border: 1px solid transparent;
+  font: inherit; font-size: 0.85rem; font-weight: 600; cursor: pointer;
+}
+.ce-btn:disabled { opacity: 0.6; cursor: wait; }
+.ce-btn-ghost { background: transparent; border-color: var(--color-border); color: var(--color-text); }
+.ce-btn-ghost:hover:not(:disabled) { border-color: var(--color-accent); }
+.ce-btn-primary { background: var(--color-accent); color: #fff; }
+.ce-btn-primary:hover:not(:disabled) { filter: brightness(0.92); }
+`

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogPage.edit.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogPage.edit.test.tsx
@@ -115,52 +115,27 @@ describe('CatalogPage admin edit (#3603)', () => {
     expect(screen.queryByTestId('sov-app-edit-bp-cilium')).toBeNull()
   })
 
-  it('opens the edit form (name / topologies / icons) on Edit click', async () => {
+  // #3648 (founder item #1) — the popup editor was removed; the Edit chip now
+  // navigates to the catalog DETAIL page, which edits in place. The form
+  // fields + save + topology multiselect are covered by the CatalogEditDialog
+  // + CatalogDetail tests; here we lock in that the chip navigates and that
+  // NO popup is mounted on the grid page anymore.
+  it('navigates to the catalog detail page on Edit click (no popup)', async () => {
     renderCatalog()
     fireEvent.click(await screen.findByTestId('sov-app-edit-bp-cilium'))
-    const dialog = await screen.findByTestId('catalog-edit-dialog')
-    expect(within(dialog).getByTestId('catalog-edit-name')).toBeTruthy()
-    expect(within(dialog).getByTestId('catalog-edit-topologies')).toBeTruthy()
-    expect(within(dialog).getByTestId('catalog-edit-icon-light')).toBeTruthy()
-    expect(within(dialog).getByTestId('catalog-edit-icon-dark')).toBeTruthy()
-    // Topology multiselect exposes the canonical ALL_MODES options.
-    expect(within(dialog).getByTestId('catalog-edit-topo-single-region')).toBeTruthy()
-    expect(within(dialog).getByTestId('catalog-edit-topo-active-active')).toBeTruthy()
-    expect(within(dialog).getByTestId('catalog-edit-topo-active-hotstandby')).toBeTruthy()
+    expect(await screen.findByTestId('catalog-detail-target')).toBeTruthy()
+    expect(screen.queryByTestId('catalog-edit-dialog')).toBeNull()
   })
 
-  it('saves the edit via the #3602 API with the typed body', async () => {
-    renderCatalog()
-    fireEvent.click(await screen.findByTestId('sov-app-edit-bp-cilium'))
-    const dialog = await screen.findByTestId('catalog-edit-dialog')
-    fireEvent.change(within(dialog).getByTestId('catalog-edit-name'), {
-      target: { value: 'Cilium (Edited)' },
-    })
-    fireEvent.click(within(dialog).getByTestId('catalog-edit-topo-active-active'))
-    fireEvent.change(within(dialog).getByTestId('catalog-edit-icon-dark'), {
-      target: { value: 'https://cdn/cilium-dark.svg' },
-    })
-    fireEvent.click(within(dialog).getByTestId('catalog-edit-save'))
+  // (The save itself — the #3602 API call with the typed body — now happens in
+  // the inline CatalogEditForm on the detail page; it is covered by the
+  // CatalogEditDialog + CatalogDetail tests, not on the grid page.)
 
-    await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(1))
-    const [slugArg, editArg] = saveSpy.mock.calls[0]
-    expect(slugArg).toBe('bp-cilium')
-    expect(editArg).toMatchObject({
-      name: 'Cilium (Edited)',
-      icon_dark: 'https://cdn/cilium-dark.svg',
-    })
-    expect(editArg.supported_topologies).toContain('active-active')
-  })
-
-  it('reflects a saved name on the card after the edits refetch', async () => {
-    renderCatalog()
-    await screen.findByTestId('sov-app-card-bp-cilium')
-    // After a save the edits query refetches; simulate the store now
-    // carrying the renamed cilium row, then trigger the dialog save path.
+  it('reflects a saved name on the card from the edits overlay', async () => {
+    // The edits overlay (listApps) carries a renamed cilium row; the grid card
+    // must render the edited name regardless of where the edit was made.
     listAppsHolder.value = [{ slug: 'cilium', name: 'Cilium (Renamed)' }]
-    fireEvent.click(screen.getByTestId('sov-app-edit-bp-cilium'))
-    fireEvent.click(await screen.findByTestId('catalog-edit-save'))
-    // editsQuery.refetch() re-reads listApps → the card title updates.
+    renderCatalog()
     await waitFor(() => {
       const card = screen.getByTestId('sov-app-card-bp-cilium')
       expect(within(card).getByText('Cilium (Renamed)')).toBeTruthy()

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogPage.tsx
@@ -28,7 +28,7 @@ import { authedFetch } from '@/shared/lib/authedFetch'
 import { useWizardStore } from '@/entities/deployment/store'
 import { PortalShell } from './PortalShell'
 import { AppCard } from './AppsPage'
-import { CatalogEditDialog } from './CatalogEditDialog'
+import { useNavigate } from '@tanstack/react-router'
 import { resolveApplications, type ApplicationDescriptor } from './applicationCatalog'
 import type { ApplicationStatus } from './eventReducer'
 import { useCatalogAdmin } from '@/shared/lib/useCatalogAdmin'
@@ -171,8 +171,9 @@ export function CatalogPage() {
   })
   const editsBySlug = editsQuery.data ?? {}
 
-  // The catalog entry currently open in the edit dialog (null = closed).
-  const [editing, setEditing] = useState<ApplicationDescriptor | null>(null)
+  // #3648 (founder item #1) — the popup editor was removed; the admin Edit
+  // chip navigates to the catalog detail page, which edits in place.
+  const navigate = useNavigate()
 
   const [query, setQuery] = useState('')
 
@@ -256,7 +257,19 @@ export function CatalogPage() {
                 slug={slug}
                 iconLight={edit?.iconLight}
                 iconDark={edit?.iconDark}
-                onEdit={isAdmin ? () => setEditing(app) : undefined}
+                onEdit={
+                  isAdmin
+                    ? () => {
+                        // Chroot-aware: on the mothership provision monitor the
+                        // catalog lives under /provision/$deploymentId/…; on the
+                        // Sovereign's own console it is the bare /catalog/….
+                        const detail = deploymentId
+                          ? `/provision/${deploymentId}/catalog/${slug}`
+                          : `/catalog/${slug}`
+                        void navigate({ to: detail as never })
+                      }
+                    : undefined
+                }
                 onPublishedChange={async (next) => {
                   const r = await authedFetch(
                     `${API_BASE}/v1/sovereign/apps/${encodeURIComponent(slug)}/publish`,
@@ -278,30 +291,9 @@ export function CatalogPage() {
         </div>
       )}
 
-      {/* #3603 — the admin edit form. Mounted only while an entry is being
-       * edited; saving persists via the #3602 API and refetches the edits
-       * map so the card reflects the new name + icon live. */}
-      {editing ? (
-        <CatalogEditDialog
-          blueprintId={editing.id}
-          initial={(() => {
-            const slug = editing.id.replace(/^bp-/, '')
-            const e = editsBySlug[slug]
-            return {
-              name: e?.name || editing.title,
-              summary: e?.summary || editing.description || '',
-              supportedTopologies: e?.supportedTopologies ?? [],
-              iconLight: e?.iconLight ?? '',
-              iconDark: e?.iconDark ?? '',
-            }
-          })()}
-          onClose={() => setEditing(null)}
-          onSaved={async () => {
-            setEditing(null)
-            await editsQuery.refetch()
-          }}
-        />
-      ) : null}
+      {/* #3648 (founder item #1) — the popup editor was removed. Editing now
+          happens inline on the catalog detail page (/catalog/$blueprintName);
+          the admin Edit chip above navigates there. */}
     </PortalShell>
   )
 }

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.test.tsx
@@ -52,6 +52,32 @@ describe('TopologyEditor — mode picker', () => {
     const apply = screen.getByTestId('topology-editor-apply-btn') as HTMLButtonElement
     expect(apply.disabled).toBe(false)
   })
+
+  it('constrains the picker to the Blueprint supported topologies (#3648)', () => {
+    render(
+      withProviders(
+        <TopologyEditor
+          sovereignId="dep-1"
+          applicationName="grafana"
+          currentMode="active-hotstandby"
+          currentRegions={['hz-fsn-rtz-prod']}
+          availableRegions={['hz-fsn-rtz-prod', 'hz-hel-rtz-prod']}
+          supportedCanonical={['singleton', 'active-hot-standby']}
+          disableNetwork
+        />,
+      ),
+    )
+    // active-hotstandby canonicalises to active-hot-standby → supported → enabled
+    const hot = screen.getByTestId('topology-editor-mode-active-hotstandby-radio') as HTMLInputElement
+    expect(hot.disabled).toBe(false)
+    // single-region canonicalises to singleton → supported → enabled
+    const single = screen.getByTestId('topology-editor-mode-single-region-radio') as HTMLInputElement
+    expect(single.disabled).toBe(false)
+    // active-active is NOT in the Blueprint's supported set → disabled (the
+    // contradiction the operator flagged 3×: never offer an unsupported mode).
+    const aa = screen.getByTestId('topology-editor-mode-active-active-radio') as HTMLInputElement
+    expect(aa.disabled).toBe(true)
+  })
 })
 
 describe('TopologyEditor — destructive transitions', () => {

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.tsx
@@ -47,6 +47,14 @@ export interface TopologyEditorProps {
   namespace?: string
   /** Blueprint card backing this Application — used to constrain modes. */
   blueprint?: CatalogItem
+  /**
+   * #3648 — the Blueprint's canonical SupportedTopologies (singleton /
+   * active-active / active-hot-standby / active-passive). When provided, the
+   * picker offers ONLY the modes the Blueprint supports, never one it
+   * doesn't (the AppDetail "active-active on a hot-standby-only app"
+   * contradiction). Falls back to placementSchema.modes / ALL_MODES.
+   */
+  supportedCanonical?: string[]
   /** Fired after a successful Apply. */
   onApplied?: () => void
   /** Test seam — bypass the network call for snapshot testing. */
@@ -64,6 +72,30 @@ export const ALL_MODES = ['single-region', 'active-active', 'active-hotstandby']
 
 export type TopologyMode = (typeof ALL_MODES)[number]
 
+/**
+ * canonicalizeMode (#3648) maps BOTH the editor dialect (single-region /
+ * active-hotstandby) AND the canonical matrix vocabulary (singleton /
+ * active-hot-standby / active-passive) onto one token, so the
+ * supported-constraint can compare an ALL_MODES entry against a Blueprint's
+ * canonical SupportedTopologies regardless of spelling.
+ */
+export function canonicalizeMode(raw: string): string {
+  switch (raw.trim().toLowerCase()) {
+    case 'active-hot-standby':
+    case 'active-hotstandby':
+      return 'active-hot-standby'
+    case 'active-passive':
+      return 'active-passive'
+    case 'active-active':
+      return 'active-active'
+    case 'singleton':
+    case 'single-region':
+      return 'singleton'
+    default:
+      return raw.trim().toLowerCase()
+  }
+}
+
 export function TopologyEditor({
   sovereignId,
   applicationName,
@@ -72,6 +104,7 @@ export function TopologyEditor({
   availableRegions,
   namespace,
   blueprint,
+  supportedCanonical,
   onApplied,
   disableNetwork = false,
 }: TopologyEditorProps) {
@@ -94,12 +127,22 @@ export function TopologyEditor({
   }, [currentMode, applicationName, currentRegions])
 
   const allowedModes = useMemo(() => {
+    // #3648 — prefer the Blueprint's canonical SupportedTopologies (the
+    // topology-matrix truth) so the picker never offers a mode the Blueprint
+    // doesn't support (e.g. active-active on a hot-standby-only app — the
+    // AppDetail contradiction the operator flagged 3×). Compare canonically
+    // so the editor dialect (active-hotstandby) matches the canonical form
+    // (active-hot-standby).
+    if (Array.isArray(supportedCanonical) && supportedCanonical.length > 0) {
+      const canon = new Set(supportedCanonical.map(canonicalizeMode))
+      return new Set<string>(ALL_MODES.filter((m) => canon.has(canonicalizeMode(m))))
+    }
     const fromSchema = blueprint?.placementSchema?.modes
     if (Array.isArray(fromSchema) && fromSchema.length > 0) {
       return new Set(fromSchema)
     }
     return new Set<string>(ALL_MODES)
-  }, [blueprint])
+  }, [supportedCanonical, blueprint])
 
   const isDirty = mode !== currentMode || !sameRegionSet(regions, currentRegions)
 


### PR DESCRIPTION
## What
Canonicalise the topology `override` in `chooseTopology` (catalyst-api create + placement path) so the catalyst-ui placement-editor dialect (`single-region` / `active-active` / `active-hotstandby`) resolves against the Blueprint's canonical `SupportedTopologies` (`singleton` / `active-active` / `active-hot-standby` / `active-passive`).

## Why
Founder-reported (item #3, 2026-06-16 review): creating a postgres data-instance with **any** topology failed `topology "active-hotstandby" not in supported [singleton active-hot-standby] (invalid-topology)`. The UI posts the editor dialect; the validator did an exact string match → `active-hotstandby` ≠ `active-hot-standby`. Same dual-vocabulary underlies the AppDetail placement contradiction (item #2).

## UAT (founder-walk)
1. Create a postgres instance with `active-hotstandby` + 2 regions → **succeeds**.
2. Create with `singleton` / `single-region` → succeeds.
3. An unsupported value (`active-active` for postgres) is still rejected.

Regression test: `TestChooseTopology_CanonicalisesEditorDialect`. Refs #3648 (backend half; the UI constrain-to-supported half tracked there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)