### PR TITLE
fix(bp-newapi): run newapi app INSIDE vc-mgmt via CNPG-owner host-bridge (placement.role split, 1.4.111 / bp-mgmt-vcluster 0.2.23)

### DIFF
--- a/clusters/_template/bootstrap-kit-crs/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit-crs/80-newapi.yaml
@@ -1,0 +1,44 @@
+# placement-generated (#3804 / Refs #3642) — host-bridge CRD-dependent CRs
+# for slot 80-newapi.yaml. SOURCE OF TRUTH: clusters/_template/bootstrap-kit/
+# placement.yaml (the matching slot's hostBridge.hostDocuments). Edit THERE
+# + run scripts/render-slot-placement.py fix — never hand-edit this file.
+#
+# Reconciled by the `bootstrap-kit-crs` Flux Kustomization (defined in
+# infra/providers/_shared/cloudinit-control-plane.tftpl), which
+# `dependsOn: [bootstrap-kit]` so these gateway.networking.k8s.io /
+# external-secrets.io / postgresql.cnpg.io CRs are validated + applied
+# only AFTER their operator CRDs exist — never in the bootstrap-kit atomic
+# dry-run (the fresh-prov `no matches for kind` deadlock, hw161).
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: newapi-server
+  namespace: mgmt
+  labels:
+    catalyst.openova.io/blueprint: bp-newapi
+    catalyst.openova.io/component: newapi
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  parentRefs:
+  - name: cilium-gateway
+    namespace: kube-system
+  hostnames:
+  - newapi.${SOVEREIGN_FQDN}
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /
+    backendRefs:
+    - name: newapi-bp-newapi-bridge-x-newapi-x-mgmt-vcluster
+      namespace: mgmt
+      port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: newapi-bp-newapi-x-newapi-x-mgmt-vcluster
+      namespace: mgmt
+      port: 3000

--- a/clusters/_template/bootstrap-kit-crs/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit-crs/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - 19-harbor.yaml
   - 25-grafana.yaml
   - 52-bp-guacamole.yaml
+  - 80-newapi.yaml

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -151,7 +151,11 @@ spec:
       # DeadlineExceeded → Helm rollback → no webapp → `guacamole.<fqdn>` edge
       # 500/503 on hw167 (32 installFailures). Same #3737 4th-layer DNS gap, now
       # extended to guacamole's host-rendered CNPG cluster.
-      version: 0.2.22
+      # 0.2.23 (#3831, Refs #3642): + the newapi-pg `-rw`/`-ro` Service mirror —
+      # the SERVICE half for re-homing newapi (the CNPG-OWNER app) into vc-mgmt
+      # (slot 80 flips to placement.role=vcluster-app; slot 80a host-renders the
+      # CNPG-owner seams). The `newapi/*` secret mapping already delivers the DSN.
+      version: 0.2.23
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -44,7 +44,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-newapi
-  namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
     catalyst.openova.io/vcluster: mgmt
     catalyst.openova.io/slot: "80"
@@ -52,11 +52,24 @@ spec:
   interval: 15m
   releaseName: newapi
   targetNamespace: newapi
+  storageNamespace: newapi
+  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
   dependsOn:
     # bp-mgmt-vcluster MUST be Ready first — the vc-mgmt
     # Secret doesn't exist until then. placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-mgmt-vcluster
+      namespace: flux-system
+    # #3831: the host-seams HR (slot 80a) renders the CNPG Cluster + the
+    # database-secret-sync Job that PATCHes the real DSN into
+    # newapi-bp-newapi-newapi-db-dsn before the bp-mgmt-vcluster `newapi/*`
+    # mirror delivers it into vc-mgmt — gate the app on it so the Deployment's
+    # SQL_DSN-readiness initContainer is not left waiting on an unmirrored Secret.
+    - name: bp-newapi-host-seams
       namespace: flux-system
     # G92.2 #2661 (2026-06-01): bp-openbao + bp-keycloak HRs moved to
     # host ns `mgmt`.
@@ -276,7 +289,13 @@ spec:
       # 1.4.109 (#3858): seed/promote Job pods no longer carry the workload
       # selector labels, so they stop leaking into the newapi + bridge Service
       # EndpointSlices → no more intermittent "upstream connect error 111".
-      version: 1.4.110
+      # 1.4.111 (#3831, Refs #3642): placement.role render-split. This slot runs
+      # placement.role=vcluster-app (stamped via placement.yaml hostBridge.
+      # suppress) so ONLY the app workload (Deployment + Service) renders INSIDE
+      # vc-mgmt; the CNPG-owner seams render host-side via slot 80a host-seams.
+      # database.existingSecret is wired (suppress) to the host-rendered,
+      # mirrored-in DSN Secret so the Deployment render-gate resolves at mgmt.
+      version: 1.4.111
       sourceRef:
         kind: HelmRepository
         name: bp-newapi
@@ -315,6 +334,10 @@ spec:
   # family model, `qwen3-coder`); the operator overlay overrides any of
   # these by setting them in this HelmRelease's spec.values.
   values:
+    database:
+      existingSecret: newapi-bp-newapi-newapi-db-dsn  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+    placement:
+      role: vcluster-app  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     # ── Bootstrap self-registration (#3687, extends #3370) ──────────────
     # The chart self-registers the Application CR for newapi (the canonical
     # instance representation every console surface reads), marked
@@ -338,7 +361,7 @@ spec:
     # Mirror the chart's value path. (Same shape for slot 81-sme if that
     # chart also reads cnpg.cluster.instances — track separately.)
     cnpg:
-      enabled: true
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       cluster:
         instances: ${SOVEREIGN_CNPG_INSTANCES:=1}
     postgres:
@@ -364,14 +387,14 @@ spec:
       # API spec, so enabling this on every Sovereign restores LLM
       # reachability without touching the marketplace wildcard.
       httpRoute:
-        enabled: true
+        enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
         host: newapi.${SOVEREIGN_FQDN}
     auth:
       adminUI:
         mode: keycloak
         keycloak:
           ssoBridgeSync:
-            enabled: true
+            enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
           # #3374: was realms/ops — a realm that does not exist on any
           # Sovereign (bp-keycloak imports only `sovereign` + per-Org
           # realms; measured live on hw130 2026-06-13). The sovereign
@@ -386,7 +409,7 @@ spec:
       enabled: true
       existingSecret: catalyst-newapi-admin-token
       externalSecret:
-        enabled: true
+        enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
         refreshInterval: "1h"
         secretStoreRef:
           kind: ClusterSecretStore

