### PR TITLE
fix(catalyst-api): Jobs-view identity-collapse — Day-2 scanners fold to ONE identity row w/ run-history (Refs #3925 #3646 #3918 #3920)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/jobs_backfill.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_backfill.go
@@ -189,9 +189,24 @@ func snapshotsToSeedsForRegion(snap []helmwatch.ComponentSnapshot, region string
 			}
 			regionDeps = rescoped
 		}
+		// Anti-flap (issue #3916): a HelmRelease whose Ready condition is
+		// transiently *Failed but whose Flux remediation.retries are NOT yet
+		// exhausted (Stalled==false) is STILL RECONCILING — Flux will flip it
+		// back installing→installed. The chroot /jobs page re-reads live
+		// state on every poll, so projecting that transient `failed` as a
+		// terminal Failed leaf made the row flap Failed↔Succeeded while the
+		// prov converged green. Downgrade a not-yet-stalled `failed` to
+		// `installing` (in-progress) here on the READ-side seed only; the
+		// live Watcher's own DeriveState still reports StateFailed so its
+		// late-poll/recovery machinery (issue #910) is untouched. A STABLY
+		// stalled HR (Stalled==true) keeps its terminal Failed leaf.
+		state := s.Status
+		if state == helmwatch.StateFailed && !s.Stalled {
+			state = helmwatch.StateInstalling
+		}
 		out = append(out, jobs.InformerSeed{
 			Component:  prefix + s.AppID,
-			State:      s.Status,
+			State:      state,
 			Message:    s.Message,
 			ObservedAt: s.LastTransitionAt,
 			DependsOn:  regionDeps,

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_backfill_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_backfill_test.go
@@ -34,9 +34,40 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
 )
+
+// TestSnapshotsToSeeds_TransientFailedNotStalledIsInProgress pins the
+// read-side install-leaf anti-flap (issue #3916): a HelmRelease whose Ready
+// condition is transiently *Failed but whose Flux remediation.retries are
+// NOT yet exhausted (Stalled==false) is STILL RECONCILING, so the /jobs seed
+// must project it as in-progress ("installing"), never a terminal "failed"
+// that flaps back to "succeeded" on the next poll. A STABLY-stalled HR keeps
+// its terminal "failed".
+func TestSnapshotsToSeeds_TransientFailedNotStalledIsInProgress(t *testing.T) {
+	snap := []helmwatch.ComponentSnapshot{
+		{AppID: "keycloak", Status: helmwatch.StateFailed, Stalled: false},  // retrying
+		{AppID: "openbao", Status: helmwatch.StateFailed, Stalled: true},    // stalled
+		{AppID: "cilium", Status: helmwatch.StateInstalled, Stalled: false}, // green
+	}
+	seeds := snapshotsToSeeds(snap)
+	got := map[string]string{}
+	for _, s := range seeds {
+		got[s.Component] = s.State
+	}
+	if got["keycloak"] != helmwatch.StateInstalling {
+		t.Errorf("transient-failed-not-stalled keycloak seed = %q, want %q (in-progress, no flap)",
+			got["keycloak"], helmwatch.StateInstalling)
+	}
+	if got["openbao"] != helmwatch.StateFailed {
+		t.Errorf("stalled openbao seed = %q, want %q (terminal)", got["openbao"], helmwatch.StateFailed)
+	}
+	if got["cilium"] != helmwatch.StateInstalled {
+		t.Errorf("installed cilium seed = %q, want %q (unchanged)", got["cilium"], helmwatch.StateInstalled)
+	}
+}
 
 // newBackfillRouter wires the two new endpoints + a jobs.Store so the
 // /refresh-watch handler can write Jobs through the bridge.

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_scanner_exclusion_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_scanner_exclusion_test.go
@@ -1,0 +1,237 @@
+// jobs_scanner_exclusion_test.go — end-to-end proof of the Day-2 scanner
+// COLLAPSE (#3925, jobs-convergence-monitor-model.md §4 Surface B). It drives
+// the FULL ingestion pipeline a live /jobs read uses —
+//
+//	helmwatch.ListReconcilerObservations  (the cluster-wide GVR list)
+//	  → reconcilerObsToBridge             (wire-shape translation)
+//	  → jobs.Bridge.SeedReconcilerObservations (project into jobs.Store)
+//	  → Handler.flowSnapshotFromJobs      (build the flow-diagram DAG)
+//
+// and asserts that a 100s-strong trivy-operator + syft-grype scan flood
+// collapses to EXACTLY TWO identity-keyed LEAVES in jobs.Store (one per
+// scanner) — never a per-run row, never excluded — and therefore exactly two
+// scanner NODES (no per-run nodes) in the DAG, while every genuine reconciler
+// Job survives as its own node. The flow diagram is derived strictly from the
+// leaves in jobs.Store, so collapsing scanners at ingestion is what keeps the
+// graph to one node per scanner — this test pins that the collapse holds all
+// the way through the graph builder, not just at the observation layer.
+package handler
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strconv"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+)
+
+// scannerExclusionListScheme registers the *List GVKs the dynamic fake needs
+// so List(...) resolves for every GVR ListReconcilerObservations enumerates.
+func scannerExclusionListScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Kind: "KustomizationList"},
+		&unstructured.UnstructuredList{})
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJobList"},
+		&unstructured.UnstructuredList{})
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "JobList"},
+		&unstructured.UnstructuredList{})
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "DeploymentList"},
+		&unstructured.UnstructuredList{})
+	return scheme
+}
+
+func scannerExclusionFakeClient(objs ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scannerExclusionListScheme(),
+		map[schema.GroupVersionResource]string{
+			helmwatch.KustomizationGVR: "KustomizationList",
+			helmwatch.CronJobGVR:       "CronJobList",
+			helmwatch.JobGVR:           "JobList",
+			helmwatch.DeploymentGVR:    "DeploymentList",
+		},
+		objs...,
+	)
+}
+
+// mkJob builds a batch/v1 Job; ownerCron non-empty stamps a CronJob owner ref.
+func mkJob(namespace, name, ownerCron string, labels map[string]string) *unstructured.Unstructured {
+	meta := map[string]any{"name": name, "namespace": namespace}
+	if ownerCron != "" {
+		meta["ownerReferences"] = []any{map[string]any{
+			"apiVersion": "batch/v1", "kind": "CronJob", "name": ownerCron, "uid": "uid-" + ownerCron,
+		}}
+	}
+	if len(labels) > 0 {
+		l := map[string]any{}
+		for k, v := range labels {
+			l[k] = v
+		}
+		meta["labels"] = l
+	}
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "batch/v1",
+		"kind":       "Job",
+		"metadata":   meta,
+		"status": map[string]any{
+			"startTime": "2026-06-20T01:00:00Z",
+			"conditions": []any{map[string]any{
+				"type": "Complete", "status": "True", "lastTransitionTime": "2026-06-20T01:01:00Z",
+			}},
+		},
+	}}
+	u.SetGroupVersionKind(schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"})
+	return u
+}
+
+func mkCron(namespace, name string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "batch/v1",
+		"kind":       "CronJob",
+		"metadata":   map[string]any{"name": name, "namespace": namespace},
+		"spec":       map[string]any{"schedule": "0 * * * *"},
+	}}
+	u.SetGroupVersionKind(schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"})
+	return u
+}
+
+// TestFlowDiagram_CollapsesDay2Scanners is the DAG-level guard: a scan flood
+// collapses to EXACTLY ONE node per scanner identity (no per-run nodes), while
+// real reconciler Jobs each become their own node.
+func TestFlowDiagram_CollapsesDay2Scanners(t *testing.T) {
+	const depID = "dep-scan-collapse"
+	st, err := jobs.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	h := NewWithJobsStore(slog.New(slog.NewJSONHandler(io.Discard, nil)), st)
+
+	objs := []runtime.Object{}
+
+	// --- the scanner flood (must collapse to ONE node per scanner) ---
+	// trivy-operator scan Jobs across all three detection paths.
+	const trivyRuns = 120
+	for i := 0; i < trivyRuns; i++ {
+		var labels map[string]string
+		switch i % 3 {
+		case 0:
+			labels = map[string]string{"app.kubernetes.io/managed-by": "trivy-operator"}
+		case 1:
+			labels = map[string]string{"trivy-operator.resource.kind": "Pod"}
+		default:
+			labels = nil // scan-* name in trivy-system
+		}
+		objs = append(objs, mkJob("trivy-system", "scan-vulnerabilityreport-"+strconv.Itoa(i), "", labels))
+	}
+	// syft-grype: the CronJob + its spawned Jobs (owner ref) + a label-only
+	// Job + a bare namespace-only Job — all fold onto the one syft identity.
+	objs = append(objs, mkCron("syft-grype", "syft-grype"))
+	for i := 0; i < 12; i++ {
+		objs = append(objs, mkJob("syft-grype", "syft-grype-run-"+strconv.Itoa(i), "syft-grype", nil))
+	}
+	objs = append(objs, mkJob("syft-grype", "syft-grype-orphan", "",
+		map[string]string{"catalyst.openova.io/blueprint": "bp-syft-grype"}))
+	objs = append(objs, mkJob("syft-grype", "stray-job-no-labels", "", nil))
+
+	// --- the real convergence set (must each become a DAG node) ---
+	objs = append(objs,
+		mkJob("cnpg", "cnpg-pair-primary-join", "", nil),
+		mkJob("openbao", "openbao-init-29000111", "", nil),
+		mkJob("gitea", "gitea-sso-configure", "", nil),
+	)
+
+	obs, err := helmwatch.ListReconcilerObservations(context.Background(), scannerExclusionFakeClient(objs...))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+
+	bridge := jobs.NewBridge(st, depID)
+	if _, _, err := bridge.SeedReconcilerObservations(reconcilerObsToBridge(obs)); err != nil {
+		t.Fatalf("SeedReconcilerObservations: %v", err)
+	}
+
+	// Build the flow-diagram DAG exactly as the snapshot/stream endpoints do.
+	msg, ok := h.flowSnapshotFromJobs(depID)
+	if !ok || msg == nil {
+		t.Fatal("flowSnapshotFromJobs returned no snapshot")
+	}
+
+	// EXACTLY ONE collapsed node per scanner identity — and ZERO per-run nodes.
+	trivyNodeID := depID + ":" + jobs.TaskJobPrefix + "trivy-security-scan"
+	syftNodeID := depID + ":" + jobs.TaskJobPrefix + "syft-sbom"
+	trivyNodes, syftNodes, perRunNodes := 0, 0, 0
+	for _, n := range msg.Nodes {
+		switch n.ID {
+		case trivyNodeID:
+			trivyNodes++
+		case syftNodeID:
+			syftNodes++
+		default:
+			if perRunLooksLikeScanner(n.ID) || perRunLooksLikeScanner(n.Label) {
+				perRunNodes++
+				t.Errorf("a per-run scanner node leaked into the DAG: id=%q label=%q — runs must fold onto the identity node", n.ID, n.Label)
+			}
+		}
+	}
+	if trivyNodes != 1 {
+		t.Errorf("expected exactly 1 collapsed trivy node (%s); got %d (flood was %d runs)", trivyNodeID, trivyNodes, trivyRuns)
+	}
+	if syftNodes != 1 {
+		t.Errorf("expected exactly 1 collapsed syft node (%s); got %d", syftNodeID, syftNodes)
+	}
+	if perRunNodes != 0 {
+		t.Errorf("%d per-run scanner nodes leaked — scanners must collapse to one node each", perRunNodes)
+	}
+
+	// The collapsed scanner leaves each carry their run-history (run-count =
+	// Executions) in jobs.Store, proving the runs are NOT lost.
+	if _, execs, gerr := st.GetJob(depID, jobs.TaskJobPrefix+"trivy-security-scan"); gerr != nil {
+		t.Errorf("collapsed trivy leaf missing from store: %v", gerr)
+	} else if len(execs) != trivyRuns {
+		t.Errorf("collapsed trivy leaf should carry %d runs as run-history; got %d Executions", trivyRuns, len(execs))
+	}
+
+	// The 3 real reconciler Jobs each ARE nodes (as Reconcilers-group task leaves).
+	wantNodeSuffixes := []string{
+		jobs.TaskJobPrefix + "cnpg-pair-primary-join",
+		jobs.TaskJobPrefix + "openbao-init", // run-suffix stripped
+		jobs.TaskJobPrefix + "gitea-sso-configure",
+	}
+	for _, suf := range wantNodeSuffixes {
+		found := false
+		for _, n := range msg.Nodes {
+			if strings.HasSuffix(n.ID, ":"+suf) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("real reconciler node %q missing from the flow DAG — collapse must not drop genuine reconcilers", suf)
+		}
+	}
+}
+
+// perRunLooksLikeScanner reports whether a node id/label references a PER-RUN
+// scanner artifact (an individual trivy scan-* Job, a syft-grype-run-* Job, or
+// the retired "security-scans" summary). The COLLAPSED identity nodes
+// (trivy-security-scan / syft-sbom) are expected and are NOT flagged here.
+func perRunLooksLikeScanner(s string) bool {
+	l := strings.ToLower(s)
+	return strings.Contains(l, "scan-vulnerabilityreport") ||
+		strings.Contains(l, "syft-grype-run") ||
+		strings.Contains(l, "syft-grype-orphan") ||
+		strings.Contains(l, "stray-job-no-labels") ||
+		strings.Contains(l, "security-scans")
+}

