### PR TITLE
fix(bp-openbao): openbao zero-click SSO — in-vCluster k8s-auth mount + gateway-decoupled landing (#3374)

### DIFF
--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.2.49
+  version: 1.2.50  # lockstep with chart/Chart.yaml (#3374 openbao zero-click SSO: in-vCluster k8s-auth mount + gateway-decoupled landing)
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -141,7 +141,33 @@ name: bp-openbao
 # Job soft-waits (backoffLimit retries) for the mirror. DEFAULT false →
 # single-region / Catalyst-Zero / host-side-openbao render byte-identical +
 # in-cluster TokenReview path unchanged. Refs #3642 #3736.
-version: 1.2.49
+#
+# 1.2.50 (#3374, 2026-06-19): FIX openbao zero-click SSO on a vCluster Sovereign
+# — two independent #3642-fallout breaks, both measured live on hw167:
+#   (A) AUTH: #3825's cross-cluster mode points the SINGLE `kubernetes/` auth
+#       mount's TokenReview at the HOST apiserver (right for ESO's host SA, FATAL
+#       for the in-vCluster sso-configure SA — host rejects the vCluster-signed
+#       JWT: "invalid signature, no keys found" → every login 403s → the OIDC
+#       reconciler NEVER writes auth/oidc/config / default_role / role/operator →
+#       the landing page's unauth oidc/auth_url returns "permission denied" →
+#       /sso/landing fails → chrome-error). FIX: auth-bootstrap Job enables a
+#       SECOND `kubernetes-vcluster/` mount that TokenReviews against the
+#       IN-VCLUSTER apiserver (local SA+CA — kubernetes.default.svc IS the
+#       vCluster apiserver from openbao-0's view), binds the in-vCluster-SA roles
+#       (sso-configure/sso-bridge/openbao-snapshot) there, and the consumers log
+#       in against it under the SAME XCR gate.
+#   (B) LANDING: the chart's sso-landing.yaml gated the landing nginx
+#       Deployment/Service/ConfigMap on `gateway.enabled`, but the vCluster pivot
+#       sets gateway.enabled:false (the HTTPRoute is re-created host-side as a
+#       host-bridge resource pointing at openbao-sso-landing-x-…-mgmt-vcluster) →
+#       the landing nginx never rendered → the host-bridge HTTPRoute's backend was
+#       missing → /sso/landing 500. FIX: gate the landing WORKLOAD only on
+#       sso.bareURL.enabled (it has zero gateway dependency); the HTTPRoute stays
+#       gateway-gated in httproute.yaml.
+# Both default-OFF for host-side openbao (XCR off) → byte-identical render.
+# Verified GREEN live hw167 2026-06-19: bao.<fqdn>/ui/ → /sso/landing → lands
+# /ui/vault/secrets (sso-zero-click-probe openbao row GREEN). Pin in lockstep.
+version: 1.2.50
 # 1.2.46 (#3629, 2026-06-16): the SECONDARY (fetch) snapshot CronJob no longer
 # performs an OpenBao k8s-auth login. The fetch path is PURE S3 I/O
 # (list-objects-v2 + `s3 cp` to the restore-staging PVC) and NEVER reads

--- a/platform/openbao/chart/templates/auth-bootstrap-job.yaml
+++ b/platform/openbao/chart/templates/auth-bootstrap-job.yaml
@@ -294,6 +294,44 @@ spec:
                   disable_iss_validation=true
               fi
 
+              # ─── #3374 (Refs #3642 #3825) SECOND mount: in-vCluster TokenReview ─
+              # In cross-cluster mode the $AUTH_MOUNT_PATH mount above TokenReviews
+              # against the HOST apiserver (correct for ESO, a host-SA role). But
+              # the in-vCluster-SA roles — sso-configure (ns=this release ns),
+              # sso-bridge, openbao-snapshot — present a JWT signed by the VCLUSTER
+              # apiserver, which the host apiserver CANNOT validate ("invalid
+              # signature, no keys found") → those logins 403 → silent SSO never
+              # configures (measured live hw167 2026-06-19: openbao /sso/landing
+              # chrome-error). Enable a parallel `kubernetes-vcluster/` mount that
+              # validates against the IN-VCLUSTER apiserver using this Job's OWN
+              # local SA + local CA: `kubernetes.default.svc` from a Pod inside the
+              # vCluster IS the vCluster apiserver (NOT the host — that is only
+              # reachable via the explicit 10.96.0.1 host-bridge), and the Job's SA
+              # carries system:auth-delegator there (auto-unseal SA). disable_local_
+              # ca_jwt stays default(false) so OpenBao uses its own in-pod token to
+              # call the review. Runtime-gated on XCR_ENABLED: when XCR is off
+              # (host-side openbao / Catalyst-Zero) the block is INERT — no second
+              # mount is enabled and no role is rebound, so OpenBao behaviour is
+              # unchanged (the single `kubernetes/` mount is already the in-cluster
+              # apiserver). The gate is the same XCR_ENABLED env the host-bridge
+              # config block above keys on.
+              if [ "${XCR_ENABLED}" = "true" ]; then
+                VC_AUTH_MOUNT_PATH="kubernetes-vcluster"
+                VC_EXISTING_AUTH=$(bao auth list -format=json 2>/dev/null || echo "{}")
+                if echo "$VC_EXISTING_AUTH" | grep -qE "\"$VC_AUTH_MOUNT_PATH/\""; then
+                  echo "[openbao-auth-bootstrap] auth method $VC_AUTH_MOUNT_PATH/ already enabled"
+                else
+                  echo "[openbao-auth-bootstrap] enabling Kubernetes auth at $VC_AUTH_MOUNT_PATH/ (in-vCluster TokenReview)"
+                  bao auth enable -path=$VC_AUTH_MOUNT_PATH kubernetes
+                fi
+                VC_KUBE_CA=$(cat /var/run/secrets/kubernetes.io/serviceaccount/ca.crt)
+                echo "[openbao-auth-bootstrap] writing auth/$VC_AUTH_MOUNT_PATH/config (kubernetes_host=in-vCluster apiserver)"
+                bao write auth/$VC_AUTH_MOUNT_PATH/config \
+                  kubernetes_host="https://kubernetes.default.svc" \
+                  kubernetes_ca_cert="$VC_KUBE_CA" \
+                  disable_iss_validation=true
+              fi
+
               # ─── Ensure kv-v2 backend at $KV_MOUNT_PATH/ ────────────────
               EXISTING_MOUNTS=$(bao secrets list -format=json 2>/dev/null || echo "{}")
               if echo "$EXISTING_MOUNTS" | grep -qE "\"$KV_MOUNT_PATH/\""; then
@@ -349,6 +387,19 @@ spec:
                 policies=sso-bridge-write,external-secrets-read \
                 ttl=$TOKEN_TTL \
                 max_ttl=$TOKEN_MAX_TTL
+              # #3374 — sso-bridge runs in the mgmt vCluster (ns sso-bridge); in
+              # XCR mode its vCluster-signed SA token only validates on the
+              # in-vCluster mount. Bind the SAME role there too (idempotent;
+              # no-op when XCR off).
+              if [ "${XCR_ENABLED}" = "true" ]; then
+                bao write auth/$VC_AUTH_MOUNT_PATH/role/sso-bridge \
+                  bound_service_account_names=sso-bridge-reconciler \
+                  bound_service_account_namespaces=sso-bridge \
+                  policies=sso-bridge-write,external-secrets-read \
+                  ttl=$TOKEN_TTL \
+                  max_ttl=$TOKEN_MAX_TTL \
+                  && echo "[openbao-auth-bootstrap] sso-bridge role also bound on $VC_AUTH_MOUNT_PATH/"
+              fi
 
               # sso-configure: admin-scoped policy for the in-namespace
               # Deployment that enables + configures the oidc auth method
@@ -382,6 +433,24 @@ spec:
                 policies=sso-configure-admin \
                 ttl=$TOKEN_TTL \
                 max_ttl=$TOKEN_MAX_TTL
+              # #3374 (THE openbao zero-click fix) — the sso-configure reconciler
+              # is an in-vCluster Pod (ns=$NAMESPACE inside the mgmt vCluster); its
+              # vCluster-signed SA token is rejected by the HOST apiserver that the
+              # `kubernetes/` mount targets in XCR mode. Bind the role on the
+              # in-vCluster mount so its login succeeds (sso-configure-deployment.yaml
+              # sets BAO_K8S_AUTH_PATH=kubernetes-vcluster under the same XCR gate).
+              # Verified live hw167 2026-06-19: login → oidc/auth_url returns a real
+              # auth_url → /sso/landing → lands /ui/vault/secrets. Idempotent; no-op
+              # when XCR off.
+              if [ "${XCR_ENABLED}" = "true" ]; then
+                bao write auth/$VC_AUTH_MOUNT_PATH/role/sso-configure \
+                  bound_service_account_names=openbao-sso-configure \
+                  bound_service_account_namespaces=$NAMESPACE \
+                  policies=sso-configure-admin \
+                  ttl=$TOKEN_TTL \
+                  max_ttl=$TOKEN_MAX_TTL \
+                  && echo "[openbao-auth-bootstrap] sso-configure role also bound on $VC_AUTH_MOUNT_PATH/ (in-vCluster TokenReview — #3374)"
+              fi
 
               # ─── #3376 — catalyst-api handover-archive writer role ──────
               # The Sovereign's catalyst-api seals the phase0 tofu archive
@@ -437,6 +506,18 @@ spec:
                 policies=openbao-snapshot \
                 ttl=$TOKEN_TTL \
                 max_ttl=$TOKEN_MAX_TTL
+              # #3374 — the snapshot CronJob runs in the mgmt vCluster (ns=$NAMESPACE);
+              # in XCR mode its vCluster-signed SA token only validates on the
+              # in-vCluster mount. Bind the role there too (idempotent; no-op off).
+              if [ "${XCR_ENABLED}" = "true" ]; then
+                bao write auth/$VC_AUTH_MOUNT_PATH/role/{{ $srAuthRole }} \
+                  bound_service_account_names=openbao-snapshot \
+                  bound_service_account_namespaces=$NAMESPACE \
+                  policies=openbao-snapshot \
+                  ttl=$TOKEN_TTL \
+                  max_ttl=$TOKEN_MAX_TTL \
+                  && echo "[openbao-auth-bootstrap] {{ $srAuthRole }} role also bound on $VC_AUTH_MOUNT_PATH/"
+              fi
 {{- end }}
 
               # ─── Revoke + cleanup root token ──────────────────────────

--- a/platform/openbao/chart/templates/snapshot-replication.yaml
+++ b/platform/openbao/chart/templates/snapshot-replication.yaml
@@ -65,6 +65,14 @@ objects). The primary vs secondary CronJob is selected by
 {{- $backoff := $sr.backoffLimit | default 3 -}}
 {{- $kAuth := $sr.kubernetesAuth | default dict -}}
 {{- $authMount := $kAuth.mountPath | default "kubernetes" -}}
