### PR TITLE
fix(bp-cnpg-pair): cross-region replica as synchronous standby — RPO=0 (0.2.5)

### DIFF
--- a/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
+++ b/clusters/_template/bootstrap-kit/16b-bp-cnpg-pair.yaml
@@ -192,7 +192,9 @@ spec:
       # it default-denied the primary's own instance-2 join (>1h wedge).
       # 0.2.3 (#3195 G6): production Continuum seed flipped ON (real
       # region labels; CRD pattern relaxed in lockstep, catalyst chart).
-      version: 0.2.4
+      # 0.2.5 (#3740): cross-region replica pinned as the synchronous
+      # standby (standbyNamesPre + maxStandbyNamesFromCluster:0) → RPO=0.
+      version: 0.2.5
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg-pair

--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-9-disaster-recovery
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.2.4
+  version: 0.2.5
   card:
     title: CNPG Cluster-Pair (Active-Hotstandby DR)
     summary: |

--- a/platform/cnpg-pair/chart/Chart.yaml
+++ b/platform/cnpg-pair/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cnpg-pair
-version: 0.2.4
+version: 0.2.5
 appVersion: "0.2.1"
 description: |
   Catalyst-curated Blueprint for an active-hotstandby CNPG cluster-pair
@@ -40,6 +40,34 @@ description: |
 
   Changelog
   ─────────
