### PR TITLE
fix(bp-mgmt-vcluster): mirror guacamole-pg-rw/-ro into vc-mgmt — un-wedge guacamole install (0.2.21)

### DIFF
--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -144,7 +144,14 @@ spec:
       # 0.2.20 (#3859): add `org-services` to the NATS isolation allow-list
       # (was only `sme`; the BSS tier was renamed to org-services) — unblocks
       # tenant/provisioning → NATS, the #3376 funnel back-half.
-      version: 0.2.20
+      # 0.2.21 (#3374): mirror `catalyst-system/guacamole-pg-rw` + `-ro` into
+      # vc-mgmt via networking.replicateServices.fromHost. The host-bridged
+      # (#3642) guacamole-pg Service was NXDOMAIN inside vc-mgmt → the JDBC
+      # schema-seed Job (and the webapp) could not reach postgres → seed Job
+      # DeadlineExceeded → Helm rollback → no webapp → `guacamole.<fqdn>` edge
+      # 500/503 on hw167 (32 installFailures). Same #3737 4th-layer DNS gap, now
+      # extended to guacamole's host-rendered CNPG cluster.
+      version: 0.2.21
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -224,7 +224,26 @@ name: bp-mgmt-vcluster
 # `openbao-host-token-reviewer-static` Secret (no `service-account.name`
 # annotation → mirror-stable) for the auth-bootstrap Job to mount. Never
 # wildcard a namespace that holds a `kubernetes.io/service-account-token`.
-version: 0.2.20
+# 0.2.21 (#3374, the hw167 guacamole zero-click 500/503 fix): add
+# `catalyst-system/guacamole-pg-rw` + `-ro` to
+# `networking.replicateServices.fromHost`. guacamole is host-bridged (#3642 —
+# slot 52 ships `database.cluster.enabled=false`), so its CNPG `guacamole-pg`
+# Cluster is HOST-rendered in `catalyst-system` while the webapp + JDBC
+# schema-seed Job run INSIDE vc-mgmt. The `guacamole-pg-app` Secret was already
+# mirrored (the `catalyst-system/*` fromHost.secrets mapping), but the CNPG
+# `-rw`/`-ro` SERVICES were not — so `guacamole-pg-rw` resolved to NXDOMAIN
+# inside vc-mgmt (verified live on hw167: seed pod stuck at `waiting for
+# postgres (57/60)`, `getent hosts guacamole-pg-rw` → NXDOMAIN). The seed Job's
+# 5-min wait_for_db exhausted, hit activeDeadlineSeconds → DeadlineExceeded →
+# Helm rolled the entire install back → no webapp/guacd/HTTPRoute backend →
+# `https://guacamole.<fqdn>` returned edge 500/503 (32 installFailures). This is
+# the same 4th-layer host→vCluster DNS gap fixed for shared-pg (#3737) but never
+# extended to guacamole's host-rendered CNPG cluster. Mirroring these two
+# Services makes both the seed Job (short name) and the webapp runtime
+# (`POSTGRESQL_HOSTNAME=guacamole-pg-rw.catalyst-system.svc.cluster.local`)
+# resolve. Additive + idempotent (no-op until the host-bridge renders the
+# Cluster). Lockstep: 58-bp-mgmt-vcluster.yaml pin → 0.2.21. Refs #3374.
+version: 0.2.21
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -386,6 +386,27 @@ vcluster:
           to: shared-data/shared-pg-c-rw
         - from: shared-data/shared-pg-c-ro
           to: shared-data/shared-pg-c-ro
