### PR TITLE
fix(bp-openbao): escape host-token-reviewer-export shell ${...} vars from Flux postBuild substitution

### DIFF
--- a/clusters/_template/bootstrap-kit-crs/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit-crs/08-openbao.yaml
@@ -248,35 +248,46 @@ spec:
           \nDST=\"openbao-host-token-reviewer-static\"\nNS=\"openbao\"\n# The token\
           \ controller populates the SA-token Secret\n# ASYNCHRONOUSLY \u2014 poll\
           \ until token + ca.crt are both\n# present (the Job's backoffLimit covers\
-          \ a cold prov).\necho \"waiting for ${SRC} data keys (token + ca.crt)\u2026\
-          \"\ntok=\"\"; ca=\"\"\nfor i in $(seq 1 120); do\n  code=$(curl -s -o /tmp/src.json\
-          \ -w '%{http_code}' --cacert \"${CA}\" \\\n    -H \"Authorization: Bearer\
-          \ ${TOKEN}\" \\\n    \"${API}/api/v1/namespaces/${NS}/secrets/${SRC}\")\n\
-          \  if [ \"${code}\" = \"200\" ]; then\n    tok=$(tr -d '\\n' < /tmp/src.json\
+          \ a cold prov).\n#\n# \u26A0\uFE0F  Flux postBuild substitution: the bootstrap-kit-crs\n\
+          # Kustomization (cloudinit-control-plane.tftpl) runs\n# postBuild.substitute\
+          \ over THIS rendered manifest, and\n# Flux replaces EVERY ${VAR} token \u2014\
+          \ including shell vars it\n# has no value for \u2014 with the empty string.\
+          \ So every shell\n# ${...} below is escaped as $${...}: Flux turns $$ into\
+          \ a\n# literal $, leaving ${...} for /bin/sh to expand at runtime\n# (same\
+          \ idiom as sovereign-tls/cilium-envoy-tls-restart-job).\n# Without the escape\
+          \ the rendered script gets --cacert \"\",\n# Authorization: Bearer , and\
+          \ URL \u2026/namespaces//secrets/ \u2192\n# the export Job CrashLoops \u2192\
+          \ bootstrap-kit-crs never goes\n# Ready (Job spec.template immutable so\
+          \ Flux can't repair it)\n# \u2192 the whole platform spine wedges (Refs\
+          \ #3642).\necho \"waiting for $${SRC} data keys (token + ca.crt)\u2026\"\
+          \ntok=\"\"; ca=\"\"\nfor i in $(seq 1 120); do\n  code=$(curl -s -o /tmp/src.json\
+          \ -w '%{http_code}' --cacert \"$${CA}\" \\\n    -H \"Authorization: Bearer\
+          \ $${TOKEN}\" \\\n    \"$${API}/api/v1/namespaces/$${NS}/secrets/$${SRC}\"\
+          )\n  if [ \"$${code}\" = \"200\" ]; then\n    tok=$(tr -d '\\n' < /tmp/src.json\
           \ | grep -oE '\"token\"[[:space:]]*:[[:space:]]*\"[^\"]*\"' | head -1 |\
           \ sed 's/.*\"\\([^\"]*\\)\"$/\\1/')\n    ca=$(tr -d '\\n' < /tmp/src.json\
           \ | grep -oE '\"ca\\.crt\"[[:space:]]*:[[:space:]]*\"[^\"]*\"' | head -1\
-          \ | sed 's/.*\"\\([^\"]*\\)\"$/\\1/')\n    if [ -n \"${tok}\" ] && [ -n\
-          \ \"${ca}\" ]; then\n      echo \"source populated\"; break\n    fi\n  fi\n\
-          \  if [ \"${i}\" = \"120\" ]; then\n    echo \"timeout: ${SRC} token/ca.crt\
+          \ | sed 's/.*\"\\([^\"]*\\)\"$/\\1/')\n    if [ -n \"$${tok}\" ] && [ -n\
+          \ \"$${ca}\" ]; then\n      echo \"source populated\"; break\n    fi\n \
+          \ fi\n  if [ \"$${i}\" = \"120\" ]; then\n    echo \"timeout: $${SRC} token/ca.crt\
           \ absent after 10m\" >&2\n    exit 1\n  fi\n  sleep 5\ndone\n# Build the\
           \ Opaque destination Secret. Data values are\n# the ALREADY-base64 bytes\
           \ from the source (token/ca.crt\n# under .data are base64-encoded), so reuse\
           \ verbatim.\ncat > /tmp/dst.json <<EOF\n{\"apiVersion\":\"v1\",\"kind\"\
-          :\"Secret\",\"metadata\":{\"name\":\"${DST}\",\"namespace\":\"${NS}\",\"\
-          labels\":{\"catalyst.openova.io/blueprint\":\"bp-openbao\",\"catalyst.openova.io/component\"\
+          :\"Secret\",\"metadata\":{\"name\":\"$${DST}\",\"namespace\":\"$${NS}\"\
+          ,\"labels\":{\"catalyst.openova.io/blueprint\":\"bp-openbao\",\"catalyst.openova.io/component\"\
           :\"openbao-host-token-reviewer\",\"app.kubernetes.io/managed-by\":\"flux\"\
-          }},\"type\":\"Opaque\",\"data\":{\"token\":\"${tok}\",\"ca.crt\":\"${ca}\"\
+          }},\"type\":\"Opaque\",\"data\":{\"token\":\"$${tok}\",\"ca.crt\":\"$${ca}\"\
           }}\nEOF\n# Create, or update if it already exists (idempotent).\ncode=$(curl\
-          \ -s -o /tmp/out.json -w '%{http_code}' -X POST --cacert \"${CA}\" \\\n\
-          \  -H \"Authorization: Bearer ${TOKEN}\" -H \"Content-Type: application/json\"\
-          \ \\\n  --data @/tmp/dst.json \\\n  \"${API}/api/v1/namespaces/${NS}/secrets\"\
-          )\nif [ \"${code}\" = \"409\" ]; then\n  echo \"${DST} exists \u2014 updating\"\
+          \ -s -o /tmp/out.json -w '%{http_code}' -X POST --cacert \"$${CA}\" \\\n\
+          \  -H \"Authorization: Bearer $${TOKEN}\" -H \"Content-Type: application/json\"\
+          \ \\\n  --data @/tmp/dst.json \\\n  \"$${API}/api/v1/namespaces/$${NS}/secrets\"\
+          )\nif [ \"$${code}\" = \"409\" ]; then\n  echo \"$${DST} exists \u2014 updating\"\
           \n  code=$(curl -s -o /tmp/out.json -w '%{http_code}' -X PUT --cacert \"\
-          ${CA}\" \\\n    -H \"Authorization: Bearer ${TOKEN}\" -H \"Content-Type:\
-          \ application/json\" \\\n    --data @/tmp/dst.json \\\n    \"${API}/api/v1/namespaces/${NS}/secrets/${DST}\"\
-          )\nfi\ncase \"${code}\" in\n  200|201) echo \"wrote ${DST} (${code})\";;\n\
-          \  *) echo \"failed to write ${DST}: HTTP ${code}\" >&2; cat /tmp/out.json\
+          $${CA}\" \\\n    -H \"Authorization: Bearer $${TOKEN}\" -H \"Content-Type:\
+          \ application/json\" \\\n    --data @/tmp/dst.json \\\n    \"$${API}/api/v1/namespaces/$${NS}/secrets/$${DST}\"\
+          )\nfi\ncase \"$${code}\" in\n  200|201) echo \"wrote $${DST} ($${code})\"\
+          ;;\n  *) echo \"failed to write $${DST}: HTTP $${code}\" >&2; cat /tmp/out.json\
           \ >&2; exit 1;;\nesac\n"
       volumes:
       - name: scratch

