### PR TITLE
fix(bp-newapi): per-minute CronJob retries the SSO provider reload — zero-click SSO deterministic on a fresh prov (Refs #3374 #3563) — 1.4.97

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -253,7 +253,9 @@ spec:
       # build-bp-newapi-sandbox-bridge.yaml re-tags the sidecar + may auto-bump
       # this pin further on merge (it rebuilds the bridge that carries this fix).
       # #3648 — lockstep with platform/newapi Chart.yaml + blueprint.yaml 1.4.95.
-      version: 1.4.96
+      # #3374/#3563 — 1.4.97: per-minute CronJob now retries the SSO provider
+      # reload until the NewAPI Deployment is restarted (fresh-prov determinism).
+      version: 1.4.97
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.96
+  version: 1.4.97
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,33 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.97 (#3374/#3563, 2026-06-17): SELF-HEALING provider reload — make the
+# zero-click SSO custom-provider reload DETERMINISTIC on a fresh install. ROOT
+# CAUSE re-surfaced live on hw158: newapi's in-app OIDC callback
+# /api/oauth/sovereign returned `{"message":"Unknown OAuth provider"}` (3/3) and
+# the pod boot-logged "Loaded 0 custom OAuth providers". The `sovereign`
+# custom_oauth_providers DB row was correct (enabled, client_id/secret/endpoints
+# present, created 03:25:05) but the running NewAPI pod was NEVER restarted to
+# reload it — the Deployment carried restartCount=0 and NO
+# `catalyst.openova.io/newapi-provider-reload-hash` annotation. 1.4.91's
+# reload_newapi_provider (rollout-restart so LoadCustomProviders re-runs) is
+# CORRECT, but it ran EXACTLY ONCE in the post-install/upgrade seed Job and is
+# best-effort (`python3 /scripts/reload.py || echo`; reload.py raises
+# SystemExit(0) on any GET/PATCH error). On hw158 that one-shot silently did not
+# land (the provider INSERT and the hash-query/PATCH run microseconds apart in
+# the same script while the pod does its own first rollout — any transient
+# skip/blip leaves the annotation unset), and the per-minute promote CronJob's
+# promote.sh called ONLY promote_oidc_users, so NOTHING ever retried the reload
+# → broken forever. FIX (admin-sso-seed-job.yaml): promote.sh now ALSO calls
+# reload_newapi_provider, so the per-minute CronJob RETRIES the reload until the
+# Deployment's reload-hash annotation matches the live provider hash. Idempotent
+# + hash-gated (reload.py no-ops once cur==want — never a restart loop). No RBAC
+# or volume change: the CronJob already runs as the admin-seed SA (get+patch on
+# the NewAPI Deployment) and already mounts /scripts (incl. reload.py) + /cnpg.
+# Verified live hw158: a one-off run of reload_newapi_provider under the
+# admin-seed SA patched the Deployment ("rollout-restart triggered ... provider
+# hash none -> 593838668f7a") and rolled a fresh pod — proving the mechanism is
+# sound and only its retry cadence was missing. Lockstep: 80-newapi.yaml pin +
+# blueprint.yaml → 1.4.97. Refs #3374, #3563.
 # 1.4.93 (#3563, 2026-06-15): zero-click RE-login fix — the bare-URL SSO landing
 # page (sandbox-bridge sso_init.go 0.1.17) is now IDEMPOTENT. After 1.4.92 the
 # FIRST bare-URL visit bound the SSO identity to a NewAPI user (role=100) and
@@ -646,7 +674,7 @@ name: bp-newapi
 # URL/client_id are unset the page degrades to the SPA /login link. The bridge
 # IMAGE TAG + a further chart patch bump are auto-committed by
 # build-bp-newapi-sandbox-bridge.yaml on merge (push to internal/handler/**).
-version: 1.4.96
+version: 1.4.97
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/admin-sso-seed-job.yaml
+++ b/platform/newapi/chart/templates/admin-sso-seed-job.yaml
@@ -422,6 +422,34 @@ data:
     . /scripts/common.sh
     wait_for_users_table
     promote_oidc_users
+    # (e') #3374/#3563 — SELF-HEALING provider reload. The one-shot seed.sh
+    #      reload (step e) fires EXACTLY ONCE and is best-effort: if it is
+    #      skipped or fails for ANY transient reason at first-install time —
+    #      the provider INSERT not yet visible to the hash query's psql
+    #      connection when reload ran microseconds later, an apiserver blip,
+    #      the seed Pod's SA-token not yet propagated, or the PATCH racing the
+    #      Deployment's own initial rollout — the NewAPI Deployment never gets
+    #      the `{{ $reloadHashAnno }}` annotation, the pod that booted "Loaded
+    #      0 custom OAuth providers" is never restarted, and
+    #      /api/oauth/{{ $providerSlug }} returns "Unknown OAuth provider"
+    #      FOREVER (measured live hw158 2026-06-17: admin-seed Job Complete,
+    #      `{{ $providerSlug }}` custom_oauth_providers row enabled+correct,
+    #      created 03:25:05 — 4s AFTER the pod boot-logged "Loaded 0 custom
+    #      OAuth providers" at 03:25:01 — yet the Deployment had restartCount=0
+    #      and NO `{{ $reloadHashAnno }}` annotation; the one-shot reload
+    #      silently did not land and nothing ever retried it → 3/3 SSO callbacks
+    #      "Unknown OAuth provider"). The per-minute promote CronJob now ALSO
+    #      runs the reload so it RETRIES every minute until the Deployment
+    #      annotation matches the live provider hash. IDEMPOTENT + hash-gated
+    #      (reload.py no-ops when the recorded hash already == the live hash),
+    #      so once the running pod has loaded the provider this is a pure
+    #      GET-and-compare — never a restart loop. This makes zero-click SSO
+    #      deterministic on a FRESH install, not merely on a later chart
+    #      upgrade. The CronJob already runs as the admin-seed ServiceAccount
+    #      (which holds get+patch on exactly the NewAPI Deployment) and already
+    #      mounts /scripts (incl. reload.py) + the CNPG /cnpg secret, so no RBAC
+    #      or volume change is needed.
+    reload_newapi_provider
   reload.py: |
     # #3374 (2026-06-15) — rollout-restart NewAPI so the running pod reloads the
     # seeded custom OAuth provider (boot-only registry; the 60s sync loop never


### PR DESCRIPTION
## What

`bp-newapi` 1.4.97 — make the zero-click SSO custom-provider reload **deterministic on a fresh install** by having the per-minute admin-promote CronJob retry it until it lands.

## Root cause (re-validated live on hw158, 2026-06-17)

newapi's in-app OIDC callback `/api/oauth/sovereign` returned `{"message":"Unknown OAuth provider"}` (3/3) and the pod boot-logged `Loaded 0 custom OAuth providers`. The `sovereign` `custom_oauth_providers` DB row was **correct** (enabled, client_id/secret/endpoints, created `03:25:05`) — but the running NewAPI pod was **never restarted** to reload it:

- newapi container booted `03:25:01` → `Loaded 0 custom OAuth providers`
- provider row created `03:25:05` (4s **after** boot)
- Deployment: `restartCount=0`, **no** `catalyst.openova.io/newapi-provider-reload-hash` annotation

1.4.91's `reload_newapi_provider` (rollout-restart so `LoadCustomProviders` re-runs — NewAPI's custom-provider registry is boot-only and the 60s sync loop never re-reads `custom_oauth_providers`) is **correct**, but it ran **exactly once** in the post-install/upgrade seed Job and is best-effort (`python3 /scripts/reload.py || echo`; `reload.py` `raise SystemExit(0)` on any GET/PATCH error). On hw158 that one-shot **silently did not land** — the provider INSERT and the hash-query/PATCH run microseconds apart in the same `seed.sh` while the pod does its own first rollout, so any transient skip/blip leaves the annotation unset — and the per-minute promote CronJob's `promote.sh` called **only** `promote_oidc_users`. Nothing ever retried the reload → broken forever.

**File:line:** `platform/newapi/chart/templates/admin-sso-seed-job.yaml` — `promote.sh` (was lines 421-424) ran only `wait_for_users_table` + `promote_oidc_users`; the reload (`reload_newapi_provider`, seed.sh line 419) fired once and never retried.

## Fix

`promote.sh` now **also** calls `reload_newapi_provider`, so the per-minute CronJob **retries** the reload until the Deployment's reload-hash annotation matches the live provider hash.

- **Idempotent + hash-gated** — `reload.py` no-ops once `cur == want`; never a restart loop.
- **No RBAC / volume change** — the CronJob already runs as the admin-seed ServiceAccount (which holds `get`+`patch` on exactly the NewAPI Deployment) and already mounts `/scripts` (incl. `reload.py`) + the CNPG `/cnpg` secret.
- Makes zero-click SSO deterministic on a **fresh install**, not merely on a later chart upgrade.

## Live proof (hw158)

A one-off run of `reload_newapi_provider` under the admin-seed SA (exactly what the CronJob now does):

```
[admin-seed] reload: rollout-restart triggered for newapi-bp-newapi (provider hash none -> 593838668f7a)
```

Result on the live cluster:
- new pod `7d6dbd4f47-dn6xr` → `3/3 Running`
- Deployment annotation `catalyst.openova.io/newapi-provider-reload-hash: 593838668f7a1d16cfb93c03d7734e2d`
- new pod boot log: **`Loaded 1 custom OAuth providers`** (was `Loaded 0`)

This proves the mechanism is sound — only its retry cadence was missing. (hw158's live SSO is repaired as a side effect.)

## Validation

- `helm template` renders **exit 0**; `promote.sh` now runs `wait_for_users_table` → `promote_oidc_users` → `reload_newapi_provider`.
- Existing chart render tests (`httproute` / `imagepullsecrets` / `startup-probe`) **PASS**.
- The `helm lint` "invalid Yaml document separator" warning is **pre-existing** (helm-lint mishandles the template's leading comment + `{{- if }}` guard; reproduces on the unmodified base template) — not introduced here.

## Lockstep (Inviolable Principle #14)

`platform/newapi/chart/Chart.yaml` + `platform/newapi/blueprint.yaml` + `clusters/_template/bootstrap-kit/80-newapi.yaml` pin → **1.4.97**.

Refs #3374, #3563

🤖 Generated with [Claude Code](https://claude.com/claude-code)