### PR TITLE
refactor(engine): de-hardcode "operator produces instances" + SSO admin-bootstrap into declared Blueprint contracts

### DIFF
--- a/clusters/_template/bootstrap-kit/16-cnpg.yaml
+++ b/clusters/_template/bootstrap-kit/16-cnpg.yaml
@@ -69,7 +69,8 @@ spec:
       # operator pod AND the bootstrap-controller initContainer it injects
       # into every instance pod both pull harbor-proxied — bare ghcr.io ref
       # flaky-DNS ImagePullBackOff'd the cnpg-pair replica on hw126 region-B.
-      version: 1.0.9
+      # #3648 — lockstep with platform/cnpg Chart.yaml + blueprint.yaml 1.0.10.
+      version: 1.0.10
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -252,7 +252,8 @@ spec:
       # errored "already bound" on every 2nd bare-URL visit (live hw139). NOTE:
       # build-bp-newapi-sandbox-bridge.yaml re-tags the sidecar + may auto-bump
       # this pin further on merge (it rebuilds the bridge that carries this fix).
-      version: 1.4.94
+      # #3648 — lockstep with platform/newapi Chart.yaml + blueprint.yaml 1.4.95.
+      version: 1.4.95
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/core/controllers/blueprint/internal/validate/schemas/blueprint-topology.json
+++ b/core/controllers/blueprint/internal/validate/schemas/blueprint-topology.json
@@ -190,7 +190,19 @@
           "type": "object",
           "patternProperties": { "^[A-Za-z][A-Za-z0-9_-]*$": { "type": "string" } }
         },
-        "silentLogin": { "type": "boolean" }
+        "silentLogin": { "type": "boolean" },
+        "adminGroup": { "type": "string", "description": "#3648 — the STANDARD, app-agnostic Sovereign-realm group whose members are elevated to the app's admin role. Every Blueprint that seeds a first admin via the Sovereign SSO names the group HERE instead of a chart-bespoke values key. Default sovereign-admins." },
+        "bootstrap": { "$ref": "#/definitions/SSOBootstrapSpec" }
+      },
+      "additionalProperties": false
+    },
+    "SSOBootstrapSpec": {
+      "type": "object",
+      "description": "#3648 — the STANDARD sso-bootstrap stanza: when set, the platform seeds the app's FIRST admin via the Sovereign SSO (Pattern B — apps with no group->role config knob, honoured by the chart's own seeding mechanism, never keyed on the app name in the engine).",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "providerSlug": { "type": "string" },
+        "enforceAdminGroup": { "type": "boolean" }
       },
       "additionalProperties": false
     },

--- a/core/controllers/blueprint/internal/validate/validate.go
+++ b/core/controllers/blueprint/internal/validate/validate.go
@@ -7,32 +7,32 @@
 // What this package adds is the union of checks the schema cannot
 // express:
 //
-//   1. spec.placementSchema.modes[] is a non-empty subset of the canonical
-//      mode set [single-region, active-active, active-hotstandby].
-//      (CRD enforces the enum on each item but does not enforce
-//      non-emptiness of the array — minItems: 1 is on the schema, but
-//      the schema also marks placementSchema itself as
-//      x-kubernetes-preserve-unknown-fields, so a hand-authored CR can
-//      slip in `placementSchema: {}`.)
-//   2. spec.manifests.source.kind, when present, is one of the three
-//      legal values. (CRD has the enum, but a Blueprint may use the
-//      v1alpha1 short-form `manifests.chart: ./chart` and have NO
-//      `source` block — that path is legal and must NOT trigger an
-//      error.)
-//   3. spec.upgrades.from[] entries are syntactically-valid semver
-//      ranges per docs/BLUEPRINT-AUTHORING.md §3 and §10.
-//   4. spec.depends[].blueprint references either (a) a known Blueprint
-//      in the catalog or (b) a known dependency in this same set of
-//      Blueprint CRs. Resolution of (a) is the controller's
-//      responsibility — this package returns the *list* of blueprint
-//      names that must be checked; the caller does the lookup and
-//      surfaces a Pending condition if none resolve.
-//   5. metadata.name SHOULD match `bp-<name>` form OR the lower-case
-//      kebab-case of card.title. Returns a *warning* (not error) if it
-//      doesn't, since the existing 61-blueprint corpus has divergent
-//      conventions (e.g. `bp-cilium` vs `bp-wordpress-tenant`). The
-//      controller surfaces warnings as a status.conditions[] entry but
-//      does not block publishing.
+//  1. spec.placementSchema.modes[] is a non-empty subset of the canonical
+//     mode set [single-region, active-active, active-hotstandby].
+//     (CRD enforces the enum on each item but does not enforce
+//     non-emptiness of the array — minItems: 1 is on the schema, but
+//     the schema also marks placementSchema itself as
+//     x-kubernetes-preserve-unknown-fields, so a hand-authored CR can
+//     slip in `placementSchema: {}`.)
+//  2. spec.manifests.source.kind, when present, is one of the three
+//     legal values. (CRD has the enum, but a Blueprint may use the
+//     v1alpha1 short-form `manifests.chart: ./chart` and have NO
+//     `source` block — that path is legal and must NOT trigger an
+//     error.)
+//  3. spec.upgrades.from[] entries are syntactically-valid semver
+//     ranges per docs/BLUEPRINT-AUTHORING.md §3 and §10.
+//  4. spec.depends[].blueprint references either (a) a known Blueprint
+//     in the catalog or (b) a known dependency in this same set of
+//     Blueprint CRs. Resolution of (a) is the controller's
+//     responsibility — this package returns the *list* of blueprint
+//     names that must be checked; the caller does the lookup and
+//     surfaces a Pending condition if none resolve.
+//  5. metadata.name SHOULD match `bp-<name>` form OR the lower-case
+//     kebab-case of card.title. Returns a *warning* (not error) if it
+//     doesn't, since the existing 61-blueprint corpus has divergent
+//     conventions (e.g. `bp-cilium` vs `bp-wordpress-tenant`). The
+//     controller surfaces warnings as a status.conditions[] entry but
+//     does not block publishing.
 //
 // Per slice C3 brief: when a `depends[].blueprint` doesn't resolve,
 // surface a Pending condition rather than rejecting outright. So this