+{{- /* #3374 (Refs #3642 #3825) — this CronJob runs in the mgmt vCluster; in
+       cross-cluster mode its vCluster-signed SA token only validates on the
+       in-vCluster `kubernetes-vcluster/` mount (the `kubernetes/` mount
+       TokenReviews against the HOST apiserver, which rejects it). Switch the
+       login path under the same XCR gate the auth-bootstrap Job binds the role
+       on. No-op (default `kubernetes`) when XCR is off → byte-identical. */ -}}
+{{- $xcrSnap := ((((.Values.autoUnseal | default dict).kubernetesAuth | default dict).crossClusterTokenReview | default dict).enabled | default false) -}}
+{{- if $xcrSnap -}}{{- $authMount = "kubernetes-vcluster" -}}{{- end -}}
 {{- $authRole := $kAuth.role | default "openbao-snapshot" -}}
 {{- $s3 := $sr.s3 | default dict -}}
 {{- /* #3373 Batch A: seaweedfs moved into the rtz vCluster → synced host Service name. */ -}}

--- a/platform/openbao/chart/templates/sso-configure-deployment.yaml
+++ b/platform/openbao/chart/templates/sso-configure-deployment.yaml
@@ -47,6 +47,34 @@ the server → the oidc auth method was never configured → silent SSO never
 worked. (#3150)
 */}}
 {{- $baoAddrSSO := (.Values.autoUnseal | default dict).baoAddress | default (printf "http://%s-openbao.%s.svc.cluster.local:8200" .Release.Name .Release.Namespace) -}}
