### PR TITLE
fix(sso): restore the SSO secret chain after #3642 host→mgmt-vcluster move (#3820)

### DIFF
--- a/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
+++ b/clusters/_template/bootstrap-kit/13b-bp-sso-bridge.yaml
@@ -150,7 +150,8 @@ spec:
       # kind=reconciler HEALTH leaf. Label-only addition → render otherwise
       # byte-identical. Refs #3646.
       # 0.2.19: reconciler configmap generic gate coverage (#3374).
-      version: 0.2.20
+      # 0.2.21: keycloak/openbao egress namespace default → mgmt (#3820 #3642).
+      version: 0.2.21
       sourceRef:
         kind: HelmRepository
         name: bp-sso-bridge

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -118,7 +118,7 @@ spec:
       # (templates/host-service-aliases.yaml) giving keycloak/gitea-http/openbao
       # plain->mangled reachability — verified live on hw164 (persist + resolve,
       # zero syncer crash).
-      version: 0.2.16
+      version: 0.2.17
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.16
+  version: 0.2.17
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -1,5 +1,18 @@
 apiVersion: v2
 name: bp-mgmt-vcluster
+# 0.2.17 — Refs #3820 #3642: add `external-secrets-system` to
+# mgmtVcluster.networkPolicy.allowedIngressNamespaces. The #3642 host→vCluster
+# move re-homed OpenBao into vc-mgmt, but the isolation NetworkPolicy's ingress
+# carve-out list never allowed external-secrets-system — the host ESO's PRIMARY
+# consumer of OpenBao. Result on hw165: ClusterSecretStore vault-region1
+# InvalidProviderConfig (`unable to log in with Kubernetes auth: context
+# deadline exceeded`) → every *-sso-oidc-credentials ExternalSecret
+# SecretSyncedError → grafana/hubble oidc-gate sidecars + per-app SSO consumers
+# CreateContainerConfigError → public surface 503. Same class as the openbao/*
+# fromHost-mirror miss (#3760). Live-verified: a host pod in
+# external-secrets-system timed out to openbao:8200 while a freshly-minted host
+# ESO SA token logged in fine from inside the openbao pod (XCR TokenReview
+# healthy) — the ONLY wall was this ingress allow-list.
 # 0.1.0 — initial implementation of DoD A4 vCluster topology
 # (sovereign-multi-region-DoD invariant #4). Founder ruling
 # 2026-05-16: every Sovereign must materialise the MGMT + DMZ + RTZ
@@ -167,7 +180,7 @@ name: bp-mgmt-vcluster
 # pre-install hook `secret "catalyst-gitea-token" not found` → install times out
 # → console never comes up. Adds `networking.replicateServices.toHost` exporting
 # the in-vCluster gitea-http back to the host `gitea/gitea-http` Service.
-version: 0.2.16
+version: 0.2.17
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -198,6 +198,24 @@ mgmtVcluster:
       #     cross-vCluster DB wire) instead of owning its host-bridged Cluster,
       #     its in-mgmt Pod must reach rtz. Required once batch-C moves shared-pg.
       - rtz
+      #   external-secrets-system — the host external-secrets-operator (slot 15)
+      #     is the PRIMARY consumer of the now-in-vCluster OpenBao: its
+      #     ClusterSecretStore `vault-region1` dials
+      #     `openbao-x-openbao-x-mgmt-vcluster.mgmt.svc:8200` on EVERY reconcile
+      #     (K8s-auth login + every `secret/sso/*` read). Dropped here, the store
+      #     is `InvalidProviderConfig` (`unable to log in with Kubernetes auth:
+      #     context deadline exceeded`) and EVERY `*-sso-oidc-credentials`
+      #     ExternalSecret stays SecretSyncedError → the oidc-gate sidecars
+      #     (grafana/hubble) + the per-app SSO consumers CreateContainerConfigError
+      #     → the public surface 503s. The #3642 carve-out list shipped the
+      #     gateway/consumer namespaces but DROPPED external-secrets-system even
+      #     though openbao moved INTO vc-mgmt — the same secret-not-reachable
+      #     class as the openbao/* fromHost-mirror miss (#3760). hw165 live RCA
+      #     (#3820): a host pod pinned in external-secrets-system timed out to
+      #     openbao:8200 while a freshly-minted host ESO SA token logged in fine
+      #     from inside the openbao pod (cross-cluster TokenReview healthy) — the
+      #     ONLY wall was this ingress allow-list. Refs #3820 #3642.
+      - external-secrets-system
 
 # ─── Host→vCluster plain-name reachability aliases (#3642 hw164 fix) ───
 # Static host ExternalName Services that alias the PLAIN in-vCluster app

