### PR TITLE
fix(console): stop AppDetail Topology "Live status" 404-polling loop for bootstrap HelmReleases

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
@@ -736,6 +736,7 @@ export function AppDetail({ disableStream = false }: AppDetailProps = {}) {
               applicationName={componentId}
               namespace={appNamespace}
               callerTier={callerTier}
+              isBootstrap={appIsBootstrap}
             />
           </div>
         ) : appTab === 'resources' ? (

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * TopologyTab.test.tsx — #3656 regression lock (founder #6, UI-faithfulness).
+ *
+ * Founder report (hw150, 2026-06-16): on a bootstrap-kit HelmRelease with NO
+ * Application CR (e.g. bp-alloy — the AppDetail hero shows
+ * `source: HelmRelease`), the Topology tab's "Live status" panel stuck on
+ * "Loading status…" while the browser console accumulated 59+ errors in ~2 min,
+ * all `GET /applications/{name}/status?namespace=flux-system → 404`. The status
+ * poller assumed an Application CR exists and retried in a tight loop forever.
+ *
+ * These tests lock the fix:
+ *   1. When `isBootstrap`, the status endpoint is NEVER called (no poll, no
+ *      404 loop) and the panel renders the calm n/a message.
+ *   2. When NOT bootstrap, the status endpoint IS called (normal behaviour
+ *      preserved).
+ *
+ * The fix is GENERIC — it gates on "no Application CR" (the `isBootstrap`
+ * signal the parent derives from `apiApp.bootstrap`), never on a blueprint
+ * name.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+/* ── Mock the API + infra clients so no network is hit ─────────────────── */
+
+const getApplicationStatus = vi.fn()
+const getCatalogItem = vi.fn()
+const getHierarchicalInfrastructure = vi.fn()
+
+vi.mock('@/lib/catalog.api', () => ({
+  getApplicationStatus: (...a: unknown[]) => getApplicationStatus(...a),
+  getCatalogItem: (...a: unknown[]) => getCatalogItem(...a),
+}))
+
+vi.mock('@/lib/infrastructure.types', () => ({
+  getHierarchicalInfrastructure: (...a: unknown[]) => getHierarchicalInfrastructure(...a),
+}))
+
+// Stub the heavy child widgets — the poller behaviour is what we assert,
+// not the editor / DR section internals (covered by their own tests).
+vi.mock('@/widgets/topology/TopologyEditor', () => ({
+  TopologyEditor: () => <div data-testid="stub-topology-editor" />,
+}))
+vi.mock('@/widgets/continuum/DRSection', () => ({
+  DRSection: () => <div data-testid="stub-dr-section" />,
+}))
+
+import { TopologyTab } from './TopologyTab'
+
+function withProviders(node: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{node}</QueryClientProvider>
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('TopologyTab — bootstrap HelmRelease status poll (#3656)', () => {
+  it('does NOT poll the status endpoint for a bootstrap component (no 404 loop)', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+
+    render(
+      withProviders(
+        <TopologyTab
+          sovereignId="test-sov"
+          applicationName="bp-alloy"
+          namespace="flux-system"
+          isBootstrap
+        />,
+      ),
+    )
+
+    // The calm n/a panel renders instead of a perpetual "Loading status…".
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-status-bootstrap')).toBeTruthy()
+    })
+    expect(screen.queryByTestId('topology-tab-status-loading')).toBeNull()
+
+    // Crucially: the status endpoint was never called, so it can never 404-loop.
+    expect(getApplicationStatus).not.toHaveBeenCalled()
+  })
+
+  it('DOES poll the status endpoint for a non-bootstrap app (Application CR exists)', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue({ topology: { regions: [] } })
+    getApplicationStatus.mockResolvedValue({
+      name: 'wordpress',
+      namespace: 'qa-omantel',
+      spec: { placement: 'single-region', regions: [] },
+      status: {},
+    })
+
+    render(
+      withProviders(
+        <TopologyTab
+          sovereignId="test-sov"
+          applicationName="wordpress"
+          namespace="qa-omantel"
+        />,
+      ),
+    )
+
+    await waitFor(() => {
+      expect(getApplicationStatus).toHaveBeenCalled()
+    })
+    // The bootstrap panel must NOT show for a CR-backed app.
+    expect(screen.queryByTestId('topology-tab-status-bootstrap')).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -103,6 +103,18 @@ export interface TopologyTabProps {
   callerTier?: string
   /** Continuum CR name (slice U-DR-1) — when omitted, derived as `dr-<applicationName>`. */
   continuumName?: string
+  /**
+   * #3656 — true when this app is a bootstrap-kit HelmRelease with NO
+   * companion Application CR (the parent AppDetail computes this from
+   * `apiApp.bootstrap`; the hero already renders `source: HelmRelease`).
+   * The GET /applications/{name}/status endpoint 404s for these — the CR
+   * it reads does not exist — so we MUST NOT poll it. Without this gate the
+   * Live-status poller hammered the 404 forever (founder #6: a faithful UI
+   * never sticks on "Loading…" against a state that can never resolve).
+   * Generic by construction — keys on "has Application CR", never a
+   * blueprint name.
+   */
+  isBootstrap?: boolean
 }
 
 interface ApplicationStatus {
@@ -136,15 +148,23 @@ export function TopologyTab({
   disableNetwork = false,
   callerTier,
   continuumName,
+  isBootstrap = false,
 }: TopologyTabProps) {
   const qc = useQueryClient()
   const [refreshTick, setRefreshTick] = useState(0)
 
+  // #3656 — bootstrap-kit HelmReleases (bp-alloy/gitea/harbor/openbao/…)
+  // have NO Application CR, so the status endpoint 404s forever. Don't poll
+  // it for them, and never retry/loop on a 404: a faithful UI renders the
+  // calm n/a state below instead of sticking on "Loading…" against a state
+  // that can never resolve. `retry: false` + `refetchInterval: false` (when
+  // bootstrap) kills the tight 404 loop the founder caught on hw150.
   const statusQ = useQuery({
     queryKey: ['application-status', sovereignId, applicationName, namespace, refreshTick],
     queryFn: () => getApplicationStatus(sovereignId, applicationName, namespace),
-    enabled: !initialApp && !!sovereignId && !!applicationName,
-    refetchInterval: 10_000,
+    enabled: !initialApp && !isBootstrap && !!sovereignId && !!applicationName,
+    refetchInterval: isBootstrap ? false : 10_000,
+    retry: false,
   })
 
   // Resolve the spec view of the Application — this comes from the
@@ -338,7 +358,12 @@ export function TopologyTab({
         className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-3"
         data-testid="topology-tab-status-panel"
       >
-        {!app ? (
+        {isBootstrap ? (
+          <p className="text-xs text-[var(--color-text-dim)]" data-testid="topology-tab-status-bootstrap">
+            n/a — bootstrap component (HelmRelease, no Application CR). Live
+            rollout status is tracked via Flux, not the per-region controller.
+          </p>
+        ) : !app ? (
           <p className="text-xs text-[var(--color-text-dim)]" data-testid="topology-tab-status-loading">
             Loading status…
           </p>


### PR DESCRIPTION
## Problem (founder #6 — UI faithfulness)

Live evidence (hw150): on `console.hw150.omantel.biz/app/bp-alloy` → **Topology** tab, the **Live status** panel sticks on "Loading status…" and the browser console accumulates **59+ errors in ~2 min**, all:

```
GET /api/v1/sovereigns/{id}/applications/{app}/status?namespace=flux-system → 404 (Not Found)
```

**Root cause**: `TopologyTab` polls `getApplicationStatus()` on a 10s `refetchInterval`. `bp-alloy` is a **bootstrap-kit HelmRelease with NO Application CR** (the hero already renders `source: HelmRelease`). That status endpoint reads the Application CR — which does not exist — so it **404s**, and the query retried it in a tight loop forever. `getApplicationStatus` throws on any non-OK status, and nothing gated the poll on "does an Application CR exist".

## Fix (surgical + generic — no per-app hardcoding)

Gates on **"has Application CR"**, never on a blueprint name:

1. Thread the `isBootstrap` signal the parent `AppDetail` already derives from `apiApp.bootstrap` into `TopologyTab`.
2. When bootstrap: **disable** the status query (no poll, no 404 loop) and render a calm **"n/a — bootstrap component (HelmRelease, no Application CR)"** message instead of the perpetual "Loading status…".
3. Set `retry: false` on the status query so a 404 never loops even for a non-bootstrap edge case.

The DR section already had a `declaredClass` fallback for bootstrap apps; this just stops the *status poll* from hammering the 404.

## Files changed

- `products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx` — new `isBootstrap` prop; gate `statusQ` (`enabled` + `refetchInterval:false` + `retry:false`); render bootstrap n/a panel.
- `products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx` — pass `isBootstrap={appIsBootstrap}` into `<TopologyTab>`.
- `products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.test.tsx` — new regression test (bootstrap → no status call + n/a panel; non-bootstrap → polls as before).

## Verification

- `npm run typecheck` ✅ clean
- `npx vitest run TopologyTab.test.tsx` ✅ 2/2 pass
- `npx vitest run AppDetail.test.tsx SettingsTab.test.tsx` ✅ 31/31 pass (no regression)
- `npm run build` ✅ production build succeeds

Refs #3656

🤖 Generated with [Claude Code](https://claude.com/claude-code)