### PR TITLE
test(bp-gitea): align SSO tests with #3851 Job->Deployment refactor — unblock 1.2.38 publish

### DIFF
--- a/platform/gitea/chart/tests/g117-5-sso-tier1.sh
+++ b/platform/gitea/chart/tests/g117-5-sso-tier1.sh
@@ -8,12 +8,16 @@
 #   2. The ExternalSecret's `authorize_url` template appends
 #      `?kc_idp_hint=catalyst-pin` (defense-in-depth to the bp-keycloak
 #      1.4.9+ realm-config IDR `defaultProvider` binding).
-#   3. The sso-configure-oauth-job mounts the SSO Secret as a Projected
-#      Volume (so it can read authorize_url alongside the env-var
-#      key+secret) and ships IDP_HINT env defaulting to catalyst-pin.
-#   4. The Job script uses `--use-custom-url-mapping --custom-auth-url`
-#      when IDP_HINT is non-empty AND the bundle files exist.
-#   5. Opt-out: sso.idpHint="" reverts to --auto-discover-url path.
+#   3. The sso-configure reconciler (a Deployment post-#3851) mounts the
+#      SSO Secret gitea-oauth-source-credentials at /etc/sso-creds so it can
+#      read authorize_url (kc_idp_hint already baked in by the ExternalSecret).
+#   4. The reconcile script uses `--use-custom-url-mapping --custom-auth-url`
+#      when the idp hint is set AND the bundle files exist.
+#   5. Opt-out: sso.idpHint="" drops kc_idp_hint + reverts to --auto-discover-url.
+#
+# NOTE (#3851): the one-shot configure-oauth Job was refactored into a
+# continuously-reconciling Deployment (the openbao file-read posture). The
+# cases below assert the rendered reconciler manifest, not a Job.
 
 set -euo pipefail
 
@@ -54,14 +58,20 @@ if ! grep -q 'authorize_url:.*kc_idp_hint=catalyst-pin' "${tmpdir}/default.yaml"
 fi
 echo "  PASS"
 
-# Case 3: Job mounts SSO Secret + IDP_HINT env present
-echo "[g117-5-sso-tier1] Case 3: configure-oauth Job mounts sso-bundle + has IDP_HINT env"
-if ! grep -q 'name: sso-bundle' "${tmpdir}/default.yaml"; then
-  echo "FAIL: configure-oauth Job missing sso-bundle volume" >&2
+# Case 3: the sso-configure reconciler mounts the SSO Secret as files.
+# #3851 refactored the one-shot configure-oauth Job into a continuously-
+# reconciling Deployment (the openbao file-read posture): instead of a
+# projected volume named `sso-bundle` + an IDP_HINT env var, the bundle
+# Secret `gitea-oauth-source-credentials` is mounted at /etc/sso-creds and
+# the reconcile script reads authorize_url (kc_idp_hint already baked in by
+# the ExternalSecret — Case 2) from those files.
+echo "[g117-5-sso-tier1] Case 3: sso-configure reconciler mounts gitea-oauth-source-credentials at /etc/sso-creds"
+if ! grep -q 'secretName: gitea-oauth-source-credentials' "${tmpdir}/default.yaml"; then
+  echo "FAIL: sso-configure reconciler does not mount the gitea-oauth-source-credentials Secret" >&2
   exit 1
 fi
-if ! grep -q 'name: IDP_HINT' "${tmpdir}/default.yaml"; then
-  echo "FAIL: configure-oauth Job missing IDP_HINT env var" >&2
+if ! grep -q 'mountPath: /etc/sso-creds' "${tmpdir}/default.yaml"; then
+  echo "FAIL: sso-configure reconciler missing the /etc/sso-creds bundle mount" >&2
   exit 1
 fi
 echo "  PASS"
@@ -78,17 +88,20 @@ if ! grep -q '\-\-custom-auth-url' "${tmpdir}/default.yaml"; then
 fi
 echo "  PASS"
 
-# Case 5: Opt-out — idpHint="" still renders + Job still uses --auto-discover-url fallback
+# Case 5: Opt-out — idpHint="" drops the hint from authorize_url AND the
+# reconciler falls back to the --auto-discover-url path (post-#3851 the
+# obsolete IDP_HINT env var is gone; the opt-out signal is the absence of
+# kc_idp_hint in the ExternalSecret + the auto-discover-url codepath).
 echo "[g117-5-sso-tier1] Case 5: opt-out path (idpHint='') falls back to --auto-discover-url"
-"$helm" template smoke "$chart_dir" --set sso.sovereignFqdn=smoke.omani.works --set sso.idpHint='' 2>/dev/null > "${tmpdir}/optout.yaml"
+"$helm" template smoke "$chart_dir" --set sso.sovereignFqdn=smoke.omani.works --set sso.idpHint='' --api-versions "external-secrets.io/v1beta1" 2>/dev/null > "${tmpdir}/optout.yaml"
 # The ExternalSecret template should not carry "kc_idp_hint=" anymore
 if grep -q 'authorize_url:.*kc_idp_hint=' "${tmpdir}/optout.yaml"; then
   echo "FAIL: opt-out (idpHint='') still appends kc_idp_hint to authorize_url" >&2
   exit 1
 fi
