### PR TITLE
fix(bootstrap): disable IPv6 on Huawei nodes for DETERMINISTIC ghcr image-pull resolution — supersedes #3837's per-host pin (Refs #3835)

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -72,6 +72,45 @@ write_files:
       fs.inotify.max_user_instances = 8192
       fs.inotify.max_user_watches = 1048576
       fs.inotify.max_queued_events = 16384
+%{ if provider == "huawei" ~}
+
+  # ── Disable IPv6 (#3840 — the DETERMINISTIC fix for the ghcr image-pull
+  # "Try again" wedge that #3837's per-host /etc/hosts pin could not close).
+  #
+  # ROOT CAUSE (proven live on hw167 worker w5c3dea, 2026-06-19): the Huawei
+  # VPC is IPv4-ONLY — the node has NO global IPv6 address — yet IPv6 was left
+  # ENABLED in the kernel (disable_ipv6=0). github's ghcr image-blob CDN host
+  # `pkg-containers.githubusercontent.com` (where ghcr.io redirects every blob)
+  # is dual-stack and resolves to a REAL global AAAA (2606:50c0:8002::154,
+  # verified on the node). The Go dual-stack resolver inside containerd/kubelet
+  # hands BOTH the A and the unreachable AAAA to the dialer; the IPv6 attempt
+  # fails on this IPv4-only VPC and containerd surfaces it as
+  # `dial tcp: lookup ghcr.io: Try again` → ImagePullBackOff → the bootstrap
+  # flux controllers never start → 0 HelmReleases → permanent fresh-prov wedge.
+  #
+  # Why #3837 (pin pkg-containers in /etc/hosts) was insufficient: (1) the live
+  # failing host is `ghcr.io` itself, pinned nowhere; (2) the flux controllers
+  # run on WORKER nodes, whose template pins only harbor/registry — no ghcr
+  # host at all; (3) the pin itself depends on the SAME flaky boot-time VPC
+  # resolver. Enumerating every image-pull host (ghcr.io + pkg-containers +
+  # codeload + harbor + every future registry) is a losing game. Removing the
+  # AAAA path entirely is deterministic and host-agnostic: with IPv6 off the
+  # resolver returns ONLY A records and containerd never dials IPv6.
+  #
+  # SAFE on kom4dc (verified): no node has a global IPv6 address, k3s
+  # cluster/service CIDRs are IPv4-only, cilium runs ipam.mode=kubernetes with
+  # no IPv6 toggles, and ClusterMesh peers over IPv4 EIPs/NodePorts. Nothing
+  # on kom4dc uses IPv6. Applied via a sysctl drop-in (survives any later
+  # `sysctl --system`) AND `sysctl -w` in the FIRST runcmd item below so it is
+  # in effect before the r4() DNS pin, the k3s install, and every image pull.
+  # Huawei-gated → the byte-tight Hetzner render stays byte-identical.
+  - path: /etc/sysctl.d/99-catalyst-disable-ipv6.conf
+    permissions: '0644'
+    content: |
+      net.ipv6.conf.all.disable_ipv6 = 1
+      net.ipv6.conf.default.disable_ipv6 = 1
+      net.ipv6.conf.lo.disable_ipv6 = 1
+%{ endif ~}
 
   # ── OS hardening: SSH daemon ──────────────────────────────────────────
   # The operator's only valid path in is the cloud-project SSH key injected
@@ -709,6 +748,15 @@ runcmd:
   - sed -i '/swap/d' /etc/fstab
   - update-alternatives --set iptables /usr/sbin/iptables-legacy || true
   - update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || true
+%{ if provider == "huawei" ~}
+  # #3840 — disable IPv6 NOW (before the r4() DNS pin, k3s install + every image
+  # pull below) so containerd's Go resolver never receives/dials an unreachable
+  # AAAA on this IPv4-only VPC (the `lookup ghcr.io: Try again` 0-HR wedge that
+  # #3837's per-host /etc/hosts pin could not deterministically close). The
+  # sysctl drop-in written above persists it across any later `sysctl --system`;
+  # `sysctl -w` makes it live immediately. Huawei-gated (see the drop-in header).
+  - sysctl -w net.ipv6.conf.all.disable_ipv6=1 net.ipv6.conf.default.disable_ipv6=1 net.ipv6.conf.lo.disable_ipv6=1 || true
+%{ endif ~}
 
   # Apply inotify-limit bumps + hardened sshd written by write_files.
   - sysctl --system

--- a/infra/providers/huawei/cloudinit-worker.tftpl
+++ b/infra/providers/huawei/cloudinit-worker.tftpl
@@ -90,6 +90,28 @@ write_files:
       fs.inotify.max_user_watches = 1048576
       fs.inotify.max_queued_events = 16384
 
+  # ── Disable IPv6 (#3840) — the WORKER half of the deterministic ghcr
+  # image-pull "Try again" fix. The flux controllers (source / notification /
+  # image-automation) land on WORKER nodes and pull from ghcr.io; on the
+  # IPv4-only Huawei VPC the dual-stack AAAA of ghcr's blob CDN
+  # (pkg-containers.githubusercontent.com → 2606:50c0:8002::154, unreachable
+  # here) makes containerd's Go resolver attempt an IPv6 dial that fails →
+  # `dial tcp: lookup ghcr.io: Try again` → ImagePullBackOff → 0 HelmReleases
+  # (proven live on hw167 worker w5c3dea). #3837 only touched the CP template,
+  # so this worker tier — where the flux controllers actually run — kept the
+  # AAAA path open. Disabling IPv6 makes the resolver return ONLY A records, so
+  # no image-pull host (ghcr.io / pkg-containers / harbor / future registries)
+  # can be reached over the unreachable IPv6 path. Drop-in survives any later
+  # `sysctl --system`; applied live below before the k3s-agent install + every
+  # pull. SAFE: kom4dc is IPv4-only end to end (no node IPv6 address, IPv4 k3s
+  # CIDRs, cilium ipam.mode=kubernetes, ClusterMesh over IPv4). Refs #3835.
+  - path: /etc/sysctl.d/99-catalyst-disable-ipv6.conf
+    permissions: '0644'
+    content: |
+      net.ipv6.conf.all.disable_ipv6 = 1
+      net.ipv6.conf.default.disable_ipv6 = 1
+      net.ipv6.conf.lo.disable_ipv6 = 1
+
   - path: /etc/ssh/sshd_config.d/99-catalyst-hardening.conf
     permissions: '0644'
     content: |
