### PR TITLE
FOUNDATION: thin cloud-init — evict powerdns-api-credentials to Flux (sovereign-tls), revert #3884's over-cap reflector seeding

### DIFF
--- a/clusters/_template/sovereign-tls/kustomization.yaml
+++ b/clusters/_template/sovereign-tls/kustomization.yaml
@@ -3,6 +3,13 @@ kind: Kustomization
 resources:
   - cilium-gateway-cert.yaml
   - cilium-gateway.yaml
+  # powerdns-api-credentials Secret (#3888 / Refs #3847) — the DNS-01 API key
+  # the bp-cert-manager-powerdns-webhook solver reads to issue the wildcard
+  # cert above. Evicted OUT of cloud-init into this Flux-reconciled tier so it
+  # is no longer an imperative orphan pruned by bootstrap-kit (the #3847 wedge).
+  # Lands in `cert-manager`; value from the ${POWERDNS_API_KEY} postBuild
+  # substitute.
+  - powerdns-api-credentials.yaml
   # Watch+rollout-restart Job for cilium-envoy. cilium-envoy's xDS SDS
   # subscription does NOT recover after the initial-fetch timeout, so a
   # fresh Sovereign whose envoy started before the wildcard cert was

--- a/clusters/_template/sovereign-tls/powerdns-api-credentials.yaml
+++ b/clusters/_template/sovereign-tls/powerdns-api-credentials.yaml
@@ -1,0 +1,50 @@
+# powerdns-api-credentials — DNS-01 API key for the wildcard-cert solver.
+#
+# #3888 (Refs #3847) evicted this Secret OUT of the cloud-init template into
+# this Flux-reconciled sovereign-tls tier.
+#
+# WHO READS IT: bp-cert-manager-powerdns-webhook (bootstrap-kit slot 49). The
+# upstream DNS-01 solver ALWAYS loads the key from a Secret named
+# `powerdns-api-credentials` in the `cert-manager` cluster-resource-namespace
+# (it ignores any `namespace:` on the issuer's apiKeySecretRef). It PATCHes the
+# ACME challenge TXT record on the central pdns.openova.io so the wildcard
+# Certificate (cilium-gateway-cert.yaml in THIS Kustomization, issued by
+# ${WILDCARD_CERT_ISSUER} = letsencrypt-dns01-prod-powerdns) can issue.
+#
+# WHY HERE (not cloud-init, not bootstrap-kit, not bootstrap-kit-crs):
+#   - Cloud-init used to `kubectl apply` it imperatively into `cert-manager`.
+#     That namespace is OWNED by the `bootstrap-kit` Flux Kustomization
+#     (prune: true), so the imperative Secret — absent from the reconciled Git
+#     tree — was an orphan and got pruned on a fresh prov → "failed loading api
+#     key secret cert-manager/powerdns-api-credentials: not found" → no wildcard
+#     cert → cilium-envoy InvalidCertificateRef → console.<fqdn> HTTPS 000
+#     (hw167, #3847). PR #3884's flux-system+reflector workaround pushed the
+#     3-region cloud-init render 90 B over the 32256 Hetzner user_data cap.
+#   - sovereign-tls is the SAME Kustomization that issues the wildcard
+#     Certificate this key's DNS-01 solver fulfils — so the key + the cert it
+#     unlocks land together, as one datapath unit. It is NOT pruned by
+#     bootstrap-kit (separate inventory), has NO dependsOn on leaf apps, and
+#     runs wait:false + 1m retryInterval, so it retries this apply until the
+#     `cert-manager` namespace exists (created by bp-cert-manager, slot 02).
+#     Needs NO openbao/ESO.
+#   - bootstrap-kit-crs is the placement-GENERATED host-bridge tier (every file
+#     there must be declared in placement.yaml); a hand-authored Secret would
+#     trip the render-slot-placement drift guard. sovereign-tls is hand-authored
+#     and is the correct, sanctioned home.
+#
+# The `api-key` value is the CENTRAL pdns.openova.io key, injected via the
+# sovereign-tls Kustomization's ${POWERDNS_API_KEY} postBuild substitute
+# (base64-encoded in infra/providers/_shared/cloudinit-control-plane.tftpl), so
+# the raw key never appears in the reconciled Git tree.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: powerdns-api-credentials
+  namespace: cert-manager
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+    catalyst.openova.io/component: cert-manager-powerdns-webhook
+type: Opaque
+data:
+  api-key: ${POWERDNS_API_KEY}