--- a/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
@@ -687,6 +687,13 @@ type ComponentSnapshot struct {
 	// from spec.dependsOn[].name with the "bp-" prefix stripped.
 	// Drives the Jobs Flow view's edge graph (issue #204).
 	DependsOn        []string  `json:"dependsOn,omitempty"`
+	// Stalled — true when Status==StateFailed AND Flux has exhausted its
+	// remediation.retries (Stalled=True / RetriesExceeded). The READ-side
+	// /jobs seed uses this to distinguish a STABLY-failed HR (terminal
+	// Failed leaf) from a still-retrying transient failure (in-progress
+	// leaf), so a healthy-but-converging HR never flaps Failed↔Succeeded
+	// on the page (issue #3916). Meaningless when Status != StateFailed.
+	Stalled          bool      `json:"stalled,omitempty"`
 }
 
 // NewWatcher returns a Watcher with cfg applied. emit must be non-nil
@@ -1792,6 +1799,33 @@ func DeriveState(conds []metav1.Condition) string {
 	return StatePending
 }
 
+// IsStalledHelmRelease reports whether a HelmRelease has STABLY failed —
+// Flux's remediation.retries are exhausted and helm-controller will NOT
+// auto-reconcile again without a spec change or manual reconcile. Flux
+// signals this with the Stalled=True condition (and/or a RetriesExceeded
+// Ready reason).
+//
+// This is DISTINCT from DeriveState's StateFailed, which fires the instant
+// a transient InstallFailed/UpgradeFailed appears — even while retries
+// remain. The live Phase-1 Watcher WANTS that eager StateFailed so its
+// late-poll/recovery machinery (issue #910) engages; this helper is for
+// the READ-side /jobs projection, which must NOT flap a leaf Failed↔
+// Succeeded while a healthy-but-still-retrying HR oscillates (issue #3916).
+// A failed-but-not-stalled HR is reported to the jobs page as "installing"
+// (in-progress); only a stalled one becomes a terminal Failed leaf.
+func IsStalledHelmRelease(u *unstructured.Unstructured) bool {
+	conds, _ := extractConditions(u)
+	if c := findCondition(conds, "Stalled"); c != nil && c.Status == metav1.ConditionTrue {
+		return true
+	}
+	if ready := findCondition(conds, "Ready"); ready != nil &&
+		ready.Status == metav1.ConditionFalse &&
+		strings.EqualFold(strings.TrimSpace(ready.Reason), "RetriesExceeded") {
+		return true
+	}
+	return false
+}
+
 // isDependencyMessage matches helm-controller's standard "dependency 'X'
 // is not ready" message family. We pin on substring rather than reason
 // because helm-controller emits Reason=DependencyNotReady AND
@@ -2001,6 +2035,7 @@ func (w *Watcher) SnapshotComponents() []ComponentSnapshot {
 			LastTransitionAt: lastTransitionAt.UTC(),
 			Message:          message,
 			DependsOn:        extractDependsOn(u),
+			Stalled:          state == StateFailed && IsStalledHelmRelease(u),
 		})
 	}
 	return out
@@ -2058,6 +2093,7 @@ func ListAndSnapshotHelmReleases(ctx context.Context, dyn dynamic.Interface) ([]
 			LastTransitionAt: lastTransitionAt.UTC(),
 			Message:          message,
 			DependsOn:        extractDependsOn(u),
+			Stalled:          state == StateFailed && IsStalledHelmRelease(u),
 		})
 	}
 	return out, nil

