### PR TITLE
feat(catalyst-api): live 'Bootstrapping cluster' timeline phase — fill the ~30-min provisioning void (Refs #3914)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -166,6 +166,15 @@ type Deployment struct {
 	// store is nil (tests without persistence).
 	jobsBridge *jobs.Bridge
 
+	// bootstrapBridge — per-deployment bridge that fills the ~30-minute
+	// "Bootstrapping cluster" window between "Provision <provider>: Success"
+	// (tofu apply returned) and the first bp-* HelmRelease appearing. Driven
+	// by runPhase1Watch's own phase1-watch signals so the provisioning
+	// timeline never shows a static Success with a silent void behind it.
+	// Allocated lazily by bootstrapBridgeFor. Nil-tolerant: every drive site
+	// no-ops when the Handler's jobs store is nil (tests without persistence).
+	bootstrapBridge *jobs.BootstrapBridge
+
 	// liveWatcher — pointer to the helmwatch.Watcher currently
 	// driving Phase-1 events for this deployment, populated by
 	// runPhase1Watch / resumePhase1Watch / refreshWatch. The

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -163,6 +163,12 @@ type Handler struct {
 	kubeconfigArrivalTimeout      time.Duration
 	kubeconfigArrivalPollInterval time.Duration
 
+	// bootstrapFluxProgressInterval — test-override for the cadence at which
+	// the bootstrap-window "Flux installing — HR X/Y ready" counter is
+	// recomputed from the watcher's HelmRelease census. Zero falls back to
+	// the bootstrapFluxProgressInterval constant (5s); tests inject a few ms.
+	bootstrapFluxProgressInterval time.Duration
+
 	// ClusterMesh level-triggered reconcile knobs (#3241). The
 	// runAutoEstablishClusterMesh wrapper re-runs the idempotent
 	// AutoEstablishClusterMesh until every region is fully meshed:

--- a/products/catalyst/bootstrap/api/internal/handler/infrastructure.go
+++ b/products/catalyst/bootstrap/api/internal/handler/infrastructure.go
@@ -1527,6 +1527,26 @@ func (h *Handler) bridgeFor(dep *Deployment) *jobs.Bridge {
 	return bridge
 }
 
+// bootstrapBridgeFor — returns the per-deployment jobs.BootstrapBridge,
+// allocating one when the deployment doesn't have it yet. The bridge drives
+// the "Bootstrapping cluster" timeline group that fills the ~30-minute window
+// between "Provision <provider>: Success" and the first bp-* HelmRelease.
+// Returns nil when the Handler has no jobs store (tests without persistence)
+// so every drive site can no-op cheaply with a single nil-check.
+func (h *Handler) bootstrapBridgeFor(dep *Deployment) *jobs.BootstrapBridge {
+	if h.jobs == nil {
+		return nil
+	}
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+	if dep.bootstrapBridge != nil {
+		return dep.bootstrapBridge
+	}
+	bridge := jobs.NewBootstrapBridge(h.jobs, dep.ID)
+	dep.bootstrapBridge = bridge
+	return bridge
+}
+
 // registerMutation — thin wrapper around bridge.RegisterMutationJob
 // so the in-test no-op bridge can short-circuit without writing to
 // disk. Production passes through unchanged.

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_bootstrap_window_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_bootstrap_window_test.go
@@ -1,0 +1,202 @@
+// phase1_bootstrap_window_test.go — proves runPhase1Watch fills the
+// ~30-minute "Bootstrapping cluster" window (between "Provision <provider>:
+// Success" and the first bp-* HelmRelease) with a live group + step children
+// on the Jobs timeline, instead of a static Success with a silent void.
+//
+// The provisioning-observability gap: the Phase-0 "Provision <provider>"
+// lifecycle group flips Success the moment `tofu apply` returns, then nothing
+// streams to the timeline for up to half an hour while cloud-init → k3s →
+// kubeconfig-PUT → Flux-install runs cluster-side. These tests assert the new
+// GroupClusterConverge group surfaces continuous motion across that window.
+package handler
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+)
+
+// handlerWithJobsStore builds a NewWithPDM Handler and attaches a real
+// temp-dir jobs Store so the bootstrap-window bridge writes are observable
+// (NewWithPDM alone leaves h.jobs nil, which the bridge no-ops against).
+func handlerWithJobsStore(t *testing.T) *Handler {
+	t.Helper()
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	js, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("jobs.NewStore: %v", err)
+	}
+	h.jobs = js
+	return h
+}
+
+func findJobByName(t *testing.T, in []jobs.Job, name string) jobs.Job {
+	t.Helper()
+	for _, j := range in {
+		if j.JobName == name {
+			return j
+		}
+	}
+	t.Fatalf("job %q not found among %d rows", name, len(in))
+	return jobs.Job{}
+}
+
+// TestBootstrapWindow_GroupRendersDuringPhase1Watching is the core acceptance
+// test for the gap: while the deployment is still "phase1-watching" (the
+// kubeconfig has not yet arrived — the exact window that used to be silent),
+// the "Bootstrapping cluster" group exists and rolls up to "running" with its
+// nodes-booting step in flight, so the operator sees motion the whole time.
+func TestBootstrapWindow_GroupRendersDuringPhase1Watching(t *testing.T) {
+	h := handlerWithJobsStore(t)
+	// No kubeconfig on disk → runPhase1Watch sits in waitForKubeconfig (the
+	// real void). We don't run runPhase1Watch here (it would block on the
+	// wait); we drive the same seed+start the watch performs at entry and
+	// assert the timeline shows the live group.
+	dep := makeDeploymentWithKubeconfig(t, h, "bootstrap-window-live", "")
+	if dep.Status != "phase1-watching" {
+		t.Fatalf("precondition: dep.Status = %q, want phase1-watching", dep.Status)
+	}
+
+	bb := h.bootstrapBridgeFor(dep)
+	if bb == nil {
+		t.Fatalf("bootstrapBridgeFor returned nil with a jobs store wired")
+	}
+	if err := bb.Seed(); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	if err := bb.StartStep(jobs.BootstrapStepNodesBooting, "Nodes booting", time.Now().UTC()); err != nil {
+		t.Fatalf("StartStep: %v", err)
+	}
+	// A heartbeat (what the kubeconfig-wait loop fires each tick) keeps motion
+	// flowing without terminating the step.
+	if err := bb.Heartbeat(jobs.BootstrapStepNodesBooting, "cloud-init: running modules:final", time.Now().UTC()); err != nil {
+		t.Fatalf("Heartbeat: %v", err)
+	}
+
+	got, err := h.jobs.ListJobs(dep.ID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	group := findJobByName(t, got, jobs.GroupClusterConverge)
+	if group.DisplayName != jobs.GroupClusterConvergeDisplay {
+		t.Errorf("group DisplayName = %q, want %q", group.DisplayName, jobs.GroupClusterConvergeDisplay)
+	}
+	if group.Status != jobs.StatusRunning {
+		t.Errorf("group Status = %q, want running during the phase1-watching window", group.Status)
+	}
+	if len(group.ChildIDs) != 3 {
+		t.Errorf("group ChildIDs = %d, want 3 step children", len(group.ChildIDs))
+	}
+	nodes := findJobByName(t, got, jobs.ActivityStepJobName(jobs.GroupClusterConverge, jobs.BootstrapStepNodesBooting))
+	if nodes.Status != jobs.StatusRunning {
+		t.Errorf("nodes-booting Status = %q, want running", nodes.Status)
+	}
+}
+
+// TestBootstrapWindow_FullWatchConvergesGroup runs the full runPhase1Watch
+// against three already-ready HRs and asserts the bootstrap window closes
+// cleanly: all three steps succeed, the flux step carries the live "HR X/Y
+// ready" counter, and the group rolls up succeeded — the bootstrap-kit install
+// rows then own the timeline.
+func TestBootstrapWindow_FullWatchConvergesGroup(t *testing.T) {
+	h := handlerWithJobsStore(t)
+	h.dynamicFactory = fakeDynamicFactoryFromObjects(
+		makeReadyHR("bp-cilium"),
+		makeReadyHR("bp-cert-manager"),
+		makeReadyHR("bp-flux"),
+	)
+	h.phase1WatchTimeout = 5 * time.Second
+	h.bootstrapFluxProgressInterval = 10 * time.Millisecond
+
+	dep := makeDeploymentWithKubeconfig(t, h, "bootstrap-window-converge", "fake-kubeconfig: yaml")
+	h.runPhase1Watch(dep)
+
+	if dep.Status != "ready" {
+		t.Fatalf("Status = %q, want ready", dep.Status)
+	}
+
+	got, err := h.jobs.ListJobs(dep.ID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+
+	group := findJobByName(t, got, jobs.GroupClusterConverge)
+	if group.Status != jobs.StatusSucceeded {
+		t.Errorf("group Status = %q, want succeeded after convergence", group.Status)
+	}
+
+	nodes := findJobByName(t, got, jobs.ActivityStepJobName(jobs.GroupClusterConverge, jobs.BootstrapStepNodesBooting))
+	kube := findJobByName(t, got, jobs.ActivityStepJobName(jobs.GroupClusterConverge, jobs.BootstrapStepKubeconfig))
+	flux := findJobByName(t, got, jobs.ActivityStepJobName(jobs.GroupClusterConverge, jobs.BootstrapStepFluxInstalling))
+
+	if nodes.Status != jobs.StatusSucceeded {
+		t.Errorf("nodes Status = %q, want succeeded", nodes.Status)
+	}
+	if kube.Status != jobs.StatusSucceeded {
+		t.Errorf("kube Status = %q, want succeeded", kube.Status)
+	}
+	if flux.Status != jobs.StatusSucceeded {
+		t.Errorf("flux Status = %q, want succeeded", flux.Status)
+	}
+	// The flux step's DisplayName must carry the "HR X/Y ready" counter shape
+	// the operator watched climb — 3/3 at convergence.
+	const wantFluxLabel = "Flux installing — HR 3/3 ready"
+	if flux.DisplayName != wantFluxLabel {
+		t.Errorf("flux DisplayName = %q, want %q (live HR counter)", flux.DisplayName, wantFluxLabel)
+	}
+}
+
+// TestBootstrapWindow_KubeconfigTimeoutFailsSteps proves a window where the
+// kubeconfig never arrives surfaces the bootstrap steps as FAILED (not
+// perpetually running) — the timeline must never lie about a dead prov.
+func TestBootstrapWindow_KubeconfigTimeoutFailsSteps(t *testing.T) {
+	h := handlerWithJobsStore(t)
+	// No kubeconfig + a tiny arrival budget → waitForKubeconfig times out,
+	// runPhase1Watch fails the bootstrap steps + markPhase1Done flips failed.
+	h.kubeconfigArrivalTimeout = 60 * time.Millisecond
+	h.kubeconfigArrivalPollInterval = 20 * time.Millisecond
+
+	dep := makeDeploymentWithKubeconfig(t, h, "bootstrap-window-timeout", "")
+	h.runPhase1Watch(dep)
+
+	if dep.Status != "failed" {
+		t.Fatalf("Status = %q, want failed (kubeconfig never arrived)", dep.Status)
+	}
+
+	got, err := h.jobs.ListJobs(dep.ID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	group := findJobByName(t, got, jobs.GroupClusterConverge)
+	if group.Status != jobs.StatusFailed {
+		t.Errorf("group Status = %q, want failed when kubeconfig never arrives", group.Status)
+	}
+}
+
+// TestBootstrapWindow_HeartbeatLineUsesCloudInitTail proves the heartbeat line
+// carries the cloud-init log tail (#3132) when present — the load-bearing
+// signal that lets the operator literally watch the bootstrap.
+func TestBootstrapWindow_HeartbeatLineUsesCloudInitTail(t *testing.T) {
+	h := handlerWithJobsStore(t)
+	dir := t.TempDir()
+	h.kubeconfigsDir = dir
+	dep := makeDeploymentWithKubeconfig(t, h, "bootstrap-window-tail", "")
+
+	// No cloud-init log yet → bare numEvents line.
+	if got := h.bootstrapHeartbeatLine(dep); got == "" {
+		t.Fatalf("heartbeat line empty, want non-empty numEvents fallback")
+	}
+
+	// Write a cloud-init log; the tail must appear in the heartbeat line.
+	logPath := dir + "/" + dep.ID + "-cloudinit.log"
+	if err := os.WriteFile(logPath, []byte("Cloud-init v. 23.4 running\n[  OK  ] k3s.service started\n"), 0o600); err != nil {
+		t.Fatalf("write cloud-init log: %v", err)
+	}
+	line := h.bootstrapHeartbeatLine(dep)
+	if want := "k3s.service started"; !strings.Contains(line, want) {
+		t.Errorf("heartbeat line = %q, want it to include cloud-init tail %q", line, want)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -45,6 +45,7 @@ import (
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
 )
 
@@ -201,6 +202,28 @@ func (h *Handler) runPhase1Watch(dep *Deployment) {
 	dep.phase1Started = true
 	dep.mu.Unlock()
 
+	// Fill the ~30-minute "Bootstrapping cluster" window. The Phase-0
+	// lifecycle group ("Provision <provider>") flipped to Success the moment
+	// `tofu apply` returned; from here the real work runs cluster-side
+	// (cloud-init → k3s → kubeconfig PUT → Flux installs → HRs reconcile)
+	// for up to half an hour. Before this group existed the provisioning
+	// timeline showed a static "Provision <provider>: Success" with NO
+	// further motion for that whole window and the operator reasonably
+	// concluded the prov was dead. Seed the group + start the nodes-booting
+	// step NOW so the timeline advances the instant provision finishes; the
+	// kubeconfig-wait loop heartbeats it (numEvents / cloud-init log tail)
+	// and the watcher below drives the live HR X/Y counter.
+	if bb := h.bootstrapBridgeFor(dep); bb != nil {
+		if err := bb.Seed(); err != nil {
+			h.log.Warn("bootstrap window: seed failed", "id", dep.ID, "err", err)
+		}
+		if err := bb.StartStep(jobs.BootstrapStepNodesBooting,
+			"Nodes booting — cloud-init is bringing up k3s on the new Sovereign; waiting for the kubeconfig PUT-back.",
+			time.Now().UTC()); err != nil {
+			h.log.Warn("bootstrap window: start nodes-booting failed", "id", dep.ID, "err", err)
+		}
+	}
+
 	// Wait for the kubeconfig file to appear on disk. The path
 	// pointer (dep.Result.KubeconfigPath) is set by PutKubeconfig
 	// when cloud-init's postback succeeds. While waiting, dep.Status
@@ -215,8 +238,28 @@ func (h *Handler) runPhase1Watch(dep *Deployment) {
 		// Timeout elapsed — surface kubeconfig-missing as before.
 		// The warn event was emitted by waitForKubeconfig at the
 		// final tick.
+		// Fail the bootstrap-window steps honestly so the timeline stops
+		// showing a perpetually-running "Nodes booting" — the kubeconfig
+		// never arrived, which is the same failure markPhase1Done surfaces.
+		if bb := h.bootstrapBridgeFor(dep); bb != nil {
+			now := time.Now().UTC()
+			_ = bb.FinishStep(jobs.BootstrapStepNodesBooting, jobs.StatusFailed,
+				"cloud-init never PUT the kubeconfig within the arrival budget — see the Phase-1 timeout reason.", now)
+			_ = bb.FinishStep(jobs.BootstrapStepKubeconfig, jobs.StatusFailed,
+				"kubeconfig never received.", now)
+		}
 		h.markPhase1Done(dep, nil, helmwatch.OutcomeKubeconfigMissing)
 		return
+	}
+
+	// Kubeconfig landed — k3s is up. Advance the bootstrap window:
+	// nodes-booting + kubeconfig-received succeed, flux-installing starts.
+	if bb := h.bootstrapBridgeFor(dep); bb != nil {
+		if err := bb.MarkKubeconfigReceived(
+			fmt.Sprintf("k3s up; kubeconfig received from cloud-init (%d bytes).", len(kubeconfig)),
+			time.Now().UTC()); err != nil {
+			h.log.Warn("bootstrap window: mark kubeconfig received failed", "id", dep.ID, "err", err)
+		}
 	}
 
 	cfg := h.phase1WatchConfigForDeployment(dep, kubeconfig)
@@ -281,6 +324,14 @@ func (h *Handler) runPhase1Watch(dep *Deployment) {
 	// typically race within ~10s of each other but not always).
 	stopSecondaries := h.spawnSecondaryRegionWatchers(dep)
 	defer stopSecondaries()
+
+	// Drive the bootstrap-window "Flux installing — HR X/Y ready" counter
+	// live off the primary watcher's in-memory HelmRelease census. This is
+	// the third bootstrap-window signal: while the bootstrap-kit reconciles,
+	// the operator watches the climbing X/Y count on the provisioning
+	// timeline instead of a static row. Stops when the watch returns.
+	stopFluxProgress := h.driveBootstrapFluxProgress(dep, watcher)
+	defer stopFluxProgress()
 
 	// Use the background context so a finished HTTP request from the
 	// caller doesn't cancel a multi-minute Phase-1 watch. The watch
@@ -779,6 +830,27 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 	// persisted, so any state read from disk was stale.
 	h.persistDeployment(dep)
 
+	// Close the bootstrap-window's "Flux installing" step now that Phase-1
+	// has terminated — succeed it on a clean ready, fail it honestly on any
+	// non-ready terminal outcome so the timeline never leaves a perpetually-
+	// running "Flux installing" row behind a failed prov. This is the third
+	// and final bootstrap-window transition: once it lands the bootstrap-kit
+	// install rows own the timeline. Best-effort + idempotent.
+	if bb := h.bootstrapBridgeFor(dep); bb != nil {
+		now := time.Now().UTC()
+		if finalStatus == "ready" {
+			ready, total := installedCensus(finalStates)
+			_ = bb.SetFluxProgress(ready, total, now)
+			_ = bb.MarkConverged(
+				fmt.Sprintf("Bootstrap-kit converged — %d/%d HelmReleases ready; per-component install rows now drive the timeline.", ready, total),
+				now)
+		} else {
+			_ = bb.FinishStep(jobs.BootstrapStepFluxInstalling, jobs.StatusFailed,
+				fmt.Sprintf("Bootstrap-kit did not converge (Phase-1 outcome %q) — see the per-component install rows + the Phase-1 banner for the failure reason.", outcome),
+				now)
+		}
+	}
+
 	h.log.Info("phase 1 watch terminated",
 		"id", dep.ID,
 		"componentCount", len(finalStates),
@@ -994,6 +1066,19 @@ func formatRegionHealth(regions []provisioner.RegionHealth) string {
 		parts = append(parts, fmt.Sprintf("%s=%d/%d%s", r.Region, r.HRReady, r.HRTotal, tag))
 	}
 	return strings.Join(parts, " ")
+}
+
+// installedCensus counts the (installed, total) HelmReleases in a terminal
+// component-state map — the final "HR X/Y ready" figure the bootstrap-window's
+// flux step stamps on convergence.
+func installedCensus(states map[string]string) (installed, total int) {
+	for _, s := range states {
+		total++
+		if s == helmwatch.StateInstalled {
+			installed++
+		}
+	}
+	return installed, total
 }
 
 // runSecondaryBridgeBackfill walks every secondary watcher attached to
@@ -1687,6 +1772,21 @@ func (h *Handler) waitForKubeconfig(dep *Deployment) (string, bool) {
 			first = false
 		}
 
+		// Heartbeat the bootstrap-window "Nodes booting" step every tick so
+		// the provisioning timeline shows continuous motion (a fresh live
+		// log line) the whole time cloud-init runs — the SSE event bus stays
+		// quiet to avoid drowning the wizard, but the Jobs timeline's
+		// per-step Exec Log gets a tail line each poll. The line is driven by
+		// the deployment's numEvents counter (climbs while cloud-init runs)
+		// and, when present, the last line of the self-uploaded cloud-init
+		// log (#3132) so the operator can literally watch the bootstrap.
+		if !first {
+			if bb := h.bootstrapBridgeFor(dep); bb != nil {
+				_ = bb.Heartbeat(jobs.BootstrapStepNodesBooting,
+					h.bootstrapHeartbeatLine(dep), time.Now().UTC())
+			}
+		}
+
 		// Check the deadline AFTER an emit so the operator-visible
 		// log includes the final timeout reason.
 		if time.Now().After(deadline) {
@@ -1701,6 +1801,108 @@ func (h *Handler) waitForKubeconfig(dep *Deployment) (string, bool) {
 
 		time.Sleep(pollEvery)
 	}
+}
+
+// bootstrapHeartbeatLine builds the live "Nodes booting" heartbeat line for
+// the bootstrap-window step from the data catalyst-api already has during the
+// kubeconfig wait: the deployment's numEvents counter (which climbs while
+// cloud-init runs) and the last non-empty line of the self-uploaded cloud-init
+// log (#3132) when it is present on the PVC. The cloud-init tail is the
+// load-bearing signal — it lets the operator literally watch the bootstrap;
+// numEvents is the always-present fallback so the line is never static.
+func (h *Handler) bootstrapHeartbeatLine(dep *Deployment) string {
+	dep.mu.Lock()
+	n := len(dep.eventsBuf)
+	dep.mu.Unlock()
+
+	base := fmt.Sprintf("Bootstrapping new Sovereign — cloud-init in progress (%d provisioning events so far)…", n)
+	if tail := h.cloudInitLogTail(dep.ID); tail != "" {
+		return base + " cloud-init: " + tail
+	}
+	return base
+}
+
+// cloudInitLogTail returns the last non-empty line of the deployment's
+// self-uploaded cloud-init log (#3132), trimmed to a sane length, or "" when
+// the log isn't on the PVC yet / can't be read. Best-effort: any error yields
+// "" so the heartbeat falls back to the numEvents-only line.
+func (h *Handler) cloudInitLogTail(depID string) string {
+	if h.kubeconfigsDir == "" {
+		return ""
+	}
+	raw, err := os.ReadFile(filepath.Join(h.kubeconfigsDir, depID+"-cloudinit.log"))
+	if err != nil || len(raw) == 0 {
+		return ""
+	}
+	lines := strings.Split(strings.TrimRight(string(raw), "\n"), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		ln := strings.TrimSpace(lines[i])
+		if ln == "" {
+			continue
+		}
+		const maxTail = 200
+		if len(ln) > maxTail {
+			ln = ln[len(ln)-maxTail:]
+		}
+		return ln
+	}
+	return ""
+}
+
+// bootstrapFluxProgressInterval — cadence at which the bootstrap-window
+// "Flux installing — HR X/Y ready" counter is recomputed from the watcher's
+// in-memory HelmRelease census. 5s matches the console's /jobs poll so the
+// operator sees the counter advance roughly once per poll. Test-overridable
+// via the Handler field so the path runs in milliseconds.
+const bootstrapFluxProgressInterval = 5 * time.Second
+
+// driveBootstrapFluxProgress starts a background goroutine that recomputes the
+// in-cluster HelmRelease census (ready = installed HRs, total = observed HRs)
+// from the primary watcher's SnapshotComponents() every tick and feeds it to
+// the bootstrap-window's flux-installing step, so the provisioning timeline
+// shows a climbing "HR X/Y ready" label while the bootstrap-kit reconciles.
+// Returns a stop function the caller defers; the watch returning closes it.
+//
+// SetFluxProgress is a no-op when the census is unchanged between ticks, so
+// this never churns the store at the poll cadence. Best-effort: a nil bridge
+// (no jobs store) or an empty snapshot (informer not yet synced) just skips
+// the tick.
+func (h *Handler) driveBootstrapFluxProgress(dep *Deployment, watcher *helmwatch.Watcher) func() {
+	bb := h.bootstrapBridgeFor(dep)
+	if bb == nil || watcher == nil {
+		return func() {}
+	}
+	interval := h.bootstrapFluxProgressInterval
+	if interval <= 0 {
+		interval = bootstrapFluxProgressInterval
+	}
+	stop := make(chan struct{})
+	var once sync.Once
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				snap := watcher.SnapshotComponents()
+				if len(snap) == 0 {
+					continue
+				}
+				ready := 0
+				for _, cs := range snap {
+					if cs.Status == helmwatch.StateInstalled {
+						ready++
+					}
+				}
+				if err := bb.SetFluxProgress(ready, len(snap), time.Now().UTC()); err != nil {
+					h.log.Warn("bootstrap window: flux progress update failed", "id", dep.ID, "err", err)
+				}
+			}
+		}
+	}()
+	return func() { once.Do(func() { close(stop) }) }
 }
 
 // certificateGVR — GroupVersionResource for cert-manager.io/v1.Certificate.

--- a/products/catalyst/bootstrap/api/internal/jobs/bootstrap_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/bootstrap_bridge.go
@@ -1,0 +1,434 @@
+// bootstrap_bridge.go — projects the ~30-minute cluster-bootstrap window
+// (between "Provision <provider>: Success" and the first bp-* HelmRelease)
+// into the same Job + Execution + LogLine model the helmwatch + activity
+// bridges use.
+//
+// # Why this exists (the provisioning-observability gap)
+//
+// The provisioning timeline (/sovereign/provision/<id>/jobs) used to show
+// the "Provision <provider>" lifecycle group flip to Success the moment
+// `tofu apply` returned — and then NOTHING for ~30 minutes while the real
+// work happened cluster-side: cloud-init boots the nodes, k3s comes up,
+// cloud-init PUTs the kubeconfig back, Flux installs the bootstrap-kit, and
+// the HelmReleases reconcile. During that whole window the operator saw a
+// static "Provision <provider>: Success" with no further motion and
+// reasonably concluded the prov was stuck or dead.
+//
+// The DATA to fill that window already exists in catalyst-api's Phase-1
+// watch — it just was not surfaced to the timeline. BootstrapBridge closes
+// that gap by materialising a "Bootstrapping cluster" group with three live
+// step children, each driven by a phase1-watch signal:
+//
+//	cluster-converge (group, "Bootstrapping cluster")
+//	    ├── cluster-converge-step-nodes-booting        ("Nodes booting · cloud-init running")
+//	    ├── cluster-converge-step-kubeconfig-received  ("k3s up · kubeconfig received")
+//	    └── cluster-converge-step-flux-installing      ("Flux installing — HR X/Y ready")
+//
+// The group's status rolls up from its step children at read time
+// (Store.deriveTreeView), so while ANY step is running the group reads
+// "running" — continuous motion in the existing 5-second /jobs poll. The
+// Flux step's DisplayName is rewritten live (SetFluxProgress) to carry the
+// climbing "HR X/Y ready" counter so the operator literally watches the
+// bootstrap-kit converge.
+//
+// # Relationship to the other bridges
+//
+// BootstrapBridge is a sibling of Bridge + ActivityBridge, not a
+// replacement. All three write into the same Store under the same deployment
+// id, so a single /jobs read returns the Phase-0 lifecycle, the bootstrap
+// window, the bootstrap-kit installs, and every projected activity in one
+// tree. The namespaces never collide: BootstrapBridge only ever writes the
+// "cluster-converge" group + its "cluster-converge-step-*" leaves.
+//
+// # Idempotency + resume
+//
+// Every method is idempotent. runPhase1Watch re-enters cleanly across a
+// catalyst-api Pod restart (a resumed watch re-seeds the steps + re-drives
+// the transitions). UpsertJob's monotonic merge (store.mergeJob) preserves
+// StartedAt/FinishedAt and a non-empty DependsOn, so re-seeding never
+// un-starts a step or drops an edge. StartStep reuses an already-open
+// Execution rather than allocating a second one — the same property
+// ActivityBridge relies on.
+package jobs
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// bootstrapSteps — the ordered step set the BootstrapBridge seeds. Order
+// drives the linear DependsOn chain (nodes-booting → kubeconfig-received →
+// flux-installing) so the canvas renders the bootstrap window as a chain
+// hanging off the last Phase-0 lifecycle step.
+var bootstrapSteps = []ActivityStep{
+	{Slug: BootstrapStepNodesBooting, DisplayName: BootstrapStepNodesBootingDisplay, Order: 1},
+	{Slug: BootstrapStepKubeconfig, DisplayName: BootstrapStepKubeconfigDisplay, Order: 2},
+	{Slug: BootstrapStepFluxInstalling, DisplayName: BootstrapStepFluxInstallingDisplay, Order: 3},
+}
+
+// BootstrapBridge projects the cluster-bootstrap window into the jobs Store
+// under a single deployment id. One bridge instance per deployment.
+// Goroutine-safe: the internal mutex serialises the per-step Execution
+// cursor; the Store serialises the actual writes.
+type BootstrapBridge struct {
+	store        *Store
+	deploymentID string
+
+	mu sync.Mutex
+
+	// activeExecID — per-step-slug id of the in-flight Execution. Set on
+	// the first StartStep, cleared on FinishStep. A resumed bridge
+	// re-attaches via the persisted Job.LatestExecutionID so a Pod restart
+	// never strands an Execution open.
+	activeExecID map[string]string
+
+	// fluxLabel — last DisplayName written for the flux-installing step, so
+	// SetFluxProgress skips a redundant UpsertJob when the HR census is
+	// unchanged between poll ticks (avoids log/persist churn at the 5s poll
+	// cadence).
+	fluxLabel string
+}
+
+// NewBootstrapBridge constructs a bridge for the cluster-bootstrap window.
+// store must be non-nil; deploymentID must be non-empty.
+func NewBootstrapBridge(store *Store, deploymentID string) *BootstrapBridge {
+	return &BootstrapBridge{
+		store:        store,
+		deploymentID: deploymentID,
+		activeExecID: map[string]string{},
+	}
+}
+
+// GroupJobID returns the stable id of the "Bootstrapping cluster" group Job.
+func (b *BootstrapBridge) GroupJobID() string {
+	return JobID(b.deploymentID, GroupClusterConverge)
+}
+
+// stepJobName returns the canonical leaf JobName for a bootstrap step, e.g.
+// "cluster-converge-step-nodes-booting".
+func (b *BootstrapBridge) stepJobName(slug string) string {
+	return ActivityStepJobName(GroupClusterConverge, slug)
+}
+
+// ensureGroupLocked idempotently materialises the "Bootstrapping cluster"
+// group Job. Its runtime status rolls up from its step children at read
+// time (deriveTreeView). Caller MUST hold b.mu.
+func (b *BootstrapBridge) ensureGroupLocked() error {
+	return b.store.UpsertJob(Job{
+		DeploymentID: b.deploymentID,
+		JobName:      GroupClusterConverge,
+		DisplayName:  GroupClusterConvergeDisplay,
+		Type:         JobTypeGroup,
+		Kind:         KindGroup,
+		ParentID:     "",
+		DependsOn:    []string{},
+		Status:       StatusPending,
+	})
+}
+
+// dependsOnForStepLocked returns the prior step's leaf JobName (length 0 for
+// the first step) so the canvas renders the linear chain. Caller MUST hold
+// b.mu.
+func (b *BootstrapBridge) dependsOnForStepLocked(slug string) []string {
+	for i, s := range bootstrapSteps {
+		if s.Slug != slug {
+			continue
+		}
+		if i == 0 {
+			return []string{}
+		}
+		return []string{b.stepJobName(bootstrapSteps[i-1].Slug)}
+	}
+	return []string{}
+}
+
+// upsertStepLocked materialises one bootstrap step leaf at the given status
+// (preserving any prior StartedAt via mergeJob). Caller MUST hold b.mu.
+func (b *BootstrapBridge) upsertStepLocked(s ActivityStep, status string) error {
+	return b.store.UpsertJob(Job{
+		DeploymentID: b.deploymentID,
+		JobName:      b.stepJobName(s.Slug),
+		DisplayName:  s.DisplayName,
+		Type:         JobTypeInstall,
+		Kind:         KindStep,
+		ParentID:     b.GroupJobID(),
+		DependsOn:    b.dependsOnForStepLocked(s.Slug),
+		Status:       status,
+	})
+}
+
+// Seed materialises the group + all three step leaves in pending state, wired
+// with the linear DependsOn chain. Called once at Phase-1 watch start so the
+// "Bootstrapping cluster" group appears (pending) the instant the Phase-0
+// lifecycle group reaches Success — there is never a frame where the timeline
+// is blank between provision and convergence.
+//
+// Idempotent + resume-safe: mergeJob lets next.Status win unconditionally, so
+// a blind re-seed would REGRESS an already-running/terminal step back to
+// pending after a Pod-restart resume. Seed therefore reads each step's current
+// status first and never writes a status LESS advanced than what is on disk —
+// a pending step is (re)seeded pending; a running/terminal one is preserved.
+func (b *BootstrapBridge) Seed() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if err := b.ensureGroupLocked(); err != nil {
+		return err
+	}
+	for _, s := range bootstrapSteps {
+		status := StatusPending
+		if job, _, err := b.store.GetJob(b.deploymentID, b.stepJobName(s.Slug)); err == nil && job.Status != "" {
+			// Preserve whatever the row already reached (running/terminal);
+			// only ever (re)assert pending for a not-yet-started step.
+			status = job.Status
+		}
+		if err := b.upsertStepLocked(s, status); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// stepBySlug returns the declared step for a slug (with its display name), or
+// a bare step carrying just the slug if it is unknown.
+func stepBySlug(slug string) ActivityStep {
+	for _, s := range bootstrapSteps {
+		if s.Slug == slug {
+			return s
+		}
+	}
+	return ActivityStep{Slug: slug, DisplayName: slug}
+}
+
+// StartStep transitions a bootstrap step into Running, allocating an
+// Execution (and stamping StartedAt) on the first call. Re-calling for a step
+// that already has an open Execution reuses it (no duplicate Execution row),
+// the load-bearing idempotency property for the Pod-restart resume path. The
+// message is appended as the first LogLine so the Exec Log surface is never
+// empty.
+func (b *BootstrapBridge) StartStep(slug, message string, t time.Time) error {
+	t = t.UTC()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.startStepLocked(slug, message, t)
+}
+
+func (b *BootstrapBridge) startStepLocked(slug, message string, t time.Time) error {
+	if err := b.ensureGroupLocked(); err != nil {
+		return err
+	}
+	s := stepBySlug(slug)
+	jobName := b.stepJobName(slug)
+
+	// Reuse an open Execution: in-memory cursor first, then the persisted
+	// LatestExecutionID while it is still running (resume). Only allocate a
+	// fresh Execution when neither is live.
+	execID := b.activeExecID[slug]
+	if execID == "" {
+		if job, _, err := b.store.GetJob(b.deploymentID, jobName); err == nil &&
+			job.LatestExecutionID != "" && !IsTerminal(job.Status) {
+			execID = job.LatestExecutionID
+			b.activeExecID[slug] = execID
+		}
+	}
+	if execID == "" {
+		exec, err := b.store.StartExecution(b.deploymentID, jobName, t)
+		if err != nil {
+			return err
+		}
+		execID = exec.ID
+		b.activeExecID[slug] = execID
+	} else {
+		// Execution already open — flip the Job to running (a resume that
+		// re-enters a step the durable record left at pending). mergeJob
+		// keeps the prior StartedAt.
+		if err := b.upsertStepLocked(s, StatusRunning); err != nil {
+			return err
+		}
+	}
+
+	msg := message
+	if msg == "" {
+		msg = "[" + slug + "] started"
+	}
+	return b.store.AppendLogLines(b.deploymentID, execID, []LogLine{{
+		Timestamp: t,
+		Level:     LevelInfo,
+		Message:   msg,
+	}})
+}
+
+// Heartbeat appends a single live LogLine to a running step's Execution
+// WITHOUT changing its status — this is what keeps the operator seeing motion
+// during the long nodes-booting wait. The catalyst-api drives it from the
+// kubeconfig-wait poll loop with a cloud-init log tail / numEvents counter so
+// every tick produces a fresh line. A no-op if the step has no open
+// Execution (it was never started or has already terminated).
+func (b *BootstrapBridge) Heartbeat(slug, message string, t time.Time) error {
+	if message == "" {
+		return nil
+	}
+	t = t.UTC()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	execID := b.activeExecID[slug]
+	if execID == "" {
+		// Resume path: re-attach to a persisted open Execution.
+		if job, _, err := b.store.GetJob(b.deploymentID, b.stepJobName(slug)); err == nil &&
+			job.LatestExecutionID != "" && !IsTerminal(job.Status) {
+			execID = job.LatestExecutionID
+			b.activeExecID[slug] = execID
+		}
+	}
+	if execID == "" {
+		return nil
+	}
+	return b.store.AppendLogLines(b.deploymentID, execID, []LogLine{{
+		Timestamp: t,
+		Level:     LevelInfo,
+		Message:   message,
+	}})
+}
+
+// SetFluxProgress rewrites the flux-installing step's DisplayName to carry the
+// live "Flux installing — HR X/Y ready" counter and appends a progress
+// LogLine. Driven each poll tick from the in-cluster HelmRelease census the
+// helmwatch snapshot exposes, so the operator watches the bootstrap-kit
+// converge in real time. The step must already be running (StartStep called);
+// this only mutates the label + log, never the status. A no-op when the
+// (ready,total) census is unchanged since the last call (avoids churn at the
+// 5s poll cadence). total<=0 is treated as "not yet known" and renders the
+// bare baseline label.
+func (b *BootstrapBridge) SetFluxProgress(ready, total int, t time.Time) error {
+	t = t.UTC()
+	label := BootstrapStepFluxInstallingDisplay
+	if total > 0 {
+		label = fmt.Sprintf("%s — HR %d/%d ready", BootstrapStepFluxInstallingDisplay, ready, total)
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if label == b.fluxLabel {
+		return nil
+	}
+	b.fluxLabel = label
+
+	// Keep the step running while progress streams; mergeJob preserves the
+	// prior StartedAt and never regresses a terminal status, so a late tick
+	// after FinishStep can't un-finish it.
+	if err := b.store.UpsertJob(Job{
+		DeploymentID: b.deploymentID,
+		JobName:      b.stepJobName(BootstrapStepFluxInstalling),
+		DisplayName:  label,
+		Type:         JobTypeInstall,
+		Kind:         KindStep,
+		ParentID:     b.GroupJobID(),
+		DependsOn:    b.dependsOnForStepLocked(BootstrapStepFluxInstalling),
+		Status:       StatusRunning,
+	}); err != nil {
+		return err
+	}
+
+	execID := b.activeExecID[BootstrapStepFluxInstalling]
+	if execID == "" {
+		return nil
+	}
+	return b.store.AppendLogLines(b.deploymentID, execID, []LogLine{{
+		Timestamp: t,
+		Level:     LevelInfo,
+		Message:   label,
+	}})
+}
+
+// FinishStep transitions a bootstrap step into a terminal state and closes
+// its Execution. status must be StatusSucceeded or StatusFailed. The message
+// is appended as the final LogLine. Idempotent: a step with no open Execution
+// gets one allocated retroactively so the JobsTable never renders an em-dash
+// duration cell (matching the activity + helmwatch bridges).
+func (b *BootstrapBridge) FinishStep(slug, status, message string, t time.Time) error {
+	if !IsTerminal(status) {
+		status = StatusSucceeded
+	}
+	t = t.UTC()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.finishStepLocked(slug, status, message, t)
+}
+
+func (b *BootstrapBridge) finishStepLocked(slug, status, message string, t time.Time) error {
+	if err := b.ensureGroupLocked(); err != nil {
+		return err
+	}
+	jobName := b.stepJobName(slug)
+
+	execID := b.activeExecID[slug]
+	if execID == "" {
+		if job, _, err := b.store.GetJob(b.deploymentID, jobName); err == nil && job.LatestExecutionID != "" {
+			if priorExec, ferr := b.store.FindExecution(b.deploymentID, job.LatestExecutionID); ferr == nil && !IsTerminal(priorExec.Status) {
+				execID = job.LatestExecutionID
+			}
+		}
+	}
+	if execID == "" {
+		exec, err := b.store.StartExecution(b.deploymentID, jobName, t)
+		if err != nil {
+			return err
+		}
+		execID = exec.ID
+	}
+
+	if message != "" {
+		level := LevelInfo
+		if status == StatusFailed {
+			level = LevelError
+		}
+		if err := b.store.AppendLogLines(b.deploymentID, execID, []LogLine{{
+			Timestamp: t,
+			Level:     level,
+			Message:   message,
+		}}); err != nil {
+			return err
+		}
+	}
+
+	if err := b.store.FinishExecution(b.deploymentID, execID, status, t); err != nil {
+		return err
+	}
+	delete(b.activeExecID, slug)
+	return nil
+}
+
+// MarkKubeconfigReceived is the convenience transition the kubeconfig-PUT
+// callback fires: it succeeds nodes-booting + kubeconfig-received and starts
+// flux-installing in one atomic critical section, so the timeline advances
+// from "Nodes booting" → "k3s up · kubeconfig received" → "Flux installing"
+// the instant the PUT lands. Idempotent: re-firing is a no-op once the steps
+// are terminal (FinishExecution is a no-op on an already-terminal Execution;
+// StartStep reuses the open flux Execution).
+func (b *BootstrapBridge) MarkKubeconfigReceived(message string, t time.Time) error {
+	t = t.UTC()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if err := b.finishStepLocked(BootstrapStepNodesBooting, StatusSucceeded, "Nodes booted; cloud-init PUT the kubeconfig back.", t); err != nil {
+		return err
+	}
+	msg := message
+	if msg == "" {
+		msg = "k3s up; kubeconfig received from cloud-init."
+	}
+	if err := b.finishStepLocked(BootstrapStepKubeconfig, StatusSucceeded, msg, t); err != nil {
+		return err
+	}
+	return b.startStepLocked(BootstrapStepFluxInstalling, "Flux is reconciling the bootstrap-kit Kustomization; watching HelmReleases converge.", t)
+}
+
+// MarkConverged succeeds the flux-installing step at OutcomeReady — the
+// bootstrap window is closed and the bootstrap-kit installs take over the
+// timeline. Idempotent.
+func (b *BootstrapBridge) MarkConverged(message string, t time.Time) error {
+	msg := message
+	if msg == "" {
+		msg = "Bootstrap-kit converged; per-component HelmReleases now drive the timeline."
+	}
+	return b.FinishStep(BootstrapStepFluxInstalling, StatusSucceeded, msg, t)
+}

--- a/products/catalyst/bootstrap/api/internal/jobs/bootstrap_bridge_test.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/bootstrap_bridge_test.go
@@ -1,0 +1,321 @@
+// bootstrap_bridge_test.go — proves the BootstrapBridge fills the ~30-minute
+// "Bootstrapping cluster" window with a group + three live step children whose
+// status rolls up so the provisioning timeline shows continuous motion instead
+// of a static "Provision <provider>: Success".
+package jobs
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func newBootstrapFixture(t *testing.T) (*Store, *BootstrapBridge, string) {
+	t.Helper()
+	st, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	depID := "dep-bootstrap"
+	return st, NewBootstrapBridge(st, depID), depID
+}
+
+func findBootstrapJob(t *testing.T, in []Job, name string) Job {
+	t.Helper()
+	for _, j := range in {
+		if j.JobName == name {
+			return j
+		}
+	}
+	t.Fatalf("job %q not found in %d rows", name, len(in))
+	return Job{}
+}
+
+// TestBootstrapBridge_SeedProjectsGroupAndChain is the core structural test:
+// Seed materialises the "Bootstrapping cluster" group + the three step leaves
+// in pending, each step depending on the prior one (linear chain).
+func TestBootstrapBridge_SeedProjectsGroupAndChain(t *testing.T) {
+	st, bb, depID := newBootstrapFixture(t)
+
+	if err := bb.Seed(); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	got, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+
+	group := findBootstrapJob(t, got, GroupClusterConverge)
+	if group.Type != JobTypeGroup {
+		t.Fatalf("group Type = %q, want %q", group.Type, JobTypeGroup)
+	}
+	if group.DisplayName != GroupClusterConvergeDisplay {
+		t.Fatalf("group DisplayName = %q, want %q", group.DisplayName, GroupClusterConvergeDisplay)
+	}
+	// Empty/pending group at seed time.
+	if group.Status != StatusPending {
+		t.Fatalf("group Status = %q, want pending at seed", group.Status)
+	}
+
+	nodes := findBootstrapJob(t, got, ActivityStepJobName(GroupClusterConverge, BootstrapStepNodesBooting))
+	kube := findBootstrapJob(t, got, ActivityStepJobName(GroupClusterConverge, BootstrapStepKubeconfig))
+	flux := findBootstrapJob(t, got, ActivityStepJobName(GroupClusterConverge, BootstrapStepFluxInstalling))
+
+	for _, s := range []Job{nodes, kube, flux} {
+		if s.Status != StatusPending {
+			t.Fatalf("step %q Status = %q, want pending", s.JobName, s.Status)
+		}
+		if s.ParentID != JobID(depID, GroupClusterConverge) {
+			t.Fatalf("step %q ParentID = %q, want group id", s.JobName, s.ParentID)
+		}
+		if s.Kind != KindStep {
+			t.Fatalf("step %q Kind = %q, want %q", s.JobName, s.Kind, KindStep)
+		}
+	}
+
+	// Linear chain: nodes has no dep; kube depends on nodes; flux depends on kube.
+	if len(nodes.DependsOn) != 0 {
+		t.Fatalf("nodes DependsOn = %v, want empty", nodes.DependsOn)
+	}
+	if len(kube.DependsOn) != 1 || kube.DependsOn[0] != ActivityStepJobName(GroupClusterConverge, BootstrapStepNodesBooting) {
+		t.Fatalf("kube DependsOn = %v, want [nodes step]", kube.DependsOn)
+	}
+	if len(flux.DependsOn) != 1 || flux.DependsOn[0] != ActivityStepJobName(GroupClusterConverge, BootstrapStepKubeconfig) {
+		t.Fatalf("flux DependsOn = %v, want [kube step]", flux.DependsOn)
+	}
+}
+
+// TestBootstrapBridge_GroupRunsWhileNodesBooting proves the group rolls up to
+// "running" the instant the nodes-booting step starts — this is the signal
+// that fills the void: the operator never sees a static Success behind which
+// nothing is moving.
+func TestBootstrapBridge_GroupRunsWhileNodesBooting(t *testing.T) {
+	st, bb, depID := newBootstrapFixture(t)
+	now := time.Now().UTC()
+
+	if err := bb.Seed(); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	if err := bb.StartStep(BootstrapStepNodesBooting, "Nodes booting", now); err != nil {
+		t.Fatalf("StartStep: %v", err)
+	}
+
+	got, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	group := findBootstrapJob(t, got, GroupClusterConverge)
+	if group.Status != StatusRunning {
+		t.Fatalf("group Status = %q, want running while nodes booting", group.Status)
+	}
+	nodes := findBootstrapJob(t, got, ActivityStepJobName(GroupClusterConverge, BootstrapStepNodesBooting))
+	if nodes.Status != StatusRunning {
+		t.Fatalf("nodes Status = %q, want running", nodes.Status)
+	}
+	if nodes.StartedAt == nil {
+		t.Fatalf("nodes StartedAt nil, want stamped")
+	}
+}
+
+// TestBootstrapBridge_Heartbeat appends live log lines to the running step
+// WITHOUT changing its status — the always-there motion during the long wait.
+func TestBootstrapBridge_Heartbeat(t *testing.T) {
+	st, bb, depID := newBootstrapFixture(t)
+	now := time.Now().UTC()
+
+	_ = bb.Seed()
+	_ = bb.StartStep(BootstrapStepNodesBooting, "started", now)
+
+	if err := bb.Heartbeat(BootstrapStepNodesBooting, "cloud-init: running module final", now.Add(time.Second)); err != nil {
+		t.Fatalf("Heartbeat: %v", err)
+	}
+
+	jobName := ActivityStepJobName(GroupClusterConverge, BootstrapStepNodesBooting)
+	job, execs, err := st.GetJob(depID, jobName)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.Status != StatusRunning {
+		t.Fatalf("after heartbeat status = %q, want running (heartbeat must not terminate)", job.Status)
+	}
+	if len(execs) != 1 {
+		t.Fatalf("execs = %d, want 1 (heartbeat reuses the open execution)", len(execs))
+	}
+	page, err := st.PageLogs(depID, execs[0].ID, 0, 100)
+	if err != nil {
+		t.Fatalf("PageLogs: %v", err)
+	}
+	var sawHeartbeat bool
+	for _, l := range page.Lines {
+		if strings.Contains(l.Message, "module final") {
+			sawHeartbeat = true
+		}
+	}
+	if !sawHeartbeat {
+		t.Fatalf("heartbeat line not found in %d log lines", len(page.Lines))
+	}
+}
+
+// TestBootstrapBridge_MarkKubeconfigReceived advances the window: nodes +
+// kubeconfig steps succeed, flux step starts running — exactly the timeline
+// motion the operator sees the instant the kubeconfig PUT lands.
+func TestBootstrapBridge_MarkKubeconfigReceived(t *testing.T) {
+	st, bb, depID := newBootstrapFixture(t)
+	now := time.Now().UTC()
+
+	_ = bb.Seed()
+	_ = bb.StartStep(BootstrapStepNodesBooting, "started", now)
+	if err := bb.MarkKubeconfigReceived("kubeconfig received (4321 bytes)", now.Add(2*time.Minute)); err != nil {
+		t.Fatalf("MarkKubeconfigReceived: %v", err)
+	}
+
+	got, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	nodes := findBootstrapJob(t, got, ActivityStepJobName(GroupClusterConverge, BootstrapStepNodesBooting))
+	kube := findBootstrapJob(t, got, ActivityStepJobName(GroupClusterConverge, BootstrapStepKubeconfig))
+	flux := findBootstrapJob(t, got, ActivityStepJobName(GroupClusterConverge, BootstrapStepFluxInstalling))
+
+	if nodes.Status != StatusSucceeded {
+		t.Fatalf("nodes Status = %q, want succeeded", nodes.Status)
+	}
+	if kube.Status != StatusSucceeded {
+		t.Fatalf("kube Status = %q, want succeeded", kube.Status)
+	}
+	if flux.Status != StatusRunning {
+		t.Fatalf("flux Status = %q, want running after kubeconfig received", flux.Status)
+	}
+	// The group is still running because flux is in flight.
+	group := findBootstrapJob(t, got, GroupClusterConverge)
+	if group.Status != StatusRunning {
+		t.Fatalf("group Status = %q, want running while flux installs", group.Status)
+	}
+}
+
+// TestBootstrapBridge_FluxProgressLiveLabel proves the flux step's DisplayName
+// carries the live "HR X/Y ready" counter the operator watches climb, and that
+// an unchanged census is a no-op (no churn at the poll cadence).
+func TestBootstrapBridge_FluxProgressLiveLabel(t *testing.T) {
+	st, bb, depID := newBootstrapFixture(t)
+	now := time.Now().UTC()
+
+	_ = bb.Seed()
+	_ = bb.StartStep(BootstrapStepNodesBooting, "started", now)
+	_ = bb.MarkKubeconfigReceived("kc", now.Add(time.Minute))
+
+	jobName := ActivityStepJobName(GroupClusterConverge, BootstrapStepFluxInstalling)
+
+	if err := bb.SetFluxProgress(3, 11, now.Add(2*time.Minute)); err != nil {
+		t.Fatalf("SetFluxProgress: %v", err)
+	}
+	job, execs, err := st.GetJob(depID, jobName)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	wantLabel := "Flux installing — HR 3/11 ready"
+	if job.DisplayName != wantLabel {
+		t.Fatalf("flux DisplayName = %q, want %q", job.DisplayName, wantLabel)
+	}
+
+	before, _ := st.PageLogs(depID, execs[0].ID, 0, 1000)
+	// Same census again → no-op (no new label, no new log line).
+	if err := bb.SetFluxProgress(3, 11, now.Add(3*time.Minute)); err != nil {
+		t.Fatalf("SetFluxProgress repeat: %v", err)
+	}
+	after, _ := st.PageLogs(depID, execs[0].ID, 0, 1000)
+	if after.Total != before.Total {
+		t.Fatalf("repeat unchanged census appended a log line (%d → %d), want no-op", before.Total, after.Total)
+	}
+
+	// Census advances → label climbs.
+	if err := bb.SetFluxProgress(11, 11, now.Add(4*time.Minute)); err != nil {
+		t.Fatalf("SetFluxProgress climb: %v", err)
+	}
+	job, _, _ = st.GetJob(depID, jobName)
+	if job.DisplayName != "Flux installing — HR 11/11 ready" {
+		t.Fatalf("flux DisplayName = %q, want climbed to 11/11", job.DisplayName)
+	}
+}
+
+// TestBootstrapBridge_MarkConverged closes the window cleanly — flux succeeds,
+// the whole group rolls up to succeeded so the bootstrap-kit install rows take
+// over the timeline.
+func TestBootstrapBridge_MarkConverged(t *testing.T) {
+	st, bb, depID := newBootstrapFixture(t)
+	now := time.Now().UTC()
+
+	_ = bb.Seed()
+	_ = bb.StartStep(BootstrapStepNodesBooting, "started", now)
+	_ = bb.MarkKubeconfigReceived("kc", now.Add(time.Minute))
+	_ = bb.SetFluxProgress(11, 11, now.Add(2*time.Minute))
+	if err := bb.MarkConverged("converged", now.Add(3*time.Minute)); err != nil {
+		t.Fatalf("MarkConverged: %v", err)
+	}
+
+	got, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	group := findBootstrapJob(t, got, GroupClusterConverge)
+	if group.Status != StatusSucceeded {
+		t.Fatalf("group Status = %q, want succeeded after convergence", group.Status)
+	}
+	flux := findBootstrapJob(t, got, ActivityStepJobName(GroupClusterConverge, BootstrapStepFluxInstalling))
+	if flux.Status != StatusSucceeded {
+		t.Fatalf("flux Status = %q, want succeeded", flux.Status)
+	}
+	if flux.FinishedAt == nil {
+		t.Fatalf("flux FinishedAt nil, want stamped on convergence")
+	}
+}
+
+// TestBootstrapBridge_KubeconfigTimeoutFailsHonestly proves a failed window
+// (kubeconfig never arrives) surfaces the steps as failed, not perpetually
+// running — the timeline must never lie about a dead prov.
+func TestBootstrapBridge_KubeconfigTimeoutFailsHonestly(t *testing.T) {
+	st, bb, depID := newBootstrapFixture(t)
+	now := time.Now().UTC()
+
+	_ = bb.Seed()
+	_ = bb.StartStep(BootstrapStepNodesBooting, "started", now)
+	if err := bb.FinishStep(BootstrapStepNodesBooting, StatusFailed, "no kubeconfig", now.Add(time.Minute)); err != nil {
+		t.Fatalf("FinishStep nodes: %v", err)
+	}
+	if err := bb.FinishStep(BootstrapStepKubeconfig, StatusFailed, "no kubeconfig", now.Add(time.Minute)); err != nil {
+		t.Fatalf("FinishStep kube: %v", err)
+	}
+
+	got, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	group := findBootstrapJob(t, got, GroupClusterConverge)
+	if group.Status != StatusFailed {
+		t.Fatalf("group Status = %q, want failed when kubeconfig never arrives", group.Status)
+	}
+}
+
+// TestBootstrapBridge_SeedIdempotent proves re-seeding (Pod-restart resume)
+// never un-starts a running step.
+func TestBootstrapBridge_SeedIdempotent(t *testing.T) {
+	st, bb, depID := newBootstrapFixture(t)
+	now := time.Now().UTC()
+
+	_ = bb.Seed()
+	_ = bb.StartStep(BootstrapStepNodesBooting, "started", now)
+	// Re-seed (resume) must preserve the running nodes step.
+	if err := bb.Seed(); err != nil {
+		t.Fatalf("Seed re-run: %v", err)
+	}
+	job, _, err := st.GetJob(depID, ActivityStepJobName(GroupClusterConverge, BootstrapStepNodesBooting))
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.Status != StatusRunning {
+		t.Fatalf("after re-seed nodes Status = %q, want still running (idempotent)", job.Status)
+	}
+	if job.StartedAt == nil {
+		t.Fatalf("after re-seed nodes StartedAt nil, want preserved")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/jobs/types.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/types.go
@@ -210,6 +210,40 @@ const (
 	// green under bootstrap-kit — the operator sees the truth (issue
 	// #3646 §3a/§6).
 	GroupReconcilers = "reconcilers"
+	// GroupClusterConverge — the "Bootstrapping cluster" group that fills
+	// the ~30-minute window between "Provision <provider>: Success" (tofu
+	// apply returned) and the first bp-* HelmRelease appearing under
+	// bootstrap-kit. Before this group existed the provisioning timeline
+	// showed a static "Provision <provider>: Success" for half an hour
+	// with NO further motion while cloud-init → k3s → kubeconfig-PUT →
+	// Flux-install ran cluster-side, so the operator reasonably concluded
+	// the prov was dead. Its three step children (BootstrapStep* below)
+	// are driven LIVE by the phase1-watch loop's own signals so the
+	// operator always sees a status, an event line, or a climbing counter.
+	GroupClusterConverge = "cluster-converge"
+)
+
+// Bootstrap-window step slugs — the three sub-steps of the
+// GroupClusterConverge group. Each is an "<group>-step-<slug>" leaf so the
+// namespace stays disjoint from the install-/lifecycle leaves (matching the
+// ActivityBridge convention). Driven live by internal/handler's
+// runPhase1Watch via BootstrapBridge:
+//
+//   - BootstrapStepNodesBooting — Running the instant Phase-1 begins (right
+//     after tofu-apply returns Success); a heartbeat log line is appended
+//     each poll tick (numEvents climb / cloud-init log tail) so the operator
+//     sees motion. Succeeds when the kubeconfig PUT lands.
+//   - BootstrapStepKubeconfig — k3s came up and cloud-init PUT the kubeconfig
+//     back (the callback that ends the Phase-1 kubeconfig wait). Succeeds the
+//     moment the file is readable, per region.
+//   - BootstrapStepFluxInstalling — Flux is reconciling the bootstrap-kit; the
+//     leaf's DisplayName updates live to "Flux installing — HR X/Y ready"
+//     from the in-cluster HelmRelease census the helmwatch snapshot exposes.
+//     Succeeds at OutcomeReady.
+const (
+	BootstrapStepNodesBooting   = "nodes-booting"
+	BootstrapStepKubeconfig     = "kubeconfig-received"
+	BootstrapStepFluxInstalling = "flux-installing"
 )
 
 // Group display names — user-visible labels for the synthesised
@@ -230,6 +264,20 @@ const (
 	GroupHandoverDisplay    = "Handover"
 	GroupAppsDisplay        = "Apps"
 	GroupReconcilersDisplay = "Reconcilers"
+	// GroupClusterConvergeDisplay — operator-visible label for the window-
+	// filling group. "Bootstrapping cluster" reads as live activity, never a
+	// terminal verdict.
+	GroupClusterConvergeDisplay = "Bootstrapping cluster"
+)
+
+// Bootstrap-window step display names — the friendly labels rendered for the
+// three GroupClusterConverge step children. The Flux step's label is updated
+// live by BootstrapBridge.SetFluxProgress to carry the running "HR X/Y ready"
+// counter; the static value here is its pre-progress baseline.
+const (
+	BootstrapStepNodesBootingDisplay   = "Nodes booting · cloud-init running"
+	BootstrapStepKubeconfigDisplay     = "k3s up · kubeconfig received"
+	BootstrapStepFluxInstallingDisplay = "Flux installing"
 )
 
 // providerDisplayNames maps a canonical (lower-cased) cloud provider name

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.test.tsx
@@ -412,6 +412,61 @@ describe('JobsTable — render', () => {
     expect(badge.textContent).not.toContain('Confirming')
     expect(badge.getAttribute('data-status')).toBe('pending')
   })
+
+  // ──────────────────────────────────────────────────────────────────
+  // Bootstrap-window ("Bootstrapping cluster") — the catalyst-api writes a
+  // GroupClusterConverge group + 3 step children during the ~30-minute void
+  // between "Provision <provider>: Success" and the first bp-* HelmRelease.
+  // The table is fully generic, so the new group + its live "HR X/Y ready"
+  // flux step render through the existing /jobs poll with zero adapter
+  // changes — these assertions lock that in.
+  // ──────────────────────────────────────────────────────────────────
+  it('renders the "Bootstrapping cluster" step rows with their live labels', async () => {
+    const jobs: Job[] = [
+      {
+        id: 'd-1:cluster-converge', jobName: 'cluster-converge',
+        displayName: 'Bootstrapping cluster', type: 'group', appId: '',
+        parentId: '', dependsOn: [],
+        childIds: [
+          'd-1:cluster-converge-step-nodes-booting',
+          'd-1:cluster-converge-step-kubeconfig-received',
+          'd-1:cluster-converge-step-flux-installing',
+        ],
+        status: 'running', startedAt: '2026-04-29T10:00:00Z', finishedAt: null, durationMs: 0,
+      },
+      {
+        ...baseLeaf, appId: '', id: 'd-1:cluster-converge-step-nodes-booting',
+        jobName: 'cluster-converge-step-nodes-booting',
+        displayName: 'Nodes booting · cloud-init running',
+        parentId: 'd-1:cluster-converge', status: 'succeeded',
+        startedAt: '2026-04-29T10:00:00Z', finishedAt: '2026-04-29T10:05:00Z',
+      },
+      {
+        ...baseLeaf, appId: '', id: 'd-1:cluster-converge-step-kubeconfig-received',
+        jobName: 'cluster-converge-step-kubeconfig-received',
+        displayName: 'k3s up · kubeconfig received',
+        parentId: 'd-1:cluster-converge', status: 'succeeded',
+        startedAt: '2026-04-29T10:05:00Z', finishedAt: '2026-04-29T10:05:30Z',
+      },
+      {
+        ...baseLeaf, appId: '', id: 'd-1:cluster-converge-step-flux-installing',
+        jobName: 'cluster-converge-step-flux-installing',
+        // The live HR counter the operator watches climb.
+        displayName: 'Flux installing — HR 7/11 ready',
+        parentId: 'd-1:cluster-converge', status: 'running',
+        startedAt: '2026-04-29T10:05:30Z',
+      },
+    ]
+    renderTable({ jobs })
+    await screen.findByTestId('jobs-table')
+    // The live "HR X/Y ready" counter renders on the flux step row.
+    expect(screen.getByText('Flux installing — HR 7/11 ready')).toBeTruthy()
+    expect(screen.getByText('Nodes booting · cloud-init running')).toBeTruthy()
+    // The group is selectable as a Parent (its label resolves from displayName).
+    const parentSelect = screen.getByTestId('jobs-filter-parent') as HTMLSelectElement
+    const optionLabels = Array.from(parentSelect.options).map((o) => o.textContent)
+    expect(optionLabels).toContain('Bootstrapping cluster')
+  })
 })
 
 // ── C8-005 (2026-05-17 t143): region filter helpers + dropdown ───────


### PR DESCRIPTION
## Problem

On `/sovereign/provision/<id>/jobs`, the "Provision Hetzner/Huawei" lifecycle group flips to **Success** the moment `tofu apply` finishes, then there is a **silent ~30-minute void** before any in-cluster activity appears. The operator sees "Provision <provider>: Success" for half an hour and reasonably concludes the prov is stuck/dead — when the cluster is actually bootstrapping (cloud-init → k3s → kubeconfig-PUT → Flux installing → HRs reconciling).

## Fix — a live "Bootstrapping cluster" group driven by phase1-watch signals

A new `BootstrapBridge` writes a `cluster-converge` group ("Bootstrapping cluster") with three step children into the same jobs Store the rest of the timeline uses. Each step is driven by a signal catalyst-api **already** had during the void:

| Step | Signal that drives it |
|---|---|
| **Nodes booting · cloud-init running** | `StartStep` the instant `runPhase1Watch` begins (right after tofu-apply Success). Heartbeated each `waitForKubeconfig` poll tick from the deployment's `numEvents` counter + the last line of the self-uploaded cloud-init log (#3132) — so the operator literally watches the bootstrap. |
| **k3s up · kubeconfig received** | Succeeds on the kubeconfig PUT callback (`MarkKubeconfigReceived`), the same edge that ends the Phase-1 kubeconfig wait. |
| **Flux installing — HR X/Y ready** | A background loop recomputes the in-cluster HelmRelease census from `watcher.SnapshotComponents()` every 5s and rewrites the leaf's DisplayName to the climbing `HR X/Y ready` counter (`SetFluxProgress`). Succeeds at `OutcomeReady`. |

The group rolls up to **running** the whole window (failed > running > pending > succeeded in `deriveTreeView`), so the existing 5-second `/jobs` poll surfaces continuous motion — a status, an event line, or a climbing counter at all times. When the kubeconfig never arrives, the steps are marked **failed** (not perpetually running), so the timeline never lies about a dead prov.

### How the 30-min window is now filled (signal → phase)

- **t=0 (tofu-apply Success):** group appears + "Nodes booting" goes Running → group reads **running** immediately (no static Success behind a void).
- **t=0…~kubeconfig:** "Nodes booting" heartbeats a fresh cloud-init log tail / numEvents line each poll tick.
- **kubeconfig PUT:** "Nodes booting" + "k3s up · kubeconfig received" succeed, "Flux installing" starts.
- **bootstrap-kit reconcile:** "Flux installing — HR X/Y ready" counter climbs each poll.
- **OutcomeReady:** all three steps succeed; the bp-* install rows take over the timeline.

## Files changed

**API (`products/catalyst/bootstrap/api`)**
- `internal/jobs/types.go` — `GroupClusterConverge` + the three `BootstrapStep*` slugs/displays.
- `internal/jobs/bootstrap_bridge.go` — **new** `BootstrapBridge` (Seed / StartStep / Heartbeat / SetFluxProgress / MarkKubeconfigReceived / MarkConverged / FinishStep); idempotent + Pod-restart-resume-safe.
- `internal/handler/phase1_watch.go` — seed + drive the bridge from `runPhase1Watch` / `waitForKubeconfig` (heartbeat + cloud-init tail helper + the flux-progress goroutine + terminal close).
- `internal/handler/deployments.go` / `infrastructure.go` / `handler.go` — `bootstrapBridge` field, `bootstrapBridgeFor` accessor, test-override interval.

**UI (`products/catalyst/bootstrap/ui`)**
- `src/pages/sovereign/JobsTable.test.tsx` — test locking in that the generic table renders the new group + the live "HR X/Y ready" flux label (no adapter change needed — the live `/jobs` poll surfaces the backend group verbatim).

## Validation

- `go build ./...` ✅, `go vet ./internal/jobs ./internal/handler` ✅
- `go test ./internal/jobs ./internal/handler` ✅ (new bridge + handler-window tests, plus the full existing suites green)
- `npm run build` (tsc + vite) ✅, `vitest run JobsTable.test.tsx` ✅ (56 passed)
- Env-independent; no prov fired.

Refs #3914
🤖 Generated with [Claude Code](https://claude.com/claude-code)