### PR TITLE
fix(#3375): one placement vocabulary on the wire (singleton/active-passive/active-hot-standby/active-active)

### DIFF
--- a/core/controllers/blueprint/internal/validate/placement_vocabulary_drift_test.go
+++ b/core/controllers/blueprint/internal/validate/placement_vocabulary_drift_test.go
@@ -1,0 +1,168 @@
+// placement_vocabulary_drift_test.go — #3375 DoD-1 cross-surface drift
+// guard.
+//
+// ONE canonical placement/topology vocabulary is shared by every
+// surface. The single Go source of truth is
+// core/controllers/internal/placement.CanonicalModes():
+//
+//	singleton | active-active | active-hot-standby | active-passive
+//
+// This test pins the OTHER surfaces to that exact set by scanning their
+// source from the repo root, so a future edit that re-introduces the
+// legacy editor dialect (single-region / active-hotstandby) as a primary
+// emitted value — or drops a canonical class — fails CI here:
+//
+//	(a) the catalog placementSchema enum + this package's accepted set
+//	    (the CRD products/catalyst/chart/crds/blueprint.yaml + the Go
+//	    canonicalPlacementModes map)
+//	(b) the console editor type (products/catalyst/console/src/lib/api/
+//	    types.ts BcpTopology union)
+//	(c) the bootstrap-ui editor option set
+//	    (products/catalyst/bootstrap/ui/.../TopologyEditor.tsx ALL_MODES)
+//
+// The catalyst-api surface + the FE canonicaliser parity are pinned by
+// their own drift tests (products/catalyst/bootstrap/api/.../
+// placement_vocabulary_drift_test.go and
+// products/catalyst/bootstrap/ui/.../placement-vocabulary.drift.test.tsx).
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openova-io/openova/core/controllers/internal/placement"
+)
+
+func TestPlacementVocabulary_CanonicalModesAreFour(t *testing.T) {
+	want := []string{"singleton", "active-active", "active-hot-standby", "active-passive"}
+	got := placement.CanonicalModes()
+	if len(got) != len(want) {
+		t.Fatalf("placement.CanonicalModes() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("CanonicalModes()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// The validate package's accepted placementSchema.modes set MUST include
+// every canonical Application-tier token (it also accepts the legacy
+// aliases + the bootstrap-topology tier).
+func TestPlacementVocabulary_ValidateAcceptsCanonical(t *testing.T) {
+	for _, m := range placement.CanonicalModes() {
+		if _, ok := canonicalPlacementModes[m]; !ok {
+			t.Errorf("canonicalPlacementModes is missing canonical token %q", m)
+		}
+	}
+	// Legacy spellings remain accepted (back-compat).
+	for _, legacy := range []string{"single-region", "active-hotstandby"} {
+		if _, ok := canonicalPlacementModes[legacy]; !ok {
+			t.Errorf("canonicalPlacementModes dropped legacy alias %q (must stay accepted)", legacy)
+		}
+	}
+}
+
+func TestPlacementVocabulary_CRDEnumHasCanonical(t *testing.T) {
+	root := findRepoRoot(t)
+	crd := mustReadRepoFile(t, root, "products", "catalyst", "chart", "crds", "blueprint.yaml")
+	// The CRD placementSchema enum (and default/defaultOnMultiRegion) must
+	// list every canonical token so a Blueprint can declare it structurally.
+	for _, m := range placement.CanonicalModes() {
+		if !containsYAMLEnumValue(crd, m) {
+			t.Errorf("CRD blueprint.yaml placementSchema enum is missing canonical token %q", m)
+		}
+	}
+}
+
+func TestPlacementVocabulary_ConsoleBcpTopologyIsCanonical(t *testing.T) {
+	root := findRepoRoot(t)
+	types := mustReadRepoFile(t, root, "products", "catalyst", "console", "src", "lib", "api", "types.ts")
+	// The console BcpTopology union must carry exactly the canonical set
+	// (no legacy spelling).
+	for _, m := range placement.CanonicalModes() {
+		if !strings.Contains(types, "'"+m+"'") {
+			t.Errorf("console types.ts BcpTopology is missing canonical token %q", m)
+		}
+	}
+	for _, legacy := range []string{"'single-region'", "'active-hotstandby'"} {
+		if strings.Contains(types, legacy) {
+			t.Errorf("console types.ts BcpTopology must NOT carry the legacy spelling %s", legacy)
+		}
+	}
+}
+
+func TestPlacementVocabulary_BootstrapUIAllModesIsCanonical(t *testing.T) {
+	root := findRepoRoot(t)
+	editor := mustReadRepoFile(t, root, "products", "catalyst", "bootstrap", "ui", "src", "widgets", "topology", "TopologyEditor.tsx")
+	// ALL_MODES is the bootstrap-ui editor's option set — it must be the
+	// canonical four, with no legacy spelling as a member of the array.
+	allModesLine := extractLineContaining(editor, "export const ALL_MODES")
+	if allModesLine == "" {
+		t.Fatalf("could not find ALL_MODES declaration in TopologyEditor.tsx")
+	}
+	for _, m := range placement.CanonicalModes() {
+		if !strings.Contains(allModesLine, "'"+m+"'") {
+			t.Errorf("ALL_MODES is missing canonical token %q (line: %s)", m, allModesLine)
+		}
+	}
+	for _, legacy := range []string{"'single-region'", "'active-hotstandby'"} {
+		if strings.Contains(allModesLine, legacy) {
+			t.Errorf("ALL_MODES must NOT carry the legacy spelling %s", legacy)
+		}
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+func mustReadRepoFile(t *testing.T, root string, parts ...string) string {
+	t.Helper()
+	p := filepath.Join(append([]string{root}, parts...)...)
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		t.Skipf("could not read %s (%v); skipping cross-surface drift check", p, err)
+	}
+	return string(raw)
+}
+
+// containsString reports whether sub appears in s (a tiny strings.Contains
+// alias kept local so the file has no extra import churn).
+func containsStringHelper(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+// containsYAMLEnumValue checks for a YAML list item `- <value>` (the enum
+// shape used in the CRD).
+func containsYAMLEnumValue(s, value string) bool {
+	return strings.Contains(s, "- "+value+"\n") || strings.Contains(s, "- "+value+"\r\n")
+}
+
+// extractLineContaining returns the first line of s containing marker, or
+// "" if none.
+func extractLineContaining(s, marker string) string {
+	start := indexOf(s, marker)
+	if start < 0 {
+		return ""
+	}
+	// back up to line start
+	ls := start
+	for ls > 0 && s[ls-1] != '\n' {
+		ls--
+	}
+	le := start
+	for le < len(s) && s[le] != '\n' {
+		le++
+	}
+	return s[ls:le]
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/core/controllers/blueprint/internal/validate/validate.go
+++ b/core/controllers/blueprint/internal/validate/validate.go
@@ -52,6 +52,7 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/openova-io/openova/core/controllers/internal/placement"
 	"github.com/openova-io/openova/core/controllers/internal/semver"
 )
 
@@ -106,10 +107,18 @@ func compileBlueprintTopologySchema() (*jsonschema.Schema, error) {
 // Two tiers of placement modes coexist:
 //
 //  1. Application-tier modes — operator/tenant-facing modes for normal
-//     application Blueprints (the marketplace 99%):
-//     - single-region     (one region, no replication)
-//     - active-active     (multi-region, all primary)
-//     - active-hotstandby (multi-region, primary + warm standby)
+//     application Blueprints (the marketplace 99%). ONE canonical
+//     vocabulary (#3375 DoD-1), defined once by the placement package
+//     (core/controllers/internal/placement.CanonicalModes):
+//     - singleton          (one region, no replication)
+//     - active-active      (multi-region, all primary)
+//     - active-hot-standby (multi-region, primary + warm standby)
+//     - active-passive     (multi-region, primary + cold/warm standby)
+//
+//     The legacy spellings `single-region` / `active-hotstandby` are
+//     still ACCEPTED here (folded via placement.Canonicalize) so the
+//     71-blueprint corpus that pre-dates the canonical spelling keeps
+//     validating; new blueprint.yaml authors emit the canonical token.
 //
 //  2. Bootstrap-topology modes — used by `bp-*-vcluster` and other
 //     bootstrap-kit Blueprints whose placement is dictated by the
@@ -129,15 +138,25 @@ func compileBlueprintTopologySchema() (*jsonschema.Schema, error) {
 // and must be kept in sync — see that file's `placementSchema.modes`
 // items.enum.
 var canonicalPlacementModes = map[string]struct{}{
-	// Application-tier
+	// Application-tier — canonical (placement.CanonicalModes)
+	"singleton":          {},
+	"active-active":      {},
+	"active-hot-standby": {},
+	"active-passive":     {},
+	// Application-tier — legacy spellings, accepted for back-compat
 	"single-region":     {},
-	"active-active":     {},
 	"active-hotstandby": {},
 	// Bootstrap-topology tier (docs/SOVEREIGN-MULTI-REGION-DOD.md A4)
 	"primary-only":   {},
 	"secondary-only": {},
 	"every-region":   {},
 }
+
+// placementModesLegalValues is the human-readable legal-value list for
+// error messages — the canonical Application-tier vocabulary plus the
+// bootstrap-topology tier (legacy spellings are accepted but not
+// advertised as the preferred form).
+const placementModesLegalValues = "singleton, active-active, active-hot-standby, active-passive, primary-only, secondary-only, every-region (legacy single-region / active-hotstandby also accepted)"
 
 // canonicalManifestKinds — must mirror the enum in
 // products/catalyst/chart/crds/blueprint.yaml `manifests.source.kind`.
@@ -310,21 +329,25 @@ func Validate(bp *unstructured.Unstructured, catalog map[string]struct{}) Result
 			for _, m := range modes {
 				if _, ok := canonicalPlacementModes[m]; !ok {
 					res.Errors = append(res.Errors, fmt.Sprintf(
-						"spec.placementSchema.modes contains %q; legal values: single-region, active-active, active-hotstandby, primary-only, secondary-only, every-region",
-						m,
+						"spec.placementSchema.modes contains %q; legal values: %s",
+						m, placementModesLegalValues,
 					))
 				}
 			}
 		}
 		// Optional: default mode must be one of modes[] (when both set).
+		// Membership is checked on the CANONICAL token so a `default:
+		// singleton` matches `modes: [single-region]` and vice versa —
+		// the one-vocabulary rule must not reject a Blueprint that mixes
+		// canonical + legacy spellings during the corpus migration.
 		if defaultMode, _, _ := unstructured.NestedString(pSchema, "default"); defaultMode != "" {
 			if _, ok := canonicalPlacementModes[defaultMode]; !ok {
 				res.Errors = append(res.Errors, fmt.Sprintf(
-					"spec.placementSchema.default = %q; legal values: single-region, active-active, active-hotstandby, primary-only, secondary-only, every-region",
-					defaultMode,
+					"spec.placementSchema.default = %q; legal values: %s",
+					defaultMode, placementModesLegalValues,
 				))
 			}
-			if len(modes) > 0 && !containsString(modes, defaultMode) {
+			if len(modes) > 0 && !containsCanonicalMode(modes, defaultMode) {
 				res.Errors = append(res.Errors, fmt.Sprintf(
 					"spec.placementSchema.default = %q is not in modes[]: %v",
 					defaultMode, modes,
@@ -342,11 +365,11 @@ func Validate(bp *unstructured.Unstructured, catalog map[string]struct{}) Result
 		if dMR, _, _ := unstructured.NestedString(pSchema, "defaultOnMultiRegion"); dMR != "" {
 			if _, ok := canonicalPlacementModes[dMR]; !ok {
 				res.Errors = append(res.Errors, fmt.Sprintf(
-					"spec.placementSchema.defaultOnMultiRegion = %q; legal values: single-region, active-active, active-hotstandby, primary-only, secondary-only, every-region",
-					dMR,
+					"spec.placementSchema.defaultOnMultiRegion = %q; legal values: %s",
+					dMR, placementModesLegalValues,
 				))
 			}
-			if len(modes) > 0 && !containsString(modes, dMR) {
+			if len(modes) > 0 && !containsCanonicalMode(modes, dMR) {
 				res.Errors = append(res.Errors, fmt.Sprintf(
 					"spec.placementSchema.defaultOnMultiRegion = %q is not in modes[]: %v",
 					dMR, modes,
@@ -883,6 +906,24 @@ func nestedAsMap(m map[string]interface{}, key string) (map[string]interface{}, 
 func containsString(xs []string, s string) bool {
 	for _, x := range xs {
 		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+// containsCanonicalMode reports whether s is in xs after BOTH sides are
+// folded onto the canonical placement vocabulary (#3375 DoD-1). It is
+// the membership check for `placementSchema.default` /
+// `defaultOnMultiRegion` against `modes[]`, so a Blueprint that mixes a
+// canonical default with legacy-spelled modes (or vice versa) during
+// the corpus migration is not falsely rejected. Bootstrap-topology
+// modes (primary-only / …) canonicalise to themselves, so they keep
+// exact-match semantics.
+func containsCanonicalMode(xs []string, s string) bool {
+	want := placement.Canonicalize(s)
+	for _, x := range xs {
+		if placement.Canonicalize(x) == want {
 			return true
 		}
 	}

--- a/core/controllers/internal/placement/placement.go
+++ b/core/controllers/internal/placement/placement.go
@@ -3,49 +3,144 @@
 // into the per-region work plan the application-controller writes to
 // Gitea.
 //
-// Per docs/EPICS-1-6-unified-design.md §5 (EPIC-2 contract) and the
-// CRD's `placement` enum, three modes are supported:
+// # ONE canonical placement vocabulary (#3375 §3(f), DoD-1)
 //
-//   single-region:      one cluster only (regions[0]). regions[1..]
-//                       in the spec (if any) are ignored — the schema
-//                       allows up to 5 entries because all 3 modes
-//                       share the regions[] array, but only [0] is
-//                       materialised.
+// There is exactly ONE placement/topology vocabulary on the wire,
+// shared by every surface (catalog placementSchema, the console + the
+// bootstrap-ui editors, and the Application CR). The canonical tokens
+// are:
 //
-//   active-active:      manifests fan out to ALL regions[]. Every
-//                       region renders an identical HelmRelease /
-//                       Kustomization with the same `replicas`. The
-//                       application is online in every region
-//                       simultaneously; load is balanced upstream
-//                       (Continuum / global ingress).
+//	singleton:          one cluster only (regions[0]). regions[1..]
+//	                    in the spec (if any) are ignored — the schema
+//	                    allows up to 5 entries because all modes share
+//	                    the regions[] array, but only [0] is
+//	                    materialised. (Legacy alias: single-region.)
 //
-//   active-hotstandby:  manifests fan out to ALL regions[]. regions[0]
-//                       is the PRIMARY — runs with `replicas:
-//                       parameters.replicas` (or whatever the Blueprint
-//                       declares). regions[1..] are STANDBYS — run
-//                       with `replicas: 0` (or `replica: false` on
-//                       CNPG-style resources). The Continuum
-//                       controller (#1101) flips replicas back to a
-//                       non-zero value on switchover.
+//	active-active:      manifests fan out to ALL regions[]. Every
+//	                    region renders an identical HelmRelease /
+//	                    Kustomization with the same `replicas`. The
+//	                    application is online in every region
+//	                    simultaneously; load is balanced upstream
+//	                    (Continuum / global ingress).
+//
+//	active-hot-standby: manifests fan out to ALL regions[]. regions[0]
+//	                    is the PRIMARY — runs with `replicas:
+//	                    parameters.replicas` (or whatever the Blueprint
+//	                    declares). regions[1..] are STANDBYS — run
+//	                    with `replicas: 0` (or `replica: false` on
+//	                    CNPG-style resources). The Continuum
+//	                    controller (#1101) flips replicas back to a
+//	                    non-zero value on switchover. (Legacy alias:
+//	                    active-hotstandby.)
+//
+//	active-passive:     same fan-out shape as active-hot-standby
+//	                    (primary in regions[0], standbys with
+//	                    replicas:0), but the secondary is a cold/warm
+//	                    standby (no in-flight sync; backup/restore
+//	                    cutover). Distinguished from active-hot-standby
+//	                    only by the Blueprint's replication/switchover
+//	                    knobs, not by the fan-out plan.
+//
+// Legacy spellings (`single-region`, `active-hotstandby`) are still
+// ACCEPTED everywhere they were before — Canonicalize folds them onto
+// the canonical token so no existing Application CR, blueprint.yaml
+// `placementSchema.modes`, or in-flight POST breaks. New emitters
+// (the editors, the catalog-served modes) emit the canonical spelling.
 //
 // This package is pure functions — no I/O, no K8s client calls. It is
 // consumed by `internal/render` which serializes the per-region plan
 // to YAML manifests, and by the controller's status writer which uses
-// `Plan.PrimaryRegion` to populate `status.primaryRegion`.
+// `Plan.PrimaryRegion` to populate `status.primaryRegion`. It is the
+// single Go source of truth for the canonical vocabulary; the
+// catalyst-api handler + the FE editors mirror CanonicalModes() and a
+// CI drift test pins them together.
 package placement
 
 import (
 	"fmt"
 	"sort"
+	"strings"
 )
 
-// Mode constants — mirror the CRD enum at
-// products/catalyst/chart/crds/application.yaml.
+// Mode constants — the ONE canonical placement vocabulary (#3375
+// DoD-1). Mirror Blueprint.spec.topology.supported[] in
+// core/controllers/pkg/apis/blueprint/v1alpha1/topology_types.go and
+// the catalyst-api canonicaliser (endpoint_handler.go
+// canonicalizeTopology). Legacy spellings live in the Legacy* aliases
+// below; Canonicalize folds them onto these.
 const (
-	ModeSingleRegion     = "single-region"
+	ModeSingleton        = "singleton"
 	ModeActiveActive     = "active-active"
-	ModeActiveHotStandby = "active-hotstandby"
+	ModeActiveHotStandby = "active-hot-standby"
+	ModeActivePassive    = "active-passive"
 )
+
+// Legacy spelling aliases — accepted on input (existing CRs,
+// blueprint.yaml placementSchema.modes, in-flight POSTs) and folded
+// onto the canonical tokens by Canonicalize. NOT emitted by any new
+// surface.
+//
+// ModeSingleRegion is retained (valued "single-region") so existing
+// call sites + tests that reference it keep compiling and exercising
+// the legacy spelling through Canonicalize.
+//
+// Deprecated: use ModeSingleton — the canonical token is "singleton";
+// "single-region" is accepted on the wire only as a legacy alias.
+const (
+	ModeSingleRegion           = "single-region"
+	LegacyModeActiveHotStandby = "active-hotstandby"
+)
+
+// CanonicalModes returns the ordered canonical vocabulary — the single
+// source of truth every surface (catalog placementSchema, both
+// editors, the CR resolver) must agree on. The CI drift test
+// (placement_vocabulary_test.go) pins the FE + catalyst-api emitters
+// to this exact set.
+func CanonicalModes() []string {
+	return []string{
+		ModeSingleton,
+		ModeActiveActive,
+		ModeActiveHotStandby,
+		ModeActivePassive,
+	}
+}
+
+// Canonicalize folds any accepted spelling — canonical OR legacy alias
+// (and the underscore / hyphen variants the FE/UI historically posted)
+// — onto the ONE canonical token. Empty input returns empty (so the
+// "derive the Blueprint default" path is preserved). An unrecognised
+// non-empty value is returned trimmed + lower-cased unchanged, so the
+// caller still rejects it as unsupported with a clean error rather
+// than this function silently mangling it.
+//
+// This is the Go single source of truth for the alias mapping; the
+// catalyst-api handler (canonicalizeTopology) and the FE editors
+// (canonicalizeMode / canonicalizeTopologyMode) implement the SAME
+// mapping and the drift test asserts they agree.
+func Canonicalize(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "singleton", "single-region", "single_region":
+		return ModeSingleton
+	case "active-active", "active_active":
+		return ModeActiveActive
+	case "active-hot-standby", "active-hotstandby", "active_hot_standby":
+		return ModeActiveHotStandby
+	case "active-passive", "active_passive":
+		return ModeActivePassive
+	default:
+		return strings.ToLower(strings.TrimSpace(raw))
+	}
+}
+
+// IsCanonicalMode reports whether the (already-canonicalised) mode is
+// one of the four canonical tokens.
+func IsCanonicalMode(mode string) bool {
+	switch mode {
+	case ModeSingleton, ModeActiveActive, ModeActiveHotStandby, ModeActivePassive:
+		return true
+	}
+	return false
+}
 
 // Role constants — written onto status.regions[].role and consumed by
 // the Continuum controller for failover decisions.
@@ -96,10 +191,16 @@ type Plan struct {
 //
 // Validation:
 //
-//   - mode must be one of the three constants
+//   - mode must canonicalise to one of the four canonical constants
+//     (legacy spellings single-region / active-hotstandby are accepted
+//     and folded onto the canonical token via Canonicalize)
 //   - regions must be non-empty
-//   - single-region must have exactly one entry (the schema's minItems
-//     does not enforce maxItems for single-region; we validate here)
+//   - singleton must have exactly one entry (the schema's minItems
+//     does not enforce maxItems for singleton; we validate here)
+//
+// The returned Plan.Mode always carries the CANONICAL token regardless
+// of which spelling the caller passed, so downstream status writers +
+// the fan-out renderer see one vocabulary.
 //
 // Returns a typed error so the controller can map "spec invariant
 // violated" to a status.phase=Failed Condition with reason=Invalid.
@@ -107,18 +208,22 @@ func Resolve(mode string, regions []string) (Plan, error) {
 	if len(regions) == 0 {
 		return Plan{}, fmt.Errorf("placement: regions[] is empty")
 	}
-	switch mode {
-	case ModeSingleRegion:
-		// Per CRD description: "single-region = one cluster only.
+	// One vocabulary: fold any legacy spelling onto the canonical token
+	// BEFORE switching, so callers passing single-region / active-
+	// hotstandby resolve identically to the canonical spelling.
+	canon := Canonicalize(mode)
+	switch canon {
+	case ModeSingleton:
+		// Per CRD description: "singleton = one cluster only.
 		// regions[1..] (if any) are ignored." We could enforce
 		// len==1 here, but the schema allows up to 5 entries on the
 		// shared regions[] array. We surface the constraint as an
 		// Invalid Condition rather than silently dropping.
 		if len(regions) != 1 {
-			return Plan{}, fmt.Errorf("placement: single-region requires exactly 1 entry in regions[], got %d", len(regions))
+			return Plan{}, fmt.Errorf("placement: singleton requires exactly 1 entry in regions[], got %d", len(regions))
 		}
 		return Plan{
-			Mode:          mode,
+			Mode:          canon,
 			PrimaryRegion: regions[0],
 			Regions: []RegionPlan{
 				{Name: regions[0], Role: RolePrimary, Standby: false},
@@ -138,29 +243,33 @@ func Resolve(mode string, regions []string) (Plan, error) {
 			out[i] = RegionPlan{Name: r, Role: RoleActive, Standby: false}
 		}
 		return Plan{
-			Mode:          mode,
+			Mode:          canon,
 			PrimaryRegion: "",
 			Regions:       out,
 		}, nil
 
-	case ModeActiveHotStandby:
+	case ModeActiveHotStandby, ModeActivePassive:
 		// Asymmetric: regions[0] is primary (runs hot), regions[1..]
 		// are standby (replicas: 0). Order is load-bearing — preserved
-		// from the spec.
+		// from the spec. active-passive shares the SAME fan-out plan as
+		// active-hot-standby (primary + replicas:0 standbys); the two
+		// differ only by the Blueprint's replication/switchover knobs
+		// (sync vs cold/warm), which are not expressed in the per-region
+		// work plan.
 		out := make([]RegionPlan, len(regions))
 		out[0] = RegionPlan{Name: regions[0], Role: RolePrimary, Standby: false}
 		for i := 1; i < len(regions); i++ {
 			out[i] = RegionPlan{Name: regions[i], Role: RoleStandby, Standby: true}
 		}
 		return Plan{
-			Mode:          mode,
+			Mode:          canon,
 			PrimaryRegion: regions[0],
 			Regions:       out,
 		}, nil
 
 	default:
-		return Plan{}, fmt.Errorf("placement: unknown mode %q (expected one of: %s, %s, %s)",
-			mode, ModeSingleRegion, ModeActiveActive, ModeActiveHotStandby)
+		return Plan{}, fmt.Errorf("placement: unknown mode %q (expected one of: %s, %s, %s, %s)",
+			mode, ModeSingleton, ModeActiveActive, ModeActiveHotStandby, ModeActivePassive)
 	}
 }
 
@@ -170,12 +279,20 @@ func Resolve(mode string, regions []string) (Plan, error) {
 // allowed (the legacy default for Blueprints authored before the
 // placementSchema was added; per BLUEPRINT-AUTHORING.md §3 the field
 // is optional).
+//
+// Both `mode` and each `allowed` entry are canonicalised before
+// comparison, so a Blueprint that declares the legacy spelling
+// `single-region` in `placementSchema.modes` still admits a canonical
+// `singleton` instance (and vice versa) — the one-vocabulary rule must
+// not regress the 71-blueprint corpus that pre-dates the canonical
+// spelling.
 func AllowedByBlueprint(mode string, allowed []string) bool {
 	if len(allowed) == 0 {
 		return true
 	}
+	want := Canonicalize(mode)
 	for _, m := range allowed {
-		if m == mode {
+		if Canonicalize(m) == want {
 			return true
 		}
 	}
@@ -188,6 +305,10 @@ func AllowedByBlueprint(mode string, allowed []string) bool {
 // controller startup from the SOVEREIGN_BCP_TOPOLOGY env the
 // bp-catalyst-platform chart slot 13 stamps from cloud-init. The
 // controller passes this into EffectiveDefault below.
+//
+// The env the chart stamps still carries the legacy provisioner
+// spelling (`single-region` / `active-hotstandby`), so these retain
+// the legacy values; EffectiveDefault canonicalises before comparing.
 const (
 	SovereignTopologySingleRegion     = "single-region"
 	SovereignTopologyActiveHotStandby = "active-hotstandby"
@@ -197,17 +318,19 @@ const (
 // EffectiveDefault picks the right placement mode when the Application
 // CR's spec.placement is empty:
 //
-//  1. If the Sovereign is multi-region (active-hotstandby /
+//  1. If the Sovereign is multi-region (active-hot-standby /
 //     active-active) AND the Blueprint declares
-//     `placementSchema.defaultOnMultiRegion`, return that. This is the
-//     G93.2 (Refs #2667) target-state — every CNPG-backed Blueprint
-//     sets defaultOnMultiRegion="active-hotstandby" so a fresh
-//     marketplace install on a 2-region Sovereign lands Pillar 3
-//     zero-touch.
-//  2. Otherwise fall back to `placementSchema.default` (the existing
-//     single-knob default).
-//  3. If neither is set, return "single-region" as the safe last
-//     resort.
+//     `placementSchema.defaultOnMultiRegion`, return that (canonicalised).
+//     This is the G93.2 (Refs #2667) target-state — every CNPG-backed
+//     Blueprint sets defaultOnMultiRegion so a fresh marketplace install
+//     on a 2-region Sovereign lands Pillar 3 zero-touch.
+//  2. Otherwise fall back to `placementSchema.default` (canonicalised).
+//  3. If neither is set, return "singleton" as the safe last resort.
+//
+// The returned value is always a CANONICAL token (legacy spellings in
+// the Blueprint declarations are folded). The Sovereign-topology input
+// is canonicalised before the multi-region test so the legacy env
+// spelling (`active-hotstandby`) resolves the same as the canonical.
 //
 // Per-Blueprint declarative seam: the Blueprint author picks the
 // preferred multi-region default; the application-controller honours it
@@ -221,14 +344,14 @@ const (
 // blueprint-controller's validator catches at publish time
 // (validate.go §placementSchema.defaultOnMultiRegion-in-modes).
 func EffectiveDefault(sovereignTopology, blueprintDefault, blueprintDefaultOnMultiRegion string) string {
-	switch sovereignTopology {
-	case SovereignTopologyActiveHotStandby, SovereignTopologyActiveActive:
+	switch Canonicalize(sovereignTopology) {
+	case ModeActiveHotStandby, ModeActiveActive, ModeActivePassive:
 		if blueprintDefaultOnMultiRegion != "" {
-			return blueprintDefaultOnMultiRegion
+			return Canonicalize(blueprintDefaultOnMultiRegion)
 		}
 	}
 	if blueprintDefault != "" {
-		return blueprintDefault
+		return Canonicalize(blueprintDefault)
 	}
-	return ModeSingleRegion
+	return ModeSingleton
 }

--- a/core/controllers/internal/placement/placement_test.go
+++ b/core/controllers/internal/placement/placement_test.go
@@ -4,10 +4,13 @@ import (
 	"testing"
 )
 
-func TestResolveSingleRegion(t *testing.T) {
-	p, err := Resolve(ModeSingleRegion, []string{"hetzner-fsn-rtz-prod"})
+func TestResolveSingleton(t *testing.T) {
+	p, err := Resolve(ModeSingleton, []string{"hetzner-fsn-rtz-prod"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Mode != ModeSingleton {
+		t.Errorf("Plan.Mode = %q, want canonical %q", p.Mode, ModeSingleton)
 	}
 	if p.PrimaryRegion != "hetzner-fsn-rtz-prod" {
 		t.Errorf("primary region = %q", p.PrimaryRegion)
@@ -17,10 +20,23 @@ func TestResolveSingleRegion(t *testing.T) {
 	}
 }
 
-func TestResolveSingleRegionRejectsMulti(t *testing.T) {
-	_, err := Resolve(ModeSingleRegion, []string{"a", "b"})
+// The legacy spelling resolves IDENTICALLY to the canonical token —
+// one vocabulary on the wire (#3375 DoD-1), legacy aliases folded so no
+// existing CR / blueprint.yaml / in-flight POST breaks.
+func TestResolveSingleton_LegacyAliasFoldsToCanonical(t *testing.T) {
+	p, err := Resolve(ModeSingleRegion /* "single-region" */, []string{"hetzner-fsn-rtz-prod"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Mode != ModeSingleton {
+		t.Errorf("legacy single-region must resolve to canonical singleton, got %q", p.Mode)
+	}
+}
+
+func TestResolveSingletonRejectsMulti(t *testing.T) {
+	_, err := Resolve(ModeSingleton, []string{"a", "b"})
 	if err == nil {
-		t.Fatal("expected error for single-region with 2 entries")
+		t.Fatal("expected error for singleton with 2 entries")
 	}
 }
 
@@ -54,6 +70,9 @@ func TestResolveActiveHotStandby(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if p.Mode != ModeActiveHotStandby {
+		t.Errorf("Plan.Mode = %q, want canonical %q", p.Mode, ModeActiveHotStandby)
+	}
 	if p.PrimaryRegion != "hetzner-fsn-rtz-prod" {
 		t.Errorf("primary region = %q", p.PrimaryRegion)
 	}
@@ -67,8 +86,45 @@ func TestResolveActiveHotStandby(t *testing.T) {
 	}
 }
 
+// The legacy spelling active-hotstandby folds onto the canonical token
+// AND produces the same fan-out plan.
+func TestResolveActiveHotStandby_LegacyAliasFoldsToCanonical(t *testing.T) {
+	p, err := Resolve(LegacyModeActiveHotStandby /* "active-hotstandby" */, []string{"a", "b"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Mode != ModeActiveHotStandby {
+		t.Errorf("legacy active-hotstandby must resolve to canonical active-hot-standby, got %q", p.Mode)
+	}
+	if !p.Regions[1].Standby {
+		t.Errorf("regions[1] should be standby (replicas:0): %+v", p.Regions[1])
+	}
+}
+
+// active-passive is the fourth canonical class. It shares the SAME
+// fan-out plan as active-hot-standby (primary + replicas:0 standbys) —
+// the two differ only in the Blueprint's replication/switchover knobs.
+func TestResolveActivePassive(t *testing.T) {
+	p, err := Resolve(ModeActivePassive, []string{"hetzner-fsn-rtz-prod", "hetzner-nbg-rtz-prod"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Mode != ModeActivePassive {
+		t.Errorf("Plan.Mode = %q, want canonical %q", p.Mode, ModeActivePassive)
+	}
+	if p.PrimaryRegion != "hetzner-fsn-rtz-prod" {
+		t.Errorf("primary region = %q", p.PrimaryRegion)
+	}
+	if p.Regions[0].Role != RolePrimary || p.Regions[0].Standby {
+		t.Errorf("regions[0] should be primary not standby: %+v", p.Regions[0])
+	}
+	if p.Regions[1].Role != RoleStandby || !p.Regions[1].Standby {
+		t.Errorf("regions[1] should be standby (replicas:0): %+v", p.Regions[1])
+	}
+}
+
 func TestResolveEmptyRegions(t *testing.T) {
-	_, err := Resolve(ModeSingleRegion, []string{})
+	_, err := Resolve(ModeSingleton, []string{})
 	if err == nil {
 		t.Fatal("expected error for empty regions")
 	}
@@ -81,15 +137,75 @@ func TestResolveUnknownMode(t *testing.T) {
 	}
 }
 
+// ── Canonicalize / vocabulary contract ───────────────────────────────
+
+func TestCanonicalize_FoldsEverySpelling(t *testing.T) {
+	cases := map[string]string{
+		// canonical → itself
+		"singleton":          ModeSingleton,
+		"active-active":      ModeActiveActive,
+		"active-hot-standby": ModeActiveHotStandby,
+		"active-passive":     ModeActivePassive,
+		// legacy → canonical
+		"single-region":    ModeSingleton,
+		"active-hotstandby": ModeActiveHotStandby,
+		// underscore + case variants
+		"ACTIVE_HOT_STANDBY": ModeActiveHotStandby,
+		"  Single-Region ":   ModeSingleton,
+		// unknown → trimmed/lowered, unchanged otherwise
+		"bogus": "bogus",
+		"":      "",
+	}
+	for in, want := range cases {
+		if got := Canonicalize(in); got != want {
+			t.Errorf("Canonicalize(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCanonicalModes_IsTheFourCanonicalTokens(t *testing.T) {
+	got := CanonicalModes()
+	want := []string{"singleton", "active-active", "active-hot-standby", "active-passive"}
+	if len(got) != len(want) {
+		t.Fatalf("CanonicalModes() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("CanonicalModes()[%d] = %q, want %q", i, got[i], want[i])
+		}
+		if !IsCanonicalMode(got[i]) {
+			t.Errorf("IsCanonicalMode(%q) = false, want true", got[i])
+		}
+	}
+	// No legacy spelling is a canonical token.
+	for _, legacy := range []string{"single-region", "active-hotstandby"} {
+		if IsCanonicalMode(legacy) {
+			t.Errorf("IsCanonicalMode(%q) = true, want false (legacy spelling is NOT canonical)", legacy)
+		}
+	}
+}
+
 func TestAllowedByBlueprint(t *testing.T) {
-	if !AllowedByBlueprint(ModeSingleRegion, nil) {
+	if !AllowedByBlueprint(ModeSingleton, nil) {
 		t.Error("nil allowed list should match all modes")
 	}
-	if !AllowedByBlueprint(ModeSingleRegion, []string{ModeSingleRegion, ModeActiveActive}) {
-		t.Error("expected single-region to be allowed")
+	if !AllowedByBlueprint(ModeSingleton, []string{ModeSingleton, ModeActiveActive}) {
+		t.Error("expected singleton to be allowed")
 	}
-	if AllowedByBlueprint(ModeActiveHotStandby, []string{ModeSingleRegion}) {
-		t.Error("expected active-hotstandby to be rejected")
+	if AllowedByBlueprint(ModeActiveHotStandby, []string{ModeSingleton}) {
+		t.Error("expected active-hot-standby to be rejected")
+	}
+	// Cross-spelling: a Blueprint declaring the LEGACY spelling in
+	// placementSchema.modes still admits a CANONICAL instance and vice
+	// versa — the one-vocabulary rule must not regress the corpus.
+	if !AllowedByBlueprint(ModeSingleton, []string{"single-region", "active-active"}) {
+		t.Error("canonical singleton must match legacy single-region in modes[]")
+	}
+	if !AllowedByBlueprint("single-region", []string{ModeSingleton, ModeActiveActive}) {
+		t.Error("legacy single-region must match canonical singleton in modes[]")
+	}
+	if !AllowedByBlueprint("active-hotstandby", []string{ModeActiveHotStandby}) {
+		t.Error("legacy active-hotstandby must match canonical active-hot-standby in modes[]")
 	}
 }
 
@@ -97,30 +213,32 @@ func TestAllowedByBlueprint(t *testing.T) {
 //
 // Pins the four-decision lattice (sovereign topology × Blueprint
 // declarations) so a future refactor cannot silently regress the
-// Pillar-3 zero-touch contract.
+// Pillar-3 zero-touch contract. Post-#3375 the returned value is always
+// a CANONICAL token (legacy spellings in the Blueprint declarations or
+// the Sovereign-topology env are folded).
 
 func TestEffectiveDefault_MultiRegionUsesBlueprintOverride(t *testing.T) {
 	got := EffectiveDefault(
-		SovereignTopologyActiveHotStandby,
-		ModeSingleRegion,     // single-knob default
-		ModeActiveHotStandby, // multi-region default
+		SovereignTopologyActiveHotStandby,     // legacy env spelling
+		ModeSingleRegion,                      // single-knob default (legacy spelling)
+		LegacyModeActiveHotStandby,            // multi-region default (legacy spelling)
 	)
 	if got != ModeActiveHotStandby {
-		t.Fatalf("EffectiveDefault(hot-standby, sr, ahs) = %q, want %q", got, ModeActiveHotStandby)
+		t.Fatalf("EffectiveDefault(hot-standby, sr, ahs) = %q, want canonical %q", got, ModeActiveHotStandby)
 	}
 }
 
 func TestEffectiveDefault_MultiRegionFallsBackToDefault(t *testing.T) {
 	// Blueprint did not declare defaultOnMultiRegion — fall back to the
-	// existing placementSchema.default so existing Blueprints don't
-	// change behaviour.
+	// existing placementSchema.default (canonicalised) so existing
+	// Blueprints don't change behaviour.
 	got := EffectiveDefault(
 		SovereignTopologyActiveHotStandby,
 		ModeSingleRegion,
 		"",
 	)
-	if got != ModeSingleRegion {
-		t.Fatalf("EffectiveDefault(hot-standby, sr, '') = %q, want %q", got, ModeSingleRegion)
+	if got != ModeSingleton {
+		t.Fatalf("EffectiveDefault(hot-standby, sr, '') = %q, want canonical %q", got, ModeSingleton)
 	}
 }
 
@@ -129,10 +247,10 @@ func TestEffectiveDefault_SingleRegionIgnoresMultiRegionOverride(t *testing.T) {
 	got := EffectiveDefault(
 		SovereignTopologySingleRegion,
 		ModeSingleRegion,
-		ModeActiveHotStandby,
+		LegacyModeActiveHotStandby,
 	)
-	if got != ModeSingleRegion {
-		t.Fatalf("EffectiveDefault(sr, sr, ahs) = %q, want %q", got, ModeSingleRegion)
+	if got != ModeSingleton {
+		t.Fatalf("EffectiveDefault(sr, sr, ahs) = %q, want canonical %q", got, ModeSingleton)
 	}
 }
 
@@ -150,18 +268,19 @@ func TestEffectiveDefault_ActiveActiveUsesMultiRegionOverride(t *testing.T) {
 
 func TestEffectiveDefault_NoBlueprintDefaultsAtAll(t *testing.T) {
 	// Defensive: Blueprint forgot to declare either knob — safe last
-	// resort is single-region so the controller can still install.
+	// resort is the canonical singleton so the controller can still
+	// install.
 	got := EffectiveDefault(SovereignTopologyActiveHotStandby, "", "")
-	if got != ModeSingleRegion {
-		t.Fatalf("EffectiveDefault(hot-standby, '', '') = %q, want %q (safe fallback)", got, ModeSingleRegion)
+	if got != ModeSingleton {
+		t.Fatalf("EffectiveDefault(hot-standby, '', '') = %q, want canonical %q (safe fallback)", got, ModeSingleton)
 	}
 }
 
 func TestEffectiveDefault_UnknownTopologyFallsBackToDefault(t *testing.T) {
 	// Defensive: an unset / typo'd SOVEREIGN_BCP_TOPOLOGY env should
 	// behave like single-region (no multi-region override).
-	got := EffectiveDefault("", ModeSingleRegion, ModeActiveHotStandby)
-	if got != ModeSingleRegion {
-		t.Fatalf("EffectiveDefault('', sr, ahs) = %q, want %q", got, ModeSingleRegion)
+	got := EffectiveDefault("", ModeSingleRegion, LegacyModeActiveHotStandby)
+	if got != ModeSingleton {
+		t.Fatalf("EffectiveDefault('', sr, ahs) = %q, want canonical %q", got, ModeSingleton)
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-16T16:49:44.547Z",
+  "generatedAt": "2026-06-17T09:55:11.877Z",
   "blueprints": [
     {
       "id": "bp-alloy",
@@ -267,7 +267,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
@@ -338,6 +338,62 @@
         "perTopology": {
           "singleton": {
             "replication": null,
+            "switchover": null,
+            "placement": {
+              "tier": "",
+              "clusters": [
+                "mgmt-A",
+                "mgmt-B",
+                "dmz-A",
+                "dmz-B",
+                "rtz-A",
+                "rtz-B"
+              ],
+              "roles": {
+                "mgmt-A": "singleton",
+                "mgmt-B": "singleton",
+                "dmz-A": "singleton",
+                "dmz-B": "singleton",
+                "rtz-A": "singleton",
+                "rtz-B": "singleton"
+              }
+            }
+          }
+        }
+      },
+      "hasUserUIEndpoint": false
+    },
+    {
+      "id": "bp-cert-manager-issuers",
+      "slug": "cert-manager-issuers",
+      "title": "cert-manager — Issuers",
+      "summary": "|",
+      "icon": "cert-manager.svg",
+      "category": "security",
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.0",
+      "section": "pts-3-3-security-and-policy",
+      "depends": [
+        "bp-cert-manager"
+      ],
+      "shareable": false,
+      "contextSchema": null,
+      "producesInstances": null,
+      "topology": {
+        "supported": [
+          "singleton"
+        ],
+        "multiRegion": "singleton",
+        "singleRegion": "singleton",
+        "perTopology": {
+          "singleton": {
+            "replication": {
+              "backend": "flux-git",
+              "mode": "async",
+              "lagSloSeconds": null
+            },
             "switchover": null,
             "placement": {
               "tier": "",
@@ -698,7 +754,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "listed",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "section": "pts-9-disaster-recovery",
       "depends": [
         "bp-cnpg",
@@ -1372,7 +1428,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "section": "pts-3-2-gitops-and-iac",
       "depends": [],
       "shareable": false,
@@ -1978,7 +2034,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.4.28",
+      "version": "1.4.30",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-postgres"
@@ -2179,7 +2235,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "section": "pts-3-3-security-and-policy",
       "depends": [],
       "shareable": false,
@@ -2730,7 +2786,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "section": "pts-3-2-control-plane-isolation",
       "depends": [
         "bp-cilium",
@@ -3295,7 +3351,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-cilium",
@@ -4287,7 +4343,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.1.74",
+      "version": "0.1.75",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-gitea",
@@ -4448,7 +4504,7 @@
       "tagline": null,
       "tags": [],
       "visibility": "unlisted",
-      "version": "0.2.18",
+      "version": "0.2.20",
       "section": "pts-2-3-per-sovereign-supporting-services",
       "depends": [
         "bp-keycloak",

--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -209,7 +209,8 @@ func applicationInstallRequestNormalize(b applicationInstallRequest) application
 		b.Parameters = b.ValuesShort
 	}
 	if strings.TrimSpace(b.Placement.Mode) == "" {
-		b.Placement.Mode = "single-region"
+		// One vocabulary (#3375 DoD-1): canonical default.
+		b.Placement.Mode = "singleton"
 	}
 	if len(b.Placement.Regions) == 0 {
 		b.Placement.Regions = []string{"primary"}
@@ -823,10 +824,14 @@ func validateApplicationInstallRequest(req applicationInstallRequest) (string, b
 	if strings.TrimSpace(req.Placement.Mode) == "" {
 		return "placement.mode is required", false
 	}
-	switch req.Placement.Mode {
-	case "single-region", "active-active", "active-hotstandby":
+	// One vocabulary (#3375 DoD-1): canonicalise the posted mode (folds
+	// the legacy editor dialect single-region / active-hotstandby) then
+	// accept the four canonical classes. The editors now emit canonical;
+	// legacy spellings remain admissible so in-flight callers don't break.
+	switch canonicalizeTopology(req.Placement.Mode) {
+	case "singleton", "active-active", "active-hot-standby", "active-passive":
 	default:
-		return "placement.mode must be one of single-region, active-active, active-hotstandby", false
+		return "placement.mode must be one of singleton, active-active, active-hot-standby, active-passive (legacy single-region / active-hotstandby also accepted)", false
 	}
 	if len(req.Placement.Regions) == 0 {
 		return "placement.regions must list at least one region", false
@@ -937,15 +942,22 @@ func newApplicationUnstructured(req applicationInstallRequest) *unstructured.Uns
 	for _, r := range req.Placement.Regions {
 		regions = append(regions, r)
 	}
-	// #3373 — spec.placement is dual-form. The legacy string form
-	// stays byte-identical for callers that never set the WHERE
-	// fields; the OBJECT form {mode, vcluster, regions, clusters}
-	// carries the instance placement when the caller (console
-	// advanced view / direct API) declares it.
-	var placementValue any = req.Placement.Mode
+	// One vocabulary (#3375 DoD-1): the CR always STORES the canonical
+	// placement token (singleton / active-active / active-hot-standby /
+	// active-passive), regardless of which spelling the caller posted.
+	// The legacy editor dialect (single-region / active-hotstandby) is
+	// folded here so every Application CR carries one vocabulary and the
+	// resolver/render path never sees a legacy spelling.
+	canonMode := canonicalizeTopology(req.Placement.Mode)
+	// #3373 — spec.placement is dual-form. The string form carries the
+	// canonical posture for callers that never set the WHERE fields; the
+	// OBJECT form {mode, vcluster, regions, clusters} carries the
+	// instance placement when the caller (console advanced view / direct
+	// API) declares it.
+	var placementValue any = canonMode
 	if req.Placement.VCluster != "" || len(req.Placement.Clusters) > 0 {
 		pl := map[string]any{
-			"mode":     req.Placement.Mode,
+			"mode":     canonMode,
 			"vcluster": req.Placement.VCluster,
 		}
 		if len(req.Placement.Regions) > 0 {

--- a/products/catalyst/bootstrap/api/internal/handler/applications_preview.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_preview.go
@@ -125,7 +125,8 @@ func applicationPreviewRequestNormalize(b applicationPreviewRequest) application
 		b.Parameters = b.ValuesShort
 	}
 	if strings.TrimSpace(b.Placement.Mode) == "" {
-		b.Placement.Mode = "single-region"
+		// One vocabulary (#3375 DoD-1): canonical default.
+		b.Placement.Mode = "singleton"
 	}
 	if len(b.Placement.Regions) == 0 {
 		b.Placement.Regions = []string{"primary"}
@@ -517,10 +518,13 @@ func validateApplicationPreviewRequest(req applicationPreviewRequest) (string, b
 	if strings.TrimSpace(req.Placement.Mode) == "" {
 		return "placement.mode is required", false
 	}
-	switch req.Placement.Mode {
-	case "single-region", "active-active", "active-hotstandby":
+	// One vocabulary (#3375 DoD-1): canonicalise then accept the four
+	// canonical classes (legacy single-region / active-hotstandby still
+	// folded so in-flight callers don't break).
+	switch canonicalizeTopology(req.Placement.Mode) {
+	case "singleton", "active-active", "active-hot-standby", "active-passive":
 	default:
-		return "placement.mode must be one of single-region, active-active, active-hotstandby", false
+		return "placement.mode must be one of singleton, active-active, active-hot-standby, active-passive (legacy single-region / active-hotstandby also accepted)", false
 	}
 	if len(req.Placement.Regions) == 0 {
 		return "placement.regions must list at least one region", false

--- a/products/catalyst/bootstrap/api/internal/handler/applications_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_test.go
@@ -202,8 +202,10 @@ func TestHandleApplicationInstall_CreatesApplicationCR(t *testing.T) {
 	if v, _, _ := unstructured.NestedString(got.Object, "spec", "environmentRef"); v != "acme-prod" {
 		t.Fatalf("spec.environmentRef: got %q", v)
 	}
-	if v, _, _ := unstructured.NestedString(got.Object, "spec", "placement"); v != "single-region" {
-		t.Fatalf("spec.placement: got %q", v)
+	// One vocabulary (#3375 DoD-1): the body posted the legacy spelling
+	// "single-region"; the CR STORES the canonical token "singleton".
+	if v, _, _ := unstructured.NestedString(got.Object, "spec", "placement"); v != "singleton" {
+		t.Fatalf("spec.placement: got %q, want canonical singleton (legacy single-region folded)", v)
 	}
 	regions, _, _ := unstructured.NestedStringSlice(got.Object, "spec", "regions")
 	if len(regions) != 1 || regions[0] != "hz-fsn-rtz-prod" {

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update.go
@@ -395,7 +395,10 @@ func (h *Handler) HandleApplicationUpdate(w http.ResponseWriter, r *http.Request
 		_ = unstructured.SetNestedMap(patched.Object, paramsCopy, "spec", "parameters")
 	}
 	if body.Placement != nil {
-		_ = unstructured.SetNestedField(patched.Object, body.Placement.Mode, "spec", "placement")
+		// One vocabulary (#3375 DoD-1): the patched CR stores the
+		// canonical placement token regardless of which spelling the PUT
+		// body carried.
+		_ = unstructured.SetNestedField(patched.Object, canonicalizeTopology(body.Placement.Mode), "spec", "placement")
 		regionsAny := make([]interface{}, 0, len(body.Placement.Regions))
 		for _, reg := range body.Placement.Regions {
 			regionsAny = append(regionsAny, reg)
@@ -790,15 +793,16 @@ func (h *Handler) handleApplicationChangePreview(w http.ResponseWriter, r *http.
 		target.Parameters = body.Parameters
 	}
 
-	// Default placement.mode to "single-region" when neither the body nor
-	// the current Application CR sets one. The matrix (TC-107) issues
-	// previews on Applications that pre-date the placement field; rather
-	// than 400 on the operator-friendly "preview as-is" use case we
-	// surface the canonical default. `regions` defaults to a stamped
-	// single-region list so renderApplicationPreview has something to
-	// project; downstream consumers that care override before submit.
+	// Default placement.mode to the canonical "singleton" (#3375 DoD-1)
+	// when neither the body nor the current Application CR sets one. The
+	// matrix (TC-107) issues previews on Applications that pre-date the
+	// placement field; rather than 400 on the operator-friendly "preview
+	// as-is" use case we surface the canonical default. `regions`
+	// defaults to a stamped single-entry list so renderApplicationPreview
+	// has something to project; downstream consumers that care override
+	// before submit.
 	if strings.TrimSpace(target.Placement.Mode) == "" {
-		target.Placement.Mode = "single-region"
+		target.Placement.Mode = "singleton"
 	}
 	if len(target.Placement.Regions) == 0 {
 		target.Placement.Regions = []string{previewDefaultRegion}
@@ -847,10 +851,13 @@ func validateApplicationUpdateRequest(req applicationUpdateRequest) (string, boo
 		if strings.TrimSpace(req.Placement.Mode) == "" {
 			return "placement.mode is required when placement is set", false
 		}
-		switch req.Placement.Mode {
-		case "single-region", "active-active", "active-hotstandby":
+		// One vocabulary (#3375 DoD-1): canonicalise then accept the four
+		// canonical classes (legacy single-region / active-hotstandby
+		// still folded so in-flight callers don't break).
+		switch canonicalizeTopology(req.Placement.Mode) {
+		case "singleton", "active-active", "active-hot-standby", "active-passive":
 		default:
-			return "placement.mode must be one of single-region, active-active, active-hotstandby", false
+			return "placement.mode must be one of singleton, active-active, active-hot-standby, active-passive (legacy single-region / active-hotstandby also accepted)", false
 		}
 		if len(req.Placement.Regions) == 0 {
 			return "placement.regions must list at least one region", false
@@ -870,21 +877,28 @@ func validateApplicationUpdateRequest(req applicationUpdateRequest) (string, boo
 // topologyTransitionAllowed — guards against destructive transitions
 // (anything that scales DOWN replicas) without explicit ?force=true.
 //
+// Both modes are canonicalised first (#3375 DoD-1) so the guard fires
+// correctly whether the CR stored / the request posted a canonical or
+// legacy spelling — the destructive case is "downgrade to singleton
+// from a multi-region class", in ONE vocabulary.
+//
 // Allowed without force:
 //   - same mode, same regions (no-op)
 //   - same mode, regions ADDED (scale up)
-//   - single-region → active-active or active-hotstandby (scale up)
-//   - active-hotstandby promote (regions reordered, count same/up)
+//   - singleton → active-active / active-hot-standby / active-passive (scale up)
+//   - active-hot-standby promote (regions reordered, count same/up)
 //
 // Blocked without force:
-//   - active-active → single-region (replica drop)
+//   - active-active / active-hot-standby / active-passive → singleton (replica drop)
 //   - any mode → fewer regions
 func topologyTransitionAllowed(curMode string, curRegions []string, newMode string, newRegions []string) (string, bool) {
-	if newMode == "single-region" && curMode == "active-active" {
-		return "active-active → single-region scales down replicas; pass ?force=true to confirm", false
+	cur := canonicalizeTopology(curMode)
+	next := canonicalizeTopology(newMode)
+	if next == "singleton" && cur == "active-active" {
+		return "active-active → singleton scales down replicas; pass ?force=true to confirm", false
 	}
-	if newMode == "single-region" && curMode == "active-hotstandby" {
-		return "active-hotstandby → single-region drops standby replicas; pass ?force=true to confirm", false
+	if next == "singleton" && (cur == "active-hot-standby" || cur == "active-passive") {
+		return fmt.Sprintf("%s → singleton drops standby replicas; pass ?force=true to confirm", cur), false
 	}
 	if len(newRegions) < len(curRegions) {
 		return fmt.Sprintf("regions count drops %d → %d; pass ?force=true to confirm", len(curRegions), len(newRegions)), false

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update_test.go
@@ -125,8 +125,10 @@ func TestHandleApplicationUpdate_TopologyScaleUp_Succeeds(t *testing.T) {
 	}
 	got, _ := client.Resource(ApplicationGVR()).Namespace("acme").Get(context.Background(), "wp-prod", metav1.GetOptions{})
 	mode, _, _ := unstructured.NestedString(got.Object, "spec", "placement")
-	if mode != "active-hotstandby" {
-		t.Fatalf("placement not patched: got %q", mode)
+	// One vocabulary (#3375 DoD-1): the PUT posted the legacy spelling
+	// "active-hotstandby"; the CR STORES the canonical "active-hot-standby".
+	if mode != "active-hot-standby" {
+		t.Fatalf("placement not patched to canonical: got %q, want active-hot-standby", mode)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/applications_wire_compat.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_wire_compat.go
@@ -97,9 +97,10 @@ func applicationDefaultPrimaryRegionFromEnv() string {
 }
 
 // applicationDefaultPlacementMode is the literal fallback placement.
-// Single-region is the safest default; the caller can always promote
-// post-install via PUT .../applications/{name} with ?force=true.
-const applicationDefaultPlacementMode = "single-region"
+// The canonical "singleton" (#3375 DoD-1) is the safest default — one
+// cluster, no failover; the caller can always promote post-install via
+// PUT .../applications/{name} with ?force=true.
+const applicationDefaultPlacementMode = "singleton"
 
 // applicationSimplifiedInstall mirrors the simplified-shape install
 // body. ALL fields are optional from a JSON-decode standpoint; the

--- a/products/catalyst/bootstrap/api/internal/handler/applications_wire_compat_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_wire_compat_test.go
@@ -61,8 +61,9 @@ func TestDecodeApplicationInstallBody_SimplifiedMatrixShape(t *testing.T) {
 	if got.Name != "qa-wp" {
 		t.Errorf("name wrong: %q", got.Name)
 	}
-	if got.Placement.Mode != "single-region" {
-		t.Errorf("default placement mode wrong: %q", got.Placement.Mode)
+	// One vocabulary (#3375 DoD-1): the canonical default is "singleton".
+	if got.Placement.Mode != "singleton" {
+		t.Errorf("default placement mode wrong: %q, want canonical singleton", got.Placement.Mode)
 	}
 	// Default regions is `["primary"]` (a sentinel) per
 	// applicationInstallRequestNormalize; the caller is expected to

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
@@ -2105,15 +2105,17 @@ func newApplicationCRFromSeed(seed instances.ApplicationSeed) *unstructured.Unst
 	obj.SetName(seed.Name)
 	obj.SetNamespace(seed.Namespace)
 	obj.SetLabels(seed.Labels)
-	// #3373 — spec.placement is dual-form. The legacy string form
-	// (the chosen topology) stays byte-identical when the user
-	// silently accepted the Blueprint defaults; the OBJECT form
-	// carries the advanced view's instance placement.
+	// One vocabulary (#3375 DoD-1): both the string AND object forms
+	// stamp the CANONICAL placement token. placementForTopology folds
+	// the chosen topology (which may already be a canonical G117 class,
+	// e.g. singleton / active-hot-standby) onto the canonical posture;
+	// the object form's `mode` is canonicalised too so the two forms
+	// never disagree.
 	var placementValue interface{} = placementForTopology(seed.Topology)
 	regions := []interface{}{"primary"}
 	if seed.Placement != nil {
 		pl := map[string]interface{}{
-			"mode": seed.Topology,
+			"mode": canonicalizeTopology(seed.Topology),
 		}
 		if seed.Placement.VCluster != "" {
 			pl["vcluster"] = seed.Placement.VCluster
@@ -2164,17 +2166,21 @@ func newApplicationCRFromSeed(seed instances.ApplicationSeed) *unstructured.Unst
 }
 
 // placementForTopology maps a BCP topology choice onto the Application
-// CRD's spec.placement enum (#3370).
+// CRD's spec.placement value (#3370). Post-#3375 DoD-1 it produces the
+// ONE canonical placement vocabulary (singleton / active-active /
+// active-hot-standby / active-passive) — the same set the catalog
+// placementSchema, both editors, and the application-controller's
+// resolver speak. It accepts any spelling (canonical OR the legacy
+// editor dialect) and folds it onto the canonical token via
+// canonicalizeTopology. Empty / unknown → singleton (the safe default
+// posture).
 func placementForTopology(topology string) string {
-	switch topology {
-	case "active-active":
-		return "active-active"
-	case "active-hot-standby", "active-hotstandby", "active-passive":
-		return "active-hotstandby"
-	default:
-		// singleton / empty / unknown → the single-region posture.
-		return "single-region"
+	if c := canonicalizeTopology(topology); c == "singleton" ||
+		c == "active-active" || c == "active-hot-standby" || c == "active-passive" {
+		return c
 	}
+	// empty / unknown → the singleton posture (one cluster, no failover).
+	return "singleton"
 }
 
 // readPhase + readTopology read the most-informative status field for

--- a/products/catalyst/bootstrap/api/internal/handler/placement_3373_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/placement_3373_test.go
@@ -11,18 +11,23 @@ import (
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/instances"
 )
 
-func TestNewApplicationUnstructured_LegacyStringForm(t *testing.T) {
+func TestNewApplicationUnstructured_StringForm_StoresCanonical(t *testing.T) {
 	req := applicationInstallRequest{
 		BlueprintRef:    applicationBlueprintRef{Name: "bp-wp", Version: "1.0.0"},
 		Name:            "site",
 		OrganizationRef: "acme",
 		EnvironmentRef:  "acme-prod",
-		Placement:       applicationPlacement{Mode: "single-region", Regions: []string{"fsn"}},
+		// Legacy editor dialect on the wire …
+		Placement: applicationPlacement{Mode: "single-region", Regions: []string{"fsn"}},
 	}
 	obj := newApplicationUnstructured(req)
 	pl, ok, err := unstructured.NestedString(obj.Object, "spec", "placement")
-	if err != nil || !ok || pl != "single-region" {
-		t.Fatalf("legacy callers must keep the byte-identical string form, got (%q, %v, %v)", pl, ok, err)
+	// One vocabulary (#3375 DoD-1): the CR STORES the canonical token —
+	// the legacy "single-region" is folded to "singleton" so every CR
+	// carries one vocabulary the resolver/render path can rely on. The
+	// string form is preserved (still a string, not the object form).
+	if err != nil || !ok || pl != "singleton" {
+		t.Fatalf("legacy single-region must store the canonical singleton string, got (%q, %v, %v)", pl, ok, err)
 	}
 }
 
@@ -45,8 +50,10 @@ func TestNewApplicationUnstructured_ObjectFormWhenVClusterSet(t *testing.T) {
 		t.Fatalf("spec.placement.vcluster = %q, want rtz", vc)
 	}
 	mode, _, _ := unstructured.NestedString(obj.Object, "spec", "placement", "mode")
-	if mode != "single-region" {
-		t.Fatalf("spec.placement.mode = %q, want single-region", mode)
+	// One vocabulary (#3375 DoD-1): the object form's mode also stores
+	// the canonical token (legacy single-region folded to singleton).
+	if mode != "singleton" {
+		t.Fatalf("spec.placement.mode = %q, want canonical singleton", mode)
 	}
 	clusters, _, _ := unstructured.NestedSlice(obj.Object, "spec", "placement", "clusters")
 	if len(clusters) != 1 || clusters[0] != "mgmt-A" {
@@ -103,7 +110,7 @@ func TestNewApplicationCRFromSeed_PlacementObjectStamped(t *testing.T) {
 	}
 }
 
-func TestNewApplicationCRFromSeed_NoPlacement_LegacyString(t *testing.T) {
+func TestNewApplicationCRFromSeed_NoPlacement_StringForm(t *testing.T) {
 	seed := instances.ApplicationSeed{
 		Name:      "obs",
 		Namespace: "acme",
@@ -112,13 +119,29 @@ func TestNewApplicationCRFromSeed_NoPlacement_LegacyString(t *testing.T) {
 	}
 	obj := newApplicationCRFromSeed(seed)
 	pl, ok, err := unstructured.NestedString(obj.Object, "spec", "placement")
-	// Post-#3370 merge: the legacy STRING form is the DR-posture enum
-	// (single-region|active-active|active-hotstandby) — raw topology
-	// strings like "singleton" are NOT admissible on the real
-	// apiserver, so the silent-accept flow maps through
-	// placementForTopology (singleton → single-region).
-	if err != nil || !ok || pl != "single-region" {
-		t.Fatalf("silent-accept flow must stamp the mapped DR-posture enum, got (%q, %v, %v)", pl, ok, err)
+	// One vocabulary (#3375 DoD-1): the silent-accept string form stamps
+	// the CANONICAL token via placementForTopology. A "singleton" topology
+	// maps to the canonical "singleton" placement (no longer rewritten to
+	// the legacy "single-region"); the catalog placementSchema, the
+	// editors, and the resolver all speak this single set.
+	if err != nil || !ok || pl != "singleton" {
+		t.Fatalf("silent-accept flow must stamp the canonical placement token, got (%q, %v, %v)", pl, ok, err)
+	}
+}
+
+// A legacy / hyphen-variant topology choice on the seed still folds to
+// the canonical placement token on the string form.
+func TestNewApplicationCRFromSeed_LegacyTopologyFoldsToCanonical(t *testing.T) {
+	seed := instances.ApplicationSeed{
+		Name:      "obs",
+		Namespace: "acme",
+		Blueprint: "bp-grafana",
+		Topology:  "active-hotstandby", // legacy spelling
+	}
+	obj := newApplicationCRFromSeed(seed)
+	pl, _, _ := unstructured.NestedString(obj.Object, "spec", "placement")
+	if pl != "active-hot-standby" {
+		t.Fatalf("legacy active-hotstandby topology must stamp canonical active-hot-standby, got %q", pl)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/placement_vocabulary_drift_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/placement_vocabulary_drift_test.go
@@ -1,0 +1,118 @@
+// placement_vocabulary_drift_test.go — #3375 DoD-1 drift guard for the
+// catalyst-api surface.
+//
+// Pins the ONE canonical placement/topology vocabulary the catalyst-api
+// emits/accepts (canonicalizeTopology + placementForTopology) to the
+// SAME four canonical tokens the Go placement package
+// (core/controllers/internal/placement.CanonicalModes), the catalog
+// placementSchema, and both FE editors agree on:
+//
+//	singleton | active-active | active-hot-standby | active-passive
+//
+// A future edit that re-introduces the legacy editor dialect
+// (single-region / active-hotstandby) as a PRIMARY emitted value, or
+// drops a canonical class, fails CI here.
+package handler
+
+import "testing"
+
+// canonicalPlacementVocabulary is the single literal this surface pins
+// to. It must stay byte-equal to placement.CanonicalModes() (Go),
+// CANONICAL_MODES (bootstrap-ui drift test), and BcpTopology (console
+// types.ts). The bootstrap-api module cannot import the controllers'
+// internal/placement package (Go forbids cross-module internal imports),
+// so the contract is asserted by literal here and pinned to the same set
+// on every other surface.
+var canonicalPlacementVocabulary = []string{
+	"singleton",
+	"active-active",
+	"active-hot-standby",
+	"active-passive",
+}
+
+func TestCanonicalizeTopology_FoldsToCanonicalVocabulary(t *testing.T) {
+	// Every canonical token canonicalises to itself.
+	for _, m := range canonicalPlacementVocabulary {
+		if got := canonicalizeTopology(m); got != m {
+			t.Errorf("canonicalizeTopology(%q) = %q, want itself (canonical)", m, got)
+		}
+	}
+	// Legacy spellings fold onto the canonical token — never the reverse.
+	legacy := map[string]string{
+		"single-region":      "singleton",
+		"single_region":      "singleton",
+		"active-hotstandby":  "active-hot-standby",
+		"active_hot_standby": "active-hot-standby",
+		"active_active":      "active-active",
+		"active_passive":     "active-passive",
+		"  Active-Passive ":  "active-passive",
+	}
+	for in, want := range legacy {
+		if got := canonicalizeTopology(in); got != want {
+			t.Errorf("canonicalizeTopology(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// An unknown value is returned trimmed (so the caller rejects it with
+	// a clean error) — NOT silently coerced to a canonical token.
+	if got := canonicalizeTopology("bogus-mode"); got != "bogus-mode" {
+		t.Errorf("canonicalizeTopology(bogus) = %q, want pass-through", got)
+	}
+}
+
+func TestPlacementForTopology_EmitsOnlyCanonicalTokens(t *testing.T) {
+	// The CR-stamp mapper must only ever emit a canonical token — for
+	// canonical input, legacy input, or unknown/empty (→ singleton).
+	canonSet := map[string]struct{}{}
+	for _, m := range canonicalPlacementVocabulary {
+		canonSet[m] = struct{}{}
+	}
+	inputs := []string{
+		"singleton", "active-active", "active-hot-standby", "active-passive", // canonical
+		"single-region", "active-hotstandby", // legacy
+		"", "garbage", "multi-region", // unknown → singleton
+	}
+	for _, in := range inputs {
+		got := placementForTopology(in)
+		if _, ok := canonSet[got]; !ok {
+			t.Errorf("placementForTopology(%q) = %q, which is NOT a canonical token %v",
+				in, got, canonicalPlacementVocabulary)
+		}
+	}
+	// Specific foldings that pin the one-vocabulary contract.
+	cases := map[string]string{
+		"single-region":     "singleton",
+		"active-hotstandby":  "active-hot-standby",
+		"active-passive":     "active-passive",
+		"":                   "singleton",
+		"multi-region":       "singleton", // a Sovereign posture, never an instance mode
+	}
+	for in, want := range cases {
+		if got := placementForTopology(in); got != want {
+			t.Errorf("placementForTopology(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// The install + update + preview wire-validation MUST accept every
+// canonical class and the legacy aliases, and reject a genuine unknown.
+func TestApplicationWireValidation_AcceptsCanonicalVocabulary(t *testing.T) {
+	base := func(mode string) applicationInstallRequest {
+		return applicationInstallRequest{
+			BlueprintRef:    applicationBlueprintRef{Name: "bp-wp", Version: "1.0.0"},
+			Name:            "site",
+			OrganizationRef: "acme",
+			EnvironmentRef:  "acme-prod",
+			Placement:       applicationPlacement{Mode: mode, Regions: []string{"hz-fsn-rtz-prod"}},
+		}
+	}
+	accept := append([]string{}, canonicalPlacementVocabulary...)
+	accept = append(accept, "single-region", "active-hotstandby") // legacy still admissible
+	for _, m := range accept {
+		if msg, ok := validateApplicationInstallRequest(base(m)); !ok {
+			t.Errorf("install validation rejected accepted mode %q: %s", m, msg)
+		}
+	}
+	if _, ok := validateApplicationInstallRequest(base("not-a-mode")); ok {
+		t.Errorf("install validation accepted an unknown mode")
+	}
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
@@ -252,7 +252,7 @@ export function AppDetail({ disableStream = false }: AppDetailProps = {}) {
   const appDependsOn = apiApp?.dependsOn ?? []
   const appRegions = apiApp?.regions ?? []
   const appLastReconciled = apiApp?.lastReconciledAt ?? ''
-  const appPlacement = apiApp?.placement ?? 'single-region'
+  const appPlacement = apiApp?.placement ?? 'singleton'
   const appPrimaryRegion = apiApp?.primaryRegion ?? appRegions[0] ?? ''
   // Family B (2026-05-17 t10 C4-005/007): the namespace the workload
   // actually lives in (HR spec.targetNamespace), and the label that

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.test.tsx
@@ -148,15 +148,18 @@ describe('NewInstanceDialog — dropdowns (#3600)', () => {
     })
   })
 
-  it('Topology mode is a <select> from the editor mode set', async () => {
+  it('Topology mode is a <select> from the canonical editor mode set', async () => {
     await openDialog()
     const sel = (await screen.findByTestId('select-instance-topology')) as HTMLSelectElement
     expect(sel.tagName).toBe('SELECT')
-    // Constrained to the blueprint's supported modes (single-region +
-    // active-hot-standby → active-hotstandby).
+    // One vocabulary (#3375 DoD-1): the blueprint declares the legacy
+    // spelling (supported: ['single-region', 'active-hot-standby']) but
+    // the select offers the CANONICAL tokens it folds onto.
     const values = Array.from(sel.querySelectorAll('option')).map((o) => o.getAttribute('value'))
-    expect(values).toContain('single-region')
-    expect(values).toContain('active-hotstandby')
+    expect(values).toContain('singleton')
+    expect(values).toContain('active-hot-standby')
+    expect(values).not.toContain('single-region')
+    expect(values).not.toContain('active-hotstandby')
   })
 
   it('vCluster is a <select>', async () => {
@@ -185,7 +188,7 @@ describe('NewInstanceDialog — placement (#3599)', () => {
     const name = await screen.findByTestId('input-instance-name')
     fireEvent.change(name, { target: { value: 'wp-1' } })
     fireEvent.change(await screen.findByTestId('select-instance-org'), { target: { value: 'acme' } })
-    fireEvent.change(await screen.findByTestId('select-instance-topology'), { target: { value: 'active-hotstandby' } })
+    fireEvent.change(await screen.findByTestId('select-instance-topology'), { target: { value: 'active-hot-standby' } })
 
     const submit = (await screen.findByTestId('btn-submit-instance')) as HTMLButtonElement
     // No regions yet → disabled + validation hint visible.
@@ -205,7 +208,7 @@ describe('NewInstanceDialog — placement (#3599)', () => {
     await openDialog()
     fireEvent.change(await screen.findByTestId('input-instance-name'), { target: { value: 'wp-1' } })
     fireEvent.change(await screen.findByTestId('select-instance-org'), { target: { value: 'acme' } })
-    fireEvent.change(await screen.findByTestId('select-instance-topology'), { target: { value: 'active-hotstandby' } })
+    fireEvent.change(await screen.findByTestId('select-instance-topology'), { target: { value: 'active-hot-standby' } })
     fireEvent.click(await screen.findByTestId('region-checkbox-rgn-a'))
     fireEvent.click(await screen.findByTestId('region-checkbox-rgn-b'))
     fireEvent.change(await screen.findByTestId('select-instance-vcluster'), { target: { value: 'rtz' } })
@@ -217,7 +220,8 @@ describe('NewInstanceDialog — placement (#3599)', () => {
     expect(body.blueprint).toBe('wordpress')
     expect(body.org).toBe('acme')
     expect(body.name).toBe('wp-1')
-    expect(body.topology).toBe('active-hotstandby')
+    // One vocabulary (#3375 DoD-1): the canonical topology is POSTed.
+    expect(body.topology).toBe('active-hot-standby')
     expect(body.placement).toEqual({ vcluster: 'rtz', regions: ['rgn-a', 'rgn-b'] })
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
@@ -38,8 +38,12 @@ import { BLUEPRINT_BY_ID } from '@/shared/constants/catalog.generated'
 // free-text) so an install can't be typo'd into an invalid zone.
 const VCLUSTER_OPTIONS = ['host', 'mgmt', 'dmz', 'rtz'] as const
 
-/** Modes that require ≥2 regions (the create-flow validation rule). */
-const MULTI_REGION_MODES = new Set(['active-active', 'active-hotstandby'])
+/**
+ * Modes that require ≥2 regions (the create-flow validation rule). ONE
+ * canonical vocabulary (#3375 DoD-1) — active-passive is multi-region
+ * too. Membership is tested on the canonical token (canonicalEditorMode).
+ */
+const MULTI_REGION_MODES = new Set(['active-active', 'active-hot-standby', 'active-passive'])
 
 /**
  * InstancesSection — renders the per-Blueprint instances list (one row
@@ -547,7 +551,9 @@ export function NewInstanceDialog({
       ? canonicalEditorMode(defs['multi-region'] ?? defs['single-region'] ?? '')
       : ''
     if (declaredDefault && supportedModes.includes(declaredDefault)) return declaredDefault
-    return supportedModes.includes('single-region') ? 'single-region' : supportedModes[0] ?? 'single-region'
+    // One vocabulary (#3375 DoD-1): prefer the canonical singleton, else
+    // the first supported canonical mode.
+    return supportedModes.includes('singleton') ? 'singleton' : supportedModes[0] ?? 'singleton'
   }, [bpQuery.data, supportedModes])
 
   useEffect(() => {
@@ -895,11 +901,14 @@ export function NewInstanceDialog({
 }
 
 /**
- * canonicalEditorMode — normalise a Blueprint topology token (which may
- * use the hyphenated `active-hot-standby` / `singleton` / `multi-region`
- * dialect) onto the editor mode vocabulary
- * (single-region | active-active | active-hotstandby) so the create-flow
- * dropdown intersects cleanly with ALL_MODES (#3599).
+ * canonicalEditorMode — fold a Blueprint topology token onto the ONE
+ * canonical vocabulary (#3375 DoD-1: singleton | active-active |
+ * active-hot-standby | active-passive) so the create-flow dropdown
+ * intersects cleanly with ALL_MODES (now canonical). Legacy spellings
+ * (single-region / active-hotstandby) and the `multi-region` deployment
+ * posture (which is a Sovereign shape, not an instance mode) fold to a
+ * valid canonical option; anything unknown falls back to singleton so
+ * the dropdown always offers a valid choice.
  */
 function canonicalEditorMode(raw: string): string {
   const s = (raw ?? '').trim().toLowerCase()
@@ -910,18 +919,20 @@ function canonicalEditorMode(raw: string): string {
     case 'active-hot-standby':
     case 'active-hotstandby':
     case 'active_hot_standby':
+      return 'active-hot-standby'
     case 'active-passive':
     case 'active_passive':
-      return 'active-hotstandby'
+      return 'active-passive'
     case 'singleton':
     case 'single-region':
     case 'single_region':
+      return 'singleton'
     case 'multi-region':
     default:
-      // multi-region is a deployment posture, not an editor mode; map it
-      // (and anything unknown) to single-region so the dropdown still
-      // offers a valid editor option.
-      return 'single-region'
+      // multi-region is a deployment posture, not an instance mode; map
+      // it (and anything unknown) to singleton so the dropdown still
+      // offers a valid canonical option.
+      return 'singleton'
   }
 }
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -175,11 +175,14 @@ export function TopologyTab({
   const app: ApplicationStatus | undefined = initialApp ?? statusQ.data
 
   const currentMode = useMemo(() => {
-    if (!app) return 'single-region'
+    // One vocabulary (#3375 DoD-1): default to the canonical singleton.
+    // A live legacy spelling is folded downstream by canonicalTopologyClass
+    // and the editor's canonicalizeMode.
+    if (!app) return 'singleton'
     const fromSpec = (app.spec?.placement ?? '').trim()
     if (fromSpec) return fromSpec
     const fromStatus = (app.status as Record<string, unknown> | undefined)?.placement as string | undefined
-    return fromStatus ?? 'single-region'
+    return fromStatus ?? 'singleton'
   }, [app])
 
   const currentRegions = useMemo(() => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.edit.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.edit.test.tsx
@@ -173,7 +173,10 @@ describe('CatalogDetail per-field inline editing (#3668 §5A)', () => {
     expect(edit.name).toBe('Grafana (Renamed)')
     // …and the sibling fields are preserved (merge base), not wiped.
     expect(edit.tagline).toBe('Visualization and dashboarding')
-    expect(edit.supported_topologies).toEqual(['single-region', 'active-hotstandby'])
+    // One vocabulary (#3375 DoD-1): the edit form carries the CANONICAL
+    // topology tokens (the fixture declares them canonical; the form folds
+    // any spelling onto the canonical set).
+    expect(edit.supported_topologies).toEqual(['singleton', 'active-hot-standby'])
   })
 
   it('editing the SUMMARY field saves tagline only, preserving the name', async () => {
@@ -192,14 +195,15 @@ describe('CatalogDetail per-field inline editing (#3668 §5A)', () => {
   it('editing SUPPORTED TOPOLOGIES toggles a mode and saves the set', async () => {
     renderCatalog()
     fireEvent.click(await screen.findByTestId('cif-topologies-edit'))
-    // The mapped current set pre-checks single-region + active-hotstandby;
+    // The canonical current set pre-checks singleton + active-hot-standby;
     // toggle active-active ON.
     fireEvent.click(screen.getByTestId('catalog-edit-topo-active-active'))
     fireEvent.click(screen.getByTestId('cif-topologies-save'))
     await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(1))
     const edit = saveSpy.mock.calls[0][1] as { supported_topologies: string[] }
+    // One vocabulary (#3375 DoD-1): the saved set is canonical.
     expect(edit.supported_topologies).toContain('active-active')
-    expect(edit.supported_topologies).toContain('single-region')
+    expect(edit.supported_topologies).toContain('singleton')
   })
 
   it('Cancel closes a field editor without saving', async () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
@@ -16,7 +16,7 @@ import { useTheme } from '@/shared/lib/useTheme'
 import { resolveCatalogIcon } from '@/shared/lib/resolveCatalogIcon'
 import { YamlEditor } from '@/widgets/cloud-list/YamlEditor'
 import type { K8sObject } from '@/widgets/architecture-graph/useK8sCacheStream'
-import { ALL_MODES, describeMode } from '@/widgets/topology/TopologyEditor'
+import { ALL_MODES, canonicalizeMode, describeMode } from '@/widgets/topology/TopologyEditor'
 import { type CatalogEntryEdit } from '@/lib/commerce.api'
 import { InstancesSection } from './AppDetail/InstancesSection'
 import { useCatalogAdmin } from '@/shared/lib/useCatalogAdmin'
@@ -204,7 +204,7 @@ export function CatalogDetail() {
   const currentEdit: CatalogEntryEdit = {
     name: title,
     tagline: card.tagline || card.summary || '',
-    supported_topologies: topologies.map(toEditorMode),
+    supported_topologies: topologies.map(canonicalizeMode),
     icon_light: card.iconLight || bundledLogo || '',
     icon_dark: card.iconDark || '',
   }
@@ -719,20 +719,13 @@ function readMultiInstance(cat: CatalogItem): boolean {
   return !!mi?.enabled
 }
 
-// #3648 — map BOTH the canonical matrix vocabulary (singleton /
-// active-hot-standby) AND the editor dialect onto the editor dialect
-// (single-region / active-hotstandby / active-active) the inline edit form's
-// topology checkboxes use, so a Blueprint's declared topologies pre-check
-// correctly regardless of which spelling the API returned.
-const CANONICAL_TO_EDITOR: Record<string, string> = {
-  singleton: 'single-region',
-  'active-hot-standby': 'active-hotstandby',
-  'active-active': 'active-active',
-}
-function toEditorMode(raw: string): string {
-  const s = raw.trim().toLowerCase()
-  return CANONICAL_TO_EDITOR[s] ?? s
-}
+// One vocabulary (#3375 DoD-1): the inline-edit topology checkboxes use
+// ALL_MODES (the four CANONICAL classes), so a Blueprint's declared
+// topologies are folded onto the canonical token via the shared
+// canonicalizeMode (re-exported from TopologyEditor) — they pre-check
+// correctly regardless of which spelling the API returned, and the save
+// round-trips canonical. The former CANONICAL_TO_EDITOR dialect map is
+// gone now that the editor is canonical end-to-end.
 
 function readTopologies(cat: CatalogItem): string[] {
   const modes = cat.placementSchema?.modes

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.placement.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.placement.test.tsx
@@ -51,17 +51,18 @@ describe('InstallPage placement picker (#3375 §3d)', () => {
   })
   afterEach(() => cleanup())
 
-  it('offers all four canonical placement modes including active-passive', () => {
+  it('offers all four CANONICAL placement modes (singleton / active-active / active-hot-standby / active-passive)', () => {
     render(<InstallPage preselectedBlueprint="bp-grafana" />)
 
     const select = screen.getByTestId('install-page-placement') as HTMLSelectElement
     const optionValues = Array.from(select.options).map((o) => o.value)
 
-    expect(optionValues).toContain('single-region')
-    expect(optionValues).toContain('active-active')
-    expect(optionValues).toContain('active-hotstandby')
-    // The #3375 §3(d) fix — previously absent.
-    expect(optionValues).toContain('active-passive')
+    // One vocabulary (#3375 DoD-1): the picker emits the canonical set,
+    // the same set the catalog placementSchema serves + the CR stores —
+    // NO legacy single-region / active-hotstandby spelling.
+    expect(optionValues).toEqual(['singleton', 'active-active', 'active-hot-standby', 'active-passive'])
+    expect(optionValues).not.toContain('single-region')
+    expect(optionValues).not.toContain('active-hotstandby')
   })
 
   it('lets active-passive be selected', () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.tsx
@@ -72,15 +72,16 @@ export function InstallPage({ preselectedBlueprint }: InstallPageProps = {}) {
   const [previewState, setPreviewState] = useState<ApplicationPreviewResponse | null>(null)
   const [statusName, setStatusName] = useState<string | null>(null)
 
-  // Default placement / org / env per the brief — single-region, primary
-  // region read from the deployment's first region. For slice I we keep
-  // these as plain inputs above the auto-form; a follow-up slice swaps
-  // them for richer pickers (Topology editor, see EPIC-2 slice T).
+  // Default placement / org / env per the brief — the canonical
+  // `singleton` (#3375 DoD-1), primary region read from the deployment's
+  // first region. For slice I we keep these as plain inputs above the
+  // auto-form; a follow-up slice swaps them for richer pickers (Topology
+  // editor, see EPIC-2 slice T).
   const [organizationRef, setOrganizationRef] = useState<string>('default')
   const [environmentRef, setEnvironmentRef] = useState<string>('default-prod')
   const [appName, setAppName] = useState<string>('')
   const [region, setRegion] = useState<string>('hz-fsn-rtz-prod')
-  const [placementMode, setPlacementMode] = useState<string>('single-region')
+  const [placementMode, setPlacementMode] = useState<string>('singleton')
 
   // Reset the form scaffold when a new Blueprint is selected. Keeps the
   // "click another card" UX intuitive — the prior input doesn't survive
@@ -402,15 +403,17 @@ export function InstallPage({ preselectedBlueprint }: InstallPageProps = {}) {
             <label className="flex flex-col text-xs text-[var(--color-text-dim)]">
               Placement mode
               {/*
-               * #3375 §3(d) — the install-flow placement picker must offer
-               * the SAME canonical class set the post-create TopologyEditor
-               * offers (ALL_MODES). It previously hardcoded only
-               * single-region / active-active / active-hotstandby, so a
-               * Blueprint that supports `active-passive` (primary serves;
-               * passive cold/warm standby) could be created on the editor
-               * but never AT INSTALL — a supported-vs-selectable
-               * contradiction. The fourth canonical class is added here so
-               * the install picker matches the backend's supported set.
+               * ONE canonical vocabulary (#3375 DoD-1) — the install-flow
+               * placement picker offers the SAME four canonical classes
+               * the catalog placementSchema serves, the post-create
+               * TopologyEditor (ALL_MODES) offers, the Application CR
+               * stores, and the application-controller resolves:
+               * singleton / active-active / active-hot-standby /
+               * active-passive. It previously spoke the legacy dialect
+               * (single-region / active-hotstandby) which drifted from the
+               * catalog + CR and could not represent active-passive/
+               * singleton consistently. The backend still folds any legacy
+               * value, but the editor now emits canonical end-to-end.
                */}
               <select
                 className="mt-1 rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-sm"
@@ -418,9 +421,9 @@ export function InstallPage({ preselectedBlueprint }: InstallPageProps = {}) {
                 value={placementMode}
                 onChange={(e) => setPlacementMode(e.target.value)}
               >
-                <option value="single-region">single-region</option>
+                <option value="singleton">singleton</option>
                 <option value="active-active">active-active</option>
-                <option value="active-hotstandby">active-hotstandby</option>
+                <option value="active-hot-standby">active-hot-standby</option>
                 <option value="active-passive">active-passive</option>
               </select>
             </label>

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -402,7 +402,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "section": "pts-3-3-security-and-policy",
     "depends": [],
     "shareable": false,
@@ -473,6 +473,62 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
       "perTopology": {
         "singleton": {
           "replication": null,
+          "switchover": null,
+          "placement": {
+            "tier": "",
+            "clusters": [
+              "mgmt-A",
+              "mgmt-B",
+              "dmz-A",
+              "dmz-B",
+              "rtz-A",
+              "rtz-B"
+            ],
+            "roles": {
+              "mgmt-A": "singleton",
+              "mgmt-B": "singleton",
+              "dmz-A": "singleton",
+              "dmz-B": "singleton",
+              "rtz-A": "singleton",
+              "rtz-B": "singleton"
+            }
+          }
+        }
+      }
+    },
+    "hasUserUIEndpoint": false
+  },
+  {
+    "id": "bp-cert-manager-issuers",
+    "slug": "cert-manager-issuers",
+    "title": "cert-manager — Issuers",
+    "summary": "|",
+    "icon": "cert-manager.svg",
+    "category": "security",
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.0.0",
+    "section": "pts-3-3-security-and-policy",
+    "depends": [
+      "bp-cert-manager"
+    ],
+    "shareable": false,
+    "contextSchema": null,
+    "producesInstances": null,
+    "topology": {
+      "supported": [
+        "singleton"
+      ],
+      "multiRegion": "singleton",
+      "singleRegion": "singleton",
+      "perTopology": {
+        "singleton": {
+          "replication": {
+            "backend": "flux-git",
+            "mode": "async",
+            "lagSloSeconds": null
+          },
           "switchover": null,
           "placement": {
             "tier": "",
@@ -833,7 +889,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "listed",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "section": "pts-9-disaster-recovery",
     "depends": [
       "bp-cnpg",
@@ -1507,7 +1563,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.2.6",
+    "version": "1.2.7",
     "section": "pts-3-2-gitops-and-iac",
     "depends": [],
     "shareable": false,
@@ -2113,7 +2169,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.4.28",
+    "version": "1.4.30",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-postgres"
@@ -2314,7 +2370,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.3.7",
+    "version": "1.3.8",
     "section": "pts-3-3-security-and-policy",
     "depends": [],
     "shareable": false,
@@ -2865,7 +2921,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.2.10",
+    "version": "0.2.11",
     "section": "pts-3-2-control-plane-isolation",
     "depends": [
       "bp-cilium",
@@ -3430,7 +3486,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-cilium",
@@ -4422,7 +4478,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.1.74",
+    "version": "0.1.75",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-gitea",
@@ -4583,7 +4639,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "0.2.18",
+    "version": "0.2.20",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": [
       "bp-keycloak",
@@ -5593,6 +5649,7 @@ export const PLATFORM_BLUEPRINT_FILES: readonly string[] = [
   "platform/bge/blueprint.yaml",
   "platform/catalyst-platform/blueprint.yaml",
   "platform/cert-manager-dynadot-webhook/blueprint.yaml",
+  "platform/cert-manager-issuers/blueprint.yaml",
   "platform/cert-manager-powerdns-webhook/blueprint.yaml",
   "platform/cert-manager/blueprint.yaml",
   "platform/cilium-policies/blueprint.yaml",

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.test.tsx
@@ -2,6 +2,13 @@
  * TopologyEditor.test.tsx — unit tests for EPIC-2 slice T (#1097)
  * topology editor widget. Uses disableNetwork seam so no fetch is
  * required.
+ *
+ * One vocabulary (#3375 DoD-1): the editor renders + selects the four
+ * CANONICAL classes (singleton / active-active / active-hot-standby /
+ * active-passive). These tests deliberately feed LEGACY-spelled
+ * `currentMode` / `placementSchema.modes` props to prove the editor
+ * folds them onto the canonical token (pre-selects the right radio,
+ * intersects allowedModes correctly).
  */
 import { describe, it, expect, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
@@ -17,12 +24,13 @@ function withProviders(node: React.ReactNode) {
 afterEach(() => cleanup())
 
 describe('TopologyEditor — mode picker', () => {
-  it('renders all three modes with current mode pre-selected', () => {
+  it('renders the four canonical modes; a legacy currentMode pre-selects the canonical radio', () => {
     render(
       withProviders(
         <TopologyEditor
           sovereignId="dep-1"
           applicationName="wp-prod"
+          // Legacy spelling on the wire …
           currentMode="single-region"
           currentRegions={['hz-fsn-rtz-prod']}
           availableRegions={['hz-fsn-rtz-prod', 'hz-hel-rtz-prod']}
@@ -30,24 +38,29 @@ describe('TopologyEditor — mode picker', () => {
         />,
       ),
     )
-    const single = screen.getByTestId('topology-editor-mode-single-region-radio') as HTMLInputElement
-    expect(single.checked).toBe(true)
+    // … folds to the canonical singleton radio, which is pre-selected.
+    const singleton = screen.getByTestId('topology-editor-mode-singleton-radio') as HTMLInputElement
+    expect(singleton.checked).toBe(true)
+    // All four canonical classes are representable.
+    expect(screen.getByTestId('topology-editor-mode-active-active-radio')).toBeTruthy()
+    expect(screen.getByTestId('topology-editor-mode-active-hot-standby-radio')).toBeTruthy()
+    expect(screen.getByTestId('topology-editor-mode-active-passive-radio')).toBeTruthy()
   })
 
-  it('switching to active-hotstandby allows multi-region selection', () => {
+  it('switching to active-hot-standby allows multi-region selection', () => {
     render(
       withProviders(
         <TopologyEditor
           sovereignId="dep-1"
           applicationName="wp-prod"
-          currentMode="single-region"
+          currentMode="singleton"
           currentRegions={['hz-fsn-rtz-prod']}
           availableRegions={['hz-fsn-rtz-prod', 'hz-hel-rtz-prod']}
           disableNetwork
         />,
       ),
     )
-    fireEvent.click(screen.getByTestId('topology-editor-mode-active-hotstandby-radio'))
+    fireEvent.click(screen.getByTestId('topology-editor-mode-active-hot-standby-radio'))
     fireEvent.click(screen.getByTestId('topology-editor-region-hz-hel-rtz-prod-checkbox'))
     const apply = screen.getByTestId('topology-editor-apply-btn') as HTMLButtonElement
     expect(apply.disabled).toBe(false)
@@ -59,7 +72,7 @@ describe('TopologyEditor — mode picker', () => {
         <TopologyEditor
           sovereignId="dep-1"
           applicationName="grafana"
-          currentMode="active-hotstandby"
+          currentMode="active-hot-standby"
           currentRegions={['hz-fsn-rtz-prod']}
           availableRegions={['hz-fsn-rtz-prod', 'hz-hel-rtz-prod']}
           supportedCanonical={['singleton', 'active-hot-standby']}
@@ -67,12 +80,12 @@ describe('TopologyEditor — mode picker', () => {
         />,
       ),
     )
-    // active-hotstandby canonicalises to active-hot-standby → supported → enabled
-    const hot = screen.getByTestId('topology-editor-mode-active-hotstandby-radio') as HTMLInputElement
+    // active-hot-standby is supported → enabled
+    const hot = screen.getByTestId('topology-editor-mode-active-hot-standby-radio') as HTMLInputElement
     expect(hot.disabled).toBe(false)
-    // single-region canonicalises to singleton → supported → enabled
-    const single = screen.getByTestId('topology-editor-mode-single-region-radio') as HTMLInputElement
-    expect(single.disabled).toBe(false)
+    // singleton is supported → enabled
+    const singleton = screen.getByTestId('topology-editor-mode-singleton-radio') as HTMLInputElement
+    expect(singleton.disabled).toBe(false)
     // active-active is NOT in the Blueprint's supported set → disabled (the
     // contradiction the operator flagged 3×: never offer an unsupported mode).
     const aa = screen.getByTestId('topology-editor-mode-active-active-radio') as HTMLInputElement
@@ -111,7 +124,7 @@ describe('TopologyEditor — preview', () => {
         <TopologyEditor
           sovereignId="dep-1"
           applicationName="wp-prod"
-          currentMode="single-region"
+          currentMode="singleton"
           currentRegions={['hz-fsn-rtz-prod']}
           availableRegions={['hz-fsn-rtz-prod', 'hz-hel-rtz-prod']}
           disableNetwork
@@ -125,13 +138,13 @@ describe('TopologyEditor — preview', () => {
 })
 
 describe('TopologyEditor — Blueprint constraint', () => {
-  it('disables modes the Blueprint placementSchema does not allow', () => {
+  it('disables modes the Blueprint placementSchema does not allow (legacy modes[] folded)', () => {
     render(
       withProviders(
         <TopologyEditor
           sovereignId="dep-1"
           applicationName="wp-prod"
-          currentMode="single-region"
+          currentMode="singleton"
           currentRegions={['a']}
           availableRegions={['a', 'b']}
           blueprint={{
@@ -140,6 +153,8 @@ describe('TopologyEditor — Blueprint constraint', () => {
             card: { title: 'X' },
             origin: 1,
             source: 'public',
+            // Legacy spelling in modes[] still constrains the canonical
+            // picker — active-active is not allowed.
             placementSchema: { modes: ['single-region'] },
           }}
           disableNetwork

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.tsx
@@ -67,26 +67,32 @@ export interface TopologyEditorProps {
  * reuses the SAME option set the post-create Topology editor offers,
  * instead of reinventing it.
  *
- * #3375 §3(d) — the editor must be able to SELECT all FOUR canonical
- * classes. It previously offered only `single-region` / `active-active`
- * / `active-hotstandby`, so `active-passive` could never be chosen even
- * for a blueprint that supports it (a `supported`-vs-editable
- * contradiction). `single-region` is the editor's spelling of the
- * canonical `singleton` (canonicalizeMode maps them together), so the
- * fourth class — `active-passive` — is added here. The
- * `allowedModes`/`supportedCanonical` gate still hides any class the
- * blueprint doesn't declare; this only makes the option REPRESENTABLE.
+ * ONE canonical vocabulary (#3375 DoD-1). The editor RENDERS and SELECTS
+ * the four canonical classes — `singleton` / `active-active` /
+ * `active-hot-standby` / `active-passive` — the exact set the catalog
+ * placementSchema serves, the Application CR stores, and the
+ * application-controller's resolver accepts. The editor previously spoke
+ * the legacy dialect (`single-region` / `active-hotstandby`) which (a)
+ * could not represent `active-passive`/`singleton` and (b) drifted from
+ * the catalog + CR. canonicalizeMode still folds any legacy value the
+ * server returns, so loading an older CR keeps working. The
+ * `allowedModes`/`supportedCanonical` gate hides any class the blueprint
+ * doesn't declare; this set only makes every canonical class
+ * REPRESENTABLE.
  */
-export const ALL_MODES = ['single-region', 'active-active', 'active-hotstandby', 'active-passive'] as const
+export const ALL_MODES = ['singleton', 'active-active', 'active-hot-standby', 'active-passive'] as const
 
 export type TopologyMode = (typeof ALL_MODES)[number]
 
 /**
- * canonicalizeMode (#3648) maps BOTH the editor dialect (single-region /
- * active-hotstandby) AND the canonical matrix vocabulary (singleton /
- * active-hot-standby / active-passive) onto one token, so the
- * supported-constraint can compare an ALL_MODES entry against a Blueprint's
- * canonical SupportedTopologies regardless of spelling.
+ * canonicalizeMode (#3648, #3375 DoD-1) folds BOTH the legacy editor
+ * dialect (single-region / active-hotstandby) AND the canonical
+ * vocabulary (singleton / active-active / active-hot-standby /
+ * active-passive) onto the ONE canonical token, so any value the server
+ * returns (an older CR, a legacy POST) compares correctly against the
+ * canonical ALL_MODES / SupportedTopologies. Mirrors the Go single
+ * source of truth (placement.Canonicalize) — the CI drift test asserts
+ * the FE + Go + catalyst-api agree.
  */
 export function canonicalizeMode(raw: string): string {
   switch (raw.trim().toLowerCase()) {
@@ -117,7 +123,10 @@ export function TopologyEditor({
   onApplied,
   disableNetwork = false,
 }: TopologyEditorProps) {
-  const [mode, setMode] = useState<string>(currentMode || 'single-region')
+  // One vocabulary (#3375 DoD-1): the editor works in canonical tokens.
+  // Any legacy currentMode the server returns is folded to canonical so
+  // the radio pre-selects correctly and the POST carries canonical.
+  const [mode, setMode] = useState<string>(currentMode ? canonicalizeMode(currentMode) : 'singleton')
   const [regions, setRegions] = useState<string[]>(currentRegions)
   const [preview, setPreview] = useState<ApplicationPreviewResponse | null>(null)
   const [busy, setBusy] = useState<'preview' | 'apply' | null>(null)
@@ -127,7 +136,7 @@ export function TopologyEditor({
 
   // Reset when a different Application is loaded into the tab.
   useEffect(() => {
-    setMode(currentMode || 'single-region')
+    setMode(currentMode ? canonicalizeMode(currentMode) : 'singleton')
     setRegions(currentRegions)
     setPreview(null)
     setError(null)
@@ -148,21 +157,28 @@ export function TopologyEditor({
     }
     const fromSchema = blueprint?.placementSchema?.modes
     if (Array.isArray(fromSchema) && fromSchema.length > 0) {
-      return new Set(fromSchema)
+      // One vocabulary (#3375 DoD-1): canonicalise the declared modes so a
+      // Blueprint that uses the legacy spelling (single-region /
+      // active-hotstandby) in placementSchema.modes still enables the
+      // matching CANONICAL radio (ALL_MODES is canonical).
+      const canon = new Set(fromSchema.map(canonicalizeMode))
+      return new Set<string>(ALL_MODES.filter((m) => canon.has(canonicalizeMode(m))))
     }
     return new Set<string>(ALL_MODES)
   }, [supportedCanonical, blueprint])
 
-  const isDirty = mode !== currentMode || !sameRegionSet(regions, currentRegions)
+  // Compare canonically so a canonical `mode` vs a legacy `currentMode`
+  // (older CR) is not falsely flagged dirty (#3375 DoD-1).
+  const isDirty = canonicalizeMode(mode) !== canonicalizeMode(currentMode) || !sameRegionSet(regions, currentRegions)
 
   // Compute whether the proposed change is destructive (regions drop or
-  // mode collapse) — surfaces the force-confirm UI client-side.
+  // mode collapse) — surfaces the force-confirm UI client-side. Compare
+  // on the canonical token so the guard fires regardless of spelling.
   const requiresForce = useMemo(() => {
+    const cur = canonicalizeMode(currentMode)
     if (
-      mode === 'single-region' &&
-      (currentMode === 'active-active' ||
-        currentMode === 'active-hotstandby' ||
-        currentMode === 'active-passive')
+      canonicalizeMode(mode) === 'singleton' &&
+      (cur === 'active-active' || cur === 'active-hot-standby' || cur === 'active-passive')
     ) {
       return true
     }
@@ -394,15 +410,17 @@ export function TopologyEditor({
 /**
  * describeMode — one-line human description per topology mode. Exported
  * (#3599) so the create-flow placement step shows the same helper text
- * the post-create editor shows for each mode.
+ * the post-create editor shows for each mode. Canonicalises first so it
+ * describes both the canonical tokens and any legacy spelling
+ * (#3375 DoD-1).
  */
 export function describeMode(mode: string): string {
-  switch (mode) {
-    case 'single-region':
+  switch (canonicalizeMode(mode)) {
+    case 'singleton':
       return 'one cluster; lowest cost; no failover'
     case 'active-active':
       return 'every region serves traffic; horizontal scaling'
-    case 'active-hotstandby':
+    case 'active-hot-standby':
       return 'primary serves; standby ready for switchover'
     case 'active-passive':
       return 'primary serves; passive cold/warm standby (backup-restore)'

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/placement-vocabulary.drift.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/placement-vocabulary.drift.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * placement-vocabulary.drift.test.tsx — #3375 DoD-1 drift guard.
+ *
+ * Pins the ONE canonical placement/topology vocabulary across every
+ * FRONTEND surface so a future edit that re-introduces the legacy
+ * editor dialect (`single-region` / `active-hotstandby`) fails CI here
+ * instead of silently drifting from the catalog placementSchema, the
+ * Application CR, and the application-controller's resolver.
+ *
+ * The single source of truth is the Go placement package
+ * (core/controllers/internal/placement.CanonicalModes); this test pins
+ * the FE emitters (TopologyEditor.ALL_MODES, the InstallPage <select>,
+ * fleet.api.TopologyMode) to the SAME set + asserts the FE canonicaliser
+ * folds every legacy spelling exactly as the Go Canonicalize does.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { ALL_MODES, canonicalizeMode, describeMode } from './TopologyEditor'
+import { canonicalizeTopologyMode } from '@/lib/fleet.api'
+
+// THE canonical vocabulary — must mirror Go placement.CanonicalModes()
+// and the catalyst-api canonicalizeTopology output. Keep this literal in
+// sync across Go + both FE codebases (the console mirrors it in
+// src/lib/api/types.ts BcpTopology).
+const CANONICAL_MODES = ['singleton', 'active-active', 'active-hot-standby', 'active-passive'] as const
+
+// Legacy spellings that MUST fold onto the canonical token but MUST NOT
+// appear as a primary emitted value anywhere.
+const LEGACY_SPELLINGS = ['single-region', 'active-hotstandby'] as const
+
+describe('#3375 DoD-1 — one placement vocabulary, every FE surface', () => {
+  it('TopologyEditor.ALL_MODES is exactly the canonical set (no legacy spelling)', () => {
+    expect([...ALL_MODES]).toEqual([...CANONICAL_MODES])
+    for (const legacy of LEGACY_SPELLINGS) {
+      expect(ALL_MODES as readonly string[]).not.toContain(legacy)
+    }
+  })
+
+  it('the post-create editor describes every canonical class (no blank helper text)', () => {
+    for (const m of CANONICAL_MODES) {
+      expect(describeMode(m).length).toBeGreaterThan(0)
+    }
+  })
+
+  it('canonicalizeMode folds every legacy + canonical spelling onto the canonical token', () => {
+    expect(canonicalizeMode('single-region')).toBe('singleton')
+    expect(canonicalizeMode('singleton')).toBe('singleton')
+    expect(canonicalizeMode('active-hotstandby')).toBe('active-hot-standby')
+    expect(canonicalizeMode('active-hot-standby')).toBe('active-hot-standby')
+    expect(canonicalizeMode('active-passive')).toBe('active-passive')
+    expect(canonicalizeMode('active-active')).toBe('active-active')
+    // case / whitespace robustness (mirrors Go Canonicalize)
+    expect(canonicalizeMode('  Active-HotStandby ')).toBe('active-hot-standby')
+  })
+
+  it('fleet.api canonicalizeTopologyMode agrees with the editor canonicaliser', () => {
+    for (const spelling of [...CANONICAL_MODES, ...LEGACY_SPELLINGS]) {
+      expect(canonicalizeTopologyMode(spelling)).toBe(canonicalizeMode(spelling))
+    }
+  })
+
+  it('the InstallPage placement <select> hard-codes exactly the canonical options (no legacy spelling)', () => {
+    // The render-level assertion lives in InstallPage.placement.test.tsx
+    // (it mocks the page hooks). Here we statically pin the <option>
+    // value literals so a hand-edit that re-introduces single-region /
+    // active-hotstandby in the install picker fails CI without needing the
+    // full page mount.
+    // vitest runs with cwd = the package root (products/catalyst/bootstrap/ui).
+    const src = readFileSync(
+      resolve(process.cwd(), 'src/pages/sovereign/InstallPage.tsx'),
+      'utf8',
+    )
+    const optionValues = [...src.matchAll(/<option value="([^"]+)">/g)].map((m) => m[1])
+    expect(optionValues).toEqual([...CANONICAL_MODES])
+    for (const legacy of LEGACY_SPELLINGS) {
+      expect(optionValues).not.toContain(legacy)
+    }
+  })
+})

--- a/products/catalyst/chart/crds/blueprint.yaml
+++ b/products/catalyst/chart/crds/blueprint.yaml
@@ -171,15 +171,25 @@ spec:
                         # Two tiers of placement modes coexist (see
                         # core/controllers/blueprint/internal/validate/validate.go
                         # canonicalPlacementModes):
-                        #   - Application-tier (marketplace 99%):
-                        #     single-region / active-active / active-hotstandby
+                        #   - Application-tier (marketplace 99%) — ONE
+                        #     canonical vocabulary (#3375 DoD-1, defined by
+                        #     core/controllers/internal/placement.CanonicalModes):
+                        #     singleton / active-active / active-hot-standby /
+                        #     active-passive. Legacy spellings
+                        #     single-region / active-hotstandby remain in the
+                        #     enum for back-compat (folded via
+                        #     placement.Canonicalize); new authors emit the
+                        #     canonical token.
                         #   - Bootstrap-topology tier (bp-*-vcluster +
                         #     bp-vcluster-helmrepo, per
                         #     docs/SOVEREIGN-MULTI-REGION-DOD.md A4):
                         #     primary-only / secondary-only / every-region
                         enum:
-                          - single-region
+                          - singleton
                           - active-active
+                          - active-hot-standby
+                          - active-passive
+                          - single-region
                           - active-hotstandby
                           - primary-only
                           - secondary-only
@@ -187,8 +197,11 @@ spec:
                     default:
                       type: string
                       enum:
-                        - single-region
+                        - singleton
                         - active-active
+                        - active-hot-standby
+                        - active-passive
+                        - single-region
                         - active-hotstandby
                         - primary-only
                         - secondary-only
@@ -196,7 +209,7 @@ spec:
                     # G93.2 (Refs #2667) — defaultOnMultiRegion is the
                     # Blueprint author's declarative preferred default
                     # when the Sovereign is multi-region (BCP topology =
-                    # active-hotstandby or active-active). The
+                    # active-hot-standby or active-active). The
                     # application-controller consults this when the
                     # Application CR's spec.placement is empty:
                     #   - Multi-region Sovereign + defaultOnMultiRegion
@@ -204,12 +217,16 @@ spec:
                     #     touch for CNPG-backed Blueprints).
                     #   - Otherwise → fall back to `default` (single-
                     #     knob backwards-compat).
-                    # When set, MUST be in modes[] (validator enforces).
+                    # When set, MUST be in modes[] (validator enforces;
+                    # membership is checked on the canonical token).
                     defaultOnMultiRegion:
                       type: string
                       enum:
-                        - single-region
+                        - singleton
                         - active-active
+                        - active-hot-standby
+                        - active-passive
+                        - single-region
                         - active-hotstandby
                         - primary-only
                         - secondary-only


### PR DESCRIPTION
Closes the #3375 ❌ the hw158 re-validation surfaced: three surfaces spoke three placement dialects (catalog `single-region/active-active`, console/editor `single-region/active-hotstandby`, CR `active-hotstandby`). Unifies to ONE canonical vocabulary across the CRD, placement canonicaliser, catalog schema, console + bootstrap-ui editors + legacy-alias mapping + drift tests pinning all three surfaces.

Go: `go build` + full placement/validate/handler suites green. (Salvaged from an agent build that hit a usage limit mid-commit; verified before commit.)

Refs #3375