### PR TITLE
fix(cloud-init): decouple sovereign-tls from the full bootstrap-kit health gate — a leaf app (bp-guacamole) wedged the whole Sovereign's console TLS (Refs #3845)

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -626,6 +626,28 @@ write_files:
       # sovereign-tls Kustomization — carries the cert-manager Certificate
       # that backs Cilium Gateway's wildcard-TLS listener. Split out so its
       # cert-manager.io CRD-dependent apply runs AFTER bp-cert-manager Ready.
+      #
+      # #3845 — does NOT `dependsOn: [bootstrap-kit]` (and runs wait:false +
+      # retryInterval, mirroring bootstrap-kit-crs above). RATIONALE: the
+      # Sovereign's wildcard TLS + Gateway are the datapath that the console
+      # and EVERY `*.<fqdn>` surface terminate on — they must NOT be gated on
+      # all ~50 bootstrap-kit HRs being Ready. With `dependsOn: [bootstrap-kit]
+      # + wait:true`, a SINGLE non-foundational leaf app failing (caught live
+      # hw167: bp-guacamole slot 52's jdbc-seed post-install Job stuck on a
+      # missing guacamole-pg-app secret → DeadlineExceeded → bp-guacamole
+      # never Ready → bootstrap-kit health-check never completes) wedged
+      # bootstrap-kit, which blocked sovereign-tls, so the wildcard Certificate
+      # was never created → cert Secret missing → cilium-envoy HTTPS listener
+      # InvalidCertificateRef → TLS reset on :443 → console 000 for the whole
+      # Sovereign. The ONLY real prerequisites here are the cert-manager.io
+      # (bp-cert-manager) + gateway.networking.k8s.io (bp-gateway-api/bp-cilium)
+      # CRDs plus the sovereign-tls-vars CM (bp-catalyst-platform) — all of
+      # which land early and independently of leaf apps. Reconciling in
+      # parallel with a short retryInterval RETRIES the apply until those CRDs
+      # are registered, then applies the Certificate + Gateway — exactly the
+      # bootstrap-kit-crs idiom (#3804/#3642). wait:false so the per-resource
+      # health (cert issuance, envoy restart Job) reconciles async + does not
+      # re-gate this Kustomization on the apps it never needed.
       apiVersion: kustomize.toolkit.fluxcd.io/v1
       kind: Kustomization
       metadata:
@@ -635,15 +657,18 @@ write_files:
           openova.io/wildcard-cert-issuer-tag: "${wildcard_cert_issuer}"
       spec:
         interval: 5m
+        # retryInterval short (cf. bootstrap-kit-crs): with NO dependsOn the
+        # Certificate/Gateway apply fails the dry-run until bp-cert-manager /
+        # bp-gateway-api register their CRDs + bp-catalyst-platform emits the
+        # sovereign-tls-vars CM, so retry FAST to issue the wildcard promptly
+        # after — not at the 5m interval.
+        retryInterval: 1m
         path: ./clusters/_template/sovereign-tls
         prune: true
         sourceRef:
           kind: GitRepository
           name: openova
-        dependsOn:
-          - name: bootstrap-kit
-        wait: true
-        timeout: 5m
+        wait: false
         postBuild:
           substitute:
             SOVEREIGN_FQDN: ${sovereign_fqdn}

--- a/scripts/expected-cloudinit-kustomization-deps.yaml
+++ b/scripts/expected-cloudinit-kustomization-deps.yaml
@@ -7,13 +7,19 @@
 # only covers the HelmRelease documents inside clusters/_template/
 # bootstrap-kit/. The THREE top-level Flux Kustomizations created directly
 # by cloud-init — `bootstrap-kit`, `sovereign-tls`, `infrastructure-config`
-# — had ZERO drift protection. The hazard is PROVEN: `sovereign-tls`
-# dependsOn the whole `bootstrap-kit` Kustomization, so when shared-PG
-# stalled on hw130 the wildcard-TLS cert path was serialized behind it and
-# ALL TLS was delayed ~75 min. Once that dependsOn is narrowed (so the TLS
-# cert no longer waits for the slowest thing in the kit), nothing must let
-# it silently drift back to the broad `bootstrap-kit` edge — or silently
-# broaden any other top-level Kustomization. This file is the pinned
+# — had ZERO drift protection. The hazard is PROVEN TWICE: `sovereign-tls`
+# used to dependsOn the whole `bootstrap-kit` Kustomization, so (1) when
+# shared-PG stalled on hw130 the wildcard-TLS cert path was serialized behind
+# it and ALL TLS was delayed ~75 min, and (2) on hw167 a leaf app
+# (bp-guacamole slot 52, jdbc-seed Job DeadlineExceeded on a missing
+# guacamole-pg-app secret) wedged bootstrap-kit indefinitely → the wildcard
+# Certificate was NEVER created → cilium-envoy HTTPS listener
+# InvalidCertificateRef → console 000 for the whole Sovereign. #3845 SHIPPED
+# the narrowing (`sovereign-tls` now depends_on: [] — reconciles in parallel
+# with wait:false + retryInterval, the bootstrap-kit-crs idiom), so the TLS
+# cert no longer waits for the slowest/most-broken thing in the kit. Nothing
+# must let it silently drift back to the broad `bootstrap-kit` edge — or
+# silently broaden any other top-level Kustomization. This file is the pinned
 # expectation; scripts/check-cloudinit-kustomization-deps.sh fails CI on
 # any drift.
 #
