### PR TITLE
fix(cutover): durable revert-immune cutoverComplete + true deny-egress proof — bp-self-sovereign-cutover 0.1.74 (Refs #3379)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -545,7 +545,7 @@ spec:
       # so cutoverComplete never flipped. Fixed with POSIX `grep -vxF -f` on the
       # writable /work emptyDir. Found auditing the never-run steps 08-11 to
       # pre-empt hw147's cutover wedge. Chart-only.
-      version: 0.1.73
+      version: 0.1.74
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/docs/ledger/UAT.md
+++ b/docs/ledger/UAT.md
@@ -38,7 +38,8 @@
 | **SSO** (#3374) | ✅ — handover + grafana + harbor + openbao + gitea land signed-in zero-click; Open buttons (Q6) present | [3374-sso.md](uat-walkthrough/3374-sso.md) |
 | **Topology Q1 / Q2** (#3375) | ✅ — 3 active-hotstandby cards; Q1 declared-singleton honesty render; Q2 truly-editable Topology picker | [3375-topology-dr.md](uat-walkthrough/3375-topology-dr.md) |
 | **Region-kill** (#3375 / NS#4) | ✅ — live kill→promote driven on hw144: region-a killed → region-b promoted RTO ≈ 4s → consumer keycloak data identical (RPO = 0) | [3375-topology-dr.md](uat-walkthrough/3375-topology-dr.md) |
-| **Cutover** (#3379) | ⏳ PENDING — `cutoverComplete=true` + the 600s deny-egress hold walk on hw144 not yet witnessed this session | [3379-cutover.md](uat-walkthrough/3379-cutover.md) · [3379-sovereignty.md](uat-walkthrough/3379-sovereignty.md) |
+| **Cutover** (#3379) | ⏳ PENDING — `cutoverComplete=true` + the 600s deny-egress hold walk not yet witnessed this session | [3379-cutover.md](uat-walkthrough/3379-cutover.md) · [3379-sovereignty.md](uat-walkthrough/3379-sovereignty.md) |
+| **Cutover PROOF integrity** (#3379 — durable fact · true deny-egress · faithful pivot · audit fidelity · host-loop) | ⏳ PENDING live-walk — chart `bp-self-sovereign-cutover` 0.1.74 built + unit/render/POSIX-verified; the five faces (the seal survives a chart upgrade & doesn't re-fire the hold; default-deny CCNP blocks console.openova.io; registriesYamlActive=v2 + per-node ack; cutoverStartedAt written-once; bootstrap-kit Ready + zero residual tether) are walkable per the linked doc | [cutover-durable-true-deny-egress-and-faithful-pivot.md](uat-walkthrough/cutover-durable-true-deny-egress-and-faithful-pivot.md) |
 
 **Honesty line:** the **region-kill EXECUTION** (NS#4) is now **✅** — the live kill→promote walk ran
 on hw144 (RTO ≈ 4s, RPO = 0). The one remaining open item on hw144 is the **Pillar-5 cutover** (the

--- a/docs/ledger/uat-walkthrough/cutover-durable-true-deny-egress-and-faithful-pivot.md
+++ b/docs/ledger/uat-walkthrough/cutover-durable-true-deny-egress-and-faithful-pivot.md
@@ -1,0 +1,108 @@
+# #3379 — Cutover PROOF integrity: durable fact · true deny-egress · faithful pivot · audit fidelity · host-loop + zero residual
+
+> **Scope:** this walkthrough proves the INTEGRITY, DURABILITY, and BREADTH of the cutover sovereignty
+> proof — NOT that the 11 steps run (that is the predecessor #3379 scope, already green on hw150). Every
+> row is `Go-to | do | see | ☐`. Ships against `bp-self-sovereign-cutover` chart **0.1.74** + catalyst-api.
+>
+> **What changed (the five faces):**
+> 1. **#3667 durable fact** — `cutoverComplete=true` is sealed in OpenBao (`secret/catalyst/cutover-complete`),
+>    a chart upgrade can no longer revert the flag or re-fire the 600s hold (status ConfigMap is init-only).
+> 2. **#3671 faithful pivot** — the engine flips `registriesYamlActive=v2` after `harbor-prewarm`; the
+>    registry-pivot DaemonSet writes a per-node v2 ack which step-04 COUNTS; the run REFUSES
+>    `cutoverComplete=true` while the key is still `v1`.
+> 3. **#3678 true deny-egress** — the 600s-hold CCNP is a TRUE default-deny (enableDefaultDeny.egress:true
+>    + intra-cluster allow-list) instead of a subtractive 4-CIDR block; an active call-home assertion FAILS
+>    the proof if `console.openova.io` (or any mothership host) is reachable from a pod under the hold.
+> 4. **#3681 audit fidelity** — `cutoverStartedAt` is written ONCE (true first run); resume/re-fire advance a
+>    separate `cutoverLastAttemptStartedAt`.
+> 5. **#3695 host loop + zero residual** — step-10's sso-bridge override MERGES with yq into the existing
+>    `values:` (no duplicate-key BuildFailed); step-08 HARD-gates on bootstrap-kit/sovereign-tls/sme-tenants
+>    Ready and rolls EVERY external-registry workload under deny-egress.
+
+## Section 0 — pre-state (reproduce the hw150 defects on the OLD chart, then confirm fixed)
+
+| Go to | Do | See | ☐ |
+|---|---|---|---|
+| terminal (any cutover-complete env on OLD chart ≤0.1.73) | `kubectl get cm self-sovereign-cutover-status -n catalyst -o jsonpath='{.data.cutoverComplete}'` then `helm upgrade bp-self-sovereign-cutover ...` (or `flux reconcile hr bp-self-sovereign-cutover --with-source`) | OLD: flag reverts to `false`, the auto-trigger Job re-fires the whole cutover incl. the 600s hold | ☐ |
+| terminal | `kubectl get cm self-sovereign-cutover-status -n catalyst -o jsonpath='{.data.registriesYamlActive}'` | OLD: `v1` on a `cutoverComplete=true` cluster (node containerd still on mothership Harbor) | ☐ |
+| terminal | `kubectl get ccnp cutover-egress-block -o yaml` during a hold | OLD: `enableDefaultDeny.egress:false` + 4-entry `egressDeny.toCIDRSet` (subtractive; console.openova.io reachable) | ☐ |
+| terminal | `kubectl get kustomization -n flux-system bootstrap-kit` | OLD: `BuildFailed` — `mapping key "values" already defined` (duplicate from step-10 awk injector) | ☐ |
+
+## Section 1 — Durability (#3667): a chart upgrade cannot un-prove or re-fire
+
+| Go to | Do | See | ☐ |
+|---|---|---|---|
+| terminal (fresh prov, chart 0.1.74, after cutover reached `cutoverComplete=true`) | `kubectl get secret cutover-complete -n catalyst` (note: stored via OpenBao KV at `secret/catalyst/cutover-complete`) → and read it: `kubectl exec -n openbao <bao-pod> -- bao kv get secret/catalyst/cutover-complete` | the durable seal EXISTS — `cutoverComplete:"true"`, `cutoverStartedAt`, `cutoverFinishedAt`, `sealedAt` | ☐ |
+| terminal | capture the run-epoch Jobs: `kubectl get jobs -n catalyst -l cutover.openova.io/run-epoch -o name | sort > /tmp/before.txt` | a fixed set of completed cutover Jobs | ☐ |
+| terminal | `flux reconcile hr bp-self-sovereign-cutover -n flux-system --with-source` (simulates a routine chart-pin reconcile) | HR reconciles green; the status ConfigMap is NOT re-authored (init-only `lookup` guard) | ☐ |
+| terminal | `kubectl get cm self-sovereign-cutover-status -n catalyst -o jsonpath='{.data.cutoverComplete}'` | STILL `true` (or re-derived true within one reconcile from the seal) | ☐ |
+| terminal | `kubectl get jobs -n catalyst -l cutover.openova.io/run-epoch -o name | sort > /tmp/after.txt; diff /tmp/before.txt /tmp/after.txt` | EMPTY diff — NO new run-epoch Jobs, the 600s hold did NOT re-fire | ☐ |
+| terminal | `kubectl get ccnp cutover-egress-block` | `NotFound` — no fresh deny-egress hold was armed | ☐ |
+| terminal | `kubectl rollout restart deploy/catalyst-api -n catalyst-system; kubectl logs -n catalyst-system deploy/catalyst-api | grep cutover-resume` | log: "already complete (sealed); … fired nothing" — resume hook no-ops on the seal | ☐ |
+| browser | open `console.<fqdn>` → admin → Sovereignty card | still "Sovereign" badge + NO "Achieve True Sovereignty" CTA (backend backfills cutoverComplete=true from the seal even if the CM was reverted) | ☐ |
+
+## Section 2 — Faithful pivot (#3671): containerd actually flips, step-04 verifies per node
+
+| Go to | Do | See | ☐ |
+|---|---|---|---|
+| terminal (fresh cutover, chart 0.1.74) | `kubectl get cm self-sovereign-cutover-status -n catalyst -o jsonpath='{.data.registriesYamlActive}'` | `v2` (the engine flipped it after harbor-prewarm) | ☐ |
+| terminal | `kubectl get cm self-sovereign-cutover-status -n catalyst -o json | jq -r '.data | to_entries[] | select(.key|startswith("node.")) | "\(.key)=\(.value)"'` | one `node.<name>.registriesYaml=v2` per node — acks == node count (step-04 counted these) | ☐ |
+| terminal | `kubectl debug node/<node> -it --image=busybox -- cat /host/etc/rancher/k3s/registries.yaml` | upstreams rewritten to `harbor.<fqdn>/v2/proxy-*` (NOT `harbor.openova.io`) | ☐ |
+| terminal | with mothership egress denied, roll a NON-openova image: `kubectl run dockerhub-probe --image=docker.io/library/busybox:1.36 -- sleep 30; kubectl get pod dockerhub-probe -w` | reaches `Running` — `docker.io` pull resolved through LOCAL Harbor (proves the certs.d mirror, not just the openova path #3647 masked) | ☐ |
+| terminal (NEGATIVE) | on a scratch prov, leave one node at v1 (skip its ack) → re-run cutover | step-04 does NOT green; the run reports `failedStep=registry-pivot` and `cutoverComplete` stays false | ☐ |
+
+## Section 3 — True deny-egress (#3678): block EVERY mothership tether, not 4 CIDRs
+
+| Go to | Do | See | ☐ |
+|---|---|---|---|
+| terminal (during the 600s hold of a fresh cutover) | `kubectl get ccnp cutover-egress-block -o yaml` | `enableDefaultDeny.egress: true` + an `egress:` allow-list (toCIDR 10.42/10.43/10.96 + toEntities kube-apiserver/host/remote-node/cluster + DNS toPorts) — NOT a 4-entry `egressDeny.toCIDRSet` | ☐ |
+| terminal | exec a pod under the policy: `kubectl exec -n <ns> <pod> -- curl -m5 https://console.openova.io/healthz; echo "exit=$?"` | FAILS to connect (exit non-zero / http_code 000) — the mothership front door is black-holed | ☐ |
+| terminal | same pod: `kubectl exec -n <ns> <pod> -- curl -m5 -k https://kubernetes.default/healthz; echo "exit=$?"` | SUCCEEDS — no #3640 apiserver-strand (allow-list keeps 10.96.0.1 reachable) | ☐ |
+| terminal | step-08 log: `kubectl logs -n catalyst job/<egress-block-test-job> | grep -A6 'active call-home'` | each mothership host logged "OK — … unreachable (… http_code=000) — denied as required"; final "PASS — every mothership host black-holed" | ☐ |
+| terminal | `kubectl get secret ghcr-pull -n flux-system -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d | jq '.auths | keys'` | keys `registry.<fqdn>` / `harbor.<fqdn>` — NOT `ghcr.io` | ☐ |
+| terminal (NEGATIVE, GENERALITY) | on a scratch prov inject a synthetic tether (`CATALYST_PIN_ISSUER=https://console.openova.io`) then run cutover | step-08 call-home FAILS → `cutoverComplete` stays false — proves the proof catches an ARBITRARY mothership tether, not the 4 enumerated hosts | ☐ |
+
+## Section 4 — Audit fidelity (#3681): the durable start-time is not corrupted on resume
+
+| Go to | Do | See | ☐ |
+|---|---|---|---|
+| terminal (a cutover that experienced a mid-run catalyst-api restart) | `kubectl get cm self-sovereign-cutover-status -n catalyst -o json | jq -r '.data | {cutoverStartedAt, cutoverLastAttemptStartedAt, "first_step_start": ."step.gitea-mirror.startedAt"}'` | `cutoverStartedAt` ≈ the EARLIEST `step.*.startedAt` (within seconds), NOT the resume moment | ☐ |
+| terminal | compare `cutoverLastAttemptStartedAt` | equals the restart/resume moment (the latest attempt) | ☐ |
+| terminal (unit) | `cd products/catalyst/bootstrap/api && go test -race -run TestRunCutover_StartedAtWrittenOnceAcrossResume ./internal/handler/` | PASS — two `runCutover` calls leave `cutoverStartedAt` byte-identical while the attempt field advances | ☐ |
+| browser | Sovereignty card | "Started <true-first-run-time>" + elapsed reflects the REAL full run (not the 11-min fiction hw150 showed) | ☐ |
+
+## Section 5 — Host GitOps loop + zero residual tether (#3695)
+
+| Go to | Do | See | ☐ |
+|---|---|---|---|
+| terminal (fresh prov to `cutoverComplete=true`, chart 0.1.74) | `kubectl get kustomization -n flux-system bootstrap-kit sovereign-tls sme-tenants` | all `Ready=True` at the post-cutover revision (NOT BuildFailed) | ☐ |
+| terminal | `kubectl get pods -A -o jsonpath='{range .items[*]}{range .spec.containers[*]}{.image}{"\n"}{end}{end}' | grep -E 'harbor.openova.io|ghcr.io/openova-io|github.com/openova' | sort -u` | EMPTY — no live Pod pulls from a mothership registry | ☐ |
+| terminal | `kubectl get hr -n flux-system bp-sso-bridge -o jsonpath='{.spec.values}'` then `kubectl get pods -n sso-bridge -o jsonpath='{.items[*].spec.containers[*].image}'` | `global.registryMirror=harbor.<fqdn>`; sso-bridge-reconciler image is `harbor.<fqdn>/...` (NOT harbor.openova.io) | ☐ |
+| terminal | push a trivial commit to local Gitea (`openova/openova`) → `flux reconcile source git openova -n flux-system` | `bootstrap-kit` `lastAppliedRevision` advances — the host loop reconciles local git | ☐ |
+| terminal (idempotency) | re-run cutover → `git show` the local Gitea `clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml` | exactly ONE `values:` key under the HelmRelease spec; no BuildFailed | ☐ |
+| terminal | step-08 log: `kubectl logs -n catalyst job/<egress-block-test-job> | grep -E 'host GitOps loop|external-registry workload'` | "host GitOps loop healthy"; "every external-registry workload rolled to Running pulling from the local registry under deny-egress" | ☐ |
+| terminal (NEGATIVE, GENERALITY) | leave one HR on `harbor.openova.io` → run cutover | the fresh-pull loop rolls EVERY external-registry workload; that one `ImagePullBackOff`s → proof FAILS → `cutoverComplete` stays false | ☐ |
+
+## Section 6 — End-to-end (downstream confirmation)
+
+| Go to | Do | See | ☐ |
+|---|---|---|---|
+| browser (post-cutover) | create an Organization in the console | namespace + vcluster materialize via the (now-healthy) host Flux loop — ZERO mothership dependency | ☐ |
+| browser | recipient redeems a voucher → lands on their tenant home | works with the 3 mothership hosts black-holed at the firewall | ☐ |
+| terminal | operator black-holes `console.openova.io` + `ghcr.io` + `harbor.openova.io` at the firewall | the Sovereign keeps reconciling + serving | ☐ |
+
+## Appendix A — automated guards (NOT acceptance; acceptance is the founder walking Sections 1-6)
+
+| Check | Command | Expected |
+|---|---|---|
+| Go unit + race (the new tests) | `cd products/catalyst/bootstrap/api && go test -race ./internal/handler/` | ok |
+| Durable-fact + invariant + audit tests | `go test -race -run 'TestResumeInterruptedCutover_NoOpWhenSealedDespiteRevertedCM|TestSpawnCutoverEngine_NoOpWhenSealedDespiteRevertedCM|TestRunCutover_SealsDurableFactOnSuccess|TestHandleCutoverStatus_BackfillsFromSeal|TestRunCutover_RefusesCompleteWhenRegistriesYamlV1|TestRunCutover_FlipsRegistriesYamlV2AfterHarborPrewarm|TestRunCutover_StartedAtWrittenOnceAcrossResume' ./internal/handler/` | ok |
+| Chart render + lint | `helm lint platform/self-sovereign-cutover/chart && helm template ssc platform/self-sovereign-cutover/chart --set sovereign.fqdn=hw151.omantel.biz` | 0 failures |
+| Embedded shell scripts POSIX-safe | `dash -n` each step's podSpec args + pivot.sh (busybox-ash parity) | all OK |
+| Default-deny CCNP shape | render step-08 default-deny branch | valid CCNP: `enableDefaultDeny.egress:true` + allow `egress:` rules, NO `egressDeny.toCIDRSet` |
+| Catalog-seed lockstep | `bash scripts/check-catalog-seed-lockstep.sh` | PASS |
+
+---
+
+**Status:** chart `bp-self-sovereign-cutover` **0.1.74** + catalyst-api (`Refs #3379`). Built + unit/render/POSIX-verified.
+The live founder-walk of Sections 1-6 on a fresh prov to `cutoverComplete=true` is the acceptance gate — PENDING that prov.

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.73
+  version: 0.1.74
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -854,7 +854,27 @@ name: bp-self-sovereign-cutover
 # FATAL-on-failure contract is PRESERVED (Pillar 5 requires ALL openova-io
 # images local for the deny-egress hold) — the step only FATALs once BOTH retry
 # layers are exhausted. No step-count / RBAC / timeout change.
-version: 0.1.73
+#
+# 0.1.74 (#3379 — cutover-PROOF integrity, the five faces): (1) #3667 — the
+# status ConfigMap is now INIT-ONLY (lookup guard) so a `helm upgrade` never
+# re-asserts cutoverComplete:"false"/registriesYamlActive:"v1" over the live
+# values and can no longer re-fire the 600s hold; the durable fact is sealed
+# by catalyst-api in OpenBao (secret/catalyst/cutover-complete). (2) #3671 —
+# step-04 registry-pivot DaemonSet writes a per-node v2 ack
+# (node.<name>.registriesYaml) which step-04's daemonset-wait now COUNTS
+# (acks == DesiredNumberScheduled), so a node held at v1 fails the cutover. (3)
+# #3678 — step-08's CCNP is now a TRUE default-deny egress (enableDefaultDeny.
+# egress:true + intra-cluster allow-list 10.42/10.43/10.96 + DNS/apiserver/host/
+# remote-node entities) instead of a subtractive 4-CIDR block, plus an ACTIVE
+# call-home assertion that fails the proof if console.openova.io (or any
+# blockedDomains host) is reachable from a pod under the hold. (4) #3695 —
+# step-10's sso-bridge image override is MERGED with yq into the EXISTING
+# values: mapping (no more duplicate-key BuildFailed that killed bootstrap-kit),
+# host-less so global.registryMirror stays the single source of truth; step-08
+# now HARD-gates on bootstrap-kit + sovereign-tls + sme-tenants Ready and rolls
+# EVERY external-registry workload under deny-egress (not one hand-picked).
+# RBAC adds daemonsets/statefulsets {update,patch} for the generalized roll.
+version: 0.1.74
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
@@ -193,6 +193,31 @@ data:
     target=/host/etc/rancher/k3s/registries.yaml
     src_v1=/etc/registry-pivot/registries.yaml.v1
     src_v2=/etc/registry-pivot/registries.yaml.v2
+
+    # #3671: write this node's per-node ack into the status ConfigMap so
+    # catalyst-api's step-04 daemonset-wait can assert acks ==
+    # DesiredNumberScheduled — proving EVERY node actually swapped to the
+    # local-Harbor (v2) file, not merely that the DS Pods are Ready. The
+    # key is node.<NODE_NAME>.registriesYaml. Uses a JSON merge-patch (the
+    # SA already has configmaps patch RBAC via the chart's role). Dots in
+    # the node name are fine — they are part of the ConfigMap DATA KEY, not
+    # a JSONPath. Best-effort: a failed ack just means the wait keeps
+    # polling until the next sweep retries it.
+    write_node_ack() {
+      ack_val="$1"   # "v1" | "v2" | "rollback"
+      ack_key="node.${NODE_NAME}.registriesYaml"
+      patch=$(jq -cn --arg k "${ack_key}" --arg v "${ack_val}" '{data: {($k): $v}}')
+      if curl -fsS -X PATCH \
+        --cacert "${cacert}" \
+        -H "Authorization: Bearer ${token}" \
+        -H "Content-Type: application/merge-patch+json" \
+        --data "${patch}" \
+        "${cm_url}" >/dev/null 2>&1; then
+        echo "[registry-pivot]   acked ${ack_key}=${ack_val}"
+      else
+        echo "[registry-pivot]   WARN failed to ack ${ack_key}=${ack_val} (will retry next sweep)"
+      fi
+    }
     # #3647: the containerd host-mirror dir, mounted from the host. k3s
     # generates these files from registries.yaml at startup and containerd
     # re-reads them per pull, so writing them here makes new pulls hit the
@@ -250,6 +275,8 @@ data:
           # #3647: mirror the pivot into the live containerd host-dir so a
           # pod rolled AFTER cutover pulls from local Harbor, not ghcr.io.
           write_hosts_toml "${harbor_host}"
+          # #3671: ack this node's v2 swap so step-04 can count acks.
+          write_node_ack v2
           ;;
         v1|rollback|*)
           cp "${src_v1}" "${target}.new"
@@ -260,6 +287,8 @@ data:
           # point the live containerd host-dir back at mothership Harbor.
           mothership_host=$(printf '%s' "{{ .Values.upstream.mothershipHarborURL }}" | sed -E 's,^https?://,,; s,/$,,')
           write_hosts_toml "${mothership_host}"
+          # #3671: ack this node back to v1 so a rollback de-counts it.
+          write_node_ack v1
           ;;
       esac
     }

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -69,6 +69,40 @@ data:
             value: {{ eq (toString .Values.egressTest.enforceCIDRBlock) "true" | quote }}
           - name: UPSTREAM_HOSTS
             value: {{ .Values.egressTest.blockedDomains | default (list "github.com" "ghcr.io" "harbor.openova.io") | join " " | quote }}
+          # #3678 — TRUE deny-egress. DEFAULT_DENY_EGRESS=true emits a
+          # default-deny CCNP with an explicit intra-cluster allow-list
+          # (ALLOW_CIDRS) so EVERYTHING public is denied, not just the 4
+          # enumerated tether CIDRs. The apiserver-strand (#3640) is avoided
+          # by the allow-list (10.96/12 covers 10.96.0.1), not by
+          # enableDefaultDeny.egress:false.
+          - name: DEFAULT_DENY_EGRESS
+            value: {{ eq (toString .Values.egressTest.defaultDenyEgress) "true" | quote }}
+          - name: ALLOW_CIDRS
+            value: {{ .Values.egressTest.allowIntraClusterCIDRs | default (list "10.42.0.0/16" "10.43.0.0/16" "10.96.0.0/12") | join " " | quote }}
+          # #3678 — active call-home assertion knobs. During the hold, curl
+          # each CALL_HOME_HOSTS entry FROM this pod (under the policy); any
+          # that connects fails the proof.
+          - name: CALL_HOME_ENABLED
+            value: {{ eq (toString .Values.egressTest.callHomeAssertion.enabled) "true" | quote }}
+          - name: CALL_HOME_TIMEOUT
+            value: {{ .Values.egressTest.callHomeAssertion.timeoutSeconds | default 5 | quote }}
+          - name: CALL_HOME_HOSTS
+            value: {{ .Values.egressTest.callHomeAssertion.hosts | default (list "https://console.openova.io/healthz") | join " " | quote }}
+          # #3695 — host GitOps loop gate. The root bootstrap-kit Kustomization
+          # (+ sovereign-tls + sme-tenants) MUST be Ready=True at the
+          # post-cutover revision or the proof fails BEFORE the window.
+          - name: HOST_KS_GATE_ENABLED
+            value: {{ eq (toString .Values.egressTest.hostKustomizationGate.enabled) "true" | quote }}
+          - name: HOST_KS_NAMESPACE
+            value: {{ .Values.egressTest.hostKustomizationGate.namespace | default "flux-system" | quote }}
+          - name: HOST_KS_NAMES
+            value: {{ .Values.egressTest.hostKustomizationGate.names | default (list "bootstrap-kit") | join " " | quote }}
+          # #3695 — roll EVERY external-registry workload under deny-egress,
+          # not one hand-picked openova-io Deployment.
+          - name: ROLL_ALL_EXTERNAL
+            value: {{ eq (toString .Values.egressTest.rollAllExternalRegistryWorkloads) "true" | quote }}
+          - name: LOCAL_REGISTRY_SUBSTR
+            value: {{ .Values.egressTest.localRegistryHostSubstr | default "harbor." | quote }}
           # #3647 — fresh-pull-under-deny-egress proof knobs. See the
           # FRESH-PULL phase in the script below + values.yaml egressTest.
           # freshPullProof for the full rationale.
@@ -232,28 +266,78 @@ data:
                   esac
                 done
               done
-              if [ -z "${block_ips}" ]; then
+              if [ -z "${block_ips}" ] && [ "${DEFAULT_DENY_EGRESS}" != "true" ]; then
                 echo "  WARN — zero public upstream IPs resolved; assertion-only fallback (fail-safe)"
-              else
+              elif [ "${DEFAULT_DENY_EGRESS}" = "true" ]; then
+                # ── #3678 TRUE DEFAULT-DENY EGRESS ────────────────────────
+                # The PROOF the founder demands: block EVERY mothership
+                # tether, not 4 hand-picked CIDRs. We emit a cluster-wide
+                # default-deny egress policy (enableDefaultDeny.egress:true —
+                # NOT the #3640 retreat to false) with an explicit allow-list
+                # of the Sovereign's OWN intra-cluster ranges. Result: pods
+                # can reach the apiserver (10.96.0.1, inside 10.96/12), CoreDNS,
+                # each other (10.42/16) and node-local services, but EVERY
+                # public destination — console.openova.io, ghcr.io,
+                # harbor.openova.io, and any host nobody enumerated — is
+                # black-holed. The #3640 apiserver-strand is avoided by the
+                # allow-list, not by making the policy subtractive.
+                #
+                # Cilium semantics: a CCNP with endpointSelector:{} and ANY
+                # egress: rule sets enableDefaultDeny.egress=true implicitly,
+                # so listing only the allow `egress:` toCIDR/toEntities rules
+                # denies everything else. We set it explicitly for clarity and
+                # to be robust against future Cilium default changes.
                 {
-                  # CiliumClusterwideNetworkPolicy (NOT namespaced) — a
-                  # namespaced CNP with endpointSelector:{} only covers the
-                  # cutover namespace, missing the cross-namespace tethers
-                  # this proof targets (flux-system source-controller →
-                  # ghcr.io, harbor → upstream). Cluster-wide has no
-                  # metadata.namespace. (reviewer PR #3072)
                   echo "apiVersion: cilium.io/v2"
                   echo "kind: CiliumClusterwideNetworkPolicy"
                   echo "metadata:"
                   echo "  name: cutover-egress-block"
                   echo "spec:"
                   echo "  endpointSelector: {}"
-                  # enableDefaultDeny.egress:false makes egressDeny SUBTRACTIVE (deny ONLY the 4
-                  # tether CIDRs). Cilium otherwise defaults enableDefaultDeny.egress=true for any
-                  # policy carrying egress rules, so endpointSelector:{} would flip EVERY pod into
-                  # default-deny egress with 0 allow rules -> total cluster-wide egress loss:
-                  # apiserver (10.96.0.1), DNS, inter-pod all blocked, the Job's own kubectl times
-                  # out and step-08 never captures the baseline. (#3640, hw148 step-08 wedge)
+                  echo "  enableDefaultDeny:"
+                  echo "    egress: true"
+                  echo "  egress:"
+                  # Allow the Sovereign's own intra-cluster CIDRs (pods,
+                  # services incl. apiserver ClusterIP, node ranges).
+                  echo "    - toCIDR:"
+                  for cidr in ${ALLOW_CIDRS}; do
+                    echo "        - ${cidr}"
+                  done
+                  # Allow control-plane + DNS + node entities so the apiserver
+                  # (also reachable as the `kube-apiserver` entity when it has a
+                  # non-ClusterIP address), CoreDNS, host and remote-node paths
+                  # stay up. `cluster` covers all in-cluster endpoints; `host`
+                  # + `remote-node` cover node-local + other-node kubelet/proxy.
+                  echo "    - toEntities:"
+                  echo "        - kube-apiserver"
+                  echo "        - host"
+                  echo "        - remote-node"
+                  echo "        - cluster"
+                  # Allow DNS explicitly (CoreDNS ClusterIP is inside 10.96/12,
+                  # but make the intent first-class and tolerate non-default
+                  # DNS service CIDRs): UDP/TCP 53 to world, rules-restricted to
+                  # the DNS ports so this is not a general egress hole.
+                  echo "    - toPorts:"
+                  echo "        - ports:"
+                  echo "            - port: \"53\""
+                  echo "              protocol: UDP"
+                  echo "            - port: \"53\""
+                  echo "              protocol: TCP"
+                } >/work/egress-deny.yaml
+              else
+                {
+                  # Legacy SUBTRACTIVE fallback (DEFAULT_DENY_EGRESS=false) —
+                  # kept only for environments that explicitly opt out of the
+                  # true default-deny. Deny ONLY the resolved tether CIDRs.
+                  # NOTE: this shape leaves console.openova.io + any
+                  # un-enumerated mothership host reachable — it is NOT the
+                  # ADR-0002 proof; #3678 makes default-deny the default.
+                  echo "apiVersion: cilium.io/v2"
+                  echo "kind: CiliumClusterwideNetworkPolicy"
+                  echo "metadata:"
+                  echo "  name: cutover-egress-block"
+                  echo "spec:"
+                  echo "  endpointSelector: {}"
                   echo "  enableDefaultDeny:"
                   echo "    egress: false"
                   echo "  egressDeny:"
@@ -385,8 +469,146 @@ data:
               return 1
             }
 
+            # ── #3695/#3379 §7 GENERALIZED FRESH-PULL ─────────────────────
+            # Roll EVERY workload (Deployment/DaemonSet/StatefulSet, any ns)
+            # whose image host is NOT the local registry, under deny-egress —
+            # not one hand-picked openova-io Deployment. Any that ImagePull-
+            # BackOffs FAILS the proof. This is the cross-cutting guarantee:
+            # the gate is generic across ALL workloads/HRs, so leaving ANY one
+            # on harbor.openova.io / ghcr.io/openova-io fails the proof. We
+            # roll via `kubectl rollout restart` then `rollout status` with a
+            # bounded timeout, and explicitly scan the new Pods for image-pull
+            # errors (rollout status alone would just time out on a BackOff).
+            roll_and_check_workload() {
+              kind="$1"; ns="$2"; name="$3"
+              echo "  rolling ${kind}/${name} -n ${ns} (forces fresh pull from local registry)"
+              kubectl rollout restart "${kind}/${name}" -n "${ns}" >/dev/null 2>&1 || true
+              # Bounded wait; rollout status returns non-zero on timeout.
+              if kubectl rollout status "${kind}/${name}" -n "${ns}" --timeout="${FRESH_PULL_TIMEOUT}s" >/dev/null 2>&1; then
+                echo "    PASS — ${kind}/${name} rolled out (images pulled from local registry under deny-egress)"
+                return 0
+              fi
+              # Timed out — surface WHY. An image-pull error on any Pod of this
+              # workload is the inert-mirror / residual-tether failure (#3695).
+              sel=$(kubectl get "${kind}" "${name}" -n "${ns}" -o json 2>/dev/null \
+                | jq -r '.spec.selector.matchLabels | to_entries | map("\(.key)=\(.value)") | join(",")' 2>/dev/null || true)
+              reasons=""
+              if [ -n "${sel}" ]; then
+                reasons=$(kubectl get pods -n "${ns}" -l "${sel}" \
+                  -o jsonpath='{range .items[*]}{range .status.containerStatuses[*]}{.state.waiting.reason}{" "}{end}{range .status.initContainerStatuses[*]}{.state.waiting.reason}{" "}{end}{end}' 2>/dev/null || echo "")
+              fi
+              case "${reasons}" in
+                *ImagePullBackOff*|*ErrImagePull*)
+                  echo "    FAIL — ${kind}/${name} has a Pod in image-pull error under deny-egress (${reasons}); residual external-registry tether or inert mirror (#3695)"
+                  return 1 ;;
+              esac
+              echo "    FAIL — ${kind}/${name} did not roll out within ${FRESH_PULL_TIMEOUT}s under deny-egress (reasons:${reasons:-<none>})"
+              return 1
+            }
+
+            run_fresh_pull_all() {
+              echo "[egress-block-test] #3695: rolling EVERY external-registry workload under deny-egress"
+              # Enumerate Deployments/DaemonSets/StatefulSets whose container
+              # images reference a host that is NOT the local registry. The
+              # local registry is identified by LOCAL_REGISTRY_SUBSTR
+              # (harbor.<fqdn>). We also exclude the cutover runner's own
+              # catalyst-api (FRESH_PULL_EXCLUDE) so the engine is never bounced
+              # mid-hold. Rows look like "kind ns name=img1,img2".
+              workloads=$(
+                for kind in deployments daemonsets statefulsets; do
+                  kubectl get "${kind}" -A \
+                    -o jsonpath="{range .items[*]}${kind%s} {.metadata.namespace} {.metadata.name}={.spec.template.spec.containers[*].image} {.spec.template.spec.initContainers[*].image}{\"\n\"}{end}" 2>/dev/null
+                done
+              )
+              # Keep rows whose image list contains a NON-local registry host.
+              # A bare image (docker-library short form) or a localhost/local
+              # Harbor ref is NOT a tether. We treat any image containing a
+              # dotted host (registry) that does NOT include LOCAL_REGISTRY_SUBSTR
+              # as external.
+              targets=$(printf '%s\n' "${workloads}" \
+                | grep -E '=[^ ]*[a-z0-9.-]+\.[a-z]+/' \
+                | grep -vE "[=, ]${LOCAL_REGISTRY_SUBSTR}" \
+                | { [ -n "${FRESH_PULL_EXCLUDE}" ] && grep -vE " ${FRESH_PULL_EXCLUDE}[^ ]*=" || cat; } \
+                || true)
+              if [ -z "${targets}" ]; then
+                echo "  no external-registry workloads found — every workload already pulls from the local registry (PASS)"
+                return 0
+              fi
+              echo "  external-registry workloads to roll:"
+              printf '%s\n' "${targets}" | sed 's/^/    /'
+              rc=0
+              # Roll each; collect the first failure but attempt all so the log
+              # lists every offender.
+              printf '%s\n' "${targets}" | while IFS= read -r row; do
+                [ -z "${row}" ] && continue
+                kind=$(printf '%s' "${row}" | awk '{print $1}')
+                ns=$(printf '%s' "${row}" | awk '{print $2}')
+                name=$(printf '%s' "${row}" | awk '{print $3}' | cut -d= -f1)
+                roll_and_check_workload "${kind}" "${ns}" "${name}" || echo "ROLL_FAIL ${kind}/${name}" >> /work/roll_failures.txt
+              done
+              if [ -s /work/roll_failures.txt ]; then
+                echo "  FAIL — external-registry workload(s) failed to roll under deny-egress:"
+                sed 's/^/    /' /work/roll_failures.txt
+                rc=1
+              else
+                echo "  PASS — every external-registry workload rolled to Running pulling from the local registry under deny-egress (#3695)"
+              fi
+              return "${rc}"
+            }
+
+            # ── #3678 ACTIVE CALL-HOME ASSERTION ──────────────────────────
+            # The survival poll only proves ALREADY-RUNNING HRs stay Ready —
+            # it never makes an outbound call, so a catalyst-api still issuing
+            # tokens with iss=console.openova.io kept every HR green and the
+            # 4-CIDR block left console.openova.io wide open. Here we ACTIVELY
+            # curl each mothership host FROM this pod (which is under the
+            # default-deny CCNP). Under a TRUE default-deny, EVERY one must
+            # FAIL to connect; if ANY connects, the deny-egress is leaky and
+            # the sovereignty proof FAILS. This is what makes the proof catch
+            # an ARBITRARY mothership tether, not the 4 enumerated hosts.
+            run_call_home_assertion() {
+              echo "[egress-block-test] #3678: active call-home — asserting every mothership host is UNREACHABLE under the hold"
+              leaked=""
+              for url in ${CALL_HOME_HOSTS}; do
+                # --max-time bounds each probe; -o /dev/null -s -w "%{http_code}"
+                # yields the HTTP status (000 on connect failure/timeout, which
+                # is the EXPECTED, PASSING outcome under deny-egress). A genuine
+                # 2xx/3xx/4xx/5xx means the TCP+TLS handshake SUCCEEDED → the
+                # host is reachable → LEAK.
+                code=$(curl -ksS -o /dev/null -w '%{http_code}' --max-time "${CALL_HOME_TIMEOUT}" "${url}" 2>/dev/null || echo "000")
+                if [ "${code}" = "000" ]; then
+                  echo "  OK — ${url} unreachable (curl exit/timeout, http_code=000) — denied as required"
+                else
+                  echo "  LEAK — ${url} RESPONDED http_code=${code} under deny-egress — mothership tether still reachable"
+                  leaked="${leaked} ${url}"
+                fi
+              done
+              if [ -n "${leaked}" ]; then
+                echo "  FAIL — deny-egress is leaky; reachable mothership host(s):${leaked} (#3678)"
+                return 1
+              fi
+              echo "  PASS — every mothership host black-holed by the default-deny hold (#3678)"
+              return 0
+            }
+
+            if [ "${CALL_HOME_ENABLED}" = "true" ] && [ "${POLICY_APPLIED}" = "yes" ]; then
+              if ! run_call_home_assertion; then
+                kubectl delete ciliumclusterwidenetworkpolicy cutover-egress-block --ignore-not-found=true || true
+                echo "[egress-block-test] CALL-HOME assertion FAILED — sovereignty proof FAILED (cutoverComplete stays false)"
+                exit 1
+              fi
+            elif [ "${CALL_HOME_ENABLED}" = "true" ]; then
+              echo "[egress-block-test] #3678: call-home assertion requested but egressDeny not applied — cannot prove unreachability, skipping (survival-poll only)"
+            fi
+
             if [ "${FRESH_PULL_PROOF}" = "true" ] && [ "${POLICY_APPLIED}" = "yes" ]; then
-              if ! run_fresh_pull_proof; then
+              : > /work/roll_failures.txt
+              if [ "${ROLL_ALL_EXTERNAL}" = "true" ]; then
+                fresh_pull_fn=run_fresh_pull_all
+              else
+                fresh_pull_fn=run_fresh_pull_proof
+              fi
+              if ! ${fresh_pull_fn}; then
                 # Tear the deny policy down before failing so we never leave
                 # a cluster-wide egressDeny lingering on the Sovereign.
                 kubectl delete ciliumclusterwidenetworkpolicy cutover-egress-block --ignore-not-found=true || true
@@ -395,6 +617,41 @@ data:
               fi
             elif [ "${FRESH_PULL_PROOF}" = "true" ]; then
               echo "[egress-block-test] #3647: FRESH-PULL proof requested but egressDeny not applied (enforce off / fail-safe fallback) — skipping the fresh pull, survival-poll only"
+            fi
+
+            # ── #3695 HOST GITOPS LOOP GATE ───────────────────────────────
+            # HARD gate, NOT subject to the baseline-exclude below. The root
+            # bootstrap-kit Kustomization owns all 63 bp-* HRs with prune=true
+            # — if it cannot build (e.g. step-10's awk injector duplicated a
+            # `values:` key on 13b-bp-sso-bridge.yaml, hw150), the Sovereign
+            # can no longer apply ANY git change and is not operable as a
+            # GitOps cluster, even though every already-running pod stays up
+            # and the survival poll would pass. Assert each host Kustomization
+            # is Ready=True NOW; any NotReady fails the proof before the window.
+            if [ "${HOST_KS_GATE_ENABLED}" = "true" ]; then
+              echo "[egress-block-test] #3695: asserting host GitOps Kustomizations are Ready (the loop that reconciles local git)"
+              host_ks_bad=""
+              for ks in ${HOST_KS_NAMES}; do
+                ready=$(kubectl get kustomization "${ks}" -n "${HOST_KS_NAMESPACE}" \
+                  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+                if [ "${ready}" = "True" ]; then
+                  rev=$(kubectl get kustomization "${ks}" -n "${HOST_KS_NAMESPACE}" \
+                    -o jsonpath='{.status.lastAppliedRevision}' 2>/dev/null || echo "?")
+                  echo "  OK — kustomization/${ks} Ready=True (lastAppliedRevision=${rev})"
+                else
+                  msg=$(kubectl get kustomization "${ks}" -n "${HOST_KS_NAMESPACE}" \
+                    -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}' 2>/dev/null || echo "")
+                  echo "  FAIL — kustomization/${ks} Ready=${ready:-<missing>}: ${msg}"
+                  host_ks_bad="${host_ks_bad} ${ks}"
+                fi
+              done
+              if [ -n "${host_ks_bad}" ]; then
+                # Tear down any applied policy before failing.
+                [ -n "${POLICY_APPLIED}" ] && kubectl delete ciliumclusterwidenetworkpolicy cutover-egress-block --ignore-not-found=true || true
+                echo "[egress-block-test] #3695 FAIL — host GitOps loop not reconciling (NotReady:${host_ks_bad}); the cutover corrupted its own git loop — sovereignty proof FAILED"
+                exit 1
+              fi
+              echo "[egress-block-test] #3695: host GitOps loop healthy — bootstrap-kit reconciles local git"
             fi
 
             echo "[egress-block-test] capturing baseline NotReady set"

--- a/platform/self-sovereign-cutover/chart/templates/09-cutover-status-configmap.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/09-cutover-status-configmap.yaml
@@ -21,12 +21,40 @@ products/catalyst/bootstrap/api/internal/handler/cutover.go):
 Plus this chart's own:
   registriesYamlActive     "v1" | "v2" | "rollback"
                            Read by the registry-pivot DaemonSet's
-                           reconcile loop; written by catalyst-api
-                           between step 03 success and step 05.
+                           reconcile loop to decide WHICH registries.yaml
+                           to write (v1=mothership Harbor, v2=local
+                           harbor.<fqdn>). Flipped to "v2" by catalyst-api
+                           (cutover.go runCutover) the moment the
+                           harbor-prewarm step succeeds — BEFORE the
+                           registry-pivot DaemonSet-wait — so the DS writes
+                           the LOCAL file. Each node then writes a
+                           node.<name>.registriesYaml="v2" ack which the
+                           DaemonSet-wait counts (#3671).
+  node.<nodeName>.registriesYaml
+                           "v2" per-node ack, written by the registry-pivot
+                           DaemonSet after it atomically swaps the file.
+                           Counted by step-04 (acks == DesiredNumberScheduled).
 
 helm.sh/resource-policy: keep ensures Helm leaves this ConfigMap in
 place on chart uninstall so a re-install doesn't lose state mid-cutover.
+
+#3667 — INIT-ONLY guard: the whole ConfigMap is wrapped in a `lookup`
+so Helm authors it ONLY on the FIRST install (when it does not already
+exist in the cluster). On every subsequent `helm upgrade` the `lookup`
+finds the live ConfigMap and the template renders EMPTY, so
+helm-controller's 3-way merge has nothing to re-assert — the live
+`cutoverComplete:"true"` / `cutoverStartedAt:<T0>` / `registriesYamlActive:"v2"`
+written by catalyst-api are never reverted to the template's
+"false"/""/"v1" defaults. Without this, a routine chart-pin bump
+(which lands on running Sovereigns constantly) re-armed the entire
+cutover including the 600s deny-egress hold. `helm.sh/resource-policy:
+keep` only governs uninstall, NOT upgrade — the lookup guard is what
+makes the upgrade non-reverting. catalyst-api's patchCutoverStatus
+create-path (cutover.go) still anchors the keys if the ConfigMap is
+somehow absent at runtime, so a from-scratch install with
+`--no-hooks`/dry-render is also covered.
 */ -}}
+{{- if not (lookup "v1" "ConfigMap" .Release.Namespace .Values.status.configMapName) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -95,3 +123,4 @@ data:
   step.crossplane-provider-pivot.finishedAt: ""
   step.crossplane-provider-pivot.result: ""
   step.crossplane-provider-pivot.jobName: ""
+{{- end }}

--- a/platform/self-sovereign-cutover/chart/templates/10-vcluster-registry-pivot-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/10-vcluster-registry-pivot-job.yaml
@@ -192,6 +192,32 @@ data:
             echo "[vcluster-registry-pivot] wrapper image.repository: ${wrapper_repo}"
             echo "[vcluster-registry-pivot] subchart image.registry: ${sub_registry} repository: ${sub_repo_path}"
 
+            # #3695 — a real YAML processor for the Phase-2b/2c git-persist
+            # merges (Principle #15). Line-oriented awk/sed on a multi-document
+            # YAML with an EVOLVING schema is the wrong tool: 13b-bp-sso-bridge.yaml
+            # GAINED a `spec.values` block (the #2940 global.registryMirror
+            # overlay), so the old awk injector's "append a fresh values: under
+            # spec:" produced a SECOND values: key → duplicate-mapping-key →
+            # bootstrap-kit BuildFailed → the root GitOps loop died while
+            # cutoverComplete flipped true. yq MERGES into the existing mapping
+            # and is idempotent against a file that already carries the key.
+            # The alpine/k8s image ships yq (mikefarah/Go yq); if a future image
+            # variant drops it we apk-add it (best-effort; proxied alpine repos),
+            # and fall back to a NO-OP-when-values-exists guard so we can NEVER
+            # re-introduce the duplicate-key corruption.
+            HAVE_YQ=""
+            if command -v yq >/dev/null 2>&1; then
+              HAVE_YQ="yes"
+            else
+              apk add --no-cache yq >/dev/null 2>&1 || true
+              command -v yq >/dev/null 2>&1 && HAVE_YQ="yes"
+            fi
+            if [ -n "${HAVE_YQ}" ]; then
+              echo "[vcluster-registry-pivot] yq available ($(yq --version 2>/dev/null || echo unknown)) — Phase-2 git-persist will MERGE values (#3695)"
+            else
+              echo "[vcluster-registry-pivot] WARN yq unavailable — Phase-2 image.repository merge will NO-OP when a values: block already exists (never injects a duplicate); the durable registry host pivot still rides global.registryMirror (Phase-2c)"
+            fi
+
             # ---- Phase 1: live K8s patch on each of the 3 bp-*-vcluster HelmReleases ----
             #
             # The bp-*-vcluster wrapper charts each expose:
@@ -586,72 +612,55 @@ data:
               fi
             done
 
-            # ---- Phase 2b: inject sso-bridge image override into Gitea (#2951) ----
+            # ---- Phase 2b: persist sso-bridge image override to Gitea (#2951/#3695) ----
             #
-            # 13b-bp-sso-bridge.yaml carries NO spec.values block today, so
-            # Phase-1b's live HR patch is reverted by the bootstrap-kit
-            # Kustomization reconcile within ~1 min unless we persist the
-            # override to Gitea. We inject a minimal
-            #   values:
-            #     image:
-            #       repository: harbor.<SOVEREIGN_FQDN>/proxy-dockerhub/alpine/k8s
-            # block at 2-space indent under the top-level `spec:` key.
-            # Idempotency: sentinel-comment guard; on re-run we rewrite the
-            # repository value in case SOVEREIGN_FQDN changed.
+            # 13b-bp-sso-bridge.yaml is a MULTI-DOCUMENT YAML: doc 1 is the
+            # HelmRepository (its `spec:` carries type/url/secretRef), doc 2 is
+            # the HelmRelease whose `spec.values` takes image.repository. Since
+            # #2940 the HelmRelease ALSO carries a `spec.values` block
+            # (global.registryMirror + sovereign.fqdn). The old awk injector
+            # appended a SECOND `values:` under the HelmRelease spec → duplicate
+            # mapping key → bootstrap-kit BuildFailed (hw150). We now MERGE
+            # `image.repository` INTO the existing values mapping with yq,
+            # anchored to the HelmRelease document only (select by kind), so the
+            # result always has exactly ONE `values:` key. Idempotent: yq
+            # assignment is a no-op when the value already matches.
+            #
+            # The repository is host-LESS (proxy-dockerhub/alpine/k8s): the
+            # sso-bridge chart's `bp-sso-bridge.image` helper prepends
+            # global.registryMirror (pivoted durably to harbor.<fqdn> by
+            # Phase-2c), so the registry host has exactly ONE source of truth.
+            # Writing a host-qualified repository here would FIGHT that single
+            # source — the helper honours a host-qualified repo verbatim and
+            # would ignore the pivoted mirror.
             sso_file="${target_dir}/13b-bp-sso-bridge.yaml"
-            sso_repo="harbor.${SOVEREIGN_FQDN}/proxy-dockerhub/alpine/k8s"
+            sso_repo="proxy-dockerhub/alpine/k8s"
             if [ -f "${sso_file}" ]; then
-              if grep -q "# ─── sso-bridge image registry pivot (#2951) ──" "${sso_file}"; then
-                # Existing override — rewrite the repository value line
-                # (2-space `values:` → 4-space `image:` → 6-space
-                # `repository:`). Bounded to the sentinel-anchored block by
-                # matching the 6-space repository line that follows our
-                # injected image: key.
-                if sed -i -E "s,^([[:space:]]{6}repository:[[:space:]]*)harbor\.[^/]*/proxy-dockerhub/alpine/k8s.*$,\1${sso_repo}," "${sso_file}" 2>/dev/null; then
-                  echo "[vcluster-registry-pivot] rewrote existing sso-bridge image override in ${sso_file}"
+              if [ -n "${HAVE_YQ}" ]; then
+                # MERGE into the HelmRelease document's spec.values.image.repository.
+                # `(select(.kind=="HelmRelease") | .spec.values.image.repository) = $r`
+                # creates the image: child under the EXISTING values: mapping
+                # (or creates values: if somehow absent) WITHOUT ever emitting a
+                # second values: key. Other documents (HelmRepository) are
+                # untouched. yq preserves the ${REGISTRY_MIRROR:=...} envsubst
+                # placeholders verbatim (they are plain scalar strings to yq).
+                if yq eval -i "(select(.kind == \"HelmRelease\") | .spec.values.image.repository) = \"${sso_repo}\"" "${sso_file}" 2>/dev/null; then
+                  echo "[vcluster-registry-pivot] merged sso-bridge image.repository=${sso_repo} into existing values (yq, single values: key) — ${sso_file}"
                   edited=$((edited+1))
                 else
-                  echo "[vcluster-registry-pivot] WARN: sed rewrite of sso-bridge override failed; Phase-1b K8s patch remains durable for one upgrade cycle"
+                  echo "[vcluster-registry-pivot] WARN: yq merge of sso-bridge image.repository failed on ${sso_file}; the durable registry host still rides global.registryMirror (Phase-2c)"
                 fi
+              elif grep -qE "^[[:space:]]+values:[[:space:]]*$" "${sso_file}"; then
+                # No yq AND a values: block already exists → the awk injector
+                # would duplicate the key. NO-OP rather than corrupt the file:
+                # the registry host pivot is fully covered by Phase-2c's
+                # global.registryMirror rewrite (the image host's single source
+                # of truth), so skipping the image.repository merge does NOT
+                # leave a mothership tether. (#3695: never re-introduce the
+                # duplicate-mapping-key BuildFailed.)
+                echo "[vcluster-registry-pivot] NO-OP sso-bridge image.repository merge (no yq + existing values: block) — registry host pivot covered by Phase-2c global.registryMirror"
               else
-                # No existing override. NOTE: 13b-bp-sso-bridge.yaml is a
-                # MULTI-DOCUMENT YAML — doc 1 is the HelmRepository (its
-                # own `spec:` carries `type/url/secretRef`, NOT values), doc
-                # 2 is the HelmRelease whose `spec:` is the one that takes
-                # `values.image.repository`. We MUST anchor the injection to
-                # the HelmRelease spec only, so we track `kind: HelmRelease`
-                # and inject at the NEXT top-level `spec:` after it. Anchoring
-                # on a bare `^spec:` would wrongly land inside the
-                # HelmRepository document.
-                if awk -v repo="${sso_repo}" '
-                  /^kind:[[:space:]]*HelmRelease[[:space:]]*$/ { in_hr=1 }
-                  in_hr && /^spec:[[:space:]]*$/ && !done {
-                    print
-                    print "  # ─── sso-bridge image registry pivot (#2951) ──"
-                    print "  # Injected by self-sovereign-cutover step-10 from"
-                    print "  # harbor.openova.io → harbor.<SOVEREIGN_FQDN> so the"
-                    print "  # bp-sso-bridge reconciler Pod pulls its image from the"
-                    print "  # Sovereign-local Harbor mirror, NOT mothership Harbor."
-                    print "  # Required by Principle #11 (no tether to harbor.openova.io"
-                    print "  # after handover — UAT Wave-2 ATTACK#9, #2940). Without this"
-                    print "  # override the chart default at platform/sso-bridge/chart/"
-                    print "  # values.yaml resolves back to harbor.openova.io."
-                    print "  values:"
-                    print "    image:"
-                    print "      repository: " repo
-                    done = 1
-                    next
-                  }
-                  { print }
-                  END { exit (done ? 0 : 1) }
-                ' "${sso_file}" > "${sso_file}.new"; then
-                  mv "${sso_file}.new" "${sso_file}"
-                  echo "[vcluster-registry-pivot] injected sso-bridge image override into ${sso_file}"
-                  edited=$((edited+1))
-                else
-                  rm -f "${sso_file}.new"
-                  echo "[vcluster-registry-pivot] WARN: ${sso_file} has no HelmRelease spec: anchor — Phase-1b K8s patch remains durable for one upgrade cycle"
-                fi
+                echo "[vcluster-registry-pivot] SKIP sso-bridge image.repository merge (no yq + no values: block) — Phase-1b K8s patch remains durable for one upgrade cycle"
               fi
             else
               echo "[vcluster-registry-pivot] SKIP ${sso_file} (not present)"
@@ -683,9 +692,32 @@ data:
                 echo "[vcluster-registry-pivot] SKIP registryMirror persist ${rm_path} (not present)"
                 continue
               fi
-              if grep -qE "^[[:space:]]*registryMirror:[[:space:]]*harbor\.openova\.io[[:space:]]*$" "${rm_path}"; then
+              # #3695: prefer yq for a structural assignment of the HelmRelease
+              # document's spec.values.global.registryMirror. This is robust to
+              # the overlay carrying the value as a ${REGISTRY_MIRROR:=...}
+              # placeholder OR the post-envsubst literal harbor.openova.io, and
+              # never touches a HelmRepository document in the same file. The
+              # sed fallback (value-replacement on the literal line — safe, it
+              # rewrites a scalar in place and never adds a key) covers a
+              # yq-less image. Idempotent either way.
+              if [ -n "${HAVE_YQ}" ]; then
+                cur=$(yq eval 'select(.kind == "HelmRelease") | .spec.values.global.registryMirror' "${rm_path}" 2>/dev/null | head -1 || true)
+                case "${cur}" in
+                  harbor.${SOVEREIGN_FQDN})
+                    echo "[vcluster-registry-pivot] registryMirror in ${rm_path} already harbor.${SOVEREIGN_FQDN} (yq) — no rewrite" ;;
+                  ""|null)
+                    echo "[vcluster-registry-pivot] registryMirror absent in ${rm_path} (yq) — no rewrite" ;;
+                  *)
+                    if yq eval -i "(select(.kind == \"HelmRelease\") | .spec.values.global.registryMirror) = \"harbor.${SOVEREIGN_FQDN}\"" "${rm_path}" 2>/dev/null; then
+                      echo "[vcluster-registry-pivot] rewrote global.registryMirror in ${rm_path} -> harbor.${SOVEREIGN_FQDN} (yq)"
+                      edited=$((edited+1))
+                    else
+                      echo "[vcluster-registry-pivot] WARN: yq registryMirror rewrite failed for ${rm_path}; Phase-1d K8s patch remains durable for one reconcile cycle"
+                    fi ;;
+                esac
+              elif grep -qE "^[[:space:]]*registryMirror:[[:space:]]*harbor\.openova\.io[[:space:]]*$" "${rm_path}"; then
                 if sed -i -E "s,^([[:space:]]*registryMirror:[[:space:]]*)harbor\.openova\.io[[:space:]]*\$,\1harbor.${SOVEREIGN_FQDN}," "${rm_path}" 2>/dev/null; then
-                  echo "[vcluster-registry-pivot] rewrote global.registryMirror in ${rm_path} -> harbor.${SOVEREIGN_FQDN}"
+                  echo "[vcluster-registry-pivot] rewrote global.registryMirror in ${rm_path} -> harbor.${SOVEREIGN_FQDN} (sed fallback)"
                   edited=$((edited+1))
                 else
                   echo "[vcluster-registry-pivot] WARN: registryMirror sed failed for ${rm_path}; Phase-1d K8s patch remains durable for one reconcile cycle"
@@ -695,7 +727,7 @@ data:
               fi
             done
 
-            echo "[vcluster-registry-pivot] sed edited ${edited} files"
+            echo "[vcluster-registry-pivot] edited ${edited} files (yq merge / sed fallback)"
             if [ "${edited}" -eq 0 ]; then
               echo "[vcluster-registry-pivot] no edits required — already pivoted in Gitea or files absent"
               # Phase 1 already succeeded; nothing to push.

--- a/platform/self-sovereign-cutover/chart/templates/rbac.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/rbac.yaml
@@ -128,6 +128,9 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["update", "patch"]   # step 07 sets env on catalyst-api deployment
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "statefulsets"]
+    verbs: ["update", "patch"]   # step 08 (#3695) rolls EVERY external-registry workload under deny-egress to prove fresh-pullability — kubectl rollout restart patches the workload's pod template
   - apiGroups: ["source.toolkit.fluxcd.io"]
     resources: ["gitrepositories", "helmrepositories"]
     verbs: ["update", "patch"]   # steps 05 + 06

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -477,18 +477,91 @@ egressTest:
     # headroom covers scheduler + container-create. A Pod still not Running
     # at the deadline — or any ImagePull error observed — FAILS the proof.
     timeoutSeconds: 240
+  # #3678 — TRUE deny-egress shape. defaultDenyEgress flips the Step-08
+  # CCNP from a SUBTRACTIVE 4-CIDR block (default-allow, deny only the
+  # listed hosts — which left console.openova.io + every un-enumerated
+  # mothership host reachable, so a residual call-home kept every HR Ready
+  # and the proof passed over a live tether) to a TRUE default-deny:
+  # `enableDefaultDeny.egress: true` + an explicit allow-list of the
+  # Sovereign's OWN intra-cluster CIDRs (pods/services/DNS/node). EVERYTHING
+  # public — incl. console.openova.io and any host NOT in the allow-list —
+  # is denied for the whole survival window. The #3640 apiserver-strand is
+  # avoided by ALLOWING 10.96.0.0/12 (services, covers the 10.96.0.1
+  # apiserver ClusterIP) + 10.42/10.43 (pods) + DNS, NOT by retreating to
+  # enableDefaultDeny.egress:false. blockedDomains is retained only for the
+  # active call-home assertion (the hosts we PROVE are unreachable from a
+  # pod under the policy); the policy itself no longer enumerates them.
+  defaultDenyEgress: true
+  # Intra-cluster CIDRs that stay reachable under the default-deny hold.
+  # These are the standard k3s ranges; a Sovereign on non-default CIDRs
+  # overrides via the 06a overlay. toCIDR allow-rules for these plus a
+  # toEntities allow for DNS/host/remote-node (added inline in the script)
+  # keep the apiserver, CoreDNS, and pod-to-pod paths up so the cluster
+  # keeps reconciling while every PUBLIC destination is black-holed.
+  allowIntraClusterCIDRs:
+    - "10.42.0.0/16"   # k3s pod CIDR (Cilium cluster-pool default)
+    - "10.43.0.0/16"   # k3s service CIDR
+    - "10.96.0.0/12"   # k8s default service CIDR (apiserver 10.96.0.1, CoreDNS)
+  # #3678 — active call-home assertion. During the hold, the Step-08 Job
+  # curls each of these hosts FROM a pod under the policy; if ANY connects,
+  # the deny-egress is leaky and the proof FAILS (cutoverComplete stays
+  # false). This catches an arbitrary mothership tether (e.g. a catalyst-api
+  # still issuing tokens with iss=console.openova.io) that the
+  # HR-readiness-only survival poll never exercises. console.openova.io is
+  # FIRST because #2940 enumerated ~18 openova.io endpoints the subtractive
+  # 4-CIDR block left wide open.
+  callHomeAssertion:
+    enabled: true
+    timeoutSeconds: 5
+    hosts:
+      - "https://console.openova.io/healthz"
+      - "https://github.com/openova-io"
+      - "https://ghcr.io/v2/"
+      - "https://harbor.openova.io/v2/"
+  # #3695 — the host GitOps loop MUST be healthy for cutoverComplete=true.
+  # On hw150 the cutover's OWN step-10 awk injector corrupted
+  # 13b-bp-sso-bridge.yaml (duplicate `values:` key) → bootstrap-kit went
+  # BuildFailed → the root Kustomization that owns all 63 bp-* HRs could no
+  # longer apply ANY git change → the Sovereign was no longer operable as a
+  # GitOps-driven cluster, yet cutoverComplete flipped true. These host
+  # Kustomizations are checked as a HARD pre-window gate (NOT subject to the
+  # baseline-exclude that hid bootstrap-kit's BuildFailed): if any is
+  # NotReady, the proof FAILS before the survival window even starts.
+  hostKustomizationGate:
+    enabled: true
+    namespace: "flux-system"
+    names:
+      - "bootstrap-kit"
+      - "sovereign-tls"
+      - "sme-tenants"
+  # #3695 — the fresh-pull proof must roll EVERY workload whose image host is
+  # NOT the local registry, not one hand-picked openova-io Deployment. When
+  # true, Step-08 enumerates all Deployments/DaemonSets/StatefulSets across
+  # all namespaces whose container images reference a NON-local registry
+  # (ghcr.io/openova-io, harbor.openova.io, etc.) and force-rolls EACH under
+  # deny-egress; any that ImagePullBackOff fails the proof. This generalizes
+  # the #3647 single-workload roll into the cross-cutting guarantee #3379 §7
+  # demands. localRegistryHostSubstr identifies the local registry so a
+  # Sovereign on a non-harbor.<fqdn> registry name overrides via 06a.
+  rollAllExternalRegistryWorkloads: true
+  localRegistryHostSubstr: "harbor."
   blockedDomains:
     - "github.com"
     - "ghcr.io"
     - "harbor.openova.io"
+    # console.openova.io (#3678): the mothership front door. The subtractive
+    # 4-CIDR block NEVER included it, so a catalyst-api still issuing tokens
+    # with iss=console.openova.io survived the hold. Under default-deny it is
+    # blocked by omission from the allow-list; this entry drives the active
+    # call-home assertion that PROVES it is unreachable.
+    - "console.openova.io"
     # TBD-V24 MISS-3 (chart 0.1.37): xpkg.upbound.io is the Crossplane
     # Provider package upstream. Step 11 pivots every Provider's
     # spec.package literal off this host, so the deny-egress hold proof
     # MUST also block xpkg.upbound.io — otherwise a Provider revision
     # reconcile during the hold window could silently fall through to
-    # the upstream xpkg host and break the proof. The deny implementation
-    # is TBD-V23's responsibility; this entry is the contract this list
-    # must carry once TBD-V23's CiliumNetworkPolicy applies.
+    # the upstream xpkg host and break the proof. Under default-deny this
+    # is blocked by omission from the allow-list.
     - "xpkg.upbound.io"
 
 # Status sentinel ConfigMap — initial state machine state. catalyst-api

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T12:06:11.834Z",
+  "generatedAt": "2026-06-16T16:49:44.547Z",
   "blueprints": [
     {
       "id": "bp-alloy",
@@ -3225,7 +3225,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "1.4.95",
+      "version": "1.4.96",
       "section": "pts-4-6-llm-serving",
       "depends": [
         "bp-cnpg",
@@ -4287,7 +4287,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",

--- a/products/catalyst/bootstrap/api/internal/handler/cutover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover.go
@@ -158,6 +158,16 @@ const (
 	cutoverModeJob           = "job"
 	cutoverModeDaemonSetWait = "daemonset-wait"
 
+	// Well-known step slugs (data.stepName on the step ConfigMaps). Keyed
+	// by NAME — never positional index — because the step count has drifted
+	// (8→11) as gitea-token-mint / vcluster-registry-pivot /
+	// crossplane-provider-pivot were appended, so an index hook would have
+	// silently fired against the wrong step. #3671: the engine flips
+	// registriesYamlActive=v2 the moment harbor-prewarm succeeds and the
+	// registry-pivot DaemonSet-wait then asserts per-node v2 acks.
+	cutoverStepHarborPrewarm = "harbor-prewarm"
+	cutoverStepRegistryPivot = "registry-pivot"
+
 	// SSE phase names.
 	cutoverPhaseStepStarted  = "cutover-step-started"
 	cutoverPhaseStepFinished = "cutover-step-finished"
@@ -1110,6 +1120,80 @@ func waitForDaemonSetReady(ctx context.Context, deps *cutoverDeps, dsName string
 	})
 }
 
+// registryPivotNodeAckPrefix / Suffix bracket the per-node ack key the
+// registry-pivot DaemonSet writes into the status ConfigMap AFTER it
+// atomically swaps /etc/rancher/k3s/registries.yaml on its node. The key
+// is `node.<nodeName>.registriesYaml = "v2"`. A Ready DaemonSet only
+// proves its pods are running — NOT that each pod rewrote the file; this
+// ack closes that gap (#3671 §5).
+const (
+	registryPivotNodeAckPrefix = "node."
+	registryPivotNodeAckSuffix = ".registriesYaml"
+)
+
+// waitForRegistryPivotNodeAcks blocks until the number of per-node v2 acks
+// in the status ConfigMap equals the DaemonSet's DesiredNumberScheduled
+// (#3671). This is the REAL verification step-04 was missing: a Ready
+// DaemonSet whose reconcile loop wrote the v1 (mothership) file — because
+// registriesYamlActive was never flipped — would pass the bare
+// waitForDaemonSetReady. With registriesYamlActive=v2 set before this DS
+// runs (see runCutover), each node's reconcile loop swaps the file to the
+// LOCAL Harbor and writes its ack; we count acks == desired so the cutover
+// fails (rather than greens) if ANY node is still held at v1.
+func waitForRegistryPivotNodeAcks(ctx context.Context, deps *cutoverDeps, dsName string) error {
+	// Only meaningful once the engine has flipped registriesYamlActive=v2 (via
+	// the harbor-prewarm hook). If it is still v1, the DaemonSet has NOT been
+	// instructed to write the local file, so no v2 ack will ever arrive — the
+	// ack-wait would just burn the whole timeout. In that case skip the wait;
+	// the END-of-run invariant gate (#3671) fails the cutover for "v2 never
+	// reached", which is the correct, fast verdict.
+	if st, _ := readCutoverStatus(ctx, deps); st["registriesYamlActive"] != "v2" {
+		return nil
+	}
+	timeout := cutoverDaemonSetTimeout()
+	wctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	return wait.PollUntilContextCancel(wctx, 5*time.Second, true, func(c context.Context) (bool, error) {
+		ds, err := deps.core.AppsV1().DaemonSets(deps.ns).Get(c, dsName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, fmt.Errorf("get DaemonSet %s/%s: %w", deps.ns, dsName, err)
+		}
+		desired := int(ds.Status.DesiredNumberScheduled)
+		if desired == 0 {
+			return false, nil
+		}
+
+		status, err := readCutoverStatus(c, deps)
+		if err != nil {
+			// Transient read failure — keep polling; the outer timeout bounds it.
+			return false, nil
+		}
+		acks := countRegistryPivotV2Acks(status)
+		if acks >= desired {
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+// countRegistryPivotV2Acks counts the per-node ack keys in the status map
+// whose value is exactly "v2".
+func countRegistryPivotV2Acks(status map[string]string) int {
+	n := 0
+	for k, v := range status {
+		if strings.HasPrefix(k, registryPivotNodeAckPrefix) &&
+			strings.HasSuffix(k, registryPivotNodeAckSuffix) &&
+			v == "v2" {
+			n++
+		}
+	}
+	return n
+}
+
 // ── Cutover engine ──────────────────────────────────────────────────────────
 
 // runCutover executes the discovered steps in order. It is run in a
@@ -1132,14 +1216,36 @@ func (h *Handler) runCutover(ctx context.Context, deps *cutoverDeps, steps []cut
 	runEpoch := time.Now().Unix()
 	totalSteps := len(steps)
 
+	// Read the durable prior status BEFORE seeding so the audit start-time
+	// (#3681) is written ONCE — at the first run — and never re-stamped by
+	// a resume or re-fire. Before this fix the seed unconditionally
+	// overwrote cutoverStartedAt with time.Now() at the TOP of every
+	// runCutover call; a mid-run catalyst-api roll (which triggers
+	// ResumeInterruptedCutover → runCutover) re-stamped it to the resume
+	// moment, making the durable record claim an 11-minute cutover that
+	// really took 35 (hw150: first step at 13:36, cutoverStartedAt rewritten
+	// to 14:00 by the resume). The per-step rows were ground truth; the
+	// top-level start was fiction. Now the FIRST attempt seeds
+	// cutoverStartedAt and every attempt (incl. this one) advances a
+	// separate cutoverLastAttemptStartedAt — the field used as the
+	// resume/re-fire guard keeps its original meaning ("cutover began at
+	// T0") while the new field carries "latest attempt began at Tn".
+	priorStatus, _ := readCutoverStatus(ctx, deps)
+
 	startedAt := time.Now().UTC()
-	if err := patchCutoverStatus(ctx, deps, map[string]string{
-		"cutoverStartedAt": startedAt.Format(time.RFC3339),
-		"totalSteps":       strconv.Itoa(totalSteps),
-		"cutoverComplete":  "false",
-		"failedStep":       "",
-		"lastError":        "",
-	}); err != nil {
+	seed := map[string]string{
+		"cutoverLastAttemptStartedAt": startedAt.Format(time.RFC3339),
+		"totalSteps":                  strconv.Itoa(totalSteps),
+		"cutoverComplete":             "false",
+		"failedStep":                  "",
+		"lastError":                   "",
+	}
+	if priorStatus["cutoverStartedAt"] == "" {
+		// First run only — anchor the true start. On a resume/re-fire the
+		// existing value is preserved (NOT in the seed map ⇒ untouched).
+		seed["cutoverStartedAt"] = startedAt.Format(time.RFC3339)
+	}
+	if err := patchCutoverStatus(ctx, deps, seed); err != nil {
 		h.publishCutoverEvent(bus, cutoverEvent{
 			Time:    time.Now().UTC().Format(time.RFC3339),
 			Phase:   cutoverPhaseStepFailed,
@@ -1156,11 +1262,11 @@ func (h *Handler) runCutover(ctx context.Context, deps *cutoverDeps, steps []cut
 		Message: fmt.Sprintf("Self-Sovereignty Cutover started: %d steps", totalSteps),
 	})
 
-	// Skip steps already marked success (resume-after-restart). The
-	// status ConfigMap is the durable record; if a previous run
-	// completed step 1 and 2 then crashed before step 3, a fresh
-	// /start picks up at step 3.
-	priorStatus, _ := readCutoverStatus(ctx, deps)
+	// priorStatus (read above, before the seed) is the durable record used
+	// for resume-after-restart: if a previous run completed step 1 and 2
+	// then crashed before step 3, a fresh /start picks up at step 3. The
+	// seed never touches the per-step rows, so the snapshot read at the top
+	// is the correct skip-success basis.
 
 	// Project the Cutover group + a pending step Job per discovered step
 	// (with the linear dependsOn chain) into the jobs/activity store so
@@ -1217,9 +1323,107 @@ func (h *Handler) runCutover(ctx context.Context, deps *cutoverDeps, steps []cut
 			h.log.Error("cutover: step failed", "step", step.stepName, "err", err)
 			return
 		}
+
+		// Faithful registry pivot (#3671). The node-level pivot that points
+		// containerd at harbor.<fqdn> is gated by the registriesYamlActive
+		// status key, which the registry-pivot DaemonSet's reconcile loop
+		// reads to decide WHICH registries.yaml (v1=mothership, v2=local) to
+		// write. Before this fix NOTHING in the engine ever set "v2", so the
+		// DaemonSet dutifully (re)wrote the v1 (mothership) file on every
+		// node — step registry-pivot greened while pivoting nothing. We flip
+		// it to "v2" the moment harbor-prewarm SUCCEEDS (the local Harbor now
+		// serves every bootstrap-kit image) and BEFORE the registry-pivot
+		// DaemonSet-wait step, so the DS writes the LOCAL file. Keyed on the
+		// step NAME, not a positional index (steps are label-ordered and the
+		// numbering has drifted 8→11).
+		if step.stepName == cutoverStepHarborPrewarm {
+			if err := patchCutoverStatus(ctx, deps, map[string]string{
+				"registriesYamlActive": "v2",
+			}); err != nil {
+				h.log.Warn("cutover: failed to flip registriesYamlActive=v2 after harbor-prewarm",
+					"err", err)
+			} else {
+				h.publishCutoverEvent(bus, cutoverEvent{
+					Time:    time.Now().UTC().Format(time.RFC3339),
+					Phase:   cutoverPhaseStepFinished,
+					Level:   "info",
+					Step:    step.stepName,
+					Message: "registriesYamlActive flipped to v2 — registry-pivot DaemonSet will write node containerd to local Harbor",
+				})
+			}
+		}
 	}
 
 	finishedAt := time.Now().UTC()
+
+	// Invariant gate (#3671): the cutover MUST NOT reach
+	// cutoverComplete=true while the node-level registry pivot is still on
+	// v1 (mothership Harbor). registriesYamlActive is flipped to "v2" by the
+	// harbor-prewarm hook above and the registry-pivot DaemonSet acks per
+	// node. If every step ran but the key is still "v1", the pivot silently
+	// pivoted nothing — exactly the hw150 face-2 defect (step registry-pivot
+	// result=success, node containerd still pointed at harbor.openova.io).
+	// Fail the cutover here rather than seal a false sovereignty fact over a
+	// still-tethered node.
+	//
+	// The gate applies ONLY when this chain actually CONTAINS a registry-pivot
+	// step — i.e. the cutover is responsible for the node pivot. A partial /
+	// custom chain that legitimately has no registry-pivot step (and never
+	// flips the key) is not force-failed; there is nothing to assert.
+	chainHasRegistryPivot := false
+	for _, s := range steps {
+		if s.stepName == cutoverStepRegistryPivot {
+			chainHasRegistryPivot = true
+			break
+		}
+	}
+	final, _ := readCutoverStatus(ctx, deps)
+	if active := final["registriesYamlActive"]; chainHasRegistryPivot && active != "v2" {
+		failMsg := fmt.Sprintf("cutover refuses cutoverComplete=true: registriesYamlActive=%q (want v2) — node containerd still on mothership Harbor", active)
+		_ = patchCutoverStatus(ctx, deps, map[string]string{
+			"currentStep": "",
+			"failedStep":  "registry-pivot",
+			"lastError":   failMsg,
+		})
+		h.publishCutoverEvent(bus, cutoverEvent{
+			Time:    finishedAt.Format(time.RFC3339),
+			Phase:   cutoverPhaseStepFailed,
+			Level:   "error",
+			Step:    "registry-pivot",
+			Message: failMsg,
+		})
+		h.log.Error("cutover: registry pivot invariant violated", "registriesYamlActive", active)
+		return
+	}
+
+	// Determine the TRUE first-run start (#3681): if a prior attempt already
+	// anchored cutoverStartedAt, that is the durable start; otherwise this run
+	// was the first and startedAt is the anchor. This is the value the durable
+	// seal records and the UI shows as total elapsed.
+	trueStartedAt := priorStatus["cutoverStartedAt"]
+	if trueStartedAt == "" {
+		trueStartedAt = startedAt.Format(time.RFC3339)
+	}
+
+	// Seal the DURABLE, revert-immune sovereignty fact (#3667) in the SAME
+	// transaction that flips the ConfigMap. The OpenBao seal survives a
+	// `helm upgrade bp-self-sovereign-cutover` that reverts the ConfigMap
+	// key to "false" — the resume hook + auto-trigger then read the seal
+	// FIRST and no-op, so a routine chart pin never re-fires the 600s hold.
+	if err := h.sealCutoverComplete(ctx, trueStartedAt, finishedAt.Format(time.RFC3339)); err != nil {
+		// Non-fatal: the ConfigMap still records cutoverComplete=true so the
+		// run is functionally done, but WITHOUT the seal a chart upgrade
+		// could revert + re-fire. Surface loudly so the operator re-runs (the
+		// re-run is idempotent and will re-attempt the seal).
+		h.log.Error("cutover: durable cutover-complete seal FAILED; flag is chart-revertible until re-sealed", "err", err)
+		h.publishCutoverEvent(bus, cutoverEvent{
+			Time:    finishedAt.Format(time.RFC3339),
+			Phase:   cutoverPhaseStepFailed,
+			Level:   "error",
+			Message: fmt.Sprintf("durable cutover-complete seal failed: %v — re-run /start to seal", err),
+		})
+	}
+
 	_ = patchCutoverStatus(ctx, deps, map[string]string{
 		"cutoverComplete":   "true",
 		"cutoverFinishedAt": finishedAt.Format(time.RFC3339),
@@ -1442,6 +1646,16 @@ func (h *Handler) runCutoverStep(ctx context.Context, deps *cutoverDeps, step cu
 			return fmt.Errorf("DaemonSet %s/%s did not reach ready in %s: %w",
 				deps.ns, jobOrDS, cutoverDaemonSetTimeout(), err)
 		}
+		// #3671: for the registry-pivot DaemonSet, Ready is necessary but
+		// NOT sufficient — a Ready DS whose loop wrote the v1 (mothership)
+		// file passes the bare ready-wait. Assert every node ACKED the v2
+		// (local-Harbor) swap; fail the step if any node is still on v1.
+		if step.stepName == cutoverStepRegistryPivot {
+			if err := waitForRegistryPivotNodeAcks(ctx, deps, jobOrDS); err != nil {
+				return fmt.Errorf("registry-pivot DaemonSet %s/%s ready but not all nodes acked v2 registries.yaml in %s: %w",
+					deps.ns, jobOrDS, cutoverDaemonSetTimeout(), err)
+			}
+		}
 	default:
 		return fmt.Errorf("internal error: unknown step mode %q", step.mode)
 	}
@@ -1548,6 +1762,32 @@ func (h *Handler) ResumeInterruptedCutover(ctx context.Context) {
 		h.log.Info("cutover-resume: deps factory unavailable; skipping startup resume",
 			"err", err,
 		)
+		return
+	}
+
+	// Durable, revert-immune sovereignty gate (#3667) — checked FIRST, before
+	// the status ConfigMap. If a `helm upgrade bp-self-sovereign-cutover`
+	// reverted the CM's cutoverComplete to "false" (and cutoverStartedAt to
+	// ""), the CM-only checks below would NOT early-return on
+	// cutoverComplete, but the cutoverStartedAt=="" guard would defer to the
+	// auto-trigger Job — which then re-fires the whole cutover. The sealed
+	// OpenBao fact survives the upgrade, so once it exists we backfill the CM
+	// and return without resuming anything. A seal-read error fails closed
+	// (skip resume) rather than risk a spurious re-fire.
+	if sealed, serr := h.sovereignCutoverComplete(ctx); serr != nil {
+		h.log.Warn("cutover-resume: durable seal check failed; skipping startup resume to avoid spurious re-fire",
+			"err", serr,
+		)
+		return
+	} else if sealed {
+		if deps != nil {
+			if status, rerr := readCutoverStatus(ctx, deps); rerr == nil && status["cutoverComplete"] != "true" {
+				_ = patchCutoverStatus(ctx, deps, map[string]string{"cutoverComplete": "true"})
+				h.log.Info("cutover-resume: already complete (sealed); backfilled reverted status ConfigMap, fired nothing")
+			} else {
+				h.log.Info("cutover-resume: already complete (sealed); nothing to resume")
+			}
+		}
 		return
 	}
 
@@ -1677,18 +1917,23 @@ func (h *Handler) ResumeInterruptedCutover(ctx context.Context) {
 // state — that's what was rendering `invalid CutoverState: <undefined>`
 // on otech113 (issue #933).
 type cutoverStatusResponse struct {
-	State             string              `json:"state"`
-	CutoverComplete   bool                `json:"cutoverComplete"`
-	CutoverStartedAt  string              `json:"cutoverStartedAt,omitempty"`
-	CutoverFinishedAt string              `json:"cutoverFinishedAt,omitempty"`
-	CurrentStep       string              `json:"currentStep,omitempty"`
-	CurrentStepIndex  int                 `json:"currentStepIndex"`
-	TotalSteps        int                 `json:"totalSteps"`
-	ProgressPercent   int                 `json:"progressPercent"`
-	FailedStep        string              `json:"failedStep,omitempty"`
-	LastError         string              `json:"lastError,omitempty"`
-	Steps             []cutoverStepStatus `json:"steps"`
-	Raw               map[string]string   `json:"raw,omitempty"`
+	State             string `json:"state"`
+	CutoverComplete   bool   `json:"cutoverComplete"`
+	CutoverStartedAt  string `json:"cutoverStartedAt,omitempty"`
+	CutoverFinishedAt string `json:"cutoverFinishedAt,omitempty"`
+	// CutoverLastAttemptStartedAt (#3681) carries the most-recent attempt's
+	// start (resume/re-fire), distinct from CutoverStartedAt which is the
+	// TRUE first-run anchor. The UI shows total elapsed from CutoverStartedAt
+	// and "current attempt" from this field.
+	CutoverLastAttemptStartedAt string              `json:"cutoverLastAttemptStartedAt,omitempty"`
+	CurrentStep                 string              `json:"currentStep,omitempty"`
+	CurrentStepIndex            int                 `json:"currentStepIndex"`
+	TotalSteps                  int                 `json:"totalSteps"`
+	ProgressPercent             int                 `json:"progressPercent"`
+	FailedStep                  string              `json:"failedStep,omitempty"`
+	LastError                   string              `json:"lastError,omitempty"`
+	Steps                       []cutoverStepStatus `json:"steps"`
+	Raw                         map[string]string   `json:"raw,omitempty"`
 }
 
 // cutoverStateValue returns the canonical wire string for the overall
@@ -1820,6 +2065,34 @@ func (h *Handler) HandleCutoverStatus(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+	// Durable-fact backfill (#3667). If a `helm upgrade
+	// bp-self-sovereign-cutover` reverted the status ConfigMap's
+	// cutoverComplete to "false" but the OpenBao seal exists, /status MUST
+	// still answer "sovereign" so the SovereigntyCard never flickers back to
+	// the "Achieve True Sovereignty" CTA. We re-derive from the seal here
+	// (read-only — the spawn/resume paths perform the durable backfill) and
+	// recover cutoverStartedAt/FinishedAt from the seal payload if the CM
+	// lost them too. Best-effort: a seal-read error leaves the CM-derived
+	// answer unchanged.
+	if status["cutoverComplete"] != "true" {
+		if sealed, serr := h.sovereignCutoverComplete(r.Context()); serr == nil && sealed {
+			status["cutoverComplete"] = "true"
+			if h.openbao != nil {
+				if data, derr := h.openbao.GetKVv2(r.Context(), "secret", cutoverCompleteSecretPath); derr == nil {
+					if status["cutoverStartedAt"] == "" {
+						if v, ok := data["cutoverStartedAt"].(string); ok {
+							status["cutoverStartedAt"] = v
+						}
+					}
+					if status["cutoverFinishedAt"] == "" {
+						if v, ok := data["cutoverFinishedAt"].(string); ok {
+							status["cutoverFinishedAt"] = v
+						}
+					}
+				}
+			}
+		}
+	}
 	// Pull step names from the status ConfigMap keys; the chart's
 	// step ConfigMaps may be deleted post-cutover, so /status MUST
 	// reconstruct from the durable status keys.
@@ -1944,6 +2217,7 @@ func buildCutoverStatusResponseFromMap(status map[string]string, stepNames []str
 	resp.State = cutoverStateValue(resp.CutoverComplete)
 	resp.CutoverStartedAt = status["cutoverStartedAt"]
 	resp.CutoverFinishedAt = status["cutoverFinishedAt"]
+	resp.CutoverLastAttemptStartedAt = status["cutoverLastAttemptStartedAt"]
 	resp.CurrentStep = status["currentStep"]
 	if v, err := strconv.Atoi(status["currentStepIndex"]); err == nil {
 		resp.CurrentStepIndex = v

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_activity_bridge_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_activity_bridge_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
@@ -48,6 +50,18 @@ func TestCutoverExecutionProjectsIntoJobsWithEdges(t *testing.T) {
 		makeCutoverStepCM("cutover-step-02-harbor-prewarm", "harbor-prewarm", 2, cutoverModeJob, minimalPodSpecYAML, ""),
 		makeCutoverStepCM("cutover-step-03-registry-pivot", "registry-pivot", 3, cutoverModeDaemonSetWait, "", "registry-pivot"),
 		makeReadyDaemonSet("registry-pivot"),
+		// #3671: harbor-prewarm flips registriesYamlActive=v2; pre-seed the
+		// per-node v2 acks (DesiredNumberScheduled=3) so the registry-pivot
+		// daemonset-wait ack-count passes deterministically in the fake.
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: cutoverStatusConfigMapName(), Namespace: cutoverTestNS},
+			Data: map[string]string{
+				"cutoverComplete":              "false",
+				"node.cp-1.registriesYaml":     "v2",
+				"node.worker-1.registriesYaml": "v2",
+				"node.worker-2.registriesYaml": "v2",
+			},
+		},
 	}
 	h, client := fakeHandlerWithCutover(t, objs...)
 	installJobReactor(t, client, batchv1.JobComplete)

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_durable_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_durable_test.go
@@ -1,0 +1,396 @@
+// cutover_durable_test.go — #3379 cutover-PROOF integrity tests.
+//
+// Covers the Go-side faces of #3379:
+//   - Face 1 (#3667): the durable, revert-immune sovereignty fact sealed in
+//     OpenBao gates re-fire + resume even when the status ConfigMap was
+//     reverted to cutoverComplete:"false" by a chart upgrade; runCutover
+//     seals it in the success tail; HandleCutoverStatus backfills from it.
+//   - Face 2 (#3671): runCutover refuses cutoverComplete=true while
+//     registriesYamlActive != "v2".
+//   - Face 4 (#3681): cutoverStartedAt is written ONCE (first run) and not
+//     re-stamped on resume; cutoverLastAttemptStartedAt advances per attempt.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
+)
+
+// fakeKVStore is a tiny in-memory KV-v2 backend supporting the GET + PUT
+// calls openbao.Client.{GetKVv2,PutKVv2} make, so a test can assert the
+// durable cutover-complete seal is written + read back. The path under test
+// is /v1/secret/data/<secretPath>.
+type fakeKVStore struct {
+	mu   sync.Mutex
+	data map[string]map[string]any // secretPath -> blob
+}
+
+func newFakeOpenbao(t *testing.T) (*openbao.Client, *fakeKVStore) {
+	t.Helper()
+	store := &fakeKVStore{data: map[string]map[string]any{}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Path shape: /v1/<mount>/data/<secretPath...>
+		const prefix = "/v1/secret/data/"
+		w.Header().Set("Content-Type", "application/json")
+		if len(r.URL.Path) <= len(prefix) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		key := r.URL.Path[len(prefix):]
+		store.mu.Lock()
+		defer store.mu.Unlock()
+		switch r.Method {
+		case http.MethodGet:
+			blob, ok := store.data[key]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"errors":[]}`))
+				return
+			}
+			env := map[string]any{"data": map[string]any{"data": blob}}
+			_ = json.NewEncoder(w).Encode(env)
+		case http.MethodPost, http.MethodPut:
+			var body struct {
+				Data map[string]any `json:"data"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			store.data[key] = body.Data
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"version":1}}`))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	client := &openbao.Client{Addr: srv.URL, Token: "test-token", HTTP: srv.Client()}
+	return client, store
+}
+
+// minimalPodSpec returns a one-container PodSpec for a job-mode cutover step.
+func minimalPodSpec(t *testing.T) *corev1.PodSpec {
+	t.Helper()
+	return &corev1.PodSpec{
+		RestartPolicy: corev1.RestartPolicyNever,
+		Containers: []corev1.Container{
+			{Name: "step", Image: "busybox:1.36", Command: []string{"true"}},
+		},
+	}
+}
+
+// seedCutoverSeal writes the durable cutover-complete fact directly into the
+// fake store, simulating a Sovereign that has ALREADY sealed it.
+func (s *fakeKVStore) seedCutoverSeal(startedAt, finishedAt string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[cutoverCompleteSecretPath] = map[string]any{
+		"cutoverComplete":   "true",
+		"cutoverStartedAt":  startedAt,
+		"cutoverFinishedAt": finishedAt,
+		"sealedAt":          finishedAt,
+	}
+}
+
+func (s *fakeKVStore) hasCutoverSeal() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.data[cutoverCompleteSecretPath]
+	return ok
+}
+
+// ── Face 1 (#3667) ──────────────────────────────────────────────────────────
+
+// TestResumeInterruptedCutover_NoOpWhenSealedDespiteRevertedCM proves the
+// core durability guarantee: the status ConfigMap reads cutoverComplete:"false"
+// AND cutoverStartedAt:"" (exactly the shape a `helm upgrade` revert produces),
+// yet because the OpenBao seal is present, the resume hook fires NOTHING and
+// backfills the CM to true.
+func TestResumeInterruptedCutover_NoOpWhenSealedDespiteRevertedCM(t *testing.T) {
+	// CM reverted by a chart upgrade: false + empty start (template defaults).
+	revertedCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cutoverStatusConfigMapName(), Namespace: cutoverTestNS},
+		Data: map[string]string{
+			"cutoverComplete":  "false",
+			"cutoverStartedAt": "",
+		},
+	}
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-01-x", "x", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+		revertedCM,
+	}
+	h, client := fakeHandlerWithCutover(t, objs...)
+	ob, store := newFakeOpenbao(t)
+	h.openbao = ob
+	store.seedCutoverSeal("2026-06-16T13:36:31Z", "2026-06-16T14:11:12Z")
+
+	jobCreates := 0
+	client.PrependReactor("create", "jobs", func(action clienttesting.Action) (bool, k8sruntime.Object, error) {
+		jobCreates++
+		return false, nil, nil
+	})
+
+	h.ResumeInterruptedCutover(context.Background())
+	time.Sleep(100 * time.Millisecond)
+
+	if jobCreates != 0 {
+		t.Errorf("resume created %d Jobs despite a sealed cutover (reverted CM must NOT re-fire), want 0", jobCreates)
+	}
+	cm, err := client.CoreV1().ConfigMaps(cutoverTestNS).Get(context.Background(),
+		cutoverStatusConfigMapName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get status CM: %v", err)
+	}
+	if cm.Data["cutoverComplete"] != "true" {
+		t.Errorf("cutoverComplete = %q after resume with seal present, want backfilled to true", cm.Data["cutoverComplete"])
+	}
+}
+
+// TestSpawnCutoverEngine_NoOpWhenSealedDespiteRevertedCM proves the auto-trigger
+// / operator spawn path ALSO no-ops on a reverted CM when the seal exists — so
+// the Helm post-upgrade auto-trigger Job cannot re-run the 600s hold.
+func TestSpawnCutoverEngine_NoOpWhenSealedDespiteRevertedCM(t *testing.T) {
+	revertedCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cutoverStatusConfigMapName(), Namespace: cutoverTestNS},
+		Data:       map[string]string{"cutoverComplete": "false", "cutoverStartedAt": ""},
+	}
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-01-x", "x", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+		revertedCM,
+	}
+	h, client := fakeHandlerWithCutover(t, objs...)
+	ob, store := newFakeOpenbao(t)
+	h.openbao = ob
+	store.seedCutoverSeal("2026-06-16T13:36:31Z", "2026-06-16T14:11:12Z")
+
+	jobCreates := 0
+	client.PrependReactor("create", "jobs", func(action clienttesting.Action) (bool, k8sruntime.Object, error) {
+		jobCreates++
+		return false, nil, nil
+	})
+
+	res, err := h.spawnCutoverEngine(context.Background(), &cutoverDeps{core: client, ns: cutoverTestNS}, "internal")
+	if err != nil {
+		t.Fatalf("spawnCutoverEngine: %v", err)
+	}
+	if res.outcome != cutoverSpawnAlreadyComplete {
+		t.Errorf("outcome = %v, want cutoverSpawnAlreadyComplete (sealed)", res.outcome)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if jobCreates != 0 {
+		t.Errorf("spawn created %d Jobs on a sealed (reverted-CM) cutover, want 0", jobCreates)
+	}
+}
+
+// TestRunCutover_SealsDurableFactOnSuccess proves the success tail seals the
+// durable fact in OpenBao in the same run that flips the CM to true.
+func TestRunCutover_SealsDurableFactOnSuccess(t *testing.T) {
+	statusCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cutoverStatusConfigMapName(), Namespace: cutoverTestNS},
+		// registriesYamlActive=v2 so the Face-2 invariant gate passes and the
+		// run reaches the seal (a DaemonSet-less job-only chain here).
+		Data: map[string]string{"cutoverComplete": "false", "registriesYamlActive": "v2"},
+	}
+	objs := []k8sruntime.Object{statusCM}
+	h, client := fakeHandlerWithCutover(t, objs...)
+	installJobReactor(t, client, batchv1.JobComplete)
+	ob, store := newFakeOpenbao(t)
+	h.openbao = ob
+
+	steps := []cutoverStep{
+		{stepName: "only-step", order: 1, mode: cutoverModeJob, podSpec: minimalPodSpec(t)},
+	}
+	h.runCutover(context.Background(), &cutoverDeps{core: client, ns: cutoverTestNS}, steps, false)
+
+	if !store.hasCutoverSeal() {
+		t.Errorf("durable cutover-complete seal was NOT written on success")
+	}
+	cm, _ := client.CoreV1().ConfigMaps(cutoverTestNS).Get(context.Background(),
+		cutoverStatusConfigMapName(), metav1.GetOptions{})
+	if cm.Data["cutoverComplete"] != "true" {
+		t.Errorf("cutoverComplete = %q, want true", cm.Data["cutoverComplete"])
+	}
+}
+
+// TestHandleCutoverStatus_BackfillsFromSeal proves /status answers
+// cutoverComplete=true (state=sovereign) when the CM was reverted but the seal
+// exists — so the SovereigntyCard never flickers back to the CTA.
+func TestHandleCutoverStatus_BackfillsFromSeal(t *testing.T) {
+	revertedCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cutoverStatusConfigMapName(), Namespace: cutoverTestNS},
+		Data:       map[string]string{"cutoverComplete": "false", "cutoverStartedAt": ""},
+	}
+	objs := []k8sruntime.Object{revertedCM}
+	h, _ := fakeHandlerWithCutover(t, objs...)
+	ob, store := newFakeOpenbao(t)
+	h.openbao = ob
+	store.seedCutoverSeal("2026-06-16T13:36:31Z", "2026-06-16T14:11:12Z")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereign/cutover/status", nil)
+	h.HandleCutoverStatus(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		State            string `json:"state"`
+		CutoverComplete  bool   `json:"cutoverComplete"`
+		CutoverStartedAt string `json:"cutoverStartedAt"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.CutoverComplete || resp.State != "sovereign" {
+		t.Errorf("backfill failed: cutoverComplete=%v state=%q, want true/sovereign", resp.CutoverComplete, resp.State)
+	}
+	if resp.CutoverStartedAt != "2026-06-16T13:36:31Z" {
+		t.Errorf("cutoverStartedAt = %q, want recovered from seal 2026-06-16T13:36:31Z", resp.CutoverStartedAt)
+	}
+}
+
+// ── Face 2 (#3671) ──────────────────────────────────────────────────────────
+
+// TestRunCutover_RefusesCompleteWhenRegistriesYamlV1 proves the invariant gate:
+// every step succeeds, but registriesYamlActive is still "v1" → the run FAILS
+// rather than sealing a false sovereignty fact over a still-tethered node.
+func TestRunCutover_RefusesCompleteWhenRegistriesYamlV1(t *testing.T) {
+	statusCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cutoverStatusConfigMapName(), Namespace: cutoverTestNS},
+		Data:       map[string]string{"cutoverComplete": "false", "registriesYamlActive": "v1"},
+	}
+	objs := []k8sruntime.Object{statusCM}
+	h, client := fakeHandlerWithCutover(t, objs...)
+	installJobReactor(t, client, batchv1.JobComplete)
+	ob, store := newFakeOpenbao(t)
+	h.openbao = ob
+
+	// A chain that CONTAINS registry-pivot (so the invariant gate applies) but
+	// NO harbor-prewarm step, so the engine never flips registriesYamlActive to
+	// v2 → it stays v1 → the invariant must fail. registry-pivot is run in
+	// job-mode here so the gate (which keys on step NAME) fires without
+	// invoking the DaemonSet ack-wait path.
+	steps := []cutoverStep{
+		{stepName: cutoverStepRegistryPivot, order: 1, mode: cutoverModeJob, podSpec: minimalPodSpec(t)},
+	}
+	h.runCutover(context.Background(), &cutoverDeps{core: client, ns: cutoverTestNS}, steps, false)
+
+	cm, _ := client.CoreV1().ConfigMaps(cutoverTestNS).Get(context.Background(),
+		cutoverStatusConfigMapName(), metav1.GetOptions{})
+	if cm.Data["cutoverComplete"] == "true" {
+		t.Errorf("cutoverComplete = true with registriesYamlActive=v1 — invariant gate failed to block")
+	}
+	if cm.Data["failedStep"] != "registry-pivot" {
+		t.Errorf("failedStep = %q, want registry-pivot", cm.Data["failedStep"])
+	}
+	if store.hasCutoverSeal() {
+		t.Errorf("durable seal was written despite registriesYamlActive=v1 — must NOT seal a still-tethered node")
+	}
+}
+
+// TestRunCutover_FlipsRegistriesYamlV2AfterHarborPrewarm proves the engine sets
+// registriesYamlActive=v2 the moment harbor-prewarm succeeds (keyed on step
+// NAME, not index), and then the invariant gate is satisfied so the run
+// completes.
+func TestRunCutover_FlipsRegistriesYamlV2AfterHarborPrewarm(t *testing.T) {
+	statusCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cutoverStatusConfigMapName(), Namespace: cutoverTestNS},
+		Data:       map[string]string{"cutoverComplete": "false", "registriesYamlActive": "v1"},
+	}
+	objs := []k8sruntime.Object{statusCM}
+	h, client := fakeHandlerWithCutover(t, objs...)
+	installJobReactor(t, client, batchv1.JobComplete)
+	ob, _ := newFakeOpenbao(t)
+	h.openbao = ob
+
+	steps := []cutoverStep{
+		{stepName: cutoverStepHarborPrewarm, order: 1, mode: cutoverModeJob, podSpec: minimalPodSpec(t)},
+	}
+	h.runCutover(context.Background(), &cutoverDeps{core: client, ns: cutoverTestNS}, steps, false)
+
+	cm, _ := client.CoreV1().ConfigMaps(cutoverTestNS).Get(context.Background(),
+		cutoverStatusConfigMapName(), metav1.GetOptions{})
+	if cm.Data["registriesYamlActive"] != "v2" {
+		t.Errorf("registriesYamlActive = %q, want v2 (flipped after harbor-prewarm)", cm.Data["registriesYamlActive"])
+	}
+	if cm.Data["cutoverComplete"] != "true" {
+		t.Errorf("cutoverComplete = %q, want true (v2 set → invariant satisfied)", cm.Data["cutoverComplete"])
+	}
+}
+
+// TestCountRegistryPivotV2Acks counts only node ack keys whose value is "v2".
+func TestCountRegistryPivotV2Acks(t *testing.T) {
+	status := map[string]string{
+		"node.cp-1.registriesYaml":     "v2",
+		"node.worker-1.registriesYaml": "v2",
+		"node.worker-2.registriesYaml": "v1", // not yet acked
+		"registriesYamlActive":         "v2", // not a node ack
+		"step.harbor-prewarm.result":   "success",
+	}
+	if got := countRegistryPivotV2Acks(status); got != 2 {
+		t.Errorf("countRegistryPivotV2Acks = %d, want 2 (only v2 node acks)", got)
+	}
+}
+
+// ── Face 4 (#3681) ──────────────────────────────────────────────────────────
+
+// TestRunCutover_StartedAtWrittenOnceAcrossResume proves the audit-fidelity
+// guard: two sequential runCutover calls (a resume after a catalyst-api roll)
+// leave cutoverStartedAt BYTE-IDENTICAL — the first run's value — while
+// cutoverLastAttemptStartedAt advances on the second.
+func TestRunCutover_StartedAtWrittenOnceAcrossResume(t *testing.T) {
+	statusCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cutoverStatusConfigMapName(), Namespace: cutoverTestNS},
+		Data:       map[string]string{"cutoverComplete": "false", "registriesYamlActive": "v2"},
+	}
+	objs := []k8sruntime.Object{statusCM}
+	h, client := fakeHandlerWithCutover(t, objs...)
+	installJobReactor(t, client, batchv1.JobComplete)
+	ob, _ := newFakeOpenbao(t)
+	h.openbao = ob
+
+	steps := []cutoverStep{
+		{stepName: "s1", order: 1, mode: cutoverModeJob, podSpec: minimalPodSpec(t)},
+	}
+
+	// First run.
+	h.runCutover(context.Background(), &cutoverDeps{core: client, ns: cutoverTestNS}, steps, false)
+	cm1, _ := client.CoreV1().ConfigMaps(cutoverTestNS).Get(context.Background(),
+		cutoverStatusConfigMapName(), metav1.GetOptions{})
+	firstStart := cm1.Data["cutoverStartedAt"]
+	firstAttempt := cm1.Data["cutoverLastAttemptStartedAt"]
+	if firstStart == "" {
+		t.Fatalf("cutoverStartedAt empty after first run")
+	}
+
+	// Reset cutoverComplete to false (simulate a chart-less mid-run resume that
+	// re-enters runCutover) and ensure a measurable time delta.
+	_ = patchCutoverStatus(context.Background(), &cutoverDeps{core: client, ns: cutoverTestNS},
+		map[string]string{"cutoverComplete": "false"})
+	time.Sleep(1100 * time.Millisecond)
+
+	// Second run (resume / re-fire).
+	h.runCutover(context.Background(), &cutoverDeps{core: client, ns: cutoverTestNS}, steps, false)
+	cm2, _ := client.CoreV1().ConfigMaps(cutoverTestNS).Get(context.Background(),
+		cutoverStatusConfigMapName(), metav1.GetOptions{})
+
+	if cm2.Data["cutoverStartedAt"] != firstStart {
+		t.Errorf("cutoverStartedAt changed on resume: %q -> %q (must be byte-identical, #3681)",
+			firstStart, cm2.Data["cutoverStartedAt"])
+	}
+	if cm2.Data["cutoverLastAttemptStartedAt"] == firstAttempt {
+		t.Errorf("cutoverLastAttemptStartedAt did NOT advance on resume (%q) — must carry the latest attempt time",
+			cm2.Data["cutoverLastAttemptStartedAt"])
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_internal.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_internal.go
@@ -92,6 +92,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	authnv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -175,6 +176,69 @@ func (h *Handler) sovereignHandoverComplete(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	return len(data) > 0, nil
+}
+
+// cutoverCompleteSecretPath is the KV-v2 path of the DURABLE, revert-immune
+// sovereignty fact (#3667). It mirrors the handover marker
+// (catalyst/tofu-phase0-archive) but records the FINAL state of the
+// cutover state machine: once the 11 steps run green AND the 600s
+// deny-egress hold holds, runCutover seals this in OpenBao in the SAME
+// transaction that flips the status ConfigMap's cutoverComplete=true.
+//
+// Why OpenBao and not the status ConfigMap: the status ConfigMap is
+// Helm/Flux-managed (the chart authors it at install with
+// data.cutoverComplete:"false"). A routine `helm upgrade
+// bp-self-sovereign-cutover` — chart pins land on running Sovereigns
+// constantly — runs helm-controller's 3-way merge, re-asserts the
+// template's "false" over the live "true", and re-arms the whole
+// cutover (the auto-trigger Job re-fires the 600s hold). OpenBao is
+// NOT chart-managed, so a chart upgrade cannot revert the seal. This
+// is the single durable bit that makes cutoverComplete=true a TRUE,
+// reconcile-immune proof of independence.
+const cutoverCompleteSecretPath = "catalyst/cutover-complete"
+
+// sovereignCutoverComplete reports whether THIS Sovereign has sealed the
+// durable cutover-complete fact (#3667). Modeled EXACTLY on
+// sovereignHandoverComplete: reads secret/catalyst/cutover-complete via
+// KV-v2; ABSENCE (ErrSecretNotFound) ⇒ false; a nil OpenBao client
+// (Catalyst-Zero, the orchestrator, is never itself a cutover subject)
+// reads as not-complete so the gate stays closed and a fresh prov can
+// still run its cutover.
+func (h *Handler) sovereignCutoverComplete(ctx context.Context) (bool, error) {
+	if h.openbao == nil {
+		return false, nil
+	}
+	data, err := h.openbao.GetKVv2(ctx, "secret", cutoverCompleteSecretPath)
+	if err != nil {
+		if errors.Is(err, openbao.ErrSecretNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return len(data) > 0, nil
+}
+
+// sealCutoverComplete writes the durable, revert-immune sovereignty fact
+// (#3667). Called from runCutover's success tail in the SAME block that
+// flips cutoverComplete=true in the status ConfigMap. The payload records
+// the audit anchor (true first-run start + finish) so the seal alone is
+// enough for HandleCutoverStatus to re-derive cutoverComplete=true even
+// if a chart upgrade reverted the ConfigMap.
+//
+// A nil OpenBao client is a non-fatal no-op (the orchestrator path):
+// the run still succeeds and the ConfigMap still carries the truth; only
+// the durable seal is skipped, which is correct because Catalyst-Zero is
+// never a cutover subject. The caller logs the skip.
+func (h *Handler) sealCutoverComplete(ctx context.Context, startedAt, finishedAt string) error {
+	if h.openbao == nil {
+		return nil
+	}
+	return h.openbao.PutKVv2(ctx, "secret", cutoverCompleteSecretPath, map[string]any{
+		"cutoverComplete":   "true",
+		"cutoverStartedAt":  startedAt,
+		"cutoverFinishedAt": finishedAt,
+		"sealedAt":          time.Now().UTC().Format(time.RFC3339),
+	})
 }
 
 // expectedInternalCutoverUsernames returns the set of acceptable SA
@@ -391,6 +455,39 @@ func (h *Handler) spawnCutoverEngine(ctx context.Context, deps *cutoverDeps, sou
 	status, err := readCutoverStatus(ctx, deps)
 	if err != nil {
 		return cutoverSpawnResult{}, fmt.Errorf("status-read-failed: %w", err)
+	}
+
+	// Durable, revert-immune sovereignty gate (#3667). Check the sealed
+	// OpenBao fact BEFORE the ConfigMap key. A routine `helm upgrade
+	// bp-self-sovereign-cutover` re-asserts the chart template's
+	// cutoverComplete:"false" over the live "true" (chart pins land on
+	// running Sovereigns constantly) — so the CM alone would read "false"
+	// and let the auto-trigger Job re-fire the whole cutover INCLUDING the
+	// 600s deny-egress hold on a customer cluster. The seal cannot be
+	// reverted by a chart upgrade, so once it exists we no-op regardless of
+	// what the CM says. Backfill the CM so the UI re-derives the green state
+	// on the next read. A status-read failure above is hard; a seal-read
+	// failure here is treated as "not sealed" only on ErrSecretNotFound
+	// (inside sovereignCutoverComplete) — any other error fails closed.
+	if sealed, serr := h.sovereignCutoverComplete(ctx); serr != nil {
+		return cutoverSpawnResult{}, fmt.Errorf("cutover-seal-check-failed: %w", serr)
+	} else if sealed {
+		bus := h.cutoverBusFor()
+		h.publishCutoverEvent(bus, cutoverEvent{
+			Phase:   cutoverPhaseAlreadyDone,
+			Level:   "info",
+			Message: fmt.Sprintf("cutover already complete (durable seal present); %s trigger is a no-op even if the status ConfigMap was reverted by a chart upgrade", source),
+		})
+		// Best-effort backfill so /status renders sovereign immediately.
+		if status["cutoverComplete"] != "true" {
+			_ = patchCutoverStatus(ctx, deps, map[string]string{"cutoverComplete": "true"})
+			status["cutoverComplete"] = "true"
+		}
+		return cutoverSpawnResult{
+			outcome:   cutoverSpawnAlreadyComplete,
+			status:    status,
+			stepNames: listStepNamesFromStatus(status),
+		}, nil
 	}
 
 	if status["cutoverComplete"] == "true" {

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_test.go
@@ -251,11 +251,26 @@ func TestListCutoverSteps_OrdersByOrderLabel(t *testing.T) {
 // DaemonSet wait sees a ready DS, and the status ConfigMap finishes
 // in cutoverComplete=true with every per-step row marked success.
 func TestHandleCutoverStart_RunsAllStepsAndPersistsCompleted(t *testing.T) {
+	// #3671: a real chain pivots the node registry. Include harbor-prewarm
+	// (which makes the engine flip registriesYamlActive=v2) BEFORE the
+	// registry-pivot daemonset-wait, and pre-seed the per-node v2 acks
+	// (DesiredNumberScheduled=3) the DaemonSet would write so the ack-wait
+	// passes deterministically in the fake. Without v2 + acks the cutover
+	// correctly REFUSES to complete (that negative path is its own test).
 	objs := []k8sruntime.Object{
 		makeCutoverStepCM("cutover-step-01-gitea-mirror", "gitea-mirror", 1, cutoverModeJob, minimalPodSpecYAML, ""),
-		makeCutoverStepCM("cutover-step-02-harbor-projects", "harbor-projects", 2, cutoverModeJob, minimalPodSpecYAML, ""),
+		makeCutoverStepCM("cutover-step-02-harbor-prewarm", cutoverStepHarborPrewarm, 2, cutoverModeJob, minimalPodSpecYAML, ""),
 		makeCutoverStepCM("cutover-step-03-registry-pivot", "registry-pivot", 3, cutoverModeDaemonSetWait, "", "registry-pivot"),
 		makeReadyDaemonSet("registry-pivot"),
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: cutoverStatusConfigMapName(), Namespace: cutoverTestNS},
+			Data: map[string]string{
+				"cutoverComplete":              "false",
+				"node.cp-1.registriesYaml":     "v2",
+				"node.worker-1.registriesYaml": "v2",
+				"node.worker-2.registriesYaml": "v2",
+			},
+		},
 	}
 	h, client := fakeHandlerWithCutover(t, objs...)
 	installJobReactor(t, client, batchv1.JobComplete)
@@ -290,11 +305,14 @@ func TestHandleCutoverStart_RunsAllStepsAndPersistsCompleted(t *testing.T) {
 	if cm.Data["cutoverComplete"] != "true" {
 		t.Errorf("cutoverComplete = %q, want true (data=%v)", cm.Data["cutoverComplete"], cm.Data)
 	}
-	for _, name := range []string{"gitea-mirror", "harbor-projects", "registry-pivot"} {
+	for _, name := range []string{"gitea-mirror", cutoverStepHarborPrewarm, "registry-pivot"} {
 		key := "step." + name + ".result"
 		if cm.Data[key] != "success" {
 			t.Errorf("%s = %q, want success", key, cm.Data[key])
 		}
+	}
+	if cm.Data["registriesYamlActive"] != "v2" {
+		t.Errorf("registriesYamlActive = %q, want v2 (#3671 — harbor-prewarm must flip it)", cm.Data["registriesYamlActive"])
 	}
 	if cm.Data["progressPercent"] != "100" {
 		t.Errorf("progressPercent = %q, want 100", cm.Data["progressPercent"])

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -3360,7 +3360,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "1.4.95",
+    "version": "1.4.96",
     "section": "pts-4-6-llm-serving",
     "depends": [
       "bp-cnpg",
@@ -4422,7 +4422,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.73",
+    "version": "0.1.74",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",


### PR DESCRIPTION
Refs #3379 — the five integrity faces of the cutover sovereignty proof (folds #3667 #3671 #3678 #3681 #3695). The predecessor scope proved the 11 steps RUN and the hold HOLDS; this PR makes the resulting `cutoverComplete=true` a **TRUE, DURABLE, REVERT-IMMUNE, BROAD** proof rather than a green checkmark over a still-tethered cluster.

Touches the cutover engine (`products/catalyst/bootstrap/api/internal/handler`) + the `bp-self-sovereign-cutover` chart ONLY, per the ticket's §11 boundary.

## Face 1 — durable, revert-immune fact (#3667)
- catalyst-api seals `secret/catalyst/cutover-complete` in OpenBao in `runCutover`'s success tail (`sealCutoverComplete`, modeled on `sovereignHandoverComplete`).
- `spawnCutoverEngine` + `ResumeInterruptedCutover` check the sealed fact **BEFORE** the ConfigMap key and no-op when sealed — a routine `helm upgrade bp-self-sovereign-cutover` that reverts the CM can no longer re-fire the 600s hold.
- `HandleCutoverStatus` backfills `cutoverComplete=true` from the seal so the SovereigntyCard never flickers back to the CTA.
- `09-cutover-status-configmap.yaml` is now **INIT-ONLY** (lookup guard): the chart never re-asserts `cutoverComplete:"false"`/`registriesYamlActive:"v1"` over the live values on upgrade.

## Face 2 — faithful registry pivot (#3671)
- `runCutover` flips `registriesYamlActive=v2` the moment `harbor-prewarm` succeeds (keyed on step **NAME**, not index) so the registry-pivot DaemonSet writes the **LOCAL** `registries.yaml`; the DS writes a per-node `node.<name>.registriesYaml=v2` ack which **step-04's daemonset-wait now COUNTS** (acks == `DesiredNumberScheduled`).
- `runCutover` **REFUSES** `cutoverComplete=true` while `registriesYamlActive != "v2"` (scoped to chains that contain a registry-pivot step).

## Face 3 — true deny-egress (#3678)
- step-08's CCNP is now a **TRUE default-deny egress** (`enableDefaultDeny.egress:true` + intra-cluster allow-list: `toCIDR` 10.42/10.43/10.96, `toEntities` kube-apiserver/host/remote-node/cluster, DNS `toPorts`) instead of a subtractive 4-CIDR block. The #3640 apiserver-strand is avoided by the allow-list, **not** by `enableDefaultDeny.egress:false`.
- an **active call-home assertion** curls `console.openova.io` + the mothership hosts FROM a pod under the hold and FAILS the proof if any connects (catches an *arbitrary* tether, not the 4 enumerated hosts).

## Face 4 — audit fidelity (#3681)
- `cutoverStartedAt` is written **ONCE** (first run, guarded by a prior-status read); resume/re-fire advance a separate `cutoverLastAttemptStartedAt` (surfaced on `/status`).

## Face 5 — host GitOps loop + zero residual tether (#3695)
- step-10's sso-bridge image override **MERGES with yq** into the **EXISTING** `values:` mapping (host-less, so `global.registryMirror` stays the single source of truth) — no more duplicate-`values:`-key `BuildFailed` that killed `bootstrap-kit` on hw150. A no-yq fallback **NO-OPs** when a `values:` block exists rather than corrupt the file.
- step-08 **HARD-gates** on `bootstrap-kit`/`sovereign-tls`/`sme-tenants` Ready and rolls **EVERY** external-registry workload under deny-egress (not one hand-picked).
- rbac: `daemonsets`/`statefulsets` `{update,patch}` for the generalized roll.

## Lockstep + gates
- chart `0.1.73 → 0.1.74` across `Chart.yaml` + `blueprint.yaml` + slot-06a pin (`06a-bp-self-sovereign-cutover.yaml`) + generated catalog (`blueprints.json` + `catalog.generated.ts`).
- `go test -race` green on `internal/handler` — new `cutover_durable_test.go` covers all four Go faces incl. the two-`runCutover` byte-identical audit test (#3681) + the `v1`-refusal negative (#3671).
- `helm lint`/`template` + `dash -n` on all 11 embedded scripts (busybox-ash parity) + `check-catalog-seed-lockstep.sh` all pass; UI builds.

## DoD
Founder-walkable per [`docs/ledger/uat-walkthrough/cutover-durable-true-deny-egress-and-faithful-pivot.md`](https://github.com/openova-io/openova/blob/cutover-3379-durable-true-deny-egress-faithful-pivot/docs/ledger/uat-walkthrough/cutover-durable-true-deny-egress-and-faithful-pivot.md) (Sections 0-6 + Appendix A). The live walk on a **fresh prov to `cutoverComplete=true`** is the acceptance gate — **do NOT merge**; the founder reviews against the DoD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)