### PR TITLE
feat(topology-dr): per-app Continuum CR producer + stateless CRD enum + install active-passive (Refs #3375)

### DIFF
--- a/core/controllers/application/deploy/rbac.yaml
+++ b/core/controllers/application/deploy/rbac.yaml
@@ -71,6 +71,15 @@ rules:
     resources: ["blueprints"]
     verbs: ["get", "list", "watch"]
 
+  # #3375 DoD-3 — the per-app Continuum DR contract the controller mints
+  # for every DR-capable Application (one dr-<app> CR per app, so
+  # `kubectl get continuums.dr.openova.io -A` shows a per-app roster). The
+  # producer upserts on reconcile + cascade-deletes on Application delete /
+  # topology-downgrade, so it needs the full write verb set on this CR.
+  - apiGroups: ["dr.openova.io"]
+    resources: ["continuums"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
   # Events for audit trail on every reconcile error / status flip.
   - apiGroups: [""]
     resources: ["events"]

--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -758,6 +758,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 	bpTopo := parseBlueprintTopology(bp)
 	var perClusterFanout []*unstructured.Unstructured
 	var perClusterStatus []map[string]interface{}
+	// #3375 DoD-3 — capture the resolved topology choice + variant so the
+	// per-app Continuum CR producer (reconcileContinuumCR, continuum.go)
+	// can mint the DR contract AFTER placement.Resolve runs below. nil
+	// variant / unset choice = no Blueprint topology, no DR CR.
+	var resolvedTopoChoice bpv1alpha1.BcpTopology
+	var resolvedTopoVariant *bpv1alpha1.TopologyVariant
+	var continuumOwnerLabels map[string]string
 	if bpTopo != nil {
 		appTopo := spec.Topology
 		sovRegions := len(envSpec.Regions)
@@ -779,6 +786,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 			"choice", choice,
 			"sovereignRegions", sovRegions,
 			"clusters", placementClusters(variant))
+
+		// #3375 DoD-3 — remember the resolved topology so the per-app
+		// Continuum CR producer (after placement.Resolve below) can mint
+		// the DR contract. The variant captured here is the Blueprint-
+		// derived one (pre instance-narrowing); the producer only reads
+		// its switchover/replication blocks, which the instance narrowing
+		// never touches.
+		resolvedTopoChoice = choice
+		resolvedTopoVariant = variant
 
 		// FanoutHRs is a pure renderer — we collect the per-cluster HR
 		// shape into status.perCluster[] so catalyst-api (G117.2-G117.4)
@@ -911,6 +927,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 				}
 			}
 
+			// #3375 DoD-3 — same owner labels on the per-app Continuum CR.
+			continuumOwnerLabels = fanoutOwnerLabels(envSpec, app)
+
 			hrs, ferr := topo.FanoutHRs(topo.FanoutInputs{
 				AppName:             app.GetName(),
 				AppNamespace:        app.GetNamespace(),
@@ -929,11 +948,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 				KubeConfigSecretKey: "config",
 				DependsOnFor:        fanoutDependsOnFor,
 				IntervalSeconds:     r.Cfg.HelmReleaseIntervalSeconds,
-				OwnerLabels: map[string]string{
-					"catalyst.openova.io/organization": envSpec.OrganizationRef,
-					"catalyst.openova.io/env-type":     envSpec.EnvType,
-					"catalyst.openova.io/app-uid":      string(app.GetUID()),
-				},
+				OwnerLabels:         fanoutOwnerLabels(envSpec, app),
 			})
 			if ferr != nil {
 				// Render-error path — surface as Degraded so the
@@ -992,6 +1007,29 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 	plan, err := placement.Resolve(spec.Placement, spec.Regions)
 	if err != nil {
 		return r.markFailed(ctx, app, ReasonInvalid, err.Error())
+	}
+
+	// 7.5 (#3375 DoD-3) — mint the per-app Continuum DR contract.
+	//
+	// Now that BOTH the topology variant (captured above from the fan-out
+	// resolver) AND the placement plan (primary + standby regions) are
+	// resolved, produce one Continuum.dr.openova.io/v1 CR per DR-capable
+	// Application so `kubectl get continuums.dr.openova.io -A` shows a
+	// per-app row (dr-grafana, dr-sso-bridge) and the continuum-controller
+	// (slot 62) has a real DR contract for EVERY DR app — not just the
+	// cnpg-pair (which mints its own CR from its chart). A singleton /
+	// active-active / single-region app, or a Blueprint variant with no
+	// switchover mechanism, produces NO CR (the buildContinuumPlan gate);
+	// a topology downgrade removes any stale CR. A produce error is
+	// surfaced as Degraded so the reconcile retries — a missing DR
+	// contract must not silently pass.
+	if continuumOwnerLabels == nil {
+		continuumOwnerLabels = fanoutOwnerLabels(envSpec, app)
+	}
+	if cerr := r.reconcileContinuumCR(ctx, app.GetName(), app.GetNamespace(),
+		resolvedTopoChoice, resolvedTopoVariant, plan, continuumOwnerLabels); cerr != nil {
+		return r.markDegraded(ctx, app, ReasonRenderError,
+			fmt.Sprintf("per-app Continuum DR contract: %v", cerr))
 	}
 
 	// 8. Ensure the per-Application Gitea repo exists.
@@ -1699,6 +1737,13 @@ func (r *Reconciler) handleDeletion(ctx context.Context, app *unstructured.Unstr
 		}
 	}
 
+	// #3375 DoD-3 — cascade-delete the per-app Continuum DR contract (the
+	// dr-<app> CR the fan-out minted). NotFound is a no-op, so a non-DR
+	// app (which never had one) deletes cleanly.
+	if err := r.deleteContinuumCRIfExists(ctx, app.GetName(), app.GetNamespace()); err != nil {
+		return fmt.Errorf("delete per-app Continuum CR: %w", err)
+	}
+
 	return r.removeFinalizer(ctx, app)
 }
 
@@ -2374,6 +2419,19 @@ func blueprintChart(bp *unstructured.Unstructured) string {
 	}
 	c, _, _ := unstructured.NestedString(bp.Object, "spec", "manifests", "chart")
 	return c
+}
+
+// fanoutOwnerLabels builds the org / env-type / app-uid label set the
+// reconciler stamps on every per-cluster HelmRelease AND (#3375 DoD-3)
+// the per-app Continuum CR, so both participate in the same
+// observability rollup + cascade-delete. Extracted into a helper so the
+// fan-out and the Continuum producer cannot drift apart.
+func fanoutOwnerLabels(envSpec envParsedSpec, app *unstructured.Unstructured) map[string]string {
+	return map[string]string{
+		"catalyst.openova.io/organization": envSpec.OrganizationRef,
+		"catalyst.openova.io/env-type":     envSpec.EnvType,
+		"catalyst.openova.io/app-uid":      string(app.GetUID()),
+	}
 }
 
 // placementClusters returns the variant's PlacementSpec.Clusters slice

