### PR TITLE
fix(jobs): granular human-readable /jobs names — derive DisplayName at the read chokepoint (Refs #3646)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/jobs/display.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/display.go
@@ -1,0 +1,260 @@
+// display.go — granular, human-readable Job display-name derivation
+// (issue #3646: "why I see non granular naming in
+// https://console.<fqdn>/jobs").
+//
+// # The problem this fixes
+//
+// Every leaf Job carries a URL-safe, prefix-jargon JobName ("install-
+// keycloak", "mutation-remove-region", "cron-openbao-snapshot-save",
+// "me-east-215-b-1:install-cilium"). The /jobs table renders
+// `displayName ?? jobName`, so any leaf whose producing bridge left
+// DisplayName empty surfaced the raw slug — exactly the "non granular
+// naming" the founder called out. The install + mutation bridges (the
+// dominant row volume) never set a DisplayName, and the reconciler
+// bridge set only the bare lowercase-hyphenated object name.
+//
+// # The fix — one chokepoint, structured fields
+//
+// DeriveLeafDisplayName turns a leaf Job's structured fields (Kind +
+// JobName + AppID + Region) into a human-readable label that names the
+// COMPONENT and the action's PURPOSE, not the opaque id:
+//
+//   - install-keycloak                     → "Install Keycloak"
+//   - me-east-215-b-1:install-cilium       → "Install Cilium (me-east-215-b-1)"
+//   - reconcile-flux-system                → "Reconcile Flux System"
+//   - cron-openbao-snapshot-save           → "Snapshot Save (cron)"… see note
+//   - mutation-remove-region               → "Remove Region"
+//   - reconciler-sso-bridge                → "SSO Bridge (reconciler)"
+//   - tofu-init (lifecycle, no DisplayName)→ "Tofu Init"
+//
+// It is invoked from Store.deriveTreeView's read-time back-fill — the
+// SAME single place that already back-fills the typed Kind — so every
+// wire row gets a granular name regardless of which bridge minted it
+// (and legacy persisted indexes are upgraded on read too). A bridge that
+// DOES set a friendly DisplayName (the cutover steps via
+// cutoverStepDisplay, the Phase-0 lifecycle via provisionerLifecycleDisplay,
+// every group) keeps its own label — the back-fill only ever fills an
+// EMPTY DisplayName, never overrides.
+package jobs
+
+import "strings"
+
+// acronyms maps a lower-cased slug token onto its canonical display
+// casing. Naive title-case would render "api"→"Api", "sso"→"Sso",
+// "vcluster"→"Vcluster" — wrong for the OpenOva vocabulary. This table
+// fixes the load-bearing acronyms + product names the /jobs surface
+// actually shows so a row reads the way the operator says it out loud.
+var acronyms = map[string]string{
+	"api":      "API",
+	"sso":      "SSO",
+	"oidc":     "OIDC",
+	"idp":      "IdP",
+	"dns":      "DNS",
+	"db":       "DB",
+	"pg":       "PG",
+	"cnpg":     "CNPG",
+	"cpu":      "CPU",
+	"tls":      "TLS",
+	"ssl":      "SSL",
+	"jwt":      "JWT",
+	"url":      "URL",
+	"vcluster": "vCluster",
+	"openbao":  "OpenBao",
+	"ferretdb": "FerretDB",
+	"powerdns": "PowerDNS",
+	"netbird":  "NetBird",
+	"crd":      "CRD",
+	"crds":     "CRDs",
+	"xrc":      "XRC",
+	"tofu":     "Tofu",
+	"wal":      "WAL",
+	"s3":       "S3",
+	"ip":       "IP",
+	"eip":      "EIP",
+	"ca":       "CA",
+	"ha":       "HA",
+	"bcp":      "BCP",
+	"dr":       "DR",
+}
+
+// humanizeToken renders one hyphen-separated slug token in its canonical
+// display casing: an acronym from the table verbatim, otherwise the token
+// with its first letter upper-cased ("keycloak" → "Keycloak"). A token
+// that already contains an upper-case letter (a region key segment, a
+// proper noun already cased upstream) is left untouched so we never
+// mangle e.g. "me-east-215-b-1".
+func humanizeToken(tok string) string {
+	if tok == "" {
+		return ""
+	}
+	if disp, ok := acronyms[strings.ToLower(tok)]; ok {
+		return disp
+	}
+	// Leave a token that already carries internal casing alone.
+	for _, r := range tok {
+		if r >= 'A' && r <= 'Z' {
+			return tok
+		}
+	}
+	return strings.ToUpper(tok[:1]) + tok[1:]
+}
+
+// HumanizeSlug turns a hyphen-separated slug into a space-separated,
+// acronym-aware Title Case label: "cert-manager" → "Cert Manager",
+// "catalyst-api" → "Catalyst API", "openbao-snapshot-save" → "OpenBao
+// Snapshot Save". A slug carrying a non-hyphen separator the bridges use
+// for sub-segments (a ":" region prefix, a "/" multi-region tail) is
+// caller-stripped before this is reached.
+func HumanizeSlug(slug string) string {
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return ""
+	}
+	parts := strings.Split(slug, "-")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		out = append(out, humanizeToken(p))
+	}
+	return strings.Join(out, " ")
+}
+
+// kindActionVerb maps a leaf Kind onto the action verb that prefixes its
+// display label, so a row reads as an action on a component ("Install
+// Cilium", "Reconcile Flux System") rather than a bare noun. install +
+// reconcile + step verbs read naturally as a prefix; cron / task /
+// reconciler / lifecycle carry their kind as a trailing qualifier
+// instead (handled in DeriveLeafDisplayName) because "Cron Openbao
+// Snapshot Save" reads worse than "OpenBao Snapshot Save (cron)".
+var kindActionVerb = map[string]string{
+	KindInstall:   "Install",
+	KindReconcile: "Reconcile",
+}
+
+// stripRegionPrefix splits a multi-region component / jobName of the form
+// "<region>:<rest>" into its region key and the bare remainder. A value
+// with no ":" is a primary-region row → ("", value). Mirrors
+// RegionFromComponent's "everything before the first colon" contract.
+func stripRegionPrefix(s string) (region, rest string) {
+	if i := strings.IndexByte(s, ':'); i > 0 {
+		return s[:i], s[i+1:]
+	}
+	return "", s
+}
+
+// DeriveLeafDisplayName produces a granular, human-readable label for a
+// leaf Job that has no bridge-supplied DisplayName. It NEVER returns a
+// raw slug: the worst case (an unrecognised lifecycle slug) is still
+// humanized to Title Case. Group Jobs are handled by the caller (their
+// DisplayName is always bridge-supplied); passing one here falls through
+// to a humanized JobName, which is harmless.
+//
+// The region (for a multi-region secondary install row) is surfaced as a
+// trailing "(<region>)" qualifier so two same-chart rows in different
+// regions are distinguishable at a glance — the dedicated Region column
+// shows it too, but the name must stand alone in a search result / a
+// narrow viewport where the column is scrolled off.
+func DeriveLeafDisplayName(j Job) string {
+	kind := j.Kind
+	if kind == "" {
+		kind = kindForLeaf(j.JobName)
+	}
+
+	// Region qualifier: prefer the first-class Region field; fall back to
+	// the AppID / JobName "<region>:" prefix the multi-region fan-out
+	// encodes.
+	region := j.Region
+	if region == "" {
+		if r, _ := stripRegionPrefix(j.AppID); r != "" {
+			region = r
+		} else if r, _ := stripRegionPrefix(strings.TrimPrefix(j.JobName, JobNamePrefix)); r != "" {
+			region = r
+		}
+	}
+	suffix := ""
+	if region != "" {
+		suffix = " (" + region + ")"
+	}
+
+	switch kind {
+	case KindInstall:
+		// Component = AppID without any region prefix; fall back to the
+		// JobName with "install-" + region prefix stripped.
+		_, comp := stripRegionPrefix(j.AppID)
+		if comp == "" {
+			_, comp = stripRegionPrefix(strings.TrimPrefix(j.JobName, JobNamePrefix))
+		}
+		return joinVerb(kindActionVerb[KindInstall], HumanizeSlug(comp)) + suffix
+
+	case KindReconcile:
+		name := strings.TrimPrefix(j.JobName, ReconcileJobPrefix)
+		if j.AppID != "" {
+			name = j.AppID
+		}
+		return joinVerb(kindActionVerb[KindReconcile], HumanizeSlug(name)) + suffix
+
+	case KindStep:
+		// "<group>-step-<slug>" → "<Group> · <Step>". A bridge-supplied
+		// DisplayName normally pre-empts this; here for completeness +
+		// legacy rows.
+		group, rest := splitStep(j.JobName)
+		if rest == "" {
+			return HumanizeSlug(j.JobName)
+		}
+		if group == "" {
+			return HumanizeSlug(rest)
+		}
+		return HumanizeSlug(group) + " · " + HumanizeSlug(rest)
+
+	case KindMutation:
+		// "mutation-<verb>-<kind>[-<slug>]" → "<Verb> <Kind> [<slug>]".
+		// The verb + kind read as the operator's action; a trailing slug
+		// (the target id) is appended verbatim-humanized to disambiguate.
+		rest := strings.TrimPrefix(j.JobName, MutationJobNamePrefix)
+		return HumanizeSlug(rest)
+
+	case KindCron:
+		return HumanizeSlug(strings.TrimPrefix(j.JobName, CronJobPrefix)) + " (cron)"
+
+	case KindTask:
+		return HumanizeSlug(strings.TrimPrefix(j.JobName, TaskJobPrefix)) + " (task)"
+
+	case KindReconciler:
+		return HumanizeSlug(strings.TrimPrefix(j.JobName, ReconcilerJobPrefix)) + " (reconciler)"
+
+	default:
+		// Phase-0 lifecycle slugs (tofu-init, …) + any other leaf. A
+		// bridge-supplied lifecycle DisplayName ("Terraform Init") normally
+		// pre-empts this; the bare humanized slug is the floor.
+		return HumanizeSlug(j.JobName) + suffix
+	}
+}
+
+// joinVerb prefixes a verb onto a humanized component name, tolerating an
+// empty component (returns just the verb) so a malformed row never yields
+// a dangling "Install ".
+func joinVerb(verb, name string) string {
+	verb = strings.TrimSpace(verb)
+	name = strings.TrimSpace(name)
+	switch {
+	case verb == "":
+		return name
+	case name == "":
+		return verb
+	default:
+		return verb + " " + name
+	}
+}
+
+// splitStep splits an activity step JobName "<group>-step-<slug>" into its
+// group slug and step slug. A name without the "-step-" infix returns
+// ("", name) so the caller humanizes it whole.
+func splitStep(jobName string) (group, step string) {
+	i := strings.Index(jobName, ActivityStepInfix)
+	if i < 0 {
+		return "", jobName
+	}
+	return jobName[:i], jobName[i+len(ActivityStepInfix):]
+}

