### PR TITLE
fix(pool-domain): reliably release Sovereign subdomain on wipe (Refs #3728)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -2165,9 +2165,14 @@ func (h *Handler) releasePDMReservation(dep *Deployment) {
 	if dep.pdmReservationToken == "" || h.pdm == nil {
 		return
 	}
-	pdmCtx, pdmCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	// Refs #3728 — ReleaseWithRetry so a transient PDM failure on the
+	// Phase-0-failure cleanup doesn't strand the reservation until its TTL.
+	// (A reserved row WOULD expire on its 10m TTL, but if it was already
+	// committed to `active` before the failure, only an explicit release
+	// frees it — retrying closes that window.)
+	pdmCtx, pdmCancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer pdmCancel()
-	releaseErr := h.pdm.Release(pdmCtx, dep.pdmPoolDomain, dep.pdmSubdomain)
+	releaseErr := h.pdm.ReleaseWithRetry(pdmCtx, dep.pdmPoolDomain, dep.pdmSubdomain, pdm.CommitRetryConfig{})
 	if releaseErr != nil && !errors.Is(releaseErr, pdm.ErrNotFound) {
 		h.log.Error("pdm release failed; reservation will expire on TTL",
 			"id", dep.ID,

--- a/products/catalyst/bootstrap/api/internal/handler/deployments_delete.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments_delete.go
@@ -36,12 +36,28 @@
 package handler
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/pdm"
 )
+
+// noteAppend joins a new note fragment onto an existing one with "; ".
+// Refs #3728 — the record-only delete can now surface both a store-delete
+// note and a pdm-release note in the same response.
+func noteAppend(existing, add string) string {
+	if existing == "" {
+		return add
+	}
+	return existing + "; " + add
+}
 
 // deleteDeploymentResponse is the wire shape of DELETE
 // /api/v1/deployments/{id}.
@@ -50,8 +66,18 @@ type deleteDeploymentResponse struct {
 	SovereignFQDN string `json:"sovereignFQDN,omitempty"`
 	StoreDeleted  bool   `json:"storeDeleted"`
 	LocalCleaned  bool   `json:"localCleaned"`
+	PDMReleased   bool   `json:"pdmReleased,omitempty"`
 	Mode          string `json:"mode"`
 	Note          string `json:"note,omitempty"`
+}
+
+// destroyedTerminalStatus reports whether a deployment's infra is already
+// gone (wiped or failed-before-materialising). Refs #3728 — the
+// record-only delete releases the pool subdomain ONLY in these states, so
+// a deliberately-orphaned but LIVE Sovereign keeps its DNS records intact
+// (releasing would drop its PowerDNS child zone out from under it).
+func destroyedTerminalStatus(s string) bool {
+	return s == "wiped" || s == "failed"
 }
 
 // DeleteDeployment handles DELETE /api/v1/deployments/{id}.
@@ -85,6 +111,9 @@ func (h *Handler) DeleteDeployment(w http.ResponseWriter, r *http.Request) {
 	status := dep.Status
 	fqdn := dep.Request.SovereignFQDN
 	adopted := dep.AdoptedAt != nil
+	poolDomain := dep.pdmPoolDomain
+	subdomain := dep.pdmSubdomain
+	domainMode := dep.Request.SovereignDomainMode
 	dep.mu.Unlock()
 
 	// Adopted deployments are customer-owned Sovereigns. Don't allow
@@ -154,6 +183,37 @@ func (h *Handler) DeleteDeployment(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		out.LocalCleaned = true
+	}
+
+	// Step 2b (Refs #3728) — release the pool subdomain ONLY when the
+	// Sovereign's infra is already destroyed (wiped/failed). This closes
+	// the leak where a record-only delete of an already-wiped breadcrumb
+	// left the `active` pool_allocations row orphaned → permanent 409 on
+	// re-fire of the same subdomain. We deliberately do NOT release for a
+	// LIVE deployment being orphaned (status ready/converged/…): that
+	// Sovereign still serves DNS from the pool child zone, and dropping it
+	// would break the running cluster. Best-effort + ErrNotFound-as-success
+	// on a background context (independent of the inbound request).
+	if domainMode == "pool" && (poolDomain == "" || subdomain == "") {
+		if idx := strings.IndexByte(fqdn, '.'); idx > 0 {
+			subdomain = fqdn[:idx]
+			poolDomain = fqdn[idx+1:]
+		}
+	}
+	if domainMode == "pool" && destroyedTerminalStatus(status) && poolDomain != "" && subdomain != "" {
+		if h.pdm == nil {
+			out.Note = noteAppend(out.Note, "pool release skipped: pool-domain-manager client not configured")
+		} else {
+			relCtx, relCancel := context.WithTimeout(context.Background(), 90*time.Second)
+			if err := h.pdm.ReleaseWithRetry(relCtx, poolDomain, subdomain, pdm.CommitRetryConfig{}); err != nil && !errors.Is(err, pdm.ErrNotFound) {
+				h.log.Warn("delete-deployment: pdm release failed",
+					"id", id, "poolDomain", poolDomain, "subdomain", subdomain, "err", err)
+				out.Note = noteAppend(out.Note, "pdm release: "+err.Error())
+			} else {
+				out.PDMReleased = true
+			}
+			relCancel()
+		}
 	}
 
 	// Step 3 — drop the in-memory row. The wizard's polling loop will

--- a/products/catalyst/bootstrap/api/internal/handler/deployments_delete_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments_delete_test.go
@@ -152,3 +152,84 @@ func TestDeleteDeployment_TerminalWipedAllowed(t *testing.T) {
 		t.Errorf("wiped deployment was not removed from map")
 	}
 }
+
+// newPoolDepForDelete builds a pool-mode Deployment with PDM pointers set,
+// for the #3728 record-only-delete release tests.
+func newPoolDepForDelete(id, status, sub string) *Deployment {
+	dep := &Deployment{
+		ID:     id,
+		Status: status,
+		Request: provisioner.Request{
+			SovereignFQDN:       sub + ".omani.works",
+			SovereignDomainMode: "pool",
+			Region:              "fsn1",
+		},
+		StartedAt:     time.Now().Add(-1 * time.Hour),
+		eventsCh:      make(chan provisioner.Event),
+		done:          make(chan struct{}),
+		pdmPoolDomain: "omani.works",
+		pdmSubdomain:  sub,
+	}
+	close(dep.eventsCh)
+	close(dep.done)
+	return dep
+}
+
+// TestDeleteDeployment_WipedPoolReleasesSubdomain is the #3728 closure for
+// the record-only path: deleting the breadcrumb of an ALREADY-WIPED pool
+// Sovereign must release its pool subdomain so the slot is re-fireable.
+// Previously this path never called PDM release, leaking the active row.
+func TestDeleteDeployment_WipedPoolReleasesSubdomain(t *testing.T) {
+	fpdm := &fakePDM{}
+	h := NewWithPDM(silentLogger(), fpdm)
+	dep := newPoolDepForDelete("dep-wiped-pool", "wiped", "hw155")
+	h.deployments.Store(dep.ID, dep)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/deployments/dep-wiped-pool", nil)
+	rec := httptest.NewRecorder()
+	routerForDelete(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var out deleteDeploymentResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !out.PDMReleased {
+		t.Errorf("PDMReleased=false; a record-only delete of a wiped pool Sovereign must release the subdomain (body=%s)", rec.Body.String())
+	}
+	if got := len(fpdm.releases); got != 1 || fpdm.releases[0].sub != "hw155" {
+		t.Errorf("expected one Release(omani.works, hw155), got %+v", fpdm.releases)
+	}
+}
+
+// TestDeleteDeployment_LivePoolDoesNotReleaseSubdomain is the safety
+// invariant: a record-only delete of a LIVE pool Sovereign (status=ready,
+// deliberately orphaned by the operator) must NOT release its subdomain —
+// the running cluster still serves DNS from that pool child zone, and
+// dropping it would break the live Sovereign. Refs #3728.
+func TestDeleteDeployment_LivePoolDoesNotReleaseSubdomain(t *testing.T) {
+	fpdm := &fakePDM{}
+	h := NewWithPDM(silentLogger(), fpdm)
+	dep := newPoolDepForDelete("dep-live-pool", "ready", "hw160")
+	h.deployments.Store(dep.ID, dep)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/deployments/dep-live-pool", nil)
+	rec := httptest.NewRecorder()
+	routerForDelete(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var out deleteDeploymentResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.PDMReleased {
+		t.Errorf("PDMReleased=true for a LIVE pool Sovereign; releasing would break its DNS")
+	}
+	if got := len(fpdm.releases); got != 0 {
+		t.Errorf("PDM Release fired for a live orphaned Sovereign (%d times) — must not", got)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/release_subdomain_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/release_subdomain_test.go
@@ -346,6 +346,73 @@ func TestRestoreFromStore_PodRestartOrphanReleasesPDMSlot(t *testing.T) {
 	}
 }
 
+// TestReleaseSubdomain_WipedWithRetainedPointersCompletesRelease is the
+// #3728 recovery contract. When a wipe's pool release failed, the wipe
+// handler RETAINS the deployment record (status="wiped") WITH its
+// pdmPoolDomain/pdmSubdomain pointers intact, precisely so this endpoint
+// can finish the orphaned release. The prior code returned 410 Gone for
+// ANY "wiped" deployment, which dead-ended that recovery and left the
+// subdomain permanently 409ing on re-fire. A wiped deployment that still
+// carries pool pointers must therefore PROCEED to the release.
+func TestReleaseSubdomain_WipedWithRetainedPointersCompletesRelease(t *testing.T) {
+	fpdm := &fakePDM{}
+	h := NewWithPDM(silentLogger(), fpdm)
+
+	dep := &Deployment{
+		ID:            "dep-wiped-retained",
+		Status:        "wiped", // infra gone, but pool release had failed
+		Request:       provisioner.Request{SovereignFQDN: "hw155.omani.works", SovereignDomainMode: "pool"},
+		pdmPoolDomain: "omani.works",
+		pdmSubdomain:  "hw155",
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	w := callReleaseSubdomain(h, dep.ID)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s — a wiped deployment with retained pool pointers must release, not 410", w.Code, w.Body.String())
+	}
+	var resp releaseSubdomainResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.PDMReleased {
+		t.Errorf("PDMReleased=false; the retained pool allocation for hw155.omani.works must be freed (body=%s)", w.Body.String())
+	}
+	if got := len(fpdm.releases); got != 1 || fpdm.releases[0].sub != "hw155" {
+		t.Errorf("expected exactly one Release(omani.works, hw155), got %+v", fpdm.releases)
+	}
+	// Pointers cleared so a duplicate recovery call is a clean no-op.
+	if dep.pdmPoolDomain != "" || dep.pdmSubdomain != "" {
+		t.Errorf("pointers not cleared after recovery release: pool=%q sub=%q", dep.pdmPoolDomain, dep.pdmSubdomain)
+	}
+}
+
+// TestReleaseSubdomain_WipedWithClearedPointersStill410 proves the normal
+// happy path is unchanged: a wiped deployment whose pool slot WAS released
+// (pointers cleared) still returns 410 Gone — there is nothing left to do.
+func TestReleaseSubdomain_WipedWithClearedPointersStill410(t *testing.T) {
+	fpdm := &fakePDM{}
+	h := NewWithPDM(silentLogger(), fpdm)
+
+	dep := &Deployment{
+		ID:      "dep-wiped-clean",
+		Status:  "wiped",
+		Request: provisioner.Request{SovereignFQDN: "hw155.omani.works", SovereignDomainMode: "pool"},
+		// pdmPoolDomain / pdmSubdomain intentionally empty (released on wipe)
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	w := callReleaseSubdomain(h, dep.ID)
+
+	if w.Code != http.StatusGone {
+		t.Errorf("status=%d, want 410 (already wiped, slot already released) — body=%s", w.Code, w.Body.String())
+	}
+	if got := len(fpdm.releases); got != 0 {
+		t.Errorf("no Release should fire for a fully-wiped deployment, got %d", got)
+	}
+}
+
 // TestRestoreFromStore_TerminalRecordDoesNotReleasePDM proves we DON'T
 // re-release a deployment that finished cleanly (status="failed" was
 // already the terminal state on disk, not a rewrite). A clean failure

--- a/products/catalyst/bootstrap/api/internal/handler/subdomains.go
+++ b/products/catalyst/bootstrap/api/internal/handler/subdomains.go
@@ -260,4 +260,9 @@ type pdmClient interface {
 		cfg pdm.CommitRetryConfig,
 	) error
 	Release(ctx context.Context, poolDomain, subdomain string) error
+	// ReleaseWithRetry is the production path for the wipe/decommission
+	// release (bounded backoff + ErrNotFound-as-success). Refs #3728 —
+	// the plain Release is retained for the manual ReleaseSubdomain
+	// recovery seam and tests that exercise single-shot semantics.
+	ReleaseWithRetry(ctx context.Context, poolDomain, subdomain string, cfg pdm.CommitRetryConfig) error
 }

--- a/products/catalyst/bootstrap/api/internal/handler/subdomains_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/subdomains_test.go
@@ -162,6 +162,30 @@ func (f *fakePDM) Release(ctx context.Context, pool, sub string) error {
 	return nil
 }
 
+// ReleaseWithRetry on the fake delegates to the same `release` hook used
+// by Release (so existing tests that stub `release` keep working) but
+// threads the retry loop manually — ErrNotFound counts as success, and
+// non-sentinel errors are retried up to MaxAttempts with NO sleep (fakes
+// don't sleep; callers that want to verify backoff timing use the
+// httptest-based test in pdm/client_test.go instead). Refs #3728.
+func (f *fakePDM) ReleaseWithRetry(ctx context.Context, pool, sub string, cfg pdm.CommitRetryConfig) error {
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = 5
+	}
+	var lastErr error
+	for attempt := 1; attempt <= cfg.MaxAttempts; attempt++ {
+		err := f.Release(ctx, pool, sub)
+		if err == nil || errors.Is(err, pdm.ErrNotFound) {
+			return nil
+		}
+		lastErr = err
+		if attempt == cfg.MaxAttempts {
+			break
+		}
+	}
+	return lastErr
+}
+
 func decodeResp(t *testing.T, body io.Reader) SubdomainCheckResponse {
 	t.Helper()
 	var got SubdomainCheckResponse

--- a/products/catalyst/bootstrap/api/internal/handler/wipe.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe.go
@@ -584,9 +584,27 @@ func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 		emit("wipe", "error", providerName+" G103 verification: "+itoa(residualTotal)+" catalyst-* resource(s) survived wipe (bastion-* excluded): "+kindCountSummary(report.ResidualOrphans))
 	}
 
-	// Step 3 — PDM release (pool-subdomain only). Best-effort. Resolve pool
-	// + subdomain from either the Deployment record (set during the
-	// reservation step) or from the FQDN as a fallback.
+	// Step 3 — PDM release (pool-subdomain only). Resolve pool + subdomain
+	// from either the Deployment record (set during the reservation step)
+	// or from the FQDN as a fallback.
+	//
+	// Refs #3728 — three hardening changes vs. the prior best-effort call:
+	//   1. Guard h.pdm == nil (symmetric with ReleaseSubdomain at line ~840
+	//      and the reserve path) — a wipe on a catalyst-api without
+	//      POOL_DOMAIN_MANAGER_URL must not nil-deref, and must NOT silently
+	//      forget the deployment with the pool row still active.
+	//   2. ReleaseWithRetry on a BACKGROUND context — an `active`
+	//      pool_allocations row never self-heals (the sweeper only reclaims
+	//      expired *reserved* rows), so a single transient PDM failure
+	//      orphans the subdomain permanently and 409s every re-fire. The
+	//      release context is deliberately independent of r.Context() so a
+	//      client disconnect after the long (≤30m) cloud purge can't starve
+	//      it with `context canceled`.
+	//   3. When the release still fails after retries, set pdmReleaseFailed
+	//      so the finalize step SKIPS deleting the on-disk record + reaping
+	//      the in-memory row — keeping ReleaseSubdomain (DELETE
+	//      …/release-subdomain) a viable manual recovery instead of leaving
+	//      an orphan no actor knows to clean up.
 	poolDomain, subdomain := dep.pdmPoolDomain, dep.pdmSubdomain
 	if poolDomain == "" || subdomain == "" {
 		// Fallback: split sovereignFQDN at the first dot.
@@ -595,16 +613,28 @@ func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 			poolDomain = dep.Request.SovereignFQDN[idx+1:]
 		}
 	}
+	pdmReleaseFailed := false
 	if dep.Request.SovereignDomainMode == "pool" && poolDomain != "" && subdomain != "" {
-		releaseCtx, releaseCancel := context.WithTimeout(r.Context(), 30*time.Second)
-		if err := h.pdm.Release(releaseCtx, poolDomain, subdomain); err != nil {
-			report.Errors = append(report.Errors, "pdm release: "+err.Error())
-			emit("wipe", "warn", "PDM release failed (operator must run pdm-cli force-release later): "+err.Error())
+		if h.pdm == nil {
+			pdmReleaseFailed = true
+			report.Errors = append(report.Errors, "pdm release skipped: pool-domain-manager client is not configured")
+			emit("wipe", "warn", "PDM client not configured — pool allocation for "+subdomain+"."+poolDomain+" NOT released; on-disk record retained for retry via DELETE /release-subdomain")
 		} else {
-			report.PDMReleased = true
-			emit("wipe", "info", "PDM allocation released for "+subdomain+"."+poolDomain)
+			// Background context — independent of the inbound HTTP request so
+			// an operator-console disconnect during the cloud purge cannot
+			// cancel the release. 90s covers up to 5 retry attempts of the
+			// 15s-timeout PDM client.
+			releaseCtx, releaseCancel := context.WithTimeout(context.Background(), 90*time.Second)
+			if err := h.pdm.ReleaseWithRetry(releaseCtx, poolDomain, subdomain, pdm.CommitRetryConfig{}); err != nil {
+				pdmReleaseFailed = true
+				report.Errors = append(report.Errors, "pdm release: "+err.Error())
+				emit("wipe", "warn", "PDM release failed after retries — on-disk record retained for retry via DELETE /release-subdomain (or operator pdm-cli force-release): "+err.Error())
+			} else {
+				report.PDMReleased = true
+				emit("wipe", "info", "PDM allocation released for "+subdomain+"."+poolDomain)
+			}
+			releaseCancel()
 		}
-		releaseCancel()
 	} else {
 		emit("wipe", "info", "BYO or unresolvable pool — no PDM allocation to release")
 	}
@@ -649,15 +679,22 @@ _ = deploymentSovereignName // retained for backwards-compat callers; unused on 
 		report.Errors = append(report.Errors, "remove tofu workdir: "+err.Error())
 	}
 
-	if h.store != nil {
+	// Refs #3728 — if the PDM pool release failed after retries, RETAIN the
+	// on-disk record so the deployment is still loadable after a Pod
+	// restart and DELETE /release-subdomain can drive the manual recovery.
+	// Deleting it here is what historically stranded the orphan `active`
+	// row with no actor left to release it.
+	if h.store != nil && !pdmReleaseFailed {
 		if err := h.store.Delete(id); err != nil {
 			report.Errors = append(report.Errors, "store delete: "+err.Error())
 		} else {
 			report.LocalCleaned = true
 			emit("wipe", "info", "deployment record removed from on-disk store")
 		}
-	} else {
+	} else if h.store == nil {
 		report.LocalCleaned = true
+	} else {
+		emit("wipe", "info", "on-disk deployment record retained — PDM allocation still active; retry release via DELETE /api/v1/deployments/"+id+"/release-subdomain")
 	}
 
 	// Step 5 — finalize. Mark the deployment "wiped" in memory and close
@@ -673,10 +710,17 @@ _ = deploymentSovereignName // retained for backwards-compat callers; unused on 
 	// Don't immediately remove from sync.Map — we want StreamLogs
 	// reconnects within ~30s to see the final wipe summary frames. A
 	// background goroutine reaps after a TTL.
-	go func() {
-		time.Sleep(60 * time.Second)
-		h.deployments.Delete(id)
-	}()
+	//
+	// Refs #3728 — skip the reap when the PDM release failed: the
+	// in-memory deployment (with its pdmPoolDomain/pdmSubdomain pointers)
+	// must survive so ReleaseSubdomain can retry the orphaned pool
+	// allocation. Reaping it here is what made the manual recovery 404.
+	if !pdmReleaseFailed {
+		go func() {
+			time.Sleep(60 * time.Second)
+			h.deployments.Delete(id)
+		}()
+	}
 
 	emit("wipe", "info", "Wipe complete. Start a fresh deployment from /sovereign.")
 
@@ -804,7 +848,12 @@ func (h *Handler) ReleaseSubdomain(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	if status == "wiped" {
+	// Refs #3728 — a "wiped" deployment normally has its PDM pointers
+	// cleared (the wipe released the slot), so 410 is correct. BUT when the
+	// wipe's pool release FAILED, the record is retained with its pointers
+	// intact precisely so this endpoint can finish the release. In that
+	// recovery case, fall through to the release instead of 410.
+	if status == "wiped" && (poolDomain == "" || subdomain == "") {
 		writeJSON(w, http.StatusGone, releaseSubdomainResponse{
 			DeploymentID: id,
 			PoolDomain:   poolDomain,
@@ -847,9 +896,12 @@ func (h *Handler) ReleaseSubdomain(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	releaseCtx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	// Refs #3728 — ReleaseWithRetry on a background context so this manual
+	// recovery seam is as resilient as the wipe path (a single transient
+	// PDM failure must not strand the operator's retry either).
+	releaseCtx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
-	err := h.pdm.Release(releaseCtx, poolDomain, subdomain)
+	err := h.pdm.ReleaseWithRetry(releaseCtx, poolDomain, subdomain, pdm.CommitRetryConfig{})
 	if err != nil && !errors.Is(err, pdmErrNotFound()) {
 		h.log.Warn("release-subdomain: pdm release failed",
 			"id", id,

--- a/products/catalyst/bootstrap/api/internal/pdm/client.go
+++ b/products/catalyst/bootstrap/api/internal/pdm/client.go
@@ -349,6 +349,71 @@ func (c *Client) CommitWithRetry(
 	return fmt.Errorf("pdm commit retry exhausted (%d attempts): %w", cfg.MaxAttempts, lastErr)
 }
 
+// ReleaseWithRetry runs Release with bounded exponential backoff and
+// treats pdm.ErrNotFound as success (idempotent — the row may already
+// be gone). It is the resilient sibling of CommitWithRetry for the
+// decommission path.
+//
+// Why this exists (Refs #3728): the wipe handler's pool-subdomain
+// release was best-effort and NON-retried — a single transient PDM
+// failure (5xx, network blip, basic-auth 401 during a Secret rotation,
+// or a PDM Pod roll) left the `active` pool_allocations row orphaned.
+// Because an `active` row never self-heals (the sweeper only reclaims
+// expired *reserved* rows), and the wipe path then deletes catalyst-api's
+// own deployment record, the orphaned row permanently 409s every re-fire
+// of the same subdomain — forcing operators to burn a fresh name each
+// wipe→re-fire cycle (hw155→hw156→hw157…). Retrying the release closes
+// that window the same way CommitWithRetry already closes it for /commit.
+//
+// Semantics:
+//
+//	nil / ErrNotFound  — success (the slot is free); returns nil.
+//	5xx / network      — back off (InitialBackoff * 2^attempt, capped at
+//	                     MaxBackoff) and retry, up to MaxAttempts.
+//	ctx cancelled      — returns the wrapped context error immediately.
+//
+// On final exhaustion returns the last error wrapped with
+// "pdm release retry exhausted (N attempts)". Callers should pass a
+// context that is NOT tied to the inbound HTTP request (use
+// context.Background with its own timeout) so a client disconnect during
+// a long cloud purge cannot starve the release.
+func (c *Client) ReleaseWithRetry(ctx context.Context, poolDomain, subdomain string, cfg CommitRetryConfig) error {
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = 5
+	}
+	if cfg.InitialBackoff <= 0 {
+		cfg.InitialBackoff = 1 * time.Second
+	}
+	if cfg.MaxBackoff <= 0 {
+		cfg.MaxBackoff = 16 * time.Second
+	}
+
+	var lastErr error
+	backoff := cfg.InitialBackoff
+	for attempt := 1; attempt <= cfg.MaxAttempts; attempt++ {
+		err := c.Release(ctx, poolDomain, subdomain)
+		if err == nil || errors.Is(err, ErrNotFound) {
+			// 404 means the row is already gone — the slot is free, which
+			// is exactly the post-condition the caller wants. Idempotent.
+			return nil
+		}
+		lastErr = err
+		if attempt == cfg.MaxAttempts {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("pdm release retry cancelled after %d attempts: %w", attempt, ctx.Err())
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+		if backoff > cfg.MaxBackoff {
+			backoff = cfg.MaxBackoff
+		}
+	}
+	return fmt.Errorf("pdm release retry exhausted (%d attempts): %w", cfg.MaxAttempts, lastErr)
+}
+
 // Release calls DELETE /api/v1/pool/{domain}/release.
 func (c *Client) Release(ctx context.Context, poolDomain, subdomain string) error {
 	body := map[string]string{"subdomain": subdomain}

--- a/products/catalyst/bootstrap/api/internal/pdm/client_test.go
+++ b/products/catalyst/bootstrap/api/internal/pdm/client_test.go
@@ -437,3 +437,126 @@ func TestClient_BasicAuth_OmittedWhenEnvUnset(t *testing.T) {
 		t.Errorf("expected no Authorization header, got %q", seenAuth)
 	}
 }
+
+// ── ReleaseWithRetry (Refs #3728) ───────────────────────────────────────
+//
+// The wipe path's pool-subdomain release was best-effort and non-retried;
+// a single transient PDM failure orphaned the `active` allocation row,
+// which never self-heals (the sweeper only reclaims expired *reserved*
+// rows) → permanent 409 on re-fire of the same subdomain. ReleaseWithRetry
+// gives the decommission path the same resilience Commit already has.
+
+// TestReleaseWithRetry_5xx_ThenSuccess proves a transient PDM 5xx on the
+// first DELETE /release does NOT strand the subdomain — the loop backs off
+// and the second attempt frees the slot. This is the exact hw155/hw156
+// failure window: a PDM blip during wipe left the row, forcing a fresh
+// subdomain each re-fire.
+func TestReleaseWithRetry_5xx_ThenSuccess(t *testing.T) {
+	var releases int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&releases, 1)
+		if !strings.HasSuffix(r.URL.Path, "/release") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if n == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"db down"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"freed":{"state":"active"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(srv.URL)
+	err := c.ReleaseWithRetry(context.Background(), "omani.works", "hw155",
+		CommitRetryConfig{MaxAttempts: 5, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond})
+	if err != nil {
+		t.Fatalf("ReleaseWithRetry should recover after a transient 5xx: %v", err)
+	}
+	if got := atomic.LoadInt32(&releases); got != 2 {
+		t.Errorf("releases=%d, want 2 (1 5xx + 1 success)", got)
+	}
+}
+
+// TestReleaseWithRetry_404_IsSuccess proves a 404 (row already gone) is
+// treated as success on the FIRST attempt — release is idempotent, and a
+// freed slot is exactly the post-condition the caller wants. It must NOT
+// burn the whole retry budget on an already-released row.
+func TestReleaseWithRetry_404_IsSuccess(t *testing.T) {
+	var releases int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&releases, 1)
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not-found"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(srv.URL)
+	err := c.ReleaseWithRetry(context.Background(), "omani.works", "hw155",
+		CommitRetryConfig{MaxAttempts: 5, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond})
+	if err != nil {
+		t.Fatalf("ReleaseWithRetry: 404 must be success (idempotent), got %v", err)
+	}
+	if got := atomic.LoadInt32(&releases); got != 1 {
+		t.Errorf("releases=%d, want 1 (404 returns immediately, no retry)", got)
+	}
+}
+
+// TestReleaseWithRetry_5xx_Exhaustion proves a persistently-down PDM
+// surfaces a clear 'retry exhausted' error after MaxAttempts so the wipe
+// handler can RETAIN the deployment record for manual recovery rather than
+// silently forgetting an orphaned allocation.
+func TestReleaseWithRetry_5xx_Exhaustion(t *testing.T) {
+	var releases int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&releases, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(srv.URL)
+	err := c.ReleaseWithRetry(context.Background(), "omani.works", "hw155",
+		CommitRetryConfig{MaxAttempts: 3, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond})
+	if err == nil {
+		t.Fatal("ReleaseWithRetry should fail on persistent 5xx")
+	}
+	if !strings.Contains(err.Error(), "retry exhausted") {
+		t.Errorf("err=%q should contain 'retry exhausted'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "3 attempts") {
+		t.Errorf("err=%q should mention attempt count (3)", err.Error())
+	}
+	if got := atomic.LoadInt32(&releases); got != 3 {
+		t.Errorf("releases=%d, want 3 (MaxAttempts)", got)
+	}
+}
+
+// TestReleaseWithRetry_ContextCancellation_StopsBackoff proves a cancelled
+// context (e.g. the 90s background-context timeout elapsing) stops the
+// backoff loop promptly with a wrapped error rather than spinning.
+func TestReleaseWithRetry_ContextCancellation_StopsBackoff(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := New(srv.URL)
+
+	// Cancel almost immediately so the first inter-attempt sleep aborts.
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		cancel()
+	}()
+
+	err := c.ReleaseWithRetry(ctx, "omani.works", "hw155",
+		CommitRetryConfig{MaxAttempts: 50, InitialBackoff: 50 * time.Millisecond, MaxBackoff: 50 * time.Millisecond})
+	if err == nil {
+		t.Fatal("ReleaseWithRetry should return an error when ctx is cancelled mid-backoff")
+	}
+	if !strings.Contains(err.Error(), "cancelled") && !strings.Contains(err.Error(), "context") {
+		t.Errorf("err=%q should reflect context cancellation", err.Error())
+	}
+}


### PR DESCRIPTION
## What

Makes a wiped pool-domain Sovereign's subdomain reservation reliably released back to the pool, so re-firing the **same** subdomain succeeds immediately instead of returning `409 subdomain-conflict`.

Refs #3728.

## Bug vs TTL verdict

**BUG (reachability/ordering), NOT an intended TTL/cooldown.** There is no cooldown/grace/tombstone on `active` rows anywhere in PDM — `store.Release` is a hard immediate `DELETE` (`core/pool-domain-manager/internal/store/store.go:345-388`), and the sweeper only reclaims expired `reserved` rows (`core/pool-domain-manager/internal/allocator/allocator.go:415-459`). The only deliberate hold is the **separate operator-only** `/force-release` 30-day grace, which the wipe path does not use.

The wipe handler **does** call `pdm.Release` (`wipe.go:598-610`), and that release is correct end-to-end when it runs and succeeds. The defect is it was **best-effort, unguarded, non-retried, and tied to the inbound request context** — so several paths orphan the `active` row (which then never self-heals → permanent 409 on re-fire):

- No `h.pdm == nil` guard on the wipe release (asymmetric with every sibling path).
- Release error swallowed → wipe returns 200, deletes the on-disk record, reaps the in-memory row; after the reap even the manual `ReleaseSubdomain` recovery 404s. No retry (contrast `CommitWithRetry`).
- Context starvation: `releaseCtx` derived from `r.Context()`, already cancelled if the operator console disconnects during the ≤30m cloud purge.
- Record-only `DELETE /api/v1/deployments/{id}` never released the pool row.

Observed live twice this session: `hw155.omani.works` / `hw156.omani.works` wiped → re-fire of the same subdomain → 409, forcing hw155→hw156→hw157.

## Changes

- **`pdm/client.go`** — add `ReleaseWithRetry` (bounded exponential backoff, `ErrNotFound`-as-success — idempotent), the resilient sibling `Release` lacked.
- **`wipe.go`** — `h.pdm == nil` guard; `ReleaseWithRetry` on a `context.Background` context (immune to client disconnect); on retry-exhausted failure **RETAIN** the on-disk record + **skip the in-memory reap** so `DELETE …/release-subdomain` stays a viable manual recovery. `ReleaseSubdomain` now proceeds (instead of 410) for a wiped deployment that still carries pool pointers, and itself uses `ReleaseWithRetry`.
- **`deployments_delete.go`** — the record-only `DELETE` releases the pool subdomain **only** when the infra is already destroyed (`wiped`/`failed`); a LIVE pool Sovereign being deliberately orphaned is NOT released (its cluster still serves DNS from the pool child zone).
- **`deployments.go`** — the Phase-0-failure cleanup uses `ReleaseWithRetry` too.

## Safety

Release only ever deletes the exact `(poolDomain, subdomain)` being wiped. The wipe gates on `SovereignDomainMode=="pool"`; the adopted-check still protects live customer Sovereigns; the record-only path explicitly refuses to release a live Sovereign's slot. No change to the PDM reconciler TTL/sweeper.

## Tests

- `pdm/client_test.go`: `ReleaseWithRetry` — 5xx-then-success, 404-as-success, 5xx exhaustion, context-cancellation.
- `release_subdomain_test.go`: wiped-with-retained-pointers completes the release (the #3728 recovery contract); wiped-with-cleared-pointers still 410.
- `deployments_delete_test.go`: wiped pool → releases; live pool → does NOT release.

Build green (`go build ./...`). `internal/pdm` + `internal/handler` suites pass with `-race`; `core/pool-domain-manager` suite unchanged-green.

## NOT merged — parked for review

Not merging per the founder rule against `catalyst-api`/`ui` merges right before a prov and the live-walk verification discipline (a pool wipe→re-fire on a fresh prov is the acceptance gate). The reviewer should walk: pool wipe of `hwNNN.omani.works`, then re-fire the **same** subdomain and confirm it provisions (no 409).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
