### PR TITLE
fix(provisioning): proxy the legacy per-Org DB-backing images through Sovereign Harbor — unblock funnel terminal (Refs #3760 #3785 #3376)

### DIFF
--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -277,14 +277,14 @@ func (g *ManifestGenerator) GenerateAllWithAppConfigs(slug, planSlug string, app
 				slog.Warn("provisioning/gitops: active_hot_standby requested but region pair invalid — falling back to single-cluster postgres",
 					"app", "postgres", "primary_region", primaryRegion, "replica_region", replicaRegion)
 			}
-			vcFiles["db-postgres.yaml"] = generatePostgres(appNS, dbPassword, postgresApps, pgCfg)
+			vcFiles["db-postgres.yaml"] = generatePostgres(appNS, dbPassword, postgresApps, pgCfg, g.registryMirror())
 		}
 	}
 	if len(mysqlApps) > 0 {
-		vcFiles["db-mysql.yaml"] = generateMySQL(appNS, dbPassword, mysqlApps, appConfigs["mysql"])
+		vcFiles["db-mysql.yaml"] = generateMySQL(appNS, dbPassword, mysqlApps, appConfigs["mysql"], g.registryMirror())
 	}
 	if needsRedis {
-		vcFiles["db-redis.yaml"] = generateRedis(appNS)
+		vcFiles["db-redis.yaml"] = generateRedis(appNS, g.registryMirror())
 	}
 	for _, a := range appSlugs {
 		// Shareable database slugs are emitted as db-*.yaml above; skip
@@ -531,7 +531,19 @@ metadata:
 `, ns)
 }
 
-func generatePostgres(ns, password string, apps []string, cfg map[string]any) string {
+// generatePostgres / generateMySQL / generateRedis emit the single-Pod
+// DB-backing Deployments that co-install with a customer's purchased app
+// inside the per-Org vCluster. MIRROR-EVERYTHING (#3785, Refs #3376 #3761):
+// the vCluster syncer schedules the BACKING Pod on the HOST cluster (the
+// `tenant-<slug>` host namespace), where the `harbor-proxy-pull` Kyverno
+// ClusterPolicy (Enforce) DENIES any image not matching `*/proxy-*/*`. A raw
+// `postgres:16-alpine` / `mariadb:11` / `valkey/valkey:8-alpine` is therefore
+// blocked, the DB never starts, and the app it backs can never run — the
+// funnel terminal (#3376) stays connection-refused. proxyImage re-tags each
+// through the registry-appropriate Sovereign Harbor proxy project
+// (proxy-dockerhub here), identically to the app-deployment images; it is a
+// no-op when the mirror is empty or the reference is already proxied.
+func generatePostgres(ns, password string, apps []string, cfg map[string]any, registryMirror string) string {
 	// Per-app database isolation: create db_<appSlug> for each postgres-backed
 	// app so co-installed apps (e.g. gitea + nextcloud on the same tenant)
 	// don't collide on a shared schema. The first database is also created by
@@ -635,7 +647,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: postgres:16-alpine
+          image: %s
           ports:
             - containerPort: 5432
           envFrom:
@@ -672,7 +684,7 @@ spec:
   ports:
     - port: 5432
       targetPort: 5432
-`, ns, password, primaryDB, ns, indentBlock(initSQL, "    "), ns, diskGB, ns, backupsEnabled, replicas, ns)
+`, ns, password, primaryDB, ns, indentBlock(initSQL, "    "), ns, diskGB, ns, backupsEnabled, replicas, proxyImage("postgres:16-alpine", registryMirror), ns)
 }
 
 // generateCNPGPair renders the bp-cnpg-pair HelmRelease — the Pillar-3
@@ -835,7 +847,7 @@ spec:
 `, ns, password, primaryDB, ns, ns, ns, ns, primaryRegion, instances, diskGB, primaryDB, replicaRegion, instances, diskGB)
 }
 
-func generateMySQL(ns, password string, apps []string, cfg map[string]any) string {
+func generateMySQL(ns, password string, apps []string, cfg map[string]any, registryMirror string) string {
 	// Per-app database isolation: create db_<appSlug> for each mysql-backed
 	// app so co-installed apps (e.g. wordpress + ghost) don't collide on a
 	// shared schema. MYSQL_DATABASE bootstraps the first one; an init script
@@ -925,7 +937,7 @@ spec:
     spec:
       containers:
         - name: mysql
-          image: mariadb:11
+          image: %s
           ports:
             - containerPort: 3306
           envFrom:
@@ -962,7 +974,7 @@ spec:
   ports:
     - port: 3306
       targetPort: 3306
-`, ns, password, password, primaryDB, ns, indentBlock(initSQL, "    "), ns, diskGB, ns, backupsEnabled, replicas, ns)
+`, ns, password, password, primaryDB, ns, indentBlock(initSQL, "    "), ns, diskGB, ns, backupsEnabled, replicas, proxyImage("mariadb:11", registryMirror), ns)
 }
 
 // indentBlock prefixes every non-empty line of s with indent. Used to embed a
@@ -986,7 +998,7 @@ func indentBlock(s, indent string) string {
 	return out.String()
 }
 
-func generateRedis(ns string) string {
+func generateRedis(ns, registryMirror string) string {
 	return fmt.Sprintf(`apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1004,7 +1016,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: valkey/valkey:8-alpine
+          image: %s
           ports:
             - containerPort: 6379
           resources:
@@ -1026,7 +1038,7 @@ spec:
   ports:
     - port: 6379
       targetPort: 6379
-`, ns, ns)
+`, ns, proxyImage("valkey/valkey:8-alpine", registryMirror), ns)
 }
 
 func generateAppDeployment(ns, slug, appSlug string, spec AppSpec, dbPassword string) string {

--- a/core/services/provisioning/gitops/proxy_image_test.go
+++ b/core/services/provisioning/gitops/proxy_image_test.go
@@ -1,6 +1,9 @@
 package gitops
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // #3785 (Refs #3376 #3761) — proxyImage must re-tag upstream app images
 // through the registry-appropriate Sovereign Harbor proxy-cache project so
@@ -41,5 +44,55 @@ func TestProxyImage(t *testing.T) {
 	// Empty image → empty.
 	if got := proxyImage("", mirror); got != "" {
 		t.Errorf("empty image must stay empty; got %q", got)
+	}
+}
+
+// TestDBBackingImages_Proxied (#3785, Refs #3376 #3761) — the single-Pod
+// DB-backing Deployments (postgres / mysql / redis) co-installed with a
+// customer's purchased app must ALSO route their images through the Sovereign
+// Harbor proxy-cache. Their backing Pods land on the HOST cluster where the
+// harbor-proxy-pull Kyverno ClusterPolicy (Enforce) DENIES any image not
+// matching */proxy-*/* — a bare postgres:16-alpine / mariadb:11 /
+// valkey/valkey:8-alpine would block the DB, so the app it backs never Runs
+// and the #3376 funnel terminal stays connection-refused.
+func TestDBBackingImages_Proxied(t *testing.T) {
+	g := &ManifestGenerator{BasePath: "clusters/contabo-mkt/tenants"}
+	// chatwoot needs postgres + redis; ghost needs mysql — one tenant that
+	// exercises all three DB-backing generators at once.
+	files := g.GenerateAllWithAppConfigs("acme", "flexi",
+		[]string{"chatwoot", "ghost"}, "deadbeef", nil)
+
+	want := map[string]string{
+		"db-postgres.yaml": "image: harbor.openova.io/proxy-dockerhub/postgres:16-alpine",
+		"db-mysql.yaml":    "image: harbor.openova.io/proxy-dockerhub/mariadb:11",
+		"db-redis.yaml":    "image: harbor.openova.io/proxy-dockerhub/valkey/valkey:8-alpine",
+	}
+	// The pre-fix bare references that must NEVER survive into the rendered
+	// manifest (they'd be Kyverno-denied on the host).
+	banned := map[string]string{
+		"db-postgres.yaml": "image: postgres:16-alpine",
+		"db-mysql.yaml":    "image: mariadb:11",
+		"db-redis.yaml":    "image: valkey/valkey:8-alpine",
+	}
+
+	seen := map[string]bool{}
+	for path, content := range files {
+		for suffix, proxied := range want {
+			if !strings.HasSuffix(path, suffix) {
+				continue
+			}
+			seen[suffix] = true
+			if !strings.Contains(content, proxied) {
+				t.Errorf("%s missing proxied image %q — full manifest:\n%s", suffix, proxied, content)
+			}
+			if strings.Contains(content, banned[suffix]) {
+				t.Errorf("%s still carries bare image %q — Kyverno harbor-proxy-pull would DENY it", suffix, banned[suffix])
+			}
+		}
+	}
+	for suffix := range want {
+		if !seen[suffix] {
+			t.Errorf("expected %s to be generated for the chatwoot+ghost tenant", suffix)
+		}
 	}
 }


### PR DESCRIPTION
## What

The customer's per-Org vCluster + purchased-app DB-backing pods were minting **bare Docker Hub images** that the `harbor-proxy-pull` Kyverno ClusterPolicy (Enforce) DENIES — so the customer DB never starts, the app it backs can never run, and the #3376 funnel terminal stays connection-refused.

`core/services/provisioning/gitops/gitops.go` already routed the **app** images (#3785) and the **vCluster syncer/distro** images (#3760) through the Sovereign Harbor proxy-cache via `proxyImage`, but the three **DB-backing** generators were missed:

| Generator | Was (bare, denied) | Now (proxied) |
|---|---|---|
| `generatePostgres` | `postgres:16-alpine` | `harbor.openova.io/proxy-dockerhub/postgres:16-alpine` |
| `generateMySQL` | `mariadb:11` | `harbor.openova.io/proxy-dockerhub/mariadb:11` |
| `generateRedis` | `valkey/valkey:8-alpine` | `harbor.openova.io/proxy-dockerhub/valkey/valkey:8-alpine` |

The vCluster syncer schedules these backing Pods on the HOST cluster (the `tenant-<slug>` host namespace), where the kyverno Enforce policy lives — so a bare image is admission-denied there.

## How

- Thread the configured registry mirror (`g.registryMirror()`, default `harbor.openova.io`, env `CATALYST_VCLUSTER_IMAGE_REGISTRY`, Inviolable Principle #4) into the three generators.
- Route each image through the existing `proxyImage` helper (`docker.io` → `proxy-dockerhub`), identical to the already-proxied app-deployment images. No-op when the mirror is empty or the reference is already proxied.
- No bare `ghcr.io` / `registry.k8s.io` / `docker.io` image now reaches kyverno enforce in a customer vCluster.

## Validate (render/code-level, no prov)

- `go build ./...` green on both the provisioning module and the org-controller module.
- New `TestDBBackingImages_Proxied` render-level regression: generates a chatwoot+ghost tenant (exercises postgres + mysql + redis) and asserts all three DB manifests carry `harbor.openova.io/proxy-dockerhub/*` images and that the bare references are gone.
- Full `core/services/provisioning` test suite passes.

## Files

- `core/services/provisioning/gitops/gitops.go`
- `core/services/provisioning/gitops/proxy_image_test.go`

Refs #3760 #3785 #3376

🤖 Generated with [Claude Code](https://claude.com/claude-code)