### PR TITLE
fix(console): catalog create no longer 500s on dotted environmentRef + topology <select> offers all 4 canonical modes

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -993,7 +993,14 @@ func newApplicationUnstructured(req applicationInstallRequest) *unstructured.Uns
 		placementValue = pl
 	}
 	spec := map[string]any{
-		"environmentRef": req.EnvironmentRef,
+		// #3922 — the CR's spec.environmentRef is RFC-1123-label-constrained
+		// (^[a-z][a-z0-9-]{2,63}$, no dots). On a chroot/operator install the
+		// env ref defaults to the Sovereign FQDN (e.g. "hw171.omantel.biz-prod"),
+		// which the apiserver rejected with HTTP 500. Slug it the same way the
+		// namespace is slugged (preserving whatever Environment the caller
+		// asked for, just made pattern-safe); the verbatim Org identity stays
+		// on the organization label + organizationRef.
+		"environmentRef": sanitizeEnvironmentRef(req.EnvironmentRef),
 		"blueprintRef": map[string]any{
 			"name":    req.BlueprintRef.Name,
 			"version": req.BlueprintRef.Version,

--- a/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go
@@ -2158,7 +2158,12 @@ func newApplicationCRFromSeed(seed instances.ApplicationSeed) *unstructured.Unst
 		placementValue = pl
 	}
 	spec := map[string]interface{}{
-		"environmentRef": seed.Namespace + "-prod",
+		// #3922 — slug the env ref so a dotted Sovereign FQDN (seed.Namespace
+		// is the Org, often an FQDN like "hw171.omantel.biz") does not produce
+		// a dotted spec.environmentRef the apiserver rejects against the CRD
+		// pattern ^[a-z][a-z0-9-]{2,63}$ (HTTP 500). environmentRefForOrg
+		// appends the canonical "-prod" suffix and slugs the whole value.
+		"environmentRef": environmentRefForOrg(seed.Namespace),
 		"blueprintRef": map[string]interface{}{
 			"name": seed.Blueprint,
 		},

--- a/products/catalyst/bootstrap/api/internal/handler/namespace_ensure.go
+++ b/products/catalyst/bootstrap/api/internal/handler/namespace_ensure.go
@@ -82,6 +82,51 @@ func orgNamespace(ref string) string {
 	return out
 }
 
+// sanitizeEnvironmentRef maps an Environment reference (e.g. "<org>-prod",
+// often derived from a dotted Sovereign FQDN) to a value that satisfies the
+// Application CRD's spec.environmentRef pattern `^[a-z][a-z0-9-]{2,63}$`.
+//
+// Why this exists (#3922): the CRD constrains spec.environmentRef to the
+// RFC-1123 *label* pattern (no dots). On a chroot/operator-on-Sovereign
+// install there is no customer Organization, so both create paths derive the
+// env ref from the Sovereign FQDN (`<fqdn>-prod`, e.g.
+// "hw171.omantel.biz-prod"). Every FQDN carries dots, so the apiserver
+// rejected the create with HTTP 500:
+//
+//	spec.environmentRef: Invalid value: "hw171.omantel.biz-prod":
+//	spec.environmentRef in body should match '^[a-z][a-z0-9-]{2,63}$'
+//
+// blocking ALL instance creation. #3830 slugged metadata.namespace through
+// orgNamespace() but left environmentRef dotted (the FQDN identity stays on
+// the catalyst.openova.io/organization label + organizationRef — the env ref
+// is a derived, pattern-constrained artifact, exactly like the namespace).
+// This helper closes that gap: it slugs the value through the same character
+// rules orgNamespace() uses (lowercase, dots→'-', collapse, trim), then caps
+// it at the CRD's 63-char ceiling so a long FQDN can never overflow the
+// pattern. An already-valid label (e.g. "acme-prod") round-trips unchanged.
+//
+//	sanitizeEnvironmentRef("hw171.omantel.biz-prod") → "hw171-omantel-biz-prod"
+//	sanitizeEnvironmentRef("acme-prod")              → "acme-prod"
+//
+// orgNamespace already implements exactly these character rules + the 63-char
+// cap + the empty-input fallback, so we delegate to it rather than duplicate
+// the slugging loop. (orgNamespace's "org" empty-fallback is also a valid
+// environmentRef, so the contract holds for pathological all-illegal input.)
+func sanitizeEnvironmentRef(ref string) string {
+	return orgNamespace(ref)
+}
+
+// environmentRefForOrg derives a CRD-pattern-safe spec.environmentRef from an
+// Organization reference by appending the canonical "-prod" Environment suffix
+// (one Org, one Env per chroot Sovereign) and slugging the whole thing. See
+// sanitizeEnvironmentRef for the #3922 motivation.
+//
+//	environmentRefForOrg("hw171.omantel.biz") → "hw171-omantel-biz-prod"
+//	environmentRefForOrg("acme")              → "acme-prod"
+func environmentRefForOrg(ref string) string {
+	return sanitizeEnvironmentRef(strings.TrimSpace(ref) + "-prod")
+}
+
 // ensureOrgNamespace creates the target Organization/Environment
 // namespace if it does not already exist, returning nil when the
 // namespace is present (created-or-verified).

--- a/products/catalyst/bootstrap/api/internal/handler/namespace_ensure_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/namespace_ensure_test.go
@@ -7,6 +7,7 @@ package handler
 
 import (
 	"context"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -186,5 +187,65 @@ func TestEnsureOrgNamespace_SlugsDottedFQDN(t *testing.T) {
 	// …and the raw dotted name was NEVER created.
 	if _, err := getNamespace(t, client, "hw165.omani.works"); !apierrors.IsNotFound(err) {
 		t.Fatalf("raw dotted namespace must not exist, got err=%v", err)
+	}
+}
+
+// ── #3922 — environmentRef must satisfy the Application CRD pattern ─────
+
+// applicationEnvironmentRefPattern is the EXACT pattern the Application CRD
+// (products/catalyst/chart/crds/application.yaml) applies to
+// spec.environmentRef. A dotted value (e.g. a Sovereign FQDN "<fqdn>-prod")
+// fails this server-side, surfacing as the HTTP 500 that blocked ALL instance
+// creation on hw171. We pin the literal here so the sanitizer's output is
+// asserted against the SAME rule the apiserver enforces.
+var applicationEnvironmentRefPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{2,63}$`)
+
+// TestEnvironmentRefForOrg_SlugsDottedFQDN — the headline #3922 contract: a
+// dotted Org FQDN yields a dash-joined, CRD-pattern-safe "<slug>-prod" env ref
+// (never the raw dotted "<fqdn>-prod" the apiserver 500s on).
+func TestEnvironmentRefForOrg_SlugsDottedFQDN(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"hw171.omantel.biz", "hw171-omantel-biz-prod"},
+		{"hw165.omani.works", "hw165-omani-works-prod"},
+		{"acme", "acme-prod"}, // bare slug + suffix, unchanged shape
+	}
+	for _, tc := range cases {
+		if got := environmentRefForOrg(tc.in); got != tc.want {
+			t.Fatalf("environmentRefForOrg(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestSanitizeEnvironmentRef_AlwaysMatchesCRDPattern asserts every output
+// satisfies the Application CRD's spec.environmentRef pattern — so the create
+// can never again 500 with "should match '^[a-z][a-z0-9-]{2,63}$'". Inputs are
+// deliberately abusive (the dotted FQDN that triggered #3922, uppercase, an
+// over-length FQDN, and an already-valid label that must round-trip).
+func TestSanitizeEnvironmentRef_AlwaysMatchesCRDPattern(t *testing.T) {
+	inputs := []string{
+		"hw171.omantel.biz-prod", // the exact value from the 500 on hw171
+		"hw165.omani.works-prod",
+		"acme-prod",                                 // already valid → round-trips
+		"HW171.Omantel.BIZ-prod",                    // uppercase folded
+		strings.Repeat("a", 70) + ".omani.works-prod", // > 63 chars pre-slug
+		"...___...-prod",                            // pathological
+	}
+	for _, in := range inputs {
+		got := sanitizeEnvironmentRef(in)
+		if !applicationEnvironmentRefPattern.MatchString(got) {
+			t.Fatalf("sanitizeEnvironmentRef(%q) = %q does NOT match the CRD pattern %s",
+				in, got, applicationEnvironmentRefPattern.String())
+		}
+	}
+	// An already-valid label round-trips byte-identically.
+	if got := sanitizeEnvironmentRef("acme-prod"); got != "acme-prod" {
+		t.Fatalf("sanitizeEnvironmentRef(\"acme-prod\") = %q, want unchanged acme-prod", got)
+	}
+	// environmentRefForOrg output also satisfies the CRD pattern (suffix path).
+	if got := environmentRefForOrg("hw171.omantel.biz"); !applicationEnvironmentRefPattern.MatchString(got) {
+		t.Fatalf("environmentRefForOrg output %q does NOT match the CRD pattern", got)
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/placement_3373_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/placement_3373_test.go
@@ -183,10 +183,12 @@ func TestReadTopology_ObjectFormMode(t *testing.T) {
 	}
 }
 
-// ── #3830 — dotted Org FQDN → slugged metadata.namespace on both CR
-// write paths. The CR must NEVER carry a dotted metadata.namespace (the
-// apiserver rejects it); the verbatim Org identity stays on the
-// organization label + environmentRef.
+// ── #3830 / #3922 — dotted Org FQDN → slugged metadata.namespace AND
+// slugged spec.environmentRef on both CR write paths. The CR must NEVER
+// carry a dotted metadata.namespace OR a dotted spec.environmentRef (the
+// apiserver rejects both: the env ref against the CRD pattern
+// ^[a-z][a-z0-9-]{2,63}$ → HTTP 500 that blocked ALL instance creation).
+// The verbatim Org identity stays on the organization label + organizationRef.
 
 func TestNewApplicationUnstructured_DottedOrgSlugsNamespace(t *testing.T) {
 	req := applicationInstallRequest{
@@ -204,9 +206,11 @@ func TestNewApplicationUnstructured_DottedOrgSlugsNamespace(t *testing.T) {
 	if org := obj.GetLabels()["catalyst.openova.io/organization"]; org != "hw165.omani.works" {
 		t.Fatalf("organization label = %q, want verbatim FQDN hw165.omani.works", org)
 	}
-	// … and on environmentRef (a Catalyst Environment ref, not a namespace).
-	if env, _, _ := unstructured.NestedString(obj.Object, "spec", "environmentRef"); env != "hw165.omani.works-prod" {
-		t.Fatalf("spec.environmentRef = %q, want verbatim hw165.omani.works-prod", env)
+	// … but spec.environmentRef MUST be the slugged, CRD-pattern-safe form
+	// (#3922): a dotted env ref makes the apiserver reject the create with
+	// HTTP 500 against ^[a-z][a-z0-9-]{2,63}$.
+	if env, _, _ := unstructured.NestedString(obj.Object, "spec", "environmentRef"); env != "hw165-omani-works-prod" {
+		t.Fatalf("spec.environmentRef = %q, want slugged hw165-omani-works-prod (no dots)", env)
 	}
 }
 
@@ -222,9 +226,10 @@ func TestNewApplicationCRFromSeed_DottedOrgSlugsNamespace(t *testing.T) {
 	if ns := obj.GetNamespace(); ns != "hw165-omani-works" {
 		t.Fatalf("metadata.namespace = %q, want slugged hw165-omani-works", ns)
 	}
-	// environmentRef keeps the FQDN form (seed.Namespace + "-prod").
-	if env, _, _ := unstructured.NestedString(obj.Object, "spec", "environmentRef"); env != "hw165.omani.works-prod" {
-		t.Fatalf("spec.environmentRef = %q, want hw165.omani.works-prod", env)
+	// environmentRef is the slugged "<org>-prod" form (#3922): the FQDN's dots
+	// are folded so the CR passes the CRD pattern.
+	if env, _, _ := unstructured.NestedString(obj.Object, "spec", "environmentRef"); env != "hw165-omani-works-prod" {
+		t.Fatalf("spec.environmentRef = %q, want slugged hw165-omani-works-prod (no dots)", env)
 	}
 }
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.test.tsx
@@ -162,6 +162,25 @@ describe('NewInstanceDialog — dropdowns (#3600)', () => {
     expect(values).not.toContain('active-hotstandby')
   })
 
+  it('#3922 — the create <select> enumerates ALL FOUR canonical modes (parity with the app-detail radio)', async () => {
+    await openDialog()
+    const sel = (await screen.findByTestId('select-instance-topology')) as HTMLSelectElement
+    const options = Array.from(sel.querySelectorAll('option'))
+    const values = options.map((o) => o.getAttribute('value'))
+    // The full #3856 single vocabulary is present — the create dialog no
+    // longer DROPS active-passive / active-active (the truncation bug).
+    expect(values).toEqual(['singleton', 'active-active', 'active-hot-standby', 'active-passive'])
+    // Modes the blueprint does NOT support (this fixture: only singleton +
+    // active-hot-standby) are present-but-disabled, exactly like the
+    // app-detail "Change placement" radio greys them out — they are never
+    // silently removed.
+    const byValue = (v: string) => options.find((o) => o.getAttribute('value') === v)!
+    expect((byValue('singleton') as HTMLOptionElement).disabled).toBe(false)
+    expect((byValue('active-hot-standby') as HTMLOptionElement).disabled).toBe(false)
+    expect((byValue('active-passive') as HTMLOptionElement).disabled).toBe(true)
+    expect((byValue('active-active') as HTMLOptionElement).disabled).toBe(true)
+  })
+
   it('vCluster is a <select>', async () => {
     await openDialog()
     expect(((await screen.findByTestId('select-instance-vcluster')) as HTMLSelectElement).tagName).toBe('SELECT')

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/InstancesSection.tsx
@@ -537,7 +537,15 @@ export function NewInstanceDialog({
 
   // The blueprint's declared supported topologies, normalised to the
   // editor mode vocab so they intersect with ALL_MODES. When the
-  // blueprint declares none, every editor mode is offered.
+  // blueprint declares none, every editor mode is allowed.
+  //
+  // #3922 — `supportedModes` is the ALLOWED (selectable) subset; the
+  // <select> below renders the FULL canonical ALL_MODES set and merely
+  // DISABLES the unsupported options. This mirrors the app-detail
+  // "Change placement" radio picker (TopologyEditor), which always lists
+  // all four canonical classes and greys out the ones the Blueprint
+  // doesn't support — so the create dialog can no longer silently DROP
+  // active-passive / active-active and disagree with the app-detail view.
   const supportedModes = useMemo<string[]>(() => {
     const raw = bpQuery.data?.raw as
       | { spec?: { topology?: { supported?: string[] } } }
@@ -548,6 +556,10 @@ export function NewInstanceDialog({
     const allowed = declared.length > 0 ? new Set(declared) : null
     return ALL_MODES.filter((m) => (allowed ? allowed.has(m) : true))
   }, [bpQuery.data])
+
+  // The selectable-mode gate the <select> consults to disable (not drop)
+  // unsupported options.
+  const allowedModeSet = useMemo<Set<string>>(() => new Set(supportedModes), [supportedModes])
 
   const defaultMode = useMemo<string>(() => {
     const raw = bpQuery.data?.raw as
@@ -730,8 +742,15 @@ export function NewInstanceDialog({
           ) : null}
         </label>
 
-        {/* Topology mode — dropdown reusing the editor's ALL_MODES set,
-            constrained to the Blueprint's supported modes (#3599/#3600). */}
+        {/* Topology mode — dropdown over the editor's full canonical
+            ALL_MODES set (#3856 single vocabulary: singleton / active-passive /
+            active-hot-standby / active-active). #3922 — render ALL FOUR and
+            DISABLE the ones the Blueprint doesn't support, exactly like the
+            app-detail "Change placement" radio picker; the create <select>
+            previously DROPPED unsupported modes, so active-passive /
+            active-active vanished from it while the app-detail radio still
+            listed them. Disabled options carry a "(not supported)" suffix so
+            the operator sees the full vocabulary + why a mode is unavailable. */}
         <label style={{ display: 'block', marginBottom: '0.6rem', fontSize: '0.85rem' }}>
           <span style={{ display: 'block', marginBottom: '0.2rem' }}>Topology mode</span>
           <select
@@ -741,11 +760,15 @@ export function NewInstanceDialog({
             disabled={bpQuery.isPending}
             style={fieldStyle}
           >
-            {supportedModes.map((m) => (
-              <option key={m} value={m}>
-                {m} — {describeMode(m)}
-              </option>
-            ))}
+            {ALL_MODES.map((m) => {
+              const enabled = allowedModeSet.has(m)
+              return (
+                <option key={m} value={m} disabled={!enabled}>
+                  {m} — {describeMode(m)}
+                  {enabled ? '' : ' (not supported by this blueprint)'}
+                </option>
+              )
+            })}
           </select>
         </label>
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.test.tsx
@@ -239,6 +239,47 @@ describe('CatalogDetail — #3090 class page', () => {
     expect(screen.getByTestId('catalog-dep-loki')).toBeTruthy()
   })
 
+  it('#3922 — the "Supported topologies" sidebar canonicalizes legacy/garbled spellings', async () => {
+    // A Blueprint declaring the LEGACY dialect (placementSchema.modes:
+    // [single-region] preferred-first historically + spec.topology.supported
+    // carrying the un-hyphenated active-hotstandby) must render the ONE
+    // canonical vocabulary in the sidebar — matching the create <select> + the
+    // app-detail radio — never the raw garbled tokens.
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('/instances')) return jsonRes({ items: [] })
+      if (url.includes('/catalog/')) {
+        return jsonRes({
+          ...GRAFANA_CATALOG,
+          // Legacy single-mode placementSchema (the historically-preferred,
+          // narrower source) + a richer but legacy-spelled topology.supported.
+          placementSchema: { modes: ['single-region'], default: 'single-region' },
+          raw: {
+            spec: {
+              ...GRAFANA_CATALOG.raw.spec,
+              topology: {
+                supported: ['single-region', 'active-hotstandby'],
+                defaults: { 'single-region': 'single-region' },
+              },
+            },
+          },
+        })
+      }
+      return jsonRes({})
+    }) as typeof fetch
+
+    renderCatalog('grafana')
+    await screen.findByTestId('catalog-section-topologies')
+    // Canonical rows render…
+    expect(screen.getByTestId('catalog-topology-singleton')).toBeTruthy()
+    expect(screen.getByTestId('catalog-topology-active-hot-standby')).toBeTruthy()
+    // …and the raw garbled legacy tokens NEVER do.
+    expect(screen.queryByTestId('catalog-topology-single-region')).toBeNull()
+    expect(screen.queryByTestId('catalog-topology-active-hotstandby')).toBeNull()
+    // The default marker is canonicalized too (single-region → singleton).
+    expect(screen.getByTestId('catalog-topology-default-singleton')).toBeTruthy()
+  })
+
   it('instances table exposes Version + Actions columns and an Open link', async () => {
     renderCatalog('grafana')
     await screen.findByTestId('sov-instances-table')

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogDetail.tsx
@@ -728,27 +728,58 @@ function readMultiInstance(cat: CatalogItem): boolean {
 // gone now that the editor is canonical end-to-end.
 
 function readTopologies(cat: CatalogItem): string[] {
-  const modes = cat.placementSchema?.modes
-  if (Array.isArray(modes) && modes.length > 0) return modes
+  // #3922 — the "Supported topologies" sidebar previously rendered the raw,
+  // un-canonicalized declaration verbatim: a Blueprint declaring the legacy
+  // dialect (placementSchema.modes: [single-region] / spec.topology.supported:
+  // [active-hotstandby]) showed garbled tokens that disagreed with the create
+  // <select> + the app-detail radio (both of which speak the ONE canonical
+  // vocabulary via canonicalizeMode). Fold every declared spelling onto the
+  // canonical token (#3856: singleton / active-passive / active-hot-standby /
+  // active-active) and dedupe so the sidebar matches the pickers. Prefer the
+  // richer spec.topology.supported over the legacy single-mode
+  // placementSchema.modes when present.
   const raw = cat.raw as Record<string, unknown> | undefined
   const spec = (raw?.spec as Record<string, unknown> | undefined) ?? undefined
   const topology = spec?.topology as { supported?: string[] } | undefined
-  return Array.isArray(topology?.supported) ? topology!.supported! : []
+  const declared =
+    Array.isArray(topology?.supported) && topology!.supported!.length > 0
+      ? topology!.supported!
+      : Array.isArray(cat.placementSchema?.modes)
+        ? cat.placementSchema!.modes!
+        : []
+  // Canonicalize + dedupe, preserving first-seen order.
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const m of declared) {
+    if (typeof m !== 'string') continue
+    const canon = canonicalizeMode(m)
+    if (!seen.has(canon)) {
+      seen.add(canon)
+      out.push(canon)
+    }
+  }
+  return out
 }
 
 function readDefaultTopology(cat: CatalogItem): string {
+  // #3922 — canonicalize the default marker too, so it matches the
+  // canonicalized supported set above (a legacy `single-region` default must
+  // mark the canonical `singleton` row, not a phantom un-canonical token).
   const def = cat.placementSchema?.default
-  if (typeof def === 'string' && def) return def
+  if (typeof def === 'string' && def) return canonicalizeMode(def)
   const raw = cat.raw as Record<string, unknown> | undefined
   const spec = (raw?.spec as Record<string, unknown> | undefined) ?? undefined
   const topology = spec?.topology as
     | { default?: string; defaults?: Record<string, string> }
     | undefined
-  if (typeof topology?.default === 'string' && topology.default) return topology.default
+  if (typeof topology?.default === 'string' && topology.default) {
+    return canonicalizeMode(topology.default)
+  }
   // Blueprint shape uses `defaults: { single-region, multi-region }` —
   // prefer the single-region default as the "default" marker.
   const defs = topology?.defaults
-  return defs?.['single-region'] ?? defs?.['multi-region'] ?? ''
+  const pick = defs?.['single-region'] ?? defs?.['multi-region'] ?? ''
+  return pick ? canonicalizeMode(pick) : ''
 }
 
 /**


### PR DESCRIPTION
## Two env-independent bugs in the catalog "New instance" create dialog

Surfaced live on hw171 but true on **any** Sovereign — pure derivation/enumeration logic, validated by build/test/render (no prov fire). Refs #3375 #3856 #3922.

### Bug A — create returned HTTP 500, blocking ALL instance creation
`POST /catalyst/v1/apps/instances` returned 500:
```
Application.apps.openova.io "<name>" is invalid: spec.environmentRef:
Invalid value: "hw171.omantel.biz-prod": spec.environmentRef in body
should match '^[a-z][a-z0-9-]{2,63}$'
```

**Root cause (file:line):** both Application-CR write paths stamped `spec.environmentRef` as `<org>-prod`, where on a chroot/operator install the Org defaults to the Sovereign FQDN (dots in every FQDN):
- `products/catalyst/bootstrap/api/internal/handler/applications.go:996` (`newApplicationUnstructured`) — was `"environmentRef": req.EnvironmentRef`
- `products/catalyst/bootstrap/api/internal/handler/endpoint_handler.go:2161` (`newApplicationCRFromSeed`) — was `"environmentRef": seed.Namespace + "-prod"`

The Application CRD (`products/catalyst/chart/crds/application.yaml:108`) constrains `spec.environmentRef` to `^[a-z][a-z0-9-]{2,63}$` (no dots). #3830 slugged `metadata.namespace` via `orgNamespace()` but **deliberately left `environmentRef` dotted**.

**Fix:** add `sanitizeEnvironmentRef` / `environmentRefForOrg` in `namespace_ensure.go` (delegating to `orgNamespace`'s RFC-1123 slugging + 63-char cap) and route both create paths through them. The verbatim FQDN identity stays on the `catalyst.openova.io/organization` label + `organizationRef`. An already-valid label (`acme-prod`) round-trips unchanged.

### Bug B — catalog create `<select>` dropped active-passive + active-active
The app-detail "Change placement" radio (`TopologyEditor.tsx:257`) renders all four canonical `ALL_MODES` and **disables** unsupported ones; the catalog create `<select>` (`InstancesSection.tsx:744`) rendered only the supported **subset**, so `active-passive`/`active-active` vanished entirely. The "Supported topologies" sidebar (`CatalogDetail.tsx` `readTopologies`) rendered raw, un-canonicalized (garbled legacy) tokens.

**Fix:**
- `InstancesSection.tsx` — render the full canonical `ALL_MODES` set, **disabling** (not dropping) unsupported options → parity with the app-detail radio.
- `CatalogDetail.tsx` (`readTopologies`/`readDefaultTopology`) — canonicalize + dedupe via the shared `canonicalizeMode` (#3856 single vocabulary: `singleton / active-passive / active-hot-standby / active-active`).

### Tests
- Go: new `TestEnvironmentRefForOrg_SlugsDottedFQDN` + `TestSanitizeEnvironmentRef_AlwaysMatchesCRDPattern` (asserts output against the literal CRD regex); the two #3830 tests updated to assert the slugged (no-dots) env ref.
- UI: new `#3922` tests — create `<select>` enumerates all 4 modes with unsupported ones present-but-disabled; sidebar folds legacy spellings.

### Validation
- `go build ./...` + `go vet` clean; full `internal/handler` suite green (incl. new + updated tests).
- UI `tsc -b --noEmit` clean; all touched UI suites green; the existing `#3375 DoD-1` placement-vocabulary drift guard still passes.
- The ~70 unrelated UI test failures (`PinInput6`/`ProvisionPage`/`Settings`/`StepComponents`/…) are **pre-existing on base** (confirmed by re-running on the stashed/clean tree).

Neither fix needs live-env validation — both are pure derivation/enumeration logic.

Refs #3375 #3856 #3922

🤖 Generated with [Claude Code](https://claude.com/claude-code)