### PR TITLE
fix(bp-catalyst-platform): sme→org-services rename TAIL — funnel/BSS control-plane ns defaults + reflector/policy allow-lists (1.4.702)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1039,7 +1039,9 @@ spec:
             # 1.4.696 — #3859 (Refs #3376): wire TENANT_PARENT_DOMAIN onto the provisioning Deployment (smeServices.provisioning.tenantParentDomain ← ${TENANT_PARENT_DOMAIN}). The per-Org provisioning consumer seeds spec.tenantPublic ONLY when a parent domain is set; without it every customer Org minted with NO TenantPublic HTTPRoute → the customer's own console + purchased app returned ERR_CONNECTION_REFUSED (the funnel terminal failure on every prior env, first root-caused driving walkorg/hw167). Default "" = Catalyst-Zero byte-identical. NOTE re-pin: 1.4.686–1.4.695 publish-lag may apply — verify ghcr tag before a fresh prov pins this.
             # 1.4.697 — merge-train resolution (Refs #3376 #3848): supersedes the auto-bump hook's 1.4.695; lands #3859 (1.4.696, TENANT_PARENT_DOMAIN funnel terminal) on top of #3849 (1.4.695, org-controller KC-secret host-bridge). Both additive + independent; pin bumped lockstep with the published OCI artifact.
             # 1.4.699 — #3856 (Refs #3375 #3581): ONE canonical DR vocabulary — catalog-seed (bp-cnpg-pair + bp-continuum) + cnpgpair.yaml CRD enum drop the banned un-hyphenated `active-hotstandby` for the canonical `active-hot-standby`; catalyst-ui Instances table canonicalizes for display so the bp-postgres chip renders clean. Catalyst-Zero render byte-unchanged. NOTE re-pin: the catalyst-build auto-bump may publish a higher patch (it increments from Chart.yaml at merge) — verify the ghcr tag before a fresh prov pins this.
-      version: 1.4.701
+      # 1.4.702 — #3819 #3854 #3859 (Refs #3383 #3376): sme→org-services rename TAIL — funnel/BSS
+      #   control-plane namespace defaults + reflector/policy allow-lists re-pointed at org-services.
+      version: 1.4.702
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -137,7 +137,13 @@ spec:
       # ingress rule (TCP 5432 from any in-cluster Pod) so the SHARED engine's
       # consumers reach it again; replication/own-cluster/operator carve-outs
       # unchanged; singleton stays byte-identical. Lockstep bump with 16c/16d.
-      version: 0.2.2
+      # 0.2.4 (#3878, companion to #3876): chart gains reflect.mangledTarget;
+      # the keycloak/gitea/harbor bindings below declare it so each DB Secret
+      # is delivered natively into vc-mgmt as the syncer-mangled host object
+      # (no fromHost mirror of a pod-mounted Secret → no vcluster-0.23.0
+      # from-host/to-host deadlock, and no missing credential). Lockstep with
+      # 16c/16d. Refs #3876 #3374 #3737.
+      version: 0.2.4
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -224,6 +230,14 @@ spec:
         reflect:
           secretName: harbor-database-secret
           namespaces: [harbor]
+          # #3878 (companion to #3876): harbor runs INSIDE vc-mgmt (#3642).
+          # Deliver harbor-database-secret natively into vc-mgmt by reflecting
+          # the vCluster-syncer-mangled host object into ns `mgmt` (the object
+          # the in-vc pod mounts). The DB Secret is NOT fromHost-imported, so
+          # the from-host/to-host syncers never fight over it (the #3876
+          # deadlock) AND the credential is present on a fresh prov.
+          mangledTarget:
+            vclusterNamespace: harbor
       - name: gitea             # gitea's database
         owner: gitea
         consumer:
@@ -232,6 +246,10 @@ spec:
         reflect:
           secretName: gitea-database-secret
           namespaces: [gitea]
+          # #3878: gitea runs INSIDE vc-mgmt — native DB-secret delivery (see
+          # harbor binding above for the full rationale).
+          mangledTarget:
+            vclusterNamespace: gitea
       # keycloak (#3188 three-instance model): the bitnami keycloak
       # subchart flips to externalDatabase mode off this hub Secret —
       # slot 09 gates its bundled keycloak-postgresql StatefulSet on
@@ -247,3 +265,11 @@ spec:
         reflect:
           secretName: keycloak-database-secret
           namespaces: [keycloak]
+          # #3878: keycloak runs INSIDE vc-mgmt — native DB-secret delivery.
+          # This is the durable form of the hw167 hand-fix the cycle-1
+          # validation agent applied live (created keycloak-database-secret
+          # natively in-vCluster, single toHost owner). #3876 dropped the
+          # keycloak/* fromHost wildcard entirely (keycloak has no host SSO
+          # Secret); this mangled copy is its ONLY in-vc DB-secret source.
+          mangledTarget:
+            vclusterNamespace: keycloak

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -82,7 +82,12 @@ spec:
       # primary NetworkPolicy default-denied every consumer's shared-pg-b-rw:5432
       # (grafana/powerdns hub on hw144). Adds TCP 5432 from any in-cluster Pod;
       # replication/own-cluster/operator carve-outs unchanged. Lockstep 16a/16d.
-      version: 0.2.2
+      # 0.2.4 (#3878, companion to #3876): the grafana binding declares
+      # reflect.mangledTarget so grafana-database-env is delivered natively into
+      # vc-mgmt as the syncer-mangled host object (no fromHost mirror → no
+      # vcluster-0.23.0 deadlock, no missing GF_DATABASE_* env). Lockstep with
+      # 16a/16d. Refs #3876 #3374 #3737.
+      version: 0.2.4
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -149,6 +154,16 @@ spec:
           # of a region-local literal that NXDOMAIN'd grafana in region-B.
           hostPortKeys: [GF_DATABASE_HOST]
           passwordAliases: [GF_DATABASE_PASSWORD]
