### PR TITLE
fix(per-org-serving): unblock tenant console/app external serving — route reconcile, RBAC, DNS filter, pool-zone TLS (Refs #3376)

### DIFF
--- a/clusters/_template/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/_template/bootstrap-kit/12-external-dns.yaml
@@ -84,11 +84,26 @@ spec:
       retries: 3
   # Per-Sovereign overrides — txtOwnerId MUST be the Sovereign FQDN so two
   # Sovereigns sharing a parent zone don't fight over the same record set.
-  # domainFilters narrow the zones ExternalDNS will manage; per-Sovereign
-  # cluster overlays patch this with the actual zone list.
+  # domainFilters narrow the zones ExternalDNS will manage.
+  #
+  # #3376 fix: domainFilters now covers EVERY parent zone the Sovereign
+  # brought (primary FQDN + every role=sme-pool pool TLD), not just the
+  # Sovereign FQDN. Pre-#3376 the filter was `[${SOVEREIGN_FQDN}]` only —
+  # so external-dns saw the per-Org HTTPRoute hostnames
+  # `console.<slug>.<pool-tld>` / `<app>.<slug>.<pool-tld>` (the org-
+  # controller renders them on cilium-gateway, gateway-httproute source is
+  # enabled in platform/external-dns/chart/values.yaml) but DROPPED them
+  # because their zone (e.g. omani.homes) was outside the filter → no A
+  # record written → the customer's own console + purchased app resolved
+  # NXDOMAIN → ERR_CONNECTION_REFUSED. PARENT_DOMAINS_FILTER is a YAML
+  # inline-array of zone names derived from parent_domains_yaml in
+  # infra/providers/_shared/cloudinit-control-plane.tftpl; the envsubst
+  # default `${PARENT_DOMAINS_FILTER:-["${SOVEREIGN_FQDN}"]}` preserves the
+  # legacy single-FQDN behavior on any path that does not yet substitute
+  # the new key (no regression). txtOwnerId keeps record ownership isolated
+  # when two Sovereigns share a pool zone.
   values:
     external-dns:
       txtOwnerId: ${SOVEREIGN_FQDN}
       txtPrefix: _externaldns.
-      domainFilters:
-        - ${SOVEREIGN_FQDN}
+      domainFilters: ${PARENT_DOMAINS_FILTER:-["${SOVEREIGN_FQDN}"]}

--- a/core/controllers/organization/config/rbac/role.yaml
+++ b/core/controllers/organization/config/rbac/role.yaml
@@ -35,6 +35,25 @@ rules:
   - apiGroups: ["access.openova.io"]
     resources: ["useraccesses"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
+  # #3376 fix: the reconciler renders a per-Organization Gateway-API
+  # HTTPRoute for `console.<slug>.<parentDomain>` (tenant_route.go,
+  # issue #1629 follow-up) AND the per-Org vCluster Flux loop
+  # (per_org_flux.go, PR #3700 §4.3) writes Flux GitRepository +
+  # Kustomization CRs in flux-system. Both were authored by the
+  # controller via the runtime client but had NO matching RBAC grant —
+  # so `r.Create`/`r.Update` on a live Sovereign returned 403 and the
+  # per-Org serving + vCluster loop silently stalled. Grant the minimum:
+  #   - httproutes: render the per-tenant public route on cilium-gateway
+  #   - gitrepositories/kustomizations: author the per-Org vCluster source
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: ["gitrepositories"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: ["kustomizations"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # Leader-election lease — required when --leader-elect=true.
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]

--- a/core/controllers/organization/internal/controller/organization_controller_test.go
+++ b/core/controllers/organization/internal/controller/organization_controller_test.go
@@ -1004,6 +1004,71 @@ func TestReconcile_TenantPublic_DisabledByDefault(t *testing.T) {
 	}
 }
 
+// TestReconcile_TenantPublic_ParentDomainSet_BackendPending covers the
+// #3376 ordering case: the funnel mints the Organization CR with
+// spec.tenantPublic.{parentDomain,subdomain} set but NO backendService
+// (the provisioning service patches backendService LATER, once the
+// purchased product is Ready — tenant_public_patch.go). The reconciler
+// MUST treat "parentDomain set, backendService not-yet-set" as a normal
+// transient window: the whole Org reconcile MUST still succeed (NOT fail
+// with TenantRouteFailed), and simply NO HTTPRoute is written yet (it
+// lands on the later reconcile that the backendService PATCH triggers).
+//
+// Before the #3376 fix this path returned an error from
+// reconcileTenantRoute → the caller's fail() path marked the whole Org
+// Failed and requeued forever, so the Org never went Ready and the
+// customer's `console.<slug>.<pool-tld>` console never served.
+func TestReconcile_TenantPublic_ParentDomainSet_BackendPending(t *testing.T) {
+	t.Parallel()
+	org := sampleOrg()
+	// parentDomain + subdomain set (exactly what organization_create.go
+	// seeds on the funnel path), but backendService deliberately empty.
+	org.Spec.TenantPublic = orgapi.OrganizationTenantPublic{
+		ParentDomain: "omani.homes",
+		Subdomain:    "acme",
+	}
+	r, _, _ := makeReconciler(t, org)
+	scheme := r.Scheme()
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute",
+	}, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRouteList",
+	}, &unstructured.UnstructuredList{})
+
+	// MUST NOT error — the missing backendService is a transient ordering
+	// window, not a failure.
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "acme"},
+	}); err != nil {
+		t.Fatalf("reconcile must succeed while backendService is pending (#3376), got: %v", err)
+	}
+
+	// The Org's Ready condition MUST NOT be TenantRouteFailed — the route
+	// step was skipped, not failed.
+	got := orgapi.Organization{}
+	if err := r.Get(context.Background(), client.ObjectKey{Name: "acme"}, &got); err != nil {
+		t.Fatalf("get Organization acme: %v", err)
+	}
+	for _, c := range got.Status.Conditions {
+		if c.Type == "Ready" && c.Reason == "TenantRouteFailed" {
+			t.Errorf("Ready condition must NOT be TenantRouteFailed when backendService is merely pending (#3376); got %+v", c)
+		}
+	}
+
+	// No HTTPRoute is written yet — it lands once backendService is patched.
+	hrList := unstructured.UnstructuredList{}
+	hrList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRouteList",
+	})
+	if err := r.List(context.Background(), &hrList); err != nil {
+		t.Fatalf("list HTTPRoute: %v", err)
+	}
+	if len(hrList.Items) != 0 {
+		t.Errorf("expected 0 HTTPRoutes while backendService is pending, got %d", len(hrList.Items))
+	}
+}
+
 // ── Per-Org Keycloak realm (#3084 Part 2) ────────────────────────────
 //
 // These mirror the EnsureGroup test cases (create, idempotent-already-