+{{- /*
+#3374 (Refs #3642 #3825) — the k8s-auth MOUNT this reconciler logs in against.
+
+ROOT CAUSE (measured live hw167 2026-06-19): after #3642 OpenBao runs INSIDE the
+mgmt vCluster, and THIS reconciler is also a vCluster Pod — its ServiceAccount
+JWT is signed by the VCLUSTER apiserver (iss=kubernetes.default.svc of the
+vCluster, sub=system:serviceaccount:<ns>:openbao-sso-configure). But #3825's
+cross-cluster mode points the `kubernetes/` auth mount's TokenReview at the HOST
+apiserver (kubernetes_host=10.96.0.1 + a host token_reviewer_jwt) — correct for
+ESO (a HOST-SA role) but FATAL for this in-vCluster SA: the host apiserver
+rejects the vCluster-signed token ("invalid signature, no keys found") → every
+login 403s → the reconciler NEVER writes auth/oidc/config / default_role /
+role/operator → the landing page's unauthenticated oidc/auth_url POST returns
+"permission denied" → /sso/landing hard-fails → chrome-error. (ESO worked,
+sso-configure/sso-bridge/openbao-snapshot all silently broke.)
+
+THE FIX: when XCR is on, the auth-bootstrap Job ALSO enables a SECOND mount
+`kubernetes-vcluster/` configured to TokenReview against the IN-VCLUSTER
+apiserver (OpenBao's own local SA + local CA — `kubernetes.default.svc` IS the
+vCluster apiserver from openbao-0's pod view; verified it both reaches it and
+holds system:auth-delegator there). The in-vCluster-SA roles are bound on THAT
+mount, so this reconciler must log in there. When XCR is OFF (openbao host-side
+/ Catalyst-Zero) there is no second mount and the single `kubernetes/` mount is
+the in-cluster apiserver already → keep the default path → byte-identical.
+*/}}
+{{- $xcrSSO := ((((.Values.autoUnseal | default dict).kubernetesAuth | default dict).crossClusterTokenReview | default dict).enabled | default false) -}}
+{{- $authMountSSO := ((.Values.autoUnseal | default dict).kubernetesAuth | default dict).mountPath | default "kubernetes" -}}
+{{- if $xcrSSO -}}{{- $authMountSSO = "kubernetes-vcluster" -}}{{- end -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -376,8 +404,14 @@ spec:
           env:
             - name: BAO_ADDR
               value: {{ $baoAddrSSO | quote }}
+            # #3374 (Refs #3642 #3825) — vCluster-validated mount when XCR is on
+            # (see the $authMountSSO derivation at the top of this template). The
+            # in-vCluster SA token this Pod presents is rejected by the HOST
+            # apiserver that the `kubernetes/` mount targets in cross-cluster
+            # mode, so log in against `kubernetes-vcluster/` (TokenReview = the
+            # in-vCluster apiserver). Host-side openbao keeps the default mount.
             - name: BAO_K8S_AUTH_PATH
-              value: {{ .Values.autoUnseal.kubernetesAuth.mountPath | default "kubernetes" | quote }}
+              value: {{ $authMountSSO | quote }}
             - name: BAO_K8S_AUTH_ROLE
               value: "sso-configure"
             - name: OIDC_NAME

--- a/platform/openbao/chart/templates/sso-landing.yaml
+++ b/platform/openbao/chart/templates/sso-landing.yaml
@@ -38,8 +38,25 @@ WHAT THIS PAGE DOES (gesture-free, popup-free, version-stable):
   the OIDC callback. The bare-path HTTPRoute (/, /ui, /ui/) redirects HERE;
   a re-entry that already holds a valid token short-circuits to
   /ui/vault/secrets (idempotent). API clients use /v1/* — never touched.
+
+  GATE — DO NOT re-add `.Values.gateway.enabled`/`.Values.gateway.host` here
+  (#3374, the hw167 2026-06-19 zero-click regression): the landing
+  ConfigMap/Deployment/Service are pure in-cluster workloads that serve the
+  static page on the OpenBao origin — they have ZERO dependency on the Cilium
+  Gateway. Only the bare-URL HTTPRoute (templates/httproute.yaml) is gated on
+  `gateway.enabled` (it attaches to the gateway). After #3642 the vCluster pivot
+  sets `gateway.enabled:false` on the in-vCluster HelmRelease and re-creates the
+  HTTPRoute as a HOST-BRIDGE resource (clusters/_template/bootstrap-kit-crs/
+  08-openbao.yaml, label host-bridge:mgmt) whose backendRef is
+  `openbao-sso-landing-x-<ns>-x-mgmt-vcluster` — i.e. THIS Service, vCluster-
+  synced to the host. If this gate ALSO required gateway.enabled the landing
+  nginx would NOT render in the vCluster → the host-bridge HTTPRoute's backend
+  would be missing → `/ui/` -> 302 `/sso/landing` -> 500 (no backend) ->
+  chrome-error (the exact break measured live on hw167). So gate ONLY on
+  bare-URL SSO being enabled; the HTTPRoute's owner (chart-side when openbao is
+  host-placed, host-bridge when in a vCluster) is orthogonal to this workload.
 */ -}}
