### PR TITLE
fix(bp-oidc-gate): dial keycloak in-cluster for backchannel — kill gate-pod CrashLoop on Huawei/kom4dc (0.1.5)

### DIFF
--- a/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
+++ b/clusters/_template/bootstrap-kit/13c-bp-oidc-gate.yaml
@@ -72,7 +72,14 @@ spec:
       # which sends redirect_uri=…/oidc/authorized; #3741 had over-stripped that
       # URI → KC 'Invalid parameter: redirect_uri' on hw167 (UAT row 3374-11).
       # powerdns-admin instance below sets appNativeCallbackPath:/oidc/authorized.
-      version: 0.1.4
+      # 0.1.5 (#3844, 2026-06-19): backchannel-via-internal-Service — the gate
+      # pods CrashLooped on Huawei/kom4dc because oauth2-proxy's OIDC discovery
+      # dialed the PUBLIC issuer EIP (auth.<fqdn>), which the cluster cannot
+      # hairpin (i/o timeout → openova-flow + powerdns-admin gates never
+      # initialised, hw167 UAT rows 3374-36/37/38). keycloakInternalURL below
+      # points the backchannel (discovery-skip + redeem/jwks/userinfo) at the
+      # in-cluster keycloak Service; the browser leg stays public.
+      version: 0.1.5
       sourceRef:
         kind: HelmRepository
         name: bp-oidc-gate
@@ -96,6 +103,11 @@ spec:
       registryMirror: ${REGISTRY_MIRROR:=harbor.openova.io}
     sovereignFQDN: ${SOVEREIGN_FQDN}
     realm: sovereign
+    # #3844 — the gate pods reach Keycloak for the backchannel legs over the
+    # in-cluster Service (the public auth.<fqdn> EIP does not hairpin from
+    # inside the cluster on Huawei/kom4dc). KC_HOSTNAME is pinned public by
+    # bp-keycloak so the token `iss` still matches the public issuer.
+    keycloakInternalURL: http://keycloak.keycloak.svc.cluster.local
     instances:
       # openova-flow (#3374 §3 row 9). Upstream is the slot-56 Service
       # in catalyst-system; the gate proxies it at the public hostname.

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.114
+  version: 1.4.115
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.113
+  version: 1.4.114
   card:
     title: NewAPI
     summary: |

--- a/platform/oidc-gate/blueprint.yaml
+++ b/platform/oidc-gate/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 0.1.4
+  version: 0.1.5
   card:
     title: oidc-gate
     summary: |

--- a/platform/oidc-gate/chart/Chart.yaml
+++ b/platform/oidc-gate/chart/Chart.yaml
@@ -72,7 +72,25 @@ name: bp-oidc-gate
 # two URIs so config-cli FULL-managed reconcile keeps the client correct.
 # Login-less gated apps (openova-flow) leave it unset → only /oauth2/callback
 # registers (byte-identical to the pre-0.1.4 shape).
-version: 0.1.4
+# 0.1.5 (#3844, 2026-06-19): backchannel-via-internal-Service — stop the gate
+# pods CrashLooping on Huawei/kom4dc. oauth2-proxy did its OIDC discovery (and
+# every backchannel leg) at the PUBLIC issuer `https://auth.<fqdn>/realms/...`;
+# on Huawei a Pod cannot dial the Sovereign's own public EIP (ELB-DNAT'd, no
+# hairpin — same class as #3241), so startup discovery timed out ("error while
+# discovery OIDC configuration: dial tcp <eip>:443: i/o timeout") and EVERY
+# oidc-gate instance (openova-flow, powerdns-admin) never initialised — UAT
+# rows 3374-36/37/38 RED at the POD level regardless of realm/client/secret
+# correctness (proven live hw167, dep 28d4e96f96407bbb). New value
+# `keycloakInternalURL` (default the in-cluster keycloak Service, the proven
+# bp-gitea seam): when set, the gate uses `--skip-oidc-discovery` + explicit
+# `--redeem-url`/`--oidc-jwks-url`/`--profile-url` pointed at the in-cluster
+# Service, keeping `--oidc-issuer-url` + `--login-url` + `--redirect-url`
+# PUBLIC. bp-keycloak pins KC_HOSTNAME public so the token `iss` still matches
+# the public issuer even though the discovery doc is fetched internally — the
+# exact frontchannel-public/backchannel-internal split keycloak-frontend-env.yaml
+# already establishes. Set empty to restore the pre-#3844 public-discovery
+# path (clusters where the public issuer DOES hairpin).
+version: 0.1.5
 appVersion: "7.6.0"
 description: |
   Catalyst generic OIDC gate — a per-app oauth2-proxy instance set that

