### PR TITLE
fix(cloudinit): conditional PARENT_DOMAINS_FILTER — restore 3-region render under Hetzner 32256B cap (Refs #3376)

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -448,18 +448,26 @@ write_files:
             # PARENT_DOMAINS_FILTER (#3376) — the external-dns domainFilters
             # list (bootstrap-kit slot 12, clusters/_template/bootstrap-kit/
             # 12-external-dns.yaml). Pre-#3376 the filter was ONLY the
-            # Sovereign FQDN (`${sovereign_fqdn}`), so external-dns IGNORED
-            # the per-Org HTTPRoute hostnames `console.<slug>.<pool-tld>` /
-            # `<app>.<slug>.<pool-tld>` (under the role=sme-pool parent zones
-            # like omani.homes/omani.rest/omani.trade) and never wrote their
-            # A records → the customer's own console + purchased app resolved
-            # NXDOMAIN → ERR_CONNECTION_REFUSED. Deriving the filter from EVERY
-            # parent zone (primary + sme-pool) lets external-dns manage the
-            # tenant subdomains too. Inline-flow JSON array (valid YAML scalar
-            # for Flux postBuild.substitute; same pattern as PARENT_DOMAINS_
-            # YAML). txtOwnerId=${sovereign_fqdn} still isolates record
-            # ownership when two Sovereigns share a pool zone.
-            PARENT_DOMAINS_FILTER: '${jsonencode([for z in yamldecode(coalesce(parent_domains_yaml, format("[{name: \"%s\", role: \"primary\"}]", sovereign_fqdn))) : z.name])}'
+            # Sovereign FQDN, so external-dns IGNORED the per-Org HTTPRoute
+            # hostnames `console.<slug>.<pool-tld>` / `<app>.<slug>.<pool-tld>`
+            # (under the role=sme-pool parent zones omani.homes/.rest/.trade)
+            # and never wrote their A records → NXDOMAIN → CONNECTION_REFUSED.
+            # Deriving the filter from EVERY parent zone lets external-dns
+            # manage the tenant subdomains too.
+            #
+            # SIZE (#3793 → Refs #3376): emit this key ONLY when the Sovereign
+            # brought >1 parent zone (i.e. sme-pool zones beyond the primary
+            # FQDN). When there is just the single primary zone — the default
+            # zero-touch flow + every single-zone prov — 12-external-dns.yaml's
+            # envsubst default $${PARENT_DOMAINS_FILTER:-["$${SOVEREIGN_FQDN}"]}
+            # already renders the byte-identical ["<fqdn>"], so omitting the
+            # key here is behavior-preserving AND reclaims the ~44 cloud-init
+            # bytes that pushed the 3-region render past Hetzner's 32256 guard
+            # (hard cap 32768). The filter is only NEEDED in the multi-zone
+            # pool case, which is exactly when it is emitted.
+%{ if length(distinct([for z in yamldecode(parent_domains_yaml) : z.name])) > 1 ~}
+            PARENT_DOMAINS_FILTER: '${jsonencode(distinct([for z in yamldecode(parent_domains_yaml) : z.name]))}'
+%{ endif ~}
             SOVEREIGN_CNPG_INSTANCES: "${sovereign_cnpg_instances}"
             CONTINUUM_ENABLED: "${continuum_enabled}"
             CLUSTER_MESH_NAME: "${cluster_mesh_name}"


### PR DESCRIPTION
## Regression

PR #3793 (#3376 per-Org serving) added an **unconditional** `PARENT_DOMAINS_FILTER` substitute key to the bootstrap-kit Kustomization in `infra/providers/_shared/cloudinit-control-plane.tftpl`. In the multi-region (3-region) case this pushed the rendered control-plane **and** secondary-region cloud-init past Hetzner's hard 32256-byte `user_data` guard, so the `Build & Deploy Catalyst` workflow's G36 `tofu test` step (`tests/multi_region.tftest.hcl` → `three_region_mgmt_fsn_hel`) failed and blocked **all mothership deploys + fresh provs**.

The precondition that fired:
- `infra/providers/hetzner/main.tf:949` — `length(local.control_plane_cloud_init) <= 32256`
- `infra/providers/hetzner/main.tf:1428` — `length(local.secondary_region_cloud_init[each.key]) <= 32256`

(Hetzner's actual hard cap is 32768; the 32256 guard keeps a 512 B safety buffer.)

### Bytes over (before)

| render | bytes | over 32256 |
|---|---|---|
| control-plane | **32265** | +9 |
| secondary `fsn1-1` | **32268** | +12 |
| secondary `hel1-2` | **32268** | +12 |

## Root cause

The `PARENT_DOMAINS_FILTER` value is **100% derivable from `PARENT_DOMAINS_YAML`**, which is *already* rendered into the same `postBuild.substitute` map. The added ~44-byte `PARENT_DOMAINS_FILTER: '[...]'` line was therefore pure duplication, landing on an already-razor-thin 3-region budget (the 3-region base render is 32207 B — only 49 B under the guard).

I evaluated moving the derivation out of the cloud-init entirely (the architecturally-cleanest option), but the toolchain can't do the YAML→names transform downstream:
- Flux `postBuild.substitute` is plain envsubst — no list operations.
- A Helm subchart cannot receive a parent-computed list. Verified the upstream `external-dns` chart consumes `domainFilters` only as a flat `{{- range .Values.domainFilters }}` (and the per-entry `tpl` on `extraArgs` breaks on a variable-length multi-line render — tested).

So the derivation legitimately belongs in tofu (the only engine with both the zone data and list logic), and its only delivery channel into the HelmRelease values is the cloud-init substitute map.

## Fix

Emit `PARENT_DOMAINS_FILTER` **only when the Sovereign brought >1 parent zone** (i.e. `role=sme-pool` zones beyond the primary FQDN):

```hcl
%{ if length(distinct([for z in yamldecode(parent_domains_yaml) : z.name])) > 1 ~}
            PARENT_DOMAINS_FILTER: '${jsonencode(distinct([for z in yamldecode(parent_domains_yaml) : z.name]))}'
%{ endif ~}
```

- **Single primary zone** (the default zero-touch flow + every single-zone prov, which is exactly the failing fixture): `12-external-dns.yaml`'s existing envsubst default `${PARENT_DOMAINS_FILTER:-["${SOVEREIGN_FQDN}"]}` already renders the **byte-identical** `["<fqdn>"]`. Omitting the key is **behavior-preserving** and reclaims the bytes.
- **Multi-zone pool Sovereign** (#3376's actual target): the full filter is still emitted, so external-dns keeps managing the per-Org HTTPRoute hostnames `console.<slug>.<pool-tld>` / `<app>.<slug>.<pool-tld>` under the pool TLDs.

This **does not revert** #3376's serving fix — the external-dns `domainFilter` behavior and the per-zone cert wiring are preserved; only the redundant duplication on the single-zone path is removed. Also dropped the now-redundant inner `coalesce()/format()` (`parent_domains_yaml` is already coalesced non-empty in `main.tf` before reaching the template).

### Bytes after (failing fixture now passes)

| render | bytes | under 32256 | delta |
|---|---|---|---|
| control-plane | **32207** | −49 | −58 B |
| secondary `fsn1-1` | **32210** | −46 | −58 B |
| secondary `hel1-2` | **32210** | −46 | −58 B |

The single-zone render is now byte-for-byte equal to the pre-#3793 size.

## Verification

```
infra/providers/hetzner   tofu test    10 passed, 0 failed   (was 2 passed / 1 failed / 7 skipped)
infra/providers/huawei    tofu test     5 passed, 0 failed   (shared template — no regression)
scripts/lint-cloudinit.sh both          PASS hetzner + PASS huawei (render + dash -n)
```

`three_region_mgmt_fsn_hel` and `per_region_cloud_init_carries_secondarys_own_region` both green.

## Known follow-up (pre-existing — NOT introduced here)

A multi-zone **pool** Sovereign across **3 regions** (e.g. primary + 1 `sme-pool` zone) still renders ~**32361 B** (105 over the 32256 guard, but **407 under** the 32768 hard cap). This is a pre-existing 3-region base-size constraint: the base render is already 32207 B, so *any* multi-zone content tips it independent of this filter line. Fully fitting that shape needs `PARENT_DOMAINS_YAML` relocated out of the size-capped cloud-init for its powerdns / catalyst-platform / sovereign-tls cert consumers — a separate cross-cutting refactor, out of scope for this regression hotfix.

Refs #3376

🤖 Generated with [Claude Code](https://claude.com/claude-code)