-{{- if and .Values.gateway .Values.gateway.enabled .Values.gateway.host .Values.sso .Values.sso.enabled .Values.sso.bareURL .Values.sso.bareURL.enabled }}
+{{- if and .Values.sso .Values.sso.enabled .Values.sso.bareURL .Values.sso.bareURL.enabled }}
 {{- $mount := .Values.sso.bareURL.oidcMount | default "oidc" }}
 {{- $role := .Values.sso.bareURL.oidcRole | default "operator" }}
 {{- $landingPath := .Values.sso.bareURL.landingPath | default "/sso/landing" }}


### PR DESCRIPTION
## What

Fix OpenBao **zero-click SSO landing** on a vCluster Sovereign (hw167, dep `28d4e96f96407bbb`). The probe row was RED (`bao.<fqdn>/ui/` → 302 `/sso/landing` → `chrome-error://`). Root-caused to **two independent #3642-fallout breaks**, both measured live, both fixed durably in the chart. Fix-forward only — no password/auto-owner, passwordless PIN untouched.

## Root cause (two bugs)

**(A) AUTH — in-vCluster SA token rejected by the host apiserver**
After #3642 OpenBao runs inside the mgmt vCluster. #3825's cross-cluster mode points the single `kubernetes/` auth mount's TokenReview at the **HOST** apiserver (`kubernetes_host=10.96.0.1` + host token-reviewer) — correct for ESO (a host-SA role), **fatal** for the in-vCluster `openbao-sso-configure` reconciler. Its SA token is signed by the **vCluster** apiserver, which the host rejects:
```
TokenReview(vCluster SA token) @ host apiserver -> "invalid bearer token, invalid signature, no keys found"
```
→ every `auth/kubernetes/login` 403s (115 min of `WARN: bao login returned no client_token`) → the reconciler NEVER writes `auth/oidc/config` / `default_role=operator` / `role/operator` → the landing page's unauthenticated `POST /v1/auth/oidc/oidc/auth_url {role:operator}` returns `permission denied` → `/sso/landing` dead-ends → chrome-error. (ESO + catalyst-api are host-SA roles and worked; sso-configure/sso-bridge/openbao-snapshot are in-vCluster-SA roles and all silently broke.)

