### PR TITLE
fix(bp-newapi): admin-sso-seed host-seams -> vcluster-app — break the #3831 install deadlock (1.4.114)

### DIFF
--- a/clusters/_template/bootstrap-kit-crs/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit-crs/80-newapi.yaml
@@ -1,0 +1,44 @@
+# placement-generated (#3804 / Refs #3642) — host-bridge CRD-dependent CRs
+# for slot 80-newapi.yaml. SOURCE OF TRUTH: clusters/_template/bootstrap-kit/
+# placement.yaml (the matching slot's hostBridge.hostDocuments). Edit THERE
+# + run scripts/render-slot-placement.py fix — never hand-edit this file.
+#
+# Reconciled by the `bootstrap-kit-crs` Flux Kustomization (defined in
+# infra/providers/_shared/cloudinit-control-plane.tftpl), which
+# `dependsOn: [bootstrap-kit]` so these gateway.networking.k8s.io /
+# external-secrets.io / postgresql.cnpg.io CRs are validated + applied
+# only AFTER their operator CRDs exist — never in the bootstrap-kit atomic
+# dry-run (the fresh-prov `no matches for kind` deadlock, hw161).
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: newapi-server
+  namespace: mgmt
+  labels:
+    catalyst.openova.io/blueprint: bp-newapi
+    catalyst.openova.io/component: newapi
+    catalyst.openova.io/host-bridge: mgmt
+spec:
+  parentRefs:
+  - name: cilium-gateway
+    namespace: kube-system
+  hostnames:
+  - newapi.${SOVEREIGN_FQDN}
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /
+    backendRefs:
+    - name: newapi-bp-newapi-bridge-x-newapi-x-mgmt-vcluster
+      namespace: mgmt
+      port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: newapi-bp-newapi-x-newapi-x-mgmt-vcluster
+      namespace: mgmt
+      port: 3000

--- a/clusters/_template/bootstrap-kit-crs/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit-crs/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - 19-harbor.yaml
   - 25-grafana.yaml
   - 52-bp-guacamole.yaml
+  - 80-newapi.yaml

--- a/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
+++ b/clusters/_template/bootstrap-kit/16a-bp-postgres-shared.yaml
@@ -137,7 +137,13 @@ spec:
       # ingress rule (TCP 5432 from any in-cluster Pod) so the SHARED engine's
       # consumers reach it again; replication/own-cluster/operator carve-outs
       # unchanged; singleton stays byte-identical. Lockstep bump with 16c/16d.
-      version: 0.2.2
+      # 0.2.4 (#3878, companion to #3876): chart gains reflect.mangledTarget;
+      # the keycloak/gitea/harbor bindings below declare it so each DB Secret
+      # is delivered natively into vc-mgmt as the syncer-mangled host object
+      # (no fromHost mirror of a pod-mounted Secret → no vcluster-0.23.0
+      # from-host/to-host deadlock, and no missing credential). Lockstep with
+      # 16c/16d. Refs #3876 #3374 #3737.
+      version: 0.2.4
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -224,6 +230,14 @@ spec:
         reflect:
           secretName: harbor-database-secret
           namespaces: [harbor]
+          # #3878 (companion to #3876): harbor runs INSIDE vc-mgmt (#3642).
+          # Deliver harbor-database-secret natively into vc-mgmt by reflecting
+          # the vCluster-syncer-mangled host object into ns `mgmt` (the object
+          # the in-vc pod mounts). The DB Secret is NOT fromHost-imported, so
+          # the from-host/to-host syncers never fight over it (the #3876
+          # deadlock) AND the credential is present on a fresh prov.
+          mangledTarget:
+            vclusterNamespace: harbor
       - name: gitea             # gitea's database
         owner: gitea
         consumer:
@@ -232,6 +246,10 @@ spec:
         reflect:
           secretName: gitea-database-secret
           namespaces: [gitea]
+          # #3878: gitea runs INSIDE vc-mgmt — native DB-secret delivery (see
+          # harbor binding above for the full rationale).
+          mangledTarget:
+            vclusterNamespace: gitea
       # keycloak (#3188 three-instance model): the bitnami keycloak
       # subchart flips to externalDatabase mode off this hub Secret —
       # slot 09 gates its bundled keycloak-postgresql StatefulSet on
@@ -247,3 +265,11 @@ spec:
         reflect:
           secretName: keycloak-database-secret
           namespaces: [keycloak]
+          # #3878: keycloak runs INSIDE vc-mgmt — native DB-secret delivery.
+          # This is the durable form of the hw167 hand-fix the cycle-1
+          # validation agent applied live (created keycloak-database-secret
+          # natively in-vCluster, single toHost owner). #3876 dropped the
+          # keycloak/* fromHost wildcard entirely (keycloak has no host SSO
+          # Secret); this mangled copy is its ONLY in-vc DB-secret source.
+          mangledTarget:
+            vclusterNamespace: keycloak

--- a/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
+++ b/clusters/_template/bootstrap-kit/16c-bp-postgres-shared-b.yaml
@@ -82,7 +82,12 @@ spec:
       # primary NetworkPolicy default-denied every consumer's shared-pg-b-rw:5432
       # (grafana/powerdns hub on hw144). Adds TCP 5432 from any in-cluster Pod;
       # replication/own-cluster/operator carve-outs unchanged. Lockstep 16a/16d.
-      version: 0.2.2
+      # 0.2.4 (#3878, companion to #3876): the grafana binding declares
+      # reflect.mangledTarget so grafana-database-env is delivered natively into
+      # vc-mgmt as the syncer-mangled host object (no fromHost mirror → no
+      # vcluster-0.23.0 deadlock, no missing GF_DATABASE_* env). Lockstep with
+      # 16a/16d. Refs #3876 #3374 #3737.
+      version: 0.2.4
       sourceRef:
         kind: HelmRepository
         name: bp-postgres
@@ -149,6 +154,16 @@ spec:
           # of a region-local literal that NXDOMAIN'd grafana in region-B.
           hostPortKeys: [GF_DATABASE_HOST]
           passwordAliases: [GF_DATABASE_PASSWORD]
+          # #3878 (companion to #3876): grafana runs INSIDE vc-mgmt (#3642).
+          # Deliver grafana-database-env natively into vc-mgmt by reflecting
+          # the vCluster-syncer-mangled host object into ns `mgmt` (the object
+          # the grafana pod mounts via envFromSecrets). The env Secret is NOT
+          # fromHost-imported (#3876 dropped the grafana/* wildcard), so the
+          # from-host/to-host syncers never deadlock over it AND the GF_DATABASE_*
+          # env is present on a fresh prov. The mangled copy carries the SAME
+          # GF_DATABASE_* keys as the consumer-namespace copy.
+          mangledTarget:
+            vclusterNamespace: grafana
       # pdns — READY-TO-ADOPT (schema-bootstrap follow-up, see header).
       - name: pdns
         owner: pdns

--- a/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
+++ b/clusters/_template/bootstrap-kit/16d-bp-postgres-shared-c.yaml
@@ -70,7 +70,12 @@ spec:
       # (SME mesh / newapi / openova-flow on hw144). Adds TCP 5432 from any
       # in-cluster Pod; replication/own-cluster/operator carve-outs unchanged.
       # Lockstep bump with 16a/16c.
-      version: 0.2.2
+      # 0.2.4 (#3878): pure lockstep pin bump — shared-c's bindings (SME mesh /
+      # newapi / openova-flow) declare NO reflect.mangledTarget (they are not
+      # the 4 vc-mgmt-homed deadlock apps; newapi keeps its `newapi/*` fromHost
+      # wildcard per #3876), so this slot renders byte-identical to 0.2.2 on the
+      # additive chart. Lockstep with 16a/16c. Refs #3876 #3374 #3737.
+      version: 0.2.4
       sourceRef:
         kind: HelmRepository
         name: bp-postgres

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -170,7 +170,13 @@ spec:
       # harbor/grafana natively without a fromHost mirror. This pin bump only
       # refreshes the fromHost-block RCA comment; sync config byte-identical.
       # Refs #3876 #3374 #3737.
-      version: 0.2.24
+      # 0.2.25 (#3831, Refs #3642): + the newapi-pg `-rw`/`-ro` Service mirror —
+      # the SERVICE half for re-homing newapi (the CNPG-OWNER app) into vc-mgmt
+      # (slot 80 flips to placement.role=vcluster-app; slot 80a host-renders the
+      # CNPG-owner seams). The `newapi/*` secret mapping already delivers the DSN.
+      # Cycle-1.5 train combines this with the 0.2.23 DB-secret de-conflict
+      # (#3876) + the 0.2.24 RCA-comment refresh (#3878).
+      version: 0.2.25
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -161,7 +161,16 @@ spec:
       # the DB Secret. Each app ns narrowed `<ns>/*` → EXACT-NAME SSO/OIDC creds
       # only; keycloak drops out (no host non-DB Secret). DB Secret delivered
       # natively in-vCluster (toHost sole owner).
-      version: 0.2.23
+      # 0.2.24 (#3878, companion to #3876 — comment-only chart change): the
+      # native in-vCluster DB-secret delivery #3876 promised is now IMPLEMENTED
+      # in the sibling slot-16 change (bp-postgres 0.2.4 `reflect.mangledTarget`,
+      # slots 16a/16c). The shared-pg reflector materialises the syncer-mangled
+      # host object `<secret>-x-<ns>-x-mgmt-vcluster` in host ns `mgmt` (the
+      # object the in-vc pod mounts), so the 4 DB Secrets reach keycloak/gitea/
+      # harbor/grafana natively without a fromHost mirror. This pin bump only
+      # refreshes the fromHost-block RCA comment; sync config byte-identical.
+      # Refs #3876 #3374 #3737.
+      version: 0.2.24
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -295,7 +295,10 @@ spec:
       # vc-mgmt; the CNPG-owner seams render host-side via slot 80a host-seams.
       # database.existingSecret is wired (suppress) to the host-rendered,
       # mirrored-in DSN Secret so the Deployment render-gate resolves at mgmt.
-      version: 1.4.111
+      # 1.4.114 (#3831 deadlock fix, Refs #3858): admin-sso-seed Job/CronJob
+      # moved from host-seams → vcluster-app so the seed runs AFTER the app
+      # migrates the schema (it rendered host-side and deadlocked the install).
+      version: 1.4.114
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -44,7 +44,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bp-newapi
-  namespace: flux-system  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+  namespace: mgmt  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
   labels:
     catalyst.openova.io/vcluster: mgmt
     catalyst.openova.io/slot: "80"
@@ -52,11 +52,24 @@ spec:
   interval: 15m
   releaseName: newapi
   targetNamespace: newapi
+  storageNamespace: newapi
+  # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
+  kubeConfig:
+    secretRef:
+      name: vc-mgmt
+      key: config
   # vCluster pivot — the ONE generic render mechanism (placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix)
   dependsOn:
     # bp-mgmt-vcluster MUST be Ready first — the vc-mgmt
     # Secret doesn't exist until then. placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     - name: bp-mgmt-vcluster
+      namespace: flux-system
+    # #3831: the host-seams HR (slot 80a) renders the CNPG Cluster + the
+    # database-secret-sync Job that PATCHes the real DSN into
+    # newapi-bp-newapi-newapi-db-dsn before the bp-mgmt-vcluster `newapi/*`
+    # mirror delivers it into vc-mgmt — gate the app on it so the Deployment's
+    # SQL_DSN-readiness initContainer is not left waiting on an unmirrored Secret.
+    - name: bp-newapi-host-seams
       namespace: flux-system
     # G92.2 #2661 (2026-06-01): bp-openbao + bp-keycloak HRs moved to
     # host ns `mgmt`.
