### PR TITLE
feat(console): add Organization treemap dimension to Sovereign Dashboard (Refs #3687)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/dashboard.go
+++ b/products/catalyst/bootstrap/api/internal/handler/dashboard.go
@@ -93,14 +93,20 @@ type treemapResponse struct {
 // region and vcluster added 2026-05-16 (DoD D16/D19) so multi-region
 // operators can pivot the treemap by their actual topology hierarchy
 // (Cloud → Region → Cluster → vCluster → Namespace → Application).
+// organization added 2026-06-18 (#3687 fold #3692) so the operator can
+// pivot the treemap by the owning Organization — the same
+// `openova.io/organization` label join key the per-Org showback uses.
+// podRow.org is already populated in buildPodRows; this just exposes it
+// as a first-class group_by dimension (the Lane-E UAT FAIL).
 var dashboardDimension = map[string]struct{}{
-	"sovereign":   {},
-	"region":      {},
-	"cluster":     {},
-	"vcluster":    {},
-	"family":      {},
-	"namespace":   {},
-	"application": {},
+	"sovereign":    {},
+	"region":       {},
+	"cluster":      {},
+	"vcluster":     {},
+	"family":       {},
+	"namespace":    {},
+	"application":  {},
+	"organization": {},
 }
 
 var dashboardSizeBy = map[string]struct{}{
@@ -706,6 +712,21 @@ func dimensionKey(r podRow, dim string) (string, string) {
 			return r.vcluster, r.vcluster
 		}
 		return "host", "host"
+	case "organization":
+		// Organization name derives from the pod's namespace
+		// `openova.io/organization` (or `catalyst.openova.io/organization`)
+		// label — the SAME single join key the per-Org showback
+		// (#3687 fold #3677) attributes consumption by, resolved into
+		// podRow.org at buildPodRows time. Pods in host/control-plane
+		// namespaces carry no Org label (org == "") and roll into the
+		// synthetic platform-overhead bucket — visible + labelled, never
+		// silently dropped and never mis-attributed to a tenant. The
+		// bucket id is the same `platformOrg` sentinel the showback uses
+		// so the two surfaces agree on the unattributed estate.
+		if r.org != "" {
+			return r.org, r.org
+		}
+		return platformOrg, "Platform overhead"
 	case "family":
 		return r.family, titleCase(r.family)
 	case "namespace":

--- a/products/catalyst/bootstrap/api/internal/handler/dashboard_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/dashboard_test.go
@@ -891,3 +891,95 @@ func TestDropEphemeralRows_FiltersJobOwnedPods(t *testing.T) {
 	}
 }
 
+/* ── #3687 fold #3692 — Organization dimension ───────────────────────── */
+
+// mkDashNamespaceOrg produces an unstructured Namespace carrying the
+// canonical `openova.io/organization` label the treemap's organization
+// grouping (and the per-Org showback) read. Empty `org` omits the label
+// so the host/control-plane (no-org) fallback can be exercised.
+func mkDashNamespaceOrg(name, org string) *unstructured.Unstructured {
+	labels := map[string]any{}
+	if org != "" {
+		labels["openova.io/organization"] = org
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]any{
+			"name":            name,
+			"resourceVersion": "1",
+			"labels":          labels,
+		},
+	}}
+}
+
+// TestDashboardTreemap_OrganizationFromNamespaceLabel — grouping by
+// `organization` bucketises pods by the owning Organization, resolved
+// from the host Namespace's `openova.io/organization` label (the single
+// join key the per-Org showback uses). Pods in namespaces WITHOUT an
+// org label (host/control-plane) roll into the "Platform overhead"
+// bucket — visible + labelled, never mis-attributed to a tenant.
+func TestDashboardTreemap_OrganizationFromNamespaceLabel(t *testing.T) {
+	h := newDashHandlerWithCache(t, "alpha", false,
+		mkDashNamespaceOrg("acme", "acme"),
+		mkDashNamespaceOrg("beta", "beta"),
+		mkDashNamespaceOrg("kube-system", ""), // no org label → platform overhead
+		mkDashPodOnNode("acme", "p1", "blog", ""),
+		mkDashPodOnNode("beta", "p2", "shop", ""),
+		mkDashPodOnNode("kube-system", "p3", "cilium", ""),
+	)
+	out := dashGet(t, h, "deployment_id=alpha&group_by=organization&color_by=health&size_by=cpu_request")
+	if len(out.Items) != 3 {
+		t.Fatalf("expected 3 org buckets (acme,beta,Platform overhead); got %d (%+v)",
+			len(out.Items), out)
+	}
+	names := map[string]bool{}
+	for _, it := range out.Items {
+		names[it.Name] = true
+	}
+	for _, want := range []string{"acme", "beta", "Platform overhead"} {
+		if !names[want] {
+			t.Errorf("expected org bucket %q; got %v", want, names)
+		}
+	}
+}
+
+// TestDashboardTreemap_OrganizationDrillToApplication — the canonical
+// Lane-E view: Layer-1 Organization → Layer-2 Application. A tenant's
+// org cell nests its own apps; the unattributed estate nests under
+// "Platform overhead".
+func TestDashboardTreemap_OrganizationDrillToApplication(t *testing.T) {
+	h := newDashHandlerWithCache(t, "alpha", false,
+		mkDashNamespaceOrg("acme", "acme"),
+		mkDashPodOnNode("acme", "p1", "blog", ""),
+		mkDashPodOnNode("acme", "p2", "blog", ""),
+	)
+	out := dashGet(t, h, "deployment_id=alpha&group_by=organization,application&color_by=health&size_by=cpu_request")
+	if len(out.Items) != 1 || out.Items[0].Name != "acme" {
+		t.Fatalf("expected single org bucket 'acme'; got %+v", out.Items)
+	}
+	kids := out.Items[0].Children
+	if len(kids) != 1 || kids[0].Name != "blog" {
+		t.Fatalf("expected acme to nest the 'blog' application; got %+v", kids)
+	}
+}
+
+// TestDimensionKey_OrganizationFallsBackToPlatformOverhead — the unit
+// contract: an empty-org row keys on the synthetic platformOrg id (the
+// SAME sentinel the showback uses) so the two surfaces agree on the
+// unattributed estate, and renders the human-readable "Platform
+// overhead" label.
+func TestDimensionKey_OrganizationFallsBackToPlatformOverhead(t *testing.T) {
+	id, name := dimensionKey(podRow{org: "acme"}, "organization")
+	if id != "acme" || name != "acme" {
+		t.Errorf("labelled org: got id=%q name=%q, want acme/acme", id, name)
+	}
+	id, name = dimensionKey(podRow{org: ""}, "organization")
+	if id != platformOrg {
+		t.Errorf("empty org: got id=%q, want platformOrg sentinel %q", id, platformOrg)
+	}
+	if name != "Platform overhead" {
+		t.Errorf("empty org: got name=%q, want \"Platform overhead\"", name)
+	}
+}
+

