### PR TITLE
feat(catalyst-api): project cutover EXECUTION into jobs view via generic activity-bridge (#3646)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/cutover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover.go
@@ -1162,6 +1162,15 @@ func (h *Handler) runCutover(ctx context.Context, deps *cutoverDeps, steps []cut
 	// /start picks up at step 3.
 	priorStatus, _ := readCutoverStatus(ctx, deps)
 
+	// Project the Cutover group + a pending step Job per discovered step
+	// (with the linear dependsOn chain) into the jobs/activity store so
+	// the console /jobs canvas surfaces the EXECUTION — not just the
+	// dormant chart-install row (issue #3646). Best-effort; never blocks
+	// the cutover. Re-projecting the durable prior results first means a
+	// resume already shows the real per-step states before this run's
+	// transitions land.
+	h.projectCutoverResumeSeed(stepNamesFromSteps(steps), priorStatus)
+
 	for i, step := range steps {
 		percent := int(100 * (float64(i) / float64(totalSteps)))
 		_ = patchCutoverStatus(ctx, deps, map[string]string{
@@ -1178,6 +1187,9 @@ func (h *Handler) runCutover(ctx context.Context, deps *cutoverDeps, steps []cut
 				Step:    step.stepName,
 				Message: fmt.Sprintf("step %s already succeeded on a prior run; skipping", step.stepName),
 			})
+			// Already projected as succeeded by projectCutoverResumeSeed
+			// above (the durable status carried result=success); nothing
+			// more to do for the activity view.
 			continue
 		}
 
@@ -1197,6 +1209,11 @@ func (h *Handler) runCutover(ctx context.Context, deps *cutoverDeps, steps []cut
 				Step:    step.stepName,
 				Message: fmt.Sprintf("step %s failed: %v", step.stepName, err),
 			})
+			// Project the terminal failure onto the Cutover group so the
+			// canvas shows the failed step (and the group rolls up to
+			// failed) — never a misleading "succeeded" (issue #3646).
+			h.projectCutoverStepFinished(step, "failed",
+				fmt.Sprintf("step %s failed: %v", step.stepName, err), finishedAt)
 			h.log.Error("cutover: step failed", "step", step.stepName, "err", err)
 			return
 		}
@@ -1270,6 +1287,12 @@ func (h *Handler) runCutoverStep(ctx context.Context, deps *cutoverDeps, step cu
 					JobName: job.Name,
 					Message: fmt.Sprintf("step %s already completed by prior Job %s; advancing without re-running", step.stepName, job.Name),
 				})
+				// Project the carried-over success onto the Cutover group
+				// so a resumed cutover shows the step succeeded (#3646).
+				h.projectCutoverStepStarted(step,
+					fmt.Sprintf("step %s recovered from prior Job %s", step.stepName, job.Name), finishedAt)
+				h.projectCutoverStepFinished(step, "success",
+					fmt.Sprintf("step %s already completed by prior Job %s", step.stepName, job.Name), finishedAt)
 				return nil
 			}
 			// cond == batchv1.JobFailed.
@@ -1395,6 +1418,10 @@ func (h *Handler) runCutoverStep(ctx context.Context, deps *cutoverDeps, step cu
 		JobName: jobOrDS,
 		Message: startMsg,
 	})
+	// Project the running transition onto the Cutover group's step Job
+	// (issue #3646). The actual batch/v1 Job (jobOrDS) is what runs; this
+	// row is its projection on the unified jobs canvas.
+	h.projectCutoverStepStarted(step, startMsg, startedAt)
 
 	switch step.mode {
 	case cutoverModeJob:
@@ -1435,6 +1462,11 @@ func (h *Handler) runCutoverStep(ctx context.Context, deps *cutoverDeps, step cu
 		JobName: jobOrDS,
 		Message: fmt.Sprintf("step %s completed", step.stepName),
 	})