--- a/products/catalyst/bootstrap/api/internal/jobs/display_test.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/display_test.go
@@ -1,0 +1,230 @@
+// display_test.go — locks in the granular, human-readable Job naming
+// (issue #3646: "why I see non granular naming in
+// https://console.<fqdn>/jobs"). The founder's exact complaint is the
+// raw slug ("install-keycloak", "mutation-remove-region",
+// "cron-openbao-snapshot-save") surfacing in the /jobs Name column; these
+// tests assert every leaf carries a friendly DisplayName instead.
+package jobs
+
+import "testing"
+
+func TestHumanizeSlug(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"keycloak", "Keycloak"},
+		{"cert-manager", "Cert Manager"},
+		{"catalyst-api", "Catalyst API"},
+		{"sso-bridge", "SSO Bridge"},
+		{"openbao-snapshot-save", "OpenBao Snapshot Save"},
+		{"vcluster-registry-pivot", "vCluster Registry Pivot"},
+		{"flux-system", "Flux System"},
+		{"powerdns", "PowerDNS"},
+		{"external-dns", "External DNS"},
+		// A token already carrying internal casing (a region segment) is
+		// left untouched rather than mangled.
+		{"me-east-215-b-1", "Me East 215 B 1"},
+	}
+	for _, c := range cases {
+		if got := HumanizeSlug(c.in); got != c.want {
+			t.Errorf("HumanizeSlug(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDeriveLeafDisplayName(t *testing.T) {
+	cases := []struct {
+		name string
+		job  Job
+		want string
+	}{
+		{
+			name: "install leaf — the dominant non-granular case",
+			job:  Job{JobName: "install-keycloak", AppID: "keycloak", Kind: KindInstall},
+			want: "Install Keycloak",
+		},
+		{
+			name: "install leaf acronym component",
+			job:  Job{JobName: "install-catalyst-api", AppID: "catalyst-api", Kind: KindInstall},
+			want: "Install Catalyst API",
+		},
+		{
+			name: "secondary-region install via first-class Region field",
+			job:  Job{JobName: "install-cilium", AppID: "cilium", Region: "me-east-215-b-1", Kind: KindInstall},
+			want: "Install Cilium (me-east-215-b-1)",
+		},
+		{
+			name: "secondary-region install via region-prefixed appId (no Region field)",
+			job:  Job{JobName: "install-me-east-215-b-1:harbor", AppID: "me-east-215-b-1:harbor", Kind: KindInstall},
+			want: "Install Harbor (me-east-215-b-1)",
+		},
+		{
+			name: "mutation leaf — verb + kind + target",
+			job:  Job{JobName: "mutation-remove-region", AppID: "region", Kind: KindMutation},
+			want: "Remove Region",
+		},
+		{
+			name: "mutation leaf with slug target",
+			job:  Job{JobName: "mutation-scale-node-pool-pool-a", AppID: "node-pool", Kind: KindMutation},
+			want: "Scale Node Pool Pool A",
+		},
+		{
+			name: "reconcile leaf",
+			job:  Job{JobName: "reconcile-flux-system", AppID: "flux-system", Kind: KindReconcile},
+			want: "Reconcile Flux System",
+		},
+		{
+			name: "cron leaf",
+			job:  Job{JobName: "cron-openbao-snapshot-save", AppID: "openbao-snapshot-save", Kind: KindCron},
+			want: "OpenBao Snapshot Save (cron)",
+		},
+		{
+			name: "task leaf",
+			job:  Job{JobName: "task-gitea-sso-configure", AppID: "gitea-sso-configure", Kind: KindTask},
+			want: "Gitea SSO Configure (task)",
+		},
+		{
+			name: "reconciler leaf",
+			job:  Job{JobName: "reconciler-sso-bridge", AppID: "sso-bridge", Kind: KindReconciler},
+			want: "SSO Bridge (reconciler)",
+		},
+		{
+			name: "step leaf — group · step",
+			job:  Job{JobName: "cutover-step-harbor-prewarm", Kind: KindStep},
+			want: "Cutover · Harbor Prewarm",
+		},
+		{
+			name: "lifecycle slug floor (no kind, inferred)",
+			job:  Job{JobName: "tofu-init"},
+			want: "Tofu Init",
+		},
+		{
+			name: "kind inferred from JobName when Kind empty (legacy row)",
+			job:  Job{JobName: "install-gitea", AppID: "gitea"},
+			want: "Install Gitea",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := DeriveLeafDisplayName(c.job); got != c.want {
+				t.Errorf("DeriveLeafDisplayName(%+v) = %q, want %q", c.job, got, c.want)
+			}
+		})
+	}
+}
+
+// TestDeriveLeafDisplayName_neverRawSlug is the founder-complaint guard:
+// no leaf may surface its raw "<prefix>-<slug>" id as the display label.
+// We assert the derived name contains a space (humanized) and is not byte-
+// identical to the JobName for every representative leaf shape.
+func TestDeriveLeafDisplayName_neverRawSlug(t *testing.T) {
+	jobs := []Job{
+		{JobName: "install-keycloak", AppID: "keycloak", Kind: KindInstall},
+		{JobName: "mutation-remove-region", AppID: "region", Kind: KindMutation},
+		{JobName: "cron-openbao-snapshot-save", AppID: "openbao-snapshot-save", Kind: KindCron},
+		{JobName: "reconcile-flux-system", AppID: "flux-system", Kind: KindReconcile},
+		{JobName: "task-some-batch", AppID: "some-batch", Kind: KindTask},
+		{JobName: "reconciler-sso-bridge", AppID: "sso-bridge", Kind: KindReconciler},
+	}
+	for _, j := range jobs {
+		got := DeriveLeafDisplayName(j)
+		if got == j.JobName {
+			t.Errorf("DeriveLeafDisplayName(%q) returned the raw slug unchanged", j.JobName)
+		}
+		if got == "" {
+			t.Errorf("DeriveLeafDisplayName(%q) returned empty", j.JobName)
+		}
+	}
+}
+
+// TestDeriveTreeView_backfillsLeafDisplayName proves the END-TO-END wire
+// contract: a leaf written by a bridge that left DisplayName empty (the
+// install + mutation bridges) gets a granular DisplayName at read time,
+// while a bridge-supplied friendly DisplayName + every group is preserved
+// untouched (never overridden).
+func TestDeriveTreeView_backfillsLeafDisplayName(t *testing.T) {
+	dep := "dep-x"
+	in := []Job{
+		// install leaf — bridge left DisplayName empty.
+		{
+			ID:           JobID(dep, "install-keycloak"),
+			DeploymentID: dep,
+			JobName:      "install-keycloak",
+			AppID:        "keycloak",
+			Type:         JobTypeInstall,
+			ParentID:     JobID(dep, GroupBootstrapKit),
+			Status:       StatusSucceeded,
+		},
+		// mutation leaf — bridge left DisplayName empty.
+		{
+			ID:           JobID(dep, "mutation-remove-region"),
+			DeploymentID: dep,
+			JobName:      "mutation-remove-region",
+			AppID:        "region",
+			Type:         JobTypeInstall,
+			ParentID:     JobID(dep, GroupDay2Mutations),
+			Status:       StatusRunning,
+		},
+		// group — friendly DisplayName must be preserved, not derived.
+		{
+			ID:           JobID(dep, GroupBootstrapKit),
+			DeploymentID: dep,
+			JobName:      GroupBootstrapKit,
+			DisplayName:  GroupBootstrapKitDisplay,
+			Type:         JobTypeGroup,
+			Status:       StatusPending,
+		},
+		// lifecycle leaf with a bridge-supplied friendly name — preserved.
+		{
+			ID:           JobID(dep, PhaseTofuInit),
+			DeploymentID: dep,
+			JobName:      PhaseTofuInit,
+			DisplayName:  "Terraform Init",
+			Type:         JobTypeInstall,
+			ParentID:     JobID(dep, GroupProvisioner),
+			Status:       StatusSucceeded,
+		},
+	}
+	out := deriveTreeView(in)
+	get := func(jobName string) Job {
+		t.Helper()
+		for _, j := range out {
+			if j.JobName == jobName {
+				return j
+			}
+		}
+		t.Fatalf("job %q not found in derived output", jobName)
+		return Job{}
+	}
+
+	if got := get("install-keycloak").DisplayName; got != "Install Keycloak" {
+		t.Errorf("install leaf DisplayName = %q, want %q", got, "Install Keycloak")
+	}
+	if got := get("mutation-remove-region").DisplayName; got != "Remove Region" {
+		t.Errorf("mutation leaf DisplayName = %q, want %q", got, "Remove Region")
+	}
+	if got := get(GroupBootstrapKit).DisplayName; got != GroupBootstrapKitDisplay {
+		t.Errorf("group DisplayName = %q, want %q (must be preserved)", got, GroupBootstrapKitDisplay)
+	}
+	if got := get(PhaseTofuInit).DisplayName; got != "Terraform Init" {
+		t.Errorf("lifecycle DisplayName = %q, want %q (must be preserved)", got, "Terraform Init")
+	}
+}
+
+// TestReconcilerDisplay locks the granular reconciler-leaf labels the
+// reconciler bridge stamps at write time (so the source-set value matches
+// the read-time floor).
+func TestReconcilerDisplay(t *testing.T) {
+	cases := []struct {
+		obsKind, name, want string
+	}{
+		{ObsKindCron, "openbao-snapshot-save", "OpenBao Snapshot Save (cron)"},
+		{ObsKindReconcile, "flux-system", "Reconcile Flux System"},
+		{ObsKindTask, "gitea-sso-configure", "Gitea SSO Configure (task)"},
+		{ObsKindReconciler, "sso-bridge", "SSO Bridge (reconciler)"},
+	}
+	for _, c := range cases {
+		if got := reconcilerDisplay(c.obsKind, c.name); got != c.want {
+			t.Errorf("reconcilerDisplay(%q,%q) = %q, want %q", c.obsKind, c.name, got, c.want)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/jobs/reconciler_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/reconciler_bridge.go
@@ -392,11 +392,27 @@ func (b *Bridge) seedHealthExecutionLocked(jobName, health, message string, at t
 	}})
 }
 
-// reconcilerDisplay returns a friendly label for a reconciler leaf
-// ("cron-openbao-snapshot-save" → "openbao-snapshot-save"), letting the
-// kind column carry the type so the name stays the bare object name.
-func reconcilerDisplay(kind, name string) string {
-	return name
+// reconcilerDisplay returns a granular, human-readable label for a
+// reconciler leaf — the bare K8s object name humanized + qualified by its
+// kind so the /jobs Name column reads the way the operator says it out
+// loud (issue #3646: "non granular naming"). It builds the SAME label
+// Store.deriveTreeView would back-fill, so the source-set value and the
+// read-time floor agree:
+//
+//   - cron       "openbao-snapshot-save" → "OpenBao Snapshot Save (cron)"
+//   - reconcile  "flux-system"           → "Reconcile Flux System"
+//   - task       "gitea-sso-configure"   → "Gitea SSO Configure (task)"
+//   - reconciler "sso-bridge"            → "SSO Bridge (reconciler)"
+//
+// Previously this returned the bare lowercase-hyphenated object name,
+// which the founder reads as non-granular.
+func reconcilerDisplay(obsKind, name string) string {
+	return DeriveLeafDisplayName(Job{
+		JobName: reconcilerLeafJobName(obsKind, name),
+		AppID:   name,
+		Kind:    reconcilerLeafKind(obsKind),
+		Type:    JobTypeInstall,
+	})
 }
 
 // healthStatusFromObs maps a helmwatch.ObsHealth* string onto the jobs

--- a/products/catalyst/bootstrap/api/internal/jobs/store.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/store.go
@@ -645,6 +645,20 @@ func deriveTreeView(jobs []Job) []Job {
 				jobs[i].Kind = kindForLeaf(jobs[i].JobName)
 			}
 		}
+		// Back-fill a granular, human-readable DisplayName for any LEAF
+		// whose producing bridge left it empty (issue #3646: "non granular
+		// naming"). The install + mutation bridges never set one, so the FE
+		// rendered the raw "install-<chart>" / "mutation-<verb>-<kind>"
+		// slug. DeriveLeafDisplayName names the component + action's purpose
+		// ("Install Keycloak", "Remove Region") from the structured fields.
+		// This is the SAME single chokepoint that back-fills Kind, so the
+		// granular name reaches every row regardless of which bridge minted
+		// it (and upgrades legacy persisted indexes on read). A bridge that
+		// DID set a friendly DisplayName (cutover steps, lifecycle phases,
+		// groups) keeps it — we only ever fill an EMPTY one, never override.
+		if jobs[i].DisplayName == "" && jobs[i].Type != JobTypeGroup {
+			jobs[i].DisplayName = DeriveLeafDisplayName(jobs[i])
+		}
 	}
 	// Build adjacency: parent ID → list of child indexes (children of
 	// the indexed parent's ID).


