### PR TITLE
fix(cloud-init): powerdns-api-credentials into flux-system w/ reflector — survives bootstrap-kit prune so wildcard cert issues (Refs #3847)

### DIFF
--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -240,8 +240,28 @@ write_files:
       data:
         token: ${base64encode(harbor_robot_token)}
 
-  # ── cert-manager/powerdns-api-credentials Secret ──────────────────────
+  # ── flux-system/powerdns-api-credentials Secret (#3847) ───────────────
   # bp-cert-manager-powerdns-webhook reads X-API-Key for DNS-01 challenges.
+  # The upstream webhook binary ALWAYS loads the key from a Secret named
+  # `powerdns-api-credentials` in the cert-manager cluster-resource-namespace
+  # (it ignores any `namespace:` on the issuer's apiKeySecretRef).
+  #
+  # #3847 (fresh-prov wildcard-cert wedge, hw167): this Secret was previously
+  # seeded DIRECTLY into the `cert-manager` namespace. That namespace is owned
+  # by the `bootstrap-kit` Flux Kustomization (path ./clusters/_template/
+  # bootstrap-kit, prune: true). An imperatively-applied Secret that is not in
+  # the reconciled Git tree is an orphan in a prune-managed namespace and gets
+  # pruned → DNS-01 solver "failed loading api key secret cert-manager/
+  # powerdns-api-credentials: not found" → no wildcard cert → cilium-envoy
+  # InvalidCertificateRef → console.<fqdn> HTTPS 000 on a fresh prov.
+  #
+  # Fix: mirror the resilient ghcr-pull pattern above — seed the central
+  # `pdns.openova.io` key into the NON-pruned `flux-system` namespace WITH
+  # reflector annotations that auto-reflect a copy (same name) into
+  # `cert-manager`. bp-reflector (slot 05a) keeps the cert-manager copy in
+  # sync, so it self-heals after any bootstrap-kit prune and survives a
+  # fresh prov. Preserve the CENTRAL key (len 48, pdns.openova.io) here, NOT
+  # the Sovereign-LOCAL powerdns/powerdns-api-credentials key (len 32). Refs #3847.
   - path: /var/lib/catalyst/powerdns-api-credentials.yaml
     permissions: '0600'
     content: |
@@ -249,7 +269,12 @@ write_files:
       kind: Secret
       metadata:
         name: powerdns-api-credentials
-        namespace: cert-manager
+        namespace: flux-system
+        annotations:
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "cert-manager"
+          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "cert-manager"
       type: Opaque
       data:
         api-key: ${base64encode(powerdns_api_key)}


### PR DESCRIPTION
## Refs #3847

### Problem
On a fresh prov (observed live hw167, dep `28d4e96f`), the Sovereign wildcard-cert DNS-01 challenge failed:

```
failed initializing powerdns provider: failed loading api key secret
cert-manager/powerdns-api-credentials: secrets "powerdns-api-credentials" not found
```

The cert-manager-powerdns-webhook binary **always** loads the API key from a Secret named `powerdns-api-credentials` in the cert-manager cluster-resource-namespace. Cloud-init seeded that Secret **directly into the `cert-manager` namespace**, which the `bootstrap-kit` Flux Kustomization (`path ./clusters/_template/bootstrap-kit`, `prune: true`) owns. An imperatively-applied Secret that is not part of the reconciled Git tree is an orphan in a prune-managed namespace and gets pruned → no API key → no wildcard cert → cilium-envoy `InvalidCertificateRef` → `console.<fqdn>` HTTPS 000. Recurring fresh-prov hazard, not hw167-specific.

### Fix
Mirror the resilient `flux-system/ghcr-pull` pattern already in the same template: seed the central `pdns.openova.io` key into the **non-pruned `flux-system` namespace** WITH reflector annotations that auto-reflect a same-named copy into `cert-manager`. bp-reflector (slot 05a) keeps the `cert-manager` copy in sync, so it self-heals after any bootstrap-kit prune and survives a fresh prov.

Preserves the **central** key (len 48, `pdns.openova.io`) — NOT the Sovereign-local `powerdns/powerdns-api-credentials` key (len 32).

### Files
- `infra/providers/_shared/cloudinit-control-plane.tftpl` — `powerdns-api-credentials` seed moved `cert-manager` → `flux-system` + reflector `reflection-allowed`/`reflection-auto` annotations targeting `cert-manager`. The `kubectl apply` runcmd is unchanged (same file path, `flux-system` exists at apply time alongside `ghcr-pull`).

### Validation
- `scripts/lint-cloudinit.sh both` → renders OK + `dash -n` PASSES for hetzner (39 runcmd items) and huawei (39 runcmd items).
- Rendered Secret carries `metadata.namespace: flux-system` + `reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: cert-manager` (the keep-marker / reflector-protection the issue asks for).
- YAML structural check of the embedded Secret block passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)