### PR TITLE
fix(provisioning): retry funnel Git commits on Gitea ref-lock race — Refs #3376

### DIFF
--- a/core/services/provisioning/github/client.go
+++ b/core/services/provisioning/github/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand"
 	"net/http"
 	"strings"
 	"time"
@@ -52,6 +53,60 @@ func NewClientWithAPIURL(token, owner, repo, apiURL string) *Client {
 // branch-ref level; a clean rebuild against the new HEAD succeeds on the
 // next try. 5 attempts handles bursts of ~5 parallel commits.
 const commitAttemptsMax = 5
+
+// Backoff bounds for the ref-race retry. Without a delay every concurrent
+// writer that lost the compare-and-swap retries simultaneously and re-loses
+// against the SAME winner — a thundering herd that can burn all
+// commitAttemptsMax attempts in milliseconds on the shared `sme-tenants`
+// branch (Refs #3376). A short jittered exponential backoff staggers the
+// racers so each gets a clear shot at the moved HEAD. Bounds are small —
+// Gitea ref updates land in tens of ms — so the worst-case total added
+// latency across 4 backoffs stays well under a second.
+const (
+	commitRetryBaseDelay = 50 * time.Millisecond
+	commitRetryMaxDelay  = 750 * time.Millisecond
+)
+
+// commitRetryBackoff returns the jittered backoff to wait before the given
+// 1-based retry attempt. attempt==1 is the first try (no preceding backoff);
+// the returned duration applies BEFORE attempt N (N>=2). Exponential in the
+// attempt index, capped at commitRetryMaxDelay, with full jitter in
+// [base, computed] so concurrent writers de-correlate.
+func commitRetryBackoff(attempt int) time.Duration {
+	if attempt < 2 {
+		return 0
+	}
+	// 2^(attempt-2) * base: attempt 2 → 1x, attempt 3 → 2x, attempt 4 → 4x …
+	mult := time.Duration(1) << uint(attempt-2)
+	d := commitRetryBaseDelay * mult
+	if d > commitRetryMaxDelay {
+		d = commitRetryMaxDelay
+	}
+	// Full jitter in [base, d] — never below base so we always yield the
+	// goroutine, never above the capped ceiling.
+	if d <= commitRetryBaseDelay {
+		return commitRetryBaseDelay
+	}
+	jitterSpan := int64(d - commitRetryBaseDelay)
+	return commitRetryBaseDelay + time.Duration(rand.Int63n(jitterSpan+1))
+}
+
+// sleepWithContext waits for d or until ctx is cancelled, whichever comes
+// first. Returns ctx.Err() if the context fired during the wait so the
+// caller can abort the retry loop promptly instead of blocking on a timer.
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
 
 // CommitFiles creates an atomic commit with multiple files on the given branch.
 // files maps path (e.g. "clusters/contabo-mkt/tenants/slug/namespace.yaml") to content.
@@ -131,6 +186,15 @@ func (c *Client) CommitFilesWithPruneAndRebuild(
 		}
 		slog.Warn("commit: ref moved under us — retrying with fresh HEAD",
 			"attempt", attempt, "branch", branch, "error", err)
+		// Jittered backoff before the next attempt so concurrent writers on
+		// the shared branch de-correlate instead of re-colliding immediately
+		// (Refs #3376). Skipped after the final attempt. Honours ctx so a
+		// cancelled request aborts promptly rather than sleeping.
+		if attempt < commitAttemptsMax {
+			if waitErr := sleepWithContext(ctx, commitRetryBackoff(attempt+1)); waitErr != nil {
+				return fmt.Errorf("commit: ref-race retry aborted: %w (last commit error: %v)", waitErr, lastErr)
+			}
+		}
 	}
 	return fmt.Errorf("commit: ref-race persisted after %d attempts: %w", commitAttemptsMax, lastErr)
 }