@@ -276,7 +289,13 @@ spec:
       # 1.4.109 (#3858): seed/promote Job pods no longer carry the workload
       # selector labels, so they stop leaking into the newapi + bridge Service
       # EndpointSlices → no more intermittent "upstream connect error 111".
-      version: 1.4.110
+      # 1.4.111 (#3831, Refs #3642): placement.role render-split. This slot runs
+      # placement.role=vcluster-app (stamped via placement.yaml hostBridge.
+      # suppress) so ONLY the app workload (Deployment + Service) renders INSIDE
+      # vc-mgmt; the CNPG-owner seams render host-side via slot 80a host-seams.
+      # database.existingSecret is wired (suppress) to the host-rendered,
+      # mirrored-in DSN Secret so the Deployment render-gate resolves at mgmt.
+      version: 1.4.111
       sourceRef:
         kind: HelmRepository
         name: bp-newapi
@@ -315,6 +334,10 @@ spec:
   # family model, `qwen3-coder`); the operator overlay overrides any of
   # these by setting them in this HelmRelease's spec.values.
   values:
+    database:
+      existingSecret: newapi-bp-newapi-newapi-db-dsn  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
+    placement:
+      role: vcluster-app  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
     # ── Bootstrap self-registration (#3687, extends #3370) ──────────────
     # The chart self-registers the Application CR for newapi (the canonical
     # instance representation every console surface reads), marked
@@ -338,7 +361,7 @@ spec:
     # Mirror the chart's value path. (Same shape for slot 81-sme if that
     # chart also reads cnpg.cluster.instances — track separately.)
     cnpg:
-      enabled: true
+      enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
       cluster:
         instances: ${SOVEREIGN_CNPG_INSTANCES:=1}
     postgres:
@@ -364,14 +387,14 @@ spec:
       # API spec, so enabling this on every Sovereign restores LLM
       # reachability without touching the marketplace wildcard.
       httpRoute:
-        enabled: true
+        enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
         host: newapi.${SOVEREIGN_FQDN}
     auth:
       adminUI:
         mode: keycloak
         keycloak:
           ssoBridgeSync:
-            enabled: true
+            enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
           # #3374: was realms/ops — a realm that does not exist on any
           # Sovereign (bp-keycloak imports only `sovereign` + per-Org
           # realms; measured live on hw130 2026-06-13). The sovereign
@@ -386,7 +409,7 @@ spec:
       enabled: true
       existingSecret: catalyst-newapi-admin-token
       externalSecret:
-        enabled: true
+        enabled: false  # placement-generated (#3373) — source: placement.yaml; edit THAT file + run scripts/render-slot-placement.py fix
         refreshInterval: "1h"
         secretStoreRef:
           kind: ClusterSecretStore

--- a/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
+++ b/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
@@ -1,0 +1,126 @@
+# bp-newapi-host-seams — bootstrap-kit slot 80a (#3831, Refs #3642).
+#
+# newapi is the ONLY NorthStar-#1 app that OWNS a dedicated CNPG cluster
+# (`newapi-bp-newapi-newapi-pg`) rather than CONSUMING a reflected shared-pg
+# secret like the other 6 mgmt-vCluster apps. To run newapi's app workload
+# INSIDE the mgmt vCluster (NorthStar #1: every app in a vCluster) while its
+# CNPG-owner seams stay HOST-reconciled, the chart renders in two cooperating
+# roles (platform/newapi/chart/_helpers.tpl renderSeams/renderApp):
+#
+#   - slot 80  (HR bp-newapi, vcluster: mgmt) ships placement.role=vcluster-app
+#     → the Deployment + Service + HTTPRoute run inside vc-mgmt; cnpg +
+#       ssoBridgeSync + the catalyst ExternalSecret are suppressed there.
+#   - slot 80a (THIS HR, host placement)      ships placement.role=host-seams
+#     → the CNPG Cluster + DSN-placeholder Secret + database-secret-sync Job +
+#       admin-sso-seed Job/CronJob + the newapi-admin AppRegistration ConfigMap
+#       + the oidc-sync ExternalSecret + the catalyst-newapi-admin-token
+#       ExternalSecret all render in the HOST `newapi` ns, where the host
+#       cnpg-operator owns the `<cluster>-app` Secret + DB, host bp-sso-bridge
+#       watches the AppRegistration ConfigMap cluster-wide (the OSS vCluster
+#       toHost sync is Pro-gated/INERT), and host ESO + OpenBao
+#       ClusterSecretStore vault-region1 back both ExternalSecrets.
+#
+# Both HRs share `releaseName: newapi` + chart `bp-newapi` but live in
+# DIFFERENT clusters (host k3s vs vc-mgmt apiserver), so there is NO
+# Helm-storage collision and `bp-newapi.fullname` resolves identically
+# (`newapi-bp-newapi`) on both sides — every cross-render object name (the DSN
+# Secret `newapi-bp-newapi-newapi-db-dsn`, the CNPG Cluster, the CNPG `-rw`/`-ro`
+# Services) lines up. The bp-mgmt-vcluster `sync.fromHost.secrets` `newapi/*`
+# mapping delivers the DSN/OIDC/creds/catalyst-token Secrets into vc-mgmt, and
+# its `replicateServices.fromHost` newapi-pg `-rw`/`-ro` entries make the
+# host-style CNPG FQDN resolve inside the vCluster (bp-mgmt-vcluster 0.2.23).
+#
+# The Namespace `newapi` and the HelmRepository `bp-newapi` are declared once by
+# slot 80 (host-applied) — NOT redeclared here to avoid a duplicate-resource
+# clash in the host kustomize set. This HR's `install.createNamespace: true`
+# provisions the HOST `newapi` ns idempotently.
+#
+# Wrapper chart: platform/newapi/chart/  (placement.role: host-seams)
+# Reconciled by: Flux on the Sovereign's k3s control plane (host cluster).
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-newapi-host-seams
+  namespace: flux-system
+  labels:
+    catalyst.openova.io/slot: "80a"
+spec:
+  interval: 15m
+  releaseName: newapi
+  targetNamespace: newapi
+  dependsOn:
+    # The CNPG-owner seams need: host cnpg-operator (Cluster + <cluster>-app),
+    # host ESO + OpenBao (both ExternalSecrets), host Keycloak (the admin-seed
+    # OIDC provider + the AppRegistration target realm), and bp-sso-bridge (the
+    # AppRegistration ConfigMap watcher). Gate on all of them.
+    - name: bp-cnpg
+      namespace: flux-system
+    - name: bp-external-secrets
+      namespace: flux-system
+    - name: bp-openbao
+      namespace: mgmt
+    - name: bp-keycloak
+      namespace: mgmt
+    - name: bp-sso-bridge
+      namespace: flux-system
+  chart:
+    spec:
+      chart: bp-newapi
+      # 1.4.111 (#3831): the placement.role render-split chart. Lockstep with
+      # slot 80's pin + platform/newapi blueprint.yaml.
+      version: 1.4.111
+      sourceRef:
+        kind: HelmRepository
+        name: bp-newapi
+        namespace: flux-system
+  install:
+    createNamespace: true
+    timeout: 15m
+    disableWait: true
+    remediation:
+      retries: -1
+  upgrade:
+    timeout: 15m
+    disableWait: true
+    remediation:
+      retries: 3
+  values:
+    # ── #3831 host-seams role: render ONLY the host-reconciled CNPG-owner seams.
+    placement:
+      role: host-seams
+    sovereignFQDN: ${SOVEREIGN_FQDN}
+    # The dedicated CNPG cluster newapi OWNS (single-region 1, multi-region 2).
+    cnpg:
+      enabled: true
+      cluster:
+        instances: ${SOVEREIGN_CNPG_INSTANCES:=1}
+    postgres:
+      cluster:
+        instances: ${SOVEREIGN_CNPG_INSTANCES:=1}
+    auth:
+      adminUI:
+        mode: keycloak
+        keycloak:
+          ssoBridgeSync:
+            enabled: true
+          # Same sovereign-realm wiring as slot 80 (#3374) — the admin-sso-seed
+          # writes the OIDC provider + root user into newapi's DB, and the
+          # AppRegistration ConfigMap registers the newapi-admin KC client.
+          issuer: https://auth.${SOVEREIGN_FQDN}/realms/sovereign
+          clientId: newapi-admin
+          existingSecret: newapi-oidc
+      customerAPI:
+        keyIssuer: catalyst
+    catalystIntegration:
+      enabled: true
+      existingSecret: catalyst-newapi-admin-token
+      externalSecret:
+        enabled: true
+        refreshInterval: "1h"
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: vault-region1
+        remoteRef:
+          key: sovereign/${SOVEREIGN_FQDN}/newapi/admin-token
+          property: ADMIN_API_TOKEN

--- a/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
+++ b/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
@@ -69,7 +69,13 @@ spec:
       chart: bp-newapi
       # 1.4.111 (#3831): the placement.role render-split chart. Lockstep with
       # slot 80's pin + platform/newapi blueprint.yaml.
-      version: 1.4.111
+      # 1.4.112: lockstep to the auto-bumped + published upstream-v0.13.2 chart.
+      # 1.4.114 (#3831 deadlock fix, Refs #3858): admin-sso-seed Job/CronJob no
+      # longer render under host-seams (they moved to vcluster-app) — this HR now
+      # renders only the genuine host seams (CNPG Cluster + DSN-sync Job +
+      # AppRegistration + ExternalSecrets), so its post-install no longer blocks
+      # on a schema the host never migrates.
+      version: 1.4.114
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -306,6 +306,12 @@ resources:
   # See clusters/_template/bootstrap-kit/80-newapi.yaml for full
   # dependsOn rationale and per-Sovereign override surface.
   - 80-newapi.yaml
+  # bp-newapi-host-seams (slot 80a, #3831) — the HOST-reconciled CNPG-owner
+  # seams (CNPG Cluster + DSN-sync Job + admin-sso-seed Job/CronJob +
+  # newapi-admin AppRegistration ConfigMap + both ExternalSecrets) for newapi.
+  # Slot 80 now re-homes newapi's app workload INTO vc-mgmt (placement.role=
+  # vcluster-app); this companion renders the seams host-side (host-seams).
+  - 80a-newapi-host-seams.yaml
   # bp-stalwart-sovereign (slot 95) — REMOVED 2026-05-05.
   # Phase-2 Sovereign-local mail (per-Sovereign Stalwart for Console
   # PIN/magic-link delivery, umbrella #924) is OUT OF SCOPE for the

--- a/clusters/_template/bootstrap-kit/placement.yaml
+++ b/clusters/_template/bootstrap-kit/placement.yaml
@@ -1246,37 +1246,110 @@ spec:
                 enablePodMonitor: false
     - {file: 56-bp-openova-flow-server.yaml, hr: bp-openova-flow-server, vcluster: host, target: mgmt, namespace: catalyst-system}
     - {file: 57-bp-openova-flow-emitter.yaml, hr: bp-openova-flow-emitter, vcluster: host, target: mgmt, namespace: catalyst-system}
-    # ── #3642 HOST-BRIDGE — newapi reverted to HOST placement (Refs #3831) ──
+    # ── #3831 CNPG-OWNER HOST-BRIDGE — newapi re-homed INTO vc-mgmt ──
     # newapi is the ONLY NS#1 app that OWNS a dedicated CNPG cluster