@@ -38,8 +44,17 @@ kustomizations:
   - name: bootstrap-kit
     depends_on: []
   - name: sovereign-tls
-    depends_on:
-      - bootstrap-kit
+    # #3845 — NARROWED off the broad `bootstrap-kit` edge (the #3380 row-D
+    # narrowing). The Sovereign's wildcard TLS + Gateway must not be gated on
+    # all ~50 bootstrap-kit HRs being Ready: a single leaf app failing (caught
+    # live hw167 — bp-guacamole jdbc-seed Job DeadlineExceeded) wedged
+    # bootstrap-kit, blocked sovereign-tls, and the wildcard cert was never
+    # issued → cilium-envoy HTTPS listener InvalidCertificateRef → console 000.
+    # Same hazard class as the hw130 ~75-min TLS delay this guard's header
+    # documents. Now reconciles in parallel (wait:false + retryInterval),
+    # retrying the Certificate/Gateway apply until the cert-manager.io +
+    # gateway.networking.k8s.io CRDs register — the bootstrap-kit-crs idiom.
+    depends_on: []
   - name: bootstrap-kit-crs
     # #3642/#3731/#3804 fresh-prov 0-HR deadlock fix: host-bridge CRD-dependent
     # CRs (HTTPRoute/ExternalSecret/CNPG Cluster) split into this sibling tier.


### PR DESCRIPTION
## What

Decouple the `sovereign-tls` Flux Kustomization from the full `bootstrap-kit` health gate so the Sovereign's wildcard TLS + Cilium Gateway (the datapath the console and every `*.<fqdn>` surface terminate on) no longer depend on every leaf app being Ready.

- `infra/providers/_shared/cloudinit-control-plane.tftpl`: `sovereign-tls` no longer `dependsOn: [bootstrap-kit]`; now `wait: false` + `retryInterval: 1m` (the `bootstrap-kit-crs` idiom).
- `scripts/expected-cloudinit-kustomization-deps.yaml`: drift-guard lockstep — `sovereign-tls` pinned at `depends_on: []` (this is the `#3380 row-D` narrowing the guard header anticipated).

## Why (proven live, hw167 dep `28d4e96f`, Huawei/kom4dc)

`console.hw167.omantel.biz` was unreachable over HTTPS — TLS RESET on `:443`. The external L4 datapath is healthy (EIP `212.72.24.59:443/:80` OPEN, ELB→NodePort 30443/30080 OPEN, HTTP `:80` → 200). The break was at TLS termination: cilium-envoy's HTTPS Gateway listener had `InvalidCertificateRef` because the wildcard cert Secret `sovereign-wildcard-tls-hw167-omantel-biz` did not exist.

Root-cause chain:
1. `bp-guacamole` (slot 52, mgmt vCluster) post-install Job `guacamole-bp-guacamole-jdbc-seed` stuck on a missing `guacamole-pg-app` secret → `DeadlineExceeded` → HR never Ready.
2. The host `bootstrap-kit` Kustomization owns that HR and runs `wait: true` (health-checks every HR) → bootstrap-kit stuck `Ready=Unknown` indefinitely.
3. `sovereign-tls` declared `dependsOn: [bootstrap-kit]` + `wait: true` → reported `dependency not ready` → never reconciled → the wildcard `Certificate` was never created → no cert Secret → envoy listener invalid → TLS reset → console `000`.

This is the same over-broad-gate hazard the deps-guard header already documents (hw130, ~75-min TLS delay). A leaf app must never be able to take down the console's TLS.

## Fix detail

`sovereign-tls`'s only real prerequisites are the cert-manager.io (bp-cert-manager) + gateway.networking.k8s.io (bp-gateway-api/bp-cilium) CRDs and the `sovereign-tls-vars` CM (bp-catalyst-platform) — all of which land early and independently of leaf apps. Reconciling in parallel with a short `retryInterval` retries the Certificate/Gateway apply until those CRDs register, then applies them — exactly how `bootstrap-kit-crs` already breaks the same class of deadlock (#3804/#3642).

## Live validation

Applied the same change to the live hw167 `sovereign-tls` Kustomization: it went `Ready=True` within seconds, the wildcard `Certificate` + `CertificateRequest` (approved) + ACME `Order`/`Challenge` were created immediately — confirming the cert path no longer waits on bootstrap-kit/guacamole.

## Tests
- `scripts/check-cloudinit-kustomization-deps.sh` → OK (4 checked; sovereign-tls now a root).
- `scripts/lint-cloudinit.sh both` → PASS (hetzner + huawei render OK, `dash -n` clean).

Refs #3845
🤖 Generated with [Claude Code](https://claude.com/claude-code)
