### PR TITLE
fix(bp-powerdns-admin): SQLALCHEMY_ENGINE_OPTIONS pool_pre_ping — survive CNPG SSL connection recycling (0.1.17)

### DIFF
--- a/platform/powerdns-admin/blueprint.yaml
+++ b/platform/powerdns-admin/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 0.1.16
+  version: 0.1.17
   card:
     title: powerdns-admin
     summary: |

--- a/platform/powerdns-admin/chart/Chart.yaml
+++ b/platform/powerdns-admin/chart/Chart.yaml
@@ -138,7 +138,30 @@ name: bp-powerdns-admin
 # -> /oidc/login deterministically 302s to Keycloak from t=0. The Reloader
 # annotation is KEPT for live rotations. Event-deterministic, zero-touch,
 # fresh-prov-safe. Gated on sso.oidcReadinessGate.enabled (default true).
-version: 0.1.16
+# 0.1.17 (#3374, 2026-06-19): SQLAlchemy connection-resilience — the zero-click
+# bare-URL SSO redirect to Keycloak worked, but the OIDC callback (and EVERY
+# page) 500'd on a recycled DB connection, so the operator never landed on
+# /dashboard. ROOT CAUSE measured live on hw167 (dep 28d4e96f96407bbb): PDA
+# (Flask + SQLAlchemy 1.4) has NO pool_pre_ping, so when CNPG/PostgreSQL
+# recycle an idle SSL connection server-side, PDA hands out the dead pooled
+# connection → `psycopg2.OperationalError: SSL connection has been closed
+# unexpectedly`, the transaction is left invalid, and every subsequent request
+# 500s with `PendingRollbackError` until the Pod restarts. PDA runs a
+# `Setting().get()` DB query on EVERY request (routes/index.py:70 before_request
+# + __init__.py:95 inject_sitename → models/setting.py:103), so one dropped
+# connection bricks the whole UI — including the bare `/` → /oidc/login entry
+# and the SSO-onboarding callback. FIX: inject `SQLALCHEMY_ENGINE_OPTIONS`
+# (pool_pre_ping=true, pool_recycle=280) as a JSON env var. PDA's
+# lib/settings.py load_environment maps env `SQLALCHEMY_ENGINE_OPTIONS` (a
+# known `dict`-typed default) ⇄ app.config['SQLALCHEMY_ENGINE_OPTIONS'] via
+# json.loads (called LAST in create_app, after from_object, so it wins), and
+# Flask-SQLAlchemy 2.5.1 passes that config dict straight into create_engine()
+# (db = SQLAlchemy() is built with no engine_options arg → config is
+# authoritative). pool_pre_ping issues a SELECT 1 liveness check + transparent
+# reconnect before handing out any pooled connection — the canonical fix for
+# server-side connection recycling. NO DB-host/topology change (PDA stays on
+# shared-pg-b). Configurable via config.sqlAlchemyEngineOptions; set {} to omit.
+version: 0.1.17
 description: |
   PowerDNS-Admin (ngoduykhanh/powerdns-admin) web UI Blueprint for
   per-Sovereign PowerDNS zone + record management. Drives the

--- a/platform/powerdns-admin/chart/templates/deployment.yaml
+++ b/platform/powerdns-admin/chart/templates/deployment.yaml
@@ -180,6 +180,25 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.databaseSecret.name | default "pda-database-secret" }}
                   key: {{ .Values.databaseSecret.uriKey | default "uri" }}