--- a/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
+++ b/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
@@ -1,0 +1,126 @@
+# bp-newapi-host-seams — bootstrap-kit slot 80a (#3831, Refs #3642).
+#
+# newapi is the ONLY NorthStar-#1 app that OWNS a dedicated CNPG cluster
+# (`newapi-bp-newapi-newapi-pg`) rather than CONSUMING a reflected shared-pg
+# secret like the other 6 mgmt-vCluster apps. To run newapi's app workload
+# INSIDE the mgmt vCluster (NorthStar #1: every app in a vCluster) while its
+# CNPG-owner seams stay HOST-reconciled, the chart renders in two cooperating
+# roles (platform/newapi/chart/_helpers.tpl renderSeams/renderApp):
+#
+#   - slot 80  (HR bp-newapi, vcluster: mgmt) ships placement.role=vcluster-app
+#     → the Deployment + Service + HTTPRoute run inside vc-mgmt; cnpg +
+#       ssoBridgeSync + the catalyst ExternalSecret are suppressed there.
+#   - slot 80a (THIS HR, host placement)      ships placement.role=host-seams
+#     → the CNPG Cluster + DSN-placeholder Secret + database-secret-sync Job +
+#       admin-sso-seed Job/CronJob + the newapi-admin AppRegistration ConfigMap
+#       + the oidc-sync ExternalSecret + the catalyst-newapi-admin-token
+#       ExternalSecret all render in the HOST `newapi` ns, where the host
+#       cnpg-operator owns the `<cluster>-app` Secret + DB, host bp-sso-bridge
+#       watches the AppRegistration ConfigMap cluster-wide (the OSS vCluster
+#       toHost sync is Pro-gated/INERT), and host ESO + OpenBao
+#       ClusterSecretStore vault-region1 back both ExternalSecrets.
+#
+# Both HRs share `releaseName: newapi` + chart `bp-newapi` but live in
+# DIFFERENT clusters (host k3s vs vc-mgmt apiserver), so there is NO
+# Helm-storage collision and `bp-newapi.fullname` resolves identically
+# (`newapi-bp-newapi`) on both sides — every cross-render object name (the DSN
+# Secret `newapi-bp-newapi-newapi-db-dsn`, the CNPG Cluster, the CNPG `-rw`/`-ro`
+# Services) lines up. The bp-mgmt-vcluster `sync.fromHost.secrets` `newapi/*`
+# mapping delivers the DSN/OIDC/creds/catalyst-token Secrets into vc-mgmt, and
+# its `replicateServices.fromHost` newapi-pg `-rw`/`-ro` entries make the
+# host-style CNPG FQDN resolve inside the vCluster (bp-mgmt-vcluster 0.2.23).
+#
+# The Namespace `newapi` and the HelmRepository `bp-newapi` are declared once by
+# slot 80 (host-applied) — NOT redeclared here to avoid a duplicate-resource
+# clash in the host kustomize set. This HR's `install.createNamespace: true`
+# provisions the HOST `newapi` ns idempotently.
+#
+# Wrapper chart: platform/newapi/chart/  (placement.role: host-seams)
+# Reconciled by: Flux on the Sovereign's k3s control plane (host cluster).
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-newapi-host-seams
+  namespace: flux-system
+  labels:
+    catalyst.openova.io/slot: "80a"
+spec:
+  interval: 15m
+  releaseName: newapi
+  targetNamespace: newapi
+  dependsOn:
+    # The CNPG-owner seams need: host cnpg-operator (Cluster + <cluster>-app),
+    # host ESO + OpenBao (both ExternalSecrets), host Keycloak (the admin-seed
+    # OIDC provider + the AppRegistration target realm), and bp-sso-bridge (the
+    # AppRegistration ConfigMap watcher). Gate on all of them.
+    - name: bp-cnpg
+      namespace: flux-system
+    - name: bp-external-secrets
+      namespace: flux-system
+    - name: bp-openbao
+      namespace: mgmt
+    - name: bp-keycloak
+      namespace: mgmt
+    - name: bp-sso-bridge
+      namespace: flux-system
+  chart:
+    spec:
+      chart: bp-newapi
+      # 1.4.111 (#3831): the placement.role render-split chart. Lockstep with
+      # slot 80's pin + platform/newapi blueprint.yaml.
+      version: 1.4.111
+      sourceRef:
+        kind: HelmRepository
+        name: bp-newapi
+        namespace: flux-system
+  install:
+    createNamespace: true
+    timeout: 15m
+    disableWait: true
+    remediation:
+      retries: -1
+  upgrade:
+    timeout: 15m
+    disableWait: true
+    remediation:
+      retries: 3
+  values:
+    # ── #3831 host-seams role: render ONLY the host-reconciled CNPG-owner seams.
+    placement:
+      role: host-seams
+    sovereignFQDN: ${SOVEREIGN_FQDN}
+    # The dedicated CNPG cluster newapi OWNS (single-region 1, multi-region 2).
+    cnpg:
+      enabled: true
+      cluster:
+        instances: ${SOVEREIGN_CNPG_INSTANCES:=1}
+    postgres:
+      cluster:
+        instances: ${SOVEREIGN_CNPG_INSTANCES:=1}
+    auth:
+      adminUI:
+        mode: keycloak
+        keycloak:
+          ssoBridgeSync:
+            enabled: true
+          # Same sovereign-realm wiring as slot 80 (#3374) — the admin-sso-seed
+          # writes the OIDC provider + root user into newapi's DB, and the
+          # AppRegistration ConfigMap registers the newapi-admin KC client.
+          issuer: https://auth.${SOVEREIGN_FQDN}/realms/sovereign
+          clientId: newapi-admin
+          existingSecret: newapi-oidc
+      customerAPI:
+        keyIssuer: catalyst
+    catalystIntegration:
+      enabled: true
+      existingSecret: catalyst-newapi-admin-token
+      externalSecret:
+        enabled: true
+        refreshInterval: "1h"
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: vault-region1
+        remoteRef:
+          key: sovereign/${SOVEREIGN_FQDN}/newapi/admin-token
+          property: ADMIN_API_TOKEN

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -306,6 +306,12 @@ resources:
   # See clusters/_template/bootstrap-kit/80-newapi.yaml for full
   # dependsOn rationale and per-Sovereign override surface.
   - 80-newapi.yaml
+  # bp-newapi-host-seams (slot 80a, #3831) — the HOST-reconciled CNPG-owner
+  # seams (CNPG Cluster + DSN-sync Job + admin-sso-seed Job/CronJob +
+  # newapi-admin AppRegistration ConfigMap + both ExternalSecrets) for newapi.
+  # Slot 80 now re-homes newapi's app workload INTO vc-mgmt (placement.role=
+  # vcluster-app); this companion renders the seams host-side (host-seams).
+  - 80a-newapi-host-seams.yaml
   # bp-stalwart-sovereign (slot 95) — REMOVED 2026-05-05.
   # Phase-2 Sovereign-local mail (per-Sovereign Stalwart for Console
   # PIN/magic-link delivery, umbrella #924) is OUT OF SCOPE for the

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -1246,37 +1246,110 @@ spec:
                 enablePodMonitor: false
     - {file: 56-bp-openova-flow-server.yaml, hr: bp-openova-flow-server, vcluster: host, target: mgmt, namespace: catalyst-system}
     - {file: 57-bp-openova-flow-emitter.yaml, hr: bp-openova-flow-emitter, vcluster: host, target: mgmt, namespace: catalyst-system}
