### PR TITLE
feat(#3687): foundational CR-read/write spine — per-Org showback, honest org-controller status, Git-backed Application writes, treemap Job exclusion, one tenant.created payload

### DIFF
--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -365,14 +365,35 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			"organization", org.Name)
 	}
 
-	// 6. Status update — Ready=True plus the per-step federation
-	// conditions (always present so the access-matrix UI can render
-	// the federation column without conditional logic).
+	// 6. Status update. #3687 (fold #3669): the vCluster phase + the
+	// Ready condition derive from a LIVE readback of the vCluster
+	// HelmRelease the controller wrote (+ the per-Org Namespace), NOT
+	// from "I PUT the file." The old code hardcoded Phase=Provisioning
+	// and Ready=True the instant the Gitea PutFile returned — reporting a
+	// green Org over orphaned bytes when no Flux source watched the repo.
+	// Now Ready=True requires the HR to actually be Ready AND the
+	// namespace to exist; until then it sits False with a reason naming
+	// what is pending, and the reconcile requeues so the status converges
+	// as Flux brings the vCluster up.
+	vcPhase, vcReady, vcMsg := r.vclusterReadiness(ctx, org.Spec.Slug)
+	readyCond := orgapi.Condition{
+		Type:               "Ready",
+		LastTransitionTime: metav1.NewTime(time.Now()),
+	}
+	if vcReady {
+		readyCond.Status = "True"
+		readyCond.Reason = "Reconciled"
+		readyCond.Message = "vCluster HelmRelease Ready + Keycloak group + Gitea Org reconciled"
+	} else {
+		readyCond.Status = "False"
+		readyCond.Reason = "VClusterProvisioning"
+		readyCond.Message = vcMsg
+	}
 	desired := orgapi.OrganizationStatus{
 		VCluster: orgapi.VClusterStatus{
 			Name:        org.Spec.Slug,
 			HostCluster: r.HostCluster,
-			Phase:       "Provisioning", // Flux still has to spin up the HelmRelease
+			Phase:       vcPhase,
 		},
 		KeycloakGroup: orgapi.KeycloakGroupStatus{
 			ID:    kcID,
@@ -386,13 +407,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		},
 		IacBootstrap: iacStatus,
 		Conditions: []orgapi.Condition{
-			{
-				Type:               "Ready",
-				Status:             "True",
-				Reason:             "Reconciled",
-				Message:            "vCluster HelmRelease + Keycloak group + Gitea Org reconciled",
-				LastTransitionTime: metav1.NewTime(time.Now()),
-			},
+			readyCond,
 			idpCond,
 			mappersCond,
 			iacBootstrapCondition(iacStatus),
@@ -407,8 +422,106 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	log.Info("reconcile ok",
 		"keycloak_group", kcID,
 		"gitea_org", gOrg.Username,
-		"vcluster", org.Spec.Slug)
+		"vcluster", org.Spec.Slug,
+		"vcluster_phase", vcPhase,
+		"vcluster_ready", vcReady)
+
+	// Requeue until the vCluster HR is Ready so status.vcluster.phase +
+	// the Ready condition converge as Flux applies the Git-authored
+	// manifest. A steady-state (Ready) Org needs no periodic requeue —
+	// the Organization watch re-triggers on spec changes; the HR's own
+	// Flux reconcile drives the cluster state. While provisioning we poll
+	// the readback every 30s (matching the fail() cadence).
+	if !vcReady {
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
 	return ctrl.Result{}, nil
+}
+
+// vclusterReadiness reads back the vCluster HelmRelease the controller
+// authored (name "vcluster" in namespace <slug>, matching the
+// gitops.vclusterTemplate) plus the per-Org Namespace, and derives the
+// reported phase + a Ready bool + a human message (#3687 fold #3669).
+//
+// Phase ladder:
+//   - "Ready"        — the HR's Ready condition is True AND the namespace
+//                      exists. Only here does the Org go Ready=True.
+//   - "Provisioning" — the HR exists but is not yet Ready (Flux applied it,
+//                      the vCluster pod is still coming up), OR the HR's
+//                      Ready condition is explicitly False/unknown.
+//   - "Pending"      — neither the HR nor the namespace is visible yet:
+//                      the manifest was written to Git but no Flux source
+//                      has applied it (the "orphaned bytes" case the old
+//                      code masked as Ready). Surfaced honestly so the
+//                      operator sees the gap instead of a false green.
+//
+// Keys only off slug + HostCluster (both on the CR) → generic for any
+// Org/host, no per-org-name special-casing (#3687 §7d). Read failures
+// other than NotFound degrade to Provisioning (transient API blips
+// shouldn't flip a healthy Org to Pending) and requeue.
+func (r *Reconciler) vclusterReadiness(ctx context.Context, slug string) (phase string, ready bool, message string) {
+	nsExists := false
+	ns := &corev1.Namespace{}
+	switch err := r.Get(ctx, types.NamespacedName{Name: slug}, ns); {
+	case err == nil:
+		nsExists = true
+	case apierrors.IsNotFound(err):
+		nsExists = false
+	default:
+		return "Provisioning", false,
+			fmt.Sprintf("vCluster namespace readback error (transient): %s", err)
+	}
+
+	hr := &unstructured.Unstructured{}
+	hr.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "helm.toolkit.fluxcd.io",
+		Version: "v2",
+		Kind:    "HelmRelease",
+	})
+	switch err := r.Get(ctx, types.NamespacedName{Namespace: slug, Name: "vcluster"}, hr); {
+	case apierrors.IsNotFound(err):
+		// No HR in the cluster. The manifest was PUT to the per-Org Gitea
+		// repo but nothing applied it yet — orphaned bytes, not deployed.
+		return "Pending", false,
+			"vCluster HelmRelease not yet applied by Flux (manifest authored in Gitea; awaiting a Flux source/Kustomization to reconcile it)"
+	case err != nil:
+		return "Provisioning", false,
+			fmt.Sprintf("vCluster HelmRelease readback error (transient): %s", err)
+	}
+
+	hrReady := helmReleaseReady(hr)
+	if hrReady && nsExists {
+		return "Ready", true, ""
+	}
+	if !nsExists {
+		return "Provisioning", false,
+			"vCluster HelmRelease present but the per-Org namespace is not Active yet"
+	}
+	return "Provisioning", false,
+		"vCluster HelmRelease applied; awaiting its Ready condition (vCluster pod still coming up)"
+}
+
+// helmReleaseReady reports whether a Flux HelmRelease's `Ready` condition
+// is True. Flux v2 sets status.conditions[type=Ready].status to
+// "True"/"False"/"Unknown" once it has attempted a reconcile.
+func helmReleaseReady(hr *unstructured.Unstructured) bool {
+	conds, found, err := unstructured.NestedSlice(hr.Object, "status", "conditions")
+	if err != nil || !found {
+		return false
+	}
+	for _, ci := range conds {
+		c, ok := ci.(map[string]any)
+		if !ok {
+			continue
+		}
+		t, _, _ := unstructured.NestedString(c, "type")
+		if t != "Ready" {
+			continue
+		}
+		s, _, _ := unstructured.NestedString(c, "status")
+		return s == "True"
+	}
+	return false
 }
 
 // fail records a Failed condition + non-zero observedGeneration so the

--- a/core/controllers/organization/internal/controller/organization_controller_test.go
+++ b/core/controllers/organization/internal/controller/organization_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -392,6 +393,15 @@ func makeReconciler(t *testing.T, objs ...client.Object) (*Reconciler, *giteaSer
 	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
 		Group: "access.openova.io", Version: "v1alpha1", Kind: "UserAccessList",
 	}, &unstructured.UnstructuredList{})
+	// #3687 (fold #3669): register the Flux v2 HelmRelease GVK so the
+	// vCluster-readiness readback can Get the per-Org vCluster HR (and so
+	// tests can seed a Ready HR to drive the Org to Ready=True).
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmRelease",
+	}, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmReleaseList",
+	}, &unstructured.UnstructuredList{})
 
 	cl := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -455,8 +465,13 @@ func TestReconcile_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile error: %v", err)
 	}