--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.20
+  version: 0.2.21
   card:
     title: sso-bridge
     summary: |

--- a/platform/sso-bridge/chart/Chart.yaml
+++ b/platform/sso-bridge/chart/Chart.yaml
@@ -1,6 +1,20 @@
 apiVersion: v2
 name: bp-sso-bridge
-version: 0.2.20
+version: 0.2.21
+# 0.2.21 (#3820 #3642, 2026-06-18): default networkPolicy.keycloakNamespace +
+# openbaoNamespace `keycloak`/`openbao` → `mgmt`. #3642 (+#3760/#3737) re-homed
+# BOTH keycloak and openbao INTO the mgmt vCluster; their workload Pods now run
+# in the `mgmt` HOST namespace (mangled `*-x-*-x-mgmt-vcluster`), the legacy
+# host namespaces being EMPTY of the actual workload. Cilium enforces egress
+# NetworkPolicy on the destination Pod's namespace+target-port, so the stale
+# `keycloak`/`openbao` selectors matched NOTHING — the reconciler's
+# `mint Keycloak admin token` curl timed out (curl(28)) every tick and NO
+# `secret/sso/*` bundle was written, leaving grafana/harbor/openbao/gitea +
+# every oidc-gate consumer without their SSO secret → 503. hw165 live RCA:
+# reconciler timed out to keycloak even co-located on keycloak's own node; a
+# probe Pod with a different name label (NOT selected by this policy) reached
+# keycloak fine — the egress namespace selector was the sole wall. Once flipped
+# to `mgmt` the reconciler minted tokens + reconciled all 7 SSO HRs.
 # 0.2.20 (#3646, 2026-06-17): stamp the `catalyst.openova.io/reconciler`
 # marker label on the sso-bridge-reconciler Deployment so the jobs canvas's
 # generic §5a reconciler ingestion surfaces it as a kind=reconciler leaf

--- a/platform/sso-bridge/chart/values.yaml
+++ b/platform/sso-bridge/chart/values.yaml
@@ -227,14 +227,30 @@ deploymentAnnotations:
 # NetworkPolicy template. Reviewer-agent verdict 2026-06-01T13:35Z flagged
 # the gap. This block configures the egress allow-list.
 #
-# Default keycloak/openbao Namespaces match the platform charts.
-# Post-G92.2 placement may move these inside the mgmt vCluster — operators
-# rewrite via per-Sovereign overlay in that case.
+# keycloak + openbao egress Namespaces.
+#
+# #3642 (and follow-ons #3760/#3737) re-homed BOTH keycloak and openbao INTO
+# the mgmt vCluster. Their workload Pods now run in the `mgmt` HOST namespace
+# as the syncer-mangled `keycloak-x-keycloak-x-mgmt-vcluster` /
+# `openbao-x-openbao-x-mgmt-vcluster` (the legacy `keycloak`/`openbao` host
+# namespaces still exist but are EMPTY of the actual workload). Cilium enforces
+# egress NetworkPolicy on the DESTINATION Pod's namespace+target-port, so a
+# `keycloakNamespace: keycloak` selector matches NOTHING the reconciler dials —
+# every `mint Keycloak admin token` curl times out (curl(28)) and NO
+# `secret/sso/*` bundle is ever written, leaving grafana/harbor/openbao/gitea
+# (+ every oidc-gate consumer) without their SSO secret → 503. hw165 live RCA
+# (#3820): the reconciler timed out to keycloak even co-located on keycloak's
+# own node, because this K8s NetworkPolicy egress targeted the wrong namespace;
+# a probe Pod with a different `app.kubernetes.io/name` label (so NOT selected
+# by this policy) reached keycloak fine. Default to `mgmt` — the post-#3642
+# canonical topology. A single-region / pre-#3642 placement that keeps keycloak
+# and openbao host-side in their own namespaces overrides these via per-Sovereign
+# overlay. Refs #3820 #3642.
 networkPolicy:
   enabled: true