-# The Job's IDP_HINT env should be empty string
-if ! grep -A1 'name: IDP_HINT' "${tmpdir}/optout.yaml" | grep -q 'value: ""'; then
-  echo "FAIL: opt-out (idpHint='') IDP_HINT env did not render as empty" >&2
+# The reconciler must still render the --auto-discover-url fallback codepath.
+if ! grep -q 'auto-discover-url' "${tmpdir}/optout.yaml"; then
+  echo "FAIL: opt-out (idpHint='') did not render the --auto-discover-url fallback codepath" >&2
   exit 1
 fi
 echo "  PASS"
@@ -97,9 +110,9 @@ echo "  PASS"
 # pod/gitea-0 — upstream gitea 10.5.0 renders a Deployment, not a
 # StatefulSet, so the index-name lookup never matches and the hook
 # times out. Job must instead resolve the live Pod by label selector.
-echo "[g117-5-sso-tier1] Case 6: configure-oauth Job does not hard-code pod/gitea-0"
+echo "[g117-5-sso-tier1] Case 6: sso-configure reconciler does not hard-code pod/gitea-0"
 if grep -q 'pod/gitea-0\|exec.*gitea-0' "${tmpdir}/default.yaml"; then
-  echo "FAIL: configure-oauth Job still references the hard-coded pod/gitea-0 name." >&2
+  echo "FAIL: sso-configure reconciler still references the hard-coded pod/gitea-0 name." >&2
   echo "  upstream gitea 10.5.0 renders a Deployment; pod is gitea-<rs-hash>-<id>." >&2
   exit 1
 fi

--- a/platform/gitea/chart/tests/g117-e2e-a1-auth-id-tab-strip.sh
+++ b/platform/gitea/chart/tests/g117-e2e-a1-auth-id-tab-strip.sh
@@ -29,9 +29,12 @@ CHART_DIR="$(cd "${1:-$(dirname "$0")/..}" && pwd)"
 # per Gitea source: cmd/admin_auth.go writes "%d\t|%s\t\t|%s\t|%v\t").
 SAMPLE_LIST="$(printf 'ID\t|Name\t\t|Type\t|Enabled\n1\t|openova-sso\t|OAuth2\t|true\n')"
 
-# Extract the awk one-liner used in templates/sso-configure-oauth-job.yaml.
-# We assert it strips ALL whitespace from $1 (not just spaces), so the
-# resulting AUTH_ID is the bare "1" without trailing tab.
+# Extract the awk one-liner used in templates/sso-configure-deployment.yaml
+# (the #3851 refactor moved the one-shot configure-oauth Job into a
+# continuously-reconciling Deployment — the openbao pattern — carrying this
+# AUTH_ID awk idiom with it). We assert it strips ALL whitespace from $1
+# (not just spaces), so the resulting AUTH_ID is the bare "1" without
+# trailing tab.
 AUTH_ID="$(printf '%s\n' "$SAMPLE_LIST" \
   | awk -F '|' -v name="openova-sso" \
     '$2 ~ name && $3 ~ /OAuth2/ {gsub(/[[:space:]]+/,"",$1); print $1}' \
@@ -46,10 +49,10 @@ fi
 echo "PASS 1: awk extraction strips tabs+spaces from AUTH_ID (got '${AUTH_ID}')"
 
 # Sanity check: the actual template ALSO uses [[:space:]]+ (not just bare " "),
-# so the live Job runs the same logic as this unit test.
+# so the live reconciler runs the same logic as this unit test.
 if ! grep -qF 'gsub(/[[:space:]]+/,"",$1)' \
-     "$CHART_DIR/templates/sso-configure-oauth-job.yaml"; then
-  echo "FAIL: configure-oauth-job.yaml does not use gsub(/[[:space:]]+/,...) for AUTH_ID extraction"
+     "$CHART_DIR/templates/sso-configure-deployment.yaml"; then
+  echo "FAIL: sso-configure-deployment.yaml does not use gsub(/[[:space:]]+/,...) for AUTH_ID extraction"
   echo "  The chart template has drifted from this test's contract — re-apply the"
   echo "  whitespace-strip pattern to the AUTH_ID awk script and re-run."
   exit 1


### PR DESCRIPTION
## Why

The merge-train merge of #3851 (durable gitea SSO oauth source) refactored the one-shot `gitea-sso-configure` Job into a continuously-reconciling Deployment (the openbao file-read posture), deleting `templates/sso-configure-oauth-job.yaml` for `templates/sso-configure-deployment.yaml`. Two `chart/tests/*.sh` still asserted the **old Job's** implementation details, so the integration-test step exited non-zero and **silently gated the helm-push** — `bp-gitea:1.2.38` never reached ghcr while every Sovereign slot pin already pointed at it (the `reference_blueprint_release_chart_publish_gate.md` shape).

## What

- `g117-e2e-a1-auth-id-tab-strip.sh` — grep the `gsub(/[[:space:]]+/,...)` AUTH_ID idiom in the **Deployment** template, not the deleted Job file.
- `g117-5-sso-tier1.sh` — Case 3 asserts the `gitea-oauth-source-credentials` Secret mounted at `/etc/sso-creds` (the file-read bundle) instead of the obsolete `sso-bundle` volume + `IDP_HINT` env; Case 5 opt-out asserts the `--auto-discover-url` fallback instead of the removed `IDP_HINT` env.

All hard-won behaviors (TAB-strip, POD_SELECTOR label discovery, custom-url-mapping, kc_idp_hint opt-out) still render and remain covered. All 6 gitea chart tests pass locally. Chart version unchanged at 1.2.38 — the failed run never pushed, so the re-triggered build publishes 1.2.38 fresh; no pin churn.

Refs #3851 #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)