+          # #3878 (companion to #3876): grafana runs INSIDE vc-mgmt (#3642).
+          # Deliver grafana-database-env natively into vc-mgmt by reflecting
+          # the vCluster-syncer-mangled host object into ns `mgmt` (the object
+          # the grafana pod mounts via envFromSecrets). The env Secret is NOT
+          # fromHost-imported (#3876 dropped the grafana/* wildcard), so the
+          # from-host/to-host syncers never deadlock over it AND the GF_DATABASE_*
+          # env is present on a fresh prov. The mangled copy carries the SAME
+          # GF_DATABASE_* keys as the consumer-namespace copy.
+          mangledTarget:
+            vclusterNamespace: grafana
       # pdns — READY-TO-ADOPT (schema-bootstrap follow-up, see header).
       - name: pdns
         owner: pdns

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -70,7 +70,12 @@ spec:
       # (SME mesh / newapi / openova-flow on hw144). Adds TCP 5432 from any
       # in-cluster Pod; replication/own-cluster/operator carve-outs unchanged.
       # Lockstep bump with 16a/16c.
-      version: 0.2.2
+      # 0.2.4 (#3878): pure lockstep pin bump — shared-c's bindings (SME mesh /
+      # newapi / openova-flow) declare NO reflect.mangledTarget (they are not
+      # the 4 vc-mgmt-homed deadlock apps; newapi keeps its `newapi/*` fromHost
+      # wildcard per #3876), so this slot renders byte-identical to 0.2.2 on the
+      # additive chart. Lockstep with 16a/16c. Refs #3876 #3374 #3737.
+      version: 0.2.4
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -151,7 +151,17 @@ spec:
       # DeadlineExceeded → Helm rollback → no webapp → `guacamole.<fqdn>` edge
       # 500/503 on hw167 (32 installFailures). Same #3737 4th-layer DNS gap, now
       # extended to guacamole's host-rendered CNPG cluster.
-      version: 0.2.22
+      # 0.2.23 (#3374 cycle-1): de-conflict the 4 pod-mounted DB Secrets
+      # (keycloak-database-secret / grafana-database-env / gitea-database-secret /
+      # harbor-database-secret) from the sync.fromHost.secrets namespace
+      # wildcards. On vcluster 0.23.0 a Secret that is BOTH fromHost-imported
+      # AND pod-mounted in vc-mgmt makes the from-host + to-host secret syncers
+      # fight (delete/recreate → context deadline exceeded → app Init:0/2 20m+),
+      # triggered live (hw167) by the #3872 mesh-secret regeneration repointing
+      # the DB Secret. Each app ns narrowed `<ns>/*` → EXACT-NAME SSO/OIDC creds
+      # only; keycloak drops out (no host non-DB Secret). DB Secret delivered
+      # natively in-vCluster (toHost sole owner).
+      version: 0.2.23
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -161,7 +161,16 @@ spec:
       # the DB Secret. Each app ns narrowed `<ns>/*` → EXACT-NAME SSO/OIDC creds
       # only; keycloak drops out (no host non-DB Secret). DB Secret delivered
       # natively in-vCluster (toHost sole owner).
-      version: 0.2.23
+      # 0.2.24 (#3878, companion to #3876 — comment-only chart change): the
+      # native in-vCluster DB-secret delivery #3876 promised is now IMPLEMENTED
+      # in the sibling slot-16 change (bp-postgres 0.2.4 `reflect.mangledTarget`,
+      # slots 16a/16c). The shared-pg reflector materialises the syncer-mangled
+      # host object `<secret>-x-<ns>-x-mgmt-vcluster` in host ns `mgmt` (the
+      # object the in-vc pod mounts), so the 4 DB Secrets reach keycloak/gitea/
+      # harbor/grafana natively without a fromHost mirror. This pin bump only
+      # refreshes the fromHost-block RCA comment; sync config byte-identical.
+      # Refs #3876 #3374 #3737.
+      version: 0.2.24
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -267,9 +267,9 @@ write_files:
         namespace: flux-system
         annotations:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "sme,catalyst,catalyst-system,gitea,harbor"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "sme,catalyst,catalyst-system,gitea,harbor"
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor"
       type: Opaque
       data:
         username: ${base64encode(pdm_basic_auth_user)}

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.22
+  version: 0.2.23
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.23
+  version: 0.2.24
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -283,7 +283,22 @@ name: bp-mgmt-vcluster
 # secret name now double-matches a fromHost mapping AND a known
 # keycloak/grafana/gitea/harbor pod-mount. Lockstep:
 # 58-bp-mgmt-vcluster.yaml pin + blueprint.yaml → 0.2.23. Refs #3374 #3737.
-version: 0.2.23
+# 0.2.24 (#3878, the implemented COMPANION to #3876 — comment-only here): #3876
+# (0.2.23) removed the 4 DB Secrets from the `sync.fromHost.secrets` wildcards
+# to kill the vcluster-0.23.0 from-host/to-host deadlock, and its RCA promised
+# the DB Secret would be "delivered natively in-vCluster (the shared-pg reflector
+# re-target, sibling slot-16 change)" — but #3876 did NOT contain that re-target,
+# so with #3876 alone keycloak/grafana/gitea/harbor get NO DB credential inside
+# vc-mgmt on a fresh prov. #3878 ships the re-target in bp-postgres 0.2.4
+# (`reflect.mangledTarget`, wired in slots 16a keycloak/gitea/harbor + 16c
+# grafana): the shared-pg reflector now materialises the vCluster-syncer-mangled
+# host object `<secret>-x-<ns>-x-mgmt-vcluster` in host ns `mgmt` — the exact
+# Secret the in-vc-mgmt pod mounts — carrying the live password, NEVER
+# fromHost-imported (no syncer contention). This release only updates the
+# fromHost-block RCA comment to cite the implemented companion; the sync config
+# is byte-identical to 0.2.23. Lockstep: 58-bp-mgmt-vcluster.yaml pin +
+# blueprint.yaml → 0.2.24. Refs #3876 #3374 #3737.
+version: 0.2.24
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -255,7 +255,35 @@ name: bp-mgmt-vcluster
 # (`POSTGRESQL_HOSTNAME=guacamole-pg-rw.catalyst-system.svc.cluster.local`)
 # resolve. Additive + idempotent (no-op until the host-bridge renders the
 # Cluster). Lockstep: 58-bp-mgmt-vcluster.yaml pin → 0.2.21. Refs #3374.
