### PR TITLE
fix(bp-keycloak,bp-oidc-gate): powerdns-admin KC client must register BOTH /oauth2/callback AND /oidc/authorized (hw167 'Invalid parameter: redirect_uri')

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -198,7 +198,12 @@ spec:
       # chart renders the canonical apps.openova.io/v1 Application CR for
       # this slot's HelmRelease so the console /apps list, per-app Topology
       # tab + showback resolve keycloak (no more "no Application CR").
-      version: 1.4.33
+      # 1.4.34 (#3741/#3852): powerdns-admin realm client registers BOTH
+      #         /oauth2/callback AND /oidc/authorized — 1.4.30 over-stripped
+      #         the native authlib callback, so the gate's bare-root→/oidc/login
+      #         redirect 'Invalid parameter: redirect_uri'd on PDA's own OIDC
+      #         hop (hw167 UAT row 3374-11). Lockstep with bp-oidc-gate 0.1.4.
+      version: 1.4.34
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
+++ b/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
@@ -66,7 +66,13 @@ spec:
       # PDA's own silent KC round-trip and lands signed-in (hw159: bare URL had
       # been landing on PDA's /login FORM — zero-click FAIL; PDA ships authlib
       # OIDC and ignores oauth2-proxy's X-Auth-Request-* headers).
-      version: 0.1.3
+      # 0.1.4 (#3741/#3852, 2026-06-19): appNativeCallbackPath — register the
+      # gated app's OWN native-OIDC callback as a SECOND redirectUri on the KC
+      # client. The rootRedirectPath→/oidc/login hop fires PDA's authlib flow
+      # which sends redirect_uri=…/oidc/authorized; #3741 had over-stripped that
+      # URI → KC 'Invalid parameter: redirect_uri' on hw167 (UAT row 3374-11).
+      # powerdns-admin instance below sets appNativeCallbackPath:/oidc/authorized.
+      version: 0.1.4
       sourceRef:
         kind: HelmRepository
         name: bp-oidc-gate
@@ -143,12 +149,24 @@ spec:
       # redirected; /oidc/login, /oidc/authorized, /login, /dashboard all
       # flow through untouched and PDA's post-login lands on /dashboard/
       # which never revisits `/`. bp-oidc-gate 0.1.3.
+      #
+      # #3741/#3852 (2026-06-19, hw167 UAT row 3374-11) — appNativeCallbackPath.
+      # rootRedirectPath sends the bare root to PDA's /oidc/login, which fires
+      # pda-legacy's OWN authlib OIDC flow (authlib sends
+      # redirect_uri=https://pdns-admin.<fqdn>/oidc/authorized). #3741 stripped
+      # /oidc/authorized from the KC client on the wrong premise it was 'gated,
+      # not native-OIDC' → KC 'Invalid parameter: redirect_uri' on that second
+      # hop, so the operator never landed (the /oauth2/callback the gate itself
+      # uses was the ONLY registered URI). Declaring the native callback here
+      # makes the AppRegistration register BOTH /oauth2/callback AND
+      # /oidc/authorized on the powerdns-admin client. bp-oidc-gate 0.1.4.
       - name: powerdns-admin
         enabled: true
         clientId: powerdns-admin
         hostname: "pdns-admin.${SOVEREIGN_FQDN}"
         upstream: http://powerdns-admin-bp-powerdns-admin.powerdns-admin.svc.cluster.local:80
         rootRedirectPath: /oidc/login
+        appNativeCallbackPath: /oidc/authorized
 
       # ── GENERALITY PROOF (#3374 DoD box 10a) ──────────────────────────
       # A brand-new throwaway app gated with ONLY a name + hostname +

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.33
+  version: 1.4.34
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -318,7 +318,22 @@ name: bp-keycloak
 # rotation on existing envs. Default single-region render byte-identical
 # except the SA secret value (was random → now derived; both 64/32-char
 # opaque strings, no consumer cares about the literal). Refs #3642 #3736.
