### PR TITLE
fix(sso): newapi + pdns-admin zero-click bare-URL landing (Refs #3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
+++ b/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
@@ -60,7 +60,13 @@ spec:
   chart:
     spec:
       chart: bp-oidc-gate
-      version: 0.1.2
+      # 0.1.3 (#3374, 2026-06-18): rootRedirectPath — the gate 302s ONLY the
+      # bare root (Exact `/`) to an app's native OIDC login path. powerdns-admin
+      # instance below sets rootRedirectPath:/oidc/login so its bare URL starts
+      # PDA's own silent KC round-trip and lands signed-in (hw159: bare URL had
+      # been landing on PDA's /login FORM — zero-click FAIL; PDA ships authlib
+      # OIDC and ignores oauth2-proxy's X-Auth-Request-* headers).
+      version: 0.1.3
       sourceRef:
         kind: HelmRepository
         name: bp-oidc-gate
@@ -119,14 +125,30 @@ spec:
       # (two HTTPRoutes on one hostname is undefined routing — the gate
       # now owns pdns-admin.<fqdn>). pda's /oidc/* login + callback paths
       # are reached THROUGH the gate (oauth2-proxy proxies all non-
-      # /oauth2 paths to the upstream), so the app-native OIDC the gate's
-      # session sits in front of still functions for the in-app login the
-      # first time; subsequent visits ride the gate cookie.
+      # /oauth2 paths to the upstream).
+      #
+      # #3374 (2026-06-18) — rootRedirectPath FIX. PDA ships its OWN OIDC
+      # (authlib), unlike the login-less openova-flow. oauth2-proxy auths
+      # the BROWSER at the gate then proxies path-for-path, so a bare-root
+      # hit reaches PDA's `/`, whose unauthenticated Flask session 302s to
+      # PDA's `/login` FORM with a manual "Sign in using OpenID Connect"
+      # button — a zero-click FAIL (measured live hw159: bare URL landed on
+      # the `/login` form, NOT signed-in). The gate's X-Auth-Request-*
+      # headers don't help; authlib only honours its own /oidc/login→KC
+      # round-trip. FIX: redirect ONLY the bare root (Exact `/`) to PDA's
+      # native `/oidc/login`, so PDA starts its own silent KC round-trip
+      # (kc_idp_hint=catalyst-pin, baked into OIDC_OAUTH_AUTHORIZE_URL) and
+      # lands on /dashboard/ signed-in — zero clicks, two silent KC hops.
+      # Loop-safe (the pda 0.1.11 lesson): only the Exact bare root is
+      # redirected; /oidc/login, /oidc/authorized, /login, /dashboard all
+      # flow through untouched and PDA's post-login lands on /dashboard/
+      # which never revisits `/`. bp-oidc-gate 0.1.3.
       - name: powerdns-admin
         enabled: true
         clientId: powerdns-admin
         hostname: "pdns-admin.${SOVEREIGN_FQDN}"
         upstream: http://powerdns-admin-bp-powerdns-admin.powerdns-admin.svc.cluster.local:80
+        rootRedirectPath: /oidc/login
 
       # ── GENERALITY PROOF (#3374 DoD box 10a) ──────────────────────────
       # A brand-new throwaway app gated with ONLY a name + hostname +

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -259,7 +259,14 @@ spec:
       # chart renders the canonical apps.openova.io/v1 Application CR for
       # this slot's HelmRelease so the console /apps list, per-app Topology
       # tab + showback resolve newapi (no more "no Application CR").
-      version: 1.4.101
+      # 1.4.102 (#3374, 2026-06-18): bridge landing page (sso_init.go) retries
+      # the /api/oauth/state mint (8× / 1.5s backoff) before falling back to
+      # /login, so a fresh-prov NewAPI still warming up (DSN-gate + GORM
+      # migrate) does not dead-end the first bare-URL visit at /setup (hw159:
+      # 1st-hit upstream-connect-error 111, 2nd-hit /setup wizard). Shrinks the
+      # human-visible window; the per-minute CronJob (1.4.97) self-heals the
+      # underlying convergence race.
+      version: 1.4.102
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.101
+  version: 1.4.102
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -679,7 +679,26 @@ name: bp-newapi
 # Application CR for the slot-80 HelmRelease (gated bootstrapOwned.enabled
 # + Capabilities apps.openova.io/v1) so the console /apps list, per-app
 # Topology tab + showback resolve newapi (no more "no Application CR").
-version: 1.4.101
+# 1.4.102 (#3374, 2026-06-18): bridge landing page (sso_init.go) RETRIES the
+# /api/oauth/state mint before falling back to /login. ROOT CAUSE re-walked
+# live on hw159: the bare URL's 1st hit returned an upstream-connect-error
+# (111) and the 2nd hit landed on the /setup "System initialization" wizard
+# instead of signed-in /console. On a fresh prov NewAPI's wait-for-sql-dsn
+# initContainer + GORM AutoMigrate keep the backend unreachable for up to
+# ~2min after the gateway first routes to the bare URL; the prior landing
+# page fell through to /login on the FIRST /api/oauth/state failure and the
+# SPA then showed /setup — the exact symptom. The page now retries the state
+# mint (8× with a 1.5s backoff, same-origin + idempotent) so the FIRST human
+# visit during convergence rides out NewAPI's warm-up and still lands
+# signed-in; if it never recovers it still degrades to /login (no worse than
+# before). The bridge IMAGE tag + a further chart patch bump are
+# auto-committed by build-bp-newapi-sandbox-bridge.yaml on merge (push to
+# internal/handler/**). Lockstep: 80-newapi.yaml pin + blueprint.yaml →
+# 1.4.102. NB: the 1st-hit 111 + /setup-on-2nd-hit are fundamentally a
+# fresh-prov readiness window the per-minute admin-promote CronJob self-heals
+# (#3767, 1.4.97) — this retry shrinks the human-visible window, it is not a
+# new SSO mechanism. Refs #3374.
+version: 1.4.102
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/internal/handler/sso_init.go
+++ b/platform/newapi/internal/handler/sso_init.go
@@ -175,11 +175,29 @@ var ssoInitTemplate = template.Must(template.New("sso-init").Parse(`<!doctype ht
     // 1. Mint the CSRF state (also sets the same-origin session cookie that
     //    NewAPI's /api/oauth/<slug> callback checks). This is the ONLY
     //    runtime dependency and is structurally required.
-    var sr = await fetch("/api/oauth/state", { credentials: "include" });
-    if (!sr.ok) return fallback();
-    var sj = await sr.json();
-    if (!sj || !sj.success || !sj.data) return fallback();
-    var state = sj.data;
+    //
+    // #3374 (2026-06-18) — RETRY before falling back. On a fresh prov NewAPI's
+    // SQL_DSN initContainer + GORM AutoMigrate keep the backend unreachable for
+    // up to ~2min after the gateway first routes here (the bare-URL hit returns
+    // an upstream-connect-error 111 / the /api/oauth/state fetch fails). The
+    // prior code fell through to /login on the FIRST failure, and the NewAPI SPA
+    // then showed the /setup wizard — the exact hw159 symptom (bare URL → /setup
+    // instead of signed-in). A few short retries ride out NewAPI's warm-up so
+    // the FIRST human visit during convergence still lands signed-in instead of
+    // dead-ending at /setup. Same-origin, idempotent; if it never recovers we
+    // still degrade to /login (no worse than before).
+    var state = null;
+    for (var attempt = 0; attempt < 8; attempt++) {
+      try {
+        var sr = await fetch("/api/oauth/state", { credentials: "include" });
+        if (sr.ok) {
+          var sj = await sr.json();
+          if (sj && sj.success && sj.data) { state = sj.data; break; }
+        }
+      } catch (e) { /* NewAPI still warming up — retry */ }
+      await new Promise(function (r) { setTimeout(r, 1500); });
+    }
+    if (!state) return fallback();
     // 2. Build the authorize URL EXACTLY like the SPA does
     //    (web/src/helpers/api.js onCustomOAuthClicked: redirect_uri =
     //    window.location.origin + "/oauth/" + slug) and redirect. The

--- a/platform/newapi/internal/handler/sso_init_test.go
+++ b/platform/newapi/internal/handler/sso_init_test.go
@@ -52,6 +52,12 @@ func TestSSOInitHandler_ServesLandingAtRoot(t *testing.T) {
 		`"newapi-admin"`,   // the injected client_id is present
 		`"/oauth/" + SLUG`, // redirect_uri construction matches the SPA
 		"window.location.replace(url)",
+		// #3374 (2026-06-18) — the /api/oauth/state mint must RETRY (a loop +
+		// setTimeout backoff) so a fresh-prov NewAPI still warming up
+		// (DSN-gate + GORM migrate) does not dead-end the first visit at
+		// /setup. Assert the retry loop + a backoff sleep are present.
+		"attempt < 8",
+		"setTimeout(r, 1500)",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("landing page missing %q", want)

--- a/platform/oidc-gate/blueprint.yaml
+++ b/platform/oidc-gate/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.2
+  version: 0.1.3
   card:
     title: oidc-gate
     summary: |

--- a/platform/oidc-gate/chart/Chart.yaml
+++ b/platform/oidc-gate/chart/Chart.yaml
@@ -32,7 +32,27 @@ name: bp-oidc-gate
 # gate is the single hostname owner. Adding the gate to a NEW app is now
 # one `instances:` entry — proven by the disabled `sso-generality-probe`
 # instance in the slot (#3374 DoD box 10a generality proof).
-version: 0.1.2
+# 0.1.3 (#3374, 2026-06-18): rootRedirectPath — bare-root → app-native
+# OIDC login. 0.1.2's gate coverage of powerdns-admin did NOT achieve
+# zero-click: oauth2-proxy auths the BROWSER at the gate then proxies
+# path-for-path, so a bare-root hit reached PDA's `/`, whose unauth Flask
+# session 302s to PDA's `/login` FORM with a manual "Sign in using
+# OpenID Connect" button (measured live hw159: bare URL landed on the
+# form, zero-click FAIL — a "Sign in with…" button = FAIL per the
+# contract). PDA ships its OWN authlib OIDC (unlike the login-less
+# openova-flow) and ignores oauth2-proxy's X-Auth-Request-* headers,
+# honouring only its own /oidc/login→KC round-trip. New per-instance
+# `rootRedirectPath` (+ optional `rootRedirectPort`, default 443): the
+# gate's HTTPRoute now 302s ONLY the bare root (Exact `/`) to that path
+# (e.g. `/oidc/login`) so the app starts its own SILENT KC round-trip
+# (kc_idp_hint=catalyst-pin) and lands signed-in — zero clicks, two
+# silent KC hops. Loop-safe (the pda 0.1.11 lesson): only the Exact bare
+# root is redirected; the app's login/callback/dashboard paths flow
+# through untouched and the post-login lands on /dashboard/, never
+# revisiting `/`. Default unset → byte-identical to a login-less gated
+# app (openova-flow renders no redirect rule). Slot 13c sets
+# rootRedirectPath:/oidc/login on the powerdns-admin instance.
+version: 0.1.3
 appVersion: "7.6.0"
 description: |
   Catalyst generic OIDC gate — a per-app oauth2-proxy instance set that

--- a/platform/oidc-gate/chart/templates/instances.yaml
+++ b/platform/oidc-gate/chart/templates/instances.yaml
@@ -262,6 +262,50 @@ spec:
   hostnames:
     - {{ $hostname | quote }}
   rules:
+{{- if $inst.rootRedirectPath }}
+{{- /*
+#3374 Layer-A (powerdns-admin) — bare-root → app-native OIDC login path.
+
+WHY THIS IS NEEDED for an app that ships its OWN OIDC (pda-legacy authlib),
+not just a login-less binary (openova-flow). oauth2-proxy authenticates the
+BROWSER at the gate (zero-click via kc_idp_hint) and then PROXIES path-for-
+path to the upstream — it does NOT rewrite `/`. So a bare-root hit reaches
+PDA's `/`, which (PDA's Flask session being unauthenticated, separate from
+the gate cookie) 302s to PDA's `/login` FORM with a manual "Sign in using
+OpenID Connect" button. The operator then sees a login form = the zero-click
+contract FAILS (measured live on hw159, #3374). oauth2-proxy's
+X-Auth-Request-* headers don't help — pda-legacy's authlib consumes only its
+own `/oidc/login`→KC round-trip, never header-asserted identity.
+
+FIX: redirect ONLY the bare root (Exact `/`) to the app's native OIDC login
+entrypoint (rootRedirectPath, e.g. `/oidc/login`). The chain then is:
+  bare `/` → (gate 302) → `/oidc/login` → (gate proxies, browser already
+  gate-authed silently) → PDA `/oidc/login` → KC (silent, kc_idp_hint) →
+  PDA `/oidc/authorized` → PDA session → `/login` authed-guard → `/dashboard`.
+Two silent KC round-trips, ZERO clicks.
+
+LOOP-SAFE (the pda 0.1.11 lesson, exactly): the redirect fires ONLY on the
+Exact bare root; `/oidc/login`, `/oidc/authorized`, `/login` and `/dashboard`
+all flow through the catch-all backend untouched, and PDA's post-login lands
+on `/dashboard/` which NEVER revisits `/`. An OIDC error degrades to PDA's
+visible form, never a redirect loop. Gateway API matches the most-specific
+path (Exact `/` here) ahead of the PathPrefix `/` catch-all regardless of
+rule order, so this rule wins for the bare root and ONLY the bare root.
+Default unset → byte-identical to a login-less gated app (openova-flow).
+*/}}
+    - matches:
+        - path:
+            type: Exact
+            value: /
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            port: {{ $inst.rootRedirectPort | default 443 }}
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: {{ $inst.rootRedirectPath | quote }}
+            statusCode: 302
+{{- end }}
     - matches:
         - path:
             type: PathPrefix

--- a/platform/oidc-gate/chart/tests/root-redirect-render.sh
+++ b/platform/oidc-gate/chart/tests/root-redirect-render.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# bp-oidc-gate — #3374 rootRedirectPath render audit.
+#
+# An app that ships its OWN OIDC (pda-legacy authlib) cannot be made
+# zero-click by oauth2-proxy alone: the proxy auths the BROWSER at the gate
+# then proxies path-for-path, so a bare-root hit reaches the app's `/`, whose
+# unauthenticated app-session 302s to the app's OWN /login FORM (a manual
+# "Sign in with…" button = zero-click FAIL, measured live hw159). The
+# per-instance `rootRedirectPath` makes the gate 302 ONLY the bare root
+# (Exact `/`) to the app's native OIDC login entrypoint so the app starts its
+# own silent KC round-trip and lands signed-in.
+#
+# This test asserts:
+#   1. an instance WITH rootRedirectPath renders an Exact `/` RequestRedirect
+#      to that path (port 443 default) AHEAD of the PathPrefix `/` backend;
+#   2. an instance WITHOUT it renders NO redirect (byte-identical to a
+#      login-less gated app — only the PathPrefix `/` backend);
+#   3. rootRedirectPort overrides the redirect port.
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+vals="$(mktemp)"
+trap 'rm -f "$vals"' EXIT
+cat >"$vals" <<'YAML'
+sovereignFQDN: smoke.example.com
+realm: sovereign
+instances:
+  # login-less app — NO rootRedirectPath (control)
+  - name: flowless
+    enabled: true
+    clientId: flowless
+    upstream: http://flowless.default.svc.cluster.local:80
+  # app with native OIDC — rootRedirectPath set
+  - name: pda
+    enabled: true
+    clientId: pda
+    hostname: pdns-admin.smoke.example.com
+    upstream: http://pda.default.svc.cluster.local:80
+    rootRedirectPath: /oidc/login
+  # custom redirect port
+  - name: customport
+    enabled: true
+    clientId: customport
+    upstream: http://customport.default.svc.cluster.local:80
+    rootRedirectPath: /sso/start
+    rootRedirectPort: 8443
+YAML
+
+out="$("$helm" template oidc-gate "$chart_dir" -f "$vals" 2>/dev/null)"
+
+# Split into per-document chunks so we can scope assertions to one HTTPRoute.
+route_doc() {
+  # prints the HTTPRoute document whose metadata.name == oidc-gate-<arg>
+  echo "$out" | awk -v want="oidc-gate-$1" '
+    BEGIN{RS="\n---\n"}
+    /kind: HTTPRoute/ && $0 ~ ("name: \"?" want "\"?") {print}'
+}
+
+# ── Case 1: pda gets the Exact / -> /oidc/login redirect ────────────────────
+echo "[root-redirect] Case 1: pda renders Exact / RequestRedirect to /oidc/login"
+pda="$(route_doc pda)"
+if [ -z "$pda" ]; then echo "FAIL: no HTTPRoute oidc-gate-pda rendered" >&2; echo "$out" >&2; exit 1; fi
+echo "$pda" | grep -qE 'type:\s*Exact'                       || { echo "FAIL: pda missing Exact path match" >&2; echo "$pda" >&2; exit 1; }
+echo "$pda" | grep -qE 'type:\s*RequestRedirect'             || { echo "FAIL: pda missing RequestRedirect filter" >&2; echo "$pda" >&2; exit 1; }
+echo "$pda" | grep -qE 'replaceFullPath:\s*"?/oidc/login"?'  || { echo "FAIL: pda redirect not to /oidc/login" >&2; echo "$pda" >&2; exit 1; }
+echo "$pda" | grep -qE 'port:\s*443'                         || { echo "FAIL: pda redirect not on default port 443" >&2; echo "$pda" >&2; exit 1; }
+echo "$pda" | grep -qE 'statusCode:\s*302'                   || { echo "FAIL: pda redirect not 302" >&2; echo "$pda" >&2; exit 1; }
+echo "  PASS"
+
+# ── Case 2: flowless (no rootRedirectPath) renders NO redirect ──────────────
+echo "[root-redirect] Case 2: flowless renders NO redirect (only PathPrefix backend)"
+flowless="$(route_doc flowless)"
+if [ -z "$flowless" ]; then echo "FAIL: no HTTPRoute oidc-gate-flowless rendered" >&2; exit 1; fi
+if echo "$flowless" | grep -qE 'RequestRedirect|type:\s*Exact'; then
+  echo "FAIL: flowless (no rootRedirectPath) should NOT render a redirect" >&2; echo "$flowless" >&2; exit 1
+fi
+echo "$flowless" | grep -qE 'type:\s*PathPrefix' || { echo "FAIL: flowless missing PathPrefix backend" >&2; exit 1; }
+echo "  PASS"
+
+# ── Case 3: rootRedirectPort override ───────────────────────────────────────
+echo "[root-redirect] Case 3: customport honours rootRedirectPort: 8443"
+cp="$(route_doc customport)"
+echo "$cp" | grep -qE 'replaceFullPath:\s*"?/sso/start"?' || { echo "FAIL: customport redirect path wrong" >&2; echo "$cp" >&2; exit 1; }
+echo "$cp" | grep -qE 'port:\s*8443'                      || { echo "FAIL: customport did not honour rootRedirectPort 8443" >&2; echo "$cp" >&2; exit 1; }
+echo "  PASS"
+
+echo "[bp-oidc-gate #3374 rootRedirectPath] All cases PASS"

--- a/platform/oidc-gate/chart/values.yaml
+++ b/platform/oidc-gate/chart/values.yaml
@@ -56,4 +56,17 @@ resources:
 #     skipAuthRoutes: []            # oauth2-proxy --skip-auth-route
 #                                   # entries (METHOD=^path-regex)
 #     replicas: 1
+#     # rootRedirectPath (#3374 Layer-A): for an app that ships its OWN OIDC
+#     # (e.g. pda-legacy authlib) — NOT a login-less binary. oauth2-proxy
+#     # authenticates the browser at the gate then proxies path-for-path, so a
+#     # bare-root hit reaches the app's `/` which 302s to the app's OWN login
+#     # FORM (a manual "Sign in with…" button = zero-click FAIL, measured live
+#     # hw159). Set this to the app's native OIDC login entrypoint (e.g.
+#     # `/oidc/login`) and the gate 302s ONLY the bare root (Exact `/`) there,
+#     # so the app starts its own silent KC round-trip and lands signed-in with
+#     # zero clicks. Loop-safe: only the Exact bare root is redirected; the
+#     # app's login/callback/dashboard paths flow through untouched. Default
+#     # unset → no root redirect (byte-identical to a login-less app).
+#     rootRedirectPath: ""          # e.g. "/oidc/login"
+#     rootRedirectPort: 443         # the Sovereign HTTPS listener port
 instances: []


### PR DESCRIPTION
## What

Fixes the **2 remaining `❌` SSO rows** walked live on hw159 (#3374 A4 bucket — guacamole was already ✅):

1. **pdns-admin** (`pdns-admin.hw159.omani.works`): bare URL → `/login` form with a manual **"Sign in using OpenID Connect"** button (no silent SSO). A "Sign in with…" button = FAIL per the zero-login contract.
2. **newapi** (`newapi.hw159.omani.works`): bare URL → `/setup` first-run wizard; 1st hit also threw `upstream-connect-error … delayed connect error: 111`.

## Root cause + fix — pdns-admin (chart/config bug, fixed)

Since **#3374 Layer-A** the generic `bp-oidc-gate` (slot 13c) OWNS `pdns-admin.<fqdn>` and pda's own HTTPRoute is disabled (slot 11a `gateway.enabled=false`). But the gate did **not** achieve zero-click:

- oauth2-proxy authenticates the **browser** at the gate (silent, `kc_idp_hint=catalyst-pin`) then proxies **path-for-path** to the upstream — it does **not** rewrite `/`.
- So a bare-root hit reaches PDA's `/`, whose **unauthenticated Flask session** 302s to PDA's `/login` **form**. PDA ships its OWN authlib OIDC (unlike the login-less `openova-flow`) and **ignores** oauth2-proxy's `X-Auth-Request-*` headers — it honours only its own `/oidc/login`→KC round-trip. → the operator sees a login form (the hw159 symptom).

**Fix:** new per-instance **`rootRedirectPath`** in `bp-oidc-gate` (0.1.3). The gate's HTTPRoute now 302s **ONLY the bare root** (`Exact /`) to the app's native OIDC login path. Slot 13c sets `rootRedirectPath: /oidc/login` on the pda instance.

Chain (zero clicks, two silent KC hops):
```
bare /  → (gate 302) → /oidc/login → (gate proxies; browser silently gate-authed)
        → PDA /oidc/login → KC silent (kc_idp_hint=catalyst-pin)
        → PDA /oidc/authorized → PDA session → /dashboard/
```
**Loop-safe** (the pda 0.1.11 lesson, exactly): only the `Exact` bare root is redirected; `/oidc/login`, `/oidc/authorized`, `/login`, `/dashboard` flow through untouched and the post-login lands on `/dashboard/`, which never revisits `/`. Default unset → **byte-identical** to a login-less gated app (`openova-flow` renders no redirect rule).

## Root cause + fix — newapi (readiness window, shrunk — honestly not a new SSO mechanism)

The newapi chart machinery is already **complete + correct**: `wait-for-sql-dsn` initContainer, `admin-sso-seed` Job, per-minute reload/promote CronJob (#3767), and the bridge landing page. The **1st-hit `111` + 2nd-hit `/setup`** are a **fresh-prov convergence race**: NewAPI's DSN-gate + GORM AutoMigrate keep the backend unreachable for up to ~2 min after the gateway first routes to the bare URL, and the landing page (`sso_init.go`) fell through to `/login` on the **first** `/api/oauth/state` failure → the SPA showed `/setup`.

**Fix:** the bridge landing page now **retries** the state mint (8× / 1.5 s backoff, same-origin + idempotent) so the first human visit *during* convergence rides out NewAPI's warm-up; it still degrades to `/login` if it never recovers. This **shrinks the human-visible window** — the per-minute CronJob already self-heals the underlying race. **No new SSO mechanism**, just resilience over a known readiness window.

## Render / test proof — all `exit 0` / PASS

- `helm template platform/oidc-gate/chart` (pda instance) → `Exact /` 302 → `/oidc/login` renders **ahead of** the `PathPrefix /` backend; `openova-flow` (no `rootRedirectPath`) renders **NO** redirect (byte-identical); default empty `instances` → **0 resources** (fail-closed preserved).
- **NEW** `platform/oidc-gate/chart/tests/root-redirect-render.sh` → 3 cases PASS (redirect renders / control renders no redirect / `rootRedirectPort` override).
- `helm template platform/newapi/chart` + `platform/powerdns-admin/chart` → exit 0.
- `platform/newapi/internal/handler` `go test ./...` + `go vet` → PASS.
- existing `pdns-admin/g117-w3d1-kc-idp-hint.sh` + `newapi/httproute-render.sh` → PASS (no regression).

## Versions (independent publish — safe)

- `bp-oidc-gate` 0.1.2 → **0.1.3** (Chart.yaml + blueprint.yaml + slot 13c pin)
- `bp-newapi` 1.4.101 → **1.4.102** (Chart.yaml + blueprint.yaml + slot 80 pin)
- `products/catalyst/chart/Chart.yaml` **untouched** (per task).

The bridge image rebuild + its further chart-patch bump are auto-committed by `build-bp-newapi-sandbox-bridge.yaml` on merge (push to `internal/handler/**`).

## Acceptance (post fresh-prov re-walk)

Both bare URLs land signed-in: pdns-admin → `/dashboard/` (no `/login` form, no manual button); newapi → `/console` (no `/setup` wizard).

Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)