### PR TITLE
fix(observability): drop false dependsOn:bp-seaweedfs from loki/mimir/tempo — unwedge region-b convergence (Refs #840)

### DIFF
--- a/clusters/_template/bootstrap-kit/22-loki.yaml
+++ b/clusters/_template/bootstrap-kit/22-loki.yaml
@@ -97,10 +97,22 @@ spec:
     # dependsOn requires explicit `namespace:`.
     - name: bp-mgmt-vcluster
       namespace: flux-system
-    # #2745: explicit namespace — a bare `name:` resolves in THIS HR's
-    # namespace (now `mgmt`) → dangling dep → wedge (#3191 shape).
-    - name: bp-seaweedfs
-      namespace: rtz
+    # bp-seaweedfs dependency REMOVED (Refs #840) — mirrors the slot-19
+    # bp-harbor seaweedfs-dep removal (ADR-0001 §13: "writes blobs directly
+    # to cloud Object Storage, not via SeaweedFS"). The DEFAULT Loki render
+    # is `loki.storage.type: filesystem` (platform/loki/chart/values.yaml —
+    # chunks + index on a local 10Gi PVC), NOT SeaweedFS S3. The "MUST
+    # replace storage with s3" per-Sovereign overlay every slot-comment
+    # assumed was specced but never written, so Loki never references
+    # `seaweedfs-s3` / `seaweedfs-s3-secret`. The old
+    # `dependsOn: bp-seaweedfs (ns rtz)` was therefore a FALSE coupling: it
+    # gated Loki — and grafana (slot 25, which dependsOn bp-loki) — on the
+    # rtz-vCluster seaweedfs HR reaching Ready. When seaweedfs is
+    # slow/not-Ready in the SECONDARY region's rtz vCluster, that needlessly
+    # wedged the whole LGTM+grafana chain there (hw159 region-b 41/55 vs
+    # region-a 55/55). Decoupled, Loki converges on its own PVC in BOTH
+    # regions. NOTE: a future overlay that actually flips Loki to SeaweedFS
+    # S3 MUST re-add this edge (with `namespace: rtz`) in lockstep.
   chart:
     spec:
       chart: bp-loki

--- a/clusters/_template/bootstrap-kit/23-mimir.yaml
+++ b/clusters/_template/bootstrap-kit/23-mimir.yaml
@@ -99,10 +99,21 @@ spec:
     # dependsOn requires explicit `namespace:`.
     - name: bp-mgmt-vcluster
       namespace: flux-system
-    # #2745: explicit namespace — a bare `name:` resolves in THIS HR's
-    # namespace (now `mgmt`) → dangling dep → wedge (#3191 shape).
-    - name: bp-seaweedfs
-      namespace: rtz
+    # bp-seaweedfs dependency REMOVED (Refs #840) — mirrors the slot-19
+    # bp-harbor seaweedfs-dep removal (ADR-0001 §13). The DEFAULT Mimir
+    # render runs its OWN bundled MinIO (`minio.enabled: true` in
+    # platform/mimir/chart/values.yaml — blocks-storage on the in-chart
+    # MinIO), NOT SeaweedFS S3. The "MUST set minio.enabled:false AND wire
+    # S3 at SeaweedFS" per-Sovereign overlay was specced but never written,
+    # so Mimir never references `seaweedfs-s3` / `seaweedfs-s3-secret`. The
+    # old `dependsOn: bp-seaweedfs (ns rtz)` was a FALSE coupling that gated
+    # Mimir — and grafana (slot 25, which dependsOn bp-mimir) — on the
+    # rtz-vCluster seaweedfs HR reaching Ready, needlessly wedging the
+    # LGTM+grafana chain in the SECONDARY region when seaweedfs is
+    # slow/not-Ready there (hw159 region-b 41/55). Decoupled, Mimir
+    # converges on its bundled MinIO in BOTH regions. NOTE: a future overlay
+    # that flips Mimir to SeaweedFS S3 MUST re-add this edge (ns rtz) in
+    # lockstep.
   chart:
     spec:
       chart: bp-mimir

--- a/clusters/_template/bootstrap-kit/24-tempo.yaml
+++ b/clusters/_template/bootstrap-kit/24-tempo.yaml
@@ -93,10 +93,20 @@ spec:
     # dependsOn requires explicit `namespace:`.
     - name: bp-mgmt-vcluster
       namespace: flux-system
-    # #2745: explicit namespace — a bare `name:` resolves in THIS HR's
-    # namespace (now `mgmt`) → dangling dep → wedge (#3191 shape).
-    - name: bp-seaweedfs
-      namespace: rtz
+    # bp-seaweedfs dependency REMOVED (Refs #840) — mirrors the slot-19
+    # bp-harbor seaweedfs-dep removal (ADR-0001 §13). The DEFAULT Tempo
+    # render is `tempo.storage.trace.backend: local` (platform/tempo/chart/
+    # values.yaml — traces + WAL on a local 10Gi PVC), NOT SeaweedFS S3. The
+    # "MUST replace this with S3" per-Sovereign overlay every slot-comment
+    # assumed was specced but never written, so Tempo never references
+    # `seaweedfs-s3` / `seaweedfs-s3-secret`. The old
+    # `dependsOn: bp-seaweedfs (ns rtz)` was a FALSE coupling that gated
+    # Tempo — and grafana (slot 25, which dependsOn bp-tempo) — on the
+    # rtz-vCluster seaweedfs HR reaching Ready, needlessly wedging the
+    # LGTM+grafana chain in the SECONDARY region when seaweedfs is
+    # slow/not-Ready there (hw159 region-b 41/55). Decoupled, Tempo
+    # converges on its own PVC in BOTH regions. NOTE: a future overlay that
+    # flips Tempo to SeaweedFS S3 MUST re-add this edge (ns rtz) in lockstep.
   chart:
     spec:
       chart: bp-tempo

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -367,17 +367,28 @@ slots:
   # bp-mgmt-vcluster edge so the install gates on the vc-mgmt
   # kubeconfig Secret existing before helm-controller attempts the
   # kubeConfig pivot (same shape as bp-coraza/bp-dmz-vcluster G92.4).
+  #
+  # Refs #840 (2026-06-18): bp-seaweedfs edge REMOVED from all three —
+  # mirrors the slot-19 bp-harbor seaweedfs-dep removal (ADR-0001 §13).
+  # The DEFAULT renders are filesystem (loki), bundled MinIO (mimir),
+  # local PVC (tempo) — NONE consume SeaweedFS S3 (the "MUST overlay to
+  # S3" was specced in slot-comments but never written). The old edge was
+  # a FALSE coupling that gated the LGTM stack — and grafana (which
+  # dependsOn loki/mimir/tempo) — on the rtz-vCluster seaweedfs HR reaching
+  # Ready, needlessly wedging convergence in the SECONDARY region when
+  # seaweedfs is slow/not-Ready there (hw159 region-b 41/55). A future
+  # overlay that flips any of them to SeaweedFS S3 MUST re-add the edge.
   - slot: 22
     name: bp-loki
-    depends_on: [bp-mgmt-vcluster, bp-seaweedfs]
+    depends_on: [bp-mgmt-vcluster]
     wave: W2.K2
   - slot: 23
     name: bp-mimir
-    depends_on: [bp-mgmt-vcluster, bp-seaweedfs]
+    depends_on: [bp-mgmt-vcluster]
     wave: W2.K2
   - slot: 24
     name: bp-tempo
-    depends_on: [bp-mgmt-vcluster, bp-seaweedfs]
+    depends_on: [bp-mgmt-vcluster]
     wave: W2.K2
   - slot: 25
     name: bp-grafana


### PR DESCRIPTION
## Root cause(s)

Two convergence gaps were investigated on the hw159 walk env (region-b `hrReady 41/55` degraded vs region-a 55/55; console FAILED chips for SeaweedFS + Loki/Mimir/Tempo + Valkey/nats/Coraza/vLLM). They share **one** highest-leverage root cause, fixed here.

### Gap (a) — SeaweedFS-rooted observability is a FALSE dependency

`bp-loki` (slot 22), `bp-mimir` (slot 23), `bp-tempo` (slot 24) each declared `dependsOn: bp-seaweedfs (namespace: rtz)`. But **none of them consume SeaweedFS S3 in the default fresh-prov render**:

| Chart | Default storage (committed values) | Uses SeaweedFS? |
|---|---|---|
| loki | `loki.storage.type: filesystem` (chunks/index on a local 10Gi PVC) | **No** |
| mimir | `minio.enabled: true` (its OWN bundled MinIO) | **No** |
| tempo | `storage.trace.backend: local` (traces/WAL on local PVC) | **No** |

The "per-Sovereign overlay MUST replace storage with S3 at SeaweedFS" that every slot-comment assumed **was specced but never written** — no committed overlay (`clusters/_template`, `omantel`, `otech`, `products/catalyst`) flips any of the three to S3, none reference `seaweedfs-s3` / `seaweedfs-s3-secret`, and seaweedfs's `post-install-bucket-hook` never creates `loki-data`/`mimir-data`/`tempo-data` because `createBuckets` is unset everywhere.

So `dependsOn: bp-seaweedfs` was a **FALSE coupling** (#3191 shape). SeaweedFS installs INSIDE the **rtz** vCluster (kubeConfig pivot); loki/mimir/tempo install inside the **mgmt** vCluster but were gated on the rtz-vCluster seaweedfs HR reaching Ready. `bp-grafana` (slot 25) `dependsOn` loki/mimir/tempo, so the **entire LGTM+grafana chain** was transitively gated on seaweedfs. When seaweedfs is slow/not-Ready in the secondary region's rtz vCluster, Flux blocked the whole observability stack there.

### Gap (b) — region-b 41/55 is the SAME dependsOn-cascade class (NOT #3232 IPv6)

**Honesty note:** the region-b degradation is **NOT** the kom4dc IPv6 helm-repo issue (#3232) and does **not** need re-fixing. The #3232 IPv4-pin is present in the shared cloud-init (`infra/providers/_shared/cloudinit-control-plane.tftpl`, unconditional, runs on both primary and secondary CPs), and hw159 region-b is healthy at the infra/CNI level (Cloud→Clusters 2/2 HEALTHY, 4 nodes / 3 vClusters each — a #3232 CNI-dead region would show 0 nodes). VPC-peering (#3307) is also present (`infra/providers/huawei/main.tf`).

The real region-b driver is the **`dependsOn`-on-a-fragile/slow-resource cascade**: both regions reconcile the same `clusters/_template/bootstrap-kit`; suspended HRs count as Ready, so the 41/55 gap is genuine non-convergence, not a by-design subset. The canonical instance (openbao→ESO `no matches for kind "Continuum"`) was already fixed via `.Capabilities` guards. The seaweedfs→LGTM coupling fixed here is the **highest-leverage remaining instance** of that class — it accounts for loki/mimir/tempo + grafana, which the hw159 `/jobs` canvas shows FAILED in the secondary region.

## Fix

Remove the `bp-seaweedfs` edge from all three observability slots — **exactly mirroring the slot-19 `bp-harbor` seaweedfs-dep removal** (ADR-0001 §13: "writes blobs directly to cloud Object Storage, not via SeaweedFS"). loki/mimir/tempo now converge on their own local/MinIO storage **independently in both regions**.

- `bp-grafana` keeps its loki/mimir/tempo edges (it queries them — that coupling is real).
- `scripts/expected-bootstrap-deps.yaml` updated in lockstep so the dependency-graph audit stays green.
- Inline comments document that a future overlay genuinely flipping any chart to SeaweedFS S3 **MUST re-add the edge** (`namespace: rtz`) in lockstep.

Smallest correct change: 4 files, +59/-15, no chart-template/values changes, no umbrella `Chart.yaml` bump.

**Note on stale cluster copies:** `clusters/omantel.omani.works/` + `clusters/otech.omani.works/` still carry the *pre-vCluster* observability slots (no `kubeConfig` pivot, `namespace: flux-system`) — they predate the #2745 re-homing and already drift heavily from `_template`. The drift guardrail (`cluster-template-drift.yaml`) is explicitly WARN-ONLY for exactly this reason. Fresh provs render `clusters/_template/bootstrap-kit` (per the cloud-init Flux Kustomization `path`), so the canonical fix lives there; the legacy copies are intentionally left untouched (a one-line edit would be a half-sync).

## Tests

- `scripts/check-bootstrap-deps.sh` (dependency-graph audit): **PASSED — Drift 0, Cycles 0.** Confirms `bp-loki/mimir/tempo <-- bp-mgmt-vcluster` (seaweedfs gone), `bp-grafana <-- … bp-loki bp-mimir bp-tempo` (preserved), `bp-seaweedfs <-- bp-cert-manager bp-flux bp-rtz-vcluster` and `bp-guacamole <-- … bp-seaweedfs` (both unchanged — guacamole's seaweedfs use is real).
- `kubectl kustomize clusters/_template/bootstrap-kit`: **EXIT 0** (all slot YAML parses, no merge errors).
- `helm template platform/seaweedfs/chart` and `helm template platform/loki/chart` (after `helm dependency build`): **both EXIT 0** (charts unaffected — change is slots-only).

## What a fresh prov validates

On the next 2-region prov, region-b's `bp-loki/mimir/tempo` HRs should reach Ready without waiting on the rtz-vCluster `bp-seaweedfs` HR, and `bp-grafana` should follow — closing the bulk of the region-b 41/55 → ~55/55 gap and the console FAILED chips for the LGTM stack. (SeaweedFS itself still converges in the rtz vCluster on its own `bp-cert-manager/bp-flux/bp-rtz-vcluster` deps; it just no longer blocks observability.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
