### PR TITLE
fix(bp-mgmt-vcluster): admit gateway reserved:ingress to mgmt apps — the #3642 app-plane wedge (0.2.17)

### DIFF
--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -118,7 +118,14 @@ spec:
       # (templates/host-service-aliases.yaml) giving keycloak/gitea-http/openbao
       # plain->mangled reachability — verified live on hw164 (persist + resolve,
       # zero syncer crash).
-      version: 0.2.16
+      # 0.2.17 (#2940 FOUNDATIONAL app-plane wedge, hw159-hw165 RCA): adds the
+      # gateway-ingress CiliumNetworkPolicy. The -isolation NetworkPolicy
+      # default-denied ALL mgmt-pod ingress with a namespaceSelector-only
+      # allow-list, which CANNOT match Cilium's reserved:ingress proxy identity
+      # → every gateway->app request silently dropped (curl 000/503) on every
+      # #3642 env. The new CNP admits fromEntities [ingress,host,remote-node];
+      # validated live hw165 (gitea 000/503->303, 7/11 surfaces recovered).
+      version: 0.2.17
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/docs/ledger/uat-walkthrough/_RESULT-hw165-2026-06-18.md
+++ b/docs/ledger/uat-walkthrough/_RESULT-hw165-2026-06-18.md
@@ -1,0 +1,49 @@
+# hw165 UAT walk result — 2026-06-18 (the #3642-fix env)
+
+Env: **hw165.omani.works** (deployment `9ee307969c92452e`), 2-VPC kom4dc, fired on
+**bp-mgmt-vcluster 0.2.16** (#3816 — the toHost→ExternalName root-cause fix). The
+first **zero-touch walkable** env since the #3642 apps-into-vCluster migration.
+Walk = 9 parallel browser-walker agents (screenshots only). Evidence under
+`/tmp/walk-hw165/<runbook>/` (session-local).
+
+## Aggregate (165 browser-walked rows): **57 ✅ · 44 ❌ · 28 GAP · 36 ☐**
+
+| Runbook (ticket) | ✅ | ❌ | GAP | ☐ | Headline |
+|---|:--:|:--:|:--:|:--:|---|
+| organizations #3383 | 7 | 0 | 0 | 0 | FULL PASS — persona-rename landed, create-org FIXED, zero sme/tenant |
+| catalog #3668 | 6 | 0 | 0 | 1 | FULL PASS — 64-card grid, single-source IaC YamlEditor, icon picker |
+| ns1-migrate #3642 | 9 | 0 | 1 | 1 | **NS#1 MET** — all 7 apps NAMESPACE=mgmt (vs hw159 all-host); guacamole still Provisioning |
+| jobs #3646 | 18 | 0 | 1 | 0 | multi-kind canvas ships; Retry fires real POST …/retry; 11-step tree honest |
+| object-model #3687 | 10 | 13 | 14 | 0 | treemap Org-layer + slug-rename FIXED; FAILs = no customer Org (funnel down) + mkt 503 |
+| cutover #3379 | 4 | 1 | 5 | 5 | Sovereignty 11-step progress card BUILT (closes hw159 GAP); cutover not-run; /compliance 404 |
+| topology-dr #3375 | 2 | 16 | 7 | 8 | 2-region map ✅ (Clusters 2/2, no phantom); per-app DR tab dead (#3687 Application-CR) |
+| sso-zero-login #3374 | 1 | 9 | 0 | 0 | console ✅; 9 apps unreachable (gateway→vCluster datapath) |
+| funnel #3376 | 0 | 5 | 0 | 21 | marketplace 503 "no healthy upstream" blocks the whole funnel |
+
+## Wins (the #3642 fix + prior FAILs resolved)
+- **Zero-touch walkable console** (impossible on hw164) — NS#3 console confirmed (3687-01).
+- **NS#1 — every app in the vCluster** (ns1 decisive: all 7 apps NAMESPACE=mgmt).
+- hw159 FAILs now ✅: treemap **Organization** layer (3687-E1), **persona-rename**
+  (no sme/tenant, 3383), create-org form, jobs multi-kind canvas (3646), cutover
+  11-step card (3379).
+
+## The 44 ❌ = 3 root causes (PATH-TO-100 levers)
+1. **marketplace 503** — HTTPRoute backendRefs `marketplace/gateway/admin:8080`, but the
+   only healthy backend is `marketplace-api:80` (frontend services have no pod). Kills
+   the funnel (21☐) AND the customer-Org (→ object-model customer-row FAILs cascade).
+2. **app datapath** (SSO 9❌) — two sub-gaps: (a) grafana-class — the mangled SSO/admin
+   secret `<app>-x-<app>-x-mgmt-vcluster` is missing → CreateContainerConfigError → no
+   endpoint → "no healthy upstream"; (b) gitea-class — pod Running + endpoint present, but
+   the host gateway→headless-service-pod-IP **times out** (NOT the isolation netpol — it
+   allows kube-system/gateway-system ingress). A #3642 gateway↔vCluster datapath gap.
+3. **#3687 Application-CR gap** — shared-pg (+ bootstrap apps) run as HelmReleases with NO
+   Application CR → per-app Topology/DR tab reads `n/a` everywhere (16❌ in #3375) even
+   though the 2-region cnpg-pair runs on the substrate.
+
+## Convergence follow-ups (durable, noted — manual surgery this run, must be zero-touch next prov)
+- cert-manager `powerdns-api-credentials` held the **prov** pdns key, not the **mothership**
+  key (tofu `powerdns_api_key`) → wildcard cert DNS-01 stuck "Unauthorized" → 000. Fixed
+  live; needs the mothership key reflected to cert-manager.
+- sovereign-tls (the wildcard cert) `dependsOn: bootstrap-kit` → blocked on 2 leaf SSO apps
+  (powerdns-admin/guacamole) → cert never issued. Decoupled live; should not gate on leaf apps.
+- powerdns-admin oidc-gate CreateContainerConfigError (leaf SSO app, not a spine blocker).

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.16
+  version: 0.2.17
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -167,7 +167,29 @@ name: bp-mgmt-vcluster
 # pre-install hook `secret "catalyst-gitea-token" not found` → install times out
 # → console never comes up. Adds `networking.replicateServices.toHost` exporting
 # the in-vCluster gitea-http back to the host `gitea/gitea-http` Service.
-version: 0.2.16
+#
+# 0.2.17 (#2940 FOUNDATIONAL app-plane wedge, hw159–hw165 RCA, 2026-06-19):
+# adds templates/gateway-ingress-cnp.yaml — a CiliumNetworkPolicy admitting
+# the gateway's reserved `ingress` identity (+ host / remote-node) to every
+# mgmt endpoint. ROOT CAUSE: the -isolation NetworkPolicy is podSelector:{}
+# default-deny-ingress over ALL mgmt pods with an allow-list built PURELY from
+# namespaceSelector rules. Cilium's Gateway API (envoy) proxies backend
+# traffic under the reserved:ingress identity, which is neither a pod nor a
+# namespace — so NO namespaceSelector can match it, and the 0.2.11 attempt to
+# fix this by ADDING gateway-system/kube-system to allowedIngressNamespaces was
+# structurally inert. Every gateway→app request (gitea/harbor/keycloak/openbao/
+# grafana/guacamole/pdns) was silently dropped → curl 000 (timeout) / 503
+# (envoy ejects the "unhealthy" backend). The host console worked only because
+# it sits outside this namespace. This shipped identically in every #3642 env,
+# so wipe-and-re-fire reproduced it every single time — the only fix is forward.
+# Validated LIVE on hw165 (2026-06-19): applying exactly these fromEntities
+# flipped gitea 000/503→303 and recovered 7 of 11 app surfaces instantly
+# (console/gitea/registry/auth/bao/guacamole/pdns up; the remaining 4 are a
+# separate missing-SSO-secret / no-frontend-pod cause, tracked apart). A
+# vanilla k8s NetworkPolicy cannot express reserved:ingress; Cilium unions all
+# policies selecting an endpoint, so this is purely ADDITIVE to -isolation —
+# gateway reachability without weakening tenant isolation (no `world`).
+version: 0.2.17
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/templates/gateway-ingress-cnp.yaml
+++ b/platform/bp-mgmt-vcluster/chart/templates/gateway-ingress-cnp.yaml
@@ -1,0 +1,42 @@
+{{- if and .Values.mgmtVcluster.enabled .Values.mgmtVcluster.networkPolicy.enabled -}}
+# Companion to the isolation NetworkPolicy (networkpolicy.yaml).
+#
+# ROOT CAUSE (hw159–hw165, #2940 — the foundational app-plane wedge):
+# the isolation NetworkPolicy is podSelector:{} default-deny-ingress over
+# ALL mgmt pods, and its allow-list is expressed PURELY as namespaceSelector
+# rules. The Cilium Gateway API (envoy) proxies external traffic to backend
+# pods under the reserved `ingress` security identity — which is NOT a pod
+# and NOT a namespace, so NO namespaceSelector can ever match it. Result:
+# every gateway→app request (gitea/harbor/keycloak/openbao/grafana/guacamole/
+# pdns/…) is silently dropped → curl 000 (timeout) / 503 (envoy ejects the
+# "unhealthy" backend). The host console works only because it lives outside
+# this namespace. This bug shipped identically in every #3642 env, so
+# re-firing reproduced it every time — the only fix is forward, here.
+#
+# A vanilla k8s NetworkPolicy cannot express reserved:ingress, so the gap is
+# closed with a CiliumNetworkPolicy that admits the ingress proxy (plus host /
+# remote-node, since envoy runs in the host netns and a backend pod may sit on
+# a peer node). Cilium computes the UNION of every policy selecting an
+# endpoint, so this is purely additive to the isolation policy — it grants
+# gateway reachability without weakening tenant isolation (note: no `world`,
+# so direct public ingress to MGMT stays forbidden per the DMZ design).
+#
+# Validated live on hw165 2026-06-19: applying exactly these fromEntities
+# flipped gitea 000/503→303 and recovered 7 of the app surfaces instantly.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "bp-mgmt-vcluster.fullname" . }}-allow-gateway-ingress
+  namespace: {{ include "bp-mgmt-vcluster.hostNamespace" . }}
+  labels:
+    {{- include "bp-mgmt-vcluster.labels" . | nindent 4 }}
+spec:
+  # endpointSelector {} = every endpoint in this namespace (the vCluster
+  # syncer + all synced app workloads), matching the isolation policy's scope.
+  endpointSelector: {}
+  ingress:
+    - fromEntities:
+        - ingress
+        - host
+        - remote-node
+{{- end }}


### PR DESCRIPTION
## RCA — the foundational app-plane wedge (hw159–hw165)

Every in-vCluster app surface (gitea/harbor/keycloak/openbao/grafana/guacamole/pdns) returned curl `000` (timeout) / `503` ("no healthy upstream") on every #3642 env, while the host console worked. Wipe-and-re-fire reproduced it identically every time — because the bug is in this chart, not the env.

**Root cause:** the `-isolation` NetworkPolicy is `podSelector: {}` default-deny-ingress over **all** mgmt pods, with an allow-list built **purely from `namespaceSelector` rules**. Cilium's Gateway API (envoy) proxies backend traffic under the reserved **`ingress`** security identity — which is neither a pod nor a namespace, so **no `namespaceSelector` can match it**. The earlier 0.2.11 attempt to fix this by adding `gateway-system`/`kube-system` to `allowedIngressNamespaces` was structurally inert for the same reason. Result: every `gateway→app` request silently dropped.

**Fix:** a companion `CiliumNetworkPolicy` admitting `fromEntities: [ingress, host, remote-node]`. A vanilla k8s NetworkPolicy cannot express `reserved:ingress`; Cilium unions all policies selecting an endpoint, so this is **purely additive** to `-isolation` — gateway reachability without weakening tenant isolation (no `world`, so direct public ingress to MGMT stays forbidden per the DMZ design).

**Validated live on hw165 (2026-06-19):** applying exactly these `fromEntities` flipped `gitea` `000/503→303` and recovered **7 of 11** app surfaces instantly (console/gitea/registry/auth/bao/guacamole/pdns up). The remaining 4 (newapi/grafana/hubble/marketplace) are a separate missing-SSO-secret / no-frontend-pod cause, fixed apart.

- chart `0.2.16 → 0.2.17` + blueprint + slot-58 pin lockstep
- `helm template` renders clean (whole-chart + the new CNP)

Refs #2940

🤖 Generated with [Claude Code](https://claude.com/claude-code)