### PR TITLE
fix(console): eradicate residual "tenant"/"SME" persona text from create-org form + sidebar widget (Refs #3383)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sme/CreateTenantPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sme/CreateTenantPage.tsx
@@ -315,7 +315,7 @@ export function CreateTenantPage({
 
         <label className="grid gap-1 text-sm">
           <span className="text-[var(--color-text-dim)]">
-            {isInternal ? 'Organization slug' : 'SME tenant slug'}
+            Organization slug
           </span>
           <input
             data-testid="sme-create-tenant-subdomain"
@@ -329,7 +329,7 @@ export function CreateTenantPage({
           />
           <span className="text-xs text-[var(--color-text-dim)]">
             Used in resource names (vCluster, namespace) and the URL when
-            the tenant picks free-subdomain mode.
+            the organization picks free-subdomain mode.
           </span>
         </label>
 
@@ -407,7 +407,7 @@ export function CreateTenantPage({
                 Bring your own domain
               </span>
               <span className="text-xs text-[var(--color-text-dim)]">
-                The SME owns an apex (e.g.
+                The organization owns an apex (e.g.
                 <code className="mx-1 rounded bg-[var(--color-input)] px-1">
                   acme.com
                 </code>
@@ -459,7 +459,7 @@ export function CreateTenantPage({
 
         {domainMode === 'byo' && (
           <label className="grid gap-1 text-sm">
-            <span className="text-[var(--color-text-dim)]">SME apex domain</span>
+            <span className="text-[var(--color-text-dim)]">Organization apex domain</span>
             <input
               data-testid="sme-create-tenant-byo"
               type="text"
@@ -504,7 +504,7 @@ export function CreateTenantPage({
           className="inline-flex items-center justify-center gap-2 rounded-md bg-[var(--color-accent)] px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
         >
           <Plus className="h-4 w-4" />
-          {submitting ? 'Provisioning…' : 'Onboard tenant'}
+          {submitting ? 'Provisioning…' : 'Create organization'}
         </button>
       </form>
 
@@ -540,7 +540,7 @@ export function CreateTenantPage({
                 </dd>
               </>
             )}
-            <dt className="text-[var(--color-text-dim)]">Tenant ID</dt>
+            <dt className="text-[var(--color-text-dim)]">Organization ID</dt>
             <dd className="font-mono">{created.sme_tenant_id}</dd>
           </dl>
           <TenantSteps steps={created.steps} />

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
@@ -280,7 +280,7 @@ export function SovereignSidebar({ sovereignFQDN }: SovereignSidebarProps) {
     (claims.name as string | undefined) ??
     (claims.preferred_username as string | undefined) ??
     (claims.email as string | undefined) ??
-    'Tenant'
+    'User'
   const userInitials = userName
     .split(/\s+/)
     .map((w) => w[0]?.toUpperCase() ?? '')


### PR DESCRIPTION
Refs #3383

## What & why
The hw159 UAT walk of #3383 (runbook `docs/ledger/uat-walkthrough/organizations-eradicate-sme-tenant-naming.md`) was **6 ✅ / 1 ❌ + 1 global finding**. The single FAIL row plus the global finding were the **only two user-facing surfaces still leaking** the GLOSSARY-banned persona words "tenant"/"SME" (`docs/GLOSSARY.md:18` — "tenant" → `Organization`):

1. **create-organization flow** (`/organizations/new`) — field label "SME tenant slug", submit button "Onboard tenant", plus help-text "…the **tenant** picks…" / "The **SME** owns an apex".
2. **bottom-left console user widget** — rendered "Tenant" on every console screen.

**These were verified STILL present on current `main` (HEAD `9a4499b0a`, chart 1.4.678)** — the held 1.4.677 rename PR did NOT land these strings. This PR fixes them. Every other #3383 row already renders "Organization" (directory title/cards, nav label, org-detail + breadcrumb, BSS/billing, `/bss/tenants` alias).

## Residual display strings found + fixed (file:line)
`products/catalyst/bootstrap/ui/src/pages/sme/CreateTenantPage.tsx`
| Line | Before | After |
|---|---|---|
| 318 | `'SME tenant slug'` (slug label) | `'Organization slug'` |
| 332 | "the **tenant** picks free-subdomain mode" | "the **organization** picks free-subdomain mode" |
| 410 | "The **SME** owns an apex" | "The **organization** owns an apex" |
| 462 | "SME apex domain" (BYO label) | "Organization apex domain" |
| 507 | `'Onboard tenant'` (submit) | `'Create organization'` |
| 543 | "Tenant ID" (result label) | "Organization ID" |

`products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx`
| Line | Before | After |
|---|---|---|
| 283 | OIDC user-name fallback `'Tenant'` | `'User'` |

(`SovereignSidebar` is the chroot Sovereign-Console sidebar — the operator-facing console at `console.<sov-fqdn>` the runbook walked. The `'Tenant'` was the fallback display name shown when OIDC claims carry no name/preferred_username/email.)

## Left WIRE-STABLE / untouched (intentionally `sme*`-named per Chart.yaml + naming-guard exemptions — NOT user-visible)
- `data-testid="sme-create-tenant-*"` test-contract hooks
- `SMETenant` / `SMETenantDomainMode` TS types + `sme.api.ts` client
- `created.sme_tenant_id` response field (wire contract)
- `listSovereignParentDomains('sme-pool')` role arg
- backend GAP carriers: `/api/v1/sme/tenants` route, `sme` namespace, `sme-tenants` GitOps branch, `templates/sme-services/`, `sme-secrets`
- the retained `TenantKind="sme"` `Tier` data-value enum (a value, never a persona label)
- the file-header lineage comment (`#828`/`#804` history; not user-visible)

Did **not** bump `products/catalyst/chart/Chart.yaml`.

## Test output
- **typecheck** (`tsc -b --noEmit`): **PASS** (exit 0)
- **build** (`vite`): **PASS** — built bundle contains all 6 new "Organization" strings and **zero** of the 4 old persona strings (grep-verified against `dist/assets/*.js`)
- **vitest** (`src/pages/sme` + `SovereignSidebar`): **17/17 PASS**
- **naming-guard** (`scripts/check-no-persona-machinery.sh`): **OK — no persona-named machinery introduced**; `--self-test` **BOTH directions proven** (new `/api/v1/sme/` route REJECTED; `Tier "sme"` data value PASSES)
- **lint**: error count **unchanged** before/after my edits (3 pre-existing `set-state-in-effect` on untouched lines 92/105/141 in CreateTenantPage; SovereignSidebar 0). Zero new lint introduced. (The repo-wide `npm run lint` failure is pre-existing baseline noise unrelated to this change.)

## Scope discipline
Confined to the two walked-FAIL console display surfaces. Did NOT touch: pod-truth reconciler, seaweedfs, org-controller serving logic, treemap, cutover UI, jobs handler, newapi, cloud-init, bootstrap-kit slots, or any wire-stable key. Broader educational/marketing "tenant" prose in `marketplaceCopy.ts` / wizard / BSS Revenue+Billing copy was left as-is (not part of the walked failure; much uses "tenant" in the legitimate generic multi-tenancy/architecture sense and the BSS/billing UAT row already PASSED).

Do NOT merge — awaiting review + a live re-walk on the next converged env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)