### PR TITLE
fix(bp-cert-manager): split ClusterIssuers into bp-cert-manager-issuers slot 02a — fixes InstallFailed loop (#3734)

### DIFF
--- a/clusters/_template/bootstrap-kit/02-cert-manager.yaml
+++ b/clusters/_template/bootstrap-kit/02-cert-manager.yaml
@@ -49,7 +49,10 @@ spec:
       # next-private-key informer-cache race that blocks Certificate
       # issuance on HCS provs (verified live hw54 15:07Z). Plus
       # CVE-2025-22871/22870/22872 fixes.
-      version: 1.2.5
+      # 1.2.6 (issue #3734): the two Catalyst ClusterIssuers split out to
+      # bp-cert-manager-issuers (slot 02a) to dodge the helm-controller
+      # RESTMapper-cache CRD-ordering race. crd-gate Job/RBAC stay here.
+      version: 1.2.6
       sourceRef:
         kind: HelmRepository
         name: bp-cert-manager

--- a/clusters/_template/bootstrap-kit/02a-bp-cert-manager-issuers.yaml
+++ b/clusters/_template/bootstrap-kit/02a-bp-cert-manager-issuers.yaml
@@ -1,0 +1,97 @@
+# bp-cert-manager-issuers — Catalyst bootstrap-kit Blueprint, slot 02a
+# (sub-slot of 02, follows bp-cert-manager).
+#
+# Owns the two Catalyst Let's Encrypt ClusterIssuers (letsencrypt-dns01-prod,
+# letsencrypt-http01-prod). Split from bp-cert-manager (issue #3734) to
+# resolve the helm-controller RESTMapper-cache CRD-ordering race:
+#
+#   bp-cert-manager shipped the two ClusterIssuers as in-release Helm
+#   post-install hooks (weight 5). The chart's crd-gate Job (weight -10)
+#   correctly waited for the ClusterIssuer CRD to reach Established=True on
+#   the apiserver, BUT helm-controller builds its in-process RESTMapper
+#   cache at reconcile-START — before the CRD is registered — and does NOT
+#   refresh it before the issuer hooks' before-hook-creation delete (or the
+#   create) runs. The kind is unmapped in the cached mapper, so BOTH the
+#   delete-hook AND the create fail with:
+#     no matches for kind "ClusterIssuer" in version "cert-manager.io/v1"
+#   → InstallFailed → Flux remediates (uninstall) → infinite reinstall loop
+#   (verified live on hw157). The crd-gate closed the apiserver-Established
+#   race but NOT the client RESTMapper-cache race.
+#
+# A SEPARATE HelmRelease (this slot) gets a FRESH helm-controller reconcile,
+# gated via dependsOn on bp-cert-manager reaching Ready. By then the
+# cert-manager.io ClusterIssuer CRD is registered, so the fresh reconcile's
+# RESTMapper includes the ClusterIssuer kind and the CRs apply cleanly. The
+# bp-cert-manager-issuers chart ships them as PLAIN manifests (no Helm hooks
+# — the hook machinery is what tripped the RESTMapper path) plus a
+# belt-and-suspenders pre-install crd-gate for the residual apiserver-async
+# Established lag.
+#
+# Mirrors the bp-external-secrets ↔ bp-external-secrets-stores (slot 15/15a,
+# issue #331) and bp-crossplane ↔ bp-crossplane-claims (slot 04/14, PR #247)
+# CRD-ordering split shape: controller chart owns the operator + CRDs, this
+# chart owns the CRs, Flux dependsOn orders them.
+#
+# Wrapper chart: platform/cert-manager-issuers/chart/
+# Catalyst-curated values: platform/cert-manager-issuers/chart/values.yaml
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-cert-manager-issuers
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-cert-manager-issuers
+  namespace: flux-system
+  labels:
+    catalyst.openova.io/slot: "02a"
+spec:
+  interval: 15m
+  releaseName: cert-manager-issuers
+  # Co-located with cert-manager so the ClusterIssuers' ACME account-key
+  # Secrets (privateKeySecretRef) live in the namespace cert-manager itself
+  # watches. ClusterIssuer is cluster-scoped, so the targetNamespace only
+  # governs where the account-key Secret + the crd-gate Job land.
+  targetNamespace: cert-manager
+  # Order — Flux will not start install until bp-cert-manager reaches
+  # Ready=True (upstream cert-manager controllers running AND the
+  # cert-manager.io CRDs registered). The fresh reconcile that follows
+  # builds a RESTMapper that includes the ClusterIssuer kind — the whole
+  # point of the split (#3734).
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-cert-manager-issuers
+      # 1.0.0 (issue #3734): initial release. Splits the two Catalyst
+      # ClusterIssuers out of bp-cert-manager.
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-cert-manager-issuers
+        namespace: flux-system
+  # Event-driven install per docs/INVIOLABLE-PRINCIPLES.md #3 (Flux
+  # dependsOn is the gate, not Helm timeout). The chart's pre-install
+  # crd-gate already bounds the Established wait; the plain-manifest
+  # ClusterIssuers apply in the main pass.
+  install:
+    disableWait: true
+    timeout: 15m
+    remediation:
+      retries: -1
+  upgrade:
+    disableWait: true
+    timeout: 15m
+    remediation:
+      retries: 3

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -13,6 +13,15 @@ resources:
   - 01-cilium.yaml
   - 01a-gateway-api.yaml
   - 02-cert-manager.yaml
+  # bp-cert-manager-issuers (slot 02a, #3734) — the two Catalyst Let's
+  # Encrypt ClusterIssuers, split out of bp-cert-manager into their own
+  # HelmRelease (dependsOn bp-cert-manager) to dodge the helm-controller
+  # RESTMapper-cache CRD-ordering race that looped bp-cert-manager on
+  # InstallFailed (verified live hw157). MUST be registered here or Flux
+  # never creates the HR → the issuers never apply → the Cilium Gateway's
+  # TLS Certificate never issues (the #3191 forgotten-slot wedge class).
+  # Mirrors 15a-external-secrets-stores after 15-external-secrets.
+  - 02a-bp-cert-manager-issuers.yaml
   - 03-flux.yaml
   - 04-crossplane.yaml
   - 05-sealed-secrets.yaml

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -81,6 +81,8 @@ spec:
        namespace: flux-system, justification: "HOST-MINIMUM §4 — Gateway API CRDs (cluster-scoped)"}
     - {file: 02-cert-manager.yaml, hr: bp-cert-manager, vcluster: host, target: host,
        namespace: cert-manager, justification: "HOST-MINIMUM §4 — cluster TLS substrate"}