-    # (cnpg.enabled) rather than CONSUMING a fixed-name shared-pg
-    # reflected secret like gitea/harbor/keycloak/openbao do. The #3642
-    # host-bridge was designed for shared-pg CONSUMERS (route + ES +
-    # reflected `<app>-database-secret`, mirrored into vc-mgmt via
-    # sync.fromHost.secrets) — it does NOT carry the two CNPG-owner
-    # seams newapi needs host-side: the database-secret-sync Job (reads
-    # the host CNPG `<cluster>-app` Secret, PATCHes the DSN placeholder)
-    # and the admin-sso-seed Job/CronJob (seeds the newapi DB). It also
-    # dropped the SSO AppRegistration ConfigMap (bp-sso-bridge registers
-    # the `newapi-admin` KC client + writes sso/sovereign/newapi-admin
-    # from it), and never wired database.existingSecret — so the
-    # Deployment render-gate ($effDbSecret empty) skip-renders. Verified
-    # LIVE on hw165 (`9ee307969c92452e`): host ns newapi = the CNPG db
-    # pod ONLY, 0 Deployment, both ExternalSecrets SecretSyncedError, no
-    # newapi-admin AppRegistration ConfigMap anywhere. Every OTHER NS#1
-    # app's *-sso ExternalSecret SecretSynced=True — newapi is the lone
-    # outlier. Reverting to HOST placement (the SHIPPED #3733 grafana /
-    # #3737 keycloak revert precedent) renders the chart NATIVELY —
-    # Deployment + CNPG Cluster + sso-registration ConfigMap +
-    # admin-sso-seed Job/CronJob + database-secret-sync Job + oidc-sync
-    # ExternalSecret — all in the host `newapi` ns where ESO /
-    # bp-sso-bridge / cnpg-operator already reconcile them, the identical
-    # recipe gitea/harbor use today. `target: mgmt` stays the #3642
-    # aspiration: re-promote into vc-mgmt once the host-bridge gains the
-    # CNPG-owner seams (host-side db-sync + admin-seed + AppRegistration)
-    # + vcluster 0.23.0 sync.fromHost.secrets newapi/* (already mapped at
-    # bp-mgmt-vcluster values.yaml) delivers the DSN/oidc Secrets.
+    # (`newapi-bp-newapi-newapi-pg`, cnpg.enabled) rather than CONSUMING a
+    # fixed-name shared-pg reflected secret like gitea/harbor/keycloak/openbao.
+    # The #3642 host-bridge was built for shared-pg CONSUMERS, so a NAIVE
+    # promote (just flipping vcluster: mgmt) dropped newapi's CNPG-owner seams
+    # — the database-secret-sync Job, the admin-sso-seed Job/CronJob, the
+    # newapi-admin AppRegistration ConfigMap, and the database.existingSecret
+    # wiring — so the Deployment render-gate ($effDbSecret empty) skip-rendered
+    # (0 Deployment; #3832 reverted it to host on hw165).
+    #
+    # The #3831 fix mirrors the guacamole host-bridge precedent (#3868) and
+    # extends it for a CNPG-OWNER app via a chart `placement.role` render-split
+    # (bp-newapi 1.4.111). TWO cooperating HRs share releaseName: newapi +
+    # chart bp-newapi (different clusters → no Helm-storage collision, fullname
+    # lines up):
+    #   - THIS slot 80 (vcluster: mgmt, placement.role=vcluster-app) → the
+    #     Deployment + Service run INSIDE vc-mgmt; cnpg + ssoBridgeSync + the
+    #     catalyst ExternalSecret are suppressed there + database.existingSecret
+    #     is wired to the host-rendered, mirrored-in DSN Secret so $effDbSecret
+    #     resolves non-empty → the Deployment RENDERS at mgmt.
+    #   - slot 80a (vcluster: host, placement.role=host-seams) → the CNPG
+    #     Cluster + DSN-sync Job + admin-sso-seed Job/CronJob + AppRegistration
+    #     ConfigMap + both ExternalSecrets render in the HOST `newapi` ns where
+    #     cnpg-operator / ESO / OpenBao / bp-sso-bridge reconcile them.
+    # The bp-mgmt-vcluster 0.2.23 `newapi/*` secret mirror delivers the DSN/OIDC
+    # Secrets into vc-mgmt and its newapi-pg `-rw`/`-ro` replicateServices make
+    # the host-style CNPG FQDN resolve inside the vCluster. target == vcluster
+    # == mgmt → newapi is no longer staged-for-promotion; NS#1 is 7/7.
     - file: 80-newapi.yaml
       hr: bp-newapi
-      vcluster: host
+      vcluster: mgmt
       target: mgmt
       namespace: newapi
+      hostBridge:
+        suppress:
+          # render-split: app workload only inside vc-mgmt
+          placement.role: vcluster-app
+          # the CNPG Cluster + DSN-sync + admin-seed render host-side (slot 80a)
+          cnpg.enabled: false
+          # the SSO AppRegistration ConfigMap + oidc-sync ES render host-side
+          auth.adminUI.keycloak.ssoBridgeSync.enabled: false
+          # the catalyst-newapi-admin-token ES renders host-side
+          catalystIntegration.externalSecret.enabled: false
+          # the public front door is the host-bridge HTTPRoute below
+          ingress.httpRoute.enabled: false
+          # wire the Deployment to the host-rendered, mirrored-in DSN Secret so
+          # the render-gate $effDbSecret is non-empty even with cnpg suppressed
+          database.existingSecret: newapi-bp-newapi-newapi-db-dsn
+        hostDocuments:
+          # Public front door: HTTPRoute in host ns `mgmt`, backendRefs → the
+          # syncer-mangled in-vCluster Services (mirror of guacamole slot 52).
+          # Exact `/` → the bridge (zero-click landing page,
+          # publishNotReadyAddresses) so the 1st bare-URL hit is reachable
+          # during warm-up; PathPrefix `/` → the app Service.
+          - apiVersion: gateway.networking.k8s.io/v1
+            kind: HTTPRoute
+            metadata:
+              name: newapi-server
+              namespace: mgmt
+              labels:
+                catalyst.openova.io/blueprint: bp-newapi
+                catalyst.openova.io/component: newapi
+                catalyst.openova.io/host-bridge: "mgmt"
+            spec:
+              parentRefs:
+                - name: cilium-gateway
+                  namespace: kube-system
+              hostnames:
+                - newapi.${SOVEREIGN_FQDN}
+              rules:
+                - matches:
+                    - path:
+                        type: Exact
+                        value: /
+                  backendRefs:
+                    - name: newapi-bp-newapi-bridge-x-newapi-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 8080
+                - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /
+                  backendRefs:
+                    - name: newapi-bp-newapi-x-newapi-x-mgmt-vcluster
+                      namespace: mgmt
+                      port: 3000
+    # ── #3831 host-seams companion — CNPG-owner seams stay HOST-reconciled ──
+    # Renders the CNPG Cluster + DSN-sync Job + admin-sso-seed Job/CronJob +
+    # newapi-admin AppRegistration ConfigMap + both ExternalSecrets in the host
+    # `newapi` ns (placement.role=host-seams). MUST be host: host cnpg-operator
+    # owns <cluster>-app, host bp-sso-bridge watches the AppRegistration CM
+    # cluster-wide (vCluster toHost is Pro-gated/INERT on OSS), host ESO +
+    # OpenBao ClusterSecretStore vault-region1 back both ExternalSecrets.
+    - file: 80a-newapi-host-seams.yaml
+      hr: bp-newapi-host-seams
+      vcluster: host
+      target: host
+      namespace: newapi
+      justification: >-
+        CNPG-owner seams (CNPG Cluster + DSN-sync Job + admin-sso-seed
+        Job/CronJob + newapi-admin AppRegistration ConfigMap + both
+        ExternalSecrets) are intrinsically HOST-reconciled — host cnpg-operator
+        owns the <cluster>-app Secret + DB, host bp-sso-bridge watches the
+        AppRegistration ConfigMap (OSS vCluster toHost sync is INERT), and host
+        ESO + OpenBao back both ExternalSecrets (vc-mgmt runs no ESO). The app
+        Deployment/Service run IN vc-mgmt (slot 80); this is the host seam half.

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.23
+  version: 0.2.24
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.24
+  version: 0.2.25
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -283,7 +283,22 @@ name: bp-mgmt-vcluster
 # secret name now double-matches a fromHost mapping AND a known
 # keycloak/grafana/gitea/harbor pod-mount. Lockstep:
 # 58-bp-mgmt-vcluster.yaml pin + blueprint.yaml → 0.2.23. Refs #3374 #3737.
-version: 0.2.23
+# 0.2.24 (#3878, the implemented COMPANION to #3876 — comment-only here): #3876
+# (0.2.23) removed the 4 DB Secrets from the `sync.fromHost.secrets` wildcards
+# to kill the vcluster-0.23.0 from-host/to-host deadlock, and its RCA promised
+# the DB Secret would be "delivered natively in-vCluster (the shared-pg reflector
+# re-target, sibling slot-16 change)" — but #3876 did NOT contain that re-target,
+# so with #3876 alone keycloak/grafana/gitea/harbor get NO DB credential inside
+# vc-mgmt on a fresh prov. #3878 ships the re-target in bp-postgres 0.2.4
+# (`reflect.mangledTarget`, wired in slots 16a keycloak/gitea/harbor + 16c
+# grafana): the shared-pg reflector now materialises the vCluster-syncer-mangled
+# host object `<secret>-x-<ns>-x-mgmt-vcluster` in host ns `mgmt` — the exact
+# Secret the in-vc-mgmt pod mounts — carrying the live password, NEVER
+# fromHost-imported (no syncer contention). This release only updates the
+# fromHost-block RCA comment to cite the implemented companion; the sync config
+# is byte-identical to 0.2.23. Lockstep: 58-bp-mgmt-vcluster.yaml pin +
+# blueprint.yaml → 0.2.24. Refs #3876 #3374 #3737.
+version: 0.2.24
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -298,7 +298,17 @@ name: bp-mgmt-vcluster
 # fromHost-block RCA comment to cite the implemented companion; the sync config
 # is byte-identical to 0.2.23. Lockstep: 58-bp-mgmt-vcluster.yaml pin +
 # blueprint.yaml → 0.2.24. Refs #3876 #3374 #3737.
-version: 0.2.24
+# 0.2.25 (#3831, Refs #3642): mirror the newapi-pg CNPG `-rw`/`-ro` Services
+# (host ns `newapi`) into vc-mgmt — the SERVICE half for re-homing newapi (the
+# CNPG-OWNER app) into the mgmt vCluster. Same 4th-layer host→vCluster DNS gap
+# as the guacamole-pg entries above; the `newapi/*` fromHost.secrets mapping
+# already delivers the DSN Secret. Additive + idempotent. Combined with the
+# 0.2.23 fromHost DB-secret de-conflict (#3876) + the 0.2.24 RCA-comment
+# refresh (#3878) in this cycle-1.5 train — all three values.yaml edits coexist
+# (the replicateServices.fromHost mirror, the narrowed exact-name SSO secret
+# mappings, and the refreshed fromHost-block RCA comment). Lockstep:
+# 58-bp-mgmt-vcluster.yaml pin + blueprint.yaml → 0.2.25. Refs #3831 #3876 #3878 #3374 #3737.
+version: 0.2.25
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -427,6 +427,26 @@ vcluster:
           to: catalyst-system/guacamole-pg-rw
         - from: catalyst-system/guacamole-pg-ro
           to: catalyst-system/guacamole-pg-ro