--- a/clusters/_template/bootstrap-kit-crs/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit-crs/08-openbao.yaml
@@ -248,21 +248,23 @@ spec:
           \nDST=\"openbao-host-token-reviewer-static\"\nNS=\"openbao\"\n# The token\
           \ controller populates the SA-token Secret\n# ASYNCHRONOUSLY \u2014 poll\
           \ until token + ca.crt are both\n# present (the Job's backoffLimit covers\
-          \ a cold prov).\n#\n# \u26A0\uFE0F  Flux postBuild substitution: the bootstrap-kit-crs\n\
-          # Kustomization (cloudinit-control-plane.tftpl) runs\n# postBuild.substitute\
-          \ over THIS rendered manifest, and\n# Flux replaces EVERY ${VAR} token \u2014\
-          \ including shell vars it\n# has no value for \u2014 with the empty string.\
-          \ So every shell\n# ${...} below is escaped as $${...}: Flux turns $$ into\
-          \ a\n# literal $, leaving ${...} for /bin/sh to expand at runtime\n# (same\
-          \ idiom as sovereign-tls/cilium-envoy-tls-restart-job).\n# Without the escape\
-          \ the rendered script gets --cacert \"\",\n# Authorization: Bearer , and\
-          \ URL \u2026/namespaces//secrets/ \u2192\n# the export Job CrashLoops \u2192\
-          \ bootstrap-kit-crs never goes\n# Ready (Job spec.template immutable so\
-          \ Flux can't repair it)\n# \u2192 the whole platform spine wedges (Refs\
-          \ #3642).\necho \"waiting for $${SRC} data keys (token + ca.crt)\u2026\"\
-          \ntok=\"\"; ca=\"\"\nfor i in $(seq 1 120); do\n  code=$(curl -s -o /tmp/src.json\
-          \ -w '%{http_code}' --cacert \"$${CA}\" \\\n    -H \"Authorization: Bearer\
-          \ $${TOKEN}\" \\\n    \"$${API}/api/v1/namespaces/$${NS}/secrets/$${SRC}\"\
+          \ a cold prov).\n#\n# FLUX POSTBUILD SUBSTITUTION (Refs #3642): the\n# bootstrap-kit-crs\
+          \ Kustomization (cloudinit-control-\n# plane.tftpl) runs postBuild.substitute\
+          \ (drone/envsubst)\n# over THIS rendered manifest, replacing every shell-var\n\
+          # reference it sees with the empty string. So each shell\n# variable below\
+          \ is written with a DOUBLED leading dollar\n# (the documented escape): envsubst\
+          \ collapses the double\n# dollar to a single literal one and leaves the\
+          \ brace ref\n# for /bin/sh to expand at runtime. Same idiom as\n# sovereign-tls/cilium-envoy-tls-restart-job.\
+          \ Without the\n# escape the rendered script got a blank --cacert, a blank\n\
+          # bearer token, and an empty-namespace URL, so the export\n# Job CrashLooped,\
+          \ the immutable Job blocked the whole\n# bootstrap-kit-crs tier, and the\
+          \ platform spine wedged.\n# NOTE: keep this comment free of a single-dollar\
+          \ brace\n# reference \u2014 drone/envsubst parses comments too and fails\n\
+          # hard (\"unable to parse variable name\") on a dollar-brace\n# that is\
+          \ not a valid identifier.\necho \"waiting for $${SRC} data keys (token +\
+          \ ca.crt)\u2026\"\ntok=\"\"; ca=\"\"\nfor i in $(seq 1 120); do\n  code=$(curl\
+          \ -s -o /tmp/src.json -w '%{http_code}' --cacert \"$${CA}\" \\\n    -H \"\
+          Authorization: Bearer $${TOKEN}\" \\\n    \"$${API}/api/v1/namespaces/$${NS}/secrets/$${SRC}\"\
           )\n  if [ \"$${code}\" = \"200\" ]; then\n    tok=$(tr -d '\\n' < /tmp/src.json\
           \ | grep -oE '\"token\"[[:space:]]*:[[:space:]]*\"[^\"]*\"' | head -1 |\
           \ sed 's/.*\"\\([^\"]*\\)\"$/\\1/')\n    ca=$(tr -d '\\n' < /tmp/src.json\

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -852,19 +852,24 @@ spec:
                           # ASYNCHRONOUSLY — poll until token + ca.crt are both
                           # present (the Job's backoffLimit covers a cold prov).
                           #
