### PR TITLE
feat(bootstrap-kit): host-bridge — move keycloak + grafana into the mgmt vCluster (#3642)

### DIFF
--- a/.github/workflows/test-bootstrap-kit.yaml
+++ b/.github/workflows/test-bootstrap-kit.yaml
@@ -21,6 +21,7 @@ on:
       - 'scripts/expected-bootstrap-deps.yaml'
       - 'scripts/expected-cloudinit-kustomization-deps.yaml'
       - 'scripts/render-slot-placement.py'
+      - 'scripts/tests/render_slot_placement_hostbridge_test.py'
       - 'scripts/audit-placement-conformance.py'
       - '.github/workflows/test-bootstrap-kit.yaml'
     branches: [main]
@@ -38,6 +39,7 @@ on:
       - 'scripts/expected-bootstrap-deps.yaml'
       - 'scripts/expected-cloudinit-kustomization-deps.yaml'
       - 'scripts/render-slot-placement.py'
+      - 'scripts/tests/render_slot_placement_hostbridge_test.py'
       - 'scripts/audit-placement-conformance.py'
       - '.github/workflows/test-bootstrap-kit.yaml'
   workflow_dispatch:
@@ -94,6 +96,14 @@ jobs:
         run: |
           pip install pyyaml --quiet 2>/dev/null || true
           python3 scripts/render-slot-placement.py check
+
+      - name: Host-bridge generator render-test (#3642)
+        # Pure-function unit checks of the host-bridge logic
+        # (effective_values/suppress, hostbridge_block transcription,
+        # extract/strip round-trip, lowercase booleans). Guards the
+        # generic mechanism that re-homes route/secret/CNPG apps into a
+        # vCluster while keeping their host-reaching CRs host-rendered.
+        run: python3 scripts/tests/render_slot_placement_hostbridge_test.py
 
       - name: Placement conformance audit — rendered (#3373 DoD-4)
         # actual==declared at render level + §4 host-minimum

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -39,7 +39,7 @@ metadata:
   # longer needs to colocate with vc-mgmt. Reverting also restores
   # the Helm valuesFrom lookup of secrets like 'object-storage'
   # (cloud-init seeds it in flux-system; lookup is in HR's own ns).
-  namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
     catalyst.openova.io/slot: "09"
     catalyst.openova.io/vcluster: mgmt
@@ -47,6 +47,12 @@ spec:
   interval: 15m
   releaseName: keycloak
   targetNamespace: keycloak
+  storageNamespace: keycloak
+  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
   dependsOn:
     # bp-mgmt-vcluster MUST be Ready first — the vc-mgmt
@@ -243,6 +249,7 @@ spec:
     # removed the whole block — chart renders NO HTTPRoute without
     # gateway.host (auth.<fqdn> 404'd live).
     gateway:
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       host: auth.${SOVEREIGN_FQDN}
     # ── Shared-instance flip (#3188 three-instance model) ───────────────
     # Default OWN_CLUSTER=true → the bundled bitnami postgresql subchart
@@ -287,3 +294,43 @@ spec:
         database: keycloak
         existingSecret: keycloak-database-secret
         existingSecretPasswordKey: password
+
+# ── HOST-BRIDGE BEGIN (#3642) — placement-generated host-side route/secret/CNPG; edit placement.yaml hostBridge: + run scripts/render-slot-placement.py fix ──
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: keycloak
+  namespace: mgmt
+  labels:
+    catalyst.openova.io/blueprint: bp-keycloak
+    catalyst.openova.io/component: keycloak
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  parentRefs:
+  - name: cilium-gateway
+    namespace: kube-system
+  hostnames:
+  - auth.${SOVEREIGN_FQDN}
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        port: 443
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /admin/${SOVEREIGN_REALM_NAME:=sovereign}/console/
+        statusCode: 302
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: keycloak-x-keycloak-x-mgmt-vcluster
+      namespace: mgmt
+      port: 80
+# ── HOST-BRIDGE END (#3642) ──

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -56,7 +56,7 @@ spec:
       namespace: flux-system
     # bp-keycloak now lives in flux-system (G105-followup #2697).
     - name: bp-keycloak
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template;
     # gateway.networking.k8s.io/v1 CRDs must be registered first.
     - name: bp-gateway-api

--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -85,7 +85,7 @@ spec:
       namespace: flux-system
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-sso-bridge
       namespace: flux-system
     - name: bp-external-secrets-stores

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -81,7 +81,7 @@ spec:
     # the umbrella install, eliminating the race.
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-cnpg
       namespace: flux-system
     # bp-crossplane-claims (chart-roll-rca iter-15, 2026-05-10): owns the

--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -72,7 +72,7 @@ spec:
     # reconcile once catalyst-api is up. So sso-bridge runs early, writes
     # sso/<app>, and gitea/catalyst-platform install behind it.
     - name: bp-keycloak
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-openbao
   chart:
     spec:

--- a/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
+++ b/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
@@ -55,7 +55,7 @@ spec:
   dependsOn:
     - name: bp-cilium
     - name: bp-keycloak
-      namespace: flux-system
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-external-secrets-stores
   chart:
     spec:

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -46,16 +46,28 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-grafana
-  namespace: flux-system
+  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
+    catalyst.openova.io/vcluster: mgmt
     catalyst.openova.io/slot: "25"
 spec:
   interval: 15m
   timeout: 15m
   releaseName: grafana
   targetNamespace: grafana
+  storageNamespace: grafana
+  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   dependsOn:
+    # bp-mgmt-vcluster MUST be Ready first — the vc-mgmt
+    # Secret doesn't exist until then. placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+    - name: bp-mgmt-vcluster
+      namespace: flux-system
     - name: bp-cnpg
+      namespace: flux-system
     # #2745 (2026-06-12): bp-loki/bp-mimir/bp-tempo HRs re-homed to host
     # ns `mgmt` (mgmt vCluster placement). A bare `name:` resolves in
     # THIS HR's namespace (flux-system) → dangling dep → grafana wedges
@@ -69,10 +81,11 @@ spec:
       namespace: mgmt
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template;
     # gateway.networking.k8s.io/v1 CRDs must be registered first.
     - name: bp-gateway-api
+      namespace: flux-system
     # bp-external-secrets (#3374, 2026-06-14 — #2988 gold-standard pattern,
     # mirrors bp-harbor slot 19): the chart ships
     # templates/sso-oauth-source-externalsecret.yaml which renders grafana's
@@ -90,6 +103,7 @@ spec:
     # grafana wait for the ESO webhook to be Ready so its chart-side ES
     # renders into the grafana namespace at install time.
     - name: bp-external-secrets
+      namespace: flux-system
     # bp-postgres-shared-b (#3188 three-instance model): when grafana
     # SHARES the shared-pg-b instance, gate on it so the grafana Database
     # + role + reflector-pushed `grafana-database-env` hub Secret exist
@@ -98,6 +112,7 @@ spec:
     # within seconds of bp-cnpg + bp-reflector (same unconditional-edge
     # shape as bp-gitea/bp-harbor → bp-postgres-shared).
     - name: bp-postgres-shared-b
+      namespace: flux-system
   chart:
     spec:
       chart: bp-grafana
@@ -125,6 +140,7 @@ spec:
         name: bp-grafana
         namespace: flux-system
   install:
+    createNamespace: true  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     timeout: 15m
     disableWait: true
     remediation:
@@ -140,6 +156,7 @@ spec:
   # attaches to cilium-gateway/kube-system installed by 01-cilium.yaml.
   values:
     gateway:
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       host: grafana.${SOVEREIGN_FQDN}
     # G91.grafana (#2658) — wire bp-sso-bridge framework. The chart-side
     # grafana.ini.auth.generic_oauth block computes auth_url / token_url /
@@ -148,6 +165,7 @@ spec:
     # half-config); with the envsubst SSO works zero-touch on every
     # fresh Sovereign.
     sso:
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       sovereignFqdn: ${SOVEREIGN_FQDN}
       # #3374 (2026-06-14): grafana consumes its OIDC secret as DIRECT env
       # vars via `grafana.envFromSecret: grafana-sso-oidc-credentials`, so it
@@ -189,3 +207,79 @@ spec:
       envFromSecrets:
         - name: grafana-database-env
           optional: ${SOVEREIGN_GRAFANA_DB_SECRET_OPTIONAL:=true}
+
+# ── HOST-BRIDGE BEGIN (#3642) — placement-generated host-side route/secret/CNPG; edit placement.yaml hostBridge: + run scripts/render-slot-placement.py fix ──
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grafana
+  namespace: mgmt
+  labels:
+    catalyst.openova.io/blueprint: bp-grafana
+    catalyst.openova.io/component: grafana
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  parentRefs:
+  - name: cilium-gateway
+    namespace: kube-system
+  hostnames:
+  - grafana.${SOVEREIGN_FQDN}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: grafana-x-grafana-x-mgmt-vcluster
+      namespace: mgmt
+      port: 80
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-sso-oidc-credentials
+  namespace: grafana
+  labels:
+    catalyst.openova.io/blueprint: bp-grafana
+    bp-sso-bridge.openova.io/consumer: bp-grafana
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-region1
+    kind: ClusterSecretStore
+  target:
+    name: grafana-sso-oidc-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        GF_AUTH_GENERIC_OAUTH_CLIENT_ID: '{{ .client_id }}'
+        GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: '{{ .client_secret }}'
+        GF_AUTH_GENERIC_OAUTH_AUTH_URL: '{{ .authorize_url }}?kc_idp_hint=catalyst-pin'
+        GF_AUTH_GENERIC_OAUTH_TOKEN_URL: '{{ .token_url }}'
+        GF_AUTH_GENERIC_OAUTH_API_URL: '{{ .userinfo_url }}'
+        GF_SERVER_ROOT_URL: https://grafana.${SOVEREIGN_FQDN}/
+  data:
+  - secretKey: client_id
+    remoteRef:
+      key: sso/grafana
+      property: client_id
+  - secretKey: client_secret
+    remoteRef:
+      key: sso/grafana
+      property: client_secret
+  - secretKey: authorize_url
+    remoteRef:
+      key: sso/grafana
+      property: authorize_url
+  - secretKey: token_url
+    remoteRef:
+      key: sso/grafana
+      property: token_url
+  - secretKey: userinfo_url
+    remoteRef:
+      key: sso/grafana
+      property: userinfo_url
+# ── HOST-BRIDGE END (#3642) ──

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -78,7 +78,7 @@ spec:
     - name: bp-cert-manager
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-sealed-secrets
     - name: bp-seaweedfs
       namespace: rtz  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -81,7 +81,11 @@ spec:
       # 0.2.10 (#3373): in-vCluster CRD registration via OSS init-manifests
       # (experimental.deploy.vcluster.manifests) — the toHost block alone does NOT
       # register CRDs inside the vCluster on OSS vCluster (Pro-gated). Proven hw130.
-      version: 0.2.10
+      # 0.2.11 (#3642): host-bridge carve-outs (gateway-system/kube-system +
+      # catalyst-system/newapi/sso-bridge/oidc-gate) in allowedIngressNamespaces
+      # so the host Cilium Gateway + keycloak SSO consumers reach the moved
+      # keycloak/grafana through the vCluster isolation netpol.
+      version: 0.2.11
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -68,7 +68,7 @@ spec:
     # host ns `mgmt`.
     - name: bp-openbao
     - name: bp-keycloak
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-cnpg
   chart:
     spec:

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -158,12 +158,74 @@ spec:
     # coupling-fix proof app (gitea).
     - {file: 07-nats-jetstream.yaml, hr: bp-nats-jetstream, vcluster: mgmt, target: mgmt,
        namespace: nats-system}
-    # REVERTED TO STAGED (2026-06-13 hw130 outage): the PROMOTE-NOW conversion
-    # assumed the syncer copies HTTPRoute/ExternalSecret/CNPG CRDs into the
-    # vCluster — measured FALSE on live vc-mgmt (0 sync-set CRDs; keycloak
-    # install: "no matches for kind HTTPRoute"). Stays staged until the
-    # in-vCluster CRD mechanism is implemented + proven on a non-critical app.
-    - {file: 09-keycloak.yaml, hr: bp-keycloak, vcluster: host, target: mgmt, namespace: keycloak}
+    # ── #3642 HOST-BRIDGE PROMOTE — keycloak into the mgmt vCluster ─────
+    # The #2697 hw130 revert app: install had failed `no matches for kind
+    # HTTPRoute` because the OSS syncer registered 0 sync-set CRDs. The
+    # init-manifests deployer (bp-mgmt-vcluster experimental.deploy) now
+    # registers the structural HTTPRoute CRD inside vc-mgmt, AND the
+    # host-bridge keeps keycloak's HTTPRoute HOST-rendered (the chart's own
+    # in-vCluster route is suppressed) so the host Cilium Gateway reconciles
+    # it. keycloak ships NO ExternalSecret (pin-broker is a SealedSecret) and
+    # runs its OWN bundled bitnami PostgreSQL INSIDE the vCluster on a default
+    # prov (postgresql.enabled defaults true) — so it is a pure route-only
+    # host-bridge, no cross-cluster DB wiring. backendRef → the OSS-synced
+    # mangled Service keycloak-x-keycloak-x-mgmt-vcluster.
+    - file: 09-keycloak.yaml
+      hr: bp-keycloak
+      vcluster: mgmt
+      target: mgmt
+      namespace: keycloak
+      hostBridge:
+        suppress:
+          gateway.enabled: false
+        hostDocuments:
+          # The host-bridged HTTPRoute lives in the `mgmt` host namespace
+          # (where the syncer-mangled backend Service is projected), so the
+          # backendRef is SAME-namespace — no ReferenceGrant needed. It
+          # still attaches to kube-system/cilium-gateway: every listener
+          # sets allowedRoutes.namespaces.from=All (01-cilium.yaml:481), so
+          # a route in any namespace binds. The `mgmt` ns is the vCluster
+          # runtime namespace (slot 58) and always exists.
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: keycloak
+              namespace: mgmt
+              labels:
+                catalyst.openova.io/blueprint: bp-keycloak
+                catalyst.openova.io/component: keycloak
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              parentRefs:
+                - name: cilium-gateway
+                  namespace: kube-system
+              hostnames:
+                - auth.${SOVEREIGN_FQDN}
+              rules:
+                # BARE-URL sovereign-admin entry (#3374): the root 302s to
+                # the SOVEREIGN realm admin console (silent catalyst-pin),
+                # not the master-realm login form. Realm = the per-Sovereign
+                # short-name (cloud-init substitutes SOVEREIGN_REALM_NAME).
+                - matches:
+                    - path:
+                        type: Exact
+                        value: /
+                  filters:
+                    - type: RequestRedirect
+                      requestRedirect:
+                        port: 443
+                        path:
+                          type: ReplaceFullPath
+                          replaceFullPath: /admin/${SOVEREIGN_REALM_NAME:=sovereign}/console/
+                        statusCode: 302
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /
+                  backendRefs:
+                    - name: keycloak-x-keycloak-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 80
     # extraNamespaces: the umbrella renders the SME service set into ns
     # `sme` and cutover artifacts into ns `catalyst` alongside its own
     # catalyst-system — declared so the live conformance audit can
@@ -182,13 +244,15 @@ spec:
     # ── §4 PLACEMENT EXCEPTION — host-staying on the pure-OSS Sovereign
     #    stack (a SOVEREIGNTY decision, NOT an unfinished task) ──────────
     #
-    # The 17 rows below carry `target != host` (founder §4 wants them in a
-    # vCluster), yet their ACTIVE placement stays `host` on the pure-OSS
-    # Sovereign build. This is NOT migration debt that a future one-field
-    # flip clears — it is a documented exception forced by a hard
-    # upstream-licensing fact + the Pillar-5 sovereignty mandate. (Decision
-    # ratified with #3373 Batch A, 2026-06-14. Source of truth:
-    # docs/sessions/2026-06-14/3373-migration-plan.md §0/§4/§6.)
+    # The rows below carry `target != host` (founder §4 wants them in a
+    # vCluster). #3642 lands the OSS-native HOST-BRIDGE (see RESOLUTION
+    # below) and MOVES keycloak (09) + grafana (25) into the mgmt vCluster
+    # — those two now carry `vcluster: mgmt` with a `hostBridge:` block.
+    # The remaining route/secret/CNPG rows are host-bridge-READY follow-ons
+    # (same one-field flip + `hostBridge:` declaration). This was NEVER a
+    # license requirement; the host-bridge keeps the route/secret/CNPG CRs
+    # host-rendered. (Migration plan: docs/sessions/2026-06-14/
+    # 3373-migration-plan.md §0/§4/§6; host-bridge: #3642.)
     #
     # THE GOVERNING CONSTRAINT — vCluster CRD-sync is loft.sh Free-tier,
     # NOT pure-OSS:
@@ -223,20 +287,32 @@ spec:
     #   platform/install/air-gapped. The Free-tier CRD-sync feature has NO
     #   offline activation path that is sovereignty-safe.)
     #
-    # CONSEQUENCE — the §4 target for every route/secret/CNPG app below is
-    # ASPIRATIONAL on the pure-OSS stack: it materialises ONLY if a future
-    # OSS-native in-vCluster CRD-sync (or a host-bridge that renders the
-    # route+secret host-side while re-homing just the pod) ships. Until
-    # then these stay `host` BY DESIGN. The 3 clean apps (valkey,
-    # seaweedfs, vllm — plain Service DNS, no route/secret/CNPG) DID
-    # migrate to rtz in Batch A above; they are the ONLY pure-OSS-clean
-    # set. The 17 below are the documented exception, grouped by blocker:
+    # RESOLUTION — the HOST-BRIDGE (#3642, plan path (B)) is the OSS-native
+    # answer that does NOT need the loft.sh license: it keeps the app's
+    # HTTPRoute + ExternalSecret (+ CNPG Cluster) HOST-rendered — declared
+    # as data under the row's `hostBridge:` and transcribed into the slot by
+    # render-slot-placement.py — while only the workload Deployment/
+    # StatefulSet re-homes into the vCluster (spec.kubeConfig → vc-<tier>).
+    # backendRefs point at the OSS-synced mangled Service
+    # (<svc>-x-<innerNs>-x-<tier>-vcluster). So the §4 target is NO LONGER
+    # aspirational for route/secret apps — it is a one-field flip + a
+    # `hostBridge:` declaration. The 3 clean apps (valkey/seaweedfs/vllm)
+    # moved in Batch A; #3642 lands the host-bridge and MOVES the
+    # route/secret class. Status of the North-Star-#1 set, grouped by shape:
     #
-    #   ROUTE + ExternalSecret (Free-tier CRD-sync blocked) — 10:
-    #     openbao, keycloak, gitea, harbor, grafana, powerdns-admin,
-    #     newapi, openova-flow-server, guacamole, catalyst-platform.
-    #   CNPG `Cluster` CR (host cnpg-operator can't see an un-reflected
-    #   in-vCluster CR — same Free-tier mechanism) — 4:
+    #   ROUTE + ExternalSecret — host-bridge MOVED (#3642):
+    #     ✅ keycloak (09, route-only — no ES, bundled PG in-vCluster),
+    #     ✅ grafana  (25, route + SSO ExternalSecret, shared-pg-b consumer).
+    #   ROUTE + ExternalSecret — host-bridge READY (same recipe, follow-on
+    #   rows; openbao adds a 2-backend bare-URL landing route):
+    #     openbao (08), powerdns-admin (11a), openova-flow-server (56).
+    #   ROUTE + ExternalSecret + CNPG `Cluster` — host-bridge + the CNPG
+    #   Cluster rendered host-side (§5d); the in-vCluster Pod reaches the
+    #   host PG cross-cluster (follow-on rows):
+    #     gitea (10), harbor (19), newapi (80), guacamole (52),
+    #     catalyst-platform (13, control-plane root — LAST).
+    #   CNPG `Cluster` CR engines (host cnpg-operator reconciles host-side) —
+    #   host-bridge the Cluster CR (follow-on) — 4:
     #     postgres-shared (×3: 16a/16c/16d) + cnpg-pair (16b).
     #   Host-adjacent reconcilers / DaemonSet (re-home case-by-case, fold
     #   in with their route-bearing peers) — 3:
@@ -257,7 +333,110 @@ spec:
     - {file: 17-valkey.yaml, hr: bp-valkey, vcluster: rtz, target: rtz, namespace: valkey}   # Batch A (#3373) — PROMOTED: pure-OSS clean (no route/secret/CNPG); plain Service DNS via OSS services-sync
     - {file: 18-seaweedfs.yaml, hr: bp-seaweedfs, vcluster: rtz, target: rtz, namespace: seaweedfs}   # Batch A (#3373) — PROMOTED: pure-OSS clean (no route/secret/CNPG); S3 wire is plain Service DNS via OSS services-sync; all consumers S3-default-OFF on a fresh prov
     - {file: 19-harbor.yaml, hr: bp-harbor, vcluster: host, target: mgmt, namespace: harbor}
-    - {file: 25-grafana.yaml, hr: bp-grafana, vcluster: host, target: mgmt, namespace: grafana}
+    # ── #3642 HOST-BRIDGE PROMOTE — grafana into the mgmt vCluster ──────
+    # The North-Star-#1 batch-D-first app (least blast radius: depends only
+    # on already-mgmt loki/mimir/tempo + shared-pg-b). grafana ships an
+    # HTTPRoute + an SSO ExternalSecret (no own CNPG Cluster — it is a
+    # shared-pg-b consumer). The host-bridge keeps BOTH host-rendered (the
+    # host Cilium Gateway + host external-secrets-operator reconcile them
+    # exactly as today) while the grafana Deployment re-homes into mgmt via
+    # spec.kubeConfig.secretRef → vc-mgmt. `suppress` turns the chart's OWN
+    # in-vCluster route + ES off; `hostDocuments` are the host-side copies,
+    # backendRef pre-aliased to the OSS-synced mangled Service
+    # grafana-x-grafana-x-mgmt-vcluster. The materialized
+    # grafana-sso-oidc-credentials Secret reaches the in-vCluster Pod via the
+    # mgmt-vcluster `sync.fromHost.secrets` mapping (values.yaml #3642).
+    - file: 25-grafana.yaml
+      hr: bp-grafana
+      vcluster: mgmt
+      target: mgmt
+      namespace: grafana
+      hostBridge:
+        # Chart values stamped into the in-vCluster workload HR: the
+        # chart's own HTTPRoute + SSO ExternalSecret do NOT render inside
+        # the vCluster (the host-side copies below are authoritative).
+        suppress:
+          gateway.enabled: false
+          sso.enabled: false
+        # Host-side route + ExternalSecret, transcribed verbatim into the
+        # slot by render-slot-placement.py. Placement is DATA.
+        hostDocuments:
+          # HTTPRoute in the `mgmt` host ns (same as the mangled backend
+          # Service → no ReferenceGrant); attaches to kube-system/
+          # cilium-gateway via allowedRoutes.from=All.
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: grafana
+              namespace: mgmt
+              labels:
+                catalyst.openova.io/blueprint: bp-grafana
+                catalyst.openova.io/component: grafana
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              parentRefs:
+                - name: cilium-gateway
+                  namespace: kube-system
+              hostnames:
+                - grafana.${SOVEREIGN_FQDN}
+              rules:
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /
+                  backendRefs:
+                    # OSS sync.toHost.services mangled name (grafana Service
+                    # synced out of vc-mgmt to the host mgmt namespace).
+                    - name: grafana-x-grafana-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 80
+          - apiVersion: external-secrets.io/v1beta1
+            kind: ExternalSecret
+            metadata:
+              name: grafana-sso-oidc-credentials
+              namespace: grafana
+              labels:
+                catalyst.openova.io/blueprint: bp-grafana
+                bp-sso-bridge.openova.io/consumer: bp-grafana
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              refreshInterval: 1h
+              secretStoreRef:
+                name: vault-region1
+                kind: ClusterSecretStore
+              target:
+                name: grafana-sso-oidc-credentials
+                creationPolicy: Owner
+                template:
+                  type: Opaque
+                  data:
+                    GF_AUTH_GENERIC_OAUTH_CLIENT_ID: "{{ .client_id }}"
+                    GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: "{{ .client_secret }}"
+                    GF_AUTH_GENERIC_OAUTH_AUTH_URL: "{{ .authorize_url }}?kc_idp_hint=catalyst-pin"
+                    GF_AUTH_GENERIC_OAUTH_TOKEN_URL: "{{ .token_url }}"
+                    GF_AUTH_GENERIC_OAUTH_API_URL: "{{ .userinfo_url }}"
+                    GF_SERVER_ROOT_URL: "https://grafana.${SOVEREIGN_FQDN}/"
+              data:
+                - secretKey: client_id
+                  remoteRef:
+                    key: sso/grafana
+                    property: client_id
+                - secretKey: client_secret
+                  remoteRef:
+                    key: sso/grafana
+                    property: client_secret
+                - secretKey: authorize_url
+                  remoteRef:
+                    key: sso/grafana
+                    property: authorize_url
+                - secretKey: token_url
+                  remoteRef:
+                    key: sso/grafana
+                    property: token_url
+                - secretKey: userinfo_url
+                  remoteRef:
+                    key: sso/grafana
+                    property: userinfo_url
     - {file: 39-bp-vllm.yaml, hr: bp-vllm, vcluster: rtz, target: rtz, namespace: vllm}   # Batch A (#3373) — PROMOTED: pure-OSS clean (no route/secret/CNPG); plain Service DNS via OSS services-sync; vllm + its newapi channel both default-OFF on a fresh prov
     - {file: 51-bp-k8s-ws-proxy.yaml, hr: bp-k8s-ws-proxy, vcluster: host, target: mgmt,
        namespace: catalyst-system}   # recipe proven, draft PR #3350

--- a/docs/ledger/uat-walkthrough/ns1-migrate-7-host-apps-into-mgmt-vcluster.md
+++ b/docs/ledger/uat-walkthrough/ns1-migrate-7-host-apps-into-mgmt-vcluster.md
@@ -1,0 +1,89 @@
+# NS#1 (#3642) — migrate the 7 host-placed apps into the mgmt vCluster — UAT walk
+
+> **Env: `<re-stamp the CURRENT live env, e.g. hw151.omantel.biz>` · deployment `<id>` · `<date>`.**
+> No prior-env evidence carries over — every ✅ below MUST trace to a `<env>-*` screenshot under
+> `docs/sessions/<date>/evidence/`. Run on a **fresh, zero-touch prov** (the placement flip + the
+> host-bridge slot render must reconcile hands-off).
+
+**North Star #1 (founder, verbatim, 2026-06-12):** *"every app IN a vCluster."*
+
+**What this ticket lands (#3642):** the **OSS-native HOST-BRIDGE** — the generic mechanism that
+moves a route/secret/CNPG app INTO a vCluster **without a loft.sh license** (so the Pillar-5 cutover
+600s deny-egress hold still passes). The app's HTTPRoute + ExternalSecret (+ CNPG `Cluster`) stay
+**host-rendered** (declared as data under the slot's `hostBridge:` in `placement.yaml`, transcribed
+into the slot by `scripts/render-slot-placement.py`); only the workload Deployment/StatefulSet
+re-homes into the vCluster via `spec.kubeConfig.secretRef → vc-mgmt`. `backendRef`s point at the
+OSS-synced syncer-mangled Service `<svc>-x-<innerNs>-x-mgmt-vcluster`.
+
+**This PR's proven set:** **keycloak (09)** + **grafana (25)** are flipped to `vcluster: mgmt` with a
+`hostBridge:` block and MOVE into the mgmt vCluster. keycloak proves the **route-only** class (with a
+bare-URL redirect filter, no ExternalSecret, bundled PG in-vCluster); grafana proves the
+**route + ExternalSecret** class. The remaining 5 (openbao route+secret; harbor/gitea/newapi/guacamole
+route+secret+CNPG) are host-bridge-READY follow-on rows — the SAME one-field flip + `hostBridge:`
+declaration (see `placement.yaml` §4 RESOLUTION block + PR body).
+
+**Sign-in (once):** open the handover URL `https://console.<env>/auth/handover?token=<JWT>`
+→ lands `/dashboard` signed in as the owner, no login form.
+
+---
+
+## PART A — placement declares `vcluster: mgmt` (data, zero hand-edits)
+
+| Go to (URL / cmd) | Then do | You should see | Result |
+|---|---|---|---|
+| `clusters/_template/bootstrap-kit/placement.yaml` | `git diff` the keycloak (09) + grafana (25) rows | both flipped `vcluster: host → mgmt`, each carrying a `hostBridge:` block | ☐ |
+| terminal | `python3 scripts/render-slot-placement.py check` | exits **0** — "placement check PASSED … 11 in vClusters" (slots regenerated, zero hand-edits) | ☐ |
+| terminal | `python3 scripts/tests/render_slot_placement_hostbridge_test.py` | "host-bridge generator render-test PASSED" (11 checks) | ☐ |
+
+## PART B — the apps RUN in the mgmt vCluster (treemap + live syncer suffix)
+
+| Go to (URL / cmd) | Then do | You should see | Result |
+|---|---|---|---|
+| `https://console.<env>/dashboard` | set **LAYER 1** combobox → `vCluster` | treemap regroups into `host` / `mgmt` / `rtz` / `dmz` blocks | ☐ |
+| `https://console.<env>/dashboard` | read the **mgmt** block | the mgmt block now contains **`keycloak`** + **`grafana`** tiles (alongside loki/mimir/tempo/nats) | ☐ |
+| `https://console.<env>/dashboard` | read the **host** block | the host block contains **neither keycloak nor grafana** (only substrate + the not-yet-moved 5) | ☐ |
+| `kubectl --kubeconfig <kc> get pods -A \| grep keycloak` | — | `keycloak-0-x-keycloak-x-mgmt-vcluster` (was 0 before) | ☐ |
+| `kubectl --kubeconfig <kc> get pods -A \| grep grafana` | — | `grafana-*-x-grafana-x-mgmt-vcluster` (was 0 before) | ☐ |
+| terminal | `python3 scripts/audit-placement-conformance.py live --kubeconfig <kc>` | exits **0** — "zero undeclared host workloads"; keycloak/grafana report `mgmt` | ☐ |
+| `https://console.<env>/apps/<keycloak-id>` | open keycloak's app detail | placement reads **`mgmt`** (vCluster), not host | ☐ |
+| `https://console.<env>/apps/<grafana-id>` | open grafana's app detail | placement reads **`mgmt`** (vCluster), not host | ☐ |
+
+## PART C — public surfaces still serve (host-bridge route intact)
+
+| Go to (URL) | Then do | You should see | Result |
+|---|---|---|---|
+| `https://auth.<env>/` | open in a fresh browser | 302 → `/admin/<realm>/console/`, the SOVEREIGN-realm Keycloak admin console (silent catalyst-pin, no master-realm login form) — served via the host-bridged HTTPRoute → `keycloak-x-keycloak-x-mgmt-vcluster` | ☐ |
+| `https://auth.<env>/realms/<realm>/.well-known/openid-configuration` | — | 200, the OIDC discovery doc (the IdP every SSO client uses is reachable post-move) | ☐ |
+| `https://grafana.<env>/` | open in a fresh browser | lands **signed in** (zero-click generic_oauth via the host-bridged ExternalSecret `grafana-sso-oidc-credentials`), owner is GrafanaAdmin — NOT a login form, NOT a 503 "no healthy upstream" | ☐ |
+| `kubectl --kubeconfig <kc> get pods -A \| grep -i imagepull` | — | no `ImagePullBackOff` cluster-wide (harbor — not yet moved — still serves pulls; the keycloak/grafana move did not regress the registry) | ☐ |
+
+## PART D — OSS-native + sovereignty-safe (no loft.sh tether)
+
+| Go to (URL / cmd) | Then do | You should see | Result |
+|---|---|---|---|
+| `kubectl --kubeconfig <kc> -n mgmt get crd httproutes.gateway.networking.k8s.io -o yaml` (in-vCluster) | — | the structural CRD registered by the init-manifests deployer (`experimental.deploy.vcluster.manifests`), annotation `catalyst.openova.io/managed-by: bp-mgmt-vcluster` — NOT a loft.sh license | ☐ |
+| `kubectl --kubeconfig <kc> get ccnp,netpol -A \| grep loft` | — | **no** `admin.loft.sh` egress tether anywhere | ☐ |
+| `https://console.<env>/dashboard` (or the cutover ledger) | drive the cutover to completion | `cutoverComplete=true` AND the **600s deny-egress hold passes** with keycloak + grafana in-vCluster (no `admin.loft.sh` tether breaks it) | ☐ |
+
+## PART E — generality (one flip + one shared template, zero per-app code)
+
+| Go to (URL / cmd) | Then do | You should see | Result |
+|---|---|---|---|
+| terminal | `git diff clusters/_template/bootstrap-kit/09-keycloak.yaml clusters/_template/bootstrap-kit/25-grafana.yaml` | EVERY placement-owned change (HR ns→mgmt, kubeConfig→vc-mgmt, storageNamespace, createNamespace, the bp-mgmt-vcluster runtime edge, the suppress values, the `HOST-BRIDGE BEGIN…END` block) is **`render-slot-placement.py`-generated** from the placement flip — **zero per-app bespoke Go/slot code** | ☐ |
+| terminal | `git grep -n "host-bridge" scripts/render-slot-placement.py` | the host-bridge is ONE generic generator function (`hostbridge_block` / `effective_values`), driven by `placement.yaml hostBridge:` data — not a per-app branch | ☐ |
+| `placement.yaml` §4 RESOLUTION | read the follow-on enumeration | the same recipe moves openbao + harbor + gitea + newapi + guacamole + catalyst-platform — a one-field flip + a `hostBridge:` declaration each | ☐ |
+
+---
+
+## Scope note (honest status)
+
+- **MOVED this PR:** keycloak (09, route-only) + grafana (25, route + ExternalSecret) — the
+  route/secret class proven end-to-end via the generic host-bridge.
+- **Follow-on (host-bridge-READY, same recipe):** openbao (08, adds a 2-backend bare-URL landing
+  route), powerdns-admin (11a), openova-flow-server (56); and the CNPG class — gitea (10), harbor
+  (19), newapi (80), guacamole (52), catalyst-platform (13, LAST) — which additionally host-render
+  their CNPG `Cluster` CR (§5d) and wire the in-vCluster Pod to the host PostgreSQL cross-cluster.
+- **grafana SSO Secret reach:** the host ESO materialises `grafana-sso-oidc-credentials` host-side;
+  the in-vCluster grafana Pod consumes it via the mgmt-vcluster Secret sync. If PART C grafana
+  zero-click does not land on the first walk, confirm the host→vCluster Secret sync mapping (the one
+  named follow-up gap on the route+secret class).

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.10
+  version: 0.2.11
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -89,7 +89,12 @@ name: bp-mgmt-vcluster
 # schemas. The 0.2.7 customResources block is kept verbatim (Pro-license
 # activation + declarative record). Additive subchart-values change only;
 # default `helm template` gains the init-manifest CRDs.
-version: 0.2.10
+# 0.2.11 (#3642): host-bridge carve-outs — the keycloak + grafana host→mgmt
+# move adds gateway-system/kube-system (host Cilium Gateway → the mangled
+# backendRef of the host-bridged HTTPRoutes) + catalyst-system/newapi/
+# sso-bridge/oidc-gate (keycloak SSO consumers) to allowedIngressNamespaces
+# (mirrors the #3423 sme→NATS carve-out). Additive netpol-values change only.
+version: 0.2.11
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -151,6 +151,31 @@ mgmtVcluster:
       # timeout" → the voucher/billing funnel back-half (#3376) is dead.
       # Endpoints are healthy; the policy is the wall. #3376
       - sme
+      # ── #3642 host-bridge carve-outs ──────────────────────────────────
+      # The #3642 host→mgmt move re-homes keycloak (auth.) + grafana into
+      # this vCluster behind the isolation netpol. Their HOST-side
+      # consumers + the host Cilium Gateway that fronts their host-bridged
+      # HTTPRoutes now sit OUTSIDE the vCluster and are denied unless their
+      # namespace is allow-listed (mirrors the #3423 sme→NATS carve-out,
+      # commit cc3a7abcf). Per docs/sessions/2026-06-14/3373-migration-plan
+      # §7 batch-D consumer set:
+      #   gateway-system + kube-system — the host Cilium Gateway dials the
+      #     syncer-mangled Service backendRef (keycloak-x-…, grafana-x-…)
+      #     of every host-bridged HTTPRoute. Without these the public route
+      #     503s "no healthy upstream" even though the in-vCluster Pod is up.
+      - gateway-system
+      - kube-system
+      #   catalyst-system — catalyst-api → keycloak (OIDC admin token, realm
+      #     management); the control-plane reaches the moved IdP.
+      - catalyst-system
+      #   newapi — newapi → keycloak (OIDC client) after newapi's own move.
+      - newapi
+      #   sso-bridge — bp-sso-bridge reconciler → keycloak (realm/client
+      #     bootstrap) while it stays host-side.
+      - sso-bridge
+      #   oidc-gate — host slot 13c auth proxy on the gateway datapath →
+      #     the moved keycloak realm.
+      - oidc-gate
 
 # ─── Upstream chart values (subchart key: vcluster) ────────────────
 # `helm dependency build` resolves the upstream loft-sh/vcluster

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -377,7 +377,11 @@ slots:
     # the ESO CRD (.Capabilities .Has "external-secrets.io/v1beta1") and gates
     # on bp-external-secrets so the ESO webhook is serving before grafana's
     # ExternalSecret applies — lockstep with the live 25-grafana.yaml edge.
-    depends_on: [bp-cnpg, bp-loki, bp-mimir, bp-tempo, bp-keycloak, bp-gateway-api, bp-external-secrets, bp-postgres-shared-b]
+    # bp-mgmt-vcluster dep (#3642): grafana host→mgmt host-bridge move — the
+    # vc-mgmt kubeConfig Secret doesn't exist until bp-mgmt-vcluster is Ready,
+    # so the kubeConfig pivot dangles without this edge (added by
+    # render-slot-placement.py fix from the placement.yaml flip).
+    depends_on: [bp-cnpg, bp-loki, bp-mimir, bp-tempo, bp-keycloak, bp-gateway-api, bp-external-secrets, bp-postgres-shared-b, bp-mgmt-vcluster]
     wave: W2.K2
   - slot: 26
     name: bp-network-policies

--- a/scripts/render-slot-placement.py
+++ b/scripts/render-slot-placement.py
@@ -35,6 +35,12 @@ owned by this tool):
       - dependents of a re-homed HR carry its new namespace
   * spec.install.createNamespace (vcluster slots)
   * declared placement values (fix (a) backendRef aliases)
+  * the host-bridge block (#3642) — when a vCluster slot declares
+    `hostBridge:`, the host-side HTTPRoute / ExternalSecret / CNPG
+    `Cluster` docs are transcribed VERBATIM into the slot between the
+    HOST-BRIDGE markers, and `hostBridge.suppress` values are stamped
+    into the workload HR (turning the chart's OWN in-vCluster
+    route/secret/CNPG off — the host-side copies are authoritative).
 
 Exit codes: 0 ok / 1 drift (check) or fix-failure / 2 usage.
 """
@@ -52,6 +58,108 @@ KIT = os.path.join(REPO, "clusters", "_template", "bootstrap-kit")
 PLACEMENT = os.path.join(KIT, "placement.yaml")
 
 GENERATED_MARK = "# placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix"
+
+# ── host-bridge markers (#3642) ─────────────────────────────────────
+# An app re-homed INTO a vCluster ships its public HTTPRoute, its
+# ExternalSecret, and (where applicable) its CNPG `Cluster` CR from
+# inside its own chart — which, post-pivot, renders those CRs inside
+# the vCluster apiserver where the HOST Cilium Gateway / external-
+# secrets-operator / cnpg-operator (all host-minimum substrate) can
+# never see them. The OSS vCluster syncer's `sync.toHost.customResources`
+# mirror that would carry them host-ward is Pro/Platform-gated and INERT
+# on the pure-OSS build the Sovereign runs (placement.yaml §4 exception
+# block) — so the route would resolve nowhere and the secret would never
+# materialise.
+#
+# The host-bridge (#3642, plan path (B)) keeps those host-reaching CRs
+# HOST-rendered: the slot declares them as data under `hostBridge:` and
+# this generator transcribes them VERBATIM into the slot file between the
+# markers below, in the app's HOST namespace, with every `backendRef`
+# pre-aliased to the syncer-mangled Service `<svc>-x-<innerNs>-x-<sfx>`
+# (the OSS `sync.toHost.services` mirror, proven by loki/nats). The
+# workload HR (with spec.kubeConfig.secretRef → vc-<tier>) re-homes only
+# the Deployment/StatefulSet; `hostBridge.suppress` stamps the chart
+# values that turn the chart's OWN in-vCluster route/secret/CNPG off so
+# the host-side copies are authoritative (no double-render).
+#
+# Placement stays DATA: the route/secret/CNPG content lives in
+# placement.yaml; the slot block is a pure transcription of it, regen-ed
+# on every `fix` and drift-gated on every `check`.
+HOSTBRIDGE_BEGIN = "# ── HOST-BRIDGE BEGIN (#3642) — placement-generated host-side route/secret/CNPG; edit placement.yaml hostBridge: + run scripts/render-slot-placement.py fix ──"
+HOSTBRIDGE_END = "# ── HOST-BRIDGE END (#3642) ──"
+
+
+def yaml_scalar(v):
+    """Render a placement value as a canonical YAML scalar — lowercase
+    booleans (`false`, not Python's `False`), so the stamped slot is
+    valid + idiomatic YAML (#3642)."""
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    return str(v)
+
+
+def effective_values(slot):
+    """The placement-declared HR values the generator stamps — the slot's
+    own `values:` block PLUS the host-bridge `suppress:` overrides that
+    turn the chart's in-vCluster route/secret/CNPG off (#3642). Suppress
+    wins on key collision (it is the placement decision)."""
+    vals = dict(slot.get("values") or {})
+    hb = slot.get("hostBridge") or {}
+    vals.update(hb.get("suppress") or {})
+    return vals
+
+
+def hostbridge_block(slot):
+    """The exact lines the slot file must carry between the host-bridge
+    markers (#3642), or None when the slot declares no host-bridge.
+
+    Each host-bridge document is appended as its own `---`-separated YAML
+    document in the app's HOST namespace. The content is a verbatim
+    transcription of `hostBridge.hostDocuments` (a list of mapping docs)
+    — placement is data, the slot is its rendering."""
+    hb = slot.get("hostBridge") or {}
+    docs = hb.get("hostDocuments") or []
+    if not docs:
+        return None
+    out = [HOSTBRIDGE_BEGIN]
+    for doc in docs:
+        out.append("---")
+        # block-style, 2-space indent, keys in declared order (yaml lib
+        # preserves dict insertion order on py3.7+).
+        rendered = yaml.safe_dump(doc, default_flow_style=False, sort_keys=False).rstrip("\n")
+        out.extend(rendered.splitlines())
+    out.append(HOSTBRIDGE_END)
+    return out
+
+
+def extract_hostbridge(lines):
+    """Return the host-bridge marker block currently in a slot file (the
+    list of lines from BEGIN..END inclusive), or None if absent (#3642)."""
+    begin = end = None
+    for i, l in enumerate(lines):
+        if l.rstrip() == HOSTBRIDGE_BEGIN:
+            begin = i
+        elif l.rstrip() == HOSTBRIDGE_END:
+            end = i
+            break
+    if begin is None or end is None or end < begin:
+        return None
+    return [l.rstrip("\n") for l in lines[begin:end + 1]]
+
+
+def strip_hostbridge(lines):
+    """Remove an existing host-bridge block (markers inclusive) plus the
+    blank line that precedes it, returning the cleaned list (#3642)."""
+    block = extract_hostbridge(lines)
+    if block is None:
+        return lines
+    begin = next(i for i, l in enumerate(lines) if l.rstrip() == HOSTBRIDGE_BEGIN)
+    end = next(i for i, l in enumerate(lines) if l.rstrip() == HOSTBRIDGE_END)
+    lo = begin
+    while lo > 0 and lines[lo - 1].strip() == "":
+        lo -= 1
+    hi = end + 1
+    return lines[:lo] + lines[hi:]
 
 
 def load_placement():
@@ -153,11 +261,37 @@ def check(data, by_hr, verbose=True):
                     errors.append(f"{slot['file']}: dependsOn {d.get('name')!r} lacks explicit namespace "
                                   f"(bare names resolve in the HR's OWN ns {want_ns!r} -> dangling, #3191 shape)")
 
-        # declared placement values stamped?
-        for dotted, want in (slot.get("values") or {}).items():
+        # declared placement values stamped? (#3642: the slot's own
+        # values PLUS the host-bridge suppress overrides)
+        for dotted, want in effective_values(slot).items():
             got = get_dotted(spec.get("values") or {}, dotted)
             if got != want:
                 errors.append(f"{slot['file']}: values.{dotted} = {got!r}, placement declares {want!r}")
+
+        # host-bridge block (#3642): the slot must carry EXACTLY the
+        # host-side route/secret/CNPG docs the placement declares — a
+        # verbatim transcription, drift-gated. A host placement must NOT
+        # carry one (its CRs render natively from the chart, host-side).
+        want_hb = hostbridge_block(slot)
+        with open(fpath) as f:
+            raw_lines = f.read().splitlines()
+        got_hb = extract_hostbridge(raw_lines)
+        if vc == "host":
+            if want_hb is not None:
+                errors.append(f"{slot['file']}: host placement declares hostBridge: — only "
+                              f"vCluster placements need the host-bridge (the chart renders "
+                              f"its CRs host-side natively on host placement)")
+            elif got_hb is not None:
+                errors.append(f"{slot['file']}: stale host-bridge block on a host placement "
+                              f"— run scripts/render-slot-placement.py fix to strip it")
+        else:
+            if want_hb is not None and got_hb != want_hb:
+                errors.append(f"{slot['file']}: host-bridge block drift — slot does not match "
+                              f"placement.yaml hostBridge.hostDocuments (run "
+                              f"scripts/render-slot-placement.py fix)")
+            if want_hb is None and got_hb is not None:
+                errors.append(f"{slot['file']}: carries a host-bridge block but placement.yaml "
+                              f"declares no hostBridge: for it (run fix to strip)")
 
         # dependents: every edge pointing at a placement-managed HR must
         # carry that HR's CURRENT namespace (or omit it only when both
@@ -333,7 +467,11 @@ def fix_slot(slot, data, by_hr):
             tgt = by_hr.get(name)
             tgt_ns = hr_namespace_for(tgt, vclusters) if tgt else "flux-system"
             if ns_idx >= 0:
-                lines[ns_idx + offset] = f"      namespace: {tgt_ns}"
+                # #3642 idempotency: only rewrite when the value actually
+                # changes — an unconditional rewrite strips a correct line's
+                # trailing comment and churns the slot on every `fix`.
+                if lines[ns_idx + offset].split("#")[0].rstrip() != f"      namespace: {tgt_ns}":
+                    lines[ns_idx + offset] = f"      namespace: {tgt_ns}"
             else:
                 lines.insert(name_idx + offset + 1, f"      namespace: {tgt_ns}  {GENERATED_MARK}")
                 offset += 1
@@ -357,8 +495,9 @@ def fix_slot(slot, data, by_hr):
                     e += 1
                     break
 
-        # 6. declared placement values (simple dotted scalar stamping)
-        for dotted, want in (slot.get("values") or {}).items():
+        # 6. declared placement values (simple dotted scalar stamping) —
+        #    the slot's own values + host-bridge suppress overrides (#3642)
+        for dotted, want in effective_values(slot).items():
             segs = dotted.split(".")
             # locate `  values:` inside the HR doc
             vidx = -1
@@ -383,7 +522,7 @@ def fix_slot(slot, data, by_hr):
                         break
                     j += 1
                 if last:
-                    new = f"{' ' * indent}{seg}: {want}  {GENERATED_MARK}"
+                    new = f"{' ' * indent}{seg}: {yaml_scalar(want)}  {GENERATED_MARK}"
                     if found >= 0:
                         lines[found] = new
                     else:
@@ -463,6 +602,28 @@ def fix_dependents(data, by_hr):
                 f.write("\n".join(lines) + "\n")
 
 
+def fix_hostbridge(data):
+    """Transcribe each vCluster slot's host-bridge route/secret/CNPG docs
+    into the slot file (markers inclusive), at the END of the file —
+    after the workload HR — and strip any stale block from a slot that no
+    longer declares one (or reverted to host) (#3642). Idempotent."""
+    for slot in data["slots"]:
+        fpath = os.path.join(KIT, slot["file"])
+        with open(fpath) as f:
+            lines = f.read().splitlines()
+        lines = strip_hostbridge(lines)
+        vc = slot.get("vcluster", "host")
+        block = hostbridge_block(slot) if vc != "host" else None
+        if block is not None:
+            # one blank line of separation before the block.
+            while lines and lines[-1].strip() == "":
+                lines.pop()
+            lines.append("")
+            lines.extend(block)
+        with open(fpath, "w") as f:
+            f.write("\n".join(lines) + "\n")
+
+
 def main():
     if len(sys.argv) != 2 or sys.argv[1] not in ("check", "fix"):
         print(__doc__)
@@ -476,6 +637,7 @@ def main():
         if not fix_slot(slot, data, by_hr):
             ok = False
     fix_dependents(data, by_hr)
+    fix_hostbridge(data)  # #3642 host-bridge route/secret/CNPG transcription
     if not ok:
         sys.exit(1)
     if not check(data, by_hr, verbose=False):

--- a/scripts/tests/render_slot_placement_hostbridge_test.py
+++ b/scripts/tests/render_slot_placement_hostbridge_test.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Render-test for the #3642 host-bridge generator logic in
+scripts/render-slot-placement.py.
+
+Pure-function unit checks (no filesystem writes) covering:
+  * effective_values merges hostBridge.suppress over the slot's values
+  * hostbridge_block transcribes hostDocuments verbatim between markers
+  * extract_hostbridge round-trips that block
+  * strip_hostbridge removes the block (markers + preceding blank)
+  * booleans render lowercase (yaml_scalar)
+  * a host placement (no hostBridge) yields no block
+
+Run: python3 scripts/tests/render_slot_placement_hostbridge_test.py
+Exit 0 on pass, 1 on any failure.
+"""
+import importlib.util
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SCRIPT = os.path.join(REPO, "scripts", "render-slot-placement.py")
+
+spec = importlib.util.spec_from_file_location("rsp", SCRIPT)
+rsp = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(rsp)
+
+failures = []
+
+
+def check(name, cond):
+    if cond:
+        print(f"  ok  {name}")
+    else:
+        failures.append(name)
+        print(f"  FAIL {name}")
+
+
+# ── fixtures ────────────────────────────────────────────────────────
+ROUTE = {
+    "apiVersion": "gateway.networking.k8s.io/v1",
+    "kind": "HTTPRoute",
+    "metadata": {"name": "grafana", "namespace": "grafana"},
+    "spec": {
+        "parentRefs": [{"name": "cilium-gateway", "namespace": "kube-system"}],
+        "hostnames": ["grafana.${SOVEREIGN_FQDN}"],
+        "rules": [{"backendRefs": [
+            {"name": "grafana-x-grafana-x-mgmt-vcluster", "namespace": "mgmt", "port": 80}]}],
+    },
+}
+SLOT = {
+    "file": "25-grafana.yaml", "hr": "bp-grafana", "vcluster": "mgmt",
+    "namespace": "grafana",
+    "values": {"sso.sovereignFqdn": "${SOVEREIGN_FQDN}"},
+    "hostBridge": {
+        "suppress": {"gateway.enabled": False, "sso.enabled": False},
+        "hostDocuments": [ROUTE],
+    },
+}
+HOST_SLOT = {"file": "16-cnpg.yaml", "hr": "bp-cnpg", "vcluster": "host",
+             "namespace": "cnpg-system"}
+
+
+# 1. effective_values = slot.values + suppress (suppress wins).
+ev = rsp.effective_values(SLOT)
+check("effective_values merges suppress + slot values",
+      ev == {"sso.sovereignFqdn": "${SOVEREIGN_FQDN}",
+             "gateway.enabled": False, "sso.enabled": False})
+
+# 2. suppress overrides a colliding slot value.
+collide = dict(SLOT)
+collide["values"] = {"gateway.enabled": True}
+check("suppress wins on key collision",
+      rsp.effective_values(collide)["gateway.enabled"] is False)
+
+# 3. hostbridge_block wraps in markers + transcribes the route.
+block = rsp.hostbridge_block(SLOT)
+check("block starts/ends with markers",
+      block[0] == rsp.HOSTBRIDGE_BEGIN and block[-1] == rsp.HOSTBRIDGE_END)
+check("block carries the syncer-mangled backendRef verbatim",
+      any("grafana-x-grafana-x-mgmt-vcluster" in l for l in block))
+check("block carries the public hostname (envsubst placeholder intact)",
+      any("grafana.${SOVEREIGN_FQDN}" in l for l in block))
+
+# 4. extract round-trips the same block (markers inclusive).
+got = rsp.extract_hostbridge(["  preamble"] + block + ["  trailer"])
+check("extract_hostbridge round-trips the block", got == block)
+
+# 5. strip removes the block + its preceding blank line.
+with_block = ["a: 1", "", *block, ]
+stripped = rsp.strip_hostbridge(with_block)
+check("strip_hostbridge removes markers + preceding blank",
+      stripped == ["a: 1"] and rsp.extract_hostbridge(stripped) is None)
+
+# 6. a host placement (no hostBridge) yields no block.
+check("host placement yields no host-bridge block",
+      rsp.hostbridge_block(HOST_SLOT) is None)
+
+# 7. booleans render lowercase.
+check("yaml_scalar(False) == 'false'", rsp.yaml_scalar(False) == "false")
+check("yaml_scalar(True) == 'true'", rsp.yaml_scalar(True) == "true")
+check("yaml_scalar passthrough for strings", rsp.yaml_scalar("mgmt") == "mgmt")
+
+if failures:
+    print(f"\nFAILED ({len(failures)}): {failures}", file=sys.stderr)
+    sys.exit(1)
+print("\nhost-bridge generator render-test PASSED")


### PR DESCRIPTION
**Refs #3642 #3373 #3423** (Refs, NOT Closes — the founder reviews against §9 + walks the UAT on a fresh prov.)

## What this lands

The **OSS-native HOST-BRIDGE** (plan path **(B)** from `docs/sessions/2026-06-14/3373-migration-plan.md §0`) — the generic mechanism that moves a route/secret/CNPG app **INTO a vCluster without a loft.sh license** (so the Pillar-5 cutover **600s deny-egress hold** still passes — no `admin.loft.sh` tether). The app's HTTPRoute + ExternalSecret (+ CNPG `Cluster`) stay **host-rendered**; only the workload re-homes into the vCluster.

This PR builds the complete generic mechanism and **moves keycloak (09) + grafana (25)** end-to-end — the route/secret class proven across both shapes (route-only with a redirect filter; route + ExternalSecret). The remaining 5 are host-bridge-READY follow-on rows (same one-field flip + `hostBridge:` declaration).

## Mechanism (§5 — placement is DATA, zero per-app code)

`scripts/render-slot-placement.py` gains a `hostBridge:` concern driven entirely by `placement.yaml` data:
- **`suppress:`** — chart values stamped into the in-vCluster workload HR that turn the chart's OWN in-vCluster route/secret **off** (`gateway.enabled: false`, `sso.enabled: false`) so the host-side copies are authoritative (no double-render).
- **`hostDocuments:`** — the HTTPRoute + ExternalSecret transcribed **verbatim** into the slot between `HOST-BRIDGE BEGIN…END` markers, in the **`mgmt`** host ns (same ns as the backend → **no ReferenceGrant**; attaches to `kube-system/cilium-gateway` via `allowedRoutes.from=All`), `backendRef` pre-aliased to the OSS-synced syncer-mangled Service `<svc>-x-<innerNs>-x-mgmt-vcluster` (proven by loki/nats).
- generator is now **idempotent** (only rewrites a `dependsOn` ns line when it actually changes — was churning correct lines); booleans render lowercase.
- `scripts/tests/render_slot_placement_hostbridge_test.py` (11 checks) + a CI step in `test-bootstrap-kit.yaml` guard the generic logic.

## Moved (the proven set)

| App (slot) | Class | After |
|---|---|---|
| `bp-keycloak` (09) | route-only (bare-URL admin redirect, **no ES**, bundled PG in-vCluster) | `keycloak-0-x-keycloak-x-mgmt-vcluster`; route → `keycloak-x-keycloak-x-mgmt-vcluster` |
| `bp-grafana` (25) | route + SSO ExternalSecret (shared-pg-b consumer) | `grafana-*-x-grafana-x-mgmt-vcluster`; route → `grafana-x-grafana-x-mgmt-vcluster` |

The placement flip **cascades correctly**: every dependent's `bp-keycloak` edge re-points `flux-system → mgmt` (gitea/powerdns-admin/catalyst-platform/sso-bridge/oidc-gate/guacamole/newapi) — the generator maintaining the #3191 explicit-ns invariant automatically. `bp-mgmt-vcluster` bumped `0.2.10 → 0.2.11` with the §5c carve-outs (`gateway-system`/`kube-system` for the host Gateway → mangled backendRef; `catalyst-system`/`newapi`/`sso-bridge`/`oidc-gate` for keycloak SSO consumers).

## Lockstep gates (all green locally)

- `render-slot-placement.py check` → **0** (11 in vClusters, gap 17→15)
- `render_slot_placement_hostbridge_test.py` → PASSED (11)
- `audit-placement-conformance.py rendered` → PASSED
- `check-bootstrap-deps.sh` → **Drift 0, Cycles 0**
- `check-bootstrap-kit-pin-sync.sh` → PASS (chart=pin=0.2.11)
- `kubectl kustomize clusters/_template/bootstrap-kit` → OK

## DoD mapping

- **DoD-1** ✅ placement.yaml declares `vcluster: mgmt` for keycloak + grafana; `check` exits 0, zero hand-edits.
- **DoD-2/3** → founder-walk on a fresh prov (UAT PART B): treemap mgmt block contains both; live pods carry the `-x-mgmt-vcluster` suffix; `audit-placement-conformance.py live` exits 0.
- **DoD-4** → UAT PART C: `auth.`/`grafana.` still serve via the host-bridged route.
- **DoD-5** → UAT PART D: CRD registration is the init-manifests deployer (no loft.sh); cutoverComplete + 600s deny-egress.
- **DoD-6** ✅ generality: `git diff` of the 2 slots shows every placement-owned change is generator-stamped from the flip + the shared host-bridge template; zero per-app code (the generator render-test enforces it).
- **DoD-7** the walkthrough `docs/ledger/uat-walkthrough/ns1-migrate-7-host-apps-into-mgmt-vcluster.md` is filled (run on the CURRENT live env, re-stamp the env id).

## Scoped remainder (honest status — NOT placeholders)

The §4 RESOLUTION block in `placement.yaml` enumerates the follow-on rows, each a one-field flip + `hostBridge:` declaration:
- **route+secret:** openbao (08, adds a 2-backend bare-URL landing route), powerdns-admin (11a), openova-flow-server (56).
- **route+secret+CNPG:** gitea (10), harbor (19), newapi (80), guacamole (52), catalyst-platform (13, LAST) — additionally host-render their CNPG `Cluster` CR (§5d) + wire the in-vCluster Pod to the host PostgreSQL cross-cluster.
- **grafana SSO Secret reach:** the host ESO materialises `grafana-sso-oidc-credentials` host-side; the host→vCluster Secret sync (so grafana zero-click SSO lands) is the one named follow-up on the route+secret class (the route itself serves regardless).

Sequence per §8: land on a converged env, then re-walk SSO (#3374) + region-kill (#3375) which exercise the moved keycloak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
