### PR TITLE
fix(cloud-init): deterministic github-IPv4 node pin before k3s install — fixes intermittent primary-region pre-PUT wedge (within 32256B)

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -642,6 +642,34 @@ runcmd:
   # Empty on clouds that need none. Each item is plain POSIX (dash -n clean).
   ${indent(2, provider_prelude)}
 
+  # ── IPv4-pin bootstrap hosts (#3232/#3714 — the intermittent multi-region
+  # pre-PUT/CNI killer). Huawei VPCs are IPv4-only; the node resolver can
+  # hand back an AAAA for these GitHub/helm hosts → curl + Go (helm/kubectl)
+  # try IPv6 FIRST → "network is unreachable" with NO A fallback → the
+  # github artifact pulls stall. This MUST run BEFORE the k3s install (the
+  # very first github-dependent pull: get.k3s.io redirects to the k3s
+  # release asset on github) so the PRIMARY-region pre-PUT stall (hw150,
+  # k3s/helm/git artifacts never finish → kubeconfig never PUT) cannot
+  # recur, AND before the later helm/cilium/flux pulls (region-b CNI-dead,
+  # ClusterMesh blocked). The old getent-only probe SILENTLY skipped any
+  # host whose IPv4 getent missed, leaving AAAA to win — #3714 makes
+  # resolution DETERMINISTIC via a bounded 3-tier ladder (getent →
+  # public-resolver nslookup → python3 AF_INET getaddrinfo) before pinning
+  # /etc/hosts. POSIX/dash-clean; every host is IPv4-reachable from every
+  # cloud (on a dual-stack cloud the resolved A record is still valid).
+  - |
+    r4() {
+     getent ahostsv4 "$1" 2>/dev/null | awk '{print $1; exit}' && return
+     for s in 1.1.1.1 8.8.8.8; do
+      a=$(nslookup -type=A "$1" "$s" 2>/dev/null | awk '/^Address: [0-9]/&&$2!~/#/{print $2; exit}')
+      [ -n "$a" ] && { echo "$a"; return; }
+     done
+     python3 -c 'import socket,sys;print(socket.getaddrinfo(sys.argv[1],443,2)[0][4][0])' "$1" 2>/dev/null
+    }
+    for h in github.com raw.githubusercontent.com codeload.github.com objects.githubusercontent.com helm.cilium.io get.helm.sh; do
+     a=$(r4 "$h"); [ -n "$a" ] && echo "$a $h" >>/etc/hosts || true
+    done
+
   # ── Install k3s server ────────────────────────────────────────────────
   # NODE_EXTERNAL_IP comes from the provider-injected discovery command:
   #   Hetzner → curl metadata 169.254.169.254/hetzner/v1/.../public-ipv4
@@ -684,22 +712,6 @@ runcmd:
   # ══════════════════════════════════════════════════════════════════════
   ${indent(2, kubeconfig_put_block)}
 %{ endif ~}
-
-  # ── IPv4-pin dual-stack bootstrap hosts (#3232 — the intermittent multi-
-  # region CNI killer, root-caused on hw125). Huawei VPCs are IPv4-only;
-  # helm/kubectl (Go) can resolve these GitHub-Pages/GitHub hosts to AAAA
-  # and try IPv6 FIRST → "network is unreachable" with NO fallback →
-  # `helm repo add cilium` fails → no CNI → the region's nodes stay
-  # NotReady forever. region-A happened to get the A record, region-b got
-  # AAAA (hw125: region-b CNI-dead, ClusterMesh impossible, Pillar-3
-  # blocked). Pinning the resolved IPv4 in /etc/hosts BEFORE any pull is
-  # targeted + cloud-agnostic (every host below is IPv4-reachable from
-  # every cloud; on a dual-stack cloud the A record is still valid).
-  - |
-    for h in helm.cilium.io get.helm.sh raw.githubusercontent.com github.com objects.githubusercontent.com codeload.github.com; do
-      ip="$(getent ahostsv4 "$h" 2>/dev/null | awk 'NR==1{print $1}')"
-      [ -n "$ip" ] && printf '%s %s\n' "$ip" "$h" >> /etc/hosts || true
-    done
 
   # ── gateway-api CRDs: ONE official bundle apply (lean Hetzner pattern) ─
   # Flux's bp-gateway-api re-applies post-bootstrap; this single apply just


