### PR TITLE
fix(bp-keycloak/bp-catalyst-platform): host-bridge keycloak SA/pin-broker/master-admin creds stranded in vc-mgmt after #3642 — restores zero-login SSO (#3813)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -198,7 +198,7 @@ spec:
       # chart renders the canonical apps.openova.io/v1 Application CR for
       # this slot's HelmRelease so the console /apps list, per-app Topology
       # tab + showback resolve keycloak (no more "no Application CR").
-      version: 1.4.32
+      version: 1.4.33
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1035,7 +1035,7 @@ spec:
             # 1.4.675 — #3383 ORGANIZATIONS rename (ZERO behavior change), rebased over main's 1.4.674: ns sme→org-services, templates/sme-services→templates/org-services, Secret sme-secrets→org-services-secrets (dual-rendered one release, byte-identical JWT_SECRET), .sme.svc→.org-services.svc hosts, catalyst-system→org-services CNP allow. Wire-stable: CNPG sme-pg + sme-pg-app, DBs sme_auth/sme_billing/sme_documents, Tier "sme", GitOps branch/path sme-tenants, .Values.sme* keys.
             # 1.4.677 — #3383 publish-gate fix (Chart.yaml + tests/baseline-cnp-allowlist.sh): stale Case 5c asserted the pre-rename `sme` egress namespace (1.4.675 renamed it `org-services`) → chart/tests/*.sh failed → 1.4.675/676 never reached ghcr.
             # PIN-BACK to 1.4.674 (last PUBLISHED on ghcr): 1.4.675/676/677 are not published yet (the 1.4.677 publish lands in a SEPARATE push to avoid rolling the mothership mid-prov and abandoning the in-flight hw159), so fresh-prov hw159 pins the last-published chart — the full FUNCTIONAL train (hook-fix #3780, object-model #3786, topology #3784, funnel #3376, per-Org Flux loop #3687, RBAC #3664-via-#3376); missing ONLY the cosmetic #3707 sme→Organization rename. Re-bump this slot to 1.4.677 for the NEXT prov once it is on ghcr.
-      version: 1.4.684
+      version: 1.4.686
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform
@@ -1153,6 +1153,25 @@ spec:
       realm: sovereign
       clientId: catalyst-ui
       skipClientUpsert: true
+    # ── Keycloak credentials host bridge realm override (#3813, Refs #3642) ──
+    # The host bridge (templates/catalyst-keycloak-credentials-host-bridge.yaml)
+    # bakes the realm name into catalyst-kc-sa-credentials.realm. It MUST
+    # equal bp-keycloak slot-09 sovereignRealm.name, which is the
+    # tenant-short-name on a franchised Sovereign — threaded here from the
+    # SAME postBuild.substitute var (${SOVEREIGN_REALM_NAME:=sovereign}) so
+    # the catalyst-api SA token's realm matches Keycloak's. The chart's
+    # baked-in default is `sovereign`; this envsubst override on the slot HR
+    # manifest carries the real per-Sovereign value (the substitution runs on
+    # this manifest, not on the OCI-baked chart values). All other
+    # keycloakHostBridge knobs (release coords, host addr, bitnami source)
+    # keep their chart defaults — they match the slot-09 keycloak HR
+    # releaseName/targetNamespace (`keycloak`) + the MGMT vCluster syncer
+    # mangle convention. NB: if a future overlay sets
+    # sso.tier1ClientSecretSalt on slot-09 keycloak it MUST be mirrored onto
+    # this chart's .Values.sso.tier1ClientSecretSalt too, or the derived SA
+    # secret diverges (both default empty today — in sync).
+    keycloakHostBridge:
+      realmName: ${SOVEREIGN_REALM_NAME:=sovereign}
     # G87 #2634: multi-region CNPG instances default (1 single-region, 2 multi).
     # Applies to org-services' CNPG cluster (sme-pg).
     # #2840-followup (2026-06-03): the chart reads `.Values.smePostgres.

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.32
+  version: 1.4.33
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -298,7 +298,27 @@ name: bp-keycloak
 # readTopology serves spec.placement VERBATIM to the Topology tab + the
 # Instances-table chip, so the legacy spelling leaked the banned word to the
 # operator (hw159 #3375).
