### PR TITLE
hw161 converge-readiness: openbao fromHost mapping + alloy harbor-proxy glob (Refs #3760 #3731)

### DIFF
--- a/clusters/_template/bootstrap-kit/21-alloy.yaml
+++ b/clusters/_template/bootstrap-kit/21-alloy.yaml
@@ -58,7 +58,11 @@ spec:
   chart:
     spec:
       chart: bp-alloy
-      version: 1.0.1
+      # 1.0.2 (#3760 hw161): main + config-reloader images routed through the
+      # Harbor proxy — the alloy DaemonSet runs in the un-excluded `alloy`
+      # namespace, so the upstream docker.io/quay.io defaults were post-handover
+      # harbor-proxy-pull Enforce-deniable (the #3296/#3380-D shape).
+      version: 1.0.2
       sourceRef:
         kind: HelmRepository
         name: bp-alloy

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -94,7 +94,13 @@ spec:
       # harbor/gitea/newapi/guacamole) add harbor/gitea/velero/rtz to
       # allowedIngressNamespaces (their host-bridged CNPG -rw Services + velero
       # registry backup + the cross-vCluster shared-pg wire).
-      version: 0.2.12
+      # 0.2.13 (hw161 converge-readiness, Refs #3760): add the missing
+      # `openbao/*` fromHost.secrets.mappings.byName entry — openbao is the 7th
+      # NS#1 app re-homed into vc-mgmt but the 0.2.12 mapping shipped only 6 of
+      # the 7 namespaces, so the in-vCluster openbao sso-configure Deployment
+      # waited forever for the host-minted openbao-sso-oidc-credentials Secret
+      # the mirror never delivered (the #3737 secret-not-mirrored class).
+      version: 0.2.13
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/platform/alloy/blueprint.yaml
+++ b/platform/alloy/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-observability
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.0.1
+  version: 1.0.2
   card:
     title: Alloy
     family: insights

--- a/platform/alloy/chart/Chart.yaml
+++ b/platform/alloy/chart/Chart.yaml
@@ -12,7 +12,15 @@ description: |
   bp-mimir (metrics), bp-tempo (traces). Default controller is DaemonSet
   (one pod per node) so node + pod metrics + container logs are collected.
 type: application
-version: 1.0.1
+# 1.0.2 (#3760 hw161 converge-readiness): route the main Alloy image AND the
+# config-reloader sidecar through the Sovereign Harbor proxy (proxy-dockerhub/
+# grafana/alloy + proxy-quay/prometheus-operator/prometheus-config-reloader).
+# The DaemonSet runs in the un-excluded `alloy` namespace, so the upstream
+# docker.io/quay.io defaults were post-handover Enforce-deniable by the
+# harbor-proxy-pull ClusterPolicy (the #3296/#3380-D delayed self-inflicted
+# wound). Values-only image-registry change; the chart was never swept by
+# #3380-D. Added to scripts/check-kyverno-proxy-images.sh to guard regressions.
+version: 1.0.2
 appVersion: "v1.16.0"
 keywords: [catalyst, blueprint, alloy, observability, otlp, telemetry, collector]
 maintainers:

--- a/platform/alloy/chart/values.yaml
+++ b/platform/alloy/chart/values.yaml
@@ -15,11 +15,37 @@ catalystBlueprint:
 # ─── Upstream chart values (subchart key: alloy) ─────────────────────────
 alloy:
   # Pin upstream Alloy image tag — DO NOT use floating tags.
+  #
+  # #3760 harbor-proxy-glob (hw161 converge-readiness): route BOTH the main
+  # Alloy image and the config-reloader sidecar through the Sovereign's local
+  # Harbor proxy. The alloy DaemonSet runs in the `alloy` namespace, which is
+  # NOT in the kyverno harbor-proxy-pull excludeNamespaces set (unlike
+  # mgmt/dmz/rtz/kube-system). The upstream subchart defaults
+  # (docker.io/grafana/alloy + quay.io/prometheus-operator/prometheus-config-
+  # reloader) match NEITHER allowed glob (`*/proxy-*/*` or `*/openova-io/*`),
+  # so once `compliancePolicies.bootstrapMode` flips to false post-handover
+  # (post_handover_policy_enforce.go, phase 2b) the policy goes Enforce and the
+  # next DaemonSet pod reschedule (node reboot / image roll / eviction) is
+  # admission-DENIED — the #3296 delayed self-inflicted-wound shape #3380-D
+  # fixed for the vCluster control-plane images. The alloy chart was never
+  # swept by #3380-D (last touched #3179). proxy-dockerhub/proxy-quay are the
+  # canonical proxy projects already used by bp-grafana/bp-openbao and named in
+  # bp-self-sovereign-cutover values (`proxy-docker/grafana/alloy`,
+  # `proxy-quay/...`). Bootstrap-mode Audit means this is byte-equivalent during
+  # the fresh-prov convergence walk; the proxy path simply prevents the
+  # post-handover/cutover-walk denial.
   image:
-    registry: "docker.io"
-    repository: grafana/alloy
+    registry: "harbor.openova.io"
+    repository: proxy-dockerhub/grafana/alloy
     tag: "v1.16.0"
     pullPolicy: IfNotPresent
+  # Config-reloader sidecar (upstream default quay.io/prometheus-operator/
+  # prometheus-config-reloader) — same harbor-proxy-glob fix as the main image.
+  configReloader:
+    image:
+      registry: "harbor.openova.io"
+      repository: proxy-quay/prometheus-operator/prometheus-config-reloader
+      tag: v0.81.0
 
   # Alloy runtime config. Empty by default — the upstream chart ships an
   # empty configMap that Alloy starts up against. Per-Sovereign overlays

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.12
+  version: 0.2.13
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -133,7 +133,18 @@ name: bp-mgmt-vcluster
 # gateway-system/kube-system + catalyst-system/newapi/sso-bridge/oidc-gate
 # entries from 0.2.11 already cover the host Cilium Gateway + the openbao/newapi
 # SSO consumers. Additive netpol-values change only; default render unchanged.
-version: 0.2.12
+# 0.2.13 (hw161 converge-readiness, Refs #3760): add the missing `openbao/*`
+# entry to vcluster.sync.fromHost.secrets.mappings.byName. openbao is the 7th
+# NS#1 app re-homed into vc-mgmt (placement.yaml `vcluster: mgmt, namespace:
+# openbao`); its host-bridge mints `openbao-sso-oidc-credentials` in the openbao
+# HOST namespace but the 0.2.12 mapping shipped only 6 of the 7 namespaces
+# (keycloak/gitea/harbor/newapi/grafana/catalyst-system) — DROPPING openbao.
+# Result: the in-vCluster openbao sso-configure Deployment (optional secret
+# mount) WAITS forever for openbao-sso-oidc-credentials that the host→vCluster
+# mirror never delivered → OpenBao SSO silently never configures (the #3737
+# secret-not-mirrored class, soft-wait variant). Additive values-only change;
+# default render gains one mapping entry.
+version: 0.2.13
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -422,13 +422,28 @@ vcluster:
       # namespace with zero per-secret enumeration — the generic mechanism
       # (#3642 DoD-6 "no per-app special-casing"), not a per-secret hack. The
       # namespaces are exactly the 7 NS#1 apps' inner namespaces
-      # (keycloak/gitea/harbor/newapi/grafana, plus catalyst-system for
+      # (keycloak/gitea/harbor/newapi/grafana/openbao, plus catalyst-system for
       # guacamole — guacamole's `guacamole-pg` CNPG-app Secret + the
       # bp-continuum/k8s-ws-proxy host-adjacent peers share that namespace).
       # On a fresh prov the host namespaces that don't yet exist are simply
       # not mirrored (no-op) until the host-bridge renders them — additive
       # and safe. Independent of the existing `sync.toHost.secrets`
       # (vCluster→host); the two directions don't conflict.
+      #
+      # ⚠️ openbao/* (hw161 converge-readiness fix, Refs #3760): openbao is the
+      # 7th NS#1 app re-homed into vc-mgmt (placement.yaml `hr: bp-openbao,
+      # vcluster: mgmt, namespace: openbao`). Its host-bridge mints
+      # `openbao-sso-oidc-credentials` in the `openbao` HOST namespace (the
+      # host ESO reconciles it from secret/sso/openbao), while the openbao
+      # sso-configure Deployment runs INSIDE vc-mgmt and mounts that Secret
+      # (templates/sso-configure-deployment.yaml `secretName:
+      # openbao-sso-oidc-credentials`, optional:true → it WAITS forever rather
+      # than CrashLoops). The 0.2.12 mapping shipped keycloak/gitea/harbor/
+      # newapi/grafana/catalyst-system but DROPPED openbao/* — so OpenBao SSO
+      # silently never configured (the #3737 secret-not-mirrored class, the
+      # soft-wait variant). Adding openbao/* mirrors the host Secret into
+      # vc-mgmt's openbao ns so sso-configure completes the OIDC auth-method
+      # wiring zero-touch.
       secrets:
         enabled: true
         mappings:
@@ -438,6 +453,7 @@ vcluster:
             "harbor/*": "harbor/*"
             "newapi/*": "newapi/*"
             "grafana/*": "grafana/*"
+            "openbao/*": "openbao/*"
             "catalyst-system/*": "catalyst-system/*"
 
   # ── In-vCluster CRD registration (#3373, OSS-native) ────────────────────

--- a/scripts/check-kyverno-proxy-images.sh
+++ b/scripts/check-kyverno-proxy-images.sh
@@ -103,6 +103,12 @@ CHARTS=(
   "platform/bp-mgmt-vcluster/chart|--set mgmtVcluster.enabled=true"
   "platform/bp-dmz-vcluster/chart|--set dmzVcluster.enabled=true"
   "platform/bp-rtz-vcluster/chart|--set rtzVcluster.enabled=true"
+  # bp-alloy (slot 21, #3760 hw161): subchart-wrapping (grafana/alloy 1.8.0).
+  # The alloy DaemonSet runs in the un-excluded `alloy` namespace, so its
+  # upstream image defaults (docker.io/grafana/alloy + quay.io/prometheus-
+  # operator/prometheus-config-reloader) are post-handover Enforce-deniable.
+  # Pinned through the Harbor proxy in values.yaml; this gate guards regressions.
+  "platform/alloy/chart|"
 )
 
 matches_any_glob() {


### PR DESCRIPTION
## hw161 fresh-prov convergence-readiness audit

Per-class audit of the bootstrap-kit on `origin/main` HEAD ahead of the hw161 re-prov. The last train merged 13+ cars (~20 slots, vcluster 0.21→0.23 MAJOR bump, dependsOn changes). Each named wedge class was audited; findings classified **(a) real wedge-risk → fixed** or **(b) benign/already-handled → evidence**.

### Verdict summary

| Class | Verdict | Action |
|---|---|---|
| **1. ESO/#3731 deadlock** | ✅ BENIGN — already-handled | none |
| **2. kyverno/#3760 image-gate** | 🔧 1 real gap (`bp-alloy`) | **FIXED** |
| **3. dependsOn graph integrity** | ✅ CLEAN (drift-0, cycle-0) | none |
| **4. vcluster 0.23 fromHost mapping/#3792** | 🔧 1 real gap (`openbao/*` missing) | **FIXED** |
| **5. slot-vs-ghcr pin sync** | ✅ CLEAN (only known-benign bp-postgres) | none |

Two real fixes shipped; three classes audit clean with evidence.

---

### Class 4 (FIXED) — vcluster 0.23 `fromHost.secrets` mapping: `openbao/*` was missing

PR #3792 re-homed **7** NS#1 apps into the mgmt vCluster and added vcluster 0.23 `sync.fromHost.secrets.mappings.byName` to mirror each app's host-MINTED DB/SSO Secret across the host→vCluster boundary. The 0.2.12 mapping shipped only **6 of 7** namespaces — `keycloak/gitea/harbor/newapi/grafana/catalyst-system` — and **dropped `openbao`** (the chart comment itself enumerates only 6).

- `bp-openbao` is placed at `vcluster: mgmt, namespace: openbao` (placement.yaml) and its host-bridge mints `openbao-sso-oidc-credentials` in the **`openbao` host namespace** (host ESO reconciles it from `secret/sso/openbao`).
- The openbao `sso-configure` Deployment runs **inside vc-mgmt** and mounts that Secret (`templates/sso-configure-deployment.yaml`, `secretName: openbao-sso-oidc-credentials`, `optional: true`).
- Without `openbao/*` in the mirror the Secret never crosses into vc-mgmt → `sso-configure` **waits forever** for the keys → OpenBao SSO silently never configures the OIDC auth method. This is the **#3737 secret-not-mirrored class** — the soft-wait variant (vs the keycloak hard-mount-fail variant).

**Fix:** added `"openbao/*": "openbao/*"` to `vcluster.sync.fromHost.secrets.mappings.byName`.

**Verified at rendered-config level** (not just source): the `vc-config-mgmt-vcluster` Secret now carries **all 7** `byName` entries and the syncer RBAC `resourceNames` lists `openbao`:
```
catalyst-system/*: catalyst-system/*
gitea/*: gitea/*       grafana/*: grafana/*       harbor/*: harbor/*
keycloak/*: keycloak/* newapi/*: newapi/*         openbao/*: openbao/*
```
- **dmz/rtz vClusters audited clean**: their placed apps (coraza / valkey / seaweedfs / vllm / sandbox) have NO `hostBridge` block → no host-minted secrets → no missing mappings.
- **No collision risk**: the only host `openbao`-ns Secret is `openbao-sso-oidc-credentials`; openbao's own in-vCluster secrets (`openbao-root-token`, `recovery-seed-bootstrap`) have no host copy.

Files: `platform/bp-mgmt-vcluster/chart/values.yaml` (+`Chart.yaml`/`blueprint.yaml`/slot 58 lockstep 0.2.12→0.2.13).

---

### Class 2 (FIXED) — kyverno harbor-proxy-pull: `bp-alloy` images un-globbed in a non-excluded namespace

The `harbor-proxy-pull` ClusterPolicy (`platform/kyverno-policies/chart/templates/baseline/11-harbor-proxy.yaml`, Enforce default) allows only `*/proxy-*/*` and `*/openova-io/*`, with namespace exclusions `kube-system, flux-system, cilium, …, dmz, mgmt, rtz, sso-bridge, powerdns`.

- **The task's primary suspect — vcluster 0.23 — is BENIGN**: the umbrella's `#3380-D` pins (`controlPlane.distro.k8s.{apiServer,controllerManager,scheduler}.image` → `harbor.openova.io/proxy-k8s/kube-*`) **do** cover the 0.23 image set (render-confirmed; the 0.21→0.23 bump leaked no new un-globbed control-plane image). The CoreDNS `{{.IMAGE}}` runtime-substituted pod lands in the excluded `mgmt`/`dmz`/`rtz` namespace anyway.
- **One real gap found: `bp-alloy` (slot 21).** The grafana/alloy 1.8.0 subchart defaults leak `docker.io/grafana/alloy:v1.16.0` + `quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0`, and the alloy DaemonSet runs in the **un-excluded `alloy` namespace**. The chart was never swept by #3380-D.

**Timing (why it does NOT block hw161 convergence):** `compliancePolicies.bootstrapMode: true` (fresh-prov default) forces every policy to **Audit** during Phase-1, so hw161 converges green. The Enforce denial bites only **post-handover** — after `runPostHandoverPolicyEnforceFlip` (phase-2b) sets `bootstrapMode: false` — on the next alloy pod reschedule. It's a latent post-handover/cutover-walk (Pillar 5) denial, fixed proactively per the convergence-readiness mandate (catch the whole class so the env survives the full lifecycle, not just the first walk).

**Fix:** pinned both images through the Harbor proxy (`proxy-dockerhub/grafana/alloy` + `proxy-quay/prometheus-operator/prometheus-config-reloader`) — the same canonical proxy projects already used by bp-grafana/bp-openbao and named in bp-self-sovereign-cutover values. Render-confirmed both now match `*/proxy-*/*`. Added `platform/alloy/chart` to `scripts/check-kyverno-proxy-images.sh` so the class is CI-guarded for alloy going forward.

Files: `platform/alloy/chart/values.yaml` (+`Chart.yaml`/`blueprint.yaml`/slot 21 lockstep 1.0.1→1.0.2) + `scripts/check-kyverno-proxy-images.sh`.

_Benign secondary notes (no action):_ bp-gitea's `busybox:latest` is only in the upstream Helm **test** Pod (`helm.sh/hook: test-success`) — never instantiated by Flux on a prov. `bge` (raw HF image) is not a bootstrap-kit slot.

---

### Class 1 (BENIGN) — ESO/#3731 deadlock: already-handled

- `bp-external-secrets` (slot 15) → `dependsOn: bp-cilium, bp-cert-manager`; `bp-external-secrets-stores` (slot 15a) → `dependsOn: bp-external-secrets, bp-openbao`. The controller↔stores split is intact and **acyclic** (no ESO consumer depends back onto a thing ESO needs).
- The openbao auth path (`vault-region1` ClusterSecretStore → openbao) is fed by openbao's own bootstrap token/approle, which comes from a **non-ExternalSecret** source — so no chicken-and-egg.
- Every install-time ExternalSecret-producing chart is protected by a `.Capabilities.APIVersions.Has "external-secrets.io/v1beta1"` guard (gold standard bp-external-dns) **or** an HR `dependsOn: bp-external-secrets`. The #3792 raw host-bridge ExternalSecrets render unguarded-by-design but self-heal via the 5-minute kustomize retry — not a wedge.
- Corroborated by Class 3's drift-0/cycle-0 result.

### Class 3 (CLEAN) — dependsOn graph integrity

`scripts/check-bootstrap-deps.sh`: **Drift 0, Cycles 0** (64 HRs on disk, 13 W2.K4 deferred). Phase-2.5 slot-registration audit passes (every HR-bearing slot file registered in `kustomization.yaml`); full `kustomize build` succeeds — no #3191 dangling-dependsOn / forgotten-slot from the 12-car train.

### Class 5 (CLEAN) — slot-vs-ghcr pin sync

`scripts/check-bootstrap-kit-pin-sync.sh`: every train-touched pin is published to ghcr — bp-guacamole 0.2.25 ✓, bp-newapi 1.4.108 ✓, bp-keycloak 1.4.32 ✓, bp-catalyst-platform 1.4.681 ✓, bp-mgmt-vcluster 0.2.12 ✓. The **only** drift is the known-benign `bp-postgres` 0.2.3-chart-vs-0.2.2-pin — pin 0.2.2 **is** published to ghcr (verified), so those 3 HRs install fine; not touched per scope. No NEW unpublished pins.

---

### Test output (all green)

```
e2e bootstrap-kit (go test -count=1):  ok (lockstep across Chart/slot/blueprint for both alloy + mgmt-vcluster)
check-bootstrap-deps.sh:               Drift 0, Cycles 0, PASSED
check-bootstrap-kit-pin-sync.sh:       bp-alloy 1.0.2/1.0.2 OK, bp-mgmt-vcluster 0.2.13/0.2.13 OK (only benign bp-postgres drift)
check-kyverno-proxy-images.sh:         PASS — every rendered image satisfies harbor-proxy-pull (vcluster trio + alloy)
render-slot-placement.py check:        PASSED (chart-data edits only, no placement-generated field touched)
bp-mgmt-vcluster render.sh:            all PASS
kubectl kustomize (full kit):          OK (176 resources)
```

**Confidence: high.** Both fixes are values-only / mapping-only, render-verified at the live-config level, lockstep-complete, and pass every static gate. Neither touches any excluded surface (cloud-init tftpls / org-controller / treemap / cutover UI / jobs handler / newapi / helmwatch / seaweedfs-LGTM deps). The two non-blocking classes that remain (postgres pin drift; alloy's Audit-mode-during-convergence) are documented, not silently accepted.

Do NOT merge — hold for the hw161 fresh-prov walk per task instruction.

Refs #3731 #3760 #3792 #3642 #3737