+            # ─── SQLAlchemy connection resilience (#3374) ────────────────
+            # CNPG/PostgreSQL recycle idle SSL connections server-side. Without
+            # pool_pre_ping, PDA hands out a dead pooled connection on the next
+            # request → `psycopg2.OperationalError: SSL connection has been
+            # closed unexpectedly`, the transaction is left invalid, and EVERY
+            # subsequent request 500s with `PendingRollbackError` (PDA runs a
+            # Setting().get() DB query in before_request + inject_sitename on
+            # every request) — bricking the bare-URL zero-click `/` entry and
+            # the OIDC callback that onboards the SSO user, so the operator
+            # never lands on /dashboard. Measured live on hw167 (dep
+            # 28d4e96f96407bbb). PDA's lib/settings.py load_environment maps env
+            # `SQLALCHEMY_ENGINE_OPTIONS` (a known `dict`-typed default) ⇄
+            # app.config['SQLALCHEMY_ENGINE_OPTIONS'] via json.loads, which
+            # Flask-SQLAlchemy 2.5.1 passes straight to create_engine(). Render
+            # the values map as a JSON string. Omitted when the map is empty.
+            {{- with .Values.config.sqlAlchemyEngineOptions }}
+            - name: SQLALCHEMY_ENGINE_OPTIONS
+              value: {{ toJson . | quote }}
+            {{- end }}
             # The SQLA_DB_* vars below are retained for documentation +
             # forward/backward compatibility with the older ngoduykhanh
             # image; pda-legacy ignores them but they are harmless.

--- a/platform/powerdns-admin/chart/values.yaml
+++ b/platform/powerdns-admin/chart/values.yaml
@@ -252,5 +252,43 @@ config:
   proxyFix: true
   # Default landing page after sign-in.
   defaultLandingPage: dashboard
+  # ── SQLAlchemy connection resilience (#3374, 0.1.17) ──────────────────
+  # PDA (Flask + SQLAlchemy 1.4) holds a pooled DB connection. CNPG /
+  # PostgreSQL recycle idle SSL connections server-side, so a pooled
+  # connection PDA hands out can already be dead → the next query raises
+  # `psycopg2.OperationalError: SSL connection has been closed unexpectedly`,
+  # the transaction is left invalid, and EVERY subsequent request 500s with
+  # `PendingRollbackError` until the Pod restarts. PDA runs a `Setting().get()`
+  # DB query on EVERY request (routes/index.py before_request +
+  # __init__.py inject_sitename), so a single dropped connection bricks the
+  # whole UI — including the bare-URL `/` → /oidc/login zero-click entry and
+  # the OIDC callback that onboards the SSO user. Measured live on hw167 (dep
+  # 28d4e96f96407bbb): the OIDC redirect to Keycloak worked, but the
+  # DB-touching callback path 500'd on the recycled connection → never landed
+  # on /dashboard.
+  #
+  # `pool_pre_ping` makes SQLAlchemy issue a lightweight liveness check
+  # (SELECT 1) before handing out a pooled connection and transparently
+  # reconnect if it's dead — the canonical fix for server-side connection
+  # recycling. `pool_recycle` proactively discards connections older than N
+  # seconds so they never outlive the server's idle timeout. These are passed
+  # through to SQLAlchemy's create_engine() unchanged.
+  #
+  # INJECTION PATH: PDA's lib/settings.py `AppSettings.load_environment(app)`
+  # (called LAST in create_app, after from_object) iterates its `defaults`,
+  # uppercases each key, and for any matching env var assigns
+  # app.config[KEY] = convert_type(value). `sqlalchemy_engine_options` is a
+  # known default (type `dict`), so convert_type runs `json.loads()` on the
+  # env value and lands a real dict in `app.config['SQLALCHEMY_ENGINE_OPTIONS']`
+  # — exactly the key Flask-SQLAlchemy 2.5.1 reads to build the engine (db =
+  # SQLAlchemy() is constructed with NO engine_options arg, so the config dict
+  # is authoritative). The deployment renders this map to a JSON string env
+  # var. Verified live: settings.py reads SQLALCHEMY_ENGINE_OPTIONS, fsa 2.5.1
+  # passes app.config['SQLALCHEMY_ENGINE_OPTIONS'] into create_engine.
+  #
+  # Set sqlAlchemyEngineOptions to {} (empty) to omit the env var entirely.
+  sqlAlchemyEngineOptions:
+    pool_pre_ping: true
+    pool_recycle: 280
 
 extraEnv: []


