### PR TITLE
feat(catalyst-api): catalog edit writes IaC — commit to local catalog git, not a divergent store (#3648)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/catalog_edit_blueprint_yaml.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_edit_blueprint_yaml.go
@@ -1,0 +1,192 @@
+// Package handler — catalog_edit_blueprint_yaml.go: #3648 (train/hw150).
+//
+// The bridge between the catalog-edit wire shape (catalogEdit — the
+// commerce store.App subset the UI's CatalogEntryEdit carries) and the
+// Blueprint CR YAML that lives in the catalog-sovereign Gitea Org. These
+// helpers are PURE (no I/O) so they unit-test in isolation; the git
+// read/write lives in catalog_edit_git.go.
+//
+// Field mapping (catalog edit ⇄ Blueprint CR spec), matching the seed CR
+// shape in products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+// and the read overlay in catalog_overlay.go:
+//
+//	edit.Name                → spec.card.title
+//	edit.Tagline             → spec.card.summary
+//	edit.IconLight           → spec.card.iconLight
+//	edit.IconDark            → spec.card.iconDark
+//	edit.Icon                → spec.card.icon       (legacy single icon)
+//	edit.SupportedTopologies → spec.topology.supported
+//
+// (Description is carried too for completeness — spec.card.description —
+// even though the #3603 edit form doesn't expose it; an out-of-band git
+// edit of that field still round-trips through the read path.)
+
+package handler
+
+import (
+	"fmt"
+	"strings"
+
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+// mergeCatalogEditIntoBlueprintYAML applies the edited card fields onto
+// an existing Blueprint CR (read-modify-write), or synthesises a minimal
+// CR when `existing` is empty/unparseable. Returns the re-serialised
+// YAML bytes ready to commit.
+//
+// The merge is a deep map merge that preserves every field the source CR
+// already carries (spec.source, spec.version, spec.manifests, labels …)
+// and only sets the edited card keys + supported topologies. A
+// non-empty edit field overwrites; an empty edit field is left as-is so
+// a partial edit never clobbers a value the admin didn't touch.
+func mergeCatalogEditIntoBlueprintYAML(existing []byte, bpName string, edit catalogEdit) ([]byte, error) {
+	doc := map[string]interface{}{}
+	if len(strings.TrimSpace(string(existing))) > 0 {
+		if err := yamlv3.Unmarshal(existing, &doc); err != nil {
+			// Corrupt source — start from a fresh minimal CR rather than
+			// fail the edit (the edit is the new source of truth anyway).
+			doc = map[string]interface{}{}
+		}
+	}
+
+	// Canonical envelope — set only when absent so an existing CR keeps
+	// its own apiVersion/kind/metadata.name.
+	setIfAbsent(doc, "apiVersion", "catalyst.openova.io/v1")
+	setIfAbsent(doc, "kind", "Blueprint")
+	meta := childMap(doc, "metadata")
+	if strings.TrimSpace(asString(meta["name"])) == "" {
+		meta["name"] = bpName
+	}
+
+	spec := childMap(doc, "spec")
+	// A Blueprint CR requires spec.version; when synthesising fresh, stamp
+	// a placeholder so the projector + validateBlueprintYAML accept it.
+	// An existing CR keeps its real version.
+	if strings.TrimSpace(asString(spec["version"])) == "" {
+		spec["version"] = "0.0.0"
+	}
+	if strings.TrimSpace(asString(spec["visibility"])) == "" {
+		spec["visibility"] = "listed"
+	}
+
+	card := childMap(spec, "card")
+	setIfNonEmpty(card, "title", edit.Name)
+	setIfNonEmpty(card, "summary", edit.Tagline)
+	setIfNonEmpty(card, "description", edit.Description)
+	setIfNonEmpty(card, "icon", edit.Icon)
+	setIfNonEmpty(card, "iconLight", edit.IconLight)
+	setIfNonEmpty(card, "iconDark", edit.IconDark)
+	// A card needs a title; fall back to the bare slug when neither the
+	// edit nor the existing CR carries one (the projector tolerates it,
+	// the UI shows the slug).
+	if strings.TrimSpace(asString(card["title"])) == "" {
+		card["title"] = strings.TrimPrefix(bpName, "bp-")
+	}
+
+	if len(edit.SupportedTopologies) > 0 {
+		topo := childMap(spec, "topology")
+		// Store as a plain []interface{} so yaml emits a clean sequence.
+		seq := make([]interface{}, 0, len(edit.SupportedTopologies))
+		for _, t := range edit.SupportedTopologies {
+			if s := strings.TrimSpace(t); s != "" {
+				seq = append(seq, s)
+			}
+		}
+		topo["supported"] = seq
+	}
+
+	out, err := yamlv3.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("marshal blueprint.yaml: %w", err)
+	}
+	return out, nil
+}
+
+// catalogEditFromBlueprintYAML extracts the card-overlay fields back out
+// of a Blueprint CR so the read path can surface a git-committed edit.
+// Returns (edit, true) when the YAML parses as a Blueprint with a spec;
+// (zero, false) otherwise. The slug is derived from metadata.name (its
+// `bp-` prefix stripped) so it lines up with the store-keyed slugs.
+func catalogEditFromBlueprintYAML(bpName string, raw []byte) (catalogEdit, bool) {
+	var doc map[string]interface{}
+	if err := yamlv3.Unmarshal(raw, &doc); err != nil {
+		return catalogEdit{}, false
+	}
+	spec, _ := doc["spec"].(map[string]interface{})
+	if spec == nil {
+		return catalogEdit{}, false
+	}
+	slug := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(bpName)), "bp-")
+	if meta, ok := doc["metadata"].(map[string]interface{}); ok {
+		if n := strings.TrimSpace(asString(meta["name"])); n != "" {
+			slug = strings.TrimPrefix(strings.ToLower(n), "bp-")
+		}
+	}
+	edit := catalogEdit{Slug: slug}
+	if card, ok := spec["card"].(map[string]interface{}); ok {
+		edit.Name = asString(card["title"])
+		edit.Tagline = asString(card["summary"])
+		edit.Description = asString(card["description"])
+		edit.Icon = asString(card["icon"])
+		edit.IconLight = asString(card["iconLight"])
+		edit.IconDark = asString(card["iconDark"])
+	}
+	if topo, ok := spec["topology"].(map[string]interface{}); ok {
+		edit.SupportedTopologies = asStringSlice(topo["supported"])
+	}
+	return edit, true
+}
+
+// ── tiny map helpers (yaml.v3 decodes maps as map[string]interface{}) ──
+
+// childMap returns m[key] as a map[string]interface{}, creating + storing
+// an empty one when absent or of the wrong type.
+func childMap(m map[string]interface{}, key string) map[string]interface{} {
+	if existing, ok := m[key].(map[string]interface{}); ok {
+		return existing
+	}
+	child := map[string]interface{}{}
+	m[key] = child
+	return child
+}
+
+func setIfAbsent(m map[string]interface{}, key, val string) {
+	if _, ok := m[key]; !ok {
+		m[key] = val
+	}
+}
+
+func setIfNonEmpty(m map[string]interface{}, key, val string) {
+	if strings.TrimSpace(val) != "" {
+		m[key] = val
+	}
+}
+
+func asString(v interface{}) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// asStringSlice tolerantly converts a yaml-decoded sequence (which may be
+// []interface{} of strings) to []string. Returns nil for any other shape.
+func asStringSlice(v interface{}) []string {
+	seq, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(seq))
+	for _, e := range seq {
+		if s, ok := e.(string); ok {
+			if t := strings.TrimSpace(s); t != "" {
+				out = append(out, t)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git.go
@@ -1,0 +1,195 @@
+// Package handler — catalog_edit_git.go: #3648 (train/hw150) — the
+// catalog edit becomes a git commit to the LOCAL catalog repo.
+//
+// Founder review #8 (2026-06-16): "IaC is always the single source of
+// truth. If an advanced user changes something from the code, our UI
+// gets synced to it because it always treats there as the single source
+// of truth. … For the ease of user, we allow catalog to provide an edit
+// feature so updating the IaC from the catalog UI as well."
+//
+// BEFORE this file the catalog edit (UI saveCatalogEdit → PUT/POST
+// /api/v1/sme/commerce/apps → proxyCommerce → the SME commerce catalog's
+// /catalog/admin/apps) persisted to a SEPARATE commerce-overlay store
+// (core/services/catalog store.App). That store is NOT IaC: an edit
+// never reached the catalog git, and an out-of-band git edit never
+// reached the UI. The two diverged.
+//
+// AFTER: every `apps` edit additionally COMMITS the edited card fields
+// (name, tagline, supported_topologies, icon_light, icon_dark) into the
+// per-Sovereign **catalog-sovereign** Gitea Org as a Blueprint CR
+// (`catalog-sovereign/<bp-name>/blueprint.yaml`) — the exact same repo +
+// shape the /blueprints/curate handler already writes (blueprints.go),
+// and the same source the cutover makes authoritative (the customer-sync
+// catalog mirror). The catalog projector reads that source at a HIGHER
+// priority than the public seed (resolver order PRIVATE > SOVEREIGN >
+// PUBLIC, per docs/catalog-seed/_README.txt + ADR-0001 §4.3), so a
+// committed edit wins on the next catalog read.
+//
+// git is therefore the SOURCE. The commerce store remains a pure cache /
+// projection (the existing proxyCommerce write is left intact so the API
+// response shape is byte-identical and the store stays warm), but the
+// READ overlay (fetchCatalogEdits) now prefers the git source so an
+// out-of-band edit to `catalog-sovereign/<bp>/blueprint.yaml` round-trips
+// to the UI exactly like a UI edit does.
+//
+// Graceful degradation: when the Gitea client is unwired (chroot
+// Sovereign pre-cutover / CI without a Gitea backend) the git write is a
+// best-effort no-op — the store write already succeeded, so the API call
+// still returns the catalog service's real result. The catalog edit is
+// never failed by a missing local catalog git; it merely isn't yet IaC
+// until Gitea is reachable.
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
+)
+
+// catalogEditGitBranch is the branch the catalog-sovereign Blueprint CRs
+// live on. Same default branch blueprints.go's publish/curate use.
+const catalogEditGitBranch = blueprintBranch // "main"
+
+// catalogEditCommitAuthor / Email stamp the commit so a sovereign-admin
+// scanning the catalog-sovereign repo history can tell a UI-originated
+// catalog edit from a hand-authored git push. Per Inviolable Principle #4
+// these are overridable via the canonical CATALYST_GITOPS_COMMITTER_*
+// env (shared with the tenant-gitops writer); default to the catalyst-api
+// system identity.
+func catalogEditCommitAuthor() gitea.PutFileOpts {
+	return gitea.PutFileOpts{
+		AuthorName:  envOr("CATALYST_GITOPS_COMMITTER_NAME", "catalyst-api"),
+		AuthorEmail: envOr("CATALYST_GITOPS_COMMITTER_EMAIL", "ops@openova.io"),
+	}
+}
+
+// catalogEditBlueprintName maps a bare commerce slug (`grafana`) to the
+// canonical `bp-`-prefixed Blueprint repo name (`bp-grafana`) the
+// catalog-sovereign Org keys on. Mirrors the normalizeCatalogKey ↔
+// `bp-` convention used by the read overlay.
+func catalogEditBlueprintName(slug string) string {
+	s := strings.TrimSpace(strings.ToLower(slug))
+	s = strings.TrimPrefix(s, "bp-")
+	if s == "" {
+		return ""
+	}
+	return "bp-" + s
+}
+
+// writeCatalogEditToGit commits one catalog entry's edited card fields
+// into catalog-sovereign/<bp-name>/blueprint.yaml.
+//
+// It is a READ-MODIFY-WRITE: when a Blueprint CR already exists for this
+// entry (curated earlier, or written by a prior edit) the edit is MERGED
+// onto it so non-card fields (spec.source, spec.version, spec.manifests…)
+// survive; when none exists a minimal CR carrying just the edited card +
+// supported topologies is created. Either way the result is a single git
+// commit to the local catalog repo — the IaC source of truth.
+//
+// Returns (committed, err): committed=false + err=nil when the client is
+// unwired (best-effort no-op) OR the bytes were byte-equal (PutFile
+// short-circuit). A non-nil err means the git write genuinely failed and
+// the caller decides whether to surface it (we log + continue so the
+// store-backed API response is unaffected — git is additive here).
+func (h *Handler) writeCatalogEditToGit(ctx context.Context, edit catalogEdit) (bool, error) {
+	if h.giteaClient == nil {
+		return false, nil // unwired — best-effort no-op (pre-cutover / CI)
+	}
+	bpName := catalogEditBlueprintName(edit.Slug)
+	if bpName == "" {
+		return false, fmt.Errorf("catalog-edit-git: empty slug")
+	}
+	if !edit.hasOverlay() {
+		// Nothing to persist as IaC (the proxyCommerce store write may
+		// still carry non-card columns; git only owns the card overlay).
+		return false, nil
+	}
+
+	// Ensure the catalog-sovereign Org + per-Blueprint repo exist
+	// (idempotent — same EnsureOrg/EnsureRepo blueprints.go's curate uses).
+	if _, err := h.giteaClient.EnsureOrg(ctx, catalogSovereignOrg,
+		"Sovereign-curated catalog",
+		"Curated Blueprints visible to every Org", "public"); err != nil {
+		return false, fmt.Errorf("ensure org %q: %w", catalogSovereignOrg, err)
+	}
+	if _, err := h.giteaClient.EnsureRepo(ctx, catalogSovereignOrg, bpName,
+		"Sovereign-curated Blueprint", false); err != nil {
+		return false, fmt.Errorf("ensure repo %s/%s: %w", catalogSovereignOrg, bpName, err)
+	}
+
+	// READ the existing CR (if any) so the edit is a merge, not a clobber.
+	var existing []byte
+	if f, err := h.giteaClient.GetFile(ctx, catalogSovereignOrg, bpName,
+		catalogEditGitBranch, catalogEditBlueprintPath); err == nil {
+		if b, derr := f.Decoded(); derr == nil {
+			existing = b
+		}
+	} else if !gitea.IsNotFound(err) {
+		// A real transport error reading the source (not a plain
+		// missing-file/repo) — surface it rather than silently overwriting
+		// with a fresh minimal CR.
+		return false, fmt.Errorf("get %s/%s/%s: %w", catalogSovereignOrg, bpName, catalogEditBlueprintPath, err)
+	}
+
+	merged, err := mergeCatalogEditIntoBlueprintYAML(existing, bpName, edit)
+	if err != nil {
+		return false, fmt.Errorf("merge blueprint.yaml: %w", err)
+	}
+
+	msg := fmt.Sprintf("catalog: edit %s card via catalyst-api (#3648)", bpName)
+	_, committed, err := h.giteaClient.PutFile(ctx, catalogSovereignOrg, bpName,
+		catalogEditGitBranch, catalogEditBlueprintPath, merged, msg, catalogEditCommitAuthor())
+	if err != nil {
+		return false, fmt.Errorf("put %s/%s/%s: %w", catalogSovereignOrg, bpName, catalogEditBlueprintPath, err)
+	}
+	return committed, nil
+}
+
+// fetchCatalogEditsFromGit reads every Blueprint CR in the
+// catalog-sovereign Org and indexes the card-overlay fields by normalized
+// slug — the GIT SOURCE of catalog edits. Returns an empty (non-nil) map
+// on any failure (unwired client, missing Org, unreadable file) so the
+// overlay degrades to the commerce-store projection / the seed.
+//
+// This is the read counterpart of writeCatalogEditToGit: an out-of-band
+// `git push` to catalog-sovereign/<bp>/blueprint.yaml is picked up here
+// identically to a UI edit, so the IaC round-trips to the UI.
+func (h *Handler) fetchCatalogEditsFromGit(ctx context.Context) map[string]catalogEdit {
+	edits := map[string]catalogEdit{}
+	if h.giteaClient == nil {
+		return edits
+	}
+	repos, err := h.giteaClient.ListOrgRepos(ctx, catalogSovereignOrg)
+	if err != nil {
+		return edits
+	}
+	for _, repo := range repos {
+		name := strings.TrimSpace(repo.Name)
+		if !strings.HasPrefix(name, "bp-") {
+			continue
+		}
+		f, ferr := h.giteaClient.GetFile(ctx, catalogSovereignOrg, name,
+			catalogEditGitBranch, catalogEditBlueprintPath)
+		if ferr != nil {
+			continue
+		}
+		raw, derr := f.Decoded()
+		if derr != nil || len(raw) == 0 {
+			continue
+		}
+		edit, ok := catalogEditFromBlueprintYAML(name, raw)
+		if !ok || !edit.hasOverlay() {
+			continue
+		}
+		edits[normalizeCatalogKey(name)] = edit
+	}
+	return edits
+}
+
+// catalogEditBlueprintPath is the canonical path of the Blueprint CR
+// inside its catalog-sovereign per-Blueprint repo. Matches the path
+// blueprints.go's curate writes ("blueprint.yaml").
+const catalogEditBlueprintPath = "blueprint.yaml"

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git_test.go
@@ -1,0 +1,322 @@
+// catalog_edit_git_test.go — #3648 (train/hw150) coverage for the
+// catalog-edit-to-git IaC write path.
+//
+// The DoD: a catalog edit is genuinely IaC — it produces a git commit to
+// the LOCAL catalog repo (the catalog-sovereign Gitea Org), and the
+// committed values are read back through the catalog read overlay (so an
+// out-of-band git edit round-trips to the UI). These tests pin:
+//
+//   - the pure Blueprint-CR YAML merge/parse (no I/O);
+//   - writeCatalogEditToGit → a real PutFile into catalog-sovereign;
+//   - fetchCatalogEditsFromGit reads the committed CR back;
+//   - fetchCatalogEditsMerged makes the git source WIN over the store;
+//   - commitCatalogAppEditToGit (the proxyCommerce hook) decodes the
+//     commerce App body + commits it.
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+// TestMergeCatalogEditIntoBlueprintYAML_FreshCR — with no existing CR the
+// merge synthesises a minimal-but-valid Blueprint carrying the edited
+// card + supported topologies, and the result parses back to the same
+// edit.
+func TestMergeCatalogEditIntoBlueprintYAML_FreshCR(t *testing.T) {
+	edit := catalogEdit{
+		Slug:                "grafana",
+		Name:                "Grafana (Edited)",
+		Tagline:             "Admin-curated dashboards",
+		IconLight:           "https://cdn/light.svg",
+		IconDark:            "https://cdn/dark.svg",
+		SupportedTopologies: []string{"single-region", "active-active"},
+	}
+	out, err := mergeCatalogEditIntoBlueprintYAML(nil, "bp-grafana", edit)
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+
+	// Canonical envelope present.
+	var doc map[string]interface{}
+	if err := yamlv3.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if doc["kind"] != "Blueprint" {
+		t.Errorf("kind: got %v want Blueprint", doc["kind"])
+	}
+	meta, _ := doc["metadata"].(map[string]interface{})
+	if meta == nil || meta["name"] != "bp-grafana" {
+		t.Errorf("metadata.name: got %v want bp-grafana", meta["name"])
+	}
+	spec, _ := doc["spec"].(map[string]interface{})
+	if spec == nil || strings.TrimSpace(asString(spec["version"])) == "" {
+		t.Errorf("spec.version must be stamped on a fresh CR; got %v", spec["version"])
+	}
+
+	// Round-trips back to the edit.
+	got, ok := catalogEditFromBlueprintYAML("bp-grafana", out)
+	if !ok {
+		t.Fatal("catalogEditFromBlueprintYAML returned !ok")
+	}
+	if got.Name != "Grafana (Edited)" || got.Tagline != "Admin-curated dashboards" {
+		t.Errorf("card round-trip: name=%q tagline=%q", got.Name, got.Tagline)
+	}
+	if got.IconLight != "https://cdn/light.svg" || got.IconDark != "https://cdn/dark.svg" {
+		t.Errorf("icon round-trip: light=%q dark=%q", got.IconLight, got.IconDark)
+	}
+	if len(got.SupportedTopologies) != 2 || got.SupportedTopologies[0] != "single-region" {
+		t.Errorf("topology round-trip: %v", got.SupportedTopologies)
+	}
+}
+
+// TestMergeCatalogEditIntoBlueprintYAML_PreservesExistingSpecFields — a
+// read-modify-write over a curated CR must NOT drop spec.source /
+// spec.version / spec.manifests; it only overwrites the edited card keys.
+func TestMergeCatalogEditIntoBlueprintYAML_PreservesExistingSpecFields(t *testing.T) {
+	existing := []byte(`apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-grafana
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+spec:
+  version: "9.5.1"
+  visibility: listed
+  card:
+    title: "Grafana"
+    summary: "Seed summary"
+    icon: grafana.svg
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-grafana
+    version: 9.5.1
+  manifests:
+    chart: bp-grafana
+`)
+	edit := catalogEdit{
+		Slug:                "grafana",
+		Name:                "Observability",
+		SupportedTopologies: []string{"active-active"},
+	}
+	out, err := mergeCatalogEditIntoBlueprintYAML(existing, "bp-grafana", edit)
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	var doc map[string]interface{}
+	if err := yamlv3.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	spec := doc["spec"].(map[string]interface{})
+
+	// Edited fields applied.
+	card := spec["card"].(map[string]interface{})
+	if card["title"] != "Observability" {
+		t.Errorf("edited title: got %v", card["title"])
+	}
+	// Untouched card field survives.
+	if card["summary"] != "Seed summary" {
+		t.Errorf("untouched summary must survive: got %v", card["summary"])
+	}
+	if card["icon"] != "grafana.svg" {
+		t.Errorf("untouched icon must survive: got %v", card["icon"])
+	}
+	// Real version preserved (NOT clobbered to the 0.0.0 placeholder).
+	if asString(spec["version"]) != "9.5.1" {
+		t.Errorf("existing spec.version must survive: got %v", spec["version"])
+	}
+	// spec.source + spec.manifests survive the round-trip.
+	if _, ok := spec["source"].(map[string]interface{}); !ok {
+		t.Errorf("spec.source must survive the merge; spec=%v", spec)
+	}
+	if _, ok := spec["manifests"].(map[string]interface{}); !ok {
+		t.Errorf("spec.manifests must survive the merge; spec=%v", spec)
+	}
+	// supported topologies set under spec.topology.
+	topo, ok := spec["topology"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("spec.topology must be present; spec=%v", spec)
+	}
+	if got := asStringSlice(topo["supported"]); len(got) != 1 || got[0] != "active-active" {
+		t.Errorf("spec.topology.supported: got %v", topo["supported"])
+	}
+}
+
+// TestWriteCatalogEditToGit_CommitsAndReadsBack is the core DoD: an edit
+// produces a git commit into catalog-sovereign, and the committed CR is
+// read back through fetchCatalogEditsFromGit — proving git is the source.
+func TestWriteCatalogEditToGit_CommitsAndReadsBack(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+
+	edit := catalogEdit{
+		Slug:                "cilium",
+		Name:                "Cilium (Edited)",
+		Tagline:             "eBPF networking",
+		IconLight:           "https://cdn/cilium-light.svg",
+		IconDark:            "https://cdn/cilium-dark.svg",
+		SupportedTopologies: []string{"single-region", "active-active"},
+	}
+	committed, err := h.writeCatalogEditToGit(context.Background(), edit)
+	if err != nil {
+		t.Fatalf("writeCatalogEditToGit: %v", err)
+	}
+	if !committed {
+		t.Fatalf("expected a git commit, got committed=false")
+	}
+
+	// The Blueprint CR landed at catalog-sovereign/bp-cilium/blueprint.yaml.
+	key := giteaKey(catalogSovereignOrg, "bp-cilium", catalogEditGitBranch, catalogEditBlueprintPath)
+	raw, ok := fg.files[key]
+	if !ok {
+		t.Fatalf("expected a committed blueprint.yaml at %s; have keys %v", key, fileKeys(fg))
+	}
+	if !strings.Contains(string(raw), "Cilium (Edited)") {
+		t.Errorf("committed CR missing edited title; got:\n%s", raw)
+	}
+
+	// Read it back through the git overlay source.
+	edits := h.fetchCatalogEditsFromGit(context.Background())
+	got, ok := edits["cilium"]
+	if !ok {
+		t.Fatalf("fetchCatalogEditsFromGit must surface the committed edit; got %v", editKeys(edits))
+	}
+	if got.Name != "Cilium (Edited)" || got.IconDark != "https://cdn/cilium-dark.svg" {
+		t.Errorf("read-back edit wrong: %+v", got)
+	}
+	if len(got.SupportedTopologies) != 2 {
+		t.Errorf("read-back topologies: %v", got.SupportedTopologies)
+	}
+}
+
+// TestWriteCatalogEditToGit_UnwiredIsBestEffortNoop — with no Gitea client
+// (chroot pre-cutover / CI) the write is a silent no-op, never an error,
+// so the catalog edit API never fails for lack of a local catalog git.
+func TestWriteCatalogEditToGit_UnwiredIsBestEffortNoop(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	// no SetGiteaClient → h.giteaClient == nil
+	committed, err := h.writeCatalogEditToGit(context.Background(), catalogEdit{
+		Slug: "grafana", Name: "X",
+	})
+	if err != nil {
+		t.Fatalf("unwired write must not error: %v", err)
+	}
+	if committed {
+		t.Fatalf("unwired write must not report a commit")
+	}
+}
+
+// TestFetchCatalogEditsMerged_GitSourceWinsOverStore — the read overlay
+// must treat the git source as authoritative: when both the commerce
+// store AND the catalog git carry an edit for the same entry, the git
+// value wins (IaC is the single source of truth). The store-only entry
+// still shows (git has no opinion → cache fills it).
+func TestFetchCatalogEditsMerged_GitSourceWinsOverStore(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+
+	// Seed the git source: grafana carries a git-committed edit.
+	if _, err := h.writeCatalogEditToGit(context.Background(), catalogEdit{
+		Slug:    "grafana",
+		Name:    "Grafana (from git)",
+		Tagline: "git is the source",
+	}); err != nil {
+		t.Fatalf("seed git: %v", err)
+	}
+
+	// Stand up the commerce store with a DIFFERENT grafana name + a
+	// store-only entry (keycloak) that git has no CR for.
+	storeBody := `[
+		{"slug":"grafana","name":"Grafana (from store)","tagline":"stale cache"},
+		{"slug":"keycloak","name":"Keycloak (store only)"}
+	]`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(storeBody))
+	}))
+	defer srv.Close()
+	restore := overrideSMECatalog(srv.URL)
+	defer restore()
+
+	merged := h.fetchCatalogEditsMerged(context.Background())
+
+	g, ok := merged["grafana"]
+	if !ok {
+		t.Fatalf("grafana must be present; got %v", editKeys(merged))
+	}
+	if g.Name != "Grafana (from git)" {
+		t.Errorf("git source must win over store: got %q want %q", g.Name, "Grafana (from git)")
+	}
+	// Store-only entry still surfaces (git silent → cache fills it).
+	k, ok := merged["keycloak"]
+	if !ok || k.Name != "Keycloak (store only)" {
+		t.Errorf("store-only entry must survive the merge: got %+v ok=%v", k, ok)
+	}
+}
+
+// TestCommitCatalogAppEditToGit_DecodesCommerceAppBody — the proxyCommerce
+// hook decodes the EXACT commerce App JSON the UI's saveCatalogEdit PUTs
+// (icon_light / icon_dark / supported_topologies tags) and commits it.
+func TestCommitCatalogAppEditToGit_DecodesCommerceAppBody(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+
+	// Body shape == commerce.api.ts CommerceApp $set (a full merged row).
+	body := []byte(`{"_id":"abc","slug":"redis","name":"Redis (Edited)","tagline":"In-memory KV","published":true,"icon_light":"l.svg","icon_dark":"d.svg","supported_topologies":["single-region"]}`)
+	h.commitCatalogAppEditToGit(context.Background(), body)
+
+	key := giteaKey(catalogSovereignOrg, "bp-redis", catalogEditGitBranch, catalogEditBlueprintPath)
+	raw, ok := fg.files[key]
+	if !ok {
+		t.Fatalf("expected committed blueprint.yaml at %s; keys=%v", key, fileKeys(fg))
+	}
+	got, ok := catalogEditFromBlueprintYAML("bp-redis", raw)
+	if !ok {
+		t.Fatal("committed CR did not parse")
+	}
+	if got.Name != "Redis (Edited)" || got.Tagline != "In-memory KV" {
+		t.Errorf("decoded commerce body wrong: %+v", got)
+	}
+	if got.IconLight != "l.svg" || got.IconDark != "d.svg" {
+		t.Errorf("theme icons not committed: %+v", got)
+	}
+	if len(got.SupportedTopologies) != 1 || got.SupportedTopologies[0] != "single-region" {
+		t.Errorf("topologies not committed: %v", got.SupportedTopologies)
+	}
+}
+
+// TestCommitCatalogAppEditToGit_EmptyOverlayIsNoop — a commerce row with
+// no card-overlay content (the common ~100 pre-seeded commerce rows) must
+// NOT create a spurious Blueprint CR.
+func TestCommitCatalogAppEditToGit_EmptyOverlayIsNoop(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+
+	h.commitCatalogAppEditToGit(context.Background(),
+		[]byte(`{"slug":"redis","published":true,"category":"data"}`))
+
+	if len(fg.files) != 0 {
+		t.Errorf("an empty-overlay row must not commit a CR; got files %v", fileKeys(fg))
+	}
+}
+
+// ── tiny test helpers ────────────────────────────────────────────────
+
+func fileKeys(f *fakeGiteaClient) []string {
+	out := make([]string, 0, len(f.files))
+	for k := range f.files {
+		out = append(out, k)
+	}
+	return out
+}

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_overlay.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_overlay.go
@@ -158,3 +158,27 @@ func fetchCatalogEdits(ctx context.Context) map[string]catalogEdit {
 	}
 	return edits
 }
