### PR TITLE
fix(bp-newapi): render admin-sso-seed WITH the app — break the slot-80↔80a circular deadlock (1.4.117)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -298,7 +298,12 @@ spec:
       # 1.4.112: lockstep to the auto-bumped + published upstream-v0.13.2 chart
       # (the auto-bump commit advanced the chart but its Blueprint-Release
       # lockstep step failed, leaving this pin stale at 1.4.111).
-      version: 1.4.112
+      # 1.4.117 (#3858, Refs #3831): the admin-sso-seed Job/CronJob now renders
+      # with the APP (renderApp) — this vcluster-app slot is exactly where the
+      # seed must run (it polls public.users + rollout-restarts the Deployment,
+      # both vcluster-side). Kills the slot-80↔slot-80a circular deadlock. Also
+      # absorbs the 1.4.113–1.4.116 deploy-bot upstream-v0.13.2 chart bumps.
+      version: 1.4.117
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
+++ b/clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml
@@ -70,7 +70,12 @@ spec:
       # 1.4.111 (#3831): the placement.role render-split chart. Lockstep with
       # slot 80's pin + platform/newapi blueprint.yaml.
       # 1.4.112: lockstep to the auto-bumped + published upstream-v0.13.2 chart.
-      version: 1.4.112
+      # 1.4.117 (#3858, Refs #3831): admin-sso-seed moved to renderApp — this
+      # host-seams slot NO LONGER renders the seed Job/CronJob (under host-seams
+      # the seed would block on a schema this side never migrates → deadlock).
+      # It still renders the CNPG Cluster + DSN-sync Job + AppRegistration +
+      # ExternalSecrets. Lockstep with slot 80 + blueprint.yaml → 1.4.117.
+      version: 1.4.117
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/section: pts-4-6-llm-serving
     catalyst.openova.io/tier: catalyst-cp
 spec:
-  version: 1.4.116
+  version: 1.4.117
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -784,7 +784,25 @@ name: bp-newapi
 # host-placed install is byte-identical to 1.4.110. The split mirrors the
 # guacamole host-bridge precedent (#3868) for a host-rendered CNPG + in-vCluster
 # app, extended to a CNPG-OWNER app. See _helpers.tpl renderSeams/renderApp.
-version: 1.4.116
+# 1.4.117 (#3858, Refs #3831): render the admin-sso-seed Job/CronJob WITH the
+# app (renderApp), NOT the host seams (renderSeams). Under the 1.4.111 split the
+# seed was left on the host where seed.sh/promote.sh block on `public.users` —
+# a table the host side NEVER migrates (GORM AutoMigrate runs in vc-mgmt) →
+# activeDeadline → host-seams HR install FAILS; meanwhile the vcluster-app HR
+# `dependsOn: bp-newapi-host-seams` so the app never installs to migrate the
+# schema → CIRCULAR DEADLOCK (DeadlineExceeded, measured live hw171). Moving the
+# seed to renderApp co-locates seed+migrate in the same release/cluster: the
+# post-install hook fires after the app installs+migrates, the `public.users`
+# poll resolves, and the Deployment-patch RBAC targets a Deployment that exists.
+# The CNPG `-app` + OIDC Secrets the Job mounts are mirrored host→vCluster by
+# bp-mgmt-vcluster (0.2.26) sync.fromHost.secrets `newapi/*`; the CNPG `-rw`/`-ro`
+# Services by replicateServices — both already on main. `cnpg.enabled` is dropped
+# from the gate (vcluster-app ships cnpg.enabled=false; the Job needs only the
+# MIRRORED `-app` Secret). Mirrors the channel-seed-job renderApp precedent.
+# role=all keeps the gate "true" so standalone/host-placed installs are
+# byte-identical. Lockstep: 80-newapi.yaml + 80a-newapi-host-seams.yaml pins +
+# blueprint.yaml → 1.4.117.
+version: 1.4.117
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/_helpers.tpl
+++ b/platform/newapi/chart/templates/_helpers.tpl
@@ -79,18 +79,23 @@ the chart renders in one of three roles, selected by `.Values.placement.role`:
                every host-placed Sovereign keeps the historic single-HR
                behaviour; both gates below return "true" so they are no-ops.
   host-seams   — render ONLY the host-reconciled seams: the CNPG Cluster +
