### PR TITLE
fix(bp-sso-bridge): app-registration ExternalSecrets self-deleted by the orphan sweep every tick (hubble-ui zero-click SSO)

### DIFF
--- a/platform/sso-bridge/blueprint.yaml
+++ b/platform/sso-bridge/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.2.21
+  version: 0.2.22
   card:
     title: sso-bridge
     summary: |

--- a/platform/sso-bridge/chart/Chart.yaml
+++ b/platform/sso-bridge/chart/Chart.yaml
@@ -1,6 +1,29 @@
 apiVersion: v2
 name: bp-sso-bridge
-version: 0.2.21
+version: 0.2.22
+# 0.2.22 (#3374 cleanup-race, 2026-06-19): STOP the app-registration
+# ExternalSecret create-then-delete churn. cleanup_orphans() deletes any ES
+# labelled `bp-sso-bridge.openova.io/managed=true` whose client-id is NOT in
+# `current_cids` — but current_cids is built ONLY from the HR-discovery loop,
+# so the 4 app-registration ESs (hubble-ui, newapi-admin, openova-flow,
+# powerdns-admin), which ALSO carry that managed label (applied by
+# upsert_per_org_client's externalSecret.json path), were created each tick by
+# the app-registration phase then DELETED ~3s later by the orphan sweep in the
+# SAME tick. The ES + backing Secret therefore did not exist most of the time,
+# so the consuming oauth2-proxy (hubble-ui) had no client_secret →
+# zero-click SSO token-exchange intermittently failed. Fix: track the set of
+# app-registration clientIds whose ExternalSecret was successfully applied this
+# tick in a new global APP_REG_ES_CIDS (reset at the top of
+# reconcile_app_registrations, appended on a successful apply in
+# upsert_per_org_client), and UNION it into current_cids before the
+# cleanup_orphans call. Uninstall semantics preserved: a removed
+# app-registration ConfigMap drops its cid from BOTH sets next tick and its ES
+# is correctly swept. Verified live hw167 (28d4e96f): hubble-ui ES went from
+# recreated-every-tick to a single stable creationTimestamp across 5+ ticks,
+# Ready=True, and the Hubble UI lands the operator signed-in via zero-click SSO
+# (namespace selector renders, no unauthorized_client). Pure script change, no
+# values-default change, strictly an improvement for all 4 app-reg ESs. Refs
+# #3374.
 # 0.2.21 (#3820 #3642, 2026-06-18): default networkPolicy.keycloakNamespace +
 # openbaoNamespace `keycloak`/`openbao` → `mgmt`. #3642 (+#3760/#3737) re-homed
 # BOTH keycloak and openbao INTO the mgmt vCluster; their workload Pods now run

--- a/platform/sso-bridge/chart/templates/configmap-reconciler.yaml
+++ b/platform/sso-bridge/chart/templates/configmap-reconciler.yaml
@@ -944,6 +944,15 @@ data:
             "        property: ${es_prop}" \
             | kubectl --request-timeout=15s apply -f - >/dev/null 2>&1; then
             log "app-registration[${cid}]: applied ExternalSecret ${es_ns}/${es_name} (key=${es_key} <- sso/${realm}/${cid}#${es_prop})"
+            # #3374-cleanup-race (2026-06-19): record this clientId in the
+            # app-registration keep-list so the main loop's cleanup_orphans
+            # does NOT treat the ES we just applied (labelled managed=true,
+            # client-id=${cid}) as an orphan. current_cids is built only
+            # from the HR-discovery loop, so without this the app-reg ES is
+            # created here then deleted ~3s later in the same tick. Append
+            # only on successful apply — a failed/deferred apply leaves the
+            # cid out, so a genuinely-gone declaration is still swept.
+            APP_REG_ES_CIDS="${APP_REG_ES_CIDS} ${cid}"
           else
             warn "app-registration[${cid}]: ExternalSecret apply ${es_ns}/${es_name} failed (CRD not ready yet? retry next tick)"
           fi