--- a/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers.go
@@ -61,6 +61,54 @@ var (
 // are in scope"). The reconciler chart stamps it via a render marker.
 const ReconcilerMarkerLabel = "catalyst.openova.io/reconciler"
 
+// Day-2 security-scanner namespaces (issue #3919 / #3925). The provisioning
+// Jobs view surfaces the FINITE job set (one-shot bootstrap/seed/migration
+// Jobs AND scheduled-recurring jobs like scans + backups). Day-2 background
+// scanners run FOREVER, minting a fresh Job per scan run — on a converged
+// Sovereign that is HUNDREDS of ever-growing per-run rows (614 trivy reports
+// observed live on hw171) that dwarf the ~100 real reconcilers.
+//
+// The #3925 model (jobs-convergence-monitor-model.md §4 Surface B): a
+// recurring scan is NOT a third nature and is NOT excluded — it is a finite
+// job that recurs. So each scanner COLLAPSES to exactly ONE identity-keyed
+// row carrying its run-history (run count + last-run + status), never 600
+// rows and never dropped. This supersedes the earlier #3919 disposition
+// (exclude entirely): the scanner identity is detected the same way
+// (isDay2ScannerJob), but its runs are folded onto ONE leaf as Executions
+// (the same collapse the cron + task leaves already use), so the Jobs view
+// shows "trivy security-scan · 600 runs" / "syft sbom · 37 runs" — one row
+// each. Two scanners collapse:
+//
+//   - trivy-operator — one short-lived scan-* Job per workload (+ per
+//     container), continuously re-scanned, in trivyScanNamespace. Detected by
+//     isTrivyScanJob; all runs fold onto the trivyScanIdentity row.
+//   - syft-grype     — a daily SBOM/vuln CronJob in syftGrypeNamespace whose
+//     spawned Jobs carry a CronJob ownerReference to syftGrypeCronName. The
+//     CronJob seeds the syftScanIdentity row in pass 2; its spawned + any
+//     namespace-resident scan Jobs fold on as Executions in pass 3.
+const (
+	// trivyScanNamespace — the namespace the trivy-operator runs its scan
+	// Jobs in. Scan Jobs anywhere else are still caught by the label/name
+	// checks in isDay2ScannerJob; this is the fast common-case match.
+	trivyScanNamespace = "trivy-system"
+	// syftGrypeNamespace — the namespace bp-syft-grype installs into
+	// (clusters/_template/bootstrap-kit/33-syft-grype.yaml targetNamespace).
+	syftGrypeNamespace = "syft-grype"
+	// syftGrypeCronName — the bp-syft-grype CronJob name (releaseName in the
+	// slot-33 HelmRelease). Its spawned Jobs carry it as a CronJob owner.
+	syftGrypeCronName = "syft-grype"
+
+	// trivyScanIdentity / syftScanIdentity — the STABLE identity the
+	// collapsed scanner row is keyed on (#3925). Every trivy scan Job folds
+	// onto trivyScanIdentity; every syft-grype run folds onto
+	// syftScanIdentity. These are the task-<identity> leaf names the Jobs
+	// view renders ONE row for, with all runs behind them as Executions.
+	// Names are operator-readable (DeriveLeafDisplayName humanises them to
+	// "Trivy Security Scan (task)" / "Syft SBOM (task)").
+	trivyScanIdentity = "trivy-security-scan"
+	syftScanIdentity  = "syft-sbom"
+)
+
 // Reconciler-observation Kind tags. These mirror the jobs.Kind* leaf
 // kinds 1:1 (kept as plain strings here so this package does not import
 // internal/jobs and create a cycle). The bridge maps them through.
@@ -182,9 +230,42 @@ func ListReconcilerObservations(ctx context.Context, dyn dynamic.Interface) ([]R
 	// because pass 3 only ever appends AFTER the cron rows, so out[idx]
 	// always addresses the same logical element in the current array.
 	cronIdx := map[string]int{} // ns/name → index into out
+	// taskIdx indexes standalone task leaves by ns/base-name (issue #3916)
+	// so multiple runs of the same base Job collapse into ONE stable leaf
+	// with per-run Executions, never a fresh leaf per run. Indexed by
+	// position in `out` (never a cached pointer) for the same
+	// reallocation-safety reason cronIdx is.
+	taskIdx := map[string]int{} // ns/base → index into out
+	// scannerIdx indexes the ONE collapsed Day-2 scanner row per scanner
+	// identity (#3925) — trivyScanIdentity / syftScanIdentity. Every scan
+	// Job folds its run onto the single identity row as an Execution, so a
+	// 600-run trivy flood is ONE row + 600 runs, never 600 rows (and never
+	// dropped — a recurring scan is a finite job that recurs). Position-
+	// indexed for the same reallocation-safety reason cronIdx/taskIdx are.
+	scannerIdx := map[string]int{} // scanner-identity → index into out
 	if list, err := dyn.Resource(CronJobGVR).Namespace("").List(ctx, metav1.ListOptions{}); err == nil {
 		for i := range list.Items {
 			u := &list.Items[i]
+			// Day-2 scanner CronJob (syft-grype) → COLLAPSES onto the single
+			// syftScanIdentity row (#3925), NOT a per-CronJob cron-* leaf.
+			// Seeding the identity row HERE (pending until its first run) means
+			// the Jobs view shows "syft sbom" even before any run lands, and
+			// the CronJob's spawned Jobs fold their runs onto this same row as
+			// Executions in pass 3 (keyed by scannerIdentity, not by owner).
+			if isDay2ScannerCronJob(u) {
+				key := syftScanIdentity
+				if _, ok := scannerIdx[key]; !ok {
+					out = append(out, ReconcilerObservation{
+						Kind:      ReconcilerKindTask,
+						Name:      syftScanIdentity,
+						Namespace: u.GetNamespace(),
+						Status:    ObsStatusPending,
+						Message:   "recurring SBOM scan: no run observed yet",
+					})
+					scannerIdx[key] = len(out) - 1
+				}
+				continue
+			}
 			obs := ReconcilerObservation{
 				Kind:      ReconcilerKindCron,
 				Name:      u.GetName(),
@@ -204,10 +285,27 @@ func ListReconcilerObservations(ctx context.Context, dyn dynamic.Interface) ([]R
 	// Execution on an install leaf (HR install-hook), or a standalone
 	// task-<name> leaf. The ownership de-dup (issue #3646 §5a) keys off
 	// metadata.ownerReferences + the helm hook label.
+	//
+	// Day-2 security-scanner Jobs (trivy-operator + syft-grype, #3919/#3925)
+	// COLLAPSE onto ONE identity-keyed row per scanner — they never mint a
+	// per-run task-* leaf. The trivy-operator spawns one short-lived scan Job
+	// per workload (+ per container) and re-scans forever; syft-grype runs a
+	// daily SBOM CronJob. Both are finite jobs that RECUR (model §3): a
+	// recurring scan is one entity with a run-history behind it, not 600 rows
+	// and not excluded. So each scan Job folds its run onto the single
+	// scanner-identity row as an Execution (the same collapse the cron + task
+	// leaves use), recency-resolving the headline status — the Jobs view shows
+	// "trivy security-scan · N runs" / "syft sbom · N runs", one row each.
 	if list, err := dyn.Resource(JobGVR).Namespace("").List(ctx, metav1.ListOptions{}); err == nil {
 		for i := range list.Items {
 			u := &list.Items[i]
 			status, started, finished := jobRunStatus(u)
+			// Day-2 scanner Job (trivy-operator scan-* OR a syft-grype run)
+			// → fold its run onto the ONE collapsed identity row (#3925).
+			if id, ok := scannerIdentity(u); ok {
+				foldScannerRun(&out, scannerIdx, id, u.GetNamespace(), u, status, started, finished)
+				continue
+			}
 			if cronName, ok := cronJobOwnerName(u); ok {
 				// Attach as an Execution under the owning cron leaf. Mutate
 				// through the index (out[idx]) so the write always lands on
@@ -245,6 +343,9 @@ func ListReconcilerObservations(ctx context.Context, dyn dynamic.Interface) ([]R
 			}
 			if chart, ok := installHookOwnerChart(u); ok {
 				// HR install-hook Job — attaches under install-<chart>.
+				// Keyed by the OWNING chart (the install leaf), so per-run
+				// instance names never matter here — the install bridge
+				// dedups the Execution.
 				out = append(out, ReconcilerObservation{
 					Kind:              ReconcilerKindTask,
 					Name:              u.GetName(),
@@ -256,15 +357,60 @@ func ListReconcilerObservations(ctx context.Context, dyn dynamic.Interface) ([]R
 				})
 				continue
 			}
-			// Standalone / cluster-owned batch Job → task-<name> leaf.
+			// Standalone / cluster-owned batch Job → a STABLE task-<base>
+			// leaf, NOT task-<per-run-name>.
+			//
+			// Accumulation bug (issue #3916): a Job created from a
+			// generateName (or re-created by Flux on each reconcile/retry)
+			// carries a fresh `-<hash>` run suffix every time. Keying the leaf
+			// on u.GetName() minted a brand-new task-* row per run → the /jobs
+			// model grew unbounded (region A 141→145 while the actual k8s Jobs
+			// stayed ~18-24/region). The fix keys the leaf on the STABLE base
+			// identity (taskBaseName) and records the per-run instance as an
+			// Execution under that one leaf — so N reruns = 1 row + N runs,
+			// never N rows. Identical structure across regions because the key
+			// no longer carries the run-instance entropy.
+			base := taskBaseName(u)
+			key := u.GetNamespace() + "/" + base
+			if idx, ok := taskIdx[key]; ok {
+				c := &out[idx]
+				c.Executions = append(c.Executions, ReconcilerExecution{
+					Name:       u.GetName(),
+					Status:     status,
+					StartedAt:  started,
+					FinishedAt: finished,
+					Message:    "run " + u.GetName() + ": " + status,
+				})
+				// Headline status reflects the MOST RECENT run (same recency
+				// rule as the cron leaf): a stale Succeeded run arriving after
+				// a fresh Failed one must not overwrite the failure. Recency =
+				// finish time, falling back to start for an in-flight run.
+				runAt := firstNonZero(finished, started)
+				if c.ObservedAt.IsZero() || runAt.IsZero() || !runAt.Before(c.ObservedAt) {
+					c.Status = status
+					c.Message = "last run " + u.GetName() + ": " + status
+					if !runAt.IsZero() {
+						c.ObservedAt = runAt
+					}
+				}
+				continue
+			}
 			out = append(out, ReconcilerObservation{
-				Kind:       ReconcilerKindTask,
-				Name:       u.GetName(),
-				Namespace:  u.GetNamespace(),
-				Status:     status,
-				Message:    "batch job: " + status,
+				Kind:      ReconcilerKindTask,
+				Name:      base,
+				Namespace: u.GetNamespace(),
+				Status:    status,
+				Message:   "batch job: " + status,
+				Executions: []ReconcilerExecution{{
+					Name:       u.GetName(),
+					Status:     status,
+					StartedAt:  started,
+					FinishedAt: finished,
+					Message:    "run " + u.GetName() + ": " + status,
+				}},
 				ObservedAt: firstNonZero(finished, started),
 			})
+			taskIdx[key] = len(out) - 1
 		}
 	}
 
@@ -292,10 +438,27 @@ func ListReconcilerObservations(ctx context.Context, dyn dynamic.Interface) ([]R
 	return out, nil
 }
 
-// statusFromReadyCondition maps a Ready condition onto the one-shot
-// lifecycle status. Ready=True ⇒ succeeded; Ready=False with a terminal
-// reason ⇒ failed; otherwise running (reconcile in progress); no Ready
-// condition ⇒ pending.
+// statusFromReadyCondition maps a Flux Kustomization's Ready condition
+// onto the lifecycle status WITHOUT flapping a still-reconciling object
+// into a terminal Failed (issue #3916).
+//
+// Flux reconciles continuously: a healthy-but-converging Kustomization
+// oscillates Ready between False(reason=Progressing / BuildFailed /
+// HealthCheckFailed / DependencyNotReady, while it retries) and
+// True(reason=ReconciliationSucceeded). Because the chroot seed re-reads
+// live state on every /jobs poll and the later status wins, mapping each
+// transient False to terminal `failed` made the leaf flap Failed↔Succeeded
+// on the page even though the prov converged green.
+//
+// The mapping therefore only emits a TERMINAL status for a STABLE state:
+//   - Ready=True                       ⇒ succeeded (stably reconciled).
+//   - Ready=False, reason=Stalled      ⇒ failed (Flux's own permanent /
+//     terminal signal — it has GIVEN UP retrying; this is the only honest
+//     terminal failure for a continuously-reconciling object).
+//   - Ready=False, any other reason    ⇒ running (still reconciling /
+//     retrying — a transient build/health/dependency error Flux will
+//     re-attempt; NOT a terminal failure).
+//   - Ready=Unknown / no Ready cond    ⇒ running / pending.
 func statusFromReadyCondition(conds []metav1.Condition) string {
 	ready := findCondition(conds, "Ready")
 	if ready == nil {
@@ -305,11 +468,11 @@ func statusFromReadyCondition(conds []metav1.Condition) string {
 	case metav1.ConditionTrue:
 		return ObsStatusSucceeded
 	case metav1.ConditionFalse:
-		// A Kustomization that is progressing reports Ready=False with
-		// reason=Progressing/ReconciliationFailed. Treat an explicit
-		// failure reason as failed; anything else as still running.
-		r := strings.ToLower(ready.Reason)
-		if strings.Contains(r, "fail") || strings.Contains(r, "error") || strings.Contains(r, "stalled") {
+		// Only Flux's terminal "Stalled" reason (retries exhausted, no
+		// further automatic reconcile) is a genuine terminal failure. Every
+		// other Ready=False is an in-flight reconcile/retry — running, never
+		// a flapping terminal Failed.
+		if strings.EqualFold(strings.TrimSpace(ready.Reason), "Stalled") {
 			return ObsStatusFailed
 		}
 		return ObsStatusRunning
@@ -363,6 +526,249 @@ func jobStartTime(u *unstructured.Unstructured) time.Time {
 		}
 	}
 	return time.Time{}
+}
+
+// taskBaseName returns the STABLE base identity for a standalone batch
+// Job (issue #3916) — the key the task-<base> leaf is minted under, so
+// repeated runs of the same logical task collapse into one leaf with
+// per-run Executions instead of accumulating a fresh leaf per run.
+//
+// Resolution order:
+//  1. metadata.generateName — authoritative when present. The Job
+//     controller (and Flux's prune-and-recreate) sets generateName to the
+//     base and lets the apiserver append a "-<5-char-rand>" suffix, so the
+//     generateName (minus its trailing dash) IS the stable identity.
+//  2. otherwise strip a single trailing controller-appended run suffix
+//     from metadata.name: either a numeric CronJob-style "-<digits>"
+//     stamp or a lowercase-alphanumeric "-<hash>" (>=5 chars) the Job
+//     controller / generateName path leaves. A name with no such suffix
+//     (a human-authored fixed-name Job) is returned unchanged.
+//
+// The stripping is deliberately conservative — it removes AT MOST ONE
+// trailing segment and only when that segment looks machine-generated, so
+// a meaningful final segment of a fixed name (e.g. "cnpg-pair-primary-3-
+// join") is preserved.
+func taskBaseName(u *unstructured.Unstructured) string {
+	if gn := strings.TrimSpace(u.GetGenerateName()); gn != "" {
+		return strings.TrimRight(gn, "-")
+	}
+	name := u.GetName()
+	i := strings.LastIndexByte(name, '-')
+	if i <= 0 || i == len(name)-1 {
+		return name
+	}
+	suffix := name[i+1:]
+	if isRunSuffix(suffix) {
+		return name[:i]
+	}
+	return name
+}
+
+// isRunSuffix reports whether a trailing name segment looks like a
+// controller-appended run instance id: an all-digit stamp (CronJob unix
+// minute, e.g. "28912345") OR a lowercase base36-ish hash of length >=5
+// (the apiserver's generateName suffix is 5 lowercase alphanumerics, e.g.
+// "x7f2k"). Pure-alpha words shorter than the hash length, or any segment
+// containing an uppercase letter, are treated as MEANINGFUL (not a run id)
+// so a fixed-name Job like "...-join" or "...-migrate" is never truncated.
+func isRunSuffix(s string) bool {
+	if s == "" {
+		return false
+	}
+	allDigits := true
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			allDigits = false
+			break
+		}
+	}
+	if allDigits {
+		return true
+	}
+	// generateName random suffix: exactly-5 lowercase [a-z0-9], and NOT
+	// all-letters (an all-letters 5-char tail like "build" or "enrol" is a
+	// real word, not a hash). Require at least one digit to distinguish a
+	// random suffix from a meaningful trailing word.
+	if len(s) != 5 {
+		return false
+	}
+	hasDigit := false
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		case r >= 'a' && r <= 'z':
+		default:
+			return false
+		}
+	}
+	return hasDigit
+}
+
+// isDay2ScannerJob reports whether a batch Job is a Day-2 security-scanner
+// run (trivy-operator OR syft-grype, #3919/#3925). A scanner run does NOT
+// mint its own per-run task-* leaf — instead it COLLAPSES onto ONE
+// identity-keyed row per scanner via scannerIdentity + foldScannerRun, so a
+// 600-run flood is one row with a run-history behind it (model §4 Surface B),
+// never 600 rows and never excluded.
+//
+// Day-2 scanners run forever: the trivy-operator spawns one short-lived scan
+// Job per workload (+ per container) and re-scans continuously (producing the
+// VulnerabilityReport / ConfigAuditReport / ExposedSecretReport /
+// RbacAssessmentReport CRs); syft-grype runs a daily SBOM/vuln CronJob whose
+// spawned Jobs accumulate under successfulJobsHistoryLimit. On a converged
+// Sovereign that is hundreds of ever-growing per-run rows that dwarf the ~100
+// real reconcilers. Collapsing them to one identity row each kills the flood
+// while keeping the recurring scan visible as the finite job it is.
+//
+// Detection is layered + conservative (any match ⇒ scanner Job), so a
+// TENANT's own Job named "scan-*" in some other namespace, or a non-scanner
+// user Job, is never swept up:
+//
+//	trivy-operator:
+//	 1. the trivy-operator managed-by label
+//	    (app.kubernetes.io/managed-by=trivy-operator) — stamped on every
+//	    scan Job the operator creates;
+//	 2. any trivy-operator.* label key (e.g. trivy-operator.resource.kind),
+//	    present on scan Jobs regardless of the managed-by value;
+//	 3. the well-known scan-* name prefix scoped to the trivy-system
+//	    namespace, a belt-and-braces fallback if a future operator release
+//	    strips the labels. Name-prefix alone OUTSIDE trivy-system is
+//	    intentionally NOT treated as a scan Job.
+//
+//	syft-grype:
+//	 4. a CronJob ownerReference to the syft-grype CronJob (the kube CronJob
+//	    controller stamps it on every spawned run) — authoritative;
+//	 5. the bp-syft-grype managed-by/instance label scoped to the
+//	    syft-grype namespace, for a Job that lost its owner ref;
+//	 6. residence in the syft-grype namespace, a final belt-and-braces
+//	    fallback (the whole namespace is the scanner's, so any Job there is a
+//	    scan run). Namespace-scoping keeps a same-named tenant Job elsewhere
+//	    surfaced as a real task.
+func isDay2ScannerJob(u *unstructured.Unstructured) bool {
+	return isTrivyScanJob(u) || isSyftGrypeScannerJob(u)
+}
+
+// scannerIdentity returns the STABLE collapse identity for a Day-2 scanner
+// Job (#3925) — trivyScanIdentity for any trivy-operator scan Job,
+// syftScanIdentity for any syft-grype run — and ok=false for a non-scanner
+// Job. Every run of a scanner maps to the SAME identity, which is what makes
+// the 600-run flood fold onto one row. Trivy is checked first; the two
+// detection sets are namespace-disjoint so order is immaterial in practice.
+func scannerIdentity(u *unstructured.Unstructured) (string, bool) {
+	if isTrivyScanJob(u) {
+		return trivyScanIdentity, true
+	}
+	if isSyftGrypeScannerJob(u) {
+		return syftScanIdentity, true
+	}
+	return "", false
+}
+
+// foldScannerRun records ONE scanner run as an Execution on the single
+// identity-keyed scanner row (#3925), creating the row on first sight. This
+// is the collapse: N scan Jobs sharing an identity ⇒ 1 row + N Executions
+// (run-history), never N rows. The headline status is recency-resolved (the
+// MOST RECENT run wins — a stale Succeeded arriving after a fresh Failed must
+// not overwrite the failure), identical to the cron + task leaf recency rule,
+// so the row never flaps on re-ingest. The row is indexed by position in
+// `out` (never a cached pointer) for the same reallocation-safety reason
+// cronIdx/taskIdx are.
+func foldScannerRun(out *[]ReconcilerObservation, scannerIdx map[string]int, identity, ns string, u *unstructured.Unstructured, status string, started, finished time.Time) {
+	run := ReconcilerExecution{
+		Name:       u.GetName(),
+		Status:     status,
+		StartedAt:  started,
+		FinishedAt: finished,
+		Message:    "scan run " + u.GetName() + ": " + status,
+	}
+	runAt := firstNonZero(finished, started)
+	if idx, ok := scannerIdx[identity]; ok {
+		c := &(*out)[idx]
+		c.Executions = append(c.Executions, run)
+		// Recency-resolve the headline so the collapsed row reflects the
+		// latest run, regardless of apiserver list order.
+		if c.ObservedAt.IsZero() || runAt.IsZero() || !runAt.Before(c.ObservedAt) {
+			c.Status = status
+			c.Message = "last scan run " + u.GetName() + ": " + status
+			if !runAt.IsZero() {
+				c.ObservedAt = runAt
+			}
+		}
+		return
+	}
+	*out = append(*out, ReconcilerObservation{
+		Kind:       ReconcilerKindTask,
+		Name:       identity,
+		Namespace:  ns,
+		Status:     status,
+		Message:    "recurring scan, last run " + u.GetName() + ": " + status,
+		Executions: []ReconcilerExecution{run},
+		ObservedAt: runAt,
+	})
+	scannerIdx[identity] = len(*out) - 1
+}
+
+// isTrivyScanJob — trivy-operator detection paths (1)-(3) above.
+func isTrivyScanJob(u *unstructured.Unstructured) bool {
+	labels := u.GetLabels()
+	if strings.EqualFold(strings.TrimSpace(labels["app.kubernetes.io/managed-by"]), "trivy-operator") {
+		return true
+	}
+	for k := range labels {
+		if strings.HasPrefix(k, "trivy-operator.") {
+			return true
+		}
+	}
+	if u.GetNamespace() == trivyScanNamespace && strings.HasPrefix(u.GetName(), "scan-") {
+		return true
+	}
+	return false
+}
+
+// isSyftGrypeScannerJob — syft-grype detection paths (4)-(6) above.
+func isSyftGrypeScannerJob(u *unstructured.Unstructured) bool {
+	// (4) spawned by the syft-grype CronJob — owner ref is authoritative
+	// regardless of namespace.
+	if owner, ok := cronJobOwnerName(u); ok && owner == syftGrypeCronName {
+		return true
+	}
+	// (5) bp-syft-grype-labelled Job in the syft-grype namespace. The
+	// bp-syft-grype helper labels stamp app.kubernetes.io/managed-by=Helm and
+	// app.kubernetes.io/instance=syft-grype + catalyst.openova.io/blueprint=
+	// bp-syft-grype; key off the blueprint/instance marker, namespace-scoped.
+	labels := u.GetLabels()
+	if u.GetNamespace() == syftGrypeNamespace {
+		if strings.EqualFold(strings.TrimSpace(labels["catalyst.openova.io/blueprint"]), "bp-syft-grype") {
+			return true
+		}
+		if strings.EqualFold(strings.TrimSpace(labels["app.kubernetes.io/instance"]), syftGrypeCronName) {
+			return true
+		}
+		// (6) any other Job in the syft-grype namespace — the namespace is
+		// exclusively the scanner's, so a stray Job there is still a scan run.
+		return true
+	}
+	return false
+}
+
+// isDay2ScannerCronJob reports whether a batch CronJob is a Day-2 scanner
+// CronJob (syft-grype) that must be excluded from the flow + diagram. The
+// trivy-operator does NOT use a CronJob (it self-spawns Jobs), so this only
+// matches syft-grype: by name+namespace, or by the bp-syft-grype blueprint
+// label, namespace-scoped so a tenant CronJob elsewhere is untouched.
+func isDay2ScannerCronJob(u *unstructured.Unstructured) bool {
+	if u.GetNamespace() != syftGrypeNamespace {
+		return false
+	}
+	if u.GetName() == syftGrypeCronName {
+		return true
+	}
+	labels := u.GetLabels()
+	if strings.EqualFold(strings.TrimSpace(labels["catalyst.openova.io/blueprint"]), "bp-syft-grype") {
+		return true
+	}
+	return false
 }
 
 // cronJobOwnerName returns the owning CronJob name when the Job carries a

--- a/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers_test.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/reconcilers_test.go
@@ -17,6 +17,7 @@ package helmwatch
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -236,3 +237,446 @@ func TestListReconcilerObservations_CronJobWithNoRunIsPending(t *testing.T) {
 		t.Errorf("never-run cron should carry no Executions, got %d", len(cron.Executions))
 	}
 }
+
+// makeKustomization constructs a Flux Kustomization unstructured object with
+// a single Ready condition (status + reason) so statusFromReadyCondition can
+// be driven through ListReconcilerObservations.
+func makeKustomization(namespace, name string, readyStatus metav1.ConditionStatus, reason string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+			"kind":       "Kustomization",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{
+						"type":               "Ready",
+						"status":             string(readyStatus),
+						"reason":             reason,
+						"lastTransitionTime": time.Now().UTC().Format(time.RFC3339),
+					},
+				},
+			},
+		},
+	}
+	u.SetGroupVersionKind(schema.GroupVersionKind{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Kind: "Kustomization"})
+	return u
+}
+
+func findReconcile(obs []ReconcilerObservation, name string) *ReconcilerObservation {
+	for i := range obs {
+		if obs[i].Kind == ReconcilerKindReconcile && obs[i].Name == name {
+			return &obs[i]
+		}
+	}
+	return nil
+}
+
+func findTask(obs []ReconcilerObservation, name string) *ReconcilerObservation {
+	for i := range obs {
+		if obs[i].Kind == ReconcilerKindTask && obs[i].Name == name {
+			return &obs[i]
+		}
+	}
+	return nil
+}
+
+// TestStatusFromReadyCondition_TransientFalseIsRunningNotFailed pins the
+// anti-flap contract (issue #3916): a Kustomization that is still
+// reconciling — Ready=False with a transient build/health/dependency reason
+// Flux will RETRY — must read as running (in-progress), NEVER a terminal
+// Failed that flaps back to Succeeded on the next poll. Only Flux's terminal
+// "Stalled" reason is a genuine terminal failure.
+func TestStatusFromReadyCondition_TransientFalseIsRunningNotFailed(t *testing.T) {
+	transient := []string{
+		"BuildFailed", "HealthCheckFailed", "ReconciliationFailed",
+		"Progressing", "DependencyNotReady", "ArtifactFailed",
+	}
+	for _, reason := range transient {
+		obs, err := ListReconcilerObservations(context.Background(),
+			reconcilerFakeClient(makeKustomization("flux-system", "apps-"+reason, metav1.ConditionFalse, reason)))
+		if err != nil {
+			t.Fatalf("ListReconcilerObservations(%s): %v", reason, err)
+		}
+		rec := findReconcile(obs, "apps-"+reason)
+		if rec == nil {
+			t.Fatalf("reason=%s: no reconcile observation", reason)
+		}
+		if rec.Status == ObsStatusFailed {
+			t.Errorf("reason=%s: a still-reconciling Kustomization read TERMINAL failed — this is the flap (#3916); want running", reason)
+		}
+		if rec.Status != ObsStatusRunning {
+			t.Errorf("reason=%s: status = %q, want %q (in-progress)", reason, rec.Status, ObsStatusRunning)
+		}
+	}
+}
+
+// TestStatusFromReadyCondition_StalledIsTerminalFailed pins the converse: a
+// Kustomization Flux has GIVEN UP on (Ready=False, reason=Stalled) is a
+// genuine terminal failure and must surface as Failed.
+func TestStatusFromReadyCondition_StalledIsTerminalFailed(t *testing.T) {
+	obs, err := ListReconcilerObservations(context.Background(),
+		reconcilerFakeClient(makeKustomization("flux-system", "apps-dead", metav1.ConditionFalse, "Stalled")))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+	rec := findReconcile(obs, "apps-dead")
+	if rec == nil {
+		t.Fatal("no reconcile observation for the stalled Kustomization")
+	}
+	if rec.Status != ObsStatusFailed {
+		t.Errorf("stalled Kustomization status = %q, want %q (terminal)", rec.Status, ObsStatusFailed)
+	}
+}
+
+// TestStatusFromReadyCondition_ReadyTrueIsSucceeded keeps the happy path
+// honest: Ready=True is a stable terminal success.
+func TestStatusFromReadyCondition_ReadyTrueIsSucceeded(t *testing.T) {
+	obs, err := ListReconcilerObservations(context.Background(),
+		reconcilerFakeClient(makeKustomization("flux-system", "apps-ok", metav1.ConditionTrue, "ReconciliationSucceeded")))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+	rec := findReconcile(obs, "apps-ok")
+	if rec == nil || rec.Status != ObsStatusSucceeded {
+		t.Fatalf("Ready=True Kustomization want succeeded, got %+v", rec)
+	}
+}
+
+// TestListReconcilerObservations_TaskRunsCollapseToOneStableLeaf pins the
+// accumulation fix (issue #3916): N standalone Jobs that share a base
+// identity (a generateName, or a controller-appended run suffix) collapse
+// into ONE task-<base> leaf carrying N Executions — NOT N separate leaves.
+// Before the fix each run minted task-<unique-run-name>, growing the /jobs
+// model unbounded as Flux re-created the Jobs on every reconcile.
+func TestListReconcilerObservations_TaskRunsCollapseToOneStableLeaf(t *testing.T) {
+	t0 := time.Date(2026, 6, 19, 1, 0, 0, 0, time.UTC)
+
+	// Three runs of the same logical task, named via the generateName
+	// convention base + "-<5-rand>" the apiserver appends.
+	objs := []runtime.Object{}
+	mk := func(name string, gen string, fin time.Time) *unstructured.Unstructured {
+		u := makeBatchJob("data", name, "", "Complete", metav1.ConditionTrue, fin)
+		if gen != "" {
+			meta := u.Object["metadata"].(map[string]any)
+			meta["generateName"] = gen
+		}
+		return u
+	}
+	objs = append(objs,
+		mk("db-migrate-a1b2c", "db-migrate-", t0),
+		mk("db-migrate-d3e4f", "db-migrate-", t0.Add(time.Hour)),
+		mk("db-migrate-g5h6j", "db-migrate-", t0.Add(2*time.Hour)),
+	)
+
+	obs, err := ListReconcilerObservations(context.Background(), reconcilerFakeClient(objs...))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+
+	// Exactly ONE task leaf, keyed by the stable base "db-migrate".
+	taskCount := 0
+	for i := range obs {
+		if obs[i].Kind == ReconcilerKindTask {
+			taskCount++
+		}
+	}
+	if taskCount != 1 {
+		t.Fatalf("accumulation bug: want exactly 1 stable task leaf, got %d (one per run = the #3916 unbounded growth)", taskCount)
+	}
+	task := findTask(obs, "db-migrate")
+	if task == nil {
+		t.Fatalf("no task leaf keyed by the stable base name 'db-migrate'; got %d task observations", taskCount)
+	}
+	if len(task.Executions) != 3 {
+		t.Errorf("the 3 runs must record as 3 Executions under the one leaf, got %d", len(task.Executions))
+	}
+}
+
+// TestListReconcilerObservations_TaskRunSuffixStrippedFromName pins the
+// run-suffix stripping for Jobs without a generateName (re-created by Flux):
+// a numeric CronJob-style stamp and a 5-char random hash both collapse to the
+// same base, while a meaningful trailing word is preserved.
+func TestListReconcilerObservations_TaskRunSuffixStrippedFromName(t *testing.T) {
+	fin := time.Date(2026, 6, 19, 1, 0, 0, 0, time.UTC)
+	objs := []runtime.Object{
+		makeBatchJob("data", "snapshot-28999111", "", "Complete", metav1.ConditionTrue, fin),
+		makeBatchJob("data", "snapshot-29000222", "", "Complete", metav1.ConditionTrue, fin.Add(time.Hour)),
+		// A fixed-name Job whose final segment is a real word — must NOT
+		// be truncated.
+		makeBatchJob("data", "cnpg-pair-primary-join", "", "Complete", metav1.ConditionTrue, fin),
+	}
+	obs, err := ListReconcilerObservations(context.Background(), reconcilerFakeClient(objs...))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+	if findTask(obs, "snapshot") == nil {
+		t.Error("numeric run-suffix Jobs should collapse to task 'snapshot'")
+	}
+	if findTask(obs, "cnpg-pair-primary-join") == nil {
+		t.Error("a fixed-name Job's meaningful trailing word was wrongly stripped")
+	}
+	// And the two numeric runs are ONE leaf.
+	n := 0
+	for i := range obs {
+		if obs[i].Kind == ReconcilerKindTask && obs[i].Name == "snapshot" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("numeric-suffix runs want 1 stable leaf, got %d", n)
+	}
+}
+
+// makeScanJob constructs a trivy-operator security-scan Job (issue #3919) —
+// the kind that floods the /jobs canvas. label drives which detection path
+// is exercised: "managed-by" (app.kubernetes.io/managed-by=trivy-operator),
+// "resource-label" (a trivy-operator.* label key), or "name-only" (scan-*
+// name in trivy-system with NO trivy labels — the belt-and-braces fallback).
+func makeScanJob(name, label string, fin time.Time) *unstructured.Unstructured {
+	u := makeBatchJob(trivyScanNamespace, name, "", "Complete", metav1.ConditionTrue, fin)
+	meta := u.Object["metadata"].(map[string]any)
+	switch label {
+	case "managed-by":
+		meta["labels"] = map[string]any{"app.kubernetes.io/managed-by": "trivy-operator"}
+	case "resource-label":
+		meta["labels"] = map[string]any{"trivy-operator.resource.kind": "Pod", "trivy-operator.resource.name": "some-pod"}
+	case "name-only":
+		// no labels — relies on the scan-* name + trivy-system namespace
+	}
+	return u
+}
+
+// makeSyftJob constructs a syft-grype SBOM-scan Job (issue #3919). variant
+// drives the syft detection path exercised: "owner" (a CronJob ownerReference
+// to the syft-grype CronJob — authoritative), "label" (the bp-syft-grype
+// blueprint label, namespace-scoped), or "namespace-only" (a bare Job that
+// only resides in the syft-grype namespace — the belt-and-braces fallback).
+func makeSyftJob(name, variant string, fin time.Time) *unstructured.Unstructured {
+	owner := ""
+	if variant == "owner" {
+		owner = syftGrypeCronName
+	}
+	u := makeBatchJob(syftGrypeNamespace, name, owner, "Complete", metav1.ConditionTrue, fin)
+	meta := u.Object["metadata"].(map[string]any)
+	switch variant {
+	case "label":
+		meta["labels"] = map[string]any{
+			"catalyst.openova.io/blueprint": "bp-syft-grype",
+			"app.kubernetes.io/instance":    "syft-grype",
+		}
+	case "namespace-only":
+		// no labels, no owner — relies solely on the syft-grype namespace
+	}
+	return u
+}
+
+// setJobFailed flips a batch Job's terminal condition from "Complete" to
+// "Failed" in place (status.conditions[0].type), so jobRunStatus reports it
+// as a failed run. Used to model a scan run that errored.
+func setJobFailed(u *unstructured.Unstructured) {
+	status, _ := u.Object["status"].(map[string]any)
+	conds, _ := status["conditions"].([]any)
+	if len(conds) > 0 {
+		if c, ok := conds[0].(map[string]any); ok {
+			c["type"] = "Failed"
+		}
+	}
+}
+
+// TestListReconcilerObservations_Day2ScannersCollapseToOneIdentityRow pins
+// the #3925 model (jobs-convergence-monitor-model.md §4 Surface B): Day-2
+// security-scanner Jobs (trivy-operator AND syft-grype) are NOT excluded and
+// are NOT one-row-per-run — each scanner COLLAPSES to exactly ONE
+// identity-keyed task row carrying its run-history (all runs as Executions),
+// so a 600-run flood is one row + 600 runs. This supersedes the earlier #3919
+// "exclude entirely" disposition: a recurring scan is a finite job that
+// recurs, so it belongs in the Jobs view as one row, never dropped.
+func TestListReconcilerObservations_Day2ScannersCollapseToOneIdentityRow(t *testing.T) {
+	t0 := time.Date(2026, 6, 20, 1, 0, 0, 0, time.UTC)
+	objs := []runtime.Object{}
+
+	// Simulate the live hw171 flood: a large fleet of trivy scan Jobs across
+	// all three trivy detection paths. 600 stands in for the ~614 reports
+	// observed live — this is the exact "600 runs behind it" case the model
+	// names.
+	trivyFleet := 600
+	for i := 0; i < trivyFleet; i++ {
+		var label string
+		switch i % 3 {
+		case 0:
+			label = "managed-by"
+		case 1:
+			label = "resource-label"
+		default:
+			label = "name-only"
+		}
+		// Each run finishes at a distinct minute so recency is well-defined;
+		// run i finishes at t0+i minutes, so the LAST one is the most recent.
+		objs = append(objs, makeScanJob("scan-vulnerabilityreport-"+itoaTest(i), label, t0.Add(time.Duration(i)*time.Minute)))
+	}
+
+	// A fleet of syft-grype SBOM Jobs across all three syft detection paths,
+	// PLUS the syft-grype CronJob itself (which seeds the identity row but
+	// must NOT mint its own cron-syft-grype leaf).
+	syftFleet := 30
+	for i := 0; i < syftFleet; i++ {
+		var variant string
+		switch i % 3 {
+		case 0:
+			variant = "owner"
+		case 1:
+			variant = "label"
+		default:
+			variant = "namespace-only"
+		}
+		objs = append(objs, makeSyftJob("syft-grype-2900"+itoaTest(i), variant, t0.Add(time.Duration(i)*time.Minute)))
+	}
+	objs = append(objs, makeCronJob(syftGrypeNamespace, syftGrypeCronName))
+
+	// A handful of REAL reconciler Jobs that must each still surface — incl. a
+	// fixed-name Job whose name starts "scan-" but lives in a TENANT namespace
+	// (NOT trivy-system) so it is a genuine task, not a scanner.
+	objs = append(objs,
+		makeBatchJob("cnpg", "cnpg-pair-primary-join", "", "Complete", metav1.ConditionTrue, t0),
+		makeBatchJob("openbao", "openbao-init-29000111", "", "Complete", metav1.ConditionTrue, t0),
+		makeBatchJob("gitea", "gitea-sso-configure", "", "Failed", metav1.ConditionTrue, t0),
+		makeBatchJob("acme-prod", "scan-invoices-nightly", "", "Complete", metav1.ConditionTrue, t0),
+	)
+
+	obs, err := ListReconcilerObservations(context.Background(), reconcilerFakeClient(objs...))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+
+	// Count task + cron leaves. After collapse the task leaves are: the 4 real
+	// reconcilers + exactly the 2 scanner identity rows. ZERO cron leaf for
+	// syft (its CronJob folds onto the syft identity task row instead).
+	taskLeaves := []string{}
+	cronLeaves := []string{}
+	for i := range obs {
+		switch obs[i].Kind {
+		case ReconcilerKindTask:
+			taskLeaves = append(taskLeaves, obs[i].Name)
+		case ReconcilerKindCron:
+			cronLeaves = append(cronLeaves, obs[i].Name)
+		}
+	}
+
+	// Exactly the 4 real reconciler Jobs + 2 collapsed scanner rows survive.
+	wantTasks := map[string]bool{
+		"cnpg-pair-primary-join": true,
+		"openbao-init":           true, // run-suffix stripped from -29000111
+		"gitea-sso-configure":    true,
+		"scan-invoices-nightly":  true, // tenant "scan-*" Job is a REAL task
+		trivyScanIdentity:        true, // collapsed trivy row
+		syftScanIdentity:         true, // collapsed syft row
+	}
+	if len(taskLeaves) != len(wantTasks) {
+		t.Fatalf("scanners NOT collapsed to one identity row: got %d task leaves %v, want exactly %d (4 real + 2 scanner). (pre-collapse ≈ %d trivy per-run rows)",
+			len(taskLeaves), taskLeaves, len(wantTasks), trivyFleet)
+	}
+	for _, name := range taskLeaves {
+		if !wantTasks[name] {
+			t.Errorf("unexpected task leaf %q — only the 4 real reconcilers + 2 collapsed scanner rows should exist", name)
+		}
+	}
+
+	// ZERO per-run scanner leaf leaked — no scan-vulnerabilityreport-* row, no
+	// syft-grype-<n> row, no legacy security-scans summary row, no cron leaf.
+	for _, name := range cronLeaves {
+		if name == syftGrypeCronName {
+			t.Errorf("the syft-grype scanner CronJob leaked a cron-%s leaf — it must collapse onto the %s row", name, syftScanIdentity)
+		}
+	}
+	for i := range obs {
+		n := obs[i].Name
+		if strings.HasPrefix(n, "scan-vulnerabilityreport-") ||
+			strings.HasPrefix(n, "syft-grype-") ||
+			n == "security-scans" {
+			t.Errorf("a per-run scanner leaf leaked into the flow: kind=%q name=%q — scanner runs must fold onto the identity row as Executions", obs[i].Kind, n)
+		}
+	}
+
+	// The collapsed trivy row carries ALL 600 runs as run-history (run count =
+	// number of Executions), exactly ONE row, Succeeded headline.
+	trivy := findTask(obs, trivyScanIdentity)
+	if trivy == nil {
+		t.Fatalf("expected one collapsed %q task row; got none", trivyScanIdentity)
+	}
+	if len(trivy.Executions) != trivyFleet {
+		t.Errorf("collapsed trivy row should carry %d runs (run-history); got %d Executions", trivyFleet, len(trivy.Executions))
+	}
+	if trivy.Status != ObsStatusSucceeded {
+		t.Errorf("collapsed trivy row headline should be Succeeded (all runs complete); got %q", trivy.Status)
+	}
+
+	// The collapsed syft row carries all 30 spawned runs as run-history.
+	syft := findTask(obs, syftScanIdentity)
+	if syft == nil {
+		t.Fatalf("expected one collapsed %q task row; got none", syftScanIdentity)
+	}
+	if len(syft.Executions) != syftFleet {
+		t.Errorf("collapsed syft row should carry %d runs (run-history); got %d Executions", syftFleet, len(syft.Executions))
+	}
+
+	// The genuine reconciler Jobs each survived with the right status (no
+	// flapping): gitea-sso-configure is Failed; the rest Succeeded.
+	if g := findTask(obs, "gitea-sso-configure"); g == nil || g.Status != ObsStatusFailed {
+		t.Errorf("gitea-sso-configure should survive as a Failed task, got %+v", g)
+	}
+	if c := findTask(obs, "cnpg-pair-primary-join"); c == nil || c.Status != ObsStatusSucceeded {
+		t.Errorf("cnpg-pair-primary-join should survive as a Succeeded task, got %+v", c)
+	}
+}
+
+// TestListReconcilerObservations_ScannerStickyHeadlineNoFlap pins the
+// sticky-terminal property of the collapsed scanner row (#3925/#3918): the
+// headline reflects the MOST RECENT run and never flaps to a stale run's
+// status. A fresh Failed run arriving after an older Succeeded one must leave
+// the row Failed; a later Succeeded run then recovers it — recency, not list
+// order, decides.
+func TestListReconcilerObservations_ScannerStickyHeadlineNoFlap(t *testing.T) {
+	t0 := time.Date(2026, 6, 20, 1, 0, 0, 0, time.UTC)
+
+	// List order is deliberately NON-chronological: the older Succeeded run is
+	// listed AFTER the newer Failed run, so a naive last-wins would wrongly
+	// report Succeeded. Recency resolution must pick the newer Failed.
+	older := makeScanJob("scan-vulnerabilityreport-old", "managed-by", t0)                       // succeeded, older
+	newer := makeScanJob("scan-vulnerabilityreport-new", "managed-by", t0.Add(10*time.Minute))   // failed, newer
+	// flip the newer run to a failed condition.
+	setJobFailed(newer)
+
+	obs, err := ListReconcilerObservations(context.Background(), reconcilerFakeClient(newer, older))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations: %v", err)
+	}
+	trivy := findTask(obs, trivyScanIdentity)
+	if trivy == nil {
+		t.Fatalf("expected one collapsed %q row", trivyScanIdentity)
+	}
+	if len(trivy.Executions) != 2 {
+		t.Errorf("expected 2 runs in run-history; got %d", len(trivy.Executions))
+	}
+	if trivy.Status != ObsStatusFailed {
+		t.Errorf("sticky headline should reflect the most-recent (Failed) run regardless of list order; got %q", trivy.Status)
+	}
+
+	// A still-later Succeeded run recovers the headline (real run status, not a
+	// frozen terminal — finite jobs ARE finite, the latest run wins).
+	recovered := makeScanJob("scan-vulnerabilityreport-recover", "managed-by", t0.Add(20*time.Minute))
+	obs2, err := ListReconcilerObservations(context.Background(), reconcilerFakeClient(newer, older, recovered))
+	if err != nil {
+		t.Fatalf("ListReconcilerObservations(recover): %v", err)
+	}
+	if r := findTask(obs2, trivyScanIdentity); r == nil || r.Status != ObsStatusSucceeded {
+		t.Errorf("a newer Succeeded run should recover the headline; got %+v", r)
+	}
+}
+
+// itoaTest — tiny local int→string for the test (avoids a strconv import for
+// one call site and matches the package's no-fmt helper style).
+func itoaTest(n int) string { return itoa(int64(n)) }

