### PR TITLE
fix(cycle-1.5 tail): unblock bp-postgres 0.2.4 publish + lockstep bp-newapi 1.4.112 pins

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -295,7 +295,10 @@ spec:
       # vc-mgmt; the CNPG-owner seams render host-side via slot 80a host-seams.
       # database.existingSecret is wired (suppress) to the host-rendered,
       # mirrored-in DSN Secret so the Deployment render-gate resolves at mgmt.
-      version: 1.4.111
+      # 1.4.112: lockstep to the auto-bumped + published upstream-v0.13.2 chart
+      # (the auto-bump commit advanced the chart but its Blueprint-Release
+      # lockstep step failed, leaving this pin stale at 1.4.111).
+      version: 1.4.112
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
+++ b/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
@@ -69,7 +69,8 @@ spec:
       chart: bp-newapi
       # 1.4.111 (#3831): the placement.role render-split chart. Lockstep with
       # slot 80's pin + platform/newapi blueprint.yaml.
-      version: 1.4.111
+      # 1.4.112: lockstep to the auto-bumped + published upstream-v0.13.2 chart.
+      version: 1.4.112
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.111
+  version: 1.4.112
   card:
     title: NewAPI
     summary: |

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -24,7 +24,13 @@
 
 set -euo pipefail
 
-CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+# Canonicalize to an ABSOLUTE path: CI invokes this as
+# `bash postgres-render.sh platform/postgres/chart` (a RELATIVE arg), and the
+# `cd "$CHART_DIR"` below would otherwise make the later `$CHART_DIR/../blueprint.yaml`
+# (Case 12) resolve against the post-cd cwd → blueprint.yaml-not-found, silently
+# gating the bp-postgres helm-push (no 0.2.3/0.2.4 ever published). Absolute-izing
+# here makes every `$CHART_DIR/...` reference stable regardless of the cd.
+CHART_DIR="$(cd "${1:-$(dirname "$0")/..}" && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 


### PR DESCRIPTION
Cycle-1.5 train tail — two post-merge lockstep/publish fixes surfaced while loading the train into main.

## 1. bp-postgres render-gate portability (unblocks the gated 0.2.4 helm-push)
The Blueprint-Release `Run chart integration tests` step invokes `bash postgres-render.sh platform/postgres/chart` with a RELATIVE chart-dir arg. The script `cd "$CHART_DIR"`s, so Case 12's later `$CHART_DIR/../blueprint.yaml` lookup resolved against the post-cd cwd → 'blueprint.yaml not found' → exit 1 → the helm-push step never ran. This silently gated EVERY bp-postgres publish: ghcr jumps 0.2.2 → (no 0.2.3) → 0.2.4-never-landed, with the chart + all three 16a/16c/16d slot pins already lockstepped at 0.2.4 against a non-existent OCI tag. Fix: canonicalize the arg to an absolute path so every `$CHART_DIR/...` reference is cd-stable. Verified the exact CI relative-arg invocation now passes Case 12 + the full gate (Cases 1-13).

## 2. bp-newapi 1.4.112 pin lockstep
The auto-bump commit advanced `platform/newapi/chart/Chart.yaml` 1.4.111 → 1.4.112 (upstream v0.13.2) and the 1.4.112 OCI artifact published, but its Blueprint-Release lockstep step failed, leaving slot-80 + slot-80a pins and `platform/newapi/blueprint.yaml` stranded at 1.4.111 (pin-sync-audit FAILed with 2 drifted pins). Bump all three to 1.4.112 to match the published chart.

After both: pin-sync-audit PASS, dependency-graph-audit PASS.

Refs #3878 #3375 #3831 #3642