-    # ── #3642 HOST-BRIDGE — newapi reverted to HOST placement (Refs #3831) ──
+    # ── #3831 CNPG-OWNER HOST-BRIDGE — newapi re-homed INTO vc-mgmt ──
     # newapi is the ONLY NS#1 app that OWNS a dedicated CNPG cluster
-    # (cnpg.enabled) rather than CONSUMING a fixed-name shared-pg
-    # reflected secret like gitea/harbor/keycloak/openbao do. The #3642
-    # host-bridge was designed for shared-pg CONSUMERS (route + ES +
-    # reflected `<app>-database-secret`, mirrored into vc-mgmt via
-    # sync.fromHost.secrets) — it does NOT carry the two CNPG-owner
-    # seams newapi needs host-side: the database-secret-sync Job (reads
-    # the host CNPG `<cluster>-app` Secret, PATCHes the DSN placeholder)
-    # and the admin-sso-seed Job/CronJob (seeds the newapi DB). It also
-    # dropped the SSO AppRegistration ConfigMap (bp-sso-bridge registers
-    # the `newapi-admin` KC client + writes sso/sovereign/newapi-admin
-    # from it), and never wired database.existingSecret — so the
-    # Deployment render-gate ($effDbSecret empty) skip-renders. Verified
-    # LIVE on hw165 (`9ee307969c92452e`): host ns newapi = the CNPG db
-    # pod ONLY, 0 Deployment, both ExternalSecrets SecretSyncedError, no
-    # newapi-admin AppRegistration ConfigMap anywhere. Every OTHER NS#1
-    # app's *-sso ExternalSecret SecretSynced=True — newapi is the lone
-    # outlier. Reverting to HOST placement (the SHIPPED #3733 grafana /
-    # #3737 keycloak revert precedent) renders the chart NATIVELY —
-    # Deployment + CNPG Cluster + sso-registration ConfigMap +
-    # admin-sso-seed Job/CronJob + database-secret-sync Job + oidc-sync
-    # ExternalSecret — all in the host `newapi` ns where ESO /
-    # bp-sso-bridge / cnpg-operator already reconcile them, the identical
-    # recipe gitea/harbor use today. `target: mgmt` stays the #3642
-    # aspiration: re-promote into vc-mgmt once the host-bridge gains the
-    # CNPG-owner seams (host-side db-sync + admin-seed + AppRegistration)
-    # + vcluster 0.23.0 sync.fromHost.secrets newapi/* (already mapped at
-    # bp-mgmt-vcluster values.yaml) delivers the DSN/oidc Secrets.
+    # (`newapi-bp-newapi-newapi-pg`, cnpg.enabled) rather than CONSUMING a
+    # fixed-name shared-pg reflected secret like gitea/harbor/keycloak/openbao.
+    # The #3642 host-bridge was built for shared-pg CONSUMERS, so a NAIVE
+    # promote (just flipping vcluster: mgmt) dropped newapi's CNPG-owner seams
+    # — the database-secret-sync Job, the admin-sso-seed Job/CronJob, the
+    # newapi-admin AppRegistration ConfigMap, and the database.existingSecret
+    # wiring — so the Deployment render-gate ($effDbSecret empty) skip-rendered
+    # (0 Deployment; #3832 reverted it to host on hw165).
+    #
+    # The #3831 fix mirrors the guacamole host-bridge precedent (#3868) and
+    # extends it for a CNPG-OWNER app via a chart `placement.role` render-split
+    # (bp-newapi 1.4.111). TWO cooperating HRs share releaseName: newapi +
+    # chart bp-newapi (different clusters → no Helm-storage collision, fullname
+    # lines up):
+    #   - THIS slot 80 (vcluster: mgmt, placement.role=vcluster-app) → the
+    #     Deployment + Service run INSIDE vc-mgmt; cnpg + ssoBridgeSync + the
+    #     catalyst ExternalSecret are suppressed there + database.existingSecret
+    #     is wired to the host-rendered, mirrored-in DSN Secret so $effDbSecret
+    #     resolves non-empty → the Deployment RENDERS at mgmt.
+    #   - slot 80a (vcluster: host, placement.role=host-seams) → the CNPG
+    #     Cluster + DSN-sync Job + admin-sso-seed Job/CronJob + AppRegistration
+    #     ConfigMap + both ExternalSecrets render in the HOST `newapi` ns where
+    #     cnpg-operator / ESO / OpenBao / bp-sso-bridge reconcile them.
+    # The bp-mgmt-vcluster 0.2.23 `newapi/*` secret mirror delivers the DSN/OIDC
+    # Secrets into vc-mgmt and its newapi-pg `-rw`/`-ro` replicateServices make
+    # the host-style CNPG FQDN resolve inside the vCluster. target == vcluster
+    # == mgmt → newapi is no longer staged-for-promotion; NS#1 is 7/7.
     - file: 80-newapi.yaml
       hr: bp-newapi
-      vcluster: host
+      vcluster: mgmt
       target: mgmt
       namespace: newapi
