### PR TITLE
fix(bp-mgmt-vcluster): stop the openbao SA-token fromHost loop that stalls fresh-prov keycloak — 0.2.19 (Refs #3838)

### DIFF
--- a/clusters/_template/bootstrap-kit-crs/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit-crs/08-openbao.yaml
@@ -152,3 +152,119 @@ metadata:
   annotations:
     kubernetes.io/service-account.name: openbao-host-token-reviewer
 type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: Role
+metadata:
+  name: openbao-host-token-reviewer-export
+  namespace: openbao
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao-host-token-reviewer
+    catalyst.openova.io/host-bridge: mgmt
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openbao-host-token-reviewer-export
+  namespace: openbao
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao-host-token-reviewer
+    catalyst.openova.io/host-bridge: mgmt
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openbao-host-token-reviewer-export
+subjects:
+- kind: ServiceAccount
+  name: openbao-host-token-reviewer
+  namespace: openbao
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: openbao-host-token-reviewer-export
+  namespace: openbao
+  labels:
+    catalyst.openova.io/blueprint: bp-openbao
+    catalyst.openova.io/component: openbao-host-token-reviewer
+    catalyst.openova.io/host-bridge: mgmt
+    app.kubernetes.io/managed-by: flux
+spec:
+  backoffLimit: 30
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        catalyst.openova.io/blueprint: bp-openbao
+        catalyst.openova.io/component: openbao-host-token-reviewer
+        app.kubernetes.io/managed-by: flux
+    spec:
+      serviceAccountName: openbao-host-token-reviewer
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: export
+        image: harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        command:
+        - /bin/sh
+        - -c
+        - "set -eu\nAPI=\"https://kubernetes.default.svc\"\nTOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\n\
+          CA=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\nSRC=\"openbao-host-token-reviewer\"\
+          \nDST=\"openbao-host-token-reviewer-static\"\nNS=\"openbao\"\n# The token\
+          \ controller populates the SA-token Secret\n# ASYNCHRONOUSLY \u2014 poll\
+          \ until token + ca.crt are both\n# present (the Job's backoffLimit covers\
+          \ a cold prov).\necho \"waiting for ${SRC} data keys (token + ca.crt)\u2026\
+          \"\ntok=\"\"; ca=\"\"\nfor i in $(seq 1 120); do\n  code=$(curl -s -o /tmp/src.json\
+          \ -w '%{http_code}' --cacert \"${CA}\" \\\n    -H \"Authorization: Bearer\
+          \ ${TOKEN}\" \\\n    \"${API}/api/v1/namespaces/${NS}/secrets/${SRC}\")\n\
+          \  if [ \"${code}\" = \"200\" ]; then\n    tok=$(tr -d '\\n' < /tmp/src.json\
+          \ | grep -oE '\"token\"[[:space:]]*:[[:space:]]*\"[^\"]*\"' | head -1 |\
+          \ sed 's/.*\"\\([^\"]*\\)\"$/\\1/')\n    ca=$(tr -d '\\n' < /tmp/src.json\
+          \ | grep -oE '\"ca\\.crt\"[[:space:]]*:[[:space:]]*\"[^\"]*\"' | head -1\
+          \ | sed 's/.*\"\\([^\"]*\\)\"$/\\1/')\n    if [ -n \"${tok}\" ] && [ -n\
+          \ \"${ca}\" ]; then\n      echo \"source populated\"; break\n    fi\n  fi\n\
+          \  if [ \"${i}\" = \"120\" ]; then\n    echo \"timeout: ${SRC} token/ca.crt\
+          \ absent after 10m\" >&2\n    exit 1\n  fi\n  sleep 5\ndone\n# Build the\
+          \ Opaque destination Secret. Data values are\n# the ALREADY-base64 bytes\
+          \ from the source (token/ca.crt\n# under .data are base64-encoded), so reuse\
+          \ verbatim.\ncat > /tmp/dst.json <<EOF\n{\"apiVersion\":\"v1\",\"kind\"\
+          :\"Secret\",\"metadata\":{\"name\":\"${DST}\",\"namespace\":\"${NS}\",\"\
+          labels\":{\"catalyst.openova.io/blueprint\":\"bp-openbao\",\"catalyst.openova.io/component\"\
+          :\"openbao-host-token-reviewer\",\"app.kubernetes.io/managed-by\":\"flux\"\
+          }},\"type\":\"Opaque\",\"data\":{\"token\":\"${tok}\",\"ca.crt\":\"${ca}\"\
+          }}\nEOF\n# Create, or update if it already exists (idempotent).\ncode=$(curl\
+          \ -s -o /tmp/out.json -w '%{http_code}' -X POST --cacert \"${CA}\" \\\n\
+          \  -H \"Authorization: Bearer ${TOKEN}\" -H \"Content-Type: application/json\"\
+          \ \\\n  --data @/tmp/dst.json \\\n  \"${API}/api/v1/namespaces/${NS}/secrets\"\
+          )\nif [ \"${code}\" = \"409\" ]; then\n  echo \"${DST} exists \u2014 updating\"\
+          \n  code=$(curl -s -o /tmp/out.json -w '%{http_code}' -X PUT --cacert \"\
+          ${CA}\" \\\n    -H \"Authorization: Bearer ${TOKEN}\" -H \"Content-Type:\
+          \ application/json\" \\\n    --data @/tmp/dst.json \\\n    \"${API}/api/v1/namespaces/${NS}/secrets/${DST}\"\
+          )\nfi\ncase \"${code}\" in\n  200|201) echo \"wrote ${DST} (${code})\";;\n\
+          \  *) echo \"failed to write ${DST}: HTTP ${code}\" >&2; cat /tmp/out.json\
+          \ >&2; exit 1;;\nesac\n"

--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -248,6 +248,19 @@ spec:
       kubernetesAuth:
         crossClusterTokenReview:
           enabled: true
+          # #3838: mount the Opaque COPY of the host token-reviewer
+          # (`openbao-host-token-reviewer-static`, minted by the placement.yaml
+          # `openbao-host-token-reviewer-export` Job), NOT the raw
+          # `kubernetes.io/service-account-token` Secret. The SA-token-typed
+          # Secret cannot be fromHost-mirrored into vc-mgmt without spinning an
+          # infinite vCluster token-controller re-stamp loop that starves the
+          # keycloak DB-secret sync (the 30m keycloak install-loop, ~49/64-HR
+          # spine stall). The Opaque copy carries the same `token`/`ca.crt`
+          # keys, so the auth-bootstrap Job behaviour is unchanged.
+          tokenReviewerSecret:
+            name: openbao-host-token-reviewer-static
+            tokenKey: token
+            caKey: ca.crt
     # Issue #517 (Phase-8a single-node): openbao upstream chart's
     # 3-replica StatefulSet uses required pod-anti-affinity by hostname.
     # On single-node Phase-8a Sovereigns this leaves 2/3 pods Pending

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -132,7 +132,16 @@ spec:
       # InvalidProviderConfig (k8s-auth login deadline) → every
       # *-sso-oidc-credentials ExternalSecret SecretSyncedError → per-app SSO
       # 503 on hw165. Orthogonal to the 0.2.17 gateway-ingress CNP; both ship here.
-      version: 0.2.18
+      # 0.2.19 (#3838): replace `openbao/*` fromHost.secrets wildcard with
+      # exact-name mappings — the wildcard mirrored the SA-token-typed
+      # `openbao-host-token-reviewer` Secret, which the vCluster token-controller
+      # re-stamped every reconcile → infinite from-host-secret loop (~35% of
+      # syncer work on hw166) → context-deadline-exceeded on the keycloak/harbor
+      # DB-secret toHost writes → keycloak-0 Init:0/2 → bp-keycloak 30m
+      # install-loop stalling the spine at ~49/64 HRs. Companion: placement.yaml
+      # `openbao-host-token-reviewer-export` Job mints the mirror-stable Opaque
+      # `openbao-host-token-reviewer-static` Secret.
+      version: 0.2.19
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -717,6 +717,156 @@ spec:
               annotations:
                 kubernetes.io/service-account.name: openbao-host-token-reviewer
             type: kubernetes.io/service-account-token
+          # ── #3838 mirror-stable Opaque copy of the token-reviewer ──────────
+          # The `kubernetes.io/service-account-token` Secret above CANNOT be
+          # fromHost-mirrored into vc-mgmt: vCluster's `from-host-secret`
+          # syncer copies it, then the vCluster's OWN token-controller
+          # re-stamps the SA-token Secret (the referenced SA does not exist in
+          # the vCluster), so every reconcile sees host≠virtual drift and
+          # RE-CREATES it — an infinite hot loop (2833 `Create virtual object`
+          # per 8000 syncer log lines on hw166) that saturates the syncer +
+          # host apiserver and starves the keycloak/harbor DB-secret toHost
+          # writes (`context deadline exceeded`) → keycloak-0 hangs Init:0/2 →
+          # bp-keycloak 30m install-loop stalls the spine ~49/64 HRs (#3838).
+          # This Job copies the SA-token's `token` + `ca.crt` into a PLAIN
+          # Opaque Secret with NO `kubernetes.io/service-account.name`
+          # annotation, so the vCluster token-controller never touches it and
+          # bp-mgmt-vcluster's exact-name fromHost mirror is stable. The
+          # auth-bootstrap Job mounts THIS Secret (slot 08 crossClusterToken-
+          # Review.tokenReviewerSecret.name = openbao-host-token-reviewer-static).
+          # Reconciled by bootstrap-kit-crs (dependsOn bootstrap-kit) — core
+          # resources only, no CRD risk.
+          - apiVersion: v1
+            kind: Role
+            metadata:
+              name: openbao-host-token-reviewer-export
+              namespace: openbao
+              labels:
+                catalyst.openova.io/blueprint: bp-openbao
+                catalyst.openova.io/component: openbao-host-token-reviewer
+                catalyst.openova.io/host-bridge: "mgmt"
+            rules:
+              # Read the SA-token source Secret; create/update the Opaque copy.
+              - apiGroups: [""]
+                resources: ["secrets"]
+                verbs: ["get", "create", "update", "patch"]
+          - apiVersion: rbac.authorization.k8s.io/v1
+            kind: RoleBinding
+            metadata:
+              name: openbao-host-token-reviewer-export
+              namespace: openbao
+              labels:
+                catalyst.openova.io/blueprint: bp-openbao
+                catalyst.openova.io/component: openbao-host-token-reviewer
+                catalyst.openova.io/host-bridge: "mgmt"
+            roleRef:
+              apiGroup: rbac.authorization.k8s.io
+              kind: Role
+              name: openbao-host-token-reviewer-export
+            subjects:
+              # Reuse the existing host token-reviewer SA — least-privilege:
+              # this Role adds only same-namespace Secret read/write on top of
+              # its auth-delegator grant.
+              - kind: ServiceAccount
+                name: openbao-host-token-reviewer
+                namespace: openbao
+          - apiVersion: batch/v1
+            kind: Job
+            metadata:
+              name: openbao-host-token-reviewer-export
+              namespace: openbao
+              labels:
+                catalyst.openova.io/blueprint: bp-openbao
+                catalyst.openova.io/component: openbao-host-token-reviewer
+                catalyst.openova.io/host-bridge: "mgmt"
+                # kyverno `flux-managed` Enforce DENIES a Job without this.
+                app.kubernetes.io/managed-by: flux
+            spec:
+              backoffLimit: 30
+              ttlSecondsAfterFinished: 600
+              template:
+                metadata:
+                  labels:
+                    catalyst.openova.io/blueprint: bp-openbao
+                    catalyst.openova.io/component: openbao-host-token-reviewer
+                    app.kubernetes.io/managed-by: flux
+                spec:
+                  serviceAccountName: openbao-host-token-reviewer
+                  restartPolicy: OnFailure
+                  securityContext:
+                    runAsNonRoot: true
+                    runAsUser: 65532
+                    runAsGroup: 65532
+                    fsGroup: 65532
+                    seccompProfile:
+                      type: RuntimeDefault
+                  containers:
+                    - name: export
+                      # Tiny curl+sh image via the mothership Harbor proxy-cache
+                      # (MIRROR-EVERYTHING). Talks to the k8s API directly with
+                      # the pod's projected SA token — no kubectl needed.
+                      image: harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1
+                      imagePullPolicy: IfNotPresent
+                      securityContext:
+                        allowPrivilegeEscalation: false
+                        readOnlyRootFilesystem: true
+                        capabilities:
+                          drop: ["ALL"]
+                      command:
+                        - /bin/sh
+                        - -c
+                        - |
+                          set -eu
+                          API="https://kubernetes.default.svc"
+                          TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+                          CA=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                          SRC="openbao-host-token-reviewer"
+                          DST="openbao-host-token-reviewer-static"
+                          NS="openbao"
+                          # The token controller populates the SA-token Secret
+                          # ASYNCHRONOUSLY — poll until token + ca.crt are both
+                          # present (the Job's backoffLimit covers a cold prov).
+                          echo "waiting for ${SRC} data keys (token + ca.crt)…"
+                          tok=""; ca=""
+                          for i in $(seq 1 120); do
+                            code=$(curl -s -o /tmp/src.json -w '%{http_code}' --cacert "${CA}" \
+                              -H "Authorization: Bearer ${TOKEN}" \
+                              "${API}/api/v1/namespaces/${NS}/secrets/${SRC}")
+                            if [ "${code}" = "200" ]; then
+                              tok=$(tr -d '\n' < /tmp/src.json | grep -oE '"token"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+                              ca=$(tr -d '\n' < /tmp/src.json | grep -oE '"ca\.crt"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+                              if [ -n "${tok}" ] && [ -n "${ca}" ]; then
+                                echo "source populated"; break
+                              fi
+                            fi
+                            if [ "${i}" = "120" ]; then
+                              echo "timeout: ${SRC} token/ca.crt absent after 10m" >&2
+                              exit 1
+                            fi
+                            sleep 5
+                          done
+                          # Build the Opaque destination Secret. Data values are
+                          # the ALREADY-base64 bytes from the source (token/ca.crt
+                          # under .data are base64-encoded), so reuse verbatim.
+                          cat > /tmp/dst.json <<EOF
+                          {"apiVersion":"v1","kind":"Secret","metadata":{"name":"${DST}","namespace":"${NS}","labels":{"catalyst.openova.io/blueprint":"bp-openbao","catalyst.openova.io/component":"openbao-host-token-reviewer","app.kubernetes.io/managed-by":"flux"}},"type":"Opaque","data":{"token":"${tok}","ca.crt":"${ca}"}}
+                          EOF
+                          # Create, or update if it already exists (idempotent).
+                          code=$(curl -s -o /tmp/out.json -w '%{http_code}' -X POST --cacert "${CA}" \
+                            -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" \
+                            --data @/tmp/dst.json \
+                            "${API}/api/v1/namespaces/${NS}/secrets")
+                          if [ "${code}" = "409" ]; then
+                            echo "${DST} exists — updating"
+                            code=$(curl -s -o /tmp/out.json -w '%{http_code}' -X PUT --cacert "${CA}" \
+                              -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" \
+                              --data @/tmp/dst.json \
+                              "${API}/api/v1/namespaces/${NS}/secrets/${DST}")
+                          fi
+                          case "${code}" in
+                            200|201) echo "wrote ${DST} (${code})";;
+                            *) echo "failed to write ${DST}: HTTP ${code}" >&2; cat /tmp/out.json >&2; exit 1;;
+                          esac
     - {file: 11a-bp-powerdns-admin.yaml, hr: bp-powerdns-admin, vcluster: host, target: mgmt,
        namespace: powerdns-admin}   # §4: UI not substrate — DEFAULT mgmt, listed for founder veto
     - {file: 13b-bp-sso-bridge.yaml, hr: bp-sso-bridge, vcluster: host, target: mgmt, namespace: sso-bridge}

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.18
+  version: 0.2.19
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -206,7 +206,25 @@ name: bp-mgmt-vcluster
 # gateway-ingress CNP (one admits the gateway proxy identity for north-south app
 # reachability, the other admits the host ESO namespace for the OpenBao secret
 # chain) — both ship together in this release.
-version: 0.2.18
+# 0.2.19 (#3838, the fresh-prov keycloak install-loop fix): replace the
+# `openbao/*` sync.fromHost.secrets wildcard with two EXACT-NAME mappings
+# (`openbao-sso-oidc-credentials` + `openbao-host-token-reviewer-static`). The
+# wildcard swept the host `openbao-host-token-reviewer` Secret — type
+# `kubernetes.io/service-account-token` — into the fromHost mirror, where the
+# vCluster's own token-controller re-stamped it every reconcile (the referenced
+# SA does not exist in the vCluster), spinning an infinite `from-host-secret
+# Create virtual object` loop (2833 per 8000 syncer log lines on hw166, ~35% of
+# all syncer work). That saturated the syncer queue + host k3s apiserver →
+# `context deadline exceeded` on the keycloak/harbor DB-secret toHost writes →
+# `keycloak-database-secret-x-keycloak-x-mgmt-vcluster` never landed →
+# keycloak-0 hung `Init:0/2` → the config-cli post-install hook timed out at
+# 30m → bp-keycloak install→remediate→reinstall loop stalling the spine at
+# ~49/64 HRs. The companion host slot (placement.yaml
+# `openbao-host-token-reviewer-export` Job) materialises an Opaque
+# `openbao-host-token-reviewer-static` Secret (no `service-account.name`
+# annotation → mirror-stable) for the auth-bootstrap Job to mount. Never
+# wildcard a namespace that holds a `kubernetes.io/service-account-token`.
+version: 0.2.19
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -552,20 +552,39 @@ vcluster:
       # and safe. Independent of the existing `sync.toHost.secrets`
       # (vCluster→host); the two directions don't conflict.
       #
-      # ⚠️ openbao/* (hw161 converge-readiness fix, Refs #3760): openbao is the
-      # 7th NS#1 app re-homed into vc-mgmt (placement.yaml `hr: bp-openbao,
-      # vcluster: mgmt, namespace: openbao`). Its host-bridge mints
-      # `openbao-sso-oidc-credentials` in the `openbao` HOST namespace (the
-      # host ESO reconciles it from secret/sso/openbao), while the openbao
-      # sso-configure Deployment runs INSIDE vc-mgmt and mounts that Secret
-      # (templates/sso-configure-deployment.yaml `secretName:
-      # openbao-sso-oidc-credentials`, optional:true → it WAITS forever rather
-      # than CrashLoops). The 0.2.12 mapping shipped keycloak/gitea/harbor/
-      # newapi/grafana/catalyst-system but DROPPED openbao/* — so OpenBao SSO
-      # silently never configured (the #3737 secret-not-mirrored class, the
-      # soft-wait variant). Adding openbao/* mirrors the host Secret into
-      # vc-mgmt's openbao ns so sso-configure completes the OIDC auth-method
-      # wiring zero-touch.
+      # ⚠️ openbao — EXACT-NAME mappings, NOT `openbao/*` (#3838, the
+      # fresh-prov keycloak install-loop root cause). openbao is the 7th NS#1
+      # app re-homed into vc-mgmt (placement.yaml `hr: bp-openbao, vcluster:
+      # mgmt, namespace: openbao`). Its in-vc-mgmt workloads need exactly two
+      # HOST-minted Secrets:
+      #   - `openbao-sso-oidc-credentials` (host ESO reconciles it from
+      #     secret/sso/openbao; the sso-configure Deployment mounts it,
+      #     optional:true → WAITS rather than CrashLoops).
+      #   - `openbao-host-token-reviewer-static` (the Opaque copy of the host
+      #     SA token + host CA the auth-bootstrap Job mounts for cross-cluster
+      #     TokenReview — #3825).
+      # hw161's 0.2.13 used the namespace-wildcard `openbao/*`, which ALSO
+      # swept the host `openbao-host-token-reviewer` Secret — type
+      # `kubernetes.io/service-account-token`, carrying the
+      # `kubernetes.io/service-account.name` annotation. vCluster's
+      # `from-host-secret` syncer mirrors it into vc-mgmt, where the vCluster's
+      # OWN token-controller re-stamps the SA-token Secret (the referenced SA
+      # does not exist in the vCluster), so every reconcile sees host≠virtual
+      # drift and RE-CREATES it — an infinite hot loop (measured 2833 `Create
+      # virtual object` per 8000 syncer log lines on hw166, ~35% of ALL syncer
+      # work). That loop saturates the syncer queue + host k3s apiserver →
+      # `error syncing Secret keycloak/keycloak-database-secret to host
+      # cluster: context deadline exceeded` → `keycloak-database-secret-x-
+      # keycloak-x-mgmt-vcluster` never lands → keycloak-0 hangs
+      # `Init:0/2` (MountVolume.SetUp), the post-install config-cli hook times
+      # out at 30m, bp-keycloak install→remediate→reinstall loops, and the
+      # whole spine (gitea → bp-catalyst-platform → console) stalls ~49/64 HRs.
+      # The auth-bootstrap Job genuinely needs the token+CA, so the host slot
+      # (placement.yaml `openbao-host-token-reviewer-export` Job, #3838) copies
+      # them into the Opaque `openbao-host-token-reviewer-static` Secret — no
+      # `service-account.name` annotation, so the vCluster token-controller
+      # never touches it and the mirror is stable. Mirror that Opaque copy by
+      # EXACT name; never wildcard a namespace that holds an SA-token Secret.
       secrets:
         enabled: true
         mappings:
@@ -575,7 +594,8 @@ vcluster:
             "harbor/*": "harbor/*"
             "newapi/*": "newapi/*"
             "grafana/*": "grafana/*"
-            "openbao/*": "openbao/*"
+            "openbao/openbao-sso-oidc-credentials": "openbao/openbao-sso-oidc-credentials"
+            "openbao/openbao-host-token-reviewer-static": "openbao/openbao-host-token-reviewer-static"
             "catalyst-system/*": "catalyst-system/*"
 
   # ── In-vCluster CRD registration (#3373, OSS-native) ────────────────────


### PR DESCRIPTION
## Problem (live on hw166, dep 51661a89e1451114 — NOT wiped, kept as forensic)

The 2nd fresh-prov convergence bug (after the #3837/#3835 ghcr-DNS fix). Convergence stalls ~49/64 HRs: the mgmt-vCluster `bp-keycloak` HelmRelease install→timeout→remediate→reinstall loops (30m post-install timeout), keycloak-0 hangs `0/1 Init:0/2` forever, and the spine (keycloak → gitea → bp-catalyst-platform → console) never finishes → console 000.

## Root cause (live syncer-log evidence on host `mgmt-vcluster-0`)

keycloak-0 is stuck because its projected `keycloak-secrets` volume references `keycloak-database-secret-x-keycloak-x-mgmt-vcluster`, which never lands on the host:

```
MountVolume.SetUp failed for volume "keycloak-secrets" : secret "keycloak-database-secret-x-keycloak-x-mgmt-vcluster" not found
```

The vCluster fromHost mirror creates the virtual `keycloak/keycloak-database-secret` fine, but the syncer's write-BACK to the host times out:

```
secret.keycloak-database-secret to_host_syncer.go:98 error syncing Secret keycloak/keycloak-database-secret to host cluster: create object: context deadline exceeded
```

(262 such timeouts for keycloak in an 8000-line window.)

**Why it times out:** the bp-mgmt-vcluster `sync.fromHost.secrets` `openbao/*` wildcard (added hw161, #3760) swept the host `openbao-host-token-reviewer` Secret — type `kubernetes.io/service-account-token`, carrying the `kubernetes.io/service-account.name` annotation. vCluster's `from-host-secret` syncer mirrors it into vc-mgmt, where the vCluster's OWN token-controller re-stamps the SA-token Secret (the referenced SA does not exist in the vCluster), so every reconcile sees host≠virtual drift and RE-CREATES it — an infinite hot loop:

| Secret | Type | `from-host-secret` Create count / 8000 log lines |
|---|---|---|
| `openbao-host-token-reviewer` | **SA-token** | **2833** (~35% of all syncer log lines) |
| `keycloak-database-secret` | Opaque | 468 (retry-storm from the timeouts) |
| `harbor-database-secret` | Opaque | 506 |
| `ghcr-pull`, `shared-pg-app` | Opaque/etc | 0 (mirror once, stop — correct) |

The 2833-cycle SA-token loop saturates the syncer work queue + host k3s apiserver, which is what produces the `context deadline exceeded` on the keycloak/harbor DB-secret writes. Only the `openbao` namespace holds an SA-token Secret; the other 6 mapped namespaces have none, so only keycloak/harbor suffer collateral starvation. Introduced by commit `369fb5e3` ("add missing openbao/* fromHost.secrets mapping").

## Fix

- **`platform/bp-mgmt-vcluster/chart/values.yaml`** — replace the `openbao/*` wildcard with two EXACT-NAME `sync.fromHost.secrets.mappings.byName` entries (`openbao-sso-oidc-credentials` + `openbao-host-token-reviewer-static`), so the SA-token Secret is never swept. vCluster 0.23 `byName` supports specific object names.
- **`clusters/_template/bootstrap-kit/placement.yaml`** — add an `openbao-host-token-reviewer-export` Job (+ Role/RoleBinding, reusing the existing `openbao-host-token-reviewer` SA) that copies the SA-token's `token`+`ca.crt` into a PLAIN **Opaque** `openbao-host-token-reviewer-static` Secret. No `service-account.name` annotation → the vCluster token-controller never touches it → the mirror is stable. Reconciled by `bootstrap-kit-crs` (dependsOn bootstrap-kit), core resources only.
- **`clusters/_template/bootstrap-kit/08-openbao.yaml`** — point `kubernetesAuth.crossClusterTokenReview.tokenReviewerSecret` at `openbao-host-token-reviewer-static`. The auth-bootstrap Job reads the same `token`/`ca.crt` keys, so its behaviour is unchanged.
- regenerated `bootstrap-kit-crs/08-openbao.yaml` via `render-slot-placement.py fix`; lockstep `Chart.yaml` + `blueprint.yaml` + slot-58 pin `0.2.18 → 0.2.19`.

## Why this is durable, not a patch

The loop is inherent to mirroring a `kubernetes.io/service-account-token` Secret across the vCluster boundary (two token controllers fight over the same object). Delivering the same token+CA bytes as a mirror-stable Opaque Secret removes the contention at the source, and the exact-name mapping prevents any future SA-token Secret in `openbao` from re-triggering it. The auth-bootstrap consumer is unchanged.

## Validation

- `helm template bp-mgmt-vcluster` rc=0
- all 7 `bp-mgmt-vcluster` render tests PASS
- `kubectl kustomize bootstrap-kit-crs/` rc=0 (rendered Job/Role/RoleBinding/static-secret valid)
- `render-slot-placement.py check` PASS (placement ↔ crs in sync)
- `audit-placement-conformance.py rendered` PASS (64 slots)
- auth-bootstrap Job derives `XCR_TOKEN_FILE`/`XCR_CA_FILE` from the new `tokenKey`/`caKey` correctly

Verification is a fresh-prov walk confirming keycloak-0 reaches Running first-try (no 30m loop) and the spine converges to full HRs.

Refs #3838 #3642 #3737 #3760

🤖 Generated with [Claude Code](https://claude.com/claude-code)
