### PR TITLE
fix(bp-catalyst-platform): sme→org-services rename TAIL — funnel/BSS control-plane ns defaults + reflector/policy allow-lists (1.4.702)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1039,7 +1039,9 @@ spec:
             # 1.4.696 — #3859 (Refs #3376): wire TENANT_PARENT_DOMAIN onto the provisioning Deployment (smeServices.provisioning.tenantParentDomain ← ${TENANT_PARENT_DOMAIN}). The per-Org provisioning consumer seeds spec.tenantPublic ONLY when a parent domain is set; without it every customer Org minted with NO TenantPublic HTTPRoute → the customer's own console + purchased app returned ERR_CONNECTION_REFUSED (the funnel terminal failure on every prior env, first root-caused driving walkorg/hw167). Default "" = Catalyst-Zero byte-identical. NOTE re-pin: 1.4.686–1.4.695 publish-lag may apply — verify ghcr tag before a fresh prov pins this.
             # 1.4.697 — merge-train resolution (Refs #3376 #3848): supersedes the auto-bump hook's 1.4.695; lands #3859 (1.4.696, TENANT_PARENT_DOMAIN funnel terminal) on top of #3849 (1.4.695, org-controller KC-secret host-bridge). Both additive + independent; pin bumped lockstep with the published OCI artifact.
             # 1.4.699 — #3856 (Refs #3375 #3581): ONE canonical DR vocabulary — catalog-seed (bp-cnpg-pair + bp-continuum) + cnpgpair.yaml CRD enum drop the banned un-hyphenated `active-hotstandby` for the canonical `active-hot-standby`; catalyst-ui Instances table canonicalizes for display so the bp-postgres chip renders clean. Catalyst-Zero render byte-unchanged. NOTE re-pin: the catalyst-build auto-bump may publish a higher patch (it increments from Chart.yaml at merge) — verify the ghcr tag before a fresh prov pins this.
-      version: 1.4.701
+      # 1.4.702 — #3819 #3854 #3859 (Refs #3383 #3376): sme→org-services rename TAIL — funnel/BSS
+      #   control-plane namespace defaults + reflector/policy allow-lists re-pointed at org-services.
+      version: 1.4.702
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -267,9 +267,9 @@ write_files:
         namespace: flux-system
         annotations:
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "sme,catalyst,catalyst-system,gitea,harbor"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "sme,catalyst,catalyst-system,gitea,harbor"
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "org-services,catalyst,catalyst-system,gitea,harbor"
       type: Opaque
       data:
         username: ${base64encode(pdm_basic_auth_user)}

--- a/platform/network-policies/chart/values.yaml
+++ b/platform/network-policies/chart/values.yaml
@@ -46,6 +46,14 @@ allowSystemNamespaces:
   - openbao
   - opentelemetry
   - openova-system
+  # org-services (#3859, 2026-06-19): the BSS/funnel control-plane tier was
+  # renamed `sme` → `org-services` (#3383 commit 7f6dfca23). The org-services
+  # namespace carries the marketplace/auth/billing/provisioning Deployments
+  # that the #3376 funnel depends on; it needs the same coarse-grained
+  # allow as the other control-plane namespaces so default-deny doesn't sever
+  # its inter-platform flows. The legacy `sme` entry stays one release for
+  # back-compat / any not-yet-migrated Sovereign.
+  - org-services
   - powerdns
   - reflector
   - reloader

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -2865,7 +2865,14 @@ name: bp-catalyst-platform
 # 1.4.695 — #3849 (Refs #3848): org-controller reads the keycloak SA secret from
 # the host-bridge (catalyst-openova-kc-credentials) instead of an intra-release
 # helm lookup that lost the ordering race on a cold install.
-version: 1.4.701
+version: 1.4.702
+# 1.4.702 — #3819 #3854 #3859 (Refs #3383 #3376): sme→org-services rename TAIL — the
+#   funnel/BSS control-plane templates + values default the namespace to `org-services`
+#   instead of the dead `sme` ns: provisioning-github-token / valkey-cross-ns-secret +
+#   -policy destNamespace+sourceNamespace, ferretdb + cnpg-cluster + configmap POSTGRES_HOST
+#   namespace fallbacks, the pdm-basicauth + baseline-catalyst-system + kyverno-qa-fixture +
+#   network-policies allowSystemNamespaces lists. The `sme` tier-enum value + the wire-stable
+#   sme-pg cluster/owner role names are intentionally preserved.
 # 1.4.699 — #3856 (Refs #3375 #3581): ONE canonical DR vocabulary in the catalog.
 # catalog-seed/blueprints.yaml bp-cnpg-pair + bp-continuum carried the banned
 # un-hyphenated `active-hotstandby` topology token (modes/default/tags) → the