--- a/products/catalyst/bootstrap/ui/src/components/TreemapLayerController.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/TreemapLayerController.test.tsx
@@ -130,3 +130,32 @@ describe('TreemapLayerController — dimension exclusion', () => {
     expect(values).not.toContain('family')
   })
 })
+
+describe('TreemapLayerController — Organization dimension (#3687 fold #3692)', () => {
+  it('offers Organization as a Layer-1 dimension', () => {
+    render(<Harness initialLayers={['cluster']} />)
+    const layer1 = screen.getByTestId('treemap-layer-0-select') as HTMLSelectElement
+    const values = Array.from(layer1.querySelectorAll('option')).map((o) => (o as HTMLOptionElement).value)
+    expect(values).toContain('organization')
+    // The full topology set remains available alongside the new dimension.
+    for (const dim of ['sovereign', 'region', 'cluster', 'vcluster', 'family', 'namespace', 'application']) {
+      expect(values).toContain(dim)
+    }
+  })
+
+  it('renders the human label "Organization" for the option', () => {
+    render(<Harness initialLayers={['cluster']} />)
+    const layer1 = screen.getByTestId('treemap-layer-0-select') as HTMLSelectElement
+    const orgOption = Array.from(layer1.querySelectorAll('option')).find(
+      (o) => (o as HTMLOptionElement).value === 'organization',
+    ) as HTMLOptionElement | undefined
+    expect(orgOption?.textContent).toBe('Organization')
+  })
+
+  it('selecting Organization in Layer-1 drives the layers state', () => {
+    render(<Harness initialLayers={['application']} />)
+    const layer1 = screen.getByTestId('treemap-layer-0-select') as HTMLSelectElement
+    fireEvent.change(layer1, { target: { value: 'organization' } })
+    expect(layer1.value).toBe('organization')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/components/TreemapLayerController.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/TreemapLayerController.tsx
@@ -53,13 +53,14 @@ const COLOR_OPTIONS: { value: TreemapColorBy; label: string }[] = [
 ]
 
 const DIMENSION_OPTIONS: { value: TreemapDimension; label: string }[] = [
-  { value: 'sovereign',   label: 'Sovereign' },
-  { value: 'region',      label: 'Region' },
-  { value: 'cluster',     label: 'Cluster' },
-  { value: 'vcluster',    label: 'vCluster' },
-  { value: 'family',      label: 'Family' },
-  { value: 'namespace',   label: 'Namespace' },
-  { value: 'application', label: 'Application' },
+  { value: 'organization', label: 'Organization' },
+  { value: 'sovereign',    label: 'Sovereign' },
+  { value: 'region',       label: 'Region' },
+  { value: 'cluster',      label: 'Cluster' },
+  { value: 'vcluster',     label: 'vCluster' },
+  { value: 'family',       label: 'Family' },
+  { value: 'namespace',    label: 'Namespace' },
+  { value: 'application',  label: 'Application' },
 ]
 
 /** Hard upper bound — recharts treemap legibility falls off a cliff

--- a/products/catalyst/bootstrap/ui/src/lib/treemap.types.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/treemap.types.ts
@@ -25,11 +25,17 @@ import { API_BASE } from '@/shared/config/urls'
 /**
  * The granularity dimension a treemap layer groups by.
  *
- *   • application — Helm release / bp-* unit
- *   • namespace   — Kubernetes namespace
- *   • cluster     — Sovereign cluster (one per kubeconfig)
- *   • family      — product family (observability, security, …)
- *   • sovereign   — top-level Sovereign tenant
+ *   • application  — Helm release / bp-* unit
+ *   • namespace    — Kubernetes namespace
+ *   • cluster      — Sovereign cluster (one per kubeconfig)
+ *   • family       — product family (observability, security, …)
+ *   • sovereign    — top-level Sovereign tenant
+ *   • region       — cloud region (multi-region topology)
+ *   • vcluster     — vCluster role (mgmt/dmz/rtz; host pods → "host")
+ *   • organization — owning Organization, keyed on the
+ *     `openova.io/organization` label join key (the same key the per-Org
+ *     showback attributes by). Pods with no Org label (host/control-plane
+ *     namespaces) roll into a single "Platform overhead" bucket.
  */
 export type TreemapDimension =
   | 'application'
@@ -39,6 +45,7 @@ export type TreemapDimension =
   | 'sovereign'
   | 'region'
   | 'vcluster'
+  | 'organization'
 
 /**
  * What the gradient maps to. The backend stamps every cell with a

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
@@ -9,8 +9,9 @@
  *   • Recharts <Treemap>, NOT raw D3. Recharts handles the squarified
  *     layout; we only own the cell renderer + the toolbar + drill-down.
  *   • Up to 4 layers, picked from
- *     [sovereign | cluster | family | namespace | application]. The
- *     first layer is the outer ring; deeper layers nest inside.
+ *     [organization | sovereign | region | cluster | vcluster |
+ *     family | namespace | application]. The first layer is the outer
+ *     ring; deeper layers nest inside.
  *   • Click a parent cell → drill in (push onto a breadcrumb stack).
  *     Clicking a breadcrumb pops back. NO refetch — the breadcrumb
  *     walks the in-memory tree.
@@ -150,27 +151,31 @@ export function Dashboard({
   })
   const sovereignFQDN = snapshot?.sovereignFQDN ?? snapshot?.result?.sovereignFQDN ?? null
 
-  // PR M (2026-05-17 t142 founder follow-up #1): default Layer-1 = `cluster`
-  // on multi-region Sovereigns so the operator sees the 3-cluster grouping
-  // immediately. Previously default was `['family', 'application']` —
-  // founder opened /dashboard, saw family-grouped bubbles, concluded the
-  // multi-cluster fix was broken.
+  // #3687 fold #3692 (2026-06-18): default Layer-1 = `organization` on the
+  // Sovereign Console so the operator's landing treemap groups by the
+  // owning Organization (customer estate vs platform overhead) drillable
+  // to Application — the canonical object model the Lane-E UAT asserts,
+  // not a raw infra pod treemap. The Organization dimension keys on the
+  // `openova.io/organization` label join key (same as the per-Org
+  // showback); host/control-plane pods roll into a single "Platform
+  // overhead" bucket. Operators can still pivot to cluster/region for the
+  // multi-region topology view via the Layer-1 selector.
+  //
+  // Prior default was `['cluster', 'application']` (PR M, 2026-05-17 t142
+  // founder follow-up #1) so multi-region operators saw the 3-cluster
+  // grouping; cluster/region remain one click away in the selector.
   //
   // Wave 2 Family D (t10 regression): the snapshot-driven `sovereignFQDN`
   // is fetched asynchronously via SSE — on first paint it is null, so the
-  // default fell back to `['family', 'application']` even on a Sovereign
-  // Console. Test agent caught:
-  //
-  //     DOM testid `treemap-layer-0-select` value="family" on first paint
-  //
-  // Fix: read mode synchronously from `DETECTED_MODE` (window.location-
-  // derived at module load, stable for the lifetime of the page). This
-  // is the SAME source the SovereignSidebar + cloud-list routes use for
-  // their mode-gated rendering, so default Layer-1 stays consistent with
-  // the rest of the sidebar's Sovereign affordances.
+  // default must NOT depend on it. Read mode synchronously from
+  // `DETECTED_MODE` (window.location-derived at module load, stable for
+  // the lifetime of the page) — the SAME source the SovereignSidebar +
+  // cloud-list routes use for their mode-gated rendering, so default
+  // Layer-1 stays consistent with the rest of the sidebar's Sovereign
+  // affordances and is deterministic on first paint.
   const defaultLayers: readonly TreemapDimension[] =
     DETECTED_MODE.mode === 'sovereign'
-      ? ['cluster', 'application']
+      ? ['organization', 'application']
       : ['family', 'application']
   const [layers, setLayers] = useState<readonly TreemapDimension[]>(
     initialLayers ?? defaultLayers,


### PR DESCRIPTION
## The gap (walked live on hw159 — Lane E)

`docs/ledger/uat-walkthrough/canonical-org-app-cr-model-live-end-to-end.md` Lane E rows **E1 + E4** are FAILs: the Dashboard treemap (`/dashboard`) Layer-1/Layer-2 selector offered **Sovereign · Region · Cluster · vCluster · Family · Namespace · Application** but had **no `Organization` dimension**. The #3687 object model makes Organization a first-class entity (the `/organizations` page lists parent + customer Orgs like Acme Corp), yet the treemap could not group resources BY Organization. Walk verdict:

> "the dashboard treemap still has no Organization Layer-1 → the Organization model is surfaced on `/organizations`, not as a treemap dimension."

(Maps to `docs/ledger/PATH-TO-100.md` Bucket C — "Feature with no UI yet … treemap Organization layer" → build the UI surface, GAP → ✅.)

## Key finding — the data was already wired

The treemap grouping/rollup is done **server-side** in `products/catalyst/bootstrap/api/internal/handler/dashboard.go` (the React UI just sends `group_by=` and renders the returned tree). That handler **already resolves `podRow.org`** from the `openova.io/organization` (fallback `catalyst.openova.io/organization`) namespace label — the **same single join key** the per-Org showback (#3687 fold #3677) attributes consumption by. The ONLY thing missing was registering `organization` as a `group_by` dimension + offering it in the selector. **No new backend field or collection path was needed** — this is a fully-functional dimension, not a non-functional selector.

## What I added

**Backend** (`internal/handler/dashboard.go`)
- Registered `organization` in `dashboardDimension` (so `group_by=organization` is accepted, not 400'd).
- Added `case "organization"` to `dimensionKey`: real org → its own bucket; empty org (host/control-plane namespaces) → the synthetic `platformOrg` bucket labelled **"Platform overhead"** — the SAME sentinel the showback uses, so the two surfaces agree on the unattributed estate and infra is never mis-attributed to a tenant.

**Frontend**
- `src/lib/treemap.types.ts`: added `'organization'` to the `TreemapDimension` union (+ doc).
- `src/components/TreemapLayerController.tsx`: added the **Organization** option (first, as the top-level business grouping) to `DIMENSION_OPTIONS`.
- `src/pages/sovereign/Dashboard.tsx`: default Layer-1 on the Sovereign Console is now `['organization','application']` so the landing treemap groups by Organization drillable to Application — the canonical model Lane E asserts. `cluster`/`region` remain one click away in the selector for the multi-region topology view.

## Tests

- **3 new Go tests** (`dashboard_test.go`): org-from-namespace-label bucketing (acme/beta/Platform-overhead), `organization,application` drill nesting, and a `dimensionKey` unit asserting empty-org → `platformOrg`/"Platform overhead".
- **3 new vitest tests** (`TreemapLayerController.test.tsx`): Organization offered as a Layer-1 option alongside the full topology set, the human label is "Organization", and it is selectable.

## Build / test output

```
# backend
go build ./internal/handler/                → BUILD_EXIT=0
go test  ./internal/handler/ (full package) → ok  91.978s   (3 new org tests pass; 0 regressions)

# frontend
npm run typecheck (tsc -b --noEmit)         → 0 errors
npm run build     (tsc -b && vite build)    → ✓ built
npx eslint <touched files>                  → 0 errors (2 pre-existing react-hooks warnings at Dashboard.tsx:199/334, in code I did not touch)
vitest TreemapLayerController.test.tsx      → 12 passed (9 existing + 3 new)
```

**Pre-existing unrelated failures:** the full `vitest run` shows 70 failures across 10 files (PinInput6, ParentDomains, UserAccess, ProvisionPage-SSE, ResourceDetail, Dashboard drill-click, Jobs, Settings, StepComponents, ExecPanel). I verified these are **identical on the clean baseline with my changes stashed** (jsdom/recharts/tanstack-router `waitFor` timing flakes) — this PR introduces **zero** new failures. `TreemapLayerController.test.tsx` passes fully; the 1 `Dashboard.test.tsx` failure is the recharts SVG click-navigation flake (uses explicit `initialLayers`, not my default).

Not merged — leaving for review + a live hw-prov walk to flip E1/E4.

Refs #3687

🤖 Generated with [Claude Code](https://claude.com/claude-code)