--- a/platform/oidc-gate/chart/templates/instances.yaml
+++ b/platform/oidc-gate/chart/templates/instances.yaml
@@ -36,6 +36,19 @@ minted and pre-existing clients on the next reconcile tick — zero-touch.
 {{- $cid := $inst.clientId | default $inst.name }}
 {{- $gateName := printf "oidc-gate-%s" $inst.name }}
 {{- $issuer := printf "https://auth.%s/realms/%s" $root.Values.sovereignFQDN $root.Values.realm }}
+{{- /*
+#3844 — backchannel-via-internal-Service. When keycloakInternalURL is set,
+the gate SKIPS OIDC discovery (which otherwise dials the public issuer EIP —
+unhairpinnable from inside the cluster on Huawei/kom4dc → CrashLoop) and
+points the backchannel legs (redeem/jwks/userinfo) at the in-cluster
+keycloak Service, keeping `--oidc-issuer-url` + `--login-url` public (browser
+leg + `iss` validation). KC_HOSTNAME is pinned public by bp-keycloak so the
+public issuer matches the token `iss` even though the doc is fetched
+internally. Empty → restore pre-#3844 public-discovery behavior.
+*/ -}}
+{{- $kcInternal := trimSuffix "/" ($root.Values.keycloakInternalURL | default "") }}
+{{- $internalRealm := "" }}
+{{- if $kcInternal }}{{- $internalRealm = printf "%s/realms/%s" $kcInternal $root.Values.realm }}{{- end }}
 ---
 # ── cookie secret (gate-local; lookup-or-generate, survives uninstall) ──
 {{- $existing := lookup "v1" "Secret" $root.Release.Namespace (printf "%s-cookie" $gateName) }}
@@ -179,12 +192,26 @@ spec:
           args:
             - --http-address=0.0.0.0:4180
             - --provider=keycloak-oidc
+            # PUBLIC issuer — used for `iss`-claim validation + (when discovery
+            # is NOT skipped) the discovery fetch. KC_HOSTNAME is pinned public
+            # by bp-keycloak so tokens carry this `iss` even when the backchannel
+            # endpoints are dialed in-cluster (#3844).
             - --oidc-issuer-url={{ $issuer }}
             - --client-id={{ $cid }}
             - --redirect-url=https://{{ $hostname }}/oauth2/callback
             - --upstream={{ $inst.upstream }}
             - --email-domain=*
             - --scope=openid profile email groups
+{{- if $internalRealm }}
+            # #3844 — skip discovery against the public EIP (unhairpinnable
+            # from inside the cluster on Huawei/kom4dc → i/o timeout → gate
+            # CrashLoop). Backchannel legs dial the in-cluster keycloak Service;
+            # the browser-facing --login-url + --redirect-url stay public.
+            - --skip-oidc-discovery=true
+            - --redeem-url={{ $internalRealm }}/protocol/openid-connect/token
+            - --oidc-jwks-url={{ $internalRealm }}/protocol/openid-connect/certs
+            - --profile-url={{ $internalRealm }}/protocol/openid-connect/userinfo
+{{- end }}
             # Silent zero-click: the realm IDR defaultProvider plus the
             # explicit hint cover both realm-config drift directions
             # (G113 #2725 / G117.5 #2744).