**(B) LANDING — the landing nginx was orphaned by the vCluster pivot**
`sso-landing.yaml` gated the landing ConfigMap/Deployment/Service on `gateway.enabled`. The vCluster pivot sets `gateway.enabled:false` on the in-vCluster HR and re-creates the bare-URL HTTPRoute as a **host-bridge** resource (`clusters/_template/bootstrap-kit-crs/08-openbao.yaml`) whose backendRef is `openbao-sso-landing-x-<ns>-x-mgmt-vcluster`. So the landing nginx **never rendered** (verified: 0 occurrences in the live helm release manifest + absent in the vCluster) → the host-bridge HTTPRoute's backend was missing → `/sso/landing` returned **500**.

## Fix

- **`auth-bootstrap-job.yaml`** — when XCR is on, ALSO enable a `kubernetes-vcluster/` auth mount that TokenReviews against the **in-vCluster** apiserver (the Job's own local SA + local CA; `kubernetes.default.svc` from a pod inside the vCluster IS the vCluster apiserver, and the auto-unseal SA holds `system:auth-delegator` there). Bind the three in-vCluster-SA roles (`sso-configure`, `sso-bridge`, `openbao-snapshot`) on it. Runtime-gated on `XCR_ENABLED` → inert when host-side.
- **`sso-configure-deployment.yaml`** + **`snapshot-replication.yaml`** — set `BAO_K8S_AUTH_PATH=kubernetes-vcluster` under the same XCR gate; default `kubernetes` when off → byte-identical.
- **`sso-landing.yaml`** — gate the landing **workload** only on `sso.bareURL.enabled` (it has zero gateway dependency); the HTTPRoute stays gateway-gated in `httproute.yaml`. Host-side openbao still renders it → no regression.
- Chart `1.2.49 -> 1.2.50` + `blueprint.yaml` lockstep.

All default-OFF for host-side openbao (XCR off) → behaviour unchanged. The 5 chart render/toggle tests pass (`sso-landing-render`, `httproute-render`, `auto-unseal-toggle`, `snapshot-replication-toggle`, `kyverno-harbor-proxy-images`, `g117-5-sso-tier1`).

## Live validation (hw167)

Applied the fix live (created the `kubernetes-vcluster/` mount + `sso-configure` role; rendered + applied the landing nginx into the vCluster; pointed the reconciler at the vCluster mount):
- reconciler log: `auth/oidc/config written` · `auth/oidc/role/operator written` · `tick complete — OIDC bootstrap converged`
- `POST /v1/auth/oidc/oidc/auth_url` now returns a real `data.auth_url` (was `permission denied`)
- `/sso/landing` → **200**
- **`sso-zero-click-probe` openbao row GREEN**: `https://bao.hw167.omantel.biz/ui/vault/secrets`

```
[GREEN] console   https://console.hw167.omantel.biz/dashboard
[GREEN] openbao   https://bao.hw167.omantel.biz/ui/vault/secrets
2/2 rows GREEN
```

> Note for existing envs: the auth-bootstrap Job exits early on re-run (root token revoked post-install), so the `kubernetes-vcluster/` mount self-creates only on **fresh prov**. hw167 was bridged by the live application above; the durable chart path is correct for fresh provs once 1.2.50 is pinned.

Refs #3374 #3642 #3825

🤖 Generated with [Claude Code](https://claude.com/claude-code)
