### PR TITLE
fix(bp-newapi): real fix for hw159 zero-click 1st-hit 111 + /setup — native-sidecar bridge + bridge-only Service (Refs #3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -266,7 +266,18 @@ spec:
       # 1st-hit upstream-connect-error 111, 2nd-hit /setup wizard). Shrinks the
       # human-visible window; the per-minute CronJob (1.4.97) self-heals the
       # underlying convergence race.
-      version: 1.4.105
+      # 1.4.107 (#3374, 2026-06-18): REAL fix for the hw159 1st-hit 111 — the
+      # bridge is now a NATIVE sidecar (starts before the DSN gate) behind a
+      # dedicated bridge-only Service with publishNotReadyAddresses:true, and
+      # the Exact `/` route backendRefs that Service — so the zero-click landing
+      # page is REACHABLE on the 1st hit even while `newapi` is NotReady during
+      # GORM migrate (a plain-container bridge had its endpoint suppressed by
+      # pod-readiness AND-gating → 111 → browser never loaded the page → SPA
+      # /setup). The landing page also self-reloads (not /login→/setup) on
+      # warm-up retry-exhaustion. The setup wizard stays pre-completed by the
+      # admin-sso-seed-job. This slot sets no sandboxBridge/service overrides,
+      # so the chart defaults (native sidecar + bridge Service) are what render.
+      version: 1.4.107
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.105
+  version: 1.4.107
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,48 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.107 (#3374, 2026-06-18): REAL fix for the hw159 zero-click 1st-hit 111 +
+# /setup — eliminate the readiness race at its source instead of only retrying
+# in the landing page (1.4.102 was honest race-hardening, not a fix). ROOT
+# CAUSE: the sandbox-bridge serves the Exact `/` zero-click landing page, but
+# as a PLAIN container it was gated TWICE behind NewAPI's ~2-min warm-up:
+#   (1) the wait-for-sql-dsn initContainer runs to completion BEFORE any plain
+#       container starts, so the bridge wasn't listening during the DSN-wait
+#       window; and
+#   (2) a Pod joins a Service EndpointSlice only when ALL containers are Ready
+#       (pod-readiness = AND of every readinessProbe). The `newapi` container is
+#       NotReady until GORM AutoMigrate finishes, so the WHOLE Pod stayed
+#       NotReady → the Service had ZERO ready endpoints on every port (incl. the
+#       bridge) → the gateway's Exact `/` backendRef had no healthy upstream →
+#       `upstream-connect-error ... delayed connect error: 111`. The bridge
+#       process being up was irrelevant; its endpoint was suppressed. The
+#       browser could not even LOAD the landing page, so the 1.4.102 retry never
+#       ran on the 1st hit; the SPA then showed /setup.
+# FIX (three coordinated parts, all real):
+#   (a) deployment.yaml — the bridge is now a NATIVE sidecar (initContainers
+#       entry with restartPolicy:Always, KEP-753 GA k8s 1.29; Sovereigns run
+#       k3s v1.31.4) declared FIRST, so it starts BEFORE the DSN gate and runs
+#       the whole Pod lifetime — decoupled from NewAPI's migrate. Env shared
+#       with the legacy path via the new bp-newapi.sandboxBridgeEnv helper.
+#       Operator opt-out: sandboxBridge.nativeSidecar=false (pre-1.29 clusters).
+#   (b) service.yaml — a dedicated bridge-only Service
+#       `<fullname>-bridge` with publishNotReadyAddresses:true publishes the
+#       bridge endpoint the INSTANT it binds :8080, even while `newapi` is
+#       NotReady. httproute.yaml's Exact `/` rule now backendRefs THIS Service
+#       (gateway.bridgeBackendService overrides it for the vCluster syncer-
+#       mangled name). Result: the bare URL loads the landing page on the 1st
+#       hit — no 111.
+#   (c) sso_init.go (bridge sidecar) — on /api/oauth/state retry-exhaustion
+#       while SSO IS configured (NewAPI still warming up) the page now RELOADS
+#       ITSELF instead of falling through to /login (which the SPA bounces to
+#       /setup on an unseeded NewAPI). So the first human visit never dead-ends
+#       at the setup wizard during convergence. (An unconfigured overlay still
+#       degrades to /login — reloading would loop with nothing to land on.)
+# The setup wizard itself stays pre-completed by the admin-sso-seed-job (setups
+# row + sovereign OIDC provider) and the per-minute promote/reload CronJob
+# (1.4.97); this change ensures the landing page is REACHABLE and never routes
+# the owner to /setup before the seed lands. Lockstep: 80-newapi.yaml pin +
+# blueprint.yaml → 1.4.107. NB: build-bp-newapi-sandbox-bridge.yaml auto-bumps
+# the pin further on merge (it rebuilds the sso_init.go sidecar). Refs #3374.
 # 1.4.97 (#3374/#3563, 2026-06-17): SELF-HEALING provider reload — make the
 # zero-click SSO custom-provider reload DETERMINISTIC on a fresh install. ROOT
 # CAUSE re-surfaced live on hw158: newapi's in-app OIDC callback
@@ -698,7 +741,7 @@ name: bp-newapi
 # fresh-prov readiness window the per-minute admin-promote CronJob self-heals
 # (#3767, 1.4.97) — this retry shrinks the human-visible window, it is not a
 # new SSO mechanism. Refs #3374.
-version: 1.4.105
+version: 1.4.107
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/_helpers.tpl
+++ b/platform/newapi/chart/templates/_helpers.tpl
@@ -86,6 +86,63 @@ ConfigMap name (channel + policy config).
 {{- end }}
 
 {{/*
+Sandbox-bridge env block (#3374). Shared by BOTH the native-sidecar
+initContainer (the default since 2026-06-18) and the legacy plain-container
+sidecar in deployment.yaml, so the two code paths stay byte-identical. Resolves
+the token-signing-key Secret name with the SAME precedence as the Deployment's
+$effTokenSigningKeySecret (explicit existingSecret > chart auto-provisioned
+`<release>-token-signing-key`). The #3374 zero-click SSO env (provider slug +
+deterministic authorize URL / client_id / scopes) is injected here so the
+landing page builds the Keycloak redirect directly (NewAPI v0.13.2's
+/api/status omits custom_oauth_providers, so runtime discovery is impossible).
+*/}}
+{{- define "bp-newapi.sandboxBridgeEnv" -}}
+{{- $tk := .Values.sandboxTokenSigningKey | default dict -}}
+{{- $effTokenSigningKeySecret := $tk.existingSecret -}}
+{{- if and (not $effTokenSigningKeySecret) (default true $tk.autoProvision) -}}
+{{- $effTokenSigningKeySecret = default (printf "%s-token-signing-key" (include "bp-newapi.fullname" .)) $tk.autoSecretName -}}
+{{- end -}}
+- name: BRIDGE_LISTEN
+  value: ":{{ .Values.sandboxBridge.port }}"
+- name: NEWAPI_TOKEN_SIGNING_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ $effTokenSigningKeySecret }}
+      key: SIGNING_KEY
+- name: NEWAPI_ADMIN_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ $effTokenSigningKeySecret }}
+      key: ADMIN_SECRET
+{{- /* #3374 — the OIDC provider slug the zero-click bare-URL landing page
+   (served by this sidecar at `/`, routed by the HTTPRoute's Exact `/` rule)
+   initiates. Matches the admin-sso-seed-job's custom_oauth_providers.slug.
+   #3648 — standard sso.bootstrap contract first, then legacy adminSeed, then
+   the literal default "sovereign". */}}
+- name: NEWAPI_SSO_INIT_SLUG
+  value: {{ ((.Values.sso | default dict).bootstrap | default dict).providerSlug | default (.Values.adminSeed | default dict).providerSlug | default "sovereign" | quote }}
+{{- /*
+   #3374 0.1.16 — the landing page builds the authorize redirect DIRECTLY from
+   these values instead of discovering them at runtime from GET /api/status
+   (NewAPI v0.13.2's /api/status has NO custom_oauth_providers field → the old
+   discovery returned [] → the page fell through to /login → the SPA bounced
+   the owner to /setup). These are the IDENTICAL values the admin-sso-seed-job
+   seeds into custom_oauth_providers. When sovereignFQDN is unset the
+   seed/landing are no-ops anyway (the page degrades to the SPA /login link). */}}
+{{- $sk := .Values.adminSeed | default dict }}
+{{- $ssoBoot := (.Values.sso | default dict).bootstrap | default dict }}
+{{- if .Values.sovereignFQDN }}
+{{- $slug := $ssoBoot.providerSlug | default $sk.providerSlug | default "sovereign" }}
+- name: NEWAPI_SSO_AUTHORIZE_URL
+  value: {{ printf "https://auth.%s/realms/%s/protocol/openid-connect/auth?kc_idp_hint=catalyst-pin" .Values.sovereignFQDN $slug | quote }}
+- name: NEWAPI_SSO_CLIENT_ID
+  value: {{ .Values.auth.adminUI.keycloak.clientId | default "newapi-admin" | quote }}
+- name: NEWAPI_SSO_SCOPES
+  value: {{ $sk.scopes | default "openid profile email groups" | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Effective channel list — composed default channels plus
 `.Values.channels`. Composition order matters because NewAPI's
 channel-router resolves `model` lookups in row-insertion order:

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -120,8 +120,98 @@ spec:
         the gate passes immediately). databaseDsnGate.enabled=false opts out.
       */}}
       {{- $dsnGate := .Values.databaseDsnGate | default dict -}}