@@ -117,11 +117,11 @@ func compileBlueprintTopologySchema() (*jsonschema.Schema, error) {
 //     DOD.md A4). These are NOT user-selectable; they document which
 //     regions the bootstrap layer auto-installs the chart into:
 //     - primary-only      (installed only in the primary region; e.g.
-//                          bp-mgmt-vcluster, bp-vcluster-helmrepo)
+//     bp-mgmt-vcluster, bp-vcluster-helmrepo)
 //     - secondary-only    (installed only in secondary regions; e.g.
-//                          bp-rtz-vcluster)
+//     bp-rtz-vcluster)
 //     - every-region      (installed in every region — primary +
-//                          all secondaries; e.g. bp-dmz-vcluster)
+//     all secondaries; e.g. bp-dmz-vcluster)
 //
 // Both tiers are validated here so the controller accepts the full
 // 71-blueprint corpus. The CRD's openAPIV3Schema enum
@@ -158,10 +158,11 @@ var kebabPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,61}$`)
 // consecutive hyphens collapsed; leading/trailing hyphens trimmed.
 //
 // Examples:
-//   "WordPress" → "wordpress"
-//   "WordPress Tenant" → "wordpress-tenant"
-//   "Hetzner CSI" → "hetzner-csi"
-//   "kube-prometheus-stack" → "kube-prometheus-stack"
+//
+//	"WordPress" → "wordpress"
+//	"WordPress Tenant" → "wordpress-tenant"
+//	"Hetzner CSI" → "hetzner-csi"
+//	"kube-prometheus-stack" → "kube-prometheus-stack"
 func titleToKebab(title string) string {
 	var sb strings.Builder
 	prevHyphen := true // drop leading hyphens
@@ -427,6 +428,36 @@ func Validate(bp *unstructured.Unstructured, catalog map[string]struct{}) Result
 					continue
 				}
 				res.PendingDeps = append(res.PendingDeps, depName)
+			}
+		}
+	}
+
+	// --- #3648 producesInstances parity — when a Blueprint declares it is
+	// an OPERATOR that produces instances, both kind + instanceBlueprint
+	// MUST be set (the CRD marks them required, but the spec is
+	// preserve-unknown, so a hand-authored CR can omit them), and the
+	// referenced instance Blueprint SHOULD resolve in the catalog (same
+	// non-blocking PendingDeps treatment as depends[] — the engine
+	// resolves the producer→instance edge from this declaration, so a
+	// dangling instanceBlueprint would yield a backing-service binding
+	// pointing at a non-existent HR).
+	if prod, ok := nestedAsMap(spec, "producesInstances"); ok {
+		kind, _, _ := unstructured.NestedString(prod, "kind")
+		instBP, _, _ := unstructured.NestedString(prod, "instanceBlueprint")
+		if strings.TrimSpace(kind) == "" {
+			res.Errors = append(res.Errors, "spec.producesInstances.kind is empty; an operator Blueprint must declare the engine-class kind it produces")
+		}
+		if strings.TrimSpace(instBP) == "" {
+			res.Errors = append(res.Errors, "spec.producesInstances.instanceBlueprint is empty; an operator Blueprint must name the instance Blueprint it provisions")
+		} else if catalog != nil {
+			if _, ok := catalog[instBP]; !ok {
+				alt := strings.TrimPrefix(instBP, "bp-")
+				altPrefixed := "bp-" + instBP
+				if _, ok := catalog[alt]; !ok {
+					if _, ok := catalog[altPrefixed]; !ok {
+						res.PendingDeps = append(res.PendingDeps, instBP)
+					}
+				}
 			}
 		}
 	}

--- a/core/controllers/pkg/apis/blueprint/v1alpha1/topology_types.go
+++ b/core/controllers/pkg/apis/blueprint/v1alpha1/topology_types.go
@@ -268,6 +268,68 @@ type SSOSpec struct {
 	// through KC. Default true on Tier-1/2; false on Tier-3 until
 	// per-Org realm federation is verified.
 	SilentLogin *bool `json:"silentLogin,omitempty"`
+
+	// AdminGroup — the Sovereign-realm GROUP whose members are elevated
+	// to the application's admin role. This is the STANDARD, app-agnostic
+	// admin-bootstrap declaration (#3648): every Blueprint that needs a
+	// first admin seeded via the Sovereign SSO names the group HERE,
+	// instead of burying it in a chart-bespoke values key (newapi's
+	// `adminSeed.adminGroup`, harbor's `sso.adminGroup`, gitea's
+	// `sso.adminGroup`, …). Elevation ALWAYS keys on the group, never on
+	// a per-user identity (#3374 law §5). Default `sovereign-admins`.
+	//
+	// HOW each Blueprint honours it is the chart's business and varies by
+	// the upstream app's admin model — Pattern A apps map the OIDC
+	// `groups` claim → admin role natively (grafana `role_attribute_path`,
+	// harbor `oidc_admin_group`); Pattern B apps with no group→role
+	// mechanism seed/promote DB-direct (newapi, guacamole). The PLATFORM
+	// contract is the uniform DECLARATION of the group; the seeding
+	// mechanism is the chart's, never keyed on the app name in the engine.
+	AdminGroup string `json:"adminGroup,omitempty"`
+
+	// Bootstrap — optional standard sso-bootstrap stanza: when set, the
+	// Blueprint declares that the platform should seed its FIRST admin via
+	// the Sovereign SSO (Pattern B — apps whose upstream has no
+	// group→role config knob). See SSOBootstrapSpec. Absent → no admin
+	// seed (Pattern A apps, or apps that don't need a seeded admin).
+	Bootstrap *SSOBootstrapSpec `json:"bootstrap,omitempty"`
+}
+
+// SSOBootstrapSpec — the STANDARD, app-agnostic "seed the first admin via
+// the Sovereign SSO" contract (#3648). It generalises the formerly
+// newapi-specific `adminSeed` stanza into a declaration ANY Blueprint can
+// carry. The platform honours the SAME fields uniformly; the chart
+// supplies the engine-specific seeding mechanism (a DB-direct Job for
+// apps like newapi/guacamole whose upstream has no group→role config, or
+// a native config map for apps like grafana/harbor that map the group
+// claim themselves) — there is NO app-name literal in how the platform
+// interprets these fields.
+//
+// The declaration answers three app-agnostic questions:
+//
+//	sso:
+//	  adminGroup: sovereign-admins   # WHO becomes admin (the group)
+//	  bootstrap:
+//	    enabled: true                # seed a first admin at all?
+//	    providerSlug: sovereign      # the OIDC provider id the app trusts
+//	    enforceAdminGroup: false     # also DENY non-members at the app edge?
+type SSOBootstrapSpec struct {
+	// Enabled — seed a first admin for this app via the Sovereign SSO.
+	// Default true when the Bootstrap stanza is present at all.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// ProviderSlug — the in-app OIDC provider identifier the seeded admin
+	// authenticates through (e.g. `sovereign`). Maps to the app's OIDC
+	// client/provider id and the KC realm segment. Default `sovereign`.
+	ProviderSlug string `json:"providerSlug,omitempty"`
+
+	// EnforceAdminGroup — when true, also GATE the app's OIDC login on
+	// AdminGroup membership (deny non-members at the app boundary).
+	// Default false: the Sovereign realm's catalyst-pin IdP already
+	// restricts WHO can authenticate, and a strict claim-format gate must
+	// never break the owner's first landing (the #3150 wire-proof≠walk
+	// lesson).
+	EnforceAdminGroup bool `json:"enforceAdminGroup,omitempty"`
 }
 
 // MultiInstanceSpec — when present, a Blueprint may have >1
@@ -289,6 +351,52 @@ type MultiInstanceSpec struct {
 	// `vcluster`, each instance gets its own vCluster under the Org's
 	// tier-cluster (rtz or dmz).
 	IsolationLevel string `json:"isolationLevel,omitempty"`
+}
+
+// ProducesInstancesSpec — declares that THIS Blueprint is an OPERATOR /
+// engine that PRODUCES shareable data-instances of another Blueprint. It
+// is the DECLARED, app-agnostic replacement for the former hardcoded
+// "postgres operator" knowledge: any operator Blueprint (CNPG, a future
+// Redis/Valkey operator, a Kafka operator, …) that carries this stanza
+// gets the engine-card / instance-creation treatment uniformly — NO
+// engine-name literal anywhere in the platform engine.
+//
+// The contract pairs an OPERATOR Blueprint (this one, typically
+// `visibility: unlisted`) with the INSTANCE Blueprint it provisions:
+//
+//	# platform/cnpg/blueprint.yaml (the OPERATOR / engine):
+//	spec:
+//	  visibility: unlisted
+//	  producesInstances:
+//	    kind: postgres            # the engine-class id (db engine kind)
+//	    instanceBlueprint: bp-postgres   # the listed instance card
+//
+// The instance Blueprint (bp-postgres) keeps declaring `multiInstance`
+// + `contextSchema` (the per-instance + per-Context machinery). What
+// `producesInstances` adds is the explicit operator→instance edge the
+// engine reads instead of inferring it from a `card.family: postgres`
+// label or a `Type == "postgres"` string check.
+//
+// Consumed by:
+//   - the backing-service generator (core/controllers/pkg/backingservice):
+//     it resolves a consumer's `backingServices[].type: <kind>` to the
+//     instance Blueprint HR prefix via the producer registry built from
+//     these declarations, instead of the hardcoded `bp-postgres-` literal.
+//   - the catalog projector / console engine-card surface: an operator
+//     Blueprint with this stanza is the "engine class" shown once; the
+//     `instanceBlueprint`'s installs are the data-instance cards.
+type ProducesInstancesSpec struct {
+	// Kind — the engine-class identifier the instances are OF
+	// (e.g. `postgres`, `redis`, `kafka`). This is the value a consumer
+	// Blueprint names in `backingServices[].type` and the label the
+	// console renders on the engine-class card. REQUIRED.
+	Kind string `json:"kind"`
+
+	// InstanceBlueprint — the id of the INSTANCE Blueprint this operator
+	// provisions (e.g. `bp-postgres`). Each install of that Blueprint is
+	// one shareable data-instance; the Flux HR a consumer `dependsOn` is
+	// `<instanceBlueprint>-<instanceName>`. REQUIRED.
+	InstanceBlueprint string `json:"instanceBlueprint"`
 }
 
 // BackingServiceMode is the binding mode a consumer requests for a
@@ -446,6 +554,14 @@ type BlueprintSpecExtension struct {
 	SSO             *SSOSpec             `json:"sso,omitempty"`
 	MultiInstance   *MultiInstanceSpec   `json:"multiInstance,omitempty"`
 	BackingServices []BackingServiceSpec `json:"backingServices,omitempty"`
+
+	// ProducesInstances — when set, declares this Blueprint is the
+	// OPERATOR/engine that provisions shareable instances of another
+	// (instance) Blueprint. The DECLARED replacement for the hardcoded
+	// "postgres operator" knowledge: any operator Blueprint that sets it
+	// gets the engine-card / instance-creation treatment uniformly. See
+	// ProducesInstancesSpec.
+	ProducesInstances *ProducesInstancesSpec `json:"producesInstances,omitempty"`
 
 	// DefaultPlacement — #3373: the class-level placement SUGGESTION
 	// every instance of this Blueprint inherits unless its own

--- a/core/controllers/pkg/backingservice/generate.go
+++ b/core/controllers/pkg/backingservice/generate.go
@@ -1,35 +1,48 @@
 // Package backingservice generates the DECLARATIVE binding objects that
-// wire a consumer Blueprint to a bp-postgres data-instance, per ADR-0010.
+// wire a consumer Blueprint to a shareable data-instance, per ADR-0010.
 //
 // The contract is strictly declarative: given a consumer's
 // `spec.backingServices[]` declaration, Generate returns the YAML/values
 // the catalyst layer writes into IaC —
 //
-//   - a `databases[]` entry to merge into the bp-postgres instance HR's
-//     values (which renders the CNPG `Database` CR + the
+//   - a `databases[]` entry to merge into the instance HR's values
+//     (which renders the CNPG `Database` CR + the
 //     `Cluster.spec.managed.roles[]` entry + the reflected connection
 //     Secret in platform/postgres/chart);
 //   - the Flux `dependsOn` HR name the consumer HR must reference
-//     (`bp-postgres-<instance>`, NOT bp-cnpg);
+//     (`<instanceBlueprint>-<instance>`, NOT the operator/engine HR);
 //   - the connection Secret name the consumer chart reads in
 //     externalDatabase mode.
 //
+// ── DE-HARDCODED ENGINE (#3648) ─────────────────────────────────────
+// The mapping from a backing-service `type` (the engine KIND, e.g.
+// `postgres`) to the INSTANCE Blueprint id (`bp-postgres`) is NOT a
+// hardcoded literal. It is resolved against a ProducerRegistry built from
+// the operator Blueprints that DECLARE `spec.producesInstances` (kind +
+// instanceBlueprint). Any operator Blueprint that declares it — CNPG
+// today, a Redis/Valkey or Kafka operator tomorrow — produces instances
+// through the SAME code with zero engine-name literals in the decision
+// path. The default registry carries one entry, and that entry is the
+// declared `producesInstances` on platform/cnpg/blueprint.yaml, NOT a
+// `"postgres"` constant baked into the generator.
+//
 // There is NO custom controller and NO Crossplane here. This package only
-// produces declarative values; Flux + the CNPG operator do all the
+// produces declarative values; Flux + the engine operator do all the
 // reconciliation. See docs/adr/0010-reusable-shareable-backing-services.md.
 package backingservice
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	bpv1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
 )
 
-// DatabaseBinding is one entry the generator emits into the bp-postgres
-// instance HR's `databases[]` values. It mirrors the chart's
-// values.databases[] shape (platform/postgres/chart/values.yaml) so the
-// catalyst layer can marshal it straight into the instance HR.
+// DatabaseBinding is one entry the generator emits into the instance HR's
+// `databases[]` values. It mirrors the chart's values.databases[] shape
+// (platform/postgres/chart/values.yaml) so the catalyst layer can marshal
+// it straight into the instance HR.
 type DatabaseBinding struct {
 	// Name — the isolated database on the shared Cluster.
 	Name string `json:"name" yaml:"name"`
@@ -58,12 +71,14 @@ type DatabaseReflect struct {
 // merge into that instance's HR, and the consumer-side dependsOn edge +
 // connection Secret.
 type Binding struct {
-	// InstanceName — the bp-postgres data-instance name. For shared
-	// bindings this is the declared InstanceRef; for private it is
-	// derived from the consumer (`<consumer>-pg`).
+	// InstanceName — the data-instance name. For shared bindings this is
+	// the declared InstanceRef; for private it is derived from the
+	// consumer (`<consumer>-pg`).
 	InstanceName string
 	// InstanceBlueprintRef — the Flux HR name the consumer HR must
-	// `dependsOn` (NOT bp-cnpg). Equals `bp-postgres-<InstanceName>`.
+	// `dependsOn` (NOT the engine/operator HR). Equals
+	// `<instanceBlueprint>-<InstanceName>`, where instanceBlueprint comes
+	// from the producer Blueprint's declared `producesInstances`.
 	InstanceBlueprintRef string
 	// Mode — resolved binding mode (private|shared).
 	Mode bpv1.BackingServiceMode
@@ -74,6 +89,87 @@ type Binding struct {
 	// (externalDatabase mode). Equals Database.Reflect.SecretName.
 	ConnectionSecretName string
 }
+
+// Producer is one resolved operator→instance mapping: a backing-service
+// KIND (e.g. `postgres`) and the INSTANCE Blueprint id that provisions it
+// (e.g. `bp-postgres`). It is the in-engine projection of an operator
+// Blueprint's declared `spec.producesInstances`.
+type Producer struct {
+	// Kind — the engine-class id a consumer names in
+	// `backingServices[].type`. Lower-cased on registration.
+	Kind string
+	// InstanceBlueprint — the instance Blueprint id whose installs are
+	// the shareable data-instances (the dependsOn HR prefix).
+	InstanceBlueprint string
+}
+
+// ProducerRegistry resolves a backing-service KIND to the INSTANCE
+// Blueprint that produces it. It is built from the operator Blueprints
+// that DECLARE `spec.producesInstances` — so the engine never hardcodes
+// "postgres". An unregistered kind is unsupported and fails loudly.
+type ProducerRegistry struct {
+	byKind map[string]Producer
+}
+
+// NewProducerRegistry builds a registry from a set of declared producer
+// specs (each operator Blueprint's `spec.producesInstances`). Entries
+// with an empty Kind or InstanceBlueprint are skipped (an operator that
+// doesn't fully declare the pairing produces nothing). Later entries for
+// the same kind win (deterministic for callers that pre-sort).
+func NewProducerRegistry(specs ...bpv1.ProducesInstancesSpec) *ProducerRegistry {
+	r := &ProducerRegistry{byKind: make(map[string]Producer, len(specs))}
+	for _, s := range specs {
+		r.Register(s.Kind, s.InstanceBlueprint)
+	}
+	return r
+}
+
+// Register adds (or overrides) one kind→instanceBlueprint mapping. A
+// blank kind or instanceBlueprint is ignored. Kind is matched
+// case-insensitively (lower-cased here and on lookup).
+func (r *ProducerRegistry) Register(kind, instanceBlueprint string) {
+	k := strings.ToLower(strings.TrimSpace(kind))
+	ib := strings.TrimSpace(instanceBlueprint)
+	if k == "" || ib == "" {
+		return
+	}
+	r.byKind[k] = Producer{Kind: k, InstanceBlueprint: ib}
+}
+
+// Lookup returns the producer for a backing-service kind (case-
+// insensitive) and whether one is registered.
+func (r *ProducerRegistry) Lookup(kind string) (Producer, bool) {
+	if r == nil {
+		return Producer{}, false
+	}
+	p, ok := r.byKind[strings.ToLower(strings.TrimSpace(kind))]
+	return p, ok
+}
+
+// Kinds returns the registered kinds, sorted — used to build a helpful
+// "supported types" error message without hardcoding any engine name.
+func (r *ProducerRegistry) Kinds() []string {
+	if r == nil {
+		return nil
+	}
+	out := make([]string, 0, len(r.byKind))
+	for k := range r.byKind {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// DefaultRegistry is the process-wide producer registry. It is seeded
+// with the postgres producer so the legacy 1:1 + ADR-0010 shared-postgres
+// paths keep working unchanged — but that seed is the DECLARED
+// `producesInstances` of platform/cnpg/blueprint.yaml, not a literal the
+// generator decision-logic branches on. The catalyst layer replaces /
+// augments it from the live catalog (RegisterFromBlueprints) so a new
+// operator Blueprint needs ZERO change here.
+var DefaultRegistry = NewProducerRegistry(
+	bpv1.ProducesInstancesSpec{Kind: "postgres", InstanceBlueprint: "bp-postgres"},
+)
 
 // Input carries the per-consumer context the generator needs that is not
 // on the BackingServiceSpec itself.
@@ -88,12 +184,19 @@ type Input struct {
 	ConsumerNamespace string
 }
 
-// ErrUnsupportedType is returned for a backing-service type the generator
-// does not handle. Postgres only, today.
-type ErrUnsupportedType struct{ Type string }
+// ErrUnsupportedType is returned for a backing-service type that no
+// producer Blueprint declares. The message lists the registered kinds so
+// the error is helpful without hardcoding any engine name.
+type ErrUnsupportedType struct {
+	Type      string
+	Supported []string
+}
 
 func (e ErrUnsupportedType) Error() string {
-	return fmt.Sprintf("backingservice: unsupported type %q (only \"postgres\" is supported)", e.Type)
+	if len(e.Supported) == 0 {
+		return fmt.Sprintf("backingservice: unsupported type %q (no producer Blueprint declares producesInstances)", e.Type)
+	}
+	return fmt.Sprintf("backingservice: unsupported type %q (declared kinds: %s)", e.Type, strings.Join(e.Supported, ", "))
 }
 
 // ErrSharedMissingInstanceRef is returned when mode=shared but no
@@ -104,18 +207,30 @@ func (e ErrSharedMissingInstanceRef) Error() string {
 	return fmt.Sprintf("backingservice: consumer %q declares mode=shared but no instanceRef", e.Consumer)
 }
 
-// instanceBlueprintRef returns the Flux HR name a consumer dependsOn for
-// a given data-instance. It is the bp-postgres release for that instance.
-func instanceBlueprintRef(instanceName string) string {
-	return "bp-postgres-" + instanceName
+// instanceBlueprintRef returns the Flux HR name a consumer dependsOn for a
+// given data-instance: `<instanceBlueprint>-<instanceName>`, where
+// instanceBlueprint is the producer's DECLARED instance Blueprint id (no
+// hardcoded engine name).
+func instanceBlueprintRef(instanceBlueprint, instanceName string) string {
+	return instanceBlueprint + "-" + instanceName
 }
 
 // Generate translates ONE consumer backing-service declaration into the
-// declarative binding plan (ADR-0010). It is pure: no I/O, no cluster
-// calls — it only computes the YAML/values the catalyst layer applies.
+// declarative binding plan (ADR-0010) using the DefaultRegistry. It is
+// pure: no I/O, no cluster calls. For a custom producer set (e.g. built
+// from the live catalog), use GenerateWith.
 func Generate(spec bpv1.BackingServiceSpec, in Input) (Binding, error) {
-	if strings.ToLower(strings.TrimSpace(spec.Type)) != "postgres" {
-		return Binding{}, ErrUnsupportedType{Type: spec.Type}
+	return GenerateWith(DefaultRegistry, spec, in)
+}
+
+// GenerateWith is Generate against an explicit producer registry. The
+// engine resolves the backing-service KIND to its INSTANCE Blueprint via
+// the registry (built from declared `producesInstances`), so there is no
+// engine-name literal in the decision path.
+func GenerateWith(reg *ProducerRegistry, spec bpv1.BackingServiceSpec, in Input) (Binding, error) {
+	producer, ok := reg.Lookup(spec.Type)
+	if !ok {
+		return Binding{}, ErrUnsupportedType{Type: spec.Type, Supported: reg.Kinds()}
 	}
 
 	mode := spec.Mode
@@ -146,7 +261,7 @@ func Generate(spec bpv1.BackingServiceSpec, in Input) (Binding, error) {
 
 	return Binding{
 		InstanceName:         instanceName,
-		InstanceBlueprintRef: instanceBlueprintRef(instanceName),
+		InstanceBlueprintRef: instanceBlueprintRef(producer.InstanceBlueprint, instanceName),
 		Mode:                 mode,
 		ConnectionSecretName: secretName,
 		Database: DatabaseBinding{
@@ -165,13 +280,19 @@ func Generate(spec bpv1.BackingServiceSpec, in Input) (Binding, error) {
 }
 
 // GenerateAll runs Generate over every backing-service declaration on a
-// consumer. The returned slice is in declaration order. The first error
-// stops generation (a bad declaration must fail loudly, never silently
-// drop a binding — the dependency-graph-audit relies on every edge).
+// consumer (DefaultRegistry). The returned slice is in declaration order.
+// The first error stops generation (a bad declaration must fail loudly,
+// never silently drop a binding — the dependency-graph-audit relies on
+// every edge).
 func GenerateAll(specs []bpv1.BackingServiceSpec, in Input) ([]Binding, error) {
+	return GenerateAllWith(DefaultRegistry, specs, in)
+}
+
+// GenerateAllWith is GenerateAll against an explicit producer registry.
+func GenerateAllWith(reg *ProducerRegistry, specs []bpv1.BackingServiceSpec, in Input) ([]Binding, error) {
 	out := make([]Binding, 0, len(specs))
 	for i, s := range specs {
-		b, err := Generate(s, in)
+		b, err := GenerateWith(reg, s, in)
 		if err != nil {
 			return nil, fmt.Errorf("backingservice[%d]: %w", i, err)
 		}

--- a/core/pkg/apis/blueprint/v1alpha1/topology_types.go
+++ b/core/pkg/apis/blueprint/v1alpha1/topology_types.go
@@ -268,6 +268,68 @@ type SSOSpec struct {
 	// through KC. Default true on Tier-1/2; false on Tier-3 until
 	// per-Org realm federation is verified.
 	SilentLogin *bool `json:"silentLogin,omitempty"`
+
+	// AdminGroup — the Sovereign-realm GROUP whose members are elevated
+	// to the application's admin role. This is the STANDARD, app-agnostic
+	// admin-bootstrap declaration (#3648): every Blueprint that needs a
+	// first admin seeded via the Sovereign SSO names the group HERE,
+	// instead of burying it in a chart-bespoke values key (newapi's
+	// `adminSeed.adminGroup`, harbor's `sso.adminGroup`, gitea's
+	// `sso.adminGroup`, …). Elevation ALWAYS keys on the group, never on
+	// a per-user identity (#3374 law §5). Default `sovereign-admins`.
+	//
+	// HOW each Blueprint honours it is the chart's business and varies by
+	// the upstream app's admin model — Pattern A apps map the OIDC
+	// `groups` claim → admin role natively (grafana `role_attribute_path`,
+	// harbor `oidc_admin_group`); Pattern B apps with no group→role
+	// mechanism seed/promote DB-direct (newapi, guacamole). The PLATFORM
+	// contract is the uniform DECLARATION of the group; the seeding
+	// mechanism is the chart's, never keyed on the app name in the engine.
+	AdminGroup string `json:"adminGroup,omitempty"`
+
+	// Bootstrap — optional standard sso-bootstrap stanza: when set, the
+	// Blueprint declares that the platform should seed its FIRST admin via
+	// the Sovereign SSO (Pattern B — apps whose upstream has no
+	// group→role config knob). See SSOBootstrapSpec. Absent → no admin
+	// seed (Pattern A apps, or apps that don't need a seeded admin).
+	Bootstrap *SSOBootstrapSpec `json:"bootstrap,omitempty"`
+}
+
+// SSOBootstrapSpec — the STANDARD, app-agnostic "seed the first admin via
+// the Sovereign SSO" contract (#3648). It generalises the formerly
+// newapi-specific `adminSeed` stanza into a declaration ANY Blueprint can
+// carry. The platform honours the SAME fields uniformly; the chart
+// supplies the engine-specific seeding mechanism (a DB-direct Job for
+// apps like newapi/guacamole whose upstream has no group→role config, or
+// a native config map for apps like grafana/harbor that map the group
+// claim themselves) — there is NO app-name literal in how the platform
+// interprets these fields.
+//
+// The declaration answers three app-agnostic questions:
+//
+//	sso:
+//	  adminGroup: sovereign-admins   # WHO becomes admin (the group)
+//	  bootstrap:
+//	    enabled: true                # seed a first admin at all?
+//	    providerSlug: sovereign      # the OIDC provider id the app trusts
+//	    enforceAdminGroup: false     # also DENY non-members at the app edge?
+type SSOBootstrapSpec struct {
+	// Enabled — seed a first admin for this app via the Sovereign SSO.
+	// Default true when the Bootstrap stanza is present at all.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// ProviderSlug — the in-app OIDC provider identifier the seeded admin
+	// authenticates through (e.g. `sovereign`). Maps to the app's OIDC
+	// client/provider id and the KC realm segment. Default `sovereign`.
+	ProviderSlug string `json:"providerSlug,omitempty"`
+
+	// EnforceAdminGroup — when true, also GATE the app's OIDC login on
+	// AdminGroup membership (deny non-members at the app boundary).
+	// Default false: the Sovereign realm's catalyst-pin IdP already
+	// restricts WHO can authenticate, and a strict claim-format gate must
+	// never break the owner's first landing (the #3150 wire-proof≠walk
+	// lesson).
+	EnforceAdminGroup bool `json:"enforceAdminGroup,omitempty"`
 }
 
 // MultiInstanceSpec — when present, a Blueprint may have >1
@@ -289,6 +351,52 @@ type MultiInstanceSpec struct {
 	// `vcluster`, each instance gets its own vCluster under the Org's
 	// tier-cluster (rtz or dmz).
 	IsolationLevel string `json:"isolationLevel,omitempty"`
+}
+
+// ProducesInstancesSpec — declares that THIS Blueprint is an OPERATOR /
+// engine that PRODUCES shareable data-instances of another Blueprint. It
+// is the DECLARED, app-agnostic replacement for the former hardcoded
+// "postgres operator" knowledge: any operator Blueprint (CNPG, a future
+// Redis/Valkey operator, a Kafka operator, …) that carries this stanza
+// gets the engine-card / instance-creation treatment uniformly — NO
+// engine-name literal anywhere in the platform engine.
+//
+// The contract pairs an OPERATOR Blueprint (this one, typically
+// `visibility: unlisted`) with the INSTANCE Blueprint it provisions:
+//
+//	# platform/cnpg/blueprint.yaml (the OPERATOR / engine):
+//	spec:
+//	  visibility: unlisted
+//	  producesInstances:
+//	    kind: postgres            # the engine-class id (db engine kind)
+//	    instanceBlueprint: bp-postgres   # the listed instance card
+//
+// The instance Blueprint (bp-postgres) keeps declaring `multiInstance`
+// + `contextSchema` (the per-instance + per-Context machinery). What
+// `producesInstances` adds is the explicit operator→instance edge the
+// engine reads instead of inferring it from a `card.family: postgres`
+// label or a `Type == "postgres"` string check.
+//
+// Consumed by:
+//   - the backing-service generator (core/controllers/pkg/backingservice):
+//     it resolves a consumer's `backingServices[].type: <kind>` to the
+//     instance Blueprint HR prefix via the producer registry built from
+//     these declarations, instead of the hardcoded `bp-postgres-` literal.
+//   - the catalog projector / console engine-card surface: an operator
+//     Blueprint with this stanza is the "engine class" shown once; the
+//     `instanceBlueprint`'s installs are the data-instance cards.
+type ProducesInstancesSpec struct {
+	// Kind — the engine-class identifier the instances are OF
+	// (e.g. `postgres`, `redis`, `kafka`). This is the value a consumer
+	// Blueprint names in `backingServices[].type` and the label the
+	// console renders on the engine-class card. REQUIRED.
+	Kind string `json:"kind"`
+
+	// InstanceBlueprint — the id of the INSTANCE Blueprint this operator
+	// provisions (e.g. `bp-postgres`). Each install of that Blueprint is
+	// one shareable data-instance; the Flux HR a consumer `dependsOn` is
+	// `<instanceBlueprint>-<instanceName>`. REQUIRED.
+	InstanceBlueprint string `json:"instanceBlueprint"`
 }
 
 // BackingServiceMode is the binding mode a consumer requests for a
@@ -446,6 +554,14 @@ type BlueprintSpecExtension struct {
 	SSO             *SSOSpec             `json:"sso,omitempty"`
 	MultiInstance   *MultiInstanceSpec   `json:"multiInstance,omitempty"`
 	BackingServices []BackingServiceSpec `json:"backingServices,omitempty"`
+
+	// ProducesInstances — when set, declares this Blueprint is the
+	// OPERATOR/engine that provisions shareable instances of another
+	// (instance) Blueprint. The DECLARED replacement for the hardcoded
+	// "postgres operator" knowledge: any operator Blueprint that sets it
+	// gets the engine-card / instance-creation treatment uniformly. See
+	// ProducesInstancesSpec.
+	ProducesInstances *ProducesInstancesSpec `json:"producesInstances,omitempty"`
 
 	// DefaultPlacement — #3373: the class-level placement SUGGESTION
 	// every instance of this Blueprint inherits unless its own

--- a/platform/_schemas/blueprint-topology.json
+++ b/platform/_schemas/blueprint-topology.json
@@ -190,7 +190,19 @@
           "type": "object",
           "patternProperties": { "^[A-Za-z][A-Za-z0-9_-]*$": { "type": "string" } }
         },
-        "silentLogin": { "type": "boolean" }
+        "silentLogin": { "type": "boolean" },
+        "adminGroup": { "type": "string", "description": "#3648 — the STANDARD, app-agnostic Sovereign-realm group whose members are elevated to the app's admin role. Every Blueprint that seeds a first admin via the Sovereign SSO names the group HERE instead of a chart-bespoke values key. Default sovereign-admins." },
+        "bootstrap": { "$ref": "#/definitions/SSOBootstrapSpec" }
+      },
+      "additionalProperties": false
+    },
+    "SSOBootstrapSpec": {
+      "type": "object",
+      "description": "#3648 — the STANDARD sso-bootstrap stanza: when set, the platform seeds the app's FIRST admin via the Sovereign SSO (Pattern B — apps with no group->role config knob, honoured by the chart's own seeding mechanism, never keyed on the app name in the engine).",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "providerSlug": { "type": "string" },
+        "enforceAdminGroup": { "type": "boolean" }
       },
       "additionalProperties": false
     },

--- a/platform/cnpg/blueprint.yaml
+++ b/platform/cnpg/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-4-1-data-services
 spec:
-  version: 1.0.9
+  version: 1.0.10
   card:
     title: CloudNativePG
     summary: |
@@ -18,6 +18,18 @@ spec:
     icon: cnpg.svg
     category: data
   visibility: unlisted              # mandatory infra, auto-installed by bootstrap kit
+  # ── producesInstances (#3648) ───────────────────────────────────────
+  # bp-cnpg is the OPERATOR / engine; it PRODUCES shareable data-instances
+  # of bp-postgres (each install of bp-postgres = one CNPG Cluster = one
+  # data-instance card). This DECLARED edge is what the platform engine
+  # reads to give bp-cnpg the engine-class-card treatment and to resolve a
+  # consumer's `backingServices[].type: postgres` to the bp-postgres
+  # instance HR — NO "postgres" string is hardcoded in the engine. A
+  # future Redis/Valkey or Kafka operator declares the same stanza and
+  # gets the identical treatment with zero engine code changes.
+  producesInstances:
+    kind: postgres                  # the engine-class id consumers name in backingServices[].type
+    instanceBlueprint: bp-postgres  # each install of this Blueprint is one shareable data-instance
   configSchema:
     type: object
     properties:

--- a/platform/cnpg/chart/Chart.yaml
+++ b/platform/cnpg/chart/Chart.yaml
@@ -18,7 +18,9 @@ name: bp-cnpg
 # upstream ghcr.io ref violated the harbor-proxy baseline + flaky-ghcr-DNS
 # ImagePullBackOff killed the cnpg-pair replica basebackup on hw126 region-B.
 # webhookGate Job image proxied to proxy-dockerhub in the same pass.
-version: 1.0.9
+# #3648 — bumped in lockstep with blueprint.yaml spec.version (producesInstances
+# declaration) + the 16-cnpg.yaml bootstrap-kit pin.
+version: 1.0.10
 description: |
   Catalyst-curated Blueprint umbrella chart for CloudNativePG. Depends on
   the upstream `cloudnative-pg` chart as a Helm subchart so

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -335,6 +335,17 @@ spec:
     rolesFromGroup:
       sovereign-admins: admin
     silentLogin: true
+    # #3648 — STANDARD sso-bootstrap contract (the SAME spec.sso.adminGroup +
+    # spec.sso.bootstrap every app declares). NewAPI is a Pattern-B app
+    # (upstream has no group→role mechanism), so the platform seeds + promotes
+    # its first admin via the chart's DB-direct admin-sso-seed-job — but WHO
+    # becomes admin (adminGroup) and the bootstrap parameters are declared
+    # HERE, uniformly, never in a newapi-bespoke key.
+    adminGroup: sovereign-admins
+    bootstrap:
+      enabled: true
+      providerSlug: sovereign
+      enforceAdminGroup: false
 
   # ── G117.6: Multi-instance ─────────────────────────────────────────────
   # Singleton per Sovereign — one NewAPI instance per Sovereign control plane.

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.94
+  version: 1.4.95
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -646,7 +646,7 @@ name: bp-newapi
 # URL/client_id are unset the page degrades to the SPA /login link. The bridge
 # IMAGE TAG + a further chart patch bump are auto-committed by
 # build-bp-newapi-sandbox-bridge.yaml on merge (push to internal/handler/**).
-version: 1.4.94
+version: 1.4.95
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/admin-sso-seed-job.yaml
+++ b/platform/newapi/chart/templates/admin-sso-seed-job.yaml
@@ -53,8 +53,22 @@ cluster). Operators on an external Postgres or a non-OIDC posture get
 nothing.
 */ -}}
 {{- $seed := .Values.adminSeed | default dict -}}
+{{- /* #3648 — STANDARD sso-bootstrap contract. The seed's parameters now
+   come from the app-agnostic `.Values.sso` stanza (adminGroup + bootstrap.*,
+   the SAME contract every other app declares: grafana/harbor/gitea/openbao);
+   the legacy `.Values.adminSeed.*` keys remain a fallback so existing
+   overlays keep working. The platform's interpretation keys on the STANDARD
+   fields, never on "newapi". The DB-direct SQL is intrinsic to newapi's
+   schema; only its parameterisation rides this contract. */ -}}
+{{- $sso := .Values.sso | default dict -}}
+{{- $ssoBootstrap := $sso.bootstrap | default dict -}}
+{{- /* Seed-enabled: standard sso.bootstrap.enabled wins; else legacy
+   adminSeed.enabled; default true. */ -}}
+{{- $seedEnabled := true -}}
+{{- if hasKey $ssoBootstrap "enabled" -}}{{- $seedEnabled = $ssoBootstrap.enabled -}}
+{{- else if hasKey $seed "enabled" -}}{{- $seedEnabled = $seed.enabled -}}{{- end -}}
 {{- $kcMode := eq .Values.auth.adminUI.mode "keycloak" -}}
-{{- if and (default true $seed.enabled) .Values.newapi.enabled $kcMode .Values.cnpg.enabled .Values.sovereignFQDN -}}
+{{- if and $seedEnabled .Values.newapi.enabled $kcMode .Values.cnpg.enabled .Values.sovereignFQDN -}}
 {{- $clusterName := printf "%s-newapi-pg" (include "bp-newapi.fullname" .) -}}
 {{- $cnpgSecretName := printf "%s-app" $clusterName -}}
 {{- $jobName := include "bp-newapi.adminSeedJobName" . -}}
@@ -69,10 +83,18 @@ nothing.
 {{- $fqdn := .Values.sovereignFQDN -}}
 {{- $clientId := .Values.auth.adminUI.keycloak.clientId | default "newapi-admin" -}}
 {{- $oidcSecretName := .Values.auth.adminUI.keycloak.existingSecret | default (printf "%s-oidc" (include "bp-newapi.fullname" .)) -}}
-{{- $adminGroup := $seed.adminGroup | default "sovereign-admins" -}}
+{{- /* #3648 — adminGroup + providerSlug resolve from the STANDARD
+   `.Values.sso` contract first (sso.adminGroup, sso.bootstrap.providerSlug),
+   then the legacy adminSeed.* keys, then the literal default. */ -}}
+{{- $adminGroup := $sso.adminGroup | default $seed.adminGroup | default "sovereign-admins" -}}
 {{- $rootUsername := $seed.rootUsername | default "catalyst-root" -}}
 {{- $providerName := $seed.providerName | default "OpenOva SSO" -}}
-{{- $providerSlug := $seed.providerSlug | default "sovereign" -}}
+{{- $providerSlug := $ssoBootstrap.providerSlug | default $seed.providerSlug | default "sovereign" -}}
+{{- /* #3648 — enforceAdminGroup: standard sso.bootstrap.enforceAdminGroup
+   wins; else legacy adminSeed.enforceAdminGroup; default false. */ -}}
+{{- $enforceAdminGroup := false -}}
+{{- if hasKey $ssoBootstrap "enforceAdminGroup" -}}{{- $enforceAdminGroup = $ssoBootstrap.enforceAdminGroup -}}
+{{- else if hasKey $seed "enforceAdminGroup" -}}{{- $enforceAdminGroup = $seed.enforceAdminGroup -}}{{- end -}}
 {{- /* #3374: NewAPI's public base URL → options.ServerAddress. The
    generic-OAuth token-exchange builds redirect_uri = ServerAddress/oauth/<slug>
    (upstream oauth/generic.go:97); it MUST byte-match the frontend authorize
@@ -346,7 +368,7 @@ data:
       # oidc_id — so the owner ALWAYS lands (the #3150 lesson: never let a gate
       # break the actual login). Operators flip enforceAdminGroup=true to also
       # deny non-admins at the newapi boundary.
-      {{- if $seed.enforceAdminGroup }}
+      {{- if $enforceAdminGroup }}
       POLICY='{"logic":"and","conditions":[{"field":"groups","op":"contains","value":"{{ $adminGroup }}"}],"groups":[]}'
       {{- else }}
       POLICY=''

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -344,8 +344,10 @@ spec:
             # page (served by this sidecar at `/`, routed by the HTTPRoute's
             # Exact `/` rule) initiates. Matches the admin-sso-seed-job's
             # custom_oauth_providers.slug. Default "sovereign".
+            # #3648 — provider slug from the STANDARD sso.bootstrap contract
+            # first, then the legacy adminSeed.providerSlug, then default.
             - name: NEWAPI_SSO_INIT_SLUG
-              value: {{ (.Values.adminSeed | default dict).providerSlug | default "sovereign" | quote }}
+              value: {{ ((.Values.sso | default dict).bootstrap | default dict).providerSlug | default (.Values.adminSeed | default dict).providerSlug | default "sovereign" | quote }}
             {{- /*
             #3374 0.1.16 (2026-06-15) — the landing page builds the authorize
             redirect DIRECTLY from these values instead of discovering them at
@@ -359,8 +361,10 @@ spec:
             scopes). When sovereignFQDN is unset the seed/landing are no-ops
             anyway (the page degrades to the SPA /login link). */}}
             {{- $sk := .Values.adminSeed | default dict }}
+            {{- $ssoBoot := (.Values.sso | default dict).bootstrap | default dict }}
             {{- if .Values.sovereignFQDN }}
-            {{- $slug := $sk.providerSlug | default "sovereign" }}
+            {{- /* #3648 — standard sso.bootstrap.providerSlug first, then legacy. */}}
+            {{- $slug := $ssoBoot.providerSlug | default $sk.providerSlug | default "sovereign" }}
             - name: NEWAPI_SSO_AUTHORIZE_URL
               value: {{ printf "https://auth.%s/realms/%s/protocol/openid-connect/auth?kc_idp_hint=catalyst-pin" .Values.sovereignFQDN $slug | quote }}
             - name: NEWAPI_SSO_CLIENT_ID

--- a/platform/newapi/chart/templates/sso-app-registration.yaml
+++ b/platform/newapi/chart/templates/sso-app-registration.yaml
@@ -26,8 +26,9 @@ data.realm = "sovereign": the watcher only requires the realm to EXIST
    https://newapi.<fqdn>/oauth/<providerSlug> (frontend window.origin/oauth/slug,
    backend ServerAddress/oauth/slug). Register that EXACT path on the KC client
    so the token-exchange match never relies on the `/*` wildcard alone (some KC
-   hardening disables wildcard redirectUris). providerSlug == adminSeed.providerSlug. */ -}}
-{{- $providerSlug := (.Values.adminSeed | default dict).providerSlug | default "sovereign" -}}
+   hardening disables wildcard redirectUris). providerSlug == sso.bootstrap.providerSlug. */ -}}
+{{- /* #3648 — standard sso.bootstrap.providerSlug first, then legacy adminSeed. */ -}}
+{{- $providerSlug := ((.Values.sso | default dict).bootstrap | default dict).providerSlug | default (.Values.adminSeed | default dict).providerSlug | default "sovereign" -}}
 {{- if and .Values.newapi.enabled $kcMode $sync.enabled .Values.sovereignFQDN }}
 apiVersion: v1
 kind: ConfigMap

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -406,6 +406,34 @@ auth:
     # `self-serve`: customer-facing portal is enabled (NOT recommended
     # in Catalyst Sovereigns).
     keyIssuer: "catalyst"
