### PR TITLE
fix(catalyst-ui): faithful Open chip + provisional jobs status — no pop-in, no stale-then-flip (T4 — founder #6)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-13T19:07:17.775Z",
+  "generatedAt": "2026-06-16T10:38:48.979Z",
   "blueprints": [
     {
       "id": "bp-alloy",
@@ -51,7 +51,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-anthropic-adapter",
@@ -115,7 +116,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-bge",
@@ -179,7 +181,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-catalyst-platform",
@@ -247,7 +250,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-cert-manager",
@@ -299,7 +303,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-cert-manager-dynadot-webhook",
@@ -349,7 +354,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-cert-manager-powerdns-webhook",
@@ -399,7 +405,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-cilium",
@@ -411,7 +418,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.4.1",
+      "version": "1.4.3",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [],
       "shareable": false,
@@ -447,7 +454,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-cilium-policies",
@@ -499,7 +507,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-clickhouse",
@@ -561,7 +570,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-cluster-autoscaler-hcloud",
@@ -609,7 +619,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-cnpg",
@@ -659,7 +670,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-cnpg-pair",
@@ -711,7 +723,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-coraza",
@@ -763,7 +776,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-crossplane",
@@ -815,7 +829,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-crossplane-claims",
@@ -869,7 +884,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-debezium",
@@ -931,7 +947,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-dmz-vcluster",
@@ -978,7 +995,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-external-dns",
@@ -1030,7 +1048,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-external-secrets",
@@ -1042,7 +1061,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "section": "pts-3-3-security-and-policy",
       "depends": [
         "bp-openbao",
@@ -1085,7 +1104,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-external-secrets-stores",
@@ -1137,7 +1157,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-falco",
@@ -1185,7 +1206,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-ferretdb",
@@ -1247,7 +1269,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-flink",
@@ -1309,7 +1332,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-flux",
@@ -1361,7 +1385,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-gateway-api",
@@ -1413,7 +1438,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-gitea",
@@ -1425,7 +1451,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.34",
+      "version": "1.2.35",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-postgres"
@@ -1477,7 +1503,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-grafana",
@@ -1489,7 +1516,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.12",
+      "version": "1.0.14",
       "section": "pts-3-observability",
       "depends": [],
       "shareable": false,
@@ -1539,7 +1566,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-guacamole",
@@ -1551,7 +1579,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.8",
+      "version": "0.2.20",
       "section": "pts-3-1-networking-and-service-mesh",
       "depends": [
         "bp-keycloak",
@@ -1607,7 +1635,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-harbor",
@@ -1673,7 +1702,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-hcloud-ccm",
@@ -1721,7 +1751,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-hcloud-csi",
@@ -1769,7 +1800,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-iceberg",
@@ -1831,7 +1863,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-k8s-ws-proxy",
@@ -1895,7 +1928,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-keycloak",
@@ -1907,7 +1941,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.4.27",
+      "version": "1.4.28",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-postgres"
@@ -1959,7 +1993,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-knative",
@@ -2024,7 +2059,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-kserve",
@@ -2090,7 +2126,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-kyverno",
@@ -2102,7 +2139,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
@@ -2142,7 +2179,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-kyverno-policies",
@@ -2154,7 +2192,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.33",
+      "version": "1.0.35",
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
@@ -2194,7 +2232,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-langfuse",
@@ -2256,7 +2295,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-librechat",
@@ -2323,7 +2363,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-litmus",
@@ -2363,7 +2404,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-livekit",
@@ -2429,7 +2471,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-llm-gateway",
@@ -2495,7 +2538,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-loki",
@@ -2557,7 +2601,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-matrix",
@@ -2623,7 +2668,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-mgmt-vcluster",
@@ -2635,7 +2681,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "section": "pts-3-2-control-plane-isolation",
       "depends": [
         "bp-cilium",
@@ -2670,7 +2716,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-milvus",
@@ -2732,7 +2779,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-mimir",
@@ -2794,7 +2842,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-nats-jetstream",
@@ -2856,7 +2905,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-nemo-guardrails",
@@ -2920,7 +2970,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-neo4j",
@@ -2982,7 +3033,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-netbird",
@@ -3048,7 +3100,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-network-policies",
@@ -3102,7 +3155,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-newapi",
@@ -3114,7 +3168,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "1.4.66",
+      "version": "1.4.94",
       "section": "pts-4-6-llm-serving",
       "depends": [
         "bp-cnpg",
@@ -3170,7 +3224,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-oidc-gate",
@@ -3182,7 +3237,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-cilium",
@@ -3236,7 +3291,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-openbao",
@@ -3248,7 +3304,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.31",
+      "version": "1.2.46",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [],
       "shareable": false,
@@ -3263,7 +3319,7 @@
         "perTopology": {
           "active-passive": {
             "replication": {
-              "backend": "openbao-perf-replication",
+              "backend": "raft",
               "mode": "async",
               "lagSloSeconds": 30
             },
@@ -3298,7 +3354,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-openclaw",
@@ -3340,7 +3397,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-openmeter",
@@ -3406,7 +3464,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-opensearch",
@@ -3492,7 +3551,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-opentelemetry",
@@ -3540,7 +3600,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-opentelemetry-operator",
@@ -3591,7 +3652,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-postgres",
@@ -3603,7 +3665,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.1.10",
+      "version": "0.2.2",
       "section": "pts-4-1-data-services",
       "depends": [
         "bp-cnpg",
@@ -3666,7 +3728,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-powerdns",
@@ -3716,7 +3779,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-powerdns-admin",
@@ -3728,7 +3792,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.13",
+      "version": "0.1.16",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-powerdns",
@@ -3772,7 +3836,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-qa-app",
@@ -3812,7 +3877,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-reflector",
@@ -3864,7 +3930,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-reloader",
@@ -3912,7 +3979,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-rtz-vcluster",
@@ -3924,7 +3992,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.2.8",
+      "version": "0.2.11",
       "section": "pts-3-2-control-plane-isolation",
       "depends": [
         "bp-cilium",
@@ -3959,7 +4027,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-sandbox",
@@ -4026,7 +4095,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-sealed-secrets",
@@ -4074,7 +4144,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-seaweedfs",
@@ -4086,7 +4157,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "section": "pts-3-5-storage-and-data",
       "depends": [
         "bp-cert-manager"
@@ -4128,7 +4199,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-self-sovereign-cutover",
@@ -4140,7 +4212,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.56",
+      "version": "0.1.72",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",
@@ -4173,7 +4245,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-sigstore",
@@ -4221,7 +4294,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-spire",
@@ -4283,7 +4357,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-sso-bridge",
@@ -4295,7 +4370,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.2.15",
+      "version": "0.2.18",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-keycloak",
@@ -4349,7 +4424,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-stalwart-sovereign",
@@ -4387,7 +4463,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-stalwart-tenant",
@@ -4454,7 +4531,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-strimzi",
@@ -4540,7 +4618,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-stunner",
@@ -4605,7 +4684,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-syft-grype",
@@ -4653,7 +4733,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-tempo",
@@ -4715,7 +4796,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-temporal",
@@ -4780,7 +4862,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-trivy",
@@ -4828,7 +4911,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-valkey",
@@ -4902,7 +4986,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-vcluster-helmrepo",
@@ -4952,7 +5037,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-velero",
@@ -5004,7 +5090,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-velero-hcs",
@@ -5056,7 +5143,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-vllm",
@@ -5068,7 +5156,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "section": "pts-4-6-llm-serving",
       "depends": [
         "bp-kserve"
@@ -5120,7 +5208,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     },
     {
       "id": "bp-vpa",
@@ -5132,7 +5221,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
@@ -5168,7 +5257,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": false
     },
     {
       "id": "bp-wordpress-tenant",
@@ -5236,7 +5326,8 @@
             }
           }
         }
-      }
+      },
+      "hasUserUIEndpoint": true
     }
   ],
   "bootstrapKit": [

--- a/products/catalyst/bootstrap/ui/scripts/build-catalog.mjs
+++ b/products/catalyst/bootstrap/ui/scripts/build-catalog.mjs
@@ -297,6 +297,39 @@ function extractTopology(topoRaw) {
   return { supported, multiRegion, singleRegion, perTopology }
 }
 
+/**
+ * #3656 (founder #6) — declared user-UI signal.
+ *
+ * The console's AppCard must render a confident, disabled "Open…"
+ * placeholder for a front-door app while its live externalURL is still
+ * resolving — and NOTHING for a headless app — so the Open chip never
+ * pops in late (assert-then-retract). To do that without an app-name
+ * hardcode, the card needs a STATIC, build-time signal of whether a
+ * Blueprint exposes a user UI at all.
+ *
+ * This mirrors the canonical backend predicate `blueprintHasUserUIEndpoint`
+ * (products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go)
+ * EXACTLY so the FE placeholder and the BE-projected externalURL agree:
+ * an endpoint is a user UI when ANY of
+ *   - ssoEnabled === true    (the app fronts an OIDC login the operator uses), OR
+ *   - launchDefault === true (the chart-tagged "open me" front door), OR
+ *   - name === "ui"          (the conventional UI-endpoint name).
+ * API/protocol-only endpoints (an OCI registry, a backend proxy target)
+ * set none of these and do NOT qualify. Returns false when the Blueprint
+ * declares no endpoints — the same fail-closed default the BE uses.
+ */
+function blueprintHasUserUIEndpoint(endpointsRaw) {
+  if (!Array.isArray(endpointsRaw)) return false
+  for (const ep of endpointsRaw) {
+    if (!ep || typeof ep !== 'object') continue
+    const name = typeof ep.name === 'string' ? ep.name : ''
+    if (ep.ssoEnabled === true || ep.launchDefault === true || name.toLowerCase() === 'ui') {
+      return true
+    }
+  }
+  return false
+}
+
 function listBlueprintFiles(dir) {
   if (!existsSync(dir)) return []
   const out = []
@@ -394,6 +427,17 @@ function buildCatalog() {
       // AppDetail Topology tab for EVERY app). null when the Blueprint
       // ships no `spec.topology` block.
       topology: extractTopology(spec.topology),
+      // #3656 (founder #6) — declared user-UI signal. Drives the AppCard
+      // disabled-"Open…" placeholder while the live externalURL resolves,
+      // so a front-door app's Open chip never pops in late and a headless
+      // app never flashes a transient chip. The explicit
+      // spec.hasUserUIEndpoint declaration wins when the author sets it;
+      // otherwise derive it from spec.endpoints[] with the SAME rule the BE
+      // uses (blueprintHasUserUIEndpoint: ssoEnabled / launchDefault / name="ui").
+      hasUserUIEndpoint:
+        typeof spec.hasUserUIEndpoint === 'boolean'
+          ? spec.hasUserUIEndpoint
+          : blueprintHasUserUIEndpoint(spec.endpoints),
     })
   }
 
@@ -512,6 +556,15 @@ export interface BlueprintCardEntry {
    * ships no topology block.
    */
   topology: BlueprintTopology | null
+  /**
+   * #3656 (founder #6) — whether this Blueprint declares a user-facing UI
+   * endpoint (ssoEnabled / launchDefault / name="ui" in spec.endpoints[]),
+   * mirroring the BE's blueprintHasUserUIEndpoint. The AppCard reads this
+   * to show a confident disabled "Open…" placeholder for a front-door app
+   * while its live externalURL resolves (no late pop-in), and to suppress
+   * any placeholder for a headless app (no transient chip).
+   */
+  hasUserUIEndpoint: boolean
 }
 
 /**

--- a/products/catalyst/bootstrap/ui/src/lib/jobs.types.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/jobs.types.ts
@@ -94,4 +94,19 @@ export interface Job {
   startedAt: string | null
   finishedAt: string | null
   durationMs: number
+  /**
+   * #3656 (founder #6) — FE-only provisional flag. The Jobs canvas merges
+   * reducer-derived rows (folded from the SSE replay buffer) with the live
+   * /jobs query, and the live source wins on conflict. Before the live
+   * fetch lands, a reducer-derived row's non-terminal status (pending /
+   * running) is UNCONFIRMED — a job that actually completed long ago can
+   * still read "Pending" until the live source corrects it, then flip. To
+   * stop that assert-then-retract the merge marks such a row `provisional`
+   * and the StatusBadge renders a distinct "Confirming…" state instead of a
+   * definitive Pending/Running. NEVER set on the wire — the catalyst-api
+   * Job shape has no such field; it is stamped purely in the FE merge and
+   * cleared the moment the live source confirms the row. Optional + absent
+   * by default so every backend-sourced row is non-provisional.
+   */
+  provisional?: boolean
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.open-button.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.open-button.test.tsx
@@ -51,7 +51,10 @@ const GRAFANA: ApplicationDescriptor = {
   bootstrapKit: true,
 }
 
-function renderCard(externalURL: string) {
+function renderCard(
+  externalURL: string,
+  opts: { hasUserUI?: boolean; urlPending?: boolean } = {},
+) {
   const rootRoute = createRootRoute({ component: () => <Outlet /> })
   const homeRoute = createRoute({
     getParentRoute: () => rootRoute,
@@ -66,6 +69,8 @@ function renderCard(externalURL: string) {
         marketplacePublished={null}
         slug="grafana"
         externalURL={externalURL}
+        hasUserUI={opts.hasUserUI}
+        urlPending={opts.urlPending}
       />
     ),
   })
@@ -150,5 +155,63 @@ describe('AppsPage card — #3374 per-app Open button', () => {
     // The Link target must NOT have rendered — the click was consumed by the
     // Open button (preventDefault + stopPropagation).
     expect(screen.queryByTestId('app-detail-target')).toBeNull()
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────
+// #3656 (founder #6) — the faithful Open chip: a declared-UI app shows a
+// disabled "Open…" placeholder while its live externalURL is still
+// resolving (no late pop-in), and a headless app shows NO transient chip.
+// The placeholder is driven by the STATIC declared `hasUserUI` signal
+// (projected `hasUserUIEndpoint`), never an app-name hardcode.
+// ────────────────────────────────────────────────────────────────────
+describe('AppsPage card — #3656 faithful Open chip (no flash / pop-in)', () => {
+  it('declared-UI app with the URL still pending shows a disabled "Open…" placeholder (not the enabled Open)', async () => {
+    renderCard('', { hasUserUI: true, urlPending: true })
+    const placeholder = await screen.findByTestId('sov-app-open-pending-bp-grafana')
+    expect(placeholder).toBeTruthy()
+    // It is disabled (no URL to launch yet) and reads as a placeholder…
+    expect((placeholder as HTMLButtonElement).disabled).toBe(true)
+    expect(placeholder.textContent).toContain('Open…')
+    expect(placeholder.className).toContain('is-pending')
+    // …and the ENABLED Open is NOT present while pending.
+    expect(screen.queryByTestId('sov-app-open-bp-grafana')).toBeNull()
+  })
+
+  it('headless app (no declared UI) shows NO placeholder AND no Open chip while pending — never a transient chip', async () => {
+    renderCard('', { hasUserUI: false, urlPending: true })
+    // The card still renders…
+    await screen.findByTestId('sov-app-card-bp-grafana')
+    // …but neither the enabled Open nor the disabled placeholder appears.
+    expect(screen.queryByTestId('sov-app-open-bp-grafana')).toBeNull()
+    expect(screen.queryByTestId('sov-app-open-pending-bp-grafana')).toBeNull()
+  })
+
+  it('declared-UI app once the URL resolves shows the ENABLED Open and drops the placeholder', async () => {
+    renderCard('https://grafana.hw139.omani.works', { hasUserUI: true, urlPending: false })
+    const open = await screen.findByTestId('sov-app-open-bp-grafana')
+    expect(open).toBeTruthy()
+    expect(open.textContent).toContain('Open')
+    // The placeholder must be gone — the enabled Open replaced it in place.
+    expect(screen.queryByTestId('sov-app-open-pending-bp-grafana')).toBeNull()
+  })
+
+  it('a resolved URL wins even while urlPending is still true (no placeholder when we already have the front door)', async () => {
+    // Defensive: if the live query is mid-refetch (urlPending true) but we
+    // already hold a URL, show the real Open — never downgrade to placeholder.
+    renderCard('https://grafana.hw139.omani.works', { hasUserUI: true, urlPending: true })
+    const open = await screen.findByTestId('sov-app-open-bp-grafana')
+    expect(open).toBeTruthy()
+    expect(screen.queryByTestId('sov-app-open-pending-bp-grafana')).toBeNull()
+  })
+
+  it('declared-UI app with NO pending (and no URL) shows nothing — the source has resolved to "no front door"', async () => {
+    // hasUserUI true but the query has resolved (urlPending false) and the
+    // URL is empty → the source genuinely reports no front door; the card
+    // must not assert a placeholder that never resolves.
+    renderCard('', { hasUserUI: true, urlPending: false })
+    await screen.findByTestId('sov-app-card-bp-grafana')
+    expect(screen.queryByTestId('sov-app-open-bp-grafana')).toBeNull()
+    expect(screen.queryByTestId('sov-app-open-pending-bp-grafana')).toBeNull()
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
@@ -689,6 +689,12 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
                   isCatalog={false}
                   environment={inst.environment}
                   externalURL={inst.externalURL}
+                  // #3656 — declared user-UI signal keyed on the instance's
+                  // Blueprint id; urlPending tracks the live-apps query so a
+                  // declared-UI instance shows a disabled "Open…" placeholder
+                  // until its externalURL lands (no late pop-in).
+                  hasUserUI={BLUEPRINT_BY_ID[inst.blueprint]?.hasUserUIEndpoint === true}
+                  urlPending={liveAppsQuery.isPending}
                   status={inst.status}
                   isService={false}
                   marketplacePublished={null}
@@ -720,6 +726,12 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
                 isCatalog={false}
                 environment={environment}
                 externalURL={externalURL}
+                // #3656 — declared user-UI signal from the generated catalog
+                // (projected from the Blueprint's endpoints[]); urlPending
+                // tracks the live-apps query so a declared-UI app shows a
+                // disabled "Open…" placeholder until its URL resolves.
+                hasUserUI={BLUEPRINT_BY_ID[app.id]?.hasUserUIEndpoint === true}
+                urlPending={liveAppsQuery.isPending}
                 status={(() => {
                   // Live API status wins when present.
                   const live = liveAppStatus[app.id]
@@ -852,6 +864,22 @@ interface AppCardProps {
    */
   externalURL?: string
   /**
+   * #3656 (founder #6) — whether this app's Blueprint declares a
+   * user-facing UI front door (projected `hasUserUIEndpoint`). When true
+   * and `externalURL` is still resolving (`urlPending`), the card shows a
+   * disabled "Open…" placeholder instead of nothing — so the enabled Open
+   * settles in place rather than popping in late. False/undefined ⇒
+   * headless app ⇒ no placeholder (and no transient chip). Default
+   * undefined keeps the legacy behaviour for callers that don't pass it.
+   */
+  hasUserUI?: boolean
+  /**
+   * #3656 — true while the live-apps query (which carries `externalURL`)
+   * has not resolved yet. Drives the disabled "Open…" placeholder window
+   * for a declared-UI app. Ignored entirely once `externalURL` is known.
+   */
+  urlPending?: boolean
+  /**
    * #3370 — instance-card extras. `topology` renders the placement chip
    * (`singleton`, `single-region`, `active-hotstandby`); `contextCount`
    * renders the ⛓ badge that deep-links to the instance's Contexts tab.
@@ -881,7 +909,7 @@ interface AppCardProps {
 // Exported for the #3374 render test (AppsPage.open-button.test.tsx) — the
 // per-card Open button gate + silent-SSO click routing are leaf behaviour
 // best asserted directly on the card, without the live-apps query plumbing.
-export function AppCard({ app, status, isCatalog, isService, environment, marketplacePublished, slug, onPublishedChange, topology, contextCount, externalURL, iconLight, iconDark, onEdit }: AppCardProps) {
+export function AppCard({ app, status, isCatalog, isService, environment, marketplacePublished, slug, onPublishedChange, topology, contextCount, externalURL, hasUserUI, urlPending, iconLight, iconDark, onEdit }: AppCardProps) {
   const stateClass = `state-${status}`
   const navigate = useNavigate()
   // #3603 — render the theme-correct admin icon override when present:
@@ -1050,12 +1078,20 @@ export function AppCard({ app, status, isCatalog, isService, environment, market
          * fix keeps the one-click affordance but routes it through
          * launchAppViaSSO → GET /catalyst/v1/apps/{key}/launch-url, which
          * returns the signed silent-SSO URL — so the operator lands in the
-         * app already signed in, never on a login form. Only rendered when
-         * externalURL is non-empty: the BE projects externalURL ONLY for
-         * apps whose Blueprint declares a user-UI endpoint
-         * (externalURLIfUserUI + blueprintHasUserUIEndpoint, #3224), so
-         * headless services (openova-flow, shared-pg, controllers) never
-         * get a dead button. */}
+         * app already signed in, never on a login form.
+         *
+         * #3656 (founder #6) — faithful Open chip: never assert-then-retract.
+         * The live externalURL arrives async (liveAppsQuery), so a real
+         * front-door app used to render NOTHING then POP the chip in late.
+         * The card now reads the STATIC declared `hasUserUI` signal
+         * (BLUEPRINT_BY_ID[...].hasUserUIEndpoint, projected from the
+         * Blueprint's endpoints[] — the SAME source the BE gates externalURL
+         * on) so it can show a confident disabled "Open…" placeholder for a
+         * declared-UI app WHILE its URL is still resolving. Three faithful
+         * states, no flash / pop-in / retract:
+         *   • externalURL resolved → enabled Open (silent-SSO launch).
+         *   • declared UI + URL still pending → disabled "Open…" placeholder.
+         *   • headless (no declared UI) → NOTHING (no transient chip). */}
         {externalURL ? (
           <button
             type="button"
@@ -1090,6 +1126,41 @@ export function AppCard({ app, status, isCatalog, isService, environment, market
               <path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5" />
             </svg>
             {launching ? 'Opening…' : 'Open'}
+          </button>
+        ) : hasUserUI && urlPending ? (
+          // Declared-UI app, URL not resolved yet → confident disabled
+          // placeholder. NOT clickable (no URL to launch). Replaced in
+          // place by the enabled Open the moment liveAppsQuery resolves —
+          // same slot, so the operator sees a settle, never a pop-in.
+          <button
+            type="button"
+            className="open-chip is-pending"
+            data-testid={`sov-app-open-pending-${app.id}`}
+            disabled
+            aria-disabled="true"
+            title={`Open ${app.title} — resolving the front-door URL…`}
+            aria-label={`Open ${app.title} — resolving the front-door URL`}
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+            }}
+          >
+            <svg
+              viewBox="0 0 24 24"
+              width={11}
+              height={11}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2.2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M14 3h7v7" />
+              <path d="M10 14L21 3" />
+              <path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5" />
+            </svg>
+            Open…
           </button>
         ) : null}
         {marketplacePublished !== null && marketplacePublished !== undefined && slug ? (
@@ -1362,6 +1433,21 @@ const APPS_PAGE_CSS = `
 .open-chip:hover { filter: brightness(0.92); transform: translateY(-1px); }
 .open-chip:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
 .open-chip:disabled { opacity: 0.6; cursor: wait; }
+/* #3656 (founder #6) — the "Open…" placeholder shown for a declared-UI app
+ * while its live front-door URL is still resolving. Rendered MUTED + outlined
+ * (not the solid accent of the live Open) so it reads as "loading, not yet
+ * actionable" rather than a real launch control. Default cursor + no hover
+ * lift make clear it isn't clickable; it is replaced in place by the enabled
+ * Open the moment the URL lands (no flash / pop-in). */
+.open-chip.is-pending {
+  background: transparent;
+  color: var(--color-text-dim);
+  border: 1px dashed var(--color-border);
+  box-shadow: none;
+  cursor: default;
+  opacity: 0.85;
+}
+.open-chip.is-pending:hover { filter: none; transform: none; }
 .open-chip svg { display: block; }
 /* #3603 — admin "Edit" pill (Catalog page, sovereign-admin only). Muted
  * surface tone so it reads as a secondary affordance next to the accent

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.test.tsx
@@ -354,6 +354,61 @@ describe('JobsTable — render', () => {
     expect(screen.getByTestId('jobs-cell-status-bp-crossplane').textContent?.toLowerCase()).toContain('running')
     expect(screen.getByTestId('jobs-cell-status-bp-vault').textContent?.toLowerCase()).toContain('pending')
   })
+
+  // ──────────────────────────────────────────────────────────────────
+  // #3656 (founder #6) — a provisional (live-unconfirmed) reducer-derived
+  // row renders a distinct "Confirming…" badge, NOT a definitive
+  // Pending/Running it would then flip to a terminal status.
+  // ──────────────────────────────────────────────────────────────────
+  const baseLeaf = {
+    type: 'install' as const,
+    parentId: 'applications',
+    childIds: [],
+    dependsOn: [],
+    startedAt: null,
+    finishedAt: null,
+    durationMs: 0,
+  }
+
+  it('a provisional row renders the "Confirming…" badge instead of "Pending"', async () => {
+    const jobs: Job[] = [
+      { ...baseLeaf, id: 'unconfirmed', jobName: 'Install X', appId: 'bp-x', status: 'pending', provisional: true },
+    ]
+    renderTable({ jobs })
+    await screen.findByTestId('jobs-table')
+    const badge = screen.getByTestId('jobs-cell-status-unconfirmed')
+    // Distinct provisional label + data-status, NOT the definitive "Pending".
+    expect(badge.textContent).toContain('Confirming')
+    expect(badge.textContent?.toLowerCase()).not.toContain('pending')
+    expect(badge.getAttribute('data-status')).toBe('confirming')
+    // The underlying reducer-derived status is preserved for diagnostics.
+    expect(badge.getAttribute('data-underlying-status')).toBe('pending')
+    expect(badge.className).toContain('jobs-badge-confirming')
+  })
+
+  it('a running-but-provisional row also shows "Confirming…", never a committed "Running"', async () => {
+    const jobs: Job[] = [
+      { ...baseLeaf, id: 'rp', jobName: 'Install Y', appId: 'bp-y', status: 'running', provisional: true },
+    ]
+    renderTable({ jobs })
+    await screen.findByTestId('jobs-table')
+    const badge = screen.getByTestId('jobs-cell-status-rp')
+    expect(badge.textContent).toContain('Confirming')
+    expect(badge.getAttribute('data-status')).toBe('confirming')
+    expect(badge.getAttribute('data-underlying-status')).toBe('running')
+  })
+
+  it('a NON-provisional row keeps its definitive status label (no false "Confirming…")', async () => {
+    const jobs: Job[] = [
+      { ...baseLeaf, id: 'confirmed', jobName: 'Install Z', appId: 'bp-z', status: 'pending' },
+    ]
+    renderTable({ jobs })
+    await screen.findByTestId('jobs-table')
+    const badge = screen.getByTestId('jobs-cell-status-confirmed')
+    expect(badge.textContent?.toLowerCase()).toContain('pending')
+    expect(badge.textContent).not.toContain('Confirming')
+    expect(badge.getAttribute('data-status')).toBe('pending')
+  })
 })
 
 // ── C8-005 (2026-05-17 t143): region filter helpers + dropdown ───────

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
@@ -698,7 +698,7 @@ function JobRow({ job, parentLabel, showRegion, regionUnionByGroupId }: JobRowPr
         )}
       </td>
       <td className="jobs-cell jobs-cell-status">
-        <StatusBadge status={job.status} jobId={job.id} />
+        <StatusBadge status={job.status} jobId={job.id} provisional={job.provisional === true} />
       </td>
       <td className="jobs-cell jobs-cell-started" title={started.absolute}>
         <span data-testid={`jobs-cell-started-${job.id}`}>{started.display}</span>
@@ -713,9 +713,36 @@ function JobRow({ job, parentLabel, showRegion, regionUnionByGroupId }: JobRowPr
 interface StatusBadgeProps {
   status: JobStatus
   jobId: string
+  /**
+   * #3656 (founder #6) — the row's status is reducer-derived and NOT yet
+   * confirmed by the live source. Render a distinct "Confirming…" badge
+   * instead of a definitive Pending/Running, so a job that actually
+   * completed is never shown non-terminal-then-flipped.
+   */
+  provisional?: boolean
 }
 
-function StatusBadge({ status, jobId }: StatusBadgeProps) {
+function StatusBadge({ status, jobId, provisional = false }: StatusBadgeProps) {
+  // #3656 — a provisional (live-unconfirmed) row never shows a definitive
+  // status. It renders "Confirming…" with its own tone + a spinner so the
+  // operator reads it as "settling", not as a committed state to flip.
+  if (provisional) {
+    return (
+      <span
+        className="jobs-badge jobs-badge-confirming"
+        data-testid={`jobs-cell-status-${jobId}`}
+        data-status="confirming"
+        // Preserve the underlying reducer-derived status for diagnostics +
+        // the sort comparator's transparency — the visible label stays
+        // provisional until the live source confirms.
+        data-underlying-status={status}
+        title="Awaiting confirmation from the live cluster state"
+      >
+        <span className="jobs-badge-spinner" aria-hidden />
+        <span className="jobs-badge-text">Confirming…</span>
+      </span>
+    )
+  }
   const tone = STATUS_TONE[status]
   return (
     <span
@@ -954,6 +981,20 @@ const JOBS_TABLE_CSS = `
 .jobs-badge-running   { background: rgba(56,189,248,0.10);  color: #38BDF8; border-color: rgba(56,189,248,0.35); }
 .jobs-badge-succeeded { background: rgba(74,222,128,0.10);  color: #4ADE80; border-color: rgba(74,222,128,0.35); }
 .jobs-badge-failed    { background: rgba(248,113,113,0.10); color: #F87171; border-color: rgba(248,113,113,0.35); }
+/* #3656 (founder #6) — provisional "Confirming…" badge: a reducer-derived
+ * row the live cluster state has not confirmed yet. Amber + DASHED border so
+ * it reads as a distinct "settling, not committed" state — unmistakable from
+ * the four definitive statuses; it resolves to the confirmed status the
+ * moment the live /jobs fetch lands. text-transform:none keeps the ellipsis
+ * label readable. */
+.jobs-badge-confirming {
+  background: rgba(251,191,36,0.10);
+  color: #FBBF24;
+  border-color: rgba(251,191,36,0.45);
+  border-style: dashed;
+  text-transform: none;
+  letter-spacing: 0.02em;
+}
 .jobs-badge-spinner {
   width: 8px;
   height: 8px;

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/handoverStageOverride.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/handoverStageOverride.ts
@@ -169,7 +169,10 @@ export function applyHandoverStageOverride(
     const j = jobs[i]!
     const slug = matchLifecycleStageSlug(j.id)
     if (slug !== null && isOverridableStatus(j.status)) {
-      out[i] = { ...j, status: 'succeeded' }
+      // #3656 — coercing to a terminal status SETTLES the row: clear any
+      // provisional flag so the badge shows the confirmed "Succeeded",
+      // never a terminal status still wearing the "Confirming…" label.
+      out[i] = { ...j, status: 'succeeded', provisional: false }
       mutated = true
     } else {
       out[i] = j

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.test.tsx
@@ -33,6 +33,8 @@ function makeJob(partial: Partial<Job>): Job {
     startedAt: partial.startedAt ?? null,
     finishedAt: partial.finishedAt ?? null,
     durationMs: partial.durationMs ?? 0,
+    // #3656 — only set when a test explicitly exercises the provisional flag.
+    ...(partial.provisional !== undefined ? { provisional: partial.provisional } : {}),
   }
 }
 
@@ -75,6 +77,68 @@ describe('mergeJobs — pure helper', () => {
     ]
     const merged = mergeJobs(reducer, live)
     expect(merged).toHaveLength(5)
+  })
+
+  // ──────────────────────────────────────────────────────────────────
+  // #3656 (founder #6) — a reducer-derived row whose status the LIVE
+  // source has not yet confirmed is provisional ("Confirming…"), never a
+  // definitive Pending/Running that a later live fetch flips.
+  // ──────────────────────────────────────────────────────────────────
+  it('marks reducer-derived NON-TERMINAL rows provisional when the live source has not landed', () => {
+    const reducer = [
+      makeJob({ id: 'a', status: 'pending' }),
+      makeJob({ id: 'b', status: 'running' }),
+    ]
+    const merged = mergeJobs(reducer, [])
+    expect(merged.map((j) => j.id)).toEqual(['a', 'b'])
+    // Both non-terminal rows are unconfirmed by the live source → provisional.
+    expect(merged.find((j) => j.id === 'a')!.provisional).toBe(true)
+    expect(merged.find((j) => j.id === 'b')!.provisional).toBe(true)
+    // Status is preserved (the badge swaps the LABEL, not the underlying status).
+    expect(merged.find((j) => j.id === 'a')!.status).toBe('pending')
+  })
+
+  it('does NOT mark reducer-derived TERMINAL rows provisional (a settled outcome is trustworthy)', () => {
+    const reducer = [
+      makeJob({ id: 'done', status: 'succeeded' }),
+      makeJob({ id: 'broke', status: 'failed' }),
+    ]
+    const merged = mergeJobs(reducer, [])
+    expect(merged.find((j) => j.id === 'done')!.provisional).toBeFalsy()
+    expect(merged.find((j) => j.id === 'broke')!.provisional).toBeFalsy()
+  })
+
+  it('live rows are NEVER provisional — once the live source lands its status is confirmed', () => {
+    // A completed-long-ago job: reducer still says pending, live says succeeded.
+    const reducer = [makeJob({ id: 'a', status: 'pending' })]
+    const live = [makeJob({ id: 'a', status: 'succeeded' })]
+    const merged = mergeJobs(reducer, live)
+    expect(merged).toHaveLength(1)
+    expect(merged[0]!.status).toBe('succeeded')
+    expect(merged[0]!.provisional).toBeFalsy()
+  })
+
+  it('clears a stale provisional flag carried on a live row (defensive)', () => {
+    const reducer: Job[] = []
+    const live = [makeJob({ id: 'a', status: 'running', provisional: true })]
+    const merged = mergeJobs(reducer, live)
+    expect(merged[0]!.provisional).toBe(false)
+  })
+
+  it('a completed job is shown provisional-then-confirmed, never non-terminal-then-flipped', () => {
+    // Cold open: reducer (stale) says the job is still running.
+    const reducer = [makeJob({ id: 'install-x', status: 'running' })]
+    const coldOpen = mergeJobs(reducer, [])
+    // The operator must NOT see a definitive "Running" for a job that's done —
+    // it is provisional until the live source confirms.
+    expect(coldOpen[0]!.provisional).toBe(true)
+    expect(coldOpen[0]!.status).toBe('running')
+
+    // Live fetch lands: the job actually finished. Live wins, confirmed.
+    const live = [makeJob({ id: 'install-x', status: 'succeeded' })]
+    const confirmed = mergeJobs(reducer, live)
+    expect(confirmed[0]!.status).toBe('succeeded')
+    expect(confirmed[0]!.provisional).toBeFalsy()
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.ts
@@ -149,9 +149,23 @@ export function useLiveJobsBackfill(
 }
 
 /**
+ * #3656 (founder #6) — a reducer-derived row's status is non-terminal AND
+ * unconfirmed by the live source. The reducer folds the SSE replay buffer,
+ * which can carry a stale `pending`/`running` for a job that actually
+ * finished long ago; until the live /jobs fetch lands and corrects it, the
+ * status is a guess, not ground truth.
+ */
+function isNonTerminal(status: Job['status']): boolean {
+  return status === 'pending' || status === 'running'
+}
+
+/**
  * Pure helper — merges reducer-derived jobs with live-API jobs.
  * Live data wins on conflict (same job.id). Reducer-derived rows that
- * don't appear in the live list pass through unchanged.
+ * don't appear in the live list pass through — but a reducer-derived
+ * non-terminal row is marked PROVISIONAL until the live source confirms
+ * it (#3656), so the table never asserts a definitive "Pending"/"Running"
+ * it then retracts to a terminal status.
  *
  * Stable: re-running on identical inputs produces identical output.
  * No randomness, no cached state. Exported so unit tests can lock in
@@ -169,6 +183,21 @@ export function mergeJobs(
   // navigates to a route the backend can't resolve (→ 404 → "Failed
   // to load log page"). Switch to backend-only the moment it returns
   // ≥1 row; reducer-derived stays as the empty-state fallback.
-  if (liveJobs.length > 0) return [...liveJobs]
-  return [...reducerJobs]
+  //
+  // #3656 (founder #6) — live rows are ground truth: they are NEVER
+  // provisional (clear any stale flag defensively). Their status IS the
+  // confirmed status.
+  if (liveJobs.length > 0) {
+    return liveJobs.map((j) => (j.provisional ? { ...j, provisional: false } : j))
+  }
+
+  // No live data yet (cold open, before the first /jobs fetch). Every
+  // reducer-derived row whose status is non-terminal is UNCONFIRMED —
+  // mark it provisional so the badge renders "Confirming…" rather than a
+  // definitive Pending/Running that a later live fetch may flip to
+  // succeeded/failed. Terminal reducer statuses (succeeded / failed) are
+  // a settled outcome the operator can trust, so they pass through as-is.
+  return reducerJobs.map((j) =>
+    isNonTerminal(j.status) && !j.provisional ? { ...j, provisional: true } : { ...j },
+  )
 }

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -51,6 +51,15 @@ export interface BlueprintCardEntry {
    * ships no topology block.
    */
   topology: BlueprintTopology | null
+  /**
+   * #3656 (founder #6) — whether this Blueprint declares a user-facing UI
+   * endpoint (ssoEnabled / launchDefault / name="ui" in spec.endpoints[]),
+   * mirroring the BE's blueprintHasUserUIEndpoint. The AppCard reads this
+   * to show a confident disabled "Open…" placeholder for a front-door app
+   * while its live externalURL resolves (no late pop-in), and to suppress
+   * any placeholder for a headless app (no transient chip).
+   */
+  hasUserUIEndpoint: boolean
 }
 
 /**
@@ -158,7 +167,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-anthropic-adapter",
@@ -222,7 +232,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-bge",
@@ -286,7 +297,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-catalyst-platform",
@@ -354,7 +366,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-cert-manager",
@@ -406,7 +419,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-cert-manager-dynadot-webhook",
@@ -456,7 +470,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-cert-manager-powerdns-webhook",
@@ -506,7 +521,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-cilium",
@@ -518,7 +534,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.4.1",
+    "version": "1.4.3",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [],
     "shareable": false,
@@ -554,7 +570,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-cilium-policies",
@@ -606,7 +623,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-clickhouse",
@@ -668,7 +686,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-cluster-autoscaler-hcloud",
@@ -716,7 +735,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-cnpg",
@@ -766,7 +786,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-cnpg-pair",
@@ -818,7 +839,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-coraza",
@@ -870,7 +892,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-crossplane",
@@ -922,7 +945,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-crossplane-claims",
@@ -976,7 +1000,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-debezium",
@@ -1038,7 +1063,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-dmz-vcluster",
@@ -1085,7 +1111,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-external-dns",
@@ -1137,7 +1164,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-external-secrets",
@@ -1149,7 +1177,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "section": "pts-3-3-security-and-policy",
     "depends": [
       "bp-openbao",
@@ -1192,7 +1220,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-external-secrets-stores",
@@ -1244,7 +1273,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-falco",
@@ -1292,7 +1322,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-ferretdb",
@@ -1354,7 +1385,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-flink",
@@ -1416,7 +1448,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-flux",
@@ -1468,7 +1501,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-gateway-api",
@@ -1520,7 +1554,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-gitea",
@@ -1532,7 +1567,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.34",
+    "version": "1.2.35",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-postgres"
@@ -1584,7 +1619,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-grafana",
@@ -1596,7 +1632,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.12",
+    "version": "1.0.14",
     "section": "pts-3-observability",
     "depends": [],
     "shareable": false,
@@ -1646,7 +1682,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-guacamole",
@@ -1658,7 +1695,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.8",
+    "version": "0.2.20",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": [
       "bp-keycloak",
@@ -1714,7 +1751,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-harbor",
@@ -1780,7 +1818,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-hcloud-ccm",
@@ -1828,7 +1867,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-hcloud-csi",
@@ -1876,7 +1916,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-iceberg",
@@ -1938,7 +1979,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-k8s-ws-proxy",
@@ -2002,7 +2044,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-keycloak",
@@ -2014,7 +2057,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.4.27",
+    "version": "1.4.28",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-postgres"
@@ -2066,7 +2109,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-knative",
@@ -2131,7 +2175,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-kserve",
@@ -2197,7 +2242,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-kyverno",
@@ -2209,7 +2255,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.3.6",
+    "version": "1.3.7",
     "section": "pts-3-3-security-and-policy",
     "depends": [],
     "shareable": false,
@@ -2249,7 +2295,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-kyverno-policies",
@@ -2261,7 +2308,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.33",
+    "version": "1.0.35",
     "section": "pts-3-3-security-and-policy",
     "depends": [],
     "shareable": false,
@@ -2301,7 +2348,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-langfuse",
@@ -2363,7 +2411,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-librechat",
@@ -2430,7 +2479,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-litmus",
@@ -2470,7 +2520,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-livekit",
@@ -2536,7 +2587,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-llm-gateway",
@@ -2602,7 +2654,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-loki",
@@ -2664,7 +2717,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-matrix",
@@ -2730,7 +2784,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-mgmt-vcluster",
@@ -2742,7 +2797,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.2.9",
+    "version": "0.2.10",
     "section": "pts-3-2-control-plane-isolation",
     "depends": [
       "bp-cilium",
@@ -2777,7 +2832,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-milvus",
@@ -2839,7 +2895,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-mimir",
@@ -2901,7 +2958,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-nats-jetstream",
@@ -2963,7 +3021,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-nemo-guardrails",
@@ -3027,7 +3086,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-neo4j",
@@ -3089,7 +3149,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-netbird",
@@ -3155,7 +3216,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-network-policies",
@@ -3209,7 +3271,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-newapi",
@@ -3221,7 +3284,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "1.4.66",
+    "version": "1.4.94",
     "section": "pts-4-6-llm-serving",
     "depends": [
       "bp-cnpg",
@@ -3277,7 +3340,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-oidc-gate",
@@ -3289,7 +3353,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-cilium",
@@ -3343,7 +3407,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-openbao",
@@ -3355,7 +3420,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.31",
+    "version": "1.2.46",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [],
     "shareable": false,
@@ -3370,7 +3435,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "perTopology": {
         "active-passive": {
           "replication": {
-            "backend": "openbao-perf-replication",
+            "backend": "raft",
             "mode": "async",
             "lagSloSeconds": 30
           },
@@ -3405,7 +3470,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-openclaw",
@@ -3447,7 +3513,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-openmeter",
@@ -3513,7 +3580,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-opensearch",
@@ -3599,7 +3667,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-opentelemetry",
@@ -3647,7 +3716,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-opentelemetry-operator",
@@ -3698,7 +3768,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-postgres",
@@ -3710,7 +3781,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.1.10",
+    "version": "0.2.2",
     "section": "pts-4-1-data-services",
     "depends": [
       "bp-cnpg",
@@ -3773,7 +3844,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-powerdns",
@@ -3823,7 +3895,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-powerdns-admin",
@@ -3835,7 +3908,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.13",
+    "version": "0.1.16",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-powerdns",
@@ -3879,7 +3952,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-qa-app",
@@ -3919,7 +3993,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-reflector",
@@ -3971,7 +4046,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-reloader",
@@ -4019,7 +4095,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-rtz-vcluster",
@@ -4031,7 +4108,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.2.8",
+    "version": "0.2.11",
     "section": "pts-3-2-control-plane-isolation",
     "depends": [
       "bp-cilium",
@@ -4066,7 +4143,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-sandbox",
@@ -4133,7 +4211,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-sealed-secrets",
@@ -4181,7 +4260,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-seaweedfs",
@@ -4193,7 +4273,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "section": "pts-3-5-storage-and-data",
     "depends": [
       "bp-cert-manager"
@@ -4235,7 +4315,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-self-sovereign-cutover",
@@ -4247,7 +4328,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.56",
+    "version": "0.1.72",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",
@@ -4280,7 +4361,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-sigstore",
@@ -4328,7 +4410,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-spire",
@@ -4390,7 +4473,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-sso-bridge",
@@ -4402,7 +4486,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.2.15",
+    "version": "0.2.18",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-keycloak",
@@ -4456,7 +4540,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-stalwart-sovereign",
@@ -4494,7 +4579,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-stalwart-tenant",
@@ -4561,7 +4647,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-strimzi",
@@ -4647,7 +4734,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-stunner",
@@ -4712,7 +4800,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-syft-grype",
@@ -4760,7 +4849,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-tempo",
@@ -4822,7 +4912,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-temporal",
@@ -4887,7 +4978,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-trivy",
@@ -4935,7 +5027,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-valkey",
@@ -5009,7 +5102,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-vcluster-helmrepo",
@@ -5059,7 +5153,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-velero",
@@ -5111,7 +5206,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-velero-hcs",
@@ -5163,7 +5259,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-vllm",
@@ -5175,7 +5272,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "section": "pts-4-6-llm-serving",
     "depends": [
       "bp-kserve"
@@ -5227,7 +5324,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   },
   {
     "id": "bp-vpa",
@@ -5239,7 +5337,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.1",
+    "version": "1.0.3",
     "section": "pts-3-3-security-and-policy",
     "depends": [],
     "shareable": false,
@@ -5275,7 +5373,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": false
   },
   {
     "id": "bp-wordpress-tenant",
@@ -5343,7 +5442,8 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
           }
         }
       }
-    }
+    },
+    "hasUserUIEndpoint": true
   }
 ] as const
 

--- a/products/catalyst/chart/crds/blueprint.yaml
+++ b/products/catalyst/chart/crds/blueprint.yaml
@@ -641,6 +641,30 @@ spec:
                         type: string
                     silentLogin:
                       type: boolean
+                # #3656 (founder #6) — declared user-UI capability. When a
+                # Blueprint fronts a user-facing UI (an OIDC-login front
+                # door the operator opens), the console's AppCard renders a
+                # confident disabled "Open…" placeholder while the live
+                # externalURL resolves — so the Open chip never pops in late
+                # (the faithful-view law: never assert-then-retract). A
+                # headless Blueprint (controller / operator / OCI registry /
+                # API-only backend) declares false (or omits this) and the
+                # card shows NO transient chip.
+                #
+                # Authoritative source remains spec.endpoints[]: the catalog
+                # projector (build-catalog.mjs) and the BE
+                # (blueprintHasUserUIEndpoint) both derive the signal from
+                # any endpoint with ssoEnabled / launchDefault / name="ui".
+                # This explicit field lets a Blueprint author document /
+                # override the capability at admission time and makes it
+                # visible on the CR.
+                hasUserUIEndpoint:
+                  type: boolean
+                  description: |
+                    True when this Blueprint exposes a user-facing UI front
+                    door (drives the console AppCard's "Open…" placeholder).
+                    Defaults from spec.endpoints[] (ssoEnabled / launchDefault
+                    / name="ui") when omitted.
                 multiInstance:
                   type: object
                   description: |


### PR DESCRIPTION
## T4 (UI faithfulness, founder #6) — the two remaining fixes

Completes **T4** of the IaC-first train. The new-instance-flash slice shipped in #3649; this PR builds the two remaining assert-then-retract fixes so T4 is whole. The UI is a faithful view — it never asserts a state it then retracts (no flash, no stale, no pop-in).

### (A) Open-button-late — a STATIC declared user-UI signal

`AppsPage` rendered the per-card "Open" chip **only** once the live `externalURL` (async via `liveAppsQuery`) was non-empty, so a real front-door app (harbor/gitea/grafana) showed nothing then **popped the chip in late**. A blanket placeholder was not the fix — it would flash a transient chip on headless apps.

The faithful fix threads a new Blueprint-declared `hasUserUIEndpoint` capability all the way through **declaration → projector → generated constant → UI** (no app-name hardcode):

- **CRD** (`products/catalyst/chart/crds/blueprint.yaml`) — optional `spec.hasUserUIEndpoint` boolean, admission-visible + author-overridable.
- **Projector** (`build-catalog.mjs`) — projects it onto every `BlueprintCardEntry`, deriving the default from `spec.endpoints[]` with the **same rule the BE uses** (`blueprintHasUserUIEndpoint`: `ssoEnabled` / `launchDefault` / `name=="ui"`), so the FE placeholder and the BE-projected `externalURL` always agree. 28 UI Blueprints resolve `true` (incl. grafana/gitea/harbor/keycloak/openbao); headless ones (cilium/flux/postgres/cnpg/newapi) resolve `false`.
- **UI** (`AppsPage.tsx` `AppCard`) — reads `hasUserUI` + `urlPending` and renders three faithful states: **enabled Open** when the URL resolves; a muted **disabled "Open…" placeholder** for a declared-UI app while the URL is pending; **NOTHING** for a headless app. The enabled Open replaces the placeholder in the same slot — a settle, never a pop-in.

### (B) jobs-stale — a provisional "Confirming…" state

`JobsPage` merges reducer-derived rows (folded from the SSE replay buffer) with the live `/jobs` query; on cold open a stale reducer row showed a definitive `pending`/`running` for a job that completed long ago, until the live fetch landed and flipped it.

- `mergeJobs` (`useLiveJobsBackfill.ts`) now marks a reducer-derived **non-terminal** row **provisional** whenever the live source has not confirmed it. Live rows are always authoritative (never provisional); terminal reducer statuses pass through.
- The `StatusBadge` (`JobsTable.tsx`) renders a distinct **"Confirming…"** state (amber, dashed) instead of a committed Pending/Running, with the underlying status preserved in `data-underlying-status` for diagnostics.
- `applyHandoverStageOverride` clears the flag when it settles a row to `succeeded`.
- The `provisional` flag is FE-only (`Job.provisional?`, optional, never on the catalyst-api wire).

## Files changed (file:line)

- `products/catalyst/chart/crds/blueprint.yaml` — `spec.hasUserUIEndpoint` field (~644).
- `products/catalyst/bootstrap/ui/scripts/build-catalog.mjs` — `blueprintHasUserUIEndpoint()` helper (~300) + projected onto each entry + `BlueprintCardEntry` interface.
- `products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts` + `products/catalyst/bootstrap/api/internal/catalog/blueprints.json` — regenerated (per-entry `hasUserUIEndpoint`; also folds in pre-existing cilium 1.4.1→1.4.3 pin drift).
- `products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx` — three-state Open render (~1059), `hasUserUI`/`urlPending` props + both call sites, `.open-chip.is-pending` CSS.
- `products/catalyst/bootstrap/ui/src/lib/jobs.types.ts` — `Job.provisional?` (~98).
- `products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.ts` — `mergeJobs` provisional marking (~160).
- `products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx` — `StatusBadge` "Confirming…" render (~718) + `.jobs-badge-confirming` CSS.
- `products/catalyst/bootstrap/ui/src/pages/sovereign/handoverStageOverride.ts` — clear `provisional` on settle (~172).

## Tests

14 new vitest cases: 6 for the Open placeholder (declared-UI app shows the disabled "Open…" only while pending; headless app shows no chip; enabled Open once the URL resolves), 5 for `mergeJobs` provisional marking, 3 for the "Confirming…" badge render. The files I touched are green under `npx vitest run src/pages/sovereign`; `npx tsc --noEmit` is clean.

Refs #3656. Part of train/hw150.