-version: 0.2.22
+# 0.2.23 (#3374 cycle-1 — the fromHost-vs-toHost DB-secret deadlock fix,
+# hw167 live RCA): de-conflict the 4 pod-mounted DB Secrets from the
+# `sync.fromHost.secrets.mappings.byName` namespace wildcards. On vcluster
+# 0.23.0 a Secret that matches BOTH a fromHost `<ns>/*` mapping AND is
+# pod-mounted inside vc-mgmt (so the toHost "necessary" auto-sync claims the
+# SAME virtual object) makes the from-host and to-host secret syncers fight
+# in a delete/recreate loop → `context deadline exceeded`, the host
+# projection never sticks, the app sits `Init:0/2` for 20m+ on any pod
+# restart. Latent until the #3872 mesh-secret regeneration makes the
+# emberstack reflector REPOINT the host DB Secret → the from-host importer
+# rewrites the in-vCluster copy → pod restart → deadlock. The validation
+# agent hand-fixed ONLY keycloak live (removed `keycloak/*` DB import +
+# created the DB Secret natively in-vCluster); this release applies that
+# pattern durably to ALL 4 host-bridged DB Secrets:
+# `keycloak-database-secret` / `grafana-database-env` /
+# `gitea-database-secret` / `harbor-database-secret`. Each app namespace is
+# narrowed from `<ns>/*` to EXACT-NAME mappings covering ONLY the host-minted
+# SSO/OIDC creds the in-vCluster pods/reconcilers still mount
+# (gitea-oauth-source-credentials / harbor-sso-oidc-credentials /
+# grafana-sso-oidc-credentials); keycloak has no host-minted non-DB Secret so
+# it drops out entirely. The DB Secret is no longer fromHost-imported (the
+# from-host syncer never contends with the to-host syncer over it) and is
+# delivered natively in-vCluster via the sibling slot-16 shared-pg reflector
+# re-target — toHost is then its sole owner. `newapi/*` + `catalyst-system/*`
+# wildcards and the openbao EXACT-NAME entries (#3838) are unchanged. No
+# secret name now double-matches a fromHost mapping AND a known
+# keycloak/grafana/gitea/harbor pod-mount. Lockstep:
+# 58-bp-mgmt-vcluster.yaml pin + blueprint.yaml → 0.2.23. Refs #3374 #3737.
+version: 0.2.23
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -650,15 +650,52 @@ vcluster:
       # `service-account.name` annotation, so the vCluster token-controller
       # never touches it and the mirror is stable. Mirror that Opaque copy by
       # EXACT name; never wildcard a namespace that holds an SA-token Secret.
+      # ⚠️ NEVER namespace-wildcard a host ns whose pod-mounted DB Secret the
+      # in-vCluster pod also references (#3374 cycle-1, hw167 live RCA). On
+      # vcluster 0.23.0 a Secret that is BOTH (a) imported via a
+      # `sync.fromHost.secrets` wildcard AND (b) pod-mounted inside vc-mgmt
+      # (so the `sync.toHost.secrets` "necessary" auto-sync also claims the
+      # SAME virtual object) makes the from-host and to-host secret syncers
+      # FIGHT over ownership — a delete/recreate loop that on any pod restart
+      # ends in `context deadline exceeded`, the host projection never sticks,
+      # and the app sits `Init:0/2` for 20m+. It is latent until the
+      # mesh-secret regeneration (the #3872 `<instance>-mesh-rw` mirror) makes
+      # the emberstack reflector REPOINT the host DB Secret → the from-host
+      # importer rewrites the in-vCluster copy → pod restart → deadlock.
+      # The 4 host-bridged apps each mint a pod-mounted DB Secret via the
+      # shared-pg reflector (16a/16c) — `keycloak-database-secret`,
+      # `grafana-database-env`, `gitea-database-secret`,
+      # `harbor-database-secret` — every one previously swept in by the
+      # `<ns>/*` wildcard. The validation agent hand-removed ONLY the
+      # `keycloak/*` DB-secret import live on hw167 + created the DB Secret
+      # natively in-vCluster (toHost/syncer path only → single owner, no
+      # fight); this block applies that pattern durably to ALL 4: the DB
+      # Secret is NEVER fromHost-imported, so the from-host syncer never
+      # contends with the to-host syncer over it. Each namespace is narrowed
+      # from `<ns>/*` to EXACT-NAME mappings covering ONLY the host-minted
+      # Secrets an in-vCluster pod/reconciler still needs (the SSO/OIDC
+      # ExternalSecret-materialised creds — gitea/harbor/grafana sso-configure
+      # + grafana runtime mount them). keycloak has NO host-minted non-DB
+      # Secret (its IdP creds are issued, not mounted), so it drops out
+      # entirely. The DB Secret is delivered natively in-vCluster (the
+      # shared-pg reflector re-target, sibling slot-16 change) — the toHost
+      # syncer is then its sole owner. `newapi/*` + `catalyst-system/*` keep
+      # their wildcards (out of this de-conflict's 4-app scope, no observed
+      # rotation-driven deadlock); the openbao EXACT-NAME entries (#3838)
+      # remain unchanged.
       secrets:
         enabled: true
         mappings:
           byName:
-            "keycloak/*": "keycloak/*"
-            "gitea/*": "gitea/*"
-            "harbor/*": "harbor/*"
+            # gitea/harbor/grafana — host-minted SSO/OIDC creds ONLY
+            # (the pod-mounted DB Secret is intentionally NOT imported).
+            "gitea/gitea-oauth-source-credentials": "gitea/gitea-oauth-source-credentials"
+            "harbor/harbor-sso-oidc-credentials": "harbor/harbor-sso-oidc-credentials"
+            "grafana/grafana-sso-oidc-credentials": "grafana/grafana-sso-oidc-credentials"
+            # keycloak — NO entry: the only host-minted Secret it needs is
+            # `keycloak-database-secret` (excluded above); it has no host SSO
+            # Secret (Keycloak IS the IdP, it issues client creds, mounts none).
             "newapi/*": "newapi/*"
-            "grafana/*": "grafana/*"
             "openbao/openbao-sso-oidc-credentials": "openbao/openbao-sso-oidc-credentials"
             "openbao/openbao-host-token-reviewer-static": "openbao/openbao-host-token-reviewer-static"
             "catalyst-system/*": "catalyst-system/*"

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -677,12 +677,21 @@ vcluster:
       # ExternalSecret-materialised creds — gitea/harbor/grafana sso-configure
       # + grafana runtime mount them). keycloak has NO host-minted non-DB
       # Secret (its IdP creds are issued, not mounted), so it drops out
