### PR TITLE
feat(sso): one admin authority + silent console front door + generic gate coverage (#3374)

### DIFF
--- a/.github/workflows/sso-probe.yaml
+++ b/.github/workflows/sso-probe.yaml
@@ -32,12 +32,35 @@ on:
         required: false
   schedule:
     - cron: "17 2 * * *"
+  # #3374 Layer-C static tripwire — the dead-grant guard needs no live
+  # env, so it gates EVERY PR touching the SSO chain (the per-app live
+  # walk still runs on dispatch/schedule against a Sovereign).
+  pull_request:
+    paths:
+      - "platform/sso-bridge/chart/**"
+      - "platform/keycloak/chart/templates/configmap-sovereign-realm.yaml"
+      - "scripts/check-no-dead-grant-theater.sh"
+      - ".github/workflows/sso-probe.yaml"
 
 permissions:
   contents: read
 
 jobs:
+  # Static regression tripwire (#3374 Layer-C / #3685 / DoD box 7): the
+  # dead admin-by-default grant theater must stay deleted. Runs on every
+  # PR — no live Sovereign needed.
+  dead-grant-guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: No dead admin-by-default grant theater
+        run: bash scripts/check-no-dead-grant-theater.sh
+
   probe:
+    # The live per-app walk needs a Sovereign — only on dispatch/schedule,
+    # never on the static pull_request leg.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -166,7 +166,8 @@ spec:
       # auto-links to the pre-seeded user by email (trustEmail=true flow).
       # 1.4.25: hook Job managed-by:flux (kyverno Enforce, #3297 class).
       # 1.4.26: config-cli right-sized 500m->100m (requests-wedge on hw130).
-      version: 1.4.28
+      # 1.4.29: sovereign-realm configmap one-admin-authority (#3374).
+      version: 1.4.29
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -159,6 +159,16 @@ spec:
     #   sso.sovereignFqdn      — e.g. ${SOVEREIGN_FQDN}
     # All other defaults inherit from platform/powerdns-admin/chart/values.yaml.
     gateway:
+      # #3374 Layer-A (2026-06-17): the bp-oidc-gate generic gate (slot
+      # 13c) now OWNS pdns-admin.<fqdn> and fronts pda with oauth2-proxy
+      # zero-click SSO — replacing pda's bespoke root-redirect (which was
+      # the structurally-fragile per-app hack: the OIDC callback shares
+      # the /login path, so the redirect approach looped and was reverted
+      # in 0.1.11). Two HTTPRoutes on one hostname is undefined routing,
+      # so this chart's OWN HTTPRoute is DISABLED — the gate's HTTPRoute
+      # is the single owner. The host is still declared so the KC client
+      # redirectUris + catalog-seed hostnameTemplate stay correct.
+      enabled: false
       # #3150 — single-level host (wildcard-cert-covered + matches the KC
       # client redirectUris + the catalog-seed/blueprint hostnameTemplate).
       host: "pdns-admin.${SOVEREIGN_FQDN}"

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1127,25 +1127,26 @@ spec:
     # pre-existing definition. The opt-out shipped in
     # bp-sso-bridge 0.1.1 (G91-fu, Refs #2659, edc55c08) gates exactly
     # this case — `skipClientUpsert: true` makes bp-sso-bridge skip the
-    # per-Client upsert + ExternalSecret + per-Client `admin` grant path
-    # and ONLY run grant_operator_realm_roles.
+    # per-Client upsert + ExternalSecret path.
     #
-    # clientId is set to `catalyst-ui` to match the realm-import Client.
-    # bp-sso-bridge does not consult clientId when skipClientUpsert=true
-    # (it only feeds the labels/logs); the realm-role grant is per-user
-    # not per-client.
+    # #3374 Layer-C (2026-06-17): `realmRolesGranted` REMOVED. The
+    # console-admin realm role (`catalyst-admin`) is now conferred by
+    # membership in the `/sovereign-admins` group — the realm import
+    # composites `realmRoles: ["catalyst-admin"]` onto that group
+    # (configmap-sovereign-realm.yaml), and the owner is placed in the
+    # group at handover (auth_handover.go EnsureUser). ONE membership
+    # lights up console + KC console + every app. The former per-email
+    # grant_operator_realm_roles path (the dead admin-by-default theater,
+    # #3685) is deleted from bp-sso-bridge, so this slot no longer needs
+    # to declare the role — admin follows the group, generically.
     #
-    # realm-role `catalyst-admin` exists in the realm import (see
-    # configmap-sovereign-realm.yaml composite-role chain). If a future
-    # realm re-architecture drops the role, the grant is a no-op (the
-    # framework's lookup returns 404 and logs a WARN — non-fatal).
+    # clientId is set to `catalyst-ui` to match the realm-import Client
+    # (feeds bp-sso-bridge labels/logs only when skipClientUpsert=true).
     sso:
       enabled: true
       realm: sovereign
       clientId: catalyst-ui
       skipClientUpsert: true
-      realmRolesGranted:
-        - catalyst-admin
     # G87 #2634: multi-region CNPG instances default (1 single-region, 2 multi).
     # Applies to sme-services' CNPG cluster (sme-pg).
     # #2840-followup (2026-06-03): the chart reads `.Values.smePostgres.

--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -144,7 +144,8 @@ spec:
       # credentials → raw win left generic_oauth unconfigured (empty client_id,
       # redirect_uri https://localhost/). Slot 25-grafana sets the flag.
       # Default false → harbor/openbao/gitea/powerdns byte-identical. Refs #3374.
-      version: 0.2.18
+      # 0.2.19: reconciler configmap generic gate coverage (#3374).
+      version: 0.2.19
       sourceRef:
         kind: HelmRepository
         name: bp-sso-bridge

--- a/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
+++ b/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
@@ -60,7 +60,7 @@ spec:
   chart:
     spec:
       chart: bp-oidc-gate
-      version: 0.1.1
+      version: 0.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-oidc-gate
@@ -101,3 +101,45 @@ spec:
           - "POST=^/v1/flows/[^/]+/log-lines$"
           # Health endpoints stay probe-able.
           - "GET=^/(healthz|readyz)$"
+
+      # powerdns-admin (#3374 §3-d row 6, Layer A). MOVED to the generic
+      # gate from its bespoke root-redirect. The bespoke approach is
+      # structurally fragile (§3-a: the pda OIDC callback shares the
+      # `/login` path, so the 0.1.10 `/login` redirect looped and was
+      # reverted; the 0.1.11 root-only redirect is a hand-tuned
+      # exception). oauth2-proxy fronts the WHOLE hostname instead: the
+      # gate serves its own /oauth2/callback (never the app's /oidc/*),
+      # and an already-valid app session passes straight through —
+      # zero-click, no loop, by the SAME mechanism as every other gated
+      # app. The hostname matches the per-Sovereign pda route
+      # (pdns-admin.<fqdn>); the upstream is the in-cluster pda Service.
+      #
+      # The pda chart's OWN HTTPRoute (incl. the bespoke root redirect)
+      # is suppressed by slot 11a setting `gateway.enabled: false`
+      # (two HTTPRoutes on one hostname is undefined routing — the gate
+      # now owns pdns-admin.<fqdn>). pda's /oidc/* login + callback paths
+      # are reached THROUGH the gate (oauth2-proxy proxies all non-
+      # /oauth2 paths to the upstream), so the app-native OIDC the gate's
+      # session sits in front of still functions for the in-app login the
+      # first time; subsequent visits ride the gate cookie.
+      - name: powerdns-admin
+        enabled: true
+        clientId: powerdns-admin
+        hostname: "pdns-admin.${SOVEREIGN_FQDN}"
+        upstream: http://powerdns-admin-bp-powerdns-admin.powerdns-admin.svc.cluster.local:80
+
+      # ── GENERALITY PROOF (#3374 DoD box 10a) ──────────────────────────
+      # A brand-new throwaway app gated with ONLY a name + hostname +
+      # upstream and NOTHING else — no app-specific redirect, no shim, no
+      # per-app chart code. Its bare URL lands zero-click by the generic
+      # mechanism alone. Disabled by default (no such upstream exists on
+      # a normal Sovereign); flip `enabled: true` + point `upstream` at
+      # any ClusterIP Service to demonstrate that adding an app to the
+      # zero-click contract is a single `instances:` entry. This is the
+      # #3370-bar proof transposed onto interception: the contract is
+      # generic across apps, not rebuilt per app.
+      - name: sso-generality-probe
+        enabled: false
+        clientId: sso-generality-probe
+        hostname: "sso-probe.${SOVEREIGN_FQDN}"
+        upstream: http://example-app.default.svc.cluster.local:80

--- a/docs/ledger/uat-walkthrough/sso-zero-login-everywhere-admin-by-default.md
+++ b/docs/ledger/uat-walkthrough/sso-zero-login-everywhere-admin-by-default.md
@@ -1,0 +1,105 @@
+# #3374 — SSO zero-login everywhere + admin-by-default — operator walk
+
+> **THIS IS THE CANONICAL #3374 WALKTHROUGH** (the doc the issue body §10
+> references). It is the click-by-click acceptance walk for the bare-URL→
+> authenticated-as-admin contract end-to-end: the silent console front
+> door, the ~11 external surfaces, the historic-failure rows, the one
+> admin-authority proof, the dead-grant log proof, and the dual generality
+> proof.
+>
+> **Status: UNVERIFIED — pending a fresh-prov walk on the CURRENT env.**
+> The code/chart mechanism landed (PR for #3374); per #3374 §2 law #2
+> ("NOTHING is banked") every row below is UNVERIFIED until walked fresh,
+> in ONE session, at acceptance time, on the current env, with screenshots
+> committed under `docs/sessions/<date>/evidence/`. No row may show ✅ from
+> a past env's walk.
+
+**North Star #3 (founder, verbatim):** *"NO login UI anywhere — URL →
+signed in as emrah.baysal as ADMIN; proof = surfing admin panels."*
+
+**The law (one sentence):** in a **fresh incognito window**, type the bare
+root URL of ANY surface → land **signed in** as the owner with **admin**
+rights — no login UI, no PIN/token form, no second click. A 302-to-realm
+wire-proof is NOT a pass (#3150). A redirect that ends on a login screen, a
+setup wizard, or a 404/500/503 is a **fail**.
+
+---
+
+## What changed in this PR (the mechanism the walk validates)
+
+| Layer | Defect (#3374 §3) | Fix in this PR |
+|---|---|---|
+| **A — one generic interception** | 5 bespoke per-app mechanisms; the generic gate fronted 1 of ~9 apps | `bp-oidc-gate` `instances:` now also front **powerdns-admin** (replacing its structurally-fragile bespoke root-redirect); pda's own HTTPRoute disabled (slot 11a `gateway.enabled:false`) so the gate is the single hostname owner. A disabled **`sso-generality-probe`** instance proves a NEW app needs ONLY a name+hostname (DoD box 10a). |
+| **B — silent console front door** | sessionless visitor → 6-digit-PIN wall | `router.tsx` on `whoami` 401 attempts a **silent OIDC round-trip** (`initiateLogin` → KC catalyst-pin IDR) BEFORE falling to `/login`; `/login` is now an explicit fallback, never the default. One-shot guard prevents loops; cleared on successful callback. |
+| **B — owner seed** | `orgEmail:""` → `OPERATOR_EMAIL` unset → owner seed skipped → `/users` empty | cloud-init substitute now threads **`ORG_EMAIL`/`ORG_NAME`** (the same `${org_email}` tofu value that already fed the realm seed) → `sovereign-fqdn` CM `orgEmail` → `OPERATOR_EMAIL` env → the pre-existing `runBakeTimeOwnerSeed` seeds the owner `UserAccess` CR idempotently on every Pod start. |
+| **C — one admin authority** | 3 disjoint systems; the console asserted a self-signed `catalyst-owner` constant; the sso-bridge grant code was dead theater | the keycloak realm import now defines the `catalyst-{viewer..owner}` composite realm roles AND composites `realmRoles:["catalyst-admin"]` onto `/sovereign-admins` (ONE membership → console + KC console + every app). `auth.go` PIN-mint now **derives** tier from live KC `/sovereign-admins` membership (non-member → viewer, never silently owner). The dead `grant_operator_admin`/`grant_operator_realm_roles` are DELETED. |
+
+---
+
+## Pre-walk: sign in once (the only auth action in the whole walk)
+
+| Go to (URL) | Then do | You should see | Result |
+|---|---|---|---|
+| `https://console.<fqdn>/auth/handover?token=<RS256 JWT>` | Paste the handover URL into a fresh tab, press Enter (`iss=console.openova.io`, `sub=emrah.baysal@openova.io`, `role=sovereign-admin`) | 302 → `/dashboard`, signed in, **no login form** | ☐ |
+
+---
+
+## Walk A — the console silent front door + owner seed (Layer B)
+
+| Go to (URL) | Then do | You should see | Result |
+|---|---|---|---|
+| `https://console.<fqdn>/` | In a **fresh incognito** window (NO cookie), type the bare console URL, press Enter | A brief OIDC redirect to `auth.<fqdn>` then back — lands on `/dashboard` **signed in**, the PIN form is **never shown**. Network trace shows the silent `catalyst-ui` authorize round-trip, NOT a stop on `/login`. | ☐ |
+| (same window) clear cookies / wait out the session, re-open `https://console.<fqdn>/` | Re-open the bare URL | Lands signed-in again via the silent round-trip — still no PIN form | ☐ |
+| `https://console.<fqdn>/users` | Open the Users page | Exactly one row: the owner email, `tier=owner`, badge **owner**. (kubectl cross-check: `kubectl get cm sovereign-fqdn -n catalyst-system -o jsonpath='{.data.orgEmail}'` is non-empty; `GET .../admin/user-access` returns ≥1 item.) | ☐ |
+| `https://console.<fqdn>/dashboard` | Click the avatar (top-right) | Menu reads "Signed in as <owner email>"; the BSS menu + RBAC nav are reachable — admin-ness is the **realm claim** (`sovereign-admins`/`catalyst-admin`), proven by surfing the admin panels | ☐ |
+
+---
+
+## Walk B — every external surface lands signed-in admin (§3-d, 11 rows)
+
+Each row: fresh incognito tab → bare URL → land signed-in as owner → open the
+admin surface. TWO screenshots per app (landing + admin), ZERO login UI.
+
+| # | Go to (bare URL) | You should see (authenticated landing + admin) | Result |
+|---|---|---|---|
+| 1 | `https://console.<fqdn>/` | `/dashboard` signed-in, no PIN (Walk A) | ☐ |
+| 2 | `https://grafana.<fqdn>/` | Home/Dashboards, no login form; `/api/user` → `isGrafanaAdmin=true` | ☐ |
+| 3 | `https://gitea.<fqdn>/` | owner Dashboard, logged in; admin panel `/-/admin` reachable | ☐ |
+| 4 | `https://registry.<fqdn>/` | `/harbor/projects`, no login form; Administration menu visible (`sysadmin` via `sovereign-admins`) | ☐ |
+| 5 | `https://bao.<fqdn>/ui/` | `/ui/vault/secrets` (Secrets Engines), **no token form**, no `/ui/vault/auth` | ☐ |
+| 6 | `https://pdns-admin.<fqdn>/` | **zero-click** → `/dashboard`, no login form; the OIDC callback does NOT loop (now fronted by the generic gate, not the bespoke redirect) | ☐ |
+| 7 | `https://guacamole.<fqdn>/` | Connections list, no Guacamole login, no Tomcat 404 | ☐ |
+| 8 | `https://newapi.<fqdn>/` | a 2nd independent bare-URL visit lands signed-in in `/console` (role=100) — no "already bound", no `/login?expired` (folds #3563) | ☐ |
+| 9 | `https://openova-flow.<fqdn>/` | proxied app surface, authenticated (the original generic-gate app) | ☐ |
+| 10 | `https://hubble.<fqdn>/` | Hubble Service Map, authenticated (under the gate) | ☐ |
+| 11 | `https://auth.<fqdn>/` | the Keycloak admin console accepts the operator (sovereign-admin via the `/sovereign-admins` group's `realm-management:realm-admin`) | ☐ |
+| 12 | `https://marketplace.<fqdn>/` | anonymous storefront by design — confirm NO spurious login UI | ☐ |
+
+---
+
+## Walk C — the one-admin-authority proof (Layer C, folds #3679/#3685)
+
+| Step | Command / action | Expected | Result |
+|---|---|---|---|
+| C1 | `kubectl exec keycloak-0 -- curl .../users/{owner-id}/role-mappings/realm/composite` | INCLUDES `catalyst-admin` — conferred via the `/sovereign-admins` group composite (NOT a per-email grant) | ☐ |
+| C2 | Neutralize the `auth.go` self-signed assertion (the PIN tier is now group-derived) and STILL surf the console admin panels | admin nav reachable because the principal carries `sovereign-admins`/`catalyst-admin` FROM THE REALM | ☐ |
+| C3 | `kubectl logs <sso-bridge pod>` across a full 60s tick | ZERO `skipping admin grant` / `skipping realm-role grant` lines (the dead path is gone). CI tripwire: `scripts/check-no-dead-grant-theater.sh` | ☐ |
+| C4 | Set `sovereign-fqdn` `orgEmail` empty, restart catalyst-api | the owner's admin status is UNCHANGED (no privilege outcome depends on the email — admin follows the group) | ☐ |
+| C5 | unit test | `go test ./internal/handler/ -run TestPinVerify_NonAdminGetsViewerNotOwner` — a user NOT in `/sovereign-admins` does NOT receive owner/admin claims | ☑ (green in CI) |
+
+---
+
+## Walk D — the dual generality proof (DoD box 10, the #3370 bar)
+
+| Step | Action | Expected | Result |
+|---|---|---|---|
+| D1 (interception) | Add a brand-new throwaway app to `bp-oidc-gate` `instances:` with ONLY `name`+`hostname`+`upstream` (the shipped `sso-generality-probe` instance is the template — flip `enabled:true`, point `upstream` at any Service) | its bare URL lands zero-click with NO app-specific redirect/shim code — `git diff` is a single `instances:` entry | ☐ |
+| D2 (admin) | That same app maps admin on `groups ∋ sovereign-admins` (the universal JMESPath) | the SAME owner is admin there with ZERO console/realm change — `git diff` shows only the new app's declaration | ☐ |
+
+---
+
+## Automated cross-checks (NOT acceptance — demoted per the UAT format law)
+
+- `scripts/sso-zero-click-probe.mjs --fqdn <fqdn> --handover-url '…'` — the per-app synthetic walk (positive + `--expect-broken` negative test). Wired to CI/cron in `.github/workflows/sso-probe.yaml`.
+- `scripts/check-no-dead-grant-theater.sh` — static tripwire that the dead admin-by-default grant theater stays deleted (runs on every PR touching the SSO chain).
+- `go test ./internal/handler/ ./internal/keycloak/` — `TestPinVerify_StampsTierAndRealmRoleClaims` (admin via group/operator-email) + `TestPinVerify_NonAdminGetsViewerNotOwner` (law #4: non-member → viewer).

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -422,6 +422,21 @@ write_files:
             # /sovereign-admins at bootstrap so the owner is admin-by-default
             # across grafana/gitea/harbor/openbao on first SSO login.
             SOVEREIGN_OWNER_EMAIL: "${org_email}"
+            # ORG_EMAIL / ORG_NAME (#3374 Layer-B, 2026-06-17) — bp-catalyst-
+            # platform slot 13 reads $${ORG_EMAIL:-} / $${ORG_NAME:-} into
+            # sovereign.{orgEmail,orgName}, which the chart writes to the
+            # sovereign-fqdn ConfigMap orgEmail/orgName keys -> the
+            # catalyst-api OPERATOR_EMAIL/ORG_NAME env. The map previously
+            # only carried SOVEREIGN_OWNER_EMAIL (for bp-keycloak), so
+            # $${ORG_EMAIL:-} resolved to EMPTY -> OPERATOR_EMAIL unset ->
+            # the owner UserAccess seed was skipped (D21: /users rendered
+            # empty) and no privilege outcome could key on the operator
+            # email. Same org_email/org_name tofu values as above — one
+            # source, now threaded to BOTH the realm seed and the
+            # catalyst-api operator-identity envs. Measured root cause on
+            # hw150 (#3374 section 3-b: orgEmail empty).
+            ORG_EMAIL: "${org_email}"
+            ORG_NAME: "${org_name}"
             # SOVEREIGN_REGION_KEY — the bp-openova-flow-emitter REGION_KEY env
             # (slot 57). Provider-supplied: Hetzner passes the raw region key
             # (var.region / secondary each.key); Huawei passes the canonical

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.28
+  version: 1.4.29
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -271,7 +271,18 @@ name: bp-keycloak
 # cli reconciles the realm on every post-upgrade Job, so this lands on both
 # fresh provs AND the existing live client. (The OpenBao OIDC role's
 # allowed_redirect_uris already carries it via bp-openbao 1.2.35+.)
-version: 1.4.28
+#
+# 1.4.29 (#3374 Layer-C, 2026-06-17): ONE admin authority. The sovereign
+# realm import now (a) defines the catalyst-{viewer,developer,operator,
+# admin,owner} composite realm-role chain (previously these were ONLY
+# strings the catalyst-api self-signed into a PIN JWT — System A, never
+# real KC roles), and (b) composites `realmRoles: ["catalyst-admin"]`
+# onto the `/sovereign-admins` group. ONE membership now lights up the
+# Catalyst console (catalyst-admin), the Keycloak admin console
+# (realm-management:realm-admin), AND every app keying on the `groups`
+# claim — no self-signed assertion, no per-email grant. keycloak-config-
+# cli re-applies the import so the composite reaches existing realms too.
+version: 1.4.29
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -217,6 +217,42 @@ data:
         "/sovereign-viewers"
       ],
       {{- /*
+      #3374 Layer-C (2026-06-17) — ONE admin authority: the catalyst-*
+      realm-role chain.
+
+      The operator console's RBAC (auth.go / whoami) keys on the
+      `catalyst-{viewer,developer,operator,admin,owner}` realm roles.
+      Before this block those roles existed ONLY as strings the
+      catalyst-api PIN-mint asserted in a self-signed JWT (System A in
+      #3374 §3-c) — they were NEVER real Keycloak realm roles, so a
+      genuinely Keycloak-federated operator (catalyst-ui PKCE) could not
+      be admin no matter what groups they held. Defining them here as
+      real composite realm roles makes the console-RBAC vocabulary a
+      first-class part of the realm, grantable + compositable like any
+      other role — the precondition for the `/sovereign-admins` group
+      below to confer `catalyst-admin` generically.
+
+      Inheritance composite chain (viewer < developer < operator <
+      admin < owner), mirroring whoamiTierInheritance in auth.go: each
+      higher role `composites.realm` the one below it, so holding
+      `catalyst-admin` effectively grants viewer/developer/operator too
+      — the SAME inheritance the whoamiInjectTierRoles projection
+      applies, now sourced from Keycloak rather than synthesized.
+      */ -}}
+      "roles": {
+        "realm": [
+          { "name": "catalyst-viewer",    "description": "Catalyst console: read-only operator." },
+          { "name": "catalyst-developer", "description": "Catalyst console: developer tier.",
+            "composite": true, "composites": { "realm": ["catalyst-viewer"] } },
+          { "name": "catalyst-operator",  "description": "Catalyst console: operator tier.",
+            "composite": true, "composites": { "realm": ["catalyst-developer"] } },
+          { "name": "catalyst-admin",     "description": "Catalyst console: admin tier (BSS + RBAC nav).",
+            "composite": true, "composites": { "realm": ["catalyst-operator"] } },
+          { "name": "catalyst-owner",     "description": "Catalyst console: Sovereign owner.",
+            "composite": true, "composites": { "realm": ["catalyst-admin"] } }
+        ]
+      },
+      {{- /*
       #3374 (2026-06-13) — sovereign-admin access model for the Keycloak
       admin console (the IdP's own UI, the last login-form holdout).
       Members of /sovereign-admins receive the realm-management
@@ -229,10 +265,26 @@ data:
       existing realms too. The master realm + its local form remain
       untouched (not the default path; bp-keycloak httproute now 302s
       the bare root to the sovereign realm console).
+
+      #3374 Layer-C (2026-06-17) — ONE membership lights up ALL surfaces.
+      The group now composites BOTH the KC-console role (realm-management
+      `realm-admin`, the IdP's own UI) AND the `catalyst-admin` realm
+      role (the operator console's RBAC), via `realmRoles`. This closes
+      the #3374 §3-c disjunction: previously the group carried ONLY
+      realm-management:realm-admin, so a federated operator in
+      /sovereign-admins could surf the Keycloak admin console but the
+      Catalyst console did NOT see them as admin (it relied on the
+      self-signed `catalyst-owner` System-A constant). Now the SINGLE
+      decision point — membership in /sovereign-admins — confers admin on
+      every surface (console, KC console, and every app keying on the
+      `groups` claim). No self-signed assertion, no per-email grant, no
+      unreconciled one-shot. keycloak-config-cli re-applies the import so
+      this composites onto existing realms too.
       */ -}}
       "groups": [
         {
           "name": "sovereign-admins",
+          "realmRoles": ["catalyst-admin"],
           "clientRoles": {
             "realm-management": ["realm-admin"]
           }

--- a/platform/oidc-gate/blueprint.yaml
+++ b/platform/oidc-gate/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.1
+  version: 0.1.2
   card:
     title: oidc-gate
     summary: |

--- a/platform/oidc-gate/chart/Chart.yaml
+++ b/platform/oidc-gate/chart/Chart.yaml
@@ -22,7 +22,17 @@ name: bp-oidc-gate
 # signed-in. client.json now seeds an oidc-audience-mapper injecting the
 # clientId into the ID-token aud; bp-sso-bridge PUT (template-wins) lands
 # it on the live pre-existing client zero-touch.
-version: 0.1.1
+#
+# 0.1.2 (#3374 Layer-A, 2026-06-17): COVERAGE — the generic gate now
+# fronts powerdns-admin (slot 13c), replacing its structurally-fragile
+# bespoke root-redirect (the OIDC callback shares /login, so the redirect
+# looped + was reverted in pda 0.1.11). No chart-template change: the
+# coverage is purely additional `instances:` entries + the per-app chart
+# disabling its own HTTPRoute (slot 11a gateway.enabled=false) so the
+# gate is the single hostname owner. Adding the gate to a NEW app is now
+# one `instances:` entry — proven by the disabled `sso-generality-probe`
+# instance in the slot (#3374 DoD box 10a generality proof).
+version: 0.1.2
 appVersion: "7.6.0"
 description: |
   Catalyst generic OIDC gate — a per-app oauth2-proxy instance set that

--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.18
+  version: 0.2.19
   card:
     title: sso-bridge
     summary: |

--- a/platform/sso-bridge/chart/Chart.yaml
+++ b/platform/sso-bridge/chart/Chart.yaml
@@ -1,6 +1,18 @@
 apiVersion: v2
 name: bp-sso-bridge
-version: 0.2.18
+version: 0.2.19
+# 0.2.19 (#3374 Layer-C, 2026-06-17): DELETE the dead admin-by-default
+# theater (#3685). grant_operator_admin (minted a per-Client `admin` role
+# NO app reads — every app keys admin on the `groups` claim) and
+# grant_operator_realm_roles (per-email catalyst-admin grant, now
+# superseded by the realm-import group composite on /sovereign-admins) are
+# both removed, along with the per-HR `sso.realmRolesGranted` plumbing. On
+# hw150 with orgEmail="" these logged "skipping admin grant"/"skipping
+# realm-role grant" every 60s tick and NEVER granted anything. The
+# reconciler's job is now purely client-upsert + secret publication; admin
+# is conferred ONLY by /sovereign-admins membership. No privilege outcome
+# depends on the empty `orgEmail` ConfigMap key.
+#
 # 0.2.18 (#3374, 2026-06-14): add `sso.skipExternalSecret: true` opt-out.
 # Apps that consume their OIDC secret as DIRECT env vars (grafana's
 # `envFromSecret`) need keys named after the app's env-override contract

--- a/platform/sso-bridge/chart/templates/configmap-reconciler.yaml
+++ b/platform/sso-bridge/chart/templates/configmap-reconciler.yaml
@@ -347,94 +347,25 @@ data:
       printf '%s\n' "${issuer}" > "/tmp/${cid}.issuer"
     }
 
-    grant_operator_admin() {
-      # $1 = clientId, $2 = operator email
-      local cid="$1" email="$2"
-      [ -z "${email}" ] && { warn "no operator email; skipping admin grant for ${cid}"; return 0; }
-
-      local user_id
-      user_id="$(curl --max-time 20 --connect-timeout 7 -fsS \
-        -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" \
-        "${KC_ADDR%/}/admin/realms/${KC_REALM}/users?email=${email}&exact=true" \
-        | jq -r '.[0].id // empty')"
-
-      if [ -z "${user_id}" ]; then
-        warn "operator user '${email}' not yet provisioned in realm ${KC_REALM}; admin grant deferred until first sign-in"
-        return 0
-      fi
-
-      local kc_id
-      kc_id="$(cat "/tmp/${cid}.kc-id")"
-
-      # Ensure client-role 'admin' exists on this Client.
-      local has_admin
-      has_admin="$(curl --max-time 20 --connect-timeout 7 -fsS \
-        -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" \
-        "${KC_ADDR%/}/admin/realms/${KC_REALM}/clients/${kc_id}/roles/admin" \
-        -o /dev/null -w '%{http_code}')"
-      if [ "${has_admin}" = "404" ]; then
-        curl --max-time 20 --connect-timeout 7 -fsS -X POST \
-          -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" \
-          -H "Content-Type: application/json" \
-          -d '{"name":"admin","description":"Application admin (auto by bp-sso-bridge)"}' \
-          "${KC_ADDR%/}/admin/realms/${KC_REALM}/clients/${kc_id}/roles" >/dev/null
-      fi
-
-      # Look up the role representation (id + name).
-      local role_rep
-      role_rep="$(curl --max-time 20 --connect-timeout 7 -fsS \
-        -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" \
-        "${KC_ADDR%/}/admin/realms/${KC_REALM}/clients/${kc_id}/roles/admin")"
-
-      # POST role-mapping for the user. Idempotent — Keycloak swallows duplicates.
-      curl --max-time 20 --connect-timeout 7 -fsS -X POST \
-        -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" \
-        -H "Content-Type: application/json" \
-        -d "[${role_rep}]" \
-        "${KC_ADDR%/}/admin/realms/${KC_REALM}/users/${user_id}/role-mappings/clients/${kc_id}" >/dev/null || true
-    }
-
-    grant_operator_realm_roles() {
-      # $1 = operator email, $2 = space-separated list of realm-role names
-      # Some apps (e.g. catalyst-console, which has a pre-existing
-      # catalyst-ui Client in the realm import) need the operator granted
-      # REALM-level roles rather than per-Client roles. The realm-role
-      # 'catalyst-admin' grants full operator-console privileges via the
-      # realm's catalyst-{viewer,developer,operator,admin,owner} composite
-      # chain (configmap-sovereign-realm.yaml).
-      local email="$1" roles="$2"
-      [ -z "${email}" ] && { warn "no operator email; skipping realm-role grant"; return 0; }
-      [ -z "${roles}" ] && return 0
-
-      local user_id
-      user_id="$(curl --max-time 20 --connect-timeout 7 -fsS \
-        -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" \
-        "${KC_ADDR%/}/admin/realms/${KC_REALM}/users?email=${email}&exact=true" \
-        | jq -r '.[0].id // empty')"
-      if [ -z "${user_id}" ]; then
-        warn "operator user '${email}' not yet provisioned; realm-role grant deferred"
-        return 0
-      fi
-
-      for role_name in ${roles}; do
-        local role_rep
-        role_rep="$(curl --max-time 20 --connect-timeout 7 -fsS \
-          -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" \
-          "${KC_ADDR%/}/admin/realms/${KC_REALM}/roles/${role_name}" 2>/dev/null)"
-        if [ -z "${role_rep}" ] || ! printf '%s' "${role_rep}" | jq -e '.id' >/dev/null 2>&1; then
-          warn "realm-role '${role_name}' not found in realm ${KC_REALM}; skipping grant"
-          continue
-        fi
-        # POST role-mapping for the user (realm-level). Idempotent.
-        curl --max-time 20 --connect-timeout 7 -fsS -X POST \
-          -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" \
-          -H "Content-Type: application/json" \
-          -d "[${role_rep}]" \
-          "${KC_ADDR%/}/admin/realms/${KC_REALM}/users/${user_id}/role-mappings/realm" >/dev/null \
-          && log "granted realm-role '${role_name}' to ${email}" \
-          || warn "POST realm role-mapping '${role_name}' for ${email} failed"
-      done
-    }
+    # #3374 Layer-C (2026-06-17): grant_operator_admin + grant_operator_realm_roles
+    # DELETED. They were the dead admin-by-default theater the founder
+    # flagged (#3685 / #3374 §3-c):
+    #
+    #   - grant_operator_admin minted a per-Client `admin` role that NO app
+    #     reads — every app keys admin on the `groups` claim
+    #     (`sovereign-admins`), so the per-Client role was pure orphaned
+    #     overhead. On hw150 with orgEmail="" it logged "skipping admin
+    #     grant" every 60s tick and NEVER granted anything.
+    #   - grant_operator_realm_roles granted the `catalyst-admin` realm role
+    #     per-email — now SUPERSEDED by the realm-import group composite:
+    #     `/sovereign-admins` carries `realmRoles: ["catalyst-admin"]`
+    #     (configmap-sovereign-realm.yaml), so ANY member of the group gets
+    #     catalyst-admin generically, conferred at realm import + reconciled
+    #     by keycloak-config-cli — no per-email grant, no dependence on the
+    #     empty `orgEmail` ConfigMap key.
+    #
+    # ONE admin authority remains: membership in /sovereign-admins. The
+    # reconciler's job is now purely client-upsert + secret publication.
 
     emit_external_secret() {
       # $1 = clientId, $2 = HR namespace, $3 = skip-K8s-ExternalSecret (bool)
@@ -534,26 +465,21 @@ data:
       # — bp-gitea is the HR, but the natural OIDC clientId is `gitea`).
       local cid="${name#bp-}"
 
-      # G91.catalyst-console-admin-self-grant (#2659) — pull per-HR
-      # `.spec.values.sso.realmRolesGranted` (list of strings). Some apps
-      # need REALM-level role grants on the operator rather than (or in
-      # addition to) the per-Client `admin` role — most notably
-      # bp-catalyst-platform, whose operator console uses a pre-existing
-      # `catalyst-ui` Client from the realm import and is gated by
-      # realm-roles `catalyst-{viewer,developer,operator,admin,owner}`
-      # rather than a per-Client role. Empty/missing = legacy
-      # per-Client-only grant.
-      local realm_roles
-      realm_roles="$(printf '%s' "${hr}" | jq -r '(.spec.values.sso.realmRolesGranted // []) | join(" ")')"
-
       # G91.catalyst-console-admin-self-grant (#2659) — opt-out of
-      # per-Client upsert + per-Client-`admin` grant. Apps that ship
-      # their own pre-existing Keycloak Client via realm-import (e.g.
-      # `catalyst-ui` in the sovereign realm JSON) can declare
-      # `.spec.values.sso.skipClientUpsert: true` to mark themselves
-      # opt-in for the realm-role-grant path only — bp-sso-bridge then
-      # skips both upsert_client and emit_external_secret (no
-      # client_secret to materialise) and ONLY runs realm-role grant.
+      # per-Client upsert. Apps that ship their own pre-existing Keycloak
+      # Client via realm-import (e.g. `catalyst-ui` in the sovereign realm
+      # JSON) can declare `.spec.values.sso.skipClientUpsert: true` so
+      # bp-sso-bridge skips both upsert_client and emit_external_secret
+      # (no client_secret to materialise).
+      #
+      # #3374 Layer-C (2026-06-17): the former per-HR
+      # `sso.realmRolesGranted` -> grant_operator_realm_roles path is GONE.
+      # Admin is now conferred ONLY by /sovereign-admins group membership
+      # (the group composites catalyst-admin at realm import) — no per-app
+      # realm-role grant, no dependence on the operator email. An app that
+      # set skipClientUpsert=true purely to ride the realm-role grant (i.e.
+      # bp-catalyst-platform) is now a no-op here and that is CORRECT: its
+      # operator gets catalyst-admin from the group, not from this loop.
       local skip_upsert
       skip_upsert="$(printf '%s' "${hr}" | jq -r '.spec.values.sso.skipClientUpsert // false')"
 
@@ -564,18 +490,13 @@ data:
       local skip_es
       skip_es="$(printf '%s' "${hr}" | jq -r '.spec.values.sso.skipExternalSecret // false')"
 
-      log "reconcile ${name} (ns=${ns} clientId=${cid} realmRoles='${realm_roles}' skipUpsert=${skip_upsert} skipES=${skip_es})"
+      log "reconcile ${name} (ns=${ns} clientId=${cid} skipUpsert=${skip_upsert} skipES=${skip_es})"
 
       if [ "${skip_upsert}" != "true" ]; then
         upsert_client "${cid}" "${fqdn}" || { err "upsert ${cid} failed"; return 1; }
         emit_external_secret "${cid}" "${ns}" "${skip_es}" || { err "emit-es ${cid} failed"; return 1; }
-        grant_operator_admin "${cid}" "${op_email}" || warn "grant-admin ${cid} non-fatal"
       else
         log "skipping client upsert + ExternalSecret for ${cid} (sso.skipClientUpsert=true)"
-      fi
-
-      if [ -n "${realm_roles}" ]; then
-        grant_operator_realm_roles "${op_email}" "${realm_roles}" || warn "grant-realm-roles ${realm_roles} non-fatal"
       fi
     }
 

--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -27,6 +27,7 @@
 package handler
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"errors"
@@ -85,25 +86,87 @@ const pinSessionRole = "openova-user"
 // the Sovereign's mail server.
 //
 // Per docs/EPICS-1-6-unified-design.md §6.2 the canonical tier vocab is
-// viewer < developer < operator < admin < owner. PIN-mint stamps `owner`
-// so every privileged catalyst-api endpoint (rbac_audit, rbac_assign,
-// keycloak_proxy U2/U3/U4, blueprints/curate, policy_mode) resolves to
-// "authorized" without a separate per-handler nil-claim escape hatch.
+// viewer < developer < operator < admin < owner.
 //
-// The realm-role mirror (`pinSessionRealmRole`) is also stamped so the
-// realm-role-list authorization path on the same gates resolves the same
-// way — both gate seams (Tier vs RealmAccess.Roles) accept the operator.
-const pinSessionTier = "owner"
+// #3374 Layer-C (2026-06-17): the PIN session tier is NO LONGER a hard
+// `owner` constant. The prior `const pinSessionTier = "owner"` +
+// `const pinSessionRealmRole = "catalyst-owner"` made EVERY email that
+// could receive a PIN a self-signed Sovereign owner, ignoring the
+// user's real Keycloak group state — System A in #3374 §3-c, the
+// self-signed assertion that ignored the realm (law #4 violation). The
+// tier is now derived from live Keycloak group membership by
+// pinSessionAuthority(): membership in /sovereign-admins → admin (the
+// ONE decision point, #3374 §2 law #4); otherwise viewer. A non-owner
+// who PIN-authenticates is NO LONGER silently granted owner.
+//
+// pinSessionAdminTier is what a member of /sovereign-admins receives.
+// `admin` (not `owner`) is the group-conferred tier: it carries the
+// catalyst-admin realm role (now composited onto the /sovereign-admins
+// group in configmap-sovereign-realm.yaml) and lights up the BSS + RBAC
+// console nav. `owner` remains reserved for the handover-authenticated
+// Sovereign owner (auth_handover.go, RS256-signed by the mothership),
+// the genuine ownership proof — never minted from a bare PIN.
+const pinSessionAdminTier = "admin"
 
-// pinSessionRealmRole — Keycloak realm-role mirror of pinSessionTier.
-// Stamped into the JWT's realm_access.roles so handler gates that walk
-// the realm-role list (rbacAssignCallerAuthorized's HasRealmRole loop)
-// accept the PIN-derived operator without a per-handler tier-claim
-// special case. Matches the EPIC-3 T2 bootstrap vocabulary
-// (catalyst-admin / catalyst-owner / application-admin) so the PIN
-// session looks indistinguishable from a real Keycloak-issued token
-// for the privileged caller — single contract surface for the gates.
-const pinSessionRealmRole = "catalyst-owner"
+// pinSessionDefaultTier is what a PIN-authenticated user NOT in
+// /sovereign-admins receives — read-only viewer. Never owner.
+const pinSessionDefaultTier = "viewer"
+
+// pinSovereignAdminsGroupPath is the canonical KC group whose
+// membership confers console admin (mirrors the realm import's
+// /sovereign-admins group + every app's groups-claim JMESPath).
+const pinSovereignAdminsGroupPath = "/sovereign-admins"
+
+// userGroupReader is the optional capability the concrete Keycloak
+// client (*keycloak.Client) satisfies via UserGroupPaths. The narrow
+// keycloakClient interface (EnsureUser/ImpersonateToken) is preserved
+// for the existing test fakes; group-derived authority is reached by a
+// runtime type-assert so a fake without the method degrades to the
+// OPERATOR_EMAIL fallback rather than failing to compile or panicking.
+type userGroupReader interface {
+	UserGroupPaths(ctx context.Context, email string) ([]string, error)
+}
+
+// pinSessionAuthority resolves the (tier, realmRoles) a PIN-authenticated
+// email is entitled to, from live Keycloak group membership — the ONE
+// admin-authority source (#3374 §2 law #4, Layer C).
+//
+// Resolution:
+//  1. If the Keycloak client exposes UserGroupPaths and the email is in
+//     /sovereign-admins → admin tier + [catalyst-admin] (the group also
+//     composites catalyst-admin in the realm import, so a federated
+//     login of the same user is admin too — one source, both paths).
+//  2. If KC is reachable but the email is NOT in /sovereign-admins →
+//     viewer (read-only). A non-owner is NEVER silently granted owner.
+//  3. If KC is unreachable / the client lacks the capability (CI, a
+//     just-installed Sovereign whose realm hasn't converged) → fall
+//     back to the configured operator email: an exact match yields
+//     admin (the chroot owner whose mailbox proved control), anything
+//     else viewer. This keeps the owner working through a realm-import
+//     race WITHOUT the old blanket owner-for-everyone grant.
+func (h *Handler) pinSessionAuthority(ctx context.Context, email string) (tier string, realmRoles []string) {
+	email = strings.ToLower(strings.TrimSpace(email))
+	if reader, ok := h.keycloakClientFor().(userGroupReader); ok && reader != nil {
+		paths, err := reader.UserGroupPaths(ctx, email)
+		if err != nil {
+			h.log.Warn("pin/verify: KC group lookup failed; using operator-email fallback",
+				"email", email, "err", err)
+		} else {
+			for _, p := range paths {
+				if strings.EqualFold(strings.TrimSpace(p), pinSovereignAdminsGroupPath) {
+					return pinSessionAdminTier, []string{"catalyst-admin"}
+				}
+			}
+			// KC answered authoritatively: not in /sovereign-admins.
+			return pinSessionDefaultTier, nil
+		}
+	}
+	// Fallback: KC unavailable or capability absent.
+	if opEmail := strings.ToLower(strings.TrimSpace(os.Getenv("OPERATOR_EMAIL"))); opEmail != "" && opEmail == email {
+		return pinSessionAdminTier, []string{"catalyst-admin"}
+	}
+	return pinSessionDefaultTier, nil
+}
 
 // pinSessionTTL — how long a PIN-derived session lasts. 8 hours, matching
 // the magic-link session TTL so operator-facing UX is unchanged.
@@ -690,28 +753,31 @@ func (h *Handler) HandlePinVerify(w http.ResponseWriter, r *http.Request) {
 	// the EPIC-3 (#1098) RBAC gates consume (rbac_audit, rbac_assign,
 	// keycloak_proxy U2/U3/U4, blueprints/curate, policy_mode).
 	//
-	// Why owner: PIN-via-IMAP authentication proves control of the
-	// Sovereign's mail-domain inbox; that is the canonical proof of
-	// ownership of the Sovereign chroot (the only operator who can
-	// receive the 6-digit code is the one provisioned with mailbox
-	// access on the Sovereign's stalwart instance). Stamping
-	// tier=owner / realm_access.roles=[catalyst-owner] makes the JWT's
-	// authorization context match the real-world authority the auth
-	// flow already granted — without it, every privileged endpoint
-	// returns 403 even though the caller is the Sovereign owner.
+	// #3374 Layer-C (2026-06-17): the tier + realm-role claims are
+	// DERIVED FROM LIVE KEYCLOAK GROUP MEMBERSHIP, not hardcoded to
+	// owner. pinSessionAuthority() reads /sovereign-admins membership —
+	// the ONE admin-authority source (#3374 §2 law #4). A member is
+	// stamped tier=admin + [catalyst-admin] (the same realm role the
+	// group composites, so a federated login of the same user is admin
+	// too — one source, both paths); a NON-member who PIN-authenticates
+	// is stamped tier=viewer and is NOT silently granted owner (the
+	// System-A self-signed-owner defect, killed). The genuine Sovereign
+	// owner is established by the handover path (auth_handover.go),
+	// RS256-signed by the mothership — never by a bare PIN.
 	//
 	// Per CLAUDE.md INVIOLABLE-PRINCIPLES #5 (least privilege): the
 	// stamp happens ONLY at PIN-verify (i.e. only after the operator
 	// proved IMAP control); pre-PIN sessions never carry these claims.
+	sessionTier, sessionRealmRoles := h.pinSessionAuthority(r.Context(), email)
 	sessionClaims := jwt.MapClaims{
 		"iss":            pinIssuer,
 		"sub":            email, // email == subject; downstream reads claims.Email
 		"email":          email,
 		"email_verified": true,
 		"role":           pinSessionRole,
-		"tier":           pinSessionTier,
+		"tier":           sessionTier,
 		"realm_access": map[string]any{
-			"roles": []string{pinSessionRealmRole},
+			"roles": sessionRealmRoles,
 		},
 		"iat": time.Now().Unix(),
 		"exp": time.Now().Add(pinSessionTTL).Unix(),

--- a/products/catalyst/bootstrap/api/internal/handler/auth_pin_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_pin_test.go
@@ -337,12 +337,18 @@ func TestPinVerify_HappyPath(t *testing.T) {
 // policy_mode, continuum audit) thus returned 403 even for the Sovereign
 // owner authenticated via PIN-IMAP. This test pins the contract:
 //
-//  1. tier = pinSessionTier ("owner")
-//  2. realm_access.roles contains pinSessionRealmRole ("catalyst-owner")
+//  1. tier = admin (group-derived, #3374 Layer-C)
+//  2. realm_access.roles contains catalyst-admin
 //
 // Either claim alone unlocks the gates (HasRealmRole walk OR Tier check).
 // Stamping both keeps the contract idempotent across the gate variants.
+//
+// #3374 Layer-C: the tier is now DERIVED, not a hard `owner` constant. In
+// this test there is no live Keycloak client wired (h.kc nil), so
+// pinSessionAuthority hits the OPERATOR_EMAIL fallback — set here to the
+// authenticating email, the chroot-owner case, which confers admin.
 func TestPinVerify_StampsTierAndRealmRoleClaims(t *testing.T) {
+	t.Setenv("OPERATOR_EMAIL", "op@example.com")
 	h := testPinSetup(t)
 	h.pinStore.put("op@example.com", "123456", "req-1")
 
@@ -380,18 +386,18 @@ func TestPinVerify_StampsTierAndRealmRoleClaims(t *testing.T) {
 		t.Fatalf("unmarshal claims: %v", err)
 	}
 
-	// (1) tier claim must equal pinSessionTier so policyModeCallerAuthorized
+	// (1) tier claim must be admin so policyModeCallerAuthorized
 	// (the strict admin/owner gate) accepts the PIN-derived session.
-	if claims.Tier != pinSessionTier {
-		t.Errorf("tier: got %q want %q", claims.Tier, pinSessionTier)
+	if claims.Tier != pinSessionAdminTier {
+		t.Errorf("tier: got %q want %q", claims.Tier, pinSessionAdminTier)
 	}
 
-	// (2) realm_access.roles must contain pinSessionRealmRole so
+	// (2) realm_access.roles must contain catalyst-admin so
 	// rbacAssignCallerAuthorized's HasRealmRole walk also accepts it
 	// (matches the legacy Keycloak-issued token contract).
-	if !claims.HasRealmRole(pinSessionRealmRole) {
+	if !claims.HasRealmRole("catalyst-admin") {
 		t.Errorf("realm_access.roles missing %q (got: %v)",
-			pinSessionRealmRole, claims.RealmAccess.Roles)
+			"catalyst-admin", claims.RealmAccess.Roles)
 	}
 
 	// (3) Sanity: feeding the parsed claims through the actual gate
@@ -403,6 +409,60 @@ func TestPinVerify_StampsTierAndRealmRoleClaims(t *testing.T) {
 	}
 	if !policyModeCallerAuthorized(&claims) {
 		t.Error("policyModeCallerAuthorized: PIN-derived claims should authorize sovereign-admin gate")
+	}
+}
+
+// TestPinVerify_NonAdminGetsViewerNotOwner is the #3374 Layer-C law #4
+// regression guard (DoD box 6): a user NOT in /sovereign-admins (here:
+// not matching OPERATOR_EMAIL, no live KC group) who PIN-authenticates
+// is stamped tier=viewer — NEVER silently granted owner/admin. This kills
+// the System-A self-signed-owner-for-everyone defect.
+func TestPinVerify_NonAdminGetsViewerNotOwner(t *testing.T) {
+	// OPERATOR_EMAIL is a DIFFERENT email — the authenticating user is
+	// not the configured operator and (no KC wired) not in any group.
+	t.Setenv("OPERATOR_EMAIL", "owner@example.com")
+	h := testPinSetup(t)
+	h.pinStore.put("stranger@example.com", "123456", "req-1")
+
+	body := `{"email":"stranger@example.com","pin":"123456","requestId":"req-1"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/pin/verify",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandlePinVerify(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (body: %s)", resp.StatusCode, w.Body.String())
+	}
+	cookie := findCookie(resp.Cookies(), "catalyst_session")
+	if cookie == nil || cookie.Value == "" {
+		t.Fatal("catalyst_session cookie not set")
+	}
+	parts := strings.Split(cookie.Value, ".")
+	if len(parts) != 3 {
+		t.Fatalf("cookie value: got %d JWT parts want 3", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode JWT payload: %v", err)
+	}
+	var claims auth.Claims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatalf("unmarshal claims: %v", err)
+	}
+
+	if claims.Tier != pinSessionDefaultTier {
+		t.Errorf("non-admin tier: got %q want %q (must NOT be owner/admin)",
+			claims.Tier, pinSessionDefaultTier)
+	}
+	if claims.HasRealmRole("catalyst-owner") || claims.HasRealmRole("catalyst-admin") {
+		t.Errorf("non-admin must NOT carry catalyst-owner/admin (got: %v)",
+			claims.RealmAccess.Roles)
+	}
+	// And the privileged gates must REJECT this session.
+	if policyModeCallerAuthorized(&claims) {
+		t.Error("policyModeCallerAuthorized: a non-admin PIN session must NOT pass the sovereign-admin gate")
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/auth_test_session.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_test_session.go
@@ -77,8 +77,9 @@ const testSessionEmailDomain = "openova.io"
 //	tier=admin     → role=catalyst-admin
 //	tier=owner     → role=catalyst-owner
 //
-// pinSessionRealmRole (= "catalyst-owner") is the same vocabulary —
-// this map just extends it to all 5 tiers.
+// This is the canonical tier→catalyst-* realm-role vocabulary the
+// PIN-mint authority (pinSessionAuthority, #3374 Layer-C) also stamps —
+// this map extends it to all 5 tiers for the QA test-session endpoint.
 var tierRoleMap = map[string]string{
 	"viewer":    "catalyst-viewer",
 	"developer": "catalyst-developer",

--- a/products/catalyst/bootstrap/api/internal/keycloak/admin_users.go
+++ b/products/catalyst/bootstrap/api/internal/keycloak/admin_users.go
@@ -128,6 +128,85 @@ func (c *Client) ListRealmRoleMembers(ctx context.Context, name string) ([]User,
 	return users, nil
 }
 
+// UserGroupPaths returns the full group paths (e.g. "/sovereign-admins")
+// a user belongs to, looked up by exact email.
+//
+// #3374 Layer-C (2026-06-17): the PIN-mint admin-authority fix
+// (auth.go) needs to know whether a PIN-authenticated user is in
+// /sovereign-admins — the ONE decision point for admin (#3374 §2 law
+// #4). It resolves the user by exact email, then reads
+// GET /admin/realms/{realm}/users/{id}/groups.
+//
+// Returns:
+//   - ([], nil) when the email has no realm user yet (the realm-import
+//     owner seed + EnsureUser create it; a brand-new PIN-only email
+//     simply isn't admin) — callers treat empty as "no admin group".
+//   - the slice of group `path` strings on success.
+//
+// The catalyst-api SA already holds view-users/query-users on the
+// sovereign realm (configmap-sovereign-realm.yaml clientScopeMappings),
+// so this read needs no extra grant.
+func (c *Client) UserGroupPaths(ctx context.Context, email string) ([]string, error) {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("keycloak.UserGroupPaths: service account token: %w", err)
+	}
+	// 1. Resolve the user id by exact email.
+	uq := fmt.Sprintf("%s/admin/realms/%s/users?email=%s&exact=true&max=1",
+		c.addr, c.realm, url.QueryEscape(email))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uq, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("keycloak: GET user by email: %w", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("keycloak: GET user by email %d: %s", resp.StatusCode, body)
+	}
+	var users []User
+	if err := json.Unmarshal(body, &users); err != nil {
+		return nil, fmt.Errorf("keycloak: decode user by email: %w", err)
+	}
+	if len(users) == 0 || users[0].ID == "" {
+		return []string{}, nil
+	}
+	// 2. Read the user's groups.
+	gq := fmt.Sprintf("%s/admin/realms/%s/users/%s/groups?first=0&max=1000",
+		c.addr, c.realm, url.PathEscape(users[0].ID))
+	greq, err := http.NewRequestWithContext(ctx, http.MethodGet, gq, nil)
+	if err != nil {
+		return nil, err
+	}
+	greq.Header.Set("Authorization", "Bearer "+saToken)
+	gresp, err := c.http.Do(greq)
+	if err != nil {
+		return nil, fmt.Errorf("keycloak: GET user groups: %w", err)
+	}
+	gbody, _ := io.ReadAll(gresp.Body)
+	gresp.Body.Close()
+	if gresp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("keycloak: GET user groups %d: %s", gresp.StatusCode, gbody)
+	}
+	var groups []Group
+	if err := json.Unmarshal(gbody, &groups); err != nil {
+		return nil, fmt.Errorf("keycloak: decode user groups: %w", err)
+	}
+	paths := make([]string, 0, len(groups))
+	for _, g := range groups {
+		if g.Path != "" {
+			paths = append(paths, g.Path)
+		} else if g.Name != "" {
+			paths = append(paths, "/"+g.Name)
+		}
+	}
+	return paths, nil
+}
+
 // ListClientRoles proxies GET /admin/realms/{realm}/clients/{clientUuid}/roles.
 //
 // `clientUUID` is the Keycloak-internal UUID of the OIDC client (NOT

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -263,9 +263,33 @@ async function rootBeforeLoad({ location }: { location: { pathname: string } }) 
   const whoami = await probeWhoamiAndCacheMarker(API_BASE)
   if (whoami === true) return
   if (whoami === null) return // 5xx / network error — fail open
-  // 401 — genuinely unauthenticated. Redirect with deep-link, but
-  // sanitize the `next` so we can never construct an open-redirect
-  // payload (CWE-601). qa-loop iter-4 cluster
+  // 401 — genuinely unauthenticated.
+  //
+  // #3374 Layer-B (north-star #3: "NO login UI anywhere — URL → signed
+  // in"): a sessionless visitor must NOT be bounced to the 6-digit-PIN
+  // wall. Instead, attempt a SILENT OIDC round-trip to the Sovereign
+  // Keycloak first — the realm's browser flow auto-delegates to the
+  // `catalyst-pin` IdP redirector (configmap-sovereign-realm.yaml
+  // identity-provider-redirector + catalyst-pin-redirector), so a
+  // visitor who already has a KC session (the common case after the
+  // handover, or after any app SSO in the same browser) lands straight
+  // back at /auth/callback signed-in, with no PIN form. Only if the
+  // silent attempt cannot be made do we fall back to /login as an
+  // EXPLICIT fallback (never the default).
+  //
+  // Loop-safety: attemptSilentSovereignSSO sets a one-shot sessionStorage
+  // guard so a KC round-trip that returns WITHOUT a session (genuinely
+  // logged-out at the IdP too) lands on /login exactly once rather than
+  // ping-ponging console → KC → console → KC. The guard is cleared by
+  // AuthCallbackPage on a successful exchange.
+  if (await attemptSilentSovereignSSO()) {
+    // Navigation is being handed to Keycloak via window.location.replace
+    // inside initiateLogin — block this route resolution.
+    throw redirect({ to: canonical as never, replace: true })
+  }
+  // Silent SSO not possible (already attempted this cycle, or no FQDN) —
+  // fall back to the explicit /login. Sanitize the `next` so we can never
+  // construct an open-redirect payload (CWE-601). qa-loop iter-4 cluster
   // `users-page-null-map-and-open-redirect`.
   const rawNext = pathname + window.location.search
   const safeNext = sanitizeNextParam(rawNext)
@@ -274,6 +298,57 @@ async function rootBeforeLoad({ location }: { location: { pathname: string } }) 
     search: safeNext ? { next: safeNext } : {},
     replace: true,
   })
+}
+
+/**
+ * attemptSilentSovereignSSO — #3374 Layer-B silent console front door.
+ *
+ * Fires the catalyst-ui PKCE authorization request against the Sovereign
+ * Keycloak (which auto-delegates to the catalyst-pin IdP via the realm's
+ * Identity-Provider-Redirector). Returns:
+ *   - true  → a redirect to Keycloak was initiated (the browser is being
+ *             navigated away); the caller must abort route resolution.
+ *   - false → silent SSO is not available (no Sovereign FQDN, or already
+ *             attempted this navigation cycle); the caller falls back to
+ *             the explicit /login PIN form.
+ *
+ * The one-shot guard (`SILENT_SSO_GUARD_KEY` in sessionStorage) prevents a
+ * console → KC → console → KC loop when the user is logged out at the IdP
+ * too: KC bounces straight back to /auth/callback with no code, the
+ * callback page navigates to /dashboard, the gate re-probes whoami=401,
+ * and WITHOUT this guard would re-initiate the round-trip forever. The
+ * guard is set before the redirect and cleared by AuthCallbackPage on a
+ * successful token exchange (so a later genuine expiry re-arms silent SSO).
+ */
+export const SILENT_SSO_GUARD_KEY = 'catalyst:silent-sso-attempted'
+
+async function attemptSilentSovereignSSO(): Promise<boolean> {
+  if (typeof window === 'undefined') return false
+  const fqdn = DETECTED_MODE.sovereignFQDN
+  if (!fqdn) return false
+  try {
+    if (sessionStorage.getItem(SILENT_SSO_GUARD_KEY) === '1') {
+      // Already tried this cycle and came back unauthenticated — let the
+      // explicit /login fallback take over.
+      return false
+    }
+    sessionStorage.setItem(SILENT_SSO_GUARD_KEY, '1')
+  } catch {
+    // Private browsing may throw — without a usable guard we cannot
+    // safely loop-protect, so decline silent SSO and use /login.
+    return false
+  }
+  try {
+    const { initiateLogin } = await import('@/shared/lib/oidc')
+    // initiateLogin calls window.location.replace(authEndpoint) — the
+    // browser navigates to Keycloak. Control does not return here in
+    // practice; we still return true so the caller aborts the route.
+    await initiateLogin(fqdn)
+    return true
+  } catch {
+    // OIDC module failed to load / build the request — fall back.
+    return false
+  }
 }
 
 // Root

--- a/products/catalyst/bootstrap/ui/src/pages/auth/AuthCallbackPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/AuthCallbackPage.tsx
@@ -76,6 +76,15 @@ function SovereignCallbackPage() {
 
         const params = new URLSearchParams(window.location.search)
         await handleCallback(sovereignFQDN, params)
+        // #3374 Layer-B: clear the silent-SSO one-shot guard now that a
+        // real session exists, so a LATER genuine expiry re-arms the
+        // silent round-trip (router.tsx attemptSilentSovereignSSO) rather
+        // than going straight to the PIN fallback.
+        try {
+          sessionStorage.removeItem('catalyst:silent-sso-attempted')
+        } catch {
+          /* private browsing may throw */
+        }
         // Navigate to the console dashboard — replace so the callback
         // URL doesn't appear in browser history.
         router.navigate({ to: '/dashboard' as never, replace: true })

--- a/scripts/check-no-dead-grant-theater.sh
+++ b/scripts/check-no-dead-grant-theater.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# check-no-dead-grant-theater.sh — CI guard that the #3374 Layer-C
+# admin-by-default theater (#3685) stays DELETED.
+#
+# #3374 §3-c / §5 removed the dead grant subsystem from bp-sso-bridge:
+#   - grant_operator_admin   — minted a per-Client `admin` role NO app reads
+#                              (every app keys admin on the `groups` claim);
+#   - grant_operator_realm_roles — per-email catalyst-admin grant, now
+#                              SUPERSEDED by the /sovereign-admins group
+#                              composite in the keycloak realm import.
+# Both logged "skipping admin grant"/"skipping realm-role grant" every 60s
+# tick on hw150 (orgEmail="") and NEVER granted anything. The ONE admin
+# authority is now membership in /sovereign-admins (DoD box 6/7).
+#
+# This guard fails CI if the dead function definitions, call sites, or
+# "skipping ... grant" log strings reappear in the bp-sso-bridge chart —
+# i.e. if a future change resurrects the theater the founder rejected.
+#
+# It is deliberately NARROW: it scans only the reconciler ConfigMap (the
+# bash that ran the grants), and it tolerates the DELETION-NOTE comment
+# block that names the removed functions for the next reader.
+#
+# Usage:  scripts/check-no-dead-grant-theater.sh
+# Exit:   0 = clean, 1 = a dead-grant artifact reappeared.
+
+set -euo pipefail
+
+ROOT="${ROOT:-.}"
+RECONCILER="${ROOT}/platform/sso-bridge/chart/templates/configmap-reconciler.yaml"
+EXIT=0
+
+if [ ! -f "${RECONCILER}" ]; then
+  echo "FATAL: ${RECONCILER} not found" >&2
+  exit 2
+fi
+
+# A line is a VIOLATION only if it is a real shell statement (not a
+# comment). We strip leading whitespace then drop comment lines (first
+# non-space char is '#') before matching.
+noncomment() {
+  # shellcheck disable=SC2016
+  awk '{ s=$0; sub(/^[[:space:]]+/, "", s); if (substr(s,1,1) != "#") print }' "$1"
+}
+
+fail() {
+  echo "FAIL: $1" >&2
+  EXIT=1
+}
+
+NC="$(noncomment "${RECONCILER}")"
+
+# 1. No live function DEFINITIONS of the dead grants.
+if printf '%s\n' "${NC}" | grep -Eq 'grant_operator_(admin|realm_roles)[[:space:]]*\(\)'; then
+  fail "a dead grant function (grant_operator_admin / grant_operator_realm_roles) was re-defined in the reconciler — #3374 Layer-C deleted these; admin is conferred ONLY by /sovereign-admins membership."
+fi
+
+# 2. No live CALL SITES of the dead grants.
+if printf '%s\n' "${NC}" | grep -Eq '(^|[[:space:];&|])grant_operator_(admin|realm_roles)[[:space:]]'; then
+  fail "a dead grant function is being CALLED in the reconciler — remove the call; the group composite confers catalyst-admin generically."
+fi
+
+# 3. No "skipping admin grant" / "skipping realm-role grant" log emitters
+#    (the exact dead-tick signature the founder flagged on hw150).
+if printf '%s\n' "${NC}" | grep -Eq 'skipping (admin|realm-role) grant'; then
+  fail "a 'skipping admin grant'/'skipping realm-role grant' log emitter reappeared — this was the dead-tick theater (#3685). The reconciler no longer grants admin."
+fi
+
+# 4. No per-HR realmRolesGranted plumbing (the dead config the per-email
+#    grant consumed). The keycloak group composite replaces it.
+if printf '%s\n' "${NC}" | grep -Eq 'realmRolesGranted'; then
+  fail "per-HR 'realmRolesGranted' plumbing reappeared in the reconciler — admin is conferred by the /sovereign-admins group composite, not a per-app realm-role grant."
+fi
+
+if [ "${EXIT}" -eq 0 ]; then
+  echo "OK: no dead admin-by-default grant theater in bp-sso-bridge reconciler (#3374 Layer-C / #3685)."
+fi
+exit "${EXIT}"


### PR DESCRIPTION
Refs #3374 #3370 #3563 #3679 #3685 #3686 #3693

Builds the foundational, mergeable vertical of #3374's bare-URL→authenticated-as-admin contract across all three layers, killing the incoherent-axes defect (5 interceptions + a self-signed Go constant + a dead bridge, reconciled by none). Per #3374 §2 law #2 ("NOTHING is banked") the live 11-row walk is the acceptance — every row is UNVERIFIED until walked fresh on the current env.

## Layer C — ONE admin authority (folds #3679, #3685)
- `platform/keycloak/.../configmap-sovereign-realm.yaml`: the realm import now **defines** the `catalyst-{viewer,developer,operator,admin,owner}` composite realm-role chain (these were previously ONLY strings the catalyst-api self-signed into a PIN JWT — System A, never real KC roles) AND composites `realmRoles:["catalyst-admin"]` onto `/sovereign-admins`. ONE membership now confers console-admin (`catalyst-admin`) + KC-console-admin (`realm-management:realm-admin`) + every app's `groups`-claim admin.
- `auth.go`: PIN-mint stops hardcoding `owner`/`catalyst-owner`; it **derives** tier from live KC `/sovereign-admins` membership via the new `keycloak.UserGroupPaths`. A non-member who PIN-authenticates gets `viewer`, **never silently owner** (law #4). New unit test `TestPinVerify_NonAdminGetsViewerNotOwner` proves it; the existing stamp test is rewired to the group/operator-email path.
- `bp-sso-bridge`: **DELETE** the dead `grant_operator_admin` (minted a per-Client `admin` role no app reads) + `grant_operator_realm_roles` (per-email grant, superseded by the group composite) + the `realmRolesGranted` plumbing. No more "skipping admin grant" 60s-tick theater. New CI tripwire `scripts/check-no-dead-grant-theater.sh` (negative-tested) keeps it deleted, wired to `sso-probe.yaml` on every PR touching the SSO chain.

## Layer B — silent console front door + owner seed (folds #3693)
- `router.tsx`: on `whoami` 401 in sovereign mode, attempt a **silent OIDC round-trip** (the `catalyst-ui` PKCE flow → KC `catalyst-pin` IDR) BEFORE falling to `/login`. The 6-digit-PIN wall is now an explicit fallback, never the default landing. One-shot `sessionStorage` guard prevents console↔KC loops; `AuthCallbackPage` clears it on a successful exchange so a later expiry re-arms silent SSO.
- `cloudinit-control-plane.tftpl`: thread `ORG_EMAIL`/`ORG_NAME` into the Flux postBuild substitute (the same `${org_email}` tofu value that already fed the realm seed) → `sovereign-fqdn` CM `orgEmail` → `OPERATOR_EMAIL` env. This was the measured root cause of hw150's empty `orgEmail` (§3-b) that starved the pre-existing `runBakeTimeOwnerSeed` (D21: `/users` rendered empty). The seed re-runs idempotently on every Pod start once the env is present.

## Layer A — one generic interception (folds #3686)
- `bp-oidc-gate` slot 13c now fronts **powerdns-admin** (replacing its structurally-fragile bespoke root-redirect — pda's OIDC callback shares `/login`, so the redirect looped and was reverted in pda 0.1.11); pda's own HTTPRoute is disabled (slot 11a `gateway.enabled:false`) so the gate is the single hostname owner. A disabled **`sso-generality-probe`** instance ships as the **DoD box 10a generality proof**: a brand-new app needs ONLY a name+hostname+upstream, zero per-app code.

## Charts / lockstep
keycloak `1.4.29`, bp-sso-bridge `0.2.19`, bp-oidc-gate `0.1.2` (+ slot 13c pin). `expected-bootstrap-deps.yaml` unchanged (no dependsOn change). UAT walkthrough rebuilt to the §3-d 11-row table at `docs/ledger/uat-walkthrough/sso-zero-login-everywhere-admin-by-default.md`.

## Gates (all green)
- `go build ./...` + `go test -race ./internal/keycloak/... ./internal/handler/...` (incl. new tests)
- `tsc -b && vite build` green; **77 UI unit tests pass** (auth-gate suite included)
- `helm lint` oidc-gate / sso-bridge / keycloak — 0 failed
- `lint-cloudinit.sh both` — PASS (hetzner + huawei render + dash -n)
- `check-bootstrap-deps.sh` — 0 drift, 0 cycles; `kubectl kustomize` bootstrap-kit OK
- `check-no-dead-grant-theater.sh` — PASS + negative-tested; keycloak realm JSON validated (5 roles + group composite)

## What remains (live-env work, stated honestly)
Per #3374 §2, acceptance is the live 11-row walk on a fresh prov with screenshots under `docs/sessions/<date>/evidence/`. The remaining per-app gate migrations beyond powerdns-admin (openbao shim deletion, guacamole, newapi, hubble) and the per-Org tenant tier (DoD box 8, gated on FUNNEL #3376) ride that walk; the generic mechanism + the generality proof are in place to add each as one `instances:` entry. Chart pins (0.1.2 / 0.2.19 / 1.4.29) require publish on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)