-	if res.RequeueAfter != 0 {
-		t.Errorf("happy path should not requeue: got %v", res)
+	// #3687 (fold #3669): with the vCluster HR not yet applied by Flux
+	// (the fake cluster has no HelmRelease/namespace for "acme"), the
+	// controller must NOT over-claim. It requeues so status converges as
+	// the HR comes up — the honest replacement for the old
+	// "PutFile → Ready=True, no requeue" lie.
+	if res.RequeueAfter == 0 {
+		t.Errorf("while the vCluster HR is not yet Ready the reconcile must requeue, got %v", res)
 	}
 
 	// Keycloak: 1 EnsureGroup call.
@@ -498,6 +513,13 @@ func TestReconcile_HappyPath(t *testing.T) {
 	if got.Status.VCluster.Name != "acme" || got.Status.VCluster.HostCluster != "ct-eu-mgt-prod" {
 		t.Errorf("status.vcluster: got %+v", got.Status.VCluster)
 	}
+	// #3687 (fold #3669): no Flux source has applied the vCluster HR in
+	// this fake cluster, so the phase is honestly "Pending" (manifest
+	// authored in Gitea, awaiting reconcile) — NOT a frozen "Provisioning"
+	// that masks orphaned bytes, and certainly not "Ready".
+	if got.Status.VCluster.Phase != "Pending" {
+		t.Errorf("status.vcluster.phase: got %q want Pending (HR not yet applied)", got.Status.VCluster.Phase)
+	}
 	// Slice F2 added two federation-status conditions on every
 	// reconcile (NoFederation reason when spec.identity is empty —
 	// the access-matrix UI expects them to always be present).
@@ -511,8 +533,19 @@ func TestReconcile_HappyPath(t *testing.T) {
 		t.Fatalf("expected 5 conditions (Ready + 2 federation + IacRepoBootstrapped + PerOrgRealmProvisioned), got %d: %+v",
 			len(got.Status.Conditions), got.Status.Conditions)
 	}
-	if got.Status.Conditions[0].Type != "Ready" || got.Status.Conditions[0].Status != "True" {
-		t.Errorf("expected Ready=True at index 0, got %+v", got.Status.Conditions[0])
+	// #3687 (fold #3669): Ready is honestly False until the vCluster HR
+	// is Ready AND the namespace is Active. In this fake cluster neither
+	// exists yet, so Ready=False / VClusterProvisioning with an
+	// explanatory message — the old unconditional Ready=True was the
+	// "Ready over orphaned bytes" lie this ticket kills.
+	if got.Status.Conditions[0].Type != "Ready" || got.Status.Conditions[0].Status != "False" {
+		t.Errorf("expected Ready=False at index 0 (HR not yet applied), got %+v", got.Status.Conditions[0])
+	}
+	if got.Status.Conditions[0].Reason != "VClusterProvisioning" {
+		t.Errorf("expected Ready reason VClusterProvisioning, got %q", got.Status.Conditions[0].Reason)
+	}
+	if got.Status.Conditions[0].Message == "" {
+		t.Errorf("Ready=False must carry an explanatory message naming what is pending")
 	}
 	if got.Status.Conditions[1].Type != "IdentityProviderConfigured" ||
 		got.Status.Conditions[1].Status != "False" ||
@@ -541,6 +574,52 @@ func TestReconcile_HappyPath(t *testing.T) {
 		if !strings.HasPrefix(ua.GetName(), "acme-") {
 			t.Errorf("UserAccess name should be acme-prefixed, got %q", ua.GetName())
 		}
+	}
+}
+
+// TestReconcile_ReadyOnlyWhenVClusterHRReady — #3687 (fold #3669) C4
+// proof: the Org flips Ready=True and stops requeueing ONLY once the
+// vCluster HelmRelease is actually Ready AND the per-Org namespace
+// exists. Seeds a Ready HR (name "vcluster" in ns "acme") + the "acme"
+// namespace, then reconciles and asserts status.vcluster.phase=Ready,
+// Ready=True, and no requeue — the converse of the HappyPath test which
+// proves it sits False/Pending while the HR is absent.
+func TestReconcile_ReadyOnlyWhenVClusterHRReady(t *testing.T) {
+	t.Parallel()
+	org := sampleOrg()
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "acme"}}
+	hr := &unstructured.Unstructured{}
+	hr.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmRelease",
+	})
+	hr.SetNamespace("acme")
+	hr.SetName("vcluster")
+	_ = unstructured.SetNestedSlice(hr.Object, []any{
+		map[string]any{"type": "Ready", "status": "True"},
+	}, "status", "conditions")
+
+	r, _, _ := makeReconciler(t, org, ns, hr)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "acme"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("a Ready vCluster HR must stop the requeue, got %v", res)
+	}
+
+	var got orgapi.Organization
+	if err := r.Get(context.Background(), client.ObjectKey{Name: "acme"}, &got); err != nil {
+		t.Fatalf("get post-reconcile: %v", err)
+	}
+	if got.Status.VCluster.Phase != "Ready" {
+		t.Errorf("status.vcluster.phase: got %q want Ready (HR Ready + ns Active)", got.Status.VCluster.Phase)
+	}
+	if got.Status.Conditions[0].Type != "Ready" || got.Status.Conditions[0].Status != "True" {
+		t.Errorf("expected Ready=True once the HR is Ready, got %+v", got.Status.Conditions[0])
 	}
 }
 
@@ -716,9 +795,12 @@ func TestUpsertUserAccess_NamespaceScoped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile failed (regression — empty-namespace bug?): %v", err)
 	}
-	if res.RequeueAfter != 0 {
-		t.Errorf("happy path must not requeue: got %v", res)
-	}
+	// #3687 (fold #3669): the reconcile requeues while the vCluster HR is
+	// still provisioning (no HR/namespace seeded in this fake cluster).
+	// That is correct convergence behavior — the UserAccess writes below
+	// still happen on this pass; this test asserts their namespace, not
+	// the requeue cadence.
+	_ = res
 
 	// Assert every UserAccess CR carries metadata.namespace =
 	// r.UserAccessNamespace (catalyst-system).

--- a/core/controllers/organization/internal/controller/vcluster_readiness_test.go
+++ b/core/controllers/organization/internal/controller/vcluster_readiness_test.go
@@ -1,0 +1,146 @@
+// vcluster_readiness_test.go — #3687 (fold #3669). Locks the contract
+// that the Organization's vCluster phase + Ready condition derive from a
+// LIVE readback of the vCluster HelmRelease (+ the per-Org Namespace),
+// never from "I PUT the manifest to Gitea." The old code reported
+// Phase=Provisioning frozen + Ready=True the instant the Gitea PutFile
+// returned, painting a green Org over orphaned bytes.
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// toClientObjects adapts a runtime.Object slice into the client.Object
+// slice the fake builder's WithObjects expects.
+func toClientObjects(objs []runtime.Object) []client.Object {
+	out := make([]client.Object, 0, len(objs))
+	for _, o := range objs {
+		if co, ok := o.(client.Object); ok {
+			out = append(out, co)
+		}
+	}
+	return out
+}
+
+// hrGVK is the Flux v2 HelmRelease GVK the readback Gets.
+var hrGVK = schema.GroupVersionKind{Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmRelease"}
+
+// readbackScheme registers the core types + the unstructured HelmRelease
+// (and its List kind) so the controller-runtime fake client can serve a
+// typed Namespace Get and an unstructured HR Get.
+func readbackScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("add client-go scheme: %v", err)
+	}
+	s.AddKnownTypeWithName(hrGVK, &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(hrGVK.GroupVersion().WithKind("HelmReleaseList"), &unstructured.UnstructuredList{})
+	return s
+}
+
+func newHR(slug, readyStatus string) *unstructured.Unstructured {
+	hr := &unstructured.Unstructured{}
+	hr.SetGroupVersionKind(hrGVK)
+	hr.SetNamespace(slug)
+	hr.SetName("vcluster")
+	if readyStatus != "" {
+		_ = unstructured.SetNestedSlice(hr.Object, []any{
+			map[string]any{"type": "Ready", "status": readyStatus},
+		}, "status", "conditions")
+	}
+	return hr
+}
+
+func newNS(slug string) *corev1.Namespace {
+	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: slug}}
+}
+
+func TestVClusterReadiness_PhaseLadder(t *testing.T) {
+	const slug = "acme"
+
+	cases := []struct {
+		name      string
+		objs      []runtime.Object
+		wantPhase string
+		wantReady bool
+	}{
+		{
+			name:      "no HR, no namespace → Pending (orphaned bytes, NOT Ready)",
+			objs:      nil,
+			wantPhase: "Pending",
+			wantReady: false,
+		},
+		{
+			name:      "HR present but Ready=False → Provisioning",
+			objs:      []runtime.Object{newNS(slug), newHR(slug, "False")},
+			wantPhase: "Provisioning",
+			wantReady: false,
+		},
+		{
+			name:      "HR present, no Ready condition yet → Provisioning",
+			objs:      []runtime.Object{newNS(slug), newHR(slug, "")},
+			wantPhase: "Provisioning",
+			wantReady: false,
+		},
+		{
+			name:      "HR Ready=True but namespace missing → Provisioning",
+			objs:      []runtime.Object{newHR(slug, "True")},
+			wantPhase: "Provisioning",
+			wantReady: false,
+		},
+		{
+			name:      "HR Ready=True AND namespace Active → Ready",
+			objs:      []runtime.Object{newNS(slug), newHR(slug, "True")},
+			wantPhase: "Ready",
+			wantReady: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cl := fake.NewClientBuilder().
+				WithScheme(readbackScheme(t)).
+				WithObjects(toClientObjects(tc.objs)...).
+				Build()
+			r := &Reconciler{Log: logr.Discard()}
+			r.Client = cl
+
+			phase, ready, msg := r.vclusterReadiness(context.Background(), slug)
+			if phase != tc.wantPhase {
+				t.Errorf("phase = %q, want %q (msg=%q)", phase, tc.wantPhase, msg)
+			}
+			if ready != tc.wantReady {
+				t.Errorf("ready = %v, want %v (phase=%q msg=%q)", ready, tc.wantReady, phase, msg)
+			}
+			// A not-Ready result MUST carry an explanatory message so the
+			// operator console can surface why the Org is not green.
+			if !ready && msg == "" {
+				t.Errorf("not-Ready result must carry a non-empty message")
+			}
+		})
+	}
+}
+
+func TestHelmReleaseReady(t *testing.T) {
+	if helmReleaseReady(newHR("x", "True")) != true {
+		t.Errorf("Ready=True HR must report ready")
+	}
+	if helmReleaseReady(newHR("x", "False")) != false {
+		t.Errorf("Ready=False HR must report not-ready")
+	}
+	if helmReleaseReady(newHR("x", "")) != false {
+		t.Errorf("HR with no conditions must report not-ready")
+	}
+}

--- a/core/services/provisioning/handlers/organization_create.go
+++ b/core/services/provisioning/handlers/organization_create.go
@@ -52,32 +52,14 @@ import (
 	"github.com/openova-io/openova/core/services/shared/events"
 )
 
-// tenantCreatedPayload is the wire shape this consumer expects on
-// `tenant.created`. Mirrors core/services/tenant/handlers/handlers.go's
-// CreateOrg envelope: a Tenant doc plus an owner_email sibling
-// extracted from the caller's JWT. We intentionally mirror only the
-// fields the Organization CR needs — schema drift on unused fields
-// (Apps, AddOns, CustomDomains, etc.) is non-blocking.
-type tenantCreatedPayload struct {
-	ID         string `json:"id"`
-	Slug       string `json:"slug"`
-	Name       string `json:"name"`
-	OwnerID    string `json:"owner_id"`
-	OwnerEmail string `json:"owner_email"`
-	PlanID     string `json:"plan_id"`
-	// Tier is optional — defaults to "sme" when empty (the only tier
-	// the SME-pool wizard issues vouchers for as of TBD-C16). A future
-	// corporate-tier flow that publishes tenant.created can set this
-	// to "corporate" without code changes.
-	Tier string `json:"tier,omitempty"`
-	// BillingMode is optional — defaults to "real" when empty.
-	BillingMode string `json:"billing_mode,omitempty"`
-	// ParentDomain optionally overrides Handler.TenantParentDomain
-	// when a multi-pool Sovereign wants to pick the apex zone per
-	// tenant (omani.homes vs omani.rest vs omani.trades). Empty
-	// inherits the Sovereign-wide default.
-	ParentDomain string `json:"parent_domain,omitempty"`
-}
+// tenantCreatedPayload is the wire shape this consumer decodes on
+// `tenant.created`. #3687 (fold #3690/#3673) collapses the former
+// per-service copy into the ONE canonical struct in the shared module
+// (events.TenantCreatedPayload) — the same type the producer emits and
+// the bootstrap-API funnel maps onto, killing the 3-way drift the #3687
+// §3.1 audit measured. Kept as a local alias so existing call sites +
+// tests read unchanged; the underlying type is now shared, not a copy.
+type tenantCreatedPayload = events.TenantCreatedPayload
 
 // handleTenantCreated is the consumer for `tenant.created` (subject
 // `catalyst.tenant.created` on NATS, topic `sme.tenant.events` on

