### PR TITLE
fix(bp-flux,bp-kyverno): proxy all controller images + close source-controller Recreate serving-gap; warm cnpg postgresql:16 on Huawei workers (Refs #3735)

### DIFF
--- a/clusters/_template/bootstrap-kit/03-flux.yaml
+++ b/clusters/_template/bootstrap-kit/03-flux.yaml
@@ -77,7 +77,11 @@ spec:
       # 1.2.4 captures stderr to a temp file and emits structured
       # `[A66]` log lines (detection / success / failure-with-stderr).
       # RBAC was already correct in 1.2.3.
-      version: 1.2.6
+      # 1.2.7 (#3735): all 6 Flux controller images + flux-cli proxied onto
+      # harbor.openova.io/proxy-ghcr/fluxcd/*; paired with the postRenderers
+      # RollingUpdate patch below that closes the source-controller Recreate
+      # serving-gap (Ready 26→7 regression on hw157).
+      version: 1.2.7
       sourceRef:
         kind: HelmRepository
         name: bp-flux
@@ -106,3 +110,48 @@ spec:
     # Match install behaviour — adopt rather than fail on conflict.
     remediation:
       retries: 3
+  # ── #3735 (2026-06-17): source-controller serving-gap fix ─────────────
+  # ROOT CAUSE (live on hw157, Ready 26→7 regression): the flux2 2.14.1 chart
+  # applies curated resource limits + leader-election args to source-controller
+  # (platform/flux/chart/values.yaml). Those differ from the bare cloud-init
+  # install.yaml spec, so the FIRST bp-flux reconcile rolls the Deployment. The
+  # chart HARDCODES `spec.strategy.type: Recreate` (template-level, no values
+  # knob) AND mounts /data as an emptyDir. Recreate kills the old
+  # source-controller pod BEFORE the new one is Ready → during the new pod's
+  # cold image-pull + cache rebuild there is NO source-controller serving
+  # artifacts → every HelmRelease + the bootstrap-kit Kustomization gets
+  # `dial tcp …:80: connection refused` / ArtifactFailed and all ~60 HelmCharts
+  # must re-fetch → full Ready 26→7 collapse.
+  #
+  # FIX: post-render-patch source-controller's strategy to RollingUpdate with
+  # maxUnavailable:0 (+ maxSurge:1). The OLD pod keeps serving artifacts until
+  # the NEW pod passes its /healthz readiness probe, THEN terminates — so there
+  # is NO serving gap on the (still one-time) roll. source-controller rebuilds
+  # its emptyDir cache lazily per GitRepository/HelmChart reconcile after the
+  # cutover, which consumers never observe as a hard `connection refused`.
+  #
+  # WHY a Flux postRenderer and not a `kubectl patch` in cloud-init: helm-
+  # controller owns the source-controller Deployment via the flux2 subchart and
+  # re-applies its rendered manifest (strategy:Recreate) on every reconcile,
+  # which would REVERT a raw kubectl patch and re-introduce the gap. A
+  # postRenderer kustomize patch runs INSIDE helm-controller's own render
+  # pipeline, so the patched RollingUpdate strategy IS what helm-controller
+  # applies — it can never be reverted. (The image proxying that pairs with this
+  # lives in the chart values; the roll-pull then hits Harbor's warm cache.)
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: source-controller
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: source-controller
+              spec:
+                strategy:
+                  type: RollingUpdate
+                  rollingUpdate:
+                    maxUnavailable: 0
+                    maxSurge: 1

--- a/clusters/_template/bootstrap-kit/27-kyverno.yaml
+++ b/clusters/_template/bootstrap-kit/27-kyverno.yaml
@@ -73,7 +73,12 @@ spec:
       # can always recreate its own agent (the de-CNI'd apiserver node can't
       # receive the webhook response otherwise → cnpg-pair initdb wedged on
       # hw135 → no region-b standby → region-kill impossible).
-      version: 1.3.7
+      # 1.3.8 (#3735): MIRROR-EVERYTHING — the 4 controller registries (were
+      # ghcr.io) + the previously-unoverridden kyvernopre INIT image (fell
+      # through to reg.kyverno.io, the slowest registry on the kom4dc VPC,
+      # ~13 min cold-pull on hw157) re-pointed to harbor.openova.io/proxy-ghcr/
+      # kyverno/* — proxied + satisfies the harbor-proxy-pull Enforce glob.
+      version: 1.3.8
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/infra/providers/huawei/cloudinit-worker.tftpl
+++ b/infra/providers/huawei/cloudinit-worker.tftpl
@@ -188,3 +188,42 @@ runcmd:
       sleep 5
     done
 
+  # ── #3735 (2026-06-17): BACKGROUND pre-pull of the CNPG postgresql:16 image ──
+  # The ~150 MB `harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16` cold-
+  # pulls in 7+ min through the bastion harbor-cache on this IPv4-only VPC. When
+  # several CNPG clusters (gitea / keycloak / harbor / powerdns / openova-flow,
+  # plus the cnpg-pair replicas) get co-scheduled onto a worker during the Phase-1
+  # cascade they each kick off the SAME cold pull → containerd de-dupes but the
+  # losing pulls hit `ErrImagePull: context canceled` and back off, stretching
+  # initdb well past the CNPG bootstrap timeout. Warming the image ONCE per worker
+  # at boot means by the time CNPG schedules an instance the layer is already in
+  # containerd → zero pull contention.
+  #
+  # IDEMPOTENT + NON-FATAL + DETACHED (mirrors the control-plane #3534 pre-pull):
+  # `crictl pull` is a no-op if present, every step is `|| true`, and the whole
+  # block is `nohup … &` so a slow/failed warm can NEVER affect bootstrap —
+  # kubelet still pulls on demand exactly as before. Waits for crictl + the harbor
+  # mirror to exist first (k3s ships crictl; the registries.yaml above wires the
+  # bastion :5000 harbor mirror + robot creds, so no inline --creds needed).
+  - |
+    nohup sh -c '
+      log=/var/lib/catalyst/prepull-cnpg.log
+      mkdir -p /var/lib/catalyst
+      echo "[prepull-cnpg] $(date -u +%FT%TZ) waiting for crictl + k3s-agent" >> "$log" 2>&1
+      CRICTL="$(command -v crictl || echo /var/lib/rancher/k3s/data/current/bin/crictl)"
+      for i in $(seq 1 120); do
+        if systemctl is-active k3s-agent >/dev/null 2>&1 && [ -x "$CRICTL" ]; then break; fi
+        # crictl may live under the k3s data dir once the agent unpacks.
+        CRICTL="$(command -v crictl || ls /var/lib/rancher/k3s/data/*/bin/crictl 2>/dev/null | head -1 || echo "")"
+        sleep 5
+      done
+      IMG="harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16"
+      echo "[prepull-cnpg] $(date -u +%FT%TZ) pulling $IMG via $CRICTL" >> "$log" 2>&1
+      if [ -n "$CRICTL" ] && [ -x "$CRICTL" ]; then
+        "$CRICTL" pull "$IMG" >> "$log" 2>&1 || echo "[prepull-cnpg] pull failed (non-fatal; kubelet will pull on demand)" >> "$log" 2>&1
+      else
+        echo "[prepull-cnpg] crictl not found; skipping (non-fatal)" >> "$log" 2>&1
+      fi
+      echo "[prepull-cnpg] $(date -u +%FT%TZ) done" >> "$log" 2>&1
+    ' >/dev/null 2>&1 &
+

--- a/platform/flux/blueprint.yaml
+++ b/platform/flux/blueprint.yaml
@@ -5,7 +5,10 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.6
+  # 1.2.7 (#3735): proxy all 6 Flux controller images + flux-cli onto Harbor
+  # proxy-ghcr/fluxcd; RollingUpdate(maxUnavailable:0) post-render patch on
+  # source-controller eliminates the Recreate serving-gap (Ready 26→7 on hw157).
+  version: 1.2.7
   card:
     title: flux
     summary: GitOps reconciler. One per vcluster (source + kustomize + helm controllers); host-level Flux per host cluster watches its bp-* OCI sources.

--- a/platform/flux/chart/Chart.yaml
+++ b/platform/flux/chart/Chart.yaml
@@ -41,7 +41,25 @@ name: bp-flux
 # verbs grant exists); the silent failure was diagnostic-blind, not
 # RBAC-blind. The Chart.yaml bump here exists so the bootstrap-kit
 # pin auto-sync hook propagates the new image into fresh provs.
-version: 1.2.6
+#
+# 1.2.7 (#3735, 2026-06-17): MIRROR-EVERYTHING + source-controller self-DoS fix.
+# (1) All 6 Flux controller images + the flux-cli pre-install-hook image were
+# pulled ghcr.io DIRECT (the flux2 2.14.1 chart has NO chart-wide registry knob
+# and uses FLAT `<controller>.image` scalars, so the inert `global.imageRegistry`
+# moved nothing). Re-pointed each scalar at harbor.openova.io/proxy-ghcr/fluxcd/*
+# — proxied + satisfies the kyverno `harbor-proxy-pull` Enforce glob `*/proxy-*/*`
+# on the source-controller roll. (2) The bp-flux reconcile rolls source-controller
+# (curated limits + leader-election args differ from the bare cloud-init install),
+# and the chart hardcodes `strategy: Recreate` + an emptyDir /data cache → the
+# Recreate roll killed the only artifact-serving pod mid-bootstrap → ~60 HRs
+# ArtifactFailed / `connection refused` → Ready 26→7 on hw157. The serving-gap is
+# eliminated by a RollingUpdate(maxUnavailable:0) post-render patch on the bp-flux
+# HelmRelease (clusters/_template/bootstrap-kit/03-flux.yaml) — the only override
+# point helm-controller cannot revert. Image fix class matches bp-cnpg (#3257) +
+# bp-external-secrets (#3533). NOTE: the flux2 SUBCHART pin (2.14.1) + cloud-init's
+# v2.4.0 install.yaml are UNCHANGED — the catastrophic version-pin invariant
+# (tests/version-pin-replay.sh) is untouched.
+version: 1.2.7
 description: |
   Catalyst-curated Blueprint umbrella chart for Flux. Depends on the
   upstream `flux2` chart (fluxcd-community) as a Helm subchart so

--- a/platform/flux/chart/values.yaml
+++ b/platform/flux/chart/values.yaml
@@ -9,12 +9,15 @@
 #      the values namespace).
 
 global:
-  # When set, ALL image pulls in this chart route through this registry.
-  # Used post-handover when the Sovereign's own Harbor takes over the
-  # proxy_cache role from contabo's central Harbor. Empty = no rewrite
-  # (image references use upstream defaults). The upstream flux2 chart
-  # exposes per-controller `flux2.<controller>.image.repository` knobs.
-  # Per-Sovereign overlays wire those alongside this value. Tracked under #560.
+  # ⚠️ #3735 (2026-06-17): this `global.imageRegistry` key is INERT for the
+  # upstream flux2 2.14.1 chart — that chart has NO `imageRegistry` knob and NO
+  # top-level `global:` block, and (unlike most charts) it does NOT use a nested
+  # `<controller>.image.{registry,repository,tag}` structure. Each controller's
+  # image is a FLAT scalar: `<controller>.image: <full-registry/repo/path>` with
+  # a sibling `<controller>.tag`. So a chart-wide registry value moves NOTHING.
+  # Kept here only for cross-chart umbrella-overlay symmetry (#560). The pulls
+  # are actually re-pointed per-controller under the `flux2:` key below (each
+  # `<controller>.image` scalar set to the Harbor proxy-ghcr/fluxcd cache).
   imageRegistry: ""
 
 catalystBlueprint:
@@ -121,6 +124,26 @@ flux2:
   policies:
     create: false
   sourceController:
+    # #3735 (2026-06-17): proxy the source-controller image off ghcr.io onto the
+    # Harbor proxy-ghcr/fluxcd cache. The flux2 2.14.1 chart's image is a FLAT
+    # scalar (`image: <full-path>`) + sibling `tag:` — NOT a nested image block.
+    # WHY this matters even though the node containerd ghcr.io→proxy-ghcr mirror
+    # already rewrites the pull: when bp-flux rolls source-controller (it applies
+    # the curated resources + leader-election args below, which differ from the
+    # bare cloud-init install.yaml spec → a one-time Recreate roll on first
+    # reconcile), the new pod's image STRING must satisfy the kyverno
+    # `harbor-proxy-pull` Enforce glob `*/proxy-*/*` on converged-env rolls, and
+    # the proxied string makes the roll-pull hit Harbor's warm cache directly. The
+    # SERVING-GAP half of this blocker (Recreate kills the old pod before the new
+    # one is Ready → ~60 HRs ArtifactFail / `connection refused` → Ready 26→7 on
+    # hw157) is fixed by the postRenderers RollingUpdate patch on the bp-flux
+    # HelmRelease (clusters/_template/bootstrap-kit/03-flux.yaml) — the flux2
+    # chart hardcodes `strategy: Recreate` + an emptyDir /data cache with no
+    # values knob, so the strategy override has to live as a Flux post-render
+    # kustomize patch (which runs INSIDE helm-controller's render → it can't be
+    # reverted by a subsequent reconcile, unlike a raw `kubectl patch`).
+    image: harbor.openova.io/proxy-ghcr/fluxcd/source-controller
+    tag: v1.4.1
     resources:
       requests: { cpu: 50m, memory: 64Mi }
       limits: { memory: 384Mi }
@@ -130,6 +153,9 @@ flux2:
         - --leader-election-renew-deadline=40s
         - --leader-election-retry-period=5s
   kustomizeController:
+    # #3735: proxy off ghcr.io — see sourceController.image comment.
+    image: harbor.openova.io/proxy-ghcr/fluxcd/kustomize-controller
+    tag: v1.4.0
     resources:
       requests: { cpu: 50m, memory: 64Mi }
       limits: { memory: 384Mi }
@@ -139,6 +165,9 @@ flux2:
         - --leader-election-renew-deadline=40s
         - --leader-election-retry-period=5s
   helmController:
+    # #3735: proxy off ghcr.io — see sourceController.image comment.
+    image: harbor.openova.io/proxy-ghcr/fluxcd/helm-controller
+    tag: v1.1.0
     resources:
       requests: { cpu: 50m, memory: 64Mi }
       limits: { memory: 512Mi }
@@ -147,6 +176,29 @@ flux2:
         - --leader-election-lease-duration=60s
         - --leader-election-renew-deadline=40s
         - --leader-election-retry-period=5s
+  # #3735: notification-controller is rendered by the flux2 chart by default
+  # (version-pin-replay Case 5 asserts its Deployment present). Proxy its image
+  # too so every Catalyst-installed Flux controller pulls from Harbor. Catalyst
+  # doesn't tune its resources/args (the 3 critical controllers above carry the
+  # leader-election stretch), so this block only repoints the image scalar.
+  notificationController:
+    image: harbor.openova.io/proxy-ghcr/fluxcd/notification-controller
+    tag: v1.4.0
+  # #3735: the flux2 chart renders image-automation-controller +
+  # image-reflector-controller Deployments by DEFAULT (confirmed via render) —
+  # both pulled ghcr.io direct. Proxy them too. (Catalyst doesn't use the image
+  # automation feature today, but the controllers are installed, so their images
+  # are on the live pull path + the Enforce glob.)
+  imageAutomationController:
+    image: harbor.openova.io/proxy-ghcr/fluxcd/image-automation-controller
+    tag: v0.39.0
+  imageReflectionController:
+    image: harbor.openova.io/proxy-ghcr/fluxcd/image-reflector-controller
+    tag: v0.33.0
+  # #3735: the flux-cli image backs the chart's pre-install hook Job. Proxy it.
+  cli:
+    image: harbor.openova.io/proxy-ghcr/fluxcd/flux-cli
+    tag: v2.4.0
   # Prometheus PodMonitor — DEFAULT OFF.
   #
   # Per docs/INVIOLABLE-PRINCIPLES.md #4 and docs/BLUEPRINT-AUTHORING.md

--- a/platform/kyverno/blueprint.yaml
+++ b/platform/kyverno/blueprint.yaml
@@ -11,7 +11,9 @@ spec:
   # 1.3.6 (#3149): webhook-gate non-fatal — no more fatal-hook→stuck-uninstall cascade.
   # 1.3.7 (#3499): config.webhooks.objectSelector excludes the cilium CNI stack so a
   # cilium roll can always recreate its agent (breaks the apiserver-return-path deadlock).
-  version: 1.3.7
+  # 1.3.8 (#3735): MIRROR-EVERYTHING — 4 controller registries + kyvernopre init image
+  # re-pointed from ghcr.io / reg.kyverno.io to harbor.openova.io/proxy-ghcr/kyverno/*.
+  version: 1.3.8
   card:
     title: Kyverno
     family: guardian

--- a/platform/kyverno/chart/Chart.yaml
+++ b/platform/kyverno/chart/Chart.yaml
@@ -30,7 +30,17 @@ type: application
 # self-deadlock where the de-CNI'd apiserver node can't receive the webhook
 # response (hw135: cnpg-pair initdb wedged → no region-b standby → region-kill
 # impossible). See chart/values.yaml config.webhooks for the full root cause.
-version: 1.3.7
+# 1.3.8 (#3735, 2026-06-17): MIRROR-EVERYTHING for the Kyverno image pulls. The
+# 4 per-controller registries pointed at `ghcr.io` (slow-direct on the IPv4-only
+# kom4dc VPC + failing the `harbor-proxy-pull` Enforce glob `*/proxy-*/*`) AND
+# the kyvernopre INIT container was never overridden at all, falling through to
+# the upstream `defaultRegistry: reg.kyverno.io` (the SLOWEST registry on the
+# VPC, ~13 min cold-pull on hw157, starving the helm-controller install
+# workers). Re-pointed all four controllers + added admissionController.
+# initContainer.image at harbor.openova.io/proxy-ghcr/kyverno/*. Same fix class
+# as bp-cnpg (#3257) + bp-external-secrets (#3533). The flat global.imageRegistry
+# is documented as inert (upstream reads global.image.registry).
+version: 1.3.8
 appVersion: "v1.18.0"
 keywords: [catalyst, blueprint, kyverno, policy, admission, security]
 maintainers:

--- a/platform/kyverno/chart/values.yaml
+++ b/platform/kyverno/chart/values.yaml
@@ -7,12 +7,15 @@
 # may override any of these without rebuilding the Blueprint OCI artifact.
 
 global:
-  # When set, ALL image pulls in this chart route through this registry.
-  # Used post-handover when the Sovereign's own Harbor takes over the
-  # proxy_cache role from contabo's central Harbor. Empty = no rewrite
-  # (image references use upstream defaults). The upstream Kyverno chart
-  # exposes per-controller `kyverno.<controller>.image.registry` knobs.
-  # Per-Sovereign overlays wire those alongside this value. Tracked under #560.
+  # ⚠️ #3735 (2026-06-17): this `global.imageRegistry` key is INERT for the
+  # upstream Kyverno chart — Kyverno reads `global.image.registry` (a nested
+  # `image.registry`), NOT a flat `global.imageRegistry`. It is kept here only
+  # for cross-chart umbrella-overlay symmetry (#560) and has NO effect on any
+  # Kyverno image pull. The registry that actually moves the pull is each
+  # per-controller `kyverno.<controller>.image.registry` (set to the Harbor
+  # proxy-ghcr cache below). A per-Sovereign overlay that needs to repoint ALL
+  # Kyverno images in one line should set `kyverno.global.image.registry`
+  # (the real upstream knob), not this field.
   imageRegistry: ""
 
 catalystBlueprint:
@@ -27,6 +30,15 @@ kyverno:
   # land before the controller deployments). Default upstream behavior.
   crds:
     install: true
+    # #3735: the CRD-migration hook image (kyverno-cli) defaulted to
+    # `reg.kyverno.io` (crds.migration.enabled=true → the post-upgrade-migrate-
+    # resources hook Job runs on every CRD migration, e.g. a chart bump). Proxy
+    # it so the migration hook never cold-pulls the slow un-proxied registry +
+    # never trips the harbor-proxy-pull Enforce glob.
+    migration:
+      image:
+        registry: harbor.openova.io
+        repository: proxy-ghcr/kyverno/kyverno-cli
 
   # HA mode — Kyverno 1.18 splits into 4 controllers. Solo-Sovereign default
   # is replicas=2 (Wave 5.90 #2436) so a single admission-controller restart
@@ -34,11 +46,51 @@ kyverno:
   # overlays may bump to 3 for true HA on regional Sovereigns.
   admissionController:
     replicas: 2
+    # #3735 (2026-06-17): MIRROR-EVERYTHING for ALL Kyverno image pulls. Every
+    # Kyverno image used to resolve to a NON-Harbor registry — slow-direct on the
+    # IPv4-only kom4dc VPC AND failing the `harbor-proxy-pull` Enforce glob
+    # `*/proxy-*/*` on converged-env rolls. Same fix class as bp-cnpg (#3257) +
+    # bp-external-secrets (#3533). Re-pointed at the Harbor proxy-ghcr cache.
+    #
+    # ⚠️ KEY-PATH TRAP (verified by `helm template` on hw157): the MAIN admission
+    # image is read from `admissionController.CONTAINER.image.*`, NOT
+    # `admissionController.image.*`. The legacy top-level `admissionController.image`
+    # block below is INERT for the running Pod (exactly like the `.resources`-vs-
+    # `.container.resources` trap the #2436 comment documents) — it was rendering
+    # `reg.kyverno.io/kyverno/kyverno:v1.18.0` despite carrying a tag, because the
+    # helper only reads `.container.image`. The EFFECTIVE override lives under
+    # `container.image` further down. We keep the legacy block ONLY so an operator
+    # grepping for the admission tag still finds the right value, with this warning.
+    #
+    # Resolution precedence in the upstream `kyverno.image` helper:
+    #   `<x>.image.registry` > `global.image.registry` > `image.defaultRegistry`
+    #   (= `reg.kyverno.io` for the controllers, `ghcr.io` for readiness-checker).
+    # The flat `global.imageRegistry` (top of file) is INERT — upstream reads the
+    # nested `global.image.registry`. So each per-image `registry:` is the knob
+    # that actually moves the pull. Live on hw157: `reg.kyverno.io` was the
+    # SLOWEST registry on the VPC (~13 min) and starved the helm-controller
+    # install workers.
     image:
-      registry: ghcr.io
-      repository: kyverno/kyverno
+      # INERT for the main container (see KEY-PATH TRAP above) — the effective
+      # override is admissionController.container.image. Kept proxied + in sync
+      # for grep-friendliness; harmless if upstream ever starts reading it.
+      registry: harbor.openova.io
+      repository: proxy-ghcr/kyverno/kyverno
       tag: "v1.18.0"
       pullPolicy: IfNotPresent
+    # #3735: the kyvernopre INIT container was NEVER overridden — the chart set
+    # only admissionController.image.* (itself inert), so the init image fell
+    # through to upstream `defaultRegistry: reg.kyverno.io`. kyvernopre runs on
+    # EVERY admission-controller Pod start (replicas=2 → 2 cold pulls of
+    # reg.kyverno.io/kyverno/kyvernopre:v1.18.0). The init-container image block
+    # is admissionController.initContainer.image.{registry,repository,tag}. tag
+    # pinned explicitly (else it falls through to image.tag).
+    initContainer:
+      image:
+        registry: harbor.openova.io
+        repository: proxy-ghcr/kyverno/kyvernopre
+        tag: "v1.18.0"
+        pullPolicy: IfNotPresent
     # Wave 5.90 (#2436) — main container resources bumped from upstream
     # default 100m/128Mi/384Mi → 500m/512Mi/1Gi. Surfaced live on
     # d3c6268c (#2423 fresh prov 2026-05-24T20:00Z): with the upstream
@@ -56,6 +108,15 @@ kyverno:
     # to the Pod spec). The `container:` nesting is the canonical path
     # per upstream values.yaml line 1238.
     container:
+      # #3735: the EFFECTIVE main admission-controller image override (the
+      # upstream helper reads `.container.image`, not `.image` — see KEY-PATH
+      # TRAP above). Proxies the heaviest, most-pulled Kyverno image off
+      # reg.kyverno.io onto the Harbor proxy-ghcr cache.
+      image:
+        registry: harbor.openova.io
+        repository: proxy-ghcr/kyverno/kyverno
+        tag: "v1.18.0"
+        pullPolicy: IfNotPresent
       # G67 #2616 (2026-05-31): cpu request 500m → 200m. Live use on
       # hw74 was ~50m/admission-controller — 200m is conservative
       # right-size. Original 500m × 2 replicas ate 1000m on workers,
@@ -171,9 +232,10 @@ kyverno:
 
   backgroundController:
     replicas: 1
+    # #3735: proxy-ghcr (was ghcr.io) — see admissionController.image comment.
     image:
-      registry: ghcr.io
-      repository: kyverno/background-controller
+      registry: harbor.openova.io
+      repository: proxy-ghcr/kyverno/background-controller
       tag: "v1.18.0"
       pullPolicy: IfNotPresent
     resources:
@@ -189,9 +251,10 @@ kyverno:
   cleanupController:
     enabled: true
     replicas: 1
+    # #3735: proxy-ghcr (was ghcr.io) — see admissionController.image comment.
     image:
-      registry: ghcr.io
-      repository: kyverno/cleanup-controller
+      registry: harbor.openova.io
+      repository: proxy-ghcr/kyverno/cleanup-controller
       tag: "v1.18.0"
       pullPolicy: IfNotPresent
     resources:
@@ -206,9 +269,10 @@ kyverno:
 
   reportsController:
     replicas: 1
+    # #3735: proxy-ghcr (was ghcr.io) — see admissionController.image comment.
     image:
-      registry: ghcr.io
-      repository: kyverno/reports-controller
+      registry: harbor.openova.io
+      repository: proxy-ghcr/kyverno/reports-controller
       tag: "v1.18.0"
       pullPolicy: IfNotPresent
     resources:
@@ -220,6 +284,27 @@ kyverno:
         memory: 256Mi
     serviceMonitor:
       enabled: false
+
+  # #3735: the readiness-checker image (used by the webhooksCleanup pre-delete
+  # hook Job AND `helm test`) defaulted to `ghcr.io` with an implicit `:latest`
+  # tag — un-proxied + unpinned, failing the Enforce glob and slow-direct on the
+  # VPC. Proxy both call sites onto proxy-ghcr. (webhooksCleanup runs as a Helm
+  # pre-delete hook so it IS on the live uninstall path; `test` is helm-test-only
+  # but proxied for full MIRROR-EVERYTHING glob compliance.)
+  webhooksCleanup:
+    image:
+      registry: harbor.openova.io
+      repository: proxy-ghcr/kyverno/readiness-checker
+      # tag left to upstream default (chart appVersion v1.18.0); the
+      # pre-delete hook only runs on uninstall so an unpinned tag never
+      # races a fresh-prov pull.
+  test:
+    image:
+      registry: harbor.openova.io
+      repository: proxy-ghcr/kyverno/readiness-checker
+      # #3735: pin to v1.18.0 (was implicit `:latest`) so even the helm-test
+      # image is a deterministic proxied ref, not a floating `:latest`.
+      tag: v1.18.0
 
   # Reports server — bundled subchart, default disabled. Per-Sovereign
   # overlays enable when scaling out PolicyReport storage.
@@ -378,5 +463,10 @@ webhookGate:
   tlsSecretName: kyverno-svc.kyverno.svc.kyverno-tls-pair
   timeoutSeconds: 300
   intervalSeconds: 2
-  image: "bitnamilegacy/kubectl:1.30.7"
+  # #3735: explicit Harbor proxy-dockerhub prefix (was bare
+  # `bitnamilegacy/kubectl:1.30.7`). A bare ref relies on the node containerd
+  # docker.io→proxy-dockerhub mirror AND fails the `harbor-proxy-pull` Enforce
+  # glob `*/proxy-*/*` (the glob matches the image STRING as written, pre-mirror-
+  # rewrite). Matches the cnpg webhookGate (#3257) + cert-manager idiom exactly.
+  image: "harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.30.7"
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Refs #3735

Fixes three reliability/latency convergence issues on the IPv4-only kom4dc (Huawei) VPC, all verified live on hw157, all in the same un-proxied-registry / controller-storage class as #3257 (bp-cnpg) and #3533 (bp-external-secrets).

## #3 — bp-flux source-controller self-DoS (HIGH; caused a live Ready 26→7 regression)

The flux2 2.14.1 chart applies curated resources + leader-election args to `source-controller`, which differs from the bare cloud-init `install.yaml` spec → the first bp-flux reconcile **rolls** the Deployment. The chart hardcodes `strategy: Recreate` (template-level, no values knob) with an **emptyDir** `/data` cache, so Recreate kills the only artifact-serving pod mid-bootstrap → ~60 HRs `ArtifactFailed` / `dial tcp …:80: connection refused` → full **Ready 26→7** collapse.

**Fix (two halves):**
- **(a) Image proxy** — the flux2 chart has **no** chart-wide registry knob (the `global.imageRegistry` we carried was inert) and uses **flat** `<controller>.image` scalars. Re-pointed all 6 controllers + `flux-cli` at `harbor.openova.io/proxy-ghcr/fluxcd/*`, which also satisfies the kyverno `harbor-proxy-pull` Enforce glob `*/proxy-*/*` on the roll-pull.
- **(b) Serving-gap** — added a `spec.postRenderers` kustomize patch on the bp-flux HelmRelease (slot 03) flipping source-controller to `RollingUpdate(maxUnavailable: 0)`. The old pod keeps serving artifacts until the new one is Ready → **no serving gap** on the (still one-time) roll. A postRenderer is the **only** override helm-controller cannot revert — a raw `kubectl patch` would be overwritten by the chart's `Recreate` on the next reconcile.

⚠️ The flux2 **subchart pin (2.14.1)** and cloud-init's **v2.4.0 install.yaml** are **unchanged** — the catastrophic version-pin invariant (`tests/version-pin-replay.sh`) is untouched.

## #4 — bp-kyverno un-proxied images (HIGH; ~13 min + starves helm-controller workers)

`reg.kyverno.io` was the slowest registry on the VPC. Two upstream-key traps fixed:
- the **main admission** image reads `admissionController.container.image.*`, **not** `admissionController.image.*` — the pre-existing block was **inert** and rendered `reg.kyverno.io/kyverno/kyverno` despite carrying a tag;
- the **kyvernopre init** image was never overridden → fell through to `defaultRegistry: reg.kyverno.io`.

Re-pointed **every** Kyverno image onto `harbor.openova.io/proxy-ghcr/kyverno/*`: admission main+init, background, cleanup, reports, `crds.migration` (kyverno-cli), `webhooksCleanup`+`test` (readiness-checker — also un-pinned `:latest` → `:v1.18.0`), and the `webhookGate` hook kubectl → `proxy-dockerhub`. `helm template` now shows **zero** non-Harbor images. The flat `global.imageRegistry` is documented inert (upstream reads `global.image.registry`).

## #5 — cnpg postgresql:16 cold-pull contention (MEDIUM; folded in, low-risk)

~150 MB image cold-pulls 7+ min; co-scheduled CNPG clusters overlap → `ErrImagePull: context canceled`. Added a backgrounded, idempotent, **non-fatal** `crictl pull` of `harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16` on **Huawei worker** boot (mirrors the #3534 pre-pull pattern) so the layer is warm before CNPG schedules. `nohup … &` + `|| true` — can never affect bootstrap; kubelet still pulls on demand.

## Lockstep + gates

Version bumps in lockstep (Chart.yaml + blueprint.yaml + bootstrap-kit slot pin each): **bp-flux 1.2.6 → 1.2.7**, **bp-kyverno 1.3.7 → 1.3.8**.

Local gate results:
- `check-kyverno-proxy-images.sh` — **PASS** (every rendered image satisfies the live `harbor-proxy-pull` Enforce policy globs)
- `check-bootstrap-kit-pin-sync.sh` — **PASS** (bp-flux + bp-kyverno pins in sync)
- `version-pin-replay.sh` — **ALL GREEN** (Cases 1-6; flux2 ↔ cloud-init invariant intact)
- `check-bootstrap-deps.sh` — **PASS** (no drift/cycles; `kubectl kustomize` build of the kit succeeds → the postRenderers patch renders intact)
- blueprint topology schema — **VALID** for both blueprint.yaml
- `helm lint` — clean (both charts)
- `lint-cloudinit.sh huawei` — **PASS**; tofu-rendered Huawei worker template `dash -n` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
