### PR TITLE
ci: enforce cloud-init 32256B size cap as a required PR check (Refs #3720)

### DIFF
--- a/.github/workflows/catalyst-build.yaml
+++ b/.github/workflows/catalyst-build.yaml
@@ -382,6 +382,32 @@ jobs:
           done
           echo "G36 gate OK: every templatefile() in huawei parses + renders."
 
+      # Loud-signal on a main-push build-api FAILURE (issue #3724 / Refs #3720).
+      #
+      # When #3715's cloud-init bloat merged, this job's G36 step failed on EVERY
+      # subsequent main commit — but nothing SHOUTED, so no catalyst-api image
+      # built for hours and the mothership silently froze 15 commits behind main
+      # (never receiving the #3717 fix). The regression should now be caught at
+      # PR time by `cloud-init-size.yaml` (a required check) + infra-*-tofu.yaml,
+      # but if anything still reaches a red main build, make it UNMISSABLE: an
+      # ::error:: annotation + a Step Summary block naming the broken job and the
+      # consequence (no image published → mothership freezes). `if: failure()`
+      # fires only when an earlier step in this job failed.
+      - name: Announce build-api failure (no catalyst-api image will publish)
+        if: failure()
+        run: |
+          MSG="Build & Deploy Catalyst: build-api FAILED on ${GITHUB_REF_NAME} @ ${GITHUB_SHA}. No catalyst-api image was published for this commit — the mothership will NOT roll forward and silently stays on the last green SHA until this is fixed. Most common cause: the rendered cloud-init exceeded the 32256-byte Hetzner user_data guardrail (see the G36 tofu test step + issue #3724). Inspect the failed step above and revert/trim before the mothership drifts further behind main."
+          echo "::error title=catalyst-api build FAILED — mothership will freeze::${MSG}"
+          {
+            echo "## :rotating_light: Build & Deploy Catalyst — build-api FAILED"
+            echo ""
+            echo "${MSG}"
+            echo ""
+            echo "- Ref: \`${GITHUB_REF_NAME}\`"
+            echo "- Commit: \`${GITHUB_SHA}\`"
+            echo "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
       - name: Push API image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/cloud-init-size.yaml
+++ b/.github/workflows/cloud-init-size.yaml
@@ -1,0 +1,104 @@
+name: cloud-init size gate
+
+# PR-LEVEL guardrail against the cloud-init `user_data` size regression that
+# froze "Build & Deploy Catalyst" for hours on 2026-06-16 (issue #3724 / Refs
+# #3720). Background:
+#
+# PR #3715 added +124 lines to infra/providers/_shared/cloudinit-control-
+# plane.tftpl, pushing the *rendered* Hetzner control-plane cloud-init past the
+# 32256-byte `user_data` guardrail. It merged anyway — the existing PR-level
+# `tofu test` (infra-hetzner-tofu.yaml) DID fail, but its check was not a
+# required check and shared the ambiguous name `validate + fmt + test` with the
+# huawei sibling, so the red was easy to miss. On `push: main` the catalyst-
+# build "G36 — tofu test" step then failed on EVERY commit → no catalyst-api
+# image built → the mothership silently froze 15 commits behind main and never
+# received the #3717 fix.
+#
+# This workflow exists so the size cap is enforced by a SINGLE, UNIQUELY-NAMED,
+# required-able PR check per provider (`cloud-init size gate / hetzner`,
+# `cloud-init size gate / huawei`) that:
+#   1. FAILS the PR before merge when the real rendered cloud-init exceeds the
+#      32256 / 30720 guardrails (tests/cloudinit_size.tftest.hcl — real module
+#      render under mock_provider, zero render-harness drift). This ALSO adds
+#      size coverage to the huawei module, which had no size precondition at all.
+#   2. Emits a HEADROOM WARNING + exact byte count (scripts/cloudinit-size-
+#      report.sh) so the cliff is visible before a PR trips it. Mark BOTH matrix
+#      legs required in branch protection so a red here blocks merge.
+#
+# Per CLAUDE.md "every workflow MUST be event-driven, NEVER scheduled": this is
+# pull_request-on-touch + push-on-merge; ad-hoc reruns go through
+# workflow_dispatch. No `schedule:` trigger.
+
+on:
+  pull_request:
+    paths:
+      # The shared, cloud-agnostic control-plane template (the #3715 culprit).
+      - 'infra/providers/_shared/**'
+      # Per-provider modules: their main.tf wires the templatefile() vars + the
+      # per-provider worker template, both of which change the rendered size.
+      - 'infra/providers/hetzner/**'
+      - 'infra/providers/huawei/**'
+      # The bootstrap-kit content the cloud-init bundles/threads can also move
+      # the rendered size (BOOTSTRAP_KIT substitutes), so re-check on its change.
+      - 'products/catalyst/bootstrap/**'
+      - 'scripts/cloudinit-size-report.sh'
+      - '.github/workflows/cloud-init-size.yaml'
+  push:
+    branches: [main]
+    paths:
+      - 'infra/providers/_shared/**'
+      - 'infra/providers/hetzner/**'
+      - 'infra/providers/huawei/**'
+      - 'products/catalyst/bootstrap/**'
+      - 'scripts/cloudinit-size-report.sh'
+      - '.github/workflows/cloud-init-size.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  size-gate:
+    # Unique, per-provider check name — NOT the ambiguous `validate + fmt + test`
+    # that infra-hetzner-tofu.yaml and infra-huawei-tofu.yaml both expose. Mark
+    # `cloud-init size gate / hetzner` and `cloud-init size gate / huawei`
+    # required in branch protection.
+    name: cloud-init size gate / ${{ matrix.provider }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: [hetzner, huawei]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          # Lockstep with the infra-${{ matrix.provider }}-tofu.yaml siblings
+          # (1.8.5) so a future OpenTofu bump moves all the module-local checks
+          # atomically.
+          tofu_version: 1.8.5
+
+      - name: tofu init (backend=false — no real state for the render-only check)
+        working-directory: infra/providers/${{ matrix.provider }}
+        run: tofu init -backend=false -input=false -no-color
+
+      # BLOCKING GATE — the real module renders the cloud-init under mock_provider
+      # and the size suite asserts it stays under the 32256 / 30720 guardrails.
+      # A render over the cap fails this step → fails the (required) check → the
+      # PR cannot merge. This is the gate that #3715 needed at PR time.
+      - name: cloud-init size assertions (tofu test)
+        working-directory: infra/providers/${{ matrix.provider }}
+        run: tofu test -no-color -filter=tests/cloudinit_size.tftest.hcl
+
+      # HEADROOM SIGNAL — report the exact rendered byte count and annotate a
+      # WARNING once it crosses ~93% of the cap (so the cliff is visible before a
+      # PR trips it) or an ERROR if it is already over. This step is advisory:
+      # the blocking gate above is the hard fail. `if: always()` so the count is
+      # reported even if the gate failed (then it doubles as the over-cap number).
+      - name: cloud-init headroom report
+        if: always()
+        run: scripts/cloudinit-size-report.sh "infra/providers/${{ matrix.provider }}" "${{ matrix.provider }}"

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ products/*/chart/Chart.lock
 # provider binaries; only the .terraform/ working dir + state files are
 # ignored.
 **/.terraform/
+# Throwaway probe dir written by scripts/cloudinit-size-report.sh during CI to
+# measure the rendered cloud-init size; removed on exit, never committed (#3724).
+**/.cloudinit-size-probe/
 **/terraform.tfstate
 **/terraform.tfstate.backup
 **/*.tfstate

--- a/infra/providers/hetzner/tests/cloudinit_size.tftest.hcl
+++ b/infra/providers/hetzner/tests/cloudinit_size.tftest.hcl
@@ -1,0 +1,129 @@
+# Cloud-init user_data size gate for the Catalyst Hetzner Phase-0 module.
+#
+# WHY THIS FILE EXISTS (incident 2026-06-16, issue #3724 / Refs #3720):
+# PR #3715 added +124 lines to infra/providers/_shared/cloudinit-control-
+# plane.tftpl, pushing the *rendered* Hetzner control-plane cloud-init past
+# the 32256-byte Hetzner `user_data` hard guardrail (main.tf:949 precondition,
+# Hetzner's absolute cap is 32768). The PR-level `tofu test` in
+# infra-hetzner-tofu.yaml DID fail on that PR — but the red check was not a
+# required/blocking check and shared the ambiguous name `validate + fmt + test`
+# with the huawei sibling, so it merged anyway. On `push: main` the catalyst-
+# build "G36 — tofu test" step then failed on every commit → no catalyst-api
+# image built for hours → the mothership silently froze 15 commits behind main
+# and never received the #3717 fix. Reverted in #3720/#3721.
+#
+# This dedicated, single-purpose size suite asserts the REAL rendered cloud-init
+# (rendered through the real module under mock_provider — zero render-harness
+# drift) stays under the same guardrails the production preconditions enforce.
+# The companion `.github/workflows/cloud-init-size.yaml` runs it under a UNIQUE,
+# required-able check name (`cloud-init-size / hetzner`) and additionally emits a
+# headroom WARNING once the rendered size crosses ~93% of the cap, so the cliff
+# is visible before a PR trips it.
+#
+# These thresholds mirror infra/providers/hetzner/main.tf exactly:
+#   - control_plane_cloud_init         <= 32256  (main.tf:949)
+#   - worker_cloud_init                <= 30720  (main.tf:959)
+#   - each secondary_region_cloud_init <= 32256  (main.tf:1428)
+# Keep them in lockstep if the production preconditions ever change.
+#
+# nonsensitive() wraps every length() because local.*_cloud_init embeds
+# sensitive tokens (ghcr / harbor / object-storage creds); without it OpenTofu
+# redacts the whole error_message and the operator can't see the byte overshoot
+# (same reason main.tf:956 wraps its precondition message). length() of a
+# sensitive string is itself sensitive; nonsensitive(length(...)) leaks only the
+# integer byte count, never any token bytes.
+
+mock_provider "hcloud" {
+  mock_resource "hcloud_network" {
+    defaults = { id = "1" }
+  }
+  mock_resource "hcloud_network_subnet" {
+    defaults = { id = "1" }
+  }
+  mock_resource "hcloud_load_balancer" {
+    defaults = { id = "1", ipv4 = "203.0.113.10" }
+  }
+  mock_resource "hcloud_load_balancer_network" {
+    defaults = { id = "1" }
+  }
+  mock_resource "hcloud_load_balancer_target" {
+    defaults = { id = "1" }
+  }
+  mock_resource "hcloud_load_balancer_service" {
+    defaults = { id = "1" }
+  }
+  mock_resource "hcloud_server" {
+    defaults = { id = "1", ipv4_address = "203.0.113.20" }
+  }
+  mock_resource "hcloud_ssh_key" {
+    defaults = { id = "1" }
+  }
+  mock_resource "hcloud_firewall" {
+    defaults = { id = "1" }
+  }
+}
+
+# Same aws (Object Storage) overrides the multi_region suite uses — bypass the
+# provider's schema-validation race under `tofu test` (see multi_region.tftest.hcl
+# for the full rationale). Size rendering doesn't touch these resources.
+override_resource {
+  target = aws_s3_bucket.main
+  values = { id = "catalyst-test-example-com" }
+}
+
+override_resource {
+  target = aws_s3_bucket_acl.main
+  values = {}
+}
+
+variables {
+  sovereign_fqdn             = "test.example.com"
+  sovereign_subdomain        = "test"
+  org_name                   = "Test Org"
+  org_email                  = "ops@example.com"
+  hcloud_token               = "mock-hcloud-token"
+  hcloud_project_id          = "12345"
+  region                     = "hel1"
+  control_plane_size         = "cpx22"
+  worker_size                = "cpx32"
+  worker_count               = 2
+  k3s_version                = "v1.31.4+k3s1"
+  ssh_public_key             = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEYTESTKEYTESTKEYTESTKEYTESTKEY test@local"
+  object_storage_region      = "nbg1"
+  object_storage_access_key  = "TESTACCESSKEY1234567"
+  object_storage_secret_key  = "TESTSECRETKEYTESTSECRETKEYTESTSE"
+  object_storage_bucket_name = "catalyst-test-example-com"
+  domain_mode                = "byo"
+
+  # Two-region payload so the secondary-region cloud-init locals are
+  # materialised and their size asserted (the secondary render carries its own
+  # per-region substitutes and was the exact local that also overshot on #3715).
+  regions = [
+    { provider = "hetzner", cloudRegion = "hel1", controlPlaneSize = "cpx22", workerSize = "cpx32", workerCount = 2 },
+    { provider = "hetzner", cloudRegion = "nbg1", controlPlaneSize = "cpx22", workerSize = "cpx32", workerCount = 2 }
+  ]
+}
+
+run "control_plane_cloud_init_under_32256" {
+  command = plan
+  assert {
+    condition     = nonsensitive(length(local.control_plane_cloud_init)) <= 32256
+    error_message = "Primary control-plane cloud-init is ${nonsensitive(length(local.control_plane_cloud_init))} bytes, exceeds the 32256-byte Hetzner user_data guardrail (hard cap 32768). Cull comments / move bloat out of infra/providers/_shared/cloudinit-control-plane.tftpl. See issues #966 / #3724."
+  }
+}
+
+run "worker_cloud_init_under_30720" {
+  command = plan
+  assert {
+    condition     = nonsensitive(length(local.worker_cloud_init)) <= 30720
+    error_message = "Worker cloud-init is ${nonsensitive(length(local.worker_cloud_init))} bytes, exceeds the 30720-byte worker guardrail (hard cap 32768). Cull comments / move bloat out of infra/providers/hetzner/cloudinit-worker.tftpl. See issue #966."
+  }
+}
+
+run "secondary_region_cloud_init_under_32256" {
+  command = plan
+  assert {
+    condition     = alltrue([for k, v in local.secondary_region_cloud_init : nonsensitive(length(v)) <= 32256])
+    error_message = "At least one secondary-region control-plane cloud-init exceeds the 32256-byte Hetzner user_data guardrail. Per-region sizes: ${jsonencode({ for k, v in local.secondary_region_cloud_init : k => nonsensitive(length(v)) })}."
+  }
+}

--- a/infra/providers/huawei/tests/cloudinit_size.tftest.hcl
+++ b/infra/providers/huawei/tests/cloudinit_size.tftest.hcl
@@ -1,0 +1,106 @@
+# Cloud-init user_data size gate for the Catalyst Huawei (HCS) Phase-0 module.
+#
+# WHY THIS FILE EXISTS (incident 2026-06-16, issue #3724 / Refs #3720):
+# The 32256-byte regression that froze catalyst-build for hours (PR #3715) bloated
+# infra/providers/_shared/cloudinit-control-plane.tftpl — the SAME template this
+# Huawei module renders (see local.cp_cloud_init_by_region below). Hetzner caught
+# it via its main.tf:949 precondition; Huawei caught NOTHING because this module
+# has *no* user_data size precondition at all (see the comment at main.tf:625:
+# "HCS does not document a hard cap ... but we keep the same conservative budget
+# so the same template scales to fresh-prov against either cloud"). That budget
+# was aspirational — nothing enforced it. This suite enforces it.
+#
+# A `_shared`-template bloat that happens to fit Huawei's render but overshoots
+# Hetzner's would previously only fail on the Hetzner side; a Huawei-only bloat
+# would be caught nowhere. This gate closes both gaps by asserting Huawei's REAL
+# rendered cloud-init (rendered through the real module under mock_provider —
+# zero render-harness drift) against the same conservative budget Hetzner enforces.
+# The companion `.github/workflows/cloud-init-size.yaml` runs it under a UNIQUE,
+# required-able check name (`cloud-init-size / huawei`) and emits a headroom
+# WARNING once any region's render crosses ~93% of the cap.
+#
+# Budget (mirrors the Hetzner module's hard caps — the shared template targets
+# the stricter of the two clouds so one template fresh-provs against either):
+#   - cp_cloud_init_by_region[*]     <= 32256
+#   - worker_cloud_init_by_region[*] <= 30720
+#
+# nonsensitive() wraps every length() because the rendered cloud-init embeds
+# sensitive tokens (huawei AK/SK, harbor / ghcr creds); without it OpenTofu
+# redacts the whole error_message and the operator can't see the byte overshoot.
+# length() of a sensitive string is itself sensitive; nonsensitive(length(...))
+# leaks only the integer byte count, never any token bytes.
+
+mock_provider "huaweicloud" {
+  mock_resource "huaweicloud_vpc" {
+    defaults = { id = "vpc-mock-1" }
+  }
+  mock_resource "huaweicloud_vpc_subnet" {
+    defaults = { id = "subnet-mock-1" }
+  }
+  mock_resource "huaweicloud_vpc_eip" {
+    defaults = { id = "eip-mock-1", address = "203.0.113.10" }
+  }
+  mock_resource "huaweicloud_networking_secgroup" {
+    defaults = { id = "sg-mock-1" }
+  }
+  mock_resource "huaweicloud_networking_secgroup_rule" {
+    defaults = { id = "sgr-mock-1" }
+  }
+  mock_resource "huaweicloud_compute_instance" {
+    defaults = { id = "ecs-mock-1", access_ip_v4 = "10.20.1.10" }
+  }
+  mock_resource "huaweicloud_kps_keypair" {
+    defaults = { id = "kp-mock-1" }
+  }
+  mock_resource "huaweicloud_obs_bucket" {
+    defaults = { id = "catalyst-test-bucket" }
+  }
+}
+
+variables {
+  deployment_id       = "deadbeefcafef00d"
+  sovereign_fqdn      = "t99.omani.works"
+  huawei_access_key   = "AKIAEXAMPLEAKIAEXAMPLE"
+  huawei_secret_key   = "secret-key-not-real-just-padding-32chars"
+  huawei_project_id   = "0123456789abcdef0123456789abcdef"
+  org_name            = "Acme Test"
+  org_email           = "admin@example.com"
+  obs_bucket_name     = "catalyst-t99-omani-works-deadbeef"
+  ssh_public_key      = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTest test@bastion"
+  parent_domains_yaml = ""
+
+  # Two-region Tier-B payload so BOTH the primary and the secondary per-region
+  # cloud-init renders are materialised and size-asserted.
+  regions = [
+    {
+      code               = "me-east-215-a"
+      role               = "primary"
+      control_plane_size = "s7n.large.4"
+      worker_size        = "m7n.xlarge.8"
+      worker_count       = 2
+    },
+    {
+      code               = "me-east-215-b"
+      role               = "secondary"
+      control_plane_size = "s7n.large.4"
+      worker_size        = "m7n.xlarge.8"
+      worker_count       = 2
+    }
+  ]
+}
+
+run "control_plane_cloud_init_under_32256" {
+  command = plan
+  assert {
+    condition     = alltrue([for k, v in local.cp_cloud_init_by_region : nonsensitive(length(v)) <= 32256])
+    error_message = "At least one region's control-plane cloud-init exceeds the 32256-byte user_data budget. Per-region sizes: ${jsonencode({ for k, v in local.cp_cloud_init_by_region : k => nonsensitive(length(v)) })}. Cull comments / move bloat out of infra/providers/_shared/cloudinit-control-plane.tftpl. See issue #3724."
+  }
+}
+
+run "worker_cloud_init_under_30720" {
+  command = plan
+  assert {
+    condition     = alltrue([for k, v in local.worker_cloud_init_by_region : nonsensitive(length(v)) <= 30720])
+    error_message = "At least one region's worker cloud-init exceeds the 30720-byte user_data budget. Per-region sizes: ${jsonencode({ for k, v in local.worker_cloud_init_by_region : k => nonsensitive(length(v)) })}. Cull comments / move bloat out of infra/providers/huawei/cloudinit-worker.tftpl. See issue #3724."
+  }
+}

--- a/scripts/cloudinit-size-report.sh
+++ b/scripts/cloudinit-size-report.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# cloudinit-size-report.sh — report the EXACT rendered cloud-init user_data byte
+# count for a provider module, and emit a GitHub headroom annotation.
+#
+# WHY (issue #3724 / Refs #3720): the 32256-byte Hetzner user_data cap is a
+# cliff. PR #3715 rendered the control-plane cloud-init at >32256 and froze
+# catalyst-build for hours. The blocking gate (tests/cloudinit_size.tftest.hcl)
+# fails a PR that crosses the cap — but by then you're already over. This script
+# surfaces the *exact* byte count on EVERY run and WARNS once the render crosses
+# ~93% of the cap (HEADROOM_WARN_BYTES), so the cliff is visible while there's
+# still room to act.
+#
+# HOW the byte count is obtained with ZERO render drift:
+# The only faithful source of the rendered size is the real module's own local
+# (it threads the multi-KB provider-injected strings — registry mirror, cloud-
+# credentials secret, crossplane provider yaml, kubeconfig PUT block — that a
+# standalone templatefile() harness would omit and thus undercount by KBs). A
+# `tofu test` assert can read that local directly. OpenTofu only renders an
+# assert's error_message on FAILURE, so to print the count unconditionally we run
+# a probe whose condition is deliberately false (`length(...) < 0`) and whose
+# error_message is `CLOUDINIT_<KIND>_BYTES=${nonsensitive(length(<local>))}`.
+# nonsensitive() is required because the local embeds secrets (same reason the
+# production precondition at main.tf:956 wraps its length()); it leaks only the
+# integer byte count, never any token bytes.
+#
+# The probe is generated into a throwaway module subdir and run via
+# `tofu test -test-directory=<subdir>` (relative dir under the module — OpenTofu
+# resolves test dirs relative to the module, absolute paths are NOT discovered).
+# The committed tests/ suite is never touched, so the existing infra-*-tofu.yaml
+# `tofu test` (which runs every file in tests/) stays green. The subdir is
+# removed on exit.
+#
+# This script NEVER fails the job on the size cap — that is the blocking gate's
+# job (tests/cloudinit_size.tftest.hcl, run separately). It only reports + warns.
+# It exits non-zero only on its own operational failure (couldn't render).
+#
+# Usage:  scripts/cloudinit-size-report.sh <provider-module-dir> <provider>
+#   <provider>: hetzner | huawei  (selects the right local name + probe vars)
+
+set -euo pipefail
+
+MODULE_DIR="${1:?usage: cloudinit-size-report.sh <module-dir> <hetzner|huawei>}"
+PROVIDER="${2:?usage: cloudinit-size-report.sh <module-dir> <hetzner|huawei>}"
+
+# Hetzner's hard cap is 32768; the production guardrail trips at 32256. We warn
+# at HEADROOM_WARN_BYTES (~93% of 32256) so a PR sees the cliff coming. Override
+# via env for local experimentation.
+SIZE_CAP_BYTES="${SIZE_CAP_BYTES:-32256}"
+HEADROOM_WARN_BYTES="${HEADROOM_WARN_BYTES:-30000}"
+
+PROBE_DIR_NAME=".cloudinit-size-probe"
+PROBE_DIR="${MODULE_DIR}/${PROBE_DIR_NAME}"
+cleanup() { rm -rf "${PROBE_DIR}"; }
+trap cleanup EXIT
+mkdir -p "${PROBE_DIR}"
+
+# Per-provider: the mock_provider + override + minimal variables block needed to
+# materialise the cloud-init local, plus the local name to measure. Kept in
+# lockstep with the committed tests/cloudinit_size.tftest.hcl of each provider.
+case "${PROVIDER}" in
+  hetzner)
+    LOCAL_EXPR='length(local.control_plane_cloud_init)'
+    cat > "${PROBE_DIR}/probe.tftest.hcl" <<'PROBE'
+mock_provider "hcloud" {
+  mock_resource "hcloud_network" {
+    defaults = { id = "1" }
+  }
+  mock_resource "hcloud_network_subnet" {
+    defaults = { id = "1" }
+  }
+  mock_resource "hcloud_load_balancer" {
+    defaults = { id = "1", ipv4 = "203.0.113.10" }
+  }
+  mock_resource "hcloud_load_balancer_network" {
+    defaults = { id = "1" }
+  }
+  mock_resource "hcloud_load_balancer_target" {
+    defaults = { id = "1" }
+  }
+  mock_resource "hcloud_load_balancer_service" {
+    defaults = { id = "1" }
+  }
+  mock_resource "hcloud_server" {
+    defaults = { id = "1", ipv4_address = "203.0.113.20" }
+  }
+  mock_resource "hcloud_ssh_key" {
+    defaults = { id = "1" }
+  }
+  mock_resource "hcloud_firewall" {
+    defaults = { id = "1" }
+  }
+}
+override_resource {
+  target = aws_s3_bucket.main
+  values = { id = "catalyst-test-example-com" }
+}
+override_resource {
+  target = aws_s3_bucket_acl.main
+  values = {}
+}
+variables {
+  sovereign_fqdn             = "test.example.com"
+  sovereign_subdomain        = "test"
+  org_name                   = "Test Org"
+  org_email                  = "ops@example.com"
+  hcloud_token               = "mock-hcloud-token"
+  hcloud_project_id          = "12345"
+  region                     = "hel1"
+  control_plane_size         = "cpx22"
+  worker_size                = "cpx32"
+  worker_count               = 2
+  k3s_version                = "v1.31.4+k3s1"
+  ssh_public_key             = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEYTESTKEYTESTKEYTESTKEYTESTKEY test@local"
+  object_storage_region      = "nbg1"
+  object_storage_access_key  = "TESTACCESSKEY1234567"
+  object_storage_secret_key  = "TESTSECRETKEYTESTSECRETKEYTESTSE"
+  object_storage_bucket_name = "catalyst-test-example-com"
+  domain_mode                = "byo"
+}
+run "emit_cp_bytes" {
+  command = plan
+  assert {
+    condition     = nonsensitive(length(local.control_plane_cloud_init)) < 0
+    error_message = "CLOUDINIT_CP_BYTES=${nonsensitive(length(local.control_plane_cloud_init))}"
+  }
+}
+PROBE
+    ;;
+  huawei)
+    LOCAL_EXPR='max([for v in values(local.cp_cloud_init_by_region) : length(v)]...)'
+    cat > "${PROBE_DIR}/probe.tftest.hcl" <<'PROBE'
+mock_provider "huaweicloud" {
+  mock_resource "huaweicloud_vpc" {
+    defaults = { id = "vpc-mock-1" }
+  }
+  mock_resource "huaweicloud_vpc_subnet" {
+    defaults = { id = "subnet-mock-1" }
+  }
+  mock_resource "huaweicloud_vpc_eip" {
+    defaults = { id = "eip-mock-1", address = "203.0.113.10" }
+  }
+  mock_resource "huaweicloud_networking_secgroup" {
+    defaults = { id = "sg-mock-1" }
+  }
+  mock_resource "huaweicloud_networking_secgroup_rule" {
+    defaults = { id = "sgr-mock-1" }
+  }
+  mock_resource "huaweicloud_compute_instance" {
+    defaults = { id = "ecs-mock-1", access_ip_v4 = "10.20.1.10" }
+  }
+  mock_resource "huaweicloud_kps_keypair" {
+    defaults = { id = "kp-mock-1" }
+  }
+  mock_resource "huaweicloud_obs_bucket" {
+    defaults = { id = "catalyst-test-bucket" }
+  }
+}
+variables {
+  deployment_id       = "deadbeefcafef00d"
+  sovereign_fqdn      = "t99.omani.works"
+  huawei_access_key   = "AKIAEXAMPLEAKIAEXAMPLE"
+  huawei_secret_key   = "secret-key-not-real-just-padding-32chars"
+  huawei_project_id   = "0123456789abcdef0123456789abcdef"
+  org_name            = "Acme Test"
+  org_email           = "admin@example.com"
+  obs_bucket_name     = "catalyst-t99-omani-works-deadbeef"
+  ssh_public_key      = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTest test@bastion"
+  parent_domains_yaml = ""
+  regions = [
+    {
+      code               = "me-east-215-a"
+      role               = "primary"
+      control_plane_size = "s7n.large.4"
+      worker_size        = "m7n.xlarge.8"
+      worker_count       = 2
+    }
+  ]
+}
+run "emit_cp_bytes" {
+  command = plan
+  assert {
+    condition     = nonsensitive(max([for v in values(local.cp_cloud_init_by_region) : length(v)]...)) < 0
+    error_message = "CLOUDINIT_CP_BYTES=${nonsensitive(max([for v in values(local.cp_cloud_init_by_region) : length(v)]...))}"
+  }
+}
+PROBE
+    ;;
+  *)
+    echo "::error::cloudinit-size-report: unknown provider '${PROVIDER}' (want hetzner|huawei)"
+    exit 2
+    ;;
+esac
+
+echo "Rendering ${PROVIDER} cloud-init to measure user_data size (${LOCAL_EXPR})..."
+
+# Run the probe (it is DESIGNED to fail — its condition is always false — so the
+# byte-count error_message renders). We tolerate the non-zero test exit; what
+# matters is whether the count line was emitted.
+PROBE_OUT="$(cd "${MODULE_DIR}" && tofu test -no-color -test-directory="${PROBE_DIR_NAME}" 2>&1 || true)"
+
+# Normal (under-cap) path: our probe's error_message prints CLOUDINIT_CP_BYTES=N.
+BYTES="$(printf '%s\n' "${PROBE_OUT}" | grep -oE 'CLOUDINIT_CP_BYTES=[0-9]+' | head -1 | cut -d= -f2 || true)"
+
+# Over-cap fallback: when the render is already over the guardrail, the module's
+# OWN production precondition (hcloud_server.control_plane lifecycle, main.tf:949)
+# trips during `plan` and aborts the run BEFORE our probe assert renders. That
+# precondition's message states the exact size ("... cloud-init is NNNNN bytes,
+# exceeds 32256 ..."), so we parse it as the count source. This keeps the number
+# visible (and lets us emit the over-cap ::error::) even past the cliff.
+if [ -z "${BYTES:-}" ]; then
+  BYTES="$(printf '%s\n' "${PROBE_OUT}" | grep -oE 'cloud-init (for secondary region [^ ]+ )?is [0-9]+ bytes' | grep -oE '[0-9]+' | sort -nr | head -1 || true)"
+fi
+
+if [ -z "${BYTES:-}" ]; then
+  echo "::error::cloudinit-size-report: could not extract rendered byte count for ${PROVIDER}. Probe output follows:"
+  printf '%s\n' "${PROBE_OUT}"
+  exit 1
+fi
+
+PCT=$(( BYTES * 100 / SIZE_CAP_BYTES ))
+HEADROOM=$(( SIZE_CAP_BYTES - BYTES ))
+
+SUMMARY_LINE="${PROVIDER}: rendered control-plane cloud-init = ${BYTES} bytes (${PCT}% of the ${SIZE_CAP_BYTES}-byte guardrail; ${HEADROOM} bytes headroom before the cap)."
+echo "${SUMMARY_LINE}"
+
+# GitHub Step Summary (visible on the run page).
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### cloud-init size — ${PROVIDER}"
+    echo ""
+    echo "- Rendered control-plane cloud-init: **${BYTES} bytes** (${PCT}% of ${SIZE_CAP_BYTES} guardrail)"
+    echo "- Headroom before guardrail: **${HEADROOM} bytes**"
+    echo "- Hetzner hard \`user_data\` cap: 32768 bytes"
+  } >> "${GITHUB_STEP_SUMMARY}"
+fi
+
+if [ "${BYTES}" -gt "${SIZE_CAP_BYTES}" ]; then
+  # Over the guardrail — the blocking gate (tests/cloudinit_size.tftest.hcl) will
+  # already have failed the job; emit an error annotation too so the number is
+  # unmissable.
+  echo "::error title=cloud-init OVER cap (${PROVIDER})::${SUMMARY_LINE} This exceeds the guardrail — the size gate fails. Cull comments / move bloat out of infra/providers/_shared/cloudinit-control-plane.tftpl."
+elif [ "${BYTES}" -ge "${HEADROOM_WARN_BYTES}" ]; then
+  echo "::warning title=cloud-init headroom low (${PROVIDER})::${SUMMARY_LINE} Only ${HEADROOM} bytes left before the ${SIZE_CAP_BYTES}-byte guardrail (warn threshold ${HEADROOM_WARN_BYTES}). Trim the shared cloud-init template before adding more."
+else
+  echo "::notice title=cloud-init size OK (${PROVIDER})::${SUMMARY_LINE}"
+fi


### PR DESCRIPTION
## What

Adds a **dedicated, uniquely-named, required-able PR-level gate** so a cloud-init `user_data` size regression is caught **before merge**, not hours later on a frozen main.

Closes the gap behind the 2026-06-16 incident (issue #3724): PR #3715 pushed the rendered Hetzner control-plane cloud-init past the **32256-byte** guardrail and merged anyway → `catalyst-build` ("Build & Deploy Catalyst") then failed on **every** main commit → no catalyst-api image built for hours → the mothership silently froze 15 commits behind main and never received the critical #3717 fix. Reverted in #3720/#3721.

## Root cause (more specific than "G36 only runs on push")

A PR-level size gate **already existed**: `infra-hetzner-tofu.yaml` runs `tofu test` (which evaluates the 32256 precondition) on `pull_request`. On PR #3715 it **DID run and DID fail** (check `infra/hetzner — OpenTofu validate + test`, run `27646893533`, step `tofu test`, conclusion=failure). The PR merged anyway because:

1. **Not a required/blocking check** — the red did not block merge.
2. **Ambiguous duplicate name** — `infra-hetzner-tofu.yaml` and `infra-huawei-tofu.yaml` both expose the job as `validate + fmt + test`, so the PR check list showed `validate + fmt + test  fail` next to `validate + fmt + test  pass` — easy to miss, hard to mark required.

Plus: **huawei had no size precondition at all** (renders the same `_shared` template; see `infra/providers/huawei/main.tf:625` — "we keep the same conservative budget" was aspirational, never enforced).

## Approach — new dedicated workflow (NOT extending catalyst-build)

I did **not** add `pull_request` to `catalyst-build.yaml` — that would be a **third** copy of a gate that already runs at PR level in `infra-*-tofu.yaml`. Instead:

| File | Role |
|---|---|
| `.github/workflows/cloud-init-size.yaml` | **New** PR + push gate. Per-provider matrix with **unique check names** (`cloud-init size gate / hetzner`, `cloud-init size gate / huawei`) that can be marked **required** in branch protection and won't collide. Path-scoped to `infra/providers/**` + `products/catalyst/bootstrap/**`. |
| `infra/providers/hetzner/tests/cloudinit_size.tftest.hcl` | **Blocking** size assertions on the **real** rendered cloud-init (real module under `mock_provider` — zero render-harness drift): CP ≤ 32256, worker ≤ 30720, each secondary region ≤ 32256. |
| `infra/providers/huawei/tests/cloudinit_size.tftest.hcl` | Same, for huawei — **adds size coverage that never existed** (CP-per-region ≤ 32256, worker-per-region ≤ 30720). |
| `scripts/cloudinit-size-report.sh` | **Headroom signal**: reports the exact rendered byte count, annotates `::warning::` once it crosses ~93% of the cap (30000B), `::error::` if already over, `::notice::` otherwise. Renders via the real module (no drift). |
| `.github/workflows/catalyst-build.yaml` | `if: failure()` loud-signal step on `build-api` so a red main build (no image published → mothership freezes) is **unmissable**. |

The committed size tftests are also picked up by the existing `infra-*-tofu.yaml` `tofu test` (free redundancy) and keep those suites green.

## Why the byte count has zero drift

The only faithful size source is the real module's own `local.*_cloud_init` — it threads multi-KB provider-injected strings (registry mirror, cloud-credentials secret, crossplane provider yaml, kubeconfig PUT block) that a standalone `templatefile()` harness would omit and undercount by KBs. (Proof: hetzner renders at **31539B** but huawei at **22688B** for the same shared template — the per-provider injected strings differ by ~9KB.) The report reads the real local via a `tofu test` probe; `nonsensitive(length(...))` leaks only the integer, never any token bytes (same pattern as the production precondition at `main.tf:956`).

## Proof — trips on oversized, passes on current main

Verified locally on OpenTofu 1.12 (CI pins 1.8.5, matching the `infra-*-tofu.yaml` siblings; full suites green on both):

**PASS on current main:**
```
hetzner: tofu test -filter=tests/cloudinit_size.tftest.hcl → 3 passed, 0 failed
huawei:  tofu test -filter=tests/cloudinit_size.tftest.hcl → 2 passed, 0 failed
full hetzner suite: 13 passed, 0 failed   full huawei suite: 7 passed, 0 failed
report (hetzner): rendered control-plane cloud-init = 31539 bytes (97% of 32256; 717 bytes headroom)
                  ::warning title=cloud-init headroom low (hetzner)::...   ← main is ALREADY at the cliff
report (huawei):  rendered control-plane cloud-init = 22688 bytes (70%; 9568 bytes headroom) → ::notice::
```

**FAIL when the shared tftpl is padded over the cap (then reverted):**
```
control_plane_cloud_init_under_32256... fail   →  Failure! 0 passed, 1 failed, 2 skipped
report: rendered control-plane cloud-init = 34220 bytes (106%; -1964 headroom)
        ::error title=cloud-init OVER cap (hetzner)::...
```

`fmt -check` clean, `shellcheck -S warning` clean, YAML valid.

## Follow-up (not in this PR)

Mark `cloud-init size gate / hetzner` and `cloud-init size gate / huawei` as **required status checks** on `main` branch protection — that is the human step that actually makes the red block a merge (the workflow is built to be required-able; this PR cannot edit branch protection).

## Notes

- **DO NOT merge yet** — parked for review.
- `Refs #3720` / `Refs #3724` (no auto-close).

Refs #3720
Refs #3724

🤖 Generated with [Claude Code](https://claude.com/claude-code)
