### PR TITLE
docs(#3642): NS#1 host→vCluster secret-crossing blocker — all 7 apps blocked, no safe flip

### DIFF
--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -207,16 +207,20 @@ spec:
     #    stack (a SOVEREIGNTY decision, NOT an unfinished task) ──────────
     #
     # The rows below carry `target != host` (founder §4 wants them in a
-    # vCluster). #3642 lands the OSS-native HOST-BRIDGE (see RESOLUTION
-    # below) and MOVES keycloak (09) + grafana (25) into the mgmt vCluster
-    # — those two now carry `vcluster: mgmt` with a `hostBridge:` block.
-    # The remaining route/secret/CNPG rows are host-bridge-READY follow-ons
-    # (same one-field flip + `hostBridge:` declaration). This was NEVER a
-    # license requirement; the host-bridge keeps the route/secret/CNPG CRs
-    # host-rendered. (Migration plan: docs/sessions/2026-06-14/
-    # 3373-migration-plan.md §0/§4/§6; host-bridge: #3642.)
+    # vCluster). All 7 named NS#1 apps (keycloak/grafana/harbor/gitea/
+    # openbao/newapi/guacamole) currently read `vcluster: host` — NONE has
+    # cleanly moved. #3642 designed the OSS-native HOST-BRIDGE (see RESOLUTION
+    # below) and #3703 briefly flipped keycloak (09) + grafana (25) to
+    # `vcluster: mgmt` with a `hostBridge:` block — but BOTH were REVERTED:
+    # grafana by #3731 (raw-ExternalSecret dry-run deadlock in the monolithic
+    # Kustomization) and keycloak by #3737 (the reflected DB Secret can't
+    # cross host→vCluster on OSS vcluster 0.21.0). (Migration plan:
+    # docs/sessions/2026-06-14/3373-migration-plan.md §0/§4/§6; host-bridge:
+    # #3642. Honest per-app status: the SECOND CONSTRAINT block below + the
+    # #3642 UAT walkthrough docs/ledger/uat-walkthrough/ns1-migrate-7-host-
+    # apps-into-mgmt-vcluster.md.)
     #
-    # THE GOVERNING CONSTRAINT — vCluster CRD-sync is loft.sh Free-tier,
+    # GOVERNING CONSTRAINT #1 — vCluster CRD-sync is loft.sh Free-tier,
     # NOT pure-OSS:
     #   Re-homing a chart that ships an HTTPRoute, an ExternalSecret, or a
     #   CNPG `Cluster` CR requires the vCluster syncer to register those
@@ -249,30 +253,72 @@ spec:
     #   platform/install/air-gapped. The Free-tier CRD-sync feature has NO
     #   offline activation path that is sovereignty-safe.)
     #
-    # RESOLUTION — the HOST-BRIDGE (#3642, plan path (B)) is the OSS-native
-    # answer that does NOT need the loft.sh license: it keeps the app's
-    # HTTPRoute + ExternalSecret (+ CNPG Cluster) HOST-rendered — declared
-    # as data under the row's `hostBridge:` and transcribed into the slot by
-    # render-slot-placement.py — while only the workload Deployment/
-    # StatefulSet re-homes into the vCluster (spec.kubeConfig → vc-<tier>).
-    # backendRefs point at the OSS-synced mangled Service
-    # (<svc>-x-<innerNs>-x-<tier>-vcluster). So the §4 target is NO LONGER
-    # aspirational for route/secret apps — it is a one-field flip + a
-    # `hostBridge:` declaration. The 3 clean apps (valkey/seaweedfs/vllm)
-    # moved in Batch A; #3642 lands the host-bridge and MOVES the
-    # route/secret class. Status of the North-Star-#1 set, grouped by shape:
+    # GOVERNING CONSTRAINT #2 — a host-rendered Secret CANNOT cross
+    # host→vCluster on OSS vcluster 0.21.0 (the deeper blocker the
+    # host-bridge alone does NOT solve; #3731 + #3737, re-confirmed by the
+    # #3642 chart audit 2026-06-17):
+    #   The host-bridge (Constraint-#1 answer) keeps the HTTPRoute /
+    #   ExternalSecret / CNPG `Cluster` CR HOST-rendered — but every one of
+    #   the 7 NS#1 apps' WORKLOAD Pods then needs a Secret that is MINTED ON
+    #   THE HOST delivered INTO the vCluster: a CNPG-operator DB credential
+    #   (`<app>-pg-app`, reflected/sync-jobbed into `<app>-database-secret`),
+    #   and/or a host-ESO SSO Secret (`<app>-sso-oidc-credentials`). NO OSS
+    #   0.21.0 mechanism delivers it:
+    #     - `sync.fromHost.secrets` (host→vCluster Secret mirror) does NOT
+    #       exist until vcluster 0.23.0 — 0.21.0 rejects the unknown config
+    #       key at parse, breaking the syncer.
+    #     - an in-vCluster ExternalSecret cannot reconcile: ESO is a
+    #       host-minimum substrate (slot 15, host), and toHost custom-
+    #       resource sync is Pro-gated/inert on OSS.
+    #   So the re-homed Pod hangs on `MountVolume.SetUp … secret "<name>" not
+    #   found` (keycloak-0 SHARED_PG, #3737) or boots without its SSO/DB
+    #   env (grafana zero-click never lands; harbor/gitea/newapi DB DSN
+    #   empty). This is INDEPENDENT of Constraint-#1 — even with a perfect
+    #   host-bridge, Constraint-#2 wedges the workload.
     #
-    #   ROUTE + ExternalSecret — host-bridge MOVED (#3642):
-    #     ✅ keycloak (09, route-only — no ES, bundled PG in-vCluster),
-    #     ✅ grafana  (25, route + SSO ExternalSecret, shared-pg-b consumer).
-    #   ROUTE + ExternalSecret — host-bridge READY (same recipe, follow-on
-    #   rows; openbao adds a 2-backend bare-URL landing route):
-    #     openbao (08), powerdns-admin (11a), openova-flow-server (56).
-    #   ROUTE + ExternalSecret + CNPG `Cluster` — host-bridge + the CNPG
-    #   Cluster rendered host-side (§5d); the in-vCluster Pod reaches the
-    #   host PG cross-cluster (follow-on rows):
-    #     gitea (10), harbor (19), newapi (80), guacamole (52),
-    #     catalyst-platform (13, control-plane root — LAST).
+    # SECOND STRUCTURAL constraint on two of the seven (host-pinned by ROLE,
+    # not just by Secret-crossing):
+    #   - openbao (08) IS the host-side ESO backend — the `vault-region1`
+    #     ClusterSecretStore (slot 15a, host-minimum) dials it. Move openbao
+    #     into a vCluster and EVERY host ExternalSecret cluster-wide loses
+    #     its backend. openbao must stay host irrespective of #2.
+    #   - keycloak (09) is the SSO root 8 other HRs' `*-sso-oidc-credentials`
+    #     ExternalSecrets seed from; if its OIDC seed lands inside the
+    #     vCluster the host-side ESO consumers can't reach it (the #3737
+    #     terminal cascade).
+    #
+    # RESOLUTION — the HOST-BRIDGE (#3642, plan path (B)) solves
+    # Constraint-#1 (it keeps the app's HTTPRoute + ExternalSecret + CNPG
+    # Cluster HOST-rendered, declared as data under the row's `hostBridge:`
+    # and transcribed into the slot by render-slot-placement.py; only the
+    # workload Deployment/StatefulSet re-homes via spec.kubeConfig →
+    # vc-<tier>, backendRefs at the OSS-synced mangled Service
+    # <svc>-x-<innerNs>-x-<tier>-vcluster). It does NOT, on its own, solve
+    # Constraint-#2 — so NO route/secret/CNPG app can flip yet. The full
+    # NS#1 move additionally needs the `sync.fromHost.secrets` host→vCluster
+    # Secret delivery (vcluster ≥0.23.0, OSS from 0.23.0 — genuinely not
+    # Pro-gated) for the DB + SSO Secrets, plus (for the raw-ExternalSecret
+    # apps) the ExternalSecret lifted OUT of the atomic bootstrap-kit
+    # Kustomization (#3731). That work is the PARKED #3719 (DO-NOT-MERGE)
+    # train. The 3 truly clean apps (valkey/seaweedfs/vllm — no route, no
+    # secret, no CNPG) ALREADY moved in Batch A. Status of the North-Star-#1
+    # set, grouped by what blocks each (ALL 7 currently `vcluster: host`):
+    #
+    #   ROUTE + host-ESO SSO Secret — BLOCKED on Constraint-#2 (workload
+    #   consumes a host-ESO `<app>-sso-oidc-credentials`); needs fromHost
+    #   secret-sync + (for the raw ES) the #3731 Kustomization split:
+    #     grafana (25, reverted #3731), openbao (08, ALSO host-pinned —
+    #     it IS the ESO backend), powerdns-admin (11a),
+    #     openova-flow-server (56).
+    #   ROUTE + reflected/SHARED_PG DB Secret — BLOCKED on Constraint-#2
+    #   (workload mounts a host-reflected DB credential):
+    #     keycloak (09, reverted #3737 — clean only on the DEFAULT prov;
+    #     wedges on SOVEREIGN_ENABLE_SHARED_PG=true; ALSO the SSO root).
+    #   ROUTE + host-ESO SSO + CNPG `Cluster` — BLOCKED on Constraint-#2 on
+    #   TWO axes (host-CNPG DB credential AND host-ESO SSO Secret); the
+    #   in-vCluster Pod would also need the host PG reachable cross-cluster:
+    #     gitea (10), harbor (19), newapi (80), guacamole (52, DB-only —
+    #     OIDC is chart-self-contained), catalyst-platform (13, root — LAST).
     #   CNPG `Cluster` CR engines (host cnpg-operator reconciles host-side) —
     #   host-bridge the Cluster CR (follow-on) — 4:
     #     postgres-shared (×3: 16a/16c/16d) + cnpg-pair (16b).

--- a/docs/ledger/uat-walkthrough/ns1-migrate-7-host-apps-into-mgmt-vcluster.md
+++ b/docs/ledger/uat-walkthrough/ns1-migrate-7-host-apps-into-mgmt-vcluster.md
@@ -273,3 +273,77 @@ count = 0 for all 7, placement.yaml still `vcluster: host`) does not require a b
 conclusive: **the 7 apps are NOT in the mgmt vCluster on hw158.** Automated checks are appendix only,
 demoted per the UAT format law — and the placement-conformance audit's exit-0 is the masking trap, NOT
 a migration proof.
