### PR TITLE
fix(bp-mgmt-vcluster): harbor-core host alias unblocks cutover step-02 post-#3642 (0.2.26)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -580,6 +580,16 @@ spec:
   values:
     sovereign:
       fqdn: ${SOVEREIGN_FQDN}
+      # #3642/#3926: Harbor runs INSIDE vc-mgmt post-#3642, so harbor-core
+      # syncs to the host ONLY as the mangled
+      # `harbor-core-x-harbor-x-mgmt-vcluster.mgmt.svc` (the host `harbor` ns
+      # holds only the CNPG `harbor-pg-*`). The plain `harbor-core.harbor.svc`
+      # NXDOMAIN'd → step-02 (harbor-projects, runs host-side in catalyst ns)
+      # wedged the cutover on every post-#3642 prov (root-caused live on hw171,
+      # dep 3963e9267c10a90d). bp-mgmt-vcluster (slot 58) now ships a
+      # `harbor-core.harbor` ExternalName alias to the mangled name (the proven
+      # gitea/keycloak/openbao host-service-aliases mechanism, hw164), so this
+      # plain URL resolves again with ZERO change here. Refs #3379 #3926.
       harborInternalURL: http://harbor-core.harbor.svc.cluster.local
       # NB: Harbor HTTPRoute publishes at `registry.<sov>` (see
       # `clusters/_template/bootstrap-kit/19-harbor.yaml` gateway.host),
@@ -614,6 +624,19 @@ spec:
       # hw91. This is the missing lockstep half of #3012; mirror of
       # harbor/giteaPublicURL.
       consolePublicURL: https://console.${SOVEREIGN_FQDN}
+    # #3642/#3926: post-#3642 the bp-harbor `harbor-admin` Secret is minted
+    # INSIDE vc-mgmt (with reflector `reflectionAllowedNamespaces: catalyst`);
+    # it reaches the HOST `catalyst` ns — where step-02 (harbor-projects) runs —
+    # ONLY under the vCluster-synced mangled name
+    # `harbor-admin-x-harbor-x-mgmt-vcluster` (toHost secret sync + reflector,
+    # `reflects: mgmt/harbor-admin-x-...`, verified deterministic on hw171). The
+    # chart default `harbor-admin` does NOT exist host-side, so the Job's
+    # same-namespace secretKeyRef would fail. Point it at the synced name so the
+    # password resolves. (HARBOR_ADMIN_USERNAME stays optional → the Job defaults
+    # `admin`, matching upstream Harbor's hardcoded admin user.) Refs #3379 #3926.
+    harbor:
+      adminSecretRef:
+        name: harbor-admin-x-harbor-x-mgmt-vcluster
     # #3379 (2026-06-13): enable the REAL 10-minute deny-egress hold for
     # Step-08 (egress-block-test). The chart default
     # (egressTest.enforceCIDRBlock: false, values.yaml) ships the passive

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -176,7 +176,13 @@ spec:
       # CNPG-owner seams). The `newapi/*` secret mapping already delivers the DSN.
       # Cycle-1.5 train combines this with the 0.2.23 DB-secret de-conflict
       # (#3876) + the 0.2.24 RCA-comment refresh (#3878).
-      version: 0.2.25
+      # 0.2.26 (#3926, Refs #3379 #3642): add a `harbor-core.harbor` host→vc-mgmt
+      # ExternalName alias so the bp-self-sovereign-cutover step-02
+      # (harbor-projects) Job — which runs host-side and dials the PLAIN
+      # `harbor-core.harbor.svc` — resolves Harbor again post-#3642 (it now runs
+      # INSIDE vc-mgmt; the host name NXDOMAIN'd → cutover wedged at step-02 on
+      # hw171). Same proven host-service-aliases mechanism as gitea/keycloak/openbao.
+      version: 0.2.26
       sourceRef:
         kind: HelmRepository
         name: bp-mgmt-vcluster

--- a/platform/bp-mgmt-vcluster/blueprint.yaml
+++ b/platform/bp-mgmt-vcluster/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-2-control-plane-isolation
     catalyst.openova.io/category: platform
 spec:
-  version: 0.2.25
+  version: 0.2.26
   card:
     title: Management vCluster
     summary: |

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -308,7 +308,24 @@ name: bp-mgmt-vcluster
 # (the replicateServices.fromHost mirror, the narrowed exact-name SSO secret
 # mappings, and the refreshed fromHost-block RCA comment). Lockstep:
 # 58-bp-mgmt-vcluster.yaml pin + blueprint.yaml → 0.2.25. Refs #3831 #3876 #3878 #3374 #3737.
-version: 0.2.25
+# 0.2.26 (#3926, Refs #3379 #3642): add a `harbor-core.harbor` host→vc-mgmt
+# ExternalName alias to hostServiceAliases.aliases. Post-#3642 Harbor runs INSIDE
+# vc-mgmt; harbor-core syncs to the host ONLY as the mangled
+# `harbor-core-x-harbor-x-mgmt-vcluster.mgmt.svc` (the host `harbor` ns holds only
+# the CNPG `harbor-pg-*`). The bp-self-sovereign-cutover step-02 (harbor-projects)
+# Job runs on the HOST (catalyst ns) and dials the PLAIN `harbor-core.harbor.svc`
+# → NXDOMAIN → curl can't reach Harbor → the Pillar-5 cutover WEDGED at step-02 on
+# every post-#3642 prov (root-caused live on hw171, dep 3963e9267c10a90d: pod exit
+# 137, zero proxy-cache projects created, cutoverComplete=false). gitea-http /
+# keycloak / openbao got their plain-name aliases in the #3642 hw164 audit but
+# harbor-core was MISSED — step-02 is the sole host consumer of harbor-core (the
+# harbor HTTPRoute uses harbor-nginx). Same proven crash-safe ExternalName
+# mechanism (templates/host-service-aliases.yaml), never-pruned, no-op-until-
+# present. Lockstep: 58-bp-mgmt-vcluster.yaml pin + blueprint.yaml → 0.2.26.
+# Paired with the 06a-bp-self-sovereign-cutover.yaml overlay change that points
+# harbor.adminSecretRef.name at the synced `harbor-admin-x-harbor-x-mgmt-vcluster`
+# Secret. Refs #3926 #3379 #3642.
+version: 0.2.26
 appVersion: "0.23.0"
 description: |
   Catalyst-curated Blueprint umbrella chart for the Sovereign MGMT

--- a/platform/bp-mgmt-vcluster/chart/values.yaml
+++ b/platform/bp-mgmt-vcluster/chart/values.yaml
@@ -245,6 +245,26 @@ hostServiceAliases:
       namespace: openbao
       externalName: openbao-x-openbao-x-mgmt-vcluster.mgmt.svc.cluster.local
       port: 8200
+    # ── #3926 harbor-core host→vc-mgmt plain-name reachability ──
+    # #3642 moved Harbor INTO vc-mgmt; harbor-core syncs to the host ONLY as the
+    # mangled `harbor-core-x-harbor-x-mgmt-vcluster.mgmt.svc` (the host `harbor`
+    # ns carries only the CNPG `harbor-pg-*`). But the bp-self-sovereign-cutover
+    # step-02 (harbor-projects) Job runs on the HOST (catalyst ns) and dials the
+    # PLAIN `harbor-core.harbor.svc.cluster.local` (the chart default +
+    # 06a overlay harborInternalURL) → NXDOMAIN → curl can't reach Harbor → the
+    # Pillar-5 cutover wedges at step-02 on EVERY post-#3642 prov (root-caused
+    # live on hw171, dep 3963e9267c10a90d: pod exit 137, all 7 proxy-cache
+    # projects un-created). gitea-http/keycloak/openbao got their plain-name
+    # aliases in the #3642 hw164 audit but harbor-core was MISSED — step-02 is
+    # the sole host consumer of harbor-core (the harbor HTTPRoute uses
+    # harbor-nginx, not harbor-core). This ExternalName aliases the plain name to
+    # the mangled one so the cutover chart's default URL resolves with ZERO
+    # cutover-chart change. Same no-op-until-present + never-pruned semantics as
+    # the 3 aliases above. Refs #3379. port 80 = harbor-core's API listener.
+    - name: harbor-core
+      namespace: harbor
+      externalName: harbor-core-x-harbor-x-mgmt-vcluster.mgmt.svc.cluster.local
+      port: 80
 
 # ─── Upstream chart values (subchart key: vcluster) ────────────────
 # `helm dependency build` resolves the upstream loft-sh/vcluster