--- a/core/controllers/organization/internal/controller/tenant_route.go
+++ b/core/controllers/organization/internal/controller/tenant_route.go
@@ -108,7 +108,21 @@ func (r *Reconciler) reconcileTenantRoute(ctx context.Context, org *orgapi.Organ
 	}
 	backend := strings.TrimSpace(tp.BackendService)
 	if backend == "" {
-		return false, fmt.Errorf("tenantPublic.backendService is required when parentDomain is set")
+		// #3376 fix: the funnel mints the Organization CR with
+		// tenantPublic.{parentDomain,subdomain} set but NO backendService —
+		// the provisioning service patches backendService LATER, once the
+		// purchased product becomes Ready (provision.completed /
+		// provision.app_ready → patchOrgTenantPublic, tenant_public_patch.go).
+		// Treating "parentDomain set, backendService not-yet-set" as a HARD
+		// ERROR failed the WHOLE Org reconcile at this step (the caller's
+		// fail() path) — so the Org never went Ready, the per-Org Flux loop +
+		// realm + UserAccess status never converged, and no HTTPRoute ever
+		// landed even after the product came up. This is a normal transient
+		// ordering window, NOT a failure: skip the route render (no-op) and
+		// let a later reconcile — triggered by the backendService PATCH —
+		// emit it. The Sovereign-wide `*.<sovFQDN>` tenant-wildcard route
+		// keeps the Org reachable in the meantime.
+		return false, nil
 	}
 	port := tp.BackendPort
 	if port == 0 {

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -445,6 +445,21 @@ write_files:
             SOVEREIGN_REGION_KEY: ${sovereign_region_key}
             MARKETPLACE_ENABLED: "${marketplace_enabled}"
             PARENT_DOMAINS_YAML: '${parent_domains_yaml}'
+            # PARENT_DOMAINS_FILTER (#3376) — the external-dns domainFilters
+            # list (bootstrap-kit slot 12, clusters/_template/bootstrap-kit/
+            # 12-external-dns.yaml). Pre-#3376 the filter was ONLY the
+            # Sovereign FQDN (`${sovereign_fqdn}`), so external-dns IGNORED
+            # the per-Org HTTPRoute hostnames `console.<slug>.<pool-tld>` /
+            # `<app>.<slug>.<pool-tld>` (under the role=sme-pool parent zones
+            # like omani.homes/omani.rest/omani.trade) and never wrote their
+            # A records → the customer's own console + purchased app resolved
+            # NXDOMAIN → ERR_CONNECTION_REFUSED. Deriving the filter from EVERY
+            # parent zone (primary + sme-pool) lets external-dns manage the
+            # tenant subdomains too. Inline-flow JSON array (valid YAML scalar
+            # for Flux postBuild.substitute; same pattern as PARENT_DOMAINS_
+            # YAML). txtOwnerId=${sovereign_fqdn} still isolates record
+            # ownership when two Sovereigns share a pool zone.
+            PARENT_DOMAINS_FILTER: '${jsonencode([for z in yamldecode(coalesce(parent_domains_yaml, format("[{name: \"%s\", role: \"primary\"}]", sovereign_fqdn))) : z.name])}'
             SOVEREIGN_CNPG_INSTANCES: "${sovereign_cnpg_instances}"
             CONTINUUM_ENABLED: "${continuum_enabled}"
             CLUSTER_MESH_NAME: "${cluster_mesh_name}"

--- a/products/catalyst/chart/templates/controllers/organization-controller-clusterrole.yaml
+++ b/products/catalyst/chart/templates/controllers/organization-controller-clusterrole.yaml
@@ -39,6 +39,19 @@ rules:
   - apiGroups: ["access.openova.io"]
     resources: ["useraccesses"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
+  # #3376 fix: the reconciler renders a per-Organization Gateway-API
+  # HTTPRoute for `console.<slug>.<parentDomain>` (tenant_route.go,
+  # issue #1629 follow-up) attached to cilium-gateway/kube-system. It
+  # was authored via the runtime client (r.Create/r.Update) but this
+  # ClusterRole granted NO `gateway.networking.k8s.io` verbs — so on a
+  # live Sovereign every per-tenant route write 403'd and the customer's
+  # `console.<slug>.<pool-tld>` host never attached to a route (it fell
+  # through to the Sovereign-wide tenant-wildcard / connection-refused).
+  # The Flux GitRepository + Kustomization grants below (per_org_flux.go)
+  # were already present; the HTTPRoute grant was the missing peer.
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/products/catalyst/chart/templates/sovereign-tls-vars-cm.yaml
+++ b/products/catalyst/chart/templates/sovereign-tls-vars-cm.yaml
@@ -83,6 +83,22 @@ parses it as the materialised listener list.
 {{-   $sanitised := replace "." "-" $z.name }}
 {{-   $httpsName := ternary "https" (printf "https-%s" $sanitised) $single }}
 {{-   $httpName := ternary "http" (printf "http-%s" $sanitised) $single }}
+{{- /* #3376 fix: per-zone certificate binding. The primary zone (the
+       Sovereign FQDN apex, role=primary) keeps the per-prov cert
+       sovereign-wildcard-tls-fqdnDashed minted by cilium-gateway-cert.yaml
+       (the TBD-A29 per-prov LE bucket; its SAN is the primary apex
+       wildcard). A role=sme-pool zone (e.g. omani.homes) is NOT covered by
+       that cert, so its wildcard listener previously bound to a cert that
+       did not match the hostname, leaving the listener Programmed=False and
+       tenant hosts under the pool zone connection-refused. Bind sme-pool
+       zone listeners to the per-zone Secret sovereign-wildcard-tls-
+       sanitised that sovereign-wildcard-certs.yaml now mints (re-enabled in
+       this PR). Selection keys only off the zone role field (data, not
+       code) so it is generic for any pool TLD. */}}
+{{- $zoneSecret := $secretName }}
+{{- if and (ne $z.name $fqdn) (eq (default "primary" $z.role) "sme-pool") }}
+{{-   $zoneSecret = printf "sovereign-wildcard-tls-%s" $sanitised }}
+{{- end }}
 {{-   $httpsListener := dict
         "name" $httpsName
         "port" 30443
@@ -90,7 +106,7 @@ parses it as the materialised listener list.
         "hostname" (printf "*.%s" $z.name)
         "tls" (dict
           "mode" "Terminate"
-          "certificateRefs" (list (dict "kind" "Secret" "name" $secretName))
+          "certificateRefs" (list (dict "kind" "Secret" "name" $zoneSecret))
         )
         "allowedRoutes" (dict "namespaces" (dict "from" "All"))
       }}

--- a/products/catalyst/chart/templates/sovereign-wildcard-certs.yaml
+++ b/products/catalyst/chart/templates/sovereign-wildcard-certs.yaml
@@ -82,7 +82,39 @@ Skip-render takes precedence over `.Values.wildcardCert.enabled` —
 operators that opt OUT (enabled=false) still get zero output, and
 operators that opt IN (enabled=true) now get zero output too.
 */}}
