### PR TITLE
fix(cloudinit): ghcr-pull reflect list sme→org-services — unwedge org-services ImagePullBackOff

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -145,6 +145,17 @@ write_files:
   # ── flux-system/ghcr-pull Secret ──────────────────────────────────────
   # imagePullSecret for ghcr.io/openova-io/*. bp-reflector (slot 05a) mirrors
   # it to every workload namespace so catalyst-* + bp-* pods pull cleanly.
+  #
+  # #3819 (rename sme→org-services fallout): the SME service mesh namespace was
+  # renamed `sme`→`org-services` in #3383 (commit 7f6dfca23). The companion DB
+  # secrets (`sme-database-secret` reflect target etc., 16d-bp-postgres-shared-c)
+  # were re-pointed at `org-services`, but THIS image-pull reflect list was left
+  # at the now-dead `sme` ns → `ghcr-pull` never landed in `org-services` →
+  # every org-services Deployment (imagePullSecrets:[ghcr-pull]) hit
+  # `FailedToRetrieveImagePullSecret (ghcr-pull)` → ImagePullBackOff for the whole
+  # funnel/BSS mesh (admin/auth/billing/catalog/console/domain/gateway/marketplace/
+  # notification/organization/provisioning) → marketplace 503. Point the reflect
+  # lists at the post-#3383 mesh namespace. Refs #3383.
   - path: /var/lib/catalyst/ghcr-pull-secret.yaml
     permissions: '0600'
     content: |
@@ -155,9 +166,9 @@ write_files:
         namespace: flux-system
         annotations:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "sme,catalyst,catalyst-system,gitea,harbor,cert-manager,kube-system,flux-system,reflector,reloader,kyverno,opentelemetry,openbao,seaweedfs,powerdns,grafana,loki,mimir,tempo,alloy,coraza,crossplane-system,sigstore-system,trivy-system,syft-grype,falco,vpa,valkey,vllm,dmz,mgmt,rtz,external-dns,external-secrets,cnpg-system,velero,nats-system,sealed-secrets,newapi"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor,cert-manager,kube-system,flux-system,reflector,reloader,kyverno,opentelemetry,openbao,seaweedfs,powerdns,grafana,loki,mimir,tempo,alloy,coraza,crossplane-system,sigstore-system,trivy-system,syft-grype,falco,vpa,valkey,vllm,dmz,mgmt,rtz,external-dns,external-secrets,cnpg-system,velero,nats-system,sealed-secrets,newapi"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "sme,catalyst,catalyst-system,gitea,harbor,cert-manager,kube-system,reflector,reloader,kyverno,opentelemetry,openbao,seaweedfs,powerdns,grafana,loki,mimir,tempo,alloy,coraza,crossplane-system,sigstore-system,trivy-system,syft-grype,falco,vpa,valkey,vllm,dmz,mgmt,rtz,external-dns,external-secrets,cnpg-system,velero,nats-system,sealed-secrets,newapi"
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor,cert-manager,kube-system,reflector,reloader,kyverno,opentelemetry,openbao,seaweedfs,powerdns,grafana,loki,mimir,tempo,alloy,coraza,crossplane-system,sigstore-system,trivy-system,syft-grype,falco,vpa,valkey,vllm,dmz,mgmt,rtz,external-dns,external-secrets,cnpg-system,velero,nats-system,sealed-secrets,newapi"
       type: kubernetes.io/dockerconfigjson
       data:
         .dockerconfigjson: ${base64encode(jsonencode({


### PR DESCRIPTION
## Shared root cause

Every pod in the `org-services` namespace on live hw165 was ImagePullBackOff (admin, auth, billing, catalog, console, domain, gateway, marketplace, notification, organization, provisioning), driving the marketplace to 503 — the funnel/BSS control plane (Pillar 1) was completely down.

kubelet event on every pod:
```
Warning  FailedToRetrieveImagePullSecret  (x781 over 170m)  kubelet
  Unable to retrieve some image pull secrets (ghcr-pull)
```

ONE shared root: the org-services Deployments declare `imagePullSecrets: [ghcr-pull]`, but the `ghcr-pull` dockerconfigjson is distributed by the emberstack Reflector from `flux-system/ghcr-pull` to a **hardcoded allow-list** of namespaces in `infra/providers/_shared/cloudinit-control-plane.tftpl`. That list still named the legacy `sme` namespace and never got `org-services`.

`#3383` (commit `7f6dfca23`) renamed the SME service mesh namespace `sme` → `org-services`. The companion DB-secret reflect targets (`sme-database-secret` etc. in `16d-bp-postgres-shared-c.yaml`) WERE re-pointed at `org-services`, but the `ghcr-pull` reflect list was missed — so `ghcr-pull` landed in 27 namespaces but not `org-services`.

Live proof of root: `kubectl get secret ghcr-pull -n org-services` → NotFound; `kubectl get ns sme` → NotFound; `ghcr-pull` present in 27 other namespaces. Same bug class as the already-fixed `sme-database-secret` miss, just for the image-pull secret.

## Fix

Point both `reflection-allowed-namespaces` + `reflection-auto-namespaces` on `flux-system/ghcr-pull` at `org-services` (dropping the dead `sme`). Single `_shared` template, rendered identically by hetzner + huawei (kom4dc) `main.tf` — no per-provider drift. `scripts/lint-cloudinit.sh both` renders + passes `dash -n` for both providers.

## Live proof on hw165 (post fix-forward)

Patched the live source secret's reflect annotations + bounced the org-services pods. Within ~3s the Reflector mirrored `ghcr-pull` into `org-services`; the `FailedToRetrieveImagePullSecret` error is gone on every pod and images pull cleanly:

```
admin        1/1  Running   |  catalog    1/1  Running
gateway      1/1  Running   |  marketplace 1/1 Running   |  ferretdb 1/1 Running
```

`curl -sk https://marketplace.hw165.omani.works/` → **HTTP 200** (was 503), 3× consecutive; marketplace access log confirms 200 / 19658 bytes served.

The 4 still-restarting services (`auth`→Valkey timeout, `domain`/`notification`/`tenant`→NATS-in-mgmt-vCluster timeout) are a **separate, distinct root cause** (cross-namespace NetworkPolicy / mgmt-vCluster datapath), unrelated to the image-pull layer and outside this change's scope.

Refs #3383
Refs #3819