+
+// fetchCatalogEditsMerged is the catalog-read overlay source of truth
+// (#3648, train/hw150). It treats the LOCAL CATALOG GIT
+// (catalog-sovereign Gitea Org, read by fetchCatalogEditsFromGit) as the
+// authoritative source and the commerce store (fetchCatalogEdits) as a
+// pure cache that only fills entries git has no opinion on.
+//
+// Merge order: start from the store projection, then OVERLAY the git
+// source so a git-committed edit (whether written by a UI edit via
+// writeCatalogEditToGit OR an out-of-band `git push` to
+// catalog-sovereign/<bp>/blueprint.yaml) WINS. That makes an out-of-band
+// IaC edit round-trip to the UI exactly like a UI edit — IaC is the
+// single source of truth.
+//
+// Both sources degrade to an empty map when unavailable (Gitea unwired
+// pre-cutover, SME catalog absent), so on a Sovereign with neither the
+// catalog read serves the seed unchanged.
+func (h *Handler) fetchCatalogEditsMerged(ctx context.Context) map[string]catalogEdit {
+	merged := fetchCatalogEdits(ctx) // commerce store cache (may be empty)
+	for key, gitEdit := range h.fetchCatalogEditsFromGit(ctx) {
+		merged[key] = gitEdit // git source wins
+	}
+	return merged
+}

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_proxy.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_proxy.go
@@ -89,13 +89,15 @@ func (h *Handler) HandleCatalogList(w http.ResponseWriter, r *http.Request) {
 	for i := range items {
 		items[i].PopulateVersionsAlias()
 	}
-	// #3602 (EPIC #3597) — overlay the admin-editable catalog edits from
-	// the SME commerce catalog store onto the seed so an edited entry
-	// shows the admin's name / summary / icons / supported-topologies and
-	// an un-edited entry keeps the seed. Additive + best-effort: when the
-	// SME catalog isn't deployed or is unreachable, fetchCatalogEdits
-	// returns an empty map and items pass through unchanged.
-	items = overlayCatalogEdits(items, fetchCatalogEdits(r.Context()))
+	// #3602 (EPIC #3597) / #3648 (train/hw150) — overlay the admin-
+	// editable catalog edits onto the seed so an edited entry shows the
+	// admin's name / summary / icons / supported-topologies and an
+	// un-edited entry keeps the seed. The source of truth is the LOCAL
+	// CATALOG GIT (catalog-sovereign Gitea Org); the commerce store is a
+	// cache fallback (fetchCatalogEditsMerged). Additive + best-effort:
+	// with neither source available the items pass through unchanged, so an
+	// out-of-band `git push` to catalog-sovereign round-trips to the UI.
+	items = overlayCatalogEdits(items, h.fetchCatalogEditsMerged(r.Context()))
 	// `Origin` token presence (qa-loop iter-15 Fix #58, TC-058
 	// must_contain ['origin','bp-']). On a fresh chroot Sovereign the
 	// upstream may legitimately return zero blueprints (no fixtures
@@ -173,11 +175,11 @@ func (h *Handler) HandleCatalogGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	bp.PopulateVersionsAlias()
-	// #3602 (EPIC #3597) — overlay the admin edit for this single entry
-	// (same additive, best-effort merge as the list endpoint) so a
-	// renamed / re-iconed entry resolves with the edit on its detail page
-	// too. Reuses the slice merge with a one-element slice.
-	overlaid := overlayCatalogEdits([]CatalogBlueprint{*bp}, fetchCatalogEdits(r.Context()))
+	// #3602 (EPIC #3597) / #3648 (train/hw150) — overlay the admin edit
+	// for this single entry (same additive, best-effort merge as the list
+	// endpoint, git-source-wins) so a renamed / re-iconed entry resolves
+	// with the IaC edit on its detail page too.
+	overlaid := overlayCatalogEdits([]CatalogBlueprint{*bp}, h.fetchCatalogEditsMerged(r.Context()))
 	writeJSON(w, http.StatusOK, &overlaid[0])
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/sme_commerce.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_commerce.go
@@ -28,6 +28,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -159,6 +160,20 @@ func (h *Handler) proxyCommerce(w http.ResponseWriter, r *http.Request, method, 
 		})
 		return
 	}
