### PR TITLE
fix(bootstrap-kit): stop harbor/powerdns oscillation from #3786 (revert 2 slot pins to stable)

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -194,7 +194,7 @@ spec:
       # chart renders the canonical apps.openova.io/v1 Application CR for
       # this slot's HelmRelease so the console /apps list, per-app Topology
       # tab + showback resolve harbor (no more "no Application CR").
-      version: 1.2.31
+      version: 1.2.30
       sourceRef:
         kind: HelmRepository
         name: bp-harbor


### PR DESCRIPTION
harbor 1.2.31 + powerdns 1.2.15 fail their post-upgrade hooks → fail/rollback oscillation degrading the live spine. Revert to stable 1.2.30/1.2.14. The 6 other object-model CR apps are unaffected. Refs #3687