+      hostBridge:
+        suppress:
+          # render-split: app workload only inside vc-mgmt
+          placement.role: vcluster-app
+          # the CNPG Cluster + DSN-sync + admin-seed render host-side (slot 80a)
+          cnpg.enabled: false
+          # the SSO AppRegistration ConfigMap + oidc-sync ES render host-side
+          auth.adminUI.keycloak.ssoBridgeSync.enabled: false
+          # the catalyst-newapi-admin-token ES renders host-side
+          catalystIntegration.externalSecret.enabled: false
+          # the public front door is the host-bridge HTTPRoute below
+          ingress.httpRoute.enabled: false
+          # wire the Deployment to the host-rendered, mirrored-in DSN Secret so
+          # the render-gate $effDbSecret is non-empty even with cnpg suppressed
+          database.existingSecret: newapi-bp-newapi-newapi-db-dsn
+        hostDocuments:
+          # Public front door: HTTPRoute in host ns `mgmt`, backendRefs → the
+          # syncer-mangled in-vCluster Services (mirror of guacamole slot 52).
+          # Exact `/` → the bridge (zero-click landing page,
+          # publishNotReadyAddresses) so the 1st bare-URL hit is reachable
+          # during warm-up; PathPrefix `/` → the app Service.
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: newapi-server
+              namespace: mgmt
+              labels:
+                catalyst.openova.io/blueprint: bp-newapi
+                catalyst.openova.io/component: newapi
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              parentRefs:
+                - name: cilium-gateway
+                  namespace: kube-system
+              hostnames:
+                - newapi.${SOVEREIGN_FQDN}
+              rules:
+                - matches:
+                    - path:
+                        type: Exact
+                        value: /
+                  backendRefs:
+                    - name: newapi-bp-newapi-bridge-x-newapi-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 8080
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /
+                  backendRefs:
+                    - name: newapi-bp-newapi-x-newapi-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 3000
+    # ── #3831 host-seams companion — CNPG-owner seams stay HOST-reconciled ──
+    # Renders the CNPG Cluster + DSN-sync Job + admin-sso-seed Job/CronJob +
+    # newapi-admin AppRegistration ConfigMap + both ExternalSecrets in the host
+    # `newapi` ns (placement.role=host-seams). MUST be host: host cnpg-operator
+    # owns <cluster>-app, host bp-sso-bridge watches the AppRegistration CM
+    # cluster-wide (vCluster toHost is Pro-gated/INERT on OSS), host ESO +
+    # OpenBao ClusterSecretStore vault-region1 back both ExternalSecrets.
+    - file: 80a-newapi-host-seams.yaml
+      hr: bp-newapi-host-seams
+      vcluster: host
+      target: host
+      namespace: newapi
+      justification: >-
+        CNPG-owner seams (CNPG Cluster + DSN-sync Job + admin-sso-seed
+        Job/CronJob + newapi-admin AppRegistration ConfigMap + both
+        ExternalSecrets) are intrinsically HOST-reconciled — host cnpg-operator
+        owns the <cluster>-app Secret + DB, host bp-sso-bridge watches the
+        AppRegistration ConfigMap (OSS vCluster toHost sync is INERT), and host
+        ESO + OpenBao back both ExternalSecrets (vc-mgmt runs no ESO). The app
+        Deployment/Service run IN vc-mgmt (slot 80); this is the host seam half.

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.22
+  version: 0.2.23
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -255,7 +255,12 @@ name: bp-mgmt-vcluster
 # (`POSTGRESQL_HOSTNAME=guacamole-pg-rw.catalyst-system.svc.cluster.local`)
 # resolve. Additive + idempotent (no-op until the host-bridge renders the
 # Cluster). Lockstep: 58-bp-mgmt-vcluster.yaml pin → 0.2.21. Refs #3374.
-version: 0.2.22
+# 0.2.23 (#3831, Refs #3642): mirror the newapi-pg CNPG `-rw`/`-ro` Services
+# (host ns `newapi`) into vc-mgmt — the SERVICE half for re-homing newapi (the
+# CNPG-OWNER app) into the mgmt vCluster. Same 4th-layer host→vCluster DNS gap
+# as the guacamole-pg entries above; the `newapi/*` fromHost.secrets mapping
+# already delivers the DSN Secret. Additive + idempotent.
+version: 0.2.23
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -427,6 +427,26 @@ vcluster:
           to: catalyst-system/guacamole-pg-rw
         - from: catalyst-system/guacamole-pg-ro
           to: catalyst-system/guacamole-pg-ro
+        # ── #3831 newapi-pg host→vCluster reachability (the SERVICE half) ──
+        # newapi is the ONLY NorthStar-#1 app that OWNS a dedicated CNPG cluster
+        # (it does NOT consume a reflected shared-pg secret like the other 6).
+        # Re-homed into vc-mgmt like guacamole (#3642 host-bridge): slot 80
+        # ships placement.role=vcluster-app + cnpg.enabled=false, so the CNPG
+        # `newapi-bp-newapi-newapi-pg` Cluster is HOST-rendered in the host
+        # `newapi` ns by the slot-80a host-seams HR while the app Deployment +
+        # Service run INSIDE vc-mgmt. The `newapi/*` from-host secret mapping
+        # (below) already mirrors the DSN Secret, but the CNPG `-rw`/`-ro`
+        # SERVICES live host-side only — and the DSN baked by the host
+        # database-secret-sync Job points at
+        # `newapi-bp-newapi-newapi-pg-rw.newapi.svc.cluster.local:5432`, which is
+        # NXDOMAIN inside vc-mgmt without this mirror → the app's GORM connect
+        # fails. Mirroring both Services makes that host-style FQDN resolve in
+        # the vCluster. No-op until the host-seams HR renders the Cluster
+        # (additive). Same 4th-layer DNS gap fixed for guacamole-pg above.
+        - from: newapi/newapi-bp-newapi-newapi-pg-rw
+          to: newapi/newapi-bp-newapi-newapi-pg-rw
+        - from: newapi/newapi-bp-newapi-newapi-pg-ro
+          to: newapi/newapi-bp-newapi-newapi-pg-ro
         # ClusterMesh-global write endpoints (active-hot-standby): the host
         # FQDN cross-region SHARED_PG consumers (grafana et al.) actually dial.
         - from: shared-data/shared-pg-mesh-rw

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.110
+  version: 1.4.111
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -774,7 +774,17 @@ name: bp-newapi
 # fresh-prov readiness window the per-minute admin-promote CronJob self-heals
 # (#3767, 1.4.97) — this retry shrinks the human-visible window, it is not a
 # new SSO mechanism. Refs #3374.
-version: 1.4.110
+# 1.4.111 (#3831, Refs #3642): placement.role render split — the chart now
+# renders in one of three roles (all|host-seams|vcluster-app) so newapi can run
+# its app workload INSIDE the mgmt vCluster (NorthStar #1: every app in a
+# vCluster — newapi was the lone 6/7 host-placed exception) while its
+# CNPG-owner seams (CNPG Cluster + DSN-sync Job + admin-sso-seed Job/CronJob +
+# newapi-admin AppRegistration ConfigMap + both ExternalSecrets) stay
+# HOST-reconciled. role=all (DEFAULT) is a no-op gate → every standalone /
+# host-placed install is byte-identical to 1.4.110. The split mirrors the
+# guacamole host-bridge precedent (#3868) for a host-rendered CNPG + in-vCluster
+# app, extended to a CNPG-OWNER app. See _helpers.tpl renderSeams/renderApp.
+version: 1.4.111
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/000-external-secrets-webhook-readiness-job.yaml
+++ b/platform/newapi/chart/templates/000-external-secrets-webhook-readiness-job.yaml
@@ -79,7 +79,7 @@ pay the 60s probe budget for nothing.
 {{- $ci := .Values.catalystIntegration | default dict -}}
 {{- $es := $ci.externalSecret | default dict -}}
 {{- $gate := .Values.externalSecretsWebhookGate | default dict -}}
