### PR TITLE
fix(infra): IPv4-pin harbor.openova.io on Huawei nodes — kill the kom4dc ImagePullBackOff

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -680,6 +680,24 @@ runcmd:
   # public-resolver nslookup → python3 AF_INET getaddrinfo) before pinning
   # /etc/hosts. POSIX/dash-clean; every host is IPv4-reachable from every
   # cloud (on a dual-stack cloud the resolved A record is still valid).
+  #
+  # #3735 (2026-06-18 — the hw159 ImagePullBackOff): harbor.openova.io is
+  # ALSO dual-stack (A=45.151.123.50 + AAAA). On the IPv4-only Huawei VPC the
+  # node's containerd image-pull resolver intermittently gets the AAAA →
+  # `dial tcp: lookup harbor.openova.io: Try again` → ImagePullBackOff for any
+  # image pulled through the harbor pull-through proxy (catalyst-api,
+  # controllers — they can land on a CP node). containerd reads the NODE
+  # resolver, NOT pod DNS, so a coredns-custom hosts entry does NOT fix it —
+  # the pin MUST be at the node /etc/hosts level (this block). registry.<fqdn>
+  # is the POST-CUTOVER local Harbor: pre-cutover it has no DNS record so r4()
+  # returns empty and the `[ -n "$a" ]` guard skips it (no bad pin); post-
+  # cutover it resolves to the gateway EIP (IPv4) and pins correctly. Both
+  # hosts are appended ONLY on huawei: Hetzner is dual-stack (harbor's AAAA is
+  # reachable so no pin is needed) AND its CP render sits at 32223/32256 B
+  # (#1981 ExternalIP reconciler) — only 33 B of headroom — so the
+  # provider-gated conditional keeps the Hetzner render byte-identical while
+  # giving every IPv4-only cloud the harbor pin. No hardcoded IP: r4() derives
+  # the A record at boot and self-heals if harbor's address ever changes.
   - |
     r4() {
      getent ahostsv4 "$1" 2>/dev/null | awk '{print $1; exit}' && return
@@ -689,7 +707,7 @@ runcmd:
      done
      python3 -c 'import socket,sys;print(socket.getaddrinfo(sys.argv[1],443,2)[0][4][0])' "$1" 2>/dev/null
     }
-    for h in github.com raw.githubusercontent.com codeload.github.com objects.githubusercontent.com helm.cilium.io get.helm.sh; do
+    for h in github.com raw.githubusercontent.com codeload.github.com objects.githubusercontent.com helm.cilium.io get.helm.sh%{ if provider == "huawei" } harbor.openova.io registry.${sovereign_fqdn}%{ endif ~}; do
      a=$(r4 "$h"); [ -n "$a" ] && echo "$a $h" >>/etc/hosts || true
     done
 

--- a/infra/providers/huawei/cloudinit-worker.tftpl
+++ b/infra/providers/huawei/cloudinit-worker.tftpl
@@ -99,6 +99,37 @@ write_files:
       MaxAuthTries 3
 
 runcmd:
+  # ── IPv4-pin harbor + local registry (#3735, 2026-06-18 — the hw159
+  # ImagePullBackOff). Huawei VPCs are IPv4-only; harbor.openova.io is
+  # dual-stack (A=45.151.123.50 + AAAA). The k3s-agent containerd image-pull
+  # resolver intermittently gets harbor's AAAA → `dial tcp: lookup
+  # harbor.openova.io: Try again` → ImagePullBackOff for every uncached pull
+  # (catalyst-api / controllers / CNPG land on workers too). containerd reads
+  # the NODE resolver, not pod DNS, so the only fix is a node /etc/hosts pin —
+  # the CP template carries the identical block (#3232/#3714 + #3735); the
+  # Huawei worker had NO pin block at all until now. This MUST run BEFORE the
+  # k3s-agent install below (get.k3s.io redirects to a github release asset,
+  # and every subsequent pull flows through the bastion harbor mirror whose
+  # `harbor.openova.io` mirror host must itself resolve to IPv4). registry.
+  # <fqdn> is the post-cutover LOCAL Harbor: pre-cutover it has no DNS record
+  # so r4() returns empty and the `[ -n "$a" ]` guard skips it (no bad pin);
+  # post-cutover it resolves to the gateway EIP (IPv4) and pins. Bounded
+  # 3-tier resolver ladder (getent v4 → public-resolver nslookup → python3
+  # AF_INET getaddrinfo) — DETERMINISTIC, never lets AAAA win. POSIX/dash-
+  # clean. No hardcoded IP: r4() derives the A record at boot + self-heals.
+  - |
+    r4() {
+     getent ahostsv4 "$1" 2>/dev/null | awk '{print $1; exit}' && return
+     for s in 1.1.1.1 8.8.8.8; do
+      a=$(nslookup -type=A "$1" "$s" 2>/dev/null | awk '/^Address: [0-9]/&&$2!~/#/{print $2; exit}')
+      [ -n "$a" ] && { echo "$a"; return; }
+     done
+     python3 -c 'import socket,sys;print(socket.getaddrinfo(sys.argv[1],443,2)[0][4][0])' "$1" 2>/dev/null
+    }
+    for h in harbor.openova.io registry.${sovereign_fqdn}; do
+     a=$(r4 "$h"); [ -n "$a" ] && echo "$a $h" >>/etc/hosts || true
+    done
+
   # Wave 5.20: single shell block — cloud-init runcmd list-form had two
   # silent halts on HCS Ubuntu image: (1) apt-get install fails because
   # the mirror is unreachable so fail2ban package isn't installed,


