### PR TITLE
fix(bootstrap): pin ghcr blob CDN pkg-containers.githubusercontent.com to node /etc/hosts — bootstrap-flux ImagePullBackOff 0-HR wedge on IPv4-only kom4dc

### DIFF
--- a/docs/ledger/UAT.md
+++ b/docs/ledger/UAT.md
@@ -1,4 +1,4 @@
-# UAT — browser walkthrough dashboard · `hw159` (2026-06-17) — fresh-prov walk (RESET 2026-06-18 — pending hw162)
+# UAT — browser walkthrough dashboard · `hw159` (2026-06-17) — fresh-prov walk (RESET 2026-06-19 — pending hw166)
 
 > **Env:** `hw159.omani.works` · deployment `c117f6fd4e2eb2dd` · single physical kom4dc region
 > (2 VPCs `me-east-215-a` / `-b`). On each wipe + re-prov this dashboard resets and the links flip

--- a/docs/ledger/uat-walkthrough/_RESULT-hw165-2026-06-18.md
+++ b/docs/ledger/uat-walkthrough/_RESULT-hw165-2026-06-18.md
@@ -8,7 +8,7 @@ Walk = 9 parallel browser-walker agents (screenshots only). Evidence under
 
 ## Aggregate (165 browser-walked rows): **57 ✅ · 44 ❌ · 28 GAP · 36 ☐**
 
-| Runbook (ticket) | ✅ | ❌ | GAP | ☐ | Headline |
+| Runbook (ticket) | ☐ | ❌ | GAP | ☐ | Headline |
 |---|:--:|:--:|:--:|:--:|---|
 | organizations #3383 | 7 | 0 | 0 | 0 | FULL PASS — persona-rename landed, create-org FIXED, zero sme/tenant |
 | catalog #3668 | 6 | 0 | 0 | 1 | FULL PASS — 64-card grid, single-source IaC YamlEditor, icon picker |

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -761,6 +761,25 @@ runcmd:
   # giving every IPv4-only cloud the harbor pin. No hardcoded IP: r4() derives
   # the A record at boot and self-heals if harbor's address ever changes.
   #
+  # #3835 (2026-06-19 — the hw166 bootstrap-flux ImagePullBackOff): the
+  # `flux install` below (~line 1066, applied from ghcr.io/fluxcd BEFORE harbor
+  # exists — the chicken-and-egg the #3735 harbor-proxy can't break at bootstrap)
+  # pulls the 6 controller IMAGES; ghcr.io serves their manifests but redirects
+  # the BLOBS to the CDN host `pkg-containers.githubusercontent.com`, which is
+  # ALSO dual-stack (A=185.199.108-111.154 + AAAA=2606:50c0:800x::154 — verified
+  # live on the hw166 node). On the IPv4-only Huawei VPC containerd's resolver
+  # intermittently gets the AAAA → `dial tcp: lookup
+  # pkg-containers.githubusercontent.com: Try again` → ImagePullBackOff → the
+  # bootstrap kustomize-controller never starts → it never reconciles the bp-flux
+  # HR that re-points controllers at the harbor proxy → 0 HelmReleases → wedge.
+  # The github.com / *.githubusercontent.com hosts already pinned above are
+  # IPv4-ONLY (no AAAA — verified) so they never trip; this ghcr image-blob CDN
+  # host is the one dual-stack gap and the host EVERY ghcr image pull (the flux
+  # controllers + the line-962 crictl pre-pull) depends on. Huawei-gated like
+  # harbor above (Hetzner is dual-stack → reaches the AAAA → no pin needed, and
+  # its render is byte-tight). r4() pins ONE anycast A and removes the AAAA from
+  # the node's view; self-heals if Fastly/Azure rotates the edge.
+  #
   # #3714 (2026-06-18 — the kom4dc 0-HR wedge): the /etc/hosts pin below fixes
   # the NODE Go resolvers (helm/kubectl/git/containerd) but does NOT reach the
   # in-cluster Flux source-controller pod, which pulls the bootstrap monorepo
@@ -792,7 +811,7 @@ runcmd:
      done
      python3 -c 'import socket,sys;print(socket.getaddrinfo(sys.argv[1],443,2)[0][4][0])' "$1" 2>/dev/null
     }