-               DSN-placeholder Secret + database-secret-sync Job +
-               admin-sso-seed Job/CronJob (+ their RBAC) + the newapi-admin
-               AppRegistration ConfigMap + the oidc-sync ExternalSecret + the
-               catalyst-newapi-admin-token ExternalSecret. NO Deployment /
-               Service / HTTPRoute / Ingress / Application CR.
+               DSN-placeholder Secret + database-secret-sync Job (+ their RBAC) +
+               the newapi-admin AppRegistration ConfigMap + the oidc-sync
+               ExternalSecret + the catalyst-newapi-admin-token ExternalSecret.
+               NO Deployment / Service / HTTPRoute / Ingress / Application CR.
+               NOT the admin-sso-seed Job/CronJob — those operate on the migrated
+               schema + rollout-restart the app Deployment, so they render WITH
+               the app (vcluster-app), reading the CNPG `-app` + OIDC Secrets
+               mirrored host→vCluster (#3831 deadlock fix, Refs #3858).
   vcluster-app — render ONLY the app: Deployment + Service + (HTTPRoute via the
                host-bridge) + NetworkPolicy + the Application CR + the
                in-cluster placeholder Secrets the Pod reads (credentials,
-               token-signing-key). NO CNPG / Jobs / ExternalSecrets /
-               AppRegistration (those render host-side under host-seams; the
-               host→vCluster secret mirror + replicateServices deliver the DSN
-               Secret + CNPG Service into the vCluster).
+               token-signing-key) + the admin-sso-seed Job/CronJob + the
+               channel-seed Job (both operate on the app's migrated DB schema).
+               NO CNPG / DSN-sync Job / ExternalSecrets / AppRegistration (those
+               render host-side under host-seams; the host→vCluster secret mirror
+               + replicateServices deliver the DSN/`-app`/OIDC Secrets + CNPG
+               Service into the vCluster).
 
 The two HRs share `releaseName: newapi` + chart `bp-newapi` (in DIFFERENT
 clusters — host k3s vs vc-mgmt apiserver, so NO Helm-storage collision), so

--- a/platform/newapi/chart/templates/admin-sso-seed-job.yaml
+++ b/platform/newapi/chart/templates/admin-sso-seed-job.yaml
@@ -68,7 +68,37 @@ nothing.
 {{- if hasKey $ssoBootstrap "enabled" -}}{{- $seedEnabled = $ssoBootstrap.enabled -}}
 {{- else if hasKey $seed "enabled" -}}{{- $seedEnabled = $seed.enabled -}}{{- end -}}
 {{- $kcMode := eq .Values.auth.adminUI.mode "keycloak" -}}
-{{- if and (eq (include "bp-newapi.renderSeams" .) "true") $seedEnabled .Values.newapi.enabled $kcMode .Values.cnpg.enabled .Values.sovereignFQDN -}}
+{{- /* #3831 deadlock fix (Refs #3858): render with the APP (renderApp), NOT the
+   host seams (renderSeams). The seed/promote pair operates on the migrated DB
+   schema — seed.sh/promote.sh both call wait_for_users_table, which polls
+   `public.users` (created by the app's GORM AutoMigrate on first boot) — AND
+   it rollout-restarts the app Deployment (reload_newapi_provider patches
+   <release> Deployment to reload custom_oauth_providers). The Deployment only
+   exists under vcluster-app, and the schema is only migrated once the app boots.
+   Under the #3831 split the seed was left on the host (renderSeams), where:
+     (1) the post-install hook blocks on wait_for_users_table for a schema the
+         host side NEVER migrates (the app runs in vc-mgmt) → activeDeadline
+         (420s) → DeadlineExceeded → the host-seams HR install FAILS → uninstall
+         remediation → retry forever; and
+     (2) the vcluster-app HR `dependsOn: bp-newapi-host-seams`, so the app can
+         never install to migrate the schema → CIRCULAR DEADLOCK (measured live
+         hw171, dep 3963e9267c10a90d: host-seams HR Unknown/install-failed x6,
+         vcluster-app HR False "Fulfilling prerequisites", 0 tables in the CNPG
+         `public` schema, newapi.<fqdn> → 500).
+   Rendering with the app co-locates seed+migrate in the SAME release/cluster:
+   the post-install hook fires AFTER the app Deployment installs+migrates, the
+   `public.users` poll resolves, and the Deployment-patch RBAC targets a
+   Deployment that actually exists. The CNPG `<cluster>-app` Secret + OIDC Secret
+   the Job mounts are mirrored host→vCluster by bp-mgmt-vcluster
+   sync.fromHost.secrets `"newapi/*": "newapi/*"` (#3879), and the CNPG `-rw`/`-ro`
+   Services by sync.fromHost.mappings — so everything the Job reads resolves
+   vcluster-side. This mirrors the channel-seed-job precedent (also renderApp,
+   also operates on the migrated schema). `cnpg.enabled` is dropped from the gate
+   because vcluster-app ships cnpg.enabled=false (the CNPG Cluster is host-rendered
+   by the host-seams HR); the Job needs only the MIRRORED `-app` Secret, not the
+   Cluster CR. role=all keeps both gates "true" so standalone/host-placed installs
+   are byte-identical. */ -}}
+{{- if and (eq (include "bp-newapi.renderApp" .) "true") $seedEnabled .Values.newapi.enabled $kcMode .Values.sovereignFQDN -}}
 {{- $clusterName := printf "%s-newapi-pg" (include "bp-newapi.fullname" .) -}}
 {{- $cnpgSecretName := printf "%s-app" $clusterName -}}
 {{- $jobName := include "bp-newapi.adminSeedJobName" . -}}


### PR DESCRIPTION
## What

Render the bp-newapi `admin-sso-seed` Job/CronJob **WITH the app** (`renderApp`) instead of the host seams (`renderSeams`), and drop `cnpg.enabled` from its render gate. Breaks the slot-80 ↔ slot-80a **circular install deadlock** introduced by the 1.4.111 placement.role render-split.

Clean re-cut of #3921 off **current `origin/main`** (that branch is now CONFLICTING / 44 files after #3927 merged bp-mgmt-vcluster 0.2.26 underneath it). This PR isolates ONLY the genuinely-unmerged deadlock fix — everything else in #3921 already landed on main.

## Root cause (verified RCA, live hw171)

`seed.sh`/`promote.sh` both call `wait_for_users_table`, which polls `public.users` — a table created only by the app's GORM AutoMigrate **inside vc-mgmt**. The 1.4.111 split left the seed on the **host** (`renderSeams`), where:

1. the post-install hook blocks on a schema the host side **never migrates** → `activeDeadline` (420s) → `DeadlineExceeded` → the slot-80a host-seams HR install **FAILS** → uninstall remediation → retry forever; **and**
2. the slot-80 vcluster-app HR `dependsOn: bp-newapi-host-seams`, so the app **can never install** to migrate the schema → **CIRCULAR DEADLOCK** (measured live hw171, dep `3963e9267c10a90d`: host-seams HR install-failed ×6, vcluster-app HR `False "Fulfilling prerequisites"`, 0 tables in `public`, `newapi.<fqdn>` → 500).

## The fix

Gate `admin-sso-seed` on `renderApp` — matching the existing `channel-seed-job` precedent (also `renderApp`, also operates on the migrated schema). Co-locating seed+migrate in the same release/cluster means the hook fires AFTER the app installs+migrates, the `public.users` poll resolves, and the Deployment-patch RBAC targets a Deployment that exists.

- The CNPG `-app` + OIDC Secrets the Job mounts are mirrored host→vCluster by `bp-mgmt-vcluster` (0.2.26, **already on main**) `sync.fromHost.secrets "newapi/*"`; the CNPG `-rw`/`-ro` Services by `replicateServices` (**also already on main**). **bp-mgmt-vcluster is untouched by this PR** — its newapi sync landed on main via #3927/#3879.
- `cnpg.enabled` is dropped from the gate because vcluster-app ships `cnpg.enabled=false` (the Cluster is host-rendered by the host-seams HR; the Job needs only the mirrored `-app` Secret, not the Cluster CR).
- `role=all` keeps the gate `"true"` so every standalone/host-placed install is **byte-identical**.

## Render proof (`helm template`)

| role | admin-sso-seed Job | admin-promote CronJob | cnpg.enabled |
|---|---|---|---|
| `vcluster-app` | ✅ renders | ✅ renders | false |
| `host-seams` | ❌ none (correct) | ❌ none (correct) | — |
| `all` (default) | ✅ renders | ✅ renders | true (legacy, byte-identical) |

All three roles render valid YAML; `helm lint` passes.

## Files (6)

- `platform/newapi/chart/templates/admin-sso-seed-job.yaml` — gate `renderSeams`+`cnpg.enabled` → `renderApp` (THE fix)
- `platform/newapi/chart/templates/_helpers.tpl` — docstring update (host-seams/vcluster-app roles now reflect seed-with-app)
- `platform/newapi/chart/Chart.yaml` — 1.4.116 → **1.4.117** + changelog
- `platform/newapi/blueprint.yaml` — 1.4.116 → **1.4.117**
- `clusters/_template/bootstrap-kit/80-newapi.yaml` — pin 1.4.112 → **1.4.117** (lockstep)
- `clusters/_template/bootstrap-kit/80a-newapi-host-seams.yaml` — pin 1.4.112 → **1.4.117** (lockstep)

## Dropped from #3921 (already-merged or unrelated #3878 baggage)

postgres-shared slots 16a/16c/16d, bp-postgres role-secrets churn, native-dbsecret comment churn in bp-mgmt-vcluster, scripts/expected-bootstrap-deps.yaml — all either already on main or part of the separately-merged #3879/#3927 work. The placement-role scaffolding (helpers, slots 80/80a, values.yaml `placement.role`, the 7 render-tier-gated templates, bp-mgmt-vcluster 0.2.26 sync) is **already on main**; this PR adds only the one remaining gate change.

Supersedes #3921.

Refs #3858 Refs #3831

🤖 Generated with [Claude Code](https://claude.com/claude-code)
