### PR TITLE
fix(bp-keycloak): publish 1.4.30 — align tier2 test with the pdns-admin /oauth2/callback realm fix

### DIFF
--- a/platform/keycloak/chart/tests/g117-5-tier2-sso-clients.sh
+++ b/platform/keycloak/chart/tests/g117-5-tier2-sso-clients.sh
@@ -79,8 +79,11 @@ for c in d.get('clients', []):
   fi
 }
 check_redirect guacamole      "https://guacamole.${SOV_FQDN}/*"
-check_redirect powerdns-admin "https://pdns-admin.${SOV_FQDN}/oidc/authorized"
-check_redirect powerdns-admin "https://pdns-admin.${SOV_FQDN}/*"
+# 1.4.30 (#3741/#3743): powerdns-admin is gate-fronted by the bp-oidc-gate
+# oauth2-proxy, so its ONLY valid redirectUri is /oauth2/callback (the dead
+# pre-#3374 native /oidc/authorized + /* shape was removed from the realm
+# seed). Mirror the hubble-ui gated precedent below.
+check_redirect powerdns-admin "https://pdns-admin.${SOV_FQDN}/oauth2/callback"
 check_redirect hubble-ui      "https://hubble.${SOV_FQDN}/oauth2/callback"
 echo "  PASS"
 


### PR DESCRIPTION
## Why
`bp-keycloak:1.4.30` (the #3743 pdns-admin realm fix) **never published to ghcr** — the blueprint-release run for `6f6b58531` **failed** at *Run chart integration tests*, so `helm push` never ran. Every Sovereign pinning 1.4.30 (hw158) then wedged its keycloak HR (`oci://ghcr.io/openova-io/bp-keycloak:1.4.30: not found`), cascading `dependency not ready` to gitea/grafana/guacamole/newapi/oidc-gate/sso-bridge/cutover/continuum (~16 HRs, substrate degraded to 49/64).

## Root cause
The 1.4.30 realm fix narrowed `powerdns-admin` redirectUris to the single gate-fronted `/oauth2/callback`, but `g117-5-tier2-sso-clients.sh:82-83` still asserted the removed `/oidc/authorized` + `/*` shape → test fail → no publish.

## Fix
Align the test assertion with the corrected realm (mirrors the hubble-ui gated precedent). On merge, blueprint-release re-fires on the keycloak chart path → test passes → **1.4.30 publishes** → hw158's already-waiting HR auto-pulls it → keycloak/gitea/cutover spine un-wedges live.

Surfaced by the live hw158 UAT walk (#3374 SSO + #3379 cutover walkers both root-caused this independently).

Refs #3743 #3374 #3379