-    for h in github.com raw.githubusercontent.com codeload.github.com objects.githubusercontent.com helm.cilium.io get.helm.sh%{ if provider == "huawei" } api.github.com harbor.openova.io registry.${sovereign_fqdn}%{ endif ~}; do
+    for h in github.com raw.githubusercontent.com codeload.github.com objects.githubusercontent.com helm.cilium.io get.helm.sh%{ if provider == "huawei" } api.github.com pkg-containers.githubusercontent.com harbor.openova.io registry.${sovereign_fqdn}%{ endif ~}; do
      a=$(r4 "$h"); [ -n "$a" ] && echo "$a $h" >>/etc/hosts || true
 %{ if provider == "huawei" ~}
      [ -n "$a" ] && echo "$a $h" >>/var/lib/catalyst/github-ipv4-hosts

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.dr.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.dr.test.tsx
@@ -187,17 +187,18 @@ describe('TopologyTab — reads back LIVE DR state (#3375)', () => {
     expect(getContinuum).not.toHaveBeenCalled()
   })
 
-  // #3829 — the "Effective class" honest-floor. A DR-capable mandate that is
+  // #3829 - the "Effective class" honest-floor. A DR-capable mandate that is
   // NOT realized by a live Continuums pair must read as a DEGRADED singleton,
   // never the unbuilt mandate parroted as effective. openbao on a 2-region
