### PR TITLE
fix(bp-kyverno-policies): exempt trivy-system from flux-managed + harbor-proxy-pull — unblock trivy scan jobs (1.0.36)

### DIFF
--- a/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
+++ b/clusters/_template/bootstrap-kit/27a-kyverno-policies.yaml
@@ -101,7 +101,14 @@ spec:
       # pdns-auth-50 + dnsdist-19 images to raw docker.io because proxy-docker is
       # not bootstrap-pullable on a fresh prov (#3380-D's reroute wedged hw131 +
       # hw132). powerdns stays subject to every OTHER policy (scoped carve-out).
-      version: 1.0.35
+      # 1.0.36 (#3825, hw165, 2026-06-19): EXEMPT `trivy-system` from BOTH
+      # flux-managed (10) + harbor-proxy-pull (11) Enforce policies. The
+      # trivy-operator spawns scan Jobs into trivy-system that carry no flux
+      # owner and use aquasec/trivy scanner images — both Enforce policies denied
+      # every scan-job create cluster-wide so trivy scanning was dead. Scoped
+      # per-policy carve-out (same shape as powerdns + cnpg); trivy-system stays
+      # subject to every other policy.
+      version: 1.0.36
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno-policies/blueprint.yaml
+++ b/platform/kyverno-policies/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.35
+  version: 1.0.36
   card:
     title: Kyverno Policy Library
     family: guardian

--- a/platform/kyverno-policies/chart/Chart.yaml
+++ b/platform/kyverno-policies/chart/Chart.yaml
@@ -1,5 +1,24 @@
 apiVersion: v2
 name: bp-kyverno-policies
+# 1.0.36 (#3825, hw165, 2026-06-19): EXEMPT the `trivy-system` namespace from
+# BOTH the flux-managed (10) and harbor-proxy-pull (11) Enforce policies via
+# the existing per-policy `extraExcludeNamespaces` carve-outs. The
+# trivy-operator dynamically SPAWNS vulnerability scan Jobs into `trivy-system`;
+# those Jobs (a) carry no HelmRelease owner / `app.kubernetes.io/managed-by:
+# flux` label (operator-generated ephemera — the operator definitionally cannot
+# make its dynamic jobs Flux-managed, same class as the CNPG operator's
+# Services/Jobs already exempted) and (b) are imaged from
+# `mirror.gcr.io/aquasec/trivy` + an operator-injected initContainer, neither
+# matching `*/proxy-*/*` or `*/openova-io/*`. On hw165 both Enforce policies
+# denied EVERY scan-job create cluster-wide (trivy-operator log: "creating scan
+# job failed: … workload-must-be-flux-managed … image-from-harbor-proxy-
+# workload"), so trivy vulnerability scanning was silently dead. Scoped to
+# THESE two policies only (operator-spawned scan-job ephemera) — `trivy-system`
+# stays subject to every OTHER policy (the operator Deployment + node-collector
+# pods carry pinned images + resource requests and still pass). Same proven
+# shape as the `powerdns` (harbor-proxy) + `cnpg`/`shared-data`/`powerdns-admin`
+# (flux-managed) carve-outs. values-only change; no template change.
+# Refs #3825 #3642.
 # 1.0.33 (2026-06-13): EXCLUDE the `powerdns` namespace from the
 # harbor-proxy-pull (11) Enforce policy via a new per-policy
 # `harborProxyPull.extraExcludeNamespaces` carve-out (same shape as the
@@ -193,7 +212,7 @@ type: application
 # CREATE/UPDATE only) — a truly fresh prov hits the same wall. Excluding on the
 # operator label exempts ONLY CNPG operator-owned Services + utility Jobs in any
 # namespace; every Flux/Helm/kubectl workload stays gated. Refs #3374 #3248.
-version: 1.0.35
+version: 1.0.36
 appVersion: "1.0.2"
 keywords: [catalyst, blueprint, kyverno, policy, compliance, audit]
 maintainers:

--- a/platform/kyverno-policies/chart/values.yaml
+++ b/platform/kyverno-policies/chart/values.yaml
@@ -189,6 +189,13 @@ compliancePolicies:
       - cnpg            # bp-cnpg-pair primary/replica Clusters → operator Services + Jobs
       - shared-data     # bp-postgres-shared (shared-pg) Cluster → operator Services + Jobs
       - powerdns-admin  # bp-powerdns-admin CNPG Cluster → operator Services + Jobs
+      # 2026-06-19 (#3825, hw165): trivy-operator-spawned scan Jobs carry no
+      # HelmRelease owner / flux label (operator-generated ephemera,
+      # definitionally not Flux-managed — same class as the CNPG operator
+      # Services/Jobs above). flux-managed (Enforce) denied every scan-job
+      # create cluster-wide → trivy scanning dead. Exempt the scan-job
+      # namespace here only; it stays subject to every other policy.
+      - trivy-system    # trivy-operator scan Jobs (operator-generated, no flux owner) (#3825)
 
   harborProxyPull:
     enabled: true