### PR DESCRIPTION
## Root cause (diagnosed live on hw159)

`harbor.openova.io` is **dual-stack** (A=`45.151.123.50` + AAAA/IPv6). The kom4dc Huawei VPC is **IPv4-only**. The node's containerd image-pull resolver intermittently gets the AAAA record →

```
dial tcp: lookup harbor.openova.io: Try again
```

→ `ImagePullBackOff` for **any** image pulled through the harbor pull-through proxy (catalyst-api, controllers, CNPG). On hw159 this wedged `catalyst-api`.

The hw159 runtime workaround was a `coredns-custom` hosts pin (`45.151.123.50 harbor.openova.io`) — but that only fixes **pod DNS**. **containerd uses the NODE resolver**, so the durable fix is a **node-level `/etc/hosts` pin** baked into cloud-init. This recurs on every kom4dc prov and must never need hand-patching again.

## Fix

Extends the existing `#3232`/`#3714` node `/etc/hosts` IPv4-pin mechanism (which already pins `github.com` / `helm.cilium.io` / etc. via the bounded `r4()` resolver ladder) to the **registry hosts**:

1. **`infra/providers/_shared/cloudinit-control-plane.tftpl`** — append `harbor.openova.io` + `registry.${sovereign_fqdn}` to the existing `r4()` pin loop, **gated behind `%{ if provider == "huawei" }`**. catalyst-api/controllers can land on a CP node, so the CP needs the pin too.
2. **`infra/providers/huawei/cloudinit-worker.tftpl`** — the Huawei worker had **NO `/etc/hosts` pin block at all**; add the same `r4()` ladder + harbor/registry pin (workers pull images too), running **before** the k3s-agent install.

### Design notes

- **No hardcoded IP.** `r4()` derives harbor's A record at boot via the bounded 3-tier ladder (`getent ahostsv4` → public-resolver `nslookup` → `python3` AF_INET `getaddrinfo`) and self-heals if harbor's address ever changes.
- **`registry.<fqdn>` is the post-cutover local Harbor.** Pre-cutover it has no DNS record → `r4()` returns empty → the `[ -n "$a" ]` guard skips it (no bad pin). Post-cutover it resolves to the gateway EIP (IPv4) and pins correctly.
- **Hetzner is left byte-identical.** Hetzner is dual-stack (harbor's AAAA is reachable, no pin needed) **and** its CP render sits at **32223 / 32256 B — only 33 B of headroom** (`#1981` ExternalIP reconciler). The `provider == "huawei"` gate renders to **empty string** on Hetzner, so its cloud-init is byte-for-byte unchanged. **Both harbor AND registry fit** — they only land on Huawei, which has ~9 KB of CP headroom.

## Byte budget — before / after

Measured against the **real** post-comment-strip `user_data` (the `replace(..., "/(?m)^[ ]*#.../", "")` strips all `#` comment lines, so the comment additions cost **0 rendered bytes**), using faithful 2-region (Huawei) / 3-region (Hetzner) test fixtures via `tofu test`:

| Render | Before | After | Δ | Cap | Headroom |
|---|---:|---:|---:|---:|---:|
| Huawei CP (primary) | 23192 | **23235** | +43 | 32256 | 9021 |
| Huawei CP (secondary) | 23193 | **23236** | +43 | 32256 | 9020 |
| Huawei worker | 4723 | **5253** | +530 | 30720 | 25467 |
| Hetzner CP (primary) | 32223 | **32223** | **0** | 32256 | 33 |
| Hetzner CP (secondary) | 32224 | **32224** | **0** | 32256 | 32 |
| Hetzner worker | 4764 | **4764** | **0** | 30720 | — |

Both harbor + registry fit comfortably; the byte-tight Hetzner render is provably unchanged.

## Tests

```
infra/providers/hetzner $ tofu test    → Success! 10 passed, 0 failed.
infra/providers/huawei  $ tofu test    → Success!  5 passed, 0 failed.
scripts/lint-cloudinit.sh both         → PASS (dash -n clean: hetzner 47 runcmd items, huawei 44 runcmd items)
```

Render grep-confirmed: Huawei CP loop + Huawei worker both carry `harbor.openova.io registry.<fqdn>`; Hetzner CP loop carries neither.

## Hot-apply to an in-flight prov (e.g. hw160)

This PR fixes the durable cloud-init path for the **next** prov. If a **currently-running** prov hits the same `ImagePullBackOff` before this merges, the equivalent runtime fix on each affected node is a node `/etc/hosts` pin (NOT a coredns patch — containerd uses the node resolver):

```bash
# On EVERY node (CP + workers) of the affected region, via the node or a privileged debug pod:
A=$(getent ahostsv4 harbor.openova.io | awk '{print $1; exit}')
grep -q "harbor.openova.io" /etc/hosts || echo "$A harbor.openova.io" | sudo tee -a /etc/hosts
# then bounce the stuck pulls:
kubectl -n catalyst delete pod -l app=catalyst-api   # reschedules; pull now resolves A
```

(`A` resolves to `45.151.123.50` today; deriving it keeps the command correct if harbor's IP rotates.)

Refs #3735 #3232

🤖 Generated with [Claude Code](https://claude.com/claude-code)