### PR TITLE
feat(vcluster): bump 0.21.0→0.23.0 + sync.fromHost.secrets — UNBLOCK North-Star #1 host-minted Secret delivery (Refs #3642 #3736) [DO NOT MERGE — needs fresh-prov walk]

### DIFF
--- a/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
@@ -68,7 +68,11 @@ spec:
       # 0.2.6 (#3373 fix (b)): toHost customResources sync gains HTTPRoute + ExternalSecret.
       # 0.2.7 (#3380-D): k8s distro control-plane images pinned off
       # registry.k8s.io onto Harbor proxy-k8s (harbor-proxy-pull Enforce).
-      version: 0.2.7
+      # 0.2.8 (#3642 #3736): vcluster subchart 0.21.0 → 0.23.0 LOCKSTEP with
+      # bp-mgmt-vcluster + bp-rtz-vcluster (sibling tag parity). The active
+      # fromHost.secrets mappings live in bp-mgmt-vcluster; DMZ takes the
+      # version bump only.
+      version: 0.2.8
       sourceRef:
         kind: HelmRepository
         name: bp-dmz-vcluster

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -85,7 +85,12 @@ spec:
       # catalyst-system/newapi/sso-bridge/oidc-gate) in allowedIngressNamespaces
       # so the host Cilium Gateway + keycloak SSO consumers reach the moved
       # keycloak/grafana through the vCluster isolation netpol.
-      version: 0.2.11
+      # 0.2.12 (#3642 #3736): vcluster subchart 0.21.0 → 0.23.0 +
+      # sync.fromHost.secrets.mappings.byName — delivers each re-homed app's
+      # host-MINTED DB/SSO Secret INTO vc-mgmt (GOVERNING CONSTRAINT #2; the
+      # #3737 keycloak SHARED_PG `secret not found` blocker). OSS-native, no
+      # admin.loft.sh tether → cutover deny-egress hold still passes.
+      version: 0.2.12
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
@@ -73,7 +73,11 @@ spec:
       # in allowedIngressNamespaces so seaweedfs S3 consumers reach the now-rtz-vCluster synced Service.
       # 0.2.11 (#3373 Batch A): `newapi` carve-out in allowedIngressNamespaces
       # so the LLM gateway reaches the now-rtz-vCluster bp-vllm synced Service.
-      version: 0.2.11
+      # 0.2.12 (#3642 #3736): vcluster subchart 0.21.0 → 0.23.0 LOCKSTEP with
+      # bp-mgmt-vcluster + bp-dmz-vcluster (sibling tag parity). The active
+      # fromHost.secrets mappings live in bp-mgmt-vcluster; RTZ takes the
+      # version bump only.
+      version: 0.2.12
       sourceRef:
         kind: HelmRepository
         name: bp-rtz-vcluster

--- a/platform/bp-dmz-vcluster/blueprint.yaml
+++ b/platform/bp-dmz-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.7
+  version: 0.2.8
   card:
     title: DMZ vCluster
     summary: |

--- a/platform/bp-dmz-vcluster/chart/Chart.yaml
+++ b/platform/bp-dmz-vcluster/chart/Chart.yaml
@@ -40,8 +40,19 @@ name: bp-dmz-vcluster
 # `registry.k8s.io/kube-*` — which the `harbor-proxy-pull` Enforce
 # ClusterPolicy DENIES on the next image roll. Additive values only.
 # Sibling to bp-mgmt-vcluster 0.2.8 + bp-rtz-vcluster 0.2.8.