+        # ── #3831 newapi-pg host→vCluster reachability (the SERVICE half) ──
+        # newapi is the ONLY NorthStar-#1 app that OWNS a dedicated CNPG cluster
+        # (it does NOT consume a reflected shared-pg secret like the other 6).
+        # Re-homed into vc-mgmt like guacamole (#3642 host-bridge): slot 80
+        # ships placement.role=vcluster-app + cnpg.enabled=false, so the CNPG
+        # `newapi-bp-newapi-newapi-pg` Cluster is HOST-rendered in the host
+        # `newapi` ns by the slot-80a host-seams HR while the app Deployment +
+        # Service run INSIDE vc-mgmt. The `newapi/*` from-host secret mapping
+        # (below) already mirrors the DSN Secret, but the CNPG `-rw`/`-ro`
+        # SERVICES live host-side only — and the DSN baked by the host
+        # database-secret-sync Job points at
+        # `newapi-bp-newapi-newapi-pg-rw.newapi.svc.cluster.local:5432`, which is
+        # NXDOMAIN inside vc-mgmt without this mirror → the app's GORM connect
+        # fails. Mirroring both Services makes that host-style FQDN resolve in
+        # the vCluster. No-op until the host-seams HR renders the Cluster
+        # (additive). Same 4th-layer DNS gap fixed for guacamole-pg above.
+        - from: newapi/newapi-bp-newapi-newapi-pg-rw
+          to: newapi/newapi-bp-newapi-newapi-pg-rw
+        - from: newapi/newapi-bp-newapi-newapi-pg-ro
+          to: newapi/newapi-bp-newapi-newapi-pg-ro
         # ClusterMesh-global write endpoints (active-hot-standby): the host
         # FQDN cross-region SHARED_PG consumers (grafana et al.) actually dial.
         - from: shared-data/shared-pg-mesh-rw

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -677,12 +677,21 @@ vcluster:
       # ExternalSecret-materialised creds — gitea/harbor/grafana sso-configure
       # + grafana runtime mount them). keycloak has NO host-minted non-DB
       # Secret (its IdP creds are issued, not mounted), so it drops out
