### PR TITLE
fix(sovereign-tls): harbor-proxy-glob cilium-envoy-tls-restart + slot-01 busybox images (Refs #3296)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -541,7 +541,14 @@ spec:
         - operator: Exists
       initContainers:
         - name: set-sysctl
-          image: busybox:1.36
+          # docker.io library/busybox routed through the Harbor proxy-dockerhub
+          # project so the ref satisfies the harbor-proxy-pull glob (`*/proxy-*/*`)
+          # and survives the post-handover registry pivot (bare `busybox:1.36`
+          # resolves to the upstream docker.io after the local Harbor takes over,
+          # which the cutover registries.yaml v2 no longer mirrors). Matches the
+          # canonical `harbor.openova.io/proxy-dockerhub/library/...` idiom
+          # (self-sovereign-cutover/chart/values.yaml). Refs #3296.
+          image: harbor.openova.io/proxy-dockerhub/library/busybox:1.36
           securityContext:
             privileged: true
           command:
@@ -557,7 +564,9 @@ spec:
               mountPath: /host
       containers:
         - name: pause
-          image: busybox:1.36
+          # Same docker.io library/busybox via Harbor proxy-dockerhub as the
+          # set-sysctl initContainer above. Refs #3296.
+          image: harbor.openova.io/proxy-dockerhub/library/busybox:1.36
           command: ["/bin/sh", "-c", "sleep infinity"]
           resources:
             requests:

--- a/clusters/_template/sovereign-tls/cilium-envoy-tls-restart-job.yaml
+++ b/clusters/_template/sovereign-tls/cilium-envoy-tls-restart-job.yaml
@@ -179,13 +179,27 @@ spec:
     spec:
       serviceAccountName: cilium-envoy-tls-restart
       restartPolicy: OnFailure
-      # alpine/k8s:1.31.4 — canonical kubectl image used across the
-      # Catalyst fleet (self-sovereign-cutover, seaweedfs, harbor have
-      # all converged on this after Bitnami deprecated public Docker
-      # Hub in 2025). Ships kubectl + sh + standard busybox toolchain.
+      # harbor.openova.io/proxy-dockerhub/alpine/k8s:1.31.4 — canonical
+      # kubectl image used across the Catalyst fleet (self-sovereign-cutover,
+      # seaweedfs, harbor have all converged on alpine/k8s after Bitnami
+      # deprecated public Docker Hub in 2025). Ships kubectl + sh + standard
+      # busybox toolchain.
+      #
+      # MUST route through the Harbor proxy-dockerhub project: the
+      # harbor-proxy-pull Kyverno ClusterPolicy runs validationFailureAction:
+      # Enforce on every Sovereign and only admits images matching
+      # `*/proxy-*/*` or `*/openova-io/*`
+      # (platform/kyverno-policies/chart/values.yaml →
+      # harborProxyPull.allowedImagePatterns). A bare `alpine/k8s:1.31.4`
+      # matches NEITHER glob, so on a fresh prov this Job's pod ImagePull-
+      # BackOffs (kom4dc node containerd only proxies harbor.openova.io) —
+      # cilium-envoy never reloads the freshly-issued wildcard cert and
+      # console HTTPS stays 000. Matches the proxied form already used by the
+      # two sibling jobs in this directory (cert-stuck-nextprivatekey-guard,
+      # legacy-cert-cleanup). Refs #3296.
       containers:
         - name: wait-and-restart
-          image: alpine/k8s:1.31.4
+          image: harbor.openova.io/proxy-dockerhub/alpine/k8s:1.31.4
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.114
+  version: 1.4.115
   card:
     title: NewAPI
     summary: |


### PR DESCRIPTION
## Problem

The `cilium-envoy-tls-restart` Job (ns `kube-system`) — the post-cert envoy SDS hot-reload helper in the sovereign-tls tier — used the **bare Docker Hub image** `alpine/k8s:1.31.4`:

`clusters/_template/sovereign-tls/cilium-envoy-tls-restart-job.yaml`

A bare `alpine/k8s` ref matches **neither** glob in the `harbor-proxy-pull` Kyverno `ClusterPolicy` (`*/proxy-*/*`, `*/openova-io/*` — `validationFailureAction: Enforce` on every Sovereign), and is not in the kom4dc node's containerd `harbor.openova.io` mirror. On a fresh prov this Job **ImagePullBackOffs** → cilium-envoy never reloads the freshly-issued `sovereign-wildcard-tls-*` SDS Secret → **console HTTPS stays `000`** indefinitely.

This violates the #3296 rule: ALL images (including upstream/helper defaults) must be harbor-proxy-globbed.

The two sibling Jobs in the **same directory** already use the proxied form `harbor.openova.io/proxy-dockerhub/alpine/k8s:1.31.1` (`cert-stuck-nextprivatekey-guard.yaml`, `legacy-cert-cleanup-job.yaml`) — only this Job was left bare.

## Fix

- `alpine/k8s:1.31.4` → `harbor.openova.io/proxy-dockerhub/alpine/k8s:1.31.4`

## Sibling audit

A sweep of the same cilium blast radius surfaced **two more bare images** in `clusters/_template/bootstrap-kit/01-cilium.yaml`'s `sysctl-envoy-bind` DaemonSet (slot 01):
- `set-sysctl` initContainer: `busybox:1.36`
- `pause` container: `busybox:1.36`

Both routed through the canonical `proxy-dockerhub/library/...` idiom → `harbor.openova.io/proxy-dockerhub/library/busybox:1.36`. (These run in `kube-system`, which the harbor-proxy-pull policy excludes, and docker.io IS mirrored on Huawei — so lower-risk than the alpine/k8s case — but bare busybox resolves to upstream docker.io post-handover once the bastion mirror is gone and the local Harbor takes over, so proxying is the correct durable form per #3296.)

After the fix, the full `clusters/_template/` image sweep is clean: every `image:` is proxied (`*/proxy-*/*`), native `openova-io`, templated, or an excluded special case.

## Validation

- Both files YAML-structurally validated (Flux `${...}` substitution-aware parse).
- `scripts/check-kyverno-proxy-images.sh` → PASS (no regression on the 4 subchart-wrapping charts it renders; note: this gate does not render raw `clusters/_template/` manifests, which is why this slipped — manual #3296 discipline).

## Notes

- **Env-independent.** Rides the next train — do **not** auto-merge.
- `Refs #3296` `Refs #3903` (not `Closes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
