### PR TITLE
Topology tab reads back LIVE DR state + honest Switchover enablement (Refs #3375)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.dr.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.dr.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * TopologyTab.dr.test.tsx — #3375 DR read-back + DR-UI honesty.
+ *
+ * Locks the hw158-walk fixes:
+ *   1. The Topology tab READS BACK the live DR state for an app — the observed
+ *      primary/standby/phase/lag from GET /continuums/dr-<app> — not a blank
+ *      declared-only editor.
+ *   2. Replication lag renders the REAL live value, never the hardcoded "—".
+ *   3. When no live DR pair exists (the API 404s), the observed strip says so
+ *      honestly AND the Switchover control is DISABLED (not armed against a
+ *      phantom dr-<app> Continuum).
+ *
+ * All generic: the tab keys on the app's declared topology + the live
+ * Continuum record, never on a blueprint name.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+/* ── Mock the API + infra clients so no network is hit ─────────────────── */
+
+const getApplicationStatus = vi.fn()
+const getCatalogItem = vi.fn()
+const getHierarchicalInfrastructure = vi.fn()
+const getContinuum = vi.fn()
+
+vi.mock('@/lib/catalog.api', () => ({
+  getApplicationStatus: (...a: unknown[]) => getApplicationStatus(...a),
+  getCatalogItem: (...a: unknown[]) => getCatalogItem(...a),
+}))
+
+vi.mock('@/lib/infrastructure.types', () => ({
+  getHierarchicalInfrastructure: (...a: unknown[]) => getHierarchicalInfrastructure(...a),
+}))
+
+// Keep the real parseLagSeconds (pure helper) but stub the network call.
+vi.mock('@/lib/continuum.api', async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>
+  return {
+    ...actual,
+    getContinuum: (...a: unknown[]) => getContinuum(...a),
+  }
+})
+
+// Stub the heavy editor; the DR section is NOT stubbed here — we assert its
+// armed/disabled state reflects the tab-derived drPairLive.
+vi.mock('@/widgets/topology/TopologyEditor', () => ({
+  TopologyEditor: () => <div data-testid="stub-topology-editor" />,
+}))
+
+import { TopologyTab } from './TopologyTab'
+
+function withProviders(node: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{node}</QueryClientProvider>
+}
+
+// A 2-region infra so the app's declared active-hot-standby class is the
+// effective class (isMultiRegion=true → showDR=true).
+const TWO_REGION_INFRA = {
+  topology: {
+    regions: [
+      { name: 'hw-me-east-215-a-rtz-prod', providerRegion: 'me-east-215-a' },
+      { name: 'hw-me-east-215-b-rtz-prod', providerRegion: 'me-east-215-b' },
+    ],
+  },
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('TopologyTab — reads back LIVE DR state (#3375)', () => {
+  it('renders the observed primary/standby/phase + REAL replication lag from the live Continuum', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue(TWO_REGION_INFRA)
+    getApplicationStatus.mockResolvedValue({
+      name: 'grafana',
+      namespace: 'flux-system',
+      spec: { placement: 'active-hotstandby', regions: [] },
+      status: {},
+    })
+    // The live Continuum record (could be a reconciled CR or the derived
+    // live-cnpg-pair projection — same shape) with a REAL lag.
+    getContinuum.mockResolvedValue({
+      name: 'dr-grafana',
+      namespace: 'shared-data',
+      uid: '',
+      spec: {
+        applicationRef: 'grafana',
+        primaryRegion: 'me-east-215-a',
+        hotStandbyRegions: ['me-east-215-b'],
+        switchover: { mechanism: 'cnpg-pair' },
+        source: 'live-cnpg-pair',
+      },
+      status: {
+        phase: 'Healthy',
+        primaryRegion: 'me-east-215-a',
+        replicaRegion: 'me-east-215-b',
+        replicationHealthy: true,
+        replicationLagSeconds: 7,
+      },
+    })
+
+    render(
+      withProviders(
+        <TopologyTab sovereignId="hw158" applicationName="grafana" namespace="shared-data" />,
+      ),
+    )
+
+    // The observed strip surfaces the LIVE primary + standby.
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-observed-live')).toBeTruthy()
+    })
+    expect(screen.getByTestId('topology-tab-observed-primary').textContent).toContain('me-east-215-a')
+    expect(screen.getByTestId('topology-tab-observed-standby').textContent).toContain('me-east-215-b')
+    expect(screen.getByTestId('topology-tab-observed-lag').textContent).toContain('7s')
+
+    // The "Live status" replication-lag reads the REAL value, NOT "—".
+    const lagLive = await screen.findByTestId('topology-tab-replication-lag-live')
+    expect(lagLive.textContent).toContain('7s')
+
+    // A live pair exists → the Switchover button is ARMED (owner is the
+    // default caller tier? No — callerTier undefined → not owner → hidden).
+    // We assert the honest disabled-for-tier path is NOT the no-pair path.
+    expect(screen.queryByTestId('topology-tab-replication-lag-nopair')).toBeNull()
+  })
+
+  it('shows the honest "no live DR pair" state + DISABLED Switchover when the Continuum 404s', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue(TWO_REGION_INFRA)
+    getApplicationStatus.mockResolvedValue({
+      name: 'grafana',
+      namespace: 'flux-system',
+      spec: { placement: 'active-hotstandby', regions: [] },
+      status: {},
+    })
+    // No live pair on this Sovereign — the backend 404s (the fetch throws).
+    getContinuum.mockRejectedValue(new Error('continuum get: HTTP 404'))
+
+    render(
+      withProviders(
+        <TopologyTab
+          sovereignId="hw158"
+          applicationName="grafana"
+          namespace="shared-data"
+          callerTier="owner"
+        />,
+      ),
+    )
+
+    // Observed strip is honest: no live DR pair.
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-observed-nopair')).toBeTruthy()
+    })
+    // Replication lag does NOT print a bare "—" value — it says no pair.
+    expect(screen.getByTestId('topology-tab-replication-lag-nopair')).toBeTruthy()
+
+    // Critically: the DR section's Switchover is DISABLED (honest), NEVER
+    // armed against the phantom dr-grafana. Owner tier, but no live pair.
+    await waitFor(() => {
+      expect(screen.getByTestId('continuum-dr-switchover-no-pair')).toBeTruthy()
+    })
+    expect(screen.queryByTestId('continuum-dr-switchover-btn')).toBeNull()
+  })
+
+  it('does NOT fetch a Continuum for a non-DR-capable app (no observed strip)', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue(TWO_REGION_INFRA)
+    getApplicationStatus.mockResolvedValue({
+      name: 'cilium',
+      namespace: 'kube-system',
+      spec: { placement: 'single-region', regions: [] },
+      status: {},
+    })
+
+    render(
+      withProviders(
+        <TopologyTab sovereignId="hw158" applicationName="cilium" namespace="kube-system" />,
+      ),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('topology-tab-declared-panel')).toBeTruthy()
+    })
+    // cilium's effective class is not DR-capable → no observed strip, no
+    // continuum fetch (the gate keys on showDR, not the app name).
+    expect(screen.queryByTestId('topology-tab-observed-strip')).toBeNull()
+    expect(getContinuum).not.toHaveBeenCalled()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -28,6 +28,11 @@ import {
   type CatalogItem,
 } from '@/lib/catalog.api'
 import { getHierarchicalInfrastructure } from '@/lib/infrastructure.types'
