### PR TITLE
feat(console): wire cutover progress card + severed-state to live catalyst-api shape (Refs #3379)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/shared/types/cutover.test.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/types/cutover.test.ts
@@ -16,10 +16,12 @@ import {
   CUTOVER_STEP_COUNT,
   applyCutoverStepUpdate,
   buildInitialCutoverStatus,
+  cutoverResultToStatus,
   isCutoverState,
   isCutoverStepID,
   parseCutoverState,
   parseCutoverStatus,
+  parseCutoverStatusConfigMap,
   type CutoverState,
   type CutoverStatus,
 } from './cutover'
@@ -81,24 +83,29 @@ describe('isCutoverState — type-guard variant', () => {
 
 /* ────────────────────────── CUTOVER_STEPS — canonical 8 ─────────────── */
 
-describe('CUTOVER_STEPS — canonical 8-step list', () => {
-  it('has exactly 8 entries', () => {
-    expect(CUTOVER_STEPS).toHaveLength(8)
-    expect(CUTOVER_STEP_COUNT).toBe(8)
+describe('CUTOVER_STEPS — canonical 11-step list', () => {
+  it('has exactly 11 entries', () => {
+    expect(CUTOVER_STEPS).toHaveLength(11)
+    expect(CUTOVER_STEP_COUNT).toBe(11)
   })
 
-  it('matches the catalyst-api Job sequence by id + order', () => {
-    // This list mirrors openova-io/openova#793 (Step 2 progress card)
-    // and #792 (POST /start orchestrates these in this exact order).
+  it('matches the chart cutover-order labels + the catalyst-api Job sequence', () => {
+    // Ground truth: platform/self-sovereign-cutover/chart/templates/NN-*.yaml
+    // `bp.openova.io/cutover-order` labels 01..11. The catalyst-api engine
+    // discovers + runs them in this order. The slug is `helmrepository-patches`
+    // (the prior `helmrepo-patches` never matched the chart).
     expect(CUTOVER_STEPS.map((s) => s.id)).toEqual([
       'gitea-mirror',
       'harbor-projects',
       'harbor-prewarm',
       'registry-pivot',
       'flux-gitrepository-patch',
-      'helmrepo-patches',
+      'helmrepository-patches',
       'catalyst-api-env-patch',
       'egress-block-test',
+      'gitea-token-mint',
+      'vcluster-registry-pivot',
+      'crossplane-provider-pivot',
     ])
   })
 
@@ -107,6 +114,28 @@ describe('CUTOVER_STEPS — canonical 8-step list', () => {
       expect(s.label.length).toBeGreaterThan(0)
       expect(s.description.length).toBeGreaterThan(0)
     }
+  })
+})
+
+/* ─────────────────────── cutoverResultToStatus ──────────────────────── */
+
+describe('cutoverResultToStatus — engine result → UI status', () => {
+  it('maps success + skipped → done', () => {
+    expect(cutoverResultToStatus('success')).toBe('done')
+    expect(cutoverResultToStatus('skipped')).toBe('done')
+  })
+  it('maps running → running, failed → failed', () => {
+    expect(cutoverResultToStatus('running')).toBe('running')
+    expect(cutoverResultToStatus('failed')).toBe('failed')
+  })
+  it('maps empty / absent → pending', () => {
+    expect(cutoverResultToStatus('')).toBe('pending')
+    expect(cutoverResultToStatus(undefined)).toBe('pending')
+    expect(cutoverResultToStatus(null)).toBe('pending')
+  })
+  it('returns null for an unrecognised value (forward-compat)', () => {
+    expect(cutoverResultToStatus('explodey')).toBeNull()
+    expect(cutoverResultToStatus(42)).toBeNull()
   })
 })
 
@@ -148,10 +177,87 @@ describe('parseCutoverStatus — happy paths', () => {
     })
     expect(out.state).toBe('sovereign')
     expect(out.cutoverComplete).toBe(true)
-    expect(out.steps).toHaveLength(8)
+    expect(out.steps).toHaveLength(11)
     expect(out.mirroredCommitSHA).toBe('abc123def4567890')
     expect(out.harborProjectCount).toBe(7)
     expect(out.egressTestPassed).toBe(true)
+  })
+
+  it('parses the LIVE catalyst-api wire shape (steps[].name + .result)', () => {
+    // This is the shape api/internal/handler/cutover.go actually emits
+    // from GET /sovereign/cutover/status — `name`/`result`, NOT
+    // `step`/`status`. Before the adapter every one of these records was
+    // dropped, so the progress card stayed blank on a completed cutover.
+    const out = parseCutoverStatus({
+      state: 'sovereign',
+      cutoverComplete: true,
+      cutoverStartedAt: '2026-06-18T10:00:00Z',
+      cutoverFinishedAt: '2026-06-18T10:11:00Z',
+      steps: [
+        {
+          name: 'gitea-mirror',
+          result: 'success',
+          startedAt: '2026-06-18T10:00:00Z',
+          finishedAt: '2026-06-18T10:01:00Z',
+          jobName: 'cutover-gitea-mirror-1',
+        },
+        { name: 'harbor-projects', result: 'success' },
+        { name: 'egress-block-test', result: 'success' },
+      ],
+    })
+    expect(out.cutoverComplete).toBe(true)
+    // success → done
+    expect(out.steps.find((s) => s.step === 'gitea-mirror')?.status).toBe(
+      'done',
+    )
+    expect(out.steps.find((s) => s.step === 'gitea-mirror')?.startedAt).toBe(
+      '2026-06-18T10:00:00Z',
+    )
+    // Live timestamps come off cutoverStartedAt/cutoverFinishedAt.
+    expect(out.startedAt).toBe('2026-06-18T10:00:00Z')
+    expect(out.finishedAt).toBe('2026-06-18T10:11:00Z')
+    // egressTestPassed derived from the egress-block-test step result.
+    expect(out.egressTestPassed).toBe(true)
+  })
+
+  it('derives egressTestPassed=false + folds lastError onto the failed step', () => {
+    const out = parseCutoverStatus({
+      cutoverComplete: false,
+      failedStep: 'egress-block-test',
+      lastError: 'reconcile bp-kyverno went NotReady during the deny-egress hold',
+      steps: [
+        { name: 'gitea-mirror', result: 'success' },
+        { name: 'egress-block-test', result: 'failed' },
+      ],
+    })
+    expect(out.state).toBe('tethered')
+    const egress = out.steps.find((s) => s.step === 'egress-block-test')
+    expect(egress?.status).toBe('failed')
+    expect(egress?.message).toMatch(/deny-egress hold/)
+    expect(out.egressTestPassed).toBe(false)
+  })
+
+  it('maps a running step from the live result vocabulary', () => {
+    const out = parseCutoverStatus({
+      cutoverComplete: false,
+      steps: [
+        { name: 'gitea-mirror', result: 'success' },
+        { name: 'harbor-projects', result: 'running' },
+      ],
+    })
+    expect(out.steps.find((s) => s.step === 'harbor-projects')?.status).toBe(
+      'running',
+    )
+  })
+
+  it('reads harborProjectCount from the nested raw string-map', () => {
+    const out = parseCutoverStatus({
+      cutoverComplete: true,
+      steps: [],
+      raw: { harborProjectCount: '7', mirroredCommitSHA: 'deadbeef0000' },
+    })
+    expect(out.harborProjectCount).toBe(7)
+    expect(out.mirroredCommitSHA).toBe('deadbeef0000')
   })
 
   it('drops steps with unknown ids (forward-compat)', () => {
@@ -255,15 +361,59 @@ describe('parseCutoverStatus — defensive boundaries', () => {
 /* ────────────────────────── buildInitialCutoverStatus ───────────────── */
 
 describe('buildInitialCutoverStatus — first-paint placeholder', () => {
-  it('seeds 8 pending steps in canonical order', () => {
+  it('seeds 11 pending steps in canonical order', () => {
     const init = buildInitialCutoverStatus()
     expect(init.state).toBe('tethered')
     expect(init.cutoverComplete).toBe(false)
-    expect(init.steps).toHaveLength(8)
+    expect(init.steps).toHaveLength(11)
     expect(init.steps.map((s) => s.step)).toEqual(
       CUTOVER_STEPS.map((s) => s.id),
     )
     expect(init.steps.every((s) => s.status === 'pending')).toBe(true)
+  })
+})
+
+/* ─────────────────── parseCutoverStatusConfigMap (SSE) ──────────────── */
+
+describe('parseCutoverStatusConfigMap — flat status ConfigMap (SSE snapshot)', () => {
+  it('reconstructs steps from step.<name>.<field> keys', () => {
+    // This is the flat string-map HandleCutoverEvents JSON-encodes into the
+    // `cutover-status` SSE frame's message (readCutoverStatus output).
+    const out = parseCutoverStatusConfigMap({
+      cutoverComplete: 'true',
+      cutoverStartedAt: '2026-06-18T10:00:00Z',
+      cutoverFinishedAt: '2026-06-18T10:11:00Z',
+      'step.gitea-mirror.result': 'success',
+      'step.gitea-mirror.startedAt': '2026-06-18T10:00:00Z',
+      'step.gitea-mirror.finishedAt': '2026-06-18T10:01:00Z',
+      'step.egress-block-test.result': 'success',
+    })
+    expect(out).not.toBeNull()
+    expect(out!.state).toBe('sovereign')
+    expect(out!.cutoverComplete).toBe(true)
+    expect(out!.steps.find((s) => s.step === 'gitea-mirror')?.status).toBe(
+      'done',
+    )
+    expect(out!.egressTestPassed).toBe(true)
+  })
+
+  it('derives tethered from cutoverComplete:"false" with an in-flight step', () => {
+    const out = parseCutoverStatusConfigMap({
+      cutoverComplete: 'false',
+      'step.gitea-mirror.result': 'success',
+      'step.harbor-projects.result': 'running',
+    })
+    expect(out).not.toBeNull()
+    expect(out!.state).toBe('tethered')
+    expect(out!.steps.find((s) => s.step === 'harbor-projects')?.status).toBe(
+      'running',
+    )
+  })
+
+  it('returns null for a non-map input (frame ignored, stream survives)', () => {
+    expect(parseCutoverStatusConfigMap(null)).toBeNull()
+    expect(parseCutoverStatusConfigMap('nope')).toBeNull()
+    expect(parseCutoverStatusConfigMap([1, 2, 3])).toBeNull()
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/shared/types/cutover.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/types/cutover.ts
@@ -98,10 +98,25 @@ export interface CutoverStepDef {
 }
 
 /**
- * Wire-level step identifier — matches the JobTemplate ConfigMap key
- * names installed by the bp-self-sovereign-cutover chart and the
- * `step` field on the `CutoverStepStatus` payload from
- * GET /sovereign/cutover/status.
+ * Wire-level step identifier — matches the `stepName` data key + the
+ * `bp.openova.io/cutover-order` label on each step ConfigMap installed
+ * by the bp-self-sovereign-cutover chart, and the `name` field on the
+ * per-step record the catalyst-api `/sovereign/cutover/status` endpoint
+ * emits (`cutoverStepStatus.Name` in api/internal/handler/cutover.go).
+ *
+ * #3379 (hw159, 2026-06-18): the canonical chain GREW from 8 → 11. The
+ * api handler header documents this drift verbatim ("the step count has
+ * drifted (8→11) as gitea-token-mint / vcluster-registry-pivot /
+ * crossplane-provider-pivot were appended"). The chart templates are the
+ * ground truth — verified against
+ * platform/self-sovereign-cutover/chart/templates/*.yaml:
+ *   01 gitea-mirror · 02 harbor-projects · 03 harbor-prewarm ·
+ *   04 registry-pivot · 05 flux-gitrepository-patch ·
+ *   06 helmrepository-patches · 07 catalyst-api-env-patch ·
+ *   08 egress-block-test · 09 gitea-token-mint ·
+ *   10 vcluster-registry-pivot · 11 crossplane-provider-pivot
+ * NOTE the slug is `helmrepository-patches` (NOT the prior `helmrepo-patches`)
+ * — the old FE id never matched the chart, so that row could never light up.
  */
 export type CutoverStepID =
   | 'gitea-mirror'
@@ -109,9 +124,12 @@ export type CutoverStepID =
   | 'harbor-prewarm'
   | 'registry-pivot'
   | 'flux-gitrepository-patch'
-  | 'helmrepo-patches'
+  | 'helmrepository-patches'
   | 'catalyst-api-env-patch'
   | 'egress-block-test'
+  | 'gitea-token-mint'
+  | 'vcluster-registry-pivot'
+  | 'crossplane-provider-pivot'
 
 /**
  * Per-step status the SSE stream + `/status` endpoint emit.
@@ -128,9 +146,13 @@ export type CutoverStepID =
 export type CutoverStepStatus = 'pending' | 'running' | 'done' | 'failed'
 
 /**
- * The canonical, ordered 8-step list. ANY code path that needs to
+ * The canonical, ordered 11-step list. ANY code path that needs to
  * iterate the chain (UI rendering, reducer initialisation, e2e) MUST
  * read from this list — adding or removing a step ripples here once.
+ *
+ * Order + ids mirror the chart's `bp.openova.io/cutover-order` labels
+ * (platform/self-sovereign-cutover/chart/templates/NN-*.yaml). The
+ * catalyst-api engine discovers + executes them in this exact sequence.
  */
 export const CUTOVER_STEPS: readonly CutoverStepDef[] = [
   {
@@ -159,7 +181,8 @@ export const CUTOVER_STEPS: readonly CutoverStepDef[] = [
     label: 'Pivot containerd registries',
     description:
       'Hot-reload registries.yaml on every node from harbor.openova.io ' +
-      'to harbor.<sovereign-fqdn> via a DaemonSet sentinel.',
+      'to harbor.<sovereign-fqdn> via a DaemonSet sentinel; each node ' +
+      'acks the v2 (local Harbor) rewrite.',
   },
   {
     id: 'flux-gitrepository-patch',
@@ -169,8 +192,8 @@ export const CUTOVER_STEPS: readonly CutoverStepDef[] = [
       'the local Gitea HTTP service. Flux reconciles from local Git.',
   },
   {
-    id: 'helmrepo-patches',
-    label: 'Repoint 38 HelmRepositories',
+    id: 'helmrepository-patches',
+    label: 'Repoint HelmRepositories',
     description:
       'Patch every oci://ghcr.io/openova-io HelmRepository to ' +
       'oci://harbor.<sovereign-fqdn>/openova-io.',
@@ -189,6 +212,27 @@ export const CUTOVER_STEPS: readonly CutoverStepDef[] = [
       'Apply a NetworkPolicy denying egress to github.com + ghcr.io + ' +
       'harbor.openova.io for 10 minutes; assert all reconciles stay green.',
   },
+  {
+    id: 'gitea-token-mint',
+    label: 'Mint local Gitea token',
+    description:
+      'Mint a long-lived Gitea API token so the host GitOps loop + the ' +
+      'mirror-resync CronJob authenticate against local Gitea after cutover.',
+  },
+  {
+    id: 'vcluster-registry-pivot',
+    label: 'Pivot vCluster registries',
+    description:
+      'Repoint every tenant vCluster’s containerd + pull secrets at the ' +
+      'local Harbor so Organization workloads stop pulling from ghcr.io.',
+  },
+  {
+    id: 'crossplane-provider-pivot',
+    label: 'Pivot Crossplane providers',
+    description:
+      'Rewrite Crossplane provider + function package refs from upstream ' +
+      'registries to the local Harbor proxy projects.',
+  },
 ] as const
 
 export const CUTOVER_STEP_COUNT = CUTOVER_STEPS.length
@@ -201,15 +245,88 @@ export function isCutoverStepID(s: unknown): s is CutoverStepID {
   return typeof s === 'string' && CUTOVER_STEP_IDS.has(s)
 }
 
+/**
+ * Map the catalyst-api's native per-step `result` string onto the UI's
+ * `CutoverStepStatus`. This is the seam that was MISSING — the live
+ * `/sovereign/cutover/status` endpoint emits `steps[].result`
+ * (`cutoverStepStatus.Result` in api/internal/handler/cutover.go), NOT
+ * `steps[].status`, and its vocabulary is the ENGINE's, not the UI's:
+ *
+ *   • "success" → done      (the engine writes step.<n>.result=success)
+ *   • "skipped" → done      (already-succeeded step on a resume)
+ *   • "running" → running   (the projected-Job in-flight value)
+ *   • "failed"  → failed
+ *   • ""/absent → pending   (no per-step row written yet)
+ *
+ * Without this mapping every step record off the wire was dropped by the
+ * `status !== 'done' …` filter, so the progress card rendered 8 (now 11)
+ * permanently-pending rows even on a fully-completed cutover — the
+ * GAP-missing-ui the hw159 walk recorded.
+ *
+ * Returns `null` for an unrecognised value so the caller can drop the
+ * record (forward-compat with a future engine result string).
+ */
+export function cutoverResultToStatus(result: unknown): CutoverStepStatus | null {
+  switch (result) {
+    case 'success':
+    case 'skipped':
+      return 'done'
+    case 'running':
+      return 'running'
+    case 'failed':
+      return 'failed'
+    case '':
+    case undefined:
+    case null:
+      return 'pending'
+    default:
+      return null
+  }
+}
+
+/**
+ * Resolve a per-step status from a wire record that may carry EITHER the
+ * UI vocabulary (`status: 'done'`) OR the engine vocabulary
+ * (`result: 'success'`). The live catalyst-api uses `result`; the older
+ * fixtures + the SSE-derived records use `status`. Prefer an explicit,
+ * valid `status`; otherwise fall back to mapping `result`. Returns null
+ * if neither yields a recognised status (record is then dropped).
+ */
+function resolveStepStatus(rec: Record<string, unknown>): CutoverStepStatus | null {
+  const s = rec.status
+  if (s === 'pending' || s === 'running' || s === 'done' || s === 'failed') {
+    return s
+  }
+  // Only fall back to result-mapping when status is absent — an explicit
+  // but unknown status string is a malformed record and must be dropped
+  // (preserves the existing "drops malformed status values" contract).
+  if (s === undefined || s === null) {
+    return cutoverResultToStatus(rec.result)
+  }
+  return null
+}
+
+/**
+ * Resolve the per-step wire id from a record that may carry EITHER `step`
+ * (UI/SSE vocabulary) OR `name` (the live `/status` endpoint's
+ * `cutoverStepStatus.Name`). Returns the branded id or null.
+ */
+function resolveStepID(rec: Record<string, unknown>): CutoverStepID | null {
+  if (isCutoverStepID(rec.step)) return rec.step
+  if (isCutoverStepID(rec.name)) return rec.name
+  return null
+}
+
 /* ────────────────────────────────────────────────────────────────
  * 3. Wire shapes from /sovereign/cutover/{status,events}
  * ────────────────────────────────────────────────────────────── */
 
 /**
- * Per-step record returned in `CutoverStatus.steps[]` and emitted on
- * the SSE stream as `event: cutover-step` (or, for the terminal frame,
- * folded into the `cutover-status` payload). Timestamps are RFC 3339
- * UTC strings.
+ * Per-step record returned in `CutoverStatus.steps[]`. The catalyst-api
+ * GET /status response carries each step as `{name, result, …}` (the
+ * engine vocabulary) and the SSE stream signals transitions via the
+ * `cutover-step-started/finished/failed` event NAMES; both are adapted
+ * onto this normalized record. Timestamps are RFC 3339 UTC strings.
  */
 export interface CutoverStepStatusRecord {
   /** The wire step id; the parser drops records with unknown ids. */
@@ -300,49 +417,114 @@ export function parseCutoverStatus(input: unknown): CutoverStatus {
     typeof raw.cutoverComplete === 'boolean'
       ? raw.cutoverComplete
       : state === 'sovereign'
+  // The top-level failed-step + error live on the status ConfigMap as
+  // `failedStep` / `lastError` (NOT on the per-step record) — the engine
+  // writes them in patchCutoverStatus when a step fails. Fold lastError
+  // onto the matching step's `message` so the progress card's red error
+  // row lights up off the live wire shape (it reads rec.message).
+  const failedStep =
+    typeof raw.failedStep === 'string' && raw.failedStep !== ''
+      ? raw.failedStep
+      : undefined
+  const lastError =
+    typeof raw.lastError === 'string' && raw.lastError !== ''
+      ? raw.lastError
+      : undefined
+
   const stepsRaw = Array.isArray(raw.steps) ? raw.steps : []
   const steps: CutoverStepStatusRecord[] = []
   for (const r of stepsRaw) {
     if (r === null || typeof r !== 'object') continue
     const rec = r as Record<string, unknown>
-    if (!isCutoverStepID(rec.step)) continue
-    const status = rec.status
-    if (
-      status !== 'pending' &&
-      status !== 'running' &&
-      status !== 'done' &&
-      status !== 'failed'
-    )
-      continue
+    const id = resolveStepID(rec)
+    if (id === null) continue
+    const status = resolveStepStatus(rec)
+    if (status === null) continue
+    // Per-step message wins; otherwise inherit the top-level lastError
+    // when THIS is the failed step the engine flagged.
+    let message =
+      typeof rec.message === 'string' && rec.message !== ''
+        ? rec.message
+        : undefined
+    if (message === undefined && status === 'failed' && id === failedStep) {
+      message = lastError
+    }
     steps.push({
-      step: rec.step,
+      step: id,
       status,
       startedAt: typeof rec.startedAt === 'string' ? rec.startedAt : undefined,
       finishedAt:
         typeof rec.finishedAt === 'string' ? rec.finishedAt : undefined,
-      message: typeof rec.message === 'string' ? rec.message : undefined,
+      message,
     })
   }
+  // Timestamps: prefer the legacy/typed `startedAt`/`finishedAt`, fall
+  // back to the live catalyst-api field names (`cutoverStartedAt` /
+  // `cutoverFinishedAt` — see cutoverStatusResponse in cutover.go).
+  const startedAt = firstString(raw.startedAt, raw.cutoverStartedAt)
+  const finishedAt = firstString(raw.finishedAt, raw.cutoverFinishedAt)
+
+  // egressTestPassed: the live backend does NOT emit a typed boolean; the
+  // proof is the `egress-block-test` step reaching result=success. Prefer
+  // an explicit boolean (forward-compat) then derive from that step.
+  let egressTestPassed: boolean | undefined
+  if (typeof raw.egressTestPassed === 'boolean') {
+    egressTestPassed = raw.egressTestPassed
+  } else {
+    const egressStep = steps.find((s) => s.step === 'egress-block-test')
+    if (egressStep) {
+      if (egressStep.status === 'done') egressTestPassed = true
+      else if (egressStep.status === 'failed') egressTestPassed = false
+    }
+  }
+
   return {
     state,
     cutoverComplete,
-    startedAt: typeof raw.startedAt === 'string' ? raw.startedAt : undefined,
-    finishedAt: typeof raw.finishedAt === 'string' ? raw.finishedAt : undefined,
+    startedAt,
+    finishedAt,
     steps,
-    mirroredCommitSHA:
-      typeof raw.mirroredCommitSHA === 'string'
-        ? raw.mirroredCommitSHA
-        : undefined,
-    harborProjectCount:
-      typeof raw.harborProjectCount === 'number'
-        ? raw.harborProjectCount
-        : undefined,
-    egressTestPassed:
-      typeof raw.egressTestPassed === 'boolean'
-        ? raw.egressTestPassed
-        : undefined,
-    error: typeof raw.error === 'string' ? raw.error : undefined,
+    // Summary fields are optional on the live wire (they live under the
+    // status ConfigMap's free-form keys, surfaced via `raw`). Read the
+    // typed top-level value first, then fall back to the raw key.
+    mirroredCommitSHA: firstString(raw.mirroredCommitSHA, rawKey(raw, 'mirroredCommitSHA')),
+    harborProjectCount: firstNumber(raw.harborProjectCount, rawKey(raw, 'harborProjectCount')),
+    egressTestPassed,
+    error: firstString(raw.error, raw.lastError),
   }
+}
+
+/** First argument that is a non-empty string, else undefined. */
+function firstString(...vals: unknown[]): string | undefined {
+  for (const v of vals) {
+    if (typeof v === 'string' && v !== '') return v
+  }
+  return undefined
+}
+
+/**
+ * First argument coercible to a number, else undefined. Accepts a real
+ * number or a numeric string (the status ConfigMap stores everything as
+ * strings, so `raw.harborProjectCount` arrives as e.g. "7").
+ */
+function firstNumber(...vals: unknown[]): number | undefined {
+  for (const v of vals) {
+    if (typeof v === 'number' && Number.isFinite(v)) return v
+    if (typeof v === 'string' && v.trim() !== '') {
+      const n = Number(v)
+      if (Number.isFinite(n)) return n
+    }
+  }
+  return undefined
+}
+
+/** Read a key off the optional `raw` string-map the backend nests under `raw`. */
+function rawKey(obj: Record<string, unknown>, key: string): unknown {
+  const r = obj.raw
+  if (r !== null && typeof r === 'object') {
+    return (r as Record<string, unknown>)[key]
+  }
+  return undefined
 }
 
 /**
@@ -364,7 +546,8 @@ export function buildInitialCutoverStatus(): CutoverStatus {
 
 /**
  * Merge a per-step update onto an existing status snapshot. Used by
- * the SSE reducer when it receives `event: cutover-step` frames.
+ * the SSE reducer when it receives `cutover-step-started/finished/failed`
+ * frames.
  *
  * Idempotent: an update for a step that already has the same status +
  * timestamps returns the input unchanged so React's state-equality
@@ -372,9 +555,9 @@ export function buildInitialCutoverStatus(): CutoverStatus {
  *
  * Append-on-miss: a wire snapshot from POST /start may carry only the
  * currently-running step (e.g. just `gitea-mirror`); subsequent SSE
- * `cutover-step` frames for steps that aren't present yet must be
- * APPENDED, not silently dropped. Otherwise the progress card never
- * reflects steps 2..8 because the reducer's map() never sees them.
+ * step frames for steps that aren't present yet must be APPENDED, not
+ * silently dropped. Otherwise the progress card never reflects later
+ * steps because the reducer's map() never sees them.
  */
 export function applyCutoverStepUpdate(
   prev: CutoverStatus,
@@ -402,4 +585,57 @@ export function applyCutoverStepUpdate(
   }
   if (!changed) return prev
   return { ...prev, steps: nextSteps }
+}
+
+/**
+ * Parse the FLAT status-ConfigMap map (`Record<string, string>`) that the
+ * catalyst-api SSE `cutover-status` snapshot frame carries.
+ *
+ * The SSE channel's terminal/replay snapshot is NOT a `CutoverStatus`
+ * object — `HandleCutoverEvents` JSON-encodes the raw status ConfigMap
+ * (`readCutoverStatus` → `map[string]string`) into the event `message`.
+ * That map has NO `steps` array; the per-step rows are flat keys:
+ *   step.<stepName>.result      "success" | "failed" | "running" | ""
+ *   step.<stepName>.startedAt    RFC3339
+ *   step.<stepName>.finishedAt   RFC3339
+ *   step.<stepName>.jobName
+ * plus top-level cutoverComplete / failedStep / lastError / etc.
+ *
+ * We reconstruct a `steps` array (exactly as the backend's
+ * buildCutoverStatusResponseFromMap does for the GET /status response) and
+ * delegate to `parseCutoverStatus`, so the SSE snapshot and the GET
+ * snapshot converge on one validated shape.
+ *
+ * Returns null if `input` is not a flat string-map (caller then ignores
+ * the frame rather than crashing the stream).
+ */
+export function parseCutoverStatusConfigMap(input: unknown): CutoverStatus | null {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    return null
+  }
+  const m = input as Record<string, unknown>
+  // Collect step names from the `step.<name>.<field>` keys.
+  const stepNames = new Set<string>()
+  for (const k of Object.keys(m)) {
+    if (!k.startsWith('step.')) continue
+    const rest = k.slice('step.'.length)
+    const dot = rest.lastIndexOf('.')
+    if (dot <= 0) continue
+    stepNames.add(rest.slice(0, dot))
+  }
+  const steps = [...stepNames].map((name) => ({
+    name,
+    result: m[`step.${name}.result`],
+    startedAt: m[`step.${name}.startedAt`],
+    finishedAt: m[`step.${name}.finishedAt`],
+    jobName: m[`step.${name}.jobName`],
+  }))
+  // Hand the reconstructed object to the single validated parser. The
+  // flat map's `state` key may be absent — parseCutoverStatus derives it
+  // from cutoverComplete, which IS present on the status ConfigMap.
+  return parseCutoverStatus({
+    ...m,
+    cutoverComplete: m.cutoverComplete === 'true' || m.cutoverComplete === true,
+    steps,
+  })
 }

--- a/products/catalyst/bootstrap/ui/src/widgets/sovereignty/CutoverProgressCard.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/sovereignty/CutoverProgressCard.test.tsx
@@ -48,7 +48,7 @@ describe('CutoverProgressCard — mid-flight progress', () => {
         { step: 'harbor-prewarm', status: 'running' },
       ],
     })
-    // Padding pending so the card renders 8 rows.
+    // Padding pending so the card renders all canonical rows.
     const merged: CutoverStatus = {
       ...status,
       steps: CUTOVER_STEPS.map((s) =>
@@ -59,9 +59,10 @@ describe('CutoverProgressCard — mid-flight progress', () => {
       ),
     }
     render(<CutoverProgressCard status={merged} />)
-    // 2 of 8 done = 25%.
+    // 2 done of CUTOVER_STEPS.length, rounded.
+    const expectedPct = Math.round((2 / CUTOVER_STEPS.length) * 100)
     expect(screen.getByTestId('cutover-progress-pct').textContent).toMatch(
-      /25%/,
+      new RegExp(`${expectedPct}%`),
     )
     expect(
       screen

--- a/products/catalyst/bootstrap/ui/src/widgets/sovereignty/CutoverProgressCard.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/sovereignty/CutoverProgressCard.tsx
@@ -231,7 +231,7 @@ export function CutoverProgressCard({
             {failed
               ? 'Cutover halted on a failed step. Review the error and re-trigger after the underlying issue is fixed.'
               : status.state === 'sovereign'
-                ? 'All 8 steps completed.'
+                ? `All ${CUTOVER_STEPS.length} steps completed.`
                 : `Step ${doneCount} of ${CUTOVER_STEPS.length} complete — the operator is not required to keep this tab open.`}
           </p>
         </div>

--- a/products/catalyst/bootstrap/ui/src/widgets/sovereignty/SovereigntyCard.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/sovereignty/SovereigntyCard.test.tsx
@@ -74,15 +74,15 @@ describe('SovereigntyCard — tethered, no progress', () => {
 })
 
 describe('SovereigntyCard — CTA opens explanation modal', () => {
-  it('clicking the button reveals the modal with the 8-step explainer', () => {
+  it('clicking the button reveals the modal with the per-step explainer', () => {
     render(<SovereigntyCard override={makeResult({})} />)
     fireEvent.click(screen.getByTestId('cutover-start-button'))
     const modal = screen.getByTestId('cutover-confirm-modal')
     expect(modal).toBeTruthy()
-    // The 8 numbered list items naming each step.
+    // One numbered list item per canonical cutover step.
     const list = modal.querySelector('ol')
     expect(list).toBeTruthy()
-    expect(list!.children.length).toBe(8)
+    expect(list!.children.length).toBe(CUTOVER_STEPS.length)
     // Confirm + cancel buttons are both wired.
     expect(screen.getByTestId('cutover-confirm-button')).toBeTruthy()
     expect(screen.getByTestId('cutover-confirm-cancel')).toBeTruthy()

--- a/products/catalyst/bootstrap/ui/src/widgets/sovereignty/SovereigntyCard.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/sovereignty/SovereigntyCard.tsx
@@ -43,6 +43,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/shared/ui/dialog'
+import { CUTOVER_STEPS } from '@/shared/types/cutover'
 import { CutoverProgressCard } from './CutoverProgressCard'
 import {
   useCutoverEvents,
@@ -193,9 +194,9 @@ export function SovereigntyCard({ override }: SovereigntyCardProps) {
             Achieve True Sovereignty
           </Button>
           <p className="max-w-prose text-[11px] text-[var(--color-text-dim)]">
-            Runs the 8-step cutover. ~10 minutes. Includes a 10-minute
-            egress-block self-test against github.com + ghcr.io +
-            harbor.openova.io.
+            Runs the {CUTOVER_STEPS.length}-step cutover. ~10 minutes.
+            Includes a 10-minute egress-block self-test against github.com
+            + ghcr.io + harbor.openova.io.
           </p>
         </div>
       ) : null}
@@ -279,22 +280,20 @@ function ConfirmCutoverModal({
             Achieve True Sovereignty
           </DialogTitle>
           <DialogDescription className="text-xs text-[var(--color-text-dim)]">
-            This runs an 8-step cutover that makes this Sovereign cluster
-            operationally independent of the openova-io mothership. The
-            process takes about 10 minutes and includes a final
-            10-minute egress-block self-test.
+            This runs a {CUTOVER_STEPS.length}-step cutover that makes this
+            Sovereign cluster operationally independent of the openova-io
+            mothership. The process takes about 10 minutes and includes a
+            final 10-minute egress-block self-test.
           </DialogDescription>
         </DialogHeader>
 
+        {/* Step overview — rendered from the canonical CUTOVER_STEPS list so
+            it can never drift from the engine's real chain (the per-step
+            LIVE status renders in CutoverProgressCard once the cutover runs). */}
         <ol className="mt-4 list-decimal space-y-1 pl-5 text-[12px] text-[var(--color-text)]">
-          <li>Mirror github.com/openova-io/openova into local Gitea.</li>
-          <li>Create 7 Harbor proxy projects (ghcr / docker / k8s / gcr / quay / xpkg / ecr).</li>
-          <li>Pre-warm critical images through Harbor.</li>
-          <li>Pivot containerd registries.yaml on every node.</li>
-          <li>Repoint the Flux GitRepository to local Gitea.</li>
-          <li>Repoint 38 HelmRepositories to local Harbor.</li>
-          <li>Patch catalyst-api environment to use local sources.</li>
-          <li>Apply egress-block NetworkPolicy and verify reconciles stay green for 10 min.</li>
+          {CUTOVER_STEPS.map((s) => (
+            <li key={s.id}>{s.label}</li>
+          ))}
         </ol>
 
         <p className="mt-3 rounded-md border border-amber-500/40 bg-amber-500/5 p-2 text-[11px] text-amber-300">

--- a/products/catalyst/bootstrap/ui/src/widgets/sovereignty/useCutoverEvents.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/sovereignty/useCutoverEvents.ts
@@ -10,8 +10,10 @@
  *      finished still renders the full 8-step trail (and the green
  *      "Sovereignty achieved" banner).
  *   2. SSE  /api/v1/sovereign/cutover/events — live event channel.
- *      Emits `cutover-step` frames for per-step transitions and a
- *      terminal `cutover-status` frame on completion.
+ *      Emits `cutover-step-started` / `cutover-step-finished` /
+ *      `cutover-step-failed` frames for per-step transitions (the step
+ *      outcome is the EVENT NAME) and `cutover-status` snapshot frames
+ *      (carrying the raw status ConfigMap) on connect + completion.
  *
  * Per docs/INVIOLABLE-PRINCIPLES.md:
  *   #4 (never hardcode): URLs go through `${API_BASE}` from
@@ -22,8 +24,9 @@
  *
  * Why a dedicated hook (vs reusing useDeploymentEvents)
  * ────────────────────────────────────────────────────
- * The cutover SSE channel speaks a different vocabulary (`cutover-step`,
- * `cutover-status`) than the deployment channel (`done`, `handover-ready`).
+ * The cutover SSE channel speaks a different vocabulary
+ * (`cutover-step-started/finished/failed`, `cutover-status`) than the
+ * deployment channel (`done`, `handover-ready`).
  * Multiplexing them would force every frame parser to discriminate on
  * event-type at the dispatch layer, and the reconnect/backoff logic
  * would need to know about both. Cleaner to keep them separated and
@@ -36,7 +39,9 @@ import {
   applyCutoverStepUpdate,
   buildInitialCutoverStatus,
   parseCutoverStatus,
+  parseCutoverStatusConfigMap,
   type CutoverStatus,
+  type CutoverStepStatus,
   type CutoverStepStatusRecord,
   isCutoverStepID,
 } from '@/shared/types/cutover'
@@ -165,48 +170,69 @@ export function useCutoverEvents(
   // ── SSE live stream — runs in parallel; reducer is idempotent ─
   useEffect(() => {
     if (disableStream) return
-    setStreamError(null)
+    // Note: streamError is cleared in the EventSource `onopen` callback
+    // below (an external-event handler) rather than synchronously here —
+    // a synchronous setState in an effect body triggers a cascading
+    // render (react-hooks/set-state-in-effect).
     let cancelled = false
     let es: EventSource | null = null
     let reconnectAttempts = 0
     const MAX_RECONNECT_ATTEMPTS = 5
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null
 
-    const onCutoverStep = (msg: MessageEvent) => {
-      if (cancelled) return
-      try {
-        const payload = JSON.parse(msg.data) as unknown
-        if (payload === null || typeof payload !== 'object') return
-        const rec = payload as Record<string, unknown>
-        if (!isCutoverStepID(rec.step)) return
-        const stepStatus = rec.status
-        if (
-          stepStatus !== 'pending' &&
-          stepStatus !== 'running' &&
-          stepStatus !== 'done' &&
-          stepStatus !== 'failed'
-        )
-          return
-        const update: CutoverStepStatusRecord = {
-          step: rec.step,
-          status: stepStatus,
-          startedAt:
-            typeof rec.startedAt === 'string' ? rec.startedAt : undefined,
-          finishedAt:
-            typeof rec.finishedAt === 'string' ? rec.finishedAt : undefined,
-          message: typeof rec.message === 'string' ? rec.message : undefined,
+    // The catalyst-api SSE channel emits per-step transitions as THREE
+    // distinct event types — `cutover-step-started`, `-finished`,
+    // `-failed` (the `cutoverEvent.Phase` values in
+    // api/internal/handler/cutover.go) — and encodes the step OUTCOME in
+    // the event NAME, not a payload field. Each frame's data is a
+    // `cutoverEvent{step, jobName, message, time}`. We map the event name
+    // → CutoverStepStatus here. (The old single `cutover-step` listener
+    // with a payload `status` field matched no real backend frame, so the
+    // progress card never advanced off the live stream.)
+    const onStepTransition =
+      (status: CutoverStepStatus) => (msg: MessageEvent) => {
+        if (cancelled) return
+        try {
+          const payload = JSON.parse(msg.data) as unknown
+          if (payload === null || typeof payload !== 'object') return
+          const rec = payload as Record<string, unknown>
+          if (!isCutoverStepID(rec.step)) return
+          const ts = typeof rec.time === 'string' ? rec.time : undefined
+          const update: CutoverStepStatusRecord = {
+            step: rec.step,
+            status,
+            // The engine only carries `time` on the event; use it as the
+            // start moment for a running step and the finish moment for a
+            // terminal one so the row shows a timestamp either way.
+            startedAt: status === 'running' ? ts : undefined,
+            finishedAt:
+              status === 'done' || status === 'failed' ? ts : undefined,
+            message:
+              status === 'failed' && typeof rec.message === 'string'
+                ? rec.message
+                : undefined,
+          }
+          setStatus((prev) => applyCutoverStepUpdate(prev, update))
+        } catch {
+          /* malformed event — drop, the next event recovers */
         }
-        setStatus((prev) => applyCutoverStepUpdate(prev, update))
-      } catch {
-        /* malformed event — drop, the next event recovers */
       }
-    }
 
+    // The `cutover-status` snapshot frame (replay-on-connect + terminal)
+    // carries the RAW status ConfigMap (a flat string-map) JSON-encoded
+    // into `cutoverEvent.message` — NOT a CutoverStatus object. Unwrap the
+    // envelope, then parse the flat map via parseCutoverStatusConfigMap.
     const onCutoverStatus = (msg: MessageEvent) => {
       if (cancelled) return
       try {
-        const payload = JSON.parse(msg.data) as unknown
-        const next = parseCutoverStatus(payload)
+        const envelope = JSON.parse(msg.data) as unknown
+        if (envelope === null || typeof envelope !== 'object') return
+        const env = envelope as Record<string, unknown>
+        // The status map is stringified inside `.message`.
+        const inner =
+          typeof env.message === 'string' ? JSON.parse(env.message) : env
+        const next = parseCutoverStatusConfigMap(inner)
+        if (!next) return
         setStatus(next)
         if (next.state === 'sovereign') {
           setStreamStatus('completed')
@@ -243,16 +269,34 @@ export function useCutoverEvents(
       }, backoffMs)
     }
 
+    // Bind the real backend phase names to status transitions.
+    const onStepStarted = onStepTransition('running')
+    const onStepFinished = onStepTransition('done')
+    const onStepFailed = onStepTransition('failed')
+
     const openStream = (): EventSource => {
       const next = new EventSource(cutoverEventsURL())
       next.onopen = () => {
         if (cancelled) return
+        // Connection (re)established — clear any prior transport error.
+        setStreamError(null)
         setStreamStatus((prev) =>
           prev === 'completed' ? prev : 'streaming',
         )
         reconnectAttempts = 0
       }
-      next.addEventListener('cutover-step', onCutoverStep as EventListener)
+      next.addEventListener(
+        'cutover-step-started',
+        onStepStarted as EventListener,
+      )
+      next.addEventListener(
+        'cutover-step-finished',
+        onStepFinished as EventListener,
+      )
+      next.addEventListener(
+        'cutover-step-failed',
+        onStepFailed as EventListener,
+      )
       next.addEventListener(
         'cutover-status',
         onCutoverStatus as EventListener,
@@ -270,7 +314,18 @@ export function useCutoverEvents(
       cancelled = true
       if (reconnectTimer !== null) clearTimeout(reconnectTimer)
       if (es) {
-        es.removeEventListener('cutover-step', onCutoverStep as EventListener)
+        es.removeEventListener(
+          'cutover-step-started',
+          onStepStarted as EventListener,
+        )
+        es.removeEventListener(
+          'cutover-step-finished',
+          onStepFinished as EventListener,
+        )
+        es.removeEventListener(
+          'cutover-step-failed',
+          onStepFailed as EventListener,
+        )
         es.removeEventListener(
           'cutover-status',
           onCutoverStatus as EventListener,


### PR DESCRIPTION
Refs #3379 — closes the two `GAP-missing-ui` rows the hw159 cutover walk recorded (`docs/ledger/uat-walkthrough/cutover-durable-true-deny-egress-and-faithful-pivot.md` §2 + §4; `PATH-TO-100.md` bucket C "feature with no UI yet").

## The gap (walked live on hw159)
Settings → **Sovereignty** renders the "Cluster sovereignty" panel with a TETHERED badge + "Achieve True Sovereignty" CTA, and `/jobs` shows cutover step jobs — but the **per-step progress card** and the **`cutoverComplete` / severed-state** never appear.

**Honest root cause (found by reading both sides):** the progress card (`CutoverProgressCard.tsx`) and the severed/sovereign badge (`SovereigntyCard.tsx`) **already existed in code and are already mounted** in `SettingsPage.tsx`. They could never populate because the **frontend consumed a wire contract the backend never emits** — so the card filtered out every step record and stayed blank, and the badge stayed "Tethered". This was masked by FE unit tests that asserted the imagined shape, not the real one (the `must_contain`-style anti-pattern).

Three concrete mismatches vs the **live** `GET /api/v1/sovereign/cutover/status` + the SSE `/events` channel (`api/internal/handler/cutover.go`):

1. **Per-step shape** — backend emits `steps[].name` + `steps[].result` (`"success"`/`"running"`/`"failed"`/`"skipped"`/`""`); the FE read `steps[].step` + `steps[].status` (`"done"`/…). Every record was dropped by the status filter → blank card even on a completed cutover.
2. **Step set drift** — the chart grew **8 → 11** steps (`gitea-token-mint`, `vcluster-registry-pivot`, `crossplane-provider-pivot` appended); the FE hardcoded the old 8 and used `helmrepo-patches` where the chart slug is `helmrepository-patches` (so even that row could never light up). Verified against `platform/self-sovereign-cutover/chart/templates/NN-*.yaml` `cutover-order` labels.
3. **SSE events** — backend signals transitions via the event **names** `cutover-step-started` / `-finished` / `-failed` (outcome encoded in the name) + a `cutover-status` snapshot frame carrying the **raw status ConfigMap**; the FE listened for a single `cutover-step` frame with a payload `status` field that no backend emits.

## What I built (FE-only alignment to the established backend contract)
No Go changes — the handler already exposes `state`, `cutoverComplete`, and `steps[].name/.result`. I aligned the FE to it (same shape `/jobs` consumes; the 11 steps are the canvas truth per the runbook).

- **`shared/types/cutover.ts`**
  - `CUTOVER_STEPS` + `CutoverStepID` → canonical **11** in chart order; corrected `helmrepository-patches`.
  - `parseCutoverStatus` accepts **both** the live shape (`name`/`result`) and the legacy shape (`step`/`status`); new `cutoverResultToStatus` maps the engine vocabulary (`success`/`skipped`→done, `running`→running, `failed`→failed, empty→pending); folds top-level `failedStep`/`lastError` onto the failed step's `message`; reads `cutoverStartedAt`/`cutoverFinishedAt` + nested `raw.*`; derives `egressTestPassed` from the `egress-block-test` step result.
  - new `parseCutoverStatusConfigMap` — parses the flat status-ConfigMap map the SSE `cutover-status` snapshot carries (reconstructs `steps` from `step.<name>.<field>` keys), converging SSE + GET on one validated shape.
- **`widgets/sovereignty/useCutoverEvents.ts`** — subscribe to the three real step events + unwrap the snapshot envelope; clear `streamError` in `onopen` (external-event callback) instead of synchronously in the effect body.
- **`widgets/sovereignty/{SovereigntyCard,CutoverProgressCard}.tsx`** — render the modal step list + every count from `CUTOVER_STEPS` so they can never drift from the engine again.

Once the cutover runs, the **8 (now 11)-step progress card populates with live per-step status + the % bar**, and on completion the badge flips **TETHERED → Sovereign** with the "Sovereignty achieved" summary (mirrored SHA / Harbor projects / egress-test). `cutoverComplete` drives the badge via `state === 'sovereign'`.

## Tests
- `cutover.test.ts` + `SovereigntyCard`/`CutoverProgressCard`/`useCutoverEvents` updated to the 11-step list + the **real `name`/`result` wire shape**. Added coverage: `cutoverResultToStatus`, the live wire shape, the SSE ConfigMap snapshot, `egressTestPassed` derivation, `lastError` folding.

```
UI:  npm run typecheck   → clean
     eslint (7 files)    → clean (0 errors, 0 warnings)
     npm run build       → green (exit 0)
     vitest cutover+sovereignty → 66/66 pass
API: go build ./...      → clean (no Go change)
     go test handler -run Cutover → ok
```

**Honest caveat:** the full UI `vitest run` shows 70 failures across 10 files (`PinInput6`, `SettingsPage` DNS-rows, `cloud-list/ResourceDetailPage`, `Dashboard`, etc.). I verified by stashing this branch that **those 70 fail identically on the base branch** — a pre-existing, unrelated suite breakage (generic render/timeout shape, none sovereignty-specific). This PR neither causes nor fixes them.

Do NOT merge — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)