-version: 1.4.32
+# 1.4.33 (#3813, Refs #3642, 2026-06-18): the catalyst-api-server SA client
+# secret (the value baked into the sovereign realm import's
+# `catalyst-api-server` client + the catalyst-kc-sa-credentials Secret) is
+# now derived DETERMINISTICALLY via the new
+# `bp-keycloak.catalystApiServerClientSecret` helper instead of
+# `randAlphaNum 32`. After #3642 keycloak runs in the mgmt vCluster, so the
+# Secret + the reflector that mirrored it to the HOST catalyst-system /
+# sso-bridge are both inside vc-mgmt — the host catalyst-api never sees the
+# credential and /auth/handover 401s (zero-login dead; verified live hw163).
+# The durable fix re-creates catalyst-kc-sa-credentials HOST-side from a
+# bridge in bp-catalyst-platform; for that bridge to carry the SAME value
+# baked into Keycloak the value must be REPRODUCIBLE from the keycloak
+# release coordinates (release name + namespace), which a random string is
+# not. The helper uses the SAME SHA256-seed seam as the existing
+# tier1ClientSecret / pinBrokerClientSecret derivations (namespace+release
+# scoped → unique per Sovereign; honours .sso.tier1ClientSecretSalt). The
+# upgrade-lookup branch still wins on an already-installed realm, so no
+# rotation on existing envs. Default single-region render byte-identical
+# except the SA secret value (was random → now derived; both 64/32-char
+# opaque strings, no consumer cares about the literal). Refs #3642 #3736.
+version: 1.4.33
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/_helpers.tpl
+++ b/platform/keycloak/chart/templates/_helpers.tpl
@@ -92,6 +92,61 @@ KV → ExternalSecret → per-app namespace.
 {{- end -}}
 
 {{/*
+#3813 (Refs #3642) — catalyst-api-server SA client secret, DETERMINISTIC.
+
+WHY THIS HELPER EXISTS
+======================
+#3642 moved bp-keycloak INTO the mgmt vCluster (vc-mgmt). The
+`catalyst-kc-sa-credentials` Secret + the matching `catalyst-api-server`
+realm-import client `secret` are emitted by configmap-sovereign-realm.yaml
+into the keycloak chart's `.Release.Namespace` — which is now a namespace
+INSIDE vc-mgmt, and the emberstack reflector that mirrored them to the HOST
+`catalyst-system` + `sso-bridge` also runs inside vc-mgmt. So the host
+catalyst-api / organization-controller / sso-bridge-reconciler never see
+the credential, and `/auth/handover` 401s (verified live hw163 2026-06-18).
+
+The durable fix re-creates `catalyst-kc-sa-credentials` HOST-side from a
+bridge in products/catalyst/chart. For that bridge to carry the SAME secret
+the in-vCluster realm import baked into Keycloak, the value MUST be
+reproducible from inputs the host bridge also knows (the keycloak release
+name + namespace) — a `randAlphaNum 32` (the prior behaviour, line ~94 of
+configmap-sovereign-realm.yaml) is NOT reproducible across two charts.
+
+So this helper derives the SA client secret deterministically, exactly like
+`bp-keycloak.tier1ClientSecret` / `bp-keycloak.pinBrokerClientSecret`
+already do for the per-app + pin-broker clients. The host bridge passes the
+keycloak release coordinates as values and re-derives the identical string.
+
+SECRET-VALUE RESOLUTION ORDER (preserved from the prior template):
+  1. operator override .Values.catalystApiServerClientSecret (overlay) —
+     handled by the CALLER, not here (kept first-wins in the realm template).
+  2. existing in-cluster Secret (helm lookup) — idempotent on upgrade,
+     handled by the CALLER.
+  3. this deterministic derivation — replaces the old randAlphaNum 32 for
+     genuine first-install, so the host bridge can reproduce it.
+
+The seed is namespace + release-scoped so each Sovereign (and each release
+name) gets a UNIQUE value — never a shared default across deployments —
+and honours the same .sso.tier1ClientSecretSalt rotation knob as the other
+derived secrets so an operator can atomically rotate on upgrade.
+
+Expects a dict: {ctx: .} (the keycloak chart root context). The host
+bridge constructs the same dict with a synthetic context carrying the
+keycloak Release.Name/Release.Namespace via values, so both derive equal.
+*/}}
+{{- define "bp-keycloak.catalystApiServerClientSecret" -}}
+{{- $ctx := .ctx -}}
+{{- $relName := .releaseName | default $ctx.Release.Name -}}
+{{- $relNs := .releaseNamespace | default $ctx.Release.Namespace -}}
+{{- $salt := default "" (((.ctx.Values).sso).tier1ClientSecretSalt) -}}
+{{- $seed := printf "%s|%s|catalyst-api-server-sa" $relName $relNs -}}
+{{- if ne $salt "" -}}
+{{- $seed = printf "%s|%s" $seed $salt -}}
+{{- end -}}
+{{- $seed | sha256sum -}}
+{{- end -}}
+
+{{/*
 G117.5 W3.D1 #2744 — Tier-2 silent-SSO Client secret (sovereign realm).
 
 Same shape as `bp-keycloak.tier1ClientSecret` but with a distinct seed

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -89,9 +89,25 @@ tenant emit; tenant takes precedence here.
   {{- $saSecret = .Values.catalystApiServerClientSecret -}}
 {{- end -}}
 {{- if not $saSecret -}}
-  {{- /* Genuine first install — generate 32-char random per
-         INVIOLABLE-PRINCIPLES #10. */ -}}
-  {{- $saSecret = randAlphaNum 32 -}}
+  {{- /* #3813 (Refs #3642): genuine first install. Was `randAlphaNum 32`,
+         but after #3642 keycloak runs in vc-mgmt, so this Secret + realm
+         client are stranded inside the vCluster — the host catalyst-api /
+         organization-controller / sso-bridge never see them. The durable
+         fix re-creates catalyst-kc-sa-credentials HOST-side from a bridge
+         in products/catalyst/chart; for that bridge to carry the SAME
+         value baked here it must be REPRODUCIBLE from the keycloak release
+         coordinates, which a random string is not. The
+         `bp-keycloak.catalystApiServerClientSecret` helper derives it
+         deterministically (same SHA256 seam as tier1ClientSecret /
+         pinBrokerClientSecret already use) so the host bridge re-derives
+         the identical secret. Still namespace+release-scoped (unique per
+         Sovereign) + honours .sso.tier1ClientSecretSalt rotation. The
+         lookup branch above still wins on upgrade so an already-installed
+         realm keeps its stored secret; this only sets the first-install
+         value. Per INVIOLABLE-PRINCIPLES #10 no plaintext credential is
+         committed — the value is computed at render time, never echoed to
+         chart source or disk. */ -}}
+  {{- $saSecret = include "bp-keycloak.catalystApiServerClientSecret" (dict "ctx" .) -}}
 {{- end -}}
 {{- /* Keycloak base URL — issue #781.
        This URL is consumed EXCLUSIVELY by the in-cluster catalyst-api Pod

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2776,7 +2776,33 @@ name: bp-catalyst-platform
 # is byte-unchanged (org-services egress was already correct — the test was stale, not
 # the chart). Unblocks the 1.4.67x train (hook-fix #3780 + object-model #3786 + topology
 # vocab #3784 + ORGANIZATIONS rename #3707 + RBAC #3664) for fresh-prov hw159.
-version: 1.4.684
+# 1.4.686 — #3813 (Refs #3642): host-bridge the keycloak-produced catalyst
+# credentials stranded inside vc-mgmt. #3642 moved bp-keycloak into the mgmt
+# vCluster; the keycloak chart emits catalyst-kc-sa-credentials /
+# catalyst-pin-broker-credentials / catalyst-kc-master-admin-credentials into
+# its OWN (now in-vCluster) namespace + relies on the emberstack reflector to
+# mirror them to the HOST catalyst-system + sso-bridge — but that reflector
+# now runs inside vc-mgmt too, so the host copies never appear. Host
+# catalyst-system was MISSING all of them → catalyst-api CATALYST_KC_REALM
+# empty → /auth/handover 401 (zero-login dead, North Star #3);
+# organization-controller CrashLoopBackOff; sso-bridge-reconciler
+# CreateContainerConfigError (root-caused live hw163 2026-06-18). NEW
+# templates/catalyst-keycloak-credentials-host-bridge.yaml re-creates the
+# three Secrets directly in the HOST `keycloak` ns (slot-09, host-side) with
+# the reflector annotations the keycloak chart already uses, so the running
+# HOST reflector mirrors them to catalyst-system + sso-bridge and every
+# downstream host lookup (catalyst-openova-kc-credentials,
+# catalyst-organization-controller-keycloak) renders exactly as pre-#3642.
+# The SA + pin-broker client secrets are re-derived with the SAME
+# deterministic sha256 seeds bp-keycloak 1.4.33 uses (so they byte-match what
+# the in-vCluster realm import baked into Keycloak — no cross-cluster read);
+# the master password is read from the host-mirrored bitnami secret via
+# lookup; the addr is the host-routable syncer-mirrored Service. Gated on
+# keycloakHostBridge.enabled (default true; flip false on Catalyst-Zero /
+# host-side keycloak). Catalyst-Zero render byte-unchanged when disabled.
+# Requires bp-keycloak ≥1.4.33 for the deterministic SA secret. Refs #3642
+# #3736.
+version: 1.4.686
 # 1.4.675 — #3383 ORGANIZATIONS rename (ZERO behavior change), rebased over
 # main's 1.4.674 (#3376 funnel + #3700/#3687 per-Org Flux loop + #3763
 # gitea-flux-auth-sync poll). The Organization-provisioning mesh's K8s namespace

--- a/products/catalyst/chart/templates/catalyst-keycloak-credentials-host-bridge.yaml
+++ b/products/catalyst/chart/templates/catalyst-keycloak-credentials-host-bridge.yaml
@@ -1,0 +1,252 @@
+{{- /*
+Host-side bridge for the keycloak-produced catalyst credentials (#3813,
+Refs #3642).
+
+WHY THIS FILE EXISTS
+====================
+#3642 relocated bp-keycloak INTO the mgmt vCluster (vc-mgmt). The keycloak
+chart emits three credential Secrets that the HOST control plane consumes:
+
+  1. catalyst-kc-sa-credentials       (configmap-sovereign-realm.yaml) —
+     the catalyst-api-server OIDC service-account creds. Host consumers:
+       • catalyst-api  (CATALYST_KC_ADDR/REALM/SA_CLIENT_ID/SA_CLIENT_SECRET,
+         api-deployment.yaml) — without it /auth/handover 401s with
+         "server misconfiguration: keycloak not configured".
+       • organization-controller (catalyst-organization-controller-keycloak,
+         a host template that LOOKS UP keycloak/catalyst-kc-sa-credentials).
+       • catalyst-openova-kc-credentials (PIN-auth) — same host lookup.
+       • bp-sso-bridge reconciler (sso-bridge ns, KC_ADDR + KC_SA_*).
+  2. catalyst-pin-broker-credentials  (pin-broker-secret.yaml) — the
+     catalyst-pin OIDC broker client secret; catalyst-api uses it to back
+     the /oidc/* endpoints the realm's catalyst-pin IdP calls.
+  3. catalyst-kc-master-admin-credentials (configmap-sovereign-realm.yaml) —
+     the bitnami master `admin` creds bp-sso-bridge needs to POST
+     /admin/realms (per-Org realm creation).
+
+The keycloak chart writes all three into its OWN `.Release.Namespace`
+(now a namespace INSIDE vc-mgmt) and relies on the emberstack reflector to
+mirror them HOST-side into catalyst-system + sso-bridge. After #3642 BOTH
+the Secrets AND that reflector run inside vc-mgmt, so the host copies never
+appear:
+
+  • host sso-bridge/catalyst-kc-sa-credentials + …-master-admin-credentials
+    are the bp-sso-bridge reflector STUBS — 0 keys, never filled.
+  • host catalyst-system is MISSING catalyst-kc-sa-credentials,
+    catalyst-pin-broker-credentials, catalyst-openova-kc-credentials,
+    catalyst-organization-controller-keycloak (the last two are host
+    templates gated on `lookup keycloak/catalyst-kc-sa-credentials` → nil →
+    they render nothing).
+
+Cascade root-caused live on hw163 (deployment 83674048ff592704, 2026-06-18):
+  sso-bridge-reconciler CreateContainerConfigError → never registers the
+  console's KC clients; organization-controller CrashLoopBackOff;
+  catalyst-api CATALYST_KC_REALM empty → /auth/handover 401 → zero-login
+  (North Star #3) dead, no walk possible.
+
+WHY A HOST-SIDE BRIDGE (not a vCluster sync, not the reflector)
+===============================================================
+The #3811 gitea-admin-secret bridge Helm-`lookup`s a syncer-MANGLED HOST
+copy and renames it — but that only works because the gitea pod MOUNTS
+gitea-admin-secret, so the vCluster `sync.toHost.secrets` mirror carries it
+host-ward as `gitea-admin-secret-x-gitea-x-mgmt-vcluster`. vCluster's
+toHost secret sync ONLY mirrors secrets that are MOUNTED by a vc-mgmt pod
+(verified live: the host `mgmt` ns has the mangled bitnami `keycloak`,
+`gitea-admin-secret`, `harbor-core`, `grafana` … secrets — all mounted —
+but NOT catalyst-kc-sa-credentials / catalyst-pin-broker-credentials, which
+NO vc-mgmt pod mounts; only the HOST catalyst-api/sso-bridge consume them).
+So there is NOTHING host-side to look up or rename for these — the gitea
+seam cannot apply.
+
+Instead this bridge RE-CREATES the three Secrets directly in the HOST
+`keycloak` namespace (created host-side by bootstrap-kit slot 09, before
+this chart installs), carrying the SAME reflector annotations the keycloak
+chart's own templates use. The already-running HOST reflector then mirrors
+them into catalyst-system + sso-bridge, and every downstream host lookup
+(catalyst-openova-kc-credentials, catalyst-organization-controller-keycloak)
+renders exactly as it did pre-#3642. The pre-#3642 host contract — a
+populated `keycloak/catalyst-kc-sa-credentials` on the host — is restored
+with ZERO change to catalyst-api, the organization-controller, or
+bp-sso-bridge.
+
+REPRODUCING THE SAME SECRET VALUE (the load-bearing piece)
+==========================================================
+For the SA + pin-broker client secrets the bridge must carry the EXACT
+value the in-vCluster realm import baked into Keycloak, or catalyst-api's
+client_credentials grant / the broker callback fail `invalid_client`.
+bp-keycloak 1.4.33 (#3813) makes the SA client secret DETERMINISTIC
+(`bp-keycloak.catalystApiServerClientSecret` = sha256 of
+`<kcRelease>|<kcNamespace>|catalyst-api-server-sa`), and the pin-broker
+secret was ALREADY deterministic on first install
+(`bp-keycloak.pinBrokerClientSecret` = sha256 of
+`<kcRelease>|<kcNamespace>|catalyst-pin-broker`). This chart vendors the
+identical sha256 seeds below, parameterised on the keycloak release
+coordinates via .Values.keycloakHostBridge.* (defaults `keycloak`/`keycloak`
+— the slot-09 releaseName + targetNamespace). So both the in-vCluster realm
+import AND this host bridge independently derive the SAME strings with no
+cross-cluster read. The .sso.tier1ClientSecretSalt knob is mirrored too so
+an operator rotating the keycloak salt rotates this bridge in lockstep.
+
+The master-admin password is the bitnami `admin-password` — genuinely
+RANDOM (bitnami-generated, not derivable). But the bitnami `keycloak` Secret
+IS mounted by keycloak-0, so vCluster DOES mirror it host-side as
+`keycloak-x-keycloak-x-mgmt-vcluster` (ns `mgmt`, verified live, key
+`admin-password`). The bridge Helm-`lookup`s that mangled host secret for
+the master password (the one value it can't derive) — the SAME seam #3811
+uses for gitea.
+
+ADDR — the host-routable Keycloak URL
+=====================================
+The keycloak chart wrote addr=http://<release>.<ns>.svc.cluster.local
+(=http://keycloak.keycloak.svc) — correct when keycloak ran HOST-side, but
+that name does NOT resolve from the host now that keycloak lives in vc-mgmt.
+From the host the Keycloak Service is the syncer-mirrored
+`keycloak-x-keycloak-x-mgmt-vcluster.mgmt.svc.cluster.local:80` (verified
+live: it serves the sovereign-realm OIDC discovery doc). The bridge writes
+THAT host-routable addr so catalyst-api's in-cluster OAuth calls + the
+sso-bridge reconciler reach Keycloak. (Browsers are unaffected — they use
+auth.<fqdn> via the host Gateway HTTPRoute, host-bridged by slot 09.)
+
+GATING
+======
+Rendered only when .Values.keycloakHostBridge.enabled (default true; flip
+false on Catalyst-Zero / contabo, and on any topology where keycloak stays
+HOST-side and emits these Secrets natively — there the bridge would collide
+with the chart's own output). Independent of giteaAdminBridge (#3811). Per
+INVIOLABLE-PRINCIPLES #10 no plaintext credential is committed: the derived
+secrets are computed at render time; the master password is read back via
+lookup from the host-mirrored bitnami Secret — none appear in chart source
+or rendered manifests on disk. Per #4 (never hardcode) the keycloak release
+coordinates + destination namespace flow through .Values.keycloakHostBridge.*.
+*/}}
+{{- if .Values.keycloakHostBridge.enabled -}}
+{{- $kcRelease := .Values.keycloakHostBridge.keycloakReleaseName | default "keycloak" -}}
+{{- $kcNamespace := .Values.keycloakHostBridge.keycloakReleaseNamespace | default "keycloak" -}}
+{{- $destNs := .Values.keycloakHostBridge.destNamespace | default "keycloak" -}}
+{{- $realmName := .Values.keycloakHostBridge.realmName | default "sovereign" -}}
+{{- $salt := default "" (((.Values).sso).tier1ClientSecretSalt) -}}
+{{- /* ── host-routable Keycloak addr ──────────────────────────────────────
+       Default = the vCluster-syncer-mirrored host Service (the syncer
+       mangle <innerSvc>-x-<innerNs>-x-<vclusterRelease> in the syncer host
+       namespace). For the MGMT vCluster (releaseName mgmt-vcluster,
+       hostNamespace mgmt, inner svc+ns keycloak) →
+       keycloak-x-keycloak-x-mgmt-vcluster.mgmt.svc.cluster.local. Overridable
+       so a topology where keycloak's host Service has a different name can
+       point at it without forking. */ -}}
+{{- $kcAddr := .Values.keycloakHostBridge.keycloakAddr | default "http://keycloak-x-keycloak-x-mgmt-vcluster.mgmt.svc.cluster.local" -}}
+{{- /* ── DETERMINISTIC catalyst-api-server SA client secret ──────────────
+       MUST byte-match bp-keycloak's bp-keycloak.catalystApiServerClientSecret
+       (helpers.tpl, 1.4.33): sha256(<kcRelease>|<kcNamespace>|catalyst-api-server-sa
+       [|salt]). */ -}}
+{{- $saSeed := printf "%s|%s|catalyst-api-server-sa" $kcRelease $kcNamespace -}}
+{{- if ne $salt "" -}}{{- $saSeed = printf "%s|%s" $saSeed $salt -}}{{- end -}}
+{{- $saSecret := $saSeed | sha256sum -}}
+{{- /* ── DETERMINISTIC catalyst-pin broker client secret ────────────────
+       MUST byte-match bp-keycloak's bp-keycloak.pinBrokerClientSecret
+       first-install branch: sha256(<kcRelease>|<kcNamespace>|catalyst-pin-broker).
+       NB the pin-broker helper does NOT fold in the salt (it predates the
+       salt knob), so this seed must NOT add the salt either. */ -}}
+{{- $pinSecret := (printf "%s|%s|catalyst-pin-broker" $kcRelease $kcNamespace) | sha256sum -}}
+{{- /* ── master-admin password — read the host-mirrored bitnami Secret ───
+       The ONE value that is genuinely random (bitnami-generated). The
+       bitnami `keycloak` Secret IS mounted by keycloak-0, so vCluster
+       mirrors it host-side as `keycloak-x-keycloak-x-mgmt-vcluster` (ns
+       `mgmt`). Lookup it for the admin-password. If absent (e.g. before
+       keycloak-0 starts on a very fresh prov) we emit an EMPTY
+       master-realm-admin-password — the bp-sso-bridge reconciler logs
+       "KC master password unset" and sleeps the tick; the next Flux
+       reconcile of this chart (interval) back-fills once the bitnami
+       mirror lands. Same soft-degrade the keycloak chart's own
+       master-admin template documents. */ -}}
+{{- $bitnamiNs := .Values.keycloakHostBridge.bitnamiSecretNamespace | default "mgmt" -}}
+{{- $bitnamiName := .Values.keycloakHostBridge.bitnamiSecretName | default "keycloak-x-keycloak-x-mgmt-vcluster" -}}
+{{- $bitnami := lookup "v1" "Secret" $bitnamiNs $bitnamiName -}}
+{{- $masterAdminUser := .Values.keycloakHostBridge.masterAdminUser | default "admin" -}}
+{{- $masterAdminPassword := "" -}}
+{{- if and $bitnami $bitnami.data (index $bitnami.data "admin-password") -}}
+{{- $masterAdminPassword = index $bitnami.data "admin-password" | b64dec -}}
+{{- end -}}
+{{- $commonLabels := dict
+    "catalyst.openova.io/blueprint" "bp-catalyst-platform"
+    "catalyst.openova.io/component" "keycloak-credentials-host-bridge"
+    "app.kubernetes.io/part-of" "catalyst"
+    "app.kubernetes.io/managed-by" "flux" -}}
+---
+{{- /* 1. catalyst-kc-sa-credentials — keys + reflector targets MUST match
+       platform/keycloak/chart/templates/configmap-sovereign-realm.yaml so
+       the downstream host lookups + api-deployment secretKeyRefs resolve
+       identically to the pre-#3642 contract. */ -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: catalyst-kc-sa-credentials
+  namespace: {{ $destNs }}
+  labels:
+    {{- toYaml $commonLabels | nindent 4 }}
+  annotations:
+    catalyst.openova.io/mirrored-from: "bp-keycloak (#3642 host bridge; SA secret derived deterministically)"
+    catalyst.openova.io/bridge: "keycloak-credentials-host-bridge-3813"
+    # Source-wins on every reconcile; survive helm uninstall so the host
+    # contract is stable across re-installs.
+    helm.sh/resource-policy: keep
+    # Re-publish into catalyst-system (catalyst-api + the two host KC
+    # lookup-templates) AND sso-bridge (the reconciler) — identical target
+    # set to the keycloak chart's own source-side annotations.
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "catalyst-system,sso-bridge"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "catalyst-system,sso-bridge"
+type: Opaque
+stringData:
+  addr: {{ $kcAddr | quote }}
+  realm: {{ $realmName | quote }}
+  client-id: "catalyst-api-server"
+  client-secret: {{ $saSecret | quote }}
+---
+{{- /* 2. catalyst-pin-broker-credentials — mirrored to catalyst-system for
+       catalyst-api's /oidc/* broker backing. Keys match
+       platform/keycloak/chart/templates/pin-broker-secret.yaml. */ -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: catalyst-pin-broker-credentials
+  namespace: {{ $destNs }}
+  labels:
+    {{- toYaml $commonLabels | nindent 4 }}
+  annotations:
+    catalyst.openova.io/mirrored-from: "bp-keycloak (#3642 host bridge; pin-broker secret derived deterministically)"
+    catalyst.openova.io/bridge: "keycloak-credentials-host-bridge-3813"
+    helm.sh/resource-policy: keep
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "catalyst-system"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "catalyst-system"
+type: Opaque
+stringData:
+  client-id: "catalyst-pin"
+  client-secret: {{ $pinSecret | quote }}
+---
+{{- /* 3. catalyst-kc-master-admin-credentials — mirrored to sso-bridge for
+       the POST /admin/realms (per-Org realm create). Keys match
+       platform/keycloak/chart/templates/configmap-sovereign-realm.yaml. */ -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: catalyst-kc-master-admin-credentials
+  namespace: {{ $destNs }}
+  labels:
+    {{- toYaml $commonLabels | nindent 4 }}
+  annotations:
+    catalyst.openova.io/mirrored-from: {{ printf "%s/%s (bitnami admin-password; #3642 host bridge)" $bitnamiNs $bitnamiName | quote }}
+    catalyst.openova.io/bridge: "keycloak-credentials-host-bridge-3813"
+    helm.sh/resource-policy: keep
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "sso-bridge"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "sso-bridge"
+type: Opaque
+stringData:
+  addr: {{ $kcAddr | quote }}
+  master-realm: "master"
+  master-realm-admin-user: {{ $masterAdminUser | quote }}
+  master-realm-admin-password: {{ $masterAdminPassword | quote }}
+{{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -191,6 +191,79 @@ giteaWait:
   # gateway with rapid-fire probes during the cold-start window.
   intervalSeconds: 5
 
+# ─── Keycloak credentials host bridge (#3813, Refs #3642) ──────────────
+# #3642 moved bp-keycloak INTO the mgmt vCluster (vc-mgmt). The keycloak
+# chart emits three credential Secrets the HOST control plane needs —
+# catalyst-kc-sa-credentials (catalyst-api OIDC SA + the two host KC
+# lookup-templates + bp-sso-bridge), catalyst-pin-broker-credentials
+# (catalyst-api /oidc/* broker backing), catalyst-kc-master-admin-
+# credentials (bp-sso-bridge POST /admin/realms) — into its OWN namespace
+# inside vc-mgmt, relying on the emberstack reflector to mirror them to the
+# HOST catalyst-system + sso-bridge. After #3642 BOTH the Secrets AND that
+# reflector run inside vc-mgmt, so the host copies never appear → host
+# catalyst-system is missing all of them → catalyst-api CATALYST_KC_REALM
+# empty → /auth/handover 401 (zero-login dead); organization-controller
+# CrashLoops; sso-bridge-reconciler CreateContainerConfigError (root-caused
+# live hw163, 2026-06-18).
+#
+# templates/catalyst-keycloak-credentials-host-bridge.yaml re-creates the
+# three Secrets directly in the HOST `keycloak` ns (slot-09, host-side)
+# carrying the reflector annotations the keycloak chart already uses, so the
+# running HOST reflector mirrors them to catalyst-system + sso-bridge and
+# every downstream host lookup renders exactly as pre-#3642. The SA + pin-
+# broker client secrets are derived with the SAME deterministic sha256 seeds
+# bp-keycloak 1.4.33 uses (so the value byte-matches what the in-vCluster
+# realm import baked into Keycloak — no cross-cluster read); the master
+# password is read from the host-mirrored bitnami secret via lookup.
+keycloakHostBridge:
+  # Master gate. When false the bridge renders nothing — set false on
+  # Catalyst-Zero (contabo, keycloak-zero host-side) or any topology where
+  # bp-keycloak stays HOST-side and emits these Secrets natively (the bridge
+  # would otherwise collide with the chart's own output). On a franchised
+  # Sovereign (keycloak in vc-mgmt) leave true.
+  enabled: true
+  # The HOST namespace the bridge writes the three Secrets into — MUST be
+  # the namespace the keycloak chart's reflector source + the host
+  # catalyst-openova-kc-credentials / catalyst-organization-controller-
+  # keycloak lookups expect (`keycloak`). Created host-side by bootstrap-kit
+  # slot 09 before this chart installs.
+  destNamespace: keycloak
+  # ── Keycloak release coordinates (deterministic-secret seed inputs) ────
+  # The SA + pin-broker secrets are sha256(<release>|<namespace>|<label>),
+  # the SAME seed bp-keycloak derives. These MUST match the keycloak HR's
+  # releaseName + targetNamespace (bootstrap-kit slot 09: both `keycloak`).
+  # If a topology renames the keycloak release/namespace, move these in
+  # lockstep with the slot-09 releaseName/targetNamespace + the bp-keycloak
+  # helper inputs, or catalyst-api's client_credentials grant fails
+  # invalid_client.
+  keycloakReleaseName: keycloak
+  keycloakReleaseNamespace: keycloak
+  # The sovereign realm name baked into catalyst-kc-sa-credentials.realm —
+  # MUST match bp-keycloak slot-09 sovereignRealm.name (default `sovereign`;
+  # a tenant-short-name Sovereign sets SOVEREIGN_REALM_NAME). The
+  # bootstrap-kit slot-13 HR `values:` block overrides this with
+  # ${SOVEREIGN_REALM_NAME:=sovereign} (the postBuild.substitute envsubst
+  # runs on the slot HR manifest, not on this baked-in chart default), so
+  # the two never drift. This `sovereign` default is the correct value for
+  # the common case + Catalyst-Zero.
+  realmName: sovereign
+  # ── Host-routable Keycloak Service URL (addr field) ────────────────────
+  # keycloak now lives in vc-mgmt; from the HOST its Service is the
+  # vCluster-syncer-mirrored `<innerSvc>-x-<innerNs>-x-<vclusterRelease>` in
+  # the syncer host namespace (mgmt). For the MGMT vCluster that resolves to
+  # keycloak-x-keycloak-x-mgmt-vcluster.mgmt.svc.cluster.local (verified live
+  # serving the sovereign-realm OIDC discovery doc). The in-vCluster name
+  # `keycloak.keycloak.svc` does NOT resolve from the host. Browsers are
+  # unaffected (they use auth.<fqdn> via the host Gateway, slot-09 bridged).
+  keycloakAddr: http://keycloak-x-keycloak-x-mgmt-vcluster.mgmt.svc.cluster.local
+  # ── Source of the master admin password (the one non-derivable value) ──
+  # The bitnami `keycloak` Secret IS mounted by keycloak-0, so vCluster
+  # mirrors it host-side under the syncer-mangled name in ns `mgmt`. The
+  # bridge looks it up for `admin-password`.
+  bitnamiSecretNamespace: mgmt
+  bitnamiSecretName: keycloak-x-keycloak-x-mgmt-vcluster
+  masterAdminUser: admin
+
 # ─── Multi-zone parent domains (issue #827, parent epic #825) ──────────
 # A franchised Sovereign supports N parent zones, NOT one. The operator
 # brings 1+ parent domains at signup (`omani.works` for own use,


### PR DESCRIPTION
## What this fixes

The **zero-login SSO walk gate** after #3642. #3642 relocated bp-keycloak INTO the mgmt vCluster (vc-mgmt). The keycloak chart emits three credential Secrets the HOST control plane consumes — `catalyst-kc-sa-credentials` (catalyst-api OIDC service-account + the two host KC lookup-templates + bp-sso-bridge), `catalyst-pin-broker-credentials` (catalyst-api `/oidc/*` broker backing), `catalyst-kc-master-admin-credentials` (bp-sso-bridge `POST /admin/realms`) — into its OWN namespace and relies on the emberstack reflector to mirror them to the HOST `catalyst-system` + `sso-bridge`. After #3642 BOTH the Secrets AND that reflector run inside vc-mgmt, so the host copies never appear and the entire console+SSO bootstrap dies.

## Root cause (verified live on hw163, deployment `83674048ff592704`, 2026-06-18 — not re-diagnosed)

| Symptom | Observed (read-only via mothership kubeconfig) |
|---|---|
| host `catalyst-system/catalyst-kc-sa-credentials` | **NotFound** |
| host `catalyst-system/catalyst-pin-broker-credentials` | **NotFound** |
| host `catalyst-system/catalyst-openova-kc-credentials` | **NotFound** (host template gated on `lookup keycloak/catalyst-kc-sa-credentials` → nil) |
| host `catalyst-system/catalyst-organization-controller-keycloak` | **NotFound** (same host lookup → nil) |
| host `sso-bridge/catalyst-kc-sa-credentials` + `…-master-admin-credentials` | present but **0 keys** (the bp-sso-bridge reflector stubs, never filled) |
| host `catalyst-organization-controller` pod | **CrashLoopBackOff** |
| host `sso-bridge-reconciler` pod | **CreateContainerConfigError** (KC_ADDR/KC_SA_* non-optional from the empty stub) |
| catalyst-api `CATALYST_KC_REALM` | sourced from `catalyst-kc-sa-credentials/realm` → empty → `/auth/handover` 401 `server misconfiguration: keycloak not configured` |

**Why the #3811 gitea seam cannot apply:** vCluster `sync.toHost.secrets` only mirrors secrets **mounted by a vc-mgmt pod** (the host `mgmt` ns carries the mangled bitnami `keycloak`, `gitea-admin-secret`, `harbor-core`, `grafana` … — all mounted — but **not** `catalyst-kc-sa-credentials` / `catalyst-pin-broker-credentials`, which no vc-mgmt pod mounts; only the HOST catalyst-api/sso-bridge consume them). There is nothing host-side to look up or rename.

## Changes (9 files, 2 charts)

**bp-keycloak → 1.4.33** (Chart.yaml + blueprint.yaml + slot-09, lockstep)
1. `_helpers.tpl` — new `bp-keycloak.catalystApiServerClientSecret` deterministic derivation (sha256 of `<kcRelease>|<kcNamespace>|catalyst-api-server-sa`, same seam as `tier1ClientSecret`/`pinBrokerClientSecret`).
2. `configmap-sovereign-realm.yaml` — the SA client secret's first-install branch uses the helper instead of `randAlphaNum 32` (so a host bridge can reproduce the exact value baked into Keycloak). The upgrade-`lookup` branch still wins → no rotation on already-installed realms.

**bp-catalyst-platform → 1.4.686** (Chart.yaml + slot-13, lockstep)
3. **NEW** `templates/catalyst-keycloak-credentials-host-bridge.yaml` — re-creates the three Secrets directly in the HOST `keycloak` ns (created host-side by slot-09) carrying the reflector annotations the keycloak chart already uses, so the running HOST reflector mirrors them into `catalyst-system` + `sso-bridge` and every downstream host lookup renders exactly as pre-#3642. SA + pin-broker secrets re-derived deterministically; master password read from the host-mirrored bitnami secret via `lookup`; `addr` = the host-routable syncer-mirrored Service `keycloak-x-keycloak-x-mgmt-vcluster.mgmt.svc.cluster.local`.
4. `values.yaml` — new `keycloakHostBridge` block (`enabled` default true; release-coords / addr / bitnami-source / realm knobs, never-hardcode per Principle #4). Flip `enabled:false` on Catalyst-Zero / host-side keycloak.
5. slot-13 HR `values:` — threads `${SOVEREIGN_REALM_NAME:=sovereign}` into `keycloakHostBridge.realmName` (the envsubst runs on the slot manifest, not the OCI-baked chart default) so the SA token's realm matches a tenant-short-name Sovereign.

## The load-bearing proof — derived secrets byte-match Keycloak

```
bp-keycloak realm-import catalyst-api-server client "secret": b99ef5848c25c90dc2d1a2992150612bcc1c8dd4daafa8f69d0c2cdbc7fbea89
bp-keycloak catalyst-kc-sa-credentials client-secret:        b99ef5848c25c90dc2d1a2992150612bcc1c8dd4daafa8f69d0c2cdbc7fbea89
bridge-derived SA secret (release=keycloak ns=keycloak):     b99ef5848c25c90dc2d1a2992150612bcc1c8dd4daafa8f69d0c2cdbc7fbea89   ✓
bp-keycloak catalyst-pin IdP "clientSecret":                 88a2d8244b184b0a11c57d0e51631cc1deb7584417cfc057843126a14a5ba434
bridge-derived pin-broker secret:                            88a2d8244b184b0a11c57d0e51631cc1deb7584417cfc057843126a14a5ba434   ✓
```

So catalyst-api's `client_credentials` grant + the broker callback authenticate against the exact value Keycloak stores.

## Gate results

- `helm template` bp-catalyst-platform (default, lookups nil): **rc=0, 120 docs**.
- `helm template --set keycloakHostBridge.enabled=false` (Catalyst-Zero): bridge suppressed (**0 components**).
- `helm template` bp-keycloak (deterministic SA helper): **rc=0, 21 docs**.
- bridge SA + pin secrets **byte-identical** to the keycloak chart's realm-import (above).
- master-admin secret on a fresh prov before the bitnami mirror lands: empty `master-realm-admin-password` (soft-degrade — bridge re-renders on the next Flux tick; same pattern the keycloak chart's own master template documents).
- `go test ./...` in `tests/e2e/bootstrap-kit/` (lockstep + version-sweep + parse + placement): **PASS** (forced, no cache).
- `python3 scripts/render-slot-placement.py check`: **PASS** (64 slots, no drift).
- `platform/keycloak/chart/tests/*.sh` (publish gate): **12/12 PASS**.
- `products/catalyst/chart/tests/*.sh`: **PASS**.

## Residual / honest notes

- **bp-keycloak ≥1.4.33 is required** for the deterministic SA secret — the slot-09 + slot-13 pins are bumped in lockstep so a fresh prov gets both.
- On an **already-running pre-#3642 env** the realm import's upgrade-`lookup` branch keeps its stored (random) SA secret, which would diverge from the bridge's deterministic value. This PR targets the **next fresh prov** (the explicit goal); existing envs were never in the vc-mgmt topology, so no regression. A fresh prov installs keycloak with the deterministic value → bridge matches.
- The bridge's host addr + bitnami-source defaults track the MGMT vCluster syncer mangle convention (`<svc>-x-<innerNs>-x-mgmt-vcluster`, host ns `mgmt`) and the slot-09 keycloak `releaseName`/`targetNamespace` (`keycloak`). They are values knobs, so a topology that renames the vCluster release or the keycloak inner ns adjusts via overlay without forking. If `sso.tier1ClientSecretSalt` is ever set on slot-09 it MUST be mirrored onto this chart's `sso.tier1ClientSecretSalt` too — both default empty today (in sync).

## Do NOT merge yet

A fresh prov is live on the mothership; a mothership-rolling merge would abandon it. Hold until the in-flight prov settles, then merge → re-pin → fresh zero-touch prov to verify the console reaches a **walkable, zero-login-SSO** state.

Refs #3642 #3736 #3813