--- a/platform/oidc-gate/chart/tests/internal-discovery-render.sh
+++ b/platform/oidc-gate/chart/tests/internal-discovery-render.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# bp-oidc-gate — #3844 backchannel-via-internal-Service render audit.
+#
+# oauth2-proxy does its OIDC discovery (and every backchannel leg) at
+# `--oidc-issuer-url`, which is the PUBLIC issuer `https://auth.<fqdn>/...`.
+# On Huawei/kom4dc a Pod cannot dial the Sovereign's own public EIP (ELB-DNAT'd,
+# no hairpin — same class as #3241), so startup discovery times out
+# ("error while discovery OIDC configuration: dial tcp <eip>:443: i/o timeout")
+# and EVERY oidc-gate instance never initialises (CrashLoop) — UAT rows
+# 3374-36/37/38 RED at the POD level (proven live hw167).
+#
+# FIX: when `keycloakInternalURL` is set the gate uses --skip-oidc-discovery
+# plus explicit --redeem-url/--oidc-jwks-url/--profile-url pointed at the
+# in-cluster keycloak Service, keeping --oidc-issuer-url + --login-url +
+# --redirect-url PUBLIC (browser leg + `iss` validation; KC_HOSTNAME is pinned
+# public by bp-keycloak so the token `iss` still matches).
+#
+# This test asserts:
+#   1. with keycloakInternalURL set (default), the gate renders
+#      --skip-oidc-discovery=true + internal redeem/jwks/profile URLs, and the
+#      issuer + login + redirect URLs stay PUBLIC;
+#   2. the backchannel URLs point at the in-cluster Service, NOT the public EIP;
+#   3. with keycloakInternalURL="" the gate renders NONE of the skip-discovery
+#      flags (byte-identical to the pre-#3844 public-discovery shape).
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+fqdn="smoke.example.com"
+internal="http://keycloak.keycloak.svc.cluster.local"
+
+vals="$(mktemp)"
+trap 'rm -f "$vals"' EXIT
+cat >"$vals" <<YAML
+sovereignFQDN: ${fqdn}
+realm: sovereign
+instances:
+  - name: openova-flow
+    enabled: true
+    clientId: openova-flow
+    upstream: http://openova-flow-server.catalyst-system.svc.cluster.local:80
+YAML
+
+# ── Case 1: fix ON (keycloakInternalURL default) ────────────────────────────
+echo "[internal-discovery] Case 1: fix ON renders skip-discovery + internal backchannel"
+on="$("$helm" template oidc-gate "$chart_dir" -f "$vals" 2>/dev/null)"
+
+assert_arg() { echo "$on" | grep -qF -- "$1" || { echo "FAIL: missing arg '$1'" >&2; echo "$on" >&2; exit 1; }; }
+
+assert_arg "--skip-oidc-discovery=true"
+assert_arg "--redeem-url=${internal}/realms/sovereign/protocol/openid-connect/token"
+assert_arg "--oidc-jwks-url=${internal}/realms/sovereign/protocol/openid-connect/certs"
+assert_arg "--profile-url=${internal}/realms/sovereign/protocol/openid-connect/userinfo"
+# the browser-facing + iss-validation URLs stay PUBLIC
+assert_arg "--oidc-issuer-url=https://auth.${fqdn}/realms/sovereign"
+assert_arg "--login-url=https://auth.${fqdn}/realms/sovereign/protocol/openid-connect/auth?kc_idp_hint=catalyst-pin"
+assert_arg "--redirect-url=https://openova-flow.${fqdn}/oauth2/callback"
+echo "  PASS"
+
+# ── Case 2: backchannel never dials the public EIP host ─────────────────────
+echo "[internal-discovery] Case 2: no backchannel arg points at the public auth host"
+for bc in redeem-url oidc-jwks-url profile-url; do
+  line="$(echo "$on" | grep -E -- "--${bc}=" | head -1)"
+  if echo "$line" | grep -qF "auth.${fqdn}"; then
+    echo "FAIL: --${bc} dials the public EIP host (auth.${fqdn}) — hairpin bug not fixed" >&2
+    echo "$line" >&2; exit 1
+  fi
+done
+echo "  PASS"
+
+# ── Case 3: fix OFF (keycloakInternalURL="") — pre-#3844 shape ──────────────
+echo "[internal-discovery] Case 3: keycloakInternalURL=\"\" renders NO skip-discovery flags"
+off="$("$helm" template oidc-gate "$chart_dir" -f "$vals" --set keycloakInternalURL="" 2>/dev/null)"
+if echo "$off" | grep -qE -- '--skip-oidc-discovery|--redeem-url|--oidc-jwks-url|--profile-url'; then
+  echo "FAIL: empty keycloakInternalURL must NOT render skip-discovery flags (pre-#3844 shape)" >&2
+  echo "$off" | grep -E -- '--skip-oidc-discovery|--redeem-url|--oidc-jwks-url|--profile-url' >&2
+  exit 1
+fi
+# the public issuer + login URL still render in the OFF path
+echo "$off" | grep -qF -- "--oidc-issuer-url=https://auth.${fqdn}/realms/sovereign" \
+  || { echo "FAIL: OFF path lost the public --oidc-issuer-url" >&2; exit 1; }
+echo "  PASS"
+
+echo "[bp-oidc-gate #3844 internal-discovery] All cases PASS"

--- a/platform/oidc-gate/chart/values.yaml
+++ b/platform/oidc-gate/chart/values.yaml
@@ -27,6 +27,30 @@ sovereignFQDN: ""
 # Keycloak realm the gated clients live in.
 realm: sovereign
 