@@ -500,6 +564,23 @@ func (c *Client) ensureBranchExists(ctx context.Context, branch string) error {
 // retry loop in CommitFilesWithPruneAndRebuild treats both equivalently.
 // Gitea returns 409 Conflict or 422 with a body containing phrases like
 // "branch has been changed" / "stale base" / "ref has been updated".
+//
+// hw158 funnel re-validation (Refs #3376): the production SME funnel commits
+// every per-tenant overlay to the SINGLE shared `sme-tenants` branch. When two
+// provisioning commits (or the funnel's own multi-step commit racing a
+// concurrent teardown) try to update refs/heads/sme-tenants at once, Gitea's
+// git backend rejects the loser at the ref-lock layer with the git-native
+// message `cannot lock ref 'refs/heads/sme-tenants': ...` (a `.lock` file /
+// compare-and-swap contention) rather than any of the higher-level phrases
+// above. That string was NOT matched here, so the error fell through to the
+// fatal `change files` branch and the outer retry loop never engaged — the
+// funnel step "Committing manifests to Git" went straight to status:"failed".
+// The git ref-lock shapes below restore the fetch-rebuild-retry for that case.
+// Gitea surfaces several wordings depending on which failure path it takes:
+//   - "cannot lock ref 'refs/heads/<branch>'"                       (lock held / CAS lost)
+//   - "is at <sha> but expected <sha>"                              (CAS mismatch)
+//   - "unable to create '...refs/heads/<branch>.lock': File exists" (lock-file race)
+//   - "failed to update ref"                                       (generic ref-update wrap)
 func isGiteaRefRaceError(err error) bool {
 	if err == nil {
 		return false
@@ -509,7 +590,14 @@ func isGiteaRefRaceError(err error) bool {
 		strings.Contains(s, "branch has been changed") ||
 		strings.Contains(s, "stale base") ||
 		strings.Contains(s, "ref has been updated") ||
-		strings.Contains(s, "not a fast forward")
+		strings.Contains(s, "not a fast forward") ||
+		// git-native ref-lock contention on the shared sme-tenants branch
+		// (Refs #3376). Any of these means a concurrent writer won the CAS;
+		// a fresh fetch-rebuild-retry against the new HEAD resolves it.
+		strings.Contains(s, "cannot lock ref") ||
+		strings.Contains(s, "but expected") ||
+		(strings.Contains(s, "unable to create") && strings.Contains(s, ".lock")) ||
+		strings.Contains(s, "failed to update ref")
 }
 
 // getContentSHA returns the blob SHA of `path` at `branch`, or "" if the

--- a/core/services/provisioning/github/client_reflock_test.go
+++ b/core/services/provisioning/github/client_reflock_test.go
@@ -1,0 +1,233 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestCommitFiles_GiteaTarget_RetriesOnRefLock proves the funnel fix for the
+// hw158 re-validation (Refs #3376): when Gitea rejects a batch ChangeFiles
+// commit to the shared `sme-tenants` branch with the git-native
+// `cannot lock ref 'refs/heads/sme-tenants'` error (a concurrent-writer
+// ref-lock race), the client must fetch-rebuild-retry rather than fail the
+// whole commit. Pre-fix isGiteaRefRaceError did NOT match that string, so the
+// outer retry loop never engaged and the funnel step "Committing manifests to
+// Git" went straight to status:"failed".
+//
+// The fake Gitea server here returns the ref-lock error on the FIRST POST to
+// /contents and succeeds on the SECOND, so a passing test demonstrates the
+// retry actually fired and the commit ultimately landed.
+func TestCommitFiles_GiteaTarget_RetriesOnRefLock(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		postCount int
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/git/refs/heads/sme-tenants"):
+			// Branch exists; HEAD moves between attempts in reality, but the
+			// SHA value is immaterial to this test (the create op carries no
+			// stale base for a fresh path).
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"object":{"sha":"c3f4799deadbeef0000000000000000deadbeef"}}]`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/contents/"):
+			// Fresh path → 404 → operation=create.
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/contents"):
+			mu.Lock()
+			postCount++
+			n := postCount
+			mu.Unlock()
+			if n == 1 {
+				// First writer lost the compare-and-swap on the shared
+				// sme-tenants branch — Gitea's git backend surfaces the
+				// ref-lock failure. 409 Conflict + the git-native body.
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusConflict)
+				_, _ = w.Write([]byte(`{"message":"cannot lock ref 'refs/heads/sme-tenants': is at 1111111111111111111111111111111111111111 but expected 2222222222222222222222222222222222222222"}`))
+				return
+			}
+			// Retry against the moved HEAD succeeds.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"commit":{"sha":"newcommitsha0000000000000000000000000000"}}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClientWithAPIURL("token", "openova-io", "openova", srv.URL)
+	err := c.CommitFiles(context.Background(), "sme-tenants", "sme-tenant: provision alice", map[string]string{
+		"clusters/otech.omani.works/sme-tenants/alice/namespace.yaml": "kind: Namespace\nmetadata:\n  name: sme-alice\n",
+	})
+	if err != nil {
+		t.Fatalf("CommitFiles should have retried past the ref-lock and succeeded, got: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if postCount != 2 {
+		t.Fatalf("expected exactly 2 POST /contents (1 ref-lock reject + 1 success), got %d — retry did not fire as expected", postCount)
+	}
+}
+
+// TestCommitFiles_GiteaTarget_RefLockPersists asserts that when the ref-lock
+// race NEVER clears, the client exhausts commitAttemptsMax and returns a
+// descriptive ref-race error (rather than hanging or masking the failure).
+// This guards the bound on the retry so a pathological hot branch can't spin
+// forever.
+func TestCommitFiles_GiteaTarget_RefLockPersists(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		postCount int
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/git/refs/heads/sme-tenants"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"object":{"sha":"c3f4799deadbeef0000000000000000deadbeef"}}]`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/contents/"):
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/contents"):
+			mu.Lock()
+			postCount++
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"message":"cannot lock ref 'refs/heads/sme-tenants'"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClientWithAPIURL("token", "openova-io", "openova", srv.URL)
+	err := c.CommitFiles(context.Background(), "sme-tenants", "sme-tenant: provision bob", map[string]string{
+		"clusters/otech.omani.works/sme-tenants/bob/namespace.yaml": "kind: Namespace\n",
+	})
+	if err == nil {
+		t.Fatalf("expected a ref-race error after exhausting retries, got nil")
+	}
+	if !strings.Contains(err.Error(), "ref-race persisted") {
+		t.Errorf("error should report ref-race exhaustion, got: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if postCount != commitAttemptsMax {
+		t.Errorf("expected exactly %d POST attempts (commitAttemptsMax), got %d", commitAttemptsMax, postCount)
+	}
+}
+
+// TestCommitFiles_GiteaTarget_RefLockRetryHonoursContext asserts the
+// jittered backoff between ref-race retries aborts promptly when the request
+// context is cancelled, rather than sleeping out the full backoff.
+func TestCommitFiles_GiteaTarget_RefLockRetryHonoursContext(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/git/refs/heads/sme-tenants"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"object":{"sha":"c3f4799deadbeef0000000000000000deadbeef"}}]`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/contents/"):
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/contents"):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"message":"cannot lock ref 'refs/heads/sme-tenants'"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel shortly after the first failure so the abort lands during the
+	// backoff sleep, not the HTTP call.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	c := NewClientWithAPIURL("token", "openova-io", "openova", srv.URL)
+	start := time.Now()
+	err := c.CommitFiles(ctx, "sme-tenants", "sme-tenant: provision carol", map[string]string{
+		"clusters/otech.omani.works/sme-tenants/carol/namespace.yaml": "kind: Namespace\n",
+	})
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatalf("expected an error after context cancellation, got nil")
+	}
+	// Must bail well before all commitAttemptsMax backoffs would elapse.
+	if elapsed > 2*time.Second {
+		t.Errorf("retry loop did not honour context cancellation promptly (took %s)", elapsed)
+	}
+}
+
+// TestIsGiteaRefRaceError_RefLockShapes locks in that every git-native
+// ref-lock wording Gitea can emit on a contended branch is recognised as a
+// retryable ref-race (Refs #3376), while genuinely fatal errors are not.
+func TestIsGiteaRefRaceError_RefLockShapes(t *testing.T) {
+	retryable := []string{
+		"GitHub API POST .../contents: 409 {\"message\":\"cannot lock ref 'refs/heads/sme-tenants'\"}",
+		"change files: cannot lock ref 'refs/heads/sme-tenants': is at aaaa but expected bbbb",
+		"unable to create '.../refs/heads/sme-tenants.lock': File exists",
+		"failed to update ref refs/heads/sme-tenants",
+		// pre-existing shapes must still match
+		"GitHub API POST x: 409 Conflict",
+		"the branch has been changed",
+		"stale base",
+		"ref has been updated by another request",
+		"Update is not a fast forward",
+	}
+	for _, s := range retryable {
+		if !isGiteaRefRaceError(simpleErr(s)) {
+			t.Errorf("isGiteaRefRaceError(%q) = false, want true (ref-race should retry)", s)
+		}
+	}
+
+	fatal := []string{
+		"GitHub API POST .../contents: 403 {\"message\":\"token lacks write scope\"}",
+		"GitHub API POST .../contents: 422 {\"message\":\"content is not valid base64\"}",
+		"context deadline exceeded",
+		"dial tcp: connection refused",
+		"",
+	}
+	for _, s := range fatal {
+		if isGiteaRefRaceError(simpleErr(s)) {
+			t.Errorf("isGiteaRefRaceError(%q) = true, want false (must not retry a fatal error)", s)
+		}
+	}
+}
+
+// TestCommitRetryBackoff_Bounds asserts the backoff helper stays within its
+// declared [base, max] envelope and never precedes the first attempt.
+func TestCommitRetryBackoff_Bounds(t *testing.T) {
+	if d := commitRetryBackoff(1); d != 0 {
+		t.Errorf("commitRetryBackoff(1) = %s, want 0 (no backoff before the first attempt)", d)
+	}
+	for attempt := 2; attempt <= 12; attempt++ {
+		for i := 0; i < 64; i++ { // sample the jitter
+			d := commitRetryBackoff(attempt)
+			if d < commitRetryBaseDelay {
+				t.Fatalf("commitRetryBackoff(%d) = %s, below base %s", attempt, d, commitRetryBaseDelay)
+			}
+			if d > commitRetryMaxDelay {
+				t.Fatalf("commitRetryBackoff(%d) = %s, above max %s", attempt, d, commitRetryMaxDelay)
+			}
+		}
+	}
+}
+
+// simpleErr is a tiny error wrapper so the table tests above can build errors
+// from raw strings without pulling in errors.New everywhere.
+type simpleErr string
+
+func (e simpleErr) Error() string { return string(e) }