-      # entirely. The DB Secret is delivered natively in-vCluster (the
-      # shared-pg reflector re-target, sibling slot-16 change) — the toHost
-      # syncer is then its sole owner. `newapi/*` + `catalyst-system/*` keep
-      # their wildcards (out of this de-conflict's 4-app scope, no observed
-      # rotation-driven deadlock); the openbao EXACT-NAME entries (#3838)
-      # remain unchanged.
+      # entirely. The DB Secret is delivered natively in-vCluster by the
+      # sibling slot-16 change (#3878, the implemented companion to #3876):
+      # bp-postgres 0.2.4's `reflect.mangledTarget` makes the shared-pg
+      # reflector materialise the vCluster-syncer-mangled host object
+      # `<secret>-x-<ns>-x-mgmt-vcluster` directly in host ns `mgmt` — the EXACT
+      # object the in-vc-mgmt pod mounts in single-namespace mode (the
+      # `MountVolume.SetUp … secret "keycloak-database-secret-x-keycloak-x-mgmt-
+      # vcluster" not found` name above). Because that object is reflector-owned
+      # and NEVER `sync.fromHost.secrets`-imported, the from-host syncer never
+      # touches it (no from-host↔to-host ownership fight) AND it carries the
+      # live randAlphaNum password (no missing credential on a fresh prov). The
+      # toHost necessary-sync is its only in-vc owner. `newapi/*` +
+      # `catalyst-system/*` keep their wildcards (out of this de-conflict's
+      # 4-app scope, no observed rotation-driven deadlock); the openbao
+      # EXACT-NAME entries (#3838) remain unchanged.
       secrets:
         enabled: true
         mappings:

--- a/platform/network-policies/chart/values.yaml
+++ b/platform/network-policies/chart/values.yaml
@@ -46,6 +46,14 @@ allowSystemNamespaces:
   - openbao
   - opentelemetry
   - openova-system
+  # org-services (#3859, 2026-06-19): the BSS/funnel control-plane tier was
+  # renamed `sme` → `org-services` (#3383 commit 7f6dfca23). The org-services
+  # namespace carries the marketplace/auth/billing/provisioning Deployments
+  # that the #3376 funnel depends on; it needs the same coarse-grained
+  # allow as the other control-plane namespaces so default-deny doesn't sever
+  # its inter-platform flows. The legacy `sme` entry stays one release for
+  # back-compat / any not-yet-migrated Sovereign.
+  - org-services
   - powerdns
   - reflector
   - reloader

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-4-1-data-services
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.2.3
+  version: 0.2.4
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,5 +1,30 @@
 apiVersion: v2
 name: bp-postgres
+# 0.2.4 — #3878 (companion to #3876, the cycle-1 vc-mgmt DB-secret deadlock):
+#   add the optional `reflect.mangledTarget` knob. When a binding declares it,
+#   the chart emits a SECOND hub connection Secret named with the vCluster
+#   syncer-mangled object name `<secretName>-x-<vclusterNamespace>-x-<vcluster>`
+#   (default vcluster `mgmt-vcluster`) and auto-pushes it (emberstack reflector
+#   annotations) into the vCluster's host namespace (default `mgmt`). That
+#   mangled object is EXACTLY the host Secret an in-vc-mgmt pod mounts in
+#   single-namespace mode (`MountVolume.SetUp … secret
+#   "<secretName>-x-<ns>-x-mgmt-vcluster" not found`). WHY: #3642 re-homed
+#   keycloak/gitea/harbor/grafana INTO vc-mgmt; their pod-mounted DB Secrets
+#   reached the in-vc pod ONLY via the bp-mgmt-vcluster `sync.fromHost.secrets`
+#   namespace wildcards, which #3876 REMOVED because on vcluster 0.23.0 a Secret
+#   that is BOTH fromHost-imported AND pod-mounted (so the toHost necessary-sync
+#   ALSO claims it) makes the from-host/to-host syncers fight → context deadline
+#   exceeded → app `Init:0/2` 20m+. With #3876 alone the DB Secret reaches the
+#   pod NOWHERE. This mangled-name reflect is the native delivery #3876's RCA
+#   promised: the DB Secret is NEVER fromHost-imported (no syncer contention →
+#   no deadlock) yet the live-password object the kubelet mounts is materialised
+#   by the host reflector (no missing credential on a fresh prov). It is the
+#   durable form of the hw167 hand-fix (validation agent created the keycloak DB
+#   Secret natively in-vCluster). The mangled copy carries byte-identical data
+#   to the consumer-namespace copy ($data assembled once in role-secrets.yaml).
+#   Bindings WITHOUT mangledTarget render byte-identical to 0.2.3 — additive.
+#   tests/postgres-render.sh Case 13 added. Lockstep: 16a (keycloak/gitea/
+#   harbor) + 16c (grafana) HR pins → 0.2.4. Refs #3876 #3374 #3737.
 # 0.2.3 — #3375 / #3768 follow-up (ONE canonical placement vocabulary on the
 #   wire): the hw158 #3375 browser-walk caught the bp-postgres New-instance
 #   picker serving the BANNED legacy dialect — `placementSchema.modes`
@@ -87,7 +112,7 @@ name: bp-postgres
 #   regions so it admits under BOTH the pre-#3370 CRD (hard-required) and the
 #   #3370 CRD (CEL-waived) — breaks the live upgrade-rollback deadlock that
 #   blocked keycloak->gitea->catalyst-platform on hw130.
-version: 0.2.3
+version: 0.2.4
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable

--- a/platform/postgres/chart/templates/role-secrets.yaml
+++ b/platform/postgres/chart/templates/role-secrets.yaml
@@ -120,6 +120,23 @@ identical to pre-0.2.2. */ -}}
 {{- $db := . }}
 {{- if and $db.reflect $db.reflect.secretName }}
 {{- $password := (get $owners $db.owner).password }}
+{{- /* Build the connection-contract stringData ONCE so every hub copy of
+this binding (the consumer-namespace copy below AND the optional vc-mgmt
+mangled-name copy in Pass 4) carries byte-identical data — same minted
+password, same host, same extraData/host/alias keys. A divergent copy would
+hand an in-vCluster pod a different password than the host CNPG role. */ -}}
+{{- $data := dict
+      "username" $db.owner
+      "user" $db.owner
+      "password" $password
+      "dbname" $db.name
+      "host" $consumerHost
+      "port" "5432"
+      "uri" (printf "postgresql://%s:%s@%s:5432/%s" $db.owner $password $consumerHost $db.name) }}
+{{- range $k, $v := $db.reflect.extraData }}{{ $_ := set $data $k $v }}{{ end }}
+{{- range $hk := $db.reflect.hostKeys }}{{ $_ := set $data $hk $consumerHost }}{{ end }}
+{{- range $hpk := $db.reflect.hostPortKeys }}{{ $_ := set $data $hpk (printf "%s:5432" $consumerHost) }}{{ end }}
+{{- range $alias := $db.reflect.passwordAliases }}{{ $_ := set $data $alias $password }}{{ end }}
 ---
 # Hub connection Secret — lives in the release namespace (always exists;
 # the #3283 anti-deadlock source-side pattern) and auto-pushes a
