### PR TITLE
fix(catalyst-console): topology placement-edit dropdown derives mode descriptions from the per-component matrix (openbao active-passive no longer says 'backup-restore') (Refs #3905)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -1814,6 +1814,10 @@ func (h *Handler) runProvisioning(dep *Deployment) {
 		}
 		bridge := dep.jobsBridge
 		dep.mu.Unlock()
+		// Stamp the deployment's cloud provider so the Phase-0 lifecycle
+		// parent group renders "Provision <Provider>" (e.g. "Provision
+		// Huawei") instead of a hardcoded Hetzner label (#3895).
+		bridge.SetProvider(firstProvider(dep.Request))
 		if seedErr := bridge.SeedProvisionerJobs(); seedErr != nil {
 			h.log.Warn("jobs bridge: seed Phase-0 lifecycle jobs failed",
 				"id", dep.ID, "err", seedErr)
@@ -2228,7 +2232,14 @@ func (h *Handler) emitWatchEvent(dep *Deployment, ev provisioner.Event) {
 		bridge = jobs.NewBridge(h.jobs, dep.ID)
 		dep.jobsBridge = bridge
 	}
+	provider := firstProvider(dep.Request)
 	dep.mu.Unlock()
+	// Stamp the provider on the bridge so a lifecycle event that lazily
+	// materialises the Phase-0 group still labels it "Provision
+	// <Provider>" rather than the Hetzner default (#3895).
+	if bridge != nil {
+		bridge.SetProvider(provider)
+	}
 
 	// Forward Phase-1 component events to the jobs bridge. Phase-0
 	// OpenTofu events have no Job analogue and are silently dropped

--- a/products/catalyst/bootstrap/api/internal/handler/jobs.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs.go
@@ -259,6 +259,9 @@ func (h *Handler) chrootSeedJobsStoreIfEmpty(ctx context.Context, dep *Deploymen
 		dep.jobsBridge = bridge
 	}
 	dep.mu.Unlock()
+	// Stamp the deployment's cloud provider so a chroot-replayed Phase-0
+	// lifecycle parent group still renders "Provision <Provider>" (#3895).
+	bridge.SetProvider(firstProvider(dep.Request))
 
 	// Phase-0 lifecycle history — independent of the bootstrap-kit
 	// seed because the lifecycle Jobs live on the mother only and the
@@ -554,6 +557,92 @@ func (h *Handler) chrootSeedReconcilerObservations(ctx context.Context, dep *Dep
 	)
 }
 
+// motherSeedInClusterReconcilers projects the live in-cluster §5a
+// reconciler activities (raw Jobs, recurring CronJobs, Flux
+// Kustomizations, reconciler-marked Deployments — issue #3646) into the
+// per-deployment jobs.Store while the mothership is still watching a
+// fresh prov (#3896).
+//
+// # Why this exists
+//
+// On the mothership the phase1 watcher surfaces ONLY HelmReleases
+// (install-* leaves). The raw in-cluster Jobs that drive convergence — the
+// 17 reconcile/seed/promote batch Jobs a fresh prov spins up — were
+// invisible on the Jobs page for the ENTIRE phase1-watching window, which
+// is precisely the most useful time to watch them. The §5a generic
+// ingestion already exists (helmwatch.ListReconcilerObservations →
+// Bridge.SeedReconcilerObservations) but was wired ONLY for the chroot
+// (Sovereign-side) path via chrootSeedReconcilerObservations, gated behind
+// SOVEREIGN_FQDN. This surfaces the same activities on the mother too.
+//
+// No-op when:
+//   - jobs store / handler isn't wired (h.jobs nil);
+//   - running in chroot mode (SOVEREIGN_FQDN matches dep — the chroot path
+//     already ingests reconcilers, so we never double-run);
+//   - the deployment's kubeconfig isn't reachable yet (sovereignDynamicClient
+//     errors — cloud-init still in flight, no PUT yet). The /jobs read
+//     simply returns the install-* + lifecycle rows it already has and the
+//     next poll retries once the kubeconfig lands.
+//
+// Best-effort + idempotent: SeedReconcilerObservations monotonic-merges
+// (UpsertJob + StartExecution reuse) so repeated /jobs polls never
+// duplicate rows, and every failure path logs at debug/warn and returns —
+// a /jobs read never fails because the projection couldn't run.
+func (h *Handler) motherSeedInClusterReconcilers(ctx context.Context, dep *Deployment) {
+	if h.jobs == nil || dep == nil {
+		return
+	}
+	// Chroot mode already covers this via chrootSeedReconcilerObservations
+	// (called from chrootSeedJobsStoreIfEmpty). Bail so we never run the
+	// same projection twice on a Sovereign-side catalyst-api.
+	if selfFQDN := strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN")); selfFQDN != "" &&
+		strings.EqualFold(selfFQDN, dep.Request.SovereignFQDN) {
+		return
+	}
+
+	dyn, err := h.sovereignDynamicClient(dep)
+	if err != nil {
+		// Kubeconfig not posted back yet (cloud-init in flight) — the
+		// reconcilers simply aren't reachable. Expected during the early
+		// phase1-watching window; the next poll retries.
+		h.log.Debug("mother seed: reconciler dynamic client unavailable",
+			"depId", dep.ID, "err", err)
+		return
+	}
+
+	dep.mu.Lock()
+	bridge := dep.jobsBridge
+	if bridge == nil {
+		bridge = jobs.NewBridge(h.jobs, dep.ID)
+		dep.jobsBridge = bridge
+	}
+	provider := firstProvider(dep.Request)
+	dep.mu.Unlock()
+	bridge.SetProvider(provider)
+
+	obs, err := helmwatch.ListReconcilerObservations(ctx, dyn)
+	if err != nil {
+		h.log.Warn("mother seed: list reconciler observations failed",
+			"depId", dep.ID, "err", err)
+		return
+	}
+	if len(obs) == 0 {
+		return
+	}
+	jobsCount, execsSeeded, err := bridge.SeedReconcilerObservations(reconcilerObsToBridge(obs))
+	if err != nil {
+		h.log.Warn("mother seed: reconciler bridge seed failed",
+			"depId", dep.ID, "err", err)
+		return
+	}
+	h.log.Info("mother seed: in-cluster reconciler activities projected",
+		"depId", dep.ID,
+		"observations", len(obs),
+		"jobsWritten", jobsCount,
+		"executionsSeeded", execsSeeded,
+	)
+}
+
 // reconcilerObsToBridge translates the helmwatch wire shape into the
 // jobs-local ReconcilerObservation the bridge consumes (the same
 // snapshot→seed indirection snapshotsToSeeds uses, keeping the jobs