-{{- if and (default true $gate.enabled) $ci.enabled $es.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") -}}
+{{- if and (eq (include "bp-newapi.renderSeams" .) "true") (default true $gate.enabled) $ci.enabled $es.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") -}}
 {{- $ns := .Release.Namespace }}
 {{- $svc := $gate.service | default "external-secrets-webhook" -}}
 {{- $svcNs := $gate.namespace | default "external-secrets-system" -}}

--- a/platform/newapi/chart/templates/_helpers.tpl
+++ b/platform/newapi/chart/templates/_helpers.tpl
@@ -68,6 +68,51 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Placement-role render gates (#3831).
+
+newapi is the ONLY NorthStar-#1 app that OWNS a dedicated CNPG cluster rather
+than CONSUMING a reflected shared-pg secret. To re-home it INTO the mgmt
+vCluster (every app in a vCluster) while its CNPG-owner seams stay host-side,
+the chart renders in one of three roles, selected by `.Values.placement.role`:
+
+  all          (DEFAULT) — render EVERYTHING. Every standalone install and
+               every host-placed Sovereign keeps the historic single-HR
+               behaviour; both gates below return "true" so they are no-ops.
+  host-seams   — render ONLY the host-reconciled seams: the CNPG Cluster +
+               DSN-placeholder Secret + database-secret-sync Job +
+               admin-sso-seed Job/CronJob (+ their RBAC) + the newapi-admin
+               AppRegistration ConfigMap + the oidc-sync ExternalSecret + the
+               catalyst-newapi-admin-token ExternalSecret. NO Deployment /
+               Service / HTTPRoute / Ingress / Application CR.
+  vcluster-app — render ONLY the app: Deployment + Service + (HTTPRoute via the
+               host-bridge) + NetworkPolicy + the Application CR + the
+               in-cluster placeholder Secrets the Pod reads (credentials,
+               token-signing-key). NO CNPG / Jobs / ExternalSecrets /
+               AppRegistration (those render host-side under host-seams; the
+               host→vCluster secret mirror + replicateServices deliver the DSN
+               Secret + CNPG Service into the vCluster).
+
+The two HRs share `releaseName: newapi` + chart `bp-newapi` (in DIFFERENT
+clusters — host k3s vs vc-mgmt apiserver, so NO Helm-storage collision), so
+`bp-newapi.fullname` resolves identically (`newapi-bp-newapi`) on both sides
+and every cross-render object name (DSN Secret, CNPG Cluster) lines up.
+
+Helm has no boolean return; these emit the strings "true"/"false". Test with
+`{{- if eq (include "bp-newapi.renderSeams" .) "true" }}`.
+*/}}
+{{- define "bp-newapi.placementRole" -}}
+{{- (.Values.placement | default dict).role | default "all" -}}
+{{- end -}}
+{{- define "bp-newapi.renderSeams" -}}
+{{- $r := include "bp-newapi.placementRole" . -}}
+{{- if or (eq $r "all") (eq $r "host-seams") -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+{{- define "bp-newapi.renderApp" -}}
+{{- $r := include "bp-newapi.placementRole" . -}}
+{{- if or (eq $r "all") (eq $r "vcluster-app") -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{/*
 ServiceAccount name.
 */}}
 {{- define "bp-newapi.serviceAccountName" -}}

--- a/platform/newapi/chart/templates/admin-sso-seed-job.yaml
+++ b/platform/newapi/chart/templates/admin-sso-seed-job.yaml
@@ -68,7 +68,7 @@ nothing.
 {{- if hasKey $ssoBootstrap "enabled" -}}{{- $seedEnabled = $ssoBootstrap.enabled -}}
 {{- else if hasKey $seed "enabled" -}}{{- $seedEnabled = $seed.enabled -}}{{- end -}}
 {{- $kcMode := eq .Values.auth.adminUI.mode "keycloak" -}}
-{{- if and $seedEnabled .Values.newapi.enabled $kcMode .Values.cnpg.enabled .Values.sovereignFQDN -}}
+{{- if and (eq (include "bp-newapi.renderSeams" .) "true") $seedEnabled .Values.newapi.enabled $kcMode .Values.cnpg.enabled .Values.sovereignFQDN -}}
 {{- $clusterName := printf "%s-newapi-pg" (include "bp-newapi.fullname" .) -}}
 {{- $cnpgSecretName := printf "%s-app" $clusterName -}}
 {{- $jobName := include "bp-newapi.adminSeedJobName" . -}}

--- a/platform/newapi/chart/templates/application-cr.yaml
+++ b/platform/newapi/chart/templates/application-cr.yaml
@@ -23,7 +23,7 @@ the Capabilities apps.openova.io/v1 gate (benign skip pre-CRD; CR
 materialises on the first post-CRD upgrade). Leaf platform app — no
 shareable Context, so spec.parameters is empty.
 */ -}}
-{{- if and .Values.bootstrapOwned.enabled (.Capabilities.APIVersions.Has "apps.openova.io/v1") }}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.bootstrapOwned.enabled (.Capabilities.APIVersions.Has "apps.openova.io/v1") }}
 apiVersion: apps.openova.io/v1
 kind: Application
 metadata:

--- a/platform/newapi/chart/templates/channel-seed-job.yaml
+++ b/platform/newapi/chart/templates/channel-seed-job.yaml
@@ -79,7 +79,7 @@ Issue #915, 2026-05-05.
 {{- $vllmReady := and $vllm.enabled (ne (default "" $vllm.endpoint) "") -}}
 {{- $hasDefaults := or $qpReady $vllmReady -}}
 {{- $masterKeySecret := .Values.auth.adminUI.masterKeySecret | default "" -}}
-{{- if and $cs.enabled $hasDefaults $masterKeySecret -}}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") $cs.enabled $hasDefaults $masterKeySecret -}}
 {{- $jobName := include "bp-newapi.channelSeedJobName" . -}}
 ---
 {{- /*

--- a/platform/newapi/chart/templates/cilium-ingress-networkpolicy.yaml
+++ b/platform/newapi/chart/templates/cilium-ingress-networkpolicy.yaml
@@ -19,7 +19,7 @@ policy already allowed stays allowed, everything else stays denied.
 Gated on the cilium.io/v2 Capabilities check (the #2988/#3102 idiom) so
 the chart still installs on CRD-less clusters (kind CI).
 */ -}}
-{{- if and .Values.newapi.enabled .Values.networkPolicy.enabled .Values.networkPolicy.ingress.allowGatewayEntity (.Capabilities.APIVersions.Has "cilium.io/v2") }}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.newapi.enabled .Values.networkPolicy.enabled .Values.networkPolicy.ingress.allowGatewayEntity (.Capabilities.APIVersions.Has "cilium.io/v2") }}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:

--- a/platform/newapi/chart/templates/cnpg-cluster.yaml
+++ b/platform/newapi/chart/templates/cnpg-cluster.yaml
@@ -50,7 +50,7 @@ Without the gate, a cold install fails with "no matches for kind
 Cluster". Same pattern the bp-external-dns chart uses (issue #190) and
 the platform/powerdns/chart/templates/cnpg-cluster.yaml mirror.
 */}}