-version: 0.2.7
-appVersion: "0.21.0"
+# 0.2.8 — Refs #3642/#3736 (2026-06-17): LOCKSTEP loft-sh/vcluster subchart
+# bump 0.21.0 → 0.23.0 (sibling to bp-mgmt-vcluster 0.2.12 + bp-rtz-vcluster
+# 0.2.12). The active `sync.fromHost.secrets` mappings land in
+# bp-mgmt-vcluster (the 7 NS#1 apps re-home into vc-mgmt); this DMZ umbrella
+# carries ONLY the version bump so all 3 vCluster umbrellas stay on the same
+# loft-sh tag — drift between siblings would surface as inconsistent syncer
+# behaviour across the DMZ / MGMT / RTZ apiservers (the exact reason the
+# G92 0.20→0.21 bump was done in lockstep). DMZ hosts only bp-coraza, which
+# mints no host-side DB/SSO Secret, so no fromHost.secrets mapping is needed
+# here. Syncer image tag bumped to 0.23.0 to match. Default render unchanged
+# in shape (still default-OFF; subchart version only).
+version: 0.2.8
+appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign DMZ
   vCluster. Implements docs/SOVEREIGN-MULTI-REGION-DOD.md A4
@@ -85,7 +96,14 @@ dependencies:
     # G92 EPIC #2639 (2026-06-01) — sibling bump with bp-mgmt-vcluster
     # 0.2.0 + bp-rtz-vcluster 0.2.0. See bp-mgmt-vcluster/chart/Chart.yaml
     # for the full RCA on why the 0.21.0 schema is required.
-    version: "0.21.0"
+    #
+    # #3642/#3736 (2026-06-17): 0.21.0 → 0.23.0 LOCKSTEP with bp-mgmt-vcluster
+    # + bp-rtz-vcluster (all 3 vCluster umbrellas pin the same loft-sh tag —
+    # sibling drift = inconsistent syncer behaviour). The 0.23.0
+    # sync.fromHost.secrets mappings that unblock the host→vCluster Secret
+    # crossing are declared in bp-mgmt-vcluster (where the 7 NS#1 apps move);
+    # this umbrella takes the version bump only.
+    version: "0.23.0"
     repository: "https://charts.loft.sh"
     # The subchart only renders when the umbrella's top-level
     # `dmzVcluster.enabled` is true. Default-OFF therefore renders ZERO

--- a/platform/bp-dmz-vcluster/chart/values.yaml
+++ b/platform/bp-dmz-vcluster/chart/values.yaml
@@ -56,7 +56,8 @@ dmzVcluster:
   # host-qualified repository is honoured verbatim by the helper.
   image:
     repository: "proxy-ghcr/loft-sh/vcluster"
-    tag: "0.21.0"
+    # #3642/#3736: 0.21.0 → 0.23.0 lockstep with the subchart dependency bump.
+    tag: "0.23.0"
     pullPolicy: "IfNotPresent"
 
   # ── NetworkPolicy isolation baseline ──────────────────────────────
@@ -132,7 +133,9 @@ vcluster:
         # Keep in lockstep with the umbrella dmzVcluster.image above.
         registry: harbor.openova.io
         repository: proxy-ghcr/loft-sh/vcluster
-        tag: "0.21.0"
+        # #3642/#3736: the ACTUAL syncer image — 0.21.0 → 0.23.0 to match
+        # the subchart dependency version (Chart.yaml).
+        tag: "0.23.0"
       resources:
         requests:
           cpu: "200m"

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.11
+  version: 0.2.12
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -94,8 +94,35 @@ name: bp-mgmt-vcluster
 # backendRef of the host-bridged HTTPRoutes) + catalyst-system/newapi/
 # sso-bridge/oidc-gate (keycloak SSO consumers) to allowedIngressNamespaces
 # (mirrors the #3423 sme→NATS carve-out). Additive netpol-values change only.
