### PR TITLE
fix(bp-mgmt-vcluster): vc-mgmt apps resolve host shared-pg via replicateServices.fromHost — 0.2.14 (#3737)

### DIFF
--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -100,7 +100,12 @@ spec:
       # the 7 namespaces, so the in-vCluster openbao sso-configure Deployment
       # waited forever for the host-minted openbao-sso-oidc-credentials Secret
       # the mirror never delivered (the #3737 secret-not-mirrored class).
-      version: 0.2.13
+      # 0.2.14 (#3737 4th-layer): networking.replicateServices.fromHost mirrors
+      # the host shared-pg Services into vc-mgmt so the secret's host FQDN
+      # `shared-pg[-b|-c]-rw.shared-data.svc.cluster.local` RESOLVES inside the
+      # vCluster — keycloak-0 CrashLooped `no such host` on hw163 without it
+      # (the #3642-in-vcluster vs NorthStar-#2 host-shared-pg DNS collision).
+      version: 0.2.14
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.13
+  version: 0.2.14
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -144,7 +144,20 @@ name: bp-mgmt-vcluster
 # mirror never delivered → OpenBao SSO silently never configures (the #3737
 # secret-not-mirrored class, soft-wait variant). Additive values-only change;
 # default render gains one mapping entry.
-version: 0.2.13
+#
+# 0.2.14 (#3737 4th-layer SHARED_PG DNS, hw163 2026-06-18): the secret mirror
+# (0.2.12/0.2.13) delivers `<app>-database-secret` into vc-mgmt, but that
+# secret's host field is the HOST FQDN `shared-pg[-b|-c]-rw.shared-data.svc.
+# cluster.local` — which does NOT resolve inside vc-mgmt (its CoreDNS only
+# knows vCluster-local services; the host shared-pg lives in the host
+# `shared-data` ns). keycloak-0 CrashLoopBackOff `cannot resolve host
+# shared-pg-rw.shared-data.svc.cluster.local … no such host` — the
+# #3642-vs-NorthStar-#2 collision (apps in vc-mgmt + host-level shared-pg).
+# Adds `networking.replicateServices.fromHost` for all 3 instances × rw/ro so
+# the host shared-pg FQDN resolves natively inside vc-mgmt (the Pod is a real
+# host pod → ClusterIP reachable; only the NAME was missing). Additive,
+# values-only; zero per-app special-casing (#3642 DoD-6).
+version: 0.2.14
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -302,6 +302,44 @@ vcluster:
       spec:
         type: ClusterIP
 
+  # ── #3642/#3737-DNS host→vCluster Service mirror (4th-layer SHARED_PG fix) ──
+  # The NS#1 apps re-homed into vc-mgmt (#3642) consume the 3 HOST-level
+  # shared-pg instances that live in the host `shared-data` namespace (North
+  # Star #2: 3 shared instances, 6-7 apps many-to-many). Each app's
+  # emberstack-reflector-minted `<app>-database-secret` carries the HOST FQDN
+  # `shared-pg[-b|-c]-rw.shared-data.svc.cluster.local`. The in-vCluster Pod is
+  # a REAL host pod (shared CNI) so the host ClusterIP is reachable — but the
+  # NAME does not resolve inside vc-mgmt: the vCluster's own CoreDNS only knows
+  # vCluster-local services, and `sync.toHost.services` mirrors the OTHER
+  # direction (vCluster→host). The `sync` PG `customResources` mechanism (lines
+  # ~332-341) only resolves PG Clusters CREATED INSIDE the vCluster, NOT a
+  # host-level shared instance. Result (hw163, 2026-06-18): keycloak-0
+  # CrashLoopBackOff — `cannot resolve host
+  # "shared-pg-rw.shared-data.svc.cluster.local" … on <vc-coredns>:53: no such
+  # host` — the #3642-vs-NorthStar-#2 collision. `replicateServices.fromHost`
+  # creates a vCluster Service per host shared-pg endpoint so the host FQDN
+  # resolves natively inside vc-mgmt (routes to the host ClusterIP via the
+  # shared CNI). Eventually-consistent: the syncer watches the host service and
+  # materialises the mirror once bp-postgres-shared renders it — on a fresh
+  # prov the vCluster starts before shared-pg exists (no-op until present). All
+  # 3 instances × rw/ro so EVERY SHARED_PG consumer (any instance) resolves
+  # with zero per-app special-casing (#3642 DoD-6 "no per-app special-casing").
+  networking:
+    replicateServices:
+      fromHost:
+        - from: shared-data/shared-pg-rw
+          to: shared-data/shared-pg-rw
+        - from: shared-data/shared-pg-ro
+          to: shared-data/shared-pg-ro
+        - from: shared-data/shared-pg-b-rw
+          to: shared-data/shared-pg-b-rw
+        - from: shared-data/shared-pg-b-ro
+          to: shared-data/shared-pg-b-ro
+        - from: shared-data/shared-pg-c-rw
+          to: shared-data/shared-pg-c-rw
+        - from: shared-data/shared-pg-c-ro
+          to: shared-data/shared-pg-c-ro
+
   # sync — what host-cluster resources sync into the vCluster. The
   # MGMT vCluster needs services + endpoints + configmaps + secrets
   # to talk to the bootstrap services that live in the host (cnpg,


### PR DESCRIPTION
## 4th-layer SHARED_PG convergence wedge — root-caused live on hw163 (2026-06-18)

The complete-convergence-chain prov **hw163** (`83674048ff592704`) advanced FURTHER than every prior prov — the keycloak host-namespace fix (#3807) worked, so `keycloak-database-secret` IS now delivered into vc-mgmt by the `sync.fromHost.secrets` mirror (0.2.12/0.2.13) and keycloak-0 advanced past `Init:0/2`. But it then **CrashLoopBackOff**'d on:

```
keycloak ... Unable to connect to host shared-pg-rw.shared-data.svc.cluster.local
cannot resolve host "shared-pg-rw.shared-data.svc.cluster.local":
  lookup shared-pg-rw.shared-data.svc.cluster.local on 10.96.87.216:53: no such host
```

### Root cause — the `#3642`-vs-NorthStar-#2 collision
- **#3642** relocated the 7 NS#1 apps (keycloak/gitea/harbor/newapi/grafana/openbao/guacamole) **into the mgmt vCluster**.
- **North Star #2** puts the **3 shared-pg instances** in the **HOST** `shared-data` namespace (verified live on hw163: `shared-pg-rw`, `shared-pg-b-rw`, `shared-pg-c-rw` + ro/r).
- Each app's reflector-minted `<app>-database-secret` carries the **HOST FQDN** `shared-pg[-b|-c]-rw.shared-data.svc.cluster.local`.
- The in-vCluster Pod is a **real host pod** (shared CNI) so the host ClusterIP (`10.96.22.222`) is already **reachable** — but the **NAME does not resolve** inside vc-mgmt: the vCluster's own CoreDNS only knows vCluster-local services, `sync.toHost.services` mirrors the *other* direction, and the `sync` PG `customResources` path only resolves PG Clusters **created inside** the vCluster, not a host-level shared instance.

### Fix
`networking.replicateServices.fromHost` materialises a vCluster Service per host shared-pg endpoint (all **3 instances × rw/ro**) so the host FQDN resolves natively inside vc-mgmt. The Pod was already reachable; this supplies the missing DNS name.

- Additive, **values-only**.
- **Eventually-consistent**: the syncer watches the host service and creates the mirror once `bp-postgres-shared` renders it — on a fresh prov the vCluster starts before shared-pg exists (no-op until present).
- **Zero per-app special-casing** (#3642 DoD-6) — every SHARED_PG consumer on any instance resolves.

### Files
- `platform/bp-mgmt-vcluster/chart/values.yaml` — `networking.replicateServices.fromHost` block (6 entries).
- `platform/bp-mgmt-vcluster/chart/Chart.yaml` — `0.2.13` → `0.2.14` + changelog.
- `platform/bp-mgmt-vcluster/blueprint.yaml` — version lockstep `0.2.14`.
- `clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml` — slot pin `0.2.13` → `0.2.14`.

### Convergence trajectory (each prov advances one layer deeper)
| prov | result |
|---|---|
| hw161 | 0 HRs — CoreDNS `.override` crash + CRD-ordering + host-ns (#3806) |
| hw162 | 64 HRs — circular dep + host-ns gaps fixed (#3807); keycloak `Init:0/2` (no secret) |
| hw163 | keycloak gets secret, advances to startup → CrashLoop `no such host` (**this PR**) |

`Refs #3737 #3760`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