-{{- if .Values.cnpg.enabled -}}
+{{- if and (eq (include "bp-newapi.renderSeams" .) "true") .Values.cnpg.enabled -}}
 {{- $clusterName := printf "%s-newapi-pg" (include "bp-newapi.fullname" .) -}}
 {{- $dsnSecretName := default (printf "%s-newapi-db-dsn" (include "bp-newapi.fullname" .)) .Values.cnpg.dsnSecretName -}}
 {{- $database := .Values.cnpg.database | default "newapi" -}}

--- a/platform/newapi/chart/templates/configmap.yaml
+++ b/platform/newapi/chart/templates/configmap.yaml
@@ -1,4 +1,9 @@
 {{- include "bp-newapi.assertChannelAttestation" . -}}
+{{- /* #3831: the app config ConfigMap is consumed by the Deployment, so it
+   renders with the app (placement.role all|vcluster-app); under host-seams it
+   is suppressed (no Pod to consume it). assertChannelAttestation above stays a
+   render-time guard under every role. */ -}}
+{{- if eq (include "bp-newapi.renderApp" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -76,3 +81,4 @@ data:
         owner: {{ .attestation.owner | quote }}
         {{- end }}
 {{- end }}
+{{- end }}{{- /* #3831 renderApp wrapper */}}

--- a/platform/newapi/chart/templates/credentials-secret.yaml
+++ b/platform/newapi/chart/templates/credentials-secret.yaml
@@ -25,7 +25,10 @@ autoProvision=true AND existingSecret is empty.
 helm.sh/resource-policy: keep so a `helm uninstall` + reinstall recovers
 the same bytes (otherwise an upgrade would silently rotate the keys).
 */}}
-{{- if and .Values.credentials.autoProvision (not .Values.credentials.existingSecret) -}}
+{{- /* #3831: SESSION_SECRET/CRYPTO_SECRET is a chart-generated random Secret the
+   Pod reads — it renders WITH the app (placement.role all|vcluster-app), never
+   host-side (a host copy would diverge from the in-vCluster random bytes). */ -}}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.credentials.autoProvision (not .Values.credentials.existingSecret) -}}
 {{- $secretName := default (printf "%s-app-creds" (include "bp-newapi.fullname" .)) .Values.credentials.autoSecretName -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
 {{- $sessionSecret := "" -}}

--- a/platform/newapi/chart/templates/database-secret-sync-job.yaml
+++ b/platform/newapi/chart/templates/database-secret-sync-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cnpg.enabled }}
+{{- if and (eq (include "bp-newapi.renderSeams" .) "true") .Values.cnpg.enabled }}
 {{- /*
 Helm post-install/post-upgrade Job that composes the canonical SQL_DSN
 string from the CNPG-emitted `<cluster>-app` Secret (which holds the

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -49,7 +49,11 @@ the configmap mirrors this gate.
 {{- if and (not $effTokenSigningKeySecret) .Values.sandboxTokenSigningKey.autoProvision -}}
 {{- $effTokenSigningKeySecret = default (printf "%s-token-signing-key" (include "bp-newapi.fullname" .)) .Values.sandboxTokenSigningKey.autoSecretName -}}
 {{- end -}}
-{{- $deployReady := and .Values.newapi.enabled $effDbSecret $effCredsSecret -}}
+{{- /* #3831: the app Deployment renders ONLY under placement.role all|vcluster-app
+   (the seams + CNPG render host-side under host-seams). In vcluster-app the slot
+   suppresses cnpg.enabled and wires database.existingSecret to the mirrored DSN
+   Secret, so $effDbSecret still resolves non-empty above. */ -}}
+{{- $deployReady := and (eq (include "bp-newapi.renderApp" .) "true") .Values.newapi.enabled $effDbSecret $effCredsSecret -}}
 {{- if and $kcMode (not $kcConfigured) -}}
 {{- $deployReady = false -}}
 {{- end -}}
@@ -119,8 +123,16 @@ spec:
         an external DB via database.existingSecret populate it up-front, so
         the gate passes immediately). databaseDsnGate.enabled=false opts out.
       */}}
+      {{- /* #3831: gate on cnpg.enabled OR an explicit database.existingSecret.
+         Pre-#3831 the SQLite-fallback gate only fired for the chart-owned CNPG
+         DSN; under placement.role=vcluster-app cnpg.enabled is false but the
+         Pod still reads a (host-rendered, mirrored-in) DSN Secret whose SQL_DSN
+         starts empty until the host db-dsn-sync Job PATCHes it — so the same
+         silent-SQLite-fallback race applies. Firing the gate whenever
+         $effDbSecret is set keeps NewAPI from booting on ephemeral SQLite in
+         the vCluster too. */ -}}
       {{- $dsnGate := .Values.databaseDsnGate | default dict -}}
-      {{- $dsnGateOn := and (default true $dsnGate.enabled) .Values.cnpg.enabled -}}
+      {{- $dsnGateOn := and (default true $dsnGate.enabled) (or .Values.cnpg.enabled $effDbSecret) -}}
       {{- /*
         #3374 (2026-06-18) — sandbox-bridge as a NATIVE sidecar (initContainer
         with restartPolicy:Always), so the zero-click bare-URL landing page is

--- a/platform/newapi/chart/templates/external-secret.yaml
+++ b/platform/newapi/chart/templates/external-secret.yaml
@@ -28,7 +28,7 @@ pattern the bp-external-dns chart uses (issue #190).
 */ -}}
 {{- $ci := .Values.catalystIntegration | default dict -}}
 {{- $es := $ci.externalSecret | default dict -}}
-{{- if and $ci.enabled $es.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") -}}
+{{- if and (eq (include "bp-newapi.renderSeams" .) "true") $ci.enabled $es.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") -}}
 {{- $store := $es.secretStoreRef | default dict -}}
 {{- $remote := $es.remoteRef | default dict -}}
 {{- $secretName := $ci.existingSecret | default "catalyst-newapi-admin-token" -}}

--- a/platform/newapi/chart/templates/httproute.yaml
+++ b/platform/newapi/chart/templates/httproute.yaml
@@ -29,7 +29,7 @@ Per docs/INVIOLABLE-PRINCIPLES.md #4 every operationally-meaningful
 value (hostname, parentRef name/namespace/sectionName, backend port) is
 operator-overridable via values.yaml.
 */ -}}
-{{- if and .Values.newapi.enabled .Values.ingress.httpRoute .Values.ingress.httpRoute.enabled -}}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.newapi.enabled .Values.ingress.httpRoute .Values.ingress.httpRoute.enabled -}}
 {{- $host := .Values.ingress.httpRoute.host -}}
 {{- if and (not $host) .Values.sovereignFQDN -}}
 {{- $host = printf "newapi.%s" .Values.sovereignFQDN -}}

--- a/platform/newapi/chart/templates/ingress.yaml
+++ b/platform/newapi/chart/templates/ingress.yaml
@@ -14,7 +14,7 @@ gap as "no Ingress object materialised" — caught by the bootstrap-kit
 smoke test, not by render-time fail.
 */ -}}
 {{- /* Wave 5.81 (#2412): adminHost dropped — ops-staff admin via Catalyst BSS console only. */ -}}
