### PR TITLE
fix(console): AppDetail Topology 'Effective class' honest-floor for an unbuilt DR mandate

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.dr.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.dr.test.tsx
@@ -187,17 +187,18 @@ describe('TopologyTab — reads back LIVE DR state (#3375)', () => {
     expect(getContinuum).not.toHaveBeenCalled()
   })
 
-  // #3829 — the "Effective class" honest-floor. A DR-capable mandate that is
+  // #3829 - the "Effective class" honest-floor. A DR-capable mandate that is
   // NOT realized by a live Continuums pair must read as a DEGRADED singleton,
   // never the unbuilt mandate parroted as effective. openbao on a 2-region
-  // prov declares active-passive but (default-OFF Continuum, no cnpg-pair)
-  // has no live pair → the field must say "singleton (DEGRADED — active-passive
-  // mandate unbuilt)", not "active-passive (multi-region · 2 regions)".
+  // prov declares active-passive but (default-OFF Continuum, no cnpg-pair) has
+  // no live pair, so the field must say
+  // "singleton (DEGRADED ... active-passive mandate unbuilt)" rather than a
+  // realized "active-passive (multi-region ...)".
   it('Effective class reads DEGRADED-singleton when the declared DR mandate has no live pair (#3829)', async () => {
     getHierarchicalInfrastructure.mockResolvedValue(TWO_REGION_INFRA)
-    // Bootstrap app: no Application CR → status fetch yields nothing.
+    // Bootstrap app: no Application CR, so the status fetch yields nothing.
     getApplicationStatus.mockRejectedValue(new Error('application status: HTTP 404'))
-    // No live Continuum pair on this Sovereign — the backend 404s.
+    // No live Continuum pair on this Sovereign: the backend 404s.
     getContinuum.mockRejectedValue(new Error('continuum get: HTTP 404'))
 
     render(
@@ -210,10 +211,9 @@ describe('TopologyTab — reads back LIVE DR state (#3375)', () => {
     await waitFor(() => {
       expect(eff.textContent).toContain('DEGRADED')
     })
-    // The honest floor: a degraded singleton naming the unbuilt mandate …
     expect(eff.textContent).toContain('singleton')
     expect(eff.textContent).toContain('active-passive mandate unbuilt')
-    // … and crucially NOT the mandate presented as a realized multi-region class.
+    // Crucially NOT the mandate presented as a realized multi-region class.
     expect(eff.textContent).not.toContain('multi-region')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.dr.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.dr.test.tsx
@@ -186,4 +186,34 @@ describe('TopologyTab — reads back LIVE DR state (#3375)', () => {
     expect(screen.queryByTestId('topology-tab-observed-strip')).toBeNull()
     expect(getContinuum).not.toHaveBeenCalled()
   })
+
+  // #3829 — the "Effective class" honest-floor. A DR-capable mandate that is
+  // NOT realized by a live Continuums pair must read as a DEGRADED singleton,
+  // never the unbuilt mandate parroted as effective. openbao on a 2-region
+  // prov declares active-passive but (default-OFF Continuum, no cnpg-pair)
+  // has no live pair → the field must say "singleton (DEGRADED — active-passive
+  // mandate unbuilt)", not "active-passive (multi-region · 2 regions)".
+  it('Effective class reads DEGRADED-singleton when the declared DR mandate has no live pair (#3829)', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue(TWO_REGION_INFRA)
+    // Bootstrap app: no Application CR → status fetch yields nothing.
+    getApplicationStatus.mockRejectedValue(new Error('application status: HTTP 404'))
+    // No live Continuum pair on this Sovereign — the backend 404s.
+    getContinuum.mockRejectedValue(new Error('continuum get: HTTP 404'))
+
+    render(
+      withProviders(
+        <TopologyTab sovereignId="hw165" applicationName="openbao" namespace="openbao" />,
+      ),
+    )
+
+    const eff = await screen.findByTestId('topology-tab-declared-effective')
+    await waitFor(() => {
+      expect(eff.textContent).toContain('DEGRADED')
+    })
+    // The honest floor: a degraded singleton naming the unbuilt mandate …
+    expect(eff.textContent).toContain('singleton')
+    expect(eff.textContent).toContain('active-passive mandate unbuilt')
+    // … and crucially NOT the mandate presented as a realized multi-region class.
+    expect(eff.textContent).not.toContain('multi-region')
+  })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -691,15 +691,52 @@ function DeclaredTopologyPanel({
           <dl className="grid grid-cols-1 gap-x-6 gap-y-1.5 text-xs sm:grid-cols-2">
             <div className="flex justify-between gap-3 sm:block">
               <dt className="text-[var(--color-text-dim)]">Effective class</dt>
-              <dd
-                className="font-mono text-[var(--color-text)]"
-                data-testid="topology-tab-declared-effective"
-              >
-                {classLabel(declaredClass)}{' '}
-                <span className="text-[var(--color-text-dim)]">
-                  ({isMultiRegion ? `multi-region · ${sovereignRegionCount} regions` : 'single-region default'})
-                </span>
-              </dd>
+              {/* #3829 (DR-UI honesty floor) — the EFFECTIVE class is the
+                  REALIZED state, never the declared mandate parroted back. A
+                  DR-capable mandate (active-hot-standby / active-passive) is
+                  "effective" only when a live Continuums (dr.openova.io) CR /
+                  cnpg-pair actually backs it (liveDR.exists). When the mandate
+                  is declared but NOT realized — the openbao case: active-passive
+                  mandate, zero Continuum CR, two disconnected singletons — the
+                  honest effective state is a degraded singleton. We say so
+                  explicitly instead of printing "active-passive (2 regions…)"
+                  ahead of any built pair. While the live read is still in
+                  flight we show a neutral checking state, never a premature
+                  DEGRADED or a fabricated class. */}
+              {showDR && !liveDR.exists ? (
+                liveDR.loading ? (
+                  <dd
+                    className="font-mono text-[var(--color-text-dim)]"
+                    data-testid="topology-tab-declared-effective"
+                  >
+                    checking…{' '}
+                    <span className="text-[var(--color-text-dim)]">
+                      (resolving live {classLabel(declaredClass)} pair)
+                    </span>
+                  </dd>
+                ) : (
+                  <dd
+                    className="font-mono text-[var(--color-warning,#b45309)]"
+                    data-testid="topology-tab-declared-effective"
+                    title={`The ${classLabel(declaredClass)} mandate declared in this Blueprint is not yet realized by a live Continuums (dr.openova.io) pair on this Sovereign — the app currently runs as a single instance with no cross-region failover.`}
+                  >
+                    singleton{' '}
+                    <span className="text-[var(--color-text-dim)]">
+                      (DEGRADED — {classLabel(declaredClass)} mandate unbuilt)
+                    </span>
+                  </dd>
+                )
+              ) : (
+                <dd
+                  className="font-mono text-[var(--color-text)]"
+                  data-testid="topology-tab-declared-effective"
+                >
+                  {classLabel(declaredClass)}{' '}
+                  <span className="text-[var(--color-text-dim)]">
+                    ({isMultiRegion ? `multi-region · ${sovereignRegionCount} regions` : 'single-region default'})
+                  </span>
+                </dd>
+              )}
             </div>
             <div className="flex justify-between gap-3 sm:block">
               <dt className="text-[var(--color-text-dim)]">Supported</dt>


### PR DESCRIPTION
## Problem

The AppDetail **Topology** tab printed the DECLARED topology mandate as the **Effective class** for bootstrap-spine apps that have no realized DR pair. openbao declares `active-passive`; on a live 2-region prov it has **zero** Continuum (`dr.openova.io`) CR and two disconnected singleton pods, yet the tab rendered:

> Effective class: active-passive (multi-region · 2 regions)

with `mgmt-A active / mgmt-B passive` beneath it — a fabrication of state ahead of reality.

## Root cause (and what was already honest)

The fabrication is **client-side** in `TopologyTab.tsx`. The "Effective class" `<dd>` was gated only on region count (`isMultiRegion`), never on whether a live Continuums CR / cnpg-pair actually backs the app.

The honest live signal already exists and is already consumed elsewhere on the tab: `liveDR.exists`, derived from `GET /continuums/dr-<app>`. The catalyst-api answers that route with a real record **only** when a genuine 2-region pair exists (a reconciled Continuum CR, or the live-cnpg-pair projection), and otherwise returns an honest **404** — `continuum.go` `HandleContinuumGet` + `continuum_live.go` `deriveLiveContinuumRecord`. **The Go layer is already honest; no backend change is needed** (the Switchover *action* button in `DRSection.tsx` is likewise already disabled on `!liveDR.exists` with an honest "No live DR pair" reason, from #3375).

## Fix (the anti-fabrication floor only)

When the declared class is DR-capable (`showDR`) but **not** realized by a live pair (`!liveDR.exists`), the "Effective class" field now reads exactly:

> singleton (DEGRADED — `<declared-class>` mandate unbuilt)

instead of the unbuilt mandate presented as a realized multi-region class. While the live read is still in flight it shows a neutral `checking…` state (never a premature DEGRADED or a fabricated class). A realized pair, or a genuine singleton, keeps the original honest rendering.

This is the cheap honest-floor slice. The full bootstrap-spine Application-CR producer + realizer wiring is the larger #3829 follow-on and is intentionally **not** built here.

## Tests

- `tsc -b --noEmit` clean.
- Existing `TopologyTab.test.tsx` + `TopologyTab.dr.test.tsx` pass unchanged (non-regressive).
- Added a `TopologyTab.dr.test.tsx` case: openbao on a 2-region prov with a 404 Continuum asserts the field contains `DEGRADED` + `singleton` + `active-passive mandate unbuilt` and **not** `multi-region`.

Note: a local working-tree linter in my sandbox repeatedly reverted the added test file from the working tree (a known concurrent-agent hazard), so the new test was verified by construction + committed; CI runs it against the clean pushed branch. The production `TopologyTab.tsx` change typechecks and the existing suite is green locally.

Refs #3829 #3375

🤖 Generated with [Claude Code](https://claude.com/claude-code)