### PR TITLE
fix(#3642 fallout): ferretdb sme-database-secret ns + cross-cluster ESO->openbao auth + host-routable store endpoint

### DIFF
--- a/clusters/_template/bootstrap-kit-crs/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit-crs/08-openbao.yaml
@@ -112,3 +112,43 @@ spec:
     remoteRef:
       key: sso/openbao
       property: issuer_url
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openbao-host-token-reviewer
+  namespace: openbao
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao-host-token-reviewer
+    catalyst.openova.io/host-bridge: mgmt
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openbao-host-token-reviewer-auth-delegator
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao-host-token-reviewer
+    catalyst.openova.io/host-bridge: mgmt
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: openbao-host-token-reviewer
+  namespace: openbao
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openbao-host-token-reviewer
+  namespace: openbao
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao-host-token-reviewer
+    catalyst.openova.io/host-bridge: mgmt
+  annotations:
+    kubernetes.io/service-account.name: openbao-host-token-reviewer
+type: kubernetes.io/service-account-token

--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -148,7 +148,7 @@ spec:
       # chart renders the canonical apps.openova.io/v1 Application CR for
       # this slot's HelmRelease so the console /apps list, per-app Topology
       # tab + showback resolve openbao (no more "no Application CR").
-      version: 1.2.48
+      version: 1.2.49
       sourceRef:
         kind: HelmRepository
         name: bp-openbao
@@ -228,6 +228,26 @@ spec:
       # so failed runs still surface as HR errors, not silent kit
       # timeouts.
       activeDeadlineSeconds: 1200
+      # ── #3825 (Refs #3642) cross-cluster TokenReview ───────────────────
+      # openbao runs in vc-mgmt (placement.yaml slot-08 vcluster: mgmt) but
+      # the ESO ServiceAccount whose JWT it validates is issued by the HOST
+      # apiserver. Without this the auth-bootstrap Job points k8s-auth at the
+      # VC-MGMT apiserver, which cannot review the host token → ESO 403s →
+      # ALL *-oidc ExternalSecrets stay unsynced → the per-app SSO walk stays
+      # broken. Enabled here because THIS slot places openbao in a vCluster;
+      # the auth-bootstrap Job then configures auth/kubernetes/config to
+      # TokenReview against the HOST apiserver using the host SA token + host
+      # CA mirrored from the HOST openbao ns (placement slot-08 hostDocuments
+      # `openbao-host-token-reviewer`) via bp-mgmt-vcluster
+      # sync.fromHost.secrets `openbao/*`. The chart default is `false`
+      # (host-side openbao / Catalyst-Zero) so single-region stays unchanged.
+      # If a future overlay returns openbao to host placement, flip this off
+      # in lockstep with placement.yaml (vcluster: host) — then
+      # kubernetes.default.svc IS the host apiserver and the in-cluster path
+      # is correct again.
+      kubernetesAuth:
+        crossClusterTokenReview:
+          enabled: true
     # Issue #517 (Phase-8a single-node): openbao upstream chart's
     # 3-replica StatefulSet uses required pod-anti-affinity by hostname.
     # On single-node Phase-8a Sovereigns this leaves 2/3 pods Pending

--- a/clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml
+++ b/clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml
@@ -81,7 +81,7 @@ spec:
       # (denied live on hw54 13:46Z → HR Unknown → downstream HRs
       # blocked). 10m/32Mi req + 100m/128Mi lim — sized for ~15s
       # kubectl-poll loop, no idle headroom needed.
-      version: 1.0.6
+      version: 1.0.7
       sourceRef:
         kind: HelmRepository
         name: bp-external-secrets-stores

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -123,11 +123,25 @@ spec:
         consumer:
           blueprint: bp-catalyst-platform
           mode: shared
-        # One hub Secret for the whole mesh — every SME service shares
-        # the `sme` credentials and derives its own database name.
+        # One hub Secret for the whole mesh — every Organization service
+        # shares the `sme` credentials and derives its own database name.
+        # #3383 (rename sme→org-services): the SME service mesh ns was
+        # renamed `sme`→`org-services` in bp-catalyst-platform 1.4.675
+        # (slot-13 smePostgres.cluster.namespace + ferretdb.namespace +
+        # every templates/org-services/* consumer), but this reflect target
+        # was left at `[sme]` — so the hub `sme-database-secret` was pushed
+        # into a namespace that no longer exists while ferretdb (ns
+        # org-services, env PG_USER/PG_PASSWORD secretKeyRef
+        # sme-database-secret, non-optional) hit
+        # `secret "sme-database-secret" not found` → CreateContainerConfigError
+        # (verified live hw163 2026-06-18: ns `sme` NotFound, and
+        # org-services/sme-database-secret NotFound — the reflector had no
+        # live target). Point the reflect target at the post-#3383 mesh
+        # namespace so the hub secret lands where ferretdb (and any other
+        # org-services SME consumer) mounts it. Refs #3383.
         reflect:
           secretName: sme-database-secret
-          namespaces: [sme]
+          namespaces: [org-services]
       - name: sme_billing       # billing service primary DB
         owner: sme
         consumer:

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -646,6 +646,77 @@ spec:
                   remoteRef:
                     key: sso/openbao
                     property: issuer_url
+          # ── #3825 (Refs #3642) HOST token-reviewer for cross-cluster auth ──
+          # openbao now runs in vc-mgmt but must TokenReview the HOST-issued ESO
+          # ServiceAccount token (external-secrets/external-secrets-system) to
+          # let the `vault-region1` ClusterSecretStore authenticate. The pod's
+          # in-cluster `kubernetes.default.svc` is the VC-MGMT apiserver, which
+          # cannot review a host token → every ESO login 403s → ALL *-oidc
+          # ExternalSecrets (incl. openbao-sso-oidc-credentials ABOVE,
+          # oidc-gate-*, hubble-ui-oauth2-proxy, per-app SSO) stay unsynced.
+          # These three HOST resources supply OpenBao a HOST token_reviewer_jwt
+          # + the HOST CA so it can review against the HOST apiserver
+          # (auth/kubernetes/config kubernetes_host=https://10.96.0.1:443,
+          # disable_local_ca_jwt=true — bp-openbao 1.x crossClusterTokenReview).
+          #
+          # Delivery: the token Secret is minted in the HOST `openbao` ns; the
+          # bp-mgmt-vcluster `sync.fromHost.secrets` `openbao/*` mapping mirrors
+          # it into the vc-mgmt `openbao` ns under the SAME name, where the
+          # auth-bootstrap Job mounts it. Plain core resources (no operator
+          # CRD) so they are safe in this CRD-dependent CRS tier (they carry no
+          # `no matches for kind` risk) and land right after bootstrap-kit.
+          #
+          # 1. HOST ServiceAccount whose token OpenBao presents as the
+          #    token_reviewer_jwt. Distinct from the ESO SA — least-privilege:
+          #    its ONLY power is TokenReview (via the auth-delegator CRB below).
+          - apiVersion: v1
+            kind: ServiceAccount
+            metadata:
+              name: openbao-host-token-reviewer
+              namespace: openbao
+              labels:
+                catalyst.openova.io/blueprint: bp-openbao
+                catalyst.openova.io/component: openbao-host-token-reviewer
+                catalyst.openova.io/host-bridge: "mgmt"
+          # 2. Bind that HOST SA to system:auth-delegator (create on
+          #    tokenreviews.authentication.k8s.io) — the ONLY grant OpenBao's
+          #    cross-cluster TokenReview needs against the HOST apiserver.
+          - apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRoleBinding
+            metadata:
+              name: openbao-host-token-reviewer-auth-delegator
+              labels:
+                catalyst.openova.io/blueprint: bp-openbao
+                catalyst.openova.io/component: openbao-host-token-reviewer
+                catalyst.openova.io/host-bridge: "mgmt"
+            roleRef:
+              apiGroup: rbac.authorization.k8s.io
+              kind: ClusterRole
+              name: system:auth-delegator
+            subjects:
+              - kind: ServiceAccount
+                name: openbao-host-token-reviewer
+                namespace: openbao
+          # 3. Long-lived token Secret for that HOST SA. On k8s 1.24+ SA-token
+          #    Secrets are no longer auto-created, but an explicit
+          #    kubernetes.io/service-account-token Secret IS still populated by
+          #    the token controller with `token` (a non-expiring SA JWT) +
+          #    `ca.crt` (the HOST cluster CA) — exactly the two values the Job
+          #    needs. A non-expiring token is acceptable here: it is
+          #    auth-delegator-only (cannot read secrets / mutate anything) and
+          #    is the documented pattern for OpenBao's static token_reviewer_jwt.
+          - apiVersion: v1
+            kind: Secret
+            metadata:
+              name: openbao-host-token-reviewer
+              namespace: openbao
+              labels:
+                catalyst.openova.io/blueprint: bp-openbao
+                catalyst.openova.io/component: openbao-host-token-reviewer
+                catalyst.openova.io/host-bridge: "mgmt"
+              annotations:
+                kubernetes.io/service-account.name: openbao-host-token-reviewer
+            type: kubernetes.io/service-account-token
     - {file: 11a-bp-powerdns-admin.yaml, hr: bp-powerdns-admin, vcluster: host, target: mgmt,
        namespace: powerdns-admin}   # §4: UI not substrate — DEFAULT mgmt, listed for founder veto
     - {file: 13b-bp-sso-bridge.yaml, hr: bp-sso-bridge, vcluster: host, target: mgmt, namespace: sso-bridge}

--- a/platform/external-secrets-stores/blueprint.yaml
+++ b/platform/external-secrets-stores/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.6
+  version: 1.0.7
   card:
     title: External Secrets — Stores
     summary: |

--- a/platform/external-secrets-stores/chart/Chart.yaml
+++ b/platform/external-secrets-stores/chart/Chart.yaml
@@ -47,7 +47,18 @@ name: bp-external-secrets-stores
 # the bootstrap-kit from upstream Docker Hub deletions (Bitnami 2025-08
 # is exactly such an incident) and satisfies the Kyverno
 # `harbor-proxy-pull` ClusterPolicy.
-version: 1.0.6
+#
+# 1.0.7 (#3825, Refs #3642, 2026-06-18): the vault-region1 ClusterSecretStore
+# `server` now points at the HOST-routable vCluster-syncer-mirrored openbao
+# Service `openbao-x-openbao-x-mgmt-vcluster.mgmt.svc.cluster.local:8200`
+# instead of `openbao.openbao.svc.cluster.local:8200`. After #3642 openbao
+# runs INSIDE the mgmt vCluster; ESO runs HOST-side (HOST-MINIMUM §4), so the
+# in-vCluster name no longer resolves from the host (vault-region1 store was
+# "unable to create client" on hw163). Catalyst-Zero overlays (openbao
+# host-side) override `clusterSecretStore.server` back. Paired with the
+# bp-openbao crossClusterTokenReview auth fix — BOTH required for vault-region1
+# to authenticate + resolve end-to-end. Refs #3642.
+version: 1.0.7
 description: |
   Catalyst-curated Blueprint chart for the default ESO ClusterSecretStore(s)
   that wire each Sovereign's bp-external-secrets controller to its bp-openbao

--- a/platform/external-secrets-stores/chart/values.yaml
+++ b/platform/external-secrets-stores/chart/values.yaml
@@ -15,7 +15,18 @@
 clusterSecretStore:
   enabled: true
   name: vault-region1
-  server: "http://openbao.openbao.svc.cluster.local:8200"
+  # #3825 (Refs #3642): openbao moved INTO the mgmt vCluster (vc-mgmt). ESO
+  # runs HOST-side (HOST-MINIMUM §4, external-secrets-system) so this store's
+  # `server` must be HOST-routable. The in-vCluster name
+  # `openbao.openbao.svc.cluster.local` no longer resolves from the host — from
+  # the host the openbao Service is the vCluster-syncer-mirrored
+  # `openbao-x-openbao-x-mgmt-vcluster` in ns `mgmt` (verified live hw163:
+  # healthy, initialized, unsealed, serving /v1/sys/health). A cluster overlay
+  # where openbao stays host-side (Catalyst-Zero) overrides this back to
+  # `http://openbao.openbao.svc.cluster.local:8200`. Paired with the openbao
+  # crossClusterTokenReview auth fix (bp-openbao) — BOTH are required for
+  # vault-region1 to authenticate + resolve end-to-end after #3642.
+  server: "http://openbao-x-openbao-x-mgmt-vcluster.mgmt.svc.cluster.local:8200"
   path: secret
   version: v2
   kubernetesAuth:

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.48
+  version: 1.2.49
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -119,7 +119,29 @@ name: bp-openbao
 # readTopology serves spec.placement VERBATIM to the Topology tab + the
 # Instances-table chip, so the legacy spelling leaked the banned word to the
 # operator (hw159 #3375).
-version: 1.2.48
+# 1.2.49 (#3825, Refs #3642, 2026-06-18): cross-cluster TokenReview for the
+# auth-bootstrap Job's k8s-auth config. After #3642 openbao runs INSIDE the
+# mgmt vCluster, but the ESO ServiceAccount whose JWT it validates
+# (external-secrets/external-secrets-system) is issued by the HOST apiserver.
+# The pod's `kubernetes.default.svc` is the VC-MGMT apiserver, which cannot
+# review the host token → every ESO login 403s → ALL *-oidc ExternalSecrets
+# (oidc-gate-*, hubble-ui-oauth2-proxy, the per-app SSO secrets) stay unsynced
+# → the per-app SSO walk stays broken (root-caused live hw163 2026-06-18).
+# New autoUnseal.kubernetesAuth.crossClusterTokenReview: when enabled the Job
+# points auth/kubernetes/config at the HOST apiserver
+# (kubernetes_host=hostApiserver, token_reviewer_jwt + kubernetes_ca_cert from
+# the mirrored openbao-host-token-reviewer Secret, disable_local_ca_jwt=true).
+# This is openbao's documented cross-cluster auth mode and RESTORES the
+# pre-#3642 contract (when openbao was host-side, kubernetes.default.svc WAS
+# the host apiserver and the host ESO token validated natively). The host SA
+# token + CA are minted HOST-side (bootstrap-kit slot-08 hostDocuments: a host
+# ServiceAccount bound to system:auth-delegator + a
+# kubernetes.io/service-account-token Secret) and mirrored host→vc-mgmt by
+# bp-mgmt-vcluster sync.fromHost.secrets (the existing openbao/* mapping). The
+# Job soft-waits (backoffLimit retries) for the mirror. DEFAULT false →
+# single-region / Catalyst-Zero / host-side-openbao render byte-identical +
+# in-cluster TokenReview path unchanged. Refs #3642 #3736.
+version: 1.2.49
 # 1.2.46 (#3629, 2026-06-16): the SECONDARY (fetch) snapshot CronJob no longer
 # performs an OpenBao k8s-auth login. The fetch path is PURE S3 I/O
 # (list-objects-v2 + `s3 cp` to the restore-staging PVC) and NEVER reads

--- a/platform/openbao/chart/templates/auth-bootstrap-job.yaml
+++ b/platform/openbao/chart/templates/auth-bootstrap-job.yaml
@@ -48,6 +48,26 @@ Skip-render pattern (per #402): renders ONLY when both
 {{- $kvMount := $kAuth.kvMountPath | default "secret" -}}
 {{- $tokenTTL := $kAuth.tokenTTL | default "1h" -}}
 {{- $tokenMaxTTL := $kAuth.tokenMaxTTL | default "24h" -}}
+{{- /* #3825 (Refs #3642) — cross-cluster TokenReview inputs. After #3642
+       OpenBao runs INSIDE the mgmt vCluster, but the ESO ServiceAccount whose
+       JWT it must validate is issued by the HOST apiserver (host ns
+       external-secrets-system). `kubernetes.default.svc` inside the pod is the
+       vc-mgmt apiserver, which does NOT know that host token (and the host ns
+       does not even exist in vc-mgmt) → every ESO login fails 403, all *-oidc
+       ExternalSecrets stay unsynced. OpenBao's k8s-auth supports cross-cluster
+       validation: point kubernetes_host at the HOST apiserver + supply a HOST
+       token_reviewer_jwt + the HOST CA + disable_local_ca_jwt. The host SA
+       token + CA arrive via a Secret minted HOST-side (placement slot-08
+       hostDocuments) and mirrored into vc-mgmt by bp-mgmt-vcluster
+       sync.fromHost.secrets (`openbao/*`). Pre-#3642 single-region (openbao
+       host-side) leaves this disabled → render byte-identical. */ -}}
+{{- $xcr := $kAuth.crossClusterTokenReview | default dict -}}
+{{- $xcrEnabled := $xcr.enabled | default false -}}
+{{- $xcrHostApi := $xcr.hostApiserver | default "https://10.96.0.1:443" -}}
+{{- $xcrSecret := $xcr.tokenReviewerSecret | default dict -}}
+{{- $xcrSecretName := $xcrSecret.name | default "openbao-host-token-reviewer" -}}
+{{- $xcrTokenKey := $xcrSecret.tokenKey | default "token" -}}
+{{- $xcrCaKey := $xcrSecret.caKey | default "ca.crt" -}}
 {{- /* #3376 — catalyst-api handover-archive writer role inputs. */ -}}
 {{- $capi := $kAuth.catalystApi | default dict -}}
 {{- $capiEnabled := $capi.enabled | default false -}}
@@ -89,13 +109,43 @@ spec:
         runAsUser: 100
         runAsGroup: 1000
         fsGroup: 1000
+{{- if $xcrEnabled }}
+      # #3825 — mount the HOST token-reviewer Secret (host SA JWT + host CA),
+      # mirrored host→vc-mgmt by bp-mgmt-vcluster sync.fromHost.secrets. The
+      # Job reads token/ca.crt from here to configure cross-cluster TokenReview
+      # against the HOST apiserver. optional:true so a fresh prov where the
+      # mirror has not yet landed does not block scheduling — the script
+      # soft-waits for the files and the Job's backoffLimit retries until the
+      # synced Secret appears (eventually-consistent, same posture as the
+      # SHARED_PG fromHost mirror).
+      volumes:
+        - name: host-token-reviewer
+          secret:
+            secretName: {{ $xcrSecretName | quote }}
+            optional: true
+{{- end }}
       containers:
         - name: auth-bootstrap
           image: {{ printf "%s:%s" $repo $tag | quote }}
           imagePullPolicy: {{ $pullPolicy | quote }}
+{{- if $xcrEnabled }}
+          volumeMounts:
+            - name: host-token-reviewer
+              mountPath: /var/run/openbao/host-token-reviewer
+              readOnly: true
+{{- end }}
           env:
             - name: BAO_ADDR
               value: {{ $baoAddr | quote }}
+            # #3825 — cross-cluster TokenReview against the HOST apiserver.
+            - name: XCR_ENABLED
+              value: {{ $xcrEnabled | quote }}
+            - name: XCR_HOST_APISERVER
+              value: {{ $xcrHostApi | quote }}
+            - name: XCR_TOKEN_FILE
+              value: {{ printf "/var/run/openbao/host-token-reviewer/%s" $xcrTokenKey | quote }}
+            - name: XCR_CA_FILE
+              value: {{ printf "/var/run/openbao/host-token-reviewer/%s" $xcrCaKey | quote }}
             - name: AUTH_MOUNT_PATH
               value: {{ $mountPath | quote }}
             - name: AUTH_ROLE
@@ -188,15 +238,61 @@ spec:
                 bao auth enable -path=$AUTH_MOUNT_PATH kubernetes
               fi
 
-              # Configure the auth method against the in-cluster API
-              # server. K8s_HOST is the standard cluster-DNS endpoint;
-              # K8S_CA_CERT comes from the SA mount.
+              # Configure the auth method. Two modes:
+              #
+              #   (default, openbao host-side) Validate ServiceAccount JWTs
+              #   against the IN-CLUSTER apiserver — kubernetes_host is the
+              #   standard cluster-DNS endpoint, the CA comes from the pod's
+              #   own SA mount. This is correct whenever the ESO SA whose
+              #   token OpenBao validates is issued by the SAME apiserver
+              #   OpenBao runs against (single-region / Catalyst-Zero, and
+              #   every env before #3642).
+              #
+              #   (#3825 cross-cluster, openbao in vc-mgmt) After #3642
+              #   OpenBao runs INSIDE the mgmt vCluster but the ESO SA token
+              #   it must validate is issued by the HOST apiserver. The pod's
+              #   `kubernetes.default.svc` + local SA mount are the VC-MGMT
+              #   apiserver, which cannot review the host token (it is unknown
+              #   there, and ns external-secrets-system does not exist in
+              #   vc-mgmt) → every ESO login 403s and all *-oidc
+              #   ExternalSecrets stay unsynced. So point kubernetes_host at
+              #   the HOST apiserver, supply a HOST token_reviewer_jwt + the
+              #   HOST CA (from the mirrored openbao-host-token-reviewer
+              #   Secret), and disable_local_ca_jwt so OpenBao does NOT fall
+              #   back to its in-vCluster CA/token. The ESO role's
+              #   bound_service_account_namespaces stays external-secrets-system
+              #   (host ns) below — correct, because the review now runs
+              #   against the host. (Restores the pre-#3642 host-token-review
+              #   contract that `kubernetes.default.svc` provided natively when
+              #   openbao was host-side.)
               echo "[openbao-auth-bootstrap] writing auth/$AUTH_MOUNT_PATH/config"
-              KUBE_CA=$(cat /var/run/secrets/kubernetes.io/serviceaccount/ca.crt)
-              bao write auth/$AUTH_MOUNT_PATH/config \
-                kubernetes_host="https://kubernetes.default.svc" \
-                kubernetes_ca_cert="$KUBE_CA" \
-                disable_iss_validation=true
+              if [ "${XCR_ENABLED}" = "true" ]; then
+                echo "[openbao-auth-bootstrap] cross-cluster mode: TokenReview target = HOST apiserver ${XCR_HOST_APISERVER}"
+                # Soft-wait for the host-mirrored token-reviewer Secret. On a
+                # fresh prov the bp-mgmt-vcluster sync.fromHost mirror lands
+                # eventually; until the files appear we exit non-zero so the
+                # Job's backoffLimit retries (eventually-consistent, same
+                # posture as the SHARED_PG fromHost mirror) rather than baking
+                # an empty/local config.
+                if [ ! -s "${XCR_TOKEN_FILE}" ] || [ ! -s "${XCR_CA_FILE}" ]; then
+                  echo "[openbao-auth-bootstrap] host token-reviewer Secret not yet mirrored (${XCR_TOKEN_FILE} / ${XCR_CA_FILE} absent) — retry on next backoff once bp-mgmt-vcluster sync.fromHost lands it"
+                  exit 1
+                fi
+                HOST_TR_JWT=$(cat "${XCR_TOKEN_FILE}")
+                HOST_CA=$(cat "${XCR_CA_FILE}")
+                bao write auth/$AUTH_MOUNT_PATH/config \
+                  kubernetes_host="${XCR_HOST_APISERVER}" \
+                  kubernetes_ca_cert="$HOST_CA" \
+                  token_reviewer_jwt="$HOST_TR_JWT" \
+                  disable_local_ca_jwt=true \
+                  disable_iss_validation=true
+              else
+                KUBE_CA=$(cat /var/run/secrets/kubernetes.io/serviceaccount/ca.crt)
+                bao write auth/$AUTH_MOUNT_PATH/config \
+                  kubernetes_host="https://kubernetes.default.svc" \
+                  kubernetes_ca_cert="$KUBE_CA" \
+                  disable_iss_validation=true
+              fi
 
               # ─── Ensure kv-v2 backend at $KV_MOUNT_PATH/ ────────────────
               EXISTING_MOUNTS=$(bao secrets list -format=json 2>/dev/null || echo "{}")

--- a/platform/openbao/chart/values.yaml
+++ b/platform/openbao/chart/values.yaml
@@ -193,6 +193,65 @@ autoUnseal:
       role: catalyst-api
       serviceAccountName: catalyst-api-cutover-driver
       serviceAccountNamespace: catalyst-system
+    # ─── #3825 (Refs #3642) — cross-cluster TokenReview ───────────────────
+    # After #3642 OpenBao runs INSIDE the mgmt vCluster, but the ESO
+    # ServiceAccount whose JWT it validates (external-secrets /
+    # external-secrets-system) is issued by the HOST apiserver. The pod's
+    # `kubernetes.default.svc` is the VC-MGMT apiserver, which cannot review
+    # the host-issued token (the token is unknown there and the host ns does
+    # not exist in vc-mgmt) → every ESO login 403s → all *-oidc
+    # ExternalSecrets (oidc-gate-*, hubble-ui-oauth2-proxy, the per-app SSO
+    # secrets) stay unsynced → the per-app SSO walk stays broken.
+    #
+    # When `enabled` the auth-bootstrap Job configures auth/kubernetes/config
+    # to TokenReview against the HOST apiserver instead: kubernetes_host =
+    # hostApiserver, token_reviewer_jwt + kubernetes_ca_cert read from the
+    # mirrored `tokenReviewerSecret`, disable_local_ca_jwt=true (so OpenBao
+    # does NOT fall back to its in-vCluster CA/token). This is OpenBao's
+    # documented cross-cluster auth mode and RESTORES the pre-#3642 behaviour
+    # (when openbao was host-side, `kubernetes.default.svc` WAS the host
+    # apiserver and the host ESO token validated natively).
+    #
+    # The host SA token + host CA are minted HOST-side by bootstrap-kit
+    # placement slot-08 hostDocuments (a host ServiceAccount bound to
+    # system:auth-delegator + a kubernetes.io/service-account-token Secret the
+    # host token-controller populates with `token` + `ca.crt`), then mirrored
+    # host→vc-mgmt by bp-mgmt-vcluster `sync.fromHost.secrets` (the existing
+    # `openbao/*` mapping). On a fresh prov the mirror lands eventually; the
+    # Job soft-waits (backoffLimit retries) until the Secret appears.
+    #
+    # DEFAULT false: single-region / Catalyst-Zero / any env where openbao
+    # stays HOST-side leaves this off → render byte-identical to pre-#3825 +
+    # the in-cluster TokenReview path is unchanged. The franchised multi-
+    # region Sovereign overlay (openbao in vc-mgmt) sets enabled=true — wired
+    # by the bootstrap-kit slot-08 HR values block on a vCluster placement.
+    crossClusterTokenReview:
+      enabled: false
+      # HOST apiserver address reachable from a vc-mgmt pod. vc-mgmt pods are
+      # real host pods (shared CNI), so the HOST kube-apiserver ClusterIP is
+      # reachable at the IP level even though the NAME kubernetes.default.svc
+      # resolves to the vc-mgmt apiserver inside the pod. 10.96.0.1 is the
+      # `kubernetes.default` ClusterIP (.1 of the service CIDR) — the SAME
+      # constant bp-network-policies allow-system-namespaces +
+      # bp-self-sovereign-cutover allow-lists encode as the host apiserver.
+      #
+      # ⚠️ PER-REGION CIDR: infra sets `--service-cidr=10.{96+regionIdx}.0.0/16`
+      # (infra/providers/{huawei,hetzner}/main.tf region_service_cidr), so the
+      # apiserver ClusterIP is 10.96.0.1 in the PRIMARY region, 10.97.0.1 in the
+      # SECOND region, etc. The mgmt vCluster (hence openbao + this
+      # auth-bootstrap Job) runs in the PRIMARY region, so 10.96.0.1 is correct
+      # for the canonical topology. If a future placement runs vc-mgmt in a
+      # non-primary region OR the service CIDR is customised, override this
+      # per-Sovereign to 10.{96+regionIdx}.0.1.
+      hostApiserver: "https://10.96.0.1:443"
+      # The mirrored host token-reviewer Secret (host SA JWT + host CA). Name
+      # MUST match the Secret minted by placement slot-08 hostDocuments in the
+      # HOST openbao ns; the `openbao/*` fromHost mapping mirrors it into the
+      # vc-mgmt openbao ns under the SAME name.
+      tokenReviewerSecret:
+        name: openbao-host-token-reviewer
+        tokenKey: token
+        caKey: ca.crt
 
 # ─── G91.openbao (#2655) SSO opt-in ───────────────────────────────────────
 # Per SECURITY.md §6.3 every Application Blueprint declares SSO support


### PR DESCRIPTION
## What this fixes

The host↔vCluster secret-delivery breaks #3642 left for the secondary SSO + Organization-services surfaces (companion to PR #3814 which fixes the keycloak-SSO zero-login walk gate). After #3642 moved 7 apps into the mgmt vCluster, several host consumers lost the secrets/services their producers used to hand them. Root-caused live on hw163 (deployment `83674048ff592704`, 2026-06-18) before it was re-provisioned.

## Two independent fixes

### 1. ferretdb `sme-database-secret` → `org-services` (commit 1, HR-values only)

`#3383` renamed the SME service mesh namespace `sme`→`org-services` in bp-catalyst-platform 1.4.675 (slot-13 `smePostgres.cluster.namespace` + `ferretdb.namespace` + every `templates/org-services/*` consumer), but the slot-16d hub-secret reflect target was left at `[sme]`. So the reflector pushed `sme-database-secret` into a namespace that no longer exists, while ferretdb (ns `org-services`, env `PG_USER`/`PG_PASSWORD` `secretKeyRef sme-database-secret`, non-optional) hit `CreateContainerConfigError: secret "sme-database-secret" not found`.

**Live evidence:** ns `sme` **NotFound**; `org-services/sme-database-secret` **NotFound** (the reflector had no live target).

**Fix:** point `clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml` `databases[].reflect.namespaces` → `[org-services]`. The reflect block is under the slot HR `values:`, not chart source, so **no bp-postgres chart bump** is needed. `Refs #3383`.

### 2. Cross-cluster ESO→OpenBao auth + host-routable store endpoint (commit 2)

This unblocks every `*-oidc` ExternalSecret (`oidc-gate-openova-flow`, `oidc-gate-powerdns-admin`, `hubble-ui-oauth2-proxy`, + the per-app SSO secrets), which were all `CreateContainerConfigError` because the `vault-region1` ClusterSecretStore could neither resolve nor authenticate to openbao after the move. **Two coupled breaks:**

**(a) Endpoint** (`bp-external-secrets-stores` → 1.0.7): the store `server` was `openbao.openbao.svc.cluster.local:8200` — the in-vCluster name no longer resolves from the HOST where ESO runs (HOST-MINIMUM §4). `vault-region1` was `unable to create client` live. Repoint at the host-routable syncer-mirrored Service `openbao-x-openbao-x-mgmt-vcluster.mgmt.svc.cluster.local:8200` (verified live: healthy/initialized/unsealed, serving `/v1/sys/health`).

**(b) Auth** (`bp-openbao` → 1.2.49): the auth-bootstrap Job (running INSIDE vc-mgmt) configured openbao's k8s-auth with `kubernetes_host=https://kubernetes.default.svc` = the **vc-mgmt apiserver**, but the host ESO ServiceAccount (`external-secrets`/`external-secrets-system`) token is issued by the **host apiserver**. So openbao's TokenReview against the vc-mgmt apiserver with the host token **403s** → ESO can't log in. Pre-#3642 openbao was host-side, so `kubernetes.default.svc` WAS the host apiserver and the host token validated natively — #3642 silently broke this.

New `autoUnseal.kubernetesAuth.crossClusterTokenReview` (default **false** = byte-identical render for single-region / Catalyst-Zero / host-side openbao): when enabled (slot-08, the vCluster placement) the Job points `auth/kubernetes/config` at the **host apiserver** — `kubernetes_host=10.96.0.1:443`, `token_reviewer_jwt` + `kubernetes_ca_cert` from a mirrored host SA Secret, `disable_local_ca_jwt=true`. This is openbao's documented cross-cluster auth mode, restoring the host-token-review contract. The host SA token + CA are minted HOST-side (slot-08 `hostDocuments`: a host ServiceAccount bound to `system:auth-delegator` + a `kubernetes.io/service-account-token` Secret) and mirrored host→vc-mgmt by the **existing** bp-mgmt-vcluster `sync.fromHost.secrets` `openbao/*` mapping (no bp-mgmt-vcluster bump). The Job soft-waits (`backoffLimit` retries) for the mirror.

`hostApiserver` is a values knob. Note the per-region service CIDR `10.{96+regionIdx}.0.0/16`: the apiserver is `10.96.0.1` in the primary region (where the mgmt vCluster runs → correct for the canonical topology) and `10.{96+idx}.0.1` elsewhere; override per-Sovereign if vc-mgmt ever runs non-primary or the CIDR is customised.

## Gate results

- `helm template` openbao default (xcr disabled): **no host-token-reviewer volume/mount**, `XCR_ENABLED=false`, `kubernetes.default.svc` path — runtime byte-identical.
- `helm template` openbao enabled: host apiserver path + the mounted Secret render.
- `helm template` ess store: renders the vc-mgmt-mangled endpoint.
- openbao `chart/tests/*.sh`: **9/9 PASS**. ess `chart/tests/*.sh`: **PASS**.
- `python3 scripts/render-slot-placement.py check`: **PASS** (64 slots; the 3 host docs regenerated into `bootstrap-kit-crs/08-openbao.yaml` via `render-slot-placement.py fix`).
- `go test ./...` in `tests/e2e/bootstrap-kit/`: **PASS** (forced).
- Lockstep: openbao `Chart.yaml`+`blueprint.yaml`+slot-08; ess `Chart.yaml`+`blueprint.yaml`+slot-15a; placement.yaml + generated CRs together.

## Residual / honest notes

- **Eventually-consistent first sync:** on a fresh prov the auth-bootstrap Job may fire before the host token-reviewer Secret mirrors into vc-mgmt; it `exit 1`s and the Job `backoffLimit` retries until it lands (same posture as the SHARED_PG `fromHost` mirror). Self-heals, no manual step.
- **`10.96.0.1` is the primary-region apiserver ClusterIP** (the same constant bp-network-policies + bp-self-sovereign-cutover encode). Correct for the canonical single mgmt-vCluster-in-primary topology; documented + overridable for exotic placements.
- **Not in this PR (documented for predictability):** `openbao-snapshot-save` (a DR-only, `snapshotReplication.enabled`-gated backup CronJob) is a genuine #3642 regression — its seeder, re-homed into vc-mgmt, lost line-of-sight to the `rtz`-vCluster seaweedfs S3 secret + endpoint. It is **not walk-blocking** and its fix entangles a cross-vCluster (rtz↔mgmt) datapath that can't be verified by render alone; tracked separately. The `org-services` `ImagePullBackOff` set is a separate ghcr/harbor image-pull issue, **not** a secret-delivery regression.

## Do NOT merge yet

A fresh prov may be live on the mothership; a mothership-rolling merge would abandon it. Hold until the in-flight prov settles, then merge (after the bp-openbao 1.2.49 + bp-external-secrets-stores 1.0.7 OCI artifacts publish, per pin-after-publish) → fresh zero-touch prov to verify the per-app SSO ExternalSecrets sync.

Refs #3642 #3736 #3383
