### PR TITLE
feat(bootstrap-kit): host-bridge — move remaining 5 host apps into mgmt vCluster (Refs #3642) [DO NOT MERGE — next train]

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -83,8 +83,9 @@ spec:
     # ordering puts cutover after these two come up.
     # G92.3 #2662 (2026-06-01): both HRs moved to host ns `mgmt`.
     - name: bp-gitea
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-harbor
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     # NB on issue #1871 (TBD-A24 cutover↔gateway circular deadlock):
     # PR #1875 initially added `- name: sovereign-tls` to this list.
     # That fix was UNRESOLVABLE in Flux: HelmRelease.dependsOn can

--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -39,7 +39,7 @@ metadata:
   # longer needs to colocate with vc-mgmt. Reverting also restores
   # the Helm valuesFrom lookup of secrets like 'object-storage'
   # (cloud-init seeds it in flux-system; lookup is in HR's own ns).
-  namespace: flux-system
+  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
     catalyst.openova.io/slot: "08"
     catalyst.openova.io/vcluster: mgmt
@@ -47,6 +47,12 @@ spec:
   interval: 15m
   releaseName: openbao
   targetNamespace: openbao
+  storageNamespace: openbao
+  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   # G105-followup #2697 (2026-06-01) — G92.2 #2661 placement REVERTED.
   # Same rationale as 09-keycloak: vCluster lacks ExternalSecret + the
   # mgmt namespace inside itself for Helm release storage. Caught live
@@ -55,6 +61,10 @@ spec:
   # Application-controller G92.1 Blueprint-layer pivot stays; slot-level
   # forcing removed until vCluster CRD sync ships.
   dependsOn:
+    # bp-mgmt-vcluster MUST be Ready first — the vc-mgmt
+    # Secret doesn't exist until then. placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+    - name: bp-mgmt-vcluster
+      namespace: flux-system
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template at
     # platform/openbao/chart/templates/httproute.yaml; the
     # gateway.networking.k8s.io/v1 CRDs MUST be registered before this
@@ -157,6 +167,7 @@ spec:
   #   needs on first reconcile.
   values:
     gateway:
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       host: bao.${SOVEREIGN_FQDN}
     # G91.openbao (#2655) — wire bp-sso-bridge framework. The chart-side
     # continuous reconciler Deployment computes OIDC discovery + redirect
@@ -253,3 +264,109 @@ spec:
       primaryRegion: '${SOVEREIGN_PRIMARY_REGION:-}'
       standbyRegion: '${SOVEREIGN_REPLICA_REGION:-}'
       pdmZone: ${SOVEREIGN_FQDN}
+
+# ── HOST-BRIDGE BEGIN (#3642) — placement-generated host-side route/secret/CNPG; edit placement.yaml hostBridge: + run scripts/render-slot-placement.py fix ──
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: openbao
+  namespace: mgmt
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  parentRefs:
+  - name: cilium-gateway
+    namespace: kube-system
+  hostnames:
+  - bao.${SOVEREIGN_FQDN}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /sso/landing
+    backendRefs:
+    - name: openbao-sso-landing-x-openbao-x-mgmt-vcluster
+      namespace: mgmt
+      port: 80
+  - matches:
+    - path:
+        type: Exact
+        value: /
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: bao.${SOVEREIGN_FQDN}
+        port: 443
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /sso/landing
+        statusCode: 302
+  - matches:
+    - path:
+        type: Exact
+        value: /ui
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: bao.${SOVEREIGN_FQDN}
+        port: 443
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /sso/landing
+        statusCode: 302
+  - matches:
+    - path:
+        type: Exact
+        value: /ui/
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: bao.${SOVEREIGN_FQDN}
+        port: 443
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /sso/landing
+        statusCode: 302
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: openbao-x-openbao-x-mgmt-vcluster
+      namespace: mgmt
+      port: 8200
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: openbao-sso-oidc-credentials
+  namespace: openbao
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    bp-sso-bridge.openova.io/consumer: bp-openbao
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-region1
+    kind: ClusterSecretStore
+  target:
+    name: openbao-sso-oidc-credentials
+    creationPolicy: Owner
+  data:
+  - secretKey: client_id
+    remoteRef:
+      key: sso/openbao
+      property: client_id
+  - secretKey: client_secret
+    remoteRef:
+      key: sso/openbao
+      property: client_secret
+  - secretKey: issuer_url
+    remoteRef:
+      key: sso/openbao
+      property: issuer_url
+# ── HOST-BRIDGE END (#3642) ──

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -40,7 +40,7 @@ metadata:
   # longer needs to colocate with vc-mgmt. Reverting also restores
   # the Helm valuesFrom lookup of secrets like 'object-storage'
   # (cloud-init seeds it in flux-system; lookup is in HR's own ns).
-  namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
     catalyst.openova.io/slot: "10"
     catalyst.openova.io/vcluster: mgmt
@@ -48,6 +48,12 @@ spec:
   interval: 15m
   releaseName: gitea
   targetNamespace: gitea
+  storageNamespace: gitea
+  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
   dependsOn:
     # bp-mgmt-vcluster MUST be Ready first — the vc-mgmt
@@ -173,6 +179,7 @@ spec:
     # chart values short-circuits the configure-oauth Job; the envsubst
     # below makes SSO work zero-touch on every fresh Sovereign.
     sso:
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       sovereignFqdn: ${SOVEREIGN_FQDN}
     # G87 #2634 (2026-06-01): multi-region Sovereigns default CNPG
     # instances to 2 so the operator spreads across regions via
@@ -189,7 +196,7 @@ spec:
         # and its DB host points at the shared cluster's -rw Service. The
         # `gitea` Database + role + reflected gitea-database-secret are
         # provisioned by the shared bp-postgres instance (slot 16a).
-        enabled: ${SOVEREIGN_GITEA_PG_OWN_CLUSTER:=true}
+        enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     # Per-Sovereign overrides — issue #387:
     # Cilium Gateway HTTPRoute exposes Gitea at gitea.${SOVEREIGN_FQDN}.
     # Upstream chart's own Ingress is disabled (gitea.ingress.enabled=false
@@ -198,6 +205,7 @@ spec:
       host: gitea.${SOVEREIGN_FQDN}
     # Restored 2026-06-13 (same #3373/#3391 shape as slot 09).
     gateway:
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       host: gitea.${SOVEREIGN_FQDN}
     # DoD D25 (t129 2026-05-16): override the chart's baked dev hostname
     # `gitea.catalyst.local` so the Gitea Web UI renders the LIVE
@@ -243,3 +251,144 @@ spec:
               secretKeyRef:
                 name: ${SOVEREIGN_GITEA_PG_SECRET:=gitea-pg-app}
                 key: password
+
+# ── HOST-BRIDGE BEGIN (#3642) — placement-generated host-side route/secret/CNPG; edit placement.yaml hostBridge: + run scripts/render-slot-placement.py fix ──
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gitea
+  namespace: mgmt
+  labels:
+    catalyst.openova.io/blueprint: bp-gitea
+    catalyst.openova.io/component: gitea
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  parentRefs:
+  - name: cilium-gateway
+    namespace: kube-system
+  hostnames:
+  - gitea.${SOVEREIGN_FQDN}
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /user/login
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        port: 443
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /user/oauth2/openova-sso
+        statusCode: 302
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: gitea-http-x-gitea-x-mgmt-vcluster
+      namespace: mgmt
+      port: 3000
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: gitea-oauth-source-credentials
+  namespace: gitea
+  labels:
+    catalyst.openova.io/blueprint: bp-gitea
+    bp-sso-bridge.openova.io/consumer: bp-gitea
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-region1
+    kind: ClusterSecretStore
+  target:
+    name: gitea-oauth-source-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          catalyst.openova.io/blueprint: bp-gitea
+          bp-sso-bridge.openova.io/consumer: bp-gitea
+      data:
+        key: '{{ .client_id }}'
+        secret: '{{ .client_secret }}'
+        issuer_url: '{{ .issuer_url }}'
+        authorize_url: '{{ .authorize_url }}?kc_idp_hint=catalyst-pin'
+        token_url: '{{ .token_url }}'
+        userinfo_url: '{{ .userinfo_url }}'
+  data:
+  - secretKey: client_id
+    remoteRef:
+      key: sso/gitea
+      property: client_id
+  - secretKey: client_secret
+    remoteRef:
+      key: sso/gitea
+      property: client_secret
+  - secretKey: issuer_url
+    remoteRef:
+      key: sso/gitea
+      property: issuer_url
+  - secretKey: authorize_url
+    remoteRef:
+      key: sso/gitea
+      property: authorize_url
+  - secretKey: token_url
+    remoteRef:
+      key: sso/gitea
+      property: token_url
+  - secretKey: userinfo_url
+    remoteRef:
+      key: sso/gitea
+      property: userinfo_url
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: gitea-pg
+  namespace: gitea
+  labels:
+    catalyst.openova.io/blueprint: bp-gitea
+    catalyst.openova.io/component: gitea
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  instances: 1
+  imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16
+  bootstrap:
+    initdb:
+      database: gitea
+      owner: gitea
+  managed:
+    roles:
+    - name: gitea
+      ensure: present
+      login: true
+      passwordSecret:
+        name: gitea-pg-app
+  inheritedMetadata:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: 'true'
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: gitea
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: 'true'
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: gitea
+  postgresql:
+    parameters:
+      max_connections: '100'
+      shared_buffers: 64MB
+      effective_cache_size: 192MB
+      work_mem: 4MB
+      maintenance_work_mem: 64MB
+      log_statement: ddl
+      log_min_duration_statement: '1000'
+  storage:
+    size: 5Gi
+    storageClass: local-path
+  enableSuperuserAccess: true
+  monitoring:
+    enablePodMonitor: false
+# ── HOST-BRIDGE END (#3642) ──

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -64,7 +64,7 @@ spec:
       namespace: flux-system
     # G92.3 #2662 (2026-06-01): bp-gitea HR moved to host ns `mgmt`.
     - name: bp-gitea
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     # bp-gateway-api (issue #503): umbrella chart ships catalyst-ui +
     # catalyst-api HTTPRoute templates; gateway.networking.k8s.io/v1
     # CRDs must be registered first.

--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -74,6 +74,7 @@ spec:
     - name: bp-keycloak
       namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-openbao
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   chart:
     spec:
       chart: bp-sso-bridge

--- a/clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml
+++ b/clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml
@@ -48,6 +48,7 @@ spec:
     - name: bp-external-secrets
     # G92.2 #2661 (2026-06-01): bp-openbao HR moved to host ns `mgmt`.
     - name: bp-openbao
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   chart:
     spec:
       chart: bp-external-secrets-stores

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -81,7 +81,7 @@ metadata:
   # longer needs to colocate with vc-mgmt. Reverting also restores
   # the Helm valuesFrom lookup of secrets like 'object-storage'
   # (cloud-init seeds it in flux-system; lookup is in HR's own ns).
-  namespace: flux-system
+  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
     catalyst.openova.io/slot: "19"
     catalyst.openova.io/vcluster: mgmt
@@ -97,6 +97,12 @@ spec:
   interval: 1m
   releaseName: harbor
   targetNamespace: harbor
+  storageNamespace: harbor
+  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   # G105-followup #2697 (2026-06-01) — G92.3 #2662 placement REVERTED.
   # vCluster lacks Gateway API + ExternalSecret CRDs + the mgmt
   # namespace inside itself. App installs on HOST until vCluster CRD
@@ -259,6 +265,7 @@ spec:
   #   credentials Secret name templated by the umbrella chart.
   values:
     gateway:
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       host: registry.${SOVEREIGN_FQDN}
       # #3150 (2026-06-09): the chart's HTTPRoute backend defaults to
       # `harbor-core`, but harbor-core is the API backend — it returns 404 for
@@ -271,6 +278,7 @@ spec:
     # post-install Job PUTs /api/v2.0/configurations with
     # auth_mode=oidc_auth + oidc_endpoint computed from sovereignFqdn.
     sso:
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       sovereignFqdn: ${SOVEREIGN_FQDN}
     # G87 #2634: multi-region CNPG instances default (1 single-region, 2 multi).
     postgres:
@@ -285,7 +293,7 @@ spec:
         # Service. The `registry` Database + role + reflected
         # harbor-database-secret are provisioned by the shared bp-postgres
         # instance (slot 16a).
-        enabled: ${SOVEREIGN_HARBOR_PG_OWN_CLUSTER:=true}
+        enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     objectStorage:
       enabled: true
       useExistingSecret: false
@@ -316,3 +324,100 @@ spec:
             v4auth: true
             secure: true
             storageclass: STANDARD
+
+# ── HOST-BRIDGE BEGIN (#3642) — placement-generated host-side route/secret/CNPG; edit placement.yaml hostBridge: + run scripts/render-slot-placement.py fix ──
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: harbor
+  namespace: mgmt
+  labels:
+    catalyst.openova.io/blueprint: bp-harbor
+    catalyst.openova.io/component: harbor
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  parentRefs:
+  - name: cilium-gateway
+    namespace: kube-system
+  hostnames:
+  - registry.${SOVEREIGN_FQDN}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: harbor-x-harbor-x-mgmt-vcluster
+      namespace: mgmt
+      port: 80
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: harbor-sso-oidc-credentials
+  namespace: harbor
+  labels:
+    catalyst.openova.io/blueprint: bp-harbor
+    bp-sso-bridge.openova.io/consumer: bp-harbor
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-region1
+    kind: ClusterSecretStore
+  target:
+    name: harbor-sso-oidc-credentials
+    creationPolicy: Owner
+  data:
+  - secretKey: client_id
+    remoteRef:
+      key: sso/harbor
+      property: client_id
+  - secretKey: client_secret
+    remoteRef:
+      key: sso/harbor
+      property: client_secret
+  - secretKey: issuer_url
+    remoteRef:
+      key: sso/harbor
+      property: issuer_url
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: harbor-pg
+  namespace: harbor
+  labels:
+    catalyst.openova.io/blueprint: bp-harbor
+    catalyst.openova.io/component: harbor
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  instances: 1
+  imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16
+  bootstrap:
+    initdb:
+      database: registry
+      owner: harbor
+  inheritedMetadata:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: 'true'
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: harbor
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: 'true'
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: harbor
+  postgresql:
+    parameters:
+      max_connections: '100'
+      shared_buffers: 64MB
+      effective_cache_size: 192MB
+      work_mem: 4MB
+      maintenance_work_mem: 64MB
+      log_statement: ddl
+      log_min_duration_statement: '1000'
+  storage:
+    size: 5Gi
+    storageClass: local-path
+  enableSuperuserAccess: true
+  monitoring:
+    enablePodMonitor: false
+# ── HOST-BRIDGE END (#3642) ──

--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -108,7 +108,7 @@ spec:
     # flux-system), wedging bp-sandbox at "unable to get 'rtz/bp-harbor'
     # dependency" and holding the bootstrap-kit health gate forever.
     - name: bp-harbor
-      namespace: flux-system
+      namespace: mgmt
     # #3098 (2026-06-08, hw100): the sandbox chart ships an
     # externalsecret.external-secrets.io resource
     # (platform/sandbox/chart/templates/sso-oauth-source-externalsecret.yaml,

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -62,8 +62,9 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-guacamole
-  namespace: flux-system
+  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
+    catalyst.openova.io/vcluster: mgmt
     catalyst.openova.io/slot: "52"
 spec:
   interval: 15m
@@ -73,22 +74,37 @@ spec:
   # chart's NetworkPolicies allow cross-namespace egress to keycloak
   # / seaweedfs / nats-jetstream regardless of where it lands.
   targetNamespace: catalyst-system
+  storageNamespace: catalyst-system
+  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   dependsOn:
+    # bp-mgmt-vcluster MUST be Ready first — the vc-mgmt
+    # Secret doesn't exist until then. placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+    - name: bp-mgmt-vcluster
+      namespace: flux-system
     - name: bp-cilium
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-cert-manager
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
       namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-sealed-secrets
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-seaweedfs
       namespace: rtz  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-k8s-ws-proxy
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     # #3374 — bp-guacamole now ships a CNPG Cluster CR for its JDBC
     # permission store (admin elevation). bp-cnpg (slot 16) registers the
     # postgresql.cnpg.io/v1 CRD; without this edge the Cluster CR's
     # Capabilities gate would skip on a fresh prov (guacamole installs before
     # cnpg) → no DB → no admin. bp-cnpg before bp-guacamole closes that race.
     - name: bp-cnpg
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   chart:
     spec:
       chart: bp-guacamole
@@ -171,12 +187,16 @@ spec:
       # SSO users into sovereign-admins → admin DETERMINISTIC. 0.2.16 had the
       # USER_GROUP+ADMINISTER but the membership table stayed empty so the owner
       # got no admin menu (#3475). Proven live on hw133.
-      version: 0.2.20
+      # 0.2.21 — #3642 host-bridge: CNPG Cluster gate honours explicit
+      # database.cluster.enabled=false so the placement host-bridge can suppress
+      # the in-vCluster Cluster CR (host-rendered instead). Default byte-identical.
+      version: 0.2.21
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole
         namespace: flux-system
   install:
+    createNamespace: true  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     timeout: 15m
     disableWait: true
     remediation:
@@ -194,11 +214,15 @@ spec:
   # bytes land in the cluster.
   values:
     guacamole:
+      database:
+        cluster:
+          enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       # Default-OFF gate flipped ON by the bootstrap-kit slot. Operator
       # opts out per-Sovereign by removing this slot from
       # clusters/<sovereign>/bootstrap-kit/kustomization.yaml.
       enabled: true
       httproute:
+        enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
         # Resolved from the per-Sovereign Kustomize overlay's
         # SOVEREIGN_FQDN env var, which envsubst materializes when the
         # bootstrap-kit Kustomization renders.
@@ -221,3 +245,88 @@ spec:
         # name. Per-Sovereign overlay can override for non-SeaweedFS
         # backends (e.g. hcloud-volumes single-node fallback).
         storageClass: seaweedfs-storage
+
+# ── HOST-BRIDGE BEGIN (#3642) — placement-generated host-side route/secret/CNPG; edit placement.yaml hostBridge: + run scripts/render-slot-placement.py fix ──
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: guacamole-server
+  namespace: mgmt
+  labels:
+    catalyst.openova.io/blueprint: bp-guacamole
+    catalyst.openova.io/component: guacamole
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  parentRefs:
+  - name: cilium-gateway
+    namespace: kube-system
+  hostnames:
+  - guacamole.${SOVEREIGN_FQDN}
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        port: 443
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /guacamole/
+        statusCode: 302
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: guacamole-server-x-catalyst-system-x-mgmt-vcluster
+      namespace: mgmt
+      port: 80
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: guacamole-pg
+  namespace: catalyst-system
+  labels:
+    catalyst.openova.io/blueprint: bp-guacamole
+    catalyst.openova.io/component: guacamole-db
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  instances: 1
+  imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16
+  bootstrap:
+    initdb:
+      database: guacamole_db
+      owner: guacamole
+  managed:
+    roles:
+    - name: guacamole
+      ensure: present
+      login: true
+      passwordSecret:
+        name: guacamole-pg-app
+  postgresql:
+    parameters:
+      max_connections: '100'
+      shared_buffers: 64MB
+      effective_cache_size: 192MB
+      work_mem: 4MB
+      maintenance_work_mem: 64MB
+      log_statement: ddl
+      log_min_duration_statement: '1000'
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+  storage:
+    size: 5Gi
+    storageClass: local-path
+  enableSuperuserAccess: true
+  monitoring:
+    enablePodMonitor: false
+# ── HOST-BRIDGE END (#3642) ──

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -85,7 +85,11 @@ spec:
       # catalyst-system/newapi/sso-bridge/oidc-gate) in allowedIngressNamespaces
       # so the host Cilium Gateway + keycloak SSO consumers reach the moved
       # keycloak/grafana through the vCluster isolation netpol.
-      version: 0.2.11
+      # 0.2.12 (#3642 follow-on): the remaining 5 host→mgmt moves (openbao/
+      # harbor/gitea/newapi/guacamole) add harbor/gitea/velero/rtz to
+      # allowedIngressNamespaces (their host-bridged CNPG -rw Services + velero
+      # registry backup + the cross-vCluster shared-pg wire).
+      version: 0.2.12
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -44,13 +44,20 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-newapi
-  namespace: flux-system
+  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
+    catalyst.openova.io/vcluster: mgmt
     catalyst.openova.io/slot: "80"
 spec:
   interval: 15m
   releaseName: newapi
   targetNamespace: newapi
+  storageNamespace: newapi
+  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   # bp-newapi depends on:
   #   - bp-openbao(08): the secret backend the chart's ExternalSecret
   #     pulls `ADMIN_API_TOKEN` from. Without OpenBao Ready, the
@@ -64,12 +71,18 @@ spec:
   #     PostgresqlInstance claim once cnpg is Ready. The DSN is mounted
   #     into NewAPI via `database.existingSecret` (operator-set).
   dependsOn:
+    # bp-mgmt-vcluster MUST be Ready first — the vc-mgmt
+    # Secret doesn't exist until then. placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+    - name: bp-mgmt-vcluster
+      namespace: flux-system
     # G92.2 #2661 (2026-06-01): bp-openbao + bp-keycloak HRs moved to
     # host ns `mgmt`.
     - name: bp-openbao
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-keycloak
       namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-cnpg
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   chart:
     spec:
       chart: bp-newapi
@@ -263,6 +276,7 @@ spec:
   # ~10 s once the Postgres DSN Secret is present; the long pole is
   # waiting for the operator's Crossplane claim to materialise the DB.
   install:
+    createNamespace: true  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     timeout: 15m
     disableWait: true
     remediation:
@@ -304,6 +318,7 @@ spec:
     # Mirror the chart's value path. (Same shape for slot 81-sme if that
     # chart also reads cnpg.cluster.instances — track separately.)
     cnpg:
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       cluster:
         instances: ${SOVEREIGN_CNPG_INSTANCES:=1}
     postgres:
@@ -329,12 +344,14 @@ spec:
       # API spec, so enabling this on every Sovereign restores LLM
       # reachability without touching the marketplace wildcard.
       httpRoute:
-        enabled: true
+        enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
         host: newapi.${SOVEREIGN_FQDN}
     auth:
       adminUI:
         mode: keycloak
         keycloak:
+          ssoBridgeSync:
+            enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
           # #3374: was realms/ops — a realm that does not exist on any
           # Sovereign (bp-keycloak imports only `sovereign` + per-Org
           # realms; measured live on hw130 2026-06-13). The sovereign
@@ -349,7 +366,7 @@ spec:
       enabled: true
       existingSecret: catalyst-newapi-admin-token
       externalSecret:
-        enabled: true
+        enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
         refreshInterval: "1h"
         secretStoreRef:
           kind: ClusterSecretStore
@@ -495,3 +512,128 @@ spec:
         attestation:
           kind: in-cluster
           owner: ${SOVEREIGN_FQDN}
+
+# ── HOST-BRIDGE BEGIN (#3642) — placement-generated host-side route/secret/CNPG; edit placement.yaml hostBridge: + run scripts/render-slot-placement.py fix ──
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: newapi-bp-newapi-public
+  namespace: mgmt
+  labels:
+    catalyst.openova.io/blueprint: bp-newapi
+    catalyst.openova.io/component: newapi-public-route
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  parentRefs:
+  - name: cilium-gateway
+    namespace: kube-system
+  hostnames:
+  - newapi.${SOVEREIGN_FQDN}
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /
+    backendRefs:
+    - name: newapi-bp-newapi-x-newapi-x-mgmt-vcluster
+      namespace: mgmt
+      port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: newapi-bp-newapi-x-newapi-x-mgmt-vcluster
+      namespace: mgmt
+      port: 3000
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: catalyst-newapi-admin-token
+  namespace: newapi
+  labels:
+    catalyst.openova.io/blueprint: bp-newapi
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-region1
+  target:
+    name: catalyst-newapi-admin-token
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reflector.v1.k8s.emberstack.com/reflection-allowed: 'true'
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: catalyst-system
+          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: 'true'
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: catalyst-system
+  data:
+  - secretKey: ADMIN_API_TOKEN
+    remoteRef:
+      key: sovereign/${SOVEREIGN_FQDN}/newapi/admin-token
+      property: ADMIN_API_TOKEN
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: newapi-bp-newapi-oidc-sync
+  namespace: newapi
+  labels:
+    catalyst.openova.io/blueprint: bp-newapi
+    bp-sso-bridge.openova.io/consumer: bp-newapi
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-region1
+    kind: ClusterSecretStore
+  target:
+    name: newapi-oidc
+    creationPolicy: Merge
+    template:
+      type: Opaque
+      mergePolicy: Merge
+      data:
+        OIDC_CLIENT_SECRET: '{{ .client_secret }}'
+  data:
+  - secretKey: client_secret
+    remoteRef:
+      key: sso/sovereign/newapi-admin
+      property: client_secret
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: newapi-bp-newapi-newapi-pg
+  namespace: newapi
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    catalyst.openova.io/blueprint: bp-newapi
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  instances: 1
+  imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4
+  storage:
+    size: 5Gi
+  bootstrap:
+    initdb:
+      database: newapi
+      owner: newapi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: newapi-bp-newapi-newapi-db-dsn
+  namespace: newapi
+  labels:
+    catalyst.openova.io/blueprint: bp-newapi
+    catalyst.openova.io/host-bridge: mgmt
+type: Opaque
+data:
+  SQL_DSN: ''
+# ── HOST-BRIDGE END (#3642) ──

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -232,7 +232,178 @@ spec:
     # attribute those workloads (multi-namespace chart, not undeclared).
     - {file: 13-bp-catalyst-platform.yaml, hr: bp-catalyst-platform, vcluster: host, target: mgmt,
        namespace: catalyst-system, extraNamespaces: [sme, catalyst]}
-    - {file: 10-gitea.yaml, hr: bp-gitea, vcluster: host, target: mgmt, namespace: gitea}
+    # ── #3642 HOST-BRIDGE PROMOTE — gitea into the mgmt vCluster ────────
+    # Route + SSO ExternalSecret + CNPG `Cluster` host-bridge. `suppress` turns
+    # the chart's OWN in-vCluster HTTPRoute (gateway.enabled:false), SSO
+    # ExternalSecret (sso.enabled:false), AND CNPG Cluster CR
+    # (postgres.cluster.enabled:false) off — all three are host-rendered below
+    # so the HOST Cilium Gateway / external-secrets-operator / cnpg-operator
+    # reconcile them (they are host-minimum substrate the vCluster apiserver
+    # can't expose to). The gitea Pod re-homes into vc-mgmt and reaches the
+    # host-reconciled gitea-pg-rw.gitea.svc cross-cluster (vCluster CoreDNS
+    # forwards unknown queries to host kube-dns; the slot's DB-host default
+    # already targets that name). backendRef → the OSS-synced mangled Service
+    # gitea-http-x-gitea-x-mgmt-vcluster.
+    - file: 10-gitea.yaml
+      hr: bp-gitea
+      vcluster: mgmt
+      target: mgmt
+      namespace: gitea
+      hostBridge:
+        suppress:
+          gateway.enabled: false
+          sso.enabled: false
+          postgres.cluster.enabled: false
+        hostDocuments:
+          # HTTPRoute in the `mgmt` host ns (same ns as the mangled backend
+          # Service → no ReferenceGrant); the /user/login → OIDC entry redirect
+          # (founder zero-click root-URL) + the main backend.
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: gitea
+              namespace: mgmt
+              labels:
+                catalyst.openova.io/blueprint: bp-gitea
+                catalyst.openova.io/component: gitea
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              parentRefs:
+                - name: cilium-gateway
+                  namespace: kube-system
+              hostnames:
+                - gitea.${SOVEREIGN_FQDN}
+              rules:
+                - matches:
+                    - path:
+                        type: Exact
+                        value: /user/login
+                  filters:
+                    - type: RequestRedirect
+                      requestRedirect:
+                        port: 443
+                        path:
+                          type: ReplaceFullPath
+                          replaceFullPath: /user/oauth2/openova-sso
+                        statusCode: 302
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /
+                  backendRefs:
+                    - name: gitea-http-x-gitea-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 3000
+          # SSO OAuth-source ExternalSecret in the `gitea` host ns (HOST ESO
+          # reconciles it). Verbatim copy of the chart's default render — the
+          # target.template remaps the canonical OpenBao keys into gitea's
+          # upstream `key`/`secret` existingSecret schema (+ ?kc_idp_hint=
+          # catalyst-pin on authorize_url, the chart default idpHint).
+          - apiVersion: external-secrets.io/v1beta1
+            kind: ExternalSecret
+            metadata:
+              name: gitea-oauth-source-credentials
+              namespace: gitea
+              labels:
+                catalyst.openova.io/blueprint: bp-gitea
+                bp-sso-bridge.openova.io/consumer: bp-gitea
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              refreshInterval: 1h
+              secretStoreRef:
+                name: vault-region1
+                kind: ClusterSecretStore
+              target:
+                name: gitea-oauth-source-credentials
+                creationPolicy: Owner
+                template:
+                  type: Opaque
+                  metadata:
+                    labels:
+                      catalyst.openova.io/blueprint: bp-gitea
+                      bp-sso-bridge.openova.io/consumer: bp-gitea
+                  data:
+                    key: "{{ .client_id }}"
+                    secret: "{{ .client_secret }}"
+                    issuer_url: "{{ .issuer_url }}"
+                    authorize_url: "{{ .authorize_url }}?kc_idp_hint=catalyst-pin"
+                    token_url: "{{ .token_url }}"
+                    userinfo_url: "{{ .userinfo_url }}"
+              data:
+                - secretKey: client_id
+                  remoteRef:
+                    key: sso/gitea
+                    property: client_id
+                - secretKey: client_secret
+                  remoteRef:
+                    key: sso/gitea
+                    property: client_secret
+                - secretKey: issuer_url
+                  remoteRef:
+                    key: sso/gitea
+                    property: issuer_url
+                - secretKey: authorize_url
+                  remoteRef:
+                    key: sso/gitea
+                    property: authorize_url
+                - secretKey: token_url
+                  remoteRef:
+                    key: sso/gitea
+                    property: token_url
+                - secretKey: userinfo_url
+                  remoteRef:
+                    key: sso/gitea
+                    property: userinfo_url
+          # CNPG `Cluster` in the `gitea` host ns (HOST cnpg-operator
+          # reconciles it; the resulting gitea-pg-rw.gitea.svc is reached by the
+          # in-vCluster Pod via host-DNS forwarding). Verbatim copy of the
+          # chart's cnpg-cluster.yaml default render (instances=1, single-region
+          # — no cross-region affinity block; the multi-region overlay re-adds
+          # it the same way the chart does at instances>=2).
+          - apiVersion: postgresql.cnpg.io/v1
+            kind: Cluster
+            metadata:
+              name: gitea-pg
+              namespace: gitea
+              labels:
+                catalyst.openova.io/blueprint: bp-gitea
+                catalyst.openova.io/component: gitea
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              instances: 1
+              imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16
+              bootstrap:
+                initdb:
+                  database: gitea
+                  owner: gitea
+              managed:
+                roles:
+                  - name: gitea
+                    ensure: present
+                    login: true
+                    passwordSecret:
+                      name: gitea-pg-app
+              inheritedMetadata:
+                annotations:
+                  reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+                  reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: gitea
+                  reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+                  reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: gitea
+              postgresql:
+                parameters:
+                  max_connections: "100"
+                  shared_buffers: 64MB
+                  effective_cache_size: 192MB
+                  work_mem: 4MB
+                  maintenance_work_mem: 64MB
+                  log_statement: ddl
+                  log_min_duration_statement: "1000"
+              storage:
+                size: 5Gi
+                storageClass: local-path
+              enableSuperuserAccess: true
+              monitoring:
+                enablePodMonitor: false
 
     # Already inside their vClusters (proven recipe slots).
     - {file: 22-loki.yaml, hr: bp-loki, vcluster: mgmt, target: mgmt, namespace: loki}
@@ -247,12 +418,16 @@ spec:
     # The rows below carry `target != host` (founder §4 wants them in a
     # vCluster). #3642 lands the OSS-native HOST-BRIDGE (see RESOLUTION
     # below) and MOVES keycloak (09) + grafana (25) into the mgmt vCluster
-    # — those two now carry `vcluster: mgmt` with a `hostBridge:` block.
-    # The remaining route/secret/CNPG rows are host-bridge-READY follow-ons
-    # (same one-field flip + `hostBridge:` declaration). This was NEVER a
-    # license requirement; the host-bridge keeps the route/secret/CNPG CRs
-    # host-rendered. (Migration plan: docs/sessions/2026-06-14/
-    # 3373-migration-plan.md §0/§4/§6; host-bridge: #3642.)
+    # in the first car — those two carry `vcluster: mgmt` with a `hostBridge:`
+    # block. The #3642 follow-on car then MOVES the remaining 5 route/secret/
+    # CNPG apps the SAME way: openbao (08, route + SSO ES), harbor (19) + gitea
+    # (10) + newapi (80) + guacamole (52) (route + secret + host-rendered CNPG
+    # Cluster). All seven now carry `vcluster: mgmt` + a `hostBridge:` block.
+    # This was NEVER a license requirement; the host-bridge keeps the route/
+    # secret/CNPG CRs host-rendered (host Cilium Gateway / external-secrets-
+    # operator / cnpg-operator reconcile them) while only the workload re-homes.
+    # (Migration plan: docs/sessions/2026-06-14/3373-migration-plan.md
+    # §0/§4/§6; host-bridge: #3642.)
     #
     # THE GOVERNING CONSTRAINT — vCluster CRD-sync is loft.sh Free-tier,
     # NOT pure-OSS:
@@ -302,15 +477,17 @@ spec:
     #
     #   ROUTE + ExternalSecret — host-bridge MOVED (#3642):
     #     ✅ keycloak (09, route-only — no ES, bundled PG in-vCluster),
-    #     ✅ grafana  (25, route + SSO ExternalSecret, shared-pg-b consumer).
+    #     ✅ grafana  (25, route + SSO ExternalSecret, shared-pg-b consumer),
+    #     ✅ openbao  (08, route + SSO ES; 2-backend bare-URL landing route).
     #   ROUTE + ExternalSecret — host-bridge READY (same recipe, follow-on
-    #   rows; openbao adds a 2-backend bare-URL landing route):
-    #     openbao (08), powerdns-admin (11a), openova-flow-server (56).
+    #   rows):
+    #     powerdns-admin (11a), openova-flow-server (56).
     #   ROUTE + ExternalSecret + CNPG `Cluster` — host-bridge + the CNPG
     #   Cluster rendered host-side (§5d); the in-vCluster Pod reaches the
-    #   host PG cross-cluster (follow-on rows):
-    #     gitea (10), harbor (19), newapi (80), guacamole (52),
-    #     catalyst-platform (13, control-plane root — LAST).
+    #   host PG cross-cluster — MOVED (#3642 follow-on):
+    #     ✅ gitea (10), ✅ harbor (19), ✅ newapi (80), ✅ guacamole (52).
+    #   Still host (control-plane root — LAST):
+    #     catalyst-platform (13).
     #   CNPG `Cluster` CR engines (host cnpg-operator reconciles host-side) —
     #   host-bridge the Cluster CR (follow-on) — 4:
     #     postgres-shared (×3: 16a/16c/16d) + cnpg-pair (16b).
@@ -319,10 +496,144 @@ spec:
     #     sso-bridge, openova-flow-emitter, k8s-ws-proxy (k8s-ws-proxy is
     #     a per-node-host-reach DaemonSet → strongest keep-host case).
     #
-    # NEEDS-REWORK / staged backlog (§4 targets are ASPIRATIONAL per the
-    # exception above; active=host BY DESIGN on pure-OSS — NOT a one-field
-    # flip until OSS-native CRD-sync or a host-bridge lands).
-    - {file: 08-openbao.yaml, hr: bp-openbao, vcluster: host, target: mgmt, namespace: openbao}
+    # ── #3642 HOST-BRIDGE PROMOTE — openbao into the mgmt vCluster ──────
+    # Route + SSO ExternalSecret host-bridge (NO own CNPG — openbao reaches the
+    # host cnpg-backed audit/storage adjuncts via cross-cluster DNS, not its own
+    # Cluster CR). `suppress` turns the chart's OWN in-vCluster HTTPRoute off
+    # (gateway.enabled:false); the host-side copies below are authoritative.
+    # NOTE: sso.enabled is NOT suppressed — it gates BOTH the SSO ExternalSecret
+    # AND the in-vCluster bare-URL landing-page + sso-configure Deployments,
+    # which must keep rendering inside vc-mgmt (the chart's own in-vCluster ES CR
+    # is inert there — no ESO operator in the vCluster — while the host-side ES
+    # copy below is the one the HOST external-secrets-operator reconciles; same
+    # shape as grafana #3703). The host-bridged HTTPRoute carries openbao's full
+    # bare-URL ruleset: the on-origin /sso/landing backend (the openbao-sso-
+    # landing nginx, syncer-mangled), the bare-path 302 redirects, and the main
+    # /-prefix backend (openbao :8200, syncer-mangled). backendRefs → the
+    # OSS-synced mangled Services <svc>-x-openbao-x-mgmt-vcluster.
+    - file: 08-openbao.yaml
+      hr: bp-openbao
+      vcluster: mgmt
+      target: mgmt
+      namespace: openbao
+      hostBridge:
+        suppress:
+          gateway.enabled: false
+        hostDocuments:
+          # HTTPRoute in the `mgmt` host ns (same ns as the mangled backend
+          # Services → no ReferenceGrant); attaches to kube-system/cilium-
+          # gateway via allowedRoutes.from=All.
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: openbao
+              namespace: mgmt
+              labels:
+                catalyst.openova.io/blueprint: bp-openbao
+                catalyst.openova.io/component: openbao
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              parentRefs:
+                - name: cilium-gateway
+                  namespace: kube-system
+              hostnames:
+                - bao.${SOVEREIGN_FQDN}
+              rules:
+                # The on-origin SSO landing page (#3374 bare-URL zero-click):
+                # the openbao-sso-landing nginx, synced out of vc-mgmt.
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /sso/landing
+                  backendRefs:
+                    - name: openbao-sso-landing-x-openbao-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 80
+                # Bare-path entry → 302 to the landing page (TOP-LEVEL window
+                # OIDC round-trip; the Vault-UI popup-only callback can't land
+                # signed-in on a full-page redirect — hw133 lesson).
+                - matches:
+                    - path:
+                        type: Exact
+                        value: /
+                  filters:
+                    - type: RequestRedirect
+                      requestRedirect:
+                        hostname: bao.${SOVEREIGN_FQDN}
+                        port: 443
+                        path:
+                          type: ReplaceFullPath
+                          replaceFullPath: /sso/landing
+                        statusCode: 302
+                - matches:
+                    - path:
+                        type: Exact
+                        value: /ui
+                  filters:
+                    - type: RequestRedirect
+                      requestRedirect:
+                        hostname: bao.${SOVEREIGN_FQDN}
+                        port: 443
+                        path:
+                          type: ReplaceFullPath
+                          replaceFullPath: /sso/landing
+                        statusCode: 302
+                - matches:
+                    - path:
+                        type: Exact
+                        value: /ui/
+                  filters:
+                    - type: RequestRedirect
+                      requestRedirect:
+                        hostname: bao.${SOVEREIGN_FQDN}
+                        port: 443
+                        path:
+                          type: ReplaceFullPath
+                          replaceFullPath: /sso/landing
+                        statusCode: 302
+                # Main backend: the OpenBao server (API /v1/* + UI), synced
+                # out of vc-mgmt.
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /
+                  backendRefs:
+                    - name: openbao-x-openbao-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 8200
+          # SSO OIDC-credentials ExternalSecret in the `openbao` host ns (the
+          # HOST external-secrets-operator reconciles it). Verbatim copy of the
+          # chart's sso-oauth-source-externalsecret.yaml default render.
+          - apiVersion: external-secrets.io/v1beta1
+            kind: ExternalSecret
+            metadata:
+              name: openbao-sso-oidc-credentials
+              namespace: openbao
+              labels:
+                catalyst.openova.io/blueprint: bp-openbao
+                bp-sso-bridge.openova.io/consumer: bp-openbao
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              refreshInterval: 1h
+              secretStoreRef:
+                name: vault-region1
+                kind: ClusterSecretStore
+              target:
+                name: openbao-sso-oidc-credentials
+                creationPolicy: Owner
+              data:
+                - secretKey: client_id
+                  remoteRef:
+                    key: sso/openbao
+                    property: client_id
+                - secretKey: client_secret
+                  remoteRef:
+                    key: sso/openbao
+                    property: client_secret
+                - secretKey: issuer_url
+                  remoteRef:
+                    key: sso/openbao
+                    property: issuer_url
     - {file: 11a-bp-powerdns-admin.yaml, hr: bp-powerdns-admin, vcluster: host, target: mgmt,
        namespace: powerdns-admin}   # §4: UI not substrate — DEFAULT mgmt, listed for founder veto
     - {file: 13b-bp-sso-bridge.yaml, hr: bp-sso-bridge, vcluster: host, target: mgmt, namespace: sso-bridge}
@@ -332,7 +643,124 @@ spec:
     - {file: 16d-bp-postgres-shared-c.yaml, hr: bp-postgres-shared-c, vcluster: host, target: rtz, namespace: shared-data}
     - {file: 17-valkey.yaml, hr: bp-valkey, vcluster: rtz, target: rtz, namespace: valkey}   # Batch A (#3373) — PROMOTED: pure-OSS clean (no route/secret/CNPG); plain Service DNS via OSS services-sync
     - {file: 18-seaweedfs.yaml, hr: bp-seaweedfs, vcluster: rtz, target: rtz, namespace: seaweedfs}   # Batch A (#3373) — PROMOTED: pure-OSS clean (no route/secret/CNPG); S3 wire is plain Service DNS via OSS services-sync; all consumers S3-default-OFF on a fresh prov
-    - {file: 19-harbor.yaml, hr: bp-harbor, vcluster: host, target: mgmt, namespace: harbor}
+    # ── #3642 HOST-BRIDGE PROMOTE — harbor into the mgmt vCluster ───────
+    # Route + SSO ExternalSecret + CNPG `Cluster` host-bridge (same shape as
+    # gitea). `suppress` turns the chart's OWN in-vCluster HTTPRoute, SSO
+    # ExternalSecret, and CNPG Cluster CR off; the host-side copies below are
+    # authoritative. The harbor route backendRef points at the OSS-synced
+    # mangled Service harbor-x-harbor-x-mgmt-vcluster (the slot's
+    # gateway.backendService=harbor → the harbor-nginx front door, NOT harbor-
+    # core). The harbor Pod re-homes into vc-mgmt and reaches the host-
+    # reconciled harbor-pg-rw.harbor.svc cross-cluster via host-DNS forwarding.
+    - file: 19-harbor.yaml
+      hr: bp-harbor
+      vcluster: mgmt
+      target: mgmt
+      namespace: harbor
+      hostBridge:
+        suppress:
+          gateway.enabled: false
+          sso.enabled: false
+          postgres.cluster.enabled: false
+        hostDocuments:
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: harbor
+              namespace: mgmt
+              labels:
+                catalyst.openova.io/blueprint: bp-harbor
+                catalyst.openova.io/component: harbor
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              parentRefs:
+                - name: cilium-gateway
+                  namespace: kube-system
+              hostnames:
+                - registry.${SOVEREIGN_FQDN}
+              rules:
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /
+                  backendRefs:
+                    - name: harbor-x-harbor-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 80
+          # SSO OIDC-credentials ExternalSecret in the `harbor` host ns (HOST
+          # ESO reconciles it). Verbatim copy of the chart default render.
+          - apiVersion: external-secrets.io/v1beta1
+            kind: ExternalSecret
+            metadata:
+              name: harbor-sso-oidc-credentials
+              namespace: harbor
+              labels:
+                catalyst.openova.io/blueprint: bp-harbor
+                bp-sso-bridge.openova.io/consumer: bp-harbor
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              refreshInterval: 1h
+              secretStoreRef:
+                name: vault-region1
+                kind: ClusterSecretStore
+              target:
+                name: harbor-sso-oidc-credentials
+                creationPolicy: Owner
+              data:
+                - secretKey: client_id
+                  remoteRef:
+                    key: sso/harbor
+                    property: client_id
+                - secretKey: client_secret
+                  remoteRef:
+                    key: sso/harbor
+                    property: client_secret
+                - secretKey: issuer_url
+                  remoteRef:
+                    key: sso/harbor
+                    property: issuer_url
+          # CNPG `Cluster` in the `harbor` host ns (HOST cnpg-operator
+          # reconciles it; harbor-pg-rw.harbor.svc reached cross-cluster).
+          # Verbatim copy of the chart cnpg-cluster.yaml default render
+          # (db `registry`, owner `harbor`; no managed.roles block — harbor's
+          # chart does not declare one; instances=1 single-region).
+          - apiVersion: postgresql.cnpg.io/v1
+            kind: Cluster
+            metadata:
+              name: harbor-pg
+              namespace: harbor
+              labels:
+                catalyst.openova.io/blueprint: bp-harbor
+                catalyst.openova.io/component: harbor
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              instances: 1
+              imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16
+              bootstrap:
+                initdb:
+                  database: registry
+                  owner: harbor
+              inheritedMetadata:
+                annotations:
+                  reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+                  reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: harbor
+                  reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+                  reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: harbor
+              postgresql:
+                parameters:
+                  max_connections: "100"
+                  shared_buffers: 64MB
+                  effective_cache_size: 192MB
+                  work_mem: 4MB
+                  maintenance_work_mem: 64MB
+                  log_statement: ddl
+                  log_min_duration_statement: "1000"
+              storage:
+                size: 5Gi
+                storageClass: local-path
+              enableSuperuserAccess: true
+              monitoring:
+                enablePodMonitor: false
     # ── #3642 HOST-BRIDGE PROMOTE — grafana into the mgmt vCluster ──────
     # The North-Star-#1 batch-D-first app (least blast radius: depends only
     # on already-mgmt loki/mimir/tempo + shared-pg-b). grafana ships an
@@ -440,7 +868,278 @@ spec:
     - {file: 39-bp-vllm.yaml, hr: bp-vllm, vcluster: rtz, target: rtz, namespace: vllm}   # Batch A (#3373) — PROMOTED: pure-OSS clean (no route/secret/CNPG); plain Service DNS via OSS services-sync; vllm + its newapi channel both default-OFF on a fresh prov
     - {file: 51-bp-k8s-ws-proxy.yaml, hr: bp-k8s-ws-proxy, vcluster: host, target: mgmt,
        namespace: catalyst-system}   # recipe proven, draft PR #3350
-    - {file: 52-bp-guacamole.yaml, hr: bp-guacamole, vcluster: host, target: mgmt, namespace: catalyst-system}
+    # ── #3642 HOST-BRIDGE PROMOTE — guacamole into the mgmt vCluster ────
+    # Route + CNPG `Cluster` host-bridge — but NO ExternalSecret: guacamole's
+    # OIDC client secret is a chart-managed lookup-or-generate v1/Secret
+    # (guacamole-oidc, helm.sh/resource-policy:keep), NOT an ESO ExternalSecret,
+    # so it needs no host substrate and keeps rendering INSIDE vc-mgmt where the
+    # webapp Pod reads it (same apiserver). `suppress` turns the chart's OWN
+    # in-vCluster HTTPRoute (guacamole.httproute.enabled:false) + CNPG Cluster
+    # (guacamole.database.cluster.enabled:false) off; the host-side copies below
+    # are authoritative. ⚠️ guacamole's targetNamespace is `catalyst-system`
+    # (co-located with catalyst-api / k8s-ws-proxy), so its route/CNPG render in
+    # `catalyst-system` and the mangled backend suffix uses that inner ns. The
+    # webapp Pod reaches the host-reconciled guacamole-pg-rw.catalyst-system.svc
+    # cross-cluster via host-DNS forwarding. backendRef → guacamole-server-x-
+    # catalyst-system-x-mgmt-vcluster.
+    - file: 52-bp-guacamole.yaml
+      hr: bp-guacamole
+      vcluster: mgmt
+      target: mgmt
+      namespace: catalyst-system
+      hostBridge:
+        suppress:
+          guacamole.httproute.enabled: false
+          guacamole.database.cluster.enabled: false
+        hostDocuments:
+          # HTTPRoute in the `mgmt` host ns (same ns as the mangled backend
+          # Service → no ReferenceGrant): the bare-root 302 into the /guacamole/
+          # WAR context (Tomcat serves the webapp there, not at /) + the main
+          # backend.
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: guacamole-server
+              namespace: mgmt
+              labels:
+                catalyst.openova.io/blueprint: bp-guacamole
+                catalyst.openova.io/component: guacamole
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              parentRefs:
+                - name: cilium-gateway
+                  namespace: kube-system
+              hostnames:
+                - guacamole.${SOVEREIGN_FQDN}
+              rules:
+                - matches:
+                    - path:
+                        type: Exact
+                        value: /
+                  filters:
+                    - type: RequestRedirect
+                      requestRedirect:
+                        port: 443
+                        path:
+                          type: ReplaceFullPath
+                          replaceFullPath: /guacamole/
+                        statusCode: 302
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /
+                  backendRefs:
+                    - name: guacamole-server-x-catalyst-system-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 80
+          # CNPG `Cluster` in the `catalyst-system` host ns (HOST cnpg-operator
+          # reconciles it; guacamole-pg-rw.catalyst-system.svc reached
+          # cross-cluster). Verbatim copy of the chart cnpg-cluster.yaml default
+          # render (db `guacamole_db`, owner `guacamole`, managed.roles
+          # passwordSecret guacamole-pg-app; instances=1 single-region).
+          - apiVersion: postgresql.cnpg.io/v1
+            kind: Cluster
+            metadata:
+              name: guacamole-pg
+              namespace: catalyst-system
+              labels:
+                catalyst.openova.io/blueprint: bp-guacamole
+                catalyst.openova.io/component: guacamole-db
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              instances: 1
+              imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16
+              bootstrap:
+                initdb:
+                  database: guacamole_db
+                  owner: guacamole
+              managed:
+                roles:
+                  - name: guacamole
+                    ensure: present
+                    login: true
+                    passwordSecret:
+                      name: guacamole-pg-app
+              postgresql:
+                parameters:
+                  max_connections: "100"
+                  shared_buffers: 64MB
+                  effective_cache_size: 192MB
+                  work_mem: 4MB
+                  maintenance_work_mem: 64MB
+                  log_statement: ddl
+                  log_min_duration_statement: "1000"
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  memory: 512Mi
+              storage:
+                size: 5Gi
+                storageClass: local-path
+              enableSuperuserAccess: true
+              monitoring:
+                enablePodMonitor: false
     - {file: 56-bp-openova-flow-server.yaml, hr: bp-openova-flow-server, vcluster: host, target: mgmt, namespace: catalyst-system}
     - {file: 57-bp-openova-flow-emitter.yaml, hr: bp-openova-flow-emitter, vcluster: host, target: mgmt, namespace: catalyst-system}
-    - {file: 80-newapi.yaml, hr: bp-newapi, vcluster: host, target: mgmt, namespace: newapi}
+    # ── #3642 HOST-BRIDGE PROMOTE — newapi into the mgmt vCluster ───────
+    # Route + 2 ExternalSecrets + CNPG `Cluster` host-bridge. `suppress` turns
+    # the chart's OWN in-vCluster public HTTPRoute (ingress.httpRoute.enabled:
+    # false), its two ExternalSecrets (catalystIntegration.externalSecret.enabled
+    # :false for catalyst-newapi-admin-token; auth.adminUI.keycloak.ssoBridgeSync
+    # .enabled:false for the newapi-oidc Merge ES), and the CNPG Cluster + DSN
+    # placeholder (cnpg.enabled:false) off; the host-side copies below are
+    # authoritative. The newapi Pod re-homes into vc-mgmt and reaches the host-
+    # reconciled newapi-bp-newapi-newapi-pg-rw.newapi.svc cross-cluster via
+    # host-DNS forwarding. backendRefs → the OSS-synced mangled Service
+    # newapi-bp-newapi-x-newapi-x-mgmt-vcluster. The route carries newapi's
+    # zero-click bridge rule (Exact / → sandbox-bridge :8080) + the SPA/API
+    # backend (PathPrefix / → :3000).
+    - file: 80-newapi.yaml
+      hr: bp-newapi
+      vcluster: mgmt
+      target: mgmt
+      namespace: newapi
+      hostBridge:
+        suppress:
+          ingress.httpRoute.enabled: false
+          cnpg.enabled: false
+          catalystIntegration.externalSecret.enabled: false
+          auth.adminUI.keycloak.ssoBridgeSync.enabled: false
+        hostDocuments:
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: newapi-bp-newapi-public
+              namespace: mgmt
+              labels:
+                catalyst.openova.io/blueprint: bp-newapi
+                catalyst.openova.io/component: newapi-public-route
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              parentRefs:
+                - name: cilium-gateway
+                  namespace: kube-system
+              hostnames:
+                - newapi.${SOVEREIGN_FQDN}
+              rules:
+                # Zero-click bare-URL: the sandbox-bridge sidecar serves the
+                # same-origin init page that runs newapi's own OIDC sequence
+                # (Exact / wins over PathPrefix /).
+                - matches:
+                    - path:
+                        type: Exact
+                        value: /
+                  backendRefs:
+                    - name: newapi-bp-newapi-x-newapi-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 8080
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /
+                  backendRefs:
+                    - name: newapi-bp-newapi-x-newapi-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 3000
+          # ExternalSecret #1 — catalyst-newapi-admin-token in the `newapi`
+          # host ns (HOST ESO reconciles it; reflector mirrors it to
+          # catalyst-system where catalyst-api reads ADMIN_API_TOKEN). Verbatim
+          # copy of external-secret.yaml default render. remoteRef.key is the
+          # per-Sovereign OpenBao path the slot supplies.
+          - apiVersion: external-secrets.io/v1beta1
+            kind: ExternalSecret
+            metadata:
+              name: catalyst-newapi-admin-token
+              namespace: newapi
+              labels:
+                catalyst.openova.io/blueprint: bp-newapi
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              refreshInterval: 1h
+              secretStoreRef:
+                kind: ClusterSecretStore
+                name: vault-region1
+              target:
+                name: catalyst-newapi-admin-token
+                creationPolicy: Owner
+                template:
+                  metadata:
+                    annotations:
+                      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+                      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: catalyst-system
+                      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+                      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: catalyst-system
+              data:
+                - secretKey: ADMIN_API_TOKEN
+                  remoteRef:
+                    key: sovereign/${SOVEREIGN_FQDN}/newapi/admin-token
+                    property: ADMIN_API_TOKEN
+          # ExternalSecret #2 — newapi-oidc-sync (MERGE into newapi-oidc) in the
+          # `newapi` host ns. Verbatim copy of sso-externalsecret.yaml default
+          # render (clientId newapi-admin → sso/sovereign/newapi-admin).
+          - apiVersion: external-secrets.io/v1beta1
+            kind: ExternalSecret
+            metadata:
+              name: newapi-bp-newapi-oidc-sync
+              namespace: newapi
+              labels:
+                catalyst.openova.io/blueprint: bp-newapi
+                bp-sso-bridge.openova.io/consumer: bp-newapi
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              refreshInterval: 1h
+              secretStoreRef:
+                name: vault-region1
+                kind: ClusterSecretStore
+              target:
+                name: newapi-oidc
+                creationPolicy: Merge
+                template:
+                  type: Opaque
+                  mergePolicy: Merge
+                  data:
+                    OIDC_CLIENT_SECRET: "{{ .client_secret }}"
+              data:
+                - secretKey: client_secret
+                  remoteRef:
+                    key: sso/sovereign/newapi-admin
+                    property: client_secret
+          # CNPG `Cluster` in the `newapi` host ns (HOST cnpg-operator
+          # reconciles it). Verbatim copy of cnpg-cluster.yaml default render
+          # (helm.sh/resource-policy:keep, db `newapi`, owner `newapi`,
+          # instances=1; no managed.roles/parameters block at chart defaults).
+          - apiVersion: postgresql.cnpg.io/v1
+            kind: Cluster
+            metadata:
+              name: newapi-bp-newapi-newapi-pg
+              namespace: newapi
+              annotations:
+                helm.sh/resource-policy: keep
+              labels:
+                catalyst.openova.io/blueprint: bp-newapi
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              instances: 1
+              imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4
+              storage:
+                size: 5Gi
+              bootstrap:
+                initdb:
+                  database: newapi
+                  owner: newapi
+          # DSN placeholder Secret in the `newapi` host ns (the host-side
+          # database-secret-sync-job PATCHes SQL_DSN once the host CNPG
+          # `-app` Secret lands). Verbatim copy of the chart placeholder.
+          - apiVersion: v1
+            kind: Secret
+            metadata:
+              name: newapi-bp-newapi-newapi-db-dsn
+              namespace: newapi
+              labels:
+                catalyst.openova.io/blueprint: bp-newapi
+                catalyst.openova.io/host-bridge: "mgmt"
+            type: Opaque
+            data:
+              SQL_DSN: ""

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.11
+  version: 0.2.12
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -94,7 +94,19 @@ name: bp-mgmt-vcluster
 # backendRef of the host-bridged HTTPRoutes) + catalyst-system/newapi/
 # sso-bridge/oidc-gate (keycloak SSO consumers) to allowedIngressNamespaces
 # (mirrors the #3423 sme→NATS carve-out). Additive netpol-values change only.
-version: 0.2.11
+# 0.2.12 (#3642 follow-on): the remaining 5 host→mgmt moves (openbao, harbor,
+# gitea, newapi, guacamole) add their host-side consumers' namespaces to
+# allowedIngressNamespaces (the mangled Services of their host-bridged routes
+# + their CNPG -rw Services now sit behind this isolation netpol). Per
+# docs/sessions/2026-06-14/3373-migration-plan §7 batch-D set: harbor + gitea +
+# velero (velero → harbor registry backup; harbor/gitea also self-ingress their
+# own host-rendered CNPG -rw Service from the in-vCluster Pod once the syncer
+# mirrors it) + rtz (the cross-vCluster DB wire when a moved app SHARES the rtz
+# shared-pg/cnpg-pair instead of owning its host-bridged Cluster). The
+# gateway-system/kube-system + catalyst-system/newapi/sso-bridge/oidc-gate
+# entries from 0.2.11 already cover the host Cilium Gateway + the openbao/newapi
+# SSO consumers. Additive netpol-values change only; default render unchanged.
+version: 0.2.12
 appVersion: "0.21.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -176,6 +176,26 @@ mgmtVcluster:
       #   oidc-gate — host slot 13c auth proxy on the gateway datapath →
       #     the moved keycloak realm.
       - oidc-gate
+      # ── #3642 follow-on host-bridge carve-outs ────────────────────────
+      # The remaining 5 host→mgmt moves (openbao auth., harbor registry.,
+      # gitea gitea., newapi newapi., guacamole guacamole.) re-home behind this
+      # isolation netpol. The gateway-system/kube-system + catalyst-system/
+      # newapi/sso-bridge/oidc-gate entries above already cover the host Cilium
+      # Gateway dialing every host-bridged route's mangled backendRef + the
+      # openbao/newapi SSO consumers. Per docs/sessions/2026-06-14/
+      # 3373-migration-plan §7 batch-D set, the additional consumer namespaces:
+      #   harbor + gitea — their host-rendered CNPG `-rw` Services (harbor-pg-rw,
+      #     gitea-pg-rw) are reached cross-cluster by their now-in-vCluster Pods;
+      #     and velero (registry backup) → harbor. Allow-list both host ns.
+      - harbor
+      - gitea
+      #   velero — host slot 34 backs up harbor (registry) + the CNPG WAL/cluster
+      #     backup of the host-rendered Clusters.
+      - velero
+      #   rtz — when a moved app SHARES the rtz shared-pg/cnpg-pair (the
+      #     cross-vCluster DB wire) instead of owning its host-bridged Cluster,
+      #     its in-mgmt Pod must reach rtz. Required once batch-C moves shared-pg.
+      - rtz
 
 # ─── Upstream chart values (subchart key: vcluster) ────────────────
 # `helm dependency build` resolves the upstream loft-sh/vcluster

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/category: platform
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.20
+  version: 0.2.21
   card:
     title: Apache Guacamole
     summary: Clientless HTML5 remote-desktop gateway. Browser-based RDP / VNC / SSH and kubectl-exec into Pods, with Keycloak SSO and full session recording to SeaweedFS. One Guacamole per Sovereign per ADR-0001 §11.

--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -179,7 +179,14 @@ name: bp-guacamole
 # (`persistentvolumeclaim "guacamole-recordings" not found`) — Pending in both
 # regions on hw146. Mirror the webapp's emptyDir/PVC `if` into guacd. Lockstep:
 # 52-bp-guacamole.yaml pin → 0.2.19. Refs #3629.
-version: 0.2.20
+# 0.2.21 (#3642 host-bridge): the CNPG `Cluster` gate now honours an EXPLICIT
+# `false` on guacamole.database.enabled / .cluster.enabled (the Helm
+# `default true <bool>` idiom wrongly coerced a placement-supplied false back to
+# true). Without this the #3642 host-bridge could NOT suppress the in-vCluster
+# Cluster CR (host-rendered instead) — the Cluster double-rendered inside
+# vc-mgmt where no cnpg-operator reconciles it. Default render byte-identical
+# (the key is absent → gate stays true). Lockstep: 52-bp-guacamole.yaml pin.
+version: 0.2.21
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/templates/cnpg-cluster.yaml
+++ b/platform/guacamole/chart/templates/cnpg-cluster.yaml
@@ -21,7 +21,14 @@ template until the CRD is registered (bootstrap order lands bp-cnpg first).
 */ -}}
 {{- $db := .Values.guacamole.database | default dict -}}
 {{- $cl := $db.cluster | default dict -}}
