### PR TITLE
fix(catalyst): hook exit-0 not FATAL — stop wedging platform upgrade (live regression)

### DIFF
--- a/products/catalyst/chart/templates/catalog-sovereign-flux/gitea-flux-auth-secrets-sync-job.yaml
+++ b/products/catalyst/chart/templates/catalog-sovereign-flux/gitea-flux-auth-secrets-sync-job.yaml
@@ -263,7 +263,7 @@ spec:
               # (POLL_ATTEMPTS × POLL_INTERVAL, default 60 × 5s = 300s, well
               # inside the HR's 30m upgrade timeout) before failing. Survives
               # ANY mint-vs-sync ordering, fresh-install OR upgrade.
-              POLL_ATTEMPTS="${POLL_ATTEMPTS:-60}"
+              POLL_ATTEMPTS="${POLL_ATTEMPTS:-240}"
               POLL_INTERVAL="${POLL_INTERVAL:-5}"
               i=1
               while [ "$i" -le "$POLL_ATTEMPTS" ]; do
@@ -278,8 +278,8 @@ spec:
                 sleep "$POLL_INTERVAL"
               done
               if [ ! -s /tmp/password ]; then
-                echo "[gitea-flux-auth-sync] FATAL: ${PAT_NAMESPACE}/${PAT_SECRET}.${PAT_KEY} still empty after ${POLL_ATTEMPTS} attempts (~$((POLL_ATTEMPTS * POLL_INTERVAL))s) — mint hook did not populate the PAT" >&2
-                exit 1
+                echo "[gitea-flux-auth-sync] FATAL: ${PAT_NAMESPACE}/${PAT_SECRET}.${PAT_KEY} still empty after ${POLL_ATTEMPTS} attempts (~$((POLL_ATTEMPTS * POLL_INTERVAL))s) — catalyst-platform NOT wedged; the 2 Flux auth Secrets self-heal next reconcile once the mint lands (#3781 regression fix)" >&2
+                exit 0
               fi
               # Idempotent create-or-update of one Flux basic-auth Secret.
               # source-controller reads `username` + `password` and embeds them


### PR DESCRIPTION
The regression the founder hit. Catalog-secret-sync hook must never fail the whole platform upgrade. exit 0 + 20m poll. Live env already un-wedged (v20 upgrade succeeded). Refs #3749 #3765