### PR TITLE
fix(catalyst-api): slug Org FQDN to an RFC-1123 namespace at every create seam

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -69,6 +69,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/dynamic"
 
 	"github.com/openova-io/openova/core/controllers/pkg/validate"
@@ -443,39 +444,46 @@ func (h *Handler) HandleApplicationInstall(w http.ResponseWriter, r *http.Reques
 	// before creating the Application CR, so an install never fails with
 	// `namespaces "<org>" not found` when the organization controller's
 	// GitOps namespace reconcile hasn't landed yet. Idempotent.
+	//
+	// #3830 — the OrganizationRef is the Org identity (often a dotted
+	// FQDN, e.g. "hw165.omani.works"); the namespace is the slugged
+	// RFC-1123 form. ensureOrgNamespace + the create below + the CR's
+	// metadata.namespace (newApplicationUnstructured) all route through
+	// orgNamespace() so they resolve to ONE consistent namespace.
+	appNS := orgNamespace(body.OrganizationRef)
 	if nsErr := ensureOrgNamespace(r.Context(), client, body.OrganizationRef); nsErr != nil {
 		writeJSON(w, http.StatusOK, map[string]any{
 			"kind":       "Application",
 			"name":       body.Name,
-			"namespace":  body.OrganizationRef,
+			"namespace":  appNS,
 			"error":      "namespace-ensure-failed",
 			"status":     "503",
 			"httpStatus": 503,
 			"applied":    false,
-			"detail":     fmt.Sprintf("could not ensure namespace %q: %v", body.OrganizationRef, nsErr),
+			"detail":     fmt.Sprintf("could not ensure namespace %q: %v", appNS, nsErr),
 		})
 		return
 	}
 
 	obj := newApplicationUnstructured(body)
-	created, err := client.Resource(ApplicationGVR()).Namespace(body.OrganizationRef).Create(
+	created, err := client.Resource(ApplicationGVR()).Namespace(appNS).Create(
 		r.Context(), obj, metav1.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			writeJSON(w, http.StatusOK, map[string]any{
 				"kind":       "Application",
 				"name":       body.Name,
-				"namespace":  body.OrganizationRef,
+				"namespace":  appNS,
 				"error":      "application-exists",
 				"status":     "409",
 				"httpStatus": 409,
 				"applied":    false,
-				"detail":     fmt.Sprintf("Application %q already exists in namespace %q", body.Name, body.OrganizationRef),
+				"detail":     fmt.Sprintf("Application %q already exists in namespace %q", body.Name, appNS),
 			})
 			return
 		}
 		h.log.Warn("application install: create CR failed",
-			"depId", depID, "name", body.Name, "ns", body.OrganizationRef, "err", err)
+			"depId", depID, "name", body.Name, "ns", appNS, "err", err)
 		writeApplicationInstallSoftError(w, "application-create-failed", http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -806,8 +814,13 @@ func validateApplicationInstallRequest(req applicationInstallRequest) (string, b
 	if strings.TrimSpace(req.OrganizationRef) == "" {
 		return "organizationRef is required", false
 	}
-	if !isValidK8sName(req.OrganizationRef) {
-		return "organizationRef must be a valid K8s name", false
+	// #3830 — the OrganizationRef is the Org identity, which is a DNS
+	// subdomain / FQDN (e.g. "hw165.omani.works"), NOT an RFC-1123 label.
+	// Validating it with isValidK8sName rejected every dotted Org and 400'd
+	// the create before it reached the (now slug-mapped) namespace seam.
+	// Accept a DNS subdomain; orgNamespace() slugs it for the namespace.
+	if !isValidOrgRef(req.OrganizationRef) {
+		return "organizationRef must be a valid DNS name (Org slug or FQDN, e.g. acme or hw165.omani.works)", false
 	}
 	if strings.TrimSpace(req.EnvironmentRef) == "" {
 		return "environmentRef is required", false
@@ -929,7 +942,10 @@ func newApplicationUnstructured(req applicationInstallRequest) *unstructured.Uns
 	obj.SetAPIVersion(ApplicationGVR().Group + "/" + ApplicationGVR().Version)
 	obj.SetKind("Application")
 	obj.SetName(req.Name)
-	obj.SetNamespace(req.OrganizationRef)
+	// #3830 — metadata.namespace is the slugged RFC-1123 form of the Org
+	// ref (which is often a dotted FQDN). The verbatim Org identity is
+	// preserved on the `catalyst.openova.io/organization` label below.
+	obj.SetNamespace(orgNamespace(req.OrganizationRef))
 	obj.SetLabels(map[string]string{
 		"catalyst.openova.io/managed-by":      "catalyst-api",
 		"catalyst.openova.io/organization":    req.OrganizationRef,
@@ -1080,6 +1096,18 @@ func isValidK8sName(s string) bool {
 		}
 	}
 	return true
+}
+
+// isValidOrgRef checks the Organization-reference shape (#3830). The Org
+// identity is a DNS subdomain — either a bare slug ("acme") or a dotted
+// FQDN ("hw165.omani.works"). This is intentionally looser than
+// isValidK8sName (which forbids dots): the namespace is *derived* from the
+// Org ref via orgNamespace(), so the ref itself must be allowed to carry
+// the FQDN. We delegate to k8s' canonical RFC-1123 subdomain validator so
+// the accepted set matches what the rest of the platform treats as a valid
+// hostname (lowercase, dot-separated labels, ≤253 chars).
+func isValidOrgRef(s string) bool {
+	return len(validation.IsDNS1123Subdomain(strings.TrimSpace(s))) == 0
 }
 
 // ── HTTP handler — get (GET /sovereigns/{id}/applications/{name}) ───

--- a/products/catalyst/bootstrap/api/internal/handler/applications_preview.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_preview.go
@@ -208,8 +208,10 @@ func renderApplicationCRPreview(body applicationPreviewRequest) *applicationPrev
 		APIVersion: gvr.Group + "/" + gvr.Version,
 		Kind:       "Application",
 		Metadata: map[string]interface{}{
-			"name":      appName,
-			"namespace": body.OrganizationRef,
+			"name": appName,
+			// #3830 — preview the SLUGGED namespace the real create will
+			// land the CR in (the apiserver rejects a dotted namespace).
+			"namespace": orgNamespace(body.OrganizationRef),
 		},
 		Spec: map[string]interface{}{
 			"blueprintRef": map[string]interface{}{
@@ -500,8 +502,10 @@ func validateApplicationPreviewRequest(req applicationPreviewRequest) (string, b
 	if strings.TrimSpace(req.OrganizationRef) == "" {
 		return "organizationRef is required", false
 	}
-	if !isValidK8sName(req.OrganizationRef) {
-		return "organizationRef must be a valid K8s name", false
+	// #3830 — Org ref is a DNS subdomain / FQDN (slugged to a namespace via
+	// orgNamespace), kept in lockstep with validateApplicationInstallRequest.
+	if !isValidOrgRef(req.OrganizationRef) {
+		return "organizationRef must be a valid DNS name (Org slug or FQDN, e.g. acme or hw165.omani.works)", false
 	}
 	if strings.TrimSpace(req.EnvironmentRef) == "" {
 		return "environmentRef is required", false

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
@@ -895,7 +895,11 @@ func (h *Handler) HandleCreateInstance(w http.ResponseWriter, r *http.Request) {
 	if len(dependsOnEntries) > 0 {
 		_ = unstructured.SetNestedSlice(obj.Object, dependsOnEntries, "spec", "dependsOn")
 	}
-	created, err := client.Resource(ApplicationGVR()).Namespace(body.Org).Create(
+	// #3830 — create into the slugged namespace, matching the CR's
+	// metadata.namespace (newApplicationCRFromSeed) and the namespace
+	// ensureOrgNamespace created above. body.Org (the FQDN) stays the Org
+	// identity in user-facing messages + labels.
+	created, err := client.Resource(ApplicationGVR()).Namespace(orgNamespace(body.Org)).Create(
 		r.Context(), obj, metav1.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
@@ -987,6 +991,11 @@ func (h *Handler) wireBackingServices(ctx context.Context, client dynamic.Interf
 	if len(body.Backing) == 0 {
 		return nil, nil
 	}
+	// #3830 — slugged namespace for this Org (body.Org is the FQDN Org
+	// identity). The reflected-credential target namespace, the backing CR
+	// create, and the consumer's dependsOn pointer all use this so they
+	// agree with where the consumer + backing CRs actually live.
+	orgNS := orgNamespace(body.Org)
 	dependsOn := make([]interface{}, 0, len(body.Backing))
 	for _, sel := range body.Backing {
 		bpFull := sel.Blueprint
@@ -1018,7 +1027,9 @@ func (h *Handler) wireBackingServices(ctx context.Context, client dynamic.Interf
 			},
 			"reflect": map[string]interface{}{
 				"secretName": credential,
-				"namespaces": []interface{}{body.Org},
+				// #3830 — reflect the credential into the slugged consumer
+				// namespace (where the consumer CR + its pods live).
+				"namespaces": []interface{}{orgNS},
 			},
 		}
 
@@ -1058,7 +1069,7 @@ func (h *Handler) wireBackingServices(ctx context.Context, client dynamic.Interf
 					_ = unstructured.SetNestedField(backingObj.Object, v, "spec", "blueprintRef", "version")
 				}
 			}
-			if _, cerr := client.Resource(ApplicationGVR()).Namespace(body.Org).Create(ctx, backingObj, metav1.CreateOptions{}); cerr != nil {
+			if _, cerr := client.Resource(ApplicationGVR()).Namespace(orgNS).Create(ctx, backingObj, metav1.CreateOptions{}); cerr != nil {
 				if !apierrors.IsAlreadyExists(cerr) {
 					return nil, &backingError{status: http.StatusInternalServerError, code: "backing-create-failed", message: cerr.Error()}
 				}
@@ -1072,7 +1083,7 @@ func (h *Handler) wireBackingServices(ctx context.Context, client dynamic.Interf
 			}
 			dependsOn = append(dependsOn, map[string]interface{}{
 				"name":      backingName,
-				"namespace": body.Org,
+				"namespace": orgNS,
 				"context":   ctxSchema.Kind + "/" + contextName,
 			})
 
@@ -2075,10 +2086,15 @@ func readMultiInstance(bp *blueprintMeta) multiInstanceDecl {
 	return *bp.MultiInstance
 }
 
-// listAppsInOrg lists Applications in `org` namespace whose
+// listAppsInOrg lists Applications in the `org` namespace whose
 // spec.blueprintRef.name matches `blueprint` (with or without bp-).
+//
+// #3830 — `org` is the Org ref (often a dotted FQDN); it is slugged via
+// orgNamespace() so this existing-instance lookup addresses the SAME
+// namespace the create path writes into (the admission name-collision
+// gate that consumes this list must see the already-installed CRs).
 func listAppsInOrg(ctx context.Context, c dynamic.Interface, org, blueprint string) ([]unstructured.Unstructured, error) {
-	list, err := c.Resource(ApplicationGVR()).Namespace(org).List(ctx, metav1.ListOptions{})
+	list, err := c.Resource(ApplicationGVR()).Namespace(orgNamespace(org)).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -2103,7 +2119,11 @@ func newApplicationCRFromSeed(seed instances.ApplicationSeed) *unstructured.Unst
 	obj.SetAPIVersion(ApplicationGVR().Group + "/" + ApplicationGVR().Version)
 	obj.SetKind("Application")
 	obj.SetName(seed.Name)
-	obj.SetNamespace(seed.Namespace)
+	// #3830 — seed.Namespace carries the Org ref (often a dotted FQDN).
+	// metadata.namespace must be the slugged RFC-1123 form; the verbatim
+	// Org identity is preserved on the catalyst.openova.io/organization
+	// label (set in instances.Build) and on environmentRef below.
+	obj.SetNamespace(orgNamespace(seed.Namespace))
 	obj.SetLabels(seed.Labels)
 	// One vocabulary (#3375 DoD-1): both the string AND object forms
 	// stamp the CANONICAL placement token. placementForTopology folds

--- a/products/catalyst/bootstrap/api/internal/handler/namespace_ensure.go
+++ b/products/catalyst/bootstrap/api/internal/handler/namespace_ensure.go
@@ -22,6 +22,66 @@ func namespacesGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
 }
 
+// orgNamespace maps an Organization reference to the Kubernetes namespace
+// name that hosts that Org's Application CRs.
+//
+// Why this exists (#3830, EPIC #3376): every Sovereign Organization is
+// identified by a dotted FQDN (e.g. "hw165.omani.works"). Kubernetes
+// namespace names are RFC-1123 *labels* — they may NOT contain dots, must
+// be lowercase, ≤63 chars, and start/end with an alphanumeric. Passing the
+// FQDN straight through to `.Namespace(org).Create(...)` made the create
+// path fail UNIVERSALLY with `Namespace "<fqdn>" is invalid:
+// metadata.name: ... must not contain dots`. This helper is the single
+// canonical org→namespace seam: every place an Org ref becomes a namespace
+// routes through it, so create + lookup + the Application CR's
+// metadata.namespace always resolve to ONE consistent name (no split-brain
+// where an instance is created in one namespace and looked up in another).
+//
+// Mapping rules (sanitise, never reject — the Org identity stays on the
+// `catalyst.openova.io/organization` label as the verbatim FQDN; the
+// namespace is a derived artifact):
+//
+//   - lowercase
+//   - any character that is not [a-z0-9-] (dots included) → '-'
+//   - collapse runs of '-' to a single '-'
+//   - trim leading/trailing '-'
+//   - cap at 63 chars, then re-trim a trailing '-' the cap may have left
+//   - empty result (pathological all-illegal input) → "org" so the caller
+//     never addresses a cluster-scoped object with an empty name
+//
+// orgNamespace("hw165.omani.works") → "hw165-omani-works".
+func orgNamespace(ref string) string {
+	s := strings.ToLower(strings.TrimSpace(ref))
+
+	var sb strings.Builder
+	sb.Grow(len(s))
+	prevDash := false
+	for _, r := range s {
+		isAllowed := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if isAllowed {
+			sb.WriteRune(r)
+			prevDash = false
+			continue
+		}
+		// Every other rune (dots, slashes, spaces, underscores, unicode…)
+		// folds to a single dash; collapse consecutive dashes.
+		if !prevDash {
+			sb.WriteByte('-')
+			prevDash = true
+		}
+	}
+	out := strings.Trim(sb.String(), "-")
+
+	if len(out) > 63 {
+		out = out[:63]
+		out = strings.TrimRight(out, "-")
+	}
+	if out == "" {
+		return "org"
+	}
+	return out
+}
+
 // ensureOrgNamespace creates the target Organization/Environment
 // namespace if it does not already exist, returning nil when the
 // namespace is present (created-or-verified).
@@ -48,11 +108,17 @@ func namespacesGVR() schema.GroupVersionResource {
 // A blank namespace name is a programmer error (the caller validated the
 // Org slug upstream); we return an error rather than creating a
 // cluster-scoped object with an empty name.
+//
+// #3830 — the argument is an Organization reference (often a dotted FQDN);
+// it is run through orgNamespace() so the namespace this function
+// creates/verifies is always a valid RFC-1123 label and is byte-identical
+// to the name the Application-create call sites address via the same
+// helper (no split-brain).
 func ensureOrgNamespace(ctx context.Context, client dynamic.Interface, namespace string) error {
-	ns := strings.TrimSpace(namespace)
-	if ns == "" {
+	if strings.TrimSpace(namespace) == "" {
 		return fmt.Errorf("ensureOrgNamespace: empty namespace")
 	}
+	ns := orgNamespace(namespace)
 
 	// Fast path: already present.
 	if _, err := client.Resource(namespacesGVR()).Get(ctx, ns, metav1.GetOptions{}); err == nil {

--- a/products/catalyst/bootstrap/api/internal/handler/namespace_ensure_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/namespace_ensure_test.go
@@ -7,6 +7,7 @@ package handler
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -14,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
 
@@ -94,5 +96,95 @@ func TestEnsureOrgNamespace_RejectsEmpty(t *testing.T) {
 	client := fakeNamespaceClient()
 	if err := ensureOrgNamespace(context.Background(), client, "   "); err == nil {
 		t.Fatalf("ensureOrgNamespace(\"\") = nil, want error")
+	}
+}
+
+// ── #3830 — orgNamespace FQDN → RFC-1123 label slug ────────────────────
+
+// TestOrgNamespace_SlugsDottedFQDN is the headline #3830 contract: a
+// dotted Organization FQDN maps to a dash-joined RFC-1123 label.
+func TestOrgNamespace_SlugsDottedFQDN(t *testing.T) {
+	if got := orgNamespace("hw165.omani.works"); got != "hw165-omani-works" {
+		t.Fatalf("orgNamespace(\"hw165.omani.works\") = %q, want %q", got, "hw165-omani-works")
+	}
+}
+
+// TestOrgNamespace_OutputIsAlwaysValidLabel asserts every mapping output
+// satisfies Kubernetes' own RFC-1123 label validator — so the namespace
+// create can never fail with "must not contain dots" / "must be a valid
+// label" again. Inputs are deliberately abusive: dots, uppercase,
+// over-63-char, leading/trailing dot, underscores, unicode, all-illegal.
+func TestOrgNamespace_OutputIsAlwaysValidLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string // "" = don't assert exact, only validity
+	}{
+		{"plain-slug-untouched", "acme", "acme"},
+		{"dotted-fqdn", "hw165.omani.works", "hw165-omani-works"},
+		{"uppercase-folded", "HW165.Omani.WORKS", "hw165-omani-works"},
+		{"leading-dot-trimmed", ".acme.omani.homes", "acme-omani-homes"},
+		{"trailing-dot-trimmed", "acme.omani.homes.", "acme-omani-homes"},
+		{"underscores-and-spaces", "my_org name.omani.rest", "my-org-name-omani-rest"},
+		{"collapse-repeats", "a...b___c", "a-b-c"},
+		{"unicode-stripped", "café.omani.works", "caf-omani-works"},
+		// 70-char input → capped to ≤63 and still a valid label.
+		{"over-63-capped", strings.Repeat("a", 70) + ".omani.works", ""},
+		// All-illegal input must not yield an empty (invalid) namespace.
+		{"all-illegal-fallback", "...___...", "org"},
+		{"whitespace-only-fallback", "   ", "org"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := orgNamespace(tc.in)
+			if tc.want != "" && got != tc.want {
+				t.Fatalf("orgNamespace(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if got == "" {
+				t.Fatalf("orgNamespace(%q) returned empty string — never a valid namespace", tc.in)
+			}
+			if len(got) > 63 {
+				t.Fatalf("orgNamespace(%q) = %q is %d chars, exceeds the 63-char label cap", tc.in, got, len(got))
+			}
+			// The canonical assertion: the output passes k8s' own
+			// RFC-1123 label validation (the exact rule the apiserver
+			// applies to metadata.name on a Namespace).
+			if errs := validation.IsDNS1123Label(got); len(errs) > 0 {
+				t.Fatalf("orgNamespace(%q) = %q is NOT a valid RFC-1123 label: %v", tc.in, got, errs)
+			}
+		})
+	}
+}
+
+// TestOrgNamespace_Idempotent — slugging an already-slugged value is a
+// no-op, so a value that round-trips through the helper twice (e.g. a CR
+// whose metadata.namespace is read back and re-passed) stays stable.
+func TestOrgNamespace_Idempotent(t *testing.T) {
+	for _, in := range []string{"hw165.omani.works", "acme", "HW165.Omani.WORKS"} {
+		once := orgNamespace(in)
+		twice := orgNamespace(once)
+		if once != twice {
+			t.Fatalf("orgNamespace not idempotent for %q: once=%q twice=%q", in, once, twice)
+		}
+	}
+}
+
+// TestEnsureOrgNamespace_SlugsDottedFQDN — the end-to-end #3830 contract:
+// passing a dotted Org FQDN to ensureOrgNamespace creates the SLUGGED
+// namespace (never the raw dotted name, which the apiserver rejects).
+func TestEnsureOrgNamespace_SlugsDottedFQDN(t *testing.T) {
+	client := fakeNamespaceClient()
+
+	if err := ensureOrgNamespace(context.Background(), client, "hw165.omani.works"); err != nil {
+		t.Fatalf("ensureOrgNamespace(dotted FQDN) returned error: %v", err)
+	}
+
+	// The slugged namespace exists…
+	if _, err := getNamespace(t, client, "hw165-omani-works"); err != nil {
+		t.Fatalf("slugged namespace hw165-omani-works not present after ensure: %v", err)
+	}
+	// …and the raw dotted name was NEVER created.
+	if _, err := getNamespace(t, client, "hw165.omani.works"); !apierrors.IsNotFound(err) {
+		t.Fatalf("raw dotted namespace must not exist, got err=%v", err)
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/placement_3373_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/placement_3373_test.go
@@ -182,3 +182,64 @@ func TestReadTopology_ObjectFormMode(t *testing.T) {
 		t.Fatalf("readTopology object-form = %q, want active-hotstandby", got)
 	}
 }
+
+// ── #3830 — dotted Org FQDN → slugged metadata.namespace on both CR
+// write paths. The CR must NEVER carry a dotted metadata.namespace (the
+// apiserver rejects it); the verbatim Org identity stays on the
+// organization label + environmentRef.
+
+func TestNewApplicationUnstructured_DottedOrgSlugsNamespace(t *testing.T) {
+	req := applicationInstallRequest{
+		BlueprintRef:    applicationBlueprintRef{Name: "bp-wp", Version: "1.0.0"},
+		Name:            "site",
+		OrganizationRef: "hw165.omani.works",
+		EnvironmentRef:  "hw165.omani.works-prod",
+		Placement:       applicationPlacement{Mode: "singleton", Regions: []string{"fsn"}},
+	}
+	obj := newApplicationUnstructured(req)
+	if ns := obj.GetNamespace(); ns != "hw165-omani-works" {
+		t.Fatalf("metadata.namespace = %q, want slugged hw165-omani-works", ns)
+	}
+	// The verbatim FQDN identity is preserved on the org label …
+	if org := obj.GetLabels()["catalyst.openova.io/organization"]; org != "hw165.omani.works" {
+		t.Fatalf("organization label = %q, want verbatim FQDN hw165.omani.works", org)
+	}
+	// … and on environmentRef (a Catalyst Environment ref, not a namespace).
+	if env, _, _ := unstructured.NestedString(obj.Object, "spec", "environmentRef"); env != "hw165.omani.works-prod" {
+		t.Fatalf("spec.environmentRef = %q, want verbatim hw165.omani.works-prod", env)
+	}
+}
+
+func TestNewApplicationCRFromSeed_DottedOrgSlugsNamespace(t *testing.T) {
+	seed := instances.ApplicationSeed{
+		Name:      "obs",
+		Namespace: "hw165.omani.works", // instances.Build sets Namespace = Org (the FQDN)
+		Blueprint: "bp-grafana",
+		Topology:  "singleton",
+		Labels:    map[string]string{"catalyst.openova.io/organization": "hw165.omani.works"},
+	}
+	obj := newApplicationCRFromSeed(seed)
+	if ns := obj.GetNamespace(); ns != "hw165-omani-works" {
+		t.Fatalf("metadata.namespace = %q, want slugged hw165-omani-works", ns)
+	}
+	// environmentRef keeps the FQDN form (seed.Namespace + "-prod").
+	if env, _, _ := unstructured.NestedString(obj.Object, "spec", "environmentRef"); env != "hw165.omani.works-prod" {
+		t.Fatalf("spec.environmentRef = %q, want hw165.omani.works-prod", env)
+	}
+}
+
+// #3830 — the install validator must ACCEPT a dotted Org FQDN (the Org
+// identity is a DNS subdomain; the namespace is derived from it). Before
+// the fix this 400'd with "must be a valid K8s name".
+func TestValidateApplicationInstall_AcceptsDottedOrgFQDN(t *testing.T) {
+	req := applicationInstallRequest{
+		BlueprintRef:    applicationBlueprintRef{Name: "bp-wp", Version: "1.0.0"},
+		Name:            "site",
+		OrganizationRef: "hw165.omani.works",
+		EnvironmentRef:  "hw165.omani.works-prod",
+		Placement:       applicationPlacement{Mode: "singleton", Regions: []string{"fsn"}},
+	}
+	if msg, ok := validateApplicationInstallRequest(req); !ok {
+		t.Fatalf("dotted Org FQDN must be accepted, got rejection: %q", msg)
+	}
+}


### PR DESCRIPTION
## Problem

Creating any instance/app from the console for a real (dotted) Organization fails immediately:

```
Namespace "hw165.omani.works" is invalid: metadata.name: Invalid value:
"hw165.omani.works": must not contain dots (namespace-ensure-failed)
```

The Organization ref (an FQDN, with dots) was passed straight through as the Kubernetes namespace name. Kubernetes namespace names are RFC-1123 *labels* — dots are illegal. Every Sovereign Organization is identified by a dotted FQDN, so this breaks the create path for **any** real Org from the UI.

## Fix

A single canonical org→namespace helper, `orgNamespace(ref string) string`, maps an FQDN to a valid RFC-1123 label: lowercase, dots / illegal chars → `-`, collapse repeats, trim leading/trailing `-`, cap ≤63 chars, `"org"` fallback for pathological all-illegal input. `orgNamespace("hw165.omani.works")` → `"hw165-omani-works"`.

Every seam where an Org ref becomes a namespace routes through the **same** helper, so create + ensure + lookup + the Application CR's `metadata.namespace` + secret-reflect + dependsOn all resolve to **one consistent namespace** (no split-brain where an instance created in one namespace can't be found again):

- `ensureOrgNamespace` (slugs internally)
- `HandleApplicationInstall` create + response echo (`applications.go`)
- `newApplicationUnstructured` `SetNamespace` — the CR's `metadata.namespace` (`applications.go`)
- `HandleCreateInstance` consumer create (`endpoint_handler.go`)
- `wireBackingServices`: backing-service create, `reflect.namespaces` (secret reflection target), `dependsOn[].namespace`
- `newApplicationCRFromSeed` `SetNamespace` (`endpoint_handler.go`)
- `listAppsInOrg` existing-instance lookup that feeds the admission name-collision gate

The verbatim Org identity is preserved on the `catalyst.openova.io/organization` label and on `environmentRef` (a Catalyst Environment ref, `{org}-{env_type}`, **not** a namespace) — only the *derived namespace artifact* is slugged.

The application-controller already reads `app.GetNamespace()` off the live CR (`fanout.go` `AppNamespace`, set from `app.GetNamespace()`), so the slugged `metadata.namespace` flows through to the rendered HelmReleases unchanged — **no controller change required**.

Also relaxed the install + preview request validators: `organizationRef` is a DNS subdomain / FQDN (`isValidOrgRef`, delegating to `validation.IsDNS1123Subdomain`), not an RFC-1123 label. The previous `isValidK8sName(organizationRef)` guard would have 400'd every dotted Org *before* the create path. The preview now echoes the slugged namespace it will actually create.

## Tests

`go build ./...` + `go vet ./internal/handler/` clean. New unit tests (all green):

- `orgNamespace` output asserted against k8s' own `validation.IsDNS1123Label` on abusive inputs (dotted, uppercase, >63-char, leading/trailing dot, underscores/spaces, unicode, all-illegal, whitespace-only) + exact mapping + idempotence.
- `ensureOrgNamespace` creates the **slugged** namespace from a dotted FQDN and never the raw dotted name.
- Both CR write paths (`newApplicationUnstructured`, `newApplicationCRFromSeed`) stamp the slugged `metadata.namespace` while preserving the FQDN on the org label + `environmentRef`.
- The install validator accepts a dotted Org FQDN.

```
ok  github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler   (orgNamespace/ensure/builders/validator subset PASS)
ok  github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler   93.092s  (full package)
ok  github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/instances 0.002s
```

Refs #3830 #3376

🤖 Generated with [Claude Code](https://claude.com/claude-code)