-version: 0.2.11
-appVersion: "0.21.0"
+# 0.2.12 (#3642 #3736): UNBLOCK North-Star #1 — the host→vCluster Secret
+# delivery the host-bridge alone could NOT provide (placement.yaml
+# GOVERNING CONSTRAINT #2). loft-sh/vcluster subchart bumped 0.21.0 →
+# 0.23.0 (lockstep with bp-dmz-vcluster 0.2.8 + bp-rtz-vcluster 0.2.12) to
+# pick up `sync.fromHost.secrets.mappings.byName` — the host→vCluster
+# Secret mirror that FIRST shipped in vcluster 0.23.0 and is genuinely
+# OSS (no `product:"pro"` struct tag on SyncFromHost.Secrets → no
+# admin.loft.sh license tether → the Pillar-5 bp-self-sovereign-cutover
+# 600s deny-egress hold still passes). Each of the 7 NS#1 apps that
+# re-homes into vc-mgmt (keycloak/gitea/harbor/newapi/grafana/openbao/
+# guacamole) mounts a host-MINTED Secret — a CNPG/reflector DB credential
+# (`<app>-database-secret` / `<app>-pg-app`) and/or a host-ESO SSO Secret
+# (`<app>-sso-oidc-credentials`) — that lives in the app's HOST namespace
+# while the Pod runs inside vc-mgmt (a different apiserver). Without this
+# mirror keycloak-0 hangs on `MountVolume.SetUp … secret
+# "keycloak-database-secret-x-keycloak-x-mgmt-vcluster" not found` (#3737
+# SHARED_PG terminal blocker) and grafana/harbor/gitea/newapi boot without
+# their SSO/DB env. The new `vcluster.sync.fromHost.secrets` block (default
+# render) mirrors every host Secret in the 6 moved-app host namespaces
+# (keycloak/gitea/harbor/newapi/grafana/catalyst-system) into the
+# identically-named vCluster namespace via the documented OSS namespace-
+# wildcard idiom (`"<ns>/*": "<ns>/*"`). `sync.toHost.secrets` (existing,
+# vCluster→host) and `sync.fromHost.secrets` (host→vCluster) are
+# independent struct fields — no conflict. ⚠️ DO-NOT-MERGE until a
+# fresh-prov walk confirms the 7 apps land IN vc-mgmt with their Secrets
+# mounted: a vcluster MAJOR bump (0.21→0.23) can change syncer behaviour
+# and MUST be validated on a live env before merge.
+version: 0.2.12
+appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT
   vCluster. Implements docs/SOVEREIGN-MULTI-REGION-DOD.md A4
@@ -156,7 +183,24 @@ dependencies:
     # Cluster template (bp-gitea, bp-harbor, bp-catalyst-platform)
     # silently skips it under the chart's Capabilities gate when
     # installed inside the vCluster.
-    version: "0.21.0"
+    #
+    # #3642/#3736 (2026-06-17): bumped 0.21.0 → 0.23.0 (lockstep with
+    # bp-dmz-vcluster + bp-rtz-vcluster) so the umbrella can declare
+    # `vcluster.sync.fromHost.secrets.mappings.byName` — the host→vCluster
+    # Secret mirror that FIRST shipped in vcluster 0.23.0. This is the
+    # GOVERNING CONSTRAINT #2 fix (placement.yaml §4 exception): the 7
+    # NS#1 apps re-homed into vc-mgmt each mount a host-MINTED DB/SSO
+    # Secret that the OSS 0.21.0 syncer could not deliver across the
+    # host→vCluster boundary (0.21.0 has no `sync.fromHost.secrets` key
+    # and REJECTS it at strict-unmarshal config parse). 0.23.0's
+    # SyncFromHost.Secrets struct field carries NO `product:"pro"` tag —
+    # genuinely OSS, no admin.loft.sh tether, so the bp-self-sovereign-
+    # cutover 600s deny-egress hold still passes. Empirically verified
+    # (helm dependency build + helm template) that all pre-existing
+    # subchart values (controlPlane.distro.k8s, statefulSet.image,
+    # sync.toHost.customResources, experimental.deploy.vcluster.manifests)
+    # still parse under 0.23.0 strict-unmarshal alongside the new block.
+    version: "0.23.0"
     repository: "https://charts.loft.sh"
     # The subchart only renders when the umbrella's top-level
     # `mgmtVcluster.enabled` is true. Default-OFF therefore renders

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -115,7 +115,9 @@ mgmtVcluster:
   # (pre-#2940 shape) is still honoured verbatim by the helper.
   image:
     repository: "proxy-ghcr/loft-sh/vcluster"
