### PR TITLE
fix(provisioner): nat-eip-preflight cred-key mismatch silently disabled poisoned-EIP self-heal (PROV-BLOCKING)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/providers/huawei/preflight_eip.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/preflight_eip.go
@@ -70,12 +70,12 @@ func blocklist() map[string]bool {
 }
 
 type hwSNATRule struct {
-	ID                  string `json:"id"`
-	NATGatewayID        string `json:"nat_gateway_id"`
-	NetworkID           string `json:"network_id"`
-	FloatingIPID        string `json:"floating_ip_id"`
-	FloatingIPAddress   string `json:"floating_ip_address"`
-	Status              string `json:"status"`
+	ID                string `json:"id"`
+	NATGatewayID      string `json:"nat_gateway_id"`
+	NetworkID         string `json:"network_id"`
+	FloatingIPID      string `json:"floating_ip_id"`
+	FloatingIPAddress string `json:"floating_ip_address"`
+	Status            string `json:"status"`
 }
 
 // RotateBlocklistedNATEIPs runs the pre-flight check for one deployment.
@@ -89,21 +89,57 @@ func RotateBlocklistedNATEIPs(ctx context.Context, _provider, deploymentID, sove
 	if progress == nil {
 		progress = func(string) {}
 	}
-	creds := providers.ProviderCreds{Raw: map[string]string{
-		"huawei_access_key": accessKey,
-		"huawei_secret_key": secretKey,
-		"huawei_project_id": projectID,
-		"huawei_region":     region,
-	}}
-	hw, err := credsFromProviderCreds(creds)
-	if err != nil {
-		return 0, fmt.Errorf("creds: %w", err)
+	// Wave 5.156 (#3716) — build hwCreds DIRECTLY from the AK/SK/project
+	// args, mirroring (*Provider).VPCQuota (provider.go). The previous
+	// implementation round-tripped through a providers.ProviderCreds{Raw}
+	// map keyed with the OpenTofu *tfvars* names (`huawei_access_key`
+	// etc.) and then handed it to credsFromProviderCreds(), which reads
+	// the BARE signing-layer keys (`access_key`/`secret_key`/`project_id`,
+	// see provider_test.go). The key-name mismatch meant every lookup
+	// returned "" → credsFromProviderCreds() failed with
+	// "huawei: access_key is required" on EVERY Huawei prov, so the
+	// poisoned-EIP self-heal NEVER ran. The access_key was always
+	// present (handler stamp deployments.go:1130 → req.HuaweiAccessKey,
+	// the same field the working VPCQuota pre-flight consumes); it was
+	// simply stuffed into the creds bag under a key credsFromProviderCreds
+	// doesn't read. There was no unit test exercising this path, which is
+	// how the mismatch shipped silently.
+	hw := hwCreds{AccessKey: accessKey, SecretKey: secretKey, ProjectID: projectID}
+	if hw.AccessKey == "" {
+		return 0, fmt.Errorf("huawei: access_key is required (CATALYST_HUAWEI_ACCESS_KEY missing on catalyst-api — see secret huawei-operator-creds)")
+	}
+	if hw.SecretKey == "" {
+		return 0, fmt.Errorf("huawei: secret_key is required (CATALYST_HUAWEI_SECRET_KEY missing on catalyst-api)")
+	}
+	if hw.ProjectID == "" {
+		return 0, fmt.Errorf("huawei: project_id is required (CATALYST_HUAWEI_PROJECT_ID missing on catalyst-api)")
 	}
 	if region == "" {
-		region = regionFromCreds(creds)
+		region = defaultRegion
 	}
-	client := httpClientFor(creds)
+	// httpClientFor only consumes the `insecure` knob (default true for
+	// on-prem HCS); the signing creds come from `hw` above, not the map.
+	client := httpClientFor(providers.ProviderCreds{Raw: map[string]string{"region": region}})
 	bl := blocklist()
+	// Wave 5.156 (#3716) — aggressive pool-drain mode. The static seed
+	// blocklist only knows .48/.14; when the Huawei free-pool gets
+	// poisoned by repeated wipe→re-prov cycles (released EIPs stay
+	// reputation-blocklisted for Contabo 45.151.123.0/24 for hours), a
+	// FRESH allocation can draw a poisoned IP that isn't in the seed
+	// list — exactly the hw151–154 wedge (0 HRs, kubeconfig never PUT,
+	// no egress to harbor.openova.io 45.151.123.50). Since catalyst-api
+	// runs on Contabo it cannot reachability-probe a Huawei EIP's egress
+	// directly (the chicken-and-egg the file header documents), so the
+	// operator escape hatch is CATALYST_HUAWEI_NAT_EIP_ROTATE_ALL=true:
+	// when set, treat EVERY deployment-owned SNAT EIP as rotate-worthy.
+	// allocateCleanEIP already HOLDS rejected EIPs (drains them from the
+	// pool) before returning a clean one, so flipping this forces a
+	// re-roll that walks past the poisoned addresses and self-heals the
+	// pool. Default (unset) preserves the seed+env blocklist behaviour.
+	rotateAll := strings.EqualFold(strings.TrimSpace(os.Getenv("CATALYST_HUAWEI_NAT_EIP_ROTATE_ALL")), "true")
+	if rotateAll {
+		progress("Wave 5.156 (#3716): CATALYST_HUAWEI_NAT_EIP_ROTATE_ALL=true — re-rolling every deployment-owned SNAT EIP to drain a poisoned free-pool")
+	}
 
 	// List SNAT rules
 	url := fmt.Sprintf("%s/v2/%s/snat_rules", endpointFor("nat", region), hw.ProjectID)
@@ -123,7 +159,12 @@ func RotateBlocklistedNATEIPs(ctx context.Context, _provider, deploymentID, sove
 
 	rotated := 0
 	for _, r := range decoded.SNATRules {
-		if !bl[r.FloatingIPAddress] {
+		seedBlocked := bl[r.FloatingIPAddress]
+		// Wave 5.156 (#3716): in rotateAll mode every deployment-owned
+		// SNAT EIP is rotate-worthy even if absent from the seed/env
+		// blocklist (a freshly-poisoned free-pool address). Otherwise the
+		// historical behaviour holds: only static-blocklisted EIPs rotate.
+		if !seedBlocked && !rotateAll {
 			continue
 		}
 		// Only rotate SNAT rules whose NAT gateway is tagged for this
@@ -133,8 +174,17 @@ func RotateBlocklistedNATEIPs(ctx context.Context, _provider, deploymentID, sove
 		if !natGatewayBelongsToDeployment(ctx, client, hw, region, r.NATGatewayID, deploymentID) {
 			continue
 		}
-		progress(fmt.Sprintf("Wave 5.93: SNAT %s EIP %s is blocklisted, rotating",
-			r.ID[:8], r.FloatingIPAddress))
+		if seedBlocked {
+			progress(fmt.Sprintf("Wave 5.93: SNAT %s EIP %s is blocklisted, rotating",
+				r.ID[:8], r.FloatingIPAddress))
+		} else {
+			progress(fmt.Sprintf("Wave 5.156: SNAT %s EIP %s force-rotating (ROTATE_ALL pool-drain)",
+				r.ID[:8], r.FloatingIPAddress))
+		}
+		// Add the current EIP to the working blocklist so allocateCleanEIP
+		// never hands the same poisoned address straight back (Huawei
+		// recycles a just-released EIP into the very next allocate()).
+		bl[r.FloatingIPAddress] = true
 		newEIPID, newAddr, held, err := allocateCleanEIP(ctx, client, hw, region, deploymentID, bl, 8)
 		if err != nil {
 			return rotated, fmt.Errorf("allocate clean EIP: %w", err)

--- a/products/catalyst/bootstrap/api/internal/providers/huawei/preflight_eip_test.go
+++ b/products/catalyst/bootstrap/api/internal/providers/huawei/preflight_eip_test.go
@@ -1,0 +1,89 @@
+package huawei
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRotateBlocklistedNATEIPs_PassesAccessKeyThrough is the regression
+// guard for #3716. The original RotateBlocklistedNATEIPs built a
+// providers.ProviderCreds{Raw} map keyed with the OpenTofu *tfvars*
+// names (`huawei_access_key` etc.) and handed it to
+// credsFromProviderCreds(), which reads the BARE signing keys
+// (`access_key`/`secret_key`/`project_id`). The key-name mismatch made
+// the function fail with "huawei: access_key is required" on EVERY
+// Huawei prov — even when a valid access_key WAS supplied — so the
+// poisoned-EIP self-heal never ran and hw151–154 wedged with no egress
+// to harbor.openova.io.
+//
+// We cannot point endpointFor() at an httptest server without a wider
+// refactor, so we assert the contract at the creds boundary:
+//   - a SUPPLIED access_key must NOT yield "access_key is required"
+//     (the call proceeds to the HTTP layer and fails there on DNS/dial,
+//     which is a DIFFERENT error) — this is exactly what the bug broke;
+//   - an EMPTY access_key MUST yield "access_key is required".
+func TestRotateBlocklistedNATEIPs_PassesAccessKeyThrough(t *testing.T) {
+	// Short ctx so the real signed request to nat.<region>.kom4dc
+	// .nationalcloud.om (which does not resolve from CI) fails fast
+	// instead of hanging on the httpTimeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	t.Run("supplied access_key is not reported missing", func(t *testing.T) {
+		_, err := RotateBlocklistedNATEIPs(ctx, "huawei", "deadbeefcafef00d", "t99.omani.works",
+			"AKIA-test-key", "secret-key-of-decent-length-32chrs", "0123456789abcdef0123456789abcdef",
+			"me-east-215", nil)
+		if err == nil {
+			// A nil error would mean the HTTP call somehow succeeded — not
+			// expected from CI, but it definitively proves the creds were
+			// accepted, so it satisfies the regression guard.
+			return
+		}
+		if strings.Contains(err.Error(), "access_key is required") {
+			t.Fatalf("#3716 regression: valid access_key reported as missing — creds wiring broken: %v", err)
+		}
+		if strings.Contains(err.Error(), "secret_key is required") ||
+			strings.Contains(err.Error(), "project_id is required") {
+			t.Fatalf("#3716 regression: valid creds reported as missing: %v", err)
+		}
+	})
+
+	t.Run("empty access_key fails closed", func(t *testing.T) {
+		_, err := RotateBlocklistedNATEIPs(ctx, "huawei", "deadbeefcafef00d", "t99.omani.works",
+			"", "secret-key", "project-id", "me-east-215", nil)
+		if err == nil || !strings.Contains(err.Error(), "access_key is required") {
+			t.Fatalf("empty access_key must fail with 'access_key is required', got: %v", err)
+		}
+	})
+
+	t.Run("empty secret_key fails closed", func(t *testing.T) {
+		_, err := RotateBlocklistedNATEIPs(ctx, "huawei", "deadbeefcafef00d", "t99.omani.works",
+			"AKIA-test-key", "", "project-id", "me-east-215", nil)
+		if err == nil || !strings.Contains(err.Error(), "secret_key is required") {
+			t.Fatalf("empty secret_key must fail with 'secret_key is required', got: %v", err)
+		}
+	})
+}
+
+// TestPreflightBlocklist_SeedAndEnvMerge guards the blocklist() helper —
+// the seed addresses are always present and CATALYST_HUAWEI_NAT_EIP_BLOCKLIST
+// extends (never replaces) them. The poisoned-pool self-heal leans on
+// operators being able to add freshly-discovered bad EIPs without a code
+// change.
+func TestPreflightBlocklist_SeedAndEnvMerge(t *testing.T) {
+	for _, seed := range []string{"212.72.24.48", "212.72.24.14"} {
+		if !blocklist()[seed] {
+			t.Fatalf("seed blocklist missing %s", seed)
+		}
+	}
+
+	t.Setenv("CATALYST_HUAWEI_NAT_EIP_BLOCKLIST", " 45.151.123.77 , 45.151.123.88 ")
+	bl := blocklist()
+	for _, want := range []string{"212.72.24.48", "212.72.24.14", "45.151.123.77", "45.151.123.88"} {
+		if !bl[want] {
+			t.Fatalf("merged blocklist missing %s (got %v)", want, bl)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1473,6 +1473,22 @@ type Provisioner struct {
 	PDMBasicAuthUser string
 	PDMBasicAuthPass string
 
+	// HuaweiAccessKey / HuaweiSecretKey / HuaweiProjectID / HuaweiRegion —
+	// operator AK/SK for the Huawei (HCS kom4dc) provider, mounted from
+	// the `huawei-operator-creds` Secret as CATALYST_HUAWEI_ACCESS_KEY /
+	// _SECRET_KEY / _PROJECT_ID / _REGION. The handler stamps these onto
+	// each Request from the same envs before Validate() (deployments.go);
+	// these struct-held copies are the defense-in-depth backstop so
+	// Provision() can re-stamp them onto any Request that arrives with
+	// the `json:"-"` Huawei fields empty (#3716) — the same pattern as
+	// GHCRPullToken / HarborRobotToken above. Without this, the NAT-EIP
+	// pre-flight (which needs the AK/SK to rotate poisoned EIPs) silently
+	// no-ops whenever the per-Request creds aren't populated.
+	HuaweiAccessKey string
+	HuaweiSecretKey string
+	HuaweiProjectID string
+	HuaweiRegion    string
+
 	// TofuPluginCacheDir is the OpenTofu provider plugin cache directory
 	// (#3126). Set as TF_PLUGIN_CACHE_DIR on every `tofu` exec so the
 	// provider binaries (huaweicloud, hetznercloud, dynadot, ...) are
@@ -1534,6 +1550,14 @@ func New() *Provisioner {
 		PowerDNSAPIKey:     os.Getenv("CATALYST_POWERDNS_API_KEY"),
 		PDMBasicAuthUser:   os.Getenv("CATALYST_PDM_BASIC_AUTH_USER"),
 		PDMBasicAuthPass:   os.Getenv("CATALYST_PDM_BASIC_AUTH_PASS"),
+		// #3716 — Huawei operator AK/SK backstop (see field docs). Read
+		// once at startup from the huawei-operator-creds-projected envs so
+		// the NAT-EIP pre-flight always has signing creds even if a Request
+		// arrives with the json:"-" Huawei fields empty.
+		HuaweiAccessKey: os.Getenv("CATALYST_HUAWEI_ACCESS_KEY"),
+		HuaweiSecretKey: os.Getenv("CATALYST_HUAWEI_SECRET_KEY"),
+		HuaweiProjectID: os.Getenv("CATALYST_HUAWEI_PROJECT_ID"),
+		HuaweiRegion:    os.Getenv("CATALYST_HUAWEI_REGION"),
 	}
 }
 
@@ -1604,6 +1628,29 @@ func (p *Provisioner) Provision(ctx context.Context, req Request, events chan<- 
 	}
 	if req.PDMBasicAuthPass == "" {
 		req.PDMBasicAuthPass = p.PDMBasicAuthPass
+	}
+	// #3716 — backstop the Huawei AK/SK from the Provisioner (loaded once
+	// from CATALYST_HUAWEI_* at New()) onto the Request, mirroring the
+	// GHCR/Harbor pattern above. The handler already stamps these from the
+	// same envs before Validate(); this guarantees the NAT-EIP pre-flight
+	// (which signs HCS API calls with these creds to rotate poisoned EIPs)
+	// still receives them on any code path that reaches Provision() with
+	// the json:"-" Huawei fields empty. Empty here = the pre-flight simply
+	// fails closed with a clear "access_key is required" instead of
+	// silently no-op'ing while a poisoned EIP blocks egress to harbor.
+	if req.Provider == "huawei" {
+		if strings.TrimSpace(req.HuaweiAccessKey) == "" {
+			req.HuaweiAccessKey = p.HuaweiAccessKey
+		}
+		if strings.TrimSpace(req.HuaweiSecretKey) == "" {
+			req.HuaweiSecretKey = p.HuaweiSecretKey
+		}
+		if strings.TrimSpace(req.HuaweiProjectID) == "" {
+			req.HuaweiProjectID = p.HuaweiProjectID
+		}
+		if strings.TrimSpace(req.HuaweiRegion) == "" {
+			req.HuaweiRegion = p.HuaweiRegion
+		}
 	}
 
 	if err := req.Validate(); err != nil {


### PR DESCRIPTION
## 🛑 READY FOR IMMEDIATE MERGE — PROV-BLOCKING

4 consecutive fresh Huawei Sovereigns (hw151–154) wedged **identically**: 0 HelmReleases in both regions, kubeconfig never PUT, the node can't egress to **harbor.openova.io (45.151.123.50 — IPv4-only, an EGRESS block, not DNS/IPv6)**. Root cause: the kom4dc Huawei EIP free-pool got poisoned (repeated wipe→re-prov released EIPs that stay reputation-blocklisted for Contabo `45.151.123.0/24` for hours); each fresh prov draws a poisoned EIP → no image pull, no kubeconfig PUT → wedge.

The `nat-eip-preflight` (Wave 5.93, #2445) is **meant** to detect + rotate blocklisted NAT EIPs right after `tofu apply`, breaking the poisoned-pool loop. It silently never ran.

## The wiring bug

| | file:line | key names |
|---|---|---|
| **Producer** `RotateBlocklistedNATEIPs` builds the creds bag | `internal/providers/huawei/preflight_eip.go:92-97` | `huawei_access_key` / `huawei_secret_key` / `huawei_project_id` / `huawei_region` (OpenTofu **tfvars** names) |
| **Consumer** `credsFromProviderCreds` reads them | `internal/providers/huawei/provider.go:129-144` | `access_key` / `secret_key` / `project_id` (**bare** signing keys — canonical per `provider_test.go:57-69`) |

Key-name mismatch → every `c.Get(…)` returns `""` → `credsFromProviderCreds` returns `huawei: access_key is required` (provider.go:136) on **every** Huawei prov, regardless of creds being present.

The access_key **was always reaching the preflight** — the handler stamps `req.HuaweiAccessKey` from `CATALYST_HUAWEI_ACCESS_KEY` (`deployments.go:1130`, verified len=20 on the live pod from secret `huawei-operator-creds`), and the sibling `VPCQuotaHook` (`provisioner.go:1666`) consumes the **same** `req.HuaweiAccessKey` and works. The bug was purely that the value got stuffed into the bag under a key `credsFromProviderCreds` doesn't read. **No test ever exercised this path** — that's how it shipped silently. The proven-working sibling `VPCQuota` (`provider.go:1814-1816`) sidesteps the map and builds `hwCreds{}` directly from its args.

## What was fixed

1. **The wiring** — `RotateBlocklistedNATEIPs` now builds `hwCreds{}` **directly** from the AK/SK/project args (mirroring `VPCQuota`), eliminating the key-name coupling. Fails closed with a clear per-field error.
2. **Self-heal widened** — `CATALYST_HUAWEI_NAT_EIP_ROTATE_ALL=true` force-rotates **every** deployment-owned SNAT EIP, not just the static `.48`/`.14` seed. So a poisoned pool whose bad EIPs aren't seeded still drains: `allocateCleanEIP` already **holds** rejected EIPs to walk past them, and the currently-assigned EIP is added to the working blocklist before re-roll so Huawei can't recycle it straight back. Default (unset) preserves the seed+env blocklist behaviour.
3. **Defense-in-depth** — `Provisioner` loads `CATALYST_HUAWEI_*` at `New()` and `Provision()` re-stamps them onto any Request whose `json:"-"` Huawei fields are empty (mirrors the GHCR/Harbor backstop). Guards against any future code path entering `Provision` with empty per-Request creds.
4. **Regression test** — new `preflight_eip_test.go`: a supplied access_key must NOT be reported missing (pre-fix it was); empty creds fail closed; blocklist seed+env merge.

## How the preflight now self-heals a poisoned pool

- Default mode: rotates any seed/env-blocklisted EIP off its SNAT rule, allocating fresh EIPs while **holding** (draining) every blocklisted one it draws, then releases them — breaking the small-pool recycle loop.
- Poisoned-pool mode (`ROTATE_ALL=true`): treats every deployment-owned SNAT EIP as suspect and force-re-rolls, so even bad EIPs not in the seed list get drained out of the free-pool. The signing creds now actually reach the HCS API, so the rotation executes instead of erroring out before the first API call.

## Gates (all green)
```
go build ./...                                              → ok
go test -race ./internal/provisioner/...                   → ok
go test -race ./internal/handler/...                       → ok (92s)
go test -race ./internal/providers/huawei/...              → ok (new regression)
```

Refs #2445
Refs #3716

🤖 Generated with [Claude Code](https://claude.com/claude-code)