### PR TITLE
feat(bootstrap-kit): self-register Application CRs for 8 bootstrap platform apps (Refs #3687)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -118,7 +118,11 @@ spec:
       # deep-link) so OpenBao lands signed-in instead of the popup-only Vault
       # OIDC callback's window.opener=null error. blueprint.yaml/Chart.yaml
       # lockstep; no chart-template change (landing page already shipped 1.2.35).
-      version: 1.2.46
+      # 1.2.47 (#3687, extends #3370): bootstrap self-registration — the
+      # chart renders the canonical apps.openova.io/v1 Application CR for
+      # this slot's HelmRelease so the console /apps list, per-app Topology
+      # tab + showback resolve openbao (no more "no Application CR").
+      version: 1.2.47
       sourceRef:
         kind: HelmRepository
         name: bp-openbao
@@ -156,6 +160,16 @@ spec:
   #   Flux applies this HelmRelease, so the init Job has the seed it
   #   needs on first reconcile.
   values:
+    # ── Bootstrap self-registration (#3687, extends #3370) ──────────────
+    # The chart self-registers the Application CR for openbao (the
+    # canonical instance representation every console surface reads),
+    # marked spec.bootstrap=true so the application-controller ADOPTS this
+    # HR's install instead of re-rendering it (zero duplicate HRs).
+    bootstrapOwned:
+      enabled: true
+      helmRelease:
+        name: bp-openbao
+        namespace: flux-system
     gateway:
       host: bao.${SOVEREIGN_FQDN}
     # G91.openbao (#2655) — wire bp-sso-bridge framework. The chart-side

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -169,7 +169,11 @@ spec:
       # 1.4.29: sovereign-realm configmap one-admin-authority (#3374).
       # 1.4.30: powerdns-admin realm client -> /oauth2/callback + aud-mapper,
       #         matching the bp-oidc-gate AppRegistration (#3741, hw158 row 6).
-      version: 1.4.30
+      # 1.4.31 (#3687, extends #3370): bootstrap self-registration — the
+      # chart renders the canonical apps.openova.io/v1 Application CR for
+      # this slot's HelmRelease so the console /apps list, per-app Topology
+      # tab + showback resolve keycloak (no more "no Application CR").
+      version: 1.4.31
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak
@@ -228,6 +232,16 @@ spec:
   # ${VAR:=default} resolves to "sovereign" — backward-compat with
   # overlays that haven't been migrated.
   values:
+    # ── Bootstrap self-registration (#3687, extends #3370) ──────────────
+    # The chart self-registers the Application CR for keycloak (the
+    # canonical instance representation every console surface reads),
+    # marked spec.bootstrap=true so the application-controller ADOPTS this
+    # HR's install instead of re-rendering it (zero duplicate HRs).
+    bootstrapOwned:
+      enabled: true
+      helmRelease:
+        name: bp-keycloak
+        namespace: flux-system
     sovereignFQDN: ${SOVEREIGN_FQDN}
     # sovereignRealm.ownerEmail (founder NS-3 #3263): the deployment owner's
     # email — cloud-init threads tofu's org_email into the bootstrap-kit

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -132,7 +132,11 @@ spec:
       # 1.2.30: explicit port 443 on the SSO redirect (the #3310 class).
       # 1.2.31: LANDING_PAGE=login — anon root funnels into OIDC.
       # 1.2.35 (#3373 Batch A): objectStorage S3+filer endpoint defaults → rtz-vCluster synced name (seaweedfs moved into rtz).
-      version: 1.2.35
+      # 1.2.36 (#3687, extends #3370): bootstrap self-registration — the
+      # chart renders the canonical apps.openova.io/v1 Application CR for
+      # this slot's HelmRelease so the console /apps list, per-app Topology
+      # tab + showback resolve gitea (no more "no Application CR").
+      version: 1.2.36
       sourceRef:
         kind: HelmRepository
         name: bp-gitea
@@ -165,6 +169,16 @@ spec:
     remediation:
       retries: 3
   values:
+    # ── Bootstrap self-registration (#3687, extends #3370) ──────────────
+    # The chart self-registers the Application CR for gitea (the canonical
+    # instance representation every console surface reads), marked
+    # spec.bootstrap=true so the application-controller ADOPTS this HR's
+    # install instead of re-rendering it (zero duplicate HRs).
+    bootstrapOwned:
+      enabled: true
+      helmRelease:
+        name: bp-gitea
+        namespace: flux-system
     global:
       sovereignFQDN: ${SOVEREIGN_FQDN}
     # G91.gitea (#2653) — wire bp-sso-bridge framework. The chart-side

--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -146,7 +146,11 @@ spec:
       # (powerdns pods never started → no DNS → no wildcard TLS → console
       # down). The kyverno-Enforce concern is handled by excluding the
       # `powerdns` ns from harbor-proxy-pull (bp-kyverno-policies 1.0.33).
-      version: 1.2.14
+      # 1.2.15 (#3687, extends #3370): bootstrap self-registration — the
+      # chart renders the canonical apps.openova.io/v1 Application CR for
+      # this slot's HelmRelease so the console /apps list, per-app Topology
+      # tab + showback resolve powerdns (no more "no Application CR").
+      version: 1.2.15
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns
@@ -185,6 +189,16 @@ spec:
   # The HTTPRoute attaches to cilium-gateway/kube-system and is the
   # active path on Sovereigns.
   values:
+    # ── Bootstrap self-registration (#3687, extends #3370) ──────────────
+    # The chart self-registers the Application CR for powerdns (the
+    # canonical instance representation every console surface reads),
+    # marked spec.bootstrap=true so the application-controller ADOPTS this
+    # HR's install instead of re-rendering it (zero duplicate HRs).
+    bootstrapOwned:
+      enabled: true
+      helmRelease:
+        name: bp-powerdns
+        namespace: flux-system
     # G87 #2634: multi-region CNPG instances default (1 single-region, 2 multi).
     postgres:
       cluster:

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -190,7 +190,11 @@ spec:
       # upgrade, harbor-registry ReplicaSet FailedCreate).
       # 1.2.30 (2026-06-12, founder): primary_auth_mode=true — hitting
       # registry.<fqdn>/ auto-initiates OIDC instead of showing the form.
-      version: 1.2.30
+      # 1.2.31 (#3687, extends #3370): bootstrap self-registration — the
+      # chart renders the canonical apps.openova.io/v1 Application CR for
+      # this slot's HelmRelease so the console /apps list, per-app Topology
+      # tab + showback resolve harbor (no more "no Application CR").
+      version: 1.2.31
       sourceRef:
         kind: HelmRepository
         name: bp-harbor
@@ -258,6 +262,16 @@ spec:
   # - harbor.persistence.imageChartStorage.s3.existingSecret matches the
   #   credentials Secret name templated by the umbrella chart.
   values:
+    # ── Bootstrap self-registration (#3687, extends #3370) ──────────────
+    # The chart self-registers the Application CR for harbor (the canonical
+    # instance representation every console surface reads), marked
+    # spec.bootstrap=true so the application-controller ADOPTS this HR's
+    # install instead of re-rendering it (zero duplicate HRs).
+    bootstrapOwned:
+      enabled: true
+      helmRelease:
+        name: bp-harbor
+        namespace: flux-system
     gateway:
       host: registry.${SOVEREIGN_FQDN}
       # #3150 (2026-06-09): the chart's HTTPRoute backend defaults to

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -123,7 +123,12 @@ spec:
       # 1.0.13's 64Mi OOMKilled the searchNamespace=ALL k8s-sidecar (exitCode
       # 137 CrashLoopBackOff) → Pod stuck 1/3 NotReady → route 503 despite the
       # main grafana container serving SSO. Refs #3374.
-      version: 1.0.14
+      # 1.0.15 (#3687, extends #3370): bootstrap self-registration — the
+      # chart renders the canonical apps.openova.io/v1 Application CR for
+      # this slot's HelmRelease (adoption-guarded, Capabilities-gated) so
+      # the console /apps list, per-app Topology tab + showback resolve
+      # grafana instead of "n/a — bootstrap component, no Application CR".
+      version: 1.0.15
       sourceRef:
         kind: HelmRepository
         name: bp-grafana
@@ -143,6 +148,16 @@ spec:
   # (platform/grafana/chart/templates/httproute.yaml). The HTTPRoute
   # attaches to cilium-gateway/kube-system installed by 01-cilium.yaml.
   values:
+    # ── Bootstrap self-registration (#3687, extends #3370) ──────────────
+    # The chart self-registers the Application CR for grafana (the
+    # canonical instance representation every console surface reads),
+    # marked spec.bootstrap=true so the application-controller ADOPTS
+    # this HR's install instead of re-rendering it (zero duplicate HRs).
+    bootstrapOwned:
+      enabled: true
+      helmRelease:
+        name: bp-grafana
+        namespace: flux-system
     gateway:
       host: grafana.${SOVEREIGN_FQDN}
     # G91.grafana (#2658) — wire bp-sso-bridge framework. The chart-side

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -171,7 +171,11 @@ spec:
       # SSO users into sovereign-admins → admin DETERMINISTIC. 0.2.16 had the
       # USER_GROUP+ADMINISTER but the membership table stayed empty so the owner
       # got no admin menu (#3475). Proven live on hw133.
-      version: 0.2.20
+      # 0.2.21 (#3687, extends #3370): bootstrap self-registration — the
+      # chart renders the canonical apps.openova.io/v1 Application CR for
+      # this slot's HelmRelease so the console /apps list, per-app Topology
+      # tab + showback resolve guacamole (no more "no Application CR").
+      version: 0.2.21
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole
@@ -193,6 +197,16 @@ spec:
   # below is replaced with the concrete sovereign FQDN before the HR
   # bytes land in the cluster.
   values:
+    # ── Bootstrap self-registration (#3687, extends #3370) ──────────────
+    # The chart self-registers the Application CR for guacamole (the
+    # canonical instance representation every console surface reads),
+    # marked spec.bootstrap=true so the application-controller ADOPTS this
+    # HR's install instead of re-rendering it (zero duplicate HRs).
+    bootstrapOwned:
+      enabled: true
+      helmRelease:
+        name: bp-guacamole
+        namespace: flux-system
     guacamole:
       # Default-OFF gate flipped ON by the bootstrap-kit slot. Operator
       # opts out per-Sovereign by removing this slot from

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -255,7 +255,11 @@ spec:
       # #3648 — lockstep with platform/newapi Chart.yaml + blueprint.yaml 1.4.95.
       # #3374/#3563 — 1.4.97: per-minute CronJob now retries the SSO provider
       # reload until the NewAPI Deployment is restarted (fresh-prov determinism).
-      version: 1.4.98
+      # 1.4.99 (#3687, extends #3370): bootstrap self-registration — the
+      # chart renders the canonical apps.openova.io/v1 Application CR for
+      # this slot's HelmRelease so the console /apps list, per-app Topology
+      # tab + showback resolve newapi (no more "no Application CR").
+      version: 1.4.99
       sourceRef:
         kind: HelmRepository
         name: bp-newapi
@@ -293,6 +297,16 @@ spec:
   # family model, `qwen3-coder`); the operator overlay overrides any of
   # these by setting them in this HelmRelease's spec.values.
   values:
+    # ── Bootstrap self-registration (#3687, extends #3370) ──────────────
+    # The chart self-registers the Application CR for newapi (the canonical
+    # instance representation every console surface reads), marked
+    # spec.bootstrap=true so the application-controller ADOPTS this HR's
+    # install instead of re-rendering it (zero duplicate HRs).
+    bootstrapOwned:
+      enabled: true
+      helmRelease:
+        name: bp-newapi
+        namespace: flux-system
     sovereignFQDN: ${SOVEREIGN_FQDN}
     # G87 #2634: multi-region CNPG instances default (1 single-region, 2 multi).
     # #2840-followup (2026-06-03): bp-newapi chart reads

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -113,7 +113,12 @@ name: bp-gitea
 # syncer-mangled host Service name (seaweedfs-s3-x-seaweedfs-x-rtz-vcluster.rtz.svc).
 # objectStorage.enabled is default-OFF, so the single-region/Catalyst-Zero render
 # is byte-identical (the defaults apply only when an operator enables S3).
-version: 1.2.35
+# 1.2.36 (#3687, extends #3370): bootstrap self-registration —
+# templates/application-cr.yaml renders the canonical apps.openova.io/v1
+# Application CR for the slot-10 HelmRelease (gated bootstrapOwned.enabled
+# + Capabilities apps.openova.io/v1) so the console /apps list, per-app
+# Topology tab + showback resolve gitea (no more "no Application CR").
+version: 1.2.36
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/application-cr.yaml
+++ b/platform/gitea/chart/templates/application-cr.yaml
@@ -1,0 +1,62 @@
+{{- /*
+Bootstrap self-registration (#3687, extends #3370) — the Application CR
+for this bootstrap-kit platform instance. See platform/postgres/chart/
+templates/application-cr.yaml for the full chart-vs-slot rationale.
+
+bootstrap-kit slots install bare Flux HelmReleases; the canonical
+apps.openova.io/v1 Application CR is what every operator-console surface
+reads (the /apps list, the per-app Topology tab, per-Organization
+showback). Without it the console reports "no Application CR" for this
+platform app. The chart self-registers the canonical CR (spec.bootstrap=
+true) for its slot-installed HelmRelease; the application-controller
+ADOPTS it (status-only reconcile mirroring spec.helmRelease Ready),
+never re-rendering — the install already belongs to the slot HR.
+
+This chart has NO _helpers.tpl, so the house labels are inlined here,
+matching the literal label blocks the chart's other resources hand-write
+(e.g. templates/admin-secret.yaml). NOTE: .Release.Namespace is the gitea
+APP install namespace (the slot's targetNamespace: gitea), distinct from
+.Values.postgres.cluster.namespace (the CNPG namespace) the DB resources
+use — the CR anchors the app, so .Release.Namespace is correct.
+
+Gates (bp-valkey idiom — no top-level .Values.enabled here):
+`.Values.bootstrapOwned.enabled` (defaults false; the slot opts in) AND
+the Capabilities apps.openova.io/v1 gate (benign skip pre-CRD; CR
+materialises on the first post-CRD upgrade). Leaf platform app — no
+shareable Context, so spec.parameters is empty.
+*/ -}}
+{{- if and .Values.bootstrapOwned.enabled (.Capabilities.APIVersions.Has "apps.openova.io/v1") }}
+apiVersion: apps.openova.io/v1
+kind: Application
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    catalyst.openova.io/blueprint: bp-gitea
+    catalyst.openova.io/component: gitea
+    apps.openova.io/bootstrap-owned: "true"
+    catalyst.openova.io/organization: platform
+spec:
+  bootstrap: true
+  {{- /* OLD-CRD compatibility (hw130 outage 2026-06-13): pre-#3370 CRD
+       hard-requires environmentRef + regions; the #3370 CRD CEL-waives
+       them for bootstrap-owned instances but still ACCEPTS them. Inert
+       under both schemas. */}}
+  environmentRef: platform-bootstrap
+  regions: ["platform-bootstrap-owned-host"]
+  blueprintRef:
+    name: {{ .Chart.Name }}
+    version: {{ .Chart.Version | quote }}
+  placement: single-region
+  {{- with .Values.bootstrapOwned.helmRelease }}
+  helmRelease:
+    name: {{ .name | quote }}
+    namespace: {{ .namespace | default "flux-system" | quote }}
+  {{- end }}
+  targetNamespace: {{ .Release.Namespace }}
+  releaseName: {{ .Release.Name }}
+  parameters: {}
+{{- end }}

--- a/platform/gitea/chart/values.yaml
+++ b/platform/gitea/chart/values.yaml
@@ -495,3 +495,18 @@ objectStorage:
       limits:
         cpu: 200m
         memory: 256Mi
+
+# ── Bootstrap self-registration (#3687, extends #3370) ───────────────────
+# When a bootstrap-kit slot installs this chart, it flips
+# bootstrapOwned.enabled=true so templates/application-cr.yaml renders the
+# canonical apps.openova.io/v1 Application CR for the slot's HelmRelease
+# (the instance card every console surface reads — /apps, Topology,
+# showback). Default OFF so console-created instances are not double-carded.
+# helmRelease names the owning Flux HelmRelease (the controller's adoption
+# path mirrors its Ready condition); namespace is where that HR object
+# lives (flux-system for the slot 10 HR).
+bootstrapOwned:
+  enabled: false
+  helmRelease:
+    name: ""
+    namespace: flux-system

--- a/platform/grafana/chart/Chart.yaml
+++ b/platform/grafana/chart/Chart.yaml
@@ -56,7 +56,12 @@ type: application
 # to plain in-vCluster names when grafana itself promotes (audit
 # Phase-2). Lockstep with bootstrap-kit slots 22/23/24 + bp-catalyst-
 # platform 1.4.591 (CATALYST_MIMIR_URL + baseline CNP).
-version: 1.0.14
+# 1.0.15 (#3687, extends #3370): bootstrap self-registration —
+# templates/application-cr.yaml renders the canonical apps.openova.io/v1
+# Application CR for the slot-25 HelmRelease (gated bootstrapOwned.enabled
+# + Capabilities apps.openova.io/v1) so the console /apps list, per-app
+# Topology tab + showback resolve grafana (no more "no Application CR").
+version: 1.0.15
 appVersion: "12.3.1"
 # 1.0.14 (#3374, 2026-06-14): raise the sidecar memory limit 64Mi → 192Mi
 # (request 32Mi → 64Mi). The 1.0.13 limit was too low for the

--- a/platform/grafana/chart/templates/application-cr.yaml
+++ b/platform/grafana/chart/templates/application-cr.yaml
@@ -1,0 +1,62 @@
+{{- /*
+Bootstrap self-registration (#3687, extends #3370) — the Application CR
+for this bootstrap-kit platform instance. See platform/postgres/chart/
+templates/application-cr.yaml for the full chart-vs-slot rationale.
+
+bootstrap-kit slots install bare Flux HelmReleases; the canonical
+apps.openova.io/v1 Application CR is what every operator-console surface
+reads (the /apps list, the per-app Topology tab, per-Organization
+showback). On hw158 only the 3 shared-pg CRs existed while ~64
+HelmReleases ran live, so grafana showed "no Application CR" on every
+console surface. The chart self-registers the canonical CR
+(spec.bootstrap=true) for its slot-installed HelmRelease; the
+application-controller ADOPTS it (status-only reconcile mirroring
+spec.helmRelease Ready), never re-rendering — the install already
+belongs to the slot HR.
+
+This chart has NO _helpers.tpl, so the house labels are inlined here
+(catalyst.openova.io/blueprint + component, the app.kubernetes.io trio) —
+matching the literal label blocks the chart's other resources hand-write
+(e.g. templates/datasource-configmaps.yaml).
+
+Gates (bp-valkey idiom — no top-level .Values.enabled here):
+`.Values.bootstrapOwned.enabled` (defaults false; the slot opts in) AND
+the Capabilities apps.openova.io/v1 gate (benign skip pre-CRD; CR
+materialises on the first post-CRD upgrade). Leaf platform app — no
+shareable Context, so spec.parameters is empty.
+*/ -}}
+{{- if and .Values.bootstrapOwned.enabled (.Capabilities.APIVersions.Has "apps.openova.io/v1") }}
+apiVersion: apps.openova.io/v1
+kind: Application
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    catalyst.openova.io/blueprint: bp-grafana
+    catalyst.openova.io/component: grafana
+    apps.openova.io/bootstrap-owned: "true"
+    catalyst.openova.io/organization: platform
+spec:
+  bootstrap: true
+  {{- /* OLD-CRD compatibility (hw130 outage 2026-06-13): pre-#3370 CRD
+       hard-requires environmentRef + regions; the #3370 CRD CEL-waives
+       them for bootstrap-owned instances but still ACCEPTS them. Inert
+       under both schemas. */}}
+  environmentRef: platform-bootstrap
+  regions: ["platform-bootstrap-owned-host"]
+  blueprintRef:
+    name: {{ .Chart.Name }}
+    version: {{ .Chart.Version | quote }}
+  placement: single-region
+  {{- with .Values.bootstrapOwned.helmRelease }}
+  helmRelease:
+    name: {{ .name | quote }}
+    namespace: {{ .namespace | default "flux-system" | quote }}
+  {{- end }}
+  targetNamespace: {{ .Release.Namespace }}
+  releaseName: {{ .Release.Name }}
+  parameters: {}
+{{- end }}

--- a/platform/grafana/chart/values.yaml
+++ b/platform/grafana/chart/values.yaml
@@ -407,3 +407,20 @@ observabilityStack:
       kubeState: true
       openbaoAudit: true
       fluxReconcile: true
+
+# ── Bootstrap self-registration (#3687, extends #3370) ───────────────────
+# When a bootstrap-kit slot installs this chart, it flips
+# bootstrapOwned.enabled=true so templates/application-cr.yaml renders the
+# canonical apps.openova.io/v1 Application CR for the slot's HelmRelease
+# (the instance card every console surface reads — /apps, Topology,
+# showback). Default OFF: a console-created instance gets its CR from the
+# application-controller fan-out, so self-registering a second one would
+# violate "N instances => exactly N cards". helmRelease names the owning
+# Flux HelmRelease (the controller's adoption path mirrors its Ready
+# condition); namespace is where that HR object lives (flux-system for the
+# slot 25 HR).
+bootstrapOwned:
+  enabled: false
+  helmRelease:
+    name: ""
+    namespace: flux-system

--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -179,7 +179,12 @@ name: bp-guacamole
 # (`persistentvolumeclaim "guacamole-recordings" not found`) — Pending in both
 # regions on hw146. Mirror the webapp's emptyDir/PVC `if` into guacd. Lockstep:
 # 52-bp-guacamole.yaml pin → 0.2.19. Refs #3629.
-version: 0.2.20
+# 0.2.21 (#3687, extends #3370): bootstrap self-registration —
+# templates/application-cr.yaml renders the canonical apps.openova.io/v1
+# Application CR for the slot-52 HelmRelease (gated bootstrapOwned.enabled
+# + Capabilities apps.openova.io/v1) so the console /apps list, per-app
+# Topology tab + showback resolve guacamole (no more "no Application CR").
+version: 0.2.21
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/templates/application-cr.yaml
+++ b/platform/guacamole/chart/templates/application-cr.yaml
@@ -1,0 +1,53 @@
+{{- /*
+Bootstrap self-registration (#3687, extends #3370) — the Application CR
+for this bootstrap-kit platform instance. See platform/postgres/chart/
+templates/application-cr.yaml for the full chart-vs-slot rationale.
+
+bootstrap-kit slots install bare Flux HelmReleases; the canonical
+apps.openova.io/v1 Application CR is what every operator-console surface
+reads (the /apps list, the per-app Topology tab, per-Organization
+showback). Without it the console reports "no Application CR" for this
+platform app. The chart self-registers the canonical CR (spec.bootstrap=
+true) for its slot-installed HelmRelease; the application-controller
+ADOPTS it (status-only reconcile mirroring spec.helmRelease Ready),
+never re-rendering — the install already belongs to the slot HR.
+
+Gates (bp-valkey idiom — no top-level .Values.enabled here; the chart's
+own CC3 master switch is .Values.guacamole.enabled, but the CR opt-in is
+purely .Values.bootstrapOwned.enabled so it tracks the slot, not the
+upstream subchart toggle): `.Values.bootstrapOwned.enabled` (defaults
+false; the slot opts in) AND the Capabilities apps.openova.io/v1 gate
+(benign skip pre-CRD; CR materialises on the first post-CRD upgrade).
+Leaf platform app — no shareable Context, so spec.parameters is empty.
+*/ -}}
+{{- if and .Values.bootstrapOwned.enabled (.Capabilities.APIVersions.Has "apps.openova.io/v1") }}
+apiVersion: apps.openova.io/v1
+kind: Application
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-guacamole.labels" . | nindent 4 }}
+    apps.openova.io/bootstrap-owned: "true"
+    catalyst.openova.io/organization: platform
+spec:
+  bootstrap: true
+  {{- /* OLD-CRD compatibility (hw130 outage 2026-06-13): pre-#3370 CRD
+       hard-requires environmentRef + regions; the #3370 CRD CEL-waives
+       them for bootstrap-owned instances but still ACCEPTS them. Inert
+       under both schemas. */}}
+  environmentRef: platform-bootstrap
+  regions: ["platform-bootstrap-owned-host"]
+  blueprintRef:
+    name: {{ .Chart.Name }}
+    version: {{ .Chart.Version | quote }}
+  placement: single-region
+  {{- with .Values.bootstrapOwned.helmRelease }}
+  helmRelease:
+    name: {{ .name | quote }}
+    namespace: {{ .namespace | default "flux-system" | quote }}
+  {{- end }}
+  targetNamespace: {{ .Release.Namespace }}
+  releaseName: {{ .Release.Name }}
+  parameters: {}
+{{- end }}

--- a/platform/guacamole/chart/values.yaml
+++ b/platform/guacamole/chart/values.yaml
@@ -333,3 +333,18 @@ guacamole:
   # Sovereign for non-canonical credential names.
   imagePullSecrets:
     - name: ghcr-pull
+
+# ── Bootstrap self-registration (#3687, extends #3370) ───────────────────
+# When a bootstrap-kit slot installs this chart, it flips
+# bootstrapOwned.enabled=true so templates/application-cr.yaml renders the
+# canonical apps.openova.io/v1 Application CR for the slot's HelmRelease
+# (the instance card every console surface reads — /apps, Topology,
+# showback). Default OFF so console-created instances are not double-carded.
+# helmRelease names the owning Flux HelmRelease (the controller's adoption
+# path mirrors its Ready condition); namespace is where that HR object
+# lives (flux-system for the slot 52 HR).
+bootstrapOwned:
+  enabled: false
+  helmRelease:
+    name: ""
+    namespace: flux-system

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -73,7 +73,12 @@ type: application
 # `harbor-database-secret` (key `password`) + its host flips via the
 # SOVEREIGN_HARBOR_PG_HOST slot seam, so no other consumer change is
 # needed. own-cluster render byte-identical to 1.2.27.
-version: 1.2.30
+# 1.2.31 (#3687, extends #3370): bootstrap self-registration —
+# templates/application-cr.yaml renders the canonical apps.openova.io/v1
+# Application CR for the slot-19 HelmRelease (gated bootstrapOwned.enabled
+# + Capabilities apps.openova.io/v1) so the console /apps list, per-app
+# Topology tab + showback resolve harbor (no more "no Application CR").
+version: 1.2.31
 appVersion: "2.14.3"
 # 1.2.23 (G117.5 #2744, 2026-06-02): SSO defense-in-depth via Harbor's
 # `oidc_extra_redirect_parms` config field. The configure-oauth Job now

--- a/platform/harbor/chart/templates/application-cr.yaml
+++ b/platform/harbor/chart/templates/application-cr.yaml
@@ -1,0 +1,72 @@
+{{- /*
+Bootstrap self-registration (#3687, extends #3370) — the Application CR
+for this bootstrap-kit platform instance.
+
+WHY this exists: bootstrap-kit slots install their workloads as bare Flux
+HelmReleases. The canonical object model (apps.openova.io/v1 Application)
+is what every operator-console surface reads — the /apps list, the
+per-app Topology tab, the per-Organization showback. On hw158 only the 3
+shared-pg Application CRs existed while ~64 HelmReleases ran live, so the
+console could not see grafana/gitea/keycloak/harbor/openbao/etc.: each
+showed "n/a — bootstrap component, no Application CR", and showback rolled
+100% to the parent. This template closes that gap the SAME way bp-postgres
+/ bp-valkey already do (see platform/postgres/chart/templates/
+application-cr.yaml for the full chart-vs-slot decision rationale): the
+CHART self-registers the canonical CR for its slot-installed HelmRelease.
+
+The application-controller ADOPTS the CR (spec.bootstrap=true): it skips
+every render / fan-out / Gitea path (the install is already owned by the
+bootstrap-kit HR — rendering would duplicate it) and reconciles STATUS
+ONLY by observing spec.helmRelease's Ready condition
+(core/controllers/application/internal/controller/application_controller.go
+reconcileBootstrapOwned).
+
+Gates (the bp-valkey idiom — this chart has no top-level .Values.enabled
+master switch, so bootstrapOwned.enabled IS the opt-in):
+  - `.Values.bootstrapOwned.enabled`: defaults false; the slot opts in
+    (slot 19 sets it true). Console-created instances keep it OFF so the
+    controller-created CR is the only card ("N instances ⇒ exactly N
+    cards").
+  - Capabilities gate on apps.openova.io/v1: benign skip during first
+    bootstrap (the CRD ships in the umbrella, slot 13, which transitively
+    depends on this chart); the CR materialises on the first post-CRD
+    upgrade of this HR and immediately on converged Sovereigns.
+
+These are leaf platform apps with NO shareable Context, so spec.parameters
+is empty — the CR is the canonical instance card + Topology/showback
+anchor, not a backing-service Context publisher.
+*/ -}}
+{{- if and .Values.bootstrapOwned.enabled (.Capabilities.APIVersions.Has "apps.openova.io/v1") }}
+apiVersion: apps.openova.io/v1
+kind: Application
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-harbor.labels" . | nindent 4 }}
+    apps.openova.io/bootstrap-owned: "true"
+    catalyst.openova.io/organization: platform
+spec:
+  bootstrap: true
+  {{- /* OLD-CRD compatibility (hw130 outage 2026-06-13): the pre-#3370
+       CRD hard-requires environmentRef + regions; the #3370 CRD CEL-
+       waives them for bootstrap-owned instances but still ACCEPTS them.
+       Without these two fields, the Capabilities gate above passes on a
+       CONVERGED env still running the old CRD and the CR is rejected ->
+       upgrade fails -> rollback loop. These values are inert under both
+       schemas. */}}
+  environmentRef: platform-bootstrap
+  regions: ["platform-bootstrap-owned-host"]
+  blueprintRef:
+    name: {{ .Chart.Name }}
+    version: {{ .Chart.Version | quote }}
+  placement: single-region
+  {{- with .Values.bootstrapOwned.helmRelease }}
+  helmRelease:
+    name: {{ .name | quote }}
+    namespace: {{ .namespace | default "flux-system" | quote }}
+  {{- end }}
+  targetNamespace: {{ .Release.Namespace }}
+  releaseName: {{ .Release.Name }}
+  parameters: {}
+{{- end }}

--- a/platform/harbor/chart/values.yaml
+++ b/platform/harbor/chart/values.yaml
@@ -561,3 +561,18 @@ objectStorage:
     # never committed to git.
     accessKey: ""
     secretKey: ""
+
+# ── Bootstrap self-registration (#3687, extends #3370) ───────────────────
+# When a bootstrap-kit slot installs this chart, it flips
+# bootstrapOwned.enabled=true so templates/application-cr.yaml renders the
+# canonical apps.openova.io/v1 Application CR for the slot's HelmRelease
+# (the instance card every console surface reads — /apps, Topology,
+# showback). Default OFF so console-created instances are not double-carded.
+# helmRelease names the owning Flux HelmRelease (the controller's adoption
+# path mirrors its Ready condition); namespace is where that HR object
+# lives (flux-system for the slot 19 HR).
+bootstrapOwned:
+  enabled: false
+  helmRelease:
+    name: ""
+    namespace: flux-system

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -287,7 +287,12 @@ name: bp-keycloak
 #   dead pre-#3374 native /oidc/authorized + /* with no aud mapper, which the
 #   config-cli FULL-managed reconcile reverted over the gate's correct client).
 #   Mirrors the hubble-ui gated precedent. Refs #3741 (hw158 UAT row 6 SSO).
-version: 1.4.30
+# 1.4.31 (#3687, extends #3370): bootstrap self-registration —
+# templates/application-cr.yaml renders the canonical apps.openova.io/v1
+# Application CR for the slot-09 HelmRelease (gated bootstrapOwned.enabled
+# + Capabilities apps.openova.io/v1) so the console /apps list, per-app
+# Topology tab + showback resolve keycloak (no more "no Application CR").
+version: 1.4.31
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/application-cr.yaml
+++ b/platform/keycloak/chart/templates/application-cr.yaml
@@ -1,0 +1,61 @@
+{{- /*
+Bootstrap self-registration (#3687, extends #3370) — the Application CR
+for this bootstrap-kit platform instance. See platform/postgres/chart/
+templates/application-cr.yaml for the full chart-vs-slot rationale.
+
+bootstrap-kit slots install bare Flux HelmReleases; the canonical
+apps.openova.io/v1 Application CR is what every operator-console surface
+reads (the /apps list, the per-app Topology tab, per-Organization
+showback). Without it the console reports "no Application CR" for this
+platform app (keycloak is the SSO authority itself). The chart
+self-registers the canonical CR (spec.bootstrap=true) for its
+slot-installed HelmRelease; the application-controller ADOPTS it
+(status-only reconcile mirroring spec.helmRelease Ready), never
+re-rendering — the install already belongs to the slot HR.
+
+This chart's _helpers.tpl holds only OIDC-secret derivations (no name/
+labels helper), so the house labels are inlined here, matching the
+literal label blocks the chart's other resources hand-write (e.g.
+templates/keycloak-frontend-env.yaml).
+
+Gates (bp-valkey idiom — no top-level .Values.enabled here):
+`.Values.bootstrapOwned.enabled` (defaults false; the slot opts in) AND
+the Capabilities apps.openova.io/v1 gate (benign skip pre-CRD; CR
+materialises on the first post-CRD upgrade). Leaf platform app — no
+shareable Context, so spec.parameters is empty.
+*/ -}}
+{{- if and .Values.bootstrapOwned.enabled (.Capabilities.APIVersions.Has "apps.openova.io/v1") }}
+apiVersion: apps.openova.io/v1
+kind: Application
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    catalyst.openova.io/blueprint: bp-keycloak
+    catalyst.openova.io/component: keycloak
+    apps.openova.io/bootstrap-owned: "true"
+    catalyst.openova.io/organization: platform
+spec:
+  bootstrap: true
+  {{- /* OLD-CRD compatibility (hw130 outage 2026-06-13): pre-#3370 CRD
+       hard-requires environmentRef + regions; the #3370 CRD CEL-waives
+       them for bootstrap-owned instances but still ACCEPTS them. Inert
+       under both schemas. */}}
+  environmentRef: platform-bootstrap
+  regions: ["platform-bootstrap-owned-host"]
+  blueprintRef:
+    name: {{ .Chart.Name }}
+    version: {{ .Chart.Version | quote }}
+  placement: single-region
+  {{- with .Values.bootstrapOwned.helmRelease }}
+  helmRelease:
+    name: {{ .name | quote }}
+    namespace: {{ .namespace | default "flux-system" | quote }}
+  {{- end }}
+  targetNamespace: {{ .Release.Namespace }}
+  releaseName: {{ .Release.Name }}
+  parameters: {}
+{{- end }}

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -659,3 +659,18 @@ gateway:
     # pinning sectionName: https breaks NoMatchingListener. Cilium Gateway
     # matches by hostname filter. See PR #1888 / TBD-A40 / issue #1902.
     sectionName: ""
+
+# ── Bootstrap self-registration (#3687, extends #3370) ───────────────────
+# When a bootstrap-kit slot installs this chart, it flips
+# bootstrapOwned.enabled=true so templates/application-cr.yaml renders the
+# canonical apps.openova.io/v1 Application CR for the slot's HelmRelease
+# (the instance card every console surface reads — /apps, Topology,
+# showback). Default OFF so console-created instances are not double-carded.
+# helmRelease names the owning Flux HelmRelease (the controller's adoption
+# path mirrors its Ready condition); namespace is where that HR object
+# lives (flux-system for the slot 09 HR).
+bootstrapOwned:
+  enabled: false
+  helmRelease:
+    name: ""
+    namespace: flux-system

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -674,7 +674,12 @@ name: bp-newapi
 # URL/client_id are unset the page degrades to the SPA /login link. The bridge
 # IMAGE TAG + a further chart patch bump are auto-committed by
 # build-bp-newapi-sandbox-bridge.yaml on merge (push to internal/handler/**).
-version: 1.4.98
+# 1.4.99 (#3687, extends #3370): bootstrap self-registration —
+# templates/application-cr.yaml renders the canonical apps.openova.io/v1
+# Application CR for the slot-80 HelmRelease (gated bootstrapOwned.enabled
+# + Capabilities apps.openova.io/v1) so the console /apps list, per-app
+# Topology tab + showback resolve newapi (no more "no Application CR").
+version: 1.4.99
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/application-cr.yaml
+++ b/platform/newapi/chart/templates/application-cr.yaml
@@ -1,0 +1,56 @@
+{{- /*
+Bootstrap self-registration (#3687, extends #3370) — the Application CR
+for this bootstrap-kit platform instance. See platform/postgres/chart/
+templates/application-cr.yaml for the full chart-vs-slot rationale.
+
+bootstrap-kit slots install bare Flux HelmReleases; the canonical
+apps.openova.io/v1 Application CR is what every operator-console surface
+reads (the /apps list, the per-app Topology tab, per-Organization
+showback). Without it the console reports "no Application CR" for this
+platform app. The chart self-registers the canonical CR (spec.bootstrap=
+true) for its slot-installed HelmRelease; the application-controller
+ADOPTS it (status-only reconcile mirroring spec.helmRelease Ready),
+never re-rendering — the install already belongs to the slot HR.
+
+Note: this CR uses bp-newapi.labels (managed-by: Helm), NOT the
+bp-newapi.hookLabels variant — the Application CR is not a Helm hook, so
+the kyverno flux-managed Enforce policy that gates hook Jobs does not
+apply to it.
+
+Gates (bp-valkey idiom — no top-level .Values.enabled here):
+`.Values.bootstrapOwned.enabled` (defaults false; the slot opts in) AND
+the Capabilities apps.openova.io/v1 gate (benign skip pre-CRD; CR
+materialises on the first post-CRD upgrade). Leaf platform app — no
+shareable Context, so spec.parameters is empty.
+*/ -}}
+{{- if and .Values.bootstrapOwned.enabled (.Capabilities.APIVersions.Has "apps.openova.io/v1") }}
+apiVersion: apps.openova.io/v1
+kind: Application
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+    apps.openova.io/bootstrap-owned: "true"
+    catalyst.openova.io/organization: platform
+spec:
+  bootstrap: true
+  {{- /* OLD-CRD compatibility (hw130 outage 2026-06-13): pre-#3370 CRD
+       hard-requires environmentRef + regions; the #3370 CRD CEL-waives
+       them for bootstrap-owned instances but still ACCEPTS them. Inert
+       under both schemas. */}}
+  environmentRef: platform-bootstrap
+  regions: ["platform-bootstrap-owned-host"]
+  blueprintRef:
+    name: {{ .Chart.Name }}
+    version: {{ .Chart.Version | quote }}
+  placement: single-region
+  {{- with .Values.bootstrapOwned.helmRelease }}
+  helmRelease:
+    name: {{ .name | quote }}
+    namespace: {{ .namespace | default "flux-system" | quote }}
+  {{- end }}
+  targetNamespace: {{ .Release.Namespace }}
+  releaseName: {{ .Release.Name }}
+  parameters: {}
+{{- end }}

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -1117,3 +1117,18 @@ meteringSidecar:
     allowPrivilegeEscalation: false
     capabilities:
       drop: ["ALL"]
+
+# ── Bootstrap self-registration (#3687, extends #3370) ───────────────────
+# When a bootstrap-kit slot installs this chart, it flips
+# bootstrapOwned.enabled=true so templates/application-cr.yaml renders the
+# canonical apps.openova.io/v1 Application CR for the slot's HelmRelease
+# (the instance card every console surface reads — /apps, Topology,
+# showback). Default OFF so console-created instances are not double-carded.
+# helmRelease names the owning Flux HelmRelease (the controller's adoption
+# path mirrors its Ready condition); namespace is where that HR object
+# lives (flux-system for the slot 80 HR).
+bootstrapOwned:
+  enabled: false
+  helmRelease:
+    name: ""
+    namespace: flux-system

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -108,7 +108,12 @@ name: bp-openbao
 # render nothing). tests/continuum-render.sh Case 3 now passes
 # `--api-versions dr.openova.io/v1`; new Case 4 proves the guard skips the CR
 # (no install failure) when the CRD is absent. No upstream subchart change.
-version: 1.2.46
+# 1.2.47 (#3687, extends #3370): bootstrap self-registration —
+# templates/application-cr.yaml renders the canonical apps.openova.io/v1
+# Application CR for the slot-08 HelmRelease (gated bootstrapOwned.enabled
+# + Capabilities apps.openova.io/v1) so the console /apps list, per-app
+# Topology tab + showback resolve openbao (no more "no Application CR").
+version: 1.2.47
 # 1.2.46 (#3629, 2026-06-16): the SECONDARY (fetch) snapshot CronJob no longer
 # performs an OpenBao k8s-auth login. The fetch path is PURE S3 I/O
 # (list-objects-v2 + `s3 cp` to the restore-staging PVC) and NEVER reads

--- a/platform/openbao/chart/templates/application-cr.yaml
+++ b/platform/openbao/chart/templates/application-cr.yaml
@@ -1,0 +1,60 @@
+{{- /*
+Bootstrap self-registration (#3687, extends #3370) — the Application CR
+for this bootstrap-kit platform instance. See platform/postgres/chart/
+templates/application-cr.yaml for the full chart-vs-slot rationale.
+
+bootstrap-kit slots install bare Flux HelmReleases; the canonical
+apps.openova.io/v1 Application CR is what every operator-console surface
+reads (the /apps list, the per-app Topology tab, per-Organization
+showback). Without it the console reports "no Application CR" for this
+platform app. The chart self-registers the canonical CR (spec.bootstrap=
+true) for its slot-installed HelmRelease; the application-controller
+ADOPTS it (status-only reconcile mirroring spec.helmRelease Ready),
+never re-rendering — the install already belongs to the slot HR.
+
+This chart's _helpers.tpl holds only the cross-region raft HCL helper (no
+name/labels helper), so the house labels are inlined here, matching the
+literal label blocks the chart's other resources hand-write (e.g.
+templates/continuum.yaml).
+
+Gates (bp-valkey idiom — no top-level .Values.enabled here):
+`.Values.bootstrapOwned.enabled` (defaults false; the slot opts in) AND
+the Capabilities apps.openova.io/v1 gate (benign skip pre-CRD; CR
+materialises on the first post-CRD upgrade). Leaf platform app — no
+shareable Context, so spec.parameters is empty.
+*/ -}}
+{{- if and .Values.bootstrapOwned.enabled (.Capabilities.APIVersions.Has "apps.openova.io/v1") }}
+apiVersion: apps.openova.io/v1
+kind: Application
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao
+    apps.openova.io/bootstrap-owned: "true"
+    catalyst.openova.io/organization: platform
+spec:
+  bootstrap: true
+  {{- /* OLD-CRD compatibility (hw130 outage 2026-06-13): pre-#3370 CRD
+       hard-requires environmentRef + regions; the #3370 CRD CEL-waives
+       them for bootstrap-owned instances but still ACCEPTS them. Inert
+       under both schemas. */}}
+  environmentRef: platform-bootstrap
+  regions: ["platform-bootstrap-owned-host"]
+  blueprintRef:
+    name: {{ .Chart.Name }}
+    version: {{ .Chart.Version | quote }}
+  placement: single-region
+  {{- with .Values.bootstrapOwned.helmRelease }}
+  helmRelease:
+    name: {{ .name | quote }}
+    namespace: {{ .namespace | default "flux-system" | quote }}
+  {{- end }}
+  targetNamespace: {{ .Release.Namespace }}
+  releaseName: {{ .Release.Name }}
+  parameters: {}
+{{- end }}

--- a/platform/openbao/chart/values.yaml
+++ b/platform/openbao/chart/values.yaml
@@ -580,3 +580,18 @@ continuum:
     # replicated state, no restore. Wire it back to
     # snapshotReplication.restoreStaging.path only if running snapshot-mode DR.
     snapshotPath: ""
+
+# ── Bootstrap self-registration (#3687, extends #3370) ───────────────────
+# When a bootstrap-kit slot installs this chart, it flips
+# bootstrapOwned.enabled=true so templates/application-cr.yaml renders the
+# canonical apps.openova.io/v1 Application CR for the slot's HelmRelease
+# (the instance card every console surface reads — /apps, Topology,
+# showback). Default OFF so console-created instances are not double-carded.
+# helmRelease names the owning Flux HelmRelease (the controller's adoption
+# path mirrors its Ready condition); namespace is where that HR object
+# lives (flux-system for the slot 08 HR).
+bootstrapOwned:
+  enabled: false
+  helmRelease:
+    name: ""
+    namespace: flux-system

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -36,7 +36,12 @@ name: bp-powerdns
 # harbor-proxy-pull policy (bp-kyverno-policies 1.0.33,
 # harborProxyPull.extraExcludeNamespaces), NOT by rerouting the image.
 # The #3380-D part-(1) REST-API-Ingress gating is UNCHANGED.
-version: 1.2.14
+# 1.2.15 (#3687, extends #3370): bootstrap self-registration —
+# templates/application-cr.yaml renders the canonical apps.openova.io/v1
+# Application CR for the slot-11 HelmRelease (gated bootstrapOwned.enabled
+# + Capabilities apps.openova.io/v1) so the console /apps list, per-app
+# Topology tab + showback resolve powerdns (no more "no Application CR").
+version: 1.2.15
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/templates/application-cr.yaml
+++ b/platform/powerdns/chart/templates/application-cr.yaml
@@ -1,0 +1,51 @@
+{{- /*
+Bootstrap self-registration (#3687, extends #3370) — the Application CR
+for this bootstrap-kit platform instance. See platform/postgres/chart/
+templates/application-cr.yaml for the full chart-vs-slot rationale.
+
+bootstrap-kit slots install bare Flux HelmReleases; the canonical
+apps.openova.io/v1 Application CR is what every operator-console surface
+reads (the /apps list, the per-app Topology tab, per-Organization
+showback). Without it the console reports "no Application CR" for this
+platform app. The chart self-registers the canonical CR (spec.bootstrap=
+true) for its slot-installed HelmRelease; the application-controller
+ADOPTS it (status-only reconcile mirroring spec.helmRelease Ready),
+never re-rendering — the install already belongs to the slot HR.
+
+Gates (bp-valkey idiom — no top-level .Values.enabled here):
+`.Values.bootstrapOwned.enabled` (defaults false; the slot opts in) AND
+the Capabilities apps.openova.io/v1 gate (benign skip pre-CRD; CR
+materialises on the first post-CRD upgrade). Leaf platform app — no
+shareable Context, so spec.parameters is empty.
+*/ -}}
+{{- if and .Values.bootstrapOwned.enabled (.Capabilities.APIVersions.Has "apps.openova.io/v1") }}
+apiVersion: apps.openova.io/v1
+kind: Application
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-powerdns.labels" . | nindent 4 }}
+    apps.openova.io/bootstrap-owned: "true"
+    catalyst.openova.io/organization: platform
+spec:
+  bootstrap: true
+  {{- /* OLD-CRD compatibility (hw130 outage 2026-06-13): pre-#3370 CRD
+       hard-requires environmentRef + regions; the #3370 CRD CEL-waives
+       them for bootstrap-owned instances but still ACCEPTS them. Inert
+       under both schemas. */}}
+  environmentRef: platform-bootstrap
+  regions: ["platform-bootstrap-owned-host"]
+  blueprintRef:
+    name: {{ .Chart.Name }}
+    version: {{ .Chart.Version | quote }}
+  placement: single-region
+  {{- with .Values.bootstrapOwned.helmRelease }}
+  helmRelease:
+    name: {{ .name | quote }}
+    namespace: {{ .namespace | default "flux-system" | quote }}
+  {{- end }}
+  targetNamespace: {{ .Release.Namespace }}
+  releaseName: {{ .Release.Name }}
+  parameters: {}
+{{- end }}

--- a/platform/powerdns/chart/values.yaml
+++ b/platform/powerdns/chart/values.yaml
@@ -699,3 +699,18 @@ zoneBootstrap:
   # clusters can raise this without forking the chart per
   # docs/INVIOLABLE-PRINCIPLES.md #4.
   apiReadyTimeoutSeconds: 1800
+
+# ── Bootstrap self-registration (#3687, extends #3370) ───────────────────
+# When a bootstrap-kit slot installs this chart, it flips
+# bootstrapOwned.enabled=true so templates/application-cr.yaml renders the
+# canonical apps.openova.io/v1 Application CR for the slot's HelmRelease
+# (the instance card every console surface reads — /apps, Topology,
+# showback). Default OFF so console-created instances are not double-carded.
+# helmRelease names the owning Flux HelmRelease (the controller's adoption
+# path mirrors its Ready condition); namespace is where that HR object
+# lives (flux-system for the slot 11 HR).
+bootstrapOwned:
+  enabled: false
+  helmRelease:
+    name: ""
+    namespace: flux-system


### PR DESCRIPTION
## Problem (Refs #3687)

The object model is broken for bootstrap-kit apps. `grafana`, `gitea`, `keycloak`, `harbor`, `openbao`, `guacamole`, `newapi` and `powerdns` install as **bare Flux HelmReleases with NO `apps.openova.io/v1` Application CR**. On hw158 `kubectl get applications -A` showed only the 3 shared-pg CRs while ~64 HelmReleases ran live — so the console object model couldn't see these apps:

- the `/apps` directory 404'd them,
- per-app **Topology** read *"n/a — bootstrap component, no Application CR"*,
- **showback** rolled 100% to the parent estate.

(This is the `6✅/19❌` browser-walk gap in `docs/ledger/uat-walkthrough/canonical-org-app-cr-model-live-end-to-end.md`.)

## Fix — the #3370 chart self-registration design, extended to the 8 leaf platform charts

`bp-postgres` / `bp-valkey` already self-register their Application CR via a chart template (`templates/application-cr.yaml`, gated on `bootstrapOwned.enabled`). The other 8 bootstrap apps did **not**. There is **no** label-driven HelmRelease→Application controller (verified) — chart self-registration IS the design, and the `application-controller`'s `reconcileBootstrapOwned` adoption path is already generic over `spec.helmRelease`, so **no Go change is required**.

Per chart:

1. **`templates/application-cr.yaml`** (new) — self-registers the canonical CR for the slot HR, gated on `.Values.bootstrapOwned.enabled` **AND** `.Capabilities.APIVersions.Has "apps.openova.io/v1"` (benign skip on a cold bootstrap before the umbrella ships the CRD; materialises on the first post-CRD upgrade + immediately on converged Sovereigns). `spec.bootstrap=true` → the controller **adopts** the install (status-only reconcile mirroring the HR's `Ready` condition; zero render/fan-out/Gitea; zero duplicate HRs). Old-CRD-compat `environmentRef` + `regions` keep the CR valid against both the pre-#3370 and relaxed-#3370 schemas. Leaf apps expose no shareable Context → empty `parameters`.
2. **`values.yaml`** — adds the `bootstrapOwned` schema block, **default `enabled: false`** so console-created instances are never double-carded (*"N instances ⇒ exactly N cards"*).
3. **bootstrap-kit slot** — opts in (`bootstrapOwned.enabled: true`, `helmRelease.name: bp-<x>`, `namespace: flux-system`) and bumps the chart pin **lockstep above main**:

| chart | slot | main → new |
|---|---|---|
| grafana | 25 | 1.0.14 → **1.0.15** |
| gitea | 10 | 1.2.35 → **1.2.36** |
| keycloak | 09 | 1.4.30 → **1.4.31** |
| harbor | 19 | 1.2.30 → **1.2.31** |
| openbao | 08 | 1.2.46 → **1.2.47** |
| guacamole | 52 | 0.2.20 → **0.2.21** |
| newapi | 80 | 1.4.98 → **1.4.99** |
| powerdns | 11 | 1.2.14 → **1.2.15** |

## Result

On a converged/fresh Sovereign `kubectl get applications -A` includes the bootstrap apps → the console `/apps` list, per-app **Topology** tab and **showback** resolve them (no more *"no Application CR"*).

## Validation

- `helm template` renders a well-formed CR for **all 8** charts (correct `bootstrap`/`helmRelease`/`blueprintRef`/`placement`/labels).
- **Negative gates** for all 8: default render (`bootstrapOwned` off) → **0** Application CRs; `bootstrapOwned.enabled=true` but **no** CRD capability → **0** CRs (Capabilities gate skips). The new template is **inert by default** — default render is byte-identical to `main` modulo per-render random secrets.
- `application-controller` `go build ./...` + the bootstrap adoption tests (`-run BootstrapOwned`) + full controller suite: **green**.

## Live-materialisation caveat

The CR renders only once the cluster's `apps.openova.io/v1` CRD is registered (the umbrella ships it). On already-converged Sovereigns the lockstep pin bump forces a helm-controller upgrade that renders the CR on the next reconcile; on a fresh prov it lands after the umbrella reconciles. **Full live verification of `kubectl get applications -A` + the console surfaces needs a fresh prov / a roll on a converged env** — this PR is the chart-side fix only (do not merge until walked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)