+        # ── #3374 guacamole-pg host→vCluster reachability (the SERVICE half) ──
+        # guacamole is host-bridged (#3642): slot 52 ships
+        # `guacamole.database.cluster.enabled=false` + `httproute.enabled=false`,
+        # so the CNPG `guacamole-pg` Cluster is HOST-rendered in host
+        # `catalyst-system` while the webapp + the JDBC schema-seed Job run INSIDE
+        # vc-mgmt. The `sync.fromHost.secrets` `catalyst-system/*` mapping already
+        # mirrors the `guacamole-pg-app` Secret in, but the CNPG `-rw`/`-ro`
+        # SERVICES live host-side only — so `guacamole-pg-rw` did NOT resolve
+        # inside vc-mgmt (`getent hosts guacamole-pg-rw` → NXDOMAIN, hw167). The
+        # seed Job's psql looped its 5-min wait_for_db, hit
+        # activeDeadlineSeconds → DeadlineExceeded → Helm rolled the whole install
+        # back → no webapp/guacd/HTTPRoute backend → `guacamole.<fqdn>` edge
+        # 500/503 (32 installFailures on hw167). Same 4th-layer DNS gap fixed for
+        # shared-pg above; mirroring these two Services makes BOTH the seed Job's
+        # short-name `guacamole-pg-rw` AND the webapp's
+        # `POSTGRESQL_HOSTNAME=guacamole-pg-rw.catalyst-system.svc.cluster.local`
+        # resolve. No-op until the host-bridge renders the Cluster (additive).
+        - from: catalyst-system/guacamole-pg-rw
+          to: catalyst-system/guacamole-pg-rw
+        - from: catalyst-system/guacamole-pg-ro
+          to: catalyst-system/guacamole-pg-ro
       # ── #3642 host→vCluster gitea reachability (the MIRROR of fromHost above) ──
       # #3642 moved gitea INTO vc-mgmt, but bp-catalyst-platform stays HOST-side
       # (catalyst-system). Its in-cluster gitea consumers — the


### PR DESCRIPTION
## What

Add `catalyst-system/guacamole-pg-rw` + `catalyst-system/guacamole-pg-ro` to `bp-mgmt-vcluster`'s `networking.replicateServices.fromHost` so the host-bridged guacamole CNPG Services resolve inside vc-mgmt. Chart `0.2.20 → 0.2.21`; slot-58 pin bumped in lockstep.

## Why — root cause (verified live on hw167)

`https://guacamole.hw167.omantel.biz` returned an edge **HTTP 500/503** (no backend). This was a **health defect, not an SSO-config defect** — the redirect_uri / `/guacamole/` WAR path / oidc-gate are all correct in-chart; the webapp simply never got created.

`kubectl get hr bp-guacamole -n mgmt` showed `installFailures=32`, last condition:
```
Helm install failed ... failed post-install: job guacamole-bp-guacamole-jdbc-seed
failed: DeadlineExceeded ... Helm uninstall remediation ... succeeded
```
→ no `sh.helm.release` Secret, no webapp Deployment, no guacd, no HTTPRoute backend.

guacamole is host-bridged (#3642): slot 52 ships `guacamole.database.cluster.enabled=false` + `httproute.enabled=false`, so the CNPG `guacamole-pg` Cluster is **host-rendered** in host `catalyst-system` while the webapp + the JDBC schema-seed Job run **inside vc-mgmt**. The `guacamole-pg-app` Secret was already mirrored in (the `catalyst-system/*` `fromHost.secrets` mapping), but the CNPG `-rw`/`-ro` **Services** live host-side only — so the name did not resolve inside the vCluster:

```
seed pod:  [jdbc-seed] waiting for postgres (57/60)   # never connects
$ getent hosts guacamole-pg-rw   ->   NXDOMAIN
```

The seed Job's 5-min `wait_for_db` exhausted, hit `activeDeadlineSeconds: 420` → `DeadlineExceeded` → Helm rolled the entire install back → edge 500/503. This is the **same 4th-layer host→vCluster DNS gap fixed for shared-pg (#3737)** but never extended to guacamole's host-rendered CNPG cluster. The webapp's runtime `POSTGRESQL_HOSTNAME=guacamole-pg-rw.catalyst-system.svc.cluster.local` hits the identical gap, so one mirror fix unblocks both the seed Job (short name) and the webapp (FQDN).

## Fix

```yaml
networking:
  replicateServices:
    fromHost:
      ...existing shared-pg entries...
      - from: catalyst-system/guacamole-pg-rw
        to: catalyst-system/guacamole-pg-rw
      - from: catalyst-system/guacamole-pg-ro
        to: catalyst-system/guacamole-pg-ro
```

Additive + idempotent — no-op until the host-bridge renders the Cluster, so default render is unchanged on non-guacamole envs.

## Durability

This reproduces on a fresh prov (the slot ships the host-bridge `cluster.enabled=false` + this mirror gap), so the fix lives in the chart. Re-verify on the next fresh prov.

## Validation

- `helm template` renders clean (rc=0, no errors).
- `tests/render.sh` — all 7 checks PASS.

Refs #3374