### PR TITLE
feat(uat): reset-uat.py prose-format upgrade + uat-drift-guard.py CI backstop (Refs #3581)

### DIFF
--- a/.github/workflows/uat-drift-guard.yaml
+++ b/.github/workflows/uat-drift-guard.yaml
@@ -1,0 +1,60 @@
+# uat-drift-guard.yaml — block UAT walk-evidence that cites a PREDECESSOR env.
+#
+# THE LAW (founder 2026-06-14, the "fake snapshots" rebuke): each new env
+# flushes ALL prior evidence — a ✅ UAT row that still links a wiped env's
+# screenshot is a fabricated snapshot. `scripts/reset-uat.py` clears that
+# evidence on a fresh fire; THIS guard is the CI backstop that fails the build
+# if a ledger slips through with a ✅ row whose proof artifact references an
+# `hwNNN` env that is not the current env (resolved from the UAT.md H1 header,
+# or $UAT_CURRENT_ENV / --env).
+#
+# READ-ONLY: this guard never edits the ledger (verification stays read-only —
+# memory L7/L8). It only reports. The fix for a violation is a live re-walk on
+# the current env (the evidence half), or `python3 scripts/reset-uat.py <env>`.
+#
+# Self-test runs on every trigger so the guard's own logic is continuously
+# protected (clean tree -> 0, stale fixture -> 1, env-agnostic predecessor
+# detection both directions).
+name: uat-drift-guard
+
+on:
+  pull_request:
+    paths:
+      - "docs/ledger/UAT.md"
+      - "docs/ledger/uat-walkthrough/**"
+      - "scripts/uat-drift-guard.py"
+      - "scripts/reset-uat.py"
+      - ".github/workflows/uat-drift-guard.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/ledger/UAT.md"
+      - "docs/ledger/uat-walkthrough/**"
+      - "scripts/uat-drift-guard.py"
+      - "scripts/reset-uat.py"
+      - ".github/workflows/uat-drift-guard.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift-guard:
+    name: UAT predecessor-env drift guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Self-test the guard (clean -> 0, stale -> 1, both directions)
+        run: python3 scripts/uat-drift-guard.py --self-test
+
+      - name: Guard the live UAT ledger against predecessor-env evidence
+        # Current env is auto-derived from the `on \`hwNNN\`` token in the UAT.md
+        # H1 header. Override in an ad-hoc run with UAT_CURRENT_ENV=hwNNN.
+        run: python3 scripts/uat-drift-guard.py

--- a/scripts/reset-uat.py
+++ b/scripts/reset-uat.py
@@ -1,42 +1,186 @@
 #!/usr/bin/env python3
-"""Reset docs/ledger/UAT.md evidence on a Sovereign re-prov.
+"""Reset docs/ledger/UAT.md + docs/ledger/uat-walkthrough/*.md evidence on a re-prov.
 
-Founder rule (2026-06-08): every wipe -> re-prov MUST reset the UAT page so it
-never carries walk-evidence from a wiped environment. This is the STRUCTURAL
-enforcement of that rule — it is invoked by `scripts/sovereign-lifecycle.sh fire`
-so a re-prov cannot happen without a UAT reset (mechanism, not memory).
+Founder rule (2026-06-08, reinforced 2026-06-14 "each new env flushes ALL prior
+evidence"): every wipe -> re-prov MUST reset the UAT page(s) so they never carry
+walk-evidence from a wiped environment. This is the STRUCTURAL enforcement of that
+rule — it is invoked by `scripts/sovereign-lifecycle.sh fire` so a re-prov cannot
+happen without a UAT reset (mechanism, not memory).
 
-Usage: reset-uat.py [<env-label>]      e.g.  reset-uat.py hw107
+Usage: reset-uat.py [<env-label>]      e.g.  reset-uat.py hwNNN
 
-Resets every TC-/SSO-/TOPO-/VC- row's Result -> ☐ and Evidence -> —, PRESERVING
-⛔ code-gap rows (e.g. SSO-spire #3084, which is env-independent), and stamps the
-header with the reset date + the env the next walk will fill from scratch.
+What it clears (env-agnostic — no hardcoded hwNNN):
+
+  * The legacy id-prefixed rows (`TC-`/`SSO-`/`TOPO-`/`VC-`) — Result -> ☐, Evidence -> —.
+  * The CURRENT prose-format master/surface table rows — any status cell that
+    carries POSITIVE walk-evidence (starts with `✅` or `PASS`) is reset to `⏳`
+    (pending re-walk); an adjacent proof/evidence cell that references a specific
+    env (an `hwNNN`/`d<hex>` token or a screenshot/sessions link) is blanked to `—`.
+  * The per-walkthrough `| Go to … | Then … | You should see … | ✅ |` rows — a
+    filled `✅` Result checkbox is reset to `☐`.
+
+What it PRESERVES (genuine code-gap / honesty rows, env-independent):
+
+  * `⛔` legacy code-gap blockers.
+  * Rows already at `⏳` / `☐` / `❌` / `N/A` / `—` — these are NOT walk-evidence,
+    so they carry no stale env claim and are left untouched.
+
 Git history retains the prior evidence; the screenshots remain under
-docs/sessions/<date>/evidence/. Only the live UAT table is cleared.
+docs/sessions/<date>/evidence/. Only the live UAT tables are cleared.
 """
-import sys, re, datetime
+import sys, os, re, glob, datetime
 
 ENV = sys.argv[1] if len(sys.argv) > 1 else "pending fresh prov"
-PATH = "docs/ledger/UAT.md"
 today = datetime.date.today().isoformat()
 
-lines = open(PATH, encoding="utf-8").read().split("\n")
-out, n = [], 0
-for i, ln in enumerate(lines):
-    if i == 0 and ln.startswith("# UAT"):
-        base = re.sub(r"\s*\((?:hw\d+|RESET[^)]*)\)\s*$", "", ln).rstrip()
-        out.append(f"{base} (RESET {today} — pending {ENV})")
-        continue
-    cells = ln.split("|")
-    # data rows only: first cell is a TC-/SSO-/TOPO-/VC- id; last two cols = Result, Evidence
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+UAT_PATH = os.path.join(REPO_ROOT, "docs", "ledger", "UAT.md")
+WALK_GLOB = os.path.join(REPO_ROOT, "docs", "ledger", "uat-walkthrough", "*.md")
+
+# A cell holds POSITIVE walk-evidence iff its first non-space glyph (ignoring any
+# leading markdown emphasis markers ** / * / __ / _) is a green check or the literal
+# word PASS. ❌/🟡/⏳/☐/⛔/— and "N/A" are NOT positive evidence and are left alone.
+_EMPH = r"(?:[*_]{1,2}\s*)*"  # optional leading **/*/__/_ emphasis
+POS_EVIDENCE = re.compile(rf"^\s*{_EMPH}(✅|PASS\b)")
+
+# A bare-checkbox Result cell is exactly a green check (a filled walkthrough row),
+# optionally wrapped in emphasis / with a trailing note in parens — reset those to
+# ☐, not ⏳.
+BARE_CHECK = re.compile(rf"^\s*{_EMPH}✅{_EMPH}\s*(\(.*\))?\s*$")
+
+# An adjacent "Evidence / Proof" cell is env-specific (and therefore stale on a
+# re-prov) iff it references an env token or an evidence artifact path.
+ENV_REF = re.compile(
+    r"hw\d+"                         # hwNNN env label
+    r"|\bd[0-9a-f]{12,}\b"           # deployment id (hex)
+    r"|sessions/\d{4}-\d{2}-\d{2}"   # docs/sessions/<date>/evidence/...
+    r"|evidence/"                    # any evidence/ path
+    r"|\.txt\)|\.png\)|\.json\)",    # linked proof artifact
+    re.IGNORECASE,
+)
+
+# Header-cell sentinels: a row whose status column literally reads one of these is
+# a TABLE HEADER, never data — never touch it (defends against a header that
+# happens to contain a stray glyph).
+HEADER_CELLS = {
+    "result", "now", "status", "live result", "proof", "evidence",
+    "you should see", "you should see (screen)", "you should see (result)",
+    "then do", "then do (click / type)", "go to", "do",
+}
+
+
+def is_separator(cells):
+    """True for a |---|---| markdown separator row."""
+    body = [c.strip() for c in cells[1:-1]] if len(cells) >= 2 else []
+    return bool(body) and all(re.fullmatch(r":?-{2,}:?", c) for c in body)
+
+
+def is_header_row(cells):
+    """True for the column-title row of a table (so we never reset a header)."""
+    for c in cells[1:-1] if len(cells) >= 2 else []:
+        cl = c.strip().lower()
+        # strip a trailing parenthetical like "On hwNN (...)" -> "on hw"
+        cl_base = re.sub(r"\s*\(.*\)\s*$", "", cl).strip()
+        if cl in HEADER_CELLS or cl_base in HEADER_CELLS or cl_base.startswith("on hw"):
+            return True
+    return False
+
+
+def reset_legacy_row(cells):
+    """Old TC-/SSO-/TOPO-/VC- id rows: Result -> ☐, Evidence -> — (skip ⛔)."""
     if len(cells) >= 6 and re.match(r"^\s*(TC-|SSO-|TOPO-|VC-)", cells[1]):
-        if "⛔" not in cells[-3]:        # keep env-independent code-gap blockers
+        if "⛔" not in cells[-3]:
             cells[-3] = " ☐ "
             cells[-2] = " — "
-            n += 1
-        out.append("|".join(cells))
-        continue
-    out.append(ln)
+            return True
+    return False
 
-open(PATH, "w", encoding="utf-8").write("\n".join(out))
-print(f"UAT reset: {n} rows -> ☐/— (⛔ code-gap rows preserved); header stamped RESET {today}, pending {ENV}")
+
+def reset_prose_row(cells):
+    """Current prose tables: reset any positive-evidence cell; blank stale proof.
+
+    Returns the count of evidence cells reset in this row.
+    """
+    n = 0
+    reset_idxs = []
+    for i in range(1, len(cells) - 1):
+        if POS_EVIDENCE.match(cells[i]):
+            if BARE_CHECK.match(cells[i]):
+                cells[i] = " ☐ "          # filled walkthrough checkbox -> unfilled
+            else:
+                cells[i] = " ⏳ "          # prose status claim -> pending re-walk
+            reset_idxs.append(i)
+            n += 1
+    if reset_idxs:
+        # Blank any OTHER cell in the row that names a stale env / evidence artifact
+        # (the Proof / Evidence column sitting next to the status we just reset).
+        for j in range(1, len(cells) - 1):
+            if j in reset_idxs:
+                continue
+            if ENV_REF.search(cells[j]):
+                cells[j] = " — "
+    return n
+
+
+def process(path, is_master):
+    if not os.path.exists(path):
+        return 0, False
+    lines = open(path, encoding="utf-8").read().split("\n")
+    out, n = [], 0
+    stamped = False
+    for ln in lines:
+        # Re-stamp the H1 header with the reset date + pending env (master file only,
+        # and only the first H1). Strip any prior env clause: on `hwNNN...`, (hwNNN),
+        # (RESET ...), or a bare (pending ...).
+        if is_master and not stamped and re.match(r"^#\s+UAT\b", ln):
+            base = re.sub(
+                r"\s*(?:—\s*)?(?:ground reality\s+)?on\s+`?hw[\w.]+`?.*$",
+                "", ln, flags=re.IGNORECASE,
+            )
+            base = re.sub(
+                r"\s*\((?:hw[\w.]+|RESET[^)]*|pending[^)]*)\)\s*$", "", base
+            ).rstrip()
+            out.append(f"{base} (RESET {today} — pending {ENV})")
+            stamped = True
+            continue
+
+        if "|" not in ln:
+            out.append(ln)
+            continue
+        cells = ln.split("|")
+        if is_separator(cells) or is_header_row(cells):
+            out.append(ln)
+            continue
+        # Legacy id-row path first (old format), then the prose path.
+        if reset_legacy_row(cells):
+            n += 1
+        else:
+            n += reset_prose_row(cells)
+        out.append("|".join(cells))
+
+    open(path, "w", encoding="utf-8").write("\n".join(out))
+    return n, True
+
+
+def main():
+    total = 0
+    n_master, ok = process(UAT_PATH, is_master=True)
+    total += n_master
+    files = [("docs/ledger/UAT.md", n_master)] if ok else []
+    if not ok:
+        print(f"WARN: {UAT_PATH} not found — nothing to reset there")
+    for wpath in sorted(glob.glob(WALK_GLOB)):
+        nw, _ = process(wpath, is_master=False)
+        total += nw
+        if nw:
+            files.append((os.path.relpath(wpath, REPO_ROOT), nw))
+    print(
+        f"UAT reset: {total} evidence cell(s) -> ⏳/☐ across {len(files)} file(s) "
+        f"(⛔/❌/⏳/☐/N/A rows preserved); header stamped RESET {today}, pending {ENV}"
+    )
+    for rel, cnt in files:
+        print(f"  {rel}: {cnt}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/uat-drift-guard.py
+++ b/scripts/uat-drift-guard.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Fail CI if the UAT ledger carries walk-evidence from a PREDECESSOR environment.
+
+Founder rule (2026-06-14, the "fake snapshots" rebuke): each new env flushes ALL
+prior evidence — a ✅ row that still cites a wiped env's screenshot is a fabricated
+snapshot. `scripts/reset-uat.py` clears the evidence on a fresh fire; THIS guard is
+the CI backstop that catches a ledger which slipped through (a hand-edited ✅ row,
+a merge that re-introduced an old env's proof, or a reset that was skipped).
+
+It scans `docs/ledger/UAT.md` + `docs/ledger/uat-walkthrough/*.md` and exits
+NON-ZERO if any markdown table row is BOTH:
+
+  (a) positive walk-evidence — a status cell whose first glyph (ignoring leading
+      markdown emphasis) is ✅ or the literal word PASS, AND
+  (b) carries a concrete proof artifact — a screenshot / sessions-evidence link
+      or an env-stamped token — that references a `hwNNN` env which is NOT the
+      current env.
+
+"Current env" is resolved (first match wins):
+  1. --env hwNNN   CLI flag
+  2. $UAT_CURRENT_ENV
+  3. the `on `hwNNN`...` token in the UAT.md H1 header
+
+If the header is in the RESET/pending state (no concrete env), there is no current
+env, so ANY hwNNN proof on a ✅ row is, by definition, stale -> the guard fails.
+That is intentional: a freshly-reset ledger must carry zero ✅+hwNNN evidence.
+
+Env-agnostic: the only hwNNN ever treated as legitimate is the resolved current
+env; everything else is a predecessor. No env label is hardcoded.
+
+Usage:
+  uat-drift-guard.py [--env hwNNN]      # guard the live ledger
+  uat-drift-guard.py --self-test        # built-in both-directions self-test
+"""
+import sys, os, re, glob, argparse, tempfile
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+UAT_REL = os.path.join("docs", "ledger", "UAT.md")
+WALK_REL_GLOB = os.path.join("docs", "ledger", "uat-walkthrough", "*.md")
+
+_EMPH = r"(?:[*_]{1,2}\s*)*"  # optional leading **/*/__/_ emphasis
+POS_EVIDENCE = re.compile(rf"^\s*{_EMPH}(✅|PASS\b)")
+
+# Any hwNNN token (the env label predecessor-detector).
+HW_TOKEN = re.compile(r"\bhw\d+\b", re.IGNORECASE)
+
+# A concrete proof artifact: a screenshot / sessions-evidence link or a linked
+# proof file. A ✅ row that merely *names* a feature is fine; a ✅ row that LINKS a
+# wiped env's artifact is the fabricated snapshot we reject.
+PROOF_ARTIFACT = re.compile(
+    r"sessions/\d{4}-\d{2}-\d{2}"   # docs/sessions/<date>/evidence/...
+    r"|evidence/"                  # any evidence/ path
+    r"|\.png|\.txt\)|\.json\)"     # linked proof artifact
+    r"|hw\d+-\d+",                 # an "hwNNN-09"-style screenshot id
+    re.IGNORECASE,
+)
+
+
+def header_env(text):
+    """Extract the concrete current env from the UAT.md H1, or None if pending/reset."""
+    for ln in text.split("\n"):
+        if re.match(r"^#\s+UAT\b", ln):
+            # A reset header reads "(RESET ... — pending hwXXX)"; pending is NOT a
+            # concrete live env, so treat it as None (no env is legitimate yet).
+            if re.search(r"\bpending\b", ln, re.IGNORECASE):
+                return None
+            m = re.search(r"on\s+`?(hw\d+)", ln, re.IGNORECASE)
+            return m.group(1).lower() if m else None
+    return None
+
+
+def is_separator(cells):
+    body = [c.strip() for c in cells[1:-1]] if len(cells) >= 2 else []
+    return bool(body) and all(re.fullmatch(r":?-{2,}:?", c) for c in body)
+
+
+def scan_text(text, current_env):
+    """Return a list of (line_no, stale_envs, excerpt) violations for one file."""
+    cur = current_env.lower() if current_env else None
+    violations = []
+    for lineno, ln in enumerate(text.split("\n"), start=1):
+        if "|" not in ln:
+            continue
+        cells = ln.split("|")
+        if is_separator(cells):
+            continue
+        # Does any cell in the row assert positive walk-evidence?
+        has_pos = any(POS_EVIDENCE.match(c) for c in cells[1:-1] if c.strip())
+        if not has_pos:
+            continue
+        # Does the row carry a concrete proof artifact (a screenshot / evidence link)?
+        if not PROOF_ARTIFACT.search(ln):
+            continue
+        # Which hwNNN tokens in the row are NOT the current env?
+        hits = {h.lower() for h in HW_TOKEN.findall(ln)}
+        stale = sorted(h for h in hits if h != cur)
+        if stale:
+            excerpt = ln.strip()
+            if len(excerpt) > 160:
+                excerpt = excerpt[:157] + "..."
+            violations.append((lineno, stale, excerpt))
+    return violations
+
+
+def guard(current_env, root=REPO_ROOT, quiet=False):
+    """Scan the live ledger; return 0 (clean) or 1 (stale evidence found)."""
+    paths = []
+    uat = os.path.join(root, UAT_REL)
+    if os.path.exists(uat):
+        paths.append(uat)
+    paths += sorted(glob.glob(os.path.join(root, WALK_REL_GLOB)))
+
+    if not paths:
+        if not quiet:
+            print(f"uat-drift-guard: no UAT ledger files under {root} — nothing to check")
+        return 0
+
+    # Resolve current env from the header if not supplied.
+    if current_env is None and os.path.exists(uat):
+        current_env = header_env(open(uat, encoding="utf-8").read())
+
+    total = 0
+    for p in paths:
+        text = open(p, encoding="utf-8").read()
+        v = scan_text(text, current_env)
+        if v:
+            rel = os.path.relpath(p, root)
+            for lineno, stale, excerpt in v:
+                if not quiet:
+                    print(
+                        f"::error file={rel},line={lineno}::stale UAT walk-evidence "
+                        f"references predecessor env {','.join(stale)} "
+                        f"(current env: {current_env or 'NONE/pending'}) — {excerpt}"
+                    )
+                total += 1
+
+    if total:
+        if not quiet:
+            print("")
+            print(f"uat-drift-guard: FAIL — {total} ✅ row(s) cite a wiped/predecessor env.")
+            print("Each new env flushes ALL prior evidence (founder 2026-06-14). Run")
+            print("  python3 scripts/reset-uat.py <current-env>")
+            print("to clear stale evidence, then re-walk + re-fill on the live env.")
+        return 1
+
+    if not quiet:
+        print(
+            f"uat-drift-guard: OK — {len(paths)} ledger file(s) carry no stale "
+            f"walk-evidence (current env: {current_env or 'NONE/pending — must be evidence-free'})."
+        )
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Self-test: clean tree -> 0, stale-evidence fixture -> 1.                     #
+# --------------------------------------------------------------------------- #
+_CLEAN_UAT = """# UAT (RESET 2026-06-17 — pending hw900)
+
+| Surface (issue) | Live result | Walkthrough |
+|---|---|---|
+| **SSO** (#3374) | ⏳ | [3374-sso.md](uat-walkthrough/3374-sso.md) |
+| **Region-kill** (#3375) | ⏳ | [3375.md](uat-walkthrough/3375.md) |
+
+| # | App | Try it | Now | Proof |
+|---|---|---|---|---|
+| 1 | console | — | ☐ | — |
+| 2 | grafana | — | ☐ | — |
+"""
+
+_CLEAN_WALK = """# 3374 — SSO walkthrough
+
+| # | Go to (URL) | Then do | You should see | Result |
+|---|---|---|---|---|
+| 1 | `https://console.<fqdn>/` | type the URL | lands signed-in | ☐ |
+"""
+
+# Synthetic env labels (hw900 = current, hw800 / hw700 = predecessors). They match
+# the hwNNN detector but are deliberately NOT in the real hw1NN prov range, so the
+# fixtures can never be mistaken for — or hardcode — a live env.
+_STALE_UAT = """# UAT — ground reality on `hw900.omani.works` (2026-06-17)
+
+| Surface (issue) | Live result | Walkthrough |
+|---|---|---|
+| **SSO** (#3374) | ✅ — lands signed-in (hw800-09) | [3374-sso.md](uat-walkthrough/3374-sso.md) |
+| **Region-kill** (#3375) | ✅ — RTO 4s ([proof](../sessions/2026-06-15/evidence/hw800-ns4.txt)) | [3375.md](uat-walkthrough/3375.md) |
+| **Cutover** (#3379) | ⏳ PENDING — not yet walked | [3379.md](uat-walkthrough/3379.md) |
+"""
+
+_STALE_WALK = """# 3375 — topology walkthrough
+
+| # | Go to | Do | You should see | Result |
+|---|---|---|---|---|
+| 1 | `/cloud` | look | Region 2/2 renders (hw700-16) | ✅ |
+"""
+
+
+def _write(d, rel, content):
+    p = os.path.join(d, rel)
+    os.makedirs(os.path.dirname(p), exist_ok=True)
+    open(p, "w", encoding="utf-8").write(content)
+
+
+def self_test():
+    """Both-directions self-test on synthetic envs (current hw900; predecessors
+    hw800 / hw700). No real env label is referenced — the guard is env-agnostic."""
+    ok = True
+
+    # Direction 1: a clean (reset) tree on env hw900 -> exit 0.
+    with tempfile.TemporaryDirectory() as d:
+        _write(d, UAT_REL, _CLEAN_UAT)
+        _write(d, os.path.join("docs", "ledger", "uat-walkthrough", "3374-sso.md"), _CLEAN_WALK)
+        rc = guard(current_env="hw900", root=d, quiet=True)
+        passed = rc == 0
+        ok = ok and passed
+        print(f"[self-test] clean tree (env hw900)               -> exit {rc}  "
+              f"(expect 0)  {'PASS' if passed else 'FAIL'}")
+
+    # Direction 2: stale predecessor evidence (hw800/hw700 on an hw900 ledger) -> exit 1.
+    with tempfile.TemporaryDirectory() as d:
+        _write(d, UAT_REL, _STALE_UAT)
+        _write(d, os.path.join("docs", "ledger", "uat-walkthrough", "3375.md"), _STALE_WALK)
+        rc = guard(current_env="hw900", root=d, quiet=True)
+        passed = rc == 1
+        ok = ok and passed
+        print(f"[self-test] stale evidence (hw800/hw700)         -> exit {rc}  "
+              f"(expect 1)  {'PASS' if passed else 'FAIL'}")
+
+    # Direction 3: the SAME stale fixture but with hw800 declared current — the
+    # hw700 row is still a predecessor, so it must STILL fail (env-agnostic proof).
+    with tempfile.TemporaryDirectory() as d:
+        _write(d, UAT_REL, _STALE_UAT.replace("hw900", "hw800"))
+        _write(d, os.path.join("docs", "ledger", "uat-walkthrough", "3375.md"), _STALE_WALK)
+        rc = guard(current_env="hw800", root=d, quiet=True)
+        passed = rc == 1   # hw700-16 in the walkthrough is still stale vs hw800
+        ok = ok and passed
+        print(f"[self-test] current=hw800, hw700 leftover        -> exit {rc}  "
+              f"(expect 1)  {'PASS' if passed else 'FAIL'}")
+
+    # Direction 4: a ✅ row that cites ONLY the current env + no foreign hw -> clean.
+    with tempfile.TemporaryDirectory() as d:
+        good = (
+            "# UAT — ground reality on `hw900.omani.works`\n\n"
+            "| Surface | Live result | Walkthrough |\n|---|---|---|\n"
+            "| **SSO** | ✅ — lands signed-in (hw900-09) | [x.md](uat-walkthrough/x.md) |\n"
+        )
+        _write(d, UAT_REL, good)
+        rc = guard(current_env="hw900", root=d, quiet=True)
+        passed = rc == 0
+        ok = ok and passed
+        print(f"[self-test] current=hw900, only hw900 proof      -> exit {rc}  "
+              f"(expect 0)  {'PASS' if passed else 'FAIL'}")
+
+    # Direction 5: header-derived current env (no --env) — a pending/RESET header
+    # has NO concrete env, so any ✅+hwNNN proof must fail.
+    with tempfile.TemporaryDirectory() as d:
+        pending = (
+            "# UAT (RESET 2026-06-17 — pending hw900)\n\n"
+            "| Surface | Live result | Walkthrough |\n|---|---|---|\n"
+            "| **SSO** | ✅ — lands signed-in (hw800-09) | [x.md](uat-walkthrough/x.md) |\n"
+        )
+        _write(d, UAT_REL, pending)
+        rc = guard(current_env=None, root=d, quiet=True)  # derive from header -> None
+        passed = rc == 1
+        ok = ok and passed
+        print(f"[self-test] pending header + hw800 ✅ proof       -> exit {rc}  "
+              f"(expect 1)  {'PASS' if passed else 'FAIL'}")
+
+    print("")
+    print("uat-drift-guard self-test: " + ("ALL PASS" if ok else "FAILURES PRESENT"))
+    return 0 if ok else 1
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--env", help="the current live env label, e.g. hwNNN (else $UAT_CURRENT_ENV or the UAT.md header)")
+    ap.add_argument("--self-test", action="store_true", help="run the built-in both-directions self-test and exit")
+    args = ap.parse_args()
+
+    if args.self_test:
+        sys.exit(self_test())
+
+    env = args.env or os.environ.get("UAT_CURRENT_ENV")
+    sys.exit(guard(current_env=env))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Refs #3581** — the confirmed-deferred **CODE half** of the UAT-regen enforcer.
The walk-evidence half (re-walking every surface on the current live env) is
produced separately. **DO NOT MERGE — rides the next train.**

## § Problem (verified on `origin/main`)

1. **`scripts/reset-uat.py` is a silent no-op on the live ledger.** Its only row
   matcher was the dead `TC-/SSO-/TOPO-/VC-` id prefixes (old-format, line ~32).
   The current `docs/ledger/UAT.md` is **prose format** (`hw144` master/surface
   tables + `| Go to … | Then … | You should see … | ☐ |` walkthrough rows), so
   the script cleared **0 rows**. That is exactly why a fresh fire could not flush
   a wiped env's walk-evidence — the founder 2026-06-08 reset hook ran, did
   nothing, and the stale `✅` rows survived.

2. **`scripts/uat-drift-guard.py` did not exist.** Nothing in CI caught a UAT `✅`
   row still linking a **predecessor env's** screenshot — the founder 2026-06-14
   "fake snapshots" anti-pattern was undetected.

## § What this ships

### `scripts/reset-uat.py` (upgraded — +170/−26)
- Resets any table status cell whose first glyph (tolerating leading `**`/`*`/`__`
  markdown emphasis) is `✅` or `PASS` → `⏳` (prose claim) or `☐` (bare
  walkthrough checkbox), and blanks an **adjacent env-stamped proof cell**
  (`hwNNN` / `d<hex>` / `sessions/<date>` / `evidence/` / screenshot link) → `—`.
- Walks **both** `docs/ledger/UAT.md` **and** `docs/ledger/uat-walkthrough/*.md`.
- **Preserves** `⛔` / `❌` / `⏳` / `☐` / `N/A` / `—` rows — these are not
  walk-evidence, so they carry no stale env claim (the genuine code-gap / honesty
  rows, e.g. the `⏳ PENDING` cutover + `⏳ UNVERIFIED` jobs rows, stay intact).
- Keeps the legacy `TC-/SSO-/TOPO-/VC-` path for back-compat. **Env-agnostic** —
  no hardcoded `hwNNN`. Re-stamps the H1 header `(RESET <date> — pending <env>)`.

### `scripts/uat-drift-guard.py` (new — read-only)
- Exits **1** if any ledger file has a `✅`/`PASS` row that carries a **concrete
  proof artifact** (screenshot / `sessions/<date>` / `evidence/` link, or an
  `hwNNN-NN` screenshot id) referencing an `hwNNN` env that is **not** the current
  env. Current env resolves from `--env` → `$UAT_CURRENT_ENV` → the `UAT.md` H1
  `on \`hwNNN\`` token. A **pending/RESET** header has no concrete env, so any
  `✅`+`hwNNN` proof fails (a freshly-reset ledger must be evidence-free).
- `--self-test` runs **5 directions** (clean→0, stale→1, env-agnostic predecessor
  detection both ways, current-only→0, pending-header→1) on **synthetic
  `hw900`/`hw800`/`hw700`** labels — no real env hardcoded.
- **READ-ONLY** — never edits the ledger (verification stays read-only, memory L7/L8).

### `.github/workflows/uat-drift-guard.yaml` (new)
- On PR/push touching `docs/ledger/UAT.md`, `uat-walkthrough/**`, or either
  script: runs the self-test, then guards the live ledger. Hard-fail, `contents: read`.

## § Verification (all pass)

| Check | Result |
|---|---|
| `reset-uat.py hwTEST` clears N>0 on the current `UAT.md` (cp + diff) | **93 evidence cells across 11 files; 24 in `UAT.md`** (was **0** with the old matcher) — 48 changed lines in `UAT.md` |
| Genuine code-gap rows preserved | `⏳ PENDING` (cutover ×2) / `⏳ UNVERIFIED` (jobs) / `N/A` (newapi) untouched |
| `uat-drift-guard.py --self-test` | **ALL PASS** (exit 0), 5 directions |
| `git grep -n 'hw1[0-9][0-9]' scripts/reset-uat.py scripts/uat-drift-guard.py` | **EMPTY** (no hardcoded env) |
| `python3 -m py_compile` both scripts | OK |

## § Real drift the guard already surfaces on `main`

Run against the live `hw144` ledger, the guard fails with **22 violations** —
genuine fabricated-snapshot drift sitting in the repo today: walkthroughs
`3367-jobs.md`, `3378-organizations.md`, `3379-sovereignty.md`, `3380-robustness.md`
carry `✅` rows whose embedded screenshots / URLs reference predecessor envs
**hw139 / hw136 / hw133 / hw128** — never re-walked on hw144. This is the guard
working as designed; the fix is the **live re-walk on the current env** (the
evidence half of #3581) or `python3 scripts/reset-uat.py <env>` — **not** a ledger
edit here (that would violate the read-only-verification rule). The train
assembler reconciles this via the walk before/as this merges.

## § Adjacent surface (confirmed already fine — not touched)

`scripts/uat-sso-flip.py` (used by `sso-uat-flip.yaml`) is **already**
prose-format-aware (flips the `Now` column of the marker-delimited SSO table) — no
change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
