### PR TITLE
fix(bp-mgmt-vcluster): replace crash-prone toHost with ExternalName host-aliases — 0.2.16 (Refs #3642)

### DIFF
--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -111,7 +111,14 @@ spec:
       # resolve gitea-http.gitea.svc.cluster.local — else the console pre-install
       # hook CrashLoops `catalyst-gitea-token not found` and the console never
       # installs (root-caused live hw163).
-      version: 0.2.15
+      # 0.2.16 (#3642 hw164 root-cause): replicateServices.toHost REMOVED — its
+      # {from,to} form crash-loops the vcluster 0.23 syncer at runtime (every
+      # fresh prov wedged ~42/64, mgmt-vcluster-0 CrashLoop, vc-mgmt never minted,
+      # whole spine blocked). Replaced by static host ExternalName aliases
+      # (templates/host-service-aliases.yaml) giving keycloak/gitea-http/openbao
+      # plain->mangled reachability — verified live on hw164 (persist + resolve,
+      # zero syncer crash).
+      version: 0.2.16
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.15
+  version: 0.2.16
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -167,7 +167,7 @@ name: bp-mgmt-vcluster
 # pre-install hook `secret "catalyst-gitea-token" not found` → install times out
 # → console never comes up. Adds `networking.replicateServices.toHost` exporting
 # the in-vCluster gitea-http back to the host `gitea/gitea-http` Service.
-version: 0.2.15
+version: 0.2.16
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/templates/host-service-aliases.yaml
+++ b/platform/bp-mgmt-vcluster/chart/templates/host-service-aliases.yaml
@@ -1,0 +1,57 @@
+{{- /*
+  Host→vCluster PLAIN-NAME reachability aliases (#3642 follow-up, 2026-06-18,
+  hw164 root-cause fix).
+
+  After #3642 keycloak/gitea/openbao run INSIDE vc-mgmt; their Services sync to
+  the host ONLY under the mangled `<svc>-x-<ns>-x-mgmt-vcluster.mgmt.svc` name
+  (`sync.toHost.services`). But ~20 host-side consumers dial the PLAIN
+  `<svc>.<ns>.svc` names, which no longer exist host-side:
+    • catalyst-api (org/app/env/blueprint controllers' giteaURL),
+    • the catalyst-gitea-token mint pre-install hook + catalog-sovereign
+      GitRepository (gitea-http.gitea.svc:3000),
+    • the sso-bridge reconciler (keycloak.keycloak.svc:8080,
+      openbao.openbao.svc:8200 — writes secret/sso/<app>).
+
+  These ExternalName Services alias each plain name to the mangled one, so every
+  consumer resolves it natively with ZERO vcluster-syncer involvement. This
+  REPLACES the prior `networking.replicateServices.toHost` (see values.yaml),
+  whose `{from,to}` form crash-loops the vcluster 0.23 syncer at runtime AND
+  whose target namespace would have been wrong anyway.
+
+  Ordering / safety:
+    • The host namespaces (keycloak/gitea/openbao) are created by the
+      bootstrap-kit Kustomization BEFORE this slot (58) renders (verified live:
+      they carry `kustomize.toolkit.fluxcd.io/name: bootstrap-kit`). This chart
+      only adds Services into them — no Namespace ownership conflict.
+    • The target mangled Services materialise once the in-vCluster app installs
+      (`sync.toHost.services`); until then the alias NXDOMAINs — eventually-
+      consistent, identical to every other bootstrap wire. Consumers already
+      retry (gitea-token mint loops on /api/v1/version).
+    • The aliases live in the APP namespaces, NOT the vcluster's mgmt namespace,
+      so the syncer never prunes them (verified live on hw164 — all three
+      persisted across vcluster restarts while in-mgmt-ns copies were pruned).
+*/ -}}
+{{- if .Values.hostServiceAliases.enabled }}
+{{- range $a := .Values.hostServiceAliases.aliases }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $a.name }}
+  namespace: {{ $a.namespace }}
+  labels:
+    {{- include "bp-mgmt-vcluster.labels" $ | nindent 4 }}
+    catalyst.openova.io/host-bridge: vcluster-service-alias
+  annotations:
+    catalyst.openova.io/purpose: >-
+      host->vc-mgmt plain-name reachability; replaces the crash-prone
+      replicateServices.toHost (#3642 hw164 root-cause)
+spec:
+  type: ExternalName
+  externalName: {{ $a.externalName | quote }}
+  ports:
+    - name: http
+      port: {{ $a.port | int }}
+      targetPort: {{ $a.port | int }}
+{{- end }}
+{{- end }}

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -199,6 +199,27 @@ mgmtVcluster:
       #     its in-mgmt Pod must reach rtz. Required once batch-C moves shared-pg.
       - rtz
 
+# ─── Host→vCluster plain-name reachability aliases (#3642 hw164 fix) ───
+# Static host ExternalName Services that alias the PLAIN in-vCluster app
+# names (dialled by ~20 host-side consumers) to the `sync.toHost.services`
+# mangled names. Replaces the crash-prone replicateServices.toHost.
+# Rendered by templates/host-service-aliases.yaml (see its header).
+hostServiceAliases:
+  enabled: true
+  aliases:
+    - name: keycloak
+      namespace: keycloak
+      externalName: keycloak-x-keycloak-x-mgmt-vcluster.mgmt.svc.cluster.local
+      port: 8080
+    - name: gitea-http
+      namespace: gitea
+      externalName: gitea-http-x-gitea-x-mgmt-vcluster.mgmt.svc.cluster.local
+      port: 3000
+    - name: openbao
+      namespace: openbao
+      externalName: openbao-x-openbao-x-mgmt-vcluster.mgmt.svc.cluster.local
+      port: 8200
+
 # ─── Upstream chart values (subchart key: vcluster) ────────────────
 # `helm dependency build` resolves the upstream loft-sh/vcluster
 # chart as a subchart; values here under the `vcluster:` key flow
@@ -367,17 +388,23 @@ vcluster:
       #      org-controller keycloakAddr, sso-bridge KC_ADDR.
       #   3. openbao.openbao.svc:8200   — catalyst-api openbaoAddr, sso-bridge
       #      OPENBAO_ADDR (writes secret/sso/<app>).
-      # replicateServices.toHost exports each in-vCluster Service back to the
-      # HOST under its PLAIN name so every host consumer resolves it natively —
-      # symmetric to the shared-pg fromHost mirror above (there vCluster→host;
-      # here host→vCluster). One export per family closes ~15 walk-time wires.
-      toHost:
-        - from: gitea/gitea-http
-          to: gitea/gitea-http
-        - from: keycloak/keycloak
-          to: keycloak/keycloak
-        - from: openbao/openbao
-          to: openbao/openbao
+      # ⛔ replicateServices.toHost REMOVED (#3642 follow-up, 2026-06-18, hw164
+      # root-cause): the `{from,to}` object form CRASHES the vcluster 0.23 syncer
+      # at RUNTIME (`parse physical service mapping: invalid service mapping,
+      # please use namespace1/service1=service2`) — render-validation passes, the
+      # binary dies on boot, mgmt-vcluster-0 CrashLoops, vc-mgmt secret never
+      # mints, and EVERY in-vCluster app wedges. Worse, vcluster's toHost target
+      # is a bare service NAME placed in the vCluster's HOST-target namespace
+      # (not `<ns>/<svc>`), so it could never recreate `gitea-http.gitea.svc`
+      # anyway. The host→vCluster PLAIN-NAME reachability the 3 families need
+      # (gitea-http.gitea.svc:3000 / keycloak.keycloak.svc:8080 /
+      # openbao.openbao.svc:8200, dialled by catalyst-api, the org/app/env/
+      # blueprint controllers, the gitea-token mint, and the sso-bridge) is now
+      # delivered by static host ExternalName Services that alias the plain name
+      # to the `sync.toHost.services` mangled name (templates/host-service-
+      # aliases.yaml) — those mangled Services reliably exist (harbor proved it),
+      # so the alias resolves with zero syncer-crash risk. Proven live on hw164.
+      toHost: []
 
   # sync — what host-cluster resources sync into the vCluster. The
   # MGMT vCluster needs services + endpoints + configmaps + secrets


### PR DESCRIPTION
## Root cause (live-diagnosed on hw164)

#3642 moved keycloak/gitea/openbao into the mgmt vCluster. catalyst-api's **keycloak** addr was correctly repointed to the syncer-mangled name (#3814), but **gitea + openbao consumers (~20 of them) were left on the dead plain names** `gitea-http.gitea.svc` / `openbao.openbao.svc`. #3810 tried to bridge them with `networking.replicateServices.toHost`, but its `{from,to}` object form **crash-loops the vcluster 0.23 syncer at runtime** (`parse physical service mapping: invalid service mapping`) — render passes, the binary dies on boot. Every fresh prov: `mgmt-vcluster-0` CrashLoop -> `vc-mgmt` secret never minted -> `sync.fromHost.secrets` never delivers app DB secrets -> keycloak/gitea/harbor/openbao all wedge (~42/64 HRs). **This is why post-#3642 envs are worse than hw150/159.**

## Fix

- **Remove** the crash-prone `replicateServices.toHost` (`toHost: []`).
- **Add** static host **ExternalName aliases** (`templates/host-service-aliases.yaml`): keycloak.keycloak->mangled:8080, gitea-http.gitea->mangled:3000, openbao.openbao->mangled:8200. The mangled target Services reliably exist via normal `sync.toHost.services` (harbor proved it); the aliases live in the app namespaces (created at slots 08-10, before slot 58) so the syncer never prunes them.

## Validation

Verified **live on hw164**: all three ExternalName aliases hand-created **persisted + resolved across vcluster restarts** with zero syncer crash (in-mgmt-ns copies were pruned; these app-namespace aliases were not). `helm template` renders all three cleanly at 0.2.16. Lockstep: Chart 0.2.16 + blueprint.yaml + slot-58 pin.

Refs #3642

🤖 Generated with [Claude Code](https://claude.com/claude-code)