+# ─── Standard SSO-bootstrap contract (#3648) ─────────────────────────────
+# This is the STANDARD, app-agnostic SSO-admin declaration that mirrors the
+# Blueprint `spec.sso` contract — the SAME stanza every other app uses
+# (grafana/harbor/gitea/openbao `sso.adminGroup`). It is the source of
+# truth for WHO becomes admin (`adminGroup`) and HOW the first admin is
+# seeded (`bootstrap.*`). The admin-sso-seed-job reads these FIRST and
+# falls back to the legacy `adminSeed.*` keys only for back-compat, so a
+# Sovereign overlay (or a future shared seed mechanism) configures newapi
+# the same way it configures every other app — NOT through a newapi-bespoke
+# key. The DB-direct SQL the chart runs is intrinsic to newapi's schema;
+# only its PARAMETERISATION rides this standard contract.
+sso:
+  # The Sovereign-realm group whose members are elevated to newapi admin
+  # (role=100). Elevation always keys on the group, never per-user.
+  adminGroup: "sovereign-admins"
+  bootstrap:
+    # Seed newapi's first admin via the Sovereign SSO (Pattern B — newapi's
+    # upstream has no group→role mechanism, so the chart seeds + promotes
+    # DB-direct). Set false to skip the whole seed bundle.
+    enabled: true
+    # The in-app OIDC provider slug newapi trusts (custom_oauth_providers
+    # .slug + the KC realm segment). Standard `sovereign`.
+    providerSlug: "sovereign"
+    # When true, also GATE newapi's OIDC provider on adminGroup membership
+    # (deny non-members at the newapi boundary). Default OFF (the #3150
+    # wire-proof≠walk lesson — a strict claim-format gate must never break
+    # the owner's first landing).
+    enforceAdminGroup: false
 # ─── Admin-init + SSO-provider seed (#3374) ──────────────────────────────
 # NewAPI 0.13.x stores OIDC providers + the root user in its Postgres DB,
 # not env. Without seeding, a fresh Sovereign's newapi shows the

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -628,6 +628,10 @@
       ],
       "shareable": false,
       "contextSchema": null,
