### PR TITLE
fix(bp-mgmt-vcluster): de-conflict the 4 pod-mounted DB secrets from the fromHost wildcards — kill the vcluster 0.23 secret-ownership deadlock (0.2.23)

### DIFF
--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -151,7 +151,17 @@ spec:
       # DeadlineExceeded → Helm rollback → no webapp → `guacamole.<fqdn>` edge
       # 500/503 on hw167 (32 installFailures). Same #3737 4th-layer DNS gap, now
       # extended to guacamole's host-rendered CNPG cluster.
-      version: 0.2.22
+      # 0.2.23 (#3374 cycle-1): de-conflict the 4 pod-mounted DB Secrets
+      # (keycloak-database-secret / grafana-database-env / gitea-database-secret /
+      # harbor-database-secret) from the sync.fromHost.secrets namespace
+      # wildcards. On vcluster 0.23.0 a Secret that is BOTH fromHost-imported
+      # AND pod-mounted in vc-mgmt makes the from-host + to-host secret syncers
+      # fight (delete/recreate → context deadline exceeded → app Init:0/2 20m+),
+      # triggered live (hw167) by the #3872 mesh-secret regeneration repointing
+      # the DB Secret. Each app ns narrowed `<ns>/*` → EXACT-NAME SSO/OIDC creds
+      # only; keycloak drops out (no host non-DB Secret). DB Secret delivered
+      # natively in-vCluster (toHost sole owner).
+      version: 0.2.23
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.22
+  version: 0.2.23
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -255,7 +255,35 @@ name: bp-mgmt-vcluster
 # (`POSTGRESQL_HOSTNAME=guacamole-pg-rw.catalyst-system.svc.cluster.local`)
 # resolve. Additive + idempotent (no-op until the host-bridge renders the
 # Cluster). Lockstep: 58-bp-mgmt-vcluster.yaml pin → 0.2.21. Refs #3374.
-version: 0.2.22
+# 0.2.23 (#3374 cycle-1 — the fromHost-vs-toHost DB-secret deadlock fix,
+# hw167 live RCA): de-conflict the 4 pod-mounted DB Secrets from the
+# `sync.fromHost.secrets.mappings.byName` namespace wildcards. On vcluster
+# 0.23.0 a Secret that matches BOTH a fromHost `<ns>/*` mapping AND is
+# pod-mounted inside vc-mgmt (so the toHost "necessary" auto-sync claims the
+# SAME virtual object) makes the from-host and to-host secret syncers fight
+# in a delete/recreate loop → `context deadline exceeded`, the host
+# projection never sticks, the app sits `Init:0/2` for 20m+ on any pod
+# restart. Latent until the #3872 mesh-secret regeneration makes the
+# emberstack reflector REPOINT the host DB Secret → the from-host importer
+# rewrites the in-vCluster copy → pod restart → deadlock. The validation
+# agent hand-fixed ONLY keycloak live (removed `keycloak/*` DB import +
+# created the DB Secret natively in-vCluster); this release applies that
+# pattern durably to ALL 4 host-bridged DB Secrets:
+# `keycloak-database-secret` / `grafana-database-env` /
+# `gitea-database-secret` / `harbor-database-secret`. Each app namespace is
+# narrowed from `<ns>/*` to EXACT-NAME mappings covering ONLY the host-minted
+# SSO/OIDC creds the in-vCluster pods/reconcilers still mount
+# (gitea-oauth-source-credentials / harbor-sso-oidc-credentials /
+# grafana-sso-oidc-credentials); keycloak has no host-minted non-DB Secret so
+# it drops out entirely. The DB Secret is no longer fromHost-imported (the
+# from-host syncer never contends with the to-host syncer over it) and is
+# delivered natively in-vCluster via the sibling slot-16 shared-pg reflector
+# re-target — toHost is then its sole owner. `newapi/*` + `catalyst-system/*`
+# wildcards and the openbao EXACT-NAME entries (#3838) are unchanged. No
+# secret name now double-matches a fromHost mapping AND a known
+# keycloak/grafana/gitea/harbor pod-mount. Lockstep:
+# 58-bp-mgmt-vcluster.yaml pin + blueprint.yaml → 0.2.23. Refs #3374 #3737.
+version: 0.2.23
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -650,15 +650,52 @@ vcluster:
       # `service-account.name` annotation, so the vCluster token-controller
       # never touches it and the mirror is stable. Mirror that Opaque copy by
       # EXACT name; never wildcard a namespace that holds an SA-token Secret.
