### PR TITLE
fix(funnel): proxy the purchased app images through Sovereign Harbor — WordPress Runs after vCluster comes up (Refs #3376 #3761)

### DIFF
--- a/core/services/provisioning/gitops/apps.go
+++ b/core/services/provisioning/gitops/apps.go
@@ -1,13 +1,83 @@
 package gitops
 
+import "strings"
+
+// proxyImage re-tags an upstream image reference through the Sovereign-local
+// Harbor proxy-cache so it passes the `harbor-proxy-pull` Kyverno
+// ClusterPolicy (Enforce), which DENIES any image not matching the
+// `*/proxy-*/*` glob (#3785, follow-up to #3761, Refs #3376).
+//
+// The per-tenant app Deployments are synced INTO the tenant vCluster, whose
+// syncer schedules the BACKING Pod on the HOST cluster (in the
+// `tenant-<slug>` host namespace) — where the host kyverno ClusterPolicy
+// enforces. A raw `wordpress:6-apache` (Docker Hub) is therefore DENIED and
+// the customer's purchased app never starts (the funnel's terminal
+// acceptance). Re-tagging through the registry-appropriate Harbor proxy
+// project (`proxy-dockerhub` / `proxy-ghcr` / `proxy-quay` / `proxy-gcr` /
+// `proxy-k8s`) makes the reference match the glob.
+//
+// `mirror` is the Sovereign Harbor host (e.g. "harbor.openova.io",
+// operator-overridable; cutover Step-04 flips it to harbor.<fqdn>). An empty
+// mirror or an already-proxied reference (`<host>/proxy-*/...`) is returned
+// unchanged. Registries without an established Harbor proxy project (e.g.
+// lscr.io) are also returned unchanged — no regression for those apps, which
+// keep their pre-#3785 behaviour; they are day-2 catalog entries, not the
+// funnel terminal.
+func proxyImage(image, mirror string) string {
+	image = strings.TrimSpace(image)
+	mirror = strings.TrimSpace(strings.TrimRight(mirror, "/"))
+	if image == "" || mirror == "" {
+		return image
+	}
+	// Already routed through a Harbor proxy project — leave as-is.
+	if strings.HasPrefix(image, mirror+"/proxy-") {
+		return image
+	}
+
+	// Split the optional registry host off the front. Docker Hub references
+	// have no host (`wordpress:tag`, `chatwoot/chatwoot:tag`); explicit-
+	// registry references start with a host containing a dot or colon
+	// (`ghcr.io/...`, `lscr.io/...`).
+	first := image
+	if i := strings.IndexByte(image, '/'); i >= 0 {
+		first = image[:i]
+	}
+	hasRegistryHost := strings.ContainsAny(first, ".:") && strings.Contains(image, "/")
+
+	// registryToProxy maps an upstream registry host to its Harbor
+	// proxy-cache project. Only registries with an established proxy project
+	// (the live convention — see platform/**/values.yaml + chart comments)
+	// are listed; the DockerHub project is `proxy-dockerhub` (NOT
+	// `proxy-docker` — platform/openbao/chart/Chart.yaml).
+	registryToProxy := map[string]string{
+		"docker.io":       "proxy-dockerhub",
+		"ghcr.io":         "proxy-ghcr",
+		"quay.io":         "proxy-quay",
+		"gcr.io":          "proxy-gcr",
+		"registry.k8s.io": "proxy-k8s",
+	}
+
+	if !hasRegistryHost {
+		// Bare Docker Hub reference → harbor/proxy-dockerhub/<repo>:<tag>.
+		return mirror + "/proxy-dockerhub/" + image
+	}
+	proj, ok := registryToProxy[first]
+	if !ok {
+		// Unknown registry without a Harbor proxy project — leave unchanged
+		// (no regression; not a funnel-terminal image).
+		return image
+	}
+	return mirror + "/" + proj + "/" + strings.TrimPrefix(image, first+"/")
+}
+
 // AppSpec defines how to deploy an app.
 type AppSpec struct {
-	Image       string
-	Port        int
-	EnvVars     map[string]string // static env vars
-	NeedsDB     string            // "postgres", "mysql", or ""
-	RAMMI       string            // resource request memory
-	CPUMilli    string            // resource request cpu
+	Image    string
+	Port     int
+	EnvVars  map[string]string // static env vars
+	NeedsDB  string            // "postgres", "mysql", or ""
+	RAMMI    string            // resource request memory
+	CPUMilli string            // resource request cpu
 	// DBEnvStyle selects the env var shape used for the wired DB secret.
 	// "wordpress" → WORDPRESS_DB_* (WordPress, BookStack, InvoiceShelf, default).
 	// "ghost"     → database__client + database__connection__{host,user,password,database}.
@@ -29,43 +99,43 @@ var KnownApps = map[string]AppSpec{
 	"wordpress": {
 		Image: "wordpress:6-apache", Port: 80,
 		NeedsDB: "mysql",
-		RAMMI: "256Mi", CPUMilli: "100m",
+		RAMMI:   "256Mi", CPUMilli: "100m",
 		EnvVars: map[string]string{},
 	},
 	"umami": {
 		Image: "ghcr.io/umami-software/umami:postgresql-latest", Port: 3000,
 		NeedsDB: "postgres",
-		RAMMI: "256Mi", CPUMilli: "100m",
+		RAMMI:   "256Mi", CPUMilli: "100m",
 		EnvVars: map[string]string{},
 	},
 	"cal-com": {
 		Image: "calcom/cal.com:latest", Port: 3000,
 		NeedsDB: "postgres",
-		RAMMI: "256Mi", CPUMilli: "100m",
+		RAMMI:   "256Mi", CPUMilli: "100m",
 		EnvVars: map[string]string{
 			"NEXT_PUBLIC_WEBAPP_URL": "https://TENANT.omani.rest/calcom",
-			"NEXTAUTH_URL":          "https://TENANT.omani.rest/calcom",
+			"NEXTAUTH_URL":           "https://TENANT.omani.rest/calcom",
 		},
 	},
 	"chatwoot": {
 		Image: "chatwoot/chatwoot:latest", Port: 3000,
 		NeedsDB: "postgres",
-		RAMMI: "512Mi", CPUMilli: "200m",
+		RAMMI:   "512Mi", CPUMilli: "200m",
 		EnvVars: map[string]string{
-			"RAILS_ENV":       "production",
-			"REDIS_URL":       "redis://redis:6379",
+			"RAILS_ENV": "production",
+			"REDIS_URL": "redis://redis:6379",
 		},
 	},
 	"invoiceshelf": {
 		Image: "invoiceshelf/invoiceshelf:latest", Port: 8080,
 		NeedsDB: "mysql",
-		RAMMI: "256Mi", CPUMilli: "100m",
+		RAMMI:   "256Mi", CPUMilli: "100m",
 		EnvVars: map[string]string{},
 	},
 	"ghost": {
 		Image: "ghost:5-alpine", Port: 2368,
 		NeedsDB: "mysql",
-		RAMMI: "256Mi", CPUMilli: "100m",
+		RAMMI:   "256Mi", CPUMilli: "100m",
 		EnvVars: map[string]string{
 			"NODE_ENV": "production",
 			"url":      "https://TENANT.omani.rest/ghost",
@@ -76,31 +146,31 @@ var KnownApps = map[string]AppSpec{
 	"nextcloud": {
 		Image: "nextcloud:29-apache", Port: 80,
 		NeedsDB: "postgres",
-		RAMMI: "256Mi", CPUMilli: "100m",
+		RAMMI:   "256Mi", CPUMilli: "100m",
 		EnvVars: map[string]string{},
 	},
 	"gitea": {
 		Image: "gitea/gitea:1-rootless", Port: 3000,
 		NeedsDB: "postgres",
-		RAMMI: "256Mi", CPUMilli: "100m",
+		RAMMI:   "256Mi", CPUMilli: "100m",
 		EnvVars: map[string]string{},
 	},
 	"uptime-kuma": {
 		Image: "louislam/uptime-kuma:1", Port: 3001,
 		NeedsDB: "",
-		RAMMI: "128Mi", CPUMilli: "50m",
+		RAMMI:   "128Mi", CPUMilli: "50m",
 		EnvVars: map[string]string{},
 	},
 	"vaultwarden": {
 		Image: "vaultwarden/server:latest", Port: 80,
 		NeedsDB: "",
-		RAMMI: "128Mi", CPUMilli: "50m",
+		RAMMI:   "128Mi", CPUMilli: "50m",
 		EnvVars: map[string]string{},
 	},
 	"bookstack": {
 		Image: "lscr.io/linuxserver/bookstack:latest", Port: 80,
 		NeedsDB: "mysql",
-		RAMMI: "256Mi", CPUMilli: "100m",
+		RAMMI:   "256Mi", CPUMilli: "100m",
 		// linuxserver/bookstack reads DB_HOST/DB_USER/DB_PASS/DB_DATABASE
 		// (NOT WORDPRESS_DB_*) and refuses to start without APP_KEY. Without
 		// the bookstack DBEnvStyle the manifest emitted only WordPress-shape
@@ -113,13 +183,13 @@ var KnownApps = map[string]AppSpec{
 	"nocodb": {
 		Image: "nocodb/nocodb:latest", Port: 8080,
 		NeedsDB: "postgres",
-		RAMMI: "256Mi", CPUMilli: "100m",
+		RAMMI:   "256Mi", CPUMilli: "100m",
 		EnvVars: map[string]string{},
 	},
 	"listmonk": {
 		Image: "listmonk/listmonk:latest", Port: 9000,
 		NeedsDB: "postgres",
-		RAMMI: "128Mi", CPUMilli: "50m",
+		RAMMI:   "128Mi", CPUMilli: "50m",
 		EnvVars: map[string]string{},
 		// listmonk reads config.toml and only honours LISTMONK_db__* envs —
 		// DATABASE_URL is ignored. Issue #101.
@@ -135,13 +205,13 @@ var KnownApps = map[string]AppSpec{
 	"rocket-chat": {
 		Image: "rocket.chat:latest", Port: 3000,
 		NeedsDB: "",
-		RAMMI: "512Mi", CPUMilli: "200m",
+		RAMMI:   "512Mi", CPUMilli: "200m",
 		EnvVars: map[string]string{},
 	},
 	"formbricks": {
 		Image: "formbricks/formbricks:latest", Port: 3000,
 		NeedsDB: "postgres",
-		RAMMI: "256Mi", CPUMilli: "100m",
+		RAMMI:   "256Mi", CPUMilli: "100m",
 		EnvVars: map[string]string{},
 	},
 }

--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -294,6 +294,16 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 			continue
 		}
 		spec := GetAppSpec(a)
+		// MIRROR-EVERYTHING (#3785, Refs #3376 #3761): route the app image
+		// (main container + the InitCommand initContainer that reuses it)
+		// THROUGH the Sovereign Harbor proxy-cache. The vCluster syncer
+		// schedules the backing Pod on the HOST cluster, where the
+		// `harbor-proxy-pull` Kyverno ClusterPolicy (Enforce) DENIES any
+		// image not matching `*/proxy-*/*` — so a raw `wordpress:6-apache`
+		// pull is blocked and the purchased app never starts. proxyImage is
+		// a no-op when registryMirror is empty or the image is already
+		// proxied / on a registry without a Harbor proxy project.
+		spec.Image = proxyImage(spec.Image, g.registryMirror())
 		vcFiles[fmt.Sprintf("app-%s.yaml", a)] = generateAppDeployment(appNS, slug, a, spec, dbPassword)
 	}
 	vcFiles["kustomization.yaml"] = generateKustomization(appNS, vcFiles)

--- a/core/services/provisioning/gitops/proxy_image_test.go
+++ b/core/services/provisioning/gitops/proxy_image_test.go
@@ -1,0 +1,45 @@
+package gitops
+
+import "testing"
+
+// #3785 (Refs #3376 #3761) — proxyImage must re-tag upstream app images
+// through the registry-appropriate Sovereign Harbor proxy-cache project so
+// they pass the harbor-proxy-pull Kyverno ClusterPolicy (Enforce, glob
+// */proxy-*/*). The vCluster syncer schedules the backing Pod on the HOST
+// cluster where the policy enforces, so a raw image is admission-denied and
+// the purchased app never Runs.
+func TestProxyImage(t *testing.T) {
+	const mirror = "harbor.openova.io"
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"dockerhub library (wordpress)", "wordpress:6-apache", "harbor.openova.io/proxy-dockerhub/wordpress:6-apache"},
+		{"dockerhub namespaced", "invoiceshelf/invoiceshelf:latest", "harbor.openova.io/proxy-dockerhub/invoiceshelf/invoiceshelf:latest"},
+		{"ghcr", "ghcr.io/umami-software/umami:postgresql-latest", "harbor.openova.io/proxy-ghcr/umami-software/umami:postgresql-latest"},
+		{"quay", "quay.io/foo/bar:1", "harbor.openova.io/proxy-quay/foo/bar:1"},
+		{"registry.k8s.io", "registry.k8s.io/pause:3.9", "harbor.openova.io/proxy-k8s/pause:3.9"},
+		// lscr.io has no Harbor proxy project — pass through unchanged (no
+		// regression; day-2 catalog app, not the funnel terminal).
+		{"unknown registry passes through", "lscr.io/linuxserver/bookstack:latest", "lscr.io/linuxserver/bookstack:latest"},
+		// Already proxied — idempotent.
+		{"already proxied", "harbor.openova.io/proxy-dockerhub/wordpress:6-apache", "harbor.openova.io/proxy-dockerhub/wordpress:6-apache"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := proxyImage(c.in, mirror); got != c.want {
+				t.Errorf("proxyImage(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+
+	// Empty mirror → no rewrite (pre-Harbor bootstrap / disabled).
+	if got := proxyImage("wordpress:6-apache", ""); got != "wordpress:6-apache" {
+		t.Errorf("empty mirror must not rewrite; got %q", got)
+	}
+	// Empty image → empty.
+	if got := proxyImage("", mirror); got != "" {
+		t.Errorf("empty image must stay empty; got %q", got)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go
@@ -452,11 +452,11 @@ func (w DefaultSMETenantGitOpsWriter) DeleteTenantOverlay(ctx context.Context, r
 
 // smeTenantTemplateData is the input the rendering templates consume.
 type smeTenantTemplateData struct {
-	TenantID      string
-	Subdomain     string
-	Namespace     string
-	VClusterName  string
-	OTECHFQDN     string
+	TenantID     string
+	Subdomain    string
+	Namespace    string
+	VClusterName string
+	OTECHFQDN    string
 	// ParentDomain — the chosen sme-pool parent (multi-domain
 	// Sovereign per epic #825). Falls back to OTECHFQDN for
 	// single-domain back-compat. The console/wordpress/openclaw/
@@ -473,6 +473,28 @@ type smeTenantTemplateData struct {
 	IsBYO         bool
 	ChartVersions SMETenantChartVersions
 	GeneratedAt   string
+
+	// VClusterImageRegistry is the Sovereign-local Harbor host the
+	// per-tenant app images pull THROUGH (proxy-cache). Default
+	// "harbor.openova.io".
+	//
+	// MIRROR-EVERYTHING (#3785, follow-up to #3761, Refs #3376): the
+	// bp-wordpress-tenant chart's main + wp-cli images default to the
+	// Docker Hub `wordpress` repository (platform/wordpress-tenant/chart/
+	// values.yaml). On a kyverno-Enforce Sovereign the `harbor-proxy-pull`
+	// ClusterPolicy DENIES any image not matching the `*/proxy-*/*` glob —
+	// so a raw `wordpress:6-php8.3-apache` pull is blocked and the
+	// customer's purchased app never starts (the funnel's terminal
+	// acceptance). #3761 re-tagged the per-Org vCluster images but left the
+	// APP images raw; this field closes that gap by feeding
+	// `global.imageRegistry: <registry>/proxy-dockerhub` into the WordPress
+	// HelmRelease so BOTH WordPress images route through the Sovereign
+	// Harbor proxy-cache, exactly like the CNPG image the chart already
+	// proxies through `<registry>/proxy-ghcr`. Per Inviolable Principle #4
+	// it's read from env (CATALYST_VCLUSTER_IMAGE_REGISTRY — the same knob
+	// the org-controller uses), never hardcoded; cutover Step-04 (ADR-0002)
+	// flips it to harbor.<sovereign-fqdn> post-handover.
+	VClusterImageRegistry string
 
 	// D31 active-hot-standby — opt-in cross-region CNPG ReplicaCluster
 	// for CNPG-backed tenant apps. The bp-wordpress-tenant chart
@@ -569,27 +591,37 @@ func renderSMETenantOverlay(rec store.SMETenantProvisionRecord, versions SMETena
 		enableHotStandby = false
 	}
 
+	// MIRROR-EVERYTHING (#3785): the Sovereign-local Harbor proxy host every
+	// per-tenant app image routes through. Same env knob + default the
+	// org-controller uses for the vCluster image (CATALYST_VCLUSTER_IMAGE_
+	// REGISTRY, default harbor.openova.io); cutover Step-04 flips it to
+	// harbor.<sovereign-fqdn> post-handover (ADR-0002). Read here so the
+	// WordPress HelmRelease's `global.imageRegistry` is never hardcoded
+	// (Inviolable Principle #4).
+	imageRegistry := strings.TrimSpace(envOr("CATALYST_VCLUSTER_IMAGE_REGISTRY", "harbor.openova.io"))
+
 	data := smeTenantTemplateData{
-		TenantID:         rec.SMETenantID,
-		Subdomain:        rec.Subdomain,
-		Namespace:        rec.TenantNamespace,
-		VClusterName:     rec.VClusterName,
-		OTECHFQDN:        rec.OTECHFQDN,
-		ParentDomain:     parentZone,
-		ConsoleHost:      host,
-		WordPressHost:    wpHost,
-		OpenClawHost:     owHost,
-		MailHost:         mailHost,
-		AdminEmail:       rec.AdminEmail,
-		CompanyName:      rec.CompanyName,
-		DomainMode:       string(rec.DomainMode),
-		BYODomain:        rec.BYODomain,
-		IsBYO:            rec.DomainMode == store.SMEDomainBYO,
-		ChartVersions:    versions,
-		GeneratedAt:      time.Now().UTC().Format(time.RFC3339),
-		EnableHotStandby: enableHotStandby,
-		PrimaryRegion:    primaryRegion,
-		ReplicaRegion:    replicaRegion,
+		TenantID:              rec.SMETenantID,
+		Subdomain:             rec.Subdomain,
+		Namespace:             rec.TenantNamespace,
+		VClusterName:          rec.VClusterName,
+		OTECHFQDN:             rec.OTECHFQDN,
+		ParentDomain:          parentZone,
+		ConsoleHost:           host,
+		WordPressHost:         wpHost,
+		OpenClawHost:          owHost,
+		MailHost:              mailHost,
+		AdminEmail:            rec.AdminEmail,
+		CompanyName:           rec.CompanyName,
+		DomainMode:            string(rec.DomainMode),
+		BYODomain:             rec.BYODomain,
+		IsBYO:                 rec.DomainMode == store.SMEDomainBYO,
+		ChartVersions:         versions,
+		GeneratedAt:           time.Now().UTC().Format(time.RFC3339),
+		VClusterImageRegistry: imageRegistry,
+		EnableHotStandby:      enableHotStandby,
+		PrimaryRegion:         primaryRegion,
+		ReplicaRegion:         replicaRegion,
 	}
 
 	out := map[string]string{}
@@ -923,29 +955,29 @@ spec:
 //
 // Values contract (chart >= 1.3.0, see platform/newapi/chart/values.yaml):
 //   - sovereignFQDN          → drives the OpenBao path convention for
-//                              ExternalSecrets (sovereign/<fqdn>/...).
+//     ExternalSecrets (sovereign/<fqdn>/...).
 //   - ingress.host           → customer-facing OpenAI-compatible API at
-//                              api.<sub>.<parent>/v1
+//     api.<sub>.<parent>/v1
 //   - ingress.adminHost      → ops-staff admin UI at
-//                              admin.<sub>.<parent>
+//     admin.<sub>.<parent>
 //   - auth.adminUI           → mode=keycloak, issuer = per-tenant realm
-//                              (alice's tenant Keycloak), clientId
-//                              "newapi-admin" registered by the tenant
-//                              realm-config (see #910/#915 C1).
+//     (alice's tenant Keycloak), clientId
+//     "newapi-admin" registered by the tenant
+//     realm-config (see #910/#915 C1).
 //   - auth.customerAPI       → keyIssuer=catalyst (Catalyst mints
-//                              per-user bearer keys on signup; the
-//                              upstream's self-serve portal is OFF).
+//     per-user bearer keys on signup; the
+//     upstream's self-serve portal is OFF).
 //   - database.existingSecret → newapi-pg-app — the Secret bp-cnpg's
-//                              CNPG Cluster auto-renders for the
-//                              "newapi" Database (cnpg.enabled=true so
-//                              per-tenant Postgres auto-provisions per
-//                              #943).
+//     CNPG Cluster auto-renders for the
+//     "newapi" Database (cnpg.enabled=true so
+//     per-tenant Postgres auto-provisions per
+//     #943).
 //   - credentials.existingSecret → newapi-credentials — pulled from
-//                              OpenBao via ExternalSecret carrying the
-//                              SESSION_SECRET + CRYPTO_SECRET keys.
+//     OpenBao via ExternalSecret carrying the
+//     SESSION_SECRET + CRYPTO_SECRET keys.
 //   - defaultChannels.qwenPartner → channel #1 = partner-hosted Qwen
-//                              auto-seeded at install time (canonical
-//                              first-otech default per #915 C4 PR #919).
+//     auto-seeded at install time (canonical
+//     first-otech default per #915 C4 PR #919).
 //
 // dependsOn: bp-keycloak (OIDC for admin UI) + bp-cnpg (Postgres
 // backend). Ordering matters — without it the chart's channel-seed
@@ -1133,6 +1165,24 @@ spec:
     - name: bp-cnpg
       namespace: {{.Namespace}}
   values:
+    # MIRROR-EVERYTHING (#3785, Refs #3376 #3761): route BOTH WordPress
+    # images (the main 'wordpress' server + the 'wordpress' wp-cli the
+    # oidc-config Job runs — platform/wordpress-tenant/chart/templates/
+    # _helpers.tpl wordpressImage/wpcliImage) THROUGH the Sovereign Harbor
+    # DockerHub proxy-cache. Without this they default to the raw Docker Hub
+    # 'wordpress' repository, which the harbor-proxy-pull Kyverno
+    # ClusterPolicy (Enforce) DENIES because it doesn't match the
+    # '*/proxy-*/*' glob — so the customer's purchased app NEVER starts (the
+    # funnel's terminal acceptance, #3376). The chart prepends
+    # global.imageRegistry onto each image.repository, so the live Harbor
+    # DockerHub proxy project 'proxy-dockerhub' (NOT 'proxy-docker' — see
+    # platform/openbao/chart/Chart.yaml) renders e.g.
+    # harbor.openova.io/proxy-dockerhub/wordpress:6-php8.3-apache@sha256:...,
+    # which matches the glob. Lockstep with the CNPG image the chart already
+    # proxies via <registry>/proxy-ghcr. Registry host is operator-
+    # overridable (Principle #4) via CATALYST_VCLUSTER_IMAGE_REGISTRY.
+    global:
+      imageRegistry: {{.VClusterImageRegistry}}/proxy-dockerhub
     smeDomain: {{if .IsBYO}}{{.BYODomain}}{{else}}{{.Subdomain}}.{{.ParentDomain}}{{end}}
     # Canonical OIDC block (chart >= 0.2.0).
     oidc:
@@ -1246,7 +1296,7 @@ spec:
 {{- end }}
 `
 
-const smeTenantBPOpenClaw =`# bp-openclaw (#803, #915) — workspace controller pre-wired to the
+const smeTenantBPOpenClaw = `# bp-openclaw (#803, #915) — workspace controller pre-wired to the
 # per-tenant Keycloak realm (SSO) and the per-tenant NewAPI gateway
 # (OpenAI-compatible LLM endpoint, NOT direct OpenAI).
 #

--- a/products/catalyst/bootstrap/api/internal/handler/sme_tenant_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_tenant_test.go
@@ -638,7 +638,7 @@ func TestRenderSMETenantOverlay_NewAPIEmitted(t *testing.T) {
 		"name: bp-newapi",
 		"namespace: sme-t-alice",
 		"chart: bp-newapi",
-		`version: "*"`, // unconfigured chart version falls back to "*"
+		`version: "*"`,    // unconfigured chart version falls back to "*"
 		"name: bp-newapi", // sourceRef.name
 	} {
 		if !strings.Contains(body, want) {
@@ -837,6 +837,50 @@ func TestRenderSMETenantOverlay_WordPressEmitsOIDC(t *testing.T) {
 	// import + Secret materialisation.
 	if !strings.Contains(body, "name: bp-keycloak") {
 		t.Errorf("expected dependsOn bp-keycloak in bp-wordpress-tenant.yaml")
+	}
+}
+
+// #3785 (Refs #3376 #3761) — the WordPress HelmRelease MUST set
+// global.imageRegistry to the Sovereign Harbor DockerHub proxy-cache so the
+// chart's main + wp-cli images (Docker Hub `wordpress`) route through
+// `<registry>/proxy-dockerhub/...` and pass the harbor-proxy-pull Kyverno
+// ClusterPolicy (Enforce). Without this the customer's purchased app is
+// admission-denied and never Runs — the funnel's terminal acceptance.
+func TestRenderSMETenantOverlay_WordPressImageProxiedThroughHarbor(t *testing.T) {
+	rec := store.SMETenantProvisionRecord{
+		SMETenantID:     "t-alice",
+		Subdomain:       "alice",
+		ParentDomain:    "omantel.omani.works",
+		DomainMode:      store.SMEDomainFreeSubdomain,
+		AdminEmail:      "admin@alice.test",
+		CompanyName:     "Alice Corp",
+		OTECHFQDN:       "otech107.omani.works",
+		VClusterName:    "vc-alice",
+		TenantNamespace: "sme-t-alice",
+	}
+
+	// Default registry (env unset) → harbor.openova.io.
+	t.Setenv("CATALYST_VCLUSTER_IMAGE_REGISTRY", "")
+	files, err := renderSMETenantOverlay(rec, SMETenantChartVersions{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := files["bp-wordpress-tenant.yaml"]
+	if !strings.Contains(body, "    global:") ||
+		!strings.Contains(body, "      imageRegistry: harbor.openova.io/proxy-dockerhub") {
+		t.Fatalf("WordPress HR must proxy images via global.imageRegistry harbor.openova.io/proxy-dockerhub\n--- rendered ---\n%s", body)
+	}
+
+	// Operator override (Principle #4) → the post-cutover Harbor host.
+	t.Setenv("CATALYST_VCLUSTER_IMAGE_REGISTRY", "harbor.alice.omantel.omani.works")
+	files2, err := renderSMETenantOverlay(rec, SMETenantChartVersions{})
+	if err != nil {
+		t.Fatalf("render (override): %v", err)
+	}
+	if !strings.Contains(files2["bp-wordpress-tenant.yaml"],
+		"      imageRegistry: harbor.alice.omantel.omani.works/proxy-dockerhub") {
+		t.Errorf("CATALYST_VCLUSTER_IMAGE_REGISTRY override not honoured in WordPress HR\n%s",
+			files2["bp-wordpress-tenant.yaml"])
 	}
 }
 


### PR DESCRIPTION
## Funnel terminal — the next-in-line blocker after #3761

#3761 re-tagged the per-Org **vCluster** images through the Sovereign Harbor proxy-cache so the vCluster StatefulSet passes the `harbor-proxy-pull` Kyverno ClusterPolicy (Enforce). This PR closes the **next** denial one layer down: the customer's **purchased app** (WordPress) image was still raw, so even once the vCluster is up the WordPress Pod is admission-denied and the funnel never reaches its terminal acceptance — #3376's *"the purchased app actually RUNNING"*.

## Root cause (live evidence, hw158)

1. **SME-tenant overlay WordPress HR** — `smeTenantBPWordPress` in `products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go` set **no** `global.imageRegistry`. The `bp-wordpress-tenant` chart then defaults its main + wp-cli (oidc-config Job) images to the Docker Hub `wordpress` repo. On a kyverno-Enforce Sovereign `wordpress:6-php8.3-apache` does **not** match the allowed `*/proxy-*/*` glob → Pod DENIED.
2. **Legacy provisioning-service renderer** — `core/services/provisioning/gitops/gitops.go` `generateAppDeployment` emitted `spec.Image` (e.g. `wordpress:6-apache`) raw. The vCluster syncer schedules the backing Pod on the **HOST** cluster where the policy enforces → same denial.

(The stale `walk-stranger-co` Org's *vCluster* HR is itself still kyverno-denied because the live org-controller runs `42c4213`, the parent of the merged #3761 commit `84aaa65f8` — a deploy bump re-renders `vcluster.yaml` with `proxy-ghcr` and the vCluster comes up. This PR makes the **app** Run once it does.)

## Fix (lockstep with #3761)

- `smeTenantBPWordPress` now sets `global.imageRegistry: <registry>/proxy-dockerhub`, sourced from `CATALYST_VCLUSTER_IMAGE_REGISTRY` (the same env knob the org-controller uses; default `harbor.openova.io`; Principle #4; cutover Step-04 flips it to `harbor.<fqdn>`).
- `generateAppDeployment` routes `spec.Image` through a new `proxyImage()` helper that re-tags per upstream registry: `docker.io→proxy-dockerhub`, `ghcr.io→proxy-ghcr`, `quay.io→proxy-quay`, `gcr.io→proxy-gcr`, `registry.k8s.io→proxy-k8s`. Registries without a Harbor proxy project (e.g. `lscr.io`), empty-mirror, and already-proxied refs pass through unchanged (no regression). `proxy-dockerhub` is the live DockerHub proxy-cache project (NOT `proxy-docker` — per `platform/openbao/chart/Chart.yaml`).

## Validation

- **Helm-render proof** — `helm template bp-wordpress-tenant --set global.imageRegistry=harbor.openova.io/proxy-dockerhub` renders all images through the proxy and **every one matches the kyverno `*/proxy-*/*` glob**:
  - `harbor.openova.io/proxy-dockerhub/wordpress:6-php8.3-apache@sha256:…` (main)
  - `harbor.openova.io/proxy-dockerhub/wordpress:cli-2.12.0-php8.3@sha256:…` (wp-cli Job)
  - `harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1` (healthcheck)
  - CNPG image already used `proxy-ghcr`.
- `go build` + `go test` green for both modules (`services-provisioning`, `catalyst-api`).
- New tests: `proxyImage` table test (every KnownApps registry) + `TestRenderSMETenantOverlay_WordPressImageProxiedThroughHarbor` (default + operator override).

## Honest scope note
This is a **source** fix shipping via image rebuild (`catalyst-api` + `services-provisioning`) — no Helm chart touched, so no chart bump. Full end-to-end *redeem → running app* still needs a fresh prov to validate (and the #3761 org-controller image deployed). Pillar 1 (Marketplace + voucher onboarding) — the funnel terminal.

Refs #3376 #3761 #3785

🤖 Generated with [Claude Code](https://claude.com/claude-code)