@@ -954,6 +963,22 @@ data:
     reconcile_app_registrations() {
       # List every ConfigMap with label sso.openova.io/app-registration
       # (any namespace, any value — value is the clientId).
+      #
+      # #3374-cleanup-race (2026-06-19): reset the keep-list of
+      # app-registration clientIds that own a bp-sso-bridge-managed
+      # ExternalSecret. upsert_per_org_client appends to APP_REG_ES_CIDS
+      # whenever it APPLIES an ExternalSecret (the `externalSecret.json`
+      # path — hubble-ui, newapi-admin, openova-flow, powerdns-admin). The
+      # main loop unions this into current_cids BEFORE cleanup_orphans so
+      # the orphan sweep does NOT delete an ES the app-registration phase
+      # just created this very tick. Without this the app-registration ESs
+      # carry the `managed=true` label but are never in current_cids (that
+      # set is built only from the HR-discovery loop), so cleanup_orphans
+      # deleted them every tick — create-then-delete churn that left the
+      # consuming Secret absent most of the time (SSO token-exchange
+      # intermittently broken). Reset here, not at loop top, so the global
+      # is fresh per tick regardless of early returns.
+      APP_REG_ES_CIDS=""
       local cms
       cms="$(kubectl --request-timeout=15s get configmaps -A \
         -l 'sso.openova.io/app-registration' \
@@ -994,6 +1019,11 @@ data:
 
     # ─── main loop ──────────────────────────────────────────────────────
     log "bp-sso-bridge reconciler starting; realm=${KC_REALM} addr=${KC_ADDR} interval=${INTERVAL_SECONDS}s"
+
+    # #3374-cleanup-race (2026-06-19): app-registration ES keep-list,
+    # repopulated each tick by reconcile_app_registrations. Init here so the
+    # global is always defined under `set -u` even before the first reset.
+    APP_REG_ES_CIDS=""
 
     while true; do
       tick_started="$(date +%s)"
@@ -1077,7 +1107,18 @@ data:
       log "tick: phase app-registrations"
       reconcile_app_registrations || true
 
-      cleanup_orphans "${current_cids}" || true
+      # #3374-cleanup-race (2026-06-19): the orphan sweep keeps any ES whose
+      # client-id is in the union of (a) the HR-discovery clientIds
+      # (current_cids) AND (b) the app-registration clientIds that own a
+      # bp-sso-bridge-applied ExternalSecret this tick (APP_REG_ES_CIDS,
+      # populated by upsert_per_org_client on a successful ES apply). The
+      # app-reg ESs (hubble-ui, newapi-admin, openova-flow, powerdns-admin)
+      # carry the managed=true label but never appeared in current_cids, so
+      # cleanup_orphans was deleting them every tick right after creating
+      # them. Uninstall semantics are preserved: when an app-registration
+      # ConfigMap is removed, its cid drops out of BOTH sets next tick and
+      # the orphan ES is correctly swept.
+      cleanup_orphans "${current_cids}${APP_REG_ES_CIDS}" || true
 
       tick_done="$(date +%s)"
       log "tick complete in $(( tick_done - tick_started ))s (discovered=${discovered:-0} reconciled=${reconciled_count:-0} managed=${current_cids:-none})"


### PR DESCRIPTION
## Problem

`cleanup_orphans()` in the sso-bridge reconciler deletes any ExternalSecret labelled `bp-sso-bridge.openova.io/managed=true` whose `client-id` is **not** in the per-tick keep-set `current_cids`. But `current_cids` is built **only** from the HR-discovery loop (grafana/gitea/harbor/openbao/powerdns-admin/sandbox/catalyst-platform).

The 4 **app-registration** ExternalSecrets — `hubble-ui`, `newapi-admin`, `openova-flow`, `powerdns-admin` — are created by `upsert_per_org_client`'s `externalSecret.json` path and carry the **same** `managed=true` label, but their clientIds never entered `current_cids`. So every tick:

1. `app-registration[hubble-ui]: applied ExternalSecret kube-system/hubble-ui-oauth2-proxy-oidc`
2. ~3s later, same tick: `cleanup orphan ExternalSecret kube-system/hubble-ui-oauth2-proxy-oidc (clientId=hubble-ui)`

The ES and its backing K8s Secret were therefore **absent most of the time**. The hubble-ui oauth2-proxy Deployment env `OAUTH2_PROXY_CLIENT_SECRET` references `hubble-ui-oauth2-proxy-oidc/client-secret`, so the proxy had no client_secret and zero-click SSO token-exchange failed intermittently (founder north-star #4 / contract in #3374).

## Root cause (exact line)

`cleanup_orphans "${current_cids}"` was called with **only** the HR-path clientIds; the orphan sweep then matched the app-registration ESs (managed-labelled) as orphans because their cid was absent from that set.

## Fix (surgical, fix-forward)

`platform/sso-bridge/chart/templates/configmap-reconciler.yaml`:

- New global `APP_REG_ES_CIDS`, reset at the top of `reconcile_app_registrations`, appended (`APP_REG_ES_CIDS="${APP_REG_ES_CIDS} ${cid}"`) inside `upsert_per_org_client` **only on a successful ExternalSecret apply**.
- Main loop unions it into the cleanup call: `cleanup_orphans "${current_cids}${APP_REG_ES_CIDS}"`.

Uninstall semantics preserved: when an app-registration ConfigMap is removed, its cid drops from **both** sets next tick and its ES is correctly swept. Strictly an improvement for all 4 app-reg ESs.

## Live validation — hw167 (deployment `28d4e96f96407bbb`)

Applied the fixed `reconcile.sh` to the live ConfigMap + restarted the reconciler, then observed:

- **Before:** `applied ExternalSecret` immediately followed by `cleanup orphan ExternalSecret` for hubble-ui every tick; `kubectl get externalsecret -n kube-system` = none; Secret `hubble-ui-oauth2-proxy-oidc` = NotFound.
- **After (5+ ticks):** hubble-ui ES has a **single stable creationTimestamp** (never recreated), `Ready=True / SecretSynced`; the `cleanup orphan` log line for app-reg cids is **gone**; backing Secret present.
- **Zero-click SSO walk:** with the operator session established (console row GREEN → `/dashboard`), bare `https://hubble.hw167.omantel.biz/` now lands the operator **signed in** — the Hubble UI renders its namespace selector (`Welcome! To begin select one of the namespaces: alloy catalyst cilium ... vpa`, page title `Hubble UI`), with **no** `unauthorized_client` / `Internal Server Error`. (An unauthenticated context still correctly bounces to the catalyst-pin login — proving the render is genuinely session-gated.)

## Probe note

The `sso-zero-click-probe.mjs` hubble row currently REDs on a regex mismatch only: its positive marker is `Hubble|Service Map|Namespace` (capital N) but Hubble's rendered **body** text is lowercase `namespace` and `Hubble` lives in the page `<title>` (not `textContent('body')`). The login/error markers are absent and the final URL is the real Hubble UI — i.e. the app genuinely passes; the probe assertion is too strict. Flagged for a follow-up probe-regex fix (out of scope here — this PR is chart/IaC only).

Refs #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)