-  keycloakNamespace: keycloak
+  keycloakNamespace: mgmt
   keycloakPort: 80
-  openbaoNamespace: openbao
+  openbaoNamespace: mgmt
   openbaoPort: 8200
 
 # #2989 residual (0.2.9): the Sovereign's own FQDN as a chart value, used


### PR DESCRIPTION
## Problem
On live Sovereign hw165, the public surfaces grafana / hubble (and the SSO half of openbao/gitea/harbor/powerdns) returned HTTP 503. Root cause: every `*-sso-oidc-credentials` ExternalSecret was `SecretSyncedError`, so the oidc-gate sidecars and per-app SSO consumers sat in `CreateContainerConfigError` and the pods were never Ready (no Gateway endpoint → 503).

Two distinct NetworkPolicy gaps — both fallout from the #3642 host→mgmt-vCluster move of keycloak + openbao — were root-caused on the live cluster.

## Root cause 1 — ESO cannot reach OpenBao (bp-mgmt-vcluster)
`ClusterSecretStore/vault-region1` → `InvalidProviderConfig`: `unable to log in with Kubernetes auth: context deadline exceeded`.

OpenBao now runs inside the mgmt vCluster, fronted by the `mgmt-vcluster-bp-mgmt-vcluster-isolation` NetworkPolicy that default-denies ingress to the mgmt host namespace except `allowedIngressNamespaces`. The #3642 carve-out list added gateway-system/kube-system/catalyst-system/newapi/sso-bridge/oidc-gate/harbor/gitea/velero/rtz — but **omitted `external-secrets-system`**, the host ESO's primary OpenBao consumer.

Live evidence: a host pod pinned in `external-secrets-system` timed out to `openbao:8200` (svc + pod IP), while a freshly-minted host `external-secrets` SA token logged in fine via `bao write auth/kubernetes/login` from inside the openbao pod (cross-cluster TokenReview healthy). The openbao Cilium endpoint's realized ingress allow-list enumerated 13 namespaces, none `external-secrets-system`.

**Fix:** add `external-secrets-system` to `mgmtVcluster.networkPolicy.allowedIngressNamespaces`.

## Root cause 2 — sso-bridge cannot reach Keycloak/OpenBao (bp-sso-bridge)
Even with the store fixed, no `secret/sso/*` bundle existed in OpenBao — the bp-sso-bridge reconciler logged `failed to mint Keycloak admin token` / `curl(28) timeout` every 60s tick.

The reconciler's egress `NetworkPolicy` allowed keycloak only in namespace `keycloak` and openbao only in `openbao` — but #3642 moved both workloads INTO the mgmt vCluster (Pods now in the `mgmt` host namespace as `*-x-*-x-mgmt-vcluster`; the legacy namespaces are empty). Cilium enforces egress on the destination Pod's namespace+target-port, so the stale selectors matched nothing.

Live evidence: the reconciler timed out to keycloak **even co-located on keycloak's own node**, while a probe Pod with a different `app.kubernetes.io/name` label (so NOT selected by the reconciler's egress policy) reached keycloak's master realm fine. Flipping the namespace defaults to `mgmt` made the reconciler immediately mint tokens and reconcile all 7 SSO HRs; `grafana-sso-oidc-credentials`, harbor, openbao, gitea, oidc-gate, powerdns, sandbox ExternalSecrets all went `SecretSynced=True`.

**Fix:** default `networkPolicy.keycloakNamespace` + `openbaoNamespace` → `mgmt` (the post-#3642 canonical topology; single-region/pre-#3642 placements override via per-Sovereign overlay).

## Changes
- `bp-mgmt-vcluster` 0.2.16 → 0.2.17 — allow-list `external-secrets-system`.
- `bp-sso-bridge` 0.2.20 → 0.2.21 — keycloak/openbao egress namespace default → `mgmt`.
- Chart.yaml + blueprint.yaml + bootstrap-kit slot pins bumped in lockstep; both charts `helm template` clean.

Both root causes were also hot-fixed live on hw165 (additive NetworkPolicies) to recover the surfaces immediately; these chart changes are the durable fix for future provs.

Refs #3820
Refs #3642

🤖 Generated with [Claude Code](https://claude.com/claude-code)