### PR TITLE
feat(catalog): Flux reconcile catalog-sovereign → live Blueprint CRs — deferred half of #3702 (Refs #3668)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1029,7 +1029,8 @@ spec:
             # 1.4.626 — #3492: Continuum CRD gains spec.switchover.{mechanism,raftTransition} (bp-openbao raft-transition DR contract); additive, slot-13 crds:CreateReplace propagates the schema. Render byte-unchanged.
             # 1.4.645 — #3626: catalog-seed repoints bp-openbao launch ssoInitPath → /sso/landing (was /ui/vault/auth?with=oidc) so the console "Open" button lands signed-in instead of the popup-only Vault OIDC callback's window.opener=null error. Lockstep with platform/openbao/blueprint.yaml; template-only, default render byte-unchanged.
             # 1.4.648 — #3638 (Refs #3379): catalyst-runtime-config ConfigMap DERIVES sovereign-console-url + sovereign-api-public-url from global.sovereignFQDN on a Sovereign (was always the mothership runtime.sovereignConsoleURL default, never overridden here) — so Flux render == bp-self-sovereign-cutover step-07 Phase-3a's patch → step-07 is idempotent (no revert → no FATAL re-run → no catalyst-api re-roll → cutover engine reaches step-08). Catalyst-Zero (empty FQDN) render byte-unchanged.
