### PR TITLE
fix(bp-newapi): seed/promote Job pods stop masquerading as Service endpoints — kill intermittent 'upstream connect error 111' (1.4.109)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -273,7 +273,10 @@ spec:
       # warm-up retry-exhaustion. The setup wizard stays pre-completed by the
       # admin-sso-seed-job. This slot sets no sandboxBridge/service overrides,
       # so the chart defaults (native sidecar + bridge Service) are what render.
-      version: 1.4.108
+      # 1.4.109 (#3858): seed/promote Job pods no longer carry the workload
+      # selector labels, so they stop leaking into the newapi + bridge Service
+      # EndpointSlices → no more intermittent "upstream connect error 111".
+      version: 1.4.109
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.108
+  version: 1.4.109
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,38 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.109 (#3858, 2026-06-19): stop the seed/promote Jobs masquerading as
+# newapi Service endpoints → kill the intermittent "upstream connect error
+# 111" on newapi.<fqdn>.
+#
+# ROOT CAUSE (measured live on hw167, chart 1.4.108):
+#   The admin-seed Job, the per-minute admin-promote CronJob, and the
+#   channel-seed Job all stamped their POD TEMPLATE with
+#   `bp-newapi.selectorLabels` = {app.kubernetes.io/name: bp-newapi,
+#   app.kubernetes.io/instance: <release>}. That is EXACTLY the selector of
+#   both the `newapi-bp-newapi` Service (ports 3000/8080) and the
+#   `newapi-bp-newapi-bridge` Service (port 8080). Those Job pods are psql/curl
+#   one-shots with NO HTTP listener and NO readinessProbe, so the kubelet marks
+#   their running container ready-by-default and the endpoints controller
+#   adopts them into BOTH Services' EndpointSlices. The bridge Service's
+#   `publishNotReadyAddresses: true` (#3374) made the leak immediate. With the
+#   admin-promote CronJob firing every minute, the Cilium Gateway round-robined
+#   bare-URL `/` hits (Exact `/` → bridge:8080, PathPrefix `/` → newapi:3000)
+#   to the dead Job pod IP whenever one was alive → the gateway got
+#   connection-refused from the upstream → "upstream connect error 111".
+#   Intermittent by construction: a `/` hit landed on the real pod OR a
+#   transient Job pod depending on round-robin + whether a promote pod was
+#   alive that second (live evidence: the bridge EndpointSlice carried
+#   `10.42.0.116 → newapi-bp-newapi-admin-promote-…` next to the real pod).
+#
+# FIX: give each Job/CronJob pod template a DISTINCT `app.kubernetes.io/name`
+#   (`newapi-admin-seed` / `newapi-admin-promote` / `newapi-channel-seed`) so it
+#   matches NO Service selector — exactly the pattern the database-secret-sync
+#   Job already uses (`app.kubernetes.io/name: newapi-db-dsn-sync`, which is why
+#   that one never leaked). Pure pod-template-label change; the Jobs' own
+#   behavior, RBAC, volumes and the workload Deployment/Service are untouched.
+#   Provenance kept via `catalyst.openova.io/blueprint: bp-newapi` +
+#   `catalyst.openova.io/component`.
+#
 # 1.4.107 (#3374, 2026-06-18): REAL fix for the hw159 zero-click 1st-hit 111 +
 # /setup — eliminate the readiness race at its source instead of only retrying
 # in the landing page (1.4.102 was honest race-hardening, not a fix). ROOT
@@ -741,7 +774,7 @@ name: bp-newapi
 # fresh-prov readiness window the per-minute admin-promote CronJob self-heals
 # (#3767, 1.4.97) — this retry shrinks the human-visible window, it is not a
 # new SSO mechanism. Refs #3374.
-version: 1.4.108
+version: 1.4.109
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/admin-sso-seed-job.yaml
+++ b/platform/newapi/chart/templates/admin-sso-seed-job.yaml
@@ -528,7 +528,19 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "bp-newapi.selectorLabels" . | nindent 8 }}
+        # #3858 — DELIBERATELY NOT bp-newapi.selectorLabels. This one-shot
+        # admin-seed Pod is a psql container with NO HTTP listener; if it
+        # carried the workload's {app.kubernetes.io/name: bp-newapi,
+        # app.kubernetes.io/instance: <release>} selector it would be vacuumed
+        # into the newapi-bp-newapi + newapi-bp-newapi-bridge Service
+        # EndpointSlices (no readinessProbe ⇒ ready-by-default), and the Cilium
+        # gateway would round-robin bare-URL `/` hits to its dead :3000/:8080 ⇒
+        # "upstream connect error 111" (measured live hw167). A distinct
+        # app.kubernetes.io/name keeps it out of every Service selector. Mirrors
+        # the proven database-secret-sync-job pod-template pattern.
+        app.kubernetes.io/name: newapi-admin-seed
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        catalyst.openova.io/blueprint: bp-newapi
         catalyst.openova.io/component: admin-seed
     spec:
       restartPolicy: OnFailure
@@ -617,7 +629,20 @@ spec:
       template:
         metadata:
           labels:
-            {{- include "bp-newapi.selectorLabels" . | nindent 12 }}
+            # #3858 — DELIBERATELY NOT bp-newapi.selectorLabels. This CronJob
+            # fires EVERY MINUTE (schedule "* * * * *") and its Pod is a psql
+            # container with NO HTTP listener. With the workload selector labels
+            # it was adopted into the newapi-bp-newapi + newapi-bp-newapi-bridge
+            # Service EndpointSlices on every run (ready-by-default — no probe),
+            # so the Cilium gateway intermittently round-robined bare-URL `/`
+            # hits to its dead :3000/:8080 ⇒ "upstream connect error 111"
+            # (measured live hw167: bridge EndpointSlice carried the promote pod
+            # IP alongside the real pod; the bridge Service's
+            # publishNotReadyAddresses:true made the leak immediate). A distinct
+            # app.kubernetes.io/name keeps it out of every Service selector.
+            app.kubernetes.io/name: newapi-admin-promote
+            app.kubernetes.io/instance: {{ .Release.Name }}
+            catalyst.openova.io/blueprint: bp-newapi
             catalyst.openova.io/component: admin-promote
         spec:
           restartPolicy: OnFailure

--- a/platform/newapi/chart/templates/channel-seed-job.yaml
+++ b/platform/newapi/chart/templates/channel-seed-job.yaml
@@ -218,7 +218,18 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "bp-newapi.selectorLabels" . | nindent 8 }}
+        # #3858 — DELIBERATELY NOT bp-newapi.selectorLabels. This one-shot
+        # channel-seed Pod (curl container, no HTTP listener) must not carry the
+        # workload's {app.kubernetes.io/name: bp-newapi, .../instance: <release>}
+        # selector, or it gets adopted into the newapi-bp-newapi +
+        # newapi-bp-newapi-bridge Service EndpointSlices (ready-by-default, no
+        # probe) and the gateway round-robins bare-URL `/` to its dead port ⇒
+        # "upstream connect error 111". A distinct app.kubernetes.io/name keeps
+        # it out of every Service selector (same pattern as the admin-seed /
+        # admin-promote / database-secret-sync pods).
+        app.kubernetes.io/name: newapi-channel-seed
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        catalyst.openova.io/blueprint: bp-newapi
         catalyst.openova.io/component: channel-seed
     spec:
       restartPolicy: OnFailure


### PR DESCRIPTION
## Root cause (measured live on hw167, chart 1.4.108)

`https://newapi.hw167.omantel.biz` intermittently returned **"upstream connect error 111"** at the gateway. The newapi pod itself was healthy the whole time — `3/3 Running`, `restarts=0`, `Ready=True`. So this was never a CrashLoop or DB outage.

The `newapi-bp-newapi-bridge` Service (port 8080) and the main `newapi-bp-newapi` Service (3000/8080) both select on:

```
app.kubernetes.io/name: bp-newapi
app.kubernetes.io/instance: <release>
```

Three Job/CronJob pod templates stamped their pods with exactly those labels via `bp-newapi.selectorLabels`:

- `admin-sso-seed-job.yaml` — the admin-seed Job (one-shot)
- `admin-sso-seed-job.yaml` — the **admin-promote CronJob** (fires `* * * * *`, every minute)
- `channel-seed-job.yaml` — the channel-seed Job (one-shot)

Those pods are `psql`/`curl` one-shots with **no HTTP listener and no readinessProbe**, so the kubelet marks the running container ready-by-default and the endpoints controller adopts them into **both** Services' EndpointSlices. The bridge Service's `publishNotReadyAddresses: true` (#3374) makes the leak immediate.

The two-rule HTTPRoute sends bare-URL `/` to:
- `Exact /` → `newapi-bp-newapi-bridge:8080`
- `PathPrefix /` → `newapi-bp-newapi:3000`

With a promote pod alive every minute, the Cilium Gateway round-robined `/` hits onto the dead Job pod's IP and got connection-refused from the upstream → **"upstream connect error 111"**. Intermittent by construction — the placement walk (3642-19) landed on the real pod, the SSO walk (3374-12/-13) landed on the dead promote pod.

### Live evidence

```
# newapi-bp-newapi-bridge EndpointSlice — TWO ready endpoints:
addr=10.42.3.238 ready=true target=newapi-bp-newapi-7f86dfcbcf-9msn4      # real pod
addr=10.42.0.116 ready=true target=newapi-bp-newapi-admin-promote-…       # dead psql one-shot, image postgresql:16.4, /scripts/promote.sh, NO ports
```

Dialing the leaked promote pod IP on `:8080` and `:3000` from inside the running `newapi` container got no response (the pod has no listener).

## Fix

Give each Job/CronJob pod template a **distinct** `app.kubernetes.io/name` (`newapi-admin-seed` / `newapi-admin-promote` / `newapi-channel-seed`) so none matches a Service selector — exactly the pattern the `database-secret-sync` Job already uses (`app.kubernetes.io/name: newapi-db-dsn-sync`, which is why that one never leaked). Provenance kept via `catalyst.openova.io/blueprint` + `catalyst.openova.io/component`.

Pure pod-template-label change. The Jobs' own behavior, RBAC, volumes, and the workload Deployment/Service are untouched.

## Validation

- `helm template` renders cleanly in both the SSO/bridge config and the channel-seed config; verified every Job/CronJob pod template now carries a non-matching `app.kubernetes.io/name`, while both Services still select `bp-newapi`.
- All four chart render tests pass: `httproute-render.sh`, `startup-probe-render.sh`, `imagepullsecrets-render.sh`, `bridge-readiness-render.sh`.
- Lockstep version bump 1.4.108 → **1.4.109**: `Chart.yaml` + `blueprint.yaml` + bootstrap-kit slot 80 pin.

Re-check on a fresh prov: `newapi.<fqdn>` should serve `/` deterministically (no 111) across the minute boundary when admin-promote fires.

Refs #3858

🤖 Generated with [Claude Code](https://claude.com/claude-code)