-{{- if and .Values.newapi.enabled .Values.ingress.enabled .Values.ingress.host }}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.newapi.enabled .Values.ingress.enabled .Values.ingress.host }}
 {{- $fullName := include "bp-newapi.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $apiHost := .Values.ingress.host -}}

--- a/platform/newapi/chart/templates/keycloak-client-secret.yaml
+++ b/platform/newapi/chart/templates/keycloak-client-secret.yaml
@@ -88,7 +88,13 @@ OIDC client secret and the IdP-side wiring drifts).
 */}}
 {{- $kcMode := eq .Values.auth.adminUI.mode "keycloak" -}}
 {{- $secretName := .Values.auth.adminUI.keycloak.existingSecret -}}
-{{- if and $kcMode $secretName -}}
+{{- /* #3831: the newapi-oidc placeholder renders with the SEAMS (all|host-seams)
+   alongside its companion oidc-sync ExternalSecret (which Merge'es the live KC
+   client_secret in). Under vcluster-app it is suppressed: the host-rendered,
+   live-secret-bearing newapi-oidc is delivered into the vCluster by the
+   bp-mgmt-vcluster `newapi/*` from-host secret mirror, so a second in-vCluster
+   placeholder would only race the syncer for ownership of the same name. */ -}}
+{{- if and (eq (include "bp-newapi.renderSeams" .) "true") $kcMode $secretName -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
 {{- $clientSecret := "" -}}
 {{- if and $existing $existing.data (index $existing.data "OIDC_CLIENT_SECRET") -}}

--- a/platform/newapi/chart/templates/networkpolicy.yaml
+++ b/platform/newapi/chart/templates/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.newapi.enabled .Values.networkPolicy.enabled }}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.newapi.enabled .Values.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/platform/newapi/chart/templates/sandbox-token-signing-key-secret.yaml
+++ b/platform/newapi/chart/templates/sandbox-token-signing-key-secret.yaml
@@ -37,7 +37,9 @@ helm.sh/resource-policy: keep so a `helm uninstall` + reinstall
 recovers the same bytes (otherwise an upgrade silently invalidates
 every per-Sandbox token across the Sovereign).
 */}}
-{{- if and .Values.sandboxTokenSigningKey.autoProvision (not .Values.sandboxTokenSigningKey.existingSecret) -}}
+{{- /* #3831: the sandbox-bridge token-signing key is consumed by the bridge
+   sidecar in the Deployment — renders WITH the app (all|vcluster-app). */ -}}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.sandboxTokenSigningKey.autoProvision (not .Values.sandboxTokenSigningKey.existingSecret) -}}
 {{- $secretName := default (printf "%s-token-signing-key" (include "bp-newapi.fullname" .)) .Values.sandboxTokenSigningKey.autoSecretName -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
 {{- $signingKey := "" -}}

--- a/platform/newapi/chart/templates/service.yaml
+++ b/platform/newapi/chart/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.newapi.enabled }}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.newapi.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/platform/newapi/chart/templates/serviceaccount.yaml
+++ b/platform/newapi/chart/templates/serviceaccount.yaml
@@ -1,4 +1,6 @@
-{{- if .Values.serviceAccount.create }}
+{{- /* #3831: the workload ServiceAccount is for the app Deployment; the seam
+   Jobs render their OWN dedicated SAs. Gate with the app role. */ -}}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/platform/newapi/chart/templates/servicemonitor.yaml
+++ b/platform/newapi/chart/templates/servicemonitor.yaml
@@ -17,7 +17,7 @@ reached Phase 2 yet. The `.Capabilities.APIVersions.Has` guard also
 skip-renders on a cluster where the CRD has not yet reconciled — pattern
 matches platform/harbor/chart/templates/servicemonitor.yaml.
 */}}
-{{- if and .Values.newapi.enabled .Values.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.newapi.enabled .Values.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/platform/newapi/chart/templates/sso-app-registration.yaml
+++ b/platform/newapi/chart/templates/sso-app-registration.yaml
@@ -29,7 +29,7 @@ data.realm = "sovereign": the watcher only requires the realm to EXIST
    hardening disables wildcard redirectUris). providerSlug == sso.bootstrap.providerSlug. */ -}}
 {{- /* #3648 — standard sso.bootstrap.providerSlug first, then legacy adminSeed. */ -}}
 {{- $providerSlug := ((.Values.sso | default dict).bootstrap | default dict).providerSlug | default (.Values.adminSeed | default dict).providerSlug | default "sovereign" -}}
