### PR TITLE
fix(bootstrap): restore in-cluster coredns-custom github IPv4 pin (Huawei-gated) — the lost #3715 half that wedges every kom4dc prov at 0 HRs (Refs #3714 #3715)

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -698,7 +698,30 @@ runcmd:
   # provider-gated conditional keeps the Hetzner render byte-identical while
   # giving every IPv4-only cloud the harbor pin. No hardcoded IP: r4() derives
   # the A record at boot and self-heals if harbor's address ever changes.
+  #
+  # #3714 (2026-06-18 — the kom4dc 0-HR wedge): the /etc/hosts pin below fixes
+  # the NODE Go resolvers (helm/kubectl/git/containerd) but does NOT reach the
+  # in-cluster Flux source-controller pod, which pulls the bootstrap monorepo
+  # from github.com and resolves via CoreDNS, not the node /etc/hosts. On the
+  # IPv4-only Huawei VPC a CoreDNS upstream that hands back AAAA makes the
+  # source-controller try IPv6 → "network is unreachable" → no GitRepository
+  # artifact → 0 HelmReleases in BOTH regions → Phase-1 watcher times out + the
+  # kubeconfig is never PUT (the exact hw160 wedge; intermittent per-prov —
+  # hw159 got an A record and converged, hw160 got AAAA). #3715 first shipped
+  # both halves (node pin + an in-cluster coredns-custom ConfigMap); #3721
+  # reverted #3715 wholesale for Hetzner cloud-init bloat, and #3727 re-added
+  # ONLY the node half — so the in-cluster half was lost. The CoreDNS step that
+  # FOLLOWS (after the CNI is up) restores it, Huawei-gated. To feed that step
+  # without duplicating the r4() resolver ladder, on Huawei we ALSO persist
+  # every resolved `<ip> <host>` to a side-file the CoreDNS step reads back.
+  # Both the side-file and the api.github.com host are Huawei-gated so the
+  # byte-tight Hetzner render (only ~49 B headroom under the 32256 cap) stays
+  # byte-identical — Hetzner is dual-stack and needs neither.
   - |
+%{ if provider == "huawei" ~}
+    mkdir -p /var/lib/catalyst
+    : >/var/lib/catalyst/github-ipv4-hosts
+%{ endif ~}
     r4() {
      getent ahostsv4 "$1" 2>/dev/null | awk '{print $1; exit}' && return
      for s in 1.1.1.1 8.8.8.8; do
@@ -707,8 +730,11 @@ runcmd:
      done
      python3 -c 'import socket,sys;print(socket.getaddrinfo(sys.argv[1],443,2)[0][4][0])' "$1" 2>/dev/null
     }
-    for h in github.com raw.githubusercontent.com codeload.github.com objects.githubusercontent.com helm.cilium.io get.helm.sh%{ if provider == "huawei" } harbor.openova.io registry.${sovereign_fqdn}%{ endif ~}; do
+    for h in github.com raw.githubusercontent.com codeload.github.com objects.githubusercontent.com helm.cilium.io get.helm.sh%{ if provider == "huawei" } api.github.com harbor.openova.io registry.${sovereign_fqdn}%{ endif ~}; do
      a=$(r4 "$h"); [ -n "$a" ] && echo "$a $h" >>/etc/hosts || true
+%{ if provider == "huawei" ~}
+     [ -n "$a" ] && echo "$a $h" >>/var/lib/catalyst/github-ipv4-hosts
+%{ endif ~}
     done
 
   # ── Install k3s server ────────────────────────────────────────────────
@@ -770,6 +796,67 @@ runcmd:
       --namespace kube-system \
       -f /var/lib/catalyst/cilium-values.yaml
   - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml -n kube-system rollout status ds/cilium --timeout=240s'