-{{- if and .Values.guacamole.enabled (default true $db.enabled) (default true $cl.enabled) (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") }}
+{{- /* #3642 host-bridge: the gate must honour an EXPLICIT `false` so the
+   placement host-bridge can SUPPRESS the in-vCluster Cluster CR (host-rendered
+   instead). The Helm `default true <bool>` idiom wrongly coerces an explicit
+   false back to true (false is the bool zero-value), so test key-presence +
+   value directly — the same idiom newapi's httproute.yaml uses for ssoInit. */ -}}
+{{- $dbOn := or (not (hasKey $db "enabled")) $db.enabled -}}
+{{- $clOn := or (not (hasKey $cl "enabled")) $cl.enabled -}}
+{{- if and .Values.guacamole.enabled $dbOn $clOn (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") }}
 {{- $name := $cl.name | default "guacamole-pg" -}}
 {{- $ns := $cl.namespace | default .Release.Namespace -}}
 {{- $owner := $cl.owner | default "guacamole" -}}

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -91,9 +91,13 @@ slots:
     # bp-mgmt-vcluster as a new edge — REVERTED by G105-followup
     # PR #2697/#2715/#2717/#2719/#2720 (vCluster lacks Gateway API +
     # ExternalSecret CRDs + mgmt namespace inside itself). App installs
-    # on HOST until vCluster CRD sync ships. bp-mgmt-vcluster edge
-    # dropped to match the live slot 08-openbao.yaml.
-    depends_on: [bp-gateway-api, bp-cnpg]
+    # on HOST until vCluster CRD sync ships.
+    # #3642 (2026-06-17): RE-ADDED via the OSS host-bridge — openbao re-homes
+    # into the mgmt vCluster (placement.yaml vcluster:mgmt + hostBridge:), so
+    # the runtime edge is back (the vc-mgmt Secret must be Ready first). The
+    # route + SSO ExternalSecret are HOST-rendered by the host-bridge, so no
+    # loft.sh license is needed.
+    depends_on: [bp-gateway-api, bp-cnpg, bp-mgmt-vcluster]
     wave: present
   - slot: 9
     name: bp-keycloak
@@ -583,6 +587,12 @@ slots:
       # postgresql.cnpg.io/v1 CRD first or the Cluster CR's Capabilities gate
       # skips on a fresh prov → no admin.
       - bp-cnpg
+      # #3642 (2026-06-17): bp-mgmt-vcluster edge added — guacamole re-homes
+      # into the mgmt vCluster via the OSS host-bridge (placement.yaml
+      # vcluster:mgmt + hostBridge:); the route + CNPG Cluster are HOST-rendered
+      # (the OIDC client secret is a chart-managed lookup Secret that stays
+      # in-vCluster). The runtime edge gates on the vc-mgmt Secret Ready first.
+      - bp-mgmt-vcluster
     wave: present
 
   # ---- Slot 53 — bp-netbird WireGuard zero-trust mesh + remote-access overlay.
@@ -775,9 +785,14 @@ slots:
   #     consumed by unified-rbac (ADR-0003 §3.2 + §6).
   #   - bp-keycloak: OIDC issuer for the ops-staff admin UI.
   #   - bp-cnpg: Postgres for users/credits/channels/audit (claim-driven).
+  # #3642 (2026-06-17): bp-mgmt-vcluster edge added — newapi re-homes into the
+  # mgmt vCluster via the OSS host-bridge (placement.yaml vcluster:mgmt +
+  # hostBridge:); the route + 2 ExternalSecrets + CNPG Cluster are HOST-rendered
+  # so no loft.sh license is needed. The runtime edge gates on the vc-mgmt
+  # Secret being Ready first.
   - slot: 80
     name: bp-newapi
-    depends_on: [bp-openbao, bp-keycloak, bp-cnpg]
+    depends_on: [bp-openbao, bp-keycloak, bp-cnpg, bp-mgmt-vcluster]
     wave: present
 
   # ---- Slot 95 — bp-stalwart-sovereign REMOVED 2026-05-05.


### PR DESCRIPTION
**Refs #3642** — DO NOT MERGE (next train). The #3642 follow-on car completing the host→mgmt migration the #3703 car started for keycloak + grafana.

## What

Moves the remaining **5** host apps into the **mgmt vCluster** via the SAFE OSS-native host-bridge (path B, #3703) — **NOT** the reverted direct-HTTPRoute migration that took down hw130 (`no matches for kind HTTPRoute`).

Each app: `placement.yaml` `vcluster: host` → `mgmt` + a `hostBridge:` block. `render-slot-placement.py` stamps the `suppress` chart values (turning the chart's OWN in-vCluster route/secret/CNPG off) and transcribes the `hostDocuments` VERBATIM into the slot between the `HOST-BRIDGE` markers. The host Cilium Gateway / external-secrets-operator / cnpg-operator reconcile the host-rendered CRs (backendRef → the OSS-synced syncer-mangled Service `<svc>-x-<innerNs>-x-mgmt-vcluster`); only the workload re-homes into vc-mgmt. **No loft.sh license** — the Pillar-5 cutover 600s deny-egress hold still passes.

| App (slot) | host docs | suppress |
|---|---|---|
| **openbao** (08) | route (3-rule bare-URL landing) + SSO ES | `gateway.enabled:false` (sso.enabled kept → in-vCluster landing/configure Deployments render) |
| **harbor** (19) | route + SSO ES + CNPG `harbor-pg` | `gateway.enabled`/`sso.enabled`/`postgres.cluster.enabled` :false |
| **gitea** (10) | route (2-rule OIDC entry) + SSO ES (template remap) + CNPG `gitea-pg` | same 3 |
| **newapi** (80) | route (2-rule zero-click) + 2 ES (`catalyst-newapi-admin-token` reflected→catalyst-system + `newapi-oidc` Merge) + CNPG `newapi-bp-newapi-newapi-pg` + DSN placeholder | `ingress.httpRoute.enabled`/`cnpg.enabled`/`catalystIntegration.externalSecret.enabled`/`auth.adminUI.keycloak.ssoBridgeSync.enabled` :false |
| **guacamole** (52) | route + CNPG `guacamole-pg` (ns `catalyst-system`); **no ES** — OIDC secret is a chart-managed lookup Secret that stays in-vCluster | `guacamole.httproute.enabled`/`guacamole.database.cluster.enabled` :false |

## Lockstep

- The placement flip cascades: every dependent's edge to a moved HR re-points `flux-system` → `mgmt` (cutover / sso-bridge / es-stores / sandbox / catalyst-platform + the moved apps' cross-edges) — done by `render-slot-placement.py fix`.
- `expected-bootstrap-deps.yaml`: **+`bp-mgmt-vcluster`** runtime edge for bp-openbao / bp-newapi / bp-guacamole (harbor/gitea already had it).
- **bp-mgmt-vcluster 0.2.12** — §5c carve-outs `harbor`/`gitea`/`velero`/`rtz` added to `allowedIngressNamespaces` (their host-bridged CNPG `-rw` Services + velero registry backup + the cross-vCluster shared-pg wire). The 0.2.11 `gateway-system`/`kube-system` + `catalyst-system`/`newapi`/`sso-bridge`/`oidc-gate` entries already cover the host Cilium Gateway + SSO consumers.
- **bp-guacamole 0.2.21** — CNPG `Cluster` gate now honours an EXPLICIT `false` on `database.cluster.enabled` (the Helm `default true <bool>` idiom coerced the placement-supplied false back to true, so the host-bridge couldn't suppress the in-vCluster Cluster CR). Default render byte-identical.

## Gates (all green)

- `render-slot-placement.py check` ✅ (16 in vClusters; the 5 dropped off the staged-promotion list)
- host-bridge render-test ✅
- `audit-placement-conformance.py rendered` ✅
- `check-bootstrap-deps.sh` ✅ (drift 0 / cycles 0)
- `check-bootstrap-kit-pin-sync.sh` — bp-mgmt-vcluster 0.2.12 + bp-guacamole 0.2.21 **OK** (the pre-existing bp-catalyst-platform 1.4.656/1.4.657 drift is unrelated — untouched by this PR)
- `kubectl kustomize build` ✅
- bootstrap-kit Go static-parse (`TemplateClusterParses`) ✅
- `helm template` verified: each chart's in-vCluster route/secret/CNPG → **0** under the suppress values; baseline unchanged (newapi 3→0, gitea 3→0, harbor 3→0, openbao route 1→0, guacamole 2→0 after the 0.2.21 gate fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)