### PR DESCRIPTION
## Problem

On hw167 (dep `28d4e96f96407bbb`) the PowerDNS-Admin zero-click SSO redirect to Keycloak worked, but the OIDC callback — and **every** page — returned HTTP 500, so the operator never landed on `/dashboard`.

**Root cause (measured live on the PDA pod):**

```
sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) SSL connection has been closed unexpectedly
...
sqlalchemy.exc.PendingRollbackError: Can't reconnect until invalid transaction is rolled back.
... render_template('errors/500.html', code=500, ...) -> HTTP 500
```

PDA (Flask + SQLAlchemy 1.4) holds a pooled DB connection with **no `pool_pre_ping`**. CNPG / PostgreSQL recycle idle SSL connections server-side, so PDA hands out a dead pooled connection on the next request → `OperationalError`, the transaction is left invalid, and every subsequent request 500s with `PendingRollbackError` until the pod restarts.

PDA runs a `Setting().get()` DB query on **every** request (`routes/index.py:70` `before_request` + `__init__.py:95` `inject_sitename` → `models/setting.py:103`), so a single dropped connection bricks the whole UI — including the bare-URL `/` → `/oidc/login` zero-click entry and the OIDC callback that onboards the SSO user.

The DB topology is correct (PDA is on the healthy `shared-pg-b` instance, 3/3). The SSL drops are normal CNPG connection recycling — PDA must tolerate them.

## Fix

Inject `SQLALCHEMY_ENGINE_OPTIONS` (`pool_pre_ping=true`, `pool_recycle=280`) as a JSON env var.

**Injection path (verified live):** PDA's `lib/settings.py` `AppSettings.load_environment(app)` — called **last** in `create_app`, after `from_object`, so it wins — iterates its `defaults`, uppercases each key, and for any matching env var assigns `app.config[KEY] = convert_type(value)`. `sqlalchemy_engine_options` is a known default of type `dict`, so `convert_type` runs `json.loads()` on the env value and lands a real dict in `app.config['SQLALCHEMY_ENGINE_OPTIONS']` — exactly the key Flask-SQLAlchemy 2.5.1 reads to build the engine (`db = SQLAlchemy()` is constructed with no `engine_options` arg, so the config dict is authoritative).

`pool_pre_ping` issues a lightweight `SELECT 1` liveness check + transparent reconnect before handing out any pooled connection — the canonical fix for server-side connection recycling. `pool_recycle` proactively discards connections older than 280s.

- New values knob `config.sqlAlchemyEngineOptions` (set `{}` to omit the env var).
- **No DB-host / topology change** — PDA stays on `shared-pg-b`. Connection-resilience only.

## Live validation on hw167

Patched the live PDA deployment with the env var + rolled the pod (Recreate strategy → fresh pool), then proved end-to-end inside the running app:

```
config SQLALCHEMY_ENGINE_OPTIONS = {'pool_pre_ping': True, 'pool_recycle': 280}
engine pool pre_ping = True
engine pool recycle  = 280
```

- PDA pod log since the fix: **zero** SSL / 500 / `PendingRollbackError` errors (was 500ing every request before).
- 5 rapid `GET /` hits → all **302** (was 500). `/` → `/oidc/login` → 302 → Keycloak realm auth (`client_id=powerdns-admin`), `redirect_uri=/oauth2/callback` accepted by KC.

## Remaining blocker (out of scope for this PR)

The zero-click SSO probe row for `pdns-admin` is still RED, but **no longer due to the DB 500** — the flow now reaches Keycloak cleanly. The probe ends at the `catalyst-pin` broker IdP, which brokers to the console's **passwordless 6-digit PIN** login. A fresh probe client has no established PIN session, so it can't complete the silent exchange to `/dashboard`. This affects `grafana` / `openbao` / `guacamole` / `hubble` **identically** on the same probe — it is the platform-wide PIN-session flow (working as designed — the PIN must be collected once), not a PDA defect. The PDA DB-resilience defect this PR targets is resolved.

Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)