-                          # ⚠️  Flux postBuild substitution: the bootstrap-kit-crs
-                          # Kustomization (cloudinit-control-plane.tftpl) runs
-                          # postBuild.substitute over THIS rendered manifest, and
-                          # Flux replaces EVERY ${VAR} token — including shell vars it
-                          # has no value for — with the empty string. So every shell
-                          # ${...} below is escaped as $${...}: Flux turns $$ into a
-                          # literal $, leaving ${...} for /bin/sh to expand at runtime
-                          # (same idiom as sovereign-tls/cilium-envoy-tls-restart-job).
-                          # Without the escape the rendered script gets --cacert "",
-                          # Authorization: Bearer , and URL …/namespaces//secrets/ →
-                          # the export Job CrashLoops → bootstrap-kit-crs never goes
-                          # Ready (Job spec.template immutable so Flux can't repair it)
-                          # → the whole platform spine wedges (Refs #3642).
+                          # FLUX POSTBUILD SUBSTITUTION (Refs #3642): the
+                          # bootstrap-kit-crs Kustomization (cloudinit-control-
+                          # plane.tftpl) runs postBuild.substitute (drone/envsubst)
+                          # over THIS rendered manifest, replacing every shell-var
+                          # reference it sees with the empty string. So each shell
+                          # variable below is written with a DOUBLED leading dollar
+                          # (the documented escape): envsubst collapses the double
+                          # dollar to a single literal one and leaves the brace ref
+                          # for /bin/sh to expand at runtime. Same idiom as
+                          # sovereign-tls/cilium-envoy-tls-restart-job. Without the
+                          # escape the rendered script got a blank --cacert, a blank
+                          # bearer token, and an empty-namespace URL, so the export
+                          # Job CrashLooped, the immutable Job blocked the whole
+                          # bootstrap-kit-crs tier, and the platform spine wedged.
+                          # NOTE: keep this comment free of a single-dollar brace
+                          # reference — drone/envsubst parses comments too and fails
+                          # hard ("unable to parse variable name") on a dollar-brace
+                          # that is not a valid identifier.
                           echo "waiting for $${SRC} data keys (token + ca.crt)…"
                           tok=""; ca=""
                           for i in $(seq 1 120); do

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -851,21 +851,35 @@ spec:
                           # The token controller populates the SA-token Secret
                           # ASYNCHRONOUSLY — poll until token + ca.crt are both
                           # present (the Job's backoffLimit covers a cold prov).