+  0.2.5 (2026-06-17, cross-region sync target — RPO=0 fix, Refs #3740 / #3375)
+    - FIX (Pillar-3 zero-tx-loss): the primary Cluster CR's CNPG-native
+      `spec.postgresql.synchronous` block now pins the CROSS-REGION
+      replica as the synchronous standby via
+      `standbyNamesPre: [<replicaName>]` + `maxStandbyNamesFromCluster: 0`.
+      Before this, CNPG auto-populated `synchronous_standby_names` from the
+      LOCAL cluster's own instance Pods only (default
+      maxStandbyNamesFromCluster is unbounded). In the split-side topology
+      (0.2.0) the cross-region standby is a SEPARATE Cluster CR on
+      cluster-B, which CNPG never adds, so `FIRST 1` was satisfied by a
+      LOCAL region-A HA peer and the cross-region replica streamed ASYNC
+      (sync_state=async). A region-kill then loses in-flight transactions
+      → the canonical "zero transactions lost" claim was VIOLATED. Caught
+      LIVE on hw158 (2026-06-17): the region-B replica was byte-for-byte
+      caught up yet pg_stat_replication showed it async while a local
+      primary-2 was sync. After the fix `synchronous_standby_names =
+      FIRST 1 ("<replicaName>")` and the primary blocks COMMIT until the
+      cross-region replica has applied the WAL → RPO=0. The
+      replica-unreachable → primary-blocks-writes trade-off is unchanged
+      and already disclosed in values.yaml / DESIGN.md.
+    - Render-gate test (chart/tests/cnpg-pair-render.sh) now asserts
+      `maxStandbyNamesFromCluster: 0` AND the replica name in
+      `standbyNamesPre` on the side=primary render.
+    - Default-OFF contract UNCHANGED: cnpgPair.enabled=false renders ZERO
+      resources on BOTH sides; async mode still omits the synchronous block.
+      Resource COUNTS unchanged (two fields added inside the existing
+      synchronous block).
+
   0.2.1 (2026-06-11, operator status-probe carve-out, Refs #3236 / #3195 / #2737)
     - FIX: the per-side ingress NetworkPolicies (allow-replication-to-
       primary on side=primary, allow-probe-to-replica on side=replica)

--- a/platform/cnpg-pair/chart/templates/primary-cluster.yaml
+++ b/platform/cnpg-pair/chart/templates/primary-cluster.yaml
@@ -97,11 +97,32 @@ spec:
       `parameters` with "Can't set fixed configuration parameter".
       Verified live against CNPG 1.29.0 (hw124, 2026-06-10, #3195). We
       therefore declare synchronous replication via CNPG's NATIVE
-      `spec.postgresql.synchronous` block (CNPG ≥1.24) below — the
-      operator derives `synchronous_standby_names` from it
-      (`FIRST <number> (<replica application_name>)`). The replica's
-      externalCluster streaming connection defaults application_name to
-      the replica Cluster CR's name, which CNPG matches automatically.
+      `spec.postgresql.synchronous` block (CNPG ≥1.24) below.
+
+      🛑 CROSS-CLUSTER SYNC TARGET (#3740, hw158 2026-06-17). By default
+      CNPG auto-populates `synchronous_standby_names` from the LOCAL
+      cluster's own instance Pods ONLY (`maxStandbyNamesFromCluster`
+      defaults to unbounded). In the split-side topology (chart 0.2.0)
+      the cross-region standby is a SEPARATE Cluster CR on cluster-B,
+      which CNPG never adds — so a bare `method:first, number:1` block
+      renders `FIRST 1 (<local primary-2>,<primary-3>,<primary-1>)` and
+      the in-flight COMMIT is acked by a LOCAL region-A HA peer. The
+      cross-region replica then streams ASYNC (sync_state=async in
+      pg_stat_replication) → region-kill loses in-flight tx → the
+      Pillar-3 "zero transactions lost" claim is VIOLATED (caught live
+      on hw158: replica byte-caught-up yet async). The earlier comment
+      here claimed CNPG "matches the replica's application_name
+      automatically" — that is FALSE for the separate-cluster replica.
+
+      FIX: pin the cross-region replica as the synchronous target via
+      `standbyNamesPre: [<replicaName>]` and EXCLUDE the local pods with
+      `maxStandbyNamesFromCluster: 0`. CNPG then renders
+      `synchronous_standby_names = FIRST <number> ("<replicaName>")` and
+      the primary blocks COMMIT until the CROSS-REGION replica has
+      applied the WAL → RPO=0. The replica's externalCluster streaming
+      connection uses the replica Cluster CR name as its application_name
+      by default, which equals `cnpg-pair.replicaName` (verified live:
+      application_name=cnpg-pair-bp-cnpg-pair-replica).
 
       Mode "async" exists for forensic / lab use only; the rendered
       manifest then omits both the parameter AND the synchronous block,
@@ -113,15 +134,26 @@ spec:
       {{- end }}
     {{- if eq (default "sync" .Values.cnpgPair.replication.mode) "sync" }}
     # ── Synchronous replication — CNPG-native (NOT a raw parameter) ────
-    # method=first + number=N renders `synchronous_standby_names =
-    # FIRST N (...)`; CNPG fills the standby application_name(s) from the
-    # connected replicas. dataDurability=required strictly enforces the
+    # method=first + number=N + standbyNamesPre:[<replica>] +
+    # maxStandbyNamesFromCluster:0 renders
+    # `synchronous_standby_names = FIRST N ("<replica>")` — the
+    # CROSS-REGION replica (separate Cluster CR on cluster-B), NOT a
+    # local HA peer. dataDurability=required strictly enforces the
     # zero-tx-loss bar: COMMIT blocks when fewer than `number` healthy
     # synchronous standbys are connected (the Pillar-3 durability claim).
+    # See the #3740 note above for why standbyNamesPre is REQUIRED here.
     synchronous:
       method: first
       number: {{ int (default 1 .Values.cnpgPair.replication.sync.numSync) }}
       dataDurability: required
+      # Exclude the local cluster's own Pods from synchronous_standby_names
+      # so the cross-region replica is the ONLY synchronous target (a local
+      # region-A HA peer acking sync would leave the replica async → RPO>0).
+      maxStandbyNamesFromCluster: 0
+      # The cross-region replica's application_name == its Cluster CR name
+      # (CNPG externalCluster streaming default) == cnpg-pair.replicaName.
+      standbyNamesPre:
+        - {{ include "cnpg-pair.replicaName" . | quote }}
     {{- end }}
 
   # ── Replication-source Service (managed by CNPG, annotated for ──────

--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -167,6 +167,20 @@ grep -qE '^\s+dataDurability: required' "$TMP/primary.yaml" || {
   echo "FAIL: primary Cluster CR missing spec.postgresql.synchronous.dataDurability=required (zero-tx-loss enforcement)." >&2
   exit 1
 }
+# #3740: the CROSS-REGION replica MUST be the synchronous target, not a
+# local HA peer. Without maxStandbyNamesFromCluster:0 CNPG fills
+# synchronous_standby_names from local pods only → cross-region replica
+# streams async → RPO>0 on region-kill (caught live on hw158).
+grep -qE '^\s+maxStandbyNamesFromCluster: 0' "$TMP/primary.yaml" || {
+  echo "FAIL: primary Cluster CR missing spec.postgresql.synchronous.maxStandbyNamesFromCluster=0 — local HA peers would be acked as sync, leaving the cross-region replica async (RPO>0). See #3740." >&2
+  exit 1
+}
+# standbyNamesPre must name the cross-region replica Cluster CR (its
+# externalCluster streaming application_name) so it leads FIRST N (...).
+grep -qE '^\s+- "smoke-cnpg-pair-bp-cnpg-pair-replica"' "$TMP/primary.yaml" || {
+  echo "FAIL: primary Cluster CR missing spec.postgresql.synchronous.standbyNamesPre=[<replicaName>] — the cross-region replica is not pinned as the synchronous standby. See #3740." >&2
+  exit 1
+}
 if grep -qE '^\s*synchronous_standby_names:\s' "$TMP/primary.yaml"; then
   echo "FAIL: primary Cluster CR sets synchronous_standby_names as a raw parameter — CNPG rejects this fixed parameter at admission." >&2
   exit 1


### PR DESCRIPTION
## Problem (Refs #3740, Refs #3375)
On the live 2-region prov **hw158** (deployment `ab2135d4`), the cnpg-pair cross-region replica streamed **asynchronously** despite `replication.mode: sync` + the Pillar-3 "zero transactions lost" claim. A region-kill would lose in-flight transactions.

## Root cause
`platform/cnpg-pair/chart/templates/primary-cluster.yaml` declared the CNPG-native synchronous block with no explicit standbys:
```yaml
synchronous: { method: first, number: 1, dataDurability: required }
```
CNPG's `maxStandbyNamesFromCluster` defaults to **unbounded**, so the operator fills `synchronous_standby_names` from the **local cluster's own instance Pods only**. In the split-side topology (chart 0.2.0) the cross-region standby is a **separate Cluster CR on cluster-B**, which CNPG never adds — so `FIRST 1` was satisfied by a LOCAL region-A HA peer and the cross-region replica was `async`.

Live evidence (hw158, before fix):
```
SHOW synchronous_standby_names; -> FIRST 1 ("...-primary-2","...-primary-3","...-primary-1")
pg_stat_replication: application_name=cnpg-pair-bp-cnpg-pair-replica  sync_state=async  (client_addr 10.43.4.36 = region-B pod)
```

## Fix
Pin the cross-region replica as the synchronous target and exclude local pods:
```yaml
synchronous:
  method: first
  number: {{ numSync }}
  dataDurability: required
  maxStandbyNamesFromCluster: 0
  standbyNamesPre:
    - {{ include "cnpg-pair.replicaName" . | quote }}
```
Renders `synchronous_standby_names = FIRST 1 ("<replicaName>")` → the primary blocks COMMIT until the **cross-region** replica has applied the WAL → **RPO=0**. The replica's externalCluster streaming `application_name` equals its Cluster CR name (`cnpg-pair.replicaName`), verified live.

## Verified LIVE on hw158
Applied the equivalent patch to the live primary CR; CNPG reloaded:
```
SHOW synchronous_standby_names; -> FIRST 1 ("cnpg-pair-bp-cnpg-pair-replica")
pg_stat_replication: cnpg-pair-bp-cnpg-pair-replica (10.43.4.36)  state=streaming  sync_state=SYNC ✅
                     ...-primary-2 (local)                         sync_state=async  ✅ (correctly demoted)
```
Region-kill walk (RTO/RPO) result recorded on #3740 + `docs/ledger/UAT.md` row 11.

## Tests
`platform/cnpg-pair/chart/tests/cnpg-pair-render.sh` — all 11 gates green; new asserts: `maxStandbyNamesFromCluster: 0` + replica name in `standbyNamesPre` on side=primary.

## Contract
Default-OFF unchanged (zero resources when disabled), async-mode unchanged, resource counts unchanged. The documented replica-unreachable → primary-blocks-writes trade-off (already in values.yaml/DESIGN.md) is the intended price of zero-tx-loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)