--- a/core/services/shared/events/tenant_created.go
+++ b/core/services/shared/events/tenant_created.go
@@ -1,0 +1,78 @@
+package events
+
+// tenant_created.go — #3687 (fold #3690/#3673). ONE shared wire shape for
+// the `tenant.created` event, so the producer (tenant-service CreateOrg),
+// the consumer (provisioning-service handleTenantCreated → Organization
+// CR), and the bootstrap-API funnel all agree on a single struct instead
+// of three divergent shapes:
+//
+//   - core/services/tenant/handlers/handlers.go    — published a flat
+//     anonymous struct embedding *store.Tenant + owner_email.
+//   - core/services/provisioning/handlers/organization_create.go — decoded
+//     a local `tenantCreatedPayload` (slug/owner_email/tier/…).
+//   - products/catalyst/bootstrap/api .../sme_tenant.go — built its own
+//     `orgShape` (Tier/BillingMode/ParentDomain).
+//
+// #3687 §2 (the law): "One unified primitive, no per-path special-case."
+// A single canonical type here is the seam the producer-side
+// unification rides — the Organization CR is minted from THIS shape, the
+// same one every door emits. Lives in the shared module both the
+// tenant-service and provisioning-service already import (alongside
+// UsageRecordedPayload).
+//
+// Only the fields the Organization CR needs are modelled; unused
+// store.Tenant fields (Apps, AddOns, CustomDomains, …) are intentionally
+// omitted so schema drift on them is non-blocking. The producer maps its
+// store.Tenant onto this via NewTenantCreatedPayload; the consumer decodes
+// straight into it.
+
+import "strings"
+
+// TenantCreatedPayload is the canonical JSON shape of the `tenant.created`
+// event. Field tags match the historical wire shape both the producer
+// emitted and the consumer decoded, so adopting this struct is wire-
+// compatible (no event-format migration required).
+type TenantCreatedPayload struct {
+	// ID is the tenant's stable identifier (store.Tenant.ID). Carried so
+	// the minted Organization CR can label-back to the projection row.
+	ID string `json:"id"`
+	// Slug is the DNS-/namespace-/repo-safe Organization identifier — the
+	// canonical name the org-controller keys every artifact off.
+	Slug string `json:"slug"`
+	// Name is the human display name (defaults to Slug when empty).
+	Name string `json:"name"`
+	// OwnerID is the creator's Keycloak user UUID.
+	OwnerID string `json:"owner_id"`
+	// OwnerEmail seeds the Organization's owner roster — required to mint
+	// a non-half-populated Organization CR.
+	OwnerEmail string `json:"owner_email"`
+	// PlanID is the selected plan (informational; tier drives RBAC).
+	PlanID string `json:"plan_id"`
+	// Tier is the Organization tier (defaults to "sme" when empty — the
+	// only tier the SME-pool wizard issues vouchers for today).
+	Tier string `json:"tier,omitempty"`
+	// BillingMode defaults to "real" when empty.
+	BillingMode string `json:"billing_mode,omitempty"`
+	// ParentDomain optionally overrides the Sovereign-wide default apex
+	// zone per tenant (omani.homes vs omani.rest vs omani.trade). Empty
+	// inherits the Sovereign default.
+	ParentDomain string `json:"parent_domain,omitempty"`
+}
+
+// NewTenantCreatedPayload builds a canonical payload from the raw fields a
+// producer has (the tenant-service maps its store.Tenant onto this). It
+// trims whitespace; downstream defaulting (tier→"sme", billing→"real",
+// name→slug) stays in the consumer so every door defaults identically.
+func NewTenantCreatedPayload(id, slug, name, ownerID, ownerEmail, planID, tier, billingMode, parentDomain string) TenantCreatedPayload {
+	return TenantCreatedPayload{
+		ID:           strings.TrimSpace(id),
+		Slug:         strings.TrimSpace(slug),
+		Name:         strings.TrimSpace(name),
+		OwnerID:      strings.TrimSpace(ownerID),
+		OwnerEmail:   strings.TrimSpace(ownerEmail),
+		PlanID:       strings.TrimSpace(planID),
+		Tier:         strings.TrimSpace(tier),
+		BillingMode:  strings.TrimSpace(billingMode),
+		ParentDomain: strings.TrimSpace(parentDomain),
+	}
+}

--- a/core/services/shared/events/tenant_created_test.go
+++ b/core/services/shared/events/tenant_created_test.go
@@ -1,0 +1,83 @@
+package events
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestTenantCreatedPayload_WireCompat locks the JSON shape so adopting the
+// shared struct on the producer + consumer is wire-compatible with the
+// historical `tenant.created` envelope (#3687 fold #3690/#3673). The tags
+// MUST stay snake_case so an in-flight event published by the old producer
+// still decodes, and vice-versa.
+func TestTenantCreatedPayload_WireCompat(t *testing.T) {
+	p := NewTenantCreatedPayload(
+		"tid-1", "acme", "ACME Corp", "owner-uuid", "ceo@acme.com",
+		"plan-pro", "sme", "real", "omani.homes")
+
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Decode into a map to assert the on-wire key names.
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal to map: %v", err)
+	}
+	for k, want := range map[string]string{
+		"id":            "tid-1",
+		"slug":          "acme",
+		"name":          "ACME Corp",
+		"owner_id":      "owner-uuid",
+		"owner_email":   "ceo@acme.com",
+		"plan_id":       "plan-pro",
+		"tier":          "sme",
+		"billing_mode":  "real",
+		"parent_domain": "omani.homes",
+	} {
+		if got, _ := m[k].(string); got != want {
+			t.Errorf("wire key %q = %q, want %q", k, got, want)
+		}
+	}
+
+	// Round-trip back into the struct.
+	var back TenantCreatedPayload
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("round-trip unmarshal: %v", err)
+	}
+	if back != p {
+		t.Errorf("round-trip mismatch: got %+v want %+v", back, p)
+	}
+}
+
+// TestNewTenantCreatedPayload_TrimsWhitespace ensures the constructor
+// normalizes inputs so a slug with stray whitespace never reaches the
+// org-controller's path-component validator.
+func TestNewTenantCreatedPayload_TrimsWhitespace(t *testing.T) {
+	p := NewTenantCreatedPayload("  tid  ", "  acme ", " ACME ", " uid ", " a@b.c ", " plan ", " sme ", " real ", " omani.homes ")
+	if p.Slug != "acme" || p.ID != "tid" || p.OwnerEmail != "a@b.c" || p.Tier != "sme" {
+		t.Errorf("constructor must trim whitespace, got %+v", p)
+	}
+}
+
+// TestTenantCreatedPayload_OptionalFieldsOmitEmpty proves tier/billing/
+// parent omit when empty (the SME-pool default path), so the consumer's
+// canonical defaulting applies rather than an explicit empty string.
+func TestTenantCreatedPayload_OptionalFieldsOmitEmpty(t *testing.T) {
+	p := NewTenantCreatedPayload("tid", "acme", "ACME", "uid", "a@b.c", "plan", "", "", "")
+	b, _ := json.Marshal(p)
+	var m map[string]any
+	_ = json.Unmarshal(b, &m)
+	for _, k := range []string{"tier", "billing_mode", "parent_domain"} {
+		if _, present := m[k]; present {
+			t.Errorf("empty optional field %q must be omitted from the wire", k)
+		}
+	}
+	// Required identity fields are always present.
+	for _, k := range []string{"id", "slug", "owner_email"} {
+		if _, present := m[k]; !present {
+			t.Errorf("required field %q must always be on the wire", k)
+		}
+	}
+}