-      version: 1.4.655
+            # 1.4.656 — #3668 (Refs #3702): the deferred load-bearing half — Flux GitRepository (openova-catalog-sovereign) + Kustomization (catalog-sovereign, force:true SSA) reconcile the catalog-sovereign aggregator tree into LIVE Blueprint CRs so a console catalog edit reaches the in-cluster CR + survives helm upgrade; catalog-seed CRs gain helm.sh/resource-policy:keep (Helm→Flux ownership handoff, DoD §9.4); catalyst-api mirrors each edited/curated CR via writeCatalogSovereignAggregator. New templates/catalog-sovereign-flux/ (mirrors the SME-tenants family) + values.catalogSovereign; rendered only on a Sovereign + ingress.marketplace.enabled — Catalyst-Zero render byte-unchanged.
+      version: 1.4.656
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/handler/blueprints.go
+++ b/products/catalyst/bootstrap/api/internal/handler/blueprints.go
@@ -393,6 +393,19 @@ func (h *Handler) HandleBlueprintCurate(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// #3668 — ALSO mirror the curated CR into the Flux-reconciled aggregator
+	// tree so curate (not just the console edit) reaches the LIVE in-cluster
+	// Blueprint CR and survives `helm upgrade`. Ownership-strip first so the
+	// committed source is helm-upgrade-immune (DoD §9.4). Best-effort: a
+	// failure is logged + swallowed — the per-Blueprint write above already
+	// succeeded for the read overlay.
+	if _, aggErr := h.writeCatalogSovereignAggregator(
+		ctx, body.BlueprintName, stripBlueprintCRBytesForGit(srcBytes, body.BlueprintName),
+	); aggErr != nil {
+		h.log.Warn("blueprint curate: aggregator mirror failed (Blueprint CR will not reconcile until next write)",
+			"blueprint", body.BlueprintName, "err", aggErr)
+	}
+
 	resp := blueprintCurateResponse{
 		BlueprintName: body.BlueprintName,
 		SourceOrg:     body.SourceOrg,

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git.go
@@ -55,6 +55,96 @@ import (
 // live on. Same default branch blueprints.go's publish/curate use.
 const catalogEditGitBranch = blueprintBranch // "main"
 
+// ── #3668 catalog-sovereign Flux reconcile aggregator ──────────────────
+//
+// The merged #3702 edit (and the curate endpoint) writes each Blueprint CR
+// to a PER-BLUEPRINT repo `catalog-sovereign/<bp>/blueprint.yaml`. That is
+// the read source the UI overlay round-trips. But a Flux GitRepository
+// tracks ONE repo + branch — it cannot reconcile a whole Gitea Org of
+// per-Blueprint repos. So #3668 ALSO mirrors the SAME ownership-stripped
+// `merged` bytes into a single AGGREGATOR tree on the already-bootstrapped
+// local Gitea repo `openova/openova`, on a dedicated `catalog-sovereign`
+// branch:
+//
+//	openova/openova @ catalog-sovereign
+//	└── clusters/<sovereignFQDN>/catalog-sovereign/<bp>.yaml   (full CR)
+//
+// The chart's openova-catalog-sovereign GitRepository + catalog-sovereign
+// Kustomization (templates/catalog-sovereign-flux/) reconcile that one tree
+// into LIVE Blueprint CRs — so a console edit reaches the in-cluster CR and
+// SURVIVES `helm upgrade` (the CR becomes Flux/Git-owned, not Helm-owned;
+// see templates/catalog-seed/blueprints.yaml's helm.sh/resource-policy:keep
+// + the Kustomization's force:true SSA adoption). This is the load-bearing
+// half PR #3702 explicitly deferred.
+//
+// The aggregator repo + branch reuse the SAME local Gitea repo the SME
+// tenant gitops chain bootstraps (`openova/openova`, seeded pre-cutover by
+// the chart's repo-bootstrap hook + clonable by Flux via catalyst-gitea-
+// token basic-auth, #3454). A DEDICATED branch is immune to the cutover-
+// gitea-mirror Job's `git push --mirror --force` of `main` (same isolation
+// rationale as the SME `sme-tenants` branch, TBD-C18e).
+const (
+	// catalogSovereignAggOrg/Repo — the local Gitea repo holding the Flux-
+	// reconciled aggregator tree. Reuses the SME gitops repo coordinates so
+	// the chart's repo-bootstrap + Flux clone-auth are already wired.
+	catalogSovereignAggOrg  = "openova"
+	catalogSovereignAggRepo = "openova"
+	// catalogSovereignAggBranch — dedicated branch the chart's repo-
+	// bootstrap hook ensures + the openova-catalog-sovereign GitRepository
+	// tracks. MUST match values.catalogSovereign.{gitRepository,repoBootstrap}
+	// .branch in products/catalyst/chart/values.yaml.
+	catalogSovereignAggBranch = "catalog-sovereign"
+)
+
+// catalogSovereignAggPath returns the aggregator tree path for one
+// Blueprint, matching the Flux Kustomization's
+// `path: ./clusters/<sovereignFQDN>/catalog-sovereign`. The Kustomization
+// directory-sweeps every *.yaml beneath it into Blueprint CRs (no
+// kustomization.yaml index needed — Flux auto-generates one over the
+// directory), so a single flat PUT per Blueprint is all that is required.
+func catalogSovereignAggPath(sovereignFQDN, bpName string) string {
+	return fmt.Sprintf("clusters/%s/catalog-sovereign/%s.yaml", sovereignFQDN, bpName)
+}
+
+// writeCatalogSovereignAggregator mirrors one Blueprint's full, ownership-
+// stripped CR bytes into the Flux-reconciled aggregator tree (#3668). It is
+// best-effort + additive, exactly like the per-Blueprint write: a failure is
+// returned for the caller to log + swallow (the UI round-trip already
+// succeeded via the per-Blueprint repo; the aggregator is what makes the CR
+// reconcile, but its absence must never fail the edit/curate API call).
+//
+// No-ops (returns committed=false, err=nil) when:
+//   - the Gitea client is unwired (chroot pre-cutover / CI), OR
+//   - SOVEREIGN_FQDN is empty — i.e. the Catalyst-Zero mothership, which has
+//     no local Gitea catalog-sovereign Flux reconcile (it pushes to
+//     github.com and renders no openova-catalog-sovereign GitRepository).
+//
+// The branch is ensured by the chart's catalog-sovereign repo-bootstrap
+// hook pre-cutover; PutFile creates the file on first write. The repo
+// (openova/openova) is auto-init'd by the SME repo-bootstrap hook, so the
+// branch always has a base commit to write onto.
+func (h *Handler) writeCatalogSovereignAggregator(ctx context.Context, bpName string, merged []byte) (bool, error) {
+	if h.giteaClient == nil {
+		return false, nil // unwired — best-effort no-op (pre-cutover / CI)
+	}
+	sovereignFQDN := strings.TrimSpace(envOr("SOVEREIGN_FQDN", ""))
+	if sovereignFQDN == "" {
+		return false, nil // Catalyst-Zero mothership — no local catalog Flux
+	}
+	if strings.TrimSpace(bpName) == "" || len(merged) == 0 {
+		return false, nil
+	}
+	path := catalogSovereignAggPath(sovereignFQDN, bpName)
+	msg := fmt.Sprintf("catalog: reconcile %s into Blueprint CR via Flux (#3668)", bpName)
+	_, committed, err := h.giteaClient.PutFile(ctx, catalogSovereignAggOrg, catalogSovereignAggRepo,
+		catalogSovereignAggBranch, path, merged, msg, catalogEditCommitAuthor())
+	if err != nil {
+		return false, fmt.Errorf("put %s/%s@%s/%s: %w",
+			catalogSovereignAggOrg, catalogSovereignAggRepo, catalogSovereignAggBranch, path, err)
+	}
+	return committed, nil
+}
+
 // catalogEditCommitAuthor / Email stamp the commit so a sovereign-admin
 // scanning the catalog-sovereign repo history can tell a UI-originated
 // catalog edit from a hand-authored git push. Per Inviolable Principle #4
@@ -162,6 +252,18 @@ func (h *Handler) writeCatalogEditToGit(ctx context.Context, edit catalogEdit) (
 	if err != nil {
 		return false, fmt.Errorf("put %s/%s/%s: %w", catalogSovereignOrg, bpName, catalogEditBlueprintPath, err)
 	}
+
+	// #3668 — ALSO mirror the SAME merged CR bytes into the Flux-reconciled
+	// aggregator tree so the edit reaches the LIVE in-cluster Blueprint CR
+	// (the per-Blueprint write above is only the UI read source). Best-
+	// effort + additive: an aggregator failure is logged + swallowed so the
+	// edit API call still reports the per-Blueprint commit result (the
+	// reconcile catches up on the next successful write / out-of-band push).
+	if _, aggErr := h.writeCatalogSovereignAggregator(ctx, bpName, merged); aggErr != nil {
+		h.log.Warn("catalog-edit-git: aggregator mirror failed (Blueprint CR will not reconcile until next write)",
+			"blueprint", bpName, "err", aggErr)
+	}
+
 	return committed, nil
 }
 
@@ -240,25 +342,36 @@ func (h *Handler) seedBlueprintYAMLFromLiveCR(ctx context.Context, bpName string
 	if err != nil || bp == nil || len(bp.Raw) == 0 {
 		return nil
 	}
-	doc := deepCopyYAMLMap(bp.Raw)
+	return stripBlueprintCRMapForGit(deepCopyYAMLMap(bp.Raw), bpName)
+}
+
+// stripBlueprintCRMapForGit renders a decoded Blueprint CR map as the
+// ownership-clean YAML source committed to Gitea (the catalog-sovereign
+// per-Blueprint repo AND the Flux aggregator tree). It keeps apiVersion/
+// kind/metadata.name + the full spec, and DROPS every server-managed +
+// ownership field (status + all metadata except name — resourceVersion,
+// uid, generation, creationTimestamp, managedFields, and the Helm/Flux
+// ownership labels+annotations `app.kubernetes.io/managed-by: Helm`,
+// `helm.toolkit.fluxcd.io/*`) so a later `helm upgrade` cannot claim the
+// committed file and the Flux Kustomization can SSA-adopt the live CR
+// (DoD §9.4). Returns nil on a nil/un-marshalable map.
+func stripBlueprintCRMapForGit(doc map[string]interface{}, bpName string) []byte {
 	if doc == nil {
 		return nil
 	}
 
-	// Canonical envelope — the projector requires apiVersion/kind; the
+	// Canonical envelope — the projector requires apiVersion/kind; an
 	// in-cluster CR carries them, but a Gitea-sourced Raw might not.
 	setIfAbsent(doc, "apiVersion", "catalyst.openova.io/v1")
 	setIfAbsent(doc, "kind", "Blueprint")
 
-	// metadata: keep only name; drop server-managed + ownership fields so a
-	// helm upgrade can't claim the committed file (DoD §9.4).
+	// metadata: keep only name; drop server-managed + ownership fields.
 	if meta, ok := doc["metadata"].(map[string]interface{}); ok {
 		name := asString(meta["name"])
 		if strings.TrimSpace(name) == "" {
 			name = bpName
 		}
-		cleanMeta := map[string]interface{}{"name": name}
-		doc["metadata"] = cleanMeta
+		doc["metadata"] = map[string]interface{}{"name": name}
 	} else {
 		doc["metadata"] = map[string]interface{}{"name": bpName}
 	}
@@ -271,6 +384,24 @@ func (h *Handler) seedBlueprintYAMLFromLiveCR(ctx context.Context, bpName string
 		return nil
 	}
 	return out
+}
+
+// stripBlueprintCRBytesForGit is the bytes-in/bytes-out form used by the
+// curate path (blueprints.go), where the source `blueprint.yaml` is read
+// from `<sourceOrg>/shared-blueprints` and may carry ownership labels. It
+// decodes, applies stripBlueprintCRMapForGit, and returns the cleaned
+// bytes; on any decode failure it returns the input unchanged (best-effort
+// — a curate must never be blocked by a strip, and an org-authored source
+// usually carries no Helm ownership labels anyway).
+func stripBlueprintCRBytesForGit(raw []byte, bpName string) []byte {
+	var doc map[string]interface{}
+	if err := yamlv3.Unmarshal(raw, &doc); err != nil || doc == nil {
+		return raw
+	}
+	if out := stripBlueprintCRMapForGit(doc, bpName); len(out) > 0 {
+		return out
+	}
+	return raw
 }
 
 // deepCopyYAMLMap returns a deep copy of a JSON/YAML-decoded map so mutating

--- a/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/catalog_edit_git_test.go
@@ -492,6 +492,108 @@ func TestCommitCatalogAppEditToGit_ByteIdenticalIsDurable(t *testing.T) {
 	}
 }
 
+// TestWriteCatalogEditToGit_MirrorsToFluxAggregator — #3668: the load-bearing
+// half PR #3702 deferred. On a Sovereign (SOVEREIGN_FQDN set), a console edit
+// ALSO writes the SAME merged CR bytes into the Flux-reconciled aggregator
+// tree `openova/openova @ catalog-sovereign : clusters/<fqdn>/catalog-
+// sovereign/<bp>.yaml`, so the openova-catalog-sovereign Kustomization can
+// reconcile it into the LIVE in-cluster Blueprint CR. The per-Blueprint repo
+// write (the UI read source) is unchanged; this asserts the SECOND, Flux
+// source-of-truth write lands with byte-identical content.
+func TestWriteCatalogEditToGit_MirrorsToFluxAggregator(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+
+	edit := catalogEdit{
+		Slug:    "alloy",
+		Name:    "Alloy (Edited)",
+		Tagline: "RECONCILE-PROOF",
+	}
+	if _, err := h.writeCatalogEditToGit(context.Background(), edit); err != nil {
+		t.Fatalf("writeCatalogEditToGit: %v", err)
+	}
+
+	// The per-Blueprint repo write (UI read source) still lands.
+	perBP := giteaKey(catalogSovereignOrg, "bp-alloy", catalogEditGitBranch, catalogEditBlueprintPath)
+	perBPRaw, ok := fg.files[perBP]
+	if !ok {
+		t.Fatalf("per-Blueprint write missing at %s; keys=%v", perBP, fileKeys(fg))
+	}
+
+	// The Flux aggregator write lands on openova/openova @ catalog-sovereign.
+	aggPath := "clusters/t99.omani.works/catalog-sovereign/bp-alloy.yaml"
+	aggKey := giteaKey(catalogSovereignAggOrg, catalogSovereignAggRepo, catalogSovereignAggBranch, aggPath)
+	aggRaw, ok := fg.files[aggKey]
+	if !ok {
+		t.Fatalf("Flux aggregator write missing at %s; keys=%v", aggKey, fileKeys(fg))
+	}
+	if string(aggRaw) != string(perBPRaw) {
+		t.Errorf("aggregator bytes must equal the per-Blueprint CR bytes (same merged CR drives render+reconcile)\nagg:\n%s\nperBP:\n%s", aggRaw, perBPRaw)
+	}
+	if !strings.Contains(string(aggRaw), "RECONCILE-PROOF") {
+		t.Errorf("aggregator CR must carry the edited summary; got:\n%s", aggRaw)
+	}
+	// The aggregator path is the one the Flux Kustomization sweeps.
+	if got := catalogSovereignAggPath("t99.omani.works", "bp-alloy"); got != aggPath {
+		t.Errorf("catalogSovereignAggPath = %q, want %q", got, aggPath)
+	}
+}
+
+// TestWriteCatalogEditToGit_NoAggregatorOnMothership — #3668: the Catalyst-
+// Zero mothership (SOVEREIGN_FQDN empty) has NO local catalog-sovereign Flux
+// reconcile (it pushes to github.com), so the aggregator write must NOT fire.
+// The per-Blueprint write still lands (it is the read overlay everywhere).
+func TestWriteCatalogEditToGit_NoAggregatorOnMothership(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "")
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+
+	if _, err := h.writeCatalogEditToGit(context.Background(),
+		catalogEdit{Slug: "alloy", Name: "X", Tagline: "y"}); err != nil {
+		t.Fatalf("writeCatalogEditToGit: %v", err)
+	}
+	for k := range fg.files {
+		if strings.Contains(k, "/catalog-sovereign/bp-") && strings.HasPrefix(k, catalogSovereignAggOrg+"/"+catalogSovereignAggRepo+"/") {
+			t.Errorf("mothership must not write the Flux aggregator tree; found key %q", k)
+		}
+	}
+}
+
+// TestWriteCatalogSovereignAggregator_BestEffortGuards — the aggregator
+// mirror no-ops (committed=false, err=nil) when unwired or FQDN-less, and
+// never blocks the edit. Erroring Gitea surfaces an err for the caller to
+// log+swallow (the edit API still returns the per-Blueprint verdict).
+func TestWriteCatalogSovereignAggregator_BestEffortGuards(t *testing.T) {
+	// Unwired client → no-op.
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	if c, err := h.writeCatalogSovereignAggregator(context.Background(), "bp-alloy", []byte("x")); c || err != nil {
+		t.Errorf("unwired: want (false,nil); got (%v,%v)", c, err)
+	}
+
+	// Wired but FQDN empty → no-op.
+	t.Setenv("SOVEREIGN_FQDN", "")
+	fg := newFakeGitea()
+	h.SetGiteaClient(fg)
+	if c, err := h.writeCatalogSovereignAggregator(context.Background(), "bp-alloy", []byte("x")); c || err != nil {
+		t.Errorf("no-FQDN: want (false,nil); got (%v,%v)", c, err)
+	}
+	if len(fg.files) != 0 {
+		t.Errorf("no-FQDN must write nothing; keys=%v", fileKeys(fg))
+	}
+
+	// Wired + FQDN + erroring PutFile → err returned (caller logs+swallows).
+	t.Setenv("SOVEREIGN_FQDN", "t99.omani.works")
+	fgErr := newFakeGitea()
+	fgErr.putFileErr = errors.New("gitea: 500")
+	h.SetGiteaClient(fgErr)
+	if _, err := h.writeCatalogSovereignAggregator(context.Background(), "bp-alloy", []byte("x")); err == nil {
+		t.Errorf("erroring PutFile must return a non-nil err for the caller to log")
+	}
+}
+
 // ── tiny test helpers ────────────────────────────────────────────────
 
 func fileKeys(f *fakeGiteaClient) []string {

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2735,7 +2735,24 @@ name: bp-catalyst-platform
 # (qaFixtures.cnpgBackupEndpointURL + cnpg-clusters-qa.yaml) to the
 # syncer-mangled host Service name. qa-fixtures only; Catalyst-Zero render
 # byte-unchanged. (1.4.622 was a content-free deploy-bot image sweep.)
-version: 1.4.655
+version: 1.4.656
+# 1.4.656 — #3668 (Refs #3702): the LOAD-BEARING half PR #3702 deferred —
+# a Flux GitRepository (openova-catalog-sovereign) + Kustomization
+# (catalog-sovereign) that reconcile the catalog-sovereign aggregator tree
+# (openova/openova @ catalog-sovereign : clusters/<fqdn>/catalog-sovereign/
+# <bp>.yaml) into LIVE blueprints.catalyst.openova.io CRs. catalyst-api
+# (writeCatalogSovereignAggregator, internal/handler/catalog_edit_git.go +
+# blueprints.go curate) mirrors each edited/curated full ownership-stripped
+# CR there; the Kustomization directory-sweeps it with force:true SSA so a
+# console edit reaches the in-cluster CR and SURVIVES `helm upgrade` (the CR
+# becomes Flux-owned). catalog-seed CRs gain helm.sh/resource-policy:keep so
+# helm cannot claw back a Flux-adopted CR (the Helm→Flux ownership handoff,
+# DoD §9.4). New templates/catalog-sovereign-flux/ (GitRepository +
+# Kustomization + basic-auth Secret + pre-cutover branch/dir bootstrap hook),
+# mirroring the SME-tenants 4-file family; rendered only on a Sovereign
+# (global.sovereignFQDN) + ingress.marketplace.enabled — Catalyst-Zero render
+# byte-unchanged (the new files emit nothing without an FQDN). New
+# values.catalogSovereign block.
 # 1.4.648 — #3638 (2026-06-16, Refs #3379; rebased over main's 1.4.647 deploy-bot bump) — fix the cutover step-07 re-run
 # loop at its source. templates/configmap-catalyst-runtime-config.yaml now
 # DERIVES sovereign-console-url + sovereign-api-public-url from

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -42,6 +42,14 @@ metadata:
     catalyst.openova.io/section: pts-7-sme-tenant
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.2.0"
   visibility: listed
@@ -145,6 +153,14 @@ metadata:
     catalyst.openova.io/category: database
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -242,6 +258,14 @@ metadata:
     catalyst.openova.io/companion: bp-cnpg
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.1.1"
   visibility: listed
@@ -401,6 +425,14 @@ metadata:
     catalyst.openova.io/category: identity
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -499,6 +531,14 @@ metadata:
     catalyst.openova.io/category: observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -625,6 +665,14 @@ metadata:
     catalyst.openova.io/category: observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -685,6 +733,14 @@ metadata:
     catalyst.openova.io/category: observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -766,6 +822,14 @@ metadata:
     catalyst.openova.io/category: database
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -828,6 +892,14 @@ metadata:
     catalyst.openova.io/category: analytics
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -919,6 +991,14 @@ metadata:
     catalyst.openova.io/category: search
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -1027,6 +1107,14 @@ metadata:
     catalyst.openova.io/category: workflow
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -1115,6 +1203,14 @@ metadata:
     catalyst.openova.io/category: automation
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -1204,6 +1300,14 @@ metadata:
     catalyst.openova.io/category: ai
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -1292,6 +1396,14 @@ metadata:
     catalyst.openova.io/category: ai
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -1399,6 +1511,14 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.1"
   visibility: listed
@@ -1465,6 +1585,14 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -1539,6 +1667,14 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.2.3"
   visibility: listed
@@ -1638,6 +1774,14 @@ metadata:
     catalyst.openova.io/section: pts-4-6-ai-ml
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: unlisted
@@ -1734,6 +1878,14 @@ metadata:
     catalyst.openova.io/section: pts-3-3-security-and-policy
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -1800,6 +1952,14 @@ metadata:
     catalyst.openova.io/section: pts-4-5-communication
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -1895,6 +2055,14 @@ metadata:
     catalyst.openova.io/section: pts-4-5-communication
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.1.0"
   visibility: listed
@@ -1997,6 +2165,14 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.5"
   visibility: listed
@@ -2069,6 +2245,14 @@ metadata:
     catalyst.openova.io/section: pts-4-7-ai-safety
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -2135,6 +2319,14 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.4.63"
   visibility: listed
@@ -2235,6 +2427,14 @@ metadata:
     catalyst.openova.io/section: pts-4-7-agentic-workspace
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.2.0"
   visibility: listed
@@ -2299,6 +2499,14 @@ metadata:
     catalyst.openova.io/section: pts-4-8-identity-and-metering
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.1.0"
   visibility: listed
@@ -2401,6 +2609,14 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.2.1"
   visibility: listed
@@ -2460,6 +2676,14 @@ metadata:
     catalyst.openova.io/section: pts-3-5-storage-and-data
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.2.1"
   visibility: unlisted
@@ -2528,6 +2752,14 @@ metadata:
     catalyst.openova.io/section: pts-4-5-communication
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.1.3"
   visibility: listed
@@ -2647,6 +2879,14 @@ metadata:
     catalyst.openova.io/section: pts-4-5-communication
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: unlisted
@@ -2736,6 +2976,14 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -2808,6 +3056,14 @@ metadata:
     catalyst.openova.io/section: pts-4-1-data-services
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.1.0"
   visibility: unlisted
@@ -2905,6 +3161,14 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.2.2"
   visibility: listed
@@ -2967,6 +3231,14 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.1.0"
   visibility: listed
@@ -3037,6 +3309,14 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: listed
@@ -3124,6 +3404,14 @@ metadata:
     catalyst.openova.io/category: platform
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.2.26"
   visibility: unlisted
@@ -3225,6 +3513,14 @@ metadata:
     catalyst.openova.io/category: platform
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.2.25"
   visibility: unlisted
@@ -3353,6 +3649,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.4.539"
   visibility: unlisted
@@ -3439,6 +3743,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.2.5"
   visibility: unlisted
@@ -3490,6 +3802,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.1.0"
   visibility: unlisted
@@ -3536,6 +3856,14 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.4.0"
   visibility: unlisted
@@ -3594,6 +3922,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.3.0"
   visibility: unlisted
@@ -3640,6 +3976,14 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: unlisted
@@ -3686,6 +4030,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.1.4"
   visibility: unlisted
@@ -3732,6 +4084,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.1.5"
   visibility: unlisted
@@ -3778,6 +4138,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.1.8"
   visibility: unlisted
@@ -3824,6 +4192,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.1.1"
   visibility: unlisted
@@ -3875,6 +4251,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.6"
   visibility: unlisted
@@ -3926,6 +4310,14 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.1"
   visibility: unlisted
@@ -3977,6 +4369,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.2.6"
   visibility: unlisted
@@ -4028,6 +4428,14 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.1.0"
   visibility: unlisted
@@ -4079,6 +4487,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.2.24"
   visibility: unlisted
@@ -4167,6 +4583,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: unlisted
@@ -4213,6 +4637,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.1.14"
   visibility: unlisted
@@ -4276,6 +4708,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.3.6"
   visibility: unlisted
@@ -4327,6 +4767,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.28"
   visibility: unlisted
@@ -4378,6 +4826,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.3.3"
   visibility: unlisted
@@ -4444,6 +4900,14 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.4"
   visibility: unlisted
@@ -4490,6 +4954,14 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.2.9"
   visibility: unlisted
@@ -4555,6 +5027,14 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.1.5"
   visibility: unlisted
@@ -4629,6 +5109,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: unlisted
@@ -4680,6 +5168,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: unlisted
@@ -4731,6 +5227,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.1.2"
   visibility: unlisted
@@ -4777,6 +5281,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.1.56"
   visibility: unlisted
@@ -4827,6 +5339,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: unlisted
@@ -4882,6 +5402,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.2.15"
   visibility: unlisted
@@ -4945,6 +5473,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.0"
   visibility: unlisted
@@ -4991,6 +5527,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.3"
   visibility: unlisted
@@ -5037,6 +5581,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "1.0.1"
   visibility: unlisted
@@ -5083,6 +5635,14 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.1.4"
   visibility: unlisted
@@ -5156,6 +5716,14 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.2.3"
   visibility: unlisted
@@ -5202,6 +5770,14 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.1.1"
   visibility: unlisted
@@ -5253,6 +5829,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.2.6"
   visibility: unlisted
@@ -5299,6 +5883,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.2.5"
   visibility: unlisted
@@ -5345,6 +5937,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.2.6"
   visibility: unlisted
@@ -5391,6 +5991,14 @@ metadata:
     catalyst.openova.io/section: pts-1-control-plane
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.2.0"
   visibility: unlisted
@@ -5437,6 +6045,14 @@ metadata:
     catalyst.openova.io/section: pts-4-sandbox
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.3.10"
   visibility: unlisted
@@ -5564,6 +6180,14 @@ metadata:
     catalyst.openova.io/companion: bp-cnpg
     app.kubernetes.io/managed-by: {{ $managedBy }}
     app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
 spec:
   version: "0.1.6"
   visibility: listed

--- a/products/catalyst/chart/templates/catalog-sovereign-flux/catalog-sovereign-gitrepo-auth-secret.yaml
+++ b/products/catalyst/chart/templates/catalog-sovereign-flux/catalog-sovereign-gitrepo-auth-secret.yaml
@@ -1,0 +1,102 @@
+{{- /*
+Flux basic-auth Secret for the openova-catalog-sovereign GitRepository —
+issue #3668 (the load-bearing half of PR #3702). The byte-for-byte twin of
+templates/sme-services/sme-tenants-gitrepo-auth-secret.yaml, renamed for the
+catalog-sovereign source.
+
+WHY THIS FILE EXISTS (#3454)
+============================
+The openova-catalog-sovereign GitRepository
+(catalog-sovereign-gitrepository.yaml) clones the Sovereign-local Gitea
+`openova/openova`@`catalog-sovereign`. bp-gitea sets
+`service.REQUIRE_SIGNIN_VIEW=true` (platform/gitea/chart/values.yaml) →
+anonymous git clone returns HTTP 401 even for a PUBLIC repo (proven live on
+hw133). So source-controller CANNOT clone without credentials; the
+GitRepository reports "authentication required" forever. This Secret + the
+secretRef wiring (values.catalogSovereign.gitRepository.secretRef) supplies
+the catalyst-gitea-token PAT in the Flux basic-auth shape.
+
+CREDENTIAL SOURCE
+=================
+The `catalyst-gitea-token` Secret (key `token`) — the real Gitea PAT minted
+by this same chart's catalyst-gitea-token-secret.yaml pre-install hook. We
+re-emit it in the Flux basic-auth shape (keys `username` + `password`);
+source-controller embeds them in the clone URL. Username is the Gitea admin
+account (`gitea_admin`, matching CATALYST_GITOPS_USER in api-deployment.yaml).
+
+Lookup-and-mirror pattern (matches the SME twin + provisioning-github-token):
+read catalyst-gitea-token at render time and re-emit ONLY when the PAT is
+present + non-empty (the minter creates an empty `token` placeholder before
+its mint Job patches the real bytes — emitting an empty password is useless,
+so render nothing until the PAT exists and Flux's reconcile fills it once the
+minter completes).
+
+GATING
+======
+Rendered ONLY when BOTH .Values.global.sovereignFQDN non-empty AND
+.Values.ingress.marketplace.enabled — the same discriminator the
+openova-catalog-sovereign GitRepository uses.
+
+Per docs/PRINCIPLES.md #10: NO plaintext credentials — the PAT lives only in
+catalyst-gitea-token and is read back via lookup; the bytes never appear in
+chart source or rendered manifests on disk. Per #4 the destination/source
+Secret names + key + the Gitea admin username flow through .Values with
+sensible defaults.
+
+References:
+  - Issue #3668 (this fix), #3454 (the REQUIRE_SIGNIN_VIEW auth root cause)
+  - templates/sme-services/sme-tenants-gitrepo-auth-secret.yaml (the twin)
+  - catalog-sovereign-gitrepository.yaml (the consumer of .secretRef)
+  - templates/catalyst-gitea-token-secret.yaml (PAT source)
+*/}}
+{{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
+{{- if .Values.global.sovereignFQDN -}}
+{{- $gr := (.Values.catalogSovereign).gitRepository | default dict -}}
+{{- $sr := $gr.secretRef | default dict -}}
+{{- $secretName := $sr.name | default "openova-catalog-sovereign-git-auth" -}}
+{{- $secretNamespace := $gr.namespace | default "flux-system" -}}
+{{- $sourceNamespace := $sr.patSourceNamespace | default .Release.Namespace -}}
+{{- $sourceSecretName := $sr.patSourceSecretName | default "catalyst-gitea-token" -}}
+{{- $sourcePatKey := $sr.patSourceKey | default "token" -}}
+{{- $username := $sr.username | default "gitea_admin" -}}
+{{- $sourceSecret := lookup "v1" "Secret" $sourceNamespace $sourceSecretName -}}
+{{- $patB64 := "" -}}
+{{- if and $sourceSecret $sourceSecret.data (index $sourceSecret.data $sourcePatKey) -}}
+  {{- $candidate := index $sourceSecret.data $sourcePatKey -}}
+  {{- if not (empty ($candidate | b64dec)) -}}
+    {{- $patB64 = $candidate -}}
+  {{- end -}}
+{{- end -}}
+{{- if $patB64 -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $secretNamespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-platform
+    catalyst.openova.io/component: catalog-sovereign-git-auth
+    app.kubernetes.io/part-of: catalog
+    # source-controller (flux-system) is the consumer; flux-system is
+    # excluded from the kyverno flux-managed Enforce namespace list, but
+    # we stamp managed-by:flux for consistency with the other hook-created
+    # resources and any future policy widening.
+    app.kubernetes.io/managed-by: flux
+  annotations:
+    catalyst.openova.io/mirrored-from: {{ printf "%s/%s" $sourceNamespace $sourceSecretName | quote }}
+    # Survive helm uninstall so a re-install keeps Flux authenticated
+    # without a clone-error window.
+    helm.sh/resource-policy: keep
+type: Opaque
+stringData:
+  # Flux GitRepository basic-auth contract: source-controller reads
+  # `username` + `password` and embeds them in the HTTP(S) clone URL.
+  # The PAT (catalyst-gitea-token) authenticates as the Gitea admin — a
+  # Gitea PAT is accepted as the HTTP password for git operations
+  # (REQUIRE_SIGNIN_VIEW=true makes anonymous clone 401; this makes it 200).
+  username: {{ $username | quote }}
+data:
+  password: {{ $patB64 | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/products/catalyst/chart/templates/catalog-sovereign-flux/catalog-sovereign-gitrepository.yaml
+++ b/products/catalyst/chart/templates/catalog-sovereign-flux/catalog-sovereign-gitrepository.yaml
@@ -1,0 +1,106 @@
+{{- /*
+Flux GitRepository tracking the dedicated `catalog-sovereign` branch — the
+LOAD-BEARING half PR #3702 deferred (issue #3668).
+
+WHY THIS FILE EXISTS
+--------------------
+PR #3702 made the operator-console catalog edit (and the curate endpoint)
+COMMIT each Blueprint card to the local Gitea — but EXPLICITLY DEFERRED the
+half that makes that commit reach a LIVE in-cluster Blueprint CR. Today a
+catalog edit lands in Gitea and is read back to the UI, but
+`kubectl get blueprint bp-alloy -o jsonpath='{.spec.card.summary}'` never
+moves: nothing reconciles `catalog-sovereign/<bp>/blueprint.yaml` into the
+`blueprints.catalyst.openova.io/v1` CR. So a chart `helm upgrade` re-renders
+the catalog-seed CR over the edit (the §9.1/9.4 revert-immunity gap).
+
+This template + its sibling Kustomization
+(catalog-sovereign-kustomization.yaml) close that gap: a console edit →
+Gitea commit → Flux reconcile → LIVE Blueprint CR, surviving helm upgrade
+(the CR becomes Git/Flux-owned, see the Kustomization's force:true SSA
+adoption + templates/catalog-seed/blueprints.yaml's helm.sh/resource-policy
+:keep handoff).
+
+THE AGGREGATOR TREE (why a single repo+branch, not per-Blueprint repos)
+-----------------------------------------------------------------------
+A Flux GitRepository tracks ONE repo + branch — it cannot reconcile a whole
+Gitea Org of per-Blueprint repos (which is how #3702 writes:
+`catalog-sovereign/<bp>` is one repo each). So catalyst-api ALSO mirrors the
+same ownership-stripped CR bytes into a single AGGREGATOR tree on the
+already-bootstrapped local Gitea repo `openova/openova`, on a dedicated
+`catalog-sovereign` branch (writeCatalogSovereignAggregator in
+internal/handler/catalog_edit_git.go):
+
+  openova/openova @ catalog-sovereign
+  └── clusters/<sovereignFQDN>/catalog-sovereign/<bp>.yaml   (full CR)
+
+This GitRepository tracks that one tree.
+
+WHY THIS REPO + A DEDICATED BRANCH
+----------------------------------
+We REUSE the same local Gitea repo the SME-tenant gitops chain already
+bootstraps + Flux already clones (`openova/openova`, seeded pre-cutover by
+the SME repo-bootstrap hook, clonable via the catalyst-gitea-token basic-
+auth Secret — #3454). A DEDICATED `catalog-sovereign` branch is immune to
+the cutover-gitea-mirror Job's `git push --mirror --force` of `main` (the
+exact TBD-C18e clobber rationale the openova-sme-tenants GitRepository
+documents). The chart's catalog-sovereign repo-bootstrap hook
+(catalog-sovereign-repo-bootstrap-job.yaml) ensures the branch + an empty
+parent directory pre-cutover so this source is Ready from first convergence
+with zero curated Blueprints.
+
+AUTH (#3454)
+------------
+bp-gitea sets `service.REQUIRE_SIGNIN_VIEW=true` → anonymous git clone
+returns 401 even for PUBLIC repos. So this GitRepository carries a secretRef
+to a Flux basic-auth Secret holding the catalyst-gitea-token PAT (rendered
+by catalog-sovereign-gitrepo-auth-secret.yaml, the byte-for-byte twin of the
+SME auth Secret). Without it the source sits "authentication required".
+
+GATING
+------
+Rendered ONLY when BOTH:
+  - .Values.global.sovereignFQDN non-empty (a Sovereign — the Catalyst-Zero
+    mothership pushes to github.com and has no local catalog Flux reconcile;
+    catalyst-api's writeCatalogSovereignAggregator no-ops there too).
+  - .Values.ingress.marketplace.enabled (same discriminator the SME bundle +
+    the rest of the per-Sovereign Flux sources use).
+
+Per Inviolable Principle #4 every operationally-meaningful value is operator-
+overridable via .Values.catalogSovereign.gitRepository.*.
+
+References:
+  - Issue #3668 (this fix), the deferred half of PR #3702 / #3648
+  - templates/sme-services/sme-tenants-gitrepository.yaml (the exact pattern)
+  - internal/handler/catalog_edit_git.go (writeCatalogSovereignAggregator)
+  - catalog-sovereign-kustomization.yaml (consumer of this GitRepository)
+*/}}
+{{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
+{{- $sovFQDN := .Values.global.sovereignFQDN -}}
+{{- if $sovFQDN -}}
+{{- $gr := (.Values.catalogSovereign).gitRepository | default dict -}}
+{{- $apiURL := ($gr.apiURL | default "http://gitea-http.gitea.svc.cluster.local:3000") -}}
+{{- $org := ($gr.org | default "openova") -}}
+{{- $repo := ($gr.repo | default "openova") -}}
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: {{ $gr.name | default "openova-catalog-sovereign" | quote }}
+  namespace: {{ $gr.namespace | default "flux-system" | quote }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-platform
+    catalyst.openova.io/component: catalog-sovereign-source
+    app.kubernetes.io/part-of: catalog
+spec:
+  interval: {{ $gr.interval | default "1m" | quote }}
+  url: {{ printf "%s/%s/%s" $apiURL $org $repo | quote }}
+  ref:
+    branch: {{ $gr.branch | default "catalog-sovereign" | quote }}
+  ignore: |
+    /*
+    !/clusters/{{ $sovFQDN }}/catalog-sovereign
+  {{- if $gr.secretRef }}
+  secretRef:
+    name: {{ $gr.secretRef.name | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/products/catalyst/chart/templates/catalog-sovereign-flux/catalog-sovereign-kustomization.yaml
+++ b/products/catalyst/chart/templates/catalog-sovereign-flux/catalog-sovereign-kustomization.yaml
@@ -1,0 +1,118 @@
+{{- /*
+Flux Kustomization reconciling the catalog-sovereign aggregator tree into
+LIVE Blueprint CRs — the load-bearing half of #3668 (deferred by PR #3702).
+
+WHY THIS FILE EXISTS
+--------------------
+catalyst-api writes every edited/curated Blueprint as a full,
+ownership-stripped Blueprint CR into:
+
+  openova/openova @ catalog-sovereign
+  └── clusters/<sovereignFQDN>/catalog-sovereign/<bp>.yaml
+
+(writeCatalogSovereignAggregator in internal/handler/catalog_edit_git.go).
+This Kustomization sweeps that directory and SERVER-SIDE-APPLIES every
+`*.yaml` as a `blueprints.catalyst.openova.io/v1` CR — so a console edit
+reaches the LIVE in-cluster CR (and the chained catalog client
+`catalog_client_cluster_fallback.go` LISTs it, surfacing the edit to every
+catalog read), surviving `helm upgrade`.
+
+DIRECTORY SWEEP (no kustomization.yaml index)
+---------------------------------------------
+The aggregator directory carries NO `kustomization.yaml`. When the `path`
+has no kustomize index, Flux's kustomize-controller auto-generates one over
+every plain manifest in the directory — so catalyst-api only PUTs one flat
+`<bp>.yaml` per Blueprint and Flux reconciles the whole set, with ZERO
+index-maintenance write. The repo-bootstrap hook seeds an empty directory
+marker so this Kustomization is Ready from first convergence with no curated
+Blueprints (avoiding a permanent `path not found` NotReady the cutover
+egress-proof would otherwise accept as baseline noise).
+
+THE HELM → FLUX OWNERSHIP HANDOFF (DoD §9.4)
+--------------------------------------------
+catalog-seed (templates/catalog-seed/blueprints.yaml) bootstraps all baseline
+Blueprint CRs Helm-owned. Once a Blueprint is edited/curated, THIS
+Kustomization must become the authoritative owner of the same-named CR so a
+chart `helm upgrade` cannot revert the edit. Two coordinated mechanisms:
+
+  1. force: true (below) — SSA with force makes kustomize-controller win
+     field ownership of every field it applies. The Gitea source is
+     ownership-stripped (no app.kubernetes.io/managed-by, no helm.toolkit
+     annotations — stripBlueprintCRMapForGit), so Flux's apply does not
+     re-introduce Helm's field-manager; Flux is the durable owner of the
+     spec.
+
+  2. helm.sh/resource-policy: keep on every catalog-seed CR — so a future
+     helm reconcile that no longer renders / would prune the now-Flux-owned
+     CR leaves it intact instead of clawing it back.
+
+Together: catalog-seed seeds the CR ONCE (the t=0 fallback for un-curated
+Blueprints); Flux ADOPTS it on first edit and helm never reverts it. The two
+controllers do NOT fight — they own disjoint lifecycles keyed on whether a
+Gitea file exists for the Blueprint.
+
+CONTRACT
+--------
+  sourceRef: flux-system/openova-catalog-sovereign  (sibling GitRepository,
+             dedicated catalog-sovereign branch, mirror-clobber-immune)
+  path:      ./clusters/<sovereignFQDN>/catalog-sovereign
+  interval:  1m
+  prune:     true   (deleting a curated Blueprint from Gitea GCs its CR)
+  wait:      false  (Blueprint CRs validate at admission via the CRD schema;
+                     readiness is per-CR, no inter-CR gating)
+  force:     true   (SSA adoption over the Helm-owned catalog-seed CR)
+
+GATING
+------
+Rendered ONLY when .Values.global.sovereignFQDN non-empty AND
+.Values.ingress.marketplace.enabled — the same Sovereign discriminator the
+GitRepository + the SME bundle use.
+
+Per Inviolable Principle #3 the chart templates the resource and Flux owns
+the apply — no `kubectl apply` of CRs. Per #4 every cadence/timeout/ref knob
+is operator-overridable via .Values.catalogSovereign.kustomization.*.
+
+References:
+  - Issue #3668 (this fix), deferred half of PR #3702 / #3648
+  - templates/sme-services/sme-tenants-kustomization.yaml (the exact pattern)
+  - templates/catalog-seed/blueprints.yaml (the seed + resource-policy:keep)
+  - catalog-sovereign-gitrepository.yaml (the source)
+*/}}
+{{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
+{{- $sovFQDN := .Values.global.sovereignFQDN -}}
+{{- if $sovFQDN -}}
+{{- $kt := (.Values.catalogSovereign).kustomization | default dict -}}
+{{- $sourceRef := ($kt.sourceRef | default dict) -}}
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: {{ $kt.name | default "catalog-sovereign" | quote }}
+  namespace: {{ $kt.namespace | default "flux-system" | quote }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-platform
+    catalyst.openova.io/component: catalog-sovereign-reconciler
+    app.kubernetes.io/part-of: catalog
+spec:
+  interval: {{ $kt.interval | default "1m" | quote }}
+  retryInterval: {{ $kt.retryInterval | default "1m" | quote }}
+  timeout: {{ $kt.timeout | default "5m" | quote }}
+  path: ./clusters/{{ $sovFQDN }}/catalog-sovereign
+  prune: {{ $kt.prune | default true }}
+  # wait: false — Blueprint CRs are validated at admission by the CRD's
+  # openAPIV3Schema; there is no Ready condition to gate on, and one
+  # invalid CR must not block reconciling the rest.
+  wait: {{ $kt.wait | default false }}
+  # force: true — #3668 §9.4 Helm→Flux ownership adoption. SSA with force
+  # makes kustomize-controller the authoritative field-manager of the
+  # Blueprint CR, so a chart `helm upgrade` (which re-renders the
+  # catalog-seed CR) cannot revert a console edit. The Gitea source is
+  # ownership-stripped so Flux's apply does not re-introduce Helm's
+  # field-manager; combined with helm.sh/resource-policy:keep on the seed
+  # CRs, the edit is durable across upgrades.
+  force: {{ $kt.force | default true }}
+  sourceRef:
+    kind: GitRepository
+    name: {{ $sourceRef.name | default "openova-catalog-sovereign" | quote }}
+    namespace: {{ $sourceRef.namespace | default "flux-system" | quote }}
+{{- end }}
+{{- end }}

--- a/products/catalyst/chart/templates/catalog-sovereign-flux/catalog-sovereign-repo-bootstrap-job.yaml
+++ b/products/catalyst/chart/templates/catalog-sovereign-flux/catalog-sovereign-repo-bootstrap-job.yaml
@@ -1,0 +1,254 @@
+{{- /*
+Pre-install/pre-upgrade hook that bootstraps the `catalog-sovereign` branch +
+an empty aggregator directory the catalog-sovereign Flux source reconciles —
+issue #3668 (the load-bearing half of PR #3702). Modeled on the proven
+templates/sme-services/gitea-tenants-repo-bootstrap-job.yaml.
+
+WHY THIS FILE EXISTS
+====================
+The catalog-sovereign Flux chain (catalyst-api aggregator write +
+openova-catalog-sovereign GitRepository + catalog-sovereign Kustomization)
+targets the local Gitea repo `openova/openova` on a dedicated
+`catalog-sovereign` branch, under `clusters/<sovereignFQDN>/catalog-
+sovereign/`. PRE-cutover:
+
+  - The `openova/openova` repo + `main` branch ARE created by the SME
+    repo-bootstrap hook (gitea-tenants-repo-bootstrap-job.yaml, weight 12,
+    auto_init=true). THIS job runs at weight 13, AFTER it, so the repo +
+    default branch exist to branch from.
+  - The `catalog-sovereign` branch + the per-Sovereign aggregator directory
+    do NOT exist yet. Without them the openova-catalog-sovereign
+    GitRepository is "authentication required"/NotReady and the
+    catalog-sovereign Kustomization reports `path not found` — a permanent
+    NotReady the cutover egress-proof would silently accept as baseline
+    noise (the exact PRINCIPLES A1/A2 regression the SME job header
+    documents).
+
+A DEDICATED branch (not `main`) keeps the catalog aggregator immune to the
+cutover-gitea-mirror Job's `git push --mirror --force` of `main` (TBD-C18e).
+
+FIX
+===
+Idempotently, via the Gitea REST API (token auth, no kubectl/RBAC):
+  1. wait for the authed Gitea API to be reachable (REQUIRE_SIGNIN_VIEW=true
+     → the probe MUST send the token, else /version 403s, #3454);
+  2. ensure the `catalog-sovereign` branch exists (POST .../branches from the
+     repo's default branch — usually `main`);
+  3. seed an empty aggregator-directory marker
+     `clusters/${SOVEREIGN_FQDN}/catalog-sovereign/README.md` so the Flux
+     Kustomization `path` exists + reconciles Ready from t=0 with zero
+     curated Blueprints. (Flux's directory-sweep only reconciles *.yaml/*.yml
+     manifests, so a Markdown marker is inert — it merely makes the directory
+     non-empty so git can track it.)
+
+The repo + main branch + org are guaranteed by the SME job; this job does NOT
+recreate them — it only adds the catalog-sovereign branch + marker.
+
+GATING
+======
+Rendered ONLY when BOTH:
+  - .Values.global.sovereignFQDN non-empty (Sovereign, not Catalyst-Zero —
+    which has no local Gitea catalog reconcile);
+  - .Values.ingress.marketplace.enabled (the catalog/SME bundle is on).
+
+Per docs/PRINCIPLES.md #3 (no kubectl apply of workloads): a Helm hook Job
+that calls the Gitea REST API. Per #10 (no plaintext creds): the PAT is read
+at pod start from a same-namespace Secret via secretKeyRef (no kubectl, no
+Role, no cross-namespace race — the lesson the SME job header records from
+hw133). Per #4 (never hardcode): org/repo/branch + the in-cluster Gitea URL
+all flow through operator-overridable values.
+
+References:
+  - Issue #3668 (this fix), #3454 (the SME repo-bootstrap + auth precedent)
+  - templates/sme-services/gitea-tenants-repo-bootstrap-job.yaml (weight 12,
+    the repo auto-init this job front-runs to the catalog-sovereign branch)
+  - templates/catalyst-gitea-token-secret.yaml (PAT source, hook-weight 10)
+  - catalog-sovereign-gitrepository.yaml / catalog-sovereign-kustomization.yaml
+*/}}
+{{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
+{{- if .Values.global.sovereignFQDN -}}
+{{- $bs := (.Values.catalogSovereign).repoBootstrap | default dict -}}
+{{- $giteaURL := $bs.giteaInternalURL | default "http://gitea-http.gitea.svc.cluster.local:3000" -}}
+{{- $org := $bs.org | default "openova" -}}
+{{- $repo := $bs.repo | default "openova" -}}
+{{- $branch := $bs.branch | default "catalog-sovereign" -}}
+{{- $patSecret := $bs.patSourceSecretName | default "catalyst-gitea-token" -}}
+{{- $patKey := $bs.patSourceKey | default "token" -}}
+{{- $namespace := .Release.Namespace -}}
+{{- $sovFQDN := .Values.global.sovereignFQDN -}}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: catalyst-catalog-sovereign-repo-bootstrap
+  namespace: {{ $namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-platform
+    catalyst.openova.io/component: catalog-sovereign-repo-bootstrap
+    # Required by the kyverno `flux-managed` Enforce policy on converged
+    # Sovereigns (the release ns is NOT namespace-excluded).
+    app.kubernetes.io/managed-by: flux
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    # Weight 13: AFTER the catalyst-gitea-token mint Job (weight 10) so the
+    # PAT is populated, AND AFTER the SME repo-bootstrap Job (weight 12) which
+    # auto-inits the openova/openova repo + main branch this Job branches from.
+    helm.sh/hook-weight: "13"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 8
+  template:
+    metadata:
+      labels:
+        catalyst.openova.io/blueprint: bp-catalyst-platform
+        catalyst.openova.io/component: catalog-sovereign-repo-bootstrap
+    spec:
+      # #3454 pattern — NO ServiceAccount/Role/RoleBinding. The PAT is sourced
+      # via env secretKeyRef from a same-namespace Secret, resolved by the
+      # kubelet at pod start — no kubectl call, no cross-namespace Role race
+      # (the hw133 failure the SME job header records). Uses the default SA.
+      restartPolicy: OnFailure
+      containers:
+        - name: bootstrap
+          # Explicit harbor.openova.io/proxy-dockerhub prefix per CLAUDE.md
+          # MIRROR-EVERYTHING rule (matches the SME job + mint Job image).
+          image: harbor.openova.io/proxy-dockerhub/alpine/k8s:1.31.4
+          env:
+            - name: GITEA_URL
+              value: {{ $giteaURL | quote }}
+            - name: GITEA_ORG
+              value: {{ $org | quote }}
+            - name: GITEA_REPO
+              value: {{ $repo | quote }}
+            - name: CATALOG_BRANCH
+              value: {{ $branch | quote }}
+            - name: SOVEREIGN_FQDN
+              value: {{ $sovFQDN | quote }}
+            - name: ITERATIONS
+              value: {{ .Values.giteaWait.iterations | default 168 | quote }}
+            - name: INTERVAL
+              value: {{ .Values.giteaWait.intervalSeconds | default 5 | quote }}
+            # The Gitea admin PAT minted by catalyst-gitea-token-secret.yaml
+            # (hook-weight 10). secretKeyRef with empty .value passes the
+            # kyverno `secret-not-in-env` policy (it only denies plaintext
+            # values). optional:false — the Job MUST have the PAT.
+            - name: GITEA_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $patSecret | quote }}
+                  key: {{ $patKey | quote }}
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -eu
+              API="${GITEA_URL}/api/v1"
+
+              if [ -z "${GITEA_TOKEN:-}" ]; then
+                echo "[catalog-repo-bootstrap] FATAL: GITEA_TOKEN empty (catalyst-gitea-token PAT not yet minted)" >&2
+                exit 1
+              fi
+              # All calls use Gitea token auth (Authorization: token <PAT>).
+              # NEVER echo the token.
+
+              # Step 1: wait for the authed Gitea API to be reachable.
+              # #3454 — the probe MUST authenticate (REQUIRE_SIGNIN_VIEW=true
+              # → unauthenticated /version is 403, not 200).
+              for i in $(seq 1 "$ITERATIONS"); do
+                code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 \
+                  -H "Authorization: token ${GITEA_TOKEN}" "${API}/version" || echo 000)
+                if [ "$code" = "200" ]; then
+                  echo "[catalog-repo-bootstrap] gitea api reachable (authed /version=200)"
+                  break
+                fi
+                echo "[catalog-repo-bootstrap] waiting for gitea api ($i/$ITERATIONS, /version=${code})"
+                sleep "$INTERVAL"
+              done
+
+              # Step 2: confirm the repo exists (created by the SME job at
+              # weight 12). If it is somehow absent, wait briefly rather than
+              # racing — the SME job's own backoff will create it.
+              for i in $(seq 1 30); do
+                RC=$(curl -sS -o /dev/null -w '%{http_code}' \
+                  -H "Authorization: token ${GITEA_TOKEN}" "${API}/repos/${GITEA_ORG}/${GITEA_REPO}")
+                if [ "$RC" = "200" ]; then
+                  break
+                fi
+                echo "[catalog-repo-bootstrap] waiting for ${GITEA_ORG}/${GITEA_REPO} to exist ($i/30, GET=${RC})"
+                sleep 2
+              done
+
+              # Step 3: ensure the catalog-sovereign branch exists (from the
+              # repo's actual default branch — auto_init names it per the
+              # instance default, usually "main").
+              BR_CODE=$(curl -sS -o /dev/null -w '%{http_code}' \
+                -H "Authorization: token ${GITEA_TOKEN}" \
+                "${API}/repos/${GITEA_ORG}/${GITEA_REPO}/branches/${CATALOG_BRANCH}")
+              if [ "$BR_CODE" = "200" ]; then
+                echo "[catalog-repo-bootstrap] branch ${CATALOG_BRANCH} already present"
+              else
+                DEFAULT_BRANCH=$(curl -sS -H "Authorization: token ${GITEA_TOKEN}" \
+                  "${API}/repos/${GITEA_ORG}/${GITEA_REPO}" 2>/dev/null \
+                  | grep -oE '"default_branch":"[^"]*"' | head -1 | cut -d'"' -f4)
+                [ -n "$DEFAULT_BRANCH" ] || DEFAULT_BRANCH=main
+                echo "[catalog-repo-bootstrap] creating branch ${CATALOG_BRANCH} from ${DEFAULT_BRANCH} (GET was ${BR_CODE})"
+                curl -sS -o /dev/null -w '[catalog-repo-bootstrap] POST /branches -> %{http_code}\n' \
+                  -H "Authorization: token ${GITEA_TOKEN}" -H "Content-Type: application/json" \
+                  -X POST "${API}/repos/${GITEA_ORG}/${GITEA_REPO}/branches" \
+                  -d "{\"new_branch_name\":\"${CATALOG_BRANCH}\",\"old_branch_name\":\"${DEFAULT_BRANCH}\"}" || true
+                FINAL=$(curl -sS -o /dev/null -w '%{http_code}' \
+                  -H "Authorization: token ${GITEA_TOKEN}" \
+                  "${API}/repos/${GITEA_ORG}/${GITEA_REPO}/branches/${CATALOG_BRANCH}")
+                if [ "$FINAL" != "200" ]; then
+                  echo "[catalog-repo-bootstrap] FATAL: branch ${CATALOG_BRANCH} not present after create (HTTP ${FINAL})" >&2
+                  exit 1
+                fi
+                echo "[catalog-repo-bootstrap] branch ${CATALOG_BRANCH} present"
+              fi
+
+              # Step 4: seed the empty aggregator-directory marker so the Flux
+              # Kustomization path exists + reconciles Ready from t=0 (idempotent
+              # — GET-404-guarded; catalyst-api later PUTs bp-<name>.yaml files
+              # beside it, which Flux's directory-sweep reconciles into CRs).
+              MARKER_PATH="clusters/${SOVEREIGN_FQDN}/catalog-sovereign/README.md"
+              MC=$(curl -sS -o /dev/null -w '%{http_code}' \
+                -H "Authorization: token ${GITEA_TOKEN}" \
+                "${API}/repos/${GITEA_ORG}/${GITEA_REPO}/contents/${MARKER_PATH}?ref=${CATALOG_BRANCH}")
+              if [ "$MC" = "200" ]; then
+                echo "[catalog-repo-bootstrap] aggregator marker already present"
+              else
+                echo "[catalog-repo-bootstrap] seeding aggregator marker ${MARKER_PATH} (GET was ${MC})"
+                # base64 of the marker body (no shell heredoc — keep it literal).
+                CONTENT_B64=$(printf '%s\n' "# catalog-sovereign aggregator (#3668)" \
+                  "" \
+                  "Flux (openova-catalog-sovereign GitRepository + catalog-sovereign" \
+                  "Kustomization) reconciles every bp-<name>.yaml in this directory into a" \
+                  "live blueprints.catalyst.openova.io/v1 CR. catalyst-api writes these on" \
+                  "console catalog edit / curate (writeCatalogSovereignAggregator). This" \
+                  "README is an inert directory marker (Flux sweeps only *.yaml/*.yml)." \
+                  | base64 | tr -d '\n')
+                curl -sS -o /dev/null -w '[catalog-repo-bootstrap] PUT marker -> %{http_code}\n' \
+                  -H "Authorization: token ${GITEA_TOKEN}" -H "Content-Type: application/json" \
+                  -X POST "${API}/repos/${GITEA_ORG}/${GITEA_REPO}/contents/${MARKER_PATH}" \
+                  -d "{\"branch\":\"${CATALOG_BRANCH}\",\"message\":\"catalog-sovereign: seed aggregator directory (#3668)\",\"content\":\"${CONTENT_B64}\"}" || true
+              fi
+
+              echo "[catalog-repo-bootstrap] done — ${GITEA_ORG}/${GITEA_REPO}@${CATALOG_BRANCH} ready for catalog-sovereign reconcile"
+          resources:
+            requests: { cpu: 50m, memory: 64Mi }
+            limits:   { memory: 256Mi }
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+{{- end }}
+{{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1126,6 +1126,87 @@ smeTenants:
     repo: openova
     branch: sme-tenants
 
+# ─── catalog-sovereign Flux reconcile (#3668) ────────────────────────
+# The load-bearing half PR #3702 deferred: a Flux GitRepository +
+# Kustomization that reconcile the catalog-sovereign aggregator tree into
+# LIVE Blueprint CRs, so a console catalog edit (or curate) reaches the
+# in-cluster `blueprints.catalyst.openova.io/v1` CR and SURVIVES
+# `helm upgrade` (the CR becomes Flux/Git-owned, not Helm-owned).
+#
+# catalyst-api (writeCatalogSovereignAggregator) writes each edited/curated
+# Blueprint as a full, ownership-stripped CR to:
+#   openova/openova @ catalog-sovereign : clusters/<sovereignFQDN>/catalog-sovereign/<bp>.yaml
+# The Kustomization below directory-sweeps that tree into Blueprint CRs.
+#
+# Reuses the SME-tenant gitops repo coordinates (openova/openova) so the
+# chart's repo-bootstrap + Flux clone-auth (#3454) are already wired; a
+# DEDICATED `catalog-sovereign` branch is immune to the cutover-gitea-mirror
+# force-push of `main` (TBD-C18e). Mirrors the smeTenants block above 1:1.
+# Rendered only on a Sovereign (global.sovereignFQDN non-empty) +
+# ingress.marketplace.enabled — the same discriminator the SME bundle uses.
+catalogSovereign:
+  kustomization:
+    # Resource name. Appears in `kubectl get kustomization -n flux-system`.
+    name: catalog-sovereign
+    namespace: flux-system
+    # Consumes the dedicated openova-catalog-sovereign GitRepository
+    # (catalog-sovereign-gitrepository.yaml), tracking the catalog-sovereign
+    # branch the mirror-clobber of main cannot touch.
+    sourceRef:
+      name: openova-catalog-sovereign
+      namespace: flux-system
+    interval: 1m
+    retryInterval: 1m
+    timeout: 5m
+    # A curated Blueprint deleted from Gitea GCs its CR.
+    prune: true
+    # Blueprint CRs validate at admission via the CRD schema; no Ready
+    # condition to gate on, and one invalid CR must not block the rest.
+    wait: false
+    # #3668 §9.4 Helm→Flux ownership adoption: SSA with force makes
+    # kustomize-controller the authoritative field-manager of the Blueprint
+    # CR, so a chart `helm upgrade` (which re-renders the catalog-seed CR)
+    # cannot revert a console edit. The Gitea source is ownership-stripped so
+    # Flux's apply does not re-introduce Helm's field-manager; combined with
+    # helm.sh/resource-policy:keep on the catalog-seed CRs the edit is
+    # durable across upgrades.
+    force: true
+  # ─── Dedicated GitRepository for the catalog-sovereign aggregator ───
+  # Rendered by templates/catalog-sovereign-flux/catalog-sovereign-
+  # gitrepository.yaml. Same shape as openova-sme-tenants (a separate branch
+  # immune to the cutover mirror force-push of main).
+  gitRepository:
+    name: openova-catalog-sovereign
+    namespace: flux-system
+    branch: catalog-sovereign
+    apiURL: "http://gitea-http.gitea.svc.cluster.local:3000"
+    org: openova
+    repo: openova
+    interval: 1m
+    # #3454 — Flux MUST authenticate to clone the local Gitea even though
+    # openova/openova is PUBLIC, because bp-gitea sets
+    # service.REQUIRE_SIGNIN_VIEW=true (anon clone → 401). The secretRef
+    # points at a Flux basic-auth Secret holding the catalyst-gitea-token PAT
+    # (rendered by catalog-sovereign-gitrepo-auth-secret.yaml — the twin of
+    # the SME auth Secret).
+    secretRef:
+      name: openova-catalog-sovereign-git-auth
+      username: gitea_admin
+      patSourceSecretName: catalyst-gitea-token
+      patSourceKey: token
+  # ─── Pre-cutover branch + aggregator-dir bootstrap (#3668) ──────────
+  # Rendered by templates/catalog-sovereign-flux/catalog-sovereign-repo-
+  # bootstrap-job.yaml (hook-weight 13, AFTER the SME repo-bootstrap hook
+  # weight 12 which auto-inits openova/openova). Ensures the catalog-sovereign
+  # branch + an empty aggregator-directory marker so the Flux source is Ready
+  # from first convergence with zero curated Blueprints. MUST stay in sync
+  # with gitRepository.{org,repo,branch} above.
+  repoBootstrap:
+    giteaInternalURL: "http://gitea-http.gitea.svc.cluster.local:3000"
+    org: openova
+    repo: openova
+    branch: catalog-sovereign
+
 # ─── Per-Organization public HTTPRoutes (issue #1629 follow-up) ───────
 # PowerDNS now resolves `<slug>.<parentDomain>` for every Org that maps
 # onto a Sovereign's role=sme-pool parent domain, but without a


### PR DESCRIPTION
## Refs #3668 — the confirmed-deferred load-bearing half of #3702 (DO NOT MERGE; rides the next train)

### Measured current state (file:line)

PR #3702 (`aa7caf696`) shipped the catalog single-source-IaC **write + read** slice — `products/catalyst/bootstrap/api/internal/handler/catalog_edit_git.go:writeCatalogEditToGit` commits each Blueprint to `catalog-sovereign/<bp>/blueprint.yaml` (one Gitea **repo per Blueprint**; `blueprints.go:171 catalogSovereignOrg`, `blueprints.go:385 HandleBlueprintCurate`), and `fetchCatalogEditsFromGit` reads it back to the UI.

**The deferred half (verified absent on origin/main):**
- `grep -rn 'catalog-sovereign' clusters/` → only the `13-bp-catalyst-platform.yaml` slot **comment**; **no** Flux `GitRepository`/`Kustomization` named `catalog-sovereign`.
- The only in-cluster Blueprint CRs are **Helm-templated** in `products/catalyst/chart/templates/catalog-seed/blueprints.yaml` (78 CRs, `app.kubernetes.io/managed-by: Helm`). The chained catalog client `catalog_client_cluster_fallback.go:listFromCluster` LISTs them with no label selector — so any Blueprint CR surfaces, but **nothing reconciles `catalog-sovereign/*/blueprint.yaml` into a CR.**
- Result: after a console edit, `kubectl get blueprint bp-alloy -o jsonpath='{.spec.card.summary}'` **never moves**, and a `helm upgrade` re-renders the seed CR over the edit (DoD §9.1/9.4 revert-immunity gap).

### Target

Console edit / curate → Gitea commit → **Flux reconcile → LIVE `blueprints.catalyst.openova.io/v1` CR**, surviving `helm upgrade` (the CR becomes Flux/Git-owned, not Helm-owned).

### Mechanism

**1. Aggregator write (minimal Go, ~+25 lines + a DRY refactor).** A Flux `GitRepository` tracks ONE repo+branch — it cannot reconcile the per-Blueprint repos #3702 writes. So `catalog_edit_git.go:writeCatalogSovereignAggregator` **also** mirrors the SAME ownership-stripped `merged` CR bytes into a single aggregator tree on the already-bootstrapped local Gitea repo:

```
openova/openova @ catalog-sovereign
└── clusters/<sovereignFQDN>/catalog-sovereign/<bp>.yaml   (full CR)
```

Wired into both `writeCatalogEditToGit` (edit) and `HandleBlueprintCurate` (curate), best-effort + additive (a failure is `h.log.Warn`-logged and swallowed — the per-Blueprint UI-read write already succeeded). No-ops on the Catalyst-Zero mothership (`SOVEREIGN_FQDN` empty). The ownership-strip is factored into a reusable `stripBlueprintCRMapForGit` / `stripBlueprintCRBytesForGit` (the curate source may carry labels).

**2. Flux reconcile — `products/catalyst/chart/templates/catalog-sovereign-flux/` (4 files, mirroring the SME-tenants family verbatim):**
- `catalog-sovereign-gitrepository.yaml` — `GitRepository openova-catalog-sovereign`, `openova/openova` @ `catalog-sovereign` branch (dedicated branch immune to the cutover-gitea-mirror force-push of `main`, TBD-C18e), `secretRef` for auth.
- `catalog-sovereign-kustomization.yaml` — `Kustomization catalog-sovereign`, `path: ./clusters/<fqdn>/catalog-sovereign`, **`force: true`** (SSA adoption), `prune: true`, `wait: false`, directory-sweep (no index).
- `catalog-sovereign-gitrepo-auth-secret.yaml` — Flux basic-auth Secret from the `catalyst-gitea-token` PAT (#3454: bp-gitea `REQUIRE_SIGNIN_VIEW=true` → anon clone 401; twin of the SME auth Secret).
- `catalog-sovereign-repo-bootstrap-job.yaml` — pre-install/upgrade hook (weight 13, after the SME repo-bootstrap weight 12 that auto-inits `openova/openova`) ensuring the `catalog-sovereign` branch + an empty aggregator-dir marker so the Kustomization is Ready from t=0 with zero curated Blueprints.

All gated `global.sovereignFQDN` non-empty + `ingress.marketplace.enabled` — **Catalyst-Zero render byte-unchanged** (verified: zero catalog-sovereign objects render without an FQDN). They ride **inside the catalyst-platform chart** (Helm-only, like SME-tenants) — no new bootstrap-kit slot, no `kustomization.yaml` registration (the Kustomize-mode `templates/kustomization.yaml` allowlist excludes them).

**3. Helm → Flux ownership handoff (DoD §9.4).** catalog-seed seeds the 78 baseline CRs once (the t=0 fallback for un-curated Blueprints). On first edit, the Kustomization's `force: true` SSA over the **ownership-stripped** Gitea source adopts the same-named CR (Flux's apply never re-introduces Helm's `managed-by` field-manager). Every catalog-seed CR gains **`helm.sh/resource-policy: keep`** so a later helm reconcile cannot claw back a Flux-adopted CR. The two controllers own disjoint lifecycles keyed on whether a Gitea file exists.

### DoD / acceptance

This is **PART A** of the existing UAT walkthrough `docs/ledger/uat-walkthrough/catalog-edit-single-source-iac-not-overlay.md` (A1 a READY Flux source reconciles `catalog-sovereign` → CRs; A2 a console edit reaches the in-cluster CR; A5 a chart upgrade does NOT revert the edit). **Must be walked live** (edit → `kubectl ... jsonpath` moves → `helm upgrade` → value persists) — not claimed on render-only proof.

### Gates (all green)
- `helm lint` ✓ · `helm template` (Sovereign: GitRepository + Kustomization(force:true) + bootstrap Job render; Catalyst-Zero: nothing) ✓ · rendered YAML parses (169 docs) ✓
- `scripts/check-bootstrap-kit-pin-sync.sh` ✓ (`bp-catalyst-platform: chart=1.4.656 pin=1.4.656`)
- `scripts/check-catalog-seed-lockstep.sh` ✓ (68 checked, annotation transparent)
- `go build ./... && go vet ./... && gofmt -l` ✓ · `go test -race ./internal/handler/` ✓ (new aggregator tests: Sovereign write, mothership no-op, best-effort guards)

### Version lockstep
`Chart.yaml` 1.4.655 → **1.4.656** + bootstrap-kit slot 13 pin → 1.4.656. (There is **no** `products/catalyst/blueprint.yaml` — the umbrella has no catalog-level blueprint.yaml; lockstep is the two pins only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
