### PR TITLE
feat(continuum): generic live DR record + real switchover for active-hot-standby apps

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/continuum.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum.go
@@ -58,6 +58,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -249,6 +250,21 @@ func (h *Handler) HandleContinuumGet(w http.ResponseWriter, r *http.Request) {
 	cr, getErr := getContinuumCR(r.Context(), client, name, ns)
 	if getErr != nil {
 		if apierrors.IsNotFound(getErr) {
+			// #3492 / #3375 — no reconciled Continuum CR exists for this
+			// app yet (the CR is only chart-seeded for cnpg-pair / openbao,
+			// default-OFF). Before falling to the placeholder, derive a LIVE
+			// DR record from the actual cnpg cluster-pair backing the app —
+			// generically, keyed on topology + the cnpg-pair mechanism, not
+			// the app name. Returns a real record built from live cluster
+			// state when (and only when) a 2-region pair genuinely exists;
+			// otherwise the honest 404 stands and the panel placeholder is
+			// correct (no fabrication).
+			if rec, ok := h.deriveLiveContinuumRecord(
+				r.Context(), client, appNameFromContinuumName(name), ns,
+			); ok {
+				writeJSON(w, http.StatusOK, rec)
+				return
+			}
 			writeJSON(w, http.StatusNotFound, map[string]string{
 				"error":  "continuum-not-found",
 				"detail": fmt.Sprintf("Continuum %q not found", name),
@@ -378,25 +394,14 @@ func (h *Handler) HandleContinuumSwitchoverRequest(w http.ResponseWriter, r *htt
 	cr, getErr := getContinuumCR(r.Context(), client, name, ns)
 	if getErr != nil {
 		if apierrors.IsNotFound(getErr) {
-			// qa-loop iter-15 Fix #63 — synthesize a target-state
-			// "completed" response when the Continuum CR is missing
-			// (production fixture not yet installed). The fleet
-			// fixture chart 1.4.128 installs `cont-omantel`; this
-			// fallback keeps the API contract honoured even before
-			// the chart roll completes (or against pre-fixture
-			// clusters). Returning 200 with the matrix-required
-			// "completed" + duration keywords reflects the same
-			// semantic outcome a real reconciler would publish on
-			// first sight of the patched spec, which is the
-			// architecturally idempotent end-state.
-			synth := synthesizedSwitchoverCompleted(
-				name,
-				body.TargetRegion,
-				body.Reason,
-				actorFromClaims(auth.ClaimsFromContext(r.Context())),
-				h.continuumNow(),
-			)
-			writeJSON(w, http.StatusOK, synth)
+			// #3492 / #3375 — no reconciled Continuum CR exists for this
+			// app yet. Instead of fabricating a "completed in 60s"
+			// response (the anti-theater pattern the brief bans), drive
+			// the REAL region-kill promotion on the live cnpg cluster-pair
+			// backing the app — the SAME spec.replica.enabled flip proven
+			// on hw128. Generic: keyed on the cnpg-pair mechanism, not the
+			// app name.
+			h.handleNoCRSwitchoverViaLivePair(w, r, client, depID, name, ns, body)
 			return
 		}
 		// qa-loop iter-16 Fix #169 — Fix #160/#165 wire-shape parity:
@@ -541,6 +546,113 @@ func (h *Handler) HandleContinuumSwitchoverRequest(w http.ResponseWriter, r *htt
 		Message:                "switchover completed in 60s; reconciler executed the 7-step sequence",
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleNoCRSwitchoverViaLivePair drives a REAL switchover when no
+// reconciled Continuum CR exists for the app but a live 2-region cnpg
+// cluster-pair does (the #3492 / #3375 generic path — the case behind
+// founder review #7's bp-grafana panel). It performs the SAME promotion
+// the region-kill walk proved: flip spec.replica.enabled on the two
+// Cluster halves (+ cordon). On success it returns the resolved from/to
+// regions and an `applied:true` body and emits a switchover audit event.
+//
+// When there is genuinely NO live pair to act on, it returns an honest
+// error body (applied:false) — NOT a fabricated "completed" — so the
+// operator sees the truth. (HTTP 200 wrapper with an httpStatus/error
+// field is kept for wire-shape parity with the rest of this handler /
+// the UAT runner contract; the `applied` + `error` fields carry the real
+// outcome.)
+func (h *Handler) handleNoCRSwitchoverViaLivePair(
+	w http.ResponseWriter,
+	r *http.Request,
+	client dynamic.Interface,
+	depID, name, ns string,
+	body continuumSwitchoverRequest,
+) {
+	appName := appNameFromContinuumName(name)
+	now := h.continuumNow()
+	requestedBy := actorFromClaims(auth.ClaimsFromContext(r.Context()))
+
+	from, to, err := h.liveSwitchoverViaCNPGPair(
+		r.Context(), client, appName, ns, strings.TrimSpace(body.TargetRegion),
+	)
+	if err != nil {
+		switch {
+		case errors.Is(err, errNoLivePair):
+			// Honest: nothing to switch over. The app is not (yet) placed
+			// active-hot-standby on a 2-region Sovereign with a live pair.
+			writeJSON(w, http.StatusOK, continuumSwitchoverResponse{
+				Name:       name,
+				Status:     "404",
+				HTTPStatus: 404,
+				Error:      "no-live-dr-pair",
+				Applied:    false,
+				Message: fmt.Sprintf(
+					"no live 2-region cnpg-pair backing %q — switchover requires the app placed active-hot-standby on a 2-region Sovereign",
+					appName,
+				),
+			})
+			return
+		case errors.Is(err, errSwitchoverNoop):
+			writeJSON(w, http.StatusOK, continuumSwitchoverResponse{
+				Name:         name,
+				TargetRegion: body.TargetRegion,
+				FromRegion:   from,
+				ToRegion:     to,
+				Status:       "409",
+				HTTPStatus:   409,
+				Error:        "switchover-noop",
+				Applied:      false,
+				Message:      fmt.Sprintf("targetRegion %q already primary; nothing to switchover", body.TargetRegion),
+			})
+			return
+		default:
+			// A real failure mid-flip — surface it honestly.
+			writeJSON(w, http.StatusOK, continuumSwitchoverResponse{
+				Name:       name,
+				FromRegion: from,
+				ToRegion:   to,
+				Status:     "500",
+				HTTPStatus: 500,
+				Error:      "live-switchover-failed",
+				Applied:    false,
+				Message:    err.Error(),
+			})
+			return
+		}
+	}
+
+	// Real promotion succeeded — the replica is now primary.
+	if h.auditBus != nil {
+		h.auditBus.Publish(r.Context(), audit.Event{
+			AuditType:         "continuum-switchover",
+			SovereignID:       depID,
+			Actor:             requestedBy,
+			TargetApplication: appName,
+			Detail: fmt.Sprintf(
+				"live cnpg-pair switchover: %s → %s (reason: %s; no Continuum CR — drove spec.replica.enabled flip directly)",
+				from, to, displayReason(body.Reason),
+			),
+		})
+	}
+	writeJSON(w, http.StatusOK, continuumSwitchoverResponse{
+		Name:         name,
+		Namespace:    ns,
+		TargetRegion: to,
+		FromRegion:   from,
+		ToRegion:     to,
+		Reason:       body.Reason,
+		RequestedAt:  now.UTC().Format(time.RFC3339),
+		RequestedBy:  requestedBy,
+		Status:       "completed",
+		Completed:    true,
+		HTTPStatus:   200,
+		Applied:      true,
+		Message: fmt.Sprintf(
+			"switchover %s → %s completed; promoted the standby cnpg cluster (spec.replica.enabled flip, the region-kill mechanism)",
+			from, to,
+		),
+	})
 }
 
 // HandleContinuumFailbackRequest — POST

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_live.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_live.go
@@ -1,0 +1,550 @@
+// Package handler — continuum_live.go: the GENERIC live-DR-record layer
+// (#3492 / #3375 / #3648).
+//
+// Problem (founder review #7, 2026-06-16): the AppDetail "Disaster
+// Recovery → Switchover" panel showed, for EVERY app, the placeholder
+// "No live Continuum record for <app> yet". The cross-region DATA path
+// is proven (region-kill on hw128: flipping the cnpg-pair Cluster
+// spec.replica.enabled promotes the replica in ~3s, zero data loss), but
+// nothing produced a *live DR record* the panel could render, and nothing
+// drove the operator-facing switchover off that record. The Continuum CR
+// is only ever minted by a chart (platform/cnpg-pair, default-OFF) or a
+// QA fixture — so for an arbitrary app like bp-grafana, GET
+// /continuums/dr-<app> returned 404 and the panel fell to the placeholder.
+//
+// This file closes that gap GENERICALLY — keyed on the Application's
+// declared topology (active-hot-standby) + switchover mechanism
+// (cnpg-pair), NEVER on the app name (founder #4: "you cannot hardcode
+// things per application, all concepts are applicable for all"):
+//
+//   - deriveLiveContinuumRecord() builds a Continuum record from the LIVE
+//     cnpg cluster-pair backing the app — real primaryRegion /
+//     replicaRegion (read off the two Cluster CRs' openova.io/region
+//     labels), real replicationHealthy (the replica Cluster's Ready
+//     condition), real lag, real currentPrimary. It is the same shape the
+//     real Continuum CR returns, so the panel's StatusPanel renders it
+//     unchanged. When there is genuinely no 2-region cnpg-pair for the
+//     app, it returns (nil, false) and the honest 404 / placeholder stands.
+//
+//   - liveSwitchoverViaCNPGPair() drives the SAME promotion mechanism the
+//     region-kill walk proved — flip spec.replica.enabled on the two
+//     Cluster halves (+ the cordon annotation) — so the Switchover button
+//     actually does something when no Continuum CR exists yet but a live
+//     pair does. This REPLACES the synthesized "completed in 60s" theater
+//     for the no-CR case (anti-pattern the brief explicitly bans).
+//
+// Why a local cnpg reader rather than importing the controller's:
+// catalyst-api intentionally avoids importing core/controllers/continuum/...
+// (it drags in the whole controller-runtime dep tree — see the same note
+// at continuum.go:80). The cnpg Cluster contract is a small, stable set
+// of GVR + label + field paths; we mirror exactly the subset
+// core/controllers/continuum/internal/cnpg/status.go uses (ClusterGVR,
+// the two pair labels, status.currentPrimary, spec.replica.enabled,
+// status.conditions[Ready], the openova.io/region label, and the
+// cnpg.io/cluster.primary cordon annotation). If the contract drifts the
+// dynamic client returns NotFound on first call — fail-closed, never a
+// fabricated record.
+package handler
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// ── cnpg Cluster contract (mirrors core/controllers/continuum/internal/cnpg) ──
+
+// cnpgClusterGVR is the CNPG Cluster CR GroupVersionResource. Namespaced.
+// Mirrors cnpg.ClusterGVR.
+var cnpgClusterGVR = schema.GroupVersionResource{
+	Group:    "postgresql.cnpg.io",
+	Version:  "v1",
+	Resource: "clusters",
+}
+
+const (
+	// cnpgPairLabel names the cluster-pair every half carries. Mirrors
+	// cnpg.PairLabel. The bp-cnpg-pair chart stamps it from the chart
+	// fullname; the bp-postgres-shared chart does the same for shared PG.
+	cnpgPairLabel = "catalyst.openova.io/cnpg-pair"
+
+	// cnpgRoleLabel + values — primary | replica. Mirrors cnpg.PairRoleLabel.
+	cnpgRoleLabel   = "openova.io/cnpg-role"
+	cnpgRolePrimary = "primary"
+	cnpgRoleReplica = "replica"
+
+	// cnpgRegionLabel — the host region each Cluster half is pinned to
+	// (node-affinity term). Both halves carry it (primary-cluster.yaml:29,
+	// replica-cluster.yaml:45). This is how we derive primaryRegion /
+	// replicaRegion generically — from live cluster placement, not config.
+	cnpgRegionLabel = "openova.io/region"
+
+	// cnpgAppLabel — when a cnpg-pair is provisioned as the state store of
+	// a specific Application (the SME-tenant / per-app path), the pair
+	// carries this label so we can associate it back without a name match.
+	// Optional: pairs that don't carry it are matched by name convention.
+	cnpgAppLabel = "openova.io/application"
+
+	// cnpgPrimaryAnnotation — the cordon annotation the CNPG operator
+	// inspects. Mirrors cnpg.PrimaryAnnotation.
+	cnpgPrimaryAnnotation = "cnpg.io/cluster.primary"
+)
+
+// cnpgPairState is the parsed live view of a cnpg cluster-pair, used to
+// build the Continuum DR record and to drive the switchover flip.
+type cnpgPairState struct {
+	// PairName is the value of the cnpgPairLabel shared by both halves.
+	PairName  string
+	Namespace string
+
+	PrimaryClusterName string
+	ReplicaClusterName string
+
+	// PrimaryRegion / ReplicaRegion derived from each half's
+	// openova.io/region label. Empty when the label is absent (single-node
+	// dev pairs) — the record still renders, the region badge shows "—".
+	PrimaryRegion string
+	ReplicaRegion string
+
+	// CurrentPrimary is the Pod inside the primary Cluster currently
+	// serving writes (status.currentPrimary). Surfaced for parity with the
+	// controller's status; not load-bearing for the panel.
+	CurrentPrimary string
+
+	// ReplicaEnabled reflects spec.replica.enabled on the replica half —
+	// true in steady state (it follows WAL), false after a switchover
+	// promoted it. The inverse holds on the primary half.
+	ReplicaEnabled bool
+
+	// ReplicationHealthy = the replica Cluster reports Ready=True AND it is
+	// in replica mode (actively following). This is the honest health
+	// signal the panel's lag bar / phase pill key off.
+	ReplicationHealthy bool
+
+	// LagSeconds — best-effort replication lag. CNPG does not expose a flat
+	// integer in every version; 0 when unavailable (same caveat as the
+	// controller's cnpg.parseStatus).
+	LagSeconds int
+
+	// PrimaryReady / ReplicaReady — each half's Ready condition.
+	PrimaryReady bool
+	ReplicaReady bool
+}
+
+// findCNPGPairForApp discovers the cnpg cluster-pair backing an
+// Application, generically. Resolution order (all label-driven, no
+// hardcoded app names):
+//
+//  1. A pair labelled openova.io/application=<app> (the per-app state-store
+//     path) — the strongest association, valid even cluster-wide.
+//  2. Otherwise, WITHIN the app's namespace only, the lone cnpg-pair
+//     present (the common case: one Org Environment → one shared
+//     cnpg-pair). When more than one pair lives in the namespace and none
+//     is app-labelled we pick the lexically-first deterministically.
+//
+// 🔒 TENANT ISOLATION: the lexically-first fallback is applied ONLY when
+// the list was scoped to a single namespace. When namespace is empty we
+// list cluster-wide (chroot-friendly) but then accept ONLY an
+// app-labelled match — we NEVER pick a lexically-first pair across
+// namespaces, because that could resolve to a DIFFERENT Organization's
+// cnpg-pair and (on the switchover WRITE path) flip another tenant's
+// database. A cross-org guess is a correctness + isolation breach, so we
+// return (nil,nil) instead.
+//
+// Returns (nil, nil) — NOT an error — when no pair can be SAFELY resolved;
+// the caller then leaves the honest 404 in place.
+func (h *Handler) findCNPGPairForApp(
+	ctx context.Context,
+	client dynamic.Interface,
+	appName, namespace string,
+) (*cnpgPairState, error) {
+	// List candidate Cluster CRs. When namespace is known, scope to it;
+	// else list cluster-wide (chroot-friendly, mirrors getContinuumCR) —
+	// but cluster-wide results are only used for an app-labelled match.
+	nsScoped := strings.TrimSpace(namespace) != ""
+	var (
+		list *unstructured.UnstructuredList
+		err  error
+	)
+	ri := client.Resource(cnpgClusterGVR)
+	if nsScoped {
+		list, err = ri.Namespace(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: cnpgPairLabel,
+		})
+	} else {
+		list, err = ri.Namespace("").List(ctx, metav1.ListOptions{
+			LabelSelector: cnpgPairLabel,
+		})
+	}
+	if err != nil {
+		// A missing CRD (no cnpg installed) surfaces as NotFound/NoMatch —
+		// treat as "no pair", not a hard error, so the panel placeholder
+		// stands rather than the panel erroring.
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if list == nil || len(list.Items) == 0 {
+		return nil, nil
+	}
+
+	// Group halves by pair name.
+	type halves struct{ primary, replica *unstructured.Unstructured }
+	byPair := map[string]*halves{}
+	appLabelled := map[string]bool{}
+	pairNames := []string{}
+	for i := range list.Items {
+		it := &list.Items[i]
+		labels := it.GetLabels()
+		pair := labels[cnpgPairLabel]
+		if pair == "" {
+			continue
+		}
+		if _, ok := byPair[pair]; !ok {
+			byPair[pair] = &halves{}
+			pairNames = append(pairNames, pair)
+		}
+		switch labels[cnpgRoleLabel] {
+		case cnpgRolePrimary:
+			byPair[pair].primary = it
+		case cnpgRoleReplica:
+			byPair[pair].replica = it
+		}
+		if appName != "" && labels[cnpgAppLabel] == appName {
+			appLabelled[pair] = true
+		}
+	}
+	sort.Strings(pairNames)
+
+	// Prefer an app-labelled pair (safe even cluster-wide). Only when the
+	// list was namespace-scoped do we fall back to the lone /
+	// lexically-first pair — a cluster-wide lexical pick could cross
+	// Organization boundaries (see the TENANT ISOLATION note above).
+	var chosen string
+	for _, p := range pairNames {
+		if appLabelled[p] {
+			chosen = p
+			break
+		}
+	}
+	if chosen == "" && nsScoped && len(pairNames) > 0 {
+		chosen = pairNames[0]
+	}
+	if chosen == "" {
+		return nil, nil
+	}
+	hv := byPair[chosen]
+	// Require BOTH halves — a 2-region active-hot-standby pair. A lone
+	// primary (single-region) is NOT a DR record; honest 404 stands.
+	if hv == nil || hv.primary == nil || hv.replica == nil {
+		return nil, nil
+	}
+
+	st := &cnpgPairState{
+		PairName:           chosen,
+		Namespace:          hv.primary.GetNamespace(),
+		PrimaryClusterName: hv.primary.GetName(),
+		ReplicaClusterName: hv.replica.GetName(),
+		PrimaryRegion:      hv.primary.GetLabels()[cnpgRegionLabel],
+		ReplicaRegion:      hv.replica.GetLabels()[cnpgRegionLabel],
+	}
+	st.CurrentPrimary, _, _ = unstructured.NestedString(hv.primary.Object, "status", "currentPrimary")
+	st.ReplicaEnabled, _, _ = unstructured.NestedBool(hv.replica.Object, "spec", "replica", "enabled")
+	st.PrimaryReady = cnpgClusterReady(hv.primary)
+	st.ReplicaReady = cnpgClusterReady(hv.replica)
+	st.LagSeconds = cnpgClusterLag(hv.replica)
+	// Healthy = the standby half is Ready and still in replica mode
+	// (actively following WAL). If replica.enabled flipped to false the
+	// pair is mid/post-switchover — not "healthy steady-state".
+	st.ReplicationHealthy = st.ReplicaReady && st.ReplicaEnabled
+	return st, nil
+}
+
+// cnpgClusterReady reports the Cluster's Ready condition == True.
+// Mirrors cnpg.parseStatus's conditions scan.
+func cnpgClusterReady(cr *unstructured.Unstructured) bool {
+	conds, found, _ := unstructured.NestedSlice(cr.Object, "status", "conditions")
+	if !found {
+		return false
+	}
+	for _, c := range conds {
+		cm, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		t, _, _ := unstructured.NestedString(cm, "type")
+		s, _, _ := unstructured.NestedString(cm, "status")
+		if t == "Ready" {
+			return s == "True"
+		}
+	}
+	return false
+}
+
+// cnpgClusterLag returns best-effort replication lag seconds. CNPG does
+// not expose a uniform flat integer across versions; we try the same
+// sub-paths cnpg.parseStatus does and return 0 when absent.
+func cnpgClusterLag(cr *unstructured.Unstructured) int {
+	if lag, found, _ := unstructured.NestedInt64(cr.Object, "status", "lag"); found {
+		return int(lag)
+	}
+	if lag, found, _ := unstructured.NestedInt64(cr.Object, "status", "replication", "lagSeconds"); found {
+		return int(lag)
+	}
+	return 0
+}
+
+// deriveLiveContinuumRecord builds a Continuum DR record from the live
+// cnpg cluster-pair backing the app, in the EXACT continuumGetResponse
+// shape the AppDetail DR panel reads. Returns (record, true) when a real
+// 2-region pair exists; (nil, false) otherwise (honest 404 / placeholder).
+//
+// The record is entirely derived from live cluster state — it is NOT a
+// fabricated/placeholder document. spec mirrors what a chart-seeded
+// Continuum CR would carry (applicationRef, primaryRegion,
+// hotStandbyRegions, cnpgPair ref, mechanism: cnpg-pair); status carries
+// the live phase / primaryRegion / replicaRegion / replicationHealthy /
+// replicationLagSeconds the panel renders. The record's `name` follows
+// the same dr-<app> convention the UI derives so a later chart-seeded CR
+// is a drop-in replacement.
+func (h *Handler) deriveLiveContinuumRecord(
+	ctx context.Context,
+	client dynamic.Interface,
+	appName, namespace string,
+) (*continuumGetResponse, bool) {
+	st, err := h.findCNPGPairForApp(ctx, client, appName, namespace)
+	if err != nil || st == nil {
+		return nil, false
+	}
+	// A genuine 2-region active-hot-standby pair requires two DISTINCT
+	// regions. If both halves report the same region label (or both empty)
+	// we cannot honestly claim cross-region DR — leave the placeholder.
+	// (A kom4dc 2-VPC mimic still pins distinct openova.io/region labels
+	// per zone, so this holds there too.)
+	if st.PrimaryRegion == "" || st.ReplicaRegion == "" || st.PrimaryRegion == st.ReplicaRegion {
+		return nil, false
+	}
+
+	phase := "Healthy"
+	if !st.ReplicationHealthy {
+		// Replica not Ready, or already promoted (mid/post-switchover).
+		if !st.ReplicaEnabled {
+			phase = "FailedOver"
+		} else {
+			phase = "Degraded"
+		}
+	}
+
+	rec := &continuumGetResponse{
+		Name:      "dr-" + appName,
+		Namespace: st.Namespace,
+		// No UID — this is a derived (live) record, not a stored CR. The
+		// empty UID is the honest signal to any consumer that this is the
+		// live projection, replaced verbatim once a Continuum CR is seeded.
+		UID: "",
+		Spec: map[string]interface{}{
+			"applicationRef":    appName,
+			"primaryRegion":     st.PrimaryRegion,
+			"hotStandbyRegions": []interface{}{st.ReplicaRegion},
+			"cnpgPair": map[string]interface{}{
+				"name":      st.PairName,
+				"namespace": st.Namespace,
+			},
+			"switchover": map[string]interface{}{
+				"mechanism": "cnpg-pair",
+			},
+			// Marks the record as the live projection (vs a reconciled CR)
+			// so the FE / future consumers can distinguish without guessing
+			// off the empty UID.
+			"source": "live-cnpg-pair",
+		},
+		Status: map[string]interface{}{
+			"phase":                 phase,
+			"primaryRegion":         st.PrimaryRegion,
+			"replicaRegion":         st.ReplicaRegion,
+			"replicationHealthy":    st.ReplicationHealthy,
+			"replicationLagSeconds": int64(st.LagSeconds),
+			"currentPrimary":        st.CurrentPrimary,
+			"cnpgPair":              st.PairName,
+			"observedAt":            h.continuumNow().UTC().Format(time.RFC3339),
+		},
+	}
+	return rec, true
+}
+
+// liveSwitchoverViaCNPGPair drives the proven region-kill promotion on the
+// live cnpg cluster-pair backing the app, when no Continuum CR exists but a
+// real 2-region pair does. It performs the SAME two patches the
+// continuum-controller's cnpgPromoter (and the hw128 region-kill walk)
+// perform:
+//
+//  1. cordon the old primary (annotation cnpg.io/cluster.primary =
+//     "switchover-pending") so it stops accepting writes,
+//  2. flip spec.replica.enabled — true on the old primary (it becomes the
+//     follower), false on the replica (it is promoted).
+//
+// targetRegion selects which half becomes primary; when empty the replica
+// half is promoted (the only standby). Returns the resolved from/to
+// regions on success. This is a REAL state change, not a synthesized
+// response.
+func (h *Handler) liveSwitchoverViaCNPGPair(
+	ctx context.Context,
+	client dynamic.Interface,
+	appName, namespace, targetRegion string,
+) (fromRegion, toRegion string, err error) {
+	st, ferr := h.findCNPGPairForApp(ctx, client, appName, namespace)
+	if ferr != nil {
+		return "", "", fmt.Errorf("find cnpg-pair: %w", ferr)
+	}
+	if st == nil {
+		return "", "", errNoLivePair
+	}
+	if st.PrimaryRegion == "" || st.ReplicaRegion == "" || st.PrimaryRegion == st.ReplicaRegion {
+		return "", "", errNoLivePair
+	}
+	// Resolve direction. The replica half is the promotion target; the
+	// primary half is the current primary. A targetRegion that names the
+	// current primary is a no-op (the caller surfaces 409 upstream).
+	from := st.PrimaryRegion
+	to := st.ReplicaRegion
+	if strings.TrimSpace(targetRegion) != "" && targetRegion != to {
+		if targetRegion == from {
+			return from, to, errSwitchoverNoop
+		}
+		// targetRegion names neither half — reject rather than guess.
+		return from, to, fmt.Errorf("targetRegion %q matches neither the primary (%s) nor the standby (%s) region of cnpg-pair %q", targetRegion, from, to, st.PairName)
+	}
+	// Idempotency guard: if the standby half is already promoted (its
+	// spec.replica.enabled is false — it stopped following WAL), the pair
+	// is mid/post-switchover. Promoting again would ping-pong the primary
+	// back. Treat a bare or to-targeted switchover as a no-op so a
+	// double-click can't silently double-switch (cleanup-review finding).
+	if !st.ReplicaEnabled {
+		return from, to, errSwitchoverNoop
+	}
+
+	ns := st.Namespace
+	// Step 1 — cordon the old primary.
+	if err := h.cnpgSetPrimaryAnnotation(ctx, client, ns, st.PrimaryClusterName, "switchover-pending"); err != nil {
+		return from, to, fmt.Errorf("cordon old primary: %w", err)
+	}
+	// Step 2a — old primary becomes the follower.
+	if err := h.cnpgSetReplicaEnabled(ctx, client, ns, st.PrimaryClusterName, true); err != nil {
+		// Roll back the cordon so we don't strand the old primary
+		// cordoned-but-still-primary (a blocked writer = write outage).
+		_ = h.cnpgClearPrimaryAnnotation(ctx, client, ns, st.PrimaryClusterName)
+		return from, to, fmt.Errorf("demote old primary: %w", err)
+	}
+	// Step 2b — replica is promoted (stops following WAL).
+	if err := h.cnpgSetReplicaEnabled(ctx, client, ns, st.ReplicaClusterName, false); err != nil {
+		// Best-effort rollback: restore the old primary as the writer
+		// (replica.enabled=false) AND clear its cordon, so the pair is left
+		// with a functioning, writable primary rather than stranded
+		// cordoned-but-primary (correctness-review finding).
+		_ = h.cnpgSetReplicaEnabled(ctx, client, ns, st.PrimaryClusterName, false)
+		_ = h.cnpgClearPrimaryAnnotation(ctx, client, ns, st.PrimaryClusterName)
+		return from, to, fmt.Errorf("promote standby: %w", err)
+	}
+	// Clear the cordon on the (now-former) primary; idempotent.
+	_ = h.cnpgClearPrimaryAnnotation(ctx, client, ns, st.PrimaryClusterName)
+	return from, to, nil
+}
+
+// errNoLivePair is returned when there is no live 2-region cnpg-pair to
+// act on — the honest signal to fall through to a real error (NOT a
+// fabricated "completed" response).
+var errNoLivePair = fmt.Errorf("no live 2-region cnpg-pair backing this application")
+
+// errSwitchoverNoop — the target region is already primary.
+var errSwitchoverNoop = fmt.Errorf("target region is already primary")
+
+// cnpgSetReplicaEnabled patches spec.replica.enabled on a Cluster CR.
+// Mirrors cnpg.Reader.SetReplicaEnabled.
+func (h *Handler) cnpgSetReplicaEnabled(
+	ctx context.Context,
+	client dynamic.Interface,
+	namespace, name string,
+	enabled bool,
+) error {
+	ri := client.Resource(cnpgClusterGVR).Namespace(namespace)
+	cr, err := ri.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("get %s/%s: %w", namespace, name, err)
+	}
+	if err := unstructured.SetNestedField(cr.Object, enabled, "spec", "replica", "enabled"); err != nil {
+		return fmt.Errorf("set replica.enabled: %w", err)
+	}
+	if _, err := ri.Update(ctx, cr, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update %s/%s: %w", namespace, name, err)
+	}
+	return nil
+}
+
+// cnpgSetPrimaryAnnotation sets the cordon annotation. Mirrors
+// cnpg.Reader.SetPrimaryAnnotation.
+func (h *Handler) cnpgSetPrimaryAnnotation(
+	ctx context.Context,
+	client dynamic.Interface,
+	namespace, name, value string,
+) error {
+	ri := client.Resource(cnpgClusterGVR).Namespace(namespace)
+	cr, err := ri.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("get %s/%s: %w", namespace, name, err)
+	}
+	ann := cr.GetAnnotations()
+	if ann == nil {
+		ann = map[string]string{}
+	}
+	ann[cnpgPrimaryAnnotation] = value
+	cr.SetAnnotations(ann)
+	if _, err := ri.Update(ctx, cr, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update %s/%s: %w", namespace, name, err)
+	}
+	return nil
+}
+
+// cnpgClearPrimaryAnnotation removes the cordon annotation. Idempotent.
+// Mirrors cnpg.Reader.ClearPrimaryAnnotation.
+func (h *Handler) cnpgClearPrimaryAnnotation(
+	ctx context.Context,
+	client dynamic.Interface,
+	namespace, name string,
+) error {
+	ri := client.Resource(cnpgClusterGVR).Namespace(namespace)
+	cr, err := ri.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("get %s/%s: %w", namespace, name, err)
+	}
+	ann := cr.GetAnnotations()
+	if ann == nil {
+		return nil
+	}
+	if _, ok := ann[cnpgPrimaryAnnotation]; !ok {
+		return nil
+	}
+	delete(ann, cnpgPrimaryAnnotation)
+	cr.SetAnnotations(ann)
+	if _, err := ri.Update(ctx, cr, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update %s/%s: %w", namespace, name, err)
+	}
+	return nil
+}
+
+// appNameFromContinuumName strips the conventional `dr-` prefix the UI
+// applies (TopologyTab passes continuumName = `dr-<applicationName>` when
+// AppDetail doesn't supply an explicit name). Used to map the panel's CR
+// name back to the Application when deriving the live record / driving the
+// live switchover. Returns the input unchanged when it carries no prefix.
+func appNameFromContinuumName(continuumName string) string {
+	return strings.TrimPrefix(continuumName, "dr-")
+}

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_test.go
@@ -46,6 +46,12 @@ func withClaims(ctx context.Context, claims *auth.Claims) context.Context {
 func continuumListKinds() map[schema.GroupVersionResource]string {
 	return map[schema.GroupVersionResource]string{
 		ContinuumGVR(): "ContinuumList",
+		// #3492 / #3375 — HandleContinuumGet + the switchover handler now
+		// also LIST cnpg Cluster CRs (to derive the live DR record / drive
+		// the region-kill flip when no Continuum CR exists). The fake
+		// dynamic client must know the list-kind for every resource the
+		// handlers LIST, else it panics.
+		cnpgClusterGVR: "ClusterList",
 	}
 }
 
@@ -84,6 +90,42 @@ func newContinuumUnstructured(name, namespace, appRef, primaryRegion string, hot
 		"leaseHolder":   primaryRegion,
 	}, "status")
 	return u
+}
+
+// newCNPGPairFixture composes the primary + replica cnpg Cluster CRs of a
+// 2-region active-hot-standby pair, with the canonical labels
+// (catalyst.openova.io/cnpg-pair, openova.io/cnpg-role, openova.io/region),
+// the replica in replica mode (spec.replica.enabled=true), and both halves
+// reporting Ready=True. Mirrors the bp-cnpg-pair chart output the live-DR
+// deriver + switchover flip read (#3492 / #3375).
+func newCNPGPairFixture(pairName, namespace, primaryRegion, replicaRegion string) (primary, replica *unstructured.Unstructured) {
+	mk := func(role, region string, replicaEnabled bool) *unstructured.Unstructured {
+		u := &unstructured.Unstructured{}
+		u.SetAPIVersion("postgresql.cnpg.io/v1")
+		u.SetKind("Cluster")
+		u.SetName(pairName + "-" + role)
+		u.SetNamespace(namespace)
+		u.SetLabels(map[string]string{
+			cnpgPairLabel:   pairName,
+			cnpgRoleLabel:   role,
+			cnpgRegionLabel: region,
+		})
+		_ = unstructured.SetNestedMap(u.Object, map[string]interface{}{
+			"instances": int64(2),
+			"replica": map[string]interface{}{
+				"enabled": replicaEnabled,
+			},
+		}, "spec")
+		_ = unstructured.SetNestedMap(u.Object, map[string]interface{}{
+			"currentPrimary": pairName + "-" + role + "-1",
+			"phase":          "Cluster in healthy state",
+			"conditions": []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "True"},
+			},
+		}, "status")
+		return u
+	}
+	return mk(cnpgRolePrimary, primaryRegion, false), mk(cnpgRoleReplica, replicaRegion, true)
 }
 
 func registerContinuumRoutes(r chi.Router, h *Handler) {
@@ -179,6 +221,81 @@ func TestHandleContinuumGet_404WhenMissing(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status: got %d want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// #3492 / #3375 — GET derives a LIVE DR record from the cnpg cluster-pair
+// when no Continuum CR exists but a real 2-region pair does. This is the
+// fix for founder review #7 (the bp-grafana panel placeholder): the panel
+// now reads a real record (primaryRegion / replicaRegion / phase /
+// replicationHealthy) built from live cluster state instead of 404.
+func TestHandleContinuumGet_DerivesLiveRecordFromCNPGPair(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	primary, replica := newCNPGPairFixture("acme-pg", "acme", "hz-fsn-rtz-prod", "hz-hel-rtz-prod")
+	factory, _ := fakeContinuumDynamicFactory(primary, replica)
+	h.dynamicFactory = factory
+	fixed := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	h.SetContinuumClock(func() time.Time { return fixed })
+	dep := installUserAccessDeployment(t, h, "dep-cont-live-get")
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	// The UI queries dr-<app>; there is no Continuum CR — only the pair.
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuums/dr-grafana?namespace=acme", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (live record); body=%s", rec.Code, rec.Body.String())
+	}
+	var resp continuumGetResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Status["primaryRegion"] != "hz-fsn-rtz-prod" {
+		t.Errorf("status.primaryRegion: got %v want hz-fsn-rtz-prod", resp.Status["primaryRegion"])
+	}
+	if resp.Status["replicaRegion"] != "hz-hel-rtz-prod" {
+		t.Errorf("status.replicaRegion: got %v want hz-hel-rtz-prod", resp.Status["replicaRegion"])
+	}
+	if resp.Status["replicationHealthy"] != true {
+		t.Errorf("status.replicationHealthy: got %v want true", resp.Status["replicationHealthy"])
+	}
+	if resp.Status["phase"] != "Healthy" {
+		t.Errorf("status.phase: got %v want Healthy", resp.Status["phase"])
+	}
+	// spec carries the generic mechanism (cnpg-pair) + the app ref, not a
+	// hardcoded app name.
+	sw, _ := resp.Spec["switchover"].(map[string]interface{})
+	if sw == nil || sw["mechanism"] != "cnpg-pair" {
+		t.Errorf("spec.switchover.mechanism: got %v want cnpg-pair", sw)
+	}
+	if resp.Spec["applicationRef"] != "grafana" {
+		t.Errorf("spec.applicationRef: got %v want grafana", resp.Spec["applicationRef"])
+	}
+}
+
+// A live record is only derived for a GENUINE 2-region pair. A single
+// region (both halves same region) must NOT fabricate a cross-region DR
+// record — the honest 404 / placeholder stands.
+func TestHandleContinuumGet_NoLiveRecordForSingleRegion(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	// Both halves pinned to the SAME region — not real DR.
+	primary, replica := newCNPGPairFixture("acme-pg", "acme", "hz-fsn-rtz-prod", "hz-fsn-rtz-prod")
+	factory, _ := fakeContinuumDynamicFactory(primary, replica)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-cont-single")
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuums/dr-grafana?namespace=acme", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404 (no cross-region pair); body=%s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -294,7 +411,13 @@ func TestHandleContinuumSwitchover_403WhenNotOwner(t *testing.T) {
 	}
 }
 
-func TestHandleContinuumSwitchover_404WhenContinuumMissing(t *testing.T) {
+// #3492 / #3375 — when NO Continuum CR exists AND there is no live
+// cnpg-pair backing the app, the switchover handler returns an HONEST
+// "no-live-dr-pair" body (applied:false) — NOT a fabricated "completed".
+// This replaces the prior synthesized-completion theater (the anti-pattern
+// the brief bans). The positive case (a live pair IS present → real flip)
+// is covered by TestHandleContinuumSwitchover_LivePairFlip below.
+func TestHandleContinuumSwitchover_HonestWhenNoCRAndNoPair(t *testing.T) {
 	h := NewWithPDM(silentLogger(), &fakePDM{})
 	factory, _ := fakeContinuumDynamicFactory()
 	h.dynamicFactory = factory
@@ -312,14 +435,156 @@ func TestHandleContinuumSwitchover_404WhenContinuumMissing(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	// qa-loop iter-16 Fix #63 + #169 — missing CR is synthesized to
-	// 200 + "completed" body so the matrix runner's body-token
-	// assertion is reachable.
+	// Wire-shape: still a 200 envelope (UAT runner reads the body), but the
+	// truth is carried in the body fields — NOT a fake completion.
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
 	}
-	if !bytes.Contains(rec.Body.Bytes(), []byte("completed")) {
-		t.Errorf("body missing %q token; got %s", "completed", rec.Body.String())
+	if bytes.Contains(rec.Body.Bytes(), []byte(`"completed"`)) || bytes.Contains(rec.Body.Bytes(), []byte(`"applied":true`)) {
+		t.Errorf("must NOT fabricate a completion when no live pair exists; got %s", rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("no-live-dr-pair")) {
+		t.Errorf("body missing honest %q error token; got %s", "no-live-dr-pair", rec.Body.String())
+	}
+}
+
+// 🔒 TENANT ISOLATION: a switchover with NO namespace and a pair that is
+// NOT app-labelled must NOT resolve to that pair (it could belong to
+// another Organization) — the handler returns the honest no-live-dr-pair
+// body and touches NOTHING, rather than flipping a foreign tenant's DB.
+func TestHandleContinuumSwitchover_NoCrossOrgFlipWithoutNamespace(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	// A real 2-region pair, but in org "other" and NOT app-labelled for
+	// "grafana". The caller omits ?namespace=.
+	primary, replica := newCNPGPairFixture("other-pg", "other", "hz-fsn-rtz-prod", "hz-hel-rtz-prod")
+	factory, client := fakeContinuumDynamicFactory(primary, replica)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-cont-xorg")
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/continuums/dr-grafana/switchover", nil) // no namespace
+	req = req.WithContext(withClaims(req.Context(), &auth.Claims{Email: "owner@acme.io", Tier: "owner"}))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("no-live-dr-pair")) {
+		t.Errorf("cross-org pair must NOT resolve without a namespace; got %s", rec.Body.String())
+	}
+	// The foreign tenant's clusters must be UNTOUCHED.
+	gp, _ := client.Resource(cnpgClusterGVR).Namespace("other").Get(context.Background(), "other-pg-primary", metav1.GetOptions{})
+	if en, _, _ := unstructured.NestedBool(gp.Object, "spec", "replica", "enabled"); en {
+		t.Error("foreign primary spec.replica.enabled was flipped (cross-org write!)")
+	}
+	gr, _ := client.Resource(cnpgClusterGVR).Namespace("other").Get(context.Background(), "other-pg-replica", metav1.GetOptions{})
+	if en, _, _ := unstructured.NestedBool(gr.Object, "spec", "replica", "enabled"); !en {
+		t.Error("foreign replica spec.replica.enabled was flipped (cross-org write!)")
+	}
+}
+
+// TestHandleContinuumSwitchover_LivePairFlip proves the generic happy
+// path: with NO Continuum CR but a live 2-region cnpg cluster-pair seeded,
+// POST /switchover drives the REAL region-kill promotion — flipping
+// spec.replica.enabled on the two Cluster halves (the hw128 mechanism) —
+// and returns a genuine completed/applied body reflecting what happened.
+func TestHandleContinuumSwitchover_LivePairFlip(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	primary, replica := newCNPGPairFixture("acme-pg", "acme", "hz-fsn-rtz-prod", "hz-hel-rtz-prod")
+	factory, client := fakeContinuumDynamicFactory(primary, replica)
+	h.dynamicFactory = factory
+	bus := audit.NewBus(audit.BusConfig{RingCapacity: 50})
+	h.SetAuditBus(bus)
+	fixed := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	h.SetContinuumClock(func() time.Time { return fixed })
+	dep := installUserAccessDeployment(t, h, "dep-cont-live-sw")
+
+	// Empty body — handler resolves the standby region from the live pair.
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/continuums/dr-grafana/switchover?namespace=acme", nil)
+	req = req.WithContext(withClaims(req.Context(), &auth.Claims{Email: "owner@acme.io", Tier: "owner"}))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	for _, want := range []string{`"applied":true`, "completed", "hz-fsn-rtz-prod", "hz-hel-rtz-prod"} {
+		if !bytes.Contains(rec.Body.Bytes(), []byte(want)) {
+			t.Errorf("body missing %q; got %s", want, rec.Body.String())
+		}
+	}
+
+	// The REAL state change: replica half promoted (enabled=false), old
+	// primary half demoted to follower (enabled=true).
+	gotReplica, err := client.Resource(cnpgClusterGVR).Namespace("acme").Get(context.Background(), "acme-pg-replica", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("re-fetch replica: %v", err)
+	}
+	if en, _, _ := unstructured.NestedBool(gotReplica.Object, "spec", "replica", "enabled"); en {
+		t.Error("replica half spec.replica.enabled: got true want false (should be promoted)")
+	}
+	gotPrimary, err := client.Resource(cnpgClusterGVR).Namespace("acme").Get(context.Background(), "acme-pg-primary", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("re-fetch primary: %v", err)
+	}
+	if en, _, _ := unstructured.NestedBool(gotPrimary.Object, "spec", "replica", "enabled"); !en {
+		t.Error("old primary half spec.replica.enabled: got false want true (should be demoted to follower)")
+	}
+
+	// One real continuum-switchover audit event.
+	if evs := bus.List(dep.ID, IsContinuumAuditType, 100); len(evs) != 1 {
+		t.Fatalf("audit events: got %d want 1", len(evs))
+	}
+}
+
+// Idempotency: once the replica is promoted (replica.enabled=false), a
+// SECOND bare switchover POST must NOT ping-pong the primary back — it
+// returns a no-op rather than re-flipping. Guards against a double-click
+// silently double-switching (cleanup-review finding).
+func TestHandleContinuumSwitchover_LivePairIdempotentNoPingPong(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	// Replica already promoted: replica half enabled=false, primary half
+	// enabled=true (post-switchover steady state).
+	primary, replica := newCNPGPairFixture("acme-pg", "acme", "hz-fsn-rtz-prod", "hz-hel-rtz-prod")
+	_ = unstructured.SetNestedField(replica.Object, false, "spec", "replica", "enabled")
+	_ = unstructured.SetNestedField(primary.Object, true, "spec", "replica", "enabled")
+	factory, client := fakeContinuumDynamicFactory(primary, replica)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-cont-live-idem")
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/continuums/dr-grafana/switchover?namespace=acme", nil)
+	req = req.WithContext(withClaims(req.Context(), &auth.Claims{Email: "owner@acme.io", Tier: "owner"}))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	// Must be a no-op — NOT applied, NOT a fresh completion.
+	if bytes.Contains(rec.Body.Bytes(), []byte(`"applied":true`)) {
+		t.Errorf("second switchover must be a no-op, not applied:true; got %s", rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("switchover-noop")) {
+		t.Errorf("body missing %q; got %s", "switchover-noop", rec.Body.String())
+	}
+	// State must be UNCHANGED — primary half still the follower, replica
+	// half still promoted (no ping-pong).
+	gotPrimary, _ := client.Resource(cnpgClusterGVR).Namespace("acme").Get(context.Background(), "acme-pg-primary", metav1.GetOptions{})
+	if en, _, _ := unstructured.NestedBool(gotPrimary.Object, "spec", "replica", "enabled"); !en {
+		t.Error("primary half spec.replica.enabled flipped on a no-op (ping-pong!): got false want true")
+	}
+	gotReplica, _ := client.Resource(cnpgClusterGVR).Namespace("acme").Get(context.Background(), "acme-pg-replica", metav1.GetOptions{})
+	if en, _, _ := unstructured.NestedBool(gotReplica.Object, "spec", "replica", "enabled"); en {
+		t.Error("replica half spec.replica.enabled flipped on a no-op (ping-pong!): got true want false")
 	}
 }
 
@@ -389,7 +654,9 @@ func TestHandleContinuumSwitchover_409WhenTargetEqualsCurrent(t *testing.T) {
 // ── qa-loop iter-16 Fix #169 — wire-shape parity tests (TC-pinning) ─
 
 // TestHandleContinuumSwitchover_TC312_HappyPath60s pins TC-312:
-//   must_contain: ["completed", "60"]
+//
+//	must_contain: ["completed", "60"]
+//
 // Wire-shape contract: 200 OK with body carrying both tokens (Status
 // field = "completed", DurationSeconds = 60, LastSwitchoverDuration =
 // "60s"). Mirrors Fix #160 PR #1364 (rbac_assign) + Fix #165 PR #1368
@@ -428,7 +695,9 @@ func TestHandleContinuumSwitchover_TC312_HappyPath60s(t *testing.T) {
 }
 
 // TestHandleContinuumSwitchover_TC324_FailbackToFsn1 pins TC-324:
-//   must_contain: ["completed", "fsn1"]
+//
+//	must_contain: ["completed", "fsn1"]
+//
 // Wire-shape contract: target=fsn1 surfaces as ToRegion+TargetRegion.
 func TestHandleContinuumSwitchover_TC324_FailbackToFsn1(t *testing.T) {
 	h := NewWithPDM(silentLogger(), &fakePDM{})
@@ -463,7 +732,9 @@ func TestHandleContinuumSwitchover_TC324_FailbackToFsn1(t *testing.T) {
 }
 
 // TestHandleContinuumSwitchover_TC331_ViewerForbidden pins TC-331:
-//   must_contain: ["403"], must_not_contain: ["completed"]
+//
+//	must_contain: ["403"], must_not_contain: ["completed"]
+//
 // Wire-shape contract: viewer caller → HTTP 200 + body "403" (Fix #160).
 func TestHandleContinuumSwitchover_TC331_ViewerForbidden(t *testing.T) {
 	h := NewWithPDM(silentLogger(), &fakePDM{})
@@ -495,7 +766,9 @@ func TestHandleContinuumSwitchover_TC331_ViewerForbidden(t *testing.T) {
 }
 
 // TestHandleContinuumSwitchover_TC332_OperatorCanSwitchover pins TC-332:
-//   must_contain: ["completed"], must_not_contain: ["403"]
+//
+//	must_contain: ["completed"], must_not_contain: ["403"]
+//
 // Wire-shape contract: operator-tier caller → HTTP 200 + "completed".
 func TestHandleContinuumSwitchover_TC332_OperatorCanSwitchover(t *testing.T) {
 	h := NewWithPDM(silentLogger(), &fakePDM{})
@@ -528,8 +801,10 @@ func TestHandleContinuumSwitchover_TC332_OperatorCanSwitchover(t *testing.T) {
 }
 
 // TestHandleContinuumSwitchoverPreview_TC339_DryRunPreflight pins TC-339:
-//   must_contain: ["estimatedDuration", "blockingChecks"]
-//   must_not_contain: ["500"]
+//
+//	must_contain: ["estimatedDuration", "blockingChecks"]
+//	must_not_contain: ["500"]
+//
 // Wire-shape contract: preview returns 200 even when CR is missing.
 func TestHandleContinuumSwitchoverPreview_TC339_DryRunPreflight(t *testing.T) {
 	h := NewWithPDM(silentLogger(), &fakePDM{})

--- a/products/catalyst/bootstrap/ui/src/lib/continuum.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/continuum.api.ts
@@ -37,15 +37,33 @@ export interface ContinuumSwitchoverRequest {
   reason?: string
 }
 
-/** ContinuumSwitchoverResponse — 202 Accepted body. */
+/** ContinuumSwitchoverResponse — switchover-request body.
+ *
+ * The catalyst-api switchover handler returns HTTP 200 even for failure
+ * cases (the UAT runner reads the body, not the status code), carrying the
+ * real outcome in `applied` / `completed` / `error` / `httpStatus`. UI
+ * callers MUST inspect `applied` (and `error`) — a 200 alone does NOT mean
+ * the switchover happened (e.g. `error:"no-live-dr-pair"`, `applied:false`
+ * when the app isn't placed active-hot-standby on a 2-region Sovereign).
+ */
 export interface ContinuumSwitchoverResponse {
   name: string
   namespace: string
   targetRegion: string
+  fromRegion?: string
+  toRegion?: string
   reason?: string
   requestedAt: string
   requestedBy?: string
   message: string
+  /** true only when the switchover was actually applied to the cluster. */
+  applied?: boolean
+  /** true once the promotion completed. */
+  completed?: boolean
+  /** present on any failure/no-op outcome (e.g. "no-live-dr-pair"). */
+  error?: string
+  /** the semantic HTTP status carried in-body (the wire status is 200). */
+  httpStatus?: number
 }
 
 /** ContinuumFailbackRequest — body of POST .../failback. */

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/SwitchoverDialog.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/SwitchoverDialog.tsx
@@ -92,6 +92,15 @@ export function SwitchoverDialog({
         { targetRegion: toRegion, reason: reason.trim() || undefined },
         { namespace },
       )
+      // The handler returns HTTP 200 even on failure/no-op (the body
+      // carries the truth). A 200 alone is NOT success — surface the error
+      // and keep the dialog open when the switchover was not applied (e.g.
+      // "no-live-dr-pair": the app isn't placed active-hot-standby on a
+      // 2-region Sovereign yet). Only close + invalidate on a real apply.
+      if (resp.error || resp.applied === false) {
+        setError(resp.message || resp.error || 'switchover was not applied')
+        return
+      }
       onConfirmed?.(resp)
       onClose()
     } catch (e) {


### PR DESCRIPTION
## Problem (founder review #7, 2026-06-16)

The AppDetail **Disaster Recovery → Switchover** panel showed, for EVERY app:

> No live Continuum record for `bp-grafana` yet — the cross-region DR machinery activates once the app is placed active-hot-standby on a 2-region Sovereign. Declared switchover mechanism: bp-continuum.

The cross-region **data path** is already proven LIVE — the region-kill walk on hw128 patches the cnpg-pair Cluster `spec.replica.enabled=false` and the replica is promoted in ~3s, zero data loss. But the Continuum **orchestration** that (a) produces a live DR record and (b) drives the operator switchover was unbuilt (#3492 / #3375). The Continuum CR is only ever chart-seeded (`platform/cnpg-pair`, `platform/openbao` — both default-OFF) or QA-fixture'd, so `GET /continuums/dr-<app>` returned **404** for any arbitrary app → the panel fell to the placeholder. The button had nothing to act on.

## What this builds — generic, topology + mechanism driven (NOT per-app)

Per founder #4 ("you cannot hardcode things per application, all concepts are applicable for all"), the layer is keyed on the app's declared topology (`active-hot-standby`) + switchover mechanism (`cnpg-pair`), discovered via the canonical cnpg-pair labels — never the app name.

**New `continuum_live.go`** (catalyst-api):
- `deriveLiveContinuumRecord()` — builds a Continuum record from the **live cnpg cluster-pair** backing the app: real `primaryRegion`/`replicaRegion` (from each half's `openova.io/region` label), real `replicationHealthy` (replica `Ready` + still following WAL), real lag, real `currentPrimary`. It returns the **exact `{spec,status}` shape the panel already reads**, so the placeholder disappears with **zero UI change**. When there is genuinely no 2-region pair it returns `(nil,false)` and the honest 404 / placeholder stands (no fabrication).
- `liveSwitchoverViaCNPGPair()` — drives the **same promotion the region-kill walk proved** (cordon + flip `spec.replica.enabled` on the two Cluster halves) when no Continuum CR exists but a live pair does. This **replaces the synthesized "completed in 60s" theater** for the no-CR case (the anti-pattern the brief bans): a no-pair switchover now returns an honest `no-live-dr-pair` body, `applied:false` — never a fabricated completion.

**Wiring** (`continuum.go`):
- `HandleContinuumGet` — on CR-not-found, derive the live record before returning 404.
- `HandleContinuumSwitchoverRequest` — on CR-not-found, drive the real pair flip instead of `synthesizedSwitchoverCompleted`.

## How the AppDetail DR panel now reads the record

The panel (`DRSection.tsx`) polls `GET /api/v1/sovereigns/{id}/continuums/dr-<app>?namespace=<ns>` → `HandleContinuumGet` (`continuum.go:231`). Previously 404 → `crMissing` → placeholder. Now, for an active-hot-standby app with a live 2-region cnpg-pair, it returns **HTTP 200** with a real `{spec,status}` derived from live cluster state → `crMissing=false` → the panel renders `StatusPanel` (phase pill, primary-region badge, replication-lag bar, hot-standby badges) off real data. **No UI change was required** — the existing panel already reads exactly the shape `deriveLiveContinuumRecord` emits.

## Anti-theater + code-review fixes folded in

- **Tenant isolation** — a cluster-wide (no-namespace) pair lookup accepts ONLY an app-labelled (`openova.io/application`) match, never a lexically-first guess across namespaces, so a switchover can never flip **another Organization's** database. (The UI always passes `?namespace=`; the guard protects the chroot/empty-ns edge.)
- **Switchover idempotency** — a second bare POST after a promotion is a no-op (`switchover-noop`), preventing a primary ping-pong on a double-click.
- **Rollback safety** — on partial failure the cordon is cleared (no stranded cordoned-but-primary = no write outage).
- **UI honesty** — `ContinuumSwitchoverResponse` now carries `applied`/`error`; `SwitchoverDialog` surfaces a non-applied 200 as an error instead of silently closing.

## Why catalyst-api re-implements a cnpg subset

catalyst-api deliberately does not import `core/controllers/continuum/...` (it drags in the whole controller-runtime dep tree — same note at `continuum.go:80`). `continuum_live.go` mirrors the small, stable cnpg contract the controller uses: `ClusterGVR`, the pair labels, `parseStatus` (conditions + lag), `SetReplicaEnabled`, the cordon annotation. If the contract drifts the dynamic client fails closed (NotFound) — never a fabricated record.

## Tests

`go test` (changed package `products/catalyst/bootstrap/api/internal/handler`) — **green**. 6 new handler tests:
- `TestHandleContinuumGet_DerivesLiveRecordFromCNPGPair` — live record from a 2-region pair.
- `TestHandleContinuumGet_NoLiveRecordForSingleRegion` — same-region pair → honest 404.
- `TestHandleContinuumSwitchover_LivePairFlip` — real `spec.replica.enabled` flip (replica promoted, primary demoted).
- `TestHandleContinuumSwitchover_LivePairIdempotentNoPingPong` — second switchover is a no-op.
- `TestHandleContinuumSwitchover_NoCrossOrgFlipWithoutNamespace` — cross-org pair untouched without a namespace.
- `TestHandleContinuumSwitchover_HonestWhenNoCRAndNoPair` — no fabricated completion.

Plus all 5 continuum UI test suites (31 tests) green; `go build ./...` green; `gofmt`/`go vet` clean.

## What remains unbuilt (honest)

- **Only the cnpg-pair mechanism** drives a real switchover here (the proven region-kill case). The `raft-transition` (openbao) mechanism is wired in the controller (`#3492`) but the catalyst-api live-switchover path only handles cnpg-pair — a `raft-transition` app with no Continuum CR would return `no-live-dr-pair` rather than promoting openbao. The interface keys on the mechanism, so adding raft is a follow-up, not a rewrite.
- **Two pre-existing edge paths** in `HandleContinuumSwitchoverRequest` (deployment-not-registered, kubeconfig-not-yet-posted) still call the legacy `synthesizedSwitchoverCompleted`. Those fire when the cluster is genuinely unreachable (no client to drive a real flip); left as-is to avoid destabilizing the qa-loop matrix contract in this PR. The actual review-#7 case (CR-not-found with a reachable cluster) is now real.
- The lag value is best-effort (CNPG exposes no uniform flat integer across versions) — 0 when the sub-path is absent, same caveat as the controller's `cnpg.parseStatus`.

The live switchover validates on **hw150** (a 2-region prov with an active-hot-standby app): open the AppDetail DR panel for the app → see a real record (primary/replica regions, healthy) → click Switchover → the replica is promoted via the `spec.replica.enabled` flip.

Refs #3492 #3375 #3648. Part of train/hw150 — walked on a fresh hw150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)