--- a/core/services/tenant/handlers/handlers.go
+++ b/core/services/tenant/handlers/handlers.go
@@ -257,10 +257,17 @@ func (h *Handler) CreateOrg(w http.ResponseWriter, r *http.Request) {
 	// rather than minting a half-populated Organization CR).
 	claims, _ := middleware.ClaimsFromContext(r.Context())
 	ownerEmail, _ := claims["email"].(string)
-	tenantCreatedPayload := struct {
-		*store.Tenant
-		OwnerEmail string `json:"owner_email,omitempty"`
-	}{Tenant: tenant, OwnerEmail: ownerEmail}
+	// #3687 (fold #3690/#3673): emit the ONE canonical
+	// events.TenantCreatedPayload — the same struct the provisioning
+	// consumer decodes into and the bootstrap-API funnel maps onto —
+	// instead of a per-service anonymous struct embedding *store.Tenant
+	// (which flattened a dozen unused fields onto the wire). Tier /
+	// BillingMode / ParentDomain stay empty here (the SME-pool wizard
+	// default); the consumer applies the canonical defaults (tier→"sme",
+	// billing→"real"), so every door defaults identically.
+	tenantCreatedPayload := events.NewTenantCreatedPayload(
+		tenant.ID, tenant.Slug, tenant.Name, tenant.OwnerID, ownerEmail,
+		tenant.PlanID, "", "", "")
 	evt, err := events.NewEvent("tenant.created", "tenant-service", tenant.ID, tenantCreatedPayload)
 	if err == nil {
 		pubCtx, pubCancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/products/catalyst/bootstrap/api/internal/handler/application_iac_git.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_iac_git.go
@@ -1,0 +1,143 @@
+// Package handler — application_iac_git.go: #3687 (fold #3694) — the
+// running-Application spine's authoring home becomes Gitea (IaC), not an
+// etcd-only object the UI mutated directly.
+//
+// Founder law (#3687 §2): "IaC lives in Gitea; the Application CR's
+// authoring home is Git" (ARCHITECTURE §5.1 rule 10). "Anything must be
+// working perfectly even if you shut down Catalyst" (PRINCIPLES §3). An
+// Application CR born in etcd that the controller later mirrors to Git was
+// never IaC.
+//
+// BEFORE this file the create/update seams ended in a dynamic-client
+// `.Create`/`.Update` (endpoint_handler.go HandleCreateInstance,
+// applications_update.go HandleApplicationUpdate). The CR lived in etcd;
+// Gitea held nothing; a hand `git push` of an Application change had
+// nowhere to land. `kubectl get applications -A` could only ever reflect
+// what the API wrote directly — never a Git-resident estate.
+//
+// AFTER: every Application create/update/Context-append ALSO COMMITS the
+// desired-state CR into the per-Org `iac` repo (ADR-0009, the same repo +
+// org the org-controller bootstraps and the endpoint PR pipeline writes)
+// at `applications/<name>.yaml`. Flux on the host cluster reconciles that
+// path; a hand `git push` to the same file round-trips. The Application
+// CR's source of truth is therefore Git.
+//
+// Transitional, not big-bang (#3687 §8 — "a CONSTRAINT-driven refactor
+// enforced incrementally on each write seam as it is touched, not a
+// big-bang rewrite"): the existing etcd write is left in place as a warm
+// projection so the API response shape stays byte-identical and the
+// app-list informers keep serving while the Flux loop catches up. What
+// changes is that the bytes now ALSO exist in Git — the gap #3687 §3.4
+// measured ("Gitea IaC holds nothing") is closed for every touched seam.
+//
+// Graceful degradation (the catalog_edit_git.go precedent): when the
+// Gitea client is unwired (chroot Sovereign pre-cutover / CI without a
+// Gitea backend) the commit is a best-effort no-op — the etcd write
+// already succeeded, so the create/update still returns its real result.
+// The Application is never failed by a missing local Gitea; it merely
+// isn't yet Git-resident until Gitea is reachable.
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	sigyaml "sigs.k8s.io/yaml"
+
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/giteapr"
+)
+
+// applicationIaCBranch is the branch the per-Org `iac` Application CRs
+// live on. Same default branch the endpoint PR pipeline targets
+// (giteapr.DefaultBranch).
+const applicationIaCBranch = giteapr.DefaultBranch // "main"
+
+// applicationManifestPath is the canonical in-repo path for an
+// Application CR's IaC. Siblings the endpoint manifests the PR pipeline
+// writes under `apps/<app>/endpoints/<name>.yaml` (giteapr
+// .EndpointManifestPath); the Application's own desired state lives at
+// `applications/<name>.yaml` so Flux's per-Org Kustomization fans it out.
+func applicationManifestPath(name string) string {
+	return fmt.Sprintf("applications/%s.yaml", name)
+}
+
+// applicationIaCCommitAuthor stamps the commit so a sovereign-admin
+// scanning the `iac` repo history can tell a console-originated
+// Application write from a hand-authored git push. Per Inviolable
+// Principle #4 these are overridable via the canonical
+// CATALYST_GITOPS_COMMITTER_* env (shared with the tenant-gitops + catalog
+// writers); default to the catalyst-api identity.
+func applicationIaCCommitAuthor() gitea.PutFileOpts {
+	return gitea.PutFileOpts{
+		AuthorName:  envOr("CATALYST_GITOPS_COMMITTER_NAME", "catalyst-api"),
+		AuthorEmail: envOr("CATALYST_GITOPS_COMMITTER_EMAIL", "ops@openova.io"),
+	}
+}
+
+// applicationCRToYAML renders the desired-state Application CR to YAML for
+// Git. It strips server-populated / runtime fields (status, managedFields,
+// resourceVersion, uid, creationTimestamp, generation) so the committed
+// manifest is clean declarative IaC — what an operator would hand-author —
+// not an etcd snapshot. sigs.k8s.io/yaml honours the unstructured JSON
+// tags so the output is canonical Kubernetes YAML.
+func applicationCRToYAML(obj *unstructured.Unstructured) ([]byte, error) {
+	clean := obj.DeepCopy()
+	unstructured.RemoveNestedField(clean.Object, "status")
+	unstructured.RemoveNestedField(clean.Object, "metadata", "managedFields")
+	unstructured.RemoveNestedField(clean.Object, "metadata", "resourceVersion")
+	unstructured.RemoveNestedField(clean.Object, "metadata", "uid")
+	unstructured.RemoveNestedField(clean.Object, "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(clean.Object, "metadata", "generation")
+	unstructured.RemoveNestedField(clean.Object, "metadata", "selfLink")
+	return sigyaml.Marshal(clean.Object)
+}
+
+// commitApplicationCRToGit writes the Application CR's desired state into
+// the per-Org `iac` repo at `applications/<name>.yaml` (#3687 fold #3694).
+// Best-effort: a nil Gitea client (chroot/CI) or a byte-equal short-circuit
+// returns committed=false, err=nil; only a real write failure returns an
+// error, which the caller logs without failing the create/update (the
+// etcd projection already succeeded).
+//
+// Idempotent: EnsureOrg/EnsureRepo are find-or-create, and PutFile is a
+// byte-equal short-circuit (committed=false when the bytes are unchanged),
+// so a no-op re-commit of a steady-state CR makes zero Git writes.
+func (h *Handler) commitApplicationCRToGit(ctx context.Context, org string, obj *unstructured.Unstructured) (committed bool, err error) {
+	if h.giteaClient == nil {
+		return false, nil
+	}
+	org = strings.TrimSpace(org)
+	name := strings.TrimSpace(obj.GetName())
+	if org == "" || name == "" {
+		return false, fmt.Errorf("commitApplicationCRToGit: empty org or name")
+	}
+
+	manifest, mErr := applicationCRToYAML(obj)
+	if mErr != nil {
+		return false, fmt.Errorf("marshal Application CR: %w", mErr)
+	}
+
+	// Ensure the per-Org IaC repo exists (idempotent — the same
+	// EnsureOrg/EnsureRepo the endpoint PR pipeline + org-controller use).
+	if _, eErr := h.giteaClient.EnsureOrg(ctx, org,
+		org, fmt.Sprintf("Catalyst Organization %s", org), "private"); eErr != nil {
+		return false, fmt.Errorf("ensure gitea org %q: %w", org, eErr)
+	}
+	if _, eErr := h.giteaClient.EnsureRepo(ctx, org, giteapr.IaCRepoName,
+		"per-Org IaC — Application CRs + endpoint manifests reconciled by Flux", true); eErr != nil {
+		return false, fmt.Errorf("ensure gitea repo %s/%s: %w", org, giteapr.IaCRepoName, eErr)
+	}
+
+	path := applicationManifestPath(name)
+	msg := fmt.Sprintf("catalyst-api: commit Application %s/%s (console create/update)", org, name)
+	_, committed, pErr := h.giteaClient.PutFile(ctx, org, giteapr.IaCRepoName,
+		applicationIaCBranch, path, manifest, msg, applicationIaCCommitAuthor())
+	if pErr != nil {
+		return false, fmt.Errorf("put %s: %w", path, pErr)
+	}
+	return committed, nil
+}

--- a/products/catalyst/bootstrap/api/internal/handler/application_iac_git_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/application_iac_git_test.go
@@ -1,0 +1,126 @@
+// application_iac_git_test.go — #3687 (fold #3694). Locks the contract
+// that the running-Application write seams make Git the authoring home:
+// a create/update commits the desired-state Application CR into the
+// per-Org `iac` repo at `applications/<name>.yaml` (best-effort, clean
+// IaC, idempotent), so `kubectl get applications -A` reflects a
+// Git-resident estate and a hand `git push` round-trips.
+package handler
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/giteapr"
+)
+
+// sampleApplicationCR builds an Application CR carrying both clean
+// desired-state fields AND server-populated runtime fields, to prove the
+// YAML render strips the latter.
+func sampleApplicationCR() *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(ApplicationGVR().Group + "/" + ApplicationGVR().Version)
+	obj.SetKind("Application")
+	obj.SetName("blog")
+	obj.SetNamespace("acme")
+	obj.SetLabels(map[string]string{"catalyst.openova.io/organization": "acme"})
+	// Runtime / server fields that MUST be stripped from the IaC.
+	obj.SetResourceVersion("12345")
+	obj.SetUID("00000000-0000-0000-0000-000000000abc")
+	obj.SetGeneration(7)
+	_ = unstructured.SetNestedField(obj.Object, "Pending", "status", "phase")
+	// Desired-state spec.
+	_ = unstructured.SetNestedField(obj.Object, "bp-wordpress", "spec", "blueprintRef", "name")
+	_ = unstructured.SetNestedField(obj.Object, "1.2.3", "spec", "blueprintRef", "version")
+	_ = unstructured.SetNestedSlice(obj.Object, []any{
+		map[string]any{"name": "blog-shared-pg", "namespace": "acme", "context": "db/blog"},
+	}, "spec", "dependsOn")
+	return obj
+}
+
+func TestApplicationCRToYAML_StripsRuntimeFieldsKeepsSpec(t *testing.T) {
+	y, err := applicationCRToYAML(sampleApplicationCR())
+	if err != nil {
+		t.Fatalf("applicationCRToYAML: %v", err)
+	}
+	s := string(y)
+
+	// Desired state survives.
+	for _, want := range []string{
+		"kind: Application",
+		"name: blog",
+		"bp-wordpress",
+		"version: 1.2.3",
+		"db/blog",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("committed IaC missing %q; got:\n%s", want, s)
+		}
+	}
+	// Runtime / server fields are stripped — committed IaC is clean
+	// declarative state, not an etcd snapshot.
+	for _, bad := range []string{"status:", "resourceVersion", "uid:", "generation:", "managedFields"} {
+		if strings.Contains(s, bad) {
+			t.Errorf("committed IaC must NOT contain runtime field %q; got:\n%s", bad, s)
+		}
+	}
+}
+
+func TestCommitApplicationCRToGit_CommitsToPerOrgIaCRepo(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+
+	committed, err := h.commitApplicationCRToGit(context.Background(), "acme", sampleApplicationCR())
+	if err != nil {
+		t.Fatalf("commitApplicationCRToGit: %v", err)
+	}
+	if !committed {
+		t.Fatalf("expected a git commit, got committed=false")
+	}
+
+	// The Application CR landed at acme/iac/applications/blog.yaml.
+	key := giteaKey("acme", giteapr.IaCRepoName, applicationIaCBranch, "applications/blog.yaml")
+	raw, ok := fg.files[key]
+	if !ok {
+		t.Fatalf("expected committed Application CR at %s; have keys %v", key, fileKeys(fg))
+	}
+	if !strings.Contains(string(raw), "kind: Application") || !strings.Contains(string(raw), "name: blog") {
+		t.Errorf("committed Application CR malformed; got:\n%s", raw)
+	}
+
+	// Idempotency: a re-commit of the same CR targets the SAME single
+	// path (no duplicate / drifting files). The real gitea.Client.PutFile
+	// byte-equal short-circuit (committed=false on unchanged bytes) is its
+	// own contract; here we prove our writer is path-stable.
+	before := len(fg.files)
+	if _, err := h.commitApplicationCRToGit(context.Background(), "acme", sampleApplicationCR()); err != nil {
+		t.Fatalf("re-commit: %v", err)
+	}
+	if len(fg.files) != before {
+		t.Errorf("re-commit must not create a new file: had %d, now %d", before, len(fg.files))
+	}
+	if string(fg.files[key]) != string(raw) {
+		t.Errorf("re-commit of the same CR must produce byte-identical content")
+	}
+}
+
+func TestCommitApplicationCRToGit_UnwiredIsBestEffortNoop(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	// no SetGiteaClient → h.giteaClient == nil (chroot pre-cutover / CI)
+	committed, err := h.commitApplicationCRToGit(context.Background(), "acme", sampleApplicationCR())
+	if err != nil {
+		t.Fatalf("unwired commit must not error: %v", err)
+	}
+	if committed {
+		t.Fatalf("unwired commit must not report a commit")
+	}
+}
+
+func TestApplicationManifestPath(t *testing.T) {
+	if got := applicationManifestPath("blog"); got != "applications/blog.yaml" {
+		t.Errorf("applicationManifestPath(blog) = %q, want applications/blog.yaml", got)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update.go
@@ -425,6 +425,21 @@ func (h *Handler) HandleApplicationUpdate(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// #3687 (fold #3694) — the Application CR's authoring home is Git.
+	// A placement/topology/parameter change (e.g. single → active-active)
+	// commits the patched desired-state CR to the per-Org `iac` repo at
+	// `applications/<name>.yaml` so the fan-out is driven from Git, not an
+	// etcd-only Update. Best-effort: a missing Gitea backend / write
+	// failure does not fail the update (the etcd projection succeeded).
+	if committed, gErr := h.commitApplicationCRToGit(r.Context(), patched.GetNamespace(), patched); gErr != nil {
+		h.log.Warn("application IaC git commit failed on update (etcd projection still applied)",
+			"org", patched.GetNamespace(), "application", patched.GetName(), "error", gErr)
+	} else if committed {
+		h.log.Info("application IaC update committed to Gitea",
+			"org", patched.GetNamespace(), "application", patched.GetName(),
+			"path", applicationManifestPath(patched.GetName()))
+	}
+
 	resp := applicationUpdateResponse{
 		Kind:       "Application",
 		Name:       updated.GetName(),

--- a/products/catalyst/bootstrap/api/internal/handler/dashboard.go
+++ b/products/catalyst/bootstrap/api/internal/handler/dashboard.go
@@ -292,6 +292,21 @@ type podRow struct {
 	cluster     string  // cluster id (single-Sovereign per page today)
 	region      string  // openova.io/region label value (e.g. hz-hel-rtz-prod); empty on single-region
 	vcluster    string  // catalyst.openova.io/vcluster-role label value on the pod's host namespace (mgmt/dmz/rtz); empty for host pods
+	// org is the owning Organization, resolved from the pod's namespace
+	// `openova.io/organization` (or `catalyst.openova.io/organization`)
+	// label — the single join key across compliance/RBAC/billing
+	// (ARCHITECTURE.md:306). The organization-controller stamps it onto
+	// every per-Org namespace (gitops/manifests.go). Empty when the
+	// namespace carries no Org label (host/control-plane namespaces);
+	// showback attribution (#3687 fold #3677) buckets those under the
+	// platform-overhead line rather than mis-attributing them to a tenant.
+	org string
+	// ownerKind is the Kind of the pod's top-level owner (Deployment,
+	// StatefulSet, DaemonSet, Job, ...). showback attribution excludes
+	// `Job`-owned pods (one-shot cutover / scan / snapshot workloads) from
+	// tenant `apps[]` so ephemeral activity never renders as consumption
+	// (#3687 fold #3677).
+	ownerKind   string
 	cpuReq      float64 // millicores summed across containers (resources.requests.cpu)
 	memReq      float64 // bytes (resources.requests.memory)
 	cpuLim      float64 // millicores summed across containers (resources.limits.cpu)
@@ -404,6 +419,23 @@ func buildPodRows(pods, pvcs, podMetrics, namespaces, nodes []*unstructured.Unst
 		if region == "" && clusterCloudRegion != "" {
 			region = clusterCloudRegion
 		}
+		// org: the single billing/RBAC join key. The
+		// organization-controller stamps `openova.io/organization=<slug>`
+		// onto every per-Org namespace (gitops/manifests.go); a few
+		// surfaces also use the `catalyst.openova.io/organization` form.
+		// Host/control-plane namespaces carry neither → org stays "" and
+		// showback rolls the pod into the platform-overhead bucket
+		// instead of mis-attributing it to a tenant (#3687 fold #3677).
+		org := labelOr(nsLabels, "openova.io/organization", "catalyst.openova.io/organization")
+		if org == "" {
+			org = labelOr(p.GetLabels(), "openova.io/organization", "catalyst.openova.io/organization")
+		}
+		// ownerKind: the Kind of the pod's first (top-level) owner. Used
+		// to filter `Job`-owned one-shot pods out of tenant attribution.
+		ownerKind := ""
+		if refs := p.GetOwnerReferences(); len(refs) > 0 {
+			ownerKind = refs[0].Kind
+		}
 		row := podRow{
 			namespace:   p.GetNamespace(),
 			cluster:     clusterID,
@@ -411,6 +443,8 @@ func buildPodRows(pods, pvcs, podMetrics, namespaces, nodes []*unstructured.Unst
 			family:      family,
 			region:      region,
 			vcluster:    vcluster,
+			org:         org,
+			ownerKind:   ownerKind,
 			isReady:     podIsReady(p),
 			createdAt:   p.GetCreationTimestamp().Time,
 		}

--- a/products/catalyst/bootstrap/api/internal/handler/dashboard.go
+++ b/products/catalyst/bootstrap/api/internal/handler/dashboard.go
@@ -279,8 +279,31 @@ func (h *Handler) GetDashboardTreemap(w http.ResponseWriter, r *http.Request) {
 		nodes, _, _ := h.k8sCache.List(cid, "node", labels.Everything())
 		rows = append(rows, buildPodRows(pods, pvcs, podMetrics, namespaces, nodes, cid, clusterRegion[cid])...)
 	}
+	// #3687 (fold #3692): one-shot batch/v1 Job pods (cutover-*,
+	// scan-vulnerabilityreport-*, *-snapshot-save-*) are ephemeral
+	// activity, not estate — they must NEVER render as a treemap cell /
+	// "application". Drop them before aggregation so the Application layer
+	// reflects the durable workloads, not the Job/CronJob churn.
+	rows = dropEphemeralRows(rows)
 	resp := aggregateRows(rows, groupBy, colorBy, sizeBy)
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// dropEphemeralRows filters out pods owned by a batch/v1 Job — the
+// one-shot cutover / scan / snapshot workloads that are activity, not a
+// running application. Pods owned by anything else (Deployment,
+// StatefulSet, DaemonSet, ReplicaSet, CronJob-via-Job is still Job-owned)
+// are retained. Keys on the pod's top-level ownerRef Kind (podRow.ownerKind),
+// resolved in buildPodRows — no name-pattern matching (#3687 §7c).
+func dropEphemeralRows(rows []podRow) []podRow {
+	out := rows[:0]
+	for _, r := range rows {
+		if strings.EqualFold(r.ownerKind, "Job") {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
 }
 
 // podRow is one pod's contribution to the treemap. Built once,

--- a/products/catalyst/bootstrap/api/internal/handler/dashboard_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/dashboard_test.go
@@ -860,3 +860,34 @@ func TestDashboardTreemap_FamilyPodLabelOverridesNamespace(t *testing.T) {
 	}
 }
 
+// TestDropEphemeralRows_FiltersJobOwnedPods — #3687 (fold #3692): one-shot
+// Job pods (cutover-*, scan-vulnerabilityreport-*, *-snapshot-save-*) must
+// NEVER survive into the treemap. Durable workloads (Deployment /
+// StatefulSet / DaemonSet / ReplicaSet) are retained.
+func TestDropEphemeralRows_FiltersJobOwnedPods(t *testing.T) {
+	rows := []podRow{
+		{namespace: "harbor", application: "harbor", ownerKind: "StatefulSet", cpuReq: 200},
+		{namespace: "flux-system", application: "cutover-harbor-prewarm", ownerKind: "Job", cpuReq: 50},
+		{namespace: "trivy-system", application: "scan-vulnerabilityreport-abc", ownerKind: "Job", cpuReq: 30},
+		{namespace: "openbao", application: "openbao-snapshot-save", ownerKind: "Job", cpuReq: 20},
+		{namespace: "kube-system", application: "cilium", ownerKind: "DaemonSet", cpuReq: 100},
+	}
+	got := dropEphemeralRows(rows)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 durable rows after dropping Job pods, got %d: %+v", len(got), got)
+	}
+	for _, r := range got {
+		if strings.EqualFold(r.ownerKind, "Job") {
+			t.Errorf("a Job-owned pod survived: %+v", r)
+		}
+	}
+
+	// Integration: a Job pod produces NO treemap cell under group_by=application.
+	out := aggregateRows(dropEphemeralRows([]podRow{
+		{namespace: "trivy-system", application: "scan-vulnerabilityreport-xyz", ownerKind: "Job", cpuReq: 30},
+	}), []string{"application"}, "health", "cpu_request")
+	if len(out.Items) != 0 {
+		t.Errorf("a Job-only estate must yield zero application cells, got %d: %+v", len(out.Items), out.Items)
+	}
+}
+

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
@@ -915,6 +915,24 @@ func (h *Handler) HandleCreateInstance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// #3687 (fold #3694) — the Application CR's authoring home is Git.
+	// Commit the desired-state CR into the per-Org `iac` repo at
+	// `applications/<name>.yaml` so Flux reconciles it and a hand
+	// `git push` round-trips (the canonical representation stops being
+	// etcd-only). Best-effort: a missing Gitea backend (chroot/CI) or a
+	// write failure does NOT fail the create — the etcd projection above
+	// already succeeded and keeps the app-list warm while the Flux loop
+	// catches up. We commit `obj` (the clean desired state) rather than
+	// `created` (which carries server-populated status/managedFields).
+	if committed, gErr := h.commitApplicationCRToGit(r.Context(), body.Org, obj); gErr != nil {
+		h.log.Warn("application IaC git commit failed (etcd projection still created)",
+			"org", body.Org, "application", body.Name, "error", gErr)
+	} else if committed {
+		h.log.Info("application IaC committed to Gitea",
+			"org", body.Org, "application", body.Name,
+			"path", applicationManifestPath(body.Name))
+	}
+
 	resp := application{
 		applicationSummary: applicationSummary{
 			ID:        string(created.GetUID()),
@@ -1045,6 +1063,13 @@ func (h *Handler) wireBackingServices(ctx context.Context, client dynamic.Interf
 					return nil, &backingError{status: http.StatusInternalServerError, code: "backing-create-failed", message: cerr.Error()}
 				}
 			}
+			// #3687 (fold #3694) — the auto-created backing instance is its
+			// OWN Application; commit its desired-state CR to the per-Org
+			// `iac` repo so the new card's IaC is Git-resident too.
+			if _, gErr := h.commitApplicationCRToGit(ctx, body.Org, backingObj); gErr != nil {
+				h.log.Warn("backing-service Application IaC git commit failed (etcd projection still created)",
+					"org", body.Org, "application", backingObj.GetName(), "error", gErr)
+			}
 			dependsOn = append(dependsOn, map[string]interface{}{
 				"name":      backingName,
 				"namespace": body.Org,
@@ -1090,6 +1115,14 @@ func (h *Handler) wireBackingServices(ctx context.Context, client dynamic.Interf
 			}
 			if _, uerr := client.Resource(ApplicationGVR()).Namespace(target.GetNamespace()).Update(ctx, target, metav1.UpdateOptions{}); uerr != nil {
 				return nil, &backingError{status: http.StatusInternalServerError, code: "context-write-failed", message: uerr.Error()}
+			}
+			// #3687 (fold #3694) — the appended Context is "the declared
+			// IaC": commit the reused instance's updated CR (now carrying
+			// the new Context in spec.parameters) to its per-Org `iac` repo
+			// so the Context delta lands in Git, not only etcd.
+			if _, gErr := h.commitApplicationCRToGit(ctx, target.GetNamespace(), target); gErr != nil {
+				h.log.Warn("Context-append Application IaC git commit failed (etcd projection still applied)",
+					"org", target.GetNamespace(), "application", target.GetName(), "error", gErr)
 			}
 			dependsOn = append(dependsOn, map[string]interface{}{
 				"name":      target.GetName(),

--- a/products/catalyst/bootstrap/api/internal/handler/sme_consumption.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_consumption.go
@@ -1,10 +1,19 @@
-// sme_consumption.go — the B3 metering feed (issue #3378 §6 B3).
+// sme_consumption.go — the B3 metering feed (issue #3378 §6 B3, made
+// per-Organization-honest by #3687 fold #3677).
 //
 // Per-org consumption aggregation, labeled by org, exposed via ONE GET
-// the Organizations billing pages read. The FIRST deliverable is parent
-// self-showback (testable with zero sub-orgs): on a Sovereign with no
-// sub-orgs, 100% of consumption attributes to the parent organization,
-// broken down per application / namespace (#3378 DoD 3 + §5).
+// the Organizations billing pages read. Attribution keys on the single
+// `openova.io/organization` join key (ARCHITECTURE.md:306) stamped on
+// every per-Org namespace by the organization-controller
+// (gitops/manifests.go) — NOT a hardcoded constant. A pod whose
+// namespace carries no Org label (host/control-plane namespaces) and
+// every one-shot `Job`-owned pod (cutover / scan / snapshot) rolls up
+// into a single, visually-distinct "Platform overhead" line rather than
+// being mis-attributed to a tenant. On a Sovereign with zero customer
+// Organizations the only tenant-ish row is that Platform-overhead
+// rollup under the parent; the moment the first per-Org namespace
+// appears with the label, a second org row materializes with no code
+// change — the #3687 generality proof (DoD 6 + §7c).
 //
 // Meter source — the lean kube-metrics aggregation (the §6 B3 alternative,
 // "no new component"): this REUSES the existing per-namespace per-pod
@@ -26,17 +35,28 @@ package handler
 
 import (
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-// orgConsumption is one org's consumption rollup. With zero sub-orgs the
-// only row is the parent (org="<parent>", isParent=true) carrying 100%.
+// orgConsumption is one org's consumption rollup. The parent estate row
+// (isParent=true) is always present and ordered first; customer
+// Organizations follow, attributed via the `openova.io/organization`
+// join key; the synthetic platform-overhead row (isPlatform=true) carries
+// all control-plane + one-shot-Job consumption and is ordered last so the
+// console can render it as a single visually-distinct line (#3687 fold
+// #3677 §6).
 type orgConsumption struct {
 	Org      string `json:"org"`
 	IsParent bool   `json:"isParent"`
+	// IsPlatform flags the synthetic "Platform overhead" rollup — the
+	// control-plane / infra / one-shot-Job consumption that is NOT a
+	// tenant. The console renders this as one distinct line, never
+	// itemized inside a tenant's app list.
+	IsPlatform bool `json:"isPlatform"`
 	// CostUnits — the showback cost in abstract attribution units (the
 	// weighted CPU+memory+storage sum). Showback attributes consumption;
 	// it is not a billed currency amount.
@@ -83,6 +103,63 @@ const (
 	bytesPerGiB         = 1 << 30 // 1 GiB
 )
 
+// platformOrg is the synthetic bucket every control-plane / infra /
+// one-shot-Job pod rolls into. It is distinct from any real tenant org
+// and from the parent estate so the console can render it as a single
+// "Platform overhead" line, never itemized as `scan-vulnerabilityreport-…`
+// inside a tenant's app list (#3687 fold #3677 §6). The double-underscore
+// guards against collision with a real slug (slugs match
+// [a-z][a-z0-9-]{2,30}).
+const platformOrg = "__platform__"
+
+// defaultInfraNamespaces is the baked-in default set of host /
+// control-plane namespaces whose pods are NEVER tenant consumption. It is
+// the floor, not the law: SHOWBACK_INFRA_NAMESPACES (comma-separated)
+// extends it per Sovereign (Principle #4 — config, not a frozen literal).
+// Pods in these namespaces roll into the platformOrg bucket regardless of
+// any Org label, because the join key only becomes meaningful once a real
+// per-Org namespace exists.
+var defaultInfraNamespaces = []string{
+	"kube-system",
+	"flux-system",
+	"trivy-system",
+	"kyverno",
+	"cnpg",
+	"falco",
+	"cert-manager",
+	"external-secrets-system",
+	"sigstore-system",
+	"monitoring",
+	"observability",
+	"cilium-secrets",
+	"gateway-system",
+	"catalyst",
+	"catalyst-system",
+	"shared-data",
+	"dmz",
+	"rtz",
+	"mgmt",
+}
+
+// infraNamespaceSet builds the effective infra-namespace exclusion set:
+// the baked-in default floor merged with the SHOWBACK_INFRA_NAMESPACES
+// env override. Returned as a set for O(1) membership. Exported-to-test
+// via the explicit-set overload on aggregateConsumption so the unit test
+// drives a deterministic set with no env dependency.
+func infraNamespaceSet(envValue string) map[string]struct{} {
+	set := make(map[string]struct{}, len(defaultInfraNamespaces)+8)
+	for _, ns := range defaultInfraNamespaces {
+		set[ns] = struct{}{}
+	}
+	for _, ns := range strings.Split(envValue, ",") {
+		ns = strings.TrimSpace(ns)
+		if ns != "" {
+			set[ns] = struct{}{}
+		}
+	}
+	return set
+}
+
 // HandleSovereignConsumption — GET /api/v1/sme/consumption.
 func (h *Handler) HandleSovereignConsumption(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
@@ -115,16 +192,22 @@ func (h *Handler) HandleSovereignConsumption(w http.ResponseWriter, r *http.Requ
 
 	rows := buildPodRows(pods, pvcs, podMetrics, namespaces, nodes, clusterID, "")
 
-	resp := aggregateConsumption(rows, parentOrg)
+	resp := aggregateConsumption(rows, parentOrg, infraNamespaceSet(os.Getenv("SHOWBACK_INFRA_NAMESPACES")))
 	writeJSON(w, http.StatusOK, resp)
 }
 
 // aggregateConsumption rolls podRows up into the per-org / per-app
-// showback shape. orgFor maps a namespace to its owning org; today every
-// namespace attributes to the parent (sub-org namespaces carry the
-// vcluster/org label that a later PR keys on — until then 100% → parent,
-// which is exactly the §5 day-one showback contract).
-func aggregateConsumption(rows []podRow, parentOrg string) SovereignConsumptionResponse {
+// showback shape (#3687 fold #3677). Attribution keys on the pod's real
+// `openova.io/organization` namespace label (resolved in buildPodRows
+// into podRow.org). A pod is rolled into the synthetic platformOrg
+// bucket — never a tenant — when ANY of these hold:
+//   - its namespace is in the infra-exclusion set (host / control-plane),
+//   - it is owned by a batch/v1 Job (one-shot cutover / scan / snapshot),
+//   - or its namespace carries no Org label at all.
+// Real per-Org namespaces (stamped by the organization-controller) yield
+// their own org row immediately, with no per-name special-casing — adding
+// a third org needs zero code change (the generality proof §7c).
+func aggregateConsumption(rows []podRow, parentOrg string, infraNamespaces map[string]struct{}) SovereignConsumptionResponse {
 	// org → namespace+app key → app rollup.
 	type appKey struct{ org, ns, app string }
 	appAgg := map[appKey]*appConsumption{}
@@ -133,7 +216,12 @@ func aggregateConsumption(rows []podRow, parentOrg string) SovereignConsumptionR
 	ensureOrg := func(org string) *orgConsumption {
 		oc, ok := orgAgg[org]
 		if !ok {
-			oc = &orgConsumption{Org: org, IsParent: org == parentOrg, Apps: []appConsumption{}}
+			oc = &orgConsumption{
+				Org:        org,
+				IsParent:   org == parentOrg,
+				IsPlatform: org == platformOrg,
+				Apps:       []appConsumption{},
+			}
 			orgAgg[org] = oc
 		}
 		return oc
@@ -143,7 +231,7 @@ func aggregateConsumption(rows []podRow, parentOrg string) SovereignConsumptionR
 
 	var total float64
 	for _, row := range rows {
-		org := orgForNamespace(row, parentOrg)
+		org := orgForRow(row, infraNamespaces)
 		cpuMilli := row.cpuReq
 		memGiB := row.memReq / bytesPerGiB
 		storageGiB := row.storageLim / bytesPerGiB
@@ -197,9 +285,15 @@ func aggregateConsumption(rows []podRow, parentOrg string) SovereignConsumptionR
 		oc.StorageGiB = round2(oc.StorageGiB)
 		orgs = append(orgs, *oc)
 	}
+	// Ordering: parent estate first, then customer Organizations by
+	// descending cost, then the synthetic platform-overhead row last so
+	// the console renders it as a trailing distinct line (#3687 §6).
 	sort.Slice(orgs, func(i, j int) bool {
 		if orgs[i].IsParent != orgs[j].IsParent {
 			return orgs[i].IsParent // parent first
+		}
+		if orgs[i].IsPlatform != orgs[j].IsPlatform {
+			return orgs[j].IsPlatform // platform overhead last
 		}
 		return orgs[i].CostUnits > orgs[j].CostUnits
 	})
@@ -210,14 +304,26 @@ func aggregateConsumption(rows []podRow, parentOrg string) SovereignConsumptionR
 	}
 }
 
-// orgForNamespace maps a pod's namespace to its owning org. Today every
-// namespace attributes to the parent (§5 day-one: 100% → parent). When a
-// sub-org's vCluster/namespace carries an org label, a later PR keys on
-// it here — the showback labels stay identical, so chargeback "becomes
-// meaningful automatically when the first sub-org splits out" (§5) with
-// no new mechanism.
-func orgForNamespace(_ podRow, parentOrg string) string {
-	return parentOrg
+// orgForRow resolves the owning org for a pod row's showback attribution
+// (#3687 fold #3677). It reads the real `openova.io/organization` join key
+// carried on podRow.org (resolved in buildPodRows from the namespace
+// label the organization-controller stamps). Control-plane / infra
+// namespaces, one-shot Job-owned pods, and any pod whose namespace lacks
+// an Org label roll into the synthetic platformOrg bucket so they render
+// as a single "Platform overhead" line, never inside a tenant's app list.
+// No per-org-name or per-namespace-name special-casing: the resolver keys
+// purely on the label + the config-driven exclusion set.
+func orgForRow(row podRow, infraNamespaces map[string]struct{}) string {
+	if _, infra := infraNamespaces[row.namespace]; infra {
+		return platformOrg
+	}
+	if strings.EqualFold(row.ownerKind, "Job") {
+		return platformOrg
+	}
+	if org := strings.TrimSpace(row.org); org != "" {
+		return org
+	}
+	return platformOrg
 }
 
 // consumptionParentOrg resolves the parent org name (the Sovereign FQDN).

--- a/products/catalyst/bootstrap/api/internal/handler/sme_consumption_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_consumption_test.go
@@ -1,7 +1,14 @@
 // sme_consumption_test.go — the B3 showback aggregation (issue #3378
-// DoD 3 + §5). Locks the day-one contract: with zero sub-orgs 100% of
-// consumption attributes to the parent, broken down per application, with
-// per-app percent shares that sum to ~100.
+// DoD 3 + §5), made per-Organization-honest by #3687 fold #3677.
+//
+// Locks the corrected contract:
+//   - attribution keys on the real `openova.io/organization` namespace
+//     label carried on podRow.org (NOT a hardcoded 100%-to-parent),
+//   - control-plane / infra namespaces and one-shot Job-owned pods roll
+//     into a single synthetic "Platform overhead" row (isPlatform=true),
+//     never inside a tenant's app list,
+//   - a real per-Org namespace immediately yields its own org row with
+//     no per-name special-casing (the generality proof §7c).
 package handler
 
 import (
@@ -9,71 +16,153 @@ import (
 	"testing"
 )
 
-func TestAggregateConsumption_ParentSelfShowback(t *testing.T) {
-	const parent = "hw130.omantel.biz"
+// testInfraSet is the deterministic infra-exclusion set the unit tests
+// drive (no env dependency). Mirrors the production default floor for the
+// namespaces the tests exercise.
+func testInfraSet() map[string]struct{} {
+	return infraNamespaceSet("")
+}
+
+func TestAggregateConsumption_PlatformOverheadRollup(t *testing.T) {
+	const parent = "hw150.omantel.biz"
 	rows := []podRow{
-		// catalyst-api: 500m CPU, 1 GiB mem, no storage.
-		{namespace: "catalyst", application: "catalyst-api", cpuReq: 500, memReq: 1 << 30},
-		// grafana: 250m CPU, 0.5 GiB mem, 10 GiB storage.
-		{namespace: "monitoring", application: "grafana", cpuReq: 250, memReq: 512 << 20, storageLim: 10 << 30},
-		// a second grafana pod (same app/ns) — must fold into one app row.
-		{namespace: "monitoring", application: "grafana", cpuReq: 250, memReq: 512 << 20},
+		// catalyst-api in the control-plane namespace — platform overhead.
+		{namespace: "catalyst", application: "catalyst-api", ownerKind: "ReplicaSet", cpuReq: 500, memReq: 1 << 30},
+		// grafana in the (infra) monitoring namespace — platform overhead.
+		{namespace: "monitoring", application: "grafana", ownerKind: "StatefulSet", cpuReq: 250, memReq: 512 << 20, storageLim: 10 << 30},
+		// a one-shot scan Job pod in an otherwise-tenant namespace — must
+		// NEVER attribute to the tenant; rolls into platform overhead.
+		{namespace: "acme", application: "scan-vulnerabilityreport-xyz", org: "acme", ownerKind: "Job", cpuReq: 50, memReq: 64 << 20},
 	}
 
-	resp := aggregateConsumption(rows, parent)
+	resp := aggregateConsumption(rows, parent, testInfraSet())
 
-	// Exactly one org row — the parent — and it is flagged parent.
-	if len(resp.Orgs) != 1 {
-		t.Fatalf("expected exactly the parent org row, got %d orgs", len(resp.Orgs))
-	}
-	p := resp.Orgs[0]
-	if !p.IsParent || p.Org != parent {
-		t.Fatalf("first row must be the parent %q, got %q (isParent=%v)", parent, p.Org, p.IsParent)
+	// The parent estate row is always present and first.
+	if len(resp.Orgs) == 0 || !resp.Orgs[0].IsParent {
+		t.Fatalf("first row must be the parent estate, got %#v", resp.Orgs)
 	}
 
-	// Two distinct apps within the parent.
-	if len(p.Apps) != 2 {
-		t.Fatalf("expected 2 app rows (catalyst-api + grafana), got %d", len(p.Apps))
+	// There is exactly one platform-overhead row, flagged isPlatform, and
+	// it is ordered last.
+	last := resp.Orgs[len(resp.Orgs)-1]
+	if !last.IsPlatform {
+		t.Fatalf("platform-overhead row must be last, got %#v", resp.Orgs)
+	}
+	if last.Org != platformOrg {
+		t.Errorf("platform row org = %q, want %q", last.Org, platformOrg)
 	}
 
-	// grafana folded its two pods: 500m CPU total, 1 GiB mem, 10 GiB storage.
-	var grafana *appConsumption
-	for i := range p.Apps {
-		if p.Apps[i].Application == "grafana" {
-			grafana = &p.Apps[i]
+	// The Job pod must NOT appear under a tenant `acme` row. In fact no
+	// `acme` tenant row should exist at all (its only pod was a Job).
+	for _, oc := range resp.Orgs {
+		if oc.Org == "acme" {
+			t.Fatalf("a one-shot Job pod created a phantom tenant row %q", oc.Org)
+		}
+		for _, a := range oc.Apps {
+			if a.Application == "scan-vulnerabilityreport-xyz" && !oc.IsPlatform {
+				t.Errorf("scan Job attributed to %q (isPlatform=%v) — must be platform overhead", oc.Org, oc.IsPlatform)
+			}
 		}
 	}
-	if grafana == nil {
-		t.Fatal("grafana app row missing")
+
+	// All three pods' cost landed in platform overhead (none in a tenant).
+	if last.CPUMilli != 800 {
+		t.Errorf("platform CPUMilli = %v, want 800 (all three pods)", last.CPUMilli)
 	}
-	if grafana.CPUMilli != 500 {
-		t.Errorf("grafana CPUMilli: got %v want 500 (two pods folded)", grafana.CPUMilli)
-	}
-	if math.Abs(grafana.StorageGiB-10) > 0.001 {
-		t.Errorf("grafana StorageGiB: got %v want 10", grafana.StorageGiB)
+}
+
+func TestAggregateConsumption_RealSecondOrgViaLabelJoinKey(t *testing.T) {
+	const parent = "hw150.omantel.biz"
+	rows := []podRow{
+		// acme tenant workload — namespace carries the org label.
+		{namespace: "acme", application: "blog", org: "acme", ownerKind: "StatefulSet", cpuReq: 200, memReq: 256 << 20},
+		// beta tenant workload — a second labelled org.
+		{namespace: "beta", application: "shop", org: "beta", ownerKind: "Deployment", cpuReq: 300, memReq: 512 << 20},
+		// platform pod.
+		{namespace: "kube-system", application: "cilium", ownerKind: "DaemonSet", cpuReq: 100, memReq: 128 << 20},
 	}
 
-	// Per-app percents sum to ~100 (the parent owns 100% of the estate).
+	resp := aggregateConsumption(rows, parent, testInfraSet())
+
+	var acme, beta *orgConsumption
+	for i := range resp.Orgs {
+		switch resp.Orgs[i].Org {
+		case "acme":
+			acme = &resp.Orgs[i]
+		case "beta":
+			beta = &resp.Orgs[i]
+		}
+	}
+	if acme == nil || beta == nil {
+		t.Fatalf("both labelled orgs must materialize as rows; got %#v", resp.Orgs)
+	}
+	if acme.IsParent || acme.IsPlatform || beta.IsParent || beta.IsPlatform {
+		t.Errorf("tenant rows must be neither parent nor platform")
+	}
+	// Each tenant carries ONLY its own app.
+	if len(acme.Apps) != 1 || acme.Apps[0].Application != "blog" {
+		t.Errorf("acme must carry only blog, got %#v", acme.Apps)
+	}
+	if len(beta.Apps) != 1 || beta.Apps[0].Application != "shop" {
+		t.Errorf("beta must carry only shop, got %#v", beta.Apps)
+	}
+	// cilium (kube-system) is platform overhead, not a tenant.
+	for _, oc := range resp.Orgs {
+		for _, a := range oc.Apps {
+			if a.Application == "cilium" && !oc.IsPlatform {
+				t.Errorf("cilium attributed to %q — must be platform overhead", oc.Org)
+			}
+		}
+	}
+}
+
+func TestAggregateConsumption_PerAppPercentSumsTo100WithinOrg(t *testing.T) {
+	const parent = "hw150.omantel.biz"
+	rows := []podRow{
+		{namespace: "acme", application: "blog", org: "acme", ownerKind: "StatefulSet", cpuReq: 200, memReq: 256 << 20},
+		{namespace: "acme", application: "api", org: "acme", ownerKind: "Deployment", cpuReq: 300, memReq: 256 << 20},
+		// a second blog pod (same app/ns) — must fold into one app row.
+		{namespace: "acme", application: "blog", org: "acme", ownerKind: "StatefulSet", cpuReq: 200, memReq: 256 << 20},
+	}
+
+	resp := aggregateConsumption(rows, parent, testInfraSet())
+
+	var acme *orgConsumption
+	for i := range resp.Orgs {
+		if resp.Orgs[i].Org == "acme" {
+			acme = &resp.Orgs[i]
+		}
+	}
+	if acme == nil {
+		t.Fatal("acme org row missing")
+	}
+	if len(acme.Apps) != 2 {
+		t.Fatalf("expected 2 app rows (blog + api), got %d", len(acme.Apps))
+	}
+	var blog *appConsumption
+	for i := range acme.Apps {
+		if acme.Apps[i].Application == "blog" {
+			blog = &acme.Apps[i]
+		}
+	}
+	if blog == nil {
+		t.Fatal("blog app row missing")
+	}
+	if blog.CPUMilli != 400 {
+		t.Errorf("blog CPUMilli: got %v want 400 (two pods folded)", blog.CPUMilli)
+	}
 	var pct float64
-	for _, a := range p.Apps {
+	for _, a := range acme.Apps {
 		pct += a.Percent
 	}
 	if math.Abs(pct-100) > 0.5 {
-		t.Errorf("per-app percents should sum to ~100, got %v", pct)
-	}
-
-	// Cost is positive and equals the org total.
-	if p.CostUnits <= 0 {
-		t.Errorf("parent cost must be positive, got %v", p.CostUnits)
-	}
-	if math.Abs(p.CostUnits-resp.TotalCostUnits) > 0.01 {
-		t.Errorf("single-org estate: parent cost %v should equal total %v", p.CostUnits, resp.TotalCostUnits)
+		t.Errorf("per-app percents within an org should sum to ~100, got %v", pct)
 	}
 }
 
 func TestAggregateConsumption_EmptyEstateNeverBlank(t *testing.T) {
 	// Zero rows ⇒ still exactly one parent row (the §5 never-blank rule).
-	resp := aggregateConsumption(nil, "sovereign")
+	resp := aggregateConsumption(nil, "sovereign", testInfraSet())
 	if len(resp.Orgs) != 1 {
 		t.Fatalf("empty estate must still render the parent row, got %d orgs", len(resp.Orgs))
 	}
@@ -82,5 +171,38 @@ func TestAggregateConsumption_EmptyEstateNeverBlank(t *testing.T) {
 	}
 	if resp.Orgs[0].Apps == nil {
 		t.Errorf("apps must be a non-nil slice so the page renders []")
+	}
+}
+
+func TestOrgForRow_KeysOnLabelNotName(t *testing.T) {
+	infra := testInfraSet()
+	cases := []struct {
+		name string
+		row  podRow
+		want string
+	}{
+		{"labelled tenant", podRow{namespace: "acme", org: "acme", ownerKind: "Deployment"}, "acme"},
+		{"infra namespace", podRow{namespace: "kube-system", org: "", ownerKind: "DaemonSet"}, platformOrg},
+		{"job-owned in tenant ns", podRow{namespace: "acme", org: "acme", ownerKind: "Job"}, platformOrg},
+		{"unlabelled host pod", podRow{namespace: "some-host-ns", org: "", ownerKind: "Deployment"}, platformOrg},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := orgForRow(tc.row, infra); got != tc.want {
+				t.Errorf("orgForRow(%s) = %q, want %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInfraNamespaceSet_EnvOverrideExtendsFloor(t *testing.T) {
+	set := infraNamespaceSet("my-infra, another-infra ")
+	for _, ns := range []string{"kube-system", "flux-system", "my-infra", "another-infra"} {
+		if _, ok := set[ns]; !ok {
+			t.Errorf("infra set missing %q (floor + env override)", ns)
+		}
+	}
+	if _, ok := set["acme"]; ok {
+		t.Errorf("a real tenant namespace must NOT be in the infra set")
 	}
 }

--- a/products/catalyst/chart/templates/controllers/organization-controller-clusterrole.yaml
+++ b/products/catalyst/chart/templates/controllers/organization-controller-clusterrole.yaml
@@ -57,4 +57,15 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
+  # #3687 (fold #3669): the controller reads back the vCluster
+  # HelmRelease it wrote into the per-Org Gitea repo + the per-Org
+  # Namespace so status.vcluster.phase and the Ready condition derive
+  # from the LIVE reconcile state (never "I PUT the file → Ready=True").
+  # Read-only — the manifests are authored in Git, applied by Flux.
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
 {{- end }}


### PR DESCRIPTION
Refs #3687

Builds the **foundational CR-read/write spine** of the canonical Organization/Application CR model — the vertical the funnel (#3376) and the day-2 surfaces ride. Five coherent, independently-tested slices land 5 of the 6 folded hw150-walk findings; the producer-side **Organization-CR-from-funnel** behavior rides the seam built here and is the named remaining work below. `Refs`, never `Closes` — the founder reviews against the §9 DoD on a fresh prov.

## What this PR builds (slice → folded finding → DoD box)

### 1. Showback is per-Organization, not per-pod-to-parent — fold #3677 (DoD 6, generality §7c)
`sme_consumption.go` `orgForNamespace(_ podRow, parentOrg) { return parentOrg }` hardcoded **every** pod 100% to the parent. Replaced by `orgForRow`, which keys on the real `openova.io/organization` namespace label the organization-controller already stamps (`gitops/manifests.go`). Control-plane / infra namespaces (a baked-in default floor extended by `SHOWBACK_INFRA_NAMESPACES`, Principle #4) and `batch/v1` Job-owned pods (`cutover-*`, `scan-vulnerabilityreport-*`, `*-snapshot-save-*`) roll into a single synthetic `__platform__` overhead row (`isPlatform`, ordered last) instead of polluting a tenant's app list. A real second per-Org namespace yields its own org row with **zero per-name special-casing** — adding a third org needs no code change. `podRow` gains `org` + `ownerKind`, populated in `buildPodRows`.

### 2. The org-controller stops reporting Ready over orphaned bytes — fold #3669 (DoD 3, generality §7d)
`organization_controller.go` set `status.vcluster.phase="Provisioning"` (frozen) + `Ready=True` the instant the Gitea PutFile returned — a green Org backed by nothing when no Flux source watched the per-Org repo. New `vclusterReadiness()` Gets the vCluster HelmRelease (name `vcluster` in ns `<slug>`, matching `gitops.vclusterTemplate`) + the per-Org Namespace and derives an honest ladder: **Pending** (manifest authored in Gitea, no Flux source applied it — surfaced, not masked) → **Provisioning** (HR applied, not yet Ready) → **Ready** (HR `Ready=True` AND namespace Active; only here `Ready=True`). Requeues every 30s while not Ready. Keys only off `slug`+`HostCluster`. ClusterRole gains read-only `helmreleases` + `namespaces`.

### 3. The running-Application spine commits to Gitea, not etcd — fold #3694 (DoD 4)
`HandleCreateInstance`, the `wireBackingServices` backing-create + reuse Context-append, and `HandleApplicationUpdate` ended in a dynamic-client `.Create`/`.Update` — the CR lived in etcd, Gitea held nothing (§3.4 "Gitea IaC holds nothing"), a hand `git push` had nowhere to land. New `commitApplicationCRToGit` (mirroring the `catalog_edit_git.go` precedent) commits the desired-state CR into the per-Org `iac` repo (ADR-0009) at `applications/<name>.yaml` on every touched seam; `applicationCRToYAML` strips runtime/server fields so the manifest is clean declarative IaC. **Transitional, not big-bang** (§8): the etcd write stays as a warm projection (API shape byte-identical, app-list informers keep serving) — the bytes now ALSO live in Git. Best-effort + graceful (missing Gitea / write failure never fails the create/update).

### 4. The Dashboard treemap excludes one-shot Job pods — fold #3692 (DoD 5, E2)
`dropEphemeralRows` filters `batch/v1` Job-owned pods (keyed on `podRow.ownerKind`, no name pattern) out of the treemap before aggregation, so `cutover-*` / `scan-vulnerabilityreport-*` / `*-snapshot-save-*` never render as an Application cell. Showback keeps the opposite, intentional semantic (Jobs roll into platform-overhead, since they still consume resources) — the treemap shows what runs, showback accounts for everything.

### 5. One canonical `tenant.created` payload — fold #3690/#3673 (DoD A5, producer-side seam)
The event had **three** divergent shapes (§3.1: tenant-service flat `*store.Tenant` embed; provisioning `tenantCreatedPayload`; bootstrap-API `orgShape`). New `events.TenantCreatedPayload` in the shared module (already imported by both the tenant-service and provisioning-service) is the single canonical struct. The provisioning consumer's local type becomes a type alias to it; the tenant-service producer emits it via `NewTenantCreatedPayload`. Tags stay snake_case (in-flight events stay decodable). This is the producer-side seam the Organization-CR-from-funnel behavior rides — every door now agrees on ONE shape, the same one the Organization CR is minted from.

## Gates (all green)
- `go build ./...` — api, `core/controllers`, `core/services/{shared,tenant,provisioning}`
- `go test -race` — org-controller (incl. new `vcluster_readiness_test.go` + `TestReconcile_ReadyOnlyWhenVClusterHRReady`), showback (`sme_consumption_test.go` rewritten to the corrected per-org contract), Git-back (`application_iac_git_test.go`), dashboard (`TestDropEphemeralRows_FiltersJobOwnedPods`), shared events (`tenant_created_test.go`)
- `helm template products/catalyst/chart` renders clean (org-controller ClusterRole change)
- `go vet ./internal/handler/` clean

## What remains (named, not hidden — for the next pass on this same model)
- **Funnel `HandleCreateSMETenant` creates the Organization CR** (§4.2, fold #3673 behavioral half): the bootstrap-API funnel door must map its `orgShape` → `OrganizationSpec` and create an `orgs.openova.io/v1` CR (adopting `events.TenantCreatedPayload` built here), collapsing the `sme-<uuid>`/`vc-<sub>` naming into the org-controller's `<slug>` path. This is the larger behavior change that overlaps the in-flight #3383 rename lane (tracker #798); the wire-shape seam it rides is landed in slice 5.
- **Flux-wire the per-Org vCluster repo** (§4.3): ship the host-cluster `GitRepository`+`Kustomization` for the `<slug>/catalyst-tenant` pattern (or write the vcluster manifests into the already-watched `openova/openova` tree). Slice 2 makes the status honest about the gap (phase `Pending` until a source applies the HR); closing the gap is the follow-on.
- **Bootstrap self-registration Application CRs + adoption guard** (§4.4 / DoD 8): the bootstrap instances' Application CRs (`bootstrap-owned`-marked, adopted not duplicated) so `kubectl get applications -A` equals the running-instance count on a fresh prov. The Git-back write path (slice 3) is the spine these ride.
- **Live walk on a fresh prov** (§9): every DoD box is founder-walkable on a converged Sovereign; this PR is the code spine — the walk + screenshots + UAT.md flips happen on the next prov (UAT.md intentionally untouched here to avoid unwalked-claim carryover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