@@ -140,37 +157,65 @@ metadata:
     reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
     reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: {{ join "," $db.reflect.namespaces | quote }}
 stringData:
-  username: {{ $db.owner | quote }}
-  user: {{ $db.owner | quote }}
-  password: {{ $password | quote }}
-  dbname: {{ $db.name | quote }}
   # $consumerHost = `<instance>-rw` (singleton) or the ClusterMesh-global
   # `<instance>-mesh-rw` write alias (active-hot-standby) so the host
   # resolves in BOTH regions — see the $consumerHost note above (#3629).
-  host: {{ $consumerHost | quote }}
-  port: "5432"
-  # CNPG-app-Secret-parity connection string (0.1.5) — URI-style
-  # consumers (powerdns-admin SQLALCHEMY_DATABASE_URI) read this key
-  # verbatim. Password is chart-minted randAlphaNum (URL-safe).
-  uri: "postgresql://{{ $db.owner }}:{{ $password }}@{{ $consumerHost }}:5432/{{ $db.name }}"
-{{- range $k, $v := $db.reflect.extraData }}
+  # The connection-contract keys (username/user/password/dbname/host/port/uri
+  # + any extraData/hostKeys/hostPortKeys/passwordAliases) are pre-assembled
+  # in $data above so this copy and the optional vc-mgmt mangled copy
+  # (Pass 4) never drift.
+  {{- range $k, $v := $data }}
   {{ $k }}: {{ $v | quote }}
