### PR TITLE
fix(bp-mgmt-vcluster): mirror shared-pg `-mesh-rw`/`-mesh` global Services into vc-mgmt — grafana 503 (0.2.21) (Refs #3374)

### DIFF
--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -151,7 +151,7 @@ spec:
       # DeadlineExceeded → Helm rollback → no webapp → `guacamole.<fqdn>` edge
       # 500/503 on hw167 (32 installFailures). Same #3737 4th-layer DNS gap, now
       # extended to guacamole's host-rendered CNPG cluster.
-      version: 0.2.21
+      version: 0.2.22
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.21
+  version: 0.2.22
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -224,6 +224,18 @@ name: bp-mgmt-vcluster
 # `openbao-host-token-reviewer-static` Secret (no `service-account.name`
 # annotation → mirror-stable) for the auth-bootstrap Job to mount. Never
 # wildcard a namespace that holds a `kubernetes.io/service-account-token`.
+# 0.2.22 (#3374 cycle-1 train — COMBINE #3868 guacamole + #3872 grafana-mesh):
+# single version landing BOTH fromHost mirror extensions. #3868 added
+# `catalyst-system/guacamole-pg-rw`/`-ro` (un-wedge the host-bridged guacamole
+# JDBC schema-seed Job, hw167 32 installFailures). #3872 added the
+# ClusterMesh-global `<instance>-mesh-rw` (write) + `<instance>-mesh` (read)
+# Services for all 3 shared-pg instances (un-wedge grafana, which dials the
+# global `shared-pg-b-mesh-rw` write Service on a 2-region active-hot-standby
+# Sovereign, hw167 503 "no healthy upstream"). Both are additive,
+# eventually-consistent fromHost mirrors (no-op until the host renders the
+# target Service). Default `helm template` (mgmtVcluster.enabled=false) renders
+# byte-identical. Lockstep: 58-bp-mgmt-vcluster.yaml pin + blueprint.yaml →
+# 0.2.22. Refs #3374.
 # 0.2.21 (#3374, the hw167 guacamole zero-click 500/503 fix): add
 # `catalyst-system/guacamole-pg-rw` + `-ro` to
 # `networking.replicateServices.fromHost`. guacamole is host-bridged (#3642 —
@@ -243,7 +255,7 @@ name: bp-mgmt-vcluster
 # (`POSTGRESQL_HOSTNAME=guacamole-pg-rw.catalyst-system.svc.cluster.local`)
 # resolve. Additive + idempotent (no-op until the host-bridge renders the
 # Cluster). Lockstep: 58-bp-mgmt-vcluster.yaml pin → 0.2.21. Refs #3374.
-version: 0.2.21
+version: 0.2.22
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -371,6 +371,26 @@ vcluster:
   # prov the vCluster starts before shared-pg exists (no-op until present). All
   # 3 instances × rw/ro so EVERY SHARED_PG consumer (any instance) resolves
   # with zero per-app special-casing (#3642 DoD-6 "no per-app special-casing").
+  #
+  # ── #3374 hw167: ALSO mirror the ClusterMesh-global `-mesh-rw` / `-mesh`
+  # write/read services ──
+  # On a 2-region (active-hot-standby) Sovereign, bp-postgres mints a
+  # cross-region consumer's DB host to the GLOBAL write Service
+  # `<instance>-mesh-rw` (platform/postgres _helpers.tpl writeServiceName,
+  # gated on activeHotStandby) so writes resolve identically in either region
+  # and follow CNPG promotion. grafana is exactly such a consumer: its
+  # `grafana-database-env` Secret carries
+  # `GF_DATABASE_HOST=shared-pg-b-mesh-rw.shared-data.svc.cluster.local:5432`.
+  # The non-mesh `-rw` mirrors above DON'T cover this name, so grafana-in-vc-mgmt
+  # CrashLoopBackOff'd on hw167 — `dial tcp: lookup
+  # shared-pg-b-mesh-rw.shared-data.svc.cluster.local … no such host` — leaving
+  # the gateway with no Ready backend → `grafana.<fqdn>` 503 "no healthy
+  # upstream" (UAT 3374-05). keycloak/harbor survived only because they happen
+  # to dial the plain `shared-pg-rw` (instance "a", already mirrored). Mirror
+  # all 3 instances × {mesh-rw (global write), mesh (global read — note the read
+  # global is named `-mesh`, NOT `-mesh-ro`)} so every active-hot-standby
+  # consumer resolves with zero per-app special-casing. Same no-op-until-present
+  # semantics — the mesh Services only render once activeHotStandby is on.
   networking:
     replicateServices:
       fromHost:
@@ -407,6 +427,22 @@ vcluster:
           to: catalyst-system/guacamole-pg-rw
         - from: catalyst-system/guacamole-pg-ro
           to: catalyst-system/guacamole-pg-ro
+        # ClusterMesh-global write endpoints (active-hot-standby): the host
+        # FQDN cross-region SHARED_PG consumers (grafana et al.) actually dial.
+        - from: shared-data/shared-pg-mesh-rw
+          to: shared-data/shared-pg-mesh-rw
+        - from: shared-data/shared-pg-b-mesh-rw
+          to: shared-data/shared-pg-b-mesh-rw
+        - from: shared-data/shared-pg-c-mesh-rw
+          to: shared-data/shared-pg-c-mesh-rw
+        # ClusterMesh-global read endpoints (active-hot-standby) — named
+        # `<instance>-mesh` (the read global), no `-mesh-ro` variant exists.
+        - from: shared-data/shared-pg-mesh
+          to: shared-data/shared-pg-mesh
+        - from: shared-data/shared-pg-b-mesh
+          to: shared-data/shared-pg-b-mesh
+        - from: shared-data/shared-pg-c-mesh
+          to: shared-data/shared-pg-c-mesh
       # ── #3642 host→vCluster gitea reachability (the MIRROR of fromHost above) ──
       # #3642 moved gitea INTO vc-mgmt, but bp-catalyst-platform stays HOST-side
       # (catalyst-system). Its in-cluster gitea consumers — the


### PR DESCRIPTION
## What

Fixes the grafana `503 "no healthy upstream"` the hw167 live walk found (UAT 3374-05). `https://grafana.hw167.omantel.biz` had no Ready backend behind the gateway because the grafana pod was in `CrashLoopBackOff`.

## Root cause (debugged live on hw167 via the mothership kubeconfig)

The grafana container died on startup, exit 1, immediately:

```
logger=sqlstore level=info msg="Connecting to DB" dbtype=postgres
Error: ✗ dial tcp: lookup shared-pg-b-mesh-rw.shared-data.svc.cluster.local on 10.96.234.213:53: no such host
```

- grafana runs **inside the mgmt vCluster** (`grafana-…-x-grafana-x-mgmt-vcluster`, one of the 7 mgmt-placed apps).
- On a 2-region (active-hot-standby) Sovereign, `bp-postgres` mints a cross-region SHARED_PG consumer's DB host to the **ClusterMesh-global** write Service `<instance>-mesh-rw` (`platform/postgres/chart/templates/_helpers.tpl` `writeServiceName`, gated on `activeHotStandby`) so writes resolve identically in either region and follow CNPG promotion. grafana's `grafana-database-env` Secret therefore carries `GF_DATABASE_HOST=shared-pg-b-mesh-rw.shared-data.svc.cluster.local:5432`.
- But `bp-mgmt-vcluster`'s `networking.replicateServices.fromHost` (added in 0.2.14, #3737) mirrored only the **non-mesh** `-rw`/`-ro` service names into the vCluster. The vCluster's own CoreDNS only knows mirrored names, so `shared-pg-b-mesh-rw` did not resolve → grafana CrashLoop → gateway had no Ready backend → **503**.
- keycloak and harbor survived only because they happen to dial the plain `shared-pg-rw` (instance `a`, already mirrored). grafana is the consumer that actually dials the mesh write name.

Live confirmation on hw167:
- host service `shared-pg-b-mesh-rw` exists (ClusterIP 10.96.134.223, CNPG `shared-pg-b` primary, cluster healthy 3/3).
- `keycloak` env `KC_DB_URL=…shared-pg-rw…` and `harbor` env `POSTGRESQL_HOST=shared-pg-rw…` — both plain `-rw`, both Running.
- vc-mgmt rendered config `replicateServices.fromHost` listed only the 6 non-mesh entries.

## Fix

Extend `replicateServices.fromHost` to also mirror the global Services for all 3 shared-pg instances:
- `<instance>-mesh-rw` (global **write** endpoint — the host FQDN grafana et al. dial)
- `<instance>-mesh` (global **read** endpoint — note the read global is named `-mesh`, there is no `-mesh-ro` variant)

Same eventually-consistent no-op-until-present semantics as the existing 6 mirrors (the mesh Services only render once `activeHotStandby` is on, so single-region provs are unaffected). Zero per-app special-casing, consistent with the chart's #3642 DoD-6 principle.

## Versions (lockstep)

- `platform/bp-mgmt-vcluster/chart/Chart.yaml`: `0.2.20` → `0.2.21`
- `platform/bp-mgmt-vcluster/blueprint.yaml` `spec.version`: `0.2.20` → `0.2.21`
- `clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml` pin: `0.2.20` → `0.2.21`

## Validation

- `helm template … --set mgmtVcluster.enabled=true` renders OK (subchart accepts the extended `fromHost` list).
- All 7 `chart/tests/render.sh` cases pass.
- Default `helm template` (`mgmtVcluster.enabled=false`) renders byte-identical.
- Verified on hw167 every other mgmt-vCluster DB consumer uses a mirrored name; grafana was the sole `-mesh-rw` consumer.

Acceptance: a fresh 2-region prov should bring grafana Ready and `grafana.<fqdn>` should serve the SSO login instead of 503. Not yet re-walked on a fresh prov — `Refs #3374`, walk pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
