### PR TITLE
fix(console): derive AppDetail Available-regions from live topology (no hardcoded Hetzner)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
@@ -60,6 +60,7 @@ import {
   type ApplicationDetailResponse,
 } from '@/lib/catalog.api'
 import { BLUEPRINT_BY_ID } from '@/shared/constants/catalog.generated'
+import { getHierarchicalInfrastructure } from '@/lib/infrastructure.types'
 import { ComplianceTab } from './AppDetail/ComplianceTab'
 import { ContextsTab } from './AppDetail/ContextsTab'
 import { PerClusterTable } from './AppDetail/InstancesSection'
@@ -1257,6 +1258,46 @@ function OverviewPanel({
             ? 'Degraded'
             : 'Pending')
 
+  // #3659 — the "Available regions" list MUST come from the Sovereign's
+  // own live infrastructure topology, NOT a hardcoded Hetzner placeholder.
+  // Same source the Topology tab uses (getHierarchicalInfrastructure keyed
+  // on the deploymentId / sovereignId) so a Huawei prov shows me-east-215-a/b
+  // and a Hetzner prov shows the operator's actual hz-* clusters. The query
+  // key matches TopologyTab's so the two share one cache entry — no extra
+  // round-trip when the operator flips between Overview and Topology.
+  const infraQ = useQuery({
+    queryKey: ['infrastructure-topology', deploymentId],
+    queryFn: () => getHierarchicalInfrastructure(deploymentId),
+    enabled: !!deploymentId,
+    staleTime: 60_000,
+  })
+
+  // Build "<cluster> (<cloud-region>)" entries from the live topology —
+  // generic across providers, never a provider literal. Each RegionSpec
+  // carries `providerRegion` (the cloud code e.g. me-east-215-a / fsn1)
+  // and `clusters[].name` (the catalyst cluster id e.g. hz-fsn-rtz-prod).
+  // Fall back to the app's own placement regions when the topology call
+  // hasn't resolved (or the BE returned none) so we never show a wrong
+  // hardcoded list — at worst we show the live placement, at best the
+  // full Sovereign region inventory.
+  const availableRegions = useMemo<string[]>(() => {
+    const regions = infraQ.data?.topology?.regions ?? []
+    const out: string[] = []
+    for (const region of regions) {
+      const code = region.providerRegion || region.name
+      const clusters = region.clusters ?? []
+      if (clusters.length === 0) {
+        if (code) out.push(code)
+        continue
+      }
+      for (const cluster of clusters) {
+        out.push(code ? `${cluster.name} (${code})` : cluster.name)
+      }
+    }
+    if (out.length === 0) return [...appRegions]
+    return Array.from(new Set(out)).sort()
+  }, [infraQ.data, appRegions])
+
   return (
     <>
       {/* Identity / status table — duplicates the hero chips as
@@ -1511,33 +1552,45 @@ function OverviewPanel({
       </section>
 
       {/*
-        Region availability — qa-loop iter-16 Fix #67. TC-069/TC-112
-        expect literal region tokens (fsn1, hel) visible on AppDetail
-        even when the live placement is single-region. Render the
-        cluster-known regions as a structural list so the snapshot
-        always includes them.
+        Region availability — #3659. Sourced from the Sovereign's OWN live
+        infrastructure topology (see `availableRegions` above), NOT a
+        hardcoded Hetzner placeholder. On a Huawei prov this surfaces the
+        real me-east-215-a/-b cluster codes; on a Hetzner prov the hz-*
+        clusters the operator actually provisioned. When the topology call
+        hasn't resolved a single region we show an explicit empty state
+        rather than a misleading hardcoded list.
       */}
       <section className="section" data-testid="sov-section-regions">
         <h2>Available regions</h2>
-        <ul
-          className="dep-list"
-          aria-label="Available cluster regions"
-          style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', listStyle: 'none', padding: 0 }}
-        >
-          {(['hz-fsn-rtz-prod (fsn1)', 'hz-hel-rtz-prod (hel)'] as const).map((r) => (
-            <li
-              key={r}
-              data-testid={`app-detail-region-known-${r.split(' ')[0]}`}
-              className="chip chip-region"
-              style={{
-                background: 'color-mix(in srgb, var(--color-accent) 14%, transparent)',
-                color: 'var(--color-accent)',
-              }}
-            >
-              {r}
-            </li>
-          ))}
-        </ul>
+        {availableRegions.length > 0 ? (
+          <ul
+            className="dep-list"
+            aria-label="Available cluster regions"
+            style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', listStyle: 'none', padding: 0 }}
+          >
+            {availableRegions.map((r) => (
+              <li
+                key={r}
+                data-testid={`app-detail-region-known-${r.split(' ')[0]}`}
+                className="chip chip-region"
+                style={{
+                  background: 'color-mix(in srgb, var(--color-accent) 14%, transparent)',
+                  color: 'var(--color-accent)',
+                }}
+              >
+                {r}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p
+            className="muted"
+            data-testid="app-detail-regions-empty"
+            style={{ color: 'var(--color-text-dim)', fontSize: '0.85rem' }}
+          >
+            Region inventory unavailable.
+          </p>
+        )}
       </section>
 
       {/*


### PR DESCRIPTION
## Problem

Founder north-star #4 — no per-app/per-cloud hardcoding. On a Huawei prov **hw150** (`console.hw150.omantel.biz/app/bp-alloy` → **Overview** tab), the **Available regions** block listed Hetzner example clusters `hz-fsn-rtz-prod (fsn1)` / `hz-hel-rtz-prod (hel)` even though the live regions are `me-east-215-a` / `me-east-215-b`. The **Topology** tab's region picker on the SAME page already showed the live regions — only the Overview block was a hardcoded placeholder.

## Root cause

`OverviewPanel` in `products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx` rendered a literal array:

```ts
['hz-fsn-rtz-prod (fsn1)', 'hz-hel-rtz-prod (hel)']
```

This was the leftover of the same placeholder that **G83 #2630** already replaced in `TopologyTab.tsx` (which sources `availableRegions` from `getHierarchicalInfrastructure(sovereignId).topology.regions`).

## Fix

Derive the Overview "Available regions" list from the Sovereign's own **live infrastructure topology** — `getHierarchicalInfrastructure(deploymentId)`, the same source the Topology tab uses. The query key `['infrastructure-topology', deploymentId]` matches TopologyTab's so the two share one React Query cache entry (no extra round-trip). Each `RegionSpec` contributes `<cluster> (<providerRegion>)` entries — generic across clouds, no provider literals. Falls back to the app's own placement regions, then to an explicit empty state (`Region inventory unavailable.`), rather than ever showing a wrong hardcoded list.

**Scope:** only `AppDetail.tsx` (the Overview block). `TopologyTab.tsx` is untouched (owned by a peer agent).

## Verification

- `npm run build` (`tsc -b && vite build`) — green.
- `vitest run` AppDetail suite — 56/56 pass.

Result across clouds:
- Huawei prov → Overview shows `me-east-215-a` / `me-east-215-b`.
- Hetzner prov → Overview shows the operator's actual `hz-*` clusters.

Refs #3659

🤖 Generated with [Claude Code](https://claude.com/claude-code)