### PR TITLE
fix(catalyst-api): heal false-FAILED Blueprint chips when a HelmRelease recovers post-bootstrap (Refs #3687 #910)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/jobs_backfill.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_backfill.go
@@ -50,6 +50,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"k8s.io/client-go/dynamic"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
@@ -527,7 +528,31 @@ func (h *Handler) GetComponentsState(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// No live watcher — synthesise rows from the persisted final
+	// No live watcher — the finite Phase-1 bootstrap watch has ended.
+	// FALSE-FAILED RECOVERY (issue #3687 / #910 tail): the persisted
+	// dep.Result.ComponentStates is a FROZEN snapshot from the moment
+	// the watch terminated. A bp-* HelmRelease that hit a transient
+	// InstallFailed during the bootstrap window and then recovered to
+	// Ready=True AFTER the watch returned still shows its stale "failed"
+	// chip in that frozen map — nothing re-read the live HR, so a UAT
+	// walk done post-bootstrap counts a false ❌. The live HR Ready
+	// condition is the source of truth, so attempt a stateless ONE-SHOT
+	// live re-read of the cluster's bp-* HelmReleases (same projection
+	// SnapshotComponents uses, via DeriveState) and serve THAT. Only
+	// fall back to the frozen persisted map when the kubeconfig is
+	// unresolvable or the live list errors (Sovereign post-handover /
+	// wiped / unreachable) — never fabricate a green, just re-derive
+	// from whatever the cluster actually reports right now.
+	if live, ok := h.liveComponentsSnapshot(r.Context(), dep); ok {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"watching":   false,
+			"live":       true,
+			"components": live,
+		})
+		return
+	}
+
+	// Live re-read unavailable — synthesise rows from the persisted final
 	// state map so the FE always gets a usable snapshot. Per-component
 	// message + lastTransitionAt are unavailable on the persisted
 	// side (only the state enum is captured), so they are emitted
@@ -545,4 +570,52 @@ func (h *Handler) GetComponentsState(w http.ResponseWriter, r *http.Request) {
 		"watching":   false,
 		"components": out,
 	})
+}
+
+// liveComponentsSnapshot performs a stateless ONE-SHOT live read of the
+// deployment's bp-* HelmReleases and projects them through the same
+// DeriveState path SnapshotComponents uses. Returns (snapshot, true) on
+// success; (nil, false) when no live read is possible (no resolvable
+// kubeconfig on the PVC, dynamic-client build failure, or the list call
+// errors — e.g. the Sovereign is post-handover, wiped, or unreachable).
+//
+// This is the live-HR-truth re-read that heals a stale FALSE-FAILED chip
+// after the finite Phase-1 watch has ended (issue #3687 / #910 tail): a
+// HelmRelease that recovered to Ready=True post-bootstrap re-derives to
+// `installed` here instead of echoing the frozen persisted snapshot.
+//
+// READ-ONLY: it resolves the kubeconfig via resolvePrimaryKubeconfigPath
+// (which never mutates dep.Result, avoiding the -race against the
+// Deployment.State() marshal) and never writes the deployment record.
+func (h *Handler) liveComponentsSnapshot(ctx context.Context, dep *Deployment) ([]helmwatch.ComponentSnapshot, bool) {
+	kubeconfigPath, ok := h.resolvePrimaryKubeconfigPath(dep)
+	if !ok {
+		return nil, false
+	}
+	raw, err := os.ReadFile(kubeconfigPath)
+	if err != nil {
+		return nil, false
+	}
+	// Honour the test dynamicFactory injection (same pattern as
+	// tryDynamicClientLocked / sovereignDynamicClient) so handler tests
+	// can drive a fake.NewSimpleDynamicClient; production builds the
+	// real client from the posted-back kubeconfig.
+	var dyn dynamic.Interface
+	if h.dynamicFactory != nil {
+		dyn, err = h.dynamicFactory(string(raw))
+	} else {
+		dyn, err = helmwatch.NewDynamicClientFromKubeconfig(string(raw))
+	}
+	if err != nil {
+		return nil, false
+	}
+	// Bound the live list so a slow/unreachable apiserver cannot hang the
+	// stateless read — fall back to the persisted map instead.
+	listCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	snap, err := helmwatch.ListAndSnapshotHelmReleases(listCtx, dyn)
+	if err != nil {
+		return nil, false
+	}
+	return snap, true
 }

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_backfill_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_backfill_test.go
@@ -374,3 +374,139 @@ func TestComponentsState_404UnknownDeployment(t *testing.T) {
 		t.Errorf("status=%d want 404", rec.Code)
 	}
 }