--- a/products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml
+++ b/products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml
@@ -78,7 +78,10 @@ when qaFixtures is disabled.
      <svc>-x-<ns>-x-mgmt-vcluster Services) live in host ns `mgmt`.
      The plain loki/mimir/tempo entries stay for Sovereigns that keep
      the host-side placement via per-Sovereign overlay. */}}
-{{- $allowedPlatform := .Values.security.baselineCnp.allowedPlatformNamespaces | default (list "keycloak" "gitea" "powerdns" "cnpg-system" "openbao" "harbor" "nats-system" "loki" "mimir" "tempo" "alloy" "opentelemetry" "external-secrets-system" "cert-manager" "sme" "newapi" "mgmt") }}
+{{- /* #3859: ns `sme` → `org-services` (#3383). org-services hosts the
+     BSS/funnel control-plane Deployments; the legacy `sme` entry stays one
+     release for back-compat / any not-yet-migrated Sovereign. */}}
+{{- $allowedPlatform := .Values.security.baselineCnp.allowedPlatformNamespaces | default (list "keycloak" "gitea" "powerdns" "cnpg-system" "openbao" "harbor" "nats-system" "loki" "mimir" "tempo" "alloy" "opentelemetry" "external-secrets-system" "cert-manager" "org-services" "sme" "newapi" "mgmt") }}
 {{- $allowedIngressNs := .Values.security.baselineCnp.allowedIngressNamespaces | default (list "catalyst" "flux-system" "kube-system" "oidc-gate") }}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/products/catalyst/chart/templates/org-services/cnpg-cluster.yaml
+++ b/products/catalyst/chart/templates/org-services/cnpg-cluster.yaml
@@ -75,7 +75,7 @@ apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
   name: {{ .Values.smePostgres.cluster.name | default "sme-pg" }}
-  namespace: {{ .Values.smePostgres.cluster.namespace | default "sme" }}
+  namespace: {{ .Values.smePostgres.cluster.namespace | default "org-services" }}
   labels:
     catalyst.openova.io/blueprint: bp-catalyst-platform
     catalyst.openova.io/component: sme-postgres
@@ -91,9 +91,9 @@ spec:
   inheritedMetadata:
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: {{ .Values.smePostgres.cluster.namespace | default "sme" | quote }}
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: {{ .Values.smePostgres.cluster.namespace | default "org-services" | quote }}
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: {{ .Values.smePostgres.cluster.namespace | default "sme" | quote }}
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: {{ .Values.smePostgres.cluster.namespace | default "org-services" | quote }}
 
   bootstrap:
     initdb:

--- a/products/catalyst/chart/templates/org-services/configmap.yaml
+++ b/products/catalyst/chart/templates/org-services/configmap.yaml
@@ -189,7 +189,7 @@ data:
   # #3370 — smePostgres.externalHost (set by slot 13 in shared mode)
   # points the whole mesh at the shared-pg-c instance; empty = the
   # bundled sme-pg-rw Service (byte-identical default).
-  POSTGRES_HOST: "{{ .Values.smePostgres.externalHost | default (printf "%s-rw.%s.svc.cluster.local" (.Values.smePostgres.cluster.name | default "sme-pg") (.Values.smePostgres.cluster.namespace | default "sme")) }}"
+  POSTGRES_HOST: "{{ .Values.smePostgres.externalHost | default (printf "%s-rw.%s.svc.cluster.local" (.Values.smePostgres.cluster.name | default "sme-pg") (.Values.smePostgres.cluster.namespace | default "org-services")) }}"
   POSTGRES_PORT: "{{ .Values.smeServices.ferretdb.postgresPort | default 5432 }}"
 
   # ---- event bus ------------------------------------------------------------