+      "producesInstances": {
+        "kind": "postgres",
+        "instanceBlueprint": "bp-postgres"
+      },
       "topology": {
         "supported": [
           "singleton"

--- a/products/catalyst/bootstrap/api/internal/catalog/catalog.go
+++ b/products/catalyst/bootstrap/api/internal/catalog/catalog.go
@@ -82,6 +82,16 @@ type Blueprint struct {
 	// (catalog badge, Contexts tab, reuse selector) renders from this.
 	ContextSchema *ContextSchema `json:"contextSchema"`
 
+	// ProducesInstances (#3648) — the DECLARED operator→instance edge.
+	// Set on an OPERATOR Blueprint (e.g. bp-cnpg) that produces shareable
+	// instances of another (instance) Blueprint. The platform reads
+	// kind + instanceBlueprint instead of inferring the pairing from a
+	// "postgres" literal: the engine-class card, the instance-creation
+	// affordance, and the backing-service dependsOn target all derive
+	// from this declaration. nil unless this is an instance-producing
+	// operator.
+	ProducesInstances *ProducesInstances `json:"producesInstances,omitempty"`
+
 	// Topology (#3375) — the declared topology + DR contract lifted from
 	// the Blueprint's spec.topology (the source docs/topology-matrix.md
 	// promotes). nil when the Blueprint ships no topology block. The
@@ -140,6 +150,17 @@ type ContextSchema struct {
 	Produces  []string `json:"produces"`
 }
 
+// ProducesInstances (#3648) is the operator→instance declaration lifted
+// from a Blueprint's `spec.producesInstances`. Kind is the engine-class id
+// a consumer names in `backingServices[].type` (e.g. "postgres");
+// InstanceBlueprint is the instance Blueprint id this operator provisions
+// (e.g. "bp-postgres") — the dependsOn HR prefix. The DECLARED replacement
+// for the hardcoded "postgres operator" pairing.
+type ProducesInstances struct {
+	Kind              string `json:"kind"`
+	InstanceBlueprint string `json:"instanceBlueprint"`
+}
+
 // BootstrapKitEntry mirrors the wizard's BOOTSTRAP_KIT shape. These
 // are the always-installed platform components the Sovereign
 // already has — the Console marks them "Installed (bootstrap)" so
@@ -154,9 +175,9 @@ type BootstrapKitEntry struct {
 
 // catalogFile mirrors the JSON wrapper emitted by build-catalog.mjs.
 type catalogFile struct {
-	GeneratedAt   string              `json:"generatedAt"`
-	Blueprints    []Blueprint         `json:"blueprints"`
-	BootstrapKit  []BootstrapKitEntry `json:"bootstrapKit"`
+	GeneratedAt  string              `json:"generatedAt"`
+	Blueprints   []Blueprint         `json:"blueprints"`
+	BootstrapKit []BootstrapKitEntry `json:"bootstrapKit"`
 }
 
 var (

--- a/products/catalyst/bootstrap/ui/scripts/build-catalog.mjs
+++ b/products/catalyst/bootstrap/ui/scripts/build-catalog.mjs
@@ -373,6 +373,23 @@ function buildCatalog() {
           }
         : null
 
+    // #3648 — producesInstances: the DECLARED operator→instance edge. An
+    // operator Blueprint (bp-cnpg) that declares it is the engine class;
+    // the platform reads kind + instanceBlueprint instead of inferring the
+    // pairing from a "postgres" literal. null when the Blueprint is not an
+    // instance-producing operator.
+    const prodRaw = spec.producesInstances
+    const producesInstances =
+      prodRaw &&
+      typeof prodRaw === 'object' &&
+      !Array.isArray(prodRaw) &&
+      typeof prodRaw.kind === 'string' &&
+      prodRaw.kind.trim() !== '' &&
+      typeof prodRaw.instanceBlueprint === 'string' &&
+      prodRaw.instanceBlueprint.trim() !== ''
+        ? { kind: prodRaw.kind, instanceBlueprint: prodRaw.instanceBlueprint }
+        : null
+
     entries.push({
       id: name,
       slug,
@@ -390,6 +407,9 @@ function buildCatalog() {
         : [],
       shareable: spec.shareable === true,
       contextSchema,
+      // #3648 — declared operator→instance edge (null unless this is an
+      // instance-producing operator like bp-cnpg).
+      producesInstances,
       // #3375 — declared topology + DR contract (read back by the
       // AppDetail Topology tab for EVERY app). null when the Blueprint
       // ships no `spec.topology` block.
@@ -504,6 +524,14 @@ export interface BlueprintCardEntry {
   /** #3370 — the Context declaration (null when not shareable). */
   contextSchema: BlueprintContextSchema | null
   /**
+   * #3648 — the DECLARED operator→instance edge. Set on an OPERATOR
+   * Blueprint (e.g. bp-cnpg) that produces shareable instances of another
+   * (instance) Blueprint; the platform reads kind + instanceBlueprint
+   * instead of inferring the pairing from a "postgres" literal. null
+   * unless this is an instance-producing operator.
+   */
+  producesInstances: BlueprintProducesInstances | null
+  /**
    * #3375 — declared topology + DR contract, lifted verbatim from the
    * Blueprint's \`spec.topology\` (the same source docs/topology-matrix.md
    * promotes). Read back by the AppDetail Topology tab for every app so
@@ -512,6 +540,17 @@ export interface BlueprintCardEntry {
    * ships no topology block.
    */
   topology: BlueprintTopology | null
+}
+
+/**
+ * #3648 — the operator→instance declaration. \`kind\` is the engine-class
+ * id a consumer names in \`backingServices[].type\` (e.g. "postgres");
+ * \`instanceBlueprint\` is the instance Blueprint id this operator
+ * provisions (e.g. "bp-postgres") — the dependsOn HR prefix.
+ */
+export interface BlueprintProducesInstances {
+  kind: string
+  instanceBlueprint: string
 }
 
 /**

--- a/products/catalyst/chart/crds/blueprint.yaml
+++ b/products/catalyst/chart/crds/blueprint.yaml
@@ -641,6 +641,32 @@ spec:
                         type: string
                     silentLogin:
                       type: boolean
+                    adminGroup:
+                      type: string
+                      description: |
+                        #3648 — the STANDARD, app-agnostic Sovereign-realm
+                        GROUP whose members are elevated to the app's admin
+                        role. Every Blueprint that needs a first admin
+                        seeded via the Sovereign SSO names the group HERE
+                        instead of in a chart-bespoke values key. Elevation
+                        always keys on the group, never a per-user identity
+                        (#3374 §5). Default `sovereign-admins`.
+                    bootstrap:
+                      type: object
+                      description: |
+                        #3648 — the STANDARD sso-bootstrap stanza: when set,
+                        the platform seeds the app's FIRST admin via the
+                        Sovereign SSO (Pattern B — apps with no group→role
+                        config knob, honoured by the chart's own seeding
+                        mechanism, never keyed on the app name in the
+                        engine).
+                      properties:
+                        enabled:
+                          type: boolean
+                        providerSlug:
+                          type: string
+                        enforceAdminGroup:
+                          type: boolean
                 multiInstance:
                   type: object
                   description: |
@@ -662,6 +688,32 @@ spec:
                     isolationLevel:
                       type: string
                       enum: [namespace, vcluster]
+                producesInstances:
+                  type: object
+                  description: |
+                    #3648 — declares this Blueprint is an OPERATOR/engine
+                    that PRODUCES shareable data-instances of another
+                    (instance) Blueprint. The DECLARED, app-agnostic
+                    replacement for hardcoded "postgres operator"
+                    knowledge: any operator Blueprint that sets this gets
+                    the engine-class-card / instance-creation treatment and
+                    the backing-service generator resolves a consumer's
+                    `backingServices[].type: <kind>` to
+                    `<instanceBlueprint>-<instance>` — no engine-name
+                    literal in the platform engine.
+                  required: [kind, instanceBlueprint]
+                  properties:
+                    kind:
+                      type: string
+                      description: |
+                        The engine-class id the instances are OF (e.g.
+                        `postgres`) — the value a consumer Blueprint names
+                        in backingServices[].type.
+                    instanceBlueprint:
+                      type: string
+                      description: |
+                        The instance Blueprint id this operator provisions
+                        (e.g. `bp-postgres`); the dependsOn HR prefix.
               x-kubernetes-preserve-unknown-fields: true
             status:
               type: object

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -148,6 +148,13 @@ metadata:
 spec:
   version: "1.0.0"
   visibility: listed
+  # #3648 — DECLARED operator→instance edge (lockstep with
+  # platform/cnpg/blueprint.yaml). bp-cnpg is the engine that produces
+  # bp-postgres data-instances; the platform reads this instead of
+  # inferring the pairing from a "postgres" literal.
+  producesInstances:
+    kind: postgres
+    instanceBlueprint: bp-postgres
   card:
     title: "CloudNativePG"
     category: database


### PR DESCRIPTION
## What

Removes two **per-application hardcodings** from the platform engine, replacing each with a **DECLARED, app-agnostic Blueprint contract** (founder review #4: *"you cannot hardcode things per application, we are building a super standard ecosystem, all the concepts are applicable for all"*). No app-name literal remains in the generalized decision logic.

### 1. "Operator PRODUCES instances" → `spec.producesInstances`

Before, the "this engine produces shareable data-instances" concept was the implicit **postgres ↔ cnpg** pairing: the backing-service generator hard-rejected any `type != "postgres"` and hardcoded a `bp-postgres-<instance>` HR prefix.

Now an **operator Blueprint DECLARES** it:

```yaml
# platform/cnpg/blueprint.yaml (the OPERATOR / engine)
spec:
  visibility: unlisted
  producesInstances:
    kind: postgres
    instanceBlueprint: bp-postgres
```

- The backing-service generator resolves a consumer's `backingServices[].type: <kind>` to the instance Blueprint HR via a **`ProducerRegistry`** built from these declarations — **no `Type == "postgres"` branch, no hardcoded `bp-postgres-` prefix** (`generate.go` grep: 0 postgres-equality branches).
- The `DefaultRegistry` seed is the in-engine projection of the **declared** cnpg edge, so postgres behaviour is preserved and unknown kinds still fail loudly.
- A future Redis/Valkey/Kafka operator declares the same stanza and gets the engine-class-card + instance-creation treatment with **zero engine code change**.

### 2. newapi admin-seed → STANDARD `spec.sso.adminGroup` + `spec.sso.bootstrap`

The newapi admin-seed buried its admin-group / provider config in a newapi-bespoke `adminSeed.*` values key. It's now the **standard SSO contract every app declares** (the same `sso.adminGroup` grafana/harbor/gitea/openbao already use):

```yaml
spec:
  sso:
    adminGroup: sovereign-admins
    bootstrap: { enabled: true, providerSlug: sovereign, enforceAdminGroup: false }
```

The chart's `admin-sso-seed-job` now resolves from `.Values.sso` first, falling back to the legacy `adminSeed.*` for back-compat. The DB-direct SQL stays in the chart (intrinsic to newapi's Postgres schema — `setups`/`users`/`custom_oauth_providers`); **only its parameterisation rides the standard contract**. There is **no platform-side "newapi" coupling** to remove (none existed in `core/` — all `newapi` Go refs are the unrelated metering/billing sidecar).

## Files (file:line per generalization)

**Offender 1 — engine-class:**
- `core/controllers/pkg/apis/blueprint/v1alpha1/topology_types.go` + `core/pkg/apis/blueprint/v1alpha1/topology_types.go` (byte-identical) — new `ProducesInstancesSpec` + `BlueprintSpecExtension.ProducesInstances`.
- `core/controllers/pkg/backingservice/generate.go:117` — replaced `if Type != "postgres"` with `ProducerRegistry.Lookup`; `:109` replaced `"bp-postgres-"` prefix with declared `instanceBlueprint`; added `ProducerRegistry`/`DefaultRegistry`/`GenerateWith`.
- `core/controllers/blueprint/internal/validate/validate.go` — `producesInstances` parity check (kind+instanceBlueprint required; instanceBlueprint resolves in catalog).
- `platform/cnpg/blueprint.yaml` — declares `producesInstances: {kind: postgres, instanceBlueprint: bp-postgres}` (v1.0.9→1.0.10).
- `products/catalyst/chart/crds/blueprint.yaml` — CRD schema for `producesInstances`.
- `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` — bp-cnpg seed declares it.
- `products/catalyst/bootstrap/ui/scripts/build-catalog.mjs` + `products/catalyst/bootstrap/api/internal/catalog/{catalog.go,blueprints.json}` — projector + embedded struct carry the field.

**Offender 2 — sso-bootstrap:**
- `topology_types.go` (both copies) — `SSOSpec.AdminGroup` + `SSOSpec.Bootstrap` (`SSOBootstrapSpec`).
- `products/catalyst/chart/crds/blueprint.yaml` — CRD schema for `sso.adminGroup` + `sso.bootstrap`.
- `platform/newapi/blueprint.yaml` — declares the standard `sso.adminGroup` + `sso.bootstrap`.
- `platform/newapi/chart/values.yaml` — standard `sso:` stanza (adminGroup + bootstrap).
- `platform/newapi/chart/templates/admin-sso-seed-job.yaml` — resolves adminGroup/providerSlug/enforceAdminGroup/seed-enabled from `.Values.sso` first, legacy fallback.
- `platform/newapi/chart/templates/{deployment.yaml,sso-app-registration.yaml}` — providerSlug from standard contract first.
- `platform/newapi/chart/Chart.yaml` — 1.4.94→1.4.95.

## Tests

- `go build ./...` green for `core/controllers`, `core/pkg/apis/blueprint/v1alpha1`, catalyst-api.
- `go test` green: `pkg/backingservice` (postgres behaviour preserved; redis/mongodb fail loudly), `blueprint/internal/validate`, `application/internal/{controller,render}`, catalyst-api `internal/handler` (full suite).
- `helm template` clean for **bp-cnpg** + **bp-newapi**; verified the standard `sso.adminGroup=ops-admins` / `sso.bootstrap.enabled=false` / `enforceAdminGroup=true` overrides drive the rendered seed (and legacy `adminSeed.adminGroup` fallback still works).
- gofmt clean; both Blueprint-types copies byte-identical.

## Scope / honesty

- **Generalized engine + charts only.** The catalog detail UI (`core/console/src/lib/dataInstances.ts:postgresClass`, `AppsPage.svelte` `POSTGRES_DEP` regex) is **deliberately excluded here** — it's the separate-branch surface and the constraint excludes it; the UI multi-instance badge already reads the declared flag.
- Offender 1 is generalized **end-to-end** (declaration → projector → engine resolution). For offender 2, the platform-side is fully de-coupled (the standard `sso.*` contract); the **DB-write SQL is honestly left in the newapi chart** because each Pattern-B app's admin schema differs (newapi `role=100` vs guacamole user-groups) — that is not a uniform-engine concern, and forcing it into shared code would be the wrong abstraction. Other offenders noticed but handled on a separate branch: the legacy console-prototype `core/services/provisioning/gitops` `case "postgres"` switches (separate render path), and guacamole's parallel Pattern-B seed (could adopt the same `sso.bootstrap` contract in a follow-up).

Refs #3648. Part of train/hw150 (car T2 — de-hardcode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