### PR DESCRIPTION
## What

The SME funnel's **\"Committing manifests to Git\"** step failed on the hw158 re-validation with:

```
status:"failed"  cannot lock ref 'refs/heads/sme-tenants'
```

This is a **Gitea ref-lock race**: every per-tenant funnel commit targets the *single shared* `sme-tenants` branch. When two provisioning commits — or the funnel's own multi-step commit racing a concurrent teardown — try to update `refs/heads/sme-tenants` at once, Gitea's git backend rejects the loser at the ref-lock layer (a `.lock` file / compare-and-swap contention).

## Root cause (`core/services/provisioning/github/client.go`)

The funnel commit path is `consumer.go` → `CommitFilesWithPrune[AndRebuild]` → `commitOnce` → **`commitOnceContents`** (the Gitea Contents-API path; Sovereigns set `APIURL` to in-cluster Gitea).

A bounded fetch-rebuild-retry loop **already exists** (`commitAttemptsMax = 5`, with rebuild closures in `consumer.go`). It engages only when the error is classified as a ref-race by **`isGiteaRefRaceError`** — which matched `409` / `branch has been changed` / `stale base` / `ref has been updated` / `not a fast forward`, but **NOT** the git-native `cannot lock ref` wording Gitea actually emits on a contended branch. So the ref-lock error fell through to the fatal `change files` branch, `isFastForwardRejection` returned false, and the retry loop never fired → the funnel step failed on the first collision.