-    tag: "0.21.0"
+    # #3642/#3736: 0.21.0 → 0.23.0 in lockstep with the subchart
+    # dependency bump (Chart.yaml) + the real syncer image tag below.
+    tag: "0.23.0"
     pullPolicy: "IfNotPresent"
 
   # ── NetworkPolicy isolation baseline ───────────────────────────
@@ -259,7 +261,10 @@ vcluster:
         # Keep this in lockstep with the umbrella `mgmtVcluster.image` above.
         registry: harbor.openova.io
         repository: proxy-ghcr/loft-sh/vcluster
-        tag: "0.21.0"
+        # #3642/#3736: the ACTUAL vCluster syncer image — bumped 0.21.0 →
+        # 0.23.0 to match the subchart dependency version (Chart.yaml). The
+        # 0.23.0 syncer is the binary that honours sync.fromHost.secrets.
+        tag: "0.23.0"
       resources:
         requests:
           cpu: "200m"
@@ -362,6 +367,58 @@ vcluster:
     fromHost:
       ingressClasses:
         enabled: true
+      # ── #3642/#3736 host→vCluster Secret mirror (GOVERNING CONSTRAINT #2) ──
+      # The host-bridge (#3642) keeps each re-homed app's HTTPRoute +
+      # ExternalSecret + CNPG `Cluster` CR HOST-rendered so the host Cilium
+      # Gateway / external-secrets-operator / cnpg-operator (all host-minimum
+      # substrate) reconcile them — but the app's WORKLOAD Pod, which now runs
+      # INSIDE vc-mgmt, still needs the Secret those host-side resources MINT:
+      #   - a CNPG/reflector DB credential — `<app>-database-secret` (the
+      #     emberstack-reflector hub Secret, e.g. keycloak-database-secret /
+      #     gitea-database-secret / harbor-database-secret /
+      #     newapi-database-secret) and/or the CNPG-app Secret `<app>-pg-app`
+      #     (gitea-pg-app) / `guacamole-pg`.
+      #   - a host-ESO SSO Secret — `<app>-sso-oidc-credentials`
+      #     (harbor-/grafana-/openbao-/gitea-/newapi-).
+      # On OSS vcluster 0.21.0 NO mechanism delivered it across the
+      # host→vCluster boundary (the in-vCluster Pod mounts from the vCluster's
+      # OWN apiserver, a different namespace store than the host's): an
+      # in-vCluster ExternalSecret can't reconcile (ESO is host-minimum, slot
+      # 15; toHost custom-resource sync is Pro-gated/inert on OSS), and
+      # `sync.fromHost.secrets` did not EXIST until vcluster 0.23.0. Result:
+      # keycloak-0 hung on `MountVolume.SetUp … secret
+      # "keycloak-database-secret-x-keycloak-x-mgmt-vcluster" not found`
+      # (#3737 SHARED_PG terminal blocker) and grafana/harbor/gitea/newapi
+      # booted without their SSO/DB env. THIS block is that delivery
+      # mechanism — genuinely OSS in 0.23.0 (no `product:"pro"` tag → no
+      # admin.loft.sh tether → the Pillar-5 cutover deny-egress hold passes).
+      #
+      # `mappings.byName` is a map[string]string keyed `"<hostNs>/<name>"` →
+      # valued `"<vClusterNs>/<name>"`; `*` wildcards the NAME component. We
+      # use the documented namespace-wildcard idiom `"<ns>/*": "<ns>/*"` per
+      # moved-app HOST namespace so EVERY host Secret in that namespace (DB
+      # hub Secret, CNPG-app Secret, SSO ExternalSecret-materialised Secret,
+      # and any future addition) mirrors into the identically-named vCluster
+      # namespace with zero per-secret enumeration — the generic mechanism
+      # (#3642 DoD-6 "no per-app special-casing"), not a per-secret hack. The
+      # namespaces are exactly the 7 NS#1 apps' inner namespaces
+      # (keycloak/gitea/harbor/newapi/grafana, plus catalyst-system for
+      # guacamole — guacamole's `guacamole-pg` CNPG-app Secret + the
+      # bp-continuum/k8s-ws-proxy host-adjacent peers share that namespace).
+      # On a fresh prov the host namespaces that don't yet exist are simply
+      # not mirrored (no-op) until the host-bridge renders them — additive
+      # and safe. Independent of the existing `sync.toHost.secrets`
+      # (vCluster→host); the two directions don't conflict.
+      secrets:
+        enabled: true
+        mappings:
+          byName:
+            "keycloak/*": "keycloak/*"
+            "gitea/*": "gitea/*"
+            "harbor/*": "harbor/*"
+            "newapi/*": "newapi/*"
+            "grafana/*": "grafana/*"
+            "catalyst-system/*": "catalyst-system/*"
 
   # ── In-vCluster CRD registration (#3373, OSS-native) ────────────────────
   # The init-manifests deployer (`loft-sh/vcluster` controllers

