### PR TITLE
fix(bp-mgmt-vcluster): host catalyst-platform reaches gitea-in-vcluster via replicateServices.toHost — 0.2.15 (#3642)

### DIFF
--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -105,7 +105,13 @@ spec:
       # `shared-pg[-b|-c]-rw.shared-data.svc.cluster.local` RESOLVES inside the
       # vCluster — keycloak-0 CrashLooped `no such host` on hw163 without it
       # (the #3642-in-vcluster vs NorthStar-#2 host-shared-pg DNS collision).
-      version: 0.2.14
+      # 0.2.15 (#3642 5th layer): networking.replicateServices.toHost exports the
+      # in-vCluster gitea-http back to the host gitea/gitea-http Service so the
+      # HOST-side bp-catalyst-platform gitea-token mint hook + catalyst-api
+      # resolve gitea-http.gitea.svc.cluster.local — else the console pre-install
+      # hook CrashLoops `catalyst-gitea-token not found` and the console never
+      # installs (root-caused live hw163).
+      version: 0.2.15
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.14
+  version: 0.2.15
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -157,7 +157,17 @@ name: bp-mgmt-vcluster
 # the host shared-pg FQDN resolves natively inside vc-mgmt (the Pod is a real
 # host pod → ClusterIP reachable; only the NAME was missing). Additive,
 # values-only; zero per-app special-casing (#3642 DoD-6).
-version: 0.2.14
+#
+# 0.2.15 (#3642 host→vCluster gitea reachability, hw163 2026-06-18, 5th layer):
+# the MIRROR of 0.2.14. bp-catalyst-platform stays HOST-side but its in-cluster
+# gitea consumers (the `catalyst-gitea-token` mint hook, the tenants-repo
+# bootstrap pre-install hook, catalyst-api's CATALYST_GITEA_URL) dial
+# `gitea-http.gitea.svc.cluster.local:3000` on the host — which after #3642 has
+# only the CNPG DB (gitea-http runs inside vc-mgmt). Token never mints → console
+# pre-install hook `secret "catalyst-gitea-token" not found` → install times out
+# → console never comes up. Adds `networking.replicateServices.toHost` exporting
+# the in-vCluster gitea-http back to the host `gitea/gitea-http` Service.
+version: 0.2.15
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -350,14 +350,34 @@ vcluster:
       # real gitea-http runs INSIDE vc-mgmt → the host name does not resolve →
       # the token never mints → the bp-catalyst-platform pre-install hook
       # CrashLoops `secret "catalyst-gitea-token" not found` → install times out
-      # → CONSOLE NEVER COMES UP (root-caused live on hw163, 2026-06-18, the 5th
-      # convergence layer). replicateServices.toHost exports the in-vCluster
-      # gitea-http back to the HOST `gitea/gitea-http` Service so every host
-      # consumer resolves it natively — exactly symmetric to the shared-pg
-      # fromHost mirror above (there vCluster→host; here host→vCluster).
+      # → CONSOLE NEVER COMES UP (root-caused live on hw163, 2026-06-18).
+      #
+      # WALK-TIME EXTENSION (#3642 audit, 2026-06-18): `sync.toHost.services`
+      # only projects in-vCluster Services to the host as MANGLED
+      # `<svc>-x-<ns>-x-mgmt-vcluster.mgmt.svc` — the plain `<svc>.<ns>.svc` does
+      # NOT exist host-side (zero ExternalName aliases anywhere). So THREE host
+      # name families are stranded, dialled by every host-side controller, the
+      # gitea-token mint, AND the sso-bridge reconciler (THE walk-blocker — it
+      # mints every app's keycloak client + writes secret/sso/<app>; with these
+      # unreachable, all 6 SSO ExternalSecrets stay empty and zero-login
+      # collapses):
+      #   1. gitea-http.gitea.svc:3000  — org/app/env/blueprint controllers,
+      #      the catalyst-gitea-token mint, catalog-sovereign GitRepository.
+      #   2. keycloak.keycloak.svc:8080 — catalyst-api CATALYST_KC_ADDR,
+      #      org-controller keycloakAddr, sso-bridge KC_ADDR.
+      #   3. openbao.openbao.svc:8200   — catalyst-api openbaoAddr, sso-bridge
+      #      OPENBAO_ADDR (writes secret/sso/<app>).
+      # replicateServices.toHost exports each in-vCluster Service back to the
+      # HOST under its PLAIN name so every host consumer resolves it natively —
+      # symmetric to the shared-pg fromHost mirror above (there vCluster→host;
+      # here host→vCluster). One export per family closes ~15 walk-time wires.
       toHost:
         - from: gitea/gitea-http
           to: gitea/gitea-http
+        - from: keycloak/keycloak
+          to: keycloak/keycloak
+        - from: openbao/openbao
+          to: openbao/openbao
 
   # sync — what host-cluster resources sync into the vCluster. The
   # MGMT vCluster needs services + endpoints + configmaps + secrets

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -339,6 +339,25 @@ vcluster:
           to: shared-data/shared-pg-c-rw
         - from: shared-data/shared-pg-c-ro
           to: shared-data/shared-pg-c-ro
+      # ── #3642 host→vCluster gitea reachability (the MIRROR of fromHost above) ──
+      # #3642 moved gitea INTO vc-mgmt, but bp-catalyst-platform stays HOST-side
+      # (catalyst-system). Its in-cluster gitea consumers — the
+      # `catalyst-gitea-token` mint hook (chart catalyst-gitea-token-secret.yaml:
+      # `url: http://gitea-http.gitea.svc.cluster.local:3000`), the
+      # `catalyst-gitea-tenants-repo-bootstrap` pre-install hook, and catalyst-api
+      # itself (CATALYST_GITEA_URL) — dial `gitea-http.gitea.svc.cluster.local`
+      # on the HOST. After #3642 the host `gitea` ns has only the CNPG DB; the
+      # real gitea-http runs INSIDE vc-mgmt → the host name does not resolve →
+      # the token never mints → the bp-catalyst-platform pre-install hook
+      # CrashLoops `secret "catalyst-gitea-token" not found` → install times out
+      # → CONSOLE NEVER COMES UP (root-caused live on hw163, 2026-06-18, the 5th
+      # convergence layer). replicateServices.toHost exports the in-vCluster
+      # gitea-http back to the HOST `gitea/gitea-http` Service so every host
+      # consumer resolves it natively — exactly symmetric to the shared-pg
+      # fromHost mirror above (there vCluster→host; here host→vCluster).
+      toHost:
+        - from: gitea/gitea-http
+          to: gitea/gitea-http
 
   # sync — what host-cluster resources sync into the vCluster. The
   # MGMT vCluster needs services + endpoints + configmaps + secrets


### PR DESCRIPTION
## 5th convergence layer — root-caused live on hw163 (2026-06-18). The MIRROR of #3808.

hw163 advanced to **56/64** after the #3808 shared-pg DNS fix (keycloak now connects to shared-pg), but the console never came up: `bp-catalyst-platform` install wedged in an install→fail→retry loop on a **pre-install hook stuck in `CreateContainerConfigError`**:

```
Error: secret "catalyst-gitea-token" not found
... Helm install failed: failed pre-install: timed out waiting for the condition
```

### Root cause
`bp-catalyst-platform` stays **HOST-side** (catalyst-system), but #3642 moved **gitea into vc-mgmt**. The chart's `catalyst-gitea-token` mint hook (`catalyst-gitea-token-secret.yaml`: `url: http://gitea-http.gitea.svc.cluster.local:3000`), the `catalyst-gitea-tenants-repo-bootstrap` pre-install hook, and catalyst-api itself (`CATALYST_GITEA_URL`) all dial `gitea-http.gitea.svc.cluster.local` **on the host**. After #3642 the host `gitea` namespace holds only the CNPG DB — `gitea-http` runs inside vc-mgmt — so the host name doesn't resolve, the token never mints, and the console install times out (verified live: host `gitea` ns has no `gitea-http` svc; the real one is `mgmt/gitea-http-x-gitea-x-mgmt-vcluster`).

### Fix — the exact mirror of #3808
#3808 added `networking.replicateServices.fromHost` so vCluster apps reach the host shared-pg (vCluster→host). This adds `networking.replicateServices.toHost` exporting the in-vCluster `gitea-http` back to the host `gitea/gitea-http` Service (host→vCluster), so every host-side gitea consumer resolves it natively. Additive, values-only, render.sh green.

### Convergence trajectory (each prov one layer deeper)
| prov | result |
|---|---|
| hw161 | 0 HRs |
| hw162 | keycloak Init:0/2 (no secret) |
| hw163 (#3808) | keycloak 1/1 connected to shared-pg → 56/64 → console install wedged on gitea-token (**this PR**) |

Live hw163 was un-wedged with an equivalent host `gitea-http` ExternalName; this bakes the durable fix for every future prov.

`Refs #3642`

🤖 Generated with [Claude Code](https://claude.com/claude-code)