-                          echo "waiting for ${SRC} data keys (token + ca.crt)…"
+                          #
+                          # ⚠️  Flux postBuild substitution: the bootstrap-kit-crs
+                          # Kustomization (cloudinit-control-plane.tftpl) runs
+                          # postBuild.substitute over THIS rendered manifest, and
+                          # Flux replaces EVERY ${VAR} token — including shell vars it
+                          # has no value for — with the empty string. So every shell
+                          # ${...} below is escaped as $${...}: Flux turns $$ into a
+                          # literal $, leaving ${...} for /bin/sh to expand at runtime
+                          # (same idiom as sovereign-tls/cilium-envoy-tls-restart-job).
+                          # Without the escape the rendered script gets --cacert "",
+                          # Authorization: Bearer , and URL …/namespaces//secrets/ →
+                          # the export Job CrashLoops → bootstrap-kit-crs never goes
+                          # Ready (Job spec.template immutable so Flux can't repair it)
+                          # → the whole platform spine wedges (Refs #3642).
+                          echo "waiting for $${SRC} data keys (token + ca.crt)…"
                           tok=""; ca=""
                           for i in $(seq 1 120); do
-                            code=$(curl -s -o /tmp/src.json -w '%{http_code}' --cacert "${CA}" \
-                              -H "Authorization: Bearer ${TOKEN}" \
-                              "${API}/api/v1/namespaces/${NS}/secrets/${SRC}")
-                            if [ "${code}" = "200" ]; then
+                            code=$(curl -s -o /tmp/src.json -w '%{http_code}' --cacert "$${CA}" \
+                              -H "Authorization: Bearer $${TOKEN}" \
+                              "$${API}/api/v1/namespaces/$${NS}/secrets/$${SRC}")
+                            if [ "$${code}" = "200" ]; then
                               tok=$(tr -d '\n' < /tmp/src.json | grep -oE '"token"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
                               ca=$(tr -d '\n' < /tmp/src.json | grep -oE '"ca\.crt"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
-                              if [ -n "${tok}" ] && [ -n "${ca}" ]; then
+                              if [ -n "$${tok}" ] && [ -n "$${ca}" ]; then
                                 echo "source populated"; break
                               fi
                             fi
-                            if [ "${i}" = "120" ]; then
-                              echo "timeout: ${SRC} token/ca.crt absent after 10m" >&2
+                            if [ "$${i}" = "120" ]; then
+                              echo "timeout: $${SRC} token/ca.crt absent after 10m" >&2
                               exit 1
                             fi
                             sleep 5
@@ -874,23 +888,23 @@ spec:
                           # the ALREADY-base64 bytes from the source (token/ca.crt
                           # under .data are base64-encoded), so reuse verbatim.
                           cat > /tmp/dst.json <<EOF
-                          {"apiVersion":"v1","kind":"Secret","metadata":{"name":"${DST}","namespace":"${NS}","labels":{"catalyst.openova.io/blueprint":"bp-openbao","catalyst.openova.io/component":"openbao-host-token-reviewer","app.kubernetes.io/managed-by":"flux"}},"type":"Opaque","data":{"token":"${tok}","ca.crt":"${ca}"}}
+                          {"apiVersion":"v1","kind":"Secret","metadata":{"name":"$${DST}","namespace":"$${NS}","labels":{"catalyst.openova.io/blueprint":"bp-openbao","catalyst.openova.io/component":"openbao-host-token-reviewer","app.kubernetes.io/managed-by":"flux"}},"type":"Opaque","data":{"token":"$${tok}","ca.crt":"$${ca}"}}
                           EOF
                           # Create, or update if it already exists (idempotent).
-                          code=$(curl -s -o /tmp/out.json -w '%{http_code}' -X POST --cacert "${CA}" \
-                            -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" \
+                          code=$(curl -s -o /tmp/out.json -w '%{http_code}' -X POST --cacert "$${CA}" \
+                            -H "Authorization: Bearer $${TOKEN}" -H "Content-Type: application/json" \
                             --data @/tmp/dst.json \
-                            "${API}/api/v1/namespaces/${NS}/secrets")
-                          if [ "${code}" = "409" ]; then
-                            echo "${DST} exists — updating"
-                            code=$(curl -s -o /tmp/out.json -w '%{http_code}' -X PUT --cacert "${CA}" \
-                              -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" \
+                            "$${API}/api/v1/namespaces/$${NS}/secrets")
+                          if [ "$${code}" = "409" ]; then
+                            echo "$${DST} exists — updating"
+                            code=$(curl -s -o /tmp/out.json -w '%{http_code}' -X PUT --cacert "$${CA}" \
+                              -H "Authorization: Bearer $${TOKEN}" -H "Content-Type: application/json" \
                               --data @/tmp/dst.json \
-                              "${API}/api/v1/namespaces/${NS}/secrets/${DST}")
+                              "$${API}/api/v1/namespaces/$${NS}/secrets/$${DST}")
                           fi
-                          case "${code}" in
-                            200|201) echo "wrote ${DST} (${code})";;
-                            *) echo "failed to write ${DST}: HTTP ${code}" >&2; cat /tmp/out.json >&2; exit 1;;
+                          case "$${code}" in
+                            200|201) echo "wrote $${DST} ($${code})";;
+                            *) echo "failed to write $${DST}: HTTP $${code}" >&2; cat /tmp/out.json >&2; exit 1;;
                           esac
                   # #3842: writable scratch for the curl -o targets above
                   # (readOnlyRootFilesystem:true makes the image's own /tmp RO).

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.112
+  version: 1.4.113
   card:
     title: NewAPI
     summary: |