--- a/platform/bp-rtz-vcluster/blueprint.yaml
+++ b/platform/bp-rtz-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.11
+  version: 0.2.12
   card:
     title: RTZ vCluster
     summary: |

--- a/platform/bp-rtz-vcluster/chart/Chart.yaml
+++ b/platform/bp-rtz-vcluster/chart/Chart.yaml
@@ -57,8 +57,18 @@ name: bp-rtz-vcluster
 # vCluster; the host `newapi` namespace runs the LLM gateway whose vllm
 # channel consumes bp-vllm — without this carve-out it cannot reach the
 # synced Service. Additive; mirrors the #3423 carve-out.
-version: 0.2.11
-appVersion: "0.21.0"
+# 0.2.12 — Refs #3642/#3736 (2026-06-17): LOCKSTEP loft-sh/vcluster subchart
+# bump 0.21.0 → 0.23.0 (sibling to bp-mgmt-vcluster 0.2.12 + bp-dmz-vcluster
+# 0.2.8). The active `sync.fromHost.secrets` mappings land in
+# bp-mgmt-vcluster (the 7 NS#1 apps re-home into vc-mgmt); this RTZ umbrella
+# carries ONLY the version bump so all 3 vCluster umbrellas stay on the same
+# loft-sh tag — drift between siblings would surface as inconsistent syncer
+# behaviour across the DMZ / MGMT / RTZ apiservers. RTZ's Batch-A residents
+# (valkey/seaweedfs/vllm) mint no host-side DB/SSO Secret, so no
+# fromHost.secrets mapping is needed here. Syncer image tag bumped to 0.23.0
+# to match. Default render unchanged in shape (subchart version only).
+version: 0.2.12
+appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign RTZ
   vCluster. Implements docs/SOVEREIGN-MULTI-REGION-DOD.md A4
@@ -103,7 +113,14 @@ dependencies:
     # G92 EPIC #2639 (2026-06-01) — sibling bump with bp-mgmt-vcluster
     # 0.2.0 + bp-dmz-vcluster 0.2.0. See bp-mgmt-vcluster/chart/Chart.yaml
     # for the full RCA on why the 0.21.0 schema is required.
-    version: "0.21.0"
+    #
+    # #3642/#3736 (2026-06-17): 0.21.0 → 0.23.0 LOCKSTEP with bp-mgmt-vcluster
+    # + bp-dmz-vcluster (all 3 vCluster umbrellas pin the same loft-sh tag —
+    # sibling drift = inconsistent syncer behaviour). The 0.23.0
+    # sync.fromHost.secrets mappings that unblock the host→vCluster Secret
+    # crossing are declared in bp-mgmt-vcluster (where the 7 NS#1 apps move);
+    # this umbrella takes the version bump only.
+    version: "0.23.0"
     repository: "https://charts.loft.sh"
     # The subchart only renders when the umbrella's top-level
     # `rtzVcluster.enabled` is true. Default-OFF therefore renders ZERO

