### PR TITLE
fix(catalyst): canonicalize active-hot-standby across cnpg-pair CRD + catalyst-api

### DIFF
--- a/core/services/catalog/store/store.go
+++ b/core/services/catalog/store/store.go
@@ -34,14 +34,18 @@ type App struct {
 	IconDark        string    `bson:"icon_dark,omitempty" json:"icon_dark,omitempty"`
 	IconBg          string    `bson:"icon_bg" json:"icon_bg"`
 	// SupportedTopologies is the admin-editable set of placement modes
-	// this catalog entry advertises (e.g. ["single-region",
-	// "active-active", "active-hotstandby"]) — #3602, EPIC #3597. The
-	// canonical topology declaration still lives on the Blueprint
-	// (spec.topology.supported); this field lets the sovereign-admin
-	// curate which of those modes the catalog surfaces per entry without
-	// editing the Blueprint. Empty = no admin override; the catalog read
-	// API keeps the Blueprint/seed's own placement set. Additive — never
-	// overwrites the seed when unset.
+	// this catalog entry advertises, in the CANONICAL topology vocabulary
+	// (e.g. ["singleton", "active-active", "active-hot-standby"]) — #3602,
+	// EPIC #3597, canonicalized #3648. The canonical topology declaration
+	// still lives on the Blueprint (spec.topology.supported); this field
+	// lets the sovereign-admin curate which of those modes the catalog
+	// surfaces per entry without editing the Blueprint. The catalog-edit
+	// write path (catalog_edit_blueprint_yaml.go) normalizes the UI's
+	// placement-editor dialect (single-region / active-hotstandby) onto
+	// this canonical form before persisting, so values land hyphenated to
+	// match what the application-controller validates. Empty = no admin
+	// override; the catalog read API keeps the Blueprint/seed's own
+	// placement set. Additive — never overwrites the seed when unset.
 	SupportedTopologies []string `bson:"supported_topologies,omitempty" json:"supported_topologies,omitempty"`
 	MinimumSize     string    `bson:"minimum_size" json:"minimum_size"`
 	RecommendedSize string    `bson:"recommended_size" json:"recommended_size"`

--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -674,7 +674,7 @@ func generateCNPGPair(ns, password string, apps []string, cfg map[string]any, pr
 	// a different validation surface for `replicas` / `disk_gb`).
 	// `replicas` here maps to CNPG `instances` per region; min 3 is
 	// the bp-cnpg-pair chart's own configSchema floor for primary
-	// (active-hotstandby HA requires a 3-node quorum per region). If
+	// (active-hot-standby HA requires a 3-node quorum per region). If
 	// the customer chose 1-2 we clamp to 3 and log loud so the gap is
 	// operator-visible.
 	requested := readIntCfg(cfg, "replicas", 3, 1, 5, "postgres")

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_edit_blueprint_yaml.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_edit_blueprint_yaml.go
@@ -87,9 +87,20 @@ func mergeCatalogEditIntoBlueprintYAML(existing []byte, bpName string, edit cata
 	if len(edit.SupportedTopologies) > 0 {
 		topo := childMap(spec, "topology")
 		// Store as a plain []interface{} so yaml emits a clean sequence.
+		// #3648 — spec.topology.supported is the CANONICAL vocabulary
+		// (singleton | active-active | active-hot-standby | active-passive)
+		// that the application-controller's topology renderer validates
+		// against. The admin catalog UI may post the placement-editor
+		// dialect (single-region / active-hotstandby), so canonicalise each
+		// value before persisting — otherwise an un-hyphenated
+		// `active-hotstandby` lands in supported[] and every instance create
+		// fails `topology not in supported[]`. canonicalizeTopology mirrors
+		// the create-path normaliser in endpoint_handler.go; an unknown value
+		// is passed through trimmed so the Blueprint admission webhook still
+		// rejects genuine typos with their original spelling.
 		seq := make([]interface{}, 0, len(edit.SupportedTopologies))
 		for _, t := range edit.SupportedTopologies {
-			if s := strings.TrimSpace(t); s != "" {
+			if s := canonicalizeTopology(t); s != "" {
 				seq = append(seq, s)
 			}
 		}

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git_test.go
@@ -70,8 +70,11 @@ func TestMergeCatalogEditIntoBlueprintYAML_FreshCR(t *testing.T) {
 	if got.IconLight != "https://cdn/light.svg" || got.IconDark != "https://cdn/dark.svg" {
 		t.Errorf("icon round-trip: light=%q dark=%q", got.IconLight, got.IconDark)
 	}
-	if len(got.SupportedTopologies) != 2 || got.SupportedTopologies[0] != "single-region" {
-		t.Errorf("topology round-trip: %v", got.SupportedTopologies)
+	// #3648 — the write path canonicalizes the placement-editor dialect onto
+	// the canonical spec.topology.supported vocabulary, so single-region is
+	// stored (and read back) as singleton; active-active is already canonical.
+	if len(got.SupportedTopologies) != 2 || got.SupportedTopologies[0] != "singleton" || got.SupportedTopologies[1] != "active-active" {
+		t.Errorf("topology round-trip: got %v want [singleton active-active]", got.SupportedTopologies)
 	}
 }
 
@@ -290,8 +293,38 @@ func TestCommitCatalogAppEditToGit_DecodesCommerceAppBody(t *testing.T) {
 	if got.IconLight != "l.svg" || got.IconDark != "d.svg" {
 		t.Errorf("theme icons not committed: %+v", got)
 	}
-	if len(got.SupportedTopologies) != 1 || got.SupportedTopologies[0] != "single-region" {
-		t.Errorf("topologies not committed: %v", got.SupportedTopologies)
+	// #3648 — single-region (placement-editor dialect) canonicalizes to
+	// singleton on the canonical spec.topology.supported.
+	if len(got.SupportedTopologies) != 1 || got.SupportedTopologies[0] != "singleton" {
+		t.Errorf("topologies not committed canonically: got %v want [singleton]", got.SupportedTopologies)
+	}
+}
+
+// TestCommitCatalogAppEditToGit_CanonicalizesHotStandby (#3648) — the
+// founder's failing case: the catalog UI posts the un-hyphenated
+// placement-editor dialect `active-hotstandby`, which MUST land in the
+// canonical spec.topology.supported as `active-hot-standby` so a later
+// instance create resolves against the Blueprint instead of failing
+// `topology "active-hotstandby" not in supported [...]`.
+func TestCommitCatalogAppEditToGit_CanonicalizesHotStandby(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+
+	body := []byte(`{"slug":"postgres","name":"Postgres","published":true,"supported_topologies":["active-active","active-hotstandby"]}`)
+	h.commitCatalogAppEditToGit(context.Background(), body)
+
+	key := giteaKey(catalogSovereignOrg, "bp-postgres", catalogEditGitBranch, catalogEditBlueprintPath)
+	raw, ok := fg.files[key]
+	if !ok {
+		t.Fatalf("expected committed blueprint.yaml at %s; keys=%v", key, fileKeys(fg))
+	}
+	got, ok := catalogEditFromBlueprintYAML("bp-postgres", raw)
+	if !ok {
+		t.Fatal("committed CR did not parse")
+	}
+	if len(got.SupportedTopologies) != 2 || got.SupportedTopologies[1] != "active-hot-standby" {
+		t.Errorf("active-hotstandby must canonicalize to active-hot-standby: got %v", got.SupportedTopologies)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -183,9 +183,15 @@ const (
 )
 
 // validBcpTopologies is the wire-allowed set the validator checks
-// against. Kept in sync with the chart-side enum in
-// products/catalyst/chart/crds/cnpgpair.yaml (`spec.topology`) and the
-// applications_update.go placement.mode set.
+// against. This is the operator-signup PLACEMENT-EDITOR DIALECT — kept in
+// sync with the Sovereign CRD enum (`spec.bcpTopology` in
+// products/catalyst/chart/crds/sovereign.yaml) and the
+// applications_update.go placement.mode set. NOTE (#3648): the separate
+// cnpg-pair DR CRD (`cnpgpairs.dr.openova.io` spec.topology) uses the
+// CANONICAL hyphenated vocabulary (`active-hot-standby`); do NOT "resync"
+// this dialect set to it — they are intentionally different axes (signup
+// dialect vs canonical DR-contract). The dialect→canonical mapping lives
+// in endpoint_handler.go::canonicalizeTopology.
 var validBcpTopologies = map[string]struct{}{
 	BcpTopologySingleRegion:     {},
 	BcpTopologyActiveHotStandby: {},

--- a/products/catalyst/chart/crds/cnpgpair.yaml
+++ b/products/catalyst/chart/crds/cnpgpair.yaml
@@ -101,8 +101,16 @@ spec:
                   default: 60
                 topology:
                   type: string
-                  enum: [active-hotstandby, active-active]
-                  default: active-hotstandby
+                  # #3648 — canonical hyphenated vocabulary (matches the
+                  # Blueprint spec.topology.supported + docs/topology-matrix.md:
+                  # singleton | active-active | active-hot-standby | active-passive).
+                  # The legacy un-hyphenated `active-hotstandby` stays in the enum
+                  # for back-compat with any CnpgPair CR written before this
+                  # canonicalization (helm-controller skips crds/ on upgrade, so a
+                  # live Sovereign may still carry the old spelling until re-applied).
+                  # New writers emit the canonical default below.
+                  enum: [active-hot-standby, active-active, active-hotstandby]
+                  default: active-hot-standby
               x-kubernetes-preserve-unknown-fields: true
             status:
               type: object

--- a/products/catalyst/chart/templates/qa-fixtures/cnpgpair-qa.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/cnpgpair-qa.yaml
@@ -45,7 +45,7 @@ spec:
   replicaRegion: {{ .Values.qaFixtures.cnpgPairReplicaRegion | default (.Values.qaFixtures.standbyRegion | default "hz-hel-rtz-prod") }}
   rpoSeconds: 30
   rtoSeconds: 60
-  topology: active-hotstandby
+  topology: active-hot-standby
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -201,5 +201,5 @@ spec:
   replicaRegion: {{ .Values.qaFixtures.cnpgPairReplicaRegion | default (.Values.qaFixtures.standbyRegion | default "hz-hel-rtz-prod") }}
   rpoSeconds: 30
   rtoSeconds: 60
-  topology: active-hotstandby
+  topology: active-hot-standby
 {{- end }}


### PR DESCRIPTION
## What

Completes the topology vocabulary canonicalization that train-car **T0** (#3648) started. T0 canonicalized the Blueprint/Sovereign CRD (`topology.supported` = `[active-active, active-hot-standby, active-passive, singleton]`), but a hw150 backend validation found the un-hyphenated `active-hotstandby` dialect still lived in several backend persistence/validation layers — so a canonical `active-hot-standby` round-trip could still mismatch.

## The model (preserved, not broken)

There is an intentional **dual vocabulary**:
- **UI / placement-editor dialect** — `single-region` / `active-active` / `active-hotstandby` (Application CRD `spec.placement`, Sovereign CRD `spec.bcpTopology`, `placement.go` constants, the TopologyEditor). **Unchanged.**
- **Canonical persistence/DR vocabulary** — `singleton` / `active-active` / `active-hot-standby` / `active-passive` (Blueprint `spec.topology.supported`, `docs/topology-matrix.md`, the cnpg-pair DR CRD). The dialect is normalized to canonical at persistence.

This PR fixes only the **backend/CRD canonical layers + the dialect→canonical normalization gaps**; it does not touch the editor's displayed dialect.

## Changes

| File | Change |
|------|--------|
| `products/catalyst/chart/crds/cnpgpair.yaml` | `spec.topology` default → `active-hot-standby`; enum → `[active-hot-standby, active-active, active-hotstandby]` (canonical default; legacy spelling retained for back-compat — helm-controller skips `crds/` on upgrade so a live Sovereign may still carry the old value until re-applied). |
| `…/handler/catalog_edit_blueprint_yaml.go` | Catalog-edit git-write now runs `SupportedTopologies` through `canonicalizeTopology` before writing to `spec.topology.supported` — closes the real round-trip bug (a UI-posted `active-hotstandby` previously landed un-hyphenated in the canonical field the application-controller validates, causing `topology not in supported[]` on instance create). |
| `…/chart/templates/qa-fixtures/cnpgpair-qa.yaml` | Both CNPGPair fixtures → `active-hot-standby`. |
| `core/services/catalog/store/store.go` | `SupportedTopologies` doc comment → canonical example + notes the write-path normalization. |
| `core/services/provisioning/gitops/gitops.go` | comment → `active-hot-standby`. |
| `…/provisioner/provisioner.go` | `validBcpTopologies` comment clarified: it is the **signup editor-dialect** axis (synced to the Sovereign CRD), explicitly NOT the cnpg-pair canonical axis — prevents a future erroneous "resync" that would revert this PR. |
| `…/handler/catalog_edit_git_test.go` | Round-trip assertions updated to the canonical contract; **added** `TestCommitCatalogAppEditToGit_CanonicalizesHotStandby` covering the founder's exact failing case (`active-hotstandby` → stored `active-hot-standby`). |

## Verification

- `go build ./...` + `go test` green for all three touched modules: `products/catalyst/bootstrap/api` (handler + provisioner, full suites), `core/services/catalog`, `core/services/provisioning`.
- `cnpgpair.yaml` lints as valid YAML.
- `helm template` renders the QA fixture with `topology: active-hot-standby`.
- Round-trip confirmed: UI `active-hotstandby` → stored `active-hot-standby` → cnpg-pair CRD accepts.

Refs #3648

🤖 Generated with [Claude Code](https://claude.com/claude-code)