+%{ if provider == "huawei" ~}
+  # ── In-cluster github→IPv4 for the Flux source-controller (#3714) ──────
+  # The DEEPER half of the #3232/#3714 fix, restored after the #3721 revert
+  # (which kept only the node /etc/hosts pin). The source-controller pod pulls
+  # the bootstrap monorepo from github.com and resolves via CoreDNS — NOT the
+  # node /etc/hosts — so on the IPv4-only Huawei VPC a CoreDNS upstream that
+  # returns AAAA makes it dial IPv6 → "network is unreachable" → no
+  # GitRepository artifact → 0 HelmReleases in BOTH regions → Phase-1 watcher
+  # times out + the kubeconfig is never PUT (the hw160 wedge). We inject a
+  # `coredns-custom` ConfigMap — the k3s-native, restart/upgrade-surviving
+  # CoreDNS extension point: k3s imports `/etc/coredns/custom/*.override` into
+  # the default `.:53` server block — with a `hosts` plugin that force-resolves
+  # the github hosts to the SAME IPv4 the node pin just resolved (read back
+  # from the r4() side-file, so the resolver ladder is NOT duplicated).
+  # `fallthrough` keeps every other name resolving normally; this touches ONLY
+  # CoreDNS config, never Cilium/CNI/kube-proxy, so ClusterMesh is unaffected.
+  # Runs AFTER the CNI is up (CoreDNS pods can now go Ready + mount the
+  # override) and BEFORE Flux is installed/bootstrapped below, so the
+  # source-controller resolves github→IPv4 on its first GitRepository attempt.
+  # Huawei-only: Hetzner is dual-stack (no in-cluster IPv6 trap) and its render
+  # is byte-tight, so the whole block renders empty there. POSIX/dash-clean
+  # (printf, no nested heredoc).
+  - |
+    PIN_FILE=/var/lib/catalyst/github-ipv4-hosts
+    CM_FILE=/var/lib/catalyst/coredns-custom-github.yaml
+    KC=/etc/rancher/k3s/k3s.yaml
+    # Only the in-cluster-relevant github hosts get the CoreDNS override (the
+    # helm.cilium.io / get.helm.sh / harbor / registry pulls all run on the
+    # NODE, already pinned in /etc/hosts above — they never hit CoreDNS).
+    GH_HOSTS="github.com codeload.github.com objects.githubusercontent.com raw.githubusercontent.com api.github.com"
+    {
+     printf 'apiVersion: v1\n'
+     printf 'kind: ConfigMap\n'
+     printf 'metadata:\n'
+     printf '  name: coredns-custom\n'
+     printf '  namespace: kube-system\n'
+     printf 'data:\n'
+     printf '  github-ipv4.override: |\n'
+     printf '    hosts {\n'
+     for h in $GH_HOSTS; do
+      ip=$(awk -v host="$h" '$2 == host {print $1; exit}' "$PIN_FILE" 2>/dev/null)
+      [ -n "$ip" ] && printf '        %s %s\n' "$ip" "$h"
+     done
+     printf '        fallthrough\n'
+     printf '    }\n'
+    } >"$CM_FILE"
+    # Wait (bounded) for the CoreDNS Deployment object — the k3s addon
+    # registers it within seconds of the apiserver; the Deployment EXISTS long
+    # before its pods are Ready. A missing addon must never stall bootstrap.
+    n=0
+    while [ "$n" -lt 24 ]; do
+     kubectl --kubeconfig="$KC" -n kube-system get deploy coredns >/dev/null 2>&1 && break
+     n=$((n + 1))
+     sleep 5
+    done
+    # Apply the override (idempotent, persists immediately) + nudge a restart.
+    # We do NOT block on rollout-status: CoreDNS picks up the mounted override
+    # on its next reload, still well before Flux bootstraps the GitRepository.
+    kubectl --kubeconfig="$KC" apply -f "$CM_FILE" || true
+    kubectl --kubeconfig="$KC" -n kube-system rollout restart deploy/coredns >/dev/null 2>&1 || true
+%{ endif ~}
 
   # ── BACKGROUND pre-pull of the PRIVATE openova-io/openova image set (#3534)
   # The ~19 ghcr.io/openova-io/openova/* images (catalyst-api/ui, the


### PR DESCRIPTION
## Root cause (the hw160 wedge)

Fresh kom4dc (Huawei) provs intermittently wedge at **0 HelmReleases in both regions** (50 min phase1-watching, kubeconfig never PUT).

The in-cluster Flux **source-controller** pulls the bootstrap monorepo from `github.com` and resolves via **CoreDNS**, NOT the node `/etc/hosts`. On the IPv4-only Huawei VPC, a CoreDNS upstream that hands back **AAAA** makes source-controller dial IPv6 → `network is unreachable` → no `GitRepository` artifact → the bootstrap-kit Kustomization can't reconcile → **0 HelmReleases both regions** → Phase-1 watcher times out → kubeconfig never PUT. Intermittent per-prov (hw159 drew an A record and converged; hw160 drew AAAA and wedged) — the #3232 class.