--- a/platform/bp-rtz-vcluster/chart/values.yaml
+++ b/platform/bp-rtz-vcluster/chart/values.yaml
@@ -54,7 +54,8 @@ rtzVcluster:
   # host-qualified repository is honoured verbatim by the helper.
   image:
     repository: "proxy-ghcr/loft-sh/vcluster"
-    tag: "0.21.0"
+    # #3642/#3736: 0.21.0 → 0.23.0 lockstep with the subchart dependency bump.
+    tag: "0.23.0"
     pullPolicy: "IfNotPresent"
 
   # ── NetworkPolicy isolation baseline ──────────────────────────────
@@ -154,7 +155,9 @@ vcluster:
         # Keep in lockstep with the umbrella rtzVcluster.image above.
         registry: harbor.openova.io
         repository: proxy-ghcr/loft-sh/vcluster
-        tag: "0.21.0"
+        # #3642/#3736: the ACTUAL syncer image — 0.21.0 → 0.23.0 to match the
+        # subchart dependency version (Chart.yaml).
+        tag: "0.23.0"
       resources:
         requests:
           cpu: "200m"


### PR DESCRIPTION
**Refs #3642 #3736** — 🛑 **DO NOT MERGE** (high-risk vcluster MAJOR bump; needs a fresh-prov walk before merge).

## What this is

The **real fix** the #3719 assessment specified for North-Star #1 (*"every app IN a vCluster"*): the host→vCluster **Secret delivery** that the #3719 host-bridge (path B) alone does NOT provide.

The host-bridge keeps each re-homed app's HTTPRoute + ExternalSecret + CNPG `Cluster` CR **host-rendered** (so the host Cilium Gateway / external-secrets-operator / cnpg-operator reconcile them), and re-homes only the workload Pod into vc-mgmt. But that Pod still needs the **Secret those host-side resources MINT** — a CNPG/reflector DB credential (`<app>-database-secret` / `<app>-pg-app`) and/or a host-ESO SSO Secret (`<app>-sso-oidc-credentials`). On OSS vcluster **0.21.0 nothing delivers it across the host→vCluster boundary** (`placement.yaml` GOVERNING CONSTRAINT #2):
- an in-vCluster ExternalSecret can't reconcile (ESO is host-minimum; `toHost.customResources` is Pro-gated/inert on OSS), and
- `sync.fromHost.secrets` **did not exist until vcluster 0.23.0** — 0.21.0 *rejects* the unknown key at strict-unmarshal config parse, breaking the syncer.