--- a/core/controllers/application/internal/controller/application_controller_test.go
+++ b/core/controllers/application/internal/controller/application_controller_test.go
@@ -189,6 +189,8 @@ func newScheme() *runtime.Scheme {
 		// qa-loop iter-11 Fix #45 Cluster-B — observation of downstream
 		// HelmRelease readiness for Application.status.phase rollup.
 		{Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmRelease"},
+		// #3375 DoD-3 — the per-app Continuum DR contract the fan-out mints.
+		{Group: ContinuumGroup, Version: ContinuumVersion, Kind: ContinuumKind},
 	} {
 		s.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
 		listGVK := schema.GroupVersionKind{Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind + "List"}
@@ -207,6 +209,8 @@ func listKindMap() map[schema.GroupVersionResource]string {
 		FluxGitRepositoryGVR: "GitRepositoryList",
 		FluxKustomizationGVR: "KustomizationList",
 		FluxHelmReleaseGVR:   "HelmReleaseList",
+		// #3375 DoD-3 — per-app Continuum DR contract.
+		ContinuumGVR: "ContinuumList",
 	}
 }
 

--- a/core/controllers/application/internal/controller/continuum.go
+++ b/core/controllers/application/internal/controller/continuum.go
@@ -1,0 +1,357 @@
+// continuum.go — #3375 DoD-3: per-app Continuum CR producer.
+//
+// The #3698 spine landed the engine (generic `stateless` Promoter,
+// `canonicalizeTopology`, the standby-region integrity gate, the
+// `replicas:0` standby overlay on passive HRs) but EXPLICITLY DEFERRED
+// the producer: the thing that mints one `Continuum.dr.openova.io/v1`
+// CR per DR-capable Application so `kubectl get continuums.dr.openova.io
+// -A` shows a per-app row (dr-grafana, dr-sso-bridge, …) and the
+// continuum-controller (bootstrap-kit slot 62) has a real DR contract
+// to reconcile for EVERY DR app — not just the cnpg-pair (which mints
+// its own CR from platform/cnpg-pair/chart/templates/continuum.yaml).
+//
+// Before this, ONLY a bp-cnpg-pair install produced a Continuum CR (via
+// its own chart template). A stateless DR app (bp-sso-bridge, bp-livekit,
+// …) declared `switchover.mechanism` in its Blueprint topology but no CR
+// was ever created, so the continuum-controller had nothing to drive and
+// the DNS-flip-only switchover the #3698 stateless Promoter implements
+// could never fire. This producer closes that gap GENERICALLY — zero
+// app-name literal, keyed entirely off the resolved topology variant.
+//
+// Where it runs: in the topology fan-out persist block of Reconcile
+// (application_controller.go), right after the per-cluster HelmReleases
+// are upserted. It is additive — a singleton / single-region app, or a
+// Blueprint whose variant declares no switchover mechanism, produces NO
+// Continuum CR (the bool gate below returns nil).
+//
+// Lifecycle: upserted idempotently via upsertHostResource (byte-equal
+// short-circuit, same as the HRs) and cascade-deleted in handleDeletion.
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	topo "github.com/openova-io/openova/core/controllers/application/internal/render"
+	"github.com/openova-io/openova/core/controllers/internal/placement"
+	bpv1alpha1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+)
+
+// Continuum CR pin — mirrors the continuum-controller's constants
+// (core/controllers/continuum/internal/controller/continuum_controller.go)
+// + the CRD at products/catalyst/chart/crds/continuum.yaml. Kept local so
+// the application-controller does not import the continuum-controller
+// package (they are separate binaries).
+const (
+	ContinuumGroup    = "dr.openova.io"
+	ContinuumVersion  = "v1"
+	ContinuumKind     = "Continuum"
+	ContinuumResource = "continuums"
+)
+
+// ContinuumGVR — the dynamic-client resource the producer upserts.
+var ContinuumGVR = schema.GroupVersionResource{
+	Group:    ContinuumGroup,
+	Version:  ContinuumVersion,
+	Resource: ContinuumResource,
+}
+
+// ContinuumNamePrefix — every per-app Continuum CR is named
+// `dr-<app>` so an operator's `kubectl get continuums.dr.openova.io -A`
+// reads as a per-app DR roster (dr-grafana, dr-sso-bridge). The cnpg-pair
+// chart's own CR uses the `<fullname>-continuum` suffix convention, so
+// the two never collide.
+const ContinuumNamePrefix = "dr-"
+
+// DefaultContinuumLeaseKind is the witness backend stamped on a produced
+// Continuum CR when the Blueprint variant does not name one. `dns-quorum`
+// is the canonical air-gappable witness (no Cloudflare dependency) and is
+// one of the two values the CRD's leaseClient.kind enum accepts
+// (`[cloudflare-kv, dns-quorum]` — `in-memory` is test-only and NOT a
+// valid CRD value). Per Inviolable Principle #4 the controller could be
+// taught to read this from env later; the default keeps a fresh prov's
+// DR contract self-contained.
+const DefaultContinuumLeaseKind = "dns-quorum"
+
+// continuumPlan is the minimal, resolved input the producer needs. It is
+// computed by the reconciler from the SAME placement.Plan + topology
+// variant the fan-out already resolved — no second resolution pass.
+type continuumPlan struct {
+	// AppRef is `<namespace>/<name>` of the governed Application
+	// (Continuum.spec.applicationRef — the continuum-controller keys its
+	// per-CR goroutine off this).
+	AppRef string
+
+	// PrimaryRegion is the canonical 4-segment region name currently
+	// active (placement.Plan.PrimaryRegion). Must satisfy the CRD region
+	// pattern `^[a-z][a-z0-9]*(-[a-z0-9]+){3,}$`.
+	PrimaryRegion string
+
+	// StandbyRegions are the passive regions in priority order
+	// (placement.Plan standby rows). Index 0 is the preferred failover
+	// target.
+	StandbyRegions []string
+
+	// Mechanism is the resolved switchover mechanism the
+	// continuum-controller dispatches through (cnpg-pair | raft-transition
+	// | stateless). Derived from the Blueprint variant's
+	// switchover.mechanism + replication.backend — see
+	// resolveSwitchoverMechanism.
+	Mechanism string
+
+	// RTOSeconds / RPOSeconds — recovery objectives surfaced from the
+	// Blueprint variant's switchover block. 0 = omit (CRD defaults apply).
+	RTOSeconds int
+	RPOSeconds int
+
+	// OwnerLabels — org / env-type / app-uid, mirrored from the fan-out
+	// so the CR participates in the same observability rollup + cascade.
+	OwnerLabels map[string]string
+}
+
+// buildContinuumPlan derives the per-app Continuum contract from the
+// resolved topology variant + placement plan. Returns (plan, true) only
+// when the app is a DR-capable MULTI-region topology that declares a
+// switchover mechanism; otherwise (zero, false) — the caller then skips
+// CR production entirely.
+//
+// The DR-capable gate is intentionally strict + generic (zero app-name
+// literal):
+//
+//   - the resolved topology must be active-hot-standby OR active-passive
+//     (active-active is multi-master — no primary/standby flip to drive;
+//     singleton is single-cluster — nothing to fail over);
+//   - the placement plan must carry at least one standby region (a
+//     hot-standby topology that resolved to a single region on this
+//     Sovereign is NOT a DR contract — the #3698 standby-region integrity
+//     gate already fails such a deployment, and we must not mint a CR
+//     whose hotStandbyRegions[] would be empty, violating the CRD's
+//     required field);
+//   - the variant must declare a switchover mechanism (the Blueprint
+//     author opting the app into orchestrated failover).
+func buildContinuumPlan(
+	appRef string,
+	choice bpv1alpha1.BcpTopology,
+	variant *bpv1alpha1.TopologyVariant,
+	plan placement.Plan,
+	ownerLabels map[string]string,
+) (continuumPlan, bool) {
+	if variant == nil {
+		return continuumPlan{}, false
+	}
+	// Only the two single-primary DR topologies have a switchover to drive.
+	if choice != bpv1alpha1.BcpActiveHotStandby && choice != bpv1alpha1.BcpActivePassive {
+		return continuumPlan{}, false
+	}
+	// The Blueprint variant must opt the app into orchestrated failover.
+	if variant.Switchover == nil || variant.Switchover.Mechanism == "" {
+		return continuumPlan{}, false
+	}
+
+	primary := plan.PrimaryRegion
+	standbys := standbyRegions(plan)
+	// A DR contract needs both a primary AND ≥1 standby region. If the
+	// hot-standby topology collapsed to one region on this Sovereign,
+	// there is no second region to fail over to — skip (the #3698
+	// integrity gate flags the deployment; we simply do not mint an
+	// invalid CR with empty hotStandbyRegions[]).
+	if primary == "" || len(standbys) == 0 {
+		return continuumPlan{}, false
+	}
+
+	cp := continuumPlan{
+		AppRef:         appRef,
+		PrimaryRegion:  primary,
+		StandbyRegions: standbys,
+		Mechanism:      resolveSwitchoverMechanism(variant),
+		OwnerLabels:    ownerLabels,
+	}
+	if variant.Switchover.RtoSeconds != nil {
+		cp.RTOSeconds = *variant.Switchover.RtoSeconds
+	}
+	if variant.Switchover.RpoSeconds != nil {
+		cp.RPOSeconds = *variant.Switchover.RpoSeconds
+	}
+	return cp, true
+}
+
+// standbyRegions returns the passive region names from the placement
+// plan in plan order (priority order). A region is a standby when its
+// Role is not the primary/active role (Standby flag OR Role==standby).
+func standbyRegions(plan placement.Plan) []string {
+	out := make([]string, 0, len(plan.Regions))
+	for _, rp := range plan.Regions {
+		if rp.Name == plan.PrimaryRegion {
+			continue
+		}
+		if rp.Standby || rp.Role == placement.RoleStandby {
+			out = append(out, rp.Name)
+		}
+	}
+	return out
+}
+
+// resolveSwitchoverMechanism maps the Blueprint variant's declared
+// switchover mechanism + replication backend onto the canonical
+// continuum-controller mechanism enum (cnpg-pair | raft-transition |
+// stateless). This is the SAME three-way the switchover sequencer
+// dispatches through (core/controllers/continuum/internal/switchover/
+// promoter.go Mechanism), resolved here so the produced CR carries the
+// concrete mechanism rather than the Blueprint-authoring alias
+// `bp-continuum`.
+//
+// Resolution (zero app-name literal — keyed only off the topology
+// declaration):
+//
+//   - an explicit concrete mechanism (cnpg-pair | raft-transition |
+//     stateless) on the variant passes through verbatim;
+//   - the Blueprint-authoring alias `bp-continuum` (the convention in
+//     docs/topology-matrix.md for "continuum drives it") resolves by the
+//     replication backend: a cnpg-pair backend → cnpg-pair; a raft
+//     backend → raft-transition; ANY OTHER backend, or no replication
+//     block at all (the DNS-flip-only stateless app) → stateless;
+//   - anything else (manual, bp-velero-restore — rows continuum does NOT
+//     execute) falls through to stateless so the produced CR is at least
+//     a valid, no-op-promotable contract rather than an unrecognised
+//     mechanism the controller would reject.
+func resolveSwitchoverMechanism(variant *bpv1alpha1.TopologyVariant) string {
+	const (
+		mechCNPGPair  = "cnpg-pair"
+		mechRaft      = "raft-transition"
+		mechStateless = "stateless"
+	)
+	if variant == nil || variant.Switchover == nil {
+		return mechStateless
+	}
+	switch variant.Switchover.Mechanism {
+	case mechCNPGPair, mechRaft, mechStateless:
+		return variant.Switchover.Mechanism
+	}
+	// Alias / unknown — resolve by replication backend.
+	if variant.Replication != nil {
+		switch variant.Replication.Backend {
+		case "cnpg-pair":
+			return mechCNPGPair
+		case "raft", "openbao-raft", "raft-transition":
+			return mechRaft
+		}
+	}
+	// No cross-region state store (or an unrecognised backend) — the
+	// generic DNS-flip-only stateless contract the #3698 Promoter drives.
+	return mechStateless
+}
+
+// renderContinuumCR builds the Continuum CR Unstructured from a resolved
+// continuumPlan. Pure function — no client calls. The shape mirrors the
+// CRD's required set (applicationRef, primaryRegion, hotStandbyRegions,
+// leaseClient) + the optional switchover.mechanism the continuum-
+// controller reads (parseSpec, spec.go). Status is NEVER seeded — the
+// running continuum-controller owns status per ADR-0001 §2.7.
+func renderContinuumCR(appName, namespace string, cp continuumPlan) *unstructured.Unstructured {
+	cr := &unstructured.Unstructured{}
+	cr.SetAPIVersion(ContinuumGroup + "/" + ContinuumVersion)
+	cr.SetKind(ContinuumKind)
+	cr.SetName(ContinuumNameFor(appName))
+	cr.SetNamespace(namespace)
+
+	labels := map[string]string{}
+	for k, v := range cp.OwnerLabels {
+		labels[k] = v
+	}
+	// Back-pointer to the owning Application (cascade-delete + rollup),
+	// mirroring the fan-out HR's LabelApp contract.
+	labels[topo.LabelApp] = appName
+	// Scope marker — the cnpg-pair chart stamps openova.io/scope:platform
+	// on its CR; per-app DR CRs are application-scope so an operator can
+	// tell the two producers apart.
+	labels["openova.io/scope"] = "application"
+	cr.SetLabels(labels)
+
+	hotStandby := make([]interface{}, 0, len(cp.StandbyRegions))
+	for _, s := range cp.StandbyRegions {
+		hotStandby = append(hotStandby, s)
+	}
+
+	spec := map[string]interface{}{
+		"applicationRef":    cp.AppRef,
+		"primaryRegion":     cp.PrimaryRegion,
+		"hotStandbyRegions": hotStandby,
+		"leaseClient": map[string]interface{}{
+			"kind": DefaultContinuumLeaseKind,
+		},
+	}
+	if cp.Mechanism != "" {
+		spec["switchover"] = map[string]interface{}{
+			"mechanism": cp.Mechanism,
+		}
+	}
+	if cp.RTOSeconds > 0 {
+		spec["rto"] = fmt.Sprintf("%ds", cp.RTOSeconds)
+	}
+	if cp.RPOSeconds > 0 {
+		spec["rpo"] = fmt.Sprintf("%ds", cp.RPOSeconds)
+	}
+	cr.Object["spec"] = spec
+	return cr
+}
+
+// ContinuumNameFor composes the per-app Continuum CR name (`dr-<app>`).
+// Exported so handleDeletion + tests reference the same convention.
+func ContinuumNameFor(app string) string {
+	return ContinuumNamePrefix + app
+}
+
+// reconcileContinuumCR upserts the per-app Continuum CR for a DR-capable
+// Application, idempotently. Called from the fan-out persist block once
+// the per-cluster HelmReleases are written. Returns nil (no-op) when the
+// app is not a DR contract (buildContinuumPlan gate). Errors are surfaced
+// to the caller, which downgrades the Application to Degraded so the
+// reconcile retries — a missing DR contract must not silently pass.
+func (r *Reconciler) reconcileContinuumCR(
+	ctx context.Context,
+	appName, namespace string,
+	choice bpv1alpha1.BcpTopology,
+	variant *bpv1alpha1.TopologyVariant,
+	plan placement.Plan,
+	ownerLabels map[string]string,
+) error {
+	appRef := namespace + "/" + appName
+	cp, ok := buildContinuumPlan(appRef, choice, variant, plan, ownerLabels)
+	if !ok {
+		// Not a DR contract (singleton / active-active / single-region /
+		// no switchover mechanism). If a stale CR exists from a PRIOR
+		// topology (operator downgraded active-hot-standby → singleton),
+		// remove it so the roster reflects reality.
+		return r.deleteContinuumCRIfExists(ctx, appName, namespace)
+	}
+	cr := renderContinuumCR(appName, namespace, cp)
+	if err := r.upsertHostResource(ctx, ContinuumGVR, namespace, cr.GetName(), cr); err != nil {
+		return fmt.Errorf("upsert Continuum CR %s/%s: %w", namespace, cr.GetName(), err)
+	}
+	r.Log.Info("upserted per-app Continuum CR",
+		"namespace", namespace, "name", cr.GetName(),
+		"app", appName, "topology", string(choice),
+		"mechanism", cp.Mechanism,
+		"primaryRegion", cp.PrimaryRegion,
+		"hotStandbyRegions", cp.StandbyRegions,
+	)
+	return nil
+}
+
+// deleteContinuumCRIfExists removes the per-app Continuum CR if present.
+// Used both on a topology downgrade (DR → non-DR) and on Application
+// deletion (handleDeletion). NotFound is not an error.
+func (r *Reconciler) deleteContinuumCRIfExists(ctx context.Context, appName, namespace string) error {
+	name := ContinuumNameFor(appName)
+	err := r.Dynamic.Resource(ContinuumGVR).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete Continuum CR %s/%s: %w", namespace, name, err)
+	}
+	return nil
+}

