### PR TITLE
feat(catalog): IaC-first catalog edit — icon renders, git write load-bearing, full-CR editor (Refs #3668)

### DIFF
--- a/docs/ledger/uat-walkthrough/catalog-edit-single-source-iac-not-overlay.md
+++ b/docs/ledger/uat-walkthrough/catalog-edit-single-source-iac-not-overlay.md
@@ -1,0 +1,68 @@
+# Catalog is a SINGLE-source IaC commit — UAT walk (web UI + git + kubectl)
+
+> **Ticket:** [#3668](https://github.com/openova-io/openova/issues/3668) · folds #3657 #3672 #3676 #3682 · **Train:** next
+>
+> **What this proves (the slices shipped in this PR):**
+> 1. the **edited icon actually renders** — the catalog detail hero + grid card resolve the IaC icon (`spec.card.iconLight`/`iconDark`) first, not the build-time bundled asset (was #3672 — the icon edit was theater);
+> 2. the **git write is load-bearing** — it runs under its own ~15s budget (not the 1500ms commerce probe) and its verdict is surfaced, so a non-committed edit never reads as a durable green "Saved" (was #3676);
+> 3. the **first edit seeds the FULL CR** from the live Blueprint — `spec.source`/`manifests`/`sso`/… survive instead of a lossy `version: 0.0.0` card-only stub (§5A / was #3668 spine);
+> 4. the **full-CR IaC editor** is wired to the catalog page (reusing the shipping `YamlEditor`) so every field — `spec.source`, `spec.manifests`, `spec.sso`, `contextSchema` — is editable and commits to the SAME catalog-sovereign file the card edit writes (was #3682).
+>
+> **Format law:** UI rows + git/kubectl verification (the commit IS the acceptance). Replace
+> `<fqdn>`/`<JWT>`/`<env>` with the live env at walk time (no prior-env evidence carries over). Tick **☑**/**☒**.
+>
+> **Deferred to follow-on rows of this same ticket (enumerated, not claimed):** standing up the Flux `GitRepository`+`Kustomization` that reconciles `catalog-sovereign/*/blueprint.yaml` into the in-cluster `Blueprint` CR (DoD §9.1/9.4 + the `helm upgrade` revert-immunity), and the per-field-inline card editors + the visual icon picker (DoD §9.8 + §5B picker). The slices above are the foundational, independently-walkable vertical.
+
+**Sign-in (once).** `https://console.<fqdn>/auth/handover?token=<JWT>` → signed in as emrah.baysal (admin).
+
+## Section 1 — The edited icon RENDERS (DoD §9.5, was #3672)
+
+| Step | Go to (URL) | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 1.1 | `/catalog/bp-alloy` | note the current hero logo | the rendered icon (bundled asset fallback when IaC empty) | ☐ |
+| 1.2 | `/catalog/bp-alloy` → **Edit** (`catalog-detail-edit`) | set **Light-theme icon** to a distinct image — e.g. the red-dot data-URI `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==` → **Save** | the save reports success (see §2) | ☐ |
+| 1.3 | reload `/catalog/bp-alloy` (light theme) | observe the hero | the hero logo is now the **red dot** (the IaC icon renders — not the bundled asset) | ☐ |
+| 1.4 | `/catalog` (grid) | find the bp-alloy card | the **grid card** icon is also the red dot (same shared resolution path) | ☐ |
+| 1.5 | `/catalog/bp-alloy` → **Edit** again | observe the Light-theme icon field | it is **pre-filled with the current IaC icon** (the red-dot value), NOT the bundled asset | ☐ |
+
+## Section 2 — The git write is LOAD-BEARING (DoD §9.6, was #3676)
+
+| Step | Go to / action | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 2.1 | `/catalog/bp-alloy` → Edit → change the summary → **Save** | save with Gitea reachable | the edit response carries `committed: true` (network tab on the `PUT .../sme/commerce/apps/…` shows `{stored:true, committed:true}`) | ☐ |
+| 2.2 | local Gitea `catalog-sovereign/bp-alloy/blueprint.yaml` | `git log` / view history | a **commit** carrying the edited summary | ☐ |
+| 2.3 | `kubectl --kubeconfig /tmp/<env>.kubeconfig scale deploy/gitea -n gitea --replicas=0` | take Gitea down, then edit the summary again → Save | the edit response carries `committed: false` + a `reason` — the UI does NOT show a green durable "Saved" (it is cache-only) | ☐ |
+| 2.4 | restore Gitea (`kubectl scale deploy/gitea -n gitea --replicas=1`), re-save | save | `committed: true` again; the file lands | ☐ |
+
+> The budget proof (a 3s-slow Gitea still commits; a 1500ms-shared ctx would have aborted) is the automated test `TestCommitCatalogAppEditToGit_SlowGiteaStillCommits` — it cannot blow the demo Gitea on purpose, so it is pinned in code, not walked.
+
+## Section 3 — The first edit seeds the FULL CR (DoD §9.2/9.3 foundation, §5A)
+
+| Step | Go to / action | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 3.1 | pick a blueprint with NO `catalog-sovereign` file yet (e.g. `bp-wordpress`) | `/catalog/bp-wordpress` → Edit → change the summary → Save | committed:true | ☐ |
+| 3.2 | local Gitea `catalog-sovereign/bp-wordpress/blueprint.yaml` | view the committed file | it carries the **full spec** — real `spec.version` (e.g. `1.x`, NOT `0.0.0`), `spec.source`, `spec.manifests` — seeded from the live CR, with the edited summary overlaid | ☐ |
+
+## Section 4 — The full-CR IaC editor (DoD §9.7, was #3682)
+
+| Step | Go to / action | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 4.1 | `/catalog/bp-alloy` | click **Edit IaC ⟩** (`catalog-detail-edit-iac`) | the **full-CR YamlEditor** opens showing the complete `blueprint.yaml` (incl. `spec.source`, `spec.manifests`) | ☐ |
+| 4.2 | in the editor | toggle **Show diff** | a side-by-side current-vs-proposed diff renders | ☐ |
+| 4.3 | edit `spec.source.version` (a field the 7-field card form can NEVER touch) → **Commit IaC** | commit | "Committed to IaC ✓" — the response is committed:true | ☐ |
+| 4.4 | local Gitea `catalog-sovereign/bp-alloy/blueprint.yaml` | `git log` | the new `spec.source.version` is in the committed file (the SAME file the card edit writes) | ☐ |
+| 4.5 | `git grep "widgets/cloud-list/YamlEditor" src/pages/sovereign/CatalogDetail.tsx` | run | the catalog page imports the REUSED editor, not a new bespoke full-CR editor (DoD §9.7) | ☐ |
+
+## Section 5 — Generality (DoD §9.9)
+
+| Step | Go to | Do | Expect | ☐ |
+|---|---|---|---|---|
+| 5.1 | `bp-wordpress` (structurally different) | repeat §2.1-2.2 editing the summary, and §4 editing its `manifests` | same edit→commit→read + same Edit-IaC commit — no blueprint-specific path | ☐ |
+| 5.2 | `bp-postgres` (carries `shareable` + `contextSchema`) | §4: Edit IaC → edit `contextSchema` → Commit | the `contextSchema` survives the commit (today a card edit would have dropped it to a `version:0.0.0` stub) | ☐ |
+
+## Appendix — automated (NOT acceptance)
+
+- `resolveCatalogIcon.test.ts` (10 cases): IaC-first theme-aware icon resolution; bundled-asset fallback; bare-filename guard; letter-mark last.
+- `catalog_edit_git_test.go` (new): `…_SlowGiteaStillCommits` (3s PutFile commits under the dedicated budget), `…_ErroringGiteaReportsNotCommitted` (verdict surfaced, not swallowed), `…_UnwiredReportsCacheOnly`, `…_ByteIdenticalIsDurable`, `…_FirstEditSeedsFullCRFromLiveSpec` (real version + manifests seeded, status/managedFields stripped).
+- `catalog_iac_edit_test.go` (new): full-CR commit lands `spec.source`; 403 for non-admin; 400 on retargeted/malformed CR; 503 when Gitea unwired.
+- `parseBlueprintCRToCatalog`: now reads `card.iconLight`/`iconDark` so a CR/Gitea-sourced theme icon survives into the wire shape.

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1504,6 +1504,14 @@ func main() {
 		rg.Get("/api/v1/catalog", h.HandleCatalogList)
 		rg.Get("/api/v1/catalog/{name}", h.HandleCatalogGet)
 		rg.Get("/api/v1/catalog/{name}/versions/{version}", h.HandleCatalogGetVersion)
+		// #3668 §5D — the full-CR catalog IaC editor. Commits the WHOLE
+		// blueprint.yaml the admin edited (spec.source / manifests / sso /
+		// placementSchema / endpoints / shareable / contextSchema — fields
+		// the 7-field card form can never touch) to the SAME Gitea file the
+		// card-edit path writes (catalog-sovereign/<bp>/blueprint.yaml),
+		// under the dedicated git budget, tier-admin-gated. The console's
+		// "Edit IaC" mode (YamlEditor) drives this.
+		rg.Put("/api/v1/catalog/{name}/iac", h.HandleCatalogBlueprintIaCEdit)
 
 		// EPIC-6 (#1101) slice U-Fleet — multi-Sovereign fleet view.
 		// Read-only aggregator that backs the new live DashboardPage,

--- a/products/catalyst/bootstrap/api/internal/handler/blueprints_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/blueprints_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -21,15 +22,22 @@ import (
 
 // fakeGiteaClient is an in-memory stub of GiteaBlueprintClient.
 type fakeGiteaClient struct {
-	mu       sync.Mutex
-	files    map[string][]byte // org/repo/branch/path → bytes
-	repos    map[string]bool   // org/repo → exists
-	orgs     map[string]bool   // org → exists
-	dirs     map[string][]gitea.ContentEntry
-	branches map[string]bool                  // org/repo/branch → exists
-	prs      map[string]gitea.PullRequest     // org/repo/head→base → PR
-	prSeq    int64
+	mu           sync.Mutex
+	files        map[string][]byte // org/repo/branch/path → bytes
+	repos        map[string]bool   // org/repo → exists
+	orgs         map[string]bool   // org → exists
+	dirs         map[string][]gitea.ContentEntry
+	branches     map[string]bool              // org/repo/branch → exists
+	prs          map[string]gitea.PullRequest // org/repo/head→base → PR
+	prSeq        int64
 	failPRCreate bool // when true, CreatePullRequest returns ErrRepoNotFound
+
+	// #3668 — additive PutFile injection so the catalog-edit-git budget +
+	// failure-surfacing tests can simulate a slow / erroring Gitea on
+	// PutFile only (the source-of-truth write). Both default nil/0 →
+	// unchanged behaviour for every existing caller.
+	putFileSleep time.Duration // when >0, PutFile blocks this long (honours ctx cancel)
+	putFileErr   error         // when non-nil, PutFile returns this error
 }
 
 func newFakeGitea() *fakeGiteaClient {
@@ -61,7 +69,25 @@ func (f *fakeGiteaClient) EnsureRepo(_ context.Context, org, name, _ string, _ b
 	return gitea.Repo{Name: name}, nil
 }
 
-func (f *fakeGiteaClient) PutFile(_ context.Context, org, repo, branch, path string, data []byte, _ string, _ ...gitea.PutFileOpts) (gitea.File, bool, error) {
+func (f *fakeGiteaClient) PutFile(ctx context.Context, org, repo, branch, path string, data []byte, _ string, _ ...gitea.PutFileOpts) (gitea.File, bool, error) {
+	// #3668 — simulate a slow Gitea on PutFile (the source write) while
+	// still honouring context cancellation, so the budget test can prove
+	// the commit deadlines under a too-small budget and succeeds under the
+	// dedicated catalogEditGitBudget.
+	f.mu.Lock()
+	sleep := f.putFileSleep
+	putErr := f.putFileErr
+	f.mu.Unlock()
+	if sleep > 0 {
+		select {
+		case <-time.After(sleep):
+		case <-ctx.Done():
+			return gitea.File{}, false, ctx.Err()
+		}
+	}
+	if putErr != nil {
+		return gitea.File{}, false, putErr
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.files[giteaKey(org, repo, branch, path)] = data

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_client_cluster_fallback.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_client_cluster_fallback.go
@@ -297,6 +297,17 @@ func parseBlueprintCRToCatalog(u *unstructured.Unstructured) (*CatalogBlueprint,
 		if v, ok := cardRaw["icon"].(string); ok {
 			card.Icon = v
 		}
+		// #3668 §3B(d) — the theme-aware icons MUST survive into the wire
+		// shape from a CR/Gitea-sourced Blueprint, not only via the
+		// commerce-store overlay. Without these reads an out-of-band
+		// `card.iconLight` edit in Gitea (or a reconciled CR) would never
+		// reach the console's icon resolver.
+		if v, ok := cardRaw["iconLight"].(string); ok {
+			card.IconLight = v
+		}
+		if v, ok := cardRaw["iconDark"].(string); ok {
+			card.IconDark = v
+		}
 		if v, ok := cardRaw["category"].(string); ok {
 			card.Category = v
 		}

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git.go
@@ -46,6 +46,8 @@ import (
 	"fmt"
 	"strings"
 
+	yamlv3 "gopkg.in/yaml.v3"
+
 	"github.com/openova-io/openova/core/controllers/pkg/gitea"
 )
 
@@ -134,6 +136,21 @@ func (h *Handler) writeCatalogEditToGit(ctx context.Context, edit catalogEdit) (
 		return false, fmt.Errorf("get %s/%s/%s: %w", catalogSovereignOrg, bpName, catalogEditBlueprintPath, err)
 	}
 
+	// #3668 §5A — the FIRST console edit on a blueprint with no Gitea file
+	// must SEED from the live in-cluster CR's FULL spec, not synthesise a
+	// `version: 0.0.0` stub that drops spec.source / spec.manifests /
+	// spec.sso / spec.placementSchema / spec.endpoints / shareable /
+	// contextSchema (the §3A(b) lossy-stub violation). The seed is the same
+	// full Blueprint the install path reads — fetched via the catalog client
+	// (chainedCatalogClient resolves Gitea → in-cluster CR and returns the
+	// entire object in .Raw). With a full seed the existing setIfAbsent merge
+	// preserves every non-card field; the edit only overlays the card fields.
+	if len(existing) == 0 {
+		if seed := h.seedBlueprintYAMLFromLiveCR(ctx, bpName); len(seed) > 0 {
+			existing = seed
+		}
+	}
+
 	merged, err := mergeCatalogEditIntoBlueprintYAML(existing, bpName, edit)
 	if err != nil {
 		return false, fmt.Errorf("merge blueprint.yaml: %w", err)
@@ -193,3 +210,95 @@ func (h *Handler) fetchCatalogEditsFromGit(ctx context.Context) map[string]catal
 // inside its catalog-sovereign per-Blueprint repo. Matches the path
 // blueprints.go's curate writes ("blueprint.yaml").
 const catalogEditBlueprintPath = "blueprint.yaml"
+
+// seedBlueprintYAMLFromLiveCR resolves a blueprint's FULL definition via the
+// catalog client and renders it as the Blueprint CR YAML to seed the
+// catalog-sovereign Gitea file on the first console edit (#3668 §5A). The
+// catalog client is the chainedCatalogClient — it resolves Gitea →
+// in-cluster CR and returns the entire object in CatalogBlueprint.Raw, which
+// is the same full spec (source / version / manifests / sso / placementSchema
+// / endpoints / shareable / contextSchema) the install path consumes.
+//
+// Returns nil (the caller then falls back to mergeCatalogEditIntoBlueprintYAML
+// synthesising a minimal CR) when the client is unwired, the blueprint cannot
+// be resolved, or Raw is empty — seeding is best-effort: it upgrades the first
+// edit from a lossy stub to a full CR when the source is available, and never
+// fails the edit when it isn't.
+//
+// Server-managed + ownership metadata is stripped so the committed file is a
+// clean, hand-authorable source of truth that a later `helm upgrade` will not
+// fight over: status, resourceVersion, uid, generation, creationTimestamp,
+// managedFields, and the Helm/Flux ownership labels+annotations
+// (`app.kubernetes.io/managed-by: Helm`, `helm.toolkit.fluxcd.io/*`, the
+// release-tracking annotations) — leaving apiVersion/kind/metadata.name + the
+// full spec that the Blueprint projector and validateBlueprintYAML accept.
+func (h *Handler) seedBlueprintYAMLFromLiveCR(ctx context.Context, bpName string) []byte {
+	if h.catalogClient == nil {
+		return nil
+	}
+	bp, err := h.catalogClient.Get(ctx, bpName, "")
+	if err != nil || bp == nil || len(bp.Raw) == 0 {
+		return nil
+	}
+	doc := deepCopyYAMLMap(bp.Raw)
+	if doc == nil {
+		return nil
+	}
+
+	// Canonical envelope — the projector requires apiVersion/kind; the
+	// in-cluster CR carries them, but a Gitea-sourced Raw might not.
+	setIfAbsent(doc, "apiVersion", "catalyst.openova.io/v1")
+	setIfAbsent(doc, "kind", "Blueprint")
+
+	// metadata: keep only name; drop server-managed + ownership fields so a
+	// helm upgrade can't claim the committed file (DoD §9.4).
+	if meta, ok := doc["metadata"].(map[string]interface{}); ok {
+		name := asString(meta["name"])
+		if strings.TrimSpace(name) == "" {
+			name = bpName
+		}
+		cleanMeta := map[string]interface{}{"name": name}
+		doc["metadata"] = cleanMeta
+	} else {
+		doc["metadata"] = map[string]interface{}{"name": bpName}
+	}
+
+	// status is server-derived — never part of the source file.
+	delete(doc, "status")
+
+	out, err := yamlv3.Marshal(doc)
+	if err != nil {
+		return nil
+	}
+	return out
+}
+
+// deepCopyYAMLMap returns a deep copy of a JSON/YAML-decoded map so mutating
+// the seed never aliases the catalog client's cached Raw. Values are scalars,
+// []interface{}, or map[string]interface{} (json.Unmarshal output), so a
+// straightforward recursive copy is exact.
+func deepCopyYAMLMap(in map[string]interface{}) map[string]interface{} {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		out[k] = deepCopyYAMLValue(v)
+	}
+	return out
+}
+
+func deepCopyYAMLValue(v interface{}) interface{} {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		return deepCopyYAMLMap(t)
+	case []interface{}:
+		cp := make([]interface{}, len(t))
+		for i := range t {
+			cp[i] = deepCopyYAMLValue(t[i])
+		}
+		return cp
+	default:
+		return t
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git_test.go
@@ -16,10 +16,12 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	yamlv3 "gopkg.in/yaml.v3"
 )
@@ -341,6 +343,152 @@ func TestCommitCatalogAppEditToGit_EmptyOverlayIsNoop(t *testing.T) {
 
 	if len(fg.files) != 0 {
 		t.Errorf("an empty-overlay row must not commit a CR; got files %v", fileKeys(fg))
+	}
+}
+
+// TestWriteCatalogEditToGit_FirstEditSeedsFullCRFromLiveSpec — #3668 §5A /
+// §9.2-9.3: the FIRST console edit on a blueprint with NO Gitea file must
+// SEED the committed file from the live CR's FULL spec (resolved via the
+// catalog client), so spec.manifests / spec.version / spec.source survive —
+// NOT a lossy `version: 0.0.0` card-only stub. Before #3668 a first edit on
+// bp-wordpress committed a stub that dropped every install field.
+func TestWriteCatalogEditToGit_FirstEditSeedsFullCRFromLiveSpec(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+	// The live CR (resolved via the catalog client) carries the full spec —
+	// real version + manifests — exactly as the in-cluster Blueprint does.
+	h.SetCatalogClient(newFakeCatalog(sampleWordpressBlueprint()))
+
+	// A first edit changing only the card summary (no Gitea file yet).
+	edit := catalogEdit{Slug: "wordpress", Tagline: "Edited via console"}
+	committed, err := h.writeCatalogEditToGit(context.Background(), edit)
+	if err != nil {
+		t.Fatalf("writeCatalogEditToGit: %v", err)
+	}
+	if !committed {
+		t.Fatalf("first edit must commit a CR")
+	}
+
+	key := giteaKey(catalogSovereignOrg, "bp-wordpress", catalogEditGitBranch, catalogEditBlueprintPath)
+	raw, ok := fg.files[key]
+	if !ok {
+		t.Fatalf("expected committed blueprint.yaml at %s; keys=%v", key, fileKeys(fg))
+	}
+	var doc map[string]interface{}
+	if err := yamlv3.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal committed CR: %v", err)
+	}
+	spec, _ := doc["spec"].(map[string]interface{})
+	if spec == nil {
+		t.Fatalf("committed CR has no spec; doc=%v", doc)
+	}
+	// The REAL version is seeded from the live CR — NOT the 0.0.0 stub.
+	if asString(spec["version"]) != "1.2.3" {
+		t.Errorf("first edit must seed the real spec.version from the live CR, not a 0.0.0 stub; got %v", spec["version"])
+	}
+	// spec.manifests (an install field the old stub dropped) survives.
+	if _, ok := spec["manifests"].(map[string]interface{}); !ok {
+		t.Errorf("first edit must seed spec.manifests from the live CR; spec=%v", spec)
+	}
+	// The card edit landed on top of the seeded full CR.
+	card, _ := spec["card"].(map[string]interface{})
+	if card == nil || card["summary"] != "Edited via console" {
+		t.Errorf("the card edit must overlay the seeded CR; card=%v", card)
+	}
+	// Server-managed metadata is NOT carried into the committed source.
+	meta, _ := doc["metadata"].(map[string]interface{})
+	if meta == nil || meta["name"] != "bp-wordpress" {
+		t.Errorf("metadata.name must be bp-wordpress; meta=%v", meta)
+	}
+	if _, leaked := meta["managedFields"]; leaked {
+		t.Errorf("managedFields must be stripped from the seeded source")
+	}
+	if _, leaked := doc["status"]; leaked {
+		t.Errorf("status must be stripped from the seeded source")
+	}
+}
+
+// TestCommitCatalogAppEditToGit_SlowGiteaStillCommits — #3668 §9.6(a):
+// a Gitea that sleeps 3s on PutFile no longer aborts the commit. Before
+// #3668 the write shared the 1500ms commerce-probe ctx and deadline-d; now
+// it runs under the dedicated ~15s catalogEditGitBudget, so a busy-but-
+// healthy Gitea commits durably (committed=true).
+func TestCommitCatalogAppEditToGit_SlowGiteaStillCommits(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	fg.putFileSleep = 3 * time.Second // far over the dead 1500ms probe budget
+	h.SetGiteaClient(fg)
+
+	body := []byte(`{"slug":"alloy","name":"Alloy (IaC write test)","tagline":"telemetry","supported_topologies":["single-region"]}`)
+	committed, reason := h.commitCatalogAppEditToGit(context.Background(), body)
+	if !committed {
+		t.Fatalf("a 3s PutFile must still commit under the dedicated git budget; reason=%q", reason)
+	}
+	if reason != "" {
+		t.Errorf("a durable commit must carry no failure reason; got %q", reason)
+	}
+	key := giteaKey(catalogSovereignOrg, "bp-alloy", catalogEditGitBranch, catalogEditBlueprintPath)
+	if _, ok := fg.files[key]; !ok {
+		t.Fatalf("expected a committed blueprint.yaml at %s; keys=%v", key, fileKeys(fg))
+	}
+}
+
+// TestCommitCatalogAppEditToGit_ErroringGiteaReportsNotCommitted — #3668
+// §9.6(b): a Gitea that errors on PutFile makes the edit report
+// committed=false + a reason. Before #3668 the error was logged + swallowed
+// and the caller relayed a 200 OK; now the verdict is surfaced so the UI can
+// show "cache only / IaC commit failed" instead of a false green "Saved".
+func TestCommitCatalogAppEditToGit_ErroringGiteaReportsNotCommitted(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	fg.putFileErr = errors.New("gitea: 500 internal error")
+	h.SetGiteaClient(fg)
+
+	body := []byte(`{"slug":"alloy","name":"Alloy","tagline":"telemetry"}`)
+	committed, reason := h.commitCatalogAppEditToGit(context.Background(), body)
+	if committed {
+		t.Fatalf("an erroring PutFile must report committed=false")
+	}
+	if !strings.Contains(reason, "IaC commit failed") {
+		t.Errorf("the failure reason must name the IaC commit failure; got %q", reason)
+	}
+}
+
+// TestCommitCatalogAppEditToGit_UnwiredReportsCacheOnly — #3668 §9.6: with
+// no Gitea client (pre-cutover / CI) the commit is reported committed=false
+// with a "pre-cutover" reason, NOT swallowed as success — the store cache
+// holds the edit but the UI must know it is not yet IaC.
+func TestCommitCatalogAppEditToGit_UnwiredReportsCacheOnly(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	// no SetGiteaClient → h.giteaClient == nil
+	committed, reason := h.commitCatalogAppEditToGit(context.Background(),
+		[]byte(`{"slug":"alloy","name":"Alloy"}`))
+	if committed {
+		t.Fatalf("an unwired client must report committed=false")
+	}
+	if strings.TrimSpace(reason) == "" {
+		t.Errorf("the unwired case must carry a human reason for the UI")
+	}
+}
+
+// TestCommitCatalogAppEditToGit_ByteIdenticalIsDurable — #3668: a second
+// identical edit (PutFile's byte-equal short-circuit returns committed=false,
+// err=nil) is a DURABLE state — the source already carries these bytes — so
+// it must report committed=true, never a false "cache only" failure.
+func TestCommitCatalogAppEditToGit_ByteIdenticalIsDurable(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+
+	body := []byte(`{"slug":"alloy","name":"Alloy","tagline":"telemetry"}`)
+	if c, _ := h.commitCatalogAppEditToGit(context.Background(), body); !c {
+		t.Fatalf("first commit must report committed=true")
+	}
+	// Second identical edit — PutFile short-circuits (no new bytes written).
+	committed, reason := h.commitCatalogAppEditToGit(context.Background(), body)
+	if !committed {
+		t.Fatalf("a byte-identical re-edit is durable and must report committed=true; reason=%q", reason)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_iac_edit.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_iac_edit.go
@@ -1,0 +1,227 @@
+// Package handler — catalog_iac_edit.go: #3668 §5D — the FULL-CR catalog
+// IaC editor endpoint.
+//
+// The card-edit path (sme_commerce.go → catalog_edit_git.go) commits the 7
+// card fields to catalog-sovereign/<bp>/blueprint.yaml. The full-CR editor
+// (the console's "Edit IaC" mode mounting widgets/cloud-list/YamlEditor)
+// must be able to edit the WHOLE blueprint — spec.source / spec.manifests /
+// spec.sso / spec.placementSchema / spec.endpoints / shareable /
+// contextSchema — fields the 7-field form can never touch (§3D).
+//
+// Both paths write the SAME Gitea file (§6: "Both paths write the SAME Gitea
+// file; the page re-reads after save"). This endpoint commits the full YAML
+// the admin supplies directly to catalog-sovereign/<bp>/blueprint.yaml —
+// validated as a Blueprint CR first (reusing validateBlueprintYAML), under
+// the dedicated catalogEditGitBudget (NOT the commerce probe budget), with
+// the git verdict surfaced (committed / reason). It is the IaC source write;
+// Flux reconciles that file into the in-cluster Blueprint CR.
+//
+// Auth: the same tier-admin gate the existing /blueprints/edit-pr uses
+// (applicationInstallCallerAuthorized) — this ticket adds no new
+// authorization model (§11 excluded).
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	yamlv3 "gopkg.in/yaml.v3"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+)
+
+// catalogIaCEditRequest is the body of PUT /api/v1/catalog/{name}/iac — the
+// full blueprint.yaml the admin edited in the IaC editor.
+type catalogIaCEditRequest struct {
+	// BlueprintYAML is the complete Blueprint CR YAML to commit. It is
+	// validated as a Blueprint before the write so a malformed edit is
+	// rejected (400) rather than committed and left for Flux to choke on.
+	BlueprintYAML string `json:"blueprintYaml"`
+}
+
+// catalogIaCEditResponse mirrors the card-edit envelope (#3668 §5C) so the UI
+// reads one shape: committed=true + the resolved slug/path on a durable
+// commit, committed=false + reason otherwise.
+type catalogIaCEditResponse struct {
+	Slug      string `json:"slug"`
+	Path      string `json:"path"`
+	Committed bool   `json:"committed"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+// HandleCatalogBlueprintIaCEdit — PUT /api/v1/catalog/{name}/iac.
+//
+// Commits the supplied FULL blueprint.yaml to
+// catalog-sovereign/bp-<name>/blueprint.yaml (the same file the card-edit
+// path writes), so the console's full-CR IaC editor edits every blueprint
+// field through one Gitea source of truth. Session-gated like the rest of
+// /api/v1/*; additionally tier-admin-gated (mirrors /blueprints/edit-pr).
+func (h *Handler) HandleCatalogBlueprintIaCEdit(w http.ResponseWriter, r *http.Request) {
+	name := strings.TrimSpace(chi.URLParam(r, "name"))
+	bpName := catalogEditBlueprintName(name)
+	if bpName == "" {
+		writeBadRequest(w, "invalid-blueprint", "name path parameter is required")
+		return
+	}
+
+	// Tier-admin gate — the existing /blueprints/edit-pr authority. No new
+	// authorization model (§11 excluded).
+	if claims := auth.ClaimsFromContext(r.Context()); claims != nil {
+		if !applicationInstallCallerAuthorized(claims) {
+			writeJSON(w, http.StatusForbidden, map[string]string{
+				"error":  "forbidden",
+				"detail": "PUT /catalog/{name}/iac requires tier-admin or higher",
+			})
+			return
+		}
+	}
+
+	rawBody, readErr := readMutationBody(w, r)
+	if readErr {
+		return
+	}
+	var req catalogIaCEditRequest
+	if err := json.Unmarshal(rawBody, &req); err != nil {
+		writeBadRequest(w, "invalid-body", "request body must be JSON {blueprintYaml}")
+		return
+	}
+	yamlBytes := []byte(req.BlueprintYAML)
+	if len(strings.TrimSpace(req.BlueprintYAML)) == 0 {
+		writeBadRequest(w, "empty-blueprint", "blueprintYaml is required")
+		return
+	}
+
+	// Validate it parses as a Blueprint CR BEFORE committing — a malformed
+	// full-CR edit must 400, never land in Gitea for Flux to reject. The
+	// metadata.name must address THIS blueprint so an edit can't be
+	// retargeted to a different bp's file.
+	if msg, ok := validateCatalogBlueprintYAML(yamlBytes, bpName); !ok {
+		writeBadRequest(w, "invalid-blueprint-yaml", msg)
+		return
+	}
+
+	if h.giteaClient == nil {
+		// No local catalog git yet (pre-cutover / CI). Report it, never a
+		// false success — the IaC editor is meaningless without the source.
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "gitea-not-wired",
+			"detail": "local catalog git not yet available (pre-cutover); the full-CR IaC edit requires Gitea",
+		})
+		return
+	}
+
+	// Source write under the dedicated git budget (NOT the commerce probe).
+	ctx, cancel := context.WithTimeout(r.Context(), catalogEditGitBudgetDuration())
+	defer cancel()
+
+	committed, err := h.writeCatalogFullBlueprintToGit(ctx, bpName, yamlBytes)
+	if err != nil {
+		if h.log != nil {
+			h.log.Warn("catalog-iac-edit: commit to catalog-sovereign failed",
+				"blueprint", bpName, "err", err)
+		}
+		writeJSON(w, http.StatusBadGateway, catalogIaCEditResponse{
+			Slug:      normalizeCatalogKey(bpName),
+			Path:      catalogSovereignOrg + "/" + bpName + "/" + catalogEditBlueprintPath,
+			Committed: false,
+			Reason:    "IaC commit failed: " + err.Error(),
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, catalogIaCEditResponse{
+		Slug:      normalizeCatalogKey(bpName),
+		Path:      catalogSovereignOrg + "/" + bpName + "/" + catalogEditBlueprintPath,
+		Committed: true,
+		Reason:    iaCEditDurableReason(committed),
+	})
+}
+
+// iaCEditDurableReason gives the UI a short note: a brand-new commit vs a
+// byte-identical no-op (both durable — the source carries the bytes).
+func iaCEditDurableReason(wroteBytes bool) string {
+	if wroteBytes {
+		return ""
+	}
+	return "already up to date (no change)"
+}
+
+// writeCatalogFullBlueprintToGit commits the FULL supplied blueprint.yaml to
+// catalog-sovereign/<bpName>/blueprint.yaml — the same file + repo the
+// card-edit path (writeCatalogEditToGit) writes, so both editors drive the
+// SAME Gitea source of truth (§6). Unlike the card path this is NOT a card
+// merge: the admin owns the whole document, so it is committed verbatim
+// (after the caller's validateBlueprintYAML).
+//
+// Returns (wroteBytes, err): wroteBytes=false + err=nil when PutFile's
+// byte-equal short-circuit fired (the file already carried these exact bytes
+// — still durable). A non-nil err is a genuine transport/API failure.
+func (h *Handler) writeCatalogFullBlueprintToGit(ctx context.Context, bpName string, blueprintYAML []byte) (bool, error) {
+	if h.giteaClient == nil {
+		return false, fmt.Errorf("gitea client unwired")
+	}
+	if _, err := h.giteaClient.EnsureOrg(ctx, catalogSovereignOrg,
+		"Sovereign-curated catalog",
+		"Curated Blueprints visible to every Org", "public"); err != nil {
+		return false, fmt.Errorf("ensure org %q: %w", catalogSovereignOrg, err)
+	}
+	if _, err := h.giteaClient.EnsureRepo(ctx, catalogSovereignOrg, bpName,
+		"Sovereign-curated Blueprint", false); err != nil {
+		return false, fmt.Errorf("ensure repo %s/%s: %w", catalogSovereignOrg, bpName, err)
+	}
+	msg := fmt.Sprintf("catalog: edit %s full IaC via catalyst-api (#3668)", bpName)
+	_, committed, err := h.giteaClient.PutFile(ctx, catalogSovereignOrg, bpName,
+		catalogEditGitBranch, catalogEditBlueprintPath, blueprintYAML, msg, catalogEditCommitAuthor())
+	if err != nil {
+		return false, fmt.Errorf("put %s/%s/%s: %w", catalogSovereignOrg, bpName, catalogEditBlueprintPath, err)
+	}
+	return committed, nil
+}
+
+// validateCatalogBlueprintYAML enforces the structural Blueprint invariants
+// the full-CR catalog editor must hold before a commit, WITHOUT requiring a
+// version match (the admin may legitimately bump spec.version in the editor —
+// that round-trip is DoD §9.7). Unlike blueprints.go's validateBlueprintYAML
+// (which pins metadata.name + spec.version to a publish request), this checks:
+// the document parses; apiVersion present; kind == Blueprint; metadata.name
+// addresses THIS blueprint (so an edit can't be retargeted to another bp's
+// file); spec present with a non-empty spec.version. Returns ("", true) when
+// valid, else (reason, false).
+func validateCatalogBlueprintYAML(raw []byte, bpName string) (string, bool) {
+	var doc map[string]interface{}
+	if err := yamlv3.Unmarshal(raw, &doc); err != nil {
+		return fmt.Sprintf("blueprintYaml parse: %v", err), false
+	}
+	if apiVersion, _ := doc["apiVersion"].(string); strings.TrimSpace(apiVersion) == "" {
+		return "blueprint.yaml missing apiVersion", false
+	}
+	if kind, _ := doc["kind"].(string); kind != "Blueprint" {
+		return fmt.Sprintf("blueprint.yaml kind=%q; want Blueprint", kind), false
+	}
+	meta, _ := doc["metadata"].(map[string]interface{})
+	if meta == nil {
+		return "blueprint.yaml missing metadata", false
+	}
+	metaName, _ := meta["name"].(string)
+	if strings.TrimSpace(metaName) == "" {
+		return "blueprint.yaml missing metadata.name", false
+	}
+	// The name must address this blueprint (bare or bp-prefixed) so the edit
+	// lands in the right catalog-sovereign repo and can't clobber another's.
+	if catalogEditBlueprintName(metaName) != bpName {
+		return fmt.Sprintf("blueprint.yaml metadata.name=%q does not address %q", metaName, bpName), false
+	}
+	spec, _ := doc["spec"].(map[string]interface{})
+	if spec == nil {
+		return "blueprint.yaml missing spec", false
+	}
+	if v, _ := spec["version"].(string); strings.TrimSpace(v) == "" {
+		return "blueprint.yaml missing spec.version", false
+	}
+	return "", true
+}

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_iac_edit_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_iac_edit_test.go
@@ -1,0 +1,172 @@
+// catalog_iac_edit_test.go — #3668 §5D coverage for the full-CR catalog
+// IaC editor endpoint (PUT /api/v1/catalog/{name}/iac).
+//
+// The DoD §9.7: an "Edit IaC" action commits the WHOLE blueprint.yaml — a
+// field the 7-field card form could never touch (e.g. spec.source.version) —
+// to the SAME catalog-sovereign Gitea file the card edit writes, under the
+// dedicated git budget, gated by the tier-admin authority. These pin: the
+// happy-path commit lands the full CR; a non-admin is 403'd; a malformed /
+// retargeted CR is 400'd (never committed); an unwired Gitea is reported, not
+// faked green.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+// callCatalogIaCEdit drives PUT /api/v1/catalog/{name}/iac through a chi
+// router so the {name} URL param resolves, injecting the supplied claims.
+func callCatalogIaCEdit(t *testing.T, h *Handler, name, body string, claims *auth.Claims) *httptest.ResponseRecorder {
+	t.Helper()
+	r := chi.NewRouter()
+	r.Put("/api/v1/catalog/{name}/iac", h.HandleCatalogBlueprintIaCEdit)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/catalog/"+name+"/iac", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if claims != nil {
+		req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey, claims))
+	}
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+// fullAlloyBlueprintYAML is a complete Blueprint CR with spec.source +
+// spec.manifests — the install fields the card form can't edit.
+func fullAlloyBlueprintYAML(version string) string {
+	return `apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-alloy
+spec:
+  version: "` + version + `"
+  visibility: listed
+  card:
+    title: Grafana Alloy
+    summary: Telemetry collector
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-alloy
+    version: "` + version + `"
+  manifests:
+    chart: bp-alloy
+`
+}
+
+// TestCatalogIaCEdit_CommitsFullCR — the happy path: a tier-admin PUTs the
+// full blueprint.yaml (editing spec.source.version, a non-card field) → it
+// lands at catalog-sovereign/bp-alloy/blueprint.yaml verbatim.
+func TestCatalogIaCEdit_CommitsFullCR(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+
+	body := `{"blueprintYaml":` + jsonQuote(fullAlloyBlueprintYAML("1.0.2")) + `}`
+	rec := callCatalogIaCEdit(t, h, "bp-alloy", body, adminClaims())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	key := giteaKey(catalogSovereignOrg, "bp-alloy", catalogEditGitBranch, catalogEditBlueprintPath)
+	raw, ok := fg.files[key]
+	if !ok {
+		t.Fatalf("expected a committed blueprint.yaml at %s; keys=%v", key, fileKeys(fg))
+	}
+	// The full CR landed — including spec.source (a non-card field).
+	var doc map[string]interface{}
+	if err := yamlv3.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("committed CR did not parse: %v", err)
+	}
+	spec := doc["spec"].(map[string]interface{})
+	if _, ok := spec["source"].(map[string]interface{}); !ok {
+		t.Errorf("spec.source (a non-card field) must survive the full-CR commit; spec=%v", spec)
+	}
+	src := spec["source"].(map[string]interface{})
+	if src["version"] != "1.0.2" {
+		t.Errorf("edited spec.source.version must land; got %v", src["version"])
+	}
+}
+
+// TestCatalogIaCEdit_403ForNonAdmin — a viewer caller is rejected by the
+// tier-admin gate (the same authority as /blueprints/edit-pr).
+func TestCatalogIaCEdit_403ForNonAdmin(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+
+	body := `{"blueprintYaml":` + jsonQuote(fullAlloyBlueprintYAML("1.0.2")) + `}`
+	rec := callCatalogIaCEdit(t, h, "bp-alloy", body, &auth.Claims{Tier: "viewer"})
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status: got %d want 403; body=%s", rec.Code, rec.Body.String())
+	}
+	if len(fg.files) != 0 {
+		t.Errorf("a forbidden edit must not commit anything; files=%v", fileKeys(fg))
+	}
+}
+
+// TestCatalogIaCEdit_400OnRetargetedName — a CR whose metadata.name addresses
+// a DIFFERENT blueprint must be rejected (it cannot be allowed to clobber
+// another bp's file).
+func TestCatalogIaCEdit_400OnRetargetedName(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+
+	// PUT to /catalog/bp-alloy/iac but the CR names bp-grafana.
+	wrong := strings.Replace(fullAlloyBlueprintYAML("1.0.2"), "name: bp-alloy", "name: bp-grafana", 1)
+	body := `{"blueprintYaml":` + jsonQuote(wrong) + `}`
+	rec := callCatalogIaCEdit(t, h, "bp-alloy", body, adminClaims())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if len(fg.files) != 0 {
+		t.Errorf("a retargeted CR must not commit; files=%v", fileKeys(fg))
+	}
+}
+
+// TestCatalogIaCEdit_400OnMalformed — non-Blueprint / unparseable YAML is
+// rejected before any commit.
+func TestCatalogIaCEdit_400OnMalformed(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+
+	body := `{"blueprintYaml":"kind: ConfigMap\nmetadata:\n  name: bp-alloy\n"}`
+	rec := callCatalogIaCEdit(t, h, "bp-alloy", body, adminClaims())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if len(fg.files) != 0 {
+		t.Errorf("a malformed CR must not commit; files=%v", fileKeys(fg))
+	}
+}
+
+// TestCatalogIaCEdit_503WhenGiteaUnwired — without a local catalog git the
+// editor is reported unavailable (503), never a false success.
+func TestCatalogIaCEdit_503WhenGiteaUnwired(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	// no SetGiteaClient → h.giteaClient == nil
+	body := `{"blueprintYaml":` + jsonQuote(fullAlloyBlueprintYAML("1.0.2")) + `}`
+	rec := callCatalogIaCEdit(t, h, "bp-alloy", body, adminClaims())
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d want 503; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// jsonQuote produces a JSON-quoted string literal (incl. the surrounding
+// quotes) for embedding a multi-line YAML doc into a JSON request body.
+func jsonQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sme_catalog_client.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_catalog_client.go
@@ -32,7 +32,34 @@ const (
 	smeCatalogURLEnv      = "CATALYST_SME_CATALOG_URL"
 	smeCatalogCacheTTL    = 30 * time.Second
 	smeCatalogProbeBudget = 1500 * time.Millisecond
+
+	// catalogEditGitBudget is the budget for the catalog-edit IaC commit
+	// (#3668). The commit is the SOURCE-OF-TRUTH write — it must NOT share
+	// the 1500ms commerce-store probe budget (smeCatalogProbeBudget), which
+	// is sized for a single in-cluster HTTP probe, not a git round-trip.
+	// writeCatalogEditToGit performs FOUR sequential Gitea API calls
+	// (EnsureOrg, EnsureRepo, GetFile, PutFile) against a Gitea that — on a
+	// cut-over Sovereign — is under Flux + mirror-job load. Sized for that
+	// round-trip so a busy-but-healthy Gitea commits durably instead of the
+	// write silently deadline-ing at 1500ms minus the commerce hop and the
+	// edit evaporating on the next store rebuild (§3C). Overridable via the
+	// canonical env so an operator can widen it on a slow Sovereign without a
+	// code change (Inviolable Principle #4).
+	catalogEditGitBudget    = 15 * time.Second
+	catalogEditGitBudgetEnv = "CATALYST_CATALOG_EDIT_GIT_BUDGET"
 )
+
+// catalogEditGitBudgetDuration returns the catalog-edit git-commit budget,
+// honouring CATALYST_CATALOG_EDIT_GIT_BUDGET (a Go duration string, e.g.
+// "30s") when set + parseable, else the catalogEditGitBudget default.
+func catalogEditGitBudgetDuration() time.Duration {
+	if v := strings.TrimSpace(os.Getenv(catalogEditGitBudgetEnv)); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return catalogEditGitBudget
+}
 
 // smeCatalogApp — minimal projection of the SME catalog's GET /catalog/apps
 // response shape. Only the fields HandleSovereignApps consumes.

--- a/products/catalyst/bootstrap/api/internal/handler/sme_commerce.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_commerce.go
@@ -160,18 +160,28 @@ func (h *Handler) proxyCommerce(w http.ResponseWriter, r *http.Request, method, 
 		})
 		return
 	}
-	// #3648 (train/hw150) — make the catalog edit IaC: when an `apps`
-	// create/update succeeds at the commerce store, ALSO commit the edited
-	// card fields into the catalog-sovereign Gitea Org as a Blueprint CR.
-	// git is the single source of truth; the store stays as a cache. This
-	// is additive + best-effort — a git failure NEVER changes the API
-	// response the unchanged UI relies on (the store write already
-	// happened); it is logged for the operator. DELETEs are not mirrored
-	// here (removing a curated CR is the /blueprints lifecycle, not an
-	// edit). See catalog_edit_git.go.
+	// #3668 (train/hw150) — make the catalog edit a load-bearing IaC commit.
+	// When an `apps` create/update succeeds at the commerce store, COMMIT the
+	// edited card fields into the catalog-sovereign Gitea Org as a Blueprint
+	// CR — git is the single source of truth, the store is its cache. The
+	// commit runs under its OWN budget (catalogEditGitBudget, NOT the
+	// already-partly-consumed 1500ms probe ctx — §3C/§5C), and its result is
+	// surfaced to the caller instead of being swallowed: a non-committed edit
+	// must never read as a durable green "Saved" (§5: "no green 'Saved'
+	// unless the IaC write is durable"). DELETEs are not mirrored here
+	// (removing a curated CR is the /blueprints lifecycle, not an edit). See
+	// catalog_edit_git.go.
 	if kind == "apps" && method != http.MethodDelete &&
 		upstreamStatus >= 200 && upstreamStatus < 300 {
-		h.commitCatalogAppEditToGit(ctx, body)
+		committed, reason := h.commitCatalogAppEditToGit(r.Context(), body)
+		// The commerce store (the cache) has the edit; whether git (the
+		// source) durably accepted it is reported alongside so the UI shows
+		// "Saved to IaC ✓" vs "Saved (cache only) — IaC commit failed: …".
+		// Only a successful 2xx-with-JSON-body upstream reaches here, so we
+		// re-wrap the upstream object with the commit verdict rather than
+		// relaying it opaquely.
+		h.writeCatalogEditEnvelope(w, upstreamStatus, respBody, committed, reason)
+		return
 	}
 
 	// Relay the upstream response verbatim — status + body — so the
@@ -187,6 +197,36 @@ func (h *Handler) proxyCommerce(w http.ResponseWriter, r *http.Request, method, 
 	}
 }
 
+// catalogEditEnvelope wraps a successful commerce-store `apps` mutation with
+// the IaC-commit verdict (#3668 §5C). The UI's saveCatalogEdit reads
+// `committed` + `reason` to decide between a durable "Saved to IaC ✓" and an
+// amber "Saved (cache only) — IaC commit failed: <reason>". `store` carries
+// the upstream object verbatim so any consumer that read the raw created/
+// updated row before #3668 still finds it.
+type catalogEditEnvelope struct {
+	Stored    bool            `json:"stored"`
+	Committed bool            `json:"committed"`
+	Reason    string          `json:"reason,omitempty"`
+	Store     json.RawMessage `json:"store,omitempty"`
+}
+
+// writeCatalogEditEnvelope emits the #3668 edit envelope. The commerce store
+// write already succeeded (stored:true is unconditional on this path); the
+// `committed`/`reason` fields report whether the git source-of-truth write
+// landed. The upstream status is preserved so existing 2xx handling in the UI
+// is unchanged.
+func (h *Handler) writeCatalogEditEnvelope(w http.ResponseWriter, upstreamStatus int, storeBody []byte, committed bool, reason string) {
+	env := catalogEditEnvelope{
+		Stored:    true,
+		Committed: committed,
+		Reason:    reason,
+	}
+	if len(storeBody) > 0 && json.Valid(storeBody) {
+		env.Store = json.RawMessage(storeBody)
+	}
+	writeJSON(w, upstreamStatus, env)
+}
+
 // commitCatalogAppEditToGit decodes the `apps` mutation body (the
 // commerce App JSON the UI's saveCatalogEdit PUT/POSTs) into the catalog
 // card-overlay shape and commits it to the local catalog git
@@ -194,25 +234,60 @@ func (h *Handler) proxyCommerce(w http.ResponseWriter, r *http.Request, method, 
 // icon, icon_light, icon_dark, supported_topologies) line up with
 // catalogEdit's tags VERBATIM, so the same bytes decode straight in.
 //
-// Failures are logged + swallowed: the store write already succeeded, so
-// the API response stays correct; the entry simply isn't yet reflected in
-// git (e.g. Gitea unreachable pre-cutover). The next edit re-attempts.
-func (h *Handler) commitCatalogAppEditToGit(ctx context.Context, body []byte) {
+// #3668 §5C — the git commit is the SOURCE write, not a best-effort
+// side-effect. It runs under its OWN budget (catalogEditGitBudgetDuration,
+// derived from a FRESH context off the parent request — NOT the 1500ms
+// commerce probe ctx that was already partly consumed by AdminProxy) so a
+// busy-but-healthy Gitea commits durably. The verdict is RETURNED, never
+// swallowed: the caller surfaces (committed, reason) so the UI distinguishes
+// a durable "Saved to IaC ✓" from a cache-only "IaC commit failed".
+//
+// Returns:
+//   - (true, "")            — the bytes were committed (a new commit, or the
+//     file was already byte-identical to the edit).
+//   - (false, "<reason>")   — the edit is not yet durable in git; reason is a
+//     short human string for the UI (unwired client / nothing-to-commit /
+//     the transport error). The store write already succeeded, so the entry
+//     is served from the cache until a later edit (or a reconcile) lands it.
+func (h *Handler) commitCatalogAppEditToGit(parent context.Context, body []byte) (bool, string) {
 	if len(body) == 0 {
-		return
+		return false, "empty body"
 	}
 	var edit catalogEdit
 	if err := json.Unmarshal(body, &edit); err != nil {
 		if h.log != nil {
 			h.log.Warn("catalog-edit-git: decode apps body failed", "err", err)
 		}
-		return
+		return false, "decode apps body failed"
 	}
 	if strings.TrimSpace(edit.Slug) == "" || !edit.hasOverlay() {
-		return // nothing IaC-relevant to commit
+		return false, "nothing IaC-relevant to commit"
 	}
-	if _, err := h.writeCatalogEditToGit(ctx, edit); err != nil && h.log != nil {
-		h.log.Warn("catalog-edit-git: commit to catalog-sovereign failed",
-			"slug", edit.Slug, "err", err)
+	if h.giteaClient == nil {
+		// Pre-cutover / CI: no local catalog git yet. The store cache holds
+		// the edit; it becomes IaC once Gitea is reachable. Reported (not
+		// swallowed) so the UI can say "cache only" rather than a false green.
+		return false, "local catalog git not yet available (pre-cutover)"
 	}
+
+	// Fresh, git-sized budget off the ORIGINAL request context (so a client
+	// disconnect still cancels) — decoupled from the consumed 1500ms probe ctx.
+	ctx, cancel := context.WithTimeout(parent, catalogEditGitBudgetDuration())
+	defer cancel()
+
+	// writeCatalogEditToGit returns committed=false WITHOUT error in two
+	// cases now that the unwired + no-overlay guards are handled above:
+	// (a) a fresh commit was suppressed because the file was already
+	// BYTE-IDENTICAL to the edit (PutFile's idempotency short-circuit). That
+	// is a DURABLE state — the source of truth already carries these bytes —
+	// so it must read as committed/durable to the UI, NOT a "cache only"
+	// failure. We therefore treat (false, nil) here as durable.
+	if _, err := h.writeCatalogEditToGit(ctx, edit); err != nil {
+		if h.log != nil {
+			h.log.Warn("catalog-edit-git: commit to catalog-sovereign failed",
+				"slug", edit.Slug, "err", err)
+		}
+		return false, "IaC commit failed: " + err.Error()
+	}
+	return true, ""
 }

--- a/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/catalog.api.ts
@@ -45,6 +45,16 @@ export interface BlueprintCard {
   description?: string
   tagline?: string
   icon?: string
+  /**
+   * #3668 — theme-aware icons sourced from the blueprint IaC
+   * (`spec.card.iconLight` / `iconDark`). The Go API emits these as
+   * `iconLight` / `iconDark` (CatalogBlueprintCard). The console resolves
+   * the IaC icon FIRST (theme-aware), then the build-time vendored asset,
+   * then the letter-mark — so an admin edit to the icon actually renders
+   * (it previously round-tripped to storage but never to the screen).
+   */
+  iconLight?: string
+  iconDark?: string
   category?: string
   family?: string
   tags?: string[]
@@ -126,6 +136,43 @@ export async function getCatalogItem(name: string): Promise<CatalogItem> {
     throw new Error(`catalog get: HTTP ${res.status}`)
   }
   return res.json()
+}
+
+/**
+ * #3668 §5D — the full-CR catalog IaC editor save. Commits the WHOLE
+ * blueprint.yaml the admin edited (spec.source / manifests / sso /
+ * placementSchema / endpoints / shareable / contextSchema — fields the
+ * 7-field card form can never touch) to the SAME catalog-sovereign Gitea
+ * file the card-edit path writes, via `PUT /api/v1/catalog/{name}/iac`. The
+ * git write is the success criterion: a non-2xx means the IaC source did not
+ * accept it, so the editor must surface the failure (never a false "Saved").
+ */
+export interface CatalogIaCEditResponse {
+  slug: string
+  path: string
+  committed: boolean
+  reason?: string
+}
+
+export async function saveCatalogBlueprintIaC(
+  name: string,
+  blueprintYaml: string,
+): Promise<CatalogIaCEditResponse> {
+  const url = `${catalogBase()}/${encodeURIComponent(name)}/iac`
+  const res = await authedFetch(url, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({ blueprintYaml }),
+  })
+  const detail = await res.text().catch(() => '')
+  if (!res.ok) {
+    throw new Error(`catalog IaC edit: HTTP ${res.status} ${detail}`.trim())
+  }
+  try {
+    return JSON.parse(detail) as CatalogIaCEditResponse
+  } catch {
+    return { slug: name.replace(/^bp-/, ''), path: '', committed: true }
+  }
 }
 
 export async function getCatalogVersions(name: string): Promise<CatalogVersionsResponse> {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
@@ -50,6 +50,7 @@ import { WipeDeploymentModal } from '@/components/CrudModals/WipeDeploymentModal
 import { useNotifications } from '@/shared/ui/notifications'
 import { isDeploymentID } from '@/shared/types/deployment'
 import { useTheme } from '@/shared/lib/useTheme'
+import { resolveCatalogIcon } from '@/shared/lib/resolveCatalogIcon'
 
 interface AppsPageProps {
   /** Test seam — disables the live SSE EventSource attach. */
@@ -916,12 +917,16 @@ export function AppCard({ app, status, isCatalog, isService, environment, market
   // light icon in the light theme, dark icon in the dark theme. Fall back
   // to the other theme's icon, then the build-time logo. Empty on
   // un-edited entries → keeps app.logoUrl.
+  // #3603 / #3668 §5B — render the theme-correct IaC icon override when
+  // present (light icon in the light theme, dark icon in the dark theme),
+  // then the build-time logo, then the letter-mark. Resolved through the
+  // SAME shared resolveCatalogIcon path the catalog detail page uses, so the
+  // grid card and the hero never diverge (one mechanism, no per-blueprint
+  // branch — DoD §9.9). The iconLight/iconDark props carry the IaC edit
+  // (mirrored from Gitea via the read overlay).
   const { theme } = useTheme()
-  const themeIcon =
-    theme === 'light'
-      ? (iconLight || iconDark || '')
-      : (iconDark || iconLight || '')
-  const resolvedIcon = themeIcon || app.logoUrl || ''
+  const resolvedIcon =
+    resolveCatalogIcon({ iconLight, iconDark }, theme, app.logoUrl ?? null) ?? ''
   // #3374 — the per-card Open button resolves a silent-SSO launch via the
   // app's CR uid when known, else the bootstrap-kit blueprint/release name
   // (the BE launch-url resolver strips `bp-` and matches the HR). Mirrors

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
@@ -1,12 +1,21 @@
-import { useState } from 'react'
+import { useState, type CSSProperties } from 'react'
 import { useParams, Link } from '@tanstack/react-router'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 
-import { getCatalogItem, getApplication, type CatalogItem } from '@/lib/catalog.api'
+import {
+  getCatalogItem,
+  getApplication,
+  saveCatalogBlueprintIaC,
+  type CatalogItem,
+} from '@/lib/catalog.api'
 import { findComponent } from '@/pages/wizard/steps/componentGroups'
 import { BLUEPRINT_BY_ID } from '@/shared/constants/catalog.generated'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
+import { useTheme } from '@/shared/lib/useTheme'
+import { resolveCatalogIcon } from '@/shared/lib/resolveCatalogIcon'
+import { YamlEditor } from '@/widgets/cloud-list/YamlEditor'
+import type { K8sObject } from '@/widgets/architecture-graph/useK8sCacheStream'
 import { InstancesSection } from './AppDetail/InstancesSection'
 import { useCatalogAdmin } from '@/shared/lib/useCatalogAdmin'
 import { CatalogEditForm } from './CatalogEditForm'
@@ -61,10 +70,16 @@ export function CatalogDetail() {
   const name = (params.blueprintName ?? '').replace(/^bp-/, '')
   const { deploymentId } = useResolvedDeploymentId()
   const isAdmin = useCatalogAdmin()
+  const { theme } = useTheme()
   const qc = useQueryClient()
   // #3648 (founder item #1) — inline edit-in-place on the detail page,
   // replacing the separate edit chip + modal on the catalog grid.
   const [editing, setEditing] = useState(false)
+  // #3668 §5D — the full-CR "Edit IaC" mode: mounts the shipping YamlEditor
+  // on the WHOLE blueprint.yaml so spec.source / manifests / sso / placement
+  // / endpoints / shareable / contextSchema (fields the 7-field card form
+  // can't touch) are editable, committing to the SAME catalog-sovereign file.
+  const [editingIaC, setEditingIaC] = useState(false)
 
   // Chroot-aware "back to Catalog" target. On the mothership provision
   // monitor (`/provision/$deploymentId/...`) the apps grid is at
@@ -166,12 +181,15 @@ export function CatalogDetail() {
       ?.contextSchema?.kind ??
     ''
 
-  // Icon: reuse the same resolution as AppDetail / AppsPage — the
-  // component-catalog `logoUrl` (a real public/ asset URL) keyed by the
-  // bare blueprint id. `card.icon` from the API is only a bare SVG
-  // filename with no console-resolvable base, so we don't render it as a
-  // src; the letter-mark fallback covers components without a logo.
-  const logoUrl = findComponent(name)?.logoUrl ?? null
+  // Icon (#3668 §5B): resolve the IaC icon FIRST (theme-aware
+  // `card.iconLight` / `iconDark`), falling back to the build-time vendored
+  // asset (`componentGroups.logoUrl`) only when the IaC carries none, and the
+  // letter-mark last. Before #3668 this read the build-time map and DISCARDED
+  // the API's `card.iconLight`/`iconDark`, so an admin's icon edit landed in
+  // IaC + the API response and was thrown away at the last render step. One
+  // shared resolution path (resolveCatalogIcon) — no per-blueprint branch.
+  const bundledLogo = findComponent(name)?.logoUrl ?? null
+  const logoUrl = resolveCatalogIcon(card, theme, bundledLogo)
 
   const bootstrapApp = bootstrapQuery.data
   const isBootstrapSingleton = !!bootstrapApp?.bootstrap
@@ -206,27 +224,30 @@ export function CatalogDetail() {
           <h1>
             <span data-testid="catalog-title">{title}</span>
           </h1>
-          {isAdmin && !editing ? (
-            <button
-              type="button"
-              data-testid="catalog-detail-edit"
-              onClick={() => setEditing(true)}
-              title="Edit this catalog entry"
-              style={{
-                alignSelf: 'flex-start',
-                marginTop: '0.15rem',
-                padding: '0.3rem 0.8rem',
-                borderRadius: '8px',
-                border: '1px solid var(--color-border)',
-                background: 'transparent',
-                color: 'var(--color-text)',
-                fontSize: '0.8rem',
-                fontWeight: 600,
-                cursor: 'pointer',
-              }}
-            >
-              Edit
-            </button>
+          {isAdmin && !editing && !editingIaC ? (
+            <div style={{ display: 'flex', gap: '0.5rem', alignSelf: 'flex-start', marginTop: '0.15rem' }}>
+              <button
+                type="button"
+                data-testid="catalog-detail-edit"
+                onClick={() => setEditing(true)}
+                title="Edit this catalog entry's card fields"
+                style={CATALOG_EDIT_BTN_STYLE}
+              >
+                Edit
+              </button>
+              {/* #3668 §5D — open the full-CR IaC editor on the whole
+                  blueprint.yaml (spec.source / manifests / sso / placement /
+                  endpoints / shareable / contextSchema). */}
+              <button
+                type="button"
+                data-testid="catalog-detail-edit-iac"
+                onClick={() => setEditingIaC(true)}
+                title="Edit the full blueprint IaC (advanced)"
+                style={CATALOG_EDIT_BTN_STYLE}
+              >
+                Edit IaC ⟩
+              </button>
+            </div>
           ) : null}
           {card.tagline || card.summary ? (
             <p className="hero-tagline">{card.tagline || card.summary}</p>
@@ -333,8 +354,14 @@ export function CatalogDetail() {
               name: title,
               summary: card.tagline || card.summary || '',
               supportedTopologies: topologies.map(toEditorMode),
-              iconLight: logoUrl ?? '',
-              iconDark: '',
+              // #3668 §5B(b) — pre-fill from the CURRENT IaC icon
+              // (`card.iconLight` / `iconDark`), NOT the build-time bundled
+              // asset, so opening the form on an already-edited blueprint
+              // shows the edited value and dark is not permanently blank.
+              // The bundled asset is only a fallback when the IaC carries no
+              // light icon (so the admin starts from the rendered default).
+              iconLight: card.iconLight || bundledLogo || '',
+              iconDark: card.iconDark || '',
             }}
             onSaved={() => {
               setEditing(false)
@@ -342,6 +369,49 @@ export function CatalogDetail() {
             }}
             onCancel={() => setEditing(false)}
           />
+        </section>
+      ) : null}
+
+      {/* #3668 §5D — full-CR IaC editor. Reuses the shipping YamlEditor
+          (the same widget the cloud-list uses) on the blueprint's full CR,
+          committing the WHOLE blueprint.yaml to the SAME catalog-sovereign
+          Gitea file the card edit writes. This is where source / manifests /
+          sso / placement / endpoints / contextSchema are edited. */}
+      {editingIaC ? (
+        <section className="section" data-testid="catalog-edit-iac-section">
+          <h2>Edit IaC — full blueprint</h2>
+          <p className="section-hint">
+            Editing the complete <code>blueprint.yaml</code> in Gitea
+            (catalog-sovereign). Commit writes the IaC source of truth; Flux
+            reconciles it into the in-cluster Blueprint. Both this editor and
+            the card form above write the same file.
+          </p>
+          <YamlEditor
+            deploymentId={deploymentId ?? ''}
+            kind="Blueprint"
+            ns={undefined}
+            name={`bp-${name}`}
+            obj={(cat.raw as K8sObject | undefined) ?? null}
+            commitLabel="Commit IaC"
+            onCommit={async (yaml) => {
+              const resp = await saveCatalogBlueprintIaC(`bp-${name}`, yaml)
+              if (!resp.committed) {
+                throw new Error(resp.reason || 'IaC commit did not land')
+              }
+              void qc.invalidateQueries({ queryKey: ['catalog-item', name] })
+              return `Committed to IaC ✓ (${resp.path || 'catalog-sovereign'})`
+            }}
+          />
+          <div style={{ marginTop: '0.8rem' }}>
+            <button
+              type="button"
+              data-testid="catalog-edit-iac-close"
+              onClick={() => setEditingIaC(false)}
+              style={CATALOG_EDIT_BTN_STYLE}
+            >
+              Close
+            </button>
+          </div>
         </section>
       ) : null}
 
@@ -476,6 +546,21 @@ export function CatalogDetail() {
       ) : null}
     </section>
   )
+}
+
+/* ─── shared inline styles ───────────────────────────────────────── */
+
+// #3668 — shared button style for the catalog detail-page edit affordances
+// (Edit / Edit IaC / Close), matching the prior single Edit button.
+const CATALOG_EDIT_BTN_STYLE: CSSProperties = {
+  padding: '0.3rem 0.8rem',
+  borderRadius: '8px',
+  border: '1px solid var(--color-border)',
+  background: 'transparent',
+  color: 'var(--color-text)',
+  fontSize: '0.8rem',
+  fontWeight: 600,
+  cursor: 'pointer',
 }
 
 /* ─── spec readers ───────────────────────────────────────────────── */

--- a/products/catalyst/bootstrap/ui/src/shared/lib/resolveCatalogIcon.test.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/resolveCatalogIcon.test.ts
@@ -1,0 +1,89 @@
+/**
+ * resolveCatalogIcon tests — #3668 §5B.
+ *
+ * The model: the rendered catalog icon is the IaC icon
+ * (card.iconLight / iconDark, theme-aware), NOT the build-time bundled
+ * asset. Before #3668 the detail page read the build-time map and discarded
+ * the API's theme icons, so an admin's icon edit never rendered. These pin
+ * the single resolution path: IaC first (theme-correct), bundled asset as
+ * fallback, letter-mark last; plus the bare-filename guard.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { resolveCatalogIcon, isRenderableSrc } from './resolveCatalogIcon'
+
+describe('resolveCatalogIcon', () => {
+  it('renders the IaC light icon in the light theme (over the bundled asset)', () => {
+    expect(
+      resolveCatalogIcon(
+        { iconLight: 'https://cdn/light.svg', iconDark: 'https://cdn/dark.svg' },
+        'light',
+        '/component-logos/alloy.svg',
+      ),
+    ).toBe('https://cdn/light.svg')
+  })
+
+  it('renders the IaC dark icon in the dark theme', () => {
+    expect(
+      resolveCatalogIcon(
+        { iconLight: 'https://cdn/light.svg', iconDark: 'https://cdn/dark.svg' },
+        'dark',
+        '/component-logos/alloy.svg',
+      ),
+    ).toBe('https://cdn/dark.svg')
+  })
+
+  it('falls back to the other theme icon when one theme is unset (one-theme edit renders in both)', () => {
+    expect(
+      resolveCatalogIcon({ iconLight: 'https://cdn/light.svg' }, 'dark', null),
+    ).toBe('https://cdn/light.svg')
+  })
+
+  it('accepts a data-URI IaC icon (the DoD red-dot edit) over the bundled asset', () => {
+    const redDot = 'data:image/png;base64,iVBORw0KGgoAAAANS'
+    expect(
+      resolveCatalogIcon({ iconLight: redDot }, 'light', '/component-logos/alloy.svg'),
+    ).toBe(redDot)
+  })
+
+  it('falls back to the bundled asset when the IaC carries no icon', () => {
+    expect(resolveCatalogIcon({}, 'light', '/component-logos/alloy.svg')).toBe(
+      '/component-logos/alloy.svg',
+    )
+  })
+
+  it('returns null (letter-mark) when neither IaC nor bundled asset is present', () => {
+    expect(resolveCatalogIcon({}, 'dark', null)).toBeNull()
+    expect(resolveCatalogIcon(undefined, 'dark', '')).toBeNull()
+  })
+
+  it('does NOT treat a bare SVG filename as a renderable src (no resolvable base)', () => {
+    // The legacy card.icon is often a bare "grafana.svg" — it must fall
+    // through to the bundled asset, not render as a broken <img src>.
+    expect(
+      resolveCatalogIcon({ icon: 'grafana.svg' }, 'light', '/component-logos/grafana.svg'),
+    ).toBe('/component-logos/grafana.svg')
+  })
+
+  it('uses a rooted/relative legacy card.icon when it is a resolvable path', () => {
+    expect(resolveCatalogIcon({ icon: '/icons/x.svg' }, 'light', null)).toBe('/icons/x.svg')
+  })
+})
+
+describe('isRenderableSrc', () => {
+  it('accepts absolute URLs, data URIs, and rooted/relative paths', () => {
+    expect(isRenderableSrc('https://x/y.svg')).toBe(true)
+    expect(isRenderableSrc('http://x/y.svg')).toBe(true)
+    expect(isRenderableSrc('data:image/png;base64,AAAA')).toBe(true)
+    expect(isRenderableSrc('/a/b.svg')).toBe(true)
+    expect(isRenderableSrc('./b.svg')).toBe(true)
+    expect(isRenderableSrc('../b.svg')).toBe(true)
+  })
+
+  it('rejects bare tokens and empties', () => {
+    expect(isRenderableSrc('grafana.svg')).toBe(false)
+    expect(isRenderableSrc('')).toBe(false)
+    expect(isRenderableSrc(undefined)).toBe(false)
+    expect(isRenderableSrc(null)).toBe(false)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/shared/lib/resolveCatalogIcon.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/resolveCatalogIcon.ts
@@ -1,0 +1,86 @@
+/**
+ * resolveCatalogIcon — #3668 §5B: the SINGLE icon-resolution path for the
+ * catalog (hero, grid card, /apps tile, instance page).
+ *
+ * The model (ticket §2): "the rendered icon is the IaC icon
+ * (`spec.card.iconLight` / `iconDark`, theme-aware), not a value baked into
+ * the console bundle." Before #3668 the catalog detail/grid read a build-time
+ * TypeScript table (`componentGroups.logoUrl`) and DISCARDED the API's
+ * `card.iconLight` / `iconDark`, so an admin's icon edit landed in IaC + the
+ * API response and was thrown away at the last render step — the edit was
+ * theater.
+ *
+ * Resolution order (founder rule #2 — render = read the source):
+ *   1. the IaC icon for the active theme (`card.iconDark` in dark theme,
+ *      `card.iconLight` in light theme), with the OTHER theme's icon as a
+ *      same-source fallback so a one-theme edit still renders in both;
+ *   2. the legacy single `card.icon` IF it is a console-resolvable src (an
+ *      absolute URL or a rooted/relative path — NOT a bare SVG filename,
+ *      which has no resolvable base and must fall through);
+ *   3. the build-time vendored asset (`componentGroups.logoUrl`) — the
+ *      pre-#3668 source, now the fallback when the IaC carries no icon;
+ *   4. null → the caller renders the letter-mark.
+ *
+ * This is one generic mechanism for every blueprint (founder rule #4): no
+ * per-blueprint branch, no per-field special-casing. Pure — unit-testable in
+ * isolation.
+ */
+
+export type IconTheme = 'light' | 'dark'
+
+export interface CatalogIconCard {
+  icon?: string
+  iconLight?: string
+  iconDark?: string
+}
+
+/** isRenderableSrc — true when `s` is something an <img src> can resolve:
+ *  an absolute URL (http/https), a data: URI, or a rooted/relative path
+ *  ('/x', './x', '../x'). A bare token like "grafana.svg" has no
+ *  console-resolvable base (the pre-#3668 reason `card.icon` was discarded)
+ *  so it is NOT renderable as a src. */
+export function isRenderableSrc(s: string | undefined | null): boolean {
+  const v = (s ?? '').trim()
+  if (v === '') return false
+  return (
+    /^https?:\/\//i.test(v) ||
+    v.startsWith('data:') ||
+    v.startsWith('/') ||
+    v.startsWith('./') ||
+    v.startsWith('../')
+  )
+}
+
+/**
+ * resolveCatalogIcon — the IaC-first icon src for a catalog card.
+ *
+ * @param card     the catalog item's card (carries the IaC icons).
+ * @param theme    the active console theme.
+ * @param fallback the build-time vendored asset URL (e.g.
+ *                 `findComponent(name)?.logoUrl`) — used ONLY when the IaC
+ *                 carries no usable icon. Pass null when there is none.
+ * @returns the resolved <img src>, or null when nothing resolves (letter-mark).
+ */
+export function resolveCatalogIcon(
+  card: CatalogIconCard | undefined,
+  theme: IconTheme,
+  fallback: string | null | undefined,
+): string | null {
+  const light = (card?.iconLight ?? '').trim()
+  const dark = (card?.iconDark ?? '').trim()
+
+  // 1. theme-preferred IaC icon, with the other theme's IaC icon as a
+  //    same-source fallback (a one-theme edit still renders in both themes).
+  const themed = theme === 'dark' ? dark || light : light || dark
+  if (isRenderableSrc(themed)) return themed
+
+  // 2. the legacy single icon, only when it is itself a resolvable src.
+  if (isRenderableSrc(card?.icon)) return (card!.icon as string).trim()
+
+  // 3. the build-time vendored asset (pre-#3668 source → now the fallback).
+  const fb = (fallback ?? '').trim()
+  if (fb !== '') return fb
+
+  // 4. letter-mark.
+  return null
+}

--- a/products/catalyst/bootstrap/ui/src/widgets/cloud-list/YamlEditor.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/cloud-list/YamlEditor.tsx
@@ -42,6 +42,21 @@ export interface YamlEditorProps {
   /** Test seam — when true, "Apply" produces a PR-mode placeholder
    *  instead of a real Gitea call. */
   fluxOverride?: boolean
+  /**
+   * #3668 §5D — commit-target override. When provided, "Apply" commits the
+   * edited YAML through THIS callback instead of the default
+   * flux→edit-pr / manual→apply branching. The catalog's "Edit IaC" mode
+   * passes a callback that PUTs the full blueprint.yaml to
+   * catalog-sovereign/<bp>/blueprint.yaml (the SAME Gitea file the card edit
+   * writes), so the same shipping editor drives the catalog single source of
+   * truth. The returned string is shown as the success message. A thrown
+   * error surfaces as the apply error (so a non-committed write never reads
+   * as success). The editor UI (diff / validate / dirty-state) is unchanged.
+   */
+  onCommit?: (yaml: string) => Promise<string>
+  /** Optional label for the apply button when onCommit is set (default
+   *  "Commit IaC"). */
+  commitLabel?: string
 }
 
 /** Convert a JS object to canonical YAML — small subset suitable for
@@ -110,7 +125,7 @@ function computeDiff(left: string, right: string): DiffLine[] {
   return out
 }
 
-export function YamlEditor({ deploymentId, kind, ns, name, obj, fluxOverride }: YamlEditorProps) {
+export function YamlEditor({ deploymentId, kind, ns, name, obj, fluxOverride, onCommit, commitLabel }: YamlEditorProps) {
   const initial = useMemo(() => (obj ? objectToYAML(obj) : ''), [obj])
   const [yaml, setYaml] = useState<string>(initial)
   const [showDiff, setShowDiff] = useState(false)
@@ -145,7 +160,13 @@ export function YamlEditor({ deploymentId, kind, ns, name, obj, fluxOverride }: 
     setPRInfo(null)
     setBusy('apply')
     try {
-      if (flux) {
+      if (onCommit) {
+        // #3668 §5D — catalog "Edit IaC" mode: commit through the provided
+        // catalog-sovereign writer instead of the cloud-list edit-pr/apply
+        // branching. A thrown error surfaces below (no false success).
+        const msg = await onCommit(yaml)
+        setApplyMsg(msg)
+      } else if (flux) {
         // Slice Z3 — flux-managed resources route through the unified
         // /blueprints/edit-pr endpoint: branch + commit + PR on the
         // per-Org shared-blueprints repo. The org slug is derived from
@@ -262,7 +283,13 @@ export function YamlEditor({ deploymentId, kind, ns, name, obj, fluxOverride }: 
           data-testid="yaml-editor-apply"
           className="rounded border border-emerald-500 bg-emerald-600 px-3 py-1.5 text-sm text-white hover:bg-emerald-500 disabled:opacity-60"
         >
-          {busy === 'apply' ? 'Applying…' : flux ? 'Open PR' : 'Apply'}
+          {busy === 'apply'
+            ? 'Applying…'
+            : onCommit
+              ? (commitLabel ?? 'Commit IaC')
+              : flux
+                ? 'Open PR'
+                : 'Apply'}
         </button>
         {validateMsg && (
           <span data-testid="yaml-editor-validate-ok" className="text-xs text-emerald-300">


### PR DESCRIPTION
Refs #3668 #3657 #3672 #3676 #3682 (never Closes)

## What this PR ships

The catalog edit was a thin two-way skin in name only. This PR ships the **foundational, mergeable vertical** of the single-source-IaC spine — four reinforcing honesty fixes the ticket folds into #3668:

### 1. The edited icon RENDERS (was #3672 — it was theater)
- New shared `resolveCatalogIcon` (`src/shared/lib/resolveCatalogIcon.ts`): IaC `card.iconLight`/`iconDark` theme-aware FIRST, bundled asset fallback, letter-mark last; with a bare-filename guard (`grafana.svg` has no resolvable base).
- `CatalogDetail.tsx`: the hero icon + the edit-form `initial` now read `card.iconLight`/`iconDark` (the real IaC value), **not** the build-time `componentGroups.logoUrl` that silently shadowed it. `AppCard` (grid card) uses the same shared path — one mechanism, no per-blueprint branch.
- `parseBlueprintCRToCatalog` (Go) now reads `card.iconLight`/`iconDark` so a CR/Gitea-sourced theme icon survives into the wire shape (today only `card.icon` was read).

### 2. The git write is LOAD-BEARING (was #3676)
- New `catalogEditGitBudget` (~15s, `CATALYST_CATALOG_EDIT_GIT_BUDGET`-overridable). The commit no longer shares the already-consumed **1500ms commerce probe** ctx — it runs on a fresh git-sized context off the request.
- `commitCatalogAppEditToGit` now returns `(committed, reason)`; `proxyCommerce` surfaces it as `{stored, committed, reason}` so a non-committed edit **never reads as a durable green "Saved"**. A byte-identical re-edit reports durable (PutFile's short-circuit).

### 3. The first edit seeds the FULL CR (§5A — kills the lossy stub)
- `writeCatalogEditToGit` seeds the Gitea file from the **live Blueprint CR's full spec** (via the catalog client) when no file exists yet, stripping `status` + Helm/Flux ownership metadata, so `spec.source`/`manifests`/`sso`/`contextSchema` survive instead of a `version: 0.0.0` card-only stub.

### 4. The full-CR IaC editor is wired (was #3682)
- `YamlEditor` gains an **additive** `onCommit` override (the diff/validate/dirty UI is unchanged; existing callers untouched).
- `CatalogDetail` "Edit IaC ⟩" mounts the **reused** `YamlEditor` on the full CR, committing via a new `PUT /api/v1/catalog/{name}/iac` to the **SAME** `catalog-sovereign/<bp>/blueprint.yaml` the card edit writes — tier-admin-gated (the existing `/blueprints/edit-pr` authority), Blueprint-validated, retarget-guarded, dedicated git budget.

## Tests / gates (all green)
- `cd products/catalyst/bootstrap/api && go build ./... && go test ./internal/handler/ -race` ✅
- `cd products/catalyst/bootstrap/ui && npx tsc --noEmit && npm run build && npx vitest run src/shared/lib/resolveCatalogIcon.test.ts` ✅
- New Go tests: slow-Gitea-still-commits, erroring-Gitea-reports-not-committed, unwired-reports-cache-only, byte-identical-durable, first-edit-seeds-full-CR; full-CR IaC edit happy-path + 403/400(retarget+malformed)/503.
- New vitest: `resolveCatalogIcon` (10 cases).

## Deferred to follow-on rows of this same ticket (enumerated, not claimed)
- The Flux `GitRepository`+`Kustomization` reconciling `catalog-sovereign/*/blueprint.yaml` → in-cluster `Blueprint` CR (DoD §9.1/9.4 + `helm upgrade` revert-immunity).
- Per-field-inline card editors + the visual icon picker (DoD §9.8 + §5B picker).

## UAT
`docs/ledger/uat-walkthrough/catalog-edit-single-source-iac-not-overlay.md` — click-by-click for the four shipped slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)