### The fix existed and was lost
- `3b3aa3877` (**#3715**) shipped BOTH halves: a node `/etc/hosts` github pin AND an in-cluster **`coredns-custom` ConfigMap**.
- `a24261230` (**#3721**) **reverted all of #3715** ("cloud-init bloat — restore under Hetzner 32256B limit") — the in-cluster ConfigMap was sacrificed to the Hetzner cap.
- `6fdd6cc42` (**#3727**) re-added **only** the lighter node `/etc/hosts` pin.
- → The in-cluster `coredns-custom` github ConfigMap is **MISSING** → the 0-HR wedge returns whenever source-controller gets AAAA.

## The restore (Huawei-gated)

The byte budget that forced the #3721 revert is the **Hetzner** CP render (only ~49 B headroom under the 32256 cap). But Hetzner is dual-stack — it has **no** in-cluster IPv6 trap and needs no pin. The wedge happens only on the **IPv4-only Huawei** path, whose CP render has **~9 KB headroom**. So this restores #3715's in-cluster half gated `provider == "huawei"`, mirroring the **#3803** harbor-pin provider-gate already in this same file — keeping the byte-tight Hetzner path **byte-identical**.

**Huawei-only changes:**
- `r4()` loop: also persist every resolved `<ip> <host>` to the side-file `/var/lib/catalyst/github-ipv4-hosts` and pin `api.github.com` — so the CoreDNS step **reuses the existing `r4()` resolution** and does NOT duplicate the 3-tier resolver ladder. Both the side-file write and `api.github.com` are gated, so Hetzner stays byte-identical.
- New runcmd step (after the CNI is up, before Flux installs/bootstraps): build a `coredns-custom` ConfigMap from the side-file — filtered to the 5 in-cluster github hosts via a `GH_HOSTS` allowlist (harbor/registry/helm pull on the NODE, never hit CoreDNS) — `hosts { <ipv4> <host> ... fallthrough }`. k3s imports `/etc/coredns/custom/*.override` into the default `.:53` server. Bounded wait for the CoreDNS Deployment, apply + best-effort rollout-restart; never blocks bootstrap. POSIX/dash-clean (`printf`, no nested heredoc). Touches **only** CoreDNS config — never Cilium/CNI/kube-proxy, so ClusterMesh is unaffected.

**Worker tftpl intentionally untouched:** CoreDNS runs cluster-wide in `kube-system` and serves DNS for ALL pods (CP and worker nodes alike), so applying the ConfigMap once from a CP node fixes in-cluster DNS for the whole cluster — matching #3715's CP-only design.

## Byte budget (real post-comment-strip `user_data`)

Measured via the real module byte-probe with the faithful multi-region fixtures (comment lines strip to 0 bytes):

| Render | Before | After | Δ | Headroom (cap) |
|---|---|---|---|---|
| **Huawei CP** | 23235 B | **24508 B** | +1273 | 7748 B (32256) |
| **Hetzner CP** | 32207 B | **32207 B** | **+0 (byte-identical)** | 49 B (32256) |

Hetzner post-strip render diff is **exactly 0 bytes** (the provider gate renders empty; runcmd item count unchanged base→current).

## Tests

- `huawei tofu test`: **5/5 PASS**; `hetzner tofu test`: **10/10 PASS**.
- `scripts/lint-cloudinit.sh both`: **PASS** (dash -n clean; 45 huawei + 47 hetzner runcmd items; valid `#cloud-config` YAML).
- `tofu validate`: both providers **Success**.
- Render-grep confirm: `coredns-custom` ConfigMap **PRESENT** on Huawei (`has-coredns-custom=true`, `has-override-key=true`, side-file + `api.github.com` pinned), **ABSENT** on Hetzner (`has-coredns-custom=false`, `has-sidefile=false`).
- Generated ConfigMap validated as YAML under dash: correct `kind`/`name`/`namespace`, `hosts { ... fallthrough }` with all 5 github hosts, harbor excluded.

**This is the blocker for every kom4dc prov.** Do NOT auto-merge — needs the standard fresh-prov walk.

Refs #3714 #3715 (follow-up to #3232/#3727; mirrors the #3803 provider-gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)