### PR TITLE
fix(bp-keycloak): trim pdns-admin description ≤255 — unblock the 1.4.30 publish

### DIFF
--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -829,7 +829,7 @@ data:
         {
           "clientId": "powerdns-admin",
           "name": "PowerDNS-Admin (Tier-2 silent-SSO)",
-          "description": "#3741 — DNS UI silent-SSO via catalyst-pin broker, fronted by the bp-oidc-gate oauth2-proxy. The gate sends redirect_uri=https://pdns-admin.<fqdn>/oauth2/callback and (keycloak-oidc provider) verifies the ID-token aud contains powerdns-admin — hence the /oauth2/callback redirectUri + the oidc-audience-mapper below, matching the gate's own AppRegistration (platform/oidc-gate/chart/templates/instances.yaml) so config-cli's FULL-managed reconcile keeps the client correct rather than reverting to the dead pre-#3374 native /oidc/authorized shape.",
+          "description": "#3741 — DNS UI silent-SSO, gate-fronted by bp-oidc-gate oauth2-proxy: /oauth2/callback redirectUri + oidc-audience-mapper (aud=powerdns-admin) matching the gate AppRegistration, so config-cli FULL-managed reconcile keeps the client correct.",
           "enabled": true,
           "publicClient": false,
           "standardFlowEnabled": true,


### PR DESCRIPTION
Second latent failure in the bp-keycloak 1.4.30 publish chain. After #3750 fixed the tier2 redirect assertion, the next gate — `g117-e2e-realm-client-description-255-cap.sh` — failed: the #3743 realm fix gave powerdns-admin a **549-char description** vs keycloak's **varchar(255)** cap, so `helm push` still never ran and 1.4.30 stayed unpublished (hw158 keycloak HR wedged, cascading ~16 HRs).

Trimmed to **242 chars** (essential meaning kept). **All 12 chart tests pass locally.** On merge → blueprint-release publishes 1.4.30 → hw158 auto-pulls → spine un-wedges.

Refs #3743 #3374 #3379