### PR DESCRIPTION
## Root cause (grounded — live on hw171, dep `3963e9267c10a90d`)
The Pillar-5 cutover (`bp-self-sovereign-cutover`) **wedged at step-02 (harbor-projects)**: Job `cutover-harbor-projects-*` failed ×2 (pod exit 137 / ContainerStatusUnknown), zero proxy-cache projects created, `cutoverComplete=false`, blocking steps 03-11.

Post-#3642 **Harbor runs INSIDE the `mgmt` vCluster**. On the HOST cluster:
- `harbor-core.harbor.svc.cluster.local` → **NXDOMAIN** (the host `harbor` ns holds only the CNPG `harbor-pg-*`; the real harbor-core is `harbor-core-x-harbor-x-mgmt-vcluster.mgmt.svc`).
- The `harbor-projects` Job runs on the host in the `catalyst` ns and dials the PLAIN `harbor-core.harbor.svc` (chart default + 06a overlay `harborInternalURL`) → `curl` can't resolve → step fails.
- The admin secret it references (`harbor-admin`) doesn't exist in `catalyst`; the synced copy is `harbor-admin-x-harbor-x-mgmt-vcluster`.

**The deeper root cause:** `bp-mgmt-vcluster`'s `hostServiceAliases.aliases` exports **gitea-http / keycloak / openbao** under their plain host names (the #3642 hw164 audit, `host-service-aliases.yaml`) so those host consumers resolve — but **`harbor-core` was MISSED**. That is why step-01 (gitea-mirror) succeeds host-side and step-02 (harbor-projects) fails. step-02 is the sole host consumer of `harbor-core` (the harbor HTTPRoute uses harbor-nginx, not harbor-core).

Failing log/state evidence:
```
Pod cutover-harbor-projects-...-f9d5n: State Terminated, Exit Code 137, ContainerStatusUnknown
host probe: nslookup harbor-core.harbor.svc.cluster.local -> NXDOMAIN; curl -> 000
vcluster-synced harbor-core-x-harbor-x-mgmt-vcluster.mgmt.svc: health=200, authed /projects=200
```
Step definition: `platform/self-sovereign-cutover/chart/templates/02-harbor-projects-job.yaml:34-46` (HARBOR_INTERNAL_URL from `sovereign.harborInternalURL`; secret from `harbor.adminSecretRef.name`).

## Live fix (validated on hw171 — proof the step unstuck)
Live-patched the `cutover-step-02-harbor-projects` ConfigMap podSpec to the synced endpoint + secret, deleted the failed Job, re-triggered via `/internal/cutover/trigger`. Result:
```
[harbor-projects] project proxy-ghcr/docker/k8s/gcr/quay/xpkg/ecr OK (201) x7
[harbor-projects] push project openova-io OK (201)
job cutover-harbor-projects-1781900304: 1 succeeded / 0 failed
cutover status: step-02 harbor-projects = success; currentStep advanced to harbor-prewarm (step-03)
```
A live patch is THROWAWAY — this PR makes it permanent so a clean re-fire never re-hits it.

## Durable fix (this PR)
- **bp-mgmt-vcluster 0.2.26**: add a `harbor-core.harbor` ExternalName alias to `hostServiceAliases.aliases` → the cutover chart's DEFAULT `harborInternalURL` resolves on the host again with **zero cutover-chart change** (same proven crash-safe mechanism as gitea/keycloak/openbao; never-pruned; no-op-until-present).
- **06a-bp-self-sovereign-cutover overlay**: point `harbor.adminSecretRef.name` at the synced `harbor-admin-x-harbor-x-mgmt-vcluster` Secret (the host `catalyst`-ns copy post-#3642; the chart default `harbor-admin` no longer exists host-side) + document the alias dependency.
- **Lockstep**: `58-bp-mgmt-vcluster.yaml` pin + `blueprint.yaml` → 0.2.26.

## Validation
- `helm template` host-service-aliases renders the new `harbor-core` ExternalName (ns `harbor`, → mangled, port 80).
- `helm lint` bp-mgmt-vcluster: 0 failed.
- `helm template` cutover step-02 with overlay values → `HARBOR_INTERNAL_URL=http://harbor-core.harbor.svc` + both secret refs = synced name (matches the validated live patch).
- 06a overlay YAML parses with the new keys.

Refs #3926 #3379 #3642

🤖 Generated with [Claude Code](https://claude.com/claude-code)