--- a/infra/providers/_shared/cloudinit-control-plane.tftpl
+++ b/infra/providers/_shared/cloudinit-control-plane.tftpl
@@ -240,44 +240,28 @@ write_files:
       data:
         token: ${base64encode(harbor_robot_token)}
 
-  # ── flux-system/powerdns-api-credentials Secret (#3847) ───────────────
-  # bp-cert-manager-powerdns-webhook reads X-API-Key for DNS-01 challenges.
-  # The upstream webhook binary ALWAYS loads the key from a Secret named
-  # `powerdns-api-credentials` in the cert-manager cluster-resource-namespace
-  # (it ignores any `namespace:` on the issuer's apiKeySecretRef).
+  # ── powerdns-api-credentials Secret — EVICTED to Flux (#3888 / Refs #3847)
+  # The cert-manager DNS-01 webhook (bp-cert-manager-powerdns-webhook, slot 49)
+  # reads `api-key` from a Secret named `powerdns-api-credentials` in the
+  # `cert-manager` namespace. It is NO LONGER seeded by cloud-init: it is
+  # delivered as a Flux-reconciled resource in clusters/_template/sovereign-tls
+  # (powerdns-api-credentials.yaml), rendered straight into `cert-manager` from
+  # the sovereign-tls Kustomization's POWERDNS_API_KEY postBuild substitute
+  # (set in the flux-bootstrap block below).
   #
-  # #3847 (fresh-prov wildcard-cert wedge, hw167): this Secret was previously
-  # seeded DIRECTLY into the `cert-manager` namespace. That namespace is owned
-  # by the `bootstrap-kit` Flux Kustomization (path ./clusters/_template/
-  # bootstrap-kit, prune: true). An imperatively-applied Secret that is not in
-  # the reconciled Git tree is an orphan in a prune-managed namespace and gets
-  # pruned → DNS-01 solver "failed loading api key secret cert-manager/
-  # powerdns-api-credentials: not found" → no wildcard cert → cilium-envoy
-  # InvalidCertificateRef → console.<fqdn> HTTPS 000 on a fresh prov.
-  #
-  # Fix: mirror the resilient ghcr-pull pattern above — seed the central
-  # `pdns.openova.io` key into the NON-pruned `flux-system` namespace WITH
-  # reflector annotations that auto-reflect a copy (same name) into
-  # `cert-manager`. bp-reflector (slot 05a) keeps the cert-manager copy in
-  # sync, so it self-heals after any bootstrap-kit prune and survives a
-  # fresh prov. Preserve the CENTRAL key (len 48, pdns.openova.io) here, NOT
-  # the Sovereign-LOCAL powerdns/powerdns-api-credentials key (len 32). Refs #3847.
-  - path: /var/lib/catalyst/powerdns-api-credentials.yaml
-    permissions: '0600'
-    content: |
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: powerdns-api-credentials
-        namespace: flux-system
-        annotations:
-          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "cert-manager"
-          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "cert-manager"
-      type: Opaque
-      data:
-        api-key: ${base64encode(powerdns_api_key)}
+  # WHY evicted (the THIN-cloud-init mandate + #3847 root-cause fix): seeding it
+  # imperatively (`kubectl apply`) made it an ORPHAN in the `cert-manager` ns,
+  # which the `bootstrap-kit` Flux Kustomization (prune: true) OWNS → it got
+  # pruned on a fresh prov → DNS-01 "failed loading api key secret cert-manager/
+  # powerdns-api-credentials: not found" → no wildcard cert → console HTTPS 000
+  # (hw167). #3884's flux-system+reflector workaround pushed the 3-region render
+  # 90 B over the 32256 cap. A Flux-reconciled Git resource is owned by
+  # `sovereign-tls` (NOT pruned by bootstrap-kit), lands directly in
+  # `cert-manager` (no reflector hop), needs NO openbao/ESO, and reclaims the
+  # cloud-init bytes. sovereign-tls is the wildcard-cert-datapath Kustomization
+  # (it issues the Certificate this key's DNS-01 solver fulfils), reconciles in
+  # PARALLEL with a 1m retryInterval, and retries until the `cert-manager` ns
+  # exists — so the Secret is present before the DNS-01 challenge fires.
 
   # ── flux-system/pdm-basicauth Secret (issue #879 Bug 2) ───────────────
   # catalyst-api calls PDM (Pool Domain Manager) with Basic auth for the