-      # entirely. The DB Secret is delivered natively in-vCluster (the
-      # shared-pg reflector re-target, sibling slot-16 change) — the toHost
-      # syncer is then its sole owner. `newapi/*` + `catalyst-system/*` keep
-      # their wildcards (out of this de-conflict's 4-app scope, no observed
-      # rotation-driven deadlock); the openbao EXACT-NAME entries (#3838)
-      # remain unchanged.
+      # entirely. The DB Secret is delivered natively in-vCluster by the
+      # sibling slot-16 change (#3878, the implemented companion to #3876):
+      # bp-postgres 0.2.4's `reflect.mangledTarget` makes the shared-pg
+      # reflector materialise the vCluster-syncer-mangled host object
+      # `<secret>-x-<ns>-x-mgmt-vcluster` directly in host ns `mgmt` — the EXACT
+      # object the in-vc-mgmt pod mounts in single-namespace mode (the
+      # `MountVolume.SetUp … secret "keycloak-database-secret-x-keycloak-x-mgmt-
+      # vcluster" not found` name above). Because that object is reflector-owned
+      # and NEVER `sync.fromHost.secrets`-imported, the from-host syncer never
+      # touches it (no from-host↔to-host ownership fight) AND it carries the
+      # live randAlphaNum password (no missing credential on a fresh prov). The
+      # toHost necessary-sync is its only in-vc owner. `newapi/*` +
+      # `catalyst-system/*` keep their wildcards (out of this de-conflict's
+      # 4-app scope, no observed rotation-driven deadlock); the openbao
+      # EXACT-NAME entries (#3838) remain unchanged.
       secrets:
         enabled: true
         mappings:

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.110
+  version: 1.4.111
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,8 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.111
+  # 1.4.114 (#3831 deadlock fix, Refs #3858): admin-sso-seed moved host-seams → vcluster-app.
+  version: 1.4.114
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,23 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.114 (#3831 deadlock fix, Refs #3858, 2026-06-20): the admin-sso-seed
+# Job/CronJob now render with the APP (placement.role vcluster-app), NOT the
+# host seams (host-seams). Under the #3831 render-split they were left on the
+# host where seed.sh's wait_for_users_table blocked on the `public.users` table
+# (created by the app's GORM AutoMigrate, which runs only inside vc-mgmt) → the
+# 420s activeDeadline elapsed → DeadlineExceeded → the host-seams HR install
+# FAILED → uninstall/retry forever; and the vcluster-app HR dependsOn the
+# host-seams HR, so the app could never install to migrate the schema → CIRCULAR
+# DEADLOCK (measured live hw171 dep 3963e9267c10a90d: host-seams Unknown/failed
+# x6, vcluster-app False "Fulfilling prerequisites", 0 tables in the CNPG public
+# schema, newapi.<fqdn> → HTTP 500). Co-locating the seed with the app fires the
+# post-install hook AFTER the Deployment installs+migrates, and the
+# Deployment-patch RBAC (reload_newapi_provider) now targets a Deployment that
+# exists. The mounted CNPG `-app` + OIDC Secrets are mirrored host→vCluster by
+# bp-mgmt-vcluster sync.fromHost.secrets `"newapi/*"` (#3879). Mirrors the
+# channel-seed-job precedent (also renderApp, also schema-dependent). role=all
+# (DEFAULT) renders both as before → standalone/host-placed installs unchanged.
+#
 # 1.4.109 (#3858, 2026-06-19): stop the seed/promote Jobs masquerading as
 # newapi Service endpoints → kill the intermittent "upstream connect error
 # 111" on newapi.<fqdn>.
@@ -784,7 +802,7 @@ name: bp-newapi
 # host-placed install is byte-identical to 1.4.110. The split mirrors the
 # guacamole host-bridge precedent (#3868) for a host-rendered CNPG + in-vCluster
 # app, extended to a CNPG-OWNER app. See _helpers.tpl renderSeams/renderApp.
-version: 1.4.111
+version: 1.4.114
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -774,7 +774,17 @@ name: bp-newapi
 # fresh-prov readiness window the per-minute admin-promote CronJob self-heals
 # (#3767, 1.4.97) — this retry shrinks the human-visible window, it is not a
 # new SSO mechanism. Refs #3374.
-version: 1.4.110
+# 1.4.111 (#3831, Refs #3642): placement.role render split — the chart now
+# renders in one of three roles (all|host-seams|vcluster-app) so newapi can run
+# its app workload INSIDE the mgmt vCluster (NorthStar #1: every app in a
+# vCluster — newapi was the lone 6/7 host-placed exception) while its
+# CNPG-owner seams (CNPG Cluster + DSN-sync Job + admin-sso-seed Job/CronJob +
+# newapi-admin AppRegistration ConfigMap + both ExternalSecrets) stay
+# HOST-reconciled. role=all (DEFAULT) is a no-op gate → every standalone /
+# host-placed install is byte-identical to 1.4.110. The split mirrors the
+# guacamole host-bridge precedent (#3868) for a host-rendered CNPG + in-vCluster
+# app, extended to a CNPG-OWNER app. See _helpers.tpl renderSeams/renderApp.
+version: 1.4.111
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/000-external-secrets-webhook-readiness-job.yaml
+++ b/platform/newapi/chart/templates/000-external-secrets-webhook-readiness-job.yaml
@@ -79,7 +79,7 @@ pay the 60s probe budget for nothing.
 {{- $ci := .Values.catalystIntegration | default dict -}}
 {{- $es := $ci.externalSecret | default dict -}}
 {{- $gate := .Values.externalSecretsWebhookGate | default dict -}}
-{{- if and (default true $gate.enabled) $ci.enabled $es.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") -}}
+{{- if and (eq (include "bp-newapi.renderSeams" .) "true") (default true $gate.enabled) $ci.enabled $es.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") -}}
 {{- $ns := .Release.Namespace }}
 {{- $svc := $gate.service | default "external-secrets-webhook" -}}
 {{- $svcNs := $gate.namespace | default "external-secrets-system" -}}

--- a/platform/newapi/chart/templates/_helpers.tpl
+++ b/platform/newapi/chart/templates/_helpers.tpl
@@ -68,6 +68,51 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Placement-role render gates (#3831).
+
+newapi is the ONLY NorthStar-#1 app that OWNS a dedicated CNPG cluster rather
+than CONSUMING a reflected shared-pg secret. To re-home it INTO the mgmt
+vCluster (every app in a vCluster) while its CNPG-owner seams stay host-side,
+the chart renders in one of three roles, selected by `.Values.placement.role`:
+
+  all          (DEFAULT) — render EVERYTHING. Every standalone install and
+               every host-placed Sovereign keeps the historic single-HR
+               behaviour; both gates below return "true" so they are no-ops.
+  host-seams   — render ONLY the host-reconciled seams: the CNPG Cluster +
+               DSN-placeholder Secret + database-secret-sync Job +
+               admin-sso-seed Job/CronJob (+ their RBAC) + the newapi-admin
+               AppRegistration ConfigMap + the oidc-sync ExternalSecret + the
+               catalyst-newapi-admin-token ExternalSecret. NO Deployment /
+               Service / HTTPRoute / Ingress / Application CR.
+  vcluster-app — render ONLY the app: Deployment + Service + (HTTPRoute via the
+               host-bridge) + NetworkPolicy + the Application CR + the
+               in-cluster placeholder Secrets the Pod reads (credentials,
+               token-signing-key). NO CNPG / Jobs / ExternalSecrets /
+               AppRegistration (those render host-side under host-seams; the
+               host→vCluster secret mirror + replicateServices deliver the DSN
+               Secret + CNPG Service into the vCluster).
+
+The two HRs share `releaseName: newapi` + chart `bp-newapi` (in DIFFERENT
+clusters — host k3s vs vc-mgmt apiserver, so NO Helm-storage collision), so
+`bp-newapi.fullname` resolves identically (`newapi-bp-newapi`) on both sides
+and every cross-render object name (DSN Secret, CNPG Cluster) lines up.
+
+Helm has no boolean return; these emit the strings "true"/"false". Test with
+`{{- if eq (include "bp-newapi.renderSeams" .) "true" }}`.
+*/}}
+{{- define "bp-newapi.placementRole" -}}
+{{- (.Values.placement | default dict).role | default "all" -}}
+{{- end -}}
+{{- define "bp-newapi.renderSeams" -}}
+{{- $r := include "bp-newapi.placementRole" . -}}
+{{- if or (eq $r "all") (eq $r "host-seams") -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+{{- define "bp-newapi.renderApp" -}}
+{{- $r := include "bp-newapi.placementRole" . -}}
+{{- if or (eq $r "all") (eq $r "vcluster-app") -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{/*
 ServiceAccount name.
 */}}
 {{- define "bp-newapi.serviceAccountName" -}}

--- a/platform/newapi/chart/templates/_helpers.tpl
+++ b/platform/newapi/chart/templates/_helpers.tpl
@@ -79,18 +79,23 @@ the chart renders in one of three roles, selected by `.Values.placement.role`:
                every host-placed Sovereign keeps the historic single-HR
                behaviour; both gates below return "true" so they are no-ops.
   host-seams   — render ONLY the host-reconciled seams: the CNPG Cluster +
-               DSN-placeholder Secret + database-secret-sync Job +
-               admin-sso-seed Job/CronJob (+ their RBAC) + the newapi-admin
-               AppRegistration ConfigMap + the oidc-sync ExternalSecret + the
-               catalyst-newapi-admin-token ExternalSecret. NO Deployment /
-               Service / HTTPRoute / Ingress / Application CR.
+               DSN-placeholder Secret + database-secret-sync Job (+ their RBAC) +
+               the newapi-admin AppRegistration ConfigMap + the oidc-sync
+               ExternalSecret + the catalyst-newapi-admin-token ExternalSecret.
+               NO Deployment / Service / HTTPRoute / Ingress / Application CR.
+               NOT the admin-sso-seed Job/CronJob — those operate on the migrated
+               schema + rollout-restart the app Deployment, so they render WITH
+               the app (vcluster-app), reading the CNPG `-app` + OIDC Secrets
+               mirrored host→vCluster (#3831 deadlock fix, Refs #3858).
   vcluster-app — render ONLY the app: Deployment + Service + (HTTPRoute via the
                host-bridge) + NetworkPolicy + the Application CR + the
                in-cluster placeholder Secrets the Pod reads (credentials,
-               token-signing-key). NO CNPG / Jobs / ExternalSecrets /
-               AppRegistration (those render host-side under host-seams; the
-               host→vCluster secret mirror + replicateServices deliver the DSN
-               Secret + CNPG Service into the vCluster).
+               token-signing-key) + the admin-sso-seed Job/CronJob + the
+               channel-seed Job (both operate on the app's migrated DB schema).
+               NO CNPG / DSN-sync Job / ExternalSecrets / AppRegistration (those
+               render host-side under host-seams; the host→vCluster secret mirror
+               + replicateServices deliver the DSN/`-app`/OIDC Secrets + CNPG
+               Service into the vCluster).
 
 The two HRs share `releaseName: newapi` + chart `bp-newapi` (in DIFFERENT
 clusters — host k3s vs vc-mgmt apiserver, so NO Helm-storage collision), so

--- a/platform/newapi/chart/templates/admin-sso-seed-job.yaml
+++ b/platform/newapi/chart/templates/admin-sso-seed-job.yaml
@@ -68,7 +68,7 @@ nothing.
 {{- if hasKey $ssoBootstrap "enabled" -}}{{- $seedEnabled = $ssoBootstrap.enabled -}}
 {{- else if hasKey $seed "enabled" -}}{{- $seedEnabled = $seed.enabled -}}{{- end -}}
 {{- $kcMode := eq .Values.auth.adminUI.mode "keycloak" -}}
-{{- if and $seedEnabled .Values.newapi.enabled $kcMode .Values.cnpg.enabled .Values.sovereignFQDN -}}
+{{- if and (eq (include "bp-newapi.renderSeams" .) "true") $seedEnabled .Values.newapi.enabled $kcMode .Values.cnpg.enabled .Values.sovereignFQDN -}}
 {{- $clusterName := printf "%s-newapi-pg" (include "bp-newapi.fullname" .) -}}
 {{- $cnpgSecretName := printf "%s-app" $clusterName -}}
 {{- $jobName := include "bp-newapi.adminSeedJobName" . -}}

--- a/platform/newapi/chart/templates/admin-sso-seed-job.yaml
+++ b/platform/newapi/chart/templates/admin-sso-seed-job.yaml
@@ -68,7 +68,37 @@ nothing.
 {{- if hasKey $ssoBootstrap "enabled" -}}{{- $seedEnabled = $ssoBootstrap.enabled -}}
 {{- else if hasKey $seed "enabled" -}}{{- $seedEnabled = $seed.enabled -}}{{- end -}}
 {{- $kcMode := eq .Values.auth.adminUI.mode "keycloak" -}}
-{{- if and (eq (include "bp-newapi.renderSeams" .) "true") $seedEnabled .Values.newapi.enabled $kcMode .Values.cnpg.enabled .Values.sovereignFQDN -}}
+{{- /* #3831 deadlock fix (Refs #3858): render with the APP (renderApp), NOT the
+   host seams (renderSeams). The seed/promote pair operates on the migrated DB
+   schema — seed.sh/promote.sh both call wait_for_users_table, which polls
+   `public.users` (created by the app's GORM AutoMigrate on first boot) — AND
+   it rollout-restarts the app Deployment (reload_newapi_provider patches
+   <release> Deployment to reload custom_oauth_providers). The Deployment only
+   exists under vcluster-app, and the schema is only migrated once the app boots.
+   Under the #3831 split the seed was left on the host (renderSeams), where:
+     (1) the post-install hook blocks on wait_for_users_table for a schema the
+         host side NEVER migrates (the app runs in vc-mgmt) → activeDeadline
+         (420s) → DeadlineExceeded → the host-seams HR install FAILS → uninstall
+         remediation → retry forever; and
+     (2) the vcluster-app HR `dependsOn: bp-newapi-host-seams`, so the app can
+         never install to migrate the schema → CIRCULAR DEADLOCK (measured live
+         hw171, dep 3963e9267c10a90d: host-seams HR Unknown/install-failed x6,
+         vcluster-app HR False "Fulfilling prerequisites", 0 tables in the CNPG
+         `public` schema, newapi.<fqdn> → 500).
+   Rendering with the app co-locates seed+migrate in the SAME release/cluster:
+   the post-install hook fires AFTER the app Deployment installs+migrates, the
+   `public.users` poll resolves, and the Deployment-patch RBAC targets a
+   Deployment that actually exists. The CNPG `<cluster>-app` Secret + OIDC Secret
+   the Job mounts are mirrored host→vCluster by bp-mgmt-vcluster
+   sync.fromHost.secrets `"newapi/*": "newapi/*"` (#3879), and the CNPG `-rw`/`-ro`
+   Services by sync.fromHost.mappings — so everything the Job reads resolves
+   vcluster-side. This mirrors the channel-seed-job precedent (also renderApp,
+   also operates on the migrated schema). `cnpg.enabled` is dropped from the gate
+   because vcluster-app ships cnpg.enabled=false (the CNPG Cluster is host-rendered
+   by the host-seams HR); the Job needs only the MIRRORED `-app` Secret, not the
+   Cluster CR. role=all keeps both gates "true" so standalone/host-placed installs
+   are byte-identical. */ -}}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") $seedEnabled .Values.newapi.enabled $kcMode .Values.sovereignFQDN -}}
 {{- $clusterName := printf "%s-newapi-pg" (include "bp-newapi.fullname" .) -}}
 {{- $cnpgSecretName := printf "%s-app" $clusterName -}}
 {{- $jobName := include "bp-newapi.adminSeedJobName" . -}}

--- a/platform/newapi/chart/templates/application-cr.yaml
+++ b/platform/newapi/chart/templates/application-cr.yaml
@@ -23,7 +23,7 @@ the Capabilities apps.openova.io/v1 gate (benign skip pre-CRD; CR
 materialises on the first post-CRD upgrade). Leaf platform app — no
 shareable Context, so spec.parameters is empty.
 */ -}}
-{{- if and .Values.bootstrapOwned.enabled (.Capabilities.APIVersions.Has "apps.openova.io/v1") }}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.bootstrapOwned.enabled (.Capabilities.APIVersions.Has "apps.openova.io/v1") }}
 apiVersion: apps.openova.io/v1
 kind: Application
 metadata:

--- a/platform/newapi/chart/templates/channel-seed-job.yaml
+++ b/platform/newapi/chart/templates/channel-seed-job.yaml
@@ -79,7 +79,7 @@ Issue #915, 2026-05-05.
 {{- $vllmReady := and $vllm.enabled (ne (default "" $vllm.endpoint) "") -}}
 {{- $hasDefaults := or $qpReady $vllmReady -}}
 {{- $masterKeySecret := .Values.auth.adminUI.masterKeySecret | default "" -}}
-{{- if and $cs.enabled $hasDefaults $masterKeySecret -}}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") $cs.enabled $hasDefaults $masterKeySecret -}}
 {{- $jobName := include "bp-newapi.channelSeedJobName" . -}}
 ---
 {{- /*

--- a/platform/newapi/chart/templates/cilium-ingress-networkpolicy.yaml
+++ b/platform/newapi/chart/templates/cilium-ingress-networkpolicy.yaml
@@ -19,7 +19,7 @@ policy already allowed stays allowed, everything else stays denied.
 Gated on the cilium.io/v2 Capabilities check (the #2988/#3102 idiom) so
 the chart still installs on CRD-less clusters (kind CI).
 */ -}}
-{{- if and .Values.newapi.enabled .Values.networkPolicy.enabled .Values.networkPolicy.ingress.allowGatewayEntity (.Capabilities.APIVersions.Has "cilium.io/v2") }}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.newapi.enabled .Values.networkPolicy.enabled .Values.networkPolicy.ingress.allowGatewayEntity (.Capabilities.APIVersions.Has "cilium.io/v2") }}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:

--- a/platform/newapi/chart/templates/cnpg-cluster.yaml
+++ b/platform/newapi/chart/templates/cnpg-cluster.yaml
@@ -50,7 +50,7 @@ Without the gate, a cold install fails with "no matches for kind
 Cluster". Same pattern the bp-external-dns chart uses (issue #190) and
 the platform/powerdns/chart/templates/cnpg-cluster.yaml mirror.
 */}}
-{{- if .Values.cnpg.enabled -}}
+{{- if and (eq (include "bp-newapi.renderSeams" .) "true") .Values.cnpg.enabled -}}
 {{- $clusterName := printf "%s-newapi-pg" (include "bp-newapi.fullname" .) -}}
 {{- $dsnSecretName := default (printf "%s-newapi-db-dsn" (include "bp-newapi.fullname" .)) .Values.cnpg.dsnSecretName -}}
 {{- $database := .Values.cnpg.database | default "newapi" -}}

--- a/platform/newapi/chart/templates/configmap.yaml
+++ b/platform/newapi/chart/templates/configmap.yaml
@@ -1,4 +1,9 @@
 {{- include "bp-newapi.assertChannelAttestation" . -}}
