### PR TITLE
fix(bp-keycloak): shorten powerdns-admin client description under KC varchar(255) cap — un-block the 1.4.34 publish (1.4.35)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -203,7 +203,7 @@ spec:
       #         the native authlib callback, so the gate's bare-root→/oidc/login
       #         redirect 'Invalid parameter: redirect_uri'd on PDA's own OIDC
       #         hop (hw167 UAT row 3374-11). Lockstep with bp-oidc-gate 0.1.4.
-      version: 1.4.34
+      version: 1.4.35
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.34
+  version: 1.4.35
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -318,6 +318,14 @@ name: bp-keycloak
 # rotation on existing envs. Default single-region render byte-identical
 # except the SA secret value (was random → now derived; both 64/32-char
 # opaque strings, no consumer cares about the literal). Refs #3642 #3736.
+# 1.4.35 (#3741/#3852, 2026-06-19): SHORTEN the 1.4.34 powerdns-admin client
+# `description` from 831 -> ~190 chars. Keycloak stores public.CLIENT.DESCRIPTION
+# as varchar(255); the 1.4.34 prose (full two-callback rationale) blew the cap →
+# the blueprint-release `g117-e2e-realm-client-description-255-cap.sh` gate failed
+# → bp-keycloak:1.4.34 NEVER published (slot-09 pinned an unpublished tag). The
+# behavioural fix (BOTH /oauth2/callback + /oidc/authorized) is unchanged; only the
+# description string is trimmed so the import batch no longer aborts. The full
+# rationale lives in this changelog + PR #3869.
 # 1.4.34 (#3741/#3852, 2026-06-19): the realm-seed `powerdns-admin` client now
 # registers BOTH callbacks — `/oauth2/callback` (the oauth2-proxy gate) AND
 # `/oidc/authorized` (PDA's native authlib callback). 1.4.30 (#3741) had
@@ -333,7 +341,7 @@ name: bp-keycloak
 # keep the correct two-URI shape, matching the bp-oidc-gate 0.1.4 AppRegistration
 # (appNativeCallbackPath:/oidc/authorized). The `/*` wildcard from the dead
 # pre-#3374 shape is NOT restored — the two explicit callbacks are exact.
-version: 1.4.34
+version: 1.4.35
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -845,7 +845,7 @@ data:
         {
           "clientId": "powerdns-admin",
           "name": "PowerDNS-Admin (Tier-2 silent-SSO)",
-          "description": "#3741/#3852 — DNS UI silent-SSO, gate-fronted by bp-oidc-gate oauth2-proxy. TWO callbacks register on this client: (1) /oauth2/callback — the oauth2-proxy gate's own callback (gate-level browser auth, aud=powerdns-admin via the mapper below); (2) /oidc/authorized — PDA's NATIVE authlib callback. The gate HTTPRoute 302s the bare root / to PDA's /oidc/login (rootRedirectPath), which fires pda-legacy's OWN OIDC flow (PDA ignores oauth2-proxy X-Auth-Request-* headers, so it must session-auth itself), and authlib sends redirect_uri=…/oidc/authorized. #3741 over-stripped /oidc/authorized on the wrong premise it was dead-design → KC 'Invalid parameter: redirect_uri' on the second hop (hw167 UAT row 3374-11). Both URIs + the aud-mapper match the gate AppRegistration so config-cli FULL-managed reconcile keeps the client correct.",
+          "description": "#3741/#3852 DNS UI silent-SSO via bp-oidc-gate. Registers BOTH /oauth2/callback (gate) + /oidc/authorized (PDA authlib) — #3741 over-stripped the latter, causing KC 'Invalid parameter: redirect_uri'.",
           "enabled": true,
           "publicClient": false,
           "standardFlowEnabled": true,


### PR DESCRIPTION
## Problem

The cycle-1 train merged #3869 (powerdns-admin BOTH-callbacks fix) as bp-keycloak **1.4.34**, but the `Blueprint Release` run for that merge commit (`44907c600`, run id 27817539842) **failed** at `chart/tests/g117-e2e-realm-client-description-255-cap.sh`:

```
FAIL (sovereign realm): one or more realm-import descriptions exceed Keycloak's varchar(255) cap:
  client=powerdns-admin length=831 chars (>255 KC schema cap)
```

A failed test gate **skips the helm-push step**, so `bp-keycloak:1.4.34` was **never published to ghcr** (latest published tag is 1.4.33). Bootstrap-kit slot-09 was therefore pinned to a non-existent chart tag — a fresh prov pinning this would wedge on the missing chart.

## Fix

Trim the #3741/#3852 `powerdns-admin` client `description` from 831 -> ~190 chars. Keycloak stores `public.CLIENT.DESCRIPTION` as `varchar(255)`; the keycloak-config-cli realm import aborts the whole JDBC batch on any over-cap description. The **behaviour is unchanged** — the client still registers BOTH `/oauth2/callback` (gate) AND `/oidc/authorized` (PDA native authlib). The full rationale now lives in the Chart.yaml changelog + #3869.

Lockstep bump **1.4.34 -> 1.4.35** across `Chart.yaml` + `blueprint.yaml` + slot-09 so a clean release run publishes.

## Verification

All 12 `platform/keycloak/chart/tests/*.sh` pass locally (incl. the 255-cap test now green). `helm template` renders OK.

Refs #3741 #3852