### PR TITLE
fix(#3642): NS#1 — land the 7 host apps IN the mgmt vCluster (vcluster 0.23 fromHost.secrets + host-bridge, integrated) [DO NOT MERGE — needs fresh-prov walk]

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -83,8 +83,9 @@ spec:
     # ordering puts cutover after these two come up.
     # G92.3 #2662 (2026-06-01): both HRs moved to host ns `mgmt`.
     - name: bp-gitea
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-harbor
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     # NB on issue #1871 (TBD-A24 cutover↔gateway circular deadlock):
     # PR #1875 initially added `- name: sovereign-tls` to this list.
     # That fix was UNRESOLVABLE in Flux: HelmRelease.dependsOn can

--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -39,7 +39,7 @@ metadata:
   # longer needs to colocate with vc-mgmt. Reverting also restores
   # the Helm valuesFrom lookup of secrets like 'object-storage'
   # (cloud-init seeds it in flux-system; lookup is in HR's own ns).
-  namespace: flux-system
+  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
     catalyst.openova.io/slot: "08"
     catalyst.openova.io/vcluster: mgmt
@@ -47,6 +47,12 @@ spec:
   interval: 15m
   releaseName: openbao
   targetNamespace: openbao
+  storageNamespace: openbao
+  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   # G105-followup #2697 (2026-06-01) — G92.2 #2661 placement REVERTED.
   # Same rationale as 09-keycloak: vCluster lacks ExternalSecret + the
   # mgmt namespace inside itself for Helm release storage. Caught live
@@ -55,6 +61,10 @@ spec:
   # Application-controller G92.1 Blueprint-layer pivot stays; slot-level
   # forcing removed until vCluster CRD sync ships.
   dependsOn:
+    # bp-mgmt-vcluster MUST be Ready first — the vc-mgmt
+    # Secret doesn't exist until then. placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+    - name: bp-mgmt-vcluster
+      namespace: flux-system
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template at
     # platform/openbao/chart/templates/httproute.yaml; the
     # gateway.networking.k8s.io/v1 CRDs MUST be registered before this
@@ -171,6 +181,7 @@ spec:
         name: bp-openbao
         namespace: flux-system
     gateway:
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       host: bao.${SOVEREIGN_FQDN}
     # G91.openbao (#2655) — wire bp-sso-bridge framework. The chart-side
     # continuous reconciler Deployment computes OIDC discovery + redirect
@@ -267,3 +278,109 @@ spec:
       primaryRegion: '${SOVEREIGN_PRIMARY_REGION:-}'
       standbyRegion: '${SOVEREIGN_REPLICA_REGION:-}'
       pdmZone: ${SOVEREIGN_FQDN}
+
+# ── HOST-BRIDGE BEGIN (#3642) — placement-generated host-side route/secret/CNPG; edit placement.yaml hostBridge: + run scripts/render-slot-placement.py fix ──
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: openbao
+  namespace: mgmt
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  parentRefs:
+  - name: cilium-gateway
+    namespace: kube-system
+  hostnames:
+  - bao.${SOVEREIGN_FQDN}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /sso/landing
+    backendRefs:
+    - name: openbao-sso-landing-x-openbao-x-mgmt-vcluster
+      namespace: mgmt
+      port: 80
+  - matches:
+    - path:
+        type: Exact
+        value: /
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: bao.${SOVEREIGN_FQDN}
+        port: 443
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /sso/landing
+        statusCode: 302
+  - matches:
+    - path:
+        type: Exact
+        value: /ui
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: bao.${SOVEREIGN_FQDN}
+        port: 443
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /sso/landing
+        statusCode: 302
+  - matches:
+    - path:
+        type: Exact
+        value: /ui/
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: bao.${SOVEREIGN_FQDN}
+        port: 443
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /sso/landing
+        statusCode: 302
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: openbao-x-openbao-x-mgmt-vcluster
+      namespace: mgmt
+      port: 8200
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: openbao-sso-oidc-credentials
+  namespace: openbao
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    bp-sso-bridge.openova.io/consumer: bp-openbao
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-region1
+    kind: ClusterSecretStore
+  target:
+    name: openbao-sso-oidc-credentials
+    creationPolicy: Owner
+  data:
+  - secretKey: client_id
+    remoteRef:
+      key: sso/openbao
+      property: client_id
+  - secretKey: client_secret
+    remoteRef:
+      key: sso/openbao
+      property: client_secret
+  - secretKey: issuer_url
+    remoteRef:
+      key: sso/openbao
+      property: issuer_url
+# ── HOST-BRIDGE END (#3642) ──

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -39,7 +39,7 @@ metadata:
   # longer needs to colocate with vc-mgmt. Reverting also restores
   # the Helm valuesFrom lookup of secrets like 'object-storage'
   # (cloud-init seeds it in flux-system; lookup is in HR's own ns).
-  namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
     catalyst.openova.io/slot: "09"
     catalyst.openova.io/vcluster: mgmt
@@ -47,6 +47,12 @@ spec:
   interval: 15m
   releaseName: keycloak
   targetNamespace: keycloak
+  storageNamespace: keycloak
+  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
   dependsOn:
     # bp-mgmt-vcluster MUST be Ready first — the vc-mgmt
@@ -260,6 +266,7 @@ spec:
     # removed the whole block — chart renders NO HTTPRoute without
     # gateway.host (auth.<fqdn> 404'd live).
     gateway:
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       host: auth.${SOVEREIGN_FQDN}
     # ── Shared-instance flip (#3188 three-instance model) ───────────────
     # Default OWN_CLUSTER=true → the bundled bitnami postgresql subchart
@@ -304,3 +311,43 @@ spec:
         database: keycloak
         existingSecret: keycloak-database-secret
         existingSecretPasswordKey: password
+
+# ── HOST-BRIDGE BEGIN (#3642) — placement-generated host-side route/secret/CNPG; edit placement.yaml hostBridge: + run scripts/render-slot-placement.py fix ──
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: keycloak
+  namespace: mgmt
+  labels:
+    catalyst.openova.io/blueprint: bp-keycloak
+    catalyst.openova.io/component: keycloak
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  parentRefs:
+  - name: cilium-gateway
+    namespace: kube-system
+  hostnames:
+  - auth.${SOVEREIGN_FQDN}
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        port: 443
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /admin/${SOVEREIGN_REALM_NAME:=sovereign}/console/
+        statusCode: 302
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: keycloak-x-keycloak-x-mgmt-vcluster
+      namespace: mgmt
+      port: 80
+# ── HOST-BRIDGE END (#3642) ──

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -40,7 +40,7 @@ metadata:
   # longer needs to colocate with vc-mgmt. Reverting also restores
   # the Helm valuesFrom lookup of secrets like 'object-storage'
   # (cloud-init seeds it in flux-system; lookup is in HR's own ns).
-  namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
     catalyst.openova.io/slot: "10"
     catalyst.openova.io/vcluster: mgmt
@@ -48,6 +48,12 @@ spec:
   interval: 15m
   releaseName: gitea
   targetNamespace: gitea
+  storageNamespace: gitea
+  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
   dependsOn:
     # bp-mgmt-vcluster MUST be Ready first — the vc-mgmt
@@ -187,6 +193,7 @@ spec:
     # chart values short-circuits the configure-oauth Job; the envsubst
     # below makes SSO work zero-touch on every fresh Sovereign.
     sso:
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       sovereignFqdn: ${SOVEREIGN_FQDN}
     # G87 #2634 (2026-06-01): multi-region Sovereigns default CNPG
     # instances to 2 so the operator spreads across regions via
@@ -203,7 +210,7 @@ spec:
         # and its DB host points at the shared cluster's -rw Service. The
         # `gitea` Database + role + reflected gitea-database-secret are
         # provisioned by the shared bp-postgres instance (slot 16a).
-        enabled: ${SOVEREIGN_GITEA_PG_OWN_CLUSTER:=true}
+        enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     # Per-Sovereign overrides — issue #387:
     # Cilium Gateway HTTPRoute exposes Gitea at gitea.${SOVEREIGN_FQDN}.
     # Upstream chart's own Ingress is disabled (gitea.ingress.enabled=false
@@ -212,6 +219,7 @@ spec:
       host: gitea.${SOVEREIGN_FQDN}
     # Restored 2026-06-13 (same #3373/#3391 shape as slot 09).
     gateway:
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       host: gitea.${SOVEREIGN_FQDN}
     # DoD D25 (t129 2026-05-16): override the chart's baked dev hostname
     # `gitea.catalyst.local` so the Gitea Web UI renders the LIVE
@@ -257,3 +265,144 @@ spec:
               secretKeyRef:
                 name: ${SOVEREIGN_GITEA_PG_SECRET:=gitea-pg-app}
                 key: password
+
+# ── HOST-BRIDGE BEGIN (#3642) — placement-generated host-side route/secret/CNPG; edit placement.yaml hostBridge: + run scripts/render-slot-placement.py fix ──
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gitea
+  namespace: mgmt
+  labels:
+    catalyst.openova.io/blueprint: bp-gitea
+    catalyst.openova.io/component: gitea
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  parentRefs:
+  - name: cilium-gateway
+    namespace: kube-system
+  hostnames:
+  - gitea.${SOVEREIGN_FQDN}
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /user/login
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        port: 443
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /user/oauth2/openova-sso
+        statusCode: 302
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: gitea-http-x-gitea-x-mgmt-vcluster
+      namespace: mgmt
+      port: 3000
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: gitea-oauth-source-credentials
+  namespace: gitea
+  labels:
+    catalyst.openova.io/blueprint: bp-gitea
+    bp-sso-bridge.openova.io/consumer: bp-gitea
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-region1
+    kind: ClusterSecretStore
+  target:
+    name: gitea-oauth-source-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          catalyst.openova.io/blueprint: bp-gitea
+          bp-sso-bridge.openova.io/consumer: bp-gitea
+      data:
+        key: '{{ .client_id }}'
+        secret: '{{ .client_secret }}'
+        issuer_url: '{{ .issuer_url }}'
+        authorize_url: '{{ .authorize_url }}?kc_idp_hint=catalyst-pin'
+        token_url: '{{ .token_url }}'
+        userinfo_url: '{{ .userinfo_url }}'
+  data:
+  - secretKey: client_id
+    remoteRef:
+      key: sso/gitea
+      property: client_id
+  - secretKey: client_secret
+    remoteRef:
+      key: sso/gitea
+      property: client_secret
+  - secretKey: issuer_url
+    remoteRef:
+      key: sso/gitea
+      property: issuer_url
+  - secretKey: authorize_url
+    remoteRef:
+      key: sso/gitea
+      property: authorize_url
+  - secretKey: token_url
+    remoteRef:
+      key: sso/gitea
+      property: token_url
+  - secretKey: userinfo_url
+    remoteRef:
+      key: sso/gitea
+      property: userinfo_url
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: gitea-pg
+  namespace: gitea
+  labels:
+    catalyst.openova.io/blueprint: bp-gitea
+    catalyst.openova.io/component: gitea
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  instances: 1
+  imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16
+  bootstrap:
+    initdb:
+      database: gitea
+      owner: gitea
+  managed:
+    roles:
+    - name: gitea
+      ensure: present
+      login: true
+      passwordSecret:
+        name: gitea-pg-app
+  inheritedMetadata:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: 'true'
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: gitea
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: 'true'
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: gitea
+  postgresql:
+    parameters:
+      max_connections: '100'
+      shared_buffers: 64MB
+      effective_cache_size: 192MB
+      work_mem: 4MB
+      maintenance_work_mem: 64MB
+      log_statement: ddl
+      log_min_duration_statement: '1000'
+  storage:
+    size: 5Gi
+    storageClass: local-path
+  enableSuperuserAccess: true
+  monitoring:
+    enablePodMonitor: false
+# ── HOST-BRIDGE END (#3642) ──

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -62,7 +62,7 @@ spec:
       namespace: flux-system
     # bp-keycloak now lives in flux-system (G105-followup #2697).
     - name: bp-keycloak
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template;
     # gateway.networking.k8s.io/v1 CRDs must be registered first.
     - name: bp-gateway-api

--- a/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
+++ b/clusters/_template/bootstrap-kit/11a-bp-powerdns-admin.yaml
@@ -85,7 +85,7 @@ spec:
       namespace: flux-system
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-sso-bridge
       namespace: flux-system
     - name: bp-external-secrets-stores

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -64,7 +64,7 @@ spec:
       namespace: flux-system
     # G92.3 #2662 (2026-06-01): bp-gitea HR moved to host ns `mgmt`.
     - name: bp-gitea
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     # bp-gateway-api (issue #503): umbrella chart ships catalyst-ui +
     # catalyst-api HTTPRoute templates; gateway.networking.k8s.io/v1
     # CRDs must be registered first.

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -81,7 +81,7 @@ spec:
     # the umbrella install, eliminating the race.
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-cnpg
       namespace: flux-system
     # bp-crossplane-claims (chart-roll-rca iter-15, 2026-05-10): owns the

--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -72,7 +72,7 @@ spec:
     # reconcile once catalyst-api is up. So sso-bridge runs early, writes
     # sso/<app>, and gitea/catalyst-platform install behind it.
     - name: bp-keycloak
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-openbao
       namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   chart:

--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -74,6 +74,7 @@ spec:
     - name: bp-keycloak
       namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-openbao
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   chart:
     spec:
       chart: bp-sso-bridge

--- a/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
+++ b/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
@@ -55,7 +55,7 @@ spec:
   dependsOn:
     - name: bp-cilium
     - name: bp-keycloak
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-external-secrets-stores
   chart:
     spec:

--- a/clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml
+++ b/clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml
@@ -48,6 +48,7 @@ spec:
     - name: bp-external-secrets
     # G92.2 #2661 (2026-06-01): bp-openbao HR moved to host ns `mgmt`.
     - name: bp-openbao
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   chart:
     spec:
       chart: bp-external-secrets-stores

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -81,7 +81,7 @@ metadata:
   # longer needs to colocate with vc-mgmt. Reverting also restores
   # the Helm valuesFrom lookup of secrets like 'object-storage'
   # (cloud-init seeds it in flux-system; lookup is in HR's own ns).
-  namespace: flux-system
+  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
     catalyst.openova.io/slot: "19"
     catalyst.openova.io/vcluster: mgmt
@@ -97,6 +97,12 @@ spec:
   interval: 1m
   releaseName: harbor
   targetNamespace: harbor
+  storageNamespace: harbor
+  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   # G105-followup #2697 (2026-06-01) — G92.3 #2662 placement REVERTED.
   # vCluster lacks Gateway API + ExternalSecret CRDs + the mgmt
   # namespace inside itself. App installs on HOST until vCluster CRD
@@ -273,6 +279,7 @@ spec:
         name: bp-harbor
         namespace: flux-system
     gateway:
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       host: registry.${SOVEREIGN_FQDN}
       # #3150 (2026-06-09): the chart's HTTPRoute backend defaults to
       # `harbor-core`, but harbor-core is the API backend — it returns 404 for
@@ -285,6 +292,7 @@ spec:
     # post-install Job PUTs /api/v2.0/configurations with
     # auth_mode=oidc_auth + oidc_endpoint computed from sovereignFqdn.
     sso:
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       sovereignFqdn: ${SOVEREIGN_FQDN}
     # G87 #2634: multi-region CNPG instances default (1 single-region, 2 multi).
     postgres:
@@ -299,7 +307,7 @@ spec:
         # Service. The `registry` Database + role + reflected
         # harbor-database-secret are provisioned by the shared bp-postgres
         # instance (slot 16a).
-        enabled: ${SOVEREIGN_HARBOR_PG_OWN_CLUSTER:=true}
+        enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     objectStorage:
       enabled: true
       useExistingSecret: false
@@ -330,3 +338,100 @@ spec:
             v4auth: true
             secure: true
             storageclass: STANDARD
+
+# ── HOST-BRIDGE BEGIN (#3642) — placement-generated host-side route/secret/CNPG; edit placement.yaml hostBridge: + run scripts/render-slot-placement.py fix ──
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: harbor
+  namespace: mgmt
+  labels:
+    catalyst.openova.io/blueprint: bp-harbor
+    catalyst.openova.io/component: harbor
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  parentRefs:
+  - name: cilium-gateway
+    namespace: kube-system
+  hostnames:
+  - registry.${SOVEREIGN_FQDN}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: harbor-x-harbor-x-mgmt-vcluster
+      namespace: mgmt
+      port: 80
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: harbor-sso-oidc-credentials
+  namespace: harbor
+  labels:
+    catalyst.openova.io/blueprint: bp-harbor
+    bp-sso-bridge.openova.io/consumer: bp-harbor
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-region1
+    kind: ClusterSecretStore
+  target:
+    name: harbor-sso-oidc-credentials
+    creationPolicy: Owner
+  data:
+  - secretKey: client_id
+    remoteRef:
+      key: sso/harbor
+      property: client_id
+  - secretKey: client_secret
+    remoteRef:
+      key: sso/harbor
+      property: client_secret
+  - secretKey: issuer_url
+    remoteRef:
+      key: sso/harbor
+      property: issuer_url
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: harbor-pg
+  namespace: harbor
+  labels:
+    catalyst.openova.io/blueprint: bp-harbor
+    catalyst.openova.io/component: harbor
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  instances: 1
+  imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16
+  bootstrap:
+    initdb:
+      database: registry
+      owner: harbor
+  inheritedMetadata:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: 'true'
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: harbor
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: 'true'
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: harbor
+  postgresql:
+    parameters:
+      max_connections: '100'
+      shared_buffers: 64MB
+      effective_cache_size: 192MB
+      work_mem: 4MB
+      maintenance_work_mem: 64MB
+      log_statement: ddl
+      log_min_duration_statement: '1000'
+  storage:
+    size: 5Gi
+    storageClass: local-path
+  enableSuperuserAccess: true
+  monitoring:
+    enablePodMonitor: false
+# ── HOST-BRIDGE END (#3642) ──

--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -108,7 +108,7 @@ spec:
     # flux-system), wedging bp-sandbox at "unable to get 'rtz/bp-harbor'
     # dependency" and holding the bootstrap-kit health gate forever.
     - name: bp-harbor
-      namespace: flux-system
+      namespace: mgmt
     # #3098 (2026-06-08, hw100): the sandbox chart ships an
     # externalsecret.external-secrets.io resource
     # (platform/sandbox/chart/templates/sso-oauth-source-externalsecret.yaml,

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -46,15 +46,26 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-grafana
-  namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
+    catalyst.openova.io/vcluster: mgmt
     catalyst.openova.io/slot: "25"
 spec:
   interval: 15m
   timeout: 15m
   releaseName: grafana
   targetNamespace: grafana
+  storageNamespace: grafana
+  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   dependsOn:
+    # bp-mgmt-vcluster MUST be Ready first — the vc-mgmt
+    # Secret doesn't exist until then. placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+    - name: bp-mgmt-vcluster
+      namespace: flux-system
     - name: bp-cnpg
       namespace: flux-system
     # #2745 (2026-06-12): bp-loki/bp-mimir/bp-tempo HRs re-homed to host
@@ -70,7 +81,7 @@ spec:
       namespace: mgmt
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template;
     # gateway.networking.k8s.io/v1 CRDs must be registered first.
     - name: bp-gateway-api
@@ -134,6 +145,7 @@ spec:
         name: bp-grafana
         namespace: flux-system
   install:
+    createNamespace: true  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     timeout: 15m
     disableWait: true
     remediation:
@@ -159,6 +171,7 @@ spec:
         name: bp-grafana
         namespace: flux-system
     gateway:
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       host: grafana.${SOVEREIGN_FQDN}
     # G91.grafana (#2658) — wire bp-sso-bridge framework. The chart-side
     # grafana.ini.auth.generic_oauth block computes auth_url / token_url /
@@ -167,6 +180,7 @@ spec:
     # half-config); with the envsubst SSO works zero-touch on every
     # fresh Sovereign.
     sso:
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       sovereignFqdn: ${SOVEREIGN_FQDN}
       # #3374 (2026-06-14): grafana consumes its OIDC secret as DIRECT env
       # vars via `grafana.envFromSecret: grafana-sso-oidc-credentials`, so it
@@ -208,3 +222,79 @@ spec:
       envFromSecrets:
         - name: grafana-database-env
           optional: ${SOVEREIGN_GRAFANA_DB_SECRET_OPTIONAL:=true}
+
+# ── HOST-BRIDGE BEGIN (#3642) — placement-generated host-side route/secret/CNPG; edit placement.yaml hostBridge: + run scripts/render-slot-placement.py fix ──
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grafana
+  namespace: mgmt
+  labels:
+    catalyst.openova.io/blueprint: bp-grafana
+    catalyst.openova.io/component: grafana
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  parentRefs:
+  - name: cilium-gateway
+    namespace: kube-system
+  hostnames:
+  - grafana.${SOVEREIGN_FQDN}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: grafana-x-grafana-x-mgmt-vcluster
+      namespace: mgmt
+      port: 80
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-sso-oidc-credentials
+  namespace: grafana
+  labels:
+    catalyst.openova.io/blueprint: bp-grafana
+    bp-sso-bridge.openova.io/consumer: bp-grafana
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-region1
+    kind: ClusterSecretStore
+  target:
+    name: grafana-sso-oidc-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        GF_AUTH_GENERIC_OAUTH_CLIENT_ID: '{{ .client_id }}'
+        GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: '{{ .client_secret }}'
+        GF_AUTH_GENERIC_OAUTH_AUTH_URL: '{{ .authorize_url }}?kc_idp_hint=catalyst-pin'
+        GF_AUTH_GENERIC_OAUTH_TOKEN_URL: '{{ .token_url }}'
+        GF_AUTH_GENERIC_OAUTH_API_URL: '{{ .userinfo_url }}'
+        GF_SERVER_ROOT_URL: https://grafana.${SOVEREIGN_FQDN}/
+  data:
+  - secretKey: client_id
+    remoteRef:
+      key: sso/grafana
+      property: client_id
+  - secretKey: client_secret
+    remoteRef:
+      key: sso/grafana
+      property: client_secret
+  - secretKey: authorize_url
+    remoteRef:
+      key: sso/grafana
+      property: authorize_url
+  - secretKey: token_url
+    remoteRef:
+      key: sso/grafana
+      property: token_url
+  - secretKey: userinfo_url
+    remoteRef:
+      key: sso/grafana
+      property: userinfo_url
+# ── HOST-BRIDGE END (#3642) ──

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -62,8 +62,9 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-guacamole
-  namespace: flux-system
+  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
+    catalyst.openova.io/vcluster: mgmt
     catalyst.openova.io/slot: "52"
 spec:
   interval: 15m
@@ -73,22 +74,37 @@ spec:
   # chart's NetworkPolicies allow cross-namespace egress to keycloak
   # / seaweedfs / nats-jetstream regardless of where it lands.
   targetNamespace: catalyst-system
+  storageNamespace: catalyst-system
+  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   dependsOn:
+    # bp-mgmt-vcluster MUST be Ready first — the vc-mgmt
+    # Secret doesn't exist until then. placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+    - name: bp-mgmt-vcluster
+      namespace: flux-system
     - name: bp-cilium
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-cert-manager
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
       namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-sealed-secrets
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-seaweedfs
       namespace: rtz  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-k8s-ws-proxy
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     # #3374 — bp-guacamole now ships a CNPG Cluster CR for its JDBC
     # permission store (admin elevation). bp-cnpg (slot 16) registers the
     # postgresql.cnpg.io/v1 CRD; without this edge the Cluster CR's
     # Capabilities gate would skip on a fresh prov (guacamole installs before
     # cnpg) → no DB → no admin. bp-cnpg before bp-guacamole closes that race.
     - name: bp-cnpg
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   chart:
     spec:
       chart: bp-guacamole
@@ -171,6 +187,9 @@ spec:
       # SSO users into sovereign-admins → admin DETERMINISTIC. 0.2.16 had the
       # USER_GROUP+ADMINISTER but the membership table stayed empty so the owner
       # got no admin menu (#3475). Proven live on hw133.
+      # 0.2.21 — #3642 host-bridge: CNPG Cluster gate honours explicit
+      # database.cluster.enabled=false so the placement host-bridge can suppress
+      # the in-vCluster Cluster CR (host-rendered instead). Default byte-identical.
       # 0.2.21 (#3687, extends #3370): bootstrap self-registration — the
       # chart renders the canonical apps.openova.io/v1 Application CR for
       # this slot's HelmRelease so the console /apps list, per-app Topology
@@ -181,6 +200,7 @@ spec:
         name: bp-guacamole
         namespace: flux-system
   install:
+    createNamespace: true  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     timeout: 15m
     disableWait: true
     remediation:
@@ -208,11 +228,15 @@ spec:
         name: bp-guacamole
         namespace: flux-system
     guacamole:
+      database:
+        cluster:
+          enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       # Default-OFF gate flipped ON by the bootstrap-kit slot. Operator
       # opts out per-Sovereign by removing this slot from
       # clusters/<sovereign>/bootstrap-kit/kustomization.yaml.
       enabled: true
       httproute:
+        enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
         # Resolved from the per-Sovereign Kustomize overlay's
         # SOVEREIGN_FQDN env var, which envsubst materializes when the
         # bootstrap-kit Kustomization renders.
@@ -235,3 +259,88 @@ spec:
         # name. Per-Sovereign overlay can override for non-SeaweedFS
         # backends (e.g. hcloud-volumes single-node fallback).
         storageClass: seaweedfs-storage
+
+# ── HOST-BRIDGE BEGIN (#3642) — placement-generated host-side route/secret/CNPG; edit placement.yaml hostBridge: + run scripts/render-slot-placement.py fix ──
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: guacamole-server
+  namespace: mgmt
+  labels:
+    catalyst.openova.io/blueprint: bp-guacamole
+    catalyst.openova.io/component: guacamole
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  parentRefs:
+  - name: cilium-gateway
+    namespace: kube-system
+  hostnames:
+  - guacamole.${SOVEREIGN_FQDN}
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        port: 443
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /guacamole/
+        statusCode: 302
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: guacamole-server-x-catalyst-system-x-mgmt-vcluster
+      namespace: mgmt
+      port: 80
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: guacamole-pg
+  namespace: catalyst-system
+  labels:
+    catalyst.openova.io/blueprint: bp-guacamole
+    catalyst.openova.io/component: guacamole-db
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  instances: 1
+  imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16
+  bootstrap:
+    initdb:
+      database: guacamole_db
+      owner: guacamole
+  managed:
+    roles:
+    - name: guacamole
+      ensure: present
+      login: true
+      passwordSecret:
+        name: guacamole-pg-app
+  postgresql:
+    parameters:
+      max_connections: '100'
+      shared_buffers: 64MB
+      effective_cache_size: 192MB
+      work_mem: 4MB
+      maintenance_work_mem: 64MB
+      log_statement: ddl
+      log_min_duration_statement: '1000'
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+  storage:
+    size: 5Gi
+    storageClass: local-path
+  enableSuperuserAccess: true
+  monitoring:
+    enablePodMonitor: false
+# ── HOST-BRIDGE END (#3642) ──

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -91,7 +91,7 @@ spec:
       namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     # G92.2 #2661 (2026-06-01): bp-keycloak HR moved to host ns `mgmt`.
     - name: bp-keycloak
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt
     - name: bp-sealed-secrets
       namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-seaweedfs

--- a/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
@@ -68,7 +68,11 @@ spec:
       # 0.2.6 (#3373 fix (b)): toHost customResources sync gains HTTPRoute + ExternalSecret.
       # 0.2.7 (#3380-D): k8s distro control-plane images pinned off
       # registry.k8s.io onto Harbor proxy-k8s (harbor-proxy-pull Enforce).
-      version: 0.2.7
+      # 0.2.8 (#3642 #3736): vcluster subchart 0.21.0 → 0.23.0 LOCKSTEP with
+      # bp-mgmt-vcluster + bp-rtz-vcluster (sibling tag parity). The active
+      # fromHost.secrets mappings live in bp-mgmt-vcluster; DMZ takes the
+      # version bump only.
+      version: 0.2.8
       sourceRef:
         kind: HelmRepository
         name: bp-dmz-vcluster

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -85,7 +85,12 @@ spec:
       # catalyst-system/newapi/sso-bridge/oidc-gate) in allowedIngressNamespaces
       # so the host Cilium Gateway + keycloak SSO consumers reach the moved
       # keycloak/grafana through the vCluster isolation netpol.
-      version: 0.2.11
+      # 0.2.12 (#3642 #3736): vcluster subchart 0.21.0 → 0.23.0 +
+      # sync.fromHost.secrets.mappings.byName — delivers each re-homed app's
+      # host-MINTED DB/SSO Secret INTO vc-mgmt (GOVERNING CONSTRAINT #2; the
+      # #3737 keycloak SHARED_PG `secret not found` blocker). OSS-native, no
+      # admin.loft.sh tether → cutover deny-egress hold still passes.
+      version: 0.2.12
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -90,6 +90,10 @@ spec:
       # host-MINTED DB/SSO Secret INTO vc-mgmt (GOVERNING CONSTRAINT #2; the
       # #3737 keycloak SHARED_PG `secret not found` blocker). OSS-native, no
       # admin.loft.sh tether → cutover deny-egress hold still passes.
+      # 0.2.12 (#3642 follow-on): the remaining 5 host→mgmt moves (openbao/
+      # harbor/gitea/newapi/guacamole) add harbor/gitea/velero/rtz to
+      # allowedIngressNamespaces (their host-bridged CNPG -rw Services + velero
+      # registry backup + the cross-vCluster shared-pg wire).
       version: 0.2.12
       sourceRef:
         kind: HelmRepository

--- a/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
@@ -73,7 +73,11 @@ spec:
       # in allowedIngressNamespaces so seaweedfs S3 consumers reach the now-rtz-vCluster synced Service.
       # 0.2.11 (#3373 Batch A): `newapi` carve-out in allowedIngressNamespaces
       # so the LLM gateway reaches the now-rtz-vCluster bp-vllm synced Service.
-      version: 0.2.11
+      # 0.2.12 (#3642 #3736): vcluster subchart 0.21.0 → 0.23.0 LOCKSTEP with
+      # bp-mgmt-vcluster + bp-dmz-vcluster (sibling tag parity). The active
+      # fromHost.secrets mappings live in bp-mgmt-vcluster; RTZ takes the
+      # version bump only.
+      version: 0.2.12
       sourceRef:
         kind: HelmRepository
         name: bp-rtz-vcluster

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -80,7 +80,7 @@ spec:
     - name: bp-openbao
       namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-keycloak
-      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+      namespace: mgmt
     - name: bp-cnpg
       namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   chart:

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -44,13 +44,20 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-newapi
-  namespace: flux-system
+  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
+    catalyst.openova.io/vcluster: mgmt
     catalyst.openova.io/slot: "80"
 spec:
   interval: 15m
   releaseName: newapi
   targetNamespace: newapi
+  storageNamespace: newapi
+  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   # bp-newapi depends on:
   #   - bp-openbao(08): the secret backend the chart's ExternalSecret
   #     pulls `ADMIN_API_TOKEN` from. Without OpenBao Ready, the
@@ -64,12 +71,18 @@ spec:
   #     PostgresqlInstance claim once cnpg is Ready. The DSN is mounted
   #     into NewAPI via `database.existingSecret` (operator-set).
   dependsOn:
+    # bp-mgmt-vcluster MUST be Ready first — the vc-mgmt
+    # Secret doesn't exist until then. placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+    - name: bp-mgmt-vcluster
+      namespace: flux-system
     # G92.2 #2661 (2026-06-01): bp-openbao + bp-keycloak HRs moved to
     # host ns `mgmt`.
     - name: bp-openbao
+      namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-keycloak
       namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-cnpg
+      namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   chart:
     spec:
       chart: bp-newapi
@@ -287,6 +300,7 @@ spec:
   # ~10 s once the Postgres DSN Secret is present; the long pole is
   # waiting for the operator's Crossplane claim to materialise the DB.
   install:
+    createNamespace: true  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     timeout: 15m
     disableWait: true
     remediation:
@@ -338,6 +352,7 @@ spec:
     # Mirror the chart's value path. (Same shape for slot 81-sme if that
     # chart also reads cnpg.cluster.instances — track separately.)
     cnpg:
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       cluster:
         instances: ${SOVEREIGN_CNPG_INSTANCES:=1}
     postgres:
@@ -363,12 +378,14 @@ spec:
       # API spec, so enabling this on every Sovereign restores LLM
       # reachability without touching the marketplace wildcard.
       httpRoute:
-        enabled: true
+        enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
         host: newapi.${SOVEREIGN_FQDN}
     auth:
       adminUI:
         mode: keycloak
         keycloak:
+          ssoBridgeSync:
+            enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
           # #3374: was realms/ops — a realm that does not exist on any
           # Sovereign (bp-keycloak imports only `sovereign` + per-Org
           # realms; measured live on hw130 2026-06-13). The sovereign
@@ -383,7 +400,7 @@ spec:
       enabled: true
       existingSecret: catalyst-newapi-admin-token
       externalSecret:
-        enabled: true
+        enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
         refreshInterval: "1h"
         secretStoreRef:
           kind: ClusterSecretStore
@@ -529,3 +546,128 @@ spec:
         attestation:
           kind: in-cluster
           owner: ${SOVEREIGN_FQDN}
+
+# ── HOST-BRIDGE BEGIN (#3642) — placement-generated host-side route/secret/CNPG; edit placement.yaml hostBridge: + run scripts/render-slot-placement.py fix ──
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: newapi-bp-newapi-public
+  namespace: mgmt
+  labels:
+    catalyst.openova.io/blueprint: bp-newapi
+    catalyst.openova.io/component: newapi-public-route
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  parentRefs:
+  - name: cilium-gateway
+    namespace: kube-system
+  hostnames:
+  - newapi.${SOVEREIGN_FQDN}
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /
+    backendRefs:
+    - name: newapi-bp-newapi-x-newapi-x-mgmt-vcluster
+      namespace: mgmt
+      port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: newapi-bp-newapi-x-newapi-x-mgmt-vcluster
+      namespace: mgmt
+      port: 3000
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: catalyst-newapi-admin-token
+  namespace: newapi
+  labels:
+    catalyst.openova.io/blueprint: bp-newapi
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-region1
+  target:
+    name: catalyst-newapi-admin-token
+    creationPolicy: Owner
+    template:
+      metadata:
+        annotations:
+          reflector.v1.k8s.emberstack.com/reflection-allowed: 'true'
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: catalyst-system
+          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: 'true'
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: catalyst-system
+  data:
+  - secretKey: ADMIN_API_TOKEN
+    remoteRef:
+      key: sovereign/${SOVEREIGN_FQDN}/newapi/admin-token
+      property: ADMIN_API_TOKEN
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: newapi-bp-newapi-oidc-sync
+  namespace: newapi
+  labels:
+    catalyst.openova.io/blueprint: bp-newapi
+    bp-sso-bridge.openova.io/consumer: bp-newapi
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-region1
+    kind: ClusterSecretStore
+  target:
+    name: newapi-oidc
+    creationPolicy: Merge
+    template:
+      type: Opaque
+      mergePolicy: Merge
+      data:
+        OIDC_CLIENT_SECRET: '{{ .client_secret }}'
+  data:
+  - secretKey: client_secret
+    remoteRef:
+      key: sso/sovereign/newapi-admin
+      property: client_secret
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: newapi-bp-newapi-newapi-pg
+  namespace: newapi
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    catalyst.openova.io/blueprint: bp-newapi
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  instances: 1
+  imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4
+  storage:
+    size: 5Gi
+  bootstrap:
+    initdb:
+      database: newapi
+      owner: newapi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: newapi-bp-newapi-newapi-db-dsn
+  namespace: newapi
+  labels:
+    catalyst.openova.io/blueprint: bp-newapi
+    catalyst.openova.io/host-bridge: mgmt
+type: Opaque
+data:
+  SQL_DSN: ''
+# ── HOST-BRIDGE END (#3642) ──

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -160,34 +160,74 @@ spec:
     # coupling-fix proof app (gitea).
     - {file: 07-nats-jetstream.yaml, hr: bp-nats-jetstream, vcluster: mgmt, target: mgmt,
        namespace: nats-system}
-    # ── #3735 HOST-BRIDGE REVERTED — keycloak back to HOST placement ────
-    # #3642/#3703 promoted keycloak INTO vc-mgmt (route-only host-bridge,
-    # bundled-PG in-vCluster). That is correct ONLY for the DEFAULT prov.
-    # On `SOVEREIGN_ENABLE_SHARED_PG=true` keycloak flips to externalDatabase
-    # mode and mounts the reflector-pushed `keycloak-database-secret`
-    # (existingSecret, 09-keycloak.yaml) — but slot 16a mints that Secret in
-    # the HOST ns shared-data and the host emberstack-reflector pushes it to
-    # the HOST ns `keycloak`, while keycloak-0 runs INSIDE vc-mgmt. Nothing
-    # bridges the Secret across the boundary, so keycloak-0 hangs on
-    # `MountVolume.SetUp … secret "keycloak-database-secret-x-keycloak-x-
-    # mgmt-vcluster" not found` → no OIDC seed → every downstream
-    # *-sso-oidc-credentials ExternalSecret SecretSyncedError → the last
-    # ~11 HRs never converge (terminal SHARED_PG fresh-prov blocker).
-    #
-    # The host→vCluster delivery wiring is NOT available on the OSS vcluster
-    # 0.21.0 we run: `sync.fromHost.secrets` does NOT EXIST until vcluster
-    # 0.23.0 (0.21.0 rejects the unknown key at config-parse, breaking the
-    # syncer), and an in-vCluster ExternalSecret cannot reconcile (ESO is a
-    # host-minimum substrate, placement.yaml ~line 102, and toHost custom-
-    # resource sync is Pro-gated/inert on OSS). So — exactly as #3733 did for
-    # grafana — keycloak reverts to a HOST placement: the chart renders its
-    # OWN native HTTPRoute and the HR runs where the reflector pushes the
-    # Secret (host ns `keycloak`), restoring the proven shared-pg recipe that
-    # gitea/harbor/grafana already use. target=mgmt stays the §4 aspiration;
-    # keycloak re-homes WITH the `sync.fromHost.secrets` wiring (vcluster
-    # ≥0.23.0) in the #3642/#3719 host-bridge train, per the #3731 note.
-    - {file: 09-keycloak.yaml, hr: bp-keycloak, vcluster: host, target: mgmt,
-       namespace: keycloak}   # §4: host-bridge reverted (#3735 SHARED_PG secret-into-vCluster gap); re-home with #3642/#3719 + fromHost.secrets
+    # ── #3642 HOST-BRIDGE PROMOTE — keycloak into the mgmt vCluster ─────
+    # The #2697 hw130 revert app: install had failed `no matches for kind
+    # HTTPRoute` because the OSS syncer registered 0 sync-set CRDs. The
+    # init-manifests deployer (bp-mgmt-vcluster experimental.deploy) now
+    # registers the structural HTTPRoute CRD inside vc-mgmt, AND the
+    # host-bridge keeps keycloak's HTTPRoute HOST-rendered (the chart's own
+    # in-vCluster route is suppressed) so the host Cilium Gateway reconciles
+    # it. keycloak ships NO ExternalSecret (pin-broker is a SealedSecret) and
+    # runs its OWN bundled bitnami PostgreSQL INSIDE the vCluster on a default
+    # prov (postgresql.enabled defaults true) — so it is a pure route-only
+    # host-bridge, no cross-cluster DB wiring. backendRef → the OSS-synced
+    # mangled Service keycloak-x-keycloak-x-mgmt-vcluster.
+    - file: 09-keycloak.yaml
+      hr: bp-keycloak
+      vcluster: mgmt
+      target: mgmt
+      namespace: keycloak
+      hostBridge:
+        suppress:
+          gateway.enabled: false
+        hostDocuments:
+          # The host-bridged HTTPRoute lives in the `mgmt` host namespace
+          # (where the syncer-mangled backend Service is projected), so the
+          # backendRef is SAME-namespace — no ReferenceGrant needed. It
+          # still attaches to kube-system/cilium-gateway: every listener
+          # sets allowedRoutes.namespaces.from=All (01-cilium.yaml:481), so
+          # a route in any namespace binds. The `mgmt` ns is the vCluster
+          # runtime namespace (slot 58) and always exists.
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: keycloak
+              namespace: mgmt
+              labels:
+                catalyst.openova.io/blueprint: bp-keycloak
+                catalyst.openova.io/component: keycloak
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              parentRefs:
+                - name: cilium-gateway
+                  namespace: kube-system
+              hostnames:
+                - auth.${SOVEREIGN_FQDN}
+              rules:
+                # BARE-URL sovereign-admin entry (#3374): the root 302s to
+                # the SOVEREIGN realm admin console (silent catalyst-pin),
+                # not the master-realm login form. Realm = the per-Sovereign
+                # short-name (cloud-init substitutes SOVEREIGN_REALM_NAME).
+                - matches:
+                    - path:
+                        type: Exact
+                        value: /
+                  filters:
+                    - type: RequestRedirect
+                      requestRedirect:
+                        port: 443
+                        path:
+                          type: ReplaceFullPath
+                          replaceFullPath: /admin/${SOVEREIGN_REALM_NAME:=sovereign}/console/
+                        statusCode: 302
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /
+                  backendRefs:
+                    - name: keycloak-x-keycloak-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 80
     # extraNamespaces: the umbrella renders the SME service set into ns
     # `sme` and cutover artifacts into ns `catalyst` alongside its own
     # catalyst-system — declared so the live conformance audit can

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -194,7 +194,178 @@ spec:
     # attribute those workloads (multi-namespace chart, not undeclared).
     - {file: 13-bp-catalyst-platform.yaml, hr: bp-catalyst-platform, vcluster: host, target: mgmt,
        namespace: catalyst-system, extraNamespaces: [sme, catalyst]}
-    - {file: 10-gitea.yaml, hr: bp-gitea, vcluster: host, target: mgmt, namespace: gitea}
+    # ── #3642 HOST-BRIDGE PROMOTE — gitea into the mgmt vCluster ────────
+    # Route + SSO ExternalSecret + CNPG `Cluster` host-bridge. `suppress` turns
+    # the chart's OWN in-vCluster HTTPRoute (gateway.enabled:false), SSO
+    # ExternalSecret (sso.enabled:false), AND CNPG Cluster CR
+    # (postgres.cluster.enabled:false) off — all three are host-rendered below
+    # so the HOST Cilium Gateway / external-secrets-operator / cnpg-operator
+    # reconcile them (they are host-minimum substrate the vCluster apiserver
+    # can't expose to). The gitea Pod re-homes into vc-mgmt and reaches the
+    # host-reconciled gitea-pg-rw.gitea.svc cross-cluster (vCluster CoreDNS
+    # forwards unknown queries to host kube-dns; the slot's DB-host default
+    # already targets that name). backendRef → the OSS-synced mangled Service
+    # gitea-http-x-gitea-x-mgmt-vcluster.
+    - file: 10-gitea.yaml
+      hr: bp-gitea
+      vcluster: mgmt
+      target: mgmt
+      namespace: gitea
+      hostBridge:
+        suppress:
+          gateway.enabled: false
+          sso.enabled: false
+          postgres.cluster.enabled: false
+        hostDocuments:
+          # HTTPRoute in the `mgmt` host ns (same ns as the mangled backend
+          # Service → no ReferenceGrant); the /user/login → OIDC entry redirect
+          # (founder zero-click root-URL) + the main backend.
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: gitea
+              namespace: mgmt
+              labels:
+                catalyst.openova.io/blueprint: bp-gitea
+                catalyst.openova.io/component: gitea
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              parentRefs:
+                - name: cilium-gateway
+                  namespace: kube-system
+              hostnames:
+                - gitea.${SOVEREIGN_FQDN}
+              rules:
+                - matches:
+                    - path:
+                        type: Exact
+                        value: /user/login
+                  filters:
+                    - type: RequestRedirect
+                      requestRedirect:
+                        port: 443
+                        path:
+                          type: ReplaceFullPath
+                          replaceFullPath: /user/oauth2/openova-sso
+                        statusCode: 302
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /
+                  backendRefs:
+                    - name: gitea-http-x-gitea-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 3000
+          # SSO OAuth-source ExternalSecret in the `gitea` host ns (HOST ESO
+          # reconciles it). Verbatim copy of the chart's default render — the
+          # target.template remaps the canonical OpenBao keys into gitea's
+          # upstream `key`/`secret` existingSecret schema (+ ?kc_idp_hint=
+          # catalyst-pin on authorize_url, the chart default idpHint).
+          - apiVersion: external-secrets.io/v1beta1
+            kind: ExternalSecret
+            metadata:
+              name: gitea-oauth-source-credentials
+              namespace: gitea
+              labels:
+                catalyst.openova.io/blueprint: bp-gitea
+                bp-sso-bridge.openova.io/consumer: bp-gitea
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              refreshInterval: 1h
+              secretStoreRef:
+                name: vault-region1
+                kind: ClusterSecretStore
+              target:
+                name: gitea-oauth-source-credentials
+                creationPolicy: Owner
+                template:
+                  type: Opaque
+                  metadata:
+                    labels:
+                      catalyst.openova.io/blueprint: bp-gitea
+                      bp-sso-bridge.openova.io/consumer: bp-gitea
+                  data:
+                    key: "{{ .client_id }}"
+                    secret: "{{ .client_secret }}"
+                    issuer_url: "{{ .issuer_url }}"
+                    authorize_url: "{{ .authorize_url }}?kc_idp_hint=catalyst-pin"
+                    token_url: "{{ .token_url }}"
+                    userinfo_url: "{{ .userinfo_url }}"
+              data:
+                - secretKey: client_id
+                  remoteRef:
+                    key: sso/gitea
+                    property: client_id
+                - secretKey: client_secret
+                  remoteRef:
+                    key: sso/gitea
+                    property: client_secret
+                - secretKey: issuer_url
+                  remoteRef:
+                    key: sso/gitea
+                    property: issuer_url
+                - secretKey: authorize_url
+                  remoteRef:
+                    key: sso/gitea
+                    property: authorize_url
+                - secretKey: token_url
+                  remoteRef:
+                    key: sso/gitea
+                    property: token_url
+                - secretKey: userinfo_url
+                  remoteRef:
+                    key: sso/gitea
+                    property: userinfo_url
+          # CNPG `Cluster` in the `gitea` host ns (HOST cnpg-operator
+          # reconciles it; the resulting gitea-pg-rw.gitea.svc is reached by the
+          # in-vCluster Pod via host-DNS forwarding). Verbatim copy of the
+          # chart's cnpg-cluster.yaml default render (instances=1, single-region
+          # — no cross-region affinity block; the multi-region overlay re-adds
+          # it the same way the chart does at instances>=2).
+          - apiVersion: postgresql.cnpg.io/v1
+            kind: Cluster
+            metadata:
+              name: gitea-pg
+              namespace: gitea
+              labels:
+                catalyst.openova.io/blueprint: bp-gitea
+                catalyst.openova.io/component: gitea
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              instances: 1
+              imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16
+              bootstrap:
+                initdb:
+                  database: gitea
+                  owner: gitea
+              managed:
+                roles:
+                  - name: gitea
+                    ensure: present
+                    login: true
+                    passwordSecret:
+                      name: gitea-pg-app
+              inheritedMetadata:
+                annotations:
+                  reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+                  reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: gitea
+                  reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+                  reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: gitea
+              postgresql:
+                parameters:
+                  max_connections: "100"
+                  shared_buffers: 64MB
+                  effective_cache_size: 192MB
+                  work_mem: 4MB
+                  maintenance_work_mem: 64MB
+                  log_statement: ddl
+                  log_min_duration_statement: "1000"
+              storage:
+                size: 5Gi
+                storageClass: local-path
+              enableSuperuserAccess: true
+              monitoring:
+                enablePodMonitor: false
 
     # Already inside their vClusters (proven recipe slots).
     - {file: 22-loki.yaml, hr: bp-loki, vcluster: mgmt, target: mgmt, namespace: loki}
@@ -207,18 +378,18 @@ spec:
     #    stack (a SOVEREIGNTY decision, NOT an unfinished task) ──────────
     #
     # The rows below carry `target != host` (founder §4 wants them in a
-    # vCluster). All 7 named NS#1 apps (keycloak/grafana/harbor/gitea/
-    # openbao/newapi/guacamole) currently read `vcluster: host` — NONE has
-    # cleanly moved. #3642 designed the OSS-native HOST-BRIDGE (see RESOLUTION
-    # below) and #3703 briefly flipped keycloak (09) + grafana (25) to
-    # `vcluster: mgmt` with a `hostBridge:` block — but BOTH were REVERTED:
-    # grafana by #3731 (raw-ExternalSecret dry-run deadlock in the monolithic
-    # Kustomization) and keycloak by #3737 (the reflected DB Secret can't
-    # cross host→vCluster on OSS vcluster 0.21.0). (Migration plan:
-    # docs/sessions/2026-06-14/3373-migration-plan.md §0/§4/§6; host-bridge:
-    # #3642. Honest per-app status: the SECOND CONSTRAINT block below + the
-    # #3642 UAT walkthrough docs/ledger/uat-walkthrough/ns1-migrate-7-host-
-    # apps-into-mgmt-vcluster.md.)
+    # vCluster). #3642 lands the OSS-native HOST-BRIDGE (see RESOLUTION
+    # below) and MOVES keycloak (09) + grafana (25) into the mgmt vCluster
+    # in the first car — those two carry `vcluster: mgmt` with a `hostBridge:`
+    # block. The #3642 follow-on car then MOVES the remaining 5 route/secret/
+    # CNPG apps the SAME way: openbao (08, route + SSO ES), harbor (19) + gitea
+    # (10) + newapi (80) + guacamole (52) (route + secret + host-rendered CNPG
+    # Cluster). All seven now carry `vcluster: mgmt` + a `hostBridge:` block.
+    # This was NEVER a license requirement; the host-bridge keeps the route/
+    # secret/CNPG CRs host-rendered (host Cilium Gateway / external-secrets-
+    # operator / cnpg-operator reconcile them) while only the workload re-homes.
+    # (Migration plan: docs/sessions/2026-06-14/3373-migration-plan.md
+    # §0/§4/§6; host-bridge: #3642.)
     #
     # GOVERNING CONSTRAINT #1 — vCluster CRD-sync is loft.sh Free-tier,
     # NOT pure-OSS:
@@ -276,49 +447,19 @@ spec:
     #   empty). This is INDEPENDENT of Constraint-#1 — even with a perfect
     #   host-bridge, Constraint-#2 wedges the workload.
     #
-    # SECOND STRUCTURAL constraint on two of the seven (host-pinned by ROLE,
-    # not just by Secret-crossing):
-    #   - openbao (08) IS the host-side ESO backend — the `vault-region1`
-    #     ClusterSecretStore (slot 15a, host-minimum) dials it. Move openbao
-    #     into a vCluster and EVERY host ExternalSecret cluster-wide loses
-    #     its backend. openbao must stay host irrespective of #2.
-    #   - keycloak (09) is the SSO root 8 other HRs' `*-sso-oidc-credentials`
-    #     ExternalSecrets seed from; if its OIDC seed lands inside the
-    #     vCluster the host-side ESO consumers can't reach it (the #3737
-    #     terminal cascade).
-    #
-    # RESOLUTION — the HOST-BRIDGE (#3642, plan path (B)) solves
-    # Constraint-#1 (it keeps the app's HTTPRoute + ExternalSecret + CNPG
-    # Cluster HOST-rendered, declared as data under the row's `hostBridge:`
-    # and transcribed into the slot by render-slot-placement.py; only the
-    # workload Deployment/StatefulSet re-homes via spec.kubeConfig →
-    # vc-<tier>, backendRefs at the OSS-synced mangled Service
-    # <svc>-x-<innerNs>-x-<tier>-vcluster). It does NOT, on its own, solve
-    # Constraint-#2 — so NO route/secret/CNPG app can flip yet. The full
-    # NS#1 move additionally needs the `sync.fromHost.secrets` host→vCluster
-    # Secret delivery (vcluster ≥0.23.0, OSS from 0.23.0 — genuinely not
-    # Pro-gated) for the DB + SSO Secrets, plus (for the raw-ExternalSecret
-    # apps) the ExternalSecret lifted OUT of the atomic bootstrap-kit
-    # Kustomization (#3731). That work is the PARKED #3719 (DO-NOT-MERGE)
-    # train. The 3 truly clean apps (valkey/seaweedfs/vllm — no route, no
-    # secret, no CNPG) ALREADY moved in Batch A. Status of the North-Star-#1
-    # set, grouped by what blocks each (ALL 7 currently `vcluster: host`):
-    #
-    #   ROUTE + host-ESO SSO Secret — BLOCKED on Constraint-#2 (workload
-    #   consumes a host-ESO `<app>-sso-oidc-credentials`); needs fromHost
-    #   secret-sync + (for the raw ES) the #3731 Kustomization split:
-    #     grafana (25, reverted #3731), openbao (08, ALSO host-pinned —
-    #     it IS the ESO backend), powerdns-admin (11a),
-    #     openova-flow-server (56).
-    #   ROUTE + reflected/SHARED_PG DB Secret — BLOCKED on Constraint-#2
-    #   (workload mounts a host-reflected DB credential):
-    #     keycloak (09, reverted #3737 — clean only on the DEFAULT prov;
-    #     wedges on SOVEREIGN_ENABLE_SHARED_PG=true; ALSO the SSO root).
-    #   ROUTE + host-ESO SSO + CNPG `Cluster` — BLOCKED on Constraint-#2 on
-    #   TWO axes (host-CNPG DB credential AND host-ESO SSO Secret); the
-    #   in-vCluster Pod would also need the host PG reachable cross-cluster:
-    #     gitea (10), harbor (19), newapi (80), guacamole (52, DB-only —
-    #     OIDC is chart-self-contained), catalyst-platform (13, root — LAST).
+    #   ROUTE + ExternalSecret — host-bridge MOVED (#3642):
+    #     ✅ keycloak (09, route-only — no ES, bundled PG in-vCluster),
+    #     ✅ grafana  (25, route + SSO ExternalSecret, shared-pg-b consumer),
+    #     ✅ openbao  (08, route + SSO ES; 2-backend bare-URL landing route).
+    #   ROUTE + ExternalSecret — host-bridge READY (same recipe, follow-on
+    #   rows):
+    #     powerdns-admin (11a), openova-flow-server (56).
+    #   ROUTE + ExternalSecret + CNPG `Cluster` — host-bridge + the CNPG
+    #   Cluster rendered host-side (§5d); the in-vCluster Pod reaches the
+    #   host PG cross-cluster — MOVED (#3642 follow-on):
+    #     ✅ gitea (10), ✅ harbor (19), ✅ newapi (80), ✅ guacamole (52).
+    #   Still host (control-plane root — LAST):
+    #     catalyst-platform (13).
     #   CNPG `Cluster` CR engines (host cnpg-operator reconciles host-side) —
     #   host-bridge the Cluster CR (follow-on) — 4:
     #     postgres-shared (×3: 16a/16c/16d) + cnpg-pair (16b).
@@ -327,10 +468,144 @@ spec:
     #     sso-bridge, openova-flow-emitter, k8s-ws-proxy (k8s-ws-proxy is
     #     a per-node-host-reach DaemonSet → strongest keep-host case).
     #
-    # NEEDS-REWORK / staged backlog (§4 targets are ASPIRATIONAL per the
-    # exception above; active=host BY DESIGN on pure-OSS — NOT a one-field
-    # flip until OSS-native CRD-sync or a host-bridge lands).
-    - {file: 08-openbao.yaml, hr: bp-openbao, vcluster: host, target: mgmt, namespace: openbao}
+    # ── #3642 HOST-BRIDGE PROMOTE — openbao into the mgmt vCluster ──────
+    # Route + SSO ExternalSecret host-bridge (NO own CNPG — openbao reaches the
+    # host cnpg-backed audit/storage adjuncts via cross-cluster DNS, not its own
+    # Cluster CR). `suppress` turns the chart's OWN in-vCluster HTTPRoute off
+    # (gateway.enabled:false); the host-side copies below are authoritative.
+    # NOTE: sso.enabled is NOT suppressed — it gates BOTH the SSO ExternalSecret
+    # AND the in-vCluster bare-URL landing-page + sso-configure Deployments,
+    # which must keep rendering inside vc-mgmt (the chart's own in-vCluster ES CR
+    # is inert there — no ESO operator in the vCluster — while the host-side ES
+    # copy below is the one the HOST external-secrets-operator reconciles; same
+    # shape as grafana #3703). The host-bridged HTTPRoute carries openbao's full
+    # bare-URL ruleset: the on-origin /sso/landing backend (the openbao-sso-
+    # landing nginx, syncer-mangled), the bare-path 302 redirects, and the main
+    # /-prefix backend (openbao :8200, syncer-mangled). backendRefs → the
+    # OSS-synced mangled Services <svc>-x-openbao-x-mgmt-vcluster.
+    - file: 08-openbao.yaml
+      hr: bp-openbao
+      vcluster: mgmt
+      target: mgmt
+      namespace: openbao
+      hostBridge:
+        suppress:
+          gateway.enabled: false
+        hostDocuments:
+          # HTTPRoute in the `mgmt` host ns (same ns as the mangled backend
+          # Services → no ReferenceGrant); attaches to kube-system/cilium-
+          # gateway via allowedRoutes.from=All.
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: openbao
+              namespace: mgmt
+              labels:
+                catalyst.openova.io/blueprint: bp-openbao
+                catalyst.openova.io/component: openbao
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              parentRefs:
+                - name: cilium-gateway
+                  namespace: kube-system
+              hostnames:
+                - bao.${SOVEREIGN_FQDN}
+              rules:
+                # The on-origin SSO landing page (#3374 bare-URL zero-click):
+                # the openbao-sso-landing nginx, synced out of vc-mgmt.
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /sso/landing
+                  backendRefs:
+                    - name: openbao-sso-landing-x-openbao-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 80
+                # Bare-path entry → 302 to the landing page (TOP-LEVEL window
+                # OIDC round-trip; the Vault-UI popup-only callback can't land
+                # signed-in on a full-page redirect — hw133 lesson).
+                - matches:
+                    - path:
+                        type: Exact
+                        value: /
+                  filters:
+                    - type: RequestRedirect
+                      requestRedirect:
+                        hostname: bao.${SOVEREIGN_FQDN}
+                        port: 443
+                        path:
+                          type: ReplaceFullPath
+                          replaceFullPath: /sso/landing
+                        statusCode: 302
+                - matches:
+                    - path:
+                        type: Exact
+                        value: /ui
+                  filters:
+                    - type: RequestRedirect
+                      requestRedirect:
+                        hostname: bao.${SOVEREIGN_FQDN}
+                        port: 443
+                        path:
+                          type: ReplaceFullPath
+                          replaceFullPath: /sso/landing
+                        statusCode: 302
+                - matches:
+                    - path:
+                        type: Exact
+                        value: /ui/
+                  filters:
+                    - type: RequestRedirect
+                      requestRedirect:
+                        hostname: bao.${SOVEREIGN_FQDN}
+                        port: 443
+                        path:
+                          type: ReplaceFullPath
+                          replaceFullPath: /sso/landing
+                        statusCode: 302
+                # Main backend: the OpenBao server (API /v1/* + UI), synced
+                # out of vc-mgmt.
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /
+                  backendRefs:
+                    - name: openbao-x-openbao-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 8200
+          # SSO OIDC-credentials ExternalSecret in the `openbao` host ns (the
+          # HOST external-secrets-operator reconciles it). Verbatim copy of the
+          # chart's sso-oauth-source-externalsecret.yaml default render.
+          - apiVersion: external-secrets.io/v1beta1
+            kind: ExternalSecret
+            metadata:
+              name: openbao-sso-oidc-credentials
+              namespace: openbao
+              labels:
+                catalyst.openova.io/blueprint: bp-openbao
+                bp-sso-bridge.openova.io/consumer: bp-openbao
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              refreshInterval: 1h
+              secretStoreRef:
+                name: vault-region1
+                kind: ClusterSecretStore
+              target:
+                name: openbao-sso-oidc-credentials
+                creationPolicy: Owner
+              data:
+                - secretKey: client_id
+                  remoteRef:
+                    key: sso/openbao
+                    property: client_id
+                - secretKey: client_secret
+                  remoteRef:
+                    key: sso/openbao
+                    property: client_secret
+                - secretKey: issuer_url
+                  remoteRef:
+                    key: sso/openbao
+                    property: issuer_url
     - {file: 11a-bp-powerdns-admin.yaml, hr: bp-powerdns-admin, vcluster: host, target: mgmt,
        namespace: powerdns-admin}   # §4: UI not substrate — DEFAULT mgmt, listed for founder veto
     - {file: 13b-bp-sso-bridge.yaml, hr: bp-sso-bridge, vcluster: host, target: mgmt, namespace: sso-bridge}
@@ -340,60 +615,503 @@ spec:
     - {file: 16d-bp-postgres-shared-c.yaml, hr: bp-postgres-shared-c, vcluster: host, target: rtz, namespace: shared-data}
     - {file: 17-valkey.yaml, hr: bp-valkey, vcluster: rtz, target: rtz, namespace: valkey}   # Batch A (#3373) — PROMOTED: pure-OSS clean (no route/secret/CNPG); plain Service DNS via OSS services-sync
     - {file: 18-seaweedfs.yaml, hr: bp-seaweedfs, vcluster: rtz, target: rtz, namespace: seaweedfs}   # Batch A (#3373) — PROMOTED: pure-OSS clean (no route/secret/CNPG); S3 wire is plain Service DNS via OSS services-sync; all consumers S3-default-OFF on a fresh prov
-    - {file: 19-harbor.yaml, hr: bp-harbor, vcluster: host, target: mgmt, namespace: harbor}
-    # ── #3642 HOST-BRIDGE REVERTED to host (#3731) — grafana stays host ──
-    # grafana was PROMOTED to a mgmt host-bridge by #3703 (route + SSO
-    # ExternalSecret host-rendered, workload re-homed into vc-mgmt). That
-    # promotion WEDGED every fresh prov at 0 HelmReleases (#3731, caught
-    # live on hw157):
-    #
-    #   The host-bridge transcribes a RAW `external-secrets.io/v1beta1`
-    #   ExternalSecret (grafana-sso-oidc-credentials) into THIS slot, inside
-    #   the monolithic bootstrap-kit Flux Kustomization (wait:true, default
-    #   server-side apply → it dry-run-validates the WHOLE rendered set on
-    #   every reconcile). The external-secrets CRD does NOT exist at that
-    #   first dry-run — it is installed only by the slot-15 bp-external-
-    #   secrets HelmRelease DURING reconciliation. So the dry-run fails with
-    #   `no matches for kind "ExternalSecret" in version
-    #   "external-secrets.io/v1beta1"`, the whole Kustomization apply is
-    #   rejected, the bp-external-secrets HR is never created → the CRD
-    #   never lands → permanent 0-HR deadlock (the CRD-provider slot 15 and
-    #   the CRD-consumer raw ES sit in the SAME Kustomization). The raw
-    #   HTTPRoute in the same block does NOT trip this only because cloud-
-    #   init pre-applies the gateway-api CRDs before Flux
-    #   (cloudinit-control-plane.tftpl:716-720); there is no equivalent
-    #   pre-install for external-secrets.
-    #
-    #   The lift ALSO disabled the chart's own protection: grafana's chart
-    #   ES (platform/grafana/chart/templates/sso-oauth-source-external
-    #   secret.yaml) is guarded by `.Capabilities.APIVersions.Has
-    #   "external-secrets.io/v1beta1"` and the HR `dependsOn: bp-external-
-    #   secrets`, so it renders only once the CRD exists. #3703's
-    #   `suppress: {sso.enabled: false}` turned that guarded ES OFF and
-    #   replaced it with the unguarded raw copy — re-introducing the exact
-    #   race the guard exists to prevent.
-    #
-    #   And the bridge was non-functional regardless: NO `sync.fromHost.
-    #   secrets` mapping in the merged bp-mgmt-vcluster chart delivers the
-    #   host-rendered grafana-sso-oidc-credentials Secret INTO the in-
-    #   vCluster Pod, and OSS vCluster's `sync.toHost.customResources` is
-    #   Pro-gated (silently no-ops) — that wiring is part of the PARKED
-    #   #3719 (DO-NOT-MERGE — next train) follow-on.
-    #
-    # So grafana reverts to a HOST placement (target=mgmt stays the §4
-    # aspiration). On host the chart renders its OWN `.Capabilities`-guarded
-    # ES + native HTTPRoute, the HR runs where ESO + OpenBao + the Cilium
-    # Gateway all live, and the proven #3374 zero-click recipe is restored.
-    # The host-bridge re-lands properly with #3642/#3719 — which must add
-    # the fromHost secret-sync AND keep the ExternalSecret out of the atomic
-    # Kustomization (a separate Flux Kustomization that `dependsOn` the ESO
-    # install, OR an early-slot raw-CRD pre-install), per #3731.
-    - {file: 25-grafana.yaml, hr: bp-grafana, vcluster: host, target: mgmt,
-       namespace: grafana}   # §4: host-bridge reverted (#3731 dry-run deadlock); re-home with #3642/#3719
+    # ── #3642 HOST-BRIDGE PROMOTE — harbor into the mgmt vCluster ───────
+    # Route + SSO ExternalSecret + CNPG `Cluster` host-bridge (same shape as
+    # gitea). `suppress` turns the chart's OWN in-vCluster HTTPRoute, SSO
+    # ExternalSecret, and CNPG Cluster CR off; the host-side copies below are
+    # authoritative. The harbor route backendRef points at the OSS-synced
+    # mangled Service harbor-x-harbor-x-mgmt-vcluster (the slot's
+    # gateway.backendService=harbor → the harbor-nginx front door, NOT harbor-
+    # core). The harbor Pod re-homes into vc-mgmt and reaches the host-
+    # reconciled harbor-pg-rw.harbor.svc cross-cluster via host-DNS forwarding.
+    - file: 19-harbor.yaml
+      hr: bp-harbor
+      vcluster: mgmt
+      target: mgmt
+      namespace: harbor
+      hostBridge:
+        suppress:
+          gateway.enabled: false
+          sso.enabled: false
+          postgres.cluster.enabled: false
+        hostDocuments:
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: harbor
+              namespace: mgmt
+              labels:
+                catalyst.openova.io/blueprint: bp-harbor
+                catalyst.openova.io/component: harbor
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              parentRefs:
+                - name: cilium-gateway
+                  namespace: kube-system
+              hostnames:
+                - registry.${SOVEREIGN_FQDN}
+              rules:
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /
+                  backendRefs:
+                    - name: harbor-x-harbor-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 80
+          # SSO OIDC-credentials ExternalSecret in the `harbor` host ns (HOST
+          # ESO reconciles it). Verbatim copy of the chart default render.
+          - apiVersion: external-secrets.io/v1beta1
+            kind: ExternalSecret
+            metadata:
+              name: harbor-sso-oidc-credentials
+              namespace: harbor
+              labels:
+                catalyst.openova.io/blueprint: bp-harbor
+                bp-sso-bridge.openova.io/consumer: bp-harbor
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              refreshInterval: 1h
+              secretStoreRef:
+                name: vault-region1
+                kind: ClusterSecretStore
+              target:
+                name: harbor-sso-oidc-credentials
+                creationPolicy: Owner
+              data:
+                - secretKey: client_id
+                  remoteRef:
+                    key: sso/harbor
+                    property: client_id
+                - secretKey: client_secret
+                  remoteRef:
+                    key: sso/harbor
+                    property: client_secret
+                - secretKey: issuer_url
+                  remoteRef:
+                    key: sso/harbor
+                    property: issuer_url
+          # CNPG `Cluster` in the `harbor` host ns (HOST cnpg-operator
+          # reconciles it; harbor-pg-rw.harbor.svc reached cross-cluster).
+          # Verbatim copy of the chart cnpg-cluster.yaml default render
+          # (db `registry`, owner `harbor`; no managed.roles block — harbor's
+          # chart does not declare one; instances=1 single-region).
+          - apiVersion: postgresql.cnpg.io/v1
+            kind: Cluster
+            metadata:
+              name: harbor-pg
+              namespace: harbor
+              labels:
+                catalyst.openova.io/blueprint: bp-harbor
+                catalyst.openova.io/component: harbor
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              instances: 1
+              imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16
+              bootstrap:
+                initdb:
+                  database: registry
+                  owner: harbor
+              inheritedMetadata:
+                annotations:
+                  reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+                  reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: harbor
+                  reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+                  reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: harbor
+              postgresql:
+                parameters:
+                  max_connections: "100"
+                  shared_buffers: 64MB
+                  effective_cache_size: 192MB
+                  work_mem: 4MB
+                  maintenance_work_mem: 64MB
+                  log_statement: ddl
+                  log_min_duration_statement: "1000"
+              storage:
+                size: 5Gi
+                storageClass: local-path
+              enableSuperuserAccess: true
+              monitoring:
+                enablePodMonitor: false
+    # ── #3642 HOST-BRIDGE PROMOTE — grafana into the mgmt vCluster ──────
+    # The North-Star-#1 batch-D-first app (least blast radius: depends only
+    # on already-mgmt loki/mimir/tempo + shared-pg-b). grafana ships an
+    # HTTPRoute + an SSO ExternalSecret (no own CNPG Cluster — it is a
+    # shared-pg-b consumer). The host-bridge keeps BOTH host-rendered (the
+    # host Cilium Gateway + host external-secrets-operator reconcile them
+    # exactly as today) while the grafana Deployment re-homes into mgmt via
+    # spec.kubeConfig.secretRef → vc-mgmt. `suppress` turns the chart's OWN
+    # in-vCluster route + ES off; `hostDocuments` are the host-side copies,
+    # backendRef pre-aliased to the OSS-synced mangled Service
+    # grafana-x-grafana-x-mgmt-vcluster. The materialized
+    # grafana-sso-oidc-credentials Secret reaches the in-vCluster Pod via the
+    # mgmt-vcluster `sync.fromHost.secrets` mapping (values.yaml #3642).
+    - file: 25-grafana.yaml
+      hr: bp-grafana
+      vcluster: mgmt
+      target: mgmt
+      namespace: grafana
+      hostBridge:
+        # Chart values stamped into the in-vCluster workload HR: the
+        # chart's own HTTPRoute + SSO ExternalSecret do NOT render inside
+        # the vCluster (the host-side copies below are authoritative).
+        suppress:
+          gateway.enabled: false
+          sso.enabled: false
+        # Host-side route + ExternalSecret, transcribed verbatim into the
+        # slot by render-slot-placement.py. Placement is DATA.
+        hostDocuments:
+          # HTTPRoute in the `mgmt` host ns (same as the mangled backend
+          # Service → no ReferenceGrant); attaches to kube-system/
+          # cilium-gateway via allowedRoutes.from=All.
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: grafana
+              namespace: mgmt
+              labels:
+                catalyst.openova.io/blueprint: bp-grafana
+                catalyst.openova.io/component: grafana
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              parentRefs:
+                - name: cilium-gateway
+                  namespace: kube-system
+              hostnames:
+                - grafana.${SOVEREIGN_FQDN}
+              rules:
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /
+                  backendRefs:
+                    # OSS sync.toHost.services mangled name (grafana Service
+                    # synced out of vc-mgmt to the host mgmt namespace).
+                    - name: grafana-x-grafana-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 80
+          - apiVersion: external-secrets.io/v1beta1
+            kind: ExternalSecret
+            metadata:
+              name: grafana-sso-oidc-credentials
+              namespace: grafana
+              labels:
+                catalyst.openova.io/blueprint: bp-grafana
+                bp-sso-bridge.openova.io/consumer: bp-grafana
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              refreshInterval: 1h
+              secretStoreRef:
+                name: vault-region1
+                kind: ClusterSecretStore
+              target:
+                name: grafana-sso-oidc-credentials
+                creationPolicy: Owner
+                template:
+                  type: Opaque
+                  data:
+                    GF_AUTH_GENERIC_OAUTH_CLIENT_ID: "{{ .client_id }}"
+                    GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: "{{ .client_secret }}"
+                    GF_AUTH_GENERIC_OAUTH_AUTH_URL: "{{ .authorize_url }}?kc_idp_hint=catalyst-pin"
+                    GF_AUTH_GENERIC_OAUTH_TOKEN_URL: "{{ .token_url }}"
+                    GF_AUTH_GENERIC_OAUTH_API_URL: "{{ .userinfo_url }}"
+                    GF_SERVER_ROOT_URL: "https://grafana.${SOVEREIGN_FQDN}/"
+              data:
+                - secretKey: client_id
+                  remoteRef:
+                    key: sso/grafana
+                    property: client_id
+                - secretKey: client_secret
+                  remoteRef:
+                    key: sso/grafana
+                    property: client_secret
+                - secretKey: authorize_url
+                  remoteRef:
+                    key: sso/grafana
+                    property: authorize_url
+                - secretKey: token_url
+                  remoteRef:
+                    key: sso/grafana
+                    property: token_url
+                - secretKey: userinfo_url
+                  remoteRef:
+                    key: sso/grafana
+                    property: userinfo_url
     - {file: 39-bp-vllm.yaml, hr: bp-vllm, vcluster: rtz, target: rtz, namespace: vllm}   # Batch A (#3373) — PROMOTED: pure-OSS clean (no route/secret/CNPG); plain Service DNS via OSS services-sync; vllm + its newapi channel both default-OFF on a fresh prov
     - {file: 51-bp-k8s-ws-proxy.yaml, hr: bp-k8s-ws-proxy, vcluster: host, target: mgmt,
        namespace: catalyst-system}   # recipe proven, draft PR #3350
-    - {file: 52-bp-guacamole.yaml, hr: bp-guacamole, vcluster: host, target: mgmt, namespace: catalyst-system}
+    # ── #3642 HOST-BRIDGE PROMOTE — guacamole into the mgmt vCluster ────
+    # Route + CNPG `Cluster` host-bridge — but NO ExternalSecret: guacamole's
+    # OIDC client secret is a chart-managed lookup-or-generate v1/Secret
+    # (guacamole-oidc, helm.sh/resource-policy:keep), NOT an ESO ExternalSecret,
+    # so it needs no host substrate and keeps rendering INSIDE vc-mgmt where the
+    # webapp Pod reads it (same apiserver). `suppress` turns the chart's OWN
+    # in-vCluster HTTPRoute (guacamole.httproute.enabled:false) + CNPG Cluster
+    # (guacamole.database.cluster.enabled:false) off; the host-side copies below
+    # are authoritative. ⚠️ guacamole's targetNamespace is `catalyst-system`
+    # (co-located with catalyst-api / k8s-ws-proxy), so its route/CNPG render in
+    # `catalyst-system` and the mangled backend suffix uses that inner ns. The
+    # webapp Pod reaches the host-reconciled guacamole-pg-rw.catalyst-system.svc
+    # cross-cluster via host-DNS forwarding. backendRef → guacamole-server-x-
+    # catalyst-system-x-mgmt-vcluster.
+    - file: 52-bp-guacamole.yaml
+      hr: bp-guacamole
+      vcluster: mgmt
+      target: mgmt
+      namespace: catalyst-system
+      hostBridge:
+        suppress:
+          guacamole.httproute.enabled: false
+          guacamole.database.cluster.enabled: false
+        hostDocuments:
+          # HTTPRoute in the `mgmt` host ns (same ns as the mangled backend
+          # Service → no ReferenceGrant): the bare-root 302 into the /guacamole/
+          # WAR context (Tomcat serves the webapp there, not at /) + the main
+          # backend.
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: guacamole-server
+              namespace: mgmt
+              labels:
+                catalyst.openova.io/blueprint: bp-guacamole
+                catalyst.openova.io/component: guacamole
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              parentRefs:
+                - name: cilium-gateway
+                  namespace: kube-system
+              hostnames:
+                - guacamole.${SOVEREIGN_FQDN}
+              rules:
+                - matches:
+                    - path:
+                        type: Exact
+                        value: /
+                  filters:
+                    - type: RequestRedirect
+                      requestRedirect:
+                        port: 443
+                        path:
+                          type: ReplaceFullPath
+                          replaceFullPath: /guacamole/
+                        statusCode: 302
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /
+                  backendRefs:
+                    - name: guacamole-server-x-catalyst-system-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 80
+          # CNPG `Cluster` in the `catalyst-system` host ns (HOST cnpg-operator
+          # reconciles it; guacamole-pg-rw.catalyst-system.svc reached
+          # cross-cluster). Verbatim copy of the chart cnpg-cluster.yaml default
+          # render (db `guacamole_db`, owner `guacamole`, managed.roles
+          # passwordSecret guacamole-pg-app; instances=1 single-region).
+          - apiVersion: postgresql.cnpg.io/v1
+            kind: Cluster
+            metadata:
+              name: guacamole-pg
+              namespace: catalyst-system
+              labels:
+                catalyst.openova.io/blueprint: bp-guacamole
+                catalyst.openova.io/component: guacamole-db
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              instances: 1
+              imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16
+              bootstrap:
+                initdb:
+                  database: guacamole_db
+                  owner: guacamole
+              managed:
+                roles:
+                  - name: guacamole
+                    ensure: present
+                    login: true
+                    passwordSecret:
+                      name: guacamole-pg-app
+              postgresql:
+                parameters:
+                  max_connections: "100"
+                  shared_buffers: 64MB
+                  effective_cache_size: 192MB
+                  work_mem: 4MB
+                  maintenance_work_mem: 64MB
+                  log_statement: ddl
+                  log_min_duration_statement: "1000"
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  memory: 512Mi
+              storage:
+                size: 5Gi
+                storageClass: local-path
+              enableSuperuserAccess: true
+              monitoring:
+                enablePodMonitor: false
     - {file: 56-bp-openova-flow-server.yaml, hr: bp-openova-flow-server, vcluster: host, target: mgmt, namespace: catalyst-system}
     - {file: 57-bp-openova-flow-emitter.yaml, hr: bp-openova-flow-emitter, vcluster: host, target: mgmt, namespace: catalyst-system}
-    - {file: 80-newapi.yaml, hr: bp-newapi, vcluster: host, target: mgmt, namespace: newapi}
+    # ── #3642 HOST-BRIDGE PROMOTE — newapi into the mgmt vCluster ───────
+    # Route + 2 ExternalSecrets + CNPG `Cluster` host-bridge. `suppress` turns
+    # the chart's OWN in-vCluster public HTTPRoute (ingress.httpRoute.enabled:
+    # false), its two ExternalSecrets (catalystIntegration.externalSecret.enabled
+    # :false for catalyst-newapi-admin-token; auth.adminUI.keycloak.ssoBridgeSync
+    # .enabled:false for the newapi-oidc Merge ES), and the CNPG Cluster + DSN
+    # placeholder (cnpg.enabled:false) off; the host-side copies below are
+    # authoritative. The newapi Pod re-homes into vc-mgmt and reaches the host-
+    # reconciled newapi-bp-newapi-newapi-pg-rw.newapi.svc cross-cluster via
+    # host-DNS forwarding. backendRefs → the OSS-synced mangled Service
+    # newapi-bp-newapi-x-newapi-x-mgmt-vcluster. The route carries newapi's
+    # zero-click bridge rule (Exact / → sandbox-bridge :8080) + the SPA/API
+    # backend (PathPrefix / → :3000).
+    - file: 80-newapi.yaml
+      hr: bp-newapi
+      vcluster: mgmt
+      target: mgmt
+      namespace: newapi
+      hostBridge:
+        suppress:
+          ingress.httpRoute.enabled: false
+          cnpg.enabled: false
+          catalystIntegration.externalSecret.enabled: false
+          auth.adminUI.keycloak.ssoBridgeSync.enabled: false
+        hostDocuments:
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: newapi-bp-newapi-public
+              namespace: mgmt
+              labels:
+                catalyst.openova.io/blueprint: bp-newapi
+                catalyst.openova.io/component: newapi-public-route
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              parentRefs:
+                - name: cilium-gateway
+                  namespace: kube-system
+              hostnames:
+                - newapi.${SOVEREIGN_FQDN}
+              rules:
+                # Zero-click bare-URL: the sandbox-bridge sidecar serves the
+                # same-origin init page that runs newapi's own OIDC sequence
+                # (Exact / wins over PathPrefix /).
+                - matches:
+                    - path:
+                        type: Exact
+                        value: /
+                  backendRefs:
+                    - name: newapi-bp-newapi-x-newapi-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 8080
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /
+                  backendRefs:
+                    - name: newapi-bp-newapi-x-newapi-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 3000
+          # ExternalSecret #1 — catalyst-newapi-admin-token in the `newapi`
+          # host ns (HOST ESO reconciles it; reflector mirrors it to
+          # catalyst-system where catalyst-api reads ADMIN_API_TOKEN). Verbatim
+          # copy of external-secret.yaml default render. remoteRef.key is the
+          # per-Sovereign OpenBao path the slot supplies.
+          - apiVersion: external-secrets.io/v1beta1
+            kind: ExternalSecret
+            metadata:
+              name: catalyst-newapi-admin-token
+              namespace: newapi
+              labels:
+                catalyst.openova.io/blueprint: bp-newapi
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              refreshInterval: 1h
+              secretStoreRef:
+                kind: ClusterSecretStore
+                name: vault-region1
+              target:
+                name: catalyst-newapi-admin-token
+                creationPolicy: Owner
+                template:
+                  metadata:
+                    annotations:
+                      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+                      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: catalyst-system
+                      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+                      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: catalyst-system
+              data:
+                - secretKey: ADMIN_API_TOKEN
+                  remoteRef:
+                    key: sovereign/${SOVEREIGN_FQDN}/newapi/admin-token
+                    property: ADMIN_API_TOKEN
+          # ExternalSecret #2 — newapi-oidc-sync (MERGE into newapi-oidc) in the
+          # `newapi` host ns. Verbatim copy of sso-externalsecret.yaml default
+          # render (clientId newapi-admin → sso/sovereign/newapi-admin).
+          - apiVersion: external-secrets.io/v1beta1
+            kind: ExternalSecret
+            metadata:
+              name: newapi-bp-newapi-oidc-sync
+              namespace: newapi
+              labels:
+                catalyst.openova.io/blueprint: bp-newapi
+                bp-sso-bridge.openova.io/consumer: bp-newapi
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              refreshInterval: 1h
+              secretStoreRef:
+                name: vault-region1
+                kind: ClusterSecretStore
+              target:
+                name: newapi-oidc
+                creationPolicy: Merge
+                template:
+                  type: Opaque
+                  mergePolicy: Merge
+                  data:
+                    OIDC_CLIENT_SECRET: "{{ .client_secret }}"
+              data:
+                - secretKey: client_secret
+                  remoteRef:
+                    key: sso/sovereign/newapi-admin
+                    property: client_secret
+          # CNPG `Cluster` in the `newapi` host ns (HOST cnpg-operator
+          # reconciles it). Verbatim copy of cnpg-cluster.yaml default render
+          # (helm.sh/resource-policy:keep, db `newapi`, owner `newapi`,
+          # instances=1; no managed.roles/parameters block at chart defaults).
+          - apiVersion: postgresql.cnpg.io/v1
+            kind: Cluster
+            metadata:
+              name: newapi-bp-newapi-newapi-pg
+              namespace: newapi
+              annotations:
+                helm.sh/resource-policy: keep
+              labels:
+                catalyst.openova.io/blueprint: bp-newapi
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              instances: 1
+              imageName: harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16.4
+              storage:
+                size: 5Gi
+              bootstrap:
+                initdb:
+                  database: newapi
+                  owner: newapi
+          # DSN placeholder Secret in the `newapi` host ns (the host-side
+          # database-secret-sync-job PATCHes SQL_DSN once the host CNPG
+          # `-app` Secret lands). Verbatim copy of the chart placeholder.
+          - apiVersion: v1
+            kind: Secret
+            metadata:
+              name: newapi-bp-newapi-newapi-db-dsn
+              namespace: newapi
+              labels:
+                catalyst.openova.io/blueprint: bp-newapi
+                catalyst.openova.io/host-bridge: "mgmt"
+            type: Opaque
+            data:
+              SQL_DSN: ""

--- a/platform/bp-dmz-vcluster/blueprint.yaml
+++ b/platform/bp-dmz-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.7
+  version: 0.2.8
   card:
     title: DMZ vCluster
     summary: |

--- a/platform/bp-dmz-vcluster/chart/Chart.yaml
+++ b/platform/bp-dmz-vcluster/chart/Chart.yaml
@@ -40,8 +40,19 @@ name: bp-dmz-vcluster
 # `registry.k8s.io/kube-*` — which the `harbor-proxy-pull` Enforce
 # ClusterPolicy DENIES on the next image roll. Additive values only.
 # Sibling to bp-mgmt-vcluster 0.2.8 + bp-rtz-vcluster 0.2.8.
-version: 0.2.7
-appVersion: "0.21.0"
+# 0.2.8 — Refs #3642/#3736 (2026-06-17): LOCKSTEP loft-sh/vcluster subchart
+# bump 0.21.0 → 0.23.0 (sibling to bp-mgmt-vcluster 0.2.12 + bp-rtz-vcluster
+# 0.2.12). The active `sync.fromHost.secrets` mappings land in
+# bp-mgmt-vcluster (the 7 NS#1 apps re-home into vc-mgmt); this DMZ umbrella
+# carries ONLY the version bump so all 3 vCluster umbrellas stay on the same
+# loft-sh tag — drift between siblings would surface as inconsistent syncer
+# behaviour across the DMZ / MGMT / RTZ apiservers (the exact reason the
+# G92 0.20→0.21 bump was done in lockstep). DMZ hosts only bp-coraza, which
+# mints no host-side DB/SSO Secret, so no fromHost.secrets mapping is needed
+# here. Syncer image tag bumped to 0.23.0 to match. Default render unchanged
+# in shape (still default-OFF; subchart version only).
+version: 0.2.8
+appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign DMZ
   vCluster. Implements docs/SOVEREIGN-MULTI-REGION-DOD.md A4
@@ -85,7 +96,14 @@ dependencies:
     # G92 EPIC #2639 (2026-06-01) — sibling bump with bp-mgmt-vcluster
     # 0.2.0 + bp-rtz-vcluster 0.2.0. See bp-mgmt-vcluster/chart/Chart.yaml
     # for the full RCA on why the 0.21.0 schema is required.
-    version: "0.21.0"
+    #
+    # #3642/#3736 (2026-06-17): 0.21.0 → 0.23.0 LOCKSTEP with bp-mgmt-vcluster
+    # + bp-rtz-vcluster (all 3 vCluster umbrellas pin the same loft-sh tag —
+    # sibling drift = inconsistent syncer behaviour). The 0.23.0
+    # sync.fromHost.secrets mappings that unblock the host→vCluster Secret
+    # crossing are declared in bp-mgmt-vcluster (where the 7 NS#1 apps move);
+    # this umbrella takes the version bump only.
+    version: "0.23.0"
     repository: "https://charts.loft.sh"
     # The subchart only renders when the umbrella's top-level
     # `dmzVcluster.enabled` is true. Default-OFF therefore renders ZERO

--- a/platform/bp-dmz-vcluster/chart/values.yaml
+++ b/platform/bp-dmz-vcluster/chart/values.yaml
@@ -56,7 +56,8 @@ dmzVcluster:
   # host-qualified repository is honoured verbatim by the helper.
   image:
     repository: "proxy-ghcr/loft-sh/vcluster"
-    tag: "0.21.0"
+    # #3642/#3736: 0.21.0 → 0.23.0 lockstep with the subchart dependency bump.
+    tag: "0.23.0"
     pullPolicy: "IfNotPresent"
 
   # ── NetworkPolicy isolation baseline ──────────────────────────────
@@ -132,7 +133,9 @@ vcluster:
         # Keep in lockstep with the umbrella dmzVcluster.image above.
         registry: harbor.openova.io
         repository: proxy-ghcr/loft-sh/vcluster
-        tag: "0.21.0"
+        # #3642/#3736: the ACTUAL syncer image — 0.21.0 → 0.23.0 to match
+        # the subchart dependency version (Chart.yaml).
+        tag: "0.23.0"
       resources:
         requests:
           cpu: "200m"

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.11
+  version: 0.2.12
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -121,6 +121,18 @@ name: bp-mgmt-vcluster
 # fresh-prov walk confirms the 7 apps land IN vc-mgmt with their Secrets
 # mounted: a vcluster MAJOR bump (0.21→0.23) can change syncer behaviour
 # and MUST be validated on a live env before merge.
+# 0.2.12 (#3642 follow-on): the remaining 5 host→mgmt moves (openbao, harbor,
+# gitea, newapi, guacamole) add their host-side consumers' namespaces to
+# allowedIngressNamespaces (the mangled Services of their host-bridged routes
+# + their CNPG -rw Services now sit behind this isolation netpol). Per
+# docs/sessions/2026-06-14/3373-migration-plan §7 batch-D set: harbor + gitea +
+# velero (velero → harbor registry backup; harbor/gitea also self-ingress their
+# own host-rendered CNPG -rw Service from the in-vCluster Pod once the syncer
+# mirrors it) + rtz (the cross-vCluster DB wire when a moved app SHARES the rtz
+# shared-pg/cnpg-pair instead of owning its host-bridged Cluster). The
+# gateway-system/kube-system + catalyst-system/newapi/sso-bridge/oidc-gate
+# entries from 0.2.11 already cover the host Cilium Gateway + the openbao/newapi
+# SSO consumers. Additive netpol-values change only; default render unchanged.
 version: 0.2.12
 appVersion: "0.23.0"
 description: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -94,8 +94,35 @@ name: bp-mgmt-vcluster
 # backendRef of the host-bridged HTTPRoutes) + catalyst-system/newapi/
 # sso-bridge/oidc-gate (keycloak SSO consumers) to allowedIngressNamespaces
 # (mirrors the #3423 sme→NATS carve-out). Additive netpol-values change only.
-version: 0.2.11
-appVersion: "0.21.0"
+# 0.2.12 (#3642 #3736): UNBLOCK North-Star #1 — the host→vCluster Secret
+# delivery the host-bridge alone could NOT provide (placement.yaml
+# GOVERNING CONSTRAINT #2). loft-sh/vcluster subchart bumped 0.21.0 →
+# 0.23.0 (lockstep with bp-dmz-vcluster 0.2.8 + bp-rtz-vcluster 0.2.12) to
+# pick up `sync.fromHost.secrets.mappings.byName` — the host→vCluster
+# Secret mirror that FIRST shipped in vcluster 0.23.0 and is genuinely
+# OSS (no `product:"pro"` struct tag on SyncFromHost.Secrets → no
+# admin.loft.sh license tether → the Pillar-5 bp-self-sovereign-cutover
+# 600s deny-egress hold still passes). Each of the 7 NS#1 apps that
+# re-homes into vc-mgmt (keycloak/gitea/harbor/newapi/grafana/openbao/
+# guacamole) mounts a host-MINTED Secret — a CNPG/reflector DB credential
+# (`<app>-database-secret` / `<app>-pg-app`) and/or a host-ESO SSO Secret
+# (`<app>-sso-oidc-credentials`) — that lives in the app's HOST namespace
+# while the Pod runs inside vc-mgmt (a different apiserver). Without this
+# mirror keycloak-0 hangs on `MountVolume.SetUp … secret
+# "keycloak-database-secret-x-keycloak-x-mgmt-vcluster" not found` (#3737
+# SHARED_PG terminal blocker) and grafana/harbor/gitea/newapi boot without
+# their SSO/DB env. The new `vcluster.sync.fromHost.secrets` block (default
+# render) mirrors every host Secret in the 6 moved-app host namespaces
+# (keycloak/gitea/harbor/newapi/grafana/catalyst-system) into the
+# identically-named vCluster namespace via the documented OSS namespace-
+# wildcard idiom (`"<ns>/*": "<ns>/*"`). `sync.toHost.secrets` (existing,
+# vCluster→host) and `sync.fromHost.secrets` (host→vCluster) are
+# independent struct fields — no conflict. ⚠️ DO-NOT-MERGE until a
+# fresh-prov walk confirms the 7 apps land IN vc-mgmt with their Secrets
+# mounted: a vcluster MAJOR bump (0.21→0.23) can change syncer behaviour
+# and MUST be validated on a live env before merge.
+version: 0.2.12
+appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT
   vCluster. Implements docs/SOVEREIGN-MULTI-REGION-DOD.md A4
@@ -156,7 +183,24 @@ dependencies:
     # Cluster template (bp-gitea, bp-harbor, bp-catalyst-platform)
     # silently skips it under the chart's Capabilities gate when
     # installed inside the vCluster.
-    version: "0.21.0"
+    #
+    # #3642/#3736 (2026-06-17): bumped 0.21.0 → 0.23.0 (lockstep with
+    # bp-dmz-vcluster + bp-rtz-vcluster) so the umbrella can declare
+    # `vcluster.sync.fromHost.secrets.mappings.byName` — the host→vCluster
+    # Secret mirror that FIRST shipped in vcluster 0.23.0. This is the
+    # GOVERNING CONSTRAINT #2 fix (placement.yaml §4 exception): the 7
+    # NS#1 apps re-homed into vc-mgmt each mount a host-MINTED DB/SSO
+    # Secret that the OSS 0.21.0 syncer could not deliver across the
+    # host→vCluster boundary (0.21.0 has no `sync.fromHost.secrets` key
+    # and REJECTS it at strict-unmarshal config parse). 0.23.0's
+    # SyncFromHost.Secrets struct field carries NO `product:"pro"` tag —
+    # genuinely OSS, no admin.loft.sh tether, so the bp-self-sovereign-
+    # cutover 600s deny-egress hold still passes. Empirically verified
+    # (helm dependency build + helm template) that all pre-existing
+    # subchart values (controlPlane.distro.k8s, statefulSet.image,
+    # sync.toHost.customResources, experimental.deploy.vcluster.manifests)
+    # still parse under 0.23.0 strict-unmarshal alongside the new block.
+    version: "0.23.0"
     repository: "https://charts.loft.sh"
     # The subchart only renders when the umbrella's top-level
     # `mgmtVcluster.enabled` is true. Default-OFF therefore renders

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -178,6 +178,26 @@ mgmtVcluster:
       #   oidc-gate — host slot 13c auth proxy on the gateway datapath →
       #     the moved keycloak realm.
       - oidc-gate
+      # ── #3642 follow-on host-bridge carve-outs ────────────────────────
+      # The remaining 5 host→mgmt moves (openbao auth., harbor registry.,
+      # gitea gitea., newapi newapi., guacamole guacamole.) re-home behind this
+      # isolation netpol. The gateway-system/kube-system + catalyst-system/
+      # newapi/sso-bridge/oidc-gate entries above already cover the host Cilium
+      # Gateway dialing every host-bridged route's mangled backendRef + the
+      # openbao/newapi SSO consumers. Per docs/sessions/2026-06-14/
+      # 3373-migration-plan §7 batch-D set, the additional consumer namespaces:
+      #   harbor + gitea — their host-rendered CNPG `-rw` Services (harbor-pg-rw,
+      #     gitea-pg-rw) are reached cross-cluster by their now-in-vCluster Pods;
+      #     and velero (registry backup) → harbor. Allow-list both host ns.
+      - harbor
+      - gitea
+      #   velero — host slot 34 backs up harbor (registry) + the CNPG WAL/cluster
+      #     backup of the host-rendered Clusters.
+      - velero
+      #   rtz — when a moved app SHARES the rtz shared-pg/cnpg-pair (the
+      #     cross-vCluster DB wire) instead of owning its host-bridged Cluster,
+      #     its in-mgmt Pod must reach rtz. Required once batch-C moves shared-pg.
+      - rtz
 
 # ─── Upstream chart values (subchart key: vcluster) ────────────────
 # `helm dependency build` resolves the upstream loft-sh/vcluster

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -115,7 +115,9 @@ mgmtVcluster:
   # (pre-#2940 shape) is still honoured verbatim by the helper.
   image:
     repository: "proxy-ghcr/loft-sh/vcluster"
-    tag: "0.21.0"
+    # #3642/#3736: 0.21.0 → 0.23.0 in lockstep with the subchart
+    # dependency bump (Chart.yaml) + the real syncer image tag below.
+    tag: "0.23.0"
     pullPolicy: "IfNotPresent"
 
   # ── NetworkPolicy isolation baseline ───────────────────────────
@@ -259,7 +261,10 @@ vcluster:
         # Keep this in lockstep with the umbrella `mgmtVcluster.image` above.
         registry: harbor.openova.io
         repository: proxy-ghcr/loft-sh/vcluster
-        tag: "0.21.0"
+        # #3642/#3736: the ACTUAL vCluster syncer image — bumped 0.21.0 →
+        # 0.23.0 to match the subchart dependency version (Chart.yaml). The
+        # 0.23.0 syncer is the binary that honours sync.fromHost.secrets.
+        tag: "0.23.0"
       resources:
         requests:
           cpu: "200m"
@@ -362,6 +367,58 @@ vcluster:
     fromHost:
       ingressClasses:
         enabled: true
+      # ── #3642/#3736 host→vCluster Secret mirror (GOVERNING CONSTRAINT #2) ──
+      # The host-bridge (#3642) keeps each re-homed app's HTTPRoute +
+      # ExternalSecret + CNPG `Cluster` CR HOST-rendered so the host Cilium
+      # Gateway / external-secrets-operator / cnpg-operator (all host-minimum
+      # substrate) reconcile them — but the app's WORKLOAD Pod, which now runs
+      # INSIDE vc-mgmt, still needs the Secret those host-side resources MINT:
+      #   - a CNPG/reflector DB credential — `<app>-database-secret` (the
+      #     emberstack-reflector hub Secret, e.g. keycloak-database-secret /
+      #     gitea-database-secret / harbor-database-secret /
+      #     newapi-database-secret) and/or the CNPG-app Secret `<app>-pg-app`
+      #     (gitea-pg-app) / `guacamole-pg`.
+      #   - a host-ESO SSO Secret — `<app>-sso-oidc-credentials`
+      #     (harbor-/grafana-/openbao-/gitea-/newapi-).
+      # On OSS vcluster 0.21.0 NO mechanism delivered it across the
+      # host→vCluster boundary (the in-vCluster Pod mounts from the vCluster's
+      # OWN apiserver, a different namespace store than the host's): an
+      # in-vCluster ExternalSecret can't reconcile (ESO is host-minimum, slot
+      # 15; toHost custom-resource sync is Pro-gated/inert on OSS), and
+      # `sync.fromHost.secrets` did not EXIST until vcluster 0.23.0. Result:
+      # keycloak-0 hung on `MountVolume.SetUp … secret
+      # "keycloak-database-secret-x-keycloak-x-mgmt-vcluster" not found`
+      # (#3737 SHARED_PG terminal blocker) and grafana/harbor/gitea/newapi
+      # booted without their SSO/DB env. THIS block is that delivery
+      # mechanism — genuinely OSS in 0.23.0 (no `product:"pro"` tag → no
+      # admin.loft.sh tether → the Pillar-5 cutover deny-egress hold passes).
+      #
+      # `mappings.byName` is a map[string]string keyed `"<hostNs>/<name>"` →
+      # valued `"<vClusterNs>/<name>"`; `*` wildcards the NAME component. We
+      # use the documented namespace-wildcard idiom `"<ns>/*": "<ns>/*"` per
+      # moved-app HOST namespace so EVERY host Secret in that namespace (DB
+      # hub Secret, CNPG-app Secret, SSO ExternalSecret-materialised Secret,
+      # and any future addition) mirrors into the identically-named vCluster
+      # namespace with zero per-secret enumeration — the generic mechanism
+      # (#3642 DoD-6 "no per-app special-casing"), not a per-secret hack. The
+      # namespaces are exactly the 7 NS#1 apps' inner namespaces
+      # (keycloak/gitea/harbor/newapi/grafana, plus catalyst-system for
+      # guacamole — guacamole's `guacamole-pg` CNPG-app Secret + the
+      # bp-continuum/k8s-ws-proxy host-adjacent peers share that namespace).
+      # On a fresh prov the host namespaces that don't yet exist are simply
+      # not mirrored (no-op) until the host-bridge renders them — additive
+      # and safe. Independent of the existing `sync.toHost.secrets`
+      # (vCluster→host); the two directions don't conflict.
+      secrets:
+        enabled: true
+        mappings:
+          byName:
+            "keycloak/*": "keycloak/*"
+            "gitea/*": "gitea/*"
+            "harbor/*": "harbor/*"
+            "newapi/*": "newapi/*"
+            "grafana/*": "grafana/*"
+            "catalyst-system/*": "catalyst-system/*"
 
   # ── In-vCluster CRD registration (#3373, OSS-native) ────────────────────
   # The init-manifests deployer (`loft-sh/vcluster` controllers

--- a/platform/bp-rtz-vcluster/blueprint.yaml
+++ b/platform/bp-rtz-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.11
+  version: 0.2.12
   card:
     title: RTZ vCluster
     summary: |

--- a/platform/bp-rtz-vcluster/chart/Chart.yaml
+++ b/platform/bp-rtz-vcluster/chart/Chart.yaml
@@ -57,8 +57,18 @@ name: bp-rtz-vcluster
 # vCluster; the host `newapi` namespace runs the LLM gateway whose vllm
 # channel consumes bp-vllm — without this carve-out it cannot reach the
 # synced Service. Additive; mirrors the #3423 carve-out.
-version: 0.2.11
-appVersion: "0.21.0"
+# 0.2.12 — Refs #3642/#3736 (2026-06-17): LOCKSTEP loft-sh/vcluster subchart
+# bump 0.21.0 → 0.23.0 (sibling to bp-mgmt-vcluster 0.2.12 + bp-dmz-vcluster
+# 0.2.8). The active `sync.fromHost.secrets` mappings land in
+# bp-mgmt-vcluster (the 7 NS#1 apps re-home into vc-mgmt); this RTZ umbrella
+# carries ONLY the version bump so all 3 vCluster umbrellas stay on the same
+# loft-sh tag — drift between siblings would surface as inconsistent syncer
+# behaviour across the DMZ / MGMT / RTZ apiservers. RTZ's Batch-A residents
+# (valkey/seaweedfs/vllm) mint no host-side DB/SSO Secret, so no
+# fromHost.secrets mapping is needed here. Syncer image tag bumped to 0.23.0
+# to match. Default render unchanged in shape (subchart version only).
+version: 0.2.12
+appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign RTZ
   vCluster. Implements docs/SOVEREIGN-MULTI-REGION-DOD.md A4
@@ -103,7 +113,14 @@ dependencies:
     # G92 EPIC #2639 (2026-06-01) — sibling bump with bp-mgmt-vcluster
     # 0.2.0 + bp-dmz-vcluster 0.2.0. See bp-mgmt-vcluster/chart/Chart.yaml
     # for the full RCA on why the 0.21.0 schema is required.
-    version: "0.21.0"
+    #
+    # #3642/#3736 (2026-06-17): 0.21.0 → 0.23.0 LOCKSTEP with bp-mgmt-vcluster
+    # + bp-dmz-vcluster (all 3 vCluster umbrellas pin the same loft-sh tag —
+    # sibling drift = inconsistent syncer behaviour). The 0.23.0
+    # sync.fromHost.secrets mappings that unblock the host→vCluster Secret
+    # crossing are declared in bp-mgmt-vcluster (where the 7 NS#1 apps move);
+    # this umbrella takes the version bump only.
+    version: "0.23.0"
     repository: "https://charts.loft.sh"
     # The subchart only renders when the umbrella's top-level
     # `rtzVcluster.enabled` is true. Default-OFF therefore renders ZERO

--- a/platform/bp-rtz-vcluster/chart/values.yaml
+++ b/platform/bp-rtz-vcluster/chart/values.yaml
@@ -54,7 +54,8 @@ rtzVcluster:
   # host-qualified repository is honoured verbatim by the helper.
   image:
     repository: "proxy-ghcr/loft-sh/vcluster"
-    tag: "0.21.0"
+    # #3642/#3736: 0.21.0 → 0.23.0 lockstep with the subchart dependency bump.
+    tag: "0.23.0"
     pullPolicy: "IfNotPresent"
 
   # ── NetworkPolicy isolation baseline ──────────────────────────────
@@ -154,7 +155,9 @@ vcluster:
         # Keep in lockstep with the umbrella rtzVcluster.image above.
         registry: harbor.openova.io
         repository: proxy-ghcr/loft-sh/vcluster
-        tag: "0.21.0"
+        # #3642/#3736: the ACTUAL syncer image — 0.21.0 → 0.23.0 to match the
+        # subchart dependency version (Chart.yaml).
+        tag: "0.23.0"
       resources:
         requests:
           cpu: "200m"

--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -179,6 +179,13 @@ name: bp-guacamole
 # (`persistentvolumeclaim "guacamole-recordings" not found`) — Pending in both
 # regions on hw146. Mirror the webapp's emptyDir/PVC `if` into guacd. Lockstep:
 # 52-bp-guacamole.yaml pin → 0.2.19. Refs #3629.
+# 0.2.21 (#3642 host-bridge): the CNPG `Cluster` gate now honours an EXPLICIT
+# `false` on guacamole.database.enabled / .cluster.enabled (the Helm
+# `default true <bool>` idiom wrongly coerced a placement-supplied false back to
+# true). Without this the #3642 host-bridge could NOT suppress the in-vCluster
+# Cluster CR (host-rendered instead) — the Cluster double-rendered inside
+# vc-mgmt where no cnpg-operator reconciles it. Default render byte-identical
+# (the key is absent → gate stays true). Lockstep: 52-bp-guacamole.yaml pin.
 # 0.2.21 (#3687, extends #3370): bootstrap self-registration —
 # templates/application-cr.yaml renders the canonical apps.openova.io/v1
 # Application CR for the slot-52 HelmRelease (gated bootstrapOwned.enabled

--- a/platform/guacamole/chart/templates/cnpg-cluster.yaml
+++ b/platform/guacamole/chart/templates/cnpg-cluster.yaml
@@ -21,7 +21,14 @@ template until the CRD is registered (bootstrap order lands bp-cnpg first).
 */ -}}
 {{- $db := .Values.guacamole.database | default dict -}}
 {{- $cl := $db.cluster | default dict -}}