-      {{- if and (default true $dsnGate.enabled) .Values.cnpg.enabled }}
+      {{- $dsnGateOn := and (default true $dsnGate.enabled) .Values.cnpg.enabled -}}
+      {{- /*
+        #3374 (2026-06-18) — sandbox-bridge as a NATIVE sidecar (initContainer
+        with restartPolicy:Always), so the zero-click bare-URL landing page is
+        reachable on the FIRST hit instead of throwing `upstream-connect-error
+        ... delayed connect error: 111`.
+
+        ROOT CAUSE (re-walked live hw159): the bridge sidecar serves the
+        Exact `/` landing page, but as a PLAIN container it was gated TWICE
+        behind NewAPI's ~2-min warm-up:
+          (1) the `wait-for-sql-dsn` initContainer (below) runs to completion
+              BEFORE any plain container — including the bridge — starts, so
+              the bridge process was not even listening during the DSN-wait
+              window; and
+          (2) a Pod joins a Service's EndpointSlice only when ALL its
+              containers are Ready (pod-readiness = AND of every container's
+              readinessProbe). The `newapi` container's readinessProbe cannot
+              pass until GORM AutoMigrate finishes, so the WHOLE Pod stayed
+              NotReady → the Service had ZERO ready endpoints on EVERY port,
+              including the bridge port → the gateway's Exact `/` backendRef
+              had no healthy upstream → 111. The bridge process being up was
+              irrelevant; its endpoint was suppressed.
+        A native sidecar (KEP-753, GA k8s 1.29; Sovereigns run k3s v1.31.4)
+        declared as the FIRST initContainer starts in init-order BEFORE the
+        DSN gate and keeps running for the whole Pod lifetime, decoupling the
+        landing page from NewAPI's migrate. Paired with a bridge-only Service
+        carrying publishNotReadyAddresses:true (service.yaml) so the bridge
+        endpoint publishes the instant it listens, even while `newapi` is
+        NotReady. Together these eliminate the 1st-hit 111; the landing page
+        then rides out NewAPI's /api/oauth/state warm-up via its own retry.
+        Gated on sandboxBridge.nativeSidecar (default true); set false to fall
+        back to the legacy plain-container bridge.
+      */}}
+      {{- /* default-true gate that respects an explicit `false` — the Helm
+         `default true <bool>` idiom wrongly coerces an explicit false back to
+         true because false is the bool zero-value, so test key presence +
+         value directly (same idiom as the ssoInit gate). */ -}}
+      {{- $sb := .Values.sandboxBridge | default dict -}}
+      {{- $bridgeNativeOn := or (not (hasKey $sb "nativeSidecar")) $sb.nativeSidecar -}}
+      {{- $bridgeNative := and .Values.sandboxBridge.enabled $bridgeNativeOn -}}
+      {{- if or $bridgeNative $dsnGateOn }}
       initContainers:
+        {{- if $bridgeNative }}
+        # ── Sandbox-bridge NATIVE sidecar (#3374, 2026-06-18) ───────────
+        # restartPolicy:Always promotes this initContainer to a native
+        # sidecar: it starts FIRST (before wait-for-sql-dsn) and runs for the
+        # whole Pod lifetime. This is the SAME image/env/port/securityContext
+        # as the legacy plain-container bridge (kept identical so the only
+        # behavioural change is WHEN it starts and HOW its endpoint publishes).
+        - name: sandbox-bridge
+          image: "{{ .Values.sandboxBridge.image.repository }}:{{ .Values.sandboxBridge.image.tag }}"
+          imagePullPolicy: {{ .Values.sandboxBridge.image.pullPolicy }}
+          restartPolicy: Always
+          ports:
+            - name: bridge
+              containerPort: {{ .Values.sandboxBridge.port }}
+              protocol: TCP
+          env:
+            {{- include "bp-newapi.sandboxBridgeEnv" . | nindent 12 }}
+          # startupProbe gates "sidecar started" for the native-sidecar init
+          # ordering (the next init step waits for this probe to pass). The
+          # bridge binds :8080 in milliseconds, so this is near-instant.
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.sandboxBridge.port }}
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            timeoutSeconds: 3
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.sandboxBridge.port }}
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.sandboxBridge.port }}
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.sandboxBridge.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.sandboxBridge.securityContext | nindent 12 }}
+        {{- end }}
+        {{- if $dsnGateOn }}
         # Image defaults to the NewAPI image itself (same ghcr.io/openova-io/*
         # glob as the main container). kyverno harbor-proxy-pull uses an
         # anyPattern that requires ONE allowed glob to match BOTH the
@@ -178,6 +268,7 @@ spec:
             - name: sql-dsn-gate
               mountPath: /dsn
               readOnly: true
+        {{- end }}
       {{- end }}
       containers:
         - name: newapi
@@ -310,8 +401,22 @@ spec:
           resources:
             {{- toYaml .Values.newapi.resources | nindent 12 }}
 
-        {{- if .Values.sandboxBridge.enabled }}
-        # ── Sandbox-bridge sidecar (#2303, Wave 5.57) ───────────
+        {{- /*
+        #3374 (2026-06-18) — the sandbox-bridge is now a NATIVE sidecar
+        (initContainers, above) by default so the zero-click landing page is
+        reachable on the 1st hit (it no longer waits behind the DSN gate +
+        NewAPI's pod-readiness AND-gate → no more 111). The legacy plain
+        sidecar below renders ONLY when sandboxBridge.nativeSidecar=false (an
+        operator opt-out, e.g. for a k8s <1.29 cluster without native-sidecar
+        support). Env is shared via the bp-newapi.sandboxBridgeEnv helper so
+        both code paths stay byte-identical. */}}
+        {{- /* legacy plain-container bridge renders ONLY when nativeSidecar is
+           explicitly false (key present + value false). Mirrors $bridgeNative
+           above; avoids the `default true <bool>` false-coercion trap. */ -}}
+        {{- $sbC := .Values.sandboxBridge | default dict -}}
+        {{- $bridgeLegacy := and .Values.sandboxBridge.enabled (hasKey $sbC "nativeSidecar") (not $sbC.nativeSidecar) -}}
+        {{- if $bridgeLegacy }}
+        # ── Sandbox-bridge sidecar (#2303, Wave 5.57; legacy plain container) ──
         # Catalyst-side bridge handler at POST /admin/tokens/sandbox.
         # The upstream Calcium-Ion binary doesn't ship this route, so
         # without this sidecar sandbox-controller's token-mint call
@@ -328,50 +433,7 @@ spec:
               containerPort: {{ .Values.sandboxBridge.port }}
               protocol: TCP
           env:
-            - name: BRIDGE_LISTEN
-              value: ":{{ .Values.sandboxBridge.port }}"
-            - name: NEWAPI_TOKEN_SIGNING_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $effTokenSigningKeySecret }}
-                  key: SIGNING_KEY
-            - name: NEWAPI_ADMIN_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $effTokenSigningKeySecret }}
-                  key: ADMIN_SECRET
-            # #3374 — the OIDC provider slug the zero-click bare-URL landing
-            # page (served by this sidecar at `/`, routed by the HTTPRoute's
-            # Exact `/` rule) initiates. Matches the admin-sso-seed-job's
-            # custom_oauth_providers.slug. Default "sovereign".
-            # #3648 — provider slug from the STANDARD sso.bootstrap contract
-            # first, then the legacy adminSeed.providerSlug, then default.
-            - name: NEWAPI_SSO_INIT_SLUG
-              value: {{ ((.Values.sso | default dict).bootstrap | default dict).providerSlug | default (.Values.adminSeed | default dict).providerSlug | default "sovereign" | quote }}
-            {{- /*
-            #3374 0.1.16 (2026-06-15) — the landing page builds the authorize
-            redirect DIRECTLY from these values instead of discovering them at
-            runtime from GET /api/status. ROOT CAUSE (measured live hw138, dep
-            4b5ff7852e33fc15): NewAPI v0.13.2's /api/status payload has NO
-            `custom_oauth_providers` field, so the old discovery returned [] →
-            the page fell through to /login → the SPA bounced the owner to the
-            /setup wizard (even though the DB was correctly seeded). These are
-            the IDENTICAL values the admin-sso-seed-job seeds into
-            custom_oauth_providers (authorization_endpoint + client_id +
-            scopes). When sovereignFQDN is unset the seed/landing are no-ops
-            anyway (the page degrades to the SPA /login link). */}}
-            {{- $sk := .Values.adminSeed | default dict }}
-            {{- $ssoBoot := (.Values.sso | default dict).bootstrap | default dict }}
-            {{- if .Values.sovereignFQDN }}
-            {{- /* #3648 — standard sso.bootstrap.providerSlug first, then legacy. */}}
-            {{- $slug := $ssoBoot.providerSlug | default $sk.providerSlug | default "sovereign" }}
-            - name: NEWAPI_SSO_AUTHORIZE_URL
-              value: {{ printf "https://auth.%s/realms/%s/protocol/openid-connect/auth?kc_idp_hint=catalyst-pin" .Values.sovereignFQDN $slug | quote }}
-            - name: NEWAPI_SSO_CLIENT_ID
-              value: {{ .Values.auth.adminUI.keycloak.clientId | default "newapi-admin" | quote }}
-            - name: NEWAPI_SSO_SCOPES
-              value: {{ $sk.scopes | default "openid profile email groups" | quote }}
-            {{- end }}
+            {{- include "bp-newapi.sandboxBridgeEnv" . | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/platform/newapi/chart/templates/httproute.yaml
+++ b/platform/newapi/chart/templates/httproute.yaml
@@ -88,7 +88,15 @@ lands the owner signed-in (verified live on hw136). Gated + overrideable.
             type: Exact
             value: "/"
       backendRefs:
-        - name: {{ .Values.gateway.backendService | default (include "bp-newapi.fullname" .) }}
+        {{- /* #3374 (2026-06-18) — route the bare URL to the dedicated
+        bridge-only Service (<fullname>-bridge, publishNotReadyAddresses:true)
+        so the zero-click landing page is reachable on the 1st hit even while
+        the `newapi` container is NotReady during GORM AutoMigrate (no more
+        111). gateway.bridgeBackendService overrides the name when this chart
+        installs inside a vCluster (the syncer mangles it to
+        <svc>-x-<ns>-x-<vcluster>); empty default = chart-computed
+        <fullname>-bridge. */}}
+        - name: {{ .Values.gateway.bridgeBackendService | default (printf "%s-bridge" (include "bp-newapi.fullname" .)) }}
           port: {{ .Values.sandboxBridge.port }}
 {{- end }}
     - matches:

--- a/platform/newapi/chart/templates/service.yaml
+++ b/platform/newapi/chart/templates/service.yaml
@@ -45,4 +45,48 @@ spec:
     {{- end }}
   selector:
     {{- include "bp-newapi.selectorLabels" . | nindent 4 }}
+{{- /*
+#3374 (2026-06-18) — dedicated bridge-only Service with
+publishNotReadyAddresses:true. The main Service above only adds the Pod to its
+EndpointSlice once ALL containers are Ready (pod-readiness = AND of every
+container readinessProbe); the `newapi` container is NotReady for ~2 min during
+GORM AutoMigrate, so the main Service has ZERO ready endpoints (every port)
+during warm-up. The gateway routes the bare URL's Exact `/` here instead, and
+publishNotReadyAddresses:true publishes the bridge endpoint the INSTANT the
+bridge container is listening — even while `newapi` is NotReady — so the
+zero-click landing page loads on the 1st hit (no `upstream-connect-error ...
+delayed connect error: 111`). The landing page's own retry then rides out
+NewAPI's /api/oauth/state warm-up. Combined with the native-sidecar bridge
+(deployment.yaml), this is the real fix for the hw159 1st-hit 111. Gated on
+sandboxBridge.enabled + ssoInit (the only consumer is the Exact `/` route);
+publishNotReadyAddresses is safe here because the bridge has NO not-ready
+window that serves bad data — it answers /healthz + the static landing page as
+soon as it binds, and /api/oauth/state is proxied to NewAPI by the SPA, not by
+this Service.
+*/ -}}
+{{- $ssoInit := .Values.ssoInit | default dict -}}
+{{- $ssoInitOn := or (not (hasKey $ssoInit "enabled")) $ssoInit.enabled -}}
+{{- if and .Values.sandboxBridge.enabled $ssoInitOn }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bp-newapi.fullname" . }}-bridge
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+    catalyst.openova.io/component: newapi-bridge
+spec:
+  type: {{ .Values.service.type }}
+  # Publish the bridge endpoint even while the Pod is NotReady (the `newapi`
+  # container's GORM-migrate window). The bridge serves the zero-click landing
+  # page + /healthz the instant it binds :{{ .Values.sandboxBridge.port }}.
+  publishNotReadyAddresses: true
+  ports:
+    - name: bridge
+      port: {{ .Values.sandboxBridge.port }}
+      targetPort: {{ .Values.sandboxBridge.port }}
+      protocol: TCP
+  selector:
+    {{- include "bp-newapi.selectorLabels" . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/platform/newapi/chart/tests/bridge-readiness-render.sh
+++ b/platform/newapi/chart/tests/bridge-readiness-render.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# bp-newapi — sandbox-bridge readiness / 1st-hit-111 render audit (#3374).
+#
+# The hw159 walk showed the zero-click bare URL throwing
+# `upstream-connect-error ... delayed connect error: 111` on the 1st hit, then
+# landing on the /setup wizard. ROOT CAUSE: the bridge serves the Exact `/`
+# landing page, but as a PLAIN container it was gated behind NewAPI's ~2-min
+# warm-up TWICE — (1) the wait-for-sql-dsn initContainer runs to completion
+# before any plain container starts, and (2) a Pod only joins a Service's
+# EndpointSlice once ALL its containers are Ready (the `newapi` container is
+# NotReady during GORM AutoMigrate), so the Service had ZERO ready endpoints on
+# every port → the gateway's Exact `/` backendRef had no healthy upstream → 111.
+#
+# The fix renders THREE things this test asserts:
+#   1. The bridge is a NATIVE sidecar (initContainers entry, restartPolicy:
+#      Always) declared BEFORE wait-for-sql-dsn, carrying a readinessProbe on
+#      the bridge port — and it is NOT duplicated in the plain containers list.
+#   2. A dedicated bridge-only Service `<fullname>-bridge` with
+#      publishNotReadyAddresses:true exists, so its endpoint publishes while the
+#      Pod is NotReady.
+#   3. The HTTPRoute's Exact `/` rule backendRefs the bridge-only Service (NOT
+#      the main Service) on the bridge port.
+#
+# Plus the operator opt-out:
+#   4. sandboxBridge.nativeSidecar=false falls back to the LEGACY plain
+#      container (in containers:, no restartPolicy:Always, no native sidecar).
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+# Slot-overlay-equivalent values: keycloak mode + sovereignFQDN + httpRoute on
+# (the full zero-click SSO path the bootstrap-kit slot 80 overlay drives).
+common_values=$(mktemp)
+trap 'rm -f "$common_values"' EXIT
+cat > "$common_values" <<'EOF'
+sovereignFQDN: hw159.omani.works
+auth:
+  adminUI:
+    mode: keycloak
+    keycloak:
+      issuer: https://auth.hw159.omani.works/realms/sovereign
+      clientId: newapi-admin
+      existingSecret: newapi-oidc
+ingress:
+  host: api.hw159.omani.works
+  httpRoute:
+    enabled: true
+    host: newapi.hw159.omani.works
+EOF
+
+out=$("$helm" template smoke "$chart_dir" -f "$common_values" 2>&1)
+
+# Helper: extract the Deployment document.
+deployment_block() { echo "$out" | awk '/^kind: Deployment$/{f=1} f&&/^kind: /&&!/^kind: Deployment$/{f=0} f'; }
+
+dep=$(deployment_block)
+if [ -z "$dep" ]; then
+  echo "FAIL: Deployment did not render"
+  exit 1
+fi
+
+# ── Case 1: bridge is a native sidecar (initContainers) with readinessProbe ──
+echo "[bp-newapi] Case 1: bridge native sidecar in initContainers w/ readinessProbe"
+
+init_block=$(echo "$dep" | awk '/initContainers:/{f=1} f&&/^      containers:/{f=0} f')
+if [ -z "$init_block" ]; then
+  echo "FAIL: no initContainers block (native-sidecar bridge + dsn gate expected)"
+  exit 1
+fi
+
+# The native-sidecar bridge must be in initContainers with restartPolicy:Always.
+bridge_init=$(echo "$init_block" | awk '
+  /^        - name: sandbox-bridge[[:space:]]*$/{f=1; print; next}
+  f && /^        - name: /{f=0}
+  f{print}
+')
+if [ -z "$bridge_init" ]; then
+  echo "FAIL: sandbox-bridge not present as a native sidecar in initContainers"
+  echo "--- initContainers ---"; echo "$init_block"
+  exit 1
+fi
+if ! echo "$bridge_init" | grep -q "restartPolicy: Always"; then
+  echo "FAIL: native-sidecar bridge missing restartPolicy: Always (KEP-753 native sidecar)"
+  exit 1
+fi
+# readinessProbe on the bridge port (8080) — this is the explicit ask: the
+# Service has no ready endpoint until the bridge answers /healthz.
+bridge_ready=$(echo "$bridge_init" | awk '
+  /^          readinessProbe:/{f=1; print; next}
+  f && /^          [a-zA-Z]/{f=0}
+  f{print}
+')
+if [ -z "$bridge_ready" ]; then
+  echo "FAIL: native-sidecar bridge has no readinessProbe"
+  exit 1
+fi
+if ! echo "$bridge_ready" | grep -q "path: /healthz"; then
+  echo "FAIL: bridge readinessProbe path is not /healthz"
+  exit 1
+fi
+if ! echo "$bridge_ready" | grep -q "port: 8080"; then
+  echo "FAIL: bridge readinessProbe port is not the bridge port 8080"
+  exit 1
+fi
+# Init-ordering: the bridge must come BEFORE wait-for-sql-dsn so it starts
+# first (the DSN gate must not block the landing page).
+bridge_line=$(echo "$init_block" | grep -n "name: sandbox-bridge" | head -1 | cut -d: -f1)
+dsn_line=$(echo "$init_block" | grep -n "name: wait-for-sql-dsn" | head -1 | cut -d: -f1)
+if [ -n "$dsn_line" ] && [ "$bridge_line" -ge "$dsn_line" ]; then
+  echo "FAIL: native-sidecar bridge must be declared BEFORE wait-for-sql-dsn (got bridge@$bridge_line, dsn@$dsn_line)"
+  exit 1
+fi
+# It must NOT also appear as a plain container (no duplication).
+containers_only=$(echo "$dep" | awk '/^      containers:/{f=1} f' | awk '/^      volumes:/{exit} {print}')
+if echo "$containers_only" | grep -q "name: sandbox-bridge"; then
+  echo "FAIL: sandbox-bridge duplicated as a plain container while native sidecar is on"
+  exit 1
+fi
+echo "[bp-newapi] Case 1: PASS"
+
+# ── Case 2: bridge-only Service with publishNotReadyAddresses ────────────────
+echo "[bp-newapi] Case 2: bridge-only Service w/ publishNotReadyAddresses"
+bridge_svc=$(echo "$out" | awk 'BEGIN{RS="---\n"} /kind: Service/ && /name: smoke-bp-newapi-bridge/ {print}')
+if [ -z "$bridge_svc" ]; then
+  echo "FAIL: dedicated bridge-only Service <fullname>-bridge did not render"
+  exit 1
+fi
+if ! echo "$bridge_svc" | grep -q "publishNotReadyAddresses: true"; then
+  echo "FAIL: bridge-only Service missing publishNotReadyAddresses: true"
+  echo "--- bridge service ---"; echo "$bridge_svc"
+  exit 1
+fi
+if ! echo "$bridge_svc" | grep -q "port: 8080"; then
+  echo "FAIL: bridge-only Service does not expose the bridge port 8080"
+  exit 1
+fi
+echo "[bp-newapi] Case 2: PASS"
+
+# ── Case 3: HTTPRoute Exact / → bridge-only Service ─────────────────────────
+echo "[bp-newapi] Case 3: HTTPRoute Exact / backendRefs the bridge-only Service"
+httproute=$(echo "$out" | awk 'BEGIN{RS="---\n"} /kind: HTTPRoute/ {print}')
+if [ -z "$httproute" ]; then
+  echo "FAIL: HTTPRoute did not render"
+  exit 1
+fi
+# Extract the Exact `/` rule's backendRef name (the block following type: Exact).
+exact_backend=$(echo "$httproute" | awk '
+  /type: Exact/{e=1}
+  e && /name: /{print; e=0}
+')
+if ! echo "$exact_backend" | grep -q "smoke-bp-newapi-bridge"; then
+  echo "FAIL: Exact / rule does not backendRef the bridge-only Service smoke-bp-newapi-bridge"
+  echo "--- Exact backendRef ---"; echo "$exact_backend"
+  echo "--- httproute rules ---"; echo "$httproute" | awk '/rules:/{f=1} f'
+  exit 1
+fi
+echo "[bp-newapi] Case 3: PASS"
+
+# ── Case 4: operator opt-out → legacy plain-container bridge ─────────────────
+echo "[bp-newapi] Case 4: nativeSidecar=false → legacy plain container"
+optout_values=$(mktemp)
+cat > "$optout_values" <<'EOF'
+sovereignFQDN: hw159.omani.works
+auth:
+  adminUI:
+    mode: keycloak
+    keycloak:
+      issuer: https://auth.hw159.omani.works/realms/sovereign
+      clientId: newapi-admin
+      existingSecret: newapi-oidc
+sandboxBridge:
+  nativeSidecar: false
+EOF
+out2=$("$helm" template smoke "$chart_dir" -f "$optout_values" 2>&1)
+rm -f "$optout_values"
+dep2=$(echo "$out2" | awk '/^kind: Deployment$/{f=1} f&&/^kind: /&&!/^kind: Deployment$/{f=0} f')
+
+# In opt-out mode the bridge must be a PLAIN container, never a native sidecar.
+init_block2=$(echo "$dep2" | awk '/initContainers:/{f=1} f&&/^      containers:/{f=0} f')
+if echo "$init_block2" | grep -q "name: sandbox-bridge"; then
+  echo "FAIL: nativeSidecar=false but bridge still rendered as a native sidecar (default-true-bool coercion bug?)"
+  exit 1
+fi
+containers2=$(echo "$dep2" | awk '/^      containers:/{f=1} f' | awk '/^      volumes:/{exit} {print}')
+if ! echo "$containers2" | grep -q "name: sandbox-bridge"; then
+  echo "FAIL: nativeSidecar=false but bridge not present as a plain container"
+  exit 1
+fi
+# Exactly one bridge container in either mode.
+n=$(echo "$dep2" | grep -c "name: sandbox-bridge")
+if [ "$n" != "1" ]; then
+  echo "FAIL: expected exactly 1 sandbox-bridge container in opt-out mode, got $n"
+  exit 1
+fi
+echo "[bp-newapi] Case 4: PASS"
+
+echo "[bp-newapi] All sandbox-bridge readiness render cases PASS"

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -908,6 +908,13 @@ gateway:
   # (<svc>-x-<ns>-x-<vcluster>). Empty = chart-computed name (host
   # install, byte-identical).
   backendService: ""
+  # #3374 (2026-06-18): the HTTPRoute's Exact `/` rule (zero-click bare-URL SSO
+  # landing) backendRefs the dedicated bridge-only Service
+  # (<fullname>-bridge, publishNotReadyAddresses:true). When this chart
+  # installs inside a vCluster the syncer mangles that Service name to
+  # <svc>-x-<ns>-x-<vcluster>; set this override to the host-side synced name.
+  # Empty = chart-computed <fullname>-bridge (host install, byte-identical).
+  bridgeBackendService: ""
 # ─── NetworkPolicy ───────────────────────────────────────────────────────
 # Default-allow ingress from the platform's gateway namespace; egress
 # to Postgres, Valkey (now in the rtz host namespace — #3373 Batch A),
@@ -1029,6 +1036,20 @@ ssoInit:
   enabled: true
 sandboxBridge:
   enabled: true
+  # #3374 (2026-06-18): run the bridge as a NATIVE sidecar (initContainers
+  # entry with restartPolicy:Always) instead of a plain container. This is the
+  # real fix for the hw159 1st-hit `upstream-connect-error ... delayed connect
+  # error: 111` on the bare URL: as a plain container the bridge (a) did not
+  # start until the wait-for-sql-dsn initContainer completed, and (b) had its
+  # Service endpoint suppressed because a Pod only joins a Service's
+  # EndpointSlice when ALL containers are Ready — and the `newapi` container is
+  # NotReady for ~2 min during GORM AutoMigrate. As a native sidecar declared
+  # FIRST it starts immediately (before the DSN gate) and runs the whole Pod
+  # lifetime, so paired with the bridge-only Service (publishNotReadyAddresses)
+  # the zero-click landing page is reachable on the 1st hit. Native sidecars
+  # are GA in k8s 1.29 (Sovereigns run k3s v1.31.4). Set false to fall back to
+  # the legacy plain-container bridge (e.g. a pre-1.29 cluster).
+  nativeSidecar: true
   image:
     repository: ghcr.io/openova-io/openova/newapi-sandbox-bridge
     # Wave 5.57d (#2303, 2026-05-24): switch to `:latest` + pullPolicy

--- a/platform/newapi/internal/handler/sso_init.go
+++ b/platform/newapi/internal/handler/sso_init.go
@@ -96,6 +96,30 @@
 // Both calls are same-origin (the page is served at newapi.<fqdn>/), so the
 // session cookie is in scope. The logout is best-effort: a failure still falls
 // through to the OAuth flow (no worse than before). Refs #3563, #3374.
+//
+// ── #3374 (2026-06-18): 1st-hit 111 + /setup on a fresh prov ──────────────
+// Re-walked live on hw159: the bare URL's 1st hit returned
+// `upstream-connect-error ... delayed connect error: 111` and the 2nd hit
+// landed on the /setup wizard instead of signed-in /console. The 111 is NOT a
+// landing-page bug — it is the gateway finding no healthy upstream for the
+// Exact `/` route while NewAPI warms up (~2min: the wait-for-sql-dsn
+// initContainer + GORM AutoMigrate). As a plain container the bridge (a) did
+// not even START until the DSN gate completed, and (b) had its Service
+// endpoint suppressed because a Pod only joins a Service EndpointSlice once
+// ALL its containers are Ready and the `newapi` container is NotReady during
+// migrate. The REAL fix lives in the chart: the bridge is now a NATIVE sidecar
+// (starts first, before the DSN gate) behind a bridge-only Service with
+// publishNotReadyAddresses:true (so its endpoint publishes the instant it
+// binds, independent of `newapi`). With those in place the landing page LOADS
+// on the 1st hit; this file's job is then to ride out NewAPI's own warm-up:
+//   - the /api/oauth/state mint RETRIES (8× / 1.5s) so the first visit during
+//     convergence still completes the silent-SSO redirect; and
+//   - on retry-exhaustion (NewAPI still not up) the page RELOADS ITSELF rather
+//     than falling through to /login — because the SPA's /login bounces an
+//     unseeded NewAPI to /setup. So the first human visit never dead-ends at
+//     the setup wizard. (An overlay with no SSO configured still degrades to
+//     /login, since reloading would loop forever with nothing to land on.)
+// Refs #3374.
 package handler
 
 import (
@@ -148,6 +172,16 @@ var ssoInitTemplate = template.Must(template.New("sso-init").Parse(`<!doctype ht
   var CLIENT_ID = {{ .ClientID }};
   var SCOPES = {{ .Scopes }};
   function fallback(){ window.location.replace("/login"); }
+  // #3374 (2026-06-18) — self-reload instead of falling through to /login when
+  // NewAPI is configured for SSO but still WARMING UP (DSN-gate + GORM migrate,
+  // up to ~2min on a fresh prov). The SPA's /login bounces an unseeded NewAPI
+  // to the /setup wizard — the exact hw159 symptom. Reloading THIS bare-root
+  // page keeps re-running the whole chain (self-check → state mint → redirect)
+  // until NewAPI is up, so the FIRST human visit never dead-ends at /setup. We
+  // only reach this when AUTHORIZE_URL+CLIENT_ID ARE set (SSO IS configured),
+  // so the loop is bounded by NewAPI coming up; an unconfigured overlay takes
+  // fallback() instead and never reloads.
+  function reloadSelf(){ setTimeout(function(){ window.location.replace("/"); }, 2000); }
   // #3563 — idempotent re-login. If the visitor ALREADY holds a valid NewAPI
   // session they ARE signed in; send them straight to the app. This is the
   // common re-visit path and avoids the Keycloak round-trip entirely. Only
@@ -197,7 +231,12 @@ var ssoInitTemplate = template.Must(template.New("sso-init").Parse(`<!doctype ht
       } catch (e) { /* NewAPI still warming up — retry */ }
       await new Promise(function (r) { setTimeout(r, 1500); });
     }
-    if (!state) return fallback();
+    // #3374 (2026-06-18) — exhausted the state-mint retries while SSO IS
+    // configured ⇒ NewAPI is still warming up. RELOAD this page (keep trying)
+    // instead of falling through to /login (which the SPA bounces to /setup on
+    // an unseeded NewAPI — the hw159 symptom). The bare URL therefore never
+    // lands the first visitor on the setup wizard during convergence.
+    if (!state) return reloadSelf();
     // 2. Build the authorize URL EXACTLY like the SPA does
     //    (web/src/helpers/api.js onCustomOAuthClicked: redirect_uri =
     //    window.location.origin + "/oauth/" + slug) and redirect. The

--- a/platform/newapi/internal/handler/sso_init_test.go
+++ b/platform/newapi/internal/handler/sso_init_test.go
@@ -58,6 +58,13 @@ func TestSSOInitHandler_ServesLandingAtRoot(t *testing.T) {
 		// /setup. Assert the retry loop + a backoff sleep are present.
 		"attempt < 8",
 		"setTimeout(r, 1500)",
+		// #3374 (2026-06-18) — on retry-exhaustion with SSO configured the page
+		// must RELOAD ITSELF (keep trying) rather than fall through to /login,
+		// because the SPA's /login bounces an unseeded NewAPI to /setup. Assert
+		// the self-reload helper + that the exhausted-state path calls it.
+		"function reloadSelf()",
+		`window.location.replace("/")`,
+		"if (!state) return reloadSelf();",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("landing page missing %q", want)


### PR DESCRIPTION
## Refs #3374

The bare URL `newapi.<fqdn>` threw `upstream-connect-error ... delayed connect error: 111` on the **1st hit** and then landed on the `/setup` "System initialization" wizard instead of signed-in `/console` (walked live on hw159). PR #3791 added a landing-page retry but was **honest that it was race-hardening, not a fix** — the retry never even ran on the 1st hit because the browser could not load the landing page at all. This PR fixes the underlying readiness race at its source.

## Root cause

The `sandbox-bridge` sidecar serves the `Exact /` zero-click landing page. As a **plain container** it was gated behind NewAPI's ~2-min warm-up **twice**:

1. **Init ordering** — the `wait-for-sql-dsn` initContainer runs to completion **before any plain container starts** (incl. the bridge), so the bridge wasn't listening during the DSN-wait window.
2. **Pod-readiness AND-gating** — a Pod joins a Service's EndpointSlice only when **ALL** its containers are Ready (pod-readiness = AND of every container's readinessProbe). The `newapi` container is NotReady until GORM AutoMigrate finishes, so the **whole Pod stayed NotReady** → the Service had **zero ready endpoints on every port** (incl. the bridge port) → the gateway's `Exact /` backendRef had **no healthy upstream → 111**. The bridge process being up was irrelevant; its endpoint was suppressed. The SPA then bounced to `/setup`.

So #3791's retry was structurally unable to help the 1st hit: the landing-page HTML itself couldn't load.

## Fix (three coordinated parts — all real, not a retry)

**(a) Native-sidecar bridge** (`deployment.yaml`) — the bridge is now a **native sidecar** (`initContainers` entry with `restartPolicy: Always`; KEP-753, GA in k8s 1.29 — Sovereigns run k3s **v1.31.4**) declared **first**, so it starts **before** the DSN gate and runs the whole Pod lifetime, decoupled from NewAPI's migrate. It carries a `readinessProbe` on the bridge port (`:8080`). Env is shared with the legacy path via a new `bp-newapi.sandboxBridgeEnv` helper (byte-identical). Operator opt-out: `sandboxBridge.nativeSidecar=false` (pre-1.29 clusters) → legacy plain container.

**(b) Bridge-only Service** (`service.yaml`) — a dedicated `<fullname>-bridge` Service with **`publishNotReadyAddresses: true`** publishes the bridge endpoint the **instant** it binds `:8080`, even while `newapi` is NotReady. `httproute.yaml`'s `Exact /` rule now backendRefs **this** Service (`gateway.bridgeBackendService` overrides it for the vCluster syncer-mangled name). Result: the bare URL **loads the landing page on the 1st hit — no 111**.

**(c) Never route to /setup during warm-up** (`sso_init.go`) — on `/api/oauth/state` retry-exhaustion **while SSO is configured** (NewAPI still warming up), the landing page now **reloads itself** instead of falling through to `/login` (which the SPA bounces to `/setup` on an unseeded NewAPI). So the first human visit never dead-ends at the setup wizard during convergence. An unconfigured overlay still degrades to `/login`.

The `/setup` wizard itself stays pre-completed by the existing `admin-sso-seed-job` (`setups` row + sovereign OIDC provider) + the per-minute promote/reload CronJob (1.4.97); this change makes the landing page **reachable on the 1st hit** and ensures it never routes the owner to `/setup` before the seed lands.

## Render / test proof

`go build ./... && go vet ./... && go test ./...` green (handler module; all `TestSSOInit*` pass incl. the updated `reloadSelf` assertions).

`helm template` EXIT 0 (with cilium/gateway-api/cnpg/apps caps; no duplicate-key post-render). New `chart/tests/bridge-readiness-render.sh` (4 cases) + existing 3 render tests all PASS.

Rendered native-sidecar readinessProbe on the bridge port:
```yaml
initContainers:
  - name: sandbox-bridge
    restartPolicy: Always           # native sidecar — starts before wait-for-sql-dsn
    ports: [{name: bridge, containerPort: 8080}]
    readinessProbe:
      httpGet: {path: /healthz, port: 8080}
      initialDelaySeconds: 1
      periodSeconds: 5
      ...
  - name: wait-for-sql-dsn          # declared AFTER the bridge
```

Rendered bridge-only Service + Exact `/` route:
```yaml
kind: Service
metadata: {name: <release>-bp-newapi-bridge}
spec:
  publishNotReadyAddresses: true
  ports: [{name: bridge, port: 8080, targetPort: 8080}]
---
# HTTPRoute
- matches: [{path: {type: Exact, value: "/"}}]
  backendRefs: [{name: <release>-bp-newapi-bridge, port: 8080}]   # bridge-only Service
- matches: [{path: {type: PathPrefix, value: "/"}}]
  backendRefs: [{name: <release>-bp-newapi, port: 3000}]          # main Service → NewAPI SPA/API
```

## Honesty note

The 111 on the **bare URL** is fully eliminated by (a)+(b): the gateway now has a healthy upstream (the bridge) the instant the Pod schedules, regardless of NewAPI's migrate. The landing page's same-origin `fetch("/api/oauth/state")` still hits the **main** Service:3000 (which legitimately 503s — not 111 — until NewAPI is Ready); the existing #3791 retry + the new self-reload (c) ride that out so the silent OIDC completes on the 1st human visit. The Cilium gateway routes by EndpointSlice readiness, so a `publishNotReadyAddresses` Service is the correct lever — confirmed the repo already uses this idiom (seaweedfs) and native sidecars (gitea). **Confidence: high** on render/lockstep/unit correctness; needs a fresh-prov live walk to confirm the wire behavior end-to-end (the canonical "shipped" bar).

## Lockstep

`Chart.yaml` + `blueprint.yaml` + `clusters/_template/bootstrap-kit/80-newapi.yaml` pin → **1.4.107** (above main's 1.4.105). `tests/e2e/bootstrap-kit` lockstep sweep passes. Scope is entirely within `platform/newapi` + the slot pin. NB: `build-bp-newapi-sandbox-bridge.yaml` auto-bumps the pin +1 on merge (it rebuilds the `sso_init.go` sidecar image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)