-{{- end }}
-{{- /* Topology-aware host injection (#3629). An env-style consumer often
-needs the DB host under its OWN variable name (grafana's GF_DATABASE_HOST),
-which previously meant a STATIC `<instance>-rw` literal in reflect.extraData
-— region-local, so it broke that consumer in the replica region. Declaring
-the key under reflect.hostKeys (host only) / reflect.hostPortKeys (host:5432)
-renders the topology-aware $consumerHost instead, so the consumer follows the
-singleton vs active-hot-standby switch automatically. */ -}}
-{{- range $hk := $db.reflect.hostKeys }}
-  {{ $hk }}: {{ $consumerHost | quote }}
-{{- end }}
-{{- range $hpk := $db.reflect.hostPortKeys }}
-  {{ $hpk }}: {{ printf "%s:5432" $consumerHost | quote }}
-{{- end }}
-{{- range $alias := $db.reflect.passwordAliases }}
-  {{ $alias }}: {{ $password | quote }}
+  {{- end }}
+{{- /* Pass 4 — vc-mgmt mangled-name delivery (#3878, companion to #3876).
+When a binding declares `reflect.mangledTarget`, emit a SECOND hub Secret
+named with the vCluster syncer-mangled object name
+`<secretName>-x-<vclusterNamespace>-x-<vcluster>` (default vcluster
+`mgmt-vcluster`) and auto-push it into the host namespace the vCluster runs
+in (`hostNamespace`, default `mgmt`). That mangled object is EXACTLY the host
+secret the in-vc-mgmt pod mounts in single-namespace mode (the failure string
+`MountVolume.SetUp … secret "<secretName>-x-<ns>-x-mgmt-vcluster" not found`).
+
+This is the native, host-reflector-driven delivery #3876's RCA comment
+promised: the pod-mounted DB Secret is NEVER `sync.fromHost.secrets`-imported
+(no from-host syncer claim → no from-host↔to-host ownership fight → no
+`context deadline exceeded` deadlock), yet the live-password object the
+kubelet mounts is materialised by this reflector copy → no missing credential
+on a fresh prov. The reflector preserves the source name on the auto-push, so
+the source Secret MUST itself be named the mangled string — hence a dedicated
+copy rather than an extra namespace on the plain hub Secret. Data is
+byte-identical to the plain hub copy ($data, assembled once above). */ -}}
+{{- if $db.reflect.mangledTarget }}
+{{- $mt := $db.reflect.mangledTarget }}
+{{- $vc := default "mgmt-vcluster" $mt.vcluster }}
+{{- $vcNs := required "reflect.mangledTarget.vclusterNamespace is required" $mt.vclusterNamespace }}
+{{- $hostNs := default "mgmt" $mt.hostNamespace }}
+{{- $mangledName := printf "%s-x-%s-x-%s" $db.reflect.secretName $vcNs $vc }}
+---
+# vc-mgmt mangled-name hub Secret (#3878). Auto-pushed into the vCluster's
+# host namespace as the exact object the in-vc-mgmt pod mounts — delivering
+# the DB credential natively WITHOUT a `sync.fromHost.secrets` mirror of the
+# pod-mounted Secret (which deadlocks on vcluster 0.23.0 per #3876).
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ $mangledName | quote }}
+  namespace: {{ $ns | quote }}
+  labels:
+    {{- include "bp-postgres.labels" $ctx | nindent 4 }}
+    catalyst.openova.io/binding-secret: {{ $db.name | quote }}
+    catalyst.openova.io/vcluster-mangled-target: {{ $hostNs | quote }}
+  annotations:
+    helm.sh/resource-policy: keep
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: {{ $hostNs | quote }}
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: {{ $hostNs | quote }}
+stringData:
+  {{- range $k, $v := $data }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -594,4 +594,51 @@ if echo "$default_line" | grep -qE '\bsingle-region\b'; then
   fail "#3375 REGRESSION: placementSchema.default is the banned 'single-region' (use canonical 'singleton')"
 fi
 
-echo "[render] PASS — bp-postgres render gate green (reuse proof: 1 Cluster, 2 Databases, 2 roles, 2 Secrets; master gate OFF → empty; 3-instance shapes locked; #3370 Application-CR self-registration locked; #3375 underscore-owner role-Secret sanitization locked; #3375/#3768 ONE canonical placement vocabulary locked)"
+# ── Case 13: #3878 — reflect.mangledTarget vc-mgmt native DB-secret delivery ─
+# Companion to #3876. A binding declaring reflect.mangledTarget emits a SECOND
+# hub Secret named `<secretName>-x-<vclusterNamespace>-x-<vcluster>` (default
+# vcluster `mgmt-vcluster`) that auto-pushes (reflection-auto-namespaces) into
+# the vCluster's host ns (default `mgmt`) — the exact object an in-vc-mgmt pod
+# mounts in single-namespace mode. Its data MUST be byte-identical to the plain
+# consumer-namespace copy. A binding WITHOUT mangledTarget emits NO mangled copy
+# (additive — pre-0.2.4 bindings render unchanged).
+echo "[render] Case 13: #3878 — reflect.mangledTarget → mangled vc-mgmt copy w/ identical data; no-mangle binding unchanged"
+cat > "$TMP/mangled.values.yaml" <<'YAML'
+enabled: true
+instance: { name: shared-pg, namespace: shared-data }
+topology: { mode: singleton, instances: 1 }
+databases:
+  - name: keycloak
+    owner: keycloak
+    consumer: { blueprint: bp-keycloak, mode: shared }
+    reflect:
+      secretName: keycloak-database-secret
+      namespaces: [keycloak]
+      mangledTarget: { vclusterNamespace: keycloak }
+  - name: gitea
+    owner: gitea
+    consumer: { blueprint: bp-gitea, mode: shared }
+    reflect: { secretName: gitea-database-secret, namespaces: [gitea] }
+YAML
+helm template shared-pg . -f "$TMP/mangled.values.yaml" --namespace shared-data \
+  --api-versions postgresql.cnpg.io/v1 \
+  --show-only templates/role-secrets.yaml > "$TMP/mangled.yaml" 2> "$TMP/mangled.err" || {
+  cat "$TMP/mangled.err" >&2; fail "mangledTarget render errored"; }
+# (a) the mangled copy exists with the canonical syncer name.
+grep -qE '^  name: "keycloak-database-secret-x-keycloak-x-mgmt-vcluster"$' "$TMP/mangled.yaml" \
+  || fail "#3878: keycloak mangled hub Secret 'keycloak-database-secret-x-keycloak-x-mgmt-vcluster' not rendered"
+# (b) the mangled copy auto-pushes into the vc-mgmt host ns 'mgmt'.
+awk '/name: "keycloak-database-secret-x-keycloak-x-mgmt-vcluster"/{f=1} f&&/reflection-auto-namespaces: "mgmt"/{print "OK"; exit}' "$TMP/mangled.yaml" | grep -q OK \
+  || fail "#3878: mangled keycloak Secret must reflection-auto-namespaces into 'mgmt'"
+# (c) data parity — the mangled copy carries the SAME password as the plain copy
+#     (so the in-vc pod gets a credential that matches the host CNPG role).
+plain_pw=$(awk '/^  name: "keycloak-database-secret"$/{f=1} f&&/^  password:/{print $2; exit}' "$TMP/mangled.yaml")
+mangled_pw=$(awk '/name: "keycloak-database-secret-x-keycloak-x-mgmt-vcluster"/{f=1} f&&/^  password:/{print $2; exit}' "$TMP/mangled.yaml")
+[ -n "$plain_pw" ] || fail "#3878: plain keycloak hub Secret password not found"
+[ "$plain_pw" = "$mangled_pw" ] || fail "#3878: mangled copy password ($mangled_pw) MUST equal the plain copy ($plain_pw) — a drift hands the pod a wrong credential"
+# (d) the no-mangle binding (gitea here) emits NO mangled copy — additive.
+if grep -qE 'gitea-database-secret-x-' "$TMP/mangled.yaml"; then
+  fail "#3878 REGRESSION: a binding WITHOUT reflect.mangledTarget must NOT emit a mangled copy"
+fi
+
+echo "[render] PASS — bp-postgres render gate green (reuse proof: 1 Cluster, 2 Databases, 2 roles, 2 Secrets; master gate OFF → empty; 3-instance shapes locked; #3370 Application-CR self-registration locked; #3375 underscore-owner role-Secret sanitization locked; #3375/#3768 ONE canonical placement vocabulary locked; #3878 reflect.mangledTarget vc-mgmt native DB-secret delivery locked)"

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2865,7 +2865,14 @@ name: bp-catalyst-platform
 # 1.4.695 — #3849 (Refs #3848): org-controller reads the keycloak SA secret from
 # the host-bridge (catalyst-openova-kc-credentials) instead of an intra-release
 # helm lookup that lost the ordering race on a cold install.
-version: 1.4.701
+version: 1.4.702
+# 1.4.702 — #3819 #3854 #3859 (Refs #3383 #3376): sme→org-services rename TAIL — the
+#   funnel/BSS control-plane templates + values default the namespace to `org-services`
+#   instead of the dead `sme` ns: provisioning-github-token / valkey-cross-ns-secret +
+#   -policy destNamespace+sourceNamespace, ferretdb + cnpg-cluster + configmap POSTGRES_HOST
+#   namespace fallbacks, the pdm-basicauth + baseline-catalyst-system + kyverno-qa-fixture +
+#   network-policies allowSystemNamespaces lists. The `sme` tier-enum value + the wire-stable
+#   sme-pg cluster/owner role names are intentionally preserved.
 # 1.4.699 — #3856 (Refs #3375 #3581): ONE canonical DR vocabulary in the catalog.
 # catalog-seed/blueprints.yaml bp-cnpg-pair + bp-continuum carried the banned
 # un-hyphenated `active-hotstandby` topology token (modes/default/tags) → the

--- a/products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml
+++ b/products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml
@@ -78,7 +78,10 @@ when qaFixtures is disabled.
      <svc>-x-<ns>-x-mgmt-vcluster Services) live in host ns `mgmt`.
      The plain loki/mimir/tempo entries stay for Sovereigns that keep
      the host-side placement via per-Sovereign overlay. */}}
