### PR TITLE
fix(cloud-init): background pre-pull flux v2.4.0 controllers + cnpg postgresql:16 (#809, #3735 Blocker #5)

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -938,6 +938,15 @@ runcmd:
   # instantly. Public images — no ghcr auth. Huawei-gated: the slow egress is
   # Huawei-specific and Hetzner's cloud-init is byte-tight. Versions track
   # flux2 v2.4.0 — keep in lockstep with the install.yaml URL below.
+  #
+  # #3735 Blocker #5 (cnpg postgresql:16 cold-pull): the 3 shared-pg instances
+  # + every per-app CNPG Cluster pull cloudnative-pg/postgresql:16 (~the largest
+  # single data-plane layer) via harbor's ANONYMOUS proxy-ghcr cache (the exact
+  # kyverno-rewritten ref a fresh prov's pod uses). It serializes behind the
+  # bp-postgres-shared + cnpg-pair reconcile the same way the flux controllers
+  # do, so it rides the SAME background pre-pull — public (no auth), idempotent,
+  # dedups against the pod's own pull. Keep the tag in lockstep with the cnpg
+  # operator's imageName default + the kyverno proxy-ghcr rewrite prefix.
   - |
     ( CRICTL="$(command -v crictl 2>/dev/null || echo /var/lib/rancher/k3s/data/current/bin/crictl)"
       for img in \
@@ -946,7 +955,8 @@ runcmd:
         ghcr.io/fluxcd/helm-controller:v1.1.0 \
         ghcr.io/fluxcd/notification-controller:v1.4.0 \
         ghcr.io/fluxcd/image-reflector-controller:v0.33.0 \
-        ghcr.io/fluxcd/image-automation-controller:v0.39.0; do
+        ghcr.io/fluxcd/image-automation-controller:v0.39.0 \
+        harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16; do
         "$CRICTL" pull "$img" >/dev/null 2>&1 || true
       done ) >/dev/null 2>&1 &
 %{ endif ~}

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -925,6 +925,32 @@ runcmd:
     kubectl --kubeconfig="$KC" -n kube-system rollout restart deploy/coredns >/dev/null 2>&1 || true
 %{ endif ~}
 
+%{ if provider == "huawei" ~}
+  # ── #809: BACKGROUND pre-pull the Flux v2.4.0 controller images BEFORE the
+  # `flux install` below (~line 1019). On Huawei they pull DIRECT from
+  # ghcr.io/fluxcd over the THROTTLED Huawei→ghcr egress — kustomize-controller
+  # :v1.4.0 took 9m59s on hw162, blowing the line-1024 300s readiness wait and
+  # serializing the WHOLE convergence ~26 min behind one image. Pulling them HERE
+  # (right after CNI, ahead of the openova-io render-pull + flux install) gives
+  # containerd minutes of head start so flux-system is Ready promptly. crictl is
+  # idempotent + non-fatal (kubelet still pulls on demand) and dedups against
+  # flux install's own pulls. Static list (no chart render) so it starts
+  # instantly. Public images — no ghcr auth. Huawei-gated: the slow egress is
+  # Huawei-specific and Hetzner's cloud-init is byte-tight. Versions track
+  # flux2 v2.4.0 — keep in lockstep with the install.yaml URL below.
+  - |
+    ( CRICTL="$(command -v crictl 2>/dev/null || echo /var/lib/rancher/k3s/data/current/bin/crictl)"
+      for img in \
+        ghcr.io/fluxcd/source-controller:v1.4.1 \
+        ghcr.io/fluxcd/kustomize-controller:v1.4.0 \
+        ghcr.io/fluxcd/helm-controller:v1.1.0 \
+        ghcr.io/fluxcd/notification-controller:v1.4.0 \
+        ghcr.io/fluxcd/image-reflector-controller:v0.33.0 \
+        ghcr.io/fluxcd/image-automation-controller:v0.39.0; do
+        "$CRICTL" pull "$img" >/dev/null 2>&1 || true
+      done ) >/dev/null 2>&1 &
+%{ endif ~}
+
   # ── BACKGROUND pre-pull of the PRIVATE openova-io/openova image set (#3534)
   # The ~19 ghcr.io/openova-io/openova/* images (catalyst-api/ui, the
   # catalyst-*-controllers, catalyst-catalog, projector, marketplace-api,


### PR DESCRIPTION
## Convergence-speed: warm the two slowest cold-pull image sets in the background

On Huawei/kom4dc the throttled ghcr egress serializes convergence behind a couple of large first-pulls:
- **Flux v2.4.0 controllers** (`ghcr.io/fluxcd/*`) — `kustomize-controller:v1.4.0` took **9m59s** on hw162, blowing the 300s flux-readiness wait and serializing the whole reconcile ~26 min behind one image (#809).
- **cnpg `postgresql:16`** (`harbor.openova.io/proxy-ghcr/cloudnative-pg/postgresql:16`) — the 3 shared-pg instances + every per-app CNPG Cluster cold-pull the largest data-plane layer (#3735 Blocker #5).

### Fix
A single Huawei-gated background pre-pull loop, started right after CNI (ahead of `flux install` + the umbrella roll), so the bytes land in containerd while the rest of Phase-1 reconciles:
- public images, **no auth** (the controllers are public; harbor's `proxy-ghcr` is an anonymous cache for public upstreams);
- **idempotent + non-fatal** (`crictl pull … || true`, detached) — kubelet still pulls on demand;
- **dedups** against flux-install's + the pod's own pulls.

The postgresql ref is the exact kyverno-rewritten path a fresh prov's pod uses (verified live on hw163 `shared-pg-1`).

### Validation
- `lint-cloudinit.sh both` → dash -n clean (38 huawei runcmd items).
- Postgresql line is Huawei-gated → Hetzner byte budget unaffected.

`Refs #809 #3735`

🤖 Generated with [Claude Code](https://claude.com/claude-code)