### PR TITLE
test(provisioning): lock down the #3744 double-fire → single-provision guard with a dedup-seam unit test

### DIFF
--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -927,34 +927,25 @@ func (h *Handler) startProvisioning(ctx context.Context, tenantID, orderID, plan
 	// POST /provisioning/start) by design; without a guard both inserts fork a
 	// workflow and the two near-simultaneous Gitea commits race on the shared
 	// sme-tenants branch ("cannot lock ref"), marking the tenant failed even
-	// though the Org CR + winning commit land. CreateProvisionIfAbsent is backed
-	// by a partial unique index on (tenant_id, in-flight status), so the second
+	// though the Org CR + winning commit land. dedupProvisionCreate is backed by
+	// a partial unique index on (tenant_id, in-flight status), so the second
 	// trigger collides and we return the already-running provision without
 	// forking a duplicate workflow — mirroring CreateJobIfAbsent's #71 dedup for
-	// day-2 Jobs.
-	if err := h.Store.CreateProvisionIfAbsent(ctx, provision); err != nil {
-		if errors.Is(err, store.ErrProvisionExists) {
-			existing, getErr := h.Store.GetInFlightProvisionByTenant(ctx, tenantID)
-			if getErr != nil {
-				slog.Error("duplicate provision dispatch: failed to load in-flight provision",
-					"tenant_id", tenantID, "error", getErr)
-				return nil, getErr
-			}
-			if existing != nil {
-				slog.Info("duplicate provision dispatch — an in-flight provision already exists for this tenant; skipping",
-					"tenant_id", tenantID, "provision_id", existing.ID)
-				return existing, nil
-			}
-			// Lost the in-flight row between the collision and the lookup (it
-			// just reached a terminal state). Treat as benign: return the
-			// provision we built without forking — the prior workflow owns the
-			// outcome. A subsequent legitimate re-provision will succeed.
-			slog.Info("duplicate provision dispatch — prior provision terminated; not forking a new workflow",
-				"tenant_id", tenantID)
-			return provision, nil
-		}
-		slog.Error("failed to create provision record", "error", err)
+	// day-2 Jobs. The decision is extracted into a pure helper so the exact
+	// double-fire → single-provision semantics are unit-testable without Mongo.
+	result, err := dedupProvisionCreate(ctx, h.Store, provision, tenantID)
+	if err != nil {
+		slog.Error("provision-create dedup failed", "tenant_id", tenantID, "error", err)
 		return nil, err
+	}
+	if !result.fork {
+		// A concurrent trigger already owns the in-flight provision (or a prior
+		// one just terminated). Return the existing record WITHOUT forking a
+		// second workflow — this is the load-bearing guard that stops the
+		// self-race that marked stranger redeems failed.
+		slog.Info("duplicate provision dispatch — not forking a second workflow",
+			"tenant_id", tenantID, "provision_id", result.provision.ID)
+		return result.provision, nil
 	}
 
 	h.publishEvent(ctx, "provision.started", tenantID, map[string]string{
@@ -965,6 +956,59 @@ func (h *Handler) startProvisioning(ctx context.Context, tenantID, orderID, plan
 	go h.runProvisioningWorkflow(provision.ID, tenantID, subdomain, planSlug, depSlugs, appSlugs, len(steps), appConfigs)
 
 	return provision, nil
+}
+
+// provisionDedupStore is the narrow store surface dedupProvisionCreate needs.
+// *store.Store satisfies it in production; tests inject a fake that simulates
+// the partial-unique-index collision without a live Mongo. Keeping the surface
+// to exactly the two dedup methods means the test can model the double-fire
+// race deterministically.
+type provisionDedupStore interface {
+	CreateProvisionIfAbsent(ctx context.Context, p *store.Provision) error
+	GetInFlightProvisionByTenant(ctx context.Context, tenantID string) (*store.Provision, error)
+}
+
+// dedupDecision is the outcome of the #3744 provision-create dedup. When fork is
+// true the caller owns a freshly-inserted provision and MUST start exactly one
+// workflow; when fork is false the provision field is the already-running (or
+// just-terminated) record and the caller MUST NOT fork — returning it is the
+// no-op that defeats the self-race.
+type dedupDecision struct {
+	provision *store.Provision
+	fork      bool
+}
+
+// dedupProvisionCreate runs the #3744 create-once guard. It attempts the
+// insert; on an ErrProvisionExists collision (the second of the two
+// credit-covered checkout triggers) it surfaces the in-flight provision so the
+// loser returns it instead of forking a duplicate workflow → duplicate Gitea
+// commit → ref-lock race → failed tenant.
+//
+// Three outcomes:
+//   - insert wins  → {provision, fork:true}   (start one workflow)
+//   - collision, in-flight row found → {existing, fork:false}
+//   - collision, row already terminal → {provision, fork:false} (benign: the
+//     prior workflow owns the outcome; a later legitimate re-provision succeeds
+//     because the partial index only collides on in-flight statuses)
+func dedupProvisionCreate(ctx context.Context, st provisionDedupStore, provision *store.Provision, tenantID string) (dedupDecision, error) {
+	if err := st.CreateProvisionIfAbsent(ctx, provision); err != nil {
+		if errors.Is(err, store.ErrProvisionExists) {
+			existing, getErr := st.GetInFlightProvisionByTenant(ctx, tenantID)
+			if getErr != nil {
+				return dedupDecision{}, getErr
+			}
+			if existing != nil {
+				return dedupDecision{provision: existing, fork: false}, nil
+			}
+			// Lost the in-flight row between the collision and the lookup (it
+			// just reached a terminal state). Treat as benign: return the
+			// provision we built without forking — the prior workflow owns the
+			// outcome. A subsequent legitimate re-provision will succeed.
+			return dedupDecision{provision: provision, fork: false}, nil
+		}
+		return dedupDecision{}, err
+	}
+	return dedupDecision{provision: provision, fork: true}, nil
 }
 
 // runProvisioningWorkflow performs real K8s provisioning via GitOps and

--- a/core/services/provisioning/handlers/provision_dedup_test.go
+++ b/core/services/provisioning/handlers/provision_dedup_test.go
@@ -1,0 +1,197 @@
+package handlers
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/openova-io/openova/core/services/provisioning/store"
+)
+
+// fakeDedupStore models the partial-unique-index dedup semantics of the real
+// Mongo-backed store WITHOUT a live Mongo, so the #3744 double-fire →
+// single-provision contract is deterministically testable. The first
+// CreateProvisionIfAbsent for a tenant in an in-flight state wins; every
+// subsequent one for the same tenant collides with store.ErrProvisionExists,
+// exactly as the real partial unique index on (tenant_id, in-flight status)
+// behaves. GetInFlightProvisionByTenant surfaces the winner to the loser.
+type fakeDedupStore struct {
+	mu sync.Mutex
+	// inflight maps tenantID -> the provision that won the create race.
+	inflight map[string]*store.Provision
+	// createCalls counts every CreateProvisionIfAbsent attempt (winners + losers).
+	createCalls int32
+	// getInFlightErr, when set, is returned by GetInFlightProvisionByTenant to
+	// exercise the lookup-failure branch.
+	getInFlightErr error
+	// dropInFlight, when true, makes GetInFlightProvisionByTenant return
+	// (nil, nil) to model the "row terminated between collision and lookup" race.
+	dropInFlight bool
+}
+
+func newFakeDedupStore() *fakeDedupStore {
+	return &fakeDedupStore{inflight: map[string]*store.Provision{}}
+}
+
+func (f *fakeDedupStore) CreateProvisionIfAbsent(_ context.Context, p *store.Provision) error {
+	atomic.AddInt32(&f.createCalls, 1)
+	if p.TenantID == "" {
+		return store.ErrProvisionExists // not reached in these tests; mirror real guard intent
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, exists := f.inflight[p.TenantID]; exists {
+		return store.ErrProvisionExists
+	}
+	if p.ID == "" {
+		p.ID = "prov-" + p.TenantID
+	}
+	// Store a copy so the caller mutating its local pointer can't change what
+	// the loser observes via GetInFlightProvisionByTenant.
+	cp := *p
+	f.inflight[p.TenantID] = &cp
+	return nil
+}
+
+func (f *fakeDedupStore) GetInFlightProvisionByTenant(_ context.Context, tenantID string) (*store.Provision, error) {
+	if f.getInFlightErr != nil {
+		return nil, f.getInFlightErr
+	}
+	if f.dropInFlight {
+		return nil, nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if p, ok := f.inflight[tenantID]; ok {
+		return p, nil
+	}
+	return nil, nil
+}
+
+// TestDedupProvisionCreate_DoubleFire_SingleProvision is the direct #3744
+// acceptance test: the credit-covered checkout fires the provision-create
+// entrypoint TWICE (NATS order.placed event + POST /provisioning/start). The
+// second call MUST NOT fork a second workflow — it must return the in-flight
+// provision the first call inserted. Exactly one fork means exactly one Gitea
+// commit, so the self-race that marked stranger redeems "failed" can't happen.
+func TestDedupProvisionCreate_DoubleFire_SingleProvision(t *testing.T) {
+	st := newFakeDedupStore()
+	ctx := context.Background()
+	const tenant = "walk-stranger-co"
+
+	// First trigger (e.g. the NATS order.placed event).
+	first := &store.Provision{TenantID: tenant, Status: "provisioning"}
+	d1, err := dedupProvisionCreate(ctx, st, first, tenant)
+	if err != nil {
+		t.Fatalf("first dedupProvisionCreate errored: %v", err)
+	}
+	if !d1.fork {
+		t.Fatal("first trigger must fork exactly one workflow, got fork=false")
+	}
+	if d1.provision != first {
+		t.Fatalf("first trigger must return the freshly-inserted provision, got %+v", d1.provision)
+	}
+
+	// Second trigger (e.g. the belt-and-suspenders POST /provisioning/start),
+	// same tenant — the double-fire the bug is about.
+	second := &store.Provision{TenantID: tenant, Status: "provisioning"}
+	d2, err := dedupProvisionCreate(ctx, st, second, tenant)
+	if err != nil {
+		t.Fatalf("second dedupProvisionCreate errored: %v", err)
+	}
+	if d2.fork {
+		t.Fatal("second trigger MUST NOT fork a second workflow (the #3744 self-race), got fork=true")
+	}
+	// The loser must surface the WINNER's provision, not its own throwaway.
+	if d2.provision == nil || d2.provision.ID != first.ID {
+		t.Fatalf("second trigger must return the in-flight (winner) provision %q, got %+v", first.ID, d2.provision)
+	}
+}
+
+// TestDedupProvisionCreate_ConcurrentDoubleFire_ExactlyOneFork proves the guard
+// holds when both triggers land near-simultaneously — the actual race that
+// produced two concurrent sme-tenants commits on hw158. Across N concurrent
+// calls for one tenant, exactly ONE may return fork=true.
+func TestDedupProvisionCreate_ConcurrentDoubleFire_ExactlyOneFork(t *testing.T) {
+	st := newFakeDedupStore()
+	ctx := context.Background()
+	const tenant = "walk-stranger-co"
+	const n = 8
+
+	var forks int32
+	var wg sync.WaitGroup
+	wg.Add(n)
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			<-start // line everyone up to maximize the race window
+			d, err := dedupProvisionCreate(ctx, st, &store.Provision{TenantID: tenant, Status: "provisioning"}, tenant)
+			if err != nil {
+				t.Errorf("concurrent dedupProvisionCreate errored: %v", err)
+				return
+			}
+			if d.fork {
+				atomic.AddInt32(&forks, 1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&forks); got != 1 {
+		t.Fatalf("exactly one of %d concurrent triggers may fork a workflow, got %d", n, got)
+	}
+	if got := atomic.LoadInt32(&st.createCalls); got != n {
+		t.Fatalf("all %d triggers must attempt the insert, got %d", n, got)
+	}
+}
+
+// TestDedupProvisionCreate_TerminatedBetweenCollisionAndLookup covers the benign
+// race where the winning provision reaches a terminal state between the loser's
+// collision and its in-flight lookup: the loser must still NOT fork (the prior
+// workflow owns the outcome), returning its own built provision rather than nil.
+func TestDedupProvisionCreate_TerminatedBetweenCollisionAndLookup(t *testing.T) {
+	st := newFakeDedupStore()
+	ctx := context.Background()
+	const tenant = "walk-stranger-co"
+
+	// Seed a winner so the next create collides...
+	if _, err := dedupProvisionCreate(ctx, st, &store.Provision{TenantID: tenant, Status: "provisioning"}, tenant); err != nil {
+		t.Fatalf("seed provision errored: %v", err)
+	}
+	// ...but make the lookup find no in-flight row (it just terminated).
+	st.dropInFlight = true
+
+	own := &store.Provision{ID: "loser-built", TenantID: tenant, Status: "provisioning"}
+	d, err := dedupProvisionCreate(ctx, st, own, tenant)
+	if err != nil {
+		t.Fatalf("dedupProvisionCreate errored: %v", err)
+	}
+	if d.fork {
+		t.Fatal("must NOT fork when a prior provision already terminated, got fork=true")
+	}
+	if d.provision != own {
+		t.Fatalf("on a terminated-row race the loser returns its own built provision, got %+v", d.provision)
+	}
+}
+
+// TestDedupProvisionCreate_LookupErrorPropagates ensures a failed in-flight
+// lookup is surfaced (not swallowed) so the caller can fail loudly rather than
+// silently fork or drop the request.
+func TestDedupProvisionCreate_LookupErrorPropagates(t *testing.T) {
+	st := newFakeDedupStore()
+	ctx := context.Background()
+	const tenant = "walk-stranger-co"
+	if _, err := dedupProvisionCreate(ctx, st, &store.Provision{TenantID: tenant, Status: "provisioning"}, tenant); err != nil {
+		t.Fatalf("seed provision errored: %v", err)
+	}
+	wantErr := context.DeadlineExceeded
+	st.getInFlightErr = wantErr
+
+	_, err := dedupProvisionCreate(ctx, st, &store.Provision{TenantID: tenant, Status: "provisioning"}, tenant)
+	if err != wantErr {
+		t.Fatalf("lookup error must propagate, got %v want %v", err, wantErr)
+	}
+}


### PR DESCRIPTION
## What

Refs #3744 #3376

The credit-covered marketplace redeem self-race (#3744): a 0-OMR-due checkout fires the provision-create entrypoint **twice** by design — the NATS `order.placed` event AND a belt-and-suspenders `POST /provisioning/start` from `CheckoutStep.svelte`. Both land in `startProvisioning`, which forks `runProvisioningWorkflow`, so two near-simultaneous commits race the shared `sme-tenants` Gitea branch. The loser hits `cannot lock ref … failed to update ref` and the tenant gets marked `failed` even though the Org CR + the winning commit both land.

The **primary idempotency guard** (`CreateProvisionIfAbsent` on the shared entrypoint, backed by a partial unique index on `(tenant_id, in-flight status)`) and the **ref-race matcher widening** (`cannot lock ref` / `but expected` / `.lock` / `failed to update ref`) both already landed on `main` (PR #3798 + the #3376 work). What was missing was a test that actually exercises the **double-fire → single-provision** contract from the issue's acceptance — the existing store tests only cover the empty-tenant guard and the in-flight status set in isolation; they never prove two near-simultaneous triggers fork exactly one workflow.

## How

To make the exact race testable without a live Mongo, the dedup **decision** is lifted out of `startProvisioning` into a pure helper over a narrow store seam:

- `dedupProvisionCreate(ctx, store, provision, tenantID) → {provision, fork}` over a `provisionDedupStore` interface (`CreateProvisionIfAbsent` + `GetInFlightProvisionByTenant`). `*store.Store` satisfies it unchanged — production wiring is byte-identical and the partial-unique-index collision semantics are preserved exactly: first writer wins → fork; collision → return the in-flight provision without forking; terminated-row race → benign no-fork.
- `startProvisioning` now calls the helper and forks the workflow iff `fork == true`.

## Tests (no Mongo — a fake store models the partial unique index)

- `DoubleFire_SingleProvision` — the second trigger returns the winner's provision and never forks.
- `ConcurrentDoubleFire_ExactlyOneFork` — across 8 concurrent triggers for one tenant, exactly ONE forks (passes under `-race`).
- `TerminatedBetweenCollisionAndLookup` — benign no-fork when the winner already reached a terminal state between collision and lookup.
- `LookupErrorPropagates` — a failed in-flight lookup surfaces instead of silently forking/dropping.

## Validation

`go build ./...` + `go vet` + `go test ./...` all green (EXIT 0) in the `core/services/provisioning` module; the concurrency test passes under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)