### PR DESCRIPTION
## What

The `openbao-host-token-reviewer-export` Job (bootstrap-kit-crs tier, #3642 host-token-reviewer) embeds a `/bin/sh` script whose `${SRC}`/`${TOKEN}`/`${CA}`/`${NS}`/`${DST}`/`${tok}`/`${ca}`/`${code}`/`${i}`/`${API}` parameter expansions collide with the `bootstrap-kit-crs` Flux Kustomization's `postBuild.substitute` pass (`infra/providers/_shared/cloudinit-control-plane.tftpl`). Flux replaces **every** `${VAR}` token — including shell vars not in its substitute map — with the empty string. The rendered script therefore ran with `--cacert ""`, `Authorization: Bearer ` (blank), and URL `.../namespaces//secrets/` → the Job CrashLoops.

Because the Job `spec.template` is immutable, Flux can't repair it → `bootstrap-kit-crs` `ReconciliationFailed` atomic-voids the whole tier → `bootstrap-kit` stuck → `bp-catalyst-platform` stuck → `sovereign-tls-vars` ConfigMap never ships → the #3890 wildcard cert never issues → console HTTPS 000. Observed live on hw170 (`7dafca226f5bb7ae`), both regions: 51/65 HRs, openbao-export CrashLoop, bootstrap-kit-crs False, sovereign-tls False.

## Fix

Escape every shell `${...}` as `$${...}` — Flux turns `$$` into a literal `$`, leaving `${...}` for `/bin/sh` to expand at runtime. Established idiom (see `clusters/_template/sovereign-tls/cilium-envoy-tls-restart-job.yaml`). The HTTPRoute `${SOVEREIGN_FQDN}` stays un-escaped — that one IS a genuine Flux substitute.

Source of truth is `clusters/_template/bootstrap-kit/placement.yaml` (`hostBridge.hostDocuments`); the slot file `08-openbao.yaml` is regenerated via `scripts/render-slot-placement.py fix` (never hand-edited).

## Validation

- `scripts/render-slot-placement.py check` — green (drift gate).
- `scripts/audit-placement-conformance.py rendered` — green.
- Simulated the Flux `$$`→`$` + empty-substitution transform over the rendered Job script: the post-substitution code preserves `--cacert "${CA}"`, `Bearer ${TOKEN}`, `${API}/api/v1/namespaces/${NS}/secrets/${SRC}`; no blanked artifacts in code lines; `dash -n` clean.
- Live-patched hw170 both regions to confirm the cascade (see issue #3901 for the walk).

`openbao-auth-bootstrap` (BackoffLimitExceeded on the same env) is a downstream effect, not a separate root cause: it's a Helm hook in bp-openbao, not subject to Flux postBuild substitution; it loops only because the static Secret this export Job mints never appeared.

Refs #3642 #3901