+      # ⚠️ NEVER namespace-wildcard a host ns whose pod-mounted DB Secret the
+      # in-vCluster pod also references (#3374 cycle-1, hw167 live RCA). On
+      # vcluster 0.23.0 a Secret that is BOTH (a) imported via a
+      # `sync.fromHost.secrets` wildcard AND (b) pod-mounted inside vc-mgmt
+      # (so the `sync.toHost.secrets` "necessary" auto-sync also claims the
+      # SAME virtual object) makes the from-host and to-host secret syncers
+      # FIGHT over ownership — a delete/recreate loop that on any pod restart
+      # ends in `context deadline exceeded`, the host projection never sticks,
+      # and the app sits `Init:0/2` for 20m+. It is latent until the
+      # mesh-secret regeneration (the #3872 `<instance>-mesh-rw` mirror) makes
+      # the emberstack reflector REPOINT the host DB Secret → the from-host
+      # importer rewrites the in-vCluster copy → pod restart → deadlock.
+      # The 4 host-bridged apps each mint a pod-mounted DB Secret via the
+      # shared-pg reflector (16a/16c) — `keycloak-database-secret`,
+      # `grafana-database-env`, `gitea-database-secret`,
+      # `harbor-database-secret` — every one previously swept in by the
+      # `<ns>/*` wildcard. The validation agent hand-removed ONLY the
+      # `keycloak/*` DB-secret import live on hw167 + created the DB Secret
+      # natively in-vCluster (toHost/syncer path only → single owner, no
+      # fight); this block applies that pattern durably to ALL 4: the DB
+      # Secret is NEVER fromHost-imported, so the from-host syncer never
+      # contends with the to-host syncer over it. Each namespace is narrowed
+      # from `<ns>/*` to EXACT-NAME mappings covering ONLY the host-minted
+      # Secrets an in-vCluster pod/reconciler still needs (the SSO/OIDC
+      # ExternalSecret-materialised creds — gitea/harbor/grafana sso-configure
+      # + grafana runtime mount them). keycloak has NO host-minted non-DB
+      # Secret (its IdP creds are issued, not mounted), so it drops out
+      # entirely. The DB Secret is delivered natively in-vCluster (the
+      # shared-pg reflector re-target, sibling slot-16 change) — the toHost
+      # syncer is then its sole owner. `newapi/*` + `catalyst-system/*` keep
+      # their wildcards (out of this de-conflict's 4-app scope, no observed
+      # rotation-driven deadlock); the openbao EXACT-NAME entries (#3838)
+      # remain unchanged.
       secrets:
         enabled: true
         mappings:
           byName:
-            "keycloak/*": "keycloak/*"
-            "gitea/*": "gitea/*"
-            "harbor/*": "harbor/*"
+            # gitea/harbor/grafana — host-minted SSO/OIDC creds ONLY
+            # (the pod-mounted DB Secret is intentionally NOT imported).
+            "gitea/gitea-oauth-source-credentials": "gitea/gitea-oauth-source-credentials"
+            "harbor/harbor-sso-oidc-credentials": "harbor/harbor-sso-oidc-credentials"
+            "grafana/grafana-sso-oidc-credentials": "grafana/grafana-sso-oidc-credentials"
+            # keycloak — NO entry: the only host-minted Secret it needs is
+            # `keycloak-database-secret` (excluded above); it has no host SSO
+            # Secret (Keycloak IS the IdP, it issues client creds, mounts none).
             "newapi/*": "newapi/*"