-{{- if false }}
+{{- /* #3376 re-enable for sme-pool zones ONLY.
+
+The A29 skip-render guard (`{{- if false }}`) above was added because
+this template minted `*.<parent>` for EVERY zone — including the PRIMARY
+zone (the Sovereign's own FQDN apex). That collided with the per-prov
+cert `sovereign-wildcard-tls-<fqdnDashed>` from cilium-gateway-cert.yaml
+(both wrote a `*.<primary>` identifier set) and burned a second LE
+5/168h slot on every reprov.
+
+#3376 root cause: a role=sme-pool zone (omani.homes / omani.rest /
+omani.trade) carries the per-Org tenant subdomains (`<slug>.<pool-tld>`,
+`console.<slug>.<pool-tld>`). The Cilium Gateway renders a `*.<pool-tld>`
+listener for it (sovereign-tls-vars-cm.yaml), but NO cert covered that
+hostname — the per-prov cert is `*.<primary-fqdn>` only — so the listener
+sat Programmed=False and tenant hosts under the pool zone were
+connection-refused. The fix is a `*.<pool-tld>` cert PER sme-pool zone,
+bound to that zone's listener (sovereign-tls-vars-cm.yaml change in this
+same PR).
+
+We render this template again, but the zone loop below now SKIPS the
+primary zone (role=primary or name==sovereignFQDN) so the A29 dual-cert
+collision never returns — only the sme-pool zones, which the per-prov
+cert legitimately does not cover, get a Certificate here. Each is a
+DISTINCT LE identifier set (`{*.omani.homes, omani.homes}`) in its own
+5/168h bucket, independent of the primary-zone bucket.
+
+NOTE on wildcard depth: a `*.omani.homes` cert covers ONE label depth —
+`<slug>.omani.homes` ✅ but NOT `console.<slug>.omani.homes` (2-label).
+The 2-label per-tenant console host needs a per-Org `*.<slug>.<pool-tld>`
+listener+cert (the analogue of the TBD-A32 per-prov 2-label pair the
+Sovereign's own console uses). That per-Org listener is tracked as the
+remaining work in this ticket (see PR body) — this template closes the
+1-label-deep tenant-host gap. */}}
 {{- if .Values.wildcardCert.enabled }}
 {{- $ns := .Values.wildcardCert.namespace | default "kube-system" }}
 {{/*
@@ -132,6 +164,15 @@ operators that opt IN (enabled=true) now get zero output too.
 {{- end }}
 
 {{- range $i, $z := $zones }}
+{{- /* #3376: render the per-zone wildcard cert ONLY for sme-pool zones.
+       The PRIMARY zone (role=primary, or name == the Sovereign FQDN) is
+       already covered by the per-prov cert sovereign-wildcard-tls-
+       <fqdnDashed> from cilium-gateway-cert.yaml; minting `*.<primary>`
+       here too is the exact A29 dual-cert collision + LE double-burn the
+       skip-render guard was added to avoid. Skip it. sme-pool zones are
+       NOT covered by the per-prov cert, so they get their own cert here.
+       Keys only off the `role` field (data) — generic for any pool TLD. */}}
+{{- if and (ne $z.name $.Values.global.sovereignFQDN) (eq (default "primary" $z.role) "sme-pool") }}
 {{- /* Sanitise the zone name into a DNS-1123-compatible label suffix.
        PowerDNS zone names contain dots; K8s resource names cannot.
        `sovereign-wildcard-tls-omani.works` -> `sovereign-wildcard-tls-omani-works`.
@@ -141,10 +182,8 @@ operators that opt IN (enabled=true) now get zero output too.
        sovereign-tls Kustomization's `sovereign-wildcard-tls` resource.
        The Cilium Gateway listener for each zone references the
        corresponding sovereign-wildcard-tls-<sanitised-zone> Secret in
-       its certificateRefs block — operators that ship a multi-zone
-       Sovereign update the Gateway listener config in their per-cluster
-       overlay (or rely on the chart's Gateway template once issue #831
-       lands a multi-listener Gateway). */}}
+       its certificateRefs block — sovereign-tls-vars-cm.yaml binds the
+       sme-pool zone listeners to exactly this Secret (#3376). */}}
 {{- $sanitised := replace "." "-" $z.name }}
 {{- $secretName := default (printf "sovereign-wildcard-tls-%s" $sanitised) $z.secretName }}
 ---
@@ -175,6 +214,6 @@ spec:
   {{- with $renewBefore }}
   renewBefore: {{ . }}
   {{- end }}
-{{- end }}
-{{- end }}
-{{- end }}{{/* end A29 skip-render guard */}}
+{{- end }}{{/* end #3376 sme-pool-only gate */}}
+{{- end }}{{/* end range $zones */}}
+{{- end }}{{/* end if .Values.wildcardCert.enabled */}}


### PR DESCRIPTION
## Root cause chain (hw159 funnel terminal — `console.acme.omani.homes` + `wordpress.acme.omani.homes` = ERR_CONNECTION_REFUSED)

The funnel reaches an **ACTIVE** customer Org (`acme`), but its own console + purchased app do not serve externally. I traced the four-stage per-Org serving chain (DNS → gateway listener → wildcard cert → org-controller HTTPRoute) and found **every stage broken**:

1. **org-controller route reconcile fails the whole Org** — `reconcileTenantRoute` (`tenant_route.go:110`) treats *"`tenantPublic.parentDomain` set but `backendService` empty"* as a **hard error**. But the funnel (`organization_create.go:170-175`) mints the Org CR with `parentDomain`+`subdomain` set and **no** `backendService` (the provisioning service patches `backendService` LATER, on `provision.completed`/`provision.app_ready` → `patchOrgTenantPublic`, `tenant_public_patch.go:100-114`). So the Org reconcile hit `fail()` every 30s and never converged — no HTTPRoute, ever.

2. **org-controller has no RBAC to write HTTPRoutes** — the reconciler authors per-Org HTTPRoutes via the runtime client (`tenant_route.go` `r.Create`/`r.Update`), but the deployed ClusterRole (`organization-controller-clusterrole.yaml`) granted **zero** `gateway.networking.k8s.io` verbs → every route write would 403 on a live Sovereign. (The Flux `gitrepositories`/`kustomizations` grants were already present; the `httproutes` peer was missing.)

3. **external-dns drops the tenant subdomains** — `12-external-dns.yaml` set `domainFilters: [${SOVEREIGN_FQDN}]` only (e.g. `hw159.omani.works`). external-dns watches `gateway-httproute`, but the per-Org route hostname `console.acme.omani.homes` is under `omani.homes` (a `role: sme-pool` parent zone) — **outside the filter** → no A record written → **NXDOMAIN** → connection-refused. (Confirmed: `platform/external-dns/chart/values.yaml` enables `gateway-httproute`; the bootstrap overlay only filtered the Sovereign FQDN.)

4. **No TLS cert covers the pool zone** — the Cilium Gateway renders a `*.omani.homes` listener (`sovereign-tls-vars-cm.yaml`) when `omani.homes ∈ parentZones`, but it bound to `sovereign-wildcard-tls-<fqdn-dashed>` whose **only SANs are `*.<sovereignFQDN>` + apex** (`cilium-gateway-cert.yaml:106-107`) — no `*.omani.homes`. A Gateway listener whose cert doesn't match its hostname stays **Programmed=False** → no TLS termination. The per-zone wildcard cert that *would* mint `*.omani.homes` (`sovereign-wildcard-certs.yaml`) was **hard-disabled** (`{{- if false }}`, the A29 skip-render).

## What this PR fixes

| # | Link | Change |
|---|---|---|
| 1 | route reconcile | `reconcileTenantRoute` returns `(false, nil)` (skip, not fail) when `backendService` is pending → Org converges; route lands on the later reconcile triggered by the `backendService` PATCH. `tenant_route.go` |
| 2 | RBAC | add `gateway.networking.k8s.io/httproutes` `{get,list,watch,create,update,patch}` to the org-controller ClusterRole (chart copy + kubebuilder `config/rbac/role.yaml`). |
| 3 | DNS | `domainFilters` now covers **every** parent zone (primary + sme-pool), data-driven via a new `PARENT_DOMAINS_FILTER` substitution derived from `parent_domains_yaml` in the shared cloud-init; envsubst default `${PARENT_DOMAINS_FILTER:-["${SOVEREIGN_FQDN}"]}` = **no regression** for single-zone provs. |
| 4 | pool-zone TLS | re-enable the per-zone wildcard cert **for sme-pool zones only** (skipping the primary zone to avoid the A29 dual-cert / LE-bucket collision), and bind each sme-pool listener to its own `*.<zone>` cert. `sovereign-wildcard-certs.yaml` + `sovereign-tls-vars-cm.yaml` |

## Tests (all green locally)

- `go build` + `go vet` + `go test -race` on `core/controllers/organization/...` — incl. a **new test** `TestReconcile_TenantPublic_ParentDomainSet_BackendPending` asserting the #3376 ordering case (reconcile succeeds, **not** `TenantRouteFailed`; no route yet).
- `helm template` renders single-zone **and** 2-zone (sme-pool) correctly — verified the `*.omani.homes` listener binds to `sovereign-wildcard-tls-omani-homes`, the per-zone cert renders for `omani.homes` **only** (not the primary), and the `httproutes` grant is present. `helm lint` 0 failures.
- `kustomize build clusters/_template/bootstrap-kit` green (the `${PARENT_DOMAINS_FILTER:-…}` scalar parses).
- `tofu validate` + render of the `templatefile()` expression: `domainFilters: ["hw159.omani.works","omani.homes"]` (multi) / `["t99.omani.works"]` (single fallback).
- `scripts/lint-cloudinit.sh both` → **PASS hetzner + huawei** (cloud-agnostic).

## Remaining work (honest scope — needs a live cut-over prov to validate)

This is a genuinely multi-component failure; this PR fixes the route/RBAC/DNS/pool-TLS links but **two pieces remain**, both called out inline:

- **2-label-deep console host.** The per-tenant console is `console.<slug>.<pool-tld>` (e.g. `console.acme.omani.homes`). A `*.omani.homes` wildcard listener+cert matches **one** label depth (`acme.omani.homes`) but **not** `console.acme.omani.homes`. The clean generic fix is a **per-Org `*.<slug>.<pool-tld>` listener + cert** — the exact analogue of the existing TBD-A32 per-prov `*.<sovereignFQDN>` 2-label pair the Sovereign's own console uses. That requires either appending a per-Org listener to the shared `cilium-gateway` Gateway from the org-controller (concurrency design decision) or a Gateway-API ListenerSet; I did **not** ship a half-built Gateway mutation. After this PR, `<slug>.<pool-tld>` (1-label) hosts terminate TLS; the 2-label `console.` host still needs the per-Org pair.
- **Purchased-app HR + customer-console backend.** `console.<slug>.<pool-tld>` should route to the **Catalyst console** (`catalyst-ui`+`catalyst-api`, mirroring the parent `console.<sov-fqdn>` route), while `wordpress.<slug>.<pool-tld>` serves the app — but today the org-controller's gitops renderer authors **only a vCluster shell** (`gitops/manifests.go`), and the purchased WordPress HR + the `backendService` patch come from the **legacy provisioning path** (`consumer.go`→`runProvisioningWorkflow`, which writes to `clusters/<sov>/sme-tenants` and uses a **Traefik Ingress hardcoded to `<slug>.omani.rest`** — wrong ingress class, wrong host). Reconciling these two parallel control planes onto one Organization record + one HTTPRoute backend is **#3687**'s scope per #3376 §11; this PR makes the producer→consumer→controller chain RUN without failing.

**Do NOT merge** — opening for founder review against the DoD. Per the constraint I did **not** bump `products/catalyst/chart/Chart.yaml` (orchestrator coordinates the version + slot pins).

Refs #3376
🤖 Generated with [Claude Code](https://claude.com/claude-code)