-{{- $allowedPlatform := .Values.security.baselineCnp.allowedPlatformNamespaces | default (list "keycloak" "gitea" "powerdns" "cnpg-system" "openbao" "harbor" "nats-system" "loki" "mimir" "tempo" "alloy" "opentelemetry" "external-secrets-system" "cert-manager" "sme" "newapi" "mgmt") }}
+{{- /* #3859: ns `sme` → `org-services` (#3383). org-services hosts the
+     BSS/funnel control-plane Deployments; the legacy `sme` entry stays one
+     release for back-compat / any not-yet-migrated Sovereign. */}}
+{{- $allowedPlatform := .Values.security.baselineCnp.allowedPlatformNamespaces | default (list "keycloak" "gitea" "powerdns" "cnpg-system" "openbao" "harbor" "nats-system" "loki" "mimir" "tempo" "alloy" "opentelemetry" "external-secrets-system" "cert-manager" "org-services" "sme" "newapi" "mgmt") }}
 {{- $allowedIngressNs := .Values.security.baselineCnp.allowedIngressNamespaces | default (list "catalyst" "flux-system" "kube-system" "oidc-gate") }}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/products/catalyst/chart/templates/org-services/cnpg-cluster.yaml
+++ b/products/catalyst/chart/templates/org-services/cnpg-cluster.yaml
@@ -75,7 +75,7 @@ apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
   name: {{ .Values.smePostgres.cluster.name | default "sme-pg" }}
-  namespace: {{ .Values.smePostgres.cluster.namespace | default "sme" }}
+  namespace: {{ .Values.smePostgres.cluster.namespace | default "org-services" }}
   labels:
     catalyst.openova.io/blueprint: bp-catalyst-platform
     catalyst.openova.io/component: sme-postgres
@@ -91,9 +91,9 @@ spec:
   inheritedMetadata:
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: {{ .Values.smePostgres.cluster.namespace | default "sme" | quote }}
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: {{ .Values.smePostgres.cluster.namespace | default "org-services" | quote }}
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: {{ .Values.smePostgres.cluster.namespace | default "sme" | quote }}
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: {{ .Values.smePostgres.cluster.namespace | default "org-services" | quote }}
 
   bootstrap:
     initdb:

--- a/products/catalyst/chart/templates/org-services/configmap.yaml
+++ b/products/catalyst/chart/templates/org-services/configmap.yaml
@@ -189,7 +189,7 @@ data:
   # #3370 — smePostgres.externalHost (set by slot 13 in shared mode)
   # points the whole mesh at the shared-pg-c instance; empty = the
   # bundled sme-pg-rw Service (byte-identical default).
-  POSTGRES_HOST: "{{ .Values.smePostgres.externalHost | default (printf "%s-rw.%s.svc.cluster.local" (.Values.smePostgres.cluster.name | default "sme-pg") (.Values.smePostgres.cluster.namespace | default "sme")) }}"
+  POSTGRES_HOST: "{{ .Values.smePostgres.externalHost | default (printf "%s-rw.%s.svc.cluster.local" (.Values.smePostgres.cluster.name | default "sme-pg") (.Values.smePostgres.cluster.namespace | default "org-services")) }}"
   POSTGRES_PORT: "{{ .Values.smeServices.ferretdb.postgresPort | default 5432 }}"
 
   # ---- event bus ------------------------------------------------------------