+{{- /* #3831: the app config ConfigMap is consumed by the Deployment, so it
+   renders with the app (placement.role all|vcluster-app); under host-seams it
+   is suppressed (no Pod to consume it). assertChannelAttestation above stays a
+   render-time guard under every role. */ -}}
+{{- if eq (include "bp-newapi.renderApp" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -76,3 +81,4 @@ data:
         owner: {{ .attestation.owner | quote }}
         {{- end }}
 {{- end }}
+{{- end }}{{- /* #3831 renderApp wrapper */}}

--- a/platform/newapi/chart/templates/credentials-secret.yaml
+++ b/platform/newapi/chart/templates/credentials-secret.yaml
@@ -25,7 +25,10 @@ autoProvision=true AND existingSecret is empty.
 helm.sh/resource-policy: keep so a `helm uninstall` + reinstall recovers
 the same bytes (otherwise an upgrade would silently rotate the keys).
 */}}
-{{- if and .Values.credentials.autoProvision (not .Values.credentials.existingSecret) -}}
+{{- /* #3831: SESSION_SECRET/CRYPTO_SECRET is a chart-generated random Secret the
+   Pod reads — it renders WITH the app (placement.role all|vcluster-app), never
+   host-side (a host copy would diverge from the in-vCluster random bytes). */ -}}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.credentials.autoProvision (not .Values.credentials.existingSecret) -}}
 {{- $secretName := default (printf "%s-app-creds" (include "bp-newapi.fullname" .)) .Values.credentials.autoSecretName -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
 {{- $sessionSecret := "" -}}

--- a/platform/newapi/chart/templates/database-secret-sync-job.yaml
+++ b/platform/newapi/chart/templates/database-secret-sync-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cnpg.enabled }}
+{{- if and (eq (include "bp-newapi.renderSeams" .) "true") .Values.cnpg.enabled }}
 {{- /*
 Helm post-install/post-upgrade Job that composes the canonical SQL_DSN
 string from the CNPG-emitted `<cluster>-app` Secret (which holds the

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -49,7 +49,11 @@ the configmap mirrors this gate.
 {{- if and (not $effTokenSigningKeySecret) .Values.sandboxTokenSigningKey.autoProvision -}}
 {{- $effTokenSigningKeySecret = default (printf "%s-token-signing-key" (include "bp-newapi.fullname" .)) .Values.sandboxTokenSigningKey.autoSecretName -}}
 {{- end -}}
-{{- $deployReady := and .Values.newapi.enabled $effDbSecret $effCredsSecret -}}
+{{- /* #3831: the app Deployment renders ONLY under placement.role all|vcluster-app
+   (the seams + CNPG render host-side under host-seams). In vcluster-app the slot
+   suppresses cnpg.enabled and wires database.existingSecret to the mirrored DSN
+   Secret, so $effDbSecret still resolves non-empty above. */ -}}
+{{- $deployReady := and (eq (include "bp-newapi.renderApp" .) "true") .Values.newapi.enabled $effDbSecret $effCredsSecret -}}
 {{- if and $kcMode (not $kcConfigured) -}}
 {{- $deployReady = false -}}
 {{- end -}}
@@ -119,8 +123,16 @@ spec:
         an external DB via database.existingSecret populate it up-front, so
         the gate passes immediately). databaseDsnGate.enabled=false opts out.
       */}}
+      {{- /* #3831: gate on cnpg.enabled OR an explicit database.existingSecret.
+         Pre-#3831 the SQLite-fallback gate only fired for the chart-owned CNPG
+         DSN; under placement.role=vcluster-app cnpg.enabled is false but the
+         Pod still reads a (host-rendered, mirrored-in) DSN Secret whose SQL_DSN
+         starts empty until the host db-dsn-sync Job PATCHes it — so the same
+         silent-SQLite-fallback race applies. Firing the gate whenever
+         $effDbSecret is set keeps NewAPI from booting on ephemeral SQLite in
+         the vCluster too. */ -}}
       {{- $dsnGate := .Values.databaseDsnGate | default dict -}}
-      {{- $dsnGateOn := and (default true $dsnGate.enabled) .Values.cnpg.enabled -}}
+      {{- $dsnGateOn := and (default true $dsnGate.enabled) (or .Values.cnpg.enabled $effDbSecret) -}}
       {{- /*
         #3374 (2026-06-18) — sandbox-bridge as a NATIVE sidecar (initContainer
         with restartPolicy:Always), so the zero-click bare-URL landing page is

--- a/platform/newapi/chart/templates/external-secret.yaml
+++ b/platform/newapi/chart/templates/external-secret.yaml
@@ -28,7 +28,7 @@ pattern the bp-external-dns chart uses (issue #190).
 */ -}}
 {{- $ci := .Values.catalystIntegration | default dict -}}
 {{- $es := $ci.externalSecret | default dict -}}
-{{- if and $ci.enabled $es.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") -}}
+{{- if and (eq (include "bp-newapi.renderSeams" .) "true") $ci.enabled $es.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") -}}
 {{- $store := $es.secretStoreRef | default dict -}}
 {{- $remote := $es.remoteRef | default dict -}}
 {{- $secretName := $ci.existingSecret | default "catalyst-newapi-admin-token" -}}

--- a/platform/newapi/chart/templates/httproute.yaml
+++ b/platform/newapi/chart/templates/httproute.yaml
@@ -29,7 +29,7 @@ Per docs/INVIOLABLE-PRINCIPLES.md #4 every operationally-meaningful
 value (hostname, parentRef name/namespace/sectionName, backend port) is
 operator-overridable via values.yaml.
 */ -}}
-{{- if and .Values.newapi.enabled .Values.ingress.httpRoute .Values.ingress.httpRoute.enabled -}}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.newapi.enabled .Values.ingress.httpRoute .Values.ingress.httpRoute.enabled -}}
 {{- $host := .Values.ingress.httpRoute.host -}}
 {{- if and (not $host) .Values.sovereignFQDN -}}
 {{- $host = printf "newapi.%s" .Values.sovereignFQDN -}}

--- a/platform/newapi/chart/templates/ingress.yaml
+++ b/platform/newapi/chart/templates/ingress.yaml
@@ -14,7 +14,7 @@ gap as "no Ingress object materialised" — caught by the bootstrap-kit
 smoke test, not by render-time fail.
 */ -}}
 {{- /* Wave 5.81 (#2412): adminHost dropped — ops-staff admin via Catalyst BSS console only. */ -}}
-{{- if and .Values.newapi.enabled .Values.ingress.enabled .Values.ingress.host }}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.newapi.enabled .Values.ingress.enabled .Values.ingress.host }}
 {{- $fullName := include "bp-newapi.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $apiHost := .Values.ingress.host -}}

--- a/platform/newapi/chart/templates/keycloak-client-secret.yaml
+++ b/platform/newapi/chart/templates/keycloak-client-secret.yaml
@@ -88,7 +88,13 @@ OIDC client secret and the IdP-side wiring drifts).
 */}}
 {{- $kcMode := eq .Values.auth.adminUI.mode "keycloak" -}}
 {{- $secretName := .Values.auth.adminUI.keycloak.existingSecret -}}
-{{- if and $kcMode $secretName -}}
+{{- /* #3831: the newapi-oidc placeholder renders with the SEAMS (all|host-seams)
+   alongside its companion oidc-sync ExternalSecret (which Merge'es the live KC
+   client_secret in). Under vcluster-app it is suppressed: the host-rendered,
+   live-secret-bearing newapi-oidc is delivered into the vCluster by the
+   bp-mgmt-vcluster `newapi/*` from-host secret mirror, so a second in-vCluster
+   placeholder would only race the syncer for ownership of the same name. */ -}}
+{{- if and (eq (include "bp-newapi.renderSeams" .) "true") $kcMode $secretName -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
 {{- $clientSecret := "" -}}
 {{- if and $existing $existing.data (index $existing.data "OIDC_CLIENT_SECRET") -}}

--- a/platform/newapi/chart/templates/networkpolicy.yaml
+++ b/platform/newapi/chart/templates/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.newapi.enabled .Values.networkPolicy.enabled }}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.newapi.enabled .Values.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/platform/newapi/chart/templates/sandbox-token-signing-key-secret.yaml
+++ b/platform/newapi/chart/templates/sandbox-token-signing-key-secret.yaml
@@ -37,7 +37,9 @@ helm.sh/resource-policy: keep so a `helm uninstall` + reinstall
 recovers the same bytes (otherwise an upgrade silently invalidates
 every per-Sandbox token across the Sovereign).
 */}}
-{{- if and .Values.sandboxTokenSigningKey.autoProvision (not .Values.sandboxTokenSigningKey.existingSecret) -}}
+{{- /* #3831: the sandbox-bridge token-signing key is consumed by the bridge
+   sidecar in the Deployment — renders WITH the app (all|vcluster-app). */ -}}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.sandboxTokenSigningKey.autoProvision (not .Values.sandboxTokenSigningKey.existingSecret) -}}
 {{- $secretName := default (printf "%s-token-signing-key" (include "bp-newapi.fullname" .)) .Values.sandboxTokenSigningKey.autoSecretName -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
 {{- $signingKey := "" -}}

--- a/platform/newapi/chart/templates/service.yaml
+++ b/platform/newapi/chart/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.newapi.enabled }}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.newapi.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/platform/newapi/chart/templates/serviceaccount.yaml
+++ b/platform/newapi/chart/templates/serviceaccount.yaml
@@ -1,4 +1,6 @@
-{{- if .Values.serviceAccount.create }}
+{{- /* #3831: the workload ServiceAccount is for the app Deployment; the seam
+   Jobs render their OWN dedicated SAs. Gate with the app role. */ -}}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/platform/newapi/chart/templates/servicemonitor.yaml
+++ b/platform/newapi/chart/templates/servicemonitor.yaml
@@ -17,7 +17,7 @@ reached Phase 2 yet. The `.Capabilities.APIVersions.Has` guard also
 skip-renders on a cluster where the CRD has not yet reconciled — pattern
 matches platform/harbor/chart/templates/servicemonitor.yaml.
 */}}
-{{- if and .Values.newapi.enabled .Values.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") .Values.newapi.enabled .Values.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/platform/newapi/chart/templates/sso-app-registration.yaml
+++ b/platform/newapi/chart/templates/sso-app-registration.yaml
@@ -29,7 +29,7 @@ data.realm = "sovereign": the watcher only requires the realm to EXIST
    hardening disables wildcard redirectUris). providerSlug == sso.bootstrap.providerSlug. */ -}}
 {{- /* #3648 — standard sso.bootstrap.providerSlug first, then legacy adminSeed. */ -}}
 {{- $providerSlug := ((.Values.sso | default dict).bootstrap | default dict).providerSlug | default (.Values.adminSeed | default dict).providerSlug | default "sovereign" -}}