--- a/products/catalyst/bootstrap/api/internal/jobs/display.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/display.go
@@ -75,6 +75,9 @@ var acronyms = map[string]string{
 	"ha":       "HA",
 	"bcp":      "BCP",
 	"dr":       "DR",
+	"sbom":     "SBOM",
+	"trivy":    "Trivy",
+	"syft":     "Syft",
 }
 
 // humanizeToken renders one hyphen-separated slug token in its canonical

--- a/products/catalyst/bootstrap/api/internal/jobs/reconciler_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/reconciler_bridge.go
@@ -192,10 +192,48 @@ func (b *Bridge) onReconcilerObservationLocked(o ReconcilerObservation) (jobsWri
 		if e != nil {
 			return jobsWritten, execsSeeded, e
 		}
-	case ObsKindReconcile, ObsKindTask:
-		// One-shot leaves get a single Execution carrying the status +
-		// message so the JobDetail log surface is non-empty and the row
-		// renders a duration cell rather than an em-dash. Pending leaves
+	case ObsKindTask:
+		// A task leaf is ONE STABLE entry keyed by its base identity
+		// (issue #3916). When the producer carried per-run instances
+		// (multiple Jobs sharing a generateName / run-suffix), each becomes
+		// an Execution on this single leaf — deduped by run name across
+		// re-reads, exactly like the cron leaf — so N reruns surface as 1
+		// row + N runs, never N rows. When no per-run list is present, fall
+		// back to a single status-carrying Execution.
+		if len(o.Executions) > 0 {
+			es, e := b.seedCronExecutionsLocked(jobName, o)
+			execsSeeded += es
+			if e != nil {
+				return jobsWritten, execsSeeded, e
+			}
+			// seedCronExecutionsLocked finishes each run in list order, so the
+			// LAST-processed run (not necessarily the most recent) would
+			// otherwise leave the headline. Re-assert the producer's
+			// recency-resolved status so the leaf reflects the latest run.
+			if err := b.store.UpsertJob(Job{
+				DeploymentID: b.deploymentID,
+				JobName:      jobName,
+				DisplayName:  reconcilerDisplay(o.Kind, o.Name),
+				AppID:        o.Name,
+				Type:         JobTypeInstall,
+				Kind:         kind,
+				ParentID:     JobID(b.deploymentID, GroupReconcilers),
+				DependsOn:    []string{},
+				Status:       status,
+			}); err != nil {
+				return jobsWritten, execsSeeded, err
+			}
+		} else if isTerminalOrRunningObs(status) {
+			es, e := b.seedSingleExecutionLocked(jobName, status, o.Message, at)
+			execsSeeded += es
+			if e != nil {
+				return jobsWritten, execsSeeded, e
+			}
+		}
+	case ObsKindReconcile:
+		// One-shot reconcile leaf gets a single Execution carrying the
+		// status + message so the JobDetail log surface is non-empty and the
+		// row renders a duration cell rather than an em-dash. Pending leaves
 		// stay Job-only (no empty NDJSON file).
 		if isTerminalOrRunningObs(status) {
 			es, e := b.seedSingleExecutionLocked(jobName, status, o.Message, at)

--- a/products/catalyst/bootstrap/api/internal/jobs/reconciler_bridge_test.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/reconciler_bridge_test.go
@@ -217,3 +217,80 @@ func TestReconcilerBridge_KindBackfillOnRead(t *testing.T) {
 		t.Errorf("kind back-fill: want %q, got %q", KindReconcile, j.Kind)
 	}
 }
+
+// TestReconcilerBridge_RepeatedSeedsKeepStableCount pins the accumulation
+// fix at the bridge layer (issue #3916): re-seeding the SAME reconciler
+// identities across many polls (the chroot /jobs re-read on every request)
+// must UPDATE one entry per identity in place — never append a new row per
+// poll. The reconciler-observation producer already collapses per-run Job
+// instances to a stable base name; this asserts the bridge's UpsertJob keying
+// holds the leaf count flat across repeated seeds.
+func TestReconcilerBridge_RepeatedSeedsKeepStableCount(t *testing.T) {
+	b, st := newTestBridge(t)
+
+	obs := []ReconcilerObservation{
+		{Kind: ObsKindReconcile, Name: "flux-system", Namespace: "flux-system", Status: "installing", Message: "reconciling"},
+		{Kind: ObsKindTask, Name: "db-migrate", Namespace: "data", Status: "installing", Message: "running"},
+		{Kind: ObsKindReconciler, Name: "sso-bridge", Namespace: "sso-bridge", Status: "healthy", Health: true, Message: "1/1"},
+	}
+
+	countLeaves := func() int {
+		all, err := st.ListJobs("dep-recon")
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		n := 0
+		for _, j := range all {
+			if j.Type != JobTypeGroup {
+				n++
+			}
+		}
+		return n
+	}
+
+	// First poll establishes the leaves.
+	if _, _, err := b.SeedReconcilerObservations(obs); err != nil {
+		t.Fatalf("seed 1: %v", err)
+	}
+	first := countLeaves()
+	if first != 3 {
+		t.Fatalf("first poll leaf count = %d, want 3", first)
+	}
+
+	// 20 more polls of the SAME identities (status may even change) must not
+	// grow the count — one stable entry per reconciler identity.
+	for i := 0; i < 20; i++ {
+		if _, _, err := b.SeedReconcilerObservations(obs); err != nil {
+			t.Fatalf("seed repeat %d: %v", i, err)
+		}
+	}
+	if got := countLeaves(); got != first {
+		t.Errorf("accumulation: leaf count grew from %d to %d across repeated polls (#3916)", first, got)
+	}
+}
+
+// TestReconcilerBridge_StillReconcilingTaskIsRunningNotTerminal pins the
+// anti-flap contract at the bridge layer: an observation carrying the
+// in-progress status ("installing") writes a RUNNING leaf, never a terminal
+// failed/succeeded. The leaf only becomes terminal when the observation
+// itself is terminal.
+func TestReconcilerBridge_StillReconcilingTaskIsRunningNotTerminal(t *testing.T) {
+	b, st := newTestBridge(t)
+	if err := b.OnReconcilerObservation(ReconcilerObservation{
+		Kind: ObsKindReconcile, Name: "apps", Namespace: "flux-system",
+		Status: "installing", Message: "reconcile in progress",
+	}); err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	all, _ := st.ListJobs("dep-recon")
+	rec, ok := findByName(all, "reconcile-apps")
+	if !ok {
+		t.Fatal("reconcile-apps leaf missing")
+	}
+	if rec.Status != StatusRunning {
+		t.Errorf("still-reconciling leaf status = %q, want %q (no flapping terminal)", rec.Status, StatusRunning)
+	}
+	if IsTerminal(rec.Status) {
+		t.Errorf("a still-reconciling leaf must NOT be terminal, got %q", rec.Status)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/jobs/store.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/store.go
@@ -536,6 +536,22 @@ func (s *Store) ListJobs(deploymentID string) ([]Job, error) {
 	out := make([]Job, len(idx.Jobs))
 	copy(out, idx.Jobs)
 	out = deriveTreeView(out)
+	// RunCount — derive the per-leaf run-history depth (#3925) from the
+	// flat Execution index so a collapsed identity row (e.g. a recurring
+	// scan with 600 runs behind it) reports its run count on the row
+	// without the FE having to load the full Execution list. Group rows
+	// own no Executions of their own, so they stay 0 (omitempty drops them
+	// from the wire). Counted post-deriveTreeView so synthesized group
+	// rows are present but simply match nothing.
+	runCounts := make(map[string]int, len(idx.Jobs))
+	for i := range idx.Executions {
+		runCounts[idx.Executions[i].JobID]++
+	}
+	for i := range out {
+		if n := runCounts[out[i].ID]; n > 0 {
+			out[i].RunCount = n
+		}
+	}
 	sort.SliceStable(out, func(i, j int) bool {
 		// Pending (no StartedAt) sort last.
 		ai, bi := out[i].StartedAt, out[j].StartedAt
@@ -885,6 +901,10 @@ func (s *Store) GetJob(deploymentID, jobID string) (Job, []Execution, error) {
 			sort.Slice(execs, func(a, b int) bool {
 				return execs[a].StartedAt.After(execs[b].StartedAt)
 			})
+			// RunCount mirrors ListJobs (#3925) — the run-history depth so
+			// a single GetJob also reports a collapsed identity row's run
+			// count without re-counting the returned execs FE-side.
+			j.RunCount = len(execs)
 			return j, execs, nil
 		}
 	}

--- a/products/catalyst/bootstrap/api/internal/jobs/store_test.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/store_test.go
@@ -221,6 +221,86 @@ func TestStore_StartAndFinishExecution(t *testing.T) {
 	}
 }
 
+// TestStore_RunCount_CountsExecutionsPerLeaf pins the #3925 run-history
+// depth: ListJobs + GetJob derive RunCount from the flat Execution index, so
+// a collapsed identity row (one Job, many runs) reports its full run count.
+func TestStore_RunCount_CountsExecutionsPerLeaf(t *testing.T) {
+	st := newTestStore(t)
+	depID := "dep-runcount"
+
+	if err := st.UpsertJob(Job{
+		DeploymentID: depID,
+		JobName:      "task-trivy-security-scan",
+		AppID:        "trivy-security-scan",
+		Type:         JobTypeInstall,
+		Kind:         KindTask,
+		ParentID:     JobID(depID, GroupReconcilers),
+		Status:       StatusPending,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// A one-shot job with a single run, to prove RunCount=1 there.
+	if err := st.UpsertJob(Job{
+		DeploymentID: depID,
+		JobName:      "task-openbao-init",
+		AppID:        "openbao-init",
+		Type:         JobTypeInstall,
+		Kind:         KindTask,
+		ParentID:     JobID(depID, GroupReconcilers),
+		Status:       StatusPending,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	t0 := time.Now().UTC()
+	const scanRuns = 600
+	for i := 0; i < scanRuns; i++ {
+		e, err := st.StartExecution(depID, "task-trivy-security-scan", t0.Add(time.Duration(i)*time.Second))
+		if err != nil {
+			t.Fatalf("StartExecution[%d]: %v", i, err)
+		}
+		if err := st.FinishExecution(depID, e.ID, StatusSucceeded, t0.Add(time.Duration(i)*time.Second+time.Second)); err != nil {
+			t.Fatalf("FinishExecution[%d]: %v", i, err)
+		}
+	}
+	oneShot, err := st.StartExecution(depID, "task-openbao-init", t0)
+	if err != nil {
+		t.Fatalf("StartExecution(one-shot): %v", err)
+	}
+	if err := st.FinishExecution(depID, oneShot.ID, StatusSucceeded, t0.Add(time.Second)); err != nil {
+		t.Fatalf("FinishExecution(one-shot): %v", err)
+	}
+
+	// ListJobs: the collapsed scanner row reports all 600 runs; the one-shot 1.
+	jobsList, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	byName := map[string]Job{}
+	for _, j := range jobsList {
+		byName[j.JobName] = j
+	}
+	if got := byName["task-trivy-security-scan"].RunCount; got != scanRuns {
+		t.Errorf("collapsed scanner RunCount: want %d, got %d", scanRuns, got)
+	}
+	if got := byName["task-openbao-init"].RunCount; got != 1 {
+		t.Errorf("one-shot RunCount: want 1, got %d", got)
+	}
+	// The Reconcilers group row owns no Executions of its own → RunCount 0.
+	if grp, ok := byName[GroupReconcilers]; ok && grp.RunCount != 0 {
+		t.Errorf("group RunCount should be 0, got %d", grp.RunCount)
+	}
+
+	// GetJob mirrors ListJobs.
+	j, execs, err := st.GetJob(depID, JobID(depID, "task-trivy-security-scan"))
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if j.RunCount != scanRuns || len(execs) != scanRuns {
+		t.Errorf("GetJob RunCount/execs: want %d/%d, got %d/%d", scanRuns, scanRuns, j.RunCount, len(execs))
+	}
+}
+
 func TestStore_FinishExecution_RejectsNonTerminal(t *testing.T) {
 	st := newTestStore(t)
 	if err := st.UpsertJob(Job{DeploymentID: "d", JobName: "install-x"}); err != nil {

--- a/products/catalyst/bootstrap/api/internal/jobs/types.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/types.go
@@ -411,6 +411,15 @@ type Job struct {
 	// jobs (groups don't run Executions of their own).
 	LatestExecutionID string `json:"latestExecutionId,omitempty"`
 
+	// RunCount — number of Executions (runs) recorded for this leaf
+	// Job. DERIVED at read time by Store.ListJobs / Store.GetJob from
+	// the flat Execution index; never persisted on the Job row. This is
+	// the run-history depth the Jobs view (#3925) shows behind an
+	// identity-keyed row: a recurring scan that collapses to one row
+	// reports "600 runs" here; a one-shot job reports 1. Zero (omitted on
+	// the wire) for a pending job with no run yet and for group jobs.
+	RunCount int `json:"runCount,omitempty"`
+
 	// ChildIDs — full IDs of jobs whose ParentID == this Job's ID.
 	// DERIVED at read time by Store.ListJobs / Store.GetJob; never
 	// persisted. Empty for leaf install jobs.

--- a/products/catalyst/bootstrap/ui/src/lib/jobs.types.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/jobs.types.ts
@@ -147,6 +147,17 @@ export interface Job {
   finishedAt: string | null
   durationMs: number
   /**
+   * Run-history depth (#3925) — the number of Executions (runs) behind
+   * this leaf row. A recurring job that collapses to ONE identity-keyed
+   * row (e.g. a trivy/syft scan) reports its full run count here ("600
+   * runs"); a one-shot job reports 1. Backend-derived at read time
+   * (Store.ListJobs / GetJob); omitted on the wire (and thus undefined
+   * here) for a pending job with no run yet and for group rows. The Jobs
+   * view renders this in the Runs column so the collapse is legible — one
+   * row, N runs behind it.
+   */
+  runCount?: number
+  /**
    * #3656 (founder #6) — FE-only provisional flag. The Jobs canvas merges
    * reducer-derived rows (folded from the SSE replay buffer) with the live
    * /jobs query, and the live source wins on conflict. Before the live

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.test.tsx
@@ -126,11 +126,12 @@ describe('JobsPage — table view (NOT accordion)', () => {
     renderJobs('d-1')
     const table = await screen.findByTestId('jobs-table')
     const headers = within(table).getAllByRole('columnheader').map((h) => (h.textContent ?? '').toLowerCase().trim())
-    // Kind inserted after Name (#3646); Parent (not the legacy "batch")
-    // is the canonical column; Actions trails when a deploymentId is
-    // threaded (JobsPage threads it). Assert the stable left columns.
-    expect(headers.slice(0, 8)).toEqual([
-      'name', 'kind', 'app', 'deps', 'parent', 'status', 'started', 'duration',
+    // Kind inserted after Name (#3646); Runs after Status (#3925 run-history
+    // depth); Parent (not the legacy "batch") is the canonical column;
+    // Actions trails when a deploymentId is threaded (JobsPage threads it).
+    // Assert the stable left columns.
+    expect(headers.slice(0, 9)).toEqual([
+      'name', 'kind', 'app', 'deps', 'parent', 'status', 'runs', 'started', 'duration',
     ])
   })
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.test.tsx
@@ -280,9 +280,45 @@ describe('JobsTable — render', () => {
       .getAllByRole('columnheader')
       .map((h) => (h.textContent ?? '').toLowerCase().trim())
     // Kind is inserted after Name (#3646 typed activity discriminator).
-    // The Actions column appears only when a deploymentId is threaded,
-    // which this no-deploymentId render does not, so it's absent here.
-    expect(headers).toEqual(['name', 'kind', 'app', 'deps', 'parent', 'status', 'started', 'duration'])
+    // Runs (#3925) sits after Status — the run-history depth so a collapsed
+    // recurring row shows its run count. The Actions column appears only
+    // when a deploymentId is threaded, which this no-deploymentId render
+    // does not, so it's absent here.
+    expect(headers).toEqual(['name', 'kind', 'app', 'deps', 'parent', 'status', 'runs', 'started', 'duration'])
+  })
+
+  it('renders the run-history count in the Runs column, "—" when no runs (#3925)', async () => {
+    // A collapsed recurring scanner row (600 runs behind one identity) and a
+    // one-shot row (1 run) and a pending row (no run yet) — the Runs column
+    // must report each honestly so the collapse is legible.
+    const jobs: Job[] = [
+      {
+        id: 'd-1:task-trivy-security-scan', jobName: 'task-trivy-security-scan',
+        displayName: 'Trivy Security Scan (task)', appId: 'trivy-security-scan',
+        type: 'install', kind: 'task', parentId: 'd-1:reconcilers', childIds: [],
+        dependsOn: [], status: 'succeeded', startedAt: '2026-06-20T01:00:00Z',
+        finishedAt: '2026-06-20T01:00:05Z', durationMs: 5000, runCount: 600,
+      },
+      {
+        id: 'd-1:task-openbao-init', jobName: 'task-openbao-init',
+        appId: 'openbao-init', type: 'install', kind: 'task',
+        parentId: 'd-1:reconcilers', childIds: [], dependsOn: [],
+        status: 'succeeded', startedAt: '2026-06-20T01:00:00Z',
+        finishedAt: '2026-06-20T01:00:01Z', durationMs: 1000, runCount: 1,
+      },
+      {
+        id: 'd-1:task-pending', jobName: 'task-pending', appId: 'pending',
+        type: 'install', kind: 'task', parentId: 'd-1:reconcilers', childIds: [],
+        dependsOn: [], status: 'pending', startedAt: null, finishedAt: null,
+        durationMs: 0,
+      },
+    ]
+    renderTable({ jobs })
+    await screen.findByTestId('jobs-table')
+    expect(screen.getByTestId('jobs-cell-runs-d-1:task-trivy-security-scan').textContent).toBe('600')
+    expect(screen.getByTestId('jobs-cell-runs-d-1:task-openbao-init').textContent).toBe('1')
+    // Pending row with no run yet → em-dash, never "0".
+    expect(screen.getByTestId('jobs-cell-runs-empty-d-1:task-pending')).toBeTruthy()
   })
 
   it('row link stays scoped under /provision/$deploymentId on the mother surface (prov #59)', async () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
@@ -569,6 +569,10 @@ export function JobsTable({ jobs, appIdFilter, initialParentFilter, deploymentId
               <th data-col="deps">Deps</th>
               <th data-col="parent">Parent</th>
               <th data-col="status">Status</th>
+              {/* Runs column (#3925) — run-history depth. A recurring job
+                  that collapses to ONE identity row (e.g. a trivy/syft
+                  scan) shows its full run count here; a one-shot shows 1. */}
+              <th data-col="runs">Runs</th>
               <th data-col="started">Started</th>
               <th data-col="duration">Duration</th>
               {/* Actions column (issue #3646 §5c) — per-row Retry control
@@ -580,11 +584,11 @@ export function JobsTable({ jobs, appIdFilter, initialParentFilter, deploymentId
           <tbody>
             {visibleJobs.length === 0 ? (
               <tr>
-                {/* base 7 cols (name,app,deps,parent,status,started,
+                {/* base 8 cols (name,app,deps,parent,status,runs,started,
                     duration) + Kind (+1) + Region (showRegion) + Actions
                     (deploymentId). */}
                 <td
-                  colSpan={8 + (showRegion ? 1 : 0) + (deploymentId ? 1 : 0)}
+                  colSpan={9 + (showRegion ? 1 : 0) + (deploymentId ? 1 : 0)}
                   className="jobs-empty"
                   data-testid="jobs-table-empty"
                 >
@@ -780,6 +784,22 @@ function JobRow({ job, parentLabel, showRegion, regionUnionByGroupId, deployment
       </td>
       <td className="jobs-cell jobs-cell-status">
         <StatusBadge status={job.status} jobId={job.id} provisional={job.provisional === true} />
+      </td>
+      <td className="jobs-cell jobs-cell-runs">
+        {/* Runs (#3925) — run-history depth. A collapsed recurring row
+            (scan/backup) shows its run count ("600"); a one-shot shows 1.
+            A pending row with no run yet (undefined/0) shows "—". */}
+        {job.runCount && job.runCount > 0 ? (
+          <span
+            className="jobs-runs-count"
+            data-testid={`jobs-cell-runs-${job.id}`}
+            title={`${job.runCount} run${job.runCount === 1 ? '' : 's'} recorded`}
+          >
+            {job.runCount}
+          </span>
+        ) : (
+          <span className="jobs-empty-cell" data-testid={`jobs-cell-runs-empty-${job.id}`}>—</span>
+        )}
       </td>
       <td className="jobs-cell jobs-cell-started" title={started.absolute}>
         <span data-testid={`jobs-cell-started-${job.id}`}>{started.display}</span>
@@ -1010,6 +1030,13 @@ const JOBS_TABLE_CSS = `
 }
 .jobs-cell-name { min-width: 220px; max-width: 360px; }
 .jobs-cell-deps { min-width: 120px; }
+.jobs-cell-runs { text-align: right; min-width: 56px; }
+.jobs-runs-count {
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.8rem;
+  color: var(--color-text);
+}
 .jobs-row-link {
   display: block;
   width: 100%;


### PR DESCRIPTION
## What

Lands the **Jobs-view identity-collapse** fix (Convergence Monitor Surface B, #3925) as a CLEAN re-cut off current `main`. **Supersedes #3928**, which was CONFLICTING (200 files) because it was stacked on the drifted #3918→#3920 chain. This branch carries ONLY the real Jobs-view diff (16 files), with #3918's `taskBaseName`/`statusFromReadyCondition` primitives and #3920's scanner-detection helpers folded in (they were not yet on `main`).

The fix is env-independent — pure ingestion/render logic.

## The model (#3925 jobs-convergence-monitor-model.md §4 Surface B)

A recurring scan/job is **ONE identity-keyed row with a run-history**, never N per-run rows and never excluded. On a converged Sovereign the trivy-operator mints a fresh scan Job per workload (614 observed live on hw171) and syft-grype runs a daily SBOM CronJob — hundreds of ever-growing rows that dwarf the ~100 real reconcilers.

## Changes (16 files)

**`helmwatch/reconcilers.go`** (the heart):
- `scannerIdentity(u)` — trivy scan → `trivy-security-scan`, syft run → `syft-sbom`.
- `foldScannerRun(...)` — record each run as an Execution on the single identity row; recency-resolved headline (sticky, no flap); create the row on first sight. The syft-grype CronJob **seeds** the `syft-sbom` identity row (not a `cron-*` leaf).
- Folds in **#3918**: `taskBaseName` keying (repeated runs of a generateName/Flux-recreated Job collapse to ONE leaf + per-run Executions, never a fresh leaf per run) + `statusFromReadyCondition` sticky-terminal discipline (only Flux's terminal `Stalled` is a genuine terminal failure; every other `Ready=False` is in-flight reconcile, never a flapping `Failed`).
- **Re-targets #3920**: `isDay2ScannerJob`/`isDay2ScannerCronJob` detection from "exclude" → "collapse".

**`helmwatch/helmwatch.go` + `handler/jobs_backfill.go`** — `Stalled` snapshot field + read-side anti-flap (a failed-but-not-stalled HR projects as `installing`, not a flapping terminal `Failed` leaf).

**`jobs/types.go` + `jobs/store.go`** — derived `Job.RunCount`, populated by `ListJobs` + `GetJob` from the flat Execution index.
**`jobs/display.go`** — SBOM / Trivy / Syft acronyms.
**UI `jobs.types.ts` `Job.runCount` + a Runs column in `JobsTable.tsx`.**

## Test (before → after)

`600 trivy + 30 syft + syft CronJob + 4 real reconcilers` →
- **after collapse**: exactly **2 scanner identity rows** (trivy carries 600 runs, syft carries 30 runs as run-history) **+ 4 real reconciler rows intact**, **0 per-run rows leaked**, **0 cron leaf** for syft.
- pre-collapse would have been ~630 per-run rows.

## Validation
- `go build ./...` + `go vet ./...` clean.
- helmwatch + jobs + handler suites green.
- UI `tsc -b --noEmit` clean; `JobsTable` (56) + `jobsAdapter` (7) suites green.
- The 2 pre-existing `JobsPage` failures (back-to-apps / show-as-flow) are **unrelated** — confirmed they fail identically on a pristine `main` tree (2 failed | 11 passed, same count).

Refs #3925 #3646 #3918 #3920

🤖 Generated with [Claude Code](https://claude.com/claude-code)