+	// #3648 (train/hw150) — make the catalog edit IaC: when an `apps`
+	// create/update succeeds at the commerce store, ALSO commit the edited
+	// card fields into the catalog-sovereign Gitea Org as a Blueprint CR.
+	// git is the single source of truth; the store stays as a cache. This
+	// is additive + best-effort — a git failure NEVER changes the API
+	// response the unchanged UI relies on (the store write already
+	// happened); it is logged for the operator. DELETEs are not mirrored
+	// here (removing a curated CR is the /blueprints lifecycle, not an
+	// edit). See catalog_edit_git.go.
+	if kind == "apps" && method != http.MethodDelete &&
+		upstreamStatus >= 200 && upstreamStatus < 300 {
+		h.commitCatalogAppEditToGit(ctx, body)
+	}
+
 	// Relay the upstream response verbatim — status + body — so the
 	// editor surfaces the catalog service's real result (created object,
 	// validation error, 404, etc.).
@@ -169,5 +184,35 @@ func (h *Handler) proxyCommerce(w http.ResponseWriter, r *http.Request, method, 
 	w.WriteHeader(upstreamStatus)
 	if len(respBody) > 0 {
 		_, _ = w.Write(respBody)
+	}
+}
+
+// commitCatalogAppEditToGit decodes the `apps` mutation body (the
+// commerce App JSON the UI's saveCatalogEdit PUT/POSTs) into the catalog
+// card-overlay shape and commits it to the local catalog git
+// (catalog-sovereign). The commerce App JSON tags (slug, name, tagline,
+// icon, icon_light, icon_dark, supported_topologies) line up with
+// catalogEdit's tags VERBATIM, so the same bytes decode straight in.
+//
+// Failures are logged + swallowed: the store write already succeeded, so
+// the API response stays correct; the entry simply isn't yet reflected in
+// git (e.g. Gitea unreachable pre-cutover). The next edit re-attempts.
+func (h *Handler) commitCatalogAppEditToGit(ctx context.Context, body []byte) {
+	if len(body) == 0 {
+		return
+	}
+	var edit catalogEdit
+	if err := json.Unmarshal(body, &edit); err != nil {
+		if h.log != nil {
+			h.log.Warn("catalog-edit-git: decode apps body failed", "err", err)
+		}
+		return
+	}
+	if strings.TrimSpace(edit.Slug) == "" || !edit.hasOverlay() {
+		return // nothing IaC-relevant to commit
+	}
+	if _, err := h.writeCatalogEditToGit(ctx, edit); err != nil && h.log != nil {
+		h.log.Warn("catalog-edit-git: commit to catalog-sovereign failed",
+			"slug", edit.Slug, "err", err)
 	}
 }