+	// Project the success transition onto the Cutover group's step Job
+	// (issue #3646) so the canvas advances the step + rolls the group's
+	// status up correctly.
+	h.projectCutoverStepFinished(step, "success",
+		fmt.Sprintf("step %s completed", step.stepName), finishedAt)
 	return nil
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_activity_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_activity_bridge.go
@@ -1,0 +1,272 @@
+// cutover_activity_bridge.go — projects the 11-step self-sovereign
+// CUTOVER execution into the jobs/activity store as a `Cutover` group of
+// step Job rows with dependency edges (issue #3646).
+//
+// # Problem (issue #3646, founder-caught on hw149)
+//
+// The console /jobs page showed `install-self-sovereign-cutover` as
+// "Succeeded" — but that "Succeeded" is the chart INSTALL (the
+// bp-self-sovereign-cutover Blueprint deploying DORMANT at bootstrap; it
+// ships 11 step ConfigMaps + RBAC and fires NO steps at install). The
+// real 11-step cutover EXECUTION (fired post-handover) was invisible on
+// /jobs — its true state lived ONLY in the self-sovereign-cutover-status
+// ConfigMap. An operator reasonably read "Succeeded" as "cutover done"
+// when the execution was actually mid-flight at step 3/11.
+//
+// # Fix — one unified model
+//
+// "Flux first": every platform activity should appear on the jobs canvas
+// as a projection of a reconciling object. A HelmRelease already
+// projects to a leaf Job via the helmwatch bridge; this file does the
+// same for the cutover EXECUTION using the GENERIC jobs.ActivityBridge —
+// each of the 11 batch/v1 Job steps becomes a leaf Job under a distinct
+// `Cutover` group, with dependsOn edges along the step order. The
+// projection is driven by the SAME state transitions the engine already
+// emits (runCutover/runCutoverStep), reading the REAL Job/step results —
+// never a fabricated row. The dormant chart-install row stays a separate
+// bootstrap-kit leaf; the execution now has its own honest group whose
+// rolled-up status is "succeeded" only when every step actually
+// succeeded (and `cutoverComplete=true`).
+//
+// This bridge is the cutover-specific WIRING of the generic pattern; the
+// reusable machinery (group + step Jobs, executions, log lines, edges,
+// idempotent resume) lives entirely in jobs.ActivityBridge so a future
+// activity source (DR switchover, backup/restore) wires the same way.
+package handler
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+)
+
+// cutoverActivityProjector lazily owns the jobs.ActivityBridge for the
+// cutover group. One per Handler; resolved on first use under the once.
+// The resolved deployment id lives inside the bridge itself.
+type cutoverActivityProjector struct {
+	once   sync.Once
+	bridge *jobs.ActivityBridge
+}
+
+// cutoverActivityBridge resolves (once) the jobs.ActivityBridge the
+// cutover engine projects its steps into, or nil when projection isn't
+// possible (no jobs store wired, or no deployment id resolvable yet).
+//
+// Resolution of the deployment id (the jobs-store key the canvas reads):
+//  1. h.cutoverActivityDepID when set (tests / explicit override).
+//  2. The chroot's imported deployment — the one in the jobs store that
+//     already carries the bootstrap-kit group. On a Sovereign the jobs
+//     store holds exactly the deployment imported at handover
+//     (HandleJobsImport writes it under the mother's id), so scanning
+//     for the bootstrap-kit group uniquely identifies "this Sovereign's
+//     deployment" without depending on the in-memory deployment map.
+//
+// nil is returned (projection silently skipped) when neither resolves —
+// the cutover engine's existing ConfigMap-status path is unaffected, so
+// projection is strictly additive and never blocks the cutover.
+func (h *Handler) cutoverActivityBridge() *jobs.ActivityBridge {
+	if h.jobs == nil {
+		return nil
+	}
+	h.cutoverActivityProj.once.Do(func() {
+		depID := strings.TrimSpace(h.cutoverActivityDepID)
+		if depID == "" {
+			depID = h.resolveCutoverActivityDepID()
+		}
+		if depID == "" {
+			// Leave proj.bridge nil; a later call re-evaluates because
+			// sync.Once only ran the resolution once — so guard below.
+			return
+		}
+		h.cutoverActivityProj.bridge = jobs.NewActivityBridge(
+			h.jobs, depID, jobs.GroupCutover, jobs.GroupCutoverDisplay,
+		)
+	})
+	// If the first resolution attempt failed (no deployment imported
+	// yet), retry resolution on subsequent calls — sync.Once won't, so
+	// do it inline. This matters because the cutover may start before a
+	// /jobs read has lazily seeded the store; by the time steps run the
+	// import has landed.
+	if h.cutoverActivityProj.bridge == nil {
+		depID := strings.TrimSpace(h.cutoverActivityDepID)
+		if depID == "" {
+			depID = h.resolveCutoverActivityDepID()
+		}
+		if depID == "" {
+			return nil
+		}
+		h.cutoverActivityProj.bridge = jobs.NewActivityBridge(
+			h.jobs, depID, jobs.GroupCutover, jobs.GroupCutoverDisplay,
+		)
+	}
+	return h.cutoverActivityProj.bridge
+}
+
+// resolveCutoverActivityDepID scans the jobs store for the deployment
+// that carries the bootstrap-kit group — the imported Sovereign
+// deployment on a chroot. Returns "" when no such deployment exists yet.
+func (h *Handler) resolveCutoverActivityDepID() string {
+	if h.jobs == nil {
+		return ""
+	}
+	ids, err := h.jobs.DeploymentIDs()
+	if err != nil {
+		h.log.Debug("cutover-activity: enumerate deployments failed", "err", err)
+		return ""
+	}
+	// Prefer a deployment that already has the bootstrap-kit group (the
+	// imported Sovereign deployment). Fall back to the sole deployment id
+	// when exactly one exists (covers the window before the bootstrap-kit
+	// seed lands but after the deployment dir is created).
+	var fallback string
+	count := 0
+	for _, id := range ids {
+		count++
+		fallback = id
+		all, err := h.jobs.ListJobs(id)
+		if err != nil {
+			continue
+		}
+		for _, j := range all {
+			if j.JobName == jobs.GroupBootstrapKit {
+				return id
+			}
+		}
+	}
+	if count == 1 {
+		return fallback
+	}
+	return ""
+}
+
+// stepNamesFromSteps returns the ordered step-name slice from a
+// discovered cutoverStep list (the steps are already sorted by order in
+// listCutoverSteps). Used to feed projectCutoverResumeSeed without
+// re-deriving order.
+func stepNamesFromSteps(steps []cutoverStep) []string {
+	out := make([]string, 0, len(steps))
+	for _, s := range steps {
+		if n := strings.TrimSpace(s.stepName); n != "" {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// cutoverStepDisplay turns a step slug ("harbor-prewarm") into a
+// human-readable label ("Harbor Prewarm").
+func cutoverStepDisplay(slug string) string {
+	parts := strings.Split(slug, "-")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, " ")
+}
+
+// projectCutoverStepStarted flips a step's projected Job to running.
+func (h *Handler) projectCutoverStepStarted(step cutoverStep, message string, t time.Time) {
+	ab := h.cutoverActivityBridge()
+	if ab == nil {
+		return
+	}
+	if err := ab.StartStep(jobs.ActivityStep{
+		Slug:        step.stepName,
+		DisplayName: cutoverStepDisplay(step.stepName),
+		Order:       step.order,
+	}, message, t); err != nil {
+		h.log.Warn("cutover-activity: start step job failed", "step", step.stepName, "err", err)
+	}
+}
+
+// projectCutoverStepFinished flips a step's projected Job terminal.
+// result is the engine's native result string ("success" | "failed" |
+// "skipped").
+func (h *Handler) projectCutoverStepFinished(step cutoverStep, result, message string, t time.Time) {
+	ab := h.cutoverActivityBridge()
+	if ab == nil {
+		return
+	}
+	if err := ab.FinishStep(jobs.ActivityStep{
+		Slug:        step.stepName,
+		DisplayName: cutoverStepDisplay(step.stepName),
+		Order:       step.order,
+	}, result, message, t); err != nil {
+		h.log.Warn("cutover-activity: finish step job failed", "step", step.stepName, "err", err)
+	}
+}
+
+// projectCutoverResumeSeed re-projects the durable per-step results from
+// the status ConfigMap onto the jobs store on a fresh Pod — so a
+// catalyst-api restart mid-cutover (or a /jobs read after a completed
+// cutover whose step ConfigMaps were GC'd) still shows the execution's
+// real step states. priorStatus is the readCutoverStatus map; stepNames
+// is the ordered step-name slice (from listCutoverSteps OR
+// listStepNamesFromStatus). Best-effort.
+//
+// This is the seam that makes the projection survive the exact scenario
+// in #3646: the operator looks at /jobs LONG after handover, when the
+// cutover goroutine is gone and only the durable status ConfigMap
+// remains. Each step's `.result` is replayed through Start/FinishStep so
+// the Cutover group rolls up to the true state (succeeded only when every
+// step succeeded).
+func (h *Handler) projectCutoverResumeSeed(stepNames []string, priorStatus map[string]string) {
+	ab := h.cutoverActivityBridge()
+	if ab == nil {
+		return
+	}
+	steps := make([]jobs.ActivityStep, 0, len(stepNames))
+	for i, name := range stepNames {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		steps = append(steps, jobs.ActivityStep{
+			Slug:        name,
+			DisplayName: cutoverStepDisplay(name),
+			Order:       i + 1,
+		})
+	}
+	if err := ab.SeedSteps(steps); err != nil {
+		h.log.Warn("cutover-activity: resume seed failed", "err", err)
+		return
+	}
+	for _, s := range steps {
+		result := priorStatus["step."+s.Slug+".result"]
+		startedAt := parseCutoverStatusTime(priorStatus["step."+s.Slug+".startedAt"])
+		finishedAt := parseCutoverStatusTime(priorStatus["step."+s.Slug+".finishedAt"])
+		switch strings.ToLower(strings.TrimSpace(result)) {
+		case jobs.ActivityResultSuccess, jobs.ActivityResultSkipped, jobs.ActivityResultFailed:
+			if err := ab.StartStep(s, "[replayed from durable cutover status]", startedAt); err != nil {
+				h.log.Warn("cutover-activity: resume start failed", "step", s.Slug, "err", err)
+			}
+			if err := ab.FinishStep(s, result, "", finishedAt); err != nil {
+				h.log.Warn("cutover-activity: resume finish failed", "step", s.Slug, "err", err)
+			}
+		case jobs.ActivityResultRunning:
+			if err := ab.StartStep(s, "[in flight — replayed from durable cutover status]", startedAt); err != nil {
+				h.log.Warn("cutover-activity: resume running failed", "step", s.Slug, "err", err)
+			}
+		default:
+			// pending — SeedSteps already wrote the pending row.
+		}
+	}
+}
+
+// parseCutoverStatusTime parses an RFC3339 timestamp from the cutover
+// status ConfigMap, falling back to time.Now() so a missing/malformed
+// value never drops the projection.
+func parseCutoverStatusTime(s string) time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Now().UTC()
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC()
+	}
+	return time.Now().UTC()
+}

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_activity_bridge_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_activity_bridge_test.go
@@ -1,0 +1,195 @@
+// cutover_activity_bridge_test.go — proves the cutover EXECUTION
+// projects into the jobs/activity store as the `Cutover` group of step
+// Job rows WITH dependency edges, driven by the real engine run (issue
+// #3646). This is the wiring-level counterpart to the generic-bridge
+// unit tests in internal/jobs/activity_bridge_test.go.
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+)
+
+// waitCutoverIdle blocks until the in-process cutover running flag clears
+// (the engine goroutine finished), or the deadline elapses.
+func waitCutoverIdle(t *testing.T, h *Handler) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		bus := h.cutoverBusFor()
+		bus.mu.Lock()
+		running := bus.running
+		bus.mu.Unlock()
+		if !running {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("cutover engine did not go idle within deadline")
+}
+
+// TestCutoverExecutionProjectsIntoJobsWithEdges runs the real engine
+// (HandleCutoverStart) against a fake cluster with 3 step ConfigMaps and
+// asserts the cutover EXECUTION lands in the jobs store as a `Cutover`
+// group of step rows with the linear dependsOn chain — the unified model
+// issue #3646 asks for. Crucially the projected group reflects the real
+// execution (succeeded only because every step's Job actually Completed),
+// NOT the dormant chart-install row.
+func TestCutoverExecutionProjectsIntoJobsWithEdges(t *testing.T) {
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-01-gitea-mirror", "gitea-mirror", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+		makeCutoverStepCM("cutover-step-02-harbor-prewarm", "harbor-prewarm", 2, cutoverModeJob, minimalPodSpecYAML, ""),
+		makeCutoverStepCM("cutover-step-03-registry-pivot", "registry-pivot", 3, cutoverModeDaemonSetWait, "", "registry-pivot"),
+		makeReadyDaemonSet("registry-pivot"),
+	}
+	h, client := fakeHandlerWithCutover(t, objs...)
+	installJobReactor(t, client, batchv1.JobComplete)
+
+	// Wire a jobs store + pin the activity projection to a known
+	// deployment id so we can assert the projected rows.
+	js, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("jobs.NewStore: %v", err)
+	}
+	h.jobs = js
+	const depID = "dep-cutover-proj"
+	h.cutoverActivityDepID = depID
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sovereign/cutover/start", nil)
+	h.HandleCutoverStart(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("HandleCutoverStart: status %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	waitCutoverIdle(t, h)
+
+	// Read back the projected jobs.
+	all, err := js.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+
+	// The Cutover group must exist + roll up to succeeded (every step's
+	// Job Completed).
+	group := findCutoverJob(t, all, jobs.GroupCutover)
+	if group.Type != jobs.JobTypeGroup {
+		t.Fatalf("Cutover group Type = %q, want %q", group.Type, jobs.JobTypeGroup)
+	}
+	if group.Status != jobs.StatusSucceeded {
+		t.Errorf("Cutover group status = %q, want %q (all steps completed)", group.Status, jobs.StatusSucceeded)
+	}
+
+	// Each of the 3 steps projects as a leaf under the group.
+	mirror := findCutoverJob(t, all, jobs.ActivityStepJobName(jobs.GroupCutover, "gitea-mirror"))
+	prewarm := findCutoverJob(t, all, jobs.ActivityStepJobName(jobs.GroupCutover, "harbor-prewarm"))
+	pivot := findCutoverJob(t, all, jobs.ActivityStepJobName(jobs.GroupCutover, "registry-pivot"))
+
+	for _, s := range []jobs.Job{mirror, prewarm, pivot} {
+		if s.ParentID != jobs.JobID(depID, jobs.GroupCutover) {
+			t.Errorf("step %q ParentID = %q, want %q", s.JobName, s.ParentID, jobs.JobID(depID, jobs.GroupCutover))
+		}
+		if s.Status != jobs.StatusSucceeded {
+			t.Errorf("step %q status = %q, want %q", s.JobName, s.Status, jobs.StatusSucceeded)
+		}
+	}
+
+	// Edges: gitea-mirror (order 1) has no dep; harbor-prewarm depends on
+	// gitea-mirror; registry-pivot depends on harbor-prewarm.
+	if len(mirror.DependsOn) != 0 {
+		t.Errorf("gitea-mirror DependsOn = %v, want []", mirror.DependsOn)
+	}
+	wantPrewarmDep := jobs.ActivityStepJobName(jobs.GroupCutover, "gitea-mirror")
+	if len(prewarm.DependsOn) != 1 || prewarm.DependsOn[0] != wantPrewarmDep {
+		t.Errorf("harbor-prewarm DependsOn = %v, want [%q]", prewarm.DependsOn, wantPrewarmDep)
+	}
+	wantPivotDep := jobs.ActivityStepJobName(jobs.GroupCutover, "harbor-prewarm")
+	if len(pivot.DependsOn) != 1 || pivot.DependsOn[0] != wantPivotDep {
+		t.Errorf("registry-pivot DependsOn = %v, want [%q]", pivot.DependsOn, wantPivotDep)
+	}
+
+	// Sanity: the projected group is DISTINCT from the dormant chart
+	// install leaf (install-self-sovereign-cutover) — the whole point of
+	// #3646. The install leaf isn't written by this path (no helmwatch
+	// seed in this test), so only the execution group should be present.
+	if g := jobs.JobID(depID, jobs.GroupCutover); group.ID != g {
+		t.Errorf("group ID = %q, want %q", group.ID, g)
+	}
+}
+
+func findCutoverJob(t *testing.T, in []jobs.Job, name string) jobs.Job {
+	t.Helper()
+	for _, j := range in {
+		if j.JobName == name {
+			return j
+		}
+	}
+	t.Fatalf("projected job %q not found in %d rows", name, len(in))
+	return jobs.Job{}
+}
+
+// TestCutoverResumeSeedReplaysDurableStatus proves the read-path
+// projection: with NO live engine run, replaying the durable cutover
+// status ConfigMap surfaces the real per-step states under the Cutover
+// group — the exact #3646 scenario where an operator opens /jobs after
+// handover and the goroutine is gone.
+func TestCutoverResumeSeedReplaysDurableStatus(t *testing.T) {
+	js, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("jobs.NewStore: %v", err)
+	}
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.jobs = js
+	const depID = "dep-resume-proj"
+	h.cutoverActivityDepID = depID
+
+	now := time.Now().UTC()
+	// Durable status: step1 succeeded, step2 mid-flight, step3 pending.
+	status := map[string]string{
+		"cutoverComplete":               "false",
+		"step.gitea-mirror.result":      "success",
+		"step.gitea-mirror.startedAt":   now.Format(time.RFC3339),
+		"step.gitea-mirror.finishedAt":  now.Add(time.Minute).Format(time.RFC3339),
+		"step.harbor-prewarm.result":    "running",
+		"step.harbor-prewarm.startedAt": now.Add(time.Minute).Format(time.RFC3339),
+		"step.registry-pivot.result":    "",
+	}
+	stepNames := []string{"gitea-mirror", "harbor-prewarm", "registry-pivot"}
+
+	h.projectCutoverResumeSeed(stepNames, status)
+
+	all, err := js.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	mirror := findCutoverJob(t, all, jobs.ActivityStepJobName(jobs.GroupCutover, "gitea-mirror"))
+	prewarm := findCutoverJob(t, all, jobs.ActivityStepJobName(jobs.GroupCutover, "harbor-prewarm"))
+	pivot := findCutoverJob(t, all, jobs.ActivityStepJobName(jobs.GroupCutover, "registry-pivot"))
+
+	if mirror.Status != jobs.StatusSucceeded {
+		t.Errorf("gitea-mirror status = %q, want %q", mirror.Status, jobs.StatusSucceeded)
+	}
+	if prewarm.Status != jobs.StatusRunning {
+		t.Errorf("harbor-prewarm status = %q, want %q", prewarm.Status, jobs.StatusRunning)
+	}
+	if pivot.Status != jobs.StatusPending {
+		t.Errorf("registry-pivot status = %q, want %q", pivot.Status, jobs.StatusPending)
+	}
+
+	// The group must NOT read succeeded — the cutover is mid-flight. This
+	// is the core #3646 guarantee: never show "Succeeded" unless every
+	// step truly succeeded.
+	group := findCutoverJob(t, all, jobs.GroupCutover)
+	if group.Status == jobs.StatusSucceeded {
+		t.Errorf("Cutover group status = %q, must not be succeeded while a step is running/pending", group.Status)
+	}
+	if group.Status != jobs.StatusRunning {
+		t.Errorf("Cutover group status = %q, want %q (a step is in flight)", group.Status, jobs.StatusRunning)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -317,6 +317,19 @@ type Handler struct {
 	// dispatches to the real h.spawnCutoverEngine.
 	spawnCutoverEngineFn func(ctx context.Context, deps *cutoverDeps, source string) (cutoverSpawnResult, error)
 
+	// cutoverActivityDepID — test/override of the deployment id the
+	// cutover activity bridge projects its step rows under (issue #3646).
+	// Empty in production: cutoverActivityBridge() resolves the chroot's
+	// imported deployment from the jobs store (the deployment carrying the
+	// bootstrap-kit group). Tests set this directly so the projection can
+	// be asserted against a known id without standing up the import path.
+	cutoverActivityDepID string
+	// cutoverActivityProj — lazily-constructed projector that owns the
+	// jobs.ActivityBridge translating cutover step transitions into the
+	// `Cutover` group of Job rows the canvas reads (issue #3646). See
+	// cutover_activity_bridge.go.
+	cutoverActivityProj cutoverActivityProjector
+
 	// ── Unified RBAC SME-tier (issue #802, ADR-0003) ────────────────────────
 	// tenantRegistry — host → tenant lookup table backing the public
 	// /api/v1/tenant/discover endpoint. Same registry is used by the

--- a/products/catalyst/bootstrap/api/internal/handler/jobs.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs.go
@@ -347,6 +347,69 @@ func (h *Handler) chrootSeedJobsStoreIfEmpty(ctx context.Context, dep *Deploymen
 	// fixed here was caused exactly by this branch being unreachable on
 	// a hasBootstrapKit=true chroot.
 	h.chrootSeedSecondaryRegions(ctx, dep, bridge)
+
+	// Cutover EXECUTION projection (issue #3646). The helmwatch seed above
+	// only surfaces the DORMANT bp-self-sovereign-cutover chart install as
+	// an "install-self-sovereign-cutover" leaf — which reads "Succeeded"
+	// the instant the chart lands, regardless of whether the 11-step
+	// cutover ever ran. Project the real execution state from the cutover
+	// status ConfigMap into a distinct `Cutover` group so an operator
+	// opening /jobs long after handover (when the engine goroutine is gone)
+	// still sees the true per-step progress + cutoverComplete, never a
+	// misleading "Succeeded". Keyed under dep.ID so it joins the same tree.
+	h.chrootSeedCutoverActivity(ctx, dep)
+}
+
+// chrootSeedCutoverActivity reads the self-sovereign-cutover-status
+// ConfigMap from the chroot's own cluster and replays its per-step
+// results into the jobs/activity store as the `Cutover` group (issue
+// #3646). No-op when not on a Sovereign (cutover deps unavailable), when
+// the status ConfigMap is absent (cutover never installed), or when the
+// jobs store / activity bridge can't resolve. Best-effort: every failure
+// path logs at debug/warn and returns — a /jobs read never fails because
+// the cutover projection couldn't run.
+//
+// This is the read-path counterpart to the engine-driven projection in
+// runCutover: the engine projects live transitions while it runs; this
+// replays the durable record on demand so the Cutover group is present
+// even on a fresh Pod with no active cutover goroutine.
+func (h *Handler) chrootSeedCutoverActivity(ctx context.Context, dep *Deployment) {
+	if h.jobs == nil {
+		return
+	}
+	// Pin the activity bridge to THIS deployment id so the projection
+	// joins the same tree the /jobs read returns (resolution-by-scan
+	// would also find it, but the read already knows the id).
+	if strings.TrimSpace(h.cutoverActivityDepID) == "" && h.cutoverActivityProj.bridge == nil {
+		h.cutoverActivityDepID = dep.ID
+	}
+	deps, err := h.cutoverDepsFor()
+	if err != nil {
+		h.log.Debug("chroot seed: cutover deps unavailable; skipping activity projection",
+			"depId", dep.ID, "err", err)
+		return
+	}
+	status, err := readCutoverStatus(ctx, deps)
+	if err != nil {
+		h.log.Debug("chroot seed: cutover status read failed; skipping activity projection",
+			"depId", dep.ID, "err", err)
+		return
+	}
+	// Nothing to project until the cutover has at least been discovered.
+	// Prefer the durable per-step keys; fall back to live step discovery
+	// so a cutover that's installed-but-never-run still shows its pending
+	// steps (the honest "tethered, 0/N" picture).
+	stepNames := listStepNamesFromStatus(status)
+	if len(stepNames) == 0 {
+		if steps, derr := listCutoverSteps(ctx, deps); derr == nil {
+			stepNames = stepNamesFromSteps(steps)
+		}
+	}
+	if len(stepNames) == 0 {
+		// Cutover chart not installed / no steps — nothing to surface.
+		return
+	}
+	h.projectCutoverResumeSeed(stepNames, status)
 }
 
 // regionFromSecondaryClusterID — pure helper: given a k8sCache cluster ID

--- a/products/catalyst/bootstrap/api/internal/jobs/activity_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/activity_bridge.go
@@ -1,0 +1,474 @@
+// activity_bridge.go — the GENERIC source-bridge that projects a
+// declared platform "activity" (an ordered list of named steps with
+// per-step state) into the same Job + Execution + LogLine model the
+// helmwatch bridge uses for HelmReleases.
+//
+// # Why this exists (issue #3646)
+//
+// "Flux first" is the platform principle: every activity the operator
+// can observe should appear on the catalyst jobs/activity canvas as a
+// projection of a reconciling object — one unified model. The
+// helmwatch bridge already realises this for HelmReleases (a
+// HelmRelease IS a Flux object; its reconcile state becomes a leaf Job
+// row under the bootstrap-kit group, with dependsOn edges derived from
+// spec.dependsOn). But some platform activities run as raw batch/v1
+// Jobs the helmwatch/mutation bridges never observe — most importantly
+// the 11-step self-sovereign CUTOVER. Those activities are INVISIBLE on
+// the jobs view, or — worse — the dormant chart-install row reads
+// "Succeeded" while the real execution is mid-flight (issue #3646).
+//
+// ActivityBridge closes that gap GENERICALLY. It is NOT cutover-
+// specific: any activity source (the cutover engine, a future DR
+// switchover, a backup/restore run, …) constructs ONE ActivityBridge
+// for its declared group and feeds it step transitions. The bridge owns
+// the translation into the jobs store:
+//
+//   - The activity's group (e.g. GroupCutover) is materialised as a
+//     top-level group Job, exactly like the bootstrap-kit group. Its
+//     status/timing roll up from its step children at read time via
+//     Store.deriveTreeView — the activity source never has to compute
+//     aggregate state.
+//   - Each declared step becomes a leaf Job named
+//     "<group>-step-<slug>" with DependsOn pointing at the PRIOR step
+//     (a linear chain, the same shape SeedProvisionerJobs uses for the
+//     Phase-0 tofu lifecycle). The canvas renders the edges from these
+//     DependsOn entries.
+//   - Step state transitions (pending → running → succeeded/failed)
+//     drive StartExecution / AppendLogLines / FinishExecution so the
+//     per-step Exec Log surface resolves and the GitLab-CI log viewer
+//     has a row to deep-link to — identical to how a HelmRelease leaf
+//     behaves.
+//
+// # Relationship to the helmwatch bridge
+//
+// ActivityBridge is a sibling of Bridge, not a replacement. Both write
+// into the same Store under the same deployment id, so a single /jobs
+// read returns the bootstrap-kit installs, the Phase-0 lifecycle, AND
+// every projected activity in one tree — the unified model issue #3646
+// asks for. The two never contend: the helmwatch Bridge only ever
+// writes "install-*" leaves + the bootstrap-kit/provisioner groups;
+// ActivityBridge only ever writes "<group>-step-*" leaves + the
+// activity's own group. Store.mu serialises the actual disk writes.
+//
+// # Idempotency
+//
+// Every method is idempotent and safe to call repeatedly — the cutover
+// engine resumes across catalyst-api Pod restarts and re-emits the same
+// step transitions, and a /jobs read may lazily re-seed. UpsertJob's
+// monotonic merge (store.mergeJob) preserves StartedAt/FinishedAt and a
+// non-empty prior DependsOn, so re-seeding a step never un-starts it or
+// drops its edges. StartStep reuses an already-open Execution rather
+// than allocating a second one.
+package jobs
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+// ActivityStepResult enumerates the source-side per-step result values
+// an activity reports. These mirror the cutover status ConfigMap's
+// `step.<name>.result` vocabulary ("running" | "success" | "failed" |
+// "skipped" | "" for not-yet-started) so a source can hand its native
+// result string straight through without a translation table. The
+// bridge maps each onto the Job Status enum via activityStatusFromResult.
+const (
+	ActivityResultPending = ""        // not yet attempted
+	ActivityResultRunning = "running" // in flight
+	ActivityResultSuccess = "success" // completed OK
+	ActivityResultFailed  = "failed"  // terminal failure
+	ActivityResultSkipped = "skipped" // already-satisfied / no-op
+)
+
+// ActivityStepPrefixSep is the separator between an activity group slug
+// and a step slug in a step Job's JobName ("<group>-step-<slug>"). The
+// "-step-" infix keeps the namespace disjoint from the helmwatch
+// bridge's "install-" leaves so the two source bridges can never mint
+// colliding Job ids under the same deployment.
+const ActivityStepInfix = "-step-"
+
+// ActivityStepJobName returns the canonical leaf JobName for a step of
+// the given activity group. e.g. ActivityStepJobName("cutover",
+// "harbor-prewarm") == "cutover-step-harbor-prewarm". Exported so a
+// source (and its tests) can deep-link to GET /jobs/{jobId} for a step
+// without re-deriving the format.
+func ActivityStepJobName(groupSlug, stepSlug string) string {
+	return groupSlug + ActivityStepInfix + stepSlug
+}
+
+// ActivityStep is one declared step of an activity. Order is the
+// 1-based (or any monotonically increasing) sequence position — the
+// bridge sorts by it to build the linear DependsOn chain and to choose
+// each step's predecessor. DisplayName is the optional user-visible
+// label (falls back to Slug when empty).
+type ActivityStep struct {
+	// Slug — stable, URL-safe step identifier (e.g. "harbor-prewarm").
+	// Used as the step's JobName suffix and as the map key the source
+	// keys transitions off. Required; an empty slug is skipped.
+	Slug string
+
+	// DisplayName — friendly label rendered by the canvas/table. Empty
+	// falls back to Slug on the leaf Job (matching the helmwatch leaf
+	// convention where DisplayName is empty and the FE renders JobName).
+	DisplayName string
+
+	// Order — sequence position. Steps are sorted ascending by Order
+	// (stable secondary sort on Slug) to derive the linear dependency
+	// chain. A step depends on the step immediately before it in that
+	// sorted order; the first step has no dependency.
+	Order int
+}
+
+// ActivityBridge projects one declared activity (identified by a stable
+// group slug) into the jobs Store under a single deployment id. One
+// bridge instance per (deployment, activity-group). Goroutine-safe: the
+// internal mutex serialises the bridge's own per-step cursor map; the
+// Store serialises the actual writes.
+type ActivityBridge struct {
+	store        *Store
+	deploymentID string
+
+	// groupSlug / groupDisplay — the top-level group Job this activity's
+	// steps hang under (e.g. GroupCutover / GroupCutoverDisplay).
+	groupSlug    string
+	groupDisplay string
+
+	mu sync.Mutex
+
+	// steps — the declared step set, in the order the source registered
+	// them. Re-registering (SeedSteps) replaces this slice so a source
+	// whose step list is only discovered lazily (the cutover engine
+	// reads its steps from ConfigMaps at /start) can seed once the list
+	// is known. Keyed lookups go through stepIndex.
+	steps     []ActivityStep
+	stepIndex map[string]int // slug → position in steps
+
+	// activeExecID — per-step-slug id of the in-flight Execution. Set on
+	// the first StartStep, cleared on FinishStep. Survives only within a
+	// process lifetime; a resumed activity re-attaches via the persisted
+	// Job.LatestExecutionID (see StartStep's reuse path) so a Pod restart
+	// never strands an Execution open.
+	activeExecID map[string]string
+}
+
+// NewActivityBridge constructs a bridge for the given activity group.
+// store must be non-nil; deploymentID + groupSlug must be non-empty.
+// groupDisplay falls back to groupSlug when empty.
+func NewActivityBridge(store *Store, deploymentID, groupSlug, groupDisplay string) *ActivityBridge {
+	if groupDisplay == "" {
+		groupDisplay = groupSlug
+	}
+	return &ActivityBridge{
+		store:        store,
+		deploymentID: deploymentID,
+		groupSlug:    groupSlug,
+		groupDisplay: groupDisplay,
+		stepIndex:    map[string]int{},
+		activeExecID: map[string]string{},
+	}
+}
+
+// GroupJobID returns the stable id of this activity's top-level group
+// Job. Exported so a source can assert against it / deep-link.
+func (a *ActivityBridge) GroupJobID() string {
+	return JobID(a.deploymentID, a.groupSlug)
+}
+
+// ensureGroupLocked idempotently materialises the activity's top-level
+// group Job. The group's persisted Status is a placeholder; the runtime
+// status rolls up from its step children at read time (deriveTreeView).
+// Caller MUST hold a.mu.
+func (a *ActivityBridge) ensureGroupLocked() error {
+	return a.store.UpsertJob(Job{
+		DeploymentID: a.deploymentID,
+		JobName:      a.groupSlug,
+		DisplayName:  a.groupDisplay,
+		Type:         JobTypeGroup,
+		ParentID:     "",
+		DependsOn:    []string{},
+		Status:       StatusPending,
+	})
+}
+
+// sortedSteps returns the declared steps ordered by Order ascending
+// (stable secondary sort on Slug). Caller MUST hold a.mu.
+func (a *ActivityBridge) sortedSteps() []ActivityStep {
+	out := make([]ActivityStep, len(a.steps))
+	copy(out, a.steps)
+	// Insertion sort — step counts are tiny (the cutover has 11) so an
+	// allocation-free stable sort by hand keeps the dependency edges
+	// deterministic without pulling sort.Slice's closure overhead.
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0; j-- {
+			a0, b0 := out[j-1], out[j]
+			less := a0.Order < b0.Order || (a0.Order == b0.Order && a0.Slug <= b0.Slug)
+			if less {
+				break
+			}
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}
+
+// dependsOnForStepLocked returns the DependsOn list (length 0 for the
+// first step, length 1 thereafter) pointing at the immediately-prior
+// step's JobName, so the canvas renders the linear chain. The format
+// matches the helmwatch leaf convention (Job.DependsOn carries the
+// dependency's JobName, resolved by deriveTreeView's byJobName map for
+// the cascading-failure sweep and by the FE for edge rendering).
+// Caller MUST hold a.mu.
+func (a *ActivityBridge) dependsOnForStepLocked(slug string) []string {
+	sorted := a.sortedSteps()
+	for i, s := range sorted {
+		if s.Slug != slug {
+			continue
+		}
+		if i == 0 {
+			return []string{}
+		}
+		return []string{ActivityStepJobName(a.groupSlug, sorted[i-1].Slug)}
+	}
+	return []string{}
+}
+
+// SeedSteps registers (or re-registers) the activity's full step set and
+// writes a pending leaf Job per step under the activity group, wired
+// with the linear DependsOn chain. Idempotent: re-seeding preserves any
+// step that has already started (UpsertJob's monotonic merge keeps
+// StartedAt/Status), so a source may seed lazily once its step list is
+// known and again on resume without regressing live rows.
+//
+// Steps with an empty Slug are skipped (defence against a malformed
+// source). An empty step list materialises just the group Job (so the
+// group is visible as pending even before steps are discovered).
+func (a *ActivityBridge) SeedSteps(steps []ActivityStep) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Replace the declared set + rebuild the index. We keep only
+	// non-empty slugs so dependsOn derivation and transitions can't key
+	// off a blank.
+	a.steps = a.steps[:0]
+	a.stepIndex = make(map[string]int, len(steps))
+	for _, s := range steps {
+		s.Slug = strings.TrimSpace(s.Slug)
+		if s.Slug == "" {
+			continue
+		}
+		a.stepIndex[s.Slug] = len(a.steps)
+		a.steps = append(a.steps, s)
+	}
+
+	if err := a.ensureGroupLocked(); err != nil {
+		return err
+	}
+
+	parent := JobID(a.deploymentID, a.groupSlug)
+	for _, s := range a.sortedSteps() {
+		display := s.DisplayName
+		if err := a.store.UpsertJob(Job{
+			DeploymentID: a.deploymentID,
+			JobName:      ActivityStepJobName(a.groupSlug, s.Slug),
+			DisplayName:  display,
+			Type:         JobTypeInstall,
+			ParentID:     parent,
+			DependsOn:    a.dependsOnForStepLocked(s.Slug),
+			Status:       StatusPending,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ensureStepLocked idempotently materialises a single step's leaf Job
+// (used when a transition arrives for a step SeedSteps never declared —
+// e.g. a source that emits transitions without a prior seed). It also
+// lazily registers the step in the in-memory set so dependsOn derivation
+// has something to chain off. Caller MUST hold a.mu.
+func (a *ActivityBridge) ensureStepLocked(step ActivityStep) error {
+	step.Slug = strings.TrimSpace(step.Slug)
+	if step.Slug == "" {
+		return nil
+	}
+	if _, ok := a.stepIndex[step.Slug]; !ok {
+		a.stepIndex[step.Slug] = len(a.steps)
+		a.steps = append(a.steps, step)
+	}
+	if err := a.ensureGroupLocked(); err != nil {
+		return err
+	}
+	return a.store.UpsertJob(Job{
+		DeploymentID: a.deploymentID,
+		JobName:      ActivityStepJobName(a.groupSlug, step.Slug),
+		DisplayName:  step.DisplayName,
+		Type:         JobTypeInstall,
+		ParentID:     JobID(a.deploymentID, a.groupSlug),
+		DependsOn:    a.dependsOnForStepLocked(step.Slug),
+		Status:       StatusPending,
+	})
+}
+
+// StartStep transitions a step into Running, allocating an Execution
+// (and stamping StartedAt) on the first call. Re-calling for a step that
+// already has an open Execution reuses it (no duplicate Execution row),
+// which is the load-bearing idempotency property for the cutover
+// engine's resume path. An optional message is appended as the first
+// LogLine so the Exec Log surface is never empty.
+//
+// step carries the slug + (optional) display + order. If the step was
+// already declared via SeedSteps the display/order there win for the
+// persisted row's DependsOn chain; passing them again is harmless.
+func (a *ActivityBridge) StartStep(step ActivityStep, message string, t time.Time) error {
+	step.Slug = strings.TrimSpace(step.Slug)
+	if step.Slug == "" {
+		return nil
+	}
+	t = t.UTC()
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if err := a.ensureStepLocked(step); err != nil {
+		return err
+	}
+	jobName := ActivityStepJobName(a.groupSlug, step.Slug)
+
+	// Reuse an open Execution: prefer the in-memory cursor, then fall
+	// back to the persisted LatestExecutionID when it's still running
+	// (Pod-restart resume). Only allocate a fresh Execution when neither
+	// is live — this is what prevents a resumed activity from minting a
+	// second Execution for a step that's already in flight.
+	execID := a.activeExecID[step.Slug]
+	if execID == "" {
+		if job, _, err := a.store.GetJob(a.deploymentID, jobName); err == nil &&
+			job.LatestExecutionID != "" && !IsTerminal(job.Status) {
+			execID = job.LatestExecutionID
+			a.activeExecID[step.Slug] = execID
+		}
+	}
+	if execID == "" {
+		exec, err := a.store.StartExecution(a.deploymentID, jobName, t)
+		if err != nil {
+			return err
+		}
+		execID = exec.ID
+		a.activeExecID[step.Slug] = execID
+	} else {
+		// Execution already open — StartExecution stamps Status=running
+		// on allocation, but on a reuse we still want the Job flipped to
+		// running (e.g. a resume that re-enters a step the durable record
+		// left at pending). UpsertJob's merge keeps the prior StartedAt.
+		if err := a.store.UpsertJob(Job{
+			DeploymentID: a.deploymentID,
+			JobName:      jobName,
+			DisplayName:  step.DisplayName,
+			Type:         JobTypeInstall,
+			ParentID:     JobID(a.deploymentID, a.groupSlug),
+			DependsOn:    a.dependsOnForStepLocked(step.Slug),
+			Status:       StatusRunning,
+		}); err != nil {
+			return err
+		}
+	}
+
+	msg := strings.TrimSpace(message)
+	if msg == "" {
+		msg = "[" + step.Slug + "] started"
+	}
+	return a.store.AppendLogLines(a.deploymentID, execID, []LogLine{{
+		Timestamp: t,
+		Level:     LevelInfo,
+		Message:   msg,
+	}})
+}
+
+// FinishStep transitions a step into its terminal state and closes its
+// Execution. result is the source's native result string (one of the
+// ActivityResult* consts); it maps onto the Job Status enum. A
+// "skipped" / "success" result lands Succeeded; "failed" lands Failed.
+// An optional message is appended as the final LogLine.
+//
+// Idempotent: FinishExecution is a no-op on an already-terminal
+// Execution, and a step with no open Execution (e.g. a "skipped" step
+// the source never started) gets one allocated retroactively so the
+// JobsTable never renders an em-dash duration cell — matching the
+// helmwatch bridge's markLifecyclePhaseTerminalLocked.
+func (a *ActivityBridge) FinishStep(step ActivityStep, result, message string, t time.Time) error {
+	step.Slug = strings.TrimSpace(step.Slug)
+	if step.Slug == "" {
+		return nil
+	}
+	t = t.UTC()
+	status := activityStatusFromResult(result)
+	if !IsTerminal(status) {
+		// A non-terminal result handed to FinishStep is a source bug;
+		// treat it as success so we never leave a step wedged, but the
+		// caller really should use StartStep for "running".
+		status = StatusSucceeded
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if err := a.ensureStepLocked(step); err != nil {
+		return err
+	}
+	jobName := ActivityStepJobName(a.groupSlug, step.Slug)
+
+	execID := a.activeExecID[step.Slug]
+	if execID == "" {
+		// Re-attach to a persisted open Execution (resume) before
+		// allocating a new one.
+		if job, _, err := a.store.GetJob(a.deploymentID, jobName); err == nil && job.LatestExecutionID != "" {
+			if priorExec, ferr := a.store.FindExecution(a.deploymentID, job.LatestExecutionID); ferr == nil && !IsTerminal(priorExec.Status) {
+				execID = job.LatestExecutionID
+			}
+		}
+	}
+	if execID == "" {
+		exec, err := a.store.StartExecution(a.deploymentID, jobName, t)
+		if err != nil {
+			return err
+		}
+		execID = exec.ID
+	}
+
+	if msg := strings.TrimSpace(message); msg != "" {
+		level := LevelInfo
+		if status == StatusFailed {
+			level = LevelError
+		}
+		if err := a.store.AppendLogLines(a.deploymentID, execID, []LogLine{{
+			Timestamp: t,
+			Level:     level,
+			Message:   msg,
+		}}); err != nil {
+			return err
+		}
+	}
+
+	if err := a.store.FinishExecution(a.deploymentID, execID, status, t); err != nil {
+		return err
+	}
+	delete(a.activeExecID, step.Slug)
+	return nil
+}
+
+// activityStatusFromResult maps an activity's native per-step result
+// string onto the Job Status enum. Unknown/empty results map to
+// pending so a not-yet-attempted step renders correctly.
+func activityStatusFromResult(result string) string {
+	switch strings.ToLower(strings.TrimSpace(result)) {
+	case ActivityResultSuccess, ActivityResultSkipped:
+		return StatusSucceeded
+	case ActivityResultFailed:
+		return StatusFailed
+	case ActivityResultRunning:
+		return StatusRunning
+	default:
+		return StatusPending
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/jobs/activity_bridge_test.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/activity_bridge_test.go
@@ -1,0 +1,221 @@
+// activity_bridge_test.go — proves the GENERIC source-bridge projects a
+// declared activity (e.g. the 11-step cutover) into the same Job +
+// Execution + LogLine model the canvas reads, WITH dependsOn edges and a
+// group whose status rolls up from its steps (issue #3646).
+package jobs
+
+import (
+	"testing"
+	"time"
+)
+
+func newActivityFixture(t *testing.T) (*Store, *ActivityBridge, string) {
+	t.Helper()
+	st, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	depID := "dep-activity"
+	return st, NewActivityBridge(st, depID, GroupCutover, GroupCutoverDisplay), depID
+}
+
+// findJob returns the Job with the given JobName from a slice, or fails.
+func findActivityJob(t *testing.T, in []Job, name string) Job {
+	t.Helper()
+	for _, j := range in {
+		if j.JobName == name {
+			return j
+		}
+	}
+	t.Fatalf("job %q not found in %d rows", name, len(in))
+	return Job{}
+}
+
+// TestActivityBridge_SeedProjectsStepsWithEdges is the core acceptance
+// test for #3646: seeding a cutover-style activity projects one Job per
+// step under the Cutover group, each step depending on the prior step,
+// and the group rolls its status up from the steps.
+func TestActivityBridge_SeedProjectsStepsWithEdges(t *testing.T) {
+	st, ab, depID := newActivityFixture(t)
+
+	// A 3-step slice deliberately given OUT of order to prove the bridge
+	// sorts by Order before chaining the edges.
+	steps := []ActivityStep{
+		{Slug: "harbor-prewarm", DisplayName: "Harbor Prewarm", Order: 3},
+		{Slug: "gitea-mirror", DisplayName: "Gitea Mirror", Order: 1},
+		{Slug: "registry-pivot", DisplayName: "Registry Pivot", Order: 2},
+	}
+	if err := ab.SeedSteps(steps); err != nil {
+		t.Fatalf("SeedSteps: %v", err)
+	}
+
+	got, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+
+	// The Cutover group must exist as a group Job.
+	group := findActivityJob(t, got, GroupCutover)
+	if group.Type != JobTypeGroup {
+		t.Fatalf("group %q: Type = %q, want %q", GroupCutover, group.Type, JobTypeGroup)
+	}
+	if group.DisplayName != GroupCutoverDisplay {
+		t.Errorf("group DisplayName = %q, want %q", group.DisplayName, GroupCutoverDisplay)
+	}
+	// All steps pending => group pending.
+	if group.Status != StatusPending {
+		t.Errorf("group status = %q, want %q (all steps pending)", group.Status, StatusPending)
+	}
+
+	// Each step is a leaf under the Cutover group.
+	mirror := findActivityJob(t, got, ActivityStepJobName(GroupCutover, "gitea-mirror"))
+	pivot := findActivityJob(t, got, ActivityStepJobName(GroupCutover, "registry-pivot"))
+	prewarm := findActivityJob(t, got, ActivityStepJobName(GroupCutover, "harbor-prewarm"))
+
+	for _, s := range []Job{mirror, pivot, prewarm} {
+		if s.Type != JobTypeInstall {
+			t.Errorf("step %q: Type = %q, want %q", s.JobName, s.Type, JobTypeInstall)
+		}
+		if s.ParentID != JobID(depID, GroupCutover) {
+			t.Errorf("step %q: ParentID = %q, want %q", s.JobName, s.ParentID, JobID(depID, GroupCutover))
+		}
+		if s.Status != StatusPending {
+			t.Errorf("step %q: Status = %q, want %q", s.JobName, s.Status, StatusPending)
+		}
+	}
+
+	// Edges: first step (gitea-mirror, order 1) has NO deps; registry-pivot
+	// depends on gitea-mirror; harbor-prewarm depends on registry-pivot.
+	if len(mirror.DependsOn) != 0 {
+		t.Errorf("gitea-mirror DependsOn = %v, want [] (first step)", mirror.DependsOn)
+	}
+	wantPivotDep := ActivityStepJobName(GroupCutover, "gitea-mirror")
+	if len(pivot.DependsOn) != 1 || pivot.DependsOn[0] != wantPivotDep {
+		t.Errorf("registry-pivot DependsOn = %v, want [%q]", pivot.DependsOn, wantPivotDep)
+	}
+	wantPrewarmDep := ActivityStepJobName(GroupCutover, "registry-pivot")
+	if len(prewarm.DependsOn) != 1 || prewarm.DependsOn[0] != wantPrewarmDep {
+		t.Errorf("harbor-prewarm DependsOn = %v, want [%q]", prewarm.DependsOn, wantPrewarmDep)
+	}
+
+	// The group must list all three steps as children.
+	if len(group.ChildIDs) != 3 {
+		t.Errorf("group ChildIDs = %v, want 3 children", group.ChildIDs)
+	}
+}
+
+// TestActivityBridge_StepLifecycleRollsUp proves a step transitioning
+// running → succeeded drives an Execution + log lines and rolls the group
+// status up; and that a failed step rolls the group up to failed (never a
+// misleading "succeeded" — the #3646 defect).
+func TestActivityBridge_StepLifecycleRollsUp(t *testing.T) {
+	st, ab, depID := newActivityFixture(t)
+	base := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+
+	steps := []ActivityStep{
+		{Slug: "gitea-mirror", Order: 1},
+		{Slug: "registry-pivot", Order: 2},
+	}
+	if err := ab.SeedSteps(steps); err != nil {
+		t.Fatalf("SeedSteps: %v", err)
+	}
+
+	// Step 1 runs then succeeds.
+	if err := ab.StartStep(steps[0], "mirror started", base); err != nil {
+		t.Fatalf("StartStep(0): %v", err)
+	}
+	// Mid-run the group is running.
+	group := findActivityJob(t, mustListA(t, st, depID), GroupCutover)
+	if group.Status != StatusRunning {
+		t.Fatalf("group status mid-run = %q, want %q", group.Status, StatusRunning)
+	}
+	if err := ab.FinishStep(steps[0], ActivityResultSuccess, "mirror done", base.Add(time.Minute)); err != nil {
+		t.Fatalf("FinishStep(0): %v", err)
+	}
+
+	// Step 1 must now be succeeded with a finished Execution carrying log
+	// lines (a real exec surface, not a fabricated row).
+	step1, execs, err := st.GetJob(depID, ActivityStepJobName(GroupCutover, "gitea-mirror"))
+	if err != nil {
+		t.Fatalf("GetJob(step1): %v", err)
+	}
+	if step1.Status != StatusSucceeded {
+		t.Errorf("step1 status = %q, want %q", step1.Status, StatusSucceeded)
+	}
+	if len(execs) != 1 {
+		t.Fatalf("step1 executions = %d, want 1", len(execs))
+	}
+	if !IsTerminal(execs[0].Status) {
+		t.Errorf("step1 execution status = %q, want terminal", execs[0].Status)
+	}
+	page, err := st.PageLogs(depID, execs[0].ID, 1, 100)
+	if err != nil {
+		t.Fatalf("PageLogs(step1): %v", err)
+	}
+	if page.Total < 2 {
+		t.Errorf("step1 log lines = %d, want >= 2 (start + finish)", page.Total)
+	}
+
+	// Group is still running (step 2 pending).
+	group = findActivityJob(t, mustListA(t, st, depID), GroupCutover)
+	if group.Status != StatusPending && group.Status != StatusRunning {
+		t.Errorf("group status after step1 = %q, want pending/running (step2 not started)", group.Status)
+	}
+
+	// Step 2 fails — the group MUST roll up to failed (the #3646
+	// regression was the group/leaf reading "succeeded" while the
+	// execution had not truly completed).
+	if err := ab.StartStep(steps[1], "pivot started", base.Add(2*time.Minute)); err != nil {
+		t.Fatalf("StartStep(1): %v", err)
+	}
+	if err := ab.FinishStep(steps[1], ActivityResultFailed, "pivot blew up", base.Add(3*time.Minute)); err != nil {
+		t.Fatalf("FinishStep(1): %v", err)
+	}
+	group = findActivityJob(t, mustListA(t, st, depID), GroupCutover)
+	if group.Status != StatusFailed {
+		t.Errorf("group status after step2 failure = %q, want %q", group.Status, StatusFailed)
+	}
+}
+
+// TestActivityBridge_ResumeReusesExecution proves the resume idempotency
+// property: re-calling StartStep for a step that already has an open
+// Execution does NOT mint a second Execution (the cutover engine resumes
+// across Pod restarts and re-emits transitions).
+func TestActivityBridge_ResumeReusesExecution(t *testing.T) {
+	st, ab, depID := newActivityFixture(t)
+	base := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+
+	step := ActivityStep{Slug: "egress-block-test", Order: 1}
+	if err := ab.SeedSteps([]ActivityStep{step}); err != nil {
+		t.Fatalf("SeedSteps: %v", err)
+	}
+	if err := ab.StartStep(step, "first start", base); err != nil {
+		t.Fatalf("StartStep#1: %v", err)
+	}
+	// Simulate a Pod restart: a NEW bridge over the SAME store (in-memory
+	// cursor lost). The persisted LatestExecutionID must be reused.
+	ab2 := NewActivityBridge(st, depID, GroupCutover, GroupCutoverDisplay)
+	if err := ab2.SeedSteps([]ActivityStep{step}); err != nil {
+		t.Fatalf("SeedSteps#2: %v", err)
+	}
+	if err := ab2.StartStep(step, "resumed start", base.Add(time.Minute)); err != nil {
+		t.Fatalf("StartStep#2 (resume): %v", err)
+	}
+
+	_, execs, err := st.GetJob(depID, ActivityStepJobName(GroupCutover, "egress-block-test"))
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if len(execs) != 1 {
+		t.Fatalf("executions after resume = %d, want 1 (resume must reuse the open Execution, not mint a second)", len(execs))
+	}
+}
+
+func mustListA(t *testing.T, st *Store, depID string) []Job {
+	t.Helper()
+	got, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	return got
+}

--- a/products/catalyst/bootstrap/api/internal/jobs/store.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/store.go
@@ -888,6 +888,40 @@ func (s *Store) FindExecutionAcrossDeployments(execID string) (Execution, error)
 	return Execution{}, fmt.Errorf("jobs: FindExecutionAcrossDeployments %q: %w", execID, ErrNotFound)
 }
 
+// DeploymentIDs returns the id of every deployment the store has an
+// on-disk index for (one subdirectory per deployment). Order is the
+// filesystem ReadDir order (lexical on most filesystems). A missing
+// store root is not an error — it returns an empty slice (the store was
+// constructed but no deployment has been written yet).
+//
+// Used by activity sources that run on a Sovereign chroot and need to
+// resolve which deployment id to project under WITHOUT depending on the
+// handler's in-memory deployment map: the chroot's store carries exactly
+// the deployment imported at handover (HandleJobsImport writes it under
+// the mother's id), so the cutover/activity bridge can find its target
+// by scanning for a deployment that already has the imported
+// bootstrap-kit group. The caller does the group-presence check via
+// ListJobs; this method only enumerates.
+func (s *Store) DeploymentIDs() ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("jobs: scan store dir %q: %w", s.dir, err)
+	}
+	out := make([]string, 0, len(entries))
+	for _, ent := range entries {
+		if ent.IsDir() {
+			out = append(out, ent.Name())
+		}
+	}
+	return out, nil
+}
+
 // LogPage is the wire-contract response shape for the /logs endpoint.
 // Defined in the store package so the handler doesn't have to
 // re-declare it.


### PR DESCRIPTION
## What & why (issue #3646)

The console `/jobs` page showed `install-self-sovereign-cutover` as **"Succeeded"** — but that is the dormant **chart INSTALL** (bp-self-sovereign-cutover deploys dormant at bootstrap; it ships 11 step ConfigMaps + RBAC and fires NO steps). The real **11-step cutover EXECUTION** (fired post-handover) was invisible on `/jobs` — its true state lived ONLY in the `self-sovereign-cutover-status` ConfigMap. Operators read "Succeeded" while the execution was mid-flight at step 3/11.

**"Flux first"**: every platform activity should appear on the jobs canvas as a projection of a reconciling object — the same way a HelmRelease becomes a leaf Job via the helmwatch bridge. This extends that model so currently-INVISIBLE activities also appear, **generically**.

## Approach — a generic source-bridge, not a cutover hack

- **`internal/jobs/activity_bridge.go`** — `jobs.ActivityBridge`: the reusable source-bridge (one per activity source). Projects a declared activity's ordered steps into the **SAME** Job + Execution + LogLine model the helmwatch bridge uses: a top-level group Job + one leaf step Job each, wired with a **linear `dependsOn` chain**, with per-step executions + log lines, and **idempotent resume** across Pod restarts. Group status rolls up from its steps via the existing `deriveTreeView` (succeeded only when every step truly succeeded). A future DR switchover / backup-restore wires the same way.
- **`internal/jobs/store.go`** — `Store.DeploymentIDs()` enumerator so a chroot activity source resolves its own deployment id without the in-memory map.
- **`internal/handler/cutover_activity_bridge.go`** — the cutover-specific WIRING: feeds the bridge at the same transition points `runCutover`/`runCutoverStep` already emit, reading the **REAL** `batch/v1` Job results; plus a read-path replay from the durable status ConfigMap so the `Cutover` group is present even when no engine goroutine is running (the exact #3646 "operator opens /jobs after handover" scenario).
- **`internal/handler/cutover.go`** — projection calls at start / step-started / step-success / resume-success / failure. Best-effort + strictly additive; never blocks the cutover.
- **`internal/handler/jobs.go`** — chroot lazy-seed read path also projects the cutover execution so `/jobs` surfaces it on first read.

The dormant chart-install leaf stays a separate row; the execution now has its own honest `Cutover` group.

## Scope boundary
Backend (catalyst-api bridge + jobs model) only. **The UI canvas is handled separately** (per train plan car split) — this PR does not touch it.

## Tests (`go build ./...` + `go test` green)
- `internal/jobs/activity_bridge_test.go` — generic bridge: group + step rows under the group, dependsOn edges along step order, status rollup, **failed step → group failed** (the anti-#3646 guarantee), resume reuses the open Execution (no duplicate).
- `internal/handler/cutover_activity_bridge_test.go` — real engine run (`HandleCutoverStart`) projects the `Cutover` group with edges; durable-status replay shows a mid-flight cutover as **running, never "Succeeded"**.

Refs #3646 #3648. Part of train/hw150 (car T3 — unified activities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)