--- a/products/catalyst/chart/templates/org-services/ferretdb.yaml
+++ b/products/catalyst/chart/templates/org-services/ferretdb.yaml
@@ -54,7 +54,7 @@ Sovereign install renders cleanly without operator input.
 */}}
 {{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
 {{- $ferret := .Values.smeServices.ferretdb -}}
-{{- $ns := $ferret.namespace | default "sme" -}}
+{{- $ns := $ferret.namespace | default "org-services" -}}
 {{- $pgService := .Values.smePostgres.externalHost | default (printf "%s-rw.%s.svc.cluster.local" (.Values.smePostgres.cluster.name | default "sme-pg") $ns) -}}
 {{- $pgPort := $ferret.postgresPort | default 5432 -}}
 {{- $pgDB := $ferret.postgresDatabase | default "sme_documents" -}}

--- a/products/catalyst/chart/templates/org-services/provisioning-github-token.yaml
+++ b/products/catalyst/chart/templates/org-services/provisioning-github-token.yaml
@@ -130,7 +130,7 @@ Cutover ownership handover (TBD-C18b, 2026-05-18):
 {{- $sourceNamespace := .Values.smeServices.provisioning.gitToken.patSourceNamespace | default .Release.Namespace -}}
 {{- $sourceSecretName := .Values.smeServices.provisioning.gitToken.patSourceSecretName | default "catalyst-gitea-token" -}}
 {{- $sourcePatKey := .Values.smeServices.provisioning.gitToken.patSourceKey | default "token" -}}
-{{- $destNamespace := .Values.smeServices.provisioning.gitToken.destNamespace | default "sme" -}}
+{{- $destNamespace := .Values.smeServices.provisioning.gitToken.destNamespace | default "org-services" -}}
 {{- $destSecretName := .Values.smeServices.provisioning.gitToken.destSecretName | default "provisioning-github-token" -}}
 {{- $destKey := .Values.smeServices.provisioning.gitToken.destKey | default "GITHUB_TOKEN" -}}
 {{- /* Lookup the destination Secret first to detect whether Step 09 of

--- a/products/catalyst/chart/templates/org-services/valkey-cross-ns-policy.yaml
+++ b/products/catalyst/chart/templates/org-services/valkey-cross-ns-policy.yaml
@@ -71,7 +71,7 @@ metadata:
   annotations:
     description: |
       Allow ingress on TCP/{{ $valkey.port | default 6379 }} from pods in
-      the `{{ $valkey.crossNsPolicy.sourceNamespace | default "sme" }}`
+      the `{{ $valkey.crossNsPolicy.sourceNamespace | default "org-services" }}`
       namespace to bp-valkey workloads. Defense-in-depth — bp-valkey's
       upstream NetworkPolicy already permits port 6379 from any source.
 spec:
@@ -85,7 +85,7 @@ spec:
   ingress:
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: {{ $valkey.crossNsPolicy.sourceNamespace | default "sme" }}
+            k8s:io.kubernetes.pod.namespace: {{ $valkey.crossNsPolicy.sourceNamespace | default "org-services" }}
       toPorts:
         - ports:
             - port: {{ $valkey.port | default 6379 | quote }}

--- a/products/catalyst/chart/templates/org-services/valkey-cross-ns-secret.yaml
+++ b/products/catalyst/chart/templates/org-services/valkey-cross-ns-secret.yaml
@@ -54,7 +54,7 @@ flow through .Values.smeServices.valkey.* with sensible defaults.
 {{- $sourceNamespace := .Values.smeServices.valkey.namespace | default "valkey" -}}
 {{- $sourceSecretName := .Values.smeServices.valkey.sourceSecretName | default "valkey" -}}
 {{- $sourcePasswordKey := .Values.smeServices.valkey.sourcePasswordKey | default "valkey-password" -}}
-{{- $destNamespace := .Values.smeServices.valkey.destNamespace | default "sme" -}}
+{{- $destNamespace := .Values.smeServices.valkey.destNamespace | default "org-services" -}}
 {{- $destSecretName := .Values.smeServices.valkey.destSecretName | default "sme-valkey-auth" -}}
 {{- $sourceSecret := lookup "v1" "Secret" $sourceNamespace $sourceSecretName -}}
 {{- if and $sourceSecret $sourceSecret.data (index $sourceSecret.data $sourcePasswordKey) -}}

--- a/products/catalyst/chart/templates/qa-fixtures/kyverno-policies-qa.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/kyverno-policies-qa.yaml
@@ -56,7 +56,7 @@
   all of which are platform namespaces that legitimately host pods
   with privileged-class capabilities (CSI drivers, CNI, etc.).
 */ -}}
-{{- $excludedNamespaces := list "kube-system" "cnpg-system" "flux-system" "catalyst-system" "catalyst" "kyverno" "cilium" "openbao" "keycloak" "gitea" "powerdns" "sme" }}
+{{- $excludedNamespaces := list "kube-system" "cnpg-system" "flux-system" "catalyst-system" "catalyst" "kyverno" "cilium" "openbao" "keycloak" "gitea" "powerdns" "org-services" "sme" }}
 {{- $enforceMode := .Values.qaFixtures.kyvernoEnforceMode | default "Enforce" }}
 {{- $auditMode := "Audit" }}
 ---

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1620,7 +1620,7 @@ smeServices:
     # or key.
     sourceSecretName: valkey
     sourcePasswordKey: valkey-password
-    destNamespace: sme
+    destNamespace: org-services       # #3383: was `sme`
     destSecretName: sme-valkey-auth
     crossNsPolicy:
       # Render templates/org-services/valkey-cross-ns-policy.yaml — a
@@ -1637,7 +1637,7 @@ smeServices:
       # carve-out). Re-enable + override `namespace` only for a
       # host-placed valkey.
       enabled: false
-      sourceNamespace: sme
+      sourceNamespace: org-services   # #3383: was `sme`
   # ─── provisioning service GitHub token (issue #866) ──────────────────
   # The SME `provisioning` service Deployment references
   # `secret/provisioning-github-token` with key `GITHUB_TOKEN`. On
@@ -1685,7 +1685,7 @@ smeServices:
       # Destination: the Secret + key shape that the provisioning
       # Deployment's secretKeyRef in
       # templates/org-services/provisioning.yaml reads.
-      destNamespace: sme
+      destNamespace: org-services     # #3383: was `sme`
       destSecretName: provisioning-github-token
       destKey: GITHUB_TOKEN
     # ─── Provisioning service GitOps env (issues #940 + #944) ──────────


### PR DESCRIPTION
## What

Completes the `sme` → `org-services` namespace rename TAIL (#3383) that was wedging the #3376 funnel control plane. The auto-created namespace is `org-services` (`templates/org-services/org-namespace.yaml`), but several funnel/BSS workloads and platform allow-lists still hard-coded the now-absent `sme` namespace, so:

- a marketplace-enabled umbrella upgrade aborted with `namespaces "sme" not found` (#3854),
- org-services pods never received the reflected `ghcr-pull` / pdm-basicauth secrets (#3819 tail), and
- the residual policy refs left the org-services tier wedged (#3859 tail).

Consolidates the namespace-rename residue from **#3819 + #3854 + #3859**.

## Changes — every residual hard-coded `sme` NAMESPACE ref re-pointed to `org-services`

`products/catalyst/chart` templates + values:
- `org-services/cnpg-cluster.yaml` — cluster namespace + `reflection-{allowed,auto}-namespaces`
- `org-services/configmap.yaml` — `POSTGRES_HOST` namespace segment
- `org-services/ferretdb.yaml` — namespace fallback
- `org-services/provisioning-github-token.yaml` — `destNamespace` fallback
- `org-services/valkey-cross-ns-secret.yaml` — `destNamespace` fallback
- `org-services/valkey-cross-ns-policy.yaml` — `sourceNamespace` fallback (×2)
- `network-policies/baseline-catalyst-system.yaml` — `allowedPlatformNamespaces`
- `qa-fixtures/kyverno-policies-qa.yaml` — `excludedNamespaces`
- `values.yaml` — `valkey.destNamespace`, `valkey.crossNsPolicy.sourceNamespace`, `provisioning.gitToken.destNamespace`

Platform + infra:
- `platform/network-policies/chart/values.yaml` — `allowSystemNamespaces`
- `infra/providers/_shared/cloudinit-control-plane.tftpl` — `pdm-basicauth` reflection allow-list

The `org-services` carve-outs in `bp-mgmt-vcluster`, `bp-rtz-vcluster`, and `kyverno-policies` (#3859 Gaps 1-3) were already landed on `main`; the legacy `sme` entries there stay one release for back-compat.

## Preserved (intentionally not renamed)

- The `sme` **TenantKind tier-enum value** (`organization-sample-invalid.yaml` `tier: sme`, `manifests.go` `Tier is sme | corporate`) — data value, not a namespace.
- The wire-stable **`sme-pg` CNPG cluster name** and **`sme` postgres owner/role name** (`cnpg-cluster.yaml:101/112`) — persisted-data identifiers.

## Render proof (no prov)

`helm template` with marketplace enabled (emits org-services resources) and with marketplace off:

```
[marketplace ON]  namespace: sme count = 0
[marketplace OFF] namespace: sme count = 0
```

42 org-services resources render with `namespace: org-services` (admin, auth, billing, catalog, console, domain, ferretdb, gateway, marketplace, notification, provisioning, tenant, …). The `bp-mgmt-vcluster` / `bp-rtz-vcluster` / `network-policies` / `kyverno-policies` charts all render `org-services` in their allow/exclude lists.

## Version

`bp-catalyst-platform` chart `1.4.701` → `1.4.702`, slot-13 pin lockstep (`clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`). The deploy-bot may auto-advance the patch — lockstep maintained.

Refs #3819 #3854 #3859 #3383 #3376

🤖 Generated with [Claude Code](https://claude.com/claude-code)