### PR TITLE
fix(bp-keycloak): powerdns-admin realm-seed client -> /oauth2/callback + aud-mapper (hw158 UAT row 6 SSO)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -167,7 +167,9 @@ spec:
       # 1.4.25: hook Job managed-by:flux (kyverno Enforce, #3297 class).
       # 1.4.26: config-cli right-sized 500m->100m (requests-wedge on hw130).
       # 1.4.29: sovereign-realm configmap one-admin-authority (#3374).
-      version: 1.4.29
+      # 1.4.30: powerdns-admin realm client -> /oauth2/callback + aud-mapper,
+      #         matching the bp-oidc-gate AppRegistration (#3741, hw158 row 6).
+      version: 1.4.30
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.29
+  version: 1.4.30
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -282,7 +282,12 @@ name: bp-keycloak
 # (realm-management:realm-admin), AND every app keying on the `groups`
 # claim — no self-signed assertion, no per-email grant. keycloak-config-
 # cli re-applies the import so the composite reaches existing realms too.
-version: 1.4.29
+# 1.4.30: powerdns-admin realm-seed client aligned to the bp-oidc-gate
+#   contract — /oauth2/callback redirectUri + oidc-audience-mapper (was the
+#   dead pre-#3374 native /oidc/authorized + /* with no aud mapper, which the
+#   config-cli FULL-managed reconcile reverted over the gate's correct client).
+#   Mirrors the hubble-ui gated precedent. Refs #3741 (hw158 UAT row 6 SSO).
+version: 1.4.30
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -829,7 +829,7 @@ data:
         {
           "clientId": "powerdns-admin",
           "name": "PowerDNS-Admin (Tier-2 silent-SSO)",
-          "description": "G117.5 #2744 — DNS UI silent-SSO via catalyst-pin broker. PDA reads OIDC env via ExternalSecret materialised by bp-sso-bridge.",
+          "description": "#3741 — DNS UI silent-SSO via catalyst-pin broker, fronted by the bp-oidc-gate oauth2-proxy. The gate sends redirect_uri=https://pdns-admin.<fqdn>/oauth2/callback and (keycloak-oidc provider) verifies the ID-token aud contains powerdns-admin — hence the /oauth2/callback redirectUri + the oidc-audience-mapper below, matching the gate's own AppRegistration (platform/oidc-gate/chart/templates/instances.yaml) so config-cli's FULL-managed reconcile keeps the client correct rather than reverting to the dead pre-#3374 native /oidc/authorized shape.",
           "enabled": true,
           "publicClient": false,
           "standardFlowEnabled": true,
@@ -839,8 +839,7 @@ data:
           "authorizationServicesEnabled": false,
           "secret": {{ include "bp-keycloak.tier2ClientSecret" (dict "ctx" . "clientId" "powerdns-admin") | quote }},
           "redirectUris": [
-            "https://pdns-admin.{{ .Values.sovereignFQDN }}/oidc/authorized",
-            "https://pdns-admin.{{ .Values.sovereignFQDN }}/*"
+            "https://pdns-admin.{{ .Values.sovereignFQDN }}/oauth2/callback"
           ],
           "webOrigins": [
             "https://pdns-admin.{{ .Values.sovereignFQDN }}"
@@ -858,6 +857,18 @@ data:
             "phone",
             "offline_access",
             "microprofile-jwt"
+          ],
+          "protocolMappers": [
+            {
+              "name": "audience-powerdns-admin",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-audience-mapper",
+              "config": {
+                "included.client.audience": "powerdns-admin",
+                "id.token.claim": "true",
+                "access.token.claim": "true"
+              }
+            }
           ],
           "attributes": {
             "access.token.lifespan": "900",


### PR DESCRIPTION
Refs #3741

## What

Aligns the keycloak realm-import `powerdns-admin` client with the **bp-oidc-gate** oauth2-proxy contract, so the gated DNS-UI silent-SSO survives config-cli's `import.managed.client=FULL` reconcile (was reverting to a dead pre-#3374 native-OIDC shape).

`bp-keycloak` 1.4.29 → **1.4.30** (Chart.yaml + blueprint.yaml + slot `09-keycloak.yaml` in lockstep).

## Root cause (Defect 1 — pdns-admin SSO FAIL, hw158 UAT row 6)

`powerdns-admin` is fronted by the **bp-oidc-gate** oauth2-proxy (ns `oidc-gate`), which:
- sends `redirect_uri=https://pdns-admin.<fqdn>/oauth2/callback`
- (keycloak-oidc provider) verifies the ID-token `aud` contains `powerdns-admin`

The gate's own AppRegistration (`platform/oidc-gate/chart/templates/instances.yaml:61-102`) already mints a correct client (`/oauth2/callback` + `oidc-audience-mapper`) via bp-sso-bridge — that's what's live-correct on hw158.

**But** the realm-import (`platform/keycloak/chart/templates/configmap-sovereign-realm.yaml`) ALSO defined a `powerdns-admin` client with the **stale** shape: `redirectUris:[/oidc/authorized, /*]` and **no aud-mapper**. config-cli runs `import.managed.client=FULL` (upstream default, no override), so on every keycloak upgrade/reconcile it **reverts** the client to this stale seed — stripping `/oauth2/callback` + the aud-mapper and re-breaking the gated login. On a fresh prov where config-cli wins the mint race, the client seeds broken → the `invalid redirect` the walk reported.

## Fix

Make the realm-seed `powerdns-admin` client match the gate's AppRegistration contract — `redirectUris:["https://pdns-admin.<fqdn>/oauth2/callback"]` + the `oidc-audience-mapper` — mirroring the already-correct **hubble-ui** gated precedent in the same file. (openbao's `/oidc/callback` entries are native-OIDC, not gated, and intentionally unchanged.)

## Live re-verification (hw158, dep `ab2135d4cf2d01e4`)

Bare `https://pdns-admin.hw158.omani.works/`:
```
302 -> auth.../realms/sovereign/.../auth?client_id=powerdns-admin&redirect_uri=.../oauth2/callback   (+CSRF cookie)
303 -> auth.../realms/sovereign/broker/catalyst-pin/login?client_id=powerdns-admin   (KC ACCEPTS — no invalid_redirect)
303 -> api.hw158.../oidc/auth?client_id=catalyst-pin   (catalyst-pin silent broker)
302 -> console.hw158.../login   ->   200
```
**Byte-structurally identical to the known-PASS grafana chain** (same broker → api/oidc/auth → console terminus). The headless trace stops at `console/login` only because curl carries no existing console session; a real browser already signed into the console completes the broker hop silently and bounces back through `/oauth2/callback` into the PowerDNS-Admin UI. KC accepts `/oauth2/callback`; the redirect_uri mismatch is gone.

Live KC client (kcadm) confirmed: `redirectUris:["https://pdns-admin.hw158.omani.works/oauth2/callback"]` + protocolMapper `audience-powerdns-admin`/`oidc-audience-mapper`. This PR makes the **seed** carry the same, so config-cli no longer reverts it.

## Defect 2 — newapi `/setup` (NOT a defect; verified live, no code change)

Live on hw158, bare `https://newapi.hw158.omani.works/` → HTTP 200 `<title>Signing you in…</title>` (the `sso_init.go` zero-click bridge, #3374/#3563), which injects `AUTHORIZE_URL=.../realms/sovereign/...?kc_idp_hint=catalyst-pin` + `CLIENT_ID=newapi-admin`, mints CSRF state (`/api/oauth/state` → 200 + session cookie) and drives the OIDC handshake → `/console`. KC accepts the `newapi-admin` redirect_uri `https://newapi.<fqdn>/oauth/sovereign` (303 → catalyst-pin broker, no error).

DB ground truth (CNPG `newapi` postgres): `setups` row present, `users.catalyst-root` role=100 SSO-locked, `custom_oauth_providers.sovereign` enabled, `options.ServerAddress=https://newapi.<fqdn>`, `database_type:postgres`. `/api/setup` `status:false` is the cosmetic **built-in** OIDC flag — NewAPI's `/setup` wizard is never reached because the bridge intercepts `Exact /`. The walk's `/setup` sighting was a stale/pre-convergence observation, not a live defect.

(Doc nit for the cron-refreshed ledger: `docs/ledger/UAT.md` + `uat-walkthrough/3374-sso.md` still say newapi has "NO external HTTPRoute / N/A" — stale; it has an external `newapi.<fqdn>` route and lands signed-in. Noted in #3741.)

## Validation
- `helm dependency build` + `helm template` render: clean (rc=0), realm JSON parses, `powerdns-admin.redirectUris=[/oauth2/callback]` + `protocolMappers=[oidc-audience-mapper]`.
- chart/blueprint/slot-pin bumped in lockstep (1.4.30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)