+# In-cluster Keycloak base URL the gate pods use for the BACKCHANNEL OIDC
+# legs (discovery + token redeem + JWKS + userinfo) — #3844.
+#
+# WHY: oauth2-proxy does its OIDC discovery (and every backchannel call) at
+# `--oidc-issuer-url` by default, which is the PUBLIC issuer
+# `https://auth.<fqdn>/realms/<realm>`. On Huawei/kom4dc a Pod cannot dial
+# the Sovereign's own public EIP — the EIP is ELB-DNAT'd and does NOT
+# hairpin back in (same class as #3241 nodeIPAM EIP-DNAT) — so startup
+# discovery times out and the gate NEVER initialises ("error while discovery
+# OIDC configuration: dial tcp <eip>:443: i/o timeout" → CrashLoop, hw167).
+#
+# FIX: dial the in-cluster keycloak Service for the backchannel legs while
+# keeping the PUBLIC issuer for the browser-facing auth/redirect URLs and for
+# the `iss`-claim validation. bp-keycloak pins KC_HOSTNAME to the public URL
+# (keycloak-frontend-env.yaml) so the public issuer matches the token `iss`
+# even when the endpoints are fetched internally; the gate uses
+# `--skip-oidc-discovery` + explicit `--redeem-url`/`--oidc-jwks-url`
+# (internal) and `--login-url` (public). This is the same internal-URL seam
+# bp-gitea uses (`sso.keycloakInternalURL`).
+#
+# Set empty to restore the pre-#3844 public-discovery behavior (non-Catalyst
+# installs / clusters where the public issuer DOES hairpin).
+keycloakInternalURL: "http://keycloak.keycloak.svc.cluster.local"
+
 image:
   # Rendered as <registryMirror>/<repository>:<tag> — matches the
   # harbor-proxy-pull `*/proxy-*/*` glob.


### PR DESCRIPTION
## Verified gap (cycle-2 VERIFY-first)

The `sso`-epic #3374 walk on hw167 had ~20 RED rows. Cycle-1.5 already merged several SSO fixes (gitea durable SSO #3851, pdns-admin dual-callback #3869, gitea test alignment #3861). After verifying what is GENUINELY still unfixed on `main`:

| SSO gap | State on main |
|---|---|
| #3850 gitea-SSO durable (Job→Deployment) | **already FIXED** (855e3a07 #3851 + #3861) — `sso-configure-deployment.yaml` present |
| #3869 pdns-admin dual-callback redirect_uri | **already FIXED** (44907c60) |
| **#3844 oidc-gate discovery hairpin** | **STILL BROKEN** — no in-cluster discovery split anywhere |

## The fix (#3844)

oauth2-proxy did its OIDC discovery + every backchannel leg (token redeem, JWKS, userinfo) at the **public** issuer `https://auth.<fqdn>/realms/sovereign`. On Huawei/kom4dc a Pod cannot dial the Sovereign's own public EIP — it is ELB-DNAT'd and does NOT hairpin back in (same class as #3241). So startup discovery timed out (`error while discovery OIDC configuration: dial tcp <eip>:443: i/o timeout`) and **every** oidc-gate instance (openova-flow, powerdns-admin) CrashLooped before initialising — the #3374 zero-click rows 3374-36/37/38 were RED at the **pod** level regardless of realm/client/secret correctness (proven live hw167, dep `28d4e96f96407bbb`). A 302→realm wire-proof was never even reachable — the gate never started.

New `keycloakInternalURL` value (default the in-cluster keycloak Service `http://keycloak.keycloak.svc.cluster.local`, the proven bp-gitea seam). When set, the gate uses `--skip-oidc-discovery` + explicit `--redeem-url`/`--oidc-jwks-url`/`--profile-url` pointed at the in-cluster Service, keeping `--oidc-issuer-url` + `--login-url` + `--redirect-url` **public** (browser leg + `iss` validation). bp-keycloak pins `KC_HOSTNAME` public (`keycloak-frontend-env.yaml`), so the token `iss` still matches the public issuer even though the endpoints are dialed internally — the exact frontchannel-public/backchannel-internal split KC already establishes. Set empty to restore the pre-#3844 public-discovery path.

## Render / build proof

- `helm template` with `keycloakInternalURL` default → `--skip-oidc-discovery=true` + internal `redeem`/`jwks`/`profile` URLs; `oidc-issuer-url`/`login-url`/`redirect-url` stay public.
- `helm template` with `keycloakInternalURL=""` → byte-identical to pre-#3844 (none of the skip-discovery flags).
- New test `chart/tests/internal-discovery-render.sh` (3 cases) PASS; existing `root-redirect-render.sh` PASS (no regression).
- `helm lint` clean; `kubectl kustomize clusters/_template/bootstrap-kit` builds.
- Chart 0.1.4→0.1.5, `blueprint.yaml` + slot 13c pin lockstep.

## Note

Do NOT merge yet — a chart merge would roll the mothership and abandon the in-flight hw170 prov. Open for merge onto the next train after hw170 converges; the live re-walk of rows 3374-36/37/38 on a fresh prov is the acceptance.

Refs #3844 #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)