+
+---
+
+## WHY the flip was never done — the two governing constraints (root-cause, #3642 chart audit 2026-06-17)
+
+The walk above proves the flip *didn't happen*; this section is the *why* and the *unblock path*.
+The canonical write-up is the §4 exception block in
+`clusters/_template/bootstrap-kit/placement.yaml`. There are TWO independent blockers, and the
+host-bridge (#3642) only solves the first.
+
+### Constraint #1 — vCluster CRD-sync is loft.sh Free-tier, not pure-OSS
+Re-homing a chart that ships an HTTPRoute / ExternalSecret / CNPG `Cluster` CR needs the syncer to
+register those CRDs in the vCluster and mirror the CRs `toHost` so the host Cilium Gateway / ESO /
+cnpg-operator (host-minimum substrate) reconcile them. `sync.toHost.customResources` is a **Free-tier**
+feature needing a permanent `admin.loft.sh` tether — forbidden by the Pillar-5 600s deny-egress hold.
+The **HOST-BRIDGE (#3642)** answers this: keep the route/secret/CNPG CR HOST-rendered (declared as
+`hostBridge:` data, transcribed by `render-slot-placement.py`), re-home only the workload pod.
+
+### Constraint #2 — a host-rendered Secret can't cross host→vCluster on OSS vcluster 0.21.0
+The deeper blocker the host-bridge alone does NOT solve, and the actual reason both prior flips were
+reverted. Every one of the 7 apps' workload pods needs a Secret **minted on the host** delivered
+**into** the vCluster — a CNPG-operator DB credential and/or a host-ESO SSO Secret. No OSS 0.21.0
+mechanism delivers it:
+- `sync.fromHost.secrets` (host→vCluster Secret mirror) **does not exist until vcluster 0.23.0**
+  (0.21.0 rejects the unknown config key at parse, breaking the syncer).
+- an in-vCluster `ExternalSecret` can't reconcile — ESO is a host-minimum substrate (slot 15),
+  `toHost` CR sync is Pro-gated/inert on OSS.
+
+So a re-homed pod hangs on `MountVolume.SetUp … secret "<name>" not found` (keycloak-0 SHARED_PG,
+**#3737**) or boots without its SSO/DB env (grafana zero-click never lands, **#3731**;
+harbor/gitea/newapi DB DSN empty). This is INDEPENDENT of Constraint-#1 — even a perfect host-bridge
+leaves Constraint-#2 wedging the workload.
+
+### Per-app blocker matrix (chart audit, file:line in the slot/chart)
+
+| App (slot) | Host-produced Secret the workload consumes | Producer (host-side) | Extra |
+|---|---|---|---|
+| keycloak (09) | `keycloak-database-secret` (SHARED_PG mode only) | reflector ← slot-16a shared-data | Also **SSO seed root** for 8 HRs; clean only on the DEFAULT prov |
+| grafana (25) | `grafana-sso-oidc-credentials` (env `GF_AUTH_GENERIC_OAUTH_*`) | host ESO `vault-region1` | Raw ES also trips the #3731 dry-run deadlock if host-bridged unguarded |
+| openbao (08) | `openbao-sso-oidc-credentials` (mounted `/etc/sso-creds`) | host ESO `vault-region1` | Also **IS** the ESO backend (`vault-region1` ClusterSecretStore) → host-pinned by role |
+| harbor (19) | `harbor-database-secret` + `harbor-sso-oidc-credentials` | reflector ← CNPG `harbor-pg-app`; host ESO | CNPG `Cluster` CR rendered by chart |
+| gitea (10) | `gitea-database-secret` + `gitea-oauth-source-credentials` (+ S3) | reflector ← CNPG `gitea-pg-app`; host ESO; seaweedfs reflector | CNPG `Cluster` CR rendered by chart |
+| newapi (80) | `<release>-newapi-db-dsn` (`SQL_DSN`) | sync-job ← CNPG `<cluster>-app` | OIDC/session secrets ARE chart-self-contained; DB DSN is the blocker |
+| guacamole (52) | `guacamole-pg-app` (`POSTGRESQL_PASSWORD`, mounted directly) | host cnpg-operator | OIDC IS chart-self-contained (`lookup`-or-generate); DB is the blocker |
+
+Two apps are host-pinned **structurally** beyond Constraint-#2: **openbao** (it IS the host ESO
+backend) and **keycloak** (it IS the SSO seed root every other app's OIDC ExternalSecret reads).
+
+### Can any of the 7 flip SAFELY now? — No.
+Evaluated all 7 against "does the workload consume a host-produced Secret that must cross the
+boundary?" — **all 7 = yes**. There is **no safe partial flip**; flipping any reproduces the exact
+#3737/#3731 terminal wedge. The 3 truly clean apps (valkey/seaweedfs/vllm — no route, no secret, no
+CNPG) already moved in Batch A.
+
+## The actual #3642 hard part — unblock checklist (the PARKED #3719 train)
+
+- [ ] **Bump vcluster to ≥0.23.0** in the bp-{mgmt,rtz,dmz}-vcluster merged charts so
+      `sync.fromHost.secrets` exists (genuine OSS from 0.23.0, not Pro-gated). Re-validate the
+      existing syncer features (Service sync, init-manifests CRD deploy) survive the bump.
+- [ ] **Map each app's host-produced Secret host→vCluster** via `sync.fromHost.secrets`:
+      `<app>-database-secret`, `<app>-sso-oidc-credentials`, and (newapi) `<release>-newapi-db-dsn`.
+- [ ] **Lift the raw `ExternalSecret` OUT of the atomic bootstrap-kit Flux Kustomization** for the
+      route+SSO apps (#3731): a separate Flux Kustomization that `dependsOn` slot-15 bp-external-
+      secrets, OR an early-slot raw-CRD pre-install for `external-secrets.io` (mirroring how
+      cloud-init pre-applies the gateway-api CRDs). Do NOT replace the chart's `.Capabilities`-guarded
+      ES with an unguarded raw copy inside the monolithic Kustomization.
+- [ ] **CNPG class only** — host-render the `Cluster` CR (§5d) and wire the in-vCluster pod to the
+      host PostgreSQL **cross-cluster** (the host cnpg-operator can't see a CR inside the vCluster on
+      OSS): the pod dials `<pg-svc>-x-shared-data-x-mgmt-vcluster` (or the host PG Service).
+- [ ] **Keep openbao + keycloak host** (structural): openbao IS the ESO backend; keycloak IS the SSO
+      seed root. Re-evaluate only if the ESO `ClusterSecretStore` can target an in-vCluster Vault and
+      the OIDC seed can be consumed by host-side ExternalSecrets cross-cluster — both impossible on OSS.
+- [ ] **Then** flip each app one-field (`vcluster: host → mgmt`) + add its `hostBridge:` block,
+      `render-slot-placement.py fix`, and walk PART A–E above per app on a fresh zero-touch prov.


### PR DESCRIPTION
**Refs #3642** (does NOT close — this is the diagnosis + safe-flip evaluation; the move itself is the parked #3719 train).

## What the #3642 walker found
The 7 named apps (grafana/harbor/keycloak/gitea/openbao/newapi/guacamole) are supposed to be migrated INTO the mgmt vCluster, but their `placement.yaml` rows still read `vcluster: host`. mgmt holds only loki/mimir/tempo/nats. The `host→mgmt` flip was never done.

## What I did
Investigated whether ANY of the 7 can flip `host → mgmt` SAFELY now, vs which are blocked by the secret-crossing constraint (#3737/#3731). **A full chart audit confirms: all 7 are blocked. There is no safe partial flip.** So this PR flips **nothing** and ships the honest diagnosis + the concrete fix checklist — a partial flip would reproduce the exact #3737/#3731 terminal wedge.

## The unified blocker — GOVERNING CONSTRAINT #2 (the deeper one the host-bridge does NOT solve)
The host-bridge (#3642) solves Constraint-#1 (loft.sh Free-tier CRD-sync) by keeping the HTTPRoute / ExternalSecret / CNPG `Cluster` CR host-rendered. But every one of the 7 apps' **workload Pods** then needs a Secret **minted on the host** delivered **into** the vCluster — and no OSS vcluster 0.21.0 mechanism does that:
- `sync.fromHost.secrets` (host→vCluster Secret mirror) **does not exist until vcluster 0.23.0** (0.21.0 rejects the unknown config key at parse).
- an in-vCluster `ExternalSecret` can't reconcile — ESO is a host-minimum substrate (slot 15), `toHost` CR sync is Pro-gated/inert on OSS.

So the re-homed Pod hangs on `MountVolume.SetUp … secret "<name>" not found` (keycloak-0 SHARED_PG, #3737) or boots without its SSO/DB env (grafana zero-click never lands; harbor/gitea/newapi DB DSN empty). **This is exactly why both prior flips were reverted** (grafana #3731, keycloak #3737).

## Per-app verdict (chart audit, file:line in the slot comments)
| App | Blocked by | Host-produced Secret the workload consumes |
|---|---|---|
| keycloak (09) | Secret-crossing + **SSO seed root** | `keycloak-database-secret` (reflector, SHARED_PG mode); clean only on DEFAULT prov |
| grafana (25) | Secret-crossing (+ #3731 dry-run) | `grafana-sso-oidc-credentials` (host ESO, env `GF_AUTH_GENERIC_OAUTH_*`) |
| openbao (08) | Secret-crossing + **IS the ESO backend** | `openbao-sso-oidc-credentials` (host ESO); `vault-region1` ClusterSecretStore dials openbao |
| harbor (19) | Secret-crossing ×2 | `harbor-database-secret` (reflector←CNPG) + `harbor-sso-oidc-credentials` (host ESO) |
| gitea (10) | Secret-crossing ×2 | `gitea-database-secret` (reflector←CNPG) + `gitea-oauth-source-credentials` (host ESO) |
| newapi (80) | Secret-crossing | `<release>-newapi-db-dsn` (sync-job←CNPG); OIDC/session secrets ARE chart-self-contained |
| guacamole (52) | Secret-crossing | `guacamole-pg-app` (host cnpg-operator, mounted directly); OIDC IS chart-self-contained |

**openbao** and **keycloak** are additionally host-pinned **structurally** (openbao IS the host ESO backend; keycloak IS the SSO seed root 8 other HRs read from) — they can't move even when Constraint-#2 is fixed, without further work.

## The actual #3642 hard part — fix checklist (parked #3719)
- [ ] Bump vcluster to **≥0.23.0** so `sync.fromHost.secrets` exists (genuine OSS from 0.23.0).
- [ ] Map each app's host-produced Secret host→vCluster via `sync.fromHost.secrets` (DB + SSO).
- [ ] Lift the raw `ExternalSecret` OUT of the atomic bootstrap-kit Kustomization (#3731 dry-run deadlock) — separate Flux Kustomization dependsOn ESO, or an early-slot raw-CRD pre-install.
- [ ] CNPG class: host-render the `Cluster` CR + wire the in-vCluster Pod to the host PostgreSQL cross-cluster.
- [ ] Keep openbao + keycloak host (structural).

## Changes (2 files, comment + doc only — ZERO slot files)
- `clusters/_template/bootstrap-kit/placement.yaml` §4: corrected the stale "✅ keycloak/grafana MOVED (#3642)" claims (both reverted), added GOVERNING CONSTRAINT #2 (secret-crossing) + the host-pinned-by-role note + the per-app blocker grouping. **Comment-only — zero slot drift.**
- `docs/ledger/uat-walkthrough/ns1-migrate-7-host-apps-into-mgmt-vcluster.md`: rewritten from the optimistic "MOVED this PR" plan to honest ground reality (all 7 host, BLOCKED) + per-app blocker matrix + unblock checklist. Re-stamped to hw158.

## Gates (all green)
- `render-slot-placement.py check` — PASSED, **0 drift** (64 slots, 9 in vClusters)
- `check-bootstrap-deps.sh` — drift 0, cycles 0
- `audit-placement-conformance.py rendered` — PASSED
- `render_slot_placement_hostbridge_test.py` — PASSED
- `kubectl kustomize` bootstrap-kit — 158 docs, valid
- Zero slot `.yaml` files touched (byte-identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)