@@ -242,8 +249,22 @@ compliancePolicies:
     # Same shape as the `flux-managed` extraExcludeNamespaces carve-out.
     # Follow-up: making proxy-docker bootstrap-pullable (cred-free like
     # proxy-ghcr) would let us drop this exclude and re-do #3380-D correctly.
+    #
+    # 2026-06-19 (#3825, hw165): the trivy-operator dynamically SPAWNS
+    # vulnerability scan Jobs into `trivy-system`, imaged from
+    # `mirror.gcr.io/aquasec/trivy` plus an operator-injected initContainer —
+    # neither matches `*/proxy-*/*` or `*/openova-io/*`, so harbor-proxy-pull
+    # (Enforce) denied EVERY scan-job create cluster-wide and trivy scanning
+    # silently died (trivy-operator log: "creating scan job failed: …
+    # image-from-harbor-proxy-workload"). The operator cannot re-tag its own
+    # generated scan images through the Sovereign Harbor, so exempt the
+    # scan-job namespace here only — same operator-spawned-ephemera shape as
+    # the `powerdns` docker.io carve-out + the flux-managed cnpg/shared-data
+    # carve-out below. `trivy-system` stays subject to every OTHER policy
+    # (the operator Deployment + node-collector carry pinned images + requests).
     extraExcludeNamespaces:
       - powerdns
+      - trivy-system   # trivy-operator-spawned scan Jobs use aquasec/trivy scanner images (#3825)
 
   imageTagPinned:
     enabled: true


### PR DESCRIPTION
Refs #3825 #3642

## Symptom (live hw165, dep 9ee307969c92452e)
The trivy-operator can no longer create ANY vulnerability scan job — every create is denied by kyverno, so trivy scanning is silently dead cluster-wide. Two pre-enforcement scan pods are also stuck `Error` (kube-system clustermesh-apiserver, cilium).

trivy-trivy-operator log:
```
creating scan job failed: trivy-system/scan-vulnerabilityreport-…: admission webhook "validate.kyverno.svc-fail" denied the request:
  flux-managed: workload-must-be-flux-managed: Job/scan-vulnerabilityreport-… is not Flux-managed…
  harbor-proxy-pull: image-from-harbor-proxy-workload: Container image does not match any allowed Harbor-source glob…
```

## Root cause
The trivy-operator dynamically **spawns** scan Jobs into the `trivy-system` namespace. Those jobs are:
- **operator-generated** — no HelmRelease owner / `app.kubernetes.io/managed-by: flux` label. The operator definitionally cannot make its dynamic jobs Flux-managed → `flux-managed` (Enforce) denies them. Exact same class as the CNPG operator Services/Jobs already in `fluxManaged.extraExcludeNamespaces`.
- imaged from `mirror.gcr.io/aquasec/trivy` + an operator-injected initContainer — neither matches `*/proxy-*/*` or `*/openova-io/*` → `harbor-proxy-pull` (Enforce) denies them. Same class as the `powerdns` docker.io carve-out in `harborProxyPull.extraExcludeNamespaces`.

## Fix (values-only)
Add `trivy-system` to BOTH per-policy carve-outs in `platform/kyverno-policies/chart/values.yaml`:
- `compliancePolicies.fluxManaged.extraExcludeNamespaces` += `trivy-system`
- `compliancePolicies.harborProxyPull.extraExcludeNamespaces` += `trivy-system`

Scoped to these two policies only (operator-spawned scan-job ephemera). `trivy-system` stays subject to every OTHER policy — the operator Deployment + node-collector pods carry pinned images + resource requests and still pass. No template change.

## The two stale Failed pods
The pre-enforcement Failed scan pods (kube-system `clustermesh-apiserver` 0/4, `cilium` 0/7) separately hit a trivy fs-cache lock timeout (`unable to initialize fs cache: cache may be in use by another process: timeout`) when scanning multi-container Pods concurrently. Once the operator stops being blocked it re-creates scans; bp-trivy already sets `excludeNamespaces: kube-system,…` so those kube-system scans age out (ttlSecondsAfterFinished) and are not re-created.

## Lockstep
- chart `Chart.yaml` 1.0.35 -> 1.0.36
- `blueprint.yaml` 1.0.35 -> 1.0.36
- bootstrap-kit slot `27a-kyverno-policies.yaml` pin 1.0.35 -> 1.0.36

## Validation
- `helm template` renders `trivy-system` in all 3 harbor-proxy-pull rules (pod/workload/cronjob) + the flux-managed `workload-must-be-flux-managed` rule (4 occurrences); full render parses (21 docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)