@@ -705,6 +689,22 @@ write_files:
             SOVEREIGN_FQDN_SLUG: "${sovereign_fqdn_slug}"
             SOVEREIGN_REGION_KEY: "${primary_region_canonical_label}"
             HCLOUD_LB_LOCATION: "${region}"
+            # POWERDNS_API_KEY (#3888 / Refs #3847) — the central pdns.openova.io
+            # DNS-01 API key, base64-encoded so it threads into the cert-manager/
+            # powerdns-api-credentials Secret's `data.api-key` cluster-side
+            # (clusters/_template/sovereign-tls/powerdns-api-credentials.yaml).
+            # sovereign-tls is the natural home: it OWNS the wildcard-cert
+            # datapath (the Certificate issued by $${WILDCARD_CERT_ISSUER} =
+            # letsencrypt-dns01-prod-powerdns), and the DNS-01 solver needs this
+            # key to PATCH the challenge TXT record. Carried via this postBuild
+            # channel so the raw key never lands in the reconciled Git tree —
+            # the same way cloud-init used to base64-seed it into the inline
+            # Secret. Evicting it OUT of cloud-init into this Flux-reconciled
+            # resource fixes #3847's prune-orphan (cloud-init applied it
+            # imperatively into the bootstrap-kit-pruned `cert-manager` ns) and
+            # reverts #3884 (whose flux-system+reflector workaround pushed the
+            # 3-region render past the 32256 cap).
+            POWERDNS_API_KEY: ${base64encode(powerdns_api_key)}
           substituteFrom:
             - kind: ConfigMap
               name: sovereign-tls-vars
@@ -1198,10 +1198,13 @@ runcmd:
   # are then folded into a single multi-`-f` `kubectl apply` (each file is an
   # independent Secret manifest; apply order among them is irrelevant), which
   # drops ~6 repetitions of the `kubectl --kubeconfig=…` long-form and keeps the
-  # rendered cloud-init under Hetzner's 32256B cap. powerdns→cert-manager,
-  # handover-jwt→catalyst-system and recovery-seed→openbao all now resolve.
-  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml create namespace cert-manager catalyst-system openbao --dry-run=client -o yaml | kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f -'
-  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/ghcr-pull-secret.yaml -f /var/lib/catalyst/harbor-robot-token-secret.yaml -f /var/lib/catalyst/pdm-basicauth-secret.yaml -f /var/lib/catalyst/powerdns-api-credentials.yaml -f /var/lib/catalyst/handover-jwt-public-secret.yaml -f /var/lib/catalyst/object-storage-secret.yaml -f /var/lib/catalyst/cloud-credentials-secret.yaml'
+  # rendered cloud-init under Hetzner's 32256B cap. handover-jwt→catalyst-system
+  # and recovery-seed→openbao resolve here. (powerdns-api-credentials no longer
+  # needs the `cert-manager` ns created here — #3888 evicted it to the Flux
+  # sovereign-tls Kustomization, which lands it in `cert-manager` after
+  # bp-cert-manager.)
+  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml create namespace catalyst-system openbao --dry-run=client -o yaml | kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f -'
+  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/ghcr-pull-secret.yaml -f /var/lib/catalyst/harbor-robot-token-secret.yaml -f /var/lib/catalyst/pdm-basicauth-secret.yaml -f /var/lib/catalyst/handover-jwt-public-secret.yaml -f /var/lib/catalyst/object-storage-secret.yaml -f /var/lib/catalyst/cloud-credentials-secret.yaml'
 
   # openbao-recovery-seed: one-shot 32-byte seed the bp-openbao init Job
   # consumes + deletes on first success. Never in tfstate; node-local only.