-            "grafana/*": "grafana/*"
             "openbao/openbao-sso-oidc-credentials": "openbao/openbao-sso-oidc-credentials"
             "openbao/openbao-host-token-reviewer-static": "openbao/openbao-host-token-reviewer-static"
             "catalyst-system/*": "catalyst-system/*"


### PR DESCRIPTION
## What

De-conflict the 4 pod-mounted DB secrets from the `bp-mgmt-vcluster` `sync.fromHost.secrets` namespace wildcards, killing the vcluster 0.23 from-host/to-host secret-ownership deadlock that cycle-1 validation caught LIVE on hw167. Left unfixed, the chart ships a trap that wedges a fresh prov's keycloak/SSO on convergence.

## Root cause (confirmed live on hw167, cycle-1 validation)

On vcluster 0.23.0 a Secret that matches BOTH a `fromHost` `<ns>/*` wildcard mapping AND is pod-mounted inside vc-mgmt (so the `toHost.secrets` "necessary" auto-sync also claims the SAME virtual object) makes the from-host and to-host secret controllers fight in a delete/recreate loop → `context deadline exceeded`, the host projection never sticks, the app sits `Init:0/2` for 20m+ on any pod restart. It is latent until the #3872 mesh-secret regeneration makes the emberstack reflector REPOINT the host DB secret → the from-host importer rewrites the in-vCluster copy → pod restart → deadlock.

Affected pod-mounted DB secrets (each swept in by a `<ns>/*` wildcard): `keycloak-database-secret`, `grafana-database-env`, `gitea-database-secret`, `harbor-database-secret`. The hw167 validation agent hand-fixed ONLY keycloak live (removed the `keycloak/*` DB import + created the DB secret natively in-vCluster); the chart still shipped the trap for all 4.

## The fix

Narrow each of the 4 app namespaces from `<ns>/*` to EXACT-NAME mappings covering ONLY the host-minted secrets the in-vCluster pods/reconcilers still need:

| Host ns | New `fromHost` entry | DB secret no longer imported |
|---|---|---|
| `keycloak` | (none — dropped entirely) | `keycloak-database-secret` |
| `gitea` | `gitea-oauth-source-credentials` | `gitea-database-secret` |
| `harbor` | `harbor-sso-oidc-credentials` | `harbor-database-secret` |
| `grafana` | `grafana-sso-oidc-credentials` | `grafana-database-env` |

`keycloak` drops out completely — its only host-minted secret was the DB secret; Keycloak IS the IdP, it issues client creds and mounts no host SSO secret. The gitea/harbor/grafana SSO/OIDC creds (host-minted by the bp-sso-bridge ExternalSecret, mounted by the in-vCluster sso-configure reconcilers + the grafana runtime pod) stay mirrored. The DB secret is no longer `fromHost`-imported, so the from-host syncer never contends with the to-host syncer over it; it is delivered natively in-vCluster (toHost is its sole owner). `newapi/*` + `catalyst-system/*` wildcards and the openbao EXACT-NAME entries (#3838) are untouched.

## Validation (render-level, no prov)

`helm template` with `mgmtVcluster.enabled=true`, decode the `vc-config` syncer Secret, assert the rendered `sync.fromHost.secrets.byName` contains no `keycloak/*` / `gitea/*` / `harbor/*` / `grafana/*` wildcard → **PASS — no pod-mounted DB secret double-matches a fromHost mapping**. Chart render tests green (7/7). bootstrap-kit version-lockstep sweep + full suite green.

## Files / version

- `platform/bp-mgmt-vcluster/chart/values.yaml` — narrowed the 4 wildcards
- `platform/bp-mgmt-vcluster/chart/Chart.yaml` — `0.2.22 → 0.2.23` + changelog
- `platform/bp-mgmt-vcluster/blueprint.yaml` — `0.2.23` lockstep
- `clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml` — slot-58 pin `0.2.23`

Refs #3374 #3737

🤖 Generated with [Claude Code](https://claude.com/claude-code)
