### PR TITLE
fix(provisioning): dedup provision-create + recognize Gitea ref-lock 500 (stranger redeem self-race)

### DIFF
--- a/core/services/provisioning/github/client.go
+++ b/core/services/provisioning/github/client.go
@@ -499,7 +499,13 @@ func (c *Client) ensureBranchExists(ctx context.Context, branch string) error {
 // "not a fast forward" signal the GitHub Git Data path uses, so the outer
 // retry loop in CommitFilesWithPruneAndRebuild treats both equivalently.
 // Gitea returns 409 Conflict or 422 with a body containing phrases like
-// "branch has been changed" / "stale base" / "ref has been updated".
+// "branch has been changed" / "stale base" / "ref has been updated". It can
+// ALSO surface a concurrent-commit collision as an HTTP 500 whose body carries
+// the raw git push rejection — "PushRejected ... cannot lock ref
+// 'refs/heads/<branch>': is at X but expected Y ... failed to update ref"
+// (observed on hw158, #3744). That wording is matched here too so the outer
+// rebuild loop re-fetches the branch head and retries against fresh HEAD
+// instead of classifying the loser of a genuine concurrent commit as fatal.
 func isGiteaRefRaceError(err error) bool {
 	if err == nil {
 		return false
@@ -509,7 +515,11 @@ func isGiteaRefRaceError(err error) bool {
 		strings.Contains(s, "branch has been changed") ||
 		strings.Contains(s, "stale base") ||
 		strings.Contains(s, "ref has been updated") ||
-		strings.Contains(s, "not a fast forward")
+		strings.Contains(s, "not a fast forward") ||
+		strings.Contains(s, "cannot lock ref") ||
+		strings.Contains(s, "failed to update ref") ||
+		strings.Contains(s, "PushRejected") ||
+		strings.Contains(s, "but expected")
 }
 
 // getContentSHA returns the blob SHA of `path` at `branch`, or "" if the

--- a/core/services/provisioning/github/client_refrace_test.go
+++ b/core/services/provisioning/github/client_refrace_test.go
@@ -1,0 +1,46 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestIsGiteaRefRaceError covers the #3744 widening: Gitea surfaces a
+// concurrent-commit collision as an HTTP 500 whose body carries the raw git
+// push rejection ("PushRejected ... cannot lock ref ... failed to update ref"),
+// which the original matcher (409 / "not a fast forward" only) missed — so the
+// loser of a genuine concurrent commit was classified fatal with zero retries.
+func TestIsGiteaRefRaceError(t *testing.T) {
+	// The verbatim error string the provisioning service logged on hw158 when
+	// two provisions for one tenant raced the sme-tenants branch.
+	hw158 := fmt.Errorf(`change files: GitHub API POST http://gitea-http.gitea.svc.cluster.local:3000/api/v1/repos/openova/openova/contents: 500 {"message":"PushRejected Error: exit status 1 - remote: error: cannot lock ref 'refs/heads/sme-tenants': is at 97576e3c but expected 3fd04dbe\nTo /data/git/gitea-repositories/openova/openova.git\n ! [remote rejected] c68a2775 -> sme-tenants (failed to update ref)\nerror: failed to push some refs"}`)
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"hw158 cannot-lock-ref 500", hw158, true},
+		{"bare cannot lock ref", fmt.Errorf("remote: error: cannot lock ref 'refs/heads/sme-tenants'"), true},
+		{"failed to update ref", fmt.Errorf("! [remote rejected] -> sme-tenants (failed to update ref)"), true},
+		{"PushRejected", fmt.Errorf(`500 {"message":"PushRejected Error: exit status 1"}`), true},
+		{"is at X but expected Y", fmt.Errorf("is at 97576e3c but expected 3fd04dbe"), true},
+		// Pre-existing signals must still match (no regression).
+		{"409 conflict", fmt.Errorf("GitHub API POST ...: 409 conflict"), true},
+		{"not a fast forward", fmt.Errorf("update ref failed: not a fast forward"), true},
+		{"branch has been changed", fmt.Errorf("the target branch has been changed"), true},
+		// Genuinely unrelated errors must remain fatal (not retried).
+		{"401 unauthorized", fmt.Errorf("GitHub API POST ...: 401 unauthorized"), false},
+		{"404 not found", fmt.Errorf("GitHub API GET ...: 404 not found"), false},
+		{"malformed path 422", fmt.Errorf("422 tree.path contains a malformed path component"), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isGiteaRefRaceError(tc.err); got != tc.want {
+				t.Fatalf("isGiteaRefRaceError(%q) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -921,7 +922,37 @@ func (h *Handler) startProvisioning(ctx context.Context, tenantID, orderID, plan
 		Progress:  0,
 	}
 
-	if err := h.Store.CreateProvision(ctx, provision); err != nil {
+	// #3744 — dedup the provision-create entrypoint. A credit-covered
+	// marketplace checkout fires this path twice (NATS order.placed event +
+	// POST /provisioning/start) by design; without a guard both inserts fork a
+	// workflow and the two near-simultaneous Gitea commits race on the
+	// sme-tenants branch ("cannot lock ref"), marking the tenant failed even
+	// though the Org CR + winning commit land. CreateProvisionIfAbsent is
+	// backed by a partial unique index on (tenant_id, in-flight status), so the
+	// second trigger collides and we return the already-running provision
+	// without forking a duplicate workflow — mirroring runInstallJob's #71
+	// dedup for day-2 Jobs.
+	if err := h.Store.CreateProvisionIfAbsent(ctx, provision); err != nil {
+		if errors.Is(err, store.ErrProvisionExists) {
+			existing, getErr := h.Store.GetInFlightProvisionByTenant(ctx, tenantID)
+			if getErr != nil {
+				slog.Error("duplicate provision dispatch: failed to load in-flight provision",
+					"tenant_id", tenantID, "error", getErr)
+				return nil, getErr
+			}
+			if existing != nil {
+				slog.Info("duplicate provision dispatch — an in-flight provision already exists for this tenant; skipping",
+					"tenant_id", tenantID, "provision_id", existing.ID)
+				return existing, nil
+			}
+			// Lost the in-flight row between the collision and the lookup (it
+			// just reached a terminal state). Treat as benign: return the
+			// provision we built without forking — the prior workflow owns the
+			// outcome. A subsequent legitimate re-provision will succeed.
+			slog.Info("duplicate provision dispatch — prior provision terminated; not forking a new workflow",
+				"tenant_id", tenantID)
+			return provision, nil
+		}
 		slog.Error("failed to create provision record", "error", err)
 		return nil, err
 	}

--- a/core/services/provisioning/main.go
+++ b/core/services/provisioning/main.go
@@ -11,8 +11,8 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
-	ghclient "github.com/openova-io/openova/core/services/provisioning/github"
 	"github.com/openova-io/openova/core/services/provisioning/gitguard"
+	ghclient "github.com/openova-io/openova/core/services/provisioning/github"
 	"github.com/openova-io/openova/core/services/provisioning/gitops"
 	"github.com/openova-io/openova/core/services/provisioning/handlers"
 	"github.com/openova-io/openova/core/services/provisioning/store"
@@ -150,8 +150,17 @@ func main() {
 		slog.Error("failed to create job indexes", "error", err)
 		os.Exit(1)
 	}
+	// Ensure the partial unique index on (tenant_id, in-flight status) backing
+	// the provision-dedup guarantee (#3744) so a credit-covered checkout that
+	// fires the create entrypoint twice (event + HTTP) can't race itself into a
+	// failed tenant via a duplicate Gitea commit.
+	if err := provisionStore.EnsureProvisionIndexes(idxCtx); err != nil {
+		idxCancel()
+		slog.Error("failed to create provision indexes", "error", err)
+		os.Exit(1)
+	}
 	idxCancel()
-	slog.Info("provisioning job indexes ensured")
+	slog.Info("provisioning job + provision indexes ensured")
 	generator := gitops.NewManifestGenerator(gitBasePath)
 
 	// ── Git host coordinates (issue #940) ────────────────────────────

--- a/core/services/provisioning/store/store.go
+++ b/core/services/provisioning/store/store.go
@@ -62,6 +62,95 @@ func (s *Store) CreateProvision(ctx context.Context, p *Provision) error {
 	return nil
 }
 
+// inFlightProvisionStatuses are the provision states that count as "a
+// provision is already running for this tenant". A tenant may legitimately be
+// re-provisioned once a prior provision reaches a terminal state (completed /
+// failed), so the dedup index (EnsureProvisionIndexes) and CreateProvisionIfAbsent
+// only collide on these non-terminal states.
+var inFlightProvisionStatuses = []string{"pending", "provisioning", "running"}
+
+// EnsureProvisionIndexes creates the partial unique index on tenant_id that
+// backs the dedup guarantee in CreateProvisionIfAbsent. The marketplace
+// credit-covered checkout fires the provision-create entrypoint twice — once
+// via the NATS order.placed event and once via POST /provisioning/start (the
+// client deliberately does both as belt-and-suspenders, see CheckoutStep.svelte).
+// Without this guard both calls insert a provision + fork a workflow → two
+// concurrent commits to the same Gitea branch → a ref-lock race that marks the
+// tenant "failed" even though the Org CR + winning commit land (#3744).
+//
+// The index is PARTIAL (filtered to in-flight statuses) so a tenant can be
+// re-provisioned after a prior provision terminates. Safe to call at startup
+// every time — index creation is idempotent. Mirrors EnsureJobIndexes (#71).
+func (s *Store) EnsureProvisionIndexes(ctx context.Context) error {
+	model := mongo.IndexModel{
+		Keys: bson.D{{Key: "tenant_id", Value: 1}},
+		Options: options.Index().
+			SetUnique(true).
+			SetName("uniq_inflight_tenant").
+			SetPartialFilterExpression(bson.D{
+				{Key: "status", Value: bson.D{{Key: "$in", Value: inFlightProvisionStatuses}}},
+			}),
+	}
+	_, err := s.provisions().Indexes().CreateOne(ctx, model)
+	if err != nil {
+		return fmt.Errorf("store: ensure provision indexes: %w", err)
+	}
+	return nil
+}
+
+// ErrProvisionExists is returned by CreateProvisionIfAbsent when an in-flight
+// provision already exists for the tenant. Callers should treat this as "a
+// provision is already running for this tenant — skip this duplicate dispatch"
+// and surface the existing record via GetInFlightProvisionByTenant. See #3744.
+var ErrProvisionExists = fmt.Errorf("store: in-flight provision already exists for tenant")
+
+// CreateProvisionIfAbsent inserts a provision iff no in-flight provision exists
+// for the same tenant. Returns ErrProvisionExists when the partial unique index
+// (EnsureProvisionIndexes) rejects the insert (the first writer wins). This is
+// the create-path twin of CreateJobIfAbsent (#71) and the load-bearing fix for
+// the stranger-redeem self-race (#3744): whichever of the two checkout triggers
+// arrives second collides here and becomes a no-op instead of forking a second
+// workflow.
+func (s *Store) CreateProvisionIfAbsent(ctx context.Context, p *Provision) error {
+	if p.TenantID == "" {
+		return fmt.Errorf("store: CreateProvisionIfAbsent requires TenantID")
+	}
+	if p.ID == "" {
+		p.ID = uuid.New().String()
+	}
+	now := time.Now().UTC()
+	p.CreatedAt = now
+	p.UpdatedAt = now
+	_, err := s.provisions().InsertOne(ctx, p)
+	if err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			return ErrProvisionExists
+		}
+		return fmt.Errorf("store: create provision if absent: %w", err)
+	}
+	return nil
+}
+
+// GetInFlightProvisionByTenant returns the most-recent in-flight provision for
+// a tenant, or (nil, nil) if none exists. Used by the dedup path to surface the
+// already-running provision to the loser of a CreateProvisionIfAbsent collision.
+func (s *Store) GetInFlightProvisionByTenant(ctx context.Context, tenantID string) (*Provision, error) {
+	var p Provision
+	filter := bson.D{
+		{Key: "tenant_id", Value: tenantID},
+		{Key: "status", Value: bson.D{{Key: "$in", Value: inFlightProvisionStatuses}}},
+	}
+	opts := options.FindOne().SetSort(bson.D{{Key: "created_at", Value: -1}})
+	err := s.provisions().FindOne(ctx, filter, opts).Decode(&p)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("store: get in-flight provision by tenant %s: %w", tenantID, err)
+	}
+	return &p, nil
+}
+
 // GetProvision returns a provision by ID.
 func (s *Store) GetProvision(ctx context.Context, id string) (*Provision, error) {
 	var p Provision


### PR DESCRIPTION
## What

A credit-covered marketplace redeem (the stranger-voucher funnel) fires the provision-create entrypoint **twice** — NATS `order.placed` event **and** `POST /provisioning/start` (the checkout client does both deliberately, comment: *"broker event is best-effort"*). `startProvisioning` unconditionally inserted a provision + forked a workflow, so both calls produced two near-simultaneous Gitea commits to the shared `sme-tenants` branch → a ref-lock race (`HTTP 500 PushRejected ... cannot lock ref ... failed to update ref`). The loser marked the **tenant `failed`** even though the Organization CR + the winning commit both landed.

**Seen live on hw158** during the TC-01 funnel walk: stranger `walkstranger@omani.homes` redeemed voucher `VCH-56T66GFC2BNC`, minting Organization `walk-stranger-co` — but provisions `2a352462` (OK) / `8bceaadf` (failed: `cannot lock ref 'refs/heads/sme-tenants'`) raced.

## Fix (mirrors the proven #71 day-2 Job dedup)

**1. PRIMARY — idempotency guard on the create path:**
- `store.CreateProvisionIfAbsent` + `EnsureProvisionIndexes` — a **partial** unique index on `tenant_id` filtered to in-flight statuses `{pending,provisioning,running}` (so a tenant can still be re-provisioned after a prior provision terminates) + `GetInFlightProvisionByTenant` + `ErrProvisionExists` sentinel.
- `startProvisioning` now uses `CreateProvisionIfAbsent`; on `ErrProvisionExists` it returns the already-running provision **without forking a second workflow** (mirrors `runInstallJob`). Both triggers share the entrypoint, so both inherit the guard. `Start` still returns 201 with the existing provision, which the client already tolerates.
- `main.go` calls `EnsureProvisionIndexes` at startup next to `EnsureJobIndexes`.

**2. SECONDARY — widen `isGiteaRefRaceError`** to match Gitea's real wording (`cannot lock ref`, `failed to update ref`, `PushRejected`, `but expected`), so the existing 5-attempt rebuild-against-fresh-HEAD loop self-heals a genuine *cross-tenant* concurrent commit instead of classifying it fatal on attempt 1 (it previously only matched `409` / `not a fast forward`, while Gitea returns **500** here).

## Tests
`client_refrace_test.go` locks the matcher against the verbatim hw158 500 body + a regression matrix (pre-existing signals still match; 401/404/422-malformed stay fatal). `go build` + `go vet` + `go test ./...` all green for the provisioning module.

## Acceptance
A credit-covered stranger redeem produces exactly ONE provision per tenant; the tenant is never marked `failed` due to a self-race. To verify on a fresh prov: redeem a voucher end-to-end, then `kubectl get organizations` non-zero + exactly one provision row for the tenant + tenant not `failed`.

Refs #3744
Refs #3376

🤖 Generated with [Claude Code](https://claude.com/claude-code)