### PR TITLE
fix(bp-sso-bridge): 3646 reconciler-marker chart-test SIGPIPE — unblocks 0.2.20 publish gate

### DIFF
--- a/platform/sso-bridge/chart/tests/3646-reconciler-marker.sh
+++ b/platform/sso-bridge/chart/tests/3646-reconciler-marker.sh
@@ -12,20 +12,26 @@ RENDER="$(helm template sso-bridge "$CHART_DIR" --set enabled=true)"
 
 fail() { echo "[3646-reconciler-marker] FAIL: $1" >&2; exit 1; }
 
+# Use here-strings (<<<), NOT `echo "$RENDER" | grep -q`. Under `set -o pipefail`,
+# grep -q exits on the first match and closes the pipe, SIGPIPE-ing echo on a
+# large (>64KB / 1439-line) render → spurious "echo: write error: Broken pipe"
+# whose occurrence depends on the match position in helm's output ordering
+# (flaked the CI publish gate for bp-sso-bridge:0.2.20 while passing locally).
+
 # 1. The reconciler Deployment renders.
-echo "$RENDER" | grep -q "name: sso-bridge-reconciler" \
+grep -q "name: sso-bridge-reconciler" <<<"$RENDER" \
   || fail "sso-bridge-reconciler Deployment did not render"
 
 # 2. The metadata.labels carry the §5a marker (value "true").
-echo "$RENDER" | grep -q 'catalyst.openova.io/reconciler: "true"' \
+grep -q 'catalyst.openova.io/reconciler: "true"' <<<"$RENDER" \
   || fail "marker label catalyst.openova.io/reconciler not present"
 
 # 3. The marker is on the Deployment metadata (top-level labels block),
 #    not only the pod template — the §5a reader lists Deployments and
-#    reads metadata.labels. Assert the marker appears within ~12 lines
-#    after the Deployment kind line.
-DEPLOY_BLOCK="$(echo "$RENDER" | awk '/^kind: Deployment$/{c=1} c{print} c&&/^spec:/{c=0}')"
-echo "$DEPLOY_BLOCK" | grep -q 'catalyst.openova.io/reconciler: "true"' \
+#    reads metadata.labels. Assert the marker appears within the
+#    Deployment kind block.
+DEPLOY_BLOCK="$(awk '/^kind: Deployment$/{c=1} c{print} c&&/^spec:/{c=0}' <<<"$RENDER")"
+grep -q 'catalyst.openova.io/reconciler: "true"' <<<"$DEPLOY_BLOCK" \
   || fail "marker label not on the Deployment metadata block"
 
 echo "[3646-reconciler-marker] PASS"


### PR DESCRIPTION
## Problem
`bp-sso-bridge:0.2.20` (the #3646 reconciler-marker + #3374 dead-grant car merged in #3701/#3697) failed to publish twice — the Blueprint Release `chart/tests/*.sh` gate died at `3646-reconciler-marker.sh` with `echo: write error: Broken pipe` → spurious "Deployment did not render". The chart renders correctly (1439-line render; passes locally 3/3); the **test** was fragile.

## Root cause
`echo "$RENDER" | grep -q X` under `set -o pipefail`: `grep -q` exits on first match → closes the pipe → SIGPIPEs `echo` on the >64KB render. Whether it breaks depends on the match position in helm's output ordering — flakes CI, passes locally.

## Fix
Here-strings (`grep -q X <<<"$RENDER"`) — no pipe, no SIGPIPE. Test-only; the published 0.2.20 chart is byte-identical. Verified 3/3 with the exact CI invocation.

Refs #3646