### PR TITLE
fix(catalyst-api): EXCLUDE Day-2 scanners (trivy + syft-grype) from the provisioning flow + diagram (Refs #3919 #3918)

### DIFF
--- a/.github/workflows/pages-design-mock.yml
+++ b/.github/workflows/pages-design-mock.yml
@@ -1,0 +1,35 @@
+# Deploys the #3905 topology-tab design-review mock (and anything under docs/)
+# to GitHub Pages. Scoped to the design-mock branch so it never interferes with
+# main. The mock is static (no build step) — we upload docs/ verbatim.
+name: pages-design-mock
+
+on:
+  push:
+    branches:
+      - docs/3905-topology-tab-mock
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - name: Upload docs/ as the Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -295,10 +295,10 @@ spec:
       # vc-mgmt; the CNPG-owner seams render host-side via slot 80a host-seams.
       # database.existingSecret is wired (suppress) to the host-rendered,
       # mirrored-in DSN Secret so the Deployment render-gate resolves at mgmt.
-      # 1.4.112: lockstep to the auto-bumped + published upstream-v0.13.2 chart
-      # (the auto-bump commit advanced the chart but its Blueprint-Release
-      # lockstep step failed, leaving this pin stale at 1.4.111).
-      version: 1.4.112
+      # 1.4.114 (#3831 deadlock fix, Refs #3858): admin-sso-seed Job/CronJob
+      # moved from host-seams → vcluster-app so the seed runs AFTER the app
+      # migrates the schema (it rendered host-side and deadlocked the install).
+      version: 1.4.114
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
+++ b/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
@@ -70,7 +70,12 @@ spec:
       # 1.4.111 (#3831): the placement.role render-split chart. Lockstep with
       # slot 80's pin + platform/newapi blueprint.yaml.
       # 1.4.112: lockstep to the auto-bumped + published upstream-v0.13.2 chart.
-      version: 1.4.112
+      # 1.4.114 (#3831 deadlock fix, Refs #3858): admin-sso-seed Job/CronJob no
+      # longer render under host-seams (they moved to vcluster-app) — this HR now
+      # renders only the genuine host seams (CNPG Cluster + DSN-sync Job +
+      # AppRegistration + ExternalSecrets), so its post-install no longer blocks
+      # on a schema the host never migrates.
+      version: 1.4.114
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/docs/design/topology-tab-mock/index.html
+++ b/docs/design/topology-tab-mock/index.html
@@ -1,0 +1,763 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Catalyst — Topology Tab (final UX design review)</title>
+<!--
+  DESIGN-REVIEW ARTIFACT — issue #3905.
+  Self-contained, no build step. All matrix values below are VERBATIM from the
+  source of truth: docs/topology-matrix.md (promoted into
+  products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts).
+  This mock does NOT touch the real console code — it is the agreement surface
+  the founder signs off before code lands.
+
+  THE BUG THIS FIXES (the founder's fury): the topology CARD derives
+  openbao active-passive from the matrix (raft · async, raft-transition,
+  60s/30s, warm-standby — CORRECT). The "Change placement" EDIT dropdown
+  used a generic hardcoded describeMode() that said "cold/warm standby
+  (backup-restore)" — WRONG, matrix-blind, and logically contradicting the
+  card. THE FIX: BOTH the card AND the editor read the SAME perTopology
+  contract. One source, zero contradiction.
+-->
+<style>
+  :root{
+    --bg:#0b0f17; --bg-2:#111726; --bg-3:#0e1421; --bg-elev:#0a0e16;
+    --border:#1e2738; --border-soft:#1a2230;
+    --text:#e6edf6; --text-strong:#f5f9ff; --text-dim:#8a97ac;
+    --accent:#7c9cff; --accent-2:#5b7cff;
+    --green:#3fb950; --green-bg:rgba(63,185,80,.12);
+    --yellow:#d29922; --yellow-bg:rgba(210,153,34,.12);
+    --red:#f85149; --red-bg:rgba(248,81,73,.12);
+    --purple:#bc8cff; --purple-bg:rgba(188,140,255,.12);
+    --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--text);font-family:var(--sans);
+    font-size:14px;line-height:1.5;-webkit-font-smoothing:antialiased}
+  a{color:var(--accent)}
+  code,.mono{font-family:var(--mono)}
+  .wrap{max-width:1180px;margin:0 auto;padding:24px 20px 80px}
+
+  /* ── design-review banner ── */
+  .review-banner{background:linear-gradient(90deg,#1a1030,#10142a);
+    border:1px solid #36306a;border-radius:10px;padding:14px 18px;margin-bottom:22px}
+  .review-banner h1{margin:0 0 4px;font-size:16px;color:#cdbcff}
+  .review-banner p{margin:0;color:var(--text-dim);font-size:12.5px}
+  .review-banner .tag{display:inline-block;background:#2a1f55;color:#cdbcff;
+    border-radius:5px;padding:1px 7px;font-size:11px;font-weight:600;margin-right:6px}
+
+  /* ── faux browser chrome ── */
+  .browser{border:1px solid var(--border);border-radius:12px;overflow:hidden;
+    background:var(--bg-2);box-shadow:0 8px 40px rgba(0,0,0,.4)}
+  .chrome{display:flex;align-items:center;gap:10px;background:#0a0e16;
+    padding:9px 14px;border-bottom:1px solid var(--border)}
+  .dots{display:flex;gap:6px}
+  .dot{width:11px;height:11px;border-radius:50%}
+  .dot.r{background:#ff5f57}.dot.y{background:#febc2e}.dot.g{background:#28c840}
+  .addr{flex:1;background:#070a11;border:1px solid var(--border);border-radius:6px;
+    padding:5px 12px;font-family:var(--mono);font-size:12px;color:var(--text-dim)}
+  .addr b{color:var(--text)}
+
+  /* ── app shell ── */
+  .app{padding:20px 22px}
+  .hero{display:flex;align-items:center;gap:14px;flex-wrap:wrap;
+    padding-bottom:14px;border-bottom:1px solid var(--border-soft)}
+  .hero-icon{width:46px;height:46px;border-radius:11px;background:#1f2937;
+    display:grid;place-items:center;font-size:22px}
+  .hero h2{margin:0;font-size:19px;color:var(--text-strong)}
+  .hero .sub{color:var(--text-dim);font-weight:400}
+  .hero .tagline{margin:3px 0 0;color:var(--text-dim);font-size:12.5px;max-width:640px}
+  .chips{display:flex;gap:6px;flex-wrap:wrap;margin-top:8px}
+  .chip{font-size:11px;padding:2px 8px;border-radius:5px;background:#16203a;
+    color:#aebfe0;border:1px solid var(--border)}
+  .chip.ns{background:#0e1d18;color:#7fd1a8;border-color:#1d3a2c}
+  .chip.bp{background:#1a1830;color:#b9aaf0;border-color:#2c2750}
+  .chip.ready{background:var(--green-bg);color:var(--green);border-color:#1d3a2c}
+  .hero-cta{margin-left:auto;display:flex;flex-direction:column;align-items:flex-end;gap:3px}
+  .btn-open{background:var(--accent);color:#0a0e16;border:0;border-radius:7px;
+    padding:8px 16px;font-weight:700;font-size:13px;cursor:pointer}
+  .hero-cta .hint{font-size:11px;color:var(--text-dim)}
+
+  /* ── component picker (mock-only control) ── */
+  .picker{display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+    margin:16px 0 4px;padding:10px 12px;border:1px dashed #34406a;border-radius:9px;
+    background:#0d1426}
+  .picker .lbl{font-size:11px;text-transform:uppercase;letter-spacing:.05em;
+    color:#8aa0e0;font-weight:700}
+  .picker select{background:#070a11;color:var(--text);border:1px solid var(--border);
+    border-radius:6px;padding:6px 10px;font-family:var(--mono);font-size:13px}
+  .picker .note{font-size:11px;color:var(--text-dim)}
+
+  /* ── tab strip ── */
+  .tabs{display:flex;gap:2px;margin:16px 0 0;border-bottom:1px solid var(--border);
+    overflow-x:auto}
+  .tab{padding:9px 14px;font-size:13px;color:var(--text-dim);cursor:default;
+    border-bottom:2px solid transparent;white-space:nowrap}
+  .tab.active{color:var(--text-strong);border-bottom-color:var(--accent);font-weight:600}
+
+  /* ── panels ── */
+  .panel{margin-top:18px}
+  .card{border:1px solid var(--border);background:var(--bg-3);border-radius:10px;
+    padding:16px 18px;margin-bottom:16px}
+  .card-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px}
+  .card-head h3{margin:0;font-size:14px;color:var(--text-strong)}
+  .badge{font-size:12px;font-weight:700;padding:3px 11px;border-radius:6px}
+  .badge.dr{background:rgba(124,156,255,.16);color:var(--accent)}
+  .badge.single{background:rgba(138,151,172,.16);color:var(--text-dim)}
+  .badge.degraded{background:var(--yellow-bg);color:var(--yellow)}
+  .lead{color:var(--text-dim);font-size:12.5px;margin:0 0 14px}
+
+  .grid2{display:grid;grid-template-columns:1fr 1fr;gap:6px 28px}
+  @media(max-width:640px){.grid2{grid-template-columns:1fr}}
+  .kv{display:flex;justify-content:space-between;gap:14px;padding:4px 0;
+    border-bottom:1px dashed var(--border-soft)}
+  .kv dt{color:var(--text-dim);font-size:12.5px}
+  .kv dd{margin:0;font-family:var(--mono);font-size:12.5px;color:var(--text);text-align:right}
+  .kv dd.warn{color:var(--yellow)}
+  .kv .src-tag{font-size:10.5px;color:#5d6b82;margin-left:6px}
+
+  /* observed strip */
+  .observed{margin-top:12px;border:1px solid var(--border);background:var(--bg-elev);
+    border-radius:8px;padding:12px 14px}
+  .observed .ohead{font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;
+    color:var(--text-dim);font-weight:700;margin:0 0 9px}
+  .ph{display:inline-flex;padding:2px 8px;border-radius:5px;font-size:10px;
+    font-weight:700;text-transform:uppercase}
+  .ph.degraded{background:var(--yellow-bg);color:var(--yellow)}
+  .ph.healthy{background:var(--green-bg);color:var(--green)}
+  .nopair{color:var(--text-dim);font-size:12.5px;margin:0}
+  .nopair strong{color:var(--text)}
+
+  /* cluster pills */
+  .clusters{display:flex;gap:7px;flex-wrap:wrap;margin-top:6px}
+  .cpill{display:inline-flex;align-items:center;gap:7px;border-radius:7px;
+    padding:3px 9px;font-size:12px;border:1px solid var(--border)}
+  .cpill.active{background:var(--green-bg);color:var(--green);border-color:#1d3a2c}
+  .cpill.passive{background:var(--yellow-bg);color:var(--yellow);border-color:#3a2f1d}
+  .cpill.singleton{background:#161b27;color:var(--text-dim)}
+  .cpill .role{font-size:9.5px;font-weight:800;text-transform:uppercase;opacity:.85}
+  .ulabel{font-size:10.5px;text-transform:uppercase;letter-spacing:.05em;
+    color:var(--text-dim);font-weight:700;margin:14px 0 6px}
+
+  .note-box{margin-top:12px;border:1px solid var(--border);background:var(--bg-elev);
+    border-radius:7px;padding:9px 12px;font-size:11.5px;color:var(--text-dim)}
+  .note-box strong{color:var(--text)}
+
+  /* ── editor ── */
+  .editor h4{margin:18px 0 4px;font-size:13.5px;color:var(--text-strong)}
+  .editor .ehint{font-size:12px;color:var(--text-dim);margin:0 0 12px}
+  .modes{display:flex;flex-direction:column;gap:8px}
+  .mode{display:flex;align-items:flex-start;gap:10px;border:1px solid var(--border);
+    border-radius:8px;padding:10px 12px;cursor:pointer;transition:.12s}
+  .mode:hover{border-color:#2e3a55}
+  .mode.sel{background:rgba(124,156,255,.08);border-color:var(--accent)}
+  .mode.disabled{opacity:.4;cursor:not-allowed}
+  .mode input{margin-top:3px}
+  .mode .mname{font-family:var(--mono);font-size:13px;color:var(--text);font-weight:600;
+    min-width:142px}
+  .mode .mdesc{font-size:12px;color:var(--text-dim)}
+  .mode.sel .mdesc{color:#c3d0e8}
+  .mode .mdesc .from-matrix{color:var(--accent);font-weight:600}
+
+  .regions{display:grid;grid-template-columns:1fr 1fr;gap:7px;margin:6px 0 4px}
+  @media(max-width:640px){.regions{grid-template-columns:1fr}}
+  .region{display:flex;align-items:center;gap:9px;border:1px solid var(--border);
+    border-radius:7px;padding:7px 11px;font-family:var(--mono);font-size:12.5px;cursor:pointer}
+  .region.on{background:rgba(124,156,255,.08);border-color:var(--accent)}
+  .region .rrole{margin-left:auto;font-size:9.5px;font-weight:800;text-transform:uppercase;
+    padding:1px 6px;border-radius:4px}
+  .region .rrole.active{background:var(--green-bg);color:var(--green)}
+  .region .rrole.passive{background:var(--yellow-bg);color:var(--yellow)}
+
+  .actions{display:flex;gap:9px;margin-top:14px}
+  .btn{border:1px solid var(--border);background:transparent;color:var(--text);
+    border-radius:7px;padding:7px 15px;font-size:12.5px;cursor:pointer}
+  .btn:hover{border-color:var(--accent)}
+  .btn.primary{background:var(--accent);color:#0a0e16;border-color:var(--accent);font-weight:700}
+  .btn:disabled{opacity:.4;cursor:not-allowed}
+
+  /* preview modal */
+  .scrim{position:fixed;inset:0;background:rgba(0,0,0,.72);display:none;
+    align-items:center;justify-content:center;padding:24px;z-index:50}
+  .scrim.show{display:flex}
+  .modal{max-width:760px;width:100%;max-height:84vh;overflow:auto;
+    background:var(--bg);border:1px solid var(--border);border-radius:12px;padding:20px 22px}
+  .modal h3{margin:0 0 4px;font-size:15px;color:var(--text-strong)}
+  .modal .msub{color:var(--text-dim);font-size:12px;margin:0 0 14px}
+  .modal pre{background:var(--bg-elev);border:1px solid var(--border);border-radius:8px;
+    padding:12px 14px;font-size:11.5px;line-height:1.55;overflow:auto;color:#c8d4ea;margin:6px 0 14px}
+  .modal .mpath{font-family:var(--mono);font-size:11px;color:var(--text-dim);margin-bottom:2px}
+  .apply-note{border:1px solid #2c2750;background:rgba(124,156,255,.06);border-radius:8px;
+    padding:11px 13px;font-size:12px;color:#c3d0e8;margin-bottom:14px}
+  .apply-note b{color:var(--text-strong)}
+  .modal .mclose{float:right;background:transparent;border:0;color:var(--text-dim);
+    cursor:pointer;font-size:13px}
+
+  /* annotations */
+  .annot{margin:26px 0 0;border:1px solid #2a3350;border-radius:10px;background:#0c1120;
+    padding:16px 18px}
+  .annot h3{margin:0 0 10px;font-size:14px;color:#bcd}
+  .annot ol{margin:0;padding-left:20px}
+  .annot li{margin-bottom:9px;font-size:13px;color:var(--text-dim)}
+  .annot li b{color:var(--text)}
+  .annot .pin{display:inline-block;width:18px;height:18px;border-radius:50%;
+    background:var(--accent);color:#0a0e16;font-size:11px;font-weight:800;
+    text-align:center;line-height:18px;margin-right:7px;vertical-align:1px}
+  .consistency{margin-top:14px;border:1px solid #1d3a2c;background:var(--green-bg);
+    border-radius:8px;padding:11px 13px;font-size:12.5px;color:#9fe0b4}
+  .consistency b{color:#d6ffe4}
+  footer{margin-top:30px;color:#5d6b82;font-size:11.5px;text-align:center}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="review-banner">
+    <h1>Catalyst · Application Topology tab — FINAL UX (design review)</h1>
+    <p>
+      <span class="tag">#3905</span>
+      <span class="tag">clickable mock</span>
+      Source of truth: <code>docs/topology-matrix.md</code> → per-component
+      <code>perTopology</code> contract. The card AND the editor now read the
+      <b>same</b> matrix, so they can never contradict. Switch the component below to
+      see openbao (active-passive), keycloak (active-hot-standby) and strimzi
+      (active-active) all stay consistent.
+    </p>
+  </div>
+
+  <div class="browser">
+    <div class="chrome">
+      <div class="dots"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span></div>
+      <div class="addr">console.<b id="addr-sov">hw165</b>.omani.works/app/<b id="addr-app">bp-openbao</b>/<b>topology</b></div>
+    </div>
+
+    <div class="app">
+      <!-- hero -->
+      <div class="hero">
+        <span class="hero-icon" id="hero-icon">🔐</span>
+        <div>
+          <h2><span id="hero-name">bp-openbao</span> <span class="sub">— <span id="hero-title">OpenBao</span></span></h2>
+          <p class="tagline" id="hero-tagline"></p>
+          <div class="chips">
+            <span class="chip">Platform</span>
+            <span class="chip ns" id="hero-ns">openbao</span>
+            <span class="chip bp" id="hero-ver">bp-openbao@1.2.46</span>
+            <span class="chip ready">Ready</span>
+            <span class="chip" id="hero-region-a">mgmt-A</span>
+            <span class="chip" id="hero-region-b">mgmt-B</span>
+          </div>
+        </div>
+        <div class="hero-cta">
+          <button class="btn-open">↗ Open <span id="hero-open-label">OpenBao</span></button>
+          <span class="hint">Single sign-in — no second login.</span>
+        </div>
+      </div>
+
+      <!-- mock-only component switcher -->
+      <div class="picker">
+        <span class="lbl">Mock control</span>
+        <span class="note">Component:</span>
+        <select id="comp-select" onchange="selectComponent(this.value)"></select>
+        <span class="note" id="picker-note"></span>
+      </div>
+
+      <!-- tab strip -->
+      <div class="tabs">
+        <div class="tab">Overview</div>
+        <div class="tab active">Topology</div>
+        <div class="tab">Resources</div>
+        <div class="tab">Compliance</div>
+        <div class="tab">Logs</div>
+        <div class="tab">Settings</div>
+        <div class="tab">Members</div>
+        <div class="tab">Endpoints</div>
+      </div>
+
+      <div class="panel">
+
+        <!-- ───────── DECLARED TOPOLOGY CARD (matrix-derived) ───────── -->
+        <div class="card">
+          <div class="card-head">
+            <h3>Declared topology <span class="src-tag" style="font-weight:400">· from blueprint.yaml spec.topology (matrix)</span></h3>
+            <span class="badge dr" id="declared-badge">active-passive</span>
+          </div>
+
+          <!-- OBSERVED / live strip -->
+          <div class="observed">
+            <p class="ohead">Observed (live on this Sovereign)</p>
+            <div id="observed-body"></div>
+          </div>
+
+          <p class="lead" id="declared-desc" style="margin-top:14px"></p>
+
+          <dl class="grid2" id="declared-grid"></dl>
+
+          <p class="ulabel">Per-cluster placement</p>
+          <div class="clusters" id="declared-clusters"></div>
+
+          <div class="note-box" id="declared-note"></div>
+        </div>
+
+        <!-- ───────── CHANGE PLACEMENT (editor) ───────── -->
+        <div class="card editor">
+          <div class="card-head">
+            <h3>Change placement</h3>
+          </div>
+          <p class="ehint">
+            Edit the placement mode and region set for
+            <code id="editor-appname">bp-openbao</code>. Apply commits the change to the
+            Application CR; the application-controller fans out per-region HelmReleases
+            and reconciles the rollout.
+          </p>
+
+          <h4>Topology mode</h4>
+          <div class="modes" id="editor-modes"></div>
+
+          <h4>Regions</h4>
+          <div class="regions" id="editor-regions"></div>
+
+          <div class="actions">
+            <button class="btn" id="preview-btn" onclick="openPreview()" disabled>Preview</button>
+            <button class="btn primary" id="apply-btn" onclick="openPreview()" disabled>Apply</button>
+            <span style="font-size:12px;color:var(--text-dim);align-self:center" id="dirty-hint">
+              Pick a different mode or region set to enable Preview / Apply.
+            </span>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <!-- ───────── annotation block ───────── -->
+  <div class="annot">
+    <h3>Key design decisions (annotated)</h3>
+    <ol>
+      <li><span class="pin">1</span><b>One matrix, two readers.</b> The
+        <b>Declared topology card</b> and the <b>Change-placement editor</b> both read the
+        component's <code>perTopology[mode]</code> contract from the same
+        <code>docs/topology-matrix.md</code> source. The editor's per-mode helper text is
+        produced by <code>describeModeForComponent(mode, topology)</code> — it is
+        <i>derived</i>, never hardcoded. The old generic
+        <code>describeMode('active-passive') = "…backup-restore"</code> string is dead.</li>
+      <li><span class="pin">2</span><b>openbao active-passive now reads identically in both
+        places:</b> <span style="color:var(--accent)">raft · async replication; raft-transition
+        switchover (RTO 60s / RPO 30s)</span> — a <i>warm standby holding live KV via stretched
+        raft</i>, NOT "cold/warm backup-restore". The card said this all along; the editor now
+        agrees.</li>
+      <li><span class="pin">3</span><b>Declared vs Observed is explicit.</b> The card shows the
+        build-time <i>mandate</i>; the Observed strip shows what's <i>actually built</i> on this
+        Sovereign read from the live Continuum / cnpg-pair record. When the mandate is declared but
+        unbuilt (openbao today: no DR pair), <b>Effective class = singleton (DEGRADED — active-passive
+        mandate unbuilt)</b> with a clear "what's needed" line. No green badge over a phantom pair.</li>
+      <li><span class="pin">4</span><b>The editor can't offer a mode the component doesn't support.</b>
+        Options are gated on <code>topology.supported[]</code>; unsupported modes render disabled.
+        Region roles (active / passive) are previewed inline from the selected mode's
+        <code>placement.roles</code>.</li>
+      <li><span class="pin">5</span><b>Preview → Apply is honest about the commit.</b> Preview renders
+        the exact per-region HelmRelease manifests; Apply explains it writes
+        <code>spec.placement</code> on the Application CR → the application-controller fans out the
+        per-region HelmReleases. No silent magic.</li>
+    </ol>
+    <div class="consistency" id="consistency-line"></div>
+  </div>
+
+  <footer>
+    Design-review mock for #3905 · matrix source: <code>docs/topology-matrix.md</code> ·
+    no real console code modified · generated for founder sign-off.
+  </footer>
+</div>
+
+<!-- preview modal -->
+<div class="scrim" id="scrim" onclick="if(event.target===this)closePreview()">
+  <div class="modal">
+    <button class="mclose" onclick="closePreview()">Close ✕</button>
+    <h3 id="modal-title">Topology preview</h3>
+    <p class="msub" id="modal-sub"></p>
+    <div class="apply-note" id="modal-apply-note"></div>
+    <div id="modal-manifests"></div>
+    <div class="actions" style="margin-top:4px">
+      <button class="btn" onclick="closePreview()">Cancel</button>
+      <button class="btn primary" onclick="confirmApply()">Apply — commit to Application CR</button>
+    </div>
+  </div>
+</div>
+
+<script>
+/* ─────────────────────────────────────────────────────────────────────────
+   DATA — verbatim from docs/topology-matrix.md → catalog.generated.ts.
+   Each component carries its real `topology` block (supported / multiRegion /
+   singleRegion / perTopology). The mock renders the card AND the editor from
+   THIS single object, exactly as the real components do post-#3905.
+   ───────────────────────────────────────────────────────────────────────── */
+const COMPONENTS = {
+  "bp-openbao": {
+    icon:"🔐", title:"OpenBao", ns:"openbao", version:"1.2.46",
+    tagline:"OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.",
+    // Observed/live truth on this Sovereign — openbao today: mandate declared, pair UNBUILT.
+    observed:{ exists:false, declaredButUnbuilt:true },
+    topology:{
+      supported:["active-passive","singleton"],
+      multiRegion:"active-passive", singleRegion:"singleton",
+      perTopology:{
+        "active-passive":{
+          replication:{ backend:"raft", mode:"async", lagSloSeconds:30 },
+          switchover:{ mechanism:"raft-transition", rtoSeconds:60, rpoSeconds:30 },
+          placement:{ tier:"mgmt", clusters:["mgmt-A","mgmt-B"], roles:{ "mgmt-A":"active","mgmt-B":"passive" } }
+        },
+        "singleton":{ replication:null, switchover:null,
+          placement:{ tier:"mgmt", clusters:["mgmt-A"], roles:{ "mgmt-A":"singleton" } } }
+      }
+    }
+  },
+  "bp-keycloak": {
+    icon:"🔑", title:"Keycloak", ns:"keycloak", version:"1.4.30",
+    tagline:"Identity & access — sovereign realm SSO. PG-backed; sync hot standby via bp-cnpg-pair.",
+    observed:{ exists:true, primaryRegion:"me-east-215-a", replicaRegion:"me-east-215-b",
+      phase:"Healthy", lagSeconds:0, source:"live cnpg cluster-pair" },
+    topology:{
+      supported:["active-hot-standby","singleton"],
+      multiRegion:"active-hot-standby", singleRegion:"singleton",
+      perTopology:{
+        "active-hot-standby":{
+          replication:{ backend:"cnpg-pair", mode:"sync", lagSloSeconds:0 },
+          switchover:{ mechanism:"bp-continuum", rtoSeconds:30, rpoSeconds:0 },
+          placement:{ tier:"mgmt", clusters:["mgmt-A","mgmt-B"], roles:{ "mgmt-A":"active","mgmt-B":"passive" } }
+        },
+        "singleton":{ replication:null, switchover:null,
+          placement:{ tier:"mgmt", clusters:["mgmt-A"], roles:{ "mgmt-A":"singleton" } } }
+      }
+    }
+  },
+  "bp-strimzi": {
+    icon:"📨", title:"Strimzi", ns:"strimzi", version:"0.0.0",
+    tagline:"Apache Kafka on Kubernetes. Cross-region topic mirroring via MirrorMaker2.",
+    observed:{ exists:false, declaredButUnbuilt:true },
+    topology:{
+      supported:["active-active","active-passive","singleton"],
+      multiRegion:"active-active", singleRegion:"singleton",
+      perTopology:{
+        "active-active":{
+          replication:{ backend:"mirrormaker2", mode:"async", lagSloSeconds:null },
+          switchover:{ mechanism:"mm2-symmetric", rtoSeconds:null, rpoSeconds:null },
+          placement:{ tier:"rtz", clusters:["rtz-A","rtz-B"], roles:{ "rtz-A":"active","rtz-B":"active" } }
+        },
+        "active-passive":{
+          replication:{ backend:"mirrormaker2", mode:"async", lagSloSeconds:null },
+          switchover:{ mechanism:"mm2-symmetric", rtoSeconds:null, rpoSeconds:null },
+          placement:{ tier:"rtz", clusters:["rtz-A","rtz-B"], roles:{ "rtz-A":"active","rtz-B":"passive" } }
+        },
+        "singleton":{ replication:null, switchover:null,
+          placement:{ tier:"rtz", clusters:["rtz-A"], roles:{ "rtz-A":"singleton" } } }
+      }
+    }
+  }
+};
+
+const ALL_MODES = ["singleton","active-active","active-hot-standby","active-passive"];
+const SOVEREIGN_REGION_COUNT = 2; // this mock renders a 2-region Sovereign
+
+/* ── matrix-derived describers (mirror the real FE/Go canonical logic) ── */
+function canon(m){
+  m=(m||"").trim().toLowerCase();
+  if(m==="active-hotstandby"||m==="active-hot-standby")return"active-hot-standby";
+  if(m==="active-passive")return"active-passive";
+  if(m==="active-active")return"active-active";
+  if(m==="singleton"||m==="single-region")return"singleton";
+  return m;
+}
+function classLabel(k){return canon(k);}
+
+// The CARD's one-liner.
+function describeTopologyClass(k){
+  switch(canon(k)){
+    case"active-hot-standby":return"Primary serves; a synchronous hot standby in the second region is ready for near-zero-RTO switchover.";
+    case"active-passive":return"Primary serves; a warm standby in the second region promotes on failure (some replication lag).";
+    case"active-active":return"Both regions serve live traffic; data syncs between them.";
+    default:return"One instance in one region; no cross-region failover (cluster-local or stateless).";
+  }
+}
+
+// THE FIX (#3905): the EDITOR's per-mode helper text derives from the SAME
+// perTopology contract the card reads. NEVER the generic "backup-restore".
+function describeModeForComponent(mode, topology){
+  const c = canon(mode);
+  const generic = {
+    "singleton":"one cluster; lowest cost; no failover",
+    "active-active":"every region serves traffic; horizontal scaling",
+    "active-hot-standby":"primary serves; standby ready for switchover",
+    "active-passive":"primary serves; standby in the second region promotes on failover"
+  }[c] || "";
+  if(!topology) return {text:generic, derived:false};
+  let variant;
+  for(const [k,v] of Object.entries(topology.perTopology)){
+    if(canon(k)===c){ variant=v; break; }
+  }
+  if(!variant || c==="singleton") return {text:generic, derived:false};
+  const parts=[];
+  parts.push(c==="active-active"
+    ? "every region serves traffic"
+    : "primary serves; second-region standby promotes on failover");
+  const r=variant.replication, s=variant.switchover;
+  if(r && r.backend){ parts.push(`${r.mode?`${r.backend} · ${r.mode}`:r.backend} replication`); }
+  if(s && s.mechanism && s.mechanism.toLowerCase()!=="none"){
+    const rto=s.rtoSeconds!=null?`RTO ${s.rtoSeconds}s`:null;
+    const rpo=s.rpoSeconds!=null?`RPO ${s.rpoSeconds}s`:null;
+    const slo=[rto,rpo].filter(Boolean).join(" / ");
+    parts.push(slo?`${s.mechanism} switchover (${slo})`:`${s.mechanism} switchover`);
+  }
+  return {text:parts.join("; "), derived:true};
+}
+
+/* ── state ── */
+let currentId="bp-openbao";
+let editMode=null;          // editor's selected mode
+let editRegions=[];         // editor's selected regions
+
+function declaredClassFor(c){
+  const t=c.topology;
+  const pick = SOVEREIGN_REGION_COUNT>1
+    ? (t.multiRegion||t.singleRegion||t.supported[0])
+    : (t.singleRegion||t.supported[0]);
+  return canon(pick);
+}
+function variantFor(c, klass){
+  for(const [k,v] of Object.entries(c.topology.perTopology)){
+    if(canon(k)===canon(klass)) return v;
+  }
+  return null;
+}
+
+/* ── render ── */
+function render(){
+  const c=COMPONENTS[currentId];
+  const dClass=declaredClassFor(c);
+  const dVar=variantFor(c, dClass);
+
+  // hero + address
+  document.getElementById("addr-app").textContent=currentId;
+  document.getElementById("hero-icon").textContent=c.icon;
+  document.getElementById("hero-name").textContent=currentId;
+  document.getElementById("hero-title").textContent=c.title;
+  document.getElementById("hero-open-label").textContent=c.title;
+  document.getElementById("hero-tagline").textContent=c.tagline;
+  document.getElementById("hero-ns").textContent=c.ns;
+  document.getElementById("hero-ver").textContent=`${currentId}@${c.version}`;
+  document.getElementById("editor-appname").textContent=currentId;
+  const pcl=(dVar&&dVar.placement&&dVar.placement.clusters)||["mgmt-A","mgmt-B"];
+  document.getElementById("hero-region-a").textContent=pcl[0]||"—";
+  document.getElementById("hero-region-b").textContent=pcl[1]||pcl[0]||"—";
+  document.getElementById("hero-region-b").style.display=pcl[1]?"":"none";
+
+  // ── DECLARED CARD ──
+  const badge=document.getElementById("declared-badge");
+  badge.textContent=classLabel(dClass);
+  badge.className="badge "+(dClass==="singleton"?"single":"dr");
+  document.getElementById("declared-desc").textContent=describeTopologyClass(dClass);
+
+  // observed strip
+  renderObserved(c, dClass);
+
+  // declared grid — EFFECTIVE class is honest about declared-but-unbuilt
+  const grid=document.getElementById("declared-grid");
+  const repl=dVar&&dVar.replication, sw=dVar&&dVar.switchover, plc=dVar&&dVar.placement;
+  let effHtml;
+  if(canon(dClass)!=="singleton" && c.observed && !c.observed.exists){
+    effHtml=`<dd class="warn">singleton <span class="src-tag">(DEGRADED — ${classLabel(dClass)} mandate unbuilt)</span></dd>`;
+  }else{
+    effHtml=`<dd>${classLabel(dClass)} <span class="src-tag">(multi-region · ${SOVEREIGN_REGION_COUNT} regions)</span></dd>`;
+  }
+  const rows=[];
+  rows.push(["Effective class", effHtml, true]);
+  rows.push(["Supported", `<dd>${c.topology.supported.map(classLabel).join(" · ")}</dd>`, true]);
+  if(plc&&plc.tier) rows.push(["Tier", `<dd>${plc.tier}</dd>`, true]);
+  if(repl&&repl.backend) rows.push(["State preservation",
+    `<dd>${repl.backend}${repl.mode?` · ${repl.mode}`:""}<span class="src-tag">matrix</span></dd>`, true]);
+  if(sw&&sw.mechanism) rows.push(["Switchover", `<dd>${sw.mechanism}<span class="src-tag">matrix</span></dd>`, true]);
+  if(sw&&(sw.rtoSeconds!=null||sw.rpoSeconds!=null)) rows.push(["RTO / RPO",
+    `<dd>${sw.rtoSeconds!=null?sw.rtoSeconds+"s":"—"} / ${sw.rpoSeconds!=null?sw.rpoSeconds+"s":"—"}</dd>`, true]);
+  grid.innerHTML=rows.map(([k,dd])=>`<div class="kv"><dt>${k}</dt>${dd}</div>`).join("");
+
+  // per-cluster placement pills
+  const cwrap=document.getElementById("declared-clusters");
+  cwrap.innerHTML=(plc&&plc.clusters||[]).map(cl=>{
+    const role=(plc.roles&&plc.roles[cl])||"active";
+    return `<span class="cpill ${role}"><code>${cl}</code><span class="role">${role}</span></span>`;
+  }).join("");
+
+  // note
+  const note=document.getElementById("declared-note");
+  if(canon(dClass)!=="singleton" && c.observed && !c.observed.exists){
+    note.innerHTML=`<strong>To reach the declared ${classLabel(dClass)} state:</strong> a healthy
+      ${pcl[1]||"second-region"} standby must come up and a Continuum (dr.openova.io) pair must
+      reconcile. Until then this app runs as a single instance with no cross-region failover.`;
+    note.style.display="";
+  }else{
+    note.style.display="none";
+  }
+
+  // ── EDITOR ──
+  // default the editor selection to the declared class on (re)load
+  editMode = canon(dClass);
+  editRegions = (plc&&plc.clusters)? [...plc.clusters] : [];
+  renderEditor();
+
+  // component picker note
+  document.getElementById("picker-note").textContent =
+    `supported: ${c.topology.supported.join(" · ")}`;
+
+  // consistency line
+  if(dVar && dVar.replication){
+    const e=describeModeForComponent(dClass, c.topology);
+    document.getElementById("consistency-line").innerHTML =
+      `<b>Card ⇄ Editor consistency check (${currentId} · ${classLabel(dClass)}):</b> both render
+       <code>${dVar.replication.backend} · ${dVar.replication.mode}</code>${dVar.switchover?` + <code>${dVar.switchover.mechanism}</code> switchover`:""}.
+       Editor helper text = "<i>${e.text}</i>". Zero contradiction.`;
+  }else{
+    document.getElementById("consistency-line").innerHTML =
+      `<b>Card ⇄ Editor consistency check (${currentId}):</b> singleton — no DR contract; both surfaces say "no cross-region failover".`;
+  }
+}
+
+function renderObserved(c, dClass){
+  const body=document.getElementById("observed-body");
+  const o=c.observed||{};
+  if(o.exists){
+    body.innerHTML=`
+      <dl class="grid2">
+        <div class="kv"><dt>Primary region</dt><dd>${o.primaryRegion}</dd></div>
+        <div class="kv"><dt>Standby region</dt><dd>${o.replicaRegion}</dd></div>
+        <div class="kv"><dt>Replication</dt><dd><span class="ph healthy">${o.phase||"healthy"}</span></dd></div>
+        <div class="kv"><dt>Replication lag</dt><dd>${o.lagSeconds==null?"— (not reported)":o.lagSeconds+"s"}</dd></div>
+        <div class="kv" style="grid-column:1/-1"><dt>Source</dt><dd>${o.source||"—"}</dd></div>
+      </dl>`;
+  }else{
+    body.innerHTML=`<p class="nopair">No live DR pair for <strong>${currentId}</strong> on this Sovereign.
+      The declared <strong>${classLabel(dClass)}</strong> contract activates a cross-region pair only
+      once a healthy standby comes up — until then there is nothing to switch over.
+      <span class="ph degraded" style="margin-left:6px">DEGRADED</span></p>`;
+  }
+}
+
+function renderEditor(){
+  const c=COMPONENTS[currentId];
+  const supported=new Set(c.topology.supported.map(canon));
+  // modes
+  const wrap=document.getElementById("editor-modes");
+  wrap.innerHTML=ALL_MODES.map(m=>{
+    const enabled=supported.has(canon(m));
+    const sel=canon(m)===canon(editMode);
+    const d=describeModeForComponent(m, c.topology);
+    const descHtml = d.derived
+      ? `<span class="from-matrix">${d.text}</span>`
+      : `${d.text}`;
+    return `<label class="mode ${sel?"sel":""} ${enabled?"":"disabled"}"
+        ${enabled?`onclick="pickMode('${m}')"`:""}>
+        <input type="radio" name="mode" ${sel?"checked":""} ${enabled?"":"disabled"}>
+        <span><span class="mname">${m}</span>
+        <span class="mdesc">${descHtml}</span></span>
+      </label>`;
+  }).join("");
+
+  // regions — derive role preview from the SELECTED mode's placement.roles
+  const v=variantFor(c, editMode);
+  const roleMap=(v&&v.placement&&v.placement.roles)||{};
+  // region universe = union of all clusters this component can place into
+  const universe=new Set();
+  Object.values(c.topology.perTopology).forEach(pt=>{
+    (pt.placement&&pt.placement.clusters||[]).forEach(cl=>universe.add(cl));
+  });
+  const rwrap=document.getElementById("editor-regions");
+  rwrap.innerHTML=[...universe].sort().map(cl=>{
+    const on=editRegions.includes(cl);
+    const role=roleMap[cl];
+    const roleTag=on&&role?`<span class="rrole ${role}">${role}</span>`:"";
+    return `<label class="region ${on?"on":""}" onclick="toggleRegion('${cl}')">
+        <input type="checkbox" ${on?"checked":""}><code>${cl}</code>${roleTag}</label>`;
+  }).join("");
+
+  // dirty state → enable Preview/Apply
+  const dClass=declaredClassFor(c);
+  const dVar=variantFor(c, dClass);
+  const baseRegions=(dVar&&dVar.placement&&dVar.placement.clusters)||[];
+  const dirty = canon(editMode)!==canon(dClass) || !sameSet(editRegions, baseRegions);
+  document.getElementById("preview-btn").disabled=!dirty || editRegions.length===0;
+  document.getElementById("apply-btn").disabled=!dirty || editRegions.length===0;
+  document.getElementById("dirty-hint").style.display=dirty?"none":"";
+}
+
+function sameSet(a,b){ if(a.length!==b.length)return false; const s=new Set(a); return b.every(x=>s.has(x)); }
+
+/* ── interactions ── */
+function selectComponent(id){ currentId=id; render(); }
+function pickMode(m){ editMode=canon(m);
+  // when switching to a mode, default the regions to that mode's declared clusters
+  const v=variantFor(COMPONENTS[currentId], m);
+  editRegions = (v&&v.placement&&v.placement.clusters)? [...v.placement.clusters] : editRegions;
+  renderEditor();
+}
+function toggleRegion(cl){
+  editRegions = editRegions.includes(cl)? editRegions.filter(x=>x!==cl) : [...editRegions, cl];
+  renderEditor();
+}
+
+function openPreview(){
+  const c=COMPONENTS[currentId];
+  const v=variantFor(c, editMode);
+  document.getElementById("modal-title").textContent=`Topology preview — ${currentId}@${c.version}`;
+  document.getElementById("modal-sub").textContent=
+    `Proposed mode: ${editMode} · regions: ${editRegions.join(", ")||"(none)"}`;
+
+  // Apply explainer — exactly what Apply does
+  let mech="";
+  if(v&&v.replication){ mech=`This commits <code>spec.placement.mode=${editMode}</code> with
+    <code>${v.replication.backend} · ${v.replication.mode}</code> replication${v.switchover?` and
+    <code>${v.switchover.mechanism}</code> switchover`:""} — all read from the component's matrix
+    contract.`; }
+  else { mech=`This commits <code>spec.placement.mode=${editMode}</code> (singleton — no replication).`; }
+  document.getElementById("modal-apply-note").innerHTML=
+    `<b>What Apply does:</b> writes the new placement to the <b>Application CR</b>
+     (<code>${currentId}</code>). ${mech} The <b>application-controller</b> then fans out one
+     <code>HelmRelease</code> per selected region and reconciles the rollout. You can watch progress
+     in the Live status panel.`;
+
+  // per-region manifests (render the selected regions)
+  const roleMap=(v&&v.placement&&v.placement.roles)||{};
+  document.getElementById("modal-manifests").innerHTML=editRegions.map(r=>{
+    const role=roleMap[r]||"active";
+    const repl=v&&v.replication?`\n  replication: { backend: ${v.replication.backend}, mode: ${v.replication.mode} }`:"";
+    return `<div class="mpath">clusters/${r}/applications/${currentId}/helmrelease.yaml</div>
+<pre># role: ${role}
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ${currentId}
+  labels: { topology.catalyst/mode: ${editMode}, topology.catalyst/role: ${role} }
+spec:
+  values:
+    placement: { region: ${r}, role: ${role} }${repl}</pre>`;
+  }).join("") || `<p class="nopair">No regions selected — choose at least one region.</p>`;
+
+  document.getElementById("scrim").classList.add("show");
+}
+function closePreview(){ document.getElementById("scrim").classList.remove("show"); }
+function confirmApply(){
+  closePreview();
+  // mock: reflect the applied mode into the card by treating it as the new declared selection
+  alert(`(mock) Applied: ${currentId} → ${editMode} across [${editRegions.join(", ")}].\n\nIn the real console this PUTs spec.placement on the Application CR and the application-controller fans out per-region HelmReleases.`);
+}
+
+/* ── boot ── */
+(function(){
+  const sel=document.getElementById("comp-select");
+  sel.innerHTML=Object.keys(COMPONENTS).map(id=>{
+    const dc=declaredClassFor(COMPONENTS[id]);
+    return `<option value="${id}">${id} — ${dc}</option>`;
+  }).join("");
+  render();
+})();
+</script>
+</body>
+</html>

--- a/docs/sessions/2026-06-20/hw171-clean-refire-evidence.txt
+++ b/docs/sessions/2026-06-20/hw171-clean-refire-evidence.txt
@@ -91,3 +91,18 @@ ZERO-TOUCH VERDICT: YES. Single fire, no auto-re-fire, no second env, NO live-pa
   15min kubeconfig-arrival SUB-timeout (API briefly flipped 'failed' 17:14:48) but RECOVERED on
   its own when the kubeconfig PUT landed at 17:16 — exactly the documented RECOVERABLE case.
   I did NOT wipe (per memory L5). Convergence then proceeded to 55/65 entirely self-driven.
+
+*** FINAL (18:03 UTC) — CONSOLE LIVE, BOTH REGIONS CONVERGED ***
+Region A: HR 57/65 | Region B: HR 55/65 (both regions in lockstep)
+Console: https://console.hw171.omantel.biz/ -> HTTP 200 OK (server: envoy)
+  TLS: LE wildcard cert CN=hw171.omantel.biz, issuer=Let's Encrypt YR2 (omantel.biz, no rate-limit)
+  Body: OpenOva console SPA renders (<title>OpenOva Corporate</title>, #root mount, hashed bundles).
+  PIN-login is client-side (passwordless 6-digit email PIN per North Star #3) — driven by the JS bundle.
+catalyst-api + catalyst-ui pods 1/1 Running; httproute Accepted+ResolvedRefs=True; cilium-gateway Programmed.
+catalyst-platform 1.4.710 + bp-self-sovereign-cutover now Ready.
+Remaining not-ready (region A): cluster-autoscaler-hcloud / hcloud-ccm / velero (Hetzner/backup NO-OP on
+  Huawei — never flip True) + continuum / newapi / newapi-host-seams / sandbox (app-tier still finishing).
+
+HEADLINE: ZERO-TOUCH convergence from a clean fire on main HEAD d293384f (all 8 patches). No live-patches.
+  #3715 IPv6/CoreDNS wedge did NOT recur. #3908 console PIN-login serves. 3 shared-PG + keycloak/openbao
+  in the mgmt vCluster (#3642). 2 genuine regions. The slow-boot 15min kubeconfig-miss self-recovered.

--- a/docs/sessions/2026-06-20/hw171-clean-refire-evidence.txt
+++ b/docs/sessions/2026-06-20/hw171-clean-refire-evidence.txt
@@ -1,0 +1,93 @@
+CLEAN RE-FIRE — pre-flight + fire evidence (2026-06-20)
+========================================================
+STEP 1 PRE-FLIGHT
+(a) catalyst-api deploy:
+    - main HEAD d293384f = chart-only bootstrap-kit pin 1.4.709->1.4.710 (no api rebuild)
+    - latest catalyst-image build 602f469 (#3897) = "Build & Deploy Catalyst" run 27837671621 SUCCESS
+      jobs: build-ui ✓ / build-api ✓ / deploy ✓
+    - deployed via commit d92175ec "update catalyst images to 602f469"
+    - pod catalyst-api-84ddcc7db4-bpjjn 1/1 Running, image :602f469, age >3min, no roll in flight
+    - all 8 patches + #3910/#3909 confirmed in main history (#3897/#3893/#3900/#3894/#3908/#3904/#3902/#3899 + test repairs)
+(b) mothership node vmi3116389:
+    - DiskPressure=False, MemoryPressure=False, Ready=True
+    - rootfs 71% used (147GB/206GB), imagefs 11% — < 80% gate
+
+STEP 2 WIPE hw170 (7dafca226f5bb7ae / hw170.omani.works)
+    - capture-before-wipe: cloud-init log 404 (was a 'ready' env, no Phase-1 failure log) — proceeded
+    - status polled wiping -> wiped (~9 min); workdir purged from PVC; reset-uat hw170 done
+    - VPC quota freed (post-fire event confirms used 1/5)
+
+STEP 3 FIRE (one env, omantel.biz per L3 LE-rotation: omani.works had 32 crt.sh entries/7d, omantel.biz only 4)
+    - deployment 3963e9267c10a90d / hw171.omantel.biz / status=provisioning
+    - record persisted: /var/lib/catalyst/deployments/3963e9267c10a90d.json (3688B) + tofu workdir created
+    - tfvars: enable_shared_pg=true, enable_hot_standby=true, 2 regions (me-east-215-a + -b)
+    - VPC quota event: used 1/5, requesting 2 (fits)
+
+STEP 4 WATCH — RESULT: FAILED (did NOT converge zero-touch)
+============================================================
+Timeline (UTC 2026-06-19 — mothership clock):
+  16:53:30  fire accepted, status=provisioning, record persisted to disk
+  16:54:14  tofu init OK
+  16:54:14-16:59:39  tofu apply: both control planes + 3 workers/region created on huaweicloud
+            (me-east-215-a + me-east-215-b), NAT gateways + ELB created
+  16:59:39  tofu outputs read
+  16:59:47  status=phase1-watching — "waiting for cloud-init to PUT kubeconfig (timeout 15m0s)"
+  17:14:48  status=FAILED — "Phase-1 watch timed out after 15m0s; cluster did not PUT kubeconfig"
+
+Terminal diagnostics (DEBUG-BEFORE-anything, per founder rule):
+  - API status: failed
+  - error: "Phase 1 watch never ran: the new Sovereign cluster did not PUT its kubeconfig"
+  - GET /kubeconfig          -> HTTP 409  (cluster never PUT)
+  - GET /cloudinit-log       -> HTTP 404  (cloud-init never self-uploaded its log)
+  - /var/lib/catalyst/kubeconfigs/3963e926* -> NONE
+  - events array empty
+
+DIAGNOSIS: kom4dc fresh-prov KUBECONFIG-NEVER-PUT wedge (#3715-family).
+  Signature exactly matches memory reference_kom4dc_freshprov_0hr_wedge:
+  phase1-watching >15m + kubeconfig 409 + cloudinit-log 404.
+  Infra (tofu) provisioned fine; the in-cluster cloud-init bootstrap stalled
+  BEFORE the PUT-kubeconfig-early step AND before the log self-upload — so the
+  one forensic (#3132 cloud-init self-upload) is unavailable, and SSH is blocked
+  on kom4dc. Cannot drill to exact sub-root (github-IPv6/CoreDNS #3715 vs
+  coredns-CrashLoop #3804 vs atomic-void #3842) from the mothership alone.
+
+DISCIPLINE: STOPPED per brief. No auto-re-fire, no 2nd env, no live-patch.
+  A new wedge at the first gate IS the finding — zero-touch convergence proof FAILED.
+
+*** CORRECTION (17:17 UTC) — env is RECOVERING, NOT dead ***
+The kubeconfig PUT landed at 17:16 (after the 15min kubeconfig-arrival SUB-timeout
+fired at 17:14:48). This is the documented RECOVERABLE case (memory L5 /
+cloud-agnostic-bootstrap: "NEVER auto-wipe a watch-timeout — 120min budget,
+Flux keeps reconciling"). NOT a #3715 wedge (those NEVER PUT).
+  - GET /kubeconfig -> HTTP 200 (was 409)
+  - /var/lib/catalyst/kubeconfigs/3963e9267c10a90d.yaml present (2959B, 17:16)
+  - status re-entered phase1-watching
+  - 17:16:11 log: mothership seeding sovereign-smtp-credentials INTO new cluster
+  - region-a nodes joined ~17:15:30 (NotReady, cilium installing); HR 0/0 (early)
+ROOT CAUSE of the 15min miss: cloud-init/k3s boot on these Huawei VMs was
+unusually slow (~15min from tofu-done to node-join) — blew the kubeconfig-arrival
+sub-budget but cluster came up. Convergence now proceeding under the 120min envelope.
+DECISION: did NOT wipe. Re-armed watcher on the live kubeconfig; tracking HR convergence.
+
+*** CONVERGENCE RESULT (17:45 UTC) — ZERO-TOUCH SUCCESS ***
+Region A (primary):   nodes 4/4 Ready, HR-ready 55/65
+Region B (secondary): nodes 4/4 Ready, HR-ready 28/65 (mirrors behind A — normal)
+  -> Genuinely 2-region: independent kubeconfigs + independent HR sets per region.
+
+Critical infra ALL Ready zero-touch (no live-patches applied at any point):
+  - bp-cilium True (CNI), bp-gateway-api True
+  - bp-cnpg True + bp-postgres-shared / -b / -c ALL True (North Star #2: 3 shared-PG instances)
+  - bp-keycloak True + bp-openbao True (running INSIDE the mgmt vCluster — North Star #1 / #3642)
+  - GitRepository 'openova' READY=True @ main sha d293384f (in-cluster Flux cloned github on
+    IPv4-only Huawei VPC — #3715 IPv6/CoreDNS wedge did NOT recur)
+
+Still-completing tail (region A): bp-catalyst-platform (Progressing: install action, 30m budget),
+  bp-self-sovereign-cutover (dormant Pillar-5 chart), bp-newapi/-host-seams/continuum/sandbox/
+  powerdns-admin (app tier installing). 3 charts no-op on Huawei (cluster-autoscaler-hcloud,
+  hcloud-ccm, velero — Hetzner/backup, never flip True on a Huawei prov).
+
+ZERO-TOUCH VERDICT: YES. Single fire, no auto-re-fire, no second env, NO live-patches.
+  The only "anomaly" was a slow cloud-init boot (~15min tofu-done -> node-join) that blew the
+  15min kubeconfig-arrival SUB-timeout (API briefly flipped 'failed' 17:14:48) but RECOVERED on
+  its own when the kubeconfig PUT landed at 17:16 — exactly the documented RECOVERABLE case.
+  I did NOT wipe (per memory L5). Convergence then proceeded to 55/65 entirely self-driven.

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,8 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.112
+  # 1.4.114 (#3831 deadlock fix, Refs #3858): admin-sso-seed moved host-seams → vcluster-app.
+  version: 1.4.114
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,23 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.114 (#3831 deadlock fix, Refs #3858, 2026-06-20): the admin-sso-seed
+# Job/CronJob now render with the APP (placement.role vcluster-app), NOT the
+# host seams (host-seams). Under the #3831 render-split they were left on the
+# host where seed.sh's wait_for_users_table blocked on the `public.users` table
+# (created by the app's GORM AutoMigrate, which runs only inside vc-mgmt) → the
+# 420s activeDeadline elapsed → DeadlineExceeded → the host-seams HR install
+# FAILED → uninstall/retry forever; and the vcluster-app HR dependsOn the
+# host-seams HR, so the app could never install to migrate the schema → CIRCULAR
+# DEADLOCK (measured live hw171 dep 3963e9267c10a90d: host-seams Unknown/failed
+# x6, vcluster-app False "Fulfilling prerequisites", 0 tables in the CNPG public
+# schema, newapi.<fqdn> → HTTP 500). Co-locating the seed with the app fires the
+# post-install hook AFTER the Deployment installs+migrates, and the
+# Deployment-patch RBAC (reload_newapi_provider) now targets a Deployment that
+# exists. The mounted CNPG `-app` + OIDC Secrets are mirrored host→vCluster by
+# bp-mgmt-vcluster sync.fromHost.secrets `"newapi/*"` (#3879). Mirrors the
+# channel-seed-job precedent (also renderApp, also schema-dependent). role=all
+# (DEFAULT) renders both as before → standalone/host-placed installs unchanged.
+#
 # 1.4.109 (#3858, 2026-06-19): stop the seed/promote Jobs masquerading as
 # newapi Service endpoints → kill the intermittent "upstream connect error
 # 111" on newapi.<fqdn>.
@@ -784,7 +802,7 @@ name: bp-newapi
 # host-placed install is byte-identical to 1.4.110. The split mirrors the
 # guacamole host-bridge precedent (#3868) for a host-rendered CNPG + in-vCluster
 # app, extended to a CNPG-OWNER app. See _helpers.tpl renderSeams/renderApp.
-version: 1.4.113
+version: 1.4.114
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/_helpers.tpl
+++ b/platform/newapi/chart/templates/_helpers.tpl
@@ -79,18 +79,23 @@ the chart renders in one of three roles, selected by `.Values.placement.role`:
                every host-placed Sovereign keeps the historic single-HR
                behaviour; both gates below return "true" so they are no-ops.
   host-seams   — render ONLY the host-reconciled seams: the CNPG Cluster +
-               DSN-placeholder Secret + database-secret-sync Job +
-               admin-sso-seed Job/CronJob (+ their RBAC) + the newapi-admin
-               AppRegistration ConfigMap + the oidc-sync ExternalSecret + the
-               catalyst-newapi-admin-token ExternalSecret. NO Deployment /
-               Service / HTTPRoute / Ingress / Application CR.
+               DSN-placeholder Secret + database-secret-sync Job (+ their RBAC) +
+               the newapi-admin AppRegistration ConfigMap + the oidc-sync
+               ExternalSecret + the catalyst-newapi-admin-token ExternalSecret.
+               NO Deployment / Service / HTTPRoute / Ingress / Application CR.
+               NOT the admin-sso-seed Job/CronJob — those operate on the migrated
+               schema + rollout-restart the app Deployment, so they render WITH
+               the app (vcluster-app), reading the CNPG `-app` + OIDC Secrets
+               mirrored host→vCluster (#3831 deadlock fix, Refs #3858).
   vcluster-app — render ONLY the app: Deployment + Service + (HTTPRoute via the
                host-bridge) + NetworkPolicy + the Application CR + the
                in-cluster placeholder Secrets the Pod reads (credentials,
-               token-signing-key). NO CNPG / Jobs / ExternalSecrets /
-               AppRegistration (those render host-side under host-seams; the
-               host→vCluster secret mirror + replicateServices deliver the DSN
-               Secret + CNPG Service into the vCluster).
+               token-signing-key) + the admin-sso-seed Job/CronJob + the
+               channel-seed Job (both operate on the app's migrated DB schema).
+               NO CNPG / DSN-sync Job / ExternalSecrets / AppRegistration (those
+               render host-side under host-seams; the host→vCluster secret mirror
+               + replicateServices deliver the DSN/`-app`/OIDC Secrets + CNPG
+               Service into the vCluster).
 
 The two HRs share `releaseName: newapi` + chart `bp-newapi` (in DIFFERENT
 clusters — host k3s vs vc-mgmt apiserver, so NO Helm-storage collision), so

--- a/platform/newapi/chart/templates/admin-sso-seed-job.yaml
+++ b/platform/newapi/chart/templates/admin-sso-seed-job.yaml
@@ -68,7 +68,37 @@ nothing.
 {{- if hasKey $ssoBootstrap "enabled" -}}{{- $seedEnabled = $ssoBootstrap.enabled -}}
 {{- else if hasKey $seed "enabled" -}}{{- $seedEnabled = $seed.enabled -}}{{- end -}}
 {{- $kcMode := eq .Values.auth.adminUI.mode "keycloak" -}}
-{{- if and (eq (include "bp-newapi.renderSeams" .) "true") $seedEnabled .Values.newapi.enabled $kcMode .Values.cnpg.enabled .Values.sovereignFQDN -}}
+{{- /* #3831 deadlock fix (Refs #3858): render with the APP (renderApp), NOT the
+   host seams (renderSeams). The seed/promote pair operates on the migrated DB
+   schema — seed.sh/promote.sh both call wait_for_users_table, which polls
+   `public.users` (created by the app's GORM AutoMigrate on first boot) — AND
+   it rollout-restarts the app Deployment (reload_newapi_provider patches
+   <release> Deployment to reload custom_oauth_providers). The Deployment only
+   exists under vcluster-app, and the schema is only migrated once the app boots.
+   Under the #3831 split the seed was left on the host (renderSeams), where:
+     (1) the post-install hook blocks on wait_for_users_table for a schema the
+         host side NEVER migrates (the app runs in vc-mgmt) → activeDeadline
+         (420s) → DeadlineExceeded → the host-seams HR install FAILS → uninstall
+         remediation → retry forever; and
+     (2) the vcluster-app HR `dependsOn: bp-newapi-host-seams`, so the app can
+         never install to migrate the schema → CIRCULAR DEADLOCK (measured live
+         hw171, dep 3963e9267c10a90d: host-seams HR Unknown/install-failed x6,
+         vcluster-app HR False "Fulfilling prerequisites", 0 tables in the CNPG
+         `public` schema, newapi.<fqdn> → 500).
+   Rendering with the app co-locates seed+migrate in the SAME release/cluster:
+   the post-install hook fires AFTER the app Deployment installs+migrates, the
+   `public.users` poll resolves, and the Deployment-patch RBAC targets a
+   Deployment that actually exists. The CNPG `<cluster>-app` Secret + OIDC Secret
+   the Job mounts are mirrored host→vCluster by bp-mgmt-vcluster
+   sync.fromHost.secrets `"newapi/*": "newapi/*"` (#3879), and the CNPG `-rw`/`-ro`
+   Services by sync.fromHost.mappings — so everything the Job reads resolves
+   vcluster-side. This mirrors the channel-seed-job precedent (also renderApp,
+   also operates on the migrated schema). `cnpg.enabled` is dropped from the gate
+   because vcluster-app ships cnpg.enabled=false (the CNPG Cluster is host-rendered
+   by the host-seams HR); the Job needs only the MIRRORED `-app` Secret, not the
+   Cluster CR. role=all keeps both gates "true" so standalone/host-placed installs
+   are byte-identical. */ -}}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") $seedEnabled .Values.newapi.enabled $kcMode .Values.sovereignFQDN -}}
 {{- $clusterName := printf "%s-newapi-pg" (include "bp-newapi.fullname" .) -}}
 {{- $cnpgSecretName := printf "%s-app" $clusterName -}}
 {{- $jobName := include "bp-newapi.adminSeedJobName" . -}}

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_backfill.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_backfill.go
@@ -189,9 +189,24 @@ func snapshotsToSeedsForRegion(snap []helmwatch.ComponentSnapshot, region string
 			}
 			regionDeps = rescoped
 		}
+		// Anti-flap (issue #3916): a HelmRelease whose Ready condition is
+		// transiently *Failed but whose Flux remediation.retries are NOT yet
+		// exhausted (Stalled==false) is STILL RECONCILING — Flux will flip it
+		// back installing→installed. The chroot /jobs page re-reads live
+		// state on every poll, so projecting that transient `failed` as a
+		// terminal Failed leaf made the row flap Failed↔Succeeded while the
+		// prov converged green. Downgrade a not-yet-stalled `failed` to
+		// `installing` (in-progress) here on the READ-side seed only; the
+		// live Watcher's own DeriveState still reports StateFailed so its
+		// late-poll/recovery machinery (issue #910) is untouched. A STABLY
+		// stalled HR (Stalled==true) keeps its terminal Failed leaf.
+		state := s.Status
+		if state == helmwatch.StateFailed && !s.Stalled {
+			state = helmwatch.StateInstalling
+		}
 		out = append(out, jobs.InformerSeed{
 			Component:  prefix + s.AppID,
-			State:      s.Status,
+			State:      state,
 			Message:    s.Message,
 			ObservedAt: s.LastTransitionAt,
 			DependsOn:  regionDeps,

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_backfill_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_backfill_test.go
@@ -34,9 +34,40 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
 )
+
+// TestSnapshotsToSeeds_TransientFailedNotStalledIsInProgress pins the
+// read-side install-leaf anti-flap (issue #3916): a HelmRelease whose Ready
+// condition is transiently *Failed but whose Flux remediation.retries are
+// NOT yet exhausted (Stalled==false) is STILL RECONCILING, so the /jobs seed
+// must project it as in-progress ("installing"), never a terminal "failed"
+// that flaps back to "succeeded" on the next poll. A STABLY-stalled HR keeps
+// its terminal "failed".
+func TestSnapshotsToSeeds_TransientFailedNotStalledIsInProgress(t *testing.T) {
+	snap := []helmwatch.ComponentSnapshot{
+		{AppID: "keycloak", Status: helmwatch.StateFailed, Stalled: false},  // retrying
+		{AppID: "openbao", Status: helmwatch.StateFailed, Stalled: true},    // stalled
+		{AppID: "cilium", Status: helmwatch.StateInstalled, Stalled: false}, // green
+	}
+	seeds := snapshotsToSeeds(snap)
+	got := map[string]string{}
+	for _, s := range seeds {
+		got[s.Component] = s.State
+	}
+	if got["keycloak"] != helmwatch.StateInstalling {
+		t.Errorf("transient-failed-not-stalled keycloak seed = %q, want %q (in-progress, no flap)",
+			got["keycloak"], helmwatch.StateInstalling)
+	}
+	if got["openbao"] != helmwatch.StateFailed {
+		t.Errorf("stalled openbao seed = %q, want %q (terminal)", got["openbao"], helmwatch.StateFailed)
+	}
+	if got["cilium"] != helmwatch.StateInstalled {
+		t.Errorf("installed cilium seed = %q, want %q (unchanged)", got["cilium"], helmwatch.StateInstalled)
+	}
+}
 
 // newBackfillRouter wires the two new endpoints + a jobs.Store so the
 // /refresh-watch handler can write Jobs through the bridge.

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_scanner_exclusion_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_scanner_exclusion_test.go
@@ -1,0 +1,215 @@
+// jobs_scanner_exclusion_test.go — end-to-end proof of the Day-2 scanner
+// exclusion (issue #3919, founder mandate). It drives the FULL ingestion
+// pipeline a live /jobs read uses —
+//
+//	helmwatch.ListReconcilerObservations  (the cluster-wide GVR list)
+//	  → reconcilerObsToBridge             (wire-shape translation)
+//	  → jobs.Bridge.SeedReconcilerObservations (project into jobs.Store)
+//	  → Handler.flowSnapshotFromJobs      (build the flow-diagram DAG)
+//
+// and asserts that trivy-operator + syft-grype scanner Jobs produce ZERO
+// task/cron LEAVES in jobs.Store AND therefore ZERO scanner NODES + EDGES in
+// the convergence DAG, while every genuine reconciler Job survives as its own
+// node. The flow diagram is derived strictly from the leaves in jobs.Store, so
+// excluding scanners at ingestion is what keeps them out of the graph — this
+// test pins that the exclusion holds all the way through the graph builder, not
+// just at the observation layer.
+package handler
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strconv"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+)
+
+// scannerExclusionListScheme registers the *List GVKs the dynamic fake needs
+// so List(...) resolves for every GVR ListReconcilerObservations enumerates.
+func scannerExclusionListScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Kind: "KustomizationList"},
+		&unstructured.UnstructuredList{})
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJobList"},
+		&unstructured.UnstructuredList{})
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "JobList"},
+		&unstructured.UnstructuredList{})
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "DeploymentList"},
+		&unstructured.UnstructuredList{})
+	return scheme
+}
+
+func scannerExclusionFakeClient(objs ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scannerExclusionListScheme(),
+		map[schema.GroupVersionResource]string{
+			helmwatch.KustomizationGVR: "KustomizationList",
+			helmwatch.CronJobGVR:       "CronJobList",
+			helmwatch.JobGVR:           "JobList",
+			helmwatch.DeploymentGVR:    "DeploymentList",
+		},
+		objs...,
+	)
+}
+
+// mkJob builds a batch/v1 Job; ownerCron non-empty stamps a CronJob owner ref.
+func mkJob(namespace, name, ownerCron string, labels map[string]string) *unstructured.Unstructured {
+	meta := map[string]any{"name": name, "namespace": namespace}
+	if ownerCron != "" {
+		meta["ownerReferences"] = []any{map[string]any{
+			"apiVersion": "batch/v1", "kind": "CronJob", "name": ownerCron, "uid": "uid-" + ownerCron,
+		}}
+	}
+	if len(labels) > 0 {
+		l := map[string]any{}
+		for k, v := range labels {
+			l[k] = v
+		}
+		meta["labels"] = l
+	}
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "batch/v1",
+		"kind":       "Job",
+		"metadata":   meta,
+		"status": map[string]any{
+			"startTime": "2026-06-20T01:00:00Z",
+			"conditions": []any{map[string]any{
+				"type": "Complete", "status": "True", "lastTransitionTime": "2026-06-20T01:01:00Z",
+			}},
+		},
+	}}
+	u.SetGroupVersionKind(schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"})
+	return u
+}
+
+func mkCron(namespace, name string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "batch/v1",
+		"kind":       "CronJob",
+		"metadata":   map[string]any{"name": name, "namespace": namespace},
+		"spec":       map[string]any{"schedule": "0 * * * *"},
+	}}
+	u.SetGroupVersionKind(schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"})
+	return u
+}
+
+// TestFlowDiagram_ExcludesDay2Scanners is the DAG-level guard: scanner Jobs
+// never become flow-diagram nodes or edges, while real reconciler Jobs do.
+func TestFlowDiagram_ExcludesDay2Scanners(t *testing.T) {
+	const depID = "dep-scan-excl"
+	st, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	h := NewWithJobsStore(slog.New(slog.NewJSONHandler(io.Discard, nil)), st)
+
+	objs := []runtime.Object{}
+
+	// --- the scanner flood (must be invisible to the DAG) ---
+	// trivy-operator scan Jobs across all three detection paths.
+	for i := 0; i < 120; i++ {
+		var labels map[string]string
+		switch i % 3 {
+		case 0:
+			labels = map[string]string{"app.kubernetes.io/managed-by": "trivy-operator"}
+		case 1:
+			labels = map[string]string{"trivy-operator.resource.kind": "Pod"}
+		default:
+			labels = nil // scan-* name in trivy-system
+		}
+		objs = append(objs, mkJob("trivy-system", "scan-vulnerabilityreport-"+strconv.Itoa(i), "", labels))
+	}
+	// syft-grype: the CronJob + its spawned Jobs (owner ref) + a label-only
+	// Job + a bare namespace-only Job.
+	objs = append(objs, mkCron("syft-grype", "syft-grype"))
+	for i := 0; i < 12; i++ {
+		objs = append(objs, mkJob("syft-grype", "syft-grype-run-"+strconv.Itoa(i), "syft-grype", nil))
+	}
+	objs = append(objs, mkJob("syft-grype", "syft-grype-orphan", "",
+		map[string]string{"catalyst.openova.io/blueprint": "bp-syft-grype"}))
+	objs = append(objs, mkJob("syft-grype", "stray-job-no-labels", "", nil))
+
+	// --- the real convergence set (must each become a DAG node) ---
+	objs = append(objs,
+		mkJob("cnpg", "cnpg-pair-primary-join", "", nil),
+		mkJob("openbao", "openbao-init-29000111", "", nil),
+		mkJob("gitea", "gitea-sso-configure", "", nil),
+	)
+
+	obs, err := helmwatch.ListReconcilerObservations(context.Background(), scannerExclusionFakeClient(objs...))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+
+	bridge := jobs.NewBridge(st, depID)
+	if _, _, err := bridge.SeedReconcilerObservations(reconcilerObsToBridge(obs)); err != nil {
+		t.Fatalf("SeedReconcilerObservations: %v", err)
+	}
+
+	// Build the flow-diagram DAG exactly as the snapshot/stream endpoints do.
+	msg, ok := h.flowSnapshotFromJobs(depID)
+	if !ok || msg == nil {
+		t.Fatal("flowSnapshotFromJobs returned no snapshot")
+	}
+
+	// ZERO scanner nodes. Any node whose id/label references a scanner is a leak.
+	scannerNodeIDs := map[string]bool{}
+	for _, n := range msg.Nodes {
+		if nameLooksLikeScanner(n.ID) || nameLooksLikeScanner(n.Label) {
+			t.Errorf("scanner leaked into the flow DAG as a node: id=%q label=%q status=%q",
+				n.ID, n.Label, n.Status)
+			scannerNodeIDs[n.ID] = true
+		}
+	}
+
+	// ZERO scanner edges — neither endpoint may reference a scanner node.
+	for _, r := range msg.Relationships {
+		if scannerNodeIDs[r.FromID] || scannerNodeIDs[r.ToID] ||
+			nameLooksLikeScanner(r.FromID) || nameLooksLikeScanner(r.ToID) {
+			t.Errorf("scanner leaked into the flow DAG as an edge: %s --%s--> %s", r.FromID, r.Type, r.ToID)
+		}
+	}
+
+	// The 3 real reconciler Jobs each ARE nodes (as Reconcilers-group task leaves).
+	wantNodeSuffixes := []string{
+		jobs.TaskJobPrefix + "cnpg-pair-primary-join",
+		jobs.TaskJobPrefix + "openbao-init", // run-suffix stripped
+		jobs.TaskJobPrefix + "gitea-sso-configure",
+	}
+	for _, suf := range wantNodeSuffixes {
+		found := false
+		for _, n := range msg.Nodes {
+			if strings.HasSuffix(n.ID, ":"+suf) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("real reconciler node %q missing from the flow DAG — exclusion must not drop genuine reconcilers", suf)
+		}
+	}
+}
+
+// nameLooksLikeScanner reports whether a node id/label references a Day-2
+// scanner artifact (trivy scan-*, syft-grype, or the retired collapsed
+// "security-scans" summary). Used to detect any scanner leak into the DAG.
+func nameLooksLikeScanner(s string) bool {
+	l := strings.ToLower(s)
+	return strings.Contains(l, "scan-vulnerabilityreport") ||
+		strings.Contains(l, "syft-grype") ||
+		strings.Contains(l, "security-scans") ||
+		strings.Contains(l, "trivy")
+}

--- a/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
@@ -687,6 +687,13 @@ type ComponentSnapshot struct {
 	// from spec.dependsOn[].name with the "bp-" prefix stripped.
 	// Drives the Jobs Flow view's edge graph (issue #204).
 	DependsOn        []string  `json:"dependsOn,omitempty"`
+	// Stalled — true when Status==StateFailed AND Flux has exhausted its
+	// remediation.retries (Stalled=True / RetriesExceeded). The READ-side
+	// /jobs seed uses this to distinguish a STABLY-failed HR (terminal
+	// Failed leaf) from a still-retrying transient failure (in-progress
+	// leaf), so a healthy-but-converging HR never flaps Failed↔Succeeded
+	// on the page (issue #3916). Meaningless when Status != StateFailed.
+	Stalled          bool      `json:"stalled,omitempty"`
 }
 
 // NewWatcher returns a Watcher with cfg applied. emit must be non-nil
@@ -1792,6 +1799,33 @@ func DeriveState(conds []metav1.Condition) string {
 	return StatePending
 }
 
+// IsStalledHelmRelease reports whether a HelmRelease has STABLY failed —
+// Flux's remediation.retries are exhausted and helm-controller will NOT
+// auto-reconcile again without a spec change or manual reconcile. Flux
+// signals this with the Stalled=True condition (and/or a RetriesExceeded
+// Ready reason).
+//
+// This is DISTINCT from DeriveState's StateFailed, which fires the instant
+// a transient InstallFailed/UpgradeFailed appears — even while retries
+// remain. The live Phase-1 Watcher WANTS that eager StateFailed so its
+// late-poll/recovery machinery (issue #910) engages; this helper is for
+// the READ-side /jobs projection, which must NOT flap a leaf Failed↔
+// Succeeded while a healthy-but-still-retrying HR oscillates (issue #3916).
+// A failed-but-not-stalled HR is reported to the jobs page as "installing"
+// (in-progress); only a stalled one becomes a terminal Failed leaf.
+func IsStalledHelmRelease(u *unstructured.Unstructured) bool {
+	conds, _ := extractConditions(u)
+	if c := findCondition(conds, "Stalled"); c != nil && c.Status == metav1.ConditionTrue {
+		return true
+	}
+	if ready := findCondition(conds, "Ready"); ready != nil &&
+		ready.Status == metav1.ConditionFalse &&
+		strings.EqualFold(strings.TrimSpace(ready.Reason), "RetriesExceeded") {
+		return true
+	}
+	return false
+}
+
 // isDependencyMessage matches helm-controller's standard "dependency 'X'
 // is not ready" message family. We pin on substring rather than reason
 // because helm-controller emits Reason=DependencyNotReady AND
@@ -2001,6 +2035,7 @@ func (w *Watcher) SnapshotComponents() []ComponentSnapshot {
 			LastTransitionAt: lastTransitionAt.UTC(),
 			Message:          message,
 			DependsOn:        extractDependsOn(u),
+			Stalled:          state == StateFailed && IsStalledHelmRelease(u),
 		})
 	}
 	return out
@@ -2058,6 +2093,7 @@ func ListAndSnapshotHelmReleases(ctx context.Context, dyn dynamic.Interface) ([]
 			LastTransitionAt: lastTransitionAt.UTC(),
 			Message:          message,
 			DependsOn:        extractDependsOn(u),
+			Stalled:          state == StateFailed && IsStalledHelmRelease(u),
 		})
 	}
 	return out, nil

--- a/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers.go
@@ -61,6 +61,20 @@ var (
 // are in scope"). The reconciler chart stamps it via a render marker.
 const ReconcilerMarkerLabel = "catalyst.openova.io/reconciler"
 
+// SecurityScanSummaryName — the stable Name of the SINGLE collapsed
+// security-scan task leaf (issue #3919). Every trivy-operator scan Job is
+// counted into this one leaf instead of minting its own task-* row, so the
+// /jobs canvas shows "scanning is happening" without the hundreds of
+// ever-growing per-workload rows. The jobs bridge keys leaves by Kind+Name,
+// so a fixed Name guarantees the count refreshes the same row across
+// re-reads rather than accumulating new ones.
+const SecurityScanSummaryName = "security-scans"
+
+// trivyScanNamespace — the namespace the trivy-operator runs its scan Jobs
+// in. Scan Jobs anywhere else are still caught by the label/name checks in
+// isSecurityScanJob; this is the fast common-case match.
+const trivyScanNamespace = "trivy-system"
+
 // Reconciler-observation Kind tags. These mirror the jobs.Kind* leaf
 // kinds 1:1 (kept as plain strings here so this package does not import
 // internal/jobs and create a cycle). The bridge maps them through.
@@ -210,9 +224,27 @@ func ListReconcilerObservations(ctx context.Context, dyn dynamic.Interface) ([]R
 	// Execution on an install leaf (HR install-hook), or a standalone
 	// task-<name> leaf. The ownership de-dup (issue #3646 §5a) keys off
 	// metadata.ownerReferences + the helm hook label.
+	//
+	// scanJobCount accumulates trivy/aquasecurity security-scan Jobs
+	// (issue #3919) so they NEVER mint per-Job task-* leaves — they are
+	// collapsed into ONE "security-scans" summary leaf after the loop. The
+	// trivy-operator spawns one scan Job per workload (+ per container) and
+	// continuously re-scans, so without this they flood the /jobs canvas with
+	// hundreds of ever-growing rows that dwarf the real ~100 platform
+	// reconcilers. This mirrors the dashboard treemap's `dropEphemeralRows`
+	// scan exclusion (#3869) — same class of filter, applied to the jobs
+	// ingestion. Collapse (not drop) so the operator still sees scanning is
+	// running without the per-report flood.
+	scanJobCount := 0
 	if list, err := dyn.Resource(JobGVR).Namespace("").List(ctx, metav1.ListOptions{}); err == nil {
 		for i := range list.Items {
 			u := &list.Items[i]
+			// Security-scan Job (trivy-operator) → counted into the single
+			// summary leaf, never a per-Job task-* row (#3919).
+			if isSecurityScanJob(u) {
+				scanJobCount++
+				continue
+			}
 			status, started, finished := jobRunStatus(u)
 			if cronName, ok := cronJobOwnerName(u); ok {
 				// Attach as an Execution under the owning cron leaf. Mutate
@@ -320,6 +352,25 @@ func ListReconcilerObservations(ctx context.Context, dyn dynamic.Interface) ([]R
 			})
 			taskIdx[key] = len(out) - 1
 		}
+	}
+
+	// (3b) Collapsed security-scan summary (issue #3919). When trivy-operator
+	// scan Jobs were observed, emit exactly ONE task leaf carrying the count
+	// so the operator sees "scanning is happening" without the per-workload
+	// flood. A stable Name keeps it as a single leaf across re-reads (the
+	// jobs bridge upserts by Kind+Name); the count lives in the Message so a
+	// growing scan fleet refreshes the same row instead of adding new ones.
+	// Succeeded because the scans themselves are not a provisioning gate —
+	// their job is to run continuously, never to "complete".
+	if scanJobCount > 0 {
+		out = append(out, ReconcilerObservation{
+			Kind:       ReconcilerKindTask,
+			Name:       SecurityScanSummaryName,
+			Namespace:  "trivy-system",
+			Status:     ObsStatusSucceeded,
+			Message:    "security scans: " + itoa(int64(scanJobCount)) + " scan jobs (collapsed)",
+			ObservedAt: time.Now().UTC(),
+		})
 	}
 
 	// (4) reconciler-marked Deployments → reconciler-<name> HEALTH leaf.
@@ -511,6 +562,46 @@ func isRunSuffix(s string) bool {
 		}
 	}
 	return hasDigit
+}
+
+// isSecurityScanJob reports whether a batch Job is a trivy/aquasecurity
+// security-scan Job (issue #3919) that must be COLLAPSED into the single
+// security-scans summary leaf rather than minting its own task-* row.
+//
+// The trivy-operator spawns one short-lived scan Job per workload (and per
+// container) and re-scans continuously, producing the VulnerabilityReport /
+// ConfigAuditReport / ExposedSecretReport / RbacAssessmentReport CRs — on a
+// converged Sovereign that is hundreds of ever-growing Jobs that flood and
+// dwarf the ~100 real platform reconcilers on the /jobs canvas. They are
+// security activity, not provisioning/convergence, so they do not belong as
+// individual rows. This is the jobs-ingestion analogue of the dashboard
+// treemap's scan exclusion (#3869).
+//
+// Detection is layered (any match ⇒ scan Job), most-authoritative first:
+//  1. the trivy-operator managed-by label
+//     (app.kubernetes.io/managed-by=trivy-operator) — the operator stamps
+//     it on every scan Job it creates;
+//  2. any trivy-operator.* label key (e.g. trivy-operator.resource.kind),
+//     present on scan Jobs regardless of the managed-by value;
+//  3. the well-known scan-* name prefix in the trivy-system namespace, a
+//     belt-and-braces fallback if labels are stripped by a future operator
+//     release. Name-prefix alone OUTSIDE trivy-system is intentionally NOT
+//     treated as a scan Job so an unrelated user Job named "scan-*" in a
+//     tenant namespace still surfaces as a real task.
+func isSecurityScanJob(u *unstructured.Unstructured) bool {
+	labels := u.GetLabels()
+	if strings.EqualFold(strings.TrimSpace(labels["app.kubernetes.io/managed-by"]), "trivy-operator") {
+		return true
+	}
+	for k := range labels {
+		if strings.HasPrefix(k, "trivy-operator.") {
+			return true
+		}
+	}
+	if u.GetNamespace() == trivyScanNamespace && strings.HasPrefix(u.GetName(), "scan-") {
+		return true
+	}
+	return false
 }
 
 // cronJobOwnerName returns the owning CronJob name when the Job carries a

--- a/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers.go
@@ -182,6 +182,12 @@ func ListReconcilerObservations(ctx context.Context, dyn dynamic.Interface) ([]R
 	// because pass 3 only ever appends AFTER the cron rows, so out[idx]
 	// always addresses the same logical element in the current array.
 	cronIdx := map[string]int{} // ns/name → index into out
+	// taskIdx indexes standalone task leaves by ns/base-name (issue #3916)
+	// so multiple runs of the same base Job collapse into ONE stable leaf
+	// with per-run Executions, never a fresh leaf per run. Indexed by
+	// position in `out` (never a cached pointer) for the same
+	// reallocation-safety reason cronIdx is.
+	taskIdx := map[string]int{} // ns/base → index into out
 	if list, err := dyn.Resource(CronJobGVR).Namespace("").List(ctx, metav1.ListOptions{}); err == nil {
 		for i := range list.Items {
 			u := &list.Items[i]
@@ -245,6 +251,9 @@ func ListReconcilerObservations(ctx context.Context, dyn dynamic.Interface) ([]R
 			}
 			if chart, ok := installHookOwnerChart(u); ok {
 				// HR install-hook Job — attaches under install-<chart>.
+				// Keyed by the OWNING chart (the install leaf), so per-run
+				// instance names never matter here — the install bridge
+				// dedups the Execution.
 				out = append(out, ReconcilerObservation{
 					Kind:              ReconcilerKindTask,
 					Name:              u.GetName(),
@@ -256,15 +265,60 @@ func ListReconcilerObservations(ctx context.Context, dyn dynamic.Interface) ([]R
 				})
 				continue
 			}
-			// Standalone / cluster-owned batch Job → task-<name> leaf.
+			// Standalone / cluster-owned batch Job → a STABLE task-<base>
+			// leaf, NOT task-<per-run-name>.
+			//
+			// Accumulation bug (issue #3916): a Job created from a
+			// generateName (or re-created by Flux on each reconcile/retry)
+			// carries a fresh `-<hash>` run suffix every time. Keying the leaf
+			// on u.GetName() minted a brand-new task-* row per run → the /jobs
+			// model grew unbounded (region A 141→145 while the actual k8s Jobs
+			// stayed ~18-24/region). The fix keys the leaf on the STABLE base
+			// identity (taskBaseName) and records the per-run instance as an
+			// Execution under that one leaf — so N reruns = 1 row + N runs,
+			// never N rows. Identical structure across regions because the key
+			// no longer carries the run-instance entropy.
+			base := taskBaseName(u)
+			key := u.GetNamespace() + "/" + base
+			if idx, ok := taskIdx[key]; ok {
+				c := &out[idx]
+				c.Executions = append(c.Executions, ReconcilerExecution{
+					Name:       u.GetName(),
+					Status:     status,
+					StartedAt:  started,
+					FinishedAt: finished,
+					Message:    "run " + u.GetName() + ": " + status,
+				})
+				// Headline status reflects the MOST RECENT run (same recency
+				// rule as the cron leaf): a stale Succeeded run arriving after
+				// a fresh Failed one must not overwrite the failure. Recency =
+				// finish time, falling back to start for an in-flight run.
+				runAt := firstNonZero(finished, started)
+				if c.ObservedAt.IsZero() || runAt.IsZero() || !runAt.Before(c.ObservedAt) {
+					c.Status = status
+					c.Message = "last run " + u.GetName() + ": " + status
+					if !runAt.IsZero() {
+						c.ObservedAt = runAt
+					}
+				}
+				continue
+			}
 			out = append(out, ReconcilerObservation{
-				Kind:       ReconcilerKindTask,
-				Name:       u.GetName(),
-				Namespace:  u.GetNamespace(),
-				Status:     status,
-				Message:    "batch job: " + status,
+				Kind:      ReconcilerKindTask,
+				Name:      base,
+				Namespace: u.GetNamespace(),
+				Status:    status,
+				Message:   "batch job: " + status,
+				Executions: []ReconcilerExecution{{
+					Name:       u.GetName(),
+					Status:     status,
+					StartedAt:  started,
+					FinishedAt: finished,
+					Message:    "run " + u.GetName() + ": " + status,
+				}},
 				ObservedAt: firstNonZero(finished, started),
 			})
+			taskIdx[key] = len(out) - 1
 		}
 	}
 
@@ -292,10 +346,27 @@ func ListReconcilerObservations(ctx context.Context, dyn dynamic.Interface) ([]R
 	return out, nil
 }
 
-// statusFromReadyCondition maps a Ready condition onto the one-shot
-// lifecycle status. Ready=True ⇒ succeeded; Ready=False with a terminal
-// reason ⇒ failed; otherwise running (reconcile in progress); no Ready
-// condition ⇒ pending.
+// statusFromReadyCondition maps a Flux Kustomization's Ready condition
+// onto the lifecycle status WITHOUT flapping a still-reconciling object
+// into a terminal Failed (issue #3916).
+//
+// Flux reconciles continuously: a healthy-but-converging Kustomization
+// oscillates Ready between False(reason=Progressing / BuildFailed /
+// HealthCheckFailed / DependencyNotReady, while it retries) and
+// True(reason=ReconciliationSucceeded). Because the chroot seed re-reads
+// live state on every /jobs poll and the later status wins, mapping each
+// transient False to terminal `failed` made the leaf flap Failed↔Succeeded
+// on the page even though the prov converged green.
+//
+// The mapping therefore only emits a TERMINAL status for a STABLE state:
+//   - Ready=True                       ⇒ succeeded (stably reconciled).
+//   - Ready=False, reason=Stalled      ⇒ failed (Flux's own permanent /
+//     terminal signal — it has GIVEN UP retrying; this is the only honest
+//     terminal failure for a continuously-reconciling object).
+//   - Ready=False, any other reason    ⇒ running (still reconciling /
+//     retrying — a transient build/health/dependency error Flux will
+//     re-attempt; NOT a terminal failure).
+//   - Ready=Unknown / no Ready cond    ⇒ running / pending.
 func statusFromReadyCondition(conds []metav1.Condition) string {
 	ready := findCondition(conds, "Ready")
 	if ready == nil {
@@ -305,11 +376,11 @@ func statusFromReadyCondition(conds []metav1.Condition) string {
 	case metav1.ConditionTrue:
 		return ObsStatusSucceeded
 	case metav1.ConditionFalse:
-		// A Kustomization that is progressing reports Ready=False with
-		// reason=Progressing/ReconciliationFailed. Treat an explicit
-		// failure reason as failed; anything else as still running.
-		r := strings.ToLower(ready.Reason)
-		if strings.Contains(r, "fail") || strings.Contains(r, "error") || strings.Contains(r, "stalled") {
+		// Only Flux's terminal "Stalled" reason (retries exhausted, no
+		// further automatic reconcile) is a genuine terminal failure. Every
+		// other Ready=False is an in-flight reconcile/retry — running, never
+		// a flapping terminal Failed.
+		if strings.EqualFold(strings.TrimSpace(ready.Reason), "Stalled") {
 			return ObsStatusFailed
 		}
 		return ObsStatusRunning
@@ -363,6 +434,83 @@ func jobStartTime(u *unstructured.Unstructured) time.Time {
 		}
 	}
 	return time.Time{}
+}
+
+// taskBaseName returns the STABLE base identity for a standalone batch
+// Job (issue #3916) — the key the task-<base> leaf is minted under, so
+// repeated runs of the same logical task collapse into one leaf with
+// per-run Executions instead of accumulating a fresh leaf per run.
+//
+// Resolution order:
+//  1. metadata.generateName — authoritative when present. The Job
+//     controller (and Flux's prune-and-recreate) sets generateName to the
+//     base and lets the apiserver append a "-<5-char-rand>" suffix, so the
+//     generateName (minus its trailing dash) IS the stable identity.
+//  2. otherwise strip a single trailing controller-appended run suffix
+//     from metadata.name: either a numeric CronJob-style "-<digits>"
+//     stamp or a lowercase-alphanumeric "-<hash>" (>=5 chars) the Job
+//     controller / generateName path leaves. A name with no such suffix
+//     (a human-authored fixed-name Job) is returned unchanged.
+//
+// The stripping is deliberately conservative — it removes AT MOST ONE
+// trailing segment and only when that segment looks machine-generated, so
+// a meaningful final segment of a fixed name (e.g. "cnpg-pair-primary-3-
+// join") is preserved.
+func taskBaseName(u *unstructured.Unstructured) string {
+	if gn := strings.TrimSpace(u.GetGenerateName()); gn != "" {
+		return strings.TrimRight(gn, "-")
+	}
+	name := u.GetName()
+	i := strings.LastIndexByte(name, '-')
+	if i <= 0 || i == len(name)-1 {
+		return name
+	}
+	suffix := name[i+1:]
+	if isRunSuffix(suffix) {
+		return name[:i]
+	}
+	return name
+}
+
+// isRunSuffix reports whether a trailing name segment looks like a
+// controller-appended run instance id: an all-digit stamp (CronJob unix
+// minute, e.g. "28912345") OR a lowercase base36-ish hash of length >=5
+// (the apiserver's generateName suffix is 5 lowercase alphanumerics, e.g.
+// "x7f2k"). Pure-alpha words shorter than the hash length, or any segment
+// containing an uppercase letter, are treated as MEANINGFUL (not a run id)
+// so a fixed-name Job like "...-join" or "...-migrate" is never truncated.
+func isRunSuffix(s string) bool {
+	if s == "" {
+		return false
+	}
+	allDigits := true
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			allDigits = false
+			break
+		}
+	}
+	if allDigits {
+		return true
+	}
+	// generateName random suffix: exactly-5 lowercase [a-z0-9], and NOT
+	// all-letters (an all-letters 5-char tail like "build" or "enrol" is a
+	// real word, not a hash). Require at least one digit to distinguish a
+	// random suffix from a meaningful trailing word.
+	if len(s) != 5 {
+		return false
+	}
+	hasDigit := false
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		case r >= 'a' && r <= 'z':
+		default:
+			return false
+		}
+	}
+	return hasDigit
 }
 
 // cronJobOwnerName returns the owning CronJob name when the Job carries a

--- a/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers.go
@@ -61,19 +61,34 @@ var (
 // are in scope"). The reconciler chart stamps it via a render marker.
 const ReconcilerMarkerLabel = "catalyst.openova.io/reconciler"
 
-// SecurityScanSummaryName — the stable Name of the SINGLE collapsed
-// security-scan task leaf (issue #3919). Every trivy-operator scan Job is
-// counted into this one leaf instead of minting its own task-* row, so the
-// /jobs canvas shows "scanning is happening" without the hundreds of
-// ever-growing per-workload rows. The jobs bridge keys leaves by Kind+Name,
-// so a fixed Name guarantees the count refreshes the same row across
-// re-reads rather than accumulating new ones.
-const SecurityScanSummaryName = "security-scans"
-
-// trivyScanNamespace — the namespace the trivy-operator runs its scan Jobs
-// in. Scan Jobs anywhere else are still caught by the label/name checks in
-// isSecurityScanJob; this is the fast common-case match.
-const trivyScanNamespace = "trivy-system"
+// Day-2 security-scanner namespaces (issue #3919 / founder mandate). The
+// provisioning flow + diagram surface the FINITE convergence set (platform
+// HRs, Kustomization tiers, real bootstrap/seed/migration Jobs). Day-2
+// background scanners run FOREVER, minting a fresh Job per scan run and never
+// completing — they are security activity, not provisioning convergence, so
+// they are EXCLUDED ENTIRELY from the flow (not collapsed into an inline
+// summary leaf that still pollutes the convergence DAG). Two scanners are
+// excluded:
+//
+//   - trivy-operator — one short-lived scan-* Job per workload (+ per
+//     container), continuously re-scanned, in trivyScanNamespace. Detected by
+//     isDay2ScannerJob's trivy paths.
+//   - syft-grype     — a daily SBOM/vuln CronJob in syftGrypeNamespace whose
+//     spawned Jobs carry a CronJob ownerReference to syftGrypeCronName.
+//     The CronJob itself AND its spawned Jobs are excluded (the cron leaf is
+//     dropped in pass 2; the spawned Jobs in pass 3).
+const (
+	// trivyScanNamespace — the namespace the trivy-operator runs its scan
+	// Jobs in. Scan Jobs anywhere else are still caught by the label/name
+	// checks in isDay2ScannerJob; this is the fast common-case match.
+	trivyScanNamespace = "trivy-system"
+	// syftGrypeNamespace — the namespace bp-syft-grype installs into
+	// (clusters/_template/bootstrap-kit/33-syft-grype.yaml targetNamespace).
+	syftGrypeNamespace = "syft-grype"
+	// syftGrypeCronName — the bp-syft-grype CronJob name (releaseName in the
+	// slot-33 HelmRelease). Its spawned Jobs carry it as a CronJob owner.
+	syftGrypeCronName = "syft-grype"
+)
 
 // Reconciler-observation Kind tags. These mirror the jobs.Kind* leaf
 // kinds 1:1 (kept as plain strings here so this package does not import
@@ -205,6 +220,14 @@ func ListReconcilerObservations(ctx context.Context, dyn dynamic.Interface) ([]R
 	if list, err := dyn.Resource(CronJobGVR).Namespace("").List(ctx, metav1.ListOptions{}); err == nil {
 		for i := range list.Items {
 			u := &list.Items[i]
+			// Day-2 scanner CronJob (syft-grype) → EXCLUDED from the
+			// provisioning flow + diagram entirely (founder mandate, #3919).
+			// Dropping the cron leaf here also keeps its spawned Jobs from
+			// orphaning onto a missing cron leaf in pass 3 — those Jobs are
+			// independently excluded by isDay2ScannerJob below.
+			if isDay2ScannerCronJob(u) {
+				continue
+			}
 			obs := ReconcilerObservation{
 				Kind:      ReconcilerKindCron,
 				Name:      u.GetName(),
@@ -225,24 +248,23 @@ func ListReconcilerObservations(ctx context.Context, dyn dynamic.Interface) ([]R
 	// task-<name> leaf. The ownership de-dup (issue #3646 §5a) keys off
 	// metadata.ownerReferences + the helm hook label.
 	//
-	// scanJobCount accumulates trivy/aquasecurity security-scan Jobs
-	// (issue #3919) so they NEVER mint per-Job task-* leaves — they are
-	// collapsed into ONE "security-scans" summary leaf after the loop. The
-	// trivy-operator spawns one scan Job per workload (+ per container) and
-	// continuously re-scans, so without this they flood the /jobs canvas with
-	// hundreds of ever-growing rows that dwarf the real ~100 platform
-	// reconcilers. This mirrors the dashboard treemap's `dropEphemeralRows`
-	// scan exclusion (#3869) — same class of filter, applied to the jobs
-	// ingestion. Collapse (not drop) so the operator still sees scanning is
-	// running without the per-report flood.
-	scanJobCount := 0
+	// Day-2 security-scanner Jobs (trivy-operator + syft-grype, issue #3919)
+	// are EXCLUDED ENTIRELY here — they never mint a task-* leaf, never attach
+	// as an Execution, and (because the flow diagram is derived strictly from
+	// the leaves in jobs.Store) never become a node or edge in the convergence
+	// DAG. The trivy-operator spawns one short-lived scan Job per workload
+	// (+ per container) and re-scans forever; syft-grype runs a daily SBOM
+	// CronJob. Both are continuous background security activity, NOT the finite
+	// provisioning-convergence set the flow surfaces — so they are dropped, not
+	// collapsed into an inline summary row that would still pollute the DAG
+	// (founder mandate, #3919). This mirrors the dashboard treemap's scan
+	// exclusion (#3869) applied to the jobs ingestion.
 	if list, err := dyn.Resource(JobGVR).Namespace("").List(ctx, metav1.ListOptions{}); err == nil {
 		for i := range list.Items {
 			u := &list.Items[i]
-			// Security-scan Job (trivy-operator) → counted into the single
-			// summary leaf, never a per-Job task-* row (#3919).
-			if isSecurityScanJob(u) {
-				scanJobCount++
+			// Day-2 scanner Job (trivy-operator scan-* OR a syft-grype
+			// CronJob-spawned run) → fully excluded from the flow + diagram.
+			if isDay2ScannerJob(u) {
 				continue
 			}
 			status, started, finished := jobRunStatus(u)
@@ -352,25 +374,6 @@ func ListReconcilerObservations(ctx context.Context, dyn dynamic.Interface) ([]R
 			})
 			taskIdx[key] = len(out) - 1
 		}
-	}
-
-	// (3b) Collapsed security-scan summary (issue #3919). When trivy-operator
-	// scan Jobs were observed, emit exactly ONE task leaf carrying the count
-	// so the operator sees "scanning is happening" without the per-workload
-	// flood. A stable Name keeps it as a single leaf across re-reads (the
-	// jobs bridge upserts by Kind+Name); the count lives in the Message so a
-	// growing scan fleet refreshes the same row instead of adding new ones.
-	// Succeeded because the scans themselves are not a provisioning gate —
-	// their job is to run continuously, never to "complete".
-	if scanJobCount > 0 {
-		out = append(out, ReconcilerObservation{
-			Kind:       ReconcilerKindTask,
-			Name:       SecurityScanSummaryName,
-			Namespace:  "trivy-system",
-			Status:     ObsStatusSucceeded,
-			Message:    "security scans: " + itoa(int64(scanJobCount)) + " scan jobs (collapsed)",
-			ObservedAt: time.Now().UTC(),
-		})
 	}
 
 	// (4) reconciler-marked Deployments → reconciler-<name> HEALTH leaf.
@@ -564,31 +567,52 @@ func isRunSuffix(s string) bool {
 	return hasDigit
 }
 
-// isSecurityScanJob reports whether a batch Job is a trivy/aquasecurity
-// security-scan Job (issue #3919) that must be COLLAPSED into the single
-// security-scans summary leaf rather than minting its own task-* row.
+// isDay2ScannerJob reports whether a batch Job is a Day-2 security-scanner
+// run (trivy-operator OR syft-grype, issue #3919) that must be EXCLUDED
+// ENTIRELY from the provisioning flow + diagram — never a task-* leaf, never
+// an Execution, never a DAG node/edge.
 //
-// The trivy-operator spawns one short-lived scan Job per workload (and per
-// container) and re-scans continuously, producing the VulnerabilityReport /
-// ConfigAuditReport / ExposedSecretReport / RbacAssessmentReport CRs — on a
-// converged Sovereign that is hundreds of ever-growing Jobs that flood and
-// dwarf the ~100 real platform reconcilers on the /jobs canvas. They are
-// security activity, not provisioning/convergence, so they do not belong as
-// individual rows. This is the jobs-ingestion analogue of the dashboard
-// treemap's scan exclusion (#3869).
+// Day-2 scanners run forever: the trivy-operator spawns one short-lived scan
+// Job per workload (+ per container) and re-scans continuously (producing the
+// VulnerabilityReport / ConfigAuditReport / ExposedSecretReport /
+// RbacAssessmentReport CRs); syft-grype runs a daily SBOM/vuln CronJob whose
+// spawned Jobs accumulate under successfulJobsHistoryLimit. On a converged
+// Sovereign that is hundreds of ever-growing rows that dwarf the ~100 real
+// platform reconcilers. They are security activity, not provisioning
+// convergence, so they do not belong in the finite convergence set the flow
+// surfaces. This is the jobs-ingestion analogue of the dashboard treemap's
+// scan exclusion (#3869).
 //
-// Detection is layered (any match ⇒ scan Job), most-authoritative first:
-//  1. the trivy-operator managed-by label
-//     (app.kubernetes.io/managed-by=trivy-operator) — the operator stamps
-//     it on every scan Job it creates;
-//  2. any trivy-operator.* label key (e.g. trivy-operator.resource.kind),
-//     present on scan Jobs regardless of the managed-by value;
-//  3. the well-known scan-* name prefix in the trivy-system namespace, a
-//     belt-and-braces fallback if labels are stripped by a future operator
-//     release. Name-prefix alone OUTSIDE trivy-system is intentionally NOT
-//     treated as a scan Job so an unrelated user Job named "scan-*" in a
-//     tenant namespace still surfaces as a real task.
-func isSecurityScanJob(u *unstructured.Unstructured) bool {
+// Detection is layered + conservative (any match ⇒ scanner Job), so a
+// TENANT's own Job named "scan-*" in some other namespace, or a non-scanner
+// user Job, is never swept up:
+//
+//	trivy-operator:
+//	 1. the trivy-operator managed-by label
+//	    (app.kubernetes.io/managed-by=trivy-operator) — stamped on every
+//	    scan Job the operator creates;
+//	 2. any trivy-operator.* label key (e.g. trivy-operator.resource.kind),
+//	    present on scan Jobs regardless of the managed-by value;
+//	 3. the well-known scan-* name prefix scoped to the trivy-system
+//	    namespace, a belt-and-braces fallback if a future operator release
+//	    strips the labels. Name-prefix alone OUTSIDE trivy-system is
+//	    intentionally NOT treated as a scan Job.
+//
+//	syft-grype:
+//	 4. a CronJob ownerReference to the syft-grype CronJob (the kube CronJob
+//	    controller stamps it on every spawned run) — authoritative;
+//	 5. the bp-syft-grype managed-by/instance label scoped to the
+//	    syft-grype namespace, for a Job that lost its owner ref;
+//	 6. residence in the syft-grype namespace, a final belt-and-braces
+//	    fallback (the whole namespace is the scanner's, so any Job there is a
+//	    scan run). Namespace-scoping keeps a same-named tenant Job elsewhere
+//	    surfaced as a real task.
+func isDay2ScannerJob(u *unstructured.Unstructured) bool {
+	return isTrivyScanJob(u) || isSyftGrypeScannerJob(u)
+}
+
+// isTrivyScanJob — trivy-operator detection paths (1)-(3) above.
+func isTrivyScanJob(u *unstructured.Unstructured) bool {
 	labels := u.GetLabels()
 	if strings.EqualFold(strings.TrimSpace(labels["app.kubernetes.io/managed-by"]), "trivy-operator") {
 		return true
@@ -599,6 +623,51 @@ func isSecurityScanJob(u *unstructured.Unstructured) bool {
 		}
 	}
 	if u.GetNamespace() == trivyScanNamespace && strings.HasPrefix(u.GetName(), "scan-") {
+		return true
+	}
+	return false
+}
+
+// isSyftGrypeScannerJob — syft-grype detection paths (4)-(6) above.
+func isSyftGrypeScannerJob(u *unstructured.Unstructured) bool {
+	// (4) spawned by the syft-grype CronJob — owner ref is authoritative
+	// regardless of namespace.
+	if owner, ok := cronJobOwnerName(u); ok && owner == syftGrypeCronName {
+		return true
+	}
+	// (5) bp-syft-grype-labelled Job in the syft-grype namespace. The
+	// bp-syft-grype helper labels stamp app.kubernetes.io/managed-by=Helm and
+	// app.kubernetes.io/instance=syft-grype + catalyst.openova.io/blueprint=
+	// bp-syft-grype; key off the blueprint/instance marker, namespace-scoped.
+	labels := u.GetLabels()
+	if u.GetNamespace() == syftGrypeNamespace {
+		if strings.EqualFold(strings.TrimSpace(labels["catalyst.openova.io/blueprint"]), "bp-syft-grype") {
+			return true
+		}
+		if strings.EqualFold(strings.TrimSpace(labels["app.kubernetes.io/instance"]), syftGrypeCronName) {
+			return true
+		}
+		// (6) any other Job in the syft-grype namespace — the namespace is
+		// exclusively the scanner's, so a stray Job there is still a scan run.
+		return true
+	}
+	return false
+}
+
+// isDay2ScannerCronJob reports whether a batch CronJob is a Day-2 scanner
+// CronJob (syft-grype) that must be excluded from the flow + diagram. The
+// trivy-operator does NOT use a CronJob (it self-spawns Jobs), so this only
+// matches syft-grype: by name+namespace, or by the bp-syft-grype blueprint
+// label, namespace-scoped so a tenant CronJob elsewhere is untouched.
+func isDay2ScannerCronJob(u *unstructured.Unstructured) bool {
+	if u.GetNamespace() != syftGrypeNamespace {
+		return false
+	}
+	if u.GetName() == syftGrypeCronName {
+		return true
+	}
+	labels := u.GetLabels()
+	if strings.EqualFold(strings.TrimSpace(labels["catalyst.openova.io/blueprint"]), "bp-syft-grype") {
 		return true
 	}
 	return false

--- a/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers_test.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers_test.go
@@ -236,3 +236,196 @@ func TestListReconcilerObservations_CronJobWithNoRunIsPending(t *testing.T) {
 		t.Errorf("never-run cron should carry no Executions, got %d", len(cron.Executions))
 	}
 }
+
+// makeKustomization constructs a Flux Kustomization unstructured object with
+// a single Ready condition (status + reason) so statusFromReadyCondition can
+// be driven through ListReconcilerObservations.
+func makeKustomization(namespace, name string, readyStatus metav1.ConditionStatus, reason string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+			"kind":       "Kustomization",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{
+						"type":               "Ready",
+						"status":             string(readyStatus),
+						"reason":             reason,
+						"lastTransitionTime": time.Now().UTC().Format(time.RFC3339),
+					},
+				},
+			},
+		},
+	}
+	u.SetGroupVersionKind(schema.GroupVersionKind{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Kind: "Kustomization"})
+	return u
+}
+
+func findReconcile(obs []ReconcilerObservation, name string) *ReconcilerObservation {
+	for i := range obs {
+		if obs[i].Kind == ReconcilerKindReconcile && obs[i].Name == name {
+			return &obs[i]
+		}
+	}
+	return nil
+}
+
+func findTask(obs []ReconcilerObservation, name string) *ReconcilerObservation {
+	for i := range obs {
+		if obs[i].Kind == ReconcilerKindTask && obs[i].Name == name {
+			return &obs[i]
+		}
+	}
+	return nil
+}
+
+// TestStatusFromReadyCondition_TransientFalseIsRunningNotFailed pins the
+// anti-flap contract (issue #3916): a Kustomization that is still
+// reconciling — Ready=False with a transient build/health/dependency reason
+// Flux will RETRY — must read as running (in-progress), NEVER a terminal
+// Failed that flaps back to Succeeded on the next poll. Only Flux's terminal
+// "Stalled" reason is a genuine terminal failure.
+func TestStatusFromReadyCondition_TransientFalseIsRunningNotFailed(t *testing.T) {
+	transient := []string{
+		"BuildFailed", "HealthCheckFailed", "ReconciliationFailed",
+		"Progressing", "DependencyNotReady", "ArtifactFailed",
+	}
+	for _, reason := range transient {
+		obs, err := ListReconcilerObservations(context.Background(),
+			reconcilerFakeClient(makeKustomization("flux-system", "apps-"+reason, metav1.ConditionFalse, reason)))
+		if err != nil {
+			t.Fatalf("ListReconcilerObservations(%s): %v", reason, err)
+		}
+		rec := findReconcile(obs, "apps-"+reason)
+		if rec == nil {
+			t.Fatalf("reason=%s: no reconcile observation", reason)
+		}
+		if rec.Status == ObsStatusFailed {
+			t.Errorf("reason=%s: a still-reconciling Kustomization read TERMINAL failed — this is the flap (#3916); want running", reason)
+		}
+		if rec.Status != ObsStatusRunning {
+			t.Errorf("reason=%s: status = %q, want %q (in-progress)", reason, rec.Status, ObsStatusRunning)
+		}
+	}
+}
+
+// TestStatusFromReadyCondition_StalledIsTerminalFailed pins the converse: a
+// Kustomization Flux has GIVEN UP on (Ready=False, reason=Stalled) is a
+// genuine terminal failure and must surface as Failed.
+func TestStatusFromReadyCondition_StalledIsTerminalFailed(t *testing.T) {
+	obs, err := ListReconcilerObservations(context.Background(),
+		reconcilerFakeClient(makeKustomization("flux-system", "apps-dead", metav1.ConditionFalse, "Stalled")))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+	rec := findReconcile(obs, "apps-dead")
+	if rec == nil {
+		t.Fatal("no reconcile observation for the stalled Kustomization")
+	}
+	if rec.Status != ObsStatusFailed {
+		t.Errorf("stalled Kustomization status = %q, want %q (terminal)", rec.Status, ObsStatusFailed)
+	}
+}
+
+// TestStatusFromReadyCondition_ReadyTrueIsSucceeded keeps the happy path
+// honest: Ready=True is a stable terminal success.
+func TestStatusFromReadyCondition_ReadyTrueIsSucceeded(t *testing.T) {
+	obs, err := ListReconcilerObservations(context.Background(),
+		reconcilerFakeClient(makeKustomization("flux-system", "apps-ok", metav1.ConditionTrue, "ReconciliationSucceeded")))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+	rec := findReconcile(obs, "apps-ok")
+	if rec == nil || rec.Status != ObsStatusSucceeded {
+		t.Fatalf("Ready=True Kustomization want succeeded, got %+v", rec)
+	}
+}
+
+// TestListReconcilerObservations_TaskRunsCollapseToOneStableLeaf pins the
+// accumulation fix (issue #3916): N standalone Jobs that share a base
+// identity (a generateName, or a controller-appended run suffix) collapse
+// into ONE task-<base> leaf carrying N Executions — NOT N separate leaves.
+// Before the fix each run minted task-<unique-run-name>, growing the /jobs
+// model unbounded as Flux re-created the Jobs on every reconcile.
+func TestListReconcilerObservations_TaskRunsCollapseToOneStableLeaf(t *testing.T) {
+	t0 := time.Date(2026, 6, 19, 1, 0, 0, 0, time.UTC)
+
+	// Three runs of the same logical task, named via the generateName
+	// convention base + "-<5-rand>" the apiserver appends.
+	objs := []runtime.Object{}
+	mk := func(name string, gen string, fin time.Time) *unstructured.Unstructured {
+		u := makeBatchJob("data", name, "", "Complete", metav1.ConditionTrue, fin)
+		if gen != "" {
+			meta := u.Object["metadata"].(map[string]any)
+			meta["generateName"] = gen
+		}
+		return u
+	}
+	objs = append(objs,
+		mk("db-migrate-a1b2c", "db-migrate-", t0),
+		mk("db-migrate-d3e4f", "db-migrate-", t0.Add(time.Hour)),
+		mk("db-migrate-g5h6j", "db-migrate-", t0.Add(2*time.Hour)),
+	)
+
+	obs, err := ListReconcilerObservations(context.Background(), reconcilerFakeClient(objs...))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+
+	// Exactly ONE task leaf, keyed by the stable base "db-migrate".
+	taskCount := 0
+	for i := range obs {
+		if obs[i].Kind == ReconcilerKindTask {
+			taskCount++
+		}
+	}
+	if taskCount != 1 {
+		t.Fatalf("accumulation bug: want exactly 1 stable task leaf, got %d (one per run = the #3916 unbounded growth)", taskCount)
+	}
+	task := findTask(obs, "db-migrate")
+	if task == nil {
+		t.Fatalf("no task leaf keyed by the stable base name 'db-migrate'; got %d task observations", taskCount)
+	}
+	if len(task.Executions) != 3 {
+		t.Errorf("the 3 runs must record as 3 Executions under the one leaf, got %d", len(task.Executions))
+	}
+}
+
+// TestListReconcilerObservations_TaskRunSuffixStrippedFromName pins the
+// run-suffix stripping for Jobs without a generateName (re-created by Flux):
+// a numeric CronJob-style stamp and a 5-char random hash both collapse to the
+// same base, while a meaningful trailing word is preserved.
+func TestListReconcilerObservations_TaskRunSuffixStrippedFromName(t *testing.T) {
+	fin := time.Date(2026, 6, 19, 1, 0, 0, 0, time.UTC)
+	objs := []runtime.Object{
+		makeBatchJob("data", "snapshot-28999111", "", "Complete", metav1.ConditionTrue, fin),
+		makeBatchJob("data", "snapshot-29000222", "", "Complete", metav1.ConditionTrue, fin.Add(time.Hour)),
+		// A fixed-name Job whose final segment is a real word — must NOT
+		// be truncated.
+		makeBatchJob("data", "cnpg-pair-primary-join", "", "Complete", metav1.ConditionTrue, fin),
+	}
+	obs, err := ListReconcilerObservations(context.Background(), reconcilerFakeClient(objs...))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+	if findTask(obs, "snapshot") == nil {
+		t.Error("numeric run-suffix Jobs should collapse to task 'snapshot'")
+	}
+	if findTask(obs, "cnpg-pair-primary-join") == nil {
+		t.Error("a fixed-name Job's meaningful trailing word was wrongly stripped")
+	}
+	// And the two numeric runs are ONE leaf.
+	n := 0
+	for i := range obs {
+		if obs[i].Kind == ReconcilerKindTask && obs[i].Name == "snapshot" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("numeric-suffix runs want 1 stable leaf, got %d", n)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers_test.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers_test.go
@@ -450,22 +450,46 @@ func makeScanJob(name, label string, fin time.Time) *unstructured.Unstructured {
 	return u
 }
 
-// TestListReconcilerObservations_SecurityScansCollapseToOneSummary pins the
-// #3919 fix: trivy-operator security-scan Jobs (hundreds, one per workload,
-// ever-growing) MUST NOT each mint a task-* row — they collapse into ONE
-// "security-scans" summary leaf, so the /jobs canvas shows the real platform
-// reconcilers, not a scan flood. A handful of genuine reconciler Jobs in the
-// same list are unaffected.
-func TestListReconcilerObservations_SecurityScansCollapseToOneSummary(t *testing.T) {
+// makeSyftJob constructs a syft-grype SBOM-scan Job (issue #3919). variant
+// drives the syft detection path exercised: "owner" (a CronJob ownerReference
+// to the syft-grype CronJob — authoritative), "label" (the bp-syft-grype
+// blueprint label, namespace-scoped), or "namespace-only" (a bare Job that
+// only resides in the syft-grype namespace — the belt-and-braces fallback).
+func makeSyftJob(name, variant string, fin time.Time) *unstructured.Unstructured {
+	owner := ""
+	if variant == "owner" {
+		owner = syftGrypeCronName
+	}
+	u := makeBatchJob(syftGrypeNamespace, name, owner, "Complete", metav1.ConditionTrue, fin)
+	meta := u.Object["metadata"].(map[string]any)
+	switch variant {
+	case "label":
+		meta["labels"] = map[string]any{
+			"catalyst.openova.io/blueprint": "bp-syft-grype",
+			"app.kubernetes.io/instance":    "syft-grype",
+		}
+	case "namespace-only":
+		// no labels, no owner — relies solely on the syft-grype namespace
+	}
+	return u
+}
+
+// TestListReconcilerObservations_Day2ScannersExcludedFromFlow pins the founder
+// mandate (issue #3919): Day-2 security-scanner Jobs (trivy-operator AND
+// syft-grype) must be EXCLUDED ENTIRELY from the provisioning flow — not
+// collapsed into an inline summary leaf that still pollutes the convergence
+// view. After the fix the observation set contains ZERO scanner leaves (no
+// per-workload row, no summary row, no cron leaf) while every genuine
+// reconciler Job + HR survives with its own stable leaf + correct status.
+func TestListReconcilerObservations_Day2ScannersExcludedFromFlow(t *testing.T) {
 	t0 := time.Date(2026, 6, 20, 1, 0, 0, 0, time.UTC)
 	objs := []runtime.Object{}
 
-	// Simulate the live hw171 flood: a large fleet of scan Jobs across the
-	// three trivy detection paths (managed-by label, trivy-operator.* label,
-	// and scan-* name in trivy-system). 200 scan Jobs stands in for the ~600
-	// reports observed live.
-	scanFleet := 200
-	for i := 0; i < scanFleet; i++ {
+	// Simulate the live hw171 flood: a large fleet of trivy scan Jobs across
+	// all three trivy detection paths. 200 stands in for the ~600 reports
+	// observed live.
+	trivyFleet := 200
+	for i := 0; i < trivyFleet; i++ {
 		var label string
 		switch i % 3 {
 		case 0:
@@ -478,11 +502,32 @@ func TestListReconcilerObservations_SecurityScansCollapseToOneSummary(t *testing
 		objs = append(objs, makeScanJob("scan-vulnerabilityreport-"+itoaTest(i), label, t0))
 	}
 
-	// A handful of REAL reconciler Jobs that must each still surface.
+	// A fleet of syft-grype SBOM Jobs across all three syft detection paths,
+	// PLUS the syft-grype CronJob itself (which must also be excluded — no
+	// cron-syft-grype leaf).
+	syftFleet := 30
+	for i := 0; i < syftFleet; i++ {
+		var variant string
+		switch i % 3 {
+		case 0:
+			variant = "owner"
+		case 1:
+			variant = "label"
+		default:
+			variant = "namespace-only"
+		}
+		objs = append(objs, makeSyftJob("syft-grype-2900"+itoaTest(i), variant, t0))
+	}
+	objs = append(objs, makeCronJob(syftGrypeNamespace, syftGrypeCronName))
+
+	// A handful of REAL reconciler Jobs that must each still surface — incl. a
+	// fixed-name Job whose name starts "scan-" but lives in a TENANT namespace
+	// (NOT trivy-system) so it is a genuine task, not a scanner.
 	objs = append(objs,
 		makeBatchJob("cnpg", "cnpg-pair-primary-join", "", "Complete", metav1.ConditionTrue, t0),
 		makeBatchJob("openbao", "openbao-init-29000111", "", "Complete", metav1.ConditionTrue, t0),
 		makeBatchJob("gitea", "gitea-sso-configure", "", "Failed", metav1.ConditionTrue, t0),
+		makeBatchJob("acme-prod", "scan-invoices-nightly", "", "Complete", metav1.ConditionTrue, t0),
 	)
 
 	obs, err := ListReconcilerObservations(context.Background(), reconcilerFakeClient(objs...))
@@ -490,39 +535,63 @@ func TestListReconcilerObservations_SecurityScansCollapseToOneSummary(t *testing
 		t.Fatalf("ListReconcilerObservations: %v", err)
 	}
 
-	// Count task leaves. With 200 scan Jobs + 3 real Jobs, the PRE-FIX model
-	// would yield ~203 task rows; the fix yields 3 real + 1 summary = 4.
-	taskCount := 0
+	// Count task + cron leaves. Pre-fix: ~200 trivy task rows + 1 syft cron leaf
+	// (the 30 syft Jobs attach as Executions, or — for the labelled/namespace
+	// ones with no owner — as their own task rows). After full exclusion the
+	// ONLY leaves are the real reconcilers: 4 task leaves, 0 scanner cron leaf.
+	taskLeaves := []string{}
+	cronLeaves := []string{}
 	for i := range obs {
-		if obs[i].Kind == ReconcilerKindTask {
-			taskCount++
-		}
-	}
-	if taskCount > 10 {
-		t.Fatalf("scan flood NOT collapsed: got %d task leaves (≈the %d scan Jobs). The #3919 fix must drop these to ~the real-reconciler count.", taskCount, scanFleet)
-	}
-
-	// Exactly ONE collapsed summary leaf, carrying the scan count.
-	summary := findTask(obs, SecurityScanSummaryName)
-	if summary == nil {
-		t.Fatalf("no collapsed '%s' summary leaf — scanning must still be visible to the operator as one row", SecurityScanSummaryName)
-	}
-	if !strings.Contains(summary.Message, itoaTest(scanFleet)) {
-		t.Errorf("summary leaf must report the scan count %d, got message %q", scanFleet, summary.Message)
-	}
-
-	// The 3 real reconciler Jobs each survived as their own leaf.
-	for _, want := range []string{"cnpg-pair-primary-join", "openbao-init", "gitea-sso-configure"} {
-		if findTask(obs, want) == nil {
-			t.Errorf("real reconciler Job %q was wrongly swept into the scan collapse", want)
+		switch obs[i].Kind {
+		case ReconcilerKindTask:
+			taskLeaves = append(taskLeaves, obs[i].Name)
+		case ReconcilerKindCron:
+			cronLeaves = append(cronLeaves, obs[i].Name)
 		}
 	}
 
-	// And NO scan-* per-workload leaf leaked through.
+	// Exactly the 4 real reconciler Jobs survive as task leaves — nothing more.
+	wantTasks := map[string]bool{
+		"cnpg-pair-primary-join": true,
+		"openbao-init":           true, // run-suffix stripped from -29000111
+		"gitea-sso-configure":    true,
+		"scan-invoices-nightly":  true, // tenant "scan-*" Job is a REAL task
+	}
+	if len(taskLeaves) != len(wantTasks) {
+		t.Fatalf("Day-2 scanners NOT fully excluded: got %d task leaves %v, want exactly the %d real reconcilers. (pre-fix ≈ %d trivy scan rows)",
+			len(taskLeaves), taskLeaves, len(wantTasks), trivyFleet)
+	}
+	for _, name := range taskLeaves {
+		if !wantTasks[name] {
+			t.Errorf("unexpected task leaf %q survived — only the 4 real reconcilers should remain", name)
+		}
+	}
+
+	// ZERO scanner cron leaf — the syft-grype CronJob must not surface.
+	for _, name := range cronLeaves {
+		if name == syftGrypeCronName {
+			t.Errorf("the syft-grype scanner CronJob leaked a cron-%s leaf — it must be fully excluded", name)
+		}
+	}
+
+	// No scanner leaf of ANY kind leaked through (no per-workload trivy row, no
+	// collapsed summary row, no syft row).
 	for i := range obs {
-		if obs[i].Kind == ReconcilerKindTask && strings.HasPrefix(obs[i].Name, "scan-vulnerabilityreport-") {
-			t.Errorf("a per-workload scan leaf leaked: %q — every scan Job must fold into the summary", obs[i].Name)
+		n := obs[i].Name
+		if strings.HasPrefix(n, "scan-vulnerabilityreport-") ||
+			strings.HasPrefix(n, "syft-grype-") ||
+			n == "security-scans" {
+			t.Errorf("a scanner leaf leaked into the flow: kind=%q name=%q — Day-2 scanners must be excluded entirely (not collapsed)", obs[i].Kind, n)
 		}
+	}
+
+	// The genuine reconciler Jobs each survived with the right status (no
+	// flapping): gitea-sso-configure is Failed; the rest Succeeded.
+	if g := findTask(obs, "gitea-sso-configure"); g == nil || g.Status != ObsStatusFailed {
+		t.Errorf("gitea-sso-configure should survive as a Failed task, got %+v", g)
+	}
+	if c := findTask(obs, "cnpg-pair-primary-join"); c == nil || c.Status != ObsStatusSucceeded {
+		t.Errorf("cnpg-pair-primary-join should survive as a Succeeded task, got %+v", c)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers_test.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers_test.go
@@ -17,6 +17,7 @@ package helmwatch
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -429,3 +430,102 @@ func TestListReconcilerObservations_TaskRunSuffixStrippedFromName(t *testing.T) 
 		t.Errorf("numeric-suffix runs want 1 stable leaf, got %d", n)
 	}
 }
+
+// makeScanJob constructs a trivy-operator security-scan Job (issue #3919) —
+// the kind that floods the /jobs canvas. label drives which detection path
+// is exercised: "managed-by" (app.kubernetes.io/managed-by=trivy-operator),
+// "resource-label" (a trivy-operator.* label key), or "name-only" (scan-*
+// name in trivy-system with NO trivy labels — the belt-and-braces fallback).
+func makeScanJob(name, label string, fin time.Time) *unstructured.Unstructured {
+	u := makeBatchJob(trivyScanNamespace, name, "", "Complete", metav1.ConditionTrue, fin)
+	meta := u.Object["metadata"].(map[string]any)
+	switch label {
+	case "managed-by":
+		meta["labels"] = map[string]any{"app.kubernetes.io/managed-by": "trivy-operator"}
+	case "resource-label":
+		meta["labels"] = map[string]any{"trivy-operator.resource.kind": "Pod", "trivy-operator.resource.name": "some-pod"}
+	case "name-only":
+		// no labels — relies on the scan-* name + trivy-system namespace
+	}
+	return u
+}
+
+// TestListReconcilerObservations_SecurityScansCollapseToOneSummary pins the
+// #3919 fix: trivy-operator security-scan Jobs (hundreds, one per workload,
+// ever-growing) MUST NOT each mint a task-* row — they collapse into ONE
+// "security-scans" summary leaf, so the /jobs canvas shows the real platform
+// reconcilers, not a scan flood. A handful of genuine reconciler Jobs in the
+// same list are unaffected.
+func TestListReconcilerObservations_SecurityScansCollapseToOneSummary(t *testing.T) {
+	t0 := time.Date(2026, 6, 20, 1, 0, 0, 0, time.UTC)
+	objs := []runtime.Object{}
+
+	// Simulate the live hw171 flood: a large fleet of scan Jobs across the
+	// three trivy detection paths (managed-by label, trivy-operator.* label,
+	// and scan-* name in trivy-system). 200 scan Jobs stands in for the ~600
+	// reports observed live.
+	scanFleet := 200
+	for i := 0; i < scanFleet; i++ {
+		var label string
+		switch i % 3 {
+		case 0:
+			label = "managed-by"
+		case 1:
+			label = "resource-label"
+		default:
+			label = "name-only"
+		}
+		objs = append(objs, makeScanJob("scan-vulnerabilityreport-"+itoaTest(i), label, t0))
+	}
+
+	// A handful of REAL reconciler Jobs that must each still surface.
+	objs = append(objs,
+		makeBatchJob("cnpg", "cnpg-pair-primary-join", "", "Complete", metav1.ConditionTrue, t0),
+		makeBatchJob("openbao", "openbao-init-29000111", "", "Complete", metav1.ConditionTrue, t0),
+		makeBatchJob("gitea", "gitea-sso-configure", "", "Failed", metav1.ConditionTrue, t0),
+	)
+
+	obs, err := ListReconcilerObservations(context.Background(), reconcilerFakeClient(objs...))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+
+	// Count task leaves. With 200 scan Jobs + 3 real Jobs, the PRE-FIX model
+	// would yield ~203 task rows; the fix yields 3 real + 1 summary = 4.
+	taskCount := 0
+	for i := range obs {
+		if obs[i].Kind == ReconcilerKindTask {
+			taskCount++
+		}
+	}
+	if taskCount > 10 {
+		t.Fatalf("scan flood NOT collapsed: got %d task leaves (≈the %d scan Jobs). The #3919 fix must drop these to ~the real-reconciler count.", taskCount, scanFleet)
+	}
+
+	// Exactly ONE collapsed summary leaf, carrying the scan count.
+	summary := findTask(obs, SecurityScanSummaryName)
+	if summary == nil {
+		t.Fatalf("no collapsed '%s' summary leaf — scanning must still be visible to the operator as one row", SecurityScanSummaryName)
+	}
+	if !strings.Contains(summary.Message, itoaTest(scanFleet)) {
+		t.Errorf("summary leaf must report the scan count %d, got message %q", scanFleet, summary.Message)
+	}
+
+	// The 3 real reconciler Jobs each survived as their own leaf.
+	for _, want := range []string{"cnpg-pair-primary-join", "openbao-init", "gitea-sso-configure"} {
+		if findTask(obs, want) == nil {
+			t.Errorf("real reconciler Job %q was wrongly swept into the scan collapse", want)
+		}
+	}
+
+	// And NO scan-* per-workload leaf leaked through.
+	for i := range obs {
+		if obs[i].Kind == ReconcilerKindTask && strings.HasPrefix(obs[i].Name, "scan-vulnerabilityreport-") {
+			t.Errorf("a per-workload scan leaf leaked: %q — every scan Job must fold into the summary", obs[i].Name)
+		}
+	}
+}
+
+// itoaTest — tiny local int→string for the test (avoids a strconv import for
+// one call site and matches the package's no-fmt helper style).
+func itoaTest(n int) string { return itoa(int64(n)) }

--- a/products/catalyst/bootstrap/api/internal/jobs/reconciler_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/reconciler_bridge.go
@@ -192,10 +192,48 @@ func (b *Bridge) onReconcilerObservationLocked(o ReconcilerObservation) (jobsWri
 		if e != nil {
 			return jobsWritten, execsSeeded, e
 		}
-	case ObsKindReconcile, ObsKindTask:
-		// One-shot leaves get a single Execution carrying the status +
-		// message so the JobDetail log surface is non-empty and the row
-		// renders a duration cell rather than an em-dash. Pending leaves
+	case ObsKindTask:
+		// A task leaf is ONE STABLE entry keyed by its base identity
+		// (issue #3916). When the producer carried per-run instances
+		// (multiple Jobs sharing a generateName / run-suffix), each becomes
+		// an Execution on this single leaf — deduped by run name across
+		// re-reads, exactly like the cron leaf — so N reruns surface as 1
+		// row + N runs, never N rows. When no per-run list is present, fall
+		// back to a single status-carrying Execution.
+		if len(o.Executions) > 0 {
+			es, e := b.seedCronExecutionsLocked(jobName, o)
+			execsSeeded += es
+			if e != nil {
+				return jobsWritten, execsSeeded, e
+			}
+			// seedCronExecutionsLocked finishes each run in list order, so the
+			// LAST-processed run (not necessarily the most recent) would
+			// otherwise leave the headline. Re-assert the producer's
+			// recency-resolved status so the leaf reflects the latest run.
+			if err := b.store.UpsertJob(Job{
+				DeploymentID: b.deploymentID,
+				JobName:      jobName,
+				DisplayName:  reconcilerDisplay(o.Kind, o.Name),
+				AppID:        o.Name,
+				Type:         JobTypeInstall,
+				Kind:         kind,
+				ParentID:     JobID(b.deploymentID, GroupReconcilers),
+				DependsOn:    []string{},
+				Status:       status,
+			}); err != nil {
+				return jobsWritten, execsSeeded, err
+			}
+		} else if isTerminalOrRunningObs(status) {
+			es, e := b.seedSingleExecutionLocked(jobName, status, o.Message, at)
+			execsSeeded += es
+			if e != nil {
+				return jobsWritten, execsSeeded, e
+			}
+		}
+	case ObsKindReconcile:
+		// One-shot reconcile leaf gets a single Execution carrying the
+		// status + message so the JobDetail log surface is non-empty and the
+		// row renders a duration cell rather than an em-dash. Pending leaves
 		// stay Job-only (no empty NDJSON file).
 		if isTerminalOrRunningObs(status) {
 			es, e := b.seedSingleExecutionLocked(jobName, status, o.Message, at)

--- a/products/catalyst/bootstrap/api/internal/jobs/reconciler_bridge_test.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/reconciler_bridge_test.go
@@ -217,3 +217,80 @@ func TestReconcilerBridge_KindBackfillOnRead(t *testing.T) {
 		t.Errorf("kind back-fill: want %q, got %q", KindReconcile, j.Kind)
 	}
 }
+
+// TestReconcilerBridge_RepeatedSeedsKeepStableCount pins the accumulation
+// fix at the bridge layer (issue #3916): re-seeding the SAME reconciler
+// identities across many polls (the chroot /jobs re-read on every request)
+// must UPDATE one entry per identity in place — never append a new row per
+// poll. The reconciler-observation producer already collapses per-run Job
+// instances to a stable base name; this asserts the bridge's UpsertJob keying
+// holds the leaf count flat across repeated seeds.
+func TestReconcilerBridge_RepeatedSeedsKeepStableCount(t *testing.T) {
+	b, st := newTestBridge(t)
+
+	obs := []ReconcilerObservation{
+		{Kind: ObsKindReconcile, Name: "flux-system", Namespace: "flux-system", Status: "installing", Message: "reconciling"},
+		{Kind: ObsKindTask, Name: "db-migrate", Namespace: "data", Status: "installing", Message: "running"},
+		{Kind: ObsKindReconciler, Name: "sso-bridge", Namespace: "sso-bridge", Status: "healthy", Health: true, Message: "1/1"},
+	}
+
+	countLeaves := func() int {
+		all, err := st.ListJobs("dep-recon")
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		n := 0
+		for _, j := range all {
+			if j.Type != JobTypeGroup {
+				n++
+			}
+		}
+		return n
+	}
+
+	// First poll establishes the leaves.
+	if _, _, err := b.SeedReconcilerObservations(obs); err != nil {
+		t.Fatalf("seed 1: %v", err)
+	}
+	first := countLeaves()
+	if first != 3 {
+		t.Fatalf("first poll leaf count = %d, want 3", first)
+	}
+
+	// 20 more polls of the SAME identities (status may even change) must not
+	// grow the count — one stable entry per reconciler identity.
+	for i := 0; i < 20; i++ {
+		if _, _, err := b.SeedReconcilerObservations(obs); err != nil {
+			t.Fatalf("seed repeat %d: %v", i, err)
+		}
+	}
+	if got := countLeaves(); got != first {
+		t.Errorf("accumulation: leaf count grew from %d to %d across repeated polls (#3916)", first, got)
+	}
+}
+
+// TestReconcilerBridge_StillReconcilingTaskIsRunningNotTerminal pins the
+// anti-flap contract at the bridge layer: an observation carrying the
+// in-progress status ("installing") writes a RUNNING leaf, never a terminal
+// failed/succeeded. The leaf only becomes terminal when the observation
+// itself is terminal.
+func TestReconcilerBridge_StillReconcilingTaskIsRunningNotTerminal(t *testing.T) {
+	b, st := newTestBridge(t)
+	if err := b.OnReconcilerObservation(ReconcilerObservation{
+		Kind: ObsKindReconcile, Name: "apps", Namespace: "flux-system",
+		Status: "installing", Message: "reconcile in progress",
+	}); err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	all, _ := st.ListJobs("dep-recon")
+	rec, ok := findByName(all, "reconcile-apps")
+	if !ok {
+		t.Fatal("reconcile-apps leaf missing")
+	}
+	if rec.Status != StatusRunning {
+		t.Errorf("still-reconciling leaf status = %q, want %q (no flapping terminal)", rec.Status, StatusRunning)
+	}
+	if IsTerminal(rec.Status) {
+		t.Errorf("a still-reconciling leaf must NOT be terminal, got %q", rec.Status)
+	}
+}

--- a/products/catalyst/console/tests/e2e/fixtures/mock-blueprints.yaml
+++ b/products/catalyst/console/tests/e2e/fixtures/mock-blueprints.yaml
@@ -55,8 +55,14 @@ blueprints:
       realm: sovereign
       silentLogin: true
     endpoints:
+      # Harbor's UI + API are served on the SAME host as the registry
+      # (registry.<fqdn>): the live bootstrap-kit overlay sets BOTH gateway.host
+      # AND externalURL to registry.${SOVEREIGN_FQDN}, and platform/harbor/
+      # blueprint.yaml renders BOTH endpoints from registry.{{.SovereignFQDN}}.
+      # The earlier harbor.<fqdn> value pointed at a host with NO HTTPRoute → the
+      # console launch-url 404'd. Keep this mock aligned with the live blueprint.
       - name: ui
-        hostnameTemplate: "harbor.{{.SovereignFQDN}}"
+        hostnameTemplate: "registry.{{.SovereignFQDN}}"
         port: 443
         protocol: https
         tls: true


### PR DESCRIPTION
## What

The provisioning **Jobs page + flow diagram** must surface **only the finite convergence set** — platform HRs, Kustomization tiers, and the real bootstrap/seed/migration Jobs. Today (live on hw171) the page lists every batch/v1 Job cluster-wide, fusing finite provisioning-convergence with **infinite Day-2 background scanning**: region A shows ~128 leaves against only ~23 live Jobs + ~60 HRs because the trivy-operator + syft-grype scanners churn forever.

This PR's first cut **collapsed** the trivy flood into one inline `security-scans` summary leaf. The founder mandate is stronger: that summary still appears in the convergence view + becomes a node in the flow DAG. So this is now **full exclusion**, for **both** scanners:

- **trivy-operator** — standalone `scan-*` Jobs in `trivy-system` (one per workload + per container, ever-growing; 614 reports observed live).
- **syft-grype** — the daily SBOM/vuln **CronJob** in the `syft-grype` namespace **and** its spawned Jobs (previously a `cron-syft-grype` leaf + Executions).

## How (collapse -> exclusion)

`products/catalyst/bootstrap/api/internal/helmwatch/reconcilers.go`:

- `isSecurityScanJob` -> **`isDay2ScannerJob`**, broadened to cover syft-grype via (a) its CronJob owner ref, (b) the `bp-syft-grype` blueprint/instance label namespace-scoped, (c) `syft-grype`-namespace residence. Trivy paths unchanged. Detection stays **conservative + namespace-scoped** so a tenant's own `scan-*` Job in another namespace is never swept up.
- Added **`isDay2ScannerCronJob`** (syft-grype) — the CronJob pass skips it, so no `cron-syft-grype` leaf is minted and its spawned Jobs can't orphan.
- The Job pass `continue`s on any scanner (no task leaf, no Execution). Removed the collapsed `security-scans` summary block + the `SecurityScanSummaryName` const.

**Flow diagram:** `flowSnapshotFromJobs` builds the DAG **strictly from the leaves in `jobs.Store`**, so excluding scanners at ingestion guarantees they never become a node or edge — no separate flow-builder change needed.

## Reconciles #3918

Built on top of #3918, so it carries its two anti-regression fixes:
- **`statusFromReadyCondition`**: only Flux `Ready=False, reason=Stalled` is terminal Failed; every other `Ready=False` is `running` (no Failed<->Success flap).
- **`taskBaseName`**: standalone task leaves key on a stable base identity, so GC'd/re-created runs collapse to one leaf with N Executions instead of zombie-accumulating N leaves.

## Tests

- `helmwatch.TestListReconcilerObservations_Day2ScannersExcludedFromFlow` — 200 trivy + 30 syft Jobs + the syft CronJob + 4 real reconcilers => exactly the 4 real task leaves survive, **zero scanner leaf of any kind**, real statuses correct.
- `handler.TestFlowDiagram_ExcludesDay2Scanners` — drives the **full pipeline** and asserts **zero scanner NODES + EDGES** in the built DAG while the 3 real reconcilers each appear as nodes.

**Before:** ~203 trivy task leaves + 1 syft cron leaf. **After:** 0 scanner leaves, 0 scanner DAG nodes/edges.

`go build ./...` + `go vet ./...` clean; full helmwatch/jobs/handler suites green. No prov fired.

Refs #3919 #3918 #3869 #3646

🤖 Generated with [Claude Code](https://claude.com/claude-code)