Result today: `keycloak-0` hangs on `MountVolume.SetUp … secret "keycloak-database-secret-x-keycloak-x-mgmt-vcluster" not found` (**#3737** SHARED_PG terminal blocker) and grafana/harbor/gitea/newapi boot without their SSO/DB env.

## The fix

### 1. vcluster subchart 0.21.0 → 0.23.0, LOCKSTEP across all 3 umbrellas

`sync.fromHost.secrets.mappings.byName` first ships in **vcluster 0.23.0** (lowest 0.23.x; 0.23.0/1/2/3 available). `SyncFromHost.Secrets` carries **no `product:"pro"` struct tag** (verified against the `v0.23.0` `config.go`) — genuinely OSS, **no `admin.loft.sh` tether** → the Pillar-5 `bp-self-sovereign-cutover` 600s deny-egress hold still passes.

| Umbrella | chart ver | dep `vcluster` | slot pin |
|---|---|---|---|
| `bp-mgmt-vcluster` | 0.2.11 → **0.2.12** | 0.21.0 → **0.23.0** | 58 → 0.2.12 |
| `bp-dmz-vcluster` | 0.2.7 → **0.2.8** | 0.21.0 → **0.23.0** | 54 → 0.2.8 |
| `bp-rtz-vcluster` | 0.2.11 → **0.2.12** | 0.21.0 → **0.23.0** | 59 → 0.2.12 |

All 3 stay on the same loft-sh tag — sibling drift = inconsistent syncer behaviour (the same reason the G92 0.20→0.21 bump was lockstep). Umbrella + subchart syncer image tags bumped to `0.23.0`; `appVersion` → `0.23.0`; `blueprint.yaml` `spec.version` bumped in lockstep.

### 2. `sync.fromHost.secrets.mappings.byName` on bp-mgmt-vcluster (where the 7 NS#1 apps re-home)

Mirrors **every host Secret** in the 6 moved-app HOST namespaces into the identically-named vCluster namespace via the documented OSS namespace-wildcard idiom — generic, **no per-secret enumeration / no per-app special-casing** (#3642 DoD-6), additive (absent host namespaces are no-ops):

```yaml
vcluster:
  sync:
    fromHost:
      secrets:
        enabled: true
        mappings:
          byName:
            "keycloak/*": "keycloak/*"          # keycloak-database-secret (SHARED_PG #3737) + SSO
            "gitea/*": "gitea/*"                # gitea-database-secret / gitea-pg-app + gitea-sso-oidc-credentials
            "harbor/*": "harbor/*"              # harbor-database-secret + harbor-sso-oidc-credentials
            "newapi/*": "newapi/*"              # newapi-database-secret + newapi-oidc
            "grafana/*": "grafana/*"            # grafana-sso-oidc-credentials
            "catalyst-system/*": "catalyst-system/*"  # guacamole-pg (guacamole inner ns)
```

`bp-dmz`/`bp-rtz` take the **version bump only** (their residents — coraza; valkey/seaweedfs/vllm — mint no host-side DB/SSO Secret). `sync.toHost.secrets` (vCluster→host, existing) and `sync.fromHost.secrets` (host→vCluster) are **independent struct fields** — no conflict.

## Strict-unmarshal coexistence (the #3731 / config-parse hazard)

vcluster parses config with `yaml.UnmarshalStrict`. Empirically verified (`helm dependency build` + `helm template` + decode of the rendered `vc-config` secret the syncer reads at boot) that **all** pre-existing subchart values still parse under 0.23.0 **alongside** the new block:

```
✓ fromHost.secrets.enabled: True  + 6 byName mappings
✓ toHost.customResources: 5  [clusters/poolers/scheduledbackups.postgresql.cnpg.io, httproutes.gateway.networking.k8s.io, externalsecrets.external-secrets.io]
✓ experimental.deploy.vcluster.manifests: present  [3 init-manifest CRDs]
✓ toHost.secrets: {enabled: True}  (independent, coexists)
```

The raw ExternalSecret stays OUT of the atomic bootstrap-kit Kustomization — this PR is **chart-only** and adds no slot-level raw ES (that #3731 split is the #3719 host-bridge train's concern).

## Gates (all green)

- `bash chart/tests/render.sh` ✅ for **all 3** umbrellas (the blueprint-release publish gate, incl. the #3373 init-manifest CRD assertion)
- `render-slot-placement.py check` ✅ (placement unchanged — chart-only; still 9 in vClusters, 17 staged)
- host-bridge render-test ✅
- `check-bootstrap-deps.sh` ✅ (drift 0 / cycles 0)
- `check-bootstrap-kit-pin-sync.sh` ✅ (exit 0 — all 3 umbrellas chart == pin)
- `kubectl kustomize build clusters/_template/bootstrap-kit` ✅ (4287 lines)
- bootstrap-kit Go static-parse `TemplateClusterParses` ✅

## 🛑 Honest risk — why DO NOT MERGE

A vcluster **MAJOR** bump (0.21 → 0.23) can change syncer behaviour and CANNOT be proven by render alone. The **real acceptance** is a **fresh-prov walk** confirming the 7 NS#1 apps (keycloak/gitea/harbor/newapi/grafana/openbao/guacamole) land **IN vc-mgmt with their host-minted Secrets mounted** (the `-x-…-x-mgmt-vcluster` syncer suffix + no `MountVolume.SetUp … secret not found`), combined with the #3719 host-bridge placement flips. This PR is the **secret-delivery half**; #3719 is the **placement half** — both are needed (and both are DO-NOT-MERGE-until-walked). Merge only after a live env proves the 7 apps converge green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)