### PR DESCRIPTION
## Founder complaint (verbatim)

> "why I see non granular naming in https://console.<fqdn>/jobs"

## Verdict — STILL NON-GRANULAR after #3701 → fixed here

#3701 added the typed `Kind` field + a Kind chip column, but the **Name** column still rendered raw slugs for the dominant row volume. The FE renders `displayName ?? jobName`, and:

- **Install leaves** (every `bp-<chart>` HelmRelease — the bulk of /jobs) set **no** DisplayName → `install-keycloak`, `install-cnpg`, `me-east-215-b-1:install-cilium`.
- **Mutation leaves** set **no** DisplayName → `mutation-remove-region` (even though Verb/Kind/Slug/Action are all available).
- **Reconciler/cron/task/reconcile leaves** set only the **bare** lowercase-hyphenated object name → `openbao-snapshot-save`, `flux-system`.

(Cutover steps, Phase-0 lifecycle, and groups were already friendly — those are preserved untouched.)

## Fix — one chokepoint, structured fields

- **New `jobs/display.go`**: `DeriveLeafDisplayName` turns a leaf's `Kind` + `JobName` + `AppID` + `Region` into an acronym-aware, human-readable label naming the component + the action's purpose:

  | JobName (slug) | Name (now) |
  |---|---|
  | `install-keycloak` | **Install Keycloak** |
  | `me-east-215-b-1:install-cilium` | **Install Cilium (me-east-215-b-1)** |
  | `mutation-remove-region` | **Remove Region** |
  | `reconcile-flux-system` | **Reconcile Flux System** |
  | `cron-openbao-snapshot-save` | **OpenBao Snapshot Save (cron)** |
  | `reconciler-sso-bridge` | **SSO Bridge (reconciler)** |
  | `cutover-step-harbor-prewarm` | **Cutover · Harbor Prewarm** |

  `HumanizeSlug` carries the OpenOva acronym vocabulary (API, SSO, OIDC, CNPG, vCluster, OpenBao, PowerDNS, NetBird, …) so a row reads the way the operator says it out loud.