-{{- if and .Values.guacamole.enabled (default true $db.enabled) (default true $cl.enabled) (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") }}
+{{- /* #3642 host-bridge: the gate must honour an EXPLICIT `false` so the
+   placement host-bridge can SUPPRESS the in-vCluster Cluster CR (host-rendered
+   instead). The Helm `default true <bool>` idiom wrongly coerces an explicit
+   false back to true (false is the bool zero-value), so test key-presence +
+   value directly — the same idiom newapi's httproute.yaml uses for ssoInit. */ -}}
+{{- $dbOn := or (not (hasKey $db "enabled")) $db.enabled -}}
+{{- $clOn := or (not (hasKey $cl "enabled")) $cl.enabled -}}
+{{- if and .Values.guacamole.enabled $dbOn $clOn (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1") }}
 {{- $name := $cl.name | default "guacamole-pg" -}}
 {{- $ns := $cl.namespace | default .Release.Namespace -}}
 {{- $owner := $cl.owner | default "guacamole" -}}

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -406,13 +406,15 @@ slots:
     # the ESO CRD (.Capabilities .Has "external-secrets.io/v1beta1") and gates
     # on bp-external-secrets so the ESO webhook is serving before grafana's
     # ExternalSecret applies — lockstep with the live 25-grafana.yaml edge.
-    # bp-mgmt-vcluster edge REMOVED (#3731): the #3642 grafana host→mgmt
-    # host-bridge was reverted to a HOST placement — its raw ExternalSecret
-    # dry-run-deadlocked the bootstrap-kit Kustomization before the ESO CRD
-    # installed (0-HR fresh-prov wedge on hw157). Grafana runs on host again
-    # (chart renders its own .Capabilities-guarded ES), so the vc-mgmt
-    # runtime edge no longer applies; re-home with #3642/#3719 next train.
-    depends_on: [bp-cnpg, bp-loki, bp-mimir, bp-tempo, bp-keycloak, bp-gateway-api, bp-external-secrets, bp-postgres-shared-b]
+    # bp-mgmt-vcluster edge RE-ADDED (#3642 integration): grafana host→mgmt
+    # host-bridge re-lands here together with the #3787 secret-delivery
+    # (vcluster 0.23.0 sync.fromHost.secrets) that unblocks the #3731 wedge —
+    # the host-rendered grafana-sso-oidc-credentials Secret now mirrors INTO
+    # vc-mgmt, and grafana's HR re-homes (kubeConfig→vc-mgmt) so it MUST gate
+    # on the bp-mgmt-vcluster runtime (the vc-mgmt Secret doesn't exist until
+    # it is Ready). Lockstep with the live 25-grafana.yaml edge (placement.yaml
+    # vcluster: mgmt; render-slot-placement.py stamps the edge).
+    depends_on: [bp-mgmt-vcluster, bp-cnpg, bp-loki, bp-mimir, bp-tempo, bp-keycloak, bp-gateway-api, bp-external-secrets, bp-postgres-shared-b]
     wave: W2.K2
   - slot: 26
     name: bp-network-policies

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -105,9 +105,13 @@ slots:
     # bp-mgmt-vcluster as a new edge — REVERTED by G105-followup
     # PR #2697/#2715/#2717/#2719/#2720 (vCluster lacks Gateway API +
     # ExternalSecret CRDs + mgmt namespace inside itself). App installs
-    # on HOST until vCluster CRD sync ships. bp-mgmt-vcluster edge
-    # dropped to match the live slot 08-openbao.yaml.
-    depends_on: [bp-gateway-api, bp-cnpg]
+    # on HOST until vCluster CRD sync ships.
+    # #3642 (2026-06-17): RE-ADDED via the OSS host-bridge — openbao re-homes
+    # into the mgmt vCluster (placement.yaml vcluster:mgmt + hostBridge:), so
+    # the runtime edge is back (the vc-mgmt Secret must be Ready first). The
+    # route + SSO ExternalSecret are HOST-rendered by the host-bridge, so no
+    # loft.sh license is needed.
+    depends_on: [bp-gateway-api, bp-cnpg, bp-mgmt-vcluster]
     wave: present
   - slot: 9
     name: bp-keycloak
@@ -610,6 +614,12 @@ slots:
       # postgresql.cnpg.io/v1 CRD first or the Cluster CR's Capabilities gate
       # skips on a fresh prov → no admin.
       - bp-cnpg
+      # #3642 (2026-06-17): bp-mgmt-vcluster edge added — guacamole re-homes
+      # into the mgmt vCluster via the OSS host-bridge (placement.yaml
+      # vcluster:mgmt + hostBridge:); the route + CNPG Cluster are HOST-rendered
+      # (the OIDC client secret is a chart-managed lookup Secret that stays
+      # in-vCluster). The runtime edge gates on the vc-mgmt Secret Ready first.
+      - bp-mgmt-vcluster
     wave: present
 
   # ---- Slot 53 — bp-netbird WireGuard zero-trust mesh + remote-access overlay.
@@ -802,9 +812,14 @@ slots:
   #     consumed by unified-rbac (ADR-0003 §3.2 + §6).
   #   - bp-keycloak: OIDC issuer for the ops-staff admin UI.
   #   - bp-cnpg: Postgres for users/credits/channels/audit (claim-driven).
+  # #3642 (2026-06-17): bp-mgmt-vcluster edge added — newapi re-homes into the
+  # mgmt vCluster via the OSS host-bridge (placement.yaml vcluster:mgmt +
+  # hostBridge:); the route + 2 ExternalSecrets + CNPG Cluster are HOST-rendered
+  # so no loft.sh license is needed. The runtime edge gates on the vc-mgmt
+  # Secret being Ready first.
   - slot: 80
     name: bp-newapi
-    depends_on: [bp-openbao, bp-keycloak, bp-cnpg]
+    depends_on: [bp-openbao, bp-keycloak, bp-cnpg, bp-mgmt-vcluster]
     wave: present
 
   # ---- Slot 95 — bp-stalwart-sovereign REMOVED 2026-05-05.


### PR DESCRIPTION
**Refs #3642** — 🛑 **DO NOT MERGE** until a fresh-prov walk confirms the 7 apps land in vc-mgmt (this is a vcluster MAJOR bump + a 7-app placement flip; render-green ≠ walk-green).

## North Star #1 — "every app IN a vCluster"

hw159 walked **13 ❌**: the 7 platform apps (grafana / harbor / keycloak / gitea / openbao / newapi / guacamole) render under the **`host`** block in the Dashboard LAYER1=vCluster treemap, **none under `mgmt`** (keycloak app card: `Namespace: flux-system`, `Placement: singleton`). This PR makes all 7 reconcile **INTO the mgmt vCluster**.

## Root cause (investigated read-only, verified against upstream)

The 7 apps are `vcluster: host` in `clusters/_template/bootstrap-kit/placement.yaml` **by design** on the pure-OSS build, blocked by **two governing constraints** the placement table documents:

- **Constraint #1 (route CRDs):** a re-homed chart ships an HTTPRoute / ExternalSecret / CNPG `Cluster` CR that the host Cilium-Gateway / ESO / cnpg-operator must reconcile. vCluster's `sync.toHost.customResources` mirror is Pro-gated/inert on OSS. **Already solved** by the host-bridge generator (#3642/#870): the CR stays host-rendered, only the workload Pod re-homes. The machinery (`render-slot-placement.py`, `hostBridge:` blocks, init-manifest CRDs) is fully built.
- **Constraint #2 (host-minted Secret crossing) — the binding constraint:** each app's workload, now inside vc-mgmt, still needs a Secret **minted on the host** (`<app>-database-secret` / `<app>-pg-app` DB credential and/or `<app>-sso-oidc-credentials`). The Pod mounts from the **vCluster's** apiserver, a different store than the host. On the pinned **vcluster 0.21.0 nothing delivered it**: `sync.fromHost.secrets` **did not exist until vcluster 0.23.0**. Result today: `keycloak-0` hangs on `MountVolume.SetUp … secret "keycloak-database-secret-x-keycloak-x-mgmt-vcluster" not found` (#3737) and grafana/harbor/gitea/newapi boot without SSO/DB env. The #3703 attempt to flip keycloak+grafana was reverted (#3733/#3737) for exactly this.

### Verified facts
- `sync.fromHost.secrets` first ships in **vcluster v0.23** ([loft.io changelog](https://releases.loft.io/changelog/vcluster-v023-expanded-fromhost-resource-syncing-and-support-for-kubernetes): *"v0.23 … three new resources can be synced from the host cluster: secrets, configMaps, and namespaced custom resources"*) and is **OSS** (only the advanced `reverseExpression` patch is Enterprise) → **no `admin.loft.sh` tether** → the Pillar-5 `bp-self-sovereign-cutover` 600s deny-egress hold still passes.
- The **per-Org marketplace path already runs vcluster-oss 0.33.x** (`core/services/provisioning/gitops/gitops.go:134`). The bootstrap mgmt/dmz/rtz vClusters being stuck on **0.21.0** is a version-skew — the platform already trusts a 0.23+ OSS line elsewhere.

So this is **not** a clean one-field flip and it does **not** need a license — it needs the vcluster bump + `fromHost.secrets` wiring + the placement flips, together.

## What this PR does — integrates BOTH halves onto one mergeable branch

Two prior sessions split the fix across two DO-NOT-MERGE branches that **neither alone flips the treemap**: #3787 (secret-delivery) and #3719 (placement). This branch merges both, resolves the `bp-mgmt-vcluster` collision (combined 0.2.12 changelog, `appVersion 0.23.0`), and fixes two integration gaps the merge exposed.

1. **Secret delivery (from #3787):** loft-sh/vcluster `0.21.0 → 0.23.0` lockstep across bp-mgmt/dmz/rtz-vcluster (umbrella + subchart syncer image tags + `appVersion` + `blueprint.yaml`). `sync.fromHost.secrets.mappings.byName` on bp-mgmt-vcluster mirrors every host Secret in the 6 moved-app namespaces (`"<ns>/*": "<ns>/*"` — keycloak/gitea/harbor/newapi/grafana/catalyst-system) into the identically-named vCluster namespace. Generic, no per-secret enumeration.
2. **Placement (from #3719):** all 7 NS#1 apps → `vcluster: mgmt` + a `hostBridge:` block in placement.yaml; `render-slot-placement.py` stamps the `kubeConfig → vc-mgmt` pivot, the `bp-mgmt-vcluster` runtime edge, and transcribes the host-side route/secret/CNPG docs. bp-mgmt-vcluster netpol carve-outs (harbor/gitea/velero/rtz). bp-guacamole CNPG `Cluster` gate honours explicit `database.cluster.enabled=false` so the host-bridge can suppress the in-vCluster Cluster CR.
3. **Integration fix A:** re-added the `02a-bp-cert-manager-issuers` host-minimum row (the #3734 split landed on main after #3719 branched; taking #3719's placement.yaml wholesale had dropped it), then `render-slot-placement.py fix` regenerated every slot from the corrected table — which also correctly re-flipped keycloak(09)+grafana(25) (main had them reverted to host).
4. **Integration fix B:** restored grafana's `bp-mgmt-vcluster` edge in `expected-bootstrap-deps.yaml` (grafana is back in mgmt) so the dependency-graph audit drift is 0.

## Test output (local)

| Gate | Result |
|---|---|
| `render-slot-placement.py check` | ✅ PASS — 64 slots, **16 in vClusters**, 10 staged |
| `audit-placement-conformance.py rendered` | ✅ PASS |
| `check-bootstrap-deps.sh` (drift/cycle audit) | ✅ PASS — **drift 0**, 13 deferred |
| `tests/e2e/bootstrap-kit` Go `TemplateClusterParses` | ✅ `ok … 0.080s` |
| `kubectl kustomize clusters/_template/bootstrap-kit` | ✅ 5050 lines, exit 0 |
| `helm dependency build` (vcluster **0.23.0** pulled from charts.loft.sh) | ✅ all 3 charts |
| `bp-{mgmt,dmz,rtz}-vcluster` + `guacamole` `tests/render.sh` (publish gate) | ✅ PASS (incl. #3373 init-manifest CRD assertion) |
| pin-sync (the 4 charts touched) | ✅ mgmt 0.2.12 / dmz 0.2.8 / rtz 0.2.12 / guacamole 0.2.23 |
| `core/controllers/application` `go build ./...` | ✅ exit 0 (no Go change needed — controller already honours the kubeConfig pivot) |

**Decisive proof the secret-delivery wiring lands:** decoding the rendered `vc-config-bp-mgmt-vcluster` Secret (the config the 0.23.0 syncer reads at boot) shows `sync.fromHost.secrets.enabled: true` with all 6 `byName` mappings present, coexisting with the existing `toHost.secrets` + `toHost.customResources` (5 CRs) — i.e. 0.23.0 accepts the schema under strict-unmarshal and emits it.

> Pre-existing pin drifts (bp-harbor 1.2.31/1.2.30, bp-postgres ×3, bp-powerdns 1.2.15/1.2.14) are charts whose auto-bump pin hook hasn't run — **unrelated, untouched here** (same note as #3719).

## 🛑 Honest risk — why DO NOT MERGE

- A vcluster **MAJOR** bump (0.21 → 0.23) can change syncer behaviour and **cannot be proven by render alone**. The real acceptance is a **fresh-prov walk**: the 7 apps land **under `mgmt`** on the LAYER1=vCluster treemap, each pod carries the `-x-<innerNs>-x-mgmt-vcluster` syncer suffix, and **no `MountVolume.SetUp … secret not found`** (the #3737 signature). PART D (per-app zero-click SSO surfaces) must stay green after the move.
- This subsumes #3787 + #3719; close those in favour of this integrated branch once a live env proves convergence. **Merge only after the walk.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