@@ -635,6 +724,14 @@ func (h *Handler) ListJobs(w http.ResponseWriter, r *http.Request) {
 		// from a one-shot live HelmRelease list when running on the
 		// Sovereign cluster itself. Mother behaviour unchanged.
 		h.chrootSeedJobsStoreIfEmpty(r.Context(), dep)
+		// Mother-side in-cluster reconciler ingestion (#3896). During
+		// phase1-watching the mothership watches HelmReleases (install-*
+		// leaves) but never surfaces the raw in-cluster Jobs/CronJobs/
+		// Kustomizations/reconciler Deployments — the most useful rows to
+		// watch while a fresh prov converges. No-op on the chroot (the
+		// path above already covers it) and when the deployment's
+		// kubeconfig isn't reachable yet.
+		h.motherSeedInClusterReconcilers(r.Context(), dep)
 	}
 	out, err := st.ListJobs(depID)
 	if err != nil {

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_mother_reconcilers_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_mother_reconcilers_test.go
@@ -1,0 +1,239 @@
+// jobs_mother_reconcilers_test.go — coverage for the mother-side in-cluster
+// reconciler ingestion (#3896 / Refs #3646).
+//
+// On the mothership during phase1-watching the catalyst-api watches
+// HelmReleases (install-* leaves) but never surfaced the raw in-cluster
+// Jobs/CronJobs/Kustomizations the convergence spins up — invisible during
+// the most useful window. motherSeedInClusterReconcilers closes that gap:
+// it lists §5a reconciler observations via the deployment's reachable
+// kubeconfig and projects them into the same jobs.Store the /jobs read
+// returns. These tests prove (a) a running in-cluster Job surfaces as a
+// task-* leaf on the mother, and (b) the chroot-mode short-circuit so the
+// projection never double-runs on a Sovereign-side catalyst-api.
+package handler
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// fakeJobDynamicClient builds a dynamic.Interface serving the given batch
+// Jobs (each running, no owner) so ListReconcilerObservations surfaces them
+// as standalone task-<name> leaves. Every reconciler GVR's List kind is
+// registered (ListReconcilerObservations enumerates all four — an
+// unregistered List kind panics the fake rather than returning the empty
+// list production would see).
+func fakeJobDynamicClient(t *testing.T, jobNames ...string) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	for _, lk := range []schema.GroupVersionKind{
+		{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Kind: "KustomizationList"},
+		{Group: "batch", Version: "v1", Kind: "CronJobList"},
+		{Group: "batch", Version: "v1", Kind: "JobList"},
+		{Group: "apps", Version: "v1", Kind: "DeploymentList"},
+	} {
+		scheme.AddKnownTypeWithName(lk, &unstructured.UnstructuredList{})
+	}
+	objs := make([]runtime.Object, 0, len(jobNames))
+	for _, name := range jobNames {
+		u := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "batch/v1",
+				"kind":       "Job",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": "flux-system",
+				},
+				// No conditions ⇒ jobRunStatus defaults to "running".
+				"status": map[string]any{},
+			},
+		}
+		u.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: "batch", Version: "v1", Kind: "Job",
+		})
+		objs = append(objs, u)
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			helmwatch.KustomizationGVR: "KustomizationList",
+			helmwatch.CronJobGVR:       "CronJobList",
+			helmwatch.JobGVR:           "JobList",
+			helmwatch.DeploymentGVR:    "DeploymentList",
+		},
+		objs...,
+	)
+}
+
+// writeTempKubeconfig drops a placeholder kubeconfig file on disk so
+// sovereignDynamicClient's os.ReadFile succeeds; the bytes are never parsed
+// because the test injects h.dynamicFactory.
+func writeTempKubeconfig(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "kubeconfig.yaml")
+	if err := os.WriteFile(path, []byte("placeholder: kubeconfig"), 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+	return path
+}
+
+// TestMotherSeedInClusterReconcilers_SurfacesRunningJob is the end-to-end
+// proof for #3896: a running in-cluster Job must surface as a task-* leaf
+// in jobs.Store on the MOTHER (SOVEREIGN_FQDN unset) during
+// phase1-watching, via the deployment's reachable kubeconfig.
+func TestMotherSeedInClusterReconcilers_SurfacesRunningJob(t *testing.T) {
+	// Mother mode — explicitly unset so a polluted env never flips us to
+	// the chroot short-circuit.
+	t.Setenv("SOVEREIGN_FQDN", "")
+
+	const depID = "dep3896"
+	st, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	fake := fakeJobDynamicClient(t, "cnpg-pair-join", "openbao-init", "keycloak-realm-seed")
+	h := &Handler{
+		jobs: st,
+		log:  slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		dynamicFactory: func(string) (dynamic.Interface, error) {
+			return fake, nil
+		},
+	}
+	dep := &Deployment{
+		ID:     depID,
+		Status: "phase1-watching",
+		Request: provisioner.Request{
+			SovereignFQDN: "hw170.omani.works",
+			Regions:       []provisioner.RegionSpec{{Provider: "huawei"}},
+		},
+		Result: &provisioner.Result{KubeconfigPath: writeTempKubeconfig(t)},
+	}
+
+	h.motherSeedInClusterReconcilers(context.Background(), dep)
+
+	got, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+
+	want := map[string]bool{
+		jobs.TaskJobPrefix + "cnpg-pair-join":      false,
+		jobs.TaskJobPrefix + "openbao-init":        false,
+		jobs.TaskJobPrefix + "keycloak-realm-seed": false,
+	}
+	sawReconcilersGroup := false
+	for _, j := range got {
+		if j.JobName == jobs.GroupReconcilers {
+			sawReconcilersGroup = true
+		}
+		if _, tracked := want[j.JobName]; tracked {
+			want[j.JobName] = true
+			if j.Status != jobs.StatusRunning {
+				t.Errorf("task %q status = %q, want running", j.JobName, j.Status)
+			}
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("in-cluster Job %q never surfaced in jobs.Store on the mother", name)
+		}
+	}
+	if !sawReconcilersGroup {
+		t.Errorf("the Reconcilers parent group was never materialised")
+	}
+}
+
+// TestMotherSeedInClusterReconcilers_ChrootShortCircuits proves the
+// projection never double-runs on a Sovereign-side (chroot) catalyst-api:
+// when SOVEREIGN_FQDN matches the deployment, motherSeedInClusterReconcilers
+// is a no-op (chrootSeedReconcilerObservations already covers it).
+func TestMotherSeedInClusterReconcilers_ChrootShortCircuits(t *testing.T) {
+	const (
+		depID         = "dep3896c"
+		sovereignFQDN = "hw170.omani.works"
+	)
+	t.Setenv("SOVEREIGN_FQDN", sovereignFQDN)
+
+	st, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	// If the chroot short-circuit fails, this factory would be invoked and
+	// seed task rows. We assert it is NEVER called.
+	factoryCalled := false
+	h := &Handler{
+		jobs: st,
+		log:  slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		dynamicFactory: func(string) (dynamic.Interface, error) {
+			factoryCalled = true
+			return fakeJobDynamicClient(t, "should-not-surface"), nil
+		},
+	}
+	dep := &Deployment{
+		ID:      depID,
+		Request: provisioner.Request{SovereignFQDN: sovereignFQDN},
+		Result:  &provisioner.Result{KubeconfigPath: writeTempKubeconfig(t)},
+	}
+
+	h.motherSeedInClusterReconcilers(context.Background(), dep)
+
+	if factoryCalled {
+		t.Fatalf("chroot mode must short-circuit; dynamicFactory was invoked")
+	}
+	got, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	for _, j := range got {
+		if j.JobName == jobs.TaskJobPrefix+"should-not-surface" {
+			t.Fatalf("chroot mode seeded a task row via the mother path: %q", j.JobName)
+		}
+	}
+}
+
+// TestMotherSeedInClusterReconcilers_NoKubeconfigIsNoOp proves the early
+// phase1-watching window (kubeconfig not posted back yet) is a graceful
+// no-op rather than an error — the /jobs read just returns what it has and
+// the next poll retries.
+func TestMotherSeedInClusterReconcilers_NoKubeconfigIsNoOp(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "")
+	const depID = "dep3896nk"
+	st, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	h := &Handler{
+		jobs: st,
+		log:  slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	}
+	dep := &Deployment{
+		ID:      depID,
+		Request: provisioner.Request{SovereignFQDN: "hw170.omani.works"},
+		// No Result/KubeconfigPath — cloud-init still in flight.
+	}
+
+	// Must not panic; store stays empty.
+	h.motherSeedInClusterReconcilers(context.Background(), dep)
+
+	got, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty store when kubeconfig unreachable, got %d jobs", len(got))
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
@@ -136,6 +136,14 @@ type Bridge struct {
 	store        *Store
 	deploymentID string
 
+	// provider — the deployment's cloud provider (lower-cased, e.g.
+	// "hetzner"/"huawei"), used to derive the Phase-0 lifecycle parent
+	// group's display label so a Huawei prov shows "Provision Huawei"
+	// rather than a hardcoded "Provision Hetzner". Empty until the
+	// handler calls SetProvider; an empty value falls back to the
+	// package default (ProvisionerDisplay("")). Read under b.mu.
+	provider string
+
 	// mu serialises access to the in-memory cursors below.
 	// SeedJobsFromInformerList runs from the helmwatch.Watcher's
 	// post-Sync hook (fireOnSyncedHooks) while OnHelmReleaseEvent
@@ -166,6 +174,29 @@ func NewBridge(store *Store, deploymentID string) *Bridge {
 		activeExecID: map[string]string{},
 		lastState:    map[string]string{},
 	}
+}
+
+// SetProvider records the deployment's cloud provider so the Phase-0
+// lifecycle parent group renders "Provision <Provider>" instead of the
+// hardcoded Hetzner default. Idempotent + safe to call repeatedly (the
+// handler stamps it on every bridge construction / seed). A blank value
+// is ignored so a later real provider is never clobbered by an empty one.
+func (b *Bridge) SetProvider(provider string) {
+	p := strings.TrimSpace(provider)
+	if p == "" {
+		return
+	}
+	b.mu.Lock()
+	b.provider = p
+	b.mu.Unlock()
+}
+
+// provisionerDisplay returns the provider-aware label for the Phase-0
+// lifecycle parent group. Caller MUST hold b.mu (every call site is
+// already inside a b.mu critical section — SeedProvisionerJobs and the
+// lifecycle-event path both lock before ensuring the group).
+func (b *Bridge) provisionerDisplay() string {
+	return ProvisionerDisplay(b.provider)
 }
 
 // ensureGroupJob idempotently materialises a synthesised parent group