- **`store.go` `deriveTreeView`** back-fills an **empty** leaf DisplayName at read time — the **same single place** that already back-fills the typed `Kind`. So the granular name reaches every row regardless of which bridge minted it, and **legacy persisted indexes are upgraded on read**. A bridge-supplied friendly DisplayName (cutover steps, lifecycle "Terraform Init", every group) is **preserved, never overridden** — the back-fill only ever fills an empty one.

- **`reconciler_bridge.go` `reconcilerDisplay`** now humanizes the bare object name (was returning the raw slug) so the source-set value matches the read-time floor.

## FE unchanged

Zero FE files touched. The reducer first-paint tail was already friendly (`Install <app>`, `TOFU_PHASE_LABELS`); the non-granular names came **exclusively** from the backend `/jobs` list, now fixed. The existing, already-tested `displayName ?? jobName` render path (JobsTable.tsx) surfaces the populated field.

## Keeps #3701 intact

The typed `Kind` + faithful-status + de-merge + retry work is untouched. This is purely the Name-column granularity the founder asked for, layered on the same read-time back-fill chokepoint.

## Gates

- `go build ./...` + `go vet ./internal/jobs/...` green.
- `go test -race ./internal/jobs/...` green — `display_test.go` locks the founder-complaint shapes both directly and **end-to-end through `deriveTreeView`** (install + mutation leaves get granular names; group + lifecycle friendly names preserved).
- `go test -race ./internal/handler/... ./internal/helmwatch/...` green.
- FE: no files touched → typecheck/vitest status identical to `main`.

DO NOT MERGE — next train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)