### PR TITLE
fix(bootstrap-kit): revert grafana host-bridge — raw ExternalSecret dry-run-deadlocks the Kustomization before ESO CRD installs (Refs #3731)

### DIFF
--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -46,26 +46,15 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-grafana
-  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+  namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
-    catalyst.openova.io/vcluster: mgmt
     catalyst.openova.io/slot: "25"
 spec:
   interval: 15m
   timeout: 15m
   releaseName: grafana
   targetNamespace: grafana
-  storageNamespace: grafana
-  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
-  kubeConfig:
-    secretRef:
-      name: vc-mgmt
-      key: config
   dependsOn:
-    # bp-mgmt-vcluster MUST be Ready first — the vc-mgmt
-    # Secret doesn't exist until then. placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
-    - name: bp-mgmt-vcluster
-      namespace: flux-system
     - name: bp-cnpg
       namespace: flux-system
     # #2745 (2026-06-12): bp-loki/bp-mimir/bp-tempo HRs re-homed to host
@@ -140,7 +129,6 @@ spec:
         name: bp-grafana
         namespace: flux-system
   install:
-    createNamespace: true  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     timeout: 15m
     disableWait: true
     remediation:
@@ -156,7 +144,6 @@ spec:
   # attaches to cilium-gateway/kube-system installed by 01-cilium.yaml.
   values:
     gateway:
-      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       host: grafana.${SOVEREIGN_FQDN}
     # G91.grafana (#2658) — wire bp-sso-bridge framework. The chart-side
     # grafana.ini.auth.generic_oauth block computes auth_url / token_url /
@@ -165,7 +152,6 @@ spec:
     # half-config); with the envsubst SSO works zero-touch on every
     # fresh Sovereign.
     sso:
-      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       sovereignFqdn: ${SOVEREIGN_FQDN}
       # #3374 (2026-06-14): grafana consumes its OIDC secret as DIRECT env
       # vars via `grafana.envFromSecret: grafana-sso-oidc-credentials`, so it
@@ -207,79 +193,3 @@ spec:
       envFromSecrets:
         - name: grafana-database-env
           optional: ${SOVEREIGN_GRAFANA_DB_SECRET_OPTIONAL:=true}
-
-# ── HOST-BRIDGE BEGIN (#3642) — placement-generated host-side route/secret/CNPG; edit placement.yaml hostBridge: + run scripts/render-slot-placement.py fix ──
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: grafana
-  namespace: mgmt
-  labels:
-    catalyst.openova.io/blueprint: bp-grafana
-    catalyst.openova.io/component: grafana
-    catalyst.openova.io/host-bridge: mgmt
-spec:
-  parentRefs:
-  - name: cilium-gateway
-    namespace: kube-system
-  hostnames:
-  - grafana.${SOVEREIGN_FQDN}
-  rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /
-    backendRefs:
-    - name: grafana-x-grafana-x-mgmt-vcluster
-      namespace: mgmt
-      port: 80
----
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: grafana-sso-oidc-credentials
-  namespace: grafana
-  labels:
-    catalyst.openova.io/blueprint: bp-grafana
-    bp-sso-bridge.openova.io/consumer: bp-grafana
-    catalyst.openova.io/host-bridge: mgmt
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: vault-region1
-    kind: ClusterSecretStore
-  target:
-    name: grafana-sso-oidc-credentials
-    creationPolicy: Owner
-    template:
-      type: Opaque
-      data:
-        GF_AUTH_GENERIC_OAUTH_CLIENT_ID: '{{ .client_id }}'
-        GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: '{{ .client_secret }}'
-        GF_AUTH_GENERIC_OAUTH_AUTH_URL: '{{ .authorize_url }}?kc_idp_hint=catalyst-pin'
-        GF_AUTH_GENERIC_OAUTH_TOKEN_URL: '{{ .token_url }}'
-        GF_AUTH_GENERIC_OAUTH_API_URL: '{{ .userinfo_url }}'
-        GF_SERVER_ROOT_URL: https://grafana.${SOVEREIGN_FQDN}/
-  data:
-  - secretKey: client_id
-    remoteRef:
-      key: sso/grafana
-      property: client_id
-  - secretKey: client_secret
-    remoteRef:
-      key: sso/grafana
-      property: client_secret
-  - secretKey: authorize_url
-    remoteRef:
-      key: sso/grafana
-      property: authorize_url
-  - secretKey: token_url
-    remoteRef:
-      key: sso/grafana
-      property: token_url
-  - secretKey: userinfo_url
-    remoteRef:
-      key: sso/grafana
-      property: userinfo_url
-# ── HOST-BRIDGE END (#3642) ──

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -333,110 +333,55 @@ spec:
     - {file: 17-valkey.yaml, hr: bp-valkey, vcluster: rtz, target: rtz, namespace: valkey}   # Batch A (#3373) — PROMOTED: pure-OSS clean (no route/secret/CNPG); plain Service DNS via OSS services-sync
     - {file: 18-seaweedfs.yaml, hr: bp-seaweedfs, vcluster: rtz, target: rtz, namespace: seaweedfs}   # Batch A (#3373) — PROMOTED: pure-OSS clean (no route/secret/CNPG); S3 wire is plain Service DNS via OSS services-sync; all consumers S3-default-OFF on a fresh prov
     - {file: 19-harbor.yaml, hr: bp-harbor, vcluster: host, target: mgmt, namespace: harbor}
-    # ── #3642 HOST-BRIDGE PROMOTE — grafana into the mgmt vCluster ──────
-    # The North-Star-#1 batch-D-first app (least blast radius: depends only
-    # on already-mgmt loki/mimir/tempo + shared-pg-b). grafana ships an
-    # HTTPRoute + an SSO ExternalSecret (no own CNPG Cluster — it is a
-    # shared-pg-b consumer). The host-bridge keeps BOTH host-rendered (the
-    # host Cilium Gateway + host external-secrets-operator reconcile them
-    # exactly as today) while the grafana Deployment re-homes into mgmt via
-    # spec.kubeConfig.secretRef → vc-mgmt. `suppress` turns the chart's OWN
-    # in-vCluster route + ES off; `hostDocuments` are the host-side copies,
-    # backendRef pre-aliased to the OSS-synced mangled Service
-    # grafana-x-grafana-x-mgmt-vcluster. The materialized
-    # grafana-sso-oidc-credentials Secret reaches the in-vCluster Pod via the
-    # mgmt-vcluster `sync.fromHost.secrets` mapping (values.yaml #3642).
-    - file: 25-grafana.yaml
-      hr: bp-grafana
-      vcluster: mgmt
-      target: mgmt
-      namespace: grafana
-      hostBridge:
-        # Chart values stamped into the in-vCluster workload HR: the
-        # chart's own HTTPRoute + SSO ExternalSecret do NOT render inside
-        # the vCluster (the host-side copies below are authoritative).
-        suppress:
-          gateway.enabled: false
-          sso.enabled: false
-        # Host-side route + ExternalSecret, transcribed verbatim into the
-        # slot by render-slot-placement.py. Placement is DATA.
-        hostDocuments:
-          # HTTPRoute in the `mgmt` host ns (same as the mangled backend
-          # Service → no ReferenceGrant); attaches to kube-system/
-          # cilium-gateway via allowedRoutes.from=All.
-          - apiVersion: gateway.networking.k8s.io/v1
-            kind: HTTPRoute
-            metadata:
-              name: grafana
-              namespace: mgmt
-              labels:
-                catalyst.openova.io/blueprint: bp-grafana
-                catalyst.openova.io/component: grafana
-                catalyst.openova.io/host-bridge: "mgmt"
-            spec:
-              parentRefs:
-                - name: cilium-gateway
-                  namespace: kube-system
-              hostnames:
-                - grafana.${SOVEREIGN_FQDN}
-              rules:
-                - matches:
-                    - path:
-                        type: PathPrefix
-                        value: /
-                  backendRefs:
-                    # OSS sync.toHost.services mangled name (grafana Service
-                    # synced out of vc-mgmt to the host mgmt namespace).
-                    - name: grafana-x-grafana-x-mgmt-vcluster
-                      namespace: mgmt
-                      port: 80
-          - apiVersion: external-secrets.io/v1beta1
-            kind: ExternalSecret
-            metadata:
-              name: grafana-sso-oidc-credentials
-              namespace: grafana
-              labels:
-                catalyst.openova.io/blueprint: bp-grafana
-                bp-sso-bridge.openova.io/consumer: bp-grafana
-                catalyst.openova.io/host-bridge: "mgmt"
-            spec:
-              refreshInterval: 1h
-              secretStoreRef:
-                name: vault-region1
-                kind: ClusterSecretStore
-              target:
-                name: grafana-sso-oidc-credentials
-                creationPolicy: Owner
-                template:
-                  type: Opaque
-                  data:
-                    GF_AUTH_GENERIC_OAUTH_CLIENT_ID: "{{ .client_id }}"
-                    GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: "{{ .client_secret }}"
-                    GF_AUTH_GENERIC_OAUTH_AUTH_URL: "{{ .authorize_url }}?kc_idp_hint=catalyst-pin"
-                    GF_AUTH_GENERIC_OAUTH_TOKEN_URL: "{{ .token_url }}"
-                    GF_AUTH_GENERIC_OAUTH_API_URL: "{{ .userinfo_url }}"
-                    GF_SERVER_ROOT_URL: "https://grafana.${SOVEREIGN_FQDN}/"
-              data:
-                - secretKey: client_id
-                  remoteRef:
-                    key: sso/grafana
-                    property: client_id
-                - secretKey: client_secret
-                  remoteRef:
-                    key: sso/grafana
-                    property: client_secret
-                - secretKey: authorize_url
-                  remoteRef:
-                    key: sso/grafana
-                    property: authorize_url
-                - secretKey: token_url
-                  remoteRef:
-                    key: sso/grafana
-                    property: token_url
-                - secretKey: userinfo_url
-                  remoteRef:
-                    key: sso/grafana
-                    property: userinfo_url
+    # ── #3642 HOST-BRIDGE REVERTED to host (#3731) — grafana stays host ──
+    # grafana was PROMOTED to a mgmt host-bridge by #3703 (route + SSO
+    # ExternalSecret host-rendered, workload re-homed into vc-mgmt). That
+    # promotion WEDGED every fresh prov at 0 HelmReleases (#3731, caught
+    # live on hw157):
+    #
+    #   The host-bridge transcribes a RAW `external-secrets.io/v1beta1`
+    #   ExternalSecret (grafana-sso-oidc-credentials) into THIS slot, inside
+    #   the monolithic bootstrap-kit Flux Kustomization (wait:true, default
+    #   server-side apply → it dry-run-validates the WHOLE rendered set on
+    #   every reconcile). The external-secrets CRD does NOT exist at that
+    #   first dry-run — it is installed only by the slot-15 bp-external-
+    #   secrets HelmRelease DURING reconciliation. So the dry-run fails with
+    #   `no matches for kind "ExternalSecret" in version
+    #   "external-secrets.io/v1beta1"`, the whole Kustomization apply is
+    #   rejected, the bp-external-secrets HR is never created → the CRD
+    #   never lands → permanent 0-HR deadlock (the CRD-provider slot 15 and
+    #   the CRD-consumer raw ES sit in the SAME Kustomization). The raw
+    #   HTTPRoute in the same block does NOT trip this only because cloud-
+    #   init pre-applies the gateway-api CRDs before Flux
+    #   (cloudinit-control-plane.tftpl:716-720); there is no equivalent
+    #   pre-install for external-secrets.
+    #
+    #   The lift ALSO disabled the chart's own protection: grafana's chart
+    #   ES (platform/grafana/chart/templates/sso-oauth-source-external
+    #   secret.yaml) is guarded by `.Capabilities.APIVersions.Has
+    #   "external-secrets.io/v1beta1"` and the HR `dependsOn: bp-external-
+    #   secrets`, so it renders only once the CRD exists. #3703's
+    #   `suppress: {sso.enabled: false}` turned that guarded ES OFF and
+    #   replaced it with the unguarded raw copy — re-introducing the exact
+    #   race the guard exists to prevent.
+    #
+    #   And the bridge was non-functional regardless: NO `sync.fromHost.
+    #   secrets` mapping in the merged bp-mgmt-vcluster chart delivers the
+    #   host-rendered grafana-sso-oidc-credentials Secret INTO the in-
+    #   vCluster Pod, and OSS vCluster's `sync.toHost.customResources` is
+    #   Pro-gated (silently no-ops) — that wiring is part of the PARKED
+    #   #3719 (DO-NOT-MERGE — next train) follow-on.
+    #
+    # So grafana reverts to a HOST placement (target=mgmt stays the §4
+    # aspiration). On host the chart renders its OWN `.Capabilities`-guarded
+    # ES + native HTTPRoute, the HR runs where ESO + OpenBao + the Cilium
+    # Gateway all live, and the proven #3374 zero-click recipe is restored.
+    # The host-bridge re-lands properly with #3642/#3719 — which must add
+    # the fromHost secret-sync AND keep the ExternalSecret out of the atomic
+    # Kustomization (a separate Flux Kustomization that `dependsOn` the ESO
+    # install, OR an early-slot raw-CRD pre-install), per #3731.
+    - {file: 25-grafana.yaml, hr: bp-grafana, vcluster: host, target: mgmt,
+       namespace: grafana}   # §4: host-bridge reverted (#3731 dry-run deadlock); re-home with #3642/#3719
     - {file: 39-bp-vllm.yaml, hr: bp-vllm, vcluster: rtz, target: rtz, namespace: vllm}   # Batch A (#3373) — PROMOTED: pure-OSS clean (no route/secret/CNPG); plain Service DNS via OSS services-sync; vllm + its newapi channel both default-OFF on a fresh prov
     - {file: 51-bp-k8s-ws-proxy.yaml, hr: bp-k8s-ws-proxy, vcluster: host, target: mgmt,
        namespace: catalyst-system}   # recipe proven, draft PR #3350

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -377,11 +377,13 @@ slots:
     # the ESO CRD (.Capabilities .Has "external-secrets.io/v1beta1") and gates
     # on bp-external-secrets so the ESO webhook is serving before grafana's
     # ExternalSecret applies — lockstep with the live 25-grafana.yaml edge.
-    # bp-mgmt-vcluster dep (#3642): grafana host→mgmt host-bridge move — the
-    # vc-mgmt kubeConfig Secret doesn't exist until bp-mgmt-vcluster is Ready,
-    # so the kubeConfig pivot dangles without this edge (added by
-    # render-slot-placement.py fix from the placement.yaml flip).
-    depends_on: [bp-cnpg, bp-loki, bp-mimir, bp-tempo, bp-keycloak, bp-gateway-api, bp-external-secrets, bp-postgres-shared-b, bp-mgmt-vcluster]
+    # bp-mgmt-vcluster edge REMOVED (#3731): the #3642 grafana host→mgmt
+    # host-bridge was reverted to a HOST placement — its raw ExternalSecret
+    # dry-run-deadlocked the bootstrap-kit Kustomization before the ESO CRD
+    # installed (0-HR fresh-prov wedge on hw157). Grafana runs on host again
+    # (chart renders its own .Capabilities-guarded ES), so the vc-mgmt
+    # runtime edge no longer applies; re-home with #3642/#3719 next train.
+    depends_on: [bp-cnpg, bp-loki, bp-mimir, bp-tempo, bp-keycloak, bp-gateway-api, bp-external-secrets, bp-postgres-shared-b]
     wave: W2.K2
   - slot: 26
     name: bp-network-policies


### PR DESCRIPTION
Refs #3731

## What this fixes — the fresh-prov 0-HR convergence wedge

On a fresh kom4dc prov (hw157, `be58d12bf9e10a72`) the primary node goes Ready, the kubeconfig is PUT (#3727 github-IPv4 fix works), and the in-cluster `GitRepository` is `READY` — but `flux-system/bootstrap-kit` is **False** with **0 HelmReleases**. Exact reconcile error:

```
ExternalSecret/grafana/grafana-sso-oidc-credentials dry-run failed:
no matches for kind "ExternalSecret" in version "external-secrets.io/v1beta1"
```

## Root cause

`#3703` (host-bridge: keycloak + grafana → mgmt vCluster) added a **raw** `external-secrets.io/v1beta1` `ExternalSecret` (`grafana-sso-oidc-credentials`) into `clusters/_template/bootstrap-kit/25-grafana.yaml` — placement-generated from `placement.yaml`'s grafana `hostBridge.hostDocuments`.

The `bootstrap-kit` Flux Kustomization (`infra/providers/_shared/cloudinit-control-plane.tftpl`: `wait: true`, `prune: true`, default server-side apply) **dry-run-validates the whole rendered set against the live apiserver on every reconcile**. The `external-secrets.io` CRD does not exist at that first dry-run — it is installed only by the slot-15 `bp-external-secrets` HelmRelease **during** reconciliation. So:

1. dry-run of the raw ES fails (`no matches for kind ExternalSecret`)
2. the whole Kustomization apply is rejected (CRD-provider slot 15 + CRD-consumer raw ES live in the **same** Kustomization)
3. → `bp-external-secrets` is never created → the CRD never lands → permanent 0-HR deadlock.

The sibling raw `HTTPRoute` in the same block does **not** trip this only because cloud-init pre-applies the gateway-api CRDs before Flux (`cloudinit-control-plane.tftpl:716-720`); there is **no** equivalent pre-install for external-secrets.

The lift also disabled grafana's own protection: the chart ES (`platform/grafana/chart/templates/sso-oauth-source-externalsecret.yaml`) is guarded by `.Capabilities.APIVersions.Has "external-secrets.io/v1beta1"` + the HR `dependsOn: bp-external-secrets`, so it renders only once the CRD exists. `#3703`'s `suppress: {sso.enabled: false}` turned that guarded ES **off** and replaced it with the unguarded raw copy — re-introducing the exact race the guard prevents. And the bridge was **non-functional** regardless: the merged `bp-mgmt-vcluster` chart has no `sync.fromHost.secrets` mapping to deliver the host-rendered Secret into the in-vCluster Pod (that's the **PARKED** `#3719`, DO-NOT-MERGE next-train), and OSS vCluster `sync.toHost.customResources` is Pro-gated.

## Fix approach

Fix at the **source** (`placement.yaml` is data, #3373): revert grafana's row to a **HOST placement** (`vcluster: host`, `target: mgmt` stays the §4 aspiration). `render-slot-placement.py fix` regenerates `25-grafana.yaml` to the **proven pre-#3703 host state** — the chart renders its own `.Capabilities`-guarded ES + native HTTPRoute, the HR runs on host where ESO + OpenBao + the Cilium Gateway all live (the #3374 zero-click recipe). The `dependsOn: bp-external-secrets` edge is preserved. `expected-bootstrap-deps.yaml` drops the now-stale `bp-mgmt-vcluster` edge in lockstep.

This is the smallest correct, mergeable fix: it restores convergence without inventing a new CRD-install slot, and the host-bridge re-lands properly with `#3642`/`#3719` (which must add the fromHost secret-sync **and** keep the ExternalSecret out of the atomic Kustomization — a separate Flux Kustomization that `dependsOn` the ESO install, or an early-slot raw-CRD pre-install).

## Same-shape sweep (full bootstrap-kit)

Enumerated every resource kind in all 64 slot files. **`25-grafana.yaml`'s raw `ExternalSecret` was the ONLY raw CR in the entire bootstrap-kit referencing an HR-installed CRD with no pre-install path.** Findings:

| Slot | Raw non-Helm CR | CRD source | Deadlock? |
|---|---|---|---|
| `25-grafana.yaml` | **ExternalSecret** (external-secrets.io/v1beta1) | slot-15 `bp-external-secrets` HR (post-Kustomization) | **YES → fixed (removed)** |
| `25-grafana.yaml` | HTTPRoute (gateway.networking.k8s.io/v1) | cloud-init pre-Flux (line 719) | no (removed anyway with the host-bridge) |
| `09-keycloak.yaml` | HTTPRoute | cloud-init pre-Flux | no (left as-is — keycloak host-bridge unaffected) |
| `01-cilium.yaml` | Gateway | cloud-init pre-Flux | no |

No other raw `ExternalSecret`, CNPG `Cluster`, kyverno, crossplane, continuum, or sandbox CRs exist as slot documents.

## Validation (all green)

```
kubectl kustomize clusters/_template/bootstrap-kit   # exit 0; 0 raw ExternalSecret / 0 external-secrets.io/v1beta1 docs
bash   scripts/check-bootstrap-deps.sh               # exit 0 — DAG + kustomize-build + slot-registration
python3 scripts/render-slot-placement.py check       # exit 0 — placement-as-data drift clean
python3 scripts/tests/render_slot_placement_hostbridge_test.py   # exit 0
python3 scripts/audit-placement-conformance.py rendered          # exit 0 — grafana = host→mgmt backlog
```

The regenerated `25-grafana.yaml` is byte-equivalent to the pre-#3703 host state, modulo placement-generated explicit-namespace hygiene on cross-ns `dependsOn` edges (the `bp-keycloak` edge correctly points at `mgmt`, where keycloak still lives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