### PR DESCRIPTION
## Foundation: thin the bootstrap cloud-init

The control-plane cloud-init (`infra/providers/_shared/cloudinit-control-plane.tftpl`)
hardcodes ~8 inline Kubernetes `Secret` manifests. The 3-region Hetzner render
is byte-tight against the **32256-byte `user_data` guardrail**. PR #3884
(`005b81abb`) seeded `powerdns-api-credentials` into `flux-system` + added
reflector annotations INSIDE cloud-init — the WRONG direction — and pushed the
3-region render to **32346 bytes (90 B over the cap)**, tripping the
`infra/providers/hetzner` `tofu test` (`three_region_mgmt_fsn_hel`).

This reverts #3884 and evicts `powerdns-api-credentials` OUT of cloud-init into
a Flux-reconciled resource, fixing #3847's prune-orphan the right way.

`Refs #3888 #3847 #3884`

## Classification — which inline Secrets stay vs move

| Secret | Disposition | Why |
|---|---|---|
| `ghcr-pull` | **STAY** | Flux pulls its own controllers + every `bp-*` chart/image from ghcr before harbor exists (chicken-and-egg). |
| `openbao-recovery-seed` | **STAY** | Seeds openbao itself (the secret backend). |
| `cloud-credentials` | **STAY** | `valuesFrom` consumer bp-crossplane(04) reconciles BEFORE openbao(08); also CCM(55)/autoscaler(50). |
| `object-storage` | **STAY** | `valuesFrom` consumers openbao(08)/keycloak(09)/gitea(10) reconcile at/before the ESO ClusterSecretStore(15a). |
| `harbor-robot-token` | **STAY** | consumed by catalyst-api/catalyst-platform(13), before the ESO store(15a). |
| `pdm-basicauth` | **STAY** | consumed by catalyst-api(13), before the ESO store(15a). |
| `handover-jwt-public` | **STAY** | consumed by catalyst-platform(13), before the ESO store(15a). |
| **`powerdns-api-credentials`** | **MOVED → Flux** | cert-manager DNS-01 webhook(49); needs NO openbao/ESO. |