@@ -797,7 +828,7 @@ func (b *Bridge) OnProvisionerEvent(ev provisioner.Event) error {
 func (b *Bridge) SeedProvisionerJobs() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if err := b.ensureGroupJob(GroupProvisioner, GroupProvisionerDisplay); err != nil {
+	if err := b.ensureGroupJob(GroupProvisioner, b.provisionerDisplay()); err != nil {
 		return err
 	}
 	parent := JobID(b.deploymentID, GroupProvisioner)
@@ -833,7 +864,7 @@ func (b *Bridge) OnProvisionerLifecycleEvent(phase, level, message string, t tim
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if err := b.ensureGroupJob(GroupProvisioner, GroupProvisionerDisplay); err != nil {
+	if err := b.ensureGroupJob(GroupProvisioner, b.provisionerDisplay()); err != nil {
 		return err
 	}
 

--- a/products/catalyst/bootstrap/api/internal/jobs/provisioner_display_test.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/provisioner_display_test.go
@@ -1,0 +1,86 @@
+// provisioner_display_test.go — the Phase-0 lifecycle parent group must
+// render "Provision <Provider>" for the deployment's actual cloud provider
+// (issue #3895). A Huawei prov must never masquerade as Hetzner.
+package jobs
+
+import "testing"
+
+func TestProvisionerDisplay(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider string
+		want     string
+	}{
+		{"empty falls back to hetzner default", "", "Provision Hetzner"},
+		{"whitespace falls back to default", "   ", "Provision Hetzner"},
+		{"hetzner", "hetzner", "Provision Hetzner"},
+		{"huawei", "huawei", "Provision Huawei"},
+		{"huawei mixed case", "Huawei", "Provision Huawei"},
+		{"huawei trimmed", "  huawei  ", "Provision Huawei"},
+		{"aws upper label", "aws", "Provision AWS"},
+		{"gcp", "gcp", "Provision GCP"},
+		{"azure", "azure", "Provision Azure"},
+		{"unmapped provider title-cases", "scaleway", "Provision Scaleway"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ProvisionerDisplay(tc.provider); got != tc.want {
+				t.Fatalf("ProvisionerDisplay(%q) = %q, want %q", tc.provider, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSeedProvisionerJobsProviderLabel asserts the end-to-end path: a
+// bridge stamped with a provider seeds the lifecycle parent group with the
+// provider-specific display name, and an un-stamped bridge keeps the
+// Hetzner default (back-compat for legacy deployment records).
+func TestSeedProvisionerJobsProviderLabel(t *testing.T) {
+	t.Run("huawei provider labels the group Provision Huawei", func(t *testing.T) {
+		st, br, depID := newBridgeFixture(t)
+		br.SetProvider("huawei")
+		if err := br.SeedProvisionerJobs(); err != nil {
+			t.Fatalf("SeedProvisionerJobs: %v", err)
+		}
+		group := mustGetGroup(t, st, depID, GroupProvisioner)
+		if group.DisplayName != "Provision Huawei" {
+			t.Fatalf("provisioner group DisplayName = %q, want %q",
+				group.DisplayName, "Provision Huawei")
+		}
+	})
+
+	t.Run("unset provider keeps the Hetzner default", func(t *testing.T) {
+		st, br, depID := newBridgeFixture(t)
+		if err := br.SeedProvisionerJobs(); err != nil {
+			t.Fatalf("SeedProvisionerJobs: %v", err)
+		}
+		group := mustGetGroup(t, st, depID, GroupProvisioner)
+		if group.DisplayName != GroupProvisionerDisplay {
+			t.Fatalf("provisioner group DisplayName = %q, want default %q",
+				group.DisplayName, GroupProvisionerDisplay)
+		}
+	})
+
+	t.Run("blank SetProvider never clobbers a real provider", func(t *testing.T) {
+		st, br, depID := newBridgeFixture(t)
+		br.SetProvider("huawei")
+		br.SetProvider("") // must be ignored
+		if err := br.SeedProvisionerJobs(); err != nil {
+			t.Fatalf("SeedProvisionerJobs: %v", err)
+		}
+		group := mustGetGroup(t, st, depID, GroupProvisioner)
+		if group.DisplayName != "Provision Huawei" {
+			t.Fatalf("provisioner group DisplayName = %q, want %q (blank must not clobber)",
+				group.DisplayName, "Provision Huawei")
+		}
+	})
+}
+
+func mustGetGroup(t *testing.T, st *Store, depID, slug string) Job {
+	t.Helper()
+	job, _, err := st.GetJob(depID, JobID(depID, slug))
+	if err != nil {
+		t.Fatalf("GetJob(%s): %v", slug, err)
+	}
+	return job
+}

--- a/products/catalyst/bootstrap/api/internal/jobs/types.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/types.go
@@ -218,12 +218,55 @@ const (
 const (
 	GroupBootstrapKitDisplay  = "Bootstrap"
 	GroupDay2MutationsDisplay = "Day-2 Mutations"
-	GroupProvisionerDisplay   = "Provision Hetzner"
-	GroupCutoverDisplay       = "Cutover"
-	GroupHandoverDisplay      = "Handover"
-	GroupAppsDisplay          = "Apps"
-	GroupReconcilersDisplay   = "Reconcilers"
+	// GroupProvisionerDisplay is the provider-agnostic fallback label
+	// for the Phase-0 lifecycle parent group, used when the deployment's
+	// cloud provider is unknown/empty. When the provider IS known the
+	// bridge derives a provider-specific label via ProvisionerDisplay
+	// ("Provision Huawei", "Provision AWS", …) so a Huawei prov never
+	// masquerades as Hetzner. Defaults to Hetzner for back-compat with
+	// pre-multi-cloud deployment records that never carried a provider.
+	GroupProvisionerDisplay = "Provision Hetzner"
+	GroupCutoverDisplay     = "Cutover"
+	GroupHandoverDisplay    = "Handover"
+	GroupAppsDisplay        = "Apps"
+	GroupReconcilersDisplay = "Reconcilers"
 )
+
+// providerDisplayNames maps a canonical (lower-cased) cloud provider name
+// onto its human-readable label for the Phase-0 lifecycle parent group.
+// Kept in this package (rather than reaching into internal/providers) so
+// the jobs package stays free of a providers import — the set is small and
+// stable, and an unknown provider falls through to a Title-cased default.
+var providerDisplayNames = map[string]string{
+	"hetzner": "Hetzner",
+	"huawei":  "Huawei",
+	"aws":     "AWS",
+	"gcp":     "GCP",
+	"azure":   "Azure",
+}
+
+// ProvisionerDisplay returns the Phase-0 lifecycle parent group's display
+// label for the given cloud provider — e.g. "Provision Huawei" for
+// provider="huawei", "Provision Hetzner" for "hetzner". Matching is
+// case-insensitive + whitespace-trimmed (the deployment record may store
+// either "huawei" or "Huawei"). An empty/unknown provider falls back to
+// the package default (GroupProvisionerDisplay → "Provision Hetzner") so
+// legacy deployment records that never carried a provider keep rendering
+// exactly as before; a recognised-but-unmapped provider Title-cases its
+// own name rather than mislabelling it.
+func ProvisionerDisplay(provider string) string {
+	p := strings.ToLower(strings.TrimSpace(provider))
+	if p == "" {
+		return GroupProvisionerDisplay
+	}
+	if label, ok := providerDisplayNames[p]; ok {
+		return "Provision " + label
+	}
+	// Recognised provider string with no curated label: Title-case the
+	// raw value so "scaleway" → "Provision Scaleway" rather than silently
+	// inheriting the Hetzner default.
+	return "Provision " + strings.ToUpper(p[:1]) + p[1:]
+}
 
 // Phase-0 lifecycle phase slugs — durable Job rows the bridge writes
 // when the provisioner.Provision goroutine emits the corresponding

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
@@ -29,8 +29,8 @@ import {
 import { listOrganizations, type OrgRow } from '@/lib/organizations.api'
 import { getHierarchicalInfrastructure } from '@/lib/infrastructure.types'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
-import { ALL_MODES, canonicalizeMode, describeMode } from '@/widgets/topology/TopologyEditor'
-import { BLUEPRINT_BY_ID } from '@/shared/constants/catalog.generated'
+import { ALL_MODES, canonicalizeMode, describeModeForComponent } from '@/widgets/topology/TopologyEditor'
+import { BLUEPRINT_BY_ID, TOPOLOGY_BY_ID } from '@/shared/constants/catalog.generated'
 
 // #3599 / #3600 — the vCluster/zone options the catalyst-api backend
 // validates (`placement.vcluster ∈ {host, mgmt, dmz, rtz}`,
@@ -569,6 +569,12 @@ export function NewInstanceDialog({
 
   const requiresMultiRegion = MULTI_REGION_MODES.has(topology)
 
+  // #3905 — the per-component topology matrix (same source the declared-
+  // topology card reads) so the instance-create mode picker derives each
+  // mode's helper text from THIS component's DR contract, never the generic
+  // "backup-restore" string that contradicted the card.
+  const componentTopology = TOPOLOGY_BY_ID[`bp-${bpName}`] ?? TOPOLOGY_BY_ID[bpName]
+
   // #3370 — required backing services (declared depends[] that are
   // themselves shareable). One generic selector each.
   const backingBlueprints = useMemo<string[]>(() => {
@@ -743,7 +749,7 @@ export function NewInstanceDialog({
           >
             {supportedModes.map((m) => (
               <option key={m} value={m}>
-                {m} — {describeMode(m)}
+                {m} — {describeModeForComponent(m, componentTopology)}
               </option>
             ))}
           </select>

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -443,6 +443,11 @@ export function TopologyTab({
         namespace={namespace}
         blueprint={blueprint}
         supportedCanonical={declaredTopology?.supported}
+        // #3905 — feed the SAME per-component topology matrix the card reads
+        // so the edit dropdown's per-mode helper text derives from the
+        // component's real DR contract (replication + switchover), never the
+        // generic "backup-restore" string that contradicted the card.
+        topology={declaredTopology}
         disableNetwork={disableNetwork}
         onApplied={() => {
           setRefreshTick((t) => t + 1)

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.test.tsx
@@ -14,7 +14,8 @@ import { describe, it, expect, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
-import { TopologyEditor } from './TopologyEditor'
+import { TopologyEditor, describeModeForComponent } from './TopologyEditor'
+import { TOPOLOGY_BY_ID } from '@/shared/constants/catalog.generated'
 
 function withProviders(node: React.ReactNode) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
@@ -134,6 +135,69 @@ describe('TopologyEditor — preview', () => {
     fireEvent.click(screen.getByTestId('topology-editor-region-hz-hel-rtz-prod-checkbox'))
     fireEvent.click(screen.getByTestId('topology-editor-preview-btn'))
     expect(screen.getByTestId('topology-editor-preview-modal')).toBeTruthy()
+  })
+})
+
+describe('TopologyEditor — matrix-derived mode descriptions (#3905)', () => {
+  // The exact bug the founder flagged: the card derived openbao's
+  // active-passive as `raft · async` warm-standby from the topology matrix,
+  // while the edit dropdown printed a GENERIC "…(backup-restore)" string for
+  // every component. The dropdown now reads the SAME matrix, so its
+  // active-passive helper text must mirror the matrix contract and never say
+  // "backup-restore".
+  const openbaoTopology = TOPOLOGY_BY_ID['bp-openbao']
+
+  it('the openbao active-passive option derives raft/async/raft-transition from the matrix (no backup-restore)', () => {
+    expect(openbaoTopology).toBeTruthy()
+    render(
+      withProviders(
+        <TopologyEditor
+          sovereignId="dep-1"
+          applicationName="openbao"
+          currentMode="active-passive"
+          currentRegions={['mgmt-A']}
+          availableRegions={['mgmt-A', 'mgmt-B']}
+          supportedCanonical={openbaoTopology.supported}
+          topology={openbaoTopology}
+          disableNetwork
+        />,
+      ),
+    )
+    const desc = screen.getByTestId('topology-editor-mode-active-passive-desc')
+    const text = (desc.textContent ?? '').toLowerCase()
+    // Matches the CARD's matrix-derived semantics (raft · async + raft-transition + 60s/30s).
+    expect(text).toContain('raft')
+    expect(text).toContain('async')
+    expect(text).toContain('raft-transition')
+    expect(text).toContain('60s')
+    expect(text).toContain('30s')
+    // The contradiction is gone: no generic "backup-restore" anywhere.
+    expect(text).not.toContain('backup-restore')
+  })
+
+  it('describeModeForComponent for openbao active-passive exactly matches the matrix variant', () => {
+    const text = describeModeForComponent('active-passive', openbaoTopology).toLowerCase()
+    const v = openbaoTopology.perTopology['active-passive']
+    // Every field the dropdown shows is sourced from the matrix, not hardcoded.
+    expect(v?.replication?.backend).toBe('raft')
+    expect(v?.replication?.mode).toBe('async')
+    expect(v?.switchover?.mechanism).toBe('raft-transition')
+    expect(text).toContain(`${v!.replication!.backend} · ${v!.replication!.mode}`.toLowerCase())
+    expect(text).toContain('raft-transition switchover')
+    expect(text).not.toContain('backup-restore')
+  })
+
+  it('falls back to the generic one-liner when no matrix is supplied', () => {
+    // An app with no spec.topology block → no `topology` prop → generic copy.
+    const text = describeModeForComponent('active-passive', undefined).toLowerCase()
+    expect(text).toContain('promotes on failover')
+    // The generic fallback is mechanism-neutral; it must not claim backup-restore.
+    expect(text).not.toContain('backup-restore')
+  })
+
+  it('singleton uses the generic one-liner even with a matrix (no DR contract to derive)', () => {
+    const text = describeModeForComponent('singleton', openbaoTopology).toLowerCase()
+    expect(text).toContain('one cluster')
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/topology/TopologyEditor.tsx
@@ -33,6 +33,7 @@ import {
   type ApplicationPreviewResponse,
   type CatalogItem,
 } from '@/lib/catalog.api'
+import type { BlueprintTopology } from '@/shared/constants/catalog.generated'
 
 export interface TopologyEditorProps {
   sovereignId: string
@@ -55,6 +56,18 @@ export interface TopologyEditorProps {
    * contradiction). Falls back to placementSchema.modes / ALL_MODES.
    */
   supportedCanonical?: string[]
+  /**
+   * #3905 — the Blueprint's declared topology matrix (the SAME
+   * `BlueprintTopology` the declared-topology CARD reads from
+   * `TOPOLOGY_BY_ID`). When provided, each mode's helper text is DERIVED
+   * from this component's `perTopology` contract (replication backend/mode +
+   * switchover mechanism + RTO/RPO) so the edit dropdown can NEVER
+   * contradict the card. Without it (an app with no matrix entry) the
+   * picker falls back to the generic `describeMode` one-liners. This kills
+   * the openbao bug where the card said `raft · async` warm-standby while
+   * the dropdown said "backup-restore".
+   */
+  topology?: BlueprintTopology
   /** Fired after a successful Apply. */
   onApplied?: () => void
   /** Test seam — bypass the network call for snapshot testing. */
@@ -120,6 +133,7 @@ export function TopologyEditor({
   namespace,
   blueprint,
   supportedCanonical,
+  topology,
   onApplied,
   disableNetwork = false,
 }: TopologyEditorProps) {
@@ -274,7 +288,9 @@ export function TopologyEditor({
                 data-testid={`topology-editor-mode-${m}-radio`}
               />
               <span className="text-sm font-medium text-[var(--color-text)]">{m}</span>
-              <span className="ml-2 text-xs text-[var(--color-text-dim)]">{describeMode(m)}</span>
+              <span className="ml-2 text-xs text-[var(--color-text-dim)]" data-testid={`topology-editor-mode-${m}-desc`}>
+                {describeModeForComponent(m, topology)}
+              </span>
             </label>
           )
         })}
@@ -423,10 +439,84 @@ export function describeMode(mode: string): string {
     case 'active-hot-standby':
       return 'primary serves; standby ready for switchover'
     case 'active-passive':
-      return 'primary serves; passive cold/warm standby (backup-restore)'
+      // Generic FALLBACK only — used when an app declares no per-component
+      // topology matrix. Most active-passive apps in the catalog replicate
+      // (raft/streaming/cnpg), so the matrix-derived describer below
+      // ALWAYS wins for them. Kept deliberately mechanism-neutral.
+      return 'primary serves; standby in the second region promotes on failover'
     default:
       return ''
   }
+}
+
+/**
+ * describeModeForComponent (#3905) — the per-mode helper text the placement
+ * edit dropdown actually renders. It DERIVES the description from the SAME
+ * per-component `BlueprintTopology` matrix the declared-topology CARD reads
+ * (the component's `perTopology[variant]` contract: replication backend/mode
+ * + switchover mechanism + RTO/RPO), so the card and the edit UI can NEVER
+ * contradict for any component.
+ *
+ * The root bug this fixes: `describeMode('active-passive')` returned a
+ * GENERIC, hardcoded, component-agnostic "…(backup-restore)" string for
+ * EVERY component, while the card derived openbao's real `raft · async`
+ * warm-standby semantics from the matrix. Now the dropdown reads the matrix
+ * too, so openbao's active-passive option shows raft/async/raft-transition,
+ * not backup-restore.
+ *
+ * Falls back to the generic `describeMode` one-liner when the component
+ * declares no matrix entry for the mode (the singleton class, or an app with
+ * no `spec.topology` block at all).
+ */
+export function describeModeForComponent(mode: string, topology?: BlueprintTopology): string {
+  const canon = canonicalizeMode(mode)
+  const generic = describeMode(mode)
+  if (!topology) return generic
+
+  // perTopology keys use the matrix dialect (active-hot-standby /
+  // active-passive / active-active / singleton); match canonically so the
+  // editor's canonical token resolves the right contract.
+  let variant: BlueprintTopology['perTopology'][string] | undefined
+  for (const [key, contract] of Object.entries(topology.perTopology)) {
+    if (canonicalizeMode(key) === canon) {
+      variant = contract
+      break
+    }
+  }
+  if (!variant) return generic
+
+  // singleton carries no DR contract — the generic one-liner is correct and
+  // there is nothing matrix-specific to add.
+  if (canon === 'singleton') return generic
+
+  const repl = variant.replication
+  const sw = variant.switchover
+  const parts: string[] = []
+
+  // Lead with the operative posture per class, then append the component's
+  // concrete replication + switchover contract from the matrix.
+  if (canon === 'active-active') {
+    parts.push('every region serves traffic')
+  } else {
+    // active-hot-standby / active-passive: one region serves, the other is
+    // the standby. The replication mode (sync vs async) is what separates a
+    // hot standby from a warm one — and it comes from the matrix, never a
+    // hardcoded "backup-restore".
+    parts.push('primary serves; second-region standby promotes on failover')
+  }
+
+  if (repl?.backend) {
+    const mode = repl.mode ? `${repl.backend} · ${repl.mode}` : repl.backend
+    parts.push(`${mode} replication`)
+  }
+  if (sw?.mechanism && sw.mechanism.toLowerCase() !== 'none') {
+    const rto = sw.rtoSeconds != null ? `RTO ${sw.rtoSeconds}s` : null
+    const rpo = sw.rpoSeconds != null ? `RPO ${sw.rpoSeconds}s` : null
+    const slo = [rto, rpo].filter(Boolean).join(' / ')
+    parts.push(slo ? `${sw.mechanism} switchover (${slo})` : `${sw.mechanism} switchover`)
+  }
+
+  return parts.join('; ')
 }
 
 function sameRegionSet(a: string[], b: string[]): boolean {


### PR DESCRIPTION
## What

The placement-edit **mode dropdown** on an Application's Topology tab now derives its per-mode helper text from the **same per-component topology matrix** (`TOPOLOGY_BY_ID`) that the declared-topology **CARD** reads. The card and the edit UI can no longer contradict for any component.

## The bug (Refs #3905)

`TopologyEditor.describeMode()` returned **generic, hardcoded, component-agnostic** strings. For `active-passive` it always read *"primary serves; passive cold/warm standby (**backup-restore**)"*. The card derives each component's real DR contract from the matrix (generated from `blueprint.yaml` `spec.topology`), so for **bp-openbao** the card showed `raft · async` / `raft-transition` / RTO 60s · RPO 30s while the dropdown said "backup-restore" — the contradiction the founder flagged across many envs.

## The fix

- New exported `describeModeForComponent(mode, topology)` in `TopologyEditor.tsx` derives the dropdown copy from the same `BlueprintTopology.perTopology[variant]` contract the card reads (replication backend/mode + switchover mechanism + RTO/RPO).
- Generic `describeMode()` stays only as the fallback (no matrix entry, or the `singleton` class which carries no DR contract).
- Wired into `TopologyTab` (post-create placement editor, via a new optional `topology` prop) and `InstancesSection` (instance-create mode picker), both passing the component's `TOPOLOGY_BY_ID` entry.

For openbao active-passive the dropdown now shows **`raft · async replication; raft-transition switchover (RTO 60s / RPO 30s)`** — matching the card, never "backup-restore".

## Secondary-line verdict

The card showing **"active-passive (DEGRADED — mandate unbuilt, no live DR pair)"** while the edit UI offers active-passive as **selectable** is **by design**, not an inconsistency:
- The card's DEGRADED is the **observed/effective live state** — no live Continuum (dr.openova.io) pair backs the app on this Sovereign, so it currently runs as a degraded singleton (see `TopologyTab.tsx` "Effective class" logic, #3829).
- The edit dropdown offers the **declared/selectable mandate**; selecting active-passive is what provisions the pair.

The two describe different axes (realized state vs. selectable mandate) and are consistent. This PR does not change that behavior.

## Validation

- `npx vitest run src/widgets/topology/TopologyEditor.test.tsx` → 10/10 pass, including 4 new tests asserting the openbao active-passive dropdown derives raft/async/raft-transition/60s/30s from the matrix and contains **no** "backup-restore".
- Broader suite (`topology/` + `InstancesSection` + `TopologyTab.dr` + `CatalogDetail.edit`) → 38/38 pass.
- `npm run build` (tsc -b typecheck + vite production build) → green.

Env-independent FE/data fix. No prov fired. `Refs #3905` (not `Closes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