+
+// TestComponentsState_LiveReadHealsStaleFailed is the endpoint-level
+// acceptance for the false-FAILED-chip defect (issue #3687 / #910 tail).
+// With NO live watcher attached (the finite Phase-1 bootstrap watch has
+// ended), GET /components/state must NOT echo the frozen
+// dep.Result.ComponentStates — it must re-read the live cluster's bp-*
+// HelmReleases and re-derive their state. A HelmRelease that had a
+// transient bootstrap InstallFailed (persisted "failed") but is now
+// Ready=True must surface as "installed", killing the false ❌.
+func TestComponentsState_LiveReadHealsStaleFailed(t *testing.T) {
+	r, _, h := newBackfillRouter(t)
+
+	// The live cluster now reports every bp-* Ready=True — including
+	// bp-flux, which the persisted snapshot still has frozen at "failed".
+	h.dynamicFactory = fakeDynamicFactoryFromObjects(
+		makeReadyHR("bp-cilium"),
+		makeReadyHR("bp-cert-manager"),
+		makeReadyHR("bp-flux"),
+	)
+
+	// Persist a kubeconfig file on the PVC so resolvePrimaryKubeconfigPath
+	// resolves; the contents are irrelevant (fake factory ignores them).
+	kcPath := filepath.Join(t.TempDir(), "live-heal.yaml")
+	if err := os.WriteFile(kcPath, []byte("fake-kubeconfig: yaml"), 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+
+	dep := &Deployment{
+		ID:        "dep-live-heal",
+		Status:    "ready",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event, 4),
+		done:      make(chan struct{}),
+		Result: &provisioner.Result{
+			SovereignFQDN:  "test.example",
+			KubeconfigPath: kcPath,
+			// Frozen snapshot from when the finite watch ended: flux is
+			// stale-FAILED (transient bootstrap InstallFailed that has
+			// since recovered).
+			ComponentStates: map[string]string{
+				"cilium":       "installed",
+				"cert-manager": "installed",
+				"flux":         "failed",
+			},
+		},
+	}
+	h.deployments.Store(dep.ID, dep)
+	// No live watcher attached → the no-watcher live-re-read path fires.
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/api/v1/deployments/dep-live-heal/components/state", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Watching   bool `json:"watching"`
+		Live       bool `json:"live"`
+		Components []struct {
+			AppID  string `json:"appId"`
+			Status string `json:"status"`
+		} `json:"components"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Watching {
+		t.Errorf("watching=true; want false (no live watcher)")
+	}
+	if !body.Live {
+		t.Errorf("live=false; want true (the no-watcher path must have re-read the live cluster)")
+	}
+	statusByApp := map[string]string{}
+	for _, c := range body.Components {
+		statusByApp[c.AppID] = c.Status
+	}
+	// The load-bearing assertion: the stale FAILED chip is healed by the
+	// live HR re-read.
+	if got := statusByApp["flux"]; got != "installed" {
+		t.Errorf("flux: want %q (live HR Ready=True), got %q — stale FAILED chip not healed", "installed", got)
+	}
+	if got := statusByApp["cilium"]; got != "installed" {
+		t.Errorf("cilium: want %q, got %q", "installed", got)
+	}
+}
+
+// TestComponentsState_LiveReadUnavailableFallsBack proves the safety
+// net: when the live re-read is impossible (no resolvable kubeconfig on
+// the PVC), the endpoint still falls back to the persisted snapshot
+// rather than erroring — a post-handover / wiped Sovereign keeps its
+// last-known component view.
+func TestComponentsState_LiveReadUnavailableFallsBack(t *testing.T) {
+	r, _, h := newBackfillRouter(t)
+	// A factory is wired, but there is NO kubeconfig path on the record
+	// and kubeconfigsDir is unset, so resolvePrimaryKubeconfigPath returns
+	// false and the live read never runs → persisted fallback.
+	h.dynamicFactory = fakeDynamicFactoryFromObjects(makeReadyHR("bp-flux"))
+
+	dep := &Deployment{
+		ID:        "dep-no-kc",
+		Status:    "ready",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event, 4),
+		done:      make(chan struct{}),
+		Result: &provisioner.Result{
+			SovereignFQDN: "test.example",
+			ComponentStates: map[string]string{
+				"flux": "failed",
+			},
+		},
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/api/v1/deployments/dep-no-kc/components/state", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Live       bool `json:"live"`
+		Components []struct {
+			AppID  string `json:"appId"`
+			Status string `json:"status"`
+		} `json:"components"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Live {
+		t.Errorf("live=true; want false (no resolvable kubeconfig → persisted fallback)")
+	}
+	if len(body.Components) != 1 || body.Components[0].Status != "failed" {
+		t.Errorf("want persisted [flux=failed], got %+v", body.Components)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/helmwatch/transition_test.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/transition_test.go
@@ -622,3 +622,103 @@ func TestTransition_FirstObservation_NeverDedupsAcrossWatchers(t *testing.T) {
 	runOnce("first attach")
 	runOnce("re-attach after Pod restart")
 }
+
+// TestTransition_FailedThenReady_EndsInstalledNotFailed is the core
+// recovery contract for the false-FAILED-chip defect (issue #3687 /
+// #910 tail). A bp-* HelmRelease that is observed Failed (transient
+// bootstrap InstallFailed) and later recovers to Ready=True while the
+// informer is still attached MUST:
+//
+//   - emit a per-component recovery transition (State=installed) AFTER
+//     the earlier State=failed event — so the bridge / StatusStrip
+//     consumer flips the chip back to succeeded, AND
+//   - end with final[component] == StateInstalled (NOT StateFailed) AND
+//     Outcome() == OutcomeReady.
+//
+// This pins that StateFailed is NON-terminal at the informer level: the
+// watch keeps observing the HR after a Failed observation and the
+// recovery Update flows through processEvent. If a future refactor ever
+// short-circuited the informer on the first Failed (the bug the founder
+// reported — a stale "FAILED" snapshot inflating the UAT ❌ count), the
+// recovery transition would vanish and this test would fail.
+func TestTransition_FailedThenReady_EndsInstalledNotFailed(t *testing.T) {
+	scheme := newFakeScheme()
+	releases := []runtime.Object{
+		makeReadyHelmRelease("bp-cilium"),
+		makeReadyHelmRelease("bp-cert-manager"),
+		// bp-catalyst-platform starts Failed (transient InstallFailed in
+		// the bootstrap window).
+		makeFailedHelmRelease("bp-catalyst-platform"),
+	}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{HelmReleaseGVR: "HelmReleaseList"},
+		releases...,
+	)
+
+	rec := &recorder{}
+	cfg := Config{
+		KubeconfigYAML:     "fake",
+		WatchTimeout:       30 * time.Second,
+		FirstSeenTimeout:   30 * time.Second,
+		MinBootstrapKitHRs: 3,
+		DynamicFactory:     fakeFactory(client),
+		Resync:             0,
+		// Generous late-poll so the informer stays attached long enough
+		// to observe the recovery Update the goroutine below issues.
+		LatePollTimeout:  3 * time.Second,
+		LatePollInterval: 25 * time.Millisecond,
+	}
+	w, err := NewWatcher(cfg, rec.emit)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+
+	// Flip the failed HR to Ready=True shortly after the all-terminal
+	// trip fires (with the failure), so the recovery arrives while the
+	// late-poll keeps the informer attached — modelling Flux's
+	// remediation.retries converging post-failure.
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		updateHR(t, client, "bp-catalyst-platform", []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionTrue, Reason: "ReconciliationSucceeded", Message: "Helm install succeeded after retry"},
+		})
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	final, err := w.Watch(ctx)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	// Final per-component state + overall outcome must reflect the
+	// recovery, never the stale failure.
+	if final["catalyst-platform"] != StateInstalled {
+		t.Errorf("final[catalyst-platform] = %q, want %q (recovery must not stick on the stale Failed)", final["catalyst-platform"], StateInstalled)
+	}
+	if got, want := w.Outcome(), OutcomeReady; got != want {
+		t.Errorf("Outcome() = %q, want %q (failed component recovered to installed)", got, want)
+	}
+
+	// The event stream for catalyst-platform must end on State=installed,
+	// and it must have carried the earlier State=failed too (proving the
+	// transition was observed live, not papered over). This is exactly
+	// what the bridge.OnHelmReleaseEvent consumer needs to flip the Job
+	// chip succeeded after a failure.
+	var states []string
+	for _, ev := range rec.componentStateEvents() {
+		if ev.Component == "catalyst-platform" {
+			states = append(states, ev.State)
+		}
+	}
+	if len(states) == 0 {
+		t.Fatalf("no component-state events for catalyst-platform; got events: %+v", rec.snapshot())
+	}
+	if last := states[len(states)-1]; last != StateInstalled {
+		t.Errorf("last catalyst-platform state event = %q, want %q; full sequence=%v", last, StateInstalled, states)
+	}
+	if !containsSubsequence(states, []string{StateFailed, StateInstalled}) {
+		t.Errorf("catalyst-platform state events = %v, want the failed→installed recovery subsequence", states)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
@@ -394,22 +394,73 @@ func (b *Bridge) SeedJobsFromInformerList(seeds []InformerSeed) (jobsWritten, ex
 			// for the seed-twice path covered by
 			// TestSeedJobsFromInformerList_idempotent).
 			if isTerminalHelmState(s.State) {
+				final := StatusSucceeded
+				if s.State == HelmStateFailed {
+					final = StatusFailed
+				}
+				t := s.ObservedAt
+				if t.IsZero() {
+					t = time.Now().UTC()
+				} else {
+					t = t.UTC()
+				}
 				priorExec, findErr := b.store.FindExecution(b.deploymentID, job.LatestExecutionID)
-				if findErr == nil && !IsTerminal(priorExec.Status) {
-					final := StatusSucceeded
-					if s.State == HelmStateFailed {
-						final = StatusFailed
-					}
-					t := s.ObservedAt
-					if t.IsZero() {
-						t = time.Now().UTC()
-					} else {
-						t = t.UTC()
-					}
+				switch {
+				case findErr == nil && !IsTerminal(priorExec.Status):
+					// Orphan non-terminal Execution (Pod restart between the
+					// pending→non-pending edge and the terminal edge). Close
+					// it with the live terminal status. TBD-B6/B7.
 					if finishErr := b.store.FinishExecution(b.deploymentID, job.LatestExecutionID, final, t); finishErr != nil {
 						return jobsWritten, executionsSeeded, finishErr
 					}
+				case findErr == nil && IsTerminal(priorExec.Status) && priorExec.Status != final:
+					// FALSE-FAILED RECOVERY (issue #3687 / #910 tail): the
+					// persisted Job is frozen at one terminal status (typically
+					// `failed` from a transient bootstrap-window InstallFailed)
+					// but the LIVE HR re-read this seed is built from now shows
+					// the OPPOSITE terminal (`installed` → Ready=True). The
+					// helmwatch bootstrap watch is finite, so the recovery
+					// transition was never observed by processEvent — nothing
+					// re-read the live HR afterward and the chip stuck on the
+					// stale FAILED snapshot. A UAT walk done after the bootstrap
+					// window then counts a false ❌.
+					//
+					// The live Ready condition is the source of truth (NOT a
+					// fabricated green), so heal the Job: allocate a FRESH
+					// Execution stamped at the recovery instant, anchor it with
+					// an honest seed line, and FinishExecution flips the Job's
+					// Status + FinishedAt + DurationMs to match the live HR. The
+					// prior terminal Execution is preserved as history. This
+					// mirrors OnHelmReleaseEvent's live recovery path (which
+					// already heals failed→installed by allocating a new
+					// Execution) so the seed-re-read path and the event path
+					// agree on the converged status.
+					recExec, startErr := b.store.StartExecution(b.deploymentID, jobName, t)
+					if startErr != nil {
+						return jobsWritten, executionsSeeded, startErr
+					}
+					executionsSeeded++
+					anchor := "[seeded] recovery: state=" + s.State + " at " + t.Format(time.RFC3339)
+					if msg := strings.TrimSpace(s.Message); msg != "" {
+						anchor = anchor + ": " + msg
+					}
+					recLevel := LevelInfo
+					if s.State == HelmStateFailed {
+						recLevel = LevelError
+					}
+					if appendErr := b.store.AppendLogLines(b.deploymentID, recExec.ID, []LogLine{{
+						Timestamp: t,
+						Level:     recLevel,
+						Message:   anchor,
+					}}); appendErr != nil {
+						return jobsWritten, executionsSeeded, appendErr
+					}
+					if finishErr := b.store.FinishExecution(b.deploymentID, recExec.ID, final, t); finishErr != nil {
+						return jobsWritten, executionsSeeded, finishErr
+					}
 				}
+				// Terminal seed (orphan-closed, recovered, or already-converged):
+				// clear the cursor so a late raw-log line doesn't re-open it.
 				b.activeExecID[comp] = ""
 			} else {
 				b.activeExecID[comp] = job.LatestExecutionID

--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge_test.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge_test.go
@@ -1006,3 +1006,112 @@ func TestSeedJobsFromInformerList_resumeFailedTerminalFinishesOrphan(t *testing.
 		t.Errorf("Execution after resume: want 1×failed, got %+v", execs)
 	}
 }
+
+// TestSeedJobsFromInformerList_reseedRecoversFailedToSucceeded is the
+// bridge-side acceptance for the false-FAILED-chip defect (issue #3687 /
+// #910 tail). The finite Phase-1 bootstrap watch observed bp-catalyst-
+// platform at a transient InstallFailed and stamped the Job + its
+// Execution `failed`. The watch then RETURNED. Flux's remediation.retries
+// later converged the HR to Ready=True — but nothing re-read the live HR,
+// so the Job chip stuck on the stale `failed` snapshot and a UAT walk
+// counted a false ❌.
+//
+// A subsequent live re-read (POST /refresh-watch, or the chroot
+// list-and-seed path) feeds SeedJobsFromInformerList a seed with the
+// component now at HelmStateInstalled. The bridge MUST heal the stale
+// failure, driven by the live Ready condition (not a fabricated green):
+//
+//   - Job.Status flips failed → succeeded with FinishedAt + DurationMs set,
+//   - a FRESH succeeded Execution is allocated at the recovery instant,
+//   - the prior `failed` Execution is preserved as history,
+//   - and a repeat re-seed at the same installed state is idempotent.
+func TestSeedJobsFromInformerList_reseedRecoversFailedToSucceeded(t *testing.T) {
+	st, br, depID := newBridgeFixture(t)
+	t0 := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+
+	// Bootstrap-window seed: the HR was observed at a terminal failure.
+	if _, _, err := br.SeedJobsFromInformerList([]InformerSeed{
+		{Component: "catalyst-platform", State: HelmStateFailed, Message: "InstallFailed: missing sme namespace", ObservedAt: t0},
+	}); err != nil {
+		t.Fatalf("first (failed) seed: %v", err)
+	}
+	jobID := JobID(depID, JobNamePrefix+"catalyst-platform")
+	job, execs, err := st.GetJob(depID, jobID)
+	if err != nil {
+		t.Fatalf("GetJob after failed seed: %v", err)
+	}
+	if job.Status != StatusFailed {
+		t.Fatalf("post-failed-seed Job.Status: want %q, got %q", StatusFailed, job.Status)
+	}
+	if len(execs) != 1 || execs[0].Status != StatusFailed {
+		t.Fatalf("post-failed-seed executions: want 1×failed, got %+v", execs)
+	}
+	failedExecID := execs[0].ID
+
+	// Watch returned; later a live re-read (refresh-watch) sees Ready=True.
+	// Fresh Bridge models the Pod-restart / new-watcher path that has no
+	// in-memory cursors — the persisted store is the only state.
+	br2 := NewBridge(st, depID)
+	t1 := t0.Add(4 * time.Minute)
+	if _, execsSeeded, err := br2.SeedJobsFromInformerList([]InformerSeed{
+		{Component: "catalyst-platform", State: HelmStateInstalled, Message: "Helm install succeeded after retry", ObservedAt: t1},
+	}); err != nil {
+		t.Fatalf("recovery re-seed: %v", err)
+	} else if execsSeeded != 1 {
+		t.Errorf("recovery re-seed executionsSeeded = %d, want 1 (the fresh succeeded Execution)", execsSeeded)
+	}
+
+	job, execs, err = st.GetJob(depID, jobID)
+	if err != nil {
+		t.Fatalf("GetJob after recovery seed: %v", err)
+	}
+	// The load-bearing assertion: the stale FAILED chip is healed.
+	if job.Status != StatusSucceeded {
+		t.Errorf("recovered Job.Status: want %q, got %q (stale FAILED chip not healed)", StatusSucceeded, job.Status)
+	}
+	if job.FinishedAt == nil {
+		t.Errorf("recovered Job.FinishedAt: want non-nil, got nil")
+	} else if !job.FinishedAt.Equal(t1) {
+		t.Errorf("recovered Job.FinishedAt: want %v, got %v", t1, *job.FinishedAt)
+	}
+	if job.DurationMs <= 0 {
+		t.Errorf("recovered Job.DurationMs: want >0, got %d", job.DurationMs)
+	}
+	// History preserved: the original failed Execution survives, and a
+	// fresh succeeded Execution is now the latest.
+	if len(execs) != 2 {
+		t.Fatalf("recovered executions: want 2 (failed history + fresh succeeded), got %d: %+v", len(execs), execs)
+	}
+	var sawFailedHistory, sawSucceeded bool
+	for _, e := range execs {
+		if e.ID == failedExecID && e.Status == StatusFailed {
+			sawFailedHistory = true
+		}
+		if e.Status == StatusSucceeded {
+			sawSucceeded = true
+		}
+	}
+	if !sawFailedHistory {
+		t.Errorf("recovered executions: the original failed Execution %q must be preserved as history; got %+v", failedExecID, execs)
+	}
+	if !sawSucceeded {
+		t.Errorf("recovered executions: a fresh succeeded Execution must exist; got %+v", execs)
+	}
+	if job.LatestExecutionID == failedExecID {
+		t.Errorf("recovered Job.LatestExecutionID still points at the failed Execution %q; want the fresh succeeded one", failedExecID)
+	}
+
+	// Idempotency: re-seeding the same installed state must NOT allocate
+	// another Execution (a /refresh-watch poll loop must converge).
+	if _, execsSeeded, err := br2.SeedJobsFromInformerList([]InformerSeed{
+		{Component: "catalyst-platform", State: HelmStateInstalled, Message: "still Ready=True", ObservedAt: t1.Add(time.Second)},
+	}); err != nil {
+		t.Fatalf("idempotent re-seed: %v", err)
+	} else if execsSeeded != 0 {
+		t.Errorf("idempotent re-seed executionsSeeded = %d, want 0 (already converged)", execsSeeded)
+	}
+	_, execs, _ = st.GetJob(depID, jobID)
+	if len(execs) != 2 {
+		t.Errorf("after idempotent re-seed: want 2 executions, got %d", len(execs))
+	}
+}


### PR DESCRIPTION
## Problem — false-FAILED Blueprint chips inflate the UAT ❌ count

The console shows **FAILED** chips for platform Blueprints that are actually `Ready=True` on the live cluster (`kubectl get hr` confirms), inflating a UAT walk's failure count with false negatives.

## Root cause (confirmed) — `helmwatch.go:304-313`, terminal `StateFailed`

The per-Blueprint UI status is owned by the **helmwatch** subsystem. `StateFailed` is a **terminal** state (`terminalStates`, helmwatch.go:310-313) and the Phase-1 bootstrap watch is **finite**:

- A bp-* HelmRelease that hit a transient `InstallFailed` during the bootstrap window, then recovered to `Ready=True` **after** the watch returned, was never re-observed by `processEvent`.
- The `#910` late-poll (helmwatch.go:388-399) only catches recovery **while the informer is still attached** (the bootstrap window). Once the watch returns — `OutcomeFailed` late-poll exhaustion, or the issue-#317 handover `Cancel()` — the informer is torn down and **nothing re-reads the live HR**.
- `GET /components/state` then falls back to the **frozen** `dep.Result.ComponentStates` (the snapshot from watch-end) and the Job rows stay pinned at the stale `failed` — the false chip.

This is NOT the `pod_truth_reconciler` (that was a prior misdiagnosis).

## Fix — re-read the live HR Ready condition (source of truth), don't fabricate green

`StateFailed` is left **terminal** on purpose: making it non-terminal would break the `#910` terminate-on-all-done contract and risk a **never-terminate / event-storm** when a permanently-failed HR keeps the informer running forever (the explicit risk called out in the brief). Instead the fix re-checks the live HR on the read surfaces:

1. **`internal/handler/jobs_backfill.go` — `GetComponentsState`** (primary fix for the chip). When no watcher is live, it no longer echoes the frozen `ComponentStates`; it does a stateless **one-shot `ListAndSnapshotHelmReleases`** re-read (the same `DeriveState` projection `SnapshotComponents` uses, 10s-bounded) and serves that. A recovered HR re-derives to `installed`. Falls back to the persisted map only when the kubeconfig is unresolvable or the list errors (post-handover / wiped / unreachable). READ-ONLY via `resolvePrimaryKubeconfigPath` (no `dep.Result` mutation → no -race vs the `Deployment.State()` marshal).

2. **`internal/jobs/helmwatch_bridge.go` — `SeedJobsFromInformerList`** (heals the Jobs-table history on `/refresh-watch` + chroot re-seed). When a re-seed observes the live HR at the **opposite terminal** of the persisted Job (`failed`→`succeeded` recovery), it allocates a fresh Execution at the recovery instant + `FinishExecution` to stamp `Status`/`FinishedAt`/`DurationMs`, preserving the prior failed Execution as history. Mirrors `OnHelmReleaseEvent`'s live recovery path so the seed-re-read and event paths agree on the converged status. (The leaf `Job.Status` already flipped via `UpsertJob` "new status wins"; this completes the heal with honest timing + Execution history.)

## Tests (all green; `-race` clean)

- `helmwatch/transition_test.go` → **`TestTransition_FailedThenReady_EndsInstalledNotFailed`** — a HR observed Failed then Ready ends in `StateInstalled` / `OutcomeReady`, and the event stream carries the `failed`→`installed` recovery subsequence (the exact contract the brief asked for).
- `jobs/helmwatch_bridge_test.go` → **`TestSeedJobsFromInformerList_reseedRecoversFailedToSucceeded`** — a `failed` Job re-seeded at `installed` flips to `succeeded` + fresh succeeded Execution + preserved failed history + idempotent repeat re-seed.
- `handler/jobs_backfill_test.go` → **`TestComponentsState_LiveReadHealsStaleFailed`** (endpoint heals stale `flux=failed` via the live re-read, `live:true`) + **`TestComponentsState_LiveReadUnavailableFallsBack`** (falls back to persisted when no kubeconfig).

```
go build ./...                                        # rc=0
go test ./internal/helmwatch/... ./internal/jobs/... ./internal/handler/...   # all ok
go test ./... -count=1                                # whole api module ok
```

## Scope / non-changes

- `StatusStrip.tsx` is **presentational** (`status`/`finished`/`total` are props derived from the Job tree) — intentionally untouched. The chip-owning logic is the helmwatch → bridge → `/components/state` Go path.
- **Go-only** change in the catalyst-api image → **no chart bump**; the orchestrator-owned `products/catalyst/chart` version is left alone. No cloud-init / slots / `core/` / docs touched.

Refs #3687 #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)