### PR TITLE
fix(provisioning): reap stale in-flight provision so a crashed/rolled Pod can't permanently wedge a tenant out of the funnel

### DIFF
--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -57,6 +57,15 @@ type orderPlacedData struct {
 
 const topicProvisionEvents = "sme.provision.events"
 
+// staleProvisionTimeout (#3898) is how long an in-flight provision row may go
+// without an updated_at refresh before the dedup collision path treats it as
+// abandoned and reaps it. The workflow refreshes updated_at on every step and
+// its longest single wait is 10 minutes (waitForHelmRelease / waitForVclusterApp),
+// so 30 minutes leaves a comfortable margin: a healthy provision is never
+// reaped, but a row stranded by a Pod crash/roll is recovered well before a
+// human would notice the tenant wedged out of the funnel.
+const staleProvisionTimeout = 30 * time.Minute
+
 // StartConsumer listens for tenant + order events and routes them to the
 // per-event handlers. The subscriber argument is whatever transport the
 // service was wired with — on Sovereigns this is a NATS-backed
@@ -933,6 +942,8 @@ func (h *Handler) startProvisioning(ctx context.Context, tenantID, orderID, plan
 	// forking a duplicate workflow — mirroring CreateJobIfAbsent's #71 dedup for
 	// day-2 Jobs. The decision is extracted into a pure helper so the exact
 	// double-fire → single-provision semantics are unit-testable without Mongo.
+	// The helper also folds in the #3898 stale-in-flight reap so a crashed/rolled
+	// provisioning Pod can't permanently wedge a tenant out of the #3376 funnel.
 	result, err := dedupProvisionCreate(ctx, h.Store, provision, tenantID)
 	if err != nil {
 		slog.Error("provision-create dedup failed", "tenant_id", tenantID, "error", err)
@@ -966,6 +977,10 @@ func (h *Handler) startProvisioning(ctx context.Context, tenantID, orderID, plan
 type provisionDedupStore interface {
 	CreateProvisionIfAbsent(ctx context.Context, p *store.Provision) error
 	GetInFlightProvisionByTenant(ctx context.Context, tenantID string) (*store.Provision, error)
+	// ReapStaleInFlightProvision (#3898) clears an abandoned in-flight row whose
+	// owning workflow goroutine died with its Pod, so the partial-unique index
+	// releases and a legitimate re-provision can proceed.
+	ReapStaleInFlightProvision(ctx context.Context, tenantID string, staleAfter time.Duration) (int, error)
 }
 
 // dedupDecision is the outcome of the #3744 provision-create dedup. When fork is
@@ -984,8 +999,10 @@ type dedupDecision struct {
 // loser returns it instead of forking a duplicate workflow → duplicate Gitea
 // commit → ref-lock race → failed tenant.
 //
-// Three outcomes:
+// Outcomes:
 //   - insert wins  → {provision, fork:true}   (start one workflow)
+//   - collision, stale row reaped + re-insert wins → {provision, fork:true}
+//     (#3898 — the prior owning Pod died; this re-provision legitimately forks)
 //   - collision, in-flight row found → {existing, fork:false}
 //   - collision, row already terminal → {provision, fork:false} (benign: the
 //     prior workflow owns the outcome; a later legitimate re-provision succeeds
@@ -993,6 +1010,34 @@ type dedupDecision struct {
 func dedupProvisionCreate(ctx context.Context, st provisionDedupStore, provision *store.Provision, tenantID string) (dedupDecision, error) {
 	if err := st.CreateProvisionIfAbsent(ctx, provision); err != nil {
 		if errors.Is(err, store.ErrProvisionExists) {
+			// #3898 — before surfacing the in-flight row, reap it if it is
+			// stale. A provisioning Pod crash/roll abandons the detached
+			// runProvisioningWorkflow goroutine, stranding the row at
+			// "provisioning" forever; the partial-unique index then wedges this
+			// tenant out of the funnel because every re-provision short-circuits
+			// on the dead row. A live workflow refreshes updated_at on every
+			// step, so only a genuinely abandoned row (no progress for
+			// staleProvisionTimeout) is reaped. If one was, retry the insert so
+			// the legitimate re-provision forks a fresh workflow.
+			if reaped, reapErr := st.ReapStaleInFlightProvision(ctx, tenantID, staleProvisionTimeout); reapErr != nil {
+				slog.Warn("duplicate provision dispatch: stale-provision reap failed — surfacing existing row",
+					"tenant_id", tenantID, "error", reapErr)
+			} else if reaped > 0 {
+				slog.Info("duplicate provision dispatch: reaped stale in-flight provision — re-forking workflow",
+					"tenant_id", tenantID, "reaped", reaped)
+				if reErr := st.CreateProvisionIfAbsent(ctx, provision); reErr != nil {
+					if !errors.Is(reErr, store.ErrProvisionExists) {
+						return dedupDecision{}, reErr
+					}
+					// Another writer won the post-reap insert race; fall through
+					// to surface whatever in-flight row now exists.
+					slog.Info("duplicate provision dispatch: lost the post-reap insert race — surfacing the winner",
+						"tenant_id", tenantID)
+				} else {
+					// Won the insert post-reap — fork as a fresh provision.
+					return dedupDecision{provision: provision, fork: true}, nil
+				}
+			}
 			existing, getErr := st.GetInFlightProvisionByTenant(ctx, tenantID)
 			if getErr != nil {
 				return dedupDecision{}, getErr

--- a/core/services/provisioning/handlers/provision_dedup_test.go
+++ b/core/services/provisioning/handlers/provision_dedup_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/openova-io/openova/core/services/provisioning/store"
 )
@@ -28,6 +29,17 @@ type fakeDedupStore struct {
 	// dropInFlight, when true, makes GetInFlightProvisionByTenant return
 	// (nil, nil) to model the "row terminated between collision and lookup" race.
 	dropInFlight bool
+	// reapStale, when true, makes ReapStaleInFlightProvision (#3898) clear the
+	// in-flight row and report 1 reaped — modelling a crashed/rolled provisioning
+	// Pod whose abandoned row is now older than staleProvisionTimeout. Default
+	// false: a live in-flight workflow is NOT reaped, preserving the #3744
+	// double-fire → single-provision semantics the other tests assert.
+	reapStale bool
+	// reapErr, when set, is returned by ReapStaleInFlightProvision to exercise
+	// the reap-failure branch (which falls back to surfacing the existing row).
+	reapErr error
+	// reapCalls counts every ReapStaleInFlightProvision attempt.
+	reapCalls int32
 }
 
 func newFakeDedupStore() *fakeDedupStore {
@@ -52,6 +64,23 @@ func (f *fakeDedupStore) CreateProvisionIfAbsent(_ context.Context, p *store.Pro
 	cp := *p
 	f.inflight[p.TenantID] = &cp
 	return nil
+}
+
+func (f *fakeDedupStore) ReapStaleInFlightProvision(_ context.Context, tenantID string, _ time.Duration) (int, error) {
+	atomic.AddInt32(&f.reapCalls, 1)
+	if f.reapErr != nil {
+		return 0, f.reapErr
+	}
+	if !f.reapStale {
+		return 0, nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.inflight[tenantID]; ok {
+		delete(f.inflight, tenantID)
+		return 1, nil
+	}
+	return 0, nil
 }
 
 func (f *fakeDedupStore) GetInFlightProvisionByTenant(_ context.Context, tenantID string) (*store.Provision, error) {
@@ -193,5 +222,64 @@ func TestDedupProvisionCreate_LookupErrorPropagates(t *testing.T) {
 	_, err := dedupProvisionCreate(ctx, st, &store.Provision{TenantID: tenant, Status: "provisioning"}, tenant)
 	if err != wantErr {
 		t.Fatalf("lookup error must propagate, got %v want %v", err, wantErr)
+	}
+}
+
+// TestDedupProvisionCreate_StaleRowReapedThenForks covers the #3898 funnel-wedge
+// escape: a prior provisioning Pod crashed/rolled, abandoning an in-flight row
+// older than staleProvisionTimeout. The collision MUST reap that dead row and
+// re-insert so the legitimate re-provision forks a fresh workflow — otherwise
+// the partial-unique index wedges the tenant out of the #3376 funnel forever.
+func TestDedupProvisionCreate_StaleRowReapedThenForks(t *testing.T) {
+	st := newFakeDedupStore()
+	ctx := context.Background()
+	const tenant = "walk-stranger-co"
+
+	// Seed the abandoned in-flight row left by the crashed Pod.
+	if _, err := dedupProvisionCreate(ctx, st, &store.Provision{TenantID: tenant, Status: "provisioning"}, tenant); err != nil {
+		t.Fatalf("seed stale provision errored: %v", err)
+	}
+	// The row is now stale → the reaper clears it on the next collision.
+	st.reapStale = true
+
+	reprov := &store.Provision{ID: "reprov-after-reap", TenantID: tenant, Status: "provisioning"}
+	d, err := dedupProvisionCreate(ctx, st, reprov, tenant)
+	if err != nil {
+		t.Fatalf("dedupProvisionCreate after reap errored: %v", err)
+	}
+	if !d.fork {
+		t.Fatal("a reaped stale row must let the re-provision fork a fresh workflow, got fork=false")
+	}
+	if d.provision != reprov {
+		t.Fatalf("post-reap fork must return the freshly-inserted provision, got %+v", d.provision)
+	}
+	if got := atomic.LoadInt32(&st.reapCalls); got != 1 {
+		t.Fatalf("exactly one reap attempt expected on the collision, got %d", got)
+	}
+}
+
+// TestDedupProvisionCreate_ReapFailureSurfacesExistingRow ensures a reap error
+// does not crash the dispatch: it falls back to surfacing the existing in-flight
+// row (fork=false), exactly as a non-stale collision would.
+func TestDedupProvisionCreate_ReapFailureSurfacesExistingRow(t *testing.T) {
+	st := newFakeDedupStore()
+	ctx := context.Background()
+	const tenant = "walk-stranger-co"
+
+	first := &store.Provision{TenantID: tenant, Status: "provisioning"}
+	if _, err := dedupProvisionCreate(ctx, st, first, tenant); err != nil {
+		t.Fatalf("seed provision errored: %v", err)
+	}
+	st.reapErr = context.DeadlineExceeded
+
+	d, err := dedupProvisionCreate(ctx, st, &store.Provision{TenantID: tenant, Status: "provisioning"}, tenant)
+	if err != nil {
+		t.Fatalf("reap-failure must not propagate as a dispatch error, got %v", err)
+	}
+	if d.fork {
+		t.Fatal("reap failure must surface the existing row without forking, got fork=true")
+	}
+	if d.provision.ID != first.ID {
+		t.Fatalf("reap failure must return the existing in-flight row, got %+v", d.provision)
 	}
 }

--- a/core/services/provisioning/handlers/stale_provision_reap_test.go
+++ b/core/services/provisioning/handlers/stale_provision_reap_test.go
@@ -1,0 +1,46 @@
+// stale_provision_reap_test.go — #3898.
+//
+// The dedup collision path (startProvisioning) reaps an in-flight provision
+// row that has gone stale — abandoned by a provisioning Pod crash/roll — so the
+// uniq_inflight_tenant partial index releases and the tenant can re-provision
+// instead of wedging out of the #3376 funnel forever.
+//
+// The reap is only SAFE if the staleness threshold is strictly larger than the
+// longest gap a HEALTHY workflow can leave between updated_at refreshes. The
+// workflow stamps updated_at on every markStep / completeStep, and its longest
+// single blocking wait is 10 minutes (waitForHelmRelease / waitForVclusterApp).
+// If staleProvisionTimeout were ≤ that wait, a perfectly healthy provision that
+// happened to be mid-wait at the moment of a duplicate dispatch could be reaped
+// out from under its own running goroutine — forking a second workflow and
+// re-introducing the exact #3744 self-race the dedup exists to prevent.
+//
+// This test pins that invariant in code so a future tightening of the threshold
+// can't silently re-open the race.
+
+package handlers
+
+import (
+	"testing"
+	"time"
+)
+
+// maxSingleStepWait is the longest single blocking wait in
+// runProvisioningWorkflow (waitForHelmRelease + each waitForVclusterApp are all
+// 10 minutes). Kept here as the asserted reference; if the workflow ever grows
+// a longer wait, this constant — and staleProvisionTimeout — must grow with it.
+const maxSingleStepWait = 10 * time.Minute
+
+func TestStaleProvisionTimeout_ExceedsLongestHealthyStepWait(t *testing.T) {
+	if staleProvisionTimeout <= maxSingleStepWait {
+		t.Fatalf("staleProvisionTimeout (%s) must be strictly greater than the longest healthy single-step wait (%s); "+
+			"otherwise the #3898 reaper could kill a healthy in-flight provision mid-wait and re-open the #3744 self-race",
+			staleProvisionTimeout, maxSingleStepWait)
+	}
+	// A comfortable margin (≥2×) guards against clock skew between the worker
+	// stamping updated_at and the reaper computing its cutoff.
+	if staleProvisionTimeout < 2*maxSingleStepWait {
+		t.Errorf("staleProvisionTimeout (%s) leaves under a 2× margin over the longest step wait (%s) — "+
+			"prefer more headroom so clock skew can't trip a premature reap",
+			staleProvisionTimeout, maxSingleStepWait)
+	}
+}

--- a/core/services/provisioning/store/provision_dedup_test.go
+++ b/core/services/provisioning/store/provision_dedup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 )
 
 // TestCreateProvisionIfAbsent_RejectsEmptyTenant proves the dedup guard refuses
@@ -49,5 +50,56 @@ func TestInFlightProvisionStatuses_ExcludesTerminal(t *testing.T) {
 		if got[terminal] {
 			t.Errorf("inFlightProvisionStatuses must NOT include terminal status %q (would block legitimate re-provision)", terminal)
 		}
+	}
+}
+
+// TestProvisionIsStale_BoundaryAndFreshness pins down the staleness predicate
+// the #3898 reaper's `updated_at < now-staleAfter` Mongo filter mirrors. The
+// two load-bearing properties:
+//
+//   - a row whose updated_at is OLDER than the threshold is stale (reapable) —
+//     this is what lets a crash-/roll-stranded "provisioning" row release the
+//     uniq_inflight_tenant index so the tenant can re-provision;
+//   - a row that was JUST refreshed (or is exactly at the cutoff) is NOT stale,
+//     so a healthy workflow — which stamps updated_at on every step — is never
+//     reaped out from under itself.
+func TestProvisionIsStale_BoundaryAndFreshness(t *testing.T) {
+	now := time.Now().UTC()
+	const staleAfter = 30 * time.Minute
+
+	cases := []struct {
+		name      string
+		updatedAt time.Time
+		want      bool
+	}{
+		{"freshly refreshed", now, false},
+		{"one second old", now.Add(-1 * time.Second), false},
+		{"just under threshold", now.Add(-(staleAfter - time.Minute)), false},
+		{"exactly at cutoff is not stale", now.Add(-staleAfter), false},
+		{"just over threshold", now.Add(-(staleAfter + time.Minute)), true},
+		{"abandoned for hours", now.Add(-6 * time.Hour), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := provisionIsStale(tc.updatedAt, now, staleAfter); got != tc.want {
+				t.Fatalf("provisionIsStale(updatedAt=%s ago) = %v, want %v",
+					now.Sub(tc.updatedAt), got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReapStaleInFlightProvision_RequiresTenant proves the reaper refuses to run
+// an unscoped UpdateMany. A blank tenant_id with the in-flight-status filter
+// would otherwise reap EVERY tenant's stale provisions at once; the guard keeps
+// the reap scoped to the one tenant whose re-provision triggered the collision.
+func TestReapStaleInFlightProvision_RequiresTenant(t *testing.T) {
+	s := &Store{} // no db — the guard must return before any collection access
+	n, err := s.ReapStaleInFlightProvision(context.Background(), "", time.Minute)
+	if err == nil {
+		t.Fatal("ReapStaleInFlightProvision with empty tenantID must error, got nil")
+	}
+	if n != 0 {
+		t.Fatalf("ReapStaleInFlightProvision with empty tenantID must reap 0, got %d", n)
 	}
 }

--- a/core/services/provisioning/store/store.go
+++ b/core/services/provisioning/store/store.go
@@ -150,6 +150,66 @@ func (s *Store) GetInFlightProvisionByTenant(ctx context.Context, tenantID strin
 	return &p, nil
 }
 
+// ReapStaleInFlightProvision (#3898) marks any in-flight provision for a tenant
+// whose updated_at is older than staleAfter as failed, returning the number of
+// rows reaped.
+//
+// Why this exists: startProvisioning inserts the provision row at status
+// "provisioning" then runs the actual work in a DETACHED goroutine
+// (runProvisioningWorkflow). The workflow refreshes updated_at on every step.
+// But if the provisioning Pod crashes or is rolled mid-workflow — a routine
+// event, since a deploy roll abandons the in-flight goroutine — the row is left
+// at "provisioning" forever; nothing ever transitions it to a terminal state.
+// From then on the partial unique index uniq_inflight_tenant
+// (EnsureProvisionIndexes) makes every legitimate re-provision collide in
+// CreateProvisionIfAbsent and short-circuit on the DEAD row, permanently
+// wedging that tenant out of the #3376 funnel with no operator-free recovery.
+//
+// The reaper closes that hole: a live workflow keeps updated_at fresh
+// (UpdateStep / UpdateProvision both stamp it), so only a genuinely abandoned
+// row — no progress for staleAfter — is reaped. Marking it "failed" drops it
+// out of inFlightProvisionStatuses, releasing the partial-unique index so a
+// re-issued CreateProvisionIfAbsent succeeds.
+//
+// Called from the CreateProvisionIfAbsent collision path before surfacing the
+// existing provision, so the cost is paid only on the rare double-trigger /
+// retry — never on the happy path.
+func (s *Store) ReapStaleInFlightProvision(ctx context.Context, tenantID string, staleAfter time.Duration) (int, error) {
+	if tenantID == "" {
+		// An unscoped reap would UpdateMany across EVERY tenant's stale
+		// provisions; the caller always has a concrete tenant here (the one
+		// whose re-provision collided), so a blank value is a programmer
+		// error, not a license to reap the whole collection.
+		return 0, fmt.Errorf("store: ReapStaleInFlightProvision requires tenantID")
+	}
+	cutoff := time.Now().UTC().Add(-staleAfter)
+	filter := bson.D{
+		{Key: "tenant_id", Value: tenantID},
+		{Key: "status", Value: bson.D{{Key: "$in", Value: inFlightProvisionStatuses}}},
+		{Key: "updated_at", Value: bson.D{{Key: "$lt", Value: cutoff}}},
+	}
+	update := bson.D{
+		{Key: "$set", Value: bson.D{
+			{Key: "status", Value: "failed"},
+			{Key: "updated_at", Value: time.Now().UTC()},
+		}},
+	}
+	res, err := s.provisions().UpdateMany(ctx, filter, update)
+	if err != nil {
+		return 0, fmt.Errorf("store: reap stale in-flight provision for tenant %s: %w", tenantID, err)
+	}
+	return int(res.ModifiedCount), nil
+}
+
+// provisionIsStale is the pure predicate the ReapStaleInFlightProvision Mongo
+// `updated_at < now-staleAfter` filter mirrors. Keeping it as a standalone,
+// directly-testable function pins down the boundary semantics — a row exactly
+// at the cutoff is NOT stale (strictly-older only), so a workflow that just
+// refreshed updated_at is never reaped — without requiring a live database.
+func provisionIsStale(updatedAt, now time.Time, staleAfter time.Duration) bool {
+	return updatedAt.Before(now.Add(-staleAfter))
+}
+
 // GetProvision returns a provision by ID.
 func (s *Store) GetProvision(ctx context.Context, id string) (*Provision, error) {
 	var p Provision


### PR DESCRIPTION
Refs #3898 #3744 #3376

## Verified-first context

This is the cycle-2 VERIFY-FIRST funnel pass. Before fixing, I re-verified each cycle-1.5 funnel area against `main` and found them genuinely fixed at the code level:

- **redeem double-fire idempotency (#3744/#3798):** the billing redeem path is double-guarded (`promo_redemptions` PRIMARY KEY `(customer_id, code)` + `SELECT … FOR UPDATE` on the promo row) and the provisioning create path is dedup-guarded by the `uniq_inflight_tenant` partial index. The frontend fires `createCheckout` once and `startProvisioning` once; the redeem itself runs exactly once. Genuinely fixed.
- **per-Org image proxy (#3760/#3785/#3880):** every app + DB-backing + vCluster image flows through `proxyImage()` — no bare `docker.io`/`ghcr.io`/`registry.k8s.io` image reaches kyverno-enforce in a customer vCluster. Genuinely fixed.
- **slug-FQDN namespace (#3830/#3833):** every catalyst-api seam that turns an Org ref into a namespace routes through the single `orgNamespace()` helper (create + ensure + lookup + CR `metadata.namespace` + backing-service create) — no split-brain. Genuinely fixed.
- **redeem-page brand/host (#3376 rows 75-77):** `redeem.astro` uses relative `/api/...` + `/plans` URLs and CSS-variable branding with no `openova.io` host literal; the brand table is runtime-injected, never a source literal. Genuinely fixed.

The remaining `❌` rows in `docs/ledger/UAT.md` (funnel 87-95, model 5-25) are **runtime/env-dependent** — they failed on hw167 because that env was wedged, not because of a code defect; the code paths that produce those surfaces are correct.

## The one genuine code-fixable gap this PR closes

Verifying the dedup surfaced a real, code-level, test-verifiable hole that survives any env. The dedup partial index `uniq_inflight_tenant` filters on in-flight statuses (`pending`/`provisioning`/`running`). `startProvisioning` inserts the row at `provisioning` then runs the work in a **detached goroutine** that refreshes `updated_at` on every step. If the provisioning Pod **crashes or is rolled mid-workflow** — a routine event; a deploy roll abandons the in-flight goroutine — the row is stranded at `provisioning` **forever**. From then on every legitimate re-provision for that tenant collides in `CreateProvisionIfAbsent` and short-circuits on the **dead** row, permanently wedging the customer out of the funnel with no operator-free recovery (no TTL, no reaper).

### Fix

In the dedup collision path, reap any in-flight row whose `updated_at` is older than `staleProvisionTimeout` (30m — comfortably above the workflow's longest single 10m step wait) before surfacing the existing row. A live workflow keeps `updated_at` fresh and is never reaped; a genuinely abandoned row is marked `failed`, releasing the partial-unique index, and the insert is re-tried so the re-provision proceeds (with a post-reap insert-race fallback).

- `store.ReapStaleInFlightProvision` — scoped `UpdateMany` that refuses a blank tenant (so it can never reap the whole collection); `provisionIsStale` pure predicate mirrors the Mongo `updated_at < now-staleAfter` filter (strictly-older, so exactly-at-cutoff is not stale).
- `consumer.go` — wire the reap + re-fork into the collision branch.

### Tests

- `provisionIsStale` boundary/freshness table — exactly-at-cutoff is NOT stale, a freshly-refreshed row is never reaped.
- reaper empty-tenant guard.
- `staleProvisionTimeout` is strictly greater than the longest healthy single-step wait (10m), with a ≥2× margin assertion, so the reaper can never kill a healthy provision mid-wait and re-open the #3744 self-race.

## Validation

- `go build ./...` (provisioning module) — clean
- `go vet ./...` — clean
- `go test ./...` (provisioning module) — all green, new tests included

## Do not merge yet

Touches the provisioning surface that runs inside the mothership; a merge now would roll the mothership and abandon the in-flight hw170 prov. Opening UNMERGED for the next train.