-version: 1.4.33
+# 1.4.34 (#3741/#3852, 2026-06-19): the realm-seed `powerdns-admin` client now
+# registers BOTH callbacks — `/oauth2/callback` (the oauth2-proxy gate) AND
+# `/oidc/authorized` (PDA's native authlib callback). 1.4.30 (#3741) had
+# stripped `/oidc/authorized` on the premise the app was 'gated, not
+# native-OIDC', but the bp-oidc-gate HTTPRoute 302s the bare root to PDA's
+# `/oidc/login` (rootRedirectPath), which fires pda-legacy's OWN OIDC flow —
+# PDA ignores oauth2-proxy's X-Auth-Request-* headers so it must session-auth
+# itself — and authlib sends redirect_uri=…/oidc/authorized. With only
+# /oauth2/callback registered, KC rejected that second hop ("Invalid parameter:
+# redirect_uri", measured live hw167 dep 28d4e96f96407bbb, UAT row 3374-11) →
+# the operator never landed on /dashboard. Restoring /oidc/authorized alongside
+# /oauth2/callback (the aud-mapper stays) makes config-cli FULL-managed reconcile
+# keep the correct two-URI shape, matching the bp-oidc-gate 0.1.4 AppRegistration
+# (appNativeCallbackPath:/oidc/authorized). The `/*` wildcard from the dead
+# pre-#3374 shape is NOT restored — the two explicit callbacks are exact.
+version: 1.4.34
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -845,7 +845,7 @@ data:
         {
           "clientId": "powerdns-admin",
           "name": "PowerDNS-Admin (Tier-2 silent-SSO)",
-          "description": "#3741 — DNS UI silent-SSO, gate-fronted by bp-oidc-gate oauth2-proxy: /oauth2/callback redirectUri + oidc-audience-mapper (aud=powerdns-admin) matching the gate AppRegistration, so config-cli FULL-managed reconcile keeps the client correct.",
+          "description": "#3741/#3852 — DNS UI silent-SSO, gate-fronted by bp-oidc-gate oauth2-proxy. TWO callbacks register on this client: (1) /oauth2/callback — the oauth2-proxy gate's own callback (gate-level browser auth, aud=powerdns-admin via the mapper below); (2) /oidc/authorized — PDA's NATIVE authlib callback. The gate HTTPRoute 302s the bare root / to PDA's /oidc/login (rootRedirectPath), which fires pda-legacy's OWN OIDC flow (PDA ignores oauth2-proxy X-Auth-Request-* headers, so it must session-auth itself), and authlib sends redirect_uri=…/oidc/authorized. #3741 over-stripped /oidc/authorized on the wrong premise it was dead-design → KC 'Invalid parameter: redirect_uri' on the second hop (hw167 UAT row 3374-11). Both URIs + the aud-mapper match the gate AppRegistration so config-cli FULL-managed reconcile keeps the client correct.",
           "enabled": true,
           "publicClient": false,
           "standardFlowEnabled": true,
@@ -855,7 +855,8 @@ data:
           "authorizationServicesEnabled": false,
           "secret": {{ include "bp-keycloak.tier2ClientSecret" (dict "ctx" . "clientId" "powerdns-admin") | quote }},
           "redirectUris": [
-            "https://pdns-admin.{{ .Values.sovereignFQDN }}/oauth2/callback"
+            "https://pdns-admin.{{ .Values.sovereignFQDN }}/oauth2/callback",
+            "https://pdns-admin.{{ .Values.sovereignFQDN }}/oidc/authorized"
           ],
           "webOrigins": [
             "https://pdns-admin.{{ .Values.sovereignFQDN }}"

--- a/platform/keycloak/chart/tests/g117-5-tier2-sso-clients.sh
+++ b/platform/keycloak/chart/tests/g117-5-tier2-sso-clients.sh
@@ -79,11 +79,18 @@ for c in d.get('clients', []):
   fi
 }
 check_redirect guacamole      "https://guacamole.${SOV_FQDN}/*"
-# 1.4.30 (#3741/#3743): powerdns-admin is gate-fronted by the bp-oidc-gate
-# oauth2-proxy, so its ONLY valid redirectUri is /oauth2/callback (the dead
-# pre-#3374 native /oidc/authorized + /* shape was removed from the realm
-# seed). Mirror the hubble-ui gated precedent below.
+# 1.4.34 (#3741/#3852): powerdns-admin is gate-fronted by the bp-oidc-gate
+# oauth2-proxy, but the gate 302s the bare root to PDA's /oidc/login
+# (rootRedirectPath), which fires pda-legacy's OWN authlib OIDC flow
+# (redirect_uri=…/oidc/authorized — PDA ignores oauth2-proxy's
+# X-Auth-Request-* headers so it must session-auth itself). The client
+# therefore registers TWO callbacks: /oauth2/callback (the gate) AND
+# /oidc/authorized (PDA native). 1.4.30 had stripped /oidc/authorized → KC
+# 'Invalid parameter: redirect_uri' on that second hop (hw167 UAT row
+# 3374-11). Both must be present; the dead pre-#3374 `/*` is NOT (exact
+# callbacks only). Matches the bp-oidc-gate 0.1.4 AppRegistration.
 check_redirect powerdns-admin "https://pdns-admin.${SOV_FQDN}/oauth2/callback"
+check_redirect powerdns-admin "https://pdns-admin.${SOV_FQDN}/oidc/authorized"
 check_redirect hubble-ui      "https://hubble.${SOV_FQDN}/oauth2/callback"
 echo "  PASS"
 

--- a/platform/oidc-gate/blueprint.yaml
+++ b/platform/oidc-gate/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.3
+  version: 0.1.4
   card:
     title: oidc-gate
     summary: |

--- a/platform/oidc-gate/chart/Chart.yaml
+++ b/platform/oidc-gate/chart/Chart.yaml
@@ -52,7 +52,27 @@ name: bp-oidc-gate
 # revisiting `/`. Default unset → byte-identical to a login-less gated
 # app (openova-flow renders no redirect rule). Slot 13c sets
 # rootRedirectPath:/oidc/login on the powerdns-admin instance.
-version: 0.1.3
+# 0.1.4 (#3741/#3852, 2026-06-19): appNativeCallbackPath — register the
+# gated app's OWN native-OIDC callback as a SECOND redirectUri on the KC
+# client. 0.1.3 made the bare root 302 to the app's /oidc/login, which
+# fires PDA's authlib OIDC flow; authlib sends
+# redirect_uri=https://<host>/oidc/authorized. But the AppRegistration
+# (and the keycloak realm seed, post-#3741) registered ONLY the gate's own
+# /oauth2/callback, so KC rejected that second hop with "Invalid parameter:
+# redirect_uri" (measured live hw167, dep 28d4e96f96407bbb, UAT row
+# 3374-11 — the gate-level browser auth succeeded but PDA's native hop
+# never landed). #3741 had stripped /oidc/authorized on the wrong premise
+# the app was "gated, not native-OIDC"; in fact pda-legacy authlib must
+# session-auth ITSELF (it ignores oauth2-proxy's X-Auth-Request-* headers),
+# so the native callback is load-bearing. New per-instance
+# `appNativeCallbackPath`: when set, the AppRegistration client.json adds
+# `https://<host><appNativeCallbackPath>` alongside /oauth2/callback. Slot
+# 13c sets appNativeCallbackPath:/oidc/authorized on the powerdns-admin
+# instance; the keycloak realm seed (bp-keycloak 1.4.34) carries the same
+# two URIs so config-cli FULL-managed reconcile keeps the client correct.
+# Login-less gated apps (openova-flow) leave it unset → only /oauth2/callback
+# registers (byte-identical to the pre-0.1.4 shape).
+version: 0.1.4
 appVersion: "7.6.0"
 description: |
   Catalyst generic OIDC gate — a per-app oauth2-proxy instance set that

--- a/platform/oidc-gate/chart/templates/instances.yaml
+++ b/platform/oidc-gate/chart/templates/instances.yaml
@@ -77,8 +77,24 @@ data:
       "publicClient": false,
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": false,
+      {{- /*
+      #3741/#3852 (hw167 UAT row 3374-11) — TWO callbacks register when the
+      gated app ships its OWN native OIDC (appNativeCallbackPath set):
+        1. /oauth2/callback — the oauth2-proxy gate's own callback.
+        2. <appNativeCallbackPath> — the app's native callback (pda-legacy
+           authlib = /oidc/authorized). The gate 302s the bare root to the
+           app's /oidc/login (rootRedirectPath); that fires the app's OWN
+           OIDC flow (the app ignores oauth2-proxy X-Auth-Request-* headers
+           and must session-auth itself), and its authlib sends
+           redirect_uri=https://<host><appNativeCallbackPath>. #3741 stripped
+           this on the wrong premise the app was 'gated, not native-OIDC' →
+           KC 'Invalid parameter: redirect_uri' on the second hop. Login-less
+           gated apps (openova-flow) leave appNativeCallbackPath unset → only
+           /oauth2/callback registers (byte-identical to the old shape).
+      */ -}}
       "redirectUris": [
-        "https://{{ $hostname }}/oauth2/callback"
+        "https://{{ $hostname }}/oauth2/callback"{{- if $inst.appNativeCallbackPath }},
+        "https://{{ $hostname }}{{ $inst.appNativeCallbackPath }}"{{- end }}
       ],
       "webOrigins": [
         "https://{{ $hostname }}"

--- a/platform/oidc-gate/chart/values.yaml
+++ b/platform/oidc-gate/chart/values.yaml
@@ -69,4 +69,17 @@ resources:
 #     # unset → no root redirect (byte-identical to a login-less app).
 #     rootRedirectPath: ""          # e.g. "/oidc/login"
 #     rootRedirectPort: 443         # the Sovereign HTTPS listener port
+#     # appNativeCallbackPath (#3741/#3852): the gated app's OWN native-OIDC
+#     # callback path. Set ONLY for apps that ship their own OIDC (pda-legacy
+#     # authlib = `/oidc/authorized`) and are reached via rootRedirectPath. The
+#     # gate 302s the bare root to the app's `/oidc/login`, which fires the
+#     # app's NATIVE OIDC flow (the app ignores oauth2-proxy X-Auth-Request-*
+#     # headers, so it must session-auth itself); authlib then sends
+#     # redirect_uri=https://<host><appNativeCallbackPath>. This path is added
+#     # as a SECOND redirectUri on the KC client (alongside the gate's
+#     # /oauth2/callback) so KC accepts the app's native hop — without it KC
+#     # returns "Invalid parameter: redirect_uri" (hw167 UAT row 3374-11).
+#     # Login-less gated apps (openova-flow) leave this unset → only
+#     # /oauth2/callback registers (byte-identical to the pre-#3741 shape).
+#     appNativeCallbackPath: ""     # e.g. "/oidc/authorized"
 instances: []


### PR DESCRIPTION
## Defect (hw167 live walk, UAT row 3374-11)

Opening `https://pdns-admin.hw167.omantel.biz` redirects to Keycloak and shows **"Invalid parameter: redirect_uri"** — the operator never lands on the PDA dashboard. This is a DIFFERENT, later failure than the #3852 DB-500 (already merged): the OIDC redirect_uri mismatch.

## Root cause (verified live on hw167, dep `28d4e96f96407bbb`)

powerdns-admin is gate-fronted by the **bp-oidc-gate oauth2-proxy**. There are **two** OIDC hops, and the design needs **two** registered callbacks:

1. The gate authenticates the browser using its own `redirect_uri=…/oauth2/callback` — this part works.
2. The gate's HTTPRoute then 302s the bare root `/` to PDA's **`/oidc/login`** (`rootRedirectPath`). The gate *proxies* that path to PDA; it does not serve it. PDA's **own authlib** fires its NATIVE OIDC flow and sends `redirect_uri=https://pdns-admin.<fqdn>/oidc/authorized`. (pda-legacy must session-auth itself — it ignores oauth2-proxy's `X-Auth-Request-*` headers, per the chart's own forensics.)

**#3741 (keycloak 1.4.30) stripped `/oidc/authorized`** from the realm-seed client on the premise it was *"dead-design (gated, not native-OIDC)"*, leaving ONLY `/oauth2/callback`. So the second (native) hop hits KC with an unregistered redirect_uri → **"Invalid parameter: redirect_uri"**.

Live evidence:
```
# KC client `powerdns-admin` (config-cli FULL-managed seed, post-#3741):
redirectUris: ["https://pdns-admin.hw167.omantel.biz/oauth2/callback"]   # /oidc/authorized MISSING

# PDA GET /oidc/login 302s to:
…/realms/sovereign/protocol/openid-connect/auth?client_id=powerdns-admin&redirect_uri=…%2Foidc%2Fauthorized
```

## Fix — register BOTH callbacks (durable, fresh-prov correct)

The keycloak realm seed is config-cli **FULL-managed**, so it is authoritative and reverts any drift; both seed sources are aligned:

| File | Change |
|---|---|
| `platform/keycloak/chart/templates/configmap-sovereign-realm.yaml` | realm-seed `powerdns-admin` client → `redirectUris: [/oauth2/callback, /oidc/authorized]` (aud-mapper kept; dead `/*` NOT restored) |
| `platform/oidc-gate/chart/templates/instances.yaml` + `values.yaml` | new per-instance `appNativeCallbackPath`; when set, the AppRegistration client.json adds `https://<host><appNativeCallbackPath>` alongside `/oauth2/callback` |
| `clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml` | powerdns-admin instance: `appNativeCallbackPath: /oidc/authorized`; pin `bp-oidc-gate 0.1.3 → 0.1.4` |
| `clusters/_template/bootstrap-kit/09-keycloak.yaml` | pin `bp-keycloak 1.4.33 → 1.4.34` |
| `platform/keycloak/chart/tests/g117-5-tier2-sso-clients.sh` | assert both URIs present on the client |

Login-less gated apps (openova-flow) leave `appNativeCallbackPath` unset → only `/oauth2/callback` registers (byte-identical to the pre-fix shape — no regression).

## Verification (`helm template` against `main`)

```
keycloak realm seed   powerdns-admin → ["…/oauth2/callback", "…/oidc/authorized"]   aud-mapper: True
oidc-gate AppReg      powerdns-admin → ["…/oauth2/callback", "…/oidc/authorized"]
oidc-gate AppReg      openova-flow   → ["…/oauth2/callback"]   (unchanged)
```

- `g117-5-tier2-sso-clients.sh` — 7/7 PASS (new `/oidc/authorized` assertion included)
- `oidc-gate/root-redirect-render.sh` — 3/3 PASS
- `helm lint` both charts — green

Refs #3852 #3374 #3741

🤖 Generated with [Claude Code](https://claude.com/claude-code)