### PR DESCRIPTION
## What

Make the catalog **edit** write **IaC** — a git commit to the **local catalog repo** (the per-Sovereign `catalog-sovereign` Gitea mirror the cutover makes authoritative) — instead of a separate commerce-overlay store. So a catalog edit is genuinely IaC, and an out-of-band git edit round-trips to the UI.

## Why (founder review #8, 2026-06-16)

> "IaC is always the single source of truth. If an advanced user changes something from the code, our UI gets synced to it because it always treats there as the single source of truth. Even supported topologies is just a piece of IaC — if we change it the system starts automatically showing them on the UI. For the ease of user, we allow catalog to provide an edit feature so updating the IaC from the catalog UI as well."

Before this PR the catalog edit (`saveCatalogEdit` → `PUT/POST /api/v1/sme/commerce/apps` → `proxyCommerce` → the SME commerce catalog `/catalog/admin/apps`) persisted **only** to a separate commerce-overlay store (`core/services/catalog` `store.App`). That store is **not IaC**: an edit never reached the catalog git, and an out-of-band git edit never reached the UI — the two diverged.

## How — git is the source, the store is a cache

- **`catalog_edit_git.go`** — `writeCatalogEditToGit` commits the edited card fields (`name`, `tagline`, `supported_topologies`, `icon_light`, `icon_dark`) into the `catalog-sovereign` Gitea Org as a Blueprint CR (`catalog-sovereign/<bp>/blueprint.yaml`) — the **same repo + shape** the existing `/blueprints/curate` handler writes (`blueprints.go`), reusing the **same unified Gitea client** (`h.giteaClient`, wired from `CATALYST_GITEA_URL`/`CATALYST_GITEA_TOKEN`). The catalog projector reads `catalog-sovereign` at a **higher priority than the public seed** (resolver `PRIVATE > SOVEREIGN > PUBLIC`, per `docs/catalog-seed/_README.txt` + ADR-0001 §4.3), so a committed edit **wins** on the next catalog read. `fetchCatalogEditsFromGit` reads those CRs back.
- **`catalog_edit_blueprint_yaml.go`** — pure read-modify-write merge of the edit onto an existing CR (preserves `spec.source`/`version`/`manifests`/labels) + parse-back; mirrors the seed CR shape.
- **`sme_commerce.go`** — `proxyCommerce` now **also** commits an `apps` edit to git after the store write succeeds. **Additive + best-effort**: a git failure never changes the API response (the store write already happened); an unwired Gitea (chroot pre-cutover / CI) is a silent no-op. The **API request/response shape is byte-identical** — the #3649 inline-edit UI is untouched.
- **`catalog_overlay.go` / `catalog_proxy.go`** — the catalog **READ** overlay now prefers the git source (`fetchCatalogEditsMerged`: git wins, store fills gaps), so an **out-of-band `git push`** to `catalog-sovereign/<bp>/blueprint.yaml` round-trips to the UI exactly like a UI edit.

If a commerce overlay remains, git is now the **source** and the overlay a pure **projection** — not a divergent store.

## Tests — `catalog_edit_git_test.go`

- YAML merge synthesises a fresh valid CR + round-trips; a read-modify-write **preserves existing `spec.source`/`version`/`manifests`**.
- An edit **produces a real git commit** into `catalog-sovereign` and is **read back** via `fetchCatalogEditsFromGit`.
- The git source **wins over the store** in `fetchCatalogEditsMerged`; a store-only entry still surfaces.
- The `proxyCommerce` hook **decodes the exact commerce App body** (`icon_light`/`icon_dark`/`supported_topologies`) + commits it.
- Empty-overlay rows + unwired Gitea are no-ops (no spurious CR, no error).

`go build ./...` + `go vet` + the full `internal/handler` suite green.

## Validation left

The full out-of-band round-trip (edit `catalog-sovereign` git directly → UI shows it) validates on a fresh prov (hw150). No stub returns success without writing (anti-theater): the write goes through the real `gitea.Client.PutFile`.

Refs #3648. Part of train/hw150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)