--- a/core/controllers/application/internal/controller/continuum_test.go
+++ b/core/controllers/application/internal/controller/continuum_test.go
@@ -1,0 +1,456 @@
+// continuum_test.go — #3375 DoD-3 coverage for the per-app Continuum CR
+// producer (continuum.go).
+//
+// Two layers:
+//
+//  1. Pure-unit: resolveSwitchoverMechanism + buildContinuumPlan +
+//     renderContinuumCR — the gate (DR-capable vs not) and the
+//     mechanism-resolution table (bp-continuum alias → stateless /
+//     cnpg-pair / raft-transition), zero K8s.
+//
+//  2. Integration: drive a full Reconcile against a Blueprint whose
+//     active-hot-standby variant declares a switchover mechanism and
+//     assert the controller upserted a `dr-<app>` Continuum CR with the
+//     correct spec — AND that a singleton Blueprint mints NO CR.
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/openova-io/openova/core/controllers/internal/placement"
+	bpv1alpha1 "github.com/openova-io/openova/core/controllers/pkg/apis/blueprint/v1alpha1"
+)
+
+func intPtr(i int) *int { return &i }
+
+// ── Pure units ───────────────────────────────────────────────────────
+
+func TestResolveSwitchoverMechanism(t *testing.T) {
+	cases := []struct {
+		name    string
+		variant *bpv1alpha1.TopologyVariant
+		want    string
+	}{
+		{
+			name:    "nil variant → stateless",
+			variant: nil,
+			want:    "stateless",
+		},
+		{
+			name:    "no switchover block → stateless",
+			variant: &bpv1alpha1.TopologyVariant{},
+			want:    "stateless",
+		},
+		{
+			name: "explicit cnpg-pair passes through",
+			variant: &bpv1alpha1.TopologyVariant{
+				Switchover: &bpv1alpha1.SwitchoverSpec{Mechanism: "cnpg-pair"},
+			},
+			want: "cnpg-pair",
+		},
+		{
+			name: "explicit raft-transition passes through",
+			variant: &bpv1alpha1.TopologyVariant{
+				Switchover: &bpv1alpha1.SwitchoverSpec{Mechanism: "raft-transition"},
+			},
+			want: "raft-transition",
+		},
+		{
+			name: "explicit stateless passes through",
+			variant: &bpv1alpha1.TopologyVariant{
+				Switchover: &bpv1alpha1.SwitchoverSpec{Mechanism: "stateless"},
+			},
+			want: "stateless",
+		},
+		{
+			name: "bp-continuum alias + cnpg-pair backend → cnpg-pair",
+			variant: &bpv1alpha1.TopologyVariant{
+				Switchover:  &bpv1alpha1.SwitchoverSpec{Mechanism: "bp-continuum"},
+				Replication: &bpv1alpha1.ReplicationSpec{Backend: "cnpg-pair"},
+			},
+			want: "cnpg-pair",
+		},
+		{
+			name: "bp-continuum alias + raft backend → raft-transition",
+			variant: &bpv1alpha1.TopologyVariant{
+				Switchover:  &bpv1alpha1.SwitchoverSpec{Mechanism: "bp-continuum"},
+				Replication: &bpv1alpha1.ReplicationSpec{Backend: "raft"},
+			},
+			want: "raft-transition",
+		},
+		{
+			name: "bp-continuum alias + NO replication → stateless (the DNS-flip-only app)",
+			variant: &bpv1alpha1.TopologyVariant{
+				Switchover: &bpv1alpha1.SwitchoverSpec{Mechanism: "bp-continuum"},
+			},
+			want: "stateless",
+		},
+		{
+			name: "bp-continuum alias + unrecognised backend → stateless",
+			variant: &bpv1alpha1.TopologyVariant{
+				Switchover:  &bpv1alpha1.SwitchoverSpec{Mechanism: "bp-continuum"},
+				Replication: &bpv1alpha1.ReplicationSpec{Backend: "mirrormaker2"},
+			},
+			want: "stateless",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveSwitchoverMechanism(tc.variant); got != tc.want {
+				t.Fatalf("resolveSwitchoverMechanism = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildContinuumPlan_Gate(t *testing.T) {
+	twoRegionPlan := placement.Plan{
+		Mode:          "active-hotstandby",
+		PrimaryRegion: "hetzner-fsn-rtz-prod",
+		Regions: []placement.RegionPlan{
+			{Name: "hetzner-fsn-rtz-prod", Role: placement.RolePrimary},
+			{Name: "hetzner-nbg-rtz-prod", Role: placement.RoleStandby, Standby: true},
+		},
+	}
+	hotStandbyVariant := &bpv1alpha1.TopologyVariant{
+		Switchover: &bpv1alpha1.SwitchoverSpec{Mechanism: "bp-continuum", RtoSeconds: intPtr(30), RpoSeconds: intPtr(0)},
+	}
+
+	t.Run("active-hot-standby with standby → produces", func(t *testing.T) {
+		cp, ok := buildContinuumPlan("acme/obs", bpv1alpha1.BcpActiveHotStandby, hotStandbyVariant, twoRegionPlan, nil)
+		if !ok {
+			t.Fatal("expected a DR contract, got skip")
+		}
+		if cp.PrimaryRegion != "hetzner-fsn-rtz-prod" {
+			t.Errorf("primaryRegion = %q", cp.PrimaryRegion)
+		}
+		if len(cp.StandbyRegions) != 1 || cp.StandbyRegions[0] != "hetzner-nbg-rtz-prod" {
+			t.Errorf("standbyRegions = %v, want [hetzner-nbg-rtz-prod]", cp.StandbyRegions)
+		}
+		if cp.Mechanism != "stateless" {
+			t.Errorf("mechanism = %q, want stateless (bp-continuum alias, no replication)", cp.Mechanism)
+		}
+		if cp.RTOSeconds != 30 {
+			t.Errorf("rtoSeconds = %d, want 30", cp.RTOSeconds)
+		}
+	})
+
+	t.Run("active-passive with standby → produces", func(t *testing.T) {
+		_, ok := buildContinuumPlan("acme/obs", bpv1alpha1.BcpActivePassive, hotStandbyVariant, twoRegionPlan, nil)
+		if !ok {
+			t.Fatal("active-passive should produce a DR contract")
+		}
+	})
+
+	t.Run("singleton → skip", func(t *testing.T) {
+		if _, ok := buildContinuumPlan("acme/obs", bpv1alpha1.BcpSingleton, hotStandbyVariant, twoRegionPlan, nil); ok {
+			t.Error("singleton must NOT produce a DR contract")
+		}
+	})
+
+	t.Run("active-active → skip", func(t *testing.T) {
+		if _, ok := buildContinuumPlan("acme/obs", bpv1alpha1.BcpActiveActive, hotStandbyVariant, twoRegionPlan, nil); ok {
+			t.Error("active-active must NOT produce a DR contract (no primary/standby flip)")
+		}
+	})
+
+	t.Run("no switchover mechanism → skip", func(t *testing.T) {
+		v := &bpv1alpha1.TopologyVariant{Placement: &bpv1alpha1.PlacementSpec{}}
+		if _, ok := buildContinuumPlan("acme/obs", bpv1alpha1.BcpActiveHotStandby, v, twoRegionPlan, nil); ok {
+			t.Error("a variant with no switchover mechanism must NOT produce a DR contract")
+		}
+	})
+
+	t.Run("single-region (no standby) → skip", func(t *testing.T) {
+		singleRegionPlan := placement.Plan{
+			Mode:          "active-hotstandby",
+			PrimaryRegion: "hetzner-fsn-rtz-prod",
+			Regions: []placement.RegionPlan{
+				{Name: "hetzner-fsn-rtz-prod", Role: placement.RolePrimary},
+			},
+		}
+		if _, ok := buildContinuumPlan("acme/obs", bpv1alpha1.BcpActiveHotStandby, hotStandbyVariant, singleRegionPlan, nil); ok {
+			t.Error("a hot-standby topology that collapsed to one region must NOT mint a CR with empty hotStandbyRegions[]")
+		}
+	})
+}
+
+func TestRenderContinuumCR_Shape(t *testing.T) {
+	cp := continuumPlan{
+		AppRef:         "acme/obs",
+		PrimaryRegion:  "hetzner-fsn-rtz-prod",
+		StandbyRegions: []string{"hetzner-nbg-rtz-prod"},
+		Mechanism:      "stateless",
+		RTOSeconds:     30,
+		OwnerLabels:    map[string]string{"catalyst.openova.io/organization": "acme"},
+	}
+	cr := renderContinuumCR("obs", "acme", cp)
+
+	if cr.GetName() != "dr-obs" {
+		t.Errorf("name = %q, want dr-obs", cr.GetName())
+	}
+	if cr.GetAPIVersion() != "dr.openova.io/v1" || cr.GetKind() != "Continuum" {
+		t.Errorf("GVK = %s/%s", cr.GetAPIVersion(), cr.GetKind())
+	}
+	appRef, _, _ := unstructured.NestedString(cr.Object, "spec", "applicationRef")
+	if appRef != "acme/obs" {
+		t.Errorf("applicationRef = %q", appRef)
+	}
+	primary, _, _ := unstructured.NestedString(cr.Object, "spec", "primaryRegion")
+	if primary != "hetzner-fsn-rtz-prod" {
+		t.Errorf("primaryRegion = %q", primary)
+	}
+	standby, _, _ := unstructured.NestedStringSlice(cr.Object, "spec", "hotStandbyRegions")
+	if len(standby) != 1 || standby[0] != "hetzner-nbg-rtz-prod" {
+		t.Errorf("hotStandbyRegions = %v", standby)
+	}
+	leaseKind, _, _ := unstructured.NestedString(cr.Object, "spec", "leaseClient", "kind")
+	if leaseKind != DefaultContinuumLeaseKind {
+		t.Errorf("leaseClient.kind = %q, want %q", leaseKind, DefaultContinuumLeaseKind)
+	}
+	mech, _, _ := unstructured.NestedString(cr.Object, "spec", "switchover", "mechanism")
+	if mech != "stateless" {
+		t.Errorf("switchover.mechanism = %q", mech)
+	}
+	rto, _, _ := unstructured.NestedString(cr.Object, "spec", "rto")
+	if rto != "30s" {
+		t.Errorf("rto = %q, want 30s", rto)
+	}
+	if cr.GetLabels()[topoLabelApp()] != "obs" {
+		t.Errorf("app label = %q, want obs", cr.GetLabels()[topoLabelApp()])
+	}
+}
+
+// topoLabelApp returns the canonical app-label key so the test reads the
+// same constant the producer stamps without importing the render package
+// just for the literal.
+func topoLabelApp() string { return "catalyst.openova.io/app" }
+
+// ── Integration ──────────────────────────────────────────────────────
+
+// makeBlueprintDRTopology returns a Blueprint whose active-hot-standby
+// variant declares BOTH a placement (2 clusters) AND a switchover
+// mechanism — the shape that opts an app into the per-app Continuum DR
+// contract (#3375 DoD-3). The `bp-continuum` alias + no replication block
+// resolves to the generic `stateless` mechanism.
+func makeBlueprintDRTopology(name, version, tier string, clusters []string) *unstructured.Unstructured {
+	clustersAny := make([]interface{}, len(clusters))
+	for i, c := range clusters {
+		clustersAny[i] = c
+	}
+	roles := map[string]interface{}{}
+	for i, c := range clusters {
+		if i == 0 {
+			roles[c] = "active"
+		} else {
+			roles[c] = "passive"
+		}
+	}
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("catalyst.openova.io/v1")
+	u.SetKind("Blueprint")
+	u.SetName(name)
+	u.SetGeneration(1)
+	u.Object["spec"] = map[string]interface{}{
+		"version": version,
+		"card":    map[string]interface{}{"title": name},
+		"placementSchema": map[string]interface{}{
+			"modes": []interface{}{"active-hotstandby", "single-region"},
+		},
+		"manifests": map[string]interface{}{
+			"chart": name,
+			"source": map[string]interface{}{
+				"kind": "HelmRepository",
+				"ref":  "openova-catalog",
+			},
+		},
+		"topology": map[string]interface{}{
+			"supported": []interface{}{"active-hot-standby", "singleton"},
+			"defaults": map[string]interface{}{
+				"multi-region":  "active-hot-standby",
+				"single-region": "singleton",
+			},
+			"perTopology": map[string]interface{}{
+				"active-hot-standby": map[string]interface{}{
+					"placement": map[string]interface{}{
+						"tier":     tier,
+						"clusters": clustersAny,
+						"roles":    roles,
+					},
+					"switchover": map[string]interface{}{
+						"mechanism":  "bp-continuum",
+						"rtoSeconds": int64(30),
+						"rpoSeconds": int64(0),
+					},
+				},
+				"singleton": map[string]interface{}{
+					"placement": map[string]interface{}{
+						"tier":     tier,
+						"clusters": []interface{}{clusters[0]},
+						"roles":    map[string]interface{}{clusters[0]: "singleton"},
+					},
+				},
+			},
+		},
+	}
+	u.Object["status"] = map[string]interface{}{"ociDigest": "sha256:dr-fixture"}
+	return u
+}
+
+// TestReconcile_PerAppContinuumCR_Produced — the central #3375 DoD-3
+// acceptance: a DR-capable Application produces a `dr-<app>` Continuum CR
+// with the resolved primary/standby regions + the stateless mechanism.
+func TestReconcile_PerAppContinuumCR_Produced(t *testing.T) {
+	bp := makeBlueprintDRTopology("bp-sso-bridge", "1.0.0", "mgmt", []string{"mgmt-A", "mgmt-B"})
+	env := makeMultiRegionEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeApp("acme", "sso-bridge", "acme-prod", "bp-sso-bridge", "1.0.0",
+		"active-hotstandby",
+		[]string{"hetzner-fsn-rtz-prod", "hetzner-nbg-rtz-prod"},
+		nil,
+	)
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp)
+
+	reconcileFromCluster(t, r, "acme", "sso-bridge")
+
+	got := readApp(t, r, "acme", "sso-bridge")
+	if phase, reason, msg := readPhaseAndReason(t, got); phase == PhaseFailed {
+		t.Fatalf("unexpected Failed phase: reason=%q msg=%q", reason, msg)
+	}
+
+	cr, err := r.Dynamic.Resource(ContinuumGVR).Namespace("acme").
+		Get(context.Background(), "dr-sso-bridge", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected per-app Continuum CR dr-sso-bridge in ns acme: %v", err)
+	}
+
+	appRef, _, _ := unstructured.NestedString(cr.Object, "spec", "applicationRef")
+	if appRef != "acme/sso-bridge" {
+		t.Errorf("applicationRef = %q, want acme/sso-bridge", appRef)
+	}
+	primary, _, _ := unstructured.NestedString(cr.Object, "spec", "primaryRegion")
+	if primary != "hetzner-fsn-rtz-prod" {
+		t.Errorf("primaryRegion = %q, want hetzner-fsn-rtz-prod", primary)
+	}
+	standby, _, _ := unstructured.NestedStringSlice(cr.Object, "spec", "hotStandbyRegions")
+	if len(standby) != 1 || standby[0] != "hetzner-nbg-rtz-prod" {
+		t.Errorf("hotStandbyRegions = %v, want [hetzner-nbg-rtz-prod]", standby)
+	}
+	mech, _, _ := unstructured.NestedString(cr.Object, "spec", "switchover", "mechanism")
+	if mech != "stateless" {
+		t.Errorf("switchover.mechanism = %q, want stateless", mech)
+	}
+	if cr.GetLabels()["catalyst.openova.io/app"] != "sso-bridge" {
+		t.Errorf("app label = %q", cr.GetLabels()["catalyst.openova.io/app"])
+	}
+}
+
+// TestReconcile_PerAppContinuumCR_Idempotent — re-reconcile must not
+// mutate the produced CR (upsertHostResource byte-equal short-circuit).
+func TestReconcile_PerAppContinuumCR_Idempotent(t *testing.T) {
+	bp := makeBlueprintDRTopology("bp-sso-bridge", "1.0.0", "mgmt", []string{"mgmt-A", "mgmt-B"})
+	env := makeMultiRegionEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeApp("acme", "sso-bridge", "acme-prod", "bp-sso-bridge", "1.0.0",
+		"active-hotstandby",
+		[]string{"hetzner-fsn-rtz-prod", "hetzner-nbg-rtz-prod"},
+		nil,
+	)
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp)
+
+	reconcileFromCluster(t, r, "acme", "sso-bridge")
+	first, err := r.Dynamic.Resource(ContinuumGVR).Namespace("acme").
+		Get(context.Background(), "dr-sso-bridge", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("first get: %v", err)
+	}
+	firstSpec, _, _ := unstructured.NestedMap(first.Object, "spec")
+
+	reconcileFromCluster(t, r, "acme", "sso-bridge")
+	second, err := r.Dynamic.Resource(ContinuumGVR).Namespace("acme").
+		Get(context.Background(), "dr-sso-bridge", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("second get: %v", err)
+	}
+	secondSpec, _, _ := unstructured.NestedMap(second.Object, "spec")
+	if !specsEqual(firstSpec, secondSpec) {
+		t.Error("Continuum CR spec diverged on re-reconcile (should be byte-equal no-op)")
+	}
+}
+
+// TestReconcile_SingletonApp_NoContinuumCR — a single-region / singleton
+// app must NOT mint a Continuum CR (the buildContinuumPlan gate).
+func TestReconcile_SingletonApp_NoContinuumCR(t *testing.T) {
+	bp := makeBlueprintDRTopology("bp-sso-bridge", "1.0.0", "mgmt", []string{"mgmt-A", "mgmt-B"})
+	// Single-region environment → resolves to the singleton default.
+	env := makeEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeApp("acme", "sso-bridge", "acme-prod", "bp-sso-bridge", "1.0.0",
+		"single-region",
+		[]string{"hetzner-fsn-rtz-prod"},
+		nil,
+	)
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp)
+
+	reconcileFromCluster(t, r, "acme", "sso-bridge")
+
+	_, err := r.Dynamic.Resource(ContinuumGVR).Namespace("acme").
+		Get(context.Background(), "dr-sso-bridge", metav1.GetOptions{})
+	if err == nil {
+		t.Fatal("singleton app must NOT produce a Continuum CR, but dr-sso-bridge exists")
+	}
+}
+
+// TestReconcile_TopologyDowngrade_RemovesContinuumCR — when an app that
+// HAD a DR contract is downgraded to a non-DR topology, the stale CR is
+// removed so the roster reflects reality.
+func TestReconcile_TopologyDowngrade_RemovesContinuumCR(t *testing.T) {
+	bp := makeBlueprintDRTopology("bp-sso-bridge", "1.0.0", "mgmt", []string{"mgmt-A", "mgmt-B"})
+	env := makeMultiRegionEnv("acme-prod", "acme", "prod")
+	org := makeOrg("acme")
+	app := makeApp("acme", "sso-bridge", "acme-prod", "bp-sso-bridge", "1.0.0",
+		"active-hotstandby",
+		[]string{"hetzner-fsn-rtz-prod", "hetzner-nbg-rtz-prod"},
+		nil,
+	)
+	fg := newFakeGitea()
+	fg.orgsExist["acme"] = true
+	r := newReconciler(t, fg, app, env, org, bp)
+
+	// First reconcile mints the CR.
+	reconcileFromCluster(t, r, "acme", "sso-bridge")
+	if _, err := r.Dynamic.Resource(ContinuumGVR).Namespace("acme").
+		Get(context.Background(), "dr-sso-bridge", metav1.GetOptions{}); err != nil {
+		t.Fatalf("expected CR after first reconcile: %v", err)
+	}
+
+	// Downgrade the Application's topology to single-region and re-reconcile.
+	// A real single-region downgrade collapses BOTH the placement mode AND
+	// the regions[] to one entry (placement.Resolve rejects single-region
+	// with >1 region), so the fixture mirrors that.
+	cur := readApp(t, r, "acme", "sso-bridge")
+	_ = unstructured.SetNestedField(cur.Object, "single-region", "spec", "placement")
+	_ = unstructured.SetNestedField(cur.Object, "singleton", "spec", "topology")
+	_ = unstructured.SetNestedStringSlice(cur.Object, []string{"hetzner-fsn-rtz-prod"}, "spec", "regions")
+	if _, err := r.Dynamic.Resource(ApplicationGVR).Namespace("acme").
+		Update(context.Background(), cur, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update app to downgrade: %v", err)
+	}
+	reconcileFromCluster(t, r, "acme", "sso-bridge")
+
+	if _, err := r.Dynamic.Resource(ContinuumGVR).Namespace("acme").
+		Get(context.Background(), "dr-sso-bridge", metav1.GetOptions{}); err == nil {
+		t.Fatal("stale Continuum CR must be removed after topology downgrade to singleton")
+	}
+}

--- a/docs/ledger/uat-walkthrough/topology-dr-one-vocabulary-built-and-region-kill-proven.md
+++ b/docs/ledger/uat-walkthrough/topology-dr-one-vocabulary-built-and-region-kill-proven.md
@@ -47,22 +47,45 @@ products/catalyst/bootstrap/ui  $ npx vitest run src/lib/useFleet.test.ts \
 | `kubectl get hr -A -l catalyst.openova.io/app=<hot-standby-app>` | Diff the active vs passive HR `spec.values` | The **mgmt-B (passive)** HR carries `replicas: 0` + `_openova_standby: true`; the mgmt-A (active) HR does not | ☐ |
 | Provision active-hot-standby with the standby region capped | Read the deployment record + Sovereign Settings | Record is **`failed`**, reason `standby-region-absent`; **no** green active-hot-standby badge | ☐ |
 
-## Remaining for the live walk (NOT in this spine — follow-on)
+## Increment 2 — the per-app Continuum CR producer (DoD-3) is now BUILT
 
-These are the issue's larger items that need a fresh 2-region prov and/or the
-per-app Continuum producer; they are explicitly **not** claimed by this PR:
+> Follow-on PR `feat: #3375 per-app Continuum producer + install active-passive`.
+> This closes the **DoD-3 producer** the spine enumerated as "the next
+> increment". It does NOT claim the live region-kill (DoD-9) or the
+> cross-region chart wiring (DoD-8).
 
-- **DoD-3 / DoD-4** — the application-controller (or a slot) minting **one
-  `Continuum` CR per DR-capable Application** + the journey building the
-  per-app 2-region cnpg-pair (the backing-service generator emitting a
-  replica Cluster + externalClusters WAL). The spine makes the engine
-  *able* to drive these (stateless promoter + the `replicas:0` model + the
-  enforcement that rejects decorative backends); the producer itself is the
-  next increment.
+| # | DoD box | Delivered in this increment | Evidence |
+|---|---|---|---|
+| 3 | The journey mints **one `Continuum` CR per DR-capable Application** | The application-controller now produces a `Continuum.dr.openova.io/v1` CR (`dr-<app>`) for every DR-capable Application — keyed entirely off the resolved topology variant (active-hot-standby / active-passive + a declared `switchover.mechanism` + ≥1 standby region), **zero app-name literal**. Wired into the topology fan-out persist block; idempotent upsert + cascade-delete (on Application delete AND topology downgrade). So `kubectl get continuums.dr.openova.io -A` shows a per-app roster (`dr-grafana`, `dr-sso-bridge`) — not just the cnpg-pair's own CR. | `continuum.go`; `continuum_test.go` (`TestReconcile_PerAppContinuumCR_*`, `TestResolveSwitchoverMechanism`, `TestBuildContinuumPlan_Gate`, `-race` green) |
+| 3 | The CRD accepts the generic `stateless` mechanism | The #3698 spine added `stateless` to the Go `Mechanism` set but the **CRD enum** still rejected it — so a stateless DR app's produced CR would be denied by the API server. The enum `switchover.mechanism: [cnpg-pair, raft-transition, stateless]` now matches the engine. | `products/catalyst/chart/crds/continuum.yaml`; helm lint + CRD YAML parse green |
+| 1 | One vocabulary at the **install** picker too | The install-flow placement `<select>` now offers the canonical 4th class **`active-passive`** (it previously hardcoded only 3, so a blueprint that supports active-passive could be selected on the editor but never at install). | `InstallPage.tsx`; `InstallPage.placement.test.tsx` (2/2 green) |
+
+## Walkable on a fresh 2-region prov after increment 2 rolls (the producer)
+
+> Every row is one action. Run after a fresh 2-region prov picks up the rolled catalyst-api image.
+
+| Go to / run | Then do | You should see | Result |
+|---|---|---|---|
+| Install a DR blueprint (e.g. bp-sso-bridge) at **active-hotstandby** on a 2-region prov | `kubectl get continuums.dr.openova.io -A` | A **`dr-sso-bridge`** row in the app's namespace (NOT only the cnpg-pair's `<pair>-continuum`) | ☐ |
+| `kubectl get continuum dr-sso-bridge -o yaml` | Read `.spec` | `applicationRef: <ns>/sso-bridge`, `primaryRegion` = the active region, `hotStandbyRegions: [<standby region>]`, `leaseClient.kind: dns-quorum`, `switchover.mechanism: stateless` | ☐ |
+| `/install/bp-grafana` → placement-mode dropdown | Open the dropdown | **Four** options incl. **`active-passive`** | ☐ |
+| Delete the Application (`kubectl delete application sso-bridge`) | `kubectl get continuum dr-sso-bridge` | **NotFound** — the producer cascade-deleted the DR contract | ☐ |
+
+## Remaining for the live walk (NOT in this increment — follow-on)
+
+These are the issue's larger items that need a fresh 2-region prov; they are
+explicitly **not** claimed by this PR:
+
+- **DoD-4** — the journey building the per-app 2-region **cnpg-pair** itself
+  (the backing-service generator emitting a replica Cluster + externalClusters
+  WAL). The producer mints the Continuum *contract*; the data-plane pair for a
+  stateful DR app is the next increment. (A stateless DR app needs no pair —
+  its `dr-<app>` CR is already complete + drivable by the #3698 stateless
+  promoter.)
 - **DoD-6** — the `TopologyTab.tsx` live-DR gate (render the DR section +
   Switchover only when the API reports a live backing; bind live
-  replication lag). Meaningful only once DoD-3 produces per-app Continuum
-  CRs to read.
+  replication lag). Now UNBLOCKED — DoD-3 produces per-app Continuum CRs to
+  read; the tab-binding is a focused UI follow-on.
 - **DoD-8** — the cross-region chart wiring (`<instance>-mesh-rw`, the
   openbao S3 cred mirror, the guacd emptyDir fallback). Chart work,
   walked on a 2-region env.

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.placement.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.placement.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * InstallPage.placement.test.tsx — #3375 §3(d) lock-in.
+ *
+ * The install-flow placement picker must offer the SAME canonical 4-class
+ * set the post-create TopologyEditor offers (single-region / active-active
+ * / active-hotstandby / active-passive). It previously hardcoded only the
+ * first three, so a Blueprint that supports `active-passive` could be
+ * selected on the editor but never AT INSTALL. This test asserts all four
+ * options render + are selectable.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+
+// Mock the deployment-id resolver + catalog hooks so the page renders the
+// form scaffold (which carries the placement <select>) without a router
+// or network.
+vi.mock('@/shared/lib/useResolvedDeploymentId', () => ({
+  useResolvedDeploymentId: () => ({ deploymentId: 'dep-test' }),
+}))
+
+const grafanaCard = {
+  name: 'bp-grafana',
+  version: '1.0.6',
+  card: { title: 'Grafana', summary: 'Dashboards', description: 'Dashboards' },
+  source: 'gitea',
+}
+
+vi.mock('@/lib/useCatalog', () => ({
+  useCatalog: () => ({ data: [grafanaCard], isLoading: false, isError: false }),
+  useCatalogItemVersion: () => ({ data: { ...grafanaCard, raw: { spec: { configSchema: {} } } }, isLoading: false }),
+}))
+
+// useNavigate is only invoked on status-modal dismiss; stub it so the
+// page mounts cleanly.
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => () => Promise.resolve(undefined),
+}))
+
+// InstallForm renders the RJSF form; stub it to a no-op so the test
+// focuses on the placement scaffold the page owns.
+vi.mock('@/widgets/install/InstallForm', () => ({
+  InstallForm: () => null,
+}))
+
+import { InstallPage } from './InstallPage'
+
+describe('InstallPage placement picker (#3375 §3d)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  afterEach(() => cleanup())
+
+  it('offers all four canonical placement modes including active-passive', () => {
+    render(<InstallPage preselectedBlueprint="bp-grafana" />)
+
+    const select = screen.getByTestId('install-page-placement') as HTMLSelectElement
+    const optionValues = Array.from(select.options).map((o) => o.value)
+
+    expect(optionValues).toContain('single-region')
+    expect(optionValues).toContain('active-active')
+    expect(optionValues).toContain('active-hotstandby')
+    // The #3375 §3(d) fix — previously absent.
+    expect(optionValues).toContain('active-passive')
+  })
+
+  it('lets active-passive be selected', () => {
+    render(<InstallPage preselectedBlueprint="bp-grafana" />)
+
+    const select = screen.getByTestId('install-page-placement') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'active-passive' } })
+    expect(select.value).toBe('active-passive')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.tsx
@@ -401,6 +401,17 @@ export function InstallPage({ preselectedBlueprint }: InstallPageProps = {}) {
             </label>
             <label className="flex flex-col text-xs text-[var(--color-text-dim)]">
               Placement mode
+              {/*
+               * #3375 §3(d) — the install-flow placement picker must offer
+               * the SAME canonical class set the post-create TopologyEditor
+               * offers (ALL_MODES). It previously hardcoded only
+               * single-region / active-active / active-hotstandby, so a
+               * Blueprint that supports `active-passive` (primary serves;
+               * passive cold/warm standby) could be created on the editor
+               * but never AT INSTALL — a supported-vs-selectable
+               * contradiction. The fourth canonical class is added here so
+               * the install picker matches the backend's supported set.
+               */}
               <select
                 className="mt-1 rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-sm"
                 data-testid="install-page-placement"
@@ -410,6 +421,7 @@ export function InstallPage({ preselectedBlueprint }: InstallPageProps = {}) {
                 <option value="single-region">single-region</option>
                 <option value="active-active">active-active</option>
                 <option value="active-hotstandby">active-hotstandby</option>
+                <option value="active-passive">active-passive</option>
               </select>
             </label>
           </div>

--- a/products/catalyst/chart/crds/continuum.yaml
+++ b/products/catalyst/chart/crds/continuum.yaml
@@ -208,7 +208,7 @@ spec:
                   properties:
                     mechanism:
                       type: string
-                      enum: [cnpg-pair, raft-transition]
+                      enum: [cnpg-pair, raft-transition, stateless]
                       default: cnpg-pair
                       description: |
                         cnpg-pair (default) = bp-cnpg-pair promotion
@@ -216,7 +216,16 @@ spec:
                         Cluster CR halves). raft-transition = bp-openbao
                         promotion (`bao operator raft snapshot restore` of
                         the staged snapshot + `transition-to-primary` via
-                        Pod exec on the surviving standby; #3492).
+                        Pod exec on the surviving standby; #3492). stateless
+                        = the generic DNS-flip-only promotion for an app
+                        with NO cross-region state store (#3375 §5.1): the
+                        two state-store steps (cordon + promote) are no-ops
+                        and the five agnostic steps (lease / drain-HTTP /
+                        flip-DNS / swap-lease / audit) carry the whole
+                        switchover. This is the mechanism the
+                        application-controller stamps on the per-app
+                        Continuum CR it mints for a stateless DR blueprint
+                        (bp-sso-bridge, bp-livekit, …).
                     raftTransition:
                       type: object
                       description: |


### PR DESCRIPTION
Refs #3375 — the **DoD-3 per-app Continuum producer** the #3698 spine ([merged PR](https://github.com/openova-io/openova/pull/3698)) explicitly deferred as *"the producer itself is the next increment"*. Pure control-plane + CRD + one UI option; **no live region-kill claim** (DoD-9) and **no cross-region chart wiring** (DoD-8). Rides the next train — **do NOT merge**.

## What #3698 already landed (verified on origin/main first — NOT rebuilt)

| Deferred piece (per the brief) | Status on origin/main | Where |
|---|---|---|
| Generic `stateless` switchover Promoter | ✅ **DONE** (state-store steps no-op; 5 agnostic steps carry it; zero app-name literal) | `continuum/internal/switchover/promoter.go:153` + `sequence.go:196` |
| `replicas:0` + standby role-label on the passive HR | ✅ **DONE** (`withStandbyOverlay` overlays `replicas:0` + `_openova_standby:true`; role label stamped) | `application/internal/render/fanout.go:208,363` |
| TopologyEditor `active-passive` radio | ✅ **DONE** (`ALL_MODES` already includes it) | `widgets/topology/TopologyEditor.tsx:80` |
| `canonicalizeTopology` / one UI vocabulary | ✅ DONE | `fleet.api.ts`, `CrossSovereignView.tsx` |
| `DeclaredDRStandbyIntegrity` gate | ✅ DONE | `bootstrap/api/internal/provisioner/provisioner.go` |
| **Per-app Continuum CR producer** | ❌ **DEFERRED → this PR** | — |

So 3 of the 3 named "build" items (stateless promoter / `replicas:0` fan-out / `active-passive` editor radio) were **already complete**. The genuine remaining gap was the producer + two adjacent holes it exposed.

## What this PR adds

### 1. Per-app Continuum CR producer — DoD-3 (`core/controllers/application/internal/controller/continuum.go`, new)
The application-controller now mints **one `Continuum.dr.openova.io/v1` CR (`dr-<app>`) per DR-capable Application**, so `kubectl get continuums.dr.openova.io -A` shows a per-app roster (`dr-grafana`, `dr-sso-bridge`) — previously **only a bp-cnpg-pair install produced a CR** (via its own chart template), so a stateless DR app declared `switchover.mechanism` but no CR was ever created and the continuum-controller had nothing to drive.

- **Zero app-name literal** — the DR-capable gate (`buildContinuumPlan`) keys entirely off the resolved topology variant: active-hot-standby **or** active-passive + a declared `switchover.mechanism` + ≥1 standby region. Singleton / active-active / single-region / no-mechanism → **no CR**.
- `resolveSwitchoverMechanism` maps the Blueprint-authoring alias `bp-continuum` → the concrete engine mechanism by replication backend (`cnpg-pair` backend → cnpg-pair; `raft` → raft-transition; **no/other backend → `stateless`**, the DNS-flip-only app).
- Derives `primaryRegion` + `hotStandbyRegions[]` from the SAME `placement.Plan` the fan-out resolved (the canonical 4-segment region names that satisfy the CRD pattern) — no second resolution pass.
- Wired into the topology fan-out persist block of `Reconcile` (`application_controller.go` §7.5). **Idempotent** upsert via the existing `upsertHostResource` byte-equal short-circuit; **cascade-delete** on Application delete (`handleDeletion`) AND on a topology downgrade (DR → non-DR removes the stale CR).

### 2. CRD enum accepts `stateless` (`products/catalyst/chart/crds/continuum.yaml`)
The #3698 slice added `stateless` to the Go `Mechanism` set but the **CRD `switchover.mechanism` enum still rejected it** — so a stateless DR app's produced CR would be **denied by the API server**. Enum is now `[cnpg-pair, raft-transition, stateless]`, matching the engine + the producer.

### 3. Install picker offers `active-passive` — DoD-1 (`products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.tsx`)
The install-flow placement `<select>` hardcoded only 3 modes, so a blueprint that supports `active-passive` could be selected on the post-create TopologyEditor (which has it) but **never at install**. Added the 4th canonical class so the install picker matches the editor + backend supported set.

### 4. RBAC (`core/controllers/application/deploy/rbac.yaml`)
Added `dr.openova.io/continuums` create/get/list/watch/update/patch/delete so the producer is RBAC-complete.

## Gates (all green)
- `cd core/controllers && go build ./... && go test -race ./application/internal/controller/... ./application/internal/render/... ./continuum/internal/switchover/... ./blueprint/internal/validate/...` — **ok**
- `cd products/catalyst/bootstrap/api && go build ./... && go test ./internal/provisioner/ ./internal/handler/` — **ok** (the #3698 integrity gate package, untouched, still green)
- `cd products/catalyst/bootstrap/ui && npx tsc -b` (exit 0) + `npx vitest run` on touched specs — **23/23** (InstallPage.placement + TopologyEditor + useFleet + CrossSovereignView)
- `helm lint products/catalyst/chart` — **0 failed**; CRD YAML parses; `helm template --include-crds` renders

New tests: `continuum_test.go` (`TestResolveSwitchoverMechanism` 9-case table, `TestBuildContinuumPlan_Gate` 7-case, `TestRenderContinuumCR_Shape`, `TestReconcile_PerAppContinuumCR_Produced/_Idempotent`, `TestReconcile_SingletonApp_NoContinuumCR`, `TestReconcile_TopologyDowngrade_RemovesContinuumCR`), `InstallPage.placement.test.tsx` (2). The pre-existing UI failures (`PinInput6`, `ProvisionPage.sse-url`, `SettingsPage`, `StepComponents`, `ParentDomainsPage`, `Dashboard`, `JobsPage`, `UserAccessEditPage`, `ExecPanel`, `ResourceDetailPage` — 70 total) were **confirmed failing on a clean stash of origin/main** (identical count), unrelated to this change.

## Explicitly NOT in this PR (follow-on)
- **DoD-4** — the journey building the per-app 2-region **cnpg-pair** data plane (replica Cluster + externalClusters WAL). The producer mints the *contract*; a stateless DR app needs no pair (its `dr-<app>` CR is already complete + drivable by the #3698 stateless promoter).
- **DoD-6** — the `TopologyTab.tsx` live-DR gate — now **UNBLOCKED** (DoD-3 produces per-app CRs to read).
- **DoD-8** (cross-region chart wiring) + **DoD-9** (live region-kill within RTO/RPO) — need a converged 2-region prov.

Disjoint from the in-flight #3687 master-builder (provisioning/marketplace) — this is purely continuum-producer / render / CRD / one UI option. Walkthrough updated: `docs/ledger/uat-walkthrough/topology-dr-one-vocabulary-built-and-region-kill-proven.md` (Increment 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)