+import {
+  getContinuum,
+  parseLagSeconds,
+  type ContinuumGetResponse,
+} from '@/lib/continuum.api'
 import { TopologyEditor } from '@/widgets/topology/TopologyEditor'
 import { DRSection } from '@/widgets/continuum/DRSection'
 import {
@@ -86,6 +91,26 @@ function describeTopologyClass(klass: string): string {
 /** Whether a declared class carries a cross-region DR contract. */
 function isDRCapableClass(klass: string): boolean {
   return klass === 'active-hot-standby' || klass === 'active-passive' || klass === 'active-active'
+}
+
+/**
+ * #3375 — the OBSERVED (live) DR state of an app on THIS Sovereign, parsed
+ * from GET /continuums/dr-<app>. `exists` is the honest "a real DR pair backs
+ * this app here" — true only when the API returned a record naming both a
+ * primary and a DISTINCT standby region (a reconciled Continuum CR OR the
+ * live-cnpg-pair projection the backend derives). Everything the Topology tab
+ * reads back as OBSERVED (vs declared) state flows through this shape.
+ */
+interface LiveDRState {
+  exists: boolean
+  record?: ContinuumGetResponse
+  primaryRegion: string
+  replicaRegion: string
+  phase: string
+  lagSeconds: number | null
+  replicationHealthy: boolean
+  source: string
+  loading: boolean
 }
 
 export interface TopologyTabProps {
@@ -306,6 +331,76 @@ export function TopologyTab({
     effectiveDRClass === 'active-passive' ||
     (!!switchoverMechanism && switchoverMechanism.toLowerCase() !== 'none')
 
+  // #3375 (Topology reads back REAL state + DR-UI honesty) — fetch the LIVE
+  // DR record for this app from catalyst-api: GET /continuums/dr-<app>. The
+  // backend returns either a reconciled Continuum CR's spec+status OR (when
+  // no CR is seeded) a record DERIVED from the live cnpg cluster-pair backing
+  // the app (real primaryRegion / replicaRegion / replicationHealthy /
+  // replicationLagSeconds / phase) — see continuum_live.go
+  // deriveLiveContinuumRecord. A 404 (the fetch throws) is the HONEST signal
+  // that no live 2-region pair exists on this Sovereign — we surface that, we
+  // never invent one. Only fetched when the app is DR-capable and not a bare
+  // bootstrap HelmRelease that has no chance of a pair. Honors an explicit
+  // `continuumName` prop (AppDetail may pass the controller-minted CR name);
+  // else the conventional `dr-<app>` the backend also derives.
+  const resolvedContinuumName = continuumName ?? `dr-${applicationName}`
+  const liveContinuumQ = useQuery({
+    queryKey: ['topology-tab-continuum', sovereignId, resolvedContinuumName, namespace, refreshTick],
+    queryFn: () => getContinuum(sovereignId, resolvedContinuumName, { namespace }),
+    enabled: !disableNetwork && showDR && !!sovereignId && !!applicationName,
+    // 404 (no live pair) is an expected terminal state, not a transient
+    // failure — don't retry-loop it (mirrors the #3656 status-poll fix).
+    retry: false,
+    refetchInterval: 10_000,
+  })
+
+  // The live DR record, parsed into the single observed-truth shape the tab
+  // reads back. `exists` is the honest "a real DR pair backs this app on this
+  // Sovereign" — true only when the API returned a record carrying a usable
+  // standby/replica region (a reconciled CR OR the derived live-cnpg-pair
+  // projection). It is what gates the Switchover control (DR-UI honesty) and
+  // feeds the real replication-lag number (replacing the hardcoded "—").
+  const liveDR = useMemo(() => {
+    const rec: ContinuumGetResponse | undefined = liveContinuumQ.data
+    const spec = (rec?.spec ?? {}) as Record<string, unknown>
+    const status = (rec?.status ?? {}) as Record<string, unknown>
+
+    const primaryRegion =
+      (status['primaryRegion'] as string | undefined) ??
+      (spec['primaryRegion'] as string | undefined) ??
+      ''
+    const replicaRegion =
+      (status['replicaRegion'] as string | undefined) ??
+      (Array.isArray(spec['hotStandbyRegions'])
+        ? ((spec['hotStandbyRegions'] as unknown[])[0] as string | undefined)
+        : undefined) ??
+      ''
+    const phase = (status['phase'] as string | undefined) ?? ''
+    const lagSeconds = parseLagSeconds(status['replicationLagSeconds'])
+    const replicationHealthy = Boolean(status['replicationHealthy'] ?? false)
+    const source = (spec['source'] as string | undefined) ?? ''
+
+    // A live DR pair genuinely exists only when the record names BOTH a
+    // primary AND a distinct standby region — anything less is not a
+    // cross-region pair and must NOT arm the Switchover control.
+    const exists =
+      !!rec && !!primaryRegion && !!replicaRegion && primaryRegion !== replicaRegion
+
+    return {
+      exists,
+      record: rec,
+      primaryRegion,
+      replicaRegion,
+      phase,
+      lagSeconds,
+      replicationHealthy,
+      source,
+      // Distinguish "still loading" from "confirmed absent" so the read-back
+      // copy reads honestly (a spinner vs the no-pair state).
+      loading: liveContinuumQ.isLoading && !liveContinuumQ.isError,
+    }
+  }, [liveContinuumQ.data, liveContinuumQ.isLoading, liveContinuumQ.isError])
+
   useEffect(() => {
     // When initialApp updates, just trigger no-op so consumers re-derive.
   }, [initialApp])
@@ -325,6 +420,8 @@ export function TopologyTab({
         liveClass={liveClass}
         isMultiRegion={isMultiRegion}
         sovereignRegionCount={sovereignRegionCount}
+        liveDR={liveDR}
+        showDR={showDR}
       />
 
       <h3 className="mt-6 mb-2 text-sm font-medium text-[var(--color-text-strong)]">
@@ -407,13 +504,47 @@ export function TopologyTab({
         <div className="mt-3 grid grid-cols-2 gap-3 text-xs text-[var(--color-text-dim)]">
           <div data-testid="topology-tab-replication-lag">
             <strong className="text-[var(--color-text)]">Replication lag</strong>:{' '}
-            {effectiveDRClass === 'active-hot-standby' ? '—' : 'n/a (mode)'}
+            {/* #3375 (E4) — REAL replication lag from the live Continuum
+                record (its status.replicationLagSeconds), NOT a hardcoded
+                "—". When the app declares no replication, it's n/a; when it
+                declares active-hot-standby but no live pair exists yet on
+                this Sovereign, we say so honestly rather than print a bare
+                dash that looks like a value-that-failed-to-load. */}
+            {!isDRCapableClass(effectiveDRClass) ? (
+              <span>n/a (mode)</span>
+            ) : liveDR.exists ? (
+              <span data-testid="topology-tab-replication-lag-live">
+                {liveDR.lagSeconds == null
+                  ? '— (no lag reported)'
+                  : `${liveDR.lagSeconds}s`}
+                {liveDR.phase ? (
+                  <span className="ml-1 text-[var(--color-text-dim)]">· {liveDR.phase}</span>
+                ) : null}
+              </span>
+            ) : liveDR.loading ? (
+              <span data-testid="topology-tab-replication-lag-loading">checking…</span>
+            ) : (
+              <span data-testid="topology-tab-replication-lag-nopair">
+                no live DR pair on this Sovereign
+              </span>
+            )}
           </div>
           <div data-testid="topology-tab-last-switchover">
             <strong className="text-[var(--color-text)]">Last switchover</strong>:{' '}
-            {(app?.status as Record<string, unknown> | undefined)?.lastSwitchover
-              ? String((app?.status as Record<string, unknown>).lastSwitchover)
-              : '—'}
+            {(() => {
+              // Prefer the live Continuum record's lastSwitchover; fall back
+              // to the Application status' field for back-compat.
+              const fromCont = (liveDR.record?.status as Record<string, unknown> | undefined)
+                ?.lastSwitchover
+              const fromApp = (app?.status as Record<string, unknown> | undefined)?.lastSwitchover
+              const ls = fromCont ?? fromApp
+              if (!ls) return '—'
+              const lsObj = ls as Record<string, unknown>
+              const at = lsObj['at'] as string | undefined
+              const result = lsObj['result'] as string | undefined
+              if (at || result) return `${result ?? '—'}${at ? ` (${at})` : ''}`
+              return String(ls)
+            })()}
           </div>
         </div>
       </div>
@@ -429,13 +560,20 @@ export function TopologyTab({
       {showDR ? (
         <DRSection
           sovereignId={sovereignId}
-          continuumName={continuumName ?? `dr-${applicationName}`}
+          continuumName={resolvedContinuumName}
           applicationName={applicationName}
           namespace={namespace}
           callerTier={callerTier}
           declaredClass={effectiveDRClass}
           switchoverMechanism={switchoverMechanism}
           hasSwitchover={hasSwitchover}
+          // #3375 (DR-UI honesty) — the authoritative live-state gate: the
+          // Switchover control arms ONLY when a real DR pair backs this app
+          // on this Sovereign (a live Continuum record naming a distinct
+          // standby region). Derived from the same GET /continuums the panel
+          // reads. When false, the panel renders the honest disabled state
+          // instead of an armed button against a phantom dr-<app> CR.
+          drPairLive={liveDR.exists}
           disableNetwork={disableNetwork}
         />
       ) : null}
@@ -453,6 +591,10 @@ interface DeclaredTopologyPanelProps {
   liveClass: string
   isMultiRegion: boolean
   sovereignRegionCount: number
+  /** #3375 — the OBSERVED live DR state (from GET /continuums/dr-<app>). */
+  liveDR: LiveDRState
+  /** Whether this app's effective class is DR-capable (gates the observed strip). */
+  showDR: boolean
 }
 
 /**
@@ -474,6 +616,8 @@ function DeclaredTopologyPanel({
   liveClass,
   isMultiRegion,
   sovereignRegionCount,
+  liveDR,
+  showDR,
 }: DeclaredTopologyPanelProps) {
   const placement = declaredVariant?.placement
   const replication = declaredVariant?.replication
@@ -520,6 +664,18 @@ function DeclaredTopologyPanel({
           {classLabel(declaredClass)}
         </span>
       </div>
+
+      {/* #3375 (Topology reads back REAL state) — the OBSERVED strip. Beneath
+          the DECLARED contract (build-time, from blueprint.yaml) we surface
+          the EFFECTIVE/observed state read LIVE off this Sovereign's Continuum
+          record: which region is primary, the standby region, the replication
+          phase + lag. This is the read-back the hw158 walk found missing — the
+          tab was a declared-only editor that never reflected the app's actual
+          matrix topology. Only rendered for DR-capable apps; honest about the
+          three live states (a real pair / still checking / no pair here). */}
+      {showDR ? (
+        <ObservedDRStrip applicationName={applicationName} liveDR={liveDR} declaredClass={declaredClass} />
+      ) : null}
 
       {!declaredTopology ? (
         <p className="text-xs text-[var(--color-text-dim)]" data-testid="topology-tab-declared-none">
@@ -642,5 +798,110 @@ function DeclaredTopologyPanel({
         </>
       )}
     </section>
+  )
+}
+
+/* ─── Observed (live) DR read-back strip (#3375) ─────────────────────── */
+
+interface ObservedDRStripProps {
+  applicationName: string
+  liveDR: LiveDRState
+  declaredClass: string
+}
+
+/**
+ * ObservedDRStrip — the EFFECTIVE/observed half of the #3375 read-back.
+ *
+ * Where DeclaredTopologyPanel shows the build-time CONTRACT, this strip shows
+ * what is ACTUALLY running on THIS Sovereign for the app, read live from its
+ * Continuum record (GET /continuums/dr-<app>): the current primary region,
+ * the standby region, the replication phase, and the real replication lag.
+ *
+ * Three honest states, never a fabricated one:
+ *   • a real DR pair  → primary / standby / phase / lag rendered live;
+ *   • still checking  → a calm "reading live DR state…";
+ *   • no pair here    → the explicit "no live DR pair on this Sovereign"
+ *     (single-region prov, or the standby half isn't up) — so the operator
+ *     reads the truth instead of a green badge against a phantom.
+ */
+function ObservedDRStrip({ applicationName, liveDR, declaredClass }: ObservedDRStripProps) {
+  const phaseColor = (() => {
+    switch (liveDR.phase) {
+      case 'Healthy':
+        return 'bg-green-500/10 text-green-400'
+      case 'Degraded':
+        return 'bg-yellow-500/10 text-yellow-400'
+      case 'FailedOver':
+        return 'bg-purple-500/10 text-purple-400'
+      case 'Failed':
+        return 'bg-red-500/10 text-red-400'
+      default:
+        return 'bg-[var(--color-border)]/40 text-[var(--color-text-dim)]'
+    }
+  })()
+
+  return (
+    <div
+      className="mt-3 rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] p-3"
+      data-testid="topology-tab-observed-strip"
+    >
+      <p className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-[var(--color-text-dim)]">
+        Observed (live on this Sovereign)
+      </p>
+
+      {liveDR.exists ? (
+        <div className="grid grid-cols-1 gap-x-6 gap-y-1.5 text-xs sm:grid-cols-2" data-testid="topology-tab-observed-live">
+          <div className="flex justify-between gap-3 sm:block">
+            <dt className="text-[var(--color-text-dim)]">Primary region</dt>
+            <dd className="font-mono text-[var(--color-text)]" data-testid="topology-tab-observed-primary">
+              {liveDR.primaryRegion || '—'}
+            </dd>
+          </div>
+          <div className="flex justify-between gap-3 sm:block">
+            <dt className="text-[var(--color-text-dim)]">Standby region</dt>
+            <dd className="font-mono text-[var(--color-text)]" data-testid="topology-tab-observed-standby">
+              {liveDR.replicaRegion || '—'}
+            </dd>
+          </div>
+          <div className="flex justify-between gap-3 sm:block">
+            <dt className="text-[var(--color-text-dim)]">Replication</dt>
+            <dd data-testid="topology-tab-observed-phase">
+              <span className={`inline-flex rounded-md px-1.5 py-0.5 text-[10px] font-semibold uppercase ${phaseColor}`}>
+                {liveDR.phase || (liveDR.replicationHealthy ? 'healthy' : 'unknown')}
+              </span>
+            </dd>
+          </div>
+          <div className="flex justify-between gap-3 sm:block">
+            <dt className="text-[var(--color-text-dim)]">Replication lag</dt>
+            <dd className="font-mono text-[var(--color-text)]" data-testid="topology-tab-observed-lag">
+              {liveDR.lagSeconds == null ? '— (not reported)' : `${liveDR.lagSeconds}s`}
+            </dd>
+          </div>
+          {liveDR.source ? (
+            <div className="flex justify-between gap-3 sm:col-span-2 sm:block">
+              <dt className="text-[var(--color-text-dim)]">Source</dt>
+              <dd className="font-mono text-[11px] text-[var(--color-text-dim)]" data-testid="topology-tab-observed-source">
+                {liveDR.source === 'live-cnpg-pair'
+                  ? 'live cnpg cluster-pair (no reconciled Continuum CR yet)'
+                  : liveDR.source}
+              </dd>
+            </div>
+          ) : null}
+        </div>
+      ) : liveDR.loading ? (
+        <p className="text-xs text-[var(--color-text-dim)]" data-testid="topology-tab-observed-loading">
+          Reading live DR state…
+        </p>
+      ) : (
+        <p className="text-xs text-[var(--color-text-dim)]" data-testid="topology-tab-observed-nopair">
+          No live DR pair for{' '}
+          <code className="font-mono text-[var(--color-text)]">{applicationName}</code> on this
+          Sovereign. The declared{' '}
+          <strong className="text-[var(--color-text)]">{declaredClass}</strong> contract activates a
+          cross-region pair only on a 2-region Sovereign with a healthy standby — until then there is
+          nothing to switch over.
+        </p>
+      )}
+    </div>
   )
 }

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/DRSection.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/DRSection.test.tsx
@@ -142,3 +142,92 @@ describe('DRSection', () => {
     expect(screen.getByTestId('continuum-lua-view')).toBeTruthy()
   })
 })
+
+/**
+ * #3375 (DR-UI honesty) — the Switchover control must be ARMED only when a
+ * REAL live DR pair backs the app, and DISABLED-with-an-honest-reason when
+ * none exists. This locks the fix for the hw158 defect: an armed Switchover
+ * against a non-existent dr-grafana that 404s on click.
+ */
+describe('DRSection — Switchover armed only with a real live DR pair (#3375)', () => {
+  it('ARMS the Switchover button for an owner when drPairLive=true', () => {
+    render(
+      withProviders(
+        <DRSection
+          sovereignId="dep-1"
+          continuumName="dr-grafana"
+          applicationName="grafana"
+          callerTier="owner"
+          declaredClass="active-hot-standby"
+          drPairLive
+          initialContinuum={sampleCR}
+          disableNetwork
+        />,
+      ),
+    )
+    expect(screen.getByTestId('continuum-dr-switchover-btn')).toBeTruthy()
+    expect(screen.queryByTestId('continuum-dr-switchover-no-pair')).toBeNull()
+  })
+
+  it('DISABLES the Switchover with an honest reason when drPairLive=false (owner, no phantom arm)', () => {
+    render(
+      withProviders(
+        <DRSection
+          sovereignId="dep-1"
+          continuumName="dr-grafana"
+          applicationName="grafana"
+          callerTier="owner"
+          declaredClass="active-hot-standby"
+          drPairLive={false}
+          initialContinuum={sampleCR}
+          disableNetwork
+        />,
+      ),
+    )
+    // No armed button — the exact hw158 defect (armed against a phantom CR).
+    expect(screen.queryByTestId('continuum-dr-switchover-btn')).toBeNull()
+    // Instead, the honest disabled state.
+    const disabled = screen.getByTestId('continuum-dr-switchover-no-pair')
+    expect(disabled).toBeTruthy()
+    expect(disabled.textContent ?? '').toMatch(/no live dr pair/i)
+  })
+
+  it('does NOT arm Switchover when no live CR exists and no drPairLive signal (old crMissing arming is gone)', () => {
+    // disableNetwork + no initialContinuum → the panel has no live record.
+    // The OLD behaviour armed the button on this `crMissing` case; the fix
+    // makes it honestly disabled.
+    render(
+      withProviders(
+        <DRSection
+          sovereignId="dep-1"
+          continuumName="dr-grafana"
+          applicationName="grafana"
+          callerTier="owner"
+          declaredClass="active-hot-standby"
+          disableNetwork
+        />,
+      ),
+    )
+    expect(screen.queryByTestId('continuum-dr-switchover-btn')).toBeNull()
+    expect(screen.getByTestId('continuum-dr-switchover-no-pair')).toBeTruthy()
+  })
+
+  it('still hides the control for a non-owner even when a live pair exists', () => {
+    render(
+      withProviders(
+        <DRSection
+          sovereignId="dep-1"
+          continuumName="dr-grafana"
+          applicationName="grafana"
+          callerTier="viewer"
+          declaredClass="active-hot-standby"
+          drPairLive
+          initialContinuum={sampleCR}
+          disableNetwork
+        />,
+      ),
+    )
+    expect(screen.queryByTestId('continuum-dr-switchover-btn')).toBeNull()
+    expect(screen.getByTestId('continuum-dr-switchover-disabled')).toBeTruthy()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/DRSection.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/DRSection.tsx
@@ -70,6 +70,26 @@ export interface DRSectionProps {
    * posture but no Switchover button. Defaults true for back-compat.
    */
   hasSwitchover?: boolean
+  /**
+   * #3375 (DR-UI honesty) — whether a REAL live DR pair backs this app on
+   * THIS Sovereign: a live Continuum record (a reconciled Continuum CR OR
+   * the derived live-cnpg-pair projection) carrying a usable standby region.
+   *
+   * The Switchover control is ARMED only when this is true. When false — no
+   * 2-region pair exists for the app on this Sovereign (single-region prov,
+   * or the region-b half isn't up) — the button is DISABLED with an honest
+   * reason, NEVER armed against a phantom `dr-<app>` Continuum that 404s on
+   * click (the exact defect the hw158 walk caught: an armed Switchover
+   * against a non-existent dr-grafana). The parent (TopologyTab) derives
+   * this from the same GET /continuums/{name} this panel reads — so the gate
+   * keys on live state, never on a build-time constant or the app name.
+   *
+   * Left `undefined` (the back-compat default) means "the parent did not
+   * pass a live-state signal" — the panel then falls back to its own query
+   * result (`!crMissing`), so an embedded DRSection rendered with a live
+   * `initialContinuum` still arms correctly in isolation.
+   */
+  drPairLive?: boolean
   /** Test seam — pre-fill the Continuum CR + audit list, skip network. */
   initialContinuum?: ContinuumGetResponse
   /** Test seam — bypass the audit fetch + network calls. */
@@ -85,6 +105,7 @@ export function DRSection({
   declaredClass,
   switchoverMechanism,
   hasSwitchover = true,
+  drPairLive,
   initialContinuum,
   disableNetwork = false,
 }: DRSectionProps) {
@@ -153,15 +174,24 @@ export function DRSection({
         ? 'Disaster Recovery (active-active)'
         : 'Disaster Recovery (active-hot-standby)'
 
-  // The Switchover button is enabled for the owner tier whenever there is a
-  // failover target. When a live CR is present we use its hot-standby set;
-  // when none exists yet (no Continuum CR) the owner can still INITIATE the
-  // switchover — the catalyst-api handler defaults the target to the first
-  // hot-standby region server-side, so we pass an empty target and let the
-  // dialog/handler resolve it. This is what makes the control walkable
-  // rather than permanently absent. Suppressed entirely when the variant
-  // declares no switchover (active-active / none).
-  const canSwitchover = hasSwitchover && isOwner && (!!failoverTarget || crMissing)
+  // #3375 (DR-UI honesty) — the Switchover button is ARMED only when a REAL
+  // live DR pair backs this app on this Sovereign. The truth signal:
+  //
+  //   • the parent (TopologyTab) passed `drPairLive` — the authoritative
+  //     live-state flag it derives from the SAME GET /continuums/{name} this
+  //     panel reads (a reconciled Continuum CR OR the derived live-cnpg-pair
+  //     projection with a usable standby). We honor it directly; OR
+  //   • the panel is embedded standalone with a live record of its own
+  //     (`!crMissing`) — e.g. a test/fixture passing `initialContinuum`.
+  //
+  // Critically, the OLD `|| crMissing` arming is GONE: when there is no live
+  // pair (single-region prov, or the region-b half isn't up) the button must
+  // be DISABLED with an honest reason, never armed against a phantom
+  // `dr-<app>` Continuum that 404s on click (the hw158 defect: an armed
+  // Switchover against a non-existent dr-grafana). Suppressed entirely when
+  // the variant declares no switchover (active-active / none).
+  const livePairPresent = drPairLive !== undefined ? drPairLive : !crMissing
+  const canSwitchover = hasSwitchover && isOwner && livePairPresent
 
   return (
     <section
@@ -194,6 +224,20 @@ export function DRSection({
             className="text-xs text-[var(--color-text-dim)]"
           >
             Owner tier required to switchover
+          </span>
+        ) : !livePairPresent ? (
+          // #3375 (DR-UI honesty) — owner tier, but no live DR pair exists on
+          // this Sovereign. Disable with the honest reason instead of arming
+          // against a phantom Continuum. A title attribute spells out why so
+          // the operator never wonders if the control is "broken".
+          <span
+            data-testid="continuum-dr-switchover-no-pair"
+            className="cursor-not-allowed text-xs text-[var(--color-text-dim)]"
+            title={`No live DR pair for ${applicationName} on this Sovereign — switchover activates once the app runs ${
+              declaredClass ?? 'active-hot-standby'
+            } with a healthy standby in the second region.`}
+          >
+            No live DR pair — switchover unavailable
           </span>
         ) : (
           <span


### PR DESCRIPTION
## What & why

The AppDetail **Topology tab** was a declared-only placement editor. The hw158 re-validation (Sections C/D/E of the #3375 walkthrough) found it never reflected an app's actual matrix topology, the DR section showed an **ARMED Switchover against a non-existent `dr-grafana` Continuum**, and the replication lag rendered a hardcoded `—`. This builds the un-built **Continuum / DR-display honesty** target of #3375 (the ~25 ❌ display rows). Section H (region-kill) already passes and is untouched.

All generic — keyed on the app's declared topology + the **live Continuum record**, never on a blueprint name.

## What's built

**1. Topology tab reads back REAL state.** `TopologyTab` now fetches the live DR record (`GET /continuums/dr-<app>`), which catalyst-api returns either from a reconciled Continuum CR **or** derived from the live cnpg cluster-pair backing the app (`deriveLiveContinuumRecord` — real `primaryRegion` / `replicaRegion` / `replicationHealthy` / `replicationLagSeconds` / `phase`). A new **"Observed (live on this Sovereign)"** strip reads back the real primary region, standby region, replication phase + lag — beside the build-time DECLARED contract. A 404 (no live pair) is surfaced honestly; nothing is invented.

**2. Replication lag (E4)** renders the REAL `status.replicationLagSeconds` with three honest states — a live value · `checking…` · `no live DR pair on this Sovereign` — never the bare hardcoded `—`.

**3. Switchover honesty (C2/E1/E2/F5).** The control ARMS **only** when a real DR pair exists (a live Continuum record naming a *distinct* standby region), via a new `DRSection.drPairLive` prop `TopologyTab` derives from the same `GET`. The old `|| crMissing` arming is **removed** — with no live pair the button is **DISABLED with an honest reason** (`No live DR pair — switchover unavailable`), never armed against a phantom `dr-<app>` that 404s on click. Non-owner / no-switchover (active-active) paths unchanged.

## Backend execution tail (already present, not in this PR)

The switchover **execution** wiring already lives in catalyst-api: when no Continuum CR exists but a live 2-region cnpg-pair does, `handleNoCRSwitchoverViaLivePair` / `liveSwitchoverViaCNPGPair` drive the **proven region-kill mechanism** (cordon + `spec.replica.enabled` flip — the same path the H region-kill walk proved). This PR builds the **display + honest enablement state** on top of it; no new backend code was needed for the armed→disabled honesty slice. A genuine, on-cluster armed-Switchover-then-promote walk against a real 2-region pair remains the live-validation tail (it needs a fresh 2-region prov where the app-labelled cnpg-pair resolves from both region kubeconfigs).

## Tests / build

- `DRSection.test.tsx` — new cases lock **"armed only with a real live pair"**: `drPairLive=true` → armed; `drPairLive=false` / no-CR → honest disabled, **no phantom arm**; non-owner still hidden.
- `TopologyTab.dr.test.tsx` (new) — locks the live read-back (observed primary/standby/phase + real lag), the **no-pair honesty** + **disabled Switchover** on a 404, and the **no-fetch-for-non-DR-app** gate (keys on `showDR`, never the app name).
- FE `tsc -b --noEmit` green; `vite build` green; **15 targeted + 107 area** tests pass.

Refs #3375

🤖 Generated with [Claude Code](https://claude.com/claude-code)