-{{- if and .Values.newapi.enabled $kcMode $sync.enabled .Values.sovereignFQDN }}
+{{- if and (eq (include "bp-newapi.renderSeams" .) "true") .Values.newapi.enabled $kcMode $sync.enabled .Values.sovereignFQDN }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/platform/newapi/chart/templates/sso-externalsecret.yaml
+++ b/platform/newapi/chart/templates/sso-externalsecret.yaml
@@ -19,7 +19,7 @@ creationPolicy: Merge — NOT Owner — by design:
 {{- $kcMode := eq .Values.auth.adminUI.mode "keycloak" -}}
 {{- $sync := .Values.auth.adminUI.keycloak.ssoBridgeSync -}}
 {{- $secretName := .Values.auth.adminUI.keycloak.existingSecret -}}
-{{- if and .Values.newapi.enabled $kcMode $sync.enabled $secretName (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") }}
+{{- if and (eq (include "bp-newapi.renderSeams" .) "true") .Values.newapi.enabled $kcMode $sync.enabled $secretName (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -31,6 +31,22 @@ catalystBlueprint:
 # overlays (set to `[]` for clusters that pull from public repos only).
 imagePullSecrets:
   - name: ghcr-pull
+# ─── Placement role (#3831) ──────────────────────────────────────────────
+# Splits the chart's render across two cooperating HelmReleases when newapi
+# is re-homed INTO the mgmt vCluster (NorthStar #1: every app in a vCluster)
+# while its CNPG-owner seams must stay HOST-side. See _helpers.tpl
+# bp-newapi.renderSeams / bp-newapi.renderApp for the full contract.
+#   all          (DEFAULT) — render everything (standalone / host-placed; a
+#                no-op gate, fully backward-compatible).
+#   host-seams   — render ONLY the host-reconciled seams (CNPG Cluster +
+#                DSN-sync Job + admin-sso-seed Job/Cron + AppRegistration
+#                ConfigMap + both ExternalSecrets). No app workload.
+#   vcluster-app — render ONLY the app (Deployment + Service + HTTPRoute +
+#                Application CR). No seams; the DSN Secret + CNPG Service are
+#                delivered into the vCluster by the bp-mgmt-vcluster
+#                sync.fromHost.secrets `newapi/*` mirror + replicateServices.
+placement:
+  role: all
 # ─── NewAPI application ──────────────────────────────────────────────────
 newapi:
   enabled: true

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -819,9 +819,26 @@ slots:
   # hostBridge:); the route + 2 ExternalSecrets + CNPG Cluster are HOST-rendered
   # so no loft.sh license is needed. The runtime edge gates on the vc-mgmt
   # Secret being Ready first.
+  # #3831 (2026-06-19): newapi is the CNPG-OWNER mgmt-vCluster app. The chart now
+  # render-splits (placement.role): slot 80 runs the app workload INSIDE vc-mgmt
+  # (vcluster-app), slot 80a renders the CNPG-owner seams host-side (host-seams).
+  # The app HR gains a bp-newapi-host-seams edge so the host CNPG Cluster + the
+  # database-secret-sync Job PATCH the DSN before the app's SQL_DSN gate waits.
   - slot: 80
     name: bp-newapi
-    depends_on: [bp-openbao, bp-keycloak, bp-cnpg, bp-mgmt-vcluster]
+    depends_on: [bp-openbao, bp-keycloak, bp-cnpg, bp-mgmt-vcluster, bp-newapi-host-seams]
+    wave: present
+
+  # ---- Slot 80a — bp-newapi-host-seams (#3831). The HOST-reconciled
+  # CNPG-owner seams for newapi: the CNPG Cluster + DSN-sync Job +
+  # admin-sso-seed Job/CronJob + newapi-admin AppRegistration ConfigMap + both
+  # ExternalSecrets, all in the host `newapi` ns. Gates on the host operators
+  # that reconcile them: bp-cnpg (Cluster + <cluster>-app), bp-external-secrets
+  # (both ExternalSecrets), bp-openbao + bp-keycloak (the admin-seed OIDC +
+  # AppRegistration realm), and bp-sso-bridge (the AppRegistration watcher).
+  - slot: 80a
+    name: bp-newapi-host-seams
+    depends_on: [bp-cnpg, bp-external-secrets, bp-openbao, bp-keycloak, bp-sso-bridge]
     wave: present
 
   # ---- Slot 95 — bp-stalwart-sovereign REMOVED 2026-05-05.


### PR DESCRIPTION
## What

Makes `bp-newapi` run its app workload **INSIDE the mgmt vCluster** (NorthStar #1: every app in a vCluster — newapi was the lone 6/7 host-placed exception), while its **CNPG-owner seams stay host-reconciled**.

newapi is the ONLY mgmt-vCluster app that **OWNS** a dedicated CNPG cluster (`newapi-bp-newapi-newapi-pg`) rather than consuming a reflected shared-pg secret. The #3642 host-bridge was built for the shared-pg-consumer pattern; a naive re-promote drops newapi's CNPG-owner seams (the `database-secret-sync` Job, `admin-sso-seed` Job/CronJob, the `newapi-admin` AppRegistration ConfigMap, `database.existingSecret` wiring) → the Deployment render-gate skip-renders (#3832 reverted newapi to host).

## How — mirror the guacamole host-bridge precedent (#3868), extended for a CNPG-OWNER app

A chart `placement.role` render-split (no manifest duplication into placement.yaml):

- **`platform/newapi/chart` 1.4.111**: new `placement.role` value (`all` | `host-seams` | `vcluster-app`) + `renderSeams`/`renderApp` helpers; every template ANDs the role gate into its existing condition. `role=all` (DEFAULT) is a no-op → every standalone / host-placed install is byte-identical to 1.4.110 (27 docs, all 4 chart test suites PASS). The Deployment's SQL_DSN-readiness initContainer now also fires when `database.existingSecret` is set (not only `cnpg.enabled`), so the vc-mgmt app does not boot on ephemeral SQLite while waiting on the mirrored DSN.
- **Slot 80** (`bp-newapi`) flips to `vcluster: mgmt` + `placement.role=vcluster-app` (suppress cnpg/ssoBridgeSync/catalyst-ES, wire `database.existingSecret` to the host DSN Secret) → Deployment + Service render in vc-mgmt; a host-bridge HTTPRoute fronts the syncer-mangled Services.
- **New slot 80a** (`bp-newapi-host-seams`, host, `placement.role=host-seams`) renders the CNPG-owner seams host-side: CNPG Cluster + DSN-sync Job + admin-sso-seed Job/CronJob + `newapi-admin` AppRegistration ConfigMap + both ExternalSecrets, where host cnpg-operator / ESO / OpenBao / cluster-wide bp-sso-bridge reconcile them. Both HRs share `releaseName: newapi` (different clusters → no Helm-storage collision) so `fullname` + every cross-render object name line up.
- **`bp-mgmt-vcluster` 0.2.23**: mirror the `newapi-pg` `-rw`/`-ro` Services into vc-mgmt (`replicateServices.fromHost`) so the host-style CNPG FQDN baked into the DSN resolves in the vCluster (the #3737 mechanism). The `newapi/*` secret mapping already delivers the DSN Secret.

## Seams added (host-side, slot 80a)

| Seam | Where it renders | Why host-side |
|---|---|---|
| CNPG `Cluster` + DSN placeholder Secret | host `newapi` ns | host cnpg-operator owns `<cluster>-app` |
| `database-secret-sync` Job | host `newapi` ns | reads the host CNPG `<cluster>-app` Secret |
| `admin-sso-seed` Job + per-minute CronJob | host `newapi` ns | seeds the host CNPG DB |
| `newapi-admin` AppRegistration ConfigMap | host `newapi` ns | host bp-sso-bridge watches `-A` (toHost INERT on OSS) |
| oidc-sync + catalyst-newapi-admin-token ExternalSecrets | host `newapi` ns | host ESO + OpenBao `vault-region1` |

## Does the Deployment render at mgmt?

**Yes.** `helm template` with the exact slot-80 `vcluster-app` values renders a non-empty Deployment whose `SQL_DSN` `secretKeyRef.name` is `newapi-bp-newapi-newapi-db-dsn` (the host-rendered, mirrored-in DSN Secret) — `$effDbSecret` resolves via `database.existingSecret` with `cnpg.enabled:false`. `host-seams` renders the seams and no app; `role=all` renders everything.

## Validation (render-level, no prov)

- `helm template` role matrix: vcluster-app = Deployment+Service (no seams); host-seams = seams (no app); all = full set (27 valid docs).
- `render-slot-placement.py check` — PASSED (newapi no longer staged-for-promotion).
- `check-bootstrap-deps.sh` — PASSED (no drift, no cycles).
- `audit-placement-conformance.py rendered` — PASSED (no newapi migration gap).
- `kubectl kustomize` of both bootstrap-kit + bootstrap-kit-crs — clean.
- All 4 bp-newapi chart tests + bp-mgmt-vcluster render test — PASS.

Refs #3831 #3642

🤖 Generated with [Claude Code](https://claude.com/claude-code)