## Fix

1. **Extend `isGiteaRefRaceError`** to recognise every git-native ref-lock shape Gitea can surface (`cannot lock ref`, `is at X but expected Y`, `unable to create *.lock`, `failed to update ref`) so the existing 5× rebuild-retry engages. The detected error is then wrapped as `update ref: … not a fast forward`, which `isFastForwardRejection` already matches — so the two-layer mapping stays consistent.
2. **Add jittered exponential backoff** (50 ms .. 750 ms, full jitter) between retries. Without a delay, every concurrent writer that lost the CAS retries simultaneously and re-loses (thundering herd) — burning all 5 attempts in milliseconds. The backoff staggers racers so each gets a clear shot at the moved HEAD, and it **honours the request context** (aborts promptly on cancellation).

A single funnel run now reliably commits even under concurrent writers.

## Tests (`github` pkg — all green)

- `TestCommitFiles_GiteaTarget_RetriesOnRefLock` — 1 ref-lock reject + 1 success ⇒ commit lands (proves the retry fires).
- `TestCommitFiles_GiteaTarget_RefLockPersists` — exhausts exactly `commitAttemptsMax` then errors descriptively (bounds the hot-branch case).
- `TestCommitFiles_GiteaTarget_RefLockRetryHonoursContext` — cancels mid-backoff, bails < 2 s.
- `TestIsGiteaRefRaceError_RefLockShapes` — every ref-lock wording is retryable; genuinely fatal errors (403/422/timeout/conn-refused) are **not**.
- `TestCommitRetryBackoff_Bounds` — backoff stays within `[base, max]`.

`go build ./...`, `go vet ./github/...`, `gofmt -l`, and the full provisioning module test suite are all green.

## Notes
- `Refs #3376` (not `Closes`) — closes only after an operator funnel walk on a fresh prov.
- Commit authored as **hatiyildiz**. The PR opener may render as the `gh`-authed account (emrahbaysal) until a hatiyildiz PAT is configured — operator action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)