### PR TITLE
fix(catalyst-api): Open-button externalURL + Topology placement for mgmt-vCluster apps post-#3642 (re-cut of #3932)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -947,10 +947,10 @@ func newApplicationUnstructured(req applicationInstallRequest) *unstructured.Uns
 	// preserved on the `catalyst.openova.io/organization` label below.
 	obj.SetNamespace(orgNamespace(req.OrganizationRef))
 	obj.SetLabels(map[string]string{
-		"catalyst.openova.io/managed-by":      "catalyst-api",
-		"catalyst.openova.io/organization":    req.OrganizationRef,
-		"catalyst.openova.io/environment":     req.EnvironmentRef,
-		"catalyst.openova.io/blueprint":       req.BlueprintRef.Name,
+		"catalyst.openova.io/managed-by":        "catalyst-api",
+		"catalyst.openova.io/organization":      req.OrganizationRef,
+		"catalyst.openova.io/environment":       req.EnvironmentRef,
+		"catalyst.openova.io/blueprint":         req.BlueprintRef.Name,
 		"catalyst.openova.io/blueprint-version": req.BlueprintRef.Version,
 	})
 
@@ -1136,8 +1136,8 @@ func isValidOrgRef(s string) bool {
 // nothing returning the Application's full spec + identity, so the SPA
 // couldn't synthesise an ApplicationDescriptor on the fly.
 type applicationDetailResponse struct {
-	Name             string                   `json:"name"`
-	Namespace        string                   `json:"namespace"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
 	// UID — the Application CR's metadata.uid, lifted verbatim from
 	// the dynamic-client object. Required by the Catalyst Console's
 	// Launch button (PR #2839, G117.4): the FE calls
@@ -1149,20 +1149,20 @@ type applicationDetailResponse struct {
 	// synthesised from a HelmRelease (bootstrap-kit installs with no
 	// companion Application CR — those have no Application UID).
 	// Refs #2743 #2834 #2839.
-	UID              string                   `json:"uid"`
-	Blueprint        string                   `json:"blueprint,omitempty"`
-	Version          string                   `json:"version,omitempty"`
-	EnvironmentRef   string                   `json:"environmentRef,omitempty"`
-	Placement        string                   `json:"placement,omitempty"`
-	Regions          []string                 `json:"regions,omitempty"`
-	Parameters       map[string]interface{}   `json:"parameters,omitempty"`
-	Phase            string                   `json:"phase,omitempty"`
-	PrimaryRegion    string                   `json:"primaryRegion,omitempty"`
-	GiteaRepo        string                   `json:"giteaRepo,omitempty"`
-	LastReconciled   string                   `json:"lastReconciledAt,omitempty"`
-	Conditions       []map[string]interface{} `json:"conditions"`
-	RegionStatuses   []map[string]interface{} `json:"regionStatuses,omitempty"`
-	InstalledBlueprint map[string]interface{} `json:"installedBlueprint,omitempty"`
+	UID                string                   `json:"uid"`
+	Blueprint          string                   `json:"blueprint,omitempty"`
+	Version            string                   `json:"version,omitempty"`
+	EnvironmentRef     string                   `json:"environmentRef,omitempty"`
+	Placement          string                   `json:"placement,omitempty"`
+	Regions            []string                 `json:"regions,omitempty"`
+	Parameters         map[string]interface{}   `json:"parameters,omitempty"`
+	Phase              string                   `json:"phase,omitempty"`
+	PrimaryRegion      string                   `json:"primaryRegion,omitempty"`
+	GiteaRepo          string                   `json:"giteaRepo,omitempty"`
+	LastReconciled     string                   `json:"lastReconciledAt,omitempty"`
+	Conditions         []map[string]interface{} `json:"conditions"`
+	RegionStatuses     []map[string]interface{} `json:"regionStatuses,omitempty"`
+	InstalledBlueprint map[string]interface{}   `json:"installedBlueprint,omitempty"`
 
 	// Family B (2026-05-17 t10 founder bugs C4-003/005/007/013):
 	// AppDetail Resources/Logs tabs were querying the wrong namespace
@@ -1525,6 +1525,42 @@ func installLabelSelectorForHR(releaseName string) string {
 	return fmt.Sprintf("app.kubernetes.io/instance=%s", releaseName)
 }
 
+// placementFromHR — #3931. Project the placement CLASS for an
+// HR-synthesised (bootstrap-kit) Application that has NO companion
+// Application CR, so the CR-spec placement read in HandleApplicationGet
+// never runs for it.
+//
+// Source priority (most → least specific), normalised to the canonical
+// 4-class vocabulary (singleton / active-passive / active-hot-standby /
+// active-active) via placementForTopology so the FE Topology tab + editor
+// pre-select speak ONE dialect (#3375):
+//
+//	(1) spec.values.placement                 — explicit string posture
+//	(2) spec.values.topology.mode             — legacy object form
+//	(3) catalyst.openova.io/topology label    — stamped class, if any
+//	(4) "singleton"                           — the single-region default
+//	                                            every bootstrap front-door
+//	                                            app runs as
+//
+// The `catalyst.openova.io/vcluster` label (host/mgmt/dmz/rtz) records the
+// vCluster TIER the syncer placed the app in — orthogonal to the placement
+// CLASS, so it is NOT consulted here.
+func placementFromHR(hr *unstructured.Unstructured) string {
+	if v, ok, _ := unstructured.NestedString(hr.Object, "spec", "values", "placement"); ok && v != "" {
+		return placementForTopology(v)
+	}
+	values, _, _ := unstructured.NestedMap(hr.Object, "spec", "values")
+	if mode := readTopologyFromValues(values); mode != "" && mode != "singleton" {
+		return placementForTopology(mode)
+	}
+	if labels := hr.GetLabels(); labels != nil {
+		if v := labels["catalyst.openova.io/topology"]; v != "" {
+			return placementForTopology(v)
+		}
+	}
+	return "singleton"
+}
+
 // synthesiseAppFromHelmRelease — PR L (2026-05-17 t140 founder bug #2).
 //
 // Look up a HelmRelease by `name` in the chroot's k8sCache and synthesise
@@ -1591,6 +1627,20 @@ func (h *Handler) synthesiseAppFromHelmRelease(ctx context.Context, depID, name 
 			resp.ReleaseName = hr.GetName()
 		}
 		resp.InstallLabelSelector = installLabelSelectorForHR(resp.ReleaseName)
+		// #3931 — placement projection for HR-synthesised (bootstrap-kit) apps.
+		// These have NO Application CR, so the CR-spec placement read in
+		// HandleApplicationGet never runs for them and resp.Placement was left
+		// empty → the AppDetail Topology tab lost the live-placement signal for
+		// EVERY mgmt-vCluster app post-#3642 (the FE falls back to "singleton"
+		// but the read-back is dishonest about whether a value was actually
+		// projected). Project the create-time placement the same way the
+		// CR-spec path does: read an explicit spec.values.placement if the chart
+		// carries one, else default to the canonical single-region "singleton"
+		// (bootstrap-kit front-door apps run single-region per tier). The HR's
+		// `catalyst.openova.io/vcluster` label records the tier (host/mgmt/dmz/
+		// rtz) the syncer placed it in; surfaced for completeness but the
+		// placement CLASS is what the Topology tab reads.
+		resp.Placement = placementFromHR(hr)
 		// Map HR Ready condition → Application phase.
 		conds, _, _ := unstructured.NestedSlice(hr.Object, "status", "conditions")
 		phase := "Pending"
@@ -1712,6 +1762,54 @@ func (h *Handler) dependsOnFromHRGraph(ctx context.Context, hrs []*unstructured.
 	return out
 }
 
+// vClusterHostSyncNamespaces — the well-known HOST namespaces into which a
+// per-tier vCluster syncs its in-vCluster resources (HTTPRoutes, Services).
+//
+// #3642 moved the 7 front-door apps (gitea/grafana/harbor/keycloak/openbao/
+// newapi/guacamole) OUT of the host and INTO the `mgmt` vCluster. The loft-sh
+// syncer mirrors each app's HTTPRoute back onto the HOST cluster, but it lands
+// the mirror in the vCluster's HOST namespace (`hostNamespace: mgmt` in
+// bp-mgmt-vcluster values), NOT in the app's in-vCluster targetNamespace
+// (gitea/grafana/openbao/…). So on hw171 every front-door HTTPRoute lives in
+// host ns `mgmt` while the HelmRelease still declares
+// `spec.targetNamespace: gitea`. A namespace filter that requires
+// `route.namespace == targetNamespace` (the pre-#3642 invariant, since the app
+// AND its route shared a host namespace) therefore matches NOTHING post-#3642
+// → externalURL comes back empty → the AppDetail "Open" button + the AppsPage
+// card button vanish for EVERY mgmt-vCluster app, even though their front doors
+// (gitea.<fqdn>, bao.<fqdn>, …) are live. This is the same #3642 regression
+// family as the harbor-core cutover bug fixed in #3927 — the host-side lookup
+// must now also search the vCluster sync namespace.
+//
+// dmz/rtz tiers (bp-dmz-vcluster/bp-rtz-vcluster) sync into `dmz`/`rtz` host
+// namespaces respectively; included so the SAME fix covers apps that later move
+// into those tiers without another regression.
+var vClusterHostSyncNamespaces = []string{"mgmt", "dmz", "rtz"}
+
+// routeNamespaceMatchesApp decides whether an HTTPRoute living in routeNS may
+// front the app whose HelmRelease declares targetNS.
+//
+// The match is intentionally NOT "any namespace": the #3150 namespace filter
+// guards against a same-subdomain route in an UNRELATED namespace being
+// returned (the `namespace filter excludes other-ns route` lock-in). We only
+// widen it to the well-known vCluster HOST sync namespaces (mgmt/dmz/rtz) where
+// the syncer deterministically mirrors an app's route post-#3642 — never to
+// arbitrary namespaces. The downstream name/host-leftmost-label/backendRef
+// match rules still have to fire, and those are collision-free across apps
+// (each owns a distinct `<release>.<fqdn>` subdomain), so widening the
+// namespace set cannot false-positive one app onto another's route.
+func routeNamespaceMatchesApp(routeNS, targetNS string) bool {
+	if targetNS == "" || routeNS == targetNS {
+		return true
+	}
+	for _, syncNS := range vClusterHostSyncNamespaces {
+		if routeNS == syncNS {
+			return true
+		}
+	}
+	return false
+}
+
 // lookupExternalURL — G90 2026-06-01.
 //
 // Resolve the operator-visible front-door URL for an installed Application
@@ -1763,7 +1861,7 @@ func (h *Handler) lookupExternalURL(ctx context.Context, depID, targetNamespace,
 		return ""
 	}
 	for _, rt := range routes {
-		if targetNamespace != "" && rt.GetNamespace() != targetNamespace {
+		if !routeNamespaceMatchesApp(rt.GetNamespace(), targetNamespace) {
 			continue
 		}
 		hosts, _, _ := unstructured.NestedStringSlice(rt.Object, "spec", "hostnames")

--- a/products/catalyst/bootstrap/api/internal/handler/applications_external_url_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_external_url_test.go
@@ -174,6 +174,47 @@ func TestLookupExternalURL_MatchRules(t *testing.T) {
 			releaseName:     "guacamole",
 			want:            "",
 		},
+		{
+			// #3931 — post-#3642 the app moved INTO the mgmt vCluster: its HR
+			// still declares targetNamespace `gitea`, but the syncer mirrors the
+			// HTTPRoute onto the HOST in the `mgmt` sync namespace (keeping the
+			// route's plain name `gitea`). The host-side lookup must search the
+			// mgmt sync namespace even though it differs from targetNamespace.
+			name: "mgmt-vcluster synced route resolves via sync namespace",
+			routes: []*unstructured.Unstructured{
+				newHTTPRoute("mgmt", "gitea", "gitea.hw171.omantel.biz", "gitea-http"),
+			},
+			targetNamespace: "gitea",
+			releaseName:     "gitea",
+			want:            "https://gitea.hw171.omantel.biz",
+		},
+		{
+			// #3931 — the same widening must work via the hostname-leftmost
+			// label rule (openbao's route on the host carries host bao.<fqdn>?
+			// no — openbao keeps `openbao.<fqdn>`; use a name-divergent case:
+			// route mirrored as `guacamole-server` in mgmt, releaseName
+			// `guacamole`).
+			name: "mgmt-vcluster synced route resolves via hostname label",
+			routes: []*unstructured.Unstructured{
+				newHTTPRoute("mgmt", "guacamole-server", "guacamole.hw171.omantel.biz", "guacamole-server"),
+			},
+			targetNamespace: "guacamole",
+			releaseName:     "guacamole",
+			want:            "https://guacamole.hw171.omantel.biz",
+		},
+		{
+			// #3931 — the widening is bounded to the well-known vCluster sync
+			// namespaces (mgmt/dmz/rtz), NOT arbitrary ones. A same-subdomain
+			// route in an UNRELATED namespace stays excluded (the #3150
+			// namespace-filter protection must survive the #3642 fix).
+			name: "unrelated namespace still excluded after mgmt widening",
+			routes: []*unstructured.Unstructured{
+				newHTTPRoute("totally-other", "gitea", "gitea.hw171.omantel.biz", "gitea-http"),
+			},
+			targetNamespace: "gitea",
+			releaseName:     "gitea",
+			want:            "",
+		},
 	}
 
 	for _, tc := range cases {
@@ -186,6 +227,111 @@ func TestLookupExternalURL_MatchRules(t *testing.T) {
 			got := h.lookupExternalURL(context.Background(), "alpha", tc.targetNamespace, tc.releaseName)
 			if got != tc.want {
 				t.Fatalf("lookupExternalURL(%q, %q) = %q, want %q", tc.targetNamespace, tc.releaseName, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRouteNamespaceMatchesApp — #3931. Pure-function coverage for the
+// namespace-widening guard that fixes the #3642 mgmt-vCluster regression
+// without re-opening the #3150 cross-namespace false-positive.
+func TestRouteNamespaceMatchesApp(t *testing.T) {
+	cases := []struct {
+		name     string
+		routeNS  string
+		targetNS string
+		want     bool
+	}{
+		{"exact match", "gitea", "gitea", true},
+		{"empty target accepts any (CI / unset)", "anything", "", true},
+		{"mgmt sync namespace accepted for in-vcluster targetNS", "mgmt", "gitea", true},
+		{"dmz sync namespace accepted", "dmz", "someapp", true},
+		{"rtz sync namespace accepted", "rtz", "someapp", true},
+		{"arbitrary unrelated namespace rejected", "totally-other", "gitea", false},
+		{"host app in its own namespace still matches", "catalyst-system", "catalyst-system", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := routeNamespaceMatchesApp(tc.routeNS, tc.targetNS); got != tc.want {
+				t.Fatalf("routeNamespaceMatchesApp(%q, %q) = %v, want %v", tc.routeNS, tc.targetNS, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPlacementFromHR — #3931. The HR-synthesised (bootstrap-kit) placement
+// projection: front-door mgmt-vCluster apps with no Application CR must still
+// project a canonical placement class so the AppDetail Topology read-back is
+// honest (was empty → dishonest "no value projected").
+func TestPlacementFromHR(t *testing.T) {
+	mkHR := func(mutate func(obj map[string]any)) *unstructured.Unstructured {
+		obj := map[string]any{
+			"apiVersion": "helm.toolkit.fluxcd.io/v2",
+			"kind":       "HelmRelease",
+			"metadata": map[string]any{
+				"name":      "bp-gitea",
+				"namespace": "mgmt",
+				"labels": map[string]any{
+					"catalyst.openova.io/vcluster": "mgmt",
+				},
+			},
+			"spec": map[string]any{},
+		}
+		if mutate != nil {
+			mutate(obj)
+		}
+		return &unstructured.Unstructured{Object: obj}
+	}
+
+	cases := []struct {
+		name string
+		hr   *unstructured.Unstructured
+		want string
+	}{
+		{
+			// The default front-door mgmt-vCluster app (gitea/openbao/grafana):
+			// no explicit placement in values → canonical single-region class.
+			name: "bootstrap mgmt-vcluster app defaults to singleton",
+			hr:   mkHR(nil),
+			want: "singleton",
+		},
+		{
+			name: "explicit spec.values.placement string wins",
+			hr: mkHR(func(o map[string]any) {
+				o["spec"].(map[string]any)["values"] = map[string]any{"placement": "active-hot-standby"}
+			}),
+			want: "active-hot-standby",
+		},
+		{
+			name: "legacy spec.values.topology.mode object form",
+			hr: mkHR(func(o map[string]any) {
+				o["spec"].(map[string]any)["values"] = map[string]any{
+					"topology": map[string]any{"mode": "active-passive"},
+				}
+			}),
+			want: "active-passive",
+		},
+		{
+			name: "catalyst.openova.io/topology label fallback",
+			hr: mkHR(func(o map[string]any) {
+				o["metadata"].(map[string]any)["labels"].(map[string]any)["catalyst.openova.io/topology"] = "active-active"
+			}),
+			want: "active-active",
+		},
+		{
+			// An unknown / legacy spelling normalises to a canonical class
+			// (never leaks a raw dialect to the FE).
+			name: "unknown placement normalises to singleton",
+			hr: mkHR(func(o map[string]any) {
+				o["spec"].(map[string]any)["values"] = map[string]any{"placement": "gibberish"}
+			}),
+			want: "singleton",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := placementFromHR(tc.hr); got != tc.want {
+				t.Fatalf("placementFromHR = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign.go
@@ -579,8 +579,8 @@ type sovereignAppsResponse struct {
 //   - "installed"  — HR present & Ready=True
 //   - "installing" — HR present, Ready=False (or absent condition)
 //   - "bootstrap"  — visibility=unlisted AND part of bootstrap kit
-//                     (these always render as installed; the operator
-//                      cannot uninstall the spine)
+//     (these always render as installed; the operator
+//     cannot uninstall the spine)
 //   - "available"  — listed catalog entry, no matching HR yet
 func (h *Handler) HandleSovereignApps(w http.ResponseWriter, r *http.Request) {
 	listed, err := catalog.ListedBlueprints()
@@ -757,7 +757,30 @@ func (h *Handler) HandleSovereignApps(w http.ResponseWriter, r *http.Request) {
 			return v
 		}
 		for hrName, info := range hrInfo {
+			// #3931 — resolve the front-door route by (namespace, releaseName).
+			// Pre-#3642 the app's HTTPRoute shared its targetNamespace, so a
+			// single lookup sufficed. Post-#3642 the 7 front-door apps moved
+			// INTO the mgmt vCluster and the syncer mirrors each route onto the
+			// HOST under the vCluster sync namespace (`mgmt`/`dmz`/`rtz`), NOT
+			// the app's in-vCluster targetNamespace (gitea/grafana/openbao/…).
+			// Probe targetNamespace FIRST (the host-placed apps + the canonical
+			// pre-#3642 layout), then fall back to the well-known vCluster sync
+			// namespaces. Same widening — and same collision-free guarantee
+			// (each app owns a distinct `<release>.<fqdn>` host) — as
+			// lookupExternalURL's routeNamespaceMatchesApp. Without this the
+			// AppsPage grid Open button vanishes for every mgmt-vCluster app.
 			url, ok := hrURL[[2]string{info.targetNamespace, info.releaseName}]
+			if !ok {
+				for _, syncNS := range vClusterHostSyncNamespaces {
+					if syncNS == info.targetNamespace {
+						continue
+					}
+					if u, hit := hrURL[[2]string{syncNS, info.releaseName}]; hit {
+						url, ok = u, true
+						break
+					}
+				}
+			}
 			if !ok {
 				continue
 			}
@@ -1177,11 +1200,11 @@ type sovereignLB struct {
 }
 
 type sovereignSC struct {
-	Cluster        string `json:"cluster,omitempty"`
-	Name           string `json:"name"`
-	Provisioner    string `json:"provisioner"`
-	IsDefault      bool   `json:"isDefault"`
-	ReclaimPolicy  string `json:"reclaimPolicy"`
+	Cluster       string `json:"cluster,omitempty"`
+	Name          string `json:"name"`
+	Provisioner   string `json:"provisioner"`
+	IsDefault     bool   `json:"isDefault"`
+	ReclaimPolicy string `json:"reclaimPolicy"`
 }
 
 type sovereignPVC struct {
@@ -1461,4 +1484,3 @@ func humanizeSlug(s string) string {
 	}
 	return strings.Join(parts, " ")
 }
-


### PR DESCRIPTION
> **Re-cut of #3932 onto current `origin/main`.** The original #3932 branch (`fix/3931-mgmt-vcluster-externalurl-placement`) drifted behind main and carried a second, now-superseded commit — a parallel implementation of the Jobs-view identity-collapse work that has since landed on main via **#3930** (`5676e475d`, Refs #3925 #3918 #3920). That duplicate commit was the entire source of the "merge commit cannot be cleanly created" conflict. This PR cherry-picks **only** the #3932 fix commit (the 3 externalURL/placement files) cleanly onto current `origin/main`; the fix logic is byte-identical to the original. #3932 is closed in favour of this.

---

## Problem (grounded live on hw171, dep `3963e9267c10a90d`, catalyst-api/ui:fb423be)

The AppDetail "Open" button + AppsPage card button **vanished** and the **Topology placement read back empty** for EVERY front-door app (gitea/grafana/harbor/keycloak/openbao/guacamole/newapi). `GET /api/v1/sovereign/apps` + the per-app detail endpoint returned `externalURL='' placement=''` for every app — including `bp-openbao`/`bp-grafana`/`bp-gitea` whose front doors are live.

The UI is correct + deployed: `AppDetail.tsx` renders the Open CTA only when `apiApp.externalURL` is set, and reads `apiApp.placement`. **The backend projection was the bug.**

## Root cause — #3642 host→mgmt-vCluster migration regression (same family as #3927)

Confirmed live on hw171:

| What | Where it lives now |
|---|---|
| HelmReleases (gitea/grafana/openbao/…) | host ns `mgmt`, `spec.targetNamespace=gitea\|grafana\|openbao\|…` |
| **HTTPRoutes** (the front-door source) | host ns **`mgmt`** (`mgmt/gitea`, `mgmt/grafana`, `mgmt/openbao`, `mgmt/harbor`, `mgmt/keycloak`…) |

The loft-sh syncer mirrors each in-vCluster HTTPRoute back onto the HOST, landing it in the vCluster HOST sync namespace (`hostNamespace: mgmt` in bp-mgmt-vcluster), **NOT** the app's `targetNamespace`.

- `lookupExternalURL` (detail) + the `hrURL` join (list) both hard-required `route.namespace == targetNamespace` (the pre-#3642 invariant, when an app and its route shared a host namespace) → the `mgmt/*` route matched nothing → empty URL → no Open button.
- `synthesiseAppFromHelmRelease` (the HR-synth path ALL these CR-less bootstrap apps take, since they have no Application CR) never set `resp.Placement` → empty Topology placement.

## Fix (catalyst-api only — lookup logic is env-independent)

- **`routeNamespaceMatchesApp()`** widens the route-namespace filter to also accept the well-known vCluster host sync namespaces (`mgmt`/`dmz`/`rtz`) — **never arbitrary** namespaces, so the #3150 cross-namespace false-positive guard survives. The downstream name / host-leftmost-label / backendRef match rules are collision-free across apps (each owns a distinct `<release>.<fqdn>` host).
- The **list-endpoint `hrURL` join** probes `targetNamespace` first, then the sync namespaces.
- **`placementFromHR()`** projects a canonical placement class (singleton/active-passive/active-hot-standby/active-active) for HR-synth apps from `spec.values.placement` | `spec.values.topology.mode` | the topology label | `singleton` default — normalised via `placementForTopology` (#3375 one-vocabulary).
- The **#3224 user-UI suppression** for genuinely-headless apps stays intact.

## Tests
- `mgmt-vcluster synced route resolves` (via sync-ns + via hostname-leftmost label)
- `unrelated namespace still excluded after mgmt widening` (the #3150 guard survives)
- `TestRouteNamespaceMatchesApp` table + `TestPlacementFromHR` table
- `go build ./...` + `go vet` + full handler suite (94s) all green.

## Sibling regression found (NOT in this PR — distinct, larger surface)
The AppDetail **Resources/Logs tabs** query `targetNamespace` (`gitea`) for pods the syncer mirrors to host ns `mgmt` as `<pod>-x-gitea-x-mgmt-vcluster`, so they also come back empty post-#3642. Needs in-vCluster→host-mirror namespace + label-mangling resolution (not a simple namespace allow-list) — tracked separately.

## Verification note
The lookup-logic fix + unit tests are env-independent and proven here. Full confirmation that `externalURL`/`placement` re-populate on the live API requires a catalyst-api deploy carrying this commit (the running pod is `fb423be`).

Refs #3642 #3375 #3150 #3687

🤖 Generated with [Claude Code](https://claude.com/claude-code)
