### PR TITLE
fix(org-controller): per-Org vCluster repo clone authenticates — default fluxGiteaSecretRef (Refs #3687 #3376)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,22 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.663 — #3687 / #3376 (2026-06-17): per-Org vCluster repo clone now
+# AUTHENTICATES — default controllers.organization.fluxGiteaSecretRef to
+# `openova-sme-tenants-git-auth`. PR #3718 wired the per-Org Flux loop
+# (org-controller reconcilePerOrgFlux → catalyst-tenant-<slug> GitRepository
+# → ./vcluster Kustomization → vCluster HelmRelease) but left the secretRef
+# default empty. The per-Org `<slug>/catalyst-tenant` repo is private
+# (EnsureOrg/EnsureRepo private=true) AND bp-gitea sets REQUIRE_SIGNIN_VIEW
+# =true, so the source-controller's anonymous clone 401'd → Kustomization
+# "Source artifact not found" → the committed vCluster HR never reconciled →
+# the tenant namespace + purchased app (WordPress) never came up → the
+# funnel's terminal acceptance failed (proven live hw158 by the #3687/#3376
+# walkers). `openova-sme-tenants-git-auth` holds the gitea_admin PAT (clones
+# every Org's private repo) and is guaranteed in flux-system by the
+# sme-tenants auth-secret template + #3749's gitea-flux-auth-secrets-sync-job
+# (the deterministic runtime creator). Catalyst-Zero render byte-unchanged
+# (the value only reaches the org-controller env, which is sovereign-only).
+# Refs #3687 #3376.
 # 1.4.654 — #3376 FUNNEL (voucher→running-app) — three folded fixes so a
 # stranger with a voucher ends signed-in in their own Org console with the
 # app running, on a cut-over Sovereign, zero-touch:
@@ -2735,7 +2752,7 @@ name: bp-catalyst-platform
 # (qaFixtures.cnpgBackupEndpointURL + cnpg-clusters-qa.yaml) to the
 # syncer-mangled host Service name. qa-fixtures only; Catalyst-Zero render
 # byte-unchanged. (1.4.622 was a content-free deploy-bot image sweep.)
-version: 1.4.662
+version: 1.4.663
 # 1.4.657 — PR #3700 §4.3 (Refs #3687, 2026-06-17): close the per-Org
 # vCluster Flux loop — the deferred half of the object-model-LIVE master.
 # The organization-controller already PUT the vCluster Namespace + HelmRelease

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -497,10 +497,41 @@ controllers:
     # = 60s default.
     fluxIntervalSeconds: ""
     # Name of a Flux basic-auth Secret (in fluxNamespace) holding the Gitea
-    # PAT the per-Org GitRepository clones with — bp-gitea
-    # REQUIRE_SIGNIN_VIEW=true makes anonymous clone 401. Empty = anonymous
-    # (parity with controllers.application.fluxGiteaSecretRef).
-    fluxGiteaSecretRef: ""
+    # PAT the per-Org GitRepository clones with.
+    #
+    # WHY THIS IS NON-EMPTY BY DEFAULT (#3687 / #3376 — hw158 funnel blocker)
+    # ---------------------------------------------------------------------
+    # The per-Org `<slug>/catalyst-tenant` repo the org-controller creates is
+    # ALWAYS private (organization_controller.go EnsureOrg/EnsureRepo pass
+    # private=true), and bp-gitea additionally sets REQUIRE_SIGNIN_VIEW=true —
+    # so an anonymous git clone returns 401 "authentication required". With an
+    # empty secretRef the per-Org GitRepository (catalyst-tenant-<slug>,
+    # per_org_flux.go) carries NO `spec.secretRef`, source-controller clones
+    # anonymously, Gitea 401s, the catalyst-tenant-<slug>-vcluster
+    # Kustomization reports "Source artifact not found", the committed vCluster
+    # HelmRelease never reconciles, and the tenant namespace + purchased app
+    # (e.g. WordPress) never come up — the funnel's terminal acceptance fails
+    # (proven live on hw158 by the #3687 + #3376 walkers).
+    #
+    # `openova-sme-tenants-git-auth` is a Flux basic-auth Secret in flux-system
+    # holding the `gitea_admin` PAT (sourced from catalyst-gitea-token). Because
+    # gitea_admin is the Gitea admin it can clone EVERY Org's private
+    # catalyst-tenant repo, so this single shared secret authenticates the
+    # per-Org GitRepository for all Organizations — no per-Org secret needed.
+    # It is the exact credential the top-level openova-sme-tenants
+    # GitRepository already clones with successfully on every Sovereign (the
+    # proven #3454 pattern). The Secret is guaranteed to exist in flux-system
+    # by the catalog-sovereign-flux/gitea-flux-auth-secrets-sync-job.yaml
+    # post-install/post-upgrade hook (#3749 / #3668), which reads the
+    # runtime-minted catalyst-gitea-token PAT via secretKeyRef (NOT a render-
+    # time `lookup`) and idempotently applies BOTH openova-sme-tenants-git-auth
+    # and openova-catalog-sovereign-git-auth — so a fresh prov gets it the
+    # first time and any chart bump re-asserts it. The PAT never touches argv.
+    #
+    # Per Inviolable Principle #4 the secret name stays operator-overridable;
+    # set to "" to force anonymous clone (only valid if bp-gitea ever drops
+    # REQUIRE_SIGNIN_VIEW AND the per-Org repo is made public).
+    fluxGiteaSecretRef: "openova-sme-tenants-git-auth"
     # Free-form extra env vars threaded into the Pod (advanced; for one-off
     # operator-side knobs not yet promoted to a top-level value).
     env: {}


### PR DESCRIPTION
## The funnel terminal blocker (hw158)

When a customer redeems a voucher, the org-controller provisions a tenant Organization and (since PR #3718) creates a per-Org Flux `GitRepository` (`catalyst-tenant-<slug>`) pointing at the tenant's Gitea repo `<slug>/catalyst-tenant`, plus a Kustomization that reconciles its `./vcluster` tree onto the host cluster. **But the GitRepository clones anonymously and 401s** → the committed vCluster `HelmRelease` never reconciles → the tenant namespace + purchased app (WordPress) never come up → the funnel's terminal acceptance fails. Pinpointed live on hw158 by the #3687 + #3376 walkers.

## Root cause

`reconcilePerOrgFlux` (`core/controllers/organization/internal/controller/per_org_flux.go:185-187`) only stamps `spec.secretRef` when `r.FluxGiteaSecretRef` is non-empty:

```go
if s := strings.TrimSpace(r.FluxGiteaSecretRef); s != "" {
    grSpec["secretRef"] = map[string]any{"name": s}
}
```

The per-Org `<slug>/catalyst-tenant` repo is **always private** — `organization_controller.go` `EnsureOrg` (`"private"`) + `EnsureRepo(..., true)` both force private — **and** bp-gitea sets `service.REQUIRE_SIGNIN_VIEW=true`, so an anonymous git clone returns `401 authentication required`. The full chart→runtime chain was already wired by #3718:

`controllers.organization.fluxGiteaSecretRef` → deployment env `CATALYST_FLUX_GITEA_SECRET_REF` → `cmd/main.go:97` `envOr("CATALYST_FLUX_GITEA_SECRET_REF", "")` → `Reconciler.FluxGiteaSecretRef` → `per_org_flux.go` `secretRef`.

…but the **chart default was `""`** and no overlay set it → no `secretRef` → 401 → Kustomization `Source artifact not found` → vCluster HR never reconciles.

## Fix

Default `controllers.organization.fluxGiteaSecretRef` to **`openova-sme-tenants-git-auth`** (`products/catalyst/chart/values.yaml`).

- It is the flux-system Flux basic-auth Secret holding the **`gitea_admin`** PAT (sourced from `catalyst-gitea-token`). Because `gitea_admin` is the Gitea admin it can clone **every** Org's private `catalyst-tenant` repo → one shared secret authenticates the per-Org GitRepository for all Organizations (no per-Org secret needed).
- It is the **exact credential the top-level `openova-sme-tenants` GitRepository already clones with** (#3454, proven on every Sovereign).
- It is **guaranteed to exist in flux-system** by:
  1. `templates/sme-services/sme-tenants-gitrepo-auth-secret.yaml` (already on main — the lookup-based creator), and
  2. PR **#3749**'s `catalog-sovereign-flux/gitea-flux-auth-secrets-sync-job.yaml` post-install/post-upgrade hook (the **deterministic** runtime creator — reads the runtime-minted PAT via `secretKeyRef`, **not** a render-time `lookup`, so it sidesteps the fresh-install lookup race; the PAT never hits argv).
- This mirrors the EXACT pattern PR #3749 establishes for the `catalog-sovereign` + `sme-tenants` sources, as requested.

No Go logic change was needed — the controller already supports `secretRef` and is covered by `TestReconcilePerOrgFlux_SecretRefWhenConfigured`. Only the missing chart default is added.

## Separate finding (NOT this fix)

The #3687/#3376 walkers also flagged the org-controller's per-Org **realm** auto-wiring as disabled. That is the `per_org_realm` reconcile gated by `CATALYST_PER_ORG_REALM_ENABLED` (defaults `false` → `State=Disabled`) — an **intentionally-dormant** gate governing Tier-3 per-Org SSO, **not** whether the app comes up. It is out of scope here; the `secretRef` is the must-fix that unblocks the running app. (RBAC/`BootstrapDisabled` for iac-bootstrap is likewise a separate dormant gate.)

## Verification

- `go build ./...` (core/controllers) exits 0; all org-controller tests pass.
- `helm template` renders the org-controller env `CATALYST_FLUX_GITEA_SECRET_REF: "openova-sme-tenants-git-auth"`.
- `TestReconcilePerOrgFlux_SecretRefWhenConfigured` (+ `…CreatesGitRepositoryAndKustomization`, `…WiresPerOrgFluxEndToEnd`) PASS — the GitRepository carries `spec.secretRef.name` when the field is set.
- `scripts/check-chart-annotations.sh` passes (10349-line render OK).
- Chart `1.4.662` → `1.4.663`. Catalyst-Zero render byte-unchanged (the value only reaches the sovereign-only org-controller env).

## Files

- `products/catalyst/chart/values.yaml` — `controllers.organization.fluxGiteaSecretRef: "openova-sme-tenants-git-auth"` (+ root-cause comment).
- `products/catalyst/chart/Chart.yaml` — version bump + history note.

**Do NOT auto-merge** — the orchestrator sequences chart merges to avoid mothership rolls. Live acceptance: a fresh prov → voucher redeem → tenant Org created → `kubectl get gitrepository -n flux-system catalyst-tenant-<slug>` READY=True (was `authentication required`) → vCluster HR reconciles → WordPress reachable.

Refs #3687 #3376

🤖 Generated with [Claude Code](https://claude.com/claude-code)