+    - {file: 02a-bp-cert-manager-issuers.yaml, hr: bp-cert-manager-issuers, vcluster: host, target: host,
+       namespace: cert-manager, justification: "HOST-MINIMUM §4 — cluster TLS substrate (Let's Encrypt ClusterIssuers, #3734 split)"}
     - {file: 03-flux.yaml, hr: bp-flux, vcluster: host, target: host,
        namespace: flux-system, justification: "HOST-MINIMUM §4 — the GitOps engine itself"}
     - {file: 04-crossplane.yaml, hr: bp-crossplane, vcluster: host, target: host,

--- a/platform/cert-manager-issuers/blueprint.yaml
+++ b/platform/cert-manager-issuers/blueprint.yaml
@@ -1,0 +1,67 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-cert-manager-issuers
+  labels:
+    catalyst.openova.io/section: pts-3-3-security-and-policy
+spec:
+  version: 1.0.0
+  card:
+    title: cert-manager — Issuers
+    summary: |
+      Default Let's Encrypt ClusterIssuer CR(s) (letsencrypt-dns01-prod,
+      letsencrypt-http01-prod). Split from bp-cert-manager (#3734) to
+      resolve the helm-controller RESTMapper-cache CRD-ordering race — the
+      ClusterIssuer CRs cannot live in the same Helm release as the
+      cert-manager subchart that registers their CRD; Flux dependsOn orders
+      this chart after bp-cert-manager is Ready so a fresh reconcile maps
+      the ClusterIssuer kind and the CRs apply cleanly.
+
+      Mirrors the bp-external-secrets-stores / bp-crossplane-claims pattern.
+    icon: cert-manager.svg
+    category: security
+  visibility: unlisted              # mandatory infra, auto-installed by bootstrap kit
+  manifests:
+    chart: ./chart
+  depends:
+    - bp-cert-manager
+
+  # ── Outputs advertised to dependent Blueprints (inherited from #113) ─────
+  # The issuer NAMES are unchanged from when they lived in bp-cert-manager,
+  # so dependents that consume `issuerName` keep resolving the same CR.
+  # bp-cert-manager still advertises the issuerName output (it is the
+  # logical owner of the issuer contract); this chart is the physical
+  # owner of the CRs. Re-advertised here for discoverability.
+  outputs:
+    issuerName: letsencrypt-dns01-prod
+    issuerKind: ClusterIssuer
+    wildcardIssuerName: letsencrypt-dns01-prod
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        replication:
+          backend: flux-git
+          mode: async
+        placement:
+          tier: ''
+          clusters:
+            - mgmt-A
+            - mgmt-B
+            - dmz-A
+            - dmz-B
+            - rtz-A
+            - rtz-B
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  multiInstance:
+    enabled: false

--- a/platform/cert-manager-issuers/chart/Chart.yaml
+++ b/platform/cert-manager-issuers/chart/Chart.yaml
@@ -1,0 +1,64 @@
+apiVersion: v2
+name: bp-cert-manager-issuers
+# 1.0.0 (issue #3734): initial release. Splits the two Catalyst-curated
+# ClusterIssuers (letsencrypt-dns01-prod, letsencrypt-http01-prod) OUT of
+# the bp-cert-manager umbrella chart into this standalone chart so they are
+# reconciled by a SEPARATE HelmRelease that dependsOn bp-cert-manager.
+#
+# Why the split (the race this closes)
+# ====================================
+# bp-cert-manager@<=1.2.5 shipped both ClusterIssuers as in-release Helm
+# post-install hooks (weight 5). The chart's crd-gate Job (weight -10)
+# correctly waits for the ClusterIssuer CRD to reach Established=True on the
+# apiserver, BUT helm-controller builds its in-process RESTMapper cache at
+# reconcile-START — before the ClusterIssuer CRD is registered — and does
+# NOT refresh it before the issuer hooks' `before-hook-creation` delete
+# policy (or the create path) runs. The kind is therefore unmapped in the
+# cached mapper and BOTH the delete-hook AND the create fail with:
+#   resource mapping not found for ... "ClusterIssuer" in "cert-manager.io/v1"
+#   no matches for kind "ClusterIssuer"
+# → InstallFailed → Flux remediates (uninstall) → infinite reinstall loop
+# (verified live on hw157). The crd-gate closes the apiserver-Established
+# race but NOT the helm-controller client RESTMapper-cache race.
+#
+# A SEPARATE HelmRelease gets a FRESH helm-controller reconcile (gated, via
+# dependsOn: bp-cert-manager, on cert-manager Ready). That fresh reconcile
+# builds a RESTMapper AFTER the cert-manager.io CRDs are registered, so the
+# ClusterIssuer kind maps and the CRs apply cleanly. The issuers ship here
+# as PLAIN manifests (no Helm hooks) — the hook machinery is exactly what
+# tripped the RESTMapper path, so dropping it is strictly safer. A
+# pre-install crd-gate (belt-and-suspenders) still asserts Established=True
+# before the manifests apply, covering the residual apiserver-async lag.
+#
+# Mirrors the bp-external-secrets ↔ bp-external-secrets-stores (slot 15/15a,
+# issue #331) and bp-crossplane ↔ bp-crossplane-claims (slot 04/14, PR #247)
+# CRD-ordering split shape: controller chart owns the operator + CRDs, a
+# separate chart owns the CRs, Flux dependsOn orders them.
+#
+# Keeps zero upstream subchart deps — the chart is pure Catalyst templates
+# applying CRs against the cert-manager-registered ClusterIssuer CRD.
+version: 1.0.0
+description: |
+  Catalyst-curated Blueprint chart for the default Let's Encrypt
+  ClusterIssuer CR(s) (letsencrypt-dns01-prod, letsencrypt-http01-prod).
+  Split from bp-cert-manager (issue #3734) to resolve the helm-controller
+  RESTMapper-cache CRD-ordering race: the ClusterIssuer CRs cannot live in
+  the same Helm release as the cert-manager subchart that registers their
+  CRD — helm-controller's RESTMapper is built before the CRD exists and the
+  hook apply fails with `no matches for kind "ClusterIssuer"`. A separate
+  HelmRelease (dependsOn bp-cert-manager) gets a fresh reconcile whose
+  RESTMapper includes the now-registered CRD, so the issuers apply cleanly.
+
+  Mirrors the bp-external-secrets-stores / bp-crossplane-claims split shape:
+  controller chart owns the operator + CRDs, this chart owns the CRs, Flux
+  dependsOn orders them. Keeps zero upstream subchart deps — pure Catalyst
+  templates applying CRs against the upstream-registered ClusterIssuer CRD.
+type: application
+keywords: [catalyst, blueprint, cert-manager, clusterissuer, letsencrypt, tls, acme]
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+annotations:
+  catalyst.openova.io/no-upstream: "true"
+  catalyst.openova.io/depends-on: "bp-cert-manager"

--- a/platform/cert-manager-issuers/chart/templates/clusterissuers.yaml
+++ b/platform/cert-manager-issuers/chart/templates/clusterissuers.yaml
@@ -1,57 +1,55 @@
-# clusterissuer-letsencrypt-dns01.yaml — Catalyst-curated TLS issuer for
-# OpenOva Sovereign clusters.
-#
-# Closes #113 — "[G] dns: validate TLS issuance via cert-manager Let's
-# Encrypt DNS-01 challenge".
+# clusterissuers.yaml — Catalyst-curated Let's Encrypt ClusterIssuers,
+# split out of bp-cert-manager into bp-cert-manager-issuers (issue #3734).
 #
 # ──────────────────────────────────────────────────────────────────────────
-# Why two ClusterIssuers in one file
+# Why these are PLAIN manifests (no Helm hooks)
 # ──────────────────────────────────────────────────────────────────────────
+# In bp-cert-manager these two CRs shipped as post-install Helm hooks
+# (weight 5) with `before-hook-creation` delete policy. That tripped the
+# helm-controller RESTMapper-cache race: the cached mapper (built at
+# reconcile-start, before the cert-manager.io ClusterIssuer CRD existed)
+# never refreshed, so the hook's delete AND create both failed with
+# `no matches for kind "ClusterIssuer"` → InstallFailed → uninstall →
+# reinstall loop (verified live on hw157).
 #
+# This chart is a SEPARATE HelmRelease (bootstrap-kit slot 02a) whose Flux
+# HR `dependsOn: bp-cert-manager`. By the time Flux starts reconciling this
+# release, bp-cert-manager is Ready → the ClusterIssuer CRD is registered →
+# the FRESH helm-controller reconcile for THIS release builds a RESTMapper
+# that already includes the ClusterIssuer kind. So the CRs apply cleanly as
+# ordinary main-pass manifests; the Helm hook machinery that caused the
+# original failure is gone entirely. The chart's pre-install crd-gate
+# (templates/crd-gate-hook.yaml) is belt-and-suspenders for the residual
+# apiserver-async Established lag.
+#
+# ──────────────────────────────────────────────────────────────────────────
+# Why two ClusterIssuers
+# ──────────────────────────────────────────────────────────────────────────
 # Wildcard certificates (e.g. *.omantel.omani.works) MUST be issued via
 # DNS-01: HTTP-01 cannot prove ownership of a wildcard hostname. The
 # canonical 6-record set written by catalyst-dns includes
-# `*.<sub>.<domain>`, and the Cilium Gateway's HTTPS listener serves that
-# wildcard via a single Certificate. So DNS-01 is the target state.
-#
-# However, cert-manager's DNS-01 webhook contract is DIFFERENT from
-# external-dns's webhook contract: external-dns expects a sidecar that
-# implements its own RPC schema (records.list / records.add / records.delete),
-# while cert-manager expects a webhook that implements
-# `webhook.acme.cert-manager.io/v1alpha1` (Present / CleanUp on a
-# ChallengeRequest CRD). The Catalyst external-dns webhook at
-# products/catalyst/bootstrap/api/cmd/external-dns-dynadot-webhook/ does
-# NOT satisfy the cert-manager contract and therefore CANNOT be reused
-# here. There is no upstream cert-manager-Dynadot webhook on
-# https://cert-manager.io/docs/configuration/acme/dns01/webhook/ as of
-# 2026-04-28.
+# `*.<sub>.<domain>`, served by the Cilium Gateway's HTTPS listener via a
+# single Certificate. So DNS-01 is the target state.
 #
 # What we ship today (this file):
 #   - letsencrypt-dns01-prod   — DEPRECATED for omani.works Sovereigns,
 #     DEFAULT DISABLED. Was templated against the (now-dropped)
 #     bp-cert-manager-dynadot-webhook. The replacement DNS-01 wildcard
 #     issuer is `letsencrypt-dns01-prod-powerdns`, shipped by
-#     bp-cert-manager-powerdns-webhook against contabo's central PowerDNS
-#     (https://pdns.openova.io — authoritative for omani.works because
-#     Dynadot delegates the zone to ns1/2/3.openova.io). Cluster overlays
-#     MAY flip dns01.enabled=true and supply their own dynadot-webhook
-#     for a non-omani.works pool where Dynadot IS the API-level authority.
-#   - letsencrypt-http01-prod  — INTERIM, RETAINED. Continues to issue
-#     per-host certs for explicit hostnames. Operator may flip the
-#     active issuer at any time via certManager.issuers.dns01.enabled
-#     and certManager.issuers.http01.enabled.
+#     bp-cert-manager-powerdns-webhook (slot 49) against contabo's central
+#     PowerDNS (https://pdns.openova.io — authoritative for omani.works
+#     because Dynadot delegates the zone to ns1/2/3.openova.io). Cluster
+#     overlays MAY flip dns01.enabled=true and supply their own dynadot-
+#     webhook for a non-omani.works pool where Dynadot IS the API-level
+#     authority.
+#   - letsencrypt-http01-prod  — INTERIM, RETAINED, DEFAULT ENABLED.
+#     Continues to issue per-host certs for explicit hostnames. Operator
+#     may flip the active issuer at any time via
+#     certManager.issuers.dns01.enabled and certManager.issuers.http01.enabled.
 #
-# Webhook contract — the dns01 issuer below references
-# acme.dynadot.openova.io/v1alpha1 / solver "dynadot", which match the
-# binary's GROUP_NAME default and Solver.Name() return. See
-# core/cmd/cert-manager-dynadot-webhook/main.go and
-# platform/cert-manager-dynadot-webhook/chart/values.yaml.
-#
-# Operator runbook (rollback):
-#   1. Set certManager.issuers.dns01.enabled=false in the umbrella values
-#      to revert to http01 — existing certs remain valid until renewal.
-#   2. Optionally `flux suspend` the bp-cert-manager-dynadot-webhook
-#      HelmRelease to free cert-manager namespace resources.
+# The issuer NAMES are UNCHANGED from when they lived in bp-cert-manager —
+# ClusterIssuer is cluster-scoped, so every dependent Blueprint that
+# references these names keeps working without any change.
 #
 # Reference: https://cert-manager.io/docs/configuration/acme/dns01/
 
@@ -63,23 +61,12 @@
 {{- if $dns01.enabled }}
 # ─── TARGET STATE: DNS-01 via Catalyst Dynadot webhook ────────────────────
 # Activated when the cert-manager-dynadot-webhook is deployed alongside
-# this chart. Issues wildcard certificates for the canonical Sovereign
+# cert-manager. Issues wildcard certificates for the canonical Sovereign
 # record set (*.<sub>.<domain>).
-#
-# Helm post-install/post-upgrade hook: ClusterIssuer is a cert-manager.io/v1
-# CRD that only exists AFTER the cert-manager controllers + CRDs (installed
-# by the upstream subchart) are running. Without the hook, Helm renders
-# both the upstream chart AND this template in the same install pass and
-# the apply fails with `no matches for kind "ClusterIssuer"`. The hook
-# weight orders the two issuers below the upstream chart's CRD job.
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-dns01-prod
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "5"
-    "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     catalyst.openova.io/component: cert-manager
     catalyst.openova.io/issuer-class: dns01
@@ -122,19 +109,11 @@ spec:
 # ─── INTERIM: HTTP-01 (no wildcard support) ───────────────────────────────
 # Works today; serves explicit hostnames (console, gitea, harbor, admin,
 # api). Cannot issue wildcard certs — the Gateway listener must enumerate
-# every subdomain until the DNS-01 webhook is built. See the runbook in
-# the file header for the cutover procedure.
+# every subdomain until the DNS-01 webhook is built.
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-http01-prod
-  annotations:
-    # Same post-install hook as the DNS-01 issuer above — see the comment
-    # block on letsencrypt-dns01-prod for the rationale (CRD must be
-    # installed by the upstream subchart before this resource applies).
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "5"
-    "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     catalyst.openova.io/component: cert-manager
     catalyst.openova.io/issuer-class: http01

--- a/platform/cert-manager-issuers/chart/templates/crd-gate-hook.yaml
+++ b/platform/cert-manager-issuers/chart/templates/crd-gate-hook.yaml
@@ -1,0 +1,145 @@
+{{- /*
+ClusterIssuer CRD-establishment gate — bp-cert-manager-issuers (issue #3734).
+
+Background — the race we close
+==============================
+This chart ships the two ClusterIssuer CRs (letsencrypt-dns01-prod,
+letsencrypt-http01-prod) as PLAIN main-pass manifests (templates/
+clusterissuers.yaml). Those CRs are instances of the cert-manager.io/v1
+ClusterIssuer CRD that bp-cert-manager (a SEPARATE HelmRelease) registers.
+
+The split itself is the primary fix: this chart's Flux HR `dependsOn:
+bp-cert-manager`, so Flux only starts reconciling it AFTER cert-manager is
+Ready (CRD registered), and the FRESH helm-controller reconcile for this
+release builds a RESTMapper that already includes the ClusterIssuer kind.
+That eliminates the RESTMapper-cache miss that looped bp-cert-manager.
+
+This PRE-install Job is belt-and-suspenders for the residual
+apiserver-async lag: `kubectl apply` of the CRD object (in the
+bp-cert-manager release) returns when the resource is CREATED, not when the
+apiextensions-apiserver controller has set
+`status.conditions[?(@.type=="Established")].status == "True"`. That
+transition is asynchronous (typically <1s on a warm apiserver, observed up
+to ~30s on a fresh cold-start k3s). Gating on it here guarantees the main-
+pass ClusterIssuer manifests below never race a not-yet-Established CRD.
+
+Why PRE-install (NOT post-install)
+==================================
+Unlike bp-cert-manager — whose gate MUST be post-install because the CRDs
+it waits for come from the upstream subchart's OWN main apply pass (a
+pre-install hook would fire before that pass and never see them) — this
+chart does NOT install the ClusterIssuer CRD itself. The CRD is provided by
+the bp-cert-manager release, which is already Ready (Flux dependsOn). So the
+correct ordering is: PRE-install gate runs → asserts Established=True → then
+this release's main-pass ClusterIssuer manifests apply.
+
+Fails fast (300s budget) so a genuinely broken upstream surfaces in Flux
+conditions rather than in a 15-minute spin.
+
+Why hook-weight -10
+===================
+Lower weight than the RBAC hook (-20) in templates/crd-gate-rbac.yaml so
+the ServiceAccount + ClusterRole + Binding land BEFORE this Job needs them.
+
+Pairs with:
+  - templates/crd-gate-rbac.yaml — SA + ClusterRole + Binding
+  - values.yaml `crdGate:` — knobs (enabled, crds, timeout, image, resources)
+*/}}
+{{- $gate := .Values.crdGate | default dict -}}
+{{- $enabled := true -}}
+{{- if hasKey $gate "enabled" -}}
+{{-   $enabled = $gate.enabled -}}
+{{- end -}}
+{{- if $enabled }}
+{{- $crds := $gate.crds | default (list "clusterissuers.cert-manager.io") -}}
+{{- $timeout := $gate.timeoutSeconds | default 300 -}}
+{{- $interval := $gate.intervalSeconds | default 2 -}}
+{{- $image := $gate.image | default "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7" -}}
+{{- $pullPolicy := $gate.imagePullPolicy | default "IfNotPresent" -}}
+{{- $res := $gate.resources | default dict -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-crd-gate
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-cert-manager-issuers
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/component: crd-gate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-cert-manager-issuers
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        catalyst.openova.io/component: crd-gate
+    spec:
+      serviceAccountName: {{ .Release.Name }}-crd-gate
+      restartPolicy: Never
+      containers:
+        - name: gate
+          image: {{ $image | quote }}
+          imagePullPolicy: {{ $pullPolicy | quote }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
+          {{- with $res }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: CRDS
+              value: {{ join " " $crds | quote }}
+            - name: TIMEOUT_SECONDS
+              value: {{ $timeout | quote }}
+            - name: INTERVAL_SECONDS
+              value: {{ $interval | quote }}
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -euo pipefail
+              echo "cert-manager-issuers CRD gate: wait for Established=True on: ${CRDS} (budget=${TIMEOUT_SECONDS}s, interval=${INTERVAL_SECONDS}s)"
+              deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+              attempt=0
+              while [ "$(date +%s)" -lt "${deadline}" ]; do
+                attempt=$(( attempt + 1 ))
+                all_ok=true
+                missing=""
+                for crd in ${CRDS}; do
+                  status="$(kubectl get crd "${crd}" \
+                    --ignore-not-found \
+                    -o jsonpath='{.status.conditions[?(@.type=="Established")].status}' 2>/dev/null || true)"
+                  if [ "${status}" != "True" ]; then
+                    all_ok=false
+                    missing="${missing} ${crd}(=${status:-absent})"
+                  fi
+                done
+                if [ "${all_ok}" = "true" ]; then
+                  echo "All CRDs Established after ${attempt} attempt(s)."
+                  exit 0
+                fi
+                echo "Attempt ${attempt}: CRDs not yet Established:${missing}; sleeping ${INTERVAL_SECONDS}s."
+                sleep "${INTERVAL_SECONDS}"
+              done
+              echo "FATAL: ClusterIssuer CRD did not reach Established=True within ${TIMEOUT_SECONDS}s." >&2
+              echo "Still missing/not-Established:${missing}" >&2
+              echo "This release dependsOn bp-cert-manager; if the CRD is absent, bp-cert-manager is not Ready." >&2
+              echo "Diagnose with:" >&2
+              echo "  kubectl get crd | grep cert-manager.io" >&2
+              echo "  flux get helmrelease bp-cert-manager -n flux-system" >&2
+              echo "  kubectl describe crd clusterissuers.cert-manager.io" >&2
+              exit 1
+{{- end }}

--- a/platform/cert-manager-issuers/chart/templates/crd-gate-rbac.yaml
+++ b/platform/cert-manager-issuers/chart/templates/crd-gate-rbac.yaml
@@ -1,0 +1,84 @@
+{{- /*
+RBAC for the bp-cert-manager-issuers ClusterIssuer CRD-establishment gate
+(issue #3734).
+
+Per docs/INVIOLABLE-PRINCIPLES.md #3 (least-privilege): the gate Job ONLY
+needs `get` + `list` on CustomResourceDefinitions. Cluster-scoped because
+CRDs are cluster-scoped — a namespaced Role cannot grant access to
+apiextensions.k8s.io/v1 CRDs.
+
+Hook timing — pre-install (NOT post-install)
+============================================
+The ClusterIssuer CRD this chart's gate waits for is registered by the
+SEPARATE bp-cert-manager release (this chart's Flux HR dependsOn it, so it
+is already Ready). Therefore the gate runs PRE-install — before this
+release's main-pass ClusterIssuer manifests apply — to assert the CRD has
+reached Established=True. (Contrast bp-cert-manager's own gate, which must
+be post-install because the CRDs it waits for come from the upstream
+subchart's OWN main apply pass.)
+
+Hook ordering inside the pre-install phase:
+  weight -20 → SA + ClusterRole + ClusterRoleBinding (this file)
+  weight -10 → CRD-gate Job (templates/crd-gate-hook.yaml)
+  (then)     → main-pass ClusterIssuer manifests (templates/clusterissuers.yaml)
+
+Pairs with templates/crd-gate-hook.yaml.
+*/}}
+{{- $gate := .Values.crdGate | default dict -}}
+{{- $enabled := true -}}
+{{- if hasKey $gate "enabled" -}}
+{{-   $enabled = $gate.enabled -}}
+{{- end -}}
+{{- if $enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-crd-gate
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-cert-manager-issuers
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/component: crd-gate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-crd-gate
+  labels:
+    app.kubernetes.io/name: bp-cert-manager-issuers
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/component: crd-gate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    verbs: [get, list]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-crd-gate
+  labels:
+    app.kubernetes.io/name: bp-cert-manager-issuers
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/component: crd-gate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-crd-gate
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-crd-gate
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/platform/cert-manager-issuers/chart/tests/clusterissuer-toggle.sh
+++ b/platform/cert-manager-issuers/chart/tests/clusterissuer-toggle.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# bp-cert-manager-issuers ClusterIssuer toggle integration test (#3734).
+#
+# Sister test to platform/external-secrets-stores/chart/tests/
+# clustersecretstore-toggle.sh. Verifies the chart split shipped for #3734:
+#   - default render produces the letsencrypt-http01-prod ClusterIssuer CR
+#     (http01 default-enabled) but NOT letsencrypt-dns01-prod (dns01
+#     default-disabled)
+#   - dns01.enabled=true adds the letsencrypt-dns01-prod ClusterIssuer
+#   - http01.enabled=false suppresses letsencrypt-http01-prod
+#   - the issuers render as PLAIN manifests, NOT Helm hooks (the whole point
+#     of the split — the in-release post-install hook is what tripped the
+#     helm-controller RESTMapper-cache race in bp-cert-manager)
+#   - the pre-install crd-gate is present (belt-and-suspenders Established gate)
+#   - acmeServer override propagates
+#
+# Mirrors the bp-external-secrets-stores / bp-crossplane-claims pattern.
+#
+# Usage: bash tests/clusterissuer-toggle.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+echo "[issuer-toggle] Case 1: default render includes http01 issuer, NOT dns01"
+helm template smoke-cm-issuers . > "$TMP/default.yaml"
+if ! grep -qE "^  name: letsencrypt-http01-prod$" "$TMP/default.yaml"; then
+  echo "FAIL: default render is missing the letsencrypt-http01-prod ClusterIssuer (http01 defaults enabled)." >&2
+  exit 1
+fi
+if grep -qE "^  name: letsencrypt-dns01-prod$" "$TMP/default.yaml"; then
+  echo "FAIL: default render contains letsencrypt-dns01-prod, but dns01 defaults DISABLED." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[issuer-toggle] Case 2: issuers render as PLAIN manifests (no Helm hooks)"
+# The ClusterIssuer documents must NOT carry helm.sh/hook annotations — the
+# in-release post-install hook is the exact machinery that tripped the
+# RESTMapper-cache race in bp-cert-manager (#3734). The crd-gate Job/RBAC
+# legitimately carry hooks; those are NOT ClusterIssuers. So we split the
+# render on the `---` document separator and, for each document whose `kind:`
+# is ClusterIssuer, assert it carries no helm.sh/hook annotation. (Render the
+# dns01 issuer too so BOTH issuers are covered by this gate.)
+helm template smoke-cm-issuers . \
+  --set "certManager.issuers.dns01.enabled=true" > "$TMP/both.yaml"
+csplit -z -s -f "$TMP/doc-" -b '%03d.yaml' "$TMP/both.yaml" '/^---$/' '{*}' 2>/dev/null || true
+hooked_issuer=0
+for d in "$TMP"/doc-*.yaml; do
+  [ -f "$d" ] || continue
+  if grep -qE "^kind: ClusterIssuer$" "$d" && grep -qE "helm.sh/hook" "$d"; then
+    echo "FAIL: a ClusterIssuer document carries a helm.sh/hook annotation — the split must ship them as plain manifests:" >&2
+    echo "      $d" >&2
+    hooked_issuer=1
+  fi
+done
+if [ "$hooked_issuer" -ne 0 ]; then
+  exit 1
+fi
+echo "  PASS"
+
+echo "[issuer-toggle] Case 3: pre-install crd-gate present (belt-and-suspenders)"
+if ! grep -q "cert-manager-issuers CRD gate" "$TMP/default.yaml"; then
+  echo "FAIL: default render is missing the crd-gate Job (Established=True gate)." >&2
+  exit 1
+fi
+if ! grep -qE '"helm.sh/hook": pre-install,pre-upgrade' "$TMP/default.yaml"; then
+  echo "FAIL: crd-gate is not a pre-install hook (the CRD is provided by the already-Ready bp-cert-manager release, so the gate must be pre-install)." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[issuer-toggle] Case 4: dns01.enabled=true adds letsencrypt-dns01-prod"
+if ! helm template smoke-cm-issuers . \
+    --set "certManager.issuers.dns01.enabled=true" \
+    > "$TMP/dns01.yaml" 2> "$TMP/dns01.err"; then
+  echo "FAIL: dns01.enabled=true render failed:" >&2
+  cat "$TMP/dns01.err" >&2
+  exit 1
+fi
+if ! grep -qE "^  name: letsencrypt-dns01-prod$" "$TMP/dns01.yaml"; then
+  echo "FAIL: dns01.enabled=true did NOT render the letsencrypt-dns01-prod ClusterIssuer." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[issuer-toggle] Case 5: http01.enabled=false omits letsencrypt-http01-prod"
+if ! helm template smoke-cm-issuers . \
+    --set "certManager.issuers.http01.enabled=false" \
+    > "$TMP/http01-off.yaml" 2> "$TMP/http01-off.err"; then
+  echo "FAIL: http01.enabled=false render failed:" >&2
+  cat "$TMP/http01-off.err" >&2
+  exit 1
+fi
+if grep -qE "^  name: letsencrypt-http01-prod$" "$TMP/http01-off.yaml"; then
+  echo "FAIL: http01.enabled=false still renders letsencrypt-http01-prod — toggle broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[issuer-toggle] Case 6: acmeServer override propagates"
+if ! helm template smoke-cm-issuers . \
+    --set "certManager.issuers.acmeServer=https://acme-staging-v02.api.letsencrypt.org/directory" \
+    > "$TMP/srv.yaml" 2> "$TMP/srv.err"; then
+  echo "FAIL: acmeServer override render failed:" >&2
+  cat "$TMP/srv.err" >&2
+  exit 1
+fi
+if ! grep -q 'server: "https://acme-staging-v02.api.letsencrypt.org/directory"' "$TMP/srv.yaml"; then
+  echo "FAIL: acmeServer override did not propagate into rendered ClusterIssuer." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[issuer-toggle] All bp-cert-manager-issuers toggle gates green."

--- a/platform/cert-manager-issuers/chart/values.yaml
+++ b/platform/cert-manager-issuers/chart/values.yaml
@@ -1,0 +1,118 @@
+# Catalyst-curated values overlay for bp-cert-manager-issuers.
+#
+# This chart owns the Let's Encrypt ClusterIssuer CR(s) that the
+# bp-cert-manager umbrella chart can no longer ship in-line (the
+# helm-controller RESTMapper-cache CRD-ordering race; see Chart.yaml).
+# ALL knobs that previously lived under `certManager.issuers:` in
+# platform/cert-manager/chart/values.yaml move here UNCHANGED — cluster
+# overlays in clusters/<sovereign>/ that previously overrode
+# `certManager.issuers.*` continue to work via the SAME key path, they
+# just target this chart's HelmRelease now (slot 02a).
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) every operationally
+# meaningful value flows from this file; cluster overlays may set
+# `certManager.issuers.*` without rebuilding the Blueprint OCI artifact.
+
+# ─── Catalyst-managed ClusterIssuers (templates/clusterissuers.yaml) ──────
+# The chart ships TWO ClusterIssuers and lets the operator pick the active
+# one via these values:
+#
+#   - letsencrypt-dns01-prod  (DEPRECATED: was dynadot-webhook-backed.
+#                              DEFAULT DISABLED. The DNS-01 wildcard issuer
+#                              for Sovereigns is now `letsencrypt-dns01-prod-
+#                              powerdns`, shipped by bp-cert-manager-powerdns-
+#                              webhook against contabo's central PowerDNS —
+#                              Dynadot is NOT the API-level authority for
+#                              omani.works subdomains. Cluster overlays MAY
+#                              flip this back on if they ship their own
+#                              dynadot-webhook for a non-omani.works pool.)
+#   - letsencrypt-http01-prod (INTERIM, DEFAULT ENABLED: explicit hostnames
+#                              only, no wildcards, works today via Cilium
+#                              ingress.)
+#
+# NOTE — issuer NAMES + namespace are UNCHANGED from when these CRs lived in
+# bp-cert-manager. ClusterIssuer is cluster-scoped, so every dependent
+# Blueprint (cilium-gateway, harbor, gitea, …) that references
+# `letsencrypt-dns01-prod` / `letsencrypt-http01-prod` keeps working without
+# any change — only the Helm release that OWNS the CRs moved.
+certManager:
+  issuers:
+    # ACME account email used for renewal notifications. Per Sovereign
+    # convention this is ops@<pool-domain>.
+    email: ops@openova.io
+    # Production Let's Encrypt directory. Set to the staging URL during
+    # bring-up to avoid Let's Encrypt rate limits:
+    #   https://acme-staging-v02.api.letsencrypt.org/directory
+    acmeServer: https://acme-v02.api.letsencrypt.org/directory
+    dns01:
+      # DEFAULT DISABLED — the dynadot-webhook-backed letsencrypt-dns01-prod
+      # is deprecated for omani.works Sovereigns. The replacement issuer
+      # `letsencrypt-dns01-prod-powerdns` is shipped by
+      # bp-cert-manager-powerdns-webhook (bootstrap-kit slot 49) and writes
+      # ACME challenge TXT records to contabo's central PowerDNS at
+      # https://pdns.openova.io. Cluster overlays MAY flip this back to
+      # true if they ship a custom dynadot-webhook for a non-omani.works
+      # pool where Dynadot IS the API-level authority.
+      enabled: false
+      webhookGroupName: acme.dynadot.openova.io
+      webhookSolverName: dynadot
+    http01:
+      enabled: true
+      ingressClassName: cilium
+
+# ─── CRD-establishment gate (templates/crd-gate-{hook,rbac}.yaml) ─────────
+# Belt-and-suspenders. The split itself (separate HelmRelease + fresh
+# helm-controller reconcile gated on cert-manager Ready) is what closes the
+# RESTMapper-cache race — by the time this chart reconciles, the
+# cert-manager.io ClusterIssuer CRD is registered. This PRE-INSTALL gate
+# additionally asserts the CRD has reached Established=True on the apiserver
+# (the async apiextensions-apiserver transition can lag the CRD-create by
+# <1s warm, up to ~30s on a fresh cold-start k3s) BEFORE the plain
+# ClusterIssuer manifests in this chart apply. Unlike bp-cert-manager's
+# gate (which must be POST-install because the CRDs come from the upstream
+# subchart's MAIN apply pass), this chart's CRD is provided by a DIFFERENT
+# release that is already Ready, so a PRE-install gate is the correct shape:
+# the gate runs before the main-pass ClusterIssuer manifests.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (no hardcoded band-aids, target-state
+# every time): closes the residual async-Established race rather than
+# papering with a longer Flux retry loop.
+crdGate:
+  enabled: true
+  # CRDs the gate waits for. Only the ClusterIssuer CRD is instantiated by
+  # THIS chart, so that is all the gate needs to assert Established here
+  # (bp-cert-manager's own gate already covered Issuer + Certificate for
+  # downstream consumers). Cluster overlays MAY append CRDs.
+  crds:
+    - clusterissuers.cert-manager.io
+  # Total wait budget. 300s gives ~10x headroom over the worst-case
+  # observed Established latency (~30s on a fresh Hetzner cold-start) while
+  # still failing fast on a genuinely broken upstream. Same sizing rationale
+  # as bp-cert-manager crdGate.timeoutSeconds.
+  timeoutSeconds: 300
+  # Poll interval. 2s matches bp-cert-manager / bp-external-secrets-stores;
+  # <1s would spam the apiserver, >5s would over-pad the success path.
+  intervalSeconds: 2
+  # kubectl image. Explicit Harbor proxy-cache prefix per CLAUDE.md
+  # MIRROR-EVERYTHING inviolable rule (Fix #163 lineage): node-level
+  # containerd mirror already rewrites docker.io → harbor.openova.io/
+  # proxy-dockerhub, but explicit references defeat upstream-deletion blast
+  # radius (cf. bitnami/kubectl 2025-08 secure-images purge) AND satisfy the
+  # Kyverno harbor-proxy-pull ClusterPolicy. bitnamilegacy is Bitnami's
+  # deprecation-fallback path with bash/sh preserved (rancher/kubectl is
+  # distroless and would break the hook's bash-c shell script). 1.30.7 is
+  # the newest 1.30.x in bitnamilegacy.
+  image: harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7
+  imagePullPolicy: IfNotPresent
+  # CPU/memory requests + limits on the gate Job container so the
+  # bp-kyverno-policies 05-resource-requests + 06-resource-limits
+  # ClusterPolicies admit the pre-install hook on HCS Sovereigns. Sized for
+  # a ~15s kubectl-poll loop, no idle headroom needed (mirrors
+  # bp-external-secrets-stores webhook-gate sizing, G26 Refs #2581).
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi

--- a/platform/cert-manager/blueprint.yaml
+++ b/platform/cert-manager/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.2.5
+  version: 1.2.6
   card:
     title: cert-manager
     summary: TLS certificate automation. Lets Encrypt issuer with Dynadot DNS-01 for omani.works pool, HTTP-01 for BYO domains.
@@ -19,9 +19,17 @@ spec:
   # consume `issuerName` rather than hardcoding "letsencrypt-prod" so that
   # operators can swap the active issuer (DNS-01 vs HTTP-01) via the
   # bp-catalyst-platform umbrella values without editing every dependent
-  # chart. The chart's templates/clusterissuer-letsencrypt-dns01.yaml ships
-  # both issuers; this output names the one a dependent Blueprint should
-  # default to in production.
+  # chart.
+  #
+  # Issuer-CR ownership (#3734): as of 1.2.6 the two ClusterIssuers
+  # (letsencrypt-dns01-prod, letsencrypt-http01-prod) are PHYSICALLY shipped
+  # by the standalone bp-cert-manager-issuers chart (slot 02a, dependsOn
+  # bp-cert-manager) — split out to dodge the helm-controller RESTMapper-
+  # cache CRD-ordering race. bp-cert-manager remains the LOGICAL owner of
+  # the issuer-name contract (it owns the cert-manager.io CRDs + controllers),
+  # so these outputs stay here; the names + ClusterIssuer kind + cluster
+  # scope are unchanged, so every dependent that consumes `issuerName` keeps
+  # resolving the same CR regardless of which release applies it.
   outputs:
     # Default issuer name. As of openova#159 (bp-cert-manager-dynadot-webhook
     # ships) the wildcard-capable DNS-01 issuer is enabled by default in

--- a/platform/cert-manager/chart/Chart.yaml
+++ b/platform/cert-manager/chart/Chart.yaml
@@ -14,15 +14,33 @@ name: bp-cert-manager
 # Per CLAUDE.md inviolable rule, ALL chart-hook references MUST be
 # explicit Harbor proxy-cache form — not just rely on the node-level
 # containerd mirror in registries.yaml.
-version: 1.2.5
+#
+# 1.2.6 (issue #3734, 2026-06-17): REMOVE the two Catalyst ClusterIssuers
+# (letsencrypt-dns01-prod, letsencrypt-http01-prod) from this chart — they
+# now ship in the standalone bp-cert-manager-issuers chart (bootstrap-kit
+# slot 02a, dependsOn bp-cert-manager). The in-release post-install
+# ClusterIssuer hook tripped the helm-controller RESTMapper-cache race
+# (the cached mapper, built before the ClusterIssuer CRD existed, never
+# refreshed → `no matches for kind "ClusterIssuer"` on BOTH the
+# before-hook-creation delete AND the create → InstallFailed → uninstall →
+# reinstall loop, verified live hw157). The crd-gate closed the apiserver-
+# Established race but NOT the client RESTMapper-cache race. A SEPARATE
+# HelmRelease gets a fresh reconcile (after this chart is Ready) whose
+# RESTMapper includes the registered CRD. The crd-gate Job/RBAC REMAIN here
+# — they still gate the Issuer + Certificate CRDs Established=True for
+# downstream Blueprints that apply Certificate CRs immediately. Mirrors the
+# bp-external-secrets ↔ bp-external-secrets-stores and bp-crossplane ↔
+# bp-crossplane-claims CRD-ordering splits.
+version: 1.2.6
 description: |
   Catalyst-curated Blueprint umbrella chart for cert-manager. Depends on the
   upstream `cert-manager` chart (Jetstack) as a Helm subchart so
   `helm dependency build` pulls the upstream payload into this artifact;
-  the Catalyst overlay templates in templates/ (ClusterIssuers, NetworkPolicy,
-  ExternalSecret, ServiceMonitor) sit alongside the upstream subchart and
-  Helm renders both at install time. Catalyst-curated values flow into the
-  upstream subchart under the `cert-manager:` key in values.yaml.
+  the Catalyst overlay templates in templates/ (NetworkPolicy, ServiceMonitor,
+  CRD-establishment gate) sit alongside the upstream subchart and Helm renders
+  both at install time. Catalyst-curated values flow into the upstream subchart
+  under the `cert-manager:` key in values.yaml. The Let's Encrypt ClusterIssuers
+  moved to bp-cert-manager-issuers (slot 02a) at 1.2.6 — see #3734.
 type: application
 keywords: [catalyst, blueprint, cert-manager]
 maintainers:

--- a/platform/cert-manager/chart/values.yaml
+++ b/platform/cert-manager/chart/values.yaml
@@ -91,26 +91,17 @@ cert-manager:
         cpu: 50m
         memory: 64Mi
 
-# ─── Catalyst-managed ClusterIssuers (templates/clusterissuer-letsencrypt-dns01.yaml) ──
-# The Catalyst-curated wrapper ships TWO ClusterIssuers and lets the
-# operator pick the active one via these values:
-#
-#   - letsencrypt-dns01-prod  (DEPRECATED: was dynadot-webhook-backed.
-#                              DEFAULT DISABLED. The DNS-01 wildcard issuer
-#                              for Sovereigns is now `letsencrypt-dns01-prod-
-#                              powerdns`, shipped by bp-cert-manager-powerdns-
-#                              webhook against contabo's central PowerDNS —
-#                              Dynadot is NOT the API-level authority for
-#                              omani.works subdomains. Cluster overlays MAY
-#                              flip this back on if they ship their own
-#                              dynadot-webhook for a non-omani.works pool.)
-#   - letsencrypt-http01-prod (INTERIM: explicit hostnames only, no
-#                              wildcards, works today via Cilium ingress)
-#
-# Per docs/INVIOLABLE-PRINCIPLES.md #4 ("never hardcode") all knobs are
-# runtime-configurable; cluster overlays in clusters/<sovereign>/ may set
-# certManager.issuers.* to flip between issuers without rebuilding the
-# Blueprint OCI artifact.
+# ─── Catalyst-managed ClusterIssuers — MOVED to bp-cert-manager-issuers ──
+# (#3734) The two Catalyst ClusterIssuers (letsencrypt-dns01-prod,
+# letsencrypt-http01-prod) no longer ship in this chart. They now live in
+# the standalone bp-cert-manager-issuers chart (bootstrap-kit slot 02a,
+# dependsOn bp-cert-manager) — split out to dodge the helm-controller
+# RESTMapper-cache CRD-ordering race that looped this HR on InstallFailed.
+# The `certManager.issuers.*` knobs (email / acmeServer / dns01 / http01)
+# moved there UNCHANGED: cluster overlays that previously set
+# `certManager.issuers.*` on the bp-cert-manager HR now set the SAME key
+# path on the bp-cert-manager-issuers HR (slot 02a). See
+# platform/cert-manager-issuers/chart/values.yaml.
 # ─── CRD-establishment gate (templates/crd-gate-{hook,rbac}.yaml) ────────
 # Closes #149 — bp-cert-manager terminal failure on prov #24
 # (`c776423270f4ae30`): the post-install ClusterIssuer hook (weight 5)
@@ -123,20 +114,27 @@ cert-manager:
 # fresh Hetzner cold-start k3s.
 #
 # This Job (post-install,post-upgrade hook-weight -10) polls every CRD
-# in `crds` for Established=True before the ClusterIssuer hook (weight
-# 5) fires. Per docs/INVIOLABLE-PRINCIPLES.md #4 (no hardcoded band-
-# aids, target-state every time): closes the race rather than papering
-# with `helm.sh/hook-weight: 50` or a longer Flux retry loop.
+# in `crds` for Established=True. Per docs/INVIOLABLE-PRINCIPLES.md #4 (no
+# hardcoded band-aids, target-state every time): closes the race rather than
+# papering with `helm.sh/hook-weight: 50` or a longer Flux retry loop.
+#
+# #3734: the two ClusterIssuer CRs moved OUT of this chart into
+# bp-cert-manager-issuers (slot 02a). This gate is NO LONGER about this
+# chart's own issuers — it now exists purely so downstream Blueprints that
+# apply Issuer/Certificate CRs (and bp-cert-manager-issuers itself, via its
+# own pre-install gate) can rely on those CRDs being Established once
+# bp-cert-manager reports Ready. Kept because removing it would re-expose
+# the downstream Certificate-applier race the gate was extended to cover.
 crdGate:
   enabled: true
   # CRDs the gate waits for. Defaults cover the cert-manager.io types
-  # the Catalyst overlay templates instantiate (ClusterIssuer ships in
-  # this chart; Issuer + Certificate are consumed by dependent
-  # Blueprints — gating them here too means downstream HRs that
-  # immediately apply Certificate CRs don't have to ship their own
-  # gate). Cluster overlays MAY append CRDs here (e.g. when a custom
-  # webhook ships its own CRD that should also be Established before
-  # any dependent CR applies).
+  # dependent Blueprints instantiate: clusterissuers (applied by
+  # bp-cert-manager-issuers, slot 02a) + issuers + certificates (applied by
+  # gateway/harbor/gitea/etc.). Gating all three here means a downstream HR
+  # that immediately applies a Certificate CR after bp-cert-manager goes
+  # Ready doesn't have to ship its own gate. Cluster overlays MAY append
+  # CRDs here (e.g. when a custom webhook ships its own CRD that should also
+  # be Established before any dependent CR applies).
   crds:
     - clusterissuers.cert-manager.io
     - issuers.cert-manager.io
@@ -173,27 +171,9 @@ crdGate:
   image: harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7
   imagePullPolicy: IfNotPresent
 
-certManager:
-  issuers:
-    # ACME account email used for renewal notifications. Per Sovereign
-    # convention this is ops@<pool-domain>.
-    email: ops@openova.io
-    # Production Let's Encrypt directory. Set to the staging URL during
-    # bring-up to avoid Let's Encrypt rate limits:
-    #   https://acme-staging-v02.api.letsencrypt.org/directory
-    acmeServer: https://acme-v02.api.letsencrypt.org/directory
-    dns01:
-      # DEFAULT DISABLED — the dynadot-webhook-backed letsencrypt-dns01-prod
-      # is deprecated for omani.works Sovereigns. The replacement issuer
-      # `letsencrypt-dns01-prod-powerdns` is shipped by
-      # bp-cert-manager-powerdns-webhook (bootstrap-kit slot 49) and writes
-      # ACME challenge TXT records to contabo's central PowerDNS at
-      # https://pdns.openova.io. Cluster overlays MAY flip this back to
-      # true if they ship a custom dynadot-webhook for a non-omani.works
-      # pool where Dynadot IS the API-level authority.
-      enabled: false
-      webhookGroupName: acme.dynadot.openova.io
-      webhookSolverName: dynadot
-    http01:
-      enabled: true
-      ingressClassName: cilium
+# NOTE (#3734): the `certManager.issuers.*` block that used to live here was
+# REMOVED when the two ClusterIssuers split out to bp-cert-manager-issuers
+# (slot 02a). Those knobs now live in
+# platform/cert-manager-issuers/chart/values.yaml under the SAME key path.
+# Cluster overlays that set `certManager.issuers.*` must target the
+# bp-cert-manager-issuers HelmRelease (slot 02a), not this one.

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -3752,12 +3752,12 @@ metadata:
     # must not claw it back (DoD §9.4).
     helm.sh/resource-policy: keep
 spec:
-  version: "1.2.5"
+  version: "1.2.6"
   visibility: unlisted
   card:
     title: "cert-manager"
     category: platform
-    summary: "X.509 certificate automation for Kubernetes — Let's Encrypt ACME issuance, renewal, and the wildcard ClusterIssuer every Sovereign HTTPRoute terminates against."
+    summary: "X.509 certificate automation for Kubernetes — Let's Encrypt ACME issuance, renewal, and the controllers + CRDs the Sovereign's ClusterIssuers (bp-cert-manager-issuers) bind against."
     icon: cert-manager.svg
   placementSchema:
     modes: [single-region]
@@ -3769,7 +3769,66 @@ spec:
     type: oci
     url: oci://ghcr.io/openova-io
     chart: bp-cert-manager
-    version: "1.2.5"
+    version: "1.2.6"
+  topology:
+    supported:
+      - singleton
+    defaults:
+      multi-region: singleton
+      single-region: singleton
+    perTopology:
+      singleton:
+        placement:
+          tier: ""
+          clusters: [mgmt-A, mgmt-B, dmz-A, dmz-B, rtz-A, rtz-B]
+          roles:
+            mgmt-A: singleton
+            mgmt-B: singleton
+            dmz-A: singleton
+            dmz-B: singleton
+            rtz-A: singleton
+            rtz-B: singleton
+  endpoints: []
+---
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-cert-manager-issuers
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: security
+    catalyst.openova.io/section: pts-1-control-plane
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+  annotations:
+    # #3668 — Helm→Flux ownership handoff. Keep this seeded CR if a later
+    # helm reconcile would prune it AFTER the catalog-sovereign Flux
+    # Kustomization (force:true SSA) has adopted the same-named CR from a
+    # console edit/curate. catalog-seed seeds the CR once (the t=0 fallback
+    # for un-curated Blueprints); Flux owns it post-edit and a helm upgrade
+    # must not claw it back (DoD §9.4).
+    helm.sh/resource-policy: keep
+spec:
+  version: "1.0.0"
+  visibility: unlisted
+  card:
+    title: "cert-manager — Issuers"
+    category: security
+    summary: "The Sovereign's Let's Encrypt ClusterIssuers (letsencrypt-dns01-prod, letsencrypt-http01-prod). Split from bp-cert-manager (#3734) into a separate HelmRelease (dependsOn bp-cert-manager) so a fresh helm-controller reconcile maps the ClusterIssuer kind after its CRD registers."
+    icon: cert-manager.svg
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: bp-cert-manager-issuers
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-cert-manager-issuers
+    version: "1.0.0"
   topology:
     supported:
       - singleton

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -51,6 +51,20 @@ slots:
     name: bp-cert-manager
     depends_on: [bp-cilium]
     wave: present
+  - slot: "02a"
+    name: bp-cert-manager-issuers
+    # The two Catalyst Let's Encrypt ClusterIssuers (letsencrypt-dns01-prod,
+    # letsencrypt-http01-prod). Split from bp-cert-manager (issue #3734) to
+    # resolve the helm-controller RESTMapper-cache CRD-ordering race — the
+    # ClusterIssuer CRs cannot live in the same Helm release as the
+    # cert-manager subchart that registers their CRD (the cached RESTMapper,
+    # built before the CRD exists, never refreshes → `no matches for kind
+    # "ClusterIssuer"` on the in-release hook → InstallFailed loop, live
+    # hw157). A separate HR gets a fresh reconcile after bp-cert-manager is
+    # Ready whose RESTMapper maps the kind. Mirrors bp-external-secrets ↔
+    # bp-external-secrets-stores and bp-crossplane ↔ bp-crossplane-claims.
+    depends_on: [bp-cert-manager]
+    wave: present
   - slot: 3
     name: bp-flux
     depends_on: [bp-cert-manager]


### PR DESCRIPTION
## Problem (verified live on hw157 fresh prov)

`bp-cert-manager@1.2.5` enters an `InstallFailed → uninstall → reinstall` **infinite loop**. The post-install hook `clusterissuer-letsencrypt-dns01.yaml` fails:

```
resource mapping not found for ... "ClusterIssuer" in "cert-manager.io/v1" ...
no matches for kind "ClusterIssuer"
```

**Root cause:** the two ClusterIssuers ship as in-release Helm post-install hooks (weight 5). The chart's `crd-gate` Job (weight −10) correctly waits for the ClusterIssuer CRD to reach `Established=True`, BUT helm-controller builds its in-process **RESTMapper cache at reconcile-start** — before the CRD exists — and does **not** refresh it before the issuer hooks' `before-hook-creation` delete (or the create) runs. The kind is unmapped → both delete-hook AND create fail → InstallFailed → Flux remediates (uninstall) → loop. The crd-gate closes the apiserver-Established race but **not** the client RESTMapper-cache race. This **gates ~40 downstream HelmReleases**.

## Fix — mirror the existing CRD-ordering splits

Move the two ClusterIssuers into a standalone **`bp-cert-manager-issuers`** chart + bootstrap-kit slot **`02a`** whose HR `dependsOn: bp-cert-manager`. A **separate HelmRelease gets a fresh helm-controller reconcile** (gated, via `dependsOn`, on cert-manager Ready) whose RESTMapper is built **after** the ClusterIssuer CRD is registered → the kind maps → CRs apply cleanly.

Exact shape already proven twice in-repo:
- `bp-external-secrets` (15) ↔ `bp-external-secrets-stores` (15a) — #331 / PR #334
- `bp-crossplane` (04) ↔ `bp-crossplane-claims` (14) — PR #247

The new chart ships the issuers as **plain manifests** (no Helm hooks — the hook machinery is exactly what tripped the RESTMapper path) plus a **belt-and-suspenders pre-install crd-gate** for residual apiserver-async Established lag.

### Key invariants preserved
- **Issuer names + ClusterIssuer kind + namespace are unchanged** (`letsencrypt-dns01-prod`, `letsencrypt-http01-prod`, ns `cert-manager`). ClusterIssuer is cluster-scoped → every dependent that consumes the issuer names keeps resolving the same CR; only the Helm release that *owns* them moved.
- `certManager.issuers.*` overlay knobs moved to the new chart **unchanged** — overlays now target the slot-02a HR via the same key path.
- bp-cert-manager's `crd-gate` Job/RBAC **stay** — they still gate `issuers.cert-manager.io` + `certificates.cert-manager.io` Established for downstream Certificate appliers.

## Lockstep (every site the two sibling splits touch)
| File | Change |
|---|---|
| `platform/cert-manager-issuers/` | NEW chart (Chart.yaml `no-upstream`, values, blueprint.yaml, clusterissuers.yaml, crd-gate hook+rbac, toggle test) |
| `clusters/.../bootstrap-kit/02a-bp-cert-manager-issuers.yaml` | NEW slot HR (`dependsOn: bp-cert-manager`, pin 1.0.0) |
| `.../bootstrap-kit/kustomization.yaml` | register `02a` (avoid #3191 dangling-slot wedge) |
| `scripts/expected-bootstrap-deps.yaml` | `02a → depends_on: [bp-cert-manager]`, `wave: present` |
| `.../bootstrap-kit/placement.yaml` | host/cert-manager placement row |
| `products/catalyst/.../catalog-seed/blueprints.yaml` | seed row (mirrors external-secrets-stores) |
| `platform/cert-manager/chart/` | remove issuers template; bump 1.2.5→1.2.6 (Chart+blueprint+slot pin) |

## Validation — all green locally
- `kubectl kustomize clusters/_template/bootstrap-kit` renders (issuers HR present)
- `scripts/check-bootstrap-deps.sh` — **0 drift, 0 cycles**, slot-registration OK
- `scripts/render-slot-placement.py check` — PASSED (64 slots)
- `scripts/check-bootstrap-kit-pin-sync.sh` — PASSED (incl. `bp-cert-manager-issuers 1.0.0`)
- `scripts/check-catalog-seed-lockstep.sh` — PASSED (0 fail)
- blueprint-admission topology validation — PASSED (both blueprints)
- e2e `TestBootstrapKit_BlueprintVersionLockstepSweep` + `TestBootstrapKit_TemplateClusterParses` — PASSED (new chart discovered)
- `helm template` of bp-cert-manager — **0 ClusterIssuers, 0 issuer-name refs**, crd-gate retained
- new chart toggle test (6/6) + cert-manager observability-toggle test — PASSED

Refs #3734

🤖 Generated with [Claude Code](https://claude.com/claude-code)