### PR DESCRIPTION
## What

Re-implements the #3232 github-IPv4 `/etc/hosts` pin in the shared control-plane cloud-init (`infra/providers/_shared/cloudinit-control-plane.tftpl`) so resolution is **DETERMINISTIC** (never silently skips) AND **relocates it to run BEFORE the k3s install**, while keeping the rendered cloud-init **≤ 32256 bytes** (the Hetzner G36 cap that reverted PR #3715).

## Why (verified diagnosis — live mothership catalyst-api logs, 2026-06-17)

Fresh kom4dc 2-region provs intermittently wedge at `phase1-watching` / 0 HelmReleases. Hard evidence: the catalyst-api logged `secondary-kubeconfig: registered` (POST 201) for the SECONDARY region — so kom4dc→mothership egress WORKS; it is NOT an EIP/range-block problem. But the PRIMARY region's kubeconfig is 409 (never PUT): its node stalled **before** the PUT-back step.

Root cause: **asymmetric per-region github IPv6**. The primary VPC's node resolved `github.com` to an AAAA on the IPv4-only Huawei VPC → cloud-init stalled downloading k3s/helm/git artifacts from github → never reached the kubeconfig-PUT. The secondary VPC got an A record and came up fine. (ref: `reference_ipv6_helm_cilium_multiregion_cni_killer`; #3232.)

The existing #3232 pin used `getent ahostsv4 <h> ... || true` — it **silently skipped** any host whose IPv4 getent missed, leaving github to resolve AAAA. That non-determinism is the bug. It also ran *after* `get.k3s.io`, so it never protected the first (pre-PUT) github pull.

## Change

- Replace the silent-skip probe with a compact, bounded **3-tier resolver** `r4()`:
  1. `getent ahostsv4`
  2. public-resolver `nslookup -type=A` @ `1.1.1.1` / `8.8.8.8` (server `#53` line excluded)
  3. `python3 -c socket.getaddrinfo(host, 443, AF_INET)` (AF_INET=2 on Linux)
- Pin IPv4 for: github.com, raw.githubusercontent.com, codeload.github.com, objects.githubusercontent.com, helm.cilium.io, get.helm.sh.
- **Relocate** the pin to **after `provider_prelude` and before the k3s install** (`get.k3s.io` redirects to the k3s release asset on github), so the confirmed primary-region pre-PUT stall cannot recur — and it still covers the later gateway-api / get-helm-3 / cilium / flux github pulls.

## Size-consciousness (the hard constraint)

PR #3715 implemented a similar fix but blew Hetzner's 32256-byte `user_data` cap (`infra/providers/hetzner/main.tf` precondition, exercised by the G36 tofu-test) and was reverted in #3720/#3721. This re-implementation is a single compact POSIX fn + host loop (pure-comment lines strip to zero via main.tf's comment-strip regex).

**Measured worst-case (3-region) rendered control-plane cloud-init: 32208 bytes** (≤ 32256, ~48 B headroom).

The **NICE-TO-HAVE in-cluster coredns-custom github-IPv4 block** (so the Flux source-controller Pod also resolves github IPv4 post-PUT) does **not** fit in the remaining headroom and is **deferred as a follow-up** — the node `/etc/hosts` pin is the load-bearing fix for the confirmed pre-PUT wedge. (Tracking: #3726.)

## Validation

- `tofu test` (hetzner — the G36 size gate): **10 passed, 0 failed**.
- `tofu test` (huawei / kom4dc path): **5 passed, 0 failed**.
- `scripts/lint-cloudinit.sh hetzner`: render OK, 47 runcmd items, **dash -n PASSED** for all items + concatenated script.
- `scripts/lint-cloudinit.sh huawei`: render OK, 44 runcmd items, **dash -n PASSED**.
- Each resolver tier functionally verified to return IPv4 (getent / nslookup@1.1.1.1 / python3 AF_INET all → `20.233.83.145` for github.com).

Refs #3714
Refs #3726

🤖 Generated with [Claude Code](https://claude.com/claude-code)