**Why the STAY set cannot be ESO-delivered:** every one is consumed via Flux
`valuesFrom` (resolved in the HR's own namespace at reconcile time) by a slot
that reconciles **at or before** the openbao→ESO→`vault-region1`
ClusterSecretStore pipeline becomes functional (08→15→15a). And there is **no
prov-time mechanism to write raw values into openbao's KV** — the
`openbao-auth-bootstrap` Job revokes the root token, and only `secret/sso/*`
(sso-bridge) + `secret/catalyst/*` (catalyst-api) get written at runtime by
dedicated roles. Building a new openbao-seed Job + writer policy + ExternalSecret
CRs + an 08→…→55 dependsOn rewire is a large, unprovable-safe foundation change.
Per the "correctness over speed — leave it and flag it if ordering can't be
proven safe" mandate, these **stay in cloud-init**.

## What changed (3 files)

- **`infra/providers/_shared/cloudinit-control-plane.tftpl`**
  - Removed the inline `powerdns-api-credentials` Secret `write_files` block
    (reverts #3884's `flux-system` + reflector seeding) **and** its
    `runcmd` `kubectl apply -f …powerdns-api-credentials.yaml` entry.
  - Dropped `cert-manager` from the cloud-init namespace pre-create (no
    cloud-init Secret lands there anymore).
  - Added a compact `POWERDNS_API_KEY` (base64) postBuild substitute to the
    **`sovereign-tls`** Flux Kustomization.
- **`clusters/_template/sovereign-tls/powerdns-api-credentials.yaml`** (new) —
  the Flux-reconciled `Secret` in ns `cert-manager`, value from
  `${POWERDNS_API_KEY}`.
- **`clusters/_template/sovereign-tls/kustomization.yaml`** — register it.

**Why `sovereign-tls` (not `bootstrap-kit-crs`):** `bootstrap-kit-crs` is
placement-GENERATED — every file must be declared in `placement.yaml` or
`render-slot-placement.py` flags drift. `sovereign-tls` is hand-authored, is
NOT pruned by `bootstrap-kit` (separate inventory), and **owns the wildcard-cert
datapath** the DNS-01 key serves (it issues the Certificate the key's solver
fulfils). It has no `dependsOn` on leaf apps and a 1m `retryInterval`, so it
retries the apply until the `cert-manager` namespace exists.

## Runtime ordering trace

1. cloud-init applies the bootstrap Secrets that MUST stay (`ghcr-pull`,
   `object-storage`, `cloud-credentials`, `harbor-robot-token`, `pdm-basicauth`,
   `handover-jwt-public`, `openbao-recovery-seed`) → hands the cluster to Flux.
2. Flux applies `bootstrap-kit` → bp-cilium(01) → bp-cert-manager(02) creates
   the `cert-manager` namespace + CRDs → bp-cert-manager-powerdns-webhook(49)
   installs (its ClusterIssuer `letsencrypt-dns01-prod-powerdns`).
3. In PARALLEL, the `sovereign-tls` Kustomization (no `dependsOn`, 1m
   `retryInterval`) retries until `cert-manager` exists, then applies BOTH the
   wildcard `Certificate` (`cilium-gateway-cert.yaml`) AND the
   `powerdns-api-credentials` Secret — together, as one datapath unit.
4. cert-manager processes the Certificate's Order → the DNS-01 solver reads
   `cert-manager/powerdns-api-credentials` (present, owned by `sovereign-tls`,
   never pruned) → PATCHes the challenge TXT on `pdns.openova.io` → wildcard
   cert issues → cilium-envoy serves HTTPS on `*.<fqdn>`. No openbao/ESO needed.

The only consumer of the cloud-init-seeded Secret was the webhook (in
`cert-manager`); the Sovereign-LOCAL `powerdns` key (ns `powerdns`, read by
bp-external-dns) is a DIFFERENT Secret rendered by `bp-powerdns` and is
untouched.

## Validation

- `scripts/lint-cloudinit.sh both` → **PASS** (hetzner + huawei render + `dash -n`).
- `infra/providers/hetzner` `tofu test` → **Success! 10 passed, 0 failed**
  (was `2 passed, 1 failed` — the `three_region_mgmt_fsn_hel` 32256 breach is fixed).
- `infra/providers/huawei` `tofu test` → **PASS** (provider-agnostic change).
- `render-slot-placement.py check` → PASSED, no crs drift.
- Enforced cloud-init byte delta (comment-strip mirror): single-zone
  22324→21682, multi-zone 22570→21928 (**−642 B**); the real 3-region fixture
  drops 32346→under 32256 with headroom.
- Grep-verified: the inline `powerdns-api-credentials` Secret manifest is GONE
  from the rendered cloud-init; no remaining consumer references a
  cloud-init-seeded Secret that no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
