### PR TITLE
fix(provisioning): dedup provision-create — credit-covered redeem can't self-race into a failed tenant (Refs #3744)

### DIFF
--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -921,7 +922,37 @@ func (h *Handler) startProvisioning(ctx context.Context, tenantID, orderID, plan
 		Progress:  0,
 	}
 
-	if err := h.Store.CreateProvision(ctx, provision); err != nil {
+	// #3744 — dedup the provision-create entrypoint. A credit-covered
+	// marketplace checkout fires this path twice (NATS order.placed event +
+	// POST /provisioning/start) by design; without a guard both inserts fork a
+	// workflow and the two near-simultaneous Gitea commits race on the shared
+	// sme-tenants branch ("cannot lock ref"), marking the tenant failed even
+	// though the Org CR + winning commit land. CreateProvisionIfAbsent is backed
+	// by a partial unique index on (tenant_id, in-flight status), so the second
+	// trigger collides and we return the already-running provision without
+	// forking a duplicate workflow — mirroring CreateJobIfAbsent's #71 dedup for
+	// day-2 Jobs.
+	if err := h.Store.CreateProvisionIfAbsent(ctx, provision); err != nil {
+		if errors.Is(err, store.ErrProvisionExists) {
+			existing, getErr := h.Store.GetInFlightProvisionByTenant(ctx, tenantID)
+			if getErr != nil {
+				slog.Error("duplicate provision dispatch: failed to load in-flight provision",
+					"tenant_id", tenantID, "error", getErr)
+				return nil, getErr
+			}
+			if existing != nil {
+				slog.Info("duplicate provision dispatch — an in-flight provision already exists for this tenant; skipping",
+					"tenant_id", tenantID, "provision_id", existing.ID)
+				return existing, nil
+			}
+			// Lost the in-flight row between the collision and the lookup (it
+			// just reached a terminal state). Treat as benign: return the
+			// provision we built without forking — the prior workflow owns the
+			// outcome. A subsequent legitimate re-provision will succeed.
+			slog.Info("duplicate provision dispatch — prior provision terminated; not forking a new workflow",
+				"tenant_id", tenantID)
+			return provision, nil
+		}
 		slog.Error("failed to create provision record", "error", err)
 		return nil, err
 	}

--- a/core/services/provisioning/main.go
+++ b/core/services/provisioning/main.go
@@ -150,8 +150,17 @@ func main() {
 		slog.Error("failed to create job indexes", "error", err)
 		os.Exit(1)
 	}
+	// Ensure the partial unique index on (tenant_id, in-flight status) backing
+	// the provision-dedup guarantee (#3744) so a credit-covered checkout that
+	// fires the create entrypoint twice (event + HTTP) can't race itself into a
+	// failed tenant via a duplicate Gitea commit on the shared sme-tenants branch.
+	if err := provisionStore.EnsureProvisionIndexes(idxCtx); err != nil {
+		idxCancel()
+		slog.Error("failed to create provision indexes", "error", err)
+		os.Exit(1)
+	}
 	idxCancel()
-	slog.Info("provisioning job indexes ensured")
+	slog.Info("provisioning job + provision indexes ensured")
 	generator := gitops.NewManifestGenerator(gitBasePath)
 	// #3760 (Refs #3376 #3754) MIRROR-EVERYTHING: the Sovereign-local Harbor
 	// host the per-tenant vCluster images pull through. Without proxying, the

--- a/core/services/provisioning/store/provision_dedup_test.go
+++ b/core/services/provisioning/store/provision_dedup_test.go
@@ -1,0 +1,53 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestCreateProvisionIfAbsent_RejectsEmptyTenant proves the dedup guard refuses
+// a blank TenantID BEFORE touching Mongo. This matters because the partial
+// unique index that enforces the #3744 dedup is keyed on tenant_id filtered to
+// in-flight statuses — a blank tenant_id would either collide spuriously across
+// unrelated provisions or never collide at all, defeating the guarantee. The
+// guard makes the precondition explicit instead of relying on index semantics.
+func TestCreateProvisionIfAbsent_RejectsEmptyTenant(t *testing.T) {
+	s := &Store{} // no db needed; the guard returns before any collection access
+	err := s.CreateProvisionIfAbsent(context.Background(), &Provision{TenantID: ""})
+	if err == nil {
+		t.Fatal("CreateProvisionIfAbsent with empty TenantID must error, got nil")
+	}
+	// It must NOT be the duplicate-key sentinel — that would mislead the caller
+	// into surfacing a non-existent in-flight provision.
+	if errors.Is(err, ErrProvisionExists) {
+		t.Fatalf("empty-tenant error must not be ErrProvisionExists, got %v", err)
+	}
+}
+
+// TestInFlightProvisionStatuses_ExcludesTerminal locks down the exact set of
+// statuses the dedup index and lookup treat as "a provision is already running
+// for this tenant". A terminal state (completed/failed) MUST NOT appear here,
+// otherwise a tenant could never be legitimately re-provisioned after a prior
+// run finished — and a failed self-race (the #3744 symptom) would permanently
+// wedge re-provisioning instead of self-healing.
+func TestInFlightProvisionStatuses_ExcludesTerminal(t *testing.T) {
+	want := map[string]bool{"pending": true, "provisioning": true, "running": true}
+	got := map[string]bool{}
+	for _, s := range inFlightProvisionStatuses {
+		got[s] = true
+	}
+	if len(got) != len(want) {
+		t.Fatalf("inFlightProvisionStatuses = %v, want exactly %v", inFlightProvisionStatuses, []string{"pending", "provisioning", "running"})
+	}
+	for s := range want {
+		if !got[s] {
+			t.Errorf("inFlightProvisionStatuses missing in-flight status %q", s)
+		}
+	}
+	for _, terminal := range []string{"completed", "failed"} {
+		if got[terminal] {
+			t.Errorf("inFlightProvisionStatuses must NOT include terminal status %q (would block legitimate re-provision)", terminal)
+		}
+	}
+}

--- a/core/services/provisioning/store/store.go
+++ b/core/services/provisioning/store/store.go
@@ -62,6 +62,94 @@ func (s *Store) CreateProvision(ctx context.Context, p *Provision) error {
 	return nil
 }
 
+// inFlightProvisionStatuses are the provision states that count as "a provision
+// is already running for this tenant". A tenant may legitimately be
+// re-provisioned once a prior provision reaches a terminal state
+// (completed / failed), so the dedup index (EnsureProvisionIndexes) and
+// CreateProvisionIfAbsent only collide on these non-terminal states.
+var inFlightProvisionStatuses = []string{"pending", "provisioning", "running"}
+
+// EnsureProvisionIndexes creates the partial unique index on tenant_id that
+// backs the dedup guarantee in CreateProvisionIfAbsent. The marketplace
+// credit-covered checkout fires the provision-create entrypoint twice — once
+// via the NATS order.placed event and once via POST /provisioning/start (the
+// client deliberately does both as belt-and-suspenders, see CheckoutStep.svelte).
+// Without this guard both calls insert a provision + fork a workflow → two
+// concurrent commits to the same Gitea branch → a ref-lock race that marks the
+// tenant "failed" even though the Org CR + winning commit land (#3744).
+//
+// The index is PARTIAL (filtered to in-flight statuses) so a tenant can be
+// re-provisioned after a prior provision terminates. Safe to call at startup
+// every time — index creation is idempotent. Mirrors EnsureJobIndexes (#71).
+func (s *Store) EnsureProvisionIndexes(ctx context.Context) error {
+	model := mongo.IndexModel{
+		Keys: bson.D{{Key: "tenant_id", Value: 1}},
+		Options: options.Index().
+			SetUnique(true).
+			SetName("uniq_inflight_tenant").
+			SetPartialFilterExpression(bson.D{
+				{Key: "status", Value: bson.D{{Key: "$in", Value: inFlightProvisionStatuses}}},
+			}),
+	}
+	if _, err := s.provisions().Indexes().CreateOne(ctx, model); err != nil {
+		return fmt.Errorf("store: ensure provision indexes: %w", err)
+	}
+	return nil
+}
+
+// ErrProvisionExists is returned by CreateProvisionIfAbsent when an in-flight
+// provision already exists for the tenant. Callers should treat this as "a
+// provision is already running for this tenant — skip this duplicate dispatch"
+// and surface the existing record via GetInFlightProvisionByTenant. See #3744.
+var ErrProvisionExists = fmt.Errorf("store: in-flight provision already exists for tenant")
+
+// CreateProvisionIfAbsent inserts a provision iff no in-flight provision exists
+// for the same tenant. Returns ErrProvisionExists when the partial unique index
+// (EnsureProvisionIndexes) rejects the insert (the first writer wins). This is
+// the create-path twin of CreateJobIfAbsent (#71) and the load-bearing fix for
+// the stranger-redeem self-race (#3744): whichever of the two checkout triggers
+// arrives second collides here and becomes a no-op instead of forking a second
+// workflow.
+func (s *Store) CreateProvisionIfAbsent(ctx context.Context, p *Provision) error {
+	if p.TenantID == "" {
+		return fmt.Errorf("store: CreateProvisionIfAbsent requires TenantID")
+	}
+	if p.ID == "" {
+		p.ID = uuid.New().String()
+	}
+	now := time.Now().UTC()
+	p.CreatedAt = now
+	p.UpdatedAt = now
+	_, err := s.provisions().InsertOne(ctx, p)
+	if err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			return ErrProvisionExists
+		}
+		return fmt.Errorf("store: create provision if absent: %w", err)
+	}
+	return nil
+}
+
+// GetInFlightProvisionByTenant returns the most-recent in-flight provision for
+// a tenant, or (nil, nil) if none exists. Used by the dedup path to surface the
+// already-running provision to the loser of a CreateProvisionIfAbsent collision.
+func (s *Store) GetInFlightProvisionByTenant(ctx context.Context, tenantID string) (*Provision, error) {
+	var p Provision
+	filter := bson.D{
+		{Key: "tenant_id", Value: tenantID},
+		{Key: "status", Value: bson.D{{Key: "$in", Value: inFlightProvisionStatuses}}},
+	}
+	opts := options.FindOne().SetSort(bson.D{{Key: "created_at", Value: -1}})
+	err := s.provisions().FindOne(ctx, filter, opts).Decode(&p)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("store: get in-flight provision by tenant %s: %w", tenantID, err)
+	}
+	return &p, nil
+}
+
 // GetProvision returns a provision by ID.
 func (s *Store) GetProvision(ctx context.Context, id string) (*Provision, error) {
 	var p Provision


### PR DESCRIPTION
## Backlog triage — #3744 / #3728 / #3714 (PATH-TO-100 train)

Triaged three backlog issues for the fresh-Sovereign re-prov train. Verdicts:

### #3744 — (a) train-relevant → IMPLEMENTED here
**Funnel: credit-covered redeem double-fires provisioning → Gitea sme-tenants ref-lock race marks tenant `failed`.**

Root cause confirmed against the issue + live code:
- A credit-covered checkout fires the provision-create entrypoint **twice** — the NATS `order.placed` consumer (`consumer.go`) AND a deliberate `POST /provisioning/start` from `CheckoutStep.svelte`. Both land in `startProvisioning` (the only two callers: `handlers.go:152` + `consumer.go:845`), which unconditionally `CreateProvision` + forks `runProvisioningWorkflow` → two near-simultaneous commits race the shared `sme-tenants` branch; the loser is rejected at the ref-lock layer and the tenant is marked `failed` even though the Org CR + winning commit land.
- **Part (b) of the issue — widening `isGiteaRefRaceError` to match `cannot lock ref` / `failed to update ref` / `but expected` / `.lock` — is ALREADY ON MAIN** (landed via the #3376 funnel re-validation work, `client.go:585-602`, with `client_reflock_test.go`). The hw158 error string already matches on main; the extra `PushRejected` token from the older PR #3745 is redundant. So this PR carries **only the missing primary fix**.

Fix (mirrors the proven day-2 `CreateJobIfAbsent` dedup, #71):
- `store`: `EnsureProvisionIndexes` (PARTIAL unique index on `tenant_id` filtered to in-flight statuses `pending`/`provisioning`/`running`), `CreateProvisionIfAbsent` (returns `ErrProvisionExists` on duplicate-key), `GetInFlightProvisionByTenant` (surfaces the running provision to the loser). Partial index ⇒ a tenant can re-provision after a prior provision reaches a terminal state.
- `handlers/consumer`: `startProvisioning` now uses `CreateProvisionIfAbsent`; on `ErrProvisionExists` it returns the already-running provision **without forking a second workflow**. Both triggers share the entrypoint ⇒ both inherit the guard.
- `main`: wires `EnsureProvisionIndexes` at startup alongside `EnsureJobIndexes`.
- `store` test: empty-`TenantID` guard + in-flight-status set excludes terminal states.

Evidence: `go build ./...` + `go vet ./store/... ./handlers/...` + `go test ./...` all **EXIT 0** (provisioning module). New tests `TestCreateProvisionIfAbsent_RejectsEmptyTenant` + `TestInFlightProvisionStatuses_ExcludesTerminal` PASS; existing ref-lock `github` suite still green.

Note: supersedes the now-`CONFLICTING` PR #3745 (it conflicted with main precisely because part b had landed separately). This PR is the clean re-base of the missing primary half on current main.

### #3728 — (b) already-done as a ready PR (NOT re-implemented)
**pool-domain: wipe does not reliably release the Sovereign subdomain.**

PR **#3730** (`pool-domain-wipe-release`) already implements the exact fix the issue describes — `ReleaseWithRetry` PDM primitive, `h.pdm==nil` guard on the wipe release, background-context release immune to client disconnect, no in-memory reap on release error, and the record-only `DELETE` PDM release. It is **MERGEABLE / CLEAN** with all CI checks GREEN (`test`, `integration (kind + gitea)`, `Vendor-coupling`, `scan`). Re-implementing identical code would create a conflicting duplicate. **Recommend the orchestrator merge PR #3730 onto the train** — no new code needed from me.

### #3714 — (c) out-of-scope here / cloud-init owned by another agent (NOT touched)
**Fresh prov wedges at 0 HelmReleases on IPv4-only VPCs (in-cluster Flux source-controller half).**

The fix already landed on main via PR **#3727** (merged 2026-06-17): deterministic github-IPv4 node pin + in-cluster `coredns-custom`. The remaining headroom work (PR **#3732**, "reclaim 3,035 B control-plane headroom") is the cloud-init 32 KB epic owned by another agent. Per dispatch instructions I did **not** touch `infra/providers/_shared/cloudinit-control-plane.tftpl`. Recommendation: #3732 is marked `[DO NOT MERGE — post-walk]` by its author, so it should ride **after** the next walk, not on this train; the in-cluster resolution fix it follows is already merged.

---

Refs #3744 #3728 #3714

🤖 Generated with [Claude Code](https://claude.com/claude-code)