### PR TITLE
fix(bootstrap): drop bootstrap-kit-crs dependsOn — circular deadlock with app-DB CRs (hw162)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -16,6 +16,22 @@
 # CoreDNS forwards unknown queries to host kube-dns).
 
 ---
+# Host namespace for openbao's host-bridge Secret (openbao-sso-oidc-credentials).
+# #3642 re-homed openbao into the mgmt vCluster; its host-MINTED SSO Secret lands
+# in this HOST `openbao` namespace and the raw ExternalSecret (now in the
+# bootstrap-kit-crs tier) targets it. Flux applies Namespace kinds before
+# namespaced resources, so declaring it here guarantees it exists before
+# bootstrap-kit-crs applies the ExternalSecret — without it bootstrap-kit-crs
+# atomic-fails `namespaces "openbao" not found`, blocking ALL its CRs (caught
+# live on hw162). grafana/newapi declare theirs in their slots; gitea/harbor were
+# fixed in #3806; openbao was the remaining gap (Refs #3642 #3731 #3804).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openbao
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -16,6 +16,25 @@
 # from the same namespace (Flux v2 SecretReference contract).
 
 ---
+# Host namespace for keycloak's shared-pg connection Secret (keycloak-database-secret).
+# #3642 re-homed keycloak into the mgmt vCluster, but it consumes shared-pg (host).
+# bp-postgres-shared's connection-secret.yaml has bp-reflector AUTO-PUSH the
+# keycloak-database-secret into the keycloak namespace — but the reflector can only
+# push once that namespace EXISTS. With keycloak in the vCluster, its HOST namespace
+# is never created by its own HR, so the push silently no-ops → keycloak-0 hangs
+# Init with `secret "keycloak-database-secret" not found` → bp-keycloak never Ready
+# → bp-gitea/bp-catalyst-platform wait → console 000 (caught live on hw162, frozen
+# 49/64). Declaring it here (Flux applies Namespace kinds first) gives the reflector
+# its push target; the vCluster fromHost keycloak/* mirror then delivers it into the
+# vCluster. gitea/harbor/grafana/guacamole/newapi declare theirs; keycloak+openbao
+# were the gaps (Refs #3642 #3731 #3804).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keycloak
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -625,35 +625,37 @@ write_files:
       # CRDs never appeared → permanent 0-HelmRelease deadlock (diagnosed live
       # on hw161; pre-#3642 there were zero raw CRs in bootstrap-kit).
       #
-      # Fix: this SEPARATE Flux Kustomization carries those CRs and
-      # `dependsOn: [bootstrap-kit]`, so Flux validates + applies them only
-      # AFTER bootstrap-kit is Ready (every operator installed + its CRDs
-      # registered). Same CRD-ordering split shape as the sovereign-tls
-      # Kustomization above and the bp-cert-manager-issuers (02a) /
-      # crossplane-claims (14) / external-secrets-stores (15a) / cnpg-pair
-      # (16b) / kyverno-policies (27a) HelmRelease splits. wait:false — Flux
-      # only confirms the apply succeeds (CRDs present); per-CR health (CNPG
-      # cluster ready, ESO sync) reconciles asynchronously and must NOT gate
-      # this Kustomization. Provider-agnostic: the deadlock hits every cloud,
-      # so this is OUTSIDE the hetzner-only infrastructure-config block.
+      # Fix: this SEPARATE Flux Kustomization carries those CRs and reconciles
+      # in PARALLEL with bootstrap-kit (NO dependsOn), RETRYING (retryInterval)
+      # until the operator CRDs (cnpg / external-secrets / gateway-api) that
+      # bootstrap-kit installs are registered, then applies the CRs.
+      # It must NOT `dependsOn: [bootstrap-kit]`: several of these CRs are APP
+      # DATABASES (per-app CNPG `Cluster`s — keycloak-pg / guacamole-pg / …) that
+      # the apps INSIDE bootstrap-kit need Ready to come up, and bootstrap-kit
+      # (wait:true) cannot go Ready until those apps ARE Ready. A dependsOn would
+      # deadlock CIRCULARLY: app waits for its DB CR → DB CR (this Kustomization)
+      # waits for bootstrap-kit Ready → bootstrap-kit waits for the app. Caught
+      # live on hw162: keycloak-0 stuck Init:0/2 with no DB, convergence frozen
+      # at 49/64 HRs. Reconciling independently + retrying breaks the circle yet
+      # still applies the CRs only AFTER their CRDs exist. wait:false — per-CR
+      # health (CNPG cluster ready, ESO sync) reconciles async + must NOT gate
+      # this Kustomization. Provider-agnostic; OUTSIDE the hetzner-only block.
       apiVersion: kustomize.toolkit.fluxcd.io/v1
       kind: Kustomization
       metadata:
         name: bootstrap-kit-crs
         namespace: flux-system
       spec:
-        # retryInterval + timeout both default to `interval` (5m), so they are
-        # omitted here — for a wait:false, prune-only CR-applier the retry/
-        # timeout cadence is immaterial, and dropping them keeps the rendered
-        # cloud-init under Hetzner's 32256B cap (#3804 / Refs #3642).
         interval: 5m
+        # retryInterval short: with NO dependsOn (see header), the CRs fail the
+        # dry-run until the operators register their CRDs, so retry FAST to apply
+        # promptly after — not at the 5m interval. timeout defaults to interval.
+        retryInterval: 1m
         path: ./clusters/_template/bootstrap-kit-crs
         prune: true
         sourceRef:
           kind: GitRepository
           name: openova
-        dependsOn:
-          - name: bootstrap-kit
         wait: false
         postBuild:
           substitute:

--- a/scripts/expected-cloudinit-kustomization-deps.yaml
+++ b/scripts/expected-cloudinit-kustomization-deps.yaml
@@ -42,12 +42,13 @@ kustomizations:
       - bootstrap-kit
   - name: bootstrap-kit-crs
     # #3642/#3731/#3804 fresh-prov 0-HR deadlock fix: host-bridge CRD-dependent
-    # CRs (HTTPRoute/ExternalSecret/CNPG Cluster) split out of bootstrap-kit into
-    # this sibling tier so they validate/apply only AFTER bootstrap-kit installs
-    # the operators (bp-external-secrets/bp-cnpg/bp-gateway-api) that register
-    # their CRDs. Provider-agnostic (the deadlock is too — NOT optional).
-    depends_on:
-      - bootstrap-kit
+    # CRs (HTTPRoute/ExternalSecret/CNPG Cluster) split into this sibling tier.
+    # NO dependsOn (depends_on: []): it reconciles in parallel + retries until
+    # the operator CRDs exist. It must NOT depend on bootstrap-kit — several CRs
+    # are APP DBs the apps INSIDE bootstrap-kit need Ready, so a dependsOn
+    # deadlocks circularly (app→DB CR→bootstrap-kit Ready→app; caught live hw162).
+    # Provider-agnostic (NOT optional).
+    depends_on: []
   - name: infrastructure-config
     # Hetzner-only (HCL `%{ if provider == "hetzner" }` guard) — absent for
     # other providers, which is expected, not drift.


### PR DESCRIPTION
## bootstrap-kit-crs dependsOn → circular deadlock with app DBs (hw162)

The #3806 `bootstrap-kit-crs` tier carried `dependsOn: [bootstrap-kit]`. That deadlocks CIRCULARLY: several of its CRs are **app databases** (per-app CNPG `Cluster`s — guacamole-pg etc.) and SSO ExternalSecrets that apps INSIDE bootstrap-kit need Ready to come up. bootstrap-kit (wait:true) can't go Ready until those apps are Ready → app waits for its DB CR → DB CR (bootstrap-kit-crs) waits for bootstrap-kit Ready → bootstrap-kit waits for the app.

**Caught live on hw162:** convergence froze at 49/64 HRs — `bp-keycloak`/`bp-gitea`/`bp-catalyst-platform` stuck, console never served.

**Fix:** drop the dependsOn. bootstrap-kit-crs reconciles in parallel and RETRIES (retryInterval 1m) until the operator CRDs (cnpg/external-secrets/gateway-api) that bootstrap-kit installs are registered, then applies the CRs. bootstrap-kit itself has zero raw CRs (the #3806 fix), so its dry-run still passes — no regression to the original deadlock fix. Verified live: removing the dependsOn on hw162 let bootstrap-kit-crs apply its CRs.

Validated: `check-cloudinit-kustomization-deps.sh` ok · `lint-cloudinit both` pass · `tofu test` 10/10 (byte budget OK — net -22B).

Refs #3642 #3731 #3804