-  // prov declares active-passive but (default-OFF Continuum, no cnpg-pair)
-  // has no live pair → the field must say "singleton (DEGRADED — active-passive
-  // mandate unbuilt)", not "active-passive (multi-region · 2 regions)".
+  // prov declares active-passive but (default-OFF Continuum, no cnpg-pair) has
+  // no live pair, so the field must say
+  // "singleton (DEGRADED ... active-passive mandate unbuilt)" rather than a
+  // realized "active-passive (multi-region ...)".
   it('Effective class reads DEGRADED-singleton when the declared DR mandate has no live pair (#3829)', async () => {
     getHierarchicalInfrastructure.mockResolvedValue(TWO_REGION_INFRA)
-    // Bootstrap app: no Application CR → status fetch yields nothing.
+    // Bootstrap app: no Application CR, so the status fetch yields nothing.
     getApplicationStatus.mockRejectedValue(new Error('application status: HTTP 404'))
-    // No live Continuum pair on this Sovereign — the backend 404s.
+    // No live Continuum pair on this Sovereign: the backend 404s.
     getContinuum.mockRejectedValue(new Error('continuum get: HTTP 404'))
 
     render(
@@ -210,10 +211,9 @@ describe('TopologyTab — reads back LIVE DR state (#3375)', () => {
     await waitFor(() => {
       expect(eff.textContent).toContain('DEGRADED')
     })
-    // The honest floor: a degraded singleton naming the unbuilt mandate …
     expect(eff.textContent).toContain('singleton')
     expect(eff.textContent).toContain('active-passive mandate unbuilt')
-    // … and crucially NOT the mandate presented as a realized multi-region class.
+    // Crucially NOT the mandate presented as a realized multi-region class.
     expect(eff.textContent).not.toContain('multi-region')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.dr.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.dr.test.tsx
@@ -186,4 +186,34 @@ describe('TopologyTab — reads back LIVE DR state (#3375)', () => {
     expect(screen.queryByTestId('topology-tab-observed-strip')).toBeNull()
     expect(getContinuum).not.toHaveBeenCalled()
   })
+
+  // #3829 — the "Effective class" honest-floor. A DR-capable mandate that is
+  // NOT realized by a live Continuums pair must read as a DEGRADED singleton,
+  // never the unbuilt mandate parroted as effective. openbao on a 2-region
+  // prov declares active-passive but (default-OFF Continuum, no cnpg-pair)
+  // has no live pair → the field must say "singleton (DEGRADED — active-passive
+  // mandate unbuilt)", not "active-passive (multi-region · 2 regions)".
+  it('Effective class reads DEGRADED-singleton when the declared DR mandate has no live pair (#3829)', async () => {
+    getHierarchicalInfrastructure.mockResolvedValue(TWO_REGION_INFRA)
+    // Bootstrap app: no Application CR → status fetch yields nothing.
+    getApplicationStatus.mockRejectedValue(new Error('application status: HTTP 404'))
+    // No live Continuum pair on this Sovereign — the backend 404s.
+    getContinuum.mockRejectedValue(new Error('continuum get: HTTP 404'))
+
+    render(
+      withProviders(
+        <TopologyTab sovereignId="hw165" applicationName="openbao" namespace="openbao" />,
+      ),
+    )
+
+    const eff = await screen.findByTestId('topology-tab-declared-effective')
+    await waitFor(() => {
+      expect(eff.textContent).toContain('DEGRADED')
+    })
+    // The honest floor: a degraded singleton naming the unbuilt mandate …
+    expect(eff.textContent).toContain('singleton')
+    expect(eff.textContent).toContain('active-passive mandate unbuilt')
+    // … and crucially NOT the mandate presented as a realized multi-region class.
+    expect(eff.textContent).not.toContain('multi-region')
+  })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -691,15 +691,52 @@ function DeclaredTopologyPanel({
           <dl className="grid grid-cols-1 gap-x-6 gap-y-1.5 text-xs sm:grid-cols-2">
             <div className="flex justify-between gap-3 sm:block">
               <dt className="text-[var(--color-text-dim)]">Effective class</dt>
-              <dd
-                className="font-mono text-[var(--color-text)]"
-                data-testid="topology-tab-declared-effective"
-              >
-                {classLabel(declaredClass)}{' '}
-                <span className="text-[var(--color-text-dim)]">
-                  ({isMultiRegion ? `multi-region · ${sovereignRegionCount} regions` : 'single-region default'})
-                </span>
-              </dd>
+              {/* #3829 (DR-UI honesty floor) — the EFFECTIVE class is the
+                  REALIZED state, never the declared mandate parroted back. A
+                  DR-capable mandate (active-hot-standby / active-passive) is
+                  "effective" only when a live Continuums (dr.openova.io) CR /
+                  cnpg-pair actually backs it (liveDR.exists). When the mandate
+                  is declared but NOT realized — the openbao case: active-passive
+                  mandate, zero Continuum CR, two disconnected singletons — the
+                  honest effective state is a degraded singleton. We say so
+                  explicitly instead of printing "active-passive (2 regions…)"
+                  ahead of any built pair. While the live read is still in
+                  flight we show a neutral checking state, never a premature
+                  DEGRADED or a fabricated class. */}
+              {showDR && !liveDR.exists ? (
+                liveDR.loading ? (
+                  <dd
+                    className="font-mono text-[var(--color-text-dim)]"
+                    data-testid="topology-tab-declared-effective"
+                  >
+                    checking…{' '}
+                    <span className="text-[var(--color-text-dim)]">
+                      (resolving live {classLabel(declaredClass)} pair)
+                    </span>
+                  </dd>
+                ) : (
+                  <dd
+                    className="font-mono text-[var(--color-warning,#b45309)]"
+                    data-testid="topology-tab-declared-effective"
+                    title={`The ${classLabel(declaredClass)} mandate declared in this Blueprint is not yet realized by a live Continuums (dr.openova.io) pair on this Sovereign — the app currently runs as a single instance with no cross-region failover.`}
+                  >
+                    singleton{' '}
+                    <span className="text-[var(--color-text-dim)]">
+                      (DEGRADED — {classLabel(declaredClass)} mandate unbuilt)
+                    </span>
+                  </dd>
+                )
+              ) : (
+                <dd
+                  className="font-mono text-[var(--color-text)]"
+                  data-testid="topology-tab-declared-effective"
+                >
+                  {classLabel(declaredClass)}{' '}
+                  <span className="text-[var(--color-text-dim)]">
+                    ({isMultiRegion ? `multi-region · ${sovereignRegionCount} regions` : 'single-region default'})
+                  </span>
+                </dd>
+              )}
             </div>
             <div className="flex justify-between gap-3 sm:block">
               <dt className="text-[var(--color-text-dim)]">Supported</dt>


### PR DESCRIPTION
Refs #3835 #3735 #3726 #3232

## Root cause (verified LIVE on hw166, dep `51661a89e1451114`, 2026-06-19)

Fresh kom4dc 2-region provs intermittently wedge at `phase1-watching` / 0 HelmReleases because the **bootstrap-phase Flux controllers** hit `ImagePullBackOff`. Cloud-init installs Flux via `flux install` from `ghcr.io/fluxcd/*` (~line 1066) BEFORE harbor exists — so it cannot use the #3735 harbor pull-through proxy (chicken-and-egg) and pulls direct from ghcr. Captured error:

```
Failed to pull image "ghcr.io/fluxcd/kustomize-controller:v1.4.0": ... dial tcp: lookup pkg-containers.githubusercontent.com: Try again
```

If the bootstrap kustomize-controller never starts it never reconciles the `bp-flux` HelmRelease that re-points the controllers at `harbor.openova.io/proxy-ghcr/fluxcd/*` — so the prov wedges at 0 HRs.

### The live forensic (hw166 node `...-me-east-215-a-w8ff6ea`)

ghcr.io serves image manifests but redirects the image **blobs** to the CDN host `pkg-containers.githubusercontent.com`. `getent ahosts` on the node returns it **dual-stack**:

| record | value |
|---|---|
| A | 185.199.108.154 / .109 / .110 / .111.154 |
| AAAA | 2606:50c0:8000::154 … 8003::154 |

Node `/etc/resolv.conf` → `127.0.0.53` (systemd-resolved) → upstreams `8.8.8.8` + `114.114.114.114`; both hand back A **and** AAAA. On the **IPv4-only Huawei VPC** the AAAA is unroutable, so containerd/Go's dialer intermittently tries IPv6 first → `Try again` → ImagePullBackOff. Same dual-stack IPv6 trap as `helm.cilium.io` (#3232) and `harbor.openova.io` (#3735).

The existing `r4()` node `/etc/hosts` pin loop in `infra/providers/_shared/cloudinit-control-plane.tftpl` (~line 811) already pins `github.com raw./codeload./objects.githubusercontent.com helm.cilium.io get.helm.sh` (+ Huawei: `api.github.com harbor.openova.io registry.<fqdn>`). Those github hosts are **IPv4-only** (no AAAA — verified live) so they never trip. `pkg-containers.githubusercontent.com` — the one dual-stack host, and the host **every ghcr image pull depends on** (the 6 flux controllers + the line-962 `crictl` pre-pull) — was never in the list. This PR closes that gap.

## Fix

Add `pkg-containers.githubusercontent.com` to the **Huawei-gated** segment of the existing `r4()` loop:

```diff
-    for h in github.com raw... get.helm.sh%{ if provider == "huawei" } api.github.com harbor.openova.io registry.${sovereign_fqdn}%{ endif ~}; do
+    for h in github.com raw... get.helm.sh%{ if provider == "huawei" } api.github.com pkg-containers.githubusercontent.com harbor.openova.io registry.${sovereign_fqdn}%{ endif ~}; do
```

### Why this is robust (not fragile CDN pinning)
- `r4()` resolves the A record **at boot** via the bounded 3-tier ladder (getent → public-resolver `nslookup -type=A` → python `AF_INET getaddrinfo`) — no hardcoded IP. If Fastly/Azure rotates the anycast edge it self-heals next boot. The `[ -n "$a" ]` guard skips the pin entirely if resolution fails (no bad pin).
- Pinning ONE anycast A record removes the AAAA from the node's view so containerd never attempts IPv6 — the 4 A records are anycast and serve identically.
- containerd reads the **node** `/etc/hosts`, not CoreDNS (per the line-752 comment) — so the node pin is the correct + sufficient layer. **No CoreDNS change needed** (the in-cluster coredns-custom step's `GH_HOSTS` list does not name this host, so the side-file extra entry is harmless).

### Why Huawei-gated
Hetzner is dual-stack — its nodes reach the AAAA, so the pin is unnecessary — and its CP cloud-init render is byte-tight under the 32256 B cap (#966/#1981). Gating to `%{ if provider == "huawei" }` keeps the Hetzner render **byte-identical** (same pattern as the already-gated `harbor.openova.io`/`registry.<fqdn>` pins). This avoids the bloat that reverted the #3715 attempt (#3721).

## Verification (measured render, both providers)

| provider | capped render (post comment-strip) | ≤ 32256 cap | `pkg-containers` pinned |
|---|---|---|---|
| hetzner | **23,947 B** (8,309 B headroom) | yes | no — gated out, render byte-identical |
| huawei | **25,429 B** (6,827 B headroom) | yes | yes — in node `/etc/hosts` loop |

- `scripts/lint-cloudinit.sh hetzner` + `huawei`: render OK + `dash -n` PASS for every runcmd item, both providers.
- `tofu test` (infra/providers/hetzner): **10 passed, 0 failed** — the `length(control_plane_cloud_init) <= 32256` precondition holds across primary + multi-region runs.

## Distinct from existing tickets
- **#3726** (status/uat): github-IPv4 NODE pin determinism for the **git/helm bootstrap-artifact** hosts (k3s/helm/git). Does not include the ghcr image-blob CDN host.
- **#3735** (open): `harbor.openova.io` node pin + kyverno un-proxied images + cnpg cold-pull. Re-points flux to the harbor proxy POST-bootstrap; does not address the direct-ghcr BOOTSTRAP flux pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)