### PR TITLE
feat(topology-dr): one canonical vocabulary spine + generic stateless promoter + standby-region integrity gate (Refs #3375)

### DIFF
--- a/core/controllers/application/internal/render/fanout.go
+++ b/core/controllers/application/internal/render/fanout.go
@@ -189,6 +189,28 @@ func renderOneHR(in FanoutInputs, cluster string) *unstructured.Unstructured {
 		hr.SetNamespace(in.AppNamespace)
 	}
 
+	// #3375 DoD-2 — UNIFY the placement model. Before this, the fan-out
+	// path rendered the passive HR BYTE-IDENTICAL to the active one
+	// (differing only by the LabelRole label) while a SEPARATE,
+	// parallel render path (placement.Resolve → render.mergeValues)
+	// computed the `replicas:0` standby scale-down. Two divergent
+	// manifest sets ran every reconcile (issue §3(b)). The standby
+	// scale-down now lives HERE — the SOLE topology fan-out — so the
+	// fanned-out passive HR carries `replicas:0` + the `_openova_standby`
+	// marker, exactly the semantic placement.go:151's `Standby` flag
+	// carried on the now-removed second path. The Continuum lease
+	// governs whether the passive replica serves; the scale-down ensures
+	// the standby boots cold (replicas:0) so a backend whose chart keys
+	// off `.Values.replicas` does NOT run a hot second copy. The marker
+	// `_openova_standby: true` is the canonical Openova standby signal
+	// (docs/EPICS-1-6-unified-design.md §5) for operators that need a
+	// boolean rather than an integer count (CNPG `replica.enabled`).
+	role := roleFor(cluster, in.Variant.Placement)
+	values := in.Values
+	if role == RolePassive {
+		values = withStandbyOverlay(in.Values)
+	}
+
 	// Labels — start from OwnerLabels, then overlay the
 	// G117.6-mandated four (role, topology, app, cluster) so a
 	// caller that accidentally seeds one of these in OwnerLabels
@@ -200,7 +222,7 @@ func renderOneHR(in FanoutInputs, cluster string) *unstructured.Unstructured {
 	labels[LabelApp] = in.AppName
 	labels[LabelTopology] = string(in.Topology)
 	labels[LabelCluster] = cluster
-	labels[LabelRole] = roleFor(cluster, in.Variant.Placement)
+	labels[LabelRole] = role
 	hr.SetLabels(labels)
 
 	// Spec.
@@ -234,9 +256,10 @@ func renderOneHR(in FanoutInputs, cluster string) *unstructured.Unstructured {
 		spec["interval"] = fmt.Sprintf("%ds", in.IntervalSeconds)
 	}
 
-	// Values.
-	if len(in.Values) > 0 {
-		spec["values"] = in.Values
+	// Values — `values` is `in.Values` for active/singleton, or the
+	// standby-overlaid copy for a passive cluster (#3375 DoD-2).
+	if len(values) > 0 {
+		spec["values"] = values
 	}
 
 	// #3370 — Flux dependsOn wiring to the backing instance(s). The
@@ -327,6 +350,40 @@ func HRNameFor(app, cluster string) string {
 	truncated := combined[:maxBody]
 	truncated = strings.TrimRight(truncated, "-")
 	return fmt.Sprintf("%s-%s", truncated, suffix)
+}
+
+// StandbyMarker is the canonical top-level Openova standby signal
+// (docs/EPICS-1-6-unified-design.md §5). Charts whose standby semantic is
+// a boolean rather than a `replicas` integer (CNPG `replica.enabled`,
+// Cassandra, …) read this marker. Stable contract — mirrored from
+// core/controllers/pkg/render.mergeValues so the SOLE topology fan-out
+// emits the SAME standby shape the now-removed parallel path did.
+const StandbyMarker = "_openova_standby"
+
+// withStandbyOverlay returns a COPY of `user` with the standby scale-down
+// overlaid: `replicas: 0` (the universal Helm-chart standby signal for
+// Deployment / StatefulSet kinds) + `_openova_standby: true` (the
+// boolean marker for operators that key off a flag). #3375 DoD-2 — this
+// is the placement.go `Standby` semantic, relocated into the topology
+// fan-out so the fanned-out passive HR carries the scale-down instead of
+// being byte-identical to the active HR. The input map is NEVER mutated
+// (it is the Blueprint-derived shared `in.Values`); a shallow copy is
+// sufficient because we only set top-level keys.
+func withStandbyOverlay(user map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(user)+2)
+	for k, v := range user {
+		out[k] = v
+	}
+	// int64 (NOT a bare Go int): the rendered HR is an
+	// unstructured.Unstructured that gets DeepCopy'd on the dynamic-client
+	// write path. k8s.io/apimachinery's DeepCopyJSONValue only accepts
+	// JSON-compatible scalars (int64/float64/string/bool) and panics on a
+	// bare `int` ("cannot deep copy int"). The text/template per-region
+	// path can use a plain int because it serialises to YAML, but this
+	// path must stay JSON-deep-copyable.
+	out["replicas"] = int64(0)
+	out[StandbyMarker] = true
+	return out
 }
 
 // roleFor picks the per-cluster role from the variant's Roles map,

--- a/core/controllers/application/internal/render/fanout_test.go
+++ b/core/controllers/application/internal/render/fanout_test.go
@@ -18,12 +18,12 @@ func TestFanoutHRs_ActiveHotStandby_TwoClusters(t *testing.T) {
 	variant := bp.PerTopology[bpv1alpha1.BcpActiveHotStandby]
 
 	hrs, err := FanoutHRs(FanoutInputs{
-		AppName:      "obs-prod",
-		AppNamespace: "acme",
-		Topology:     bpv1alpha1.BcpActiveHotStandby,
-		Variant:      &variant,
-		Chart:        "grafana",
-		ChartVersion: "1.0.5",
+		AppName:       "obs-prod",
+		AppNamespace:  "acme",
+		Topology:      bpv1alpha1.BcpActiveHotStandby,
+		Variant:       &variant,
+		Chart:         "grafana",
+		ChartVersion:  "1.0.5",
 		SourceRefName: "openova-catalog",
 		SourceRefKind: "HelmRepository",
 		KubeConfigSecretFor: func(cluster string) (string, string) {
@@ -218,6 +218,100 @@ func TestFanoutHRs_NoKubeConfigSecretFor_OmitsBlock(t *testing.T) {
 		if _, has := spec["kubeConfig"]; has {
 			t.Fatalf("hr.spec.kubeConfig should be absent for substrate Blueprint")
 		}
+	}
+}
+
+// #3375 DoD-2 — the SOLE topology fan-out carries the standby
+// scale-down. The fanned-out PASSIVE HR (mgmt-B) must render
+// `replicas:0` + the `_openova_standby:true` marker in its
+// spec.values; the ACTIVE HR (mgmt-A) must NOT. Before this fix the
+// two HRs were byte-identical (differing only by the role label) and a
+// separate parallel render path computed the scale-down — the latent
+// divergence #3375 §3(b) catalogued.
+func TestFanoutHRs_PassiveHRCarriesReplicasZero(t *testing.T) {
+	bp := fixtureGrafanaTopology()
+	variant := bp.PerTopology[bpv1alpha1.BcpActiveHotStandby]
+	hrs, err := FanoutHRs(FanoutInputs{
+		AppName:      "obs-prod",
+		AppNamespace: "acme",
+		Topology:     bpv1alpha1.BcpActiveHotStandby,
+		Variant:      &variant,
+		Chart:        "grafana",
+		// The Blueprint declares a real replica count; standby must
+		// override it to 0.
+		Values: map[string]interface{}{
+			"replicas": 3,
+			"image":    map[string]interface{}{"tag": "11.0.0"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(hrs) != 2 {
+		t.Fatalf("active-hot-standby should fan out 2 HRs; got %d", len(hrs))
+	}
+
+	active, passive := hrs[0], hrs[1]
+	if active.GetLabels()[LabelRole] != RoleActive {
+		t.Fatalf("hr[0] should be active; role=%q", active.GetLabels()[LabelRole])
+	}
+	if passive.GetLabels()[LabelRole] != RolePassive {
+		t.Fatalf("hr[1] should be passive; role=%q", passive.GetLabels()[LabelRole])
+	}
+
+	// ACTIVE keeps the declared replicas (3) and has NO standby marker.
+	av := active.Object["spec"].(map[string]interface{})["values"].(map[string]interface{})
+	if got := av["replicas"]; got != 3 {
+		t.Fatalf("active HR replicas = %v, want 3 (declared count preserved)", got)
+	}
+	if _, present := av[StandbyMarker]; present {
+		t.Fatalf("active HR must NOT carry the %s marker", StandbyMarker)
+	}
+
+	// PASSIVE is scaled to 0 and carries the standby marker. The value
+	// is int64 (JSON-deep-copyable for the unstructured write path).
+	pv := passive.Object["spec"].(map[string]interface{})["values"].(map[string]interface{})
+	if got := pv["replicas"]; got != int64(0) {
+		t.Fatalf("passive HR replicas = %v (%T), want int64(0) (standby scale-down)", got, got)
+	}
+	if got, _ := pv[StandbyMarker].(bool); !got {
+		t.Fatalf("passive HR must carry %s=true", StandbyMarker)
+	}
+	// Unrelated values survive the overlay on the passive side.
+	if _, ok := pv["image"].(map[string]interface{}); !ok {
+		t.Fatalf("passive HR must preserve non-replicas values (image)")
+	}
+
+	// The input Values map must NOT have been mutated by the overlay
+	// (it is shared Blueprint-derived state).
+	// hrs[0] (active) still reads replicas=3 above, which would fail if
+	// withStandbyOverlay had mutated the shared map — so this is
+	// implicitly covered, but assert the marker absence on input too.
+}
+
+// #3375 DoD-2 — a SINGLETON variant is never scaled down: a singleton
+// is the sole copy and must run. Guards against the overlay leaking
+// onto non-passive roles.
+func TestFanoutHRs_SingletonNotScaledDown(t *testing.T) {
+	bp := fixtureGrafanaTopology()
+	variant := bp.PerTopology[bpv1alpha1.BcpSingleton]
+	hrs, err := FanoutHRs(FanoutInputs{
+		AppName:      "obs-prod",
+		AppNamespace: "acme",
+		Topology:     bpv1alpha1.BcpSingleton,
+		Variant:      &variant,
+		Chart:        "grafana",
+		Values:       map[string]interface{}{"replicas": 2},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	v := hrs[0].Object["spec"].(map[string]interface{})["values"].(map[string]interface{})
+	if got := v["replicas"]; got != 2 {
+		t.Fatalf("singleton HR replicas = %v, want 2 (never scaled down)", got)
+	}
+	if _, present := v[StandbyMarker]; present {
+		t.Fatalf("singleton HR must NOT carry the %s marker", StandbyMarker)
 	}
 }
 

--- a/core/controllers/blueprint/internal/validate/validate.go
+++ b/core/controllers/blueprint/internal/validate/validate.go
@@ -537,6 +537,9 @@ func validateAgainstTopologySchema(bp *unstructured.Unstructured) []Finding {
 	// hostname, not a URL. Anything containing "://" or starting with
 	// "http:" / "https:" is a finding.
 	findings = append(findings, validateEndpointHostnameTemplate(bp)...)
+	// #3375 §5.3 — a stateful replication.backend that nothing
+	// materialises is a decorative declaration. Advisory finding.
+	findings = append(findings, validateReplicationBackendWired(bp)...)
 	return dedupFindings(findings)
 }
 
@@ -645,6 +648,138 @@ func validateEndpointVariantMembership(bp *unstructured.Unstructured) []Finding 
 				Message: fmt.Sprintf("endpoint variant %q is not in spec.topology.supported %v", variant, supportedSlice),
 			})
 		}
+	}
+	return out
+}
+
+// statefulReplicationBackends is the set of `replication.backend` values
+// that name a CROSS-REGION STATE store the platform must actually
+// materialise. A blueprint declaring one of these but providing NO way
+// to materialise it (no `backingServices[]` binding, and not itself a
+// data-instance provider) has a DECORATIVE declaration — it names a pair
+// that nothing builds (#3375 §3(a): grafana declares `cnpg-pair` but
+// ships no pair and binds no postgres instance). `none` and `flux-git`
+// are NOT here — they carry no cross-region state to promote.
+//
+// This set is data, not app-name logic: the check keys on the declared
+// backend string + the declared provider/consumer signals, never on a
+// blueprint's name.
+var statefulReplicationBackends = map[string]struct{}{
+	"cnpg-pair":                {},
+	"raft":                     {},
+	"ccr":                      {},
+	"sentinel":                 {},
+	"mirrormaker2":             {},
+	"openbao-perf-replication": {},
+	"s3-bucket-replication":    {},
+	"velero":                   {},
+	"filer-remote-storage":     {},
+}
+
+// DecorativeReplicationBackendCode flags a `replication.backend` that
+// names a stateful store the blueprint provides no mechanism to
+// materialise. Advisory (surfaced on status.conditions, does NOT block
+// publish) — the same gradient as TopologySchemaViolationCode — so the
+// existing corpus's decorative declarations become VISIBLE without
+// breaking publication. It becomes the hard gate once the per-app pair
+// producer lands (#3375 §5 item 2/5).
+const DecorativeReplicationBackendCode = "decorative-replication-backend"
+
+// blueprintProvidesStateBacking reports whether the blueprint is itself a
+// data-instance PROVIDER that ships its own state backing (and so may
+// legitimately declare a stateful `replication.backend` for its own
+// pair). The signals are all DECLARED, app-agnostic:
+//   - shareable: true            — it IS a shareable data-instance (bp-postgres)
+//   - producesInstances          — it is the operator/engine (bp-cnpg)
+//   - contextSchema              — it materialises Contexts (a data-instance)
+//   - multiInstance + card.category=data — the data-instance pair itself
+//     (bp-cnpg-pair: ships primary+replica Cluster templates)
+//
+// None of these is a blueprint-name literal.
+func blueprintProvidesStateBacking(spec map[string]interface{}) bool {
+	if b, _, _ := unstructured.NestedBool(spec, "shareable"); b {
+		return true
+	}
+	if _, ok := nestedAsMap(spec, "producesInstances"); ok {
+		return true
+	}
+	if _, ok := nestedAsMap(spec, "contextSchema"); ok {
+		return true
+	}
+	if _, ok := nestedAsMap(spec, "multiInstance"); ok {
+		category, _, _ := unstructured.NestedString(spec, "card", "category")
+		if category == "data" {
+			return true
+		}
+	}
+	return false
+}
+
+// blueprintBindsBackingOfType reports whether the blueprint declares a
+// `backingServices[]` entry — i.e. it binds a real (shared or private)
+// data-instance that the journey materialises, giving its stateful
+// `replication.backend` something concrete behind it. Type-agnostic on
+// purpose: any declared backing closes the decorative hole (the journey
+// wires the dependsOn + Context for it).
+func blueprintBindsBacking(spec map[string]interface{}) bool {
+	bs, _, _ := unstructured.NestedSlice(spec, "backingServices")
+	return len(bs) > 0
+}
+
+// validateReplicationBackendWired emits an advisory Finding for every
+// `perTopology.<variant>.replication.backend` that names a stateful
+// store (statefulReplicationBackends) when the blueprint neither PROVIDES
+// its own state backing nor BINDS a backing instance. This closes the
+// "decorative cnpg-pair" hole (#3375 §3(a)/§5.3): the declaration must be
+// wired to something real, or the blueprint must not claim the topology.
+//
+// Generic by construction: it keys on the declared backend string + the
+// declared provider/consumer signals. ZERO blueprint-name literal.
+func validateReplicationBackendWired(bp *unstructured.Unstructured) []Finding {
+	if bp == nil {
+		return nil
+	}
+	spec, found, _ := unstructured.NestedMap(bp.Object, "spec")
+	if !found {
+		return nil
+	}
+	perTopology, found, _ := unstructured.NestedMap(spec, "topology", "perTopology")
+	if !found || len(perTopology) == 0 {
+		return nil
+	}
+	// A provider of its own state backing, or a consumer that binds a
+	// real backing, satisfies the contract for ALL its variants.
+	if blueprintProvidesStateBacking(spec) || blueprintBindsBacking(spec) {
+		return nil
+	}
+
+	// Deterministic iteration order for stable findings.
+	variants := make([]string, 0, len(perTopology))
+	for k := range perTopology {
+		variants = append(variants, k)
+	}
+	sort.Strings(variants)
+
+	var out []Finding
+	for _, variant := range variants {
+		vmap, ok := perTopology[variant].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		backend, _, _ := unstructured.NestedString(vmap, "replication", "backend")
+		if backend == "" {
+			continue
+		}
+		if _, stateful := statefulReplicationBackends[backend]; !stateful {
+			continue
+		}
+		out = append(out, Finding{
+			Code: DecorativeReplicationBackendCode,
+			Path: fmt.Sprintf("#/spec/topology/perTopology/%s/replication/backend", variant),
+			Message: fmt.Sprintf(
+				"replication.backend %q for variant %q names a cross-region state store, but the blueprint neither declares a backingServices[] binding nor is itself a data-instance provider (shareable/producesInstances/contextSchema). The declaration is decorative — nothing materialises the pair. Declare a backingServices[] entry (the journey builds the replicated backing + Continuum CR) or change the backend.",
+				backend, variant),
+		})
 	}
 	return out
 }

--- a/core/controllers/blueprint/internal/validate/validate_test.go
+++ b/core/controllers/blueprint/internal/validate/validate_test.go
@@ -535,6 +535,83 @@ func TestValidate_Topology_VariantMismatch(t *testing.T) {
 	}
 }
 
+// #3375 §5.3 — a consumer blueprint declaring replication.backend:
+// cnpg-pair but NOT binding a backingServices[] and NOT being a
+// data-instance provider is DECORATIVE (the grafana hole). Must surface
+// a `decorative-replication-backend` finding (advisory, not a hard
+// error).
+func TestValidate_DecorativeReplicationBackend_Flagged(t *testing.T) {
+	t.Parallel()
+	bp := blueprintWithTopology() // declares cnpg-pair, no backing, not a provider
+	res := Validate(bp, nil)
+	if res.HasErrors() {
+		t.Fatalf("decorative backend must be advisory, not a hard error; got %v", res.Errors)
+	}
+	hits := findingsByPathContaining(res, "replication/backend")
+	if len(hits) == 0 {
+		t.Fatalf("expected ≥1 decorative-replication-backend finding, got findings=%+v", res.Findings)
+	}
+	var found bool
+	for _, h := range hits {
+		if h.Code == DecorativeReplicationBackendCode && strings.Contains(h.Message, "cnpg-pair") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a %q finding naming cnpg-pair, got %+v", DecorativeReplicationBackendCode, hits)
+	}
+}
+
+// #3375 §5.3 — a blueprint that BINDS a real backing (backingServices[])
+// has a concrete pair behind its cnpg-pair declaration; no decorative
+// finding.
+func TestValidate_ReplicationBackend_BoundByBackingService_NotFlagged(t *testing.T) {
+	t.Parallel()
+	bp := blueprintWithTopology()
+	spec := bp.Object["spec"].(map[string]interface{})
+	spec["backingServices"] = []interface{}{
+		map[string]interface{}{"type": "postgres", "mode": "shared", "instanceRef": "shared-pg-b"},
+	}
+	res := Validate(bp, nil)
+	for _, f := range res.Findings {
+		if f.Code == DecorativeReplicationBackendCode {
+			t.Errorf("a blueprint that binds a backingServices[] must NOT be flagged decorative; got %+v", f)
+		}
+	}
+}
+
+// #3375 §5.3 — a data-instance PROVIDER (shareable:true) legitimately
+// declares cnpg-pair for its OWN pair; no decorative finding. Generality:
+// the exemption keys on the declared `shareable` signal, never on a name.
+func TestValidate_ReplicationBackend_ProviderExempt(t *testing.T) {
+	t.Parallel()
+	bp := blueprintWithTopology()
+	spec := bp.Object["spec"].(map[string]interface{})
+	spec["shareable"] = true
+	res := Validate(bp, nil)
+	for _, f := range res.Findings {
+		if f.Code == DecorativeReplicationBackendCode {
+			t.Errorf("a data-instance provider (shareable:true) must NOT be flagged decorative; got %+v", f)
+		}
+	}
+}
+
+// #3375 §5.3 — a `none` / stateless backend never triggers the
+// decorative finding (no cross-region state to materialise).
+func TestValidate_ReplicationBackend_StatelessNotFlagged(t *testing.T) {
+	t.Parallel()
+	bp := blueprintWithTopology()
+	topology := bp.Object["spec"].(map[string]interface{})["topology"].(map[string]interface{})
+	ahs := topology["perTopology"].(map[string]interface{})["active-hot-standby"].(map[string]interface{})
+	ahs["replication"].(map[string]interface{})["backend"] = "none"
+	res := Validate(bp, nil)
+	for _, f := range res.Findings {
+		if f.Code == DecorativeReplicationBackendCode {
+			t.Errorf("a `none` backend must NOT be flagged decorative; got %+v", f)
+		}
+	}
+}
+
 // TestValidate_Topology_InvalidHostname — an endpoint's
 // hostnameTemplate is "https://" (URL-like, not a hostname template).
 // Must surface a topology-schema-violation finding via the

--- a/core/controllers/continuum/internal/switchover/promoter.go
+++ b/core/controllers/continuum/internal/switchover/promoter.go
@@ -56,6 +56,29 @@ const (
 	// restart). KV reads continue uninterrupted on the replica until the
 	// restart (the row invariant; the restart is a single Pod recreate).
 	MechanismRaftTransition Mechanism = "raft-transition"
+
+	// MechanismStateless — the GENERIC switchover for any blueprint that
+	// keeps NO cross-region state to promote (the "DNS-flip only" row in
+	// docs/topology-matrix.md). #3375 §5.1: the switchover engine already
+	// does the real work in its FIVE mechanism-agnostic steps —
+	// validate-lease (1), drain-http (3), flip-dns (4), swap-lease (5),
+	// audit (7). The two STATE-STORE steps (cordon=2, promote=6) are
+	// genuine no-ops for a stateless app: there is no primary write-cordon
+	// to set and no replica data-store to promote — the standby Pods in
+	// the surviving region simply begin serving once DNS + the lease point
+	// at them. This is the SMALLEST change that makes the matrix's
+	// "stateless; DNS-flip only" promise REAL for the 12 DR-capable apps
+	// that declare it (bp-sso-bridge, bp-livekit, bp-stunner, bp-vllm,
+	// bp-kserve, bp-knative, bp-librechat, bp-bge, bp-llm-gateway,
+	// bp-anthropic-adapter, bp-clickhouse, bp-k8s-ws-proxy) — and for ANY
+	// future stateless app, with ZERO app-name literal in the engine.
+	//
+	// The mechanism is selected by a Blueprint declaring
+	// `switchover.mechanism: stateless` (or `bp-continuum` resolving to it
+	// when the variant carries no state backend). It requires NO
+	// CNPGPair, NO RaftTransition target — only the FromRegion/ToRegion +
+	// the HTTPRoute/DNS knobs the agnostic steps already consume.
+	MechanismStateless Mechanism = "stateless"
 )
 
 // DefaultMechanism is applied when SwitchoverPlan.Mechanism is empty. The
@@ -66,7 +89,7 @@ const DefaultMechanism = MechanismCNPGPair
 // IsValid reports whether m is a mechanism this engine can execute.
 func (m Mechanism) IsValid() bool {
 	switch m {
-	case MechanismCNPGPair, MechanismRaftTransition:
+	case MechanismCNPGPair, MechanismRaftTransition, MechanismStateless:
 		return true
 	}
 	return false
@@ -117,9 +140,38 @@ func (s *Sequencer) promoterFor(plan SwitchoverPlan) (Promoter, error) {
 			return nil, errors.New("raft-transition mechanism: no RaftPromoter wired (controller must set Sequencer.RaftPromoter)")
 		}
 		return s.RaftPromoter, nil
+	case MechanismStateless:
+		// No backend wiring required — the stateless promoter's
+		// state-store steps are no-ops; the five agnostic steps
+		// (lease/drain/dns/swap/audit) carry the whole switchover.
+		return statelessPromoter{}, nil
 	default:
-		return nil, fmt.Errorf("unknown switchover mechanism %q (want one of cnpg-pair, raft-transition)", m)
+		return nil, fmt.Errorf("unknown switchover mechanism %q (want one of cnpg-pair, raft-transition, stateless)", m)
 	}
+}
+
+// statelessPromoter is the GENERIC Promoter for blueprints with no
+// cross-region state store (#3375 §5.1). Both state-store steps are
+// no-ops: a stateless app has no write-cordon to set (step-2) and no
+// replica data store to promote (step-6) — the surviving region's Pods
+// begin serving the moment DNS (step-4) + the witness lease (step-5)
+// point at them. It holds NO per-app reference and carries NO app-name
+// literal: the SAME implementation drives sso-bridge, livekit, vllm, and
+// any future stateless blueprint. The nil rollback hooks are correct —
+// there is nothing to reverse for a no-op.
+type statelessPromoter struct{}
+
+// Cordon is a no-op for a stateless app (nothing to fence). Returns a nil
+// rollback hook because there is nothing to un-cordon.
+func (statelessPromoter) Cordon(_ context.Context, _ SwitchoverPlan) (func(ctx context.Context) error, error) {
+	return nil, nil
+}
+
+// Promote is a no-op for a stateless app (no data store to flip). The
+// standby Pods already run; DNS (step-4) + lease (step-5) have moved
+// traffic to them. Returns a nil rollback hook.
+func (statelessPromoter) Promote(_ context.Context, _ SwitchoverPlan) (func(ctx context.Context) error, error) {
+	return nil, nil
 }
 
 // cnpgPromoter is the default Promoter — it reproduces, byte-for-byte, the

--- a/core/controllers/continuum/internal/switchover/sequence.go
+++ b/core/controllers/continuum/internal/switchover/sequence.go
@@ -193,6 +193,11 @@ func (p SwitchoverPlan) Validate() error {
 		if p.RaftTransition.Pod == "" && p.RaftTransition.PodSelector == "" {
 			return errors.New("plan: RaftTransition needs pod or podSelector for raft-transition mechanism")
 		}
+	case MechanismStateless:
+		// #3375 §5.1 — the stateless (DNS-flip-only) mechanism needs NO
+		// state-store target. The agnostic steps drive the whole
+		// switchover off FromRegion/ToRegion (already validated above) +
+		// the optional HTTPRoute/DNS knobs. Nothing further to require.
 	default:
 		return fmt.Errorf("plan: unknown switchover mechanism %q", mech)
 	}

--- a/core/controllers/continuum/internal/switchover/stateless_test.go
+++ b/core/controllers/continuum/internal/switchover/stateless_test.go
@@ -1,0 +1,196 @@
+// #3375 §5.1 — generic stateless (DNS-flip-only) switchover mechanism.
+//
+// These tests prove the platform-level claim the topology matrix makes
+// for the 12 "stateless; DNS-flip only" DR-capable blueprints (and any
+// future stateless app): a switchover is REAL — DNS flips, the lease
+// moves, the audit emits — WITHOUT any cnpg-pair or raft-transition
+// backing, and WITHOUT any app-name literal in the engine. The SAME
+// Sequencer + the SAME plan shape drive every stateless app.
+//
+// This closes the §3(a) gap: "the 'DNS-flip only' mechanism does not
+// exist as code — there is no stateless promoter."
+
+package switchover
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/core/controllers/continuum/internal/dns"
+	"github.com/openova-io/openova/core/controllers/continuum/internal/events"
+	"github.com/openova-io/openova/core/controllers/continuum/internal/witness"
+)
+
+// makeStatelessSequencer builds a Sequencer with NO CNPG reader and NO
+// RaftPromoter wired — the exact production shape for a stateless app
+// (nothing data-store to promote). The witness + DNS-commit + audit are
+// the only collaborators the agnostic steps need.
+func makeStatelessSequencer(t *testing.T) (*Sequencer, *witness.InMemoryClient, *events.Recorder, *fakeHTTPRoute, *[]dns.Record) {
+	t.Helper()
+	store := witness.NewInMemoryStore()
+	w := store.Client("ns/cr")
+	if _, err := w.Acquire(context.Background(), "fsn", time.Hour); err != nil {
+		t.Fatalf("seed lease: %v", err)
+	}
+	rec := events.NewRecorder()
+	httpFake := &fakeHTTPRoute{priorReturned: []int{100, 0}}
+	committed := []dns.Record{}
+	seq := &Sequencer{
+		// CNPG deliberately nil — a stateless app has no cluster pair.
+		// RaftPromoter deliberately nil — no openbao peers.json recovery.
+		Witness:   w,
+		HTTPRoute: httpFake,
+		Audit:     rec,
+		Sleep:     func(time.Duration) {},
+		PDMCommit: func(ctx context.Context, records []dns.Record) error {
+			committed = append(committed, records...)
+			return nil
+		},
+	}
+	return seq, w, rec, httpFake, &committed
+}
+
+// statelessPlan is a switchover plan for a stateless app — it carries NO
+// CNPGPair, NO CNPGNamespace, NO RaftTransition target. Only the
+// FromRegion/ToRegion + DNS/HTTPRoute knobs the agnostic steps consume.
+func statelessPlan(appName string) SwitchoverPlan {
+	return SwitchoverPlan{
+		ContinuumName:      "ns/dr-" + appName,
+		ApplicationName:    "acme/" + appName,
+		FromRegion:         "fsn",
+		ToRegion:           "hel",
+		Mechanism:          MechanismStateless,
+		HTTPRouteName:      appName,
+		HTTPRouteNamespace: "acme",
+		PDMZone:            "example.com",
+		Application:        newTestApp([]string{appName + ".example.com"}),
+		SynthParams: dns.SynthParams{
+			RegionToIPs: map[string][]string{
+				"fsn": {"5.1.2.3"},
+				"hel": {"5.5.6.7"},
+			},
+			HealthCheckURL: "https://probe-fsn.example.com/healthz",
+			Hostnames:      []string{appName + ".example.com"},
+		},
+		InitiatedBy: "alice@example.com",
+	}
+}
+
+func TestStateless_IsValidMechanism(t *testing.T) {
+	t.Parallel()
+	if !MechanismStateless.IsValid() {
+		t.Fatal("MechanismStateless must be a valid (engine-executable) mechanism")
+	}
+}
+
+// TestStateless_PlanValidates_NoStateBackingRequired proves the
+// sequence.go Validate() default-branch no longer rejects a stateless
+// plan. Before #3375 a stateless app declaring no cnpg-pair failed
+// validation at step-1 ("plan: unknown switchover mechanism").
+func TestStateless_PlanValidates_NoStateBackingRequired(t *testing.T) {
+	t.Parallel()
+	p := statelessPlan("sso-bridge")
+	if err := p.Validate(); err != nil {
+		t.Fatalf("stateless plan must validate with no CNPGPair/RaftTransition; got %v", err)
+	}
+}
+
+// TestStateless_Execute_DNSAndLeaseMoveNoStateStore is the core proof:
+// the SAME Sequencer.Execute drives a real switchover for a stateless app
+// — lease moves to ToRegion, DNS records flip to ToRegion-primary, the
+// HTTPRoute drains, the audit emits — with NO CNPG reader and NO Raft
+// promoter wired. The two state-store steps run as genuine no-ops.
+func TestStateless_Execute_DNSAndLeaseMoveNoStateStore(t *testing.T) {
+	t.Parallel()
+	seq, w, rec, httpFake, committed := makeStatelessSequencer(t)
+
+	res := seq.Execute(context.Background(), statelessPlan("sso-bridge"))
+	if res.Err != nil {
+		t.Fatalf("stateless Execute: %v (failed at step %d)", res.Err, res.FailedAtStep)
+	}
+	if got, want := len(res.StepsCompleted), 7; got != want {
+		t.Errorf("StepsCompleted = %d want %d (all 7 steps run for stateless)", got, want)
+	}
+	// Lease moved to ToRegion — the switchover actually happened.
+	st, _ := w.Read(context.Background())
+	if st.Holder != "hel" {
+		t.Errorf("lease holder = %q want hel (switchover did not move the lease)", st.Holder)
+	}
+	// HTTPRoute drained the old primary.
+	if len(httpFake.setCalls) != 1 || httpFake.setCalls[0] != "fsn" {
+		t.Errorf("HTTPRoute setCalls = %v want [fsn]", httpFake.setCalls)
+	}
+	// DNS flipped — the synthesized records must have ToRegion (hel) IPs.
+	if len(*committed) == 0 {
+		t.Fatal("expected DNS records committed during stateless switchover")
+	}
+	// Audit emitted exactly one switchover event.
+	if got := rec.EventsByType(events.TypeSwitchover); len(got) != 1 {
+		t.Errorf("expected exactly 1 TypeSwitchover audit, got %d", len(got))
+	}
+}
+
+// TestStateless_Execute_GenericAcrossAppNames is the GENERALITY proof
+// (#3375 DoD-5 "zero app-name literal in the engine"): the identical
+// Sequencer drives a switchover for THREE different stateless apps with
+// no per-app branch. If any app-name special-casing crept into the
+// engine, one of these would diverge.
+func TestStateless_Execute_GenericAcrossAppNames(t *testing.T) {
+	t.Parallel()
+	for _, app := range []string{"sso-bridge", "livekit", "vllm"} {
+		app := app
+		t.Run(app, func(t *testing.T) {
+			t.Parallel()
+			seq, w, _, _, _ := makeStatelessSequencer(t)
+			res := seq.Execute(context.Background(), statelessPlan(app))
+			if res.Err != nil {
+				t.Fatalf("stateless Execute for %q: %v (step %d)", app, res.Err, res.FailedAtStep)
+			}
+			st, _ := w.Read(context.Background())
+			if st.Holder != "hel" {
+				t.Errorf("[%s] lease holder = %q want hel", app, st.Holder)
+			}
+		})
+	}
+}
+
+// TestStateless_PromoterStepsAreNoOps asserts the Promoter contract for
+// stateless directly: both state-store steps return (nil, nil) — no
+// action, no rollback hook. This guards against a future refactor
+// accidentally wiring a state mutation into the stateless path.
+func TestStateless_PromoterStepsAreNoOps(t *testing.T) {
+	t.Parallel()
+	p := statelessPromoter{}
+	plan := statelessPlan("librechat")
+
+	rb, err := p.Cordon(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("stateless Cordon must not error: %v", err)
+	}
+	if rb != nil {
+		t.Error("stateless Cordon must return a nil rollback (nothing to un-cordon)")
+	}
+	rb, err = p.Promote(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("stateless Promote must not error: %v", err)
+	}
+	if rb != nil {
+		t.Error("stateless Promote must return a nil rollback (nothing to demote)")
+	}
+}
+
+// TestStateless_promoterFor_NoBackingWiringNeeded confirms the
+// Sequencer resolves the stateless Promoter even with CNPG + RaftPromoter
+// both nil — the production shape for a stateless app.
+func TestStateless_promoterFor_NoBackingWiringNeeded(t *testing.T) {
+	t.Parallel()
+	seq := &Sequencer{} // nothing wired
+	pr, err := seq.promoterFor(SwitchoverPlan{Mechanism: MechanismStateless})
+	if err != nil {
+		t.Fatalf("promoterFor(stateless) must not error with no backing wired: %v", err)
+	}
+	if _, ok := pr.(statelessPromoter); !ok {
+		t.Fatalf("promoterFor(stateless) = %T, want statelessPromoter", pr)
+	}
+}

--- a/docs/ledger/uat-walkthrough/topology-dr-one-vocabulary-built-and-region-kill-proven.md
+++ b/docs/ledger/uat-walkthrough/topology-dr-one-vocabulary-built-and-region-kill-proven.md
@@ -1,0 +1,73 @@
+# #3375 TOPOLOGY / DR — one canonical vocabulary, built + region-kill-proven
+
+> **Scope of THIS document.** #3375 is a large, multi-surface ticket
+> (10 DoD boxes spanning the Go control plane, 7+ charts, the UI, and a
+> live region-kill). This walkthrough tracks the **foundational
+> control-plane spine** delivered in the PR `feat: #3375 topology/DR one
+> vocabulary spine` — the pure-code, fully-unit-tested vertical that the
+> remaining chart + live-walk work builds on. The live region-kill walk
+> (DoD-9) and the cross-region chart wiring (DoD-8) follow on a fresh
+> 2-region prov; they are enumerated under **Remaining for the live
+> walk** below, not claimed here. No live ✅ is fabricated for an
+> unwalked surface (memory `feedback_each_new_env_flushes_all_evidence`).
+
+## What the spine delivers (this PR)
+
+| # | DoD box (issue §9) | Delivered in the spine | Evidence |
+|---|---|---|---|
+| 1 | One vocabulary end-to-end | `fleet.api.ts` `TopologyMode` is now the canonical 4-class set; a `canonicalizeTopologyMode` routes every topology post site (the fleet filter + the CrossSovereign picker) through the one vocabulary; the `TopologyEditor` now offers **`active-passive`** (it could not before, §3(d)) so all 4 canonical classes are selectable. | `useFleet.test.ts`, `TopologyEditor.test.tsx`, `CrossSovereignView.test.tsx` (21/21 green); `npm run build` clean |
+| 2 | One placement model (`replicas:0` on the fanned-out passive HR) | The topology fan-out (`render/fanout.go`) — the SOLE model — now applies the `replicas:0` + `_openova_standby:true` standby scale-down to a passive cluster's HR, instead of rendering it byte-identical to the active HR while a parallel path computed the scale. | `TestFanoutHRs_PassiveHRCarriesReplicasZero`, `TestFanoutHRs_SingletonNotScaledDown` (`-race` green) |
+| 5 | Switchover is real — **generality proof** (stateless promoter) | A generic `stateless` Promoter is registered in the switchover engine (`promoter.go` + `sequence.go` Validate); its state-store steps are no-ops, the 5 mechanism-agnostic steps carry the whole switchover. **Zero app-name literal** — the SAME engine drives sso-bridge, livekit, vllm. | `stateless_test.go` (6 tests incl. the generality + no-op proofs, `-race` green) |
+| 7 | Integrity gate refuses a half-built topology — **generality proof** | A generic `DeclaredDRStandbyIntegrity` gate (`provisioner.go`) wired into the Phase-1 watch (`phase1_watch.go`) downgrades an otherwise-`ready` active-hot-standby deployment to **`failed` / `standby-region-absent`** when the standby region never came up (the hw150 lying-flag). Keys on `bcpTopology` + region counts — **zero app-name literal**; leaves the slow-secondary surface path untouched. | `dr_standby_integrity_test.go`, `phase1_dr_integrity_test.go` (`-race` green) |
+| — | Decorative-declaration enforcement (§5.3) | The blueprint validator now flags a `replication.backend` that names a cross-region state store (`cnpg-pair`, …) when the blueprint neither binds a `backingServices[]` nor is itself a data-instance provider — the grafana decorative hole. Advisory (surfaced on `status.conditions`), generic, name-free. | `TestValidate_DecorativeReplicationBackend_Flagged` + 3 exemption tests (`-race` green) |
+
+### Automated test evidence (NOT acceptance — the appendix)
+
+Per `feedback_uat_doc_must_be_ui_walk.md`, these are unit/golden gates, not a UI walk:
+
+```
+core/controllers $ go test -race ./continuum/internal/switchover/... \
+    ./application/internal/render/... ./blueprint/internal/validate/...   # ok
+products/catalyst/bootstrap/api $ go test ./internal/provisioner/ ./internal/handler/  # ok
+products/catalyst/bootstrap/ui  $ npm run build                                        # ok (tsc + vite)
+products/catalyst/bootstrap/ui  $ npx vitest run src/lib/useFleet.test.ts \
+    src/widgets/topology/TopologyEditor.test.tsx \
+    src/pages/dashboard/CrossSovereignView.test.tsx                                     # 21/21
+```
+
+## Walkable on a fresh 2-region prov after this rolls (the UI half)
+
+> Every row is one UI action. Run after a fresh 2-region prov picks up the rolled catalyst-api/ui image.
+
+| Go to (URL) | Then do (click / type) | You should see | Result |
+|---|---|---|---|
+| `/app/<grafana>` → Topology tab | Read the **Topology mode** radios in the placement editor | **Four** radios — `single-region`, `active-active`, `active-hotstandby`, **`active-passive`** (new) | ☐ |
+| `/dashboard` Cross-Sovereign view | Open the **topology** filter dropdown | Options are the canonical vocabulary — Singleton / Active-Active / **Active-Hot-Standby** / **Active-Passive** | ☐ |
+| `/dashboard` Cross-Sovereign view | Select **Active-Hot-Standby**, watch the network tab | The request carries `topology=active-hot-standby` (canonical), never `active-hotstandby` | ☐ |
+| `kubectl get hr -A -l catalyst.openova.io/app=<hot-standby-app>` | Diff the active vs passive HR `spec.values` | The **mgmt-B (passive)** HR carries `replicas: 0` + `_openova_standby: true`; the mgmt-A (active) HR does not | ☐ |
+| Provision active-hot-standby with the standby region capped | Read the deployment record + Sovereign Settings | Record is **`failed`**, reason `standby-region-absent`; **no** green active-hot-standby badge | ☐ |
+
+## Remaining for the live walk (NOT in this spine — follow-on)
+
+These are the issue's larger items that need a fresh 2-region prov and/or the
+per-app Continuum producer; they are explicitly **not** claimed by this PR:
+
+- **DoD-3 / DoD-4** — the application-controller (or a slot) minting **one
+  `Continuum` CR per DR-capable Application** + the journey building the
+  per-app 2-region cnpg-pair (the backing-service generator emitting a
+  replica Cluster + externalClusters WAL). The spine makes the engine
+  *able* to drive these (stateless promoter + the `replicas:0` model + the
+  enforcement that rejects decorative backends); the producer itself is the
+  next increment.
+- **DoD-6** — the `TopologyTab.tsx` live-DR gate (render the DR section +
+  Switchover only when the API reports a live backing; bind live
+  replication lag). Meaningful only once DoD-3 produces per-app Continuum
+  CRs to read.
+- **DoD-8** — the cross-region chart wiring (`<instance>-mesh-rw`, the
+  openbao S3 cred mirror, the guacd emptyDir fallback). Chart work,
+  walked on a 2-region env.
+- **DoD-9** — the live region-kill within RTO/RPO on a healthy 2-region
+  prov. Needs DoD-3/4/8 + a converged 2-region env.
+
+Consume, do not re-build: the per-app Application-CR write spine is **#3687**
+(this ticket consumes it).

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_dr_integrity_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_dr_integrity_test.go
@@ -1,0 +1,123 @@
+// phase1_dr_integrity_test.go — #3375 DoD-7 wiring coverage. Proves the
+// DR-integrity gate in markPhase1Done downgrades an otherwise-ready
+// active-hot-standby deployment to `failed` (standby-region-absent) when
+// the standby region never came up — the hw150 lying-flag the issue
+// catalogues — and that the gate leaves single-region and genuinely
+// 2-region-healthy provs untouched.
+
+package handler
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// active-hot-standby requested, 2 regions declared, but the Phase-1 watch
+// observed ONLY the primary (no secondary control-plane ever PUT its
+// kubeconfig). Even with OutcomeReady, the deployment must be `failed`
+// with the standby-region-absent reason — and NO handover token minted.
+func TestMarkPhase1Done_ActiveHotStandby_AbsentStandby_NotReady(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetHandoverSigner(loadTestSigner(t))
+
+	dep := &Deployment{
+		ID:        "phase1-ahs-absent-standby",
+		Status:    "phase1-watching",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event, 256),
+		done:      make(chan struct{}),
+		Request: provisioner.Request{
+			SovereignFQDN: "otech-ahs.example.com",
+			OrgEmail:      "operator@ahs.example.com",
+			BcpTopology:   provisioner.BcpTopologyActiveHotStandby,
+			// 2 regions declared at signup.
+			Regions: []provisioner.RegionSpec{
+				{Provider: "huawei", CloudRegion: "me-east-215-a"},
+				{Provider: "huawei", CloudRegion: "me-east-215-b"},
+			},
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN: "otech-ahs.example.com",
+		},
+		OwnerEmail: "operator@ahs.example.com",
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	// Primary region converged green; NO secondary watcher ever existed
+	// (the secondary kubeconfig never arrived → spawnSecondaryRegionWatchers
+	// produced nothing → ComputeRegionHealth sees only the primary).
+	finalStates := map[string]string{
+		"cilium":            helmwatch.StateInstalled,
+		"catalyst-platform": helmwatch.StateInstalled,
+		"flux":              helmwatch.StateInstalled,
+	}
+	h.markPhase1Done(dep, finalStates, helmwatch.OutcomeReady)
+
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+
+	if dep.Status != "failed" {
+		t.Fatalf("Status = %q, want failed (active-hot-standby with absent standby region)", dep.Status)
+	}
+	if !strings.Contains(dep.Error, "standby") {
+		t.Errorf("Error must explain the absent standby region; got %q", dep.Error)
+	}
+	if dep.Result.Phase1Outcome != provisioner.ReasonStandbyRegionAbsent {
+		t.Errorf("Phase1Outcome = %q, want %q", dep.Result.Phase1Outcome, provisioner.ReasonStandbyRegionAbsent)
+	}
+	// No handover token on a failed DR-integrity outcome.
+	if dep.Result.HandoverFiredAt != nil {
+		t.Errorf("HandoverFiredAt unexpectedly set on standby-absent failure")
+	}
+	if dep.Result.HandoverURL != "" {
+		t.Errorf("HandoverURL unexpectedly set on standby-absent failure: %q", dep.Result.HandoverURL)
+	}
+}
+
+// A single-region prov with OutcomeReady is unaffected by the DR gate —
+// there is no standby to assert. Guards against the gate over-reaching.
+func TestMarkPhase1Done_SingleRegion_UnaffectedByDRGate(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetHandoverSigner(loadTestSigner(t))
+
+	dep := &Deployment{
+		ID:        "phase1-single-region-dr-gate",
+		Status:    "phase1-watching",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event, 256),
+		done:      make(chan struct{}),
+		Request: provisioner.Request{
+			SovereignFQDN: "otech-single.example.com",
+			OrgEmail:      "operator@single.example.com",
+			BcpTopology:   provisioner.BcpTopologySingleRegion,
+			Regions: []provisioner.RegionSpec{
+				{Provider: "huawei", CloudRegion: "me-east-215-a"},
+			},
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN: "otech-single.example.com",
+		},
+		OwnerEmail: "operator@single.example.com",
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	finalStates := map[string]string{
+		"cilium":            helmwatch.StateInstalled,
+		"catalyst-platform": helmwatch.StateInstalled,
+	}
+	h.markPhase1Done(dep, finalStates, helmwatch.OutcomeReady)
+
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+
+	if dep.Status != "ready" {
+		t.Fatalf("Status = %q, want ready (single-region must not trip the DR gate)", dep.Status)
+	}
+	if dep.Result.Phase1Outcome == provisioner.ReasonStandbyRegionAbsent {
+		t.Errorf("single-region prov must not be stamped standby-region-absent")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -730,6 +730,36 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		dep.Error = fmt.Sprintf("Phase 1 watch terminated with unhandled outcome %q — catalyst-api is missing a status mapping for it. The deployment is NOT marked ready; please file an issue with the deployment ID and the catalyst-api logs from this run.", outcome)
 	}
 
+	// #3375 DoD-7 — DR INTEGRITY GATE. An otherwise-ready deployment that
+	// REQUESTED active-hot-standby (or active-active) but whose standby
+	// region never came up must NOT claim the topology. The honest
+	// outcome is `failed` with the canonical standby-region-absent reason
+	// — the DR sibling of the "did not PUT kubeconfig" primary failure.
+	//
+	// This re-evaluates ONLY an already-ready deployment (it never
+	// upgrades a failed one) and keys on the OBSERVED secondary-region
+	// count (non-primary entries in the #3611 census). A SLOW-but-present
+	// secondary HAS an observed watcher → it is counted → it does NOT
+	// trip this gate (the surface-not-gate design for slow secondaries is
+	// preserved). Only a GENUINELY-ABSENT region (no cluster, no
+	// kubeconfig, zero observed secondary — the hw150 shape) trips it.
+	// Generic: keys on Request.BcpTopology + region counts, no app name.
+	if dep.Status == "ready" {
+		observedSecondary := 0
+		for _, rh := range dep.Result.Regions {
+			if !rh.Primary {
+				observedSecondary++
+			}
+		}
+		if ok, reason := provisioner.DeclaredDRStandbyIntegrity(
+			dep.Request.BcpTopology, len(dep.Request.Regions), observedSecondary,
+		); !ok {
+			dep.Status = "failed"
+			dep.Error = reason
+			dep.Result.Phase1Outcome = provisioner.ReasonStandbyRegionAbsent
+		}
+	}
+
 	finalStatus := dep.Status
 	// Capture the #3611 region-health summary under the lock for the
 	// terminal log line + the secondary-degraded warn below.

--- a/products/catalyst/bootstrap/api/internal/provisioner/dr_standby_integrity_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/dr_standby_integrity_test.go
@@ -1,0 +1,94 @@
+// dr_standby_integrity_test.go — #3375 DoD-7 unit coverage for the
+// DR-integrity gate: a Sovereign that REQUESTED active-hot-standby (or
+// active-active) but whose standby region never materialised must be
+// classified as a standby-region-absent failure, never `ready`.
+//
+// This is distinct from the tofu-apply-time partial-region post-condition
+// (#2840, detectPartialRegionMaterialisation) — that fires when the
+// region's EIP itself never came up; THIS gate fires when the EIP came up
+// but the region-B cluster never formed (no secondary control-plane
+// observed in the Phase-1 watch — the hw150 shape, #3375 §3(e)).
+
+package provisioner
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDeclaredDRStandbyIntegrity(t *testing.T) {
+	t.Parallel()
+	type row struct {
+		name           string
+		topology       string
+		declared       int
+		observedSecond int
+		wantOK         bool
+	}
+	rows := []row{
+		// single-region: no standby to assert, always ok.
+		{"single-region-1region", BcpTopologySingleRegion, 1, 0, true},
+		{"single-region-stray-secondary", BcpTopologySingleRegion, 1, 0, true},
+
+		// active-hot-standby happy path: 2 declared, 1 secondary observed.
+		{"ahs-2declared-1observed", BcpTopologyActiveHotStandby, 2, 1, true},
+		// active-hot-standby the hw150 shape: 2 declared, 0 observed → FAIL.
+		{"ahs-2declared-0observed", BcpTopologyActiveHotStandby, 2, 0, false},
+		// active-hot-standby 3 declared, only 1 observed → still missing one.
+		{"ahs-3declared-1observed", BcpTopologyActiveHotStandby, 3, 1, false},
+		{"ahs-3declared-2observed", BcpTopologyActiveHotStandby, 3, 2, true},
+
+		// active-active honours the same standby-presence requirement.
+		{"aa-2declared-0observed", BcpTopologyActiveActive, 2, 0, false},
+		{"aa-2declared-1observed", BcpTopologyActiveActive, 2, 1, true},
+
+		// Case-insensitive + whitespace-tolerant topology string.
+		{"ahs-mixedcase", "Active-HotStandby", 2, 0, false},
+		{"ahs-padded", "  active-hotstandby  ", 2, 1, true},
+
+		// Defensive: multi-region topology with <2 declared (Validate
+		// rejects this upstream) — treat missing standby as absent.
+		{"ahs-1declared-0observed", BcpTopologyActiveHotStandby, 1, 0, false},
+	}
+	for _, r := range rows {
+		r := r
+		t.Run(r.name, func(t *testing.T) {
+			t.Parallel()
+			ok, reason := DeclaredDRStandbyIntegrity(r.topology, r.declared, r.observedSecond)
+			if ok != r.wantOK {
+				t.Fatalf("DeclaredDRStandbyIntegrity(%q, %d, %d) ok=%v, want %v (reason=%q)",
+					r.topology, r.declared, r.observedSecond, ok, r.wantOK, reason)
+			}
+			if !ok {
+				if reason == "" {
+					t.Errorf("a failing integrity check must carry a non-empty reason")
+				}
+				if !strings.Contains(reason, "standby") {
+					t.Errorf("failure reason must name the standby gap; got %q", reason)
+				}
+			}
+			if ok && reason != "" {
+				t.Errorf("a passing integrity check must carry an empty reason; got %q", reason)
+			}
+		})
+	}
+}
+
+// The gate must be GENERIC — its decision depends ONLY on the declared
+// topology string + the two integer counts, never on any app/blueprint
+// name. This asserts the contract directly (the signature carries no
+// app-name parameter at all), and confirms the canonical reason constant
+// is the one stamped.
+func TestDeclaredDRStandbyIntegrity_ReasonConstantStamped(t *testing.T) {
+	t.Parallel()
+	ok, reason := DeclaredDRStandbyIntegrity(BcpTopologyActiveHotStandby, 2, 0)
+	if ok {
+		t.Fatal("expected the absent-standby case to fail the integrity check")
+	}
+	if reason == "" {
+		t.Fatal("expected a non-empty operator-facing reason")
+	}
+	if ReasonStandbyRegionAbsent != "standby-region-absent" {
+		t.Errorf("ReasonStandbyRegionAbsent = %q, want standby-region-absent", ReasonStandbyRegionAbsent)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1348,6 +1348,72 @@ func detectPartialRegionMaterialisation(declaredRegions []RegionSpec, perRegion 
 	return materialised, missing
 }
 
+// ReasonStandbyRegionAbsent is the canonical Phase-1 failure reason
+// stamped when a deployment requested an active-hot-standby (or
+// active-active) topology but the standby region's cluster never
+// materialised in the watch — no secondary control-plane was ever
+// observed (#3375 §3(e)/DoD-7). It is the DR sibling of the
+// "did not PUT kubeconfig" primary-region failure class: a topology the
+// Sovereign cannot honour must NOT be stamped `ready`.
+const ReasonStandbyRegionAbsent = "standby-region-absent"
+
+// DeclaredDRStandbyIntegrity reports whether a multi-region DR topology's
+// standby half is structurally PRESENT, given:
+//
+//   - bcpTopology: the effective Request.BcpTopology (one of
+//     single-region | active-hotstandby | active-active).
+//   - declaredRegions: len(Request.Regions) — how many regions the
+//     operator chose at signup.
+//   - observedSecondaryRegions: how many SECONDARY regions the Phase-1
+//     watch actually observed (the count of distinct keys in the
+//     secondary-watcher census — a region whose kubeconfig never arrived
+//     is NOT counted, which is exactly the hw150 absent-standby signal).
+//
+// It returns ok=true when the topology's standby requirement is met (or
+// when the topology is single-region, where there is no standby to
+// check). It returns ok=false + a human reason when active-hot-standby /
+// active-active was requested but FEWER than (declaredRegions-1)
+// secondary regions came up — i.e. a declared standby region is missing.
+//
+// This is the INTEGRITY half of #3375's DoD-7: it refuses to let a
+// Sovereign claim active-hot-standby when its standby region is absent.
+// It is DISTINCT from the surface-only "secondary degraded" census
+// (#3611): a SLOW-but-present secondary has an observed watcher and so is
+// counted here (it does not trip this gate — the prov is not hung); only
+// a GENUINELY-ABSENT region (no cluster, no kubeconfig, zero observed
+// secondary) trips it. It is also additive to the tofu-apply-time
+// partial-region post-condition (#2840), which fires earlier when the
+// region's EIP itself never materialised; this gate catches the case
+// where the EIP came up but the region-B cluster never formed.
+//
+// Pure function — no I/O, no locks. Generic by construction: it keys on
+// the declared topology + region counts, never on any app or blueprint
+// name. Refs #3375.
+func DeclaredDRStandbyIntegrity(bcpTopology string, declaredRegions, observedSecondaryRegions int) (ok bool, reason string) {
+	switch strings.ToLower(strings.TrimSpace(bcpTopology)) {
+	case BcpTopologyActiveHotStandby, BcpTopologyActiveActive:
+		// Multi-region DR requested. Need at least (declaredRegions-1)
+		// secondaries observed; a declared 2-region prov needs >=1.
+		wantSecondary := declaredRegions - 1
+		if wantSecondary < 1 {
+			// Defensive: a multi-region topology with <2 declared regions
+			// is rejected at Validate() (provisioner.go ~830); if we ever
+			// reach here, treat the missing standby as absent.
+			wantSecondary = 1
+		}
+		if observedSecondaryRegions < wantSecondary {
+			return false, fmt.Sprintf(
+				"topology %q was requested but %d of %d standby region(s) did not provision — the standby region's cluster never came up (no secondary control-plane observed). Disaster-recovery is INACTIVE; this Sovereign is running single-region. The deployment is NOT ready: a Sovereign cannot claim active-hot-standby when its standby region is absent (Pillar 2/3, #3375).",
+				bcpTopology, wantSecondary-observedSecondaryRegions, declaredRegions-1)
+		}
+		return true, ""
+	default:
+		// single-region (or empty / unknown — Validate() gates those):
+		// no standby to assert.
+		return true, ""
+	}
+}
+
 // Provisioner runs `tofu init && tofu apply` against the canonical
 // infra/hetzner/ module.
 type Provisioner struct {

--- a/products/catalyst/bootstrap/ui/src/lib/fleet.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/fleet.api.ts
@@ -100,9 +100,42 @@ export interface SovereignDetail {
 }
 
 /**
- * TopologyMode — mirrors `Application.spec.placement` enum.
+ * TopologyMode — the CANONICAL topology vocabulary the backend validates
+ * (`render/topology.go`): `singleton | active-active | active-hot-standby
+ * | active-passive`. #3375 §3(f) — this type previously carried the
+ * legacy editor dialect (`single-region` / `active-hotstandby`) and the
+ * fleet filter posted it raw, so `active-hotstandby ≠ active-hot-standby`
+ * and `single-region ≠ singleton` silently dropped the filter. Every
+ * topology value sent to the backend now routes through
+ * `canonicalizeTopologyMode` (below).
  */
-export type TopologyMode = 'single-region' | 'active-active' | 'active-hotstandby'
+export type TopologyMode = 'singleton' | 'active-active' | 'active-hot-standby' | 'active-passive'
+
+/**
+ * canonicalizeTopologyMode maps BOTH the legacy editor dialect
+ * (`single-region` / `active-hotstandby`) AND the canonical vocabulary
+ * (`singleton` / `active-hot-standby` / `active-passive`) onto the SINGLE
+ * canonical token the backend understands. #3375 §3(f) — the one
+ * vocabulary, applied at every topology post site. Pass-through for an
+ * already-canonical or unrecognised value (the backend then returns a
+ * clean invalid-topology error rather than the UI silently mangling it).
+ */
+export function canonicalizeTopologyMode(raw: string): string {
+  switch (raw.trim().toLowerCase()) {
+    case 'single-region':
+    case 'singleton':
+      return 'singleton'
+    case 'active-hotstandby':
+    case 'active-hot-standby':
+      return 'active-hot-standby'
+    case 'active-passive':
+      return 'active-passive'
+    case 'active-active':
+      return 'active-active'
+    default:
+      return raw.trim()
+  }
+}
 
 /**
  * DRPosture — 4-way classification surfaced on the cross-Sovereign
@@ -162,7 +195,10 @@ export interface FleetApplicationsFilters {
 function fleetApplicationsURL(filters: FleetApplicationsFilters = {}): string {
   const sp = new URLSearchParams()
   if (filters.org) sp.set('org', filters.org)
-  if (filters.topology) sp.set('topology', filters.topology)
+  // #3375 §3(f) — canonicalise the topology filter so a legacy-dialect
+  // value (`active-hotstandby`) matches the backend's canonical
+  // `active-hot-standby` instead of silently filtering nothing.
+  if (filters.topology) sp.set('topology', canonicalizeTopologyMode(filters.topology))
   if (filters.drPosture) sp.set('drPosture', filters.drPosture)
   const qs = sp.toString()
   return qs ? `${API_BASE}/v1/fleet/applications?${qs}` : `${API_BASE}/v1/fleet/applications`

--- a/products/catalyst/bootstrap/ui/src/lib/useFleet.test.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/useFleet.test.ts
@@ -21,6 +21,7 @@ import type {
   SovereignDetail,
   ApplicationsResponse,
 } from './fleet.api'
+import { canonicalizeTopologyMode } from './fleet.api'
 
 function makeWrapper() {
   const qc = new QueryClient({
@@ -204,6 +205,9 @@ describe('useFleetApplications', () => {
       () =>
         useFleetApplications({
           org: 'acme',
+          // #3375 §3(f) — a legacy-dialect input is canonicalised on the
+          // wire so it matches the backend's canonical vocabulary instead
+          // of silently filtering nothing.
           topology: 'active-hotstandby',
           drPosture: 'DR active',
         }),
@@ -211,9 +215,47 @@ describe('useFleetApplications', () => {
     )
     await waitFor(() => expect(result.current.data).toBeDefined())
     expect(lastURL).toContain('org=acme')
-    expect(lastURL).toContain('topology=active-hotstandby')
+    // The legacy `active-hotstandby` dialect is posted as the canonical
+    // `active-hot-standby` (URL-encoded), never raw.
+    expect(lastURL).toContain('topology=active-hot-standby')
+    expect(lastURL).not.toContain('topology=active-hotstandby')
     // 'DR active' contains a space — encoded as DR+active or DR%20active.
     expect(/(DR\+active|DR%20active)/.test(lastURL)).toBe(true)
     expect(result.current.data?.total).toBe(1)
+  })
+
+  // #3375 §3(f) — an already-canonical topology filter passes through
+  // unchanged (no double-mangling).
+  it('passes a canonical topology filter through unchanged', async () => {
+    let lastURL = ''
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      lastURL = String(url)
+      return jsonResponse({ ...SAMPLE_APPS, total: 1, applications: [SAMPLE_APPS.applications[1]] })
+    }) as never
+    const { result } = renderHook(
+      () => useFleetApplications({ topology: 'active-hot-standby' }),
+      { wrapper: makeWrapper() },
+    )
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(lastURL).toContain('topology=active-hot-standby')
+  })
+})
+
+// #3375 §3(f) — the one-vocabulary canonicaliser. BOTH the legacy editor
+// dialect and the canonical vocabulary map onto the single canonical
+// token the backend validates.
+describe('canonicalizeTopologyMode', () => {
+  it('maps the legacy editor dialect to canonical', () => {
+    expect(canonicalizeTopologyMode('single-region')).toBe('singleton')
+    expect(canonicalizeTopologyMode('active-hotstandby')).toBe('active-hot-standby')
+  })
+  it('passes already-canonical values through unchanged', () => {
+    expect(canonicalizeTopologyMode('singleton')).toBe('singleton')
+    expect(canonicalizeTopologyMode('active-hot-standby')).toBe('active-hot-standby')
+    expect(canonicalizeTopologyMode('active-active')).toBe('active-active')
+    expect(canonicalizeTopologyMode('active-passive')).toBe('active-passive')
+  })
+  it('is case- and whitespace-insensitive', () => {
+    expect(canonicalizeTopologyMode('  Active-HotStandby ')).toBe('active-hot-standby')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/dashboard/CrossSovereignView.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/dashboard/CrossSovereignView.test.tsx
@@ -152,11 +152,13 @@ describe('CrossSovereignView — filters', () => {
     }) as never
     renderPage()
     await waitFor(() => expect(screen.getByTestId('cross-sov-filter-topology')).toBeTruthy())
+    // #3375 §3(f) — the filter now offers + posts the CANONICAL vocabulary
+    // (active-hot-standby), not the legacy editor dialect.
     fireEvent.change(screen.getByTestId('cross-sov-filter-topology'), {
-      target: { value: 'active-hotstandby' },
+      target: { value: 'active-hot-standby' },
     })
     await waitFor(() =>
-      expect(calls.some((u) => u.includes('topology=active-hotstandby'))).toBe(true),
+      expect(calls.some((u) => u.includes('topology=active-hot-standby'))).toBe(true),
     )
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/dashboard/CrossSovereignView.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/dashboard/CrossSovereignView.tsx
@@ -42,11 +42,16 @@ import {
 } from '@/lib/fleet.api'
 import { useFleetApplications } from '@/lib/useFleet'
 
+// #3375 §3(f) / DoD-1 — the filter offers all FOUR canonical topology
+// classes and posts the CANONICAL vocabulary the backend validates
+// (singleton / active-active / active-hot-standby / active-passive),
+// never the legacy editor dialect (single-region / active-hotstandby).
 const TOPOLOGY_OPTIONS: Array<{ value: '' | TopologyMode; label: string }> = [
   { value: '', label: 'All topologies' },
-  { value: 'single-region', label: 'Single region' },
+  { value: 'singleton', label: 'Singleton' },
   { value: 'active-active', label: 'Active-Active' },
-  { value: 'active-hotstandby', label: 'Active-Hotstandby' },
+  { value: 'active-hot-standby', label: 'Active-Hot-Standby' },
+  { value: 'active-passive', label: 'Active-Passive' },
 ]
 
 const DR_OPTIONS: Array<{ value: '' | DRPosture; label: string }> = [

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.tsx
@@ -62,13 +62,22 @@ export interface TopologyEditorProps {
 }
 
 /**
- * ALL_MODES — the canonical topology-mode option set for the placement
- * picker. Exported (#3599, EPIC #3597) so the create-from-catalog
- * placement step reuses the SAME option set the post-create Topology
- * editor offers, instead of reinventing it. Editor dialect:
- * `single-region` / `active-active` / `active-hotstandby`.
+ * ALL_MODES — the topology-mode option set for the placement picker.
+ * Exported (#3599, EPIC #3597) so the create-from-catalog placement step
+ * reuses the SAME option set the post-create Topology editor offers,
+ * instead of reinventing it.
+ *
+ * #3375 §3(d) — the editor must be able to SELECT all FOUR canonical
+ * classes. It previously offered only `single-region` / `active-active`
+ * / `active-hotstandby`, so `active-passive` could never be chosen even
+ * for a blueprint that supports it (a `supported`-vs-editable
+ * contradiction). `single-region` is the editor's spelling of the
+ * canonical `singleton` (canonicalizeMode maps them together), so the
+ * fourth class — `active-passive` — is added here. The
+ * `allowedModes`/`supportedCanonical` gate still hides any class the
+ * blueprint doesn't declare; this only makes the option REPRESENTABLE.
  */
-export const ALL_MODES = ['single-region', 'active-active', 'active-hotstandby'] as const
+export const ALL_MODES = ['single-region', 'active-active', 'active-hotstandby', 'active-passive'] as const
 
 export type TopologyMode = (typeof ALL_MODES)[number]
 
@@ -149,7 +158,12 @@ export function TopologyEditor({
   // Compute whether the proposed change is destructive (regions drop or
   // mode collapse) — surfaces the force-confirm UI client-side.
   const requiresForce = useMemo(() => {
-    if (mode === 'single-region' && (currentMode === 'active-active' || currentMode === 'active-hotstandby')) {
+    if (
+      mode === 'single-region' &&
+      (currentMode === 'active-active' ||
+        currentMode === 'active-hotstandby' ||
+        currentMode === 'active-passive')
+    ) {
       return true
     }
     if (regions.length < currentRegions.length) {
@@ -390,6 +404,8 @@ export function describeMode(mode: string): string {
       return 'every region serves traffic; horizontal scaling'
     case 'active-hotstandby':
       return 'primary serves; standby ready for switchover'
+    case 'active-passive':
+      return 'primary serves; passive cold/warm standby (backup-restore)'
     default:
       return ''
   }


### PR DESCRIPTION
Refs #3375 — the **foundational, correct, mergeable control-plane spine** for "TOPOLOGY/DR one canonical vocabulary, end-to-end". Pure-code, fully `-race`-tested vertical that the remaining chart + live-walk work builds on. Does **not** claim the live region-kill (DoD-9) or chart wiring (DoD-8); those are enumerated as follow-on in the walkthrough.

## What this delivers (5 coherent pieces on the one DR axis)

### 1. Generic stateless promoter — makes "DNS-flip only" REAL (DoD-5)
`core/controllers/continuum/internal/switchover/promoter.go` + `sequence.go`: a new `stateless` `Mechanism`/`Promoter` whose two state-store steps (cordon=2, promote=6) are genuine no-ops — the five mechanism-agnostic steps (lease/drain/dns/swap/audit) already carry the whole switchover. `Validate()` accepts it with **no** cnpg-pair / raft backing. **Zero app-name literal** — the same engine drives sso-bridge, livekit, vllm, and any future stateless blueprint. Closes §3(a) "the 'DNS-flip only' mechanism does not exist as code".

### 2. One placement model — `replicas:0` on the fanned-out passive HR (DoD-2)
`core/controllers/application/internal/render/fanout.go`: the topology fan-out — the **SOLE** model — now overlays `replicas:0` + `_openova_standby:true` onto a **passive** cluster's HR `spec.values`, instead of rendering it byte-identical to the active HR while a parallel `placement.Resolve` path computed the scale (the latent divergence §3(b) catalogued). `int64` so the unstructured dynamic-client write path deep-copies cleanly.

### 3. Standby-region integrity gate — refuses a half-built topology (DoD-7)
`provisioner.go` `DeclaredDRStandbyIntegrity` (pure, generic) wired into `phase1_watch.go markPhase1Done`: an otherwise-`ready` active-hot-standby deployment whose standby region never came up is downgraded to **`failed` / `standby-region-absent`** — the DR sibling of the "did not PUT kubeconfig" primary failure (the exact hw150 lying-flag, §3(e)). Keys on `bcpTopology` + region counts (**no app-name literal**); a slow-but-present secondary still has a watcher so it is **not** tripped (the deliberate surface-not-gate path for slow secondaries is preserved). Additive to the tofu-apply-time partial-region post-condition (#2840).

### 4. Decorative `replication.backend` enforcement (§5.3)
`core/controllers/blueprint/internal/validate/validate.go`: flags a `replication.backend` that names a cross-region state store (`cnpg-pair`, …) when the blueprint neither binds a `backingServices[]` nor is itself a data-instance provider (`shareable`/`producesInstances`/`contextSchema`) — the grafana decorative-`cnpg-pair` hole. Advisory finding (surfaced on `status.conditions`, the established gradient — does not break the 18 blueprints' publication), generic, name-free. Becomes the hard gate once the per-app pair producer lands.

### 5. One vocabulary at the UI post sites (DoD-1, §3(d)/§3(f))
- `fleet.api.ts`: `TopologyMode` is now the canonical 4-class set; a new `canonicalizeTopologyMode` routes every topology post site through the one vocabulary (the fleet filter URL + the CrossSovereign picker), so a legacy `active-hotstandby` no longer silently filters nothing.
- `TopologyEditor.tsx`: `ALL_MODES` now offers **`active-passive`** — the editor literally could not select it before (`single-region` is the editor's spelling of `singleton`, so all 4 canonical classes are now representable).
- `CrossSovereignView.tsx`: the topology filter offers + posts the canonical vocabulary.

## Gates (all green)
- `cd core/controllers && go build ./... && go test -race ./continuum/internal/switchover/... ./application/internal/render/... ./blueprint/internal/validate/...`
- `cd products/catalyst/bootstrap/api && go build ./... && go test ./internal/provisioner/ ./internal/handler/`
- `cd products/catalyst/bootstrap/ui && npm run build` (tsc + vite) + `vitest` on the touched specs (21/21)

New tests: `stateless_test.go` (6, incl. generality + no-op proofs), `dr_standby_integrity_test.go`, `phase1_dr_integrity_test.go`, plus golden/validator cases in `fanout_test.go` / `validate_test.go` and UI cases in `useFleet.test.ts` / `CrossSovereignView.test.tsx`. The pre-existing UI test failures (`PinInput6`, `ProvisionPage.sse-url`, `Dashboard`, `JobsPage.flow-merge`, `ResourceDetailPage` — confirmed failing on a clean stash of `origin/main`) are unrelated to this change.

## Explicitly NOT in this PR (enumerated in the walkthrough as follow-on)
- **DoD-3/4** — the application-controller minting one `Continuum` CR per DR-capable Application + the journey building the per-app 2-region cnpg-pair. The spine makes the engine *able* to drive these; the producer is the next increment.
- **DoD-6** — the `TopologyTab.tsx` live-DR gate (meaningful only once DoD-3 produces per-app Continuum CRs to read).
- **DoD-8** — cross-region chart wiring (`<instance>-mesh-rw`, openbao S3 cred mirror, guacd emptyDir).
- **DoD-9** — the live region-kill within RTO/RPO on a healthy 2-region prov.

Consumes the **#3687** Application-CR write spine (does not rebuild it); respects §11 Excluded (cutover #3379, jobs canvas #3646, region-B datapath #2745). Walkthrough: `docs/ledger/uat-walkthrough/topology-dr-one-vocabulary-built-and-region-kill-proven.md`.

Do NOT merge — opening for founder review against the DoD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)