-{{- if and .Values.newapi.enabled $kcMode $sync.enabled .Values.sovereignFQDN }}
+{{- if and (eq (include "bp-newapi.renderSeams" .) "true") .Values.newapi.enabled $kcMode $sync.enabled .Values.sovereignFQDN }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/platform/newapi/chart/templates/sso-externalsecret.yaml
+++ b/platform/newapi/chart/templates/sso-externalsecret.yaml
@@ -19,7 +19,7 @@ creationPolicy: Merge — NOT Owner — by design:
 {{- $kcMode := eq .Values.auth.adminUI.mode "keycloak" -}}
 {{- $sync := .Values.auth.adminUI.keycloak.ssoBridgeSync -}}
 {{- $secretName := .Values.auth.adminUI.keycloak.existingSecret -}}
-{{- if and .Values.newapi.enabled $kcMode $sync.enabled $secretName (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") }}
+{{- if and (eq (include "bp-newapi.renderSeams" .) "true") .Values.newapi.enabled $kcMode $sync.enabled $secretName (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -31,6 +31,22 @@ catalystBlueprint:
 # overlays (set to `[]` for clusters that pull from public repos only).
 imagePullSecrets:
   - name: ghcr-pull
+# ─── Placement role (#3831) ──────────────────────────────────────────────
+# Splits the chart's render across two cooperating HelmReleases when newapi
+# is re-homed INTO the mgmt vCluster (NorthStar #1: every app in a vCluster)
+# while its CNPG-owner seams must stay HOST-side. See _helpers.tpl
+# bp-newapi.renderSeams / bp-newapi.renderApp for the full contract.
+#   all          (DEFAULT) — render everything (standalone / host-placed; a
+#                no-op gate, fully backward-compatible).
+#   host-seams   — render ONLY the host-reconciled seams (CNPG Cluster +
+#                DSN-sync Job + admin-sso-seed Job/Cron + AppRegistration
+#                ConfigMap + both ExternalSecrets). No app workload.
+#   vcluster-app — render ONLY the app (Deployment + Service + HTTPRoute +
+#                Application CR). No seams; the DSN Secret + CNPG Service are
+#                delivered into the vCluster by the bp-mgmt-vcluster
+#                sync.fromHost.secrets `newapi/*` mirror + replicateServices.
+placement:
+  role: all
 # ─── NewAPI application ──────────────────────────────────────────────────
 newapi:
   enabled: true

--- a/platform/postgres/blueprint.yaml
+++ b/platform/postgres/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-4-1-data-services
     catalyst.openova.io/companion: bp-cnpg
 spec:
-  version: 0.2.3
+  version: 0.2.4
   card:
     title: PostgreSQL
     summary: |

--- a/platform/postgres/chart/Chart.yaml
+++ b/platform/postgres/chart/Chart.yaml
@@ -1,5 +1,30 @@
 apiVersion: v2
 name: bp-postgres
+# 0.2.4 — #3878 (companion to #3876, the cycle-1 vc-mgmt DB-secret deadlock):
+#   add the optional `reflect.mangledTarget` knob. When a binding declares it,
+#   the chart emits a SECOND hub connection Secret named with the vCluster
+#   syncer-mangled object name `<secretName>-x-<vclusterNamespace>-x-<vcluster>`
+#   (default vcluster `mgmt-vcluster`) and auto-pushes it (emberstack reflector
+#   annotations) into the vCluster's host namespace (default `mgmt`). That
+#   mangled object is EXACTLY the host Secret an in-vc-mgmt pod mounts in
+#   single-namespace mode (`MountVolume.SetUp … secret
+#   "<secretName>-x-<ns>-x-mgmt-vcluster" not found`). WHY: #3642 re-homed
+#   keycloak/gitea/harbor/grafana INTO vc-mgmt; their pod-mounted DB Secrets
+#   reached the in-vc pod ONLY via the bp-mgmt-vcluster `sync.fromHost.secrets`
+#   namespace wildcards, which #3876 REMOVED because on vcluster 0.23.0 a Secret
+#   that is BOTH fromHost-imported AND pod-mounted (so the toHost necessary-sync
+#   ALSO claims it) makes the from-host/to-host syncers fight → context deadline
+#   exceeded → app `Init:0/2` 20m+. With #3876 alone the DB Secret reaches the
+#   pod NOWHERE. This mangled-name reflect is the native delivery #3876's RCA
+#   promised: the DB Secret is NEVER fromHost-imported (no syncer contention →
+#   no deadlock) yet the live-password object the kubelet mounts is materialised
+#   by the host reflector (no missing credential on a fresh prov). It is the
+#   durable form of the hw167 hand-fix (validation agent created the keycloak DB
+#   Secret natively in-vCluster). The mangled copy carries byte-identical data
+#   to the consumer-namespace copy ($data assembled once in role-secrets.yaml).
+#   Bindings WITHOUT mangledTarget render byte-identical to 0.2.3 — additive.
+#   tests/postgres-render.sh Case 13 added. Lockstep: 16a (keycloak/gitea/
+#   harbor) + 16c (grafana) HR pins → 0.2.4. Refs #3876 #3374 #3737.
 # 0.2.3 — #3375 / #3768 follow-up (ONE canonical placement vocabulary on the
 #   wire): the hw158 #3375 browser-walk caught the bp-postgres New-instance
 #   picker serving the BANNED legacy dialect — `placementSchema.modes`
@@ -87,7 +112,7 @@ name: bp-postgres
 #   regions so it admits under BOTH the pre-#3370 CRD (hard-required) and the
 #   #3370 CRD (CEL-waived) — breaks the live upgrade-rollback deadlock that
 #   blocked keycloak->gitea->catalyst-platform on hw130.
-version: 0.2.3
+version: 0.2.4
 appVersion: "0.1.2"
 description: |
   Catalyst-authored data-instance Blueprint for a shareable, reusable

--- a/platform/postgres/chart/templates/role-secrets.yaml
+++ b/platform/postgres/chart/templates/role-secrets.yaml
@@ -120,6 +120,23 @@ identical to pre-0.2.2. */ -}}
 {{- $db := . }}
 {{- if and $db.reflect $db.reflect.secretName }}
 {{- $password := (get $owners $db.owner).password }}
+{{- /* Build the connection-contract stringData ONCE so every hub copy of
+this binding (the consumer-namespace copy below AND the optional vc-mgmt
+mangled-name copy in Pass 4) carries byte-identical data — same minted
+password, same host, same extraData/host/alias keys. A divergent copy would
+hand an in-vCluster pod a different password than the host CNPG role. */ -}}
+{{- $data := dict
+      "username" $db.owner
+      "user" $db.owner
+      "password" $password
+      "dbname" $db.name
+      "host" $consumerHost
+      "port" "5432"
+      "uri" (printf "postgresql://%s:%s@%s:5432/%s" $db.owner $password $consumerHost $db.name) }}
+{{- range $k, $v := $db.reflect.extraData }}{{ $_ := set $data $k $v }}{{ end }}
+{{- range $hk := $db.reflect.hostKeys }}{{ $_ := set $data $hk $consumerHost }}{{ end }}
+{{- range $hpk := $db.reflect.hostPortKeys }}{{ $_ := set $data $hpk (printf "%s:5432" $consumerHost) }}{{ end }}
+{{- range $alias := $db.reflect.passwordAliases }}{{ $_ := set $data $alias $password }}{{ end }}
 ---
 # Hub connection Secret — lives in the release namespace (always exists;
 # the #3283 anti-deadlock source-side pattern) and auto-pushes a
@@ -140,37 +157,65 @@ metadata:
     reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
     reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: {{ join "," $db.reflect.namespaces | quote }}
 stringData:
-  username: {{ $db.owner | quote }}
-  user: {{ $db.owner | quote }}
-  password: {{ $password | quote }}
-  dbname: {{ $db.name | quote }}
   # $consumerHost = `<instance>-rw` (singleton) or the ClusterMesh-global
   # `<instance>-mesh-rw` write alias (active-hot-standby) so the host
   # resolves in BOTH regions — see the $consumerHost note above (#3629).
-  host: {{ $consumerHost | quote }}
-  port: "5432"
-  # CNPG-app-Secret-parity connection string (0.1.5) — URI-style
-  # consumers (powerdns-admin SQLALCHEMY_DATABASE_URI) read this key
-  # verbatim. Password is chart-minted randAlphaNum (URL-safe).
-  uri: "postgresql://{{ $db.owner }}:{{ $password }}@{{ $consumerHost }}:5432/{{ $db.name }}"
-{{- range $k, $v := $db.reflect.extraData }}
+  # The connection-contract keys (username/user/password/dbname/host/port/uri
+  # + any extraData/hostKeys/hostPortKeys/passwordAliases) are pre-assembled
+  # in $data above so this copy and the optional vc-mgmt mangled copy
+  # (Pass 4) never drift.
+  {{- range $k, $v := $data }}
   {{ $k }}: {{ $v | quote }}
-{{- end }}
-{{- /* Topology-aware host injection (#3629). An env-style consumer often
-needs the DB host under its OWN variable name (grafana's GF_DATABASE_HOST),
-which previously meant a STATIC `<instance>-rw` literal in reflect.extraData
-— region-local, so it broke that consumer in the replica region. Declaring
-the key under reflect.hostKeys (host only) / reflect.hostPortKeys (host:5432)
-renders the topology-aware $consumerHost instead, so the consumer follows the
-singleton vs active-hot-standby switch automatically. */ -}}
-{{- range $hk := $db.reflect.hostKeys }}
-  {{ $hk }}: {{ $consumerHost | quote }}
-{{- end }}
-{{- range $hpk := $db.reflect.hostPortKeys }}
-  {{ $hpk }}: {{ printf "%s:5432" $consumerHost | quote }}
-{{- end }}
-{{- range $alias := $db.reflect.passwordAliases }}
-  {{ $alias }}: {{ $password | quote }}
+  {{- end }}
+{{- /* Pass 4 — vc-mgmt mangled-name delivery (#3878, companion to #3876).
+When a binding declares `reflect.mangledTarget`, emit a SECOND hub Secret
+named with the vCluster syncer-mangled object name
+`<secretName>-x-<vclusterNamespace>-x-<vcluster>` (default vcluster
+`mgmt-vcluster`) and auto-push it into the host namespace the vCluster runs
+in (`hostNamespace`, default `mgmt`). That mangled object is EXACTLY the host
+secret the in-vc-mgmt pod mounts in single-namespace mode (the failure string
+`MountVolume.SetUp … secret "<secretName>-x-<ns>-x-mgmt-vcluster" not found`).
+
+This is the native, host-reflector-driven delivery #3876's RCA comment
+promised: the pod-mounted DB Secret is NEVER `sync.fromHost.secrets`-imported
+(no from-host syncer claim → no from-host↔to-host ownership fight → no
+`context deadline exceeded` deadlock), yet the live-password object the
+kubelet mounts is materialised by this reflector copy → no missing credential
+on a fresh prov. The reflector preserves the source name on the auto-push, so
+the source Secret MUST itself be named the mangled string — hence a dedicated
+copy rather than an extra namespace on the plain hub Secret. Data is
+byte-identical to the plain hub copy ($data, assembled once above). */ -}}
+{{- if $db.reflect.mangledTarget }}
+{{- $mt := $db.reflect.mangledTarget }}
+{{- $vc := default "mgmt-vcluster" $mt.vcluster }}
+{{- $vcNs := required "reflect.mangledTarget.vclusterNamespace is required" $mt.vclusterNamespace }}
+{{- $hostNs := default "mgmt" $mt.hostNamespace }}
+{{- $mangledName := printf "%s-x-%s-x-%s" $db.reflect.secretName $vcNs $vc }}
+---
+# vc-mgmt mangled-name hub Secret (#3878). Auto-pushed into the vCluster's
+# host namespace as the exact object the in-vc-mgmt pod mounts — delivering
+# the DB credential natively WITHOUT a `sync.fromHost.secrets` mirror of the
+# pod-mounted Secret (which deadlocks on vcluster 0.23.0 per #3876).
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ $mangledName | quote }}
+  namespace: {{ $ns | quote }}
+  labels:
+    {{- include "bp-postgres.labels" $ctx | nindent 4 }}
+    catalyst.openova.io/binding-secret: {{ $db.name | quote }}
+    catalyst.openova.io/vcluster-mangled-target: {{ $hostNs | quote }}
+  annotations:
+    helm.sh/resource-policy: keep
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: {{ $hostNs | quote }}
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: {{ $hostNs | quote }}
+stringData:
+  {{- range $k, $v := $data }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/platform/postgres/chart/tests/postgres-render.sh
+++ b/platform/postgres/chart/tests/postgres-render.sh
@@ -594,4 +594,51 @@ if echo "$default_line" | grep -qE '\bsingle-region\b'; then
   fail "#3375 REGRESSION: placementSchema.default is the banned 'single-region' (use canonical 'singleton')"
 fi
 
-echo "[render] PASS — bp-postgres render gate green (reuse proof: 1 Cluster, 2 Databases, 2 roles, 2 Secrets; master gate OFF → empty; 3-instance shapes locked; #3370 Application-CR self-registration locked; #3375 underscore-owner role-Secret sanitization locked; #3375/#3768 ONE canonical placement vocabulary locked)"
+# ── Case 13: #3878 — reflect.mangledTarget vc-mgmt native DB-secret delivery ─
+# Companion to #3876. A binding declaring reflect.mangledTarget emits a SECOND
+# hub Secret named `<secretName>-x-<vclusterNamespace>-x-<vcluster>` (default
+# vcluster `mgmt-vcluster`) that auto-pushes (reflection-auto-namespaces) into
+# the vCluster's host ns (default `mgmt`) — the exact object an in-vc-mgmt pod
+# mounts in single-namespace mode. Its data MUST be byte-identical to the plain
+# consumer-namespace copy. A binding WITHOUT mangledTarget emits NO mangled copy
+# (additive — pre-0.2.4 bindings render unchanged).
+echo "[render] Case 13: #3878 — reflect.mangledTarget → mangled vc-mgmt copy w/ identical data; no-mangle binding unchanged"
+cat > "$TMP/mangled.values.yaml" <<'YAML'
+enabled: true
+instance: { name: shared-pg, namespace: shared-data }
+topology: { mode: singleton, instances: 1 }
+databases:
+  - name: keycloak
+    owner: keycloak
+    consumer: { blueprint: bp-keycloak, mode: shared }
+    reflect:
+      secretName: keycloak-database-secret
+      namespaces: [keycloak]
+      mangledTarget: { vclusterNamespace: keycloak }
+  - name: gitea
+    owner: gitea
+    consumer: { blueprint: bp-gitea, mode: shared }
+    reflect: { secretName: gitea-database-secret, namespaces: [gitea] }
+YAML
+helm template shared-pg . -f "$TMP/mangled.values.yaml" --namespace shared-data \
+  --api-versions postgresql.cnpg.io/v1 \
+  --show-only templates/role-secrets.yaml > "$TMP/mangled.yaml" 2> "$TMP/mangled.err" || {
+  cat "$TMP/mangled.err" >&2; fail "mangledTarget render errored"; }
+# (a) the mangled copy exists with the canonical syncer name.
+grep -qE '^  name: "keycloak-database-secret-x-keycloak-x-mgmt-vcluster"$' "$TMP/mangled.yaml" \
+  || fail "#3878: keycloak mangled hub Secret 'keycloak-database-secret-x-keycloak-x-mgmt-vcluster' not rendered"
+# (b) the mangled copy auto-pushes into the vc-mgmt host ns 'mgmt'.
+awk '/name: "keycloak-database-secret-x-keycloak-x-mgmt-vcluster"/{f=1} f&&/reflection-auto-namespaces: "mgmt"/{print "OK"; exit}' "$TMP/mangled.yaml" | grep -q OK \
+  || fail "#3878: mangled keycloak Secret must reflection-auto-namespaces into 'mgmt'"
+# (c) data parity — the mangled copy carries the SAME password as the plain copy
+#     (so the in-vc pod gets a credential that matches the host CNPG role).
+plain_pw=$(awk '/^  name: "keycloak-database-secret"$/{f=1} f&&/^  password:/{print $2; exit}' "$TMP/mangled.yaml")
+mangled_pw=$(awk '/name: "keycloak-database-secret-x-keycloak-x-mgmt-vcluster"/{f=1} f&&/^  password:/{print $2; exit}' "$TMP/mangled.yaml")
+[ -n "$plain_pw" ] || fail "#3878: plain keycloak hub Secret password not found"
+[ "$plain_pw" = "$mangled_pw" ] || fail "#3878: mangled copy password ($mangled_pw) MUST equal the plain copy ($plain_pw) — a drift hands the pod a wrong credential"
+# (d) the no-mangle binding (gitea here) emits NO mangled copy — additive.
+if grep -qE 'gitea-database-secret-x-' "$TMP/mangled.yaml"; then
+  fail "#3878 REGRESSION: a binding WITHOUT reflect.mangledTarget must NOT emit a mangled copy"
+fi
+
+echo "[render] PASS — bp-postgres render gate green (reuse proof: 1 Cluster, 2 Databases, 2 roles, 2 Secrets; master gate OFF → empty; 3-instance shapes locked; #3370 Application-CR self-registration locked; #3375 underscore-owner role-Secret sanitization locked; #3375/#3768 ONE canonical placement vocabulary locked; #3878 reflect.mangledTarget vc-mgmt native DB-secret delivery locked)"

--- a/products/catalyst/console/tests/e2e/fixtures/mock-blueprints.yaml
+++ b/products/catalyst/console/tests/e2e/fixtures/mock-blueprints.yaml
@@ -55,8 +55,14 @@ blueprints:
       realm: sovereign
       silentLogin: true
     endpoints:
+      # Harbor's UI + API are served on the SAME host as the registry
+      # (registry.<fqdn>): the live bootstrap-kit overlay sets BOTH gateway.host
+      # AND externalURL to registry.${SOVEREIGN_FQDN}, and platform/harbor/
+      # blueprint.yaml renders BOTH endpoints from registry.{{.SovereignFQDN}}.
+      # The earlier harbor.<fqdn> value pointed at a host with NO HTTPRoute → the
+      # console launch-url 404'd. Keep this mock aligned with the live blueprint.
       - name: ui
-        hostnameTemplate: "harbor.{{.SovereignFQDN}}"
+        hostnameTemplate: "registry.{{.SovereignFQDN}}"
         port: 443
         protocol: https
         tls: true

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -819,9 +819,26 @@ slots:
   # hostBridge:); the route + 2 ExternalSecrets + CNPG Cluster are HOST-rendered
   # so no loft.sh license is needed. The runtime edge gates on the vc-mgmt
   # Secret being Ready first.
+  # #3831 (2026-06-19): newapi is the CNPG-OWNER mgmt-vCluster app. The chart now
+  # render-splits (placement.role): slot 80 runs the app workload INSIDE vc-mgmt
+  # (vcluster-app), slot 80a renders the CNPG-owner seams host-side (host-seams).
+  # The app HR gains a bp-newapi-host-seams edge so the host CNPG Cluster + the
+  # database-secret-sync Job PATCH the DSN before the app's SQL_DSN gate waits.
   - slot: 80
     name: bp-newapi
-    depends_on: [bp-openbao, bp-keycloak, bp-cnpg, bp-mgmt-vcluster]
+    depends_on: [bp-openbao, bp-keycloak, bp-cnpg, bp-mgmt-vcluster, bp-newapi-host-seams]
+    wave: present
+
+  # ---- Slot 80a — bp-newapi-host-seams (#3831). The HOST-reconciled
+  # CNPG-owner seams for newapi: the CNPG Cluster + DSN-sync Job +
+  # admin-sso-seed Job/CronJob + newapi-admin AppRegistration ConfigMap + both
+  # ExternalSecrets, all in the host `newapi` ns. Gates on the host operators
+  # that reconcile them: bp-cnpg (Cluster + <cluster>-app), bp-external-secrets
+  # (both ExternalSecrets), bp-openbao + bp-keycloak (the admin-seed OIDC +
+  # AppRegistration realm), and bp-sso-bridge (the AppRegistration watcher).
+  - slot: 80a
+    name: bp-newapi-host-seams
+    depends_on: [bp-cnpg, bp-external-secrets, bp-openbao, bp-keycloak, bp-sso-bridge]
     wave: present
 
   # ---- Slot 95 — bp-stalwart-sovereign REMOVED 2026-05-05.


### PR DESCRIPTION
## Refs #3831, #3858

Breaks the **circular install deadlock** that leaves `bp-newapi-host-seams` failing forever and `newapi.<fqdn>` → HTTP 500 on a fresh zero-touch prov. Grounded live on **hw171** (dep `3963e9267c10a90d`).

> **Base**: this PR is stacked on `fix/3878-mgmt-vcluster-native-dbsecret` (the #3831 placement.role render-split). Merge that first, or retarget to `main` once it lands.

### Grounded root cause (evidence)

The #3831 split renders `bp-newapi` in three roles (`all` / `host-seams` / `vcluster-app`). The `admin-sso-seed` Job + `admin-promote` CronJob were left rendering **host-side** (`renderSeams`), but:

- `seed.sh` / `promote.sh` both call `wait_for_users_table` → polls `public.users`, a table created **only** by the app's GORM AutoMigrate, which runs **inside vc-mgmt** (`vcluster-app`).
- The host side never migrates that schema → the `post-install` hook hits its `activeDeadlineSeconds: 420` → `DeadlineExceeded` → the `host-seams` HR install **fails** → uninstall remediation → retry (6 failures observed).
- The `vcluster-app` HR `dependsOn: bp-newapi-host-seams`, so the app can **never** install to migrate the schema. **Circular deadlock.**
- The host-side Job also can't satisfy its `reload_newapi_provider` Deployment-patch RBAC — the Deployment only exists in `vcluster-app`.

Live evidence on hw171:
```
flux-system  bp-newapi-host-seams   Unknown  Running 'install' action ... (6 install failures)
  └ Released=False: job newapi-bp-newapi-admin-seed failed: DeadlineExceeded
mgmt         bp-newapi              False    dependency 'bp-newapi-host-seams' is not ready
```
```
$ psql -d newapi -c "SELECT to_regclass('public.users'); SELECT count(*) FROM information_schema.tables WHERE table_schema='public';"
        (null)
0                       # ← schema never migrated
```
```
[admin-seed] target=newapi-bp-newapi-newapi-pg-rw:5432/newapi user=newapi
[admin-seed] waiting for newapi schema migration (1/60)
[admin-seed] waiting for newapi schema migration (2/60)   # ← waits forever
```

### Durable fix (chart defect)

Render the `admin-sso-seed` Job/CronJob with the **app** (`renderApp`), matching the existing `channel-seed-job` precedent (also schema-dependent, already `renderApp`):

- Post-install hook fires **after** the app Deployment installs + migrates → the `public.users` poll resolves.
- The Deployment-patch RBAC now targets a Deployment that exists.
- The mounted CNPG `-app` + OIDC Secrets are mirrored host→vCluster by `bp-mgmt-vcluster` `sync.fromHost.secrets "newapi/*"` (#3879); the CNPG `-rw`/`-ro` Services by `sync.fromHost.mappings`.
- Dropped `cnpg.enabled` from the gate (vcluster-app ships `cnpg.enabled=false`; the Job needs only the mirrored `-app` Secret, not the Cluster CR).
- `role=all` (DEFAULT) renders both as before → **standalone / host-placed installs byte-identical**.

Lockstep: chart `1.4.114` + slot 80/80a + `blueprint.yaml`.

### Verification (template-level)

```
helm template ... --set placement.role=host-seams   → admin-seed/promote ABSENT (only db-dsn-sync remains)
helm template ... --set placement.role=vcluster-app → admin-seed Job + admin-promote CronJob PRESENT
helm template ... (role=all default)                → both PRESENT + Deployment (unchanged)
helm lint + 4 chart render tests → PASS
```

### Also: harbor mock-fixture alignment (Refs #3858)

While investigating the companion harbor 404: harbor is **healthy** and served correctly at its canonical hostname `registry.<fqdn>` (live hw171: `registry.hw171.omantel.biz/` → 200, `/harbor/projects` → 200, `/v2/` → 401). `harbor.<fqdn>` → 404 is **by design** — the blueprint renders both endpoints from `registry.{{.SovereignFQDN}}` (no `harbor.` HTTPRoute exists, and shouldn't). The only stale residue was the console e2e mock fixture (`mock-blueprints.yaml`) still carrying `harbor.{{.SovereignFQDN}}` for the `ui` endpoint — aligned to `registry.` to prevent the wrong-URL confusion that recurs in walks. **No harbor chart change needed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)