--- a/products/catalyst/chart/templates/org-services/ferretdb.yaml
+++ b/products/catalyst/chart/templates/org-services/ferretdb.yaml
@@ -54,7 +54,7 @@ Sovereign install renders cleanly without operator input.
 */}}
 {{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
 {{- $ferret := .Values.smeServices.ferretdb -}}
-{{- $ns := $ferret.namespace | default "sme" -}}
+{{- $ns := $ferret.namespace | default "org-services" -}}
 {{- $pgService := .Values.smePostgres.externalHost | default (printf "%s-rw.%s.svc.cluster.local" (.Values.smePostgres.cluster.name | default "sme-pg") $ns) -}}
 {{- $pgPort := $ferret.postgresPort | default 5432 -}}
 {{- $pgDB := $ferret.postgresDatabase | default "sme_documents" -}}

--- a/products/catalyst/chart/templates/org-services/provisioning-github-token.yaml
+++ b/products/catalyst/chart/templates/org-services/provisioning-github-token.yaml
@@ -130,7 +130,7 @@ Cutover ownership handover (TBD-C18b, 2026-05-18):
 {{- $sourceNamespace := .Values.smeServices.provisioning.gitToken.patSourceNamespace | default .Release.Namespace -}}
 {{- $sourceSecretName := .Values.smeServices.provisioning.gitToken.patSourceSecretName | default "catalyst-gitea-token" -}}
 {{- $sourcePatKey := .Values.smeServices.provisioning.gitToken.patSourceKey | default "token" -}}
-{{- $destNamespace := .Values.smeServices.provisioning.gitToken.destNamespace | default "sme" -}}
+{{- $destNamespace := .Values.smeServices.provisioning.gitToken.destNamespace | default "org-services" -}}
 {{- $destSecretName := .Values.smeServices.provisioning.gitToken.destSecretName | default "provisioning-github-token" -}}
 {{- $destKey := .Values.smeServices.provisioning.gitToken.destKey | default "GITHUB_TOKEN" -}}
 {{- /* Lookup the destination Secret first to detect whether Step 09 of

--- a/products/catalyst/chart/templates/org-services/valkey-cross-ns-policy.yaml
+++ b/products/catalyst/chart/templates/org-services/valkey-cross-ns-policy.yaml
@@ -71,7 +71,7 @@ metadata:
   annotations:
     description: |
       Allow ingress on TCP/{{ $valkey.port | default 6379 }} from pods in
-      the `{{ $valkey.crossNsPolicy.sourceNamespace | default "sme" }}`
+      the `{{ $valkey.crossNsPolicy.sourceNamespace | default "org-services" }}`
       namespace to bp-valkey workloads. Defense-in-depth — bp-valkey's
       upstream NetworkPolicy already permits port 6379 from any source.
 spec:
@@ -85,7 +85,7 @@ spec:
   ingress:
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: {{ $valkey.crossNsPolicy.sourceNamespace | default "sme" }}
+            k8s:io.kubernetes.pod.namespace: {{ $valkey.crossNsPolicy.sourceNamespace | default "org-services" }}
       toPorts:
         - ports:
             - port: {{ $valkey.port | default 6379 | quote }}

--- a/products/catalyst/chart/templates/org-services/valkey-cross-ns-secret.yaml
+++ b/products/catalyst/chart/templates/org-services/valkey-cross-ns-secret.yaml
@@ -54,7 +54,7 @@ flow through .Values.smeServices.valkey.* with sensible defaults.
 {{- $sourceNamespace := .Values.smeServices.valkey.namespace | default "valkey" -}}
 {{- $sourceSecretName := .Values.smeServices.valkey.sourceSecretName | default "valkey" -}}
 {{- $sourcePasswordKey := .Values.smeServices.valkey.sourcePasswordKey | default "valkey-password" -}}
-{{- $destNamespace := .Values.smeServices.valkey.destNamespace | default "sme" -}}
+{{- $destNamespace := .Values.smeServices.valkey.destNamespace | default "org-services" -}}
 {{- $destSecretName := .Values.smeServices.valkey.destSecretName | default "sme-valkey-auth" -}}
 {{- $sourceSecret := lookup "v1" "Secret" $sourceNamespace $sourceSecretName -}}
 {{- if and $sourceSecret $sourceSecret.data (index $sourceSecret.data $sourcePasswordKey) -}}

--- a/products/catalyst/chart/templates/qa-fixtures/kyverno-policies-qa.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/kyverno-policies-qa.yaml
@@ -56,7 +56,7 @@
   all of which are platform namespaces that legitimately host pods
   with privileged-class capabilities (CSI drivers, CNI, etc.).
 */ -}}
-{{- $excludedNamespaces := list "kube-system" "cnpg-system" "flux-system" "catalyst-system" "catalyst" "kyverno" "cilium" "openbao" "keycloak" "gitea" "powerdns" "sme" }}
+{{- $excludedNamespaces := list "kube-system" "cnpg-system" "flux-system" "catalyst-system" "catalyst" "kyverno" "cilium" "openbao" "keycloak" "gitea" "powerdns" "org-services" "sme" }}
 {{- $enforceMode := .Values.qaFixtures.kyvernoEnforceMode | default "Enforce" }}
 {{- $auditMode := "Audit" }}
 ---

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1620,7 +1620,7 @@ smeServices:
     # or key.
     sourceSecretName: valkey
     sourcePasswordKey: valkey-password
-    destNamespace: sme
+    destNamespace: org-services       # #3383: was `sme`
     destSecretName: sme-valkey-auth
     crossNsPolicy:
       # Render templates/org-services/valkey-cross-ns-policy.yaml — a
@@ -1637,7 +1637,7 @@ smeServices:
       # carve-out). Re-enable + override `namespace` only for a
       # host-placed valkey.
       enabled: false
-      sourceNamespace: sme
+      sourceNamespace: org-services   # #3383: was `sme`
   # ─── provisioning service GitHub token (issue #866) ──────────────────
   # The SME `provisioning` service Deployment references
   # `secret/provisioning-github-token` with key `GITHUB_TOKEN`. On
@@ -1685,7 +1685,7 @@ smeServices:
       # Destination: the Secret + key shape that the provisioning
       # Deployment's secretKeyRef in
       # templates/org-services/provisioning.yaml reads.
-      destNamespace: sme
+      destNamespace: org-services     # #3383: was `sme`
       destSecretName: provisioning-github-token
       destKey: GITHUB_TOKEN
     # ─── Provisioning service GitOps env (issues #940 + #944) ──────────


### PR DESCRIPTION
## What

Completes the `sme` → `org-services` namespace rename TAIL (#3383) that was wedging the #3376 funnel control plane. The auto-created namespace is `org-services` (`templates/org-services/org-namespace.yaml`), but several funnel/BSS workloads and platform allow-lists still hard-coded the now-absent `sme` namespace, so:

- a marketplace-enabled umbrella upgrade aborted with `namespaces "sme" not found` (#3854),
- org-services pods never received the reflected `ghcr-pull` / pdm-basicauth secrets (#3819 tail), and
- the residual policy refs left the org-services tier wedged (#3859 tail).

Consolidates the namespace-rename residue from **#3819 + #3854 + #3859**.

## Changes — every residual hard-coded `sme` NAMESPACE ref re-pointed to `org-services`

`products/catalyst/chart` templates + values:
- `org-services/cnpg-cluster.yaml` — cluster namespace + `reflection-{allowed,auto}-namespaces`
- `org-services/configmap.yaml` — `POSTGRES_HOST` namespace segment
- `org-services/ferretdb.yaml` — namespace fallback
- `org-services/provisioning-github-token.yaml` — `destNamespace` fallback
- `org-services/valkey-cross-ns-secret.yaml` — `destNamespace` fallback
- `org-services/valkey-cross-ns-policy.yaml` — `sourceNamespace` fallback (×2)
- `network-policies/baseline-catalyst-system.yaml` — `allowedPlatformNamespaces`
- `qa-fixtures/kyverno-policies-qa.yaml` — `excludedNamespaces`
- `values.yaml` — `valkey.destNamespace`, `valkey.crossNsPolicy.sourceNamespace`, `provisioning.gitToken.destNamespace`

Platform + infra:
- `platform/network-policies/chart/values.yaml` — `allowSystemNamespaces`
- `infra/providers/_shared/cloudinit-control-plane.tftpl` — `pdm-basicauth` reflection allow-list

The `org-services` carve-outs in `bp-mgmt-vcluster`, `bp-rtz-vcluster`, and `kyverno-policies` (#3859 Gaps 1-3) were already landed on `main`; the legacy `sme` entries there stay one release for back-compat.

## Preserved (intentionally not renamed)

- The `sme` **TenantKind tier-enum value** (`organization-sample-invalid.yaml` `tier: sme`, `manifests.go` `Tier is sme | corporate`) — data value, not a namespace.
- The wire-stable **`sme-pg` CNPG cluster name** and **`sme` postgres owner/role name** (`cnpg-cluster.yaml:101/112`) — persisted-data identifiers.

## Render proof (no prov)

`helm template` with marketplace enabled (the config that emits org-services resources) and with marketplace off:

```
[marketplace ON]  namespace: sme count = 0
[marketplace OFF] namespace: sme count = 0
```

42 org-services resources render with `namespace: org-services` (admin, auth, billing, catalog, console, domain, ferretdb, gateway, marketplace, notification, provisioning, tenant, …). The `bp-mgmt-vcluster` / `bp-rtz-vcluster` / `network-policies` / `kyverno-policies` charts all render `org-services` in their allow/exclude lists.

## Version

`bp-catalyst-platform` chart `1.4.701` → `1.4.702`, slot-13 pin lockstep (`clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`). The deploy-bot may auto-advance the patch — lockstep maintained.

Refs #3819 #3854 #3859 #3383 #3376

🤖 Generated with [Claude Code](https://claude.com/claude-code)