@@ -99,6 +121,13 @@ write_files:
       MaxAuthTries 3
 
 runcmd:
+  # #3840 — disable IPv6 FIRST (before the r4() DNS pin, the k3s-agent install,
+  # and every image pull below) so containerd's Go resolver never receives or
+  # dials an unreachable AAAA on this IPv4-only VPC (the `lookup ghcr.io: Try
+  # again` 0-HR wedge). The drop-in written above persists it; `sysctl -w` makes
+  # it live immediately. See the drop-in header for the full RCA + safety proof.
+  - sysctl -w net.ipv6.conf.all.disable_ipv6=1 net.ipv6.conf.default.disable_ipv6=1 net.ipv6.conf.lo.disable_ipv6=1 || true
+
   # ── IPv4-pin harbor + local registry (#3735, 2026-06-18 — the hw159
   # ImagePullBackOff). Huawei VPCs are IPv4-only; harbor.openova.io is
   # dual-stack (A=45.151.123.50 + AAAA). The k3s-agent containerd image-pull


### PR DESCRIPTION
## Problem (proven LIVE on hw167, dep `28d4e96f96407bbb`)

After #3837 merged, fresh kom4dc provs still intermittently wedge on flux-controller image pulls. Live on hw167 at the time of writing:

```
flux-system  source-controller            0/1  ImagePullBackOff
flux-system  notification-controller      0/1  ImagePullBackOff
flux-system  image-automation-controller  0/1  ImagePullBackOff
HR total: 0
```

Exact kubelet error:

```
Failed to pull image "ghcr.io/fluxcd/source-controller:v1.4.1": ... dial tcp: lookup ghcr.io: Try again
```

All three failing pods sit on the same worker node `…-w5c3dea`; the two that pulled (`helm-controller`, `kustomize-controller`) are on other nodes — per-node DNS luck.

## Why #3837's per-host /etc/hosts pin did not close it

Three compounding reasons, each confirmed live:

1. **Wrong host + wrong template tier.** #3837 added `pkg-containers.githubusercontent.com` to the `r4()` /etc/hosts pin loop in `cloudinit-control-plane.tftpl`. But the live failing host is `ghcr.io` (the manifest host), pinned nowhere — and the flux controllers run on **worker** nodes, whose template (`cloudinit-worker.tftpl`) pins only `harbor.openova.io` + `registry.<fqdn>`. The failing worker node's `/etc/hosts` carries no github/ghcr entry at all.
2. **The pin depends on boot-time DNS luck.** `r4()` resolves each host at boot via the same flaky VPC resolver (`8.8.8.8` + `114.114.114.114`, `options timeout:1`). The fix cannot depend on the resolution that is failing.
3. **The real root cause is the AAAA-dial path, not a missing pin.** Verified on the node:
   - No global IPv6 address (VPC is IPv4-only) yet IPv6 kernel-enabled (`net.ipv6.conf.all.disable_ipv6 = 0`).
   - `ghcr.io` A resolves reliably (5/5) — so it is NOT an A-lookup timeout.
   - `pkg-containers.githubusercontent.com` AAAA returns a real global `2606:50c0:8002::154` the IPv4-only VPC cannot reach. Go's dual-stack resolver hands containerd the AAAA, the IPv6 dial fails, and containerd surfaces it as `lookup … : Try again`.

Pinning one more host name can never cover `ghcr.io` + `pkg-containers` + `harbor` + `codeload` + every future registry.

## Change

Disable IPv6 at the node kernel level on Huawei nodes (`net.ipv6.conf.{all,default,lo}.disable_ipv6 = 1`) via a sysctl drop-in, applied EARLY (before the `r4()` DNS pin, the k3s install, and every image pull) in **both** `cloudinit-control-plane.tftpl` (Huawei-gated) and `cloudinit-worker.tftpl`. With IPv6 off the resolver returns only A records and containerd never attempts an IPv6 dial — deterministic and host-agnostic.

The control-plane edits are Huawei-gated, so the Hetzner render is byte-identical.

## Safety (verified live)

kom4dc is IPv4-only end to end: no node has a global IPv6 address, k3s cluster/service CIDRs are IPv4, cilium runs `ipam.mode=kubernetes` with no IPv6 toggles, and ClusterMesh peers over IPv4 EIPs/NodePorts. Nothing on kom4dc uses IPv6.

## Verification

- Hetzner control-plane render **byte-identical** to `main` (55983 == 55983, `diff` empty) — Huawei gating confirmed.
- Huawei control-plane render: the IPv6-disable runcmd lands before `r4()` and the k3s install. Worker render: same, before `r4()` and the k3s-agent install.
- `scripts/lint-cloudinit.sh both`: `dash -n` PASS (39 runcmd items each); every worker runcmd item `dash -n` clean.
- `tofu test`: huawei 5/5 pass, hetzner 10/10 pass (the 32256 B / 30720 B cloud-init preconditions hold).

Refs #3835
Refs #3840

🤖 Generated with [Claude Code](https://claude.com/claude-code)
